### PR TITLE
Update preview endpoint

### DIFF
--- a/hosting/nginx.dev.conf.hbs
+++ b/hosting/nginx.dev.conf.hbs
@@ -65,10 +65,6 @@ http {
       proxy_pass      http://{{ address }}:4001;
     }
 
-    location /preview {
-      proxy_pass      http://{{ address }}:4001;
-    }
-
     location /builder {
       proxy_pass      http://{{ address }}:3000;
       rewrite ^/builder(.*)$ /builder/$1 break;

--- a/hosting/nginx.prod.conf.hbs
+++ b/hosting/nginx.prod.conf.hbs
@@ -88,10 +88,6 @@ http {
       proxy_pass      http://$apps:4002;
     }
 
-    location /preview {
-      proxy_pass      http://$apps:4002;
-    }
-
     location = / {
       proxy_pass      http://$apps:4002;
     }

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPreview.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPreview.svelte
@@ -290,7 +290,7 @@
   <iframe
     title="componentPreview"
     bind:this={iframe}
-    src="/preview"
+    src="/app/preview"
     class:hidden={loading || error}
     class:tablet={$store.previewDevice === "tablet"}
     class:mobile={$store.previewDevice === "mobile"}

--- a/packages/server/src/api/routes/static.ts
+++ b/packages/server/src/api/routes/static.ts
@@ -56,7 +56,7 @@ router
     authorized(PermissionTypes.TABLE, PermissionLevels.WRITE),
     controller.deleteObjects
   )
-  .get("/preview", authorized(BUILDER), controller.serveBuilderPreview)
+  .get("/app/preview", authorized(BUILDER), controller.serveBuilderPreview)
   .get("/:appId/:path*", controller.serveApp)
   .get("/app/:appUrl/:path*", controller.serveApp)
   .post(

--- a/packages/server/src/api/routes/tests/static.spec.js
+++ b/packages/server/src/api/routes/tests/static.spec.js
@@ -150,14 +150,14 @@ describe("/static", () => {
     })
   })
 
-  describe("/preview", () => {
+  describe("/app/preview", () => {
     beforeEach(() => {
       jest.clearAllMocks()
     })
 
     it("should serve the builder preview", async () => {
       const headers = config.defaultHeaders()
-      const res = await request.get(`/preview`).set(headers).expect(200)
+      const res = await request.get(`/app/preview`).set(headers).expect(200)
 
       expect(res.body.appId).toBe(config.appId)
       expect(res.body.builderPreview).toBe(true)


### PR DESCRIPTION
## Description
This PR updates the preview endpoint to be prefixed with `/app` so that it works with older nginx configs.

