### PR TITLE
Misc bug fixes

### DIFF
--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -524,7 +524,7 @@ export const getFrontendStore = () => {
           }
         }
       },
-      paste: async (targetComponent, mode) => {
+      paste: async (targetComponent, mode, preserveBindings = false) => {
         let promises = []
         store.update(state => {
           // Stop if we have nothing to paste
@@ -536,7 +536,7 @@ export const getFrontendStore = () => {
           const cut = state.componentToPaste.isCut
 
           // immediately need to remove bindings, currently these aren't valid when pasted
-          if (!cut) {
+          if (!cut && !preserveBindings) {
             state.componentToPaste = removeBindings(state.componentToPaste)
           }
 

--- a/packages/builder/src/components/design/NavigationPanel/ComponentDropdownMenu.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/ComponentDropdownMenu.svelte
@@ -53,7 +53,7 @@
 
   const duplicateComponent = () => {
     storeComponentForCopy(false)
-    pasteComponent("below")
+    pasteComponent("below", true)
   }
 
   const deleteComponent = async () => {
@@ -69,9 +69,9 @@
     store.actions.components.copy(component, cut)
   }
 
-  const pasteComponent = mode => {
+  const pasteComponent = (mode, preserveBindings = false) => {
     // lives in store - also used by drag drop
-    store.actions.components.paste(component, mode)
+    store.actions.components.paste(component, mode, preserveBindings)
   }
 </script>
 

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/NavigationEditor/NavigationEditor.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/NavigationEditor/NavigationEditor.svelte
@@ -2,13 +2,15 @@
   import { Button, ActionButton, Drawer } from "@budibase/bbui"
   import { createEventDispatcher } from "svelte"
   import NavigationDrawer from "./NavigationDrawer.svelte"
+  import { cloneDeep } from "lodash/fp"
 
   export let value = []
   let drawer
+  let links = cloneDeep(value)
 
   const dispatch = createEventDispatcher()
   const save = () => {
-    dispatch("change", value)
+    dispatch("change", links)
     drawer.hide()
   }
 </script>
@@ -19,5 +21,5 @@
     Configure the links in your navigation bar.
   </svelte:fragment>
   <Button cta slot="buttons" on:click={save}>Save</Button>
-  <NavigationDrawer slot="body" bind:links={value} />
+  <NavigationDrawer slot="body" bind:links />
 </Drawer>

--- a/packages/client/src/components/app/Layout.svelte
+++ b/packages/client/src/components/app/Layout.svelte
@@ -313,6 +313,9 @@
     height: 100%;
     overflow: auto;
   }
+  .desktop.layout--left .links {
+    overflow-y: auto;
+  }
 
   .desktop .nav--left {
     width: 250px;
@@ -379,6 +382,7 @@
     justify-content: flex-start;
     align-items: stretch;
     padding: var(--spacing-xl);
+    overflow-y: auto;
   }
   .mobile .link {
     width: calc(100% - 30px);


### PR DESCRIPTION
## Description
A few bug fixes from the board:
- Preserve bindings when duplicating components #3361
- Allow layout navigation links to scroll #3505
- Don't mutate the real component structure when editing navigation links. This was causing navigation link settings to not save when editing.




