### PR TITLE
add extensions prop to specify accepted file extensions

### DIFF
--- a/packages/bbui/src/Form/Core/Dropzone.svelte
+++ b/packages/bbui/src/Form/Core/Dropzone.svelte
@@ -22,6 +22,7 @@
   export let error = null
   export let fileTags = []
   export let maximum = null
+  export let extensions = "*"
 
   const dispatch = createEventDispatcher()
   const imageExtensions = [
@@ -207,6 +208,7 @@
           {disabled}
           type="file"
           multiple
+          accept={extensions}
           on:change={handleFile}
         />
         <svg

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -2236,7 +2236,7 @@
           "setting": "optionsSource",
           "value": "provider"
         }
-      }, 
+      },
       {
         "type": "options",
         "key": "customOptions",
@@ -2418,6 +2418,11 @@
         "type": "text",
         "label": "Label",
         "key": "label"
+      },
+      {
+        "type": "text",
+        "label": "Extensions",
+        "key": "extensions"
       },
       {
         "type": "boolean",

--- a/packages/client/src/components/app/forms/AttachmentField.svelte
+++ b/packages/client/src/components/app/forms/AttachmentField.svelte
@@ -7,6 +7,7 @@
   export let label
   export let disabled = false
   export let validation
+  export let extensions
 
   let fieldState
   let fieldApi
@@ -52,6 +53,7 @@
       }}
       {processFiles}
       {handleFileTooLarge}
+      {extensions}
     />
   {/if}
 </Field>


### PR DESCRIPTION
## Description
Fixes #4042 - Adds a property to specify accepted file extensions to the attachmentField.

## Screenshots
![image](https://user-images.githubusercontent.com/1907152/149976707-6ea9db56-02d8-4049-ab37-cc2b587cda80.png)

![image](https://user-images.githubusercontent.com/1907152/149976857-ce5e3262-8598-411f-a537-b8fe5768a6ef.png)