### PR TITLE
Drag and drop fix + date filtering improvement

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/navigation/ComponentListPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/navigation/ComponentListPanel.svelte
@@ -9,6 +9,7 @@
   import { setContext } from "svelte"
   import DNDPositionIndicator from "./DNDPositionIndicator.svelte"
   import { DropPosition } from "./dndStore"
+  import { notifications } from "@budibase/bbui"
 
   let scrollRef
 
@@ -55,6 +56,15 @@
     })
   }
 
+  const onDrop = async () => {
+    try {
+      await dndStore.actions.drop()
+    } catch (error) {
+      console.error(error)
+      notifications.error("Error saving component")
+    }
+  }
+
   // Set scroll context so components can invoke scrolling when selected
   setContext("scroll", {
     scrollTo,
@@ -83,6 +93,7 @@
           opened
           scrollable
           icon="WebPage"
+          on:drop={onDrop}
         >
           <ScreenslotDropdownMenu component={$selectedScreen?.props} />
         </NavItem>

--- a/packages/client/src/components/app/blocks/CardsBlock.svelte
+++ b/packages/client/src/components/app/blocks/CardsBlock.svelte
@@ -4,6 +4,7 @@
   import BlockComponent from "components/BlockComponent.svelte"
   import { Heading } from "@budibase/bbui"
   import { makePropSafe as safe } from "@budibase/string-templates"
+  import { enrichSearchColumns, enrichFilter } from "utils/blocks.js"
 
   export let title
   export let dataSource
@@ -33,14 +34,6 @@
   const { fetchDatasourceSchema, styleable } = getContext("sdk")
   const context = getContext("context")
   const component = getContext("component")
-  const schemaComponentMap = {
-    string: "stringfield",
-    options: "optionsfield",
-    number: "numberfield",
-    datetime: "datetimefield",
-    boolean: "booleanfield",
-    formula: "stringfield",
-  }
 
   let formId
   let dataProviderId
@@ -67,39 +60,6 @@
       },
     },
   ]
