### PR TITLE
don't sent searchableSchema to getSchemaForDatasource

### DIFF
--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/FilterEditor/FilterEditor.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/FilterEditor/FilterEditor.svelte
@@ -18,9 +18,7 @@
   let tempValue = value || []
 
   $: dataSource = getDatasourceForProvider($currentAsset, componentInstance)
-  $: schema = getSchemaForDatasource($currentAsset, dataSource, {
-    searchableSchema: true,
-  })?.schema
+  $: schema = getSchemaForDatasource($currentAsset, dataSource)?.schema
   $: schemaFields = Object.values(schema || {})
 
   const saveFilter = async () => {


### PR DESCRIPTION
## Description
the rest schema doesn't have query parameters which define the schema, so don't sent `searchableSchema` option.

Fixes #4948