### PR TITLE
Fix in-preview text editing bugs

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -2529,7 +2529,6 @@
     "name": "Embedded Map",
     "icon": "Location",
     "styles": ["size"],
-    "editable": true,
     "draggable": false,
     "illegalChildren": ["section"],
     "settings": [
@@ -3631,7 +3630,6 @@
     "name": "Markdown Viewer",
     "icon": "TaskList",
     "styles": ["size"],
-    "editable": true,
     "settings": [
       {
         "type": "text",

--- a/packages/client/src/components/app/Button.svelte
+++ b/packages/client/src/components/app/Button.svelte
@@ -37,7 +37,6 @@
   <button
     class={`spectrum-Button spectrum-Button--size${size} spectrum-Button--${type}`}
     class:spectrum-Button--quiet={quiet}
-    class:editing={$component.editing}
     {disabled}
     use:styleable={$component.styles}
     on:click={onClick}

--- a/packages/client/src/components/app/Button.svelte
+++ b/packages/client/src/components/app/Button.svelte
@@ -22,41 +22,44 @@
   $: componentText = getComponentText(text, $builderStore, $component)
 
   const getComponentText = (text, builderState, componentState) => {
-    if (!builderState.inBuilder || componentState.editing) {
+    if (componentState.editing) {
       return text || " "
     }
     return text || componentState.name || "Placeholder text"
   }
 
   const updateText = e => {
-    builderStore.actions.updateProp("text", e.target.textContent.trim())
+    builderStore.actions.updateProp("text", e.target.textContent)
   }
 </script>
 
-<button
-  class={`spectrum-Button spectrum-Button--size${size} spectrum-Button--${type}`}
-  class:spectrum-Button--quiet={quiet}
-  {disabled}
-  use:styleable={$component.styles}
-  on:click={onClick}
-  contenteditable={$component.editing && !icon}
-  on:blur={$component.editing ? updateText : null}
-  bind:this={node}
-  class:active
->
-  {#if icon}
-    <svg
-      class:hasText={componentText?.length > 0}
-      class="spectrum-Icon spectrum-Icon--size{size.toUpperCase()}"
-      focusable="false"
-      aria-hidden="true"
-      aria-label={icon}
-    >
-      <use xlink:href="#spectrum-icon-18-{icon}" />
-    </svg>
-  {/if}
-  {componentText}
-</button>
+{#key $component.editing}
+  <button
+    class={`spectrum-Button spectrum-Button--size${size} spectrum-Button--${type}`}
+    class:spectrum-Button--quiet={quiet}
+    class:editing={$component.editing}
+    {disabled}
+    use:styleable={$component.styles}
+    on:click={onClick}
+    contenteditable={$component.editing && !icon}
+    on:blur={$component.editing ? updateText : null}
+    bind:this={node}
+    class:active
+  >
+    {#if icon}
+      <svg
+        class:hasText={componentText?.length > 0}
+        class="spectrum-Icon spectrum-Icon--size{size.toUpperCase()}"
+        focusable="false"
+        aria-hidden="true"
+        aria-label={icon}
+      >
+        <use xlink:href="#spectrum-icon-18-{icon}" />
+      </svg>
+    {/if}
+    {componentText}
+  </button>
+{/key}
 
 <style>
   button {

--- a/packages/client/src/components/app/Heading.svelte
+++ b/packages/client/src/components/app/Heading.svelte
@@ -47,24 +47,25 @@
 
   // Convert contenteditable HTML to text and save
   const updateText = e => {
-    const sanitized = e.target.innerHTML.replace(/<br>/gi, "\n").trim()
-    builderStore.actions.updateProp("text", sanitized)
+    builderStore.actions.updateProp("text", e.target.textContent)
   }
 </script>
 
-<h1
-  bind:this={node}
-  contenteditable={$component.editing}
-  use:styleable={styles}
-  class:placeholder
-  class:bold
-  class:italic
-  class:underline
-  class="spectrum-Heading {sizeClass} {alignClass}"
-  on:blur={$component.editing ? updateText : null}
->
-  {componentText}
-</h1>
+{#key $component.editing}
+  <h1
+    bind:this={node}
+    contenteditable={$component.editing}
+    use:styleable={styles}
+    class:placeholder
+    class:bold
+    class:italic
+    class:underline
+    class="spectrum-Heading {sizeClass} {alignClass}"
+    on:blur={$component.editing ? updateText : null}
+  >
+    {componentText}
+  </h1>
+{/key}
 
 <style>
   h1 {

--- a/packages/client/src/components/app/Link.svelte
+++ b/packages/client/src/components/app/Link.svelte
@@ -61,7 +61,7 @@
   }
 
   const updateText = e => {
-    builderStore.actions.updateProp("text", e.target.textContent.trim())
+    builderStore.actions.updateProp("text", e.target.textContent)
   }
 </script>
 

--- a/packages/client/src/components/app/Text.svelte
+++ b/packages/client/src/components/app/Text.svelte
@@ -46,24 +46,25 @@
 
   // Convert contenteditable HTML to text and save
   const updateText = e => {
-    const sanitized = e.target.innerHTML.replace(/<br>/gi, "\n").trim()
-    builderStore.actions.updateProp("text", sanitized)
+    builderStore.actions.updateProp("text", e.target.textContent)
   }
 </script>
 
-<p
-  bind:this={node}
-  contenteditable={$component.editing}
-  use:styleable={styles}
-  class:placeholder
-  class:bold
-  class:italic
-  class:underline
-  class="spectrum-Body {sizeClass} {alignClass}"
-  on:blur={$component.editing ? updateText : null}
->
-  {componentText}
-</p>
+{#key $component.editing}
+  <p
+    bind:this={node}
+    contenteditable={$component.editing}
+    use:styleable={styles}
+    class:placeholder
+    class:bold
+    class:italic
+    class:underline
+    class="spectrum-Body {sizeClass} {alignClass}"
+    on:blur={$component.editing ? updateText : null}
+  >
+    {componentText}
+  </p>
+{/key}
 
 <style>
   p {

--- a/packages/client/src/components/app/forms/Field.svelte
+++ b/packages/client/src/components/app/forms/Field.svelte
@@ -50,22 +50,24 @@
   $: labelClass = labelPos === "above" ? "" : `spectrum-FieldLabel--${labelPos}`
 
   const updateLabel = e => {
-    builderStore.actions.updateProp("label", e.target.textContent.trim())
+    builderStore.actions.updateProp("label", e.target.textContent)
   }
 </script>
 
 <FieldGroupFallback>
   <div class="spectrum-Form-item" use:styleable={$component.styles}>
-    <label
-      bind:this={labelNode}
-      contenteditable={$component.editing}
-      on:blur={$component.editing ? updateLabel : null}
-      class:hidden={!label}
-      for={fieldState?.fieldId}
-      class={`spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel ${labelClass}`}
-    >
-      {label || " "}
-    </label>
+    {#key $component.editing}
+      <label
+        bind:this={labelNode}
+        contenteditable={$component.editing}
+        on:blur={$component.editing ? updateLabel : null}
+        class:hidden={!label}
+        for={fieldState?.fieldId}
+        class={`spectrum-FieldLabel spectrum-FieldLabel--sizeM spectrum-Form-itemLabel ${labelClass}`}
+      >
+        {label || " "}
+      </label>
+    {/key}
     <div class="spectrum-Form-itemField">
       {#if !formContext}
         <Placeholder text="Form components need to be wrapped in a form" />


### PR DESCRIPTION
This fixes a couple of issues with editing text in the builder preview. This has been flagged by Joe before and has recently been raised again in https://github.com/Budibase/budibase/issues/5161.

There are 2 problems here:
- Editing text inline allows inserting HTML, so if you copy and paste from the page it messes up
- Chrome has issues with dynamically toggling the contenteditable attribute

This PR fixes these issues. Changelog:
- Only the text content is saved when editing. The downside is that new lines / empty lines are no longer possible.
- Fully remount editable components when changing the editable state. The downside is that buttons will flash briefly when starting editing but this is a very minor UI thing
- Removed some `editable` attributes from the component manifest which should not have been there
- Updated buttons so that if you add a button and don't change the text, it will actually use the default fallback text displayed in the preview rather than show an empty button