### PR TITLE
Fix oracle password config

### DIFF
--- a/packages/server/scripts/integrations/oracle/oracle.md
+++ b/packages/server/scripts/integrations/oracle/oracle.md
@@ -84,7 +84,7 @@ The `HR` schema is populated with dummy data by default in oracle for testing pu
 To connect to the HR schema first update the user password and unlock the account by performing
 ```sql
 ALTER USER hr ACCOUNT UNLOCK;
-ALTER USER hr IDENTIFIED BY hr
+ALTER USER hr IDENTIFIED BY hr;
 ```
 You should now be able to connect to the hr schema using the credentials hr/hr
 

--- a/packages/server/src/integrations/oracle.ts
+++ b/packages/server/src/integrations/oracle.ts
@@ -381,7 +381,7 @@ module OracleModule {
       }`
       const attributes: ConnectionAttributes = {
         user: this.config.user,
-        password: this.config.user,
+        password: this.config.password,
         connectString,
       }
       return oracledb.getConnection(attributes)


### PR DESCRIPTION
## Description
- The config was always supplying the username as password
- Testing was carried out with a password that matched the username so was't noticed 😅 


