### PR TITLE
Filter users table out of DataSource component and NewScreenModal

### DIFF
--- a/packages/builder/src/components/design/NavigationPanel/NewScreenModal.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/NewScreenModal.svelte
@@ -1,7 +1,6 @@
 <script>
   import { store, allScreens, selectedAccessRole } from "builderStore"
-  import { tables } from "stores/backend"
-  import { roles } from "stores/backend"
+  import { tables, roles } from "stores/backend"
   import { Input, Select, ModalContent, Toggle } from "@budibase/bbui"
   import getTemplates from "builderStore/store/screenTemplates"
   import analytics from "analytics"
@@ -16,7 +15,7 @@
   let createLink = true
   let roleId = $selectedAccessRole || "BASIC"
 
-  $: templates = getTemplates($store, $tables.list)
+  $: templates = getTemplates($store, tables.getDataSources())
   $: route = !route && $allScreens.length === 0 ? "*" : route
   $: {
     if (templates && templateIndex === undefined) {

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/DataSourceSelect.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/DataSourceSelect.svelte
@@ -31,7 +31,7 @@
   export let bindings = []
 
   $: text = value?.label ?? "Choose an option"
-  $: tables = $tablesStore.list.map(m => ({
+  $: tables = tablesStore.getDataSources().map(m => ({
     label: m.name,
     tableId: m._id,
     type: "table",

--- a/packages/builder/src/stores/backend/tables.js
+++ b/packages/builder/src/stores/backend/tables.js
@@ -87,6 +87,7 @@ export function createTablesStore() {
         draft: {},
       })
     },
+    getDataSources: () => get(store).list.filter(t => t.name !== "Users"),
     delete: async table => {
       await api.delete(`/api/tables/${table._id}/${table._rev}`)
       update(state => ({


### PR DESCRIPTION
## Description
Fixes #2018 - filter out Users table from NewScreenModal template selector and DataSourceSelect.

### Discussion
I'm not sure if this is the desired solution for preventing creating users from the UI, because now it's not possible to bind the Users table to anything, not even for viewing only. As fas as I know the DatasourceSelect is not aware if a form is selected or a dataprovider, so it cannot filter out the Users table conditionally. Is that a correct assumption?

## Screenshots
### NewScreenModal
![image](https://user-images.githubusercontent.com/1907152/130602049-b70cd726-9011-4c7f-b67a-f700bf28eb35.png)

### DataSourceSelect
![image](https://user-images.githubusercontent.com/1907152/130602158-c8358d01-c380-48fe-8ac9-2eea45e0ce1c.png)




