### PR TITLE
Don't show an error for the  endpoint `/api/global/self`

### DIFF
--- a/packages/client/src/api/api.js
+++ b/packages/client/src/api/api.js
@@ -28,6 +28,7 @@ export const API = createAPIClient({
   // Or we could check error.status and redirect to login on a 403 etc.
   onError: error => {
     const { status, method, url, message, handled } = error || {}
+    const ignoreErrorUrls = ["analytics", "/api/global/self"]
 
     // Log any errors that we haven't manually handled
     if (!handled) {
@@ -39,7 +40,14 @@ export const API = createAPIClient({
     if (message) {
       // Don't notify if the URL contains the word analytics as it may be
       // blocked by browser extensions
-      if (!url?.includes("analytics")) {
+      let ignore = false
+      for (let ignoreUrl of ignoreErrorUrls) {
+        if (url?.includes(ignoreUrl)) {
+          ignore = true
+          break
+        }
+      }
+      if (!ignore) {
         notificationStore.actions.error(message)
       }
     }


### PR DESCRIPTION
## Description
Adds the `/api/global/self` endpoint to a list of URLs for which the client app won't show errors. It was easier to fix this issue this way rather than open up the endpoint to public usage, as there are multiple places in the codebase which expect a non-200 error code for this endpoint to indicate being logged out.

Raised in #5243.

Usage of ` characters in my commit seem to have ruined the commit message... TIL.


