### PR TITLE
single image build data path for azure

### DIFF
--- a/hosting/scripts/build-target-paths.sh
+++ b/hosting/scripts/build-target-paths.sh
@@ -3,15 +3,14 @@
 echo ${TARGETBUILD} > /buildtarget.txt
 if [[ "${TARGETBUILD}" = "aas" ]]; then
     # Azure AppService uses /home for persisent data & SSH on port 2222
-    mkdir -p /home/{search,minio,couch}
-    mkdir -p /home/couch/{dbs,views}
-    chown -R couchdb:couchdb /home/couch/
+    DATA_DIR=/home
+    mkdir -p $DATA_DIR/{search,minio,couchdb}
+    mkdir -p $DATA_DIR/couchdb/{dbs,views}
+    chown -R couchdb:couchdb $DATA_DIR/couchdb/
     apt update
     apt-get install -y openssh-server
-    sed -i 's#dir=/opt/couchdb/data/search#dir=/home/search#' /opt/clouseau/clouseau.ini
-    sed -i 's#/minio/minio server /minio &#/minio/minio server /home/minio &#' /runner.sh
-    sed -i 's#database_dir = ./data#database_dir = /home/couch/dbs#' /opt/couchdb/etc/default.ini
-    sed -i 's#view_index_dir = ./data#view_index_dir = /home/couch/views#' /opt/couchdb/etc/default.ini
     sed -i "s/#Port 22/Port 2222/" /etc/ssh/sshd_config
     /etc/init.d/ssh restart
 fi
+
+sed -i 's#DATA_DIR#$DATA_DIR#' /opt/clouseau/clouseau.ini /opt/couchdb/etc/local.ini

--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -20,10 +20,10 @@ RUN node /pinVersions.js && yarn && yarn build && /cleanup.sh
 
 FROM couchdb:3.2.1
 # TARGETARCH can be amd64 or arm e.g. docker build --build-arg TARGETARCH=amd64
-ARG TARGETARCH amd64
+ARG TARGETARCH=amd64
 #TARGETBUILD can be set to single (for single docker image) or aas (for azure app service)
 # e.g. docker build --build-arg TARGETBUILD=aas ....
-ARG TARGETBUILD single
+ARG TARGETBUILD=single
 ENV TARGETBUILD $TARGETBUILD
 
 COPY --from=build /app /app
@@ -35,6 +35,7 @@ ENV \
   BUDIBASE_ENVIRONMENT=PRODUCTION \
   CLUSTER_PORT=80 \
   # CUSTOM_DOMAIN=budi001.custom.com \
+  DATA_DIR=/data \
   DEPLOYMENT_ENVIRONMENT=docker \
   MINIO_URL=http://localhost:9000 \
   POSTHOG_TOKEN=phc_fg5I3nDOf6oJVMHSaycEhpPdlgS8rzXG2r6F2IpxCHS \
@@ -114,6 +115,7 @@ RUN chmod +x ./healthcheck.sh
 ADD hosting/scripts/build-target-paths.sh .
 RUN chmod +x ./build-target-paths.sh
 
+# Script below sets the path for storing data based on $DATA_DIR
 # For Azure App Service install SSH & point data locations to /home
 RUN /build-target-paths.sh
 

--- a/hosting/single/clouseau/clouseau.ini
+++ b/hosting/single/clouseau/clouseau.ini
@@ -7,7 +7,7 @@ name=clouseau@127.0.0.1
 cookie=monster
 
 ; the path where you would like to store the search index files
-dir=/data/search
+dir=DATA_DIR/search
 
 ; the number of search indexes that can be open simultaneously
 max_indexes_open=500

--- a/hosting/single/couch/local.ini
+++ b/hosting/single/couch/local.ini
@@ -1,5 +1,5 @@
 ; CouchDB Configuration Settings
 
 [couchdb]
-database_dir = /data/couch/dbs
-view_index_dir = /data/couch/views
+database_dir = DATA_DIR/couch/dbs
+view_index_dir = DATA_DIR/couch/views


### PR DESCRIPTION
The aim of this PR is to assist with the single image build for Azure App Service (AAS). AAS requires that data is stored under /home rather than /data. It also requires SSH server installation listening on port 2222.
So these changes add variables into config files to replace DATA_DIR with either /data or /home.
 