### PR TITLE
Make sure linkedRows is an array before map

### DIFF
--- a/packages/builder/src/components/common/LinkedRowSelector.svelte
+++ b/packages/builder/src/components/common/LinkedRowSelector.svelte
@@ -8,7 +8,9 @@
   export let linkedRows = []
 
   let rows = []
-  let linkedIds = (linkedRows || [])?.map(row => row?._id || row)
+  let linkedIds = (Array.isArray(linkedRows) ? linkedRows : [])?.map(
+    row => row?._id || row
+  )
 
   $: linkedRows = linkedIds
   $: label = capitalise(schema.name)


### PR DESCRIPTION
## Description
Unrecoverable automation bug when swapping between relationship binding and value dropdown is now fixed.

Addresses: 
- https://github.com/Budibase/budibase/issues/6019



