### PR TITLE
April release fixes - MySQL dates and various form/automation fixes

### DIFF
--- a/packages/bbui/src/Table/DateTimeRenderer.svelte
+++ b/packages/bbui/src/Table/DateTimeRenderer.svelte
@@ -2,17 +2,22 @@
   import dayjs from "dayjs"
 
   export let value
+  export let schema
 
   // adding the 0- will turn a string like 00:00:00 into a valid ISO
   // date, but will make actual ISO dates invalid
   $: time = new Date(`0-${value}`)
-  $: isTime = !isNaN(time)
+  $: isTimeOnly = !isNaN(time) || schema?.timeOnly
+  $: isDateOnly = schema?.dateOnly
+  $: format = isTimeOnly
+    ? "HH:mm:ss"
+    : isDateOnly
+    ? "MMMM D YYYY"
+    : "MMMM D YYYY, HH:mm"
 </script>
 
 <div>
-  {dayjs(isTime ? time : value).format(
-    isTime ? "HH:mm:ss" : "MMMM D YYYY, HH:mm"
-  )}
+  {dayjs(isTimeOnly ? time : value).format(format)}
 </div>
 
 <style>

--- a/packages/builder/src/components/backend/DataTable/RowFieldControl.svelte
+++ b/packages/builder/src/components/backend/DataTable/RowFieldControl.svelte
@@ -37,7 +37,7 @@
   $: label = meta.name ? capitalise(meta.name) : ""
 
   const timeStamp = resolveTimeStamp(value)
-  const isTimeStamp = !!timeStamp
+  const isTimeStamp = !!timeStamp || meta?.timeOnly
 </script>
 
 {#if type === "options" && meta.constraints.inclusion.length !== 0}
@@ -49,7 +49,12 @@
     sort
   />
 {:else if type === "datetime"}
-  <DatePicker {label} timeOnly={isTimeStamp} bind:value />
+  <DatePicker
+    {label}
+    timeOnly={isTimeStamp}
+    enableTime={!meta?.dateOnly}
+    bind:value
+  />
 {:else if type === "attachment"}
   <Dropzone {label} bind:value />
 {:else if type === "boolean"}

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/FilterEditor/FilterDrawer.svelte
@@ -49,6 +49,10 @@
     filters = [...filters, duplicate]
   }
 
+  const getSchema = filter => {
+    return schemaFields.find(field => field.name === filter.field)
+  }
+
   const onFieldChange = (expression, field) => {
     // Update the field type
     expression.type = enrichedSchemaFields.find(x => x.name === field)?.type
@@ -150,7 +154,12 @@
                 bind:value={filter.value}
               />
             {:else if filter.type === "datetime"}
-              <DatePicker disabled={filter.noValue} bind:value={filter.value} />
+              <DatePicker
+                disabled={filter.noValue}
+                enableTime={!getSchema(filter).dateOnly}
+                timeOnly={getSchema(filter).timeOnly}
+                bind:value={filter.value}
+              />
             {:else}
               <DrawerBindableInput disabled />
             {/if}

--- a/packages/client/src/components/app/dynamic-filter/FilterModal.svelte
+++ b/packages/client/src/components/app/dynamic-filter/FilterModal.svelte
@@ -88,6 +88,10 @@
     const schema = schemaFields.find(x => x.name === field)
     return schema?.constraints?.inclusion || []
   }
+
+  const getSchema = filter => {
+    return schemaFields.find(field => field.name === filter.field)
+  }
 </script>
 
 <div class="container" class:mobile={$context.device.mobile}>
@@ -134,7 +138,12 @@
               bind:value={filter.value}
             />
           {:else if filter.type === "datetime"}
-            <DatePicker disabled={filter.noValue} bind:value={filter.value} />
+            <DatePicker
+              disabled={filter.noValue}
+              enableTime={!getSchema(filter).dateOnly}
+              timeOnly={getSchema(filter).timeOnly}
+              bind:value={filter.value}
+            />
           {:else}
             <Input disabled />
           {/if}

