### PR TITLE
Fix crash when attempting to parse a nullish automation error

### DIFF
--- a/packages/server/src/automations/logging/index.ts
+++ b/packages/server/src/automations/logging/index.ts
@@ -23,6 +23,9 @@ export async function checkAppMetadata(apps: App[]) {
     for (let [key, errors] of Object.entries(metadata.automationErrors)) {
       const updated = []
       for (let error of errors) {
+        if (!error) {
+          continue
+        }
         const startDate = error.split(dbUtils.SEPARATOR)[2]
         if (startDate > maxStartDate) {
           updated.push(error)


### PR DESCRIPTION
## Description
This is an attempt to fix the internal server errors which are sometimes thrown when calling the `/applications` endpoint. I believe that was intermittently happening due to a nullish automation error existing, so this PR simply ensures that nullish automation errors will be ignored.

The inner error being thrown (captured inside the test env) was referencing `.split` on an undefined object and this is the only reference I could find. There's no risk in merging this in and we'll be able to see soon enough in the test env if this fixes it.



