### PR TITLE
show correct error and keep modal open

### DIFF
--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/DatasourceConfigModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/DatasourceConfigModal.svelte
@@ -20,7 +20,9 @@
       $goto(`./datasource/${resp._id}`)
       notifications.success(`Datasource updated successfully.`)
     } catch (err) {
-      notifications.error("Error saving datasource")
+      notifications.error(err?.message ?? "Error saving datasource")
+      // prevent the modal from closing
+      return false
     }
   }
 


### PR DESCRIPTION
## Description
When the connection to a data source fails, a very generic error is thrown and the modal is closed. This should not happen, the user should be able to fix the issue and know what's wrong. This PR fixes #4812 

## Screenshots
<img width="798" alt="image" src="https://user-images.githubusercontent.com/1907152/157216423-7274a87b-2999-4826-8f4b-aebc1561f6f1.png">



