### PR TITLE
adds the ability to paste a component on a screen

### DIFF
--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -536,18 +536,30 @@ export const getFrontendStore = () => {
             if (!selectedAsset) {
               return state
             }
-            const parent = findComponentParent(
-              selectedAsset.props,
-              targetComponent._id
-            )
-            if (!parent) {
-              return state
-            }
+            // if the selected target is a screen, add it to the children, save it, select the screen and than the component
+            if (targetComponent.layoutId) {
+              targetComponent.props._children.push(cloneDeep(componentToPaste))
 
-            // Insert the component in the correct position
-            const targetIndex = parent._children.indexOf(targetComponent)
-            const index = mode === "above" ? targetIndex : targetIndex + 1
-            parent._children.splice(index, 0, cloneDeep(componentToPaste))
+              promises.push(store.actions.preview.saveSelected())
+              store.actions.screens.select(targetComponent._id)
+              store.actions.components.select(componentToPaste)
+            } else {
+              const parent = findComponentParent(
+                selectedAsset.props,
+                targetComponent._id
+              )
+              if (!parent) {
+                return state
+              }
+
+              // Insert the component in the correct position
+              const targetIndex = parent._children.indexOf(targetComponent)
+              const index = mode === "above" ? targetIndex : targetIndex + 1
+              parent._children.splice(index, 0, cloneDeep(componentToPaste))
+
+              promises.push(store.actions.preview.saveSelected())
+              store.actions.components.select(componentToPaste)
+            }
           }
 
           // Save and select the new component

--- a/packages/builder/src/components/design/NavigationPanel/ComponentNavigationTree/ScreenDropdownMenu.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/ComponentNavigationTree/ScreenDropdownMenu.svelte
@@ -9,6 +9,7 @@
   let confirmDeleteDialog
 
   $: screen = $allScreens.find(screen => screen._id === screenId)
+  $: noPaste = !$store.componentToPaste
 
   const deleteScreen = async () => {
     try {
@@ -19,12 +20,24 @@
       notifications.error("Error deleting screen")
     }
   }
+
+  const pasteComponent = () => {
+    try {
+      // lives in store - also used by drag drop
+      store.actions.components.paste(screen, "below")
+    } catch (error) {
+      notifications.error("Error saving component")
+    }
+  }
 </script>
 
 <ActionMenu>
   <div slot="control" class="icon">
     <Icon size="S" hoverable name="MoreSmallList" />
   </div>
+  <MenuItem icon="Paste" on:click={pasteComponent} disabled={noPaste}>
+    Paste
+  </MenuItem>
   <MenuItem icon="Delete" on:click={confirmDeleteDialog.show}>Delete</MenuItem>
 </ActionMenu>
 


### PR DESCRIPTION
## Description
Fixes #4819 - paste a component on a screen
**Note:** I was not sure how to differentiate components from screens. Currently I check if the targetComponent has a layoutId (which components don't have), but is that the only way? 

## Screenshots
![image](https://user-images.githubusercontent.com/1907152/158690143-5d947b63-2f0d-4bbe-ab53-8fe501b69516.png)



