### PR TITLE
Quick fix for issue #1710

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditUser.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditUser.svelte
@@ -104,6 +104,7 @@
     options={$roles}
     getOptionLabel={role => role.name}
     getOptionValue={role => role._id}
+    disabled={!creating}
   />
   {#each customSchemaKeys as [key, meta]}
     {#if !meta.autocolumn}

--- a/packages/builder/src/pages/builder/portal/manage/users/[userId].svelte
+++ b/packages/builder/src/pages/builder/portal/manage/users/[userId].svelte
@@ -33,12 +33,17 @@
     role: {},
   }
 
+  $: defaultRoleId = $userFetch?.data?.builder?.global ? "ADMIN" : ""
+  $: console.log(defaultRoleId)
   // Merge the Apps list and the roles response to get something that makes sense for the table
-  $: appList = Object.keys($apps?.data).map(id => ({
-    ...$apps?.data?.[id],
-    _id: id,
-    role: [$userFetch?.data?.roles?.[id]],
-  }))
+  $: appList = Object.keys($apps?.data).map(id => {
+    const role = $userFetch?.data?.roles?.[id] || defaultRoleId
+    return {
+      ...$apps?.data?.[id],
+      _id: id,
+      role: [role],
+    }
+  })
   let selectedApp
 
   const userFetch = fetchData(`/api/admin/users/${userId}`)

--- a/packages/builder/src/pages/builder/portal/manage/users/[userId].svelte
+++ b/packages/builder/src/pages/builder/portal/manage/users/[userId].svelte
@@ -34,7 +34,6 @@
   }
 
   $: defaultRoleId = $userFetch?.data?.builder?.global ? "ADMIN" : ""
-  $: console.log(defaultRoleId)
   // Merge the Apps list and the roles response to get something that makes sense for the table
   $: appList = Object.keys($apps?.data).map(id => {
     const role = $userFetch?.data?.roles?.[id] || defaultRoleId

--- a/packages/server/src/api/controllers/user.js
+++ b/packages/server/src/api/controllers/user.js
@@ -4,7 +4,6 @@ const {
   getUserMetadataParams,
 } = require("../../db/utils")
 const { InternalTables } = require("../../db/utils")
-const { addAppRoleToUser } = require("../../utilities/workerRequests")
 const { getGlobalUsers } = require("../../utilities/global")
 const { getFullUser } = require("../../utilities/users")
 

--- a/packages/server/src/api/controllers/user.js
+++ b/packages/server/src/api/controllers/user.js
@@ -53,9 +53,6 @@ exports.updateMetadata = async function (ctx) {
   const appId = ctx.appId
   const db = new CouchDB(appId)
   const user = removeGlobalProps(ctx.request.body)
-  if (user.roleId) {
-    await addAppRoleToUser(ctx, appId, user.roleId, user._id)
-  }
   const metadata = {
     tableId: InternalTables.USER_METADATA,
     ...user,

--- a/packages/server/src/utilities/global.js
+++ b/packages/server/src/utilities/global.js
@@ -12,14 +12,14 @@ exports.updateAppRole = (appId, user) => {
   if (!user.roles) {
     return user
   }
-  if (user.builder && user.builder.global) {
+
+  // always use the deployed app
+  user.roleId = user.roles[getDeployedAppID(appId)]
+  // if a role wasn't found then either set as admin (builder) or public (everyone else)
+  if (!user.roleId && user.builder && user.builder.global) {
     user.roleId = BUILTIN_ROLE_IDS.ADMIN
-  } else {
-    // always use the deployed app
-    user.roleId = user.roles[getDeployedAppID(appId)]
-    if (!user.roleId) {
-      user.roleId = BUILTIN_ROLE_IDS.PUBLIC
-    }
+  } else if (!user.roleId) {
+    user.roleId = BUILTIN_ROLE_IDS.PUBLIC
   }
   delete user.roles
   return user

--- a/packages/worker/src/api/routes/tests/realEmail.spec.js
+++ b/packages/worker/src/api/routes/tests/realEmail.spec.js
@@ -3,6 +3,9 @@ const { EmailTemplatePurpose } = require("../../../constants")
 const nodemailer = require("nodemailer")
 const fetch = require("node-fetch")
 
+// need a longer timeout for getting these
+jest.setTimeout(30000)
+
 describe("/api/admin/email", () => {
   let request = setup.getRequest()
   let config = setup.getConfig()


### PR DESCRIPTION
## Description
Fix for #1710 - don't allow setting setting info from within apps and making the user portal a bit more clear about builders being global admins.

This also makes it so that its possible to "downgrade" a builder if this is required, e.g. give them a lower than admin role and have it be respected - before this change a global builder would always be upgraded to admin, irrespective on the role they have actually been given in an app (builders now just default to admin).

Just a note as well, this isn't a fix to allow setting user information from within an app, this a rabbit hole I don't think we should descend down, instead this simply makes sure there is no way to try setting any of this information from within the app, making sure all global user properties are read only.