### PR TITLE
Adding options to SMTP form for configuring TLS/STARTTLS

### DIFF
--- a/packages/builder/src/pages/builder/portal/manage/email/index.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/email/index.svelte
@@ -75,9 +75,6 @@
         type: ConfigTypes.SMTP,
         config: {
           secure: true,
-          auth: {
-            type: "login",
-          },
         },
       }
     } else {
@@ -85,6 +82,11 @@
     }
     loading = false
     requireAuth = smtpConfig.config.auth != null
+    // always attach the auth for the forms purpose -
+    // this will be removed later if required
+    smtpConfig.config.auth = {
+      type: "login",
+    }
   }
 
   fetchSmtp()

--- a/packages/builder/src/pages/builder/portal/manage/email/index.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/email/index.svelte
@@ -116,7 +116,7 @@
         <Input bind:value={smtpConfig.config.host} />
       </div>
       <div class="form-row">
-        <Label siz="L">Security type</Label>
+        <Label size="L">Security type</Label>
         <Select
           bind:value={smtpConfig.config.secure}
           options={[

--- a/packages/worker/src/utilities/email.js
+++ b/packages/worker/src/utilities/email.js
@@ -20,11 +20,16 @@ const FULL_EMAIL_PURPOSES = [
 
 function createSMTPTransport(config) {
   let options
+  let secure = config.secure
+  // default it if not specified
+  if (secure == null) {
+    secure = config.port === 465
+  }
   if (!TEST_MODE) {
     options = {
       port: config.port,
       host: config.host,
-      secure: config.secure || false,
+      secure: secure,
       auth: config.auth,
     }
     options.tls = {


### PR DESCRIPTION
## Description
Some discussions around issue #1637 - the form was a little ambiguous as to how some SMTP settings were configured, I've updated it to closely align with the form that is used in Android/iPhones to configure the outgoing (SMTP) settings of their email client, as this covers the vast majority of use cases and is a well known form layout.

## Screenshots
![image](https://user-images.githubusercontent.com/4407001/121510301-6556a800-c9df-11eb-9572-5e922d62af3b.png)
