### PR TITLE
Fix form binding to attachments in forms

### DIFF
--- a/packages/standard-components/src/forms/Field.svelte
+++ b/packages/standard-components/src/forms/Field.svelte
@@ -25,6 +25,7 @@
   const labelPosition = fieldGroupContext?.labelPosition || "above"
   const formField = formApi?.registerField(
     field,
+    type,
     defaultValue,
     disabled,
     validation,


### PR DESCRIPTION
This PR fixes #2481.

Forms now expose additional context enrichments so that binding to attachments works the same as it does when binding to an attachment type of a row returned by the API. Attachments bindings are enriched so that the URL of the first attachment is displayed, and so this is the behaviour that happens for forms now as well.

Here's an (ugly) example showing an identical binding to an attachment from 3 different places, the last one being bound to a form field.
![image](https://user-images.githubusercontent.com/9075550/131495143-e222f81e-a1c1-4ec4-9c75-b329ddc9cab6.png)
