### PR TITLE
fix the example of the avg helper

### DIFF
--- a/packages/string-templates/manifest.json
+++ b/packages/string-templates/manifest.json
@@ -22,7 +22,7 @@
         "array"
       ],
       "numArgs": 1,
-      "example": "{{ avg [1,2,3,4,5] }} -> 3",
+      "example": "{{ avg 1 2 3 4 5 }} -> 3",
       "description": "<p>Returns the average of all numbers in the given array.</p>\n"
     },
     "ceil": {


### PR DESCRIPTION
## Description
Fixes #2671 - The example for the AVG helper is incorrect. The code shown is not working, the unit test was using a different syntax, which I now use for the example.

## Screenshots
![image](https://user-images.githubusercontent.com/1907152/134012246-2e4aaab5-1025-40a4-9d06-6036cb1e8dc4.png)




