### PR TITLE
Fixing handlebars binding bug

### DIFF
--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -472,7 +472,7 @@ function bindingReplacement(bindableProperties, textWithBindings, convertTo) {
           idx = searchString.indexOf(from)
           if (idx !== -1) {
             let end = idx + from.length,
-              searchReplace = Array(binding[convertTo].length).join("*")
+              searchReplace = Array(binding[convertTo].length + 1).join("*")
             // blank out parts of the search string
             searchString = replaceBetween(searchString, idx, end, searchReplace)
             newBoundValue = replaceBetween(

--- a/packages/builder/src/components/start/CreateAppModal.svelte
+++ b/packages/builder/src/components/start/CreateAppModal.svelte
@@ -66,6 +66,11 @@
   const checkValidity = async (values, validator) => {
     const obj = object().shape(validator)
     Object.keys(validator).forEach(key => ($errors[key] = null))
+    if (template?.fromFile && values.file == null) {
+      valid = false
+      return
+    }
+
     try {
       await obj.validate(values, { abortEarly: false })
     } catch (validationErrors) {
@@ -73,6 +78,7 @@
         $errors[error.path] = capitalise(error.message)
       })
     }
+
     valid = await obj.isValid(values)
   }
 


### PR DESCRIPTION
## Description
Fixing two issues, not verifying a file has been uploaded for import app and fixing HBS visual issue where handlebars statement could get screwed up.

This fixes the issues seen in #2955.

This was caused by our search system during runtime/readable binding conversions, there was an issue when there were multiple bindings to be replaced within the same handlebars statement (a semi uncommon problem) the search system would end up off by 1 character, eventually this problem would multiply.