### PR TITLE
Add role IDs as bindings

### DIFF
--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -7,7 +7,11 @@ import {
   getComponentSettings,
 } from "./componentUtils"
 import { store } from "builderStore"
-import { queries as queriesStores, tables as tablesStore } from "stores/backend"
+import {
+  queries as queriesStores,
+  tables as tablesStore,
+  roles as rolesStore,
+} from "stores/backend"
 import {
   makePropSafe,
   isJSBinding,
@@ -33,6 +37,7 @@ export const getBindableProperties = (asset, componentId) => {
   const deviceBindings = getDeviceBindings()
   const stateBindings = getStateBindings()
   const selectedRowsBindings = getSelectedRowsBindings(asset)
+  const roleBindings = getRoleBindings()
   return [
     ...contextBindings,
     ...urlBindings,
@@ -40,6 +45,7 @@ export const getBindableProperties = (asset, componentId) => {
     ...userBindings,
     ...deviceBindings,
     ...selectedRowsBindings,
+    ...roleBindings,
   ]
 }
 
@@ -389,6 +395,16 @@ const getUrlBindings = asset => {
     runtimeBinding: `${safeURL}.${makePropSafe(param)}`,
     readableBinding: `URL.${param}`,
   }))
+}
+
+const getRoleBindings = () => {
+  return (get(rolesStore) || []).map(role => {
+    return {
+      type: "context",
+      runtimeBinding: `trim "${role._id}"`,
+      readableBinding: `Roles.${role.name}`,
+    }
+  })
 }
 
 /**

--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -402,7 +402,7 @@ const getRoleBindings = () => {
     return {
       type: "context",
       runtimeBinding: `trim "${role._id}"`,
-      readableBinding: `Roles.${role.name}`,
+      readableBinding: `Role.${role.name}`,
     }
   })
 }


### PR DESCRIPTION
Adds bindings for all roles. This was actually extremely simple to implement as we don't need a corresponding client library change - we can provide the role IDs immediately in the builder as we know them at that stage.

![image](https://user-images.githubusercontent.com/9075550/161785331-8c765e90-28ac-42a9-afd7-d024a732c8ce.png)



