### PR TITLE
Fix date picker in admin

### DIFF
--- a/packages/bbui/src/Form/Core/DatePicker.svelte
+++ b/packages/bbui/src/Form/Core/DatePicker.svelte
@@ -13,7 +13,7 @@
   export let enableTime = true
   export let value = null
   export let placeholder = null
-  export let appendTo = null
+  export let appendTo = undefined
 
   const dispatch = createEventDispatcher()
   const flatpickrId = `${generateID()}-wrapper`

--- a/packages/bbui/src/Form/DatePicker.svelte
+++ b/packages/bbui/src/Form/DatePicker.svelte
@@ -10,7 +10,7 @@
   export let error = null
   export let enableTime = true
   export let placeholder = null
-  export let appendTo = null
+  export let appendTo = undefined
 
   const dispatch = createEventDispatcher()
   const onChange = e => {


### PR DESCRIPTION
## Description
Fixes #2636 - set appendTo to undefined, because FlatPicker checks for !== undefined, which is false when appendTo = null

This line in the flatpicker module fails currently:
```javascript
const customAppend = self.config.appendTo !== undefined &&
            self.config.appendTo.nodeType !== undefined;
```


