### PR TITLE
Allow fully qualified redis url use in koa ratelimit store

### DIFF
--- a/packages/server/src/api/routes/public/index.ts
+++ b/packages/server/src/api/routes/public/index.ts
@@ -31,16 +31,23 @@ function getApiLimitPerSecond(): number {
 
 if (!env.isTest()) {
   const REDIS_OPTS = getRedisOptions()
-  RateLimit.defaultOptions({
-    store: new Stores.Redis({
-      // @ts-ignore
+  let options
+  if (REDIS_OPTS.redisProtocolUrl) {  // fully qualified redis URL
+    options = {
+      url: REDIS_OPTS.redisProtocolUrl,
+    }
+  } else {
+    options = {
       socket: {
         host: REDIS_OPTS.host,
         port: REDIS_OPTS.port,
       },
       password: REDIS_OPTS.opts.password,
       database: 1,
-    }),
+    }
+  }
+  RateLimit.defaultOptions({
+    store: new Stores.Redis(options)
   })
 }
 // rate limiting, allows for 2 requests per second


### PR DESCRIPTION
## Description
Adding a way to use redis over SSL as well as specifying database number through already existing option `REDIS_OPTS.redisProtocolUrl` in backend-core