### PR TITLE
Re-introducing relationship tags - showing the display column

### DIFF
--- a/packages/builder/cypress/integration/createTable.spec.js
+++ b/packages/builder/cypress/integration/createTable.spec.js
@@ -30,7 +30,7 @@ context("Create a Table", () => {
     // Unset table display column
     cy.contains("display column").click()
     cy.contains("Save Column").click()
-    cy.contains("nameupdated").should("have.text", "nameupdated")
+    cy.contains("nameupdated ").should("have.text", "nameupdated ")
   })
 
   it("edits a row", () => {

--- a/packages/builder/cypress/integration/createView.spec.js
+++ b/packages/builder/cypress/integration/createView.spec.js
@@ -1,3 +1,11 @@
+function removeSpacing(headers) {
+  let newHeaders = []
+  for (let header of headers) {
+    newHeaders.push(header.replace(/\s\s+/g, " "))
+  }
+  return newHeaders
+}
+
 context("Create a View", () => {
   before(() => {
     cy.visit("localhost:4001/_builder")
@@ -28,7 +36,7 @@ context("Create a View", () => {
       const headers = Array.from($headers).map(header =>
         header.textContent.trim()
       )
-      expect(headers).to.deep.eq([ 'rating', 'age', 'group' ])
+      expect(removeSpacing(headers)).to.deep.eq([ "rating Number", "age Number", "group Text" ])
     })
   })
 
@@ -60,13 +68,19 @@ context("Create a View", () => {
       const headers = Array.from($headers).map(header =>
         header.textContent.trim()
       )
-      expect(headers).to.deep.eq([ 'avg', 'sumsqr', 'count', 'max', 'min', 'sum', 'field' ])
+      expect(removeSpacing(headers)).to.deep.eq([ "avg Number",
+        "sumsqr Number",
+        "count Number",
+        "max Number",
+        "min Number",
+        "sum Number",
+        "field Text" ])
     })
     cy.get(".ag-cell").then($values => {
       let values = Array.from($values).map(header =>
         header.textContent.trim()
       )
-      expect(values).to.deep.eq([ '31', '5347', '5', '49', '20', '155', 'age' ])
+      expect(values).to.deep.eq([ "31", "5347", "5", "49", "20", "155", "age" ])
     })
   })
 
@@ -85,7 +99,7 @@ context("Create a View", () => {
       .find(".ag-cell")
       .then($values => {
         const values = Array.from($values).map(value => value.textContent)
-        expect(values).to.deep.eq([ 'Students', '23.333333333333332', '1650', '3', '25', '20', '70' ])
+        expect(values).to.deep.eq([ "Students", "23.333333333333332", "1650", "3", "25", "20", "70" ])
       })
   })
 

--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -136,7 +136,7 @@ const getContextBindings = (asset, componentId) => {
       // Replace certain bindings with a new property to help display components
       let runtimeBoundKey = key
       if (fieldSchema.type === "link") {
-        runtimeBoundKey = `${key}_count`
+        runtimeBoundKey = `${key}_text`
       } else if (fieldSchema.type === "attachment") {
         runtimeBoundKey = `${key}_first`
       }
@@ -176,7 +176,7 @@ const getUserBindings = () => {
     // Replace certain bindings with a new property to help display components
     let runtimeBoundKey = key
     if (fieldSchema.type === "link") {
-      runtimeBoundKey = `${key}_count`
+      runtimeBoundKey = `${key}_text`
     } else if (fieldSchema.type === "attachment") {
       runtimeBoundKey = `${key}_first`
     }

--- a/packages/builder/src/components/backend/DataTable/Table.svelte
+++ b/packages/builder/src/components/backend/DataTable/Table.svelte
@@ -301,4 +301,13 @@
     padding-top: var(--spacing-xs);
     padding-bottom: var(--spacing-xs);
   }
+
+  :global(.ag-header) {
+    height: 61px !important;
+    min-height: 61px !important;
+  }
+
+  :global(.ag-header-row) {
+    height: 60px !important;
+  }
 </style>

--- a/packages/builder/src/components/backend/DataTable/TableHeader/TableHeader.svelte
+++ b/packages/builder/src/components/backend/DataTable/TableHeader/TableHeader.svelte
@@ -62,9 +62,11 @@
   on:mouseover={() => (hovered = true)}
   on:mouseleave={() => (hovered = false)}>
   <div class="column-header">
-    {#if field.autocolumn}<i class="auto ri-magic-fill" />{/if}
     <div class="column-header-text">
-      <div class="column-header-name">{displayName}</div>
+      <div class="column-header-name">
+        {displayName}
+        {#if field.autocolumn}<i class="auto ri-magic-fill" />{/if}
+      </div>
       {#if type}
         <div class="column-header-type">{type}</div>
       {/if}
@@ -149,10 +151,12 @@
     font-weight: 500;
   }
   .auto {
-    font-size: var(--font-size-xs);
+    font-size: 9px;
     transition: none;
-    margin-right: 6px;
-    margin-top: 2px;
+    position: relative;
+    margin-left: 2px;
+    top: -3px;
+    color: var(--grey-6);
   }
 
   .icon:hover {

--- a/packages/builder/src/components/backend/DataTable/TableHeader/TableHeader.svelte
+++ b/packages/builder/src/components/backend/DataTable/TableHeader/TableHeader.svelte
@@ -53,7 +53,7 @@
     column.removeEventListener("filterActiveChanged", setFilterActive)
   })
 
-  $: type = FIELDS[field.type.toUpperCase()]?.name
+  $: type = FIELDS[field?.type?.toUpperCase()]?.name
 </script>
 
 <header

--- a/packages/builder/src/components/backend/DataTable/TableHeader/TableHeader.svelte
+++ b/packages/builder/src/components/backend/DataTable/TableHeader/TableHeader.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy } from "svelte"
   import { Modal, ModalContent } from "@budibase/bbui"
   import CreateEditColumn from "../modals/CreateEditColumn.svelte"
+  import { FIELDS } from "constants/backend"
 
   const SORT_ICON_MAP = {
     asc: "ri-arrow-down-fill",
@@ -51,6 +52,8 @@
     column.removeEventListener("sortChanged", setSort)
     column.removeEventListener("filterActiveChanged", setFilterActive)
   })
+
+  $: type = FIELDS[field.type.toUpperCase()]?.name
 </script>
 
 <header
@@ -58,12 +61,15 @@
   data-cy="table-header"
   on:mouseover={() => (hovered = true)}
   on:mouseleave={() => (hovered = false)}>
-  <div>
-    <div class="col-icon">
-      {#if field.autocolumn}<i class="auto ri-magic-fill" />{/if}
-      <span class="column-header-name">{displayName}</span>
+  <div class="column-header">
+    {#if field.autocolumn}<i class="auto ri-magic-fill" />{/if}
+    <div class="column-header-text">
+      <div class="column-header-name">{displayName}</div>
+      {#if type}
+        <div class="column-header-type">{type}</div>
+      {/if}
     </div>
-    <i class={`${SORT_ICON_MAP[sortDirection]} sort-icon icon`} />
+    <i class={`${SORT_ICON_MAP[sortDirection]} icon`} />
   </div>
   <Modal bind:this={modal}>
     <ModalContent
@@ -106,6 +112,23 @@
     opacity: 1;
   }
 
+  .column-header {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    gap: var(--spacing-s);
+  }
+
+  .column-header-text {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: stretch;
+    gap: var(--spacing-xs);
+  }
+
   .column-header-name {
     white-space: normal !important;
     text-overflow: ellipsis;
@@ -115,9 +138,9 @@
     overflow: hidden;
   }
 
-  .sort-icon {
-    position: relative;
-    top: 2px;
+  .column-header-type {
+    font-size: var(--font-size-xs);
+    color: var(--grey-6);
   }
 
   .icon {
@@ -125,11 +148,6 @@
     font-size: var(--font-size-m);
     font-weight: 500;
   }
-
-  .col-icon {
-    display: flex;
-  }
-
   .auto {
     font-size: var(--font-size-xs);
     transition: none;

--- a/packages/builder/src/components/backend/DataTable/cells/RelationshipCell.svelte
+++ b/packages/builder/src/components/backend/DataTable/cells/RelationshipCell.svelte
@@ -3,24 +3,43 @@
   export let row
   export let selectRelationship
 
-  $: count =
-    row && columnName && Array.isArray(row[columnName])
-      ? row[columnName].length
-      : 0
+  $: items = row?.[columnName] || []
 </script>
 
-<div class:link={count} on:click={() => selectRelationship(row, columnName)}>
-  {count}
-  related row(s)
+<div
+  class="container"
+  class:link={!!items.length}
+  on:click={() => selectRelationship(row, columnName)}>
+  {#each items as item}
+    <div class="item">{item}</div>
+  {/each}
 </div>
 
 <style>
-  .link {
-    text-decoration: underline;
+  .container {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    gap: var(--spacing-xs);
   }
 
   .link:hover {
     color: var(--grey-6);
     cursor: pointer;
+  }
+  .link:hover .item {
+    color: var(--ink);
+    border-color: var(--ink);
+  }
+
+  .item {
+    font-size: var(--font-size-xs);
+    padding: var(--spacing-xs) var(--spacing-s);
+    border: 1px solid var(--grey-5);
+    color: var(--grey-7);
+    line-height: normal;
+    border-radius: 4px;
+    text-decoration: none;
   }
 </style>

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -45,7 +45,7 @@
   $: uneditable =
     $backendUiStore.selectedTable?._id === TableNames.USERS &&
     UNEDITABLE_USER_FIELDS.includes(field.name)
-  $: invalid = (field.type === FIELDS.LINK.type && !field.tableId)
+  $: invalid = field.type === FIELDS.LINK.type && !field.tableId
 
   // used to select what different options can be displayed for column type
   $: canBeSearched =
@@ -235,7 +235,9 @@
       <TextButton text on:click={confirmDelete}>Delete Column</TextButton>
     {/if}
     <Button secondary on:click={onClosed}>Cancel</Button>
-    <Button primary on:click={saveColumn} bind:disabled={invalid}>Save Column</Button>
+    <Button primary on:click={saveColumn} bind:disabled={invalid}>
+      Save Column
+    </Button>
   </footer>
 </div>
 <ConfirmDialog

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -18,6 +18,7 @@
   import ConfirmDialog from "components/common/ConfirmDialog.svelte"
 
   const AUTO_COL = "auto"
+  const LINK_TYPE = FIELDS.LINK.type
   let fieldDefinitions = cloneDeep(FIELDS)
 
   export let onClosed
@@ -44,15 +45,16 @@
   $: uneditable =
     $backendUiStore.selectedTable?._id === TableNames.USERS &&
     UNEDITABLE_USER_FIELDS.includes(field.name)
+  $: invalid = (field.type === FIELDS.LINK.type && !field.tableId)
 
   // used to select what different options can be displayed for column type
   $: canBeSearched =
-    field.type !== "link" &&
+    field.type !== LINK_TYPE &&
     field.subtype !== AUTO_COLUMN_SUB_TYPES.CREATED_BY &&
     field.subtype !== AUTO_COLUMN_SUB_TYPES.UPDATED_BY
-  $: canBeDisplay = field.type !== "link" && field.type !== AUTO_COL
+  $: canBeDisplay = field.type !== LINK_TYPE && field.type !== AUTO_COL
   $: canBeRequired =
-    field.type !== "link" && !uneditable && field.type !== AUTO_COL
+    field.type !== LINK_TYPE && !uneditable && field.type !== AUTO_COL
 
   async function saveColumn() {
     if (field.type === AUTO_COL) {
@@ -84,13 +86,17 @@
     }
   }
 
-  function handleFieldConstraints(event) {
+  function handleTypeChange(event) {
     const definition = fieldDefinitions[event.target.value.toUpperCase()]
     if (!definition) {
       return
     }
     field.type = definition.type
     field.constraints = definition.constraints
+    // remove any extra fields that may not be related to this type
+    delete field.autocolumn
+    delete field.subtype
+    delete field.tableId
   }
 
   function onChangeRequired(e) {
@@ -138,7 +144,7 @@
     secondary
     thin
     label="Type"
-    on:change={handleFieldConstraints}
+    on:change={handleTypeChange}
     bind:value={field.type}>
     {#each Object.values(fieldDefinitions) as field}
       <option value={field.type}>{field.name}</option>
@@ -229,7 +235,7 @@
       <TextButton text on:click={confirmDelete}>Delete Column</TextButton>
     {/if}
     <Button secondary on:click={onClosed}>Cancel</Button>
-    <Button primary on:click={saveColumn}>Save Column</Button>
+    <Button primary on:click={saveColumn} bind:disabled={invalid}>Save Column</Button>
   </footer>
 </div>
 <ConfirmDialog

--- a/packages/builder/src/components/deploy/DeploymentHistory.svelte
+++ b/packages/builder/src/components/deploy/DeploymentHistory.svelte
@@ -24,7 +24,7 @@
     timeOnly: {
       hour: "numeric",
       minute: "numeric",
-      hour12: true,
+      hourCycle: "h12",
     },
   }
   const POLL_INTERVAL = 5000

--- a/packages/client/src/api/rows.js
+++ b/packages/client/src/api/rows.js
@@ -119,8 +119,8 @@ export const enrichRows = async (rows, tableId) => {
         for (let key of keys) {
           const type = schema[key].type
           if (type === "link") {
-            // Enrich row with the count of any relationship fields
-            row[`${key}_count`] = Array.isArray(row[key]) ? row[key].length : 0
+            // Enrich row a string join of relationship fields
+            row[`${key}_text`] = row[key]?.join(", ") || ""
           } else if (type === "attachment") {
             // Enrich row with the first image URL for any attachment fields
             let url = null

--- a/packages/server/src/api/routes/tests/couchTestUtils.js
+++ b/packages/server/src/api/routes/tests/couchTestUtils.js
@@ -137,6 +137,7 @@ exports.addPermission = async (
 exports.createLinkedTable = async (request, appId) => {
   // get the ID to link to
   const table = await exports.createTable(request, appId)
+  table.displayName = "name"
   table.schema.link = {
     type: "link",
     fieldName: "link",

--- a/packages/server/src/api/routes/tests/couchTestUtils.js
+++ b/packages/server/src/api/routes/tests/couchTestUtils.js
@@ -137,7 +137,7 @@ exports.addPermission = async (
 exports.createLinkedTable = async (request, appId) => {
   // get the ID to link to
   const table = await exports.createTable(request, appId)
-  table.displayName = "name"
+  table.primaryDisplay = "name"
   table.schema.link = {
     type: "link",
     fieldName: "link",

--- a/packages/server/src/api/routes/tests/row.spec.js
+++ b/packages/server/src/api/routes/tests/row.spec.js
@@ -287,7 +287,7 @@ describe("/rows", () => {
       })).body
       const enriched = await outputProcessing(appId, table, [secondRow])
       expect(enriched[0].link.length).toBe(1)
-      expect(enriched[0].link[0]._id).toBe(firstRow._id)
+      expect(enriched[0].link[0]).toBe("Test Contact")
     })
   })
 

--- a/packages/server/src/api/routes/tests/row.spec.js
+++ b/packages/server/src/api/routes/tests/row.spec.js
@@ -287,7 +287,7 @@ describe("/rows", () => {
       })).body
       const enriched = await outputProcessing(appId, table, [secondRow])
       expect(enriched[0].link.length).toBe(1)
-      expect(enriched[0].link[0]).toBe(firstRow._id)
+      expect(enriched[0].link[0]._id).toBe(firstRow._id)
     })
   })
 

--- a/packages/server/src/db/linkedRows/index.js
+++ b/packages/server/src/db/linkedRows/index.js
@@ -140,13 +140,6 @@ exports.updateLinks = async function({
  * then an array will be output, object input -> object output.
  */
 exports.attachLinkIDs = async (appId, rows) => {
-  // handle a single row as well as multiple
-  let wasArray = true
-  if (!(rows instanceof Array)) {
-    rows = [rows]
-    wasArray = false
-  }
-
   const links = await getLinksForRows(appId, rows)
   // now iterate through the rows and all field information
   for (let row of rows) {
@@ -162,7 +155,7 @@ exports.attachLinkIDs = async (appId, rows) => {
   }
   // if it was an array when it came in then handle it as an array in response
   // otherwise return the first element as there was only one input
-  return wasArray ? rows : rows[0]
+  return rows
 }
 
 /**
@@ -177,11 +170,6 @@ exports.attachLinkedPrimaryDisplay = async (appId, table, rows) => {
   const linkedTableIds = getLinkedTableIDs(table)
   if (linkedTableIds.length === 0) {
     return rows
-  }
-  let wasArray = true
-  if (!(rows instanceof Array)) {
-    rows = [rows]
-    wasArray = false
   }
   const db = new CouchDB(appId)
   const linkedTables = await Promise.all(linkedTableIds.map(id => db.get(id)))
@@ -214,5 +202,5 @@ exports.attachLinkedPrimaryDisplay = async (appId, table, rows) => {
         }
       })
   }
-  return wasArray ? rows : rows[0]
+  return rows
 }

--- a/packages/server/src/db/linkedRows/index.js
+++ b/packages/server/src/db/linkedRows/index.js
@@ -36,6 +36,20 @@ function getLinkedTableIDs(table) {
     .map(column => column.tableId)
 }
 
+function getRelatedTableForField(table, fieldName) {
+  // look to see if its on the table, straight in the schema
+  const field = table.schema[fieldName]
+  if (field != null) {
+    return field.tableId
+  }
+  for (let column of Object.values(table.schema)) {
+    if (column.type === FieldTypes.LINK && column.fieldName === fieldName) {
+      return column.tableId
+    }
+  }
+  return null
+}
+
 async function getLinksForRows(appId, rows) {
   const tableIds = [...new Set(rows.map(el => el.tableId))]
   // start by getting all the link values for performance reasons
@@ -185,7 +199,7 @@ exports.attachLinkedPrimaryDisplay = async (appId, table, rows) => {
         if (row[link.fieldName] == null) {
           row[link.fieldName] = []
         }
-        const linkedTableId = table.schema[link.fieldName].tableId
+        const linkedTableId = getRelatedTableForField(table, link.fieldName)
         const linkedRow = linked.find(row => row._id === link.id)
         const linkedTable = linkedTables.find(
           table => table._id === linkedTableId

--- a/packages/server/src/db/linkedRows/linkUtils.js
+++ b/packages/server/src/db/linkedRows/linkUtils.js
@@ -1,6 +1,7 @@
 const CouchDB = require("../index")
 const Sentry = require("@sentry/node")
 const { ViewNames, getQueryIndex } = require("../utils")
+const { FieldTypes } = require("../../constants")
 
 /**
  * Only needed so that boolean parameters are being used for includeDocs
@@ -119,4 +120,36 @@ exports.getUniqueByProp = (array, prop) => {
   return array.filter((obj, pos, arr) => {
     return arr.map(mapObj => mapObj[prop]).indexOf(obj[prop]) === pos
   })
+}
+
+exports.getLinkedTableIDs = table => {
+  return Object.values(table.schema)
+    .filter(column => column.type === FieldTypes.LINK)
+    .map(column => column.tableId)
+}
+
+exports.getLinkedTable = async (db, id, tables) => {
+  let linkedTable = tables.find(table => table._id === id)
+  if (linkedTable) {
+    return linkedTable
+  }
+  linkedTable = await db.get(id)
+  if (linkedTable) {
+    tables.push(linkedTable)
+  }
+  return linkedTable
+}
+
+exports.getRelatedTableForField = (table, fieldName) => {
+  // look to see if its on the table, straight in the schema
+  const field = table.schema[fieldName]
+  if (field != null) {
+    return field.tableId
+  }
+  for (let column of Object.values(table.schema)) {
+    if (column.type === FieldTypes.LINK && column.fieldName === fieldName) {
+      return column.tableId
+    }
+  }
+  return null
 }

--- a/packages/server/src/db/utils.js
+++ b/packages/server/src/db/utils.js
@@ -277,3 +277,20 @@ exports.getQueryParams = (datasourceId = null, otherProps = {}) => {
     otherProps
   )
 }
+
+/**
+ * This can be used with the db.find functionality to get a list of IDs
+ */
+exports.getMultiIDParams = (ids, fields = null) => {
+  let config = {
+    selector: {
+      _id: {
+        $in: ids,
+      },
+    },
+  }
+  if (fields) {
+    config.fields = fields
+  }
+  return config
+}

--- a/packages/server/src/db/utils.js
+++ b/packages/server/src/db/utils.js
@@ -279,18 +279,11 @@ exports.getQueryParams = (datasourceId = null, otherProps = {}) => {
 }
 
 /**
- * This can be used with the db.find functionality to get a list of IDs
+ * This can be used with the db.allDocs to get a list of IDs
  */
-exports.getMultiIDParams = (ids, fields = null) => {
-  let config = {
-    selector: {
-      _id: {
-        $in: ids,
-      },
-    },
+exports.getMultiIDParams = ids => {
+  return {
+    keys: ids,
+    include_docs: true,
   }
-  if (fields) {
-    config.fields = fields
-  }
-  return config
 }

--- a/packages/server/src/utilities/rowProcessor.js
+++ b/packages/server/src/utilities/rowProcessor.js
@@ -167,7 +167,7 @@ exports.inputProcessing = async (user, table, row) => {
  */
 exports.outputProcessing = async (appId, table, rows) => {
   // attach any linked row information
-  const outputRows = await linkRows.attachLinkedRows(appId, rows)
+  const outputRows = await linkRows.attachLinkedDisplayName(appId, table, rows)
   // update the attachments URL depending on hosting
   if (env.CLOUD && env.SELF_HOSTED) {
     for (let [property, column] of Object.entries(table.schema)) {

--- a/packages/server/src/utilities/rowProcessor.js
+++ b/packages/server/src/utilities/rowProcessor.js
@@ -157,6 +157,11 @@ exports.inputProcessing = (user, table, row) => {
  * @returns {object[]} the enriched rows will be returned.
  */
 exports.outputProcessing = async (appId, table, rows) => {
+  let wasArray = true
+  if (!(rows instanceof Array)) {
+    rows = [rows]
+    wasArray = false
+  }
   // attach any linked row information
   const outputRows = await linkRows.attachLinkedPrimaryDisplay(
     appId,
@@ -179,5 +184,5 @@ exports.outputProcessing = async (appId, table, rows) => {
       }
     }
   }
-  return outputRows
+  return wasArray ? outputRows : outputRows[0]
 }

--- a/packages/server/src/utilities/rowProcessor.js
+++ b/packages/server/src/utilities/rowProcessor.js
@@ -167,7 +167,7 @@ exports.inputProcessing = async (user, table, row) => {
  */
 exports.outputProcessing = async (appId, table, rows) => {
   // attach any linked row information
-  const outputRows = await linkRows.attachLinkInfo(appId, rows)
+  const outputRows = await linkRows.attachLinkedRows(appId, rows)
   // update the attachments URL depending on hosting
   if (env.CLOUD && env.SELF_HOSTED) {
     for (let [property, column] of Object.entries(table.schema)) {

--- a/packages/server/src/utilities/rowProcessor.js
+++ b/packages/server/src/utilities/rowProcessor.js
@@ -3,7 +3,6 @@ const { OBJ_STORE_DIRECTORY } = require("../constants")
 const linkRows = require("../db/linkedRows")
 const { cloneDeep } = require("lodash/fp")
 const { FieldTypes, AutoFieldSubTypes } = require("../constants")
-const CouchDB = require("../db")
 
 const BASE_AUTO_ID = 1
 
@@ -71,14 +70,13 @@ const TYPE_TRANSFORM_MAP = {
  * @param {Object} user The user to be used for an appId as well as the createdBy and createdAt fields.
  * @param {Object} table The table which is to be used for the schema, as well as handling auto IDs incrementing.
  * @param {Object} row The row which is to be updated with information for the auto columns.
- * @returns {Promise<{row: Object, table: Object}>} The updated row and table, the table may need to be updated
+ * @returns {{row: Object, table: Object}} The updated row and table, the table may need to be updated
  * for automatic ID purposes.
  */
-async function processAutoColumn(user, table, row) {
+function processAutoColumn(user, table, row) {
   let now = new Date().toISOString()
   // if a row doesn't have a revision then it doesn't exist yet
   const creating = !row._rev
-  let tableUpdated = false
   for (let [key, schema] of Object.entries(table.schema)) {
     if (!schema.autocolumn) {
       continue
@@ -104,16 +102,9 @@ async function processAutoColumn(user, table, row) {
         if (creating) {
           schema.lastID = !schema.lastID ? BASE_AUTO_ID : schema.lastID + 1
           row[key] = schema.lastID
-          tableUpdated = true
         }
         break
     }
-  }
-  if (tableUpdated) {
-    const db = new CouchDB(user.appId)
-    const response = await db.put(table)
-    // update the revision
-    table._rev = response._rev
   }
   return { table, row }
 }
@@ -143,7 +134,7 @@ exports.coerce = (row, type) => {
  * @param {object} table the table which the row is being saved to.
  * @returns {object} the row which has been prepared to be written to the DB.
  */
-exports.inputProcessing = async (user, table, row) => {
+exports.inputProcessing = (user, table, row) => {
   let clonedRow = cloneDeep(row)
   for (let [key, value] of Object.entries(clonedRow)) {
     const field = table.schema[key]
@@ -167,7 +158,11 @@ exports.inputProcessing = async (user, table, row) => {
  */
 exports.outputProcessing = async (appId, table, rows) => {
   // attach any linked row information
-  const outputRows = await linkRows.attachLinkedDisplayName(appId, table, rows)
+  const outputRows = await linkRows.attachLinkedPrimaryDisplay(
+    appId,
+    table,
+    rows
+  )
   // update the attachments URL depending on hosting
   if (env.CLOUD && env.SELF_HOSTED) {
     for (let [property, column] of Object.entries(table.schema)) {

--- a/packages/standard-components/src/grid/Relationship/RelationshipCount.svelte
+++ b/packages/standard-components/src/grid/Relationship/RelationshipCount.svelte
@@ -2,13 +2,14 @@
   export let columnName
   export let row
 
-  $: count =
-    row && columnName && Array.isArray(row[columnName])
-      ? row[columnName].length
-      : 0
+  $: items = row?.[columnName] || []
 </script>
 
-<div class="container">{count} related row(s)</div>
+<div class="container">
+  {#each items as item}
+    <div class="item">{item}</div>
+  {/each}
+</div>
 
 <style>
   .container {
@@ -18,5 +19,14 @@
     align-items: center;
     gap: var(--spacing-xs);
     width: 100%;
+  }
+
+  .item {
+    font-size: var(--font-size-xs);
+    padding: var(--spacing-xs) var(--spacing-s);
+    border: 1px solid #888;
+    color: #666;
+    line-height: normal;
+    border-radius: 4px;
   }
 </style>

--- a/packages/standard-components/src/grid/Relationship/RelationshipCount.svelte
+++ b/packages/standard-components/src/grid/Relationship/RelationshipCount.svelte
@@ -24,8 +24,8 @@
   .item {
     font-size: var(--font-size-xs);
     padding: var(--spacing-xs) var(--spacing-s);
-    border: 1px solid #888;
-    color: #666;
+    border: 1px solid var(--grey-5);
+    color: var(--grey-7);
     line-height: normal;
     border-radius: 4px;
   }


### PR DESCRIPTION
## Description
This was previously a feature, however it was based on enriching each record individually from the client - this created thousands of requests which massively slowed down the system.

After some performance testing and improvements this feature has been re-introduced. This has been tested with tables of 50K records, with some records utilising relationships. Ideally we would want to implement pagination id we wanted to have tables of 50K rows with 50K relationships, as the system is already relatively slow when working with such large data sets, as discussed in #1025 - however for now this feature didn't introduce any sort of noticable/extra lag even with large tables.

There has also been a small type badge added in the data section of the builder, along the table column headings, to show which type the column is - without this it was sometimes confusing if a relationship was empty.

Thanks to @aptkingston for doing the UI work on this!

## Screenshots
In builder:
![image](https://user-images.githubusercontent.com/4407001/108520008-1b2ba880-72c2-11eb-936a-3d80dd1970aa.png)

In app:
![image](https://user-images.githubusercontent.com/4407001/108520484-a3aa4900-72c2-11eb-8faf-16682a7b011c.png)