### PR TITLE
Colorpicker - Swatch Panel, Logic and UI Updates

### DIFF
--- a/packages/builder/src/components/userInterface/Colorpicker/CheckedBackground.svelte
+++ b/packages/builder/src/components/userInterface/Colorpicker/CheckedBackground.svelte
@@ -1,5 +1,6 @@
 <script>
     import {buildStyle} from "./helpers.js"
+    import {fade} from "svelte/transition"
 
     export let backgroundSize = "10px"
     export let borderRadius = ""
@@ -18,6 +19,6 @@
   }
 </style>
 
-<div {style}>
+<div transition:fade {style}>
     <slot />
 </div>

--- a/packages/builder/src/components/userInterface/Colorpicker/CheckedBackground.svelte
+++ b/packages/builder/src/components/userInterface/Colorpicker/CheckedBackground.svelte
@@ -6,8 +6,9 @@
     export let borderRadius = ""
     export let height = ""
     export let width = ""
+    export let margin = ""
 
-    $: style = buildStyle({backgroundSize, borderRadius, height, width})
+    $: style = buildStyle({backgroundSize, borderRadius, height, width, margin})
 
 </script>
 
@@ -19,6 +20,6 @@
   }
 </style>
 
-<div transition:fade {style}>
+<div in:fade {style}>
     <slot />
 </div>

--- a/packages/builder/src/components/userInterface/Colorpicker/Colorpicker.svelte
+++ b/packages/builder/src/components/userInterface/Colorpicker/Colorpicker.svelte
@@ -1,5 +1,6 @@
 <script>
   import { onMount, createEventDispatcher } from "svelte";
