### PR TITLE
Fix for MySQL number parsing issue

### DIFF
--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -15,6 +15,7 @@ import {
 } from "./utils"
 import { DatasourcePlus } from "./base/datasourcePlus"
 import dayjs from "dayjs"
+const { NUMBER_REGEX } = require("../utilities")
 
 module MySQLModule {
   const mysql = require("mysql2/promise")
@@ -87,7 +88,7 @@ module MySQLModule {
       if (typeof binding !== "string") {
         continue
       }
-      const matches = binding.match(/^\d*$/g)
+      const matches = binding.match(NUMBER_REGEX)
       // check if number first
       if (matches && matches[0] !== "" && !isNaN(Number(matches[0]))) {
         bindings[i] = parseFloat(binding)

--- a/packages/server/src/utilities/index.js
+++ b/packages/server/src/utilities/index.js
@@ -11,6 +11,8 @@ exports.wait = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 exports.isDev = env.isDev
 
+exports.NUMBER_REGEX = /^[+-]?([0-9]*[.])?[0-9]+$/g
+
 exports.removeFromArray = (array, element) => {
   const index = array.indexOf(element)
   if (index !== -1) {


### PR DESCRIPTION
## Description
Fix for issue discovered in #5187 - expanding regex to cover all sorts of number coercion. This was discovered after re-testing of the date parsing issue for MySQL, both parsing has to be a catch all, anything that slips through (e.g. negative numbers) will be incorrectly coerced, strict typing is critical in MySQL for SQL variables.