### PR TITLE
Cypress: Smoke Build Changes

### DIFF
--- a/packages/builder/cypress/integration/addMultiOptionDatatype.spec.js
+++ b/packages/builder/cypress/integration/addMultiOptionDatatype.spec.js
@@ -2,7 +2,7 @@ import filterTests from "../support/filterTests"
 const interact = require('../support/interact')
 
 filterTests(['all'], () => {
-  context("Add Multi-Option Datatype", () => {
+  xcontext("Add Multi-Option Datatype", () => {
     before(() => {
       cy.login()
       cy.createTestApp()

--- a/packages/builder/cypress/integration/appOverview.spec.js
+++ b/packages/builder/cypress/integration/appOverview.spec.js
@@ -266,7 +266,7 @@ filterTests(["all"], () => {
           cy.reload()
           cy.log("Current deployment version: " + clientPackage.version)
 
-          cy.get(".version-status a", { timeout: 1000 }).contains("Update").click()
+          cy.get(".version-status a", { timeout: 5000 }).contains("Update").click()
           cy.get(".spectrum-Tabs-item.is-selected").contains("Settings")
 
           cy.get(".version-section .page-action button")

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -448,7 +448,7 @@ Cypress.Commands.add("createTable", (tableName, initialTable) => {
         .contains("Continue")
         .click({ force: true })
     })
-  cy.get(".spectrum-Modal", { timeout: 2000 }).should(
+  cy.get(".spectrum-Modal", { timeout: 10000 }).should(
     "not.contain",
     "Add data source"
   )

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -128,7 +128,9 @@ Cypress.Commands.add("updateUserInformation", (firstName, lastName) => {
         .should("have.value", lastName)
         .blur()
     }
-    cy.get("button").contains("Update information").click({ force: true })
+    cy.get(".confirm-wrap").within(() => {
+      cy.get("button").contains("Update information").click({ force: true })
+    })
     cy.get(".spectrum-Dialog-grid").should("not.exist")
   })
 })
@@ -432,6 +434,7 @@ Cypress.Commands.add("createAppFromScratch", appName => {
 
 // TABLES
 Cypress.Commands.add("createTable", (tableName, initialTable) => {
+  // Creates an internal Budibase DB table
   if (!initialTable) {
     cy.navigateToDataSection()
     cy.get(`[data-cy="new-table"]`, { timeout: 2000 }).click()
@@ -445,6 +448,10 @@ Cypress.Commands.add("createTable", (tableName, initialTable) => {
         .contains("Continue")
         .click({ force: true })
     })
+  cy.get(".spectrum-Modal", { timeout: 2000 }).should(
+    "not.contain",
+    "Add data source"
+  )
   cy.get(".spectrum-Modal", { timeout: 2000 }).within(() => {
     cy.get("input", { timeout: 2000 }).first().type(tableName).blur()
     cy.get(".spectrum-ButtonGroup").contains("Create").click()


### PR DESCRIPTION
**Removing Add Multi-Option Datatype Test from Cypress Suite**

We don't need a specific test file for this.
The test file will remain for now but will not run. The test will be reworked into a different test file or as part of the API testing

**also included:**
- Timeout increase for createTable Cypress Command
- Adding a few corrections to support failing/Flakey smoke tests (timing issues)


