### PR TITLE
adding version metadata to docker build

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -27,15 +27,19 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-1
 
+      - name: 'Get Previous tag'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+
       - name: Build/release Docker images (Self Host)
         run: | 
           docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
           yarn build
-          yarn build:docker:production
+          yarn build:docker:selfhost
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}
-          BUDIBASE_RELEASE_VERSION: latest
+          BUDIBASE_RELEASE_VERSION: ${{ steps.previoustag.outputs.tag }}
       
       - uses: azure/setup-helm@v1
         id: install

--- a/hosting/scripts/linux/release-to-docker-hub.sh
+++ b/hosting/scripts/linux/release-to-docker-hub.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 tag=$1
-production=$2
 
 if [[ ! "$tag" ]]; then
 	echo "No tag present. You must pass a tag to this script"
@@ -12,12 +11,6 @@ echo "Tagging images with tag: $tag"
 
 docker tag app-service budibase/apps:$tag
 docker tag worker-service budibase/worker:$tag
-
-if [[ "$production" ]]; then
-	echo "Production Deployment. Tagging latest.."
-	docker tag app-service budibase/apps:latest
-	docker tag worker-service budibase/worker:latest
-fi
 
 docker push --all-tags budibase/apps 
 docker push --all-tags budibase/worker

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:e2e": "lerna run cy:test",
     "test:e2e:ci": "lerna run cy:ci",
     "build:docker": "lerna run build:docker && cd hosting/scripts/linux/ && ./release-to-docker-hub.sh $BUDIBASE_RELEASE_VERSION && cd -",
-    "build:docker:production": "lerna run build:docker && cd hosting/scripts/linux/ && ./release-to-docker-hub.sh $BUDIBASE_RELEASE_VERSION release && cd -",
+    "build:docker:selfhost": "lerna run build:docker && cd hosting/scripts/linux/ && ./release-to-docker-hub.sh latest && cd -",
     "build:docker:develop": "node scripts/pinVersions && lerna run build:docker && cd hosting/scripts/linux/ && ./release-to-docker-hub.sh develop && cd -",
     "release:helm": "./scripts/release_helm_chart.sh",
     "env:multi:enable": "lerna run env:multi:enable",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,7 +14,7 @@
     "test": "jest --coverage --maxWorkers=2",
     "test:watch": "jest --watch",
     "predocker": "copyfiles -f ../client/dist/budibase-client.js ../client/manifest.json client",
-    "build:docker": "yarn run predocker && docker build . -t app-service",
+    "build:docker": "yarn run predocker && docker build . -t app-service --label version=$BUDIBASE_RELEASE_VERSION",
     "run:docker": "node dist/index.js",
     "dev:stack:up": "node scripts/dev/manage.js up",
     "dev:stack:down": "node scripts/dev/manage.js down",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "run:docker": "node src/index.js",
-    "build:docker": "docker build . -t worker-service",
+    "build:docker": "docker build . -t worker-service --label version=$BUDIBASE_RELEASE_VERSION",
     "dev:stack:init": "node ./scripts/dev/manage.js init",
     "dev:builder": "npm run dev:stack:init && nodemon",
     "test": "jest --runInBand",


### PR DESCRIPTION
## Description
After discussion last week, we realised it's not easy to see the latest self host version after a release due to the use of the `latest` tag.

This PR adds build config that will add a docker label with the latest release version when releasing.

You can `docker inspect` the latest image to see the labels.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



