### PR TITLE
roll out release services after deployment

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -68,6 +68,13 @@ jobs:
             ]
         env:
           KUBECONFIG_FILE: '${{ secrets.RELEASE_KUBECONFIG }}'
+      
+      - name: Re roll the services
+        uses: actions-hub/kubectl@master
+        env:
+          KUBE_CONFIG: ${{ secrets.RELEASE_KUBECONFIG }}
+        with:
+          args: rollout restart deployment proxy-service -n budibase && kubectl rollout restart deployment app-service -n budibase && kubectl rollout restart deployment worker-service -n budibase
 
       - name: Discord Webhook Action
         uses: tsickert/discord-webhook@v4.0.0

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -58,7 +58,7 @@ jobs:
           helm: helm3
           values: |
             globals: 
-              appVersion: develop
+              appVersion: ${{ env.RELEASE_VERSION }}
             ingress:
               enabled: true
               nginx: true

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -58,7 +58,7 @@ jobs:
           helm: helm3
           values: |
             globals: 
-              appVersion: ${{ env.RELEASE_VERSION }}
+              appVersion: develop
             ingress:
               enabled: true
               nginx: true

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -120,6 +120,13 @@ jobs:
         env:
           KUBECONFIG_FILE: '${{ secrets.RELEASE_KUBECONFIG }}'
 
+      - name: Re roll the services
+        uses: actions-hub/kubectl@master
+        env:
+          KUBE_CONFIG: ${{ secrets.RELEASE_KUBECONFIG }}
+        with:
+          args: rollout restart deployment proxy-service -n budibase && kubectl rollout restart deployment app-service -n budibase && kubectl rollout restart deployment worker-service -n budibase
+
       - name: Discord Webhook Action
         uses: tsickert/discord-webhook@v4.0.0
         with:

--- a/packages/builder/src/components/backend/DataTable/DataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/DataTable.svelte
@@ -167,6 +167,7 @@
         {/if}
         <HideAutocolumnButton bind:hideAutocolumns />
         <ImportButton
+          disabled={$tables.selected?._id === "ta_users"}
           tableId={$tables.selected?._id}
           on:updaterows={onUpdateRows}
         />

--- a/packages/builder/src/components/backend/DataTable/buttons/ImportButton.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/ImportButton.svelte
@@ -3,11 +3,12 @@
   import ImportModal from "../modals/ImportModal.svelte"
 
   export let tableId
+  export let disabled
 
   let modal
 </script>
 
-<ActionButton icon="DataUpload" size="S" quiet on:click={modal.show}>
+<ActionButton icon="DataUpload" size="S" quiet on:click={modal.show} {disabled}>
   Import
 </ActionButton>
 <Modal bind:this={modal}>


### PR DESCRIPTION
## Description
Some small ones just:
- Disabling "Import" on users metadata table. It's pointless and it's tripped up some users thinking that is how you upload more users to the platform
- Performing a manual rollout of release services on deployment so that they are updated until we have proper tagging and private images with ECR

Addresses: 
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._



