### PR TITLE
ARM support - single image

### DIFF
--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -41,7 +41,6 @@ ENV DEPLOYMENT_ENVIRONMENT=docker \
   SELF_HOSTED=1 \
   CLUSTER_PORT=10000 \
   REDIS_PASSWORD=budibase \
-  ARCHITECTURE=amd \
   APP_PORT=4001 \
   WORKER_PORT=4002
 
@@ -89,7 +88,7 @@ ADD hosting/single/vm.args ./etc/
 
 # setup minio
 WORKDIR /minio
-RUN wget https://dl.min.io/server/minio/release/linux-${ARCHITECTURE}64/minio && chmod +x minio
+RUN wget https://dl.min.io/server/minio/release/linux-${TARGETARCH}/minio && chmod +x minio
 
 # setup runner file
 WORKDIR /

--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -20,6 +20,8 @@ RUN node /pinVersions.js && yarn && yarn build && /cleanup.sh
 
 FROM couchdb:3.2.1
 
+ARG TARGETARCH
+
 COPY --from=build /app /app
 COPY --from=build /worker /worker
 
@@ -66,7 +68,7 @@ RUN mkdir /etc/nginx/logs && \
 WORKDIR /
 RUN mkdir -p scripts/integrations/oracle
 ADD packages/server/scripts/integrations/oracle scripts/integrations/oracle
-RUN /bin/bash -e ./scripts/integrations/oracle/instantclient/linux/x86-64/install.sh
+RUN /bin/bash -e ./scripts/integrations/oracle/instantclient/linux/install.sh
 
 # setup clouseau
 WORKDIR /

--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -20,7 +20,7 @@ RUN node /pinVersions.js && yarn && yarn build && /cleanup.sh
 
 FROM couchdb:3.2.1
 
-ARG TARGETARCH
+ARG TARGETARCH amd64
 
 COPY --from=build /app /app
 COPY --from=build /worker /worker
@@ -88,7 +88,8 @@ ADD hosting/single/vm.args ./etc/
 
 # setup minio
 WORKDIR /minio
-RUN wget https://dl.min.io/server/minio/release/linux-${TARGETARCH}/minio && chmod +x minio
+ADD scripts/install-minio.sh ./install.sh
+RUN chmod +x install.sh && ./install.sh
 
 # setup runner file
 WORKDIR /

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "build:docker:develop": "node scripts/pinVersions && lerna run build:docker && npm run build:docker:proxy:compose && cd hosting/scripts/linux/ && ./release-to-docker-hub.sh develop && cd -",
     "build:docker:airgap": "node hosting/scripts/airgapped/airgappedDockerBuild",
     "build:digitalocean": "cd hosting/digitalocean && ./build.sh && cd -",
+    "build:docker:single:multiarch": "docker buildx build --platform linux/arm64,linux/amd64 -f hosting/single/Dockerfile -t budibase:latest .",
     "build:docker:single:image": "docker build -f hosting/single/Dockerfile -t budibase:latest .",
     "build:docker:single": "lerna run build && lerna run predocker && npm run build:docker:single:image",
     "build:docs": "lerna run build:docs",

--- a/packages/server/scripts/integrations/oracle/instantclient/linux/arm64/install.sh
+++ b/packages/server/scripts/integrations/oracle/instantclient/linux/arm64/install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash 
+
+# Must be root to continue
+if [[ $(id -u) -ne 0 ]] ; then echo "Please run as root" ; exit 1 ; fi
+
+# Allow for re-runs
+rm -rf /opt/oracle
+
+echo "Installing oracle instant client"
+
+# copy and unzip package
+mkdir -p /opt/oracle
+cp scripts/integrations/oracle/instantclient/linux/arm64/basiclite-19.10.zip /opt/oracle
+cd /opt/oracle
+unzip -qq basiclite-19.10.zip -d .
+rm *.zip
+mv instantclient* instantclient
+
+# update runtime link path
+sh -c "echo /opt/oracle/instantclient > /etc/ld.so.conf.d/oracle-instantclient.conf"
+ldconfig /etc/ld.so.conf.d
+
+echo "Installation complete"

--- a/packages/server/scripts/integrations/oracle/instantclient/linux/install.sh
+++ b/packages/server/scripts/integrations/oracle/instantclient/linux/install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+if [[ $TARGETARCH == arm* ]] ;
+then
+  echo "Installing ARM Oracle instant client..."
+  arm64/install.sh
+else
+  echo "Installing x86-64 Oracle instant client..."
+  x86-64/install.sh
+fi

--- a/packages/server/scripts/integrations/oracle/instantclient/linux/install.sh
+++ b/packages/server/scripts/integrations/oracle/instantclient/linux/install.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )"
 if [[ $TARGETARCH == arm* ]] ;
 then
   echo "Installing ARM Oracle instant client..."
-  arm64/install.sh
+  $SCRIPT_DIR/arm64/install.sh
 else
   echo "Installing x86-64 Oracle instant client..."
-  x86-64/install.sh
+  $SCRIPT_DIR/x86-64/install.sh
 fi

--- a/scripts/buildx-multiarch.sh
+++ b/scripts/buildx-multiarch.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+sudo apt-get install -y qemu qemu-user-static
+docker buildx create --name budibase
+docker buildx use budibase

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 dir=$(pwd)
-mv dist /
-mv package.json /
+declare -a keep=("dist" "package.json" "yarn.lock" "client" "builder" "build" "pm2.config.js" "docker_run.sh")
+for moveDir in "${keep[@]}"
+do
+  mv $moveDir / 2>/dev/null
+done
 cd /
 rm -r $dir
 mkdir $dir
-mv /dist $dir
-mv /package.json $dir
+for keepDir in "${keep[@]}"
+do
+  mv /$keepDir $dir/ 2>/dev/null
+done
 cd $dir
 NODE_ENV=production yarn

--- a/scripts/install-minio.sh
+++ b/scripts/install-minio.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ $TARGETARCH == arm* ]] ;
+then
+  wget https://dl.min.io/server/minio/release/linux-arm64/minio
+else
+  wget https://dl.min.io/server/minio/release/linux-amd64/minio
+fi
+chmod +x minio


### PR DESCRIPTION
## Description
Single image ARM support (Oracle instant client) and adding ARM commands. This uses `docker buildx` to manage the multi-arch build, there is a new command at the top level `yarn build:docker:single:multiarch` which will build both an amd64 image and an arm64 image as well.

To do this on Linux you'll need to install QEMU as a multi-arch emulator, this can be done with the packages `qemu` and `qemu-user-static`. I've add a script which will setup your environment to install these packages (for aptitude based distros) and create a docker-container builder which can be used for multi platform building.

This will need to be added to the Github actions pipeline, we can likely use [this action](https://github.com/docker/setup-buildx-action#with-qemu) to get it setup in our environment, if we run this before the above yarn command then it should just work, we will then have both arch images available to upload.