### PR TITLE
Fix duplicate screens

### DIFF
--- a/packages/server/src/api/routes/utils/validators.js
+++ b/packages/server/src/api/routes/utils/validators.js
@@ -167,7 +167,6 @@ exports.screenValidator = () => {
       _id: Joi.string().required(),
       _component: Joi.string().required(),
       _children: Joi.array().required(),
-      _instanceName: Joi.string().required(),
       _styles: Joi.object().required(),
       type: OPTIONAL_STRING,
       table: OPTIONAL_STRING,


### PR DESCRIPTION
## Description
Removes `_instanceName` as a required setting for screens, as we don't show this field for them any more.

Addresses #5809.


