### PR TITLE
Prevent screen slot from being deleted

### DIFF
--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -8,7 +8,6 @@ import {
   selectedComponent,
   selectedAccessRole,
 } from "builderStore"
-import { notifications } from "@budibase/bbui"
 import {
   datasources,
   integrations,
@@ -16,7 +15,6 @@ import {
   database,
   tables,
 } from "stores/backend"
-
 import { fetchComponentLibDefinitions } from "../loadComponentLibraries"
 import api from "../api"
 import { FrontendTypes } from "constants"
@@ -472,8 +470,7 @@ export const getFrontendStore = () => {
 
         // Ensure we aren't deleting the screen slot
         if (component._component?.endsWith("/screenslot")) {
-          notifications.error("You can't delete the screen slot")
-          return
+          throw "You can't delete the screen slot"
         }
 
         // Ensure we aren't deleting something that contains the screen slot
@@ -482,10 +479,7 @@ export const getFrontendStore = () => {
           "@budibase/standard-components/screenslot"
         )
         if (screenslot != null) {
-          notifications.error(
-            "You can't delete a component that contains the screen slot"
-          )
-          return
+          throw "You can't delete a component that contains the screen slot"
         }
 
         const parent = findComponentParent(asset.props, component._id)

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -8,6 +8,7 @@ import {
   selectedComponent,
   selectedAccessRole,
 } from "builderStore"
+import { notifications } from "@budibase/bbui"
 import {
   datasources,
   integrations,
@@ -25,6 +26,7 @@ import {
   findComponentParent,
   findClosestMatchingComponent,
   findAllMatchingComponents,
+  findComponent,
 } from "../storeUtils"
 import { uuid } from "../uuid"
 import { removeBindings } from "../dataBinding"
@@ -464,6 +466,28 @@ export const getFrontendStore = () => {
         if (!asset) {
           return
         }
+
+        // Fetch full definition
+        component = findComponent(asset.props, component._id)
+
+        // Ensure we aren't deleting the screen slot
+        if (component._component?.endsWith("/screenslot")) {
+          notifications.error("You can't delete the screen slot")
+          return
+        }
+
+        // Ensure we aren't deleting something that contains the screen slot
+        const screenslot = findComponentType(
+          component,
+          "@budibase/standard-components/screenslot"
+        )
+        if (screenslot != null) {
+          notifications.error(
+            "You can't delete a component that contains the screen slot"
+          )
+          return
+        }
+
         const parent = findComponentParent(asset.props, component._id)
         if (parent) {
           parent._children = parent._children.filter(

--- a/packages/builder/src/components/design/AppPreview/CurrentItemPreview.svelte
+++ b/packages/builder/src/components/design/AppPreview/CurrentItemPreview.svelte
@@ -6,7 +6,13 @@
   import { Screen } from "builderStore/store/screenTemplates/utils/Screen"
   import { FrontendTypes } from "constants"
   import ConfirmDialog from "components/common/ConfirmDialog.svelte"
-  import { ProgressCircle, Layout, Heading, Body } from "@budibase/bbui"
+  import {
+    ProgressCircle,
+    Layout,
+    Heading,
+    Body,
+    notifications,
+  } from "@budibase/bbui"
   import ErrorSVG from "assets/error.svg?raw"
   import { findComponent, findComponentPath } from "builderStore/storeUtils"
 
@@ -166,10 +172,15 @@
     confirmDeleteDialog.show()
   }
 
-  const deleteComponent = () => {
-    store.actions.components.delete({ _id: idToDelete })
+  const deleteComponent = async () => {
+    try {
+      await store.actions.components.delete({ _id: idToDelete })
+    } catch (error) {
+      notifications.error(error)
+    }
     idToDelete = null
   }
+
   const cancelDeleteComponent = () => {
     idToDelete = null
   }

--- a/packages/builder/src/components/design/NavigationPanel/ComponentDropdownMenu.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/ComponentDropdownMenu.svelte
@@ -3,7 +3,7 @@
   import { store, currentAsset } from "builderStore"
   import ConfirmDialog from "components/common/ConfirmDialog.svelte"
   import { findComponentParent } from "builderStore/storeUtils"
-  import { ActionMenu, MenuItem, Icon } from "@budibase/bbui"
+  import { ActionMenu, MenuItem, Icon, notifications } from "@budibase/bbui"
 
   export let component
 
@@ -51,7 +51,11 @@
   }
 
   const deleteComponent = async () => {
-    await store.actions.components.delete(component)
+    try {
+      await store.actions.components.delete(component)
+    } catch (error) {
+      notifications.error(error)
+    }
   }
 
   const storeComponentForCopy = (cut = false) => {


### PR DESCRIPTION
This PR makes it impossible to delete the screen slot. When deleting a component, we now check if the component is the screen slot (as currently you can actually delete the screen slot using the keyboard), or if the component contains the screen slot. If either is true, then an appropriate error is displayed informing the user of this and the component is not deleted.

Closes #2652.

Errors in action:
![image](https://user-images.githubusercontent.com/9075550/135633309-10e147f5-13bc-41c9-9a4b-4d2a980331f1.png)
![image](https://user-images.githubusercontent.com/9075550/135633372-b658b1d2-1d5a-4c45-9d10-d5d278ed5a97.png)