### PR TITLE
Fix checklist spinner and progress

### DIFF
--- a/packages/bbui/src/ProgressCircle/ProgressCircle.svelte
+++ b/packages/bbui/src/ProgressCircle/ProgressCircle.svelte
@@ -17,8 +17,6 @@
   export let minValue = 0
   export let maxValue = 100
 
-  $: console.log(value)
-
   let subMask1Style
   let subMask2Style
   $: calculateSubMasks(value)

--- a/packages/bbui/src/ProgressCircle/ProgressCircle.svelte
+++ b/packages/bbui/src/ProgressCircle/ProgressCircle.svelte
@@ -17,6 +17,8 @@
   export let minValue = 0
   export let maxValue = 100
 
+  $: console.log(value)
+
   let subMask1Style
   let subMask2Style
   $: calculateSubMasks(value)
@@ -42,7 +44,7 @@
 
 <div
   on:click
-  class:spectrum-ProgressCircle--indeterminate={!value}
+  class:spectrum-ProgressCircle--indeterminate={value == null}
   class:spectrum-ProgressCircle--overBackground={overBackground}
   class="spectrum-ProgressCircle spectrum-ProgressCircle--{convertSize(size)}"
 >

--- a/packages/builder/src/stores/portal/admin.js
+++ b/packages/builder/src/stores/portal/admin.js
@@ -25,20 +25,14 @@ export function createAdminStore() {
         `/api/global/configs/checklist?tenantId=${tenantId}`
       )
       const json = await response.json()
-
-      const onboardingSteps = Object.keys(json)
-
-      const stepsComplete = onboardingSteps.reduce(
-        (score, step) => (score + step.checked ? 1 : 0),
-        0
-      )
+      const totalSteps = Object.keys(json).length
+      const completedSteps = Object.values(json).filter(x => x?.checked).length
 
       await getFlags()
       admin.update(store => {
         store.loaded = true
         store.checklist = json
-        store.onboardingProgress =
-          (stepsComplete / onboardingSteps.length) * 100
+        store.onboardingProgress = (completedSteps / totalSteps) * 100
         return store
       })
     } catch (err) {


### PR DESCRIPTION
## Description
This PR fixes a couple of issues with the getting started checklist that were introduced in #2556.

The first issue was that the ProgressCircle component uses a falsey check to see whether or not a value had been provided. This meant a progress of 0 was treated as "no value provided" and therefore cause it to spin. This issue was not introduced by the recent PR, but just highlighted it as the second bug caused a value of 0 to always be passed in.

The second issue was that the array `reduce` function that was used to calculate the progress of steps was incorrect, and was always returning 0. It was iterating over the `keys` of the JSON and expecting to see the values inside, which are not there. There's no need for a `reduce` there anyway so I've replaced it with a simple filter.

Closes #2583.


