### PR TITLE
don't check for hydrationComplete

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[assetType]/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[assetType]/_layout.svelte
@@ -25,7 +25,6 @@
   let previousType
   let previousAsset
   let previousComponentId
-  let hydrationComplete = false
 
   // Manage the layout modal flow from here
   let showModal
@@ -41,12 +40,6 @@
   )
 
   const hydrateStateFromURL = (params, leftover) => {
-    if (hydrationComplete) {
-      return
-    } else {
-      hydrationComplete = true
-    }
-
     // Do nothing if no asset type, as that means we've left the page
     if (!params.assetType) {
       return


### PR DESCRIPTION
## Description
I removed the check for `hydrationComplete` since that boolean was set to true the first time the screen was rendered. When clicking the layouts tab and back to the screens tab, the state was not updated by the url and didn't change anymore. After removing the `hydrationComplete` boolean, the state was updated correctly.

Fixes #4075

## Screenshots
![image](https://user-images.githubusercontent.com/1907152/149836960-4b29e3fc-193c-40eb-bf23-94ec580e96ce.png)




