### PR TITLE
Fix dynamic validators not correctly validating form components

### DIFF
--- a/packages/client/src/components/app/forms/InnerForm.svelte
+++ b/packages/client/src/components/app/forms/InnerForm.svelte
@@ -141,8 +141,18 @@
         return
       }
 
+      // Create validation function based on field schema
+      const schemaConstraints = schema?.[field]?.constraints
+      const validator = createValidatorFromConstraints(
+        schemaConstraints,
+        validationRules,
+        field,
+        table
+      )
+
       // If we've already registered this field then keep some existing state
       let initialValue = deepGet(initialValues, field) ?? defaultValue
+      let initialError = null
       let fieldId = `id-${generateID()}`
       const existingField = getField(field)
       if (existingField) {
@@ -156,19 +166,16 @@
         } else {
           initialValue = fieldState.value ?? initialValue
         }
+
+        // If this field has already been registered and we previously had an
+        // error set, then re-run the validator to see if we can unset it
+        if (fieldState.error) {
+          initialError = validator(initialValue)
+        }
       }
 
       // Auto columns are always disabled
       const isAutoColumn = !!schema?.[field]?.autocolumn
-
-      // Create validation function based on field schema
-      const schemaConstraints = schema?.[field]?.constraints
-      const validator = createValidatorFromConstraints(
-        schemaConstraints,
-        validationRules,
-        field,
-        table
-      )
 
       // Construct field info
       const fieldInfo = writable({
@@ -178,7 +185,7 @@
         fieldState: {
           fieldId,
           value: initialValue,
-          error: null,
+          error: initialError,
           disabled: disabled || fieldDisabled || isAutoColumn,
           defaultValue,
           validator,
@@ -254,6 +261,7 @@
 
       // Update field state
       const error = validator ? validator(value) : null
+      console.log("value changed to", value, "new error is", error)
       fieldInfo.update(state => {
         state.fieldState.value = value
         state.fieldState.error = error

--- a/packages/client/src/components/app/forms/InnerForm.svelte
+++ b/packages/client/src/components/app/forms/InnerForm.svelte
@@ -261,7 +261,6 @@
 
       // Update field state
       const error = validator ? validator(value) : null
-      console.log("value changed to", value, "new error is", error)
       fieldInfo.update(state => {
         state.fieldState.value = value
         state.fieldState.error = error


### PR DESCRIPTION
This fixes an issue reported in #3675, where sometimes validation did not seem to work.

The error was actually caused by having `{{ now }}` inside a validation rule - because any time this is enriched it is a new timestamp, therefore causing the validation rules to change and the field to re-register itself. There was an oversight in field registration in the form logic that always wiped errors when re-registering an existing field.

This has been updated so that whenever an existing field is re-reigstered and it used to have an error, the new validator function is invoked and an initial error can be set if required.



