### PR TITLE
Removing the concept of permissions hierarchy from backend for resources

### DIFF
--- a/packages/auth/src/security/permissions.js
+++ b/packages/auth/src/security/permissions.js
@@ -139,8 +139,7 @@ exports.doesHaveResourcePermission = (
   // set foundSub to not subResourceId, incase there is no subResource
   let foundMain = false,
     foundSub = false
-  for (let [resource, level] of Object.entries(permissions)) {
-    const levels = getAllowedLevels(level)
+  for (let [resource, levels] of Object.entries(permissions)) {
     if (resource === resourceId && levels.indexOf(permLevel) !== -1) {
       foundMain = true
     }
@@ -175,10 +174,6 @@ exports.doesHaveBasePermission = (permType, permLevel, permissionIds) => {
     }
   }
   return false
-}
-
-exports.higherPermission = (perm1, perm2) => {
-  return levelToNumber(perm1) > levelToNumber(perm2) ? perm1 : perm2
 }
 
 exports.isPermissionLevelHigherThanRead = level => {

--- a/packages/auth/src/security/roles.js
+++ b/packages/auth/src/security/roles.js
@@ -1,6 +1,6 @@
 const { getDB } = require("../db")
 const { cloneDeep } = require("lodash/fp")
-const { BUILTIN_PERMISSION_IDS, higherPermission } = require("./permissions")
+const { BUILTIN_PERMISSION_IDS } = require("./permissions")
 const {
   generateRoleID,
   getRoleParams,
@@ -193,8 +193,17 @@ exports.getUserPermissions = async (appId, userRoleId) => {
   const permissions = {}
   for (let role of rolesHierarchy) {
     if (role.permissions) {
-      for (let [resource, level] of Object.entries(role.permissions)) {
-        permissions[resource] = higherPermission(permissions[resource], level)
+      for (let [resource, levels] of Object.entries(role.permissions)) {
+        if (!permissions[resource]) {
+          permissions[resource] = []
+        }
+        const permsSet = new Set(permissions[resource])
+        if (Array.isArray(levels)) {
+          levels.forEach(level => permsSet.add(level))
+        } else {
+          permsSet.add(levels)
+        }
+        permissions[resource] = [...permsSet]
       }
     }
   }

--- a/packages/server/src/api/routes/tests/role.spec.js
+++ b/packages/server/src/api/routes/tests/role.spec.js
@@ -72,7 +72,7 @@ describe("/roles", () => {
         .expect(200)
       expect(res.body.length).toBeGreaterThan(0)
       const power = res.body.find(role => role._id === BUILTIN_ROLE_IDS.POWER)
-      expect(power.permissions[table._id]).toEqual("read")
+      expect(power.permissions[table._id]).toEqual(["read"])
     })
   })
 

--- a/packages/server/src/utilities/index.js
+++ b/packages/server/src/utilities/index.js
@@ -10,6 +10,14 @@ exports.wait = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 exports.isDev = env.isDev
 
+exports.removeFromArray = (array, element) => {
+  const index = array.indexOf(element)
+  if (index !== -1) {
+    array.splice(index, 1)
+  }
+  return array
+}
+
 /**
  * Makes sure that a URL has the correct number of slashes, while maintaining the
  * http(s):// double slashes.


### PR DESCRIPTION
## Description
This was raised by some issues found by @mjashanks - after some discussion there is a definite need for the ability to have a separate read and write role, with no bearing on each other. The previous method meant that occasionally the write would override the read, like a public write but basic read. I had a look at whether or not this would be possible to implement and it turns out the external API already returned an array of permissions, which it worked out, and in a lot of places it used it as an array of permissions, so I simply got rid of the steps where it worked out the array of permissions from the single resource permission and replaced it with an actual stored array.

This also handles migration, if it finds a single level rather than an array it will convert it.

Welcome to feedback on this, raising it as I think it would be good to resolve this issue as the way to get around this safely is quite complicated (multiple tables and automations).