### PR TITLE
Some deployed automation bug fixes

### DIFF
--- a/packages/server/src/api/controllers/hosting.js
+++ b/packages/server/src/api/controllers/hosting.js
@@ -14,7 +14,6 @@ exports.fetchInfo = async ctx => {
 }
 
 exports.save = async ctx => {
-  console.trace("DID A SAVE!")
   const db = new CouchDB(BUILDER_CONFIG_DB)
   const { type } = ctx.request.body
   if (type === HostingTypes.CLOUD && ctx.request.body._rev) {

--- a/packages/server/src/automations/actions.js
+++ b/packages/server/src/automations/actions.js
@@ -53,6 +53,10 @@ module.exports.getAction = async function(actionName) {
   if (BUILTIN_ACTIONS[actionName] != null) {
     return BUILTIN_ACTIONS[actionName]
   }
+  // worker pools means that a worker may not have manifest
+  if (env.CLOUD && MANIFEST == null) {
+    MANIFEST = await module.exports.init()
+  }
   // env setup to get async packages
   if (!MANIFEST || !MANIFEST.packages || !MANIFEST.packages[actionName]) {
     return null
@@ -86,8 +90,10 @@ module.exports.init = async function() {
         ? Object.assign(MANIFEST.packages, BUILTIN_DEFINITIONS)
         : BUILTIN_DEFINITIONS
   } catch (err) {
+    console.error(err)
     Sentry.captureException(err)
   }
+  return MANIFEST
 }
 
 module.exports.DEFINITIONS = BUILTIN_DEFINITIONS

--- a/packages/server/src/automations/index.js
+++ b/packages/server/src/automations/index.js
@@ -34,7 +34,7 @@ module.exports.init = function() {
   actions.init().then(() => {
     triggers.automationQueue.process(async job => {
       try {
-        if (env.CLOUD && job.data.automation) {
+        if (env.CLOUD && job.data.automation && !env.SELF_HOSTED) {
           job.data.automation.apiKey = await updateQuota(job.data.automation)
         }
         if (env.BUDIBASE_ENVIRONMENT === "PRODUCTION") {

--- a/packages/server/src/utilities/usageQuota.js
+++ b/packages/server/src/utilities/usageQuota.js
@@ -50,6 +50,9 @@ exports.Properties = {
 }
 
 exports.getAPIKey = async appId => {
+  if (env.SELF_HOSTED) {
+    return { apiKey: null }
+  }
   return apiKeyTable.get({ primary: appId })
 }
 
@@ -63,7 +66,7 @@ exports.getAPIKey = async appId => {
  */
 exports.update = async (apiKey, property, usage) => {
   // don't try validate in builder
-  if (!env.CLOUD) {
+  if (!env.CLOUD || env.SELF_HOSTED) {
     return
   }
   try {


### PR DESCRIPTION
## Description
Two fixes for deployed automations:
1. Deployed automations make use of a worker pool rather than the standard server resources, this means that they do not have access to variables stored in the main servers memory, have to re-init when running in the cloud for each worker pool thread started.
2. Fixed some issues with self hosted deployed automations, whereby they were attempting to write to Dynamo (not accessible) for quotas that aren't used.