### PR TITLE
Replace all column spaces with underscores when performing internal searches

### DIFF
--- a/packages/server/src/api/controllers/row/internalSearch.js
+++ b/packages/server/src/api/controllers/row/internalSearch.js
@@ -145,7 +145,7 @@ class QueryBuilder {
 
     function build(structure, queryFn) {
       for (let [key, value] of Object.entries(structure)) {
-        key = builder.preprocess(key.replace(/ /, "_"), {
+        key = builder.preprocess(key.replace(/ /g, "_"), {
           escape: true,
         })
         const expression = queryFn(key, value)


### PR DESCRIPTION
Fixes an issue where searching would not work when using a column containing more than one space. We fixed this issue recently but either overlooked this one usage or introduced a regression at some point.

Addresses https://github.com/Budibase/budibase/issues/6421.