### PR TITLE
Ignore harmless 409s in write-through cache

### DIFF
--- a/packages/backend-core/src/cache/writethrough.ts
+++ b/packages/backend-core/src/cache/writethrough.ts
@@ -1,6 +1,6 @@
 import BaseCache from "./base"
 import { getWritethroughClient } from "../redis/init"
-import { logInfo } from "../logging"
+import { logWarn } from "../logging"
 
 const DEFAULT_WRITE_RATE_MS = 10000
 let CACHE: BaseCache | null = null
@@ -53,7 +53,7 @@ export async function put(
         throw err
       } else {
         // Swallow 409s but log them
-        logInfo(`Ignoring conflict in write-through cache`)
+        logWarn(`Ignoring conflict in write-through cache`)
       }
     }
   }

--- a/packages/backend-core/src/cache/writethrough.ts
+++ b/packages/backend-core/src/cache/writethrough.ts
@@ -1,5 +1,6 @@
 import BaseCache from "./base"
 import { getWritethroughClient } from "../redis/init"
+import { logInfo } from "../logging"
 
 const DEFAULT_WRITE_RATE_MS = 10000
 let CACHE: BaseCache | null = null
@@ -51,10 +52,8 @@ export async function put(
       if (err.status !== 409) {
         throw err
       } else {
-        // get the rev, update over it - this is risky, may change in future
-        const readDoc = await db.get(doc._id)
-        doc._rev = readDoc._rev
-        await writeDb(doc)
+        // Swallow 409s but log them
+        logInfo(`Ignoring conflict in write-through cache`)
       }
     }
   }

--- a/packages/backend-core/src/logging.ts
+++ b/packages/backend-core/src/logging.ts
@@ -15,6 +15,11 @@ export function logAlert(message: string, e?: any) {
   console.error(`bb-alert: ${message} ${errorJson}`)
 }
 
+export function logInfo(message: string) {
+  console.warn(`bb-info: ${message}`)
+}
+
 export default {
   logAlert,
+  logInfo,
 }

--- a/packages/backend-core/src/logging.ts
+++ b/packages/backend-core/src/logging.ts
@@ -16,7 +16,7 @@ export function logAlert(message: string, e?: any) {
 }
 
 export function logInfo(message: string) {
-  console.warn(`bb-info: ${message}`)
+  console.log(`bb-info: ${message}`)
 }
 
 export default {

--- a/packages/backend-core/src/logging.ts
+++ b/packages/backend-core/src/logging.ts
@@ -15,11 +15,11 @@ export function logAlert(message: string, e?: any) {
   console.error(`bb-alert: ${message} ${errorJson}`)
 }
 
-export function logInfo(message: string) {
-  console.log(`bb-info: ${message}`)
+export function logWarn(message: string) {
+  console.warn(`bb-warn: ${message}`)
 }
 
 export default {
   logAlert,
-  logInfo,
+  logWarn,
 }


### PR DESCRIPTION
## Description
This is a small PR to simply ignore 409s which occur in our write through cache. This is safe to ignore as if a 409 occurs here, it simply means that this particular workload has already been handled by someone else. Redis itself will still continue to hold the correct and up to date information.

Added in a small log so we can at least detect the frequency with which these are happening. Didn't think it was worth running this through the full log processor, and the only info we have available to us here is doc IDs which I also didn't think was worth logging.

Addresses #6691


