### PR TITLE
Fix for SQL Server - fix pagination issue

### DIFF
--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/SearchFieldSelect.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/SearchFieldSelect.svelte
@@ -25,7 +25,7 @@
       return base
     }
     const currentTable = $tables.list.find(table => table._id === ds.tableId)
-    return getFields(base, { allowLinks: currentTable.sql }).map(
+    return getFields(base, { allowLinks: currentTable?.sql }).map(
       field => field.name
     )
   }

--- a/packages/server/scripts/integrations/mssql/data/Dockerfile
+++ b/packages/server/scripts/integrations/mssql/data/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/mssql/server
+FROM mcr.microsoft.com/mssql/server:2017-latest
 
 ENV ACCEPT_EULA=Y
 ENV SA_PASSWORD=Passw0rd

--- a/packages/server/scripts/integrations/mssql/data/setup.sql
+++ b/packages/server/scripts/integrations/mssql/data/setup.sql
@@ -48,7 +48,20 @@ INSERT tasks
 VALUES
   ('Processing', 1);
 
-INSERT people
-  (name, age)
-VALUES
-  ('Bob', '30');
+INSERT INTO people (name, age)
+VALUES ('Bob', '30'),
+  ('Bert', '10'),
+  ('Jack', '12'),
+  ('Mike', '31'),
+  ('Dave', '44'),
+  ('Jim', '43'),
+  ('Kerry', '32'),
+  ('Julie', '12'),
+  ('Kim', '55'),
+  ('Andy', '33'),
+  ('John', '22'),
+  ('Ruth', '66'),
+  ('Robert', '88'),
+  ('Bobert', '99'),
+  ('Jan', '22'),
+  ('Megan', '11');

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -166,15 +166,13 @@ class InternalBuilder {
 
   addSorting(query: KnexQuery, json: QueryJson): KnexQuery {
     let { sort, paginate } = json
-    if (!sort) {
-      return query
-    }
     const table = json.meta?.table
-    for (let [key, value] of Object.entries(sort)) {
-      const direction = value === SortDirection.ASCENDING ? "asc" : "desc"
-      query = query.orderBy(`${table?.name}.${key}`, direction)
-    }
-    if (this.client === SqlClients.MS_SQL && !sort && paginate?.limit) {
+    if (sort) {
+      for (let [key, value] of Object.entries(sort)) {
+        const direction = value === SortDirection.ASCENDING ? "asc" : "desc"
+        query = query.orderBy(`${table?.name}.${key}`, direction)
+      }
+    } else if (this.client === SqlClients.MS_SQL && paginate?.limit) {
       // @ts-ignore
       query = query.orderBy(`${table?.name}.${table?.primary[0]}`)
     }


### PR DESCRIPTION
## Description
This is a quick fix for the pagination issue in SQL Server, after testing this in a few different versions I found that we could simply force Knex to search on the primary key, which would allow pagination to work correctly for older SQL Server versions.

This resolves the issue that many people have seen such as `invalid use of "FETCH" ...`.

Issue #3928
and
Discussed #3883