### PR TITLE
Fix datepicker not working when toggling disabled state

### DIFF
--- a/packages/bbui/src/Form/Core/DatePicker.svelte
+++ b/packages/bbui/src/Form/Core/DatePicker.svelte
@@ -156,8 +156,8 @@
         <input
           data-input
           type="text"
-          {disabled}
           class="spectrum-Textfield-input spectrum-InputGroup-input"
+          class:is-disabled={disabled}
           {placeholder}
           {id}
           {value}
@@ -167,7 +167,7 @@
         type="button"
         class="spectrum-Picker spectrum-Picker--sizeM spectrum-InputGroup-button"
         tabindex="-1"
-        {disabled}
+        class:is-disabled={disabled}
         class:is-invalid={!!error}
         on:click={flatpickr?.open}
       >
@@ -211,5 +211,8 @@
   }
   :global(.flatpickr-calendar) {
     font-family: "Source Sans Pro", sans-serif;
+  }
+  .is-disabled {
+    pointer-events: none !important;
   }
 </style>


### PR DESCRIPTION
## Description
Fixes an issue where if date pickers were initially set to disabled, then they sometimes did not work when they were enabled again. As usual this was an issue with Flatpickr - it seems to not correctly attach the required event handlers if initialised targetting a disabled element.

Addresses #5727.



