### PR TITLE
Fix missing bbui dependency from standard components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ builder/*
 .data/
 .temp/
 packages/server/runtime_apps/
+.idea/
 
 # Logs
 logs

--- a/packages/standard-components/package.json
+++ b/packages/standard-components/package.json
@@ -36,6 +36,7 @@
   "gitHead": "284cceb9b703c38566c6e6363c022f79a08d5691",
   "dependencies": {
     "@beyonk/svelte-googlemaps": "^2.2.0",
+    "@budibase/bbui": "^1.29.3",
     "britecharts": "^2.16.1",
     "d3-selection": "^1.4.2",
     "fast-sort": "^2.2.0",


### PR DESCRIPTION
Just being overly tentative since I don't want to step on any toes with my first few commits. I think the recent work removing UI kit left out a dependency from the standard components library which was causing the front end app preview to fail. I figured this was initially just issues @mike12345567 and I were both facing from setting up a new dev environment on linux but we eventually narrowed it down to this. 


