### PR TITLE
Fixing backend-core build, as raised in.

### DIFF
--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -60,7 +60,7 @@
     ]
   },
   "devDependencies": {
-    "@shopify/jest-koa-mocks": "^5.0.1",
+    "@shopify/jest-koa-mocks": "5.0.1",
     "@types/jest": "27.5.1",
     "@types/koa": "2.0.52",
     "@types/lodash": "4.14.180",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -60,7 +60,7 @@
     ]
   },
   "devDependencies": {
-    "@shopify/jest-koa-mocks": "3.1.5",
+    "@shopify/jest-koa-mocks": "^5.0.1",
     "@types/jest": "27.5.1",
     "@types/koa": "2.0.52",
     "@types/lodash": "4.14.180",

--- a/packages/backend-core/tsconfig.build.json
+++ b/packages/backend-core/tsconfig.build.json
@@ -20,6 +20,8 @@
     "package.json"
   ],
   "exclude": [
+    "scripts",
+    "tests",
     "node_modules",
     "dist",
     "**/*.spec.ts",


### PR DESCRIPTION
## Description
Two part issue, a dependency was not included as required in the backend-core and also the typescript build for the worker was including scripts and tests, which should not be used outside of development and therefore do not need to built.

Addresses: 
-  #7603