### PR TITLE
adding deploy script to upload assets to s3 after release

### DIFF
--- a/packages/server/src/api/controllers/static.js
+++ b/packages/server/src/api/controllers/static.js
@@ -95,6 +95,7 @@ exports.serveComponentLibrary = async function(ctx) {
     )
   }
 
+  // TODO: component libs should be versioned based on app version
   if (process.env.CLOUD) {
     const appId = ctx.user.appId
     const S3_URL = encodeURI(

--- a/packages/standard-components/package.json
+++ b/packages/standard-components/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "rollup -c",
     "prepublishOnly": "npm run build",
+    "postpublish": "scripts/deploy.sh",
     "testbuild": "rollup -w -c rollup.testconfig.js",
     "dev": "run-p start:dev testbuild",
     "start:dev": "sirv public --single --dev",

--- a/packages/standard-components/scripts/deploy.sh
+++ b/packages/standard-components/scripts/deploy.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+aws s3 sync dist s3://prod-budi-app-assets/assets/componentlibrary/@budibase/standard-components/dist --profile budibase


### PR DESCRIPTION
## Description
Little bash script to upload the standard-components JS to S3 so it can be served by running budibase apps in production.

Will be run automatically when we run an `npm publish` on the standard-components as part of the release.



