### PR TITLE
Fix/feature flag safari

### DIFF
--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -44,6 +44,7 @@ const INITIAL_FRONTEND_STATE = {
     state: false,
     customThemes: false,
     devicePreview: false,
+    messagePassing: false,
   },
   currentFrontEndType: "none",
   selectedScreenId: "",

--- a/packages/builder/src/components/design/AppPreview/CurrentItemPreview.svelte
+++ b/packages/builder/src/components/design/AppPreview/CurrentItemPreview.svelte
@@ -122,10 +122,10 @@
       window.addEventListener("message", receiveMessage)
     } else {
       // Legacy - remove in later versions of BB
-       iframe.contentWindow.addEventListener("ready", () => {
+      iframe.contentWindow.addEventListener("ready", () => {
         receiveMessage({ data: { type: MessageTypes.READY }})
       }, { once: true })
-       iframe.contentWindow.addEventListener("error", event => {
+      iframe.contentWindow.addEventListener("error", event => {
         receiveMessage({ data: { type: MessageTypes.ERROR, error: event.detail }})
       }, { once: true })
       // Add listener for events sent by client library in preview
@@ -138,7 +138,7 @@
   onDestroy(() => {
     if (iframe.contentWindow) {
       if ($store.clientFeatures.messagePassing) {
-      window.removeEventListener("message", receiveMessage) //
+        window.removeEventListener("message", receiveMessage) //
       } else {
         // Legacy - remove in later versions of BB
         iframe.contentWindow.removeEventListener("bb-event", handleBudibaseEvent)

--- a/packages/builder/src/components/design/AppPreview/CurrentItemPreview.svelte
+++ b/packages/builder/src/components/design/AppPreview/CurrentItemPreview.svelte
@@ -138,7 +138,7 @@
   onDestroy(() => {
     if (iframe.contentWindow) {
       if ($store.clientFeatures.messagePassing) {
-        window.removeEventListener("message", receiveMessage) //
+        window.removeEventListener("message", receiveMessage)
       } else {
         // Legacy - remove in later versions of BB
         iframe.contentWindow.removeEventListener("bb-event", handleBudibaseEvent)

--- a/packages/builder/src/components/design/AppPreview/CurrentItemPreview.svelte
+++ b/packages/builder/src/components/design/AppPreview/CurrentItemPreview.svelte
@@ -96,7 +96,9 @@
         // Initialise the app when mounted
         // Display preview immediately if the intelligent loading feature
         // is not supported
-        if (!loading) return
+        if ($store.clientFeatures.messagePassing) {
+          if (!loading) return
+        }
 
         if (!$store.clientFeatures.intelligentLoading) {
           loading = false
@@ -116,18 +118,37 @@
   }
 
   onMount(() => {
-    window.addEventListener("message", receiveMessage)
+    if ($store.clientFeatures.messagePassing) {
+      window.addEventListener("message", receiveMessage)
+    } else {
+      // Legacy - remove in later versions of BB
+       iframe.contentWindow.addEventListener("ready", () => {
+        receiveMessage({ data: { type: MessageTypes.READY }})
+      }, { once: true })
+       iframe.contentWindow.addEventListener("error", event => {
+        receiveMessage({ data: { type: MessageTypes.ERROR, error: event.detail }})
+      }, { once: true })
+      // Add listener for events sent by client library in preview
+      iframe.contentWindow.addEventListener("bb-event", handleBudibaseEvent)
+      iframe.contentWindow.addEventListener("keydown", handleKeydownEvent)
+    }
   })
 
   // Remove all iframe event listeners on component destroy
   onDestroy(() => {
     if (iframe.contentWindow) {
+      if ($store.clientFeatures.messagePassing) {
       window.removeEventListener("message", receiveMessage) //
+      } else {
+        // Legacy - remove in later versions of BB
+        iframe.contentWindow.removeEventListener("bb-event", handleBudibaseEvent)
+        iframe.contentWindow.removeEventListener("keydown", handleKeydownEvent)
+      }
     }
   })
 
   const handleBudibaseEvent = event => {
-    const { type, data } = event.data
+    const { type, data } = event.data || event.detail
     if (type === "select-component" && data.id) {
       store.actions.components.select({ _id: data.id })
     } else if (type === "update-prop") {
@@ -164,7 +185,7 @@
   }
 
   const handleKeydownEvent = event => {
-    const { key } = event.data
+    const { key } = event.data || event
     if (
       (key === "Delete" || key === "Backspace") &&
       selectedComponentId &&

--- a/packages/builder/src/components/start/TemplateList.svelte
+++ b/packages/builder/src/components/start/TemplateList.svelte
@@ -37,33 +37,33 @@
           <p class="detail">{template?.category?.toUpperCase()}</p>
         </div>
       {/each}
-      <div class="template start-from-scratch" on:click={() => onSelect(null)}>
-        <div
-          class="background-icon"
-          style={`background: rgb(50, 50, 50); color: white;`}
-        >
-          <Icon name="Add" />
-        </div>
-        <Heading size="XS">Start from scratch</Heading>
-        <p class="detail">BLANK</p>
-      </div>
-      <div
-        class="template import"
-        on:click={() => onSelect(null, { useImport: true })}
-      >
-        <div
-          class="background-icon"
-          style={`background: rgb(50, 50, 50); color: white;`}
-        >
-          <Icon name="Add" />
-        </div>
-        <Heading size="XS">Import an app</Heading>
-        <p class="detail">BLANK</p>
-      </div>
     </div>
   {:catch err}
     <h1 style="color:red">{err}</h1>
   {/await}
+  <div class="template start-from-scratch" on:click={() => onSelect(null)}>
+    <div
+      class="background-icon"
+      style={`background: rgb(50, 50, 50); color: white;`}
+    >
+      <Icon name="Add" />
+    </div>
+    <Heading size="XS">Start from scratch</Heading>
+    <p class="detail">BLANK</p>
+  </div>
+  <div
+    class="template import"
+    on:click={() => onSelect(null, { useImport: true })}
+  >
+    <div
+      class="background-icon"
+      style={`background: rgb(50, 50, 50); color: white;`}
+    >
+      <Icon name="Add" />
+    </div>
+    <Heading size="XS">Import an app</Heading>
+    <p class="detail">BLANK</p>
+  </div>
 </Layout>
 
 <style>

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -5,7 +5,8 @@
     "deviceAwareness": true,
     "state": true,
     "customThemes": true,
-    "devicePreview": true
+    "devicePreview": true,
+    "messagePassing": true
   },
   "layout": {
     "name": "Layout",


### PR DESCRIPTION
## Description
Adding feature flag support for message passing so that old versions of the client library still work inside the builder. This will allow us to release master with the latest bug fixes and updates.

I've also fixed an issue where the call to fetch templates failing prevents users from creating an app. The "Start from scratch" and "Import app" buttons will appear regardless as to whether the template call fails or not. I'll make the alert look better by using the `InlineAlert` component added in `develop` as part of the next work I do off `develop`.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



