### PR TITLE
Updating self host docs and making CLI pkgs part of release

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -9,11 +9,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
         with:
-          fetch_depth: 0
+          node-version: 14.x
 
       - name: Tag and release Docker images (Self Host)
-        run: | 
+        run: |
           docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
 
           # Get latest release version
@@ -28,7 +29,7 @@ jobs:
           # Tag apps and worker images
           docker tag budibase/apps:$release_tag budibase/apps:$SELFHOST_TAG
           docker tag budibase/worker:$release_tag budibase/worker:$SELFHOST_TAG
-          
+
           # Push images
           docker push budibase/apps:$SELFHOST_TAG
           docker push budibase/worker:$SELFHOST_TAG
@@ -36,13 +37,20 @@ jobs:
           DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}
           SELFHOST_TAG: latest
-      
-      - name: Setup Helm 
+
+      - name: Setup Helm
         uses: azure/setup-helm@v1
         id: helm-install
 
+      - name: Build CLI executables
+        run: |
+          pushd packages/cli
+          yarn
+          yarn build
+          popd
+
       # - name: Build and release helm chart
-      #   run: | 
+      #   run: |
       #     git config user.name "Budibase Helm Bot"
       #     git config user.email "<>"
       #     mv budibase-${{ env.RELEASE_VERSION }}.tgz docs
@@ -67,3 +75,7 @@ jobs:
           name: v${{ env.RELEASE_VERSION }}
           tag_name: v${{ env.RELEASE_VERSION }}
           generate_release_notes: true
+          files: |
+            packages/cli/build/cli-win.exe
+            packages/cli/build/cli-linux
+            packages/cli/build/cli-macos

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ hosting/.generated-envoy.dev.yaml
 # Sublime text
 *.sublime-project
 *.sublime-workspace
+
+bin/

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,9 @@
   },
   "pkg": {
     "targets": [
-      "node14"
+      "node14-linux",
+      "node14-win",
+      "node14-macos"
     ],
     "outputPath": "build"
   },


### PR DESCRIPTION
## Description
This is a fix for https://github.com/budibase/budibase/issues/3245

Previous to this the docs only referenced an old version of the CLI that was released once, future versions would not be available. I've built a new version and added these to the latest release, as well as updating the docs to always point to `releases/latest/downloads` rather than a specific release.

This also includes a change to the `release-selfhost.yml` workflow to build the CLI executables and include them when putting together the automated release, meaning the CLI can be updated easily.

Tested this with https://github.com/nektos/act (allows running workflows locally, just commented out the steps that can't be run outside of Github).