### PR TITLE
Fixes and making login/forgot/reset password pages respect logo and company name

### DIFF
--- a/packages/auth/src/middleware/authenticated.js
+++ b/packages/auth/src/middleware/authenticated.js
@@ -50,10 +50,9 @@ module.exports = (noAuthPatterns = [], opts) => {
       if (authCookie) {
         try {
           const db = database.getDB(StaticDatabases.GLOBAL.name)
-          const foundUser = await db.get(authCookie.userId)
-          delete foundUser.password
+          user = await db.get(authCookie.userId)
+          delete user.password
           authenticated = true
-          user = foundUser
         } catch (err) {
           // remove the cookie as the use does not exist anymore
           clearCookie(ctx, Cookies.Auth)

--- a/packages/builder/cypress/setup.js
+++ b/packages/builder/cypress/setup.js
@@ -20,6 +20,7 @@ process.env.MINIO_ACCESS_KEY = "budibase"
 process.env.MINIO_SECRET_KEY = "budibase"
 process.env.COUCH_DB_USER = "budibase"
 process.env.COUCH_DB_PASSWORD = "budibase"
+process.env.INTERNAL_API_KEY = "budibase"
 
 // Stop info logs polluting test outputs
 process.env.LOG_LEVEL = "error"

--- a/packages/builder/src/pages/builder/auth/forgot.svelte
+++ b/packages/builder/src/pages/builder/auth/forgot.svelte
@@ -9,6 +9,7 @@
   } from "@budibase/bbui"
   import { organisation, auth } from "stores/portal"
   import Logo from "assets/bb-emblem.svg"
+  import { onMount } from "svelte"
 
   let email = ""
 
@@ -20,6 +21,10 @@
       notifications.error("Unable to send reset password link")
     }
   }
+
+  onMount(async () => {
+    await organisation.init()
+  })
 </script>
 
 <div class="login">

--- a/packages/builder/src/pages/builder/auth/login.svelte
+++ b/packages/builder/src/pages/builder/auth/login.svelte
@@ -10,12 +10,15 @@
     notifications,
   } from "@budibase/bbui"
   import { goto, params } from "@roxi/routify"
-  import { auth } from "stores/portal"
+  import { auth, organisation } from "stores/portal"
   import GoogleButton from "./_components/GoogleButton.svelte"
   import Logo from "assets/bb-emblem.svg"
+  import { onMount } from "svelte"
 
   let username = ""
   let password = ""
+
+  $: company = $organisation.company || "Budibase"
 
   async function login() {
     try {
@@ -43,6 +46,10 @@
   function handleKeydown(evt) {
     if (evt.key === "Enter") login()
   }
+
+  onMount(async () => {
+    await organisation.init()
+  })
 </script>
 
 <svelte:window on:keydown={handleKeydown} />
@@ -50,8 +57,8 @@
   <div class="main">
     <Layout>
       <Layout noPadding justifyItems="center">
-        <img alt="logo" src={Logo} />
-        <Heading>Sign in to Budibase</Heading>
+        <img alt="logo" src={$organisation.logoUrl || Logo} />
+        <Heading>Sign in to {company}</Heading>
       </Layout>
       <GoogleButton />
       <Divider noGrid />
@@ -66,7 +73,7 @@
         />
       </Layout>
       <Layout gap="XS" noPadding>
-        <Button cta on:click={login}>Sign in to Budibase</Button>
+        <Button cta on:click={login}>Sign in to {company}</Button>
         <ActionButton quiet on:click={() => $goto("./forgot")}>
           Forgot password?
         </ActionButton>

--- a/packages/builder/src/pages/builder/auth/reset.svelte
+++ b/packages/builder/src/pages/builder/auth/reset.svelte
@@ -2,8 +2,9 @@
   import { Body, Button, Heading, Layout, notifications } from "@budibase/bbui"
   import { goto, params } from "@roxi/routify"
   import PasswordRepeatInput from "components/common/users/PasswordRepeatInput.svelte"
-  import { auth } from "stores/portal"
+  import { auth, organisation } from "stores/portal"
   import Logo from "assets/bb-emblem.svg"
+  import { onMount } from "svelte"
 
   const resetCode = $params["?code"]
   let password, error
@@ -28,13 +29,17 @@
       notifications.error("Unable to reset password")
     }
   }
+
+  onMount(async () => {
+    await organisation.init()
+  })
 </script>
 
 <div class="login">
   <div class="main">
     <Layout>
       <Layout noPadding justifyItems="center">
-        <img src={Logo} alt="Organisation logo" />
+        <img src={$organisation.logoUrl || Logo} alt="Organisation logo" />
       </Layout>
       <Layout gap="XS" noPadding>
         <Heading textAlign="center">Reset your password</Heading>

--- a/packages/builder/src/pages/builder/portal/settings/organisation.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/organisation.svelte
@@ -57,11 +57,17 @@
       await organisation.init()
     }
 
