### PR TITLE
Fix/oidc fixes

### DIFF
--- a/packages/builder/src/pages/builder/portal/manage/auth/index.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/auth/index.svelte
@@ -217,6 +217,10 @@
       }
       originalGoogleDoc = cloneDeep(googleDoc)
     } else {
+      // default activated to true for older configs
+      if (googleDoc.config.activated === undefined) {
+        googleDoc.config.activated = true
+      }
       originalGoogleDoc = cloneDeep(googleDoc)
       providers.google = googleDoc
     }

--- a/packages/worker/src/api/controllers/admin/auth.js
+++ b/packages/worker/src/api/controllers/admin/auth.js
@@ -144,7 +144,9 @@ async function oidcStrategyFactory(ctx, configId) {
 
   const chosenConfig = config.configs.filter(c => c.uuid === configId)[0]
 
-  const callbackUrl = `${ctx.protocol}://${ctx.host}/api/admin/auth/oidc/callback`
+  // require https callback in production
+  const protocol = process.env.NODE_ENV === "production" ? "https" : "http"
+  const callbackUrl = `${protocol}://${ctx.host}/api/admin/auth/oidc/callback`
 
   return oidc.strategyFactory(chosenConfig, callbackUrl)
 }


### PR DESCRIPTION
## Description
Two fixes:
1. Require https on oidc callback in production
   - Previously we reused the scheme of the request to work out the protocol
   - Envoy relays traffic with http so the original https value was being dropped
   - oidc providers only allow http for localhost, so use a environment flag to set the protocol instead
2. Set the google auth form `activated` field to true when it doesn't exist
   - Existing configs were showing as activated false 