-
-  // Enrich the default filter with the specified search fields
-  const enrichFilter = (filter, columns, formId) => {
-    let enrichedFilter = [...(filter || [])]
-    columns?.forEach(column => {
-      const safePath = column.name.split(".").map(safe).join(".")
-      enrichedFilter.push({
-        field: column.name,
-        operator: column.type === "string" ? "string" : "equal",
-        type: column.type,
-        valueType: "Binding",
-        value: `{{ ${safe(formId)}.${safePath} }}`,
-      })
-    })
-    return enrichedFilter
-  }
-
-  // Determine data types for search fields and only use those that are valid
-  const enrichSearchColumns = (searchColumns, schema) => {
-    let enrichedColumns = []
-    searchColumns?.forEach(column => {
-      const schemaType = schema?.[column]?.type
-      const componentType = schemaComponentMap[schemaType]
-      if (componentType) {
-        enrichedColumns.push({
-          name: column,
-          componentType,
-          type: schemaType,
-        })
-      }
-    })
-    return enrichedColumns.slice(0, 5)
-  }
 
   // Builds a full details page URL for the card title
   const buildFullCardUrl = (link, url, repeaterId, linkColumn) => {

--- a/packages/client/src/components/app/forms/Form.svelte
+++ b/packages/client/src/components/app/forms/Form.svelte
@@ -13,6 +13,10 @@
   // for fields rendered in things like search blocks.
   export let disableValidation = false
 
+  // Not exposed as a builder setting. Used internally to allow searching on
+  // auto columns.
+  export let editAutoColumns = false
+
   const context = getContext("context")
   const { API, fetchDatasourceSchema } = getContext("sdk")
 
@@ -107,6 +111,7 @@
       {table}
       {initialValues}
       {disableValidation}
+      {editAutoColumns}
     >
       <slot />
     </InnerForm>

--- a/packages/client/src/components/app/forms/InnerForm.svelte
+++ b/packages/client/src/components/app/forms/InnerForm.svelte
@@ -11,6 +11,7 @@
   export let schema
   export let table
   export let disableValidation = false
+  export let editAutoColumns = false
 
   const component = getContext("component")
   const { styleable, Provider, ActionTypes } = getContext("sdk")
@@ -183,7 +184,8 @@
           fieldId,
           value: initialValue,
           error: initialError,
-          disabled: disabled || fieldDisabled || isAutoColumn,
+          disabled:
+            disabled || fieldDisabled || (isAutoColumn && !editAutoColumns),
           defaultValue,
           validator,
           lastUpdate: Date.now(),

--- a/packages/client/src/utils/blocks.js
+++ b/packages/client/src/utils/blocks.js
@@ -1,0 +1,81 @@
+import { makePropSafe as safe } from "@budibase/string-templates"
+
+// Map of data types to component types for search fields inside blocks
+const schemaComponentMap = {
+  string: "stringfield",
+  options: "optionsfield",
+  number: "numberfield",
+  datetime: "datetimefield",
+  boolean: "booleanfield",
+  formula: "stringfield",
+}
+
+/**
+ * Determine data types for search fields and only use those that are valid
+ * @param searchColumns the search columns to use
+ * @param schema the data source schema
+ */
+export const enrichSearchColumns = (searchColumns, schema) => {
+  let enrichedColumns = []
+  searchColumns?.forEach(column => {
+    const schemaType = schema?.[column]?.type
+    const componentType = schemaComponentMap[schemaType]
+    if (componentType) {
+      enrichedColumns.push({
+        name: column,
+        componentType,
+        type: schemaType,
+      })
+    }
+  })
+  return enrichedColumns.slice(0, 5)
+}
+
+/**
+ * Enriches a normal datasource filter with bindings representing the additional
+ * search fields configured as part of a searchable block. These bindings are
+ * fields inside a form used as part of the block.
+ * @param filter the normal data provider filter
+ * @param columns the enriched search column structure
+ * @param formId the ID of the form containing the search fields
+ */
+export const enrichFilter = (filter, columns, formId) => {
+  let enrichedFilter = [...(filter || [])]
+  columns?.forEach(column => {
+    const safePath = column.name.split(".").map(safe).join(".")
+    const stringType = column.type === "string" || column.type === "formula"
+    const dateType = column.type === "datetime"
+    const binding = `${safe(formId)}.${safePath}`
+
+    // For dates, use a range of the entire day selected
+    if (dateType) {
+      enrichedFilter.push({
+        field: column.name,
+        type: column.type,
+        operator: "rangeLow",
+        valueType: "Binding",
+        value: `{{ ${binding} }}`,
+      })
+      const format = "YYYY-MM-DDTHH:mm:ss.SSSZ"
+      enrichedFilter.push({
+        field: column.name,
+        type: column.type,
+        operator: "rangeHigh",
+        valueType: "Binding",
+        value: `{{ date (add (date ${binding} "x") 86399999) "${format}" }}`,
+      })
+    }
+
+    // For other fields, do an exact match
+    else {
+      enrichedFilter.push({
+        field: column.name,
+        type: column.type,
+        operator: stringType ? "string" : "equal",
+        valueType: "Binding",
+        value: `{{ ${binding} }}`,
+      })
+    }
+  })
+  return enrichedFilter
+}

--- a/packages/frontend-core/src/utils/lucene.js
+++ b/packages/frontend-core/src/utils/lucene.js
@@ -99,8 +99,16 @@ export const buildLuceneQuery = filter => {
     filter.forEach(expression => {
       let { operator, field, type, value, externalType } = expression
       // Parse all values into correct types
-      if (type === "datetime" && value) {
-        value = new Date(value).toISOString()
+      if (type === "datetime") {
+        // Ensure date value is a valid date and parse into correct format
+        if (!value) {
+          return
+        }
+        try {
+          value = new Date(value).toISOString()
+        } catch (error) {
+          return
+        }
       }
       if (type === "number" && !Array.isArray(value)) {
         if (operator === "oneOf") {


### PR DESCRIPTION
## Description
This PR is a couple of small improvements.

### Drag and drop update update
Allow dropping on root "Screen" component in the component tree so that drag and drop works as expected when targeting this node. The root screen can't be dragged though, of course.

### Make searching on date fields in blocks useful
Previously, when selecting a date field as a search column in a block it was not particularly useful. This was due to us always doing an exact match on the value specified, meaning that only other dates which matched the exact millisecond selected would be returned.

I've updated this to actually do a range search for dates, spanning the entirety of the selected day. This means that any dates falling within the range of the date you pick will be matched. This is how most users would expect this to work, and actually makes it useful.

Here's the date filter working and returning rows with different times on a given day:
![image](https://user-images.githubusercontent.com/9075550/180418092-75b16dd2-5b3a-4e18-9df3-ac5ef1a2db0b.png)

This works for both table block and cards block. I've refactored some of the core utilities used in these blocks to avoid duplication. 

Addresses: 
- #6842
- #6142, #6141, #5548, #3612,  
- Autocolumns are now also editable when used as search fields #6833
