### PR TITLE
Using the user's name in emails sent out where possible

### DIFF
--- a/packages/worker/src/constants/templates/passwordRecovery.hbs
+++ b/packages/worker/src/constants/templates/passwordRecovery.hbs
@@ -6,7 +6,7 @@
       <tr>
         <td class="content-cell">
           <div class="f-fallback">
-            <h1>Hi {{ email }},</h1>
+            <h1>Hi {{#if name}}{{ name }}{{else}}{{ email }}{{/if}},</h1>
             <p>You recently requested to reset your password for your {{ company }} account in your Budibase platform. Use the button below to reset it. <strong>This password reset is only valid for the next 24 hours.</strong></p>
             <!-- Action -->
             <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" role="presentation">

--- a/packages/worker/src/constants/templates/welcome.hbs
+++ b/packages/worker/src/constants/templates/welcome.hbs
@@ -6,7 +6,7 @@
       <tr>
         <td class="content-cell">
           <div class="f-fallback">
-            <h1>Welcome, {{ email }}!</h1>
+            <h1>Welcome, {{#if name}}{{ name }}{{else}}{{ email }}{{/if}}!</h1>
             <p>Thanks for getting started with {{ company }}'s Budibase platform.</p>
             <p>For reference, here's how to login:</p>
             <table class="attributes" width="100%" cellpadding="0" cellspacing="0" role="presentation">

--- a/packages/worker/src/utilities/email.js
+++ b/packages/worker/src/utilities/email.js
@@ -83,10 +83,15 @@ async function buildEmail(purpose, email, context, { user, contents } = {}) {
   }
   base = base.contents
   body = body.contents
+  let name = user ? user.name : undefined
+  if (user && !name && user.firstName) {
+    name = user.lastName ? `${user.firstName} ${user.lastName}` : user.firstName
+  }
   context = {
     ...context,
     contents,
     email,
+    name,
     user: user || {},
   }
 


### PR DESCRIPTION
## Description
As with the account portal, updating the monorepo to use the users name if it is available for some email templates.