### PR TITLE
Fix/sept various fixes

### DIFF
--- a/packages/backend-core/src/db/Replication.ts
+++ b/packages/backend-core/src/db/Replication.ts
@@ -1,4 +1,5 @@
 import { dangerousGetDB, closeDB } from "."
+import { DocumentType } from "./constants"
 
 class Replication {
   source: any
@@ -53,6 +54,14 @@ class Replication {
     return this.replication
   }
 
+  appReplicateOpts() {
+    return {
+      filter: (doc: any) => {
+        return doc._id !== DocumentType.APP_METADATA
+      },
+    }
+  }
+
   /**
    * Rollback the target DB back to the state of the source DB
    */
@@ -60,6 +69,7 @@ class Replication {
     await this.target.destroy()
     // Recreate the DB again
     this.target = dangerousGetDB(this.target.name)
+    // take the opportunity to remove deleted tombstones
     await this.replicate()
   }
 

--- a/packages/backend-core/src/db/utils.ts
+++ b/packages/backend-core/src/db/utils.ts
@@ -254,7 +254,16 @@ export async function getAllApps({ dev, all, idsOnly, efficient }: any = {}) {
     return false
   })
   if (idsOnly) {
-    return appDbNames
+    const devAppIds = appDbNames.filter(appId => isDevAppID(appId))
+    const prodAppIds = appDbNames.filter(appId => !isDevAppID(appId))
+    switch (dev) {
+      case true:
+        return devAppIds
+      case false:
+        return prodAppIds
+      default:
+        return appDbNames
+    }
   }
   const appPromises = appDbNames.map((app: any) =>
     // skip setup otherwise databases could be re-created

--- a/packages/bbui/src/Tabs/Tabs.svelte
+++ b/packages/bbui/src/Tabs/Tabs.svelte
@@ -10,6 +10,7 @@
   export let noHorizPadding = false
   export let quiet = false
   export let emphasized = false
+  export let onTop = false
   export let size = "M"
 
   let thisSelected = undefined
@@ -75,6 +76,7 @@
   bind:this={container}
   class:spectrum-Tabs--quiet={quiet}
   class:noHorizPadding
+  class:onTop
   class:spectrum-Tabs--vertical={vertical}
   class:spectrum-Tabs--horizontal={!vertical}
   class="spectrum-Tabs spectrum-Tabs--size{size}"
@@ -121,5 +123,8 @@
   }
   .noPadding {
     margin: 0;
+  }
+  .onTop {
+    z-index: 100;
   }
 </style>

--- a/packages/builder/src/components/automation/SetupPanel/CronBuilder.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/CronBuilder.svelte
@@ -1,6 +1,7 @@
 <script>
   import { Button, Select, Input, Label } from "@budibase/bbui"
-  import { createEventDispatcher } from "svelte"
+  import { onMount, createEventDispatcher } from "svelte"
+  import { flags } from "stores/backend"
   const dispatch = createEventDispatcher()
 
   export let value
@@ -29,11 +30,16 @@
       label: "Every Night at Midnight",
       value: "0 0 * * *",
     },
-    {
-      label: "Every Budibase Reboot",
-      value: "@reboot",
-    },
   ]
+
+  onMount(() => {
+    if (!$flags.cloud) {
+      CRON_EXPRESSIONS.push({
+        label: "Every Budibase Reboot",
+        value: "@reboot",
+      })
+    }
+  })
 </script>
 
 <div class="block-field">

--- a/packages/builder/src/components/common/bindings/DrawerBindableInput.svelte
+++ b/packages/builder/src/components/common/bindings/DrawerBindableInput.svelte
@@ -23,6 +23,7 @@
   const dispatch = createEventDispatcher()
   let bindingDrawer
   let valid = true
+  let currentVal = value
 
   $: readableValue = runtimeToReadableBinding(bindings, value)
   $: tempValue = readableValue
@@ -30,11 +31,17 @@
 
   const saveBinding = () => {
     onChange(tempValue)
+    onBlur()
     bindingDrawer.hide()
   }
 
   const onChange = value => {
-    dispatch("change", readableToRuntimeBinding(bindings, value))
+    currentVal = readableToRuntimeBinding(bindings, value)
+    dispatch("change", currentVal)
+  }
+
+  const onBlur = () => {
+    dispatch("blur", currentVal)
   }
 </script>
 
