### PR TITLE
adding AWS region to bucket config

### DIFF
--- a/packages/auth/src/environment.js
+++ b/packages/auth/src/environment.js
@@ -16,6 +16,7 @@ module.exports = {
   REDIS_PASSWORD: process.env.REDIS_PASSWORD,
   MINIO_ACCESS_KEY: process.env.MINIO_ACCESS_KEY,
   MINIO_SECRET_KEY: process.env.MINIO_SECRET_KEY,
+  AWS_REGION: process.env.AWS_REGION,
   MINIO_URL: process.env.MINIO_URL,
   INTERNAL_API_KEY: process.env.INTERNAL_API_KEY,
   MULTI_TENANCY: process.env.MULTI_TENANCY,

--- a/packages/auth/src/objectStore/index.js
+++ b/packages/auth/src/objectStore/index.js
@@ -73,6 +73,7 @@ exports.ObjectStore = bucket => {
   AWS.config.update({
     accessKeyId: env.MINIO_ACCESS_KEY,
     secretAccessKey: env.MINIO_SECRET_KEY,
+    region: env.AWS_REGION,
   })
   const config = {
     s3ForcePathStyle: true,


### PR DESCRIPTION
## Description
We were seeing an issue with the AWS_REGION env variable not being set properly in the S3 configuration, causing app exports to fail in production.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



