### PR TITLE
Revert "Filter users table out of DataSource component and NewScreenModal"

### DIFF
--- a/packages/builder/src/components/design/NavigationPanel/NewScreenModal.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/NewScreenModal.svelte
@@ -1,6 +1,7 @@
 <script>
   import { store, allScreens, selectedAccessRole } from "builderStore"
-  import { tables, roles } from "stores/backend"
+  import { tables } from "stores/backend"
+  import { roles } from "stores/backend"
   import { Input, Select, ModalContent, Toggle } from "@budibase/bbui"
   import getTemplates from "builderStore/store/screenTemplates"
   import analytics from "analytics"
@@ -15,7 +16,7 @@
   let createLink = true
   let roleId = $selectedAccessRole || "BASIC"
 
-  $: templates = getTemplates($store, tables.getDataSources())
+  $: templates = getTemplates($store, $tables.list)
   $: route = !route && $allScreens.length === 0 ? "*" : route
   $: {
     if (templates && templateIndex === undefined) {

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/DataSourceSelect.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/DataSourceSelect.svelte
@@ -31,7 +31,7 @@
   export let bindings = []
 
   $: text = value?.label ?? "Choose an option"
-  $: tables = tablesStore.getDataSources().map(m => ({
+  $: tables = $tablesStore.list.map(m => ({
     label: m.name,
     tableId: m._id,
     type: "table",

--- a/packages/builder/src/stores/backend/tables.js
+++ b/packages/builder/src/stores/backend/tables.js
@@ -87,7 +87,6 @@ export function createTablesStore() {
         draft: {},
       })
     },
-    getDataSources: () => get(store).list.filter(t => t.name !== "Users"),
     delete: async table => {
       await api.delete(`/api/tables/${table._id}/${table._rev}`)
       update(state => ({


### PR DESCRIPTION
Reverts Budibase/budibase#2446

We are reverting this for now due to the comments made in the original PR. 

The way we solve this requires more thought, before removing potentially useful functionality for users.