### PR TITLE
Don't attempt to invalidate related datasources when invalidating queries

### DIFF
--- a/packages/client/src/components/overlay/PeekScreenDisplay.svelte
+++ b/packages/client/src/components/overlay/PeekScreenDisplay.svelte
@@ -20,8 +20,8 @@
   let listenersAttached = false
 
   const proxyInvalidation = event => {
-    const { dataSourceId } = event.detail
-    dataSourceStore.actions.invalidateDataSource(dataSourceId)
+    const { dataSourceId, options } = event.detail
+    dataSourceStore.actions.invalidateDataSource(dataSourceId, options)
   }
 
   const proxyNotification = event => {

--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -37,7 +37,9 @@ const saveRowHandler = async (action, context) => {
     notificationStore.actions.success("Row saved")
 
     // Refresh related datasources
-    await dataSourceStore.actions.invalidateDataSource(row.tableId)
+    await dataSourceStore.actions.invalidateDataSource(row.tableId, {
+      invalidateRelationships: true,
+    })
 
     return { row }
   } catch (error) {
@@ -65,7 +67,9 @@ const duplicateRowHandler = async (action, context) => {
       notificationStore.actions.success("Row saved")
 
       // Refresh related datasources
-      await dataSourceStore.actions.invalidateDataSource(row.tableId)
+      await dataSourceStore.actions.invalidateDataSource(row.tableId, {
+        invalidateRelationships: true,
+      })
 
       return { row }
     } catch (error) {
@@ -83,7 +87,9 @@ const deleteRowHandler = async action => {
       notificationStore.actions.success("Row deleted")
 
       // Refresh related datasources
-      await dataSourceStore.actions.invalidateDataSource(tableId)
+      await dataSourceStore.actions.invalidateDataSource(tableId, {
+        invalidateRelationships: true,
+      })
     } catch (error) {
       // Abort next actions
       return false


### PR DESCRIPTION
## Description
This PR fixes a harmless error which was appearing when executing "create" queries, which would request the schema for the datasource in order to check for relationship fields, in order to invalidate related data providers. This was sending a datasource ID to an endpoint which did not support that, which was in turn returning a HTTP 500 causing the client to display it.

Fixes #4938.


