### PR TITLE
Escape mysql describe to handle non standard table names

### DIFF
--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -143,7 +143,7 @@ module MySQLModule {
         const schema: TableSchema = {}
         const descResp = await internalQuery(
           this.client,
-          { sql: `DESCRIBE ${tableName};` },
+          { sql: `DESCRIBE \`${tableName}\`;` },
           false
         )
         for (let column of descResp) {


### PR DESCRIPTION
## Description
Fix for https://github.com/Budibase/budibase/issues/3713
Escape table name in the the `DESCRIBE` statement to handle table names with a `-`. e.g. `my-users`
Credit to @mike12345567 for the fix


