### PR TITLE
Fix exporting data from table

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/ExportModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/ExportModal.svelte
@@ -18,10 +18,12 @@
   let exportFormat = FORMATS[0].key
 
   async function exportView() {
+    const filename = `export.${exportFormat}`
     download(
       `/api/views/export?view=${encodeURIComponent(
         view
-      )}&format=${exportFormat}`
+      )}&format=${exportFormat}`,
+      filename
     )
   }
 </script>

--- a/packages/server/src/api/controllers/view/exporters.js
+++ b/packages/server/src/api/controllers/view/exporters.js
@@ -6,7 +6,7 @@ exports.csv = function (headers, rows) {
       .map(header => {
         let val = row[header]
         val = typeof val === "object" ? JSON.stringify(val) : val
-        return `"${val}"`.trim() 
+        return `"${val}"`.trim()
       })
       .join(",")}`
   }

--- a/packages/server/src/api/controllers/view/exporters.js
+++ b/packages/server/src/api/controllers/view/exporters.js
@@ -3,7 +3,11 @@ exports.csv = function (headers, rows) {
 
   for (let row of rows) {
     csv = `${csv}\n${headers
-      .map(header => `"${row[header]}"`.trim())
+      .map(header => {
+        let val = row[header]
+        val = typeof val === "object" ? JSON.stringify(val) : val
+        return `"${val}"`.trim() 
+      })
       .join(",")}`
   }
   return csv

--- a/packages/server/src/middleware/currentapp.js
+++ b/packages/server/src/middleware/currentapp.js
@@ -10,7 +10,7 @@ const CouchDB = require("../db")
 
 module.exports = async (ctx, next) => {
   // try to get the appID from the request
-  const requestAppId = getAppId(ctx)
+  let requestAppId = getAppId(ctx)
   // get app cookie if it exists
   let appCookie = null
   try {
@@ -29,6 +29,8 @@ module.exports = async (ctx, next) => {
       clearCookie(ctx, Cookies.CurrentApp)
       return next()
     }
+    // if the request app ID wasn't set, update it with the cookie
+    requestAppId = requestAppId || appId
   }
 
   let appId,


### PR DESCRIPTION
## Description
Fixing a few issues related to exporting data from a table, as follows:
1. #2193 exporting didn't work due to it not knowing the app ID, fixing this
2. Fixing the name of the exporting file, CSV files were always just named `export` or `export.txt` - making them `export.csv`
3. Fixing an issue with relationships being exported giving `[object Object]` - JSON stringifying it instead
