### PR TITLE
Fix spaces not being allowed in formula columns

### DIFF
--- a/packages/builder/src/components/common/bindings/ServerBindingPanel.svelte
+++ b/packages/builder/src/components/common/bindings/ServerBindingPanel.svelte
@@ -12,8 +12,8 @@
   const enrichBindings = bindings => {
     return bindings?.map(binding => ({
       ...binding,
-      readableBinding: binding.label || binding.readableBinding,
-      runtimeBinding: binding.path || binding.runtimeBinding,
+      readableBinding: binding.readableBinding || binding.label,
+      runtimeBinding: binding.runtimeBinding || binding.path,
     }))
   }
 </script>


### PR DESCRIPTION
Fixes an issue where spaces were not allowed in formula column bindings due to incorrect order of precedence when determining binding structures.

FIxes #4217.