### PR TITLE
Format change after input- Set format correctly

### DIFF
--- a/packages/builder/src/components/userInterface/Colorpicker/components/Colorpicker.svelte
+++ b/packages/builder/src/components/userInterface/Colorpicker/components/Colorpicker.svelte
@@ -125,7 +125,7 @@
   }
 
   function handleColorInput(text) {
-    let format = getColorFormat(text)
+    format = getColorFormat(text)
     if (format) {
       value = text
       convertAndSetHSVA()


### PR DESCRIPTION
Colorpicker was losing format after accepting textfield input


