### PR TITLE
Make view UI read only and limit rows to 10

### DIFF
--- a/packages/builder/src/components/backend/DataTable/ViewDataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/ViewDataTable.svelte
@@ -57,7 +57,8 @@
   {data}
   {loading}
   {type}
-  allowEditing={!view?.calculation}
+  allowEditing={false}
+  rowCount={10}
   bind:hideAutocolumns
 >
   <ViewFilterButton {view} />


### PR DESCRIPTION
## Description
This PR makes the view data UI readonly, in that you can't edit rows or columns. I believe this was always the intended functionality, but at some point we must have opened this up accidentally.

I've also limited the view UI to show 10 rows at once before the table scrolls (the same as the table UI) as otherwise the table will never scroll vertically, which in turn makes it very hard to scroll horizontally if required.

Fixes https://github.com/Budibase/budibase/issues/4723.



