### PR TITLE
External data source plus - Integer filter range validation

### DIFF
--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/FilterEditor/FilterDrawer.svelte
@@ -54,8 +54,9 @@
   }
 
   const onFieldChange = (expression, field) => {
-    // Update the field type
+    // Update the field types
     expression.type = enrichedSchemaFields.find(x => x.name === field)?.type
+    expression.externalType = getSchema(expression)?.externalType
 
     // Ensure a valid operator is set
     const validOperators = LuceneUtils.getValidOperatorsForType(

--- a/packages/frontend-core/src/constants.js
+++ b/packages/frontend-core/src/constants.js
@@ -67,7 +67,7 @@ export const ApiVersion = "1"
 /**
  * Maximum minimum range for SQL number values
  */
-export const SQL_NUMBER_TYPE_RANGE_MAP = {
+export const SqlNumberTypeRangeMap = {
   integer: {
     max: 2147483647,
     min: -2147483648,

--- a/packages/frontend-core/src/constants.js
+++ b/packages/frontend-core/src/constants.js
@@ -63,3 +63,25 @@ export const TableNames = {
  *   - Coerce types for search endpoint
  */
 export const ApiVersion = "1"
+
+/**
+ * Maximum minimum range for SQL number values
+ */
+export const SQL_NUMBER_TYPE_RANGE_MAP = {
+  integer: {
+    max: 2147483647,
+    min: -2147483648,
+  },
+  int: {
+    max: 2147483647,
+    min: -2147483648,
+  },
+  smallint: {
+    max: 32767,
+    min: -32768,
+  },
+  mediumint: {
+    max: 8388607,
+    min: -8388608,
+  },
+}

--- a/packages/frontend-core/src/utils/lucene.js
+++ b/packages/frontend-core/src/utils/lucene.js
@@ -107,11 +107,9 @@ export const buildLuceneQuery = filter => {
       }
       if (operator.startsWith("range")) {
         const minint =
-        SqlNumberTypeRangeMap[externalType]?.min ||
-          Number.MIN_SAFE_INTEGER
+          SqlNumberTypeRangeMap[externalType]?.min || Number.MIN_SAFE_INTEGER
         const maxint =
-        SqlNumberTypeRangeMap[externalType]?.max ||
-          Number.MAX_SAFE_INTEGER
+          SqlNumberTypeRangeMap[externalType]?.max || Number.MAX_SAFE_INTEGER
         if (!query.range[field]) {
           query.range[field] = {
             low: type === "number" ? minint : "0000-00-00T00:00:00.000Z",

--- a/packages/frontend-core/src/utils/lucene.js
+++ b/packages/frontend-core/src/utils/lucene.js
@@ -1,5 +1,5 @@
 import { Helpers } from "@budibase/bbui"
-import { OperatorOptions, SQL_NUMBER_TYPE_RANGE_MAP } from "../constants"
+import { OperatorOptions, SqlNumberTypeRangeMap } from "../constants"
 
 /**
  * Returns the valid operator options for a certain data type
@@ -107,10 +107,10 @@ export const buildLuceneQuery = filter => {
       }
       if (operator.startsWith("range")) {
         const minint =
-          SQL_NUMBER_TYPE_RANGE_MAP[externalType]?.min ||
+        SqlNumberTypeRangeMap[externalType]?.min ||
           Number.MIN_SAFE_INTEGER
         const maxint =
-          SQL_NUMBER_TYPE_RANGE_MAP[externalType]?.max ||
+        SqlNumberTypeRangeMap[externalType]?.max ||
           Number.MAX_SAFE_INTEGER
         if (!query.range[field]) {
           query.range[field] = {

--- a/packages/frontend-core/src/utils/lucene.js
+++ b/packages/frontend-core/src/utils/lucene.js
@@ -1,5 +1,5 @@
 import { Helpers } from "@budibase/bbui"
-import { OperatorOptions } from "../constants"
+import { OperatorOptions, SQL_NUMBER_TYPE_RANGE_MAP } from "../constants"
 
 /**
  * Returns the valid operator options for a certain data type
@@ -94,7 +94,7 @@ export const buildLuceneQuery = filter => {
   }
   if (Array.isArray(filter)) {
     filter.forEach(expression => {
-      let { operator, field, type, value } = expression
+      let { operator, field, type, value, externalType } = expression
       // Parse all values into correct types
       if (type === "datetime" && value) {
         value = new Date(value).toISOString()
@@ -106,16 +106,16 @@ export const buildLuceneQuery = filter => {
         value = `${value}`?.toLowerCase() === "true"
       }
       if (operator.startsWith("range")) {
+        const minint =
+          SQL_NUMBER_TYPE_RANGE_MAP[externalType]?.min ||
+          Number.MIN_SAFE_INTEGER
+        const maxint =
+          SQL_NUMBER_TYPE_RANGE_MAP[externalType]?.max ||
+          Number.MAX_SAFE_INTEGER
         if (!query.range[field]) {
           query.range[field] = {
-            low:
-              type === "number"
-                ? Number.MIN_SAFE_INTEGER
-                : "0000-00-00T00:00:00.000Z",
-            high:
-              type === "number"
-                ? Number.MAX_SAFE_INTEGER
-                : "9999-00-00T00:00:00.000Z",
+            low: type === "number" ? minint : "0000-00-00T00:00:00.000Z",
+            high: type === "number" ? maxint : "9999-00-00T00:00:00.000Z",
           }
         }
         if (operator === "rangeLow" && value != null && value !== "") {

--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -246,6 +246,7 @@ module MSSQLModule {
             autocolumn: !!autoColumns.find((col: string) => col === name),
             name: name,
             ...convertSqlType(def.DATA_TYPE),
+            externalType: def.DATA_TYPE,
           }
         }
         tables[tableName] = {

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -232,6 +232,7 @@ module MySQLModule {
               autocolumn: isAuto,
               constraints,
               ...convertSqlType(column.Type),
+              externalType: column.Type,
             }
           }
           if (!tables[tableName]) {

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -271,6 +271,7 @@ module PostgresModule {
             autocolumn: isAuto,
             name: columnName,
             ...convertSqlType(column.data_type),
+            externalType: column.data_type,
           }
         }
 

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -1094,10 +1094,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.207-alpha.1":
-  version "1.0.207-alpha.1"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.207-alpha.1.tgz#7cc8e585dadbc1f10489c31bd59402f334c283b6"
-  integrity sha512-3M/rBYQP/Xy7fewrSd7msNgg37VOa+HuAGDSulokNCjoxlq/51Ks87FkWQgQOVpagtERV0WyZdH8qfFWzOqpnQ==
+"@budibase/backend-core@1.0.207-alpha.3":
+  version "1.0.207-alpha.3"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.207-alpha.3.tgz#98bced0575ec4e2b158239a8c73b39ca2d816719"
+  integrity sha512-DU4X6jJ+DfhzOv4TTa1w4Dk5ZEdlK/z1joCTruT+SGM5qI75bXrGeol5OX2OaEbNKtXFKJ1zeVTmBCYcu7OFUg==
   dependencies:
     "@techpass/passport-openidconnect" "0.3.2"
     aws-sdk "2.1030.0"
@@ -1175,12 +1175,12 @@
     svelte-flatpickr "^3.2.3"
     svelte-portal "^1.0.0"
 
-"@budibase/pro@1.0.207-alpha.1":
-  version "1.0.207-alpha.1"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.207-alpha.1.tgz#a8323f28e695843891eeb3225426e2a478fbd467"
-  integrity sha512-osdEwc27lUCkt7bci9wCZXeGOL45XtH4qBPIAzuRrYUvPwipzb8ro603cRpmvn9q7LN+Dt1xrF/OIlGAUUE2lQ==
+"@budibase/pro@1.0.207-alpha.3":
+  version "1.0.207-alpha.3"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.207-alpha.3.tgz#9bde845ceb685f1b43286a124620c21fdf891a01"
+  integrity sha512-WFEMujpKTVAMvAgLBnMdw8ou9PxsbM4Oa9Dq+DAUsWpPACsMWOProyHLsdRxJyvHlgGfwVjo5MEusvStjI4j6g==
   dependencies:
-    "@budibase/backend-core" "1.0.207-alpha.1"
+    "@budibase/backend-core" "1.0.207-alpha.3"
     node-fetch "^2.6.1"
 
 "@budibase/standard-components@^0.9.139":

--- a/packages/worker/yarn.lock
+++ b/packages/worker/yarn.lock
@@ -291,10 +291,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@1.0.207-alpha.1":
-  version "1.0.207-alpha.1"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.207-alpha.1.tgz#7cc8e585dadbc1f10489c31bd59402f334c283b6"
-  integrity sha512-3M/rBYQP/Xy7fewrSd7msNgg37VOa+HuAGDSulokNCjoxlq/51Ks87FkWQgQOVpagtERV0WyZdH8qfFWzOqpnQ==
+"@budibase/backend-core@1.0.207-alpha.3":
+  version "1.0.207-alpha.3"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-1.0.207-alpha.3.tgz#98bced0575ec4e2b158239a8c73b39ca2d816719"
+  integrity sha512-DU4X6jJ+DfhzOv4TTa1w4Dk5ZEdlK/z1joCTruT+SGM5qI75bXrGeol5OX2OaEbNKtXFKJ1zeVTmBCYcu7OFUg==
   dependencies:
     "@techpass/passport-openidconnect" "0.3.2"
     aws-sdk "2.1030.0"
@@ -322,12 +322,12 @@
     uuid "8.3.2"
     zlib "1.0.5"
 
-"@budibase/pro@1.0.207-alpha.1":
-  version "1.0.207-alpha.1"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.207-alpha.1.tgz#a8323f28e695843891eeb3225426e2a478fbd467"
-  integrity sha512-osdEwc27lUCkt7bci9wCZXeGOL45XtH4qBPIAzuRrYUvPwipzb8ro603cRpmvn9q7LN+Dt1xrF/OIlGAUUE2lQ==
+"@budibase/pro@1.0.207-alpha.3":
+  version "1.0.207-alpha.3"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-1.0.207-alpha.3.tgz#9bde845ceb685f1b43286a124620c21fdf891a01"
+  integrity sha512-WFEMujpKTVAMvAgLBnMdw8ou9PxsbM4Oa9Dq+DAUsWpPACsMWOProyHLsdRxJyvHlgGfwVjo5MEusvStjI4j6g==
   dependencies:
-    "@budibase/backend-core" "1.0.207-alpha.1"
+    "@budibase/backend-core" "1.0.207-alpha.3"
     node-fetch "^2.6.1"
 
 "@cspotcode/source-map-consumer@0.8.0":


### PR DESCRIPTION
## Description
All of the external SQL data sources were throwing validation errors when filtering by integer range, because the JavaScript max/min values exceeded for example Int32, and small int.

Now passing through the external data types to the filter so that the range limits can be determined from a map if needed.

Addresses: 
- https://github.com/Budibase/budibase/issues/6398



