### PR TITLE
Allow app preview to handle garbage iframe messages

### DIFF
--- a/packages/builder/src/components/design/AppPreview/iframeTemplate.js
+++ b/packages/builder/src/components/design/AppPreview/iframeTemplate.js
@@ -47,6 +47,18 @@ export default `
           return
         }
 
+        // Parse received message
+        // If parsing fails, just ignore and wait for the next message
+        let parsed
+        try {
+          parsed = JSON.parse(event.data)
+        } catch (error) {
+          // Ignore
+        }
+        if (!parsed) {
+          return
+        }
+        
         // Extract data from message
         const {
           selectedComponentId,
@@ -55,7 +67,7 @@ export default `
           previewType,
           appId,
           theme
-        } = JSON.parse(event.data)
+        } = parsed
 
         // Set some flags so the app knows we're in the builder
         window["##BUDIBASE_IN_BUILDER##"] = true


### PR DESCRIPTION
## Description
This PR adds the ability for the app preview inside the iframe to handle garbage iframe messages. As desribed in https://github.com/Budibase/budibase/discussions/1979, certain browser extensions (Dashlane specifically in this case) seem to post messages to iframe elements for some reason, which causes the app preview to crash.

This adds the ability for the app preview to just ignore messages that are garbage, and wait for the real message from the builder, which should hopefully fix this issue. The real problem here lies with the browser extension, but maybe there's a valid reason for the strange behaviour so we may as well add in a quick fix to allow it.

Fixes #1979.
Fixes #1901 (hopefully).

Merging this straight into master as the incompatibility issue is live at the moment.

