### PR TITLE
Windows filename fixes

### DIFF
--- a/packages/server/src/api/controllers/apikeys.js
+++ b/packages/server/src/api/controllers/apikeys.js
@@ -1,4 +1,5 @@
 const fs = require("fs")
+const { join } = require("../../utilities/sanitisedPath")
 const readline = require("readline")
 const { budibaseAppsDir } = require("../../utilities/budibaseDir")
 const ENV_FILE_PATH = "/.env"
@@ -28,8 +29,9 @@ exports.update = async function(ctx) {
 async function updateValues([key, value]) {
   let newContent = ""
   let keyExists = false
+  let envPath = join(budibaseAppsDir(), ENV_FILE_PATH)
   const readInterface = readline.createInterface({
-    input: fs.createReadStream(`${budibaseAppsDir()}/${ENV_FILE_PATH}`),
+    input: fs.createReadStream(envPath),
     output: process.stdout,
     console: false,
   })
@@ -47,6 +49,6 @@ async function updateValues([key, value]) {
       // Add API Key if it doesn't exist in the file at all
       newContent = `${newContent}\n${key}=${value}`
     }
-    fs.writeFileSync(`${budibaseAppsDir()}/${ENV_FILE_PATH}`, newContent)
+    fs.writeFileSync(envPath, newContent)
   })
 }

--- a/packages/server/src/api/controllers/application.js
+++ b/packages/server/src/api/controllers/application.js
@@ -135,7 +135,7 @@ const createEmptyAppPackage = async (ctx, app) => {
   )
 
   const appsFolder = budibaseAppsDir()
