### PR TITLE
Use app prefix to try and determine the app ID more consistently

### DIFF
--- a/packages/client/src/render/getAppId.js
+++ b/packages/client/src/render/getAppId.js
@@ -2,14 +2,43 @@ const COOKIE_SEPARATOR = ";"
 const APP_PREFIX = "app_"
 const KEY_VALUE_SPLIT = "="
 
-export const getAppId = allCookies => {
-  const cookie = allCookies
+function confirmAppId(possibleAppId) {
+  return possibleAppId && possibleAppId.startsWith(APP_PREFIX)
+    ? possibleAppId
+    : undefined
+}
+
+function tryGetFromCookie({ cookies }) {
+  const cookie = cookies
     .split(COOKIE_SEPARATOR)
     .find(cookie => cookie.trim().startsWith("budibase:currentapp"))
-  let appId = location.pathname.split("/")[1]
-  appId = appId && appId.startsWith(APP_PREFIX) ? appId : undefined
-  if (!appId && cookie && cookie.split(KEY_VALUE_SPLIT).length === 2) {
+  let appId
+  if (cookie && cookie.split(KEY_VALUE_SPLIT).length === 2) {
     appId = cookie.split("=")[1]
+  }
+  return confirmAppId(appId)
+}
+
+function tryGetFromPath() {
+  const appId = location.pathname.split("/")[1]
+  return confirmAppId(appId)
+}
+
+function tryGetFromSubdomain() {
+  const parts = window.location.host.split(".")
+  const appId = parts[1] ? parts[0] : undefined
+  return confirmAppId(appId)
+}
+
+export const getAppId = cookies => {
+  const functions = [tryGetFromSubdomain, tryGetFromPath, tryGetFromCookie]
+  // try getting the app Id in order
+  let appId
+  for (let func of functions) {
+    appId = func({ cookies })
+    if (appId) {
+      break
+    }
   }
   return appId
 }

--- a/packages/server/src/utilities/index.js
+++ b/packages/server/src/utilities/index.js
@@ -3,6 +3,12 @@ const { DocumentTypes, SEPARATOR } = require("../db/utils")
 
 const APP_PREFIX = DocumentTypes.APP + SEPARATOR
 
+function confirmAppId(possibleAppId) {
+  return possibleAppId && possibleAppId.startsWith(APP_PREFIX)
+    ? possibleAppId
+    : undefined
+}
+
 exports.wait = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 exports.isDev = () => {
@@ -20,19 +26,19 @@ exports.isDev = () => {
  * @returns {string|undefined} If an appId was found it will be returned.
  */
 exports.getAppId = ctx => {
-  let appId = ctx.headers["x-budibase-app-id"]
+  let appId = confirmAppId(ctx.headers["x-budibase-app-id"])
   if (!appId) {
-    appId = env.CLOUD ? ctx.subdomains[1] : ctx.params.appId
+    appId = confirmAppId(env.CLOUD ? ctx.subdomains[1] : ctx.params.appId)
   }
   // look in body if can't find it in subdomain
   if (!appId && ctx.request.body && ctx.request.body.appId) {
-    appId = ctx.request.body.appId
+    appId = confirmAppId(ctx.request.body.appId)
   }
   let appPath =
     ctx.request.headers.referrer ||
     ctx.path.split("/").filter(subPath => subPath.startsWith(APP_PREFIX))
   if (!appId && appPath.length !== 0) {
-    appId = appPath[0]
+    appId = confirmAppId(appPath[0])
   }
   return appId
 }


### PR DESCRIPTION
## Description
Improving consistency of how appId is retrieved and making sure it is valid when being used. This should fix the issues being seen with deployed apps.



