### PR TITLE
Some fixes for internal and external relationships

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/CreateEditRelationship/CreateEditRelationship.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/CreateEditRelationship/CreateEditRelationship.svelte
@@ -199,6 +199,9 @@
       delete datasource.entities[toTable.name].schema[originalToName]
     }
 
+    // store the original names so it won't cause an error
+    originalToName = toRelationship.name
+    originalFromName = fromRelationship.name
     await save()
     await tables.fetch()
   }

--- a/packages/server/src/api/routes/tests/datasource.spec.js
+++ b/packages/server/src/api/routes/tests/datasource.spec.js
@@ -82,7 +82,7 @@ describe("/datasources", () => {
             entityId: "users",
           },
           resource: {
-            fields: ["name", "age"],
+            fields: ["users.name", "users.age"],
           },
           filters: {
             string: {
@@ -94,7 +94,7 @@ describe("/datasources", () => {
         .expect(200)
       // this is mock data, can't test it
       expect(res.body).toBeDefined()
-      expect(pg.queryMock).toHaveBeenCalledWith(`select "name", "age" from "users" where "users"."name" like $1 limit $2`, ["John%", 5000])
+      expect(pg.queryMock).toHaveBeenCalledWith(`select "users"."name" as "users.name", "users"."age" as "users.age" from "users" where "users"."name" like $1 limit $2`, ["John%", 5000])
     })
   })
 

--- a/packages/server/src/db/linkedRows/LinkController.js
+++ b/packages/server/src/db/linkedRows/LinkController.js
@@ -322,7 +322,7 @@ class LinkController {
     // remove schema from other table
     let linkedTable = await this._db.get(field.tableId)
     delete linkedTable.schema[field.fieldName]
-    this._db.put(linkedTable)
+    await this._db.put(linkedTable)
   }
 
   /**

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -151,7 +151,7 @@ function buildRead(knex: Knex, json: QueryJson, limit: number): KnexQuery {
   }
   // handle select
   if (resource.fields && resource.fields.length > 0) {
-    query = query.select(resource.fields)
+    query = query.select(resource.fields.map(field => `${field} as ${field}`))
   } else {
     query = query.select("*")
   }

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -151,6 +151,8 @@ function buildRead(knex: Knex, json: QueryJson, limit: number): KnexQuery {
   }
   // handle select
   if (resource.fields && resource.fields.length > 0) {
+    // select the resources as the format "table.columnName" - this is what is provided
+    // by the resource builder further up
     query = query.select(resource.fields.map(field => `${field} as ${field}`))
   } else {
     query = query.select("*")

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -242,7 +242,7 @@ module MySQLModule {
       const input = this._query(json, { disableReturning: true })
       let row
       // need to manage returning, a feature mySQL can't do
-      if (operation === "awdawd") {
+      if (operation === operation.DELETE) {
         row = this.getReturningRow(json)
       }
       const results = await internalQuery(this.client, input, false)

--- a/packages/server/src/integrations/tests/sql.spec.js
+++ b/packages/server/src/integrations/tests/sql.spec.js
@@ -62,12 +62,13 @@ describe("SQL query builder", () => {
   })
 
   it("should test a read with specific columns", () => {
+    const nameProp = `${TABLE_NAME}.name`, ageProp = `${TABLE_NAME}.age`
     const query = sql._query(generateReadJson({
-      fields: ["name", "age"]
+      fields: [nameProp, ageProp]
     }))
     expect(query).toEqual({
       bindings: [limit],
-      sql: `select "name", "age" from "${TABLE_NAME}" limit $1`
+      sql: `select "${TABLE_NAME}"."name" as "${nameProp}", "${TABLE_NAME}"."age" as "${ageProp}" from "${TABLE_NAME}" limit $1`
     })
   })
 

--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -40,8 +40,13 @@ export function breakRowIdField(_id: string): any[] {
   // have to replace on the way back as we swapped out the double quotes
   // when encoding, but JSON can't handle the single quotes
   const decoded: string = decodeURIComponent(_id).replace(/'/g, '"')
-  const parsed = JSON.parse(decoded)
-  return Array.isArray(parsed) ? parsed : [parsed]
+  try {
+    const parsed = JSON.parse(decoded)
+    return Array.isArray(parsed) ? parsed : [parsed]
+  } catch (err) {
+    // wasn't json - likely was handlebars for a many to many
+    return [_id]
+  }
 }
 
 export function convertType(type: string, map: { [key: string]: any }) {

--- a/packages/server/src/utilities/index.js
+++ b/packages/server/src/utilities/index.js
@@ -1,5 +1,5 @@
 const env = require("../environment")
-const { OBJ_STORE_DIRECTORY, ObjectStoreBuckets } = require("../constants")
+const { OBJ_STORE_DIRECTORY } = require("../constants")
 const { getAllApps } = require("@budibase/auth/db")
 const { sanitizeKey } = require("@budibase/auth/src/objectStore")
 


### PR DESCRIPTION
## Description
A variety of fixes after doing some testing around internal and external relationships:
1. When creating an SQL relationship an error would flash in the modal before it closed, getting rid of this
2. Some external relationships wouldn't work if there were overlapping columns, as per example in #2167 
3. Fixing an issue where internal relationships couldn't be deleted if they were made against the user table #2174 
4. Fixing an issue where many to many relationships didn't get created occasionally

Some of these fixes were required due to some of the changes that had to be made for SQL relationships previously.