### PR TITLE
Various minor fixes

### DIFF
--- a/packages/auth/src/redis/index.js
+++ b/packages/auth/src/redis/index.js
@@ -191,6 +191,12 @@ class RedisWrapper {
     }
   }
 
+  async getTTL(key) {
+    const db = this._db
+    const prefixedKey = addDbPrefix(db, key)
+    return CLIENT.ttl(prefixedKey)
+  }
+
   async setExpiry(key, expirySeconds) {
     const db = this._db
     const prefixedKey = addDbPrefix(db, key)

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -67,6 +67,14 @@ export const getFrontendStore = () => {
     initialise: async pkg => {
       const { layouts, screens, application, clientLibPath } = pkg
       const components = await fetchComponentLibDefinitions(application.appId)
+      // make sure app isn't locked
+      if (
+        components &&
+        components.status === 400 &&
+        components.message?.includes("lock")
+      ) {
+        throw { ok: false, reason: "locked" }
+      }
       store.update(state => ({
         ...state,
         libraries: application.componentLibraries,

--- a/packages/builder/src/components/backend/DatasourceNavigator/DatasourceNavigator.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/DatasourceNavigator.svelte
@@ -11,16 +11,18 @@
   import ICONS from "./icons"
 
   let openDataSources = []
-  $: enrichedDataSources = $datasources.list.map(datasource => {
-    const selected = $datasources.selected === datasource._id
-    const open = openDataSources.includes(datasource._id)
-    const containsSelected = containsActiveEntity(datasource)
-    return {
-      ...datasource,
-      selected,
-      open: selected || open || containsSelected,
-    }
-  })
+  $: enrichedDataSources = Array.isArray($datasources.list)
+    ? $datasources.list.map(datasource => {
+        const selected = $datasources.selected === datasource._id
+        const open = openDataSources.includes(datasource._id)
+        const containsSelected = containsActiveEntity(datasource)
+        return {
+          ...datasource,
+          selected,
+          open: selected || open || containsSelected,
+        }
+      })
+    : []
   $: openDataSource = enrichedDataSources.find(x => x.open)
   $: {
     // Ensure the open data source is always included in the list of open

--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/DatasourceConfigModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/DatasourceConfigModal.svelte
@@ -3,7 +3,7 @@
   import { ModalContent, notifications, Body, Layout } from "@budibase/bbui"
   import analytics, { Events } from "analytics"
   import IntegrationConfigForm from "components/backend/DatasourceNavigator/TableIntegrationMenu/IntegrationConfigForm.svelte"
-  import { datasources } from "stores/backend"
+  import { datasources, tables } from "stores/backend"
   import { IntegrationNames } from "constants"
 
   export let integration
@@ -32,6 +32,8 @@
       // Create datasource
       const resp = await datasources.save(datasource, datasource.plus)
 
+      // update the tables incase data source plus
+      await tables.fetch()
       await datasources.select(resp._id)
       $goto(`./datasource/${resp._id}`)
       notifications.success(`Datasource updated successfully.`)

--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/DatasourceConfigModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/DatasourceConfigModal.svelte
@@ -11,12 +11,14 @@
   function prepareData() {
     let datasource = {}
     let existingTypeCount = $datasources.list.filter(
-      ds => ds.source == integration.type
+      ds => ds.source === integration.type
     ).length
 
     let baseName = IntegrationNames[integration.type]
     let name =
-      existingTypeCount == 0 ? baseName : `${baseName}-${existingTypeCount + 1}`
+      existingTypeCount === 0
+        ? baseName
+        : `${baseName}-${existingTypeCount + 1}`
 
     datasource.type = "datasource"
     datasource.source = integration.type

--- a/packages/builder/src/constants/lucene.js
+++ b/packages/builder/src/constants/lucene.js
@@ -44,6 +44,15 @@ export const OperatorOptions = {
   },
 }
 
+export const NoEmptyFilterStrings = [
+  OperatorOptions.StartsWith.value,
+  OperatorOptions.Like.value,
+  OperatorOptions.Equals.value,
+  OperatorOptions.NotEquals.value,
+  OperatorOptions.Contains.value,
+  OperatorOptions.NotContains.value,
+]
+
 /**
  * Returns the valid operator options for a certain data type
  * @param type the data type

--- a/packages/builder/src/helpers/lucene.js
+++ b/packages/builder/src/helpers/lucene.js
@@ -1,3 +1,26 @@
+import { NoEmptyFilterStrings } from "../constants/lucene"
+
+/**
+ * Removes any fields that contain empty strings that would cause inconsistent
+ * behaviour with how backend tables are filtered (no value means no filter).
+ */
+function cleanupQuery(query) {
+  if (!query) {
+    return query
+  }
+  for (let filterField of NoEmptyFilterStrings) {
+    if (!query[filterField]) {
+      continue
+    }
+    for (let [key, value] of Object.entries(query[filterField])) {
+      if (!value || value === "") {
+        delete query[filterField][key]
+      }
+    }
+  }
+  return query
+}
+
 /**
  * Builds a lucene JSON query from the filter structure generated in the builder
  * @param filter the builder filter structure
@@ -76,6 +99,8 @@ export const luceneQuery = (docs, query) => {
   if (!query) {
     return docs
   }
+  // make query consistent first
+  query = cleanupQuery(query)
 
   // Iterates over a set of filters and evaluates a fail function against a doc
   const match = (type, failFn) => doc => {

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -178,7 +178,12 @@ module External {
         manyRelationships: ManyRelationship[] = []
       for (let [key, field] of Object.entries(table.schema)) {
         // if set already, or not set just skip it
-        if (!row[key] || newRow[key] || field.autocolumn) {
+        if ((!row[key] && row[key] !== "") || newRow[key] || field.autocolumn) {
+          continue
+        }
+        // if its an empty string then it means return the column to null (if possible)
+        if (row[key] === "") {
+          newRow[key] = null
           continue
         }
         // parse floats/numbers

--- a/packages/server/src/api/controllers/row/external.js
+++ b/packages/server/src/api/controllers/row/external.js
@@ -2,6 +2,7 @@ const {
   DataSourceOperation,
   SortDirection,
   FieldTypes,
+  NoEmptyFilterStrings,
 } = require("../../../constants")
 const {
   breakExternalTableId,
@@ -11,6 +12,19 @@ const ExternalRequest = require("./ExternalRequest")
 const CouchDB = require("../../../db")
 
 async function handleRequest(appId, operation, tableId, opts = {}) {
+  // make sure the filters are cleaned up, no empty strings for equals, fuzzy or string
+  if (opts && opts.filters) {
+    for (let filterField of NoEmptyFilterStrings) {
+      if (!opts.filters[filterField]) {
+        continue
+      }
+      for (let [key, value] of Object.entries(opts.filters[filterField])) {
+        if (!value || value === "") {
+          delete opts.filters[filterField][key]
+        }
+      }
+    }
+  }
   return new ExternalRequest(appId, operation, tableId, opts.datasource).run(
     opts
   )

--- a/packages/server/src/constants/index.js
+++ b/packages/server/src/constants/index.js
@@ -6,6 +6,29 @@ exports.JobQueues = {
   AUTOMATIONS: "automationQueue",
 }
 
+const FilterTypes = {
+  STRING: "string",
+  FUZZY: "fuzzy",
+  RANGE: "range",
+  EQUAL: "equal",
+  NOT_EQUAL: "notEqual",
+  EMPTY: "empty",
+  NOT_EMPTY: "notEmpty",
+  CONTAINS: "contains",
+  NOT_CONTAINS: "notContains",
+  ONE_OF: "oneOf",
+}
+
+exports.FilterTypes = FilterTypes
+exports.NoEmptyFilterStrings = [
+  FilterTypes.STRING,
+  FilterTypes.FUZZY,
+  FilterTypes.EQUAL,
+  FilterTypes.NOT_EQUAL,
+  FilterTypes.CONTAINS,
+  FilterTypes.NOT_CONTAINS,
+]
+
 exports.FieldTypes = {
   STRING: "string",
   LONGFORM: "longform",

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -141,6 +141,12 @@ function buildCreate(
   const { endpoint, body } = json
   let query: KnexQuery = knex(endpoint.entityId)
   const parsedBody = parseBody(body)
+  // make sure no null values in body for creation
+  for (let [key, value] of Object.entries(parsedBody)) {
+    if (value == null) {
+      delete parsedBody[key]
+    }
+  }
   // mysql can't use returning
   if (opts.disableReturning) {
     return query.insert(parsedBody)

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -55,6 +55,12 @@ function addFilters(
       query = query[fnc](key, "ilike", `${value}%`)
     })
   }
+  if (filters.fuzzy) {
+    iterate(filters.fuzzy, (key, value) => {
+      const fnc = allOr ? "orWhere" : "where"
+      query = query[fnc](key, "ilike", `%${value}%`)
+    })
+  }
   if (filters.range) {
     iterate(filters.range, (key, value) => {
       if (!value.high || !value.low) {

--- a/packages/server/src/middleware/builder.js
+++ b/packages/server/src/middleware/builder.js
@@ -33,7 +33,7 @@ async function checkDevAppLocks(ctx) {
     return
   }
   if (!(await doesUserHaveLock(appId, ctx.user))) {
-    ctx.throw(403, "User does not hold app lock.")
+    ctx.throw(400, "User does not hold app lock.")
   }
 
   // they do have lock, update it


### PR DESCRIPTION
## Description
Just a few fixes after playing around a little bit and testing:
1. Fixing an issue with a redirect loop in the builder if a user went to an app that is locked, or tried to access an app that wasn't locked when they first reached the app screen (happened to me in the cloud when I had been sitting on the main page for a while).
2. Fixing issue #2788 - makes client-side and SQL based queries consistent with that of the internal tables, if no value is provided to the filter then no filter is applied.
3. `Like` as an operator for SQL tables, previously this did nothing because we don't have a fuzzy SQL search, but this caused confusion (especially since like is an SQL operator) so now it operates the same as a contains filter (`ilike %search value%`)
4. Fixing an issue with data source creation, when creating any data source plus you would need to refresh the builder to be able to access any of the tables UI.
5. Fixes #2277 means that SQL row values can be reverted to null.