### PR TITLE
Fix popover min-width to have parents full width

### DIFF
--- a/packages/bbui/src/Popover/Popover.svelte
+++ b/packages/bbui/src/Popover/Popover.svelte
@@ -63,7 +63,7 @@
 
 <style>
   .spectrum-Popover {
-    min-width: var(--spectrum-global-dimension-size-2000) !important;
+    min-width: var(--spectrum-global-dimension-size-2000);
   }
   .spectrum-Popover.is-open.spectrum-Popover--withTip {
     margin-top: var(--spacing-xs);


### PR DESCRIPTION
## Description
_Describe the problem or feature in addition to a link to the relevant github issues._

https://github.com/Budibase/budibase/issues/6769

UI fix for data provider's popover list select

## Screenshots

## Before

![image](https://user-images.githubusercontent.com/69702813/179446533-4f539151-d619-4c83-adb4-f6a0a6d1dcd9.png)



##After

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/69702813/179446397-38bcb692-2830-441d-b8bd-232aec1c5f3d.png">


