### PR TITLE
Add fix for user metadata sync when deleting

### DIFF
--- a/packages/server/src/api/controllers/user.js
+++ b/packages/server/src/api/controllers/user.js
@@ -81,7 +81,7 @@ exports.syncUser = async function (ctx) {
       throw err
     }
   }
-  const roles = user.roles
+  const roles = deleting ? {} : user.roles
   // remove props which aren't useful to metadata
   delete user.password
   delete user.forceResetPassword


### PR DESCRIPTION
## Description
Fixing issue with user deletion. 
The sync endpoint in app service is throwing an error here 
https://github.com/Budibase/budibase/blob/develop/packages/server/src/api/controllers/user.js#L100
due to empty roles object for deleted user



