### PR TITLE
#383 rename Model > Table (ui only) & #290 field name validation

### DIFF
--- a/packages/builder/src/components/database/ModelDataTable/modals/CreateEditModel/CreateEditModel.svelte
+++ b/packages/builder/src/components/database/ModelDataTable/modals/CreateEditModel/CreateEditModel.svelte
@@ -37,7 +37,7 @@
 <div class="heading">
   {#if !showFieldView}
     <i class="ri-list-settings-line button--toggled" />
-    <h3 class="budibase__title--3">Create / Edit Model</h3>
+    <h3 class="budibase__title--3">Create / Edit Table</h3>
   {:else}
     <i class="ri-file-list-line button--toggled" />
     <h3 class="budibase__title--3">Create / Edit Field</h3>

--- a/packages/builder/src/components/nav/ModelNavigator/EmptyModel.svelte
+++ b/packages/builder/src/components/nav/ModelNavigator/EmptyModel.svelte
@@ -19,19 +19,19 @@
         ...rest,
       },
     })
-    notifier.success(`${model.name} model created.`)
+    notifier.success(`${model.name} table created.`)
   }
 </script>
 
 <section transition:fade>
   <header>
-    <h2>Create New Model</h2>
-    <p>Before you can view your model, you need to set it up.</p>
+    <h2>Create New Table</h2>
+    <p>Before you can view your table, you need to set it up.</p>
   </header>
 
   <div class="block-row">
     <span class="block-row-title">Fields</span>
