### PR TITLE
Optional autoscreens

### DIFF
--- a/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
@@ -87,7 +87,7 @@
     bind:value={name}
     {error} />
   <Toggle
-    text="Create screens to view and edit rows in this table"
+    text="Generate screens in the design section"
     bind:checked={createAutoscreens} />
   <div>
     <Label grey extraSmall>Create Table from CSV (Optional)</Label>

--- a/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
@@ -87,7 +87,7 @@
     bind:value={name}
     {error} />
   <Toggle
-    text="Create screens to view and edit items in this table"
+    text="Create screens to view and edit rows in this table"
     bind:checked={createAutoscreens} />
   <div>
     <Label grey extraSmall>Create Table from CSV (Optional)</Label>

--- a/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
@@ -1,8 +1,8 @@
 <script>
-  import { goto, params } from "@sveltech/routify"
+  import { goto } from "@sveltech/routify"
   import { backendUiStore, store } from "builderStore"
   import { notifier } from "builderStore/store/notifications"
-  import { Input, Label, ModalContent } from "@budibase/bbui"
+  import { Input, Label, ModalContent, Toggle } from "@budibase/bbui"
   import TableDataImport from "../TableDataImport.svelte"
   import analytics from "analytics"
   import screenTemplates from "builderStore/store/screenTemplates"
@@ -20,6 +20,7 @@
   let name
   let dataImport
   let error = ""
+  let createAutoscreens = true
 
   function checkValid(evt) {
     const tableName = evt.target.value
@@ -48,23 +49,25 @@
     analytics.captureEvent("Table Created", { name })
 
     // Create auto screens
-    const screens = screenTemplates($store, [table])
-      .filter(template => defaultScreens.includes(template.id))
-      .map(template => template.create())
-    for (let screen of screens) {
-      // Record the table that created this screen so we can link it later
-      screen.autoTableId = table._id
-      await store.actions.screens.create(screen)
-    }
+    if (createAutoscreens) {
+      const screens = screenTemplates($store, [table])
+        .filter(template => defaultScreens.includes(template.id))
+        .map(template => template.create())
+      for (let screen of screens) {
+        // Record the table that created this screen so we can link it later
+        screen.autoTableId = table._id
+        await store.actions.screens.create(screen)
+      }
 
-    // Create autolink to newly created list screen
-    const listScreen = screens.find(screen =>
-      screen.props._instanceName.endsWith("List")
-    )
-    await store.actions.components.links.save(
-      listScreen.routing.route,
-      table.name
-    )
+      // Create autolink to newly created list screen
+      const listScreen = screens.find(screen =>
+        screen.props._instanceName.endsWith("List")
+      )
+      await store.actions.components.links.save(
+        listScreen.routing.route,
+        table.name
+      )
+    }
 
     // Navigate to new table
     $goto(`./table/${table._id}`)
@@ -83,6 +86,9 @@
     on:input={checkValid}
     bind:value={name}
     {error} />
+  <Toggle
+    text="Create screens to view and edit items in this table"
+    bind:checked={createAutoscreens} />
   <div>
     <Label grey extraSmall>Create Table from CSV (Optional)</Label>
     <TableDataImport bind:dataImport />

--- a/packages/client/src/utils/styleable.js
+++ b/packages/client/src/utils/styleable.js
@@ -36,7 +36,7 @@ const addBuilderPreviewStyles = (styleString, componentId, selectable) => {
 
     // Highlighted selected element
     if (componentId === state.selectedComponentId) {
-      str += `;box-shadow: 0 0 0 ${selectedComponentWidth}px ${selectedComponentColor} inset !important;`
+      str += `;border: ${selectedComponentWidth}px solid ${selectedComponentColor} !important;`
     }
   }
 


### PR DESCRIPTION
## Description
This makes autoscreens be optional whenever creating tables by adding a toggle to the create table modal. It defaults to on.
This PR also reverts the selected component style in the builder preview to border again, because inset box shadow isn't perfect and sometimes gets hidden by child components.

## Screenshots
Toggle with nice explicit text, controlling whether autoscreens will be created
![image](https://user-images.githubusercontent.com/9075550/103876268-58015e80-50cb-11eb-8602-03a0ec7e5267.png)



