### PR TITLE
limit the width of the preview component

### DIFF
--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -218,6 +218,7 @@
 
   .viewer {
     min-height: 200px;
+    width: 640px;
   }
 
   .preview {


### PR DESCRIPTION
## Description
Fixes #2189 - limits the width of the query builder results view

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/1907152/130475506-66c88390-b8f7-443f-9945-10869f6275b6.png)

### After
![image](https://user-images.githubusercontent.com/1907152/130475576-71fe6c84-1e93-4046-91cf-6692cae11329.png)



