### PR TITLE
Adding link to self hosting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,14 @@ Budibase is made to scale. With Budibase, you can self-host on your own infrastr
 
 ## 🏁 Get started
 
-<img src="https://res.cloudinary.com/daog6scxm/image/upload/v1634808888/logo/deploy_npl9za.png" />
+<a href="https://docs.budibase.com/self-hosting/self-host"><img src="https://res.cloudinary.com/daog6scxm/image/upload/v1634808888/logo/deploy_npl9za.png" /></a>
 
-Deploy Budibase self-Hosted in your existing infrastructure, using Docker, Kubernetes, and Digital Ocean.
+Deploy Budibase self-hosted in your existing infrastructure, using Docker, Kubernetes, and Digital Ocean.
 Or use Budibase Cloud if you don't need to self-host, and would like to get started quickly.
 
-### [Get started with Budibase](https://budibase.com)
+### [Get started with self-hosting Budibase](https://docs.budibase.com/self-hosting/self-host)
+
+### [Get started with Budibase Cloud](https://budibase.com)
 
 
 <br /><br />


### PR DESCRIPTION
I was expecting to get to the self hosting documentation when clicking on the docker, kubernetes image. Also a link to the self hosting documentation is missing here.

## Description
_Describe the problem or feature in addition to a link to the relevant github issues._

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



