### PR TITLE
Extend Postgres data type map

### DIFF
--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -84,10 +84,13 @@ module PostgresModule {
     bigint: FieldTypes.NUMBER,
     decimal: FieldTypes.NUMBER,
     smallint: FieldTypes.NUMBER,
+    real: FieldTypes.NUMBER,
+    "double precision": FieldTypes.NUMBER,
     timestamp: FieldTypes.DATETIME,
     time: FieldTypes.DATETIME,
     boolean: FieldTypes.BOOLEAN,
     json: FieldTypes.JSON,
+    date: FieldTypes.DATETIME,
   }
 
   async function internalQuery(client: any, query: SqlQuery) {


### PR DESCRIPTION
## Description
There are some Postgres data types missing from the data tyoe map in the postgres integration. This PR adds the following Postgres data types:
- real (float4)
- double precision (float8)
- date 

Fixes #2642



