### PR TITLE
Allow sort type to change - Internal DB and REST query search

### DIFF
--- a/packages/frontend-core/src/fetch/DataFetch.js
+++ b/packages/frontend-core/src/fetch/DataFetch.js
@@ -136,14 +136,12 @@ export default class DataFetch {
     }
 
     // Determine what sort type to use
-    if (!this.options.sortType) {
-      let sortType = "string"
-      if (sortColumn) {
-        const type = schema?.[sortColumn]?.type
-        sortType = type === "number" ? "number" : "string"
-      }
-      this.options.sortType = sortType
+    let sortType = "string"
+    if (sortColumn) {
+      const type = schema?.[sortColumn]?.type
+      sortType = type === "number" ? "number" : "string"
     }
+    this.options.sortType = sortType
 
     // Build the lucene query
     let query = this.options.query


### PR DESCRIPTION
## Description
Sort type can change between number and string. Removed falsey check.

Addresses: 
- https://github.com/Budibase/budibase/issues/5865
- https://github.com/Budibase/budibase/issues/4804

## Screenshots
**Before**
<img width="163" alt="Screenshot 2022-09-23 at 09 34 55" src="https://user-images.githubusercontent.com/101575380/191922138-58b09242-d068-43e8-a47b-63f785461a3b.png">

**After**
<img width="163" alt="Screenshot 2022-09-23 at 09 35 43" src="https://user-images.githubusercontent.com/101575380/191922281-a642459e-70dc-4a51-8f28-ec5b4abce1a6.png">

*And can change to string sort order*
![Screenshot 2022-09-23 at 09 37 45](https://user-images.githubusercontent.com/101575380/191922636-519269b5-0398-482f-8727-18cabe0a58e2.png)

**REST query number type sorting**
![Screenshot 2022-09-23 at 09 42 49](https://user-images.githubusercontent.com/101575380/191923563-173832b0-cc47-4b7e-9f7b-2ea026f234ea.png)

