### PR TITLE
Refetch the admin checklist on SMTP config save

### DIFF
--- a/packages/builder/src/pages/builder/portal/manage/email/index.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/email/index.svelte
@@ -13,7 +13,7 @@
     Table,
     Checkbox,
   } from "@budibase/bbui"
-  import { email } from "stores/portal"
+  import { email, admin } from "stores/portal"
   import { API } from "api"
   import { cloneDeep } from "lodash/fp"
   import analytics, { Events } from "analytics"
@@ -58,6 +58,7 @@
       const savedConfig = await API.saveConfig(smtp)
       smtpConfig._rev = savedConfig._rev
       smtpConfig._id = savedConfig._id
+      await admin.getChecklist()
       notifications.success(`Settings saved`)
       analytics.captureEvent(Events.SMTP.SAVED)
     } catch (error) {

--- a/packages/builder/src/stores/portal/admin.js
+++ b/packages/builder/src/stores/portal/admin.js
@@ -24,14 +24,8 @@ export function createAdminStore() {
   const admin = writable(DEFAULT_CONFIG)
 
   async function init() {
-    const tenantId = get(auth).tenantId
-    const checklist = await API.getChecklist(tenantId)
-    const totalSteps = Object.keys(checklist).length
-    const completedSteps = Object.values(checklist).filter(
-      x => x?.checked
-    ).length
+    await getChecklist()
     await getEnvironment()
-
     // enable system status checks in the cloud
     if (get(admin).cloud) {
       await getSystemStatus()
@@ -40,8 +34,6 @@ export function createAdminStore() {
 
     admin.update(store => {
       store.loaded = true
-      store.checklist = checklist
-      store.onboardingProgress = (completedSteps / totalSteps) * 100
       return store
     })
   }
@@ -81,6 +73,20 @@ export function createAdminStore() {
     })
   }
 
+  async function getChecklist() {
+    const tenantId = get(auth).tenantId
+    const checklist = await API.getChecklist(tenantId)
+    const totalSteps = Object.keys(checklist).length
+    const completedSteps = Object.values(checklist).filter(
+      x => x?.checked
+    ).length
+    admin.update(store => {
+      store.checklist = checklist
+      store.onboardingProgress = (completedSteps / totalSteps) * 100
+      return store
+    })
+  }
+
   function unload() {
     admin.update(store => {
       store.loaded = false
@@ -93,6 +99,7 @@ export function createAdminStore() {
     init,
     checkImportComplete,
     unload,
+    getChecklist,
   }
 }
 


### PR DESCRIPTION
## Description
The SMTP automation step was not being enabled after configuration was entered: https://github.com/Budibase/budibase/issues/5416

The code now updates the admin store with the refetched checklist upon successful save of the SMTP config.  



