### PR TITLE
Fix: Load apps when using the default multi tenant

### DIFF
--- a/packages/auth/src/db/utils.js
+++ b/packages/auth/src/db/utils.js
@@ -224,8 +224,15 @@ exports.getAllDbs = async () => {
     }
   }
   let couchUrl = `${exports.getCouchUrl()}/_all_dbs`
-  if (env.MULTI_TENANCY) {
-    let tenantId = getTenantId()
+  let tenantId = getTenantId()
+  if (!env.MULTI_TENANCY || tenantId == DEFAULT_TENANT_ID) {
+    // just get all DBs when:
+    // - single tenancy
+    // - default tenant
+    //    - apps dbs don't contain tenant id
+    //    - non-default tenant dbs are filtered out application side in getAllApps
+    await addDbs(couchUrl)
+  } else {
     // get prod apps
     await addDbs(
       exports.getStartEndKeyURL(couchUrl, DocumentTypes.APP, tenantId)
@@ -236,9 +243,6 @@ exports.getAllDbs = async () => {
     )
     // add global db name
     dbs.push(getGlobalDBName(tenantId))
-  } else {
-    // just get all DBs in self host
-    await addDbs(couchUrl)
   }
   return dbs
 }


### PR DESCRIPTION
## Description
- Apps weren't loading when using the default tenant in multi tenant mode 
- Just load all apps in this case and rely on subsequent application side filtering to produce the correct list of apps
- Would not be performant if there were a giant number of tenants and the default tenant was being accessed, but this is a) not supported in cloud (we don't use the default tenant) and b) not supported in self hosted (we don't officially support multi tenant self host)




