### PR TITLE
Fix bindings not appearing in certain button actions

### DIFF
--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/EventsEditor/EventPropertyControl.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/EventsEditor/EventPropertyControl.svelte
@@ -9,6 +9,7 @@
 
   export let value = []
   export let name
+  export let bindings
 
   let drawer
 
@@ -57,5 +58,5 @@
     Define what actions to run.
   </svelte:fragment>
   <Button cta slot="buttons" on:click={saveEventData}>Save</Button>
-  <EventEditor slot="body" bind:actions={value} eventType={name} />
+  <EventEditor slot="body" bind:actions={value} eventType={name} {bindings} />
 </Drawer>

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/EventsEditor/actions/SaveRow.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/EventsEditor/actions/SaveRow.svelte
@@ -9,6 +9,7 @@
   import SaveFields from "./SaveFields.svelte"
 
   export let parameters
+  export let bindings = []
 
   $: dataProviderComponents = getDataProviderComponents(
     $currentAsset,
@@ -70,6 +71,7 @@
         parameterFields={parameters.fields}
         {schemaFields}
         on:change={onFieldsChanged}
+        {bindings}
       />
     </div>
   {/if}

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/EventsEditor/actions/TriggerAutomation.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/EventsEditor/actions/TriggerAutomation.svelte
@@ -3,12 +3,13 @@
   import { automationStore } from "builderStore"
   import SaveFields from "./SaveFields.svelte"
 
+  export let parameters = {}
+  export let bindings = []
+
   const AUTOMATION_STATUS = {
     NEW: "new",
     EXISTING: "existing",
   }
-
-  export let parameters = {}
 
   let automationStatus = parameters.automationId
     ? AUTOMATION_STATUS.EXISTING
@@ -109,6 +110,7 @@
         parameterFields={parameters.fields}
         fieldLabel="Field"
         on:change={onFieldsChanged}
+        {bindings}
       />
     {/key}
   </div>


### PR DESCRIPTION
## Description
This fixes an issue where bindings aren't available in certain parts of some button action settings.
The values for `SaveRow` fields had no bindings, and the bindings for `TriggerAutomation` fields had no bindings.
Closes #2245.


