### PR TITLE
Add 'Is In' filter to Option data type

### DIFF
--- a/packages/bbui/src/Form/Multiselect.svelte
+++ b/packages/bbui/src/Form/Multiselect.svelte
@@ -27,7 +27,7 @@
     {error}
     {disabled}
     {readonly}
-    {value}
+    value={Array.isArray(value) ? value : [value]}
     {options}
     {placeholder}
     {sort}

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -140,7 +140,7 @@
               />
             {:else if ["string", "longform", "number", "formula"].includes(filter.type)}
               <Input disabled={filter.noValue} bind:value={filter.value} />
-            {:else if filter.type === "array"}
+            {:else if filter.type === "array" || (filter.type === "options" && filter.operator === "oneOf")}
               <Multiselect
                 disabled={filter.noValue}
                 options={getFieldOptions(filter.field)}

--- a/packages/frontend-core/src/utils/lucene.js
+++ b/packages/frontend-core/src/utils/lucene.js
@@ -30,7 +30,7 @@ export const getValidOperatorsForType = type => {
   } else if (type === "number") {
     return numOps
   } else if (type === "options") {
-    return [Op.Equals, Op.NotEquals, Op.Empty, Op.NotEmpty]
+    return [Op.Equals, Op.NotEquals, Op.Empty, Op.NotEmpty, Op.In]
   } else if (type === "array") {
     return [Op.Contains, Op.NotContains, Op.Empty, Op.NotEmpty, Op.ContainsAny]
   } else if (type === "boolean") {


### PR DESCRIPTION
## Description
Added the 'Is in' filter for options type. 
Includes value matching multiselect, or binding that returns array or string with commas to delimit the values.

Addresses: 
- https://github.com/Budibase/budibase/issues/6975

## Screenshots
![Screenshot 2022-07-29 at 16 12 35](https://user-images.githubusercontent.com/101575380/181790119-1f19b925-38f0-429b-afbb-0c7b4c6754bd.png)

![Screenshot 2022-07-29 at 16 16 43](https://user-images.githubusercontent.com/101575380/181790849-a2a05f2f-abf8-495a-968e-d0cd4c304905.png)

![Screenshot 2022-07-29 at 16 17 08](https://user-images.githubusercontent.com/101575380/181790926-b696417b-2aa5-4be0-955f-cd832407f01e.png)

![Screenshot 2022-07-29 at 16 17 26](https://user-images.githubusercontent.com/101575380/181790976-fc5b2e94-e514-4242-b8ab-bbe0cc8ac70a.png)



