### PR TITLE
Delete attachments on field clear from minio bucket

### DIFF
--- a/packages/bbui/src/Form/Core/Dropzone.svelte
+++ b/packages/bbui/src/Form/Core/Dropzone.svelte
@@ -17,6 +17,7 @@
   export let disabled = false
   export let fileSizeLimit = BYTES_IN_MB * 20
   export let processFiles = null
+  export let deleteAttachments = null
   export let handleFileTooLarge = null
   export let handleTooManyFiles = null
   export let gallery = true
@@ -95,6 +96,7 @@
       value.filter((x, idx) => idx !== selectedImageIdx)
     )
     selectedImageIdx = 0
+    await deleteAttachments(value.map(item => item.key))
   }
 
   function navigateLeft() {

--- a/packages/bbui/src/Form/Core/Dropzone.svelte
+++ b/packages/bbui/src/Form/Core/Dropzone.svelte
@@ -95,9 +95,11 @@
       "change",
       value.filter((x, idx) => idx !== selectedImageIdx)
     )
-    await deleteAttachments(
-      value.filter((x, idx) => idx === selectedImageIdx).map(item => item.key)
-    )
+    if (deleteAttachments) {
+      await deleteAttachments(
+        value.filter((x, idx) => idx === selectedImageIdx).map(item => item.key)
+      )
+    }
     selectedImageIdx = 0
   }
 

--- a/packages/bbui/src/Form/Core/Dropzone.svelte
+++ b/packages/bbui/src/Form/Core/Dropzone.svelte
@@ -95,8 +95,10 @@
       "change",
       value.filter((x, idx) => idx !== selectedImageIdx)
     )
+    await deleteAttachments(
+      value.filter((x, idx) => idx === selectedImageIdx).map(item => item.key)
+    )
     selectedImageIdx = 0
-    await deleteAttachments(value.map(item => item.key))
   }
 
   function navigateLeft() {

--- a/packages/bbui/src/Form/Dropzone.svelte
+++ b/packages/bbui/src/Form/Dropzone.svelte
@@ -10,6 +10,7 @@
   export let error = null
   export let fileSizeLimit = undefined
   export let processFiles = undefined
+  export let deleteAttachments = undefined
   export let handleFileTooLarge = undefined
   export let handleTooManyFiles = undefined
   export let gallery = true
@@ -30,6 +31,7 @@
     {value}
     {fileSizeLimit}
     {processFiles}
+    {deleteAttachments}
     {handleFileTooLarge}
     {handleTooManyFiles}
     {gallery}

--- a/packages/builder/src/components/common/Dropzone.svelte
+++ b/packages/builder/src/components/common/Dropzone.svelte
@@ -27,6 +27,14 @@
       return []
     }
   }
+
+  async function deleteAttachments(fileList) {
+    try {
+      return await API.deleteBuilderAttachments(fileList)
+    } catch (error) {
+      return []
+    }
+  }
 </script>
 
 <Dropzone
@@ -34,5 +42,6 @@
   {label}
   {...$$restProps}
   {processFiles}
+  {deleteAttachments}
   {handleFileTooLarge}
 />

--- a/packages/client/src/components/app/forms/AttachmentField.svelte
+++ b/packages/client/src/components/app/forms/AttachmentField.svelte
@@ -47,6 +47,17 @@
     }
   }
 
+  const deleteAttachments = async fileList => {
+    try {
+      return await API.deleteAttachments({
+        keys: fileList,
+        tableId: formContext?.dataSource?.tableId,
+      })
+    } catch (error) {
+      return []
+    }
+  }
+
   const handleChange = e => {
     fieldApi.setValue(e.detail)
     if (onChange) {
@@ -72,6 +83,7 @@
       error={fieldState.error}
       on:change={handleChange}
       {processFiles}
+      {deleteAttachments}
       {handleFileTooLarge}
       {handleTooManyFiles}
       {maximum}

--- a/packages/frontend-core/src/api/attachments.js
+++ b/packages/frontend-core/src/api/attachments.js
@@ -61,5 +61,19 @@ export const buildAttachmentEndpoints = API => {
       })
       return { publicUrl }
     },
+
+    /**
+     * Deletes attachments from the bucket.
+     * @param keys the attachments to delete
+     * @param tableId the associated table ID
+     */
+    deleteAttachments: async ({ keys, tableId }) => {
+      return await API.post({
+        url: `/api/attachments/${tableId}/delete`,
+        body: {
+          keys,
+        },
+      })
+    },
   }
 }

--- a/packages/frontend-core/src/api/attachments.js
+++ b/packages/frontend-core/src/api/attachments.js
@@ -75,5 +75,18 @@ export const buildAttachmentEndpoints = API => {
         },
       })
     },
