### PR TITLE
Dev stack improvement + organisation page fixes

### DIFF
--- a/packages/builder/src/pages/builder/portal/settings/organisation.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/organisation.svelte
@@ -88,14 +88,14 @@
       <Heading size="S">Information</Heading>
       <Body size="S">Here you can update your logo and organization name.</Body>
     </Layout>
-    <div className="fields">
-      <div className="field">
+    <div class="fields">
+      <div class="field">
         <Label size="L">Org. name</Label>
         <Input thin bind:value={$values.company} />
       </div>
-      <div className="field logo">
+      <div class="field logo">
         <Label size="L">Logo</Label>
-        <div className="file">
+        <div class="file">
           <Dropzone
             value={[$values.logo]}
             on:change={e => {
@@ -115,13 +115,14 @@
         <Heading size="S">Platform</Heading>
         <Body size="S">Here you can set up general platform settings.</Body>
       </Layout>
-      <div className="fields">
-        <div className="field">
+      <div class="fields">
+        <div class="field">
           <Label
             size="L"
             tooltip={"Update the Platform URL to match your Budibase web URL. This keeps email templates and authentication configs up to date."}
-            >Platform URL</Label
           >
+            Platform URL
+          </Label>
           <Input thin bind:value={$values.platformUrl} />
         </div>
       </div>

--- a/packages/server/scripts/dev/manage.js
+++ b/packages/server/scripts/dev/manage.js
@@ -71,6 +71,10 @@ async function init() {
 async function up() {
   console.log("Spinning up your budibase dev environment... 🔧✨")
   await init()
+
+  // We always ensure to restart the proxy service in case of nginx conf changes
+  await compose.restartOne("proxy-service", CONFIG)
+
   await compose.upAll(CONFIG)
 }
 


### PR DESCRIPTION
## Description
This PR updates the dev stack to always restart the proxy service container when running the `dev` command. This ensures that any nginx conf changes are properly reflected, as currently swapping between branches with nginx conf changes does not work as the container does not restart, meaning it ignores changes in the mounted config.

This also fixes some incorrect usages of react style `className` attributes on the organisation settings page.



