### PR TITLE
Prevent multiple concurrent release jobs and fix dependency

### DIFF
--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -1,4 +1,5 @@
 name: Budibase Release Staging
+concurrency: release-develop
 
 on: 
  push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Budibase Release
+concurrency: release
 
 on:
  push:

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -71,7 +71,7 @@
     "@apidevtools/swagger-parser": "^10.0.3",
     "@budibase/backend-core": "^1.0.157",
     "@budibase/client": "^1.0.157",
-    "@budibase/pro": "1.0.157",
+    "@budibase/pro": "1.0.156",
     "@budibase/string-templates": "^1.0.157",
     "@bull-board/api": "^3.7.0",
     "@bull-board/koa": "^3.7.0",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -32,7 +32,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@budibase/backend-core": "^1.0.157",
-    "@budibase/pro": "1.0.157",
+    "@budibase/pro": "1.0.156",
     "@budibase/string-templates": "^1.0.157",
     "@koa/router": "^8.0.0",
     "@sentry/node": "6.17.7",


### PR DESCRIPTION
## Description
- Add `concurrency` flag to `release-develop` and `release` jobs
- This ensures there will be no upstream changes pushed to either pro or budibase in one release while another release is in progress, which was causing the release step to fail when multiple builds overlap

See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

Also: 
- Fix pro dependency version from previous failed build


