### PR TITLE
use deleteColName when deleting a column

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -127,6 +127,7 @@
   }
 
   function deleteColumn() {
+    field.name = deleteColName
     if (field.name === $tables.selected.primaryDisplay) {
       notifications.error("You cannot delete the display column")
     } else {
@@ -470,16 +471,16 @@
   onOk={deleteColumn}
   onCancel={hideDeleteDialog}
   title="Confirm Deletion"
-  disabled={deleteColName !== field.name}
+  disabled={deleteColName !== originalName}
 >
   <p>
-    Are you sure you wish to delete the column <b>{field.name}?</b>
+    Are you sure you wish to delete the column <b>{originalName}?</b>
     Your data will be deleted and this action cannot be undone - enter the column
     name to confirm.
   </p>
   <Input
     dataCy="delete-column-confirm"
     bind:value={deleteColName}
-    placeholder={field.name}
+    placeholder={originalName}
   />
 </ConfirmDialog>


### PR DESCRIPTION
## Description
A confirmation dialog opens up when deleting a column. The input from this confirmation dialog is used to set the field.name and to remove the field. In order to delete the right field. we should either ask for the confirmation of the original name or store the original field and don't use the input for defining which field to remove.

Fixes #4070

## Screenshots
![image](https://user-images.githubusercontent.com/1907152/149903962-dfeeb884-17b1-43eb-a03a-9ed9757a868a.png)




