### PR TITLE
Joi validator update to accommodate 'createdAt' and 'updatedAt'

### DIFF
--- a/packages/server/src/middleware/joi-validator.js
+++ b/packages/server/src/middleware/joi-validator.js
@@ -1,3 +1,5 @@
+const Joi = require("joi")
+
 function validate(schema, property) {
   // Return a Koa middleware function
   return (ctx, next) => {
@@ -10,6 +12,12 @@ function validate(schema, property) {
     } else if (ctx.request[property] != null) {
       params = ctx.request[property]
     }
+
+    schema = schema.append({
+      createdAt: Joi.any().optional(),
+      updatedAt: Joi.any().optional(),
+    })
+
     const { error } = schema.validate(params)
     if (error) {
       ctx.throw(400, `Invalid ${property} - ${error.message}`)


### PR DESCRIPTION
## Description
Minor fix to add 'createdAt' and 'updatedAt' to the Joi validation schema. This is applied globally and both entries are marked as optional.

