### PR TITLE
Fix asset type selection

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[assetType]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[assetType]/index.svelte
@@ -45,6 +45,14 @@
         store.actions.screens.select(id)
       }
     }
+
+    // If we didn't find a valid asset, just update the preview type
+    if (!id) {
+      store.update(state => {
+        state.currentFrontEndType = assetType
+        return state
+      })
+    }
   }
 </script>
 

--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -108,7 +108,7 @@
               <!-- Actual app -->
               <div id="app-root">
                 <CustomThemeWrapper>
-                  {#key $screenStore.activeLayout._id}
+                  {#key `${$screenStore.activeLayout._id}-${$builderStore.previewType}`}
                     <Component
                       isLayout
                       instance={$screenStore.activeLayout.props}


### PR DESCRIPTION
## Description
This is a quick fix for https://github.com/Budibase/budibase/issues/4075. The real issue was that whenever no assets of a certain type exist (for example when you have no screens in a fresh app), and you click on layouts and then back to screens, state was not update as a valid screen could not be found. This mean that the client preview never changed. The logic that normally updates state is inside `packages/builder/src/pages/builder/app/[application]/design/[assetType]/index.svelte`.

The issue was compounded with the fact that client app previews inside the builder did not always remount properly, if you toggled between a layout and a screen that shared the same layout ID. This PR fixes this by adding the current builder preview asset type to the keying of the rendering of the layout. This is fine for production apps too as this string will always just evaluate to `null`.


