### PR TITLE
fix: views not loading in deployed apps

### DIFF
--- a/packages/client/src/api/views.js
+++ b/packages/client/src/api/views.js
@@ -18,7 +18,7 @@ export const fetchViewData = async ({
     params.set("calculation", calculation)
   }
   if (groupBy) {
-    params.set("group", groupBy)
+    params.set("group", groupBy ? "true" : "false")
   }
 
   const QUERY_VIEW_URL = field


### PR DESCRIPTION
## Description

Network requests for views were failing due to an incorrect query parameter




