### PR TITLE
Add bindings for screen on load setting

### DIFF
--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -502,11 +502,11 @@ const getRoleBindings = () => {
 }
 
 /**
- * Gets all bindable properties exposed in a button action flow up until
+ * Gets all bindable properties exposed in an event action flow up until
  * the specified action ID, as well as context provided for the action
  * setting as a whole by the component.
  */
-export const getButtonContextBindings = (
+export const getEventContextBindings = (
   asset,
   componentId,
   settingKey,

--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -502,7 +502,7 @@ const getRoleBindings = () => {
 }
 
 /**
- * Gets all bindable properties exposed in a button actions flow up until
+ * Gets all bindable properties exposed in a button action flow up until
  * the specified action ID, as well as context provided for the action
  * setting as a whole by the component.
  */
@@ -520,10 +520,7 @@ export const getButtonContextBindings = (
   const component = findComponent(asset.props, componentId)
   const settings = getComponentSettings(component?._component)
   const eventSetting = settings.find(setting => setting.key === settingKey)
-  if (!eventSetting) {
-    return bindings
-  }
-  if (eventSetting.context?.length) {
+  if (eventSetting?.context?.length) {
     eventSetting.context.forEach(contextEntry => {
       bindings.push({
         readableBinding: contextEntry.label,

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionDrawer.svelte
@@ -11,7 +11,7 @@
   } from "@budibase/bbui"
   import { getAvailableActions } from "./index"
   import { generate } from "shortid"
-  import { getButtonContextBindings } from "builderStore/dataBinding"
+  import { getEventContextBindings } from "builderStore/dataBinding"
   import { currentAsset, store } from "builderStore"
 
   const flipDurationMs = 150
@@ -41,14 +41,14 @@
   }, {})
 
   // These are ephemeral bindings which only exist while executing actions
-  $: buttonContextBindings = getButtonContextBindings(
+  $: eventContexBindings = getEventContextBindings(
     $currentAsset,
     $store.selectedComponentId,
     key,
     actions,
     selectedAction?.id
   )
-  $: allBindings = buttonContextBindings.concat(bindings)
+  $: allBindings = eventContexBindings.concat(bindings)
 
   // Assign a unique ID to each action
   $: {


### PR DESCRIPTION
## Description
This PR fixes an issue preventing the "on load" setting for screens to generate data bindings for previous actions.

Addresses: 
- https://github.com/Budibase/budibase/issues/7338

## Screenshots
![image](https://user-images.githubusercontent.com/9075550/185377543-69fd8950-b090-4c0e-86d0-423d17793e96.png)


