### PR TITLE
making sure relationships for autocolumns are created when uploading …

### DIFF
--- a/packages/server/src/api/controllers/table/utils.js
+++ b/packages/server/src/api/controllers/table/utils.js
@@ -1,4 +1,5 @@
 const CouchDB = require("../../../db")
+const linkRows = require("../../../db/linkedRows")
 const csvParser = require("../../../utilities/csvParser")
 const {
   getRowParams,
@@ -74,6 +75,15 @@ exports.handleDataImport = async (appId, user, table, dataImport) => {
       const processed = inputProcessing(user, table, row)
       table = processed.table
       row = processed.row
+      // make sure link rows are up to date
+      row = await linkRows.updateLinks({
+        appId,
+        eventType: linkRows.EventType.ROW_SAVE,
+        row,
+        tableId: row.tableId,
+        table,
+      })
+
       for (let [fieldName, schema] of Object.entries(table.schema)) {
         // check whether the options need to be updated for inclusion as part of the data import
         if (


### PR DESCRIPTION
## Description
Fixing an issue where link docs were not being created on CSV upload. This caused calls to `edit` to throw an error due to the broken links. This has actually always been an issue, but we just didn't detect it until we added some recent code that depends on the relationship link documents.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



