### PR TITLE
Fix for bindings not passing through falsy values

### DIFF
--- a/packages/string-templates/src/helpers/index.js
+++ b/packages/string-templates/src/helpers/index.js
@@ -31,7 +31,7 @@ const HELPERS = [
     }
     // null/undefined values produce bad results
     if (value == null || typeof value !== "string") {
-      return value || ""
+      return value == null ? "" : value
     }
     if (value && value.string) {
       value = value.string

--- a/packages/string-templates/test/basic.spec.js
+++ b/packages/string-templates/test/basic.spec.js
@@ -125,6 +125,18 @@ describe("check the utility functions", () => {
   })
 })
 
+describe("check falsy values", () => {
+  it("should get a zero out when context contains it", async () => {
+    const output = await processString("{{ number }}", { number: 0 })
+    expect(output).toEqual("0")
+  })
+
+  it("should get false out when context contains it", async () => {
+    const output = await processString("{{ bool }}", { bool: false })
+    expect(output).toEqual("false")
+  })
+})
+
 describe("check manifest", () => {
   it("should be able to retrieve the manifest", () => {
     const manifest = getManifest()


### PR DESCRIPTION
## Description
Fixing bug #3195 with zero/falsy values not being passed out of bindings.

## Screenshots
Below you can see the binding to the paragraph working as expected:
![image](https://user-images.githubusercontent.com/4407001/139906766-8b136d68-1c10-47c6-af7f-498bbc582489.png)