### PR TITLE
Automate setup menu

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/automate/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/automate/_layout.svelte
@@ -58,5 +58,6 @@
     align-items: stretch;
     gap: var(--spacing-l);
     background-color: var(--background);
+    overflow-y: auto;
   }
 </style>


### PR DESCRIPTION
## Description
Fixes #1889 
When a table has more than 14 columns, the setup menu in the automations tab won't scroll. This PR fixes that.

## Screenshots
After:
![image](https://user-images.githubusercontent.com/1907152/126954405-298ff506-bd35-4862-8b44-aaac074f7d49.png)




