### PR TITLE
Datasource hot reloading fix

### DIFF
--- a/packages/server/src/utilities/fileSystem/index.js
+++ b/packages/server/src/utilities/fileSystem/index.js
@@ -412,6 +412,7 @@ exports.getDatasourcePlugin = async (name, url, hash) => {
       return require(filename)
     } else {
       console.log(`Updating plugin: ${name}`)
+      delete require.cache[require.resolve(filename)]
       fs.unlinkSync(filename)
     }
   }


### PR DESCRIPTION
## Description
Minor fix - datasource hot reloading was working apart from the the CJS require caching, need to clear down the cache entry before reloading.

Thanks to @melohagan for finding this issue.