### PR TITLE
adding larger limits to the NGINX ingress contoller

### DIFF
--- a/charts/budibase/Chart.yaml
+++ b/charts/budibase/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/Budibase/budibase
   - https://budibase.com
 type: application
-version: 0.2.8
+version: 0.2.9
 appVersion: 1.0.48
 dependencies:
   - name: couchdb

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -47,6 +47,8 @@ ingress:
   className: ""
   annotations:
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/client-max-body-size: 150M
+    nginx.ingress.kubernetes.io/proxy-body-size: 50m
   hosts:
     - host: # change if using custom domain
       paths:


### PR DESCRIPTION
## Description
Fix for https://github.com/Budibase/budibase/discussions/5556

The NGINX ingress controller did not have the correct `client_max_body_size` and `proxy_body_size` settings, causing a 413 when someone tried to import a large file (an app import).

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



