### PR TITLE
simplify couchDB configuration

### DIFF
--- a/packages/auth/src/db/utils.js
+++ b/packages/auth/src/db/utils.js
@@ -166,6 +166,12 @@ exports.getCouchUrl = () => {
 
   const [protocol, ...rest] = env.COUCH_DB_URL.split("://")
 
+  if (!env.COUCH_DB_USERNAME || !env.COUCH_DB_PASSWORD) {
+    throw new Error(
+      "CouchDB configuration invalid. You must provide a fully qualified CouchDB url, or the COUCH_DB_USER and COUCH_DB_PASSWORD environment variables."
+    )
+  }
+
   return `${protocol}://${env.COUCH_DB_USERNAME}:${env.COUCH_DB_PASSWORD}@${rest}`
 }
 

--- a/packages/auth/src/db/utils.js
+++ b/packages/auth/src/db/utils.js
@@ -159,6 +159,8 @@ exports.getDeployedAppID = appId => {
 }
 
 exports.getCouchUrl = () => {
+  if (!env.COUCH_DB_URL) return
+
   // username and password already exist in URL
   if (env.COUCH_DB_URL.includes("@")) {
     return env.COUCH_DB_URL

--- a/packages/auth/src/environment.js
+++ b/packages/auth/src/environment.js
@@ -9,7 +9,7 @@ function isTest() {
 module.exports = {
   JWT_SECRET: process.env.JWT_SECRET,
   COUCH_DB_URL: process.env.COUCH_DB_URL,
-  COUCH_DB_USERNAME: process.env.COUCH_DB_USER || process.env.COUCH_DB_USERNAME,
+  COUCH_DB_USERNAME: process.env.COUCH_DB_USER,
   COUCH_DB_PASSWORD: process.env.COUCH_DB_PASSWORD,
   SALT_ROUNDS: process.env.SALT_ROUNDS,
   REDIS_URL: process.env.REDIS_URL,

--- a/packages/server/src/db/client.js
+++ b/packages/server/src/db/client.js
@@ -1,10 +1,11 @@
 const PouchDB = require("pouchdb")
+const { getCouchUrl } = require("@budibase/auth/db")
 const replicationStream = require("pouchdb-replication-stream")
 const allDbs = require("pouchdb-all-dbs")
 const find = require("pouchdb-find")
 const env = require("../environment")
 
-const COUCH_DB_URL = env.COUCH_DB_URL || "http://localhost:10000/db/"
+const COUCH_DB_URL = getCouchUrl() || "http://localhost:10000/db/"
 
 PouchDB.plugin(replicationStream.plugin)
 PouchDB.plugin(find)
@@ -12,13 +13,6 @@ PouchDB.adapter("writableStream", replicationStream.adapters.writableStream)
 
 let POUCH_DB_DEFAULTS = {
   prefix: COUCH_DB_URL,
-}
-
-if (env.COUCH_DB_USERNAME && env.COUCH_DB_PASSWORD) {
-  POUCH_DB_DEFAULTS.auth = {
-    username: env.COUCH_DB_USERNAME,
-    password: env.COUCH_DB_PASSWORD,
-  }
 }
 
 if (env.isTest()) {

--- a/packages/server/src/environment.js
+++ b/packages/server/src/environment.js
@@ -24,8 +24,6 @@ module.exports = {
   PORT: process.env.PORT,
   JWT_SECRET: process.env.JWT_SECRET,
   COUCH_DB_URL: process.env.COUCH_DB_URL,
-  COUCH_DB_USERNAME: process.env.COUCH_DB_USER,
-  COUCH_DB_PASSWORD: process.env.COUCH_DB_PASSWORD,
   MINIO_URL: process.env.MINIO_URL,
   WORKER_URL: process.env.WORKER_URL,
   SELF_HOSTED: process.env.SELF_HOSTED,

--- a/packages/worker/src/db/index.js
+++ b/packages/worker/src/db/index.js
@@ -1,19 +1,13 @@
 const PouchDB = require("pouchdb")
 const allDbs = require("pouchdb-all-dbs")
 const env = require("../environment")
+const { getCouchUrl } = require("@budibase/auth/db")
 
 // level option is purely for testing (development)
-const COUCH_DB_URL = env.COUCH_DB_URL || "http://localhost:10000/db/"
+const COUCH_DB_URL = getCouchUrl() || "http://localhost:10000/db/"
 
 let POUCH_DB_DEFAULTS = {
   prefix: COUCH_DB_URL,
-}
-
-if (env.COUCH_DB_USERNAME && env.COUCH_DB_PASSWORD) {
-  POUCH_DB_DEFAULTS.auth = {
-    username: env.COUCH_DB_USERNAME,
-    password: env.COUCH_DB_PASSWORD,
-  }
 }
 
 if (env.isTest()) {


### PR DESCRIPTION
## Description
Simplify couchDB configuration that will work both across docker-compose and kubernetes environments by centralising how the couchDB Url is fetched. This also adds some validation to ensure that budibase can connect to couch, and will throw an error if the URL cannot be formed correctly.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



