### PR TITLE
RBAC - resource level access control (backend)

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/EditRoles.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/EditRoles.svelte
@@ -6,7 +6,7 @@
   import ErrorsBox from "components/common/ErrorsBox.svelte"
   import { backendUiStore } from "builderStore"
 
-  let permissions = []
+  let basePermissions = []
   let selectedRole = {}
   let errors = []
   let builtInRoles = ["Admin", "Power", "Basic", "Public"]
@@ -16,9 +16,9 @@
   )
   $: isCreating = selectedRoleId == null || selectedRoleId === ""
 
-  const fetchPermissions = async () => {
-    const permissionsResponse = await api.get("/api/permissions")
-    permissions = await permissionsResponse.json()
+  const fetchBasePermissions = async () => {
+    const permissionsResponse = await api.get("/api/permission/builtin")
+    basePermissions = await permissionsResponse.json()
   }
 
   // Changes the selected role
@@ -81,7 +81,7 @@
     }
   }
 
-  onMount(fetchPermissions)
+  onMount(fetchBasePermissions)
 </script>
 
 <ModalContent
@@ -121,11 +121,11 @@
     <Select
       thin
       secondary
-      label="Permissions"
+      label="Base Permissions"
       bind:value={selectedRole.permissionId}>
       <option value="">Choose permissions</option>
