### PR TITLE
Export issues and fix for automation app action permissions spamming

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
@@ -52,8 +52,9 @@
       x => x.blockToLoop === block.id
     )
 
-  $: setPermissions(role)
-  $: getPermissions(automationId)
+  $: isAppAction = block?.stepId === TriggerStepID.APP
+  $: isAppAction && setPermissions(role)
+  $: isAppAction && getPermissions(automationId)
 
   async function setPermissions(role) {
     if (!role || !automationId) {
@@ -238,7 +239,7 @@
           </div>
         {/if}
 
-        {#if block.stepId === TriggerStepID.APP}
+        {#if isAppAction}
           <Label>Role</Label>
           <RoleSelect bind:value={role} />
         {/if}

--- a/packages/builder/src/pages/builder/portal/overview/[application]/index.svelte
+++ b/packages/builder/src/pages/builder/portal/overview/[application]/index.svelte
@@ -271,7 +271,7 @@
                 on:click={() => exportApp(selectedApp, { published: false })}
                 icon="DownloadFromCloud"
               >
-                Export
+                Export latest
               </MenuItem>
               {#if isPublished}
                 <MenuItem

--- a/packages/builder/src/pages/builder/portal/overview/[application]/index.svelte
+++ b/packages/builder/src/pages/builder/portal/overview/[application]/index.svelte
@@ -139,9 +139,10 @@
     notifications.success("App ID copied to clipboard.")
   }
 
-  const exportApp = app => {
-    const id = isPublished ? app.prodId : app.devId
+  const exportApp = (app, opts = { published: false }) => {
     const appName = encodeURIComponent(app.name)
+    const id = opts?.published ? app.prodId : app.devId
+    // always export the development version
     window.location = `/api/backups/export?appId=${id}&appname=${appName}`
   }
 
@@ -266,12 +267,21 @@
               <span slot="control" class="app-overview-actions-icon">
                 <Icon hoverable name="More" />
               </span>
-              <MenuItem on:click={() => exportApp(selectedApp)} icon="Download">
+              <MenuItem
+                on:click={() => exportApp(selectedApp, { published: false })}
+                icon="DownloadFromCloud"
+              >
                 Export
               </MenuItem>
               {#if isPublished}
+                <MenuItem
+                  on:click={() => exportApp(selectedApp, { published: true })}
+                  icon="DownloadFromCloudOutline"
+                >
+                  Export published
+                </MenuItem>
                 <MenuItem on:click={() => copyAppId(selectedApp)} icon="Copy">
-                  Copy App ID
+                  Copy app ID
                 </MenuItem>
               {/if}
               {#if !isPublished}

--- a/packages/server/src/utilities/fileSystem/index.js
+++ b/packages/server/src/utilities/fileSystem/index.js
@@ -111,20 +111,12 @@ exports.apiFileReturn = contents => {
 }
 
 exports.defineFilter = excludeRows => {
+  const ids = [USER_METDATA_PREFIX, LINK_USER_METADATA_PREFIX]
   if (excludeRows) {
-    return doc =>
-      !(
-        doc._id.includes(USER_METDATA_PREFIX) ||
-        doc._id.includes(LINK_USER_METADATA_PREFIX) ||
-        doc._id.includes(TABLE_ROW_PREFIX)
-      )
-  } else if (!excludeRows) {
-    return doc =>
-      !(
-        doc._id.includes(USER_METDATA_PREFIX) ||
-        doc._id.includes(LINK_USER_METADATA_PREFIX)
-      )
+    ids.push(TABLE_ROW_PREFIX)
   }
+  return doc =>
+    !ids.map(key => doc._id.includes(key)).reduce((prev, curr) => prev || curr)
 }
 
 /**
@@ -132,6 +124,7 @@ exports.defineFilter = excludeRows => {
  * data or user relationships.
  * @param {string} appId The app to backup
  * @param {object} config Config to send to export DB
+ * @param {boolean} includeRows Flag to state whether the export should include data.
  * @returns {*} either a string or a stream of the backup
  */
 const backupAppData = async (appId, config, includeRows) => {
@@ -154,6 +147,7 @@ exports.performBackup = async (appId, backupName) => {
 /**
  * Streams a backup of the database state for an app
  * @param {string} appId The ID of the app which is to be backed up.
+ * @param {boolean} includeRows Flag to state whether the export should include data.
  * @returns {*} a readable stream of the backup which is written in real time
  */
 exports.streamBackup = async (appId, includeRows) => {


### PR DESCRIPTION
## Description
This addresses two issues with the export functionality:
1. Each export carries deleted documents with it as well, which affects the overall size of the export.
2. The user didn't have a choice when working with the a published app to export the dev version.

Also fixes an issue pointed out by @NEOLPAR about permission spamming in the automation UI, flow items weren't correctly making the decision to only process roles/permissions for app actions.

## Screenshot
Updated menu with option to export published (only shown when app is published)
![image](https://user-images.githubusercontent.com/4407001/180983191-157e96f0-2381-4543-80e0-0e57e9f7e7d4.png)