### PR TITLE
Fix newline bug for Firebase private key

### DIFF
--- a/packages/server/src/integrations/firebase.ts
+++ b/packages/server/src/integrations/firebase.ts
@@ -95,7 +95,7 @@ module Firebase {
         projectId: config.projectId,
         credentials: {
           client_email: config.email,
-          private_key: config.privateKey,
+          private_key: config.privateKey?.replace(/\\n/g, "\n"),
         },
       })
     }

--- a/packages/server/src/integrations/firebase.ts
+++ b/packages/server/src/integrations/firebase.ts
@@ -11,7 +11,6 @@ module Firebase {
     email: string
     privateKey: string
     projectId: string
-    serviceAccount?: string
   }
 
   const SCHEMA: Integration = {
@@ -31,10 +30,6 @@ module Firebase {
       projectId: {
         type: DatasourceFieldTypes.STRING,
         required: true,
-      },
-      serviceAccount: {
-        type: DatasourceFieldTypes.JSON,
-        required: false,
       },
     },
     query: {
@@ -96,24 +91,13 @@ module Firebase {
 
     constructor(config: FirebaseConfig) {
       this.config = config
-      if (config.serviceAccount) {
-        const serviceAccount = JSON.parse(config.serviceAccount)
-        this.client = new Firestore({
-          projectId: serviceAccount.project_id,
-          credentials: {
-            client_email: serviceAccount.client_email,
-            private_key: serviceAccount.private_key,
-          },
-        })
-      } else {
-        this.client = new Firestore({
-          projectId: config.projectId,
-          credentials: {
-            client_email: config.email,
-            private_key: config.privateKey,
-          },
-        })
-      }
+      this.client = new Firestore({
+        projectId: config.projectId,
+        credentials: {
+          client_email: config.email,
+          private_key: config.privateKey,
+        },
+      })
     }
 
     async create(query: { json: object; extra: { [key: string]: string } }) {

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -1014,10 +1014,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.197":
-  version "1.0.197"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.197.tgz#3458d70c6d44376b7930672d6af8c6e89ddf4069"
-  integrity sha512-Cgzr1bJWKRg3+jqte7rnKPziWiH5Q+r/piRvHuD7EVmh2+xJLfWUz9iml72aFfcgRIOX8SyhejG7KTwxILx/vg==
+"@budibase/backend-core@1.0.198":
+  version "1.0.198"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.198.tgz#4b9a4dc4dabc73da31b5f95e38c6cfd2c87bfd09"
+  integrity sha512-IYTY3yuZQ0YVFy4v9zqX0L3ZhFowzY40DgthfbdCbdwHiaoLFpSi0+ynLHxholz3a7eCTcW6M5a3dHqy4kXtIQ==
   dependencies:
     "@techpass/passport-openidconnect" "^0.3.0"
     aws-sdk "^2.901.0"
@@ -1092,12 +1092,12 @@
     svelte-flatpickr "^3.2.3"
     svelte-portal "^1.0.0"
 
-"@budibase/pro@1.0.197":
-  version "1.0.197"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.197.tgz#a171b46bb8ee6251881ae9262136270533b3958d"
-  integrity sha512-SCVKjNgpzefmrXnLmkpQJLvYViykyzA6B9TwL7qrb6fBeXwAiSZ3hXGjNgZkVpy/v43hccPWt9BJFzFp457wgQ==
+"@budibase/pro@1.0.198":
+  version "1.0.198"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.198.tgz#b585e269e12317ede722e2b3814329bc63b60185"
+  integrity sha512-ow3R2MZZKwTsAZQ8knPQsVdzS28frAP5/csj0rW1O53mOsVu6K5LZLJMlZ72cLsLDZPHKtAku7Xgb+b+YWtbvA==
   dependencies:
-    "@budibase/backend-core" "1.0.197"
+    "@budibase/backend-core" "1.0.198"
     node-fetch "^2.6.1"
 
 "@budibase/standard-components@^0.9.139":

--- a/packages/worker/yarn.lock
+++ b/packages/worker/yarn.lock
@@ -293,10 +293,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.197":
-  version "1.0.197"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.197.tgz#3458d70c6d44376b7930672d6af8c6e89ddf4069"
-  integrity sha512-Cgzr1bJWKRg3+jqte7rnKPziWiH5Q+r/piRvHuD7EVmh2+xJLfWUz9iml72aFfcgRIOX8SyhejG7KTwxILx/vg==
+"@budibase/backend-core@1.0.198":
+  version "1.0.198"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.198.tgz#4b9a4dc4dabc73da31b5f95e38c6cfd2c87bfd09"
+  integrity sha512-IYTY3yuZQ0YVFy4v9zqX0L3ZhFowzY40DgthfbdCbdwHiaoLFpSi0+ynLHxholz3a7eCTcW6M5a3dHqy4kXtIQ==
   dependencies:
     "@techpass/passport-openidconnect" "^0.3.0"
     aws-sdk "^2.901.0"
@@ -322,12 +322,12 @@
     uuid "^8.3.2"
     zlib "^1.0.5"
 
-"@budibase/pro@1.0.197":
-  version "1.0.197"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.197.tgz#a171b46bb8ee6251881ae9262136270533b3958d"
-  integrity sha512-SCVKjNgpzefmrXnLmkpQJLvYViykyzA6B9TwL7qrb6fBeXwAiSZ3hXGjNgZkVpy/v43hccPWt9BJFzFp457wgQ==
+"@budibase/pro@1.0.198":
+  version "1.0.198"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.198.tgz#b585e269e12317ede722e2b3814329bc63b60185"
+  integrity sha512-ow3R2MZZKwTsAZQ8knPQsVdzS28frAP5/csj0rW1O53mOsVu6K5LZLJMlZ72cLsLDZPHKtAku7Xgb+b+YWtbvA==
   dependencies:
-    "@budibase/backend-core" "1.0.197"
+    "@budibase/backend-core" "1.0.198"
     node-fetch "^2.6.1"
 
 "@cspotcode/source-map-consumer@0.8.0":


### PR DESCRIPTION
## Description
Authentication was failing because the newline character was being escaped. 
Fixed by replacing '\\\n' with '\n'.
Also removed **ServiceAccount** as this is a confusing property and doesn't save much effort for three fields.

## Screenshots
![Screenshot 2022-06-10 at 14 17 58](https://user-images.githubusercontent.com/101575380/173072751-bdd3c7f9-a338-4a3d-b05e-1731bda4dd41.png)

![Screenshot 2022-06-10 at 14 18 29](https://user-images.githubusercontent.com/101575380/173072893-102b83a8-2fb8-4448-a779-81dc94c40cca.png)




