### PR TITLE
Mark table block table column setting as nested to fix custom values

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -264,7 +264,8 @@
           {
             "label": "Primary",
             "value": "primary"
-          }, {
+          },
+          {
             "label": "Secondary",
             "value": "secondary"
           },
@@ -507,7 +508,7 @@
       },
       {
         "type": "static",
-        "values":  [
+        "values": [
           {
             "label": "Row Index",
             "key": "index"
@@ -626,28 +627,36 @@
         "defaultValue": "M",
         "showInBar": true,
         "barStyle": "picker",
-        "options": [{
-          "label": "Extra Small",
-          "value": "XS"
-        }, {
-          "label": "Small",
-          "value": "S"
-        }, {
-          "label": "Medium",
-          "value": "M"
-        }, {
-          "label": "Large",
-          "value": "L"
-        }, {
-          "label": "Extra Large",
-          "value": "XL"
-        }, {
-          "label": "2XL",
-          "value": "XXL"
-        }, {
-          "label": "3XL",
-          "value": "XXXL"
-        }]
+        "options": [
+          {
+            "label": "Extra Small",
+            "value": "XS"
+          },
+          {
+            "label": "Small",
+            "value": "S"
+          },
+          {
+            "label": "Medium",
+            "value": "M"
+          },
+          {
+            "label": "Large",
+            "value": "L"
+          },
+          {
+            "label": "Extra Large",
+            "value": "XL"
+          },
+          {
+            "label": "2XL",
+            "value": "XXL"
+          },
+          {
+            "label": "3XL",
+            "value": "XXXL"
+          }
+        ]
       },
       {
         "type": "color",
@@ -689,27 +698,32 @@
         "defaultValue": "left",
         "showInBar": true,
         "barStyle": "buttons",
-        "options": [{
-          "label": "Left",
-          "value": "left",
-          "barIcon": "TextAlignLeft",
-          "barTitle": "Align left"
-        }, {
-          "label": "Center",
-          "value": "center",
-          "barIcon": "TextAlignCenter",
-          "barTitle": "Align center"
-        }, {
-          "label": "Right",
-          "value": "right",
-          "barIcon": "TextAlignRight",
-          "barTitle": "Align right"
-        }, {
-          "label": "Justify",
-          "value": "justify",
-          "barIcon": "TextAlignJustify",
-          "barTitle": "Justify text"
-        }]
+        "options": [
+          {
+            "label": "Left",
+            "value": "left",
+            "barIcon": "TextAlignLeft",
+            "barTitle": "Align left"
+          },
+          {
+            "label": "Center",
+            "value": "center",
+            "barIcon": "TextAlignCenter",
+            "barTitle": "Align center"
+          },
+          {
+            "label": "Right",
+            "value": "right",
+            "barIcon": "TextAlignRight",
+            "barTitle": "Align right"
+          },
+          {
+            "label": "Justify",
+            "value": "justify",
+            "barIcon": "TextAlignJustify",
+            "barTitle": "Justify text"
+          }
+        ]
       }
     ]
   },
@@ -733,28 +747,36 @@
         "defaultValue": "M",
         "showInBar": true,
         "barStyle": "picker",
-        "options": [{
-          "label": "Extra Small",
-          "value": "XS"
-        }, {
-          "label": "Small",
-          "value": "S"
-        }, {
-          "label": "Medium",
-          "value": "M"
-        }, {
-          "label": "Large",
-          "value": "L"
-        }, {
-          "label": "Extra Large",
-          "value": "XL"
-        }, {
-          "label": "2XL",
-          "value": "XXL"
-        }, {
-          "label": "3XL",
-          "value": "XXXL"
-        }]
+        "options": [
+          {
+            "label": "Extra Small",
+            "value": "XS"
+          },
+          {
+            "label": "Small",
+            "value": "S"
+          },
+          {
+            "label": "Medium",
+            "value": "M"
+          },
+          {
+            "label": "Large",
+            "value": "L"
+          },
+          {
+            "label": "Extra Large",
+            "value": "XL"
+          },
+          {
+            "label": "2XL",
+            "value": "XXL"
+          },
+          {
+            "label": "3XL",
+            "value": "XXXL"
+          }
+        ]
       },
       {
         "type": "color",
@@ -796,27 +818,32 @@
         "defaultValue": "left",
         "showInBar": true,
         "barStyle": "buttons",
-        "options": [{
-          "label": "Left",
-          "value": "left",
-          "barIcon": "TextAlignLeft",
-          "barTitle": "Align left"
-        }, {
-          "label": "Center",
-          "value": "center",
-          "barIcon": "TextAlignCenter",
-          "barTitle": "Align center"
-        }, {
-          "label": "Right",
-          "value": "right",
-          "barIcon": "TextAlignRight",
-          "barTitle": "Align right"
-        }, {
-          "label": "Justify",
-          "value": "justify",
-          "barIcon": "TextAlignJustify",
-          "barTitle": "Justify text"
-        }]
+        "options": [
+          {
+            "label": "Left",
+            "value": "left",
+            "barIcon": "TextAlignLeft",
+            "barTitle": "Align left"
+          },
+          {
+            "label": "Center",
+            "value": "center",
+            "barIcon": "TextAlignCenter",
+            "barTitle": "Align center"
+          },
+          {
+            "label": "Right",
+            "value": "right",
+            "barIcon": "TextAlignRight",
+            "barTitle": "Align right"
+          },
+          {
+            "label": "Justify",
+            "value": "justify",
+            "barIcon": "TextAlignJustify",
+            "barTitle": "Justify text"
+          }
+        ]
       }
     ]
   },
