### PR TITLE
Mark google activated by default for old configs

### DIFF
--- a/packages/server/src/api/routes/tests/misc.spec.js
+++ b/packages/server/src/api/routes/tests/misc.spec.js
@@ -31,7 +31,13 @@ describe("run misc tests", () => {
   describe("/version", () => {
     it("should confirm version", async () => {
       const res = await request.get("/version").expect(200)
-      expect(res.text.split(".").length).toEqual(3)
+      const text = res.text
+      if (text.includes("alpha")) {
+        expect(text.split(".").length).toEqual(4)
+      } else {
+        expect(text.split(".").length).toEqual(3)
+      }
+      
     })
   })
 

--- a/packages/worker/src/api/controllers/admin/configs.js
+++ b/packages/worker/src/api/controllers/admin/configs.js
@@ -149,16 +149,16 @@ exports.publicSettings = async function (ctx) {
       config = publicConfig
     }
 
-    config.config.google = !googleConfig
-      ? !!googleConfig
-      : !googleConfig.config.activated
-      ? false
-      : true
-    config.config.oidc = !oidcConfig
-      ? !!oidcConfig
-      : !oidcConfig.config.configs[0].activated
-      ? false
-      : true
+    // google button flag
+    const googleActivated =
+      googleConfig.config.activated == undefined || // activated by default for configs pre-activated flag
+      googleConfig.config.activated
+    config.config.google = !googleConfig ? false : googleActivated
+
+    // oidc button flag
+    const oidcActivated = !oidcConfig.config.configs[0].activated
+    config.config.oidc = !oidcConfig ? false : oidcActivated
+
     ctx.body = config
   } catch (err) {
     ctx.throw(err.status, err)


### PR DESCRIPTION
## Description
The google button was't showing in staging because the existing config did not have the enabled flag. 
Enable config by default when it does not exists as this is an old one.


