### PR TITLE
Misc bug fixes

### DIFF
--- a/packages/bbui/src/Form/Core/Picker.svelte
+++ b/packages/bbui/src/Form/Core/Picker.svelte
@@ -64,7 +64,7 @@
     if (autocomplete && term) {
       const lowerCaseTerm = term.toLowerCase()
       return options.filter(option => {
-        return `${getLabel(option)}`?.toLowerCase().includes(lowerCaseTerm)
+        return `${getLabel(option)}`.toLowerCase().includes(lowerCaseTerm)
       })
     }
     return options

--- a/packages/bbui/src/Form/Core/Picker.svelte
+++ b/packages/bbui/src/Form/Core/Picker.svelte
@@ -63,9 +63,9 @@
   const getFilteredOptions = (options, term, getLabel) => {
     if (autocomplete && term) {
       const lowerCaseTerm = term.toLowerCase()
-      return options.filter(option =>
-        getLabel(option)?.toLowerCase().includes(lowerCaseTerm)
-      )
+      return options.filter(option => {
+        return `${getLabel(option)}`?.toLowerCase().includes(lowerCaseTerm)
+      })
     }
     return options
   }

--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -96,13 +96,16 @@
         allSteps[idx].schema?.outputs?.properties ?? {}
       )
       bindings = bindings.concat(
-        outputs.map(([name, value]) => ({
-          label: name,
-          type: value.type,
-          description: value.description,
-          category: idx === 0 ? "Trigger outputs" : `Step ${idx} outputs`,
-          path: idx === 0 ? `trigger.${name}` : `steps.${idx}.${name}`,
-        }))
+        outputs.map(([name, value]) => {
+          const runtime = idx === 0 ? `trigger.${name}` : `steps.${idx}.${name}`
+          return {
+            label: runtime,
+            type: value.type,
+            description: value.description,
+            category: idx === 0 ? "Trigger outputs" : `Step ${idx} outputs`,
+            path: runtime,
+          }
+        })
       )
     }
     return bindings
@@ -261,7 +264,6 @@
               value={inputData[key]}
               on:change={e => onChange(e, key)}
               {bindings}
-              allowJS={false}
             />
           </div>
         {/if}

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/DataSourceSelect.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/DataSourceSelect.svelte
@@ -17,7 +17,6 @@
     queries as queriesStore,
   } from "stores/backend"
   import { datasources, integrations } from "stores/backend"
-  import { notifications } from "@budibase/bbui"
   import ParameterBuilder from "components/integration/QueryParameterBuilder.svelte"
   import IntegrationQueryEditor from "components/integration/index.svelte"
   import { makePropSafe as safe } from "@budibase/string-templates"

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/DataSourceSelect.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/DataSourceSelect.svelte
@@ -31,6 +31,7 @@
   const arrayTypes = ["attachment", "array"]
   let anchorRight, dropdownRight
   let drawer
+  let tmpQueryParams
 
   $: text = value?.label ?? "Choose an option"
   $: tables = $tablesStore.list.map(m => ({
@@ -105,12 +106,12 @@
       }
     })
 
