### PR TITLE
Only allow bindings for 'Is In' operator in conditional UI

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ConditionalUIDrawer.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ConditionalUIDrawer.svelte
@@ -206,7 +206,7 @@
                 on:change={e => onOperatorChange(condition, e.detail)}
               />
               <Select
-                disabled={condition.noValue}
+                disabled={condition.noValue || condition.operator === "oneOf"}
                 options={condition.operator === "oneOf"
                   ? [
                       {

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ConditionalUIDrawer.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ConditionalUIDrawer.svelte
@@ -112,7 +112,7 @@
       Constants.OperatorOptions.NotEmpty.value,
     ]
     condition.noValue = noValueOptions.includes(newOperator)
-    if (condition.noValue) {
+    if (condition.noValue || condition.operator === "oneOf") {
       condition.referenceValue = null
       condition.valueType = "string"
     }
@@ -207,7 +207,14 @@
               />
               <Select
                 disabled={condition.noValue}
-                options={valueTypeOptions}
+                options={condition.operator === "oneOf"
+                  ? [
+                      {
+                        value: "string",
+                        label: "Binding",
+                      },
+                    ]
+                  : valueTypeOptions}
                 bind:value={condition.valueType}
                 placeholder={null}
                 on:change={e => onValueTypeChange(condition, e.detail)}

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ConditionalUIDrawer.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ConditionalUIDrawer.svelte
@@ -112,7 +112,7 @@
       Constants.OperatorOptions.NotEmpty.value,
     ]
     condition.noValue = noValueOptions.includes(newOperator)
-    if (condition.noValue || condition.operator === "oneOf") {
+    if (condition.noValue || newOperator === "oneOf") {
       condition.referenceValue = null
       condition.valueType = "string"
     }
@@ -207,14 +207,7 @@
               />
               <Select
                 disabled={condition.noValue || condition.operator === "oneOf"}
-                options={condition.operator === "oneOf"
-                  ? [
-                      {
-                        value: "string",
-                        label: "Binding",
-                      },
-                    ]
-                  : valueTypeOptions}
+                options={valueTypeOptions}
                 bind:value={condition.valueType}
                 placeholder={null}
                 on:change={e => onValueTypeChange(condition, e.detail)}

--- a/packages/frontend-core/src/utils/lucene.js
+++ b/packages/frontend-core/src/utils/lucene.js
@@ -114,7 +114,7 @@ export const buildLuceneQuery = filter => {
           return
         }
       }
-      if (type === "number" && !Array.isArray(value)) {
+      if (type === "number" && typeof value === "string") {
         if (operator === "oneOf") {
           value = value.split(",").map(item => parseFloat(item))
         } else if (!isHbs) {


### PR DESCRIPTION
## Description
When using the 'Is In' operator within conditional ui, you can no longer select primitive types as the comparison , e.g. number, date, etc. 
You can only select binding, which will either parse a comma separated string, or accept an array returned by a JS function binding. 

Addresses: 
- https://github.com/Budibase/budibase/issues/7296

## Screenshots
![Screenshot 2022-08-16 at 13 47 12](https://user-images.githubusercontent.com/101575380/184883112-59a821ee-3add-4809-8f62-be08ab9f33f0.png)

