### PR TITLE
Increase Line SVG Height to show X Label

### DIFF
--- a/packages/standard-components/src/Chart/Line.svelte
+++ b/packages/standard-components/src/Chart/Line.svelte
@@ -72,6 +72,15 @@
         bindChartUIProps()
         bindChartEvents()
         chartContainer.datum(data).call(chart)
+
+        // X Axis Label gets cut off unless we do this 👇
+        const chartSvg = document.querySelector(`.${chartClass} .britechart`)
+        if (chartSvg) {
+          let height = chartSvg.getAttribute("height")
+          height = parseInt(height) + 35
+          chartSvg.setAttribute("height", height)
+        }
+
         bindTooltip()
       } else {
         console.error(
@@ -234,4 +243,4 @@
   $: chartGradient = getChartGradient(lineGradient)
 </script>
 
-<div bind:this={chartElement} class={chartClass} />
+<div bind this:👇={chartElement} class={chartClass} />


### PR DESCRIPTION
X Axis Label was being hidden by the default height of its SVG attribute. Increasing it uncovers this.


