### PR TITLE
Improve block searching

### DIFF
--- a/packages/client/src/components/app/blocks/CardListWithSearch.svelte
+++ b/packages/client/src/components/app/blocks/CardListWithSearch.svelte
@@ -49,7 +49,7 @@
     columns?.forEach(column => {
       enrichedFilter.push({
         field: column.name,
-        operator: "equal",
+        operator: column.type === "string" ? "string" : "equal",
         type: "string",
         valueType: "Binding",
         value: `{{ [${formId}].[${column.name}] }}`,
@@ -68,6 +68,7 @@
         enrichedColumns.push({
           name: column,
           componentType,
+          type: schemaType,
         })
       }
     })

--- a/packages/client/src/components/app/blocks/TableWithSearch.svelte
+++ b/packages/client/src/components/app/blocks/TableWithSearch.svelte
@@ -48,7 +48,7 @@
     columns?.forEach(column => {
       enrichedFilter.push({
         field: column.name,
-        operator: "equal",
+        operator: column.type === "string" ? "string" : "equal",
         type: "string",
         valueType: "Binding",
         value: `{{ [${formId}].[${column.name}] }}`,
@@ -67,6 +67,7 @@
         enrichedColumns.push({
           name: column,
           componentType,
+          type: schemaType,
         })
       }
     })


### PR DESCRIPTION
## Description
This PR updates the searching logic used in block components so that using a string field will perform a "starts with" search rather than an exact match, which is what it currently does.

