### PR TITLE
Properly set required constraints for display columns

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -12,7 +12,7 @@
     Modal,
     notifications,
   } from "@budibase/bbui"
-  import { createEventDispatcher } from "svelte"
+  import { createEventDispatcher, onMount } from "svelte"
   import { cloneDeep } from "lodash/fp"
   import { tables } from "stores/backend"
   import { TableNames, UNEDITABLE_USER_FIELDS } from "constants"
@@ -321,6 +321,12 @@
     }
     return newError
   }
+
+  onMount(() => {
+    if (primaryDisplay) {
+      field.constraints.presence = { allowEmpty: false }
+    }
+  })
 </script>
 
 <ModalContent


### PR DESCRIPTION
Whenever the first column is created for a table we default it to being the primary display column. We don't actually set the required constraint though whenever this is the case. Toggling the display column on correctly sets this field, so the bug only happens when creating the first column for a table, which is defaulted to being the display column. Any internal table that was created from scratch, for which the primary display column has never been changed, will probably have this issue.

I believe this is the real cause of the issue https://github.com/Budibase/budibase/issues/4910. We have lots of tables out there now with incorrect schema constraints.

We have extra frontend validation which also checks whether a field is the display column, so this will catch all those existing tables which do not have the correct schema validation set. This frontend validation was currently not working which was highlighting the real issue of bad schema constraints, but there's another PR up to fix the frontend validation.


