### PR TITLE
Bug/quick handlebars fix

### DIFF
--- a/packages/string-templates/src/index.js
+++ b/packages/string-templates/src/index.js
@@ -110,7 +110,7 @@ module.exports.makePropSafe = property => {
  * @returns {boolean} Whether or not the input string is valid.
  */
 module.exports.isValid = string => {
-  const specialCases = ["isNumber", "expected a number"]
+  const specialCases = ["string", "number", "object", "array"]
   // don't really need a real context to check if its valid
   const context = {}
   try {
@@ -118,7 +118,7 @@ module.exports.isValid = string => {
     return true
   } catch (err) {
     const msg = err ? err.message : ""
-    const foundCase = specialCases.find(spCase => msg.includes(spCase))
+    const foundCase = specialCases.find(spCase => msg.toLowerCase().includes(spCase))
     // special case for maths functions - don't have inputs yet
     return !!foundCase
   }

--- a/packages/string-templates/src/index.js
+++ b/packages/string-templates/src/index.js
@@ -118,7 +118,9 @@ module.exports.isValid = string => {
     return true
   } catch (err) {
     const msg = err ? err.message : ""
-    const foundCase = specialCases.find(spCase => msg.toLowerCase().includes(spCase))
+    const foundCase = specialCases.find(spCase =>
+      msg.toLowerCase().includes(spCase)
+    )
     // special case for maths functions - don't have inputs yet
     return !!foundCase
   }

--- a/packages/string-templates/test/helpers.spec.js
+++ b/packages/string-templates/test/helpers.spec.js
@@ -311,4 +311,9 @@ describe("Cover a few complex use cases", () => {
     const output = await processString(`{{first ( split "a-b-c" "-") 2}}`, {})
     expect(output).toBe(`a,b`)
   })
+
+  it("should confirm a subtraction validity", () => {
+    const validity = isValid("{{ subtract [c390c23a7f1b6441c98d2fe2a51248ef3].[total profit] [c390c23a7f1b6441c98d2fe2a51248ef3].[total revenue]  }}")
+    expect(validity).toBe(true)
+  })
 })


### PR DESCRIPTION
## Description
Quick fix to remove type errors when calling the `isValid` function on the string templates package. It does this by simply catching any error with contains the word `object`, `string`, `number` or `array`.




