### PR TITLE
POC Pipelines (temp for testing)

### DIFF
--- a/.github/workflows/pro-release-develop.yml
+++ b/.github/workflows/pro-release-develop.yml
@@ -1,0 +1,47 @@
+name: Budibase Release Staging (Pro)
+
+#  Temporary pipeline - eventualy this will be merged with the regular one
+
+on:
+  push:
+    branches:
+      - pro-develop
+    paths:
+      - ".aws/**"
+      - ".github/**"
+      - "charts/**"
+      - "packages/**"
+      - "scripts/**"
+      - "package.json"
+      - "yarn.lock"
+      - "package.json"
+      - "yarn.lock"
+
+env:
+  POSTHOG_TOKEN: ${{ secrets.POSTHOG_TOKEN }}
+  INTERCOM_TOKEN: ${{ secrets.INTERCOM_TOKEN }}
+  POSTHOG_URL: ${{ secrets.POSTHOG_URL }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - run: yarn
+      - run: yarn bootstrap
+      - run: yarn lint
+      - run: yarn build
+      - run: yarn test
+
+      - name: Build/release Docker images (Pro)
+        run: |
+          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+          yarn build:docker:develop:pro
+          yarn release:docker:pro develop
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}

--- a/.github/workflows/pro-release-selfhost.yml
+++ b/.github/workflows/pro-release-selfhost.yml
@@ -1,0 +1,37 @@
+name: Budibase Release Selfhost (Pro)
+
+#  Temporary pipeline - eventualy this will be merged with the regular one
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          node-version: 14.x
+          fetch_depth: 0
+
+      - name: Tag and release Docker images (Pro) (Self Host)
+        run: |
+          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+          # Get latest release version
+          release_version=$(cat lerna.json | jq -r '.version')
+          echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
+          release_tag=v$release_version
+          # Pull apps and worker images
+          docker pull budibase/apps-pro:$release_tag
+          docker pull budibase/worker-pro:$release_tag
+          # Tag apps and worker images
+          docker tag budibase/apps-pro:$release_tag budibase/apps-pro:$SELFHOST_TAG
+          docker tag budibase/worker-pro:$release_tag budibase/worker-pro:$SELFHOST_TAG
+          # Push images
+          docker push budibase/apps-pro:$SELFHOST_TAG
+          docker push budibase/worker-pro:$SELFHOST_TAG
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}
+          SELFHOST_TAG: latest

--- a/.github/workflows/pro-release.yml
+++ b/.github/workflows/pro-release.yml
@@ -1,0 +1,53 @@
+name: Budibase Release (Pro)
+
+#  Temporary pipeline - eventualy this will be merged with the regular one
+
+on:
+  push:
+    branches:
+      - pro-master
+    paths:
+      - ".aws/**"
+      - ".github/**"
+      - "charts/**"
+      - "packages/**"
+      - "scripts/**"
+      - "package.json"
+      - "yarn.lock"
+      - "package.json"
+      - "yarn.lock"
+
+env:
+  POSTHOG_TOKEN: ${{ secrets.POSTHOG_TOKEN }}
+  INTERCOM_TOKEN: ${{ secrets.INTERCOM_TOKEN }}
+  POSTHOG_URL: ${{ secrets.POSTHOG_URL }}
+  SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - run: yarn
+      - run: yarn bootstrap
+      - run: yarn lint
+      - run: yarn build
+      - run: yarn test
+
+      - name: "Get Previous tag"
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+
+      - name: Build/release Docker images
+        run: |
+          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+          yarn build:docker:pro
+          yarn release:docker:pro ${BUDIBASE_RELEASE_VERSION}
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}
+          BUDIBASE_RELEASE_VERSION: ${{ steps.previoustag.outputs.tag }}


### PR DESCRIPTION
## Description
Some separate pipelines for testing out the pro docker builds 
These are targeted `pro-master` and `pro-develop` and use new image names so they can be tested in isolation

Pipelines copied from the work so far in this branch
https://github.com/Budibase/budibase/compare/licensing-poc?expand=1
which will be merged to the branches mentioned above

Main changes are
- Add import for `@budibase/pro` to server
- Import by default pulls the public pro package from npm 
   - e.g. https://www.npmjs.com/package/@budibase/pro/v/0.0.2-alpha.27
   - This package has types only and no source implementation
   - This enables imports to work without having to wrap with conditionals and therefore force the use of `require` (no autocomplete)
- The pro docker build will pull the sources from the matching github release on the pro repo
   - e.g. https://github.com/Budibase/budibase-pro/releases/tag/v0.0.2-alpha.27
   - This is injected manually in place of the no sources version 
   

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



