### PR TITLE
Airtable 500 Fix: Only fetch the table definition if id is not query

### DIFF
--- a/packages/client/src/api/patches.js
+++ b/packages/client/src/api/patches.js
@@ -96,7 +96,9 @@ export const patchAPI = API => {
   // handlebars enrichment
   const fetchTableDefinition = API.fetchTableDefinition
   API.fetchTableDefinition = async tableId => {
-    const definition = tableId.startsWith("ta_") ? await fetchTableDefinition(tableId) : undefined
+    const definition = !tableId.startsWith("query")
+      ? await fetchTableDefinition(tableId)
+      : undefined
     Object.keys(definition?.schema || {}).forEach(field => {
       if (definition.schema[field]?.type === "formula") {
         delete definition.schema[field].formula

--- a/packages/client/src/api/patches.js
+++ b/packages/client/src/api/patches.js
@@ -96,7 +96,7 @@ export const patchAPI = API => {
   // handlebars enrichment
   const fetchTableDefinition = API.fetchTableDefinition
   API.fetchTableDefinition = async tableId => {
-    const definition = await fetchTableDefinition(tableId)
+    const definition = tableId.startsWith("ta_") ? await fetchTableDefinition(tableId) : undefined
     Object.keys(definition?.schema || {}).forEach(field => {
       if (definition.schema[field]?.type === "formula") {
         delete definition.schema[field].formula


### PR DESCRIPTION
## Description
Airtable 500 bug: https://github.com/Budibase/budibase/issues/5318

Made a change to prevent a call being made to the fetch table definition if it's a query datasource. 



