### PR TITLE
Fix conditional layout links

### DIFF
--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/NavigationEditor/NavigationDrawer.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/NavigationEditor/NavigationDrawer.svelte
@@ -17,6 +17,7 @@
   const flipDurationMs = 150
   let dragDisabled = true
 
+  $: links = links || []
   $: links.forEach(link => {
     if (!link.id) {
       link.id = generate()

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/NavigationEditor/NavigationDrawer.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/NavigationEditor/NavigationDrawer.svelte
@@ -17,7 +17,6 @@
   const flipDurationMs = 150
   let dragDisabled = true
 
-  $: links = links || []
   $: links.forEach(link => {
     if (!link.id) {
       link.id = generate()

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/NavigationEditor/NavigationEditor.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/NavigationEditor/NavigationEditor.svelte
@@ -6,7 +6,7 @@
 
   export let value = []
   let drawer
-  let links = cloneDeep(value)
+  let links = cloneDeep(value || [])
 
   const dispatch = createEventDispatcher()
   const save = () => {


### PR DESCRIPTION
## Description
Fixes a console error being thrown when using conditional UI to change the `links` setting on a layout.

Addresses #3665 and #3656.

Ensures the `links` prop is always an array. I have no idea what changed to cause this though... Unless this was always an issue that has only now been discovered, but I doubt that.



