### PR TITLE
Fix for query public API spec - was missing description of parameters property

### DIFF
--- a/packages/server/specs/openapi.json
+++ b/packages/server/specs/openapi.json
@@ -1260,10 +1260,30 @@
         ]
       },
       "executeQuery": {
-        "description": "The query body must contain the required parameters for the query, this depends on query type, setup and bindings.",
+        "description": "The parameters required for executing a query.",
         "type": "object",
-        "additionalProperties": {
-          "description": "Key value properties of any type, depending on the query output schema."
+        "properties": {
+          "parameters": {
+            "type": "object",
+            "description": "This contains the required parameters for the query, this depends on query type, setup and bindings.",
+            "additionalProperties": {
+              "description": "Key value properties of any type, depending on the query output schema."
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "description": "For supported query types (currently on REST) pagination can be performed using these properties.",
+            "properties": {
+              "page": {
+                "type": "string",
+                "description": "The page which has been returned from a previous query."
+              },
+              "limit": {
+                "type": "number",
+                "description": "The number of rows to return per page."
+              }
+            }
+          }
         }
       },
       "executeQueryOutput": {

--- a/packages/server/specs/openapi.yaml
+++ b/packages/server/specs/openapi.yaml
@@ -951,11 +951,27 @@ components:
       required:
         - data
     executeQuery:
-      description: The query body must contain the required parameters for the query,
-        this depends on query type, setup and bindings.
+      description: The parameters required for executing a query.
       type: object
-      additionalProperties:
-        description: Key value properties of any type, depending on the query output schema.
+      properties:
+        parameters:
+          type: object
+          description: This contains the required parameters for the query, this depends
+            on query type, setup and bindings.
+          additionalProperties:
+            description: Key value properties of any type, depending on the query output
+              schema.
+        pagination:
+          type: object
+          description: For supported query types (currently on REST) pagination can be
+            performed using these properties.
+          properties:
+            page:
+              type: string
+              description: The page which has been returned from a previous query.
+            limit:
+              type: number
+              description: The number of rows to return per page.
     executeQueryOutput:
       type: object
       properties:

--- a/packages/server/specs/resources/query.js
+++ b/packages/server/specs/resources/query.js
@@ -124,12 +124,34 @@ const querySchema = object(
 )
 
 const executeQuerySchema = {
-  description:
-    "The query body must contain the required parameters for the query, this depends on query type, setup and bindings.",
+  description: "The parameters required for executing a query.",
   type: "object",
-  additionalProperties: {
-    description:
-      "Key value properties of any type, depending on the query output schema.",
+  properties: {
+    parameters: {
+      type: "object",
+      description:
+        "This contains the required parameters for the query, this depends on query type, setup and bindings.",
+      additionalProperties: {
+        description:
+          "Key value properties of any type, depending on the query output schema.",
+      },
+    },
+    pagination: {
+      type: "object",
+      description:
+        "For supported query types (currently on REST) pagination can be performed using these properties.",
+      properties: {
+        page: {
+          type: "string",
+          description:
+            "The page which has been returned from a previous query.",
+        },
+        limit: {
+          type: "number",
+          description: "The number of rows to return per page.",
+        },
+      },
+    },
   },
 }
 

--- a/packages/server/src/definitions/openapi.ts
+++ b/packages/server/src/definitions/openapi.ts
@@ -935,8 +935,18 @@ export interface components {
         _id: string;
       }[];
     };
-    /** @description The query body must contain the required parameters for the query, this depends on query type, setup and bindings. */
-    executeQuery: { [key: string]: unknown };
+    /** @description The parameters required for executing a query. */
+    executeQuery: {
+      /** @description This contains the required parameters for the query, this depends on query type, setup and bindings. */
+      parameters?: { [key: string]: unknown };
+      /** @description For supported query types (currently on REST) pagination can be performed using these properties. */
+      pagination?: {
+        /** @description The page which has been returned from a previous query. */
+        page?: string;
+        /** @description The number of rows to return per page. */
+        limit?: number;
+      };
+    };
     executeQueryOutput: {
       /** @description The data response from the query. */
       data: { [key: string]: unknown }[];


### PR DESCRIPTION
## Description
Fix for #5117 - this issue raised a point that the docs didn't describe where to put properties for a query when running through the public API - fixing the spec. Couldn't just pass the whole body through as this would mean that REST pagination couldn't be used, so I've documented the `parameters` property of the body, as well as the `pagination` structure used by REST queries (as well as documenting it is only for REST).