### PR TITLE
Remove docker push from main CI job in favour of release-develop

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -42,15 +42,3 @@ jobs:
         name: codecov-umbrella
         verbose: true 
     - run: yarn test:e2e:ci
-
-    - name: Build and Push Development Docker Image
-      # Only run on push
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-      run: |
-        docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-        yarn build
-        yarn build:docker:develop
-      env:
-        DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}
-

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -1,4 +1,4 @@
-name: Budibase Release
+name: Budibase Release Staging
 
 on: 
  push:


### PR DESCRIPTION
## Description
Prerelease build for develop branch were added in
https://github.com/Budibase/budibase/pull/2066
https://github.com/Budibase/budibase/pull/2070

Update the main CI job to no longer push to dockerhub as this is being done also in 
https://github.com/Budibase/budibase/blob/develop/.github/workflows/release-develop.yml#L45


