### PR TITLE
reset field.name to originalName after cancel

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -126,6 +126,10 @@
     }
   }
 
+  function cancelEdit() {
+    field.name = originalName
+  }
+
   function deleteColumn() {
     if (field.name === $tables.selected.primaryDisplay) {
       notifications.error("You cannot delete the display column")
@@ -307,6 +311,7 @@
   title={originalName ? "Edit Column" : "Create Column"}
   confirmText="Save Column"
   onConfirm={saveColumn}
+  onCancel={cancelEdit}
   disabled={invalid}
 >
   <Input


### PR DESCRIPTION
## Description
Field.name should be set to originalName after canceling edit column dialog, otherwise the new name is prefilled when editing the same column again.

Fixes #4081


