### PR TITLE
Syncing user metadata - allow builder to interact with user metadata in app

### DIFF
--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -45,6 +45,7 @@ services:
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
       MINIO_URL: http://minio-service:9000
+      APPS_URL: http://app-service:4002
       COUCH_DB_USERNAME: ${COUCH_DB_USER}
       COUCH_DB_PASSWORD: ${COUCH_DB_PASSWORD}
       COUCH_DB_URL: http://${COUCH_DB_USER}:${COUCH_DB_PASSWORD}@couchdb-service:5984

--- a/hosting/kubernetes/budibase/templates/worker-service-deployment.yaml
+++ b/hosting/kubernetes/budibase/templates/worker-service-deployment.yaml
@@ -113,6 +113,8 @@ spec:
           value: {{ .Values.globals.smtp.port | quote }}
         - name: SMTP_FROM_ADDRESS
           value: {{ .Values.globals.smtp.from | quote }}
+        - name: APPS_URL
+          value: http://app-service:{{ .Values.services.apps.port }}
         image: budibase/worker
         imagePullPolicy: Always
         name: bbworker

--- a/packages/auth/src/db/utils.js
+++ b/packages/auth/src/db/utils.js
@@ -152,6 +152,17 @@ exports.getDeployedAppID = appId => {
   return appId
 }
 
+/**
+ * Convert a deployed app ID to a development app ID.
+ */
+exports.getDevelopmentAppID = appId => {
+  if (!appId.startsWith(exports.APP_DEV_PREFIX)) {
+    const id = appId.split(exports.APP_PREFIX)[1]
+    return `${exports.APP_DEV_PREFIX}${id}`
+  }
+  return appId
+}
+
 exports.getCouchUrl = () => {
   if (!env.COUCH_DB_URL) return
 

--- a/packages/auth/src/db/utils.js
+++ b/packages/auth/src/db/utils.js
@@ -259,6 +259,24 @@ exports.getAllApps = async (CouchDB, { dev, all, idsOnly } = {}) => {
   }
 }
 
