### PR TITLE
Convert roleId prop to reactive prop

### DIFF
--- a/packages/builder/src/components/design/NavigationPanel/ScreenWizard.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/ScreenWizard.svelte
@@ -6,13 +6,14 @@
   import { store, selectedAccessRole, allScreens } from "builderStore"
   import analytics, { Events } from "analytics"
 
+  $: roleId = $selectedAccessRole || "BASIC"
+
   let newScreenModal
   let navigationSelectionModal
   let screenDetailsModal
   let screenName = ""
   let url = ""
   let selectedScreens = []
-  let roleId = $selectedAccessRole || "BASIC"
   let showProgressCircle = false
   let routeError
   let createdScreens = []


### PR DESCRIPTION
## Description
The prop roleId is set after the creation of the screen, which always results in 'BASIC'. When it's reactive, it will always re-evaluate it's value when used.
Fixes #4506



