### PR TITLE
Fix for RBAC on apps built from templates containing public screens

### DIFF
--- a/packages/server/src/api/controllers/permission.js
+++ b/packages/server/src/api/controllers/permission.js
@@ -4,6 +4,7 @@ const {
   getDBRoleID,
   getExternalRoleID,
   getBuiltinRoles,
+  checkForRoleResourceArray,
 } = require("@budibase/backend-core/roles")
 const { getRoleParams } = require("../../db/utils")
 const {
@@ -144,12 +145,11 @@ exports.getResourcePerms = async function (ctx) {
   for (let level of SUPPORTED_LEVELS) {
     // update the various roleIds in the resource permissions
     for (let role of roles) {
-      const rolePerms = role.permissions
+      const rolePerms = checkForRoleResourceArray(role.permissions, resourceId)
       if (
         rolePerms &&
         rolePerms[resourceId] &&
-        (rolePerms[resourceId] === level ||
-          rolePerms[resourceId].indexOf(level) !== -1)
+        rolePerms[resourceId].indexOf(level) !== -1
       ) {
         permissions[level] = getExternalRoleID(role._id)
       }

--- a/packages/server/src/api/routes/table.js
+++ b/packages/server/src/api/routes/table.js
@@ -40,7 +40,7 @@ router
   .get(
     "/api/tables/:tableId",
     paramResource("tableId"),
-    authorized(PermissionTypes.TABLE, PermissionLevels.READ),
+    authorized(PermissionTypes.TABLE, PermissionLevels.READ, { schema: true }),
     tableController.find
   )
   /**


### PR DESCRIPTION
## Description
Fix for #5103 - some templates are built on an older version that stored permissions differently, we can't migrate these as they will keep being added, easiest to just support the old method (apply the old rule and convert to the new format when retrieving roles).

This fixes the templates which contain public roles, converted the roles which are stored as:
```
"ta_a889aa4c78b14eedaaf2765e30558054": "write"
```
to
```
"ta_d0eaf94963834567ba4fc083d7072118": [
      "write",
      "read"
    ]
```
Which is the new method. Previously "write" as a string implied "read" but that was updated a little while ago. Its easy enough to convert this when reading roles and resolve the issue where used, making use of the older rule that write is a higher level than read.

This also introduces the ability to set a public write, but have a basic read, and the table schema will use the lower of the two roles which provides it access - table schemas see if either of the levels would provide access using the `{ schema: true }` option on the authorized middleware.