### PR TITLE
Fix sticky hover state for icons on mobile

### DIFF
--- a/packages/client/src/components/app/Icon.svelte
+++ b/packages/client/src/components/app/Icon.svelte
@@ -36,8 +36,13 @@
   div {
     font-style: italic;
   }
-  .hoverable:hover {
+  @media (hover: hover) {
+    .hoverable:hover {
+      color: var(--spectrum-alias-icon-color-selected-hover) !important;
+      cursor: pointer;
+    }
+  }
+  .hoverable:active {
     color: var(--spectrum-alias-icon-color-selected-hover) !important;
-    cursor: pointer;
   }
 </style>


### PR DESCRIPTION
## Description
Fixes an issue where the hover styles for icons were applied permanently after clicking an icon on mobile.

Fixes https://github.com/Budibase/budibase/issues/5471.


