### PR TITLE
Fix cannot Duplicate Screen cause by undefined screenName

### DIFF
--- a/packages/builder/src/components/design/NavigationPanel/ComponentNavigationTree/ScreenDropdownMenu.svelte
+++ b/packages/builder/src/components/design/NavigationPanel/ComponentNavigationTree/ScreenDropdownMenu.svelte
@@ -35,7 +35,7 @@
 
     // Attach the new name and URL
     duplicateScreen.routing.route = sanitizeUrl(screenUrl)
-    duplicateScreen.props._instanceName = screenName
+    duplicateScreen.props._instanceName = screen.props._instanceName
 
     try {
       // Create the screen


### PR DESCRIPTION
## Description
Fix cannot Duplicate Screen cause by undefined screenName

## Screenshots
![image](https://user-images.githubusercontent.com/4613808/167216121-a3d00ee2-0212-4833-a926-40f58eae10fd.png)



