### PR TITLE
Various fixes, including replacing live replication from prod -> dev

### DIFF
--- a/packages/auth/src/db/Replication.js
+++ b/packages/auth/src/db/Replication.js
@@ -46,22 +46,6 @@ class Replication {
   }
 
   /**
-   * Set up an ongoing live sync between 2 CouchDB databases.
-   * @param {Object} opts - PouchDB replication options
-   */
-  subscribe(opts = {}) {
-    this.replication = this.source.replicate
-      .to(this.target, {
-        live: true,
-        retry: true,
-        ...opts,
-      })
-      .on("error", function (err) {
-        throw new Error(`Replication Error: ${err}`)
-      })
-  }
-
-  /**
    * Rollback the target DB back to the state of the source DB
    */
   async rollback() {

--- a/packages/builder/src/components/settings/UpdateUserInfoModal.svelte
+++ b/packages/builder/src/components/settings/UpdateUserInfoModal.svelte
@@ -26,6 +26,7 @@
   <Body size="S">
     Personalise the platform by adding your first name and last name.
   </Body>
+  <Input disabled bind:value={$auth.user.email} label="Email" />
   <Input bind:value={$values.firstName} label="First name" />
   <Input bind:value={$values.lastName} label="Last name" />
 </ModalContent>

--- a/packages/builder/src/pages/builder/portal/manage/users/_components/BasicOnboardingModal.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/users/_components/BasicOnboardingModal.svelte
@@ -16,7 +16,13 @@
     admin = false
 
   async function createUser() {
-    const res = await users.create({ email: $email, password, builder, admin })
+    const res = await users.create({
+      email: $email,
+      password,
+      builder,
+      admin,
+      forceResetPassword: true,
+    })
     if (res.status) {
       notifications.error(res.message)
     } else {

--- a/packages/builder/src/stores/portal/users.js
+++ b/packages/builder/src/stores/portal/users.js
@@ -35,11 +35,20 @@ export function createUsersStore() {
     return await response.json()
   }
 
-  async function create({ email, password, admin, builder }) {
+  async function create({
+    email,
+    password,
+    admin,
+    builder,
+    forceResetPassword,
+  }) {
     const body = {
       email,
       password,
       roles: {},
+    }
+    if (forceResetPassword) {
+      body.forceResetPassword = forceResetPassword
     }
     if (builder) {
       body.builder = { global: true }

--- a/packages/server/src/api/controllers/auth.js
+++ b/packages/server/src/api/controllers/auth.js
@@ -28,14 +28,23 @@ exports.fetchSelf = async ctx => {
         ...metadata,
       })
     } catch (err) {
+      let response
       // user didn't exist in app, don't pretend they do
       if (user.roleId === BUILTIN_ROLE_IDS.PUBLIC) {
-        ctx.body = {}
+        response = {}
       }
       // user has a role of some sort, return them
-      else {
-        ctx.body = user
+      else if (err.status === 404) {
+        const metadata = {
+          _id: userId,
+        }
+        const dbResp = await db.put(metadata)
+        user._rev = dbResp.rev
+        response = user
+      } else {
+        response = user
       }
+      ctx.body = response
     }
   } else {
     ctx.body = user

--- a/packages/server/src/api/routes/application.js
+++ b/packages/server/src/api/routes/application.js
@@ -7,6 +7,7 @@ const usage = require("../../middleware/usageQuota")
 const router = Router()
 
 router
+  .post("/api/applications/:appId/sync", authorized(BUILDER), controller.sync)
   .post("/api/applications", authorized(BUILDER), usage, controller.create)
   .get("/api/applications/:appId/definition", controller.fetchAppDefinition)
   .get("/api/applications", controller.fetch)


### PR DESCRIPTION
## Description
An assortment of fixes after looking into some other issues and finding things that didn't work exactly as required:
1. When looking into issues with the auto column created by/updated I thought it would be good to make sure the user metadata always exists, as in some cases a relation could be created to user metadata that isn't present. To resolve this I added a check to the `self` call, if it gets 404 and the user has a role for the app, then it will create a basic user metadata doc which can be fleshed out with relationships etc. Also fixes some issues with the relationship system in the edge case that a related doc doesn't exist, in this case it should simply ignore the relationship.

2. The basic onboarding flow generates a password for the admin to provide to the user, it is basically the same flow as the "force reset password". The difference is that the basic onboarding flow didn't set the `forceResetPassword` flag, so the user wasn't prompted to change their password on first login, fixed this.

3. One thing I noticed when playing with many different users, was that it is very difficult to determine which user you're logged into at any one time, due to the lack of a profile page, or anything like that. To help with this I added the email as a disabled field in the "Update user information" modal.

![image](https://user-images.githubusercontent.com/4407001/138463878-88d2c827-7803-4ac5-956d-b6ac8ff8b186.png)

4. Lastly, the live replication that was supposed to be kicked off when a deployment was carried out was not working as expected, after some discussion we decided that the idea of live replication is relatively pointless and adds un-necessary load to Couch, even when no one is using the development apps. Instead I've made it so that a sync is performed when the application is opened in the builder, meaning that when a developer is working on an app it will have pulled in the latest information. This could be tuned to do it more often, for example everytime they open the data UI, but for now this felt enough given that it wasn't doing it at all, bar when an app was deployed.