### PR TITLE
Minor fix to truncate app names and a general layout fix for smaller resolutions.

### DIFF
--- a/packages/builder/src/components/start/AppRow.svelte
+++ b/packages/builder/src/components/start/AppRow.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <div class="title" data-cy={`${app.devId}`}>
-  <div style="display: flex;">
+  <div>
     <div class="app-icon" style="color: {app.icon?.color || ''}">
       <Icon size="XL" name={app.icon?.name || "Apps"} />
     </div>
@@ -61,6 +61,11 @@
 </div>
 
 <style>
+  div.title,
+  div.title > div {
+    display: flex;
+    max-width: 100%;
+  }
   .app-row-actions {
     grid-gap: var(--spacing-s);
     display: flex;

--- a/packages/builder/src/pages/builder/portal/apps/index.svelte
+++ b/packages/builder/src/pages/builder/portal/apps/index.svelte
@@ -478,9 +478,10 @@
   .appTable :global(> div) {
     border-bottom: var(--border-light);
   }
+
   @media (max-width: 640px) {
     .appTable {
-      grid-template-columns: 1fr auto;
+      grid-template-columns: 1fr auto !important;
     }
   }
   .empty-wrapper {


### PR DESCRIPTION
Addresses: 
- https://github.com/Budibase/budibase/issues/7073
- When the screen width moves to under 640px, the grid layout is trying to account for too many columns and the app table collapses.

## Screenshots
Row name truncation 

![Screenshot 2022-09-23 at 10 35 43](https://user-images.githubusercontent.com/5913006/191936055-5e3fa452-9a2e-4583-9dc9-d6639ac29f48.png)

App layout issue at lower resolutions. Fixed as part of this ticket.

![Screenshot 2022-09-23 at 10 16 09](https://user-images.githubusercontent.com/5913006/191936142-455ac7af-1f4e-4115-88cb-043772269238.png)



