### PR TITLE
New app modal fixes

### DIFF
--- a/packages/builder/src/components/backend/DataTable/Table.svelte
+++ b/packages/builder/src/components/backend/DataTable/Table.svelte
@@ -175,7 +175,7 @@
     flex: 1 1 auto;
   }
   :global(.grid-wrapper) {
-    --ag-modal-overlay-background-color: rgba(0, 0, 0, 0.05);
+    --ag-modal-overlay-background-color: transparent;
     --ag-border-color: var(--grey-3);
     --ag-header-background-color: var(--grey-1);
     --ag-odd-row-background-color: var(--grey-1);

--- a/packages/builder/src/components/start/Steps/API.svelte
+++ b/packages/builder/src/components/start/Steps/API.svelte
@@ -5,7 +5,7 @@
   let blurred = { api: false }
 </script>
 
-<h2>Setup your API Key</h2>
+<h2>Set up your API Key</h2>
 <div class="container">
   <Input
     on:input={() => (blurred.api = true)}
@@ -21,5 +21,13 @@
   .container {
     display: grid;
     grid-gap: 40px;
+  }
+  a {
+    color: var(--grey-7);
+    font-weight: 500;
+    font-size: var(--font-size-s);
+  }
+  a:hover {
+    color: var(--ink);
   }
 </style>

--- a/packages/builder/src/components/start/Steps/Info.svelte
+++ b/packages/builder/src/components/start/Steps/Info.svelte
@@ -6,7 +6,7 @@
   let blurred = { appName: false }
 </script>
 
-<h2>Create your web app</h2>
+<h2>Create your Web App</h2>
 <div class="container">
   {#if template}
     <div class="template">

--- a/packages/builder/src/components/start/Steps/User.svelte
+++ b/packages/builder/src/components/start/Steps/User.svelte
@@ -5,7 +5,7 @@
   let blurred = { username: false, password: false }
 </script>
 
-<h2>Create new user</h2>
+<h2>Create your first User</h2>
 <div class="container">
   <Input
     on:input={() => (blurred.username = true)}

--- a/packages/builder/src/global.css
+++ b/packages/builder/src/global.css
@@ -36,26 +36,6 @@ html, body {
     overflow-y: hidden;
 }
 
-h1 {
-    font-size: 36pt;
-}
-
-h2 {
-    font-size: 30pt;
-}
-
-h3 {
-    font-size: 24pt;
-}
-
-h4 {
-    font-size: 18pt;
-}
-
-h5 {
-    font-size: 14pt;
-}
-
 .hoverable:hover {
     cursor: pointer;
 }


### PR DESCRIPTION
## Description
Just a couple of fixes for the new app modal. Doing the theme changes exposed a small bug where some BBUI styles are now being overridden, causing the "Create your Web App" title in the new app modal to wrap to a new line. I've also just fixed the capitalisation of the titles to be consistent, and styled the "Get API Key" link so that it doesn't take the chrome default styling.

**Fixes**
- Fix BBUI style override causing text wrapping
- Standardise new app modal stage titles (capitalisation and all include the word "your")
"Setup your API Key" > "**Set up** your API Key"
"Create your web app" > "Create your **W**eb **A**pp"
"Create new user" > "Create **your first User**"
- Fix "Get API Key" link styling which previously had none
- Unrelated, but sneaking in the removal of the ag-grid loading overlay colour because it is unnecessary and looks better without it


