### PR TITLE
fix schema constraint mapping to validation rule

### DIFF
--- a/packages/client/src/components/app/forms/validation.js
+++ b/packages/client/src/components/app/forms/validation.js
@@ -37,7 +37,7 @@ export const createValidatorFromConstraints = (
       const length = schemaConstraints.length.maximum
       rules.push({
         type: "string",
-        constraint: "length",
+        constraint: "maxLength",
         value: length,
         error: `Maximum length is ${length}`,
       })


### PR DESCRIPTION
## Description
Fixes #4072 - mapping between `schemaConstraints.length?.maximum` and validation `handlerMap` was incorrect for `maxLength` constraint. 

## Screenshots
![image](https://user-images.githubusercontent.com/1907152/149843289-ba7f5b8f-fd26-40f4-a2b0-3e9b4758d434.png)



