### PR TITLE
Run Budibase Dev Server from top level, server side watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
     "initialise": "lerna run initialise",
-    "clean": "lerna clean"
+    "clean": "lerna clean",
+    "dev": "lerna run --parallel --stream dev:builder"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -73,9 +73,12 @@ if you then want to run the builder in dev mode (i.e. with hot reloading):
 
 ... keep the server running, and..
 1. Open a new console
-2. `cd packages/builder`
-3. `yarn start`
-4. Access the builder on http://localhost:3000
+2. `yarn dev`
+3. Access the builder on http://localhost:3000
+
+This will enable watch mode for both the client AND the server.
+
+### Running Commands from /server Directory 
 
 Notice that when inside `packages/server`, you can use any Budibase CLI command via yarn:
 


### PR DESCRIPTION
First small step towards improved budibase development experience.

- We can now run budibase in development at the top level with `yarn dev` 
- This enables watch mode for the server side code as well as the client side
- It will stream the logs from both into one terminal window concurrently, but lerna makes it clear which is which