### PR TITLE
Collapsible routes

### DIFF
--- a/packages/builder/src/builderStore/index.js
+++ b/packages/builder/src/builderStore/index.js
@@ -2,7 +2,6 @@ import { getFrontendStore } from "./store/frontend"
 import { getBackendUiStore } from "./store/backend"
 import { getAutomationStore } from "./store/automation"
 import { getHostingStore } from "./store/hosting"
-
 import { getThemeStore } from "./store/theme"
 import { derived, writable } from "svelte/store"
 import analytics from "analytics"
@@ -66,3 +65,5 @@ export const initialise = async () => {
     console.log(err)
   }
 }
+
+export const screenSearchString = writable(null)

--- a/packages/builder/src/components/design/NavigationPanel/ComponentNavigationTree/PathTree.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/ComponentNavigationTree/PathTree.svelte
@@ -1,8 +1,11 @@
 <script>
-  import { goto } from "@sveltech/routify"
-  import { store, selectedComponent, currentAsset } from "builderStore"
+  import {
+    store,
+    selectedComponent,
+    currentAsset,
+    screenSearchString,
+  } from "builderStore"
   import instantiateStore from "./dragDropStore"
-
   import ComponentTree from "./ComponentTree.svelte"
   import NavItem from "components/common/NavItem.svelte"
   import ScreenDropdownMenu from "./ScreenDropdownMenu.svelte"
@@ -21,38 +24,67 @@
   export let indent
   export let border
 
+  let routeManuallyOpened = false
   $: selectedScreen = $currentAsset
+  $: allScreens = getAllScreens(route)
+  $: filteredScreens = getFilteredScreens(allScreens, $screenSearchString)
+  $: hasSearchMatch = $screenSearchString && filteredScreens.length > 0
+  $: noSearchMatch = $screenSearchString && !filteredScreens.length
+  $: routeSelected = route.subpaths[selectedScreen.routing.route] !== undefined
+  $: routeOpened = routeManuallyOpened || routeSelected || hasSearchMatch
 
   const changeScreen = screenId => {
     store.actions.screens.select(screenId)
+
+    // Reset manually opened flag every time a new screen is selected
+    routeManuallyOpened = false
+  }
+
+  const getAllScreens = route => {
+    let screens = []
+    Object.entries(route.subpaths).forEach(([route, subpath]) => {
+      Object.entries(subpath.screens).forEach(([role, id]) => {
+        screens.push({ id, route, role })
+      })
+    })
+    return screens
+  }
+
+  const getFilteredScreens = (screens, searchString) => {
+    return screens.filter(
+      screen => !searchString || screen.route.includes(searchString)
+    )
   }
 </script>
 
