### PR TITLE
QUERY_THREAD_TIMEOUT is string instead of int

### DIFF
--- a/packages/server/src/environment.js
+++ b/packages/server/src/environment.js
@@ -68,6 +68,7 @@ module.exports = {
   SENDGRID_API_KEY: process.env.SENDGRID_API_KEY,
   DYNAMO_ENDPOINT: process.env.DYNAMO_ENDPOINT,
   POSTHOG_TOKEN: process.env.POSTHOG_TOKEN,
+  QUERY_THREAD_TIMEOUT: parseIntSafe(process.env.QUERY_THREAD_TIMEOUT),
   // old - to remove
   CLIENT_ID: process.env.CLIENT_ID,
   BUDIBASE_DIR: process.env.BUDIBASE_DIR,
@@ -77,7 +78,6 @@ module.exports = {
   DEPLOYMENT_CREDENTIALS_URL: process.env.DEPLOYMENT_CREDENTIALS_URL,
   ALLOW_DEV_AUTOMATIONS: process.env.ALLOW_DEV_AUTOMATIONS,
   DISABLE_THREADING: process.env.DISABLE_THREADING,
-  QUERY_THREAD_TIMEOUT: parseIntSafe(process.env.QUERY_THREAD_TIMEOUT),
   SQL_MAX_ROWS: process.env.SQL_MAX_ROWS,
   _set(key, value) {
     process.env[key] = value

--- a/packages/server/src/environment.js
+++ b/packages/server/src/environment.js
@@ -24,6 +24,12 @@ if (!LOADED && isDev() && !isTest()) {
   LOADED = true
 }
 
+function parseIntSafe(number) {
+  if (number) {
+    return parseInt(number)
+  }
+}
+
 let inThread = false
 
 module.exports = {
@@ -71,7 +77,7 @@ module.exports = {
   DEPLOYMENT_CREDENTIALS_URL: process.env.DEPLOYMENT_CREDENTIALS_URL,
   ALLOW_DEV_AUTOMATIONS: process.env.ALLOW_DEV_AUTOMATIONS,
   DISABLE_THREADING: process.env.DISABLE_THREADING,
-  QUERY_THREAD_TIMEOUT: parseInt(process.env.QUERY_THREAD_TIMEOUT),
+  QUERY_THREAD_TIMEOUT: parseIntSafe(process.env.QUERY_THREAD_TIMEOUT),
   SQL_MAX_ROWS: process.env.SQL_MAX_ROWS,
   _set(key, value) {
     process.env[key] = value

--- a/packages/server/src/environment.js
+++ b/packages/server/src/environment.js
@@ -71,7 +71,7 @@ module.exports = {
   DEPLOYMENT_CREDENTIALS_URL: process.env.DEPLOYMENT_CREDENTIALS_URL,
   ALLOW_DEV_AUTOMATIONS: process.env.ALLOW_DEV_AUTOMATIONS,
   DISABLE_THREADING: process.env.DISABLE_THREADING,
-  QUERY_THREAD_TIMEOUT: process.env.QUERY_THREAD_TIMEOUT,
+  QUERY_THREAD_TIMEOUT: parseInt(process.env.QUERY_THREAD_TIMEOUT),
   SQL_MAX_ROWS: process.env.SQL_MAX_ROWS,
   _set(key, value) {
     process.env[key] = value


### PR DESCRIPTION
## Description
`QUERY_THREAD_TIMEOUT` is passed to application as a string and can't be used for options which requires integer as a parameter. docker-compose pass all environment variables as strings so declaration like:
```
...
    environment:
      QUERY_THREAD_TIMEOUT: 120000
      ...
```
becomes to:
```
...
    environment:
      QUERY_THREAD_TIMEOUT: "120000"
      ...
```

It's used in 2 places:
- packages/server/src/api/controllers/query/index.js
- packages/server/src/automations/steps/bash.js
In both cases default value is integer.