### PR TITLE
add radio buttons to standard components options picker

### DIFF
--- a/packages/standard-components/manifest.json
+++ b/packages/standard-components/manifest.json
@@ -1842,6 +1842,22 @@
         "placeholder": "Choose an option"
       },
       {
+        "type": "select",
+        "label": "Type",
+        "key": "optionsType",
+        "placeholder": "Pick an options type",
+        "options": [
+          {
+            "label": "Select",
+            "value": "select"
+          },
+          {
+            "label": "Radio buttons",
+            "value": "radio"
+          }
+        ]
+      },
+      {
         "type": "boolean",
         "label": "Disabled",
         "key": "disabled",

--- a/packages/standard-components/src/forms/OptionsField.svelte
+++ b/packages/standard-components/src/forms/OptionsField.svelte
@@ -1,11 +1,12 @@
 <script>
-  import { CoreSelect } from "@budibase/bbui"
+  import { CoreSelect, RadioGroup } from "@budibase/bbui"
   import Field from "./Field.svelte"
 
   export let field
   export let label
   export let placeholder
   export let disabled = false
+  export let optionsType = "select"
 
   let fieldState
   let fieldApi
@@ -22,14 +23,25 @@
   bind:fieldSchema
 >
   {#if fieldState}
-    <CoreSelect
-      value={$fieldState.value}
-      id={$fieldState.fieldId}
-      disabled={$fieldState.disabled}
-      error={$fieldState.error}
-      options={fieldSchema?.constraints?.inclusion ?? []}
-      {placeholder}
-      on:change={e => fieldApi.setValue(e.detail)}
-    />
+    {#if optionsType === 'select'}
+      <CoreSelect
+        value={$fieldState.value}
+        id={$fieldState.fieldId}
+        disabled={$fieldState.disabled}
+        error={$fieldState.error}
+        options={fieldSchema?.constraints?.inclusion ?? []}
+        {placeholder}
+        on:change={e => fieldApi.setValue(e.detail)}
+      />
+    {:else if optionsType === 'radio'}
+      <RadioGroup
+        value={$fieldState.value}
+        id={$fieldState.fieldId}
+        disabled={$fieldState.disabled}
+        error={$fieldState.error}
+        options={fieldSchema?.constraints?.inclusion ?? []}
+        on:change={e => fieldApi.setValue(e.detail)}
+      />
+    {/if}
   {/if}
 </Field>

--- a/packages/standard-components/src/forms/OptionsField.svelte
+++ b/packages/standard-components/src/forms/OptionsField.svelte
@@ -23,7 +23,7 @@
   bind:fieldSchema
 >
   {#if fieldState}
-    {#if optionsType === 'select'}
+    {#if optionsType === "select"}
       <CoreSelect
         value={$fieldState.value}
         id={$fieldState.fieldId}
@@ -33,7 +33,7 @@
         {placeholder}
         on:change={e => fieldApi.setValue(e.detail)}
       />
-    {:else if optionsType === 'radio'}
+    {:else if optionsType === "radio"}
       <RadioGroup
         value={$fieldState.value}
         id={$fieldState.fieldId}


### PR DESCRIPTION
## Description
Fixes #2228 
Adds a new property to the options picker: type, which contains to options: radio buttons and select. When you select Radio buttons, a RadioGroup will be used instead of the CoreSelect. 

## Screenshots
Type Options of Options Picker
![image](https://user-images.githubusercontent.com/1907152/128075019-117d1a5f-b211-4bb6-8264-8b480ff99677.png)

Radio buttons in the form
![image](https://user-images.githubusercontent.com/1907152/128075092-5868fc16-7140-4c94-b832-447081a0252a.png)




