### PR TITLE
Add 'extra' validation for plugin datasource

### DIFF
--- a/packages/backend-core/src/plugin/utils.js
+++ b/packages/backend-core/src/plugin/utils.js
@@ -75,6 +75,15 @@ function validateDatasource(schema) {
         })
         .unknown(true)
         .required(),
+      extra: joi.object().pattern(
+        joi.string(),
+        joi.object({
+          type: joi.string().required(),
+          displayName: joi.string().required(),
+          required: joi.boolean(),
+          data: joi.object(),
+        })
+      ),
     }),
   })
   runJoi(validator, schema)


### PR DESCRIPTION
## Description
Wanted to add the 'extra' field to my custom datasource but couldn't because the validation was missing.



