### PR TITLE
Some tweaks for Joe

### DIFF
--- a/packages/bbui/src/ColorPicker/ColorPicker.svelte
+++ b/packages/bbui/src/ColorPicker/ColorPicker.svelte
@@ -19,7 +19,7 @@
   const dispatch = createEventDispatcher()
   const categories = [
     {
-      label: "Grays",
+      label: "Theme",
       colors: [
         "gray-50",
         "gray-75",

--- a/packages/bbui/src/ColorPicker/ColorPicker.svelte
+++ b/packages/bbui/src/ColorPicker/ColorPicker.svelte
@@ -72,6 +72,9 @@
         "blue-700",
         "indigo-700",
         "magenta-700",
+
+        "static-white",
+        "static-black",
       ],
     },
   ]
@@ -101,9 +104,19 @@
   }
 
   const getCheckColor = value => {
-    return /^.*(white|(gray-(50|75|100|200|300|400|500)))\)$/.test(value)
-      ? "var(--spectrum-global-color-gray-900)"
-      : "var(--spectrum-global-color-gray-50)"
+    // Use dynamic color for theme grays
+    if (value?.includes("gray")) {
+      return /^.*(gray-(50|75|100|200|300|400|500))\)$/.test(value)
+        ? "var(--spectrum-global-color-gray-900)"
+        : "var(--spectrum-global-color-gray-50)"
+    }
+
+    // Use black check for static white
+    if (value?.includes("static-black")) {
+      return "var(--spectrum-global-color-static-gray-50)"
+    }
+
+    return "var(--spectrum-global-color-static-gray-900)"
   }
 </script>
 

