### PR TITLE
Dates without timezones (master)

### DIFF
--- a/packages/bbui/src/Form/DatePicker.svelte
+++ b/packages/bbui/src/Form/DatePicker.svelte
@@ -12,6 +12,7 @@
   export let timeOnly = false
   export let placeholder = null
   export let appendTo = undefined
+  export let ignoreTimezones = false
 
   const dispatch = createEventDispatcher()
 
@@ -30,6 +31,7 @@
     {enableTime}
     {timeOnly}
     {appendTo}
+    {ignoreTimezones}
     on:change={onChange}
   />
 </Field>

--- a/packages/bbui/src/Tooltip/TooltipWrapper.svelte
+++ b/packages/bbui/src/Tooltip/TooltipWrapper.svelte
@@ -39,7 +39,6 @@
     position: relative;
     display: flex;
     justify-content: center;
-    margin-top: 1px;
     margin-left: 5px;
     margin-right: 5px;
   }

--- a/packages/builder/src/builderStore/store/screenTemplates/utils/commonComponents.js
+++ b/packages/builder/src/builderStore/store/screenTemplates/utils/commonComponents.js
@@ -170,28 +170,29 @@ export function makeDatasourceFormComponents(datasource) {
           optionsType: "select",
           optionsSource: "schema",
         })
-      }
-      if (fieldType === "longform") {
+      } else if (fieldType === "longform") {
         component.customProps({
           format: "auto",
         })
-      }
-      if (fieldType === "array") {
+      } else if (fieldType === "array") {
         component.customProps({
           placeholder: "Choose an option",
           optionsSource: "schema",
         })
-      }
-
-      if (fieldType === "link") {
+      } else if (fieldType === "link") {
         let placeholder =
           fieldSchema.relationshipType === "one-to-many"
             ? "Choose an option"
             : "Choose some options"
         component.customProps({ placeholder })
-      }
-      if (fieldType === "boolean") {
+      } else if (fieldType === "boolean") {
         component.customProps({ text: field, label: "" })
+      } else if (fieldType === "datetime") {
+        component.customProps({
+          enableTime: !fieldSchema?.dateOnly,
+          timeOnly: fieldSchema?.timeOnly,
+          ignoreTimezones: fieldSchema.ignoreTimezones,
+        })
       }
       components.push(component)
     }

--- a/packages/builder/src/components/backend/DataTable/RowFieldControl.svelte
+++ b/packages/builder/src/components/backend/DataTable/RowFieldControl.svelte
@@ -53,6 +53,7 @@
     {label}
     timeOnly={isTimeStamp}
     enableTime={!meta?.dateOnly}
+    ignoreTimezones={meta?.ignoreTimezones}
     bind:value
   />
 {:else if type === "attachment"}

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -14,7 +14,7 @@
   } from "@budibase/bbui"
   import { createEventDispatcher, onMount } from "svelte"
   import { cloneDeep } from "lodash/fp"
