### PR TITLE
Remove 'internal' from dataprovider / paginate info

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -2385,7 +2385,7 @@
   },
   "dataprovider": {
     "name": "Data Provider",
-    "info": "Pagination is only available for data stored in internal tables.",
+    "info": "Pagination is only available for data stored in tables.",
     "icon": "Data",
     "illegalChildren": ["section"],
     "hasChildren": true,


### PR DESCRIPTION
## Description
https://github.com/Budibase/budibase/issues/2991

Pagination is available for both internal and plus datasources. Update to reflect.

## Screenshots
Before
![Screenshot 2021-10-15 at 10 27 38](https://user-images.githubusercontent.com/8755148/137465466-0fee4771-ec16-42b2-bd45-1828513700a6.png)

After
![Screenshot 2021-10-15 at 10 29 23](https://user-images.githubusercontent.com/8755148/137465654-51b78990-9eb1-4328-a6ca-7a743b4275a0.png)





