### PR TITLE
Misc bug fixes

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
@@ -28,7 +28,6 @@
   let blockComplete
   let showLooping = false
 
-  $: rowControl = $automationStore.selectedAutomation.automation.rowControl
   $: showBindingPicker =
     block.stepId === "CREATE_ROW" || block.stepId === "UPDATE_ROW"
 
@@ -256,7 +255,7 @@
                   on:change={toggleFieldControl}
                   defaultValue="Use values"
                   autoWidth
-                  value={rowControl ? "Use bindings" : "Use values"}
+                  value={block.rowControl ? "Use bindings" : "Use values"}
                   options={["Use values", "Use bindings"]}
                   placeholder={null}
                 />

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -3007,6 +3007,7 @@
     "illegalChildren": ["section"],
     "hasChildren": true,
     "showEmptyState": false,
+    "info": "Row selection is only compatible with internal or SQL tables", 
     "settings": [
       {
         "type": "dataProvider",
@@ -3295,6 +3296,7 @@
       {
         "section": true,
         "name": "Table",
+        "info": "Row selection is only compatible with internal or SQL tables",
         "settings": [
           {
             "type": "number",

--- a/packages/client/src/components/app/table/Table.svelte
+++ b/packages/client/src/components/app/table/Table.svelte
@@ -39,6 +39,8 @@
     dataProvider?.id,
     ActionTypes.SetDataProviderSorting
   )
+  $: table = dataProvider?.datasource?.type === "table"
+
   $: {
     rowSelectionStore.actions.updateSelection(
       $component.id,
@@ -142,7 +144,7 @@
     {quiet}
     {compact}
     {customRenderers}
-    allowSelectRows={!!allowSelectRows}
+    allowSelectRows={allowSelectRows && table}
     bind:selectedRows
     allowEditRows={false}
     allowEditColumns={false}

--- a/packages/server/src/threads/automation.js
+++ b/packages/server/src/threads/automation.js
@@ -219,7 +219,7 @@ class Orchestrator {
           }
           if (
             index === parseInt(env.AUTOMATION_MAX_ITERATIONS) ||
-            index === loopStep.inputs.iterations
+            index === parseInt(loopStep.inputs.iterations)
           ) {
             this.updateContextAndOutput(loopStepNumber, step, tempOutput, {
               status: AutomationErrors.MAX_ITERATIONS,


### PR DESCRIPTION
## Description

Addresses: 
#5491 - Partially addresses, adds some context that informs the user that row selection can only be used with internal tables and MySQL.
#5980 - Ensures binding / values selection persists within automations

Also fixes an issues with automation looping where the user inputted max iterations wasn't being parsed correctly. 


<img width="240" alt="image" src="https://user-images.githubusercontent.com/5665926/169344247-b33d5033-4550-482b-9512-34003c4b7e3b.png">

![image](https://user-images.githubusercontent.com/5665926/169344988-6e0417bc-e0d2-4fce-9cad-a6a17f1d05a2.png)




