### PR TITLE
feat: toggle for sort order in options type field

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -2228,6 +2228,12 @@
       },
       {
         "type": "boolean",
+        "label": "Sort in lexographic order",
+        "key": "sort",
+        "defaultValue": true
+      },
+      {
+        "type": "boolean",
         "label": "Disabled",
         "key": "disabled",
         "defaultValue": false

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -2228,7 +2228,7 @@
       },
       {
         "type": "boolean",
-        "label": "Sort in lexographic order",
+        "label": "Sort in alphabetical order",
         "key": "sort",
         "defaultValue": true
       },

--- a/packages/client/src/components/app/forms/OptionsField.svelte
+++ b/packages/client/src/components/app/forms/OptionsField.svelte
@@ -17,6 +17,7 @@
   export let autocomplete = false
   export let direction = "vertical"
   export let onChange
+  export let sort = true
 
   let fieldState
   let fieldApi
@@ -64,7 +65,7 @@
         getOptionLabel={flatOptions ? x => x : x => x.label}
         getOptionValue={flatOptions ? x => x : x => x.value}
         {autocomplete}
-        sort={true}
+        {sort}
       />
     {:else if optionsType === "radio"}
       <CoreRadioGroup


### PR DESCRIPTION
## Description
The options picker automatically sorts options alphabetically. This commit adds a setting to disable the sorting, in which case the options picker will default to whatever order of rows the data provider has.

Addresses: 
- [Allow disabling sorting options in options pickers #5160](https://github.com/Budibase/budibase/issues/5160)

## Screenshots
![image](https://user-images.githubusercontent.com/104622748/171828120-4b4bc251-65e6-4bcf-bf8d-0a4a6733fb41.png)




