### PR TITLE
fix launch.json for worker after TS migration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,9 +22,16 @@
             "name": "Budibase Worker",
             "type": "node",
             "request": "launch",
-            "program": "${workspaceFolder}/packages/worker/src/index.js",
+            "runtimeArgs": [
+                "--nolazy",
+                "-r",
+                "ts-node/register/transpile-only"
+            ],
+            "args": [
+                "${workspaceFolder}/packages/worker/src/index.ts"
+            ],
             "cwd": "${workspaceFolder}/packages/worker"
-        }
+        },
     ],
     "compounds": [
         {

--- a/packages/worker/.vscode/launch.json
+++ b/packages/worker/.vscode/launch.json
@@ -5,10 +5,13 @@
     "version": "0.2.0",
     "configurations": [
       {
+        "name": "Start Server",
         "type": "node",
         "request": "launch",
-        "name": "Start Server",
-        "program": "${workspaceFolder}/src/index.js"
+        "runtimeExecutable": "node",
+        "runtimeArgs": ["--nolazy", "-r", "ts-node/register/transpile-only"],
+        "args": ["src/index.ts"],
+        "cwd": "${workspaceRoot}",
       },
       {
         "type": "node",


### PR DESCRIPTION
## Description
After worker migration to TS, the `launch.json` configuration in VSCode was no longer working for debugging the worker. Updated in both the top level `launch.json` and the worker `launch.json`. 

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



