### PR TITLE
Cypress: Smoke Build Timing based Changes

### DIFF
--- a/packages/builder/cypress.json
+++ b/packages/builder/cypress.json
@@ -13,7 +13,7 @@
     "HOST_IP": ""
   },
   "retries": {
-    "runMode": 1,
+    "runMode": 0,
     "openMode": 0
   }
 }

--- a/packages/builder/cypress/integration/adminAndManagement/userManagement.spec.js
+++ b/packages/builder/cypress/integration/adminAndManagement/userManagement.spec.js
@@ -174,14 +174,16 @@ filterTests(["smoke", "all"], () => {
 
     it("Should edit user details within user details page", () => {
       // Add First name
-      cy.get(interact.FIELD, { timeout: 500 }).eq(2).within(() => {
-        cy.get(interact.SPECTRUM_TEXTFIELD_INPUT, { timeout: 500 }).type("bb")
+      cy.get(interact.FIELD, { timeout: 1000 }).eq(2).within(() => {
+        cy.wait(500)
+        cy.get(interact.SPECTRUM_TEXTFIELD_INPUT, { timeout: 1000 }).click().type("bb")
       })
       // Add Last name
-      cy.get(interact.FIELD).eq(3).within(() => {
-        cy.get(interact.SPECTRUM_TEXTFIELD_INPUT).type("test")
+      cy.get(interact.FIELD, { timeout: 1000 }).eq(3).within(() => {
+        cy.wait(500)
+        cy.get(interact.SPECTRUM_TEXTFIELD_INPUT, { timeout: 1000 }).click().type("test")
       })
-      cy.get(interact.FIELD).eq(0).click()
+      cy.get(interact.FIELD, { timeout: 1000 }).eq(0).click()
       // Reload page
       cy.reload()
 
@@ -189,8 +191,8 @@ filterTests(["smoke", "all"], () => {
       cy.get(interact.FIELD, { timeout: 1000 }).eq(2).within(() => {
         cy.get(interact.SPECTRUM_TEXTFIELD_INPUT).should('have.value', "bb")
       })
-      cy.get(interact.FIELD).eq(3).within(() => {
-        cy.get(interact.SPECTRUM_TEXTFIELD_INPUT, { timeout: 500 }).should('have.value', "test")
+      cy.get(interact.FIELD, { timeout: 1000 }).eq(3).within(() => {
+        cy.get(interact.SPECTRUM_TEXTFIELD_INPUT, { timeout: 1000 }).should('have.value', "test")
       })
     })
 

--- a/packages/builder/cypress/integration/appOverview.spec.js
+++ b/packages/builder/cypress/integration/appOverview.spec.js
@@ -301,7 +301,7 @@ filterTests(["all"], () => {
     })
 
     it("Should allow editing of the app details.", () => {
-      cy.visit(`${Cypress.config().baseUrl}/builder`)
+      cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 5000 })
       cy.get(".appTable .app-row-actions button")
         .contains("Manage")
         .eq(0)
@@ -316,7 +316,8 @@ filterTests(["all"], () => {
       cy.updateAppName("sample name")
 
       //publish and check its disabled
-      cy.visit(`${Cypress.config().baseUrl}/builder`)
+      cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 5000 })
+      cy.wait(500)
       cy.get(".appTable .app-row-actions button")
         .contains("Edit")
         .eq(0)
@@ -332,7 +333,7 @@ filterTests(["all"], () => {
           cy.wait(1000)
         })
 
-      cy.visit(`${Cypress.config().baseUrl}/builder`)
+      cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 5000 })
       cy.get(".appTable .app-row-actions button", { timeout: 1000 })
         .contains("Manage")
         .eq(0)

--- a/packages/builder/cypress/integration/appPublishWorkflow.spec.js
+++ b/packages/builder/cypress/integration/appPublishWorkflow.spec.js
@@ -11,7 +11,7 @@ filterTests(['all'], () => {
     })
 
     it("Should reflect the unpublished status correctly", () => {
-      cy.visit(`${Cypress.config().baseUrl}/builder`)
+      cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 5000 })
 
       cy.get(interact.APP_TABLE_STATUS, { timeout: 3000 }).eq(0)
       .within(() => {
@@ -30,6 +30,7 @@ filterTests(['all'], () => {
 
     it("Should publish an application and correctly reflect that", () => {
       //Assuming the previous test was run and the unpublished app is open in edit mode.
+      cy.closeModal()
       cy.get(interact.TOPRIGHTNAV_BUTTON_SPECTRUM).contains("Publish").click({ force : true })
 
       cy.get(interact.DEPLOY_APP_MODAL).should("be.visible")
@@ -73,7 +74,7 @@ filterTests(['all'], () => {
     it("Should unpublish an application using the link and reflect the status change", () => {
       //Assuming the previous test app exists and is published
 
-      cy.visit(`${Cypress.config().baseUrl}/builder`)
+      cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 5000 })
 
       cy.get(interact.APP_TABLE_STATUS).eq(0)
       .within(() => {
@@ -86,6 +87,7 @@ filterTests(['all'], () => {
         cy.get(interact.APP_TABLE_APP_NAME).click({ force: true })
       })
 
+      cy.closeModal()
       cy.get(interact.DEPLOYMENT_TOP_GLOBE).should("exist").click({ force: true })
       
       cy.get("[data-cy='publish-popover-menu']")
@@ -98,7 +100,8 @@ filterTests(['all'], () => {
         cy.get(interact.CONFIRM_WRAP_BUTTON).click({ force: true }
       )})
 
-      cy.visit(`${Cypress.config().baseUrl}/builder`)
+      cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 6000 })
+      cy.wait(500)
       cy.get(interact.APP_TABLE_STATUS, { timeout: 1000 }).eq(0).contains("Unpublished")
 
     })


### PR DESCRIPTION
Still some timing issues against the smoke build, but less this time.

- Mainly adding timeouts against cy.visit
- Improving some structure with the close modal command in a few places



