### PR TITLE
Fix hot reloading component plugins

### DIFF
--- a/packages/server/src/api/controllers/plugin/index.ts
+++ b/packages/server/src/api/controllers/plugin/index.ts
@@ -129,6 +129,6 @@ export async function processUploadedPlugin(
   }
 
   const doc = await plugins.storePlugin(metadata, directory, source)
-  ClientAppSocket.emit("plugins-update", { name: doc.name, hash: doc.hash })
+  ClientAppSocket.emit("plugin-update", { name: doc.name, hash: doc.hash })
   return doc
 }


### PR DESCRIPTION
## Description
This PR fixes hot reloading of component plugins. There was a regression in some of the server refactoring which changed the name of the event sent down the websocket, breaking hot reloading.



