### PR TITLE
Support for tenancy subdomain locally + improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "multi:disable": "lerna run multi:disable",
     "selfhost:enable": "lerna run selfhost:enable",
     "selfhost:disable": "lerna run selfhost:disable",
+    "localdomain:enable": "lerna run localdomain:enable",
+    "localdomain:disable": "lerna run localdomain:disable",
     "postinstall": "husky install"
   }
 }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -20,7 +20,9 @@
     "multi:enable": "node scripts/multiTenancy.js enable",
     "multi:disable": "node scripts/multiTenancy.js disable",
     "selfhost:enable": "node scripts/selfhost.js enable",
-    "selfhost:disable": "node scripts/selfhost.js disable"
+    "selfhost:disable": "node scripts/selfhost.js disable",
+    "localdomain:enable": "node scripts/localdomain.js enable",
+    "localdomain:disable": "node scripts/localdomain.js disable"
   },
   "author": "Budibase",
   "license": "AGPL-3.0-or-later",

--- a/packages/worker/scripts/localdomain.js
+++ b/packages/worker/scripts/localdomain.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+const updateDotEnv = require("update-dotenv")
+
+const arg = process.argv.slice(2)[0]
+
+/**
+ * For testing multi tenancy sub domains locally.
+ *
+ * Relies on an entry in /etc/hosts e.g:
+ *
+ * 127.0.0.1   local.com
+ *
+ * and an entry for each tenant you wish to test locally e.g:
+ *
+ * 127.0.0.1   t1.local.com
+ * 127.0.0.1   t2.local.com
+ */
+updateDotEnv({
+  ACCOUNT_PORTAL_URL:
+    arg === "enable" ? "http://local.com:10001" : "http://localhost:10001",
+  COOKIE_DOMAIN: arg === "enable" ? ".local.com" : "",
+}).then(() => console.log("Updated worker!"))


### PR DESCRIPTION
## Description
- Allow for easier testing of url tenancy in a local dev environment
- Fixes to prevent logging out when hitting the root budibase.app domain

see: https://github.com/Budibase/account-portal/pull/37


