### PR TITLE
Ensure binding exists before continuing with loop

### DIFF
--- a/packages/server/src/threads/automation.js
+++ b/packages/server/src/threads/automation.js
@@ -161,7 +161,7 @@ class Orchestrator {
         let originalStepInput = cloneDeep(step.inputs)
 
         // Handle if the user has set a max iteration count or if it reaches the max limit set by us
-        if (loopStep) {
+        if (loopStep && input.binding) {
           let newInput = await processObject(
             loopStep.inputs,
             cloneDeep(this._context)


### PR DESCRIPTION
## Description
 Fixes the `Cannot read property '0' of null` error we were seeing due to the binding being undefined while in a loop block. 

