### PR TITLE
Fix for SQL relationship issue

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/CreateEditRelationship/CreateEditRelationship.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/CreateEditRelationship/CreateEditRelationship.svelte
@@ -158,10 +158,16 @@
         fieldName: fromTable.primary[0],
       }
     } else {
+      // the relateFrom.fieldName should remain the same, as it is the foreignKey in the other
+      // table, this is due to the way that budibase represents relationships, the fieldName in a
+      // link column schema is the column linked to (FK in this case). The foreignKey column is
+      // essentially what is linked to in the from table, this is unique to SQL as this isn't a feature
+      // of Budibase internal tables.
+      // Essentially this means the fieldName is what we are linking to in the other table, and the
+      // foreignKey is what is linking out of the current table.
       relateFrom = {
         ...relateFrom,
-        foreignKey: relateFrom.fieldName,
-        fieldName: fromTable.primary[0],
+        foreignKey: fromTable.primary[0],
       }
       relateTo = {
         ...relateTo,


### PR DESCRIPTION
## Description
Fix for issue #2167, the foreign key was not being set correctly in all scenarios for the from table in SQL relationships, our test data happened to hide this fact due to the foreign key and the key in from table having the same name.

Also included an explanation of the somewhat confusing structure that has to be used to replicate the structure used for Budibase internal relationships.