### PR TITLE
Restores Icon components design panel functionality

### DIFF
--- a/packages/standard-components/src/Icon.svelte
+++ b/packages/standard-components/src/Icon.svelte
@@ -1,15 +1,16 @@
 <script>
   import { getContext } from "svelte"
 
-  // Add this back once we can define specific design options to expose
-  // const { styleable } = getContext("sdk")
-  // const component = getContext("component")
+  const { styleable } = getContext("sdk")
+  const component = getContext("component")
 
   export let icon = ""
   export let size = "fa-lg"
   export let color = "#000"
 </script>
 
-<i
-  style={`color: ${color};`}
-  class={`${icon} ${size}`} />
+<div style="color: {color}; display: contents">
+  <i
+  use:styleable={$component.styles}
+  class="{icon} {size}" />
+</div>

--- a/packages/standard-components/src/Icon.svelte
+++ b/packages/standard-components/src/Icon.svelte
@@ -6,11 +6,15 @@
 
   export let icon = ""
   export let size = "fa-lg"
-  export let color = "#000"
+  export let color = "#f00"
+  $: styles = {
+  ...$component.styles,
+  normal: {
+    ...$component.styles.normal,
+    color
+  }
+}
 </script>
 
-<div style="color: {color}; display: contents">
-  <i
-  use:styleable={$component.styles}
+<i use:styleable={styles}
   class="{icon} {size}" />
-</div>


### PR DESCRIPTION
## Description
This fix enables the possibility to use the design panel again while retaining the ability to change the color from the settings panel.

## Screenshots
No visual changes