-      {#each permissions as permission}
-        <option value={permission._id}>{permission.name}</option>
+      {#each basePermissions as basePerm}
+        <option value={basePerm._id}>{basePerm.name}</option>
       {/each}
     </Select>
   {/if}

--- a/packages/server/src/api/controllers/hosting.js
+++ b/packages/server/src/api/controllers/hosting.js
@@ -14,6 +14,7 @@ exports.fetchInfo = async ctx => {
 }
 
 exports.save = async ctx => {
+  console.trace("DID A SAVE!")
   const db = new CouchDB(BUILDER_CONFIG_DB)
   const { type } = ctx.request.body
   if (type === HostingTypes.CLOUD && ctx.request.body._rev) {

--- a/packages/server/src/api/controllers/permission.js
+++ b/packages/server/src/api/controllers/permission.js
@@ -1,6 +1,25 @@
-const { BUILTIN_PERMISSIONS } = require("../../utilities/security/permissions")
+const {
+  BUILTIN_PERMISSIONS,
+  PermissionLevels,
+} = require("../../utilities/security/permissions")
 
-exports.fetch = async function(ctx) {
-  // TODO: need to build out custom permissions
+function updatePermissionOnRole(roleId, permissions, remove = false) {
+
+}
+
+exports.fetchBuiltin = function(ctx) {
   ctx.body = Object.values(BUILTIN_PERMISSIONS)
+}
+
+exports.fetchLevels = function(ctx) {
+  ctx.body = Object.values(PermissionLevels)
+}
+
+exports.addPermission = async function(ctx) {
+  const permissions = ctx.body.permissions, appId = ctx.appId
+  updatePermissionOnRole
+}
+
+exports.removePermission = async function(ctx) {
+  const permissions = ctx.body.permissions, appId = ctx.appId
 }

--- a/packages/server/src/api/controllers/permission.js
+++ b/packages/server/src/api/controllers/permission.js
@@ -26,6 +26,8 @@ async function updatePermissionOnRole(
   const dbRoles = body.rows.map(row => row.doc)
   const docUpdates = []
 
+  // TODO NEED TO HANDLE BUILTINS HERE - THE dbRoles doesn't contain them
+
   // now try to find any roles which need updated, e.g. removing the
   // resource from another role and then adding to the new role
   for (let role of dbRoles) {

--- a/packages/server/src/api/controllers/permission.js
+++ b/packages/server/src/api/controllers/permission.js
@@ -1,17 +1,23 @@
 const {
   BUILTIN_PERMISSIONS,
   PermissionLevels,
+  higherPermission,
 } = require("../../utilities/security/permissions")
 const { getRoleParams } = require("../../db/utils")
 const CouchDB = require("../../db")
 
+const PermissionUpdateType = {
+  REMOVE: "remove",
+  ADD: "add",
+}
+
 async function updatePermissionOnRole(
   appId,
-  roleId,
-  permissions,
-  remove = false
+  { roleId, resourceId, level },
+  updateType
 ) {
   const db = new CouchDB(appId)
+  const remove = updateType === PermissionUpdateType.REMOVE
   const body = await db.allDocs(
     getRoleParams(null, {
       include_docs: true,
@@ -23,13 +29,32 @@ async function updatePermissionOnRole(
   // now try to find any roles which need updated, e.g. removing the
   // resource from another role and then adding to the new role
   for (let role of dbRoles) {
-    if (role.permissions) {
-      // TODO
+    let updated = false
+    const rolePermissions = role.permissions ? role.permissions : {}
+    // handle the removal/updating the role which has this permission first
+    // the updating (role._id !== roleId) is required because a resource/level can
+    // only be permitted in a single role (this reduces hierarchy confusion and simplifies
+    // the general UI for this, rather than needing to show everywhere it is used)
+    if (
+      (role._id !== roleId || remove) &&
+      rolePermissions[resourceId] === level
+    ) {
+      delete rolePermissions[resourceId]
+      updated = true
+    }
+    // handle the adding, we're on the correct role, at it to this
+    if (!remove && role._id === roleId) {
+      rolePermissions[resourceId] = level
+      updated = true
+    }
+    // handle the update, add it to bulk docs to perform at end
+    if (updated) {
+      role.permissions = rolePermissions
+      docUpdates.push(role)
     }
   }
 
-  // TODO: NEED TO WORK THIS PART OUT
-  return await db.bulkDocs(docUpdates)
+  return db.bulkDocs(docUpdates)
 }
 
 exports.fetchBuiltin = function(ctx) {
@@ -37,19 +62,44 @@ exports.fetchBuiltin = function(ctx) {
 }
 
 exports.fetchLevels = function(ctx) {
-  ctx.body = Object.values(PermissionLevels)
+  // for now only provide the read/write perms externally
+  ctx.body = [PermissionLevels.WRITE, PermissionLevels.READ]
+}
+
+exports.getResourcePerms = async function(ctx) {
+  const resourceId = ctx.params.resourceId
+  const db = new CouchDB(ctx.appId)
+  const body = await db.allDocs(
+    getRoleParams(null, {
+      include_docs: true,
+    })
+  )
+  const roles = body.rows.map(row => row.doc)
+  const resourcePerms = {}
+  for (let role of roles) {
+    // update the various roleIds in the resource permissions
+    if (role.permissions && role.permissions[resourceId]) {
+      resourcePerms[role._id] = higherPermission(
+        resourcePerms[role._id],
+        role.permissions[resourceId]
+      )
+    }
+  }
+  ctx.body = resourcePerms
 }
 
 exports.addPermission = async function(ctx) {
-  const appId = ctx.appId,
-    roleId = ctx.params.roleId,
-    resourceId = ctx.params.resourceId
-  ctx.body = await updatePermissionOnRole(appId, roleId, resourceId)
+  ctx.body = await updatePermissionOnRole(
+    ctx.appId,
+    ctx.params,
+    PermissionUpdateType.ADD
+  )
 }
 
 exports.removePermission = async function(ctx) {
-  const appId = ctx.appId,
-    roleId = ctx.params.roleId,
-    resourceId = ctx.params.resourceId
-  ctx.body = await updatePermissionOnRole(appId, roleId, resourceId, true)
+  ctx.body = await updatePermissionOnRole(
+    ctx.appId,
+    ctx.params,
+    PermissionUpdateType.REMOVE
+  )
 }

--- a/packages/server/src/api/controllers/permission.js
+++ b/packages/server/src/api/controllers/permission.js
@@ -2,9 +2,34 @@ const {
   BUILTIN_PERMISSIONS,
   PermissionLevels,
 } = require("../../utilities/security/permissions")
+const { getRoleParams } = require("../../db/utils")
+const CouchDB = require("../../db")
 
-function updatePermissionOnRole(roleId, permissions, remove = false) {
+async function updatePermissionOnRole(
+  appId,
+  roleId,
+  permissions,
+  remove = false
+) {
+  const db = new CouchDB(appId)
+  const body = await db.allDocs(
+    getRoleParams(null, {
+      include_docs: true,
+    })
+  )
+  const dbRoles = body.rows.map(row => row.doc)
+  const docUpdates = []
 
+  // now try to find any roles which need updated, e.g. removing the
+  // resource from another role and then adding to the new role
+  for (let role of dbRoles) {
+    if (role.permissions) {
+      // TODO
+    }
+  }
+
+  // TODO: NEED TO WORK THIS PART OUT
+  return await db.bulkDocs(docUpdates)
 }
 
 exports.fetchBuiltin = function(ctx) {
@@ -16,10 +41,15 @@ exports.fetchLevels = function(ctx) {
 }
 
 exports.addPermission = async function(ctx) {
-  const permissions = ctx.body.permissions, appId = ctx.appId
-  updatePermissionOnRole
+  const appId = ctx.appId,
+    roleId = ctx.params.roleId,
+    resourceId = ctx.params.resourceId
+  ctx.body = await updatePermissionOnRole(appId, roleId, resourceId)
 }
 
 exports.removePermission = async function(ctx) {
-  const permissions = ctx.body.permissions, appId = ctx.appId
+  const appId = ctx.appId,
+    roleId = ctx.params.roleId,
+    resourceId = ctx.params.resourceId
+  ctx.body = await updatePermissionOnRole(appId, roleId, resourceId, true)
 }

--- a/packages/server/src/api/controllers/permission.js
+++ b/packages/server/src/api/controllers/permission.js
@@ -71,10 +71,11 @@ async function updatePermissionOnRole(
   }
 
   const response = await db.bulkDocs(docUpdates)
-  return response.map(resp => ({
-    ...resp,
-    _id: getExternalRoleID(resp._id),
-  }))
+  return response.map(resp => {
+    resp._id = getExternalRoleID(resp.id)
+    delete resp.id
+    return resp
+  })
 }
 
 exports.fetchBuiltin = function(ctx) {

--- a/packages/server/src/api/controllers/role.js
+++ b/packages/server/src/api/controllers/role.js
@@ -1,8 +1,11 @@
 const CouchDB = require("../../db")
 const {
   BUILTIN_ROLES,
+  BUILTIN_ROLE_IDS,
   Role,
   getRole,
+  isBuiltin,
+  getExternalRoleID,
 } = require("../../utilities/security/roles")
 const {
   generateRoleID,
@@ -15,6 +18,14 @@ const UpdateRolesOptions = {
   CREATED: "created",
   REMOVED: "removed",
 }
+
+// exclude internal roles like builder
+const EXTERNAL_BUILTIN_ROLE_IDS = [
+  BUILTIN_ROLE_IDS.ADMIN,
+  BUILTIN_ROLE_IDS.POWER,
+  BUILTIN_ROLE_IDS.BASIC,
+  BUILTIN_ROLE_IDS.PUBLIC,
+]
 
 async function updateRolesOnUserTable(db, roleId, updateOption) {
   const table = await db.get(ViewNames.USERS)
@@ -46,16 +57,22 @@ exports.fetch = async function(ctx) {
       include_docs: true,
     })
   )
-  const customRoles = body.rows.map(row => row.doc)
+  const roles = body.rows.map(row => row.doc)
 
-  // exclude internal roles like builder
-  const staticRoles = [
-    BUILTIN_ROLES.ADMIN,
-    BUILTIN_ROLES.POWER,
-    BUILTIN_ROLES.BASIC,
-    BUILTIN_ROLES.PUBLIC,
-  ]
-  ctx.body = [...staticRoles, ...customRoles]
+  // need to combine builtin with any DB record of them (for sake of permissions)
+  for (let builtinRoleId of EXTERNAL_BUILTIN_ROLE_IDS) {
+    const builtinRole = BUILTIN_ROLES[builtinRoleId]
+    const dbBuiltin = roles.filter(
+      dbRole => getExternalRoleID(dbRole._id) === builtinRoleId
+    )[0]
+    if (dbBuiltin == null) {
+      roles.push(builtinRole)
+    } else {
+      dbBuiltin._id = getExternalRoleID(dbBuiltin._id)
+      roles.push(Object.assign(builtinRole, dbBuiltin))
+    }
+  }
+  ctx.body = roles
 }
 
 exports.find = async function(ctx) {
@@ -67,6 +84,8 @@ exports.save = async function(ctx) {
   let { _id, name, inherits, permissionId } = ctx.request.body
   if (!_id) {
     _id = generateRoleID()
+  } else if (isBuiltin(_id)) {
+    ctx.throw(400, "Cannot update builtin roles.")
   }
   const role = new Role(_id, name)
     .addPermission(permissionId)
@@ -84,6 +103,9 @@ exports.save = async function(ctx) {
 exports.destroy = async function(ctx) {
   const db = new CouchDB(ctx.user.appId)
   const roleId = ctx.params.roleId
+  if (isBuiltin(roleId)) {
+    ctx.throw(400, "Cannot delete builtin role.")
+  }
   // first check no users actively attached to role
   const users = (
     await db.allDocs(
@@ -94,7 +116,7 @@ exports.destroy = async function(ctx) {
   ).rows.map(row => row.doc)
   const usersWithRole = users.filter(user => user.roleId === roleId)
   if (usersWithRole.length !== 0) {
-    ctx.throw("Cannot delete role when it is in use.")
+    ctx.throw(400, "Cannot delete role when it is in use.")
   }
 
   await db.remove(roleId, ctx.params.rev)

--- a/packages/server/src/api/controllers/row.js
+++ b/packages/server/src/api/controllers/row.js
@@ -54,7 +54,7 @@ async function findRow(db, appId, tableId, rowId) {
 exports.patch = async function(ctx) {
   const appId = ctx.user.appId
   const db = new CouchDB(appId)
-  let row = await db.get(ctx.params.id)
+  let row = await db.get(ctx.params.rowId)
   const table = await db.get(row.tableId)
   const patchfields = ctx.request.body
 
@@ -123,7 +123,7 @@ exports.save = async function(ctx) {
   // if the row obj had an _id then it will have been retrieved
   const existingRow = ctx.preExisting
   if (existingRow) {
-    ctx.params.id = row._id
+    ctx.params.rowId = row._id
     await exports.patch(ctx)
     return
   }

--- a/packages/server/src/api/index.js
+++ b/packages/server/src/api/index.js
@@ -47,6 +47,7 @@ router.use(async (ctx, next) => {
       message: err.message,
       status: ctx.status,
     }
+    console.trace(err)
   }
 })
 

--- a/packages/server/src/api/routes/automation.js
+++ b/packages/server/src/api/routes/automation.js
@@ -8,6 +8,7 @@ const {
   PermissionTypes,
 } = require("../../utilities/security/permissions")
 const Joi = require("joi")
+const { bodyResource, paramResource } = require("../../middleware/resourceId")
 
 const router = Router()
 
@@ -64,9 +65,15 @@ router
     controller.getDefinitionList
   )
   .get("/api/automations", authorized(BUILDER), controller.fetch)
-  .get("/api/automations/:id", authorized(BUILDER), controller.find)
+  .get(
+    "/api/automations/:id",
+    paramResource("id"),
+    authorized(BUILDER),
+    controller.find
+  )
   .put(
     "/api/automations",
+    bodyResource("_id"),
     authorized(BUILDER),
     generateValidator(true),
     controller.update
@@ -79,9 +86,15 @@ router
   )
   .post(
     "/api/automations/:id/trigger",
+    paramResource("id"),
     authorized(PermissionTypes.AUTOMATION, PermissionLevels.EXECUTE),
     controller.trigger
   )
-  .delete("/api/automations/:id/:rev", authorized(BUILDER), controller.destroy)
+  .delete(
+    "/api/automations/:id/:rev",
+    paramResource("id"),
+    authorized(BUILDER),
+    controller.destroy
+  )
 
 module.exports = router

--- a/packages/server/src/api/routes/permission.js
+++ b/packages/server/src/api/routes/permission.js
@@ -30,16 +30,14 @@ function generateRemoveValidator() {
 router
   .get("/api/permission/builtin", authorized(BUILDER), controller.fetchBuiltin)
   .get("/api/permission/levels", authorized(BUILDER), controller.fetchLevels)
-  .patch(
-    "/api/permission/:roleId/add",
+  .post(
+    "/api/permission/:roleId/:resourceId",
     authorized(BUILDER),
-    generateAddValidator(),
     controller.addPermission
   )
-  .patch(
-    "/api/permission/:roleId/remove",
+  .delete(
+    "/api/permission/:roleId/:resourceId",
     authorized(BUILDER),
-    generateRemoveValidator(),
     controller.removePermission
   )
 

--- a/packages/server/src/api/routes/permission.js
+++ b/packages/server/src/api/routes/permission.js
@@ -23,6 +23,7 @@ function generateValidator() {
 router
   .get("/api/permission/builtin", authorized(BUILDER), controller.fetchBuiltin)
   .get("/api/permission/levels", authorized(BUILDER), controller.fetchLevels)
+  .get("/api/permission", authorized(BUILDER), controller.fetch)
   .get(
     "/api/permission/:resourceId",
     authorized(BUILDER),

--- a/packages/server/src/api/routes/permission.js
+++ b/packages/server/src/api/routes/permission.js
@@ -1,10 +1,46 @@
 const Router = require("@koa/router")
 const controller = require("../controllers/permission")
 const authorized = require("../../middleware/authorized")
-const { BUILDER } = require("../../utilities/security/permissions")
+const {
+  BUILDER,
+  PermissionLevels,
+} = require("../../utilities/security/permissions")
+const Joi = require("joi")
+const joiValidator = require("../../middleware/joi-validator")
 
 const router = Router()
 
-router.get("/api/permissions", authorized(BUILDER), controller.fetch)
+function generateAddValidator() {
+  const permLevelArray = Object.values(PermissionLevels)
+  // prettier-ignore
+  return joiValidator.body(Joi.object({
+    permissions: Joi.object()
+      .pattern(/.*/, [Joi.string().valid(...permLevelArray)])
+      .required()
+  }).unknown(true))
+}
+
+function generateRemoveValidator() {
+  // prettier-ignore
+  return joiValidator.body(Joi.object({
+    permissions: Joi.array().items(Joi.string())
+  }).unknown(true))
+}
+
+router
+  .get("/api/permission/builtin", authorized(BUILDER), controller.fetchBuiltin)
+  .get("/api/permission/levels", authorized(BUILDER), controller.fetchLevels)
+  .patch(
+    "/api/permission/:roleId/add",
+    authorized(BUILDER),
+    generateAddValidator(),
+    controller.addPermission
+  )
+  .patch(
+    "/api/permission/:roleId/remove",
+    authorized(BUILDER),
+    generateRemoveValidator(),
+    controller.removePermission
+  )
 
 module.exports = router

--- a/packages/server/src/api/routes/query.js
+++ b/packages/server/src/api/routes/query.js
@@ -8,6 +8,11 @@ const {
   PermissionTypes,
 } = require("../../utilities/security/permissions")
 const joiValidator = require("../../middleware/joi-validator")
+const {
+  bodyResource,
+  bodySubResource,
+  paramResource,
+} = require("../../middleware/resourceId")
 
 const router = Router()
 
@@ -50,23 +55,27 @@ router
   .get("/api/queries", authorized(BUILDER), queryController.fetch)
   .post(
     "/api/queries",
+    bodySubResource("datasourceId", "_id"),
     authorized(BUILDER),
     generateQueryValidation(),
     queryController.save
   )
   .post(
     "/api/queries/preview",
+    bodyResource("datasourceId"),
     authorized(BUILDER),
     generateQueryPreviewValidation(),
     queryController.preview
   )
   .post(
     "/api/queries/:queryId",
+    paramResource("queryId"),
     authorized(PermissionTypes.QUERY, PermissionLevels.WRITE),
     queryController.execute
   )
   .delete(
     "/api/queries/:queryId/:revId",
+    paramResource("queryId"),
     authorized(BUILDER),
     queryController.destroy
   )

--- a/packages/server/src/api/routes/role.js
+++ b/packages/server/src/api/routes/role.js
@@ -1,7 +1,10 @@
 const Router = require("@koa/router")
 const controller = require("../controllers/role")
 const authorized = require("../../middleware/authorized")
-const { BUILDER } = require("../../utilities/security/permissions")
+const {
+  BUILDER,
+  PermissionLevels,
+} = require("../../utilities/security/permissions")
 const Joi = require("joi")
 const joiValidator = require("../../middleware/joi-validator")
 const {
@@ -11,12 +14,17 @@ const {
 const router = Router()
 
 function generateValidator() {
+  const permLevelArray = Object.values(PermissionLevels)
   // prettier-ignore
   return joiValidator.body(Joi.object({
     _id: Joi.string().optional(),
     _rev: Joi.string().optional(),
     name: Joi.string().required(),
+    // this is the base permission ID (for now a built in)
     permissionId: Joi.string().valid(...Object.values(BUILTIN_PERMISSION_IDS)).required(),
+    permissions: Joi.object()
+      .pattern(/.*/, [Joi.string().valid(...permLevelArray)])
+      .optional(),
     inherits: Joi.string().optional(),
   }).unknown(true))
 }

--- a/packages/server/src/api/routes/row.js
+++ b/packages/server/src/api/routes/row.js
@@ -3,6 +3,10 @@ const rowController = require("../controllers/row")
 const authorized = require("../../middleware/authorized")
 const usage = require("../../middleware/usageQuota")
 const {
+  paramResource,
+  paramSubResource,
+} = require("../../middleware/resourceId")
+const {
   PermissionLevels,
   PermissionTypes,
 } = require("../../utilities/security/permissions")
@@ -12,37 +16,44 @@ const router = Router()
 router
   .get(
     "/api/:tableId/:rowId/enrich",
+    paramSubResource("tableId", "rowId"),
     authorized(PermissionTypes.TABLE, PermissionLevels.READ),
     rowController.fetchEnrichedRow
   )
   .get(
     "/api/:tableId/rows",
+    paramResource("tableId"),
     authorized(PermissionTypes.TABLE, PermissionLevels.READ),
     rowController.fetchTableRows
   )
   .get(
     "/api/:tableId/rows/:rowId",
+    paramSubResource("tableId", "rowId"),
     authorized(PermissionTypes.TABLE, PermissionLevels.READ),
     rowController.find
   )
   .post(
     "/api/:tableId/rows",
+    paramResource("tableId"),
     authorized(PermissionTypes.TABLE, PermissionLevels.WRITE),
     usage,
     rowController.save
   )
   .patch(
-    "/api/:tableId/rows/:id",
+    "/api/:tableId/rows/:rowId",
+    paramSubResource("tableId", "rowId"),
     authorized(PermissionTypes.TABLE, PermissionLevels.WRITE),
     rowController.patch
   )
   .post(
     "/api/:tableId/rows/validate",
+    paramResource("tableId"),
     authorized(PermissionTypes.TABLE, PermissionLevels.WRITE),
     rowController.validate
   )
   .delete(
     "/api/:tableId/rows/:rowId/:revId",
+    paramSubResource("tableId", "rowId"),
     authorized(PermissionTypes.TABLE, PermissionLevels.WRITE),
     usage,
     rowController.destroy

--- a/packages/server/src/api/routes/table.js
+++ b/packages/server/src/api/routes/table.js
@@ -1,6 +1,7 @@
 const Router = require("@koa/router")
 const tableController = require("../controllers/table")
 const authorized = require("../../middleware/authorized")
+const { paramResource, bodyResource } = require("../../middleware/resourceId")
 const {
   BUILDER,
   PermissionLevels,
@@ -13,10 +14,17 @@ router
   .get("/api/tables", authorized(BUILDER), tableController.fetch)
   .get(
     "/api/tables/:id",
+    paramResource("id"),
     authorized(PermissionTypes.TABLE, PermissionLevels.READ),
     tableController.find
   )
-  .post("/api/tables", authorized(BUILDER), tableController.save)
+  .post(
+    "/api/tables",
+    // allows control over updating a table
+    bodyResource("_id"),
+    authorized(BUILDER),
+    tableController.save
+  )
   .post(
     "/api/tables/csv/validate",
     authorized(BUILDER),
@@ -24,6 +32,7 @@ router
   )
   .delete(
     "/api/tables/:tableId/:revId",
+    paramResource("tableId"),
     authorized(BUILDER),
     tableController.destroy
   )

--- a/packages/server/src/api/routes/tests/couchTestUtils.js
+++ b/packages/server/src/api/routes/tests/couchTestUtils.js
@@ -88,6 +88,21 @@ exports.createRole = async (request, appId) => {
   return res.body
 }
 
+exports.addPermission = async (
+  request,
+  appId,
+  role,
+  resource,
+  level = "read"
+) => {
+  const res = await request
+    .post(`/api/permission/${role}/${resource}/${level}`)
+    .set(exports.defaultHeaders(appId))
+    .expect("Content-Type", /json/)
+    .expect(200)
+  return res.body
+}
+
 exports.createLinkedTable = async (request, appId) => {
   // get the ID to link to
   const table = await exports.createTable(request, appId)

--- a/packages/server/src/api/routes/tests/couchTestUtils.js
+++ b/packages/server/src/api/routes/tests/couchTestUtils.js
@@ -73,6 +73,22 @@ exports.createTable = async (request, appId, table, removeId = true) => {
   return res.body
 }
 
+exports.createRow = async (request, appId, tableId, row = null) => {
+  row = row || {
+    name: "Test Contact",
+    description: "original description",
+    status: "new",
+    tableId: tableId,
+  }
+  const res = await request
+    .post(`/api/${tableId}/rows`)
+    .send(row)
+    .set(exports.defaultHeaders(appId))
+    .expect("Content-Type", /json/)
+    .expect(200)
+  return res.body
+}
+
 exports.createRole = async (request, appId) => {
   const roleBody = {
     name: "NewRole",

--- a/packages/server/src/api/routes/tests/couchTestUtils.js
+++ b/packages/server/src/api/routes/tests/couchTestUtils.js
@@ -40,6 +40,17 @@ exports.defaultHeaders = appId => {
   return headers
 }
 
+exports.publicHeaders = appId => {
+  const headers = {
+    Accept: "application/json",
+  }
+  if (appId) {
+    headers["x-budibase-app-id"] = appId
+  }
+
+  return headers
+}
+
 exports.BASE_TABLE = {
   name: "TestTable",
   type: "table",
@@ -73,13 +84,17 @@ exports.createTable = async (request, appId, table, removeId = true) => {
   return res.body
 }
 
-exports.createRow = async (request, appId, tableId, row = null) => {
-  row = row || {
+exports.makeBasicRow = tableId => {
+  return {
     name: "Test Contact",
     description: "original description",
     status: "new",
     tableId: tableId,
   }
+}
+
+exports.createRow = async (request, appId, tableId, row = null) => {
+  row = row || exports.makeBasicRow(tableId)
   const res = await request
     .post(`/api/${tableId}/rows`)
     .send(row)

--- a/packages/server/src/api/routes/tests/couchTestUtils.js
+++ b/packages/server/src/api/routes/tests/couchTestUtils.js
@@ -4,6 +4,9 @@ const { BUILTIN_ROLE_IDS } = require("../../../utilities/security/roles")
 const packageJson = require("../../../../package")
 const jwt = require("jsonwebtoken")
 const env = require("../../../environment")
+const {
+  BUILTIN_PERMISSION_IDS,
+} = require("../../../utilities/security/permissions")
 
 const TEST_CLIENT_ID = "test-client-id"
 
@@ -67,6 +70,21 @@ exports.createTable = async (request, appId, table, removeId = true) => {
     .post(`/api/tables`)
     .set(exports.defaultHeaders(appId))
     .send(table)
+  return res.body
+}
+
+exports.createRole = async (request, appId) => {
+  const roleBody = {
+    name: "NewRole",
+    inherits: BUILTIN_ROLE_IDS.BASIC,
+    permissionId: BUILTIN_PERMISSION_IDS.READ_ONLY,
+  }
+  const res = await request
+    .post(`/api/roles`)
+    .send(roleBody)
+    .set(exports.defaultHeaders(appId))
+    .expect("Content-Type", /json/)
+    .expect(200)
   return res.body
 }
 

--- a/packages/server/src/api/routes/tests/permissions.spec.js
+++ b/packages/server/src/api/routes/tests/permissions.spec.js
@@ -48,7 +48,7 @@ describe("/permission", () => {
   describe("test", () => {
     it("should be able to add permission to a role for the table", async () => {
       expect(perms.length).toEqual(1)
-      expect(perms[0].id).toEqual(`${STD_ROLE_ID}`)
+      expect(perms[0]._id).toEqual(`${STD_ROLE_ID}`)
     })
 
     it("should get the resource permissions", async () => {

--- a/packages/server/src/api/routes/tests/permissions.spec.js
+++ b/packages/server/src/api/routes/tests/permissions.spec.js
@@ -1,12 +1,14 @@
 const {
   createApplication,
   createTable,
+  createRow,
   supertest,
   defaultHeaders,
   addPermission,
 } = require("./couchTestUtils")
 const { BUILTIN_ROLE_IDS } = require("../../../utilities/security/roles")
 
+const HIGHER_ROLE_ID = BUILTIN_ROLE_IDS.BASIC
 const STD_ROLE_ID = BUILTIN_ROLE_IDS.PUBLIC
 
 describe("/permission", () => {
@@ -15,6 +17,7 @@ describe("/permission", () => {
   let appId
   let table
   let perms
+  let row
 
   beforeAll(async () => {
     ;({ request, server } = await supertest())
@@ -29,7 +32,16 @@ describe("/permission", () => {
     appId = app.instance._id
     table = await createTable(request, appId)
     perms = await addPermission(request, appId, STD_ROLE_ID, table._id)
+    row = await createRow(request, appId, table._id)
   })
+
+  async function getTablePermissions() {
+    return request
+      .get(`/api/permission/${table._id}`)
+      .set(defaultHeaders(appId))
+      .expect("Content-Type", /json/)
+      .expect(200)
+  }
 
   describe("levels", () => {
     it("should be able to get levels", async () => {
@@ -45,7 +57,7 @@ describe("/permission", () => {
     })
   })
 
-  describe("test", () => {
+  describe("add", () => {
     it("should be able to add permission to a role for the table", async () => {
       expect(perms.length).toEqual(1)
       expect(perms[0]._id).toEqual(`${STD_ROLE_ID}`)
@@ -57,6 +69,40 @@ describe("/permission", () => {
         .set(defaultHeaders(appId))
         .expect("Content-Type", /json/)
         .expect(200)
+      expect(res.body[STD_ROLE_ID]).toEqual("read")
+    })
+
+    it("should get resource permissions with multiple roles", async () => {
+      perms = await addPermission(request, appId, HIGHER_ROLE_ID, table._id, "write")
+      const res = await getTablePermissions()
+      expect(res.body[HIGHER_ROLE_ID]).toEqual("write")
+      expect(res.body[STD_ROLE_ID]).toEqual("read")
+      const allRes = await request
+        .get(`/api/permission`)
+        .set(defaultHeaders(appId))
+        .expect("Content-Type", /json/)
+        .expect(200)
+      expect(allRes.body[HIGHER_ROLE_ID][table._id]).toEqual("write")
+      expect(allRes.body[STD_ROLE_ID][table._id]).toEqual("read")
+    })
+  })
+
+  describe("remove", () => {
+    it("should be able to remove the permission", async () => {
+      const res = await request
+        .delete(`/api/permission/${STD_ROLE_ID}/${table._id}/read`)
+        .set(defaultHeaders(appId))
+        .expect("Content-Type", /json/)
+        .expect(200)
+      expect(res.body[0]._id).toEqual(STD_ROLE_ID)
+      const permsRes = await getTablePermissions()
+      expect(permsRes.body[STD_ROLE_ID]).toBeUndefined()
+    })
+  })
+
+  describe("check public user allowed", () => {
+    it("should be able to read the row", async () => {
+      // TODO
     })
   })
 })

--- a/packages/server/src/api/routes/tests/permissions.spec.js
+++ b/packages/server/src/api/routes/tests/permissions.spec.js
@@ -3,16 +3,18 @@ const {
   createTable,
   supertest,
   defaultHeaders,
+  addPermission,
 } = require("./couchTestUtils")
 const { BUILTIN_ROLE_IDS } = require("../../../utilities/security/roles")
 
-const STD_ROLE_ID = BUILTIN_ROLE_IDS.BASIC
+const STD_ROLE_ID = BUILTIN_ROLE_IDS.PUBLIC
 
 describe("/permission", () => {
   let server
   let request
   let appId
   let table
+  let perms
 
   beforeAll(async () => {
     ;({ request, server } = await supertest())
@@ -26,6 +28,7 @@ describe("/permission", () => {
     let app = await createApplication(request)
     appId = app.instance._id
     table = await createTable(request, appId)
+    perms = await addPermission(request, appId, STD_ROLE_ID, table._id)
   })
 
   describe("levels", () => {
@@ -42,10 +45,15 @@ describe("/permission", () => {
     })
   })
 
-  describe("add", () => {
+  describe("test", () => {
     it("should be able to add permission to a role for the table", async () => {
+      expect(perms.length).toEqual(1)
+      expect(perms[0].id).toEqual(`${STD_ROLE_ID}`)
+    })
+
+    it("should get the resource permissions", async () => {
       const res = await request
-        .post(`/api/permission/${STD_ROLE_ID}/${table._id}/read`)
+        .get(`/api/permission/${table._id}`)
         .set(defaultHeaders(appId))
         .expect("Content-Type", /json/)
         .expect(200)

--- a/packages/server/src/api/routes/tests/permissions.spec.js
+++ b/packages/server/src/api/routes/tests/permissions.spec.js
@@ -1,0 +1,54 @@
+const {
+  createApplication,
+  createTable,
+  supertest,
+  defaultHeaders,
+} = require("./couchTestUtils")
+const { BUILTIN_ROLE_IDS } = require("../../../utilities/security/roles")
+
+const STD_ROLE_ID = BUILTIN_ROLE_IDS.BASIC
+
+describe("/permission", () => {
+  let server
+  let request
+  let appId
+  let table
+
+  beforeAll(async () => {
+    ;({ request, server } = await supertest())
+  })
+
+  afterAll(() => {
+    server.close()
+  })
+
+  beforeEach(async () => {
+    let app = await createApplication(request)
+    appId = app.instance._id
+    table = await createTable(request, appId)
+  })
+
+  describe("levels", () => {
+    it("should be able to get levels", async () => {
+      const res = await request
+        .get(`/api/permission/levels`)
+        .set(defaultHeaders(appId))
+        .expect("Content-Type", /json/)
+        .expect(200)
+      expect(res.body).toBeDefined()
+      expect(res.body.length).toEqual(2)
+      expect(res.body).toContain("read")
+      expect(res.body).toContain("write")
+    })
+  })
+
+  describe("add", () => {
+    it("should be able to add permission to a role for the table", async () => {
+      const res = await request
+        .post(`/api/permission/${STD_ROLE_ID}/${table._id}/read`)
+        .set(defaultHeaders(appId))
+        .expect("Content-Type", /json/)
+        .expect(200)
+    })
+  })
+})

--- a/packages/server/src/api/routes/tests/permissions.spec.js
+++ b/packages/server/src/api/routes/tests/permissions.spec.js
@@ -5,6 +5,8 @@ const {
   supertest,
   defaultHeaders,
   addPermission,
+  publicHeaders,
+  makeBasicRow,
 } = require("./couchTestUtils")
 const { BUILTIN_ROLE_IDS } = require("../../../utilities/security/roles")
 
@@ -102,7 +104,22 @@ describe("/permission", () => {
 
   describe("check public user allowed", () => {
     it("should be able to read the row", async () => {
-      // TODO
+      const res = await request
+        .get(`/api/${table._id}/rows`)
+        .set(publicHeaders(appId))
+        .expect("Content-Type", /json/)
+        .expect(200)
+      expect(res.body[0]._id).toEqual(row._id)
+    })
+
+    it("shouldn't allow writing from a public user", async () => {
+      const res = await request
+        .post(`/api/${table._id}/rows`)
+        .send(makeBasicRow(table._id))
+        .set(publicHeaders(appId))
+        .expect("Content-Type", /json/)
+        .expect(403)
+      expect(res.status).toEqual(403)
     })
   })
 })

--- a/packages/server/src/api/routes/tests/role.spec.js
+++ b/packages/server/src/api/routes/tests/role.spec.js
@@ -1,7 +1,5 @@
 const {
   createApplication,
-  createTable,
-  createView,
   supertest,
   defaultHeaders,
 } = require("./couchTestUtils")
@@ -20,8 +18,6 @@ describe("/roles", () => {
   let server
   let request
   let appId
-  let table
-  let view
 
   beforeAll(async () => {
     ;({ request, server } = await supertest())
@@ -34,8 +30,6 @@ describe("/roles", () => {
   beforeEach(async () => {
     let app = await createApplication(request)
     appId = app.instance._id
-    table = await createTable(request, appId)
-    view = await createView(request, appId, table._id)
   })
 
   describe("create", () => {

--- a/packages/server/src/api/routes/tests/row.spec.js
+++ b/packages/server/src/api/routes/tests/row.spec.js
@@ -5,6 +5,7 @@ const {
   defaultHeaders,
   createLinkedTable,
   createAttachmentTable,
+  makeBasicRow,
 } = require("./couchTestUtils");
 const { enrichRows } = require("../../../utilities")
 const env = require("../../../environment")
@@ -30,12 +31,7 @@ describe("/rows", () => {
     app = await createApplication(request)
     appId = app.instance._id
     table = await createTable(request, appId)
-    row = {
-      name: "Test Contact",
-      description: "original description",
-      status: "new",
-      tableId: table._id
-    }
+    row = makeBasicRow(table._id)
   })
 
   const createRow = async r => 

--- a/packages/server/src/db/utils.js
+++ b/packages/server/src/db/utils.js
@@ -170,8 +170,8 @@ exports.getAppParams = (appId = null, otherProps = {}) => {
  * Generates a new role ID.
  * @returns {string} The new role ID which the role doc can be stored under.
  */
-exports.generateRoleID = () => {
-  return `${DocumentTypes.ROLE}${SEPARATOR}${newid()}`
+exports.generateRoleID = id => {
+  return `${DocumentTypes.ROLE}${SEPARATOR}${id || newid()}`
 }
 
 /**

--- a/packages/server/src/middleware/authorized.js
+++ b/packages/server/src/middleware/authorized.js
@@ -1,10 +1,11 @@
 const {
   BUILTIN_ROLE_IDS,
-  getUserPermissionIds,
+  getUserPermissions,
 } = require("../utilities/security/roles")
 const {
   PermissionTypes,
-  doesHavePermission,
+  doesHaveResourcePermission,
+  doesHaveBasePermission,
 } = require("../utilities/security/permissions")
 const env = require("../environment")
 const { isAPIKeyValid } = require("../utilities/security/apikey")
@@ -13,6 +14,10 @@ const { AuthTypes } = require("../constants")
 const ADMIN_ROLES = [BUILTIN_ROLE_IDS.ADMIN, BUILTIN_ROLE_IDS.BUILDER]
 
 const LOCAL_PASS = new RegExp(["webhooks/trigger", "webhooks/schema"].join("|"))
+
+function hasResource(ctx) {
+  return ctx.resourceId != null
+}
 
 module.exports = (permType, permLevel = null) => async (ctx, next) => {
   // webhooks can pass locally
@@ -47,7 +52,10 @@ module.exports = (permType, permLevel = null) => async (ctx, next) => {
   }
 
   const role = ctx.user.role
-  const permissions = await getUserPermissionIds(ctx.appId, role._id)
+  const { basePermissions, permissions } = await getUserPermissions(
+    ctx.appId,
+    role._id
+  )
   if (ADMIN_ROLES.indexOf(role._id) !== -1) {
     return next()
   }
@@ -56,7 +64,14 @@ module.exports = (permType, permLevel = null) => async (ctx, next) => {
     ctx.throw(403, "Not Authorized")
   }
 
-  if (!doesHavePermission(permType, permLevel, permissions)) {
+  if (
+    hasResource(ctx) &&
+    doesHaveResourcePermission(permissions, permLevel, ctx)
+  ) {
+    return next()
+  }
+
+  if (!doesHaveBasePermission(permType, permLevel, basePermissions)) {
     ctx.throw(403, "User does not have permission")
   }
 

--- a/packages/server/src/middleware/authorized.js
+++ b/packages/server/src/middleware/authorized.js
@@ -64,12 +64,12 @@ module.exports = (permType, permLevel = null) => async (ctx, next) => {
     ctx.throw(403, "Not Authorized")
   }
 
-  // if (
-  //   hasResource(ctx) &&
-  //   doesHaveResourcePermission(permissions, permLevel, ctx)
-  // ) {
-  //   return next()
-  // }
+  if (
+    hasResource(ctx) &&
+    doesHaveResourcePermission(permissions, permLevel, ctx)
+  ) {
+    return next()
+  }
 
   if (!doesHaveBasePermission(permType, permLevel, basePermissions)) {
     ctx.throw(403, "User does not have permission")

--- a/packages/server/src/middleware/authorized.js
+++ b/packages/server/src/middleware/authorized.js
@@ -64,12 +64,12 @@ module.exports = (permType, permLevel = null) => async (ctx, next) => {
     ctx.throw(403, "Not Authorized")
   }
 
-  if (
-    hasResource(ctx) &&
-    doesHaveResourcePermission(permissions, permLevel, ctx)
-  ) {
-    return next()
-  }
+  // if (
+  //   hasResource(ctx) &&
+  //   doesHaveResourcePermission(permissions, permLevel, ctx)
+  // ) {
+  //   return next()
+  // }
 
   if (!doesHaveBasePermission(permType, permLevel, basePermissions)) {
     ctx.throw(403, "User does not have permission")

--- a/packages/server/src/middleware/joi-validator.js
+++ b/packages/server/src/middleware/joi-validator.js
@@ -22,3 +22,7 @@ function validate(schema, property) {
 module.exports.body = schema => {
   return validate(schema, "body")
 }
+
+module.exports.params = schema => {
+  return validate(schema, "params")
+}

--- a/packages/server/src/middleware/resourceId.js
+++ b/packages/server/src/middleware/resourceId.js
@@ -1,0 +1,55 @@
+class ResourceIdGetter {
+  constructor(ctxProperty) {
+    this.parameter = ctxProperty
+    this.main = null
+    this.sub = null
+    return this
+  }
+
+  mainResource(field) {
+    this.main = field
+    return this
+  }
+
+  subResource(field) {
+    this.sub = field
+    return this
+  }
+
+  build() {
+    const parameter = this.parameter,
+      main = this.main,
+      sub = this.sub
+    return (ctx, next) => {
+      if (main != null && ctx.request[parameter][main]) {
+        ctx.resourceId = ctx.request[parameter][main]
+      }
+      if (sub != null && ctx.request[parameter][sub]) {
+        ctx.subResourceId = ctx.request[parameter][sub]
+      }
+      next()
+    }
+  }
+}
+
+module.exports.paramResource = main => {
+  return new ResourceIdGetter("params").mainResource(main).build()
+}
+
+module.exports.paramSubResource = (main, sub) => {
+  return new ResourceIdGetter("params")
+    .mainResource(main)
+    .subResource(sub)
+    .build()
+}
+
+module.exports.bodyResource = main => {
+  return new ResourceIdGetter("body").mainResource(main).build()
+}
+
+module.exports.bodySubResource = (main, sub) => {
+  return new ResourceIdGetter("body")
+    .mainResource(main)
+    .subResource(sub)
+    .build()
+}

--- a/packages/server/src/middleware/resourceId.js
+++ b/packages/server/src/middleware/resourceId.js
@@ -21,13 +21,17 @@ class ResourceIdGetter {
       main = this.main,
       sub = this.sub
     return (ctx, next) => {
-      if (main != null && ctx.request[parameter][main]) {
-        ctx.resourceId = ctx.request[parameter][main]
+      const request = ctx.request[parameter] || ctx[parameter]
+      if (request == null) {
+        return next()
       }
-      if (sub != null && ctx.request[parameter][sub]) {
-        ctx.subResourceId = ctx.request[parameter][sub]
+      if (main != null && request[main]) {
+        ctx.resourceId = request[main]
       }
-      next()
+      if (sub != null && request[sub]) {
+        ctx.subResourceId = request[sub]
+      }
+      return next()
     }
   }
 }

--- a/packages/server/src/utilities/builder/hosting.js
+++ b/packages/server/src/utilities/builder/hosting.js
@@ -23,6 +23,7 @@ exports.HostingTypes = {
 }
 
 exports.getHostingInfo = async () => {
+  console.trace("DID A GET!")
   const db = new CouchDB(BUILDER_CONFIG_DB)
   let doc
   try {

--- a/packages/server/src/utilities/builder/hosting.js
+++ b/packages/server/src/utilities/builder/hosting.js
@@ -23,7 +23,6 @@ exports.HostingTypes = {
 }
 
 exports.getHostingInfo = async () => {
-  console.trace("DID A GET!")
   const db = new CouchDB(BUILDER_CONFIG_DB)
   let doc
   try {

--- a/packages/server/src/utilities/builder/hosting.js
+++ b/packages/server/src/utilities/builder/hosting.js
@@ -94,17 +94,22 @@ exports.getDeployedApps = async () => {
   }
   const workerUrl = !env.CLOUD ? await exports.getWorkerUrl() : env.WORKER_URL
   const hostingKey = !env.CLOUD ? hostingInfo.selfHostKey : env.HOSTING_KEY
-  const response = await fetch(`${workerUrl}/api/apps`, {
-    method: "GET",
-    headers: {
-      "x-budibase-auth": hostingKey,
-    },
-  })
-  const json = await response.json()
-  for (let value of Object.values(json)) {
-    if (value.url) {
-      value.url = value.url.toLowerCase()
+  try {
+    const response = await fetch(`${workerUrl}/api/apps`, {
+      method: "GET",
+      headers: {
+        "x-budibase-auth": hostingKey,
+      },
+    })
+    const json = await response.json()
+    for (let value of Object.values(json)) {
+      if (value.url) {
+        value.url = value.url.toLowerCase()
+      }
     }
+    return json
+  } catch (err) {
+    // error, cannot determine deployed apps, don't stop app creation - sort this later
+    return {}
   }
-  return json
 }

--- a/packages/server/src/utilities/security/permissions.js
+++ b/packages/server/src/utilities/security/permissions.js
@@ -97,7 +97,35 @@ exports.BUILTIN_PERMISSIONS = {
   },
 }
 
-exports.doesHavePermission = (permType, permLevel, permissionIds) => {
+exports.doesHaveResourcePermission = (
+  permissions,
+  permLevel,
+  { resourceId, subResourceId }
+) => {
+  // set foundSub to not subResourceId, incase there is no subResource
+  let foundMain = false,
+    foundSub = !subResourceId
+  for (let [resource, level] of Object.entries(permissions)) {
+    const levels = getAllowedLevels(level)
+    if (resource === resourceId && levels.indexOf(permLevel) !== -1) {
+      foundMain = true
+    }
+    if (
+      subResourceId &&
+      resource === subResourceId &&
+      levels.indexOf(permLevel) !== -1
+    ) {
+      foundSub = true
+    }
+    // this will escape if foundMain only when no sub resource
+    if (foundMain && foundSub) {
+      break
+    }
+  }
+  return foundMain && foundSub
+}
+
+exports.doesHaveBasePermission = (permType, permLevel, permissionIds) => {
   const builtins = Object.values(exports.BUILTIN_PERMISSIONS)
   let permissions = flatten(
     builtins

--- a/packages/server/src/utilities/security/permissions.js
+++ b/packages/server/src/utilities/security/permissions.js
@@ -7,6 +7,7 @@ const PermissionLevels = {
   ADMIN: "admin",
 }
 
+// these are the global types, that govern the underlying default behaviour
 const PermissionTypes = {
   TABLE: "table",
   USER: "user",

--- a/packages/server/src/utilities/security/permissions.js
+++ b/packages/server/src/utilities/security/permissions.js
@@ -30,12 +30,11 @@ function Permission(type, level) {
  */
 function getAllowedLevels(userPermLevel) {
   switch (userPermLevel) {
-    case PermissionLevels.READ:
-      return [PermissionLevels.READ]
-    case PermissionLevels.WRITE:
-      return [PermissionLevels.READ, PermissionLevels.WRITE]
     case PermissionLevels.EXECUTE:
       return [PermissionLevels.EXECUTE]
+    case PermissionLevels.READ:
+      return [PermissionLevels.EXECUTE, PermissionLevels.READ]
+    case PermissionLevels.WRITE:
     case PermissionLevels.ADMIN:
       return [
         PermissionLevels.READ,
@@ -114,6 +113,25 @@ exports.doesHavePermission = (permType, permLevel, permissionIds) => {
     }
   }
   return false
+}
+
+exports.higherPermission = (perm1, perm2) => {
+  function toNum(perm) {
+    switch (perm) {
+      // not everything has execute privileges
+      case PermissionLevels.EXECUTE:
+        return 0
+      case PermissionLevels.READ:
+        return 1
+      case PermissionLevels.WRITE:
+        return 2
+      case PermissionLevels.ADMIN:
+        return 3
+      default:
+        return -1
+    }
+  }
+  return toNum(perm1) > toNum(perm2) ? perm1 : perm2
 }
 
 // utility as a lot of things need simply the builder permission

--- a/packages/server/src/utilities/security/roles.js
+++ b/packages/server/src/utilities/security/roles.js
@@ -66,14 +66,23 @@ exports.getRole = async (appId, roleId) => {
   if (!roleId) {
     return null
   }
-  let role
+  let role = {}
+  // built in roles mostly come from the in-code implementation,
+  // but can be extended by a doc stored about them (e.g. permissions)
   if (isBuiltin(roleId)) {
     role = cloneDeep(
       Object.values(exports.BUILTIN_ROLES).find(role => role._id === roleId)
     )
-  } else {
+  }
+  try {
     const db = new CouchDB(appId)
-    role = await db.get(roleId)
+    const dbRole = await db.get(roleId)
+    role = Object.assign(role, dbRole)
+  } catch (err) {
+    // only throw an error if there is no role at all
+    if (Object.keys(role).length === 0) {
+      throw err
+    }
   }
   return role
 }

--- a/packages/server/src/utilities/security/roles.js
+++ b/packages/server/src/utilities/security/roles.js
@@ -77,7 +77,7 @@ exports.getRole = async (appId, roleId) => {
   }
   try {
     const db = new CouchDB(appId)
-    const dbRole = await db.get(roleId)
+    const dbRole = await db.get(exports.getDBRoleID(roleId))
     role = Object.assign(role, dbRole)
     // finalise the ID
     role._id = exports.getExternalRoleID(role._id)


### PR DESCRIPTION
## Description
Please note this PR is purely the backend for RBAC - @shogunpurple will be taking on the task of completing the frontend for this functionality.

This PR introduces the full backend capability of RBAC at a resource level - meaning that we can now control tables, rows, queries and automations access individually based on a role.

This system has quite a bit of complexity underlying it, with the intention of making the API as simple to use, leading to a simple UX. Most of this API design is based on the designs from Joe, which suggest that we should have a "select" per resource which allows specifying which role can access it. This introduces a bit more complexity than this, with a concept of "permission levels". Basically a permission level is the hierarchy of what a user can do to that resource, saying for example anyone of role level "PUBLIC" can read from a table, but not write.

The API introduces a couple of key endpoints in a normal CRUD style:
1. GET `/api/permission/builtin` and `/api/permission/levels` - basic utility APIs which simply provide some arrays of permission constants that are supported by the system.
2. GET `/api/permission` - lists all custom permissions in the system by role and resource, down to the permission level.
3. GET `/api/permission/:resourceId` - gets the permissions by role for a particular resource ID.
4. POST `/api/permission/:roleId/:resourceId/:level` - adds a permission for the role, resource and level, no body required, simply the URL params.
5. DELETE `/api/permission/:roleId/:resourceId/:level` - inverse of above, removes the permission altogether.

Please note the DELETE endpoint probably won't be needed in most implementations as if you simply want to move the permission to a different role/level, the system will adjust for this by removing the resource/level from any other role in which it is used, then adding it to the new role - this is part of the complexity of the internal system that makes the API easy to use.

This system also introduces the concept of a `resourceId` and `subResourceId` which are added by a middleware, `server/src/middlewares/resourceId.js`, this middleware will extract from the URL params/body the ID of the resource. Currently no query params are used for any of this so I didn't implement it for the time being.

Some basic tests have also been added for this which check whether a public user can read a row from a table, but cannot write to the table.