### PR TITLE
Allowing use of timezones with date helper

### DIFF
--- a/packages/string-templates/scripts/gen-collection-info.js
+++ b/packages/string-templates/scripts/gen-collection-info.js
@@ -20,7 +20,8 @@ const ADDED_HELPERS = {
       args: ["datetime", "format"],
       numArgs: 2,
       example: '{{date now "DD-MM-YYYY" "America/New_York" }} -> 21-01-2021',
-      description: "Format a date using moment.js date formatting - the timezone is optional and uses the tz database.",
+      description:
+        "Format a date using moment.js date formatting - the timezone is optional and uses the tz database.",
     },
     duration: {
       args: ["time", "durationType"],

--- a/packages/string-templates/scripts/gen-collection-info.js
+++ b/packages/string-templates/scripts/gen-collection-info.js
@@ -19,8 +19,8 @@ const ADDED_HELPERS = {
     date: {
       args: ["datetime", "format"],
       numArgs: 2,
-      example: '{{date now "DD-MM-YYYY"}} -> 21-01-2021',
-      description: "Format a date using moment.js date formatting.",
+      example: '{{date now "DD-MM-YYYY" "America/New_York" }} -> 21-01-2021',
+      description: "Format a date using moment.js date formatting - the timezone is optional and uses the tz database.",
     },
     duration: {
       args: ["time", "durationType"],

--- a/packages/string-templates/src/helpers/date.js
+++ b/packages/string-templates/src/helpers/date.js
@@ -3,6 +3,7 @@ dayjs.extend(require("dayjs/plugin/duration"))
 dayjs.extend(require("dayjs/plugin/advancedFormat"))
 dayjs.extend(require("dayjs/plugin/relativeTime"))
 dayjs.extend(require("dayjs/plugin/utc"))
+dayjs.extend(require("dayjs/plugin/timezone"))
 
 /**
  * This file was largely taken from the helper-date package - we did this for two reasons:
@@ -72,7 +73,8 @@ function setLocale(str, pattern, options) {
   // if options is null then it'll get updated here
   const config = initialConfig(str, pattern, options)
   const defaults = { lang: "en", date: new Date(config.str) }
-  const opts = getContext(this, defaults, config.options)
+  // for now don't allow this to be configurable, don't pass in options
+  const opts = getContext(this, defaults, {})
 
   // set the language to use
   dayjs.locale(opts.lang || opts.language)
@@ -89,7 +91,15 @@ module.exports.date = (str, pattern, options) => {
 
   setLocale(config.str, config.pattern, config.options)
 
-  const date = dayjs(new Date(config.str)).utc()
+  let date = dayjs(new Date(config.str))
+  if (typeof config.options === "string") {
+    date =
+      config.options.toLowerCase() === "utc"
+        ? date.utc()
+        : date.tz(config.options)
+  } else {
+    date = date.tz(dayjs.tz.guess())
+  }
   if (config.pattern === "") {
     return date.toISOString()
   }

--- a/packages/string-templates/test/helpers.spec.js
+++ b/packages/string-templates/test/helpers.spec.js
@@ -163,7 +163,7 @@ describe("test the date helpers", () => {
   it("should allow use of the date helper", async () => {
     const date = new Date(1611577535000)
     const output = await processString("{{ date time 'YYYY-MM-DD' }}", {
-      time: date.toISOString(),
+      time: date.toUTCString(),
     })
     expect(output).toBe("2021-01-25")
   })
@@ -177,15 +177,16 @@ describe("test the date helpers", () => {
   it("should test the timezone capabilities", async () => {
     const date = new Date(1611577535000)
     const output = await processString("{{ date time 'HH-mm-ss Z' 'America/New_York' }}", {
-      time: date.toISOString(),
+      time: date.toUTCString(),
     })
-    expect(output).toBe("07-25-35 -04:00")
+    const formatted = new dayjs(date).tz("America/New_York").format("HH-mm-ss Z")
+    expect(output).toBe(formatted)
   })
 
   it("should guess the users timezone when not specified", async () => {
     const date = new Date()
     const output = await processString("{{ date time 'Z' }}", {
-      time: date.toISOString()
+      time: date.toUTCString()
     })
     const timezone = dayjs.tz.guess()
     const offset = new dayjs(date).tz(timezone).format("Z")

--- a/packages/string-templates/test/helpers.spec.js
+++ b/packages/string-templates/test/helpers.spec.js
@@ -1,5 +1,6 @@
 const { processString, processObject, isValid } = require("../src/index.cjs")
 const tableJson = require("./examples/table.json")
+const dayjs = require("dayjs")
 
 describe("test the custom helpers we have applied", () => {
   it("should be able to use the object helper", async () => {
@@ -171,6 +172,24 @@ describe("test the date helpers", () => {
     const date = new Date()
     const output = await processString("{{ date now 'DD' }}", {})
     expect(parseInt(output)).toBe(date.getDate())
+  })
+
+  it("should test the timezone capabilities", async () => {
+    const date = new Date(1611577535000)
+    const output = await processString("{{ date time 'HH-mm-ss Z' 'America/New_York' }}", {
+      time: date.toISOString(),
+    })
+    expect(output).toBe("07-25-35 -04:00")
+  })
+
+  it("should guess the users timezone when not specified", async () => {
+    const date = new Date()
+    const output = await processString("{{ date time 'Z' }}", {
+      time: date.toISOString()
+    })
+    const timezone = dayjs.tz.guess()
+    const offset = new dayjs(date).tz(timezone).format("Z")
+    expect(output).toBe(offset)
   })
 })
 


### PR DESCRIPTION
## Description
Updating date helper to allow timezone capabilities - namely in three ways:

1. Guessing the users timezone based on the system time and using this
2. Exposing `UTC` via `{{ date <time property> "HH::mm:ss" "UTC" }}`
3. Exposing any timezone via `{{ date <time property> "HH:mm:ss" "America/New_York" }}`

Timezone list can be found at: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones