### PR TITLE
Prevent users table from being used as a datasource

### DIFF
--- a/packages/builder/src/components/userInterface/NewScreenModal.svelte
+++ b/packages/builder/src/components/userInterface/NewScreenModal.svelte
@@ -4,8 +4,7 @@
   import { Input, Select, ModalContent, Toggle } from "@budibase/bbui"
   import getTemplates from "builderStore/store/screenTemplates"
   import analytics from "analytics"
-  import { onMount } from "svelte"
-  import api from "builderStore/api"
+  import { TableNames } from "constants"
 
   const CONTAINER = "@budibase/standard-components/container"
 
@@ -17,7 +16,10 @@
   let createLink = true
   let roleId = "BASIC"
 
-  $: templates = getTemplates($store, $backendUiStore.tables)
+  $: filteredTables = $backendUiStore.tables.filter(
+    table => table._id !== TableNames.USERS
+  )
+  $: templates = getTemplates($store, filteredTables)
   $: route = !route && $allScreens.length === 0 ? "*" : route
   $: baseComponents = Object.values($store.components)
     .filter(componentDefinition => componentDefinition.baseComponent)

--- a/packages/builder/src/components/userInterface/TableSelect.svelte
+++ b/packages/builder/src/components/userInterface/TableSelect.svelte
@@ -1,14 +1,19 @@
 <script>
   import { Select } from "@budibase/bbui"
   import { backendUiStore } from "builderStore"
+  import { TableNames } from "constants"
 
   export let value
+
+  $: filteredTales = $backendUiStore.tables.filter(
+    table => table._id !== TableNames.USERS
+  )
 </script>
 
 <div>
   <Select extraThin secondary wide on:change {value}>
     <option value="">Choose a table</option>
-    {#each $backendUiStore.tables as table}
+    {#each filteredTales as table}
       <option value={table._id}>{table.name}</option>
     {/each}
   </Select>

--- a/packages/builder/src/components/userInterface/TableSelect.svelte
+++ b/packages/builder/src/components/userInterface/TableSelect.svelte
@@ -5,7 +5,7 @@
 
   export let value
 
-  $: filteredTales = $backendUiStore.tables.filter(
+  $: filteredTables = $backendUiStore.tables.filter(
     table => table._id !== TableNames.USERS
   )
 </script>
@@ -13,7 +13,7 @@
 <div>
   <Select extraThin secondary wide on:change {value}>
     <option value="">Choose a table</option>
-    {#each filteredTales as table}
+    {#each filteredTables as table}
       <option value={table._id}>{table.name}</option>
     {/each}
   </Select>

--- a/packages/builder/src/components/userInterface/TableViewSelect.svelte
+++ b/packages/builder/src/components/userInterface/TableViewSelect.svelte
@@ -1,8 +1,9 @@
 <script>
-  import { Button, Icon, DropdownMenu, Spacer, Heading } from "@budibase/bbui"
+  import { Icon, DropdownMenu, Heading } from "@budibase/bbui"
   import { createEventDispatcher } from "svelte"
   import { store, backendUiStore, currentAsset } from "builderStore"
   import fetchBindableProperties from "../../builderStore/fetchBindableProperties"
+  import { TableNames } from "constants"
 
   const dispatch = createEventDispatcher()
   let anchorRight, dropdownRight
@@ -14,14 +15,19 @@
     dropdownRight.hide()
   }
 
-  $: tables = $backendUiStore.tables.map(m => ({
-    label: m.name,
-    name: `all_${m._id}`,
-    tableId: m._id,
-    type: "table",
-  }))
+  $: tables = $backendUiStore.tables
+    .filter(table => table._id !== TableNames.USERS)
+    .map(m => ({
+      label: m.name,
+      name: `all_${m._id}`,
+      tableId: m._id,
+      type: "table",
+    }))
 
   $: views = $backendUiStore.tables.reduce((acc, cur) => {
+    if (cur._id === TableNames.USERS) {
+      return acc
+    }
     let viewsArr = Object.entries(cur.views).map(([key, value]) => ({
       label: key,
       name: key,


### PR DESCRIPTION
## Description
This prevents the users table from being selected as a datasource in front end of client apps. The reasoning for this is that the users table is not a normal table and does not work with the normal front end components. Issue is detailed here https://github.com/Budibase/budibase/issues/921.

