### PR TITLE
Fixing various issues caused by PouchDB allDbs call

### DIFF
--- a/packages/auth/src/db/utils.js
+++ b/packages/auth/src/db/utils.js
@@ -185,9 +185,7 @@ exports.getAllDbs = async () => {
  */
 exports.getAllApps = async ({ CouchDB, dev, all } = {}) => {
   let dbs = await exports.getAllDbs()
-  const appDbNames = dbs.filter(dbName =>
-    dbName.startsWith(exports.APP_PREFIX)
-  )
+  const appDbNames = dbs.filter(dbName => dbName.startsWith(exports.APP_PREFIX))
   const appPromises = appDbNames.map(db =>
     // skip setup otherwise databases could be re-created
     new CouchDB(db, { skip_setup: true }).get(DocumentTypes.APP_METADATA)

--- a/packages/auth/src/middleware/passport/tests/utilities/db.js
+++ b/packages/auth/src/middleware/passport/tests/utilities/db.js
@@ -1,5 +1,4 @@
 const PouchDB = require("pouchdb")
-const allDbs = require("pouchdb-all-dbs")
 const env = require("../../../../environment")
 
 let POUCH_DB_DEFAULTS
@@ -14,7 +13,5 @@ if (env.isTest()) {
 }
 
 const Pouch = PouchDB.defaults(POUCH_DB_DEFAULTS)
-
-allDbs(Pouch)
 
 module.exports = Pouch

--- a/packages/builder/src/components/start/CreateAppModal.svelte
+++ b/packages/builder/src/components/start/CreateAppModal.svelte
@@ -9,6 +9,7 @@
     Checkbox,
   } from "@budibase/bbui"
   import { store, automationStore, hostingStore } from "builderStore"
+  import { admin } from "stores/portal"
   import { string, mixed, object } from "yup"
   import api, { get, post } from "builderStore/api"
   import analytics from "analytics"
@@ -102,6 +103,8 @@
       if (applicationPkg.ok) {
         await store.actions.initialise(pkg)
         await automationStore.actions.fetch()
+        // update checklist - incase first app
+        await admin.init()
       } else {
         throw new Error(pkg)
       }

--- a/packages/builder/src/pages/builder/portal/apps/index.svelte
+++ b/packages/builder/src/pages/builder/portal/apps/index.svelte
@@ -18,7 +18,7 @@
   import api, { del } from "builderStore/api"
   import analytics from "analytics"
   import { onMount } from "svelte"
-  import { apps, auth } from "stores/portal"
+  import { apps, auth, admin } from "stores/portal"
   import download from "downloadjs"
   import { goto } from "@roxi/routify"
   import ConfirmDialog from "components/common/ConfirmDialog.svelte"
@@ -159,6 +159,8 @@
         throw json.message
       }
       await apps.load()
+      // get checklist, just in case that was the last app
+      await admin.init()
       notifications.success("App deleted successfully")
     } catch (err) {
       notifications.error(`Error deleting app: ${err}`)

--- a/packages/builder/src/stores/portal/organisation.js
+++ b/packages/builder/src/stores/portal/organisation.js
@@ -2,7 +2,7 @@ import { writable, get } from "svelte/store"
 import api from "builderStore/api"
 
 const DEFAULT_CONFIG = {
-  platformUrl: "http://localhost:1000",
+  platformUrl: "http://localhost:10000",
   logoUrl: undefined,
   docsUrl: undefined,
   company: "Budibase",

--- a/packages/server/scripts/replicateApp.js
+++ b/packages/server/scripts/replicateApp.js
@@ -7,6 +7,7 @@
 
 const CouchDB = require("../src/db")
 const { DocumentTypes } = require("../src/db/utils")
+const { getAllDbs } = require("@budibase/auth/db")
 
 const appName = process.argv[2].toLowerCase()
 const remoteUrl = process.argv[3]
@@ -14,8 +15,8 @@ const remoteUrl = process.argv[3]
 console.log(`Replicating from ${appName} to ${remoteUrl}/${appName}`)
 
 const run = async () => {
-  const allDbs = await CouchDB.allDbs()
-  const appDbNames = allDbs.filter(dbName => dbName.startsWith("inst_app"))
+  const dbs = await getAllDbs()
+  const appDbNames = dbs.filter(dbName => dbName.startsWith("inst_app"))
   let apps = []
   for (let dbName of appDbNames) {
     const db = new CouchDB(dbName)

--- a/packages/server/src/db/client.js
+++ b/packages/server/src/db/client.js
@@ -24,21 +24,7 @@ if (env.isTest()) {
 
 const Pouch = PouchDB.defaults(POUCH_DB_DEFAULTS)
 
+// have to still have pouch alldbs for testing
 allDbs(Pouch)
-
-// replicate your local levelDB pouch to a running HTTP compliant couch or pouchdb server.
-/* istanbul ignore next */
-// eslint-disable-next-line no-unused-vars
-function replicateLocal() {
-  Pouch.allDbs().then(dbs => {
-    for (let db of dbs) {
-      new Pouch(db).sync(
-        new PouchDB(`http://127.0.0.1:5984/${db}`, { live: true })
-      )
-    }
-  })
-}
-
-// replicateLocal()
 
 module.exports = Pouch

--- a/packages/worker/src/api/controllers/admin/configs.js
+++ b/packages/worker/src/api/controllers/admin/configs.js
@@ -10,8 +10,6 @@ const {
 const { Configs } = require("../../../constants")
 const email = require("../../../utilities/email")
 const { upload, ObjectStoreBuckets } = require("@budibase/auth").objectStore
-const fetch = require("node-fetch")
-const env = require("../../../environment")
 
 const APP_PREFIX = "app_"
 

--- a/packages/worker/src/api/controllers/admin/configs.js
+++ b/packages/worker/src/api/controllers/admin/configs.js
@@ -5,10 +5,13 @@ const {
   getConfigParams,
   getGlobalUserParams,
   getScopedFullConfig,
+  getAllDbs,
 } = require("@budibase/auth").db
 const { Configs } = require("../../../constants")
 const email = require("../../../utilities/email")
 const { upload, ObjectStoreBuckets } = require("@budibase/auth").objectStore
+const fetch = require("node-fetch")
+const env = require("../../../environment")
 
 const APP_PREFIX = "app_"
 
@@ -229,8 +232,8 @@ exports.configChecklist = async function (ctx) {
     // TODO: Watch get started video
 
     // Apps exist
-    let allDbs = await CouchDB.allDbs()
-    const appDbNames = allDbs.filter(dbName => dbName.startsWith(APP_PREFIX))
+    let dbs = await getAllDbs()
+    const appDbNames = dbs.filter(dbName => dbName.startsWith(APP_PREFIX))
 
     // They have set up SMTP
     const smtpConfig = await getScopedFullConfig(db, {

--- a/packages/worker/src/api/controllers/app.js
+++ b/packages/worker/src/api/controllers/app.js
@@ -1,15 +1,14 @@
-const { DocumentTypes } = require("@budibase/auth").db
+const { DocumentTypes, getAllDbs } = require("@budibase/auth").db
 const CouchDB = require("../../db")
 
 const APP_PREFIX = "app_"
 const URL_REGEX_SLASH = /\/|\\/g
 
 exports.getApps = async ctx => {
-  // allDbs call of CouchDB is very inaccurate in production
-  const allDbs = await CouchDB.allDbs()
-  const appDbNames = allDbs.filter(dbName => dbName.startsWith(APP_PREFIX))
+  const dbs = await getAllDbs()
+  const appDbNames = dbs.filter(dbName => dbName.startsWith(APP_PREFIX))
   const appPromises = appDbNames.map(db =>
-    new CouchDB(db).get(DocumentTypes.APP_METADATA)
+    new CouchDB(db, { skip_setup: true }).get(DocumentTypes.APP_METADATA)
   )
 
   const apps = await Promise.allSettled(appPromises)

--- a/packages/worker/src/db/index.js
+++ b/packages/worker/src/db/index.js
@@ -19,6 +19,7 @@ if (env.isTest()) {
 
 const Pouch = PouchDB.defaults(POUCH_DB_DEFAULTS)
 
+// have to still have pouch alldbs for testing
 allDbs(Pouch)
 
 module.exports = Pouch


### PR DESCRIPTION
## Description
Fixes for a lot of issues generated by the use of the pouchdb allDb call, which is not designed for multi-client DB setups like ours, using CouchDB method instead.

The issues fixed by this work are namely:
1. #2283 - the checklist did not update correctly as different services were creating/deleting apps, meaning the services didn't know about other DBs.
2. #2195 - as with the previous issue, no service knew about what other services were doing, so databases would go missing.
3. #2282 - simple fix, just the wrong URL specified in the builder codebase.