-  import { tables } from "stores/backend"
+  import { tables, datasources } from "stores/backend"
   import { TableNames, UNEDITABLE_USER_FIELDS } from "constants"
   import {
     FIELDS,
@@ -63,6 +63,7 @@
   let primaryDisplay =
     $tables.selected.primaryDisplay == null ||
     $tables.selected.primaryDisplay === field.name
+  let isCreating = originalName == null
 
   let table = $tables.selected
   let indexes = [...($tables.selected.indexes || [])]
@@ -81,6 +82,9 @@
     (field.type === LINK_TYPE && !field.tableId) ||
     Object.keys(errors).length !== 0
   $: errors = checkErrors(field)
+  $: datasource = $datasources.list.find(
+    source => source._id === table?.sourceId
+  )
 
   // used to select what different options can be displayed for column type
   $: canBeSearched =
@@ -430,6 +434,18 @@
       bind:value={field.constraints.datetime.earliest}
     />
     <DatePicker label="Latest" bind:value={field.constraints.datetime.latest} />
+    {#if datasource?.source !== "ORACLE" && datasource?.source !== "SQL_SERVER"}
+      <div>
+        <Label
+          tooltip={isCreating
+            ? null
+            : "We recommend not changing how timezones are handled for existing columns, as existing data will not be updated"}
+        >
+          Time zones
+        </Label>
+        <Toggle bind:value={field.ignoreTimezones} text="Ignore time zones" />
+      </div>
+    {/if}
   {:else if field.type === "number"}
     <Input
       type="number"

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -2620,14 +2620,20 @@
       },
       {
         "type": "boolean",
-        "label": "Show Time",
+        "label": "Show time",
         "key": "enableTime",
         "defaultValue": true
       },
       {
         "type": "boolean",
-        "label": "Time Only",
+        "label": "Time only",
         "key": "timeOnly",
+        "defaultValue": false
+      },
+      {
+        "type": "boolean",
+        "label": "Ignore time zones",
+        "key": "ignoreTimezones",
         "defaultValue": false
       },
       {

--- a/packages/client/src/components/app/forms/DateTimeField.svelte
+++ b/packages/client/src/components/app/forms/DateTimeField.svelte
@@ -8,6 +8,7 @@
   export let disabled = false
   export let enableTime = false
   export let timeOnly = false
+  export let ignoreTimezones = false
   export let validation
   export let defaultValue
   export let onChange
@@ -43,6 +44,7 @@
       appendTo={document.getElementById("flatpickr-root")}
       {enableTime}
       {timeOnly}
+      {ignoreTimezones}
       {placeholder}
     />
   {/if}

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -29,7 +29,10 @@ import { breakExternalTableId, isSQL } from "../../../integrations/utils"
 import { processObjectSync } from "@budibase/string-templates"
 // @ts-ignore
 import { cloneDeep } from "lodash/fp"
-import { processFormulas } from "../../../utilities/rowProcessor/utils"
+import {
+  processFormulas,
+  processDates,
+} from "../../../utilities/rowProcessor/utils"
 // @ts-ignore
 import { getAppDB } from "@budibase/backend-core/context"
 
@@ -434,7 +437,13 @@ module External {
           relationships
         )
       }
-      return processFormulas(table, Object.values(finalRows)).map((row: Row) =>
+
+      // Process some additional data types
+      let finalRowArray = Object.values(finalRows)
+      finalRowArray = processDates(table, finalRowArray)
+      finalRowArray = processFormulas(table, finalRowArray)
+
+      return finalRowArray.map((row: Row) =>
         this.squashRelationshipColumns(table, row, relationships)
       )
     }

--- a/packages/server/src/definitions/common.ts
+++ b/packages/server/src/definitions/common.ts
@@ -25,6 +25,7 @@ export interface FieldSchema {
   formula?: string
   formulaType?: string
   main?: boolean
+  ignoreTimezones?: boolean
   meta?: {
     toTable: string
     toKey: string

--- a/packages/server/src/integrations/base/sqlTable.ts
+++ b/packages/server/src/integrations/base/sqlTable.ts
@@ -61,7 +61,9 @@ function generateSchema(
         schema.boolean(key)
         break
       case FieldTypes.DATETIME:
-        schema.datetime(key)
+        schema.datetime(key, {
+          useTz: !column.ignoreTimezones,
+        })
         break
       case FieldTypes.ARRAY:
         schema.json(key)

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -16,9 +16,15 @@ import {
 import { DatasourcePlus } from "./base/datasourcePlus"
 
 module PostgresModule {
-  const { Client } = require("pg")
+  const { Client, types } = require("pg")
   const Sql = require("./base/sql")
   const { escapeDangerousCharacters } = require("../utilities")
+
+  // Return "date" and "timestamp" types as plain strings.
+  // This lets us reference the original stored timezone.
+  types.setTypeParser(1114, (val: any) => val) // timestamp
+  types.setTypeParser(1082, (val: any) => val) // date
+  types.setTypeParser(1184, (val: any) => val) // timestampz
 
   const JSON_REGEX = /'{.*}'::json/s
 

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -22,9 +22,12 @@ module PostgresModule {
 
   // Return "date" and "timestamp" types as plain strings.
   // This lets us reference the original stored timezone.
-  types.setTypeParser(1114, (val: any) => val) // timestamp
-  types.setTypeParser(1082, (val: any) => val) // date
-  types.setTypeParser(1184, (val: any) => val) // timestampz
+  // types is undefined when running in a test env for some reason.
+  if (types) {
+    types.setTypeParser(1114, (val: any) => val) // timestamp
+    types.setTypeParser(1082, (val: any) => val) // date
+    types.setTypeParser(1184, (val: any) => val) // timestampz
+  }
 
   const JSON_REGEX = /'{.*}'::json/s
 

--- a/packages/server/src/utilities/rowProcessor/utils.js
+++ b/packages/server/src/utilities/rowProcessor/utils.js
@@ -65,3 +65,28 @@ exports.processFormulas = (
   }
   return single ? rows[0] : rows
 }
+
+/**
+ * Processes any date columns and ensures that those without the ignoreTimezones
+ * flag set are parsed as UTC rather than local time.
+ */
+exports.processDates = (table, rows) => {
+  let datesWithTZ = []
+  for (let [column, schema] of Object.entries(table.schema)) {
+    if (schema.type !== FieldTypes.DATETIME) {
+      continue
+    }
+    if (!schema.ignoreTimezones) {
+      datesWithTZ.push(column)
+    }
+  }
+
+  for (let row of rows) {
+    for (let col of datesWithTZ) {
+      if (row[col] && typeof row[col] === "string" && !row[col].endsWith("Z")) {
+        row[col] = new Date(row[col]).toISOString()
+      }
+    }
+  }
+  return rows
+}

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -1014,10 +1014,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.194":
-  version "1.0.194"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.194.tgz#08b2b1aec3c88efbc7cfb14145ce6f199475c538"
-  integrity sha512-BbnJFtAioJeD9tQfSwc2uftFK8SagREgSfUYv06dfnf/NsmkrONzZiTon1oA57S7ifcSiu+WZf87lNX0k8pwfQ==
+"@budibase/backend-core@1.0.195":
+  version "1.0.195"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.195.tgz#ee40c690ae4a54febab8b140c9bbb7d04221f3b9"
+  integrity sha512-6diWgRV9t4DU3kXteJJAhCxyta9m1wvzN7vNbflhY4kYJeg7BC+7jcvc2r8zl6s1vVeSW4ic5/ueSLRaTDySuw==
   dependencies:
     "@techpass/passport-openidconnect" "^0.3.0"
     aws-sdk "^2.901.0"
@@ -1092,12 +1092,12 @@
     svelte-flatpickr "^3.2.3"
     svelte-portal "^1.0.0"
 
-"@budibase/pro@1.0.194":
-  version "1.0.194"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.194.tgz#fbf977b292b9a6dbf7b072b2e0379dcf4379943a"
-  integrity sha512-LSqVwlhKWwFNnC3acvLnCzbeBoze1Ma6GELE/b5ZxS65owsigu0KC6T/UuujEbU9xqbFJ3R6uV+4Fz4NUibLIw==
+"@budibase/pro@1.0.195":
+  version "1.0.195"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.195.tgz#368652398d1da95f160fc0192b77144b11147ff5"
+  integrity sha512-zf1f1exHop4m6vda5hObUnTZa2PIBRnc4e0r9iqFbzvGBMfBLGUhGzu23JEwNYaS2xhWHj2FNv4/IVzIyLG4eA==
   dependencies:
-    "@budibase/backend-core" "1.0.194"
+    "@budibase/backend-core" "1.0.195"
     node-fetch "^2.6.1"
 
 "@budibase/standard-components@^0.9.139":

--- a/packages/worker/yarn.lock
+++ b/packages/worker/yarn.lock
@@ -293,10 +293,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.194":
-  version "1.0.194"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.194.tgz#08b2b1aec3c88efbc7cfb14145ce6f199475c538"
-  integrity sha512-BbnJFtAioJeD9tQfSwc2uftFK8SagREgSfUYv06dfnf/NsmkrONzZiTon1oA57S7ifcSiu+WZf87lNX0k8pwfQ==
+"@budibase/backend-core@1.0.195":
+  version "1.0.195"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.195.tgz#ee40c690ae4a54febab8b140c9bbb7d04221f3b9"
+  integrity sha512-6diWgRV9t4DU3kXteJJAhCxyta9m1wvzN7vNbflhY4kYJeg7BC+7jcvc2r8zl6s1vVeSW4ic5/ueSLRaTDySuw==
   dependencies:
     "@techpass/passport-openidconnect" "^0.3.0"
     aws-sdk "^2.901.0"
@@ -322,12 +322,12 @@
     uuid "^8.3.2"
     zlib "^1.0.5"
 
-"@budibase/pro@1.0.194":
-  version "1.0.194"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.194.tgz#fbf977b292b9a6dbf7b072b2e0379dcf4379943a"
-  integrity sha512-LSqVwlhKWwFNnC3acvLnCzbeBoze1Ma6GELE/b5ZxS65owsigu0KC6T/UuujEbU9xqbFJ3R6uV+4Fz4NUibLIw==
+"@budibase/pro@1.0.195":
+  version "1.0.195"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.195.tgz#368652398d1da95f160fc0192b77144b11147ff5"
+  integrity sha512-zf1f1exHop4m6vda5hObUnTZa2PIBRnc4e0r9iqFbzvGBMfBLGUhGzu23JEwNYaS2xhWHj2FNv4/IVzIyLG4eA==
   dependencies:
-    "@budibase/backend-core" "1.0.194"
+    "@budibase/backend-core" "1.0.195"
     node-fetch "^2.6.1"
 
 "@cspotcode/source-map-consumer@0.8.0":


### PR DESCRIPTION
The original branch was based off develop and rebasing to be off master was impossible because every single commit caused conflicts due to our automated package versioning. The only option was to create a patch from the original branch and apply it to a new branch off master.

## Description
This PR adds the ability to use dates/timestamps without timezones. This is a really messy topic so there are some caveats and limitations here. This should be fully backwards compatible. There should be no change to existing apps unless you enable this new feature.

Targetting develop as this definitely requires some more manual testing before release. I've tested this as much as possible with multiple server/client/database timezones and multiple database types but I doubt I have accounted for all permutations.

Addresses #1504.

## Other new features
- When generating auto screens or generating form fields inside a field group, all date field metadata (such as "date only", "time only", and the new "ignore time zones" flag) are correctly honoured and passed into the date form fields
- When creating dates through Budibase, we know inform knex whether we wish to use timezone awareness or not. This lets knex pick more accurate underlying types in external databases when creating columns.

## Limitations
- This only works with datasource plus tables (i.e. internal tables, or SQL tables)
- For external SQL tables, this only works with Postgres and MySQL. SQL server and Oracle are not supported. You can read more about why at the bottom of this PR.
- This only works automatically when using date pickers. If you use JS bindings to edit dates before sending them to the server, you must ensure you send up the correct ISO 8601 string *without a timezone suffix*.
- It is possible, but not recommended, to change the "ignore timezones" flag on tables that already have data. Changing this flag does not change existing data, but it will change how your existing data is presented in the browser.
- Not a limitiation as much as a design decision, but this new flag is never set when importing external tables. If you are using non-timezone-aware types, you must edit your columns after import and mark them as such.

## New ignore timezones flag
When creating a new date field in Budibase, or editing an existing one, a new option called "Ignore time zones" is available.

![image](https://user-images.githubusercontent.com/9075550/172187916-3c917921-384b-473d-a6c6-9452367f46d2.png)

When this option is checked, the values selected in date pickers will be represented exactly as they are in the target database. There is no UTC conversion performed by Budibase - but there may be (transparent) UTC conversion done at the database level in certain circumstances (e.g. a `timestamp` in MySQL). Regardless of the timezone the browser is in, you will always see the same exact timestamp when this option is selected. 

As an example, here is a snippet of a table where I changed my browsers locale to 3 different timezones and picked the time `12:00` in each. You can see that the column "BB no timezone" (which has this new option set) will always show the same time time, whereas the "BB normal" column (a normal date/time without this flag) is using UTC conversion and relative dates that do change as the browser timezone changes.

![image](https://user-images.githubusercontent.com/9075550/172188609-974dec81-f0ca-4011-9108-d11ac51f164e.png)

## Detail around limitations
### Frontend support
The reason frontend support is required for this feature is that the server is not aware of the client's timezone. If the server was aware of the client's timezone then the frontend could be entirely agnostic of this feature, and could continue to send up UTC timestamps, which could then be converted as required on the server. Since we do not know the client's timezone. we depend on the client sending up a timestamp string which is already formatted in their timezone. We then must ensure this string is preserved right until it is written into the database, and never converted into a date object during server processing.

### SQL server
SQL server is not supported as the `mssql` node library (the underlying driver used by knex when connecting to a SQL server DB) does not support custom type casting. In order for this feature to work we need to be able to retrieve dates as strings from databases. By default knex parses all date types into JS date objects, but this prevents us from being able to preserve the original timezone as that data is effectively lost as soon as it is parsed into a date object.

As we cannot do custom type casting with `mssql`, we cannot support ignoring timezones for SQL server databases as knex will always parse dates as objects.

### Oracle
Oracle is not supported as we cannot write date values as strings through knex into Oracle databases. Oracle requires a specific date format when writing dates. This format can be customised and specifed per connection, and this is handled by knex. As we have no awareness above knex of the date format being used, we must pass dates as real date objects into knex, which will itself correctly serialise these into the correct string format before saving them to the DB.

As we cannot control and do not know this format, we cannot support ignoring timezones as the standard ISO 8601 format without timezone that we use to support this feature is considered an illegal format. And once again, we cannot pass in literal date objects to knex as it will either convert them to UTC or parse them in the servers timezone - but neither will preserve the original timezone.

## Future work
- "Time only" should really be removed as an option
- "Date only" should be an exposed schema-level setting rather than a presentational setting on date pickers. It's already a schema-level property, but only when importing external tables
