### PR TITLE
Adds notification toasts on different actions client apps

### DIFF
--- a/packages/client/src/api/api.js
+++ b/packages/client/src/api/api.js
@@ -1,6 +1,7 @@
 /**
  * API cache for cached request responses.
  */
+import { notificationStore } from "../store/notification"
 let cache = {}
 
 /**
@@ -35,10 +36,12 @@ const makeApiCall = async ({ method, url, body, json = true }) => {
       case 200:
         return response.json()
       case 404:
+        notificationStore.danger("Not found")
         return handleError(`${url}: Not Found`)
       case 400:
         return handleError(`${url}: Bad Request`)
       case 403:
+        notificationStore.danger("Forbidden")
         return handleError(`${url}: Forbidden`)
       default:
         if (response.status >= 200 && response.status < 400) {

--- a/packages/client/src/api/api.js
+++ b/packages/client/src/api/api.js
@@ -9,7 +9,7 @@ let cache = {}
  * Handler for API errors.
  */
 const handleError = error => {
-  notificationStore.danger(error)
+  notificationStore.danger('An error has occured.')
   return { error }
 }
 

--- a/packages/client/src/api/api.js
+++ b/packages/client/src/api/api.js
@@ -1,5 +1,3 @@
-import { notificationStore } from "../store/notification"
-
 /**
  * API cache for cached request responses.
  */
@@ -9,7 +7,6 @@ let cache = {}
  * Handler for API errors.
  */
 const handleError = error => {
-  notificationStore.danger('An error has occured.')
   return { error }
 }
 

--- a/packages/client/src/api/automations.js
+++ b/packages/client/src/api/automations.js
@@ -1,10 +1,15 @@
+import { notificationStore } from "../store/notification"
 import API from "./api"
 /**
  * Executes an automation. Must have "App Action" trigger.
  */
 export const triggerAutomation = async (automationId, fields) => {
-  return await API.post({
+  const res = await API.post({
     url: `/api/automations/${automationId}/trigger`,
     body: { fields },
   })
+  res.error
+    ? notificationStore.danger("En error has occured")
+    : notificationStore.success("Automation triggered.")
+  return res
 }

--- a/packages/client/src/api/automations.js
+++ b/packages/client/src/api/automations.js
@@ -9,7 +9,7 @@ export const triggerAutomation = async (automationId, fields) => {
     body: { fields },
   })
   res.error
-    ? notificationStore.danger("En error has occured")
+    ? notificationStore.danger("En error has occurred")
     : notificationStore.success("Automation triggered")
   return res
 }

--- a/packages/client/src/api/automations.js
+++ b/packages/client/src/api/automations.js
@@ -10,6 +10,6 @@ export const triggerAutomation = async (automationId, fields) => {
   })
   res.error
     ? notificationStore.danger("En error has occured")
-    : notificationStore.success("Automation triggered.")
+    : notificationStore.success("Automation triggered")
   return res
 }

--- a/packages/client/src/api/automations.js
+++ b/packages/client/src/api/automations.js
@@ -9,7 +9,7 @@ export const triggerAutomation = async (automationId, fields) => {
     body: { fields },
   })
   res.error
-    ? notificationStore.danger("En error has occurred")
+    ? notificationStore.danger("An error has occurred")
     : notificationStore.success("Automation triggered")
   return res
 }

--- a/packages/client/src/api/queries.js
+++ b/packages/client/src/api/queries.js
@@ -12,7 +12,7 @@ export const executeQuery = async ({ queryId, parameters }) => {
     },
   })
   res.error
-    ? notificationStore.danger("En error has occured")
+    ? notificationStore.danger("En error has occurred")
     : notificationStore.success("Query successful")
   return response
 }

--- a/packages/client/src/api/queries.js
+++ b/packages/client/src/api/queries.js
@@ -12,7 +12,7 @@ export const executeQuery = async ({ queryId, parameters }) => {
     },
   })
   res.error
-    ? notificationStore.danger("En error has occurred")
+    ? notificationStore.danger("An error has occurred")
     : notificationStore.success("Query successful")
-  return response
+  return res
 }