@@ -837,16 +864,20 @@
         "defaultValue": "M",
         "showInBar": true,
         "barStyle": "picker",
-        "options": [{
-          "label": "Small",
-          "value": "S"
-        }, {
-          "label": "Medium",
-          "value": "M"
-        }, {
-          "label": "Large",
-          "value": "L"
-        }]
+        "options": [
+          {
+            "label": "Small",
+            "value": "S"
+          },
+          {
+            "label": "Medium",
+            "value": "M"
+          },
+          {
+            "label": "Large",
+            "value": "L"
+          }
+        ]
       },
       {
         "type": "color",
@@ -1037,16 +1068,20 @@
         "defaultValue": "M",
         "showInBar": true,
         "barStyle": "picker",
-        "options": [{
-          "label": "Small",
-          "value": "S"
-        }, {
-          "label": "Medium",
-          "value": "M"
-        }, {
-          "label": "Large",
-          "value": "L"
-        }]
+        "options": [
+          {
+            "label": "Small",
+            "value": "S"
+          },
+          {
+            "label": "Medium",
+            "value": "M"
+          },
+          {
+            "label": "Large",
+            "value": "L"
+          }
+        ]
       },
       {
         "type": "color",
@@ -1088,27 +1123,32 @@
         "defaultValue": "left",
         "showInBar": true,
         "barStyle": "buttons",
-        "options": [{
-          "label": "Left",
-          "value": "left",
-          "barIcon": "TextAlignLeft",
-          "barTitle": "Align left"
-        }, {
-          "label": "Center",
-          "value": "center",
-          "barIcon": "TextAlignCenter",
-          "barTitle": "Align center"
-        }, {
-          "label": "Right",
-          "value": "right",
-          "barIcon": "TextAlignRight",
-          "barTitle": "Align right"
-        }, {
-          "label": "Justify",
-          "value": "justify",
-          "barIcon": "TextAlignJustify",
-          "barTitle": "Justify text"
-        }]
+        "options": [
+          {
+            "label": "Left",
+            "value": "left",
+            "barIcon": "TextAlignLeft",
+            "barTitle": "Align left"
+          },
+          {
+            "label": "Center",
+            "value": "center",
+            "barIcon": "TextAlignCenter",
+            "barTitle": "Align center"
+          },
+          {
+            "label": "Right",
+            "value": "right",
+            "barIcon": "TextAlignRight",
+            "barTitle": "Align right"
+          },
+          {
+            "label": "Justify",
+            "value": "justify",
+            "barIcon": "TextAlignJustify",
+            "barTitle": "Justify text"
+          }
+        ]
       }
     ]
   },
@@ -1165,7 +1205,15 @@
         "type": "select",
         "label": "Card Width",
         "key": "cardWidth",
