### PR TITLE
Fix attachment renderer

### DIFF
--- a/packages/bbui/src/Table/AttachmentRenderer.svelte
+++ b/packages/bbui/src/Table/AttachmentRenderer.svelte
@@ -1,5 +1,4 @@
 <script>
-  import TooltipWrapper from "../Tooltip/TooltipWrapper.svelte"
   import Link from "../Link/Link.svelte"
 
   export let value

--- a/packages/bbui/src/Table/AttachmentRenderer.svelte
+++ b/packages/bbui/src/Table/AttachmentRenderer.svelte
@@ -1,5 +1,5 @@
 <script>
-  import Tooltip from "../Tooltip/Tooltip.svelte"
+  import TooltipWrapper from "../Tooltip/TooltipWrapper.svelte"
   import Link from "../Link/Link.svelte"
 
   export let value
@@ -17,18 +17,16 @@
 {#each attachments as attachment}
   {#if isImage(attachment.extension)}
     <Link quiet target="_blank" href={attachment.url}>
-      <div class="center">
+      <div class="center" title={attachment.name}>
         <img src={attachment.url} alt={attachment.extension} />
       </div>
     </Link>
   {:else}
-    <Tooltip text={attachment.name} direction="right">
-      <div class="file">
-        <Link quiet target="_blank" href={attachment.url}>
-          {attachment.extension}
-        </Link>
-      </div>
-    </Tooltip>
+    <div class="file" title={attachment.name}>
+      <Link quiet target="_blank" href={attachment.url}>
+        {attachment.extension}
+      </Link>
+    </div>
   {/if}
 {/each}
 {#if leftover}
@@ -52,7 +50,7 @@
     padding: 0 8px;
     color: var(--spectrum-global-color-gray-800);
     border: 1px solid var(--spectrum-global-color-gray-300);
-    border-radius: 2px;
+    border-radius: 4px;
     text-transform: uppercase;
     font-weight: 600;
     font-size: 11px;


### PR DESCRIPTION
## Description
Fixes an issue where non-image files were not working inside tables due to our tooltip component. The tooltip component causes a lot of issues and needs rewritten at some point.

This affected not only client app table and table block components, but also tables inside the data section on the builder.

Addresses: 
- #6896

Working renderer:
![image](https://user-images.githubusercontent.com/9075550/181218278-cf7c1884-e2e9-40f5-8b68-596ddbbf4c0d.png)

Attachment open in new tab after clicking:
![image](https://user-images.githubusercontent.com/9075550/181218191-29585de1-3610-4cc5-89a2-7dc12c283b0a.png)