### PR TITLE
fix: create app failing from unknown folder copy issues

### DIFF
--- a/packages/server/src/api/controllers/application.js
+++ b/packages/server/src/api/controllers/application.js
@@ -11,6 +11,7 @@ const { exec } = require("child_process")
 const sqrl = require("squirrelly")
 const setBuilderToken = require("../../utilities/builder/setBuilderToken")
 const fs = require("fs-extra")
+const chmodr = require("../../utilities/chmodr")
 
 exports.fetch = async function(ctx) {
   const db = new CouchDB(ClientDb.name(getClientId(ctx)))
@@ -137,6 +138,11 @@ const createEmptyAppPackage = async (ctx, app) => {
   }
 
   await copy(templateFolder, newAppFolder)
+
+  // this line allows full permission on copied files
+  // we have an unknown problem without this, whereby the
+  // files get weird permissions and cant be written to :(
+  await chmodr(newAppFolder, 0o777)
 
   await updateJsonFile(join(appsFolder, app._id, "package.json"), {
     name: npmFriendlyAppName(app.name),

--- a/packages/server/src/utilities/chmodr.js
+++ b/packages/server/src/utilities/chmodr.js
@@ -1,0 +1,17 @@
+const fs = require("fs-extra")
+const { join } = require("path")
+
+const chmodr = async (dir, perms) => {
+  const children = await fs.readdir(dir)
+  for (let child of children) {
+    const fullChildPath = join(dir, child)
+    const stat = await fs.stat(join(dir, child))
+    if (stat.isFile()) {
+      await fs.chmod(fullChildPath, perms)
+    } else {
+      await chmodr(fullChildPath, perms)
+    }
+  }
+}
+
+module.exports = chmodr


### PR DESCRIPTION
recursively chmod on all files in the appDirectoryTemplate folder.
also added a "placeholder" files in the unauthenticated screens directory, so that folder gets copied
