### PR TITLE
Fix issue showing selected component indicators on initial load

### DIFF
--- a/packages/client/src/components/preview/IndicatorSet.svelte
+++ b/packages/client/src/components/preview/IndicatorSet.svelte
@@ -72,6 +72,7 @@
     // Sanity limit of 100 active indicators
     const children = Array.from(parents)
       .map(parent => parent?.children?.[0])
+      .filter(x => x != null)
       .slice(0, 100)
 
     // If there aren't any nodes then reset


### PR DESCRIPTION
## Description
This PR fixes an issue where sometimes the selected component indiciators would not appear on the initial load of the client preview, also causing the preview to not function properly due to an unhandled null reference exception.



