### PR TITLE
More Smoke Build Test Changes - Timing for Smoke Build and Deleting Apps

### DIFF
--- a/packages/builder/cypress/integration/adminAndManagement/userManagement.spec.js
+++ b/packages/builder/cypress/integration/adminAndManagement/userManagement.spec.js
@@ -6,7 +6,7 @@ filterTests(["smoke", "all"], () => {
     before(() => {
       cy.login()
       cy.deleteApp("Cypress Tests")
-      cy.createApp("Cypress Tests")
+      cy.createApp("Cypress Tests", false)
     })
 
     it("should create a user via basic onboarding", () => {
@@ -45,7 +45,8 @@ filterTests(["smoke", "all"], () => {
                 if(i < 1){
                   cy.createApp(name)
                 } else {
-                  cy.visit(`${Cypress.config().baseUrl}/builder`)
+                  cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 5000})
+                  cy.wait(500)
                   cy.get(interact.CREATE_APP_BUTTON, { timeout: 1000 }).click({ force: true })
                   cy.createAppFromScratch(name)
                 }
@@ -53,7 +54,7 @@ filterTests(["smoke", "all"], () => {
             }
           })
         // Navigate back to the user
-        cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 500})
+        cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 5000})
         cy.get(interact.SPECTRUM_SIDENAV).contains("Users").click()
         cy.get(interact.SPECTRUM_TABLE, { timeout: 500 }).contains("bbuser").click()
         for (let i = 0; i < 3; i++) {

--- a/packages/builder/cypress/integration/appOverview.spec.js
+++ b/packages/builder/cypress/integration/appOverview.spec.js
@@ -5,6 +5,7 @@ filterTests(["all"], () => {
   context("Application Overview screen", () => {
     before(() => {
       cy.login()
+      cy.deleteAllApps()
       cy.createTestApp()
     })
 

--- a/packages/builder/cypress/integration/appPublishWorkflow.spec.js
+++ b/packages/builder/cypress/integration/appPublishWorkflow.spec.js
@@ -6,7 +6,8 @@ filterTests(['all'], () => {
   context("Publish Application Workflow", () => {
     before(() => {
       cy.login()
-      cy.createTestApp()
+      cy.deleteAllApps()
+      cy.createApp("Cypress Tests", false)
     })
 
     it("Should reflect the unpublished status correctly", () => {

--- a/packages/builder/cypress/integration/datasources/mySql.spec.js
+++ b/packages/builder/cypress/integration/datasources/mySql.spec.js
@@ -111,6 +111,7 @@ filterTests(["all"], () => {
           // Save relationship & reload page
           cy.get(".spectrum-Button").contains("Save").click({ force: true })
           cy.reload()
+          cy.wait(1000)
         })
         // Confirm table length & relationship name
         cy.get(".spectrum-Table", { timeout: 1000 })


### PR DESCRIPTION
Adding appropriate deleteAllApps commands and adding waits:

- The waits seem to be essential for the smoke build.
- Tests pass locally, but timing issues causes failure on the smoke build





