### PR TITLE
Cypress: User Details Test Fix

### DIFF
--- a/packages/builder/cypress/integration/adminAndManagement/userManagement.spec.js
+++ b/packages/builder/cypress/integration/adminAndManagement/userManagement.spec.js
@@ -176,12 +176,12 @@ filterTests(["smoke", "all"], () => {
       // Add First name
       cy.get(interact.FIELD, { timeout: 1000 }).eq(2).within(() => {
         cy.wait(500)
-        cy.get(interact.SPECTRUM_TEXTFIELD_INPUT, { timeout: 1000 }).click().type("bb")
+        cy.get(interact.SPECTRUM_TEXTFIELD_INPUT, { timeout: 1000 }).wait(500).clear().click().type("bb")
       })
       // Add Last name
       cy.get(interact.FIELD, { timeout: 1000 }).eq(3).within(() => {
         cy.wait(500)
-        cy.get(interact.SPECTRUM_TEXTFIELD_INPUT, { timeout: 1000 }).click().type("test")
+        cy.get(interact.SPECTRUM_TEXTFIELD_INPUT, { timeout: 1000 }).click().wait(500).clear().type("test")
       })
       cy.get(interact.FIELD, { timeout: 1000 }).eq(0).click()
       // Reload page


### PR DESCRIPTION
It seems that at times, Cypress is running so fast that it does not type entire words (it sometimes misses the first couple of letters.

I've put a small change in the userManagement test file to try and revolve this.
- Adding a wait and clear in association with the type command