-        "options": ["24rem", "28rem", "32rem", "40rem", "48rem", "60rem", "100%"],
+        "options": [
+          "24rem",
+          "28rem",
+          "32rem",
+          "40rem",
+          "48rem",
+          "60rem",
+          "100%"
+        ],
         "defaultValue": "32rem"
       },
       {
@@ -1785,11 +1833,7 @@
     "icon": "Form",
     "hasChildren": true,
     "illegalChildren": ["section", "form"],
-    "actions": [
-      "ValidateForm",
-      "ClearForm",
-      "ChangeFormStep"
-    ],
+    "actions": ["ValidateForm", "ClearForm", "ChangeFormStep"],
     "styles": ["size"],
     "settings": [
       {
@@ -1816,7 +1860,8 @@
           {
             "label": "Medium",
             "value": "spectrum--medium"
-          }, {
+          },
+          {
             "label": "Large",
             "value": "spectrum--large"
           }
@@ -1833,7 +1878,7 @@
     "context": [
       {
         "type": "static",
-        "values":  [
+        "values": [
           {
             "label": "Value",
             "key": "__value"
@@ -1947,27 +1992,32 @@
         "defaultValue": "left",
         "showInBar": true,
         "barStyle": "buttons",
-        "options": [{
-          "label": "Left",
-          "value": "left",
-          "barIcon": "TextAlignLeft",
-          "barTitle": "Align left"
-        }, {
-          "label": "Center",
-          "value": "center",
-          "barIcon": "TextAlignCenter",
-          "barTitle": "Align center"
-        }, {
-          "label": "Right",
-          "value": "right",
-          "barIcon": "TextAlignRight",
-          "barTitle": "Align right"
-        }, {
-          "label": "Justify",
-          "value": "justify",
-          "barIcon": "TextAlignJustify",
-          "barTitle": "Justify text"
-        }]
+        "options": [
+          {
+            "label": "Left",
+            "value": "left",
+            "barIcon": "TextAlignLeft",
+            "barTitle": "Align left"
+          },
+          {
+            "label": "Center",
+            "value": "center",
+            "barIcon": "TextAlignCenter",
+            "barTitle": "Align center"
+          },
+          {
+            "label": "Right",
+            "value": "right",
+            "barIcon": "TextAlignRight",
+            "barTitle": "Align right"
+          },
+          {
+            "label": "Justify",
+            "value": "justify",
+            "barIcon": "TextAlignJustify",
+            "barTitle": "Justify text"
+          }
+        ]
       }
     ]
   },
@@ -2634,15 +2684,15 @@
     ],
     "context": {
       "type": "static",
-      "values":  [
+      "values": [
         {
           "label": "Rows",
           "key": "rows"
         },
-	{
-	  "label": "Extra Info",
-	  "key": "info"
-	},
+        {
+          "label": "Extra Info",
+          "key": "info"
+        },
         {
           "label": "Rows Length",
           "key": "rowsLength"
@@ -2964,7 +3014,8 @@
             "label": "Table Columns",
             "key": "tableColumns",
             "dependsOn": "dataSource",
-            "placeholder": "All columns"
+            "placeholder": "All columns",
+            "nested": true
           },
           {
             "type": "boolean",
@@ -3116,7 +3167,6 @@
             "key": "cardDescription",
             "label": "Description",
             "nested": true
-
           },
           {
             "type": "text",
@@ -3381,12 +3431,12 @@
       {
         "type": "static",
         "suffix": "provider",
-        "values":  [
+        "values": [
           {
             "label": "Rows",
             "key": "rows"
           },
-	  {
+          {
             "label": "Extra Info",
             "key": "info"
           },
@@ -3407,12 +3457,12 @@
       {
         "type": "static",
         "suffix": "repeater",
-        "values":  [
+        "values": [
           {
             "label": "Row Index",
             "key": "index"
           }
-         ]
+        ]
       },
       {
         "type": "schema",


### PR DESCRIPTION
Marks the table block tabe column setting as nested to fix custom values not working. This was already done for the table component itself but was left out for the block.

As described in the [docs](https://app.gitbook.com/o/-LrDgq6yzTKOIMH5iQRQ/s/sHOuIQuakYeJTpF5aHYZ/frontend/client-library/component-manifest#settings), `nested` settings are not enriched automatically by the client library and are instead treated as raw strings. This is required in this case as the table itself handles the enrichment.

Also ran prettier over the manifest to standardise all the indentation and structure - but the only relevant change here is `"nested": true` for the table block.

Fixes https://github.com/Budibase/budibase/issues/5063.


