### PR TITLE
Make 'to' field undefined if empty for consistent validation

### DIFF
--- a/packages/server/src/automations/steps/sendSmtpEmail.js
+++ b/packages/server/src/automations/steps/sendSmtpEmail.js
@@ -53,6 +53,7 @@ exports.run = async function ({ inputs }) {
   if (!contents) {
     contents = "<h1>No content</h1>"
   }
+  to = to || undefined
   try {
     let response = await sendSmtpEmail(to, from, subject, contents, true)
     return {


### PR DESCRIPTION
## Description
If an invalid binding is used in the 'To' field, the error message is improved to "Unable to send email - No recipients defined"

Addresses: 
- https://github.com/Budibase/budibase/issues/5905




