### PR TITLE
Fix date format of dates created with Flatpickr (the date picker in apps)

### DIFF
--- a/packages/bbui/src/Form/Core/DatePicker.svelte
+++ b/packages/bbui/src/Form/Core/DatePicker.svelte
@@ -31,7 +31,11 @@
 
   const handleChange = event => {
     const [dates] = event.detail
-    dispatch("change", dates[0])
+    let newValue = dates[0]
+    if (newValue) {
+      newValue = newValue.toISOString()
+    }
+    dispatch("change", newValue)
   }
 
   const clearDateOnBackspace = event => {
@@ -57,11 +61,38 @@
     const els = document.querySelectorAll(`#${flatpickrId} input`)
     els.forEach(el => el.blur())
   }
+
+  const parseDate = val => {
+    if (!val) {
+      return null
+    }
+    let date
+    if (val instanceof Date) {
+      // Use real date obj if already parsed
+      date = val
+    } else if (isNaN(val)) {
+      // Treat as date string of some sort
+      date = new Date(val)
+    } else {
+      // Treat as numerical timestamp
+      date = new Date(parseInt(val))
+    }
+    const time = date.getTime()
+    if (isNaN(time)) {
+      return null
+    }
+    // By rounding to the nearest second we avoid locking up in an endless
+    // loop in the builder, caused by potentially enriching {{ now }} to every
+    // millisecond.
+    return new Date(Math.floor(time / 1000) * 1000)
+  }
+
+  $: console.log(value)
 </script>
 
 <Flatpickr
   bind:flatpickr
-  {value}
+  value={parseDate(value)}
   on:open={onOpen}
   on:close={onClose}
   options={flatpickrOptions}

--- a/packages/bbui/src/Form/DatePicker.svelte
+++ b/packages/bbui/src/Form/DatePicker.svelte
@@ -1,6 +1,7 @@
 <script>
   import Field from "./Field.svelte"
   import DatePicker from "./Core/DatePicker.svelte"
+  import { createEventDispatcher } from "svelte"
 
   export let value = null
   export let label = null
@@ -10,6 +11,13 @@
   export let enableTime = true
   export let placeholder = null
   export let appendTo = undefined
+
+  const dispatch = createEventDispatcher()
+
+  const onChange = e => {
+    value = e.detail
+    dispatch("change", e.detail)
+  }
 </script>
 
 <Field {label} {labelPosition} {error}>
@@ -20,6 +28,6 @@
     {placeholder}
     {enableTime}
     {appendTo}
-    on:change
+    on:change={onChange}
   />
 </Field>

--- a/packages/bbui/src/Form/DatePicker.svelte
+++ b/packages/bbui/src/Form/DatePicker.svelte
@@ -1,7 +1,6 @@
 <script>
   import Field from "./Field.svelte"
   import DatePicker from "./Core/DatePicker.svelte"
-  import { createEventDispatcher } from "svelte"
 
   export let value = null
   export let label = null
@@ -11,13 +10,6 @@
   export let enableTime = true
   export let placeholder = null
   export let appendTo = undefined
-
-  const dispatch = createEventDispatcher()
-  const onChange = e => {
-    const isoString = e.detail.toISOString()
-    value = isoString
-    dispatch("change", isoString)
-  }
 </script>
 
 <Field {label} {labelPosition} {error}>
@@ -28,6 +20,6 @@
     {placeholder}
     {enableTime}
     {appendTo}
-    on:change={onChange}
+    on:change
   />
 </Field>

--- a/packages/client/src/components/app/forms/DateTimeField.svelte
+++ b/packages/client/src/components/app/forms/DateTimeField.svelte
@@ -12,31 +12,6 @@
 
   let fieldState
   let fieldApi
-
-  const parseDate = val => {
-    if (!val) {
-      return null
-    }
-    let date
-    if (val instanceof Date) {
-      // Use real date obj if already parsed
-      date = val
-    } else if (isNaN(val)) {
-      // Treat as date string of some sort
-      date = new Date(val)
-    } else {
-      // Treat as numerical timestamp
-      date = new Date(parseInt(val))
-    }
-    const time = date.getTime()
-    if (isNaN(time)) {
-      return null
-    }
-    // By rounding to the nearest second we avoid locking up in an endless
-    // loop in the builder, caused by potentially enriching {{ now }} to every
-    // millisecond.
-    return new Date(Math.floor(time / 1000) * 1000)
-  }
 </script>
 
 <Field
@@ -44,7 +19,7 @@
   {field}
   {disabled}
   {validation}
-  defaultValue={parseDate(defaultValue)}
+  {defaultValue}
   type="datetime"
   bind:fieldState
   bind:fieldApi


### PR DESCRIPTION
## Description
In our BBUI implementation of a date picker there is parsing logic to ensure the value is always treated correctly as an ISO string. This logic was contained in the main DatePicker file rather than the "core" version. The client component for date pickers uses the core version directly, which means it did not benefit from this parsing logic.

I've moved the parsing logic into the core BBUI date picker so that all date pickers should now be consistent.

- The value passed to the Flatpickr instance is always a real JS date object
- The value emitted from date pickers is always an ISO string

This should ensure that going forward, all dates will be stored correctly as ISO strings and therefore can be sorted properly.

This does not fix current dates which have been stored as an incorrect format. Those fields are now in the database and will still be sorted incorrectly when using a data provider, until they are manually edited - at which point they will then be saved with the proper structure. Bad dates should now always display properly at least, but the sorting order from data providers will be continue to be incorrect. All new data will never experience this issue.

This fixes the core issue that caused #2108, but since sorting will still be wrong for old dates I'll not close that issue until the affected people have seen this change and understand that old data will still be sorted wrong until it is edited, but new data will not have this problem any more.


