### PR TITLE
Fix automation TypeError: Pouch is not a constructor 

### DIFF
--- a/packages/server/src/threads/automation.js
+++ b/packages/server/src/threads/automation.js
@@ -1,6 +1,5 @@
-// when thread starts, make sure it is recorded
+require("./utils").threadSetup()
 const env = require("../environment")
-env.setInThread()
 const actions = require("../automations/actions")
 const automationUtils = require("../automations/automationUtils")
 const AutomationEmitter = require("../events/AutomationEmitter")

--- a/packages/server/src/threads/query.js
+++ b/packages/server/src/threads/query.js
@@ -1,6 +1,4 @@
-// when thread starts, make sure it is recorded
-const env = require("../environment")
-env.setInThread()
+require("./utils").threadSetup()
 const ScriptRunner = require("../utilities/scriptRunner")
 const { integrations } = require("../integrations")
 

--- a/packages/server/src/threads/utils.js
+++ b/packages/server/src/threads/utils.js
@@ -3,6 +3,10 @@ const CouchDB = require("../db")
 const { init } = require("@budibase/auth")
 
 exports.threadSetup = () => {
+  // don't run this if not threading
+  if (env.isTest() || env.DISABLE_THREADING) {
+    return
+  }
   // when thread starts, make sure it is recorded
   env.setInThread()
   init(CouchDB)

--- a/packages/server/src/threads/utils.js
+++ b/packages/server/src/threads/utils.js
@@ -1,0 +1,9 @@
+const env = require("../environment")
+const CouchDB = require("../db")
+const { init } = require("@budibase/auth")
+
+exports.threadSetup = () => {
+  // when thread starts, make sure it is recorded
+  env.setInThread()
+  init(CouchDB)
+}


### PR DESCRIPTION
## Description
Fixing an issue with automations throwing a Pouch error due to the auth library database not being setup.