--- a/packages/client/src/api/queries.js
+++ b/packages/client/src/api/queries.js
@@ -1,3 +1,4 @@
+import { notificationStore } from "../store/notification"
 import API from "./api"
 
 /**

--- a/packages/client/src/api/queries.js
+++ b/packages/client/src/api/queries.js
@@ -4,11 +4,14 @@ import API from "./api"
  * Executes a query against an external data connector.
  */
 export const executeQuery = async ({ queryId, parameters }) => {
-  const response = await API.post({
+  const res = await API.post({
     url: `/api/queries/${queryId}`,
     body: {
       parameters,
     },
   })
+  res.error
+    ? notificationStore.danger("En error has occured")
+    : notificationStore.success("Query successful")
   return response
 }

--- a/packages/client/src/api/rows.js
+++ b/packages/client/src/api/rows.js
@@ -1,3 +1,4 @@
+import { notificationStore } from "../store/notification"
 import API from "./api"
 import { fetchTableDefinition } from "./tables"
 
@@ -15,42 +16,50 @@ export const fetchRow = async ({ tableId, rowId }) => {
  * Creates a row in a table.
  */
 export const saveRow = async row => {
-  return await API.post({
+  const res = await API.post({
     url: `/api/${row.tableId}/rows`,
     body: row,
   })
+  notificationStore.success("Row saved")
+  return res
 }
 
 /**
  * Updates a row in a table.
  */
 export const updateRow = async row => {
-  return await API.patch({
+  const res = await API.patch({
     url: `/api/${row.tableId}/rows/${row._id}`,
     body: row,
   })
+  notificationStore.success("Row updated")
+  return res
 }
 
 /**
  * Deletes a row from a table.
  */
 export const deleteRow = async ({ tableId, rowId, revId }) => {
-  return await API.del({
+  const res = await API.del({
     url: `/api/${tableId}/rows/${rowId}/${revId}`,
   })
+  notificationStore.success("Row deleted")
+  return res
 }
 
 /**
  * Deletes many rows from a table.
  */
 export const deleteRows = async ({ tableId, rows }) => {
-  return await API.post({
+  const res = await API.post({
     url: `/api/${tableId}/rows`,
     body: {
       rows,
       type: "delete",
     },
   })
+  notificationStore.success(`${rows.length} rows deleted.`)
+  return res
 }
 
 /**

--- a/packages/client/src/api/rows.js
+++ b/packages/client/src/api/rows.js
@@ -66,7 +66,7 @@ export const deleteRows = async ({ tableId, rows }) => {
   })
   res.error
     ? notificationStore.danger("En error has occured")
-    : notificationStore.success(`${rows.length} rows deleted.`)
+    : notificationStore.success(`${rows.length} row(s) deleted`)
   return res
 }
 

--- a/packages/client/src/api/rows.js
+++ b/packages/client/src/api/rows.js
@@ -20,7 +20,9 @@ export const saveRow = async row => {
     url: `/api/${row.tableId}/rows`,
     body: row,
   })
-  notificationStore.success("Row saved")
+  res.error
+    ? notificationStore.danger("En error has occured")
+    : notificationStore.success("Row saved")
   return res
 }
 
@@ -32,7 +34,9 @@ export const updateRow = async row => {
     url: `/api/${row.tableId}/rows/${row._id}`,
     body: row,
   })
-  notificationStore.success("Row updated")
+  res.error
+    ? notificationStore.danger("En error has occured")
+    : notificationStore.success("Row updated")
   return res
 }
 
@@ -43,7 +47,9 @@ export const deleteRow = async ({ tableId, rowId, revId }) => {
   const res = await API.del({
     url: `/api/${tableId}/rows/${rowId}/${revId}`,
   })
-  notificationStore.success("Row deleted")
+  res.error
+    ? notificationStore.danger("En error has occured")
+    : notificationStore.success("Row deleted")
   return res
 }
 
@@ -58,7 +64,9 @@ export const deleteRows = async ({ tableId, rows }) => {
       type: "delete",
     },
   })
-  notificationStore.success(`${rows.length} rows deleted.`)
+  res.error
+    ? notificationStore.danger("En error has occured")
+    : notificationStore.success(`${rows.length} rows deleted.`)
   return res
 }
 

--- a/packages/client/src/api/rows.js
+++ b/packages/client/src/api/rows.js
@@ -21,7 +21,7 @@ export const saveRow = async row => {
     body: row,
   })
   res.error
-    ? notificationStore.danger("En error has occurred")
+    ? notificationStore.danger("An error has occurred")
     : notificationStore.success("Row saved")
   return res
 }
@@ -35,7 +35,7 @@ export const updateRow = async row => {
     body: row,
   })
   res.error
-    ? notificationStore.danger("En error has occurred")
+    ? notificationStore.danger("An error has occurred")
     : notificationStore.success("Row updated")
   return res
 }
@@ -48,7 +48,7 @@ export const deleteRow = async ({ tableId, rowId, revId }) => {
     url: `/api/${tableId}/rows/${rowId}/${revId}`,
   })
   res.error
-    ? notificationStore.danger("En error has occurred")
+    ? notificationStore.danger("An error has occurred")
     : notificationStore.success("Row deleted")
   return res
 }
@@ -65,7 +65,7 @@ export const deleteRows = async ({ tableId, rows }) => {
     },
   })
   res.error
-    ? notificationStore.danger("En error has occurred")
+    ? notificationStore.danger("An error has occurred")
     : notificationStore.success(`${rows.length} row(s) deleted`)
   return res
 }

--- a/packages/client/src/api/rows.js
+++ b/packages/client/src/api/rows.js
@@ -21,7 +21,7 @@ export const saveRow = async row => {
     body: row,
   })
   res.error
-    ? notificationStore.danger("En error has occured")
+    ? notificationStore.danger("En error has occurred")
     : notificationStore.success("Row saved")
   return res
 }
@@ -35,7 +35,7 @@ export const updateRow = async row => {
     body: row,
   })
   res.error
-    ? notificationStore.danger("En error has occured")
+    ? notificationStore.danger("En error has occurred")
     : notificationStore.success("Row updated")
   return res
 }
@@ -48,7 +48,7 @@ export const deleteRow = async ({ tableId, rowId, revId }) => {
     url: `/api/${tableId}/rows/${rowId}/${revId}`,
   })
   res.error
-    ? notificationStore.danger("En error has occured")
+    ? notificationStore.danger("En error has occurred")
     : notificationStore.success("Row deleted")
   return res
 }
@@ -65,7 +65,7 @@ export const deleteRows = async ({ tableId, rows }) => {
     },
   })
   res.error
-    ? notificationStore.danger("En error has occured")
+    ? notificationStore.danger("En error has occurred")
     : notificationStore.success(`${rows.length} row(s) deleted`)
   return res
 }

--- a/packages/client/yarn.lock
+++ b/packages/client/yarn.lock
@@ -1362,11 +1362,6 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-mustache@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.0.1.tgz#d99beb031701ad433338e7ea65e0489416c854a2"
-  integrity sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA==
-
 nanoid@^2.1.0:
   version "2.1.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -228,16 +228,6 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@budibase/client@^0.5.3":
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/@budibase/client/-/client-0.5.3.tgz#d2406b9a5b25ac446ba0f776b0ef3a38777a131a"
-  integrity sha512-pv8pMH5vxgvIAEl+2zjp1ScWAtqVWqeH65e9EDqX6oVK2AsnJe9r0HxywOHN5mCgOFxou972+39c6fYR9/enyw==
-  dependencies:
-    deep-equal "^2.0.1"
-    mustache "^4.0.1"
-    regexparam "^1.3.0"
-    svelte-spa-router "^3.0.5"
-
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -5554,11 +5544,6 @@ mssql@^6.2.3:
     tarn "^1.1.5"
     tedious "^6.6.2"
 
-mustache@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.0.1.tgz#d99beb031701ad433338e7ea65e0489416c854a2"
-  integrity sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA==
-
 mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
@@ -5615,11 +5600,6 @@ negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
-
-neo-async@^2.6.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
-  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
 new-github-issue-url@^0.2.1:
   version "0.2.1"
@@ -7912,11 +7892,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-uglify-js@^3.1.4:
-  version "3.11.4"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.11.4.tgz#b47b7ae99d4bd1dca65b53aaa69caa0909e6fadf"
-  integrity sha512-FyYnoxVL1D6+jDGQpbK5jW6y/2JlVfRfEeQ67BPCUg5wfCjaKOpr2XeceE4QL+MkhxliLtf5EbrMDZgzpt2CNw==
-
 unbzip2-stream@^1.0.9:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
@@ -8198,11 +8173,6 @@ word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
-
-wordwrap@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
-  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 worker-farm@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
## Description
This PR adds some error/success messages to the client library. Will fire whenever rows are updated/saved/deleted, queries are run and when an automation is triggered. Requests that aren't status code `400` will still be caught using a catch-all.

I've opted to do a very simple solution here but I think in the future whenever we want to display actual descriptive messages such as "Field age must be greater than 5 but lower than 10" I think we should abstract out the notification handling to a function that we pass in object that defines all the messages instead.

## Screenshots
https://cln.sh/OkvGVl



