### PR TITLE
bash automation stdout

### DIFF
--- a/packages/server/src/automations/steps/bash.js
+++ b/packages/server/src/automations/steps/bash.js
@@ -44,7 +44,7 @@ module.exports.run = async function ({ inputs, context }) {
 
     let stdout
     try {
-      stdout = execSync(command, { timeout: 500 })
+      stdout = execSync(command, { timeout: 500 }).toString()
     } catch (err) {
       stdout = err.message
     }


### PR DESCRIPTION
## Description
The bash automation was not writing to stdout - noticed by pentesters.

This is because the `execSync` function returns a buffer - it needs to be stringified.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



