### PR TITLE
Fix for date picker on row creation

### DIFF
--- a/packages/builder/src/components/backend/DataTable/RowFieldControl.svelte
+++ b/packages/builder/src/components/backend/DataTable/RowFieldControl.svelte
@@ -20,6 +20,9 @@
   export let readonly
 
   const resolveTimeStamp = timestamp => {
+    if (!timestamp) {
+      return null
+    }
     let maskedDate = new Date(`0-${timestamp}`)
     if (maskedDate instanceof Date && !isNaN(maskedDate.getTime())) {
       return maskedDate


### PR DESCRIPTION
## Description
Fix for #5633 - making sure when timestamp is null (creating row) date picker can be used.

## Screenshots
![image](https://user-images.githubusercontent.com/4407001/165750546-903b6825-3cbd-4884-a827-f83cfc5b10cd.png)