### PR TITLE
Use execute v2 in External Data Connector automation step

### DIFF
--- a/packages/server/src/automations/steps/executeQuery.js
+++ b/packages/server/src/automations/steps/executeQuery.js
@@ -72,7 +72,7 @@ exports.run = async function ({ inputs, appId, emitter }) {
   })
 
   try {
-    await queryController.executeV1(ctx)
+    await queryController.executeV2(ctx)
     const { data, ...rest } = ctx.body
     return {
       response: data,

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -1014,10 +1014,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.197":
-  version "1.0.197"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.197.tgz#3458d70c6d44376b7930672d6af8c6e89ddf4069"
-  integrity sha512-Cgzr1bJWKRg3+jqte7rnKPziWiH5Q+r/piRvHuD7EVmh2+xJLfWUz9iml72aFfcgRIOX8SyhejG7KTwxILx/vg==
+"@budibase/backend-core@1.0.198":
+  version "1.0.198"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.198.tgz#4b9a4dc4dabc73da31b5f95e38c6cfd2c87bfd09"
+  integrity sha512-IYTY3yuZQ0YVFy4v9zqX0L3ZhFowzY40DgthfbdCbdwHiaoLFpSi0+ynLHxholz3a7eCTcW6M5a3dHqy4kXtIQ==
   dependencies:
     "@techpass/passport-openidconnect" "^0.3.0"
     aws-sdk "^2.901.0"
@@ -1092,12 +1092,12 @@
     svelte-flatpickr "^3.2.3"
     svelte-portal "^1.0.0"
 
-"@budibase/pro@1.0.197":
-  version "1.0.197"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.197.tgz#a171b46bb8ee6251881ae9262136270533b3958d"
-  integrity sha512-SCVKjNgpzefmrXnLmkpQJLvYViykyzA6B9TwL7qrb6fBeXwAiSZ3hXGjNgZkVpy/v43hccPWt9BJFzFp457wgQ==
+"@budibase/pro@1.0.198":
+  version "1.0.198"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.198.tgz#b585e269e12317ede722e2b3814329bc63b60185"
+  integrity sha512-ow3R2MZZKwTsAZQ8knPQsVdzS28frAP5/csj0rW1O53mOsVu6K5LZLJMlZ72cLsLDZPHKtAku7Xgb+b+YWtbvA==
   dependencies:
-    "@budibase/backend-core" "1.0.197"
+    "@budibase/backend-core" "1.0.198"
     node-fetch "^2.6.1"
 
 "@budibase/standard-components@^0.9.139":

--- a/packages/worker/yarn.lock
+++ b/packages/worker/yarn.lock
@@ -293,10 +293,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.197":
-  version "1.0.197"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.197.tgz#3458d70c6d44376b7930672d6af8c6e89ddf4069"
-  integrity sha512-Cgzr1bJWKRg3+jqte7rnKPziWiH5Q+r/piRvHuD7EVmh2+xJLfWUz9iml72aFfcgRIOX8SyhejG7KTwxILx/vg==
+"@budibase/backend-core@1.0.198":
+  version "1.0.198"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.198.tgz#4b9a4dc4dabc73da31b5f95e38c6cfd2c87bfd09"
+  integrity sha512-IYTY3yuZQ0YVFy4v9zqX0L3ZhFowzY40DgthfbdCbdwHiaoLFpSi0+ynLHxholz3a7eCTcW6M5a3dHqy4kXtIQ==
   dependencies:
     "@techpass/passport-openidconnect" "^0.3.0"
     aws-sdk "^2.901.0"
@@ -322,12 +322,12 @@
     uuid "^8.3.2"
     zlib "^1.0.5"
 
-"@budibase/pro@1.0.197":
-  version "1.0.197"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.197.tgz#a171b46bb8ee6251881ae9262136270533b3958d"
-  integrity sha512-SCVKjNgpzefmrXnLmkpQJLvYViykyzA6B9TwL7qrb6fBeXwAiSZ3hXGjNgZkVpy/v43hccPWt9BJFzFp457wgQ==
+"@budibase/pro@1.0.198":
+  version "1.0.198"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.198.tgz#b585e269e12317ede722e2b3814329bc63b60185"
+  integrity sha512-ow3R2MZZKwTsAZQ8knPQsVdzS28frAP5/csj0rW1O53mOsVu6K5LZLJMlZ72cLsLDZPHKtAku7Xgb+b+YWtbvA==
   dependencies:
-    "@budibase/backend-core" "1.0.197"
+    "@budibase/backend-core" "1.0.198"
     node-fetch "^2.6.1"
 
 "@cspotcode/source-map-consumer@0.8.0":


### PR DESCRIPTION
## Description
The old response was an object, where each row was index key (see issue)
Now using new execute endpoint to return query response in array format.

Addresses: 
- https://github.com/Budibase/budibase/issues/5912
- https://github.com/Budibase/budibase/issues/6003

## Screenshots
![Screenshot 2022-06-09 at 11 18 19](https://user-images.githubusercontent.com/101575380/172824626-45986077-f15c-485f-ab20-b3ea1465ed6b.png)




