### PR TITLE
remove cf invalidation, adding validation around successful deploys only

### DIFF
--- a/packages/builder/src/components/deploy/DeploymentHistory.svelte
+++ b/packages/builder/src/components/deploy/DeploymentHistory.svelte
@@ -44,6 +44,7 @@
   }
 
   onMount(() => {
+    fetchDeployments()
     poll = setInterval(fetchDeployments, POLL_INTERVAL)
   })
 
@@ -55,10 +56,12 @@
     <header>
       <h4>Deployment History</h4>
       <div class="deploy-div">
-        <a target="_blank" href={`https://${appId}.app.budi.live/${appId}`}>
-          View Your Deployed App →
-        </a>
-        <Button primary on:click={() => modal.show()}>View webhooks</Button>
+        {#if deployments.some(deployment => deployment.status === 'SUCCESS')}
+          <a target="_blank" href={`https://${appId}.app.budi.live/${appId}`}>
+            View Your Deployed App →
+          </a>
+          <Button primary on:click={() => modal.show()}>View webhooks</Button>
+        {/if}
       </div>
     </header>
     <div class="deployment-list">

--- a/packages/builder/src/pages/[application]/deploy/index.svelte
+++ b/packages/builder/src/pages/[application]/deploy/index.svelte
@@ -17,19 +17,16 @@
   $: appId = $store.appId
 
   async function deployApp() {
-    loading = true
     const DEPLOY_URL = `/api/deploy`
 
     try {
-      notifier.info("Starting Deployment..")
+      notifier.info(`Deployment started. Please wait.`)
       const response = await api.post(DEPLOY_URL)
       const json = await response.json()
       if (response.status !== 200) {
         throw new Error()
       }
 
-      notifier.info(`Deployment started. Please wait.`)
-      loading = false
       analytics.captureEvent("Deployed App", {
         appId,
       })
@@ -43,7 +40,6 @@
       })
       analytics.captureException(err)
       notifier.danger("Deployment unsuccessful. Please try again later.")
-      loading = false
     }
   }
 </script>
@@ -51,13 +47,7 @@
 <section>
   <div>
     <h4>It's time to shine!</h4>
-    <Button secondary medium on:click={deployApp}>
-      Deploy App
-      {#if loading}
-        <Spacer extraSmall />
-        <Spinner size="10" />
-      {/if}
-    </Button>
+    <Button secondary medium on:click={deployApp}>Deploy App</Button>
   </div>
   <img
     src="/_builder/assets/deploy-rocket.jpg"

--- a/packages/server/.env.template
+++ b/packages/server/.env.template
@@ -12,7 +12,7 @@ JWT_SECRET={{cookieKey1}}
 PORT=4001 
 
 # error level for koa-pino
-LOG_LEVEL=error
+LOG_LEVEL=info
 
 DEPLOYMENT_CREDENTIALS_URL="https://dt4mpwwap8.execute-api.eu-west-1.amazonaws.com/prod/"
 DEPLOYMENT_DB_URL="https://couchdb.budi.live:5984"

--- a/packages/server/src/api/controllers/deploy/aws.js
+++ b/packages/server/src/api/controllers/deploy/aws.js
@@ -2,45 +2,10 @@ const fs = require("fs")
 const { join } = require("../../../utilities/centralPath")
 const AWS = require("aws-sdk")
 const fetch = require("node-fetch")
-const uuid = require("uuid")
 const sanitize = require("sanitize-s3-objectkey")
 const { budibaseAppsDir } = require("../../../utilities/budibaseDir")
 const PouchDB = require("../../../db")
 const env = require("../../../environment")
-
-async function invalidateCDN(cfDistribution, appId) {
-  const cf = new AWS.CloudFront({})
-  const resp = await cf
-    .createInvalidation({
-      DistributionId: cfDistribution,
-      InvalidationBatch: {
-        CallerReference: `${appId}-${uuid.v4()}`,
-        Paths: {
-          Quantity: 1,
-          Items: [`/assets/${appId}/*`],
-        },
-      },
-    })
-    .promise()
-  return resp.Invalidation.Id
-}
-
-exports.isInvalidationComplete = async function(
-  distributionId,
-  invalidationId
-) {
-  if (distributionId == null || invalidationId == null) {
-    return false
-  }
-  const cf = new AWS.CloudFront({})
-  const resp = await cf
-    .getInvalidation({
-      DistributionId: distributionId,
-      Id: invalidationId,
-    })
-    .promise()
-  return resp.Invalidation.Status === "Completed"
-}
 
 /**
  * Finalises the deployment, updating the quota for the user API key
@@ -162,12 +127,7 @@ async function prepareUploadForS3({ s3Key, metadata, s3, file }) {
 
 exports.prepareUploadForS3 = prepareUploadForS3
 
-exports.uploadAppAssets = async function({
-  appId,
-  bucket,
-  cfDistribution,
-  accountId,
-}) {
+exports.uploadAppAssets = async function({ appId, bucket, accountId }) {
   const s3 = new AWS.S3({
     params: {
       Bucket: bucket,
@@ -224,8 +184,7 @@ exports.uploadAppAssets = async function({
   db.put(fileUploads)
 
   try {
-    await Promise.all(uploads)
-    return await invalidateCDN(cfDistribution, appId)
+    return await Promise.all(uploads)
   } catch (err) {
     console.error("Error uploading budibase app assets to s3", err)
     throw err

--- a/packages/server/src/api/index.js
+++ b/packages/server/src/api/index.js
@@ -66,6 +66,8 @@ router.use(async (ctx, next) => {
   }
 })
 
+router.get("/health", ctx => (ctx.status = 200))
+
 router.use(authRoutes.routes())
 router.use(authRoutes.allowedMethods())
 


### PR DESCRIPTION
## Description
Partial work towards - https://github.com/Budibase/budibase/issues/844


- Adding health check endpoint to the server
- Removing checks for cloudfront invalidation now that the caching is turned off. I have left the deploy process as an asynchronous one though - we don't want to rely on a single HTTP request for deployment status. It also allows us to clean up old, broken deployments and mark them as such
- Validation to only show the deployed app link if you have at least one successful deployment

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



