### PR TITLE
adding more descriptive error messages to query UI

### DIFF
--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -72,7 +72,7 @@
       fields = response.schema
       notifications.success("Query executed successfully")
     } catch (error) {
-      notifications.error("Error previewing query")
+      notifications.error(`Query Error: ${error.message}`)
     }
   }
 


### PR DESCRIPTION
## Description
All query errors in the datasource configuration UI currently show an "Error Previewing Query" - even though the error is more descriptive than that in the `message` response. This makes debugging a bit frustrating as you must use the devtools to see the actual error.

Targeting master with this one as its a one liner and affects everyone.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



