### PR TITLE
Fix validation for query preview endpoint

### DIFF
--- a/packages/server/src/api/controllers/query/validation.js
+++ b/packages/server/src/api/controllers/query/validation.js
@@ -33,6 +33,9 @@ exports.generateQueryPreviewValidation = () => {
   return joiValidator.body(Joi.object({
     fields: Joi.object().required(),
     queryVerb: Joi.string().allow().required(),
+    name: Joi.string().required(),
+    flags: Joi.object().optional(),
+    schema: Joi.object().optional(),
     extra: Joi.object().optional(),
     datasourceId: Joi.string().required(),
     transformer: Joi.string().optional(),

--- a/packages/server/src/api/controllers/query/validation.js
+++ b/packages/server/src/api/controllers/query/validation.js
@@ -31,6 +31,9 @@ exports.generateQueryValidation = () => {
 exports.generateQueryPreviewValidation = () => {
   // prettier-ignore
   return joiValidator.body(Joi.object({
+    _id: Joi.string().optional(),
+    _rev: Joi.string().optional(),
+    readable: Joi.boolean().optional(),
     fields: Joi.object().required(),
     queryVerb: Joi.string().allow().required(),
     name: Joi.string().required(),

--- a/packages/server/src/api/routes/tests/query.spec.js
+++ b/packages/server/src/api/routes/tests/query.spec.js
@@ -169,6 +169,7 @@ describe("/queries", () => {
           parameters: {},
           fields: {},
           queryVerb: "read",
+          name: datasource.name,
         })
         .set(config.defaultHeaders())
         .expect("Content-Type", /json/)
@@ -261,9 +262,13 @@ describe("/queries", () => {
     })
 
     it("check that it automatically retries on fail with cached dynamics", async () => {
-      const { datasource, query: base } = await config.dynamicVariableDatasource()
+      const { datasource, query: base } =
+        await config.dynamicVariableDatasource()
       // preview once to cache
-      await preview(datasource, { path: "www.google.com", queryString: "test={{ variable3 }}" })
+      await preview(datasource, {
+        path: "www.google.com",
+        queryString: "test={{ variable3 }}",
+      })
       // check its in cache
       const contents = await checkCacheForDynamicVariable(base._id, "variable3")
       expect(contents.rows.length).toEqual(1)
@@ -276,9 +281,13 @@ describe("/queries", () => {
     })
 
     it("deletes variables when linked query is deleted", async () => {
-      const { datasource, query: base } = await config.dynamicVariableDatasource()
+      const { datasource, query: base } =
+        await config.dynamicVariableDatasource()
       // preview once to cache
-      await preview(datasource, { path: "www.google.com", queryString: "test={{ variable3 }}" })
+      await preview(datasource, {
+        path: "www.google.com",
+        queryString: "test={{ variable3 }}",
+      })
       // check its in cache
       let contents = await checkCacheForDynamicVariable(base._id, "variable3")
       expect(contents.rows.length).toEqual(1)

--- a/packages/server/src/tests/utilities/TestConfiguration.js
+++ b/packages/server/src/tests/utilities/TestConfiguration.js
@@ -393,6 +393,7 @@ class TestConfiguration {
         parameters: {},
         fields,
         queryVerb: "read",
+        name: datasource.name,
       })
       .set(config.defaultHeaders())
       .expect("Content-Type", /json/)


### PR DESCRIPTION
## Description
It is currently not possible to preview a REST query, it throws errors because the validation is missing three fields. This PR fixes that.

Fixes #4413

