### PR TITLE
Remove automatic dismissal of error notifications

### DIFF
--- a/packages/bbui/src/Notification/Notification.svelte
+++ b/packages/bbui/src/Notification/Notification.svelte
@@ -1,7 +1,12 @@
 <script>
+  import { createEventDispatcher } from "svelte"
+
   export let type = "info"
   export let icon = "Info"
   export let message = ""
+  export let dismissable = false
+
+  const dispatch = createEventDispatcher()
 </script>
 
 <div class="spectrum-Toast spectrum-Toast--{type}">
@@ -17,4 +22,28 @@
   <div class="spectrum-Toast-body">
     <div class="spectrum-Toast-content">{message || ""}</div>
   </div>
+  {#if dismissable}
+    <div class="spectrum-Toast-buttons">
+      <button
+        class="spectrum-ClearButton spectrum-ClearButton--overBackground spectrum-ClearButton--sizeM"
+        on:click={() => dispatch("dismiss")}
+      >
+        <div class="spectrum-ClearButton-fill">
+          <svg
+            class="spectrum-ClearButton-icon spectrum-Icon spectrum-UIIcon-Cross100"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <use xlink:href="#spectrum-css-icon-Cross100" />
+          </svg>
+        </div>
+      </button>
+    </div>
+  {/if}
 </div>
+
+<style>
+  .spectrum-Toast {
+    pointer-events: all;
+  }
+</style>

--- a/packages/bbui/src/Notification/NotificationDisplay.svelte
+++ b/packages/bbui/src/Notification/NotificationDisplay.svelte
@@ -1,7 +1,6 @@
 <script>
   import "@spectrum-css/toast/dist/index-vars.css"
   import Portal from "svelte-portal"
-  import { flip } from "svelte/animate"
   import { notifications } from "../Stores/notifications"
   import Notification from "./Notification.svelte"
   import { fly } from "svelte/transition"
@@ -9,9 +8,15 @@
 
 <Portal target=".modal-container">
   <div class="notifications">
-    {#each $notifications as { type, icon, message, id } (id)}
-      <div animate:flip transition:fly={{ y: -30 }}>
-        <Notification {type} {icon} {message} />
+    {#each $notifications as { type, icon, message, id, dismissable } (id)}
+      <div transition:fly={{ y: -30 }}>
+        <Notification
+          {type}
+          {icon}
+          {message}
+          {dismissable}
+          on:dismiss={() => notifications.dismiss(id)}
+        />
       </div>
     {/each}
   </div>

--- a/packages/bbui/src/Stores/notifications.js
+++ b/packages/bbui/src/Stores/notifications.js
@@ -20,15 +20,18 @@ export const createNotificationStore = () => {
     setTimeout(() => (block = false), timeout)
   }
 
-  const send = (message, type = "default", icon = "", timeout = true) => {
+  const send = (message, type = "default", icon = "", autoDismiss = true) => {
     if (block) {
       return
     }
     let _id = id()
     _notifications.update(state => {
-      return [...state, { id: _id, type, message, icon, dismissable: !timeout }]
+      return [
+        ...state,
+        { id: _id, type, message, icon, dismissable: !autoDismiss },
+      ]
     })
-    if (timeout) {
+    if (autoDismiss) {
       const timeoutId = setTimeout(() => {
         dismissNotification(_id)
       }, NOTIFICATION_TIMEOUT)

--- a/packages/client/src/components/overlay/NotificationDisplay.svelte
+++ b/packages/client/src/components/overlay/NotificationDisplay.svelte
@@ -19,6 +19,8 @@
           type={$notificationStore.type}
           message={$notificationStore.message}
           icon={$notificationStore.icon}
+          dismissable={$notificationStore.dismissable}
+          on:dismiss={notificationStore.actions.dismiss}
         />
       </div>
     {/key}

--- a/packages/client/src/components/overlay/PeekScreenDisplay.svelte
+++ b/packages/client/src/components/overlay/PeekScreenDisplay.svelte
@@ -25,8 +25,8 @@
   }
 
   const proxyNotification = event => {
-    const { message, type, icon } = event.detail
-    notificationStore.actions.send(message, type, icon)
+    const { message, type, icon, autoDismiss } = event.detail
+    notificationStore.actions.send(message, type, icon, autoDismiss)
   }
 
   const proxyStateUpdate = event => {

--- a/packages/client/src/stores/notification.js
+++ b/packages/client/src/stores/notification.js
@@ -19,7 +19,7 @@ const createNotificationStore = () => {
     setTimeout(() => (block = false), timeout)
   }
 
-  const send = (message, type = "info", icon) => {
+  const send = (message, type = "info", icon, autoDismiss = true) => {
     if (block) {
       return
     }
@@ -32,6 +32,7 @@ const createNotificationStore = () => {
           message,
           type,
           icon,
+          autoDismiss,
         },
       })
       return
@@ -42,12 +43,20 @@ const createNotificationStore = () => {
       type,
       message,
       icon,
+      dismissable: !autoDismiss,
       delay: get(store) != null,
     })
     clearTimeout(timeout)
-    timeout = setTimeout(() => {
-      store.set(null)
-    }, NOTIFICATION_TIMEOUT)
+    if (autoDismiss) {
+      timeout = setTimeout(() => {
+        store.set(null)
+      }, NOTIFICATION_TIMEOUT)
+    }
+  }
+
+  const dismiss = () => {
+    clearTimeout(timeout)
+    store.set(null)
   }
 
   return {
@@ -57,8 +66,9 @@ const createNotificationStore = () => {
       info: msg => send(msg, "info", "Info"),
       success: msg => send(msg, "success", "CheckmarkCircle"),
       warning: msg => send(msg, "warning", "Alert"),
-      error: msg => send(msg, "error", "Alert"),
+      error: msg => send(msg, "error", "Alert", false),
       blockNotifications,
+      dismiss,
     },
   }
 }


### PR DESCRIPTION
## Description
This PR prevents error notifications from being automatically dismissed, both in the builder and in client apps.

In the builder we can show multiple notifications as once, in a vertical list. Error notifications behave normally and move as normal, but have an X icon to manually dismiss them and they will not be automatically removed. Non-error notifications do not have this X icon, and can not be manually dismissed.

Client apps can only show one notification at once, but behave exactly the same as the new builder notifications.

The new error notifications look like this - the only change being the X icon indicating it needs to be manually dismissed:
![image](https://user-images.githubusercontent.com/9075550/152818063-7899bfff-3359-4df6-9c3a-12c2923cff9f.png)

Addresses #3739.

