### PR TITLE
Caching app metadata to improve application fetch performance

### DIFF
--- a/packages/auth/cache.js
+++ b/packages/auth/cache.js
@@ -1,3 +1,4 @@
 module.exports = {
   user: require("./src/cache/user"),
+  app: require("./src/cache/appMetadata"),
 }

--- a/packages/auth/src/cache/appMetadata.js
+++ b/packages/auth/src/cache/appMetadata.js
@@ -1,0 +1,35 @@
+const redis = require("../redis/authRedis")
+const { getDB } = require("../db")
+const { DocumentTypes } = require("../db/constants")
+
+const EXPIRY_SECONDS = 3600
+
+/**
+ * The default populate app metadata function
+ */
+const populateFromDB = async appId => {
+  return getDB(appId, { skip_setup: true }).get(DocumentTypes.APP_METADATA)
+}
+
+/**
+ * Get the requested app metadata by id.
+ * Use redis cache to first read the app metadata.
+ * If not present fallback to loading the app metadata directly and re-caching.
+ * @param {*} appId the id of the app to get metadata from.
+ * @returns {object} the app metadata.
+ */
+exports.getAppMetadata = async appId => {
+  const client = await redis.getAppClient()
+  // try cache
+  let metadata = await client.get(appId)
+  if (!metadata) {
+    metadata = await populateFromDB(appId)
+    client.store(appId, metadata, EXPIRY_SECONDS)
+  }
+  return metadata
+}
+
+exports.invalidateAppMetadata = async appId => {
+  const client = await redis.getAppClient()
+  await client.delete(appId)
+}

--- a/packages/auth/src/db/index.js
+++ b/packages/auth/src/db/index.js
@@ -4,8 +4,8 @@ module.exports.setDB = pouch => {
   Pouch = pouch
 }
 
