### PR TITLE
Reduce websocket polling frequency and cap reconnection attemps

### DIFF
--- a/packages/client/src/websocket.js
+++ b/packages/client/src/websocket.js
@@ -18,6 +18,14 @@ export const initWebsocket = () => {
   const port = location.port || (tls ? 443 : 80)
   const socket = io(`${proto}//${host}:${port}`, {
     path: "/socket/client",
+    // Cap reconnection attempts to 10 (total of 95 seconds before giving up)
+    reconnectionAttempts: 10,
+    // Delay initial reconnection attempt by 5 seconds
+    reconnectionDelay: 5000,
+    // Then decrease to 10 second intervals
+    reconnectionDelayMax: 10000,
+    // Timeout after 5 seconds so we never stack requests
+    timeout: 5000,
   })
 
   // Event handlers


### PR DESCRIPTION
## Description
This PR reduces the frequency of polling whenever the client websocket fails to connect.

The new config limits it to:
- 10 reconnection attempts total
- 5 second initial reconnection, followed by every 10 seconds after that
- Timeout each attempt after 5 seconds to stop any request stacking

After 95 seconds total (1x5 sec reconnection attempt and 9x10 second attempts) it will give up attempting to connect and do no more requests.

Quick example showing it stopping after 10 attempts total (and timed to ensure config works):
![image](https://user-images.githubusercontent.com/9075550/191782358-6f26f825-5c5e-45fd-8b50-4dd19206b506.png)

