### PR TITLE
Fix for external DB date only columns in various timezones

### DIFF
--- a/packages/bbui/src/Form/Core/DatePicker.svelte
+++ b/packages/bbui/src/Form/Core/DatePicker.svelte
@@ -58,6 +58,11 @@
     if (timeOnly) {
       newValue = `2000-01-01T${newValue.split("T")[1]}`
     }
+    // date only, offset for timezone so always right date
+    else if (!enableTime) {
+      const offset = dates[0].getTimezoneOffset() * 60000
+      newValue = new Date(dates[0].getTime() - offset).toISOString()
+    }
     dispatch("change", newValue)
   }
 


### PR DESCRIPTION
## Description
Addresses an issue with Date only columns from external DBs, offset the UTC offset in ISO strings to allow dateonly columns in external DBs to save the correct date when in a timezone differing from UTC.

Addresses: 
- #5731