### PR TITLE
only add account portal people to intercom

### DIFF
--- a/packages/builder/src/analytics/IntercomClient.js
+++ b/packages/builder/src/analytics/IntercomClient.js
@@ -52,13 +52,13 @@ export default class IntercomClient {
    * @param {Object} user - user to identify
    * @returns Intercom global object
    */
-  show(user = {}) {
-    if (this.initialised && user?.admin && user?.cloud) {
-      return window.Intercom("boot", {
-        app_id: this.token,
-        ...user,
-      })
-    }
+  show(user = {}, enabled) {
+    if (!this.initialised || !enabled) return
+
+    return window.Intercom("boot", {
+      app_id: this.token,
+      ...user,
+    })
   }
 
   /**

--- a/packages/builder/src/stores/portal/auth.js
+++ b/packages/builder/src/stores/portal/auth.js
@@ -54,23 +54,24 @@ export function createAuthStore() {
     })
 
     if (user) {
-      const adminStore = get(admin)
       analytics
         .activate()
         .then(() => {
           analytics.identify(user._id)
-          analytics.showChat({
-            email: user.email,
-            created_at: (user.createdAt || Date.now()) / 1000,
-            name: user.account?.name,
-            user_id: user._id,
-            tenant: user.tenantId,
-            admin: user?.admin?.global,
-            builder: user?.builder?.global,
-            "Company size": user.account?.size,
-            "Job role": user.account?.profession,
-            cloud: adminStore.cloud,
-          })
+          analytics.showChat(
+            {
+              email: user.email,
+              created_at: (user.createdAt || Date.now()) / 1000,
+              name: user.account?.name,
+              user_id: user._id,
+              tenant: user.tenantId,
+              admin: user?.admin?.global,
+              builder: user?.builder?.global,
+              "Company size": user.account?.size,
+              "Job role": user.account?.profession,
+            },
+            !!user?.account
+          )
         })
         .catch(() => {
           // This request may fail due to browser extensions blocking requests


### PR DESCRIPTION
## Description
Found a better way to do this - that ensures that only account portal users will be shown the bubble.

Addresses: 
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._



