### PR TITLE
Infra/improved ci selfhost

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -1,9 +1,7 @@
 name: Budibase Release
 
 on:
- push:
-    branches:
-      - master
+ workflow_dispatch:
 
 env:
   POSTHOG_TOKEN: ${{ secrets.POSTHOG_TOKEN }}
@@ -22,9 +20,6 @@ jobs:
           node-version: 12.x
       - run: yarn
       - run: yarn bootstrap
-      - run: yarn lint
-      - run: yarn build
-      - run: yarn test
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -33,26 +28,30 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-1
 
-      - name: Publish budibase packages to NPM
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          # setup the username and email. I tend to use 'GitHub Actions Bot' with no email by default
-          git config user.name "Budibase Release Bot"
-          git config user.email "<>"
-          echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} >> .npmrc
-          yarn release
-
       - name: 'Get Previous tag'
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"
 
-      - name: Build/release Docker images
+      - name: Build/release Docker images (Self Host)
+        if: ${{ github.event.inputs.release_self_host == 'Y' }}
         run: | 
           docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
           yarn build
-          yarn build:docker
+          yarn build:docker:production
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}
           BUDIBASE_RELEASE_VERSION: ${{ steps.previoustag.outputs.tag }}
+      
+      - uses: azure/setup-helm@v1
+        id: install
+
+      # So, we need to inject the values into this
+      - run: yarn release:helm
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.1.0
+        with:
+          charts_dir: docs
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         run: | 
           docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
           yarn build
-          yarn build:docker
+          yarn build:docker:production
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.158-alpha.0",
+  "version": "0.9.158",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.158",
+  "version": "0.9.159",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/auth",
-  "version": "0.9.158",
+  "version": "0.9.159",
   "description": "Authentication middlewares for budibase builder and apps",
   "main": "src/index.js",
   "author": "Budibase",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/auth",
-  "version": "0.9.158-alpha.0",
+  "version": "0.9.158",
   "description": "Authentication middlewares for budibase builder and apps",
   "main": "src/index.js",
   "author": "Budibase",

--- a/packages/bbui/package.json
+++ b/packages/bbui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/bbui",
   "description": "A UI solution used in the different Budibase projects.",
-  "version": "0.9.158",
+  "version": "0.9.159",
   "license": "AGPL-3.0",
   "svelte": "src/index.js",
   "module": "dist/bbui.es.js",

--- a/packages/bbui/package.json
+++ b/packages/bbui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/bbui",
   "description": "A UI solution used in the different Budibase projects.",
-  "version": "0.9.158-alpha.0",
+  "version": "0.9.158",
   "license": "AGPL-3.0",
   "svelte": "src/index.js",
   "module": "dist/bbui.es.js",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/builder",
