### PR TITLE
Add separate rate limiting config for webhooks + environment variable support

### DIFF
--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -75,7 +75,9 @@ services:
     ports:
       - "${MAIN_PORT}:10000"
     container_name: bbproxy
-    image: budibase/proxy
+    image: proxy-service
+    environment:
+      - PROXY_RATE_LIMIT_WEBHOOKS_PER_SECOND=10
     depends_on:
       - minio-service
       - worker-service

--- a/hosting/nginx.prod.conf.hbs
+++ b/hosting/nginx.prod.conf.hbs
@@ -9,7 +9,11 @@ events {
 }
 
 http {
+  # rate limiting
+  limit_req_status 429;
   limit_req_zone $binary_remote_addr zone=ratelimit:10m rate=20r/s;
+  limit_req_zone $binary_remote_addr zone=webhooks:10m rate=${PROXY_RATE_LIMIT_WEBHOOKS_PER_SECOND}r/s;
+
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
   proxy_set_header Host $host;
@@ -112,6 +116,25 @@ http {
       # calls to the API are rate limited with bursting
       limit_req zone=ratelimit burst=20 nodelay;
 
+      # 120s timeout on API requests
+      proxy_read_timeout 120s;
+      proxy_connect_timeout 120s;
+      proxy_send_timeout 120s;
+
+      proxy_http_version  1.1;
+      proxy_set_header    Connection          $connection_upgrade;
+      proxy_set_header    Upgrade             $http_upgrade;
+      proxy_set_header    X-Real-IP           $remote_addr;
+      proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+
+      proxy_pass      http://$apps:4002;
+    }
+
+    location /api/webhooks/ {
+      # calls to webhooks are rate limited
+      limit_req zone=webhooks nodelay;
+
+      # Rest of configuration copied from /api/ location above
       # 120s timeout on API requests
       proxy_read_timeout 120s;
       proxy_connect_timeout 120s;

--- a/hosting/proxy/Dockerfile
+++ b/hosting/proxy/Dockerfile
@@ -1,3 +1,13 @@
 FROM nginx:latest
-COPY .generated-nginx.prod.conf /etc/nginx/nginx.conf
+
+# nginx.conf
+# use the default nginx behaviour for *.template files which are processed with envsubst
+# override the output dir to output directly to /etc/nginx instead of /etc/nginx/conf.d
+ENV NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
+COPY .generated-nginx.prod.conf /etc/nginx/templates/nginx.conf.template
+
+# Error handling
 COPY error.html /usr/share/nginx/html/error.html
+
+# Default environment
+ENV PROXY_RATE_LIMIT_WEBHOOKS_PER_SECOND=10


### PR DESCRIPTION
## Description
- Add separate `/api/webhooks` location + rate limiting config
- Change default rate limit status from 503 to 429
- Add support for environment variables in proxy-service image 



