### PR TITLE
Fix slash appearing in the tag settings bar

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -851,16 +851,12 @@
         "type": "color",
         "label": "Color",
         "key": "color",
-        "showInBar": true,
-        "barSeparator": false
+        "showInBar": true
       },
       {
         "type": "boolean",
         "label": "Show delete icon",
-        "key": "closable",
-        "showInBar": true,
-        "barIcon": "TagItalic",
-        "barTitle": "Show delete icon"
+        "key": "closable"
       },
       {
         "type": "event",


### PR DESCRIPTION
## Description
Fixes a slash appearing in the tag settings bar. The setting to control showing the delete icon should not appear in the bar at all.

New settings bar: 
![image](https://user-images.githubusercontent.com/9075550/154046971-3d7cd1f7-8bd2-413f-97a1-f2c728742df5.png)

Fixes #4504.