### PR TITLE
Add limit placeholder for Automation queries

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -53,6 +53,7 @@
     : { schema: {} }
   $: schema = getSchemaForTable(tableId, { searchableSchema: true }).schema
   $: schemaFields = Object.values(schema || {})
+  $: queryLimit = tableId?.includes("datasource") ? "∞" : "1000"
 
   const onChange = Utils.sequential(async (e, key) => {
     try {
@@ -330,6 +331,7 @@
               on:change={e => onChange(e, key)}
               {bindings}
               updateOnChange={false}
+              placeholder={value.customType === "queryLimit" ? queryLimit : ""}
             />
           </div>
         {/if}

--- a/packages/server/src/automations/steps/queryRows.js
+++ b/packages/server/src/automations/steps/queryRows.js
@@ -50,6 +50,7 @@ exports.definition = {
         limit: {
           type: "number",
           title: "Limit",
+          customType: "queryLimit",
         },
       },
       required: ["tableId"],


### PR DESCRIPTION
## Description
It was not clear that there was a default limit of 1000 for internal queries in automation. Placeholder added.

Addresses: 
- https://github.com/Budibase/budibase/issues/4659
- https://github.com/Budibase/budibase/discussions/5685

## Screenshots
*Internal Table*
![Screenshot 2022-05-11 at 11 30 04](https://user-images.githubusercontent.com/101575380/167829426-d6d1b524-afa2-416a-bb3b-4c2aa2cd4b70.png)

*MySQL (external) Table*
![Screenshot 2022-05-11 at 11 30 25](https://user-images.githubusercontent.com/101575380/167829484-a25543d4-b25f-4f9f-a0e5-11009c500816.png)


