### PR TITLE
Table column config

### DIFF
--- a/packages/bbui/src/Drawer/Drawer.svelte
+++ b/packages/bbui/src/Drawer/Drawer.svelte
@@ -74,4 +74,12 @@
     align-items: flex-start;
     gap: var(--spacing-xs);
   }
+
+  .buttons {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    gap: var(--spacing-m);
+  }
 </style>

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ColumnEditor/ColumnDrawer.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ColumnEditor/ColumnDrawer.svelte
@@ -7,6 +7,7 @@
     Input,
     Select,
     Label,
+    Body,
   } from "@budibase/bbui"
   import { flip } from "svelte/animate"
   import { dndzone } from "svelte-dnd-action"
@@ -59,59 +60,81 @@
     updateColumnOrder(e)
     dragDisabled = true
   }
+
+  const reset = () => {
+    columns = options.map(col => ({
+      name: col,
+      displayName: col,
+    }))
+  }
 </script>
 
 <DrawerContent>
   <div class="container">
     <Layout noPadding gap="S">
       {#if columns?.length}
-        <div
-          class="columns"
-          use:dndzone={{
-            items: columns,
-            flipDurationMs,
-            dropTargetStyle: { outline: "none" },
-            dragDisabled,
-          }}
-          on:finalize={handleFinalize}
-          on:consider={updateColumnOrder}
-        >
+        <Layout noPadding gap="XS">
           <div class="column">
             <div />
             <Label size="L">Column</Label>
             <Label size="L">Label</Label>
             <div />
           </div>
-          {#each columns as column (column.id)}
-            <div class="column" animate:flip={{ duration: flipDurationMs }}>
-              <div
-                class="handle"
-                aria-label="drag-handle"
-                style={dragDisabled ? "cursor: grab" : "cursor: grabbing"}
-                on:mousedown={() => (dragDisabled = false)}
-              >
-                <Icon name="DragHandle" size="XL" />
+          <div
+            class="columns"
+            use:dndzone={{
+              items: columns,
+              flipDurationMs,
+              dropTargetStyle: { outline: "none" },
+              dragDisabled,
+            }}
+            on:finalize={handleFinalize}
+            on:consider={updateColumnOrder}
+          >
+            {#each columns as column (column.id)}
+              <div class="column" animate:flip={{ duration: flipDurationMs }}>
+                <div
+                  class="handle"
+                  aria-label="drag-handle"
+                  style={dragDisabled ? "cursor: grab" : "cursor: grabbing"}
+                  on:mousedown={() => (dragDisabled = false)}
+                >
+                  <Icon name="DragHandle" size="XL" />
+                </div>
+                <Select
+                  bind:value={column.name}
+                  placeholder="Column"
+                  options={getRemainingColumnOptions(column.name)}
+                  on:change={e => (column.displayName = e.detail)}
+                />
+                <Input bind:value={column.displayName} placeholder="Label" />
+                <Icon
+                  name="Close"
+                  hoverable
+                  size="S"
+                  on:click={() => removeColumn(column.id)}
+                  disabled={columns.length === 1}
+                />
               </div>
-              <Select
-                bind:value={column.name}
-                placeholder="Column"
-                options={getRemainingColumnOptions(column.name)}
-                on:change={e => (column.displayName = e.detail)}
-              />
-              <Input bind:value={column.displayName} placeholder="Label" />
-              <Icon
-                name="Close"
-                hoverable
-                size="S"
-                on:click={() => removeColumn(column.id)}
-              />
-            </div>
-          {/each}
+            {/each}
+          </div>
+        </Layout>
+      {:else}
+        <div class="column">
+          <div />
+          <Body size="S">Add the first column to your table.</Body>
         </div>
       {/if}
-      <div class="column">
-        <div />
-        <Button secondary icon="Add" on:click={addColumn}>Add Column</Button>
+      <div class="columns">
+        <div class="column">
+          <div />
+          <div class="buttons">
+            <Button secondary icon="Add" on:click={addColumn}>
+              Add column
+            </Button>
+            <Button secondary quiet on:click={reset}>Reset columns</Button>
+          </div>
+        </div>
       </div>
     </Layout>
   </div>
@@ -144,5 +167,12 @@
   .handle {
     display: grid;
     place-items: center;
+  }
+  .buttons {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    gap: var(--spacing-m);
   }
 </style>

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ColumnEditor/ColumnDrawer.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ColumnEditor/ColumnDrawer.svelte
@@ -6,6 +6,7 @@
     Layout,
     Input,
     Select,
+    Label,
   } from "@budibase/bbui"
   import { flip } from "svelte/animate"
   import { dndzone } from "svelte-dnd-action"
@@ -75,6 +76,12 @@
           on:finalize={handleFinalize}
           on:consider={updateColumnOrder}
         >
+          <div class="column">
+            <div />
+            <Label size="L">Column</Label>
+            <Label size="L">Label</Label>
+            <div />
+          </div>
           {#each columns as column (column.id)}
             <div class="column" animate:flip={{ duration: flipDurationMs }}>
               <div
@@ -102,7 +109,8 @@
           {/each}
         </div>
       {/if}
-      <div>
+      <div class="column">
+        <div />
         <Button secondary icon="Add" on:click={addColumn}>Add Column</Button>
       </div>
     </Layout>
@@ -124,19 +132,14 @@
   }
   .column {
     gap: var(--spacing-l);
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: 20px 1fr 1fr 20px;
     align-items: center;
     border-radius: var(--border-radius-s);
     transition: background-color ease-in-out 130ms;
   }
   .column:hover {
     background-color: var(--spectrum-global-color-gray-100);
-  }
-  .column > :global(.spectrum-Form-item) {
-    flex: 1 1 auto;
-    width: 0;
   }
   .handle {
     display: grid;

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ColumnEditor/ColumnDrawer.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ColumnEditor/ColumnDrawer.svelte
@@ -1,0 +1,145 @@
+<script>
+  import {
+    Button,
+    Icon,
+    DrawerContent,
+    Layout,
+    Input,
+    Select,
+  } from "@budibase/bbui"
+  import { flip } from "svelte/animate"
+  import { dndzone } from "svelte-dnd-action"
+  import { generate } from "shortid"
+
+  export let columns = []
+  export let options = []
+
+  const flipDurationMs = 150
+  let dragDisabled = true
+
+  $: unselectedColumns = getUnselectedColumns(options, columns)
+  $: columns.forEach(column => {
+    if (!column.id) {
+      column.id = generate()
+    }
+  })
+
+  const getUnselectedColumns = (allColumns, selectedColumns) => {
+    let optionsObj = {}
+    allColumns.forEach(option => {
+      optionsObj[option] = true
+    })
+    selectedColumns?.forEach(column => {
+      delete optionsObj[column.name]
+    })
+    return Object.keys(optionsObj)
+  }
+
+  const getRemainingColumnOptions = selectedColumn => {
+    if (!selectedColumn || unselectedColumns.includes(selectedColumn)) {
+      return unselectedColumns
+    }
+    return [selectedColumn, ...unselectedColumns]
+  }
+
+  const addColumn = () => {
+    columns = [...columns, {}]
+  }
+
+  const removeColumn = id => {
+    columns = columns.filter(column => column.id !== id)
+  }
+
+  const updateColumnOrder = e => {
+    columns = e.detail.items
+  }
+
+  const handleFinalize = e => {
+    updateColumnOrder(e)
+    dragDisabled = true
+  }
+</script>
+
+<DrawerContent>
+  <div class="container">
+    <Layout noPadding gap="S">
+      {#if columns?.length}
+        <div
+          class="columns"
+          use:dndzone={{
+            items: columns,
+            flipDurationMs,
+            dropTargetStyle: { outline: "none" },
+            dragDisabled,
+          }}
+          on:finalize={handleFinalize}
+          on:consider={updateColumnOrder}
+        >
+          {#each columns as column (column.id)}
+            <div class="column" animate:flip={{ duration: flipDurationMs }}>
+              <div
+                class="handle"
+                aria-label="drag-handle"
+                style={dragDisabled ? "cursor: grab" : "cursor: grabbing"}
+                on:mousedown={() => (dragDisabled = false)}
+              >
+                <Icon name="DragHandle" size="XL" />
+              </div>
+              <Select
+                bind:value={column.name}
+                placeholder="Column"
+                options={getRemainingColumnOptions(column.name)}
+                on:change={e => (column.displayName = e.detail)}
+              />
+              <Input bind:value={column.displayName} placeholder="Label" />
+              <Icon
+                name="Close"
+                hoverable
+                size="S"
+                on:click={() => removeColumn(column.id)}
+              />
+            </div>
+          {/each}
+        </div>
+      {/if}
+      <div>
+        <Button secondary icon="Add" on:click={addColumn}>Add Column</Button>
+      </div>
+    </Layout>
+  </div>
+</DrawerContent>
+
+<style>
+  .container {
+    width: 100%;
+    max-width: 600px;
+    margin: 0 auto;
+  }
+  .columns {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: stretch;
+    gap: var(--spacing-m);
+  }
+  .column {
+    gap: var(--spacing-l);
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    border-radius: var(--border-radius-s);
+    transition: background-color ease-in-out 130ms;
+  }
+  .column:hover {
+    background-color: var(--spectrum-global-color-gray-100);
+  }
+  .column > :global(.spectrum-Form-item) {
+    flex: 1 1 auto;
+    width: 0;
+  }
+  .handle {
+    display: grid;
+    place-items: center;
+  }
+</style>

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ColumnEditor/ColumnEditor.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ColumnEditor/ColumnEditor.svelte
@@ -1,0 +1,64 @@
+<script>
+  import { Button, ActionButton, Drawer } from "@budibase/bbui"
+  import { createEventDispatcher } from "svelte"
+  import ColumnDrawer from "./ColumnDrawer.svelte"
+  import { cloneDeep } from "lodash/fp"
+  import {
+    getDatasourceForProvider,
+    getSchemaForDatasource,
+  } from "builderStore/dataBinding"
+  import { currentAsset } from "builderStore"
+
+  export let componentInstance
+  export let value = []
+
+  const dispatch = createEventDispatcher()
+
+  let drawer
+  let boundValue
+
+  $: datasource = getDatasourceForProvider($currentAsset, componentInstance)
+  $: schema = getSchemaForDatasource($currentAsset, datasource).schema
+  $: options = Object.keys(schema || {})
+  $: sanitisedValue = getValidColumns(value, options)
+  $: updateBoundValue(sanitisedValue)
+
+  const updateBoundValue = value => {
+    boundValue = cloneDeep(value)
+  }
+
+  const getValidColumns = (columns, options) => {
+    // If no columns then default to all columns
+    if (!Array.isArray(columns) || !columns.length) {
+      return options.map(col => ({
+        name: col,
+        displayName: col,
+      }))
+    }
+    // We need to account for legacy configs which would just be an array
+    // of strings
+    if (typeof columns[0] === "string") {
+      columns = columns.map(col => ({
+        name: col,
+        displayName: col,
+      }))
+    }
+    return columns.filter(column => {
+      return options.includes(column.name)
+    })
+  }
+
+  const save = () => {
+    dispatch("change", getValidColumns(boundValue, options))
+    drawer.hide()
+  }
+</script>
+
+<ActionButton on:click={drawer.show}>Configure columns</ActionButton>
+<Drawer bind:this={drawer} title="Table Columns">
+  <svelte:fragment slot="description">
+    Configure the columns in your table.
+  </svelte:fragment>
+  <Button cta slot="buttons" on:click={save}>Save</Button>
+  <ColumnDrawer slot="body" bind:columns={boundValue} {options} />
+</Drawer>

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/NavigationEditor/NavigationEditor.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/NavigationEditor/NavigationEditor.svelte
@@ -15,7 +15,7 @@
   }
 </script>
 
-<ActionButton on:click={drawer.show}>Configure Links</ActionButton>
+<ActionButton on:click={drawer.show}>Configure links</ActionButton>
 <Drawer bind:this={drawer} title={"Navigation Links"}>
   <svelte:fragment slot="description">
     Configure the links in your navigation bar.

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/componentSettings.js
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/componentSettings.js
@@ -18,6 +18,7 @@ import OptionsEditor from "./OptionsEditor/OptionsEditor.svelte"
 import FormFieldSelect from "./FormFieldSelect.svelte"
 import ValidationEditor from "./ValidationEditor/ValidationEditor.svelte"
 import DrawerBindableCombobox from "components/common/bindings/DrawerBindableCombobox.svelte"
+import ColumnEditor from "./ColumnEditor/ColumnEditor.svelte"
 
 const componentMap = {
   text: DrawerBindableCombobox,
@@ -40,6 +41,7 @@ const componentMap = {
   navigation: NavigationEditor,
   filter: FilterEditor,
   url: URLSelect,
+  columns: ColumnEditor,
   "field/string": FormFieldSelect,
   "field/number": FormFieldSelect,
   "field/options": FormFieldSelect,

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -2950,7 +2950,7 @@
             "defaultValue": 8
           },
           {
-            "type": "multifield",
+            "type": "columns",
             "label": "Table Columns",
             "key": "tableColumns",
             "dependsOn": "dataSource",

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -2680,11 +2680,10 @@
         "defaultValue": 8
       },
       {
-        "type": "multifield",
+        "type": "columns",
         "label": "Columns",
         "key": "columns",
-        "dependsOn": "dataProvider",
-        "placeholder": "All columns"
+        "dependsOn": "dataProvider"
       },
       {
         "type": "select",

--- a/packages/client/src/components/app/table/Table.svelte
+++ b/packages/client/src/components/app/table/Table.svelte
@@ -40,7 +40,8 @@
     // Check for an invalid column selection
     let invalid = false
     customColumns?.forEach(column => {
-      if (schema[column] == null) {
+      const columnName = typeof column === "string" ? column : column.name
+      if (schema[columnName] == null) {
         invalid = true
       }
     })
@@ -75,9 +76,16 @@
     }
 
     fields.forEach(field => {
-      newSchema[field] = schema[field]
-      if (schema[field] && UnsortableTypes.indexOf(schema[field].type) !== -1) {
-        newSchema[field].sortable = false
+      const columnName = typeof field === "string" ? field : field.name
+      if (!schema[columnName]) {
+        return
+      }
+      newSchema[columnName] = schema[columnName]
+      if (UnsortableTypes.includes(schema[columnName].type)) {
+        newSchema[columnName].sortable = false
+      }
+      if (field?.displayName) {
+        newSchema[columnName].displayName = field?.displayName
       }
     })
     return newSchema


### PR DESCRIPTION
## Description
This PR adds a new component for configuring table columns. This feature is available on both the table component and table block.

The new available features are:
- Add and remove columns
- Drag to reorder columns
- Set custom labels for columns
- Quickly reset to add all columns

Some clarification of functionality:
- Initially all columns are added, as before
- You cannot remove all columns, and the delete icon will be disabled when you are down to one column remaining
- The component does correctly handle if no columns are selected though, for example if the datasource has no columns available

This change is fully backwards compatible. The previous setting value was a flat array of column names. The new component can handle this format, and will transform it in to the new structure the first time it is saved.

## Screenshots
![image](https://user-images.githubusercontent.com/9075550/153871116-fd199b92-2073-4a07-b08d-0c23e563045e.png)




