### PR TITLE
Changes for Table test - Commands.js

### DIFF
--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -39,7 +39,7 @@ Cypress.Commands.add("createApp", name => {
   cy.get(".spectrum-Modal").within(() => {
     cy.get("input").eq(0).type(name).should("have.value", name).blur()
     cy.get(".spectrum-ButtonGroup").contains("Create app").click()
-    cy.wait(5000)
+    cy.wait(10000)
   })
   cy.createTable("Cypress Tests", true)
 })
@@ -116,10 +116,10 @@ Cypress.Commands.add("createTestTableWithData", () => {
 Cypress.Commands.add("createTable", (tableName, initialTable) => {
   if (!initialTable) {
     cy.navigateToDataSection()
-    cy.get(".add-button").click()
+    cy.get(`[data-cy="new-table"]`).click()
   }
-  cy.wait(7000)
-  cy.get(".spectrum-Modal")
+  cy.wait(5000)
+  cy.get(".spectrum-Dialog-grid")
     .contains("Budibase DB")
     .click({ force: true })
     .then(() => {


### PR DESCRIPTION
Seems like a potential timing issue for the Create Table test

Specifically:
-The datasource modal looks to be sometimes delayed when appearing after app creation
--increasing wait time for after app creation
--Reducing wait within the createTable command
--Updating specific ID to use 'data-cy'
--Updating another ID for the data source modal

I am unable to reproduce this potential issue locally, so making changes in hopes the CI picks it up (if the timing issue still exists)



