### PR TITLE
Fix for DynamoDB queries - connecting with endpoint set

### DIFF
--- a/packages/server/src/integrations/dynamodb.ts
+++ b/packages/server/src/integrations/dynamodb.ts
@@ -131,11 +131,12 @@ module DynamoModule {
 
     constructor(config: DynamoDBConfig) {
       this.config = config
-      if (!this.config.endpoint) {
+      if (this.config.endpoint && !this.config.endpoint.includes("localhost")) {
         this.connect()
       }
       let options = {
         correctClockSkew: true,
+        region: this.config.region || AWS_REGION,
         endpoint: config.endpoint ? config.endpoint : undefined,
       }
       this.client = new AWS.DynamoDB.DocumentClient(options)


### PR DESCRIPTION
## Description
Fixing issue #5322 - when endpoint is specified for DynamoDB and not in a the region that the whole instance expects it will throw an odd credentials error - making sure connection is commenced everywhere other than localhost.