### PR TITLE
Fix indexing of rows with attachments

### DIFF
--- a/packages/server/src/db/views/staticViews.js
+++ b/packages/server/src/db/views/staticViews.js
@@ -100,11 +100,11 @@ exports.createAllSearchIndex = async appId => {
           let idxKey = prev != null ? `${prev}.${key}` : key
           idxKey = idxKey.replace(/ /, "_")
           if (Array.isArray(input[key])) {
-            for (let val in input[key]) {
-              // eslint-disable-next-line no-undef
-              index(idxKey, input[key][val], {
-                store: true,
-              })
+            for (let val of input[key]) {
+              if (typeof val !== "object") {
+                // eslint-disable-next-line no-undef
+                index(idxKey, val, { store: true })
+              }
             }
           } else if (key === "_id" || key === "_rev" || input[key] == null) {
             continue


### PR DESCRIPTION
## Description
This fixes an issue where having an attachment on a row means the row will not be indexed correctly by lucene, and therefore never be pulled back inside data providers. The problem was that we added the capability to index array values in order to implement the multi-select options type, but we did not check the type of the items inside the array. Attempting to index full objects is what causes it to break.

Fixes #2523.

PR'ing straight to master as this is a pretty significant bug which is currently live.

## Screenshots
Before (only the row without an attachment is returned)
![image](https://user-images.githubusercontent.com/9075550/131833074-0d00a5f9-9cf1-4193-abec-0a9af6841e48.png)

After (all rows are returned, including one with an attachment)
![image](https://user-images.githubusercontent.com/9075550/131833137-fa9e0728-871d-4627-b18f-cdc24359d216.png)



