### PR TITLE
Oracle + datasource Wizard Test skips

### DIFF
--- a/packages/builder/cypress/integration/datasources/datasourceWizard.spec.js
+++ b/packages/builder/cypress/integration/datasources/datasourceWizard.spec.js
@@ -1,7 +1,7 @@
 import filterTests from "../../support/filterTests"
 
 filterTests(['all'], () => {
-  context("Datasource Wizard", () => {
+  xcontext("Datasource Wizard", () => {
     if (Cypress.env("TEST_ENV")) {
       before(() => {
         cy.login()

--- a/packages/builder/cypress/integration/datasources/oracle.spec.js
+++ b/packages/builder/cypress/integration/datasources/oracle.spec.js
@@ -1,7 +1,7 @@
 import filterTests from "../../support/filterTests"
 
 filterTests(["all"], () => {
-  context("Oracle Datasource Testing", () => {
+  xcontext("Oracle Datasource Testing", () => {
     if (Cypress.env("TEST_ENV")) {
       before(() => {
         cy.login()


### PR DESCRIPTION
Skipping tests for Oracle & datasourceWizard

Both are covered during general regressions
There are timing issues associated with the CI Smoke run This will help reduce the smoke build run time
The oracle test file was only covering a basic check of invalid configuration (Not essential for the smoke run)