### PR TITLE
Adding Retries for Cypress tests

### DIFF
--- a/packages/builder/cypress.json
+++ b/packages/builder/cypress.json
@@ -7,5 +7,9 @@
     "WORKER_PORT": "4200",
     "JWT_SECRET": "test",
     "HOST_IP": ""
+  },
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
   }
 }

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -573,7 +573,7 @@ Cypress.Commands.add("addDatasourceConfig", (datasource, skipFetch) => {
       cy.get(".spectrum-Button")
         .contains("Save and fetch tables")
         .click({ force: true })
-      cy.wait(1000)
+      cy.wait(3000)
     })
   }
 })


### PR DESCRIPTION
Adding retries capabilities
-Tests in Cypress run mode will retry up to 2 times (Beneficial for the smoke build flakey tests)
-Tests in Cypress open mode will not retry (more ideal for local testing)

Increase wait for addDatasourceConfig function
-Timing issue against the nightly smoke build. This should help with it