### PR TITLE
removing a basic warning so it doesn't add to the others that will su…

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,7 +4,7 @@
   "singleQuote": false,
   "trailingComma": "es5",
   "arrowParens": "avoid",
-  "jsxBracketSameLine": false,
+  "bracketSameLine": false,
   "plugins": ["prettier-plugin-svelte"],
   "svelteSortOrder": "options-scripts-markup-styles"
 }


### PR DESCRIPTION
…rely come.

## Description
When writing a commit for something else, I noticed a largely innocuous warning. I removed the warning to prevent more bloat at the commit stage. There are other ones later in the toolchain that I or someone else will likely work through. Thanks for taking a look at something super basic. 

Addresses: 
You will see it is too basic to warrant an issue. I don't want to give you more work.

## Screenshots

<img width="353" alt="image" src="https://user-images.githubusercontent.com/2353608/187131938-6fd1338b-8133-441b-8799-78ae914ee2ce.png">




