### PR TITLE
Handle duplicate keys for query params - REST API

### DIFF
--- a/packages/builder/src/components/integration/KeyValueBuilder.svelte
+++ b/packages/builder/src/components/integration/KeyValueBuilder.svelte
@@ -33,6 +33,7 @@
   export let showMenu = false
   export let bindings = []
   export let bindingDrawerLeft
+  export let handleDuplicateKeys = false
 
   let fields = Object.entries(object || {}).map(([name, value]) => ({
     name,
@@ -40,10 +41,20 @@
   }))
   let fieldActivity = buildFieldActivity(activity)
 
-  $: object = fields.reduce(
-    (acc, next) => ({ ...acc, [next.name]: next.value }),
-    {}
-  )
+  $: {
+    object = fields.reduce(
+      (acc, next) => ({ ...acc, [next.name]: next.value }),
+      {}
+    )
+    if (handleDuplicateKeys) {
+      for (const key in object) {
+        const fieldValues = fields.filter(field => field.name === key)
+        if (fieldValues.length > 1) {
+          object[key] = fieldValues.map(field => field.value)
+        }
+      }
+    }
+  }
 
   function buildFieldActivity(obj) {
     if (!obj || typeof obj !== "object") {

--- a/packages/builder/src/components/integration/KeyValueBuilder.svelte
+++ b/packages/builder/src/components/integration/KeyValueBuilder.svelte
@@ -35,10 +35,32 @@
   export let bindingDrawerLeft
   export let handleDuplicateKeys = false
 
-  let fields = Object.entries(object || {}).map(([name, value]) => ({
-    name,
-    value,
-  }))
+  function initFields() {
+    if (handleDuplicateKeys) {
+      let objectFields = []
+      for (const key in object) {
+        if (Array.isArray(object[key])) {
+          for (const item of object[key]) {
+            objectFields.push({
+              name: key,
+              value: item,
+            })
+          }
+        } else {
+          objectFields.push({
+            name: key,
+            value: object[key],
+          })
+        }
+      }
+      return objectFields
+    }
+    return Object.entries(object || {}).map(([name, value]) => ({
+      name,
+      value,
+    }))
+  }
+  let fields = initFields()
   let fieldActivity = buildFieldActivity(activity)
 
   $: {

--- a/packages/builder/src/helpers/data/utils.js
+++ b/packages/builder/src/helpers/data/utils.js
@@ -31,7 +31,14 @@ export function breakQueryString(qs) {
   let paramObj = {}
   for (let param of params) {
     const split = param.split("=")
-    paramObj[split[0]] = split.slice(1).join("=")
+    if (!paramObj[split[0]]) {
+      paramObj[split[0]] = split.slice(1).join("=")
+    } else {
+      if (!Array.isArray(paramObj[split[0]])) {
+        paramObj[split[0]] = [paramObj[split[0]]]
+      }
+      paramObj[split[0]].push(split.slice(1).join("="))
+    }
   }
   return paramObj
 }

--- a/packages/builder/src/helpers/data/utils.js
+++ b/packages/builder/src/helpers/data/utils.js
@@ -46,7 +46,16 @@ export function buildQueryString(obj) {
       if (str !== "") {
         str += "&"
       }
-      str += `${key}=${value || ""}`
+      if (Array.isArray(value)) {
+        for (let i = 0; i < value.length; i++) {
+          str += `${key}=${value[i] || ""}`
+          if (i < value.length - 1) {
+            str += "&"
+          }
+        }
+      } else {
+        str += `${key}=${value || ""}`
+      }
     }
   }
   return str

--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/rest/[query]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/rest/[query]/index.svelte
@@ -460,6 +460,7 @@
               bind:object={breakQs}
               name="param"
               headings
+              handleDuplicateKeys
               bindings={mergedBindings}
               bindingDrawerLeft="260px"
             />


### PR DESCRIPTION
## Description
The REST query builder was using key/value pairs for query params. This isn't quite ideal because REST query params are not required to be unique. Duplicate query keys can be interpreted as array values by a server (see issue linked discussion).

A *handleDuplicateKeys* prop was added to the KeyValueBuilder so that if there is a duplicate key, rather than override the value it should instead aggregate the values in an array.  

Addresses: 
- https://github.com/Budibase/budibase/issues/4844

## Screenshots
![Screenshot 2022-08-23 at 14 36 21](https://user-images.githubusercontent.com/101575380/186172305-111ca6f9-49ed-4322-97f6-2db13de75875.png)



