### PR TITLE
Ensure the calculations are present before attempting to build overlays.

### DIFF
--- a/packages/builder/src/components/portal/licensing/LicensingOverlays.svelte
+++ b/packages/builder/src/components/portal/licensing/LicensingOverlays.svelte
@@ -83,6 +83,18 @@
   }
 
   $: if (
+    !licensingLoaded &&
+    Object.keys($licensing?.usageMetrics).length &&
+    isEnabled(FEATURE_FLAGS.LICENSING)
+  ) {
+    licensingLoaded = true
+  }
+
+  $: if (!userLoaded && $auth.user && isEnabled(FEATURE_FLAGS.LICENSING)) {
+    userLoaded = true
+  }
+
+  $: if (
     userLoaded &&
     licensingLoaded &&
     loaded &&
@@ -95,17 +107,6 @@
   }
 
   onMount(async () => {
-    auth.subscribe(state => {
-      if (state.user && !userLoaded) {
-        userLoaded = true
-      }
-    })
-
-    licensing.subscribe(state => {
-      if (state.usageMetrics && !licensingLoaded) {
-        licensingLoaded = true
-      }
-    })
     loaded = true
   })
 </script>


### PR DESCRIPTION
## Description
Ensures that the UI waits for usage metrics to be calculated and available before determining whether or not to load licensing overlays.