### PR TITLE
Local forbidden issue

### DIFF
--- a/packages/server/src/api/index.js
+++ b/packages/server/src/api/index.js
@@ -3,6 +3,7 @@ const authenticated = require("../middleware/authenticated")
 const compress = require("koa-compress")
 const zlib = require("zlib")
 const { budibaseAppsDir } = require("../utilities/budibaseDir")
+const { isDev } = require("../utilities")
 const {
   authRoutes,
   pageRoutes,
@@ -45,10 +46,7 @@ router
       jwtSecret: env.JWT_SECRET,
       useAppRootPath: true,
     }
-    ctx.isDev =
-      process.env.NODE_ENV !== "production" &&
-      process.env.NODE_ENV !== "jest" &&
-      process.env.NODE_ENV !== "cypress"
+    ctx.isDev = isDev()
     await next()
   })
   .use("/health", ctx => (ctx.status = 200))

--- a/packages/server/src/environment.js
+++ b/packages/server/src/environment.js
@@ -1,3 +1,17 @@
+const { resolve, join } = require("./utilities/centralPath")
+const { homedir } = require("os")
+const { app } = require("electron")
+
+let LOADED = false
+
+if (!LOADED) {
+  const homeDir = app ? app.getPath("home") : homedir()
+  const budibaseDir = join(homeDir, ".budibase")
+  process.env.BUDIBASE_DIR = budibaseDir
+  require("dotenv").config({ path: resolve(budibaseDir, ".env") })
+  LOADED = true
+}
+
 module.exports = {
   CLIENT_ID: process.env.CLIENT_ID,
   NODE_ENV: process.env.NODE_ENV,

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -7,7 +7,7 @@ const fs = require("fs")
 async function runServer() {
   if (isDev() && !fs.existsSync(budibaseTempDir())) {
     console.error(
-      "Please run a build before attempting to run server indepdently to fill 'tmp' directory."
+      "Please run a build before attempting to run server independently to fill 'tmp' directory."
     )
     process.exit(-1)
   }

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -1,18 +1,18 @@
-const { resolve, join } = require("./utilities/centralPath")
-const { homedir } = require("os")
-const { app } = require("electron")
+const { budibaseTempDir } = require("./utilities/budibaseDir")
+const { isDev } = require("./utilities")
+
 const fixPath = require("fix-path")
+const fs = require("fs")
 
 async function runServer() {
-  const homeDir = app ? app.getPath("home") : homedir()
-
-  const budibaseDir = join(homeDir, ".budibase")
-  process.env.BUDIBASE_DIR = budibaseDir
+  if (isDev() && !fs.existsSync(budibaseTempDir())) {
+    console.error(
+      "Please run a build before attempting to run server indepdently to fill 'tmp' directory."
+    )
+    process.exit(-1)
+  }
 
   fixPath()
-
-  require("dotenv").config({ path: resolve(budibaseDir, ".env") })
-
   require("./app")
 }
 

--- a/packages/server/src/utilities/index.js
+++ b/packages/server/src/utilities/index.js
@@ -1,1 +1,9 @@
 exports.wait = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+exports.isDev = () => {
+  return (
+    process.env.NODE_ENV !== "production" &&
+    process.env.NODE_ENV !== "jest" &&
+    process.env.NODE_ENV !== "cypress"
+  )
+}


### PR DESCRIPTION
Found an issue where environment variables would load before they had actually been updated from dotenv, made sure they are always loaded correctly.

Basically this presents itself as a `Forbidden` message as no JWT secret can be loaded locally and the builder will simply fail to load.



