### PR TITLE
wrapping lerna commands in NPM scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,5 +4,10 @@
   "devDependencies": {
     "lerna": "^3.14.1"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "scripts": {
+    "bootstrap": "lerna bootstrap",
+    "build": "lerna run build",
+    "init": "lerna run initialise"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -56,8 +56,6 @@ Install requires [node-gyp](https://github.com/nodejs/node-gyp), due to a depend
 
 *yarn -* `npm install -g yarn`
 
-*lerna -* `npm install -g lerna`
-
 *jest* - `npm install -g jest`
 
 ### 2. Clone this repository
@@ -68,11 +66,11 @@ then `cd ` into your local copy...
 
 ### 3.  Install and Build
 
-`lerna bootstrap` will install all modules
+`yarn bootstrap` will install all modules
 
-`lerna run build` will build all packages
+`yarn build` will build all packages
 
-`lerna run initialise` will initialise your budibase (i.e. create local database)
+`yarn initialise` will initialise your budibase (i.e. create local database)
 
 ### 4. Running
 


### PR DESCRIPTION
- Creating NPM scripts for running lerna build commands.
- This allows us to pin the version of lerna the developer uses and prevents people having to install lerna globally and potentially having strange issues related to their lerna version
- Updated README to reflect the change