### PR TITLE
Fix CSRF token not present using local auth

### DIFF
--- a/packages/builder/src/pages/builder/_layout.svelte
+++ b/packages/builder/src/pages/builder/_layout.svelte
@@ -61,7 +61,7 @@
       await auth.setInitInfo({ init_template: $params["?template"] })
     }
 
-    await auth.checkAuth()
+    await auth.getSelf()
     await admin.init()
 
     if (useAccountPortal && multiTenancyEnabled) {

--- a/packages/builder/src/pages/builder/auth/reset.svelte
+++ b/packages/builder/src/pages/builder/auth/reset.svelte
@@ -31,7 +31,7 @@
   }
 
   onMount(async () => {
-    await auth.checkAuth()
+    await auth.getSelf()
     await organisation.init()
   })
 </script>

--- a/packages/builder/src/stores/portal/auth.js
+++ b/packages/builder/src/stores/portal/auth.js
@@ -108,11 +108,7 @@ export function createAuthStore() {
     return json
   }
 
-  return {
-    subscribe: store.subscribe,
-    setOrganisation,
-    getInitInfo,
-    setInitInfo,
+  const actions = {
     checkQueryString: async () => {
       const urlParams = new URLSearchParams(window.location.search)
       if (urlParams.has("tenantId")) {
@@ -123,7 +119,7 @@ export function createAuthStore() {
     setOrg: async tenantId => {
       await setOrganisation(tenantId)
     },
-    checkAuth: async () => {
+    getSelf: async () => {
       const response = await api.get("/api/global/users/self")
       if (response.status !== 200) {
         setUser(null)
@@ -138,13 +134,12 @@ export function createAuthStore() {
         `/api/global/auth/${tenantId}/login`,
         creds
       )
-      const json = await response.json()
       if (response.status === 200) {
-        setUser(json.user)
+        await actions.getSelf()
       } else {
+        const json = await response.json()
         throw new Error(json.message ? json.message : "Invalid credentials")
       }
-      return json
     },
     logout: async () => {
       const response = await api.post(`/api/global/auth/logout`)
@@ -196,6 +191,14 @@ export function createAuthStore() {
       }
       await response.json()
     },
+  }
+
+  return {
+    subscribe: store.subscribe,
+    setOrganisation,
+    getInitInfo,
+    setInitInfo,
+    ...actions,
   }
 }
 

--- a/packages/worker/src/api/controllers/global/auth.js
+++ b/packages/worker/src/api/controllers/global/auth.js
@@ -74,10 +74,7 @@ async function authInternal(ctx, user, err = null, info = null) {
 exports.authenticate = async (ctx, next) => {
   return passport.authenticate("local", async (err, user, info) => {
     await authInternal(ctx, user, err, info)
-
-    delete user.token
-
-    ctx.body = { user }
+    ctx.status = 200
   })(ctx, next)
 }
 


### PR DESCRIPTION
## Description
- Update fetch current user to always use the `self` call
- No longer set user information as a result of the `login` call
- This results in consistent experience for SSO and password login
- Prevents small differences between the responses
   - e.g. current login response https://github.com/Budibase/budibase/blob/develop/packages/worker/src/api/controllers/global/auth.js#L75-L81
   - e.g. current self response https://github.com/Budibase/budibase/blob/develop/packages/worker/src/api/controllers/global/users.js#L172-L175 


## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



