### PR TITLE
Fix/helm make multitenancy configurable

### DIFF
--- a/hosting/kubernetes/budibase/templates/app-service-deployment.yaml
+++ b/hosting/kubernetes/budibase/templates/app-service-deployment.yaml
@@ -73,7 +73,11 @@ spec:
               name: {{ template "budibase.fullname" . }}
               key: objectStoreSecret
         - name: MINIO_URL
+          {{ if .Values.services.objectStore.url }}
           value: {{ .Values.services.objectStore.url }}
+          {{ else }}
+          value: http://minio-service:{{ .Values.services.objectStore.port }}
+          {{ end }}
         - name: PORT
           value: {{ .Values.services.apps.port | quote }}
         - name: MULTI_TENANCY

--- a/hosting/kubernetes/budibase/templates/app-service-deployment.yaml
+++ b/hosting/kubernetes/budibase/templates/app-service-deployment.yaml
@@ -77,7 +77,7 @@ spec:
         - name: PORT
           value: {{ .Values.services.apps.port | quote }}
         - name: MULTI_TENANCY
-          value: "1"
+          value: {{ .Values.globals.multiTenancy | quote }}
         - name: REDIS_PASSWORD
           value: {{ .Values.services.redis.password }}
         - name: REDIS_URL

--- a/hosting/kubernetes/budibase/templates/worker-service-deployment.yaml
+++ b/hosting/kubernetes/budibase/templates/worker-service-deployment.yaml
@@ -74,7 +74,7 @@ spec:
         - name: PORT
           value: {{ .Values.services.worker.port | quote }}
         - name: MULTI_TENANCY
-          value: "1"
+          value: {{ .Values.globals.multiTenancy | quote }}
         - name: REDIS_PASSWORD
           value: {{ .Values.services.redis.password | quote }}
         - name: REDIS_URL

--- a/hosting/kubernetes/budibase/templates/worker-service-deployment.yaml
+++ b/hosting/kubernetes/budibase/templates/worker-service-deployment.yaml
@@ -70,7 +70,11 @@ spec:
               name: {{ template "budibase.fullname" . }}
               key: objectStoreSecret
         - name: MINIO_URL
+          {{ if .Values.services.objectStore.url }}
           value: {{ .Values.services.objectStore.url }}
+          {{ else }}
+          value: http://minio-service:{{ .Values.services.objectStore.port }}
+          {{ end }}
         - name: PORT
           value: {{ .Values.services.worker.port | quote }}
         - name: MULTI_TENANCY

--- a/hosting/kubernetes/budibase/values.yaml
+++ b/hosting/kubernetes/budibase/values.yaml
@@ -24,10 +24,12 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -42,23 +44,24 @@ service:
 ingress:
   enabled: false
   aws: false
-  nginx: true 
-  certificateArn: ""  
+  nginx: true
+  certificateArn: ""
   className: ""
-  annotations: 
+  annotations:
     kubernetes.io/ingress.class: nginx
   hosts:
     - host: # change if using custom domain
       paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: proxy-service
-            port:
-              number: 10000 
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: proxy-service
+              port:
+                number: 10000
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -89,10 +92,11 @@ globals:
   sentryDSN: ""
   posthogToken: ""
   logLevel: info
-  selfHosted: ""
-  accountPortalUrl: "" 
+  selfHosted: "1" # set to 0 for budibase cloud environment, set to 1 for self-hosted setup
+  multiTenancy: "0" # set to 0 to disable multiple orgs, set to 1 to enable multiple orgs
+  accountPortalUrl: ""
   accountPortalApiKey: ""
-  cookieDomain: "" 
+  cookieDomain: ""
   platformUrl: ""
 
   createSecrets: true # creates an internal API key, JWT secrets and redis password for you
@@ -128,7 +132,7 @@ services:
     # password: "" # only change if pointing to existing couch server
     port: 5984
     storage: 100Mi
-  
+
   redis:
     enabled: true # disable if using external redis
     port: 6379
@@ -136,7 +140,7 @@ services:
     url: "" # only change if pointing to existing redis cluster and enabled: false
     password: "budibase" # recommended to override if using built-in redis
     storage: 100Mi
-  
+
   objectStore:
     minio: true
     browser: true
@@ -147,4 +151,3 @@ services:
     region: "" # AWS_REGION if using S3 or existing minio secret
     url: "" # only change if pointing to existing minio cluster and minio: false
     storage: 100Mi
-


### PR DESCRIPTION
## Description
This PR addresses the following issues with the helm chart:
1. Make helm chart self-hosted by default
2. Set a correct default value for the minio service
3. Expose multi-tenancy in the values.yaml

Also, apologies for some unneccessary diffs due to my autoformatter. If those are undesired I can update the PR.

