### PR TITLE
Collapse queries with their datasource

### DIFF
--- a/packages/builder/src/components/backend/DatasourceNavigator/DatasourceNavigator.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/DatasourceNavigator.svelte
@@ -63,20 +63,19 @@
 
       {#if openDataSources.includes(datasource._id)}
         <TableNavigator sourceId={datasource._id} />
+        {#each $queries.list.filter(query => query.datasourceId === datasource._id) as query}
+          <NavItem
+            indentLevel={1}
+            icon="SQLQuery"
+            text={query.name}
+            opened={$queries.selected === query._id}
+            selected={$queries.selected === query._id}
+            on:click={() => onClickQuery(query)}
+          >
+            <EditQueryPopover {query} />
+          </NavItem>
+        {/each}
       {/if}
-
-      {#each $queries.list.filter(query => query.datasourceId === datasource._id) as query}
-        <NavItem
-          indentLevel={1}
-          icon="SQLQuery"
-          text={query.name}
-          opened={$queries.selected === query._id}
-          selected={$queries.selected === query._id}
-          on:click={() => onClickQuery(query)}
-        >
-          <EditQueryPopover {query} />
-        </NavItem>
-      {/each}
     {/each}
   </div>
 {/if}


### PR DESCRIPTION
## Description
With issue #2155 datasources can be collapsed and expanded. But queries belonging  to those datasources were left untouched, which results in a strange looking DatasourceNavigator, where datasources are collapsed, but their queries are not. This PR fixes that (issue #2708)

## Screenshots
![image](https://user-images.githubusercontent.com/1907152/134465460-b2cfb313-d50e-4de5-bdf1-49eff00d2a0f.png)
_Collapsed_

![image](https://user-images.githubusercontent.com/1907152/134465525-84409ab4-b562-4a04-ab90-7400615d1188.png)
_Expanded_




