### PR TITLE
Fixing issue with relationships that was uncovered by having same primary display and table name

### DIFF
--- a/packages/client/src/api/rows.js
+++ b/packages/client/src/api/rows.js
@@ -121,7 +121,7 @@ export const enrichRows = async (rows, tableId) => {
       rows.forEach(row => {
         for (let key of keys) {
           const type = schema[key].type
-          if (type === "link") {
+          if (type === "link" && Array.isArray(row[key])) {
             // Enrich row a string join of relationship fields
             row[`${key}_text`] =
               row[key]

--- a/packages/client/src/api/rows.js
+++ b/packages/client/src/api/rows.js
@@ -112,13 +112,21 @@ export const enrichRows = async (rows, tableId) => {
   if (!Array.isArray(rows)) {
     return []
   }
-  if (rows.length && tableId) {
-    // Fetch table schema so we can check column types
-    const tableDefinition = await fetchTableDefinition(tableId)
-    const schema = tableDefinition && tableDefinition.schema
-    if (schema) {
-      const keys = Object.keys(schema)
-      rows.forEach(row => {
+  if (rows.length) {
+    // map of tables, incase a row being loaded is not from the same table
+    const tables = {}
+    for (let row of rows) {
+      // fallback to passed in tableId if row doesn't have it specified
+      let rowTableId = row.tableId || tableId
+      let table = tables[rowTableId]
+      if (!table) {
+        // Fetch table schema so we can check column types
+        table = await fetchTableDefinition(rowTableId)
+        tables[rowTableId] = table
+      }
+      const schema = table?.schema
+      if (schema) {
+        const keys = Object.keys(schema)
         for (let key of keys) {
           const type = schema[key].type
           if (type === "link" && Array.isArray(row[key])) {
@@ -137,7 +145,7 @@ export const enrichRows = async (rows, tableId) => {
             row[`${key}_first`] = url
           }
         }
-      })
+      }
     }
   }
   return rows


### PR DESCRIPTION
## Description
Issue is described here: https://github.com/Budibase/budibase/issues/2378

This is a simple fix for this issue, when using the enrich call rows may not all be from the same table, for whatever reason this is uncovered by the issue.



