### PR TITLE
Fix: Unable to use parameters with Rest conenctor

### DIFF
--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/EventsEditor/actions/ExecuteQuery.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/EventsEditor/actions/ExecuteQuery.svelte
@@ -56,6 +56,7 @@
       {query}
       schema={fetchQueryDefinition(query)}
       editable={false}
+      {datasource}
     />
   {/if}
 </Layout>


### PR DESCRIPTION
## Description
We are unable to add parameters to the the Rest API datasource.

Copied this across from `master`: https://github.com/Budibase/budibase/pull/1480/commits/c92d99eaf99c4fc4644faa7d51bcf95fcacded22 - which has been tested and released



