### PR TITLE
Fixes for google sso, cloud email url and cloud logo updates

### DIFF
--- a/packages/auth/src/db/utils.js
+++ b/packages/auth/src/db/utils.js
@@ -1,6 +1,6 @@
 const { newid } = require("../hashing")
 const Replication = require("./Replication")
-const { DEFAULT_TENANT_ID } = require("../constants")
+const { DEFAULT_TENANT_ID, Configs } = require("../constants")
 const env = require("../environment")
 const { StaticDatabases, SEPARATOR, DocumentTypes } = require("./constants")
 const { getTenantId, getTenantIDFromAppID } = require("../tenancy")
@@ -322,11 +322,48 @@ const getScopedFullConfig = async function (db, { type, user, workspace }) {
   }
 
   // Find the config with the most granular scope based on context
-  const scopedConfig = response.rows.sort(
+  let scopedConfig = response.rows.sort(
     (a, b) => determineScore(a) - determineScore(b)
   )[0]
 
+  // custom logic for settings doc
+  // always provide the platform URL
+  if (type === Configs.SETTINGS) {
+    if (scopedConfig && scopedConfig.doc) {
+      scopedConfig.doc.config.platformUrl = await getPlatformUrl(
+        scopedConfig.doc.config
+      )
+    } else {
+      scopedConfig = {
+        doc: {
+          config: {
+            platformUrl: await getPlatformUrl(),
+          },
+        },
+      }
+    }
+  }
+
   return scopedConfig && scopedConfig.doc
+}
+
+const getPlatformUrl = async settings => {
+  let platformUrl = env.PLATFORM_URL
+
+  if (!env.SELF_HOSTED && env.MULTI_TENANCY) {
+    // cloud and multi tenant - add the tenant to the default platform url
+    const tenantId = getTenantId()
+    if (!platformUrl.includes("localhost:")) {
+      platformUrl = platformUrl.replace("://", `://${tenantId}.`)
+    }
+  } else {
+    // self hosted - check for platform url override
+    if (settings && settings.platformUrl) {
+      platformUrl = settings.platformUrl
+    }
+  }
+
+  return platformUrl ? platformUrl : "http://localhost:10000"
 }
 
 async function getScopedConfig(db, params) {

--- a/packages/auth/src/environment.js
+++ b/packages/auth/src/environment.js
@@ -25,6 +25,7 @@ module.exports = {
   DISABLE_ACCOUNT_PORTAL: process.env.DISABLE_ACCOUNT_PORTAL,
   SELF_HOSTED: !!parseInt(process.env.SELF_HOSTED),
   COOKIE_DOMAIN: process.env.COOKIE_DOMAIN,
+  PLATFORM_URL: process.env.PLATFORM_URL,
   isTest,
   _set(key, value) {
     process.env[key] = value

--- a/packages/auth/src/objectStore/utils.js
+++ b/packages/auth/src/objectStore/utils.js
@@ -6,6 +6,7 @@ exports.ObjectStoreBuckets = {
   APPS: "prod-budi-app-assets",
   TEMPLATES: "templates",
   GLOBAL: "global",
+  GLOBAL_CLOUD: "prod-budi-tenant-uploads",
 }
 
 exports.budibaseTempDir = function () {

--- a/packages/bbui/src/Label/Label.svelte
+++ b/packages/bbui/src/Label/Label.svelte
@@ -1,16 +1,67 @@
 <script>
   import "@spectrum-css/fieldlabel/dist/index-vars.css"
+  import Tooltip from "../Tooltip/Tooltip.svelte"
+  import Icon from "../Icon/Icon.svelte"
 
   export let size = "M"
+  export let tooltip = ""
+  export let showTooltip = false
 </script>
 
-<label for="" class={`spectrum-FieldLabel spectrum-FieldLabel--size${size}`}>
-  <slot />
-</label>
+{#if tooltip}
+  <div class="container">
+    <label
+      for=""
+      class={`spectrum-FieldLabel spectrum-FieldLabel--size${size}`}
+    >
+      <slot />
+    </label>
+    <div class="icon-container">
+      <div
+        class="icon"
+        on:mouseover={() => (showTooltip = true)}
+        on:mouseleave={() => (showTooltip = false)}
+      >
+        <Icon name="InfoOutline" size="S" disabled={true} />
+      </div>
+      {#if showTooltip}
+        <div class="tooltip">
+          <Tooltip textWrapping={true} direction={"bottom"} text={tooltip} />
+        </div>
+      {/if}
+    </div>
+  </div>
+{:else}
+  <label for="" class={`spectrum-FieldLabel spectrum-FieldLabel--size${size}`}>
+    <slot />
+  </label>
+{/if}
 
 <style>
   label {
     padding: 0;
     white-space: nowrap;
+  }
+  .container {
+    display: flex;
+  }
+  .icon-container {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    margin-top: 1px;
+    margin-left: 5px;
+    margin-right: 5px;
+  }
+  .tooltip {
+    position: absolute;
+    display: flex;
+    justify-content: center;
+    top: 15px;
+    z-index: 1;
+    width: 160px;
+  }
+  .icon {
+    transform: scale(0.75);
   }
 </style>

--- a/packages/bbui/src/Tooltip/Tooltip.svelte
+++ b/packages/bbui/src/Tooltip/Tooltip.svelte
@@ -3,12 +3,22 @@
 
   export let direction = "top"
   export let text = ""
+  export let textWrapping = false
 </script>
 
-<span class="u-tooltip-showOnHover tooltip">
-  <slot />
-  <div class={`spectrum-Tooltip spectrum-Tooltip--${direction}`}>
+<!-- Showing / Hiding a text wrapped tooltip should be handled outside the component -->
+{#if textWrapping}
+  <span class="spectrum-Tooltip spectrum-Tooltip--{direction} is-open">
     <span class="spectrum-Tooltip-label">{text}</span>
     <span class="spectrum-Tooltip-tip" />
-  </div>
-</span>
+  </span>
+{:else}
+  <!-- The default show on hover tooltip does not support text wrapping -->
+  <span class="u-tooltip-showOnHover tooltip">
+    <slot />
+    <div class={`spectrum-Tooltip spectrum-Tooltip--${direction}`}>
+      <span class="spectrum-Tooltip-label">{text}</span>
+      <span class="spectrum-Tooltip-tip" />
+    </div>
+  </span>
+{/if}

--- a/packages/builder/src/pages/builder/portal/settings/organisation.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/organisation.svelte
@@ -116,7 +116,11 @@
       </Layout>
       <div class="fields">
         <div class="field">
-          <Label size="L">Platform URL</Label>
+          <Label
+            size="L"
+            tooltip={"Update the Platform URL to match your Budibase web URL. This keeps email templates and authentication configs up to date."}
+            >Platform URL</Label
+          >
           <Input thin bind:value={$values.platformUrl} />
         </div>
       </div>
@@ -135,6 +139,7 @@
   .field {
     display: grid;
     grid-template-columns: 100px 1fr;
+    grid-gap: var(--spacing-l);
     align-items: center;
   }
   .file {

--- a/packages/builder/src/stores/portal/organisation.js
+++ b/packages/builder/src/stores/portal/organisation.js
@@ -3,12 +3,14 @@ import api from "builderStore/api"
 import { auth } from "stores/portal"
 
 const DEFAULT_CONFIG = {
-  platformUrl: "http://localhost:10000",
+  platformUrl: "",
   logoUrl: undefined,
   docsUrl: undefined,
   company: "Budibase",
   oidc: undefined,
   google: undefined,
+  oidcCallbackUrl: "",
+  googleCallbackUrl: "",
 }
 
 export function createOrganisationStore() {
@@ -28,6 +30,13 @@ export function createOrganisationStore() {
   }
 
   async function save(config) {
+    // delete non-persisted fields
+    const storeConfig = get(store)
+    delete storeConfig.oidc
+    delete storeConfig.google
+    delete storeConfig.oidcCallbackUrl
+    delete storeConfig.googleCallbackUrl
+
     const res = await api.post("/api/global/configs", {
       type: "settings",
       config: { ...get(store), ...config },

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -130,7 +130,7 @@ module PostgresModule {
     public tables: Record<string, Table> = {}
     public schemaErrors: Record<string, string> = {}
 
-    COLUMNS_SQL!: string 
+    COLUMNS_SQL!: string
 
     PRIMARY_KEYS_SQL = `
     select tc.table_schema, tc.table_name, kc.column_name as primary_key 
@@ -165,11 +165,11 @@ module PostgresModule {
 
     setSchema() {
       if (!this.config.schema) {
-        this.config.schema = 'public'
+        this.config.schema = "public"
       }
-      this.client.on('connect', (client: any) => {    
-        client.query(`SET search_path TO ${this.config.schema}`);
-      });
+      this.client.on("connect", (client: any) => {
+        client.query(`SET search_path TO ${this.config.schema}`)
+      })
       this.COLUMNS_SQL = `select * from information_schema.columns where table_schema = '${this.config.schema}'`
     }
 

--- a/packages/worker/src/api/controllers/global/auth.js
+++ b/packages/worker/src/api/controllers/global/auth.js
@@ -1,4 +1,5 @@
 const authPkg = require("@budibase/auth")
+const { getScopedConfig } = require("@budibase/auth/db")
 const { google } = require("@budibase/auth/src/middleware")
 const { oidc } = require("@budibase/auth/src/middleware")
 const { Configs, EmailTemplatePurpose } = require("../../../constants")
@@ -21,17 +22,32 @@ const {
 } = require("@budibase/auth/tenancy")
 const env = require("../../../environment")
 
-function googleCallbackUrl(config) {
+const ssoCallbackUrl = async (config, type) => {
   // incase there is a callback URL from before
   if (config && config.callbackURL) {
     return config.callbackURL
   }
+
+  const db = getGlobalDB()
+  const publicConfig = await getScopedConfig(db, {
+    type: Configs.SETTINGS,
+  })
+
   let callbackUrl = `/api/global/auth`
   if (isMultiTenant()) {
     callbackUrl += `/${getTenantId()}`
   }
-  callbackUrl += `/google/callback`
-  return callbackUrl
+  callbackUrl += `/${type}/callback`
+
+  return `${publicConfig.platformUrl}${callbackUrl}`
+}
+
+exports.googleCallbackUrl = async config => {
+  return ssoCallbackUrl(config, "google")
+}
+
+exports.oidcCallbackUrl = async config => {
+  return ssoCallbackUrl(config, "oidc")
 }
 
 async function authInternal(ctx, user, err = null, info = null) {
@@ -152,7 +168,7 @@ exports.googlePreAuth = async (ctx, next) => {
     type: Configs.GOOGLE,
     workspace: ctx.query.workspace,
   })
-  let callbackUrl = googleCallbackUrl(config)
+  let callbackUrl = await exports.googleCallbackUrl(config)
   const strategy = await google.strategyFactory(config, callbackUrl)
 
   return passport.authenticate(strategy, {
@@ -167,7 +183,7 @@ exports.googleAuth = async (ctx, next) => {
     type: Configs.GOOGLE,
     workspace: ctx.query.workspace,
   })
-  const callbackUrl = googleCallbackUrl(config)
+  const callbackUrl = await exports.googleCallbackUrl(config)
   const strategy = await google.strategyFactory(config, callbackUrl)
 
   return passport.authenticate(
@@ -189,13 +205,7 @@ async function oidcStrategyFactory(ctx, configId) {
   })
 
   const chosenConfig = config.configs.filter(c => c.uuid === configId)[0]
-
-  const protocol = env.NODE_ENV === "production" ? "https" : "http"
-  let callbackUrl = `${protocol}://${ctx.host}/api/global/auth`
-  if (isMultiTenant()) {
-    callbackUrl += `/${getTenantId()}`
-  }
-  callbackUrl += `/oidc/callback`
+  let callbackUrl = await exports.oidcCallbackUrl(chosenConfig)
 
   return oidc.strategyFactory(chosenConfig, callbackUrl)
 }

--- a/packages/worker/src/api/routes/tests/auth.spec.js
+++ b/packages/worker/src/api/routes/tests/auth.spec.js
@@ -76,7 +76,7 @@ describe("/api/global/auth", () => {
     afterEach(() => {
       expect(strategyFactory).toBeCalledWith(
         chosenConfig, 
-        `http://127.0.0.1:4003/api/global/auth/${TENANT_ID}/oidc/callback` // calculated url
+        `http://localhost:10000/api/global/auth/${TENANT_ID}/oidc/callback`
       )
     })
 

--- a/packages/worker/src/utilities/templates.js
+++ b/packages/worker/src/utilities/templates.js
@@ -6,7 +6,6 @@ const {
   EmailTemplatePurpose,
 } = require("../constants")
 const { checkSlashesInUrl } = require("./index")
-const env = require("../environment")
 const { getGlobalDB, addTenantToUrl } = require("@budibase/auth/tenancy")
 const BASE_COMPANY = "Budibase"
 
@@ -14,9 +13,6 @@ exports.getSettingsTemplateContext = async (purpose, code = null) => {
   const db = getGlobalDB()
   // TODO: use more granular settings in the future if required
   let settings = (await getScopedConfig(db, { type: Configs.SETTINGS })) || {}
-  if (!settings || !settings.platformUrl) {
-    settings.platformUrl = env.PLATFORM_URL
-  }
   const URL = settings.platformUrl
   const context = {
     [InternalTemplateBindings.LOGO_URL]:


### PR DESCRIPTION
## Description
Fixes for:
- https://github.com/Budibase/budibase/issues/3234
- https://github.com/Budibase/budibase/issues/3310
- https://github.com/Budibase/budibase/issues/3295


## Cloud logo upload
The problem here was that the bucket referenced by cloud uploads was `undefined` so the upload was always failing. 
This has been updated to point to a newly created bucket `prod-budi-tenant-uploads`. This bucket works the same way as the minio `global` folder, with the addition of tenancy path prefixes to avoid name collisions. The bucket is referenced in the same way as the app uploads using a cloudfront distribution and a new dns name: tenants.cdn.budi.live

Bucket: https://s3.console.aws.amazon.com/s3/buckets/prod-budi-tenant-uploads?region=eu-west-1&tab=objects
Distribution: https://console.aws.amazon.com/cloudfront/v3/home#/distributions/E26JN515KBF91A

## Email containing localhost in the cloud
This was caused by the default value http://localhost:10000 being saved to the public settings for cloud tenants, this occurs when the name of a tenant is updated. This handling of the Platform URL has been updated to always return the tenant aware cloud url if the environment is cloud based, or to fallback to the set value / env var in self hosted. The most failsafe way of integrating this into the current and future usages was to add some overriding behaviour when fetching `Configs.SETTINGS` document to always honour the new logic. 

## Google sso issues
Currently it's unclear on the UI of the exact URL that will be used by the google callback. Previously this was a free text field that could be edited, which was then updated to be a more opinionated default path. The hostname is inferred by the incoming request hostname / protocol which is appended to the path. This causes problems for https hosts as the proxy -> worker communication always takes place over http and results in an incorrect url being used. The fix is to link the platform url to the callback urls (also done for oidc, which followed a similar behaviour), additionally the urls are now fetched from the server instead of being populated on the UI so there can be no difference and we can guarantee on the UI what will be redirected to. 

The google callback url has now been enabled for edits when there is an existing config, so that the user may delete their existing value to fallback to the new behaviour. After this takes place the URL is no longer editable. 

## Label Tooltips
Tooltip support has been added to the `Label` component to help explain the link between platform url and the callback plus behaviour when there is an existing.

## Screenshots

Platform url / tooltips on google and oidc 

https://user-images.githubusercontent.com/8755148/141477946-45b07c81-fe7e-4922-8ada-b04e80648ed4.mov

Behaviour when there is an existing callback url

https://user-images.githubusercontent.com/8755148/141477918-76c6d534-575c-42fd-9285-db124ba44ea0.mov





