### PR TITLE
Improve Couch DB URL parsing to handle edge cases and special characters

### DIFF
--- a/packages/backend-core/src/db/pouch.js
+++ b/packages/backend-core/src/db/pouch.js
@@ -1,21 +1,42 @@
 const PouchDB = require("pouchdb")
 const env = require("../environment")
 
-function getUrlInfo() {
-  let url = env.COUCH_DB_URL
-  let username, password, host
-  const [protocol, rest] = url.split("://")
-  if (url.includes("@")) {
-    const hostParts = rest.split("@")
-    host = hostParts[1]
-    const authParts = hostParts[0].split(":")
-    username = authParts[0]
-    password = authParts[1]
-  } else {
-    host = rest
+exports.getUrlInfo = (url = env.COUCH_DB_URL) => {
+  let cleanUrl, username, password, host
+  if (url) {
+    // Ensure the URL starts with a protocol
+    const protoRegex = /^https?:\/\//i
+    if (!protoRegex.test(url)) {
+      url = `http://${url}`
+    }
+
+    // Split into protocol and remainder
+    const split = url.split("://")
+    const protocol = split[0]
+    const rest = split.slice(1).join("://")
+
+    // Extract auth if specified
+    if (url.includes("@")) {
+      // Split into host and remainder
+      let parts = rest.split("@")
+      host = parts[parts.length - 1]
+      let auth = parts.slice(0, -1).join("@")
+
+      // Split auth into username and password
+      if (auth.includes(":")) {
+        const authParts = auth.split(":")
+        username = authParts[0]
+        password = authParts.slice(1).join(":")
+      } else {
+        username = auth
+      }
+    } else {
+      host = rest
+    }
+    cleanUrl = `${protocol}://${host}`
   }
   return {
-    url: `${protocol}://${host}`,
+    url: cleanUrl,
     auth: {
       username,
       password,
@@ -24,7 +45,7 @@ function getUrlInfo() {
 }
 
 exports.getCouchInfo = () => {
-  const urlInfo = getUrlInfo()
+  const urlInfo = exports.getUrlInfo()
   let username
   let password
   if (env.COUCH_DB_USERNAME) {

--- a/packages/backend-core/src/db/tests/pouch.spec.js
+++ b/packages/backend-core/src/db/tests/pouch.spec.js
@@ -1,0 +1,62 @@
+require("../../../tests/utilities/TestConfiguration")
+const getUrlInfo = require("../pouch").getUrlInfo
+
+describe("pouch", () => {
+  describe("Couch DB URL parsing", () => {
+    it("should handle a null Couch DB URL", () => {
+      const info = getUrlInfo(null)
+      expect(info.url).toBeUndefined()
+      expect(info.auth.username).toBeUndefined()
+    })
+    it("should be able to parse a basic Couch DB URL", () => {
+      const info = getUrlInfo("http://host.com")
+      expect(info.url).toBe("http://host.com")
+      expect(info.auth.username).toBeUndefined()
+    })
+    it("should be able to parse a Couch DB basic URL with HTTPS", () => {
+      const info = getUrlInfo("https://host.com")
+      expect(info.url).toBe("https://host.com")
+      expect(info.auth.username).toBeUndefined()
+    })
+    it("should be able to parse a basic Couch DB URL with a custom port", () => {
+      const info = getUrlInfo("https://host.com:1234")
+      expect(info.url).toBe("https://host.com:1234")
+      expect(info.auth.username).toBeUndefined()
+    })
+    it("should be able to parse a Couch DB URL with auth", () => {
+      const info = getUrlInfo("https://user:pass@host.com:1234")
+      expect(info.url).toBe("https://host.com:1234")
+      expect(info.auth.username).toBe("user")
+      expect(info.auth.password).toBe("pass")
+    })
+    it("should be able to parse a Couch DB URL with auth and special chars", () => {
+      const info = getUrlInfo("https://user:s:p@s://@://:d@;][~s@host.com:1234")
+      expect(info.url).toBe("https://host.com:1234")
+      expect(info.auth.username).toBe("user")
+      expect(info.auth.password).toBe("s:p@s://@://:d@;][~s")
+    })
+    it("should be able to parse a Couch DB URL without a protocol", () => {
+      const info = getUrlInfo("host.com:1234")
+      expect(info.url).toBe("http://host.com:1234")
+      expect(info.auth.username).toBeUndefined()
+    })
+    it("should be able to parse a Couch DB URL with auth and without a protocol", () => {
+      const info = getUrlInfo("user:s:p@s://@://:d@;][~s@host.com:1234")
+      expect(info.url).toBe("http://host.com:1234")
+      expect(info.auth.username).toBe("user")
+      expect(info.auth.password).toBe("s:p@s://@://:d@;][~s")
+    })
+    it("should be able to parse a Couch DB URL with only username auth", () => {
+      const info = getUrlInfo("https://user@host.com:1234")
+      expect(info.url).toBe("https://host.com:1234")
+      expect(info.auth.username).toBe("user")
+      expect(info.auth.password).toBeUndefined()
+    })
+    it("should be able to parse a Couch DB URL with only username auth and without a protocol", () => {
+      const info = getUrlInfo("user@host.com:1234")
+      expect(info.url).toBe("http://host.com:1234")
+      expect(info.auth.username).toBe("user")
+      expect(info.auth.password).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Description
This PR improves the parsing logic for Couch DB URLs, which are passed in as an env variable. The parsing now supports multiple different URL formats and edge cases, and also supports using special characters such as `:/@` in the password.

Addresses #5962.
Mentioned in #5939.

