### PR TITLE
Close on select and wrap selection

### DIFF
--- a/packages/builder/src/components/userInterface/OptionSelect.svelte
+++ b/packages/builder/src/components/userInterface/OptionSelect.svelte
@@ -80,6 +80,7 @@
   function handleClick(val) {
     value = val
     onChange(value)
+    toggleSelect(false)
   }
 
   $: menuStyle = buildStyle({
@@ -108,7 +109,7 @@
   bind:this={select}
   class="bb-select-container"
   on:click={() => toggleSelect(!open)}>
-  <div bind:this={selectAnchor} class="bb-select-anchor selected">
+  <div bind:this={selectAnchor} title={value} class="bb-select-anchor selected">
     <span>{displayLabel}</span>
     <i bind:this={icon} class="ri-arrow-down-s-fill" />
   </div>
@@ -174,6 +175,7 @@
     background-color: var(--grey-2);
     border-radius: 5px;
     align-items: center;
+    white-space: nowrap;
   }
 
   .bb-select-anchor > span {


### PR DESCRIPTION
- Close select menu on option select.
- Wrap selection text in anchor.
- Use title to display selection in full.


