### PR TITLE
Handle error when running a a Query Rows automation with a deleted column

### DIFF
--- a/packages/server/src/automations/steps/queryRows.js
+++ b/packages/server/src/automations/steps/queryRows.js
@@ -85,7 +85,7 @@ exports.run = async function ({ inputs, appId }) {
   const { tableId, filters, sortColumn, sortOrder, limit } = inputs
   const table = await getTable(appId, tableId)
   let sortType = FieldTypes.STRING
-  if (table && table.schema && sortColumn) {
+  if (table && table.schema && table.schema[sortColumn] && sortColumn) {
     const fieldType = table.schema[sortColumn].type
     sortType =
       fieldType === FieldTypes.NUMBER ? FieldTypes.NUMBER : FieldTypes.STRING


### PR DESCRIPTION
## Description
Running a Query Rows automation that had a deleted column as it's sort was causing repeated errors and affecting performance. 


