### PR TITLE
Fix: Prevent user updates in multi tenant mode from deleting user password

### DIFF
--- a/packages/auth/src/middleware/passport/local.js
+++ b/packages/auth/src/middleware/passport/local.js
@@ -10,6 +10,7 @@ const { getTenantId } = require("../../tenancy")
 
 const INVALID_ERR = "Invalid Credentials"
 const SSO_NO_PASSWORD = "SSO user does not have a password set"
+const EXPIRED = "This account has expired. Please reset your password"
 
 exports.options = {
   passReqToCallback: true,
@@ -46,8 +47,8 @@ exports.authenticate = async function (ctx, email, password, done) {
       return authError(done, SSO_NO_PASSWORD)
     }
 
-    console.error("User has no password", dbUser)
-    return authError(done, INVALID_ERR)
+    console.error("Non SSO usser has no password set", dbUser)
+    return authError(done, EXPIRED)
   }
 
   // authenticate

--- a/packages/auth/src/middleware/passport/local.js
+++ b/packages/auth/src/middleware/passport/local.js
@@ -9,6 +9,7 @@ const { createASession } = require("../../security/sessions")
 const { getTenantId } = require("../../tenancy")
 
 const INVALID_ERR = "Invalid Credentials"
+const SSO_NO_PASSWORD = "SSO user does not have a password set"
 
 exports.options = {
   passReqToCallback: true,
@@ -33,6 +34,19 @@ exports.authenticate = async function (ctx, email, password, done) {
 
   // check that the user is currently inactive, if this is the case throw invalid
   if (dbUser.status === UserStatus.INACTIVE) {
+    return authError(done, INVALID_ERR)
+  }
+
+  // check that the user has a stored password before proceeding
+  if (!dbUser.password) {
+    if (
+      (dbUser.account && dbUser.account.authType === "sso") || // root account sso
+      dbUser.thirdPartyProfile // internal sso
+    ) {
+      return authError(done, SSO_NO_PASSWORD)
+    }
+
+    console.error("User has no password", dbUser)
     return authError(done, INVALID_ERR)
   }
 

--- a/packages/auth/src/utils.js
+++ b/packages/auth/src/utils.js
@@ -181,8 +181,8 @@ exports.saveUser = async (
 
     // check budibase users in other tenants
     if (env.MULTI_TENANCY) {
-      dbUser = await getTenantUser(email)
-      if (dbUser != null && dbUser.tenantId !== tenantId) {
+      const tenantUser = await getTenantUser(email)
+      if (tenantUser != null && tenantUser.tenantId !== tenantId) {
         throw `Email address ${email} already in use.`
       }
     }

--- a/packages/builder/src/pages/builder/auth/login.svelte
+++ b/packages/builder/src/pages/builder/auth/login.svelte
@@ -44,7 +44,7 @@
       }
     } catch (err) {
       console.error(err)
-      notifications.error("Invalid credentials")
+      notifications.error(err.message ? err.message : "Invalid Credentials")
     }
   }
 

--- a/packages/builder/src/stores/portal/auth.js
+++ b/packages/builder/src/stores/portal/auth.js
@@ -112,7 +112,7 @@ export function createAuthStore() {
       if (response.status === 200) {
         setUser(json.user)
       } else {
-        throw "Invalid credentials"
+        throw new Error(json.message ? json.message : "Invalid credentials")
       }
       return json
     },


### PR DESCRIPTION
## Description
- Prevent user updates in multi tenant mode from deleting user password
- Forward the authentication error from the backend to the login page to warn when an sso user is trying to log in with a password when one is not present
- Prevent bcrypt error and hanging login request when a password is missing. Show expired user error

## Screenshots
SSO with no password error message
![Screenshot 2021-11-03 at 13 04 45](https://user-images.githubusercontent.com/8755148/140086536-3b99b5d5-1c51-44d6-a1ca-57dd383bc5f2.png)

Expired user error message
![Screenshot 2021-11-03 at 15 44 20](https://user-images.githubusercontent.com/8755148/140094526-55caa419-218d-47b7-873b-14884ebf4b01.png)

Incorrect credentials error message
![Screenshot 2021-11-03 at 15 48 10](https://user-images.githubusercontent.com/8755148/140094636-d9ba1604-e11c-478d-be5d-85c2058995a6.png)
