### PR TITLE
Update for app metadata caching to improve long term performance

### DIFF
--- a/packages/auth/src/cache/appMetadata.js
+++ b/packages/auth/src/cache/appMetadata.js
@@ -67,7 +67,19 @@ exports.getAppMetadata = async (appId, CouchDB = null) => {
   return metadata
 }
 
-exports.invalidateAppMetadata = async appId => {
+/**
+ * Invalidate/reset the cached metadata when a change occurs in the db.
+ * @param appId {string} the cache key to bust/update.
+ * @param newMetadata {object|undefined} optional - can simply provide the new metadata to update with.
+ * @return {Promise<void>} will respond with success when cache is updated.
+ */
+exports.invalidateAppMetadata = async (appId, newMetadata = null) => {
+  if (!appId) {
+    throw "Cannot invalidate if no app ID provided."
+  }
   const client = await redis.getAppClient()
   await client.delete(appId)
+  if (newMetadata) {
+    await client.store(appId, newMetadata, EXPIRY_SECONDS)
+  }
 }

--- a/packages/auth/src/cache/appMetadata.js
+++ b/packages/auth/src/cache/appMetadata.js
@@ -44,7 +44,7 @@ exports.getAppMetadata = async (appId, CouchDB = null) => {
         throw err
       }
     }
