### PR TITLE
fix sed apostrophe error and couchdb path

### DIFF
--- a/hosting/scripts/build-target-paths.sh
+++ b/hosting/scripts/build-target-paths.sh
@@ -11,6 +11,10 @@ if [[ "${TARGETBUILD}" = "aas" ]]; then
     apt-get install -y openssh-server
     sed -i "s/#Port 22/Port 2222/" /etc/ssh/sshd_config
     /etc/init.d/ssh restart
-fi
+    sed -i "s#DATA_DIR#/home#g" /opt/clouseau/clouseau.ini
+    sed -i "s#DATA_DIR#/home#g" /opt/couchdb/etc/local.ini
+else
+    sed -i "s#DATA_DIR#/data#g" /opt/clouseau/clouseau.ini
+    sed -i "s#DATA_DIR#/data#g" /opt/couchdb/etc/local.ini
 
-sed -i 's#DATA_DIR#$DATA_DIR#' /opt/clouseau/clouseau.ini /opt/couchdb/etc/local.ini
+fi

--- a/hosting/single/couch/local.ini
+++ b/hosting/single/couch/local.ini
@@ -1,5 +1,5 @@
 ; CouchDB Configuration Settings
 
 [couchdb]
-database_dir = DATA_DIR/couch/dbs
-view_index_dir = DATA_DIR/couch/views
+database_dir = DATA_DIR/couchdb/dbs
+view_index_dir = DATA_DIR/couchdb/views

--- a/hosting/single/healthcheck.sh
+++ b/hosting/single/healthcheck.sh
@@ -3,6 +3,11 @@ healthy=true
 
 if [ -f "/data/.env" ]; then
   export $(cat /data/.env | xargs)
+elif [ -f "/home/.env" ]; then
+  export $(cat /home/.env | xargs)
+else
+  echo "No .env file found"
+  healthy=false
 fi
 
 if [[ $(curl -Lfk -s -w "%{http_code}\n" http://localhost/ -o /dev/null) -ne 200 ]]; then


### PR DESCRIPTION
- sed wasn't expanding an env variable due to single apostrophe
- couch data path needed updated in local.ini
- add /home/.env to healthcheck for aas

I still have an issue when building. The app server is reporting:
```
ENOENT: no such file or directory, stat '/app/builder/index.html'
```
Possibly another unrelated build issue. But I will test again in a few days on the develop branch. 

