### PR TITLE
Fixing SQL constant character usage in queries with bindings

### DIFF
--- a/packages/server/src/integrations/base/datasourcePlus.ts
+++ b/packages/server/src/integrations/base/datasourcePlus.ts
@@ -8,5 +8,6 @@ export interface DatasourcePlus extends IntegrationBase {
   // if the datasource supports the use of bindings directly (to protect against SQL injection)
   // this returns the format of the identifier
   getBindingIdentifier(): string
+  getStringConcat(parts: string[]): string
   buildSchema(datasourceId: string, entities: Record<string, Table>): any
 }

--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -115,6 +115,10 @@ module GoogleSheetsModule {
       return ""
     }
 
+    getStringConcat(parts: string[]) {
+      return ""
+    }
+
     /**
      * Pull the spreadsheet ID out from a valid google sheets URL
      * @param spreadsheetId - the URL or standard spreadsheetId of the google sheet

--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -129,6 +129,10 @@ module MSSQLModule {
       return `(@p${this.index++})`
     }
 
+    getStringConcat(parts: string[]): string {
+      return `concat(${parts.join(", ")})`
+    }
+
     async connect() {
       try {
         this.client = await this.pool.connect()

--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -126,7 +126,7 @@ module MSSQLModule {
     }
 
     getBindingIdentifier(): string {
-      return `(@p${this.index++})`
+      return `@p${this.index++}`
     }
 
     getStringConcat(parts: string[]): string {

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -99,6 +99,10 @@ module MySQLModule {
       return "?"
     }
 
+    getStringConcat(parts: string[]): string {
+      return `concat(${parts.join(", ")})`
+    }
+
     async connect() {
       this.client = await mysql.createConnection(this.config)
     }

--- a/packages/server/src/integrations/oracle.ts
+++ b/packages/server/src/integrations/oracle.ts
@@ -179,6 +179,10 @@ module OracleModule {
       return `:${this.index++}`
     }
 
+    getStringConcat(parts: string[]): string {
+      return `concat(${parts.join(", ")})`
+    }
+
     /**
      * Map the flat tabular columns and constraints data into a nested object
      */

--- a/packages/server/src/integrations/oracle.ts
+++ b/packages/server/src/integrations/oracle.ts
@@ -180,7 +180,7 @@ module OracleModule {
     }
 
     getStringConcat(parts: string[]): string {
-      return `concat(${parts.join(", ")})`
+      return parts.join(" || ")
     }
 
     /**

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -148,6 +148,10 @@ module PostgresModule {
       return `$${this.index++}`
     }
 
+    getStringConcat(parts: string[]): string {
+      return parts.join(" || ")
+    }
+
     async internalQuery(query: SqlQuery) {
       const client = this.client
       this.index = 1


### PR DESCRIPTION
## Description
After our change to use vars in queries, there was some issues with them being used within character constants, e.g. `'{{binding}}'` would become `'$1'` which is not valid SQL syntax - the variable will break and throw an error.

 I've had to account for a few scenarios here because not only could you do something like `'{{binding}}'` but you could also do something like `'hello there {{binding}} welcome!'` which needs to be converted into some form of concat statement.

The way the concat is handled is dialect specific, so I had to add new methods to all the datasource plus implementations.

For most it will become either `concat('hello there ', $1,  'welcome!')` or `'hello there ' || $1 || ' welcome!'`. I've tested this across all of the differnet SQL datasource plus databases that we currently support, with a variety of use cases and haven't run into any issues.