### PR TITLE
Null safety for App Action no fields

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/FieldSelector.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/FieldSelector.svelte
@@ -14,7 +14,7 @@
   $: {
     let fields = {}
 
-    for (const [key, type] of Object.entries(block?.inputs?.fields)) {
+    for (const [key, type] of Object.entries(block?.inputs?.fields ?? {})) {
       fields = {
         ...fields,
         [key]: {

--- a/packages/server/src/automations/steps/queryRows.js
+++ b/packages/server/src/automations/steps/queryRows.js
@@ -125,6 +125,14 @@ const hasNullFilters = filters =>
 
 exports.run = async function ({ inputs, appId }) {
   const { tableId, filters, sortColumn, sortOrder, limit } = inputs
+  if (!tableId) {
+    return {
+      success: false,
+      response: {
+        message: "You must select a table to query.",
+      },
+    }
+  }
   const table = await getTable(appId, tableId)
   let sortType = FieldTypes.STRING
   if (table && table.schema && table.schema[sortColumn] && sortColumn) {


### PR DESCRIPTION
## Description
Fixed a crash when testing an automation with no app action fields provided.
Fixed a crash when no table was selected for query rows.

Addresses: 
- https://github.com/Budibase/budibase/issues/7360

## Screenshots
**No table selected**
![Screenshot 2022-08-19 at 15 02 42](https://user-images.githubusercontent.com/101575380/185635813-40a423cb-d1a1-41ca-a0b8-9a34aa357a93.png)

**Select table (no app action fields needed)**
![Screenshot 2022-08-19 at 15 03 14](https://user-images.githubusercontent.com/101575380/185635920-3eff28ab-f3eb-4c19-bbf5-4241a0e34e61.png)

