### PR TITLE
Respect tenant in url in UI app. Reject tenant and session mismatch

### DIFF
--- a/packages/builder/src/pages/builder/_layout.svelte
+++ b/packages/builder/src/pages/builder/_layout.svelte
@@ -9,10 +9,31 @@
   $: hasAdminUser = $admin?.checklist?.adminUser?.checked
   $: tenantSet = $auth.tenantSet
   $: cloud = $admin.cloud
+  $: user = $auth.user
+
+  const validateTenantId = async () => {
+    // set the tenant from the url in the cloud
+    const tenantId = window.location.host.split(".")[0]
+
+    if (!tenantId.includes("localhost:")) {
+      // user doesn't have permission to access this tenant - kick them out
+      if (user && user.tenantId && user.tenantId !== tenantId) {
+        await auth.logout()
+        await auth.setOrganisation(null)
+      } else {
+        await auth.setOrganisation(tenantId)
+      }
+    }
+  }
 
   onMount(async () => {
     await auth.checkAuth()
     await admin.init()
+
+    if (cloud && multiTenancyEnabled) {
+      await validateTenantId()
+    }
+
     loaded = true
   })
 

--- a/packages/builder/src/pages/builder/_layout.svelte
+++ b/packages/builder/src/pages/builder/_layout.svelte
@@ -17,7 +17,7 @@
 
     if (!tenantId.includes("localhost:")) {
       // user doesn't have permission to access this tenant - kick them out
-      if (user && user.tenantId && user.tenantId !== tenantId) {
+      if (user?.tenantId !== tenantId) {
         await auth.logout()
         await auth.setOrganisation(null)
       } else {

--- a/packages/builder/src/stores/portal/auth.js
+++ b/packages/builder/src/stores/portal/auth.js
@@ -80,6 +80,7 @@ export function createAuthStore() {
 
   return {
     subscribe: store.subscribe,
+    setOrganisation: setOrganisation,
     checkQueryString: async () => {
       const urlParams = new URLSearchParams(window.location.search)
       if (urlParams.has("tenantId")) {


### PR DESCRIPTION
## Description
- Force logout users who try to access a tenant that does not belong to their session
- Set the UI app tenant id from the URL
   - Currently used `default` when there was no session, breaking sso-non redirect flow
 


