### PR TITLE
Fix/templates

### DIFF
--- a/packages/builder/cypress/integration/renameAnApplication.spec.js
+++ b/packages/builder/cypress/integration/renameAnApplication.spec.js
@@ -11,7 +11,8 @@ it("should rename an unpublished application", () => {
     renameApp(appRename)
     cy.searchForApplication(appRename)
     cy.get(".appGrid").find(".wrapper").should("have.length", 1)
-    })
+    cy.deleteApp(appRename)
+})
     
 xit("Should rename a published application", () => {
     // It is not possible to rename a published application

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -51,8 +51,11 @@ Cypress.Commands.add("deleteApp", appName => {
     .then(val => {
       if (val.length > 0) {
         cy.get(".title > :nth-child(3) > .spectrum-Icon").click()
-        cy.get(`[data-cy="delete-app-confirmation"]`).type(appName)
-        cy.get(".spectrum-Button--warning").click()
+        cy.contains("Delete").click()
+        cy.get(".spectrum-Modal").within(() => {
+          cy.get("input").type(appName)
+          cy.get(".spectrum-Button--warning").click()
+        })
       }
     })
 })

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -43,7 +43,7 @@ Cypress.Commands.add("createApp", name => {
   })
 })
 
-Cypress.Commands.add("deleteApp", () => {
+Cypress.Commands.add("deleteApp", appName => {
   cy.visit(`localhost:${Cypress.env("PORT")}/builder`)
   cy.wait(1000)
   cy.request(`localhost:${Cypress.env("PORT")}/api/applications?status=all`)
@@ -51,7 +51,7 @@ Cypress.Commands.add("deleteApp", () => {
     .then(val => {
       if (val.length > 0) {
         cy.get(".title > :nth-child(3) > .spectrum-Icon").click()
-        cy.contains("Delete").click()
+        cy.get(`[data-cy="delete-app-confirmation"]`).type(appName)
         cy.get(".spectrum-Button--warning").click()
       }
     })

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -43,7 +43,7 @@ Cypress.Commands.add("createApp", name => {
   })
 })
 
-Cypress.Commands.add("deleteApp", () => {
+Cypress.Commands.add("deleteApp", appName => {
   cy.visit(`localhost:${Cypress.env("PORT")}/builder`)
   cy.wait(1000)
   cy.request(`localhost:${Cypress.env("PORT")}/api/applications?status=all`)
@@ -52,6 +52,7 @@ Cypress.Commands.add("deleteApp", () => {
       console.log(val)
       if (val.length > 0) {
         cy.get(".title > :nth-child(3) > .spectrum-Icon").click()
+        cy.get("input").type(appName)
         cy.contains("Delete").click()
         cy.get(".spectrum-Button--warning").click()
       }
@@ -60,7 +61,7 @@ Cypress.Commands.add("deleteApp", () => {
 
 Cypress.Commands.add("createTestApp", () => {
   const appName = "Cypress Tests"
-  cy.deleteApp()
+  cy.deleteApp(appName)
   cy.createApp(appName, "This app is used for Cypress testing.")
 })
 

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -43,16 +43,14 @@ Cypress.Commands.add("createApp", name => {
   })
 })
 
-Cypress.Commands.add("deleteApp", appName => {
+Cypress.Commands.add("deleteApp", () => {
   cy.visit(`localhost:${Cypress.env("PORT")}/builder`)
   cy.wait(1000)
   cy.request(`localhost:${Cypress.env("PORT")}/api/applications?status=all`)
     .its("body")
     .then(val => {
-      console.log(val)
       if (val.length > 0) {
         cy.get(".title > :nth-child(3) > .spectrum-Icon").click()
-        cy.get("input").type(appName)
         cy.contains("Delete").click()
         cy.get(".spectrum-Button--warning").click()
       }

--- a/packages/builder/src/components/common/ConfirmDialog.svelte
+++ b/packages/builder/src/components/common/ConfirmDialog.svelte
@@ -8,6 +8,7 @@
   export let onOk = undefined
   export let onCancel = undefined
   export let warning = true
+  export let disabled
 
   let modal
 
@@ -26,6 +27,7 @@
     confirmText={okText}
     {cancelText}
     {warning}
+    {disabled}
   >
     <Body size="S">
       {body}

--- a/packages/builder/src/components/deploy/RevertModal.svelte
+++ b/packages/builder/src/components/deploy/RevertModal.svelte
@@ -1,9 +1,16 @@
 <script>
-  import { Icon, Modal, notifications, ModalContent } from "@budibase/bbui"
+  import {
+    Icon,
+    Input,
+    Modal,
+    notifications,
+    ModalContent,
+  } from "@budibase/bbui"
   import { store } from "builderStore"
   import api from "builderStore/api"
 
   let revertModal
+  let appName
 
   $: appId = $store.appId
 
@@ -33,10 +40,17 @@
 
 <Icon name="Revert" hoverable on:click={revertModal.show} />
 <Modal bind:this={revertModal}>
-  <ModalContent title="Revert Changes" confirmText="Revert" onConfirm={revert}>
+  <ModalContent
+    title="Revert Changes"
+    confirmText="Revert"
+    onConfirm={revert}
+    disabled={appName !== $store.name}
+  >
     <span
       >The changes you have made will be deleted and the application reverted
       back to its production state.</span
     >
+    <span>Please enter your app name to continue.</span>
+    <Input bind:value={appName} />
   </ModalContent>
 </Modal>

--- a/packages/builder/src/components/design/AppPreview/CurrentItemPreview.svelte
+++ b/packages/builder/src/components/design/AppPreview/CurrentItemPreview.svelte
@@ -69,6 +69,7 @@
     theme: $store.theme,
     customTheme: $store.customTheme,
     previewDevice: $store.previewDevice,
+    messagePassing: $store.clientFeatures.messagePassing
   }
 
   // Saving pages and screens to the DB causes them to have _revs.

--- a/packages/builder/src/components/design/AppPreview/CurrentItemPreview.svelte
+++ b/packages/builder/src/components/design/AppPreview/CurrentItemPreview.svelte
@@ -95,12 +95,12 @@
     const handlers = {
       [MessageTypes.READY]: () => {
         // Initialise the app when mounted
-        // Display preview immediately if the intelligent loading feature
-        // is not supported
         if ($store.clientFeatures.messagePassing) {
           if (!loading) return
         }
 
+        // Display preview immediately if the intelligent loading feature
+        // is not supported
         if (!$store.clientFeatures.intelligentLoading) {
           loading = false
         }
@@ -119,9 +119,8 @@
   }
 
   onMount(() => {
-    if ($store.clientFeatures.messagePassing) {
-      window.addEventListener("message", receiveMessage)
-    } else {
+    window.addEventListener("message", receiveMessage)
+    if (!$store.clientFeatures.messagePassing) {
       // Legacy - remove in later versions of BB
       iframe.contentWindow.addEventListener("ready", () => {
         receiveMessage({ data: { type: MessageTypes.READY }})
@@ -132,15 +131,14 @@
       // Add listener for events sent by client library in preview
       iframe.contentWindow.addEventListener("bb-event", handleBudibaseEvent)
       iframe.contentWindow.addEventListener("keydown", handleKeydownEvent)
-    }
+    }  
   })
 
   // Remove all iframe event listeners on component destroy
   onDestroy(() => {
     if (iframe.contentWindow) {
-      if ($store.clientFeatures.messagePassing) {
-        window.removeEventListener("message", receiveMessage)
-      } else {
+      window.removeEventListener("message", receiveMessage)
+      if (!$store.clientFeatures.messagePassing) {
         // Legacy - remove in later versions of BB
         iframe.contentWindow.removeEventListener("bb-event", handleBudibaseEvent)
         iframe.contentWindow.removeEventListener("keydown", handleKeydownEvent)

--- a/packages/builder/src/components/design/AppPreview/iframeTemplate.js
+++ b/packages/builder/src/components/design/AppPreview/iframeTemplate.js
@@ -65,7 +65,6 @@ export default `
           theme,
           customTheme,
           previewDevice,
-          messagePassing
         } = parsed
 
         // Set some flags so the app knows we're in the builder
@@ -90,11 +89,7 @@ export default `
             throw "The client library couldn't be loaded"
           }
         } catch (error) {
-          if (messagePassing) {
-            window.parent.postMessage({ type: "error", error })
-          } else {
-            window.dispatchEvent(new CustomEvent("error", { detail: error }))
-          }
+          window.parent.postMessage({ type: "error", error })
         }
       }
 
@@ -104,7 +99,6 @@ export default `
       })
 
       window.parent.postMessage({ type: "ready" })
-      window.dispatchEvent(new Event("ready"))
     </script>
   </head>
   <body/>

--- a/packages/builder/src/components/design/AppPreview/iframeTemplate.js
+++ b/packages/builder/src/components/design/AppPreview/iframeTemplate.js
@@ -65,6 +65,7 @@ export default `
           theme,
           customTheme,
           previewDevice,
+          messagePassing
         } = parsed
 
         // Set some flags so the app knows we're in the builder
@@ -89,7 +90,11 @@ export default `
             throw "The client library couldn't be loaded"
           }
         } catch (error) {
-          window.parent.postMessage({ type: "error", error })
+          if (messagePassing) {
+            window.parent.postMessage({ type: "error", error })
+          } else {
+            window.dispatchEvent(new CustomEvent("error", { detail: error }))
+          }
         }
       }
 
@@ -97,7 +102,9 @@ export default `
       window.addEventListener("keydown", evt => {
         window.parent.postMessage({ type: "keydown", key: event.key })
       })
+
       window.parent.postMessage({ type: "ready" })
+      window.dispatchEvent(new Event("ready"))
     </script>
   </head>
   <body/>

--- a/packages/builder/src/components/start/CreateAppModal.svelte
+++ b/packages/builder/src/components/start/CreateAppModal.svelte
@@ -157,6 +157,11 @@
     }
     return title
   }
+
+  async function onCancel() {
+    template = null
+    await auth.setInitInfo({})
+  }
 </script>
 
 {#if showTemplateSelection}
@@ -186,7 +191,7 @@
     title={getModalTitle()}
     confirmText={template?.fromFile ? "Import app" : "Create app"}
     onConfirm={createNewApp}
-    onCancel={inline ? () => (template = null) : null}
+    onCancel={inline ? onCancel : null}
     cancelText={inline ? "Back" : undefined}
     showCloseIcon={!inline}
     disabled={!valid}

--- a/packages/builder/src/pages/builder/_layout.svelte
+++ b/packages/builder/src/pages/builder/_layout.svelte
@@ -30,11 +30,11 @@
     if (user && user.tenantId) {
       // no tenant in the url - send to account portal to fix this
       if (!urlTenantId) {
-        let redirectUrl = $admin.accountPortalUrl
         if (!window.location.host.includes("localhost")) {
-          const redirectUrl = redirectUrl.replace("://", `://${user.tenantId}.`)
+          let redirectUrl = window.location.href
+          redirectUrl = redirectUrl.replace("://", `://${user.tenantId}.`)
+          window.location.href = redirectUrl
         }
-        window.location.href = redirectUrl
         return
       }
 

--- a/packages/builder/src/pages/builder/_layout.svelte
+++ b/packages/builder/src/pages/builder/_layout.svelte
@@ -30,7 +30,11 @@
     if (user && user.tenantId) {
       // no tenant in the url - send to account portal to fix this
       if (!urlTenantId) {
-        window.location.href = $admin.accountPortalUrl
+        let redirectUrl = $admin.accountPortalUrl
+        if (!window.location.host.includes("localhost")) {
+          const redirectUrl = redirectUrl.replace("://", `://${user.tenantId}.`)
+        }
+        window.location.href = redirectUrl
         return
       }
 

--- a/packages/builder/src/pages/builder/_layout.svelte
+++ b/packages/builder/src/pages/builder/_layout.svelte
@@ -28,8 +28,8 @@
     }
 
     if (user && user.tenantId) {
-      // no tenant in the url - send to account portal to fix this
       if (!urlTenantId) {
+        // redirect to correct tenantId subdomain
         if (!window.location.host.includes("localhost")) {
           let redirectUrl = window.location.href
           redirectUrl = redirectUrl.replace("://", `://${user.tenantId}.`)

--- a/packages/builder/src/pages/builder/portal/apps/index.svelte
+++ b/packages/builder/src/pages/builder/portal/apps/index.svelte
@@ -303,7 +303,7 @@
   Are you sure you want to delete the app <b>{selectedApp?.name}</b>?
 
   <p>Please enter the app name below to confirm.</p>
-  <Input bind:value={appName} />
+  <Input bind:value={appName} data-cy="delete-app-confirmation" />
 </ConfirmDialog>
 <ConfirmDialog
   bind:this={unpublishModal}

--- a/packages/builder/src/pages/builder/portal/apps/index.svelte
+++ b/packages/builder/src/pages/builder/portal/apps/index.svelte
@@ -6,6 +6,7 @@
     ActionButton,
     ActionGroup,
     ButtonGroup,
+    Input,
     Select,
     Modal,
     Page,
@@ -36,6 +37,7 @@
   let loaded = false
   let searchTerm = ""
   let cloud = $admin.cloud
+  let appName = ""
 
   $: enrichedApps = enrichApps($apps, $auth.user, sortBy)
   $: filteredApps = enrichedApps.filter(app =>
@@ -296,8 +298,12 @@
   title="Confirm deletion"
   okText="Delete app"
   onOk={confirmDeleteApp}
+  disabled={appName !== selectedApp?.name}
 >
   Are you sure you want to delete the app <b>{selectedApp?.name}</b>?
+
+  <p>Please enter the app name below to confirm.</p>
+  <Input bind:value={appName} />
 </ConfirmDialog>
 <ConfirmDialog
   bind:this={unpublishModal}

--- a/packages/builder/src/stores/portal/auth.js
+++ b/packages/builder/src/stores/portal/auth.js
@@ -81,16 +81,29 @@ export function createAuthStore() {
   }
 
   async function setInitInfo(info) {
-    await api.post(`/api/global/auth/init`, info)
+    const response = await api.post(`/api/global/auth/init`, info)
+    const json = await response.json()
+    auth.update(store => {
+      store.initInfo = json
+      return store
+    })
+    return json
+  }
+
+  async function getInitInfo() {
+    const response = await api.get(`/api/global/auth/init`)
+    const json = response.json()
+    auth.update(store => {
+      store.initInfo = json
+      return store
+    })
+    return json
   }
 
   return {
     subscribe: store.subscribe,
     setOrganisation: setOrganisation,
-    getInitInfo: async () => {
-      const response = await api.get(`/api/global/auth/init`)
-      return await response.json()
-    },
+    getInitInfo,
     setInitInfo,
     checkQueryString: async () => {
       const urlParams = new URLSearchParams(window.location.search)

--- a/packages/builder/src/stores/portal/auth.js
+++ b/packages/builder/src/stores/portal/auth.js
@@ -80,6 +80,10 @@ export function createAuthStore() {
     }
   }
 
+  async function setInitInfo(info) {
+    await api.post(`/api/global/auth/init`, info)
+  }
+
   return {
     subscribe: store.subscribe,
     setOrganisation: setOrganisation,
@@ -87,9 +91,7 @@ export function createAuthStore() {
       const response = await api.get(`/api/global/auth/init`)
       return await response.json()
     },
-    setInitInfo: async info => {
-      await api.post(`/api/global/auth/init`, info)
-    },
+    setInitInfo,
     checkQueryString: async () => {
       const urlParams = new URLSearchParams(window.location.search)
       if (urlParams.has("tenantId")) {
@@ -129,6 +131,7 @@ export function createAuthStore() {
         throw "Unable to create logout"
       }
       await response.json()
+      await setInitInfo({})
       setUser(null)
     },
     updateSelf: async fields => {

--- a/packages/builder/src/stores/portal/auth.js
+++ b/packages/builder/src/stores/portal/auth.js
@@ -81,13 +81,12 @@ export function createAuthStore() {
   }
 
   async function setInitInfo(info) {
-    const response = await api.post(`/api/global/auth/init`, info)
-    const json = await response.json()
+    await api.post(`/api/global/auth/init`, info)
     auth.update(store => {
-      store.initInfo = json
+      store.initInfo = info
       return store
     })
-    return json
+    return info
   }
 
   async function getInitInfo() {
@@ -102,7 +101,7 @@ export function createAuthStore() {
 
   return {
     subscribe: store.subscribe,
-    setOrganisation: setOrganisation,
+    setOrganisation,
     getInitInfo,
     setInitInfo,
     checkQueryString: async () => {

--- a/packages/server/src/api/controllers/application.js
+++ b/packages/server/src/api/controllers/application.js
@@ -323,7 +323,7 @@ exports.delete = async ctx => {
   ctx.body = result
 }
 
-exports.sync = async ctx => {
+exports.sync = async (ctx, next) => {
   const appId = ctx.params.appId
   if (!isDevAppID(appId)) {
     ctx.throw(400, "This action cannot be performed for production apps")
@@ -336,10 +336,11 @@ exports.sync = async ctx => {
     if (info.error) throw info.error
   } catch (err) {
     // the database doesn't exist. Don't replicate
+    ctx.status = 200
     ctx.body = {
       message: "App sync not required, app not deployed.",
     }
-    return
+    return next()
   }
 
   const replication = new Replication({


### PR DESCRIPTION
## Description
- Fix issue where `ready` event was still required for safari feature flagging
- Fixes for https://github.com/Budibase/budibase/issues/3256
- Added an input for users to have to enter their app name to revert - it's a destructive operation and should have safety
- Apply tenant ID from user rather than redirect to account portal to fetch it for account owners

## Screenshots

<img width="454" alt="Screenshot 2021-11-09 at 18 01 41" src="https://user-images.githubusercontent.com/11256663/140970174-74075610-a0d8-4ad9-b186-1e60f355d46e.png">


