### PR TITLE
support for external webhooks

### DIFF
--- a/packages/builder/src/components/settings/tabs/APIKeys.svelte
+++ b/packages/builder/src/components/settings/tabs/APIKeys.svelte
@@ -1,6 +1,7 @@
 <script>
-  import { Input } from "@budibase/bbui"
+  import { Input, Label } from "@budibase/bbui"
   import api from "builderStore/api"
+  import { backendUiStore } from "builderStore"
   import analytics from "analytics"
 
   let keys = { budibase: "" }
@@ -38,11 +39,20 @@
     edit
     value={keys.budibase}
     label="Budibase API Key" />
+  <div>
+    <Label extraSmall grey>Instance ID (Webhooks)</Label>
+    <span>{$backendUiStore.selectedDatabase._id}</span>
+  </div>
 </div>
 
 <style>
   .container {
     display: grid;
     grid-gap: var(--spacing-xl);
+  }
+
+  span {
+    font-size: var(--font-size-xs);
+    font-weight: 500;
   }
 </style>

--- a/packages/server/src/api/controllers/static.js
+++ b/packages/server/src/api/controllers/static.js
@@ -136,7 +136,7 @@ exports.performLocalFileProcessing = async function(ctx) {
 }
 
 exports.serveApp = async function(ctx) {
-  const mainOrAuth = ctx.isAuthenticated ? "main" : "unauthenticated"
+  const mainOrAuth = ctx.auth.authenticated ? "main" : "unauthenticated"
 
   // default to homedir
   const appPath = resolve(
@@ -154,7 +154,7 @@ exports.serveApp = async function(ctx) {
   // only set the appId cookie for /appId .. we COULD check for valid appIds
   // but would like to avoid that DB hit
   const looksLikeAppId = /^(app_)?[0-9a-f]{32}$/.test(appId)
-  if (looksLikeAppId && !ctx.isAuthenticated) {
+  if (looksLikeAppId && !ctx.auth.authenticated) {
     const anonUser = {
       userId: "ANON",
       accessLevelId: ANON_LEVEL_ID,
@@ -200,7 +200,7 @@ exports.serveAttachment = async function(ctx) {
 
 exports.serveAppAsset = async function(ctx) {
   // default to homedir
-  const mainOrAuth = ctx.isAuthenticated ? "main" : "unauthenticated"
+  const mainOrAuth = ctx.auth.authenticated ? "main" : "unauthenticated"
 
   const appPath = resolve(
     budibaseAppsDir(),

--- a/packages/server/src/app.js
+++ b/packages/server/src/app.js
@@ -24,6 +24,7 @@ app.use(
 )
 
 app.context.eventEmitter = eventEmitter
+app.context.auth = {}
 
 // api routes
 app.use(api.routes())

--- a/packages/server/src/middleware/authorized.js
+++ b/packages/server/src/middleware/authorized.js
@@ -5,8 +5,33 @@ const {
   BUILDER_LEVEL_ID,
   BUILDER,
 } = require("../utilities/accessLevels")
+const environment = require("../environment")
+const { apiKeyTable } = require("../db/dynamoClient")
 
 module.exports = (permName, getItemId) => async (ctx, next) => {
+  if (
+    environment.CLOUD &&
+    ctx.headers["x-api-key"] &&
+    ctx.headers["x-instanceid"]
+  ) {
+    // api key header passed by external webhook
+    const apiKeyInfo = await apiKeyTable.get({
+      primary: ctx.headers["x-api-key"],
+    })
+
+    if (apiKeyInfo) {
+      ctx.isAuthenticated = true
+      ctx.externalWebhook = true
+      ctx.apiKey = ctx.headers["x-api-key"]
+      ctx.user = {
+        instanceId: ctx.headers["x-instanceid"],
+      }
+      return next()
+    }
+
+    ctx.throw(403, "API key invalid")
+  }
+
   if (!ctx.isAuthenticated) {
     ctx.throw(403, "Session not authenticated")
   }

--- a/packages/server/src/middleware/authorized.js
+++ b/packages/server/src/middleware/authorized.js
@@ -20,9 +20,11 @@ module.exports = (permName, getItemId) => async (ctx, next) => {
     })
 
     if (apiKeyInfo) {
-      ctx.isAuthenticated = true
-      ctx.externalWebhook = true
-      ctx.apiKey = ctx.headers["x-api-key"]
+      ctx.auth = {
+        authenticated: true,
+        external: true,
+        apiKey: ctx.headers["x-api-key"],
+      }
       ctx.user = {
         instanceId: ctx.headers["x-instanceid"],
       }
@@ -32,7 +34,7 @@ module.exports = (permName, getItemId) => async (ctx, next) => {
     ctx.throw(403, "API key invalid")
   }
 
-  if (!ctx.isAuthenticated) {
+  if (!ctx.auth.authenticated) {
     ctx.throw(403, "Session not authenticated")
   }
 

--- a/packages/server/src/middleware/usageQuota.js
+++ b/packages/server/src/middleware/usageQuota.js
@@ -55,7 +55,7 @@ module.exports = async (ctx, next) => {
     return next()
   }
   try {
-    await usageQuota.update(ctx.apiKey, property, usage)
+    await usageQuota.update(ctx.auth.apiKey, property, usage)
     return next()
   } catch (err) {
     ctx.throw(403, err)


### PR DESCRIPTION
## Description
Addresses https://github.com/Budibase/budibase/issues/495

This PR enables support for external web hooks in budibase.

A user must provide:
- Their API key as a `x-api-key` header
- Their instance ID as a `x-instanceid` header

If the app is deployed and running in the cloud, this will check dynamo for their information and authenticate as appropriate. Calls from external web hooks will also be counted towards a users usage quota.

I've also added the instanceID to the API Keys part of the settings, so it's accessible for people using external webhooks. There's probably a bit more work to do to make the web hooks experience truly great for our users, but this will certainly allow people to interact with budibase through HTTP calls.

## Screenshots
![Screenshot 2020-10-12 at 11 55 28](https://user-images.githubusercontent.com/11256663/95739355-9fba4a80-0c82-11eb-8915-8c27a936edc8.png)





