### PR TITLE
Fix select icons

### DIFF
--- a/packages/bbui/src/Form/Core/Picker.svelte
+++ b/packages/bbui/src/Form/Core/Picker.svelte
@@ -18,7 +18,7 @@
   export let onSelectOption = () => {}
   export let getOptionLabel = option => option
   export let getOptionValue = option => option
-  export let getOptionIcon = null
+  export let getOptionIcon = () => null
   export let open = false
   export let readonly = false
   export let quiet = false
@@ -45,7 +45,7 @@
 >
   {#if fieldIcon}
     <span class="icon-Placeholder-Padding">
-      <img src={fieldIcon} alt="Picker Icon" width="20" height="15" />
+      <img src={fieldIcon} alt="icon" width="20" height="15" />
     </span>
   {/if}
 
@@ -115,7 +115,7 @@
               <span class="icon-Padding">
                 <img
                   src={getOptionIcon(option, idx)}
-                  alt="test"
+                  alt="icon"
                   width="20"
                   height="15"
                 />

--- a/packages/bbui/src/Form/Core/Select.svelte
+++ b/packages/bbui/src/Form/Core/Select.svelte
@@ -10,7 +10,7 @@
   export let options = []
   export let getOptionLabel = option => option
   export let getOptionValue = option => option
-  export let getOptionIcon = null
+  export let getOptionIcon = () => null
   export let readonly = false
   export let quiet = false
   export let autoWidth = false

--- a/packages/builder/src/constants/backend/index.js
+++ b/packages/builder/src/constants/backend/index.js
@@ -1,7 +1,6 @@
 export const FIELDS = {
   STRING: {
     name: "Text",
-    icon: "ri-text",
     type: "string",
     constraints: {
       type: "string",
@@ -11,7 +10,6 @@ export const FIELDS = {
   },
   LONGFORM: {
     name: "Long Form Text",
-    icon: "ri-file-text-line",
     type: "longform",
     constraints: {
       type: "string",
@@ -21,7 +19,6 @@ export const FIELDS = {
   },
   OPTIONS: {
     name: "Options",
-    icon: "ri-list-check-2",
     type: "options",
     constraints: {
       type: "string",
@@ -31,7 +28,6 @@ export const FIELDS = {
   },
   NUMBER: {
     name: "Number",
-    icon: "ri-number-1",
     type: "number",
     constraints: {
       type: "number",
@@ -41,7 +37,6 @@ export const FIELDS = {
   },
   BOOLEAN: {
     name: "Boolean",
-    icon: "ri-toggle-line",
     type: "boolean",
     constraints: {
       type: "boolean",
@@ -50,7 +45,6 @@ export const FIELDS = {
   },
   DATETIME: {
     name: "Date/Time",
-    icon: "ri-calendar-event-fill",
     type: "datetime",
     constraints: {
       type: "string",
@@ -64,7 +58,6 @@ export const FIELDS = {
   },
   ATTACHMENT: {
     name: "Attachment",
-    icon: "ri-file-line",
     type: "attachment",
     constraints: {
       type: "array",
@@ -73,7 +66,6 @@ export const FIELDS = {
   },
   LINK: {
     name: "Relationship",
-    icon: "ri-link",
     type: "link",
     constraints: {
       type: "array",
@@ -82,7 +74,6 @@ export const FIELDS = {
   },
   FORMULA: {
     name: "Formula",
-    icon: "ri-braces-line",
     type: "formula",
     constraints: {
       type: "string",


### PR DESCRIPTION
## Description
This is a quick fix for some issues with the new icon functionality in selects. I had raised these issues in the OIDC PR but I was off for a few days and didn't see the merge, so some wee things must have just got lost in the review comments.

In short - the `getOptionIcon` default prop needs to be a function as it is invoked without checking for being nullish. Currently the default is just `null` in the core Select and Picker components, which means any direct usage of these will throw a JS error as soon as a value is picked. This is most evident from the client apps, where it's no longer possible to use an `options` or `relationship` field. All I've done is change the default prop to be what I had suggested in the review, `() => null`.

The other quick fix is that because icons are shown by default for any object which have an `icon` property, icons were trying to appear when creating a new column, as shown here:
![image](https://user-images.githubusercontent.com/9075550/126499432-6c5f98e1-86cc-4f0a-a7b6-f782f93594b0.png)

This is because the definition of these options include `icon` properties for some reason (and old remix icons, at that), which is likely just a leftover remnant from a previous feature. I've just removed the `icon` property from the definition to prevent the select from attempting to render invalid icons.

I've also updated the `alt` description of the icons to be shorter and more generic, but hopefully this never gets displayed again anyway.

