### PR TITLE
Add global debug configs for single project debugging + readme instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -126,7 +126,16 @@ To run the budibase server and builder in dev mode (i.e. with live reloading):
 
 This will enable watch mode for both the builder app, server, client library and any component libraries.
 
-### 5. Cleanup
+### 5. Debugging using VS Code
+
+To debug the budibase server and worker a VS Code launch configuration has been provided. 
+
+Visit the debug window and select `Budibase Server` or `Budibase Worker` to debug the respective component. 
+Alternatively to start both components simultaneously select `Start Budibase`.
+
+In addition to the above, the remaining budibase components may be ran in dev mode using: `yarn dev:noserver`.
+
+### 6. Cleanup
 
 If you wish to delete all the apps created in development and reset the environment then run the following:
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,27 @@
             "args": [],
             "cwd":"C:/code/my-apps",
             "console": "externalTerminal" 
+        },
+        {
+            "name": "Budibase Server",
+            "type": "node",
+            "request": "launch",
+            "runtimeArgs": ["--nolazy", "-r", "ts-node/register/transpile-only"],
+            "args": ["${workspaceFolder}/packages/server/src/index.ts"],
+            "cwd": "${workspaceFolder}/packages/server"
+          },
+          {
+            "name": "Budibase Worker",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceFolder}/packages/worker/src/index.js",
+            "cwd": "${workspaceFolder}/packages/worker"
+          }
+    ],
+    "compounds": [
+        {
+          "name": "Start Budibase",
+          "configurations": ["Budibase Server", "Budibase Worker"]
         }
     ]
 }


### PR DESCRIPTION
## Description
I believe to debug these components currently a vscode instance must be used per sub folder. Add global launch configurations for running the worker and server from a single VS Code instance. 

Add debug details to the contributing guide

## Screenshots

In the debug selection:
![Screenshot 2021-07-02 at 13 31 25](https://user-images.githubusercontent.com/8755148/124275646-ba975c80-db3a-11eb-934f-671601ac1163.png)

When running:
![Screenshot 2021-07-02 at 13 31 38](https://user-images.githubusercontent.com/8755148/124275676-c4b95b00-db3a-11eb-9d01-926479247ba5.png)





