### PR TITLE
Fix for joins in SQL tables

### DIFF
--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -541,7 +541,7 @@ module External {
         if (!linkTable || !linkPrimary) {
           return
         }
-        const rows = related[key].rows || []
+        const rows = related[key]?.rows || []
         const found = rows.find(
           (row: { [key: string]: any }) =>
             row[linkPrimary] === relationship.id ||

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -210,49 +210,37 @@ class InternalBuilder {
       const { toTable, throughTable } = JSON.parse(key)
       if (!throughTable) {
         // @ts-ignore
-        query = query.join(
-          toTable,
-          function () {
-            for (let relationship of relationships) {
-              const from = relationship.from,
-                to = relationship.to
-              // @ts-ignore
-              this.orOn(`${fromTable}.${from}`, "=", `${toTable}.${to}`)
-            }
-          },
-          "left"
-        )
+        query = query.leftJoin(toTable, function () {
+          for (let relationship of relationships) {
+            const from = relationship.from,
+              to = relationship.to
+            // @ts-ignore
+            this.orOn(`${fromTable}.${from}`, "=", `${toTable}.${to}`)
+          }
+        })
       } else {
         query = query
           // @ts-ignore
-          .join(
-            throughTable,
-            function () {
-              for (let relationship of relationships) {
-                const fromPrimary = relationship.fromPrimary
-                const from = relationship.from
-                // @ts-ignore
-                this.orOn(
-                  `${fromTable}.${fromPrimary}`,
-                  "=",
-                  `${throughTable}.${from}`
-                )
-              }
-            },
-            "left"
-          )
-          .join(
-            toTable,
-            function () {
-              for (let relationship of relationships) {
-                const toPrimary = relationship.toPrimary
-                const to = relationship.to
-                // @ts-ignore
-                this.orOn(`${toTable}.${toPrimary}`, `${throughTable}.${to}`)
-              }
-            },
-            "left"
-          )
+          .leftJoin(throughTable, function () {
+            for (let relationship of relationships) {
+              const fromPrimary = relationship.fromPrimary
+              const from = relationship.from
+              // @ts-ignore
+              this.orOn(
+                `${fromTable}.${fromPrimary}`,
+                "=",
+                `${throughTable}.${from}`
+              )
+            }
+          })
+          .leftJoin(toTable, function () {
+            for (let relationship of relationships) {
+              const toPrimary = relationship.toPrimary
+              const to = relationship.to
+              // @ts-ignore
+              this.orOn(`${toTable}.${toPrimary}`, `${throughTable}.${to}`)
+            }
+          })
       }
     }
     return query.limit(BASE_LIMIT)


### PR DESCRIPTION
## Description
Fix for #4431 - converting SQL joins back to left joins, syntax specifying join type as string is old which doesn't work in latest versions of Knex.