### PR TITLE
make labels for editing more consistent

### DIFF
--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/UpdateDatasourceModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/UpdateDatasourceModal.svelte
@@ -42,9 +42,9 @@
 
 <Modal bind:this={modal} on:hide={onCancel}>
   <ModalContent
-    title="Update Datasource"
+    title="Edit Datasource"
     size="L"
-    confirmText="Update"
+    confirmText="Save"
     onConfirm={updateDatasource}
     disabled={error || !name || !datasource?.type}
   >

--- a/packages/builder/src/components/backend/DatasourceNavigator/popovers/EditDatasourcePopover.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/popovers/EditDatasourcePopover.svelte
@@ -26,7 +26,7 @@
   <div slot="control" class="icon">
     <Icon size="S" hoverable name="MoreSmallList" />
   </div>
-  <MenuItem icon="Edit" on:click={updateDatasourceDialog.show}>Update</MenuItem>
+  <MenuItem icon="Edit" on:click={updateDatasourceDialog.show}>Edit</MenuItem>
   <MenuItem icon="Delete" on:click={confirmDeleteDialog.show}>Delete</MenuItem>
 </ActionMenu>
 

--- a/packages/builder/src/components/start/AppCard.svelte
+++ b/packages/builder/src/components/start/AppCard.svelte
@@ -54,9 +54,7 @@
           </MenuItem>
         {/if}
         {#if !app.deployed}
-          <MenuItem on:click={() => updateApp(app)} icon="Edit">
-            Update
-          </MenuItem>
+          <MenuItem on:click={() => updateApp(app)} icon="Edit">Edit</MenuItem>
           <MenuItem on:click={() => deleteApp(app)} icon="Delete">
             Delete
           </MenuItem>

--- a/packages/builder/src/components/start/AppRow.svelte
+++ b/packages/builder/src/components/start/AppRow.svelte
@@ -83,7 +83,7 @@
       </MenuItem>
     {/if}
     {#if !app.deployed}
-      <MenuItem on:click={() => updateApp(app)} icon="Edit">Update</MenuItem>
+      <MenuItem on:click={() => updateApp(app)} icon="Edit">Edit</MenuItem>
       <MenuItem on:click={() => deleteApp(app)} icon="Delete">Delete</MenuItem>
     {/if}
   </ActionMenu>

--- a/packages/builder/src/components/start/UpdateAppModal.svelte
+++ b/packages/builder/src/components/start/UpdateAppModal.svelte
@@ -103,8 +103,8 @@
 
 <Modal bind:this={modal} on:hide={onCancel} on:show={onShow}>
   <ModalContent
-    title={"Update app"}
-    confirmText={"Update app"}
+    title={"Edit app"}
+    confirmText={"Save"}
     onConfirm={updateApp}
     disabled={!(valid && dirty)}
   >


### PR DESCRIPTION
## Description
Fixes #2458 - `update` labels should be `edit`, since they all do the same thing: updating the name of the resource.

## Screenshots
### Update app context menu
<img width="377" alt="image" src="https://user-images.githubusercontent.com/1907152/130784073-e37a545b-636b-497d-b6a3-786c4dd95e0a.png">

### Update app modal
<img width="398" alt="image" src="https://user-images.githubusercontent.com/1907152/130784118-f0581a0b-019e-4796-ae70-f4987f86dced.png">

### Update datasource context menu
<img width="374" alt="image" src="https://user-images.githubusercontent.com/1907152/130784174-4e542ef6-b234-45de-af2b-739a3f5e5ed8.png">

### Update datasource modal
<img width="640" alt="image" src="https://user-images.githubusercontent.com/1907152/130784211-039d9467-6933-4147-9ba4-23ff3ace4601.png">




