### PR TITLE
config for windows signing cert

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           mac_certs: ${{ secrets.mac_certs }}
           mac_certs_password: ${{ secrets.mac_certs_password }}
           windows_certs: ${{ secrets.windows_certs }}
-          mac_certs_password: ${{ secrets.windows_certs_password }}
+          windows_certs_password: ${{ secrets.windows_certs_password }}
 
           # release the app after building
           release: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,8 @@ jobs:
 
           mac_certs: ${{ secrets.mac_certs }}
           mac_certs_password: ${{ secrets.mac_certs_password }}
+          windows_certs: ${{ secrets.windows_certs }}
+          mac_certs_password: ${{ secrets.windows_certs_password }}
 
           # release the app after building
           release: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
## Description
Electron builder CI configuration for our windows code signing cert.

I've already added the relevant base64 encoded p12 file (WINDOWS_CERTS) and certificate export password (WINDOWS_CERTS_PASSWORD) to the GH secrets in this repo.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



