### PR TITLE
Full bindings for relationships and attachments

### DIFF
--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -217,18 +217,8 @@ const getProviderContextBindings = (asset, dataProviders) => {
       keys.forEach(key => {
         const fieldSchema = schema[key]
 
-        // Make safe runtime binding and replace certain bindings with a
-        // new property to help display components
-        let runtimeBoundKey = key
-        if (fieldSchema.type === "link") {
-          runtimeBoundKey = `${key}_text`
-        } else if (fieldSchema.type === "attachment") {
-          runtimeBoundKey = `${key}_first`
-        }
-
-        const runtimeBinding = `${safeComponentId}.${makePropSafe(
-          runtimeBoundKey
-        )}`
+        // Make safe runtime binding
+        const runtimeBinding = `${safeComponentId}.${makePropSafe(key)}`
 
         // Optionally use a prefix with readable bindings
         let readableBinding = component._instanceName
@@ -267,17 +257,9 @@ const getUserBindings = () => {
   const safeUser = makePropSafe("user")
   keys.forEach(key => {
     const fieldSchema = schema[key]
-    // Replace certain bindings with a new property to help display components
-    let runtimeBoundKey = key
-    if (fieldSchema.type === "link") {
-      runtimeBoundKey = `${key}_text`
-    } else if (fieldSchema.type === "attachment") {
-      runtimeBoundKey = `${key}_first`
-    }
-
     bindings.push({
       type: "context",
-      runtimeBinding: `${safeUser}.${makePropSafe(runtimeBoundKey)}`,
+      runtimeBinding: `${safeUser}.${makePropSafe(key)}`,
       readableBinding: `Current User.${key}`,
       // Field schema and provider are required to construct relationship
       // datasource options, based on bindable properties

--- a/packages/client/src/api/rows.js
+++ b/packages/client/src/api/rows.js
@@ -107,6 +107,8 @@ export const deleteRows = async ({ tableId, rows }) => {
 /**
  * Enriches rows which contain certain field types so that they can
  * be properly displayed.
+ * The ability to create these bindings has been removed, but they will still
+ * exist in client apps to support backwards compatibility.
  */
 export const enrichRows = async (rows, tableId) => {
   if (!Array.isArray(rows)) {

--- a/packages/client/src/utils/linkable.js
+++ b/packages/client/src/utils/linkable.js
@@ -4,6 +4,9 @@ import { builderStore } from "stores"
 
 export const linkable = (node, href) => {
   if (get(builderStore).inBuilder) {
+    node.onclick = e => {
+      e.preventDefault()
+    }
     return
   }
   link(node, href)


### PR DESCRIPTION
## Description
This PR removes the binding transformers that we used to have in order to make relationships and attachments easily bindable. Previously we used to append a suffix to runtime bindings for data fields of certain types, and then created these artificial data fields in the client library.

Addresses #3151, #3152.

This PR removes that feature, and means that using a binding for a relationship or an attachment will instead be served the full real array. It's much easier to work with this in JS than HBS.

I've done this in a non-breaking way, by ensuring that any apps that are using the existing transformed bindings will continue to function. The client library side of this feature is not being removed yet, so although it will not be possible to create new bindings like these, existing ones will continue to work as they always have.

I've also fixed a small bug with links, where clicking on links in the builder preview would actually change the iframe location.

Things like dropzones and the way tables handle displaying relationships did not need updated as these do not use bindings - they already directly use the full array instance from the row.