### PR TITLE
Do not allow non-matching types for primary/foreign keys - External DB

### DIFF
--- a/packages/builder/src/components/backend/Datasources/CreateEditRelationship.svelte
+++ b/packages/builder/src/components/backend/Datasources/CreateEditRelationship.svelte
@@ -90,16 +90,13 @@
     if (inSchema(toTable, toRelate.name, originalToName)) {
       errObj.toCol = colError
     }
-    if (
-      fromPrimary &&
-      fromRelate.fieldName &&
-      plusTables.filter(table => table.name === fromTable?.name)[0]?.schema[
-        fromPrimary
-      ]?.type !==
-        plusTables.filter(table => table.name === toTable?.name)[0]?.schema[
-          fromRelate.fieldName
-        ]?.type
-    ) {
+
+    let fromType, toType
+    if (fromPrimary && fromRelate.fieldName) {
+      fromType = fromTable?.schema[fromPrimary]?.type
+      toType = toTable?.schema[fromRelate.fieldName]?.type
+    }
+    if (fromType && toType && fromType !== toType) {
       errObj.foreign =
         "Column type of the foreign key must match the primary key"
     }

--- a/packages/builder/src/components/backend/Datasources/CreateEditRelationship.svelte
+++ b/packages/builder/src/components/backend/Datasources/CreateEditRelationship.svelte
@@ -90,6 +90,19 @@
     if (inSchema(toTable, toRelate.name, originalToName)) {
       errObj.toCol = colError
     }
+    if (
+      fromPrimary &&
+      fromRelate.fieldName &&
+      plusTables.filter(table => table.name === fromTable?.name)[0]?.schema[
+        fromPrimary
+      ]?.type !==
+        plusTables.filter(table => table.name === toTable?.name)[0]?.schema[
+          fromRelate.fieldName
+        ]?.type
+    ) {
+      errObj.foreign =
+        "Column type of the foreign key must match the primary key"
+    }
     errors = errObj
   }
 


### PR DESCRIPTION
## Description
Previously you could select an Integer primary key against a Text foreign key and save successfully. This would cause issues fetching data later.
Added validation to prevent primary/foreign keys of non-matching types from being saved.

Addresses: 
- https://github.com/Budibase/budibase/issues/6847

## Screenshots
![Screenshot 2022-09-21 at 09 13 17](https://user-images.githubusercontent.com/101575380/191451579-962ddabd-51d4-499f-b68a-00f643627cdf.png)

![Screenshot 2022-09-21 at 09 13 36](https://user-images.githubusercontent.com/101575380/191451633-076578d3-7256-4a50-b012-695ae1576683.png)




