### PR TITLE
Templates Details Tests

### DIFF
--- a/packages/builder/cypress/integration/templates/HR/hrTemplateDetails.spec.js
+++ b/packages/builder/cypress/integration/templates/HR/hrTemplateDetails.spec.js
@@ -1,0 +1,62 @@
+import filterTests from "../../../support/filterTests"
+
+filterTests(["all"], () => {
+  context("Verify HR Template Details", () => {
+
+    before(() => {
+      cy.login()
+
+      // Template navigation
+      cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+      .its("body")
+      .then(val => {
+        if (val.length > 0) {
+          cy.get(".spectrum-Button").contains("Templates").click({force: true})
+        }
+      })
+
+      // Filter HR Templates
+      cy.get(".template-category-filters").within(() => {
+        cy.get('[data-cy="HR"]').click()
+      })
+    })
+
+  it("should verify the details option for HR templates", () => {
+    cy.get(".template-grid").find(".template-card").its('length')
+    .then(len => {
+      for (let i = 0; i < len; i++) {
+        cy.get(".template-card").eq(i).within(() => {
+          const templateName = cy.get(".template-thumbnail-text")
+          templateName.invoke('text')
+          .then(templateNameText => {
+            const templateNameParsed = templateNameText.toLowerCase().replace(/\s+/g, '-')
+
+            if (templateNameText == "Job Application Tracker") {
+              // Template name should include 'applicant-tracking-system'
+              cy.get('a')
+              .should('have.attr', 'href').and('contain', 'applicant-tracking-system')
+            }
+            else if (templateNameText == "Job Portal App") {
+              // Template name should include 'job-portal'
+              const templateNameSplit = templateNameParsed.split('-app')[0]
+              cy.get('a')
+              .should('have.attr', 'href').and('contain', templateNameSplit)
+            }
+            else {
+              cy.get('a')
+              .should('have.attr', 'href').and('contain', templateNameParsed)
+            }
+          })
+          // Verify correct status from Details link - 200
+          cy.get('a')
+          .then(link => {
+            cy.request(link.prop('href'))
+            .its('status')
+            .should('eq', 200)
+          })
+        })
+      }
+    })
+  })
+})
+})

--- a/packages/builder/cypress/integration/templates/IT/ITTemplateDetails.spec.js
+++ b/packages/builder/cypress/integration/templates/IT/ITTemplateDetails.spec.js
@@ -1,0 +1,66 @@
+import filterTests from "../../../support/filterTests"
+
+filterTests(["all"], () => {
+  context("Verify IT Template Details", () => {
+
+    before(() => {
+      cy.login()
+
+      // Template navigation
+      cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+      .its("body")
+      .then(val => {
+        if (val.length > 0) {
+          cy.get(".spectrum-Button").contains("Templates").click({force: true})
+        }
+      })
+
+      // Filter IT Templates
+      cy.get(".template-category-filters").within(() => {
+        cy.get('[data-cy="IT"]').click()
+      })
+    })
+
+  it("should verify the details option for IT templates", () => {
+    cy.get(".template-grid").find(".template-card").its('length')
+    .then(len => {
+        // Verify template name is within details link
+      for (let i = 0; i < len; i++) {
+        cy.get(".template-card").eq(i).within(() => {
+          const templateName = cy.get(".template-thumbnail-text")
+          templateName.invoke('text')
+          .then(templateNameText => {
+            const templateNameParsed = templateNameText.toLowerCase().replace(/\s+/g, '-')
+            
+            if (templateNameText == "Hashicorp Scorecard Template") {
+                const templateNameSplit = templateNameParsed.split('-template')[0]
+                cy.get('a')
+                .should('have.attr', 'href').and('contain', templateNameSplit)
+            }
+            else if (templateNameText == "IT Ticketing System") {
+                const templateNameSplit = templateNameParsed.split('it-')[1]
+                cy.get('a')
+                .should('have.attr', 'href').and('contain', templateNameSplit)
+            }
+            else if (templateNameText == "IT Incident Report Form") {
+                const templateNameSplit = templateNameParsed.split('-form')[0]
+                cy.get('a')
+                .should('have.attr', 'href').and('contain', templateNameSplit)
+            }
+            else {
+                cy.get('a').should('have.attr', 'href').and('contain', templateNameParsed)
+            }
+          })
+          // Verify correct status from Details link - 200
+          cy.get('a')
+          .then(link => {
+            cy.request(link.prop('href'))
+            .its('status')
+            .should('eq', 200)
+          })
+        })
+      }
+    })
+  })
+})
+})

