### PR TITLE
SQL Auto columns

### DIFF
--- a/packages/builder/src/components/backend/DataTable/DataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/DataTable.svelte
@@ -72,9 +72,7 @@
     {#if isUsersTable}
       <EditRolesButton />
     {/if}
-    {#if isInternal}
-      <HideAutocolumnButton bind:hideAutocolumns />
-    {/if}
+    <HideAutocolumnButton bind:hideAutocolumns />
     <!-- always have the export last -->
     <ExportButton view={$tables.selected?._id} />
   {/if}

--- a/packages/server/scripts/integrations/mysql/init.sql
+++ b/packages/server/scripts/integrations/mysql/init.sql
@@ -1,9 +1,22 @@
 CREATE DATABASE IF NOT EXISTS main;
 USE main;
 CREATE TABLE Persons (
-    PersonID int NOT NULL PRIMARY KEY,
+    PersonID int NOT NULL AUTO_INCREMENT,
     LastName varchar(255),
     FirstName varchar(255),
     Address varchar(255),
-    City varchar(255)
+    City varchar(255),
+    PRIMARY KEY (PersonID)
 );
+CREATE TABLE Tasks (
+    TaskID int NOT NULL AUTO_INCREMENT,
+    PersonID INT,
+    TaskName varchar(255),
+    PRIMARY KEY (TaskID),
+    CONSTRAINT fkPersons
+        FOREIGN KEY(PersonID)
+	    REFERENCES Persons(PersonID)
+);
+INSERT INTO Persons (FirstName, LastName, Address, City) VALUES ('Mike', 'Hughes', '123 Fake Street', 'Belfast');
+INSERT INTO Tasks (PersonID, TaskName) VALUES (1, 'assembling');
+INSERT INTO Tasks (PersonID, TaskName) VALUES (1, 'processing');

--- a/packages/server/scripts/integrations/mysql/reset.sh
+++ b/packages/server/scripts/integrations/mysql/reset.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker-compose down
+docker volume prune -f

--- a/packages/server/scripts/integrations/postgres/init.sql
+++ b/packages/server/scripts/integrations/postgres/init.sql
@@ -1,14 +1,14 @@
 SELECT 'CREATE DATABASE main'
 WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'main')\gexec
 CREATE TABLE Persons (
-    PersonID INT NOT NULL PRIMARY KEY,
+    PersonID SERIAL PRIMARY KEY,
     LastName varchar(255),
     FirstName varchar(255),
     Address varchar(255),
-    City varchar(255)
+    City varchar(255) DEFAULT 'Belfast'
 );
 CREATE TABLE Tasks (
-    TaskID INT NOT NULL PRIMARY KEY,
+    TaskID SERIAL PRIMARY KEY,
     PersonID INT,
     TaskName varchar(255),
     CONSTRAINT fkPersons
@@ -16,7 +16,7 @@ CREATE TABLE Tasks (
 	    REFERENCES Persons(PersonID)
 );
 CREATE TABLE Products (
-    ProductID INT NOT NULL PRIMARY KEY,
+    ProductID SERIAL PRIMARY KEY,
     ProductName varchar(255)
 );
 CREATE TABLE Products_Tasks (
@@ -30,12 +30,12 @@ CREATE TABLE Products_Tasks (
 	    REFERENCES Tasks(TaskID),
     PRIMARY KEY (ProductID, TaskID)
 );
-INSERT INTO Persons (PersonID, FirstName, LastName, Address, City) VALUES (1, 'Mike', 'Hughes', '123 Fake Street', 'Belfast');
-INSERT INTO Tasks (TaskID, PersonID, TaskName) VALUES (1, 1, 'assembling');
-INSERT INTO Tasks (TaskID, PersonID, TaskName) VALUES (2, 1, 'processing');
-INSERT INTO Products (ProductID, ProductName) VALUES (1, 'Computers');
-INSERT INTO Products (ProductID, ProductName) VALUES (2, 'Laptops');
-INSERT INTO Products (ProductID, ProductName) VALUES (3, 'Chairs');
+INSERT INTO Persons (FirstName, LastName, Address, City) VALUES ('Mike', 'Hughes', '123 Fake Street', 'Belfast');
+INSERT INTO Tasks (PersonID, TaskName) VALUES (1, 'assembling');
+INSERT INTO Tasks (PersonID, TaskName) VALUES (1, 'processing');
+INSERT INTO Products (ProductName) VALUES ('Computers');
+INSERT INTO Products (ProductName) VALUES ('Laptops');
+INSERT INTO Products (ProductName) VALUES ('Chairs');
 INSERT INTO Products_Tasks (ProductID, TaskID) VALUES (1, 1);
 INSERT INTO Products_Tasks (ProductID, TaskID) VALUES (2, 1);
 INSERT INTO Products_Tasks (ProductID, TaskID) VALUES (3, 1);

--- a/packages/server/src/definitions/common.ts
+++ b/packages/server/src/definitions/common.ts
@@ -14,6 +14,7 @@ export interface FieldSchema {
   relationshipType?: string
   through?: string
   foreignKey?: string
+  autocolumn?: boolean
   constraints?: {
     type?: string
     email?: boolean

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -169,7 +169,10 @@ module MySQLModule {
           const constraints = {
             presence: column.Null !== "YES",
           }
-          const isAuto: boolean = typeof column.Extra === "string" && (column.Extra === "auto_increment" || column.Extra.toLowerCase().includes("generated"))
+          const isAuto: boolean =
+            typeof column.Extra === "string" &&
+            (column.Extra === "auto_increment" ||
+              column.Extra.toLowerCase().includes("generated"))
           schema[columnName] = {
             name: columnName,
             autocolumn: isAuto,

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -169,8 +169,10 @@ module MySQLModule {
           const constraints = {
             presence: column.Null !== "YES",
           }
+          const isAuto: boolean = typeof column.Extra === "string" && (column.Extra === "auto_increment" || column.Extra.toLowerCase().includes("generated"))
           schema[columnName] = {
             name: columnName,
+            autocolumn: isAuto,
             type: convertType(column.Type, TYPE_MAP),
             constraints,
           }

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -184,7 +184,9 @@ module PostgresModule {
         }
 
         const type: string = convertType(column.data_type, TYPE_MAP)
+        const isAuto: boolean = typeof column.column_default === "string" && column.column_default.startsWith("nextval")
         tables[tableName].schema[columnName] = {
+          autocolumn: isAuto,
           name: columnName,
           type,
         }

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -184,7 +184,9 @@ module PostgresModule {
         }
 
         const type: string = convertType(column.data_type, TYPE_MAP)
-        const isAuto: boolean = typeof column.column_default === "string" && column.column_default.startsWith("nextval")
+        const isAuto: boolean =
+          typeof column.column_default === "string" &&
+          column.column_default.startsWith("nextval")
         tables[tableName].schema[columnName] = {
           autocolumn: isAuto,
           name: columnName,


### PR DESCRIPTION
## Description
This was mentioned by Sypher, if auto-increment is enabled on a column we already have a mechanism for handling this, its just an auto column to Budibase. This may not be 100% full proof, but thought it would be a good idea to try and catch it, this definitely catches the methods that I could think of/find in my research for sequences/serial in Postgres and auto increment/generated columns in MySQL.

I also updated the Postgres/MySQL examples to use auto-incrementing IDs since this is the way they should be configured (if they were real databases).

This doesn't affect the backend at all since the rows API as under the hood nothing in the external rows API is looking for the `autocolumn: true` attribute on a column schema, this is purely for the sake of the frontend and automatically hiding/removing the ID from forms (or making it readonly).

## Screenshots
Person ID has been marked as an auto column, can see it with the magic icon.
![image](https://user-images.githubusercontent.com/4407001/124503557-bd55b400-ddbd-11eb-8315-ae003dc62d31.png)