### PR TITLE
Binding panel overflow

### DIFF
--- a/packages/builder/src/components/common/bindings/BindingPanel.svelte
+++ b/packages/builder/src/components/common/bindings/BindingPanel.svelte
@@ -238,9 +238,7 @@
     border: var(--border-light);
     transition: background-color 130ms ease-in-out, color 130ms ease-in-out,
       border-color 130ms ease-in-out;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    word-wrap: break-word;
   }
   li:not(:last-of-type) {
     margin-bottom: var(--spacing-s);

--- a/packages/builder/src/components/common/bindings/BindingPanel.svelte
+++ b/packages/builder/src/components/common/bindings/BindingPanel.svelte
@@ -238,6 +238,9 @@
     border: var(--border-light);
     transition: background-color 130ms ease-in-out, color 130ms ease-in-out,
       border-color 130ms ease-in-out;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   li:not(:last-of-type) {
     margin-bottom: var(--spacing-s);


### PR DESCRIPTION
## Description
Fixes #4191 - Set word-wrap to word, so the text spreads on multiple lines if it's too long.

## Screenshots
![image](https://user-images.githubusercontent.com/1907152/158681039-02ae8e51-d3c9-423b-9405-45ec2fed9296.png)


