### PR TITLE
Fix missing component store (form step issues + duplicate issues)

### DIFF
--- a/packages/client/src/components/app/forms/FormStep.svelte
+++ b/packages/client/src/components/app/forms/FormStep.svelte
@@ -22,7 +22,7 @@
     if (
       formContext &&
       $builderStore.inBuilder &&
-      $componentStore?.selectedComponentPath?.includes($component.id)
+      $componentStore.selectedComponentPath?.includes($component.id)
     ) {
       formContext.formApi.setStep(step)
     }

--- a/packages/client/src/components/preview/SettingsBar.svelte
+++ b/packages/client/src/components/preview/SettingsBar.svelte
@@ -155,7 +155,7 @@
       icon="Duplicate"
       on:click={() => {
         builderStore.actions.duplicateComponent(
-          $builderStore.selectedComponent._id
+          $builderStore.selectedComponentId
         )
       }}
       title="Duplicate component"

--- a/packages/client/src/sdk.js
+++ b/packages/client/src/sdk.js
@@ -7,6 +7,7 @@ import {
   builderStore,
   uploadStore,
   rowSelectionStore,
+  componentStore,
 } from "stores"
 import { styleable } from "utils/styleable"
 import { linkable } from "utils/linkable"
@@ -24,6 +25,7 @@ export default {
   screenStore,
   builderStore,
   uploadStore,
+  componentStore,
   styleable,
   linkable,
   getAction,


### PR DESCRIPTION
## Description
This PR adds the client library component store to the SDK. This was the real reason that we've had multiple form step issues recently.

I've also fixed a small issue with the duplicate component action in the settings bar not working.

Fixes #5669.
Fixes #5713.
Fixes #5711.


