### PR TITLE
Fixed expression mutation

### DIFF
--- a/packages/server/src/api/routes/tests/query.spec.js
+++ b/packages/server/src/api/routes/tests/query.spec.js
@@ -218,7 +218,6 @@ describe("/queries", () => {
       expect(res.body.schemaFields).toEqual(["a", "b"])
       expect(res.body.rows.length).toEqual(1)
       expect(events.query.previewed).toBeCalledTimes(1)
-      datasource.config = { schema: "public" }
       expect(events.query.previewed).toBeCalledWith(datasource, query)
     })
 

--- a/packages/server/src/threads/query.js
+++ b/packages/server/src/threads/query.js
@@ -191,8 +191,9 @@ class QueryRunner {
     } else {
       // In this event the user may have oAuth issues that
       // could require re-authenticating with their provider.
+      let errorMessage = resp.err.data ? resp.err.data : resp.err.toString()
       throw new Error(
-        "OAuth2 access token could not be refreshed: " + resp.err.toString()
+        "OAuth2 access token could not be refreshed: " + errorMessage
       )
     }
 


### PR DESCRIPTION
## Description
I found an issue where upon retrying a rest query after updating the accessToken, any expressions used to embed the token had already been mutated by the previous attempt. This fix ensures the process preserves the original.

Addresses: https://github.com/Budibase/budibase/issues/3827

