### PR TITLE
Fixing issue with RBAC always defaulting to base permissions

### DIFF
--- a/packages/auth/src/security/permissions.js
+++ b/packages/auth/src/security/permissions.js
@@ -131,38 +131,14 @@ exports.getBuiltinPermissionByID = id => {
   return perms.find(perm => perm._id === id)
 }
 
-exports.doesHaveResourcePermission = (
-  permissions,
-  permLevel,
-  { resourceId, subResourceId }
-) => {
-  // set foundSub to not subResourceId, incase there is no subResource
-  let foundMain = false,
-    foundSub = false
-  for (let [resource, levels] of Object.entries(permissions)) {
-    if (resource === resourceId && levels.indexOf(permLevel) !== -1) {
-      foundMain = true
-    }
-    if (
-      subResourceId &&
-      resource === subResourceId &&
-      levels.indexOf(permLevel) !== -1
-    ) {
-      foundSub = true
-    }
-    // this will escape if foundMain only when no sub resource
-    if (foundMain && foundSub) {
-      break
-    }
-  }
-  return foundMain || foundSub
-}
-
-exports.doesHaveBasePermission = (permType, permLevel, permissionIds) => {
+exports.doesHaveBasePermission = (permType, permLevel, rolesHierarchy) => {
+  const basePermissions = [
+    ...new Set(rolesHierarchy.map(role => role.permissionId)),
+  ]
   const builtins = Object.values(BUILTIN_PERMISSIONS)
   let permissions = flatten(
     builtins
-      .filter(builtin => permissionIds.indexOf(builtin._id) !== -1)
+      .filter(builtin => basePermissions.indexOf(builtin._id) !== -1)
       .map(builtin => builtin.permissions)
   )
   for (let permission of permissions) {

--- a/packages/auth/src/security/roles.js
+++ b/packages/auth/src/security/roles.js
@@ -231,7 +231,8 @@ exports.getRequiredResourceRole = async (
   { resourceId, subResourceId }
 ) => {
   const roles = await exports.getAllRoles(appId)
-  let main, sub
+  let main = [],
+    sub = []
   for (let role of roles) {
     // no permissions, ignore it
     if (!role.permissions) {
@@ -240,12 +241,13 @@ exports.getRequiredResourceRole = async (
     const mainRes = role.permissions[resourceId]
     const subRes = role.permissions[subResourceId]
     if (mainRes && mainRes.indexOf(permLevel) !== -1) {
-      main = role
+      main.push(role._id)
     } else if (subRes && subRes.indexOf(permLevel) !== -1) {
-      sub = role
+      sub.push(role._id)
     }
   }
-  return sub ? sub : main
+  // for now just return the IDs
+  return main.concat(sub)
 }
 
 class AccessController {

--- a/packages/server/src/middleware/authorized.js
+++ b/packages/server/src/middleware/authorized.js
@@ -1,7 +1,10 @@
-const { getUserPermissions } = require("@budibase/auth/roles")
+const {
+  getUserRoleHierarchy,
+  getRequiredResourceRole,
+  BUILTIN_ROLE_IDS,
+} = require("@budibase/auth/roles")
 const {
   PermissionTypes,
-  doesHaveResourcePermission,
   doesHaveBasePermission,
 } = require("@budibase/auth/permissions")
 const builderMiddleware = require("./builder")
@@ -28,13 +31,7 @@ module.exports =
     await builderMiddleware(ctx, permType)
 
     const isAuthed = ctx.isAuthenticated
-    const { basePermissions, permissions } = await getUserPermissions(
-      ctx.appId,
-      ctx.roleId
-    )
-
     // builders for now have permission to do anything
-    // TODO: in future should consider separating permissions with an require("@budibase/auth").isClient check
     let isBuilder = ctx.user && ctx.user.builder && ctx.user.builder.global
     const isBuilderApi = permType === PermissionTypes.BUILDER
     if (isBuilder) {
@@ -43,19 +40,27 @@ module.exports =
       return ctx.throw(403, "Not Authorized")
     }
 
-    if (
-      hasResource(ctx) &&
-      doesHaveResourcePermission(permissions, permLevel, ctx)
-    ) {
-      return next()
+    // need to check this first, in-case public access, don't check authed until last
+    const roleId = ctx.roleId || BUILTIN_ROLE_IDS.PUBLIC
+    const hierarchy = await getUserRoleHierarchy(ctx.appId, roleId, {
+      idOnly: false,
+    })
+    const permError = "User does not have permission"
+    let requiredRole
+    if (hasResource(ctx)) {
+      requiredRole = await getRequiredResourceRole(ctx.appId, permLevel, ctx)
+    }
+    // check if we found a role, if not fallback to base permissions
+    if (requiredRole) {
+      const found = hierarchy.find(role => role._id === requiredRole._id)
+      return found ? next() : ctx.throw(403, permError)
+    } else if (!doesHaveBasePermission(permType, permLevel, hierarchy)) {
+      ctx.throw(403, permError)
     }
 
+    // if they are not authed, then anything using the authorized middleware will fail
     if (!isAuthed) {
       ctx.throw(403, "Session not authenticated")
-    }
-
-    if (!doesHaveBasePermission(permType, permLevel, basePermissions)) {
-      ctx.throw(403, "User does not have permission")
     }
 
     return next()

--- a/packages/server/src/middleware/authorized.js
+++ b/packages/server/src/middleware/authorized.js
@@ -46,13 +46,15 @@ module.exports =
       idOnly: false,
     })
     const permError = "User does not have permission"
-    let requiredRole
+    let possibleRoleIds = []
     if (hasResource(ctx)) {
-      requiredRole = await getRequiredResourceRole(ctx.appId, permLevel, ctx)
+      possibleRoleIds = await getRequiredResourceRole(ctx.appId, permLevel, ctx)
     }
     // check if we found a role, if not fallback to base permissions
-    if (requiredRole) {
-      const found = hierarchy.find(role => role._id === requiredRole._id)
+    if (possibleRoleIds.length > 0) {
+      const found = hierarchy.find(
+        role => possibleRoleIds.indexOf(role._id) !== -1
+      )
       return found ? next() : ctx.throw(403, permError)
     } else if (!doesHaveBasePermission(permType, permLevel, hierarchy)) {
       ctx.throw(403, permError)

--- a/packages/server/src/middleware/tests/authorized.spec.js
+++ b/packages/server/src/middleware/tests/authorized.spec.js
@@ -10,6 +10,7 @@ jest.mock("../../environment", () => ({
 const authorizedMiddleware = require("../authorized")
 const env = require("../../environment")
 const { PermissionTypes, PermissionLevels } = require("@budibase/auth/permissions")
+require("@budibase/auth").init(require("../../db"))
 
 class TestConfiguration {
   constructor(role) {
@@ -21,6 +22,7 @@ class TestConfiguration {
       request: {
         url: ""
       },
+      appId: "",
       auth: {},
       next: this.next,
       throw: this.throw


### PR DESCRIPTION
## Description
Fixing an issue discovered in #3385 - RBAC roles worked for applying lower levels of roles, but they didn't revoke access correctly, it would always fallback to the base permissions if higher permissions were set.

All in all this change removes more than it adds because it changes the way in which the `authorized` middleware approaches RBAC.

There is basically four steps to how the middleware works:
1. Check if the user is a builder and is building an app, if they are then simply proceed (as builders can currently do anything)
2. Check the endpoint being called has a `resourceId` or `subResourceId` - if it does then retrieve all role information and see if a specific role has been assigned this resource.
3. If no resource, then check if there are any base permissions for all resources of its type
4. If no base permissions then reject users that aren't logged in, any logged in users are allowed through (they have some sort of non-public role for the app and the endpoint they are hitting has no specific authorization rules).

The big change here lies around step 2 and 3, managing resources and base permissions - to make sure if a resource has some specific permissions its not possible to fallback to the base ones.

This removes a bunch of code because the previous method worked by retrieving a list of permissions the user had and then comparing them against a list of permissions for the resource and then the base permissions, but it was better to just flip this, retrieve the list of permissions required to access the resource and then check if they existed in the users hierarchy of roles, based on the role and which ones they have inherited.