### PR TITLE
Duration binding helper

### DIFF
--- a/packages/string-templates/manifest.json
+++ b/packages/string-templates/manifest.json
@@ -1097,8 +1097,17 @@
         "format"
       ],
       "numArgs": 2,
-      "example": "{{date now \"DD-MM-YYYY\"}}",
+      "example": "{{date now \"DD-MM-YYYY\"}} -> 21-01-2021",
       "description": "<p>Format a date using moment.js date formatting.</p>\n"
+    },
+    "duration": {
+      "args": [
+        "time",
+        "durationType"
+      ],
+      "numArgs": 2,
+      "example": "{{duration timeLeft \"seconds\"}} -> a few seconds",
+      "description": "<p>Produce a humanized duration left/until given an amount of time and the type of time measurement.</p>\n"
     }
   }
 }

--- a/packages/string-templates/scripts/gen-collection-info.js
+++ b/packages/string-templates/scripts/gen-collection-info.js
@@ -5,18 +5,31 @@ const fs = require("fs")
 const doctrine = require("doctrine")
 const marked = require("marked")
 
-const DIRECTORY = fs.existsSync("node_modules") ? "." : ".."
-
-const FILENAME = `${DIRECTORY}/manifest.json`
-
 /**
  * full list of supported helpers can be found here:
- * https://github.com/helpers/handlebars-helpers
+ * https://github.com/budibase/handlebars-helpers
  */
 
+const DIRECTORY = fs.existsSync("node_modules") ? "." : ".."
 const COLLECTIONS = ["math", "array", "number", "url", "string", "comparison"]
-
+const FILENAME = `${DIRECTORY}/manifest.json`
 const outputJSON = {}
+const ADDED_HELPERS = {
+  date: {
+    date: {
+      args: ["datetime", "format"],
+      numArgs: 2,
+      example: '{{date now "DD-MM-YYYY"}} -> 21-01-2021',
+      description: "Format a date using moment.js date formatting.",
+    },
+    duration: {
+      args: ["time", "durationType"],
+      numArgs: 2,
+      example: '{{duration timeLeft "seconds"}} -> a few seconds',
+      description: "Produce a humanized duration left/until given an amount of time and the type of time measurement."
+    }
+  }
+}
 
 function fixSpecialCases(name, obj) {
   const args = obj.args
@@ -134,15 +147,15 @@ function run() {
     }
     outputJSON[collection] = collectionInfo
   }
