### PR TITLE
Update row automation action fix

### DIFF
--- a/packages/server/src/automations/steps/updateRow.js
+++ b/packages/server/src/automations/steps/updateRow.js
@@ -76,7 +76,10 @@ module.exports.run = async function ({ inputs, appId, emitter }) {
       rowId: inputs.rowId,
     },
     request: {
-      body: inputs.row,
+      body: {
+        ...inputs.row,
+        _id: inputs.rowId,
+      },
     },
     appId,
     eventEmitter: emitter,


### PR DESCRIPTION
## Description
After the SQL rows API update there was some minor changes that were breaking the update row action, fixing this.



