### PR TITLE
Updating createApp test command

### DIFF
--- a/packages/builder/cypress/integration/addMultiOptionDatatype.spec.js
+++ b/packages/builder/cypress/integration/addMultiOptionDatatype.spec.js
@@ -2,7 +2,7 @@ import filterTests from "../support/filterTests"
 const interact = require('../support/interact')
 
 filterTests(['all'], () => {
-  xcontext("Add Multi-Option Datatype", () => {
+  context("Add Multi-Option Datatype", () => {
     before(() => {
       cy.login()
       cy.createTestApp()

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -164,7 +164,7 @@ Cypress.Commands.add("createApp", (name, addDefaultTable) => {
     typeof addDefaultTable != "boolean" ? true : addDefaultTable
 
   cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 10000 })
-  cy.wait(1000)
+  cy.url({ timeout: 30000 }).should("include", "/apps")
   cy.get(`[data-cy="create-app-btn"]`, { timeout: 5000 }).click({ force: true })
 
   // If apps already exist


### PR DESCRIPTION
In some cases Cypress is running too fast, meaning that the test runs ahead of what is actual seen on Budibase.

This issue mainly occurs at the start of the smoke build and around logging in.

I am attempting to combat this by ensuring the url includes 'apps' after visiting the baseURL and before attempting to create an app



