### PR TITLE
Fix vite warnings

### DIFF
--- a/packages/bbui/src/Button/Button.svelte
+++ b/packages/bbui/src/Button/Button.svelte
@@ -30,6 +30,7 @@
     {disabled}
     on:click|preventDefault
     on:mouseover={() => (showTooltip = true)}
+    on:focus={() => (showTooltip = true)}
     on:mouseleave={() => (showTooltip = false)}
   >
     {#if icon}

--- a/packages/builder/src/components/backend/DataTable/modals/ImportModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/ImportModal.svelte
@@ -48,6 +48,3 @@
     <TableDataImport bind:dataImport bind:existingTableId={tableId} />
   </Layout>
 </ModalContent>
-
-<style>
-</style>

--- a/packages/builder/src/components/backend/DatasourceNavigator/TableIntegrationMenu/rest/auth/RestAuthenticationModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/TableIntegrationMenu/rest/auth/RestAuthenticationModal.svelte
@@ -213,6 +213,3 @@
     {/if}
   </Layout>
 </ModalContent>
-
-<style>
-</style>

--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/ImportRestQueriesModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/ImportRestQueriesModal.svelte
@@ -130,6 +130,3 @@
     </Tabs>
   </Layout>
 </ModalContent>
-
-<style>
-</style>

--- a/packages/builder/vite.config.js
+++ b/packages/builder/vite.config.js
@@ -15,6 +15,7 @@ export default ({ mode }) => {
     build: {
       minify: isProduction,
       outDir: "../server/builder",
+      sourcemap: !isProduction,
     },
     plugins: [
       svelte({


### PR DESCRIPTION
## Description
This is a quick PR to fix the spam of `[vite] Failed to load source map for /node_modules/.vite/...` when running the builder in dev. This was just caused by not actually including sourcemaps in the vite config, so I've instructed vite to use sourcemaps when not running in production.

This change would probably also have helped us diagnose the recent issue with safari faster, as it would probably have pointed us to the source of the JS error being thrown due to the look behind regex.

I also addressed the other couple of vite warnings which were printed in the console - namely removing some empty style blocks and fixing some A11y issues.

Before:
![image](https://user-images.githubusercontent.com/9075550/154032418-f7478f4e-32eb-4004-993c-5cb87ca94f5f.png)

After (no logs at all from vite in the builder):
![image](https://user-images.githubusercontent.com/9075550/154033269-092d4245-a1a2-4b6b-a4bd-f75119525cc7.png)