### PR TITLE
Bug/table changes fix

### DIFF
--- a/packages/server/src/db/linkedRecords/LinkController.js
+++ b/packages/server/src/db/linkedRecords/LinkController.js
@@ -234,8 +234,16 @@ class LinkController {
     for (let fieldName of Object.keys(schema)) {
       const field = schema[fieldName]
       if (field.type === "link") {
+        // handle this in a separate try catch, want
+        // the put to bubble up as an error, if can't update
+        // table for some reason
+        let linkedModel
+        try {
+          linkedModel = await this._db.get(field.modelId)
+        } catch (err) {
+          continue
+        }
         // create the link field in the other model
-        const linkedModel = await this._db.get(field.modelId)
         linkedModel.schema[field.fieldName] = {
           name: field.fieldName,
           type: "link",

--- a/packages/server/src/db/linkedRecords/LinkController.js
+++ b/packages/server/src/db/linkedRecords/LinkController.js
@@ -161,7 +161,7 @@ class LinkController {
           })
         // now add the docs to be deleted to the bulk operation
         operations.push(...toDeleteDocs)
-        // replace this field with a simple entry to denote there are links
+        // remove the field from this row, link doc will be added to record on way out
         delete record[fieldName]
       }
     }

--- a/packages/server/src/db/linkedRecords/index.js
+++ b/packages/server/src/db/linkedRecords/index.js
@@ -42,6 +42,7 @@ exports.updateLinks = async function({
   model,
   oldModel,
 }) {
+  const baseReturnObj = record == null ? model : record
   if (instanceId == null) {
     throw "Cannot operate without an instance ID."
   }
@@ -50,12 +51,16 @@ exports.updateLinks = async function({
     arguments[0].modelId = model._id
   }
   let linkController = new LinkController(arguments[0])
-  if (
-    !(await linkController.doesModelHaveLinkedFields()) &&
-    (oldModel == null ||
-      !(await linkController.doesModelHaveLinkedFields(oldModel)))
-  ) {
-    return record
+  try {
+    if (
+      !(await linkController.doesModelHaveLinkedFields()) &&
+      (oldModel == null ||
+        !(await linkController.doesModelHaveLinkedFields(oldModel)))
+    ) {
+      return baseReturnObj
+    }
+  } catch (err) {
+    return baseReturnObj
   }
   switch (eventType) {
     case EventType.RECORD_SAVE:

--- a/packages/server/src/db/utils.js
+++ b/packages/server/src/db/utils.js
@@ -57,21 +57,26 @@ exports.generateModelID = () => {
 
 /**
  * Gets the DB allDocs/query params for retrieving a record.
- * @param {string} modelId The model in which the records have been stored.
+ * @param {string|null} modelId The model in which the records have been stored.
  * @param {string|null} recordId The ID of the record which is being specifically queried for. This can be
  * left null to get all the records in the model.
  * @param {object} otherProps Any other properties to add to the request.
  * @returns {object} Parameters which can then be used with an allDocs request.
  */
-exports.getRecordParams = (modelId, recordId = null, otherProps = {}) => {
+exports.getRecordParams = (
+  modelId = null,
+  recordId = null,
+  otherProps = {}
+) => {
   if (modelId == null) {
-    throw "Cannot build params for records without a model ID"
+    return getDocParams(DocumentTypes.RECORD, null, otherProps)
+  } else {
+    const endOfKey =
+      recordId == null
+        ? `${modelId}${SEPARATOR}`
+        : `${modelId}${SEPARATOR}${recordId}`
+    return getDocParams(DocumentTypes.RECORD, endOfKey, otherProps)
   }
-  const endOfKey =
-    recordId == null
-      ? `${modelId}${SEPARATOR}`
-      : `${modelId}${SEPARATOR}${recordId}`
-  return getDocParams(DocumentTypes.RECORD, endOfKey, otherProps)
 }
 
 /**


### PR DESCRIPTION
## Description
Fixes two bugs in the backend, namely:
1. Save relationship column without any settings
2. Ensure all records are deleted when table deleted

When bulk docs is being used to remove objects it seems that the id and revision need to be specified, `id` + `_deleted` doesn't appear to be enough to remove a doc fully.