### PR TITLE
improvements to redis connector - multi line pipelines and lowercase …

### DIFF
--- a/packages/server/src/integrations/redis.ts
+++ b/packages/server/src/integrations/redis.ts
@@ -132,12 +132,22 @@ module RedisModule {
 
     async command(query: { json: string }) {
       return this.redisContext(async () => {
-        const commands = query.json.trim().split(" ")
-        const pipeline = this.client.pipeline([commands])
-        const result = await pipeline.exec()
-        return {
-          response: result[0][1],
+        // commands split line by line
+        const commands = query.json.trim().split("\n")
+        let pipelineCommands = []
+
+        // process each command separately
+        for (let command of commands) {
+          const tokenised = command.trim().split(" ")
+          // Pipeline only accepts lower case commands
+          tokenised[0] = tokenised[0].toLowerCase()
+          pipelineCommands.push(tokenised)
         }
+
+        const pipeline = this.client.pipeline(pipelineCommands)
+        const result = await pipeline.exec()
+
+        return result.map((output: string | string[]) => output[1])
       })
     }
   }


### PR DESCRIPTION
…commands

## Description
Some improvements to the redis connector off the back of some feedback from @melohagan - the `pipeline` method doesn't actually support upper case redis methods, which tend to be the default. 

- Improved the redis connector pipeline method to lowercase commands, and to accept multi line commands to execute several commands against redis
- Test to cover new mapping code
- Return the results of every command in the pipeline in an array, not just the one

Addresses: 
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._



