### PR TITLE
fixing s3 outage errors and scoping AWS configuration to service level

### DIFF
--- a/packages/backend-core/src/objectStore/index.ts
+++ b/packages/backend-core/src/objectStore/index.ts
@@ -66,15 +66,13 @@ const PUBLIC_BUCKETS = [ObjectStoreBuckets.APPS, ObjectStoreBuckets.GLOBAL]
  * @constructor
  */
 export const ObjectStore = (bucket: any) => {
-  AWS.config.update({
-    accessKeyId: env.MINIO_ACCESS_KEY,
-    secretAccessKey: env.MINIO_SECRET_KEY,
-    region: env.AWS_REGION,
-  })
   const config: any = {
     s3ForcePathStyle: true,
     signatureVersion: "v4",
     apiVersion: "2006-03-01",
+    accessKeyId: env.MINIO_ACCESS_KEY,
+    secretAccessKey: env.MINIO_SECRET_KEY,
+    region: env.AWS_REGION,
   }
   if (bucket) {
     config.params = {

--- a/packages/server/src/db/dynamoClient.js
+++ b/packages/server/src/db/dynamoClient.js
@@ -103,11 +103,9 @@ class Table {
 
 exports.init = endpoint => {
   let AWS = require("aws-sdk")
-  AWS.config.update({
-    region: AWS_REGION,
-  })
   let docClientParams = {
     correctClockSkew: true,
+    region: AWS_REGION,
   }
   if (endpoint) {
     docClientParams.endpoint = endpoint

--- a/packages/server/src/integrations/tests/dynamodb.spec.js
+++ b/packages/server/src/integrations/tests/dynamodb.spec.js
@@ -100,4 +100,52 @@ describe("DynamoDB Integration", () => {
       Name: "John"
     })
   })
+
+  it("configures the dynamoDB constructor based on an empty endpoint parameter", async () => {
+    const config = {
+      region: "us-east-1",
+      accessKeyId: "test",
+      secretAccessKeyId: "test"
+    }
+
+    const integration = new DynamoDBIntegration.integration(config)
+
+    expect(integration.config).toEqual({
+      currentClockSkew: true,
+      ...config
+    })
+  })
+
+  it("configures the dynamoDB constructor based on a localhost endpoint parameter", async () => {
+    const config = {
+      region: "us-east-1",
+      accessKeyId: "test",
+      secretAccessKeyId: "test",
+      endpoint: "localhost:8080"
+    }
+
+    const integration = new DynamoDBIntegration.integration(config)
+
+    expect(integration.config).toEqual({
+      region: "us-east-1",
+      currentClockSkew: true,
+      endpoint: "localhost:8080"
+    })
+  })
+
+  it("configures the dynamoDB constructor based on a remote endpoint parameter", async () => {
+    const config = {
+      region: "us-east-1",
+      accessKeyId: "test",
+      secretAccessKeyId: "test",
+      endpoint: "dynamodb.aws.foo.net"
+    }
+
+    const integration = new DynamoDBIntegration.integration(config)
+
+    expect(integration.config).toEqual({
+      currentClockSkew: true,
+      ...config
+    })
+  })
 })


### PR DESCRIPTION
## Description
Prevent global configuration of AWS to avoid config leaking between services. This was the root cause of our S3 woes and it was being caused by work performed in the dynamo constructor. This PR updates all AWS configuration to be scoped only to the service that uses it. Tested locally with a docker dynamo and all seems well, but could do with more rigorous testing in our cloud envs before deployment.


Addresses: 
- https://github.com/Budibase/budibase/issues/7410
- https://github.com/Budibase/budibase/discussions/7409

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._



