### PR TITLE
Add version modal back into builder

### DIFF
--- a/packages/builder/src/components/deploy/VersionModal.svelte
+++ b/packages/builder/src/components/deploy/VersionModal.svelte
@@ -69,7 +69,14 @@
 
 {#if !hideIcon}
   <div class="icon-wrapper" class:highlight={updateAvailable}>
-    <Icon name="Refresh" hoverable on:click={updateModal.show} />
+    <Icon
+      name="Refresh"
+      hoverable
+      on:click={updateModal.show}
+      tooltip={updateAvailable
+        ? "An update is available"
+        : "No updates are available"}
+    />
   </div>
 {/if}
 <Modal bind:this={updateModal}>

--- a/packages/builder/src/pages/builder/app/[application]/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/_layout.svelte
@@ -3,6 +3,7 @@
   import { roles, flags } from "stores/backend"
   import { Icon, Tabs, Tab, Heading, notifications } from "@budibase/bbui"
   import RevertModal from "components/deploy/RevertModal.svelte"
+  import VersionModal from "components/deploy/VersionModal.svelte"
   import DeployNavigation from "components/deploy/DeployNavigation.svelte"
   import { API } from "api"
   import { isActive, goto, layout, redirect } from "@roxi/routify"
@@ -107,6 +108,7 @@
         </Tabs>
       </div>
       <div class="toprightnav">
+        <VersionModal />
         <RevertModal />
         <Icon
           name="Visibility"


### PR DESCRIPTION
## Description
Adds the version modal back into the builder. This is a temporary measure until we properly address the app update UX. Currently app updates are very hidden, yet updating the client app version is an important step in enabling full use of the new design UI features.

Also adds a tooltip to this icon to be in line with the rest of the new design UI top icons.

Functionally this is identical to the version modal which was historically here.

## Screenshots
![image](https://user-images.githubusercontent.com/9075550/178769342-2d929431-d4e1-4966-955e-779103ba1974.png)




