### PR TITLE
Make 'use bindings' persist in automation

### DIFF
--- a/packages/builder/src/builderStore/store/automation/index.js
+++ b/packages/builder/src/builderStore/store/automation/index.js
@@ -134,6 +134,12 @@ const automationActions = store => ({
   toggleFieldControl: value => {
     store.update(state => {
       state.selectedBlock.rowControl = value
+      const idx =
+        state.selectedAutomation.automation.definition.steps.findIndex(
+          x => x.id === state.selectedBlock.id
+        )
+      state.selectedAutomation.automation.definition.steps[idx].rowControl =
+        value
       return state
     })
   },

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
@@ -28,7 +28,7 @@
   let blockComplete
   let showLooping = false
 
-  $: rowControl = $automationStore.selectedAutomation.automation.rowControl
+  $: rowControl = steps[blockIdx]?.rowControl
   $: showBindingPicker =
     block.stepId === "CREATE_ROW" || block.stepId === "UPDATE_ROW"
 


### PR DESCRIPTION
## Description
rowControl (Use values/Use bindings) is now stored on a per step basis, rather than per automation.

Addresses: 
- https://github.com/Budibase/budibase/issues/5910

## Screenshots
![bug](https://user-images.githubusercontent.com/101575380/169336214-5736e088-2956-4130-81f5-6b1ac8812540.gif)




