### PR TITLE
Update MultiFieldSelect to accept a defaultValue

### DIFF
--- a/packages/client/src/components/app/forms/MultiFieldSelect.svelte
+++ b/packages/client/src/components/app/forms/MultiFieldSelect.svelte
@@ -20,6 +20,7 @@
   let fieldSchema
 
   $: flatOptions = optionsSource == null || optionsSource === "schema"
+  $: expandedDefaultValue = expand(fieldState?.defaultValue)
   $: expandedValue = expand(fieldState?.value)
   $: options = getOptions(
     optionsSource,
@@ -39,7 +40,7 @@
       return values
     }
 
-    return values.split(",")
+    return values.split(",").map(value => value.trim())
   }
 </script>
 
@@ -57,6 +58,7 @@
   {#if fieldState}
     <CoreMultiselect
       value={expandedValue}
+      defaultValue={expandedDefaultValue}
       error={fieldState.error}
       getOptionLabel={flatOptions ? x => x : x => x.label}
       getOptionValue={flatOptions ? x => x : x => x.value}

--- a/packages/client/src/components/app/forms/MultiFieldSelect.svelte
+++ b/packages/client/src/components/app/forms/MultiFieldSelect.svelte
@@ -20,6 +20,7 @@
   let fieldSchema
 
   $: flatOptions = optionsSource == null || optionsSource === "schema"
+  $: expandedValue = expand(fieldState?.value)
   $: options = getOptions(
     optionsSource,
     fieldSchema,
@@ -28,6 +29,18 @@
     valueColumn,
     customOptions
   )
+
+  const expand = values => {
+    if (!values) {
+      return []
+    }
+
+    if (Array.isArray(values)) {
+      return values
+    }
+
+    return values.split(",")
+  }
 </script>
 
 <Field
@@ -43,7 +56,7 @@
 >
   {#if fieldState}
     <CoreMultiselect
-      value={fieldState.value || []}
+      value={expandedValue}
       error={fieldState.error}
       getOptionLabel={flatOptions ? x => x : x => x.label}
       getOptionValue={flatOptions ? x => x : x => x.value}

--- a/packages/client/src/components/app/forms/MultiFieldSelect.svelte
+++ b/packages/client/src/components/app/forms/MultiFieldSelect.svelte
@@ -20,8 +20,7 @@
   let fieldSchema
 
   $: flatOptions = optionsSource == null || optionsSource === "schema"
-  $: expandedDefaultValue = expand(fieldState?.defaultValue)
-  $: expandedValue = expand(fieldState?.value)
+  $: expandedDefaultValue = expand(defaultValue)
   $: options = getOptions(
     optionsSource,
     fieldSchema,
@@ -49,7 +48,7 @@
   {label}
   {disabled}
   {validation}
-  {defaultValue}
+  defaultValue={expandedDefaultValue}
   type="array"
   bind:fieldState
   bind:fieldApi
@@ -57,8 +56,7 @@
 >
   {#if fieldState}
     <CoreMultiselect
-      value={expandedValue}
-      defaultValue={expandedDefaultValue}
+      value={fieldState.value || []}
       error={fieldState.error}
       getOptionLabel={flatOptions ? x => x : x => x.label}
       getOptionValue={flatOptions ? x => x : x => x.value}


### PR DESCRIPTION
This changes the multi select control to accept defaultValues. As these are passed in as strings (flattened arrays in the form of "1, 2, 3") they need to be split into an array to be accepted by the control.

This solves #4067
