### PR TITLE
configure bash step to use automation query timeout

### DIFF
--- a/packages/server/src/automations/steps/bash.js
+++ b/packages/server/src/automations/steps/bash.js
@@ -1,6 +1,7 @@
 const { execSync } = require("child_process")
 const { processStringSync } = require("@budibase/string-templates")
 const automationUtils = require("../automationUtils")
+const environment = require("../../environment")
 
 exports.definition = {
   name: "Bash Scripting",
@@ -51,7 +52,9 @@ exports.run = async function ({ inputs, context }) {
     let stdout,
       success = true
     try {
-      stdout = execSync(command, { timeout: 500 }).toString()
+      stdout = execSync(command, {
+        timeout: environment.QUERY_THREAD_TIMEOUT || 500,
+      }).toString()
     } catch (err) {
       stdout = err.message
       success = false


### PR DESCRIPTION
## Description
Off the back of https://github.com/Budibase/budibase/pull/5257, we decided it would just be easier to set the bash step timeout to be the timeout of our queries, instead of introducing a new environment variable.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



