### PR TITLE
Custom colour palette for charts

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -1466,10 +1466,11 @@
       },
       {
         "type": "select",
-        "label": "Colours",
+        "label": "Colors",
         "key": "palette",
         "defaultValue": "Palette 1",
         "options": [
+          "Custom",
           "Palette 1",
           "Palette 2",
           "Palette 3",
@@ -1481,6 +1482,16 @@
           "Palette 9",
           "Palette 10"
         ]
+      },
+      {
+        "type": "color",
+        "label": "C1",
+        "key": "c1",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
       },
       {
         "type": "boolean",

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -1487,7 +1487,6 @@
         "type": "color",
         "label": "C1",
         "key": "c1",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1497,7 +1496,6 @@
         "type": "color",
         "label": "C2",
         "key": "c2",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1507,7 +1505,6 @@
         "type": "color",
         "label": "C3",
         "key": "c3",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1517,7 +1514,6 @@
         "type": "color",
         "label": "C4",
         "key": "c4",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1527,7 +1523,6 @@
         "type": "color",
         "label": "C5",
         "key": "c5",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1653,7 +1648,6 @@
         "type": "color",
         "label": "C1",
         "key": "c1",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1663,7 +1657,6 @@
         "type": "color",
         "label": "C2",
         "key": "c2",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1673,7 +1666,6 @@
         "type": "color",
         "label": "C3",
         "key": "c3",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1683,7 +1675,6 @@
         "type": "color",
         "label": "C4",
         "key": "c4",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1693,7 +1684,6 @@
         "type": "color",
         "label": "C5",
         "key": "c5",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1818,7 +1808,6 @@
         "type": "color",
         "label": "C1",
         "key": "c1",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1828,7 +1817,6 @@
         "type": "color",
         "label": "C2",
         "key": "c2",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1838,7 +1826,6 @@
         "type": "color",
         "label": "C3",
         "key": "c3",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1848,7 +1835,6 @@
         "type": "color",
         "label": "C4",
         "key": "c4",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1858,7 +1844,6 @@
         "type": "color",
         "label": "C5",
         "key": "c5",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1974,7 +1959,6 @@
         "type": "color",
         "label": "C1",
         "key": "c1",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1984,7 +1968,6 @@
         "type": "color",
         "label": "C2",
         "key": "c2",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -1994,7 +1977,6 @@
         "type": "color",
         "label": "C3",
         "key": "c3",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -2004,7 +1986,6 @@
         "type": "color",
         "label": "C4",
         "key": "c4",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -2014,7 +1995,6 @@
         "type": "color",
         "label": "C5",
         "key": "c5",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -2107,7 +2087,6 @@
         "type": "color",
         "label": "C1",
         "key": "c1",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -2117,7 +2096,6 @@
         "type": "color",
         "label": "C2",
         "key": "c2",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -2127,7 +2105,6 @@
         "type": "color",
         "label": "C3",
         "key": "c3",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -2137,7 +2114,6 @@
         "type": "color",
         "label": "C4",
         "key": "c4",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"
@@ -2147,7 +2123,6 @@
         "type": "color",
         "label": "C5",
         "key": "c5",
-        "barSeparator": false,
         "dependsOn": {
           "setting": "palette",
           "value": "Custom"

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -1632,10 +1632,11 @@
       },
       {
         "type": "select",
-        "label": "Colours",
+        "label": "Colors",
         "key": "palette",
         "defaultValue": "Palette 1",
         "options": [
+          "Custom",
           "Palette 1",
           "Palette 2",
           "Palette 3",
@@ -1647,6 +1648,56 @@
           "Palette 9",
           "Palette 10"
         ]
+      },
+      {
+        "type": "color",
+        "label": "C1",
+        "key": "c1",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C2",
+        "key": "c2",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C3",
+        "key": "c3",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C4",
+        "key": "c4",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C5",
+        "key": "c5",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
       },
       {
         "type": "select",

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -1797,10 +1797,11 @@
       },
       {
         "type": "select",
-        "label": "Colours",
+        "label": "Colors",
         "key": "palette",
         "defaultValue": "Palette 1",
         "options": [
+          "Custom",
           "Palette 1",
           "Palette 2",
           "Palette 3",
@@ -1812,6 +1813,56 @@
           "Palette 9",
           "Palette 10"
         ]
+      },
+      {
+        "type": "color",
+        "label": "C1",
+        "key": "c1",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C2",
+        "key": "c2",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C3",
+        "key": "c3",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C4",
+        "key": "c4",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C5",
+        "key": "c5",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
       },
       {
         "type": "select",

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -1811,10 +1811,11 @@
       },
       {
         "type": "select",
-        "label": "Colours",
+        "label": "Colors",
         "key": "palette",
         "defaultValue": "Palette 1",
         "options": [
+          "Custom",
           "Palette 1",
           "Palette 2",
           "Palette 3",
@@ -1826,6 +1827,56 @@
           "Palette 9",
           "Palette 10"
         ]
+      },
+      {
+        "type": "color",
+        "label": "C1",
+        "key": "c1",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C2",
+        "key": "c2",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C3",
+        "key": "c3",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C4",
+        "key": "c4",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C5",
+        "key": "c5",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
       },
       {
         "type": "boolean",
@@ -1893,10 +1944,11 @@
       },
       {
         "type": "select",
-        "label": "Colours",
+        "label": "Colors",
         "key": "palette",
         "defaultValue": "Palette 1",
         "options": [
+          "Custom",
           "Palette 1",
           "Palette 2",
           "Palette 3",
@@ -1908,6 +1960,16 @@
           "Palette 9",
           "Palette 10"
         ]
+      },
+      {
+        "type": "color",
+        "label": "Color",
+        "key": "color",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
       },
       {
         "type": "boolean",

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -1494,6 +1494,46 @@
         }
       },
       {
+        "type": "color",
+        "label": "C2",
+        "key": "c2",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C3",
+        "key": "c3",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C4",
+        "key": "c4",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C5",
+        "key": "c5",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
         "type": "boolean",
         "label": "Stacked",
         "key": "stacked",
@@ -1963,8 +2003,48 @@
       },
       {
         "type": "color",
-        "label": "Color",
-        "key": "color",
+        "label": "C1",
+        "key": "c1",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C2",
+        "key": "c2",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C3",
+        "key": "c3",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C4",
+        "key": "c4",
+        "barSeparator": false,
+        "dependsOn": {
+          "setting": "palette",
+          "value": "Custom"
+        }
+      },
+      {
+        "type": "color",
+        "label": "C5",
+        "key": "c5",
         "barSeparator": false,
         "dependsOn": {
           "setting": "palette",

--- a/packages/client/src/components/app/charts/ApexChart.svelte
+++ b/packages/client/src/components/app/charts/ApexChart.svelte
@@ -10,7 +10,9 @@
 </script>
 
 {#if options}
-  <div use:chart={options} use:styleable={$component.styles} />
+  {#key options.customColor}
+    <div use:chart={options} use:styleable={$component.styles} />
+  {/key}
 {:else if $builderStore.inBuilder}
   <div use:styleable={$component.styles}>
     <Placeholder />

--- a/packages/client/src/components/app/charts/ApexOptionsBuilder.js
+++ b/packages/client/src/components/app/charts/ApexOptionsBuilder.js
@@ -62,8 +62,14 @@ export class ApexOptionsBuilder {
     return this.setOption(["title", "text"], title)
   }
 
-  color(color) {
-    return this.setOption(["colors"], [color])
+  colors(colors) {
+    if (!colors) {
+      delete this.options.colors
+      this.options["customColor"] = false
+      return this
+    }
+    this.options["customColor"] = true
+    return this.setOption(["colors"], colors)
   }
 
   width(width) {

--- a/packages/client/src/components/app/charts/BarChart.svelte
+++ b/packages/client/src/components/app/charts/BarChart.svelte
@@ -16,6 +16,7 @@
   export let stacked
   export let yAxisUnits
   export let palette
+  export let c1, c2, c3, c4, c5
   export let horizontal
 
   $: options = setUpChart(
@@ -33,8 +34,12 @@
     stacked,
     yAxisUnits,
     palette,
-    horizontal
+    horizontal,
+    c1 ? [c1] : null,
+    customColor
   )
+
+  $: customColor = palette === "Custom"
 
   const setUpChart = (
     title,
@@ -51,7 +56,9 @@
     stacked,
     yAxisUnits,
     palette,
-    horizontal
+    horizontal,
+    colors,
+    customColor
   ) => {
     const allCols = [labelColumn, ...(valueColumns || [null])]
     if (
@@ -85,6 +92,7 @@
       .stacked(stacked)
       .palette(palette)
       .horizontal(horizontal)
+      .colors(customColor ? colors : null)
 
     // Add data
     let useDates = false

--- a/packages/client/src/components/app/charts/BarChart.svelte
+++ b/packages/client/src/components/app/charts/BarChart.svelte
@@ -35,7 +35,7 @@
     yAxisUnits,
     palette,
     horizontal,
-    c1 ? [c1] : null,
+    c1 && c2 && c3 && c4 && c5 ? [c1, c2, c3, c4, c5] : null,
     customColor
   )
 

--- a/packages/client/src/components/app/charts/LineChart.svelte
+++ b/packages/client/src/components/app/charts/LineChart.svelte
@@ -17,6 +17,7 @@
   export let legend
   export let yAxisUnits
   export let palette
+  export let c1, c2, c3, c4, c5
 
   // Area specific props
   export let area
@@ -40,8 +41,12 @@
     palette,
     area,
     stacked,
-    gradient
+    gradient,
+    c1 && c2 && c3 && c4 && c5 ? [c1, c2, c3, c4, c5] : null,
+    customColor
   )
+
+  $: customColor = palette === "Custom"
 
   const setUpChart = (
     title,
@@ -60,7 +65,9 @@
     palette,
     area,
     stacked,
-    gradient
+    gradient,
+    colors,
+    customColor
   ) => {
     const allCols = [labelColumn, ...(valueColumns || [null])]
     if (
@@ -96,6 +103,7 @@
       .legend(legend)
       .yUnits(yAxisUnits)
       .palette(palette)
+      .colors(customColor ? colors : null)
 
     // Add data
     let useDates = false

--- a/packages/client/src/components/app/charts/PieChart.svelte
+++ b/packages/client/src/components/app/charts/PieChart.svelte
@@ -13,6 +13,7 @@
   export let legend
   export let donut
   export let palette
+  export let c1, c2, c3, c4, c5
 
   $: options = setUpChart(
     title,
@@ -25,8 +26,12 @@
     animate,
     legend,
     donut,
-    palette
+    palette,
+    c1 && c2 && c3 && c4 && c5 ? [c1, c2, c3, c4, c5] : null,
+    customColor
   )
+
+  $: customColor = palette === "Custom"
 
   const setUpChart = (
     title,
@@ -39,7 +44,9 @@
     animate,
     legend,
     donut,
-    palette
+    palette,
+    colors,
+    customColor
   ) => {
     if (
       !dataProvider ||
@@ -70,6 +77,7 @@
       .legend(legend)
       .legendPosition("right")
       .palette(palette)
+      .colors(customColor ? colors : null)
 
     // Add data if valid datasource
     const series = data.map(row => parseFloat(row[valueColumn]))


### PR DESCRIPTION
## Description
You can now select five custom colours instead of using a pre-set palette.
All five colours must be set to render the theme. 

Addresses: 
- https://github.com/Budibase/budibase/issues/6232

## Screenshots
![Screenshot 2022-08-11 at 18 02 48](https://user-images.githubusercontent.com/101575380/184191920-2b0428c5-c87a-44e8-b28b-4e1829612ce5.png)

![Screenshot 2022-08-11 at 18 03 10](https://user-images.githubusercontent.com/101575380/184191989-47f60508-6c1d-4970-bd19-711dd024ad8c.png)

