### PR TITLE
Import Users CSV Carriage Return Support #7398

### DIFF
--- a/packages/builder/src/pages/builder/portal/manage/users/_components/ImportUsersModal.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/users/_components/ImportUsersModal.svelte
@@ -62,7 +62,7 @@
       csvString = e.target.result
       files = fileArray
 
-      userEmails = csvString.split("\n")
+      userEmails = csvString.split(/\r?\n/)
     })
     reader.readAsText(fileArray[0])
   }


### PR DESCRIPTION
## Description
The ImportUsersModal takes in a CSV file expecting each line to have a valid email address. When this file is created in Microsoft Excel, Windows in general, or a text editor that uses the carriage return character `\r`, the import fails. This is because the CSV string is split into an email list by `csvString.split("\n")` which fails to account for `\r\n` newlines. This PR changes the split to be the regex `/\r?\n/` which will split on either `\n` or `\r\n`.

Addresses: 
- Issue #7398
- Discussion #7397