### PR TITLE
Graceful server shutdown and cleaning up hooks which keep instance alive

### DIFF
--- a/packages/backend-core/logging.js
+++ b/packages/backend-core/logging.js
@@ -1,0 +1,1 @@
+module.exports = require("./src/logging")

--- a/packages/backend-core/src/logging.js
+++ b/packages/backend-core/src/logging.js
@@ -1,0 +1,16 @@
+const NonErrors = ["AccountError"]
+
+function isSuppressed(e) {
+  return e && e["suppressAlert"]
+}
+
+module.exports.logAlert = (message, e = null) => {
+  if (e && NonErrors.includes(e.name) && isSuppressed(e)) {
+    return
+  }
+  let errorJson = ""
+  if (e) {
+    errorJson = ": " + JSON.stringify(e, Object.getOwnPropertyNames(e))
+  }
+  console.error(`bb-alert: ${message} ${errorJson}`)
+}

--- a/packages/backend-core/src/redis/index.js
+++ b/packages/backend-core/src/redis/index.js
@@ -23,7 +23,7 @@ function connectionError(timeout, err) {
   if (CLOSED) {
     return
   }
-  CLIENT.end()
+  CLIENT.disconnect()
   CLOSED = true
   // always clear this on error
   clearTimeout(timeout)

--- a/packages/server/src/api/index.js
+++ b/packages/server/src/api/index.js
@@ -12,6 +12,7 @@ const { mainRoutes, staticRoutes, publicRoutes } = require("./routes")
 const pkg = require("../../package.json")
 const env = require("../environment")
 const { middleware: pro } = require("@budibase/pro")
+const { shutdown } = require("./routes/public")
 
 const router = new Router()
 
@@ -90,4 +91,5 @@ router.use(publicRoutes.allowedMethods())
 router.use(staticRoutes.routes())
 router.use(staticRoutes.allowedMethods())
 
-module.exports = router
+module.exports.router = router
+module.exports.shutdown = shutdown

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -84,6 +84,7 @@ server.on("close", async () => {
   await redis.shutdown()
   await Thread.shutdown()
   api.shutdown()
+  process.exit()
 })
 
 module.exports = server.listen(env.PORT || 0, async () => {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -102,6 +102,11 @@ const shutdown = () => {
 }
 
 process.on("uncaughtException", err => {
+  // @ts-ignore
+  // don't worry about this error, comes from zlib isn't important
+  if (err && err["code"] === "ERR_INVALID_CHAR") {
+    return
+  }
   console.error(err)
   shutdown()
 })

--- a/packages/server/src/automations/bullboard.js
+++ b/packages/server/src/automations/bullboard.js
@@ -45,4 +45,12 @@ exports.init = () => {
   return serverAdapter.registerPlugin()
 }
 
+exports.shutdown = async () => {
+  if (automationQueue) {
+    clearInterval(cleanupInternal)
+    await automationQueue.close()
+    automationQueue = null
+  }
+}
+
 exports.queue = automationQueue

--- a/packages/server/src/automations/index.js
+++ b/packages/server/src/automations/index.js
@@ -1,5 +1,5 @@
 const { processEvent } = require("./utils")
-const { queue } = require("./bullboard")
+const { queue, shutdown } = require("./bullboard")
 
 /**
  * This module is built purely to kick off the worker farm and manage the inputs/outputs
@@ -14,4 +14,9 @@ exports.init = function () {
 exports.getQueues = () => {
   return [queue]
 }
+
+exports.shutdown = () => {
+  return shutdown()
+}
+
 exports.queue = queue

--- a/packages/server/src/utilities/queue/inMemoryQueue.js
+++ b/packages/server/src/utilities/queue/inMemoryQueue.js
@@ -76,6 +76,13 @@ class InMemoryQueue {
   }
 
   /**
+   * replicating the close function from bull, which waits for jobs to finish.
+   */
+  async close() {
+    return []
+  }
+
+  /**
    * This removes a cron which has been implemented, this is part of Bull API.
    * @param {string} cronJobId The cron which is to be removed.
    */

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -71,6 +71,7 @@ server.on("close", async () => {
     console.log("Server Closed")
   }
   await redis.shutdown()
+  process.exit()
 })
 
 const shutdown = () => {


### PR DESCRIPTION
## Description
Fixing issue with server not shutting down correctly when an error occurs, making sure that everything clears up gracefully.

After testing a bit I found the following components where keeping the server from shutting down:
1. The rate limiting store for the public Koa API (Redis connection)
2. The Bull automation queue and its Redis connection
3. The threads running in the background

I did some testing around this and found that it was safe to finish the shutdown process with a `process.exit()` due to the fact that the bull shutdown waits all jobs that are currently running to finish. This means that all shut downs that follow a graceful process using `SIGTERM` will now gracefully wait for everything to stop within the instance before actually restarting it.

The `process.exit` at the end isn't technically required, but the automation queue is already cleaned up and all operations have ended, the server will stop naturally anyway without the `exit` call, but my concern is around things like stray `setInterval` calls, any timeout or interval could cause the server to not shutdown correctly again - in environments outside of Kubernetes this could be problematic.

In the future if there are any background processes which need to be gracefully shutdown they should be added to the server/workers close operation, so that under any circumstance if the process is ending it will correctly clear up the background operations.