### PR TITLE
Quick change for SQL existing relationships - allow picking both keys

### DIFF
--- a/packages/builder/src/components/backend/Datasources/CreateEditRelationship.svelte
+++ b/packages/builder/src/components/backend/Datasources/CreateEditRelationship.svelte
@@ -98,12 +98,16 @@
     return errors
   }
 
+  let fromPrimary
+  $: {
+    if (!fromPrimary && fromTable) {
+      fromPrimary = fromTable.primary[0]
+    }
+  }
   $: isManyToMany =
     fromRelationship?.relationshipType === RelationshipTypes.MANY_TO_MANY
   $: isManyToOne =
     fromRelationship?.relationshipType === RelationshipTypes.MANY_TO_ONE
-  $: fromPrimary =
-    !fromPrimary && fromTable ? fromTable.primary[0] : fromPrimary
   $: tableOptions = plusTables.map(table => ({
     label: table.name,
     value: table._id,


### PR DESCRIPTION
## Description
Quick fix for #3485 - default the key to the primary key but allow another field to be selected, just making the UI flexible enough to represent all types of SQL relationships.

## Screenshots
Adding a field just below the from table selection to pick the key in the from table, this defaults to the primary key of the table.
![image](https://user-images.githubusercontent.com/4407001/143022199-b87ad745-2749-4be7-8dac-4a966afb2d46.png)




