### PR TITLE
fix revert on unpublished app

### DIFF
--- a/packages/server/src/api/controllers/application.js
+++ b/packages/server/src/api/controllers/application.js
@@ -337,7 +337,7 @@ exports.sync = async ctx => {
   } catch (err) {
     // the database doesn't exist. Don't replicate
     ctx.body = {
-      message: "App sync completed successfully.",
+      message: "App sync not required, app not deployed.",
     }
     return
   }

--- a/packages/server/src/api/controllers/application.js
+++ b/packages/server/src/api/controllers/application.js
@@ -329,6 +329,19 @@ exports.sync = async ctx => {
     ctx.throw(400, "This action cannot be performed for production apps")
   }
   const prodAppId = getDeployedAppID(appId)
+
+  try {
+    const prodDb = new CouchDB(prodAppId, { skip_setup: true })
+    const info = await prodDb.info()
+    if (info.error) throw info.error
+  } catch (err) {
+    // the database doesn't exist. Don't replicate
+    ctx.body = {
+      message: "App sync completed successfully.",
+    }
+    return
+  }
+
   const replication = new Replication({
     source: prodAppId,
     target: appId,

--- a/packages/server/src/api/controllers/dev.js
+++ b/packages/server/src/api/controllers/dev.js
@@ -82,6 +82,13 @@ exports.revert = async ctx => {
     const db = new CouchDB(productionAppId, { skip_setup: true })
     const info = await db.info()
     if (info.error) throw info.error
+    const deploymentDoc = await db.get(DocumentTypes.DEPLOYMENTS)
+    if (
+      !deploymentDoc.history ||
+      Object.keys(deploymentDoc.history).length === 0
+    ) {
+      throw new Error("No deployments for app")
+    }
   } catch (err) {
     return ctx.throw(400, "App has not yet been deployed")
   }


### PR DESCRIPTION
## Description
Fixes https://github.com/Budibase/budibase/issues/3277

This PR contains code that prevents reverting an app when it hasn't been published. The problem wasn't actually the logic in the controller, it was the fact that the **production app database gets created on app creation** so when you click revert, it just reverts your app to an empty app with no metadata.

We can't rely on the prod app database not being there anymore without doing a fairly large backfill job, because so many apps have been created, but we can check when they click deploy to make sure that the app has no deployments, and throw accordingly. I also considered adding logic to add a `published` field to the app metadata or pull the number of deployments in the `appPackage` call to determine this, but this would have to be kept up to date on deploy and felt a little nasty.

_If a UI facing feature, some screenshots of the new functionality._



