### PR TITLE
Remove account url from docker images

### DIFF
--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -51,7 +51,6 @@ services:
       INTERNAL_API_KEY: ${INTERNAL_API_KEY}
       REDIS_URL: redis-service:6379
       REDIS_PASSWORD: ${REDIS_PASSWORD}
-      ACCOUNT_PORTAL_URL: https://portal.budi.live
     volumes:
       - ./logs:/logs
     depends_on:


### PR DESCRIPTION
## Description
Noticed in this issue
https://github.com/Budibase/budibase/issues/3008

The root cause has been fixed here https://github.com/Budibase/budibase/pull/2959/files
however we still provide an `ACCOUNT_PORTAL_URL` env var that points to staging, which should be removed for self hosters



