### PR TITLE
Update CouchDB in kubernetes to be 3.2.1

### DIFF
--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -215,7 +215,7 @@ couchdb:
   ## The CouchDB image
   image:
     repository: couchdb
-    tag: 3.1.0
+    tag: 3.2.1
     pullPolicy: IfNotPresent
 
   ## Experimental integration with Lucene-powered fulltext search


### PR DESCRIPTION
## Description
- Was experiencing an issues with views in the default version 3.1.0. 
- Bump couch in k8s to match our production cloud version


