### PR TITLE
Redis update for pro usage

### DIFF
--- a/packages/backend-core/cache.js
+++ b/packages/backend-core/cache.js
@@ -3,5 +3,6 @@ const generic = require("./src/cache/generic")
 module.exports = {
   user: require("./src/cache/user"),
   app: require("./src/cache/appMetadata"),
+  writethrough: require("./src/cache/writethrough"),
   ...generic,
 }

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -63,6 +63,7 @@
     "@types/koa": "2.0.52",
     "@types/node": "14.18.20",
     "@types/node-fetch": "2.6.1",
+    "@types/pouchdb": "^6.4.0",
     "@types/redlock": "4.0.3",
     "@types/semver": "7.3.7",
     "@types/tar-fs": "2.0.1",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -63,7 +63,7 @@
     "@types/koa": "2.0.52",
     "@types/node": "14.18.20",
     "@types/node-fetch": "2.6.1",
-    "@types/pouchdb": "^6.4.0",
+    "@types/pouchdb": "6.4.0",
     "@types/redlock": "4.0.3",
     "@types/semver": "7.3.7",
     "@types/tar-fs": "2.0.1",

--- a/packages/backend-core/redis.js
+++ b/packages/backend-core/redis.js
@@ -1,5 +1,5 @@
 module.exports = {
   Client: require("./src/redis"),
   utils: require("./src/redis/utils"),
-  clients: require("./src/redis/authRedis"),
+  clients: require("./src/redis/init"),
 }

--- a/packages/backend-core/src/cache/appMetadata.js
+++ b/packages/backend-core/src/cache/appMetadata.js
@@ -1,4 +1,4 @@
-const redis = require("../redis/authRedis")
+const redis = require("../redis/init")
 const { doWithDB } = require("../db")
 const { DocumentTypes } = require("../db/constants")
 

--- a/packages/backend-core/src/cache/base/index.ts
+++ b/packages/backend-core/src/cache/base/index.ts
@@ -1,0 +1,92 @@
+import { getTenantId } from "../../context"
+import redis from "../../redis/init"
+import RedisWrapper from "../../redis"
+
+function generateTenantKey(key: string) {
+  const tenantId = getTenantId()
+  return `${key}:${tenantId}`
+}
+
+export = class BaseCache {
+  client: RedisWrapper | undefined
+
+  constructor(client: RedisWrapper | undefined = undefined) {
+    this.client = client
+  }
+
+  async getClient() {
+    return !this.client ? await redis.getCacheClient() : this.client
+  }
+
+  async keys(pattern: string) {
+    const client = await this.getClient()
+    return client.keys(pattern)
+  }
+
+  /**
+   * Read only from the cache.
+   */
+  async get(key: string, opts = { useTenancy: true }) {
+    key = opts.useTenancy ? generateTenantKey(key) : key
+    const client = await this.getClient()
+    return client.get(key)
+  }
+
+  /**
+   * Write to the cache.
+   */
+  async store(
+    key: string,
+    value: any,
+    ttl: number | null = null,
+    opts = { useTenancy: true }
+  ) {
+    key = opts.useTenancy ? generateTenantKey(key) : key
+    const client = await this.getClient()
+    await client.store(key, value, ttl)
+  }
+
+  /**
+   * Remove from cache.
+   */
+  async delete(key: string, opts = { useTenancy: true }) {
+    key = opts.useTenancy ? generateTenantKey(key) : key
+    const client = await this.getClient()
+    return client.delete(key)
+  }
+
+  /**
+   * Read from the cache. Write to the cache if not exists.
+   */
+  async withCache(
+    key: string,
+    ttl: number,
+    fetchFn: any,
+    opts = { useTenancy: true }
+  ) {
+    const cachedValue = await this.get(key, opts)
+    if (cachedValue) {
+      return cachedValue
+    }
+
+    try {
+      const fetchedValue = await fetchFn()
+
+      await this.store(key, fetchedValue, ttl, opts)
+      return fetchedValue
+    } catch (err) {
+      console.error("Error fetching before cache - ", err)
+      throw err
+    }
+  }
+
+  async bustCache(key: string, opts = { client: null }) {
+    const client = await this.getClient()
+    try {
+      await client.delete(generateTenantKey(key))
+    } catch (err) {
+      console.error("Error busting cache - ", err)
+      throw err
+    }
+  }
+}

