### PR TITLE
Fix issue displaying linked records in a table

### DIFF
--- a/packages/standard-components/src/DataTable.svelte
+++ b/packages/standard-components/src/DataTable.svelte
@@ -99,7 +99,7 @@
             {#if schema[header].type === 'attachment'}
               <AttachmentList files={row[header]} />
             {:else if schema[header].type === 'link'}
-              <td>{row[header] ? row[header].length : 0} related row(s)</td>
+              <td>{row[header]} related row(s)</td>
             {:else if row[header]}
               <td>{row[header]}</td>
             {/if}


### PR DESCRIPTION
Really small fix for displaying linked records in a table which will currently always say `undefined`. Tiny bugfix and won't affect anything else.
