### PR TITLE
Remount button action components fully

### DIFF
--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ButtonActionEditor/ButtonActionDrawer.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ButtonActionEditor/ButtonActionDrawer.svelte
@@ -126,13 +126,15 @@
   </Layout>
   <Layout noPadding>
     {#if selectedActionComponent}
-      <div class="selected-action-container">
-        <svelte:component
-          this={selectedActionComponent}
-          parameters={selectedAction.parameters}
-          bindings={allBindings}
-        />
-      </div>
+      {#key selectedAction.id}
+        <div class="selected-action-container">
+          <svelte:component
+            this={selectedActionComponent}
+            parameters={selectedAction.parameters}
+            bindings={allBindings}
+          />
+        </div>
+      {/key}
     {/if}
   </Layout>
 </DrawerContent>


### PR DESCRIPTION
## Description
This PR fixes a UI issue where button action components can sometimes show stale data due to not fully remounting when changing step.

This is descibed in https://github.com/Budibase/budibase/discussions/4461, but the actual issue was only visual and the data being saved to the rows was always correct.



