### PR TITLE
Add timeout to node mailer, lower than jest default

### DIFF
--- a/packages/worker/src/api/routes/tests/realEmail.spec.js
+++ b/packages/worker/src/api/routes/tests/realEmail.spec.js
@@ -3,9 +3,6 @@ const { EmailTemplatePurpose } = require("../../../constants")
 const nodemailer = require("nodemailer")
 const fetch = require("node-fetch")
 
-// need a longer timeout for getting these
-jest.setTimeout(30000)
-
 describe("/api/global/email", () => {
   let request = setup.getRequest()
   let config = setup.getConfig()

--- a/packages/worker/src/api/routes/tests/utilities/TestConfiguration.js
+++ b/packages/worker/src/api/routes/tests/utilities/TestConfiguration.js
@@ -234,6 +234,7 @@ class TestConfiguration {
             user: "don.bahringer@ethereal.email",
             pass: "yCKSH8rWyUPbnhGYk9",
           },
+          connectionTimeout: 1000, // must be less than the jest default of 5000
         },
       },
       null,

--- a/packages/worker/src/utilities/email.js
+++ b/packages/worker/src/utilities/email.js
@@ -35,6 +35,9 @@ function createSMTPTransport(config) {
     options.tls = {
       rejectUnauthorized: false,
     }
+    if (config.connectionTimeout) {
+      options.connectionTimeout = config.connectionTimeout
+    }
   } else {
     options = {
       port: 587,


### PR DESCRIPTION
## Description
- The node mailer has a default timeout of 2 minutes
- This was causing our flaky test condition to never been caught due to exceeding the jest default
- Set the node mailer to use a 1 second timeout and revert the 30 second jest exception to a default of 5 seconds



