### PR TITLE
Relationship cardinality fix

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -162,15 +162,15 @@
       linkName = truncate(linkTable.name, { length: 15 })
     return [
       {
-        name: `Many ${thisName} rows has many ${linkName} rows`,
+        name: `Many ${thisName} rows → many ${linkName} rows`,
         value: RelationshipTypes.MANY_TO_MANY,
       },
       {
-        name: `One ${thisName} row has many ${linkName} rows`,
+        name: `One ${linkName} row → many ${thisName} rows`,
         value: RelationshipTypes.ONE_TO_MANY,
       },
       {
-        name: `Many ${thisName} rows has one ${linkName} row`,
+        name: `One ${thisName} row → many ${linkName} rows`,
         value: RelationshipTypes.MANY_TO_ONE,
       },
     ]
@@ -270,9 +270,9 @@
               {value}
               bind:group={field.relationshipType}>
               <div class="radio-button-labels">
-                <label for={value}>{name.split('has')[0]}</label>
-                <label class="rel-type-center" for={value}>has</label>
-                <label for={value}>{name.split('has')[1]}</label>
+                <label for={value}>{name.split('→')[0]}</label>
+                <label class="rel-type-center" for={value}>→</label>
+                <label for={value}>{name.split('→')[1]}</label>
               </div>
             </Radio>
           {/each}


### PR DESCRIPTION
## Description
Discovered by @arladmin mentioned [here](https://github.com/Budibase/budibase/issues/1178#issuecomment-791170863) there was an issue with the cardinality of relationships being flipped to what was described in the column settings, this resolves it for now. In the future we may re-factor this to simplify the one to many/one to one schema.

Fixing an issue discovered where the relationshipType currently specifies the wrong cardinality, for now just flipping the way it is specified in the front end as this will accurately describe what the backend is performing.

## Screenshots
![image](https://user-images.githubusercontent.com/4407001/110137756-1f2eee80-7dc9-11eb-8ede-2d5d45baf5a3.png)
