### PR TITLE
Quick fixes for Public API and spec

### DIFF
--- a/packages/backend-core/src/redis/utils.js
+++ b/packages/backend-core/src/redis/utils.js
@@ -22,12 +22,25 @@ exports.Databases = {
 exports.SEPARATOR = SEPARATOR
 
 exports.getRedisOptions = (clustered = false) => {
-  const [host, port, ...rest] = REDIS_URL.split(":")
+  let password = REDIS_PASSWORD
+  let url = REDIS_URL.split("//")
+  // get rid of the protocol
+  url = url.length > 1 ? url[1] : url[0]
+  // check for a password etc
+  url = url.split("@")
+  if (url.length > 1) {
+    // get the password
+    password = url[0].split(":")[1]
+    url = url[1]
+  } else {
+    url = url[0]
+  }
+  const [host, port] = url.split(":")
 
   let redisProtocolUrl
 
   // fully qualified redis URL
-  if (rest.length && /rediss?/.test(host)) {
+  if (/rediss?/.test(REDIS_URL)) {
     redisProtocolUrl = REDIS_URL
   }
 
@@ -37,13 +50,13 @@ exports.getRedisOptions = (clustered = false) => {
   if (clustered) {
     opts.redisOptions = {}
     opts.redisOptions.tls = {}
-    opts.redisOptions.password = REDIS_PASSWORD
+    opts.redisOptions.password = password
     opts.slotsRefreshTimeout = SLOT_REFRESH_MS
     opts.dnsLookup = (address, callback) => callback(null, address)
   } else {
     opts.host = host
     opts.port = port
-    opts.password = REDIS_PASSWORD
+    opts.password = password
   }
   return { opts, host, port, redisProtocolUrl }
 }

--- a/packages/server/specs/openapi.json
+++ b/packages/server/specs/openapi.json
@@ -437,8 +437,7 @@
           }
         },
         "required": [
-          "name",
-          "url"
+          "name"
         ]
       },
       "applicationOutput": {
@@ -1802,11 +1801,6 @@
         "description": "Based on application properties (currently only name) search for applications.",
         "tags": [
           "applications"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/appId"
-          }
         ],
         "requestBody": {
           "required": true,

--- a/packages/server/specs/openapi.yaml
+++ b/packages/server/specs/openapi.yaml
@@ -309,7 +309,6 @@ components:
           type: string
       required:
         - name
-        - url
     applicationOutput:
       type: object
       properties:
@@ -1346,8 +1345,6 @@ paths:
         applications.
       tags:
         - applications
-      parameters:
-        - $ref: "#/components/parameters/appId"
       requestBody:
         required: true
         content:

--- a/packages/server/specs/resources/application.js
+++ b/packages/server/specs/resources/application.js
@@ -27,7 +27,7 @@ const base = {
   },
 }
 
-const applicationSchema = object(base, { required: ["name", "url"] })
+const applicationSchema = object(base, { required: ["name"] })
 
 const applicationOutputSchema = object(
   {

--- a/packages/server/src/api/routes/public/applications.ts
+++ b/packages/server/src/api/routes/public/applications.ts
@@ -121,8 +121,6 @@ read.push(new Endpoint("get", "/applications/:appId", controller.read))
  *     description: Based on application properties (currently only name) search for applications.
  *     tags:
  *       - applications
- *     parameters:
- *       - $ref: '#/components/parameters/appId'
  *     requestBody:
  *       required: true
  *       content:

--- a/packages/server/src/definitions/openapi.ts
+++ b/packages/server/src/definitions/openapi.ts
@@ -85,12 +85,6 @@ export interface paths {
   "/applications/search": {
     /** Based on application properties (currently only name) search for applications. */
     post: {
-      parameters: {
-        header: {
-          /** The ID of the app which this request is targeting. */
-          "x-budibase-app-id": components["parameters"]["appId"];
-        };
-      };
       responses: {
         /** Returns the applications that were found based on the search parameters. */
         200: {
@@ -554,7 +548,7 @@ export interface components {
       /** @description The name of the app. */
       name: string;
       /** @description The URL by which the app is accessed, this must be URL encoded. */
-      url: string;
+      url?: string;
     };
     applicationOutput: {
       data: {


### PR DESCRIPTION
## Description
Making the URL optional for application creation/update in OpenAPI spec, removing unused parameter and fixing `getRedisOptions` function to work with fully qualified URLs.