### PR TITLE
remove unused and non-existing initialise script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "setup": "node ./hosting/scripts/setup.js && yarn && yarn bootstrap && yarn build && yarn dev",
     "bootstrap": "lerna link && lerna bootstrap",
     "build": "lerna run build",
-    "initialise": "lerna run initialise",
     "publishdev": "lerna run publishdev",
     "publishnpm": "yarn build && lerna publish --force-publish",
     "release": "yarn build && lerna publish patch --yes --force-publish",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,7 +23,6 @@
     "format": "prettier --config ../../.prettierrc.json 'src/**/*.ts' --write",
     "lint": "eslint --fix src/",
     "lint:fix": "yarn run format && yarn run lint",
-    "initialise": "node scripts/initialise.js",
     "multi:enable": "node scripts/multiTenancy.js enable",
     "multi:disable": "node scripts/multiTenancy.js disable"
   },


### PR DESCRIPTION
## Description
The server contains a script reference in the package.json (initialise) to a file that does not exist. After removing this reference, the main initialise script (`lerna run initialise`) has become obsolete, so I removed it.
