### PR TITLE
Relationship field default value

### DIFF
--- a/packages/bbui/src/Table/InternalRenderer.svelte
+++ b/packages/bbui/src/Table/InternalRenderer.svelte
@@ -8,10 +8,35 @@
     copyToClipboard(value)
   }
 
-  function copyToClipboard(value) {
-    navigator.clipboard.writeText(value).then(() => {
-      notifications.success("Copied")
+  const copyToClipboard = value => {
+    return new Promise(res => {
+      if (navigator.clipboard && window.isSecureContext) {
+        // Try using the clipboard API first
+        navigator.clipboard.writeText(value).then(res)
+      } else {
+        // Fall back to the textarea hack
+        let textArea = document.createElement("textarea")
+        textArea.value = value
+        textArea.style.position = "fixed"
+        textArea.style.left = "-9999px"
+        textArea.style.top = "-9999px"
+        document.body.appendChild(textArea)
+        textArea.focus()
+        textArea.select()
+        document.execCommand("copy")
+        textArea.remove()
+        res()
+      }
     })
+      .then(() => {
+        notifications.success("Copied to clipboard")
+      })
+      .catch(() => {
+        notifications.error(
+          "Failed to copy to clipboard. Check the dev console for the value."
+        )
+        console.warn("Failed to copy the value", value)
+      })
   }
 </script>
 

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -2538,6 +2538,11 @@
         "key": "placeholder"
       },
       {
+        "type": "text",
+        "label": "Default value",
+        "key": "defaultValue"
+      },
+      {
         "type": "boolean",
         "label": "Autocomplete",
         "key": "autocomplete",

--- a/packages/client/src/components/app/forms/RelationshipField.svelte
+++ b/packages/client/src/components/app/forms/RelationshipField.svelte
@@ -12,6 +12,7 @@
   export let disabled = false
   export let validation
   export let autocomplete = false
+  export let defaultValue
 
   let fieldState
   let fieldApi
@@ -27,6 +28,7 @@
   $: singleValue = flatten(fieldState?.value)?.[0]
   $: multiValue = flatten(fieldState?.value) ?? []
   $: component = multiselect ? CoreMultiselect : CoreSelect
+  $: expandedDefaultValue = expand(defaultValue)
 
   const fetchTable = async id => {
     if (id) {
@@ -62,6 +64,16 @@
   const multiHandler = e => {
     fieldApi.setValue(e.detail)
   }
+
+  const expand = values => {
+    if (!values) {
+      return []
+    }
+    if (Array.isArray(values)) {
+      return values
+    }
+    return values.split(",").map(value => value.trim())
+  }
 </script>
 
 <Field
@@ -69,11 +81,11 @@
   {field}
   {disabled}
   {validation}
+  defaultValue={expandedDefaultValue}
   type={FieldTypes.LINK}
   bind:fieldState
   bind:fieldApi
   bind:fieldSchema
-  defaultValue={[]}
 >
   {#if fieldState}
     <svelte:component


### PR DESCRIPTION
## Description
This PR adds a default value setting for relationship fields as raised in https://github.com/Budibase/budibase/issues/4320. It also fixes the clipboard functionality for copying IDs to the clipboard in the data UI, which previously depended on the clipboard API which depends on a secure context.

The relationship field default value works for both internal tables and SQL.
The relationship field default value needs to use Budibase row IDs rather than actual SQL IDs. This might trip people up. 

The value format can be any of:
- (HBS or JS) a single ID
- (HBS or JS) multiple IDs separated by commas (spaces optional)
- (JS) a literal array of IDs

New default value setting for a SQL datasource with 2 rows pre-selected:
![image](https://user-images.githubusercontent.com/9075550/152500107-e2f71c44-5d1c-4f85-b844-2efe64709095.png)



