### PR TITLE
Fixing issue with SQL tables and automation update row action

### DIFF
--- a/packages/server/src/api/controllers/table/index.js
+++ b/packages/server/src/api/controllers/table/index.js
@@ -9,11 +9,7 @@ const {
   BudibaseInternalDB,
 } = require("../../../db/utils")
 const { FieldTypes } = require("../../../constants")
-const { TableSaveFunctions, getExternalTable } = require("./utils")
-const {
-  isExternalTable,
-  breakExternalTableId,
-} = require("../../../integrations/utils")
+const { TableSaveFunctions, getTable } = require("./utils")
 
 exports.fetch = async function (ctx) {
   const db = new CouchDB(ctx.appId)
@@ -48,14 +44,8 @@ exports.fetch = async function (ctx) {
 }
 
 exports.find = async function (ctx) {
-  const db = new CouchDB(ctx.appId)
   const tableId = ctx.params.id
-  if (isExternalTable(tableId)) {
-    let { datasourceId, tableName } = breakExternalTableId(tableId)
-    ctx.body = await getExternalTable(ctx.appId, datasourceId, tableName)
-  } else {
-    ctx.body = await db.get(ctx.params.id)
-  }
+  ctx.body = await getTable(ctx.appId, tableId)
 }
 
 exports.save = async function (ctx) {

--- a/packages/server/src/api/controllers/table/utils.js
+++ b/packages/server/src/api/controllers/table/utils.js
@@ -9,6 +9,10 @@ const { isEqual } = require("lodash/fp")
 const { AutoFieldSubTypes, FieldTypes } = require("../../../constants")
 const { inputProcessing } = require("../../../utilities/rowProcessor")
 const { USERS_TABLE_SCHEMA } = require("../../../constants")
+const {
+  isExternalTable,
+  breakExternalTableId,
+} = require("../../../integrations/utils")
 
 exports.checkForColumnUpdates = async (db, oldTable, updatedTable) => {
   let updatedRows = []
@@ -221,6 +225,16 @@ exports.getAllExternalTables = async (appId, datasourceId) => {
 exports.getExternalTable = async (appId, datasourceId, tableName) => {
   const entities = await exports.getAllExternalTables(appId, datasourceId)
   return entities[tableName]
+}
+
+exports.getTable = async (appId, tableId) => {
+  const db = new CouchDB(appId)
+  if (isExternalTable(tableId)) {
+    let { datasourceId, tableName } = breakExternalTableId(tableId)
+    return exports.getExternalTable(appId, datasourceId, tableName)
+  } else {
+    return db.get(tableId)
+  }
 }
 
 exports.TableSaveFunctions = TableSaveFunctions

--- a/packages/server/src/automations/steps/bash.js
+++ b/packages/server/src/automations/steps/bash.js
@@ -1,5 +1,6 @@
 const { execSync } = require("child_process")
 const { processStringSync } = require("@budibase/string-templates")
+const automationUtils = require("../automationUtils")
 
 exports.definition = {
   name: "Bash Scripting",
@@ -63,7 +64,7 @@ exports.run = async function ({ inputs, context }) {
   } catch (err) {
     return {
       success: false,
-      response: err,
+      response: automationUtils.getError(err),
     }
   }
 }

--- a/packages/server/src/automations/steps/createRow.js
+++ b/packages/server/src/automations/steps/createRow.js
@@ -97,7 +97,7 @@ exports.run = async function ({ inputs, appId, emitter }) {
   } catch (err) {
     return {
       success: false,
-      response: err,
+      response: automationUtils.getError(err),
     }
   }
 }

--- a/packages/server/src/automations/steps/deleteRow.js
+++ b/packages/server/src/automations/steps/deleteRow.js
@@ -2,6 +2,7 @@ const rowController = require("../../api/controllers/row")
 const env = require("../../environment")
 const usage = require("../../utilities/usageQuota")
 const { buildCtx } = require("./utils")
+const automationUtils = require("../automationUtils")
 
 exports.definition = {
   description: "Delete a row from your database",
@@ -85,7 +86,7 @@ exports.run = async function ({ inputs, appId, emitter }) {
   } catch (err) {
     return {
       success: false,
-      response: err,
+      response: automationUtils.getError(err),
     }
   }
 }

--- a/packages/server/src/automations/steps/executeQuery.js
+++ b/packages/server/src/automations/steps/executeQuery.js
@@ -1,5 +1,6 @@
 const queryController = require("../../api/controllers/query")
 const { buildCtx } = require("./utils")
+const automationUtils = require("../automationUtils")
 
 exports.definition = {
   name: "External Data Connector",
@@ -74,7 +75,7 @@ exports.run = async function ({ inputs, appId, emitter }) {
   } catch (err) {
     return {
       success: false,
-      response: err,
+      response: automationUtils.getError(err),
     }
   }
 }

--- a/packages/server/src/automations/steps/executeScript.js
+++ b/packages/server/src/automations/steps/executeScript.js
@@ -1,5 +1,6 @@
 const scriptController = require("../../api/controllers/script")
 const { buildCtx } = require("./utils")
+const automationUtils = require("../automationUtils")
 
 exports.definition = {
   name: "JS Scripting",
@@ -63,7 +64,7 @@ exports.run = async function ({ inputs, appId, context, emitter }) {
   } catch (err) {
     return {
       success: false,
-      response: err,
+      response: automationUtils.getError(err),
     }
   }
 }

--- a/packages/server/src/automations/steps/outgoingWebhook.js
+++ b/packages/server/src/automations/steps/outgoingWebhook.js
@@ -1,5 +1,6 @@
 const fetch = require("node-fetch")
 const { getFetchResponse } = require("./utils")
+const automationUtils = require("../automationUtils")
 
 const RequestType = {
   POST: "POST",
@@ -127,7 +128,7 @@ exports.run = async function ({ inputs }) {
     /* istanbul ignore next */
     return {
       success: false,
-      response: err,
+      response: automationUtils.getError(err),
     }
   }
 }

--- a/packages/server/src/automations/steps/queryRows.js
+++ b/packages/server/src/automations/steps/queryRows.js
@@ -2,6 +2,7 @@ const rowController = require("../../api/controllers/row")
 const tableController = require("../../api/controllers/table")
 const { FieldTypes } = require("../../constants")
 const { buildCtx } = require("./utils")
+const automationUtils = require("../automationUtils")
 
 const SortOrders = {
   ASCENDING: "ascending",
@@ -110,7 +111,7 @@ exports.run = async function ({ inputs, appId }) {
   } catch (err) {
     return {
       success: false,
-      response: err,
+      response: automationUtils.getError(err),
     }
   }
 }

--- a/packages/server/src/automations/steps/sendSmtpEmail.js
+++ b/packages/server/src/automations/steps/sendSmtpEmail.js
@@ -1,4 +1,5 @@
 const { sendSmtpEmail } = require("../../utilities/workerRequests")
+const automationUtils = require("../automationUtils")
 
 exports.definition = {
   description: "Send an email using SMTP",
@@ -61,7 +62,7 @@ exports.run = async function ({ inputs }) {
   } catch (err) {
     return {
       success: false,
-      response: err,
+      response: automationUtils.getError(err),
     }
   }
 }

--- a/packages/server/src/automations/steps/updateRow.js
+++ b/packages/server/src/automations/steps/updateRow.js
@@ -64,6 +64,7 @@ exports.run = async function ({ inputs, appId, emitter }) {
       },
     }
   }
+  const tableId = inputs.row.tableId
 
   // clear any falsy properties so that they aren't updated
   for (let propKey of Object.keys(inputs.row)) {
@@ -80,15 +81,14 @@ exports.run = async function ({ inputs, appId, emitter }) {
     },
     params: {
       rowId: inputs.rowId,
+      tableId: tableId,
     },
   })
 
   try {
-    inputs.row = await automationUtils.cleanUpRowById(
-      appId,
-      inputs.rowId,
-      inputs.row
-    )
+    if (tableId) {
+      inputs.row = await automationUtils.cleanUpRow(appId, tableId, inputs.row)
+    }
     await rowController.patch(ctx)
     return {
       row: ctx.body,
@@ -100,7 +100,7 @@ exports.run = async function ({ inputs, appId, emitter }) {
   } catch (err) {
     return {
       success: false,
-      response: err,
+      response: automationUtils.getError(err),
     }
   }
 }


### PR DESCRIPTION
## Description
Fixing issue with SQL tables and automations updating a row, also making error handling better across automations to make sure some sort of error message is always returned.

Previously our update endpoint didn't specifically require a table ID to be specified, however for external tables we need to know this information up front to decide whether to use internal or not. Our automation action already knows the table ID anyway so just passing it down to the row controller.