### PR TITLE
Fixing issue with existing SQL relationships and deleting tables externally to Budibase

### DIFF
--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -429,13 +429,14 @@ Cypress.Commands.add("addDatasourceConfig", (datasource, skipFetch) => {
   // Click to fetch tables
   if (skipFetch) {
     cy.get(".spectrum-Dialog-grid").within(() => {
-      cy.get(".spectrum-Button").contains("Skip table fetch")
+      cy.get(".spectrum-Button")
+        .contains("Skip table fetch")
         .click({ force: true })
     })
-  }
-  else {
+  } else {
     cy.get(".spectrum-Dialog-grid").within(() => {
-      cy.get(".spectrum-Button").contains("Save and fetch tables")
+      cy.get(".spectrum-Button")
+        .contains("Save and fetch tables")
         .click({ force: true })
       cy.wait(1000)
     })

--- a/packages/builder/cypress/support/queryLevelTransformerFunction.js
+++ b/packages/builder/cypress/support/queryLevelTransformerFunction.js
@@ -1,12 +1,13 @@
+// eslint-disable-next-line
 const breweries = data
 const totals = {}
 
-for (let brewery of breweries) 
-  {const state = brewery.state
-  if (totals[state] == null) 
-    {totals[state] = 1
-  } else 
-    {totals[state]++
+for (let brewery of breweries) {
+  const state = brewery.state
+  if (totals[state] == null) {
+    totals[state] = 1
+  } else {
+    totals[state]++
   }
 }
 const entries = Object.entries(totals)

--- a/packages/builder/cypress/support/queryLevelTransformerFunctionWithData.js
+++ b/packages/builder/cypress/support/queryLevelTransformerFunctionWithData.js
@@ -1,15 +1,16 @@
+// eslint-disable-next-line
 const breweries = data
 const totals = {}
-for (let brewery of breweries) 
-  {const state = brewery.state
-  if (totals[state] == null) 
-    {totals[state] = 1
-  } else 
-    {totals[state]++
+for (let brewery of breweries) {
+  const state = brewery.state
+  if (totals[state] == null) {
+    totals[state] = 1
+  } else {
+    totals[state]++
   }
 }
-const stateCodes = 
-  {texas: "tx",
+const stateCodes = {
+  texas: "tx",
   colorado: "co",
   florida: "fl",
   iwoa: "ia",
@@ -24,7 +25,7 @@ const stateCodes =
   ohio: "oh",
 }
 const entries = Object.entries(totals)
-return entries.map(([state, count]) => 
-  {stateCodes[state.toLowerCase()]
+return entries.map(([state, count]) => {
+  stateCodes[state.toLowerCase()]
   return { state, count, flag: "http://flags.ox3.in/svg/us/${stateCode}.svg" }
 })

--- a/packages/builder/src/components/backend/DatasourceNavigator/TableIntegrationMenu/CreateExternalTableModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/TableIntegrationMenu/CreateExternalTableModal.svelte
@@ -6,9 +6,12 @@
   export let datasource
 
   let name = ""
+  let submitted = false
   $: valid = name && name.length > 0 && !datasource?.entities[name]
   $: error =
-    name && datasource?.entities[name] ? "Table name already in use." : null
+    !submitted && name && datasource?.entities[name]
+      ? "Table name already in use."
+      : null
 
   function buildDefaultTable(tableName, datasourceId) {
     return {
@@ -26,6 +29,7 @@
   }
 
   async function saveTable() {
+    submitted = true
     const table = await tables.save(buildDefaultTable(name, datasource._id))
     await datasources.fetch()
     $goto(`../../table/${table._id}`)

--- a/packages/worker/src/api/controllers/system/environment.js
+++ b/packages/worker/src/api/controllers/system/environment.js
@@ -6,6 +6,7 @@ exports.fetch = async ctx => {
     cloud: !env.SELF_HOSTED,
     accountPortalUrl: env.ACCOUNT_PORTAL_URL,
     disableAccountPortal: env.DISABLE_ACCOUNT_PORTAL,
-    isDev: env.isDev(),
+    // in test need to pretend its in production for the UI (Cypress)
+    isDev: env.isDev() && !env.isTest(),
   }
 }


### PR DESCRIPTION
## Description
Fix for #3721 - deleting invalid relationships if tables have been removed external to Budibase - otherwise these could not be removed without deleting the datasource.

There was also some unrelated Cypress files that needed linted/eslint disables added to.