### PR TITLE
couchDB auth options

### DIFF
--- a/packages/auth/src/db/utils.js
+++ b/packages/auth/src/db/utils.js
@@ -158,6 +158,17 @@ exports.getDeployedAppID = appId => {
   return appId
 }
 
+exports.getCouchUrl = () => {
+  // username and password already exist in URL
+  if (env.COUCH_DB_URL.includes("@")) {
+    return env.COUCH_DB_URL
+  }
+
+  const [protocol, ...rest] = env.COUCH_DB_URL.split("://")
+
+  return `${protocol}://${env.COUCH_DB_USERNAME}:${env.COUCH_DB_PASSWORD}@${rest}`
+}
+
 /**
  * if in production this will use the CouchDB _all_dbs call to retrieve a list of databases. If testing
  * when using Pouch it will use the pouchdb-all-dbs package.
@@ -167,7 +178,7 @@ exports.getAllDbs = async () => {
   if (env.isTest()) {
     return getCouch().allDbs()
   }
-  const response = await fetch(`${env.COUCH_DB_URL}/_all_dbs`)
+  const response = await fetch(`${exports.getCouchUrl()}/_all_dbs`)
   if (response.status === 200) {
     return response.json()
   } else {

--- a/packages/auth/src/environment.js
+++ b/packages/auth/src/environment.js
@@ -9,6 +9,8 @@ function isTest() {
 module.exports = {
   JWT_SECRET: process.env.JWT_SECRET,
   COUCH_DB_URL: process.env.COUCH_DB_URL,
+  COUCH_DB_USERNAME: process.env.COUCH_DB_USER || process.env.COUCH_DB_USERNAME,
+  COUCH_DB_PASSWORD: process.env.COUCH_DB_PASSWORD,
   SALT_ROUNDS: process.env.SALT_ROUNDS,
   REDIS_URL: process.env.REDIS_URL,
   REDIS_PASSWORD: process.env.REDIS_PASSWORD,

--- a/packages/server/scripts/dev/manage.js
+++ b/packages/server/scripts/dev/manage.js
@@ -37,7 +37,7 @@ async function init() {
     const envFileJson = {
       PORT: 4001,
       MINIO_URL: "http://localhost:10000/",
-      COUCH_DB_URL: "http://budibase:budibase@localhost:10000/db/",
+      COUCH_DB_URL: "http://@localhost:10000/db/",
       REDIS_URL: "localhost:6379",
       WORKER_URL: "http://localhost:4002",
       INTERNAL_API_KEY: "budibase",

--- a/packages/server/src/api/controllers/row/internalSearch.js
+++ b/packages/server/src/api/controllers/row/internalSearch.js
@@ -1,5 +1,4 @@
 const { SearchIndexes } = require("../../../db/utils")
-const env = require("../../../environment")
 const fetch = require("node-fetch")
 const { getCouchUrl } = require("@budibase/auth/db")
 

--- a/packages/server/src/api/controllers/row/internalSearch.js
+++ b/packages/server/src/api/controllers/row/internalSearch.js
@@ -1,6 +1,7 @@
 const { SearchIndexes } = require("../../../db/utils")
 const env = require("../../../environment")
 const fetch = require("node-fetch")
+const { getCouchUrl } = require("@budibase/auth/db")
 
 /**
  * Class to build lucene query URLs.
@@ -233,7 +234,9 @@ class QueryBuilder {
   }
 
   async run() {
-    const url = `${env.COUCH_DB_URL}/${this.appId}/_design/database/_search/${SearchIndexes.ROWS}`
+    const url = `${getCouchUrl()}/${this.appId}/_design/database/_search/${
+      SearchIndexes.ROWS
+    }`
     const body = this.buildSearchBody()
     return await runQuery(url, body)
   }

--- a/packages/server/src/db/client.js
+++ b/packages/server/src/db/client.js
@@ -12,6 +12,10 @@ PouchDB.adapter("writableStream", replicationStream.adapters.writableStream)
 
 let POUCH_DB_DEFAULTS = {
   prefix: COUCH_DB_URL,
+  auth: {
+    username: env.COUCH_DB_USERNAME,
+    password: env.COUCH_DB_PASSWORD,
+  },
 }
 
 if (env.isTest()) {

--- a/packages/server/src/environment.js
+++ b/packages/server/src/environment.js
@@ -24,6 +24,8 @@ module.exports = {
   PORT: process.env.PORT,
   JWT_SECRET: process.env.JWT_SECRET,
   COUCH_DB_URL: process.env.COUCH_DB_URL,
+  COUCH_DB_USERNAME: process.env.COUCH_DB_USER,
+  COUCH_DB_PASSWORD: process.env.COUCH_DB_PASSWORD,
   MINIO_URL: process.env.MINIO_URL,
   WORKER_URL: process.env.WORKER_URL,
   SELF_HOSTED: process.env.SELF_HOSTED,

--- a/packages/worker/scripts/dev/manage.js
+++ b/packages/worker/scripts/dev/manage.js
@@ -17,6 +17,8 @@ async function init() {
       REDIS_PASSWORD: "budibase",
       MINIO_URL: "http://localhost:10000/",
       COUCH_DB_URL: "http://budibase:budibase@localhost:10000/db/",
+      COUCH_DB_USERNAME: "budibase",
+      COUCH_DB_PASSWORD: "budibase",
       // empty string is false
       MULTI_TENANCY: "",
     }

--- a/packages/worker/src/db/index.js
+++ b/packages/worker/src/db/index.js
@@ -7,6 +7,10 @@ const COUCH_DB_URL = env.COUCH_DB_URL || "http://localhost:10000/db/"
 
 let POUCH_DB_DEFAULTS = {
   prefix: COUCH_DB_URL,
+  auth: {
+    username: env.COUCH_DB_USERNAME,
+    password: env.COUCH_DB_PASSWORD,
+  },
 }
 
 if (env.isTest()) {


### PR DESCRIPTION
## Description
Merging this one into `develop` first to test with kubernetes before going to master, because we had some issues with it this morning. This PR is necessary to allow budibase to have couchDB secrets configured correctly by the helm chart.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



