### PR TITLE
Minor bug fix for template screens and fixing link doc IDs

### DIFF
--- a/packages/builder/src/builderStore/storeUtils.js
+++ b/packages/builder/src/builderStore/storeUtils.js
@@ -36,7 +36,8 @@ export const saveCurrentPreviewItem = s =>
     : saveScreenApi(s.currentPreviewItem, s)
 
 export const savePage = async s => {
-  const page = s.pages[s.currentPageName]
+  const pageName = s.currentPageName || "main"
+  const page = s.pages[pageName]
   await api.post(`/_builder/api/${s.appId}/pages/${s.currentPageName}`, {
     page: { componentLibraries: s.pages.componentLibraries, ...page },
     uiFunctions: s.currentPageFunctions,

--- a/packages/builder/src/components/backend/ModelNavigator/modals/CreateTableModal.svelte
+++ b/packages/builder/src/components/backend/ModelNavigator/modals/CreateTableModal.svelte
@@ -41,7 +41,6 @@
       .map(template => template.create())
 
     for (let screen of screens) {
-      console.log(JSON.stringify(screen))
       try {
         await store.createScreen(screen)
       } catch (_) {

--- a/packages/server/src/db/utils.js
+++ b/packages/server/src/db/utils.js
@@ -124,7 +124,14 @@ exports.generateAutomationID = () => {
  * @returns {string} The new link doc ID which the automation doc can be stored under.
  */
 exports.generateLinkID = (modelId1, modelId2, recordId1, recordId2) => {
-  return `${DocumentTypes.AUTOMATION}${SEPARATOR}${modelId1}${SEPARATOR}${modelId2}${SEPARATOR}${recordId1}${SEPARATOR}${recordId2}`
+  return `${DocumentTypes.LINK}${SEPARATOR}${modelId1}${SEPARATOR}${modelId2}${SEPARATOR}${recordId1}${SEPARATOR}${recordId2}`
+}
+
+/**
+ * Gets parameters for retrieving link docs, this is a utility function for the getDocParams function.
+ */
+exports.getLinkParams = (otherProps = {}) => {
+  return getDocParams(DocumentTypes.LINK, null, otherProps)
 }
 
 /**


### PR DESCRIPTION
## Description
When I was testing link docs I noticed that the link doc IDs where prefaced with `au` instead of `li` accidentally (my mistake!) and fixed a bug that was crashing system when creating a new table.


