### PR TITLE
Add check for missing _rev 

### DIFF
--- a/packages/server/src/utilities/rowProcessor/index.js
+++ b/packages/server/src/utilities/rowProcessor/index.js
@@ -201,7 +201,7 @@ exports.inputProcessing = (
     }
   }
 
-  if (!clonedRow._id) {
+  if (!clonedRow._id || !clonedRow._rev) {
     clonedRow._id = row._id
     clonedRow._rev = row._rev
   }


### PR DESCRIPTION
## Description
Was missing a check for the _rev, was possible to be in a state where the _id was populated but the _rev was undefined



