### PR TITLE
Add dispatch deploy job for release env

### DIFF
--- a/.github/workflows/deploy-cloud.yaml
+++ b/.github/workflows/deploy-cloud.yaml
@@ -1,4 +1,4 @@
-name: Budibase Cloud Deploy
+name: Budibase Deploy Production
 
 on:
  workflow_dispatch:

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,11 +1,7 @@
-name: Budibase Deploy Preprod
+name: Budibase Deploy Release
 
 on:
  workflow_dispatch:
-
-env:
-  INTERCOM_TOKEN: ${{ secrets.INTERCOM_TOKEN }}
-  SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
 jobs:
   release:
@@ -21,6 +17,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-1
 
+      - name: Fail if branch is not develop
+        if: github.ref != 'refs/heads/release'
+        run: | 
+          echo "Ref is not develop, you must run this job from develop."
+          exit 1
 
       - name: Get the latest budibase release version
         id: version
@@ -31,46 +32,46 @@ jobs:
       - name: Tag and release Proxy service docker image
         run: | 
           docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-          yarn build:docker:proxy:preprod
-          docker tag proxy-service budibase/proxy:$PREPROD_TAG
-          docker push budibase/proxy:$PREPROD_TAG
+          yarn build:docker:proxy:release
+          docker tag proxy-service budibase/proxy:$RELEASE_TAG
+          docker push budibase/proxy:$RELEASE_TAG
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}
-          PREPROD_TAG: k8s-preprod
+          RELEASE_TAG: k8s-release
 
       - name: Pull values.yaml from budibase-infra
         run: | 
           curl -H "Authorization: token ${{ secrets.GH_PERSONAL_TOKEN }}" \
           -H 'Accept: application/vnd.github.v3.raw' \
-          -o values.preprod.yaml \
-          -L https://api.github.com/repos/budibase/budibase-infra/contents/kubernetes/budibase-preprod/values.yaml
-          wc -l values.preprod.yaml
+          -o values.release.yaml \
+          -L https://api.github.com/repos/budibase/budibase-infra/contents/kubernetes/budibase-release/values.yaml
+          wc -l values.release.yaml
 
-      - name: Deploy to Preprod Environment
+      - name: Deploy to Release Environment
         uses: glopezep/helm@v1.7.1
         with:
-          release: budibase-preprod
+          release: budibase-release
           namespace: budibase
           chart: charts/budibase
           token: ${{ github.token }}
           helm: helm3
           values: |
             globals: 
-              appVersion: v${{ env.RELEASE_VERSION }}
+              appVersion: develop
             ingress:
               enabled: true
               nginx: true
           value-files: >-
             [
-              "values.preprod.yaml"
+              "values.release.yaml"
             ]
         env:
-          KUBECONFIG_FILE: '${{ secrets.PREPROD_KUBECONFIG }}'
+          KUBECONFIG_FILE: '${{ secrets.RELEASE_KUBECONFIG }}'
 
       - name: Discord Webhook Action
         uses: tsickert/discord-webhook@v4.0.0
         with:
           webhook-url: ${{ secrets.PROD_DEPLOY_WEBHOOK_URL }}
-          content: "Preprod Deployment Complete: ${{ env.RELEASE_VERSION }} deployed to Budibase Pre-prod."
+          content: "Release Env Deployment Complete: ${{ env.RELEASE_VERSION }} deployed to Budibase Release Env."
           embed-title: ${{ env.RELEASE_VERSION }}

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -1094,10 +1094,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.201-alpha.4":
-  version "1.0.201-alpha.4"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.201-alpha.4.tgz#51fda5838e9c51c88c85204ad867811e49b7d34c"
-  integrity sha512-5oQMfKPDMpB4x5MzGgOtWFIPzc7RG/uu+rSe65PVwWfp77bDa3kxtCtC1p6vtJuPlb4GYrHqGLtr7WePbJf4fA==
+"@budibase/backend-core@1.0.207-alpha.0":
+  version "1.0.207-alpha.0"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.207-alpha.0.tgz#8e27dced0ed675c81f8139434e9a605d620967c2"
+  integrity sha512-Xwd2ywdWI2m3vGoxhnCDb8D8CDhiTQCWiqkU8V2kKhAkZsmwgAEEL9V/8VuNMYH3Lym3OAqZW0zC75NqRiS6mg==
   dependencies:
     "@techpass/passport-openidconnect" "0.3.2"
     aws-sdk "2.1030.0"
