### PR TITLE
Move settings bar below element if at very top [TWEAK]

### DIFF
--- a/packages/client/src/components/preview/SettingsBar.svelte
+++ b/packages/client/src/components/preview/SettingsBar.svelte
@@ -67,7 +67,7 @@
       }
 
       //If element is at the very top of the screen, put the bar below the element
-      if (elBounds.top < elBounds.height) {
+      if (elBounds.top < elBounds.height && elBounds.height < 80) {
         newTop = elBounds.bottom + verticalOffset
       }
 


### PR DESCRIPTION
## Description
Only apply this to small components (e.g. button, headline)
Issue: https://github.com/Budibase/budibase/issues/4349



