### PR TITLE
Insert table ID back into query for follow-up pagination query

### DIFF
--- a/packages/server/src/api/controllers/row/internalSearch.js
+++ b/packages/server/src/api/controllers/row/internalSearch.js
@@ -423,6 +423,7 @@ exports.paginatedSearch = async (query, params) => {
   // Try fetching 1 row in the next page to see if another page of results
   // exists or not
   const nextResults = await search
+    .setTable(params.tableId)
     .setBookmark(searchResults.bookmark)
     .setLimit(1)
     .run()


### PR DESCRIPTION
## Description
Fixes an issue, which is live, where pagination always appears active. This includes even when there is no data in tables. The fix replaces the table ID param in the lucene query for the follow up pagination search, as the table ID is now stripped from the original query to facilitate more advanced searching with `or`.

Addresses: 
- #7115 

