### PR TITLE
Feature - CLI quick init

### DIFF
--- a/packages/builder/src/components/automation/AutomationPanel/EditAutomationPopover.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/EditAutomationPopover.svelte
@@ -1,4 +1,4 @@
-<script>    
+<script>
   import { goto } from "@sveltech/routify"
   import { automationStore, backendUiStore } from "builderStore"
   import { notifier } from "builderStore/store/notifications"
@@ -24,7 +24,7 @@
       automation,
     })
     notifier.success("Automation deleted.")
-    $goto('../automate')
+    $goto("../automate")
   }
 </script>
 

--- a/packages/builder/src/components/backend/DatasourceNavigator/popovers/EditDatasourcePopover.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/popovers/EditDatasourcePopover.svelte
@@ -24,7 +24,7 @@
   async function deleteDatasource() {
     await backendUiStore.actions.datasources.delete(datasource)
     notifier.success("Datasource deleted")
-    $goto('./datasource')
+    $goto("./datasource")
     hideEditor()
   }
 </script>

--- a/packages/builder/src/components/deploy/DeploymentHistory.svelte
+++ b/packages/builder/src/components/deploy/DeploymentHistory.svelte
@@ -119,11 +119,13 @@
             {#if deployment.status.toLowerCase() === 'pending'}
               <Spinner size="10" />
             {/if}
-            <div on:click={() => showErrorReasonModal(deployment.err)} class={`deployment-status ${deployment.status}`}>
+            <div
+              on:click={() => showErrorReasonModal(deployment.err)}
+              class={`deployment-status ${deployment.status}`}>
               <span>
                 {deployment.status}
                 {#if deployment.status === DeploymentStatus.FAILURE}
-                  <i class="ri-information-line"/>
+                  <i class="ri-information-line" />
                 {/if}
               </span>
             </div>

--- a/packages/builder/src/pages/[application]/automate/[automation]/index.svelte
+++ b/packages/builder/src/pages/[application]/automate/[automation]/index.svelte
@@ -1,6 +1,5 @@
 <script>
   import AutomationBuilder from "components/automation/AutomationBuilder/AutomationBuilder.svelte"
 </script>
-  
+
 <AutomationBuilder />
-  

--- a/packages/builder/src/pages/[application]/automate/index.svelte
+++ b/packages/builder/src/pages/[application]/automate/index.svelte
@@ -1,18 +1,19 @@
 <script>
   import { goto, leftover } from "@sveltech/routify"
-  import { onMount } from 'svelte'
+  import { onMount } from "svelte"
   import { automationStore } from "builderStore"
 
   onMount(async () => {
-      // navigate to first automation in list, if not already selected
-      if (
-        !$leftover &&
-        $automationStore.automations.length > 0 &&
-        (!$automationStore.selectedAutomation || !$automationStore.selectedAutomation?.automation?._id)
-      ) {
-        $goto(`../${$automationStore.automations[0]._id}`)
-      }
-    })
+    // navigate to first automation in list, if not already selected
+    if (
+      !$leftover &&
+      $automationStore.automations.length > 0 &&
+      (!$automationStore.selectedAutomation ||
+        !$automationStore.selectedAutomation?.automation?._id)
+    ) {
+      $goto(`../${$automationStore.automations[0]._id}`)
+    }
+  })
 </script>
 
 <i>Create your first automation to get started</i>

--- a/packages/builder/src/pages/[application]/data/_layout.svelte
+++ b/packages/builder/src/pages/[application]/data/_layout.svelte
@@ -17,11 +17,11 @@
     },
   ]
 
