### PR TITLE
Checklist API performance on default tenants and email invitations

### DIFF
--- a/packages/builder/src/pages/builder/portal/manage/users/index.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/users/index.svelte
@@ -43,7 +43,7 @@
   let createUserModal
   let basicOnboardingModal
 
-  function openBasicOnoboardingModal() {
+  function openBasicOnboardingModal() {
     createUserModal.hide()
     basicOnboardingModal.show()
   }
@@ -91,7 +91,7 @@
 </Layout>
 
 <Modal bind:this={createUserModal}>
-  <AddUserModal on:change={openBasicOnoboardingModal} />
+  <AddUserModal on:change={openBasicOnboardingModal} />
 </Modal>
 <Modal bind:this={basicOnboardingModal}><BasicOnboardingModal {email} /></Modal>
 

--- a/packages/builder/src/stores/portal/users.js
+++ b/packages/builder/src/stores/portal/users.js
@@ -11,7 +11,7 @@ export function createUsersStore() {
   }
 
   async function invite({ email, builder, admin }) {
-    await API.inviteUser({
+    return API.inviteUser({
       email,
       builder,
       admin,
@@ -19,7 +19,7 @@ export function createUsersStore() {
   }
 
   async function acceptInvite(inviteCode, password) {
-    await API.acceptInvite({
+    return API.acceptInvite({
       inviteCode,
       password,
     })

--- a/packages/frontend-core/src/api/user.js
+++ b/packages/frontend-core/src/api/user.js
@@ -113,11 +113,11 @@ export const buildUserEndpoints = API => ({
   },
 
   /**
-   * Accepts an invitation to join the platform and creates a user.
+   * Accepts an invite to join the platform and creates a user.
    * @param inviteCode the invite code sent in the email
    * @param password the password for the newly created user
    */
-  acceptInvitation: async ({ inviteCode, password }) => {
+  acceptInvite: async ({ inviteCode, password }) => {
     return await API.post({
       url: "/api/global/users/invite/accept",
       body: {

--- a/packages/worker/src/api/controllers/global/configs.js
+++ b/packages/worker/src/api/controllers/global/configs.js
@@ -246,12 +246,16 @@ exports.destroy = async function (ctx) {
 
 exports.configChecklist = async function (ctx) {
   const db = getGlobalDB()
+  const tenantId = getTenantId()
 
   try {
     // TODO: Watch get started video
 
-    // Apps exist
-    const apps = await getAllApps({ idsOnly: true, efficient: true })
+    let apps = []
+    if (!env.MULTI_TENANCY || tenantId) {
+      // Apps exist
+      apps = await getAllApps({ idsOnly: true, efficient: true })
+    }
 
     // They have set up SMTP
     const smtpConfig = await getScopedFullConfig(db, {

--- a/packages/worker/src/api/controllers/global/configs.js
+++ b/packages/worker/src/api/controllers/global/configs.js
@@ -251,7 +251,7 @@ exports.configChecklist = async function (ctx) {
     // TODO: Watch get started video
 
     // Apps exist
-    const apps = await getAllApps({ idsOnly: true })
+    const apps = await getAllApps({ idsOnly: true, efficient: true })
 
     // They have set up SMTP
     const smtpConfig = await getScopedFullConfig(db, {


### PR DESCRIPTION
## Description
There was an issue with the checklist call taking upwards of two seconds to respond. This is a relatively simple call, it shouldn't have any heavy database calls.

This also fixes #4522 - there was some issues introduced by the frontend-core that needed fixed for this flow to work correctly.

Can see the call here:
![image](https://user-images.githubusercontent.com/4407001/154266237-fe1479dd-f1e4-42cf-bc5f-bf587b172f03.png)

It appeared to be tied to the default tenant, as there was an edge case which meant that the default tenant couldn't use the more efficient app tenant lookup, instead it has to lookup the full list of app IDs. I added an efficient flag to the `getAllApps` function so that we can state that we want it to be as fast as possible, perhaps sacrificing some accuracy in the default tenant. This is fine for the checklist call because it only needs a list of apps in the tenant. This should speed up the login process for the default tenant fairly significantly.