### PR TITLE
fetch the table which contains info about the primaryDisplay

### DIFF
--- a/packages/client/src/components/app/forms/Form.svelte
+++ b/packages/client/src/components/app/forms/Form.svelte
@@ -17,6 +17,7 @@
   let table
 
   $: fetchSchema(dataSource)
+  $: fetchTable(dataSource)
 
   // Returns the closes data context which isn't a built in context
   const getInitialValues = (type, dataSource, context) => {
@@ -71,6 +72,16 @@
 
     if (!loaded) {
       loaded = true
+    }
+  }
+
+  const fetchTable = async dataSource => {
+    if (dataSource?.tableId) {
+      try {
+        table = await API.fetchTableDefinition(dataSource.tableId)
+      } catch (error) {
+        table = null
+      }
     }
   }
 


### PR DESCRIPTION
## Description
All code for using the primaryDisplay column as a required validation constraint was already present in `createValidatorFromConstraints`, but it needed a table object, which was never passed, so when I retrieved the table and passed it to the `createValidatorFromConstraints` method, it added a required constraint. 
I am not sure if I used the best method to retrieve the table definition. I copied it from the `RelationShipField.svelte` component.

Fixes #4910


