### PR TITLE
Quick fix for CLI build

### DIFF
--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -25,6 +25,7 @@
     "@techpass/passport-openidconnect": "0.3.2",
     "aws-sdk": "2.1030.0",
     "bcrypt": "5.0.1",
+    "bcryptjs": "2.4.3",
     "dotenv": "16.0.1",
     "emitter-listener": "1.1.2",
     "ioredis": "4.28.0",

--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -19,6 +19,7 @@ if (!LOADED && isDev() && !isTest()) {
 const env = {
   isTest,
   isDev,
+  JS_BCRYPT: process.env.JS_BCRYPT,
   JWT_SECRET: process.env.JWT_SECRET,
   COUCH_DB_URL: process.env.COUCH_DB_URL || "http://localhost:4005",
   COUCH_DB_USERNAME: process.env.COUCH_DB_USER,

--- a/packages/backend-core/src/hashing.js
+++ b/packages/backend-core/src/hashing.js
@@ -1,5 +1,5 @@
-const bcrypt = require("bcrypt")
 const env = require("./environment")
+const bcrypt = env.JS_BCRYPT ? require("bcryptjs") : require("bcrypt")
 const { v4 } = require("uuid")
 
 const SALT_ROUNDS = env.SALT_ROUNDS || 10

--- a/packages/cli/src/environment.js
+++ b/packages/cli/src/environment.js
@@ -1,1 +1,2 @@
 process.env.NO_JS = "1"
+process.env.JS_BCRYPT = "1"

--- a/packages/cli/src/plugins/index.js
+++ b/packages/cli/src/plugins/index.js
@@ -25,7 +25,7 @@ function checkInPlugin() {
 async function askAboutTopLevel(name) {
   const files = fs.readdirSync(process.cwd())
   // we are in an empty git repo, don't ask
-  if (files.length === 1 && files[0] === ".git") {
+  if (files.find(file => file === ".git")) {
     return false
   } else {
     console.log(

--- a/packages/cli/src/plugins/index.js
+++ b/packages/cli/src/plugins/index.js
@@ -22,6 +22,24 @@ function checkInPlugin() {
   }
 }
 
+async function askAboutTopLevel() {
+  const files = fs.readdirSync(process.cwd())
+  // we are in an empty git repo, don't ask
+  if (files.length === 1 && files[0] === ".git") {
+    return false
+  } else {
+    console.log(
+      info(`By default the plugin will be created in the directory "${name}"`)
+    )
+    console.log(
+      info(
+        "if you are already in an empty directory, such as a new Git repo, you can disable this functionality."
+      )
+    )
+    return questions.confirmation("Create top level directory?")
+  }
+}
+
 async function init(opts) {
   const type = opts["init"] || opts
   if (!type || !PLUGIN_TYPE_ARR.includes(type)) {
@@ -45,15 +63,7 @@ async function init(opts) {
     `An amazing Budibase ${type}!`
   )
   const version = await questions.string("Version", "1.0.0")
-  console.log(
-    info(`By default the plugin will be created in the directory "${name}"`)
-  )
-  console.log(
-    info(
-      "if you are already in an empty directory, such as a new Git repo, you can disable this functionality."
-    )
-  )
-  const topLevel = await questions.confirmation("Create top level directory?")
+  const topLevel = await askAboutTopLevel()
   // get the skeleton
   console.log(info("Retrieving project..."))
   await getSkeleton(type, name)

--- a/packages/cli/src/plugins/index.js
+++ b/packages/cli/src/plugins/index.js
@@ -22,7 +22,7 @@ function checkInPlugin() {
   }
 }
 
-async function askAboutTopLevel() {
+async function askAboutTopLevel(name) {
   const files = fs.readdirSync(process.cwd())
   // we are in an empty git repo, don't ask
   if (files.length === 1 && files[0] === ".git") {
@@ -63,7 +63,7 @@ async function init(opts) {
     `An amazing Budibase ${type}!`
   )
   const version = await questions.string("Version", "1.0.0")
-  const topLevel = await askAboutTopLevel()
+  const topLevel = await askAboutTopLevel(name)
   // get the skeleton
   console.log(info("Retrieving project..."))
   await getSkeleton(type, name)

--- a/packages/cli/src/plugins/index.js
+++ b/packages/cli/src/plugins/index.js
@@ -7,7 +7,7 @@ const { PLUGIN_TYPE_ARR } = require("@budibase/types")
 const { validate } = require("@budibase/backend-core/plugins")
 const { runPkgCommand } = require("../exec")
 const { join } = require("path")
-const { success, error, info } = require("../utils")
+const { success, error, info, moveDirectory } = require("../utils")
 
 function checkInPlugin() {
   if (!fs.existsSync("package.json")) {
@@ -45,13 +45,28 @@ async function init(opts) {
     `An amazing Budibase ${type}!`
   )
   const version = await questions.string("Version", "1.0.0")
+  console.log(
+    info(`By default the plugin will be created in the directory "${name}"`)
+  )
+  console.log(
+    info(
+      "if you are already in an empty directory, such as a new Git repo, you can disable this functionality."
+    )
+  )
+  const topLevel = await questions.confirmation("Create top level directory?")
   // get the skeleton
   console.log(info("Retrieving project..."))
   await getSkeleton(type, name)
   await fleshOutSkeleton(type, name, desc, version)
   console.log(info("Installing dependencies..."))
   await runPkgCommand("install", join(process.cwd(), name))
-  console.log(info(`Plugin created in directory "${name}"`))
+  // if no parent directory desired move to cwd
+  if (!topLevel) {
+    moveDirectory(name, process.cwd())
+    console.log(info(`Plugin created in current directory.`))
+  } else {
+    console.log(info(`Plugin created in directory "${name}"`))
+  }
 }
 
 async function verify() {

--- a/packages/cli/src/prebuilds.js
+++ b/packages/cli/src/prebuilds.js
@@ -27,7 +27,10 @@ function checkForBinaries() {
 }
 
 function cleanup(evt) {
-  if (evt && evt.errno) {
+  if (!isNaN(evt)) {
+    return
+  }
+  if (evt) {
     console.error(
       error(
         "Failed to run CLI command - please report with the following message:"

--- a/packages/cli/src/utils.js
+++ b/packages/cli/src/utils.js
@@ -3,6 +3,7 @@ const fs = require("fs")
 const axios = require("axios")
 const path = require("path")
 const progress = require("cli-progress")
+const { join } = require("path")
 
 exports.downloadFile = async (url, filePath) => {
   filePath = path.resolve(filePath)
@@ -66,4 +67,20 @@ exports.progressBar = total => {
 
 exports.checkSlashesInUrl = url => {
   return url.replace(/(https?:\/\/)|(\/)+/g, "$1$2")
+}
+
+exports.moveDirectory = (oldPath, newPath) => {
+  const files = fs.readdirSync(oldPath)
+  // check any file exists already
+  for (let file of files) {
+    if (fs.existsSync(file)) {
+      throw new Error(
+        "Unable to remove top level directory - some skeleton files already exist."
+      )
+    }
+  }
+  for (let file of files) {
+    fs.renameSync(join(oldPath, file), join(newPath, file))
+  }
+  fs.rmdirSync(oldPath)
 }

--- a/packages/cli/src/utils.js
+++ b/packages/cli/src/utils.js
@@ -73,7 +73,7 @@ exports.moveDirectory = (oldPath, newPath) => {
   const files = fs.readdirSync(oldPath)
   // check any file exists already
   for (let file of files) {
-    if (fs.existsSync(file)) {
+    if (fs.existsSync(join(newPath, file))) {
       throw new Error(
         "Unable to remove top level directory - some skeleton files already exist."
       )


### PR DESCRIPTION
## Description
Fixing CLI build - prebuilds required for hashing can be disabled via environment variable. This was an issue introduced in the plugin UI branch - hashing requires some prebuilds and there was some more hashing work added to the backend-core which caused it to break - allow swapping out for a pure JS build if needed.

Also included a small feature to disable parent directory creation - if the user is creating within an already empty directory, say a new git repo, they might not necessarily want to move all the files from the parent into the git repo, allowing disabling of this option is beneficial. By default this will still be done, and if any of the files exist in the current working directory then it will not move files to the cwd.

By default it will not ask this question if it realises it is in an empty git project (a directory with nothing but a `.git` directory within it).