### PR TITLE
Deny only when usage quota is exceeded

### DIFF
--- a/packages/server/src/utilities/usageQuota.js
+++ b/packages/server/src/utilities/usageQuota.js
@@ -58,7 +58,7 @@ exports.update = async (property, usage) => {
     // increment the quota
     quota.usageQuota[property] += usage
 
-    if (quota.usageQuota[property] >= quota.usageLimits[property]) {
+    if (quota.usageQuota[property] > quota.usageLimits[property]) {
       throw new Error(
         `You have exceeded your usage quota of ${quota.usageLimits[property]} ${property}.`
       )


### PR DESCRIPTION
## Description
The quota exceeded notification was misleading; when creating a fourth app the message was
> You have exceeded your usage quota of 4 apps

![Screenshot 2021-10-04 at 14 04 39](https://user-images.githubusercontent.com/8755148/135856899-e1ef3342-0d93-4c55-861c-bf5df9bf5215.png)

Change the logic to use `>` only, so that this message is seen when trying to create the fifth app
![Screenshot 2021-10-04 at 14 05 28](https://user-images.githubusercontent.com/8755148/135857040-a82b807b-5327-4075-b49b-14598264fd9f.png)