+/**
+ * Utility function for getAllApps but filters to production apps only.
+ */
+exports.getDeployedAppIDs = async CouchDB => {
+  return (await exports.getAllApps(CouchDB, { idsOnly: true })).filter(
+    id => !exports.isDevAppID(id)
+  )
+}
+
+/**
+ * Utility function for the inverse of above.
+ */
+exports.getDevAppIDs = async CouchDB => {
+  return (await exports.getAllApps(CouchDB, { idsOnly: true })).filter(id =>
+    exports.isDevAppID(id)
+  )
+}
+
 exports.dbExists = async (CouchDB, dbName) => {
   let exists = false
   try {

--- a/packages/server/src/api/controllers/application.js
+++ b/packages/server/src/api/controllers/application.js
@@ -44,6 +44,7 @@ const {
   revertClientLibrary,
 } = require("../../utilities/fileSystem/clientLibrary")
 const { getTenantId, isMultiTenant } = require("@budibase/auth/tenancy")
+const { syncGlobalUsers } = require("./user")
 
 const URL_REGEX_SLASH = /\/|\\/g
 
@@ -328,6 +329,8 @@ exports.sync = async ctx => {
   if (!isDevAppID(appId)) {
     ctx.throw(400, "This action cannot be performed for production apps")
   }
+
+  // replicate prod to dev
   const prodAppId = getDeployedAppID(appId)
   const replication = new Replication({
     source: prodAppId,
@@ -343,6 +346,10 @@ exports.sync = async ctx => {
   } catch (err) {
     error = err
   }
+
+  // sync the users
+  await syncGlobalUsers(appId)
+
   if (error) {
     ctx.throw(400, error)
   } else {

--- a/packages/server/src/api/controllers/auth.js
+++ b/packages/server/src/api/controllers/auth.js
@@ -14,6 +14,8 @@ exports.fetchSelf = async ctx => {
   }
 
   const user = await getFullUser(ctx, userId)
+  // this shouldn't be returned by the app self
+  delete user.roles
 
   if (appId) {
     const db = new CouchDB(appId)
@@ -36,6 +38,7 @@ exports.fetchSelf = async ctx => {
       // user has a role of some sort, return them
       else if (err.status === 404) {
         const metadata = {
+          ...user,
           _id: userId,
         }
         const dbResp = await db.put(metadata)

--- a/packages/server/src/api/routes/user.js
+++ b/packages/server/src/api/routes/user.js
@@ -35,7 +35,7 @@ router
     controller.destroyMetadata
   )
   .post(
-    "/api/users/sync/:id",
+    "/api/users/metadata/sync/:id",
     authorized(PermissionTypes.USER, PermissionLevels.WRITE),
     controller.syncUser
   )

--- a/packages/server/src/api/routes/user.js
+++ b/packages/server/src/api/routes/user.js
@@ -34,5 +34,10 @@ router
     authorized(PermissionTypes.USER, PermissionLevels.WRITE),
     controller.destroyMetadata
   )
+  .post(
+    "/api/users/sync/:id",
+    authorized(PermissionTypes.USER, PermissionLevels.WRITE),
+    controller.syncUser
+  )
 
 module.exports = router

--- a/packages/server/src/middleware/authorized.js
+++ b/packages/server/src/middleware/authorized.js
@@ -18,7 +18,8 @@ module.exports =
   (permType, permLevel = null) =>
   async (ctx, next) => {
     // webhooks don't need authentication, each webhook unique
-    if (WEBHOOK_ENDPOINTS.test(ctx.request.url)) {
+    // also internal requests (between services) don't need authorized
+    if (WEBHOOK_ENDPOINTS.test(ctx.request.url) || ctx.internal) {
       return next()
     }
 

--- a/packages/server/src/utilities/global.js
+++ b/packages/server/src/utilities/global.js
@@ -77,6 +77,7 @@ exports.getGlobalUsers = async (appId = null, users = null) => {
     .filter(user => user != null)
     .map(user => {
       delete user.password
+      delete user.forceResetPassword
       return user
     })
   if (!appId) {

--- a/packages/server/src/utilities/global.js
+++ b/packages/server/src/utilities/global.js
@@ -46,9 +46,13 @@ exports.getCachedSelf = async (ctx, appId) => {
   return processUser(appId, user)
 }
 
-exports.getGlobalUser = async (appId, userId) => {
+exports.getRawGlobalUser = async userId => {
   const db = getGlobalDB()
-  let user = await db.get(getGlobalIDFromUserMetadataID(userId))
+  return db.get(getGlobalIDFromUserMetadataID(userId))
+}
+
+exports.getGlobalUser = async (appId, userId) => {
+  let user = await exports.getRawGlobalUser(userId)
   return processUser(appId, user)
 }
 

--- a/packages/server/src/utilities/index.js
+++ b/packages/server/src/utilities/index.js
@@ -134,3 +134,9 @@ exports.stringToReadStream = string => {
     },
   })
 }
+
+exports.doesDatabaseExist = async dbName => {
+  const db = new CouchDB(dbName, { skip_setup: true })
+  const info = await db.info()
+  return info && !info.error
+}

--- a/packages/server/src/utilities/index.js
+++ b/packages/server/src/utilities/index.js
@@ -136,7 +136,11 @@ exports.stringToReadStream = string => {
 }
 
 exports.doesDatabaseExist = async dbName => {
-  const db = new CouchDB(dbName, { skip_setup: true })
-  const info = await db.info()
-  return info && !info.error
+  try {
+    const db = new CouchDB(dbName, { skip_setup: true })
+    const info = await db.info()
+    return info && !info.error
+  } catch (err) {
+    return false
+  }
 }

--- a/packages/worker/scripts/dev/manage.js
+++ b/packages/worker/scripts/dev/manage.js
@@ -25,6 +25,7 @@ async function init() {
       ACCOUNT_PORTAL_URL: "http://localhost:10001",
       ACCOUNT_PORTAL_API_KEY: "budibase",
       PLATFORM_URL: "http://localhost:10000",
+      APPS_URL: "http://localhost:4001",
     }
     let envFile = ""
     Object.keys(envFileJson).forEach(key => {

--- a/packages/worker/src/environment.js
+++ b/packages/worker/src/environment.js
@@ -42,6 +42,7 @@ module.exports = {
   SMTP_FROM_ADDRESS: process.env.SMTP_FROM_ADDRESS,
   PLATFORM_URL: process.env.PLATFORM_URL,
   COOKIE_DOMAIN: process.env.COOKIE_DOMAIN,
+  APPS_URL: process.env.APPS_URL,
   _set(key, value) {
     process.env[key] = value
     module.exports[key] = value
@@ -51,6 +52,13 @@ module.exports = {
   isProd: () => {
     return !isDev()
   },
+}
+
+// if some var haven't been set, define them
+if (!module.exports.APPS_URL) {
+  module.exports.APPS_URL = isDev()
+    ? "http://localhost:4001"
+    : "http://app-service:4002"
 }
 
 // clean up any environment variable edge cases

--- a/packages/worker/src/utilities/appService.js
+++ b/packages/worker/src/utilities/appService.js
@@ -27,7 +27,7 @@ exports.syncUserInApps = async userId => {
     "POST",
     {}
   )
-  if (response.status !== 200) {
+  if (response && response.status !== 200) {
     throw "Unable to sync user."
   }
 }

--- a/packages/worker/src/utilities/appService.js
+++ b/packages/worker/src/utilities/appService.js
@@ -5,6 +5,9 @@ const { checkSlashesInUrl } = require("../utilities")
 const env = require("../environment")
 
 exports.syncUserInApps = async userId => {
+  if (env.isTest()) {
+    return
+  }
   const request = { headers: {} }
   request.headers[Headers.API_KEY] = env.INTERNAL_API_KEY
   if (isTenantIdSet()) {

--- a/packages/worker/src/utilities/appService.js
+++ b/packages/worker/src/utilities/appService.js
@@ -1,0 +1,23 @@
+const fetch = require("node-fetch")
+const { Headers } = require("@budibase/auth/constants")
+const { getTenantId, isTenantIdSet } = require("@budibase/auth/tenancy")
+const { checkSlashesInUrl } = require("../utilities")
+const env = require("../environment")
+
+exports.syncUserInApps = async userId => {
+  const request = { headers: {} }
+  request.headers[Headers.API_KEY] = env.INTERNAL_API_KEY
+  if (isTenantIdSet()) {
+    request.headers[Headers.TENANT_ID] = getTenantId()
+  }
+  request.headers["Content-Type"] = "application/json"
+  request.body = JSON.stringify({})
+  request.method = "POST"
+  const response = await fetch(
+    checkSlashesInUrl(env.APPS_URL + `/api/users/sync/${userId}`),
+    request
+  )
+  if (response.status !== 200) {
+    throw "Unable to sync user."
+  }
+}


### PR DESCRIPTION
## Description
This issue arose when testing #3215 - which was about being able to manipulate/use metadata about users within apps before they have logged into the app. This feature makes it so that when the user is created they will be added to the metadata database, assuming they have access to the app.

Originally I had been going to implement this by just reversing the way we looked up users, looking to the global set of users and then enriching with metadata but this doesn't work for one big reason: we now use Lucene to lookup users. As we are actually searching for the users, the call needs to support pagination, filtering and sorting; to do this across two different databases (one of which doesn't support searching/isn't indexed) was far too complicated. Instead I decided that keeping the relevant elements of the user metadata within apps up to date would be easier to achieve and will simplify a few things moving forward. This has the added benefit that we can now search the metadata docs on things like `email` or `roleId`, something which we couldn't do before.

There are a few core features to mention about this:
1. When the user `save` endpoint is hit in the worker it makes a call to the server to alert that a user has been updated. This call syncs the user across all apps that they have access to (if they are a builder then that means all apps). The sync is quite simple, it has two paths it can take:
    * The user is not a builder, it will retrieve their `roles`, remove props that aren't of importance (`password`, `forceResetPassword`) then use the roles object to find the production app IDs which they have access to. It will iterate through the production and development databases and update the metadata within.
    * They are a builder, in which case it simply retrieves a list of production app IDs and proceeds with the above step, but instead their role ID will be ADMIN for them all.
2. The sync call will also occur when the user is deleted, but rather than deleting the metadata it sets the user's status in the app to `inactive` - meaning they are disabled but no data is lost.
3. When a builder opens an app for the first time as part of the production -> development sync it also makes sure all users are up to date.

This also introduces a new environment variable to the worker `APPS_URL` so that it can communicate with the apps service, i've made it so that if this isn't filled out it will be injected with a the best value for it, depending on whether the service is being run in development or production.