### PR TITLE
Fix not showing pagination of query on production

### DIFF
--- a/packages/client/src/utils/fetch/QueryFetch.js
+++ b/packages/client/src/utils/fetch/QueryFetch.js
@@ -16,7 +16,10 @@ export default class QueryFetch extends DataFetch {
     if (!datasource?._id) {
       return null
     }
-    return await fetchQueryDefinition(datasource._id)
+    const definition = await fetchQueryDefinition(datasource._id)
+    // After getting the definition of query, it loses "fields" attribute because of security reason from the server. However, this attribute needs to be inside of defintion for pagination.
+    definition.fields = datasource.fields
+    return definition
   }
 
   async getData() {

--- a/packages/client/src/utils/fetch/QueryFetch.js
+++ b/packages/client/src/utils/fetch/QueryFetch.js
@@ -18,7 +18,9 @@ export default class QueryFetch extends DataFetch {
     }
     const definition = await fetchQueryDefinition(datasource._id)
     // After getting the definition of query, it loses "fields" attribute because of security reason from the server. However, this attribute needs to be inside of defintion for pagination.
-    definition.fields = datasource.fields
+    if (!definition.fields) {
+      definition.fields = datasource.fields
+    }
     return definition
   }
 


### PR DESCRIPTION
## Description
#3962 adds a feature of pagination for REST query but there is no pagination component showing on production.
It's because the server doesn't want to send 'fields' attribute in production when finding the definition of the query.
So I've attached the attribute on the front side and it can handle the definition?.fields?.pagination value.

## Screenshots
![image](https://user-images.githubusercontent.com/114452/151404811-3a4c393d-d591-4ab4-99c3-48a6ef700be6.png)

