### PR TITLE
Automation binding drawer for test data was not showing correctly

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -265,6 +265,7 @@
           value={inputData[key]}
           on:change={e => onChange(e, key)}
           {bindings}
+          {isTestModal}
         />
       {:else if value.customType === "webhookUrl"}
         <WebhookDisplay

--- a/packages/builder/src/components/automation/SetupPanel/RowSelector.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/RowSelector.svelte
@@ -4,14 +4,15 @@
   import DrawerBindableInput from "../../common/bindings/DrawerBindableInput.svelte"
   import AutomationBindingPanel from "../../common/bindings/ServerBindingPanel.svelte"
   import { createEventDispatcher } from "svelte"
-  import { automationStore } from "builderStore"
   import RowSelectorTypes from "./RowSelectorTypes.svelte"
+  import ModalBindableInput from "../../common/bindings/ModalBindableInput.svelte"
 
   const dispatch = createEventDispatcher()
 
   export let value
   export let bindings
   export let block
+  export let isTestModal
 
   let table
   let schemaFields
@@ -103,35 +104,18 @@
     {#each schemaFields as [field, schema]}
       {#if !schema.autocolumn}
         {#if schema.type !== "attachment"}
-          {#if $automationStore.selectedAutomation.automation.testData}
-            {#if !rowControl}
-              <RowSelectorTypes
-                {field}
-                {schema}
-                {bindings}
-                {value}
-                {onChange}
-              />
-            {:else}
-              <DrawerBindableInput
-                placeholder={placeholders[schema.type]}
-                panel={AutomationBindingPanel}
-                value={Array.isArray(value[field])
-                  ? value[field].join(" ")
-                  : value[field]}
-                on:change={e => onChange(e, field, schema.type)}
-                label={field}
-                type="string"
-                {bindings}
-                fillWidth={true}
-                allowJS={true}
-                updateOnChange={false}
-              />
-            {/if}
-          {:else if !rowControl}
-            <RowSelectorTypes {field} {schema} {bindings} {value} {onChange} />
+          {#if !rowControl}
+            <RowSelectorTypes
+              {isTestModal}
+              {field}
+              {schema}
+              {bindings}
+              {value}
+              {onChange}
+            />
           {:else}
-            <DrawerBindableInput
+            <svelte:component
+              this={isTestModal ? ModalBindableInput : DrawerBindableInput}
               placeholder={placeholders[schema.type]}
               panel={AutomationBindingPanel}
               value={Array.isArray(value[field])

--- a/packages/builder/src/components/automation/SetupPanel/RowSelectorTypes.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/RowSelectorTypes.svelte
@@ -8,6 +8,7 @@
   } from "@budibase/bbui"
   import LinkedRowSelector from "components/common/LinkedRowSelector.svelte"
   import DrawerBindableInput from "../../common/bindings/DrawerBindableInput.svelte"
+  import ModalBindableInput from "../../common/bindings/ModalBindableInput.svelte"
   import AutomationBindingPanel from "../../common/bindings/ServerBindingPanel.svelte"
 
   export let onChange
@@ -15,6 +16,7 @@
   export let schema
   export let value
   export let bindings
+  export let isTestModal
 
   function schemaHasOptions(schema) {
     return !!schema.constraints?.inclusion?.length
@@ -51,7 +53,8 @@
 {:else if schema.type === "link"}
   <LinkedRowSelector bind:linkedRows={value[field]} {schema} />
 {:else if schema.type === "string" || schema.type === "number"}
-  <DrawerBindableInput
+  <svelte:component
+    this={isTestModal ? ModalBindableInput : DrawerBindableInput}
     panel={AutomationBindingPanel}
     value={value[field]}
     on:change={e => onChange(e, field)}


### PR DESCRIPTION
As described in: #5649 the binding panel for test data was not showing correctly, and was using the `DrawerBindableInput` instead of `ModalBindableInput` which meant the user wasn't able to use handlebars within the test modal. 

Also refactored a dodgy if statement in the same area to use `svelte:component` instead. 



