### PR TITLE
Add Quiet and Emphasized variants to the Tabs and Tab components

### DIFF
--- a/packages/bbui/src/Tabs/Tab.svelte
+++ b/packages/bbui/src/Tabs/Tab.svelte
@@ -30,6 +30,7 @@
   on:click={onClick}
   class:is-selected={$selected.title === title}
   class="spectrum-Tabs-item"
+  class:emphasized={$selected.title === title && $selected.emphasized}
   tabindex="0"
 >
   {#if icon}
@@ -49,3 +50,9 @@
     <slot />
   </Portal>
 {/if}
+
+<style>
+  .emphasized {
+    color: var(--spectrum-global-color-blue-600);
+  }
+</style>

--- a/packages/bbui/src/Tabs/Tabs.svelte
+++ b/packages/bbui/src/Tabs/Tabs.svelte
@@ -68,7 +68,7 @@
   {#if $tab.info}
     <div
       class="spectrum-Tabs-selectionIndicator indicator-transition"
-      style="{quiet &&
+      style="{emphasized &&
         'background-color: var(--spectrum-global-color-blue-400)'}; width: {width}; height: {height}; left: {left}; top: {top};"
     />
   {/if}

--- a/packages/bbui/src/Tabs/Tabs.svelte
+++ b/packages/bbui/src/Tabs/Tabs.svelte
@@ -68,7 +68,8 @@
   {#if $tab.info}
     <div
       class="spectrum-Tabs-selectionIndicator indicator-transition"
-      style=" background-color: {'var(--spectrum-global-color-blue-400)'}; width: {width}; height: {height}; left: {left}; top: {top};"
+      style="{quiet &&
+        'background-color: var(--spectrum-global-color-blue-400)'}; width: {width}; height: {height}; left: {left}; top: {top};"
     />
   {/if}
 </div>

--- a/packages/bbui/src/Tabs/Tabs.svelte
+++ b/packages/bbui/src/Tabs/Tabs.svelte
@@ -6,9 +6,11 @@
   export let selected
   export let vertical = false
   export let noPadding = false
+  export let quiet = false
+  export let emphasized = false
 
   let _id = id()
-  const tab = writable({ title: selected, id: _id })
+  const tab = writable({ title: selected, id: _id, emphasized })
   setContext("tab", tab)
 
   let container
@@ -56,7 +58,9 @@
 
 <div
   bind:this={container}
-  class="selected-border spectrum-Tabs spectrum-Tabs--{vertical
+  class:quiet
+  class="selected-border spectrum-Tabs {quiet &&
+    'spectrum-Tabs--quiet'} spectrum-Tabs--{vertical
     ? 'vertical'
     : 'horizontal'}"
 >
@@ -64,7 +68,7 @@
   {#if $tab.info}
     <div
       class="spectrum-Tabs-selectionIndicator indicator-transition"
-      style="width: {width}; height: {height}; left: {left}; top: {top};"
+      style=" background-color: {'var(--spectrum-global-color-blue-400)'}; width: {width}; height: {height}; left: {left}; top: {top};"
     />
   {/if}
 </div>
@@ -75,6 +79,10 @@
 />
 
 <style>
+  .quiet {
+    border-bottom: none !important;
+  }
+
   .spectrum-Tabs {
     padding-left: var(--spacing-xl);
     padding-right: var(--spacing-xl);


### PR DESCRIPTION
## Description
This adds quiet and emphasized variants to the BBUI Tabs component. 

Quiet is just a conditional using the Spectrum quiet class, but emphasized doesn't actually exist in the Spectrum CSS so had to change the colour myself. 

The <Tab> component needs to be aware of the emphasized prop so i passed it through in the existing context, think this make sense. I didn't like the idea of having to pass an emphasized prop to every tab component. 

## Screenshots

Using both quiet and emphasized: 
<img width="207" alt="Screenshot 2021-08-09 at 15 51 29" src="https://user-images.githubusercontent.com/5665926/128726649-714496a2-d720-4a80-a741-b4ed1d0fe2d5.png">


Just emphasized: 
![image](https://user-images.githubusercontent.com/5665926/128728015-d72f77f6-a6cd-44b8-9797-1a2ba81eb1b5.png)

Just quiet:
![image](https://user-images.githubusercontent.com/5665926/128728068-687d6e29-1b12-49de-b121-c9c31b82f3c0.png)
