### PR TITLE
Attempting to fix the 4001 bug - using ephemeral ports in production (builder)

### DIFF
--- a/packages/builder/cypress.json
+++ b/packages/builder/cypress.json
@@ -1,5 +1,8 @@
 {
-  "baseUrl": "http://localhost:4001/_builder/",
+  "baseUrl": "http://localhost:4005/_builder/",
   "video": true,
-  "projectId": "bmbemn"
+  "projectId": "bmbemn",
+  "env": {
+    "PORT": "4005"
+  }
 }

--- a/packages/builder/cypress/integration/createApp.spec.js
+++ b/packages/builder/cypress/integration/createApp.spec.js
@@ -2,7 +2,7 @@ context('Create an Application', () => {
 
     beforeEach(() => {
         cy.server()
-        cy.visit('localhost:4001/_builder')
+        cy.visit(`localhost:${Cypress.env("PORT")}/_builder`)
     })
 
     // https://on.cypress.io/interacting-with-elements
@@ -11,7 +11,7 @@ context('Create an Application', () => {
         // https://on.cypress.io/type
         cy.createApp('My Cool App', 'This is a description')
 
-        cy.visit('localhost:4001/_builder')
+        cy.visit(`localhost:${Cypress.env("PORT")}/_builder`)
 
         cy.contains('My Cool App').should('exist')
     })

--- a/packages/builder/cypress/integration/createAutomation.spec.js
+++ b/packages/builder/cypress/integration/createAutomation.spec.js
@@ -1,7 +1,7 @@
 context("Create a automation", () => {
   before(() => {
     cy.server()
-    cy.visit("localhost:4001/_builder")
+    cy.visit(`localhost:${Cypress.env("PORT")}/_builder`)
 
     cy.createApp(
       "Automation Test App",

--- a/packages/builder/cypress/integration/createBinding.spec.js
+++ b/packages/builder/cypress/integration/createBinding.spec.js
@@ -1,6 +1,6 @@
 xcontext('Create a Binding', () => {
     before(() => {
-        cy.visit('localhost:4001/_builder')
+        cy.visit(`localhost:${Cypress.env("PORT")}/_builder`)
         cy.createApp('Binding App', 'Binding App Description')
         cy.navigateToFrontend()
     })

--- a/packages/builder/cypress/integration/createComponents.spec.js
+++ b/packages/builder/cypress/integration/createComponents.spec.js
@@ -1,7 +1,7 @@
 xcontext("Create Components", () => {
   before(() => {
     cy.server()
-    cy.visit("localhost:4001/_builder")
+    cy.visit(`localhost:${Cypress.env("PORT")}/_builder`)
     // https://on.cypress.io/type
     cy.createApp("Table App", "Table App Description")
     cy.createTable("dog", "name", "age")

--- a/packages/builder/cypress/integration/createTable.spec.js
+++ b/packages/builder/cypress/integration/createTable.spec.js
@@ -1,6 +1,6 @@
 context("Create a Table", () => {
   before(() => {
-    cy.visit("localhost:4001/_builder")
+    cy.visit(`localhost:${Cypress.env("PORT")}/_builder`)
     cy.createApp("Table App", "Table App Description")
   })
 

--- a/packages/builder/cypress/integration/createUser.spec.js
+++ b/packages/builder/cypress/integration/createUser.spec.js
@@ -2,7 +2,7 @@ context('Create a User', () => {
 
     before(() => {
         cy.server()
-        cy.visit('localhost:4001/_builder')
+        cy.visit(`localhost:${Cypress.env("PORT")}/_builder`)
         // https://on.cypress.io/type
         cy.createApp('User App', 'This app is used to test user creation')
     })

--- a/packages/builder/cypress/integration/createView.spec.js
+++ b/packages/builder/cypress/integration/createView.spec.js
@@ -1,6 +1,6 @@
 context("Create a View", () => {
   before(() => {
-    cy.visit("localhost:4001/_builder")
+    cy.visit(`localhost:${Cypress.env("PORT")}/_builder`)
     cy.createApp("View App", "View App Description")
     cy.createTable("data")
     cy.addColumn("data", "group", "Text")

--- a/packages/builder/cypress/integration/screens.spec.js
+++ b/packages/builder/cypress/integration/screens.spec.js
@@ -2,7 +2,7 @@
 context('Screen Tests', () => {
     before(() => {
         cy.server()
-        cy.visit('localhost:4001/_builder')
+        cy.visit(`localhost:${Cypress.env("PORT")}/_builder`)
         cy.createApp('Conor Cy App', 'Table App Description')
         cy.navigateToFrontend()
     })

--- a/packages/builder/cypress/setup.js
+++ b/packages/builder/cypress/setup.js
@@ -7,6 +7,7 @@ const rimraf = require("rimraf")
 const { join, resolve } = require("path")
 // const run = require("../../cli/src/commands/run/runHandler")
 const initialiseBudibase = require("../../server/src/utilities/initialiseBudibase")
+const cypressConfig = require("../cypress.json")
 
 const homedir = join(require("os").homedir(), ".budibase")
 
@@ -15,6 +16,7 @@ rimraf.sync(homedir)
 process.env.BUDIBASE_API_KEY = "6BE826CB-6B30-4AEC-8777-2E90464633DE"
 process.env.NODE_ENV = "cypress"
 process.env.ENABLE_ANALYTICS = "false"
+process.env.PORT = cypressConfig.env.PORT
 
 // Stop info logs polluting test outputs
 process.env.LOG_LEVEL = "error"

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -14,8 +14,8 @@
     "cy:run": "cypress run",
     "cy:open": "cypress open",
     "cy:run:ci": "cypress run --browser electron --record --key f308590b-6070-41af-b970-794a3823d451",
-    "cy:test": "start-server-and-test cy:setup http://localhost:4001/_builder cy:run",
-    "cy:ci": "start-server-and-test cy:setup http://localhost:4001/_builder cy:run:ci"
+    "cy:test": "start-server-and-test cy:setup http://localhost:4005/_builder cy:run",
+    "cy:ci": "start-server-and-test cy:setup http://localhost:4005/_builder cy:run:ci"
   },
   "jest": {
     "globals": {

--- a/packages/builder/src/components/automation/Shared/WebhookDisplay.svelte
+++ b/packages/builder/src/components/automation/Shared/WebhookDisplay.svelte
@@ -13,7 +13,8 @@
     if (production) {
       return `${appUrl}/${uri}`
     } else {
-      return `http://localhost:4001/${uri}`
+
+      return `${window.location.origin}/${uri}`
     }
   }
 

--- a/packages/server/.env.template
+++ b/packages/server/.env.template
@@ -8,9 +8,6 @@ CLIENT_ID={{clientId}}
 # used to create cookie hashes
 JWT_SECRET={{cookieKey1}}
 
-# port to run http server on
-PORT=4001 
-
 # error level for koa-pino
 LOG_LEVEL=info
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,7 +36,7 @@
     "test:integration": "jest routes --runInBand",
     "test:watch": "jest --watch",
     "run:docker": "node src/index",
-    "dev:builder": "nodemon src/index.js",
+    "dev:builder": "PORT=4001 nodemon src/index.js",
     "electron": "electron src/electron.js",
     "build:electron": "electron-builder --dir",
     "publish:electron": "electron-builder -mwl --publish always",

--- a/packages/server/src/app.js
+++ b/packages/server/src/app.js
@@ -50,8 +50,10 @@ destroyable(server)
 
 server.on("close", () => console.log("Server Closed"))
 
-module.exports = server.listen(env.PORT || 4001, async () => {
+module.exports = server.listen(env.PORT || 0, async () => {
   console.log(`Budibase running on ${JSON.stringify(server.address())}`)
+  env._set("PORT", server.address().port)
+  eventEmitter.emitPort(env.PORT)
   automations.init()
   if (env.SELF_HOSTED) {
     await selfhost.init()

--- a/packages/server/src/events/index.js
+++ b/packages/server/src/events/index.js
@@ -19,6 +19,10 @@ class BudibaseEmitter extends EventEmitter {
   emitTable(eventName, appId, table = null) {
     tableEmission({ emitter: this, eventName, appId, table })
   }
+
+  emitPort(portNumber) {
+    this.emit("internal:port", portNumber)
+  }
 }
 
 const emitter = new BudibaseEmitter()


### PR DESCRIPTION
## Description
This is an issue that has been around forever and has been discussed at length, as per #1075 attempting to solve this with the use of port zero. I've made a few changes here to make this easy to do:
1. replaced anywhere in the builder that used a hard coded port number with `window.location.origin` - this does work in electron and the browser so shouldn't be an issue.
2. In development it still uses the 4001 port, this isn't a total solution as we have to use a consistent port or else development would be a massive pain.
3. Fixed up cypress to use an environment variable for the port so its easier to change in the future.
4. Removed the port number from the dotenv because this would just cause a similar issue, it wouldn't be ephemeral.

*NOTE: Not necessarily saying we should definitely merge this, it does introduce a few problems because it isn't "sticky" per say in production, if it were then we'd be in a similar position as before, but webhooks will now have an ever changing URL as the server keeps starting on different ports when testing, a bit of a pain.*

One thing we could do is use the dotenv to enforce a level of stickiness, e.g. always try to use the same ephemeral port after we've picked one, but if it doesn't work then just use another one anyway, this for 99% of use cases would be an improvement.