### PR TITLE
Improve parsing of REST query strings to support equals symbol in values

### DIFF
--- a/packages/builder/src/helpers/data/utils.js
+++ b/packages/builder/src/helpers/data/utils.js
@@ -30,8 +30,8 @@ export function breakQueryString(qs) {
   const params = qs.split("&")
   let paramObj = {}
   for (let param of params) {
-    const [key, value] = param.split("=")
-    paramObj[key] = value
+    const split = param.split("=")
+    paramObj[split[0]] = split.slice(1).join("=")
   }
   return paramObj
 }


### PR DESCRIPTION
## Description
This PR updates the builder parsing of REST queries to support an equals symbol `=` in values, as previously this was not accounted for. While I would highly discourage using an `=` in a query string with multiple values, it is technically a valid URL.

Fixes https://github.com/Budibase/budibase/issues/4667.



