### PR TITLE
Postgres (and other external DBs) support foreign key bigint -> smallint

### DIFF
--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -371,7 +371,10 @@ module External {
         const toColumn = `${linkedTable.name}.${relationship.to}`
         // this is important when working with multiple relationships
         // between the same tables, don't want to overlap/multiply the relations
-        if (!relationship.through && row[fromColumn]?.toString() !== row[toColumn]?.toString()) {
+        if (
+          !relationship.through &&
+          row[fromColumn]?.toString() !== row[toColumn]?.toString()
+        ) {
           continue
         }
         let linked = basicProcessing(row, linkedTable)

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -371,7 +371,7 @@ module External {
         const toColumn = `${linkedTable.name}.${relationship.to}`
         // this is important when working with multiple relationships
         // between the same tables, don't want to overlap/multiply the relations
-        if (!relationship.through && row[fromColumn] !== row[toColumn]) {
+        if (!relationship.through && row[fromColumn]?.toString() !== row[toColumn]?.toString()) {
           continue
         }
         let linked = basicProcessing(row, linkedTable)


### PR DESCRIPTION
## Description
Currently relationships between bigint and smallint don't work because bigint is returned as type *string* whereas smallint is returned as type *number*.
When comparing relationships, the values are now cast as strings so that the equality check passes. 

Addresses: 
- https://github.com/Budibase/budibase/issues/6000

## Screenshots
**Owners ID**
![pgadmin_bigint](https://user-images.githubusercontent.com/101575380/189665995-dac6f4b1-a338-4b48-a1b1-dc99233f1d24.png)

**Pets fk_owner**
![pgadmin_smallint](https://user-images.githubusercontent.com/101575380/189666050-59971cac-e792-4c34-93cb-b3d297c4fa85.png)

**Define relationship**
![define_relationships](https://user-images.githubusercontent.com/101575380/189666112-9cf0718c-8d71-4fe7-9e28-3401129a6cbf.png)

**BEFORE**
![owners_nopets](https://user-images.githubusercontent.com/101575380/189666132-ff700259-0d4b-432e-a1ed-939e7d3cfd82.png)

**AFTER**
![owners_success](https://user-images.githubusercontent.com/101575380/189666162-c05e1602-00d7-4546-bbfb-0af254da506c.png)



