### PR TITLE
Colorpicker bugs

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@budibase/bbui": "^1.58.13",
     "@budibase/client": "^0.8.3",
-    "@budibase/colorpicker": "1.0.1",
+    "@budibase/colorpicker": "1.1.2",
     "@budibase/string-templates": "^0.8.3",
     "@budibase/svelte-ag-grid": "^1.0.4",
     "@sentry/browser": "5.19.1",

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ColorPicker.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ColorPicker.svelte
@@ -1,7 +1,38 @@
 <script>
+  import { createEventDispatcher } from 'svelte'
   import Colorpicker from "@budibase/colorpicker"
+  
+  const dispatch = createEventDispatcher();
 
   export let value
+  
+  const WAIT = 150;
+  
+  function throttle(callback, wait, immediate = false) {
+    let timeout = null 
+    let initialCall = true
+    
+    return function() {
+      const callNow = immediate && initialCall
+      const next = () => {
+        callback.apply(this, arguments)
+        timeout = null
+      }
+      
+      if (callNow) { 
+        initialCall = false
+        next()
+      }
+  
+      if (!timeout) {
+        timeout = setTimeout(next, wait)
+      }
+    }
+  }
+  
+  const onChange = throttle(e => {
+    dispatch('change', e.detail)
+  }, WAIT, true)
 </script>
 
-<Colorpicker value={value || '#000'} on:change />
+<Colorpicker value={value || '#000'} on:change={onChange} />

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ColorPicker.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ColorPicker.svelte
@@ -35,4 +35,4 @@
   }, WAIT, true)
 </script>
 
-<Colorpicker value={value || '#000'} on:change={onChange} />
+<Colorpicker value={value || '#C4C4C4'} on:change={onChange} />

--- a/packages/builder/yarn.lock
+++ b/packages/builder/yarn.lock
@@ -833,10 +833,10 @@
     svelte-portal "^1.0.0"
     turndown "^7.0.0"
 
-"@budibase/colorpicker@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@budibase/colorpicker/-/colorpicker-1.0.1.tgz#940c180e7ebba0cb0756c4c8ef13f5dfab58e810"
-  integrity sha512-+DTHYhU0sTi5RfCyd7AAvMsLFwyF/wgs0owf7KyQU+ZILRW+YsWa7OQMz+hKQfgVAmvzwrNz8ATiBlG3Ac6Asg==
+"@budibase/colorpicker@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@budibase/colorpicker/-/colorpicker-1.1.2.tgz#f7436924ee746d7be9b2009c2fa193e710c30f89"
+  integrity sha512-2PlZBVkATDqDC4b4Ri8Xi8X3OxhuHOGfmZwtXbZL38lNIeofaQT3Qyc1ECzEY5N+HrdGrWhY9EnliF6QM+LIuA==
 
 "@budibase/svelte-ag-grid@^1.0.4":
   version "1.0.4"


### PR DESCRIPTION
## Description
Closes #1228 

## Discussion
I added a throttle function to stop the conflict errors that happens when you spam requests to the server. This currently lives in the place where the colorpicker is imported but I think another way to solve this could be to handle throttling/debouncing in the builderstore - that way all settings can take advantage of it. Thoughts welcome.

## Screenshots
No visual differences



