### PR TITLE
Empty layout tweaks

### DIFF
--- a/packages/standard-components/manifest.json
+++ b/packages/standard-components/manifest.json
@@ -31,7 +31,7 @@
         "type": "select",
         "label": "Width",
         "key": "width",
-        "options": ["Small", "Medium", "Large"],
+        "options": ["Small", "Medium", "Large", "Max"],
         "defaultValue": "Large"
       },
       {

--- a/packages/standard-components/src/Layout.svelte
+++ b/packages/standard-components/src/Layout.svelte
@@ -20,6 +20,7 @@
     None: "none",
   }
   const widthClasses = {
+    Max: "max",
     Large: "l",
     Medium: "m",
     Small: "s",
@@ -178,6 +179,9 @@
     position: relative;
     padding: 32px;
   }
+  .layout--none .main {
+    padding: 0;
+  }
   .size--s {
     width: 800px;
   }
@@ -186,6 +190,9 @@
   }
   .size--l {
     width: 1400px;
+  }
+  .size--max {
+    width: 100%;
   }
 
   /*  Nav components */


### PR DESCRIPTION
Just quickly firing this up while it's fresh in my memory. Can look at it again on Monday.

Sergey made a valid point that empty layouts still don't let you easily create custom navigation bars since there is built in padding. I think it makes sense to remove the built in padding from empty layouts, and also allow layout content to be full width via a new size option "Max".

![image](https://user-images.githubusercontent.com/9075550/125160705-539b2880-e176-11eb-90c4-015f558b9b2e.png)
