### PR TITLE
Add preview endpoint to prod nginx conf

### DIFF
--- a/hosting/nginx.prod.conf.hbs
+++ b/hosting/nginx.prod.conf.hbs
@@ -85,6 +85,10 @@ http {
       proxy_pass      http://$apps:4002;
     }
 
+    location /preview {
+      proxy_pass      http://$apps:4002;
+    }
+
     location = / {
       proxy_pass      http://$apps:4002;
     }
@@ -94,6 +98,7 @@ http {
       proxy_pass      http://$watchtower:8080;
     }
     {{/if}}
+
     location ~ ^/(builder|app_) {
       proxy_http_version  1.1;
       proxy_set_header    Connection          $connection_upgrade;


### PR DESCRIPTION
## Description
Forgot to add the new `/preview` endpoint for serving the builder preview to the prod nginx conf.

