### PR TITLE
Bindings for device type

### DIFF
--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -17,7 +17,13 @@ export const getBindableProperties = (asset, componentId) => {
   const contextBindings = getContextBindings(asset, componentId)
   const userBindings = getUserBindings()
   const urlBindings = getUrlBindings(asset)
-  return [...contextBindings, ...userBindings, ...urlBindings]
+  const deviceBindings = getDeviceBindings()
+  return [
+    ...deviceBindings,
+    ...urlBindings,
+    ...contextBindings,
+    ...userBindings,
+  ]
 }
 
 /**
@@ -218,6 +224,27 @@ const getUserBindings = () => {
     })
   })
 
+  return bindings
+}
+
+/**
+ * Gets all device bindings that are globally available.
+ */
+const getDeviceBindings = () => {
+  let bindings = []
+  if (get(store).clientFeatures?.deviceAwareness) {
+    const safeDevice = makePropSafe("device")
+    bindings.push({
+      type: "context",
+      runtimeBinding: `${safeDevice}.${makePropSafe("mobile")}`,
+      readableBinding: `Device.Mobile`,
+    })
+    bindings.push({
+      type: "context",
+      runtimeBinding: `${safeDevice}.${makePropSafe("tablet")}`,
+      readableBinding: `Device.Tablet`,
+    })
+  }
   return bindings
 }
 

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -35,6 +35,7 @@ const INITIAL_FRONTEND_STATE = {
   clientFeatures: {
     spectrumThemes: false,
     intelligentLoading: false,
+    deviceAwareness: false,
   },
   currentFrontEndType: "none",
   selectedScreenId: "",

--- a/packages/builder/src/components/common/bindings/BindingPanel.svelte
+++ b/packages/builder/src/components/common/bindings/BindingPanel.svelte
@@ -38,7 +38,7 @@
       </section>
       {#if filteredColumns?.length}
         <section>
-          <div class="heading">Columns</div>
+          <div class="heading">Bindable Values</div>
           <ul>
             {#each filteredColumns as { readableBinding }}
               <li

--- a/packages/client/src/components/DeviceBindingsProvider.svelte
+++ b/packages/client/src/components/DeviceBindingsProvider.svelte
@@ -2,21 +2,19 @@
   import Provider from "./Provider.svelte"
   import { onMount } from "svelte"
 
+  let width = window.innerWidth
   const tabletBreakpoint = 768
   const desktopBreakpoint = 1280
-
-  let screenWidth = window.innerWidth
   const resizeObserver = new ResizeObserver(entries => {
     if (entries?.[0]) {
-      screenWidth = entries[0].contentRect?.width
+      width = entries[0].contentRect?.width
     }
   })
-  $: mobile = screenWidth && screenWidth < tabletBreakpoint
-  $: tablet =
-    screenWidth &&
-    screenWidth >= tabletBreakpoint &&
-    screenWidth < desktopBreakpoint
-  $: data = { mobile, tablet }
+
+  $: data = {
+    mobile: width && width < tabletBreakpoint,
+    tablet: width && width >= tabletBreakpoint && width < desktopBreakpoint,
+  }
 
   onMount(() => {
     const doc = document.documentElement

--- a/packages/client/src/components/DeviceBindingsProvider.svelte
+++ b/packages/client/src/components/DeviceBindingsProvider.svelte
@@ -1,0 +1,33 @@
+<script>
+  import Provider from "./Provider.svelte"
+  import { onMount } from "svelte"
+
+  const tabletBreakpoint = 768
+  const desktopBreakpoint = 1280
+
+  let screenWidth = window.innerWidth
+  const resizeObserver = new ResizeObserver(entries => {
+    if (entries?.[0]) {
+      screenWidth = entries[0].contentRect?.width
+    }
+  })
+  $: mobile = screenWidth && screenWidth < tabletBreakpoint
+  $: tablet =
+    screenWidth &&
+    screenWidth >= tabletBreakpoint &&
+    screenWidth < desktopBreakpoint
+  $: data = { mobile, tablet }
+
+  onMount(() => {
+    const doc = document.documentElement
+    resizeObserver.observe(doc)
+
+    return () => {
+      resizeObserver.unobserve(doc)
+    }
+  })
+</script>
+
+<Provider key="device" {data}>
+  <slot />
+</Provider>

--- a/packages/client/src/components/UserBindingsProvider.svelte
+++ b/packages/client/src/components/UserBindingsProvider.svelte
@@ -1,0 +1,19 @@
+<script>
+  import Provider from "./Provider.svelte"
+  import { authStore } from "../store"
+  import { ActionTypes, TableNames } from "../constants"
+
+  // Register this as a refreshable datasource so that user changes cause
+  // the user object to be refreshed
+  $: actions = [
+    {
+      type: ActionTypes.RefreshDatasource,
+      callback: () => authStore.actions.fetchUser(),
+      metadata: { dataSource: { type: "table", tableId: TableNames.USERS } },
+    },
+  ]
+</script>
+
+<Provider key="user" data={$authStore} {actions}>
+  <slot />
+</Provider>

--- a/packages/standard-components/manifest.json
+++ b/packages/standard-components/manifest.json
@@ -1,7 +1,8 @@
 {
   "features": {
     "spectrumThemes": true,
-    "intelligentLoading": true
+    "intelligentLoading": true,
+    "deviceAwareness": true
   },
   "layout": {
     "name": "Layout",


### PR DESCRIPTION
## Description
This is a quick feature to add global data bindings for device type. Combining this with conditional UI finally lets users change the settings of their components depending on screen resolution, so should help massively with mobile support. This is related to #2263.

2 new bindings have been added - `Device.Mobile` and `Device.Tablet`. After discussion with Joe, the breakpoints are as follows:
Mobile: 0-767px
Tablet: 768-1279px
Desktop: 1280px+

Everything is desktop by default, so there is no binding for desktop. You design apps for desktop, and can add mobile or tablet compatibility rules as required.

Here are the new bindable properties:
![image](https://user-images.githubusercontent.com/9075550/129343897-83e30d78-37f0-4d1d-9edb-b809f4b3a147.png)

They evaluate to true or false if you bind to them:
![image](https://user-images.githubusercontent.com/9075550/129343980-85549071-d939-4df4-a2df-baac19163595.png)

Here's an example of using conditional UI to change a setting to make a button larger on mobile:
![image](https://user-images.githubusercontent.com/9075550/129344067-8de83795-e17c-43da-a3ab-b5b81067d45a.png)


