### PR TITLE
Fix for SQL relationship based formulas

### DIFF
--- a/packages/builder/src/components/backend/DataTable/formula.js
+++ b/packages/builder/src/components/backend/DataTable/formula.js
@@ -60,6 +60,7 @@ export function getBindings({
     )
 
     const label = path == null ? column : `${path}.0.${column}`
+    const binding = path == null ? `[${column}]` : `${path}.0.[${column}]`
     // only supply a description for relationship paths
     const description =
       path == null
@@ -73,8 +74,8 @@ export function getBindings({
       description,
       // don't include path, it messes things up, relationship path
       // will be replaced by the main array binding
-      readableBinding: column,
-      runtimeBinding: `[${column}]`,
+      readableBinding: label,
+      runtimeBinding: binding,
     })
   }
   return bindings

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -323,6 +323,28 @@ module External {
       return { row: newRow, manyRelationships }
     }
 
+    squashRelationshipColumns(
+      table: Table,
+      row: Row,
+      relationships: RelationshipsJson[]
+    ): Row {
+      for (let relationship of relationships) {
+        const linkedTable = this.tables[relationship.tableName]
+        if (!linkedTable) {
+          continue
+        }
+        const display = linkedTable.primaryDisplay
+        for (let key of Object.keys(row[relationship.column])) {
+          const related: Row = row[relationship.column][key]
+          row[relationship.column][key] = {
+            primaryDisplay: display ? related[display] : undefined,
+            _id: related._id,
+          }
+        }
+      }
+      return row
+    }
+
     /**
      * This iterates through the returned rows and works out what elements of the rows
      * actually match up to another row (based on primary keys) - this is pretty specific
@@ -353,12 +375,6 @@ module External {
         let linked = basicProcessing(row, linkedTable)
         if (!linked._id) {
           continue
-        }
-        // if not returning full docs then get the minimal links out
-        const display = linkedTable.primaryDisplay
-        linked = {
-          primaryDisplay: display ? linked[display] : undefined,
-          _id: linked._id,
         }
         columns[relationship.column] = linked
       }
@@ -417,7 +433,9 @@ module External {
           relationships
         )
       }
-      return processFormulas(table, Object.values(finalRows))
+      return processFormulas(table, Object.values(finalRows)).map((row: Row) =>
+        this.squashRelationshipColumns(table, row, relationships)
+      )
     }
 
     /**

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -27,7 +27,8 @@ module MySQLModule {
     user: string
     password: string
     database: string
-    ssl?: object
+    ssl?: { [key: string]: any }
+    rejectUnauthorized: boolean
   }
 
   const SCHEMA: Integration = {
@@ -63,6 +64,11 @@ module MySQLModule {
       },
       ssl: {
         type: DatasourceFieldTypes.OBJECT,
+        required: false,
+      },
+      rejectUnauthorized: {
+        type: DatasourceFieldTypes.BOOLEAN,
+        default: true,
         required: false,
       },
     },
@@ -114,6 +120,16 @@ module MySQLModule {
       if (config.ssl && Object.keys(config.ssl).length === 0) {
         delete config.ssl
       }
+      // make sure this defaults to true
+      if (
+        config.rejectUnauthorized != null &&
+        !config.rejectUnauthorized &&
+        config.ssl
+      ) {
+        config.ssl.rejectUnauthorized = config.rejectUnauthorized
+      }
+      // @ts-ignore
+      delete config.rejectUnauthorized
       this.config = config
     }
 


### PR DESCRIPTION
## Description
Fixes for:
1. #5495 - there was an issue where SQL tables wouldn't have access to relational data - the relational data was being squashed to the `{ primaryDisplay: ..., _id: ... }` structure before the formulas were being calculated which meant they could not access any of the relational properties. Also updated the frontend binding generation, when you clicked on a relationship value it was just adding the relational column name, not the path to it e.g. `relatedColumn.0.someColumn` - fixed this.
2. #5530 - Quick fix for the MySQL `RejectUnauthorized` flag.

## Screenshots
The new Reject unauthorized flag for MySQL SSL connections.
![image](https://user-images.githubusercontent.com/4407001/164732084-a435a0e9-d212-4d92-b072-6ac8cb9ef265.png)



