### PR TITLE
Fix issue where external datasource action wasn't saving it's values

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/QueryParamSelector.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/QueryParamSelector.svelte
@@ -3,9 +3,23 @@
   import { Select } from "@budibase/bbui"
   import DrawerBindableInput from "../../common/bindings/DrawerBindableInput.svelte"
   import AutomationBindingPanel from "../../common/bindings/ServerBindingPanel.svelte"
+  import { createEventDispatcher } from "svelte"
+
+  const dispatch = createEventDispatcher()
 
   export let value
   export let bindings
+
+  const onChangeQuery = e => {
+    value.queryId = e.detail
+    dispatch("change", value)
+  }
+
+  const onChange = (e, field) => {
+    console.log(field)
+    value[field.name] = e.detail
+    dispatch("change", value)
+  }
 
   $: query = $queries.list.find(query => query._id === value?.queryId)
   $: parameters = query?.parameters ?? []
@@ -13,12 +27,14 @@
   // Ensure any nullish queryId values get set to empty string so
   // that the select works
   $: if (value?.queryId == null) value = { queryId: "" }
+  $: console.log(value)
 </script>
 
 <div class="block-field">
   <Select
     label="Query"
-    bind:value={value.queryId}
+    on:change={onChangeQuery}
+    value={value.queryId}
     options={$queries.list}
     getOptionValue={query => query._id}
     getOptionLabel={query => query.name}
@@ -32,9 +48,7 @@
         panel={AutomationBindingPanel}
         extraThin
         value={value[field.name]}
-        on:change={e => {
-          value[field.name] = e.detail
-        }}
+        on:change={e => onChange(e, field)}
         label={field.name}
         type="string"
         {bindings}

--- a/packages/builder/src/components/automation/SetupPanel/QueryParamSelector.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/QueryParamSelector.svelte
@@ -16,7 +16,6 @@
   }
 
   const onChange = (e, field) => {
-    console.log(field)
     value[field.name] = e.detail
     dispatch("change", value)
   }
@@ -27,7 +26,6 @@
   // Ensure any nullish queryId values get set to empty string so
   // that the select works
   $: if (value?.queryId == null) value = { queryId: "" }
-  $: console.log(value)
 </script>
 
 <div class="block-field">


### PR DESCRIPTION
## Description
Needed to a change event to the QueryParamSelector component (handles the External Datasource Source action) as it wasn't saving any changes made to it. 





