### PR TITLE
Remove RPM

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -22,7 +22,6 @@
       "icon": "./build/icons/",
       "target": [
         "deb",
-        "rpm",
         "pacman",
         "snap"
       ],


### PR DESCRIPTION
## Description
We can't build RPM for our scoped package due to - https://github.com/electron-userland/electron-builder/issues/5240

Need to remove RPM for now as it's blocking the release

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



