### PR TITLE
Add additional logging to automations

### DIFF
--- a/packages/server/src/automations/utils.js
+++ b/packages/server/src/automations/utils.js
@@ -17,10 +17,14 @@ const Runner = new Thread(ThreadType.AUTOMATION)
 exports.processEvent = async job => {
   try {
     // need to actually await these so that an error can be captured properly
+    console.log(
+      `${job.data.automation.appId} automation ${job.data.automation._id} running`
+    )
     return await Runner.run(job)
   } catch (err) {
+    const errJson = JSON.stringify(err)
     console.error(
-      `${job.data.automation.appId} automation ${job.data.automation._id} was unable to run - ${err}`
+      `${job.data.automation.appId} automation ${job.data.automation._id} was unable to run - ${errJson}`
     )
     console.trace(err)
     return { err }


### PR DESCRIPTION
## Description
Add some log statements so we know
- When automations are running - for better insights in grafana
- The full error rather than `Object [object]` when the error is a non-string



