### PR TITLE
convert automation icons into toggle

### DIFF
--- a/packages/bbui/src/Form/Core/Switch.svelte
+++ b/packages/bbui/src/Form/Core/Switch.svelte
@@ -6,15 +6,18 @@
   export let id = null
   export let text = null
   export let disabled = false
+  export let dataCy = null
 
   const dispatch = createEventDispatcher()
   const onChange = event => {
     dispatch("change", event.target.checked)
   }
+
 </script>
 
 <div class="spectrum-Switch spectrum-Switch--emphasized">
   <input
+    data-cy={dataCy}
     checked={value}
     {disabled}
     on:change={onChange}

--- a/packages/bbui/src/Form/Core/Switch.svelte
+++ b/packages/bbui/src/Form/Core/Switch.svelte
@@ -12,7 +12,6 @@
   const onChange = event => {
     dispatch("change", event.target.checked)
   }
-
 </script>
 
 <div class="spectrum-Switch spectrum-Switch--emphasized">

--- a/packages/bbui/src/Form/Toggle.svelte
+++ b/packages/bbui/src/Form/Toggle.svelte
@@ -9,6 +9,7 @@
   export let text = null
   export let disabled = false
   export let error = null
+  export let dataCy = null
 
   const dispatch = createEventDispatcher()
   const onChange = e => {
@@ -18,5 +19,5 @@
 </script>
 
 <Field {label} {labelPosition} {error}>
-  <Switch {error} {disabled} {text} {value} on:change={onChange} />
+  <Switch {dataCy} {error} {disabled} {text} {value} on:change={onChange} />
 </Field>

--- a/packages/builder/cypress/integration/createAutomation.spec.js
+++ b/packages/builder/cypress/integration/createAutomation.spec.js
@@ -29,10 +29,10 @@ context("Create a automation", () => {
     cy.get(".setup").within(() => {
       cy.get(".spectrum-Picker-label").click()
       cy.contains("dog").click()
-      cy.get("input")
+      cy.get(".spectrum-Textfield-input")
         .first()
         .type("goodboy")
-      cy.get("input")
+      cy.get(".spectrum-Textfield-input")
         .eq(1)
         .type("11")
     })
@@ -41,7 +41,7 @@ context("Create a automation", () => {
     cy.contains("Save Automation").click()
 
     // Activate Automation
-    cy.get("[aria-label=PlayCircle]").click()
+    cy.get("[data-cy=activate-automation]").click()
   })
 
   it("should add row when a new row is added", () => {

--- a/packages/builder/src/components/automation/SetupPanel/SetupPanel.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/SetupPanel.svelte
@@ -15,7 +15,7 @@
     if (automationLive === live) {
       return
     }
-    automation.live = live;
+    automation.live = live
     automationStore.actions.save({ instanceId, automation })
     if (live) {
       notifications.info(`Automation ${automation.name} enabled.`)

--- a/packages/builder/src/components/automation/SetupPanel/SetupPanel.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/SetupPanel.svelte
@@ -1,7 +1,7 @@
 <script>
   import { automationStore } from "builderStore"
   import { database } from "stores/backend"
-  import { notifications, Icon, Button, Modal, Heading } from "@budibase/bbui"
+  import { notifications, Button, Modal, Heading, Toggle } from "@budibase/bbui"
   import AutomationBlockSetup from "./AutomationBlockSetup.svelte"
   import CreateWebookModal from "../Shared/CreateWebhookModal.svelte"
 
@@ -12,10 +12,10 @@
   $: automationLive = automation?.live
 
   function setAutomationLive(live) {
-    if (automation.live === live) {
+    if (automationLive === live) {
       return
     }
-    automation.live = live
+    automation.live = live;
     automationStore.actions.save({ instanceId, automation })
     if (live) {
       notifications.info(`Automation ${automation.name} enabled.`)
@@ -48,20 +48,11 @@
 
 <div class="title">
   <Heading size="S">Setup</Heading>
-  <Icon
-    l
-    disabled={!automationLive}
-    hoverable={automationLive}
-    name="PauseCircle"
-    on:click={() => setAutomationLive(false)}
-  />
-  <Icon
-    l
-    name="PlayCircle"
-    disabled={automationLive}
-    hoverable={!automationLive}
+  <Toggle
+    value={automationLive}
+    on:change={() => setAutomationLive(!automationLive)}
     data-cy="activate-automation"
-    on:click={() => setAutomationLive(true)}
+    text="Live"
   />
 </div>
 {#if $automationStore.selectedBlock}

--- a/packages/builder/src/components/automation/SetupPanel/SetupPanel.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/SetupPanel.svelte
@@ -51,7 +51,7 @@
   <Toggle
     value={automationLive}
     on:change={() => setAutomationLive(!automationLive)}
-    data-cy="activate-automation"
+    dataCy="activate-automation"
     text="Live"
   />
 </div>


### PR DESCRIPTION
## Description
Partly Fixes #2021. The issue is about a full redesign of the Automate page, this issue just addresses the tiny play/pause buttons, which it converts into a toggle.

## Screenshots
![image](https://user-images.githubusercontent.com/1907152/127154120-13834950-b11c-4ee4-a531-893274d606b8.png)




