### PR TITLE
Add dedicated renderer for roles tags

### DIFF
--- a/packages/builder/src/pages/builder/portal/manage/users/[userId].svelte
+++ b/packages/builder/src/pages/builder/portal/manage/users/[userId].svelte
@@ -19,7 +19,8 @@
   import { fetchData } from "helpers"
   import { users, auth } from "stores/portal"
 
-  import TagsRenderer from "./_components/TagsTableRenderer.svelte"
+  import TagsRenderer from "./_components/RolesTagsTableRenderer.svelte"
+
   import UpdateRolesModal from "./_components/UpdateRolesModal.svelte"
   import ForceResetPasswordModal from "./_components/ForceResetPasswordModal.svelte"
 

--- a/packages/builder/src/pages/builder/portal/manage/users/_components/RolesTagsTableRenderer.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/users/_components/RolesTagsTableRenderer.svelte
@@ -1,0 +1,8 @@
+<script>
+  import TagsTableRenderer from "./TagsTableRenderer.svelte"
+  export let value
+
+  $: roles = value?.filter(role => role != null).map(role => role.name) ?? []
+</script>
+
+<TagsTableRenderer value={roles} />

--- a/packages/builder/src/pages/builder/portal/manage/users/_components/TagsTableRenderer.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/users/_components/TagsTableRenderer.svelte
@@ -4,9 +4,9 @@
 
   const displayLimit = 5
 
-  $: roles = value?.filter(role => role != null).map(role => role.name) ?? []
-  $: tags = roles.slice(0, displayLimit)
-  $: leftover = roles.length - tags.length
+  $: values = value?.filter(value => value != null) ?? []
+  $: tags = values.slice(0, displayLimit)
+  $: leftover = values.length - tags.length
 </script>
 
 <div class="tag-renderer">


### PR DESCRIPTION
## Description
A regression was added in https://github.com/Budibase/budibase/pull/2078 that resulted in the group tag being rendered as `undefined`. This was caused by the tags renderer behaviour being changed to require an object instead of an array of values. The scenario where an object is required (nested `name` field in roles) has been brought out into its own component to perform custom logic and delegates to the basic tag renderer. 

## Screenshots
Before

<img width="611" alt="Screenshot 2021-07-25 at 21 17 20" src="https://user-images.githubusercontent.com/8755148/126912271-f11981e8-afe8-478f-923a-329a2109afd4.png">
<img width="653" alt="Screenshot 2021-07-25 at 21 17 26" src="https://user-images.githubusercontent.com/8755148/126912272-9b8bd7e6-6e99-4af1-9807-dfc98821eba8.png">

After
<img width="622" alt="Screenshot 2021-07-25 at 21 17 33" src="https://user-images.githubusercontent.com/8755148/126912275-abe686fd-a51a-46a5-bef8-bdb3b71ec6d6.png">
<img width="665" alt="Screenshot 2021-07-25 at 21 17 38" src="https://user-images.githubusercontent.com/8755148/126912276-9a6a4afd-1722-485b-9849-cfc3ec6662a6.png">




