### PR TITLE
Design polish + misc fixes

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItemHeader.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItemHeader.svelte
@@ -96,7 +96,7 @@
           onSelect(block)
         }}
       >
-        <Icon name={blockComplete ? "ChevronUp" : "ChevronDown"} />
+        <Icon hoverable name={blockComplete ? "ChevronUp" : "ChevronDown"} />
       </div>
     </div>
   </div>

--- a/packages/builder/src/components/automation/AutomationBuilder/TestDisplay.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/TestDisplay.svelte
@@ -67,27 +67,20 @@
           {/if}
 
           <div class="tabs">
-            <Tabs quiet noPadding selected="Input">
+            <Tabs noHorizPadding selected="Input">
               <Tab title="Input">
-                <div style="padding: 10px 10px 10px 10px;">
-                  <TextArea
-                    minHeight="80px"
-                    disabled
-                    value={textArea(filteredResults?.[idx]?.inputs, "No input")}
-                  />
-                </div></Tab
-              >
+                <TextArea
+                  minHeight="80px"
+                  disabled
+                  value={textArea(filteredResults?.[idx]?.inputs, "No input")}
+                />
+              </Tab>
               <Tab title="Output">
-                <div style="padding: 10px 10px 10px 10px;">
-                  <TextArea
-                    minHeight="100px"
-                    disabled
-                    value={textArea(
-                      filteredResults?.[idx]?.outputs,
-                      "No output"
-                    )}
-                  />
-                </div>
+                <TextArea
+                  minHeight="100px"
+                  disabled
+                  value={textArea(filteredResults?.[idx]?.outputs, "No output")}
+                />
               </Tab>
             </Tabs>
           </div>
@@ -113,6 +106,7 @@
     align-items: stretch;
     position: relative;
     flex: 1 1 auto;
+    padding: 0 var(--spacing-xl) var(--spacing-xl) var(--spacing-xl);
   }
 
   .block {

--- a/packages/builder/src/components/portal/overview/automation/HistoryDetailsPanel.svelte
+++ b/packages/builder/src/components/portal/overview/automation/HistoryDetailsPanel.svelte
@@ -23,7 +23,7 @@
         <ActionButton noPadding size="S" icon="Close" quiet on:click={close} />
       </div>
     </div>
-    <Layout paddingX="XL" gap="S">
+    <Layout paddingY="XL" paddingX="XL" gap="S">
       <div class="icon">
         <Icon name="Clock" />
         <DateTimeRenderer value={history.createdAt} />
@@ -71,7 +71,6 @@
   }
 
   .bottom {
-    margin-top: var(--spacing-m);
     border-top: var(--border-light);
     padding-top: calc(var(--spacing-xl) * 2);
     padding-bottom: calc(var(--spacing-xl) * 2);

--- a/packages/builder/src/components/portal/overview/automation/HistoryTab.svelte
+++ b/packages/builder/src/components/portal/overview/automation/HistoryTab.svelte
@@ -157,6 +157,7 @@
           data={runHistory}
           {customRenderers}
           placeholderText="No history found"
+          border={false}
         />
         <div class="pagination">
           <Pagination
@@ -186,7 +187,8 @@
     display: grid;
     grid-template-columns: 1fr;
     height: 100%;
-    padding: var(--spacing-xl) var(--spectrum-alias-grid-gutter-large);
+    padding: var(--spectrum-alias-grid-gutter-medium)
+      var(--spectrum-alias-grid-gutter-large);
   }
 
   .search {
@@ -209,7 +211,7 @@
 
   .panel {
     display: none;
-    margin-top: calc(-1 * var(--spacing-xl));
+    margin-top: calc(-1 * var(--spectrum-alias-grid-gutter-medium));
   }
 
   .panelShow {

--- a/packages/builder/src/components/portal/overview/automation/HistoryTab.svelte
+++ b/packages/builder/src/components/portal/overview/automation/HistoryTab.svelte
@@ -119,7 +119,7 @@
 </script>
 
 <div class="root" class:panelOpen={showPanel}>
-  <Layout paddingX="XL" gap="S" alignContent="start">
+  <Layout noPadding gap="M" alignContent="start">
     <div class="search">
       <div class="select">
         <Select
@@ -147,16 +147,27 @@
       </div>
     </div>
     {#if runHistory}
-      <Table
-        on:click={viewDetails}
-        schema={runHistorySchema}
-        allowSelectRows={false}
-        allowEditColumns={false}
-        allowEditRows={false}
-        data={runHistory}
-        {customRenderers}
-        placeholderText="No history found"
-      />
+      <div>
+        <Table
+          on:click={viewDetails}
+          schema={runHistorySchema}
+          allowSelectRows={false}
+          allowEditColumns={false}
+          allowEditRows={false}
+          data={runHistory}
+          {customRenderers}
+          placeholderText="No history found"
+        />
+        <div class="pagination">
+          <Pagination
+            page={$pageInfo.pageNumber}
+            hasPrevPage={$pageInfo.loading ? false : $pageInfo.hasPrevPage}
+            hasNextPage={$pageInfo.loading ? false : $pageInfo.hasNextPage}
+            goToPrevPage={pageInfo.prevPage}
+            goToNextPage={pageInfo.nextPage}
+          />
+        </div>
+      </div>
     {/if}
   </Layout>
   <div class="panel" class:panelShow={showPanel}>
@@ -169,26 +180,18 @@
     />
   </div>
 </div>
-<div class="pagination">
-  <Pagination
-    page={$pageInfo.pageNumber}
-    hasPrevPage={$pageInfo.loading ? false : $pageInfo.hasPrevPage}
-    hasNextPage={$pageInfo.loading ? false : $pageInfo.hasNextPage}
-    goToPrevPage={pageInfo.prevPage}
-    goToNextPage={pageInfo.nextPage}
-  />
-</div>
 
 <style>
   .root {
     display: grid;
     grid-template-columns: 1fr;
     height: 100%;
+    padding: var(--spacing-xl) var(--spectrum-alias-grid-gutter-large);
   }
 
   .search {
     display: flex;
-    gap: var(--spacing-l);
+    gap: var(--spacing-xl);
     width: 100%;
     align-items: flex-end;
   }
@@ -198,15 +201,15 @@
   }
 
   .pagination {
-    position: absolute;
-    bottom: 0;
-    margin-bottom: var(--spacing-xl);
-    margin-left: var(--spacing-l);
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    margin-top: var(--spacing-xl);
   }
 
   .panel {
     display: none;
-    background-color: var(--background);
+    margin-top: calc(-1 * var(--spacing-xl));
   }
 
   .panelShow {

--- a/packages/builder/src/pages/builder/portal/overview/[application]/index.svelte
+++ b/packages/builder/src/pages/builder/portal/overview/[application]/index.svelte
@@ -395,7 +395,7 @@
     line-height: 1em;
     margin-bottom: var(--spacing-s);
   }
-  .tab-wrap :global(.spectrum-Tabs) {
+  .tab-wrap :global(> .spectrum-Tabs) {
     padding-left: var(--spectrum-alias-grid-gutter-large);
     padding-right: var(--spectrum-alias-grid-gutter-large);
   }

--- a/packages/builder/src/pages/builder/portal/overview/[application]/index.svelte
+++ b/packages/builder/src/pages/builder/portal/overview/[application]/index.svelte
@@ -207,11 +207,6 @@
 <span class="overview-wrap">
   <Page wide noPadding>
     {#await promise}
-      <span class="page-header">
-        <ActionButton secondary icon={"ArrowLeft"} on:click={backToAppList}>
-          Back
-        </ActionButton>
-      </span>
       <div class="loading">
         <ProgressCircle size="XL" />
       </div>

--- a/packages/builder/src/pages/builder/portal/overview/_components/SettingsTab.svelte
+++ b/packages/builder/src/pages/builder/portal/overview/_components/SettingsTab.svelte
@@ -58,16 +58,16 @@
         </Layout>
       </span>
       <span class="version-section">
-        <Layout gap="XS" paddingY="XXL" paddingX="">
+        <Layout gap="XS" noPadding>
           <Heading size="S">App version</Heading>
           <Divider />
           <Body>
             {#if updateAvailable}
-              <p class="version-status">
+              <Body>
                 The app is currently using version
                 <strong>{$store.version}</strong>
                 but version <strong>{clientPackage.version}</strong> is available.
-              </p>
+              </Body>
             {:else}
               <p class="version-status">
                 The app is currently using version

--- a/packages/client/src/components/app/Layout.svelte
+++ b/packages/client/src/components/app/Layout.svelte
@@ -323,6 +323,9 @@
     position: relative;
     padding: 32px;
   }
+  .main.size--max {
+    padding: 0;
+  }
   .layout--none .main {
     padding: 0;
   }
@@ -464,6 +467,9 @@
   /* Reduce padding */
   .mobile:not(.layout--none) .main {
     padding: 16px;
+  }
+  .mobile .main.size--max {
+    padding: 0;
   }
 
   /* Transform links into drawer */

--- a/packages/client/src/components/app/blocks/CardsBlock.svelte
+++ b/packages/client/src/components/app/blocks/CardsBlock.svelte
@@ -98,7 +98,7 @@
         })
       }
     })
