### PR TITLE
Add current user relationships as a data source, and current user bindings

### DIFF
--- a/packages/client/src/api/auth.js
+++ b/packages/client/src/api/auth.js
@@ -1,4 +1,6 @@
 import API from "./api"
+import { enrichRows } from "./rows"
+import { TableNames } from "../constants"
 
 /**
  * Performs a log in request.
@@ -14,4 +16,16 @@ export const logIn = async ({ email, password }) => {
     url: "/api/authenticate",
     body: { email, password },
   })
+}
+
+/**
+ * Fetches the currently logged in user object
+ */
+export const fetchSelf = async () => {
+  const user = await API.get({ url: "/api/self" })
+  if (user?._id) {
+    return (await enrichRows([user], TableNames.USERS))[0]
+  } else {
+    return null
+  }
 }

--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -4,12 +4,7 @@
   import Component from "./Component.svelte"
   import NotificationDisplay from "./NotificationDisplay.svelte"
   import SDK from "../sdk"
-  import {
-    createDataStore,
-    initialise,
-    screenStore,
-    notificationStore,
-  } from "../store"
+  import { createDataStore, initialise, screenStore, authStore } from "../store"
 
   // Provide contexts
   setContext("sdk", SDK)
@@ -22,6 +17,7 @@
   // Load app config
   onMount(async () => {
     await initialise()
+    await authStore.actions.fetchUser()
     loaded = true
   })
 </script>

--- a/packages/client/src/components/Component.svelte
+++ b/packages/client/src/components/Component.svelte
@@ -4,7 +4,7 @@
   import * as ComponentLibrary from "@budibase/standard-components"
   import Router from "./Router.svelte"
   import { enrichProps, propsAreSame } from "../utils/componentProps"
-  import { bindingStore, builderStore } from "../store"
+  import { authStore, bindingStore, builderStore } from "../store"
 
   export let definition = {}
 
@@ -23,7 +23,7 @@
   $: constructor = getComponentConstructor(definition._component)
   $: children = definition._children || []
   $: id = definition._id
-  $: enrichComponentProps(definition, $dataContext, $bindingStore)
+  $: enrichComponentProps(definition, $dataContext, $bindingStore, $authStore)
   $: updateProps(enrichedProps)
   $: styles = definition._styles
 
@@ -67,8 +67,8 @@
   }
 
   // Enriches any string component props using handlebars
-  const enrichComponentProps = async (definition, context, bindingStore) => {
-    enrichedProps = await enrichProps(definition, context, bindingStore)
+  const enrichComponentProps = async (definition, context, bindings, user) => {
+    enrichedProps = await enrichProps(definition, context, bindings, user)
   }
 
   // Returns a unique key to let svelte know when to remount components.

--- a/packages/client/src/constants.js
+++ b/packages/client/src/constants.js
@@ -1,0 +1,3 @@
+export const TableNames = {
+  USERS: "ta_users",
+}

--- a/packages/client/src/store/auth.js
+++ b/packages/client/src/store/auth.js
@@ -52,16 +52,8 @@ const createAuthStore = () => {
 
     // Or fetch the current user from localstorage in a real app
     else {
-      if (get(store) == null) {
-        const user = await API.fetchSelf()
-        if (user) {
-          store.set(user)
-        } else {
-          await logOut()
-        }
-      } else {
-        await logOut()
-      }
+      const user = await API.fetchSelf()
+      store.set(user)
     }
   }
 

--- a/packages/client/src/utils/componentProps.js
+++ b/packages/client/src/utils/componentProps.js
@@ -21,7 +21,7 @@ export const propsAreSame = (a, b) => {
  * Enriches component props.
  * Data bindings are enriched, and button actions are enriched.
  */
-export const enrichProps = async (props, dataContexts, dataBindings) => {
+export const enrichProps = async (props, dataContexts, dataBindings, user) => {
   // Exclude all private props that start with an underscore
   let validProps = {}
   Object.entries(props)
@@ -35,6 +35,7 @@ export const enrichProps = async (props, dataContexts, dataBindings) => {
   const context = {
     ...dataContexts,
     ...dataBindings,
+    user,
     data: dataContexts[dataContexts.closestComponentId],
     data_draft: dataContexts[`${dataContexts.closestComponentId}_draft`],
   }

--- a/packages/server/src/api/controllers/auth.js
+++ b/packages/server/src/api/controllers/auth.js
@@ -57,3 +57,17 @@ exports.authenticate = async ctx => {
     ctx.throw(401, "Invalid credentials.")
   }
 }
+
+exports.fetchSelf = async ctx => {
+  const { userId, appId } = ctx.user
+  if (!userId || !appId) {
+    ctx.body = {}
+  } else {
+    const database = new CouchDB(appId)
+    const user = await database.get(userId)
+    if (user) {
+      delete user.password
+    }
+    ctx.body = user
+  }
+}

--- a/packages/server/src/api/controllers/static/index.js
+++ b/packages/server/src/api/controllers/static/index.js
@@ -177,7 +177,6 @@ exports.serveApp = async function(ctx) {
   })
 
   const appHbs = fs.readFileSync(`${__dirname}/templates/app.hbs`, "utf8")
-  console.log(appHbs)
   ctx.body = await processString(appHbs, {
     head,
     body: html,

--- a/packages/server/src/api/routes/auth.js
+++ b/packages/server/src/api/routes/auth.js
@@ -4,5 +4,6 @@ const controller = require("../controllers/auth")
 const router = Router()
 
 router.post("/api/authenticate", controller.authenticate)
+router.get("/api/self", controller.fetchSelf)
 
 module.exports = router


### PR DESCRIPTION
## Description
This allows data bindings to the properties of the currently logged in user, and adds relationships of the currently logged in user to be used as datasources anywhere in the app.

Part of implementing this required adding a new API endpoint to return the currently logged in user object - because in order to enrich data bindings about the current user, we always need to have the current user definition. Every time the app is initialised (so every page load) the current user document is pulled and stored, as it is on log in / log out.

## Screenshots
Data binding to the current user
![image](https://user-images.githubusercontent.com/9075550/106156084-07849a80-6179-11eb-8c52-1375ce277db8.png)

Current user relationships as a datasource
![image](https://user-images.githubusercontent.com/9075550/106156156-1cf9c480-6179-11eb-9e5d-5c8bd87bf46d.png)