--- a/packages/builder/src/components/design/PropertiesPanel/componentStyles.js
+++ b/packages/builder/src/components/design/PropertiesPanel/componentStyles.js
@@ -14,6 +14,7 @@ export const margin = {
       options: [
         { label: "4px", value: "4px" },
         { label: "8px", value: "8px" },
+        { label: "12px", value: "12px" },
         { label: "16px", value: "16px" },
         { label: "20px", value: "20px" },
         { label: "32px", value: "32px" },
@@ -34,6 +35,7 @@ export const margin = {
       options: [
         { label: "4px", value: "4px" },
         { label: "8px", value: "8px" },
+        { label: "12px", value: "12px" },
         { label: "16px", value: "16px" },
         { label: "20px", value: "20px" },
         { label: "32px", value: "32px" },
@@ -54,6 +56,7 @@ export const margin = {
       options: [
         { label: "4px", value: "4px" },
         { label: "8px", value: "8px" },
+        { label: "12px", value: "12px" },
         { label: "16px", value: "16px" },
         { label: "20px", value: "20px" },
         { label: "32px", value: "32px" },
@@ -74,6 +77,7 @@ export const margin = {
       options: [
         { label: "4px", value: "4px" },
         { label: "8px", value: "8px" },
+        { label: "12px", value: "12px" },
         { label: "16px", value: "16px" },
         { label: "20px", value: "20px" },
         { label: "32px", value: "32px" },
@@ -101,6 +105,7 @@ export const padding = {
       options: [
         { label: "4px", value: "4px" },
         { label: "8px", value: "8px" },
+        { label: "12px", value: "12px" },
         { label: "16px", value: "16px" },
         { label: "20px", value: "20px" },
         { label: "32px", value: "32px" },
@@ -121,6 +126,7 @@ export const padding = {
       options: [
         { label: "4px", value: "4px" },
         { label: "8px", value: "8px" },
+        { label: "12px", value: "12px" },
         { label: "16px", value: "16px" },
         { label: "20px", value: "20px" },
         { label: "32px", value: "32px" },
@@ -141,6 +147,7 @@ export const padding = {
       options: [
         { label: "4px", value: "4px" },
         { label: "8px", value: "8px" },
+        { label: "12px", value: "12px" },
         { label: "16px", value: "16px" },
         { label: "20px", value: "20px" },
         { label: "32px", value: "32px" },
@@ -161,6 +168,7 @@ export const padding = {
       options: [
         { label: "4px", value: "4px" },
         { label: "8px", value: "8px" },
+        { label: "12px", value: "12px" },
         { label: "16px", value: "16px" },
         { label: "20px", value: "20px" },
         { label: "32px", value: "32px" },

--- a/packages/standard-components/manifest.json
+++ b/packages/standard-components/manifest.json
@@ -595,6 +595,9 @@
         "showInBar": true,
         "barStyle": "picker",
         "options": [{
+          "label": "Extra Small",
+          "value": "XS"
+        }, {
           "label": "Small",
           "value": "S"
         }, {
@@ -603,6 +606,15 @@
         }, {
           "label": "Large",
           "value": "L"
+        }, {
+          "label": "Extra Large",
+          "value": "XL"
+        }, {
+          "label": "2XL",
+          "value": "XXL"
+        }, {
+          "label": "3XL",
+          "value": "XXXL"
         }]
       },
       {
@@ -689,6 +701,9 @@
         "showInBar": true,
         "barStyle": "picker",
         "options": [{
+          "label": "Extra Small",
+          "value": "XS"
+        }, {
           "label": "Small",
           "value": "S"
         }, {
@@ -697,6 +712,15 @@
         }, {
           "label": "Large",
           "value": "L"
+        }, {
+          "label": "Extra Large",
+          "value": "XL"
+        }, {
+          "label": "2XL",
+          "value": "XXL"
+        }, {
+          "label": "3XL",
+          "value": "XXXL"
         }]
       },
       {

--- a/packages/standard-components/manifest.json
+++ b/packages/standard-components/manifest.json
@@ -267,6 +267,10 @@
           {
             "label": "Warning",
             "value": "warning"
+          },
+          {
+            "label": "Over Background",
+            "value": "overBackground"
           }
         ],
         "defaultValue": "primary"

--- a/packages/standard-components/package.json
+++ b/packages/standard-components/package.json
@@ -34,6 +34,7 @@
   "gitHead": "d1836a898cab3f8ab80ee6d8f42be1a9eed7dcdc",
   "dependencies": {
     "@budibase/bbui": "^0.9.105-alpha.6",
+    "@spectrum-css/button": "^3.0.3",
     "@spectrum-css/card": "^3.0.3",
     "@spectrum-css/divider": "^1.0.3",
     "@spectrum-css/link": "^3.1.3",

--- a/packages/standard-components/src/Button.svelte
+++ b/packages/standard-components/src/Button.svelte
@@ -1,5 +1,6 @@
 <script>
   import { getContext } from "svelte"
+  import "@spectrum-css/button/dist/index-vars.css"
 
   const { styleable } = getContext("sdk")
   const component = getContext("component")
@@ -26,5 +27,8 @@
   button {
     width: fit-content;
     width: -moz-fit-content;
+  }
+  .spectrum-Button--overBackground:hover {
+    color: #555;
   }
 </style>

--- a/packages/standard-components/src/Text.svelte
+++ b/packages/standard-components/src/Text.svelte
@@ -16,6 +16,8 @@
   $: componentText = $builderStore.inBuilder
     ? text || $component.name || "Placeholder text"
     : text || ""
+  $: sizeClass = `spectrum-Body--size${size || "M"}`
+  $: alignClass = `align--${align || "left"}`
 
   // Add color styles to main styles object, otherwise the styleable helper
   // overrides the color when it's passed as inline style.
@@ -41,7 +43,7 @@
   class:bold
   class:italic
   class:underline
-  class="align--{align || 'left'} size--{size || 'M'}"
+  class="spectrum-Body {sizeClass} {alignClass}"
 >
   {componentText}
 </p>
@@ -64,15 +66,6 @@
   }
   .underline {
     text-decoration: underline;
-  }
-  .size--S {
-    font-size: 14px;
-  }
-  .size--M {
-    font-size: 16px;
-  }
-  .size--L {
-    font-size: 18px;
   }
   .align--left {
     text-align: left;


### PR DESCRIPTION
## Description
This is a collection of tweaks which @joebudi requested:
- Add XS, XL, XXL and XXXL size options to parapraph and heading components
![image](https://user-images.githubusercontent.com/9075550/129352217-e76453dc-1294-4900-853b-d7fbb3348bbe.png)
- Add static white text color (I added static black too). I also updated the first heading to "Theme" instead of "Grays" to make it more obvious that the gray palette is dynamic, but the colours are not. We can add more to the theme section when we implement custom theme colours.
![image](https://user-images.githubusercontent.com/9075550/129352542-1dbb1a80-d649-4aad-9214-c7bfb35329c4.png)
- Add "over background" button variant
![image](https://user-images.githubusercontent.com/9075550/129352290-9465f58b-1e91-4022-bd15-9a85d9680d79.png)
![image](https://user-images.githubusercontent.com/9075550/129352338-5898568b-efa2-49f8-a6b6-49ec17bc9294.png)
- Add 12px options for margin and padding
![image](https://user-images.githubusercontent.com/9075550/129352357-d32097a8-8b95-40b5-83b5-b90a522152cb.png)