### PR TITLE
Quick attachments fix discovered when investigating the MinIO issue

### DIFF
--- a/hosting/docker-compose.dev.yaml
+++ b/hosting/docker-compose.dev.yaml
@@ -14,7 +14,6 @@ services:
     environment:
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
-      MINIO_BROWSER: "off"
     command: server /data
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]

--- a/packages/server/src/api/controllers/static/index.js
+++ b/packages/server/src/api/controllers/static/index.js
@@ -71,7 +71,7 @@ exports.uploadFile = async function (ctx) {
 
     return prepareUpload({
       file,
-      s3Key: `/${ctx.appId}/attachments/${processedFileName}`,
+      s3Key: `${ctx.appId}/attachments/${processedFileName}`,
       bucket: ObjectStoreBuckets.APPS,
     })
   })

--- a/packages/server/src/api/controllers/static/index.js
+++ b/packages/server/src/api/controllers/static/index.js
@@ -71,7 +71,7 @@ exports.uploadFile = async function (ctx) {
 
     return prepareUpload({
       file,
-      s3Key: `assets/${ctx.appId}/attachments/${processedFileName}`,
+      s3Key: `/${ctx.appId}/attachments/${processedFileName}`,
       bucket: ObjectStoreBuckets.APPS,
     })
   })

--- a/packages/server/src/api/routes/tests/row.spec.js
+++ b/packages/server/src/api/routes/tests/row.spec.js
@@ -385,7 +385,7 @@ describe("/rows", () => {
         name: "test",
         description: "test",
         attachment: [{
-          key: `${config.getAppId()}/attachment/test/thing.csv`,
+          key: `${config.getAppId()}/attachments/test/thing.csv`,
         }],
         tableId: table._id,
       })
@@ -393,7 +393,7 @@ describe("/rows", () => {
       await setup.switchToSelfHosted(async () => {
         const enriched = await outputProcessing(config.getAppId(), table, [row])
         expect(enriched[0].attachment[0].url).toBe(
-          `/prod-budi-app-assets/${config.getAppId()}/attachment/test/thing.csv`
+          `/prod-budi-app-assets/${config.getAppId()}/attachments/test/thing.csv`
         )
       })
     })


### PR DESCRIPTION
## Description
Super quick fix for attachments, keeping in correct object store directory - this doesn't require migration as old attachments will have been stored with the correct URL to their old location.
