### PR TITLE
Step 2: adding production couchDB URL for backup as secret

### DIFF
--- a/.github/workflows/deploy-cloud.yaml
+++ b/.github/workflows/deploy-cloud.yaml
@@ -66,7 +66,7 @@ jobs:
           config-files: values.production.yaml
           chart-path: charts/budibase
           namespace: budibase
-          values: globals.appVersion=v${{ env.RELEASE_VERSION }}
+          values: globals.appVersion=v${{ env.RELEASE_VERSION }},services.couchdb.backup.target=${{ secrets.PRODUCTION_COUCHDB_URL }}
           name: budibase-prod
 
       - name: Discord Webhook Action


### PR DESCRIPTION
## Description
Step 2 of the couchdb migration - updating the backup target so that we can perform a replication from our existing couchDB database to the new one.

Note: after this is merged, we need to run the `cloud-deploy.yaml` job with version 1.0.118.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



