### PR TITLE
Prevent root account users being re-created as internal budibase users

### DIFF
--- a/packages/auth/accounts.js
+++ b/packages/auth/accounts.js
@@ -1,0 +1,1 @@
+module.exports = require("./src/cloud/accounts")


### PR DESCRIPTION
## Description
- Currently a duplicate user can be created inside budibase that conflicts with a root account in another tenant
- This breaks application logic for 1 user in 1 tenant 
- Multi-tenant users may exist in future but not as above, restrict this action by checking if an account exists for the email first. 


