### PR TITLE
withCache wrapper for working with redis

### DIFF
--- a/packages/backend-core/src/redis/utils.js
+++ b/packages/backend-core/src/redis/utils.js
@@ -18,6 +18,7 @@ exports.Databases = {
   APP_METADATA: "appMetadata",
   QUERY_VARS: "queryVars",
   LICENSES: "license",
+  DATA_CACHE: "data_cache",
 }
 
 exports.SEPARATOR = SEPARATOR

--- a/packages/worker/src/api/controllers/global/configs.js
+++ b/packages/worker/src/api/controllers/global/configs.js
@@ -14,6 +14,7 @@ const {
 const { getGlobalDB, getTenantId } = require("@budibase/backend-core/tenancy")
 const env = require("../../../environment")
 const { googleCallbackUrl, oidcCallbackUrl } = require("./auth")
+const { withCache } = require("../../../utilities/redis")
 
 const BB_TENANT_CDN = "https://tenants.cdn.budi.live"
 
@@ -249,59 +250,64 @@ exports.configChecklist = async function (ctx) {
   const tenantId = getTenantId()
 
   try {
-    // TODO: Watch get started video
+    const ONE_MINUTE = 600
 
-    let apps = []
-    if (!env.MULTI_TENANCY || tenantId) {
-      // Apps exist
-      apps = await getAllApps({ idsOnly: true, efficient: true })
-    }
+    ctx.body = await withCache(
+      `checklist:${tenantId}`,
+      ONE_MINUTE,
+      async () => {
+        let apps = []
+        if (!env.MULTI_TENANCY || tenantId) {
+          // Apps exist
+          apps = await getAllApps({ idsOnly: true, efficient: true })
+        }
 
-    // They have set up SMTP
-    const smtpConfig = await getScopedFullConfig(db, {
-      type: Configs.SMTP,
-    })
+        // They have set up SMTP
+        const smtpConfig = await getScopedFullConfig(db, {
+          type: Configs.SMTP,
+        })
 
-    // They have set up Google Auth
-    const googleConfig = await getScopedFullConfig(db, {
-      type: Configs.GOOGLE,
-    })
+        // They have set up Google Auth
+        const googleConfig = await getScopedFullConfig(db, {
+          type: Configs.GOOGLE,
+        })
 
-    // They have set up OIDC
-    const oidcConfig = await getScopedFullConfig(db, {
-      type: Configs.OIDC,
-    })
+        // They have set up OIDC
+        const oidcConfig = await getScopedFullConfig(db, {
+          type: Configs.OIDC,
+        })
 
-    // They have set up an global user
-    const users = await db.allDocs(
-      getGlobalUserParams(null, {
-        include_docs: true,
-        limit: 1,
-      })
+        // They have set up an global user
+        const users = await db.allDocs(
+          getGlobalUserParams(null, {
+            include_docs: true,
+            limit: 1,
+          })
+        )
+        return {
+          apps: {
+            checked: apps.length > 0,
+            label: "Create your first app",
+            link: "/builder/portal/apps",
+          },
+          smtp: {
+            checked: !!smtpConfig,
+            label: "Set up email",
+            link: "/builder/portal/manage/email",
+          },
+          adminUser: {
+            checked: users && users.rows.length >= 1,
+            label: "Create your first user",
+            link: "/builder/portal/manage/users",
+          },
+          sso: {
+            checked: !!googleConfig || !!oidcConfig,
+            label: "Set up single sign-on",
+            link: "/builder/portal/manage/auth",
+          },
+        }
+      }
     )
-
-    ctx.body = {
-      apps: {
-        checked: apps.length > 0,
-        label: "Create your first app",
-        link: "/builder/portal/apps",
-      },
-      smtp: {
-        checked: !!smtpConfig,
-        label: "Set up email",
-        link: "/builder/portal/manage/email",
-      },
-      adminUser: {
-        checked: users && users.rows.length >= 1,
-        label: "Create your first user",
-        link: "/builder/portal/manage/users",
-      },
-      sso: {
-        checked: !!googleConfig || !!oidcConfig,
-        label: "Set up single sign-on",
-        link: "/builder/portal/manage/auth",
-      },
-    }
   } catch (err) {
     ctx.throw(err.status, err)
   }

--- a/packages/worker/src/utilities/redis.js
+++ b/packages/worker/src/utilities/redis.js
@@ -1,5 +1,6 @@
 const { Client, utils } = require("@budibase/backend-core/redis")
 const { newid } = require("@budibase/backend-core/utils")
+const env = require("../environment")
 
 function getExpirySecondsForDB(db) {
   switch (db) {
@@ -119,7 +120,9 @@ exports.withCache = async (key, ttl, fetchFn) => {
   try {
     const fetchedValue = await fetchFn()
 
-    await cachingClient.store(key, fetchedValue, ttl)
+    if (!env.isTest()) {
+      await cachingClient.store(key, fetchedValue, ttl)
+    }
     return fetchedValue
   } catch (err) {
     console.error("Error calling fetch function", err)


### PR DESCRIPTION
## Description
The `/checklist` call has been optimised to limit the amount of data it brings back, speeding up the query significantly. However, when under load that call is still querying 4-5 separate documents in couch, for data that changes almost never. I've added a `withCache` helper (heavily inspired by `Rails.cache` from RoR) that allows us to wrap any value with a cache helper, and will go through the following steps:
- Try and read the value with the key from the cache
- if available, return directly from redis
- If not, call the `fetchFn()` and fetch the value from the original source
- Cache the result so the next call is cached

There's a TODO in here to move this to `backend-core` - where it makes more sense as a global option.

Addresses: 
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._



