### PR TITLE
add support for staging image that gets built on master push

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -34,3 +34,12 @@ jobs:
         CI: true
         name: Budibase CI
     - run: yarn test:e2e:ci
+
+    - name: Build and Push Staging Docker Image
+      # Only run on push
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      run: yarn build:staging:docker
+      env:
+        DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}
+

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -38,7 +38,9 @@ jobs:
     - name: Build and Push Staging Docker Image
       # Only run on push
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-      run: yarn build:staging:docker
+      run: |
+        docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+        yarn build:staging:docker
       env:
         DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}

--- a/hosting/scripts/linux/release-to-docker-hub.sh
+++ b/hosting/scripts/linux/release-to-docker-hub.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
+
+tag=$1
+tag=${tag:-latest}
+
 pushd ../../build
 docker-compose build --force app-service
 docker-compose build --force worker-service
-docker tag build_app-service budibase/budibase-apps:latest
+
+docker tag build_app-service budibase/budibase-apps:$tag
+docker tag build_worker-service budibase/budibase-worker:$tag
+
 docker push budibase/budibase-apps
-docker tag build_worker-service budibase/budibase-worker:latest
 docker push budibase/budibase-worker
 popd

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "format": "prettier --write \"{,!(node_modules)/**/}*.{js,jsx,svelte}\"",
     "test:e2e": "lerna run cy:test",
     "test:e2e:ci": "lerna run cy:ci",
-    "build:docker": "cd hosting/scripts/linux/ && ./release-to-docker-hub.sh && cd -"
+    "build:docker": "cd hosting/scripts/linux/ && ./release-to-docker-hub.sh && cd -",
+    "build:docker:staging": "cd hosting/scripts/linux/ && ./release-to-docker-hub.sh staging && cd -"
   }
 }


### PR DESCRIPTION
## Description
CI code to build and push a "staging" docker image that will be used by the staging environment. This means we always have a docker image available representing master.

The staging environment will check for the new images every 10 minutes.



