### PR TITLE
Allow SQL many to many relationships to use arbitrarily named columns in junction table

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/CreateEditRelationship/CreateEditRelationship.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/CreateEditRelationship/CreateEditRelationship.svelte
@@ -156,6 +156,8 @@
         ...relateTo,
         through: through._id,
         fieldName: fromTable.primary[0],
+        throughFrom: relateFrom.throughTo,
+        throughTo: relateFrom.throughFrom,
       }
     } else {
       // the relateFrom.fieldName should remain the same, as it is the foreignKey in the other
@@ -251,6 +253,22 @@
       bind:error={errors.through}
       bind:value={fromRelationship.through}
     />
+    {#if fromTable && toTable && through}
+      <Select
+        label={`Foreign Key (${fromTable?.name})`}
+        options={Object.keys(through?.schema)}
+        on:change={() => ($touched.fromForeign = true)}
+        bind:error={errors.fromForeign}
+        bind:value={fromRelationship.throughTo}
+      />
+      <Select
+        label={`Foreign Key (${toTable?.name})`}
+        options={Object.keys(through?.schema)}
+        on:change={() => ($touched.toForeign = true)}
+        bind:error={errors.toForeign}
+        bind:value={fromRelationship.throughFrom}
+      />
+    {/if}
   {:else if fromRelationship?.relationshipType && toTable}
     <Select
       label={`Foreign Key (${toTable?.name})`}

--- a/packages/server/scripts/integrations/customer-categories/docker-compose.yml
+++ b/packages/server/scripts/integrations/customer-categories/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.8"
+services:
+  db:
+    container_name: postgres
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: root
+      POSTGRES_DB: main
+    ports:
+      - "5432:5432"
+    volumes:
+      #- pg_data:/var/lib/postgresql/data/
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+
+  pgadmin:
+    container_name: pgadmin-pg
+    image: dpage/pgadmin4
+    restart: always
+    environment:
+      PGADMIN_DEFAULT_EMAIL: root@root.com
+      PGADMIN_DEFAULT_PASSWORD: root
+    ports:
+      - "5050:80"
+
+#volumes:
+#  pg_data:

--- a/packages/server/scripts/integrations/customer-categories/init.sql
+++ b/packages/server/scripts/integrations/customer-categories/init.sql
@@ -1,0 +1,41 @@
+SELECT 'CREATE DATABASE main'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'main')\gexec
+
+CREATE TABLE categories
+(
+    name text COLLATE pg_catalog."default",
+    id integer NOT NULL GENERATED ALWAYS AS IDENTITY ( INCREMENT 1 START 1 MINVALUE 1 MAXVALUE 2147483647 CACHE 1 ),
+    CONSTRAINT categories_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE customers
+(
+    id integer NOT NULL GENERATED ALWAYS AS IDENTITY ( INCREMENT 1 START 1 MINVALUE 1 MAXVALUE 2147483647 CACHE 1 ),
+    name text COLLATE pg_catalog."default",
+    email text COLLATE pg_catalog."default",
+    age integer,
+    "dateOfBirth" date,
+    CONSTRAINT customers_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE customer_category
+(
+    customer_id integer,
+    category_id integer,
+    notes text COLLATE pg_catalog."default",
+    id integer NOT NULL GENERATED ALWAYS AS IDENTITY ( INCREMENT 1 START 1 MINVALUE 1 MAXVALUE 2147483647 CACHE 1 ),
+    CONSTRAINT "Category" FOREIGN KEY (category_id)
+        REFERENCES public.categories (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+        NOT VALID,
+    CONSTRAINT "Customer" FOREIGN KEY (customer_id)
+        REFERENCES public.customers (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+        NOT VALID
+);
+
+
+INSERT INTO customers (name, email, age) VALUES ('Mike', 'mike@mike.com', 30);
+INSERT INTO categories (name) VALUES ('Books');

--- a/packages/server/scripts/integrations/customer-categories/reset.sh
+++ b/packages/server/scripts/integrations/customer-categories/reset.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker-compose down
+docker volume prune -f

--- a/packages/server/src/definitions/common.ts
+++ b/packages/server/src/definitions/common.ts
@@ -15,6 +15,8 @@ export interface FieldSchema {
   through?: string
   foreignKey?: string
   autocolumn?: boolean
+  throughFrom?: string
+  throughTo?: string
   constraints?: {
     type?: string
     email?: boolean

--- a/packages/server/src/definitions/datasource.ts
+++ b/packages/server/src/definitions/datasource.ts
@@ -121,6 +121,8 @@ export interface RelationshipsJson {
   through?: string
   from?: string
   to?: string
+  fromPrimary?: string
+  toPrimary?: string
   tableName: string
   column: string
 }

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -112,14 +112,16 @@ function addRelationships(
       )
     } else {
       const throughTable = relationship.through
+      const fromPrimary = relationship.fromPrimary
+      const toPrimary = relationship.toPrimary
       query = query
         // @ts-ignore
         .leftJoin(
           throughTable,
-          `${fromTable}.${from}`,
+          `${fromTable}.${fromPrimary}`,
           `${throughTable}.${from}`
         )
-        .leftJoin(toTable, `${toTable}.${to}`, `${throughTable}.${to}`)
+        .leftJoin(toTable, `${toTable}.${toPrimary}`, `${throughTable}.${to}`)
     }
   }
   return query


### PR DESCRIPTION
## Description
Fixes #2792 - as well as adding the example as an integration script (useful for testing/re-testing).

Fix for many to many relationships where the union table has arbitrarily named foreign key constraint columns, an example has been provided in the scripts directory.

## Screenshots
Below is how the many to many relationship creation looks.
![image](https://user-images.githubusercontent.com/4407001/135659721-4d3c77f5-3f56-49ec-b07b-23a4c353f591.png)