### PR TITLE
Adding init process back after removing CLI package

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,7 +32,8 @@
     "build:electron": "electron-builder --dir",
     "publish:electron": "electron-builder -mwl --publish always",
     "postinstall": "electron-builder install-app-deps",
-    "lint": "eslint --fix src/"
+    "lint": "eslint --fix src/",
+    "initialise": "node scripts/initialise.js"
   },
   "keywords": [
     "budibase"

--- a/packages/server/scripts/initialise.js
+++ b/packages/server/scripts/initialise.js
@@ -1,0 +1,17 @@
+const { join } = require("path")
+const { homedir } = require("os")
+
+const initialiseBudibase = require("../src/utilities/initialiseBudibase")
+const DIRECTORY = "~/.budibase"
+
+function run() {
+  let opts = {}
+  let dir = DIRECTORY
+  opts.quiet = true
+  opts.dir = dir.startsWith("~") ? join(homedir(), dir.substring(1)) : dir
+  return initialiseBudibase(opts)
+}
+
+run().then(() => {
+  console.log("Init complete.")
+})


### PR DESCRIPTION
The removal of CLI package meant there was no way to init the system anymore so nuking budibase directory was unrecoverable, fixing this.