### PR TITLE
Rename filter to be condition

### DIFF
--- a/packages/server/src/automations/steps/filter.js
+++ b/packages/server/src/automations/steps/filter.js
@@ -16,10 +16,10 @@ exports.FilterConditions = FilterConditions
 exports.PrettyFilterConditions = PrettyFilterConditions
 
 exports.definition = {
-  name: "Filter",
+  name: "Condition",
   tagline: "{{inputs.field}} {{inputs.condition}} {{inputs.value}}",
   icon: "Branch2",
-  description: "Filter any automations which do not meet certain conditions",
+  description: "Conditionally halt automations which do not meet certain conditions",
   type: "LOGIC",
   internal: true,
   stepId: "FILTER",

--- a/packages/server/src/automations/steps/filter.js
+++ b/packages/server/src/automations/steps/filter.js
@@ -19,7 +19,8 @@ exports.definition = {
   name: "Condition",
   tagline: "{{inputs.field}} {{inputs.condition}} {{inputs.value}}",
   icon: "Branch2",
-  description: "Conditionally halt automations which do not meet certain conditions",
+  description:
+    "Conditionally halt automations which do not meet certain conditions",
   type: "LOGIC",
   internal: true,
   stepId: "FILTER",


### PR DESCRIPTION
## Description
The "Filter" automation step is unclear in naming, what it actually does, is conditionally halt or proceed within an automation. I've updated the name and description to reflect this.


