### PR TITLE
Fix env variable parsing

### DIFF
--- a/packages/server/src/environment.js
+++ b/packages/server/src/environment.js
@@ -74,9 +74,10 @@ module.exports = {
   },
 }
 
-// convert any strings to numbers if required, like "0" would be true otherwise
+// clean up any environment variable edge cases
 for (let [key, value] of Object.entries(module.exports)) {
-  if (typeof value === "string" && !isNaN(parseInt(value))) {
-    module.exports[key] = parseInt(value)
+  // handle the edge case of "0" to disable an environment variable
+  if (value === "0") {
+    module.exports[key] = 0
   }
 }

--- a/packages/worker/src/environment.js
+++ b/packages/worker/src/environment.js
@@ -52,3 +52,11 @@ module.exports = {
     return !isDev()
   },
 }
+
+// clean up any environment variable edge cases
+for (let [key, value] of Object.entries(module.exports)) {
+  // handle the edge case of "0" to disable an environment variable
+  if (value === "0") {
+    module.exports[key] = 0
+  }
+}


### PR DESCRIPTION
## Description
Fixing an issue with env variables becoming numbers if they started with one. Instead of doing the full number parsing, just looking for the case of "0" which is why the feature was implemented at all.