### PR TITLE
prevent portal link from navigating in builder preview

### DIFF
--- a/packages/standard-components/src/Layout.svelte
+++ b/packages/standard-components/src/Layout.svelte
@@ -2,7 +2,7 @@
   import { getContext } from "svelte"
   import { Heading, Icon } from "@budibase/bbui"
 
-  const { styleable, linkable } = getContext("sdk")
+  const { styleable, linkable, builderStore } = getContext("sdk")
   const component = getContext("component")
 
   export let title
@@ -41,6 +41,11 @@
   const close = () => {
     mobileOpen = false
   }
+
+  const navigateToPortal = () => {
+    if ($builderStore.inBuilder) return
+    window.location.href = "/builder/apps"
+  }
 </script>
 
 <div class="layout layout--{typeClass}" use:styleable={$component.styles}>
@@ -72,7 +77,7 @@
             <Icon
               hoverable
               name="Apps"
-              on:click={() => (window.location.href = "/builder/apps")}
+              on:click={navigateToPortal}
             />
           </div>
         </div>

--- a/packages/standard-components/src/Layout.svelte
+++ b/packages/standard-components/src/Layout.svelte
@@ -74,11 +74,7 @@
             {/if}
           </div>
           <div class="portal">
-            <Icon
-              hoverable
-              name="Apps"
-              on:click={navigateToPortal}
-            />
+            <Icon hoverable name="Apps" on:click={navigateToPortal} />
           </div>
         </div>
         <div


### PR DESCRIPTION
## Description
Small fix to prevent app portal link in apps from taking you to the portal inside the app preview.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



