### PR TITLE
Screen modal fixes for state and datasource invalidation

### DIFF
--- a/packages/client/src/components/Router.svelte
+++ b/packages/client/src/components/Router.svelte
@@ -1,8 +1,9 @@
 <script>
-  import { setContext, getContext } from "svelte"
+  import { setContext, getContext, onMount } from "svelte"
   import Router, { querystring } from "svelte-spa-router"
-  import { routeStore } from "stores"
+  import { routeStore, stateStore } from "stores"
   import Screen from "./Screen.svelte"
+  import { get } from "svelte/store"
 
   const { styleable } = getContext("sdk")
   const component = getContext("component")
@@ -17,15 +18,17 @@
   }
 
   // Keep query params up to date
-  $: {
+  $: routeStore.actions.setQueryParams(parseQueryString($querystring))
+
+  const parseQueryString = query => {
     let queryParams = {}
-    if ($querystring) {
-      const urlSearchParams = new URLSearchParams($querystring)
+    if (query) {
+      const urlSearchParams = new URLSearchParams(query)
       for (const [key, value] of urlSearchParams) {
         queryParams[key] = value
       }
     }
-    routeStore.actions.setQueryParams(queryParams)
+    return queryParams
   }
 
   const getRouterConfig = routes => {
@@ -42,6 +45,19 @@
   const onRouteLoading = ({ detail }) => {
     routeStore.actions.setActiveRoute(detail.route)
   }
+
+  // Initialise state store from query string on initial load
+  onMount(() => {
+    const queryParams = parseQueryString(get(querystring))
+    if (queryParams.state) {
+      try {
+        const state = JSON.parse(atob(queryParams.state))
+        stateStore.actions.initialise(state)
+      } catch (error) {
+        // Swallow error and do nothing
+      }
+    }
+  })
 </script>
 
 {#key config.id}

--- a/packages/client/src/stores/dataSource.js
+++ b/packages/client/src/stores/dataSource.js
@@ -1,6 +1,7 @@
 import { writable, get } from "svelte/store"
 import { fetchTableDefinition } from "../api"
 import { FieldTypes } from "../constants"
+import { routeStore } from "./routes"
 
 export const createDataSourceStore = () => {
   const store = writable([])
@@ -60,10 +61,12 @@ export const createDataSourceStore = () => {
 
     // Emit this as a window event, so parent screens which are iframing us in
     // can also invalidate the same datasource
-    window.parent.postMessage({
-      type: "close-screen-modal",
-      detail: { dataSourceId },
-    })
+    if (get(routeStore).queryParams?.peek) {
+      window.parent.postMessage({
+        type: "invalidate-datasource",
+        detail: { dataSourceId },
+      })
+    }
 
     let invalidations = [dataSourceId]
 

--- a/packages/client/src/stores/peek.js
+++ b/packages/client/src/stores/peek.js
@@ -1,4 +1,5 @@
-import { writable } from "svelte/store"
+import { writable, get } from "svelte/store"
+import { stateStore } from "./state.js"
 
 const initialState = {
   showPeek: false,
@@ -14,7 +15,10 @@ const createPeekStore = () => {
     let href = url
     let external = !url.startsWith("/")
     if (!external) {
-      href = `${window.location.href.split("#")[0]}#${url}?peek=true`
+      const state = get(stateStore)
+      const serialised = encodeURIComponent(btoa(JSON.stringify(state)))
+      const query = `peek=true&state=${serialised}`
+      href = `${window.location.href.split("#")[0]}#${url}?${query}`
     }
     store.set({
       showPeek: true,

--- a/packages/client/src/stores/state.js
+++ b/packages/client/src/stores/state.js
@@ -1,9 +1,9 @@
 import { writable, get, derived } from "svelte/store"
 import { localStorageStore } from "builder/src/builderStore/store/localStorage"
-import { appStore } from "./app"
 
 const createStateStore = () => {
-  const localStorageKey = `${get(appStore).appId}.state`
+  const appId = window["##BUDIBASE_APP_ID##"] || "app"
+  const localStorageKey = `${appId}.state`
   const persistentStore = localStorageStore(localStorageKey, {})
 
   // Initialise the temp store to mirror the persistent store

--- a/packages/client/src/stores/state.js
+++ b/packages/client/src/stores/state.js
@@ -34,6 +34,9 @@ const createStateStore = () => {
     })
   }
 
+  // Initialises the temporary state store with a certain value
+  const initialise = tempStore.set
+
   // Derive the combination of both persisted and non persisted stores
   const store = derived(
     [tempStore, persistentStore],
@@ -47,7 +50,7 @@ const createStateStore = () => {
 
   return {
     subscribe: store.subscribe,
-    actions: { setValue, deleteValue },
+    actions: { setValue, deleteValue, initialise },
   }
 }
 

--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -116,6 +116,15 @@ const updateStateHandler = action => {
   } else if (type === "delete") {
     stateStore.actions.deleteValue(key)
   }
+
+  // Emit this as an event so that parent windows which are iframing us in
+  // can also update their state
+  if (get(routeStore).queryParams?.peek) {
+    window.parent.postMessage({
+      type: "update-state",
+      detail: { type, key, value, persist },
+    })
+  }
 }
 
 const handlerMap = {


### PR DESCRIPTION
## Description
Fixes app state not being shared with screen modals. #3781
- When a screen modal is opened, the current state is passed into the new iframe modal by serialising it and passing it as a query param
- When a state update action is executed inside a screen modal, this event is proxied back to the parent window so that it also updates

Also some other bug fixes:
- Fix datasource invalidation (for hot reloading) inside screen modals not being proxied back to the parent window
- Fix persisted app state using an incorrect local storage key

Merging to master as this addressesa couple of bugs which are currently live.