-  let tab = $isActive('./datasource') ? "datasource" : "table"
+  let tab = $isActive("./datasource") ? "datasource" : "table"
 
   function selectFirstTableOrSource({ detail }) {
     const type = detail.heading.key
-    if (type === 'datasource') {
+    if (type === "datasource") {
       $goto("./datasource")
     } else {
       $goto("./table")
@@ -34,7 +34,10 @@
 <!-- routify:options index=0 -->
 <div class="root">
   <div class="nav">
-    <Switcher headings={tabs} bind:value={tab} on:change={selectFirstTableOrSource}>
+    <Switcher
+      headings={tabs}
+      bind:value={tab}
+      on:change={selectFirstTableOrSource}>
       <div class="title">
         <i
           data-cy={`new-${tab}`}

--- a/packages/builder/src/pages/[application]/data/datasource/[selectedDatasource]/[query]/_layout.svelte
+++ b/packages/builder/src/pages/[application]/data/datasource/[selectedDatasource]/[query]/_layout.svelte
@@ -3,9 +3,7 @@
   import { backendUiStore } from "builderStore"
 
   if ($params.query) {
-    const query = $backendUiStore.queries.find(
-      m => m._id === $params.query
-    )
+    const query = $backendUiStore.queries.find(m => m._id === $params.query)
     if (query) {
       backendUiStore.actions.queries.select(query)
     }

--- a/packages/builder/src/pages/[application]/data/datasource/index.svelte
+++ b/packages/builder/src/pages/[application]/data/datasource/index.svelte
@@ -1,22 +1,23 @@
 <script>
-    import { backendUiStore } from "builderStore"
-    import { goto } from "@sveltech/routify"
-    import { onMount } from "svelte"
+  import { backendUiStore } from "builderStore"
+  import { goto } from "@sveltech/routify"
+  import { onMount } from "svelte"
 
-    onMount(async () => {
-      // navigate to first table in list, if not already selected
-      $backendUiStore.datasources.length > 0 && $goto(`../${$backendUiStore.datasources[0]._id}`)
-    })
-  </script>
-  
-  {#if $backendUiStore.tables.length === 0}
-    <i>Connect your first datasource to start building.</i>
-  {:else}<i>Select a datasource to edit</i>{/if}
-  
-  <style>
-    i {
-      font-size: var(--font-size-m);
-      color: var(--grey-5);
-      margin-top: 2px;
-    }
-  </style>
+  onMount(async () => {
+    // navigate to first table in list, if not already selected
+    $backendUiStore.datasources.length > 0 &&
+      $goto(`../${$backendUiStore.datasources[0]._id}`)
+  })
+</script>
+
+{#if $backendUiStore.tables.length === 0}
+  <i>Connect your first datasource to start building.</i>
+{:else}<i>Select a datasource to edit</i>{/if}
+
+<style>
+  i {
+    font-size: var(--font-size-m);
+    color: var(--grey-5);
+    margin-top: 2px;
+  }
+</style>

--- a/packages/builder/src/pages/[application]/data/table/index.svelte
+++ b/packages/builder/src/pages/[application]/data/table/index.svelte
@@ -4,7 +4,8 @@
   import { onMount } from "svelte"
 
   onMount(async () => {
-    $backendUiStore.tables.length > 0 && $goto(`../${$backendUiStore.tables[0]._id}`)
+    $backendUiStore.tables.length > 0 &&
+      $goto(`../${$backendUiStore.tables[0]._id}`)
   })
 </script>
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,6 @@
     "chalk": "^4.1.0",
     "commander": "^7.1.0",
     "docker-compose": "^0.23.6",
-    "envfile": "^6.14.0",
     "inquirer": "^8.0.0",
     "lookpath": "^1.1.0",
     "pkg": "^4.4.9",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@budibase/cli",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Budibase CLI, for developers, self hosting and migrations.",
   "main": "src/index.js",
-  "bin": "src/index.js",
+  "bin": {
+    "budi": "src/index.js"
+  },
   "author": "Budibase",
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,6 +14,7 @@
     "chalk": "^4.1.0",
     "commander": "^7.1.0",
     "docker-compose": "^0.23.6",
+    "envfile": "^6.14.0",
     "inquirer": "^8.0.0",
     "lookpath": "^1.1.0",
     "pkg": "^4.4.9",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cli",
-  "version": "0.8.7",
+  "name": "@budibase/cli",
+  "version": "0.8.9",
   "description": "Budibase CLI, for developers, self hosting and migrations.",
   "main": "src/index.js",
   "bin": "src/index.js",

--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -5,4 +5,5 @@ exports.CommandWords = {
 
 exports.InitTypes = {
   QUICK: "quick",
+  DIGITAL_OCEAN: "do",
 }

--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -2,3 +2,7 @@ exports.CommandWords = {
   HOSTING: "hosting",
   HELP: "help",
 }
+
+exports.InitTypes = {
+  QUICK: "quick",
+}

--- a/packages/cli/src/hosting/index.js
+++ b/packages/cli/src/hosting/index.js
@@ -1,5 +1,5 @@
 const Command = require("../structures/Command")
-const { CommandWords } = require("../constants")
+const { CommandWords, InitTypes } = require("../constants")
 const { lookpath } = require("lookpath")
 const { downloadFile, logErrorToFile, success, info } = require("../utils")
 const { confirmation } = require("../questions")
@@ -50,17 +50,21 @@ async function handleError(func) {
   }
 }
 
-async function init() {
+async function init(info) {
+  const isQuick = info === InitTypes.QUICK
   await checkDockerConfigured()
-  const shouldContinue = await confirmation(
-    "This will create multiple files in current directory, should continue?"
-  )
-  if (!shouldContinue) {
-    console.log("Stopping.")
-    return
+  if (!isQuick) {
+    const shouldContinue = await confirmation(
+      "This will create multiple files in current directory, should continue?"
+    )
+    if (!shouldContinue) {
+      console.log("Stopping.")
+      return
+    }
   }
   await downloadFiles()
-  await envFile.make()
+  const config = isQuick ? envFile.QUICK_CONFIG : {}
+  await envFile.make(config)
 }
 
 async function start() {
@@ -128,8 +132,8 @@ async function update() {
 const command = new Command(`${CommandWords.HOSTING}`)
   .addHelp("Controls self hosting on the Budibase platform.")
   .addSubOption(
-    "--init",
-    "Configure a self hosted platform in current directory.",
+    "--init [type]",
+    "Configure a self hosted platform in current directory, type can be unspecified or 'quick'.",
     init
   )
   .addSubOption(

--- a/packages/cli/src/hosting/makeEnv.js
+++ b/packages/cli/src/hosting/makeEnv.js
@@ -30,15 +30,23 @@ BUDIBASE_ENVIRONMENT=PRODUCTION`
 }
 
 module.exports.filePath = FILE_PATH
+module.exports.QUICK_CONFIG = {
+  key: "budibase",
+  port: 10000,
+}
 
-module.exports.make = async () => {
-  const hostingKey = await string(
-    "Please input the password you'd like to use as your hosting key: "
-  )
-  const hostingPort = await number(
-    "Please enter the port on which you want your installation to run: ",
-    10000
-  )
+module.exports.make = async (inputs = {}) => {
+  const hostingKey =
+    inputs.key ||
+    (await string(
+      "Please input the password you'd like to use as your hosting key: "
+    ))
+  const hostingPort =
+    inputs.port ||
+    (await number(
+      "Please enter the port on which you want your installation to run: ",
+      10000
+    ))
   const fileContents = getContents(hostingPort, hostingKey)
   fs.writeFileSync(FILE_PATH, fileContents)
   console.log(

--- a/packages/cli/src/hosting/makeEnv.js
+++ b/packages/cli/src/hosting/makeEnv.js
@@ -30,6 +30,10 @@ BUDIBASE_ENVIRONMENT=PRODUCTION`
 }
 
 module.exports.filePath = FILE_PATH
+module.exports.ConfigMap = {
+  HOSTING_KEY: "key",
+  MAIN_PORT: "port",
+}
 module.exports.QUICK_CONFIG = {
   key: "budibase",
   port: 10000,

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const { getCommands } = require("./options")
 const { Command } = require("commander")
 const { getHelpDescription } = require("./utils")

--- a/packages/cli/src/structures/Command.js
+++ b/packages/cli/src/structures/Command.js
@@ -13,8 +13,8 @@ class Command {
     return this
   }
 
-  addSubOption(command, help, func) {
-    this.opts.push({ command, help, func })
+  addSubOption(command, help, func, extras = []) {
+    this.opts.push({ command, help, func, extras })
     return this
   }
 
@@ -37,13 +37,10 @@ class Command {
     command.action(async options => {
       try {
         let executed = false
-        if (thisCmd.func) {
-          await thisCmd.func(options)
-          executed = true
-        }
         for (let opt of thisCmd.opts) {
-          if (options[opt.command.replace("--", "")]) {
-            await opt.func(options)
+          const lookup = opt.command.split(" ")[0].replace("--", "")
+          if (options[lookup]) {
+            await opt.func(options[lookup])
             executed = true
           }
         }

--- a/packages/cli/src/utils.js
+++ b/packages/cli/src/utils.js
@@ -44,3 +44,15 @@ exports.info = info => {
 exports.logErrorToFile = (file, error) => {
   fs.writeFileSync(path.resolve(`./${file}`), `Budiase Error\n${error}`)
 }
+
+exports.parseEnv = env => {
+  const lines = env.toString().split("\n")
+  let result = {}
+  for (const line of lines) {
+    const match = line.match(/^([^=:#]+?)[=:](.*)/)
+    if (match) {
+      result[match[1].trim()] = match[2].trim()
+    }
+  }
+  return result
+}

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -391,6 +391,11 @@ enquirer@^2.3.5:
   dependencies:
     ansi-colors "^4.1.1"
 
+envfile@^6.14.0:
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/envfile/-/envfile-6.14.0.tgz#8dab1ab915a4c6567087a6bb9e732b1f164c2b30"
+  integrity sha512-JxpcaOgJQB/x0XFmNiqFu0BLK22PlI3F0d95of5SOqcLvBlGC0ug7MHYDWnmZqmx9svIue8v0cVcqAygPTyXHQ==
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -15,30 +15,30 @@
   integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
 
 "@babel/highlight@^7.10.4":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.12.13.tgz#8ab538393e00370b26271b01fa08f7f27f2e795c"
-  integrity sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.13.10.tgz#a8b2a66148f5b27d666b15d81774347a731d52d1"
+  integrity sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
 "@babel/parser@^7.9.4":
-  version "7.13.4"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.4.tgz#340211b0da94a351a6f10e63671fa727333d13ab"
-  integrity sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==
+  version "7.13.11"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.11.tgz#f93ebfc99d21c1772afbbaa153f47e7ce2f50b88"
+  integrity sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q==
 
 "@babel/runtime@^7.9.2":
-  version "7.13.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.7.tgz#d494e39d198ee9ca04f4dcb76d25d9d7a1dc961a"
-  integrity sha512-h+ilqoX998mRVM5FtB5ijRuHUDVt5l3yfoOi2uh18Z/O3hvyaHQ39NpxVkCIG5yFs+mLq/ewFp8Bss6zmWv6ZA==
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
+  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@eslint/eslintrc@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.3.0.tgz#d736d6963d7003b6514e6324bec9c602ac340318"
-  integrity sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==
+"@eslint/eslintrc@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
+  integrity sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==
   dependencies:
     ajv "^6.12.4"
     debug "^4.1.1"
@@ -47,7 +47,6 @@
     ignore "^4.0.6"
     import-fresh "^3.2.1"
     js-yaml "^3.13.1"
-    lodash "^4.17.20"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
@@ -93,9 +92,9 @@ ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
     uri-js "^4.2.2"
 
 ajv@^7.0.2:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-7.1.1.tgz#1e6b37a454021fa9941713f38b952fc1c8d32a84"
-  integrity sha512-ga/aqDYnUy/o7vbsRTFhhTsNeXiYb5JWDIcRIeZfwRNCefwjNTVYCGdGSUrEmiu3yDK3vFvNbgJxvrQW4JXrYQ==
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-7.2.1.tgz#a5ac226171912447683524fa2f1248fcf8bac83d"
+  integrity sha512-+nu0HDv7kNSOua9apAVc979qd932rrZeb3WOvoiD31A/p1mIE5/9bN2027pE2rOPYEdS3UHzsvof4hY+lM9/WQ==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -391,11 +390,6 @@ enquirer@^2.3.5:
   dependencies:
     ansi-colors "^4.1.1"
 
-envfile@^6.14.0:
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/envfile/-/envfile-6.14.0.tgz#8dab1ab915a4c6567087a6bb9e732b1f164c2b30"
-  integrity sha512-JxpcaOgJQB/x0XFmNiqFu0BLK22PlI3F0d95of5SOqcLvBlGC0ug7MHYDWnmZqmx9svIue8v0cVcqAygPTyXHQ==
-
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -439,12 +433,12 @@ eslint-visitor-keys@^2.0.0:
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
 eslint@^7.20.0:
-  version "7.20.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.20.0.tgz#db07c4ca4eda2e2316e7aa57ac7fc91ec550bdc7"
-  integrity sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==
+  version "7.22.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.22.0.tgz#07ecc61052fec63661a2cab6bd507127c07adc6f"
+  integrity sha512-3VawOtjSJUQiiqac8MQc+w457iGLfuNGLFn8JmF051tTKbh5/x/0vlcEj8OgDCaw7Ysa2Jn8paGshV7x2abKXg==
   dependencies:
     "@babel/code-frame" "7.12.11"
-    "@eslint/eslintrc" "^0.3.0"
+    "@eslint/eslintrc" "^0.4.0"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -457,10 +451,10 @@ eslint@^7.20.0:
     espree "^7.3.1"
     esquery "^1.4.0"
     esutils "^2.0.2"
-    file-entry-cache "^6.0.0"
+    file-entry-cache "^6.0.1"
     functional-red-black-tree "^1.0.1"
     glob-parent "^5.0.0"
-    globals "^12.1.0"
+    globals "^13.6.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
@@ -468,7 +462,7 @@ eslint@^7.20.0:
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
-    lodash "^4.17.20"
+    lodash "^4.17.21"
     minimatch "^3.0.4"
     natural-compare "^1.4.0"
     optionator "^0.9.1"
@@ -594,7 +588,7 @@ figures@^3.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-file-entry-cache@^6.0.0:
+file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
@@ -622,9 +616,9 @@ flatted@^3.1.0:
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
 follow-redirects@^1.10.0:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.2.tgz#dd73c8effc12728ba5cf4259d760ea5fb83e3147"
-  integrity sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.3.tgz#e5598ad50174c1bc4e872301e82ac2cd97f90267"
+  integrity sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -680,9 +674,9 @@ getpass@^0.1.1:
     assert-plus "^1.0.0"
 
 glob-parent@^5.0.0, glob-parent@^5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
-  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
@@ -704,6 +698,13 @@ globals@^12.1.0:
   integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
   dependencies:
     type-fest "^0.8.1"
+
+globals@^13.6.0:
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.7.0.tgz#aed3bcefd80ad3ec0f0be2cf0c895110c0591795"
+  integrity sha512-Aipsz6ZKRxa/xQkZhNg0qIWXT6x6rD46f6x/PCnBomlttdIyAPak4YD9jTmKpZ72uROSMU87qJtcgpgHaVchiA==
+  dependencies:
+    type-fest "^0.20.2"
 
 globby@^11.0.0:
   version "11.0.2"
@@ -962,9 +963,9 @@ lodash@^4.17.20, lodash@^4.17.21:
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lookpath@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/lookpath/-/lookpath-1.1.0.tgz#932d68371a2f0b4a5644f03d6a2b4728edba96d2"
-  integrity sha512-B9NM7XpVfkyWqfOBI/UW0kVhGw7pJztsduch+1wkbYDi90mYK6/InFul3lG0hYko/VEcVMARVBJ5daFRc5aKCw==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/lookpath/-/lookpath-1.2.0.tgz#5fccf91497acec085e66d98cb12446c21fe665ae"
+  integrity sha512-cUl+R2bGJcSJiHLVKzGHRTYTBhudbHIgd7s63gfGHteaz0BBKEEz2yw2rgbxZAFze92KlbkiWzL1ylYOmqIPVA==
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -1422,9 +1423,9 @@ stream-meter@^1.0.4:
     readable-stream "^2.1.4"
 
 string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.1.tgz#1933ce1f470973d224368009bd1316cad81d5f4f"
-  integrity sha512-LL0OLyN6AnfV9xqGQpDBwedT2Rt63737LxvsRxbcwpa2aIeynBApG2Sm//F3TaLHIR1aJBN52DWklc06b94o5Q==
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
+  integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
   dependencies:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
@@ -1546,6 +1547,11 @@ type-fest@^0.11.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
 type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
@@ -1588,9 +1594,9 @@ uuid@^3.3.2:
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 v8-compile-cache@^2.0.3:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
-  integrity sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
## Description
Small modification to the CLI, before it required user input to perform some tasks, after discussing with @shogunpurple the idea of using the CLI to manage our Digital Ocean one click deployments realised that the user input wouldn't work so implemented an init type, `cli hosting --init quick` will now run the command in one go, pull down all required files and init the system from there, correctly setting up all of the required hosting variables - this will default the port and hosting key to `10000` and `"budibase"` respectively.

For DigitalOcean it should be as simple as `cli hosting --init quick && cli hosting --start` to get the system up and running.

This will require us to release the CLI, making the `pkg` version of it available, or making it available as a package on NPM, so that we can pull it into the DO droplet.