### PR TITLE
Form fixes

### DIFF
--- a/packages/builder/src/builderStore/store/screenTemplates/newRowScreen.js
+++ b/packages/builder/src/builderStore/store/screenTemplates/newRowScreen.js
@@ -35,6 +35,7 @@ const createScreen = table => {
   const form = makeMainForm()
     .instanceName("Form")
     .customProps({
+      actionType: "Create",
       theme: "spectrum--lightest",
       size: "spectrum--medium",
       dataSource: {

--- a/packages/builder/src/builderStore/store/screenTemplates/rowDetailScreen.js
+++ b/packages/builder/src/builderStore/store/screenTemplates/rowDetailScreen.js
@@ -110,6 +110,7 @@ const createScreen = table => {
   const form = makeMainForm()
     .instanceName("Form")
     .customProps({
+      actionType: "Update",
       theme: "spectrum--lightest",
       size: "spectrum--medium",
       dataSource: {

--- a/packages/standard-components/manifest.json
+++ b/packages/standard-components/manifest.json
@@ -1026,7 +1026,7 @@
       {
         "type": "select",
         "label": "Type",
-        "key": "type",
+        "key": "actionType",
         "options": ["Create", "Update"],
         "defaultValue": "Create"
       },

--- a/packages/standard-components/manifest.json
+++ b/packages/standard-components/manifest.json
@@ -1024,6 +1024,13 @@
     ],
     "settings": [
       {
+        "type": "select",
+        "label": "Type",
+        "key": "type",
+        "options": ["Create", "Update"],
+        "defaultValue": "Create"
+      },
+      {
         "type": "schema",
         "label": "Schema",
         "key": "dataSource"

--- a/packages/standard-components/src/forms/Form.svelte
+++ b/packages/standard-components/src/forms/Form.svelte
@@ -42,18 +42,6 @@
       // Auto columns are always disabled
       const isAutoColumn = !!schema?.[field]?.autocolumn
 
-      if (fieldMap[field] != null) {
-        // Update disabled property just so that toggling the disabled field
-        // state in the builder makes updates in real time.
-        // We only need this because of optimisations which prevent fully
-        // remounting when settings change.
-        fieldMap[field].fieldState.update(state => {
-          state.disabled = disabled || fieldDisabled || isAutoColumn
-          return state
-        })
-        return fieldMap[field]
-      }
-
       // Create validation function based on field schema
       const constraints = schema?.[field]?.constraints
       const validate = createValidatorFromConstraints(constraints, field, table)
@@ -67,6 +55,10 @@
         fieldApi: makeFieldApi(field, defaultValue, validate),
         fieldSchema: schema?.[field] ?? {},
       }
+
+      // Set initial value
+      fieldMap[field].fieldApi.setValue(defaultValue, true)
+
       return fieldMap[field]
     },
     validate: () => {

--- a/packages/standard-components/src/forms/Form.svelte
+++ b/packages/standard-components/src/forms/Form.svelte
@@ -8,7 +8,7 @@
   export let theme
   export let size
   export let disabled = false
-  export let type = "Create"
+  export let actionType = "Create"
 
   const component = getContext("component")
   const context = getContext("context")
@@ -42,7 +42,7 @@
   }
 
   // Use the closest data context as the initial form values
-  const initialValues = getInitialValues(type, dataSource, $context)
+  const initialValues = getInitialValues(actionType, dataSource, $context)
 
   // Form state contains observable data about the form
   const formState = writable({ values: initialValues, errors: {}, valid: true })

--- a/packages/string-templates/src/index.cjs
+++ b/packages/string-templates/src/index.cjs
@@ -16,9 +16,6 @@ registerAll(hbsInstance)
  * utility function to check if the object is valid
  */
 function testObject(object) {
-  if (object == null) {
-    throw "Unable to process null object"
-  }
   // JSON stringify will fail if there are any cycles, stops infinite recursion
   try {
     JSON.stringify(object)

--- a/packages/string-templates/test/basic.spec.js
+++ b/packages/string-templates/test/basic.spec.js
@@ -81,14 +81,14 @@ describe("Test that the object processing works correctly", () => {
     expect(error).not.toBeNull()
   })
 
-  it("should fail gracefully when wrong type is passed in", async () => {
+  it("should be able to handle null objects", async () => {
     let error = null
     try {
       await processObject(null, null)
     } catch (err) {
       error = err
     }
-    expect(error).not.toBeNull()
+    expect(error).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Description
This PR addresses a couple of form issues which currently exist that prevent some fundamental functionality such as being able to add related data to a row that's inside a data provider.

- Field initial values are now correctly registered on mount, which means running validate is no longer mandatory in order for fields to have a value after mounting the form. This prevents rare errors where no values were being sent up if fields were not changed.
- Forms have a new setting to specify if they are for creating or updating rows. This setting is needed so that the form knows whether or not to inherit initial values from a parent data context. This determination of initial values has also been improved to be more strict, and ensure that only contexts of the same table are inherited.
- Unrelated, but I've updated the string templates library to allow processing of `null` rather than throw an error, as this is sometimes the case when called from client library contexts.

**This PR requires migration if pulled into exisiting apps.**
**All exisiting forms which update data need to be updated to specify the "Update" type setting, otherwise they will not have initial values and will function as if they are creating new rows.**
There won't be any crashes or errors - they'll just function as "Create" forms rather than "Update".

Since there is currently no client library upgrade strategy this will not affect customers - only dev environments where the client version is always updated.

Closes https://github.com/Budibase/budibase/issues/1580.
