### PR TITLE
Quick fix for single image volumes

### DIFF
--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -122,8 +122,7 @@ RUN yarn cache clean -f
 
 EXPOSE 80
 EXPOSE 443
-VOLUME /opt/couchdb/data
-VOLUME /minio
+VOLUME /data
 
 #  setup letsencrypt certificate
 RUN apt-get install -y certbot python3-certbot-nginx


### PR DESCRIPTION
## Description
Removing the volume tags from the old directories, instead focusing on the single data directory that is now used - #6715.

Previously we had two separate volumes that had to be mounted, I merged these into a single, simple directory to make use of the image easier, but I hadn't removed the old volume references that things like portainer picks up.