### PR TITLE
Add css print styles to ensure multi-page print is possible

### DIFF
--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -227,6 +227,7 @@
     border-radius: 4px;
   }
 
+  /* Print styles */
   @media print {
     #spectrum-root,
     #clip-root,

--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -226,4 +226,12 @@
     border: 1px solid var(--spectrum-global-color-gray-300);
     border-radius: 4px;
   }
+
+  @media print {
+    #spectrum-root,
+    #clip-root,
+    #app-root {
+      overflow: visible !important;
+    }
+  }
 </style>

--- a/packages/client/src/components/app/Layout.svelte
+++ b/packages/client/src/components/app/Layout.svelte
@@ -427,4 +427,20 @@
     height: var(--height);
     z-index: 998;
   }
+
+  /* Print styles */
+  @media print {
+    .layout,
+    .main-wrapper {
+      overflow: visible !important;
+    }
+    .nav-wrapper {
+      display: none !important;
+    }
+    .layout {
+      flex-direction: column !important;
+      justify-content: flex-start !important;
+      align-items: stretch !important;
+    }
+  }
 </style>


### PR DESCRIPTION
## Description
This PR adds `print` media queries to ensure the app looks good when printed. It ensures content spans multiple pages when required and also removes the nav bar.

Unfortunately as our table uses a grid layout we cannot control the page break behaviour, which means that sometimes breaks might occur in the middle of rows. But apart from this edge case things work well.

Fixes https://github.com/Budibase/budibase/issues/4870.



