### PR TITLE
Add option to customise which columns are exported in export data action

### DIFF
--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ButtonActionEditor/actions/ExportData.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ButtonActionEditor/actions/ExportData.svelte
@@ -1,26 +1,17 @@
 <script>
-  import { Label, Select, Body } from "@budibase/bbui"
-  import { findAllMatchingComponents } from "builderStore/componentUtils"
+  import { Label, Select, Body, Multiselect } from "@budibase/bbui"
+  import {
+    findAllMatchingComponents,
+    findComponent,
+  } from "builderStore/componentUtils"
   import { currentAsset } from "builderStore"
   import { onMount } from "svelte"
+  import {
+    getDatasourceForProvider,
+    getSchemaForDatasource,
+  } from "builderStore/dataBinding"
 
   export let parameters
-
-  $: tables = findAllMatchingComponents($currentAsset?.props, component =>
-    component._component.endsWith("table")
-  ).map(table => ({
-    label: table._instanceName,
-    value: table._id,
-  }))
-
-  $: tableBlocks = findAllMatchingComponents($currentAsset?.props, component =>
-    component._component.endsWith("tableblock")
-  ).map(block => ({
-    label: block._instanceName,
-    value: `${block._id}-table`,
-  }))
-
-  $: componentOptions = tables.concat(tableBlocks)
 
   const FORMATS = [
     {
@@ -32,6 +23,32 @@
       value: "json",
     },
   ]
+
+  $: tables = findAllMatchingComponents($currentAsset?.props, component =>
+    component._component.endsWith("table")
+  ).map(table => ({
+    label: table._instanceName,
+    value: table._id,
+  }))
+  $: tableBlocks = findAllMatchingComponents($currentAsset?.props, component =>
+    component._component.endsWith("tableblock")
+  ).map(block => ({
+    label: block._instanceName,
+    value: `${block._id}-table`,
+  }))
+  $: componentOptions = tables.concat(tableBlocks)
+  $: columnOptions = getColumnOptions(parameters.tableComponentId)
+
+  const getColumnOptions = tableId => {
+    // Strip block suffix if block component
+    if (tableId?.includes("-")) {
+      tableId = tableId.split("-")[0]
+    }
+    const selectedTable = findComponent($currentAsset?.props, tableId)
+    const datasource = getDatasourceForProvider($currentAsset, selectedTable)
+    const { schema } = getSchemaForDatasource($currentAsset, datasource)
+    return Object.keys(schema || {})
+  }
 
   onMount(() => {
     if (!parameters.type) {
@@ -53,10 +70,16 @@
     <Select
       bind:value={parameters.tableComponentId}
       options={componentOptions}
+      on:change={() => (parameters.columns = [])}
     />
-
     <Label small>Export as</Label>
     <Select bind:value={parameters.type} options={FORMATS} />
+    <Label small>Export columns</Label>
+    <Multiselect
+      placeholder="All columns"
+      bind:value={parameters.columns}
+      options={columnOptions}
+    />
   </div>
 </div>
 
@@ -80,7 +103,7 @@
     display: grid;
     column-gap: var(--spacing-xs);
     row-gap: var(--spacing-s);
-    grid-template-columns: 70px 1fr;
+    grid-template-columns: 90px 1fr;
     align-items: center;
   }
 </style>

--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -270,6 +270,7 @@ const exportDataHandler = async action => {
         tableId: selection.tableId,
         rows: selection.selectedRows,
         format: action.parameters.type,
+        columns: action.parameters.columns,
       })
       download(data, `${selection.tableId}.${action.parameters.type}`)
     } catch (error) {

--- a/packages/frontend-core/src/api/rows.js
+++ b/packages/frontend-core/src/api/rows.js
@@ -65,12 +65,15 @@ export const buildRowEndpoints = API => ({
    * Exports rows.
    * @param tableId the table ID to export the rows from
    * @param rows the array of rows to export
+   * @param format the format to export (csv or json)
+   * @param columns which columns to export (all if undefined)
    */
-  exportRows: async ({ tableId, rows, format }) => {
+  exportRows: async ({ tableId, rows, format, columns }) => {
     return await API.post({
       url: `/api/${tableId}/rows/exportRows?format=${format}`,
       body: {
         rows,
+        columns,
       },
       parseResponse: async response => {
         return await response.text()


### PR DESCRIPTION
## Description
This PR adds an option to the `Export data` action to allow choosing which columns should be exported. Leaving this setting blank defaults to exporting all columns.

Selecting specific columns:
![image](https://user-images.githubusercontent.com/9075550/174596458-6341372f-6cbc-47b8-a613-d4d479aab3c7.png)
![image](https://user-images.githubusercontent.com/9075550/174596498-c7323099-84bd-43ea-a66c-beeba34bcb5b.png)

Defaut to all columms:
![image](https://user-images.githubusercontent.com/9075550/174596544-f64d7fd8-62a2-4ede-b367-4f35b0e6adec.png)
![image](https://user-images.githubusercontent.com/9075550/174596623-203bd549-57a3-4ac5-8f8f-6a1b75485e17.png)

Addresses: 
- #6175
