### PR TITLE
bust cache when app versions are different

### DIFF
--- a/packages/server/src/api/controllers/application.js
+++ b/packages/server/src/api/controllers/application.js
@@ -197,7 +197,7 @@ exports.fetchAppPackage = async ctx => {
     application,
     screens,
     layouts,
-    clientLibPath: clientLibraryPath(ctx.params.appId),
+    clientLibPath: clientLibraryPath(ctx.params.appId, application.version),
   }
 }
 

--- a/packages/server/src/api/controllers/static/index.js
+++ b/packages/server/src/api/controllers/static/index.js
@@ -87,7 +87,7 @@ exports.serveApp = async function (ctx) {
     title: appInfo.name,
     production: env.isProd(),
     appId,
-    clientLibPath: clientLibraryPath(appId),
+    clientLibPath: clientLibraryPath(appId, appInfo.version),
   })
 
   const appHbs = loadHandlebarsFile(`${__dirname}/templates/app.hbs`)

--- a/packages/server/src/utilities/index.js
+++ b/packages/server/src/utilities/index.js
@@ -51,11 +51,16 @@ exports.objectStoreUrl = () => {
  * @return {string} The URL to be inserted into appPackage response or server rendered
  * app index file.
  */
-exports.clientLibraryPath = appId => {
+exports.clientLibraryPath = (appId, version) => {
   if (env.isProd()) {
-    return `${exports.objectStoreUrl()}/${sanitizeKey(
+    let url = `${exports.objectStoreUrl()}/${sanitizeKey(
       appId
     )}/budibase-client.js`
+    // append app version to bust the cache
+    if (version) {
+      url += `?v=${version}`
+    }
+    return url
   } else {
     return `/api/assets/client`
   }


### PR DESCRIPTION
## Description
Adding a version flag to the client library fetch with the app version to ensure that we do not get cached versions of `budibase-client.js` between versions.

Credit to @aptkingston for the idea 👍 

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



