### PR TITLE
Remove Row Rev field for Actions and Automations

### DIFF
--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ButtonActionEditor/actions/DeleteRow.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ButtonActionEditor/actions/DeleteRow.svelte
@@ -26,14 +26,6 @@
     on:change={value => (parameters.rowId = value.detail)}
   />
 
-  <Label small>Row Rev</Label>
-  <DrawerBindableInput
-    {bindings}
-    title="Row rev to delete"
-    value={parameters.revId}
-    on:change={value => (parameters.revId = value.detail)}
-  />
-
   <Label small />
   <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
 

--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -81,7 +81,7 @@ const duplicateRowHandler = async (action, context) => {
 
 const deleteRowHandler = async action => {
   const { tableId, revId, rowId } = action.parameters
-  if (tableId && revId && rowId) {
+  if (tableId && rowId) {
     try {
       await API.deleteRow({ tableId, rowId, revId })
       notificationStore.actions.success("Row deleted")

--- a/packages/frontend-core/src/api/rows.js
+++ b/packages/frontend-core/src/api/rows.js
@@ -35,7 +35,7 @@ export const buildRowEndpoints = API => ({
    * @param revId the rev of the row to delete
    */
   deleteRow: async ({ tableId, rowId, revId }) => {
-    if (!tableId || !rowId || !revId) {
+    if (!tableId || !rowId) {
       return
     }
     return await API.delete({

--- a/packages/server/src/api/controllers/row/internal.js
+++ b/packages/server/src/api/controllers/row/internal.js
@@ -259,8 +259,9 @@ exports.find = async ctx => {
 
 exports.destroy = async function (ctx) {
   const db = getAppDB()
-  const { _id, _rev } = ctx.request.body
+  const { _id } = ctx.request.body
   let row = await db.get(_id)
+  let _rev = ctx.request.body._rev || row._rev
 
   if (row.tableId !== ctx.params.tableId) {
     throw "Supplied tableId doesn't match the row's tableId"

--- a/packages/server/src/automations/steps/deleteRow.js
+++ b/packages/server/src/automations/steps/deleteRow.js
@@ -23,13 +23,9 @@ exports.definition = {
         id: {
           type: "string",
           title: "Row ID",
-        },
-        revision: {
-          type: "string",
-          title: "Row Revision",
-        },
+        }
       },
-      required: ["tableId", "id", "revision"],
+      required: ["tableId", "id"],
     },
     outputs: {
       properties: {

--- a/packages/server/src/automations/steps/deleteRow.js
+++ b/packages/server/src/automations/steps/deleteRow.js
@@ -23,7 +23,7 @@ exports.definition = {
         id: {
           type: "string",
           title: "Row ID",
-        }
+        },
       },
       required: ["tableId", "id"],
     },

--- a/packages/server/src/automations/steps/deleteRow.js
+++ b/packages/server/src/automations/steps/deleteRow.js
@@ -49,7 +49,7 @@ exports.definition = {
 }
 
 exports.run = async function ({ inputs, appId, emitter }) {
-  if (inputs.id == null || inputs.revision == null) {
+  if (inputs.id == null) {
     return {
       success: false,
       response: {


### PR DESCRIPTION
## Description
A few users were confused about Row Rev, and it was decided it should be removed as it has a very niche use-case. Deletes from the internal DB will now behave similar to those in SQL. 
The latest Row Rev is taken when the row data is retrieved. 

## Screenshots
![Screenshot 2022-04-20 at 12 15 06](https://user-images.githubusercontent.com/101575380/164218894-f3bccb2d-9009-4378-9fa7-e5226f8429d5.png)

![Screenshot 2022-04-20 at 12 15 40](https://user-images.githubusercontent.com/101575380/164218985-d13e63ad-cd33-4b40-8156-eced053ed6e8.png)




