### PR TITLE
record cypress runs in smoke test

### DIFF
--- a/.github/workflows/smoke_test.yaml
+++ b/.github/workflows/smoke_test.yaml
@@ -33,6 +33,8 @@ jobs:
         with:
           install: false
           command: yarn test:e2e:ci
+        env:
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
       
       # TODO: upload recordings to s3
       # - name: Configure AWS Credentials

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -13,7 +13,7 @@
     "cy:setup:ci": "node ./cypress/setup.js",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "cy:run:ci": "xvfb-run cypress run --headed --browser chrome",
+    "cy:run:ci": "xvfb-run cypress run --headed --browser chrome --record",
     "cy:test": "start-server-and-test cy:setup http://localhost:4100/builder cy:run",
     "cy:ci": "start-server-and-test cy:setup:ci http://localhost:4100/builder cy:run:ci",
     "cy:debug": "start-server-and-test cy:setup http://localhost:4100/builder cy:open",


### PR DESCRIPTION
## Description
Record the manual smoke tests and send them to cypress for viewing.

I've added the `CYPRESS_RECORD_KEY` to our secrets.

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