-    return enrichedColumns.slice(0, 3)
+    return enrichedColumns.slice(0, 5)
   }
 
   // Builds a full details page URL for the card title

--- a/packages/client/src/components/app/blocks/TableBlock.svelte
+++ b/packages/client/src/components/app/blocks/TableBlock.svelte
@@ -89,7 +89,7 @@
         })
       }
     })
-    return enrichedColumns.slice(0, 3)
+    return enrichedColumns.slice(0, 5)
   }
 
   // Load the datasource schema so we can determine column types


### PR DESCRIPTION
## Description
Bunch of small fixes and features and some design polishing.

- Remove back button from flashing while loading app overview
- Adjust spacing on automation run log tab to look better and match designs
![image](https://user-images.githubusercontent.com/9075550/178727234-2c41b968-0f5a-4a72-8d4a-22076f7ea7f7.png)
- Move automation run log pagination control to bottom right of table to match convention
![image](https://user-images.githubusercontent.com/9075550/178727344-e4093ba0-0263-4e21-a712-0d6526714cfc.png)
- Tidy up some spacing in automation details panel and add hover states to some clickable icons for better UX
![image](https://user-images.githubusercontent.com/9075550/178727965-a1282ed9-9da3-4d69-a860-42a8d2fd414e.png)
![image](https://user-images.githubusercontent.com/9075550/178727565-0d763cfe-7139-4ae3-b0de-6922d0e8d5a7.png)
- Make spacing consistent in app settings tab
![image](https://user-images.githubusercontent.com/9075550/178727460-7290d606-e45e-4b61-a200-17cd742c90f3.png)
- Update table and cards block filter limit to 5 #6664
![image](https://user-images.githubusercontent.com/9075550/178728172-1f38e998-4804-474f-b1b8-9274a7418d02.png)
- Remove layout padding for "max" width screens #6657
![image](https://user-images.githubusercontent.com/9075550/178728241-4416c793-71b1-4364-b61b-d7cc737f0a48.png)
