### PR TITLE
Frontend store improvements for conflicts and performance

### DIFF
--- a/packages/builder/src/builderStore/index.js
+++ b/packages/builder/src/builderStore/index.js
@@ -2,7 +2,6 @@ import { getFrontendStore } from "./store/frontend"
 import { getAutomationStore } from "./store/automation"
 import { getThemeStore } from "./store/theme"
 import { derived } from "svelte/store"
-import { LAYOUT_NAMES } from "../constants"
 import { findComponent, findComponentPath } from "./componentUtils"
 import { RoleUtils } from "@budibase/frontend-core"
 
@@ -27,6 +26,10 @@ export const selectedComponent = derived(
     return findComponent($selectedScreen?.props, $store.selectedComponentId)
   }
 )
+
+// For legacy compatibility only, but with the new design UI this is just
+// the selected screen
+export const currentAsset = selectedScreen
 
 export const sortedScreens = derived(store, $store => {
   return $store.screens.slice().sort((a, b) => {
@@ -66,12 +69,3 @@ export const selectedComponentPath = derived(
     ).map(component => component._id)
   }
 )
-
-export const mainLayout = derived(store, $store => {
-  return $store.layouts?.find(
-    layout => layout._id === LAYOUT_NAMES.MASTER.PRIVATE
-  )
-})
-
-// For compatibility
-export const currentAsset = selectedScreen

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -177,15 +177,6 @@ export const getFrontendStore = () => {
         })
       },
     },
