### PR TITLE
ignore AWS config when using endpoint field

### DIFF
--- a/packages/server/src/integrations/dynamodb.ts
+++ b/packages/server/src/integrations/dynamodb.ts
@@ -131,7 +131,9 @@ module DynamoModule {
 
     constructor(config: DynamoDBConfig) {
       this.config = config
-      this.connect()
+      if (!this.config.endpoint) {
+        this.connect()
+      }
       let options = {
         correctClockSkew: true,
         endpoint: config.endpoint ? config.endpoint : undefined,


### PR DESCRIPTION
## Description
Fix for local `endpoint` in dynamo connector

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



