### PR TITLE
fixing more bugs

### DIFF
--- a/packages/builder/src/builderStore/store/index.js
+++ b/packages/builder/src/builderStore/store/index.js
@@ -106,10 +106,6 @@ const setPackage = (store, initial) => async pkg => {
   initial.pages = pkg.pages
   initial.hasAppPackage = true
   initial.screens = values(pkg.screens)
-  initial.allScreens = [
-    ...Object.values(main_screens),
-    ...Object.values(unauth_screens),
-  ]
   initial.builtins = [getBuiltin("##builtin/screenslot")]
   initial.appInstances = pkg.application.instances
   initial.appId = pkg.application._id
@@ -139,7 +135,6 @@ const _saveScreen = async (store, s, screen) => {
         innerState.pages[pageName]._screens = screens
         innerState.screens = screens
         innerState.currentPreviewItem = screen
-        innerState.allScreens = [...innerState.allScreens, screen]
         const safeProps = makePropsSafe(
           innerState.components[screen.props._component],
           screen.props

--- a/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
@@ -52,6 +52,8 @@
       .map(template => template.create())
 
     for (let screen of screens) {
+      // record the table that created this screen so we can link it later
+      screen.autoTableId = table._id
       try {
         await store.createScreen(screen)
       } catch (_) {

--- a/packages/builder/src/components/backend/TableNavigator/popovers/EditTablePopover.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/popovers/EditTablePopover.svelte
@@ -30,8 +30,8 @@
   }
 
   function showModal() {
-    const screens = $store.allScreens
-    templateScreens = screens.filter(screen => screen.props.table === table._id)
+    const screens = $store.screens
+    templateScreens = screens.filter(screen => screen.autoTableId === table._id)
     willBeDeleted = ["All table data"].concat(
       templateScreens.map(screen => `Screen ${screen.props._instanceName}`)
     )

--- a/packages/builder/src/components/userInterface/EventsEditor/StateBindingCascader.svelte
+++ b/packages/builder/src/components/userInterface/EventsEditor/StateBindingCascader.svelte
@@ -29,7 +29,7 @@
   {:else if parameter.name === 'url'}
     <DataList on:change bind:value={parameter.value}>
       <option value="" />
-      {#each $store.allScreens as screen}
+      {#each $store.screens as screen}
         <option value={screen.route}>{screen.props._instanceName}</option>
       {/each}
     </DataList>

--- a/packages/server/src/api/controllers/auth.js
+++ b/packages/server/src/api/controllers/auth.js
@@ -70,6 +70,7 @@ exports.authenticate = async ctx => {
       expires,
       path: "/",
       httpOnly: false,
+      overwrite: true,
     })
 
     ctx.body = {

--- a/packages/server/src/middleware/authenticated.js
+++ b/packages/server/src/middleware/authenticated.js
@@ -51,6 +51,7 @@ module.exports = async (ctx, next) => {
     ctx.auth.apiKey = jwtPayload.apiKey
     ctx.user = {
       ...jwtPayload,
+      instanceId: jwtPayload.instanceId,
       accessLevel: await getAccessLevel(
         jwtPayload.instanceId,
         jwtPayload.accessLevelId

--- a/packages/server/src/utilities/builder/setBuilderToken.js
+++ b/packages/server/src/utilities/builder/setBuilderToken.js
@@ -15,7 +15,16 @@ module.exports = (ctx, appId, instanceId) => {
     expiresIn: "30 days",
   })
 
-  var expiry = new Date()
+  const expiry = new Date()
   expiry.setDate(expiry.getDate() + 30)
-  ctx.cookies.set("builder:token", token, { expires: expiry, httpOnly: false })
+  // remove the app token
+  ctx.cookies.set("budibase:token", "", {
+    overwrite: true,
+  })
+  // set the builder token
+  ctx.cookies.set("builder:token", token, {
+    expires: expiry,
+    httpOnly: false,
+    overwrite: true,
+  })
 }

--- a/packages/standard-components/src/DataGrid/AttachmentCell/Button.svelte
+++ b/packages/standard-components/src/DataGrid/AttachmentCell/Button.svelte
@@ -27,4 +27,3 @@
         on:newRow={() => dispatch('newRow')} />
  </DropdownMenu> -->
 
-<!--<style ✂prettier:content✂="CiAgZGl2IHsKICAgIGRpc3BsYXk6IGdyaWQ7CiAgICBncmlkLXRlbXBsYXRlLWNvbHVtbnM6IGF1dG8gYXV0bzsKICAgIHBsYWNlLWl0ZW1zOiBzdGFydCBjZW50ZXI7CiAgfQogIGg1IHsKICAgIHBhZGRpbmc6IHZhcigtLXNwYWNpbmcteGwpIDAgMCB2YXIoLS1zcGFjaW5nLXhsKTsKICAgIG1hcmdpbjogMDsKICAgIGZvbnQtd2VpZ2h0OiA1MDA7CiAgfQo=" ✂prettier:content✂="" ✂prettier:content✂="" ✂prettier:content✂="" ✂prettier:content✂="" ✂prettier:content✂="" ✂prettier:content✂=""></style>-->


### PR DESCRIPTION
## Description
Fixes some authentication issues and does away with the `allScreens` prop that was just adding confusion to the store. This should make sure auto screens get fully cleaned up properly.

On the authentication front the app token was getting set when we were previewing an app, this would stay set forever and then the builder token wouldn't be used, causing things to start to break.

Also overwrite was not set for the cookies so weird things were happening in terms of old cookies for apps being used in the builder and old cookies for the builder attempting to be used in apps.