-    <p>Blocks are pre-made fields and help you build your model quicker.</p>
+    <p>Blocks are pre-made fields and help you build your table quicker.</p>
     <div class="blocks">
       {#each Object.values(FIELDS) as field}
         <Block
@@ -45,7 +45,7 @@
 
   <div class="block-row">
     <span class="block-row-title">Blocks</span>
-    <p>Blocks are pre-made fields and help you build your model quicker.</p>
+    <p>Blocks are pre-made fields and help you build your table quicker.</p>
     <div class="blocks">
       {#each Object.values(BLOCKS) as field}
         <Block
@@ -58,8 +58,8 @@
   </div>
 
   <div class="block-row">
-    <span class="block-row-title">Models</span>
-    <p>Blocks are pre-made fields and help you build your model quicker.</p>
+    <span class="block-row-title">Tables</span>
+    <p>Blocks are pre-made fields and help you build your table quicker.</p>
     <div class="blocks">
       {#each Object.values(MODELS) as model}
         <Block

--- a/packages/builder/src/components/nav/ModelNavigator/ModelNavigator.svelte
+++ b/packages/builder/src/components/nav/ModelNavigator/ModelNavigator.svelte
@@ -53,7 +53,7 @@
           bind:value={$backendUiStore.tabs.NAVIGATION_PANEL}>
           {#if selectedTab === 'NAVIGATE'}
             <Button purple wide on:click={setupForNewModel}>
-              Create New Model
+              Create New Table
             </Button>
             <div class="hierarchy-items-container">
               {#each $backendUiStore.models as model}

--- a/packages/builder/src/components/nav/ModelSetupNav/ModelSetupNav.svelte
+++ b/packages/builder/src/components/nav/ModelSetupNav/ModelSetupNav.svelte
@@ -52,7 +52,35 @@
     })
   }
 
+  function validate() {
+    let errors = []
+    for (let field of Object.values($backendUiStore.draftModel.schema)) {
+      const restrictedFieldNames = ["type", "modelId"]
+      if (field.name.startsWith("_")) {
+        errors.push(`field '${field.name}' - name cannot begin with '_''`)
+      } else if (restrictedFieldNames.includes(field.name)) {
+        errors.push(`field '${field.name}' - is a restricted name, please rename`)
+      } else if (!field.name || !field.name.trim()) {
+        errors.push("field name cannot be blank")
+      }
+    }
+
+    if (!$backendUiStore.draftModel.name) {
+      errors.push("Table name cannot be blank")
+    }
+
+    return errors
+  }
+
   async function saveModel() {
+    const errors = validate()
+    if (errors.length > 0) {
+      notifier.danger(
+        errors.join("/n")
+      )
+      return
+    }
+
     await backendUiStore.actions.models.save({
       model: $backendUiStore.draftModel,
     })

--- a/packages/builder/src/components/userInterface/temporaryPanelStructure.js
+++ b/packages/builder/src/components/userInterface/temporaryPanelStructure.js
@@ -313,7 +313,7 @@ export default {
           icon: "ri-archive-drawer-fill",
           properties: {
             design: { ...all },
-            settings: [{ label: "Model", key: "model", control: ModelSelect }],
+            settings: [{ label: "Table", key: "model", control: ModelSelect }],
           },
           children: [],
         },
@@ -331,7 +331,7 @@ export default {
                 design: { ...all },
                 settings: [
                   {
-                    label: "Model",
+                    label: "Table",
                     key: "model",
                     control: ModelSelect,
                   },
@@ -351,7 +351,7 @@ export default {
                 design: { ...all },
                 settings: [
                   {
-                    label: "Model",
+                    label: "Table",
                     key: "model",
                     control: ModelSelect,
                   },
@@ -368,7 +368,7 @@ export default {
           properties: {
             design: { ...all },
             settings: [
-              { label: "Model", key: "model", control: ModelSelect },
+              { label: "Table", key: "model", control: ModelSelect },
               {
                 label: "Chart Type",
                 key: "type",
@@ -399,18 +399,18 @@ export default {
           icon: "ri-file-list-fill",
           properties: {
             design: { ...all },
-            settings: [{ label: "Model", key: "model", control: ModelSelect }],
+            settings: [{ label: "Table", key: "model", control: ModelSelect }],
           },
           children: [],
         },
         {
           name: "List",
           _component: "@budibase/standard-components/list",
-          description: "Renders all children once per record, of a given model",
+          description: "Renders all children once per record, of a given table",
           icon: "ri-file-list-fill",
           properties: {
             design: { ...all },
-            settings: [{ label: "Model", key: "model", control: ModelSelect }],
+            settings: [{ label: "Table", key: "model", control: ModelSelect }],
           },
           children: [],
         },
@@ -422,7 +422,7 @@ export default {
           icon: "ri-profile-line",
           properties: {
             design: { ...all },
-            settings: [{ label: "Model", key: "model", control: ModelSelect }],
+            settings: [{ label: "Table", key: "model", control: ModelSelect }],
           },
           children: [],
         },

--- a/packages/builder/src/pages/[application]/backend/model/[selectedModel]/index.svelte
+++ b/packages/builder/src/pages/[application]/backend/model/[selectedModel]/index.svelte
@@ -28,7 +28,7 @@
 {:else if $backendUiStore.selectedDatabase._id && selectedModel.name}
   <ModelDataTable />
 {:else}
-  <i style="color: var(--grey-4)">create your first model to start building</i>
+  <i style="color: var(--grey-4)">create your first table to start building</i>
 {/if}
 
 <style>

--- a/packages/builder/src/pages/[application]/backend/model/index.svelte
+++ b/packages/builder/src/pages/[application]/backend/model/index.svelte
@@ -22,5 +22,5 @@
 </script>
 
 {#if $backendUiStore.models.length === 0}
-  Please create a model
-{:else}Please select a model{/if}
+  Please create a table
+{:else}Please select a table{/if}

--- a/packages/standard-components/components.json
+++ b/packages/standard-components/components.json
@@ -196,21 +196,21 @@
 		}
 	},
 	"datatable": {
-		"description": "an HTML table that fetches data from a model or view and displays it.",
+		"description": "an HTML table that fetches data from a table or view and displays it.",
 		"data": true,
 		"props": {
 			"model": "models" 
 		}
 	},
 	"dataform": {
-		"description": "an HTML table that fetches data from a model or view and displays it.",
+		"description": "an HTML table that fetches data from a table or view and displays it.",
 		"data": true,
 		"props": {
 			"model": "models"
 		}
 	},
 	"dataformwide": {
-		"description": "an HTML table that fetches data from a model or view and displays it.",
+		"description": "an HTML table that fetches data from a table or view and displays it.",
 		"data": true,
 		"props": {
 			"model": "models"


### PR DESCRIPTION
#383 

Models are now called Tables, in the builder UI

#290 

fields are no longer allowed to be named
- `type` or `modelId`
- anything beginning with `_`
- whitespace

