### PR TITLE
Make page and screen props editable.

### DIFF
--- a/packages/builder/src/builderStore/store.js
+++ b/packages/builder/src/builderStore/store.js
@@ -112,7 +112,7 @@ export const getStore = () => {
   store.moveDownComponent = moveDownComponent(store)
   store.copyComponent = copyComponent(store)
   store.addTemplatedComponent = addTemplatedComponent(store)
-  store.setDetailProp = setDetailProp(store)
+  store.setMetadataProp = setMetadataProp(store)
   return store
 }
 
@@ -956,7 +956,7 @@ const walkProps = (props, action, cancelToken = null) => {
   }
 }
 
-const setDetailProp = store => (name, prop) => {
+const setMetadataProp = store => (name, prop) => {
   store.update(s => {
     s.currentPreviewItem[name] = prop
     return s

--- a/packages/builder/src/builderStore/store.js
+++ b/packages/builder/src/builderStore/store.js
@@ -112,6 +112,7 @@ export const getStore = () => {
   store.moveDownComponent = moveDownComponent(store)
   store.copyComponent = copyComponent(store)
   store.addTemplatedComponent = addTemplatedComponent(store)
+  store.setDetailProp = setDetailProp(store)
   return store
 }
 
@@ -517,6 +518,7 @@ const setCurrentScreen = store => screenName => {
     screen._css = generate_screen_css([screen.props])
     s.currentPreviewItem = screen
     s.currentFrontEndType = "screen"
+    s.currentView = "detail"
 
     s.currentComponentInfo = makePropsSafe(
       getContainerComponent(s.components),
@@ -764,6 +766,7 @@ const addChildComponent = store => (componentToAdd, presetName) => {
       ? _savePage(state)
       : _saveScreenApi(state.currentPreviewItem, state)
 
+    state.currentView = "component"
     state.currentComponentInfo = newComponent.props
 
     return state
@@ -794,6 +797,7 @@ const selectComponent = store => component => {
       ? component
       : state.components.find(c => c.name === component._component)
     state.currentComponentInfo = makePropsSafe(componentDef, component)
+    state.currentView = "component"
     return state
   })
 }
@@ -950,6 +954,13 @@ const walkProps = (props, action, cancelToken = null) => {
       walkProps(child, action, cancelToken)
     }
   }
+}
+
+const setDetailProp = store => (name, prop) => {
+  store.update(s => {
+    s.currentPreviewItem[name] = prop
+    return s
+  })
 }
 
 const _saveCurrentPreviewItem = s =>

--- a/packages/builder/src/userInterface/ComponentPropertiesPanel.svelte
+++ b/packages/builder/src/userInterface/ComponentPropertiesPanel.svelte
@@ -36,7 +36,6 @@
   function getProps(obj, keys) {
     return keys.map((k, i) => [k, obj[k], obj.props._id + i])
   }
-  $: console.log($store, component)
 </script>
 
 <div class="root">
@@ -87,7 +86,7 @@
             <input
               id={k}
               value={v}
-              on:input={({ target }) => store.setDetailProp(k, target.value)} />
+              on:input={({ target }) => store.setMetadataProp(k, target.value)} />
           </div>
         {/each}
         <PropsView {component} {components} {onPropChanged} />

--- a/packages/builder/src/userInterface/ComponentsPaneSwitcher.svelte
+++ b/packages/builder/src/userInterface/ComponentsPaneSwitcher.svelte
@@ -45,8 +45,6 @@
       {/if}
 
     </div>
-  {:else}
-    <p>Please create a new screen</p>
   {/if}
 
 </div>


### PR DESCRIPTION
This adds certain screen and page properties to the props panel and makes them editable.

Working a little blind here so if someone could take a look and see if anything else needs adding, or even if this is where they belong at all, that would be great.

I put them here for consistency with other props, there are already some styling and element-specific props that also needed to be accounted for, the 'page' and 'screen' specific props just sit above those and can be edited as expected.

I specifically didn't put them in a separate panel because I don't know if there is any mechanism for selecting a page in isolation from its container or if such a mechanism makes sense. This would also mean more context switching for the user who may not understand the distinction between a screen/page metadata and the container props. That would introduce another concept to learn that could add confusion.

I tried to work out why `_budbase.css` is not loading but I'm unsure where this regression was introduced or if it is just a local problem (since no-one else has mentioned it). I'm assuming that is why some styles don't seem to exists even though the functionality is correct.