### PR TITLE
Properly invalidate the cached user

### DIFF
--- a/packages/backend-core/src/auth.js
+++ b/packages/backend-core/src/auth.js
@@ -20,6 +20,8 @@ const {
   internalApi,
 } = require("./middleware")
 
+const { invalidateUser } = require("./cache/user")
+
 // Strategies
 passport.use(new LocalStrategy(local.options, local.authenticate))
 passport.use(new JwtStrategy(jwt.options, jwt.authenticate))
@@ -149,6 +151,8 @@ async function updateUserOAuth(userId, oAuthConfig) {
     }
 
     await db.put(dbUser)
+
+    await invalidateUser(userId)
   } catch (e) {
     console.error("Could not update OAuth details for current user", e)
   }

--- a/packages/server/src/threads/query.js
+++ b/packages/server/src/threads/query.js
@@ -8,6 +8,7 @@ const {
   refreshOAuthToken,
   updateUserOAuth,
 } = require("@budibase/backend-core/auth")
+const { user: userCache } = require("@budibase/backend-core/cache")
 const { getGlobalIDFromUserMetadataID } = require("../db/utils")
 
 const { isSQL } = require("../integrations/utils")
@@ -112,15 +113,9 @@ class QueryRunner {
         info.code === 401 &&
         !this.hasRefreshedOAuth
       ) {
+        await this.refreshOAuth2(this.ctx)
         // Attempt to refresh the access token from the provider
         this.hasRefreshedOAuth = true
-        const authResponse = await this.refreshOAuth2(this.ctx)
-
-        if (!authResponse || authResponse.err) {
-          // In this event the user may have oAuth issues that
-          // could require re-authenticating with their provider.
-          throw new Error("OAuth2 access token could not be refreshed")
-        }
       }
 
       this.hasRerun = true
@@ -174,8 +169,7 @@ class QueryRunner {
     const { configId } = ctx.auth
 
     if (!providerType || !oauth2?.refreshToken) {
-      console.error("No refresh token found for authenticated user")
-      return
+      throw new Error("No refresh token found for authenticated user")
     }
 
     const resp = await refreshOAuthToken(
@@ -189,6 +183,11 @@ class QueryRunner {
     if (!resp.error) {
       const globalUserId = getGlobalIDFromUserMetadataID(_id)
       await updateUserOAuth(globalUserId, resp)
+      this.ctx.user = await userCache.getUser(globalUserId)
+    } else {
+      // In this event the user may have oAuth issues that
+      // could require re-authenticating with their provider.
+      throw new Error("OAuth2 access token could not be refreshed")
     }
 
     return resp

--- a/packages/server/src/threads/query.js
+++ b/packages/server/src/threads/query.js
@@ -180,14 +180,14 @@ class QueryRunner {
 
     // Refresh session flow. Should be in same location as refreshOAuthToken
     // There are several other properties available in 'resp'
-    if (!resp.error) {
+    if (!resp.err) {
       const globalUserId = getGlobalIDFromUserMetadataID(_id)
       await updateUserOAuth(globalUserId, resp)
       this.ctx.user = await userCache.getUser(globalUserId)
     } else {
       // In this event the user may have oAuth issues that
       // could require re-authenticating with their provider.
-      throw new Error("OAuth2 access token could not be refreshed")
+      throw new Error("OAuth2 access token could not be refreshed: " + resp.err.toString())
     }
 
     return resp

--- a/packages/server/src/threads/query.js
+++ b/packages/server/src/threads/query.js
@@ -187,7 +187,9 @@ class QueryRunner {
     } else {
       // In this event the user may have oAuth issues that
       // could require re-authenticating with their provider.
-      throw new Error("OAuth2 access token could not be refreshed: " + resp.err.toString())
+      throw new Error(
+        "OAuth2 access token could not be refreshed: " + resp.err.toString()
+      )
     }
 
     return resp


### PR DESCRIPTION
Authentication tokens were not properly being refreshed on the cached user when new ones were acquired. 

The user cache is now properly invalidated and updated with the correct values in the DB.
