### PR TITLE
Bunch of bug fixes - relationships and handlebars

### DIFF
--- a/packages/server/src/db/linkedRows/linkUtils.js
+++ b/packages/server/src/db/linkedRows/linkUtils.js
@@ -84,6 +84,13 @@ exports.getLinkDocuments = async function({
     // filter to get unique entries
     const foundIds = []
     linkRows = linkRows.filter(link => {
+      // make sure anything unique is the correct key
+      if (
+        (tableId && link.key[0] !== tableId) ||
+        (rowId && link.key[1] !== rowId)
+      ) {
+        return false
+      }
       const unique = foundIds.indexOf(link.id) === -1
       if (unique) {
         foundIds.push(link.id)

--- a/packages/string-templates/manifest.json
+++ b/packages/string-templates/manifest.json
@@ -1097,8 +1097,8 @@
         "format"
       ],
       "numArgs": 2,
-      "example": "{{date now \"YYYY\"}}",
-      "description": "<p>Format a date using moment.js data formatting.</p>\n"
+      "example": "{{date now \"DD-MM-YYYY\"}}",
+      "description": "<p>Format a date using moment.js date formatting.</p>\n"
     }
   }
 }

--- a/packages/string-templates/package.json
+++ b/packages/string-templates/package.json
@@ -15,9 +15,9 @@
   },
   "dependencies": {
     "@budibase/handlebars-helpers": "^0.11.3",
+    "dayjs": "^1.10.4",
     "handlebars": "^4.7.6",
     "handlebars-utils": "^1.0.6",
-    "helper-date": "^1.0.1",
     "lodash": "^4.17.20"
   },
   "devDependencies": {

--- a/packages/string-templates/scripts/gen-collection-info.js
+++ b/packages/string-templates/scripts/gen-collection-info.js
@@ -139,8 +139,8 @@ function run() {
     date: {
       args: ["datetime", "format"],
       numArgs: 2,
-      example: '{{date now "YYYY"}}',
-      description: "Format a date using moment.js data formatting.",
+      example: '{{date now "DD-MM-YYYY"}}',
+      description: "Format a date using moment.js date formatting.",
     },
   }
   // convert all markdown to HTML

--- a/packages/string-templates/src/helpers/date.js
+++ b/packages/string-templates/src/helpers/date.js
@@ -10,13 +10,15 @@ const dayjs = require("dayjs")
  */
 
 function isOptions(val) {
-  return typeof(val) === "object" && typeof(val.hash) === "object"
+  return typeof val === "object" && typeof val.hash === "object"
 }
 
 function isApp(thisArg) {
-  return typeof(thisArg) === "object"
-    && typeof(thisArg.options) === "object"
-    && typeof(thisArg.app) === "object"
+  return (
+    typeof thisArg === "object" &&
+    typeof thisArg.options === "object" &&
+    typeof thisArg.app === "object"
+  )
 }
 
 function getContext(thisArg, locals, options) {
@@ -66,7 +68,7 @@ module.exports = function dateHelper(str, pattern, options) {
     return dayjs().format("MMMM DD, YYYY")
   }
 
-  const defaults = {lang: "en", date: new Date(str)}
+  const defaults = { lang: "en", date: new Date(str) }
   const opts = getContext(this, defaults, options)
 
   // set the language to use

--- a/packages/string-templates/src/helpers/date.js
+++ b/packages/string-templates/src/helpers/date.js
@@ -1,0 +1,76 @@
+const dayjs = require("dayjs")
+
+/**
+ * This file was largely taken from the helper-date package - we did this for two reasons:
+ * 1. It made use of both moment of date.js - this caused some weird bugs with some relatively simple
+ * syntax and didn't offer much in return.
+ * 2. Replacing moment with dayjs helps massively reduce bundle size.
+ * The original package can be found here:
+ * https://github.com/helpers/helper-date
+ */
+
+function isOptions(val) {
+  return typeof(val) === "object" && typeof(val.hash) === "object"
+}
+
+function isApp(thisArg) {
+  return typeof(thisArg) === "object"
+    && typeof(thisArg.options) === "object"
+    && typeof(thisArg.app) === "object"
+}
+
+function getContext(thisArg, locals, options) {
+  if (isOptions(thisArg)) {
+    return getContext({}, locals, thisArg)
+  }
+  // ensure args are in the correct order
+  if (isOptions(locals)) {
+    return getContext(thisArg, options, locals)
+  }
+  const appContext = isApp(thisArg) ? thisArg.context : {}
+  options = options || {}
+
+  // if "options" is not handlebars options, merge it onto locals
+  if (!isOptions(options)) {
+    locals = Object.assign({}, locals, options)
+  }
+  // merge handlebars root data onto locals if specified on the hash
+  if (isOptions(options) && options.hash.root === true) {
+    locals = Object.assign({}, options.data.root, locals)
+  }
+  let context = Object.assign({}, appContext, locals, options.hash)
+  if (!isApp(thisArg)) {
+    context = Object.assign({}, thisArg, context)
+  }
+  if (isApp(thisArg) && thisArg.view && thisArg.view.data) {
+    context = Object.assign({}, context, thisArg.view.data)
+  }
+  return context
+}
+
+module.exports = function dateHelper(str, pattern, options) {
+  if (isOptions(pattern)) {
+    options = pattern
+    pattern = null
+  }
+
+  if (isOptions(str)) {
+    options = str
+    pattern = null
+    str = null
+  }
+
+  // if no args are passed, return a formatted date
+  if (str == null && pattern == null) {
+    dayjs.locale("en")
+    return dayjs().format("MMMM DD, YYYY")
+  }
+
+  const defaults = {lang: "en", date: new Date(str)}
+  const opts = getContext(this, defaults, options)
+
+  // set the language to use
+  dayjs.locale(opts.lang || opts.language)
+
+  return dayjs(new Date(str)).format(pattern)
+}

--- a/packages/string-templates/src/helpers/external.js
+++ b/packages/string-templates/src/helpers/external.js
@@ -1,5 +1,5 @@
 const helpers = require("@budibase/handlebars-helpers")
-const dateHelper = require("helper-date")
+const dateHelper = require("./date")
 const { HelperFunctionBuiltin } = require("./constants")
 
 /**

--- a/packages/string-templates/src/index.js
+++ b/packages/string-templates/src/index.js
@@ -2,7 +2,11 @@ const handlebars = require("handlebars")
 const { registerAll } = require("./helpers/index")
 const processors = require("./processors")
 const { cloneDeep } = require("lodash/fp")
-const { removeNull, addConstants, removeHandlebarsStatements } = require("./utilities")
+const {
+  removeNull,
+  addConstants,
+  removeHandlebarsStatements,
+} = require("./utilities")
 const manifest = require("../manifest.json")
 
 const hbsInstance = handlebars.create()
@@ -121,7 +125,13 @@ module.exports.makePropSafe = property => {
  * @returns {boolean} Whether or not the input string is valid.
  */
 module.exports.isValid = string => {
-  const validCases = ["string", "number", "object", "array", "cannot read property"]
+  const validCases = [
+    "string",
+    "number",
+    "object",
+    "array",
+    "cannot read property",
+  ]
   // this is a portion of a specific string always output by handlebars in the case of a syntax error
   const invalidCases = [`expecting '`]
   // don't really need a real context to check if its valid

--- a/packages/string-templates/src/index.js
+++ b/packages/string-templates/src/index.js
@@ -83,25 +83,21 @@ module.exports.processObjectSync = (object, context) => {
  * @returns {string} The enriched string, all templates should have been replaced if they can be.
  */
 module.exports.processStringSync = (string, context) => {
-  const input = cloneDeep(string)
+  if (!exports.isValid(string)) {
+    return string
+  }
   let clonedContext = removeNull(cloneDeep(context))
   clonedContext = addConstants(clonedContext)
   // remove any null/undefined properties
   if (typeof string !== "string") {
     throw "Cannot process non-string types."
   }
-  try {
-    string = processors.preprocess(string)
-    // this does not throw an error when template can't be fulfilled, have to try correct beforehand
-    const template = hbsInstance.compile(string, {
-      strict: false,
-    })
-    return processors.postprocess(template(clonedContext))
-  } catch (err) {
-    // suggested that we should always return input if an error occurs, incase string wasn't supposed to
-    // contain any handlebars statements
-    return input
-  }
+  string = processors.preprocess(string)
+  // this does not throw an error when template can't be fulfilled, have to try correct beforehand
+  const template = hbsInstance.compile(string, {
+    strict: false,
+  })
+  return processors.postprocess(template(clonedContext))
 }
 
 /**
@@ -119,9 +115,9 @@ module.exports.makePropSafe = property => {
  * @returns {boolean} Whether or not the input string is valid.
  */
 module.exports.isValid = string => {
-  const validCases = ["string", "number", "object", "array"]
+  const validCases = ["string", "number", "object", "array", "cannot read property"]
   // this is a portion of a specific string always output by handlebars in the case of a syntax error
-  const invalidCases = [`expecting 'id', 'string', 'number'`]
+  const invalidCases = [`expecting '`]
   // don't really need a real context to check if its valid
   const context = {}
   try {

--- a/packages/string-templates/src/index.js
+++ b/packages/string-templates/src/index.js
@@ -91,7 +91,9 @@ module.exports.processStringSync = (string, context) => {
   }
   string = processors.preprocess(string)
   // this does not throw an error when template can't be fulfilled, have to try correct beforehand
-  const template = hbsInstance.compile(string)
+  const template = hbsInstance.compile(string, {
+    strict: false,
+  })
   return processors.postprocess(template(clonedContext))
 }
 

--- a/packages/string-templates/src/processors/preprocessor.js
+++ b/packages/string-templates/src/processors/preprocessor.js
@@ -63,7 +63,7 @@ module.exports.processors = [
         return statement
       }
     }
-    if (HelperNames().some(option => possibleHelper.includes(option))) {
+    if (HelperNames().some(option => option.includes(possibleHelper))) {
       insideStatement = `(${insideStatement})`
     }
     return `{{ all ${insideStatement} }}`

--- a/packages/string-templates/src/utilities.js
+++ b/packages/string-templates/src/utilities.js
@@ -32,3 +32,16 @@ module.exports.addConstants = obj => {
   }
   return obj
 }
+
+module.exports.removeHandlebarsStatements = string => {
+  let regexp = new RegExp(exports.FIND_HBS_REGEX)
+  let matches = string.match(regexp)
+  if (matches == null) {
+    return string
+  }
+  for (let match of matches) {
+    const idx = string.indexOf(match)
+    string = exports.swapStrings(string, idx, match.length, "Invalid Binding")
+  }
+  return string
+}

--- a/packages/string-templates/test/helpers.spec.js
+++ b/packages/string-templates/test/helpers.spec.js
@@ -317,9 +317,12 @@ describe("Cover a few complex use cases", () => {
     expect(validity).toBe(true)
   })
 
-  it("should confirm an invalid string", () => {
-    const validity = isValid("{{ awdd () ")
-    expect(validity).toBe(false)
+  it("should confirm a bunch of invalid strings", () => {
+    const invalids = ["{{ awd )", "{{ awdd () ", "{{ awdwad ", "{{ awddawd }"]
+    for (let invalid of invalids) {
+      const validity = isValid(invalid)
+      expect(validity).toBe(false)
+    }
   })
 
   it("input a garbage string, expect it to be returned", async () => {

--- a/packages/string-templates/test/helpers.spec.js
+++ b/packages/string-templates/test/helpers.spec.js
@@ -1,5 +1,6 @@
 const {
   processString,
+  processObject,
   isValid,
 } = require("../src/index")
 
@@ -329,5 +330,12 @@ describe("Cover a few complex use cases", () => {
     const input = `{{{{{{ } {{ ]] ] ] }}} {{ ] {{ {   } { dsa { dddddd }}}}}}} }DDD`
     const output = await processString(input, {})
     expect(output).toBe(input)
+  })
+
+  it("getting a nice date from the user", async () => {
+    const input = {text: `{{ date user.subscriptionDue "DD-MM" }}`}
+    const context = JSON.parse(`{"user":{"email":"test@test.com","roleId":"ADMIN","type":"user","tableId":"ta_users","subscriptionDue":"2021-01-12T12:00:00.000Z","_id":"ro_ta_users_us_test@test.com","_rev":"2-24cc794985eb54183ecb93e148563f3d"}}`)
+    const output = await processObject(input, context)
+    expect(output.text).toBe("12-01")
   })
 })

--- a/packages/string-templates/test/helpers.spec.js
+++ b/packages/string-templates/test/helpers.spec.js
@@ -316,4 +316,15 @@ describe("Cover a few complex use cases", () => {
     const validity = isValid("{{ subtract [c390c23a7f1b6441c98d2fe2a51248ef3].[total profit] [c390c23a7f1b6441c98d2fe2a51248ef3].[total revenue]  }}")
     expect(validity).toBe(true)
   })
+
+  it("should confirm an invalid string", () => {
+    const validity = isValid("{{ awdd () ")
+    expect(validity).toBe(false)
+  })
+
+  it("input a garbage string, expect it to be returned", async () => {
+    const input = `{{{{{{ } {{ ]] ] ] }}} {{ ] {{ {   } { dsa { dddddd }}}}}}} }DDD`
+    const output = await processString(input, {})
+    expect(output).toBe(input)
+  })
 })

--- a/packages/string-templates/yarn.lock
+++ b/packages/string-templates/yarn.lock
@@ -1596,6 +1596,11 @@ date.js@^0.3.1:
   dependencies:
     debug "~3.1.0"
 
+dayjs@^1.10.4:
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.4.tgz#8e544a9b8683f61783f570980a8a80eaf54ab1e2"
+  integrity sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==
+
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
## Description
As the title, basically just a bunch of stability improvements, mainly around our string templates library and one for relationships.
1. Relationship fix - occasionally links weren't showing up their many to many link, this was found by @aptkingston 
2. String templates - the `isValid` check was going too easy after more recent update, made a bunch of changes around this to try and only find syntax errors but let through type errors.
3. string templates - when a syntax error is found for a string that is being processed it now simply returns the string, intention of this being that if someone creates a string that doesn't have bindings in it, but something that looks like a binding, they won't run into trouble with it.
4. string templates - removed invalid handlebars statements that have had a typing error from strings, replace them with the string "Invalid Binding" so that it is obvious something has gone wrong.
5. String templates, date helper - there was some issues with the date helper, mainly around the use of both `date.js` and `moment` - we don't really need the functionality that `date.js` offered and `moment` is not really used anymore, so took the bits we needed and re-built it with `day.js` because this is much more lightweight and less error prone.