### PR TITLE
Fix dates with custom templates

### DIFF
--- a/packages/bbui/src/Table/CellRenderer.svelte
+++ b/packages/bbui/src/Table/CellRenderer.svelte
@@ -26,11 +26,19 @@
     array: ArrayRenderer,
     internal: InternalRenderer,
   }
-  $: type = schema?.type ?? "string"
+  $: type = getType(schema)
   $: customRenderer = customRenderers?.find(x => x.column === schema?.name)
   $: renderer = customRenderer?.component ?? typeMap[type] ?? StringRenderer
   $: width = schema?.width || "150px"
   $: cellValue = getCellValue(value, schema.template)
+
+  const getType = schema => {
+    // Use a string renderer for dates if we use a custom template
+    if (schema?.type === "datetime" && schema?.template) {
+      return "string"
+    }
+    return schema?.type || "string"
+  }
 
   const getCellValue = (value, template) => {
     if (!template) {

--- a/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ColumnEditor/ColumnDrawer.svelte
+++ b/packages/builder/src/components/design/PropertiesPanel/PropertyControls/ColumnEditor/ColumnDrawer.svelte
@@ -178,7 +178,7 @@
   .column {
     gap: var(--spacing-l);
     display: grid;
-    grid-template-columns: 20px 1fr 1fr auto auto;
+    grid-template-columns: 20px 1fr 1fr 16px 16px;
     align-items: center;
     border-radius: var(--border-radius-s);
     transition: background-color ease-in-out 130ms;


### PR DESCRIPTION
## Description
This PR updates table cell renderer to use a string renderer for date values that use a custom expression. This means that if you have a date column and use a custom JS or HBS expression to alter the date, you'll now actually see the custom value, rather than having the value being parsed again by the date cell renderer. Also fixes a small issue with layout in the column editor component.

Here's a date field with a custom value, correctly being rendered in a table. Before this change, this would have displayed as `Invalid date` as this string would have been attempted to be parsed as a date.
![image](https://user-images.githubusercontent.com/9075550/175956947-d2835115-df8d-477d-867a-dc8c059d4868.png)

Addresses #6433.


