### PR TITLE
Improve returning logic for oracle

### DIFF
--- a/packages/server/scripts/integrations/oracle/docker-compose.yml
+++ b/packages/server/scripts/integrations/oracle/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3.8"
 services:
   db:
-    container_name: oracle-xe
+    restart: always
     platform: linux/x86_64
     image: container-registry.oracle.com/database/express:18.4.0-xe
     environment:

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -435,8 +435,6 @@ class SqlQueryBuilder extends SqlTableQueryBuilder {
         id = results?.[0].id
       } else if (sqlClient === SqlClients.MY_SQL) {
         id = results?.insertId
-      } else if (sqlClient === SqlClients.ORACLE) {
-        id = response.outBinds[0][0]
       }
       row = processFn(
         await this.getReturningRow(queryFn, this.checkLookupKeys(id, json))


### PR DESCRIPTION
## Description
Adding an improvement for returning logic to oracle. There were some scenarios where the primary key wasn't available in queries being made when a row being updated had relationships attached. Use the built in `lastRowId` identifier and a corresponding lookup that will always give us a row that was created or updated when there are no other rows returned in the result set. 

The `ROWID` is an identifier for a row that exists in every table in oracle. The value is usually something like `*BAEAqeMCUlD+` which is an encoded mechanism of telling oracle exactly where to go to get the row it needs. 




