### PR TITLE
Fixing some issues with exporting CSV/JSON

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/ExportModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/ExportModal.svelte
@@ -1,6 +1,7 @@
 <script>
-  import { Select, ModalContent } from "@budibase/bbui"
+  import { Select, ModalContent, notifications } from "@budibase/bbui"
   import download from "downloadjs"
+  import { get } from "builderStore/api"
 
   const FORMATS = [
     {
@@ -18,11 +19,18 @@
   let exportFormat = FORMATS[0].key
 
   async function exportView() {
-    download(
-      `/api/views/export?view=${encodeURIComponent(
-        view
-      )}&format=${exportFormat}`
+    const uri = encodeURIComponent(view)
+    const response = await get(
+      `/api/views/export?view=${uri}&format=${exportFormat}`
     )
+    if (response.status === 200) {
+      const data = await response.text()
+      download(data, `export.${exportFormat}`)
+    } else {
+      notifications.error(
+        `Unable to export ${exportFormat.toUpperCase()} data.`
+      )
+    }
   }
 </script>
 

--- a/packages/server/src/api/controllers/row/external.js
+++ b/packages/server/src/api/controllers/row/external.js
@@ -55,7 +55,8 @@ exports.save = async ctx => {
 exports.fetchView = async ctx => {
   // there are no views in external data sources, shouldn't ever be called
   // for now just fetch
-  ctx.params.tableId = ctx.params.viewName.split("all_")[1]
+  const split = ctx.params.viewName.split("all_")
+  ctx.params.tableId = split[1] ? split[1] : split[0]
   return exports.fetch(ctx)
 }
 

--- a/packages/server/src/api/controllers/view/exporters.js
+++ b/packages/server/src/api/controllers/view/exporters.js
@@ -16,3 +16,8 @@ exports.csv = function (headers, rows) {
 exports.json = function (headers, rows) {
   return JSON.stringify(rows, undefined, 2)
 }
+
+exports.ExportFormats = {
+  CSV: "csv",
+  JSON: "json",
+}


### PR DESCRIPTION
## Description
Fixing issue with exporting CSV/JSON, also saving as right file type - previously it would always save as `export` with no file extension, now it should always save as the right filetype and it will throw an error if an error is returned by the API (rather than saving error to file).