### PR TITLE
Bulk session wipe fix + logging

### DIFF
--- a/packages/backend-core/src/security/sessions.ts
+++ b/packages/backend-core/src/security/sessions.ts
@@ -23,6 +23,10 @@ function makeSessionID(userId: string, sessionId: string) {
 }
 
 export async function getSessionsForUser(userId: string) {
+  if (!userId) {
+    console.trace("Cannot get sessions for undefined userId")
+    return []
+  }
   const client = await redis.getSessionClient()
   const sessions = await client.scan(userId)
   return sessions.map((session: Session) => session.value)

--- a/packages/backend-core/src/security/tests/sessions.spec.ts
+++ b/packages/backend-core/src/security/tests/sessions.spec.ts
@@ -1,0 +1,12 @@
+import * as sessions from "../sessions"
+
+describe("sessions", () => {
+  describe("getSessionsForUser", () => {
+    it("returns empty when user is undefined", async () => {
+      // @ts-ignore - allow the undefined to be passed
+      const results = await sessions.getSessionsForUser(undefined)
+
+      expect(results).toStrictEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## Description
Adding a fix to prevent all sessions being wiped when the requested userId is undefined. Ideally we wanted to put this fixed lower into the redis client `scan` function, however there are a number of places that currently rely on the argument being undefined to return all results. Instead move the fix up one call into the `getSessionsForUser` function. 

Addresses: 
Fixes: https://github.com/Budibase/budibase/issues/4901