@@ -1175,12 +1175,12 @@
     svelte-flatpickr "^3.2.3"
     svelte-portal "^1.0.0"
 
-"@budibase/pro@1.0.201-alpha.4":
-  version "1.0.201-alpha.4"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.201-alpha.4.tgz#5b92dc7a4bb2004bcd43339c863430ea640e0b74"
-  integrity sha512-fsDlE8O4Y4JpZI3NwBoN8udX4cEx7/ebZ41Q7qD5VwA6Q2niapRcX0MvDmGdjDSVECG+NJU1uqCdg5cDq1Odxw==
+"@budibase/pro@1.0.207-alpha.0":
+  version "1.0.207-alpha.0"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.207-alpha.0.tgz#b79cd0b32f722a11b52feeb0c39456334a524362"
+  integrity sha512-L39oqPoUe0r74PKR3Jry/BNeP6Dn/HxwSwbIxIpsxM90g0ZtTXQthwcx+Ni9kmd3+Uucf9i+8b72ZYTK2ab+MQ==
   dependencies:
-    "@budibase/backend-core" "1.0.201-alpha.4"
+    "@budibase/backend-core" "1.0.207-alpha.0"
     node-fetch "^2.6.1"
 
 "@budibase/standard-components@^0.9.139":

--- a/packages/worker/yarn.lock
+++ b/packages/worker/yarn.lock
@@ -291,10 +291,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.201-alpha.4":
-  version "1.0.201-alpha.4"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.201-alpha.4.tgz#51fda5838e9c51c88c85204ad867811e49b7d34c"
-  integrity sha512-5oQMfKPDMpB4x5MzGgOtWFIPzc7RG/uu+rSe65PVwWfp77bDa3kxtCtC1p6vtJuPlb4GYrHqGLtr7WePbJf4fA==
+"@budibase/backend-core@1.0.207-alpha.0":
+  version "1.0.207-alpha.0"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.207-alpha.0.tgz#8e27dced0ed675c81f8139434e9a605d620967c2"
+  integrity sha512-Xwd2ywdWI2m3vGoxhnCDb8D8CDhiTQCWiqkU8V2kKhAkZsmwgAEEL9V/8VuNMYH3Lym3OAqZW0zC75NqRiS6mg==
   dependencies:
     "@techpass/passport-openidconnect" "0.3.2"
     aws-sdk "2.1030.0"
@@ -322,12 +322,12 @@
     uuid "8.3.2"
     zlib "1.0.5"
 
-"@budibase/pro@1.0.201-alpha.4":
-  version "1.0.201-alpha.4"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.201-alpha.4.tgz#5b92dc7a4bb2004bcd43339c863430ea640e0b74"
-  integrity sha512-fsDlE8O4Y4JpZI3NwBoN8udX4cEx7/ebZ41Q7qD5VwA6Q2niapRcX0MvDmGdjDSVECG+NJU1uqCdg5cDq1Odxw==
+"@budibase/pro@1.0.207-alpha.0":
+  version "1.0.207-alpha.0"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.207-alpha.0.tgz#b79cd0b32f722a11b52feeb0c39456334a524362"
+  integrity sha512-L39oqPoUe0r74PKR3Jry/BNeP6Dn/HxwSwbIxIpsxM90g0ZtTXQthwcx+Ni9kmd3+Uucf9i+8b72ZYTK2ab+MQ==
   dependencies:
-    "@budibase/backend-core" "1.0.201-alpha.4"
+    "@budibase/backend-core" "1.0.207-alpha.0"
     node-fetch "^2.6.1"
 
 "@cspotcode/source-map-consumer@0.8.0":


### PR DESCRIPTION
## Description
Add a workflow dispatch (manual) job for deploying to the release env based on the most recent version in the develop branch. This replicates the config for production and preprod. Used for when there are non source based changes such as kubernetes config. 

Also update the naming convention across the deploy jobs:
- `Budibase Cloud Deploy` -> `Budibase Deploy Production`
- `Budibase Release Preprod` -> `Budibase Deploy Preprod`
- `Budibase Deploy Release`

This should result in better grouping in the GH actions UI
