### PR TITLE
added 'you agree to license' on cloud login

### DIFF
--- a/packages/builder/src/pages/builder/auth/login.svelte
+++ b/packages/builder/src/pages/builder/auth/login.svelte
@@ -8,6 +8,7 @@
     Input,
     Layout,
     notifications,
+    Link,
   } from "@budibase/bbui"
   import { goto, params } from "@roxi/routify"
   import { auth, organisation, oidc, admin } from "stores/portal"
@@ -97,6 +98,16 @@
           </ActionButton>
         {/if}
       </Layout>
+      {#if cloud}
+        <Body size="xs" textAlign="center">
+          By using Budibase Cloud
+          <br />
+          you are agreeing to our
+          <Link href="https://budibase.com/eula" target="_blank"
+            >License Agreement</Link
+          >
+        </Body>
+      {/if}
     </Layout>
   </div>
 </div>


### PR DESCRIPTION
We must display a link to the license agreement on login - this should only appear for Budibase Cloud

![image](https://user-images.githubusercontent.com/3524181/136221319-791c3c7e-0310-43a1-8751-5bdb6b4f537b.png)



