### PR TITLE
Smoke build Test Changes

### DIFF
--- a/packages/builder/cypress/integration/appPublishWorkflow.spec.js
+++ b/packages/builder/cypress/integration/appPublishWorkflow.spec.js
@@ -102,7 +102,7 @@ filterTests(['all'], () => {
 
       cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 6000 })
       cy.wait(500)
-      cy.get(interact.APP_TABLE_STATUS, { timeout: 1000 }).eq(0).contains("Unpublished")
+      cy.get(interact.APP_TABLE_STATUS, { timeout: 10000 }).eq(0).contains("Unpublished")
 
     })
   })

--- a/packages/builder/cypress/integration/datasources/mySql.spec.js
+++ b/packages/builder/cypress/integration/datasources/mySql.spec.js
@@ -175,7 +175,10 @@ filterTests(["all"], () => {
         cy.get("@query").its("response.statusCode").should("eq", 200)
         cy.get("@query").its("response.body").should("not.be.empty")
         // Save query
+        cy.intercept("POST", "**/queries").as("saveQuery")
         cy.get(".spectrum-Button").contains("Save Query").click({ force: true })
+        cy.wait("@saveQuery")
+        cy.get("@saveQuery").its("response.statusCode").should("eq", 200)
         cy.get(".nav-item").should("contain", queryName)
       })
 

--- a/packages/builder/cypress/integration/datasources/postgreSql.spec.js
+++ b/packages/builder/cypress/integration/datasources/postgreSql.spec.js
@@ -252,7 +252,8 @@ filterTests(["all"], () => {
           .contains("Delete Query")
           .click({ force: true })
         // Confirm deletion
-        cy.reload({ timeout: 5000 })
+        cy.reload()
+        cy.get(".nav-item", { timeout: 30000 }).contains(datasource).click({ force: true })
         cy.get(".nav-item", { timeout: 1000 }).should("not.contain", queryRename)
       })
 

--- a/packages/builder/cypress/integration/revertApp.spec.js
+++ b/packages/builder/cypress/integration/revertApp.spec.js
@@ -48,6 +48,7 @@ filterTests(['smoke', 'all'], () => {
                 cy.get(interact.AREA_LABEL_REVERT).click({ force: true })
             })
             cy.get(interact.SPECTRUM_DIALOG_GRID).within(() => {
+                cy.get("input").type("Cypress Tests")
                 // Click Revert
                 cy.get(interact.SPECTRUM_BUTTON).contains("Revert").click({ force: true })
                 cy.wait(2000) // Wait for app to finish reverting

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -448,10 +448,7 @@ Cypress.Commands.add("createTable", (tableName, initialTable) => {
         .contains("Continue")
         .click({ force: true })
     })
-  cy.get(".spectrum-Modal", { timeout: 10000 }).should(
-    "not.contain",
-    "Add data source"
-  )
+  cy.get(".spectrum-Modal").contains("Create Table", { timeout: 10000 })
   cy.get(".spectrum-Modal", { timeout: 2000 }).within(() => {
     cy.get("input", { timeout: 2000 }).first().type(tableName).blur()
     cy.get(".spectrum-ButtonGroup").contains("Create").click()
@@ -742,8 +739,15 @@ Cypress.Commands.add("deleteAllScreens", () => {
 Cypress.Commands.add("navigateToFrontend", () => {
   // Clicks on Design tab and then the Home nav item
   cy.wait(500)
+  cy.intercept("**/preview").as("preview")
   cy.contains("Design").click()
-  cy.get(".spectrum-Search", { timeout: 2000 }).type("/")
+  cy.wait("@preview")
+  cy.get("@preview").then(res => {
+    if (res.statusCode != 200) {
+      cy.reload()
+    }
+  })
+  cy.get(".spectrum-Search", { timeout: 20000 }).type("/")
   cy.get(".nav-item", { timeout: 2000 }).contains("home").click({ force: true })
 })
 


### PR DESCRIPTION
Update createTable test command
createTable command
- Changing how a check is completed when dealing with the create table modals

appPublishWorkflow
- Increasing timeout value related to the app table status
- This increased timeout value is needed specifically for CI runs

MySQL
- Timing issue for the smoke build
- Including an intercept after saving a query and then confirming it exists. Sometimes Cypress tries to find the query within the nav item section before the query has finished

PostgreSQL
- Timing issue for the smoke build
- Sometimes Cypress will continue the test before the page has finished reloading. Increased timeout value here to ensure the page loads. Also ensuring the entire nav item section is visible

## Description
_Describe the problem or feature in addition to a link to the relevant github issues._

Addresses: 
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._



