### PR TITLE
Retrieve all columns from all not internal tables

### DIFF
--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -105,7 +105,7 @@ module PostgresModule {
     private readonly config: PostgresConfig
 
     COLUMNS_SQL =
-      "select * from information_schema.columns where table_schema = 'public'"
+      "select * from information_schema.columns where not table_schema = 'information_schema' and not table_schema = 'pg_catalog'"
 
     PRIMARY_KEYS_SQL = `
     select tc.table_schema, tc.table_name, kc.column_name as primary_key 


### PR DESCRIPTION
## Description
Fixes #2578 - changed the column query for Postgres to get all columns from all schemas except the internal schemas like `information_schema` and `pg_catalog`. 

