### PR TITLE
remove unnecessary deployment poll

### DIFF
--- a/packages/builder/src/components/deploy/DeployModal.svelte
+++ b/packages/builder/src/components/deploy/DeployModal.svelte
@@ -1,21 +1,10 @@
 <script>
-  import { onMount, onDestroy } from "svelte"
   import { Button, Modal, notifications, ModalContent } from "@budibase/bbui"
   import api from "builderStore/api"
   import analytics, { Events } from "analytics"
   import { store } from "builderStore"
 
-  const DeploymentStatus = {
-    SUCCESS: "SUCCESS",
-    PENDING: "PENDING",
-    FAILURE: "FAILURE",
-  }
-
-  const POLL_INTERVAL = 10000
-
   let feedbackModal
-  let deployments = []
-  let poll
   let publishModal
 
   async function deployApp() {
@@ -34,62 +23,6 @@
       notifications.error(`Error publishing app: ${err}`)
     }
   }
-
-  async function fetchDeployments() {
-    try {
-      const response = await api.get(`/api/deployments`)
-      const json = await response.json()
-
-      if (deployments.length > 0) {
-        checkIncomingDeploymentStatus(deployments, json)
-      }
-
-      deployments = json
-    } catch (err) {
-      console.error(err)
-      clearInterval(poll)
-      notifications.error(
-        "Error fetching deployment history. Please try again."
-      )
-    }
-  }
-
-  // Required to check any updated deployment statuses between polls
-  function checkIncomingDeploymentStatus(current, incoming) {
-    for (let incomingDeployment of incoming) {
-      if (
-        incomingDeployment.status === DeploymentStatus.FAILURE ||
-        incomingDeployment.status === DeploymentStatus.SUCCESS
-      ) {
-        const currentDeployment = current.find(
-          deployment => deployment._id === incomingDeployment._id
-        )
-
-        // We have just been notified of an ongoing deployments status change
-        if (
-          !currentDeployment ||
-          currentDeployment.status === DeploymentStatus.PENDING
-        ) {
-          if (incomingDeployment.status === DeploymentStatus.FAILURE) {
-            notifications.error(incomingDeployment.err)
-          } else {
-            notifications.send(
-              "Published to Production.",
-              "success",
-              "CheckmarkCircle"
-            )
-          }
-        }
-      }
-    }
-  }
-
-  onMount(() => {
-    fetchDeployments()
-    poll = setInterval(fetchDeployments, POLL_INTERVAL)
-  })
-
-  onDestroy(() => clearInterval(poll))
 </script>
 
 <Button secondary on:click={publishModal.show}>Publish</Button>


### PR DESCRIPTION
## Description
Remove deployment polling as it is no longer needed. It was here to maintain state between refreshes, but the deployment should not take a very long time, and we can rely on the single API call.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



