### PR TITLE
fix: Navigate To & Other Actions broken

### DIFF
--- a/packages/client/src/state/eventHandlers.js
+++ b/packages/client/src/state/eventHandlers.js
@@ -1,3 +1,4 @@
+import api from "../api"
 import renderTemplateString from "./renderTemplateString"
 
 export const EVENT_TYPE_MEMBER_NAME = "##eventHandlerType"
@@ -5,6 +6,9 @@ export const EVENT_TYPE_MEMBER_NAME = "##eventHandlerType"
 export const eventHandlers = routeTo => {
   const handlers = {
     "Navigate To": param => routeTo(param && param.url),
+    "Create Record": api.createRecord,
+    "Update Record": api.updateRecord,
+    "Trigger Workflow": api.triggerWorkflow,
   }
 
   // when an event is called, this is what gets run


### PR DESCRIPTION
The "Navigate To" action was causing apps to break. 

I am supicious that this commit directly addressed the issue - even though this commit is necessary as this file got changed by a dodgy merge.

I am currently unable to recreate the issue either on this commit, or on current master, or in the 0.1.22 release - even though I could recreate is yesterday.