### PR TITLE
Fix nullish booleans

### DIFF
--- a/packages/standard-components/src/lucene.js
+++ b/packages/standard-components/src/lucene.js
@@ -13,7 +13,9 @@ export const buildLuceneQuery = filter => {
     notEmpty: {},
   }
   if (Array.isArray(filter)) {
-    filter.forEach(({ operator, field, type, value }) => {
+    // Build up proper range filters
+    filter.forEach(expression => {
+      const { operator, field, type, value } = expression
       if (operator.startsWith("range")) {
         if (!query.range[field]) {
           query.range[field] = {
@@ -33,10 +35,26 @@ export const buildLuceneQuery = filter => {
           query.range[field].high = value
         }
       } else if (query[operator]) {
-        query[operator][field] = value
+        if (type === "boolean") {
+          // Transform boolean filters to cope with null.
+          // "equals false" needs to be "not equals true"
+          // "not equals false" needs to be "equals true"
+          if (operator === "equal" && value === "false") {
+            query.notEqual[field] = "true"
+          } else if (operator === "notEqual" && value === "false") {
+            query.equal[field] = "true"
+          } else {
+            query[operator][field] = value
+          }
+        } else {
+          query[operator][field] = value
+        }
       }
     })
   }
+
+  console.log(query)
+
   return query
 }
 

--- a/packages/standard-components/src/lucene.js
+++ b/packages/standard-components/src/lucene.js
@@ -53,8 +53,6 @@ export const buildLuceneQuery = filter => {
     })
   }
 
-  console.log(query)
-
   return query
 }
 


### PR DESCRIPTION
## Description
Fixes https://github.com/Budibase/budibase/issues/1581. This addresses the issue of filtering `false` on boolean fields not being possible unless the field has actually been explicitly set to false. A better description has been copied from my comment on that linked issue:

### Issue description
Indexing `null` as `false` is impossible, because when indexing we only have access to the document, but not the schema, so we can't tell if a field is supposed to be `boolean` or not, and we also don't know what fields we might be missing.

So I figured it would be possible by inverting the filter expressions to always work on `true` properties instead. The following transformations will solve the problem:
- Transform `equals false` to `not equals true`
- Transform `not equals false` to `equals true`

These two rules ensure that `null` values are always assumed to be false, because any fields set to `true` are obviously not `null` any more. This basically considers boolean logic to always be concerned with `true` and `not true` rather than `true`, `false` and `null`.

I can't apply this transformation in the filter editor because it will screw up the UI and be confusing, so instead I've implemented it in the data provider, when the luncene query is being built to be sent to the server. This keeps the UI consistent and transparently solves this issue.

## Screenshots
Here's a screenshot with this patch, showing a table filtered with a boolean field equal to false:
![image](https://user-images.githubusercontent.com/9075550/121385366-f460b300-c940-11eb-828f-48c323c7f6da.png)

Here's the table before this patch, for reference:
![image](https://user-images.githubusercontent.com/9075550/121386629-11e24c80-c942-11eb-8f18-e1b7b29154c4.png)

And here's the table after this patch, showing rows with both `false` and `undefined` in the field:
![image](https://user-images.githubusercontent.com/9075550/121385471-0b9fa080-c941-11eb-9d98-384de26f7b70.png)




