### PR TITLE
Fix default input for newly created datasource query bindings

### DIFF
--- a/packages/builder/src/components/integration/QueryBindingBuilder.svelte
+++ b/packages/builder/src/components/integration/QueryBindingBuilder.svelte
@@ -58,7 +58,7 @@
         thin
         disabled={bindable}
         on:change={evt => onBindingChange(binding.name, evt.detail)}
-        value={runtimeToReadableBinding(bindings, binding.default)}
+        bind:value={binding.default}
       />
       {#if bindable}
         <DrawerBindableInput


### PR DESCRIPTION
## Description
Fixes when newly created datasource query bindings are clearing when saved. 

Addresses: https://github.com/Budibase/budibase/issues/6778

