### PR TITLE
Remove logo customisation feature from self hosting

### DIFF
--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -9,7 +9,6 @@ services:
       SELF_HOSTED: 1 
       COUCH_DB_URL: http://${COUCH_DB_USER}:${COUCH_DB_PASSWORD}@couchdb-service:5984
       BUDIBASE_ENVIRONMENT: ${BUDIBASE_ENVIRONMENT}
-      LOGO_URL: ${LOGO_URL}
       PORT: 4002
       JWT_SECRET: ${JWT_SECRET}
     depends_on:

--- a/hosting/hosting.properties
+++ b/hosting/hosting.properties
@@ -5,9 +5,6 @@ MAIN_PORT=10000
 # This should be updated
 HOSTING_KEY=budibase
 
-# This section contains customisation options
-LOGO_URL=https://logoipsum.com/logo/logo-15.svg
-
 # This section contains all secrets pertaining to the system
 # These should be updated
 JWT_SECRET=testsecret

--- a/packages/server/src/environment.js
+++ b/packages/server/src/environment.js
@@ -36,8 +36,6 @@ module.exports = {
   ENABLE_ANALYTICS: process.env.ENABLE_ANALYTICS,
   DEPLOYMENT_DB_URL: process.env.DEPLOYMENT_DB_URL,
   LOCAL_TEMPLATES: process.env.LOCAL_TEMPLATES,
-  // self hosting features
-  LOGO_URL: process.env.LOGO_URL,
   _set(key, value) {
     process.env[key] = value
     module.exports[key] = value

--- a/packages/server/src/utilities/index.js
+++ b/packages/server/src/utilities/index.js
@@ -169,15 +169,6 @@ exports.coerceRowValues = (row, table) => {
   return clonedRow
 }
 
-/**
- * Gets the correct link to the logo URL depending on if running in Cloud or if running in self hosting.
- * @returns {string} A URL which links to the correct default logo for new apps.
- */
 exports.getLogoUrl = () => {
-  const BB_LOGO_URL =
-    "https://d33wubrfki0l68.cloudfront.net/aac32159d7207b5085e74a7ef67afbb7027786c5/2b1fd/img/logo/bb-emblem.svg"
-  if (env.SELF_HOSTED) {
-    return env.LOGO_URL || BB_LOGO_URL
-  }
-  return BB_LOGO_URL
+  return "https://d33wubrfki0l68.cloudfront.net/aac32159d7207b5085e74a7ef67afbb7027786c5/2b1fd/img/logo/bb-emblem.svg"
 }


### PR DESCRIPTION
## Description
This simply removes the self hosting logo URL feature as it doesn't really make sense, screen/layout templates are held in the builder codebase and therefore controlling the logo from the server isn't really possible.

If a user wants to change the logo in their app then they can change it while building it, in the future if users could save components (like using the same layout across multiple apps) then theres very little need for a feature to customise logo URL.