-    routing: {
-      fetch: async () => {
-        const response = await API.fetchAppRoutes()
-        store.update(state => {
-          state.routes = response.routes
-          return state
-        })
-      },
-    },
     screens: {
       select: screenId => {
         // Check this screen exists
@@ -214,23 +205,27 @@ export const getFrontendStore = () => {
       save: async screen => {
         const creatingNewScreen = screen._id === undefined
         const savedScreen = await API.saveScreen(screen)
+        const routesResponse = await API.fetchAppRoutes()
         store.update(state => {
+          // Update screen object
           const idx = state.screens.findIndex(x => x._id === savedScreen._id)
           if (idx !== -1) {
             state.screens.splice(idx, 1, savedScreen)
           } else {
             state.screens.push(savedScreen)
           }
+
+          // Select the new screen if creating a new one
+          if (creatingNewScreen) {
+            state.selectedScreenId = savedScreen._id
+            state.selectedComponentId = savedScreen.props._id
+          }
+
+          // Update routes
+          state.routes = routesResponse.routes
+
           return state
         })
-
-        // Refresh routes
-        await store.actions.routing.fetch()
-
-        // Select the new screen if creating a new one
-        if (creatingNewScreen) {
-          store.actions.screens.select(savedScreen._id)
-        }
         return savedScreen
       },
       delete: async screens => {

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -642,9 +642,11 @@ export const getFrontendStore = () => {
           }
         })
 
-        // Update state
         store.update(state => {
-          delete state.componentToPaste
+          // Remove copied component if cutting
+          if (state.componentToPaste.isCut) {
+            delete state.componentToPaste
+          }
           state.selectedComponentId = newComponentId
           return state
         })

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -61,6 +61,10 @@ const INITIAL_FRONTEND_STATE = {
 export const getFrontendStore = () => {
   const store = writable({ ...INITIAL_FRONTEND_STATE })
 
+  store.subscribe(state => {
+    console.log("new state")
+  })
+
   store.actions = {
     reset: () => {
       store.set({ ...INITIAL_FRONTEND_STATE })
@@ -184,12 +188,24 @@ export const getFrontendStore = () => {
     },
     screens: {
       select: screenId => {
-        store.update(state => {
-          let screens = state.screens
-          let screen =
-            screens.find(screen => screen._id === screenId) || screens[0]
-          if (!screen) return state
+        // Check this screen exists
+        const state = get(store)
+        const screen = state.screens.find(screen => screen._id === screenId)
+        console.log(screen)
+        if (!screen) {
+          return
+        }
 
+        // Check screen isn't already selected
+        if (
+          state.selectedScreenId === screen._id &&
+          state.selectedComponentId === screen.props?._id
+        ) {
+          return
+        }
+
+        // Select new screen
+        store.update(state => {
           state.selectedScreenId = screen._id
           state.selectedComponentId = screen.props?._id
           return state

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -333,7 +333,7 @@ export const getFrontendStore = () => {
       select: layoutId => {
         // Check this layout exists
         const state = get(store)
-        const layout = store.actions.layouts.find(layoutId)
+        const layout = state.layouts.find(layout => layout._id === layoutId)
         if (!layout) {
           return
         }
@@ -353,32 +353,6 @@ export const getFrontendStore = () => {
           return state
         })
       },
-      save: async layout => {
-        const creatingNewLayout = layout._id === undefined
-        const savedLayout = await API.saveLayout(layout)
-        store.update(state => {
-          const idx = state.layouts.findIndex(x => x._id === savedLayout._id)
-          if (idx !== -1) {
-            state.layouts.splice(idx, 1, savedLayout)
-          } else {
-            state.layouts.push(savedLayout)
-          }
-          return state
-        })
-
-        // Select layout if creating a new one
-        if (creatingNewLayout) {
-          store.actions.layouts.select(savedLayout._id)
-        }
-        return savedLayout
-      },
-      find: layoutId => {
-        if (!layoutId) {
-          return get(mainLayout)
-        }
-        const storeContents = get(store)
-        return storeContents.layouts.find(layout => layout._id === layoutId)
-      },
       delete: async layout => {
         if (!layout?._id) {
           return
@@ -388,10 +362,6 @@ export const getFrontendStore = () => {
           layoutRev: layout._rev,
         })
         store.update(state => {
-          // Select main layout if we deleted the selected layout
-          if (layout._id === state.selectedLayoutId) {
-            state.selectedLayoutId = get(mainLayout)._id
-          }
           state.layouts = state.layouts.filter(x => x._id !== layout._id)
           return state
         })

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -309,13 +309,17 @@ export const getFrontendStore = () => {
             )
           })
           if (existingHomeScreen) {
-            const patch = screen => (screen.routing.homeScreen = false)
+            const patch = screen => {
+              screen.routing.homeScreen = false
+            }
             await store.actions.screens.patch(patch, existingHomeScreen._id)
           }
         }
 
         // Update the passed in screen
-        const patch = screen => (screen.routing.homeScreen = makeHomeScreen)
+        const patch = screen => {
+          screen.routing.homeScreen = makeHomeScreen
+        }
         await store.actions.screens.patch(patch, screen._id)
       },
       removeCustomLayout: async screen => {

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -583,7 +583,7 @@ export const getFrontendStore = () => {
           }
         }
       },
-      paste: async (targetComponent, mode) => {
+      paste: async (targetComponent, mode, targetScreen) => {
         const state = get(store)
         if (!state.componentToPaste) {
           return
@@ -591,7 +591,7 @@ export const getFrontendStore = () => {
         let newComponentId
 
         // Patch screen
-        await store.actions.screens.patch(screen => {
+        const patch = screen => {
           // Get up to date ref to target
           targetComponent = findComponent(screen.props, targetComponent._id)
           if (!targetComponent) {
@@ -640,13 +640,16 @@ export const getFrontendStore = () => {
             const index = mode === "above" ? targetIndex : targetIndex + 1
             parent._children.splice(index, 0, componentToPaste)
           }
-        })
+        }
+        const targetScreenId = targetScreen?._id || state.selectedScreenId
+        await store.actions.screens.patch(patch, targetScreenId)
 
         store.update(state => {
           // Remove copied component if cutting
           if (state.componentToPaste.isCut) {
             delete state.componentToPaste
           }
+          state.selectedScreenId = targetScreenId
           state.selectedComponentId = newComponentId
           return state
         })

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -294,25 +294,27 @@ export const getFrontendStore = () => {
             )
           })
           if (existingHomeScreen) {
-            const patchFn = screen => (screen.routing.homeScreen = false)
+            const patch = screen => (screen.routing.homeScreen = false)
             promises.push(
-              store.actions.screens.patch(existingHomeScreen._id, patchFn)
+              store.actions.screens.patch(existingHomeScreen._id, patch)
             )
           }
         }
 
         // Update the passed in screen
-        const patchFn = screen => (screen.routing.homeScreen = makeHomeScreen)
-        promises.push(store.actions.screens.patch(screen._id, patchFn))
+        const patch = screen => (screen.routing.homeScreen = makeHomeScreen)
+        promises.push(store.actions.screens.patch(screen._id, patch))
         return await Promise.all(promises)
       },
       removeCustomLayout: async screen => {
         // Pull relevant settings from old layout, if required
         const layout = get(store).layouts.find(x => x._id === screen.layoutId)
-        screen.layoutId = null
-        screen.showNavigation = layout?.props.navigation !== "None"
-        screen.width = layout?.props.width || "Large"
-        await store.actions.screens.save(screen)
+        const patch = screen => {
+          screen.layoutId = null
+          screen.showNavigation = layout?.props.navigation !== "None"
+          screen.width = layout?.props.width || "Large"
+        }
+        await store.actions.screens.patch(screen._id, patch)
       },
     },
     preview: {

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -1,6 +1,6 @@
 import { get, writable } from "svelte/store"
 import { cloneDeep } from "lodash/fp"
-import { currentAsset, selectedScreen, selectedComponent } from "builderStore"
+import { selectedScreen, selectedComponent } from "builderStore"
 import {
   datasources,
   integrations,
@@ -155,12 +155,12 @@ export const getFrontendStore = () => {
     theme: {
       save: async theme => {
         const appId = get(store).appId
-        await API.saveAppMetadata({
+        const app = await API.saveAppMetadata({
           appId,
           metadata: { theme },
         })
         store.update(state => {
-          state.theme = theme
+          state.theme = app.theme
           return state
         })
       },
@@ -168,12 +168,12 @@ export const getFrontendStore = () => {
     customTheme: {
       save: async customTheme => {
         const appId = get(store).appId
-        await API.saveAppMetadata({
+        const app = await API.saveAppMetadata({
           appId,
           metadata: { customTheme },
         })
         store.update(state => {
-          state.customTheme = customTheme
+          state.customTheme = app.customTheme
           return state
         })
       },
@@ -181,12 +181,12 @@ export const getFrontendStore = () => {
     navigation: {
       save: async navigation => {
         const appId = get(store).appId
-        await API.saveAppMetadata({
+        const app = await API.saveAppMetadata({
           appId,
           metadata: { navigation },
         })
         store.update(state => {
-          state.navigation = navigation
+          state.navigation = app.navigation
           return state
         })
       },
@@ -407,7 +407,7 @@ export const getFrontendStore = () => {
         }
         if (componentName.endsWith("/formstep")) {
           const parentForm = findClosestMatchingComponent(
-            get(currentAsset).props,
+            get(selectedScreen).props,
             get(selectedComponent)._id,
             component => component._component.endsWith("/form")
           )

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -61,6 +61,12 @@ const INITIAL_FRONTEND_STATE = {
 export const getFrontendStore = () => {
   const store = writable({ ...INITIAL_FRONTEND_STATE })
 
+  // This is a fake implementation of a "patch" API endpoint to try and prevent
+  // 409s. All screen doc mutations (aside from creation) use this function,
+  // which queues up invocations sequentially and ensures pending mutations are
+  // always applied to the most up-to-date doc revision.
+  // This is slightly better than just a traditional "patch" endpoint and this
+  // supports deeply mutating the current doc rather than just appending data.
   const sequentialScreenPatch = Utils.sequential(async (patchFn, screenId) => {
     const state = get(store)
     const screen = state.screens.find(screen => screen._id === screenId)
@@ -73,10 +79,6 @@ export const getFrontendStore = () => {
       return
     }
     return await store.actions.screens.save(clone)
-  })
-
-  store.subscribe(() => {
-    console.log("new state")
   })
 
   store.actions = {

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -331,10 +331,23 @@ export const getFrontendStore = () => {
     },
     layouts: {
       select: layoutId => {
+        // Check this layout exists
+        const state = get(store)
+        const layout = store.actions.layouts.find(layoutId)
+        if (!layout) {
+          return
+        }
+
+        // Check layout isn't already selected
+        if (
+          state.selectedLayoutId === layout._id &&
+          state.selectedComponentId === layout.props?._id
+        ) {
+          return
+        }
+
+        // Select new layout
         store.update(state => {
-          const layout =
-            store.actions.layouts.find(layoutId) || get(store).layouts[0]
-          if (!layout) return
           state.selectedLayoutId = layout._id
           state.selectedComponentId = layout.props?._id
           return state

--- a/packages/builder/src/components/design/settings/controls/ResetFieldsButton.svelte
+++ b/packages/builder/src/components/design/settings/controls/ResetFieldsButton.svelte
@@ -18,7 +18,7 @@
     const dataSource = form?.dataSource
     const fields = makeDatasourceFormComponents(dataSource)
     try {
-      await store.actions.components.updateProp(
+      await store.actions.components.updateSetting(
         "_children",
         fields.map(field => field.json())
       )

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPanel.svelte
@@ -17,7 +17,8 @@
         getOptionValue={x => x._id}
         getOptionIcon={x => (x.routing.homeScreen ? "Home" : "WebPage")}
         getOptionColour={x => RoleUtils.getRoleColour(x.routing.roleId)}
-        bind:value={$store.selectedScreenId}
+        value={$store.selectedScreenId}
+        on:change={e => store.actions.screens.select(e.detail)}
       />
     </div>
     <div class="header-right">

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPreview.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPreview.svelte
@@ -85,6 +85,10 @@
     previewDevice: $store.previewDevice,
     messagePassing: $store.clientFeatures.messagePassing,
     navigation: $store.navigation,
+    hiddenComponentIds:
+      $store.componentToPaste?._id && $store.componentToPaste?.isCut
+        ? [$store.componentToPaste?._id]
+        : [],
     isBudibaseEvent: true,
   }
 

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPreview.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPreview.svelte
@@ -138,7 +138,7 @@
           $goto("./components")
         }
       } else if (type === "update-prop") {
-        await store.actions.components.updateProp(data.prop, data.value)
+        await store.actions.components.updateSetting(data.prop, data.value)
       } else if (type === "delete-component" && data.id) {
         confirmDeleteComponent(data.id)
       } else if (type === "duplicate-component" && data.id) {

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/iframeTemplate.js
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/iframeTemplate.js
@@ -65,7 +65,8 @@ export default `
           theme,
           customTheme,
           previewDevice,
-          navigation
+          navigation,
+          hiddenComponentIds
         } = parsed
 
         // Set some flags so the app knows we're in the builder
@@ -79,6 +80,7 @@ export default `
         window["##BUDIBASE_PREVIEW_CUSTOM_THEME##"] = customTheme
         window["##BUDIBASE_PREVIEW_DEVICE##"] = previewDevice
         window["##BUDIBASE_PREVIEW_NAVIGATION##"] = navigation
+        window["##BUDIBASE_HIDDEN_COMPONENT_IDS##"] = hiddenComponentIds
 
         // Initialise app
         try {

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/navigation/ComponentDropdownMenu.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/navigation/ComponentDropdownMenu.svelte
@@ -1,8 +1,6 @@
 <script>
-  import { get } from "svelte/store"
-  import { store, currentAsset } from "builderStore"
+  import { store } from "builderStore"
   import ConfirmDialog from "components/common/ConfirmDialog.svelte"
-  import { findComponentParent } from "builderStore/componentUtils"
   import { ActionMenu, MenuItem, Icon, notifications } from "@budibase/bbui"
 
   export let component

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/navigation/ComponentDropdownMenu.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/navigation/ComponentDropdownMenu.svelte
@@ -19,43 +19,19 @@
   // not show a context menu.
   $: showMenu = definition?.editable !== false && definition?.static !== true
 
-  const moveUpComponent = () => {
-    const asset = get(currentAsset)
-    const parent = findComponentParent(asset?.props, component._id)
-    if (!parent) {
-      return
-    }
-    const currentIndex = parent._children.indexOf(component)
-    if (currentIndex === 0) {
-      return
-    }
+  const moveUpComponent = async () => {
     try {
-      const newChildren = parent._children.filter(c => c !== component)
-      newChildren.splice(currentIndex - 1, 0, component)
-      parent._children = newChildren
-      store.actions.preview.saveSelected()
+      await store.actions.components.moveUp(component)
     } catch (error) {
-      notifications.error("Error saving screen")
+      notifications.error("Error moving component up")
     }
   }
 
-  const moveDownComponent = () => {
-    const asset = get(currentAsset)
-    const parent = findComponentParent(asset?.props, component._id)
-    if (!parent) {
-      return
-    }
-    const currentIndex = parent._children.indexOf(component)
-    if (currentIndex === parent._children.length - 1) {
-      return
-    }
+  const moveDownComponent = async () => {
     try {
-      const newChildren = parent._children.filter(c => c !== component)
-      newChildren.splice(currentIndex + 1, 0, component)
-      parent._children = newChildren
-      store.actions.preview.saveSelected()
+      await store.actions.components.moveDown(component)
     } catch (error) {
-      notifications.error("Error saving screen")
+      notifications.error("Error moving component down")
     }
   }
 

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/navigation/ComponentTree.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/navigation/ComponentTree.svelte
@@ -18,6 +18,13 @@
 
   let closedNodes = {}
 
+  $: filteredComponents = components?.filter(component => {
+    return (
+      !$store.componentToPaste?.isCut ||
+      component._id !== $store.componentToPaste?._id
+    )
+  })
+
   const dragover = (component, index) => e => {
     const mousePosition = e.offsetY / e.currentTarget.offsetHeight
     dndStore.actions.dragover({
@@ -91,7 +98,7 @@
 </script>
 
 <ul>
-  {#each components || [] as component, index (component._id)}
+  {#each filteredComponents || [] as component, index (component._id)}
     {@const opened = isOpen(component, $selectedComponentPath, closedNodes)}
     <li
       on:click|stopPropagation={() => {

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ComponentSettingsSection.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ComponentSettingsSection.svelte
@@ -5,7 +5,6 @@
   import PropertyControl from "components/design/settings/controls/PropertyControl.svelte"
   import ResetFieldsButton from "components/design/settings/controls/ResetFieldsButton.svelte"
   import { getComponentForSetting } from "components/design/settings/componentSettings"
-  import { Utils } from "@budibase/frontend-core"
 
   export let componentDefinition
   export let componentInstance
@@ -29,9 +28,9 @@
     ]
   }
 
-  const updateProp = async (key, value) => {
+  const updateSetting = async (key, value) => {
     try {
-      await store.actions.components.updateProp(key, value)
+      await store.actions.components.updateSetting(key, value)
     } catch (error) {
       notifications.error("Error updating component prop")
     }
@@ -84,7 +83,7 @@
         label="Name"
         key="_instanceName"
         value={componentInstance._instanceName}
-        onChange={val => updateProp("_instanceName", val)}
+        onChange={val => updateSetting("_instanceName", val)}
       />
     {/if}
     {#each section.settings as setting (setting.key)}
@@ -97,7 +96,7 @@
           value={componentInstance[setting.key]}
           defaultValue={setting.defaultValue}
           nested={setting.nested}
-          onChange={val => updateProp(setting.key, val)}
+          onChange={val => updateSetting(setting.key, val)}
           highlighted={$store.highlightedSettingKey === setting.key}
           props={{
             // Generic settings

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ComponentSettingsSection.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ComponentSettingsSection.svelte
@@ -29,13 +29,13 @@
     ]
   }
 
-  const updateProp = Utils.sequential(async (key, value) => {
+  const updateProp = async (key, value) => {
     try {
       await store.actions.components.updateProp(key, value)
     } catch (error) {
       notifications.error("Error updating component prop")
     }
-  })
+  }
 
   const canRenderControl = setting => {
     const control = getComponentForSetting(setting)

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/layouts/[layoutId]/_components/LayoutListPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/layouts/[layoutId]/_components/LayoutListPanel.svelte
@@ -13,7 +13,7 @@
         indentLevel={0}
         selected={$store.selectedLayoutId === layout._id}
         text={layout.name}
-        on:click={() => ($store.selectedLayoutId = layout._id)}
+        on:click={() => store.actions.layouts.select(layout._id)}
       >
         <LayoutDropdownMenu {layout} />
       </NavItem>

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/screens/_components/ScreenDropdownMenu.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/screens/_components/ScreenDropdownMenu.svelte
@@ -23,7 +23,7 @@
 
   const pasteComponent = mode => {
     try {
-      store.actions.components.paste(screen.props, mode)
+      store.actions.components.paste(screen.props, mode, screen)
     } catch (error) {
       notifications.error("Error saving component")
     }

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/screens/_components/ScreenListPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/screens/_components/ScreenListPanel.svelte
@@ -60,7 +60,7 @@
       indentLevel={0}
       selected={$store.selectedScreenId === screen._id}
       text={screen.routing.route}
-      on:click={() => ($store.selectedScreenId = screen._id)}
+      on:click={() => store.actions.screens.select(screen._id)}
       color={RoleUtils.getRoleColour(screen.routing.roleId)}
     >
       <ScreenDropdownMenu screenId={screen._id} />

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/screens/_components/ScreenSettingsPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/screens/_components/ScreenSettingsPanel.svelte
@@ -42,7 +42,7 @@
     )
   }
 
-  const setScreenSetting = (setting, value) => {
+  const setScreenSetting = async (setting, value) => {
     const { key, parser, validate } = setting
 
     // Parse value if required
@@ -69,26 +69,16 @@
 
     // Home screen changes need to be handled manually
     if (key === "routing.homeScreen") {
-      store.actions.screens.updateHomeScreen(get(selectedScreen), value)
+      console.log(value)
+      await store.actions.screens.updateHomeScreen(get(selectedScreen), value)
       return
     }
 
-    // Update screen object in store
-    // If there are 2 home screens after this change, remove this screen as a
-    // home screen
-    const screen = get(selectedScreen)
-    setWith(screen, key.split("."), value, Object)
-    const roleId = screen.routing.roleId
-    const homeScreens = get(store).screens.filter(screen => {
-      return screen.routing.roleId === roleId && screen.routing.homeScreen
-    })
-    if (homeScreens.length > 1) {
-      screen.routing.homeScreen = false
-    }
-
-    // Save new definition
+    // Update screen setting
     try {
-      store.actions.screens.save(screen)
+      await store.actions.screens.patch(screen => {
+        setWith(screen, key.split("."), value, Object)
+      })
     } catch (error) {
       notifications.error("Error saving screen settings")
     }

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/screens/_components/ScreenSettingsPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/screens/_components/ScreenSettingsPanel.svelte
@@ -1,7 +1,7 @@
 <script>
   import Panel from "components/design/Panel.svelte"
   import { get } from "svelte/store"
-  import { get as deepGet, setWith } from "lodash"
+  import { Helpers } from "@budibase/bbui"
   import {
     Input,
     Layout,
@@ -67,19 +67,11 @@
       }
     }
 
-    // Home screen changes need to be handled manually
-    if (key === "routing.homeScreen") {
-      console.log(value)
-      await store.actions.screens.updateHomeScreen(get(selectedScreen), value)
-      return
-    }
-
     // Update screen setting
     try {
-      await store.actions.screens.patch(screen => {
-        setWith(screen, key.split("."), value, Object)
-      })
+      await store.actions.screens.updateSetting(get(selectedScreen), key, value)
     } catch (error) {
+      console.log(error)
       notifications.error("Error saving screen settings")
     }
   }
@@ -174,7 +166,7 @@
         control={setting.control}
         label={setting.label}
         key={setting.key}
-        value={deepGet($selectedScreen, setting.key)}
+        value={Helpers.deepGet($selectedScreen, setting.key)}
         onChange={val => setScreenSetting(setting, val)}
         props={{ ...setting.props, error: errors[setting.key] }}
         {bindings}

--- a/packages/client/src/components/Component.svelte
+++ b/packages/client/src/components/Component.svelte
@@ -121,6 +121,8 @@
     !isScreen &&
     definition?.draggable !== false
   $: droppable = interactive && !isLayout && !isScreen
+  $: builderHidden =
+    $builderStore.inBuilder && $builderStore.hiddenComponentIds?.includes(id)
 
   // Empty components are those which accept children but do not have any.
   // Empty states can be shown for these components, but can be disabled
@@ -434,7 +436,7 @@
   })
 </script>
 
-{#if constructor && initialSettings && (visible || inSelectedPath)}
+{#if constructor && initialSettings && (visible || inSelectedPath) && !builderHidden}
   <!-- The ID is used as a class because getElementsByClassName is O(1) -->
   <!-- and the performance matters for the selection indicators -->
   <div

--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -20,6 +20,7 @@ const loadBudibase = () => {
     customTheme: window["##BUDIBASE_PREVIEW_CUSTOM_THEME##"],
     previewDevice: window["##BUDIBASE_PREVIEW_DEVICE##"],
     navigation: window["##BUDIBASE_PREVIEW_NAVIGATION##"],
+    hiddenComponentIds: window["##BUDIBASE_HIDDEN_COMPONENT_IDS##"],
   })
 
   // Set app ID - this window flag is set by both the preview and the real

--- a/packages/client/src/stores/builder.js
+++ b/packages/client/src/stores/builder.js
@@ -17,6 +17,7 @@ const createBuilderStore = () => {
     previewDevice: "desktop",
     isDragging: false,
     navigation: null,
+    hiddenComponentIds: [],
 
     // Legacy - allow the builder to specify a layout
     layout: null,

--- a/packages/frontend-core/src/utils/utils.js
+++ b/packages/frontend-core/src/utils/utils.js
@@ -9,7 +9,7 @@ export const sequential = fn => {
   return async (...params) => {
     queue.push(async () => {
       await fn(...params)
-      queue.pop()
+      queue.shift()
       if (queue.length) {
         await queue[0]()
       }

--- a/packages/frontend-core/src/utils/utils.js
+++ b/packages/frontend-core/src/utils/utils.js
@@ -5,13 +5,17 @@
  * @return {Promise} a sequential version of the function
  */
 export const sequential = fn => {
-  let promise
+  let queue = []
   return async (...params) => {
-    if (promise) {
-      await promise
+    queue.push(async () => {
+      await fn(...params)
+      queue.pop()
+      if (queue.length) {
+        await queue[0]()
+      }
+    })
+    if (queue.length === 1) {
+      await queue[0]()
     }
-    promise = fn(...params)
-    await promise
-    promise = null
   }
 }


### PR DESCRIPTION
## Description
This PR refactors most of the frontend store methods to apply a fake "patch" to screen docs, in an attempt to reduce the frequency of 409 conflicts.

TLDR:
- Hopefully far fewer 409s
- Better performance
- Bugfix for cutting and pasting
- Fixes for messy cases of updating state via derived stores rather than via real source of truth store

~Targeting develop as changing the core frontend store is slightly risky in general, and some manual testing would be good.~
Maybe I'll rebase to master to get this out sooner as develop might not be merged for a while.

### 409s
When designing an app, almost all changes saved (component settings, screen settings) are stored in screen documents. This means that when we change a setting for a component, the full screen definition is sent up and saved. Depending on the frequency of these updates, and the latency between client and server (and performance of the server), multiple successive calls could be made before the first one had responded - leading to a stale revision ID in the screen document being sent up in subsequent in-flght calls.

This refactor creates a core "patch" function for saving screen documents. This function is queued and executed sequentially, and is the underlying mechanism now for all screen and component changes. A patch function is supplied as a parameter, which is applied to the latest version of the screen doc. As the screen docs are only pulled at the moment of execution, and all executions are queued and executed sequentiually, we can always be sure that the version of the screen doc being used is the latest. We take this latest version of the screen doc, clone it and then allow full mutation by the patch function before saving this to the server.

Going forward, the new `store.actions.screens.patch` and `store.actions.components.path` functions should always be used to acutally mutate any component or screen settings.

In my testing I've been unable to reproduce any 409 conflicts, even with introducing massive latency and queuing up 10+ actions. I've also added more protection around every store method - so if you do things like queue a deletion and then queue settings changes to the deleted component, no errors will be throw and it will fail gracefully.

### Performance
I've also combined store updates where possible to reduce unecessary recomputation of derived state, and UI paints.

Going forward we would benefit heavily from breaking this monolith store into multiple smaller stores, as Svelte is not very clever at checking for store changes and updating any property of a store triggers a full recomputation of derived state. Breaking our store into smaller chunks of related state will allow us to optimise this much further.

### Cutting and pasting
Our old version of cutting and pasting was extremely fragile. We were actually removing the cut component from the `selectedScreen` store - so if we had ever used the `selectedScreen` derived store to save a screen doc change while a cut was in progress, we would actually have deleted the component being cut.

I've rewrote this so that cutting a component hides it from the UI entirely as if it was removed, but does not actually remove it from the definition until it is pasted.


