### PR TITLE
Fix QUERY_THREAD_TIMEOUT out of range

### DIFF
--- a/packages/server/src/automations/steps/bash.js
+++ b/packages/server/src/automations/steps/bash.js
@@ -53,7 +53,7 @@ exports.run = async function ({ inputs, context }) {
       success = true
     try {
       stdout = execSync(command, {
-        timeout: environment.QUERY_THREAD_TIMEOUT || 500,
+        timeout: parseInt(environment.QUERY_THREAD_TIMEOUT) || 500,
       }).toString()
     } catch (err) {
       stdout = err.message


### PR DESCRIPTION
## Description
environment.QUERY_THREAD_TIMEOUT must be an unsigned integer, but environment.QUERY_THREAD_TIMEOUT now return a string
lead to error: The value of "timeout" is out of range. It must be an unsigned integer. Received '10000'"

This is minor fix for [#5267](https://github.com/Budibase/budibase/pull/5267) of @shogunpurple 

## Screenshots
![image](https://user-images.githubusercontent.com/4613808/164558253-b02471dd-afd0-4bd3-80f6-47e626d94f0f.png)



