### PR TITLE
Remove initial screen defintion so user can see the new screen creation button

### DIFF
--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -182,7 +182,9 @@ Cypress.Commands.add("navigateToFrontend", () => {
   cy.wait(1000)
   cy.contains("Design").click()
   cy.get(".spectrum-Search").type("/")
-  cy.get(".nav-item").contains("Home").click()
+  cy.createScreen("home", "home")
+  cy.addComponent("Elements", "Headline")
+  cy.get(".nav-item").contains("home").click()
 })
 
 Cypress.Commands.add("createScreen", (screenName, route) => {

--- a/packages/builder/src/components/design/NavigationPanel/NewScreenModal.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/NewScreenModal.svelte
@@ -132,7 +132,7 @@
     padding: var(--spectrum-alias-item-padding-s);
     background: var(--spectrum-alias-background-color-primary);
     transition: 0.3s all;
-    border: 1px solid #e7e7e7;
+    border: 1px solid var(--spectrum-global-color-gray-300);
     border-radius: 4px;
     box-sizing: border-box;
     border-width: 1px;

--- a/packages/server/src/api/controllers/application.js
+++ b/packages/server/src/api/controllers/application.js
@@ -15,14 +15,12 @@ const {
   generateAppID,
   getLayoutParams,
   getScreenParams,
-  generateScreenID,
   generateDevAppID,
   DocumentTypes,
   AppStatus,
 } = require("../../db/utils")
 const { BUILTIN_ROLE_IDS, AccessController } = require("@budibase/auth/roles")
 const { BASE_LAYOUTS } = require("../../constants/layouts")
-const { createHomeScreen } = require("../../constants/screens")
 const { cloneDeep } = require("lodash/fp")
 const { processObject } = require("@budibase/string-templates")
 const {
@@ -408,10 +406,6 @@ const createEmptyAppPackage = async (ctx, app) => {
     const cloned = cloneDeep(layout)
     screensAndLayouts.push(await processObject(cloned, app))
   }
-
-  const homeScreen = createHomeScreen(app)
-  homeScreen._id = generateScreenID()
-  screensAndLayouts.push(homeScreen)
 
   await db.bulkDocs(screensAndLayouts)
 }

--- a/packages/server/src/api/routes/tests/application.spec.js
+++ b/packages/server/src/api/routes/tests/application.spec.js
@@ -75,7 +75,6 @@ describe("/applications", () => {
         .expect("Content-Type", /json/)
         .expect(200)
       // should have empty packages
-      expect(res.body.screens.length).toEqual(1)
       expect(res.body.layouts.length).toEqual(2)
     })
   })
@@ -88,7 +87,6 @@ describe("/applications", () => {
         .expect("Content-Type", /json/)
         .expect(200)
       expect(res.body.application).toBeDefined()
-      expect(res.body.screens.length).toEqual(1)
       expect(res.body.layouts.length).toEqual(2)
     })
   })

--- a/packages/server/src/api/routes/tests/screen.spec.js
+++ b/packages/server/src/api/routes/tests/screen.spec.js
@@ -21,7 +21,7 @@ describe("/screens", () => {
         .set(config.defaultHeaders())
         .expect("Content-Type", /json/)
         .expect(200)
-      expect(res.body.length).toEqual(2)
+      expect(res.body.length).toEqual(1)
       expect(res.body.some(s => s._id === screen._id)).toEqual(true)
     })
 


### PR DESCRIPTION
## Description
Just removes the part of the code that added the `Welcome to Budibase` heading. We want the user to immediately see the splash screen with the spaceman image etc. 




