### PR TITLE
Honour cookie domain when custom sso is enabled

### DIFF
--- a/packages/worker/src/api/controllers/global/auth.js
+++ b/packages/worker/src/api/controllers/global/auth.js
@@ -41,13 +41,19 @@ async function authInternal(ctx, user, err = null, info = null) {
     return ctx.throw(403, info ? info : "Unauthorized")
   }
 
-  // just store the user ID
-  ctx.cookies.set(Cookies.Auth, user.token, {
+  const config = {
     expires,
     path: "/",
     httpOnly: false,
     overwrite: true,
-  })
+  }
+
+  if (env.COOKIE_DOMAIN) {
+    config.domain = env.COOKIE_DOMAIN
+  }
+
+  // just store the user ID
+  ctx.cookies.set(Cookies.Auth, user.token, config)
 }
 
 exports.authenticate = async (ctx, next) => {

--- a/packages/worker/src/environment.js
+++ b/packages/worker/src/environment.js
@@ -41,6 +41,7 @@ module.exports = {
   SMTP_PORT: process.env.SMTP_PORT,
   SMTP_FROM_ADDRESS: process.env.SMTP_FROM_ADDRESS,
   PLATFORM_URL: process.env.PLATFORM_URL,
+  COOKIE_DOMAIN: process.env.COOKIE_DOMAIN,
   _set(key, value) {
     process.env[key] = value
     module.exports[key] = value


### PR DESCRIPTION
## Description
- The internal login (custom sso tenants) did not previously honour the cookie domain shared between account portal and budibase
- This caused sessions that were unable to logout due to the difference between the domain in the set-cookie response headers

