### PR TITLE
Handle null values when filtering rows

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/TestPanel.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/TestPanel.svelte
@@ -67,7 +67,7 @@
               <Tab title="Input">
                 <div style="padding: 10px 10px 10px 10px;">
                   <TextArea
-                    minHeight="80px"
+                    minHeight="150px"
                     disabled
                     value={JSON.stringify(testResults?.[idx]?.inputs, null, 2)}
                   />
@@ -76,7 +76,7 @@
               <Tab title="Output">
                 <div style="padding: 10px 10px 10px 10px;">
                   <TextArea
-                    minHeight="100px"
+                    minHeight="150px"
                     disabled
                     value={JSON.stringify(testResults?.[idx]?.outputs, null, 2)}
                   />

--- a/packages/server/src/api/controllers/row/internalSearch.js
+++ b/packages/server/src/api/controllers/row/internalSearch.js
@@ -304,6 +304,26 @@ const recursiveSearch = async (query, params) => {
   if (rows.length > params.limit - 200) {
     pageSize = params.limit - rows.length
   }
+
+  /*
+  If a null value is passed to a filter expression, we currently return 
+  every row, this can and has resulted in data loss via automation loops etc.
+  So here we are checking if any null values exist in the filters, and if they do
+  just return an empty rows array.
+  */
+  let nullValuesExist = false
+  Object.keys(query).forEach(key => {
+    Object.values(query[key]).forEach(innerVal => {
+      if (innerVal === "" || innerVal === null) {
+        nullValuesExist = true
+      }
+    })
+  })
+
+  if (nullValuesExist) {
+    return rows
+  }
+
   const page = await new QueryBuilder(query)
     .setVersion(params.version)
     .setTable(params.tableId)


### PR DESCRIPTION
## Description
Users who tried to use a filter, that included a null or empty value would end up returning every value in that specific table. 

i.e a filter like this 
![image](https://user-images.githubusercontent.com/5665926/172331323-418f9ab7-86ef-4a7b-811d-98abbb7dc56c.png)

Where the value is empty, or the handlebars or JS expression returns a null value this will return every row in the queried table, this was previously an issue, but has became even more so with the introduction of the loop block, where you can do some serious damage by including a delete row block after a query block whose filter returns null. i.e, delete an entire table. 

This addresses it by returning an empty array if any of the filters in the lucene expression are null. 

Addresses: 
#6013 



n.b also snuck a change in here to increase the size of the automation test panel text box sizes. 


