### PR TITLE
Fixing case sensitivity in generated client app URLs

### DIFF
--- a/packages/server/src/utilities/workerRequests.js
+++ b/packages/server/src/utilities/workerRequests.js
@@ -71,7 +71,7 @@ exports.getDeployedApps = async () => {
     for (let [key, value] of Object.entries(json)) {
       if (value.url) {
         value.url = value.url.toLowerCase()
-        apps[key] = value
+        apps[key.toLowerCase()] = value
       }
     }
     return apps


### PR DESCRIPTION
## Description
Quick fix for #4093 - make sure the App ID/App URL returned for deployed apps is always lowercase, as URLs are not case sensitive and should not be compared as such.

Previously if the app was named `App Name` then a URL of `App%20Name` would be generated in the server for comparison, which is wrong as the URL will always be case insensitive.

Merging to master to get quick fix out.