### PR TITLE
Adding important to some email color properties (link color)

### DIFF
--- a/packages/worker/src/constants/templates/base.hbs
+++ b/packages/worker/src/constants/templates/base.hbs
@@ -19,7 +19,7 @@
     }
 
     a {
-      color: #3869D4;
+      color: #3869D4 !important;
     }
 
     a img {
@@ -115,8 +115,8 @@
       border-bottom: 10px solid #3869D4;
       border-left: 18px solid #3869D4;
       display: inline-block;
-      color: #FFF;
-      text-decoration: none;
+      color: #FFF !important;
+      text-decoration: none !important;
       border-radius: 3px;
       box-shadow: 0 2px 3px rgba(0, 0, 0, 0.16);
       -webkit-text-size-adjust: none;


### PR DESCRIPTION
## Description
As per @joebudi findings this helps with gmail clients, making sure the templates are coloured as expected - this may have affects in other clients but for now this fixes issues in gmail.