### PR TITLE
gap not supported in electron

### DIFF
--- a/packages/builder/src/components/database/DataTable/ModelDataTable.svelte
+++ b/packages/builder/src/components/database/DataTable/ModelDataTable.svelte
@@ -178,7 +178,6 @@
 
   .popovers {
     display: flex;
-    gap: var(--spacing-m);
   }
 
   .no-data {

--- a/packages/builder/src/components/database/DataTable/Table.svelte
+++ b/packages/builder/src/components/database/DataTable/Table.svelte
@@ -132,7 +132,10 @@
 
   .popovers {
     display: flex;
-    gap: var(--spacing-l);
+  }
+
+  :global(.popovers > div) {
+    margin-right: var(--spacing-m);
   }
 
   .no-data {

--- a/packages/builder/src/components/database/DataTable/popovers/View.svelte
+++ b/packages/builder/src/components/database/DataTable/popovers/View.svelte
@@ -43,7 +43,7 @@
 
 <div bind:this={anchor}>
   <TextButton text small on:click={dropdown.show}>
-    <Icon name="addrow" />
+    <Icon name="view" />
     Create New View
   </TextButton>
 </div>


### PR DESCRIPTION
## Description
- `gap` is not supported in electron, making the view buttons squish together.
- "Create New View" Button has wrong icon