--- a/packages/client/src/components/app/forms/FormStep.svelte
+++ b/packages/client/src/components/app/forms/FormStep.svelte
@@ -22,7 +22,7 @@
     if (
       formContext &&
       $builderStore.inBuilder &&
-      $componentStore.selectedComponentPath?.includes($component.id)
+      $componentStore?.selectedComponentPath?.includes($component.id)
     ) {
       formContext.formApi.setStep(step)
     }

--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -242,12 +242,10 @@ module MSSQLModule {
           if (typeof name !== "string") {
             continue
           }
-          const type: string = convertSqlType(def.DATA_TYPE)
-
           schema[name] = {
             autocolumn: !!autoColumns.find((col: string) => col === name),
             name: name,
-            type,
+            ...convertSqlType(def.DATA_TYPE),
           }
         }
         tables[tableName] = {

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -15,6 +15,7 @@ import {
 } from "./utils"
 import { DatasourcePlus } from "./base/datasourcePlus"
 import dayjs from "dayjs"
+import { FieldTypes } from "../constants"
 const { NUMBER_REGEX } = require("../utilities")
 
 module MySQLModule {
@@ -215,8 +216,8 @@ module MySQLModule {
             schema[columnName] = {
               name: columnName,
               autocolumn: isAuto,
-              type: convertSqlType(column.Type),
               constraints,
+              ...convertSqlType(column.Type),
             }
           }
           if (!tables[tableName]) {

--- a/packages/server/src/integrations/oracle.ts
+++ b/packages/server/src/integrations/oracle.ts
@@ -279,9 +279,9 @@ module OracleModule {
       )
     }
 
-    private internalConvertType(column: OracleColumn): string {
+    private internalConvertType(column: OracleColumn): { type: string } {
       if (this.isBooleanType(column)) {
-        return FieldTypes.BOOLEAN
+        return { type: FieldTypes.BOOLEAN }
       }
 
       return convertSqlType(column.type)
@@ -328,7 +328,7 @@ module OracleModule {
               fieldSchema = {
                 autocolumn: OracleIntegration.isAutoColumn(oracleColumn),
                 name: columnName,
-                type: this.internalConvertType(oracleColumn),
+                ...this.internalConvertType(oracleColumn),
               }
               table.schema[columnName] = fieldSchema
             }

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -227,7 +227,6 @@ module PostgresModule {
           }
         }
 
-        const type: string = convertSqlType(column.data_type)
         const identity = !!(
           column.identity_generation ||
           column.identity_start ||
@@ -242,7 +241,7 @@ module PostgresModule {
         tables[tableName].schema[columnName] = {
           autocolumn: isAuto,
           name: columnName,
-          type,
+          ...convertSqlType(column.data_type),
         }
       }
 

--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -85,9 +85,9 @@ export function breakExternalTableId(tableId: string | undefined) {
     return {}
   }
   const parts = tableId.split(DOUBLE_SEPARATOR)
-  let tableName = parts.pop()
+  let datasourceId = parts.shift()
   // if they need joined
-  let datasourceId = parts.join(DOUBLE_SEPARATOR)
+  let tableName = parts.join(DOUBLE_SEPARATOR)
   return { datasourceId, tableName }
 }
 

--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -35,6 +35,9 @@ const SQL_DATE_TYPE_MAP = {
   date: FieldTypes.DATETIME,
 }
 
+const SQL_DATE_ONLY_TYPES = ["date"]
+const SQL_TIME_ONLY_TYPES = ["time"]
+
 const SQL_STRING_TYPE_MAP = {
   varchar: FieldTypes.STRING,
   char: FieldTypes.STRING,
@@ -137,12 +140,20 @@ export function breakRowIdField(_id: string | { _id: string }): any[] {
 }
 
 export function convertSqlType(type: string) {
+  let foundType = FieldTypes.STRING
+  const lcType = type.toLowerCase()
   for (let [external, internal] of Object.entries(SQL_TYPE_MAP)) {
-    if (type.toLowerCase().includes(external)) {
-      return internal
+    if (lcType.includes(external)) {
+      foundType = internal
+      break
     }
   }
-  return FieldTypes.STRING
+  const schema: any = { type: foundType }
+  if (foundType === FieldTypes.DATETIME) {
+    schema.dateOnly = SQL_DATE_ONLY_TYPES.includes(lcType)
+    schema.timeOnly = SQL_TIME_ONLY_TYPES.includes(lcType)
+  }
+  return schema
 }
 
 export function getSqlQuery(query: SqlQuery | string): SqlQuery {

--- a/packages/server/src/threads/automation.js
+++ b/packages/server/src/threads/automation.js
@@ -100,10 +100,10 @@ class Orchestrator {
     let automation = this._automation
     const app = await this.getApp()
     let stopped = false
-    let loopStep
+    let loopStep = null
 
     let stepCount = 0
-    let loopStepNumber
+    let loopStepNumber = null
     let loopSteps = []
     for (let step of automation.definition.steps) {
       stepCount++

--- a/packages/server/src/threads/automation.js
+++ b/packages/server/src/threads/automation.js
@@ -286,18 +286,16 @@ class Orchestrator {
 
 module.exports = (input, callback) => {
   const appId = input.data.event.appId
-  doInAppContext(appId, () => {
+  doInAppContext(appId, async () => {
     const automationOrchestrator = new Orchestrator(
       input.data.automation,
       input.data.event
     )
-    automationOrchestrator
-      .execute()
-      .then(response => {
-        callback(null, response)
-      })
-      .catch(err => {
-        callback(err)
-      })
+    try {
+      const response = await automationOrchestrator.execute()
+      callback(null, response)
+    } catch (err) {
+      callback(err)
+    }
   })
 }

--- a/packages/server/src/threads/query.js
+++ b/packages/server/src/threads/query.js
@@ -191,14 +191,13 @@ class QueryRunner {
 }
 
 module.exports = (input, callback) => {
-  doInAppContext(input.appId, () => {
+  doInAppContext(input.appId, async () => {
     const Runner = new QueryRunner(input)
-    Runner.execute()
-      .then(response => {
-        callback(null, response)
-      })
-      .catch(err => {
-        callback(err)
-      })
+    try {
+      const response = await Runner.execute()
+      callback(null, response)
+    } catch (err) {
+      callback(err)
+    }
   })
 }

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -1014,10 +1014,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.131":
-  version "1.0.131"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.131.tgz#4b284405e19a345de1af723d0c1e3fa315463140"
-  integrity sha512-1r6JjIcSBHogGm2YLB7k712+3LLE1+42C3eITa6n8r/QQIkyK7DJwm0I403IRKeh/93gwgQtBiRpJfhy2p7Pew==
+"@budibase/backend-core@1.0.135":
+  version "1.0.135"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.135.tgz#b8cf217243b285c6e74435acba7c8960a1651c23"
+  integrity sha512-7gnTW6w8upJSPNqdyt5gpkubf0glDyTiSszLVVRZdxJypYAnBjcVrSFvlNPDzI4X2glnNnGcXBxFdDg6Z9ZS5w==
   dependencies:
     "@techpass/passport-openidconnect" "^0.3.0"
     aws-sdk "^2.901.0"
@@ -1091,12 +1091,12 @@
     svelte-flatpickr "^3.2.3"
     svelte-portal "^1.0.0"
 
-"@budibase/pro@1.0.131":
-  version "1.0.131"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.131.tgz#65907e7ca528d237bf12dbe5c159156d03e8d5c3"
-  integrity sha512-pmK18/1TPDY+3IHUzGh0fG5CEy7+kSPpcl72smri8jvo5OsD4lWQVOTHSdqRn8aIf/qEHHWc2sspEEDGhYMv0Q==
+"@budibase/pro@1.0.135":
+  version "1.0.135"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.135.tgz#fa4f3b2a8e14905c97305a79e4b91d1094dba1a0"
+  integrity sha512-XfZTfrplyY03zuTE3dPzdJvVD3qO5ShbRUYNX/05VBubwhS7S0mczwfCTJPi8agfx3LGN4yQd7GhFbaN2zrOPg==
   dependencies:
-    "@budibase/backend-core" "1.0.131"
+    "@budibase/backend-core" "1.0.135"
     node-fetch "^2.6.1"
 
 "@budibase/standard-components@^0.9.139":

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -1014,10 +1014,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.127":
-  version "1.0.127"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.127.tgz#5d1f4b18b31436ddb770dc1ddf16f201ec95dda7"
-  integrity sha512-3INFkAIxL0Q8Sa65ELRGQqPs+4baykKyb1z/XuO1MyuDPnbFKXGOjl1V61EMy622gsmLk90IJL6aQfh3Grwhvw==
+"@budibase/backend-core@1.0.131":
+  version "1.0.131"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.131.tgz#4b284405e19a345de1af723d0c1e3fa315463140"
+  integrity sha512-1r6JjIcSBHogGm2YLB7k712+3LLE1+42C3eITa6n8r/QQIkyK7DJwm0I403IRKeh/93gwgQtBiRpJfhy2p7Pew==
   dependencies:
     "@techpass/passport-openidconnect" "^0.3.0"
     aws-sdk "^2.901.0"
@@ -1091,12 +1091,12 @@
     svelte-flatpickr "^3.2.3"
     svelte-portal "^1.0.0"
 
-"@budibase/pro@1.0.127":
-  version "1.0.127"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.127.tgz#a8bcffb8ccc6afde64370b3a3dc22e2d0dd04f46"
-  integrity sha512-dj0SFTmO8JuMQ97/Ik6jVPQsh9AW7U5Wkgpa4yeNfwWw3DvSoktCxpeZ9mND6BR/DWTaeZljFKsQ6uk6nimzdQ==
+"@budibase/pro@1.0.131":
+  version "1.0.131"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.131.tgz#65907e7ca528d237bf12dbe5c159156d03e8d5c3"
+  integrity sha512-pmK18/1TPDY+3IHUzGh0fG5CEy7+kSPpcl72smri8jvo5OsD4lWQVOTHSdqRn8aIf/qEHHWc2sspEEDGhYMv0Q==
   dependencies:
-    "@budibase/backend-core" "1.0.127"
+    "@budibase/backend-core" "1.0.131"
     node-fetch "^2.6.1"
 
 "@budibase/standard-components@^0.9.139":

--- a/packages/worker/yarn.lock
+++ b/packages/worker/yarn.lock
@@ -293,10 +293,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.131":
-  version "1.0.131"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.131.tgz#4b284405e19a345de1af723d0c1e3fa315463140"
-  integrity sha512-1r6JjIcSBHogGm2YLB7k712+3LLE1+42C3eITa6n8r/QQIkyK7DJwm0I403IRKeh/93gwgQtBiRpJfhy2p7Pew==
+"@budibase/backend-core@1.0.135":
+  version "1.0.135"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.135.tgz#b8cf217243b285c6e74435acba7c8960a1651c23"
+  integrity sha512-7gnTW6w8upJSPNqdyt5gpkubf0glDyTiSszLVVRZdxJypYAnBjcVrSFvlNPDzI4X2glnNnGcXBxFdDg6Z9ZS5w==
   dependencies:
     "@techpass/passport-openidconnect" "^0.3.0"
     aws-sdk "^2.901.0"
@@ -321,12 +321,12 @@
     uuid "^8.3.2"
     zlib "^1.0.5"
 
-"@budibase/pro@1.0.131":
-  version "1.0.131"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.131.tgz#65907e7ca528d237bf12dbe5c159156d03e8d5c3"
-  integrity sha512-pmK18/1TPDY+3IHUzGh0fG5CEy7+kSPpcl72smri8jvo5OsD4lWQVOTHSdqRn8aIf/qEHHWc2sspEEDGhYMv0Q==
+"@budibase/pro@1.0.135":
+  version "1.0.135"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.135.tgz#fa4f3b2a8e14905c97305a79e4b91d1094dba1a0"
+  integrity sha512-XfZTfrplyY03zuTE3dPzdJvVD3qO5ShbRUYNX/05VBubwhS7S0mczwfCTJPi8agfx3LGN4yQd7GhFbaN2zrOPg==
   dependencies:
-    "@budibase/backend-core" "1.0.131"
+    "@budibase/backend-core" "1.0.135"
     node-fetch "^2.6.1"
 
 "@cspotcode/source-map-consumer@0.8.0":

--- a/packages/worker/yarn.lock
+++ b/packages/worker/yarn.lock
@@ -293,10 +293,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.127":
-  version "1.0.127"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.127.tgz#5d1f4b18b31436ddb770dc1ddf16f201ec95dda7"
-  integrity sha512-3INFkAIxL0Q8Sa65ELRGQqPs+4baykKyb1z/XuO1MyuDPnbFKXGOjl1V61EMy622gsmLk90IJL6aQfh3Grwhvw==
+"@budibase/backend-core@1.0.131":
+  version "1.0.131"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.131.tgz#4b284405e19a345de1af723d0c1e3fa315463140"
+  integrity sha512-1r6JjIcSBHogGm2YLB7k712+3LLE1+42C3eITa6n8r/QQIkyK7DJwm0I403IRKeh/93gwgQtBiRpJfhy2p7Pew==
   dependencies:
     "@techpass/passport-openidconnect" "^0.3.0"
     aws-sdk "^2.901.0"
@@ -321,12 +321,12 @@
     uuid "^8.3.2"
     zlib "^1.0.5"
 
-"@budibase/pro@1.0.127":
-  version "1.0.127"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.127.tgz#a8bcffb8ccc6afde64370b3a3dc22e2d0dd04f46"
-  integrity sha512-dj0SFTmO8JuMQ97/Ik6jVPQsh9AW7U5Wkgpa4yeNfwWw3DvSoktCxpeZ9mND6BR/DWTaeZljFKsQ6uk6nimzdQ==
+"@budibase/pro@1.0.131":
+  version "1.0.131"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.131.tgz#65907e7ca528d237bf12dbe5c159156d03e8d5c3"
+  integrity sha512-pmK18/1TPDY+3IHUzGh0fG5CEy7+kSPpcl72smri8jvo5OsD4lWQVOTHSdqRn8aIf/qEHHWc2sspEEDGhYMv0Q==
   dependencies:
-    "@budibase/backend-core" "1.0.127"
+    "@budibase/backend-core" "1.0.131"
     node-fetch "^2.6.1"
 
 "@cspotcode/source-map-consumer@0.8.0":


### PR DESCRIPTION
## Description
Various fixes for release as follows:
1. https://github.com/Budibase/budibase/issues/5594 - minor fix, allow using `__` in SQL table names.
2. https://github.com/Budibase/budibase/issues/5612 - edge case, some formats of string being passed to MySQL were causing mis-processing, making sure this can't happen for data source plus tables and reducing the risk of date mis-processing for queries.
3. https://github.com/Budibase/budibase/issues/5553 - some work towards handling this, importing SQL tables will look for `date` and `time` types, appending a property to our `datetime` type (as we don't have a specific type for each) of `dateOnly` or `timeOnly` respectively. This is handled in the frontend, making sure the date picker only displays what it needs to. This should likely be added to the internal tables as well, to allow them to be date or time only at a data level, but for now just handling it for SQL tables. This isn't a total fix as some of the query engines still return time with the data, this may need to be stripped rather than just removed from the display, but it appears to fix issues with filtering etc.
4. Fixing an issue with exporting apps, streaming of the app export meant that our middlewares have finished execution but the DB connection needs to remain open, adding an edge case which opens the database outside of context and closes it when the stream finishes.
5. Fix for https://github.com/Budibase/budibase/issues/5669 - form step was erroring when loaded in an empty state.
6. Automation and query fix, there was an issue with context being closed prematurely as the threading uses callbacks, meaning that the `doInContext` functions would return before the automation/query has completed. Adjusted to use async functions and simply perform the callback at the end of the async function, meaning that the context function can wait for completion before closing out context.