### PR TITLE
Fix colour picker inconsistencies when app theme has never been changed

### DIFF
--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -70,7 +70,7 @@ export const getFrontendStore = () => {
         url: application.url,
         layouts,
         screens,
-        theme: application.theme,
+        theme: application.theme || "spectrum--light",
         hasAppPackage: true,
         appInstance: application.instance,
         clientLibPath,

--- a/packages/builder/src/components/design/AppPreview/AppThemeSelect.svelte
+++ b/packages/builder/src/components/design/AppPreview/AppThemeSelect.svelte
@@ -24,7 +24,7 @@
 
 <div>
   <Select
-    value={$store.theme || "spectrum--light"}
+    value={$store.theme}
     options={themeOptions}
     placeholder={null}
     on:change={e => store.actions.theme.save(e.detail)}


### PR DESCRIPTION
## Description
Fixes an issue with color pickers being inconsistent in new apps by ensuring a default app theme of "light" is globally set.
Closes #2219.


