### PR TITLE
Small change that drastically improves the performance of linked records

### DIFF
--- a/packages/server/src/db/linkedRecords/index.js
+++ b/packages/server/src/db/linkedRecords/index.js
@@ -1,5 +1,6 @@
 const LinkController = require("./LinkController")
 const { IncludeDocs, getLinkDocuments, createLinkView } = require("./linkUtils")
+const _ = require("lodash")
 
 /**
  * This functionality makes sure that when records with links are created, updated or deleted they are processed
@@ -90,8 +91,7 @@ exports.attachLinkInfo = async (instanceId, records) => {
   }
   let modelIds = [...new Set(records.map(el => el.modelId))]
   // start by getting all the link values for performance reasons
-  let responses = [].concat.apply(
-    [],
+  let responses = _.flatten(
     await Promise.all(
       modelIds.map(modelId =>
         getLinkDocuments({

--- a/packages/server/src/db/linkedRecords/index.js
+++ b/packages/server/src/db/linkedRecords/index.js
@@ -88,23 +88,24 @@ exports.attachLinkInfo = async (instanceId, records) => {
     records = [records]
     wasArray = false
   }
+  let modelIds = [...new Set(records.map(el => el.modelId))]
   // start by getting all the link values for performance reasons
-  let responses = await Promise.all(
-    records.map(record =>
-      getLinkDocuments({
-        instanceId,
-        modelId: record.modelId,
-        recordId: record._id,
-        includeDocs: IncludeDocs.EXCLUDE,
-      })
+  let responses = [].concat.apply(
+    [],
+    await Promise.all(
+      modelIds.map(modelId =>
+        getLinkDocuments({
+          instanceId,
+          modelId: modelId,
+          includeDocs: IncludeDocs.EXCLUDE,
+        })
+      )
     )
   )
-  // can just use an index to access responses, order maintained
-  let index = 0
   // now iterate through the records and all field information
   for (let record of records) {
     // get all links for record, ignore fieldName for now
-    const linkVals = responses[index++]
+    const linkVals = responses.filter(el => el.thisId === record._id)
     for (let linkVal of linkVals) {
       // work out which link pertains to this record
       if (!(record[linkVal.fieldName] instanceof Array)) {

--- a/packages/server/src/db/linkedRecords/linkUtils.js
+++ b/packages/server/src/db/linkedRecords/linkUtils.js
@@ -27,10 +27,12 @@ exports.createLinkView = async instanceId => {
         let doc2 = doc.doc2
         emit([doc1.modelId, doc1.recordId], {
           id: doc2.recordId,
+          thisId: doc1.recordId,
           fieldName: doc1.fieldName,
         })
         emit([doc2.modelId, doc2.recordId], {
           id: doc1.recordId,
+          thisId: doc2.recordId,
           fieldName: doc2.fieldName,
         })
       }


### PR DESCRIPTION
## Description
Issues had been seen with the performance of linked records under heavy load, it appears if you perform many `get` operations on a view while it is still building it will also slow down the building of the view (perhaps it attempts to re-build it each time or something like that?) - until the view is built queries can be quite slow.

To fix this I made a few small changes to the view emissions so that a table query could be used rather than getting records individually, this has drastically improved performance to the point there is not appreciable difference anymore when uploading smaller CSVs - I haven't tested it with tens of thousands however.



