### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/packages/bbui/src/Stores/notifications.js
+++ b/packages/bbui/src/Stores/notifications.js
@@ -60,7 +60,7 @@ export const createNotificationStore = () => {
 }
 
 function id() {
-  return "_" + Math.random().toString(36).substr(2, 9)
+  return "_" + Math.random().toString(36).slice(2, 9)
 }
 
 export const notifications = createNotificationStore()

--- a/packages/bbui/src/Tabs/Tabs.svelte
+++ b/packages/bbui/src/Tabs/Tabs.svelte
@@ -68,7 +68,7 @@
   })
 
   function id() {
-    return "_" + Math.random().toString(36).substr(2, 9)
+    return "_" + Math.random().toString(36).slice(2, 9)
   }
 </script>
 

--- a/packages/builder/src/pages/builder/portal/manage/users/_components/BasicOnboardingModal.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/users/_components/BasicOnboardingModal.svelte
@@ -11,7 +11,7 @@
   import { users } from "stores/portal"
 
   const [email, error, touched] = createValidationStore("", emailValidator)
-  const password = Math.random().toString(36).substr(2, 20)
+  const password = Math.random().toString(36).slice(2, 20)
   let builder = false,
     admin = false
 

--- a/packages/builder/src/pages/builder/portal/manage/users/_components/ForceResetPasswordModal.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/users/_components/ForceResetPasswordModal.svelte
@@ -7,7 +7,7 @@
 
   export let user
 
-  const password = Math.random().toString(36).substr(2, 20)
+  const password = Math.random().toString(36).slice(2, 20)
 
   async function resetPassword() {
     try {

--- a/packages/server/scripts/docs/toSwagger.js
+++ b/packages/server/scripts/docs/toSwagger.js
@@ -51,7 +51,7 @@ function extractPaths(apidocJson) {
     // Surrounds URL parameters with curly brackets -> :email with {email}
     let pathKeys = []
     for (let j = 1; j < matches.length; j++) {
-      let key = matches[j].substr(1)
+      let key = matches[j].slice(1)
       url = url.replace(matches[j], "{" + key + "}")
       pathKeys.push(key)
     }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.