### PR TITLE
Revert "sameSite and secure cookie settings"

### DIFF
--- a/packages/backend-core/src/environment.js
+++ b/packages/backend-core/src/environment.js
@@ -6,13 +6,6 @@ function isTest() {
   )
 }
 
-function isDev() {
-  return (
-    process.env.NODE_ENV !== "production" &&
-    process.env.BUDIBASE_ENVIRONMENT !== "production"
-  )
-}
-
 module.exports = {
   JWT_SECRET: process.env.JWT_SECRET,
   COUCH_DB_URL: process.env.COUCH_DB_URL,
@@ -34,7 +27,6 @@ module.exports = {
   COOKIE_DOMAIN: process.env.COOKIE_DOMAIN,
   PLATFORM_URL: process.env.PLATFORM_URL,
   isTest,
-  isDev,
   _set(key, value) {
     process.env[key] = value
     module.exports[key] = value

--- a/packages/backend-core/src/utils.js
+++ b/packages/backend-core/src/utils.js
@@ -23,7 +23,6 @@ const { getUserSessions, invalidateSessions } = require("./security/sessions")
 const { migrateIfRequired } = require("./migrations")
 const { USER_EMAIL_VIEW_CASING } = require("./migrations").MIGRATIONS
 const { GLOBAL_DB } = require("./migrations").MIGRATION_DBS
-const { isDev, isTest } = require("./environment")
 
 const APP_PREFIX = DocumentTypes.APP + SEPARATOR
 
@@ -107,11 +106,6 @@ exports.setCookie = (ctx, value, name = "builder", opts = { sign: true }) => {
     path: "/",
     httpOnly: false,
     overwrite: true,
-  }
-
-  if (!isDev() && !isTest()) {
-    config.sameSite = "none"
-    config.secure = true
   }
 
   if (environment.COOKIE_DOMAIN) {


### PR DESCRIPTION
Reverts Budibase/budibase#4027

Reverting this as its not working correctly on pre-prod. The use of `samesite` and `secure` together expects HTTPS, and even in preprod with HTTPS, it still doesn't work correctly and throws errors. 

Will re-evaluate solution so it works across browsers and in dev etc.