-  function handleSelected(selected) {
+  const handleSelected = selected => {
     dispatch("change", selected)
     dropdownRight.hide()
   }
 
-  function fetchQueryDefinition(query) {
+  const fetchQueryDefinition = query => {
     const source = $datasources.list.find(
       ds => ds._id === query.datasourceId
     ).source
@@ -124,6 +125,19 @@
   const getQueryDatasource = query => {
     return $datasources.list.find(ds => ds._id === query?.datasourceId)
   }
+
+  const openQueryParamsDrawer = () => {
+    tmpQueryParams = value.queryParams
+    drawer.show()
+  }
+
+  const saveQueryParams = () => {
+    handleSelected({
+      ...value,
+      queryParams: tmpQueryParams,
+    })
+    drawer.hide()
+  }
 </script>
 
 <div class="container" bind:this={anchorRight}>
@@ -134,24 +148,14 @@
     on:click={dropdownRight.show}
   />
   {#if value?.type === "query"}
-    <i class="ri-settings-5-line" on:click={drawer.show} />
+    <i class="ri-settings-5-line" on:click={openQueryParamsDrawer} />
     <Drawer title={"Query Parameters"} bind:this={drawer}>
-      <Button
-        slot="buttons"
-        cta
-        on:click={() => {
-          notifications.success("Query parameters saved.")
-          handleSelected(value)
-          drawer.hide()
-        }}
-      >
-        Save
-      </Button>
+      <Button slot="buttons" cta on:click={saveQueryParams}>Save</Button>
       <DrawerContent slot="body">
         <Layout noPadding>
           {#if getQueryParams(value).length > 0}
             <ParameterBuilder
-              bind:customParams={value.queryParams}
+              bind:customParams={tmpQueryParams}
               parameters={getQueryParams(value)}
               {bindings}
             />

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -393,13 +393,13 @@
           {
             "label": "Column",
             "value": "column",
-            "barIcon": "ViewRow",
+            "barIcon": "ViewColumn",
             "barTitle": "Column layout"
           },
           {
             "label": "Row",
             "value": "row",
-            "barIcon": "ViewColumn",
+            "barIcon": "ViewRow",
             "barTitle": "Row layout"
           }
         ],

--- a/packages/client/src/components/app/Link.svelte
+++ b/packages/client/src/components/app/Link.svelte
@@ -21,10 +21,24 @@
   $: target = openInNewTab ? "_blank" : "_self"
   $: placeholder = $builderStore.inBuilder && !text
   $: componentText = getComponentText(text, $builderStore, $component)
+  $: sanitizedUrl = getSanitizedUrl(url, externalLink, openInNewTab)
 
   // Add color styles to main styles object, otherwise the styleable helper
   // overrides the color when it's passed as inline style.
   $: styles = enrichStyles($component.styles, color)
+
+  const getSanitizedUrl = (url, externalLink, newTab) => {
+    if (!url) {
+      return externalLink || newTab ? "#/" : "/"
+    }
+    if (externalLink) {
+      return url
+    }
+    if (openInNewTab) {
+      return `#${url}`
+    }
+    return url
+  }
 
   const getComponentText = (text, builderState, componentState) => {
     if (!builderState.inBuilder || componentState.editing) {
@@ -65,10 +79,10 @@
     {componentText}
   </div>
 {:else if $builderStore.inBuilder || componentText}
-  {#if externalLink}
+  {#if externalLink || openInNewTab}
     <a
       {target}
-      href={url || "/"}
+      href={sanitizedUrl}
       use:styleable={styles}
       class:placeholder
       class:bold
@@ -79,10 +93,10 @@
       {componentText}
     </a>
   {:else}
-    {#key url}
+    {#key sanitizedUrl}
       <a
         use:linkable
-        href={url || "/"}
+        href={sanitizedUrl}
         use:styleable={styles}
         class:placeholder
         class:bold

--- a/packages/client/src/components/app/Link.svelte
+++ b/packages/client/src/components/app/Link.svelte
@@ -79,18 +79,20 @@
       {componentText}
     </a>
   {:else}
-    <a
-      use:linkable
-      href={url || "/"}
-      use:styleable={styles}
-      class:placeholder
-      class:bold
-      class:italic
-      class:underline
-      class="align--{align || 'left'} size--{size || 'M'}"
-    >
-      {componentText}
-    </a>
+    {#key url}
+      <a
+        use:linkable
+        href={url || "/"}
+        use:styleable={styles}
+        class:placeholder
+        class:bold
+        class:italic
+        class:underline
+        class="align--{align || 'left'} size--{size || 'M'}"
+      >
+        {componentText}
+      </a>
+    {/key}
   {/if}
 {/if}
 


### PR DESCRIPTION
## Description
- Fix links becoming invalid when the URL setting changes due to the `link` `svelte-spa-router` action not correctly updating #3715 
- Fix incorrect icon being used in settings bar for repeater layout #3700 
- Fix internal links not being able to be opened in a new tab #3704 
- Fix query params not being saved after being edited due to them directly mutating the app structure in the store #3706 
- Fix non-string option labels causing a crash when used with the `autocomplete` option #3657
- Fix automation bindings not working
- Allow JS bindings when using the backend log automation step as it helps a lot for debugging


