### PR TITLE
fixing broken migration and single image

### DIFF
--- a/packages/server/src/migrations/functions/tests/userEmailViewCasing.spec.js
+++ b/packages/server/src/migrations/functions/tests/userEmailViewCasing.spec.js
@@ -4,15 +4,13 @@ const { getGlobalDB, doInTenant } = require("@budibase/backend-core/tenancy")
 
 // mock email view creation
 const coreDb = require("@budibase/backend-core/db")
-const createUserEmailView = jest.fn()
-coreDb.createUserEmailView = createUserEmailView
+const createNewUserEmailView = jest.fn()
+coreDb.createNewUserEmailView = createNewUserEmailView
 
 const migration = require("../userEmailViewCasing")
 
 describe("run", () => {
-  doInTenant(TENANT_ID, () => {
     let config = new TestConfig(false)
-    const globalDb = getGlobalDB()
 
     beforeEach(async () => {
       await config.init()
@@ -21,8 +19,10 @@ describe("run", () => {
     afterAll(config.end)
 
     it("runs successfully", async () => {
-      await migration.run(globalDb)
-      expect(createUserEmailView).toHaveBeenCalledTimes(1)
+      await doInTenant(TENANT_ID, async () => {
+        const globalDb = getGlobalDB()
+        await migration.run(globalDb)
+        expect(createNewUserEmailView).toHaveBeenCalledTimes(1)
+      })
     })
-  })
 })

--- a/packages/server/src/migrations/functions/userEmailViewCasing.ts
+++ b/packages/server/src/migrations/functions/userEmailViewCasing.ts
@@ -1,4 +1,4 @@
-const { createUserEmailView } = require("@budibase/backend-core/db")
+const { createNewUserEmailView } = require("@budibase/backend-core/db")
 
 /**
  * Date:
@@ -9,5 +9,5 @@ const { createUserEmailView } = require("@budibase/backend-core/db")
  */
 
 export const run = async (db: any) => {
-  await createUserEmailView(db)
+  await createNewUserEmailView(db)
 }


### PR DESCRIPTION
## Description
Fixing issue described on: 
- reddit
- https://github.com/Budibase/budibase/issues/6753

We updated the name of a migration as part of the work to fix the broken users email view, but didn't update the code that runs the migration to use the new function name. As a result, the migrations were failing on startup, and the server/worker could not start properly.

## Screenshots
<img width="1252" alt="Screenshot 2022-07-17 at 16 24 47" src="https://user-images.githubusercontent.com/11256663/179405216-1a70db58-a6bf-44b4-9026-9b688809717a.png">




