### PR TITLE
Options picker set value for relationship picker - handle non-array values

### DIFF
--- a/packages/client/src/components/app/forms/RelationshipField.svelte
+++ b/packages/client/src/components/app/forms/RelationshipField.svelte
@@ -55,6 +55,9 @@
     if (!values) {
       return []
     }
+    if (!Array.isArray(values)) {
+      values = [values]
+    }
     return values.map(value => (typeof value === "object" ? value._id : value))
   }
 


### PR DESCRIPTION
## Description
If a non-array value is passed into a Relationship picker, this will now be handled and not crash the app.

Addresses: 
- https://github.com/Budibase/budibase/issues/7112



