### PR TITLE
SQL varchar/number parsing fix

### DIFF
--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -165,6 +165,10 @@ module External {
         if (!row[key] || newRow[key] || field.autocolumn) {
           continue
         }
+        // parse floats/numbers
+        if (field.type === FieldTypes.NUMBER && !isNaN(parseFloat(row[key]))) {
+          newRow[key] = parseFloat(row[key])
+        }
         // if its not a link then just copy it over
         if (field.type !== FieldTypes.LINK) {
           newRow[key] = row[key]

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -19,8 +19,6 @@ function parseBody(body: any) {
     }
     if (isIsoDateString(value)) {
       body[key] = new Date(value)
-    } else if (!isNaN(parseFloat(value))) {
-      body[key] = parseFloat(value)
     }
   }
   return body


### PR DESCRIPTION
## Description
Quick fix for #2250, strings were being parsed for numbers which was causing the issue for strings starting with numbers, using the table schema to determine is parsing necessary.