### PR TITLE
Fix bug making apps swap to different apps randomly

### DIFF
--- a/packages/builder/src/components/feedback/FeedbackNavLink.svelte
+++ b/packages/builder/src/components/feedback/FeedbackNavLink.svelte
@@ -1,18 +1,22 @@
 <script>
   import { Popover } from "@budibase/bbui"
   import { store } from "builderStore"
+  import { onMount } from "svelte"
 
   import FeedbackIframe from "./FeedbackIframe.svelte"
   import analytics from "analytics"
 
-  const FIVE_MINUTES = 300000
+  const FIVE_MINUTES = 30000
 
   let iconContainer
   let popover
 
-  setInterval(() => {
-    $store.highlightFeedbackIcon = analytics.highlightFeedbackIcon()
-  }, FIVE_MINUTES)
+  onMount(() => {
+    const interval = setInterval(() => {
+      $store.highlightFeedbackIcon = analytics.highlightFeedbackIcon()
+    }, FIVE_MINUTES)
+    return () => clearInterval(interval)
+  })
 </script>
 
 <div class="container" bind:this={iconContainer} on:click={popover.show}>

--- a/packages/builder/src/components/feedback/FeedbackNavLink.svelte
+++ b/packages/builder/src/components/feedback/FeedbackNavLink.svelte
@@ -13,7 +13,10 @@
 
   onMount(() => {
     const interval = setInterval(() => {
-      $store.highlightFeedbackIcon = analytics.highlightFeedbackIcon()
+      store.update(state => {
+        state.highlightFeedbackIcon = analytics.highlightFeedbackIcon()
+        return state
+      })
     }, FIVE_MINUTES)
     return () => clearInterval(interval)
   })

--- a/packages/builder/src/components/feedback/FeedbackNavLink.svelte
+++ b/packages/builder/src/components/feedback/FeedbackNavLink.svelte
@@ -6,7 +6,7 @@
   import FeedbackIframe from "./FeedbackIframe.svelte"
   import analytics from "analytics"
 
-  const FIVE_MINUTES = 30000
+  const FIVE_MINUTES = 300000
 
   let iconContainer
   let popover


### PR DESCRIPTION
## Description
An interval was being created to make the feedback icon flash every 5 minutes. This interval was never being cleaned up, which meant going back to the main screen and opening a different app would create a new interval, as the `FeedbackNavLink` component was being remounted. Therefore there were multiple intervals updating the singleton reference of the frontend store to the stale subscribed value of the store from the previous interval execution.



