### PR TITLE
Quick fix for data section filtering

### DIFF
--- a/packages/builder/src/builderStore/api.js
+++ b/packages/builder/src/builderStore/api.js
@@ -6,6 +6,7 @@ const apiCall =
   method =>
   async (url, body, headers = { "Content-Type": "application/json" }) => {
     headers["x-budibase-app-id"] = svelteGet(store).appId
+    headers["x-budibase-api-version"] = "1"
     const json = headers["Content-Type"] === "application/json"
     const resp = await fetch(url, {
       method: method,


### PR DESCRIPTION
## Description
Minor fix, when testing the filtering the data section noticed some stuff didn't work, like filtering by just a number (which is actually text) we fixed this previously but had to version the API to fix it, builder needed to send up the API version it desires to use.