### PR TITLE
Replace all spaces with underscores in column names

### DIFF
--- a/packages/server/src/api/controllers/row/internalSearch.js
+++ b/packages/server/src/api/controllers/row/internalSearch.js
@@ -235,7 +235,7 @@ class QueryBuilder {
     if (this.sort) {
       const order = this.sortOrder === "descending" ? "-" : ""
       const type = `<${this.sortType}>`
-      body.sort = `${order}${this.sort.replace(/ /, "_")}${type}`
+      body.sort = `${order}${this.sort.replace(/ /g, "_")}${type}`
     }
     return body
   }

--- a/packages/server/src/db/views/staticViews.js
+++ b/packages/server/src/db/views/staticViews.js
@@ -96,7 +96,7 @@ exports.createAllSearchIndex = async () => {
       function idx(input, prev) {
         for (let key of Object.keys(input)) {
           let idxKey = prev != null ? `${prev}.${key}` : key
-          idxKey = idxKey.replace(/ /, "_")
+          idxKey = idxKey.replace(/ /g, "_")
           if (Array.isArray(input[key])) {
             for (let val of input[key]) {
               if (typeof val !== "object") {


### PR DESCRIPTION
## Description
This PR fixes an issue reported in https://github.com/Budibase/budibase/issues/4449, where only the first space in column names was being replaced for the search index, due to us not using a global regex.