--- a/packages/backend-core/src/cache/generic.js
+++ b/packages/backend-core/src/cache/generic.js
@@ -1,5 +1,6 @@
-const redis = require("../redis/authRedis")
-const { getTenantId } = require("../context")
+const BaseCache = require("./base")
+
+const GENERIC = new BaseCache()
 
 exports.CacheKeys = {
   CHECKLIST: "checklist",
@@ -16,67 +17,9 @@ exports.TTL = {
   ONE_DAY: 86400,
 }
 
-function generateTenantKey(key) {
-  const tenantId = getTenantId()
-  return `${key}:${tenantId}`
-}
-
-exports.keys = async pattern => {
-  const client = await redis.getCacheClient()
-  return client.keys(pattern)
-}
-
-/**
- * Read only from the cache.
- */
-exports.get = async (key, opts = { useTenancy: true }) => {
-  key = opts.useTenancy ? generateTenantKey(key) : key
-  const client = await redis.getCacheClient()
-  const value = await client.get(key)
-  return value
-}
-
-/**
- * Write to the cache.
- */
-exports.store = async (key, value, ttl, opts = { useTenancy: true }) => {
-  key = opts.useTenancy ? generateTenantKey(key) : key
-  const client = await redis.getCacheClient()
-  await client.store(key, value, ttl)
-}
-
-exports.delete = async (key, opts = { useTenancy: true }) => {
-  key = opts.useTenancy ? generateTenantKey(key) : key
-  const client = await redis.getCacheClient()
-  return client.delete(key)
-}
-
-/**
- * Read from the cache. Write to the cache if not exists.
- */
-exports.withCache = async (key, ttl, fetchFn, opts = { useTenancy: true }) => {
-  const cachedValue = await exports.get(key, opts)
-  if (cachedValue) {
-    return cachedValue
-  }
-
-  try {
-    const fetchedValue = await fetchFn()
-
-    await exports.store(key, fetchedValue, ttl, opts)
-    return fetchedValue
-  } catch (err) {
-    console.error("Error fetching before cache - ", err)
-    throw err
-  }
-}
-
-exports.bustCache = async key => {
-  const client = await redis.getCacheClient()
-  try {
-    await client.delete(generateTenantKey(key))
-  } catch (err) {
-    console.error("Error busting cache - ", err)
-    throw err
-  }
-}
+exports.keys = GENERIC.keys
+exports.get = GENERIC.get
+exports.store = GENERIC.store
+exports.delete = GENERIC.delete
+exports.withCache = GENERIC.withCache
+exports.bustCache = GENERIC.bustCache

--- a/packages/backend-core/src/cache/generic.js
+++ b/packages/backend-core/src/cache/generic.js
@@ -17,9 +17,13 @@ exports.TTL = {
   ONE_DAY: 86400,
 }
 
-exports.keys = GENERIC.keys
-exports.get = GENERIC.get
-exports.store = GENERIC.store
-exports.delete = GENERIC.delete
-exports.withCache = GENERIC.withCache
-exports.bustCache = GENERIC.bustCache
+function performExport(funcName) {
+  return (...args) => GENERIC[funcName](...args)
+}
+
+exports.keys = performExport("keys")
+exports.get = performExport("get")
+exports.store = performExport("store")
+exports.delete = performExport("delete")
+exports.withCache = performExport("withCache")
+exports.bustCache = performExport("bustCache")

--- a/packages/backend-core/src/cache/tests/writethrough.spec.js
+++ b/packages/backend-core/src/cache/tests/writethrough.spec.js
@@ -1,0 +1,47 @@
+require("../../../tests/utilities/TestConfiguration")
+const { get, put } = require("../writethrough")
+const { dangerousGetDB } = require("../../db")
+const tk = require("timekeeper")
+
+const START_DATE = Date.now()
+tk.freeze(START_DATE)
+
+const DELAY = 5000
+
+const db = dangerousGetDB("test")
+
+describe("writethrough", () => {
+
+  describe("put", () => {
+    let first
+    it("should be able to store, will go to DB", async () => {
+      const response = await put(db,{ _id: "test", value: 1 }, DELAY)
+      const output = await db.get(response._id)
+      first = output
+      expect(output.value).toBe(1)
+    })
+
+    it("second put shouldn't update DB", async () => {
+      const response = await put(db, { ...first, value: 2 }, DELAY)
+      const output = await db.get(response._id)
+      expect(first._rev).toBe(output._rev)
+      expect(output.value).toBe(1)
+    })
+
+    it("should put it again after delay period", async () => {
+      tk.freeze(START_DATE + DELAY + 1)
+      const response = await put(db, { ...first, value: 3 }, DELAY)
+      const output = await db.get(response._id)
+      expect(response._rev).not.toBe(first._rev)
+      expect(output.value).toBe(3)
+    })
+  })
+
+  describe("get", () => {
+    it("should be able to retrieve", async () => {
+      const response = await get(db, "test")
+      expect(response.value).toBe(3)
+    })
+  })
+})
+

--- a/packages/backend-core/src/cache/tests/writethrough.spec.js
+++ b/packages/backend-core/src/cache/tests/writethrough.spec.js
@@ -9,30 +9,30 @@ tk.freeze(START_DATE)
 const DELAY = 5000
 
 const db = dangerousGetDB("test")
-const writethrough = new Writethrough(db)
+const writethrough = new Writethrough(db, DELAY)
 
 describe("writethrough", () => {
   describe("put", () => {
     let first
     it("should be able to store, will go to DB", async () => {
-      const response = await writethrough.put({ _id: "test", value: 1 }, DELAY)
-      const output = await db.get(response._id)
+      const response = await writethrough.put({ _id: "test", value: 1 })
+      const output = await db.get(response.id)
       first = output
       expect(output.value).toBe(1)
     })
 
     it("second put shouldn't update DB", async () => {
-      const response = await writethrough.put({ ...first, value: 2 }, DELAY)
-      const output = await db.get(response._id)
+      const response = await writethrough.put({ ...first, value: 2 })
+      const output = await db.get(response.id)
       expect(first._rev).toBe(output._rev)
       expect(output.value).toBe(1)
     })
 
     it("should put it again after delay period", async () => {
       tk.freeze(START_DATE + DELAY + 1)
-      const response = await writethrough.put({ ...first, value: 3 }, DELAY)
-      const output = await db.get(response._id)
-      expect(response._rev).not.toBe(first._rev)
+      const response = await writethrough.put({ ...first, value: 3 })
+      const output = await db.get(response.id)
+      expect(response.rev).not.toBe(first._rev)
       expect(output.value).toBe(3)
     })
   })

--- a/packages/backend-core/src/cache/tests/writethrough.spec.js
+++ b/packages/backend-core/src/cache/tests/writethrough.spec.js
@@ -9,7 +9,8 @@ tk.freeze(START_DATE)
 const DELAY = 5000
 
 const db = dangerousGetDB("test")
-const writethrough = new Writethrough(db, DELAY)
+const db2 = dangerousGetDB("test2")
+const writethrough = new Writethrough(db, DELAY), writethrough2 = new Writethrough(db2, DELAY)
 
 describe("writethrough", () => {
   describe("put", () => {
@@ -41,6 +42,17 @@ describe("writethrough", () => {
     it("should be able to retrieve", async () => {
       const response = await writethrough.get("test")
       expect(response.value).toBe(3)
+    })
+  })
+
+  describe("same doc, different databases (tenancy)", () => {
+    it("should be able to two different databases", async () => {
+      const resp1 = await writethrough.put({ _id: "db1", value: "first" })
+      const resp2 = await writethrough2.put({ _id: "db1", value: "second" })
+      expect(resp1.rev).toBeDefined()
+      expect(resp2.rev).toBeDefined()
+      expect((await db.get("db1")).value).toBe("first")
+      expect((await db2.get("db1")).value).toBe("second")
     })
   })
 })

--- a/packages/backend-core/src/cache/user.js
+++ b/packages/backend-core/src/cache/user.js
@@ -1,4 +1,4 @@
-const redis = require("../redis/authRedis")
+const redis = require("../redis/init")
 const { getTenantId, lookupTenantId, doWithGlobalDB } = require("../tenancy")
 const env = require("../environment")
 const accounts = require("../cloud/accounts")

--- a/packages/backend-core/src/cache/writethrough.ts
+++ b/packages/backend-core/src/cache/writethrough.ts
@@ -21,11 +21,11 @@ function makeCacheItem(value: any, lastWrite: number | null = null): CacheItem {
   return { value, lastWrite: lastWrite || Date.now() }
 }
 
-exports.put = async (
+export async function put(
   db: PouchDB.Database,
   value: any,
   writeRateMs: number = DEFAULT_WRITE_RATE_MS
-) => {
+) {
   const cache = await getCache()
   const key = value._id
   let cacheItem: CacheItem | undefined = await cache.get(key)
@@ -46,7 +46,7 @@ exports.put = async (
   return output
 }
 
-exports.get = async (db: PouchDB.Database, id: string): Promise<any> => {
+export async function get(db: PouchDB.Database, id: string): Promise<any> {
   const cache = await getCache()
   let cacheItem: CacheItem = await cache.get(id)
   if (!cacheItem) {
@@ -55,4 +55,19 @@ exports.get = async (db: PouchDB.Database, id: string): Promise<any> => {
     await cache.store(id, cacheItem)
   }
   return cacheItem.value
+}
+
+export class Writethrough {
+  db: PouchDB.Database
+  constructor(db: PouchDB.Database) {
+    this.db = db
+  }
+
+  async put(value: any, writeRateMs: number = DEFAULT_WRITE_RATE_MS) {
+    return put(this.db, value, writeRateMs)
+  }
+
+  async get(id: string) {
+    return get(this.db, id)
+  }
 }

--- a/packages/backend-core/src/cache/writethrough.ts
+++ b/packages/backend-core/src/cache/writethrough.ts
@@ -1,0 +1,58 @@
+import BaseCache from "./base"
+import { getWritethroughClient } from "../redis/init"
+
+const DEFAULT_WRITE_RATE_MS = 10000
+let CACHE: BaseCache | null = null
+
+interface CacheItem {
+  value: any
+  lastWrite: number
+}
+
+async function getCache() {
+  if (!CACHE) {
+    const client = await getWritethroughClient()
+    CACHE = new BaseCache(client)
+  }
+  return CACHE
+}
+
+function makeCacheItem(value: any, lastWrite: number | null = null): CacheItem {
+  return { value, lastWrite: lastWrite || Date.now() }
+}
+
+exports.put = async (
+  db: PouchDB.Database,
+  value: any,
+  writeRateMs: number = DEFAULT_WRITE_RATE_MS
+) => {
+  const cache = await getCache()
+  const key = value._id
+  let cacheItem: CacheItem | undefined = await cache.get(key)
+  const updateDb = !cacheItem || cacheItem.lastWrite < Date.now() - writeRateMs
+  let output = value
+  if (updateDb) {
+    // value should contain the _id and _rev
+    const response = await db.put(value)
+    output = {
+      ...value,
+      _id: response.id,
+      _rev: response.rev,
+    }
+  }
+  // if we are updating the DB then need to set the lastWrite to now
+  cacheItem = makeCacheItem(value, updateDb ? null : cacheItem?.lastWrite)
+  await cache.store(key, cacheItem)
+  return output
+}
+
+exports.get = async (db: PouchDB.Database, id: string): Promise<any> => {
+  const cache = await getCache()
+  let cacheItem: CacheItem = await cache.get(id)
+  if (!cacheItem) {
+    const value = await db.get(id)
+    cacheItem = makeCacheItem(value)
+    await cache.store(id, cacheItem)
+  }
+  return cacheItem.value
+}

--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -16,7 +16,7 @@ if (!LOADED && isDev() && !isTest()) {
   LOADED = true
 }
 
-const env: any = {
+const env = {
   isTest,
   isDev,
   JWT_SECRET: process.env.JWT_SECRET,
@@ -66,6 +66,7 @@ const env: any = {
 for (let [key, value] of Object.entries(env)) {
   // handle the edge case of "0" to disable an environment variable
   if (value === "0") {
+    // @ts-ignore
     env[key] = 0
   }
 }

--- a/packages/backend-core/src/pkg/redis.ts
+++ b/packages/backend-core/src/pkg/redis.ts
@@ -2,7 +2,7 @@
 // The outer exports can't be used as they now reference dist directly
 import Client from "../redis"
 import utils from "../redis/utils"
-import clients from "../redis/authRedis"
+import clients from "../redis/init"
 
 export = {
   Client,

--- a/packages/backend-core/src/redis/init.js
+++ b/packages/backend-core/src/redis/init.js
@@ -2,7 +2,7 @@ const Client = require("./index")
 const utils = require("./utils")
 const { getRedlock } = require("./redlock")
 
-let userClient, sessionClient, appClient, cacheClient
+let userClient, sessionClient, appClient, cacheClient, writethroughClient
 let migrationsRedlock
 
 // turn retry off so that only one instance can ever hold the lock
@@ -13,6 +13,10 @@ async function init() {
   sessionClient = await new Client(utils.Databases.SESSIONS).init()
   appClient = await new Client(utils.Databases.APP_METADATA).init()
   cacheClient = await new Client(utils.Databases.GENERIC_CACHE).init()
+  writethroughClient = await new Client(
+    utils.Databases.WRITE_THROUGH,
+    utils.SelectableDatabases.WRITE_THROUGH
+  ).init()
   // pass the underlying ioredis client to redlock
   migrationsRedlock = getRedlock(
     cacheClient.getClient(),
@@ -25,6 +29,7 @@ process.on("exit", async () => {
   if (sessionClient) await sessionClient.finish()
   if (appClient) await appClient.finish()
   if (cacheClient) await cacheClient.finish()
+  if (writethroughClient) await writethroughClient.finish()
 })
 
 module.exports = {
@@ -51,6 +56,12 @@ module.exports = {
       await init()
     }
     return cacheClient
+  },
+  getWritethroughClient: async () => {
+    if (!writethroughClient) {
+      await init()
+    }
+    return writethroughClient
   },
   getMigrationsRedlock: async () => {
     if (!migrationsRedlock) {

--- a/packages/backend-core/src/redis/utils.js
+++ b/packages/backend-core/src/redis/utils.js
@@ -6,6 +6,14 @@ const SEPARATOR = "-"
 const REDIS_URL = !env.REDIS_URL ? "localhost:6379" : env.REDIS_URL
 const REDIS_PASSWORD = !env.REDIS_PASSWORD ? "budibase" : env.REDIS_PASSWORD
 
+/**
+ * These Redis databases help us to segment up a Redis keyspace by prepending the
+ * specified database name onto the cache key. This means that a single real Redis database
+ * can be split up a bit; allowing us to use scans on small databases to find some particular
+ * keys within.
+ * If writing a very large volume of keys is expected (say 10K+) then it is better to keep these out
+ * of the default keyspace and use a separate one - the SelectableDatabases can be used for this.
+ */
 exports.Databases = {
   PW_RESETS: "pwReset",
   VERIFICATIONS: "verification",
@@ -22,6 +30,15 @@ exports.Databases = {
   WRITE_THROUGH: "writeThrough",
 }
 
+/**
+ * These define the numeric Redis databases that can be access with the SELECT command -
+ * (https://redis.io/commands/select/). By default a Redis server/cluster will have 16 selectable
+ * databases, increasing this count increases the amount of CPU/memory required to run the server.
+ * Ideally new Redis keyspaces should be used sparingly, only when absolutely necessary for performance
+ * to be maintained. Generally a keyspace can grow to be very large is scans are not needed or desired,
+ * but if you need to walk through all values in a database periodically then a separate selectable
+ * keyspace should be used.
+ */
 exports.SelectableDatabases = {
   DEFAULT: 0,
   WRITE_THROUGH: 1,

--- a/packages/backend-core/src/redis/utils.js
+++ b/packages/backend-core/src/redis/utils.js
@@ -19,6 +19,26 @@ exports.Databases = {
   QUERY_VARS: "queryVars",
   LICENSES: "license",
   GENERIC_CACHE: "data_cache",
+  WRITE_THROUGH: "writeThrough",
+}
+
+exports.SelectableDatabases = {
+  DEFAULT: 0,
+  WRITE_THROUGH: 1,
+  UNUSED_1: 2,
+  UNUSED_2: 3,
+  UNUSED_3: 4,
+  UNUSED_4: 5,
+  UNUSED_5: 6,
+  UNUSED_6: 7,
+  UNUSED_7: 8,
+  UNUSED_8: 9,
+  UNUSED_9: 10,
+  UNUSED_10: 11,
+  UNUSED_11: 12,
+  UNUSED_12: 13,
+  UNUSED_13: 14,
+  UNUSED_14: 15,
 }
 
 exports.SEPARATOR = SEPARATOR

--- a/packages/backend-core/src/security/sessions.js
+++ b/packages/backend-core/src/security/sessions.js
@@ -1,4 +1,4 @@
-const redis = require("../redis/authRedis")
+const redis = require("../redis/init")
 const { v4: uuidv4 } = require("uuid")
 
 // a week in seconds

--- a/packages/backend-core/src/utils.js
+++ b/packages/backend-core/src/utils.js
@@ -197,3 +197,7 @@ exports.platformLogout = async ({ ctx, userId, keepActiveSession }) => {
   await events.auth.logout()
   await userCache.invalidateUser(userId)
 }
+
+exports.timeout = timeMs => {
+  return new Promise(resolve => setTimeout(resolve, timeMs))
+}

--- a/packages/backend-core/yarn.lock
+++ b/packages/backend-core/yarn.lock
@@ -291,6 +291,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@budibase/types@^1.0.209":
+  version "1.0.210"
+  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-1.0.210.tgz#b28f9d7b37d2cbc6b75ae8de201958ccc540cf06"
+  integrity sha512-16foNHGAlJxvh4IpPEPw9eZyIvA2n9nssrNu54Ag73E85A+mIiZ6NGHrw+mojrdC1yaSrj/xeQ461iYXdxT6/g==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -656,6 +661,13 @@
     "@types/keygrip" "*"
     "@types/node" "*"
 
+"@types/debug@*":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/express-serve-static-core@^4.17.18":
   version "4.17.28"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz#c47def9f34ec81dc6328d0b1b5303d1ec98d86b8"
@@ -762,6 +774,11 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
   integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
 
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
+
 "@types/node-fetch@2.6.1":
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.1.tgz#8f127c50481db65886800ef496f20bbf15518975"
@@ -779,6 +796,152 @@
   version "14.18.20"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.20.tgz#268f028b36eaf51181c3300252f605488c4f0650"
   integrity sha512-Q8KKwm9YqEmUBRsqJ2GWJDtXltBDxTdC4m5vTdXBolu2PeQh8LX+f6BTwU+OuXPu37fLxoN6gidqBmnky36FXA==
+
+"@types/pouchdb-adapter-cordova-sqlite@*":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-adapter-cordova-sqlite/-/pouchdb-adapter-cordova-sqlite-1.0.1.tgz#49e5ee6df7cc0c23196fcb340f43a560e74eb1d6"
+  integrity sha512-nqlXpW1ho3KBg1mUQvZgH2755y3z/rw4UA7ZJCPMRTHofxGMY8izRVw5rHBL4/7P615or0J2udpRYxgkT3D02g==
+  dependencies:
+    "@types/pouchdb-core" "*"
+
+"@types/pouchdb-adapter-fruitdown@*":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-adapter-fruitdown/-/pouchdb-adapter-fruitdown-6.1.3.tgz#9b140ad9645cc56068728acf08ec19ac0046658e"
+  integrity sha512-Wz1Z1JLOW1hgmFQjqnSkmyyfH7by/iWb4abKn684WMvQfmxx6BxKJpJ4+eulkVPQzzgMMSgU1MpnQOm9FgRkbw==
+  dependencies:
+    "@types/pouchdb-core" "*"
+
+"@types/pouchdb-adapter-http@*":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-adapter-http/-/pouchdb-adapter-http-6.1.3.tgz#6e592d5f48deb6274a21ddac1498dd308096bcf3"
+  integrity sha512-9Z4TLbF/KJWy/D2sWRPBA+RNU0odQimfdvlDX+EY7rGcd3aVoH8qjD/X0Xcd/0dfBH5pKrNIMFFQgW/TylRCmA==
+  dependencies:
+    "@types/pouchdb-core" "*"
+
+"@types/pouchdb-adapter-idb@*":
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-adapter-idb/-/pouchdb-adapter-idb-6.1.4.tgz#cb9a18864585d600820cd325f007614c5c3989cd"
+  integrity sha512-KIAXbkF4uYUz0ZwfNEFLtEkK44mEWopAsD76UhucH92XnJloBysav+TjI4FFfYQyTjoW3S1s6V+Z14CUJZ0F6w==
+  dependencies:
+    "@types/pouchdb-core" "*"
+
+"@types/pouchdb-adapter-leveldb@*":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-adapter-leveldb/-/pouchdb-adapter-leveldb-6.1.3.tgz#17c7e75d75b992050bca15991e97fba575c61bb3"
+  integrity sha512-ex8NFqQGFwEpFi7AaZ5YofmuemfZNsL3nTFZBUCAKYMBkazQij1pe2ILLStSvJr0XS0qxgXjCEW19T5Wqiiskg==
+  dependencies:
+    "@types/pouchdb-core" "*"
+
+"@types/pouchdb-adapter-localstorage@*":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-adapter-localstorage/-/pouchdb-adapter-localstorage-6.1.3.tgz#0dde02ba6b9d6073a295a20196563942ba9a54bd"
+  integrity sha512-oor040tye1KKiGLWYtIy7rRT7C2yoyX3Tf6elEJRpjOA7Ja/H8lKc4LaSh9ATbptIcES6MRqZDxtp7ly9hsW3Q==
+  dependencies:
+    "@types/pouchdb-core" "*"
+
+"@types/pouchdb-adapter-memory@*":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-adapter-memory/-/pouchdb-adapter-memory-6.1.3.tgz#9eabdbc890fcf58960ee8b68b8685f837e75c844"
+  integrity sha512-gVbsIMzDzgZYThFVT4eVNsmuZwVm/4jDxP1sjlgc3qtDIxbtBhGgyNfcskwwz9Zu5Lv1avkDsIWvcxQhnvRlHg==
+  dependencies:
+    "@types/pouchdb-core" "*"
+
+"@types/pouchdb-adapter-node-websql@*":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-adapter-node-websql/-/pouchdb-adapter-node-websql-6.1.3.tgz#aa18bc68af8cf509acd12c400010dcd5fab2243d"
+  integrity sha512-F/P+os6Jsa7CgHtH64+Z0HfwIcj0hIRB5z8gNhF7L7dxPWoAfkopK5H2gydrP3sQrlGyN4WInF+UJW/Zu1+FKg==
+  dependencies:
+    "@types/pouchdb-adapter-websql" "*"
+    "@types/pouchdb-core" "*"
+
+"@types/pouchdb-adapter-websql@*":
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-adapter-websql/-/pouchdb-adapter-websql-6.1.4.tgz#359fbe42ccac0ac90b492ddb8c32fafd0aa96d79"
+  integrity sha512-zMJQCtXC40hBsIDRn0GhmpeGMK0f9l/OGWfLguvczROzxxcOD7REI+e6SEmX7gJKw5JuMvlfuHzkQwjmvSJbtg==
+  dependencies:
+    "@types/pouchdb-core" "*"
+
+"@types/pouchdb-browser@*":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-browser/-/pouchdb-browser-6.1.3.tgz#8f33d6ef58d6817d1f6d36979148a1c7f63244d8"
+  integrity sha512-EdYowrWxW9SWBMX/rux2eq7dbHi5Zeyzz+FF/IAsgQKnUxgeCO5VO2j4zTzos0SDyJvAQU+EYRc11r7xGn5tvA==
+  dependencies:
+    "@types/pouchdb-adapter-http" "*"
+    "@types/pouchdb-adapter-idb" "*"
+    "@types/pouchdb-adapter-websql" "*"
+    "@types/pouchdb-core" "*"
+    "@types/pouchdb-mapreduce" "*"
+    "@types/pouchdb-replication" "*"
+
+"@types/pouchdb-core@*":
+  version "7.0.10"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-core/-/pouchdb-core-7.0.10.tgz#d1ea1549e7fad6cb579f71459b1bc27252e06a5a"
+  integrity sha512-mKhjLlWWXyV3PTTjDhzDV1kc2dolO7VYFa75IoKM/hr8Er9eo8RIbS7mJLfC8r/C3p6ihZu9yZs1PWC1LQ0SOA==
+  dependencies:
+    "@types/debug" "*"
+    "@types/pouchdb-find" "*"
+
+"@types/pouchdb-find@*":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-find/-/pouchdb-find-6.3.7.tgz#f713534a53c1a7f3fd8fbbfb74131a1b04711ddc"
+  integrity sha512-b2dr9xoZRK5Mwl8UiRA9l5j9mmCxNfqXuu63H1KZHwJLILjoIIz7BntCvM0hnlnl7Q8P8wORq0IskuaMq5Nnnw==
+  dependencies:
+    "@types/pouchdb-core" "*"
+
+"@types/pouchdb-http@*":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-http/-/pouchdb-http-6.1.3.tgz#09576c0d409da1f8dee34ec5b768415e2472ea52"
+  integrity sha512-0e9E5SqNOyPl/3FnEIbENssB4FlJsNYuOy131nxrZk36S+y1R/6qO7ZVRypWpGTqBWSuVd7gCsq2UDwO/285+w==
+  dependencies:
+    "@types/pouchdb-adapter-http" "*"
+    "@types/pouchdb-core" "*"
+
+"@types/pouchdb-mapreduce@*":
+  version "6.1.7"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-mapreduce/-/pouchdb-mapreduce-6.1.7.tgz#9ab32d1e0f234f1bf6d1e4c5d7e216e9e23ac0a3"
+  integrity sha512-WzBwm7tmO9QhfRzVaWT4v6JQSS/fG2OoUDrWrhX87rPe2Pn6laPvdK5li6myNRxCoI/l5e8Jd+oYBAFnaiFucA==
+  dependencies:
+    "@types/pouchdb-core" "*"
+
+"@types/pouchdb-node@*":
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-node/-/pouchdb-node-6.1.4.tgz#5214c0169fcfd2237d373380bbd65a934feb5dfb"
+  integrity sha512-wnTCH8X1JOPpNOfVhz8HW0AvmdHh6pt40MuRj0jQnK7QEHsHS79WujsKTKSOF8QXtPwpvCNSsI7ut7H7tfxxJQ==
+  dependencies:
+    "@types/pouchdb-adapter-http" "*"
+    "@types/pouchdb-adapter-leveldb" "*"
+    "@types/pouchdb-core" "*"
+    "@types/pouchdb-mapreduce" "*"
+    "@types/pouchdb-replication" "*"
+
+"@types/pouchdb-replication@*":
+  version "6.4.4"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-replication/-/pouchdb-replication-6.4.4.tgz#743406c90f13a988fa3e346ea74ce40acd170d00"
+  integrity sha512-BsE5LKpjJK4iAf6Fx5kyrMw+33V+Ip7uWldUnU2BYrrvtR+MLD22dcImm7DZN1st2wPPb91i0XEnQzvP0w1C/Q==
+  dependencies:
+    "@types/pouchdb-core" "*"
+    "@types/pouchdb-find" "*"
+
+"@types/pouchdb@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb/-/pouchdb-6.4.0.tgz#f9c41ca64b23029f9bf2eb4bf6956e6431cb79f8"
+  integrity sha512-eGCpX+NXhd5VLJuJMzwe3L79fa9+IDTrAG3CPaf4s/31PD56hOrhDJTSmRELSXuiqXr6+OHzzP0PldSaWsFt7w==
+  dependencies:
+    "@types/pouchdb-adapter-cordova-sqlite" "*"
+    "@types/pouchdb-adapter-fruitdown" "*"
+    "@types/pouchdb-adapter-http" "*"
+    "@types/pouchdb-adapter-idb" "*"
+    "@types/pouchdb-adapter-leveldb" "*"
+    "@types/pouchdb-adapter-localstorage" "*"
+    "@types/pouchdb-adapter-memory" "*"
+    "@types/pouchdb-adapter-node-websql" "*"
+    "@types/pouchdb-adapter-websql" "*"
+    "@types/pouchdb-browser" "*"
+    "@types/pouchdb-core" "*"
+    "@types/pouchdb-http" "*"
+    "@types/pouchdb-mapreduce" "*"
+    "@types/pouchdb-node" "*"
+    "@types/pouchdb-replication" "*"
 
 "@types/prettier@^2.1.5":
   version "2.6.3"

--- a/packages/backend-core/yarn.lock
+++ b/packages/backend-core/yarn.lock
@@ -291,11 +291,6 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/types@^1.0.209":
-  version "1.0.210"
-  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-1.0.210.tgz#b28f9d7b37d2cbc6b75ae8de201958ccc540cf06"
-  integrity sha512-16foNHGAlJxvh4IpPEPw9eZyIvA2n9nssrNu54Ag73E85A+mIiZ6NGHrw+mojrdC1yaSrj/xeQ461iYXdxT6/g==
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -922,7 +917,7 @@
     "@types/pouchdb-core" "*"
     "@types/pouchdb-find" "*"
 
-"@types/pouchdb@^6.4.0":
+"@types/pouchdb@6.4.0":
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/@types/pouchdb/-/pouchdb-6.4.0.tgz#f9c41ca64b23029f9bf2eb4bf6956e6431cb79f8"
   integrity sha512-eGCpX+NXhd5VLJuJMzwe3L79fa9+IDTrAG3CPaf4s/31PD56hOrhDJTSmRELSXuiqXr6+OHzzP0PldSaWsFt7w==


### PR DESCRIPTION
## Description
This addresses some of the problems with the `usage_quota` doc, where the write rate is so large for a single document that a hot shard is created and causes snowball CPU usage.

The `writethrough.ts` file provides wrappers for the `put` and `get` functionality provided by PouchDB, essentially you pass a database to it and then attempt to put or get items and it will use the cache as needed, based on the write rate that is specified.

This acts as a "debounce", reducing the rate at which a document/key is updated to that of once per specified update period. It will also handle when no document is present and will read from redis when it is available.

I've added some basic test cases to prove it out using the `timekeeper` package to control the value of `Date.now()` and confirm it works as expected.