-module.exports.getDB = dbName => {
-  return new Pouch(dbName)
+module.exports.getDB = (dbName, opts = {}) => {
+  return new Pouch(dbName, opts)
 }
 
 module.exports.getCouch = () => {

--- a/packages/auth/src/db/index.js
+++ b/packages/auth/src/db/index.js
@@ -4,8 +4,8 @@ module.exports.setDB = pouch => {
   Pouch = pouch
 }
 
-module.exports.getDB = (dbName, opts = {}) => {
-  return new Pouch(dbName, opts)
+module.exports.getDB = dbName => {
+  return new Pouch(dbName)
 }
 
 module.exports.getCouch = () => {

--- a/packages/auth/src/db/utils.js
+++ b/packages/auth/src/db/utils.js
@@ -54,6 +54,9 @@ exports.isProdAppID = appId => {
 }
 
 function isDevApp(app) {
+  if (!app) {
+    return false
+  }
   return exports.isDevAppID(app.appId)
 }
 
@@ -233,16 +236,16 @@ exports.getAllApps = async (CouchDB, { dev, all, idsOnly } = {}) => {
   if (idsOnly) {
     return appDbNames
   }
-  const appPromises = appDbNames.map(db =>
+  const appPromises = appDbNames.map(app =>
     // skip setup otherwise databases could be re-created
-    getAppMetadata(db)
+    getAppMetadata(app, CouchDB)
   )
   if (appPromises.length === 0) {
     return []
   } else {
     const response = await Promise.allSettled(appPromises)
     const apps = response
-      .filter(result => result.status === "fulfilled")
+      .filter(result => result.status === "fulfilled" && result.value != null)
       .map(({ value }) => value)
     if (!all) {
       return apps.filter(app => {

--- a/packages/auth/src/db/utils.js
+++ b/packages/auth/src/db/utils.js
@@ -6,6 +6,7 @@ const { StaticDatabases, SEPARATOR, DocumentTypes } = require("./constants")
 const { getTenantId, getTenantIDFromAppID } = require("../tenancy")
 const fetch = require("node-fetch")
 const { getCouch } = require("./index")
+const { getAppMetadata } = require("../cache/appMetadata")
 
 const UNICODE_MAX = "\ufff0"
 
@@ -234,7 +235,7 @@ exports.getAllApps = async (CouchDB, { dev, all, idsOnly } = {}) => {
   }
   const appPromises = appDbNames.map(db =>
     // skip setup otherwise databases could be re-created
-    new CouchDB(db, { skip_setup: true }).get(DocumentTypes.APP_METADATA)
+    getAppMetadata(db)
   )
   if (appPromises.length === 0) {
     return []

--- a/packages/auth/src/db/utils.js
+++ b/packages/auth/src/db/utils.js
@@ -8,6 +8,8 @@ const fetch = require("node-fetch")
 const { getCouch } = require("./index")
 const { getAppMetadata } = require("../cache/appMetadata")
 
+const NO_APP_ERROR = "No app provided"
+
 const UNICODE_MAX = "\ufff0"
 
 exports.ViewNames = {
@@ -46,16 +48,22 @@ function getDocParams(docType, docId = null, otherProps = {}) {
 }
 
 exports.isDevAppID = appId => {
+  if (!appId) {
+    throw NO_APP_ERROR
+  }
   return appId.startsWith(exports.APP_DEV_PREFIX)
 }
 
 exports.isProdAppID = appId => {
+  if (!appId) {
+    throw NO_APP_ERROR
+  }
   return appId.startsWith(exports.APP_PREFIX) && !exports.isDevAppID(appId)
 }
 
 function isDevApp(app) {
   if (!app) {
-    return false
+    throw NO_APP_ERROR
   }
   return exports.isDevAppID(app.appId)
 }

--- a/packages/auth/src/redis/authRedis.js
+++ b/packages/auth/src/redis/authRedis.js
@@ -1,16 +1,18 @@
 const Client = require("./index")
 const utils = require("./utils")
 
-let userClient, sessionClient
+let userClient, sessionClient, appClient
 
 async function init() {
   userClient = await new Client(utils.Databases.USER_CACHE).init()
   sessionClient = await new Client(utils.Databases.SESSIONS).init()
+  appClient = await new Client(utils.Databases.APP_METADATA).init()
 }
 
 process.on("exit", async () => {
   if (userClient) await userClient.finish()
   if (sessionClient) await sessionClient.finish()
+  if (appClient) await appClient.finish()
 })
 
 module.exports = {
@@ -25,5 +27,11 @@ module.exports = {
       await init()
     }
     return sessionClient
+  },
+  getAppClient: async () => {
+    if (!appClient) {
+      await init()
+    }
+    return appClient
   },
 }

--- a/packages/auth/src/redis/utils.js
+++ b/packages/auth/src/redis/utils.js
@@ -15,6 +15,7 @@ exports.Databases = {
   SESSIONS: "session",
   USER_CACHE: "users",
   FLAGS: "flags",
+  APP_METADATA: "appMetadata",
 }
 
 exports.SEPARATOR = SEPARATOR

--- a/packages/server/src/api/controllers/deploy/index.js
+++ b/packages/server/src/api/controllers/deploy/index.js
@@ -6,6 +6,7 @@ const {
   disableAllCrons,
   enableCronTrigger,
 } = require("../../../automations/utils")
+const { app: appCache } = require("@budibase/auth/cache")
 
 // the max time we can wait for an invalidation to complete before considering it failed
 const MAX_PENDING_TIME_MS = 30 * 60000
@@ -103,6 +104,7 @@ async function deployApp(deployment) {
     appDoc.appId = productionAppId
     appDoc.instance._id = productionAppId
     await db.put(appDoc)
+    await appCache.invalidateAppMetadata(productionAppId)
     console.log("New app doc written successfully.")
     await initDeployedApp(productionAppId)
     console.log("Deployed app initialised, setting deployment to successful")

--- a/packages/server/src/api/controllers/dev.js
+++ b/packages/server/src/api/controllers/dev.js
@@ -6,6 +6,7 @@ const { request } = require("../../utilities/workerRequests")
 const { clearLock } = require("../../utilities/redis")
 const { Replication } = require("@budibase/auth").db
 const { DocumentTypes } = require("../../db/utils")
+const { app: appCache } = require("@budibase/auth/cache")
 
 async function redirect(ctx, method, path = "global") {
   const { devPath } = ctx.params
@@ -106,6 +107,7 @@ exports.revert = async ctx => {
     appDoc.appId = appId
     appDoc.instance._id = appId
     await db.put(appDoc)
+    await appCache.invalidateAppMetadata(appId)
     ctx.body = {
       message: "Reverted changes successfully.",
     }

--- a/packages/server/src/middleware/builder.js
+++ b/packages/server/src/middleware/builder.js
@@ -8,6 +8,7 @@ const {
 const CouchDB = require("../db")
 const { DocumentTypes } = require("../db/utils")
 const { PermissionTypes } = require("@budibase/auth/permissions")
+const { app: appCache } = require("@budibase/auth/cache")
 
 const DEBOUNCE_TIME_SEC = 30
 
@@ -51,6 +52,7 @@ async function updateAppUpdatedAt(ctx) {
   const metadata = await db.get(DocumentTypes.APP_METADATA)
   metadata.updatedAt = new Date().toISOString()
   await db.put(metadata)
+  await appCache.invalidateAppMetadata(appId)
   // set a new debounce record with a short TTL
   await setDebounce(appId, DEBOUNCE_TIME_SEC)
 }

--- a/packages/server/src/utilities/index.js
+++ b/packages/server/src/utilities/index.js
@@ -48,6 +48,7 @@ exports.objectStoreUrl = () => {
  * via a specific endpoint (under /api/assets/client).
  * @param {string} appId In production we need the appId to look up the correct bucket, as the
  * version of the client lib may differ between apps.
+ * @param {string} version The version to retrieve.
  * @return {string} The URL to be inserted into appPackage response or server rendered
  * app index file.
  */

--- a/packages/worker/src/api/controllers/global/users.js
+++ b/packages/worker/src/api/controllers/global/users.js
@@ -43,11 +43,7 @@ exports.save = async ctx => {
 }
 
 const parseBooleanParam = param => {
-  if (param && param === "false") {
-    return false
-  } else {
-    return true
-  }
+  return !(param && param === "false")
 }
 
 exports.adminUser = async ctx => {


### PR DESCRIPTION
## Description
When playing around with the test/staging environment I noticed that the get `/api/applications?status=all` call was taking at least 2 seconds to complete. This is compounded by the fact that you might access the apps quite a bit and the fact that the `getAllApps` call is beginning to be used more and more.

As this data is frequently accessed, but infrequently updated (its only really updated by a builder when they are actually editting an app) it makes sense for it to be cached. The real slow down here was the fact that everytime the call was made it had to run through each of the Couch databases to retrieve a single doc, the metadata doc - which is known to be a very slow process.

I didn't change the logic much, instead making this call retrieve from a Redis cache instead - its hard to see the benefits locally as my system is quite quick, but it did go from a 400ms call to a less than 100ms call and I believe these benefits will be larger against staging/test envs.

There are five key locations that the cache state is busted for an app, these are as follows:
1. The updated at timestamp middleware, this will be the heaviest but it only occurs when a builder is working on an app - the rest of the apps won't need invalidated.
2. When an app client is reverted
3. When an app is deployed
4. When an app metadata is specifically updated
5. When an app is deleted

Even if the metadata cache is out of sync it is really only used for fetching a list of apps, where the data isn't super critical, it can be a few seconds out of data and not cause problems. The cache will also be bust on a time expiry, so there shouldn't be any chance of stale data causing problems - I believe the performance gain will outweigh anything here.