### PR TITLE
set app theme when creating the app, and use it in the client

### DIFF
--- a/packages/builder/src/builderStore/store/theme.js
+++ b/packages/builder/src/builderStore/store/theme.js
@@ -1,10 +1,16 @@
 import { localStorageStore } from "./localStorage"
+import { SPECTRUM_THEMES } from "../../constants";
 
 export const getThemeStore = () => {
   const themeElement = document.documentElement
   const initialValue = {
-    theme: "darkest",
-    options: ["lightest", "light", "dark", "darkest"],
+    theme: SPECTRUM_THEMES.DARKEST,
+    options: [
+      SPECTRUM_THEMES.LIGHTER,
+      SPECTRUM_THEMES.LIGHT,
+      SPECTRUM_THEMES.DARK,
+      SPECTRUM_THEMES.DARKEST
+    ],
   }
   const store = localStorageStore("bb-theme", initialValue)
 

--- a/packages/builder/src/components/start/CreateAppModal.svelte
+++ b/packages/builder/src/components/start/CreateAppModal.svelte
@@ -7,18 +7,20 @@
     Dropzone,
     Body,
     Checkbox,
+    Select
   } from "@budibase/bbui"
-  import { store, automationStore, hostingStore } from "builderStore"
+  import { store, automationStore, hostingStore, themeStore } from "builderStore"
   import { string, mixed, object } from "yup"
   import api, { get, post } from "builderStore/api"
   import analytics from "analytics"
   import { onMount } from "svelte"
   import { capitalise } from "helpers"
   import { goto } from "@roxi/routify"
+  import { SPECTRUM_THEMES } from "../../constants";
 
   export let template
 
-  const values = writable({ name: null })
+  const values = writable({ name: null, theme: SPECTRUM_THEMES.LIGHT })
   const errors = writable({})
   const touched = writable({})
   const validator = {
@@ -75,6 +77,7 @@
       let data = new FormData()
       data.append("name", $values.name)
       data.append("useTemplate", template != null)
+      data.append("theme", $values.theme)
       if (template) {
         data.append("templateName", template.name)
         data.append("templateKey", template.key)
@@ -148,6 +151,13 @@
     error={$touched.name && $errors.name}
     on:blur={() => ($touched.name = true)}
     label="Name"
+  />
+  <Select
+    label="App theme"
+    options={$themeStore.options}
+    bind:value={$values.theme}
+    placeholder={null}
+    getOptionLabel={capitalise}
   />
   <Checkbox label="Group access" disabled value={true} text="All users" />
 </ModalContent>

--- a/packages/builder/src/constants/index.js
+++ b/packages/builder/src/constants/index.js
@@ -33,3 +33,10 @@ export const LAYOUT_NAMES = {
 }
 
 export const BUDIBASE_INTERNAL_DB = "bb_internal"
+
+export const SPECTRUM_THEMES = {
+  LIGHTER: "lighter",
+  LIGHT: "light",
+  DARK: "dark",
+  DARKEST: "darkest"
+}

--- a/packages/client/src/api/app.js
+++ b/packages/client/src/api/app.js
@@ -8,3 +8,12 @@ export const fetchAppDefinition = async appId => {
     url: `/api/applications/${appId}/definition`,
   })
 }
+
+/* Fetches application package */
+export const fetchAppPackage = async appId => {
+  return await API.get({
+    url: `/api/applications/${appId}/appPackage`,
+  })
+}
+
+

--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -13,6 +13,7 @@
     authStore,
     routeStore,
     builderStore,
+    appStore,
   } from "../store"
   import { TableNames, ActionTypes } from "../constants"
   import SettingsBar from "./preview/SettingsBar.svelte"
@@ -77,7 +78,7 @@
     id="spectrum-root"
     lang="en"
     dir="ltr"
-    class="spectrum spectrum--medium spectrum--light"
+    class="spectrum spectrum--medium spectrum--{$appStore.theme}"
   >
     {#if permissionError}
       <div class="error">

--- a/packages/client/src/store/app.js
+++ b/packages/client/src/store/app.js
@@ -1,0 +1,19 @@
+import { get, writable } from "svelte/store";
+import * as API from "../api";
+import { builderStore } from "./builder";
+
+const createAppStore = () => {
+  const store = writable(null);
+
+  const fetchPackage = async () => {
+    const appDefinition = await API.fetchAppPackage(get(builderStore).appId)
+    store.set(appDefinition.application);
+  }
+
+  return {
+    subscribe: store.subscribe,
+    actions: { fetchPackage },
+  }
+}
+
+export const appStore = createAppStore()

--- a/packages/client/src/store/index.js
+++ b/packages/client/src/store/index.js
@@ -5,6 +5,7 @@ export { screenStore } from "./screens"
 export { builderStore } from "./builder"
 export { dataSourceStore } from "./dataSource"
 export { confirmationStore } from "./confirmation"
+export { appStore } from "./app"
 
 // Context stores are layered and duplicated, so it is not a singleton
 export { createContextStore } from "./context"

--- a/packages/client/src/store/initialise.js
+++ b/packages/client/src/store/initialise.js
@@ -1,7 +1,9 @@
 import { routeStore } from "./routes"
 import { screenStore } from "./screens"
+import { appStore } from "./app";
 
 export async function initialise() {
   await routeStore.actions.fetchRoutes()
   await screenStore.actions.fetchScreens()
+  await appStore.actions.fetchPackage()
 }

--- a/packages/server/src/api/controllers/application.js
+++ b/packages/server/src/api/controllers/application.js
@@ -172,7 +172,7 @@ exports.fetchAppPackage = async function (ctx) {
 }
 
 exports.create = async function (ctx) {
-  const { useTemplate, templateKey } = ctx.request.body
+  const { useTemplate, templateKey, theme } = ctx.request.body
   const instanceConfig = {
     useTemplate,
     key: templateKey,
@@ -204,6 +204,7 @@ exports.create = async function (ctx) {
     url: url,
     template: ctx.request.body.template,
     instance: instance,
+    theme,
     updatedAt: new Date().toISOString(),
     createdAt: new Date().toISOString(),
   }


### PR DESCRIPTION
## Description
Fixes issue #1847
The user is now able to select a spectrum theme when creating a new app. This theme is stored inside the app metadata in the backend and used in the client. 

## Components
### CreateAppModal
A select has been added to the CreateAppModal, in order to define the theme for the new app. The default style is "light", which is selected by default. The select is identical to the theme selector for the builder, and uses the same $themeStore.options.
![image](https://user-images.githubusercontent.com/1907152/126657023-d6310736-7226-4d88-842a-6eac22a3e7ad.png)

### ClientApp
In order to use the selected theme in the client, a new store is added, the app store, which contains the meta data of the current app. This metadata is loaded on initialise. When the client is loaded, the theme class is added to the spectrum-root.



