### PR TITLE
Fix table two-way binding of data

### DIFF
--- a/packages/bbui/src/Table/Table.svelte
+++ b/packages/bbui/src/Table/Table.svelte
@@ -3,6 +3,7 @@
   import "@spectrum-css/table/dist/index-vars.css"
   import CellRenderer from "./CellRenderer.svelte"
   import SelectEditRenderer from "./SelectEditRenderer.svelte"
+  import { cloneDeep } from "lodash"
 
   /**
    * The expected schema is our normal couch schemas for our tables.
@@ -197,7 +198,7 @@
 
   const editRow = (e, row) => {
     e.stopPropagation()
-    dispatch("editrow", row)
+    dispatch("editrow", cloneDeep(row))
   }
 
   const toggleSelectRow = row => {


### PR DESCRIPTION
## Description
This fixes an obscure issue that no one has probably ever seen other than Mike, who discovered that if you view a table in the data section that has relationships, click edit, close the edit modal, then sort the table, then the relationships stop displaying.

This was due to the relationship editor that appears when you click "edit" actually mutating the value of the table row to be a flat array of ID's. This is the intended function of the relationship editor, but it should not be directly mutating the actual row object that the table is displaying. So this was fixed by deeply cloning the object passed back from the table's `editrow` callback.

