### PR TITLE
Fix Bug adding custom column to Users table results in blank Created By & Updated By columns in linked table

### DIFF
--- a/packages/server/src/db/linkedRows/LinkController.js
+++ b/packages/server/src/db/linkedRows/LinkController.js
@@ -369,6 +369,20 @@ class LinkController {
           tableId: table._id,
           fieldName: fieldName,
         })
+        
+        if(/(.+)-Created By/.test(field.name) || /(.+)-Updated By/.test(field.name)){
+            // these are props specially for Created By and Updated By linked column
+              fields.linkedField = {
+                  ...fields.linkedField,  
+                  subtype: (/(.+)-Created By/.test(field.name)) ? 'createdBy' : 'updatedBy',
+                  icon: 'ri-magic-line',
+                  autocolumn: true,
+                  constraints: {
+                    type: 'array',
+                    presence: false
+                  },
+              }
+        }
 
         // update table schema after checking relationship types
         schema[fieldName] = fields.linkerField


### PR DESCRIPTION
When adding custom column to Users table results in blank Created By & Updated By columns in linked table

Bug report here: [#5269](https://github.com/Budibase/budibase/issues/5269)
Bug discussion here: [#5260](https://github.com/Budibase/budibase/discussions/5260)

## Description
When adding custom column to Users table results in blank Created By & Updated By columns in linked table

## Screenshots
when add new Column to Users table of app

![image](https://user-images.githubusercontent.com/4613808/161821154-ddf61b18-a9c8-41cf-a9ca-42196ef1ba07.png)

It will make all other table cannot create row with Create By, Update By any more

![image](https://user-images.githubusercontent.com/4613808/161821425-801c11be-7c7b-4170-83b1-02d9f140e61d.png)



