### PR TITLE
Dates without timezones

### DIFF
--- a/packages/bbui/src/Form/Core/DatePicker.svelte
+++ b/packages/bbui/src/Form/Core/DatePicker.svelte
@@ -66,7 +66,8 @@
     else if (!enableTime) {
       const year = dates[0].getFullYear()
       const month = `${dates[0].getMonth() + 1}`.padStart(2, "0")
-      const day = `${dates[0].getDay() + 1}`.padStart(2, "0")
+      const day = `${dates[0].getDate()}`.padStart(2, "0")
+      console.log(year, month, day)
       newValue = `${year}-${month}-${day}T00:00:00.000`
     }
 

--- a/packages/bbui/src/Form/Core/DatePicker.svelte
+++ b/packages/bbui/src/Form/Core/DatePicker.svelte
@@ -15,7 +15,7 @@
   export let placeholder = null
   export let appendTo = undefined
   export let timeOnly = false
-  export let disableTimezone = false
+  export let ignoreTimezones = false
 
   const dispatch = createEventDispatcher()
   const flatpickrId = `${uuid()}-wrapper`
@@ -51,7 +51,7 @@
 
   const handleChange = event => {
     const [dates] = event.detail
-    const noTimezone = enableTime && !timeOnly && disableTimezone
+    const noTimezone = enableTime && !timeOnly && ignoreTimezones
     let newValue = dates[0]
     if (newValue) {
       newValue = newValue.toISOString()
@@ -62,15 +62,18 @@
       newValue = `2000-01-01T${newValue.split("T")[1]}`
     }
 
-    // Offset for local timezone if using a date only field or if timezone
-    // awareness is disabled
-    else if (!enableTime || noTimezone) {
-      const offset = dates[0].getTimezoneOffset() * 60000
-      newValue = new Date(dates[0].getTime() - offset).toISOString()
+    // Date only
+    else if (!enableTime) {
+      const year = dates[0].getFullYear()
+      const month = `${dates[0].getMonth() + 1}`.padStart(2, "0")
+      const day = `${dates[0].getDay() + 1}`.padStart(2, "0")
+      newValue = `${year}-${month}-${day}T00:00:00.000`
     }
 
-    // Strip time timezone suffix if required
-    if (noTimezone) {
+    // Non timezone aware timestamps
+    else if (noTimezone) {
+      const offset = dates[0].getTimezoneOffset() * 60000
+      newValue = new Date(dates[0].getTime() - offset).toISOString()
       newValue = newValue.slice(0, -1)
     }
 
@@ -125,7 +128,7 @@
     }
 
     // If not using UTC conversion, we need to offset the timezone again here
-    // if (!timeOnly && enableTime && noUTCConversion) {
+    // if (!timeOnly && enableTime && ignoreTimezones) {
     //   const offset = date.getTimezoneOffset() * 60000
     //   date = new Date(date.getTime() + offset)
     // }

--- a/packages/bbui/src/Form/Core/DatePicker.svelte
+++ b/packages/bbui/src/Form/Core/DatePicker.svelte
@@ -127,12 +127,6 @@
       date = new Date(parseInt(val))
     }
 
-    // If not using UTC conversion, we need to offset the timezone again here
-    // if (!timeOnly && enableTime && ignoreTimezones) {
-    //   const offset = date.getTimezoneOffset() * 60000
-    //   date = new Date(date.getTime() + offset)
-    // }
-
     time = date.getTime()
     if (isNaN(time)) {
       return null

--- a/packages/bbui/src/Form/Core/DatePicker.svelte
+++ b/packages/bbui/src/Form/Core/DatePicker.svelte
@@ -67,7 +67,6 @@
       const year = dates[0].getFullYear()
       const month = `${dates[0].getMonth() + 1}`.padStart(2, "0")
       const day = `${dates[0].getDate()}`.padStart(2, "0")
-      console.log(year, month, day)
       newValue = `${year}-${month}-${day}T00:00:00.000`
     }
 

--- a/packages/bbui/src/Form/Core/DatePicker.svelte
+++ b/packages/bbui/src/Form/Core/DatePicker.svelte
@@ -62,7 +62,8 @@
       newValue = `2000-01-01T${newValue.split("T")[1]}`
     }
 
-    // Date only
+    // For date-only fields, construct a manual timestamp string without a time
+    // or time zone
     else if (!enableTime) {
       const year = dates[0].getFullYear()
       const month = `${dates[0].getMonth() + 1}`.padStart(2, "0")
@@ -70,11 +71,13 @@
       newValue = `${year}-${month}-${day}T00:00:00.000`
     }
 
