### PR TITLE
Fix client side lucene filtering

### DIFF
--- a/packages/client/src/components/Component.svelte
+++ b/packages/client/src/components/Component.svelte
@@ -127,7 +127,9 @@
   // Empty components are those which accept children but do not have any.
   // Empty states can be shown for these components, but can be disabled
   // in the component manifest.
-  $: empty = interactive && !children.length && hasChildren
+  $: empty =
+    (interactive && !children.length && hasChildren) ||
+    hasMissingRequiredSettings
   $: emptyState = empty && showEmptyState
 
   // Enrich component settings

--- a/packages/client/src/components/app/ComponentPlaceholder.svelte
+++ b/packages/client/src/components/app/ComponentPlaceholder.svelte
@@ -2,28 +2,25 @@
   import { getContext } from "svelte"
   import { builderStore } from "stores"
 
-  const { styleable } = getContext("sdk")
   const component = getContext("component")
 
   $: requiredSetting = $component.missingRequiredSettings?.[0]
 </script>
 
 {#if $builderStore.inBuilder && requiredSetting}
-  <div use:styleable={$component.styles}>
-    <div class="component-placeholder">
-      <span>
-        Add the <mark>{requiredSetting.label}</mark> setting to start using your
-        component -
-      </span>
-      <span
-        class="spectrum-Link"
-        on:click={() => {
-          builderStore.actions.highlightSetting(requiredSetting.key)
-        }}
-      >
-        Show me
-      </span>
-    </div>
+  <div class="component-placeholder">
+    <span>
+      Add the <mark>{requiredSetting.label}</mark> setting to start using your component
+      -
+    </span>
+    <span
+      class="spectrum-Link"
+      on:click={() => {
+        builderStore.actions.highlightSetting(requiredSetting.key)
+      }}
+    >
+      Show me
+    </span>
   </div>
 {/if}
 

--- a/packages/client/src/components/app/DataProvider.svelte
+++ b/packages/client/src/components/app/DataProvider.svelte
@@ -133,11 +133,7 @@
         <ProgressCircle />
       </div>
     {:else}
-      {#if $component.emptyState}
-        <Placeholder />
-      {:else}
-        <slot />
-      {/if}
+      <slot />
       {#if paginate && $fetch.supportsPagination}
         <div class="pagination">
           <Pagination

--- a/packages/client/src/components/app/DataProvider.svelte
+++ b/packages/client/src/components/app/DataProvider.svelte
@@ -1,7 +1,6 @@
 <script>
   import { getContext } from "svelte"
   import { ProgressCircle, Pagination } from "@budibase/bbui"
-  import Placeholder from "./Placeholder.svelte"
   import { fetchData, LuceneUtils } from "@budibase/frontend-core"
 
   export let dataSource

--- a/packages/frontend-core/src/utils/lucene.js
+++ b/packages/frontend-core/src/utils/lucene.js
@@ -83,11 +83,13 @@ const cleanupQuery = query => {
 /**
  * Removes a numeric prefix on field names designed to give fields uniqueness
  */
-const removeFieldPrefix = field => {
-  if (field && typeof field === "string" && field.includes(":")) {
-    return field.split(":")[1]
+const removeKeyNumbering = key => {
+  if (typeof key === "string" && key.match(/\d[0-9]*:/g) != null) {
+    const parts = key.split(":")
+    parts.shift()
+    return parts.join(":")
   } else {
-    return field
+    return key
   }
 }
 
@@ -205,7 +207,7 @@ export const runLuceneQuery = (docs, query) => {
     const filters = Object.entries(query[type] || {})
     for (let i = 0; i < filters.length; i++) {
       const [key, testValue] = filters[i]
-      const docValue = Helpers.deepGet(doc, removeFieldPrefix(key))
+      const docValue = Helpers.deepGet(doc, removeKeyNumbering(key))
       if (failFn(docValue, testValue)) {
         return false
       }

--- a/packages/frontend-core/src/utils/lucene.js
+++ b/packages/frontend-core/src/utils/lucene.js
@@ -81,6 +81,17 @@ const cleanupQuery = query => {
 }
 
 /**
+ * Removes a numeric prefix on field names designed to give fields uniqueness
+ */
+const removeFieldPrefix = field => {
+  if (field && typeof field === "string" && field.includes(":")) {
+    return field.split(":")[1]
+  } else {
+    return field
+  }
+}
+
+/**
  * Builds a lucene JSON query from the filter structure generated in the builder
  * @param filter the builder filter structure
  */
@@ -194,7 +205,7 @@ export const runLuceneQuery = (docs, query) => {
     const filters = Object.entries(query[type] || {})
     for (let i = 0; i < filters.length; i++) {
       const [key, testValue] = filters[i]
-      const docValue = Helpers.deepGet(doc, key)
+      const docValue = Helpers.deepGet(doc, removeFieldPrefix(key))
       if (failFn(docValue, testValue)) {
         return false
       }


### PR DESCRIPTION
## Description
This PR fixes client side lucene searching, which was currently broken. Client side filtering was not working due to recent changes in lucene filtering to allow multiple expressions on the same field (using numeric prefixes) not being accounted for in client side logic.

This also fixes a couple of minor display issues with component empty states (most notably the double empty state border around an empty data provider).

Addresses: 
- #7691

## Screenshots
Quick examples of empty state fixes:

Before:
![image](https://user-images.githubusercontent.com/9075550/189604456-927a0922-ee2c-471b-8530-2ad1fb736cc6.png)

After:
![image](https://user-images.githubusercontent.com/9075550/189604558-df3435e7-c7e0-41d2-a19b-e36da6031411.png)

Before:
![image](https://user-images.githubusercontent.com/9075550/189604619-865f99be-6450-4668-87f7-0e31edd6e6fb.png)

After:
![image](https://user-images.githubusercontent.com/9075550/189604709-e16cdd8e-dd48-43fb-832c-cadd751cbe6d.png)

