### PR TITLE
Handle longform types within Automations

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/RowSelector.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/RowSelector.svelte
@@ -1,6 +1,12 @@
 <script>
   import { tables } from "stores/backend"
-  import { Select, Toggle, DatePicker, Multiselect } from "@budibase/bbui"
+  import {
+    Select,
+    Toggle,
+    DatePicker,
+    Multiselect,
+    TextArea,
+  } from "@budibase/bbui"
   import DrawerBindableInput from "../../common/bindings/DrawerBindableInput.svelte"
   import AutomationBindingPanel from "../../common/bindings/ServerBindingPanel.svelte"
   import { createEventDispatcher } from "svelte"
@@ -43,6 +49,7 @@
   function schemaHasOptions(schema) {
     return !!schema.constraints?.inclusion?.length
   }
+  $: console.log(schemaFields)
 </script>
 
 <Select
@@ -52,7 +59,6 @@
   getOptionLabel={table => table.name}
   getOptionValue={table => table._id}
 />
-
 {#if schemaFields.length}
   <div class="schema-fields">
     {#each schemaFields as [field, schema]}
@@ -82,6 +88,8 @@
             label={field}
             options={schema.constraints.inclusion}
           />
+        {:else if schema.type === "longform"}
+          <TextArea label={field} bind:value={value[field]} />
         {:else if schema.type === "link"}
           <LinkedRowSelector bind:linkedRows={value[field]} {schema} />
         {:else if schema.type === "string" || schema.type === "number"}

--- a/packages/builder/src/components/automation/SetupPanel/RowSelector.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/RowSelector.svelte
@@ -49,7 +49,6 @@
   function schemaHasOptions(schema) {
     return !!schema.constraints?.inclusion?.length
   }
-  $: console.log(schemaFields)
 </script>
 
 <Select


### PR DESCRIPTION
## Description
We've never handled a longform type correctly within the automations, so this just displays a TextArea for that specific case

## Screenshots


<img width="477" alt="image" src="https://user-images.githubusercontent.com/5665926/137344332-c9d0379f-aa25-4e93-bb9c-6b09e53d822f.png">


