### PR TITLE
Display correct selector label for JS Scripting

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -104,9 +104,9 @@
       )
       bindings = bindings.concat(
         outputs.map(([name, value]) => {
-          const stepsLabel = block.name.toLowerCase().includes("bash")
-            ? `steps.${idx}.${name}`
-            : `steps[${idx - 1}].${name}`
+          const stepsLabel = block.name.startsWith("JS")
+            ? `steps[${idx}].${name}`
+            : `steps.${idx}.${name}`
           const runtime = idx === 0 ? `trigger.${name}` : stepsLabel
           return {
             label: runtime,

--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -104,7 +104,10 @@
       )
       bindings = bindings.concat(
         outputs.map(([name, value]) => {
-          const runtime = idx === 0 ? `trigger.${name}` : `steps.${idx}.${name}`
+          const stepsLabel = block.name.toLowerCase().includes("bash")
+            ? `steps.${idx}.${name}`
+            : `steps[${idx - 1}].${name}`
+          const runtime = idx === 0 ? `trigger.${name}` : stepsLabel
           return {
             label: runtime,
             type: value.type,


### PR DESCRIPTION
## Description
See issue: https://github.com/Budibase/budibase/issues/3926
The correct label and path is now shown for JS Scripting bindings. 



