### PR TITLE
filtering datasources for execute query actions

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/ExecuteQuery.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/ExecuteQuery.svelte
@@ -3,6 +3,7 @@
   import { datasources, integrations, queries } from "stores/backend"
   import BindingBuilder from "components/integration/QueryBindingBuilder.svelte"
   import IntegrationQueryEditor from "components/integration/index.svelte"
+  import { IntegrationTypes } from "constants/backend"
 
   export let parameters
   export let bindings = []
@@ -10,6 +11,12 @@
   $: query = $queries.list.find(q => q._id === parameters.queryId)
   $: datasource = $datasources.list.find(
     ds => ds._id === parameters.datasourceId
+  )
+  // Executequery action just works on PostgreSQL and MongoDB datasources
+  $: executeQueryDatasources = $datasources.list.filter(
+    x =>
+      x.source === IntegrationTypes.POSTGRES ||
+      x.source === IntegrationTypes.MONGODB
   )
 
   function fetchQueryDefinition(query) {
@@ -24,7 +31,7 @@
   <Select
     label="Datasource"
     bind:value={parameters.datasourceId}
-    options={$datasources.list}
+    options={executeQueryDatasources}
     getOptionLabel={source => source.name}
     getOptionValue={source => source._id}
   />


### PR DESCRIPTION
## Description
Fixed execute query returning all datasources instead of the allowed PostgreSQL and MongoDB.

Addresses: 
- fixing issue #6342 

**BEFORE**
![image](https://user-images.githubusercontent.com/3016564/183407176-3f3309e6-d135-4130-a85e-352e02ef066c.png)

**AFTER**
![image](https://user-images.githubusercontent.com/3016564/183409393-4d4046c7-433e-428f-bac8-58111a934fc4.png)


