### PR TITLE
Revert "Fix dev app preview return url"

### DIFF
--- a/packages/backend-core/src/constants.js
+++ b/packages/backend-core/src/constants.js
@@ -8,7 +8,6 @@ exports.Cookies = {
   Auth: "budibase:auth",
   Init: "budibase:init",
   OIDC_CONFIG: "budibase:oidc:config",
-  RETURN_URL: "budibase:returnurl",
 }
 
 exports.Headers = {

--- a/packages/backend-core/src/utils.js
+++ b/packages/backend-core/src/utils.js
@@ -96,12 +96,7 @@ exports.getCookie = (ctx, name) => {
  * @param {string|object} value The value of cookie which will be set.
  * @param {object} opts options like whether to sign.
  */
-exports.setCookie = (
-  ctx,
-  value,
-  name = "builder",
-  opts = { sign: true, requestDomain: false }
-) => {
+exports.setCookie = (ctx, value, name = "builder", opts = { sign: true }) => {
   if (value && opts && opts.sign) {
     value = jwt.sign(value, options.secretOrKey)
   }
@@ -113,7 +108,7 @@ exports.setCookie = (
     overwrite: true,
   }
 
-  if (environment.COOKIE_DOMAIN && !opts.requestDomain) {
+  if (environment.COOKIE_DOMAIN) {
     config.domain = environment.COOKIE_DOMAIN
   }
 

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -43,8 +43,8 @@ const coreFields = {
     enum: Object.values(BodyTypes),
   },
   pagination: {
-    type: DatasourceFieldTypes.OBJECT,
-  },
+    type: DatasourceFieldTypes.OBJECT
+  }
 }
 
 module RestModule {
@@ -178,17 +178,12 @@ module RestModule {
           headers,
         },
         pagination: {
-          cursor: nextCursor,
-        },
+          cursor: nextCursor
+        }
       }
     }
 
-    getUrl(
-      path: string,
-      queryString: string,
-      pagination: PaginationConfig | null,
-      paginationValues: PaginationValues | null
-    ): string {
+    getUrl(path: string, queryString: string, pagination: PaginationConfig | null, paginationValues: PaginationValues | null): string {
       // Add pagination params to query string if required
       if (pagination?.location === "query" && paginationValues) {
         const { pageParam, sizeParam } = pagination
@@ -222,22 +217,14 @@ module RestModule {
       return complete
     }
 
-    addBody(
-      bodyType: string,
-      body: string | any,
-      input: any,
-      pagination: PaginationConfig | null,
-      paginationValues: PaginationValues | null
-    ) {
+    addBody(bodyType: string, body: string | any, input: any, pagination: PaginationConfig | null, paginationValues: PaginationValues | null) {
       if (!input.headers) {
         input.headers = {}
       }
       if (bodyType === BodyTypes.NONE) {
         return input
       }
-      let error,
-        object: any = {},
-        string = ""
+      let error, object: any = {}, string = ""
       try {
         if (body) {
           string = typeof body !== "string" ? JSON.stringify(body) : body
@@ -346,7 +333,7 @@ module RestModule {
         requestBody,
         authConfigId,
         pagination,
-        paginationValues,
+        paginationValues
       } = query
       const authHeaders = this.getAuthHeaders(authConfigId)
 
@@ -365,13 +352,7 @@ module RestModule {
       }
 
       let input: any = { method, headers: this.headers }
-      input = this.addBody(
-        bodyType,
-        requestBody,
-        input,
-        pagination,
-        paginationValues
-      )
+      input = this.addBody(bodyType, requestBody, input, pagination, paginationValues)
 
       this.startTimeMs = performance.now()
       const url = this.getUrl(path, queryString, pagination, paginationValues)

--- a/packages/server/src/integrations/s3.ts
+++ b/packages/server/src/integrations/s3.ts
@@ -38,7 +38,7 @@ module S3Module {
       signatureVersion: {
         type: "string",
         required: false,
-        default: "v4",
+        default: "v4"
       },
     },
     query: {

--- a/packages/server/src/middleware/currentapp.js
+++ b/packages/server/src/middleware/currentapp.js
@@ -47,15 +47,6 @@ module.exports = async (ctx, next) => {
     (!ctx.user || !ctx.user.builder || !ctx.user.builder.global)
   ) {
     clearCookie(ctx, Cookies.CurrentApp)
-    // have to set the return url on the server side as client side is not available
-    setCookie(ctx, ctx.url, Cookies.RETURN_URL, {
-      // don't sign so the browser can easily read
-      sign: false,
-      // use the request domain to match how ui handles the return url cookie.
-      // it's important we don't use the shared domain here as the builder
-      // can't delete from it without awareness of the domain.
-      requestDomain: true,
-    })
     return ctx.redirect("/")
   }
 


### PR DESCRIPTION
This reverts commit e76ea10fc228a3da7c12da3bc9e54d3331d86440.

## Description
To fix an issue highlighted by @aptkingston:

lets say you were logged in and your session expires and you're sitting on the app list screen
- you click on an app name
- the first request the builder does is a POST to the application sync endpoint
- the server 403s it and responds with a set cookie for the return URL of the API endpoint
- builder reloads
- log in again
- builder now pushes you to the return URL, which is an API endpoint so not a valid URL to push the browser to

Fix is to revert any setting or return url on the server, with the known limitation that visiting a dev preview app without a session does not return you to the correct url after login



