### PR TITLE
onEmptyFilter selection for automations

### DIFF
--- a/packages/server/src/automations/steps/queryRows.js
+++ b/packages/server/src/automations/steps/queryRows.js
@@ -14,6 +14,16 @@ const SortOrdersPretty = {
   [SortOrders.DESCENDING]: "Descending",
 }
 
+const EmptyFilterOptions = {
+  RETURN_ALL: "all",
+  RETURN_NONE: "none",
+}
+
+const EmptyFilterOptionsPretty = {
+  [EmptyFilterOptions.RETURN_ALL]: "Return all table rows",
+  [EmptyFilterOptions.RETURN_NONE]: "Return no rows",
+}
+
 exports.definition = {
   description: "Query rows from the database",
   icon: "Search",
@@ -51,6 +61,12 @@ exports.definition = {
           type: "number",
           title: "Limit",
           customType: "queryLimit",
+        },
+        onEmptyFilter: {
+          pretty: Object.values(EmptyFilterOptionsPretty),
+          enum: Object.values(EmptyFilterOptions),
+          type: "string",
+          title: "When Filter Empty",
         },
       },
       required: ["tableId"],
@@ -103,6 +119,9 @@ function typeCoercion(filters, table) {
   return filters
 }
 
+const hasNullFilters = filters =>
+  filters.length === 0 || filters.some(filter => filter.value === null)
+
 exports.run = async function ({ inputs, appId }) {
   const { tableId, filters, sortColumn, sortOrder, limit } = inputs
   const table = await getTable(appId, tableId)
@@ -127,9 +146,21 @@ exports.run = async function ({ inputs, appId }) {
     version: "1",
   })
   try {
-    await rowController.search(ctx)
+    let rows
+
+    if (
+      inputs.onEmptyFilter === EmptyFilterOptions.RETURN_NONE &&
+      inputs["filters-def"] &&
+      hasNullFilters(inputs["filters-def"])
+    ) {
+      rows = []
+    } else {
+      await rowController.search(ctx)
+      rows = ctx.body ? ctx.body.rows : []
+    }
+
     return {
-      rows: ctx.body ? ctx.body.rows : [],
+      rows,
       success: ctx.status === 200,
     }
   } catch (err) {

--- a/packages/server/src/automations/steps/queryRows.js
+++ b/packages/server/src/automations/steps/queryRows.js
@@ -120,7 +120,8 @@ function typeCoercion(filters, table) {
 }
 
 const hasNullFilters = filters =>
-  filters.length === 0 || filters.some(filter => filter.value === null)
+  filters.length === 0 ||
+  filters.some(filter => filter.value === null || filter.value === "")
 
 exports.run = async function ({ inputs, appId }) {
   const { tableId, filters, sortColumn, sortOrder, limit } = inputs

--- a/packages/server/src/automations/tests/queryRows.spec.js
+++ b/packages/server/src/automations/tests/queryRows.spec.js
@@ -16,7 +16,7 @@ describe("Test a query step automation", () => {
   let table
   let config = setup.getConfig()
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     await config.init()
     table = await config.createTable()
     const row = {
@@ -47,5 +47,72 @@ describe("Test a query step automation", () => {
     expect(res.rows).toBeDefined()
     expect(res.rows.length).toBe(2)
     expect(res.rows[0].name).toBe(NAME)
+  })
+
+  it("Returns all rows when onEmptyFilter has no value and no filters are passed", async () => {
+    console.log(rows)
+    const inputs = {
+      tableId: table._id,
+      filters: {},
+      sortColumn: "name",
+      sortOrder: "ascending",
+      limit: 10,
+    }
+    const res = await setup.runStep(setup.actions.QUERY_ROWS.stepId, inputs)
+    expect(res.success).toBe(true)
+    expect(res.rows).toBeDefined()
+    expect(res.rows.length).toBe(2)
+    expect(res.rows[0].name).toBe(NAME)
+  })
+
+  it("Returns no rows when onEmptyFilter is RETURN_NONE and theres no filters", async () => {
+    const inputs = {
+      tableId: table._id,
+      filters: {},
+      "filters-def": [],
+      sortColumn: "name",
+      sortOrder: "ascending",
+      limit: 10,
+      onEmptyFilter: "none",
+    }
+    const res = await setup.runStep(setup.actions.QUERY_ROWS.stepId, inputs)
+    expect(res.success).toBe(false)
+    expect(res.rows).toBeDefined()
+    expect(res.rows.length).toBe(0)
+  })
+
+  it("Returns no rows when onEmptyFilters RETURN_NONE and a filter is passed with a null value", async () => {
+    const inputs = {
+      tableId: table._id,
+      onEmptyFilter: "none",
+      filters: {},
+      "filters-def": [
+        {
+          value: null
+        }
+      ],
+      sortColumn: "name",
+      sortOrder: "ascending",
+      limit: 10,
+    }
+    const res = await setup.runStep(setup.actions.QUERY_ROWS.stepId, inputs)
+    expect(res.success).toBe(false)
+    expect(res.rows).toBeDefined()
+    expect(res.rows.length).toBe(0)
+  })
+
+  it("Returns rows when onEmptyFilter is RETURN_ALL and no filter is passed", async () => {
+    const inputs = {
+      tableId: table._id,
+      onEmptyFilter: "all",
+      filters: {},
+      sortColumn: "name",
+      sortOrder: "ascending",
+      limit: 10,
+    }
+    const res = await setup.runStep(setup.actions.QUERY_ROWS.stepId, inputs)
+    expect(res.success).toBe(true)
+    expect(res.rows).toBeDefined()
+    expect(res.rows.length).toBe(2)
   })
 })

--- a/packages/server/src/automations/tests/queryRows.spec.js
+++ b/packages/server/src/automations/tests/queryRows.spec.js
@@ -50,7 +50,6 @@ describe("Test a query step automation", () => {
   })
 
   it("Returns all rows when onEmptyFilter has no value and no filters are passed", async () => {
-    console.log(rows)
     const inputs = {
       tableId: table._id,
       filters: {},


### PR DESCRIPTION
## Description
This PR contains code that allows you to specify the behaviour of the query rows automation step whenever a `null` filter is encountered. The reasoning for this is that couch will return all results of the table if you filter on a value of `null`, rather than nothing. This is particularly dangerous if you plan to delete rows or perform actions on a loop. 

**Empty Filter Setting**
I've opted for a "When Filter Empty" option in the query rows automation. I felt this was more descriptive and clear than just a checkbox.

<img width="552" alt="Screenshot 2022-08-10 at 15 52 40" src="https://user-images.githubusercontent.com/11256663/183935162-9b9392d7-90e3-4124-9c0b-85475f708c3c.png">

The 2 options work as follows:

**Return all table rows**
When a user passes no filters, or a value is null, just retain the old behaviour. This maintains backwards compatibility and still lets you account for use cases such as `not equals null`. 

**Return no rows**
When no filters are passed, or any filter is passed that has a `null` value - simply return an empty array, and a success value of `false`. This is a safeguard for users who want to ensure that all their filters are populated before performing a query to the database. This is a good option to use if your next step is `Delete Row` or any other destructive operation. This should probably be the default - but I didn't want to break any backwards compat for existing automation users.

Addresses: 
- https://github.com/Budibase/budibase/issues/6013

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._



