### PR TITLE
Mongodb objectid relationship

### DIFF
--- a/packages/server/src/integrations/mongodb.ts
+++ b/packages/server/src/integrations/mongodb.ts
@@ -92,10 +92,8 @@ module MongoDBModule {
           if (json[field] instanceof Object) {
             json[field] = self.createObjectIds(json[field])
           }
-          if (
-            (field === "_id" || field?.startsWith("$")) &&
-            typeof json[field] === "string"
-          ) {
+          if (typeof json[field] === "string" && json[field].toLowerCase().startsWith("objectid"))
+          {
             const id = json[field].match(
               /(?<=objectid\(['"]).*(?=['"]\))/gi
             )?.[0]

--- a/packages/server/src/integrations/mongodb.ts
+++ b/packages/server/src/integrations/mongodb.ts
@@ -92,8 +92,10 @@ module MongoDBModule {
           if (json[field] instanceof Object) {
             json[field] = self.createObjectIds(json[field])
           }
-          if (typeof json[field] === "string" && json[field].toLowerCase().startsWith("objectid"))
-          {
+          if (
+            typeof json[field] === "string" &&
+            json[field].toLowerCase().startsWith("objectid")
+          ) {
             const id = json[field].match(
               /(?<=objectid\(['"]).*(?=['"]\))/gi
             )?.[0]

--- a/packages/server/src/integrations/tests/mongo.spec.js
+++ b/packages/server/src/integrations/tests/mongo.spec.js
@@ -103,16 +103,16 @@ describe("MongoDB Integration", () => {
     restore()
   })
 
-  it("creates ObjectIds if the _id fields contains a match on ObjectId", async () => {
+  it("creates ObjectIds if the field contains a match on ObjectId", async () => {
     const query = {
       json: {
         filter: {
           _id: "ObjectId('ACBD12345678ABCD12345678')",
-          name: "ObjectId('name')"
+          name: "ObjectId('BBBB12345678ABCD12345678')"
         },
         update: {
           _id: "ObjectId('FFFF12345678ABCD12345678')",
-          name: "ObjectId('updatedName')",
+          name: "ObjectId('CCCC12345678ABCD12345678')",
         },
         options: {
           upsert: false,
@@ -126,11 +126,11 @@ describe("MongoDB Integration", () => {
     const args = config.integration.client.updateOne.mock.calls[0]
     expect(args[0]).toEqual({
       _id: mongo.ObjectID.createFromHexString("ACBD12345678ABCD12345678"),
-      name: "ObjectId('name')",
+      name: mongo.ObjectID.createFromHexString("BBBB12345678ABCD12345678"),
     })
     expect(args[1]).toEqual({
       _id: mongo.ObjectID.createFromHexString("FFFF12345678ABCD12345678"),
-      name: "ObjectId('updatedName')",
+      name: mongo.ObjectID.createFromHexString("CCCC12345678ABCD12345678"),
     })
     expect(args[2]).toEqual({
       upsert: false


### PR DESCRIPTION
## Description
The objectid parsing/casting was too specific.
Using *startsWith* "objectid" to handle all cases of ObjectId including relationship fields.

Addresses: 
- https://github.com/Budibase/budibase/discussions/7375



