### PR TITLE
Update the name of the datasource

### DIFF
--- a/packages/bbui/src/ActionMenu/ActionMenu.svelte
+++ b/packages/bbui/src/ActionMenu/ActionMenu.svelte
@@ -23,7 +23,7 @@
     dropdown.show()
   }
 
-  const openMenu = (event) => {
+  const openMenu = event => {
     if (!disabled) {
       event.stopPropagation()
       show()

--- a/packages/bbui/src/ActionMenu/ActionMenu.svelte
+++ b/packages/bbui/src/ActionMenu/ActionMenu.svelte
@@ -23,8 +23,11 @@
     dropdown.show()
   }
 
-  const openMenu = () => {
-    if (!disabled) show()
+  const openMenu = (event) => {
+    if (!disabled) {
+      event.stopPropagation()
+      show()
+    }
   }
 
   setContext("actionMenu", { show, hide })

--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/UpdateDatasourceModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/UpdateDatasourceModal.svelte
@@ -1,0 +1,62 @@
+<script>
+  import { datasources } from "stores/backend"
+  import { notifications } from "@budibase/bbui"
+  import { Input, ModalContent, Modal } from "@budibase/bbui"
+  import analytics from "analytics"
+
+  let error = ""
+  let modal
+  let name
+
+  export let datasource
+  export let onCancel = undefined
+
+  export const show = () => {
+    name = datasource?.name
+    modal.show()
+  }
+  export const hide = () => {
+    modal.hide()
+  }
+
+  function checkValid(evt) {
+    const datasourceName = evt.target.value
+    if (
+      $datasources?.list.some(ds => ds.name === datasourceName)
+    ) {
+      error = `Datasource with name ${datasourceName} already exists. Please choose another name.`
+      return
+    }
+    error = ""
+  }
+
+  async function updateDatasource() {
+    const updatedDatasource = {
+      ...datasource,
+      name,
+    }
+    await datasources.save(updatedDatasource)
+    notifications.success(`Datasource ${name} updated successfully.`)
+    analytics.captureEvent("Datasource Updated", updatedDatasource)
+    hide()
+  }
+</script>
+
+<Modal bind:this={modal} on:hide={onCancel}>
+  <ModalContent
+    title="Update Datasource"
+    size="L"
+    confirmText="Update"
+    onConfirm={updateDatasource}
+    disabled={error || !name || !datasource?.type}
+  >
+    <Input
+      data-cy="datasource-name-input"
+      label="Datasource Name"
+      on:input={checkValid}
+      bind:value={name}
+      {error}
+    />
+  </ModalContent>
+</Modal>
+

--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/UpdateDatasourceModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/UpdateDatasourceModal.svelte
@@ -21,9 +21,7 @@
 
   function checkValid(evt) {
     const datasourceName = evt.target.value
-    if (
-      $datasources?.list.some(ds => ds.name === datasourceName)
-    ) {
+    if ($datasources?.list.some(ds => ds.name === datasourceName)) {
       error = `Datasource with name ${datasourceName} already exists. Please choose another name.`
       return
     }
@@ -59,4 +57,3 @@
     />
   </ModalContent>
 </Modal>
-

--- a/packages/builder/src/components/backend/DatasourceNavigator/popovers/EditDatasourcePopover.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/popovers/EditDatasourcePopover.svelte
@@ -4,10 +4,12 @@
   import { notifications } from "@budibase/bbui"
   import { ActionMenu, MenuItem, Icon } from "@budibase/bbui"
   import ConfirmDialog from "components/common/ConfirmDialog.svelte"
+  import UpdateDatasourceModal from "components/backend/DatasourceNavigator/modals/UpdateDatasourceModal.svelte"
 
   export let datasource
 
   let confirmDeleteDialog
+  let updateDatasourceDialog
 
   async function deleteDatasource() {
     const wasSelectedSource = $datasources.selected
@@ -24,6 +26,7 @@
   <div slot="control" class="icon">
     <Icon size="S" hoverable name="MoreSmallList" />
   </div>
+  <MenuItem icon="Edit" on:click={updateDatasourceDialog.show}>Update</MenuItem>
   <MenuItem icon="Delete" on:click={confirmDeleteDialog.show}>Delete</MenuItem>
 </ActionMenu>
 
@@ -37,6 +40,7 @@
   <i>{datasource.name}?</i>
   This action cannot be undone.
 </ConfirmDialog>
+<UpdateDatasourceModal {datasource} bind:this={updateDatasourceDialog} />
 
 <style>
   div.icon {

--- a/packages/builder/src/stores/backend/datasources.js
+++ b/packages/builder/src/stores/backend/datasources.js
@@ -59,9 +59,16 @@ export function createDatasourcesStore() {
       return json
     },
     save: async datasource => {
-      let url = "/api/datasources"
+      let response
+      if (datasource._id) {
+        response = await api.put(
+          `/api/datasources/${datasource._id}`,
+          datasource
+        )
+      } else {
+        response = await api.post("/api/datasources", datasource)
+      }
 
-      const response = await api.post(url, datasource)
       const json = await response.json()
 
       if (response.status !== 200) {

--- a/packages/server/src/api/routes/datasource.js
+++ b/packages/server/src/api/routes/datasource.js
@@ -66,6 +66,11 @@ router
     authorized(PermissionTypes.TABLE, PermissionLevels.READ),
     datasourceController.find
   )
+  .put(
+    "/api/datasources/:datasourceId",
+    authorized(PermissionTypes.TABLE, PermissionLevels.READ),
+    datasourceController.update
+  )
   .post(
     "/api/datasources/query",
     authorized(PermissionTypes.TABLE, PermissionLevels.READ),


### PR DESCRIPTION
## Description
Fixes #2190 - update the name of a non external datasource, using a simple update modal. I also stop the propagation of the actionmenu event, to prevent selecting the navItem when clicking the actionmenu icon.

## Screenshots
### Added update action menu item
![image](https://user-images.githubusercontent.com/1907152/129806271-2f84fa99-fb60-4f64-8c71-9e7c6d1ccf93.png)

### Update datasource modal
![image](https://user-images.githubusercontent.com/1907152/129806304-cc1933a1-e6c4-487e-943e-dbe877d6444c.png)




