### PR TITLE
Feature/add icon custom datasource

### DIFF
--- a/packages/backend-core/src/plugin/utils.js
+++ b/packages/backend-core/src/plugin/utils.js
@@ -65,6 +65,7 @@ function validateDatasource(schema) {
       friendlyName: joi.string().required(),
       type: joi.string().allow(...DATASOURCE_TYPES),
       description: joi.string().required(),
+      iconUrl: joi.string().optional(),
       datasource: joi.object().pattern(joi.string(), fieldValidator).required(),
       query: joi
         .object({

--- a/packages/builder/src/components/backend/DatasourceNavigator/_components/DatasourceCard.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/_components/DatasourceCard.svelte
@@ -20,6 +20,7 @@
       this={getIcon(integrationType, schema)}
       height="20"
       width="20"
+      iconUrl={schema?.iconUrl}
     />
     <div class="text">
       <Heading size="XXS">{schema.friendlyName}</Heading>

--- a/packages/builder/src/components/backend/DatasourceNavigator/icons/UserProvided.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/icons/UserProvided.svelte
@@ -1,0 +1,7 @@
+<script>
+  export let width = "100"
+  export let height = "100"
+  export let iconUrl
+</script>
+
+<img alt="Custom datasource" src={iconUrl} {width} {height} />

--- a/packages/builder/src/components/backend/DatasourceNavigator/icons/index.js
+++ b/packages/builder/src/components/backend/DatasourceNavigator/icons/index.js
@@ -16,6 +16,7 @@ import Firebase from "./Firebase.svelte"
 import Redis from "./Redis.svelte"
 import Snowflake from "./Snowflake.svelte"
 import Custom from "./Custom.svelte"
+import UserProvided from "./UserProvided.svelte"
 
 const ICONS = {
   BUDIBASE: Budibase,
@@ -36,14 +37,17 @@ const ICONS = {
   REDIS: Redis,
   SNOWFLAKE: Snowflake,
   CUSTOM: Custom,
+  USER_PROVIDED: UserProvided,
 }
 
 export default ICONS
 
-export function getIcon(integrationType, schema) {
+export function getIcon(integrationType, schema, iconUrl) {
+  if (iconUrl || schema?.iconUrl) {
+    return ICONS.USER_PROVIDED
+  }
   if (schema?.custom || !ICONS[integrationType]) {
     return ICONS.CUSTOM
-  } else {
-    return ICONS[integrationType]
   }
+  return ICONS[integrationType]
 }


### PR DESCRIPTION
## Description
Spike for custom datasource user provided icons.
Currently just grabbing the icon image from a URL.

## Screenshots
**Plugin schema**
<img width="805" alt="Screenshot 2022-09-22 at 16 11 18" src="https://user-images.githubusercontent.com/101575380/191784963-462873aa-e457-484d-be10-2d13fdad3552.png">

**Datasource Navigator**
![Screenshot 2022-09-22 at 16 12 39](https://user-images.githubusercontent.com/101575380/191785330-0bcfb9b0-07cc-4f19-8e9c-83e6cc3002d2.png)

**Add datasource**
![Screenshot 2022-09-22 at 16 13 10](https://user-images.githubusercontent.com/101575380/191785430-bcbf6672-68bb-44f6-8dfa-dba003e53913.png)