-    client.store(appId, metadata, expiry)
+    await client.store(appId, metadata, expiry)
   }
   // we've stored in the cache an object to tell us that it is currently invalid
   if (!metadata || metadata.state === AppState.INVALID) {

--- a/packages/auth/src/middleware/authenticated.js
+++ b/packages/auth/src/middleware/authenticated.js
@@ -92,6 +92,10 @@ module.exports = (
       finalise(ctx, { authenticated, user, internal, version, publicEndpoint })
       return next()
     } catch (err) {
+      // invalid token, clear the cookie
+      if (err && err.name === "JsonWebTokenError") {
+        clearCookie(ctx, Cookies.Auth)
+      }
       // allow configuring for public access
       if ((opts && opts.publicAllowed) || publicEndpoint) {
         finalise(ctx, { authenticated: false, version, publicEndpoint })

--- a/packages/builder/cypress/setup.js
+++ b/packages/builder/cypress/setup.js
@@ -17,6 +17,7 @@ process.env.JWT_SECRET = cypressConfig.env.JWT_SECRET
 process.env.COUCH_URL = `leveldb://${tmpdir}/.data/`
 process.env.SELF_HOSTED = 1
 process.env.WORKER_URL = "http://localhost:10002/"
+process.env.APPS_URL = `http://localhost:${MAIN_PORT}/`
 process.env.MINIO_URL = `http://localhost:${MAIN_PORT}/`
 process.env.MINIO_ACCESS_KEY = "budibase"
 process.env.MINIO_SECRET_KEY = "budibase"

--- a/packages/server/scripts/likeCypress.ts
+++ b/packages/server/scripts/likeCypress.ts
@@ -1,0 +1,33 @@
+/******************************************************
+ * This script just makes it easy to re-create        *
+ * a cypress like environment for testing the backend *
+ ******************************************************/
+const path = require("path")
+const tmpdir = path.join(require("os").tmpdir(), ".budibase")
+
+const MAIN_PORT = "4002"
+const WORKER_PORT = "4001"
+
+// @ts-ignore
+process.env.PORT = "4001"
+process.env.BUDIBASE_API_KEY = "6BE826CB-6B30-4AEC-8777-2E90464633DE"
+process.env.NODE_ENV = "cypress"
+process.env.ENABLE_ANALYTICS = "false"
+process.env.JWT_SECRET = "budibase"
+process.env.COUCH_URL = `leveldb://${tmpdir}/.data/`
+process.env.SELF_HOSTED = "1"
+process.env.WORKER_URL = "http://localhost:4002/"
+process.env.MINIO_URL = `http://localhost:4001/`
+process.env.MINIO_ACCESS_KEY = "budibase"
+process.env.MINIO_SECRET_KEY = "budibase"
+process.env.COUCH_DB_USER = "budibase"
+process.env.COUCH_DB_PASSWORD = "budibase"
+process.env.INTERNAL_API_KEY = "budibase"
+process.env.ALLOW_DEV_AUTOMATIONS = "1"
+
+// don't make this a variable or top level require
+// it will cause environment module to be loaded prematurely
+const server = require("../src/app")
+process.env.PORT = "4002"
+const worker = require("../../worker/src/index")
+process.env.PORT = "4001"

--- a/packages/server/scripts/likeCypress.ts
+++ b/packages/server/scripts/likeCypress.ts
@@ -5,19 +5,19 @@
 const path = require("path")
 const tmpdir = path.join(require("os").tmpdir(), ".budibase")
 
-const MAIN_PORT = "4002"
-const WORKER_PORT = "4001"
+const MAIN_PORT = "10001"
+const WORKER_PORT = "10002"
 
 // @ts-ignore
-process.env.PORT = "4001"
+process.env.PORT = MAIN_PORT
 process.env.BUDIBASE_API_KEY = "6BE826CB-6B30-4AEC-8777-2E90464633DE"
 process.env.NODE_ENV = "cypress"
 process.env.ENABLE_ANALYTICS = "false"
 process.env.JWT_SECRET = "budibase"
 process.env.COUCH_URL = `leveldb://${tmpdir}/.data/`
 process.env.SELF_HOSTED = "1"
-process.env.WORKER_URL = "http://localhost:4002/"
-process.env.MINIO_URL = `http://localhost:4001/`
+process.env.WORKER_URL = `http://localhost:${WORKER_PORT}/`
+process.env.MINIO_URL = `http://localhost:${MAIN_PORT}/`
 process.env.MINIO_ACCESS_KEY = "budibase"
 process.env.MINIO_SECRET_KEY = "budibase"
 process.env.COUCH_DB_USER = "budibase"
@@ -28,6 +28,6 @@ process.env.ALLOW_DEV_AUTOMATIONS = "1"
 // don't make this a variable or top level require
 // it will cause environment module to be loaded prematurely
 const server = require("../src/app")
-process.env.PORT = "4002"
+process.env.PORT = WORKER_PORT
 const worker = require("../../worker/src/index")
-process.env.PORT = "4001"
+process.env.PORT = MAIN_PORT

--- a/packages/server/src/api/controllers/application.js
+++ b/packages/server/src/api/controllers/application.js
@@ -255,6 +255,7 @@ exports.create = async ctx => {
     await createApp(appId)
   }
 
+  await appCache.invalidateAppMetadata(appId, newApplication)
   ctx.status = 200
   ctx.body = newApplication
 }

--- a/packages/server/src/api/controllers/dev.js
+++ b/packages/server/src/api/controllers/dev.js
@@ -25,7 +25,8 @@ async function redirect(ctx, method, path = "global") {
     )
   )
   if (response.status !== 200) {
-    ctx.throw(response.status, response.statusText)
+    const err = await response.text()
+    ctx.throw(400, err)
   }
   const cookie = response.headers.get("set-cookie")
   if (cookie) {

--- a/packages/server/src/middleware/builder.js
+++ b/packages/server/src/middleware/builder.js
@@ -51,8 +51,9 @@ async function updateAppUpdatedAt(ctx) {
   const db = new CouchDB(appId)
   const metadata = await db.get(DocumentTypes.APP_METADATA)
   metadata.updatedAt = new Date().toISOString()
-  await db.put(metadata)
-  await appCache.invalidateAppMetadata(appId)
+  const response = await db.put(metadata)
+  metadata._rev = response.rev
+  await appCache.invalidateAppMetadata(appId, metadata)
   // set a new debounce record with a short TTL
   await setDebounce(appId, DEBOUNCE_TIME_SEC)
 }


### PR DESCRIPTION
## Description
Quick update to the app caching to improve performance even further, cache when an app doesn't have metadata/is invalid, meaning we don't need to poll the database everytime to see if the metadata doc exists.

The need for this likely needs to be investigated, we know that sometimes the app databases stick around a while after they have been deleted, usually due to the `_all_dbs` call returning them despite the fact they don't exist. Staging has this problem in particular because its been running through so many development updates, its probably seen a pile of bugs which would cause these databases to be replicated.

In any case, if an app database is totally invalid/doesn't have any metadata/useful docs within it then we shouldn't need to poll the database everytime to find this out, instead we can cache a doc in Redis to tell us its invalid and if it becomes valid through a revert/package update, then the cache will be busted and we will be made aware of this.