### PR TITLE
fix exporting internal tables

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/ExportModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/ExportModal.svelte
@@ -18,12 +18,10 @@
   let exportFormat = FORMATS[0].key
 
   async function exportView() {
-    const filename = `export.${exportFormat}`
     download(
       `/api/views/export?view=${encodeURIComponent(
         view
-      )}&format=${exportFormat}`,
-      filename
+      )}&format=${exportFormat}`
     )
   }
 </script>


### PR DESCRIPTION
## Description
Fixes #2526 - exporting internal tables. The issue was caused by downloadjs: when passing a filename argument to downloadjs, it expects a payload instead of getting the data from the passed url. 

### Discussion
The downside from this is that the filename is automatically set by downloadjs and cannot be passed to the download function (it uses the last part of the path). So every export will be called `export` (without an extension). I'm not sure if this is what we want. 



