### PR TITLE
Allow list of named tables to be fetched

### DIFF
--- a/packages/builder/src/components/backend/DatasourceNavigator/TableIntegrationMenu/PlusConfigForm.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/TableIntegrationMenu/PlusConfigForm.svelte
@@ -8,6 +8,7 @@
     notifications,
     Modal,
     Table,
+    Toggle,
   } from "@budibase/bbui"
   import { datasources, integrations, tables } from "stores/backend"
   import CreateEditRelationship from "components/backend/Datasources/CreateEditRelationship.svelte"
@@ -15,6 +16,7 @@
   import ArrayRenderer from "components/common/renderers/ArrayRenderer.svelte"
   import ConfirmDialog from "components/common/ConfirmDialog.svelte"
   import { goto } from "@roxi/routify"
+  import ValuesList from "components/common/ValuesList.svelte"
 
   export let datasource
   export let save
@@ -31,6 +33,8 @@
   let createExternalTableModal
   let selectedFromRelationship, selectedToRelationship
   let confirmDialog
+  let specificTables = null
+  let requireSpecificTables = false
 
   $: integration = datasource && $integrations[datasource.source]
   $: plusTables = datasource?.plus
@@ -87,7 +91,7 @@
 
   async function updateDatasourceSchema() {
     try {
-      await datasources.updateSchema(datasource)
+      await datasources.updateSchema(datasource, specificTables)
       notifications.success(`Datasource ${name} tables updated successfully.`)
       await tables.fetch()
     } catch (error) {
@@ -150,6 +154,19 @@
   warning={false}
   title="Confirm table fetch"
 >
+  <Toggle
+    bind:value={requireSpecificTables}
+    on:change={e => {
+      requireSpecificTables = e.detail
+      specificTables = null
+    }}
+    thin
+    text="Fetch listed tables only (one per line)"
+  />
+  {#if requireSpecificTables}
+    <ValuesList label="" bind:values={specificTables} />
+  {/if}
+  <br />
   <Body>
     If you have fetched tables from this database before, this action may
     overwrite any changes you made after your initial fetch.

--- a/packages/builder/src/stores/backend/datasources.js
+++ b/packages/builder/src/stores/backend/datasources.js
@@ -62,8 +62,11 @@ export function createDatasourcesStore() {
     unselect: () => {
       update(state => ({ ...state, selected: null }))
     },
-    updateSchema: async datasource => {
-      const response = await API.buildDatasourceSchema(datasource?._id)
+    updateSchema: async (datasource, tablesFilter) => {
+      const response = await API.buildDatasourceSchema({
+        datasourceId: datasource?._id,
+        tablesFilter,
+      })
       return await updateDatasource(response)
     },
     save: async (body, fetchSchema = false) => {

--- a/packages/frontend-core/src/api/datasources.js
+++ b/packages/frontend-core/src/api/datasources.js
@@ -11,10 +11,14 @@ export const buildDatasourceEndpoints = API => ({
   /**
    * Prompts the server to build the schema for a datasource.
    * @param datasourceId the datasource ID to build the schema for
+   * @param tablesFilter list of specific table names to be build the schema
    */
-  buildDatasourceSchema: async datasourceId => {
+  buildDatasourceSchema: async ({ datasourceId, tablesFilter }) => {
     return await API.post({
       url: `/api/datasources/${datasourceId}/schema`,
+      body: {
+        tablesFilter,
+      },
     })
   },
 

--- a/packages/server/src/api/controllers/datasource.js
+++ b/packages/server/src/api/controllers/datasource.js
@@ -58,7 +58,9 @@ exports.buildSchemaFromDb = async function (ctx) {
       datasource.entities = {}
     }
     for (let key in tables) {
-      if (tablesFilter.includes(key)) {
+      if (
+        tablesFilter.some(filter => filter.toLowerCase() === key.toLowerCase())
+      ) {
         datasource.entities[key] = tables[key]
       }
     }
@@ -237,7 +239,7 @@ const buildSchemaHelper = async datasource => {
   await connector.buildSchema(datasource._id, datasource.entities)
 
   // make sure they all have a display name selected
-  for (let entity of Object.values(datasource.entities)) {
+  for (let entity of Object.values(datasource.entities ?? {})) {
     if (entity.primaryDisplay) {
       continue
     }

--- a/packages/server/src/api/controllers/datasource.js
+++ b/packages/server/src/api/controllers/datasource.js
@@ -50,9 +50,21 @@ exports.fetch = async function (ctx) {
 exports.buildSchemaFromDb = async function (ctx) {
   const db = getAppDB()
   const datasource = await db.get(ctx.params.datasourceId)
+  const tablesFilter = ctx.request.body.tablesFilter
 
-  const { tables, error } = await buildSchemaHelper(datasource)
-  datasource.entities = tables
+  let { tables, error } = await buildSchemaHelper(datasource)
+  if (tablesFilter) {
+    if (!datasource.entities) {
+      datasource.entities = {}
+    }
+    for (let key in tables) {
+      if (tablesFilter.includes(key)) {
+        datasource.entities[key] = tables[key]
+      }
+    }
+  } else {
+    datasource.entities = tables
+  }
 
   const dbResp = await db.put(datasource)
   datasource._rev = dbResp.rev
@@ -223,7 +235,6 @@ const buildSchemaHelper = async datasource => {
   // Connect to the DB and build the schema
   const connector = new Connector(datasource.config)
   await connector.buildSchema(datasource._id, datasource.entities)
-  datasource.entities = connector.tables
 
   // make sure they all have a display name selected
   for (let entity of Object.values(datasource.entities)) {


### PR DESCRIPTION
## Description
Formula columns were being cleared on fetch tables. By being able to specify the tables you want to fetch, you can now prevent that from happening. 
In other cases you may only want to pull a subset of your tables, although this could be solved with database level schemas and multiple datasources in Budibase.

Addresses: 
- https://github.com/Budibase/budibase/discussions/5539
- https://github.com/Budibase/budibase/issues/4651

## Screenshots
1. Fetch all tables.
2. Add a formula column to the **Owners** table.
3. Within postgres add new column to the **Appointments** table
<img width="471" alt="Screenshot 2022-08-17 at 18 24 30" src="https://user-images.githubusercontent.com/101575380/185203259-2ad46834-1d94-4814-bbf8-af4691ebccb7.png">

4. Fetch tables (Appointments, Pets, Vehicles, etc)
![Screenshot 2022-08-17 at 18 27 40](https://user-images.githubusercontent.com/101575380/185203813-7d117fd7-b904-429c-a332-c672011e2851.png)

5. See that **Appointments** has been updated
![Screenshot 2022-08-17 at 18 26 06](https://user-images.githubusercontent.com/101575380/185203552-ace23562-3aa1-4e01-9830-621137c7a885.png)

6. **Owners** has been preserved
![Screenshot 2022-08-17 at 18 26 30](https://user-images.githubusercontent.com/101575380/185203649-d796a96d-b95b-497a-aec4-fda6e9c88c61.png)

**Toggle is off by default**
![Screenshot 2022-08-17 at 18 27 03](https://user-images.githubusercontent.com/101575380/185203701-682af75e-6b5d-47b5-9d54-10df70372771.png)

