### PR TITLE
prevent redirect on app overview by allowing builders access to user …

### DIFF
--- a/packages/worker/src/api/routes/global/users.js
+++ b/packages/worker/src/api/routes/global/users.js
@@ -69,7 +69,7 @@ router
   )
   .get("/api/global/users/tenant/:id", controller.tenantUserLookup)
   // global endpoint but needs to come at end (blocks other endpoints otherwise)
-  .get("/api/global/users/:id", adminOnly, controller.find)
+  .get("/api/global/users/:id", builderOrAdmin, controller.find)
   // DEPRECATED - use new versions with self API
   .get("/api/global/users/self", selfController.getSelf)
   .post(


### PR DESCRIPTION
…endpoint

## Description
Prevent redirection on app overview page for non-admin users trying to access to `/api/global/users/:id` endpoint.

Addresses: 
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._



