### PR TITLE
Update server and worker lockfiles after pro release

### DIFF
--- a/scripts/pro/release.sh
+++ b/scripts/pro/release.sh
@@ -88,8 +88,13 @@ jq '.dependencies."@budibase/pro"="'$VERSION'"' package.json > package.json.tmp 
 # Go back to budibase repo root
 cd -
 
+# Update lockfile with new pro version
+yarn bootstrap
+
 # Commit and push changes
 git add packages/server/package.json
+git add packages/server/yarn.lock
 git add packages/worker/package.json
+git add packages/worker/yarn.lock
 git commit -m "Update pro version to $VERSION"
 git push


### PR DESCRIPTION
## Description
Update the pro release script to ensure lockfile changes are committed. 


Background:

Normally lerna doesn't put our mono repo dependencies in the lockfile at all, so bootstrap won't affect it. e.g. 
- Release commit - https://github.com/Budibase/budibase/commit/e30e9a6925f6ab4b7b1ccf34434e16676f16af38 (package.json only)

The reason we have backend-core in a lockfile is because pro dependecy on backend-core and server / worker depend on pro e.g. 
- Subsequent pro release commit - https://github.com/Budibase/budibase-pro/commit/2290b09ba0978bda5925e38fd5fc0af5446f92b7
- Subsequent pro bump in budibase - https://github.com/Budibase/budibase/commit/82c7ce421cd650fbf2592b615cf1469d5886281f

The CI flow looks like
- yarn release - perform the above changes
- yarn build:docker - build the above changes into a container, using npm
   - This will always use the pinned version of pro / backend-core in the container build

The reason we see lockfile changes locally after a bootstrap is because the release changes to the lock aren't comitted
It doesn't cause a problem because of the pinned changes in the container build, but it's annoying that we see that and can seem like a red herring. 


