### PR TITLE
set content type on client lib upload

### DIFF
--- a/packages/auth/src/objectStore/index.js
+++ b/packages/auth/src/objectStore/index.js
@@ -159,7 +159,7 @@ exports.upload = async ({
  * Similar to the upload function but can be used to send a file stream
  * through to the object store.
  */
-exports.streamUpload = async (bucketName, filename, stream) => {
+exports.streamUpload = async (bucketName, filename, stream, extra = {}) => {
   const objectStore = exports.ObjectStore(bucketName)
   await exports.makeSureBucketExists(objectStore, bucketName)
 
@@ -167,6 +167,7 @@ exports.streamUpload = async (bucketName, filename, stream) => {
     Bucket: sanitizeBucket(bucketName),
     Key: sanitizeKey(filename),
     Body: stream,
+    ...extra,
   }
   return objectStore.upload(params).promise()
 }

--- a/packages/server/src/api/controllers/static/templates/BudibaseApp.svelte
+++ b/packages/server/src/api/controllers/static/templates/BudibaseApp.svelte
@@ -31,7 +31,6 @@
       margin: 0;
       padding: 0;
     }
-
     *,
     *:before,
     *:after {
@@ -41,9 +40,9 @@
 </svelte:head>
 
 <body id="app">
-  <script src={clientLibPath}>
+  <script type="application/javascript" src={clientLibPath}>
   </script>
-  <script>
+  <script type="application/javascript">
     loadBudibase()
   </script>
 </body>

--- a/packages/server/src/utilities/fileSystem/newApp.js
+++ b/packages/server/src/utilities/fileSystem/newApp.js
@@ -30,5 +30,7 @@ exports.uploadClientLibrary = async appId => {
   const sourcepath = require.resolve("@budibase/client")
   const destPath = join(appId, "budibase-client.js")
 
-  await streamUpload(BUCKET_NAME, destPath, fs.createReadStream(sourcepath))
+  await streamUpload(BUCKET_NAME, destPath, fs.createReadStream(sourcepath), {
+    ContentType: "application/javascript",
+  })
 }


### PR DESCRIPTION
## Description
Fixes https://github.com/Budibase/budibase/issues/1579

We weren't setting the `ContentType` on the client lib, causing budibase to think the MIME type was the default `octet-stream`. We are now passing `application/javascript` to the MinIO upload params.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



