### PR TITLE
Some quick fixes for relationship UI

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -43,6 +43,7 @@
   }
 
   let originalName = field.name
+  const linkEditDisabled = originalName != null
   let primaryDisplay =
     $tables.selected.primaryDisplay == null ||
     $tables.selected.primaryDisplay === field.name
@@ -197,7 +198,7 @@
   <Input
     label="Name"
     bind:value={field.name}
-    disabled={uneditable || (originalName && field.type === LINK_TYPE)}
+    disabled={uneditable || (linkEditDisabled && field.type === LINK_TYPE)}
   />
 
   <Select
@@ -284,6 +285,7 @@
   {:else if field.type === "link"}
     <Select
       label="Table"
+      disabled={linkEditDisabled}
       bind:value={field.tableId}
       options={tableOptions}
       getOptionLabel={table => table.name}
@@ -291,7 +293,7 @@
     />
     {#if relationshipOptions && relationshipOptions.length > 0}
       <RadioGroup
-        disabled={originalName != null}
+        disabled={linkEditDisabled}
         label="Define the relationship"
         bind:value={field.relationshipType}
         options={relationshipOptions}
@@ -299,7 +301,11 @@
         getOptionValue={option => option.value}
       />
     {/if}
-    <Input label={`Column name in other table`} bind:value={field.fieldName} />
+    <Input
+      disabled={linkEditDisabled}
+      label={`Column name in other table`}
+      bind:value={field.fieldName}
+    />
   {:else if field.type === FORMULA_TYPE}
     <ModalBindableInput
       title="Handlebars Formula"

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -197,7 +197,7 @@
   <Input
     label="Name"
     bind:value={field.name}
-    disabled={uneditable || field.type === LINK_TYPE}
+    disabled={uneditable || (originalName && field.type === LINK_TYPE)}
   />
 
   <Select

--- a/packages/server/src/api/controllers/application.js
+++ b/packages/server/src/api/controllers/application.js
@@ -99,12 +99,18 @@ async function createInstance(template) {
   // replicate the template data to the instance DB
   // this is currently very hard to test, downloading and importing template files
   /* istanbul ignore next */
+  let _rev
   if (template && template.useTemplate === "true") {
     const { ok } = await db.load(await getTemplateStream(template))
     if (!ok) {
       throw "Error loading database dump from template."
     }
-    var { _rev } = await db.get(DocumentTypes.APP_METADATA)
+    try {
+      const response = await db.get(DocumentTypes.APP_METADATA)
+      _rev = response._rev
+    } catch (err) {
+      _rev = null
+    }
   } else {
     // create the users table
     await db.put(USERS_TABLE_SCHEMA)


### PR DESCRIPTION
## Description
Was playing around with relationship columns a bit and realised they were a bit out of whack, it was possible to edit a lot of breaking things in a relationship column after it was created, and it wasn't possible to name the column.

Also fixed an issue where old apps being imported caused an error, error was allowable.