### PR TITLE
Reset the builder store whenever unmounting the app root layout

### DIFF
--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -65,6 +65,9 @@ export const getFrontendStore = () => {
   const store = writable({ ...INITIAL_FRONTEND_STATE })
 
   store.actions = {
+    reset: () => {
+      store.set({ ...INITIAL_FRONTEND_STATE })
+    },
     initialise: async pkg => {
       const { layouts, screens, application, clientLibPath } = pkg
       const components = await fetchComponentLibDefinitions(application.appId)

--- a/packages/builder/src/pages/builder/app/[application]/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/_layout.svelte
@@ -12,7 +12,7 @@
   import Logo from "assets/bb-emblem.svg"
   import { capitalise } from "helpers"
   import UpgradeModal from "../../../../components/upgrade/UpgradeModal.svelte"
-  import { onMount } from "svelte"
+  import { onMount, onDestroy } from "svelte"
 
   // Get Package and set store
   export let application
@@ -80,6 +80,10 @@
       }
       hasSynced = true
     }
+  })
+
+  onDestroy(() => {
+    store.actions.reset()
   })
 </script>
 


### PR DESCRIPTION
## Description
Resets the builder store whenever the root app layout is unmounted. This means whenever changing apps in the builder, we properly reset state and don't hang on to any extra stale values.

The problem with stale data was highlighted by the fact we were sending up the app ID of the previously opened app in the call to fetch the app package,


