### PR TITLE
Minor automation fixes

### DIFF
--- a/packages/frontend-core/src/utils/lucene.js
+++ b/packages/frontend-core/src/utils/lucene.js
@@ -1,6 +1,8 @@
 import { Helpers } from "@budibase/bbui"
 import { OperatorOptions, SqlNumberTypeRangeMap } from "../constants"
 
+const HBS_REGEX = /{{([^{].*?)}}/g
+
 /**
  * Returns the valid operator options for a certain data type
  * @param type the data type
@@ -98,6 +100,7 @@ export const buildLuceneQuery = filter => {
   if (Array.isArray(filter)) {
     filter.forEach(expression => {
       let { operator, field, type, value, externalType } = expression
+      const isHbs = typeof value === "string" && value.match(HBS_REGEX)?.length > 0
       // Parse all values into correct types
       if (type === "datetime" && value) {
         value = new Date(value).toISOString()
@@ -105,7 +108,7 @@ export const buildLuceneQuery = filter => {
       if (type === "number" && !Array.isArray(value)) {
         if (operator === "oneOf") {
           value = value.split(",").map(item => parseFloat(item))
-        } else {
+        } else if (!isHbs) {
           value = parseFloat(value)
         }
       }

--- a/packages/frontend-core/src/utils/lucene.js
+++ b/packages/frontend-core/src/utils/lucene.js
@@ -100,7 +100,8 @@ export const buildLuceneQuery = filter => {
   if (Array.isArray(filter)) {
     filter.forEach(expression => {
       let { operator, field, type, value, externalType } = expression
-      const isHbs = typeof value === "string" && value.match(HBS_REGEX)?.length > 0
+      const isHbs =
+        typeof value === "string" && value.match(HBS_REGEX)?.length > 0
       // Parse all values into correct types
       if (type === "datetime" && value) {
         value = new Date(value).toISOString()

--- a/packages/server/src/automations/steps/queryRows.js
+++ b/packages/server/src/automations/steps/queryRows.js
@@ -82,6 +82,27 @@ async function getTable(appId, tableId) {
   return ctx.body
 }
 
+function typeCoercion(filters, table) {
+  if (!filters || !table) {
+    return filters
+  }
+  for (let key of Object.keys(filters)) {
+    if (typeof filters[key] === "object") {
+      for (let [property, value] of Object.entries(filters[key])) {
+        const column = table.schema[property]
+        // convert string inputs
+        if (!column || typeof value !== "string") {
+          continue
+        }
+        if (column.type === FieldTypes.NUMBER) {
+          filters[key][property] = parseFloat(value)
+        }
+      }
+    }
+  }
+  return filters
+}
+
 exports.run = async function ({ inputs, appId }) {
   const { tableId, filters, sortColumn, sortOrder, limit } = inputs
   const table = await getTable(appId, tableId)
@@ -99,7 +120,7 @@ exports.run = async function ({ inputs, appId }) {
       sortType,
       limit,
       sort: sortColumn,
-      query: filters || {},
+      query: typeCoercion(filters || {}, table),
       // default to ascending, like data tab
       sortOrder: sortOrder || SortOrders.ASCENDING,
     },

--- a/packages/server/src/automations/steps/serverLog.js
+++ b/packages/server/src/automations/steps/serverLog.js
@@ -31,15 +31,21 @@ exports.definition = {
           type: "boolean",
           description: "Whether the action was successful",
         },
+        message: {
+          type: "string",
+          description: "What was output",
+        },
       },
-      required: ["success"],
+      required: ["success", "message"],
     },
   },
 }
 
 exports.run = async function ({ inputs, appId }) {
-  console.log(`App ${appId} - ${inputs.text}`)
+  const message = `App ${appId} - ${inputs.text}`
+  console.log(message)
   return {
     success: true,
+    message,
   }
 }


### PR DESCRIPTION
## Description
A minor fix uncovered by recent changes to the automation `queryRows` action - now when working with number/string type differences it would break (couldn't specify a HBS statement for a number filter).

Also added a minor output the `serverLog` action, so that what it actually output can be seen in the automation run log.

Addresses: 
- #6090 - discovered the type issue.