### PR TITLE
Fix: Text overlap in data table #961

### DIFF
--- a/packages/builder/src/components/backend/DataTable/TableHeader/TableHeader.svelte
+++ b/packages/builder/src/components/backend/DataTable/TableHeader/TableHeader.svelte
@@ -103,6 +103,15 @@
     opacity: 1;
   }
 
+  .column-header-name {
+    white-space: normal !important;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+    overflow: hidden;
+  }
+
   .sort-icon {
     position: relative;
     top: 2px;


### PR DESCRIPTION
Fix: Text overlap in data table #961 

This fix clamps the column header text to one line and hides the overflow with an ellipsis.

![Screenshot 2021-01-07 at 12 16 43](https://user-images.githubusercontent.com/49767913/103891711-3d86af80-50e2-11eb-8829-8414daaaac7a.png)
