### PR TITLE
Minor patch - moving sendgrid API key to be a input of send email

### DIFF
--- a/packages/builder/src/components/settings/tabs/APIKeys.svelte
+++ b/packages/builder/src/components/settings/tabs/APIKeys.svelte
@@ -5,7 +5,7 @@
   import posthog from "posthog-js"
   import analytics from "analytics"
 
-  let keys = { budibase: "", sendGrid: "" }
+  let keys = { budibase: "" }
 
   async function updateKey([key, value]) {
     if (key === "budibase") {
@@ -41,14 +41,6 @@
       edit
       value={keys.budibase}
       label="Budibase" />
-  </div>
-  <div class="background">
-    <Input
-      on:save={e => updateKey(['sendgrid', e.detail])}
-      thin
-      edit
-      value={keys.sendgrid}
-      label="Sendgrid" />
   </div>
 </div>
 

--- a/packages/server/src/api/controllers/apikeys.js
+++ b/packages/server/src/api/controllers/apikeys.js
@@ -7,7 +7,6 @@ exports.fetch = async function(ctx) {
   ctx.status = 200
   ctx.body = {
     budibase: process.env.BUDIBASE_API_KEY,
-    sendgrid: process.env.SENDGRID_API_KEY,
     userId: process.env.USERID_API_KEY,
   }
 }

--- a/packages/server/src/automations/steps/sendEmail.js
+++ b/packages/server/src/automations/steps/sendEmail.js
@@ -1,7 +1,3 @@
-const environment = require("../../environment")
-const sgMail = require("@sendgrid/mail")
-sgMail.setApiKey(environment.SENDGRID_API_KEY)
-
 module.exports.definition = {
   description: "Send an email",
   tagline: "Send email to {{inputs.to}}",
@@ -13,6 +9,10 @@ module.exports.definition = {
   schema: {
     inputs: {
       properties: {
+        apiKey: {
+          type: "string",
+          title: "SendGrid API key",
+        },
         to: {
           type: "string",
           title: "Send To",
@@ -49,6 +49,8 @@ module.exports.definition = {
 }
 
 module.exports.run = async function({ inputs }) {
+  const sgMail = require("@sendgrid/mail")
+  sgMail.setApiKey(inputs.apiKey)
   const msg = {
     to: inputs.to,
     from: inputs.from,


### PR DESCRIPTION
## Description
Previously the send email action of an automation simply used a value straight from environment variables, this works fine when running in the builder, however when a user attempts to move to using production they will be unable to send emails from their own domain.

The decision was made to allow the user to put in their own send grid API key which we can then use to send emails from their own specified domains.

## Screenshot
![image](https://user-images.githubusercontent.com/4407001/95199998-95590600-07d5-11eb-9992-4dc7b007959f.png)