-    // Update settings
-    const res = await organisation.save({
+    const config = {
       company: $values.company ?? "",
       platformUrl: $values.platformUrl ?? "",
-    })
+    }
+    // remove logo if required
+    if (!$values.logo) {
+      config.logoUrl = ""
+    }
+
+    // Update settings
+    const res = await organisation.save(config)
     if (res.status === 200) {
       notifications.success("Settings saved successfully")
     } else {
@@ -98,7 +104,11 @@
           <Dropzone
             value={[$values.logo]}
             on:change={e => {
-              $values.logo = e.detail?.[0]
+              if (!e.detail || e.detail.length === 0) {
+                $values.logo = null
+              } else {
+                $values.logo = e.detail[0]
+              }
             }}
           />
         </div>

--- a/packages/builder/src/stores/portal/organisation.js
+++ b/packages/builder/src/stores/portal/organisation.js
@@ -13,7 +13,7 @@ export function createOrganisationStore() {
   const { subscribe, set } = store
 
   async function init() {
-    const res = await api.get(`/api/admin/configs/settings`)
+    const res = await api.get(`/api/admin/configs/public`)
     const json = await res.json()
 
     if (json.status === 400) {

--- a/packages/server/src/api/controllers/dev.js
+++ b/packages/server/src/api/controllers/dev.js
@@ -14,7 +14,7 @@ async function redirect(ctx, method) {
     request(ctx, {
       method,
       body: ctx.request.body,
-    })
+    }, true)
   )
   if (response.status !== 200) {
     ctx.throw(response.status, response.statusText)

--- a/packages/server/src/api/controllers/dev.js
+++ b/packages/server/src/api/controllers/dev.js
@@ -11,10 +11,14 @@ async function redirect(ctx, method) {
   const { devPath } = ctx.params
   const response = await fetch(
     checkSlashesInUrl(`${env.WORKER_URL}/api/admin/${devPath}`),
-    request(ctx, {
-      method,
-      body: ctx.request.body,
-    }, true)
+    request(
+      ctx,
+      {
+        method,
+        body: ctx.request.body,
+      },
+      true
+    )
   )
   if (response.status !== 200) {
     ctx.throw(response.status, response.statusText)

--- a/packages/worker/src/api/controllers/admin/configs.js
+++ b/packages/worker/src/api/controllers/admin/configs.js
@@ -98,6 +98,18 @@ exports.find = async function (ctx) {
   }
 }
 
+exports.publicSettings = async function (ctx) {
+  const db = new CouchDB(GLOBAL_DB)
+  try {
+    // Find the config with the most granular scope based on context
+    ctx.body = await getScopedFullConfig(db, {
+      type: Configs.SETTINGS,
+    })
+  } catch (err) {
+    ctx.throw(err.status, err)
+  }
+}
+
 exports.upload = async function (ctx) {
   if (ctx.request.files == null || ctx.request.files.file.length > 1) {
     ctx.throw(400, "One file must be uploaded.")

--- a/packages/worker/src/api/controllers/admin/configs.js
+++ b/packages/worker/src/api/controllers/admin/configs.js
@@ -102,9 +102,14 @@ exports.publicSettings = async function (ctx) {
   const db = new CouchDB(GLOBAL_DB)
   try {
     // Find the config with the most granular scope based on context
-    ctx.body = await getScopedFullConfig(db, {
+    const config = await getScopedFullConfig(db, {
       type: Configs.SETTINGS,
     })
+    if (!config) {
+      ctx.body = {}
+    } else {
+      ctx.body = config
+    }
   } catch (err) {
     ctx.throw(err.status, err)
   }

--- a/packages/worker/src/api/controllers/admin/configs.js
+++ b/packages/worker/src/api/controllers/admin/configs.js
@@ -90,7 +90,8 @@ exports.find = async function (ctx) {
     if (scopedConfig) {
       ctx.body = scopedConfig
     } else {
-      ctx.throw(400, "No configuration exists.")
+      // don't throw an error, there simply is nothing to return
+      ctx.body = {}
     }
   } catch (err) {
     ctx.throw(err.status, err)

--- a/packages/worker/src/api/controllers/admin/users.js
+++ b/packages/worker/src/api/controllers/admin/users.js
@@ -130,6 +130,9 @@ exports.removeAppRole = async ctx => {
 }
 
 exports.getSelf = async ctx => {
+  if (!ctx.user) {
+    ctx.throw(403, "User not logged in")
+  }
   ctx.params = {
     id: ctx.user._id,
   }

--- a/packages/worker/src/api/index.js
+++ b/packages/worker/src/api/index.js
@@ -40,7 +40,7 @@ const PUBLIC_ENDPOINTS = [
   {
     route: "/api/admin/configs/public",
     method: "GET",
-  }
+  },
 ]
 
 const router = new Router()

--- a/packages/worker/src/api/index.js
+++ b/packages/worker/src/api/index.js
@@ -37,6 +37,10 @@ const PUBLIC_ENDPOINTS = [
     route: "/api/apps",
     method: "GET",
   },
+  {
+    route: "/api/admin/configs/public",
+    method: "GET",
+  }
 ]
 
 const router = new Router()

--- a/packages/worker/src/api/routes/admin/configs.js
+++ b/packages/worker/src/api/routes/admin/configs.js
@@ -26,7 +26,7 @@ function settingValidation() {
   // prettier-ignore
   return Joi.object({
     platformUrl: Joi.string().optional(),
-    logoUrl: Joi.string().optional(),
+    logoUrl: Joi.string().optional().allow("", null),
     docsUrl: Joi.string().optional(),
     company: Joi.string().required(),
   }).unknown(true)
@@ -91,6 +91,7 @@ router
     buildConfigGetValidation(),
     controller.fetch
   )
+  .get("/api/admin/configs/public", controller.publicSettings)
   .get("/api/admin/configs/:type", buildConfigGetValidation(), controller.find)
   .post(
     "/api/admin/configs/upload/:type/:name",


### PR DESCRIPTION
## Description
This is an update for issue #1700 and it also fixes some issues that I found when playing around with the `INTERNAL_API_KEY` in cypress and issues it was causing. It appears that the `isAuthenticated` attribute that we use in the `auth` middleware, which is then passed out to the server/worker, is actually a function provided by passport. I moved things around a little bit in the middleware so that it was never doing `!ctx.isAuthenticated` during the middleware itself, once the middleware is finished processing it just sets `isAuthenticated = authenticated` and on exit of middleware it is simply a boolean, this fits in with how the rest of the system expects it to be.

