### PR TITLE
fixes link component being broken if the Url setting is left empty

### DIFF
--- a/packages/standard-components/components.json
+++ b/packages/standard-components/components.json
@@ -612,7 +612,10 @@
 		"name": "Link",
 		"description": "an HTML anchor <a> tag",
 		"props": {
-			"url": "string",
+			"url": {
+				"type": "string",
+				"default": "/"
+			},
 			"openInNewTab": "bool",
 			"text": "string"
 		}

--- a/packages/standard-components/src/Link.svelte
+++ b/packages/standard-components/src/Link.svelte
@@ -4,7 +4,7 @@
   const { linkable, styleable } = getContext("sdk")
   const component = getContext("component")
 
-  export let url = ""
+  export let url = "/"
   export let text = ""
   export let openInNewTab = false
 


### PR DESCRIPTION
## Description
Small fix to the Link component that stops it from crashing if you don't enter a url

