### PR TITLE
Update koa2-ratelimit

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -117,7 +117,7 @@
     "koa-send": "5.0.0",
     "koa-session": "5.12.0",
     "koa-static": "5.0.0",
-    "koa2-ratelimit": "1.1.0",
+    "koa2-ratelimit": "1.1.1",
     "lodash": "4.17.21",
     "memorystream": "0.3.1",
     "mongodb": "3.6.3",


### PR DESCRIPTION
Update koa2-ratelimit to _hopefully_ fix ratelimit not being reset after the set interval.

## Description
I just came across the same issue in the above issue. Ratelimits for the API weren't being reset even after the set period of time elapsed. The account was stuck in limbo not able to run any API requests. The issue suggested bumping the koa2-ratelimit package to v1.1.1 to fix the issue. I haven't bumped the yarn.lock file in this commit as I'm creating the commit from the Github website instead.

Addresses: 
- #5469

