### PR TITLE
Fix the query of search_path to include the default search_path in postgres

### DIFF
--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -162,7 +162,9 @@ module PostgresModule {
       if (!this.config.schema) {
         this.config.schema = "public"
       }
-      this.client.query(`SET search_path TO ${this.config.schema}`)
+      this.client.query(
+        `SELECT set_config('search_path',current_setting('search_path') || ',${this.config.schema}',false) WHERE current_setting('search_path') !~ '(^|,)${this.config.schema}(,|$)';`
+      )
       this.COLUMNS_SQL = `select * from information_schema.columns where table_schema = '${this.config.schema}'`
       this.open = true
     }


### PR DESCRIPTION
## Description
Regarding Postgres, the current query of search_path is just to set the schema from config while ignoring the database default schema. For example, schema 'A' need to call a function in schema 'B' but the search_path is just set with schema 'A' so it cannot find the function. So when we set the search_path, we need to set it with the default schema.

## Screenshots
gen_random_uuid function exists in public schema but cannot call it.
![image](https://user-images.githubusercontent.com/114452/176439871-0e9ac907-ab12-49a0-8c57-7a82c02ee8e7.png)