--- a/packages/builder/cypress/integration/templates/adminPanels/adminPanelsTemplateDetails.spec.js
+++ b/packages/builder/cypress/integration/templates/adminPanels/adminPanelsTemplateDetails.spec.js
@@ -1,0 +1,48 @@
+import filterTests from "../../../support/filterTests"
+
+filterTests(["all"], () => {
+  context("Verify Admin Panel Template Details", () => {
+
+    before(() => {
+      cy.login()
+
+      // Template navigation
+      cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+      .its("body")
+      .then(val => {
+        if (val.length > 0) {
+          cy.get(".spectrum-Button").contains("Templates").click({force: true})
+        }
+      })
+
+      // Filter Admin Panels Templates
+      cy.get(".template-category-filters").within(() => {
+        cy.get('[data-cy="Admin Panels"]').click()
+      })
+    })
+
+  it("should verify the details option for Admin Panels templates", () => {
+    cy.get(".template-grid").find(".template-card").its('length')
+    .then(len => {
+        // Verify template name is within details link
+      for (let i = 0; i < len; i++) {
+        cy.get(".template-card").eq(i).within(() => {
+          const templateName = cy.get(".template-thumbnail-text")
+          templateName.invoke('text')
+          .then(templateNameText => {
+            const templateNameParsed = templateNameText.toLowerCase().replace(/\s+/g, '-')
+            cy.get('a').should('have.attr', 'href').and('contain', templateNameParsed)
+          })
+          // Verify correct status from Details link - 200
+          cy.get('a')
+          .then(link => {
+            cy.request(link.prop('href'))
+            .its('status')
+            .should('eq', 200)
+          })
+        })
+      }
+    })
+  })
+})
+})

--- a/packages/builder/cypress/integration/templates/approvalApps/approvalAppsTemplateDetails.spec.js
+++ b/packages/builder/cypress/integration/templates/approvalApps/approvalAppsTemplateDetails.spec.js
@@ -1,0 +1,57 @@
+import filterTests from "../../../support/filterTests"
+
+filterTests(["all"], () => {
+  context("Verify Aproval Apps Template Details", () => {
+
+    before(() => {
+      cy.login()
+
+      // Template navigation
+      cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+      .its("body")
+      .then(val => {
+        if (val.length > 0) {
+          cy.get(".spectrum-Button").contains("Templates").click({force: true})
+        }
+      })
+
+      // Filter Approval Apps Templates
+      cy.get(".template-category-filters").within(() => {
+        cy.get('[data-cy="Approval Apps"]').click()
+      })
+    })
+
+  it("should verify the details option for Approval Apps templates", () => {
+    cy.get(".template-grid").find(".template-card").its('length')
+    .then(len => {
+        // Verify template name is within details link
+      for (let i = 0; i < len; i++) {
+        cy.get(".template-card").eq(i).within(() => {
+          const templateName = cy.get(".template-thumbnail-text")
+          templateName.invoke('text')
+          .then(templateNameText => {
+            const templateNameParsed = templateNameText.toLowerCase().replace(/\s+/g, '-')
+            
+            if (templateNameText == "Content Approval System") {
+                // Template name should include 'content-approval'
+                const templateNameSplit = templateNameParsed.split('-system')[0]
+                cy.get('a')
+                .should('have.attr', 'href').and('contain', templateNameSplit)
+            }
+            else {
+                cy.get('a').should('have.attr', 'href').and('contain', templateNameParsed)
+            }
+          })
+          // Verify correct status from Details link - 200
+          cy.get('a')
+          .then(link => {
+            cy.request(link.prop('href'))
+            .its('status')
+            .should('eq', 200)
+          })
+        })
+      }
+    })
+  })
+})
+})

