### PR TITLE
disables input to edit builtin role name

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/EditRoles.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/EditRoles.svelte
@@ -9,6 +9,7 @@
   let permissions = []
   let selectedRole = {}
   let errors = []
+  let builtInRoles = ['Admin', 'Power', 'Basic', 'Public']
   $: selectedRoleId = selectedRole._id
   $: otherRoles = $backendUiStore.roles.filter(
     role => role._id !== selectedRoleId
@@ -102,7 +103,7 @@
     {/each}
   </Select>
   {#if selectedRole}
-    <Input label="Name" bind:value={selectedRole.name} thin />
+    <Input label="Name" bind:value={selectedRole.name} thin disabled={builtInRoles.includes(selectedRole.name)}/>
     <Select
       thin
       secondary


### PR DESCRIPTION
## Description
This MR fixes #979 by disabling the input field to restrict the user from editing builtin role names

## Screenshots
![budibase_inpt_disabled](https://user-images.githubusercontent.com/37672190/106383794-acbb9080-637c-11eb-801f-c86f93ce2368.png)



