### PR TITLE
Minor OpenAPI spec change

### DIFF
--- a/packages/server/specs/generate.js
+++ b/packages/server/specs/generate.js
@@ -17,14 +17,8 @@ const options = {
     },
     servers: [
       {
-        url: "https://{organisationId}.budibase.app/api/public/v1",
+        url: "https://budibase.app/api/public/v1",
         description: "Budibase Cloud API",
-        variables: {
-          organisationId: {
-            default: "organisation",
-            description: "The organisation you are attempting to access.",
-          },
-        },
       },
       {
         url: "{protocol}://{hostname}/api/public/v1",

--- a/packages/server/specs/generate.js
+++ b/packages/server/specs/generate.js
@@ -17,12 +17,29 @@ const options = {
     },
     servers: [
       {
-        url: "http://budibase.app/api/public/v1",
+        url: "https://{organisationId}.budibase.app/api/public/v1",
         description: "Budibase Cloud API",
+        variables: {
+          organisationId: {
+            default: "organisation",
+            description: "The organisation you are attempting to access.",
+          },
+        },
       },
       {
-        url: "{protocol}://{hostname}:10000/api/public/v1",
+        url: "{protocol}://{hostname}/api/public/v1",
         description: "Budibase self hosted API",
+        variables: {
+          protocol: {
+            default: "http",
+            description:
+              "Whether HTTP or HTTPS should be used to communicate with your Budibase instance.",
+          },
+          hostname: {
+            default: "localhost:10000",
+            description: "The URL of your Budibase instance.",
+          },
+        },
       },
     ],
     components: {

--- a/packages/server/specs/openapi.json
+++ b/packages/server/specs/openapi.json
@@ -7,12 +7,28 @@
   },
   "servers": [
     {
-      "url": "http://budibase.app/api/public/v1",
-      "description": "Budibase Cloud API"
+      "url": "https://{organisationId}.budibase.app/api/public/v1",
+      "description": "Budibase Cloud API",
+      "variables": {
+        "organisationId": {
+          "default": "organisation",
+          "description": "The organisation you are attempting to access."
+        }
+      }
     },
     {
-      "url": "{protocol}://{hostname}:10000/api/public/v1",
-      "description": "Budibase self hosted API"
+      "url": "{protocol}://{hostname}/api/public/v1",
+      "description": "Budibase self hosted API",
+      "variables": {
+        "protocol": {
+          "default": "http",
+          "description": "Whether HTTP or HTTPS should be used to communicate with your Budibase instance."
+        },
+        "hostname": {
+          "default": "localhost:10000",
+          "description": "The URL of your Budibase instance."
+        }
+      }
     }
   ],
   "components": {

--- a/packages/server/specs/openapi.json
+++ b/packages/server/specs/openapi.json
@@ -7,14 +7,8 @@
   },
   "servers": [
     {
-      "url": "https://{organisationId}.budibase.app/api/public/v1",
-      "description": "Budibase Cloud API",
-      "variables": {
-        "organisationId": {
-          "default": "organisation",
-          "description": "The organisation you are attempting to access."
-        }
-      }
+      "url": "https://budibase.app/api/public/v1",
+      "description": "Budibase Cloud API"
     },
     {
       "url": "{protocol}://{hostname}/api/public/v1",

--- a/packages/server/specs/openapi.yaml
+++ b/packages/server/specs/openapi.yaml
@@ -4,10 +4,22 @@ info:
   description: The public API for Budibase apps and its services.
   version: 1.0.0
 servers:
-  - url: http://budibase.app/api/public/v1
+  - url: https://{organisationId}.budibase.app/api/public/v1
     description: Budibase Cloud API
-  - url: "{protocol}://{hostname}:10000/api/public/v1"
+    variables:
+      organisationId:
+        default: organisation
+        description: The organisation you are attempting to access.
+  - url: "{protocol}://{hostname}/api/public/v1"
     description: Budibase self hosted API
+    variables:
+      protocol:
+        default: http
+        description: Whether HTTP or HTTPS should be used to communicate with your
+          Budibase instance.
+      hostname:
+        default: localhost:10000
+        description: The URL of your Budibase instance.
 components:
   parameters:
     tableId:

--- a/packages/server/specs/openapi.yaml
+++ b/packages/server/specs/openapi.yaml
@@ -4,12 +4,8 @@ info:
   description: The public API for Budibase apps and its services.
   version: 1.0.0
 servers:
-  - url: https://{organisationId}.budibase.app/api/public/v1
+  - url: https://budibase.app/api/public/v1
     description: Budibase Cloud API
-    variables:
-      organisationId:
-        default: organisation
-        description: The organisation you are attempting to access.
   - url: "{protocol}://{hostname}/api/public/v1"
     description: Budibase self hosted API
     variables:


### PR DESCRIPTION
## Description
I was playing around with the spec in Readme, noted there was no easy way to set the tenant ID/org ID when dealing with the Cloud, added it as a variable to the server spec. Also updated the local server spec so that the protocol and host can be set as variables as well - this is important for being able to make calls directly from Readme/copy and pasting the cURL requests directly.

Looks like this in Readme:
![image](https://user-images.githubusercontent.com/4407001/157043329-6def2ebb-d5c5-4b4a-af1c-34f5fe030c47.png)