### PR TITLE
Keep views in sync with table schema changes

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/FilterModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/FilterModal.svelte
@@ -82,34 +82,30 @@
 
   function isMultipleChoice(field) {
     return (
-      (viewTable.schema[field].constraints &&
-        viewTable.schema[field].constraints.inclusion &&
-        viewTable.schema[field].constraints.inclusion.length) ||
-      viewTable.schema[field].type === "boolean"
+      viewTable.schema[field]?.constraints?.inclusion?.length ||
+      viewTable.schema[field]?.type === "boolean"
     )
   }
 
   function fieldOptions(field) {
-    return viewTable.schema[field].type === "options"
-      ? viewTable.schema[field].constraints.inclusion
+    return viewTable.schema[field]?.type === "options"
+      ? viewTable.schema[field]?.constraints.inclusion
       : [true, false]
   }
 
   function isDate(field) {
-    return viewTable.schema[field].type === "datetime"
+    return viewTable.schema[field]?.type === "datetime"
   }
 
   function isNumber(field) {
-    return viewTable.schema[field].type === "number"
+    return viewTable.schema[field]?.type === "number"
   }
 
   const fieldChanged = filter => ev => {
-    // reset if type changed
-    if (
-      filter.key &&
-      ev.detail &&
-      viewTable.schema[filter.key].type !== viewTable.schema[ev.detail].type
-    ) {
+    // Reset if type changed
+    const oldType = viewTable.schema[filter.key]?.type
+    const newType = viewTable.schema[ev.detail]?.type
+    if (filter.key && ev.detail && oldType !== newType) {
       filter.value = ""
     }
   }

--- a/packages/server/src/api/controllers/table/utils.js
+++ b/packages/server/src/api/controllers/table/utils.js
@@ -13,6 +13,8 @@ const {
   isExternalTable,
   breakExternalTableId,
 } = require("../../../integrations/utils")
+const { getViews, saveView } = require("../view/utils")
+const viewTemplate = require("../view/viewBuilder")
 
 exports.checkForColumnUpdates = async (db, oldTable, updatedTable) => {
   let updatedRows = []
@@ -25,6 +27,7 @@ exports.checkForColumnUpdates = async (db, oldTable, updatedTable) => {
   }
   // check for renaming of columns or deleted columns
   if (rename || deletedColumns.length !== 0) {
+    // Update all rows
     const rows = await db.allDocs(
       getRowParams(updatedTable._id, null, {
         include_docs: true,
@@ -39,6 +42,9 @@ exports.checkForColumnUpdates = async (db, oldTable, updatedTable) => {
       }
       return doc
     })
+
+    // Update views
+    await exports.checkForViewUpdates(db, updatedTable, rename, deletedColumns)
     delete updatedTable._rename
   }
   return { rows: updatedRows, table: updatedTable }
@@ -234,6 +240,76 @@ exports.getTable = async (appId, tableId) => {
     return exports.getExternalTable(appId, datasourceId, tableName)
   } else {
     return db.get(tableId)
+  }
+}
+
+exports.checkForViewUpdates = async (db, table, rename, deletedColumns) => {
+  const views = await getViews(db)
+  const tableViews = views.filter(view => view.meta.tableId === table._id)
+
+  // Check each table view to see if impacted by this table action
+  for (let view of tableViews) {
+    let needsUpdated = false
+
+    // First check for renames, otherwise check for deletions
+    if (rename) {
+      // Update calculation field if required
+      if (view.meta.field === rename.old) {
+        view.meta.field = rename.updated
+        needsUpdated = true
+      }
+
+      // Update group by field if required
+      if (view.meta.groupBy === rename.old) {
+        view.meta.groupBy = rename.updated
+        needsUpdated = true
+      }
+
+      // Update filters if required
+      view.meta.filters?.forEach(filter => {
+        if (filter.key === rename.old) {
+          filter.key = rename.updated
+          needsUpdated = true
+        }
+      })
+    } else if (deletedColumns?.length) {
+      deletedColumns.forEach(column => {
+        // Remove calculation statement if required
+        if (view.meta.field === column) {
+          delete view.meta.field
+          delete view.meta.calculation
+          delete view.meta.groupBy
+          needsUpdated = true
+        }
+
+        // Remove group by field if required
+        if (view.meta.groupBy === column) {
+          delete view.meta.groupBy
+          needsUpdated = true
+        }
+
+        // Remove filters referencing deleted field if required
+        if (view.meta.filters?.length) {
+          const initialLength = view.meta.filters.length
+          view.meta.filters = view.meta.filters.filter(filter => {
+            return filter.key !== column
+          })
+          if (initialLength !== view.meta.filters.length) {
+            needsUpdated = true
+          }
+        }
+      })
+    }
+
+    // Update view if required
+    if (needsUpdated) {
+      const newViewTemplate = viewTemplate(view.meta)
+      await saveView(db, null, view.name, newViewTemplate)
+      if (!newViewTemplate.meta.schema) {
+        newViewTemplate.meta.schema = table.schema
+      }
+      table.views[view.name] = newViewTemplate.meta
+    }
   }
 }
 

--- a/packages/server/src/api/controllers/table/utils.js
+++ b/packages/server/src/api/controllers/table/utils.js
@@ -266,13 +266,15 @@ exports.checkForViewUpdates = async (db, table, rename, deletedColumns) => {
       }
 
       // Update filters if required
-      view.meta.filters?.forEach(filter => {
-        if (filter.key === rename.old) {
-          filter.key = rename.updated
-          needsUpdated = true
-        }
-      })
-    } else if (deletedColumns?.length) {
+      if (view.meta.filters) {
+        view.meta.filters.forEach(filter => {
+          if (filter.key === rename.old) {
+            filter.key = rename.updated
+            needsUpdated = true
+          }
+        })
+      }
+    } else if (deletedColumns) {
       deletedColumns.forEach(column => {
         // Remove calculation statement if required
         if (view.meta.field === column) {
@@ -289,7 +291,7 @@ exports.checkForViewUpdates = async (db, table, rename, deletedColumns) => {
         }
 
         // Remove filters referencing deleted field if required
-        if (view.meta.filters?.length) {
+        if (view.meta.filters && view.meta.filters.length) {
           const initialLength = view.meta.filters.length
           view.meta.filters = view.meta.filters.filter(filter => {
             return filter.key !== column


### PR DESCRIPTION
## Description
While investigating #3084 it became clear that there was a larger problem with views, in that any changes to the table schema (renaming columns or deleting columns) would leave views stale, potentially referencing columns which don't exit any more. This problem did not just relate to view filters, but any view property that uses column names - group by, calculation and filters.

This PR fixes the issue where views crash when referencing old column names, but the main freature is that any affected views are now updated whenever table columns are renamed or deleted to avoid this issue in the first place.

- When a column is renamed and that column is referenced by a view, the view is updated with the new column name so it continues to work without any intervention
- When a column is deleted, that configuration part of the view is deleted
- If a column referenced by a view filter is deleted, only that specific filter statement is deleted
- If a column referenced by a "group by" is deleted, the "group by" is deleted
- If a column referenced by a "calculation" is deleted, the "calculation" and "group by" are both deleted, as "group by" makes no sense without "calculation"
- Fix errors being thrown when views reference old fields (errors can still be thrown by an invalid field in a calculation, as couch seems to throw that itself). This should only be the case for any existing malconfigured views, as it can't happen any more.