+  import { fade } from 'svelte/transition';
   import CheckedBackground from "./CheckedBackground.svelte"
   import {buildStyle} from "./helpers.js"
   import {
@@ -14,6 +15,11 @@
 
   export let value = "#3ec1d3ff";
   export let format = "hexa";
+  
+  let recentColors = []
+
+  export let pickerHeight = 0;
+  export let pickerWidth = 0;
 
   let h = null;
   let s = null;
@@ -23,10 +29,29 @@
   const dispatch = createEventDispatcher();
 
   onMount(() => {
+    getRecentColors()
+
     if (format) {
       convertAndSetHSVA()
     }
   });
+
+  function getRecentColors() {
+    let colorStore = localStorage.getItem("cp:recent-colors")
+    if (colorStore) {
+      recentColors = JSON.parse(colorStore)
+    }
+  }
+
+  function setRecentColor(color) {
+    if (recentColors.length === 6) {
+      recentColors.splice(0, 1)
+    }
+    if (!recentColors.includes(color)) {
+      recentColors = [...recentColors, color]
+      localStorage.setItem("cp:recent-colors", JSON.stringify(recentColors))
+    }
+  }
 
   function convertAndSetHSVA() {
     let hsva = convertToHSVA(value, format);
@@ -45,17 +70,30 @@
     s = detail.s;
     v = detail.v;
     value = convertHsvaToFormat([h, s, v, a], format);
+    setRecentColor(value)
+    dispatchValue()
+  }
+
+  function setHue({color, isDrag}) {
+    h = color;
+    value = convertHsvaToFormat([h, s, v, a], format);   
+    if(!isDrag) {
+      setRecentColor(value)
+      dispatchValue()
+    } 
+  }
+
+  function setAlpha({color, isDrag}) {
+    a = color === "1.00" ? "1" : color;
+    value = convertHsvaToFormat([h, s, v, a], format);    
+    if(!isDrag) {
+        setRecentColor(value)
+        dispatchValue()
+      } 
+  }
+
+  function dispatchValue() {
     dispatch("change", value)
-  }
-
-  function setHue(hue) {
-    h = hue;
-    value = convertHsvaToFormat([h, s, v, a], format);    
-  }
-
-  function setAlpha(alpha) {
-    a = alpha === "1.00" ? "1" :alpha;
-    value = convertHsvaToFormat([h, s, v, a], format);    
   }
 
   function changeFormatAndConvert(f) {
@@ -64,16 +102,32 @@
   }
 
   function handleColorInput(text) {
-    let f = getColorFormat(text)
-    if(f) {
-      format = f;
+    let format = getColorFormat(text)
+    if(format) {
       value = text
       convertAndSetHSVA()
-      dispatch("change", value)
     }
   }
 
-    $: border = s < 10 ? "1px dashed #dedada" : ""
+  function dispatchInputChange() {
+    if(format) {
+      setRecentColor(value)
+      dispatchValue()
+    }
+  }
+  
+
+  function applyRecentColor(color) {
+    if(value !== color) {
+      format = getColorFormat(color)
+      if(format) {
+        value = color
+        convertAndSetHSVA()
+        dispatchValue()
+      }
+    }
+  }
+    $: border = (v > 90 && s < 5) ? "1px dashed #dedada" : ""
     $: style = buildStyle({background: value, border})
 </script>
 
@@ -83,7 +137,8 @@
     font-size: 11px;
     font-weight: 400;
     flex-direction: column;
-    height: 265px;
+    /* height: 265px; */
+    height: auto;
     width: 220px;
     background: #ffffff;
     border-radius: 2px;
@@ -118,6 +173,24 @@
     border-radius: 50%;
   }
 
+  .recent-color-panel {
+    flex: 0 0 15px;
+    display: grid;
+    grid-gap: 10px;
+    justify-content: flex-start;
+    grid-auto-flow: column;
+    padding: 5px;
+    margin-left: 6px;
+  }
+
+  .recent-color {
+    cursor: pointer;
+    border-radius: 6px;
+    border: 1px solid #dedada;  
+    height: 20px; 
+    width: 20px;   
+  }
+
   .format-input-panel {
     display: flex;
     flex-direction: column;
@@ -125,7 +198,7 @@
   }
 </style>
 
-<div class="colorpicker-container">
+<div class="colorpicker-container" bind:clientHeight={pickerHeight} bind:clientWidth={pickerWidth}>
 
   <div class="palette-panel">
     <Palette on:change={setSaturationAndValue} {h} {s} {v} {a} />
@@ -139,21 +212,33 @@
         </CheckedBackground>
       </div>
       <div>
-        <Slider type="hue" value={h} on:change={hue => setHue(hue.detail)} />
+        <Slider type="hue" value={h} on:change={(hue) => setHue(hue.detail)} on:dragend={dispatchValue} />
 
         <CheckedBackground borderRadius="10px" backgroundSize="7px">
           <Slider
             type="alpha"
             value={a}
-            on:change={alpha => setAlpha(alpha.detail)} />
+            on:change={(alpha, isDrag) => setAlpha(alpha.detail, isDrag)} 
+            on:dragend={dispatchValue}
+            />
         </CheckedBackground>
         
       </div>
     </div>
 
+    {#if recentColors.length > 0}
+      <div transition:fade class="recent-color-panel">
+        {#each recentColors as color}
+          <CheckedBackground borderRadius="6px"> 
+            <div transition:fade class="recent-color" style={`background: ${color};`} on:click={() => applyRecentColor(color)} />
+          </CheckedBackground>
+        {/each}
+      </div>
+    {/if}
+
     <div class="format-input-panel">
       <ButtonGroup {format} onclick={changeFormatAndConvert} />
-      <Input {value} on:input={event => handleColorInput(event.target.value)} />
+      <Input {value} on:input={event => handleColorInput(event.target.value)} on:change={dispatchInputChange} />
     </div>
   </div>
 

--- a/packages/builder/src/components/userInterface/Colorpicker/Colorpreview.svelte
+++ b/packages/builder/src/components/userInterface/Colorpicker/Colorpreview.svelte
@@ -2,6 +2,7 @@
     import Colorpicker from "./Colorpicker.svelte"
     import CheckedBackground from "./CheckedBackground.svelte"
     import {createEventDispatcher, afterUpdate, beforeUpdate} from "svelte"
+
     import {buildStyle} from "./helpers.js"
     import { fade } from 'svelte/transition';
     import {getColorFormat} from "./utils.js"
@@ -17,8 +18,8 @@
 
     let previewHeight = null    
     let previewWidth = null
-    let pickerWidth = 250
-    let pickerHeight = 300
+    let pickerWidth = 0
+    let pickerHeight = 0
 
     let anchorEl = null
     let parentNodes = [];
@@ -61,30 +62,33 @@
 
     function openColorpicker(event) {
         if(colorPreview) {
-            const {top: spaceAbove, width, bottom, right, left: spaceLeft} = colorPreview.getBoundingClientRect()   
-            const {innerHeight, innerWidth} = window
-
-            const {offsetLeft, offsetTop} = colorPreview
-            //get the scrollTop value for all scrollable parent elements 
-            let scrollTop = parentNodes.reduce((scrollAcc, el) => scrollAcc += el.scrollTop, 0);
-
-            const spaceBelow = (innerHeight - spaceAbove) - previewHeight
-            const top = spaceAbove > spaceBelow ? (offsetTop - pickerHeight) - scrollTop : (offsetTop + previewHeight) - scrollTop      
-            
-            //TOO: Testing and Scroll Awareness for x Scroll
-            const spaceRight = (innerWidth - spaceLeft) + previewWidth
-            const left = spaceRight > spaceLeft ? (offsetLeft + previewWidth) : offsetLeft - pickerWidth
-
-            dimensions = {top, left}
-
             open = true;        
         }
+    }
+
+    $: if(open && colorPreview) {
+        const {top: spaceAbove, width, bottom, right, left: spaceLeft} = colorPreview.getBoundingClientRect()   
+        const {innerHeight, innerWidth} = window
+
+        const {offsetLeft, offsetTop} = colorPreview
+        //get the scrollTop value for all scrollable parent elements 
+        let scrollTop = parentNodes.reduce((scrollAcc, el) => scrollAcc += el.scrollTop, 0);
+
+        const spaceBelow = (innerHeight - spaceAbove) - previewHeight
+        const top = spaceAbove > spaceBelow ? (offsetTop - pickerHeight) - scrollTop : (offsetTop + previewHeight) - scrollTop      
+        
+        //TOO: Testing and Scroll Awareness for x Scroll
+        const spaceRight = (innerWidth - spaceLeft) + previewWidth
+        const left = spaceRight > spaceLeft ? (offsetLeft + previewWidth) : offsetLeft - pickerWidth
+
+        dimensions = {top, left}
     }
 
     function onColorChange(color) {
         value = color.detail;
         dispatch("change", color.detail)
     }
+
 </script>
 
 <div class="color-preview-container">
@@ -94,8 +98,8 @@
         </CheckedBackground>
 
         {#if open}
-        <div class="picker-container" bind:clientHeight={pickerHeight} bind:clientWidth={pickerWidth} style={pickerStyle}>
-            <Colorpicker on:change={onColorChange} {format} {value} />
+        <div transition:fade class="picker-container" style={pickerStyle}>
+            <Colorpicker on:change={onColorChange} bind:format bind:value bind:pickerHeight bind:pickerWidth />
         </div>
         <div on:click|self={() => open = false} class="overlay"></div>
         {/if}

--- a/packages/builder/src/components/userInterface/Colorpicker/Colorpreview.svelte
+++ b/packages/builder/src/components/userInterface/Colorpicker/Colorpreview.svelte
@@ -8,6 +8,8 @@
     import {getColorFormat} from "./utils.js"
 
     export let value = "#3ec1d3ff"
+    export let swatches = []
+    export let disableSwatches = false
     export let open = false;
     export let width = "25px"
     export let height = "25px"
@@ -99,7 +101,7 @@
 
         {#if open}
         <div transition:fade class="picker-container" style={pickerStyle}>
-            <Colorpicker on:change={onColorChange} bind:format bind:value bind:pickerHeight bind:pickerWidth />
+            <Colorpicker on:change={onColorChange} on:addswatch on:removeswatch bind:format bind:value bind:pickerHeight bind:pickerWidth {swatches} {disableSwatches} {open} />
         </div>
         <div on:click|self={() => open = false} class="overlay"></div>
         {/if}

--- a/packages/builder/src/components/userInterface/Colorpicker/Input.svelte
+++ b/packages/builder/src/components/userInterface/Colorpicker/Input.svelte
@@ -24,5 +24,5 @@
 </style>
 
 <div>
-  <input on:input type="text" {value} maxlength="25" />
+  <input on:input on:change type="text" {value} maxlength="25" />
 </div>

--- a/packages/builder/src/components/userInterface/Colorpicker/Slider.svelte
+++ b/packages/builder/src/components/userInterface/Colorpicker/Slider.svelte
@@ -10,7 +10,7 @@
   let slider;
   let sliderWidth = 0;
 
-  function handleClick(mouseX) {
+  function onSliderChange(mouseX, isDrag = false) {
     const { left, width } = slider.getBoundingClientRect();
     let clickPosition = mouseX - left;
 
@@ -21,7 +21,8 @@
         type === "hue"
           ? 360 * percentageClick
           : percentageClick;
-      dispatch("change", value);
+      
+      dispatch("change", {color: value, isDrag});
     }
   }
 
@@ -75,13 +76,14 @@
 <div
   bind:this={slider}
   bind:clientWidth={sliderWidth}
-  on:click={event => handleClick(event.clientX)}
+  on:click={event => onSliderChange(event.clientX)}
   class="color-format-slider"
   class:hue={type === 'hue'}
   class:alpha={type === 'alpha'}>
   <div
     use:dragable
-    on:drag={e => handleClick(e.detail)}
+    on:drag={e => onSliderChange(e.detail, true)}
+    on:dragend
     class="slider-thumb"
     {style} />
 </div>

--- a/packages/builder/src/components/userInterface/Colorpicker/Swatch.svelte
+++ b/packages/builder/src/components/userInterface/Colorpicker/Swatch.svelte
@@ -1,0 +1,53 @@
+<script>
+    import {createEventDispatcher} from "svelte"
+    import { fade } from 'svelte/transition';
+    import CheckedBackground from "./CheckedBackground.svelte"
+
+    export let hovered = false
+    export let color = "#fff"
+
+    const dispatch = createEventDispatcher()
+
+</script>
+
+<style>
+  .swatch {
+    position: relative;
+    cursor: pointer;
+    border-radius: 6px;
+    border: 1px solid #dedada;  
+    height: 20px; 
+    width: 20px;
+  }
+
+  .space {
+      padding: 3px 5px;
+  }
+
+  .remove-icon {
+    position: absolute;
+    right: 0;
+    top: -5px;
+    right: -4px;
+    width:10px;
+    height: 10px;
+    border-radius: 50%;
+    background-color: #800000;
+    color: #fff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+</style>
+
+<div class="space">
+  <CheckedBackground borderRadius="6px"> 
+    <div in:fade class="swatch" style={`background: ${color};`} on:click|self on:mouseover={() => hovered = true} on:mouseleave={() => hovered = false}>
+        {#if hovered}
+        <div in:fade class="remove-icon" on:click|self={()=> dispatch("removeswatch")}>
+            <span on:click|self={()=> dispatch("removeswatch")}>&times;</span>
+        </div>
+        {/if}
+    </div>            
+</CheckedBackground>
+</div>

--- a/packages/builder/src/components/userInterface/Colorpicker/drag.js
+++ b/packages/builder/src/components/userInterface/Colorpicker/drag.js
@@ -16,6 +16,7 @@ export default function(node) {
   function handleMouseUp() {
     window.removeEventListener("mousedown", handleMouseDown)
     window.removeEventListener("mousemove", handleMouseMove)
+    node.dispatchEvent(new CustomEvent("dragend"))
   }
 
   node.addEventListener("mousedown", handleMouseDown)


### PR DESCRIPTION
**Demo Video**
https://www.loom.com/share/34b30e702996453793f8ac7d173e47cf

**DONE**
- Swatches (recent colours) are now user definable
- The user can add up to 12 swatches / recent colours
- The user can remove swatches using the close icon in the top right of the swatch
- If an array of swatches are passed to the color picker they will be used instead of locally stored recent colours. This will allow Budibase users to save colours to the Db and pass them to the Colorpicker Note: colours added will still save to local storage
- Added and exposed events `on:removeswatch` and `on:addswatch` so the user can react to these things whichever way they want
- Added a prop to disableSwatches 
- Styling updates and transition events

**TODO**
- Bug fixes, testing and tweaks to make it ready for publishing