### PR TITLE
Digitalocean

### DIFF
--- a/hosting/bootstrap.sh
+++ b/hosting/bootstrap.sh
@@ -17,4 +17,4 @@ fetch_config_files() {
 fetch_config_files
 
 # Start budibase
-docker-compose --env-file hosting.properties up
+docker-compose --env-file hosting.properties up -d

--- a/hosting/bootstrap.sh
+++ b/hosting/bootstrap.sh
@@ -15,3 +15,6 @@ fetch_config_files() {
 }
 
 fetch_config_files
+
+# Start budibase
+docker-compose --env-file hosting.properties up

--- a/hosting/bootstrap.sh
+++ b/hosting/bootstrap.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+GITHUB_BASE_URL=https://raw.githubusercontent.com/Budibase/budibase/master/hosting
+
+if ! [ -x "$(command -v wget)" ]; then
+  echo 'Error: wget is not installed. Please install it for your operating system.' >&2
+  exit 1
+fi
+
+fetch_config_files() {
+  wget $GITHUB_BASE_URL/docker-compose.yaml
+  wget $GITHUB_BASE_URL/envoy.yaml
+  wget $GITHUB_BASE_URL/hosting.properties
+  wget $GITHUB_BASE_URL/start.sh
+}
+
+fetch_config_files

--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -2,6 +2,7 @@ version: "3"
 
 services:
   app-service:
+    restart: always
     image: budibase/budibase-apps
     ports:
       - "${APP_PORT}:4002"
@@ -18,6 +19,7 @@ services:
       - worker-service
 
   worker-service:
+    restart: always
     image: budibase/budibase-worker
     ports:
       - "${WORKER_PORT}:4003"
@@ -36,6 +38,7 @@ services:
       - couch-init
 
   minio-service:
+    restart: always
     image: minio/minio
     volumes:
       - minio_data:/data
@@ -53,6 +56,7 @@ services:
       retries: 3
 
   proxy-service:
+    restart: always
     image: envoyproxy/envoy:v1.16-latest
     volumes:
       - ./envoy.yaml:/etc/envoy/envoy.yaml
@@ -66,6 +70,7 @@ services:
       - couchdb-service
 
   couchdb-service:
+    restart: always
     image: apache/couchdb:3.0
     environment:
       - COUCHDB_PASSWORD=${COUCH_DB_PASSWORD}


### PR DESCRIPTION
## Description
Script for easier DigitalOcean deployment. The user data of the DigitalOcean Droplet will fetch the bootstrap script and run budibase on the new droplet.

Also added `always` to the docker compose config to allow services to restart when someone reboots their host.

Originally we tried to do this with Heroku, but it proved to be much too cumbersome to run our distributed architecture on a PaaS at this time.

## Screenshots
https://www.loom.com/share/6a65f9f09c2b45e3a79f9f9d8662c05b



