### PR TITLE
Allow access to query parameters in transformer

### DIFF
--- a/packages/server/src/threads/query.js
+++ b/packages/server/src/threads/query.js
@@ -46,7 +46,10 @@ class QueryRunner {
 
     // transform as required
     if (transformer) {
-      const runner = new ScriptRunner(transformer, { data: rows })
+      const runner = new ScriptRunner(transformer, {
+        data: rows,
+        params: parameters,
+      })
       rows = runner.execute()
     }
 


### PR DESCRIPTION
## Description
Fixing #3228 - allowing access to parameters in the transformer.

This was a small change, noticed it wasn't mentioned in the docs, then realised that it hadn't actually been enabled.