### PR TITLE
Automation list sort alphabetically by name #7565

### DIFF
--- a/packages/builder/src/components/automation/AutomationPanel/AutomationList.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationList.svelte
@@ -5,7 +5,6 @@
   import NavItem from "components/common/NavItem.svelte"
   import EditAutomationPopover from "./EditAutomationPopover.svelte"
   import { notifications } from "@budibase/bbui"
-  import _ from "lodash"
 
   $: selectedAutomationId = $automationStore.selectedAutomation?.automation?._id
 
@@ -24,7 +23,7 @@
 </script>
 
 <div class="automations-list">
-  {#each _.orderBy($automationStore.automations, ["name"], ["asc"]) as automation, idx}
+  {#each $automationStore.automations.sort(aut => aut.name) as automation, idx}
     <NavItem
       border={idx > 0}
       icon="ShareAndroid"

--- a/packages/builder/src/components/automation/AutomationPanel/AutomationList.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationList.svelte
@@ -23,7 +23,7 @@
 </script>
 
 <div class="automations-list">
-  {#each $automationStore.automations as automation, idx}
+  {#each _.orderBy($automationStore.automations, ['name'], ['asc']) as automation, idx}
     <NavItem
       border={idx > 0}
       icon="ShareAndroid"

--- a/packages/builder/src/components/automation/AutomationPanel/AutomationList.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationList.svelte
@@ -5,6 +5,7 @@
   import NavItem from "components/common/NavItem.svelte"
   import EditAutomationPopover from "./EditAutomationPopover.svelte"
   import { notifications } from "@budibase/bbui"
+  import _ from 'lodash'
 
   $: selectedAutomationId = $automationStore.selectedAutomation?.automation?._id
 

--- a/packages/builder/src/components/automation/AutomationPanel/AutomationList.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationList.svelte
@@ -5,7 +5,7 @@
   import NavItem from "components/common/NavItem.svelte"
   import EditAutomationPopover from "./EditAutomationPopover.svelte"
   import { notifications } from "@budibase/bbui"
-  import _ from 'lodash'
+  import _ from "lodash"
 
   $: selectedAutomationId = $automationStore.selectedAutomation?.automation?._id
 
@@ -24,7 +24,7 @@
 </script>
 
 <div class="automations-list">
-  {#each _.orderBy($automationStore.automations, ['name'], ['asc']) as automation, idx}
+  {#each _.orderBy($automationStore.automations, ["name"], ["asc"]) as automation, idx}
     <NavItem
       border={idx > 0}
       icon="ShareAndroid"


### PR DESCRIPTION
This PR addresses issue #7565 (mine). Automations are currently sorted by internal ID and not by name, which makes it slightly harder to find an automation from a user's point of view.

## Description
The Automation list in the BB builder was sorted by an internal ID instead of the Automation name, making it confusing for users with many Automations. This PR changes the `each` loop to work off the `$automationStore.automations` list, but sorted by `name`, ascending.

Addresses: 
- #7565

## Screenshots
Old:
![image](https://user-images.githubusercontent.com/34921506/187891045-4e1a7a2c-7c25-4dfd-8657-7d0bc65cce5c.png)

New:
![image](https://user-images.githubusercontent.com/34921506/187891577-eadeb862-4119-498b-937f-6994d5dca3af.png)



