### PR TITLE
Fix role being stale when creating screens

### DIFF
--- a/packages/builder/src/components/design/NavigationPanel/ScreenWizard.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/ScreenWizard.svelte
@@ -12,10 +12,11 @@
   let screenName = ""
   let url = ""
   let selectedScreens = []
-  let roleId = $selectedAccessRole || "BASIC"
   let showProgressCircle = false
   let routeError
   let createdScreens = []
+
+  $: roleId = $selectedAccessRole || "BASIC"
 
   const createScreens = async () => {
     for (let screen of selectedScreens) {

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/FilterEditor/FilterDrawer.svelte
@@ -90,7 +90,7 @@
 </script>
 
 <DrawerContent>
-  <div className="container">
+  <div class="container">
     <Layout noPadding>
       <Body size="S">
         {#if !filters?.length}

--- a/packages/string-templates/src/index.js
+++ b/packages/string-templates/src/index.js
@@ -139,8 +139,13 @@ module.exports.disableEscaping = string => {
   if (matches == null) {
     return string
   }
-  for (let match of matches) {
-    string = string.replace(match, `{${match}}`)
+
+  // find the unique set
+  const unique = [...new Set(matches)]
+  for (let match of unique) {
+    // add a negative lookahead to exclude any already
+    const regex = new RegExp(`${match}(?!})`, "g")
+    string = string.replace(regex, `{${match}}`)
   }
   return string
 }

--- a/packages/string-templates/test/basic.spec.js
+++ b/packages/string-templates/test/basic.spec.js
@@ -194,5 +194,9 @@ describe("check that disabling escaping function works", () => {
   it("should work with a combination", () => {
     expect(disableEscaping("{{ name }} welcome to {{{ platform }}}")).toEqual("{{{ name }}} welcome to {{{ platform }}}")
   })
+
+  it("should work with multiple escaped", () => {
+    expect(disableEscaping("{{ name }} welcome to {{ name }}")).toEqual("{{{ name }}} welcome to {{{ name }}}")
+  })
 })
 


### PR DESCRIPTION
## Description
The value of `roleId` is determined initially in `ScreenWizard` and never updated, but because `ScreenWizard` never actually remounts - the value is stale. This PR just swaps it to a reactive statement to ensure it is always up to date.

This affects the uniqueness validation as well as the role attached to new screens. This affects the patch earlier today to honour the selected role when creating screens, but this bug has always existed and was not introduced by that change.


