### PR TITLE
add link to checklist items for direct navigation (and lint issues)

### DIFF
--- a/packages/builder/src/components/common/ConfigChecklist.svelte
+++ b/packages/builder/src/components/common/ConfigChecklist.svelte
@@ -27,7 +27,7 @@
         on:click={() => $goto($admin.checklist[checklistItem].link)}
       >
         <span>{idx + 1}. {$admin.checklist[checklistItem].label}</span>
-        <Checkbox value={!!$admin.checklist[checklistItem].checked} />
+        <Checkbox value={$admin.checklist[checklistItem].checked} />
       </div>
     </MenuItem>
   {/each}

--- a/packages/builder/src/components/common/ConfigChecklist.svelte
+++ b/packages/builder/src/components/common/ConfigChecklist.svelte
@@ -7,13 +7,7 @@
     ProgressCircle,
   } from "@budibase/bbui"
   import { admin } from "stores/portal"
-
-  const MESSAGES = {
-    apps: "Create your first app",
-    smtp: "Set up email",
-    adminUser: "Create your first user",
-    sso: "Set up single sign-on",
-  }
+  import { goto } from "@roxi/routify"
 </script>
 
 <ActionMenu>
@@ -28,9 +22,12 @@
   </MenuItem>
   {#each Object.keys($admin.checklist) as checklistItem, idx}
     <MenuItem>
-      <div class="item">
-        <span>{idx + 1}. {MESSAGES[checklistItem]}</span>
-        <Checkbox value={!!$admin.checklist[checklistItem]} />
+      <div
+        class="item"
+        on:click={() => $goto($admin.checklist[checklistItem].link)}
+      >
+        <span>{idx + 1}. {$admin.checklist[checklistItem].label}</span>
+        <Checkbox value={!!$admin.checklist[checklistItem].checked} />
       </div>
     </MenuItem>
   {/each}

--- a/packages/builder/src/pages/builder/_layout.svelte
+++ b/packages/builder/src/pages/builder/_layout.svelte
@@ -6,7 +6,7 @@
   let loaded = false
 
   $: multiTenancyEnabled = $admin.multiTenancy
-  $: hasAdminUser = !!$admin?.checklist?.adminUser.checked
+  $: hasAdminUser = $admin?.checklist?.adminUser.checked
   $: tenantSet = $auth.tenantSet
 
   onMount(async () => {
@@ -26,7 +26,6 @@
       $redirect("./admin")
     }
   }
-
   // Redirect to log in at any time if the user isn't authenticated
   $: {
     if (

--- a/packages/builder/src/pages/builder/_layout.svelte
+++ b/packages/builder/src/pages/builder/_layout.svelte
@@ -6,7 +6,7 @@
   let loaded = false
 
   $: multiTenancyEnabled = $admin.multiTenancy
-  $: hasAdminUser = !!$admin?.checklist?.adminUser
+  $: hasAdminUser = !!$admin?.checklist?.adminUser.checked
   $: tenantSet = $auth.tenantSet
 
   onMount(async () => {

--- a/packages/builder/src/pages/builder/admin/_layout.svelte
+++ b/packages/builder/src/pages/builder/admin/_layout.svelte
@@ -6,7 +6,7 @@
   let loaded = false
 
   onMount(() => {
-    if ($admin?.checklist?.adminUser) {
+    if ($admin?.checklist?.adminUser.checked) {
       $redirect("../")
     } else {
       loaded = true

--- a/packages/builder/src/stores/portal/admin.js
+++ b/packages/builder/src/stores/portal/admin.js
@@ -8,7 +8,12 @@ export function createAdminStore() {
     multiTenancy: false,
     sandbox: false,
     onboardingProgress: 0,
-    checklist: { apps: 0, smtp: false, adminUser: false, sso: false },
+    checklist: {
+      apps: { checked: false },
+      smtp: { checked: false },
+      adminUser: { checked: false },
+      sso: { checked: false },
+    },
   }
 
   const admin = writable(DEFAULT_CONFIG)

--- a/packages/builder/src/stores/portal/admin.js
+++ b/packages/builder/src/stores/portal/admin.js
@@ -24,7 +24,7 @@ export function createAdminStore() {
       const onboardingSteps = Object.keys(json)
 
       const stepsComplete = onboardingSteps.reduce(
-        (score, step) => score + Number(!!json[step]),
+        (score, step) => (score + step.checked ? 1 : 0),
         0
       )
 

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -6,8 +6,16 @@ import {
   SearchFilters,
   SortJson,
 } from "../../../definitions/datasource"
-import {Datasource, FieldSchema, Row, Table} from "../../../definitions/common"
-import {breakRowIdField, generateRowIdField} from "../../../integrations/utils"
+import {
+  Datasource,
+  FieldSchema,
+  Row,
+  Table,
+} from "../../../definitions/common"
+import {
+  breakRowIdField,
+  generateRowIdField,
+} from "../../../integrations/utils"
 import { RelationshipTypes } from "../../../constants"
 
 interface ManyRelationship {
@@ -348,7 +356,7 @@ module External {
      * information.
      */
     async lookupRelations(tableId: string, row: Row) {
-      const related: {[key: string]: any} = {}
+      const related: { [key: string]: any } = {}
       const { tableName } = breakExternalTableId(tableId)
       const table = this.tables[tableName]
       // @ts-ignore
@@ -387,7 +395,11 @@ module External {
      * isn't supposed to exist anymore and delete those. This is better than the usual method of delete them
      * all and then re-create, as theres no chance of losing data (e.g. delete succeed, but write fail).
      */
-    async handleManyRelationships(mainTableId: string, row: Row, relationships: ManyRelationship[]) {
+    async handleManyRelationships(
+      mainTableId: string,
+      row: Row,
+      relationships: ManyRelationship[]
+    ) {
       const { appId } = this
       // if we're creating (in a through table) need to wipe the existing ones first
       const promises = []
@@ -399,8 +411,10 @@ module External {
         // @ts-ignore
         const linkPrimary = linkTable.primary[0]
         const rows = related[key].rows || []
-        const found = rows.find((row: { [key: string]: any }) =>
-          row[linkPrimary] === relationship.id || row[linkPrimary] === body[linkPrimary]
+        const found = rows.find(
+          (row: { [key: string]: any }) =>
+            row[linkPrimary] === relationship.id ||
+            row[linkPrimary] === body[linkPrimary]
         )
         const operation = isUpdate
           ? DataSourceOperation.UPDATE
@@ -420,13 +434,17 @@ module External {
         }
       }
       // finally cleanup anything that needs to be removed
-      for (let [colName, {isMany, rows, tableId}] of Object.entries(related)) {
+      for (let [colName, { isMany, rows, tableId }] of Object.entries(
+        related
+      )) {
         const table = this.getTable(tableId)
         for (let row of rows) {
           const filters = buildFilters(generateIdForRow(row, table), {}, table)
           // safety check, if there are no filters on deletion bad things happen
           if (Object.keys(filters).length !== 0) {
-            const op = isMany ? DataSourceOperation.DELETE : DataSourceOperation.UPDATE
+            const op = isMany
+              ? DataSourceOperation.DELETE
+              : DataSourceOperation.UPDATE
             const body = isMany ? null : { [colName]: null }
             promises.push(
               makeExternalQuery(this.appId, {
@@ -448,7 +466,10 @@ module External {
      * Creating the specific list of fields that we desire, and excluding the ones that are no use to us
      * is more performant and has the added benefit of protecting against this scenario.
      */
-    buildFields(table: Table, includeRelations: IncludeRelationships = IncludeRelationships.INCLUDE) {
+    buildFields(
+      table: Table,
+      includeRelations: IncludeRelationships = IncludeRelationships.INCLUDE
+    ) {
       function extractNonLinkFieldNames(table: Table, existing: string[] = []) {
         return Object.entries(table.schema)
           .filter(
@@ -523,7 +544,10 @@ module External {
       // can't really use response right now
       const response = await makeExternalQuery(appId, json)
       // handle many to many relationships now if we know the ID (could be auto increment)
-      if (operation !== DataSourceOperation.READ && processed.manyRelationships) {
+      if (
+        operation !== DataSourceOperation.READ &&
+        processed.manyRelationships
+      ) {
         await this.handleManyRelationships(
           table._id || "",
           response[0],

--- a/packages/server/src/definitions/datasource.ts
+++ b/packages/server/src/definitions/datasource.ts
@@ -42,7 +42,7 @@ export enum SourceNames {
 
 export enum IncludeRelationships {
   INCLUDE = 1,
-  EXCLUDE = 0
+  EXCLUDE = 0,
 }
 
 export interface QueryDefinition {

--- a/packages/worker/src/api/controllers/global/configs.js
+++ b/packages/worker/src/api/controllers/global/configs.js
@@ -248,10 +248,26 @@ exports.configChecklist = async function (ctx) {
     const adminUser = users.rows.some(row => row.doc.admin)
 
     ctx.body = {
-      apps: apps.length,
-      smtp: !!smtpConfig,
-      adminUser,
-      sso: !!googleConfig || !!oidcConfig,
+      apps: {
+        checked: apps.length > 0,
+        label: "Create your first app",
+        link: "/builder/portal/apps",
+      },
+      smtp: {
+        checked: !!smtpConfig,
+        label: "Set up email",
+        link: "/builder/portal/manage/email",
+      },
+      adminUser: {
+        checked: adminUser != null,
+        label: "Create your first user",
+        link: "/builder/portal/manage/users",
+      },
+      sso: {
+        checked: !!googleConfig || !!oidcConfig,
+        label: "Set up single sign-on",
+        link: "/builder/portal/manage/auth",
+      },
     }
   } catch (err) {
     ctx.throw(err.status, err)

--- a/packages/worker/src/api/controllers/global/configs.js
+++ b/packages/worker/src/api/controllers/global/configs.js
@@ -259,7 +259,7 @@ exports.configChecklist = async function (ctx) {
         link: "/builder/portal/manage/email",
       },
       adminUser: {
-        checked: adminUser != null,
+        checked: adminUser,
         label: "Create your first user",
         link: "/builder/portal/manage/users",
       },

--- a/packages/worker/src/api/routes/tests/configs.spec.js
+++ b/packages/worker/src/api/routes/tests/configs.spec.js
@@ -4,7 +4,7 @@ const setup = require("./utilities")
 jest.mock("nodemailer")
 const nodemailer = require("nodemailer")
 nodemailer.createTransport.mockReturnValue({
-  verify: jest.fn()
+  verify: jest.fn(),
 })
 
 describe("/api/global/configs/checklist", () => {
@@ -25,11 +25,11 @@ describe("/api/global/configs/checklist", () => {
       .set(config.defaultHeaders())
       .expect("Content-Type", /json/)
       .expect(200)
-    
+
     const checklist = res.body
 
-    expect(checklist.apps).toBe(0)
-    expect(checklist.smtp).toBe(true)
-    expect(checklist.adminUser).toBe(true)
+    expect(checklist.apps.checked).toBeFalsy()
+    expect(checklist.smtp.checked).toBeTruthy()
+    expect(checklist.adminUser.checked).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Description
Fixes  #2397
The onboarding checklist on the portal screen only contains checks at the moment. This PR adds links to the items in the list which allows the user to jump to the page where the checklist item can be done.

## Screenshots
Not applicable, the UI remains the same, the items have just become clickable



