### PR TITLE
Allow newlines in Postgres JSON inputs

### DIFF
--- a/packages/server/scripts/integrations/pg-json/docker-compose.yml
+++ b/packages/server/scripts/integrations/pg-json/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.8"
+services:
+  db:
+    container_name: postgres-json
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: root
+      POSTGRES_DB: main
+    ports:
+      - "5432:5432"
+    volumes:
+      #- pg_data:/var/lib/postgresql/data/
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+
+  pgadmin:
+    container_name: pgadmin-json
+    image: dpage/pgadmin4
+    restart: always
+    environment:
+      PGADMIN_DEFAULT_EMAIL: root@root.com
+      PGADMIN_DEFAULT_PASSWORD: root
+    ports:
+      - "5050:80"
+
+#volumes:
+#  pg_data:

--- a/packages/server/scripts/integrations/pg-json/init.sql
+++ b/packages/server/scripts/integrations/pg-json/init.sql
@@ -1,0 +1,22 @@
+SELECT 'CREATE DATABASE main'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'main')\gexec
+CREATE TABLE jsonTable (
+    id character varying(32),
+    data jsonb,
+    text text
+);
+
+INSERT INTO jsonTable (id, data) VALUES ('1', '{"id": 1, "age": 1, "name": "Mike", "newline": "this is text with a\n newline in it"}');
+
+CREATE VIEW jsonView AS SELECT
+	x.id,
+	x.age,
+	x.name,
+	x.newline
+FROM
+	jsonTable c,
+	LATERAL jsonb_to_record(c.data) x (id character varying(32),
+		age BIGINT,
+		name TEXT,
+		newline TEXT
+		);

--- a/packages/server/scripts/integrations/pg-json/reset.sh
+++ b/packages/server/scripts/integrations/pg-json/reset.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker-compose down
+docker volume prune -f

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -99,11 +99,13 @@ module PostgresModule {
   async function internalQuery(client: any, query: SqlQuery) {
     // need to handle a specific issue with json data types in postgres,
     // new lines inside the JSON data will break it
-    const matches = query.sql.match(JSON_REGEX)
-    if (matches && matches.length > 0) {
-      for (let match of matches) {
-        const escaped = escapeDangerousCharacters(match)
-        query.sql = query.sql.replace(match, escaped)
+    if (query && query.sql) {
+      const matches = query.sql.match(JSON_REGEX)
+      if (matches && matches.length > 0) {
+        for (let match of matches) {
+          const escaped = escapeDangerousCharacters(match)
+          query.sql = query.sql.replace(match, escaped)
+        }
       }
     }
     try {

--- a/packages/server/src/utilities/index.js
+++ b/packages/server/src/utilities/index.js
@@ -110,7 +110,6 @@ exports.deleteEntityMetadata = async (appId, type, entityId) => {
 exports.escapeDangerousCharacters = string => {
   return string
     .replace(/[\\]/g, "\\\\")
-    .replace(/[\/]/g, "\\/")
     .replace(/[\b]/g, "\\b")
     .replace(/[\f]/g, "\\f")
     .replace(/[\n]/g, "\\n")

--- a/packages/server/src/utilities/index.js
+++ b/packages/server/src/utilities/index.js
@@ -106,3 +106,14 @@ exports.deleteEntityMetadata = async (appId, type, entityId) => {
     await db.remove(id, rev)
   }
 }
+
+exports.escapeDangerousCharacters = string => {
+  return string
+    .replace(/[\\]/g, "\\\\")
+    .replace(/[\/]/g, "\\/")
+    .replace(/[\b]/g, "\\b")
+    .replace(/[\f]/g, "\\f")
+    .replace(/[\n]/g, "\\n")
+    .replace(/[\r]/g, "\\r")
+    .replace(/[\t]/g, "\\t")
+}


### PR DESCRIPTION
## Description
This issue is quite specific to Postgres, when carrying out queries that include JSON there is an opportunity for the a newline to cause a break in the query. This issue is documented in #2612.

I've created an example database that can be used to show the symptom of this problem for testing (found in the `server/scripts/integrations` directory) and I have fixed the issue by putting together a regex for Postgres queries which includes JSON. It will find the JSON input in the query and make sure that newlines have been escaped correctly.

This is a simple and quick fix for Postgres - rather than doing an expansive fix which could break other things I felt a narrow fix would be best.