### PR TITLE
Fix/table cell attachment click propagation

### DIFF
--- a/packages/bbui/src/Table/AttachmentRenderer.svelte
+++ b/packages/bbui/src/Table/AttachmentRenderer.svelte
@@ -20,6 +20,9 @@
       target="_blank"
       download={attachment.name}
       href={attachment.url}
+      on:click={e => {
+        e.stopPropagation()
+      }}
     >
       <div class="center" title={attachment.name}>
         <img src={attachment.url} alt={attachment.extension} />
@@ -32,6 +35,9 @@
         target="_blank"
         download={attachment.name}
         href={attachment.url}
+        on:click={e => {
+          e.stopPropagation()
+        }}
       >
         {attachment.extension}
       </Link>


### PR DESCRIPTION
## Description
Minor fixe to stop event propagation when clicking on an attachment link in a table row. This avoids row selection in tables with the selection enabled.

Addresses: 
- https://github.com/Budibase/budibase/issues/7372

