### PR TITLE
Exclude test utils from server and worker builds

### DIFF
--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@budibase/types": "^1.3.10",
+    "@shopify/jest-koa-mocks": "5.0.1",
     "@techpass/passport-openidconnect": "0.3.2",
     "aws-sdk": "2.1030.0",
     "bcrypt": "5.0.1",
@@ -60,7 +61,6 @@
     ]
   },
   "devDependencies": {
-    "@shopify/jest-koa-mocks": "5.0.1",
     "@types/jest": "27.5.1",
     "@types/koa": "2.0.52",
     "@types/lodash": "4.14.180",

--- a/packages/backend-core/tsconfig.build.json
+++ b/packages/backend-core/tsconfig.build.json
@@ -20,8 +20,6 @@
     "package.json"
   ],
   "exclude": [
-    "scripts",
-    "tests",
     "node_modules",
     "dist",
     "**/*.spec.ts",

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -19,6 +19,7 @@
   "exclude": [
     "node_modules",
     "dist",
+    "src/tests",
     "**/*.spec.ts",
     "**/*.spec.js"
   ]

--- a/packages/worker/tsconfig.build.json
+++ b/packages/worker/tsconfig.build.json
@@ -19,6 +19,7 @@
   "exclude": [
     "node_modules",
     "dist",
+    "src/tests",
     "**/*.spec.ts",
     "**/*.spec.js"
   ]


### PR DESCRIPTION
## Description
- Exclude `src/tests` from the server and worker builds
- Revert the backend-core `/tests` exclusion, which is required to be in the output artifact by account-portal 
- Add the required dev dependency so it doesn't need to be re-declared by account-portal 

Addresses: 
- https://github.com/Budibase/budibase/issues/7603




