### PR TITLE
Forward Host header to worker and server through NGINX

### DIFF
--- a/hosting/nginx.dev.conf.hbs
+++ b/hosting/nginx.dev.conf.hbs
@@ -34,6 +34,7 @@ http {
 
     location ~ ^/api/(system|admin|global)/ {
       proxy_pass      http://{{ address }}:4002;
+      proxy_set_header Host $host;
     }
 
     location /api/ {
@@ -41,24 +42,29 @@ http {
       proxy_connect_timeout 120s;
       proxy_send_timeout 120s; 
       proxy_pass      http://{{ address }}:4001;
+      proxy_set_header Host $host;
     }
 
     location = / {
       proxy_pass      http://{{ address }}:4001;
+      proxy_set_header Host $host;
     }
 
     location /app_ {
       proxy_pass      http://{{ address }}:4001;
+      proxy_set_header Host $host;
     }
 
     location /app/ {
       proxy_pass      http://{{ address }}:4001;
       rewrite ^/app/(.*)$ /$1 break;
+      proxy_set_header Host $host;
     }
 
     location /builder {
       proxy_pass      http://{{ address }}:3000;
       rewrite ^/builder(.*)$ /builder/$1 break;
+      proxy_set_header Host $host;
     }
 
     location /builder/ {

--- a/hosting/nginx.dev.conf.hbs
+++ b/hosting/nginx.dev.conf.hbs
@@ -11,6 +11,7 @@ events {
 http {
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
+  proxy_set_header Host $host;
 
   log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                     '$status $body_bytes_sent "$http_referer" '
@@ -34,7 +35,6 @@ http {
 
     location ~ ^/api/(system|admin|global)/ {
       proxy_pass      http://{{ address }}:4002;
-      proxy_set_header Host $host;
     }
 
     location /api/ {
@@ -42,29 +42,24 @@ http {
       proxy_connect_timeout 120s;
       proxy_send_timeout 120s; 
       proxy_pass      http://{{ address }}:4001;
-      proxy_set_header Host $host;
     }
 
     location = / {
       proxy_pass      http://{{ address }}:4001;
-      proxy_set_header Host $host;
     }
 
     location /app_ {
       proxy_pass      http://{{ address }}:4001;
-      proxy_set_header Host $host;
     }
 
     location /app/ {
       proxy_pass      http://{{ address }}:4001;
       rewrite ^/app/(.*)$ /$1 break;
-      proxy_set_header Host $host;
     }
 
     location /builder {
       proxy_pass      http://{{ address }}:3000;
       rewrite ^/builder(.*)$ /builder/$1 break;
-      proxy_set_header Host $host;
     }
 
     location /builder/ {
@@ -73,7 +68,6 @@ http {
       proxy_http_version  1.1;
       proxy_set_header    Connection          $connection_upgrade;
       proxy_set_header    Upgrade             $http_upgrade;
-      proxy_set_header    Host                $host;
       proxy_set_header    X-Real-IP           $remote_addr;
       proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
     }
@@ -82,7 +76,6 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header Host $http_host;
 
       proxy_connect_timeout 300;
       proxy_http_version 1.1;

--- a/hosting/nginx.prod.conf.hbs
+++ b/hosting/nginx.prod.conf.hbs
@@ -12,6 +12,7 @@ http {
   limit_req_zone $binary_remote_addr zone=ratelimit:10m rate=20r/s;
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
+  proxy_set_header Host $host;
   charset utf-8;
   sendfile on;
   tcp_nopush on;
@@ -68,12 +69,10 @@ http {
     location /app {
       proxy_pass      http://$apps:4002;
       rewrite ^/app/(.*)$ /$1 break;
-      proxy_set_header Host $host;
     }
 
     location = / {
       proxy_pass      http://$apps:4002;
-      proxy_set_header Host $host;
     }
 
     {{#if watchtower}}
@@ -85,22 +84,18 @@ http {
       proxy_http_version  1.1;
       proxy_set_header    Connection          $connection_upgrade;
       proxy_set_header    Upgrade             $http_upgrade;
-      proxy_set_header    Host                $host;
       proxy_set_header    X-Real-IP           $remote_addr;
       proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
       proxy_pass      http://$apps:4002;
-      proxy_set_header Host $host;
     }
 
     location ~ ^/api/(system|admin|global)/ {
       proxy_pass      http://$worker:4003;
-      proxy_set_header Host $host;
     }
 
     location /worker/ {
       proxy_pass      http://$worker:4003;
       rewrite ^/worker/(.*)$ /$1 break;
-      proxy_set_header Host $host;
     }
 
     location /api/ {
@@ -115,7 +110,6 @@ http {
       proxy_http_version  1.1;
       proxy_set_header    Connection          $connection_upgrade;
       proxy_set_header    Upgrade             $http_upgrade;
-      proxy_set_header    Host                $host;
       proxy_set_header    X-Real-IP           $remote_addr;
       proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
 
@@ -131,7 +125,6 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header Host $http_host;
 
       proxy_connect_timeout 300;
       proxy_http_version 1.1;

--- a/hosting/nginx.prod.conf.hbs
+++ b/hosting/nginx.prod.conf.hbs
@@ -68,10 +68,12 @@ http {
     location /app {
       proxy_pass      http://$apps:4002;
       rewrite ^/app/(.*)$ /$1 break;
+      proxy_set_header Host $host;
     }
 
     location = / {
       proxy_pass      http://$apps:4002;
+      proxy_set_header Host $host;
     }
 
     {{#if watchtower}}
@@ -87,15 +89,18 @@ http {
       proxy_set_header    X-Real-IP           $remote_addr;
       proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
       proxy_pass      http://$apps:4002;
+      proxy_set_header Host $host;
     }
 
     location ~ ^/api/(system|admin|global)/ {
       proxy_pass      http://$worker:4003;
+      proxy_set_header Host $host;
     }
 
     location /worker/ {
       proxy_pass      http://$worker:4003;
       rewrite ^/worker/(.*)$ /$1 break;
+      proxy_set_header Host $host;
     }
 
     location /api/ {


### PR DESCRIPTION
## Description
Fixes https://github.com/Budibase/budibase/issues/4547

- Forward the Host header through nginx
- This fixes tenancy parsing for subdomains
- Which fixes app list retrieval for matching custom urls
- Did not affect self host due to single tenancy 


