### PR TITLE
Fixing white screen issue for builders

### DIFF
--- a/packages/auth/src/security/roles.js
+++ b/packages/auth/src/security/roles.js
@@ -13,7 +13,6 @@ const BUILTIN_IDS = {
   POWER: "POWER",
   BASIC: "BASIC",
   PUBLIC: "PUBLIC",
-  BUILDER: "BUILDER",
 }
 
 // exclude internal roles like builder

--- a/packages/server/src/api/controllers/auth.js
+++ b/packages/server/src/api/controllers/auth.js
@@ -5,7 +5,7 @@ const { getFullUser } = require("../../utilities/users")
 
 exports.fetchSelf = async ctx => {
   const appId = ctx.appId
-  const { userId } = ctx.user
+  let userId = ctx.user.userId || ctx.user._id
   /* istanbul ignore next */
   if (!userId) {
     ctx.body = {}

--- a/packages/server/src/api/controllers/routing.js
+++ b/packages/server/src/api/controllers/routing.js
@@ -63,10 +63,6 @@ exports.fetch = async ctx => {
 exports.clientFetch = async ctx => {
   const routing = await getRoutingStructure(ctx.appId)
   let roleId = ctx.user.role._id
-  // builder is a special case, always return the full routing structure
-  if (roleId === BUILTIN_ROLE_IDS.BUILDER) {
-    roleId = BUILTIN_ROLE_IDS.ADMIN
-  }
   const roleIds = await getUserRoleHierarchy(ctx.appId, roleId)
   for (let topLevel of Object.values(routing.routes)) {
     for (let subpathKey of Object.keys(topLevel.subpaths)) {

--- a/packages/server/src/api/controllers/user.js
+++ b/packages/server/src/api/controllers/user.js
@@ -4,7 +4,6 @@ const {
   getUserMetadataParams,
 } = require("../../db/utils")
 const { InternalTables } = require("../../db/utils")
-const { BUILTIN_ROLE_IDS } = require("@budibase/auth/roles")
 const {
   getGlobalUsers,
   addAppRoleToUser,
@@ -47,10 +46,6 @@ exports.fetchMetadata = async function (ctx) {
 exports.updateSelfMetadata = async function (ctx) {
   // overwrite the ID with current users
   ctx.request.body._id = ctx.user._id
-  if (ctx.user.builder && ctx.user.builder.global) {
-    // specific case, update self role in global user
-    await addAppRoleToUser(ctx, ctx.appId, BUILTIN_ROLE_IDS.ADMIN)
-  }
   // make sure no stale rev
   delete ctx.request.body._rev
   await exports.updateMetadata(ctx)

--- a/packages/server/src/api/routes/tests/routing.spec.js
+++ b/packages/server/src/api/routes/tests/routing.spec.js
@@ -28,9 +28,7 @@ describe("/routing", () => {
     it("returns the correct routing for basic user", async () => {
       workerRequests.getGlobalUsers.mockImplementationOnce((ctx, appId) => {
         return {
-          roles: {
-            [appId]: BUILTIN_ROLE_IDS.BASIC,
-          }
+          roleId: BUILTIN_ROLE_IDS.BASIC,
         }
       })
       const res = await request

--- a/packages/server/src/middleware/currentapp.js
+++ b/packages/server/src/middleware/currentapp.js
@@ -33,7 +33,7 @@ module.exports = async (ctx, next) => {
     updateCookie = true
     appId = requestAppId
     // retrieving global user gets the right role
-    roleId = globalUser.roleId
+    roleId = globalUser.roleId || BUILTIN_ROLE_IDS.PUBLIC
   } else if (appCookie != null) {
     appId = appCookie.appId
     roleId = appCookie.roleId || BUILTIN_ROLE_IDS.PUBLIC

--- a/packages/server/src/tests/utilities/TestConfiguration.js
+++ b/packages/server/src/tests/utilities/TestConfiguration.js
@@ -101,7 +101,7 @@ class TestConfiguration {
       userId: GLOBAL_USER_ID,
     }
     const app = {
-      roleId: BUILTIN_ROLE_IDS.BUILDER,
+      roleId: BUILTIN_ROLE_IDS.ADMIN,
       appId: this.appId,
     }
     const authToken = jwt.sign(auth, env.JWT_SECRET)
@@ -306,11 +306,10 @@ class TestConfiguration {
     return await this._req(config, null, controllers.layout.save)
   }
 
-  async createUser(roleId = BUILTIN_ROLE_IDS.POWER) {
+  async createUser() {
     const globalId = `us_${Math.random()}`
     const resp = await this.globalUser(
       globalId,
-      roleId === BUILTIN_ROLE_IDS.BUILDER
     )
     return {
       ...resp,
@@ -319,7 +318,6 @@ class TestConfiguration {
   }
 
   async login(email, password, { roleId, userId, builder } = {}) {
-    roleId = !roleId ? BUILTIN_ROLE_IDS.BUILDER : roleId
     userId = !userId ? `us_uuid1` : userId
     if (!this.request) {
       throw "Server has not been opened, cannot login."

--- a/packages/server/src/tests/utilities/TestConfiguration.js
+++ b/packages/server/src/tests/utilities/TestConfiguration.js
@@ -308,9 +308,7 @@ class TestConfiguration {
 
   async createUser() {
     const globalId = `us_${Math.random()}`
-    const resp = await this.globalUser(
-      globalId,
-    )
+    const resp = await this.globalUser(globalId)
     return {
       ...resp,
       globalId,


### PR DESCRIPTION
## Description
Fixing issue with builder not always having the correct roles to view an app - global builders are now admins in all apps. This is an attempt to fix this issue for builders properly, if they are a global builder then they don't need to have a role within the app, it will simply work for them.

I also removed the need for them to always have their role updated at creation as this does nothing now - simply adds another path for things to go wrong/get stale.