### PR TITLE
Fix remounting component settings

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ComponentSettingsPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ComponentSettingsPanel.svelte
@@ -27,20 +27,26 @@
 </script>
 
 {#if $selectedComponent}
-  <Panel {title} icon={componentDefinition.icon} borderLeft>
-    <ComponentSettingsSection
-      {componentInstance}
-      {componentDefinition}
-      {bindings}
-      {componentBindings}
-      {isScreen}
-    />
-    <DesignSection {componentInstance} {componentDefinition} {bindings} />
-    <CustomStylesSection {componentInstance} {componentDefinition} {bindings} />
-    <ConditionalUISection
-      {componentInstance}
-      {componentDefinition}
-      {bindings}
-    />
-  </Panel>
+  {#key $selectedComponent._id}
+    <Panel {title} icon={componentDefinition.icon} borderLeft>
+      <ComponentSettingsSection
+        {componentInstance}
+        {componentDefinition}
+        {bindings}
+        {componentBindings}
+        {isScreen}
+      />
+      <DesignSection {componentInstance} {componentDefinition} {bindings} />
+      <CustomStylesSection
+        {componentInstance}
+        {componentDefinition}
+        {bindings}
+      />
+      <ConditionalUISection
+        {componentInstance}
+        {componentDefinition}
+        {bindings}
+      />
+    </Panel>
+  {/key}
 {/if}


### PR DESCRIPTION
## Description
Fixes an issue where some component settings were stale when selecting another component of the same type. This change ensures the component settings panel fully remounts when changing component.

Addresses: 
- #6905