### PR TITLE
allow copying of app ID from the edit menu

### DIFF
--- a/packages/builder/src/components/start/AppRow.svelte
+++ b/packages/builder/src/components/start/AppRow.svelte
@@ -19,6 +19,7 @@
   export let unpublishApp
   export let releaseLock
   export let editIcon
+  export let copyAppId
 </script>
 
 <div class="title">
@@ -101,6 +102,9 @@
     {#if app.deployed}
       <MenuItem on:click={() => unpublishApp(app)} icon="GlobeRemove">
         Unpublish
+      </MenuItem>
+      <MenuItem on:click={() => copyAppId(app)} icon="Copy">
+        Copy App ID
       </MenuItem>
     {/if}
     {#if !app.deployed}

--- a/packages/builder/src/pages/builder/portal/apps/index.svelte
+++ b/packages/builder/src/pages/builder/portal/apps/index.svelte
@@ -12,6 +12,7 @@
     Body,
     Search,
     Divider,
+    Helpers,
   } from "@budibase/bbui"
   import TemplateDisplay from "components/common/TemplateDisplay.svelte"
   import Spinner from "components/common/Spinner.svelte"
@@ -261,6 +262,11 @@
     }
   }
 
+  const copyAppId = async app => {
+    await Helpers.copyToClipboard(app.prodId)
+    notifications.success("App ID copied to clipboard.")
+  }
+
   function createAppFromTemplateUrl(templateKey) {
     // validate the template key just to make sure
     const templateParts = templateKey.split("/")
@@ -394,6 +400,7 @@
           <div class="appTable">
             {#each filteredApps as app (app.appId)}
               <AppRow
+                {copyAppId}
                 {releaseLock}
                 {editIcon}
                 {app}


### PR DESCRIPTION
## Description
Based off discussion https://github.com/Budibase/budibase/discussions/5759, it's quite difficult for the user to find the appId of their app, without parsing the URL. 

Adding a small edit to allow you to copy it directly using the app edit menu on the portal home screen.

## Screenshots
<img width="332" alt="Screenshot 2022-05-08 at 19 26 53" src="https://user-images.githubusercontent.com/11256663/167310186-6e8267bd-9344-4dbe-8ac1-4de5dc6ae716.png">




<img width="493" alt="Screenshot 2022-05-08 at 19 27 03" src="https://user-images.githubusercontent.com/11256663/167310173-97112b9a-c2c6-42bb-9278-741c9cde6376.png">

