### PR TITLE
Quick healthcheck update for single image

### DIFF
--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -108,7 +108,7 @@ RUN chmod +x install.sh && ./install.sh
 WORKDIR /
 ADD hosting/single/runner.sh .
 RUN chmod +x ./runner.sh
-ADD hosting/scripts/healthcheck.sh .
+ADD hosting/single/healthcheck.sh .
 RUN chmod +x ./healthcheck.sh
 
 ADD hosting/scripts/build-target-paths.sh .

--- a/hosting/single/healthcheck.sh
+++ b/hosting/single/healthcheck.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 healthy=true
 
+if [ -f "/data/.env" ]; then
+  export $(cat /data/.env | xargs)
+fi
+
 if [[ $(curl -Lfk -s -w "%{http_code}\n" http://localhost/ -o /dev/null) -ne 200 ]]; then
   echo 'ERROR: Budibase is not running';
   healthy=false


### PR DESCRIPTION
## Description
Moving the single image healthcheck script to be within the single image directory and updating it to look for the environment variable file.

There was an issue where the environment variables wouldn't be loaded before the healthcheck script runs, meaning that the state of Redis couldn't be confirmed (without password).

Addresses: 
- #6795