### PR TITLE
Allow airtable numRecords arg

### DIFF
--- a/packages/server/src/api/controllers/query.js
+++ b/packages/server/src/api/controllers/query.js
@@ -61,9 +61,11 @@ async function enrichQueryFields(fields, parameters) {
     if (typeof fields[key] === "object") {
       // enrich nested fields object
       enrichedQuery[key] = await enrichQueryFields(fields[key], parameters)
-    } else {
+    } else if (typeof fields[key] === "string") {
       // enrich string value as normal
       enrichedQuery[key] = await processString(fields[key], parameters)
+    } else {
+      enrichedQuery[key] = fields[key]
     }
   }
 

--- a/packages/server/src/integrations/airtable.js
+++ b/packages/server/src/integrations/airtable.js
@@ -40,6 +40,10 @@ const SCHEMA = {
           type: FIELD_TYPES.STRING,
           required: true,
         },
+        numRecords: {
+          type: FIELD_TYPES.NUMBER,
+          default: 10,
+        },
       },
     },
     update: {


### PR DESCRIPTION
## Description
Allow users to query more records from airtable by using parameters.

NB. We will eventually need to paginate this, but pagination in general is something that we need to discuss and design so it can be applied to all data elements, internal tables and external data sources.




