### PR TITLE
add patch method to the rest api interface

### DIFF
--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -89,6 +89,26 @@ module RestModule {
           },
         },
       },
+      patch: {
+        displayName: "PATCH",
+        readable: true,
+        type: QueryTypes.FIELDS,
+        urlDisplay: true,
+        fields: {
+          path: {
+            type: DatasourceFieldTypes.STRING,
+          },
+          queryString: {
+            type: DatasourceFieldTypes.STRING,
+          },
+          headers: {
+            type: DatasourceFieldTypes.OBJECT,
+          },
+          requestBody: {
+            type: DatasourceFieldTypes.JSON,
+          },
+        },
+      },
       delete: {
         displayName: "DELETE",
         type: QueryTypes.FIELDS,
@@ -168,6 +188,21 @@ module RestModule {
 
       const response = await fetch(this.config.url + path + queryString, {
         method: "POST",
+        headers: this.headers,
+        body: JSON.stringify(json),
+      })
+
+      return await this.parseResponse(response)
+    }
+
+    async patch({ path = "", queryString = "", headers = {}, json = {} }) {
+      this.headers = {
+        ...this.config.defaultHeaders,
+        ...headers,
+      }
+
+      const response = await fetch(this.config.url + path + queryString, {
+        method: "PATCH",
         headers: this.headers,
         body: JSON.stringify(json),
       })


### PR DESCRIPTION
## Description
Fixes #2482 - Adds the patch http method to the REST api datasource type. 

## Screenshots
![image](https://user-images.githubusercontent.com/1907152/131406148-fd8e92a2-df32-4780-87a9-ca83f55e70ce.png)




