### PR TITLE
fix ingress-nginx repo url

### DIFF
--- a/hosting/kubernetes/budibase/Chart.yaml
+++ b/hosting/kubernetes/budibase/Chart.yaml
@@ -37,5 +37,5 @@ dependencies:
     condition: services.couchdb.enabled
   - name: ingress-nginx
     version: 3.35.0 
-    repository: https://github.com/kubernetes/ingress-nginx
+    repository: https://kubernetes.github.io/ingress-nginx
     condition: services.ingress.nginx


### PR DESCRIPTION
## Description

Corrects the ingress-nginx repository URL given in the Helm chart's depedencies to fix #2613.


