### PR TITLE
Fix lucene filtering

### DIFF
--- a/packages/auth/constants.js
+++ b/packages/auth/constants.js
@@ -1,0 +1,1 @@
+module.exports = require("./src/constants")

--- a/packages/auth/src/constants.js
+++ b/packages/auth/src/constants.js
@@ -8,6 +8,13 @@ exports.Cookies = {
   Auth: "budibase:auth",
 }
 
+exports.Headers = {
+  API_KEY: "x-budibase-api-key",
+  API_VER: "x-budibase-api-version",
+  APP_ID: "x-budibase-app-id",
+  TYPE: "x-budibase-type",
+}
+
 exports.GlobalRoles = {
   OWNER: "owner",
   ADMIN: "admin",

--- a/packages/auth/src/utils.js
+++ b/packages/auth/src/utils.js
@@ -8,6 +8,7 @@ const jwt = require("jsonwebtoken")
 const { options } = require("./middleware/passport/jwt")
 const { createUserEmailView } = require("./db/views")
 const { getDB } = require("./db")
+const { Headers } = require("./constants")
 
 const APP_PREFIX = DocumentTypes.APP + SEPARATOR
 
@@ -23,7 +24,7 @@ function confirmAppId(possibleAppId) {
  * @returns {string|undefined} If an appId was found it will be returned.
  */
 exports.getAppId = ctx => {
-  const options = [ctx.headers["x-budibase-app-id"], ctx.params.appId]
+  const options = [ctx.headers[Headers.APP_ID], ctx.params.appId]
   if (ctx.subdomains) {
     options.push(ctx.subdomains[1])
   }
@@ -102,7 +103,7 @@ exports.clearCookie = (ctx, name) => {
  * @return {boolean} returns true if the call is from the client lib (a built app rather than the builder).
  */
 exports.isClient = ctx => {
-  return ctx.headers["x-budibase-type"] === "client"
+  return ctx.headers[Headers.TYPE] === "client"
 }
 
 /**

--- a/packages/client/src/api/api.js
+++ b/packages/client/src/api/api.js
@@ -1,7 +1,9 @@
+import { notificationStore } from "../store"
+import { ApiVersion } from "../constants"
+
 /**
  * API cache for cached request responses.
  */
-import { notificationStore } from "../store"
 let cache = {}
 
 /**
@@ -22,6 +24,7 @@ const makeApiCall = async ({ method, url, body, json = true }) => {
     const headers = {
       Accept: "application/json",
       "x-budibase-app-id": window["##BUDIBASE_APP_ID##"],
+      "x-budibase-api-version": ApiVersion,
       ...(json && { "Content-Type": "application/json" }),
       ...(!inBuilder && { "x-budibase-type": "client" }),
     }

--- a/packages/client/src/constants.js
+++ b/packages/client/src/constants.js
@@ -7,3 +7,11 @@ export const ActionTypes = {
   RefreshDatasource: "RefreshDatasource",
   SetDataProviderQuery: "SetDataProviderQuery",
 }
+
+export const ApiVersion = "1"
+
+/**
+ * API Version Changelog
+ * v1:
+ *   - Coerce types for search endpoint
+ */

--- a/packages/server/src/api/controllers/row/internal.js
+++ b/packages/server/src/api/controllers/row/internal.js
@@ -278,6 +278,7 @@ exports.search = async ctx => {
   const { tableId } = ctx.params
   const db = new CouchDB(appId)
   const { paginate, query, ...params } = ctx.request.body
+  params.version = ctx.version
   params.tableId = tableId
 
   let response

--- a/packages/server/src/api/controllers/row/internalSearch.js
+++ b/packages/server/src/api/controllers/row/internalSearch.js
@@ -335,6 +335,7 @@ exports.paginatedSearch = async (appId, query, params) => {
   }
   limit = Math.min(limit, 200)
   const search = new QueryBuilder(appId, query)
+    .setVersion(params.version)
     .setTable(params.tableId)
     .setSort(params.sort)
     .setSortOrder(params.sortOrder)

--- a/packages/server/src/api/controllers/row/internalSearch.js
+++ b/packages/server/src/api/controllers/row/internalSearch.js
@@ -22,7 +22,7 @@ const preprocess = (
   }
 
   // Escape characters
-  if (options.escape) {
+  if (options.escape && originalType === "string") {
     value = `${value}`.replace(/[ #+\-&|!(){}\]^"~*?:\\]/g, "\\$&")
   }
 
@@ -136,7 +136,8 @@ class QueryBuilder {
     function build(structure, queryFn) {
       for (let [key, value] of Object.entries(structure)) {
         key = preprocess(key.replace(/ /, "_"), {
-          escape: true,
+          wrap: false,
+          lowercase: false,
         })
         const expression = queryFn(key, value)
         if (expression == null) {
@@ -152,10 +153,7 @@ class QueryBuilder {
         if (!value) {
           return null
         }
-        value = preprocess(value, {
-          escape: true,
-          lowercase: true,
-        })
+        value = preprocess(value)
         return `${key}:${value}*`
       })
     }
@@ -180,10 +178,7 @@ class QueryBuilder {
         if (!value) {
           return null
         }
-        value = preprocess(value, {
-          escape: true,
-          lowercase: true,
-        })
+        value = preprocess(value)
         return `${key}:${value}~`
       })
     }

--- a/packages/server/src/api/controllers/row/internalSearch.js
+++ b/packages/server/src/api/controllers/row/internalSearch.js
@@ -17,8 +17,8 @@ const preprocess = (
   const originalType = typeof value
 
   // Convert to lowercase
-  if (options.lowercase) {
-    value = value?.toLowerCase ? value.toLowerCase() : value
+  if (value && options.lowercase) {
+    value = value.toLowerCase ? value.toLowerCase() : value
   }
 
   // Escape characters

--- a/packages/server/src/api/controllers/row/internalSearch.js
+++ b/packages/server/src/api/controllers/row/internalSearch.js
@@ -28,6 +28,7 @@ class QueryBuilder {
 
   setVersion(version) {
     this.version = version
+    return this
   }
 
   setTable(tableId) {

--- a/packages/server/src/middleware/currentapp.js
+++ b/packages/server/src/middleware/currentapp.js
@@ -12,7 +12,12 @@ module.exports = async (ctx, next) => {
   // try to get the appID from the request
   const requestAppId = getAppId(ctx)
   // get app cookie if it exists
-  const appCookie = getCookie(ctx, Cookies.CurrentApp)
+  let appCookie = null
+  try {
+    appCookie = getCookie(ctx, Cookies.CurrentApp)
+  } catch (err) {
+    clearCookie(ctx, Cookies.CurrentApp)
+  }
   if (!appCookie && !requestAppId) {
     return next()
   }

--- a/packages/server/src/tests/utilities/TestConfiguration.js
+++ b/packages/server/src/tests/utilities/TestConfiguration.js
@@ -14,7 +14,7 @@ const {
 const controllers = require("./controllers")
 const supertest = require("supertest")
 const { cleanup } = require("../../utilities/fileSystem")
-const { Cookies } = require("@budibase/auth").constants
+const { Cookies, Headers } = require("@budibase/auth").constants
 const { jwt } = require("@budibase/auth").auth
 const { StaticDatabases } = require("@budibase/auth/db")
 const CouchDB = require("../../db")
@@ -118,7 +118,7 @@ class TestConfiguration {
       ],
     }
     if (this.appId) {
-      headers["x-budibase-app-id"] = this.appId
+      headers[Headers.APP_ID] = this.appId
     }
     return headers
   }
@@ -128,7 +128,7 @@ class TestConfiguration {
       Accept: "application/json",
     }
     if (this.appId) {
-      headers["x-budibase-app-id"] = this.appId
+      headers[Headers.APP_ID] = this.appId
     }
     return headers
   }
@@ -349,7 +349,7 @@ class TestConfiguration {
         `${Cookies.Auth}=${authToken}`,
         `${Cookies.CurrentApp}=${appToken}`,
       ],
-      "x-budibase-app-id": this.appId,
+      [Headers.APP_ID]: this.appId,
     }
   }
 }

--- a/packages/server/src/utilities/workerRequests.js
+++ b/packages/server/src/utilities/workerRequests.js
@@ -3,13 +3,14 @@ const env = require("../environment")
 const { checkSlashesInUrl } = require("./index")
 const { getDeployedAppID } = require("@budibase/auth/db")
 const { updateAppRole, getGlobalUser } = require("./global")
+const { Headers } = require("@budibase/auth/constants")
 
 function request(ctx, request, noApiKey) {
   if (!request.headers) {
     request.headers = {}
   }
   if (!noApiKey) {
-    request.headers["x-budibase-api-key"] = env.INTERNAL_API_KEY
+    request.headers[Headers.API_KEY] = env.INTERNAL_API_KEY
   }
   if (request.body && Object.keys(request.body).length > 0) {
     request.headers["Content-Type"] = "application/json"

--- a/packages/standard-components/src/lucene.js
+++ b/packages/standard-components/src/lucene.js
@@ -15,9 +15,15 @@ export const buildLuceneQuery = filter => {
   if (Array.isArray(filter)) {
     filter.forEach(expression => {
       let { operator, field, type, value } = expression
-      // Ensure date fields are transformed into ISO strings
+      // Parse all values into correct types
       if (type === "datetime" && value) {
         value = new Date(value).toISOString()
+      }
+      if (type === "number") {
+        value = parseFloat(value)
+      }
+      if (type === "boolean") {
+        value = value?.toLowerCase() === "true"
       }
       if (operator.startsWith("range")) {
         if (!query.range[field]) {
@@ -42,10 +48,10 @@ export const buildLuceneQuery = filter => {
           // Transform boolean filters to cope with null.
           // "equals false" needs to be "not equals true"
           // "not equals false" needs to be "equals true"
-          if (operator === "equal" && value === "false") {
-            query.notEqual[field] = "true"
-          } else if (operator === "notEqual" && value === "false") {
-            query.equal[field] = "true"
+          if (operator === "equal" && value === false) {
+            query.notEqual[field] = true
+          } else if (operator === "notEqual" && value === false) {
+            query.equal[field] = true
           } else {
             query[operator][field] = value
           }


### PR DESCRIPTION
## Description
This PR fixes a couple of issues with server side searching, particularly of internal tables using lucene. Lucene is very picky about what values should and should not be wrapped in quotes, and this PR wraps all required values and leaves other unwrapped. This also helps with server side searching of external SQL DB's as filter values are parsed to the correct type depending on the table schema before being sent to the server.

Fixes https://github.com/Budibase/budibase/issues/2038.
