### PR TITLE
Duplicate queries

### DIFF
--- a/packages/builder/src/components/backend/DatasourceNavigator/popovers/EditQueryPopover.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/popovers/EditQueryPopover.svelte
@@ -14,7 +14,7 @@
 
   async function duplicateQuery() {
     try {
-      await queries.duplicate(query, queries.save)
+      await queries.duplicate(query)
     } catch (e) {
       notifications.error(e.message)
     }

--- a/packages/builder/src/components/backend/DatasourceNavigator/popovers/EditQueryPopover.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/popovers/EditQueryPopover.svelte
@@ -11,6 +11,14 @@
     await queries.delete(query)
     notifications.success("Query deleted")
   }
+
+  async function duplicateQuery() {
+    try {
+      await queries.duplicate(query, queries.save)
+    } catch (e) {
+      notifications.error(e.message)
+    }
+  }
 </script>
 
 <ActionMenu>
@@ -18,6 +26,7 @@
     <Icon size="S" hoverable name="MoreSmallList" />
   </div>
   <MenuItem icon="Delete" on:click={confirmDeleteDialog.show}>Delete</MenuItem>
+  <MenuItem icon="Duplicate" on:click={duplicateQuery}>Duplicate</MenuItem>
 </ActionMenu>
 
 <ConfirmDialog

--- a/packages/builder/src/helpers/duplicate.js
+++ b/packages/builder/src/helpers/duplicate.js
@@ -1,0 +1,50 @@
+/**
+ * Duplicates a name with respect to a collection of existing names
+ * e.g.
+ *    name           all names          result
+ *   ------        -----------         --------
+ * ("foo")       ["foo"]              "foo (1)"
+ * ("foo")       ["foo", "foo (1)"]   "foo (2)"
+ * ("foo (1)")   ["foo", "foo (1)"]   "foo (2)"
+ * ("foo")       ["foo", "foo (2)"]   "foo (1)"
+ *
+ * Repl
+ */
+export const duplicateName = (name, allNames) => {
+  const baseName = name.split(" (")[0]
+  const isDuplicate = new RegExp(`${baseName}\\s\\((\\d+)\\)$`)
+
+  // get the sequence from matched names
+  const sequence = []
+  allNames.filter(n => {
+    if (n === baseName) {
+      return true
+    }
+    const match = n.match(isDuplicate)
+    if (match) {
+      sequence.push(parseInt(match[1]))
+      return true
+    }
+    return false
+  })
+  sequence.sort((a, b) => a - b)
+
+  // get the next number in the sequence
+  let number
+  if (sequence.length === 0) {
+    number = 1
+  } else {
+    // get the next number in the sequence
+    for (let i = 0; i < sequence.length; i++) {
+      if (sequence[i] !== i + 1) {
+        number = i + 1
+        break
+      }
+    }
+    if (!number) {
+      number = sequence.length + 1
+    }
+  }
+
+  return `${baseName} (${number})`
+}

--- a/packages/builder/src/helpers/tests/duplicate.spec.js
+++ b/packages/builder/src/helpers/tests/duplicate.spec.js
@@ -1,0 +1,42 @@
+const { duplicateName } = require("../duplicate")
+
+describe("duplicate", () => {
+  
+  describe("duplicates a name ", () => {
+    it("with a single existing", async () => {
+      const names = ["foo"]
+      const name = "foo"
+
+      const duplicate = duplicateName(name, names)
+
+      expect(duplicate).toBe("foo (1)")
+    })
+
+    it("with multiple existing", async () => {
+      const names = ["foo", "foo (1)", "foo (2)"]
+      const name = "foo"
+
+      const duplicate = duplicateName(name, names)
+
+      expect(duplicate).toBe("foo (3)")
+    })
+
+    it("with mixed multiple existing", async () => {
+      const names = ["foo", "foo (1)", "foo (2)", "bar", "bar (1)", "bar (2)"]
+      const name = "foo"
+
+      const duplicate = duplicateName(name, names)
+
+      expect(duplicate).toBe("foo (3)")
+    })
+
+    it("with incomplete sequence", async () => {
+      const names = ["foo", "foo (2)", "foo (3)"]
+      const name = "foo"
+
+      const duplicate = duplicateName(name, names)
+
+      expect(duplicate).toBe("foo (1)")
+    })
+  })
+})

