### PR TITLE
1240 - restore notification blocknotifications method, since it was c…

### DIFF
--- a/packages/client/src/store/notification.js
+++ b/packages/client/src/store/notification.js
@@ -13,8 +13,17 @@ const createNotificationStore = () => {
       _notifications.set([])
     }
   })
+  let block = false
+
+  const blockNotifications = (timeout = 1000) => {
+    block = true
+    setTimeout(() => (block = false), timeout)
+  }
 
   const send = (message, type = "default") => {
+    if (block) {
+      return
+    }
     let _id = id()
     _notifications.update(state => {
       return [...state, { id: _id, type, message }]
@@ -36,6 +45,7 @@ const createNotificationStore = () => {
     warning: msg => send(msg, "warning"),
     info: msg => send(msg, "info"),
     success: msg => send(msg, "success"),
+    blockNotifications,
   }
 }
 


### PR DESCRIPTION
…alled in the datasource

## Description of bug 1240
I created a screen for Creating a new user (like signing in for user) i put its access to public and created a link to it on login screen.

so when clicking on "Create New User" on login screen we go to "New User" screen but when try to submit the user it shows an error (see the screenshot)

**To Reproduce**
Steps to reproduce the behavior:

Create a screen From "New User Template" and set it public
Create a link on login page and provide the New Screen's URL.
preview the app click on "Create New User" (on "login screen") and you will go to "Create New User" Screen
Provide data in "email" and "other" fields and click on "save"
see the error

**Expected behavior**
New user should have been created


