### PR TITLE
Expose option to limit amount of uploads in attatchment field

### DIFF
--- a/packages/bbui/src/Form/Core/Dropzone.svelte
+++ b/packages/bbui/src/Form/Core/Dropzone.svelte
@@ -18,6 +18,7 @@
   export let fileSizeLimit = BYTES_IN_MB * 20
   export let processFiles = null
   export let handleFileTooLarge = null
+  export let handleTooManyFiles = null
   export let gallery = true
   export let error = null
   export let fileTags = []
@@ -71,6 +72,13 @@
       handleFileTooLarge(fileSizeLimit, value)
       return
     }
+
+    const fileCount = fileList.length + value.length
+    if (handleTooManyFiles && maximum && fileCount > maximum) {
+      handleTooManyFiles(maximum)
+      return
+    }
+
     if (processFiles) {
       const processedFiles = await processFiles(fileList)
       const newValue = [...value, ...processedFiles]

--- a/packages/bbui/src/Form/Dropzone.svelte
+++ b/packages/bbui/src/Form/Dropzone.svelte
@@ -11,6 +11,7 @@
   export let fileSizeLimit = undefined
   export let processFiles = undefined
   export let handleFileTooLarge = undefined
+  export let handleTooManyFiles = undefined
   export let gallery = true
   export let fileTags = []
   export let maximum = undefined
@@ -30,6 +31,7 @@
     {fileSizeLimit}
     {processFiles}
     {handleFileTooLarge}
+    {handleTooManyFiles}
     {gallery}
     {fileTags}
     {maximum}

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -2792,6 +2792,12 @@
         "key": "extensions"
       },
       {
+        "type": "number",
+        "label": "No. of attachment",
+        "key": "maximum",
+        "min": 1
+      },
+      {
         "type": "event",
         "label": "On Change",
         "key": "onChange",

--- a/packages/client/src/components/app/forms/AttachmentField.svelte
+++ b/packages/client/src/components/app/forms/AttachmentField.svelte
@@ -9,6 +9,7 @@
   export let validation
   export let extensions
   export let onChange
+  export let maximum = undefined
 
   let fieldState
   let fieldApi
@@ -22,6 +23,12 @@
       `Files cannot exceed ${
         fileSizeLimit / BYTES_IN_MB
       } MB. Please try again with smaller files.`
+    )
+  }
+
+  const handleTooManyFiles = fileLimit => {
+    notificationStore.actions.warning(
+      `Please select a maximum of ${fileLimit} files.`
     )
   }
 
@@ -66,6 +73,8 @@
       on:change={handleChange}
       {processFiles}
       {handleFileTooLarge}
+      {handleTooManyFiles}
+      {maximum}
       {extensions}
     />
   {/if}


### PR DESCRIPTION
## Description
Expose option to limit the amount of uploads in attachment field.

Addresses: 
- [#4952](https://github.com/Budibase/budibase/issues/4952)

## Screenshots
- New option in attachment field to set the limit
  <img width="1432" alt="Screenshot 2022-05-25 at 21 05 29" src="https://user-images.githubusercontent.com/9115894/170269515-fa1298d9-e4fa-47f2-a543-59367c53d6cf.png">

- Hide dropdown zone when it hit the limit
  <img width="754" alt="Screenshot 2022-05-25 at 21 08 06" src="https://user-images.githubusercontent.com/9115894/170269828-751ede50-d121-49d2-9eac-483e2f2e07c9.png">

- Show warning when user upload more than the limit
  <img width="742" alt="Screenshot 2022-05-25 at 21 19 57" src="https://user-images.githubusercontent.com/9115894/170271698-0da9a682-c759-45a5-85ae-2655cd542357.png">





