### PR TITLE
Add new automation trigger for updating rows

### DIFF
--- a/packages/builder/cypress/integration/createAutomation.spec.js
+++ b/packages/builder/cypress/integration/createAutomation.spec.js
@@ -17,23 +17,33 @@ context("Create a automation", () => {
     cy.get("[data-cy=new-automation]").click()
     cy.get(".modal").within(() => {
       cy.get("input").type("Add Row")
-      cy.get(".buttons").contains("Create").click()
+      cy.get(".buttons")
+        .contains("Create")
+        .click()
     })
 
     // Add trigger
     cy.contains("Trigger").click()
-    cy.contains("Row Saved").click()
+    cy.contains("Row Created").click()
     cy.get(".setup").within(() => {
-      cy.get("select").first().select("dog")
+      cy.get("select")
+        .first()
+        .select("dog")
     })
 
     // Create action
     cy.contains("Action").click()
     cy.contains("Create Row").click()
     cy.get(".setup").within(() => {
-      cy.get("select").first().select("dog")
-      cy.get("input").first().type("goodboy")
-      cy.get("input").eq(1).type("11")
+      cy.get("select")
+        .first()
+        .select("dog")
+      cy.get("input")
+        .first()
+        .type("goodboy")
+      cy.get("input")
+        .eq(1)
+        .type("11")
     })
 
     // Save

--- a/packages/server/src/api/controllers/row.js
+++ b/packages/server/src/api/controllers/row.js
@@ -111,7 +111,6 @@ exports.patch = async function(ctx) {
   }
   row._rev = response.rev
   row.type = "row"
-
   ctx.eventEmitter && ctx.eventEmitter.emitRow(`row:update`, appId, row, table)
   ctx.body = row
   ctx.status = 200

--- a/packages/server/src/automations/triggers.js
+++ b/packages/server/src/automations/triggers.js
@@ -55,7 +55,7 @@ const BUILTIN_DEFINITIONS = {
   ROW_UPDATED: {
     name: "Row Updated",
     event: "row:update",
-    icon: "ri-save-line",
+    icon: "ri-refresh-line",
     tagline: "Row is updated in {{inputs.enriched.table.name}}",
     description: "Fired when a row is updated in your database",
     stepId: "ROW_UPDATED",

--- a/packages/server/src/automations/triggers.js
+++ b/packages/server/src/automations/triggers.js
@@ -13,11 +13,11 @@ const FAKE_DATETIME = "1970-01-01T00:00:00.000Z"
 
 const BUILTIN_DEFINITIONS = {
   ROW_SAVED: {
-    name: "Row Saved",
+    name: "Row Created",
     event: "row:save",
     icon: "ri-save-line",
     tagline: "Row is added to {{inputs.enriched.table.name}}",
-    description: "Fired when a row is saved to your database",
+    description: "Fired when a row is added to your database",
     stepId: "ROW_SAVED",
     inputs: {},
     schema: {
@@ -36,7 +36,47 @@ const BUILTIN_DEFINITIONS = {
           row: {
             type: "object",
             customType: "row",
-            description: "The new row that was saved",
+            description: "The new row that was created",
+          },
+          id: {
+            type: "string",
+            description: "Row ID - can be used for updating",
+          },
+          revision: {
+            type: "string",
+            description: "Revision of row",
+          },
+        },
+        required: ["row", "id"],
+      },
+    },
+    type: "TRIGGER",
+  },
+  ROW_UPDATED: {
+    name: "Row Updated",
+    event: "row:update",
+    icon: "ri-save-line",
+    tagline: "Row is updated in {{inputs.enriched.table.name}}",
+    description: "Fired when a row is updated in your database",
+    stepId: "ROW_UPDATED",
+    inputs: {},
+    schema: {
+      inputs: {
+        properties: {
+          tableId: {
+            type: "string",
+            customType: "table",
+            title: "Table",
+          },
+        },
+        required: ["tableId"],
+      },
+      outputs: {
+        properties: {
+          row: {
+            type: "object",
+            customType: "row",
+            description: "The row that was updated",
           },
           id: {
             type: "string",
@@ -79,7 +119,7 @@ const BUILTIN_DEFINITIONS = {
             description: "The row that was deleted",
           },
         },
-        required: ["row", "id"],
+        required: ["row"],
       },
     },
     type: "TRIGGER",
@@ -189,6 +229,13 @@ emitter.on("row:save", async function(event) {
     return
   }
   await queueRelevantRowAutomations(event, "row:save")
+})
+
+emitter.on("row:update", async function(event) {
+  if (!event || !event.row || !event.row.tableId) {
+    return
+  }
+  await queueRelevantRowAutomations(event, "row:update")
 })
 
 emitter.on("row:delete", async function(event) {


### PR DESCRIPTION
## Description
Adds a separate automation trigger that fires on row updates. Now there are 2 different triggers - row created and row updated.

The diff looks slightly weird, but it's literally just copying the row created trigger and changing the definition slightly. The rest of the functionality was already there, just not activated.

This closes #952.

## Screenshots 
![image](https://user-images.githubusercontent.com/9075550/108856326-d9607200-75e1-11eb-8a18-4cb9332c69b8.png)




