### PR TITLE
Fix for error when adding a plugin

### DIFF
--- a/packages/builder/src/stores/portal/plugins.js
+++ b/packages/builder/src/stores/portal/plugins.js
@@ -34,8 +34,7 @@ export function createPluginsStore() {
     }
 
     let res = await API.createPlugin(pluginData)
-
-    let newPlugin = res.plugins[0]
+    let newPlugin = res.plugin
     update(state => {
       const currentIdx = state.findIndex(plugin => plugin._id === newPlugin._id)
       if (currentIdx >= 0) {


### PR DESCRIPTION
## Description
The server now returns a response like `plugin: {...}` when creating a plugin, so needed to adjust the svelte store to handle this

## Address
 - https://github.com/Budibase/budibase/issues/7877