### PR TITLE
Fix for query preview validation 

### DIFF
--- a/packages/bbui/src/ButtonGroup/ButtonGroup.svelte
+++ b/packages/bbui/src/ButtonGroup/ButtonGroup.svelte
@@ -1,6 +1,16 @@
 <script>
   import "@spectrum-css/buttongroup/dist/index-vars.css"
   export let vertical = false
+  export let gap = ""
+
+  $: gapStyle =
+    gap === "L"
+      ? "var(--spacing-l)"
+      : gap === "M"
+      ? "var(--spacing-m)"
+      : gap === "S"
+      ? "var(--spacing-s)"
+      : null
 
   function group(element) {
     const buttons = Array.from(element.getElementsByTagName("button"))
@@ -14,6 +24,7 @@
   use:group
   class="spectrum-ButtonGroup"
   class:spectrum-ButtonGroup--vertical={vertical}
+  style={gapStyle ? `gap: ${gapStyle};` : null}
 >
   <slot />
 </div>

--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -39,7 +39,7 @@
   $: datasource = $datasources.list.find(ds => ds._id === query.datasourceId)
   $: query.schema = fieldsToSchema(fields)
   $: datasourceType = datasource?.source
-  $: integrationInfo = $integrations[datasourceType]
+  $: integrationInfo = datasourceType ? $integrations[datasourceType] : null
   $: queryConfig = integrationInfo?.query
   $: shouldShowQueryConfig = queryConfig && query.queryVerb
   $: readQuery = query.queryVerb === "read" || query.readable
@@ -160,7 +160,7 @@
     </div>
     <div class="viewer-controls">
       <Heading size="S">Results</Heading>
-      <ButtonGroup>
+      <ButtonGroup gap="M">
         <Button cta disabled={queryInvalid} on:click={saveQuery}>
           Save Query
         </Button>

--- a/packages/server/src/api/controllers/query/validation.js
+++ b/packages/server/src/api/controllers/query/validation.js
@@ -1,6 +1,8 @@
 const joiValidator = require("../../../middleware/joi-validator")
 const Joi = require("joi")
 
+const OPTIONAL_STRING = Joi.string().optional().allow(null).allow("")
+
 exports.queryValidation = () => {
   return Joi.object({
     _id: Joi.string(),
@@ -18,7 +20,7 @@ exports.queryValidation = () => {
     queryVerb: Joi.string().allow().required(),
     extra: Joi.object().optional(),
     schema: Joi.object({}).required().unknown(true),
-    transformer: Joi.string().optional(),
+    transformer: OPTIONAL_STRING,
     flags: Joi.object().optional(),
   })
 }
@@ -31,18 +33,18 @@ exports.generateQueryValidation = () => {
 exports.generateQueryPreviewValidation = () => {
   // prettier-ignore
   return joiValidator.body(Joi.object({
-    _id: Joi.string().optional(),
-    _rev: Joi.string().optional(),
+    _id: OPTIONAL_STRING,
+    _rev: OPTIONAL_STRING,
     readable: Joi.boolean().optional(),
     fields: Joi.object().required(),
-    queryVerb: Joi.string().allow().required(),
-    name: Joi.string().required(),
+    queryVerb: Joi.string().required(),
+    name: OPTIONAL_STRING,
     flags: Joi.object().optional(),
     schema: Joi.object().optional(),
     extra: Joi.object().optional(),
     datasourceId: Joi.string().required(),
-    transformer: Joi.string().optional(),
+    transformer: OPTIONAL_STRING,
     parameters: Joi.object({}).required().unknown(true),
-    queryId: Joi.string().optional(),
+    queryId: OPTIONAL_STRING,
   }))
 }

--- a/packages/server/src/api/controllers/query/validation.js
+++ b/packages/server/src/api/controllers/query/validation.js
@@ -33,6 +33,9 @@ exports.generateQueryPreviewValidation = () => {
   return joiValidator.body(Joi.object({
     fields: Joi.object().required(),
     queryVerb: Joi.string().allow().required(),
+    name: Joi.string().required(),
+    flags: Joi.object().optional(),
+    schema: Joi.object().optional(),
     extra: Joi.object().optional(),
     datasourceId: Joi.string().required(),
     transformer: Joi.string().optional(),

--- a/packages/server/src/api/controllers/query/validation.js
+++ b/packages/server/src/api/controllers/query/validation.js
@@ -31,6 +31,9 @@ exports.generateQueryValidation = () => {
 exports.generateQueryPreviewValidation = () => {
   // prettier-ignore
   return joiValidator.body(Joi.object({
+    _id: Joi.string().optional(),
+    _rev: Joi.string().optional(),
+    readable: Joi.boolean().optional(),
     fields: Joi.object().required(),
     queryVerb: Joi.string().allow().required(),
     name: Joi.string().required(),

--- a/packages/server/src/api/routes/tests/query.spec.js
+++ b/packages/server/src/api/routes/tests/query.spec.js
@@ -169,6 +169,7 @@ describe("/queries", () => {
           parameters: {},
           fields: {},
           queryVerb: "read",
+          name: datasource.name,
         })
         .set(config.defaultHeaders())
         .expect("Content-Type", /json/)
@@ -261,9 +262,13 @@ describe("/queries", () => {
     })
 
     it("check that it automatically retries on fail with cached dynamics", async () => {
-      const { datasource, query: base } = await config.dynamicVariableDatasource()
+      const { datasource, query: base } =
+        await config.dynamicVariableDatasource()
       // preview once to cache
-      await preview(datasource, { path: "www.google.com", queryString: "test={{ variable3 }}" })
+      await preview(datasource, {
+        path: "www.google.com",
+        queryString: "test={{ variable3 }}",
+      })
       // check its in cache
       const contents = await checkCacheForDynamicVariable(base._id, "variable3")
       expect(contents.rows.length).toEqual(1)
@@ -276,9 +281,13 @@ describe("/queries", () => {
     })
 
     it("deletes variables when linked query is deleted", async () => {
-      const { datasource, query: base } = await config.dynamicVariableDatasource()
+      const { datasource, query: base } =
+        await config.dynamicVariableDatasource()
       // preview once to cache
-      await preview(datasource, { path: "www.google.com", queryString: "test={{ variable3 }}" })
+      await preview(datasource, {
+        path: "www.google.com",
+        queryString: "test={{ variable3 }}",
+      })
       // check its in cache
       let contents = await checkCacheForDynamicVariable(base._id, "variable3")
       expect(contents.rows.length).toEqual(1)

--- a/packages/server/src/tests/utilities/TestConfiguration.js
+++ b/packages/server/src/tests/utilities/TestConfiguration.js
@@ -393,6 +393,7 @@ class TestConfiguration {
         parameters: {},
         fields,
         queryVerb: "read",
+        name: datasource.name,
       })
       .set(config.defaultHeaders())
       .expect("Content-Type", /json/)


### PR DESCRIPTION
## Description
This fixes the validation in the released version for query preview, e.g. SQL queries. There was some problems with the validation using the new method of API request.

This issue has been mentioned in #4440 and #4431.

Also fixed an issue with button group being close together, no gap attribute, allowed it to be added so not to risk causing issues elsewhere.