-  const newAppFolder = resolve(join(appsFolder, app._id))
+  const newAppFolder = resolve(appsFolder, app._id)
 
   if (await exists(newAppFolder)) {
     ctx.throw(400, "App folder already exists for this application")

--- a/packages/server/src/api/controllers/application.js
+++ b/packages/server/src/api/controllers/application.js
@@ -3,12 +3,12 @@ const ClientDb = require("../../db/clientDb")
 const { getPackageForBuilder, buildPage } = require("../../utilities/builder")
 const env = require("../../environment")
 const instanceController = require("./instance")
-const { resolve, join } = require("path")
 const { copy, exists, readFile, writeFile } = require("fs-extra")
 const { budibaseAppsDir } = require("../../utilities/budibaseDir")
 const sqrl = require("squirrelly")
 const setBuilderToken = require("../../utilities/builder/setBuilderToken")
 const fs = require("fs-extra")
+const { join, resolve } = require("../../utilities/sanitisedPath")
 const { promisify } = require("util")
 const chmodr = require("chmodr")
 const { generateAppID, getAppParams } = require("../../db/utils")
@@ -116,7 +116,7 @@ exports.delete = async function(ctx) {
   const db = new CouchDB(ClientDb.name(getClientId(ctx)))
   const app = await db.get(ctx.params.applicationId)
   const result = await db.remove(app)
-  await fs.rmdir(`${budibaseAppsDir()}/${ctx.params.applicationId}`, {
+  await fs.rmdir(join(budibaseAppsDir(), ctx.params.applicationId), {
     recursive: true,
   })
 
@@ -135,7 +135,7 @@ const createEmptyAppPackage = async (ctx, app) => {
   )
 
   const appsFolder = budibaseAppsDir()
-  const newAppFolder = resolve(appsFolder, app._id)
+  const newAppFolder = resolve(join(appsFolder, app._id))
 
   if (await exists(newAppFolder)) {
     ctx.throw(400, "App folder already exists for this application")

--- a/packages/server/src/api/controllers/component.js
+++ b/packages/server/src/api/controllers/component.js
@@ -1,6 +1,6 @@
 const CouchDB = require("../../db")
 const ClientDb = require("../../db/clientDb")
-const { resolve, join } = require("path")
+const { resolve, join } = require("../../utilities/sanitisedPath")
 const {
   budibaseTempDir,
   budibaseAppsDir,

--- a/packages/server/src/api/controllers/deploy/aws.js
+++ b/packages/server/src/api/controllers/deploy/aws.js
@@ -1,4 +1,5 @@
 const fs = require("fs")
+const { join } = require("../../../utilities/sanitisedPath")
 const AWS = require("aws-sdk")
 const fetch = require("node-fetch")
 const { budibaseAppsDir } = require("../../../utilities/budibaseDir")
@@ -108,7 +109,7 @@ exports.uploadAppAssets = async function({
     },
   })
 
-  const appAssetsPath = `${budibaseAppsDir()}/${appId}/public`
+  const appAssetsPath = join(budibaseAppsDir(), appId, "public")
 
   const appPages = fs.readdirSync(appAssetsPath)
 
@@ -116,7 +117,7 @@ exports.uploadAppAssets = async function({
 
   for (let page of appPages) {
     // Upload HTML, CSS and JS for each page of the web app
-    walkDir(`${appAssetsPath}/${page}`, function(filePath) {
+    walkDir(join(appAssetsPath, page), function(filePath) {
       const appAssetUpload = prepareUploadForS3({
         file: {
           path: filePath,

--- a/packages/server/src/api/controllers/instance.js
+++ b/packages/server/src/api/controllers/instance.js
@@ -2,6 +2,7 @@ const fs = require("fs")
 const CouchDB = require("../../db")
 const client = require("../../db/clientDb")
 const newid = require("../../db/newid")
+const { join } = require("../../utilities/sanitisedPath")
 const { downloadTemplate } = require("../../utilities/templates")
 
 exports.create = async function(ctx) {
@@ -34,7 +35,9 @@ exports.create = async function(ctx) {
   // replicate the template data to the instance DB
   if (template) {
     const templatePath = await downloadTemplate(...template.key.split("/"))
-    const dbDumpReadStream = fs.createReadStream(`${templatePath}/db/dump.txt`)
+    const dbDumpReadStream = fs.createReadStream(
+      join(templatePath, "db", "dump.txt")
+    )
     const { ok } = await db.load(dbDumpReadStream)
     if (!ok) {
       ctx.throw(500, "Error loading database dump from template.")

--- a/packages/server/src/api/controllers/static.js
+++ b/packages/server/src/api/controllers/static.js
@@ -1,5 +1,5 @@
 const send = require("koa-send")
-const { resolve, join } = require("path")
+const { resolve, join } = require("../../utilities/sanitisedPath")
 const jwt = require("jsonwebtoken")
 const fetch = require("node-fetch")
 const fs = require("fs-extra")

--- a/packages/server/src/api/controllers/view/index.js
+++ b/packages/server/src/api/controllers/view/index.js
@@ -1,7 +1,7 @@
 const CouchDB = require("../../../db")
 const viewTemplate = require("./viewBuilder")
 const fs = require("fs")
-const path = require("path")
+const { join } = require("../../../utilities/sanitisedPath")
 const os = require("os")
 const exporters = require("./exporters")
 
@@ -105,7 +105,7 @@ const controller = {
 
     const filename = `${view.name}.${format}`
 
-    fs.writeFileSync(path.join(os.tmpdir(), filename), exportedFile)
+    fs.writeFileSync(join(os.tmpdir(), filename), exportedFile)
 
     ctx.body = {
       url: `/api/views/export/download/${filename}`,
@@ -116,7 +116,7 @@ const controller = {
     const filename = ctx.params.fileName
 
     ctx.attachment(filename)
-    ctx.body = fs.createReadStream(path.join(os.tmpdir(), filename))
+    ctx.body = fs.createReadStream(join(os.tmpdir(), filename))
   },
 }
 

--- a/packages/server/src/automations/actions.js
+++ b/packages/server/src/automations/actions.js
@@ -6,7 +6,7 @@ const createUser = require("./steps/createUser")
 const environment = require("../environment")
 const download = require("download")
 const fetch = require("node-fetch")
-const path = require("path")
+const { join } = require("../utilities/sanitisedPath")
 const os = require("os")
 const fs = require("fs")
 const Sentry = require("@sentry/node")
@@ -43,7 +43,7 @@ async function downloadPackage(name, version, bundleName) {
     `${AUTOMATION_BUCKET}/${name}/${version}/${bundleName}`,
     AUTOMATION_DIRECTORY
   )
-  return require(path.join(AUTOMATION_DIRECTORY, bundleName))
+  return require(join(AUTOMATION_DIRECTORY, bundleName))
 }
 
 module.exports.getAction = async function(actionName) {
@@ -57,7 +57,7 @@ module.exports.getAction = async function(actionName) {
   const pkg = MANIFEST.packages[actionName]
   const bundleName = buildBundleName(pkg.stepId, pkg.version)
   try {
-    return require(path.join(AUTOMATION_DIRECTORY, bundleName))
+    return require(join(AUTOMATION_DIRECTORY, bundleName))
   } catch (err) {
     return downloadPackage(pkg.stepId, pkg.version, bundleName)
   }
@@ -66,7 +66,7 @@ module.exports.getAction = async function(actionName) {
 module.exports.init = async function() {
   // set defaults
   if (!AUTOMATION_DIRECTORY) {
-    AUTOMATION_DIRECTORY = path.join(os.homedir(), DEFAULT_DIRECTORY)
+    AUTOMATION_DIRECTORY = join(os.homedir(), DEFAULT_DIRECTORY)
   }
   if (!AUTOMATION_BUCKET) {
     AUTOMATION_BUCKET = DEFAULT_BUCKET

--- a/packages/server/src/db/client.js
+++ b/packages/server/src/db/client.js
@@ -2,6 +2,7 @@ const PouchDB = require("pouchdb")
 const replicationStream = require("pouchdb-replication-stream")
 const allDbs = require("pouchdb-all-dbs")
 const { budibaseAppsDir } = require("../utilities/budibaseDir")
+const { sanitise } = require("../utilities/sanitisedPath")
 const env = require("../environment")
 
 const COUCH_DB_URL = env.COUCH_DB_URL || `leveldb://${budibaseAppsDir()}/.data/`
@@ -26,4 +27,10 @@ const Pouch = PouchDB.defaults(POUCH_DB_DEFAULTS)
 
 allDbs(Pouch)
 
-module.exports = Pouch
+function PouchWrapper(instance) {
+  Pouch.apply(this, [sanitise(instance)])
+}
+
+PouchWrapper.prototype = Object.create(Pouch.prototype)
+
+module.exports = PouchWrapper

--- a/packages/server/src/electron.js
+++ b/packages/server/src/electron.js
@@ -1,5 +1,5 @@
 const { app, BrowserWindow, shell, dialog } = require("electron")
-const { join } = require("path")
+const { join } = require("./utilities/sanitisedPath")
 const isDev = require("electron-is-dev")
 const { autoUpdater } = require("electron-updater")
 const unhandled = require("electron-unhandled")

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -1,4 +1,4 @@
-const { resolve, join } = require("path")
+const { resolve, join } = require("./utilities/sanitisedPath")
 const { homedir } = require("os")
 const { app } = require("electron")
 const fixPath = require("fix-path")

--- a/packages/server/src/utilities/budibaseDir.js
+++ b/packages/server/src/utilities/budibaseDir.js
@@ -1,4 +1,4 @@
-const { join } = require("path")
+const { join } = require("./sanitisedPath")
 const { homedir, tmpdir } = require("os")
 const env = require("../environment")
 

--- a/packages/server/src/utilities/builder/buildPage.js
+++ b/packages/server/src/utilities/builder/buildPage.js
@@ -6,7 +6,7 @@ const {
   readFile,
   writeJSON,
 } = require("fs-extra")
-const { join, resolve } = require("path")
+const { join, resolve } = require("../sanitisedPath")
 const sqrl = require("squirrelly")
 const { convertCssToFiles } = require("./convertCssToFiles")
 const publicPath = require("./publicPath")

--- a/packages/server/src/utilities/builder/convertCssToFiles.js
+++ b/packages/server/src/utilities/builder/convertCssToFiles.js
@@ -1,6 +1,6 @@
 const crypto = require("crypto")
 const { ensureDir, emptyDir, writeFile } = require("fs-extra")
-const { join } = require("path")
+const { join } = require("../sanitisedPath")
 
 module.exports.convertCssToFiles = async (publicPagePath, pkg) => {
   const cssDir = join(publicPagePath, "css")

--- a/packages/server/src/utilities/builder/getPages.js
+++ b/packages/server/src/utilities/builder/getPages.js
@@ -1,5 +1,5 @@
 const { readJSON, readdir } = require("fs-extra")
-const { join } = require("path")
+const { join } = require("../sanitisedPath")
 
 module.exports = async appPath => {
   const pages = {}

--- a/packages/server/src/utilities/builder/index.js
+++ b/packages/server/src/utilities/builder/index.js
@@ -8,7 +8,8 @@ const {
   unlink,
   rmdir,
 } = require("fs-extra")
-const { join, dirname, resolve } = require("path")
+const { join, resolve } = require("../sanitisedPath")
+const { dirname } = require("path")
 const env = require("../../environment")
 
 const buildPage = require("./buildPage")

--- a/packages/server/src/utilities/builder/listScreens.js
+++ b/packages/server/src/utilities/builder/listScreens.js
@@ -1,6 +1,6 @@
 const { appPackageFolder } = require("../createAppPackage")
 const { readJSON, readdir, stat } = require("fs-extra")
-const { join } = require("path")
+const { join } = require("../sanitisedPath")
 const { keyBy } = require("lodash/fp")
 
 module.exports = async (config, appname, pagename) => {

--- a/packages/server/src/utilities/builder/publicPath.js
+++ b/packages/server/src/utilities/builder/publicPath.js
@@ -1,3 +1,3 @@
-const { join } = require("path")
+const { join } = require("../sanitisedPath")
 
 module.exports = (appPath, pageName) => join(appPath, "public", pageName)

--- a/packages/server/src/utilities/createAppPackage.js
+++ b/packages/server/src/utilities/createAppPackage.js
@@ -1,4 +1,4 @@
-const { resolve } = require("path")
+const { resolve } = require("./sanitisedPath")
 const { cwd } = require("process")
 const stream = require("stream")
 const fetch = require("node-fetch")

--- a/packages/server/src/utilities/initialiseBudibase.js
+++ b/packages/server/src/utilities/initialiseBudibase.js
@@ -1,5 +1,5 @@
 const { exists, readFile, writeFile, ensureDir } = require("fs-extra")
-const { join, resolve } = require("path")
+const { join, resolve } = require("./sanitisedPath")
 const Sqrl = require("squirrelly")
 const uuid = require("uuid")
 

--- a/packages/server/src/utilities/sanitisedPath.js
+++ b/packages/server/src/utilities/sanitisedPath.js
@@ -1,0 +1,27 @@
+const path = require("path")
+
+function sanitiseArgs(args) {
+  let sanitised = []
+  for (let arg of args) {
+    sanitised.push(arg.replace(":", ""))
+  }
+  return sanitised
+}
+
+/**
+ * Exactly the same as path.join but creates a sanitised path.
+ * @param args Any number of string arguments to add to a path
+ * @returns {string} The final path ready to use
+ */
+exports.join = function(...args) {
+  return path.join(...sanitiseArgs(args))
+}
+
+/**
+ * Exactly the same as path.resolve but creates a sanitised path.
+ * @param args Any number of string arguments to add to a path
+ * @returns {string} The final path ready to use
+ */
+exports.resolve = function(...args) {
+  return path.resolve(...sanitiseArgs(args))
+}

--- a/packages/server/src/utilities/sanitisedPath.js
+++ b/packages/server/src/utilities/sanitisedPath.js
@@ -27,3 +27,12 @@ exports.join = function(...args) {
 exports.resolve = function(...args) {
   return path.resolve(...sanitiseArgs(args))
 }
+
+/**
+ * Sanitise a single string
+ * @param string input string to sanitise
+ * @returns {string} the final sanitised string
+ */
+exports.sanitise = function(string) {
+  return sanitiseArgs([string])[0]
+}

--- a/packages/server/src/utilities/sanitisedPath.js
+++ b/packages/server/src/utilities/sanitisedPath.js
@@ -1,9 +1,11 @@
 const path = require("path")
 
+const regex = new RegExp(/:(?![\\/])/g)
+
 function sanitiseArgs(args) {
   let sanitised = []
   for (let arg of args) {
-    sanitised.push(arg.replace(":", ""))
+    sanitised.push(arg.replace(regex, ""))
   }
   return sanitised
 }

--- a/packages/server/src/utilities/templates.js
+++ b/packages/server/src/utilities/templates.js
@@ -1,5 +1,5 @@
-const path = require("path")
 const fs = require("fs-extra")
+const { join } = require("./sanitisedPath")
 const os = require("os")
 const fetch = require("node-fetch")
 const stream = require("stream")
@@ -27,10 +27,10 @@ exports.downloadTemplate = async function(type, name) {
   await streamPipeline(
     response.body,
     zlib.Unzip(),
-    tar.extract(path.join(budibaseAppsDir(), "templates", type))
+    tar.extract(join(budibaseAppsDir(), "templates", type))
   )
 
-  return path.join(budibaseAppsDir(), "templates", type, name)
+  return join(budibaseAppsDir(), "templates", type, name)
 }
 
 exports.exportTemplateFromApp = async function({
@@ -39,15 +39,17 @@ exports.exportTemplateFromApp = async function({
   instanceId,
 }) {
   // Copy frontend files
-  const appToExport = path.join(os.homedir(), ".budibase", appId, "pages")
-  const templatesDir = path.join(os.homedir(), ".budibase", "templates")
+  const appToExport = join(os.homedir(), ".budibase", appId, "pages")
+  const templatesDir = join(os.homedir(), ".budibase", "templates")
   fs.ensureDirSync(templatesDir)
 
-  const templateOutputPath = path.join(templatesDir, templateName)
-  fs.copySync(appToExport, `${templateOutputPath}/pages`)
+  const templateOutputPath = join(templatesDir, templateName)
+  fs.copySync(appToExport, join(templateOutputPath, "pages"))
 
-  fs.ensureDirSync(path.join(templateOutputPath, "db"))
-  const writeStream = fs.createWriteStream(`${templateOutputPath}/db/dump.txt`)
+  fs.ensureDirSync(join(templateOutputPath, "db"))
+  const writeStream = fs.createWriteStream(
+    join(templateOutputPath, "db", "dump.txt")
+  )
 
   // perform couch dump
   const instanceDb = new CouchDB(instanceId)


### PR DESCRIPTION
## Description
With the introduction of the new ID system it is possible for IDs to consist of characters which may be considered illegal by the file-system, especially in Windows.

To handle this I have created path functions which sanitise the inputs before performing the function itself. The functions in question are found in `packages/server/src/utilities/sanitisedPath.js` and I have created `join` and `resolve` as these were the primary functions used throughout the system.

I have also gone through the system and found anywhere that an ID was being written to the disk but instead of using a path join function to create the directory path a string template was being used and replaced these with joins.

Finally the PouchDB data files were being written to the disk with instance IDs that contained colons, to resolve this I created a Pouch wrapper which cleans up the file names before using them with the same sanitisation functions.

I believe this was a choice of either changing the character that was used for joining IDs together or actually allowing sanitisation of file paths, I went for the later as while it is more difficult having all of our file paths go through a centralised source allows us to control them a lot better.