### PR TITLE
Query schema fixes + card fixes

### DIFF
--- a/packages/client/src/components/app/blocks/CardsBlock.svelte
+++ b/packages/client/src/components/app/blocks/CardsBlock.svelte
@@ -182,7 +182,7 @@
           }}
           styles={{
             display: "grid",
-            "grid-template-columns": `repeat(auto-fill, minmax(${cardWidth}px, 1fr))`,
+            "grid-template-columns": `repeat(auto-fill, minmax(min(${cardWidth}px, 100%), 1fr))`,
           }}
         >
           <BlockComponent

--- a/packages/server/src/api/controllers/query.js
+++ b/packages/server/src/api/controllers/query.js
@@ -1,6 +1,10 @@
 const { processString } = require("@budibase/string-templates")
 const CouchDB = require("../../db")
-const { generateQueryID, getQueryParams } = require("../../db/utils")
+const {
+  generateQueryID,
+  getQueryParams,
+  isProdAppID,
+} = require("../../db/utils")
 const { BaseQueryVerbs } = require("../../constants")
 const env = require("../../environment")
 const { Thread, ThreadType } = require("../../threads")
@@ -90,10 +94,9 @@ exports.find = async function (ctx) {
   const db = new CouchDB(ctx.appId)
   const query = enrichQueries(await db.get(ctx.params.queryId))
   // remove properties that could be dangerous in real app
-  if (env.isProd()) {
+  if (isProdAppID(ctx.appId)) {
     delete query.fields
     delete query.parameters
-    delete query.schema
   }
   ctx.body = query
 }

--- a/packages/server/src/api/controllers/query.js
+++ b/packages/server/src/api/controllers/query.js
@@ -6,7 +6,6 @@ const {
   isProdAppID,
 } = require("../../db/utils")
 const { BaseQueryVerbs } = require("../../constants")
-const env = require("../../environment")
 const { Thread, ThreadType } = require("../../threads")
 
 const Runner = new Thread(ThreadType.QUERY, { timeoutMs: 10000 })

--- a/packages/server/src/api/routes/tests/query.spec.js
+++ b/packages/server/src/api/routes/tests/query.spec.js
@@ -19,10 +19,12 @@ describe("/queries", () => {
   })
 
   async function createInvalidIntegration() {
-    const datasource = await config.createDatasource({datasource: {
-      ...basicDatasource().datasource,
-      source: "INVALID_INTEGRATION",
-    }})
+    const datasource = await config.createDatasource({
+      datasource: {
+        ...basicDatasource().datasource,
+        source: "INVALID_INTEGRATION",
+      },
+    })
     const query = await config.createQuery()
     return { datasource, query }
   }
@@ -98,7 +100,6 @@ describe("/queries", () => {
           .expect("Content-Type", /json/)
         expect(res.body.fields).toBeUndefined()
         expect(res.body.parameters).toBeUndefined()
-        expect(res.body.schema).toBeUndefined()
       })
     })
   })

--- a/packages/server/src/api/routes/tests/query.spec.js
+++ b/packages/server/src/api/routes/tests/query.spec.js
@@ -1,5 +1,12 @@
-// mock out postgres for this
+// Mock out postgres for this
 jest.mock("pg")
+
+// Mock isProdAppID to we can later mock the implementation and pretend we are
+// using prod app IDs
+const authDb = require("@budibase/auth/db")
+const { isProdAppID } = authDb
+const mockIsProdAppID = jest.fn(isProdAppID)
+authDb.isProdAppID = mockIsProdAppID
 
 const setup = require("./utilities")
 const { checkBuilderEndpoint } = require("./utilities/TestFunctions")
@@ -98,9 +105,31 @@ describe("/queries", () => {
           .set(await config.defaultHeaders())
           .expect(200)
           .expect("Content-Type", /json/)
-        expect(res.body.fields).toBeUndefined()
-        expect(res.body.parameters).toBeUndefined()
+        expect(res.body.fields).toBeDefined()
+        expect(res.body.parameters).toBeDefined()
+        expect(res.body.schema).toBeDefined()
       })
+    })
+
+    it("should remove sensitive info for prod apps", async () => {
+      // Mock isProdAppID to pretend we are using a prod app
+      mockIsProdAppID.mockClear()
+      mockIsProdAppID.mockImplementation(() => true)
+
+      const query = await config.createQuery()
+      const res = await request
+        .get(`/api/queries/${query._id}`)
+        .set(await config.defaultHeaders())
+        .expect("Content-Type", /json/)
+        .expect(200)
+      expect(res.body._id).toEqual(query._id)
+      expect(res.body.fields).toBeUndefined()
+      expect(res.body.parameters).toBeUndefined()
+      expect(res.body.schema).toBeDefined()
+
+      // Reset isProdAppID mock
+      expect(mockIsProdAppID).toHaveBeenCalledTimes(1)
+      mockIsProdAppID.mockImplementation(isProdAppID)
     })
   })
 


### PR DESCRIPTION
## Description
Couple of fixes for some issues:
- Fix horizontal spectrum cards in the card block being too wide on mobile #3337
- Fix query definitions using the wrong logic to determine whether sensitive fields should be stripped (thanks @mike12345567)
- Fix query definitions removing the schema from the definition as this is required and not sensitive #3262



