### PR TITLE
Clear quota cache on deprovision + gracefully handle account metadata deletion

### DIFF
--- a/packages/worker/src/api/controllers/system/tenants.js
+++ b/packages/worker/src/api/controllers/system/tenants.js
@@ -1,6 +1,7 @@
 const { StaticDatabases, doWithDB } = require("@budibase/backend-core/db")
 const { getTenantId } = require("@budibase/backend-core/tenancy")
 const { deleteTenant } = require("@budibase/backend-core/deprovision")
+const { quotas } = require("@budibase/pro")
 
 exports.exists = async ctx => {
   const tenantId = ctx.request.params
@@ -48,6 +49,7 @@ exports.delete = async ctx => {
 
   try {
     await deleteTenant(tenantId)
+    await quotas.bustCache()
     ctx.status = 204
   } catch (err) {
     ctx.log.error(err)

--- a/packages/worker/src/api/routes/system/tests/accounts.spec.ts
+++ b/packages/worker/src/api/routes/system/tests/accounts.spec.ts
@@ -47,10 +47,7 @@ describe("accounts", () => {
 
         const response = await api.accounts.destroyMetadata(id)
 
-        expect(response.status).toBe(404)
-        expect(response.body.message).toBe(
-          `id=${accounts.formatAccountMetadataId(id)} does not exist`
-        )
+        expect(response.status).toBe(204)
       })
     })
   })

--- a/packages/worker/src/sdk/accounts/accounts.ts
+++ b/packages/worker/src/sdk/accounts/accounts.ts
@@ -46,8 +46,14 @@ export const destroyMetadata = async (accountId: string) => {
   await db.doWithDB(StaticDatabases.PLATFORM_INFO.name, async (db: any) => {
     const metadata = await getMetadata(accountId)
     if (!metadata) {
-      throw new HTTPError(`id=${accountId} does not exist`, 404)
+      return
     }
-    await db.remove(accountId, metadata._rev)
+    try {
+      await db.remove(accountId, metadata._rev)
+    } catch (e: any) {
+      if (e.status !== 404) {
+        throw e
+      }
+    }
   })
 }


### PR DESCRIPTION
## Description
Reliant on https://github.com/Budibase/budibase-pro/pull/49
> Currently the quota cache exists with a TTL of -1 meaning it will never expire. Adding the ability to clear the cache so that it may be used during deprovisioning

Also add more graceful handling to the deletion of account metadata docs

