### PR TITLE
Dynamic picker options

### DIFF
--- a/packages/builder/src/components/design/PropertiesPanel/ComponentSettingsSection.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/ComponentSettingsSection.svelte
@@ -32,9 +32,29 @@
     if (!control) {
       return false
     }
-    if (setting.dependsOn && isEmpty(componentInstance[setting.dependsOn])) {
-      return false
+
+    // Parse dependant settings
+    if (setting.dependsOn) {
+      let dependantSetting = setting.dependsOn
+      let dependantValue = null
+      if (typeof setting.dependsOn === "object") {
+        dependantSetting = setting.dependsOn.setting
+        dependantValue = setting.dependsOn.value
+      }
+      if (!dependantSetting) {
+        return false
+      }
+
+      // If no specific value is depended upon, check if a value exists at all
+      // for the dependent setting
+      if (dependantValue == null) {
+        return !isEmpty(componentInstance[dependantSetting])
+      }
+
+      // Otherwise check the value matches
+      return componentInstance[dependantSetting] === dependantValue
     }
+
     return true
   }
 </script>

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/OptionsEditor/OptionsDrawer.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/OptionsEditor/OptionsDrawer.svelte
@@ -1,0 +1,83 @@
+<script>
+  import {
+    Icon,
+    Button,
+    Input,
+    DrawerContent,
+    Layout,
+    Body,
+  } from "@budibase/bbui"
+  import { generate } from "shortid"
+
+  export let options = []
+
+  const removeOption = id => {
+    options = options.filter(option => option.id !== id)
+  }
+
+  const addOption = () => {
+    options = [
+      ...options,
+      {
+        id: generate(),
+        label: null,
+        value: null,
+      },
+    ]
+  }
+</script>
+
+<DrawerContent>
+  <div class="container">
+    <Layout noPadding>
+      <Body size="S">
+        {#if !options.length}
+          Add a custom option.
+        {/if}
+      </Body>
+
+      <div class="options">
+        {#each options as option (option.id)}
+          <Input
+            placeholder="Label"
+            bind:value={option.label}
+            label="Label"
+            labelPosition="left"
+          />
+          <Input
+            placeholder="Value"
+            bind:value={option.value}
+            label="Value"
+            labelPosition="left"
+          />
+          <Icon
+            name="Close"
+            hoverable
+            size="S"
+            on:click={() => removeOption(option.id)}
+          />
+        {/each}
+      </div>
+      <div>
+        <Button icon="AddCircle" size="M" on:click={addOption} secondary
+          >Add Option</Button
+        >
+      </div>
+    </Layout>
+  </div>
+</DrawerContent>
+
+<style>
+  .container {
+    width: 100%;
+    max-width: 1000px;
+    margin: 0 auto;
+  }
+  .options {
+    display: grid;
+    column-gap: var(--spacing-l);
+    row-gap: var(--spacing-s);
+    align-items: center;
+    grid-template-columns: auto auto 20px;
+  }
+</style>

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/OptionsEditor/OptionsDrawer.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/OptionsEditor/OptionsDrawer.svelte
@@ -32,7 +32,7 @@
     <Layout noPadding>
       <Body size="S">
         {#if !options.length}
-          Add a custom option.
+          Add an option to get started.
         {/if}
       </Body>
 

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/OptionsEditor/OptionsDrawer.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/OptionsEditor/OptionsDrawer.svelte
@@ -29,39 +29,38 @@
 
 <DrawerContent>
   <div class="container">
-    <Layout noPadding>
-      <Body size="S">
-        {#if !options.length}
-          Add an option to get started.
-        {/if}
-      </Body>
-
-      <div class="options">
-        {#each options as option (option.id)}
-          <Input
-            placeholder="Label"
-            bind:value={option.label}
-            label="Label"
-            labelPosition="left"
-          />
-          <Input
-            placeholder="Value"
-            bind:value={option.value}
-            label="Value"
-            labelPosition="left"
-          />
-          <Icon
-            name="Close"
-            hoverable
-            size="S"
-            on:click={() => removeOption(option.id)}
-          />
-        {/each}
-      </div>
+    <Layout noPadding gap="S">
+      {#if !options.length}
+        <Body size="S">Add an option to get started.</Body>
+      {/if}
+      {#if options?.length}
+        <div class="options">
+          {#each options as option (option.id)}
+            <Input
+              placeholder="Label"
+              bind:value={option.label}
+              label="Label"
+              labelPosition="left"
+            />
+            <Input
+              placeholder="Value"
+              bind:value={option.value}
+              label="Value"
+              labelPosition="left"
+            />
+            <Icon
+              name="Close"
+              hoverable
+              size="S"
+              on:click={() => removeOption(option.id)}
+            />
+          {/each}
+        </div>
+      {/if}
       <div>
-        <Button icon="AddCircle" size="M" on:click={addOption} secondary
-          >Add Option</Button
-        >
+        <Button icon="AddCircle" size="M" on:click={addOption} secondary>
+          Add Option
+        </Button>
       </div>
     </Layout>
   </div>
@@ -70,7 +69,7 @@
 <style>
   .container {
     width: 100%;
-    max-width: 1000px;
+    max-width: 800px;
     margin: 0 auto;
   }
   .options {
@@ -78,6 +77,6 @@
     column-gap: var(--spacing-l);
     row-gap: var(--spacing-s);
     align-items: center;
-    grid-template-columns: auto auto 20px;
+    grid-template-columns: 1fr 1fr auto;
   }
 </style>

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/OptionsEditor/OptionsEditor.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/OptionsEditor/OptionsEditor.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { notifications, ActionButton, Button, Drawer } from "@budibase/bbui"
+  import { ActionButton, Button, Drawer } from "@budibase/bbui"
   import { createEventDispatcher } from "svelte"
   import OptionsDrawer from "./OptionsDrawer.svelte"
 
@@ -11,10 +11,9 @@
   let tempValue = value || []
 
   const saveFilter = async () => {
-    // Filter out null objects
+    // Filter out incomplete options
     tempValue = tempValue.filter(option => option.value && option.label)
     dispatch("change", tempValue)
-    notifications.success("Options saved.")
     drawer.hide()
   }
 </script>

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/OptionsEditor/OptionsEditor.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/OptionsEditor/OptionsEditor.svelte
@@ -12,7 +12,7 @@
 
   const saveFilter = async () => {
     // Filter out null objects
-    tempValue = tempValue.filter(optionValue => optionValue.value)
+    tempValue = tempValue.filter(option => option.value && option.label)
     dispatch("change", tempValue)
     notifications.success("Options saved.")
     drawer.hide()

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/OptionsEditor/OptionsEditor.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/OptionsEditor/OptionsEditor.svelte
@@ -22,7 +22,7 @@
 <ActionButton on:click={drawer.show}>Define Options</ActionButton>
 <Drawer bind:this={drawer} title="Options">
   <svelte:fragment slot="description">
-    Add custom picker options
+    Define the options for this picker.
   </svelte:fragment>
   <Button cta slot="buttons" on:click={saveFilter}>Save</Button>
   <OptionsDrawer bind:options={tempValue} slot="body" />

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/OptionsEditor/OptionsEditor.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/OptionsEditor/OptionsEditor.svelte
@@ -1,0 +1,29 @@
+<script>
+  import { notifications, ActionButton, Button, Drawer } from "@budibase/bbui"
+  import { createEventDispatcher } from "svelte"
+  import OptionsDrawer from "./OptionsDrawer.svelte"
+
+  const dispatch = createEventDispatcher()
+
+  export let value
+
+  let drawer
+  let tempValue = value || []
+
+  const saveFilter = async () => {
+    // Filter out null objects
+    tempValue = tempValue.filter(optionValue => optionValue.value)
+    dispatch("change", tempValue)
+    notifications.success("Options saved.")
+    drawer.hide()
+  }
+</script>
+
+<ActionButton on:click={drawer.show}>Define Options</ActionButton>
+<Drawer bind:this={drawer} title="Options">
+  <svelte:fragment slot="description">
+    Add custom picker otpions
+  </svelte:fragment>
+  <Button cta slot="buttons" on:click={saveFilter}>Save</Button>
+  <OptionsDrawer bind:options={tempValue} slot="body" />
+</Drawer>

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/OptionsEditor/OptionsEditor.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/OptionsEditor/OptionsEditor.svelte
@@ -22,7 +22,7 @@
 <ActionButton on:click={drawer.show}>Define Options</ActionButton>
 <Drawer bind:this={drawer} title="Options">
   <svelte:fragment slot="description">
-    Add custom picker otpions
+    Add custom picker options
   </svelte:fragment>
   <Button cta slot="buttons" on:click={saveFilter}>Save</Button>
   <OptionsDrawer bind:options={tempValue} slot="body" />

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/componentSettings.js
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/componentSettings.js
@@ -20,6 +20,8 @@ import LongFormFieldSelect from "./LongFormFieldSelect.svelte"
 import DateTimeFieldSelect from "./DateTimeFieldSelect.svelte"
 import AttachmentFieldSelect from "./AttachmentFieldSelect.svelte"
 import RelationshipFieldSelect from "./RelationshipFieldSelect.svelte"
+import OptionsEditor from "./OptionsEditor/OptionsEditor.svelte"
+
 
 const componentMap = {
   text: Input,
@@ -34,6 +36,7 @@ const componentMap = {
   icon: IconSelect,
   field: FieldSelect,
   multifield: MultiFieldSelect,
+  options: OptionsEditor,
   schema: SchemaSelect,
   section: SectionSelect,
   navigation: NavigationEditor,

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/componentSettings.js
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/componentSettings.js
@@ -22,7 +22,6 @@ import AttachmentFieldSelect from "./AttachmentFieldSelect.svelte"
 import RelationshipFieldSelect from "./RelationshipFieldSelect.svelte"
 import OptionsEditor from "./OptionsEditor/OptionsEditor.svelte"
 
-
 const componentMap = {
   text: Input,
   select: Select,

--- a/packages/standard-components/manifest.json
+++ b/packages/standard-components/manifest.json
@@ -1964,7 +1964,15 @@
           "setting": "optionsSource",
           "value": "provider"
         }
+      }, 
+      {
+        "type": "options",
+        "key": "customOptions",
+        "dependsOn": {
+          "setting": "optionsSource",
+          "value": "custom"
       }
+    }
     ]
   },
   "booleanfield": {

--- a/packages/standard-components/manifest.json
+++ b/packages/standard-components/manifest.json
@@ -1893,6 +1893,7 @@
         "type": "select",
         "label": "Type",
         "key": "optionsType",
+        "defaultValue": "select",
         "placeholder": "Pick an options type",
         "options": [
           {
@@ -1915,6 +1916,54 @@
         "label": "Disabled",
         "key": "disabled",
         "defaultValue": false
+      },
+      {
+        "type": "select",
+        "label": "Options source",
+        "key": "optionsSource",
+        "defaultValue": "schema",
+        "placeholder": "Pick an options source",
+        "options": [
+          {
+            "label": "Schema",
+            "value": "schema"
+          },
+          {
+            "label": "Data provider",
+            "value": "provider"
+          },
+          {
+            "label": "Custom",
+            "value": "custom"
+          }
+        ]
+      },
+      {
+        "type": "dataProvider",
+        "label": "Options Provider",
+        "key": "dataProvider",
+        "dependsOn": {
+          "setting": "optionsSource",
+          "value": "provider"
+        }
+      },
+      {
+        "type": "field",
+        "label": "Label Column",
+        "key": "labelColumn",
+        "dependsOn": {
+          "setting": "optionsSource",
+          "value": "provider"
+        }
+      },
+      {
+        "type": "field",
+        "label": "Value Column",
+        "key": "valueColumn",
+        "dependsOn": {
+          "setting": "optionsSource",
+          "value": "provider"
+        }
       }
     ]
   },

--- a/packages/standard-components/src/forms/OptionsField.svelte
+++ b/packages/standard-components/src/forms/OptionsField.svelte
@@ -8,10 +8,51 @@
   export let disabled = false
   export let optionsType = "select"
   export let defaultValue
+  export let optionsSource = "schema"
+  export let dataProvider
+  export let labelColumn
+  export let valueColumn
 
   let fieldState
   let fieldApi
   let fieldSchema
+
+  $: flatOptions = optionsSource == null || optionsSource === "schema"
+  $: options = getOptions(
+    optionsSource,
+    fieldSchema,
+    dataProvider,
+    labelColumn,
+    valueColumn
+  )
+
+  const getOptions = (
+    optionsSource,
+    fieldSchema,
+    dataProvider,
+    labelColumn,
+    valueColumn
+  ) => {
+    // Take options from schema
+    if (optionsSource == null || optionsSource === "schema") {
+      return fieldSchema?.constraints?.inclusion ?? []
+    }
+
+    // Extract options from data provider
+    if (optionsSource === "provider" && valueColumn) {
+      let optionsSet = {}
+      dataProvider?.rows?.forEach(row => {
+        const value = row?.[valueColumn]
+        if (value) {
+          const label = row[labelColumn] || value
+          optionsSet[value] = { value, label }
+        }
+      })
+      return Object.values(optionsSet)
+    }
+
+    return []
+  }
 </script>
 
 <Field
@@ -31,9 +72,11 @@
         id={$fieldState.fieldId}
         disabled={$fieldState.disabled}
         error={$fieldState.error}
-        options={fieldSchema?.constraints?.inclusion ?? []}
+        {options}
         {placeholder}
         on:change={e => fieldApi.setValue(e.detail)}
+        getOptionLabel={flatOptions ? x => x : x => x.label}
+        getOptionValue={flatOptions ? x => x : x => x.value}
       />
     {:else if optionsType === "radio"}
       <RadioGroup

--- a/packages/standard-components/src/forms/OptionsField.svelte
+++ b/packages/standard-components/src/forms/OptionsField.svelte
@@ -12,6 +12,7 @@
   export let dataProvider
   export let labelColumn
   export let valueColumn
+  export let customOptions
 
   let fieldState
   let fieldApi
@@ -49,6 +50,11 @@
         }
       })
       return Object.values(optionsSet)
+    }
+
+    // Extract custom options
+    if (optionsSource === "custom" && customOptions) {
+      return customOptions
     }
 
     return []


### PR DESCRIPTION
Addresses: https://github.com/Budibase/budibase/issues/2094

## Description
This PR adds a dropdown that allows the user to specify the data in a given option picker. 

Previously only the Schema was used, but now Data Provider and Custom options are also available 
## Screenshots

Available options:
<img width="289" alt="Screenshot 2021-08-17 at 11 07 52" src="https://user-images.githubusercontent.com/5665926/129707278-8acdfc6c-5082-4ae0-8ee8-0b85ffca4a96.png">

Data Provider Options:
<img width="264" alt="Screenshot 2021-08-17 at 11 07 58" src="https://user-images.githubusercontent.com/5665926/129707353-8b4a2168-f8ee-4585-b2f5-487995089876.png">

Custom Options:
<img width="240" alt="Screenshot 2021-08-17 at 11 10 49" src="https://user-images.githubusercontent.com/5665926/129707725-05e432ae-24af-440c-ab55-33c4f9642d7f.png">

Custom Options Drawer:
<img width="2093" alt="Screenshot 2021-08-17 at 11 13 04" src="https://user-images.githubusercontent.com/5665926/129708185-e08a9162-3dce-43e4-8242-07aa8801de95.png">

Custom Options Drawer with values:
<img width="2091" alt="Screenshot 2021-08-17 at 11 13 20" src="https://user-images.githubusercontent.com/5665926/129708216-5b589db3-fd32-48d7-b2b2-ac2e7b777fb1.png">

Dropdown with custom values:
<img width="1365" alt="Screenshot 2021-08-17 at 11 13 55" src="https://user-images.githubusercontent.com/5665926/129708254-a00bd12e-2527-4742-b0c3-a9973c0e0add.png">




