### PR TITLE
Mike fixes

### DIFF
--- a/packages/builder/src/builderStore/store/screenTemplates/sanitizeUrl.js
+++ b/packages/builder/src/builderStore/store/screenTemplates/sanitizeUrl.js
@@ -4,7 +4,7 @@ export default function(url) {
     .map(part => {
       // if parameter, then use as is
       if (part.startsWith(":")) return part
-      return encodeURIComponent(part.replace(" ", "-"))
+      return encodeURIComponent(part.replace(/ /g, "-"))
     })
     .join("/")
     .toLowerCase()

--- a/packages/client/src/render/screenRouter.js
+++ b/packages/client/src/render/screenRouter.js
@@ -44,7 +44,7 @@ export const screenRouter = ({ screens, onScreenSelected, window }) => {
   }
 
   const routes = screens.map(s => makeRootedPath(s.route))
-  let fallback = routes.findIndex(([p]) => p === "*")
+  let fallback = routes.findIndex(([p]) => p === makeRootedPath("*"))
   if (fallback < 0) fallback = 0
 
   let current
@@ -53,7 +53,7 @@ export const screenRouter = ({ screens, onScreenSelected, window }) => {
     const _url = makeRootedPath(url.state || url)
     current = routes.findIndex(
       p =>
-        p !== "*" &&
+        p !== makeRootedPath("*") &&
         new RegExp("^" + p.toLowerCase() + "$").test(_url.toLowerCase())
     )
 
@@ -61,6 +61,8 @@ export const screenRouter = ({ screens, onScreenSelected, window }) => {
 
     if (current === -1) {
       routes.forEach((p, i) => {
+        // ignore home - which matched everything
+        if (p === makeRootedPath("*")) return
         const pm = regexparam(p)
         const matches = pm.pattern.exec(_url)
 


### PR DESCRIPTION
1. The home screen was matching every route.

This has been a big that has been about since the beginning... but only raised its head now, because we are now alphabetically sorting screens. This means that Home can appear half way down the list, and **sometimes** override the actual matching screen!

previously, the home screen was always the first in the list, and so was not an issue

2. Typo - sanitizeUrl for screen template was not doing a  `replace(" ", "-")` not `replace(/ /g, "-") ` 


