### PR TITLE
Add lerna prereleases

### DIFF
--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -1,0 +1,52 @@
+name: Budibase Release
+
+on: 
+ push:
+    branches:
+      - develop
+
+env:
+  POSTHOG_TOKEN: ${{ secrets.POSTHOG_TOKEN }}
+  POSTHOG_URL: ${{ secrets.POSTHOG_URL }}
+  SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      
+jobs:
+  release:
+    runs-on: ubuntu-latest 
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - run: yarn 
+      - run: yarn bootstrap 
+      - run: yarn lint 
+      - run: yarn build 
+      - run: yarn test
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Publish budibase packages to NPM
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: | 
+          # setup the username and email. I tend to use 'GitHub Actions Bot' with no email by default
+          git config user.name "Budibase Release Bot"
+          git config user.email "<>"
+          echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} >> .npmrc 
+          yarn release:develop
+
+      - name: Build/release Docker images
+        run: | 
+          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+          yarn build
+          yarn build:docker
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -37,7 +37,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: | 
           # setup the username and email. I tend to use 'GitHub Actions Bot' with no email by default
-          git config user.name "Budibase Release Bot"
+          git config user.name "Budibase Staging Release Bot"
           git config user.email "<>"
           echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} >> .npmrc 
           yarn release:develop

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "publishdev": "lerna run publishdev",
     "publishnpm": "yarn build && lerna publish --force-publish",
     "release": "yarn build && lerna publish patch --yes --force-publish",
+    "release:develop": "yarn build && lerna publish prerelease --yes --force-publish --dist-tag develop",
     "restore": "yarn run clean && yarn run bootstrap && yarn run build",
     "nuke": "yarn run nuke:packages && yarn run nuke:docker",
     "nuke:packages": "yarn run restore",


### PR DESCRIPTION
## Description
Adding in a prerelease publish on the develop branch to publish packages to NPM. 

This uses the lerna prerelease functionality:
`lerna publish prerelease --yes --force-publish --dist-tag develop`

This will create a new version based on the current lerna version, adding a suffix `-alpha.0`, then `-alpha.1` and so on until the version is released. 


The tag in NPM has been updated to use `develop` in this scenario instead of the default `latest`. 
https://github.com/lerna/lerna/tree/main/commands/publish#--pre-dist-tag-tag

Example repo / package
- https://www.npmjs.com/package/@rpowell/lerna-npm-1
- https://github.com/Rory-Powell/lerna-npm

Example commit history:
![Screenshot 2021-07-22 at 17 18 31](https://user-images.githubusercontent.com/8755148/126673356-a2065129-4106-4f04-b465-cbc67ceadee6.png)
