### PR TITLE
Fixing CLI CI build

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -3,6 +3,10 @@ name: Budibase Release Selfhost
 on:
  workflow_dispatch:
 
+env:
+  BRANCH: ${{ github.event.pull_request.head.ref }}
+  BASE_BRANCH: ${{ github.event.pull_request.base.ref}}
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -40,13 +44,15 @@ jobs:
           DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}
           SELFHOST_TAG: latest
-      
-      - name: Build CLI executables
+
+      - name: Install Pro
+        run: yarn install:pro $BRANCH $BASE_BRANCH
+
+      - name: Bootstrap and build (CLI)
         run: |
-          pushd packages/cli
           yarn
+          yarn bootstrap
           yarn build
-          popd
 
       - name: Build OpenAPI spec
         run: |


### PR DESCRIPTION
## Description
Updating self host release to fix issues with CLI build - with the update to support backups via the CLI we have imported usage of the backend-core, however this means that the whole monorepo needs to be bootstrapped and setup, including installing pro (used by backend-core).

This will be necessary for dev experience CLI features as we will need the backend-core for them too - so updating the self host build to allow building the full monorepo is necessary.