### PR TITLE
Set errors to null rather than deleting when validating user emails

### DIFF
--- a/packages/builder/src/pages/builder/portal/manage/users/_components/AddUserModal.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/users/_components/AddUserModal.svelte
@@ -48,7 +48,7 @@
     if (email) {
       const res = emailValidator(email)
       if (res === true) {
-        delete userData[index].error
+        userData[index].error = null
       } else {
         userData[index].error = res
       }


### PR DESCRIPTION
## Description
Mihail pointed out that validation errors on emails were not being properly cleared after being deleted. This is a small change to fix that. This is live at the moment so I'm targetting master here.

The cause is that calling `delete foo.bar` does not trigger svelte reactivity, but `foo.bar = null` does.


