### PR TITLE
Job Application Template Test + Smoke Build test fix

### DIFF
--- a/packages/builder/cypress/integration/datasources/postgreSql.spec.js
+++ b/packages/builder/cypress/integration/datasources/postgreSql.spec.js
@@ -207,7 +207,7 @@ filterTests(["all"], () => {
           .contains(queryName)
           .siblings(".actions")
           .within(() => {
-            cy.get(".icon").click({ force: true })
+            cy.get(".spectrum-Icon").click({ force: true })
           })
         // Select and confirm duplication
         cy.get(".spectrum-Menu").contains("Duplicate").click()

--- a/packages/builder/cypress/integration/templates/HR/jobApplicationTracker.spec.js
+++ b/packages/builder/cypress/integration/templates/HR/jobApplicationTracker.spec.js
@@ -1,0 +1,61 @@
+import filterTests from "../../../support/filterTests"
+
+filterTests(["all"], () => {
+  context("Job Application Functionality", () => {
+    const templateName = "Job Application Tracker"
+    const templateNameParsed = templateName.toLowerCase().replace(/\s+/g, '-')
+    
+    before(() => {
+        cy.login()
+        cy.deleteApp(templateName)
+        cy.visit(`${Cypress.config().baseUrl}/builder`, {
+            onBeforeLoad(win) {
+                cy.stub(win, 'open')
+            }
+        })
+        cy.wait(2000)
+
+        // Template navigation
+        cy.request(`${Cypress.config().baseUrl}/api/applications?status=all`)
+        .its("body")
+        .then(val => {
+            if (val.length > 0) {
+            cy.get(".spectrum-Button").contains("Templates").click({force: true})
+            }
+        })
+        })
+
+    it("should create and publish app with Job Application Tracker template", () => {
+        // Select Job Application Tracker template
+        cy.get(".template-thumbnail-text")
+            .contains(templateName).parentsUntil(".template-grid").within(() => {
+                cy.get(".spectrum-Button").contains("Use template").click({ force: true })
+            })
+
+        // Confirm URL matches template name
+        const appUrl = cy.get(".app-server")
+        appUrl.invoke('text').then(appUrlText => {
+            expect(appUrlText).to.equal(`${Cypress.config().baseUrl}/app/` + templateNameParsed)
+        })
+
+        // Create App
+        cy.get(".spectrum-Dialog-grid").within(() => {
+            cy.get(".spectrum-Button").contains("Create app").click({ force: true })
+        })
+
+        // Publish App
+        cy.wait(2000) // Wait for app to generate
+        cy.get(".toprightnav").contains("Publish").click({ force: true })
+        cy.get(".spectrum-Dialog-grid").within(() => {
+            cy.get(".spectrum-Button").contains("Publish").click({ force: true })
+        })
+
+        // Verify Published app
+        cy.wait(2000) // Wait for App to publish and modal to appear
+        cy.get(".spectrum-Dialog-grid").within(() => {
+            cy.get(".spectrum-Button").contains("View App").click({ force: true })
+            cy.window().its('open').should('be.calledOnce')
+        })
+    })
+    })
+})

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -44,7 +44,7 @@ Cypress.Commands.add("createApp", (name, addDefaultTable) => {
     typeof addDefaultTable != "boolean" ? true : addDefaultTable
 
   cy.visit(`${Cypress.config().baseUrl}/builder`)
-  cy.wait(500)
+  cy.wait(1000)
   cy.get(`[data-cy="create-app-btn"]`).click({ force: true })
 
   // If apps already exist

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -94,19 +94,21 @@ Cypress.Commands.add("deleteApp", name => {
           cy.get(actionEleId).within(() => {
             cy.get(".spectrum-Icon").eq(0).click()
           })
-
           cy.get(".spectrum-Menu").then($menu => {
             if ($menu.text().includes("Unpublish")) {
               cy.get(".spectrum-Menu").contains("Unpublish").click()
               cy.get(".spectrum-Dialog-grid").contains("Unpublish app").click()
-            } else {
-              cy.get(".spectrum-Menu").contains("Delete").click()
-              cy.get(".spectrum-Dialog-grid").within(() => {
-                cy.get("input").type(name)
-              })
-              cy.get(".spectrum-Button--warning").click()
             }
           })
+
+          cy.get(actionEleId).within(() => {
+            cy.get(".spectrum-Icon").eq(0).click()
+          })
+          cy.get(".spectrum-Menu").contains("Delete").click()
+          cy.get(".spectrum-Dialog-grid").within(() => {
+            cy.get("input").type(name)
+          })
+          cy.get(".spectrum-Button--warning").click()
         } else {
           return
         }


### PR DESCRIPTION
Job Application Template Test

jobApplicationTracker.spec.js
- New file and test
- Creates and publishes Job Application Tracker app - Verifies View URL button works

commands.js
- Updated deleteApp function

Fix PostgreSQL Smoke Build Test
Specifically with the duplicate query test
- Looks for spectrum-icon instead of icon
