### PR TITLE
[feature] select all datatable rows

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,6 +5,9 @@
   "trailingComma": "es5",
   "arrowParens": "avoid",
   "jsxBracketSameLine": false,
-  "plugins": ["prettier-plugin-svelte"],
+  "endOfLine": "auto",
+  "plugins": [
+    "prettier-plugin-svelte"
+  ],
   "svelteSortOrder": "options-scripts-markup-styles"
 }

--- a/packages/bbui/src/Table/Table.svelte
+++ b/packages/bbui/src/Table/Table.svelte
@@ -5,6 +5,7 @@
   import SelectEditRenderer from "./SelectEditRenderer.svelte"
   import { cloneDeep, deepGet } from "../helpers"
   import ProgressCircle from "../ProgressCircle/ProgressCircle.svelte"
+  import Checkbox from "../Form/Checkbox.svelte"
 
   /**
    * The expected schema is our normal couch schemas for our tables.
@@ -36,6 +37,7 @@
   export let disableSorting = false
   export let autoSortColumns = true
   export let compact = false
+  export let allSelected = false
 
   const dispatch = createEventDispatcher()
 
@@ -202,6 +204,17 @@
     } else {
       selectedRows = [...selectedRows, row]
     }
+    allSelected = selectedRows.length === rows.length
+  }
+  const toggleAllSelected = () => {
+    if (!allowSelectRows) {
+      return
+    }
+    if (!allSelected) {
+      selectedRows = []
+    } else {
+      selectedRows = [...rows]
+    }
   }
 
   const computeCellStyles = schema => {
@@ -244,6 +257,12 @@
             <div
               class="spectrum-Table-headCell spectrum-Table-headCell--divider spectrum-Table-headCell--edit"
             >
+              {#if allowSelectRows}
+                <Checkbox
+                  bind:value={allSelected}
+                  on:change={toggleAllSelected}
+                />
+              {/if}
               {editColumnTitle || ""}
             </div>
           {/if}

--- a/packages/builder/cypress/integration/createTable.spec.js
+++ b/packages/builder/cypress/integration/createTable.spec.js
@@ -44,7 +44,7 @@ filterTests(["smoke", "all"], () => {
     })
 
     it("deletes a row", () => {
-      cy.get(".spectrum-Checkbox-input").check({ force: true })
+      cy.get(".spectrum-Table-row > .spectrum-Checkbox-input").check({ force: true })
       cy.contains("Delete 1 row(s)").click()
       cy.get(".spectrum-Modal").contains("Delete").click()
       cy.contains("RoverUpdated").should("not.exist")

--- a/packages/builder/src/components/backend/DataTable/Table.svelte
+++ b/packages/builder/src/components/backend/DataTable/Table.svelte
@@ -27,6 +27,7 @@
   export let disableSorting = false
 
   let selectedRows = []
+  let allSelected = false
   let editableColumn
   let editableRow
   let editRowModal
@@ -79,6 +80,7 @@
 
   const resetSelectedRows = () => {
     selectedRows = []
+    allSelected = false
   }
 
   const selectRelationship = ({ tableId, rowId, fieldName }) => {
@@ -145,6 +147,7 @@
         {rowCount}
         {disableSorting}
         bind:selectedRows
+        bind:allSelected
         allowSelectRows={allowEditing && !isUsersTable}
         allowEditRows={allowEditing}
         allowEditColumns={allowEditing}


### PR DESCRIPTION
## Description
In the admin data screens I would like to select all rows by clicking a "select all" button.
The checkbox should auto check if all the rows are manually selected.
The checkbox should auto un-check if any of the rows are manually deselected.
The checkbox should auto un-check when new rows are loaded.

N.b. I was unable to run the cypress tests to determine if the cypress test change was valid.

## Screenshots
![image](https://user-images.githubusercontent.com/3536589/155789685-6c5eb2da-640c-439f-9f9b-7cb514308116.png)
![image](https://user-images.githubusercontent.com/3536589/155789772-10ab2339-481a-46a5-a9ff-60ad4f6aced8.png)




