### PR TITLE
Fixes for custom queries

### DIFF
--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/DataSourceSelect.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/DataSourceSelect.svelte
@@ -52,7 +52,6 @@
     .map(query => ({
       label: query.name,
       name: query.name,
-      tableId: query._id,
       ...query,
       type: "query",
     }))

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/SearchFieldSelect.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/SearchFieldSelect.svelte
@@ -22,7 +22,7 @@
   function getOptions(ds, dsSchema) {
     let base = Object.values(dsSchema)
     if (!ds?.tableId) {
-      return base
+      return base.map(field => field.name)
     }
     const currentTable = $tables.list.find(table => table._id === ds.tableId)
     return getFields(base, { allowLinks: currentTable?.sql }).map(

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/SearchFieldSelect.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/SearchFieldSelect.svelte
@@ -15,9 +15,7 @@
 
   const dispatch = createEventDispatcher()
   $: datasource = getDatasourceForProvider($currentAsset, componentInstance)
-  $: schema = getSchemaForDatasource($currentAsset, datasource, {
-    searchableSchema: true,
-  }).schema
+  $: schema = getSchemaForDatasource($currentAsset, datasource).schema
   $: options = getOptions(datasource, schema || {})
   $: boundValue = getSelectedOption(value, options)
 

--- a/packages/client/src/components/app/forms/Form.svelte
+++ b/packages/client/src/components/app/forms/Form.svelte
@@ -80,7 +80,7 @@
   }
 
   const fetchTable = async dataSource => {
-    if (dataSource?.tableId) {
+    if (dataSource?.tableId && dataSource?.type !== "query") {
       try {
         table = await API.fetchTableDefinition(dataSource.tableId)
       } catch (error) {


### PR DESCRIPTION
## Description
Fixes a couple of issues with handling custom queries and attempting to search.
- Use the readable schema rather than the searchable schema when generating lists of fields to search by (mentioned here https://github.com/Budibase/budibase/issues/5144#issuecomment-1096802409)
- Remove table ID from datasource definitions for custom queries to prevent 500 errors being thrown when attempting to fetch a table definition and sending up a query ID https://github.com/Budibase/budibase/issues/5318 https://github.com/Budibase/budibase/issues/5339
- Fix issue with search field select not being able to parse schemas for datasources that don't include a table ID