-<NavItem
-  icon="ri-folder-line"
-  text={path}
-  opened={true}
-  {border}
-  withArrow={route.subpaths} />
+{#if !noSearchMatch}
+  <NavItem
+    icon="ri-folder-line"
+    text={path}
+    on:click={() => (routeManuallyOpened = !routeManuallyOpened)}
+    opened={routeOpened}
+    {border}
+    withArrow={route.subpaths} />
 
-{#each Object.entries(route.subpaths) as [url, subpath]}
-  {#each Object.entries(subpath.screens) as [role, screenId]}
-    <NavItem
-      icon="ri-artboard-2-line"
-      indentLevel={indent || 1}
-      selected={$store.selectedScreenId === screenId}
-      opened={$store.selectedScreenId === screenId}
-      text={ROUTE_NAME_MAP[url]?.[role] || url}
-      withArrow={route.subpaths}
-      on:click={() => changeScreen(screenId)}>
-      <ScreenDropdownMenu {screenId} />
-    </NavItem>
-    {#if selectedScreen?._id === screenId}
-      <ComponentTree
-        level={1}
-        components={selectedScreen.props._children}
-        currentComponent={$selectedComponent}
-        {dragDropStore} />
-    {/if}
-  {/each}
-{/each}
+  {#if routeOpened}
+    {#each filteredScreens as screen (screen.id)}
+      <NavItem
+        icon="ri-artboard-2-line"
+        indentLevel={indent || 1}
+        selected={$store.selectedScreenId === screen.id}
+        opened={$store.selectedScreenId === screen.id}
+        text={ROUTE_NAME_MAP[screen.route]?.[screen.role] || screen.route}
+        withArrow={route.subpaths}
+        on:click={() => changeScreen(screen.id)}>
+        <ScreenDropdownMenu screenId={screen.id} />
+      </NavItem>
+      {#if selectedScreen?._id === screen.id}
+        <ComponentTree
+          level={1}
+          components={selectedScreen.props._children}
+          currentComponent={$selectedComponent}
+          {dragDropStore} />
+      {/if}
+    {/each}
+  {/if}
+{/if}

--- a/packages/builder/src/components/design/NavigationPanel/ComponentNavigationTree/PathTree.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/ComponentNavigationTree/PathTree.svelte
@@ -30,7 +30,8 @@
   $: filteredScreens = getFilteredScreens(allScreens, $screenSearchString)
   $: hasSearchMatch = $screenSearchString && filteredScreens.length > 0
   $: noSearchMatch = $screenSearchString && !filteredScreens.length
-  $: routeSelected = route.subpaths[selectedScreen.routing.route] !== undefined
+  $: routeSelected =
+    route.subpaths[selectedScreen?.routing?.route] !== undefined
   $: routeOpened = routeManuallyOpened || routeSelected || hasSearchMatch
 
   const changeScreen = screenId => {

--- a/packages/builder/src/components/design/NavigationPanel/ComponentNavigationTree/PathTree.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/ComponentNavigationTree/PathTree.svelte
@@ -37,9 +37,6 @@
 
   const changeScreen = screenId => {
     store.actions.screens.select(screenId)
-
-    // Reset manually opened flag every time a new screen is selected
-    routeManuallyOpened = false
   }
 
   const getAllScreens = route => {

--- a/packages/builder/src/components/design/NavigationPanel/ComponentNavigationTree/PathTree.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/ComponentNavigationTree/PathTree.svelte
@@ -9,6 +9,7 @@
   import ComponentTree from "./ComponentTree.svelte"
   import NavItem from "components/common/NavItem.svelte"
   import ScreenDropdownMenu from "./ScreenDropdownMenu.svelte"
+  import { get } from "svelte/store"
 
   const ROUTE_NAME_MAP = {
     "/": {
@@ -56,13 +57,20 @@
       screen => !searchString || screen.route.includes(searchString)
     )
   }
+
+  const toggleManuallyOpened = () => {
+    if (get(screenSearchString)) {
+      return
+    }
+    routeManuallyOpened = !routeManuallyOpened
+  }
 </script>
 
 {#if !noSearchMatch}
   <NavItem
     icon="ri-folder-line"
     text={path}
-    on:click={() => (routeManuallyOpened = !routeManuallyOpened)}
+    on:click={toggleManuallyOpened}
     opened={routeOpened}
     {border}
     withArrow={route.subpaths} />

--- a/packages/builder/src/components/design/NavigationPanel/ComponentNavigationTree/index.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/ComponentNavigationTree/index.svelte
@@ -56,7 +56,7 @@
 </script>
 
 <div class="root">
-  {#each paths as path, idx}
+  {#each paths as path, idx (path)}
     <PathTree border={idx > 0} {path} route={routes[path]} />
   {/each}
 

--- a/packages/builder/src/components/design/NavigationPanel/FrontendNavigatePane.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/FrontendNavigatePane.svelte
@@ -85,11 +85,16 @@
             <option value={role._id}>{role.name}</option>
           {/each}
         </Select>
-        <Input
-          extraThin
-          placeholder="Enter a route to search"
-          label="Search Screens"
-          bind:value={$screenSearchString} />
+        <div class="search-screens">
+          <Input
+            extraThin
+            placeholder="Enter a route to search"
+            label="Search Screens"
+            bind:value={$screenSearchString} />
+          <i
+            class="ri-close-line"
+            on:click={() => ($screenSearchString = null)} />
+        </div>
       </div>
       <div class="nav-items-container">
         <ComponentNavigationTree />
@@ -138,5 +143,24 @@
     align-items: stretch;
     margin-bottom: var(--spacing-m);
     gap: var(--spacing-m);
+  }
+
+  .search-screens {
+    position: relative;
+  }
+  .search-screens i {
+    right: 2px;
+    bottom: 2px;
+    position: absolute;
+    box-sizing: border-box;
+    padding: var(--spacing-s);
+    border-left: 1px solid var(--grey-4);
+    background-color: var(--grey-2);
+    border-top-right-radius: var(--border-radius-m);
+    border-bottom-right-radius: var(--border-radius-m);
+    color: var(--grey-7);
+    font-size: 14px;
+    line-height: 15px;
+    top: auto;
   }
 </style>

--- a/packages/builder/src/components/design/NavigationPanel/FrontendNavigatePane.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/FrontendNavigatePane.svelte
@@ -87,6 +87,7 @@
         </Select>
         <Input
           extraThin
+          placeholder="Enter a route to search"
           label="Search Screens"
           bind:value={$screenSearchString} />
       </div>

--- a/packages/builder/src/components/design/NavigationPanel/FrontendNavigatePane.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/FrontendNavigatePane.svelte
@@ -1,19 +1,19 @@
 <script>
   import { onMount } from "svelte"
-  import { goto, params, url } from "@sveltech/routify"
+  import { goto, params } from "@sveltech/routify"
   import {
     store,
     allScreens,
-    currentAsset,
     backendUiStore,
     selectedAccessRole,
+    screenSearchString,
   } from "builderStore"
   import { FrontendTypes } from "constants"
   import ComponentNavigationTree from "components/design/NavigationPanel/ComponentNavigationTree/index.svelte"
   import Layout from "components/design/NavigationPanel/Layout.svelte"
   import NewScreenModal from "components/design/NavigationPanel/NewScreenModal.svelte"
   import NewLayoutModal from "components/design/NavigationPanel/NewLayoutModal.svelte"
-  import { Modal, Switcher, Select } from "@budibase/bbui"
+  import { Modal, Switcher, Select, Input } from "@budibase/bbui"
 
   const tabs = [
     {
@@ -85,6 +85,10 @@
             <option value={role._id}>{role.name}</option>
           {/each}
         </Select>
+        <Input
+          extraThin
+          label="Search Screens"
+          bind:value={$screenSearchString} />
       </div>
       <div class="nav-items-container">
         <ComponentNavigationTree />
@@ -127,6 +131,11 @@
   }
 
   .role-select {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: stretch;
     margin-bottom: var(--spacing-m);
+    gap: var(--spacing-m);
   }
 </style>


### PR DESCRIPTION
## Description
Adds the ability to search for screens and the ability to collapse route folders. These 2 features are intertwined and could potentially hinder each other, so the behaviour has been explicitly defined.

Current behaviour:
- All route folders are closed by default, except for the folder containing the selected screen
- Route folders can be opened and closed by clicking on them, but the currently selected folder can never be closed
- Clicking on a new screen will close all other folders
- When a search string is entered, folders cannot be opened and closed manually by clicking
- When a search string is entered, any folders with no matching routes are hidden entirely
- When a search string is entered, any folders with matching screens are open

Questions about behaviour:
- When a search string is entered and a new screen is selected, should we clear the search field? Currently this does not happen.
- When a search string is entered and the user leaves the page or navigates to layout, should we clear the search field? Currently this does not happen.

There's pros and cons to those couple of questions above, so any feedback is welcome.

## Screenshots
Default closed folders:
![image](https://user-images.githubusercontent.com/9075550/110610303-00907500-8186-11eb-8d7f-34dd1a7d5cc6.png)

Search showing only matching screens and folders:
![image](https://user-images.githubusercontent.com/9075550/110610385-143bdb80-8186-11eb-9be1-256591c9ef62.png)

Search with multiple matching folders:
![image](https://user-images.githubusercontent.com/9075550/110610455-274eab80-8186-11eb-9594-d9fe27a9e081.png)



