### PR TITLE
Fixing apps import from cloud (removing user export)

### DIFF
--- a/packages/builder/src/pages/builder/admin/_components/ImportAppsModal.svelte
+++ b/packages/builder/src/pages/builder/admin/_components/ImportAppsModal.svelte
@@ -1,6 +1,7 @@
 <script>
   import { notifications, ModalContent, Dropzone, Body } from "@budibase/bbui"
   import { post } from "builderStore/api"
+  import { admin } from "stores/portal"
 
   let submitting = false
 
@@ -20,8 +21,8 @@
       if (!importResp.ok) {
         throw new Error(importJson.message)
       }
-      // now reload to get to login
-      window.location.reload()
+      await admin.checkImportComplete()
+      notifications.success("Import complete, please finish registration!")
     } catch (error) {
       notifications.error(error)
       submitting = false

--- a/packages/builder/src/pages/builder/admin/index.svelte
+++ b/packages/builder/src/pages/builder/admin/index.svelte
@@ -15,6 +15,7 @@
   import PasswordRepeatInput from "components/common/users/PasswordRepeatInput.svelte"
   import ImportAppsModal from "./_components/ImportAppsModal.svelte"
   import Logo from "assets/bb-emblem.svg"
+  import { onMount } from "svelte"
 
   let adminUser = {}
   let error
@@ -23,6 +24,7 @@
   $: tenantId = $auth.tenantId
   $: multiTenancyEnabled = $admin.multiTenancy
   $: cloud = $admin.cloud
+  $: imported = $admin.importComplete
 
   async function save() {
     try {
@@ -40,6 +42,12 @@
       notifications.error(`Failed to create admin user`)
     }
   }
+
+  onMount(async () => {
+    if (!cloud) {
+      await admin.checkImportComplete()
+    }
+  })
 </script>
 
 <Modal bind:this={modal} padding={false} width="600px">
@@ -73,7 +81,7 @@
           >
             Change organisation
           </ActionButton>
-        {:else if !cloud}
+        {:else if !cloud && !imported}
           <ActionButton
             quiet
             on:click={() => {

--- a/packages/builder/src/stores/portal/admin.js
+++ b/packages/builder/src/stores/portal/admin.js
@@ -9,6 +9,7 @@ export function createAdminStore() {
     cloud: false,
     disableAccountPortal: false,
     accountPortalUrl: "",
+    importComplete: false,
     onboardingProgress: 0,
     checklist: {
       apps: { checked: false },
@@ -40,6 +41,17 @@ export function createAdminStore() {
     } catch (err) {
       admin.update(store => {
         store.checklist = null
+        return store
+      })
+    }
+  }
+
+  async function checkImportComplete() {
+    const response = await api.get(`/api/cloud/import/complete`)
+    if (response.status === 200) {
+      const json = await response.json()
+      admin.update(store => {
+        store.importComplete = json ? json.imported : false
         return store
       })
     }
@@ -79,6 +91,7 @@ export function createAdminStore() {
   return {
     subscribe: admin.subscribe,
     init,
+    checkImportComplete,
     unload,
   }
 }

--- a/packages/server/src/api/controllers/application.js
+++ b/packages/server/src/api/controllers/application.js
@@ -86,6 +86,7 @@ async function getAppUrlIfNotInUse(ctx) {
   if (
     url &&
     deployedApps[url] != null &&
+    ctx.params != null &&
     deployedApps[url].appId !== ctx.params.appId
   ) {
     ctx.throw(400, "App name/URL is already in use.")

--- a/packages/server/src/api/routes/cloud.js
+++ b/packages/server/src/api/routes/cloud.js
@@ -9,5 +9,6 @@ router
   .get("/api/cloud/export", authorized(BUILDER), controller.exportApps)
   // has to be public, only run if apps don't exist
   .post("/api/cloud/import", controller.importApps)
+  .get("/api/cloud/import/complete", controller.hasBeenImported)
 
 module.exports = router

--- a/packages/worker/src/middleware/cloudRestricted.js
+++ b/packages/worker/src/middleware/cloudRestricted.js
@@ -6,7 +6,7 @@ const { Headers } = require("@budibase/auth").constants
  * Ensure that the correct API key has been supplied.
  */
 module.exports = async (ctx, next) => {
-  if (!env.SELF_HOSTED) {
+  if (!env.SELF_HOSTED && !env.DISABLE_ACCOUNT_PORTAL) {
     const apiKey = ctx.request.headers[Headers.API_KEY]
     if (apiKey !== env.INTERNAL_API_KEY) {
       ctx.throw(403, "Unauthorized")


### PR DESCRIPTION
## Description
Fixing some issues with cloud export/import, removing the ability to export and import your users as this was dangerous and didn't really work with passwords/SSO.

The main adjustments are that the export doesn't include any users details, the reason being two fold:
1. Users passwords are hashed with a secret key that obviously cannot be shared, password hashes can't be exported from the cloud and therefore we don't really have an easy way for users to get back into their accounts when they are imported, apart from going through a forgotten password flow, it just seems easier to not export the users and have the users be re-invited to the new self hosted platform.
2. This was even more awkward if SSO was enabled in the cloud as this isn't really exportable and would be confusing to users on the new platform that they have to use a forgotten password flow for their previously SSO configured app.