### PR TITLE
Enhance email preview

### DIFF
--- a/packages/builder/src/components/start/AppCard.svelte
+++ b/packages/builder/src/components/start/AppCard.svelte
@@ -9,8 +9,6 @@
     StatusLight,
   } from "@budibase/bbui"
   import { gradient } from "actions"
-  import { auth } from "stores/portal"
-  import { AppStatus } from "constants"
 
   export let app
   export let exportApp

--- a/packages/builder/src/components/start/AppRow.svelte
+++ b/packages/builder/src/components/start/AppRow.svelte
@@ -8,7 +8,6 @@
     MenuItem,
     StatusLight,
   } from "@budibase/bbui"
-  import { auth } from "stores/portal"
 
   export let app
   export let exportApp

--- a/packages/builder/src/stores/portal/email.js
+++ b/packages/builder/src/stores/portal/email.js
@@ -2,7 +2,7 @@ import { writable } from "svelte/store"
 import api from "builderStore/api"
 
 export function createEmailStore() {
-  const store = writable([])
+  const store = writable({})
 
   return {
     subscribe: store.subscribe,


### PR DESCRIPTION
This PR improves the email templates in 2 ways. Firstly it renders the preview inside an iframe to scope the CSS, because we're currently rendering it directly in our own page, which means that all the style rules defined in the template are affecting our own page. For example, the base template already changes font colours and the background colour to `#333` on our actual page.

Before this change, here's the effect of the template HTML, changing our page background to a lighter grey:
![image](https://user-images.githubusercontent.com/9075550/119145285-654b3400-ba41-11eb-8464-7250c9f2f06e.png)


Secondly, the preview now renders any email templates inside the base template. This means you can get an actual idea of what your email will look like, and you get the added bonus of inherited styles.

Welcome template before:
![before](https://user-images.githubusercontent.com/9075550/119145103-3a60e000-ba41-11eb-83da-290e78a7aead.png)

Welcome template after:
![after](https://user-images.githubusercontent.com/9075550/119145116-3f259400-ba41-11eb-8d4b-18426625cf0c.png)





