### PR TITLE
Fix formula fields causing handlebars enrichment to fail

### DIFF
--- a/packages/client/src/api/tables.js
+++ b/packages/client/src/api/tables.js
@@ -6,7 +6,16 @@ import { enrichRows } from "./rows"
  * Since definitions cannot change at runtime, the result is cached.
  */
 export const fetchTableDefinition = async tableId => {
-  return await API.get({ url: `/api/tables/${tableId}`, cache: true })
+  const res = await API.get({ url: `/api/tables/${tableId}`, cache: true })
+
+  // Wipe any HBS formulae, as these interfere with handlebars enrichment
+  Object.keys(res?.schema || {}).forEach(field => {
+    if (res.schema[field]?.type === "formula") {
+      delete res.schema[field].formula
+    }
+  })
+
+  return res
 }
 
 /**


### PR DESCRIPTION
## Description
This fixes an error where handlebars enrichment of client component settings will fail for datasources due to a handelbars expression being present in field schema for fields of type `formula`. The actual formula expression is not needed by client apps so this can be safely deleted after being retrieved.


