### PR TITLE
Fixing issue with SQL _id field

### DIFF
--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -37,7 +37,7 @@ export function breakRowIdField(_id: string) {
   }
   // have to replace on the way back as we swapped out the double quotes
   // when encoding, but JSON can't handle the single quotes
-  const decoded = decodeURIComponent(_id).replace(/'/g, "\"")
+  const decoded = decodeURIComponent(_id).replace(/'/g, '"')
   const parsed = JSON.parse(decoded)
   return Array.isArray(parsed) ? parsed : [parsed]
 }

--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -25,6 +25,8 @@ export function generateRowIdField(keyProps: any[] = []) {
     keyProps = [keyProps]
   }
   // this conserves order and types
+  // we have to swap the double quotes to single quotes for use in HBS statements
+  // when using the literal helper the double quotes can break things
   return encodeURIComponent(JSON.stringify(keyProps).replace(/"/g, "'"))
 }
 
@@ -33,7 +35,11 @@ export function breakRowIdField(_id: string) {
   if (!_id) {
     return null
   }
-  return JSON.parse(decodeURIComponent(_id))
+  // have to replace on the way back as we swapped out the double quotes
+  // when encoding, but JSON can't handle the single quotes
+  const decoded = decodeURIComponent(_id).replace(/'/g, "\"")
+  const parsed = JSON.parse(decoded)
+  return Array.isArray(parsed) ? parsed : [parsed]
 }
 
 export function convertType(type: string, map: { [key: string]: any }) {


### PR DESCRIPTION
## Description
Issue discovered with string primary keys, for the purposes of compatibility with HBS we replaced double quotes with single quotes, however this breaks JSON parsing, so need to swap it back when decoding.
