### PR TITLE
fix issue where automation was not being added in the correct order

### DIFF
--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -5,7 +5,7 @@
 // ***********************************************
 //
 
-Cypress.on('uncaught:exception', (err, runnable) => {
+Cypress.on("uncaught:exception", () => {
   return false
 })
 

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/ActionModal.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/ActionModal.svelte
@@ -4,10 +4,11 @@
   import { externalActions } from "./ExternalActions"
 
   export let blockIdx
+  export let blockComplete
+
   let selectedAction
   let actionVal
   let actions = Object.entries($automationStore.blockDefinitions.ACTION)
-  export let blockComplete
 
   const external = actions.reduce((acc, elm) => {
     const [k, v] = elm
@@ -36,10 +37,9 @@
       actionVal.stepId,
       actionVal
     )
-    automationStore.actions.addBlockToAutomation(newBlock)
+    automationStore.actions.addBlockToAutomation(newBlock, blockIdx + 1)
     await automationStore.actions.save(
-      $automationStore.selectedAutomation?.automation,
-      blockIdx
+      $automationStore.selectedAutomation?.automation
     )
   }
 </script>

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
@@ -151,7 +151,7 @@
             >
           {/if}
           <Button
-            disabled={disableAddButton ? true : !hasCompletedInputs}
+            disabled={!hasCompletedInputs}
             on:click={() => {
               setupToggled = false
               actionModal.show()


### PR DESCRIPTION
## Description
The blockIdx wasn't being passed to the addBlock function. Not sure how I missed this in testing, think i might have popped a previous stash before I merged. 

But this fixes it - I tested:

- Adding an action using the plus icon between two blocks
- Adding an action using the button between two block
- Adding an action to the end using the plus icon
- Adding an action to the end using the button

Also fixes an issue with where the 'Add Action' wouldn't be enabled if there was a following block, but this was inconsistent with how the 'plus' icon worked as we can add blocks at any stage now. it is now enabled as long as long as the inputs have been completed.
## Screenshots



https://user-images.githubusercontent.com/5665926/136774544-b6ec92e5-0468-4986-9e57-37fd3d47357a.mp4




