### PR TITLE
Return QA templates when environment variable is set

### DIFF
--- a/packages/frontend-core/src/api/templates.js
+++ b/packages/frontend-core/src/api/templates.js
@@ -29,7 +29,7 @@ export const buildTemplateEndpoints = API => ({
    */
   getAppTemplates: async () => {
     return await API.get({
-      url: "/api/templates?type=app",
+      url: "/api/templates",
     })
   },
 })

--- a/packages/server/src/api/controllers/templates.js
+++ b/packages/server/src/api/controllers/templates.js
@@ -7,7 +7,7 @@ const DEFAULT_TEMPLATES_BUCKET =
   "prod-budi-templates.s3-eu-west-1.amazonaws.com"
 
 exports.fetch = async function (ctx) {
-  let type = env.TEMPLATE_REPOSITORY || "app"
+  let type = env.TEMPLATE_REPOSITORY
   let response,
     error = false
   try {

--- a/packages/server/src/api/controllers/templates.js
+++ b/packages/server/src/api/controllers/templates.js
@@ -7,7 +7,7 @@ const DEFAULT_TEMPLATES_BUCKET =
   "prod-budi-templates.s3-eu-west-1.amazonaws.com"
 
 exports.fetch = async function (ctx) {
-  let type = env.TEST_ENV ? "qa" : "app"
+  let type = env.TEMPLATE_REPOSITORY || "app"
   let response,
     error = false
   try {

--- a/packages/server/src/api/controllers/templates.js
+++ b/packages/server/src/api/controllers/templates.js
@@ -1,12 +1,13 @@
 const fetch = require("node-fetch")
 const { downloadTemplate } = require("../../utilities/fileSystem")
+const env = require("../../environment")
 
 // development flag, can be used to test against templates exported locally
 const DEFAULT_TEMPLATES_BUCKET =
   "prod-budi-templates.s3-eu-west-1.amazonaws.com"
 
 exports.fetch = async function (ctx) {
-  const { type = "app" } = ctx.query
+  let type = env.TEST_ENV ? "qa" : "app"
   let response,
     error = false
   try {

--- a/packages/server/src/environment.js
+++ b/packages/server/src/environment.js
@@ -78,6 +78,7 @@ module.exports = {
   ALLOW_DEV_AUTOMATIONS: process.env.ALLOW_DEV_AUTOMATIONS,
   DISABLE_THREADING: process.env.DISABLE_THREADING,
   SQL_MAX_ROWS: process.env.SQL_MAX_ROWS,
+  TEST_ENV: true,
   _set(key, value) {
     process.env[key] = value
     module.exports[key] = value

--- a/packages/server/src/environment.js
+++ b/packages/server/src/environment.js
@@ -78,7 +78,7 @@ module.exports = {
   ALLOW_DEV_AUTOMATIONS: process.env.ALLOW_DEV_AUTOMATIONS,
   DISABLE_THREADING: process.env.DISABLE_THREADING,
   SQL_MAX_ROWS: process.env.SQL_MAX_ROWS,
-  TEST_ENV: true,
+  TEST_ENV: process.env.TEST_ENV,
   _set(key, value) {
     process.env[key] = value
     module.exports[key] = value

--- a/packages/server/src/environment.js
+++ b/packages/server/src/environment.js
@@ -78,7 +78,7 @@ module.exports = {
   ALLOW_DEV_AUTOMATIONS: process.env.ALLOW_DEV_AUTOMATIONS,
   DISABLE_THREADING: process.env.DISABLE_THREADING,
   SQL_MAX_ROWS: process.env.SQL_MAX_ROWS,
-  TEST_ENV: process.env.TEST_ENV,
+  TEMPLATE_REPOSITORY: process.env.TEMPLATE_REPOSITORY,
   _set(key, value) {
     process.env[key] = value
     module.exports[key] = value

--- a/packages/server/src/environment.js
+++ b/packages/server/src/environment.js
@@ -78,7 +78,7 @@ module.exports = {
   ALLOW_DEV_AUTOMATIONS: process.env.ALLOW_DEV_AUTOMATIONS,
   DISABLE_THREADING: process.env.DISABLE_THREADING,
   SQL_MAX_ROWS: process.env.SQL_MAX_ROWS,
-  TEMPLATE_REPOSITORY: process.env.TEMPLATE_REPOSITORY,
+  TEMPLATE_REPOSITORY: process.env.TEMPLATE_REPOSITORY || "app",
   _set(key, value) {
     process.env[key] = value
     module.exports[key] = value


### PR DESCRIPTION
## Description
QA need to have their own templates folder in which to pull from, specifically limited to their test environment. So this PR introduces a variable (set in the test environments docker-compose) that when set, will ensure that the templates are pulled from a new QA folder (created in the templates repo)

Addresses: 
#5364 

## Screenshots
Not much to demo, but tested with the `TEST_ENV` variable set, and successfully returning the one template I had added to the new QA folder. 

<img width="983" alt="image" src="https://user-images.githubusercontent.com/5665926/169080161-cab1a2df-9e0d-46ab-aaa2-0ec8464c1653.png">



