### PR TITLE
Fixing issues with multi-tenancy breaking various server endpoints in prod

### DIFF
--- a/packages/auth/src/middleware/tenancy.js
+++ b/packages/auth/src/middleware/tenancy.js
@@ -2,12 +2,16 @@ const { setTenantId } = require("../tenancy")
 const ContextFactory = require("../tenancy/FunctionContext")
 const { buildMatcherRegex, matches } = require("./matchers")
 
-module.exports = (allowQueryStringPatterns, noTenancyPatterns) => {
+module.exports = (
+  allowQueryStringPatterns,
+  noTenancyPatterns,
+  { noTenancyRequired }
+) => {
   const allowQsOptions = buildMatcherRegex(allowQueryStringPatterns)
   const noTenancyOptions = buildMatcherRegex(noTenancyPatterns)
 
   return ContextFactory.getMiddleware(ctx => {
-    const allowNoTenant = !!matches(ctx, noTenancyOptions)
+    const allowNoTenant = noTenancyRequired || !!matches(ctx, noTenancyOptions)
     const allowQs = !!matches(ctx, allowQsOptions)
     setTenantId(ctx, { allowQs, allowNoTenant })
   })

--- a/packages/auth/src/middleware/tenancy.js
+++ b/packages/auth/src/middleware/tenancy.js
@@ -2,16 +2,13 @@ const { setTenantId } = require("../tenancy")
 const ContextFactory = require("../tenancy/FunctionContext")
 const { buildMatcherRegex, matches } = require("./matchers")
 
-module.exports = (
-  allowQueryStringPatterns,
-  noTenancyPatterns,
-  opts = {} 
-) => {
+module.exports = (allowQueryStringPatterns, noTenancyPatterns, opts = {}) => {
   const allowQsOptions = buildMatcherRegex(allowQueryStringPatterns)
   const noTenancyOptions = buildMatcherRegex(noTenancyPatterns)
 
   return ContextFactory.getMiddleware(ctx => {
-    const allowNoTenant = opts.noTenancyRequired || !!matches(ctx, noTenancyOptions)
+    const allowNoTenant =
+      opts.noTenancyRequired || !!matches(ctx, noTenancyOptions)
     const allowQs = !!matches(ctx, allowQsOptions)
     setTenantId(ctx, { allowQs, allowNoTenant })
   })

--- a/packages/auth/src/middleware/tenancy.js
+++ b/packages/auth/src/middleware/tenancy.js
@@ -5,13 +5,13 @@ const { buildMatcherRegex, matches } = require("./matchers")
 module.exports = (
   allowQueryStringPatterns,
   noTenancyPatterns,
-  { noTenancyRequired }
+  opts = {} 
 ) => {
   const allowQsOptions = buildMatcherRegex(allowQueryStringPatterns)
   const noTenancyOptions = buildMatcherRegex(noTenancyPatterns)
 
   return ContextFactory.getMiddleware(ctx => {
-    const allowNoTenant = noTenancyRequired || !!matches(ctx, noTenancyOptions)
+    const allowNoTenant = opts.noTenancyRequired || !!matches(ctx, noTenancyOptions)
     const allowQs = !!matches(ctx, allowQsOptions)
     setTenantId(ctx, { allowQs, allowNoTenant })
   })

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -6,8 +6,16 @@ import {
   SearchFilters,
   SortJson,
 } from "../../../definitions/datasource"
-import {Datasource, FieldSchema, Row, Table} from "../../../definitions/common"
-import {breakRowIdField, generateRowIdField} from "../../../integrations/utils"
+import {
+  Datasource,
+  FieldSchema,
+  Row,
+  Table,
+} from "../../../definitions/common"
+import {
+  breakRowIdField,
+  generateRowIdField,
+} from "../../../integrations/utils"
 import { RelationshipTypes } from "../../../constants"
 
 interface ManyRelationship {
@@ -348,7 +356,7 @@ module External {
      * information.
      */
     async lookupRelations(tableId: string, row: Row) {
-      const related: {[key: string]: any} = {}
+      const related: { [key: string]: any } = {}
       const { tableName } = breakExternalTableId(tableId)
       const table = this.tables[tableName]
       // @ts-ignore
@@ -387,7 +395,11 @@ module External {
      * isn't supposed to exist anymore and delete those. This is better than the usual method of delete them
      * all and then re-create, as theres no chance of losing data (e.g. delete succeed, but write fail).
      */
-    async handleManyRelationships(mainTableId: string, row: Row, relationships: ManyRelationship[]) {
+    async handleManyRelationships(
+      mainTableId: string,
+      row: Row,
+      relationships: ManyRelationship[]
+    ) {
       const { appId } = this
       // if we're creating (in a through table) need to wipe the existing ones first
       const promises = []
@@ -399,8 +411,10 @@ module External {
         // @ts-ignore
         const linkPrimary = linkTable.primary[0]
         const rows = related[key].rows || []
-        const found = rows.find((row: { [key: string]: any }) =>
-          row[linkPrimary] === relationship.id || row[linkPrimary] === body[linkPrimary]
+        const found = rows.find(
+          (row: { [key: string]: any }) =>
+            row[linkPrimary] === relationship.id ||
+            row[linkPrimary] === body[linkPrimary]
         )
         const operation = isUpdate
           ? DataSourceOperation.UPDATE
@@ -420,13 +434,17 @@ module External {
         }
       }
       // finally cleanup anything that needs to be removed
-      for (let [colName, {isMany, rows, tableId}] of Object.entries(related)) {
+      for (let [colName, { isMany, rows, tableId }] of Object.entries(
+        related
+      )) {
         const table = this.getTable(tableId)
         for (let row of rows) {
           const filters = buildFilters(generateIdForRow(row, table), {}, table)
           // safety check, if there are no filters on deletion bad things happen
           if (Object.keys(filters).length !== 0) {
-            const op = isMany ? DataSourceOperation.DELETE : DataSourceOperation.UPDATE
+            const op = isMany
+              ? DataSourceOperation.DELETE
+              : DataSourceOperation.UPDATE
             const body = isMany ? null : { [colName]: null }
             promises.push(
               makeExternalQuery(this.appId, {
@@ -448,7 +466,10 @@ module External {
      * Creating the specific list of fields that we desire, and excluding the ones that are no use to us
      * is more performant and has the added benefit of protecting against this scenario.
      */
-    buildFields(table: Table, includeRelations: IncludeRelationships = IncludeRelationships.INCLUDE) {
+    buildFields(
+      table: Table,
+      includeRelations: IncludeRelationships = IncludeRelationships.INCLUDE
+    ) {
       function extractNonLinkFieldNames(table: Table, existing: string[] = []) {
         return Object.entries(table.schema)
           .filter(
@@ -523,7 +544,10 @@ module External {
       // can't really use response right now
       const response = await makeExternalQuery(appId, json)
       // handle many to many relationships now if we know the ID (could be auto increment)
-      if (operation !== DataSourceOperation.READ && processed.manyRelationships) {
+      if (
+        operation !== DataSourceOperation.READ &&
+        processed.manyRelationships
+      ) {
         await this.handleManyRelationships(
           table._id || "",
           response[0],

--- a/packages/server/src/api/index.js
+++ b/packages/server/src/api/index.js
@@ -10,27 +10,6 @@ const env = require("../environment")
 
 const router = new Router()
 
-const NO_TENANCY_ENDPOINTS = [
-  {
-    route: "/api/analytics",
-    method: "GET",
-  },
-  {
-    route: "/builder",
-    method: "GET",
-  },
-  // when using this locally there can be pass through, need
-  // to allow all pass through endpoints to go without tenancy
-  {
-    route: "/api/global",
-    method: "ALL",
-  },
-  {
-    route: "/api/system",
-    method: "ALL",
-  },
-]
-
 router
   .use(
     compress({
@@ -61,7 +40,13 @@ router
     })
   )
   // nothing in the server should allow query string tenants
-  .use(buildTenancyMiddleware(null, NO_TENANCY_ENDPOINTS))
+  // the server can be public anywhere, so nowhere should throw errors
+  // if the tenancy has not been set, it'll have to be discovered at application layer
+  .use(
+    buildTenancyMiddleware(null, null, {
+      noTenancyRequired: true,
+    })
+  )
   .use(currentApp)
   .use(auditLog)
 

--- a/packages/server/src/api/index.js
+++ b/packages/server/src/api/index.js
@@ -53,6 +53,8 @@ router
   })
   .use("/health", ctx => (ctx.status = 200))
   .use("/version", ctx => (ctx.body = pkg.version))
+  // re-direct before any middlewares occur
+  .redirect("/", "/builder")
   .use(
     buildAuthMiddleware(null, {
       publicAllowed: true,
@@ -92,8 +94,5 @@ for (let route of mainRoutes) {
 // WARNING - static routes will catch everything else after them this must be last
 router.use(staticRoutes.routes())
 router.use(staticRoutes.allowedMethods())
-
-// add a redirect for when hitting server directly
-router.redirect("/", "/builder")
 
 module.exports = router

--- a/packages/server/src/definitions/datasource.ts
+++ b/packages/server/src/definitions/datasource.ts
@@ -42,7 +42,7 @@ export enum SourceNames {
 
 export enum IncludeRelationships {
   INCLUDE = 1,
-  EXCLUDE = 0
+  EXCLUDE = 0,
 }
 
 export interface QueryDefinition {


### PR DESCRIPTION
## Description
An issue we kept seeing was the error `tenant id not set` as the server was only allowing a few endpoints to not have a tenant ID set. As a lot of endpoints in the server can be public it is possible for a lot of endpoints to not set the tenant ID, if its needed it will error further down the chain. Fixing the codebase up so this is reflected.



