### PR TITLE
Smoke Build Test Changes

### DIFF
--- a/packages/builder/cypress/integration/createApp.spec.js
+++ b/packages/builder/cypress/integration/createApp.spec.js
@@ -25,9 +25,13 @@ filterTests(['smoke', 'all'], () => {
       cy.visit(`${Cypress.config().baseUrl}/builder`)
       cy.wait(500)
 
-      if (Cypress.env("TEST_ENV")) {
-        cy.get(".spectrum-Button").contains("Templates").click({force: true})
-      }
+      cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+        .its("body")
+        .then(val => {
+          if (val.length > 0) {
+            cy.get(".spectrum-Button").contains("Templates").click({force: true})
+          }
+        })
 
       cy.get(".template-category-filters").should("exist")
       cy.get(".template-categories").should("exist")

--- a/packages/builder/cypress/integration/createTable.spec.js
+++ b/packages/builder/cypress/integration/createTable.spec.js
@@ -61,7 +61,8 @@ filterTests(["smoke", "all"], () => {
         for (let i = 1; i < totalRows; i++) {
           cy.addRow([i])
         }
-        cy.wait(1000)
+        cy.reload()
+        cy.wait(2000)
         cy.get(".spectrum-Pagination").within(() => {
           cy.get(".spectrum-ActionButton").eq(1).click()
         })
@@ -71,12 +72,12 @@ filterTests(["smoke", "all"], () => {
       })
 
       it("Deletes rows and checks pagination", () => {
-        // Delete rows, removing second page of rows from table
-        const deleteRows = 5
+        // Delete rows, removing second page from table
         cy.get(".spectrum-Checkbox-input").check({ force: true })
-        cy.get(".spectrum-Table")
-        cy.contains("Delete 5 row(s)").click()
-        cy.get(".spectrum-Modal").contains("Delete").click()
+        cy.get(".popovers").within(() => {
+          cy.get(".spectrum-Button").click({ force: true })
+        })
+        cy.get(".spectrum-Dialog-grid").contains("Delete").click({ force: true })
         cy.wait(1000)
 
         // Confirm table only has one page

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -60,44 +60,50 @@ Cypress.Commands.add("deleteApp", name => {
   cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
     .its("body")
     .then(val => {
-      if (val.length > 0) {
-        if (Cypress.env("TEST_ENV")) {
-          cy.searchForApplication(name)
-          cy.get(".appTable").within(() => {
-            cy.get(".spectrum-Icon").eq(1).click()
+      const findAppName = val.some(val => val.name == name)
+      if (findAppName) {
+        if (val.length > 0) {
+          if (Cypress.env("TEST_ENV")) {
+            cy.searchForApplication(name)
+            cy.get(".appTable").within(() => {
+              cy.get(".spectrum-Icon").eq(1).click()
+            })
+          } else {
+            const appId = val.reduce((acc, app) => {
+              if (name === app.name) {
+                acc = app.appId
+              }
+              return acc
+            }, "")
+  
+            if (appId == "") {
+              return
+            }
+  
+            const appIdParsed = appId.split("_").pop()
+            const actionEleId = `[data-cy=row_actions_${appIdParsed}]`
+            cy.get(actionEleId).within(() => {
+              cy.get(".spectrum-Icon").eq(0).click()
+            })
+          }
+  
+          cy.get(".spectrum-Menu").then($menu => {
+            if ($menu.text().includes("Unpublish")) {
+              cy.get(".spectrum-Menu").contains("Unpublish").click()
+              cy.get(".spectrum-Dialog-grid").contains("Unpublish app").click()
+            } else {
+              cy.get(".spectrum-Menu").contains("Delete").click()
+              cy.get(".spectrum-Dialog-grid").within(() => {
+                cy.get("input").type(name)
+              })
+              cy.get(".spectrum-Button--warning").click()
+            }
           })
         } else {
-          const appId = val.reduce((acc, app) => {
-            if (name === app.name) {
-              acc = app.appId
-            }
-            return acc
-          }, "")
-
-          if (appId == "") {
-            return
-          }
-
-          const appIdParsed = appId.split("_").pop()
-          const actionEleId = `[data-cy=row_actions_${appIdParsed}]`
-          cy.get(actionEleId).within(() => {
-            cy.get(".spectrum-Icon").eq(0).click()
-          })
+          return
         }
-
-        cy.get(".spectrum-Menu").then($menu => {
-          if ($menu.text().includes("Unpublish")) {
-            cy.get(".spectrum-Menu").contains("Unpublish").click()
-            cy.get(".spectrum-Dialog-grid").contains("Unpublish app").click()
-          } else {
-            cy.get(".spectrum-Menu").contains("Delete").click()
-            cy.get(".spectrum-Dialog-grid").within(() => {
-              cy.get("input").type(name)
-            })
-            cy.get(".spectrum-Button--warning").click()
-          }
-        })
-      } else {
+      }
+      else {
         return
       }
     })

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -75,18 +75,18 @@ Cypress.Commands.add("deleteApp", name => {
               }
               return acc
             }, "")
-  
+
             if (appId == "") {
               return
             }
-  
+
             const appIdParsed = appId.split("_").pop()
             const actionEleId = `[data-cy=row_actions_${appIdParsed}]`
             cy.get(actionEleId).within(() => {
               cy.get(".spectrum-Icon").eq(0).click()
             })
           }
-  
+
           cy.get(".spectrum-Menu").then($menu => {
             if ($menu.text().includes("Unpublish")) {
               cy.get(".spectrum-Menu").contains("Unpublish").click()
@@ -102,8 +102,7 @@ Cypress.Commands.add("deleteApp", name => {
         } else {
           return
         }
-      }
-      else {
+      } else {
         return
       }
     })


### PR DESCRIPTION
Changes to tests affecting the nightly smoke build.
This build runs with the `test_env` enabled - but differs from the daily test env.

### Updated deleteApp function
- No longer tries to delete an app that does not exist

### Table Pagination Tests
- Updated to include a page reload, page navigation not possible otherwise

### createApp.spec.js
- Test fix for `should provide filterable templates`. Checks if apps already exist and acts accordingly
