### PR TITLE
Prevent opening a screen modal if already inside a screen modal

### DIFF
--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -42,7 +42,9 @@ const triggerAutomationHandler = async action => {
 const navigationHandler = action => {
   const { url, peek } = action.parameters
   if (url) {
-    if (peek) {
+    // If we're already peeking, don't peek again
+    const isPeeking = get(routeStore).queryParams?.peek
+    if (peek && !isPeeking) {
       peekStore.actions.showPeek(url)
     } else {
       const external = !url.startsWith("/")


### PR DESCRIPTION
## Description
This PR prevents opening a screen modal when already inside a screen modal. Addresses feedback from QA described here: https://github.com/Budibase/budibase/issues/2103#issuecomment-904605995

The solution was easier than I thought. We can simply treat every navigation as a normal navigation if we're already inside a screen modal, which then just always updates the modal's URL.


