### PR TITLE
Refactor of Classbuilder along with some bug fixes

### DIFF
--- a/packages/materialdesign-components/src/Button/Button.svelte
+++ b/packages/materialdesign-components/src/Button/Button.svelte
@@ -1,40 +1,50 @@
 <script>
-  import { setContext, getContext } from "svelte"
-  import Icon from "../Icon.svelte"
-  import ripple from "../Ripple.js"
-  import ClassBuilder from "../ClassBuilder.js"
+  import { setContext, getContext } from "svelte";
+  import Icon from "../Icon.svelte";
+  import ripple from "../Ripple.js";
+  import ClassBuilder from "../ClassBuilder.js";
 
-  const cb = new ClassBuilder("button", ["primary", "medium"])
+  const cb = new ClassBuilder("button", ["primary", "medium"]);
 
-  export let variant = "raised"
-  export let colour = "primary"
-  export let size = "medium"
+  export let variant = "raised";
+  export let colour = "primary";
+  export let size = "medium";
 
-  export let href = ""
-  export let icon = ""
-  export let trailingIcon = false
-  export let fullwidth = false
+  export let href = "";
+  export let icon = "";
+  export let trailingIcon = false;
+  export let fullwidth = false;
 
-  export let text = ""
-  export let disabled = false
+  export let text = "";
+  export let disabled = false;
+
+  let modifiers = {};
+  let customs = { size, colour };
+
+  if (!href) modifiers = { variant };
+
+  let props = { modifiers, customs };
+
+  let blockClasses = cb.build({ props });
+  const labelClass = cb.elem("label");
 
   $: if (icon) {
-    setContext("BBMD:icon:context", "button")
+    setContext("BBMD:icon:context", "button");
   }
 
-  $: renderLeadingIcon = !!icon && !trailingIcon
-  $: renderTrailingIcon = !!icon && trailingIcon
-
-  let blockClasses = cb.blocks({
-    modifiers: !href ? [variant] : null,
-    customs: { size, colour },
-  })
+  $: renderLeadingIcon = !!icon && !trailingIcon;
+  $: renderTrailingIcon = !!icon && trailingIcon;
 </script>
 
-<!-- TODO: Activated colour on primary elevated buttons seems to be rendering weird  -->
+<style>
+  .fullwidth {
+    width: 100%;
+  }
+</style>
+
 {#if href}
   <a class={blockClasses} {href} on:click>
-    <span class={cb.elements('label')}>{text}</span>
+    <span class={labelClass}>{text}</span>
   </a>
 {:else}
   <button
@@ -46,15 +56,9 @@
     {#if renderLeadingIcon}
       <Icon {icon} />
     {/if}
-    <span class={cb.elements('label')}>{text}</span>
+    <span class={labelClass}>{text}</span>
     {#if renderTrailingIcon}
       <Icon {icon} />
     {/if}
   </button>
 {/if}
-
-<style>
-  .fullwidth {
-    width: 100%;
-  }
-</style>

--- a/packages/materialdesign-components/src/Test/props.js
+++ b/packages/materialdesign-components/src/Test/props.js
@@ -1,5 +1,6 @@
 const getComponent = comp => `@budibase//materialdesign-components/${comp}`;
 
+
 export const props = {
   justAnH1: {
     _component: "@budibase/materialdesign-components/h1",
@@ -27,11 +28,11 @@ export const props = {
   textfield: {
     _component: "@budibase/materialdesign-components/textfield",
     _children: [],
-    label: "Surname",
-    icon: "alarm_on",
-    variant: "outlined",
-    helperText: "Add Surname",
+    label: "First",
+    colour: "secondary",
     textarea: true,
+    fullwidth:true,
+    helperText: "Add Surname",
     useCharCounter: true
   }
 };

--- a/packages/materialdesign-components/src/Textfield/Textfield.svelte
+++ b/packages/materialdesign-components/src/Textfield/Textfield.svelte
@@ -44,15 +44,14 @@
   export let persistent = false
 
   let id = `${label}-${variant}`
-  let helperClasses = `${cb.block}-helper-text`
 
-  let modifiers = []
+  let modifiers = { fullwidth, disabled, textarea }
   let customs = { colour }
 
   if (variant == "standard" || fullwidth) {
     customs = { ...customs, variant }
   } else {
-    modifiers.push(variant)
+    modifiers = { ...modifiers, variant }
   }
 
   if (!textarea && size !== "medium") {
@@ -60,15 +59,12 @@
   }
 
   if (!label || fullwidth) {
-    modifiers.push("no-label")
+    modifiers = { ...modifiers, noLabel: "no-label" }
   }
 
-  //TODO: Refactor - this could be handled better using an object as modifier instead of an array
-  if (fullwidth) modifiers.push("fullwidth")
-  if (disabled) modifiers.push("disabled")
-  if (textarea) modifiers.push("textarea")
-  if (persistent) helperClasses += ` ${cb.block}-helper-text--persistent`
-  if (validation) helperClasses += ` ${cb.block}-helper-text--validation`
+  let helperClasses = cb.debase(`${cb.block}-helper-text`, {
+    modifiers: { persistent, validation },
+  })
 
   let useLabel = !!label && (!fullwidth || (fullwidth && textarea))
   let useIcon = !!icon && (!textarea && !fullwidth)
@@ -77,16 +73,16 @@
 
   if (useIcon) {
     setContext("BBMD:icon:context", "text-field")
-    trailingIcon
-      ? modifiers.push("with-trailing-icon")
-      : modifiers.push("with-leading-icon")
+    let iconClass = trailingIcon ? "with-trailing-icon" : "with-leading-icon"
+    modifiers = { ...modifiers, iconClass }
   }
 
   $: renderLeadingIcon = useIcon && !trailingIcon
   $: renderTrailingIcon = useIcon && trailingIcon
 
-  const blockClasses = cb.blocks({ modifiers, customs })
-  const inputClasses = cb.elements("input")
+  let props = { modifiers, customs }
+  const blockClasses = cb.build({ props })
+  const inputClasses = cb.elem("input")
 
   let renderMaxLength = !!maxLength ? `0 / ${maxLength}` : "0"
 

--- a/packages/materialdesign-components/src/Textfield/_mixins.scss
+++ b/packages/materialdesign-components/src/Textfield/_mixins.scss
@@ -16,11 +16,12 @@
     &.bbmd-mdc-text-field--colour-secondary {
       &.mdc-text-field--focused {
         .mdc-floating-label--float-above {
-          color: var(--mdc-theme-secondary);
+          @include mdc-floating-label-ink-color(secondary)
+
         }
       }
       .mdc-line-ripple--active {
-        background-color: var(--mdc-theme-secondary);
+        @include mdc-line-ripple-color(secondary);
       }
 
       &.mdc-text-field--outlined,


### PR DESCRIPTION
**Classbuilder can now:**
- Accept props as they are and tack on relevant modifier and custom classes 
- Better / easier function naming conventions 
- debase fn - escape function in case I need to use a different base than the defined block
- elem fn - create an element class off the block by passing element name as arg
- Ignore defaults from both custom and modifier values

**Bug Fixes:**
- Using relevant mixins for custom colours instead of css vars and properties