### PR TITLE
Backend/Workflow layout update

### DIFF
--- a/packages/builder/src/components/common/Switcher.svelte
+++ b/packages/builder/src/components/common/Switcher.svelte
@@ -65,6 +65,7 @@
     margin-right: 20px;
     background: none;
     outline: none;
+    font-family: Inter;
   }
 
   .switcher > .selected {

--- a/packages/builder/src/pages/[application]/backend/_layout.svelte
+++ b/packages/builder/src/pages/[application]/backend/_layout.svelte
@@ -22,7 +22,8 @@
 <style>
   .root {
     height: 100%;
-    display: flex;
+    display: grid;
+    grid-template-columns: 300px minmax(0, 1fr) 300px;
     background: var(--grey-1);
     line-height: 1;
   }

--- a/packages/builder/src/pages/[application]/workflow/_layout.svelte
+++ b/packages/builder/src/pages/[application]/workflow/_layout.svelte
@@ -27,7 +27,8 @@
 
   .root {
     height: 100%;
-    display: flex;
+    display: grid;
+    grid-template-columns: 300px minmax(0, 1fr) 300px;
     background: var(--grey-1);
     line-height: 1;
   }

--- a/packages/standard-components/src/DataTable.svelte
+++ b/packages/standard-components/src/DataTable.svelte
@@ -71,6 +71,8 @@
     background: #fff;
     border-radius: 3px;
     border-collapse: collapse;
+    overflow: scroll; /* Scrollbar are always visible */
+    overflow: auto; /* Scrollbar is displayed as it's needed */
   }
 
   thead {


### PR DESCRIPTION
The backend table was pushing the right panel out of sight on smaller screens. I have added CSS grid to control the layout, including a minimax section so the content does not dictate the size of the middle screen.

## Screenshots
![Screenshot 2020-07-14 at 14 52 40](https://user-images.githubusercontent.com/49767913/87433813-abde2f80-c5e1-11ea-9557-19520465194a.png)


