### PR TITLE
6491 - move date range picker to data category

### DIFF
--- a/packages/builder/src/components/design/AppPreview/componentStructure.json
+++ b/packages/builder/src/components/design/AppPreview/componentStructure.json
@@ -23,7 +23,8 @@
       "dataprovider",
       "repeater",
       "table",
-      "dynamicfilter"
+      "dynamicfilter",
+      "daterangepicker"
     ]
   },
   {
@@ -42,7 +43,6 @@
       "datetimefield",
       "attachmentfield",
       "relationshipfield",
-      "daterangepicker",
       "multifieldselect",
       "jsonfield",
       "s3upload"


### PR DESCRIPTION
## Description
The date picker belongs to the data components instead of the form components

Addresses: 
- #6491 

## Screenshots
<img width="686" alt="image" src="https://user-images.githubusercontent.com/1907152/178010486-26033b4b-cfb7-4529-8c00-4d1f926c041d.png">



