### PR TITLE
fix: incorrect parameters for public rows editing

### DIFF
--- a/packages/server/src/api/controllers/public/rows.ts
+++ b/packages/server/src/api/controllers/public/rows.ts
@@ -52,7 +52,7 @@ export async function read(ctx: any, next: any) {
 }
 
 export async function update(ctx: any, next: any) {
-  ctx.request.body = await addRev(fixRow(ctx.request.body, ctx.params.tableId))
+  ctx.request.body = await addRev(fixRow(ctx.request.body, ctx.params))
   await rowController.save(ctx)
   await next()
 }
@@ -60,7 +60,7 @@ export async function update(ctx: any, next: any) {
 export async function destroy(ctx: any, next: any) {
   // set the body as expected, with the _id and _rev fields
   ctx.request.body = await addRev(
-    fixRow({ _id: ctx.params.rowId }, ctx.params.tableId)
+    fixRow({ _id: ctx.params.rowId }, ctx.params)
   )
   await rowController.destroy(ctx)
   // destroy controller doesn't currently return the row as the body, need to adjust this


### PR DESCRIPTION
When calling `PUT /api/public/v1/tables/{tableId}/rows/{rowId}`, a new row is created instead of patching an existing row. I believe the bug is caused by passing an incorrect parameter to `fixRow` function