### PR TITLE
Fix: Update global db context when tenant is updated + configurable couch integration in tenancy middleware

### DIFF
--- a/packages/backend-core/src/context/index.js
+++ b/packages/backend-core/src/context/index.js
@@ -71,7 +71,9 @@ exports.doInTenant = (tenantId, task) => {
     // set the tenant id
     if (!opts.existing) {
       cls.setOnContext(ContextKeys.TENANT_ID, tenantId)
-      exports.setGlobalDB(tenantId)
+      if (env.USE_COUCH) {
+        exports.setGlobalDB(tenantId)
+      }
     }
 
     try {
@@ -80,7 +82,9 @@ exports.doInTenant = (tenantId, task) => {
     } finally {
       const using = cls.getFromContext(ContextKeys.IN_USE)
       if (!using || using <= 1) {
-        await closeDB(exports.getGlobalDB())
+        if (env.USE_COUCH) {
+          await closeDB(exports.getGlobalDB())
+        }
         // clear from context now that database is closed/task is finished
         cls.setOnContext(ContextKeys.TENANT_ID, null)
         cls.setOnContext(ContextKeys.GLOBAL_DB, null)
@@ -167,6 +171,7 @@ exports.doInAppContext = (appId, task) => {
 
 exports.updateTenantId = tenantId => {
   cls.setOnContext(ContextKeys.TENANT_ID, tenantId)
+  exports.setGlobalDB(tenantId)
 }
 
 exports.updateAppId = async appId => {

--- a/packages/backend-core/src/environment.js
+++ b/packages/backend-core/src/environment.js
@@ -30,9 +30,18 @@ module.exports = {
   COOKIE_DOMAIN: process.env.COOKIE_DOMAIN,
   PLATFORM_URL: process.env.PLATFORM_URL,
   TENANT_FEATURE_FLAGS: process.env.TENANT_FEATURE_FLAGS,
+  USE_COUCH: process.env.USE_COUCH || true,
   isTest,
   _set(key, value) {
     process.env[key] = value
     module.exports[key] = value
   },
+}
+
+// clean up any environment variable edge cases
+for (let [key, value] of Object.entries(module.exports)) {
+  // handle the edge case of "0" to disable an environment variable
+  if (value === "0") {
+    module.exports[key] = 0
+  }
 }

--- a/packages/server/src/middleware/tests/currentapp.spec.js
+++ b/packages/server/src/middleware/tests/currentapp.spec.js
@@ -1,10 +1,14 @@
 mockAuthWithNoCookie()
 mockWorker()
 
-jest.mock("@budibase/backend-core/db", () => ({
-  ...jest.requireActual("@budibase/backend-core/db"),
-  dbExists: () => true,
-}))
+jest.mock("@budibase/backend-core/db", () => {
+  const coreDb = jest.requireActual("@budibase/backend-core/db")
+  coreDb.init()
+  return {
+    ...coreDb,
+    dbExists: () => true,
+  }
+})
 
 function mockWorker() {
   jest.mock("../../utilities/workerRequests", () => ({

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -1014,10 +1014,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.105-alpha.42":
-  version "1.0.105-alpha.42"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.105-alpha.42.tgz#732daf9234312261c91158303459bb02f95656e0"
-  integrity sha512-takLU6UcUVVzcF8EZEazxmY37Th8DwjG8CEtBrlYZn+yrAO+27XixOws72P+6Xr9IxGyAWxMpIQ8E5uZi6Zl9w==
+"@budibase/backend-core@1.0.105-alpha.43":
+  version "1.0.105-alpha.43"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.105-alpha.43.tgz#9790310c2758867b958f6c4a8313e9fbd2a4df4e"
+  integrity sha512-pS2VmSPi/i+r4EjsG4WszQ2VeIssu+ugVgl1O+oXA8/acPMWSWv1ct3JKrckz3sdKiSjllXhy+B4ZPvfN1Ezpg==
   dependencies:
     "@techpass/passport-openidconnect" "^0.3.0"
     aws-sdk "^2.901.0"
@@ -1087,12 +1087,12 @@
     svelte-flatpickr "^3.2.3"
     svelte-portal "^1.0.0"
 
-"@budibase/pro@1.0.105-alpha.42":
-  version "1.0.105-alpha.42"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.105-alpha.42.tgz#b616b24d9008c268f87b532b89493670d5a0a915"
-  integrity sha512-ibiJRm+22B4t8XZVkDQz8RU8Jd3XSS0M0K8vLRqdFaB632Vt/dnnMx6GbUvurjSfqxsa72R2+jNOME64oUl0Gg==
+"@budibase/pro@1.0.105-alpha.43":
+  version "1.0.105-alpha.43"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.105-alpha.43.tgz#0f90aa8570d789b8a69acf3895b6af036e32cc75"
+  integrity sha512-fz9JbHcWMsu2lHt7rH6HZqx6SosKjwKF2CUH3FMQgtQqCjJfe58GIPXgLh/eLT8O8Eq2F46HzRjABlqMUFjQSw==
   dependencies:
-    "@budibase/backend-core" "1.0.105-alpha.42"
+    "@budibase/backend-core" "1.0.105-alpha.43"
     node-fetch "^2.6.1"
 
 "@budibase/standard-components@^0.9.139":

--- a/scripts/pro/install.sh
+++ b/scripts/pro/install.sh
@@ -20,8 +20,12 @@ if [[ -d "budibase-pro" ]]; then
 
   # Try to checkout the matching pro branch
   git checkout $BRANCH
-  # Try to checkout the matching pro base (master or develop) branch
-  git checkout $BASE_BRANCH
+
+  if [[ $? == "1" ]] && [[ $BASE_BRANCH ]]; then
+    # There is no matching branch, try to match the base branch
+    git checkout $BASE_BRANCH
+  fi
+
   # If neither branch exists continue with default branch 'develop'
   git pull
 


### PR DESCRIPTION
## Description
- Add `setGlobalDB` to `updateTenantId` to make sure the correct global db is being accessed (fixes login)
- Add option `USE_COUCH` to turn off global db initialisation when using tenancy middleware (for account portal)