### PR TITLE
Null safety when creating automation from design

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionEditor.svelte
@@ -66,7 +66,6 @@
         $automationStore.selectedAutomation.automation._id
       delete parameters.newAutomationName
     } catch (error) {
-      console.log("ERROR ", error)
       notifications.error("Error creating automation")
     }
   }

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionEditor.svelte
@@ -52,7 +52,7 @@
       )
 
       newBlock.inputs = {
-        fields: Object.keys(parameters.fields).reduce((fields, key) => {
+        fields: Object.keys(parameters.fields ?? {}).reduce((fields, key) => {
           fields[key] = "string"
           return fields
         }, {}),
@@ -66,6 +66,7 @@
         $automationStore.selectedAutomation.automation._id
       delete parameters.newAutomationName
     } catch (error) {
+      console.log("ERROR ", error)
       notifications.error("Error creating automation")
     }
   }


### PR DESCRIPTION
## Description
When creating a new app action automation from the Design section, an error would be thrown if no fields were added.
You can now create an app action automation from the Design section without any fields.

Addresses: 
- https://github.com/Budibase/budibase/issues/6624



