### PR TITLE
Prevent self deletion

### DIFF
--- a/packages/builder/src/pages/builder/portal/manage/users/[userId].svelte
+++ b/packages/builder/src/pages/builder/portal/manage/users/[userId].svelte
@@ -237,18 +237,21 @@
             </div>
           </div>
         </div>
-        <div>
-          <ActionMenu align="right">
-            <span slot="control">
-              <Icon hoverable name="More" />
-            </span>
-            <MenuItem on:click={resetPasswordModal.show} icon="Refresh"
-              >Force Password Reset</MenuItem
-            >
-            <MenuItem on:click={deleteModal.show} icon="Delete">Delete</MenuItem
-            >
-          </ActionMenu>
-        </div>
+        {#if userId !== $auth.user._id}
+          <div>
+            <ActionMenu align="right">
+              <span slot="control">
+                <Icon hoverable name="More" />
+              </span>
+              <MenuItem on:click={resetPasswordModal.show} icon="Refresh">
+                Force password reset
+              </MenuItem>
+              <MenuItem on:click={deleteModal.show} icon="Delete">
+                Delete
+              </MenuItem>
+            </ActionMenu>
+          </div>
+        {/if}
       </div>
     </Layout>
     <Layout gap="S" noPadding>

--- a/packages/builder/src/pages/builder/portal/manage/users/index.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/users/index.svelte
@@ -28,6 +28,7 @@
   import ImportUsersModal from "./_components/ImportUsersModal.svelte"
   import { createPaginationStore } from "helpers/pagination"
   import { Constants } from "@budibase/frontend-core"
+  import { get } from "svelte/store"
 
   const accessTypes = [
     {
@@ -198,6 +199,10 @@
   const deleteRows = async () => {
     try {
       let ids = selectedRows.map(user => user._id)
+      if (ids.includes(get(auth).user._id)) {
+        notifications.error("You cannot delete yourself")
+        return
+      }
       await users.bulkDelete(ids)
       notifications.success(`Successfully deleted ${selectedRows.length} rows`)
       selectedRows = []


### PR DESCRIPTION
## Description
This PR prevents a user from deleting themselves in both the users list and the user details pages. They also cannot force reset their own password, but they can always change their password from the top nav popover.


