### PR TITLE
Pass through type when creating internal table

### DIFF
--- a/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
@@ -45,6 +45,8 @@
       name,
       schema: addAutoColumns(name, dataImport.schema || {}),
       dataImport,
+      type: "internal",
+      sourceId: "bb_internal",
     }
 
     // Only set primary display if defined


### PR DESCRIPTION
## Description
On initial create, Internal DB did not show relationship options: https://github.com/Budibase/budibase/issues/5444

Now passing through a default type and sourceId for the *CreateTableModal* because as far as I can see, this modal is only ever used for internal tables. 