-    // Non timezone aware timestamps
+    // For non-timezone-aware fields, create an ISO 8601 timestamp of the exact
+    // time picked, without timezone
     else if (noTimezone) {
       const offset = dates[0].getTimezoneOffset() * 60000
-      newValue = new Date(dates[0].getTime() - offset).toISOString()
-      newValue = newValue.slice(0, -1)
+      newValue = new Date(dates[0].getTime() - offset)
+        .toISOString()
+        .slice(0, -1)
     }
 
     dispatch("change", newValue)

--- a/packages/bbui/src/Form/DatePicker.svelte
+++ b/packages/bbui/src/Form/DatePicker.svelte
@@ -17,7 +17,6 @@
   const dispatch = createEventDispatcher()
 
   const onChange = e => {
-    console.log("VALUE", e.detail)
     value = e.detail
     dispatch("change", e.detail)
   }

--- a/packages/bbui/src/Form/DatePicker.svelte
+++ b/packages/bbui/src/Form/DatePicker.svelte
@@ -12,10 +12,12 @@
   export let timeOnly = false
   export let placeholder = null
   export let appendTo = undefined
+  export let disableTimezone = false
 
   const dispatch = createEventDispatcher()
 
   const onChange = e => {
+    console.log("VALUE", e.detail)
     value = e.detail
     dispatch("change", e.detail)
   }

--- a/packages/bbui/src/Form/DatePicker.svelte
+++ b/packages/bbui/src/Form/DatePicker.svelte
@@ -12,7 +12,7 @@
   export let timeOnly = false
   export let placeholder = null
   export let appendTo = undefined
-  export let disableTimezone = false
+  export let ignoreTimezones = false
 
   const dispatch = createEventDispatcher()
 
@@ -32,6 +32,7 @@
     {enableTime}
     {timeOnly}
     {appendTo}
+    {ignoreTimezones}
     on:change={onChange}
   />
 </Field>

--- a/packages/bbui/src/Tooltip/TooltipWrapper.svelte
+++ b/packages/bbui/src/Tooltip/TooltipWrapper.svelte
@@ -39,7 +39,6 @@
     position: relative;
     display: flex;
     justify-content: center;
-    margin-top: 1px;
     margin-left: 5px;
     margin-right: 5px;
   }

--- a/packages/builder/src/builderStore/store/screenTemplates/utils/commonComponents.js
+++ b/packages/builder/src/builderStore/store/screenTemplates/utils/commonComponents.js
@@ -170,28 +170,29 @@ export function makeDatasourceFormComponents(datasource) {
           optionsType: "select",
           optionsSource: "schema",
         })
-      }
-      if (fieldType === "longform") {
+      } else if (fieldType === "longform") {
         component.customProps({
           format: "auto",
         })
-      }
-      if (fieldType === "array") {
+      } else if (fieldType === "array") {
         component.customProps({
           placeholder: "Choose an option",
           optionsSource: "schema",
         })
-      }
-
-      if (fieldType === "link") {
+      } else if (fieldType === "link") {
         let placeholder =
           fieldSchema.relationshipType === "one-to-many"
             ? "Choose an option"
             : "Choose some options"
         component.customProps({ placeholder })
-      }
-      if (fieldType === "boolean") {
+      } else if (fieldType === "boolean") {
         component.customProps({ text: field, label: "" })
+      } else if (fieldType === "datetime") {
+        component.customProps({
+          enableTime: !fieldSchema?.dateOnly,
+          timeOnly: fieldSchema?.timeOnly,
+          ignoreTimezones: fieldSchema.ignoreTimezones,
+        })
       }
       components.push(component)
     }

--- a/packages/builder/src/components/backend/DataTable/RowFieldControl.svelte
+++ b/packages/builder/src/components/backend/DataTable/RowFieldControl.svelte
@@ -53,7 +53,7 @@
     {label}
     timeOnly={isTimeStamp}
     enableTime={!meta?.dateOnly}
-    disableTimezone={meta?.disableTimezone}
+    ignoreTimezones={meta?.ignoreTimezones}
     bind:value
   />
 {:else if type === "attachment"}

--- a/packages/builder/src/components/backend/DataTable/RowFieldControl.svelte
+++ b/packages/builder/src/components/backend/DataTable/RowFieldControl.svelte
@@ -53,6 +53,7 @@
     {label}
     timeOnly={isTimeStamp}
     enableTime={!meta?.dateOnly}
