### PR TITLE
Backend button width fix

### DIFF
--- a/packages/builder/src/components/nav/ModelSetupNav/ModelSetupNav.svelte
+++ b/packages/builder/src/components/nav/ModelSetupNav/ModelSetupNav.svelte
@@ -131,7 +131,7 @@
   }
 
   footer {
-    width: 100%;
+    width: 260px;
     position: fixed;
     bottom: 20px;
   }


### PR DESCRIPTION
## Description
In the backend of the builder, where tables are edited, the footer button was not contained within its container.
## Screenshots
![Screenshot 2020-08-07 at 17 10 29](https://user-images.githubusercontent.com/49767913/89665660-e67d7400-d8d0-11ea-9e71-30e416c1aefb.png)