@@ -45,6 +52,7 @@
     readonly={isJS}
     value={isJS ? "(JavaScript function)" : readableValue}
     on:change={event => onChange(event.detail)}
+    on:blur={onBlur}
     {placeholder}
     {updateOnChange}
   />

--- a/packages/builder/src/components/integration/KeyValueBuilder.svelte
+++ b/packages/builder/src/components/integration/KeyValueBuilder.svelte
@@ -107,7 +107,7 @@
         placeholder={keyPlaceholder}
         readonly={readOnly}
         bind:value={field.name}
-        on:change={changed}
+        on:blur={changed}
       />
       {#if options}
         <Select bind:value={field.value} on:change={changed} {options} />
@@ -115,7 +115,10 @@
         <DrawerBindableInput
           {bindings}
           placeholder="Value"
-          on:change={e => (field.value = e.detail)}
+          on:blur={e => {
+            field.value = e.detail
+            changed()
+          }}
           disabled={readOnly}
           value={field.value}
           allowJS={false}
@@ -127,7 +130,7 @@
           placeholder={valuePlaceholder}
           readonly={readOnly}
           bind:value={field.value}
-          on:change={changed}
+          on:blur={changed}
         />
       {/if}
       {#if toggle}

--- a/packages/builder/src/components/start/ExportAppModal.svelte
+++ b/packages/builder/src/components/start/ExportAppModal.svelte
@@ -1,16 +1,24 @@
 <script>
-  import { ModalContent, Toggle } from "@budibase/bbui"
+  import { ModalContent, Toggle, Body } from "@budibase/bbui"
 
   export let app
+  export let published
   let excludeRows = false
 
+  $: title = published ? "Export published app" : "Export latest app"
+  $: confirmText = published ? "Export published" : "Export latest"
+
   const exportApp = () => {
-    const id = app.deployed ? app.prodId : app.devId
+    const id = published ? app.prodId : app.devId
     const appName = encodeURIComponent(app.name)
     window.location = `/api/backups/export?appId=${id}&appname=${appName}&excludeRows=${excludeRows}`
   }
 </script>
 
-<ModalContent title={"Export"} confirmText={"Export"} onConfirm={exportApp}>
+<ModalContent {title} {confirmText} onConfirm={exportApp}>
+  <Body
+    >Apps can be exported with or without data that is within internal tables -
+    select this below.</Body
+  >
   <Toggle text="Exclude Rows" bind:value={excludeRows} />
 </ModalContent>

--- a/packages/builder/src/helpers/data/utils.js
+++ b/packages/builder/src/helpers/data/utils.js
@@ -46,7 +46,7 @@ export function buildQueryString(obj) {
       if (str !== "") {
         str += "&"
       }
-      str += `${key}=${value || ""}`
+      str += `${key}=${encodeURIComponent(value || "")}`
     }
   }
   return str

--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/rest/[query]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/rest/[query]/index.svelte
@@ -28,25 +28,25 @@
   import { onMount } from "svelte"
   import restUtils from "helpers/data/utils"
   import {
-    RestBodyTypes as bodyTypes,
-    SchemaTypeOptions,
     PaginationLocations,
     PaginationTypes,
+    RawRestBodyTypes,
+    RestBodyTypes as bodyTypes,
+    SchemaTypeOptions,
   } from "constants/backend"
   import JSONPreview from "components/integration/JSONPreview.svelte"
   import AccessLevelSelect from "components/integration/AccessLevelSelect.svelte"
   import DynamicVariableModal from "../../_components/DynamicVariableModal.svelte"
   import Placeholder from "assets/bb-spaceship.svg"
   import { cloneDeep } from "lodash/fp"
-  import { RawRestBodyTypes } from "constants/backend"
 
   import {
     getRestBindings,
-    toBindingsArray,
-    runtimeToReadableBinding,
     readableToRuntimeBinding,
-    runtimeToReadableMap,
     readableToRuntimeMap,
+    runtimeToReadableBinding,
+    runtimeToReadableMap,
+    toBindingsArray,
   } from "builderStore/dataBinding"
 
   let query, datasource
@@ -95,7 +95,7 @@
   $: runtimeUrlQueries = readableToRuntimeMap(mergedBindings, breakQs)
 
   function getSelectedQuery() {
-    const cloneQuery = cloneDeep(
+    return cloneDeep(
       $queries.list.find(q => q._id === $queries.selected) || {
         datasourceId: $params.selectedDatasource,
         parameters: [],
@@ -107,7 +107,6 @@
         queryVerb: "read",
       }
     )
-    return cloneQuery
   }
 
   function checkQueryName(inputUrl = null) {
@@ -121,14 +120,15 @@
     if (!base) {
       return base
     }
-    const qs = restUtils.buildQueryString(
+    let qs = restUtils.buildQueryString(
       runtimeToReadableMap(mergedBindings, qsObj)
     )
     let newUrl = base
     if (base.includes("?")) {
-      newUrl = base.split("?")[0]
+      const split = base.split("?")
+      newUrl = split[0]
     }
-    return qs.length > 0 ? `${newUrl}?${qs}` : newUrl
+    return qs.length === 0 ? newUrl : `${newUrl}?${qs}`
   }
 
   function buildQuery() {
@@ -314,6 +314,27 @@
     }
   }
 
+  $: console.log(breakQs)
+
+  const paramsChanged = evt => {
+    breakQs = {}
+    for (let param of evt.detail) {
+      breakQs[param.name] = param.value
+    }
+  }
+
+  const urlChanged = evt => {
+    breakQs = {}
+    const qs = evt.target.value.split("?")[1]
+    if (qs && qs.length > 0) {
+      const parts = qs.split("&")
+      for (let part of parts) {
+        const [key, value] = part.split("=")
+        breakQs[key] = value
+      }
+    }
+  }
+
   onMount(async () => {
     query = getSelectedQuery()
 
@@ -426,7 +447,11 @@
             />
           </div>
           <div class="url">
-            <Input bind:value={url} placeholder="http://www.api.com/endpoint" />
+            <Input
+              on:blur={urlChanged}
+              bind:value={url}
+              placeholder="http://www.api.com/endpoint"
+            />
           </div>
           <Button primary disabled={!url} on:click={runQuery}>Send</Button>
           <Button
@@ -456,13 +481,16 @@
             />
           </Tab>
           <Tab title="Params">
-            <KeyValueBuilder
-              bind:object={breakQs}
-              name="param"
-              headings
-              bindings={mergedBindings}
-              bindingDrawerLeft="260px"
-            />
+            {#key breakQs}
+              <KeyValueBuilder
+                on:change={paramsChanged}
+                object={breakQs}
+                name="param"
+                headings
+                bindings={mergedBindings}
+                bindingDrawerLeft="260px"
+              />
+            {/key}
           </Tab>
           <Tab title="Headers">
             <KeyValueBuilder

--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/rest/[query]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[selectedDatasource]/rest/[query]/index.svelte
@@ -314,8 +314,6 @@
     }
   }
 
-  $: console.log(breakQs)
-
   const paramsChanged = evt => {
     breakQs = {}
     for (let param of evt.detail) {

--- a/packages/builder/src/pages/builder/portal/apps/index.svelte
+++ b/packages/builder/src/pages/builder/portal/apps/index.svelte
@@ -39,9 +39,6 @@
   let creatingFromTemplate = false
   let automationErrors
   let accessFilterList = null
-  let welcomeHeader, welcomeBody
-  let createAppButtonText
-  let enrichedApps, filteredApps, lockedApps, unlocked
 
   const resolveWelcomeMessage = (auth, apps) => {
     const userWelcome = auth?.user?.firstName

--- a/packages/builder/src/pages/builder/portal/apps/index.svelte
+++ b/packages/builder/src/pages/builder/portal/apps/index.svelte
@@ -15,7 +15,6 @@
   import Spinner from "components/common/Spinner.svelte"
   import CreateAppModal from "components/start/CreateAppModal.svelte"
   import UpdateAppModal from "components/start/UpdateAppModal.svelte"
-  import ExportAppModal from "components/start/ExportAppModal.svelte"
 
   import { store, automationStore } from "builderStore"
   import { API } from "api"
@@ -33,7 +32,6 @@
   let selectedApp
   let creationModal
   let updatingModal
-  let exportModal
   let creatingApp = false
   let loaded = $apps?.length || $templates?.length
   let searchTerm = ""
@@ -41,6 +39,9 @@
   let creatingFromTemplate = false
   let automationErrors
   let accessFilterList = null
+  let welcomeHeader, welcomeBody
+  let createAppButtonText
+  let enrichedApps, filteredApps, lockedApps, unlocked
 
   const resolveWelcomeMessage = (auth, apps) => {
     const userWelcome = auth?.user?.firstName
@@ -405,10 +406,6 @@
 
 <Modal bind:this={updatingModal} padding={false} width="600px">
   <UpdateAppModal app={selectedApp} />
-</Modal>
-
-<Modal bind:this={exportModal} padding={false} width="600px">
-  <ExportAppModal app={selectedApp} />
 </Modal>
 
 <style>

--- a/packages/builder/src/pages/builder/portal/overview/[application]/index.svelte
+++ b/packages/builder/src/pages/builder/portal/overview/[application]/index.svelte
@@ -16,6 +16,7 @@
     MenuItem,
     Icon,
     Helpers,
+    Modal,
   } from "@budibase/bbui"
   import OverviewTab from "../_components/OverviewTab.svelte"
   import SettingsTab from "../_components/SettingsTab.svelte"
@@ -29,6 +30,7 @@
   import EditableIcon from "components/common/EditableIcon.svelte"
   import ConfirmDialog from "components/common/ConfirmDialog.svelte"
   import HistoryTab from "components/portal/overview/automation/HistoryTab.svelte"
+  import ExportAppModal from "components/start/ExportAppModal.svelte"
   import { checkIncomingDeploymentStatus } from "components/deploy/utils"
   import { onDestroy, onMount } from "svelte"
 
@@ -38,7 +40,9 @@
   let loaded = false
   let deletionModal
   let unpublishModal
+  let exportModal
   let appName = ""
+  let published
 
   // App
   $: filteredApps = $apps.filter(app => app.devId === application)
@@ -140,11 +144,9 @@
     notifications.success("App ID copied to clipboard.")
   }
 
-  const exportApp = (app, opts = { published: false }) => {
-    const appName = encodeURIComponent(app.name)
-    const id = opts?.published ? app.prodId : app.devId
-    // always export the development version
-    window.location = `/api/backups/export?appId=${id}&appname=${appName}`
+  const exportApp = opts => {
+    published = opts.published
+    exportModal.show()
   }
 
   const unpublishApp = app => {
@@ -205,6 +207,10 @@
     }
   })
 </script>
+
+<Modal bind:this={exportModal} padding={false} width="600px">
+  <ExportAppModal app={selectedApp} {published} />
+</Modal>
 
 <span class="overview-wrap">
   <Page wide noPadding>
@@ -269,14 +275,14 @@
                 <Icon hoverable name="More" />
               </span>
               <MenuItem
-                on:click={() => exportApp(selectedApp, { published: false })}
+                on:click={() => exportApp({ published: false })}
                 icon="DownloadFromCloud"
               >
                 Export latest
               </MenuItem>
               {#if isPublished}
                 <MenuItem
-                  on:click={() => exportApp(selectedApp, { published: true })}
+                  on:click={() => exportApp({ published: true })}
                   icon="DownloadFromCloudOutline"
                 >
                   Export published

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -553,11 +553,7 @@ export const sync = async (ctx: any, next: any) => {
   })
   let error
   try {
-    await replication.replicate({
-      filter: function (doc: any) {
-        return doc._id !== DocumentType.APP_METADATA
-      },
-    })
+    await replication.replicate(replication.appReplicateOpts())
   } catch (err) {
     error = err
   } finally {

--- a/packages/server/src/api/controllers/backup.js
+++ b/packages/server/src/api/controllers/backup.js
@@ -1,11 +1,12 @@
 const { streamBackup } = require("../../utilities/fileSystem")
 const { events, context } = require("@budibase/backend-core")
 const { DocumentType } = require("../../db/utils")
+const { isQsTrue } = require("../../utilities")
 
 exports.exportAppDump = async function (ctx) {
   let { appId, excludeRows } = ctx.query
   const appName = decodeURI(ctx.query.appname)
-  excludeRows = excludeRows === "true"
+  excludeRows = isQsTrue(excludeRows)
   const backupIdentifier = `${appName}-export-${new Date().getTime()}.txt`
   ctx.attachment(backupIdentifier)
   ctx.body = await streamBackup(appId, excludeRows)

--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -125,7 +125,7 @@ async function deployApp(deployment: any) {
       const prodAppDoc = await db.get(DocumentType.APP_METADATA)
       appDoc._rev = prodAppDoc._rev
     } catch (err) {
-      // ignore the error - doesn't exist
+      delete appDoc._rev
     }
 
     // switch to production app ID

--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -15,6 +15,7 @@ import {
   getAppId,
   getAppDB,
   getProdAppDB,
+  getDevAppDB,
 } from "@budibase/backend-core/context"
 import { quotas } from "@budibase/pro"
 import { events } from "@budibase/backend-core"
@@ -110,17 +111,29 @@ async function deployApp(deployment: any) {
       target: productionAppId,
     }
     replication = new Replication(config)
-
+    const devDb = getDevAppDB()
+    console.log("Compacting development DB")
+    await devDb.compact()
     console.log("Replication object created")
-    await replication.replicate()
+    await replication.replicate(replication.appReplicateOpts())
     console.log("replication complete.. replacing app meta doc")
+    // app metadata is excluded as it is likely to be in conflict
+    // replicate the app metadata document manually
     const db = getProdAppDB()
-    const appDoc = await db.get(DocumentType.APP_METADATA)
+    const appDoc = await devDb.get(DocumentType.APP_METADATA)
+    try {
+      const prodAppDoc = await db.get(DocumentType.APP_METADATA)
+      appDoc._rev = prodAppDoc._rev
+    } catch (err) {
+      // ignore the error - doesn't exist
+    }
 
+    // switch to production app ID
     deployment.appUrl = appDoc.url
-
     appDoc.appId = productionAppId
     appDoc.instance._id = productionAppId
+    // remove automation errors if they exist
+    delete appDoc.automationErrors
     await db.put(appDoc)
     await appCache.invalidateAppMetadata(productionAppId)
     console.log("New app doc written successfully.")

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -534,7 +534,7 @@ module External {
         })
         // this is the response from knex if no rows found
         const rows = !response[0].read ? response : []
-        const storeTo = isMany ? field.throughFrom || linkPrimaryKey : manyKey
+        const storeTo = isMany ? field.throughFrom || linkPrimaryKey : fieldName
         related[storeTo] = { rows, isMany, tableId }
       }
       return related

--- a/packages/server/src/api/routes/tests/query.spec.js
+++ b/packages/server/src/api/routes/tests/query.spec.js
@@ -311,7 +311,7 @@ describe("/queries", () => {
         "url": "string",
         "value": "string"
       })
-      expect(res.body.rows[0].url).toContain("doctype html")
+      expect(res.body.rows[0].url).toContain("doctype%20html")
     })
 
     it("check that it automatically retries on fail with cached dynamics", async () => {
@@ -396,7 +396,7 @@ describe("/queries", () => {
         "queryHdr": userDetails.firstName,
         "secondHdr" : "1234"
       })
-      expect(res.body.rows[0].url).toEqual("http://www.google.com?email=" + userDetails.email)
+      expect(res.body.rows[0].url).toEqual("http://www.google.com?email=" + userDetails.email.replace("@", "%40"))
     })
 
     it("should bind the current user to query parameters", async () => {
@@ -413,7 +413,7 @@ describe("/queries", () => {
         "testParam" : "1234"
       })
   
-      expect(res.body.rows[0].url).toEqual("http://www.google.com?test=" + userDetails.email + 
+      expect(res.body.rows[0].url).toEqual("http://www.google.com?test=" + userDetails.email.replace("@", "%40") +
         "&testName=" + userDetails.firstName + "&testParam=1234")
     })
 

--- a/packages/server/src/automations/index.js
+++ b/packages/server/src/automations/index.js
@@ -1,16 +1,19 @@
 const { processEvent } = require("./utils")
 const { queue, shutdown } = require("./bullboard")
-const { TRIGGER_DEFINITIONS } = require("./triggers")
+const { TRIGGER_DEFINITIONS, rebootTrigger } = require("./triggers")
 const { ACTION_DEFINITIONS } = require("./actions")
 
 /**
  * This module is built purely to kick off the worker farm and manage the inputs/outputs
  */
-exports.init = function () {
+exports.init = async function () {
   // this promise will not complete
-  return queue.process(async job => {
+  const promise = queue.process(async job => {
     await processEvent(job)
   })
+  // on init we need to trigger any reboot automations
+  await rebootTrigger()
+  return promise
 }
 
 exports.getQueues = () => {

--- a/packages/server/src/automations/triggers.js
+++ b/packages/server/src/automations/triggers.js
@@ -9,11 +9,20 @@ const { checkTestFlag } = require("../utilities/redis")
 const utils = require("./utils")
 const env = require("../environment")
 const { doInAppContext, getAppDB } = require("@budibase/backend-core/context")
+const { getAllApps } = require("@budibase/backend-core/db")
 
 const TRIGGER_DEFINITIONS = definitions
 const JOB_OPTS = {
   removeOnComplete: true,
   removeOnFail: true,
+}
+
+async function getAllAutomations() {
+  const db = getAppDB()
+  let automations = await db.allDocs(
+    getAutomationParams(null, { include_docs: true })
+  )
+  return automations.rows.map(row => row.doc)
 }
 
 async function queueRelevantRowAutomations(event, eventType) {
@@ -22,18 +31,13 @@ async function queueRelevantRowAutomations(event, eventType) {
   }
 
   doInAppContext(event.appId, async () => {
-    const db = getAppDB()
-    let automations = await db.allDocs(
-      getAutomationParams(null, { include_docs: true })
-    )
+    let automations = await getAllAutomations()
 
     // filter down to the correct event type
-    automations = automations.rows
-      .map(automation => automation.doc)
-      .filter(automation => {
-        const trigger = automation.definition.trigger
-        return trigger && trigger.event === eventType
-      })
+    automations = automations.filter(automation => {
+      const trigger = automation.definition.trigger
+      return trigger && trigger.event === eventType
+    })
 
     for (let automation of automations) {
       let automationDef = automation.definition
@@ -107,6 +111,36 @@ exports.externalTrigger = async function (
     return utils.processEvent({ data })
   } else {
     return queue.add(data, JOB_OPTS)
+  }
+}
+
+exports.rebootTrigger = async () => {
+  // reboot cron option is only available on the main thread at
+  // startup and only usable in self host
+  if (env.isInThread() || !env.SELF_HOSTED) {
+    return
+  }
+  // iterate through all production apps, find the reboot crons
+  // and trigger events for them
+  const appIds = await getAllApps({ dev: false, idsOnly: true })
+  for (let prodAppId of appIds) {
+    await doInAppContext(prodAppId, async () => {
+      let automations = await getAllAutomations()
+      let rebootEvents = []
+      for (let automation of automations) {
+        if (utils.isRebootTrigger(automation)) {
+          const job = {
+            automation,
+            event: {
+              appId: prodAppId,
+              timestamp: Date.now(),
+            },
+          }
+          rebootEvents.push(queue.add(job, JOB_OPTS))
+        }
+      }
+      await Promise.all(rebootEvents)
+    })
   }
 }
 

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -14,6 +14,7 @@ import {
   BearerAuthConfig,
 } from "../definitions/datasource"
 import { get } from "lodash"
+import qs from "querystring"
 
 const BodyTypes = {
   NONE: "none",
@@ -215,7 +216,8 @@ module RestModule {
         }
       }
 
-      const main = `${path}?${encodeURIComponent(queryString)}`
+      // make sure the query string is fully encoded
+      const main = `${path}?${qs.encode(qs.decode(queryString))}`
       let complete = main
       if (this.config.url && !main.startsWith("http")) {
         complete = !this.config.url ? main : `${this.config.url}/${main}`

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -215,7 +215,7 @@ module RestModule {
         }
       }
 
-      const main = `${path}?${queryString}`
+      const main = `${path}?${encodeURIComponent(queryString)}`
       let complete = main
       if (this.config.url && !main.startsWith("http")) {
         complete = !this.config.url ? main : `${this.config.url}/${main}`

--- a/packages/server/src/integrations/tests/rest.spec.js
+++ b/packages/server/src/integrations/tests/rest.spec.js
@@ -50,7 +50,7 @@ describe("REST Integration", () => {
         name: "test",
       }),
     }
-    const response = await config.integration.create(query)
+    await config.integration.create(query)
     expect(fetch).toHaveBeenCalledWith(`${BASE_URL}/api?test=1`, {
       method: "POST",
       body: '{"name":"test"}',
@@ -295,7 +295,7 @@ describe("REST Integration", () => {
       }
       await config.integration.read(query)
       expect(fetch).toHaveBeenCalledWith(
-        `${BASE_URL}/api?${pageParam}=${pageValue}&${sizeParam}=${sizeValue}&`,
+        `${BASE_URL}/api?${pageParam}=${pageValue}&${sizeParam}=${sizeValue}`,
         {
           headers: {},
           method: "GET",
@@ -420,7 +420,7 @@ describe("REST Integration", () => {
       }
       const res = await config.integration.read(query)
       expect(fetch).toHaveBeenCalledWith(
-        `${BASE_URL}/api?${pageParam}=${pageValue}&${sizeParam}=${sizeValue}&`,
+        `${BASE_URL}/api?${pageParam}=${pageValue}&${sizeParam}=${sizeValue}`,
         {
           headers: {},
           method: "GET",
@@ -527,6 +527,24 @@ describe("REST Integration", () => {
       expect(sentData.has(sizeParam))
       expect(sentData.get(sizeParam)).toEqual(sizeValue.toString())
       expect(res.pagination.cursor).toEqual(123)
+    })
+
+    it("should encode query string correctly", async () => {
+      const query = {
+        path: "api",
+        queryString: "test=1 2",
+        headers: HEADERS,
+        bodyType: "json",
+        requestBody: JSON.stringify({
+          name: "test",
+        }),
+      }
+      await config.integration.create(query)
+      expect(fetch).toHaveBeenCalledWith(`${BASE_URL}/api?test=1%202`, {
+        method: "POST",
+        body: '{"name":"test"}',
+        headers: HEADERS,
+      })
     })
   })
 })

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -458,6 +458,9 @@ class Orchestrator {
 
 export function execute(input: AutomationEvent, callback: WorkerCallback) {
   const appId = input.data.event.appId
+  if (!appId) {
+    throw new Error("Unable to execute, event doesn't contain app ID.")
+  }
   doInAppContext(appId, async () => {
     const automationOrchestrator = new Orchestrator(
       input.data.automation,
@@ -475,6 +478,9 @@ export function execute(input: AutomationEvent, callback: WorkerCallback) {
 
 export const removeStalled = async (input: AutomationEvent) => {
   const appId = input.data.event.appId
+  if (!appId) {
+    throw new Error("Unable to execute, event doesn't contain app ID.")
+  }
   await doInAppContext(appId, async () => {
     const automationOrchestrator = new Orchestrator(
       input.data.automation,

--- a/packages/server/src/utilities/fileSystem/index.js
+++ b/packages/server/src/utilities/fileSystem/index.js
@@ -125,13 +125,13 @@ exports.defineFilter = excludeRows => {
  * data or user relationships.
  * @param {string} appId The app to backup
  * @param {object} config Config to send to export DB
- * @param {boolean} includeRows Flag to state whether the export should include data.
+ * @param {boolean} excludeRows Flag to state whether the export should include data.
  * @returns {*} either a string or a stream of the backup
  */
-const backupAppData = async (appId, config, includeRows) => {
+const backupAppData = async (appId, config, excludeRows) => {
   return await exports.exportDB(appId, {
     ...config,
-    filter: exports.defineFilter(includeRows),
+    filter: exports.defineFilter(excludeRows),
   })
 }
 
@@ -148,11 +148,11 @@ exports.performBackup = async (appId, backupName) => {
 /**
  * Streams a backup of the database state for an app
  * @param {string} appId The ID of the app which is to be backed up.
- * @param {boolean} includeRows Flag to state whether the export should include data.
+ * @param {boolean} excludeRows Flag to state whether the export should include data.
  * @returns {*} a readable stream of the backup which is written in real time
  */
-exports.streamBackup = async (appId, includeRows) => {
-  return await backupAppData(appId, { stream: true }, includeRows)
+exports.streamBackup = async (appId, excludeRows) => {
+  return await backupAppData(appId, { stream: true }, excludeRows)
 }
 
 /**

--- a/packages/server/src/utilities/index.js
+++ b/packages/server/src/utilities/index.js
@@ -162,3 +162,11 @@ exports.convertBookmark = bookmark => {
   }
   return bookmark
 }
+
+exports.isQsTrue = param => {
+  if (typeof param === "string") {
+    return param.toLowerCase() === "true"
+  } else {
+    return param === true
+  }
+}

--- a/packages/server/src/utilities/rowProcessor/utils.js
+++ b/packages/server/src/utilities/rowProcessor/utils.js
@@ -76,7 +76,7 @@ exports.processDates = (table, rows) => {
     if (schema.type !== FieldTypes.DATETIME) {
       continue
     }
-    if (!schema.ignoreTimezones) {
+    if (!schema.timeOnly && !schema.ignoreTimezones) {
       datesWithTZ.push(column)
     }
   }

--- a/packages/server/src/utilities/usageQuota/rows.js
+++ b/packages/server/src/utilities/usageQuota/rows.js
@@ -72,7 +72,8 @@ exports.getUniqueRows = async appIds => {
     // ensure uniqueness on a per app pair basis
     // this can't be done on all rows because app import results in
     // duplicate row ids across apps
-    uniqueRows = uniqueRows.concat(...new Set(appRows))
+    // the array pre-concat is important to avoid stack overflow
+    uniqueRows = uniqueRows.concat([...new Set(appRows)])
   }
 
   return uniqueRows

--- a/packages/string-templates/test/helpers.spec.js
+++ b/packages/string-templates/test/helpers.spec.js
@@ -272,6 +272,14 @@ describe("test the string helpers", () => {
     )
     expect(output).toBe("Hi!")
   })
+
+  it("should allow use of the ellipsis helper", async () => {
+    const output = await processString(
+      "{{ ellipsis \"adfasdfasdfasf\" 7 }}",
+      {},
+    )
+    expect(output).toBe("adfasdf…")
+  })
 })
 
 describe("test the comparison helpers", () => {

--- a/packages/types/src/documents/app/automation.ts
+++ b/packages/types/src/documents/app/automation.ts
@@ -25,6 +25,10 @@ export interface AutomationStep {
 export interface AutomationTrigger {
   id: string
   stepId: string
+  inputs: {
+    [key: string]: any
+  }
+  cronJobId?: string
 }
 
 export enum AutomationStatus {


### PR DESCRIPTION
## Description
Various fixes gathered over the last few days, discussed in the addresses section.

Addresses: 
- Adds a test case for #7617 to prove that it works as expected.
- Adds compaction in before replication, this should help with replication time in the case that a lot of rows have been deleted right before replication.
- #7431 the reboot option for CRON simply did not work, I've removed it as an option in the Cloud as it doesn't really make sense there and I've made it work in self host (events are triggered as part of the automation init at startup). There are still some issues, like this occurring multiple times in a clustered environment each time an app service starts up, but at least it functions now. Also stopped it from breaking app publishing (which means there are likely no apps using this today since they couldn't be published).
- #7683 URI parameters in a REST query were not being correctly encoded, this meant parameters containing special characters (say spaces) would not work consistently.
- Fixing a z-index issue uncovered in #7679.
- Fixed an issue I found with MySQL time only fields being unloadable after recent changes to support timezones better.
- #6980 fixed an issue with SQL relationships and foreign keys with mis-matching foreign key labels, depending on the way round the update was occurring sometimes this would fail but not alert the user - looking like updates have just been ignored.
- Another issue discussed in #7683, if you changed a query string parameter in the URL bar rather than through the params tab for a REST query, it would look like it has changed but simply be ignored. I've changed how URL params are handled so that you can update them through the URL bar and have them correctly reflected in the params tab as well.
- #7583 bring back the modal that allows exporting apps with/without internal table data.
- Fixed an issue with deleting very large apps - it would stack overflow if you had too many (200K) internal table rows.

# Screenshots
Fixed modal for exporting apps with/without internal table data.
![image](https://user-images.githubusercontent.com/4407001/189425292-29b3656b-0e66-4cf4-8ef5-3d9fa77e88ab.png)
