### PR TITLE
Potential fix for issues with updating and saving rows and columns

### DIFF
--- a/packages/bbui/src/Table/CellRenderer.svelte
+++ b/packages/bbui/src/Table/CellRenderer.svelte
@@ -5,7 +5,6 @@
   import RelationshipRenderer from "./RelationshipRenderer.svelte"
   import AttachmentRenderer from "./AttachmentRenderer.svelte"
   import ArrayRenderer from "./ArrayRenderer.svelte"
-  import InternalRenderer from "./InternalRenderer.svelte"
 
   export let row
   export let schema
@@ -23,9 +22,7 @@
     number: StringRenderer,
     longform: StringRenderer,
     array: ArrayRenderer,
-    internal: InternalRenderer,
   }
-
   $: type = schema?.type ?? "string"
   $: customRenderer = customRenderers?.find(x => x.column === schema?.name)
   $: renderer = customRenderer?.component ?? typeMap[type] ?? StringRenderer

--- a/packages/builder/src/components/backend/DataTable/DataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/DataTable.svelte
@@ -16,29 +16,11 @@
   import { Pagination } from "@budibase/bbui"
 
   let hideAutocolumns = true
-  let schema
   $: isUsersTable = $tables.selected?._id === TableNames.USERS
   $: type = $tables.selected?.type
   $: isInternal = type !== "external"
-  $: {
-    schema = $tables.selected?.schema
+  $: schema = $tables.selected?.schema
 
-    // Manually add these as we don't want them to be 'real' auto-columns
-    schema._id = {
-      type: "internal",
-      editable: false,
-      displayName: "ID",
-      autocolumn: true,
-    }
-    if (isInternal) {
-      schema._rev = {
-        type: "internal",
-        editable: false,
-        displayName: "Revision",
-        autocolumn: true,
-      }
-    }
-  }
   $: id = $tables.selected?._id
   $: search = searchTable(id)
   $: columnOptions = Object.keys($search.schema || {})

--- a/packages/server/src/api/controllers/table/index.js
+++ b/packages/server/src/api/controllers/table/index.js
@@ -91,6 +91,9 @@ exports.save = async function (ctx) {
     for (let propKey of Object.keys(tableToSave.schema)) {
       let column = tableToSave.schema[propKey]
       let oldColumn = oldTable.schema[propKey]
+      if (oldColumn && oldColumn.type === "internal") {
+        oldColumn.type = "auto"
+      }
       if (oldColumn && oldColumn.type !== column.type) {
         ctx.throw(400, "Cannot change the type of a column")
       }

--- a/packages/server/src/constants/index.js
+++ b/packages/server/src/constants/index.js
@@ -42,6 +42,7 @@ exports.FieldTypes = {
   FORMULA: "formula",
   AUTO: "auto",
   JSON: "json",
+  INTERNAL: "internal",
 }
 
 exports.RelationshipTypes = {

--- a/packages/server/src/utilities/rowProcessor/index.js
+++ b/packages/server/src/utilities/rowProcessor/index.js
@@ -200,6 +200,12 @@ exports.inputProcessing = (
       clonedRow[key] = exports.coerce(value, field.type)
     }
   }
+
+  if (!clonedRow._id) {
+    clonedRow._id = row._id
+    clonedRow._rev = row._rev
+  }
+
   // handle auto columns - this returns an object like {table, row}
   return processAutoColumn(user, copiedTable, clonedRow, opts)
 }


### PR DESCRIPTION
## Description
So this issue (https://github.com/Budibase/budibase/issues/3031) came out of this PR (https://github.com/Budibase/budibase/pull/2984/files) and the addition of the _id and _rev fields to autocolumns, I didn't realise, and obviously didn't fully understand the reprocussions of adding these, in that I didn't realise the columns would then actually get saved. Totally my bad and hold my hands up for it. 

The crux of the issue is essentially that if changes have been made to a document,  it means they are in a bad state, in that the `_id` field has become undefined.

This has led to some serious issues in which users can't save or edit columns and rows. However a fix was pushed to master tonight that stops this from happening, but obviously some users may have made some changes over the weekend. 

This PR seems to fix it (but that's with some brief testing and some very hacky code) but I have more testing to do and thought I would get this up so people could see what the issue was and get some input on potential fixes for users who have edited or made changes to their data. 

Outstanding issues I can see:

- other autocolumns aren't visible for the table that I am looking at (new tables are fine)
- saving an attachment causes the row to dissapear and not return in any further calls to the /search endpoint (but I am not sure if this related, as i reverted the changes from that PR and still seeing that issue



