### PR TITLE
Disable action if SMTP has not been setup

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/ActionModal.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/ActionModal.svelte
@@ -16,7 +16,7 @@
 
   const disabled = {
     SEND_EMAIL_SMTP: {
-      disabled: $admin.checklist.smtp.checked,
+      disabled: !$admin.checklist.smtp.checked,
       message: "Please configure SMTP",
     },
   }
@@ -101,12 +101,12 @@
 
     <div class="item-list">
       {#each Object.entries(internal) as [idx, action]}
-        {#if disabled[idx] && !disabled[idx].disabled}
+        {#if disabled[idx] && disabled[idx].disabled}
           <Tooltip text={disabled[idx].message} direction="bottom">
             <div
               class="item"
               class:selected={selectedAction === action.name}
-              class:disabled={disabled[idx]}
+              class:disabled={true}
               on:click={() => selectAction(action)}
             >
               <div class="item-body">

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/ActionModal.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/ActionModal.svelte
@@ -1,10 +1,25 @@
 <script>
-  import { ModalContent, Layout, Detail, Body, Icon } from "@budibase/bbui"
+  import {
+    ModalContent,
+    Layout,
+    Detail,
+    Body,
+    Icon,
+    Tooltip,
+  } from "@budibase/bbui"
   import { automationStore } from "builderStore"
+  import { admin } from "stores/portal"
   import { externalActions } from "./ExternalActions"
 
   export let blockIdx
   export let blockComplete
+
+  const disabled = {
+    SEND_EMAIL_SMTP: {
+      disabled: $admin.checklist.smtp.checked,
+      message: "Please configure SMTP",
+    },
+  }
 
   let selectedAction
   let actionVal
@@ -55,6 +70,7 @@
   }}
 >
   <Body size="XS">Select an app or event.</Body>
+
   <Layout noPadding>
     <Body size="S">Apps</Body>
 
@@ -85,24 +101,46 @@
 
     <div class="item-list">
       {#each Object.entries(internal) as [idx, action]}
-        <div
-          class="item"
-          class:selected={selectedAction === action.name}
-          on:click={() => selectAction(action)}
-        >
-          <div class="item-body">
-            <Icon name={action.icon} />
-            <span class="icon-spacing">
-              <Body size="XS">{action.name}</Body></span
+        {#if disabled[idx] && !disabled[idx].disabled}
+          <Tooltip text={disabled[idx].message} direction="bottom">
+            <div
+              class="item"
+              class:selected={selectedAction === action.name}
+              class:disabled={disabled[idx]}
+              on:click={() => selectAction(action)}
             >
+              <div class="item-body">
+                <Icon name={action.icon} />
+                <span class="icon-spacing">
+                  <Body size="XS">{action.name}</Body></span
+                >
+              </div>
+            </div>
+          </Tooltip>
+        {:else}
+          <div
+            class="item"
+            class:selected={selectedAction === action.name}
+            on:click={() => selectAction(action)}
+          >
+            <div class="item-body">
+              <Icon name={action.icon} />
+              <span class="icon-spacing">
+                <Body size="XS">{action.name}</Body></span
+              >
+            </div>
           </div>
-        </div>
+        {/if}
       {/each}
     </div>
   </Layout>
 </ModalContent>
 
 <style>
+  .disabled {
+    opacity: 0.3;
+    pointer-events: none;
+  }
   .icon-spacing {
     margin-left: var(--spacing-m);
   }
@@ -118,7 +156,6 @@
 
   .item {
     cursor: pointer;
-    display: grid;
     grid-gap: var(--spectrum-alias-grid-margin-xsmall);
     padding: var(--spectrum-alias-item-padding-s);
     background: var(--spectrum-alias-background-color-secondary);


### PR DESCRIPTION
## Description
Adds a tooltip and disables the action button if SMTP has not been configured. 

I've added the tooltip at the bottom, I know the top is probably a little bit more intuitive but there's something really weird going on with the tooltip component and specifically how adding it to the top it interacts with the CSS for this. 

I can go back and spend some more time to try and figure it out if needed, but didn't want to get too bogged down on this so thought i'd get a PR up at least. 

## Screenshots
<img width="560" alt="image" src="https://user-images.githubusercontent.com/5665926/138303354-2b944568-b14d-4852-85d4-15384b62155c.png">