+
+    /**
+     * Deletes attachments from the builder bucket.
+     * @param keys the attachments to delete
+     */
+    deleteBuilderAttachments: async keys => {
+      return await API.post({
+        url: `/api/attachments/delete`,
+        body: {
+          keys,
+        },
+      })
+    },
   }
 }

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -12,7 +12,7 @@ const {
 } = require("../../../utilities/fileSystem")
 const env = require("../../../environment")
 const { clientLibraryPath } = require("../../../utilities")
-const { upload } = require("../../../utilities/fileSystem")
+const { upload, deleteFiles } = require("../../../utilities/fileSystem")
 const { attachmentsRelativeURL } = require("../../../utilities")
 const { DocumentType } = require("../../../db/utils")
 const { getAppDB, getAppId } = require("@budibase/backend-core/context")
@@ -95,6 +95,10 @@ export const uploadFile = async function (ctx: any) {
   })
 
   ctx.body = await Promise.all(uploads)
+}
+
+export const deleteObjects = async function (ctx: any) {
+  ctx.body = await deleteFiles(ObjectStoreBuckets.APPS, ctx.request.body.keys)
 }
 
 export const serveApp = async function (ctx: any) {

--- a/packages/server/src/api/routes/static.ts
+++ b/packages/server/src/api/routes/static.ts
@@ -45,6 +45,12 @@ router
     authorized(PermissionTypes.TABLE, PermissionLevels.WRITE),
     controller.uploadFile
   )
+  .post(
+    "/api/attachments/:tableId/delete",
+    paramResource("tableId"),
+    authorized(PermissionTypes.TABLE, PermissionLevels.WRITE),
+    controller.deleteObjects
+  )
   .get("/:appId/:path*", controller.serveApp)
   .get("/app/:appUrl/:path*", controller.serveApp)
   .post(

--- a/packages/server/src/api/routes/static.ts
+++ b/packages/server/src/api/routes/static.ts
@@ -38,6 +38,11 @@ router
   // TODO: for now this builder endpoint is not authorized/secured, will need to be
   .get("/builder/:file*", controller.serveBuilder)
   .post("/api/attachments/process", authorized(BUILDER), controller.uploadFile)
+  .post(
+    "/api/attachments/delete",
+    authorized(BUILDER),
+    controller.deleteObjects
+  )
   .post("/api/beta/:feature", controller.toggleBetaUiFeature)
   .post(
     "/api/attachments/:tableId/upload",

--- a/packages/server/src/utilities/fileSystem/index.js
+++ b/packages/server/src/utilities/fileSystem/index.js
@@ -15,6 +15,7 @@ const {
   streamUpload,
   deleteFolder,
   downloadTarball,
+  deleteFiles,
 } = require("./utilities")
 const { updateClientLibrary } = require("./clientLibrary")
 const env = require("../../environment")
@@ -327,5 +328,6 @@ exports.cleanup = appIds => {
 exports.upload = upload
 exports.retrieve = retrieve
 exports.retrieveToTmp = retrieveToTmp
+exports.deleteFiles = deleteFiles
 exports.TOP_LEVEL_PATH = TOP_LEVEL_PATH
 exports.NODE_MODULES_PATH = NODE_MODULES_PATH


### PR DESCRIPTION
## Description
Clearing an attachment field will now remove the file from MinIO

Addresses: 
- https://github.com/Budibase/budibase/issues/5564

## Screenshots
**Two files uploaded**
![Screenshot 2022-08-12 at 11 41 45](https://user-images.githubusercontent.com/101575380/184338413-5bd8f249-1afe-497b-abc7-08ad6fbd7f86.png)
![Screenshot 2022-08-12 at 11 41 57](https://user-images.githubusercontent.com/101575380/184338447-d0b84fd2-1a52-4fc4-9e45-8d43241f01d8.png)

**Clear one file**
![Screenshot 2022-08-12 at 11 42 26](https://user-images.githubusercontent.com/101575380/184338513-ea988afe-5342-4445-aeac-02b9119c1eea.png)
![Screenshot 2022-08-12 at 11 42 42](https://user-images.githubusercontent.com/101575380/184338557-d5c32afd-d1d6-46cd-972e-edeaf8bd52f7.png)

**Clear the last file**
![Screenshot 2022-08-12 at 11 43 05](https://user-images.githubusercontent.com/101575380/184338625-21feab21-05a7-47d8-924a-0549d5ec5998.png)
![Screenshot 2022-08-12 at 11 43 16](https://user-images.githubusercontent.com/101575380/184338663-1a9a3674-6515-4311-8cb4-89d845872bc1.png)


