### PR TITLE
Quick fix for sync issue

### DIFF
--- a/packages/server/src/api/controllers/user.js
+++ b/packages/server/src/api/controllers/user.js
@@ -115,17 +115,17 @@ exports.syncUser = async function (ctx) {
           tableId: InternalTables.USER_METADATA,
         }
       }
-      let combined
-      if (deleting) {
-        combined = {
-          ...metadata,
-          status: UserStatus.INACTIVE,
-          metadata: BUILTIN_ROLE_IDS.PUBLIC,
-        }
-      } else {
-        combined = combineMetadataAndUser(user, metadata)
+      let combined = !deleting
+        ? combineMetadataAndUser(user, metadata)
+        : {
+            ...metadata,
+            status: UserStatus.INACTIVE,
+            metadata: BUILTIN_ROLE_IDS.PUBLIC,
+          }
+      // if its null then there was no updates required
+      if (combined) {
+        await db.put(combined)
       }
-      await db.put(combined)
     }
   }
   ctx.body = {

--- a/packages/server/src/api/controllers/user.js
+++ b/packages/server/src/api/controllers/user.js
@@ -97,6 +97,7 @@ exports.syncUser = async function (ctx) {
       .map(([appId]) => appId)
   }
   for (let prodAppId of prodAppIds) {
+    const roleId = roles[prodAppId]
     const devAppId = getDevelopmentAppID(prodAppId)
     for (let appId of [prodAppId, devAppId]) {
       if (!(await doesDatabaseExist(appId))) {
@@ -114,6 +115,10 @@ exports.syncUser = async function (ctx) {
         metadata = {
           tableId: InternalTables.USER_METADATA,
         }
+      }
+      // assign the roleId for the metadata doc
+      if (roleId) {
+        metadata.roleId = roleId
       }
       let combined = !deleting
         ? combineMetadataAndUser(user, metadata)


### PR DESCRIPTION
## Description
When updating user roles it was possible for a sync issue to occur - this was two part:
1. We weren't updating the `roleId` in the user metadata docs consistently
2. The sync didn't manage if nothing needed updated



