### PR TITLE
prevent SSO configured tenants being redirected to account portal

### DIFF
--- a/packages/builder/src/pages/builder/auth/_layout.svelte
+++ b/packages/builder/src/pages/builder/auth/_layout.svelte
@@ -12,7 +12,12 @@
     }
 
     // redirect to account portal for authentication in the cloud
-    if (!$auth.user && $admin.cloud && $admin.accountPortalUrl && !$admin?.checklist?.sso?.checked) {
+    if (
+      !$auth.user &&
+      $admin.cloud &&
+      $admin.accountPortalUrl &&
+      !$admin?.checklist?.sso?.checked
+    ) {
       window.location.href = $admin.accountPortalUrl
     }
   })

--- a/packages/builder/src/pages/builder/auth/_layout.svelte
+++ b/packages/builder/src/pages/builder/auth/_layout.svelte
@@ -12,7 +12,7 @@
     }
 
     // redirect to account portal for authentication in the cloud
-    if (!$auth.user && $admin.cloud && $admin.accountPortalUrl) {
+    if (!$auth.user && $admin.cloud && $admin.accountPortalUrl && !$admin?.checklist?.sso?.checked) {
       window.location.href = $admin.accountPortalUrl
     }
   })


### PR DESCRIPTION
## Description
SSO enabled tenants need to authenticate with the standard budibase login page. This PR prevents them being redirected to the account portal. 

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



