### PR TITLE
replace all handlebars bindings, not just the first

### DIFF
--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -443,7 +443,10 @@ function bindingReplacement(bindableProperties, textWithBindings, convertTo) {
     for (let from of convertFromProps) {
       if (shouldReplaceBinding(newBoundValue, from, convertTo)) {
         const binding = bindableProperties.find(el => el[convertFrom] === from)
-        newBoundValue = newBoundValue.replace(from, binding[convertTo])
+        newBoundValue = newBoundValue.replace(
+          new RegExp(from, "gi"),
+          binding[convertTo]
+        )
       }
     }
     result = result.replace(boundValue, newBoundValue)


### PR DESCRIPTION
## Description
Fixes #2679 - When using bindings in handlebars helpers, only the first binding is replaced with the real value. This PR fixes that by replacing all bindings inside the string.


