### PR TITLE
make secretkey refs conditional

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -34,6 +34,7 @@ spec:
           {{ else }}
           value: http://{{ .Release.Name }}-svc-couchdb:{{ .Values.services.couchdb.port }}
           {{ end }}
+        {{ if .Values.services.couchdb.enabled }}
         - name: COUCH_DB_USER
           valueFrom:
             secretKeyRef:
@@ -44,6 +45,7 @@ spec:
             secretKeyRef:
               name: {{ template "couchdb.fullname" . }}
               key: adminPassword
+        {{ end }}
         - name: ENABLE_ANALYTICS
           value: {{ .Values.globals.enableAnalytics | quote }}
         - name: INTERNAL_API_KEY

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -29,6 +29,7 @@ spec:
       - env:
         - name: CLUSTER_PORT
           value: {{ .Values.services.worker.port | quote }}
+        {{ if .Values.services.couchdb.enabled }}
         - name: COUCH_DB_USER
           valueFrom:
             secretKeyRef:
@@ -39,6 +40,7 @@ spec:
             secretKeyRef:
               name: {{ template "couchdb.fullname" . }}
               key: adminPassword
+        {{ end }}
         - name: COUCH_DB_URL
           {{ if .Values.services.couchdb.url }}
           value: {{ .Values.services.couchdb.url }}


### PR DESCRIPTION
## Description
Prevent our docker images from looking for couchDB secrets when using external couch

## Screenshots
_If a UI facing feature, some screenshots of the new functionality._



