### PR TITLE
Remove platform url in the cloud, remove analytics picker completely

### DIFF
--- a/packages/builder/src/analytics/index.js
+++ b/packages/builder/src/analytics/index.js
@@ -3,8 +3,6 @@ import PosthogClient from "./PosthogClient"
 import IntercomClient from "./IntercomClient"
 import SentryClient from "./SentryClient"
 import { Events } from "./constants"
-import { auth } from "stores/portal"
-import { get } from "svelte/store"
 
 const posthog = new PosthogClient(
   process.env.POSTHOG_TOKEN,
@@ -19,27 +17,13 @@ class AnalyticsHub {
   }
 
   async activate() {
-    // Setting the analytics env var off in the backend overrides org/tenant settings
     const analyticsStatus = await api.get("/api/analytics")
     const json = await analyticsStatus.json()
 
-    // Multitenancy disabled on the backend
+    // Analytics disabled
     if (!json.enabled) return
 
-    const tenantId = get(auth).tenantId
-
-    if (tenantId) {
-      const res = await api.get(
-        `/api/global/configs/public?tenantId=${tenantId}`
-      )
-      const orgJson = await res.json()
-
-      // analytics opted out for the tenant
-      if (orgJson.config?.analytics === false) return
-    }
-
     this.clients.forEach(client => client.init())
-    this.enabled = true
   }
 
   identify(id, metadata) {

--- a/packages/builder/src/pages/builder/portal/settings/organisation.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/organisation.svelte
@@ -7,13 +7,11 @@
     Divider,
     Label,
     Input,
-    Toggle,
     Dropzone,
     notifications,
   } from "@budibase/bbui"
-  import { auth, organisation } from "stores/portal"
+  import { auth, organisation, admin } from "stores/portal"
   import { post } from "builderStore/api"
-  import analytics from "analytics"
   import { writable } from "svelte/store"
   import { redirect } from "@roxi/routify"
 
@@ -25,7 +23,6 @@
   }
 
   const values = writable({
-    analytics: analytics.enabled,
     company: $organisation.company,
     platformUrl: $organisation.platformUrl,
     logo: $organisation.logoUrl
@@ -57,7 +54,6 @@
     const config = {
       company: $values.company ?? "",
       platformUrl: $values.platformUrl ?? "",
-      analytics: $values.analytics,
     }
     // remove logo if required
     if (!$values.logo) {
@@ -112,34 +108,22 @@
         </div>
       </div>
     </div>
-    <Divider size="S" />
-    <Layout gap="XS" noPadding>
-      <Heading size="S">Platform</Heading>
-      <Body size="S">Here you can set up general platform settings.</Body>
-    </Layout>
-    <div class="fields">
-      <div class="field">
-        <Label size="L">Platform URL</Label>
-        <Input thin bind:value={$values.platformUrl} />
-      </div>
-    </div>
-    <Divider size="S" />
-    <Layout gap="S" noPadding>
+    {#if !$admin.cloud}
+      <Divider size="S" />
       <Layout gap="XS" noPadding>
-        <Heading size="S">Analytics</Heading>
-        <Body size="S">
-          If you would like to send analytics that help us make Budibase better,
-          please let us know below.
-        </Body>
+        <Heading size="S">Platform</Heading>
+        <Body size="S">Here you can set up general platform settings.</Body>
       </Layout>
-      <Toggle
-        text="Send Analytics to Budibase"
-        bind:value={$values.analytics}
-      />
-      <div>
-        <Button disabled={loading} on:click={saveConfig} cta>Save</Button>
+      <div class="fields">
+        <div class="field">
+          <Label size="L">Platform URL</Label>
+          <Input thin bind:value={$values.platformUrl} />
+        </div>
       </div>
-    </Layout>
+    {/if}
+    <div>
+      <Button disabled={loading} on:click={saveConfig} cta>Save</Button>
+    </div>
   </Layout>
 {/if}
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,7 +25,9 @@
     "lint:fix": "yarn run format && yarn run lint",
     "initialise": "node scripts/initialise.js",
     "multi:enable": "node scripts/multiTenancy.js enable",
-    "multi:disable": "node scripts/multiTenancy.js disable"
+    "multi:disable": "node scripts/multiTenancy.js disable",
+    "selfhost:enable": "node scripts/selfhost.js enable",
+    "selfhost:disable": "node scripts/selfhost.js disable"
   },
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
## Description
Removing the ability to turn on / off analytics
They will be turned on only in the cloud going forward and will not be configurable. 

Also removing the ability to configure the platform url 

## Screenshots

Cloud
![Screenshot 2021-09-27 at 16 40 20](https://user-images.githubusercontent.com/8755148/134940644-bf7c8cdb-b67d-41ab-b6a2-5eea65edcd45.png)

Self hosting
![Screenshot 2021-09-27 at 16 41 20](https://user-images.githubusercontent.com/8755148/134940800-3547c775-3f49-4718-a457-e0325fabd0b5.png)

