### PR TITLE
Image Component

### DIFF
--- a/packages/builder/src/components/userInterface/temporaryPanelStructure.js
+++ b/packages/builder/src/components/userInterface/temporaryPanelStructure.js
@@ -195,7 +195,7 @@ export default {
           children: [],
           properties: {
             design: { ...all },
-            settings: [{label: "URL", key: "url", control: Input }],
+            settings: [{ label: "URL", key: "url", control: Input }],
           },
         },
         {

--- a/packages/builder/src/components/userInterface/temporaryPanelStructure.js
+++ b/packages/builder/src/components/userInterface/temporaryPanelStructure.js
@@ -188,6 +188,17 @@ export default {
           },
         },
         {
+          _component: "@budibase/standard-components/image",
+          name: "Image",
+          description: "A basic component for displaying images",
+          icon: "ri-image-fill",
+          children: [],
+          properties: {
+            design: { ...all },
+            settings: [{label: "URL", key: "url", control: Input }],
+          },
+        },
+        {
           _component: "@budibase/standard-components/icon",
           name: "Icon",
           description: "A basic component for displaying icons",

--- a/packages/standard-components/src/DataForm.svelte
+++ b/packages/standard-components/src/DataForm.svelte
@@ -87,7 +87,6 @@
 
   .form-content {
     margin-bottom: 20px;
-
   }
 
   .input {

--- a/packages/standard-components/src/DataTable.svelte
+++ b/packages/standard-components/src/DataTable.svelte
@@ -65,7 +65,7 @@
   }
 
   thead {
-    background: #393C44;
+    background: #393c44;
     border: 1px solid #ccc;
     height: 40px;
     text-align: left;
@@ -87,7 +87,7 @@
   tbody tr {
     border-bottom: 1px solid #ccc;
     transition: 0.3s background-color;
-    color: #393C44;
+    color: #393c44;
     font-size: 14px;
     height: 40px;
   }

--- a/packages/standard-components/src/Image.svelte
+++ b/packages/standard-components/src/Image.svelte
@@ -7,6 +7,8 @@
   export let height
   export let width
 
+  export let _bb
+
   $: style = buildStyle({ height, width })
 </script>
 


### PR DESCRIPTION
Image component added to builder

## Description
Before, you could not add an image to the UI which was a pain when attempted to add, for example, an avatar.

## Screenshots
![Screenshot 2020-06-09 at 11 37 05](https://user-images.githubusercontent.com/49767913/84138041-8d66a080-aa45-11ea-892f-bf438c4a7002.png)



