### PR TITLE
Add inputmode attribute for number inputs

### DIFF
--- a/packages/bbui/src/Form/Core/TextField.svelte
+++ b/packages/bbui/src/Form/Core/TextField.svelte
@@ -90,6 +90,7 @@
     on:input={onInput}
     on:keyup={updateValueOnEnter}
     {type}
+    inputmode={type === "number" ? "decimal" : "text"}
     class="spectrum-Textfield-input"
   />
 </div>


### PR DESCRIPTION
## Description
This PR adds the `inputmode` HTML attribute on input fields and sets it to `decimal` for numeric inputs, which forces a number-only keyboard on mobile devices. This was already the case on all platforms other than iOS as they respect the `type` attribute. iOS does not respect the `type` attribute, so the `inputmode` attribute is required.

Closes https://github.com/Budibase/budibase/issues/2414.


