### PR TITLE
Fix execute query action

### DIFF
--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -133,6 +133,10 @@ const queryExecutionHandler = async action => {
 
     return { result }
   } catch (error) {
+    notificationStore.actions.error(
+      "An error occurred while executing the query"
+    )
+
     // Abort next actions
     return false
   }

--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -127,7 +127,7 @@ const queryExecutionHandler = async action => {
     // Trigger a notification and invalidate the datasource as long as this
     // was not a readable query
     if (!query.readable) {
-      API.notifications.error.success("Query executed successfully")
+      notificationStore.actions.success("Query executed successfully")
       await dataSourceStore.actions.invalidateDataSource(query.datasourceId)
     }
 


### PR DESCRIPTION
## Description
Quick fix for the execute query button action, which was working but then always throwing an error (for non-readable queries) due to incorrect syntax for showing a notification. This prevented automatic refreshing of data providers and prevented further button actions.

Also adding in an error notification since we should never have silent errors.

Fixes https://github.com/Budibase/budibase/issues/4548
