### PR TITLE
Move settings bar below element if at very top

### DIFF
--- a/packages/client/src/components/preview/SettingsBar.svelte
+++ b/packages/client/src/components/preview/SettingsBar.svelte
@@ -66,6 +66,11 @@
         newTop = deviceBottom - 44
       }
 
+      //If element is at the very top of the screen, put the bar below the element
+      if (elBounds.top < elBounds.height) {
+        newTop = elBounds.bottom + verticalOffset
+      }
+
       // Horizontally, try to center first.
       // Failing that, render to left edge of component.
       // Failing that, render to right edge of component,


### PR DESCRIPTION
## Description
(https://github.com/Budibase/budibase/issues/4349)
Button at very top of screen is no longer covered by the settings bar.

## Screenshots
![Screenshot 2022-04-06 at 17 35 36](https://user-images.githubusercontent.com/101575380/162023926-2b582a37-f723-41c3-888a-294611f57eba.png)




