### PR TITLE
Fix regex binding replacement issue due to not being escaped

### DIFF
--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -443,10 +443,9 @@ function bindingReplacement(bindableProperties, textWithBindings, convertTo) {
     for (let from of convertFromProps) {
       if (shouldReplaceBinding(newBoundValue, from, convertTo)) {
         const binding = bindableProperties.find(el => el[convertFrom] === from)
-        newBoundValue = newBoundValue.replace(
-          new RegExp(from, "gi"),
-          binding[convertTo]
-        )
+        while (newBoundValue.includes(from)) {
+          newBoundValue = newBoundValue.replace(from, binding[convertTo])
+        }
       }
     }
     result = result.replace(boundValue, newBoundValue)


### PR DESCRIPTION
## Description
This PR fixes an issue introduced in https://github.com/Budibase/budibase/pull/2686, where bindings were showing up totally mangled due to the fact that the new regex expressions being created were not escaped.

Bindings were being generated that looked like this:
![image](https://user-images.githubusercontent.com/9075550/134700820-de50b69f-c932-4e04-8dc9-f47b0f5101a5.png)

A quick regexr example shows what was happening - using this as a literal regex expression was replacing some random characters in the string with the full expression.
![image](https://user-images.githubusercontent.com/9075550/134700694-2e823ba8-c595-4e5c-b650-0968f57055ba.png)

This mostly affected the runtime to readable conversion, so sometimes the saved version in the DB would work correctly but just be displayed incorrectly.

I've reverted the functionality to a simple string replace, but now just calling it repeatedly until every string instance has been replaced. This way we don't need to worry about trying to escape every regex character.

