### PR TITLE
Add timezone to served events

### DIFF
--- a/packages/backend-core/src/events/publishers/serve.ts
+++ b/packages/backend-core/src/events/publishers/serve.ts
@@ -7,22 +7,26 @@ import {
   AppServedEvent,
 } from "@budibase/types"
 
-export async function servedBuilder() {
-  const properties: BuilderServedEvent = {}
+export async function servedBuilder(timezone: string) {
+  const properties: BuilderServedEvent = {
+    timezone,
+  }
   await publishEvent(Event.SERVED_BUILDER, properties)
 }
 
-export async function servedApp(app: App) {
+export async function servedApp(app: App, timezone: string) {
   const properties: AppServedEvent = {
     appVersion: app.version,
+    timezone,
   }
   await publishEvent(Event.SERVED_APP, properties)
 }
 
-export async function servedAppPreview(app: App) {
+export async function servedAppPreview(app: App, timezone: string) {
   const properties: AppPreviewServedEvent = {
     appId: app.appId,
     appVersion: app.version,
+    timezone,
   }
   await publishEvent(Event.SERVED_APP_PREVIEW, properties)
 }

--- a/packages/frontend-core/src/api/analytics.js
+++ b/packages/frontend-core/src/api/analytics.js
@@ -8,9 +8,10 @@ export const buildAnalyticsEndpoints = API => ({
     })
   },
   analyticsPing: async ({ source }) => {
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
     return await API.post({
       url: "/api/bbtel/ping",
-      body: { source },
+      body: { source, timezone },
     })
   },
 })

--- a/packages/server/src/api/controllers/analytics.ts
+++ b/packages/server/src/api/controllers/analytics.ts
@@ -19,14 +19,14 @@ export const ping = async (ctx: any) => {
       let appId = context.getAppId()
 
       if (isDevAppID(appId)) {
-        await events.serve.servedAppPreview(appInfo)
+        await events.serve.servedAppPreview(appInfo, body.timezone)
       } else {
-        await events.serve.servedApp(appInfo)
+        await events.serve.servedApp(appInfo, body.timezone)
       }
       break
     }
     case PingSource.BUILDER: {
-      await events.serve.servedBuilder()
+      await events.serve.servedBuilder(body.timezone)
       break
     }
   }

--- a/packages/server/src/api/routes/tests/analytics.spec.js
+++ b/packages/server/src/api/routes/tests/analytics.spec.js
@@ -6,6 +6,8 @@ describe("/static", () => {
   let config = setup.getConfig()
   let app
 
+  const timezone = "Europe/London"
+
   afterAll(setup.afterAll)
 
   beforeEach(async () => {
@@ -17,22 +19,25 @@ describe("/static", () => {
     it("should ping from builder", async () => {
       await request
         .post("/api/bbtel/ping")
-        .send({source: "builder"})
+        .send({source: "builder", timezone})
         .set(config.defaultHeaders())
         .expect(200)
 
       expect(events.serve.servedBuilder).toBeCalledTimes(1)
+      expect(events.serve.servedBuilder).toBeCalledWith(timezone)
+      expect(events.serve.servedApp).not.toBeCalled()
+      expect(events.serve.servedAppPreview).not.toBeCalled()
     })
 
     it("should ping from app preview", async () => {
       await request
         .post("/api/bbtel/ping")
-        .send({source: "app"})
+        .send({source: "app", timezone})
         .set(config.defaultHeaders())
         .expect(200)
 
       expect(events.serve.servedAppPreview).toBeCalledTimes(1)
-      expect(events.serve.servedAppPreview).toBeCalledWith(config.getApp())
+      expect(events.serve.servedAppPreview).toBeCalledWith(config.getApp(), timezone)
       expect(events.serve.servedApp).not.toBeCalled()
     })
 
@@ -42,12 +47,12 @@ describe("/static", () => {
 
       await request
         .post("/api/bbtel/ping")
-        .send({source: "app"})
+        .send({source: "app", timezone})
         .set(headers)
         .expect(200)
 
       expect(events.serve.servedApp).toBeCalledTimes(1)
-      expect(events.serve.servedApp).toBeCalledWith(config.getProdApp())
+      expect(events.serve.servedApp).toBeCalledWith(config.getProdApp(), timezone)
       expect(events.serve.servedAppPreview).not.toBeCalled()
     })
   })

--- a/packages/types/src/api/web/analytics.ts
+++ b/packages/types/src/api/web/analytics.ts
@@ -5,4 +5,5 @@ export enum PingSource {
 
 export interface AnalyticsPingRequest {
   source: PingSource
+  timezone: string
 }

--- a/packages/types/src/sdk/events/serve.ts
+++ b/packages/types/src/sdk/events/serve.ts
@@ -1,11 +1,15 @@
 import { BaseEvent } from "./event"
 
-export interface BuilderServedEvent extends BaseEvent {}
+export interface BuilderServedEvent extends BaseEvent {
+  timezone: string
+}
 
 export interface AppServedEvent extends BaseEvent {
   appVersion: string
+  timezone: string
 }
 
 export interface AppPreviewServedEvent extends BaseEvent {
   appVersion: string
+  timezone: string
 }


### PR DESCRIPTION
## Description
- Pageview events have been removed due to volume
- To some awareness of location, add timezone to served events instead 
- Note: this is not perfect, e.g. belfast based timezone is `Europe/London`, however it is good enough to give us an indication of where requests are coming from in the cloud 


