### PR TITLE
SQL columns with spaces LIKE fix and dynamic REST variable UI change

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/_components/DynamicVariableModal.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/_components/DynamicVariableModal.svelte
@@ -1,5 +1,8 @@
 <script>
   import { Input, ModalContent, Modal, Body } from "@budibase/bbui"
+  import { createEventDispatcher } from "svelte"
+
+  const dispatch = createEventDispatcher()
 
   export let dynamicVariables
   export let datasource
@@ -35,6 +38,7 @@
     name = null
     binding = null
     dynamicVariables[copiedName] = copiedBinding
+    dispatch("change", dynamicVariables)
   }
 </script>
 

--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/rest/[query]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/rest/[query]/index.svelte
@@ -299,6 +299,7 @@
   {dynamicVariables}
   bind:binding={varBinding}
   bind:this={addVariableModal}
+  on:change={saveQuery}
 />
 {#if query && queryConfig}
   <div class="inner">

--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/rest/[query]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/rest/[query]/index.svelte
@@ -37,7 +37,7 @@
   import AccessLevelSelect from "components/integration/AccessLevelSelect.svelte"
   import DynamicVariableModal from "../../_components/DynamicVariableModal.svelte"
   import Placeholder from "assets/bb-spaceship.svg"
-  import { cloneDeep } from "lodash/fp"
+  import { cloneDeep, isEqual } from "lodash/fp"
   import { RawRestBodyTypes } from "constants/backend"
 
   let query, datasource
@@ -47,6 +47,7 @@
   let response, schema, enabledHeaders
   let authConfigId
   let dynamicVariables, addVariableModal, varBinding
+  let baseQuery, baseDatasource, baseVariables
 
   $: datasourceType = datasource?.source
   $: integrationInfo = $integrations[datasourceType]
@@ -62,6 +63,15 @@
   $: hasSchema =
     Object.keys(schema || {}).length !== 0 ||
     Object.keys(query?.schema || {}).length !== 0
+  $: baseQuery = !baseQuery ? cloneDeep(query) : baseQuery
+  $: baseDatasource = !baseDatasource ? cloneDeep(datasource) : baseDatasource
+  $: baseVariables = !baseVariables
+    ? cloneDeep(dynamicVariables)
+    : baseVariables
+  $: hasChanged =
+    !isEqual(baseQuery, query) ||
+    !isEqual(baseDatasource, datasource) ||
+    !isEqual(baseVariables, dynamicVariables)
 
   function getSelectedQuery() {
     return cloneDeep(
@@ -120,6 +130,9 @@
         datasource.config.dynamicVariables = rebuildVariables(saveId)
         datasource = await datasources.save(datasource)
       }
+      baseQuery = query
+      baseDatasource = datasource
+      baseVariables = dynamicVariables
     } catch (err) {
       notifications.error(`Error saving query`)
     }
@@ -333,7 +346,7 @@
           </div>
           <Button primary disabled={!url} on:click={runQuery}>Send</Button>
           <Button
-            disabled={!query.name}
+            disabled={!query.name || !hasChanged}
             cta
             on:click={saveQuery}
             tooltip={!hasSchema

--- a/packages/string-templates/src/helpers/index.js
+++ b/packages/string-templates/src/helpers/index.js
@@ -25,7 +25,7 @@ const HELPERS = [
     if (
       value != null &&
       typeof value === "object" &&
-      value.toString() === "[object Object]"
+      (value.toString() === "[object Object]" || Array.isArray(value))
     ) {
       return new SafeString(JSON.stringify(value))
     }

--- a/packages/string-templates/src/helpers/index.js
+++ b/packages/string-templates/src/helpers/index.js
@@ -13,6 +13,16 @@ const HTML_SWAPS = {
   ">": "&gt;",
 }
 
+function isObject(value) {
+  if (value == null || typeof value !== "object") {
+    return false
+  }
+  return (
+    value.toString() === "[object Object]" ||
+    (value.length > 0 && typeof value[0] === "object")
+  )
+}
+
 const HELPERS = [
   // external helpers
   new Helper(HelperFunctionNames.OBJECT, value => {
@@ -22,11 +32,7 @@ const HELPERS = [
   new Helper(HelperFunctionNames.JS, processJS, false),
   // this help is applied to all statements
   new Helper(HelperFunctionNames.ALL, (value, { __opts }) => {
-    if (
-      value != null &&
-      typeof value === "object" &&
-      (value.toString() === "[object Object]" || Array.isArray(value))
-    ) {
+    if (isObject(value)) {
       return new SafeString(JSON.stringify(value))
     }
     // null/undefined values produce bad results

--- a/packages/string-templates/src/processors/preprocessor.js
+++ b/packages/string-templates/src/processors/preprocessor.js
@@ -64,9 +64,10 @@ module.exports.processors = [
         return statement
       }
     }
+    const testHelper = possibleHelper.trim().toLowerCase()
     if (
       !noHelpers &&
-      HelperNames().some(option => option.includes(possibleHelper))
+      HelperNames().some(option => testHelper === option.toLowerCase())
     ) {
       insideStatement = `(${insideStatement})`
     }

--- a/packages/string-templates/test/basic.spec.js
+++ b/packages/string-templates/test/basic.spec.js
@@ -106,6 +106,16 @@ describe("Test that the object processing works correctly", () => {
   })
 })
 
+describe("check returning objects", () => {
+  it("should handle an array of objects", async () => {
+    const json = [{a: 1},{a: 2}]
+    const output = await processString("{{ testing }}", {
+      testing: json
+    })
+    expect(output).toEqual(JSON.stringify(json))
+  })
+})
+
 describe("check the utility functions", () => {
   it("should return false for an invalid template string", () => {
     const valid = isValid("{{ table1.thing prop }}")

--- a/packages/string-templates/test/escapes.spec.js
+++ b/packages/string-templates/test/escapes.spec.js
@@ -30,6 +30,11 @@ describe("Handling context properties with spaces in their name", () => {
     })
     expect(output).toBe("testcase 1")
   })
+
+  it("should allow the use of a", async () => {
+    const output = await processString("{{ a }}", { a: 1 })
+    expect(output).toEqual("1")
+  })
 })
 
 describe("attempt some complex problems", () => {


### PR DESCRIPTION
## Description
Includes a possible fix for #4736 - I believe the issue was that the query needed to be saved again for the dynamic variable to be usable, this wasn't obvious in the UI so instead made it so that the query is automatically saved when a dynamic variable is added via modal. Also fixed an issue reported in #5669 SQL tables with columns that contain spaces would not work with LIKE statements in MySQL, Oracle and MS-SQL. This was due to the fact we have to use a raw statement rather than purely Knex to gain access to the `LOWER` function, to achieve something like the `ilike` command of postgres.

Also added a change to the REST query UI which should hopefully make it more clear when the query needs saved, it will disable the save button unless something has changed, so if switches between two different queries it becomes more obvious that something is unsaved (if editing stuff directly, not through the modal).