### PR TITLE
Fix bug with filter editor preventing some types being filtered

### DIFF
--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/FilterEditor/FilterDrawer.svelte
@@ -133,7 +133,7 @@
               />
             {:else if ["string", "longform", "number"].includes(filter.type)}
               <Input disabled={filter.noValue} bind:value={filter.value} />
-            {:else if filter.type === "options" || "array"}
+            {:else if ["options", "array"].includes(filter.type)}
               <Combobox
                 disabled={filter.noValue}
                 options={getFieldOptions(filter.field)}


### PR DESCRIPTION
## Description
This fixes a bug I spotted which currently prevents filtering on `datetime` or `boolean` fields. The syntax for checking if the field type is `options` or `array` is invalid and is instead evaluating `if "array"` which is always true, therefore preventing the further conditions from ever being evaluated.

The scope of this is just that if you were trying to filter a data provider on a date or boolean field then you be shown a combobox to enter your value rather than a datepicker or a checkbox.

This does currently exist live on master as well. It looks like a small oversight when the recent work on the multi-options data type was merged in.



