### PR TITLE
Sync versions on release

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,7 +14,6 @@ staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  recent activity.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false

--- a/packages/backend-core/src/environment.js
+++ b/packages/backend-core/src/environment.js
@@ -22,7 +22,8 @@ module.exports = {
   MINIO_URL: process.env.MINIO_URL,
   INTERNAL_API_KEY: process.env.INTERNAL_API_KEY,
   MULTI_TENANCY: process.env.MULTI_TENANCY,
-  ACCOUNT_PORTAL_URL: process.env.ACCOUNT_PORTAL_URL,
+  ACCOUNT_PORTAL_URL:
+    process.env.ACCOUNT_PORTAL_URL || "https://account.budibase.app",
   ACCOUNT_PORTAL_API_KEY: process.env.ACCOUNT_PORTAL_API_KEY,
   DISABLE_ACCOUNT_PORTAL: process.env.DISABLE_ACCOUNT_PORTAL,
   SELF_HOSTED: !!parseInt(process.env.SELF_HOSTED),


### PR DESCRIPTION
## Description

Do a two way sync between budibase and pro versions:
- In budibase, sync the pro version to the current version 
   - This ensures OSS contributors pull the correct version of pro without needing to upgrade the lock file manually 
- In pro, sync the backend core version to the current budibase version
   - This ensures pro always uses the latest version of the core dependency and doesn't produce a nested `node_modules` folder when installing 

Also update the `stale.yml` to remove mention of closing stale issues which we no longer do. 



