### PR TITLE
MongoDB Delete - Add empty options if missing

### DIFF
--- a/packages/server/src/integrations/mongodb.ts
+++ b/packages/server/src/integrations/mongodb.ts
@@ -263,6 +263,12 @@ module MongoDBModule {
           filter: FilterQuery<any>
           options: CommonOptions
         }
+        if (!json.options) {
+          json = {
+            filter: json,
+            options: {},
+          }
+        }
 
         switch (query.extra.actionTypes) {
           case "deleteOne": {

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -1028,10 +1028,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.201-alpha.4":
-  version "1.0.201-alpha.4"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.201-alpha.4.tgz#51fda5838e9c51c88c85204ad867811e49b7d34c"
-  integrity sha512-5oQMfKPDMpB4x5MzGgOtWFIPzc7RG/uu+rSe65PVwWfp77bDa3kxtCtC1p6vtJuPlb4GYrHqGLtr7WePbJf4fA==
+"@budibase/backend-core@1.0.206":
+  version "1.0.206"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.206.tgz#bf9f4153358e3b07c9df1dbc1cc8a100da880699"
+  integrity sha512-WjeWP58GumjW2sHqlsgbYYGi5nEm2oUjqo4UOX5QLKancVPfcKPB7DQal1K9il8vxiiT3ZVNG8XakUGjq2G7Uw==
   dependencies:
     "@techpass/passport-openidconnect" "0.3.2"
     aws-sdk "2.1030.0"
@@ -1109,12 +1109,12 @@
     svelte-flatpickr "^3.2.3"
     svelte-portal "^1.0.0"
 
-"@budibase/pro@1.0.201-alpha.4":
-  version "1.0.201-alpha.4"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.201-alpha.4.tgz#5b92dc7a4bb2004bcd43339c863430ea640e0b74"
-  integrity sha512-fsDlE8O4Y4JpZI3NwBoN8udX4cEx7/ebZ41Q7qD5VwA6Q2niapRcX0MvDmGdjDSVECG+NJU1uqCdg5cDq1Odxw==
+"@budibase/pro@1.0.206":
+  version "1.0.206"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.206.tgz#14343df74106d7bdc7f6e2a396305a06f6e446e5"
+  integrity sha512-SpXUX/xNaNRnDPemvQGe8bmH5yBK6u3TMG60KEBKHTou9OCsEw39x2qy2aHQkMhDFg8YTlfs42fVvhwKJlHbBw==
   dependencies:
-    "@budibase/backend-core" "1.0.201-alpha.4"
+    "@budibase/backend-core" "1.0.206"
     node-fetch "^2.6.1"
 
 "@budibase/standard-components@^0.9.139":

--- a/packages/worker/yarn.lock
+++ b/packages/worker/yarn.lock
@@ -291,10 +291,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.201-alpha.4":
-  version "1.0.201-alpha.4"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.201-alpha.4.tgz#51fda5838e9c51c88c85204ad867811e49b7d34c"
-  integrity sha512-5oQMfKPDMpB4x5MzGgOtWFIPzc7RG/uu+rSe65PVwWfp77bDa3kxtCtC1p6vtJuPlb4GYrHqGLtr7WePbJf4fA==
+"@budibase/backend-core@1.0.206":
+  version "1.0.206"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.206.tgz#bf9f4153358e3b07c9df1dbc1cc8a100da880699"
+  integrity sha512-WjeWP58GumjW2sHqlsgbYYGi5nEm2oUjqo4UOX5QLKancVPfcKPB7DQal1K9il8vxiiT3ZVNG8XakUGjq2G7Uw==
   dependencies:
     "@techpass/passport-openidconnect" "0.3.2"
     aws-sdk "2.1030.0"
@@ -322,12 +322,12 @@
     uuid "8.3.2"
     zlib "1.0.5"
 
-"@budibase/pro@1.0.201-alpha.4":
-  version "1.0.201-alpha.4"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.201-alpha.4.tgz#5b92dc7a4bb2004bcd43339c863430ea640e0b74"
-  integrity sha512-fsDlE8O4Y4JpZI3NwBoN8udX4cEx7/ebZ41Q7qD5VwA6Q2niapRcX0MvDmGdjDSVECG+NJU1uqCdg5cDq1Odxw==
+"@budibase/pro@1.0.206":
+  version "1.0.206"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.206.tgz#14343df74106d7bdc7f6e2a396305a06f6e446e5"
+  integrity sha512-SpXUX/xNaNRnDPemvQGe8bmH5yBK6u3TMG60KEBKHTou9OCsEw39x2qy2aHQkMhDFg8YTlfs42fVvhwKJlHbBw==
   dependencies:
-    "@budibase/backend-core" "1.0.201-alpha.4"
+    "@budibase/backend-core" "1.0.206"
     node-fetch "^2.6.1"
 
 "@cspotcode/source-map-consumer@0.8.0":


### PR DESCRIPTION
## Description
If the optional options object was omitted, the filter was ignored, which meant ALL records could accidentally be deleted.
Quite a nasty surprise!