--- a/packages/builder/cypress/integration/templates/businessApps/businessAppsTemplateDetails.spec.js
+++ b/packages/builder/cypress/integration/templates/businessApps/businessAppsTemplateDetails.spec.js
@@ -1,0 +1,57 @@
+import filterTests from "../../../support/filterTests"
+
+filterTests(["all"], () => {
+  context("Verify Business Apps Template Details", () => {
+
+    before(() => {
+      cy.login()
+
+      // Template navigation
+      cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+      .its("body")
+      .then(val => {
+        if (val.length > 0) {
+          cy.get(".spectrum-Button").contains("Templates").click({force: true})
+        }
+      })
+
+      // Filter Business Apps Templates
+      cy.get(".template-category-filters").within(() => {
+        cy.get('[data-cy="Business Apps"]').click()
+      })
+    })
+
+  it("should verify the details option for Business Apps templates", () => {
+    cy.get(".template-grid").find(".template-card").its('length')
+    .then(len => {
+        // Verify template name is within details link
+      for (let i = 0; i < len; i++) {
+        cy.get(".template-card").eq(i).within(() => {
+          const templateName = cy.get(".template-thumbnail-text")
+          templateName.invoke('text')
+          .then(templateNameText => {
+            const templateNameParsed = templateNameText.toLowerCase().replace(/\s+/g, '-')
+            
+            if (templateNameText == "Employee Check-in/Check-Out Template") {
+                // Remove / from template name
+                const templateNameReplace = templateNameParsed.replace(/\//g, "-")
+                cy.get('a')
+                .should('have.attr', 'href').and('contain', templateNameReplace)
+            }
+            else {
+                cy.get('a').should('have.attr', 'href').and('contain', templateNameParsed)
+            }
+          })
+          // Verify correct status from Details link - 200
+          cy.get('a')
+          .then(link => {
+            cy.request(link.prop('href'))
+            .its('status')
+            .should('eq', 200)
+          })
+        })
+      }
+    })
+  })
+})
+})

--- a/packages/builder/cypress/integration/templates/directories/directoriesTemplateDetails.spec.js
+++ b/packages/builder/cypress/integration/templates/directories/directoriesTemplateDetails.spec.js
@@ -1,0 +1,50 @@
+import filterTests from "../../../support/filterTests"
+
+filterTests(["all"], () => {
+  context("Verify Directories Template Details", () => {
+
+    before(() => {
+      cy.login()
+
+      // Template navigation
+      cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+      .its("body")
+      .then(val => {
+        if (val.length > 0) {
+          cy.get(".spectrum-Button").contains("Templates").click({force: true})
+        }
+      })
+
+      // Filter Directories Templates
+      cy.get(".template-category-filters").within(() => {
+        cy.get('[data-cy="Directories"]').click()
+      })
+    })
+
+  it("should verify the details option for Directories templates", () => {
+    cy.get(".template-grid").find(".template-card").its('length')
+    .then(len => {
+        // Verify template name is within details link
+      for (let i = 0; i < len; i++) {
+        cy.get(".template-card").eq(i).within(() => {
+          const templateName = cy.get(".template-thumbnail-text")
+          templateName.invoke('text')
+          .then(templateNameText => {
+            const templateNameParsed = templateNameText.toLowerCase().replace(/\s+/g, '-')
+            const templateNameSplit = templateNameParsed.split('-template')[0]
+            cy.get('a')
+            .should('have.attr', 'href').and('contain', templateNameSplit)
+          })
+          // Verify correct status from Details link - 200
+          cy.get('a')
+          .then(link => {
+            cy.request(link.prop('href'))
+            .its('status')
+            .should('eq', 200)
+          })
+        })
+      }
+    })
+  })
+})
+})

--- a/packages/builder/cypress/integration/templates/forms/formsTemplateDetails.spec.js
+++ b/packages/builder/cypress/integration/templates/forms/formsTemplateDetails.spec.js
@@ -1,0 +1,48 @@
+import filterTests from "../../../support/filterTests"
+
+filterTests(["all"], () => {
+  context("Verify Forms Template Details", () => {
+
+    before(() => {
+      cy.login()
+
+      // Template navigation
+      cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+      .its("body")
+      .then(val => {
+        if (val.length > 0) {
+          cy.get(".spectrum-Button").contains("Templates").click({force: true})
+        }
+      })
+
+      // Filter Forms Templates
+      cy.get(".template-category-filters").within(() => {
+        cy.get('[data-cy="Forms"]').click()
+      })
+    })
+
+  it("should verify the details option for Forms templates", () => {
+    cy.get(".template-grid").find(".template-card").its('length')
+    .then(len => {
+        // Verify template name is within details link
+      for (let i = 0; i < len; i++) {
+        cy.get(".template-card").eq(i).within(() => {
+          const templateName = cy.get(".template-thumbnail-text")
+          templateName.invoke('text')
+          .then(templateNameText => {
+            const templateNameParsed = templateNameText.toLowerCase().replace(/\s+/g, '-')
+            cy.get('a').should('have.attr', 'href').and('contain', templateNameParsed)
+          })
+          // Verify correct status from Details link - 200
+          cy.get('a')
+          .then(link => {
+            cy.request(link.prop('href'))
+            .its('status')
+            .should('eq', 200)
+          })
+        })
+      }
+    })
+  })
+})
+})

--- a/packages/builder/cypress/integration/templates/healthcare/healthcareTemplateDetails.spec.js
+++ b/packages/builder/cypress/integration/templates/healthcare/healthcareTemplateDetails.spec.js
@@ -1,0 +1,49 @@
+import filterTests from "../../../support/filterTests"
+
+filterTests(["all"], () => {
+  context("Verify Healthcare Template Details", () => {
+
+    before(() => {
+      cy.login()
+
+      // Template navigation
+      cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+      .its("body")
+      .then(val => {
+        if (val.length > 0) {
+          cy.get(".spectrum-Button").contains("Templates").click({force: true})
+        }
+      })
+
+      // Filter Healthcare Templates
+      cy.get(".template-category-filters").within(() => {
+        cy.get('[data-cy="Healthcare"]').click()
+      })
+    })
+
+  it("should verify the details option for Healthcare templates", () => {
+    cy.get(".template-grid").find(".template-card").its('length')
+    .then(len => {
+        // Verify template name is within details link
+      for (let i = 0; i < len; i++) {
+        cy.get(".template-card").eq(i).within(() => {
+          const templateName = cy.get(".template-thumbnail-text")
+          templateName.invoke('text')
+          .then(templateNameText => {
+            const templateNameParsed = templateNameText.toLowerCase().replace(/\s+/g, '-')
+            
+            cy.get('a').should('have.attr', 'href').and('contain', templateNameParsed)
+          })
+          // Verify correct status from Details link - 200
+          cy.get('a')
+          .then(link => {
+            cy.request(link.prop('href'))
+            .its('status')
+            .should('eq', 200)
+          })
+        })
+      }
+    })
+  })
+})
+})

--- a/packages/builder/cypress/integration/templates/legal/legalTemplateDetails.spec.js
+++ b/packages/builder/cypress/integration/templates/legal/legalTemplateDetails.spec.js
@@ -1,0 +1,48 @@
+import filterTests from "../../../support/filterTests"
+
+filterTests(["all"], () => {
+  context("Verify Legal Template Details", () => {
+
+    before(() => {
+      cy.login()
+
+      // Template navigation
+      cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+      .its("body")
+      .then(val => {
+        if (val.length > 0) {
+          cy.get(".spectrum-Button").contains("Templates").click({force: true})
+        }
+      })
+
+      // Filter Legal Templates
+      cy.get(".template-category-filters").within(() => {
+        cy.get('[data-cy="Legal"]').click()
+      })
+    })
+
+  it("should verify the details option for Legal templates", () => {
+    cy.get(".template-grid").find(".template-card").its('length')
+    .then(len => {
+        // Verify template name is within details link
+      for (let i = 0; i < len; i++) {
+        cy.get(".template-card").eq(i).within(() => {
+          const templateName = cy.get(".template-thumbnail-text")
+          templateName.invoke('text')
+          .then(templateNameText => {
+            const templateNameParsed = templateNameText.toLowerCase().replace(/\s+/g, '-')
+            cy.get('a').should('have.attr', 'href').and('contain', templateNameParsed)
+          })
+          // Verify correct status from Details link - 200
+          cy.get('a')
+          .then(link => {
+            cy.request(link.prop('href'))
+            .its('status')
+            .should('eq', 200)
+          })
+        })
+      }
+    })
+  })
+})
+})

--- a/packages/builder/cypress/integration/templates/logistics/logisticsTemplateDetails.spec.js
+++ b/packages/builder/cypress/integration/templates/logistics/logisticsTemplateDetails.spec.js
@@ -1,0 +1,48 @@
+import filterTests from "../../../support/filterTests"
+
+filterTests(["all"], () => {
+  context("Verify Logistics Template Details", () => {
+
+    before(() => {
+      cy.login()
+
+      // Template navigation
+      cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+      .its("body")
+      .then(val => {
+        if (val.length > 0) {
+          cy.get(".spectrum-Button").contains("Templates").click({force: true})
+        }
+      })
+
+      // Filter Logistics Templates
+      cy.get(".template-category-filters").within(() => {
+        cy.get('[data-cy="Logistics"]').click()
+      })
+    })
+
+  it("should verify the details option for Logistics templates", () => {
+    cy.get(".template-grid").find(".template-card").its('length')
+    .then(len => {
+        // Verify template name is within details link
+      for (let i = 0; i < len; i++) {
+        cy.get(".template-card").eq(i).within(() => {
+          const templateName = cy.get(".template-thumbnail-text")
+          templateName.invoke('text')
+          .then(templateNameText => {
+            const templateNameParsed = templateNameText.toLowerCase().replace(/\s+/g, '-')
+            cy.get('a').should('have.attr', 'href').and('contain', templateNameParsed)
+          })
+          // Verify correct status from Details link - 200
+          cy.get('a')
+          .then(link => {
+            cy.request(link.prop('href'))
+            .its('status')
+            .should('eq', 200)
+          })
+        })
+      }
+    })
+  })
+})
+})

--- a/packages/builder/cypress/integration/templates/manufacturing/manufacturingTemplateDetails.spec.js
+++ b/packages/builder/cypress/integration/templates/manufacturing/manufacturingTemplateDetails.spec.js
@@ -1,0 +1,48 @@
+import filterTests from "../../../support/filterTests"
+
+filterTests(["all"], () => {
+  context("Verify Manufacturing Template Details", () => {
+
+    before(() => {
+      cy.login()
+
+      // Template navigation
+      cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+      .its("body")
+      .then(val => {
+        if (val.length > 0) {
+          cy.get(".spectrum-Button").contains("Templates").click({force: true})
+        }
+      })
+
+      // Filter Manufacturing Templates
+      cy.get(".template-category-filters").within(() => {
+        cy.get('[data-cy="Manufacturing"]').click()
+      })
+    })
+
+  it("should verify the details option for Manufacturing templates", () => {
+    cy.get(".template-grid").find(".template-card").its('length')
+    .then(len => {
+        // Verify template name is within details link
+      for (let i = 0; i < len; i++) {
+        cy.get(".template-card").eq(i).within(() => {
+          const templateName = cy.get(".template-thumbnail-text")
+          templateName.invoke('text')
+          .then(templateNameText => {
+            const templateNameParsed = templateNameText.toLowerCase().replace(/\s+/g, '-')
+            cy.get('a').should('have.attr', 'href').and('contain', templateNameParsed)
+          })
+          // Verify correct status from Details link - 200
+          cy.get('a')
+          .then(link => {
+            cy.request(link.prop('href'))
+            .its('status')
+            .should('eq', 200)
+          })
+        })
+      }
+    })
+  })
+})
+})

--- a/packages/builder/cypress/integration/templates/marketing/marketingTemplateDetails.spec.js
+++ b/packages/builder/cypress/integration/templates/marketing/marketingTemplateDetails.spec.js
@@ -1,0 +1,57 @@
+import filterTests from "../../../support/filterTests"
+
+filterTests(["all"], () => {
+  context("Verify Marketing Template Details", () => {
+
+    before(() => {
+      cy.login()
+
+      // Template navigation
+      cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+      .its("body")
+      .then(val => {
+        if (val.length > 0) {
+          cy.get(".spectrum-Button").contains("Templates").click({force: true})
+        }
+      })
+
+      // Filter Marketing Templates
+      cy.get(".template-category-filters").within(() => {
+        cy.get('[data-cy="Marketing"]').click()
+      })
+    })
+
+  it("should verify the details option for Marketing templates", () => {
+    cy.get(".template-grid").find(".template-card").its('length')
+    .then(len => {
+        // Verify template name is within details link
+      for (let i = 0; i < len; i++) {
+        cy.get(".template-card").eq(i).within(() => {
+          const templateName = cy.get(".template-thumbnail-text")
+          templateName.invoke('text')
+          .then(templateNameText => {
+            const templateNameParsed = templateNameText.toLowerCase().replace(/\s+/g, '-')
+            
+            if (templateNameText == "Lead Generation Form") {
+                // Multi-step lead form
+                // Template name includes 'multi-step-lead-form'
+                cy.get('a')
+                .should('have.attr', 'href').and('contain', 'multi-step-lead-form')
+            }
+            else {
+                cy.get('a').should('have.attr', 'href').and('contain', templateNameParsed)
+            }
+          })
+          // Verify correct status from Details link - 200
+          cy.get('a')
+          .then(link => {
+            cy.request(link.prop('href'))
+            .its('status')
+            .should('eq', 200)
+          })
+        })
+      }
+    })
+  })
+})
+})

--- a/packages/builder/cypress/integration/templates/operations/operationsTemplateDetails.spec.js
+++ b/packages/builder/cypress/integration/templates/operations/operationsTemplateDetails.spec.js
@@ -1,0 +1,48 @@
+import filterTests from "../../../support/filterTests"
+
+filterTests(["all"], () => {
+  context("Verify Operations Template Details", () => {
+
+    before(() => {
+      cy.login()
+
+      // Template navigation
+      cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+      .its("body")
+      .then(val => {
+        if (val.length > 0) {
+          cy.get(".spectrum-Button").contains("Templates").click({force: true})
+        }
+      })
+
+      // Filter Operations Templates
+      cy.get(".template-category-filters").within(() => {
+        cy.get('[data-cy="Operations"]').click()
+      })
+    })
+
+  it("should verify the details option for Operations templates", () => {
+    cy.get(".template-grid").find(".template-card").its('length')
+    .then(len => {
+        // Verify template name is within details link
+      for (let i = 0; i < len; i++) {
+        cy.get(".template-card").eq(i).within(() => {
+          const templateName = cy.get(".template-thumbnail-text")
+          templateName.invoke('text')
+          .then(templateNameText => {
+            const templateNameParsed = templateNameText.toLowerCase().replace(/\s+/g, '-')
+            cy.get('a').should('have.attr', 'href').and('contain', templateNameParsed)
+          })
+          // Verify correct status from Details link - 200
+          cy.get('a')
+          .then(link => {
+            cy.request(link.prop('href'))
+            .its('status')
+            .should('eq', 200)
+          })
+        })
+      }
+    })
+  })
+})
+})

--- a/packages/builder/cypress/integration/templates/portals/portalsTemplateDetails.spec.js
+++ b/packages/builder/cypress/integration/templates/portals/portalsTemplateDetails.spec.js
@@ -1,0 +1,77 @@
+import filterTests from "../../../support/filterTests"
+
+filterTests(["all"], () => {
+  context("Verify Portals Template Details", () => {
+
+    before(() => {
+      cy.login()
+
+      // Template navigation
+      cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+      .its("body")
+      .then(val => {
+        if (val.length > 0) {
+          cy.get(".spectrum-Button").contains("Templates").click({force: true})
+        }
+      })
+    })
+
+  it("should verify the details option for Portal templates", () => {
+    // Filter Portal Templates
+    cy.get(".template-category-filters").within(() => {
+        cy.get('[data-cy="Portal"]').click()
+      })
+    
+    cy.get(".template-grid").find(".template-card").its('length')
+    .then(len => {
+      for (let i = 0; i < len; i++) {
+        cy.get(".template-card").eq(i).within(() => {
+          const templateName = cy.get(".template-thumbnail-text")
+          templateName.invoke('text')
+          .then(templateNameText => {
+            const templateNameParsed = templateNameText.toLowerCase().replace(/\s+/g, '-')
+            cy.get('a')
+            .should('have.attr', 'href').and('contain', templateNameParsed)
+          })
+          // Verify correct status from Details link - 200
+          cy.get('a')
+          .then(link => {
+            cy.request(link.prop('href'))
+            .its('status')
+            .should('eq', 200)
+          })
+        })
+      }
+    })
+  })
+
+  it("should verify the details option for Portals templates", () => {
+    // Filter Portals Templates
+    cy.get(".template-category-filters").within(() => {
+        cy.get('[data-cy="Portals"]').click()
+      })
+    
+    cy.get(".template-grid").find(".template-card").its('length')
+    .then(len => {
+      for (let i = 0; i < len; i++) {
+        cy.get(".template-card").eq(i).within(() => {
+          const templateName = cy.get(".template-thumbnail-text")
+          templateName.invoke('text')
+          .then(templateNameText => {
+            const templateNameParsed = templateNameText.toLowerCase().replace(/\s+/g, '-')
+            cy.get('a')
+            .should('have.attr', 'href').and('contain', templateNameParsed)
+          })
+          // Verify correct status from Details link - 200
+          cy.get('a')
+          .then(link => {
+            cy.request(link.prop('href'))
+            .its('status')
+            .should('eq', 200)
+          })
+        })
+      }
+    })
+  })
+})
+})

--- a/packages/builder/cypress/integration/templates/professionalServices/professionalServicesTemplateDetails.spec.js
+++ b/packages/builder/cypress/integration/templates/professionalServices/professionalServicesTemplateDetails.spec.js
@@ -1,0 +1,48 @@
+import filterTests from "../../../support/filterTests"
+
+filterTests(["all"], () => {
+  context("Verify Professional Services Template Details", () => {
+
+    before(() => {
+      cy.login()
+
+      // Template navigation
+      cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+      .its("body")
+      .then(val => {
+        if (val.length > 0) {
+          cy.get(".spectrum-Button").contains("Templates").click({force: true})
+        }
+      })
+
+      // Filter Professional Services Templates
+      cy.get(".template-category-filters").within(() => {
+        cy.get('[data-cy="Professional Services"]').click()
+      })
+    })
+
+  it("should verify the details option for Professional Services templates", () => {
+    cy.get(".template-grid").find(".template-card").its('length')
+    .then(len => {
+        // Verify template name is within details link
+      for (let i = 0; i < len; i++) {
+        cy.get(".template-card").eq(i).within(() => {
+          const templateName = cy.get(".template-thumbnail-text")
+          templateName.invoke('text')
+          .then(templateNameText => {
+            const templateNameParsed = templateNameText.toLowerCase().replace(/\s+/g, '-')
+            cy.get('a').should('have.attr', 'href').and('contain', templateNameParsed)
+          })
+          // Verify correct status from Details link - 200
+          cy.get('a')
+          .then(link => {
+            cy.request(link.prop('href'))
+            .its('status')
+            .should('eq', 200)
+          })
+        })
+      }
+    })
+  })
+})
+})

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -77,27 +77,23 @@ Cypress.Commands.add("deleteApp", name => {
         if (val.length > 0) {
           if (Cypress.env("TEST_ENV")) {
             cy.searchForApplication(name)
-            cy.get(".appTable").within(() => {
-              cy.get(".spectrum-Icon").eq(1).click()
-            })
-          } else {
-            const appId = val.reduce((acc, app) => {
-              if (name === app.name) {
-                acc = app.appId
-              }
-              return acc
-            }, "")
-
-            if (appId == "") {
-              return
-            }
-
-            const appIdParsed = appId.split("_").pop()
-            const actionEleId = `[data-cy=row_actions_${appIdParsed}]`
-            cy.get(actionEleId).within(() => {
-              cy.get(".spectrum-Icon").eq(0).click()
-            })
           }
+          const appId = val.reduce((acc, app) => {
+            if (name === app.name) {
+              acc = app.appId
+            }
+            return acc
+          }, "")
+
+          if (appId == "") {
+            return
+          }
+
+          const appIdParsed = appId.split("_").pop()
+          const actionEleId = `[data-cy=row_actions_${appIdParsed}]`
+          cy.get(actionEleId).within(() => {
+            cy.get(".spectrum-Icon").eq(0).click()
+          })
 
           cy.get(".spectrum-Menu").then($menu => {
             if ($menu.text().includes("Unpublish")) {


### PR DESCRIPTION
Added tests which check the details button for each template.
- Split per category (Will add more specific template tests under each category)
- Checks template name matches url (There are a few exceptions)
- Checks status of url - expects 200 back each time

Also updated the DeleteApp Function
- Fixed a smoke test issue associated with deleting the tests app




