### PR TITLE
Use tableId parameter when saving rows from button action

### DIFF
--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -4,13 +4,16 @@ import { saveRow, deleteRow, executeQuery, triggerAutomation } from "../api"
 import { ActionTypes } from "../constants"
 
 const saveRowHandler = async (action, context) => {
-  const { fields, providerId } = action.parameters
+  const { fields, providerId, tableId } = action.parameters
   if (providerId) {
     let draft = context[providerId]
     if (fields) {
       for (let [field, value] of Object.entries(fields)) {
         draft[field] = value
       }
+    }
+    if (tableId) {
+      draft.tableId = tableId
     }
     await saveRow(draft)
   }


### PR DESCRIPTION
## Description
This PR fixes an issue where the table ID parameter to the save row action was not being used.

Fixes #2039.
Issue #2040 is already fixed by existing work on develop, so that issue can be closed when develop is merged.

