### PR TITLE
Quick relationship fix

### DIFF
--- a/packages/server/src/db/linkedRows/linkUtils.js
+++ b/packages/server/src/db/linkedRows/linkUtils.js
@@ -77,11 +77,21 @@ exports.getLinkDocuments = async function({
   }
   params.include_docs = !!includeDocs
   try {
-    const response = await db.query(getQueryIndex(ViewNames.LINK), params)
+    let linkRows = (await db.query(getQueryIndex(ViewNames.LINK), params)).rows
+    // filter to get unique entries
+    const foundIds = []
+    linkRows = linkRows.filter(link => {
+      const unique = foundIds.indexOf(link.id) === -1
+      if (unique) {
+        foundIds.push(link.id)
+      }
+      return unique
+    })
+
     if (includeDocs) {
-      return response.rows.map(row => row.doc)
+      return linkRows.map(row => row.doc)
     } else {
-      return response.rows.map(row => row.value)
+      return linkRows.map(row => row.value)
     }
   } catch (err) {
     // check if the view doesn't exist, it should for all new instances


### PR DESCRIPTION
Under certain conditions the out-going links were being duplicated, basically the system has records in each link doc to say both directions which sometimes both come out when querying, easiest way to solve this is to simply get the unique set of records on the way out and only use these.



