### PR TITLE
Replace 'replaceAll' with 'replace' and a regular expression

### DIFF
--- a/packages/builder/src/components/design/AppPreview/CurrentItemPreview.svelte
+++ b/packages/builder/src/components/design/AppPreview/CurrentItemPreview.svelte
@@ -58,7 +58,7 @@
   // By deleting all _rev properties we can avoid this and increase
   // performance.
   $: json = JSON.stringify(previewData)
-  $: strippedJson = json.replaceAll(/"_rev":\s*"[^"]+"/g, `"_rev":""`)
+  $: strippedJson = json.replace(/"_rev":\s*"[^"]+"/g, `"_rev":""`)
 
   // Update the iframe with the builder info to render the correct preview
   const refreshContent = message => {

--- a/packages/builder/src/components/design/NavigationPanel/NewScreenModal.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/NewScreenModal.svelte
@@ -84,7 +84,7 @@
     if (!event.detail.startsWith("/")) {
       route = "/" + event.detail
     }
-    route = route.replaceAll(" ", "-")
+    route = route.replace(/ +/g, "-")
   }
 </script>
 

--- a/packages/builder/src/components/design/PropertiesPanel/ScreenSettingsSection.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/ScreenSettingsSection.svelte
@@ -37,7 +37,7 @@
       key: "routing.route",
       label: "Route",
       control: Input,
-      parser: val => val.replaceAll(" ", "-"),
+      parser: val => val.replace(/ +/g, "-"),
     },
     { key: "routing.roleId", label: "Access", control: RoleSelect },
     { key: "layoutId", label: "Layout", control: LayoutSelect },


### PR DESCRIPTION
## Description
Older browser don't support replaceAll yet, so it's better to use a regular expression to replace all occurrences in a string, to support the older browsers.
So, instead of `string.replaceAll(" ", "-")` we use `string.replace(/ +/g, "-")`

