### PR TITLE
add storageClass to redis and objectStore PVCs

### DIFF
--- a/charts/budibase/templates/minio-data-persistentvolumeclaim.yaml
+++ b/charts/budibase/templates/minio-data-persistentvolumeclaim.yaml
@@ -12,5 +12,10 @@ spec:
   resources:
     requests:
       storage: {{ .Values.services.objectStore.storage }}
+  {{- if (eq "-" .Values.services.objectStore.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: "{{ .Values.services.objectStore.storageClass }}"
+  {{- end }}
 status: {}
 {{- end }}

--- a/charts/budibase/templates/redis-data-persistentvolumeclaim.yaml
+++ b/charts/budibase/templates/redis-data-persistentvolumeclaim.yaml
@@ -12,5 +12,10 @@ spec:
   resources:
     requests:
       storage: {{ .Values.services.redis.storage }}
+  {{- if (eq "-" .Values.services.redis.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: "{{ .Values.services.redis.storageClass }}"
+  {{- end }}
 status: {}
 {{- end }}

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -149,6 +149,11 @@ services:
     url: "" # only change if pointing to existing redis cluster and enabled: false
     password: "budibase" # recommended to override if using built-in redis
     storage: 100Mi
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.
+    storageClass: "-"
 
   objectStore:
     minio: true
@@ -160,6 +165,11 @@ services:
     region: "" # AWS_REGION if using S3 or existing minio secret
     url: "http://minio-service:9000" # only change if pointing to existing minio cluster or S3 and minio: false
     storage: 100Mi
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.
+    storageClass: "-"
 
 # Override values in couchDB subchart
 couchdb:


### PR DESCRIPTION
## Description
Problem: PVC storageClass option not available in helm chart
Solution: modified redis and objectStore PVC templates to avail option to set storageClassName


