### PR TITLE
Allow full spectrum cards to be clickable

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -3509,17 +3509,18 @@
       },
       {
         "type": "boolean",
-        "label": "Show button",
+        "label": "Use button for click action",
         "key": "showButton"
       },
       {
         "type": "text",
         "key": "buttonText",
-        "label": "Button text"
+        "label": "Button text",
+        "dependsOn": "showButton"
       },
       {
         "type": "event",
-        "label": "Button action",
+        "label": "Click action",
         "key": "buttonOnClick"
       }
     ]
@@ -3841,18 +3842,19 @@
           },
           {
             "type": "boolean",
-            "label": "Show button",
+            "label": "Use button for click action",
             "key": "showCardButton"
           },
           {
             "type": "text",
             "key": "cardButtonText",
             "label": "Button text",
-            "nested": true
+            "nested": true,
+            "dependsOn": "showCardButton"
           },
           {
             "type": "event",
-            "label": "Button action",
+            "label": "Click action",
             "key": "cardButtonOnClick",
             "nested": true
           }

--- a/packages/client/src/components/app/SpectrumCard.svelte
+++ b/packages/client/src/components/app/SpectrumCard.svelte
@@ -19,9 +19,10 @@
 
   const handleLink = e => {
     if (!linkURL) {
-      return
+      return false
     }
     e.preventDefault()
+    e.stopPropagation()
     routeStore.actions.navigate(linkURL, linkPeek)
   }
 </script>
@@ -32,6 +33,8 @@
   tabindex="0"
   role="figure"
   class:horizontal
+  class:clickable={buttonOnClick && !showButton}
+  on:click={showButton ? null : buttonOnClick}
 >
   {#if imageURL}
     <div
@@ -67,7 +70,9 @@
     {/if}
     {#if showButton}
       <div class="spectrum-Card-footer button-container">
-        <Button on:click={buttonOnClick} secondary>{buttonText || ""}</Button>
+        <Button on:click={buttonOnClick} secondary>
+          {buttonText || "Click me"}
+        </Button>
       </div>
     {/if}
   </div>
@@ -81,6 +86,11 @@
     flex-direction: column;
     justify-content: flex-start;
     align-items: stretch;
+    transition: border-color 130ms ease-out;
+  }
+  .spectrum-Card.clickable:hover {
+    cursor: pointer;
+    border-color: var(--spectrum-global-color-gray-500) !important;
   }
   .spectrum-Card.horizontal {
     flex-direction: row;
@@ -90,7 +100,7 @@
     padding: var(--spectrum-global-dimension-size-50) 0;
   }
   .spectrum-Card-title.link {
-    transition: color 130ms ease-in-out;
+    transition: color 130ms ease-out;
   }
   .spectrum-Card-title.link:hover {
     cursor: pointer;


### PR DESCRIPTION
## Description
This PR allows for cards to be entirely clickable. You can define a click action for cards and control whether or not the full card is used (default) or a button is used (using the `Use button for click action` setting).

- Both cards and card blocks support being fully clickable
- Button text setting only shown if using a button
- Compatible with title link setting (title link takes priority if both are in use)
- Hover state added to clickable cards

Addresses: 
- #6244 

## Screenshots
New settings labels:
![image](https://user-images.githubusercontent.com/9075550/179534863-3b68ded8-1804-4ef6-af5a-a8840b6be305.png)

Full card hover state:
![image](https://user-images.githubusercontent.com/9075550/179534767-534d7c40-d2c9-4093-ad41-fb57b2970da5.png)




