### PR TITLE
Fixing issues seen with numbers/dates in MySQL

### DIFF
--- a/packages/server/scripts/integrations/mysql/init.sql
+++ b/packages/server/scripts/integrations/mysql/init.sql
@@ -2,6 +2,7 @@ CREATE DATABASE IF NOT EXISTS main;
 USE main;
 CREATE TABLE Persons (
     PersonID int NOT NULL AUTO_INCREMENT,
+    CreatedAt datetime,
     LastName varchar(255),
     FirstName varchar(255),
     Address varchar(255),
@@ -17,6 +18,6 @@ CREATE TABLE Tasks (
         FOREIGN KEY(PersonID)
 	    REFERENCES Persons(PersonID)
 );
-INSERT INTO Persons (FirstName, LastName, Address, City) VALUES ('Mike', 'Hughes', '123 Fake Street', 'Belfast');
+INSERT INTO Persons (FirstName, LastName, Address, City, CreatedAt) VALUES ('Mike', 'Hughes', '123 Fake Street', 'Belfast', '2021-01-19 03:14:07');
 INSERT INTO Tasks (PersonID, TaskName) VALUES (1, 'assembling');
 INSERT INTO Tasks (PersonID, TaskName) VALUES (1, 'processing');

--- a/packages/server/scripts/integrations/mysql/init.sql
+++ b/packages/server/scripts/integrations/mysql/init.sql
@@ -3,6 +3,7 @@ USE main;
 CREATE TABLE Persons (
     PersonID int NOT NULL AUTO_INCREMENT,
     CreatedAt datetime,
+    Age float,
     LastName varchar(255),
     FirstName varchar(255),
     Address varchar(255),
@@ -18,6 +19,6 @@ CREATE TABLE Tasks (
         FOREIGN KEY(PersonID)
 	    REFERENCES Persons(PersonID)
 );
-INSERT INTO Persons (FirstName, LastName, Address, City, CreatedAt) VALUES ('Mike', 'Hughes', '123 Fake Street', 'Belfast', '2021-01-19 03:14:07');
+INSERT INTO Persons (FirstName, LastName, Age, Address, City, CreatedAt) VALUES ('Mike', 'Hughes', 28.2, '123 Fake Street', 'Belfast', '2021-01-19 03:14:07');
 INSERT INTO Tasks (PersonID, TaskName) VALUES (1, 'assembling');
 INSERT INTO Tasks (PersonID, TaskName) VALUES (1, 'processing');

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -29,6 +29,7 @@ module MySQLModule {
     blob: FieldTypes.LONGFORM,
     enum: FieldTypes.STRING,
     varchar: FieldTypes.STRING,
+    float: FieldTypes.NUMBER,
     int: FieldTypes.NUMBER,
     numeric: FieldTypes.NUMBER,
     bigint: FieldTypes.NUMBER,

--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -68,3 +68,11 @@ export function isSQL(datasource: Datasource): boolean {
   const SQL = [SourceNames.POSTGRES, SourceNames.SQL_SERVER, SourceNames.MYSQL]
   return SQL.indexOf(datasource.source) !== -1
 }
+
+export function isIsoDateString(str: string) {
+  if (!/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(str)) {
+    return false
+  }
+  let d = new Date(str)
+  return d.toISOString() === str
+}


### PR DESCRIPTION
## Description
Fixing some issues discovered with the new SQL connectors were the input type would always be string (causing some SQL types to break) - parsing these before input to attempt to fix this problem - issue referenced in #1943.

This is purely an internal tweak, as a lot of our form elements send up strings (e.g. ISO strings for dates) internally this looks for anything that might be a number or date and converts it. This way Knex can work out what this means to the SQL database itself and parse in the correct format based on the input type.