### PR TITLE
Only replace bindings whenever value is primitive

### DIFF
--- a/packages/builder/src/components/userInterface/PropertyControl.svelte
+++ b/packages/builder/src/components/userInterface/PropertyControl.svelte
@@ -67,7 +67,11 @@
         innerVal = props.valueKey ? v.target[props.valueKey] : v.target.value
       }
     }
-    replaceBindings(innerVal)
+    if (typeof innerVal !== "object") {
+      replaceBindings(innerVal)
+    } else {
+      onChange(key, innerVal)
+    }
   }
 
   const safeValue = () => {


### PR DESCRIPTION
replaceBindings function errored whenever on change was fired from the ModelViewSelect component. This is because an object is sent back for its value. Added check for this.


