### PR TITLE
Maintaining options and boolean types when fetching SQL schemas

### DIFF
--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -43,8 +43,8 @@ const coreFields = {
     enum: Object.values(BodyTypes),
   },
   pagination: {
-    type: DatasourceFieldTypes.OBJECT
-  }
+    type: DatasourceFieldTypes.OBJECT,
+  },
 }
 
 module RestModule {
@@ -178,12 +178,17 @@ module RestModule {
           headers,
         },
         pagination: {
-          cursor: nextCursor
-        }
+          cursor: nextCursor,
+        },
       }
     }
 
-    getUrl(path: string, queryString: string, pagination: PaginationConfig | null, paginationValues: PaginationValues | null): string {
+    getUrl(
+      path: string,
+      queryString: string,
+      pagination: PaginationConfig | null,
+      paginationValues: PaginationValues | null
+    ): string {
       // Add pagination params to query string if required
       if (pagination?.location === "query" && paginationValues) {
         const { pageParam, sizeParam } = pagination
@@ -217,14 +222,22 @@ module RestModule {
       return complete
     }
 
-    addBody(bodyType: string, body: string | any, input: any, pagination: PaginationConfig | null, paginationValues: PaginationValues | null) {
+    addBody(
+      bodyType: string,
+      body: string | any,
+      input: any,
+      pagination: PaginationConfig | null,
+      paginationValues: PaginationValues | null
+    ) {
       if (!input.headers) {
         input.headers = {}
       }
       if (bodyType === BodyTypes.NONE) {
         return input
       }
-      let error, object: any = {}, string = ""
+      let error,
+        object: any = {},
+        string = ""
       try {
         if (body) {
           string = typeof body !== "string" ? JSON.stringify(body) : body
@@ -333,7 +346,7 @@ module RestModule {
         requestBody,
         authConfigId,
         pagination,
-        paginationValues
+        paginationValues,
       } = query
       const authHeaders = this.getAuthHeaders(authConfigId)
 
@@ -352,7 +365,13 @@ module RestModule {
       }
 
       let input: any = { method, headers: this.headers }
-      input = this.addBody(bodyType, requestBody, input, pagination, paginationValues)
+      input = this.addBody(
+        bodyType,
+        requestBody,
+        input,
+        pagination,
+        paginationValues
+      )
 
       this.startTimeMs = performance.now()
       const url = this.getUrl(path, queryString, pagination, paginationValues)

--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -1,12 +1,8 @@
 import { SqlQuery } from "../definitions/datasource"
 import { Datasource, Table } from "../definitions/common"
 import { SourceNames } from "../definitions/datasource"
-const { DocumentTypes, SEPARATOR } = require("../db/utils")
-const {
-  FieldTypes,
-  BuildSchemaErrors,
-  InvalidColumns,
-} = require("../constants")
+import { DocumentTypes, SEPARATOR } from "../db/utils"
+import { FieldTypes, BuildSchemaErrors, InvalidColumns } from "../constants"
 
 const DOUBLE_SEPARATOR = `${SEPARATOR}${SEPARATOR}`
 const ROW_ID_REGEX = /^\[.*]$/g
@@ -158,7 +154,12 @@ function copyExistingPropsOver(
       if (!existingTableSchema.hasOwnProperty(key)) {
         continue
       }
-      if (existingTableSchema[key].type === "link") {
+      if (
+        existingTableSchema[key].type === FieldTypes.LINK ||
+        existingTableSchema[key].type === FieldTypes.OPTIONS ||
+        ((!table.schema[key] || table.schema[key].type === FieldTypes.NUMBER) &&
+          existingTableSchema[key].type === FieldTypes.BOOLEAN)
+      ) {
         table.schema[key] = existingTableSchema[key]
       }
     }


### PR DESCRIPTION
## Description
Fixing issue #4010 - options and boolean types can be maintained - checks the same way we do for relationships.

Also ran a TS lint which hadn't been run in a while, accounts for most of the changes.