### PR TITLE
Handling URL.id usage with SQL tables

### DIFF
--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -5,6 +5,7 @@ const { DocumentTypes, SEPARATOR } = require("../db/utils")
 const { FieldTypes } = require("../constants")
 
 const DOUBLE_SEPARATOR = `${SEPARATOR}${SEPARATOR}`
+const ROW_ID_REGEX = /^\[.*]$/g
 
 export function isExternalTable(tableId: string) {
   return tableId.includes(DocumentTypes.DATASOURCE)
@@ -30,6 +31,20 @@ export function generateRowIdField(keyProps: any[] = []) {
   // we have to swap the double quotes to single quotes for use in HBS statements
   // when using the literal helper the double quotes can break things
   return encodeURIComponent(JSON.stringify(keyProps).replace(/"/g, "'"))
+}
+
+export function isRowId(field: any) {
+  return Array.isArray(field) || (typeof field === "string" && field.match(ROW_ID_REGEX) != null)
+}
+
+export function convertRowId(field: any) {
+  if (Array.isArray(field)) {
+    return field[0]
+  }
+  if (typeof field === "string" && field.match(ROW_ID_REGEX) != null) {
+    return field.substring(1, field.length - 1)
+  }
+  return field
 }
 
 // should always return an array


### PR DESCRIPTION
## Description
As #2417 demonstrates the usage of `URL.id` with SQL tables could be a little complicated/confusing due to the way we build our `_id` field for SQL table rows. Due to the nature of primary keys and the fact they could be built out of a composite we had to handle the mixture of ways unique identifiers could be built. We handled this by aggregating the keys into an array, then serialising the array into a string. This technique did not fit well when using the `URL.id` field to input values directly to the SQL database (like using the ID for a foreign key field).

Due to the way we query SQL databases all queries are built from one central part of the code, which means we can manipulate the values being input. The configuration used to run a query is defined as follows (in our Typescript definitions):

```typescript
interface RunConfig {
  id?: string
  filters?: SearchFilters
  sort?: SortJson
  paginate?: PaginationJson
  row?: Row
}
```

The important parts that the `_id` field could have been used as an input for are `filters` and `row`. The sorting and pagination properties don't take a value, they are simply linked to previous query and table schema information. The ID field already handles the ID mechanism we have in place (as can be seen when querying a route like `/customers/10` or `/customers/[10]`).

The way I have implemented this is a clean up function which looks at the table schema, to see if any of the input fields could contain a key field (e.g. they are of type like integer or string which could be a foreign key/key field) and then looking for strings like `[10]`. If these are seen then the brackets are stripped and the raw value is used. There are two negatives to this approach:
1. Using a string like `[Hello there!]` as a raw row value in SQL will have the brackets removed, we perhaps could solve this if it is a serious issue by looking through our relationship configuration to see if the field we are trying to manipulate is a foreign key for any table, but then users have to fully setup their relationships for this fix to apply, a more all encompassing fix felt better here.
2. Currently it can't technically handle composite keys, as the user has input the `_id` field for a single row value, if the foreign key is actually a composite key then this won't work. Again if this is a massive issue we can use the table schema information + provided relationship info to work out where the `_id` components should be inserted, but this would require we support composite keys for relationships (currently unsupported).

## Screenshots
My test scenario, I created a child form on a detail page where you could create a related row to the parent using the `{{ URL.id }}` binding.
![image](https://user-images.githubusercontent.com/4407001/137776719-75abf86f-dcf6-4706-923d-ef42af7b281d.png)
![image](https://user-images.githubusercontent.com/4407001/137776913-da5ff92a-d302-4e39-8a79-34101c5d2b21.png)
![image](https://user-images.githubusercontent.com/4407001/137776824-36f6c203-7448-45d1-a84b-4e8e9e89de4f.png)