### PR TITLE
fix fetching tables from database with uppercase name

### DIFF
--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -152,7 +152,7 @@ module MySQLModule {
         false
       )
       const tableNames = tablesResp.map(
-        (obj: any) => obj[`Tables_in_${database}`]
+        (obj: any) => obj[`Tables_in_${database.toLowerCase()}`]
       )
       for (let tableName of tableNames) {
         const primaryKeys = []


### PR DESCRIPTION
## Description
Fixes #2550 - It is not possible to fetch tables from a database with a name in CapitalCase



