### PR TITLE
Hotfixes for query params and potential solution for apps sometimes not loading

### DIFF
--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -82,7 +82,7 @@ export const getFrontendStore = () => {
         libraries: application.componentLibraries,
         components,
         clientFeatures: {
-          ...state.clientFeatures,
+          ...INITIAL_FRONTEND_STATE.clientFeatures,
           ...components.features,
         },
         name: application.name,

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/DataSourceSelect.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/DataSourceSelect.svelte
@@ -149,7 +149,7 @@
       </Button>
       <DrawerContent slot="body">
         <Layout noPadding>
-          {#if getQueryParams(value._id).length > 0}
+          {#if getQueryParams(value).length > 0}
             <ParameterBuilder
               bind:customParams={value.queryParams}
               parameters={getQueryParams(value)}


### PR DESCRIPTION
## Description
Couple of hotfixes.

- Fix custom query params not showing #3634 
- Reset client feature flags when selecting a new app so that previous features are removed



