### PR TITLE
Fix postgres integration schema credentials

### DIFF
--- a/packages/server/src/integrations/postgres.js
+++ b/packages/server/src/integrations/postgres.js
@@ -18,7 +18,7 @@ const SCHEMA = {
       default: "postgres",
       required: true,
     },
-    username: {
+    user: {
       type: "string",
       default: "root",
       required: true,


### PR DESCRIPTION
## Description
Just fixes the schema of the postgres integration which should be `user` rather than `username`


