### PR TITLE
Switching bug

### DIFF
--- a/packages/builder/src/components/backend/DataTable/DataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/DataTable.svelte
@@ -31,7 +31,7 @@
 
 <Table {title} {schema} {data} allowEditing={true} {loading}>
   <CreateColumnButton />
-  {#if Object.keys(schema).length > 0}
+  {#if schema && Object.keys(schema).length > 0}
     <CreateRowButton />
     <CreateViewButton />
     <ExportButton view={tableView} />

--- a/packages/server/src/api/controllers/application.js
+++ b/packages/server/src/api/controllers/application.js
@@ -80,7 +80,9 @@ exports.fetch = async function(ctx) {
     ctx.body = []
   } else {
     const response = await Promise.allSettled(apps)
-    ctx.body = response.filter(result => result.status === "fulfilled")
+    ctx.body = response
+      .filter(result => result.status === "fulfilled")
+      .map(({ value }) => value)
   }
 }
 

--- a/packages/server/src/api/controllers/application.js
+++ b/packages/server/src/api/controllers/application.js
@@ -79,7 +79,8 @@ exports.fetch = async function(ctx) {
   if (apps.length === 0) {
     ctx.body = []
   } else {
-    ctx.body = await Promise.all(apps)
+    const response = await Promise.allSettled(apps)
+    ctx.body = response.filter(result => result.status === "fulfilled")
   }
 }
 

--- a/packages/standard-components/package.json
+++ b/packages/standard-components/package.json
@@ -36,7 +36,7 @@
   "gitHead": "284cceb9b703c38566c6e6363c022f79a08d5691",
   "dependencies": {
     "@budibase/bbui": "^1.50.1",
-    "@budibase/svelte-ag-grid": "^0.0.13",
+    "@budibase/svelte-ag-grid": "^0.0.16",
     "@fortawesome/fontawesome-free": "^5.14.0",
     "@svelteschool/svelte-forms": "^0.7.0",
     "apexcharts": "^3.22.1",

--- a/packages/standard-components/src/DataGrid/Component.svelte
+++ b/packages/standard-components/src/DataGrid/Component.svelte
@@ -140,12 +140,6 @@
   }
 </script>
 
-<svelte:head>
-  <link
-    rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" />
-</svelte:head>
-
 <div class="container" style="--grid-height: {height}px">
   {#if dataLoaded}
     {#if canAddDelete}
@@ -153,9 +147,7 @@
         {#if selectedRows.length > 0}
           <DeleteButton text small on:click={modal.show()}>
             <Icon name="addrow" />
-            Delete
-            {selectedRows.length}
-            row(s)
+            Delete {selectedRows.length} row(s)
           </DeleteButton>
         {/if}
       </div>

--- a/packages/standard-components/src/DataGrid/Component.svelte
+++ b/packages/standard-components/src/DataGrid/Component.svelte
@@ -147,7 +147,9 @@
         {#if selectedRows.length > 0}
           <DeleteButton text small on:click={modal.show()}>
             <Icon name="addrow" />
-            Delete {selectedRows.length} row(s)
+            Delete
+            {selectedRows.length}
+            row(s)
           </DeleteButton>
         {/if}
       </div>

--- a/packages/standard-components/src/index.js
+++ b/packages/standard-components/src/index.js
@@ -1,4 +1,5 @@
 import "@budibase/bbui/dist/bbui.css"
+import "flatpickr/dist/flatpickr.css"
 
 export { default as container } from "./Container.svelte"
 export { default as text } from "./Text.svelte"


### PR DESCRIPTION
## Description
Solves https://github.com/Budibase/budibase/issues/871, https://github.com/Budibase/budibase/issues/862

This PR: 
- prevents one or more broken apps or strange folder issues from breaking your builder completely
- Stops race condition when switching between views
- Bump standard-components svelte-ag-grid dependency so the grid is less janky - it was pulling all its CSS in the head tag every time it was rendered. Also moved flatpickr.css to be part of standard-components bundle, rather than dynamically loaded in a `style` tag

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



