### PR TITLE
Move date range picker into data

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/new/_components/componentStructure.json
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/new/_components/componentStructure.json
@@ -23,7 +23,8 @@
       "dataprovider",
       "repeater",
       "table",
-      "dynamicfilter"
+      "dynamicfilter",
+      "daterangepicker"
     ]
   },
   {
@@ -60,7 +61,6 @@
       "booleanfield",
       "longformfield",
       "attachmentfield",
-      "daterangepicker",
       "jsonfield",
       "relationshipfield",
       "datetimefield",
@@ -81,4 +81,3 @@
     ]
   }
 ]
-


### PR DESCRIPTION
## Description
Moved Date Range Picker into the *Data* section as it is a Data Provider filter and is not a form field. 

Addresses: 
- https://github.com/Budibase/budibase/issues/6491

## Screenshots
![Screenshot 2022-09-12 at 09 21 43](https://user-images.githubusercontent.com/101575380/189606451-25295bd1-7fb1-4c5c-85c5-cc8072546f10.png)


