### PR TITLE
Embedded Map V2

### DIFF
--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/MapLayersEditor/MapLayersDrawer.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/MapLayersEditor/MapLayersDrawer.svelte
@@ -1,0 +1,176 @@
+<script>
+  import {
+    DrawerContent,
+    Layout,
+    Input,
+    Label,
+    Body,
+    Button,
+    Select,
+    Icon,
+  } from "@budibase/bbui"
+  import DrawerBindableInput from "components/common/bindings/DrawerBindableInput.svelte"
+  import { dndzone } from "svelte-dnd-action"
+  import { flip } from "svelte/animate"
+  import { generate } from "shortid"
+
+  export let tileLayers = []
+  export let bindableProperties = []
+
+  const types = ["XYZ", "WMS"]
+
+  $: tileLayers.forEach(tileLayer => {
+    if (!tileLayer.id) {
+      tileLayer.id = generate()
+    }
+  })
+
+  const addLayer = () => {
+    tileLayers = [...tileLayers, {}]
+  }
+
+  const removeLayer = id => {
+    tileLayers = tileLayers.filter(tileLayer => tileLayer.id !== id)
+  }
+
+  const flipDurationMs = 150
+  let dragDisabled = true
+
+  const handleFinalize = e => {
+    updateLayersOrder(e)
+    dragDisabled = true
+  }
+
+  const updateLayersOrder = e => {
+    tileLayers = e.detail.items
+  }
+</script>
+
+<DrawerContent>
+  <div class="container">
+    <Layout noPadding gap="S">
+      {#if tileLayers?.length}
+        <Layout noPadding gap="XS">
+          <div class="column">
+            <div />
+            <Label size="L">Type</Label>
+            <Label size="L">URL</Label>
+            <Label size="L">Leaflet Options</Label>
+            <Label size="L">Visibility</Label>
+            <div />
+          </div>
+          <div
+            class="columns"
+            use:dndzone={{
+              items: tileLayers,
+              flipDurationMs,
+              dropTargetStyle: { outline: "none" },
+              dragDisabled,
+            }}
+            on:finalize={handleFinalize}
+            on:consider={updateLayersOrder}
+          >
+            {#each tileLayers as tileLayer (tileLayer.id)}
+              <div class="column" animate:flip={{ duration: flipDurationMs }}>
+                <div
+                  class="handle"
+                  aria-label="drag-handle"
+                  style={dragDisabled ? "cursor: grab" : "cursor: grabbing"}
+                  on:mousedown={() => (dragDisabled = false)}
+                >
+                  <Icon name="DragHandle" size="XL" />
+                </div>
+                <Select
+                  bind:value={tileLayer.type}
+                  placeholder="Type"
+                  options={types}
+                  on:change={e => (tileLayer.type = e.detail)}
+                />
+                <Input bind:value={tileLayer.url} placeholder="URL" />
+                <DrawerBindableInput
+                  value={tileLayer.leafletOptions}
+                  on:change={e => (tileLayer.leafletOptions = e.detail)}
+                  placeholder={'{ attributions: "" }'}
+                />
+                <DrawerBindableInput
+                  value={tileLayer.visibility}
+                  on:change={e => (tileLayer.visibility = e.detail)}
+                  placeholder={"{{ Visibility }}"}
+                  bindings={bindableProperties}
+                />
+                <Icon
+                  name="Close"
+                  hoverable
+                  size="S"
+                  on:click={() => removeLayer(tileLayer.id)}
+                  disabled={tileLayers.length === 1}
+                />
+              </div>
+            {/each}
+          </div>
+        </Layout>
+      {:else}
+        <div class="column">
+          <div class="wide">
+            <Body size="S">
+              You can control the order of rendering of your overlay layers of
+              your map, and bind their visibility.
+            </Body>
+          </div>
+        </div>
+      {/if}
+      <div class="column">
+        <div class="buttons wide">
+          <Button secondary icon="Add" on:click={addLayer}>Add layer</Button>
+        </div>
+      </div>
+    </Layout>
+  </div>
+</DrawerContent>
+
+<style>
+  .container {
+    width: 100%;
+    max-width: 960px;
+    margin: 0 auto;
+  }
+
+  .columns {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: stretch;
+    gap: var(--spacing-m);
+  }
+
+  .column {
+    gap: var(--spacing-l);
+    display: grid;
+    grid-template-columns: 20px 80px 1fr 1fr 1fr auto;
+    align-items: center;
+    border-radius: var(--border-radius-s);
+    transition: background-color ease-in-out 130ms;
+    padding-right: 10px;
+  }
+
+  .handle {
+    display: grid;
+    place-items: center;
+  }
+
+  .column:hover {
+    background-color: var(--spectrum-global-color-gray-100);
+  }
+
+  .wide {
+    grid-column: 2 / -1;
+  }
+
+  .buttons {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    gap: var(--spacing-m);
+  }
+</style>

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/MapLayersEditor/MapLayersEditor.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/MapLayersEditor/MapLayersEditor.svelte
@@ -1,0 +1,60 @@
+<script>
+  import { Button, ActionButton, Drawer } from "@budibase/bbui"
+  import MapLayersDrawer from "./MapLayersDrawer.svelte"
+  import { cloneDeep } from "lodash/fp"
+  import { createEventDispatcher } from "svelte"
+  import { getBindableProperties } from "builderStore/dataBinding"
+  import { currentAsset } from "builderStore"
+
+  export let componentInstance
+  export let value = []
+
+  const dispatch = createEventDispatcher()
+
+  $: bindableProperties = getBindableProperties(
+    $currentAsset,
+    componentInstance._id
+  )
+  $: updateBoundValue(value)
+
+  const updateBoundValue = value => {
+    boundValue = cloneDeep(value)
+  }
+
+  let boundValue
+  let drawer
+
+  const open = () => {
+    if (!value?.length) {
+      value = [
+        {
+          type: "XYZ",
+          url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+          visibility: "true",
+          leafletOptions:
+            '{{ js "cmV0dXJuIHsKCWF0dHJpYnV0aW9uOiAnJmNvcHk7IDxhIGhyZWY9Imh0dHBzOi8vd3d3Lm9wZW5zdHJlZXRtYXAub3JnL2NvcHlyaWdodCI+T3BlblN0cmVldE1hcDwvYT4gY29udHJpYnV0b3JzJywKfTs=" }}',
+        },
+      ]
+    }
+    updateBoundValue(value)
+    drawer.show()
+  }
+
+  const save = () => {
+    dispatch("change", boundValue)
+    drawer.hide()
+  }
+</script>
+
+<ActionButton on:click={open}>Configure Layers</ActionButton>
+<Drawer bind:this={drawer} title="Map Layers">
+  <svelte:fragment slot="description">
+    Configure the layers in your map.
+  </svelte:fragment>
+  <Button cta slot="buttons" on:click={save}>Save</Button>
+  <MapLayersDrawer
+    slot="body"
+    bind:tileLayers={boundValue}
+    {bindableProperties}
+  />
+</Drawer>

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/componentSettings.js
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/componentSettings.js
@@ -1,11 +1,17 @@
-import { Checkbox, Select, Stepper } from "@budibase/bbui"
+import {
+  Checkbox,
+  Select,
+  Stepper
+} from "@budibase/bbui"
 import DataSourceSelect from "./DataSourceSelect.svelte"
 import S3DataSourceSelect from "./S3DataSourceSelect.svelte"
 import DataProviderSelect from "./DataProviderSelect.svelte"
 import ButtonActionEditor from "./ButtonActionEditor/ButtonActionEditor.svelte"
 import TableSelect from "./TableSelect.svelte"
 import ColorPicker from "./ColorPicker.svelte"
-import { IconSelect } from "./IconSelect"
+import {
+  IconSelect
+} from "./IconSelect"
 import FieldSelect from "./FieldSelect.svelte"
 import MultiFieldSelect from "./MultiFieldSelect.svelte"
 import SearchFieldSelect from "./SearchFieldSelect.svelte"
@@ -19,6 +25,7 @@ import FormFieldSelect from "./FormFieldSelect.svelte"
 import ValidationEditor from "./ValidationEditor/ValidationEditor.svelte"
 import DrawerBindableCombobox from "components/common/bindings/DrawerBindableCombobox.svelte"
 import ColumnEditor from "./ColumnEditor/ColumnEditor.svelte"
+import MapLayersEditor from "./MapLayersEditor/MapLayersEditor.svelte"
 
 const componentMap = {
   text: DrawerBindableCombobox,
@@ -42,6 +49,7 @@ const componentMap = {
   filter: FilterEditor,
   url: URLSelect,
   columns: ColumnEditor,
+  mapLayers: MapLayersEditor,
   "field/string": FormFieldSelect,
   "field/number": FormFieldSelect,
   "field/options": FormFieldSelect,

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/componentSettings.js
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/componentSettings.js
@@ -1,17 +1,11 @@
-import {
-  Checkbox,
-  Select,
-  Stepper
-} from "@budibase/bbui"
+import { Checkbox, Select, Stepper } from "@budibase/bbui"
 import DataSourceSelect from "./DataSourceSelect.svelte"
 import S3DataSourceSelect from "./S3DataSourceSelect.svelte"
 import DataProviderSelect from "./DataProviderSelect.svelte"
 import ButtonActionEditor from "./ButtonActionEditor/ButtonActionEditor.svelte"
 import TableSelect from "./TableSelect.svelte"
 import ColorPicker from "./ColorPicker.svelte"
-import {
-  IconSelect
-} from "./IconSelect"
+import { IconSelect } from "./IconSelect"
 import FieldSelect from "./FieldSelect.svelte"
 import MultiFieldSelect from "./MultiFieldSelect.svelte"
 import SearchFieldSelect from "./SearchFieldSelect.svelte"

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -2533,57 +2533,78 @@
     "illegalChildren": ["section"],
     "settings": [
       {
-        "type": "dataProvider",
-        "label": "Provider",
-        "key": "dataProvider"
-      },
-      {
-        "type": "field",
-        "label": "Latitude Key",
-        "key": "latitudeKey",
-        "dependsOn": "dataProvider"
-      },
-      {
-        "type": "field",
-        "label": "Longitude Key",
-        "key": "longitudeKey",
-        "dependsOn": "dataProvider"
-      },
-      {
-        "type": "field",
-        "label": "Title Key",
-        "key": "titleKey",
-        "dependsOn": "dataProvider"
-      },
-      {
-        "type": "event",
-        "label": "On Click Marker",
-        "key": "onClickMarker",
-        "context": [
+        "section": true,
+        "name": "Markers",
+        "settings": [
           {
-            "label": "Clicked marker",
-            "key": "marker"
+            "type": "dataProvider",
+            "label": "Data Provider",
+            "key": "markerProvider"
+          },
+          {
+            "type": "field",
+            "label": "Marker Latitude Key",
+            "key": "markerLatitudeKey",
+            "dependsOn": "markerProvider"
+          },
+          {
+            "type": "field",
+            "label": "Marker Longitude Key",
+            "key": "markerLongitudeKey",
+            "dependsOn": "markerProvider"
+          },
+          {
+            "type": "field",
+            "label": "Marker Title Key",
+            "key": "markerTitleKey",
+            "dependsOn": "markerProvider"
+          },
+          {
+            "type": "boolean",
+            "label": "Enable creating markers",
+            "key": "markerCreationEnabled",
+            "defaultValue": false
+          },
+          {
+            "type": "event",
+            "label": "On Click Marker",
+            "key": "onClickMarker",
+            "context": [
+              {
+                "label": "Clicked marker",
+                "key": "marker"
+              }
+            ]
+          },
+          {
+            "type": "event",
+            "label": "On Create Marker",
+            "key": "onCreateMarker",
+            "dependsOn": "markerCreationEnabled",
+            "context": [
+              {
+                "label": "New marker latitude",
+                "key": "lat"
+              },
+              {
+                "label": "New marker longitude",
+                "key": "lng"
+              }
+            ]
           }
         ]
       },
       {
-        "type": "boolean",
-        "label": "Enable creating markers",
-        "key": "creationEnabled",
-        "defaultValue": false
-      },
-      {
         "type": "event",
-        "label": "On Create Marker",
-        "key": "onCreateMarker",
-        "dependsOn": "creationEnabled",
+        "label": "On Click Map",
+        "key": "onClickMap",
         "context": [
           {
-            "label": "New marker latitude",
+            "label": "Latitude",
             "key": "lat"
           },
           {
-            "label": "New marker longitude",
+            "label": "Longitude",
             "key": "lng"
           }
         ]
@@ -2607,12 +2628,29 @@
         "defaultValue": true
       },
       {
-        "type": "text",
-        "label": "Tile URL",
-        "key": "tileURL",
-        "defaultValue": "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        "section": true,
+        "name": "GIS Integration",
+        "settings": [
+          {
+            "type": "mapLayers",
+            "label": "Configure layers",
+            "key": "tileLayers"
+          },
+          {
+            "type": "boolean",
+            "label": "Enable Attribution Prefix",
+            "key": "enableAttributionPrefix",
+            "defaultValue": "false"
+          },
+          {
+            "type": "text",
+            "label": "Custom Attribution Prefix",
+            "key": "customAttributionPrefix",
+            "dependsOn": "enableAttributionPrefix",
+            "defaultValue": ""
+          }
+        ]
       },
-
       {
         "type": "text",
         "label": "Default Location (when empty)",
@@ -2621,17 +2659,21 @@
       },
       {
         "type": "number",
-        "label": "Default Location Zoom Level (0-100)",
-        "key": "zoomLevel",
-        "placeholder": 50,
-        "max": 100,
-        "min": 0
+        "label": "Minimum Zoom Level",
+        "key": "minZoomLevel",
+        "defaultValue": 0
       },
       {
-        "type": "text",
-        "label": "Map Attribution",
-        "key": "mapAttribution",
-        "defaultValue": "OpenStreetMap contributors"
+        "type": "number",
+        "label": "Default Zoom Level",
+        "key": "defaultZoomLevel",
+        "defaultValue": 9
+      },
+      {
+        "type": "number",
+        "label": "Maximum Zoom Level",
+        "key": "maxZoomLevel",
+        "defaultValue": 18
       }
     ]
   },


### PR DESCRIPTION
## Description

Addresses #5314. This overhauls the integration of the embedded map with GIS services together with a collection of changes with the previous embedded map

### GIS Integration Overhaul
 - Support multiple tile layers
 - Support multiple tile services (currently, the initial pull request only adds XYZ and WMS services)
 - Fine-grained access to Leaflet options
 - Support binding visibility of layers

### Changes/Fixes 
 - Marker-related features have been grouped into a section
 - Input for default zoom level has been changed from percentage numbering to the actual zoom level numbering since Leaflet doesn't zoom seamlessly anyway
 - Added configurable minimum and maximum zoom levels
 - Added On Click Map Action with Lat/Long parameters supplied
 - Configurable Attribution Prefix

## Screenshots

![image](https://user-images.githubusercontent.com/53972232/162648777-1289748c-4253-4e67-a79f-ca45cd9dcaef.png)

## Remarks

In relation to #5281, directly integrating private GIS services can't be supported at the moment since it would require those GIS services to have their own middleware for authenticating incoming requests. A solution would be to add a "REST API Proxy" data source in Budibase aside from the "REST API Connector" that proxies internal services to authenticate incoming requests so users won't have to go through the hassle of making their own middleware. Moreover, being able to proxy internal APIs will open a lot of room for customizability when developing apps with Budibase without the hassle of dealing with security