### PR TITLE
Fixing table permissions issue

### DIFF
--- a/packages/server/src/api/controllers/permission.js
+++ b/packages/server/src/api/controllers/permission.js
@@ -147,6 +147,7 @@ exports.getResourcePerms = async function (ctx) {
       const rolePerms = role.permissions
       if (
         rolePerms &&
+        rolePerms[resourceId] &&
         (rolePerms[resourceId] === level ||
           rolePerms[resourceId].indexOf(level) !== -1)
       ) {


### PR DESCRIPTION
## Description
Fixing issue with permissions, if some permissions have already been set for a role an error would be thrown which would break the UI and make it impossible to setup permissions for other tables.

This issue has been seen in #2934 and #3017.


