### PR TITLE
Fixes for button actions, block contexts and nester data provider settings

### DIFF
--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -61,7 +61,7 @@ export const getComponentBindableProperties = (asset, componentId) => {
 /**
  * Gets all data provider components above a component.
  */
-export const getContextProviderComponents = (asset, componentId) => {
+export const getContextProviderComponents = (asset, componentId, type) => {
   if (!asset || !componentId) {
     return []
   }
@@ -74,7 +74,18 @@ export const getContextProviderComponents = (asset, componentId) => {
   // Filter by only data provider components
   return path.filter(component => {
     const def = store.actions.components.getDefinition(component._component)
-    return def?.context != null
+    if (!def?.context) {
+      return false
+    }
+
+    // If no type specified, return anything that exposes context
+    if (!type) {
+      return true
+    }
+
+    // Otherwise only match components with the specific context type
+    const contexts = Array.isArray(def.context) ? def.context : [def.context]
+    return contexts.find(context => context.type === type) != null
   })
 }
 

--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -61,7 +61,7 @@ export const getComponentBindableProperties = (asset, componentId) => {
 /**
  * Gets all data provider components above a component.
  */
-export const getDataProviderComponents = (asset, componentId) => {
+export const getContextProviderComponents = (asset, componentId) => {
   if (!asset || !componentId) {
     return []
   }
@@ -143,7 +143,7 @@ export const getDatasourceForProvider = (asset, component) => {
  */
 const getContextBindings = (asset, componentId) => {
   // Extract any components which provide data contexts
-  const dataProviders = getDataProviderComponents(asset, componentId)
+  const dataProviders = getContextProviderComponents(asset, componentId)
 
   // Generate bindings for all matching components
   return getProviderContextBindings(asset, dataProviders)

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/DataSourceSelect.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/DataSourceSelect.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { getDataProviderComponents } from "builderStore/dataBinding"
+  import { getContextProviderComponents } from "builderStore/dataBinding"
   import {
     Button,
     Popover,
@@ -58,16 +58,19 @@
       ...query,
       type: "query",
     }))
-  $: dataProviders = getDataProviderComponents(
+  $: contextProviders = getContextProviderComponents(
     $currentAsset,
     $store.selectedComponentId
-  ).map(provider => ({
-    label: provider._instanceName,
-    name: provider._instanceName,
-    providerId: provider._id,
-    value: `{{ literal ${safe(provider._id)} }}`,
-    type: "provider",
-  }))
+  )
+  $: dataProviders = contextProviders
+    .filter(component => component._component?.endsWith("/dataprovider"))
+    .map(provider => ({
+      label: provider._instanceName,
+      name: provider._instanceName,
+      providerId: provider._id,
+      value: `{{ literal ${safe(provider._id)} }}`,
+      type: "provider",
+    }))
   $: links = bindings
     .filter(x => x.fieldSchema?.type === "link")
     .map(binding => {

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/EventsEditor/actions/SaveRow.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/EventsEditor/actions/SaveRow.svelte
@@ -3,7 +3,7 @@
   import { store, currentAsset } from "builderStore"
   import { tables } from "stores/backend"
   import {
-    getDataProviderComponents,
+    getContextProviderComponents,
     getSchemaForDatasource,
   } from "builderStore/dataBinding"
   import SaveFields from "./SaveFields.svelte"
@@ -11,7 +11,7 @@
   export let parameters
   export let bindings = []
 
-  $: dataProviderComponents = getDataProviderComponents(
+  $: dataProviderComponents = getContextProviderComponents(
     $currentAsset,
     $store.selectedComponentId
   )


### PR DESCRIPTION
## Description
Few fixes for some issues I discovered:

- Data providers were able to reference any other component that provided context as an available source. This doesn't make sense, and it should only show other data providers. This is fixed and now only shows data providers in this list.
- Fix button actions not saving as they were directly mutating the real component structure, preventing them from saving due to the original and new component definitions being the same
- Fix "save row" action not using the correct runtime context path when combined with a block. The "save row" action will now also only use either "schema" or "form" context types as available sources which filters out invalid options that we used to show.

We should hotfix this to master as well as I'm pretty sure button actions cannot be saved at the moment. It will look like everything works, but it won't actually save the definition to the server until another change is made, which will then effectively send up both changes.



