### PR TITLE
Some small SQL core fixes

### DIFF
--- a/packages/builder/src/components/backend/DatasourceNavigator/TableIntegrationMenu/PlusConfigForm.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/TableIntegrationMenu/PlusConfigForm.svelte
@@ -188,29 +188,27 @@
 {:else}
   <Body size="S"><i>No tables found.</i></Body>
 {/if}
-{#if plusTables?.length !== 0 && integration.relationships}
-  <Divider size="S" />
-  <div class="query-header">
-    <Heading size="S">Relationships</Heading>
-    <Button primary on:click={openRelationshipModal}>
-      Define relationship
-    </Button>
-  </div>
-  <Body>
-    Tell budibase how your tables are related to get even more smart features.
-  </Body>
-  {#if relationshipInfo && relationshipInfo.length > 0}
-    <Table
-      on:click={({ detail }) => openRelationshipModal(detail.from, detail.to)}
-      schema={relationshipSchema}
-      data={relationshipInfo}
-      allowEditColumns={false}
-      allowEditRows={false}
-      allowSelectRows={false}
-    />
-  {:else}
-    <Body size="S"><i>No relationships configured.</i></Body>
-  {/if}
+<Divider size="S" />
+<div class="query-header">
+  <Heading size="S">Relationships</Heading>
+  <Button primary on:click={() => openRelationshipModal()}>
+    Define relationship
+  </Button>
+</div>
+<Body>
+  Tell budibase how your tables are related to get even more smart features.
+</Body>
+{#if relationshipInfo && relationshipInfo.length > 0}
+  <Table
+    on:click={({ detail }) => openRelationshipModal(detail.from, detail.to)}
+    schema={relationshipSchema}
+    data={relationshipInfo}
+    allowEditColumns={false}
+    allowEditRows={false}
+    allowSelectRows={false}
+  />
+{:else}
+  <Body size="S"><i>No relationships configured.</i></Body>
 {/if}
 
 <style>

--- a/packages/server/scripts/integrations/postgres/init.sql
+++ b/packages/server/scripts/integrations/postgres/init.sql
@@ -9,12 +9,16 @@ CREATE TABLE Persons (
 );
 CREATE TABLE Tasks (
     TaskID SERIAL PRIMARY KEY,
-    PersonID INT,
+    ExecutorID INT,
+    QaID INT,
     Completed BOOLEAN,
     TaskName varchar(255),
-    CONSTRAINT fkPersons
-        FOREIGN KEY(PersonID)
-            REFERENCES Persons(PersonID)
+    CONSTRAINT fkexecutor
+        FOREIGN KEY(ExecutorID)
+            REFERENCES Persons(PersonID),
+    CONSTRAINT fkqa
+        FOREIGN KEY(QaID)
+	    REFERENCES Persons(PersonID)
 );
 CREATE TABLE Products (
     ProductID SERIAL PRIMARY KEY,
@@ -32,8 +36,9 @@ CREATE TABLE Products_Tasks (
     PRIMARY KEY (ProductID, TaskID)
 );
 INSERT INTO Persons (FirstName, LastName, Address, City) VALUES ('Mike', 'Hughes', '123 Fake Street', 'Belfast');
-INSERT INTO Tasks (PersonID, TaskName, Completed) VALUES (1, 'assembling', TRUE);
-INSERT INTO Tasks (PersonID, TaskName, Completed) VALUES (1, 'processing', FALSE);
+INSERT INTO Persons (FirstName, LastName, Address, City) Values ('John', 'Smith', '64 Updown Road', 'Dublin');
+INSERT INTO Tasks (ExecutorID, QaID, TaskName, Completed) VALUES (1, 2, 'assembling', TRUE);
+INSERT INTO Tasks (ExecutorID, QaID, TaskName, Completed) VALUES (2, 1, 'processing', FALSE);
 INSERT INTO Products (ProductName) VALUES ('Computers');
 INSERT INTO Products (ProductName) VALUES ('Laptops');
 INSERT INTO Products (ProductName) VALUES ('Chairs');

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -184,7 +184,7 @@ module External {
     thisRow._id = generateIdForRow(row, table)
     thisRow.tableId = table._id
     thisRow._rev = "rev"
-    return thisRow
+    return processFormulas(table, thisRow)
   }
 
   function fixArrayTypes(row: Row, table: Table) {

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -225,8 +225,8 @@ class InternalBuilder {
           "left"
         )
       } else {
-        // @ts-ignore
         query = query
+          // @ts-ignore
           .join(
             throughTable,
             function () {

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -191,29 +191,70 @@ class InternalBuilder {
     if (!relationships) {
       return query
     }
+    const tableSets: Record<string, [any]> = {}
+    // aggregate into table sets (all the same to tables)
     for (let relationship of relationships) {
-      const from = relationship.from,
-        to = relationship.to,
-        toTable = relationship.tableName
-      if (!relationship.through) {
+      const keyObj: { toTable: string; throughTable: string | undefined } = {
+        toTable: relationship.tableName,
+        throughTable: undefined,
+      }
+      if (relationship.through) {
+        keyObj.throughTable = relationship.through
+      }
+      const key = JSON.stringify(keyObj)
+      if (tableSets[key]) {
+        tableSets[key].push(relationship)
+      } else {
+        tableSets[key] = [relationship]
+      }
+    }
+    for (let [key, relationships] of Object.entries(tableSets)) {
+      const { toTable, throughTable } = JSON.parse(key)
+      if (!throughTable) {
         // @ts-ignore
-        query = query.leftJoin(
+        query = query.join(
           toTable,
-          `${fromTable}.${from}`,
-          `${toTable}.${to}`
+          function () {
+            for (let relationship of relationships) {
+              const from = relationship.from,
+                to = relationship.to
+              // @ts-ignore
+              this.orOn(`${fromTable}.${from}`, "=", `${toTable}.${to}`)
+            }
+          },
+          "left"
         )
       } else {
-        const throughTable = relationship.through
-        const fromPrimary = relationship.fromPrimary
-        const toPrimary = relationship.toPrimary
+        // @ts-ignore
         query = query
-          // @ts-ignore
-          .leftJoin(
+          .join(
             throughTable,
-            `${fromTable}.${fromPrimary}`,
-            `${throughTable}.${from}`
+            function () {
+              for (let relationship of relationships) {
+                const fromPrimary = relationship.fromPrimary
+                const from = relationship.from
+                // @ts-ignore
+                this.orOn(
+                  `${fromTable}.${fromPrimary}`,
+                  "=",
+                  `${throughTable}.${from}`
+                )
+              }
+            },
+            "left"
           )
-          .leftJoin(toTable, `${toTable}.${toPrimary}`, `${throughTable}.${to}`)
+          .join(
+            toTable,
+            function () {
+              for (let relationship of relationships) {
+                const toPrimary = relationship.toPrimary
+                const to = relationship.to
+                // @ts-ignore
+                this.orOn(`${toTable}.${toPrimary}`, `${throughTable}.${to}`)
+              }
+            },
+            "left"
+          )
       }
     }
     return query.limit(BASE_LIMIT)


### PR DESCRIPTION
## Description
Two issues were raised recently, features that weren't supported by Budibase SQL core but should have been:

1. Multiple relationships between the two same tables - this would break Budibase previously, supporting it by changing join syntax - #4255 
2. A quick fix for using formula columns added to SQL tables as the primary display field, making sure it is enriched onto relationships before they are turned into links - #4256.