### PR TITLE
Permissions fix - fetch enriched was 403ing in public

### DIFF
--- a/packages/server/src/utilities/security/permissions.js
+++ b/packages/server/src/utilities/security/permissions.js
@@ -138,7 +138,7 @@ exports.doesHaveResourcePermission = (
 ) => {
   // set foundSub to not subResourceId, incase there is no subResource
   let foundMain = false,
-    foundSub = !subResourceId
+    foundSub = false
   for (let [resource, level] of Object.entries(permissions)) {
     const levels = getAllowedLevels(level)
     if (resource === resourceId && levels.indexOf(permLevel) !== -1) {

--- a/packages/server/src/utilities/security/permissions.js
+++ b/packages/server/src/utilities/security/permissions.js
@@ -156,7 +156,7 @@ exports.doesHaveResourcePermission = (
       break
     }
   }
-  return foundMain && foundSub
+  return foundMain || foundSub
 }
 
 exports.doesHaveBasePermission = (permType, permLevel, permissionIds) => {


### PR DESCRIPTION
## Description
@aptkingston found an issue while working on lab day project with public enriching of rows, this is a two character change to resolve this, when working with main/sub resources access to either of these should allow access to the particular record (e.g. if you only have access to a row but not the table, its ok to access row, while if you have access to the table, but no rows specified, you have access to everything in table).


