### PR TITLE
Fix budibase builder preview on safari

### DIFF
--- a/packages/builder/src/components/design/AppPreview/iframeTemplate.js
+++ b/packages/builder/src/components/design/AppPreview/iframeTemplate.js
@@ -54,7 +54,7 @@ export default `
         if (!parsed) {
           return
         }
-        
+
         // Extract data from message
         const {
           selectedComponentId,
@@ -84,17 +84,20 @@ export default `
           if (window.loadBudibase) {
             window.loadBudibase()
             document.documentElement.classList.add("loaded")
-            window.dispatchEvent(new Event("iframe-loaded"))
+            window.parent.postMessage({ type: "iframe-loaded" })
           } else {
             throw "The client library couldn't be loaded"
           }
         } catch (error) {
-          window.dispatchEvent(new CustomEvent("error", { detail: error }))
+          window.parent.postMessage({ type: "error", error })
         }
       }
 
       window.addEventListener("message", receiveMessage)
-      window.dispatchEvent(new Event("ready"))
+      window.addEventListener("keydown", evt => {
+        window.parent.postMessage({ type: "keydown", key: event.key })
+      })
+      window.parent.postMessage({ type: "ready" })
     </script>
   </head>
   <body/>

--- a/packages/client/src/stores/builder.js
+++ b/packages/client/src/stores/builder.js
@@ -4,11 +4,7 @@ import { findComponentById, findComponentPathById } from "../utils/components"
 import { pingEndUser } from "../api"
 
 const dispatchEvent = (type, data = {}) => {
-  window.dispatchEvent(
-    new CustomEvent("bb-event", {
-      detail: { type, data },
-    })
-  )
+  window.parent.postMessage({ type, data })
 }
 
 const createBuilderStore = () => {

--- a/packages/client/src/stores/notification.js
+++ b/packages/client/src/stores/notification.js
@@ -26,11 +26,19 @@ const createNotificationStore = () => {
 
     // If peeking, pass notifications back to parent window
     if (get(routeStore).queryParams?.peek) {
-      window.dispatchEvent(
-        new CustomEvent("notification", {
-          detail: { message, type, icon },
-        })
-      )
+      window.parent.postMessage({
+        type: "notification",
+        detail: {
+          message,
+          type,
+          icon,
+        },
+      })
+      // window.dispatchEvent(
+      //   new CustomEvent("notification", {
+      //     detail: { message, type, icon },
+      //   })
+      // )
       return
     }
 

--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -124,7 +124,10 @@ function copyExistingPropsOver(
   return table
 }
 
-export function finaliseExternalTables(tables: { [key: string]: any }, entities: { [key: string]: any }) {
+export function finaliseExternalTables(
+  tables: { [key: string]: any },
+  entities: { [key: string]: any }
+) {
   const finalTables: { [key: string]: any } = {}
   const errors: { [key: string]: string } = {}
   for (let [name, table] of Object.entries(tables)) {


### PR DESCRIPTION
## Description
- Closes https://github.com/Budibase/budibase/issues/2945

This PR contains code that makes the budibase preview work on safari.

The issue that was happening was that safari does not allow you to pass custom events between frames directly for security reasons, so you have to make use of the `postMessage` and `receiveMessage` APIs for cross frame communication. We already use these APIs for communicating between preview and iframe, so there's nothing new being introduced here that would break a browser that didn't support it.

I've updated all of the inner iframe events to fire a `postMessage` to the parent, which is handled and runs the correct logic in the builder. All communication between inner iframe and builder is now reliant on the messaging API.

## Screenshots
<img width="1643" alt="Screenshot 2021-10-28 at 19 41 28" src="https://user-images.githubusercontent.com/11256663/139308968-dbe2836c-fb1e-4b1d-b332-e22a102a2850.png">