--- a/packages/builder/src/stores/backend/queries.js
+++ b/packages/builder/src/stores/backend/queries.js
@@ -13,10 +13,7 @@ export function createQueriesStore() {
   const store = writable({ list: [], selected: null })
   const { subscribe, set, update } = store
 
-  return {
-    subscribe,
-    set,
-    update,
+  const actions = {
     init: async () => {
       const response = await api.get(`/api/queries`)
       const json = await response.json()
@@ -86,7 +83,7 @@ export function createQueriesStore() {
       })
       return response
     },
-    duplicate: async (query, saveFn) => {
+    duplicate: async query => {
       let list = get(store).list
       const newQuery = { ...query }
       const datasourceId = query.datasourceId
@@ -98,8 +95,15 @@ export function createQueriesStore() {
         list.map(q => q.name)
       )
 
-      saveFn(datasourceId, newQuery)
+      actions.save(datasourceId, newQuery)
     },
+  }
+
+  return {
+    subscribe,
+    set,
+    update,
+    ...actions,
   }
 }
 

--- a/packages/builder/src/stores/backend/queries.js
+++ b/packages/builder/src/stores/backend/queries.js
@@ -1,9 +1,17 @@
 import { writable, get } from "svelte/store"
 import { datasources, integrations, tables, views } from "./"
 import api from "builderStore/api"
+import { duplicateName } from "../../helpers/duplicate"
+
+const sortQueries = queryList => {
+  queryList.sort((q1, q2) => {
+    return q1.name.localeCompare(q2.name)
+  })
+}
 
 export function createQueriesStore() {
-  const { subscribe, set, update } = writable({ list: [], selected: null })
+  const store = writable({ list: [], selected: null })
+  const { subscribe, set, update } = store
 
   return {
     subscribe,
@@ -17,6 +25,7 @@ export function createQueriesStore() {
     fetch: async () => {
       const response = await api.get(`/api/queries`)
       const json = await response.json()
+      sortQueries(json)
       update(state => ({ ...state, list: json }))
       return json
     },
@@ -49,6 +58,7 @@ export function createQueriesStore() {
         } else {
           queries.push(json)
         }
+        sortQueries(queries)
         return { list: queries, selected: json._id }
       })
       return json
@@ -75,6 +85,20 @@ export function createQueriesStore() {
         return state
       })
       return response
+    },
+    duplicate: async (query, saveFn) => {
+      let list = get(store).list
+      const newQuery = { ...query }
+      const datasourceId = query.datasourceId
+
+      delete newQuery._id
+      delete newQuery._rev
+      newQuery.name = duplicateName(
+        query.name,
+        list.map(q => q.name)
+      )
+
+      saveFn(datasourceId, newQuery)
     },
   }
 }

--- a/packages/builder/src/stores/backend/tests/queries.spec.js
+++ b/packages/builder/src/stores/backend/tests/queries.spec.js
@@ -6,7 +6,6 @@ jest.mock('builderStore/api');
 import { SOME_QUERY, SAVE_QUERY_RESPONSE } from './fixtures/queries'
 
 import { createQueriesStore } from "../queries"
-import { datasources } from '../datasources'
 
 describe("Queries Store", () => {
   let store = createQueriesStore()


### PR DESCRIPTION
## Description
Duplicate a datasource query. Use the same logic as postman:
```
     name           all names          result
    ------        -----------         --------
  ("foo")       ["foo"]              "foo (1)"
  ("foo")       ["foo", "foo (1)"]   "foo (2)"
  ("foo (1)")   ["foo", "foo (1)"]   "foo (2)"
  ("foo")       ["foo", "foo (2)"]   "foo (1)"
```

## Screenshots

https://user-images.githubusercontent.com/8755148/145028921-d917a512-dcb3-438d-a731-578062849e8f.mov





