### PR TITLE
Quick fixes for various issues

### DIFF
--- a/packages/bbui/src/Form/Core/DatePicker.svelte
+++ b/packages/bbui/src/Form/Core/DatePicker.svelte
@@ -86,8 +86,6 @@
     // millisecond.
     return new Date(Math.floor(time / 1000) * 1000)
   }
-
-  $: console.log(value)
 </script>
 
 <Flatpickr

--- a/packages/bbui/src/Form/Core/Picker.svelte
+++ b/packages/bbui/src/Form/Core/Picker.svelte
@@ -115,7 +115,7 @@
 {#if open}
   <div
     use:clickOutside={() => (open = false)}
-    transition:fly={{ y: -20, duration: 200 }}
+    transition:fly|local={{ y: -20, duration: 200 }}
     class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover is-open"
     class:auto-width={autoWidth}
   >

--- a/packages/builder/src/components/start/TemplateList.svelte
+++ b/packages/builder/src/components/start/TemplateList.svelte
@@ -87,10 +87,10 @@
   }
 
   .template {
-    height: 60px;
+    min-height: 60px;
     display: grid;
-    grid-gap: var(--layout-m);
-    grid-template-columns: 5% 1fr 15%;
+    grid-gap: var(--layout-s);
+    grid-template-columns: auto 1fr auto;
     border: 1px solid #494949;
     align-items: center;
     cursor: pointer;


### PR DESCRIPTION
## Description
Couple of small changes to close off a couple of easy issues.
- Display template text properly on mobile. Closes #3088.
- Fix picker duplication when having it open and changing settings. I believe this bug was also responsible for rare strange behaviour like the whole builder sometome duplicating pages whenever moving from data to design section and vice versa. Closes #2980.
- Remove a leftover log statement

p.s. I think I win some sort of efficiency award for this one 😄 2 issues fixed with a change size of:
![image](https://user-images.githubusercontent.com/9075550/138282035-fa13878a-76e8-4ccc-80dd-c61e449d5c0e.png)