+    disableTimezone={meta?.disableTimezone}
     bind:value
   />
 {:else if type === "attachment"}

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -432,7 +432,7 @@
       bind:value={field.constraints.datetime.earliest}
     />
     <DatePicker label="Latest" bind:value={field.constraints.datetime.latest} />
-    {#if datasource.source !== "ORACLE"}
+    {#if datasource?.source !== "ORACLE" && datasource?.source !== "SQL_SERVER"}
       <div>
         <Label
           tooltip={isCreating

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -10,12 +10,11 @@
     ModalContent,
     Context,
     Modal,
-    Banner,
     notifications,
   } from "@budibase/bbui"
   import { createEventDispatcher, onMount } from "svelte"
   import { cloneDeep } from "lodash/fp"
-  import { tables } from "stores/backend"
+  import { tables, datasources } from "stores/backend"
   import { TableNames, UNEDITABLE_USER_FIELDS } from "constants"
   import {
     FIELDS,
@@ -83,6 +82,9 @@
     (field.type === LINK_TYPE && !field.tableId) ||
     Object.keys(errors).length !== 0
   $: errors = checkErrors(field)
+  $: datasource = $datasources.list.find(
+    source => source._id === table?.sourceId
+  )
 
   // used to select what different options can be displayed for column type
   $: canBeSearched =
@@ -430,16 +432,18 @@
       bind:value={field.constraints.datetime.earliest}
     />
     <DatePicker label="Latest" bind:value={field.constraints.datetime.latest} />
-    <div>
-      <Label
-        tooltip={isCreating
-          ? null
-          : "We recommend not changing how timezones are handled for existing columns, as existing data will not be updated"}
-      >
-        Time zones
-      </Label>
-      <Toggle bind:value={field.ignoreTimezones} text="Ignore time zones" />
-    </div>
+    {#if datasource.source !== "ORACLE"}
+      <div>
+        <Label
+          tooltip={isCreating
+            ? null
+            : "We recommend not changing how timezones are handled for existing columns, as existing data will not be updated"}
+        >
+          Time zones
+        </Label>
+        <Toggle bind:value={field.ignoreTimezones} text="Ignore time zones" />
+      </div>
+    {/if}
   {:else if field.type === "number"}
     <Input
       type="number"

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -428,6 +428,18 @@
       bind:value={field.constraints.datetime.earliest}
     />
     <DatePicker label="Latest" bind:value={field.constraints.datetime.latest} />
+    <div>
+      <Label
+        size="S"
+        tooltip="By default, date/time values are timezone aware and stored as UTC timestamps. You can disable timezone awareness if you would prefer that date/time values are always stored relative to the servers timezone."
+      >
+        Timezone
+      </Label>
+      <Toggle
+        bind:value={field.disableTimezone}
+        text="Disable timezone awareness"
+      />
+    </div>
   {:else if field.type === "number"}
     <Input
       type="number"

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -10,6 +10,7 @@
     ModalContent,
     Context,
     Modal,
+    Banner,
     notifications,
   } from "@budibase/bbui"
   import { createEventDispatcher, onMount } from "svelte"
@@ -63,6 +64,7 @@
   let primaryDisplay =
     $tables.selected.primaryDisplay == null ||
     $tables.selected.primaryDisplay === field.name
+  let isCreating = originalName == null
 
   let table = $tables.selected
   let indexes = [...($tables.selected.indexes || [])]
@@ -430,15 +432,13 @@
     <DatePicker label="Latest" bind:value={field.constraints.datetime.latest} />
     <div>
       <Label
-        size="S"
-        tooltip="By default, date/time values are timezone aware and stored as UTC timestamps. You can disable timezone awareness if you would prefer that date/time values are always stored relative to the servers timezone."
+        tooltip={isCreating
+          ? null
+          : "We recommend not changing how timezones are handled for existing columns, as existing data will not be updated"}
       >
-        Timezone
+        Time zones
       </Label>
-      <Toggle
-        bind:value={field.disableTimezone}
-        text="Disable timezone awareness"
-      />
+      <Toggle bind:value={field.ignoreTimezones} text="Ignore time zones" />
     </div>
   {:else if field.type === "number"}
     <Input

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -2620,14 +2620,20 @@
       },
       {
         "type": "boolean",
-        "label": "Show Time",
+        "label": "Show time",
         "key": "enableTime",
         "defaultValue": true
       },
       {
         "type": "boolean",
-        "label": "Time Only",
+        "label": "Time only",
         "key": "timeOnly",
+        "defaultValue": false
+      },
+      {
+        "type": "boolean",
+        "label": "Ignore time zones",
+        "key": "ignoreTimezones",
         "defaultValue": false
       },
       {

--- a/packages/client/src/components/app/forms/DateTimeField.svelte
+++ b/packages/client/src/components/app/forms/DateTimeField.svelte
@@ -14,6 +14,7 @@
 
   let fieldState
   let fieldApi
+  let fieldSchema
 
   const handleChange = e => {
     fieldApi.setValue(e.detail)
@@ -32,6 +33,7 @@
   type="datetime"
   bind:fieldState
   bind:fieldApi
+  bind:fieldSchema
 >
   {#if fieldState}
     <CoreDatePicker
@@ -44,6 +46,7 @@
       {enableTime}
       {timeOnly}
       {placeholder}
+      ignoreTimezones={fieldSchema?.ignoreTimezones}
     />
   {/if}
 </Field>

--- a/packages/client/src/components/app/forms/DateTimeField.svelte
+++ b/packages/client/src/components/app/forms/DateTimeField.svelte
@@ -8,13 +8,13 @@
   export let disabled = false
   export let enableTime = false
   export let timeOnly = false
+  export let ignoreTimezones = false
   export let validation
   export let defaultValue
   export let onChange
 
   let fieldState
   let fieldApi
-  let fieldSchema
 
   const handleChange = e => {
     fieldApi.setValue(e.detail)
@@ -33,7 +33,6 @@
   type="datetime"
   bind:fieldState
   bind:fieldApi
-  bind:fieldSchema
 >
   {#if fieldState}
     <CoreDatePicker
@@ -45,8 +44,8 @@
       appendTo={document.getElementById("flatpickr-root")}
       {enableTime}
       {timeOnly}
+      {ignoreTimezones}
       {placeholder}
-      ignoreTimezones={fieldSchema?.ignoreTimezones}
     />
   {/if}
 </Field>

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -29,7 +29,10 @@ import { breakExternalTableId, isSQL } from "../../../integrations/utils"
 import { processObjectSync } from "@budibase/string-templates"
 // @ts-ignore
 import { cloneDeep } from "lodash/fp"
-import { processFormulas } from "../../../utilities/rowProcessor/utils"
+import {
+  processFormulas,
+  processDates,
+} from "../../../utilities/rowProcessor/utils"
 // @ts-ignore
 import { getAppDB } from "@budibase/backend-core/context"
 
@@ -434,7 +437,13 @@ module External {
           relationships
         )
       }
-      return processFormulas(table, Object.values(finalRows)).map((row: Row) =>
+
+      // Process some additional data types
+      let finalRowArray = Object.values(finalRows)
+      finalRowArray = processDates(table, finalRowArray)
+      finalRowArray = processFormulas(table, finalRowArray)
+
+      return finalRowArray.map((row: Row) =>
         this.squashRelationshipColumns(table, row, relationships)
       )
     }

--- a/packages/server/src/definitions/common.ts
+++ b/packages/server/src/definitions/common.ts
@@ -25,6 +25,7 @@ export interface FieldSchema {
   formula?: string
   formulaType?: string
   main?: boolean
+  ignoreTimezones?: boolean
   meta?: {
     toTable: string
     toKey: string

--- a/packages/server/src/integrations/base/sqlTable.ts
+++ b/packages/server/src/integrations/base/sqlTable.ts
@@ -61,7 +61,9 @@ function generateSchema(
         schema.boolean(key)
         break
       case FieldTypes.DATETIME:
-        schema.datetime(key)
+        schema.datetime(key, {
+          useTz: !column.ignoreTimezones,
+        })
         break
       case FieldTypes.ARRAY:
         schema.json(key)

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -136,7 +136,11 @@ module MySQLModule {
       this.config = {
         ...config,
         typeCast: function (field: any, next: any) {
-          if (field.type == "DATETIME") {
+          if (
+            field.type == "DATETIME" ||
+            field.type === "DATE" ||
+            field.type === "TIMESTAMP"
+          ) {
             return field.string()
           }
           return next()

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -15,7 +15,6 @@ import {
 } from "./utils"
 import { DatasourcePlus } from "./base/datasourcePlus"
 import dayjs from "dayjs"
-import { FieldTypes } from "../constants"
 const { NUMBER_REGEX } = require("../utilities")
 
 module MySQLModule {
@@ -30,6 +29,7 @@ module MySQLModule {
     database: string
     ssl?: { [key: string]: any }
     rejectUnauthorized: boolean
+    typeCast: Function
   }
 
   const SCHEMA: Integration = {
@@ -89,6 +89,8 @@ module MySQLModule {
     },
   }
 
+  const TimezoneAwareDateTypes = ["timestamp"]
+
   function bindingTypeCoerce(bindings: any[]) {
     for (let i = 0; i < bindings.length; i++) {
       const binding = bindings[i]
@@ -131,7 +133,15 @@ module MySQLModule {
       }
       // @ts-ignore
       delete config.rejectUnauthorized
-      this.config = config
+      this.config = {
+        ...config,
+        typeCast: function (field: any, next: any) {
+          if (field.type == "DATETIME") {
+            return field.string()
+          }
+          return next()
+        },
+      }
     }
 
     getBindingIdentifier(): string {

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -22,8 +22,9 @@ module PostgresModule {
 
   // Return "date" and "timestamp" types as plain strings.
   // This lets us reference the original stored timezone.
-  types.setTypeParser(1114, (val: any) => val)
-  types.setTypeParser(1082, (val: any) => val)
+  types.setTypeParser(1114, (val: any) => val) // timestamp
+  types.setTypeParser(1082, (val: any) => val) // date
+  types.setTypeParser(1184, (val: any) => val) // timestampz
 
   const JSON_REGEX = /'{.*}'::json/s
 

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -16,9 +16,14 @@ import {
 import { DatasourcePlus } from "./base/datasourcePlus"
 
 module PostgresModule {
-  const { Client } = require("pg")
+  const { Client, types } = require("pg")
   const Sql = require("./base/sql")
   const { escapeDangerousCharacters } = require("../utilities")
+
+  // Return "date" and "timestamp" types as plain strings.
+  // This lets us reference the original stored timezone.
+  types.setTypeParser(1114, (val: any) => val)
+  types.setTypeParser(1082, (val: any) => val)
 
   const JSON_REGEX = /'{.*}'::json/s
 

--- a/packages/server/src/utilities/rowProcessor/index.js
+++ b/packages/server/src/utilities/rowProcessor/index.js
@@ -2,11 +2,7 @@ const linkRows = require("../../db/linkedRows")
 const { cloneDeep } = require("lodash/fp")
 const { FieldTypes, AutoFieldSubTypes } = require("../../constants")
 const { attachmentsRelativeURL } = require("../index")
-const {
-  processFormulas,
-  processDates,
-  fixAutoColumnSubType,
-} = require("./utils")
+const { processFormulas, fixAutoColumnSubType } = require("./utils")
 const { deleteFiles } = require("../../utilities/fileSystem/utilities")
 const { ObjectStoreBuckets } = require("../../constants")
 const {
@@ -277,9 +273,6 @@ exports.outputProcessing = async (table, rows, opts = { squash: true }) => {
 
   // process formulas
   enriched = processFormulas(table, enriched, { dynamic: true })
-
-  // process non timezone aware dates
-  enriched = processDates(table, enriched)
 
   // update the attachments URL depending on hosting
   for (let [property, column] of Object.entries(table.schema)) {

--- a/packages/server/src/utilities/rowProcessor/index.js
+++ b/packages/server/src/utilities/rowProcessor/index.js
@@ -2,7 +2,11 @@ const linkRows = require("../../db/linkedRows")
 const { cloneDeep } = require("lodash/fp")
 const { FieldTypes, AutoFieldSubTypes } = require("../../constants")
 const { attachmentsRelativeURL } = require("../index")
-const { processFormulas, fixAutoColumnSubType } = require("./utils")
+const {
+  processFormulas,
+  processDates,
+  fixAutoColumnSubType,
+} = require("./utils")
 const { deleteFiles } = require("../../utilities/fileSystem/utilities")
 const { ObjectStoreBuckets } = require("../../constants")
 const {
@@ -273,6 +277,9 @@ exports.outputProcessing = async (table, rows, opts = { squash: true }) => {
 
   // process formulas
   enriched = processFormulas(table, enriched, { dynamic: true })
+
+  // process non timezone aware dates
+  enriched = processDates(table, enriched)
 
   // update the attachments URL depending on hosting
   for (let [property, column] of Object.entries(table.schema)) {

--- a/packages/server/src/utilities/rowProcessor/utils.js
+++ b/packages/server/src/utilities/rowProcessor/utils.js
@@ -84,7 +84,6 @@ exports.processDates = (table, rows) => {
   for (let row of rows) {
     for (let col of datesWithTZ) {
       if (row[col] && typeof row[col] === "string" && !row[col].endsWith("Z")) {
-        console.log(col, "needs converted to UTC!")
         row[col] = new Date(row[col]).toISOString()
       }
     }


### PR DESCRIPTION
## Description
This PR adds the ability to use dates/timestamps without timezones. This is a really messy topic so there are some caveats and limitations here. This should be fully backwards compatible. There should be no change to existing apps unless you enable this new feature.

Targetting develop as this definitely requires some more manual testing before release. I've tested this as much as possible with multiple server/client/database timezones and multiple database types but I doubt I have accounted for all permutations.

Addresses #1504.

## Other new features
- When generating auto screens or generating form fields inside a field group, all date field metadata (such as "date only", "time only", and the new "ignore time zones" flag) are correctly honoured and passed into the date form fields
- When creating dates through Budibase, we know inform knex whether we wish to use timezone awareness or not. This lets knex pick more accurate underlying types in external databases when creating columns.

## Limitations
- This only works with datasource plus tables (i.e. internal tables, or SQL tables)
- For external SQL tables, this only works with Postgres and MySQL. SQL server and Oracle are not supported. You can read more about why at the bottom of this PR.
- This only works automatically when using date pickers. If you use JS bindings to edit dates before sending them to the server, you must ensure you send up the correct ISO 8601 string *without a timezone suffix*.
- It is possible, but not recommended, to change the "ignore timezones" flag on tables that already have data. Changing this flag does not change existing data, but it will change how your existing data is presented in the browser.
- Not a limitiation as much as a design decision, but this new flag is never set when importing external tables. If you are using non-timezone-aware types, you must edit your columns after import and mark them as such.

## New ignore timezones flag
When creating a new date field in Budibase, or editing an existing one, a new option called "Ignore time zones" is available.

![image](https://user-images.githubusercontent.com/9075550/172187916-3c917921-384b-473d-a6c6-9452367f46d2.png)

When this option is checked, the values selected in date pickers will be represented exactly as they are in the target database. There is no UTC conversion performed by Budibase - but there may be (transparent) UTC conversion done at the database level in certain circumstances (e.g. a `timestamp` in MySQL). Regardless of the timezone the browser is in, you will always see the same exact timestamp when this option is selected. 

As an example, here is a snippet of a table where I changed my browsers locale to 3 different timezones and picked the time `12:00` in each. You can see that the column "BB no timezone" (which has this new option set) will always show the same time time, whereas the "BB normal" column (a normal date/time without this flag) is using UTC conversion and relative dates that do change as the browser timezone changes.

![image](https://user-images.githubusercontent.com/9075550/172188609-974dec81-f0ca-4011-9108-d11ac51f164e.png)

## Detail around limitations
### Frontend support
The reason frontend support is required for this feature is that the server is not aware of the client's timezone. If the server was aware of the client's timezone then the frontend could be entirely agnostic of this feature, and could continue to send up UTC timestamps, which could then be converted as required on the server. Since we do not know the client's timezone. we depend on the client sending up a timestamp string which is already formatted in their timezone. We then must ensure this string is preserved right until it is written into the database, and never converted into a date object during server processing.

### SQL server
SQL server is not supported as the `mssql` node library (the underlying driver used by knex when connecting to a SQL server DB) does not support custom type casting. In order for this feature to work we need to be able to retrieve dates as strings from databases. By default knex parses all date types into JS date objects, but this prevents us from being able to preserve the original timezone as that data is effectively lost as soon as it is parsed into a date object.

As we cannot do custom type casting with `mssql`, we cannot support ignoring timezones for SQL server databases as knex will always parse dates as objects.

### Oracle
Oracle is not supported as we cannot write date values as strings through knex into Oracle databases. Oracle requires a specific date format when writing dates. This format can be customised and specifed per connection, and this is handled by knex. As we have no awareness above knex of the date format being used, we must pass dates as real date objects into knex, which will itself correctly serialise these into the correct string format before saving them to the DB.

As we cannot control and do not know this format, we cannot support ignoring timezones as the standard ISO 8601 format without timezone that we use to support this feature is considered an illegal format. And once again, we cannot pass in literal date objects to knex as it will either convert them to UTC or parse them in the servers timezone - but neither will preserve the original timezone.

## Future work
- "Time only" should really be removed as an option
- "Date only" should be an exposed schema-level setting rather than a presentational setting on date pickers. It's already a schema-level property, but only when importing external tables
