### PR TITLE
adding subdomain checking to tenancy middleware

### DIFF
--- a/packages/auth/src/tenancy/context.js
+++ b/packages/auth/src/tenancy/context.js
@@ -53,6 +53,11 @@ exports.setTenantId = (
   // processed later in the chain
   tenantId = user.tenantId || header || tenantId
 
+  // Set the tenantId from the subdomain
+  if (!tenantId) {
+    tenantId = ctx.subdomains && ctx.subdomains[0]
+  }
+
   if (!tenantId && !allowNoTenant) {
     ctx.throw(403, "Tenant id not set")
   }


### PR DESCRIPTION
## Description
Set at tenantId from the subdomain in the URL if the other methods fail.

Allows `mytenant.budibase.app` in cloud.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



