### PR TITLE
Respect custom tenantIds in run migrations endpoint

### DIFF
--- a/charts/budibase/Chart.yaml
+++ b/charts/budibase/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/Budibase/budibase
   - https://budibase.com
 type: application
-version: 0.2.7
+version: 0.2.8
 appVersion: 1.0.48
 dependencies:
   - name: couchdb

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -100,6 +100,9 @@ globals:
   cookieDomain: ""
   platformUrl: ""
   httpMigrations: "0"
+  google:
+    clientId: "" 
+    secret: ""
 
   createSecrets: true # creates an internal API key, JWT secrets and redis password for you
 

--- a/hosting/nginx.dev.conf.hbs
+++ b/hosting/nginx.dev.conf.hbs
@@ -34,6 +34,7 @@ http {
 
     location ~ ^/api/(system|admin|global)/ {
       proxy_pass      http://{{ address }}:4002;
+      proxy_set_header Host $host;
     }
 
     location /api/ {
@@ -41,24 +42,29 @@ http {
       proxy_connect_timeout 120s;
       proxy_send_timeout 120s; 
       proxy_pass      http://{{ address }}:4001;
+      proxy_set_header Host $host;
     }
 
     location = / {
       proxy_pass      http://{{ address }}:4001;
+      proxy_set_header Host $host;
     }
 
     location /app_ {
       proxy_pass      http://{{ address }}:4001;
+      proxy_set_header Host $host;
     }
 
     location /app/ {
       proxy_pass      http://{{ address }}:4001;
       rewrite ^/app/(.*)$ /$1 break;
+      proxy_set_header Host $host;
     }
 
     location /builder {
       proxy_pass      http://{{ address }}:3000;
       rewrite ^/builder(.*)$ /builder/$1 break;
+      proxy_set_header Host $host;
     }
 
     location /builder/ {

--- a/hosting/nginx.dev.conf.hbs
+++ b/hosting/nginx.dev.conf.hbs
@@ -43,6 +43,10 @@ http {
       proxy_pass      http://{{ address }}:4001;
     }
 
+    location = / {
+      proxy_pass      http://{{ address }}:4001;
+    }
+
     location /app_ {
       proxy_pass      http://{{ address }}:4001;
     }

--- a/hosting/nginx.dev.conf.hbs
+++ b/hosting/nginx.dev.conf.hbs
@@ -11,6 +11,7 @@ events {
 http {
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
+  proxy_set_header Host $host;
 
   log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                     '$status $body_bytes_sent "$http_referer" '
@@ -34,7 +35,6 @@ http {
 
     location ~ ^/api/(system|admin|global)/ {
       proxy_pass      http://{{ address }}:4002;
-      proxy_set_header Host $host;
     }
 
     location /api/ {
@@ -42,29 +42,24 @@ http {
       proxy_connect_timeout 120s;
       proxy_send_timeout 120s; 
       proxy_pass      http://{{ address }}:4001;
-      proxy_set_header Host $host;
     }
 
     location = / {
       proxy_pass      http://{{ address }}:4001;
-      proxy_set_header Host $host;
     }
 
     location /app_ {
       proxy_pass      http://{{ address }}:4001;
-      proxy_set_header Host $host;
     }
 
     location /app/ {
       proxy_pass      http://{{ address }}:4001;
       rewrite ^/app/(.*)$ /$1 break;
-      proxy_set_header Host $host;
     }
 
     location /builder {
       proxy_pass      http://{{ address }}:3000;
       rewrite ^/builder(.*)$ /builder/$1 break;
-      proxy_set_header Host $host;
     }
 
     location /builder/ {
@@ -73,7 +68,6 @@ http {
       proxy_http_version  1.1;
       proxy_set_header    Connection          $connection_upgrade;
       proxy_set_header    Upgrade             $http_upgrade;
-      proxy_set_header    Host                $host;
       proxy_set_header    X-Real-IP           $remote_addr;
       proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
     }
@@ -82,7 +76,6 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header Host $http_host;
 
       proxy_connect_timeout 300;
       proxy_http_version 1.1;

--- a/hosting/nginx.prod.conf.hbs
+++ b/hosting/nginx.prod.conf.hbs
@@ -12,6 +12,7 @@ http {
   limit_req_zone $binary_remote_addr zone=ratelimit:10m rate=20r/s;
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
+  proxy_set_header Host $host;
   charset utf-8;
   sendfile on;
   tcp_nopush on;
@@ -68,12 +69,10 @@ http {
     location /app {
       proxy_pass      http://$apps:4002;
       rewrite ^/app/(.*)$ /$1 break;
-      proxy_set_header Host $host;
     }
 
     location = / {
       proxy_pass      http://$apps:4002;
-      proxy_set_header Host $host;
     }
 
     {{#if watchtower}}
@@ -85,22 +84,18 @@ http {
       proxy_http_version  1.1;
       proxy_set_header    Connection          $connection_upgrade;
       proxy_set_header    Upgrade             $http_upgrade;
-      proxy_set_header    Host                $host;
       proxy_set_header    X-Real-IP           $remote_addr;
       proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
       proxy_pass      http://$apps:4002;
-      proxy_set_header Host $host;
     }
 
     location ~ ^/api/(system|admin|global)/ {
       proxy_pass      http://$worker:4003;
-      proxy_set_header Host $host;
     }
 
     location /worker/ {
       proxy_pass      http://$worker:4003;
       rewrite ^/worker/(.*)$ /$1 break;
-      proxy_set_header Host $host;
     }
 
     location /api/ {
@@ -115,7 +110,6 @@ http {
       proxy_http_version  1.1;
       proxy_set_header    Connection          $connection_upgrade;
       proxy_set_header    Upgrade             $http_upgrade;
-      proxy_set_header    Host                $host;
       proxy_set_header    X-Real-IP           $remote_addr;
       proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
 
@@ -131,7 +125,6 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header Host $http_host;
 
       proxy_connect_timeout 300;
       proxy_http_version 1.1;

--- a/hosting/nginx.prod.conf.hbs
+++ b/hosting/nginx.prod.conf.hbs
@@ -68,10 +68,12 @@ http {
     location /app {
       proxy_pass      http://$apps:4002;
       rewrite ^/app/(.*)$ /$1 break;
+      proxy_set_header Host $host;
     }
 
     location = / {
       proxy_pass      http://$apps:4002;
+      proxy_set_header Host $host;
     }
 
     {{#if watchtower}}
@@ -87,15 +89,18 @@ http {
       proxy_set_header    X-Real-IP           $remote_addr;
       proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
       proxy_pass      http://$apps:4002;
+      proxy_set_header Host $host;
     }
 
     location ~ ^/api/(system|admin|global)/ {
       proxy_pass      http://$worker:4003;
+      proxy_set_header Host $host;
     }
 
     location /worker/ {
       proxy_pass      http://$worker:4003;
       rewrite ^/worker/(.*)$ /$1 break;
+      proxy_set_header Host $host;
     }
 
     location /api/ {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.69",
+  "version": "1.0.70",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.71",
+  "version": "1.0.72",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.70",
+  "version": "1.0.71",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.68",
+  "version": "1.0.69",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "build:docker:proxy:preprod": "lerna run generate:proxy:preprod && npm run build:docker:proxy",
     "build:docker:proxy:prod": "lerna run generate:proxy:prod && npm run build:docker:proxy",
     "build:docker:selfhost": "lerna run build:docker && cd hosting/scripts/linux/ && ./release-to-docker-hub.sh latest && cd -",
-    "build:docker:develop": "node scripts/pinVersions && lerna run build:docker && npm run build:docker:proxy && cd hosting/scripts/linux/ && ./release-to-docker-hub.sh develop && cd -",
+    "build:docker:develop": "node scripts/pinVersions && lerna run build:docker && npm run build:docker:proxy:compose && cd hosting/scripts/linux/ && ./release-to-docker-hub.sh develop && cd -",
     "build:docker:airgap": "node hosting/scripts/airgapped/airgappedDockerBuild",
     "build:digitalocean": "cd hosting/digitalocean && ./build.sh && cd -",
     "build:docs": "lerna run build:docs",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/backend-core",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "description": "Budibase backend core libraries used in server and worker",
   "main": "src/index.js",
   "author": "Budibase",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/backend-core",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "description": "Budibase backend core libraries used in server and worker",
   "main": "src/index.js",
   "author": "Budibase",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/backend-core",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "description": "Budibase backend core libraries used in server and worker",
   "main": "src/index.js",
   "author": "Budibase",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/backend-core",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "description": "Budibase backend core libraries used in server and worker",
   "main": "src/index.js",
   "author": "Budibase",

--- a/packages/backend-core/src/cloud/accounts.js
+++ b/packages/backend-core/src/cloud/accounts.js
@@ -17,7 +17,7 @@ exports.getAccount = async email => {
   const json = await response.json()
 
   if (response.status !== 200) {
-    throw Error(`Error getting account by email ${email}`, json)
+    throw new Error(`Error getting account by email ${email}`, json)
   }
 
   return json[0]

--- a/packages/backend-core/src/context/deprovision.js
+++ b/packages/backend-core/src/context/deprovision.js
@@ -1,5 +1,5 @@
 const { getGlobalUserParams, getAllApps } = require("../db/utils")
-const { getDB, getCouch } = require("../db")
+const { getDB } = require("../db")
 const { getGlobalDB } = require("../tenancy")
 const { StaticDatabases } = require("../db/constants")
 
@@ -79,7 +79,7 @@ const removeGlobalDB = async tenantId => {
 
 const removeTenantApps = async tenantId => {
   try {
-    const apps = await getAllApps(getCouch(), { all: true })
+    const apps = await getAllApps({ all: true })
     const destroyPromises = apps.map(app => getDB(app.appId).destroy())
     await Promise.allSettled(destroyPromises)
   } catch (err) {

--- a/packages/backend-core/src/context/index.js
+++ b/packages/backend-core/src/context/index.js
@@ -121,7 +121,7 @@ exports.getTenantId = () => {
   }
   const tenantId = cls.getFromContext(ContextKeys.TENANT_ID)
   if (!tenantId) {
-    throw Error("Tenant id not found")
+    throw new Error("Tenant id not found")
   }
   return tenantId
 }

--- a/packages/backend-core/src/migrations/index.js
+++ b/packages/backend-core/src/migrations/index.js
@@ -22,6 +22,7 @@ exports.getMigrationsDoc = async db => {
     if (err.status && err.status === 404) {
       return { _id: DocumentTypes.MIGRATIONS }
     }
+    console.error(err)
   }
 }
 

--- a/packages/backend-core/src/migrations/index.js
+++ b/packages/backend-core/src/migrations/index.js
@@ -95,6 +95,8 @@ exports.runMigrations = async (CouchDB, migrations, options = {}) => {
     if (!options.tenantIds || !options.tenantIds.length) {
       // run for all tenants
       tenantIds = await getTenantIds()
+    } else {
+      tenantIds = options.tenantIds
     }
   } else {
     // single tenancy

--- a/packages/bbui/package.json
+++ b/packages/bbui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/bbui",
   "description": "A UI solution used in the different Budibase projects.",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "license": "MPL-2.0",
   "svelte": "src/index.js",
   "module": "dist/bbui.es.js",

--- a/packages/bbui/package.json
+++ b/packages/bbui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/bbui",
   "description": "A UI solution used in the different Budibase projects.",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "license": "MPL-2.0",
   "svelte": "src/index.js",
   "module": "dist/bbui.es.js",

--- a/packages/bbui/package.json
+++ b/packages/bbui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/bbui",
   "description": "A UI solution used in the different Budibase projects.",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "license": "MPL-2.0",
   "svelte": "src/index.js",
   "module": "dist/bbui.es.js",

--- a/packages/bbui/package.json
+++ b/packages/bbui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/bbui",
   "description": "A UI solution used in the different Budibase projects.",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "license": "MPL-2.0",
   "svelte": "src/index.js",
   "module": "dist/bbui.es.js",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/builder",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "license": "GPL-3.0",
   "private": true,
   "scripts": {
@@ -64,10 +64,10 @@
     }
   },
   "dependencies": {
-    "@budibase/bbui": "^1.0.70",
-    "@budibase/client": "^1.0.70",
-    "@budibase/frontend-core": "^1.0.70",
-    "@budibase/string-templates": "^1.0.70",
+    "@budibase/bbui": "^1.0.71",
+    "@budibase/client": "^1.0.71",
+    "@budibase/frontend-core": "^1.0.71",
+    "@budibase/string-templates": "^1.0.71",
     "@sentry/browser": "5.19.1",
     "@spectrum-css/page": "^3.0.1",
     "@spectrum-css/vars": "^3.0.1",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/builder",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "license": "GPL-3.0",
   "private": true,
   "scripts": {
@@ -64,10 +64,10 @@
     }
   },
   "dependencies": {
-    "@budibase/bbui": "^1.0.69",
-    "@budibase/client": "^1.0.69",
-    "@budibase/frontend-core": "^1.0.69",
-    "@budibase/string-templates": "^1.0.69",
+    "@budibase/bbui": "^1.0.70",
+    "@budibase/client": "^1.0.70",
+    "@budibase/frontend-core": "^1.0.70",
+    "@budibase/string-templates": "^1.0.70",
     "@sentry/browser": "5.19.1",
     "@spectrum-css/page": "^3.0.1",
     "@spectrum-css/vars": "^3.0.1",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/builder",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "license": "GPL-3.0",
   "private": true,
   "scripts": {
@@ -64,10 +64,10 @@
     }
   },
   "dependencies": {
-    "@budibase/bbui": "^1.0.68",
-    "@budibase/client": "^1.0.68",
-    "@budibase/frontend-core": "^1.0.68",
-    "@budibase/string-templates": "^1.0.68",
+    "@budibase/bbui": "^1.0.69",
+    "@budibase/client": "^1.0.69",
+    "@budibase/frontend-core": "^1.0.69",
+    "@budibase/string-templates": "^1.0.69",
     "@sentry/browser": "5.19.1",
     "@spectrum-css/page": "^3.0.1",
     "@spectrum-css/vars": "^3.0.1",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/builder",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "license": "GPL-3.0",
   "private": true,
   "scripts": {
@@ -64,10 +64,10 @@
     }
   },
   "dependencies": {
-    "@budibase/bbui": "^1.0.71",
-    "@budibase/client": "^1.0.71",
-    "@budibase/frontend-core": "^1.0.71",
-    "@budibase/string-templates": "^1.0.71",
+    "@budibase/bbui": "^1.0.72",
+    "@budibase/client": "^1.0.72",
+    "@budibase/frontend-core": "^1.0.72",
+    "@budibase/string-templates": "^1.0.72",
     "@sentry/browser": "5.19.1",
     "@spectrum-css/page": "^3.0.1",
     "@spectrum-css/vars": "^3.0.1",

--- a/packages/builder/src/components/common/bindings/BindingPanel.svelte
+++ b/packages/builder/src/components/common/bindings/BindingPanel.svelte
@@ -146,7 +146,7 @@
                   <div class="helper__description">
                     {@html helper.description}
                   </div>
-                  <pre class="helper__example">{helper.example || ''}</pre>
+                  <pre class="helper__example">{helper.example || ""}</pre>
                 </div>
               </li>
             {/each}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/cli",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "description": "Budibase CLI, for developers, self hosting and migrations.",
   "main": "src/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/cli",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "description": "Budibase CLI, for developers, self hosting and migrations.",
   "main": "src/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/cli",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "description": "Budibase CLI, for developers, self hosting and migrations.",
   "main": "src/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/cli",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "description": "Budibase CLI, for developers, self hosting and migrations.",
   "main": "src/index.js",
   "bin": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/client",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "license": "MPL-2.0",
   "module": "dist/budibase-client.js",
   "main": "dist/budibase-client.js",
@@ -19,9 +19,9 @@
     "dev:builder": "rollup -cw"
   },
   "dependencies": {
-    "@budibase/bbui": "^1.0.70",
-    "@budibase/frontend-core": "^1.0.70",
-    "@budibase/string-templates": "^1.0.70",
+    "@budibase/bbui": "^1.0.71",
+    "@budibase/frontend-core": "^1.0.71",
+    "@budibase/string-templates": "^1.0.71",
     "regexparam": "^1.3.0",
     "rollup-plugin-polyfill-node": "^0.8.0",
     "shortid": "^2.2.15",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/client",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "license": "MPL-2.0",
   "module": "dist/budibase-client.js",
   "main": "dist/budibase-client.js",
@@ -19,9 +19,9 @@
     "dev:builder": "rollup -cw"
   },
   "dependencies": {
-    "@budibase/bbui": "^1.0.68",
-    "@budibase/frontend-core": "^1.0.68",
-    "@budibase/string-templates": "^1.0.68",
+    "@budibase/bbui": "^1.0.69",
+    "@budibase/frontend-core": "^1.0.69",
+    "@budibase/string-templates": "^1.0.69",
     "regexparam": "^1.3.0",
     "rollup-plugin-polyfill-node": "^0.8.0",
     "shortid": "^2.2.15",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/client",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "license": "MPL-2.0",
   "module": "dist/budibase-client.js",
   "main": "dist/budibase-client.js",
@@ -19,9 +19,9 @@
     "dev:builder": "rollup -cw"
   },
   "dependencies": {
-    "@budibase/bbui": "^1.0.71",
-    "@budibase/frontend-core": "^1.0.71",
-    "@budibase/string-templates": "^1.0.71",
+    "@budibase/bbui": "^1.0.72",
+    "@budibase/frontend-core": "^1.0.72",
+    "@budibase/string-templates": "^1.0.72",
     "regexparam": "^1.3.0",
     "rollup-plugin-polyfill-node": "^0.8.0",
     "shortid": "^2.2.15",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/client",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "license": "MPL-2.0",
   "module": "dist/budibase-client.js",
   "main": "dist/budibase-client.js",
@@ -19,9 +19,9 @@
     "dev:builder": "rollup -cw"
   },
   "dependencies": {
-    "@budibase/bbui": "^1.0.69",
-    "@budibase/frontend-core": "^1.0.69",
-    "@budibase/string-templates": "^1.0.69",
+    "@budibase/bbui": "^1.0.70",
+    "@budibase/frontend-core": "^1.0.70",
+    "@budibase/string-templates": "^1.0.70",
     "regexparam": "^1.3.0",
     "rollup-plugin-polyfill-node": "^0.8.0",
     "shortid": "^2.2.15",

--- a/packages/frontend-core/package.json
+++ b/packages/frontend-core/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@budibase/frontend-core",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "description": "Budibase frontend core libraries used in builder and client",
   "author": "Budibase",
   "license": "MPL-2.0",
   "svelte": "src/index.js",
   "dependencies": {
-    "@budibase/bbui": "^1.0.70",
+    "@budibase/bbui": "^1.0.71",
     "lodash": "^4.17.21",
     "svelte": "^3.46.2"
   }

--- a/packages/frontend-core/package.json
+++ b/packages/frontend-core/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@budibase/frontend-core",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "description": "Budibase frontend core libraries used in builder and client",
   "author": "Budibase",
   "license": "MPL-2.0",
   "svelte": "src/index.js",
   "dependencies": {
-    "@budibase/bbui": "^1.0.69",
+    "@budibase/bbui": "^1.0.70",
     "lodash": "^4.17.21",
     "svelte": "^3.46.2"
   }

--- a/packages/frontend-core/package.json
+++ b/packages/frontend-core/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@budibase/frontend-core",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "description": "Budibase frontend core libraries used in builder and client",
   "author": "Budibase",
   "license": "MPL-2.0",
   "svelte": "src/index.js",
   "dependencies": {
-    "@budibase/bbui": "^1.0.68",
+    "@budibase/bbui": "^1.0.69",
     "lodash": "^4.17.21",
     "svelte": "^3.46.2"
   }

--- a/packages/frontend-core/package.json
+++ b/packages/frontend-core/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@budibase/frontend-core",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "description": "Budibase frontend core libraries used in builder and client",
   "author": "Budibase",
   "license": "MPL-2.0",
   "svelte": "src/index.js",
   "dependencies": {
-    "@budibase/bbui": "^1.0.71",
+    "@budibase/bbui": "^1.0.72",
     "lodash": "^4.17.21",
     "svelte": "^3.46.2"
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/server",
   "email": "hi@budibase.com",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "description": "Budibase Web Server",
   "main": "src/index.ts",
   "repository": {
@@ -73,9 +73,9 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.0.3",
-    "@budibase/backend-core": "^1.0.71",
-    "@budibase/client": "^1.0.71",
-    "@budibase/string-templates": "^1.0.71",
+    "@budibase/backend-core": "^1.0.72",
+    "@budibase/client": "^1.0.72",
+    "@budibase/string-templates": "^1.0.72",
     "@bull-board/api": "^3.7.0",
     "@bull-board/koa": "^3.7.0",
     "@elastic/elasticsearch": "7.10.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/server",
   "email": "hi@budibase.com",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "description": "Budibase Web Server",
   "main": "src/index.ts",
   "repository": {
@@ -73,9 +73,9 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.0.3",
-    "@budibase/backend-core": "^1.0.69",
-    "@budibase/client": "^1.0.69",
-    "@budibase/string-templates": "^1.0.69",
+    "@budibase/backend-core": "^1.0.70",
+    "@budibase/client": "^1.0.70",
+    "@budibase/string-templates": "^1.0.70",
     "@bull-board/api": "^3.7.0",
     "@bull-board/koa": "^3.7.0",
     "@elastic/elasticsearch": "7.10.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/server",
   "email": "hi@budibase.com",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "description": "Budibase Web Server",
   "main": "src/index.ts",
   "repository": {
@@ -73,9 +73,9 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.0.3",
-    "@budibase/backend-core": "^1.0.68",
-    "@budibase/client": "^1.0.68",
-    "@budibase/string-templates": "^1.0.68",
+    "@budibase/backend-core": "^1.0.69",
+    "@budibase/client": "^1.0.69",
+    "@budibase/string-templates": "^1.0.69",
     "@bull-board/api": "^3.7.0",
     "@bull-board/koa": "^3.7.0",
     "@elastic/elasticsearch": "7.10.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/server",
   "email": "hi@budibase.com",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "description": "Budibase Web Server",
   "main": "src/index.ts",
   "repository": {
@@ -73,9 +73,9 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.0.3",
-    "@budibase/backend-core": "^1.0.70",
-    "@budibase/client": "^1.0.70",
-    "@budibase/string-templates": "^1.0.70",
+    "@budibase/backend-core": "^1.0.71",
+    "@budibase/client": "^1.0.71",
+    "@budibase/string-templates": "^1.0.71",
     "@bull-board/api": "^3.7.0",
     "@bull-board/koa": "^3.7.0",
     "@elastic/elasticsearch": "7.10.0",

--- a/packages/server/scripts/dev/manage.js
+++ b/packages/server/scripts/dev/manage.js
@@ -37,7 +37,7 @@ async function init() {
     const envFileJson = {
       PORT: 4001,
       MINIO_URL: "http://localhost:4004",
-      COUCH_DB_URL: "http://budibase:budibase@localhost:10000/db/",
+      COUCH_DB_URL: "http://budibase:budibase@localhost:4005",
       REDIS_URL: "localhost:6379",
       WORKER_URL: "http://localhost:4002",
       INTERNAL_API_KEY: "budibase",

--- a/packages/server/src/db/client.js
+++ b/packages/server/src/db/client.js
@@ -5,7 +5,7 @@ const allDbs = require("pouchdb-all-dbs")
 const find = require("pouchdb-find")
 const env = require("../environment")
 
-const COUCH_DB_URL = getCouchUrl() || "http://localhost:10000/db/"
+const COUCH_DB_URL = getCouchUrl() || "http://localhost:4005"
 
 PouchDB.plugin(replicationStream.plugin)
 PouchDB.plugin(find)

--- a/packages/string-templates/package.json
+++ b/packages/string-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/string-templates",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "description": "Handlebars wrapper for Budibase templating.",
   "main": "src/index.cjs",
   "module": "dist/bundle.mjs",

--- a/packages/string-templates/package.json
+++ b/packages/string-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/string-templates",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "description": "Handlebars wrapper for Budibase templating.",
   "main": "src/index.cjs",
   "module": "dist/bundle.mjs",

--- a/packages/string-templates/package.json
+++ b/packages/string-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/string-templates",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "description": "Handlebars wrapper for Budibase templating.",
   "main": "src/index.cjs",
   "module": "dist/bundle.mjs",

--- a/packages/string-templates/package.json
+++ b/packages/string-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/string-templates",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "description": "Handlebars wrapper for Budibase templating.",
   "main": "src/index.cjs",
   "module": "dist/bundle.mjs",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/worker",
   "email": "hi@budibase.com",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "description": "Budibase background service",
   "main": "src/index.ts",
   "repository": {
@@ -34,8 +34,8 @@
   "author": "Budibase",
   "license": "GPL-3.0",
   "dependencies": {
-    "@budibase/backend-core": "^1.0.69",
-    "@budibase/string-templates": "^1.0.69",
+    "@budibase/backend-core": "^1.0.70",
+    "@budibase/string-templates": "^1.0.70",
     "@koa/router": "^8.0.0",
     "@sentry/node": "^6.0.0",
     "@techpass/passport-openidconnect": "^0.3.0",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/worker",
   "email": "hi@budibase.com",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "description": "Budibase background service",
   "main": "src/index.ts",
   "repository": {
@@ -34,8 +34,8 @@
   "author": "Budibase",
   "license": "GPL-3.0",
   "dependencies": {
-    "@budibase/backend-core": "^1.0.71",
-    "@budibase/string-templates": "^1.0.71",
+    "@budibase/backend-core": "^1.0.72",
+    "@budibase/string-templates": "^1.0.72",
     "@koa/router": "^8.0.0",
     "@sentry/node": "^6.0.0",
     "@techpass/passport-openidconnect": "^0.3.0",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/worker",
   "email": "hi@budibase.com",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "description": "Budibase background service",
   "main": "src/index.ts",
   "repository": {
@@ -34,8 +34,8 @@
   "author": "Budibase",
   "license": "GPL-3.0",
   "dependencies": {
-    "@budibase/backend-core": "^1.0.70",
-    "@budibase/string-templates": "^1.0.70",
+    "@budibase/backend-core": "^1.0.71",
+    "@budibase/string-templates": "^1.0.71",
     "@koa/router": "^8.0.0",
     "@sentry/node": "^6.0.0",
     "@techpass/passport-openidconnect": "^0.3.0",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/worker",
   "email": "hi@budibase.com",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "description": "Budibase background service",
   "main": "src/index.ts",
   "repository": {
@@ -34,8 +34,8 @@
   "author": "Budibase",
   "license": "GPL-3.0",
   "dependencies": {
-    "@budibase/backend-core": "^1.0.68",
-    "@budibase/string-templates": "^1.0.68",
+    "@budibase/backend-core": "^1.0.69",
+    "@budibase/string-templates": "^1.0.69",
     "@koa/router": "^8.0.0",
     "@sentry/node": "^6.0.0",
     "@techpass/passport-openidconnect": "^0.3.0",

--- a/packages/worker/scripts/dev/manage.js
+++ b/packages/worker/scripts/dev/manage.js
@@ -16,7 +16,7 @@ async function init() {
       REDIS_URL: "localhost:6379",
       REDIS_PASSWORD: "budibase",
       MINIO_URL: "http://localhost:4004",
-      COUCH_DB_URL: "http://budibase:budibase@localhost:10000/db/",
+      COUCH_DB_URL: "http://budibase:budibase@localhost:4005",
       COUCH_DB_USERNAME: "budibase",
       COUCH_DB_PASSWORD: "budibase",
       // empty string is false

--- a/packages/worker/src/db/index.js
+++ b/packages/worker/src/db/index.js
@@ -4,7 +4,7 @@ const env = require("../environment")
 const { getCouchUrl } = require("@budibase/backend-core/db")
 
 // level option is purely for testing (development)
-const COUCH_DB_URL = getCouchUrl() || "http://localhost:10000/db/"
+const COUCH_DB_URL = getCouchUrl() || "http://localhost:4005"
 
 let POUCH_DB_DEFAULTS = {
   prefix: COUCH_DB_URL,


### PR DESCRIPTION
## Description
Update the migration handler to use the `tenantIds` when supplied (previously this was just being ignored)



