### PR TITLE
Checkboxgroup with builder specific logic

### DIFF
--- a/packages/materialdesign-components/src/Checkbox/CheckboxGroup.svelte
+++ b/packages/materialdesign-components/src/Checkbox/CheckboxGroup.svelte
@@ -1,26 +1,29 @@
 <script>
+  import { onMount } from "svelte"
   import Checkbox from "./Checkbox.svelte"
   import Label from "../Common/Label.svelte"
+  import createItemsStore from "../Common/ItemStore.js"
 
+  let selectedItemsStore
+  let checkItems
+
+  export let _bb
   export let label = ""
   export let orientation = "row"
   export let fullwidth = false
   export let onChange = selectedItems => {}
 
-  export let items = []
-
   export let disabled = false
   export let alignEnd = false
   let selectedItems = []
 
-  function handleonChange(item) {
-    if (!!item.checked) {
-      item.checked = !item.checked
-    } else {
-      item.checked = true
-    }
-    onChange(items.filter(i => i.checked))
-  }
+  onMount(() => {
+    _bb.setContext("BBMD:input:context", "checkboxgroup")
+    selectedItemsStore = createItemsStore(() => onChange($selectedItemsStore))
+    _bb.setContext("BBMD:checkbox:selectedItemsStore", selectedItemsStore)
+  })
+
+  $: checkItems && _bb.attachChildren(checkItems)
 </script>
 
 <div class="checkbox-group">
@@ -28,18 +31,7 @@
     <Label text={label} bold />
   </div>
   <div class={`checkbox-group__boxes ${orientation}`}>
-    {#each items as item, i}
-      <div class:fullwidth>
-        <Checkbox
-          id={`${item.label}-${i}`}
-          {disabled}
-          {alignEnd}
-          indeterminate={item.indeterminate || false}
-          label={item.label}
-          checked={item.checked || false}
-          onClick={() => handleonChange(item)} />
-      </div>
-    {/each}
+    <div bind:this={checkItems} class:fullwidth />
   </div>
 </div>
 

--- a/packages/materialdesign-components/src/Radiobutton/Radiobutton.svelte
+++ b/packages/materialdesign-components/src/Radiobutton/Radiobutton.svelte
@@ -45,7 +45,6 @@
     if (context === "radiobuttongroup") {
       selectedItems.addSingleItem(item)
     } else {
-      debugger
       onClick(item)
     }
   }

--- a/packages/materialdesign-components/src/Radiobutton/RadiobuttonGroup.svelte
+++ b/packages/materialdesign-components/src/Radiobutton/RadiobuttonGroup.svelte
@@ -29,7 +29,7 @@
   //   item.checked = true
   //   selected = item
   //   items = items
-  //   onChange(selected)
+  //   onChange(selected)w
   // }
 
   $: alignRight = orientation === "column" && alignEnd

--- a/packages/materialdesign-components/src/Test/TestApp.svelte
+++ b/packages/materialdesign-components/src/Test/TestApp.svelte
@@ -40,6 +40,8 @@
             Select,
             Radiobutton,
             Radiobuttongroup,
+            Checkbox,
+            Checkboxgroup,
           ],
         },
       }

--- a/packages/materialdesign-components/src/Test/props.js
+++ b/packages/materialdesign-components/src/Test/props.js
@@ -82,14 +82,26 @@ export const props = {
   },
   Checkboxgroup: {
     _component: "@budibase/materialdesign-components/Checkboxgroup",
-    _children: [],
     label: "Whats your favourite?",
-    items: [
-      { label: "Currys", indeterminate: true },
-      { label: "Chips", checked: true },
-      { label: "Pasties" },
-    ],
     onChange: selectedItems => console.log(selectedItems),
+    _children: [
+      {
+        _component: "@budibase/materialdesign-components/Checkbox",
+        _children: [],
+        label: "Currys",
+        indeterminate: true,
+      },
+      {
+        _component: "@budibase/materialdesign-components/Checkbox",
+        _children: [],
+        label: "Chips",
+      },
+      {
+        _component: "@budibase/materialdesign-components/Checkbox",
+        _children: [],
+        label: "Pasties",
+      },
+    ],
   },
   Radiobutton: {
     _component: "@budibase/materialdesign-components/Radiobutton",
@@ -188,5 +200,5 @@ export const props = {
         value: "2",
       },
     ],
-  },
+  }
 }


### PR DESCRIPTION
Previously Checkbox groups worked by passing an items array that would be iterated over to produce Checkboxes that would be tied to the group, this didn't match up with how the tree structure of the builder worked.
Now, checkbox groups are handled similar to lists in that they use a svelte store and context to manage the items and keep the data in sync with the UI. It allow the Checkboxgroup component track the selected state of its children (Checkboxes) and pass the selected items out of itself using an onChange(selectedItems:[]) event handler