### PR TITLE
sameSite and secure cookie settings

### DIFF
--- a/packages/backend-core/src/environment.js
+++ b/packages/backend-core/src/environment.js
@@ -6,6 +6,13 @@ function isTest() {
   )
 }
 
+function isDev() {
+  return (
+    process.env.NODE_ENV !== "production" &&
+    process.env.BUDIBASE_ENVIRONMENT !== "production"
+  )
+}
+
 module.exports = {
   JWT_SECRET: process.env.JWT_SECRET,
   COUCH_DB_URL: process.env.COUCH_DB_URL,
@@ -27,6 +34,7 @@ module.exports = {
   COOKIE_DOMAIN: process.env.COOKIE_DOMAIN,
   PLATFORM_URL: process.env.PLATFORM_URL,
   isTest,
+  isDev,
   _set(key, value) {
     process.env[key] = value
     module.exports[key] = value

--- a/packages/backend-core/src/utils.js
+++ b/packages/backend-core/src/utils.js
@@ -23,6 +23,7 @@ const { getUserSessions, invalidateSessions } = require("./security/sessions")
 const { migrateIfRequired } = require("./migrations")
 const { USER_EMAIL_VIEW_CASING } = require("./migrations").MIGRATIONS
 const { GLOBAL_DB } = require("./migrations").MIGRATION_DBS
+const { isDev, isTest } = require("./environment")
 
 const APP_PREFIX = DocumentTypes.APP + SEPARATOR
 
@@ -106,6 +107,11 @@ exports.setCookie = (ctx, value, name = "builder", opts = { sign: true }) => {
     path: "/",
     httpOnly: false,
     overwrite: true,
+  }
+
+  if (!isDev() && !isTest()) {
+    config.sameSite = "none"
+    config.secure = true
   }
 
   if (environment.COOKIE_DOMAIN) {


### PR DESCRIPTION
## Description
Adding `sameSite: none` and `secure` flags to cookies so they work on the latest version of firefox when running over HTTPS.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



