### PR TITLE
component libraries - looking in wrong dir, in dev

### DIFF
--- a/packages/server/src/api/controllers/component.js
+++ b/packages/server/src/api/controllers/component.js
@@ -27,7 +27,6 @@ exports.fetchAppComponentDefinitions = async function(ctx) {
       const componentJson = require(join(
         appDirectory,
         componentLibrary,
-        "package",
         "components.json"
       ))
 


### PR DESCRIPTION
The `package` dir (see commit) is required when components are donwloaded from NPM, but not when sym-linking in dev.