-  // add the date helper
-  outputJSON["date"] = {
-    date: {
-      args: ["datetime", "format"],
-      numArgs: 2,
-      example: '{{date now "DD-MM-YYYY"}}',
-      description: "Format a date using moment.js date formatting.",
-    },
+  // add extra helpers
+  for (let [collectionName, collection] of Object.entries(ADDED_HELPERS)) {
+    let input = collection
+    if (outputJSON[collectionName]) {
+      input = Object.assign(outputJSON[collectionName], collection)
+    }
+    outputJSON[collectionName] = input
   }
+
   // convert all markdown to HTML
   for (let collection of Object.values(outputJSON)) {
     for (let helper of Object.values(collection)) {

--- a/packages/string-templates/scripts/gen-collection-info.js
+++ b/packages/string-templates/scripts/gen-collection-info.js
@@ -26,9 +26,10 @@ const ADDED_HELPERS = {
       args: ["time", "durationType"],
       numArgs: 2,
       example: '{{duration timeLeft "seconds"}} -> a few seconds',
-      description: "Produce a humanized duration left/until given an amount of time and the type of time measurement."
-    }
-  }
+      description:
+        "Produce a humanized duration left/until given an amount of time and the type of time measurement.",
+    },
+  },
 }
 
 function fixSpecialCases(name, obj) {

--- a/packages/string-templates/src/helpers/date.js
+++ b/packages/string-templates/src/helpers/date.js
@@ -53,7 +53,7 @@ function getContext(thisArg, locals, options) {
   return context
 }
 
-function initialSteps(str, pattern, options) {
+function initialConfig(str, pattern, options) {
   if (isOptions(pattern)) {
     options = pattern
     pattern = null
@@ -69,34 +69,34 @@ function initialSteps(str, pattern, options) {
 
 function setLocale(str, pattern, options) {
   // if options is null then it'll get updated here
-  ;({ str, pattern, options } = initialSteps(str, pattern, options))
-  const defaults = { lang: "en", date: new Date(str) }
-  const opts = getContext(this, defaults, options)
+  const config = initialConfig(str, pattern, options)
+  const defaults = { lang: "en", date: new Date(config.str) }
+  const opts = getContext(this, defaults, config.options)
 
   // set the language to use
   dayjs.locale(opts.lang || opts.language)
 }
 
 module.exports.date = (str, pattern, options) => {
-  ;({ str, pattern, options } = initialSteps(str, pattern, options))
+  const config = initialConfig(str, pattern, options)
 
   // if no args are passed, return a formatted date
-  if (str == null && pattern == null) {
+  if (config.str == null && config.pattern == null) {
     dayjs.locale("en")
     return dayjs().format("MMMM DD, YYYY")
   }
 
-  setLocale(str, pattern, options)
+  setLocale(config.str, config.pattern, config.options)
 
-  return dayjs(new Date(str)).format(pattern)
+  return dayjs(new Date(config.str)).format(config.pattern)
 }
 
 module.exports.duration = (str, pattern, format) => {
-  ;({ str, pattern } = initialSteps(str, pattern))
+  const config = initialConfig(str, pattern)
 
-  setLocale(str, pattern)
+  setLocale(config.str, config.pattern)
 
-  const duration = dayjs.duration(str, pattern)
+  const duration = dayjs.duration(config.str, config.pattern)
   if (!isOptions(format)) {
     return duration.format(format)
   } else {

--- a/packages/string-templates/src/helpers/date.js
+++ b/packages/string-templates/src/helpers/date.js
@@ -64,12 +64,12 @@ function initialSteps(str, pattern, options) {
     pattern = null
     str = null
   }
-  return {str, pattern, options}
+  return { str, pattern, options }
 }
 
 function setLocale(str, pattern, options) {
   // if options is null then it'll get updated here
-  ({str, pattern, options} = initialSteps(str, pattern, options))
+  ;({ str, pattern, options } = initialSteps(str, pattern, options))
   const defaults = { lang: "en", date: new Date(str) }
   const opts = getContext(this, defaults, options)
 
@@ -78,7 +78,7 @@ function setLocale(str, pattern, options) {
 }
 
 module.exports.date = (str, pattern, options) => {
-  ({str, pattern, options} = initialSteps(str, pattern, options))
+  ;({ str, pattern, options } = initialSteps(str, pattern, options))
 
   // if no args are passed, return a formatted date
   if (str == null && pattern == null) {
@@ -92,7 +92,7 @@ module.exports.date = (str, pattern, options) => {
 }
 
 module.exports.duration = (str, pattern, format) => {
-  ({str, pattern} = initialSteps(str, pattern))
+  ;({ str, pattern } = initialSteps(str, pattern))
 
   setLocale(str, pattern)
 

--- a/packages/string-templates/src/helpers/external.js
+++ b/packages/string-templates/src/helpers/external.js
@@ -19,8 +19,8 @@ const EXTERNAL_FUNCTION_COLLECTIONS = [
 ]
 
 const ADDED_HELPERS = {
-  "date": date,
-  "duration": duration,
+  date: date,
+  duration: duration,
 }
 
 exports.registerAll = handlebars => {

--- a/packages/string-templates/src/helpers/external.js
+++ b/packages/string-templates/src/helpers/external.js
@@ -1,5 +1,5 @@
 const helpers = require("@budibase/handlebars-helpers")
-const dateHelper = require("./date")
+const { date, duration } = require("./date")
 const { HelperFunctionBuiltin } = require("./constants")
 
 /**
@@ -18,10 +18,15 @@ const EXTERNAL_FUNCTION_COLLECTIONS = [
   "regex",
 ]
 
-const DATE_NAME = "date"
+const ADDED_HELPERS = {
+  "date": date,
+  "duration": duration,
+}
 
 exports.registerAll = handlebars => {
-  handlebars.registerHelper(DATE_NAME, dateHelper)
+  for (let [name, helper] of Object.entries(ADDED_HELPERS)) {
+    handlebars.registerHelper(name, helper)
+  }
   let externalNames = []
   for (let collection of EXTERNAL_FUNCTION_COLLECTIONS) {
     // collect information about helper
@@ -43,12 +48,13 @@ exports.registerAll = handlebars => {
     })
   }
   // add date external functionality
-  externalNames.push(DATE_NAME)
-  exports.externalHelperNames = externalNames
+  exports.externalHelperNames = externalNames.concat(Object.keys(ADDED_HELPERS))
 }
 
 exports.unregisterAll = handlebars => {
-  handlebars.unregisterHelper(DATE_NAME)
+  for (let name of Object.keys(ADDED_HELPERS)) {
+    handlebars.unregisterHelper(name)
+  }
   for (let name of module.exports.externalHelperNames) {
     handlebars.unregisterHelper(name)
   }

--- a/packages/string-templates/test/helpers.spec.js
+++ b/packages/string-templates/test/helpers.spec.js
@@ -318,6 +318,17 @@ describe("Cover a few complex use cases", () => {
     expect(validity).toBe(true)
   })
 
+  it("test a very complex duration output", async () => {
+    const currentTime = new Date(1612432082000).toISOString(),
+      eventTime = new Date(1612432071000).toISOString()
+    const input = `{{duration ( subtract (date currentTime "X")(date eventTime "X")) "seconds"}}`
+    const output = await processString(input, {
+      currentTime,
+      eventTime,
+    })
+    expect(output).toBe("a few seconds")
+  })
+
   it("should confirm a bunch of invalid strings", () => {
     const invalids = ["{{ awd )", "{{ awdd () ", "{{ awdwad ", "{{ awddawd }"]
     for (let invalid of invalids) {


### PR DESCRIPTION
## Description
Quick addition of a duration helper which can be used to create relative humanized date strings. This comes from a question on Discord where they wanted to recreate the following JS function in Budibase:
```
var eventTime = '1366549200';
var currentTime = '1366547400';
//Now i am passing the left time from controller itself which handles timezone stuff (UTC), just to simply question i used
//harcoded values.
var leftTime = eventTime - currentTime;
var duration = moment.duration(leftTime, 'seconds');
var interval = 1000;
```
This helper makes this possible (and arguably easier!) as such:
```
{{duration ( subtract (date currentTime "X")(date eventTime "X")) "seconds"}}
```

This was a great use case for making sure the helpers system is very easily extensible - this also uncovered some features that were missing from our main date formatter after the transition from moment -> dayjs (dayjs by default is quite light weight, needs extensions).