### PR TITLE
Replace screen template datatable

### DIFF
--- a/packages/builder/src/builderStore/store/screenTemplates/recordListScreen.js
+++ b/packages/builder/src/builderStore/store/screenTemplates/recordListScreen.js
@@ -86,7 +86,7 @@ const createScreen = model => ({
       },
       {
         _id: "",
-        _component: "@budibase/standard-components/datatable",
+        _component: "@budibase/standard-components/datagrid",
         _styles: {
           normal: {},
           hover: {},
@@ -100,10 +100,6 @@ const createScreen = model => ({
           modelId: model._id,
           isModel: true,
         },
-        stripeColor: "",
-        borderColor: "",
-        backgroundColor: "",
-        color: "",
         _instanceName: `${model.name} Table`,
         _children: [],
       },

--- a/packages/server/src/utilities/appDirectoryTemplate/pages/main/page.json
+++ b/packages/server/src/utilities/appDirectoryTemplate/pages/main/page.json
@@ -54,34 +54,6 @@
             "_instanceId": "inst_cf8ace4_69efc0d72e6f443db2d4c902c14d9394",
             "_instanceName": "Home Link",
             "_children": []
-          },
-          {
-            "_id": "d3325634-0945-4387-8bb3-d9d9be186c1c",
-            "_component": "@budibase/standard-components/link",
-            "_styles": {
-              "normal": {
-                "font-family": "Inter",
-                "font-weight": "400",
-                "color": "#000000",
-                "text-decoration-line": "none",
-                "font-size": "16px"
-              },
-              "hover": {},
-              "active": {},
-              "selected": {}
-            },
-            "_code": "",
-            "url": "/screen1",
-            "openInNewTab": false,
-            "text": "Screen 1",
-            "color": "",
-            "hoverColor": "",
-            "underline": false,
-            "fontSize": "",
-            "fontFamily": "initial",
-            "_instanceId": "inst_cf8ace4_69efc0d72e6f443db2d4c902c14d9394",
-            "_instanceName": "Screen 1 Link",
-            "_children": []
           }
         ]
       },


### PR DESCRIPTION
## Description
- Replace the record detail list table with ag grid
- Remove screen 1 from the dummy app screens on app creation

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



