### PR TITLE
Improve app export experience

### DIFF
--- a/hosting/envoy.dev.yaml.hbs
+++ b/hosting/envoy.dev.yaml.hbs
@@ -41,6 +41,7 @@ static_resources:
               - match: { prefix: "/api/" }
                 route:
                   cluster: server-dev
+                  timeout: 120s
 
               - match: { prefix: "/app_" }
                 route:

--- a/hosting/envoy.yaml
+++ b/hosting/envoy.yaml
@@ -58,6 +58,7 @@ static_resources:
               - match: { prefix: "/api/" }
                 route:
                   cluster: app-service
+                  timeout: 120s
 
               - match: { prefix: "/worker/" }
                 route: 

--- a/packages/builder/src/pages/builder/portal/apps/index.svelte
+++ b/packages/builder/src/pages/builder/portal/apps/index.svelte
@@ -112,16 +112,8 @@
 
   const exportApp = app => {
     const id = app.deployed ? app.prodId : app.devId
-    try {
-      download(
-        `/api/backups/export?appId=${id}&appname=${encodeURIComponent(
-          app.name
-        )}`
-      )
-      notifications.success("App exported successfully")
-    } catch (err) {
-      notifications.error(`Error exporting app: ${err}`)
-    }
+    const appName = encodeURIComponent(app.name)
+    window.location = `/api/backups/export?appId=${id}&appname=${appName}`
   }
 
   const unpublishApp = app => {

--- a/packages/server/src/api/controllers/backup.js
+++ b/packages/server/src/api/controllers/backup.js
@@ -1,10 +1,9 @@
-const { performBackup } = require("../../utilities/fileSystem")
+const { streamBackup } = require("../../utilities/fileSystem")
 
 exports.exportAppDump = async function (ctx) {
   const { appId } = ctx.query
-  const appname = decodeURI(ctx.query.appname)
-  const backupIdentifier = `${appname}Backup${new Date().getTime()}.txt`
-
+  const appName = decodeURI(ctx.query.appname)
+  const backupIdentifier = `${appName}-export-${new Date().getTime()}.txt`
   ctx.attachment(backupIdentifier)
-  ctx.body = await performBackup(appId, backupIdentifier)
+  ctx.body = await streamBackup(appId)
 }


### PR DESCRIPTION
## Description
After looking in to #1718, there are a couple of issues with how we handle app exports, especially for large apps. One is that the dumping the app DB is fundamentally slow, and I don't believe we can speed that up. We use [PouchDB replication stream](https://github.com/pouchdb-community/pouchdb-replication-stream) which uses  [PouchDB dump CLI](https://github.com/pouchdb-community/pouchdb-dump-cli) to actually do the dump, and that seems like the only/best tool for the job already.

The other (and bigger, IMO) issue is that we wait for the backup to complete serverside before returning anything to the client. This causes timeouts because the default envoy config is a 15 second timeout on the proxy. For any big apps, 15 seconds is not enough for the server backup to complete the backup and therefore the request is terminated.

This PR introduces the following changes:
- Increase envoy timeout to 120s for `/api` routes. This matches the default Koa config.
- Refactor the app export functionality to add a new option for streaming app exports. This means we can now export an app to file, to a string, or as a stream which can be immediately sent to the client.
- App exports are now treated like file downloads, and handled by the browser. This means that when exporting an app, you will immediatly get a popup asking where you want to save the export. The download will then commence and the PouchDB dump will be streamed in real time, so you can see the progress of the download and get immediate feedback. Large exports can still take upwards of 30 seconds to complete, but because it is clearly an ongoing download, this feels totally fine. The only caveat is that there is no known file size (since we're streaming an unknown size app DB in real time), so it will say "unknown time remaining" on your download.
- As soon as a download is started, you can continue using the builder normally. You don't need to hang around and wait for the download (like we used to have to) since it's just a normal browser download that's being handled separately from your Budibase tab.
- Small bugfix for the app export filter. I believe we were incorrectly including user relationship data in our exports, when they should have been filtered out.
![image](https://user-images.githubusercontent.com/9075550/137722464-8e15f864-26b8-4007-8d0e-92ef5522e836.png)


## Video
Here's a video of exporting a massive (20MB) app. You can see that it takes a while to stream the download, but since it looks like a normal download this is totally fine. You can see that afterwards I download a small app which completes instantly. I sit and wait for the download to complete to show the functionality, but I could have immediately opened an app or left the page - the download will still continue in the background like a normal download.

https://user-images.githubusercontent.com/9075550/137721611-2abd053e-675a-4ff8-9c29-a33c05fac9d7.mp4

## Future work
This same strategy is probably required for the "export all aps" functionality, since that is just a much larger version of this same feature. It could also potentially be used for table exports, since they could probably also be large. This PR, with the timeout increase, will allow for much bigger exports of both of those other use cases, but the downside is that you will need to sit on an unresponsive page for however long is required before you get the prompt to save your completed dump.