-  "version": "0.9.158-alpha.0",
+  "version": "0.9.158",
   "license": "AGPL-3.0",
   "private": true,
   "scripts": {
@@ -65,10 +65,10 @@
     }
   },
   "dependencies": {
-    "@budibase/bbui": "^0.9.158-alpha.0",
-    "@budibase/client": "^0.9.158-alpha.0",
+    "@budibase/bbui": "^0.9.158",
+    "@budibase/client": "^0.9.158",
     "@budibase/colorpicker": "1.1.2",
-    "@budibase/string-templates": "^0.9.158-alpha.0",
+    "@budibase/string-templates": "^0.9.158",
     "@sentry/browser": "5.19.1",
     "@spectrum-css/page": "^3.0.1",
     "@spectrum-css/vars": "^3.0.1",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/builder",
-  "version": "0.9.158",
+  "version": "0.9.159",
   "license": "AGPL-3.0",
   "private": true,
   "scripts": {
@@ -65,10 +65,10 @@
     }
   },
   "dependencies": {
-    "@budibase/bbui": "^0.9.158",
-    "@budibase/client": "^0.9.158",
+    "@budibase/bbui": "^0.9.159",
+    "@budibase/client": "^0.9.159",
     "@budibase/colorpicker": "1.1.2",
-    "@budibase/string-templates": "^0.9.158",
+    "@budibase/string-templates": "^0.9.159",
     "@sentry/browser": "5.19.1",
     "@spectrum-css/page": "^3.0.1",
     "@spectrum-css/vars": "^3.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/cli",
-  "version": "0.9.158-alpha.0",
+  "version": "0.9.158",
   "description": "Budibase CLI, for developers, self hosting and migrations.",
   "main": "src/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/cli",
-  "version": "0.9.158",
+  "version": "0.9.159",
   "description": "Budibase CLI, for developers, self hosting and migrations.",
   "main": "src/index.js",
   "bin": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/client",
-  "version": "0.9.158-alpha.0",
+  "version": "0.9.158",
   "license": "MPL-2.0",
   "module": "dist/budibase-client.js",
   "main": "dist/budibase-client.js",
@@ -19,9 +19,9 @@
     "dev:builder": "rollup -cw"
   },
   "dependencies": {
-    "@budibase/bbui": "^0.9.158-alpha.0",
+    "@budibase/bbui": "^0.9.158",
     "@budibase/standard-components": "^0.9.139",
-    "@budibase/string-templates": "^0.9.158-alpha.0",
+    "@budibase/string-templates": "^0.9.158",
     "regexparam": "^1.3.0",
     "shortid": "^2.2.15",
     "svelte-spa-router": "^3.0.5"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/client",
-  "version": "0.9.158",
+  "version": "0.9.159",
   "license": "MPL-2.0",
   "module": "dist/budibase-client.js",
   "main": "dist/budibase-client.js",
@@ -19,9 +19,9 @@
     "dev:builder": "rollup -cw"
   },
   "dependencies": {
-    "@budibase/bbui": "^0.9.158",
+    "@budibase/bbui": "^0.9.159",
     "@budibase/standard-components": "^0.9.139",
-    "@budibase/string-templates": "^0.9.158",
+    "@budibase/string-templates": "^0.9.159",
     "regexparam": "^1.3.0",
     "shortid": "^2.2.15",
     "svelte-spa-router": "^3.0.5"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/server",
   "email": "hi@budibase.com",
-  "version": "0.9.158",
+  "version": "0.9.159",
   "description": "Budibase Web Server",
   "main": "src/index.js",
   "repository": {
@@ -66,9 +66,9 @@
   "author": "Budibase",
   "license": "AGPL-3.0-or-later",
   "dependencies": {
-    "@budibase/auth": "^0.9.158",
-    "@budibase/client": "^0.9.158",
-    "@budibase/string-templates": "^0.9.158",
+    "@budibase/auth": "^0.9.159",
+    "@budibase/client": "^0.9.159",
+    "@budibase/string-templates": "^0.9.159",
     "@elastic/elasticsearch": "7.10.0",
     "@koa/router": "8.0.0",
     "@sendgrid/mail": "7.1.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/server",
   "email": "hi@budibase.com",
-  "version": "0.9.158-alpha.0",
+  "version": "0.9.158",
   "description": "Budibase Web Server",
   "main": "src/index.js",
   "repository": {
@@ -66,9 +66,9 @@
   "author": "Budibase",
   "license": "AGPL-3.0-or-later",
   "dependencies": {
-    "@budibase/auth": "^0.9.158-alpha.0",
-    "@budibase/client": "^0.9.158-alpha.0",
-    "@budibase/string-templates": "^0.9.158-alpha.0",
+    "@budibase/auth": "^0.9.158",
+    "@budibase/client": "^0.9.158",
+    "@budibase/string-templates": "^0.9.158",
     "@elastic/elasticsearch": "7.10.0",
     "@koa/router": "8.0.0",
     "@sendgrid/mail": "7.1.1",

--- a/packages/string-templates/package.json
+++ b/packages/string-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/string-templates",
-  "version": "0.9.158-alpha.0",
+  "version": "0.9.158",
   "description": "Handlebars wrapper for Budibase templating.",
   "main": "src/index.cjs",
   "module": "dist/bundle.mjs",

--- a/packages/string-templates/package.json
+++ b/packages/string-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/string-templates",
-  "version": "0.9.158",
+  "version": "0.9.159",
   "description": "Handlebars wrapper for Budibase templating.",
   "main": "src/index.cjs",
   "module": "dist/bundle.mjs",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/worker",
   "email": "hi@budibase.com",
-  "version": "0.9.158",
+  "version": "0.9.159",
   "description": "Budibase background service",
   "main": "src/index.js",
   "repository": {
@@ -27,8 +27,8 @@
   "author": "Budibase",
   "license": "AGPL-3.0-or-later",
   "dependencies": {
-    "@budibase/auth": "^0.9.158",
-    "@budibase/string-templates": "^0.9.158",
+    "@budibase/auth": "^0.9.159",
+    "@budibase/string-templates": "^0.9.159",
     "@koa/router": "^8.0.0",
     "@techpass/passport-openidconnect": "^0.3.0",
     "aws-sdk": "^2.811.0",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/worker",
   "email": "hi@budibase.com",
-  "version": "0.9.158-alpha.0",
+  "version": "0.9.158",
   "description": "Budibase background service",
   "main": "src/index.js",
   "repository": {
@@ -27,8 +27,8 @@
   "author": "Budibase",
   "license": "AGPL-3.0-or-later",
   "dependencies": {
-    "@budibase/auth": "^0.9.158-alpha.0",
-    "@budibase/string-templates": "^0.9.158-alpha.0",
+    "@budibase/auth": "^0.9.158",
+    "@budibase/string-templates": "^0.9.158",
     "@koa/router": "^8.0.0",
     "@techpass/passport-openidconnect": "^0.3.0",
     "aws-sdk": "^2.811.0",


### PR DESCRIPTION
## Description
This PR contains code to improve the CI for releases. Since self host release should not be run until the `master` build completes, we do not need to publish to NPM, or run the tests/lint since it will already be done on `master`. Right now, another NPM version gets released with the same code from master, which is pointless.

This should significantly speed up the build time and allow us to push out to self hosters by just building the docker images.

- Created another `release-selfhost` pipeline that gets manually triggered
- Moved all self host logic out of the `release` pipeline
- Added the helm release into the `release-selfhost` pipeline only 

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



