### PR TITLE
Configurable api rate limit through nginx

### DIFF
--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -78,6 +78,7 @@ services:
     image: budibase/proxy
     environment:
       - PROXY_RATE_LIMIT_WEBHOOKS_PER_SECOND=10
+      - PROXY_RATE_LIMIT_API_PER_SECOND=20
     depends_on:
       - minio-service
       - worker-service

--- a/hosting/nginx.prod.conf.hbs
+++ b/hosting/nginx.prod.conf.hbs
@@ -11,7 +11,7 @@ events {
 http {
   # rate limiting
   limit_req_status 429;
-  limit_req_zone $binary_remote_addr zone=ratelimit:10m rate=20r/s;
+  limit_req_zone $binary_remote_addr zone=ratelimit:10m rate=${PROXY_RATE_LIMIT_API_PER_SECOND}r/s;
   limit_req_zone $binary_remote_addr zone=webhooks:10m rate=${PROXY_RATE_LIMIT_WEBHOOKS_PER_SECOND}r/s;
 
   include       /etc/nginx/mime.types;

--- a/hosting/proxy/Dockerfile
+++ b/hosting/proxy/Dockerfile
@@ -11,3 +11,4 @@ COPY error.html /usr/share/nginx/html/error.html
 
 # Default environment
 ENV PROXY_RATE_LIMIT_WEBHOOKS_PER_SECOND=10
+ENV PROXY_RATE_LIMIT_API_PER_SECOND=20


### PR DESCRIPTION
## Description
Currently there is a flag for controlling the public api rate limit `API_REQ_LIMIT_PER_SEC`. However this is superseded by the NGINX configuration for the `/api` route which covers the `/api/public/xxx` location for public api endpoints. 

Add configuration similar to how webhook rate limiting to allow this to be configured at runtime via environment variables. 

Addresses: 
https://github.com/Budibase/budibase/issues/7608




