### PR TITLE
Updating Helm chart couch version

### DIFF
--- a/charts/budibase/Chart.yaml
+++ b/charts/budibase/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.2.8
 appVersion: 1.0.48
 dependencies:
   - name: couchdb
-    version: 3.3.4
+    version: 3.6.1
     repository: https://apache.github.io/couchdb-helm
     condition: services.couchdb.enabled
   - name: ingress-nginx


### PR DESCRIPTION
## Description
Using the latest version of the CouchDB chart in the helm chart. This was discovered in discussion https://github.com/Budibase/budibase/discussions/5165, thanks to @melohagan for his debugging efforts and finding that the core of the issue appears to be related to the CouchDB 3.1 version which is in use, some of the views created by Budibase are not compatible with this version.