### PR TITLE
error recovery notification banner

### DIFF
--- a/packages/builder/src/App.svelte
+++ b/packages/builder/src/App.svelte
@@ -6,12 +6,26 @@
   import { onMount } from "svelte"
   import IconButton from "./common/IconButton.svelte"
   import Spinner from "./common/Spinner.svelte"
+  import AppNotification, { showAppNotification } from "./common/AppNotification.svelte"
 
   let init = initialise()
+
+  function showErrorBanner() {
+    showAppNotification({
+      status: "danger",
+      message:
+        "Whoops! Looks like we're having trouble. Please refresh the page.",
+    })
+  }
+
+  onMount(() => {
+    window.addEventListener("error", showErrorBanner)
+    window.addEventListener("unhandledrejection", showErrorBanner)
+  })
 </script>
 
 <main>
-
+  <AppNotification />
   {#await init}
     <div class="spinner-container">
       <Spinner />

--- a/packages/builder/src/PackageRoot.svelte
+++ b/packages/builder/src/PackageRoot.svelte
@@ -5,7 +5,6 @@
   import BackendRoot from "./BackendRoot.svelte"
   import { fade } from "svelte/transition"
   import { SettingsIcon, PreviewIcon } from "./common/Icons/"
-  import { showAppNotification } from "./common/AppNotification.svelte"
 
   const TABS = {
     BACKEND: "backend",

--- a/packages/builder/src/PackageRoot.svelte
+++ b/packages/builder/src/PackageRoot.svelte
@@ -5,6 +5,7 @@
   import BackendRoot from "./BackendRoot.svelte"
   import { fade } from "svelte/transition"
   import { SettingsIcon, PreviewIcon } from "./common/Icons/"
+  import { showAppNotification } from "./common/AppNotification.svelte"
 
   const TABS = {
     BACKEND: "backend",

--- a/packages/builder/src/builderStore/store/index.js
+++ b/packages/builder/src/builderStore/store/index.js
@@ -44,7 +44,7 @@ export const getStore = () => {
     currentNode: null,
     libraries: null,
     showSettings: false,
-    useAnalytics: true,
+    useAnalytics: true
   }
 
   const store = writable(initial)

--- a/packages/builder/src/common/AppNotification.svelte
+++ b/packages/builder/src/common/AppNotification.svelte
@@ -1,0 +1,76 @@
+<script context="module">
+  import UIKit from "uikit"
+
+  export function showAppNotification({ message, status }) {
+    UIKit.notification({
+      message: `
+          <div class="message-container">
+            <i class="ri-information-fill information-icon"></i> 
+            <span class="notification-message"> 
+              ${message}
+            </span>
+            <button class="hoverable refresh-page-button" onclick="window.location.reload()">Refresh Page</button>
+          </div>
+        `,
+      status,
+      timeout: 100000
+    })
+  }
+</script>
+
+<style>
+  :global(.information-icon) {
+    font-size: 24px;
+  }
+
+  :global(.uk-nofi) {
+    display: grid;
+    grid-template-columns: 40px 1fr auto;
+    grid-gap: 5px;
+    align-items: center;
+  }
+
+  :global(.message-container) {
+    display: grid;
+    grid-template-columns: 40px 1fr auto;
+    grid-gap: 5px;
+    align-items: center;
+  }
+
+  :global(.uk-notification) {
+    width: 50% !important;
+    left: 0 !important;
+    right: 0 !important;
+    margin-right: auto !important;
+    margin-left: auto !important;
+    border-radius: 10px;
+    box-shadow: 0px 3px 6px #00000029;
+  }
+
+  :global(.uk-notification-message) {
+    border-radius: 5px;
+  }
+
+  :global(.uk-notification-message:hover .uk-notification-close) {
+    visibility: hidden;
+  }
+
+  :global(.uk-notification-message-danger) {
+    background: #f2545b !important;
+    color: #fff !important;
+    font-family: Roboto;
+    font-size: 14px !important;
+  }
+
+  :global(.refresh-page-button) {
+    font-size: 12px;
+    font-weight: 600;
+    border-radius: 5px;
+    border: none;
+    padding: 5px;
+    width: 91px;
+    height: 28px;
+    color: #f2545b;
+    background: #ffffff;
+  }
+</style>


### PR DESCRIPTION
Addresses https://github.com/Budibase/budibase/issues/173

- Catch all banner for errors
- This will happen for all uncaught promises and runtime exceptions in the UI

Please note that I had to use module scope, `!important` and a bit of vanilla JS to make UIKits imperative API able to display the notification and work in the global error handler. If you let svelte render it declaratively, the uncaught exception prevents the next render and you don't see the notification.

The module context provides a simple API for showing and hiding notifications in budibase.

#### Screenshots
![Screenshot 2020-03-30 at 21 15 42](https://user-images.githubusercontent.com/11256663/77957872-146ffd80-72cc-11ea-9152-2ad0f56b51ee.png)

