### PR TITLE
Fix flatpickr hijacking key events on the whole page

### DIFF
--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -113,6 +113,13 @@
                     />
                   {/key}
 
+                  <!--
+                    Flatpickr needs to be inside the theme wrapper.
+                    It also needs its own container because otherwise it hijacks
+                    key events on the whole page. It is painful to work with.
+                  -->
+                  <div id="flatpickr-root" />
+
                   <!-- Layers on top of app -->
                   <NotificationDisplay />
                   <ConfirmationDisplay />

--- a/packages/client/src/components/app/forms/DateTimeField.svelte
+++ b/packages/client/src/components/app/forms/DateTimeField.svelte
@@ -56,7 +56,7 @@
       disabled={fieldState.disabled}
       error={fieldState.error}
       id={fieldState.fieldId}
-      appendTo={document.getElementById("theme-root")}
+      appendTo={document.getElementById("flatpickr-root")}
       {enableTime}
       {placeholder}
     />


### PR DESCRIPTION
For some reason, if Flatpickr is given a custom target element to append to (as we do in client apps so that we can theme it) it hijacks all key events for that element and prevents the usage of enter or arrow keys, as well as many other keys I'm sure. This meant that if you had a date picker anywhere on a your page in an app, you could not use the enter key or arrow keys on that page.

 I've given it its own root component so that this does not happen any more.

Closes #3043.

p.s. Flatpickr needs replaced, it has caused so many issues.



