### PR TITLE
try converting query parameters to numbers

### DIFF
--- a/packages/builder/src/stores/backend/queries.js
+++ b/packages/builder/src/stores/backend/queries.js
@@ -79,7 +79,9 @@ export function createQueriesStore() {
       const parameters = query.parameters.reduce(
         (acc, next) => ({
           ...acc,
-          [next.name]: next.default,
+          [next.name]: isNaN(next.default)
+            ? next.default
+            : Number(next.default),
         }),
         {}
       )

--- a/packages/server/src/threads/query.js
+++ b/packages/server/src/threads/query.js
@@ -264,11 +264,13 @@ class QueryRunner {
         enrichedQuery[key] = this.enrichQueryFields(fields[key], parameters)
       } else if (typeof fields[key] === "string") {
         // enrich string value as normal
-        enrichedQuery[key] = processStringSync(fields[key], parameters, {
+        const fieldValue = processStringSync(fields[key], parameters, {
           noEscaping: true,
           noHelpers: true,
           escapeNewlines: true,
         })
+        // try to parse the value to a number
+        enrichedQuery[key] = isNaN(fieldValue) ? fieldValue : Number(fieldValue)
       } else {
         enrichedQuery[key] = fields[key]
       }


### PR DESCRIPTION
## Description
Values like offset and limit should be numbers, so we should try to parse numbers when replacing bindings in the query. 
Fixes #5149


