### PR TITLE
Add watchtower hooks

### DIFF
--- a/packages/server/.gitignore
+++ b/packages/server/.gitignore
@@ -7,3 +7,4 @@ public/
 db/dev.db/
 dist
 coverage/
+watchtower-hook.json

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:12-alpine
 
+LABEL com.centurylinklabs.watchtower.lifecycle.pre-check="scripts/watchtower-hooks/pre-check.sh"
+LABEL com.centurylinklabs.watchtower.lifecycle.pre-update="scripts/watchtower-hooks/pre-update.sh"
+LABEL com.centurylinklabs.watchtower.lifecycle.post-update="scripts/watchtower-hooks/post-update.sh"
+LABEL com.centurylinklabs.watchtower.lifecycle.post-check="scripts/watchtower-hooks/post-check.sh"
+
 WORKDIR /app
 
 ENV PORT=4001

--- a/packages/server/scripts/watchtower-hooks/post-check.sh
+++ b/packages/server/scripts/watchtower-hooks/post-check.sh
@@ -1,0 +1,1 @@
+echo '{ "current-hook" : "post-check" }' > 'watchtower-hook.json'

--- a/packages/server/scripts/watchtower-hooks/post-update.sh
+++ b/packages/server/scripts/watchtower-hooks/post-update.sh
@@ -1,0 +1,1 @@
+echo '{ "current-hook" : "post-update" }' > 'watchtower-hook.json'

--- a/packages/server/scripts/watchtower-hooks/pre-check.sh
+++ b/packages/server/scripts/watchtower-hooks/pre-check.sh
@@ -1,0 +1,1 @@
+echo '{ "current-hook" : "pre-check" }' > 'watchtower-hook.json'

--- a/packages/server/scripts/watchtower-hooks/pre-update.sh
+++ b/packages/server/scripts/watchtower-hooks/pre-update.sh
@@ -1,0 +1,1 @@
+echo '{ "current-hook" : "pre-update" }' > 'watchtower-hook.json'

--- a/packages/worker/.gitignore
+++ b/packages/worker/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .env
+watchtower-hook.json

--- a/packages/worker/Dockerfile
+++ b/packages/worker/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:12-alpine
 
+LABEL com.centurylinklabs.watchtower.lifecycle.pre-check="scripts/watchtower-hooks/pre-check.sh"
+LABEL com.centurylinklabs.watchtower.lifecycle.pre-update="scripts/watchtower-hooks/pre-update.sh"
+LABEL com.centurylinklabs.watchtower.lifecycle.post-update="scripts/watchtower-hooks/post-update.sh"
+LABEL com.centurylinklabs.watchtower.lifecycle.post-check="scripts/watchtower-hooks/post-check.sh"
+
 WORKDIR /app
 
 # copy files and install dependencies

--- a/packages/worker/scripts/watchtower-hooks/post-check.sh
+++ b/packages/worker/scripts/watchtower-hooks/post-check.sh
@@ -1,0 +1,1 @@
+echo '{ "current-hook" : "post-check" }' > 'watchtower-hook.json'

--- a/packages/worker/scripts/watchtower-hooks/post-update.sh
+++ b/packages/worker/scripts/watchtower-hooks/post-update.sh
@@ -1,0 +1,1 @@
+echo '{ "current-hook" : "post-update" }' > 'watchtower-hook.json'

--- a/packages/worker/scripts/watchtower-hooks/pre-check.sh
+++ b/packages/worker/scripts/watchtower-hooks/pre-check.sh
@@ -1,0 +1,1 @@
+echo '{ "current-hook" : "pre-check" }' > 'watchtower-hook.json'

--- a/packages/worker/scripts/watchtower-hooks/pre-update.sh
+++ b/packages/worker/scripts/watchtower-hooks/pre-update.sh
@@ -1,0 +1,1 @@
+echo '{ "current-hook" : "pre-update" }' > 'watchtower-hook.json'


### PR DESCRIPTION
## Description
Add scripts that hook into the watchtower lifecycle when checking/updating a container. 
More details: https://containrrr.dev/watchtower/lifecycle-hooks/

Write to a new file `watchtower-hook.json` to indicate which hook has been executed most recently.
In future these scripts could evolve to do more or become node scripts. 

This enables follow up work to read the hook file via the api and provide a more responsive updates page.


