### PR TITLE
Automate fixes

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -113,8 +113,9 @@
 
     // Extract all outputs from all previous steps as available bindins
     let bindings = []
+    let loopBlockCount = 0
     for (let idx = 0; idx < blockIdx; idx++) {
-      let wasLoopBlock = allSteps[idx]?.stepId === ActionStepID.LOOP
+      let wasLoopBlock = allSteps[idx - 1]?.stepId === ActionStepID.LOOP
       let isLoopBlock =
         allSteps[idx]?.stepId === ActionStepID.LOOP &&
         allSteps.find(x => x.blockToLoop === block.id)
@@ -122,7 +123,8 @@
       // If the previous block was a loop block, decerement the index so the following
       // steps are in the correct order
       if (wasLoopBlock) {
-        blockIdx--
+        loopBlockCount++
+        continue
       }
 
       let schema = allSteps[idx]?.schema?.outputs?.properties ?? {}
@@ -143,8 +145,8 @@
           let runtimeName = isLoopBlock
             ? `loop.${name}`
             : block.name.startsWith("JS")
-            ? `steps[${idx}].${name}`
-            : `steps.${idx}.${name}`
+            ? `steps[${idx - loopBlockCount}].${name}`
+            : `steps.${idx - loopBlockCount}.${name}`
           const runtime = idx === 0 ? `trigger.${name}` : runtimeName
           return {
             label: runtime,
@@ -155,7 +157,7 @@
                 ? "Trigger outputs"
                 : isLoopBlock
                 ? "Loop Outputs"
-                : `Step ${idx} outputs`,
+                : `Step ${idx - loopBlockCount} outputs`,
             path: runtime,
           }
         })
@@ -229,6 +231,7 @@
             {bindings}
             {schemaFields}
             panel={AutomationBindingPanel}
+            fillWidth
           />
         </Drawer>
       {:else if value.customType === "password"}

--- a/packages/builder/src/components/common/bindings/BindingPanel.svelte
+++ b/packages/builder/src/components/common/bindings/BindingPanel.svelte
@@ -247,7 +247,7 @@
                       return
                     }
                     hoverTarget = {
-                      title: binding.display.name || binding.fieldSchema.name,
+                      title: binding.display?.name || binding.fieldSchema.name,
                       description: binding.description,
                     }
                     popover.show()

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -27,6 +27,7 @@
   export let panel = ClientBindingPanel
   export let allowBindings = true
   export let allOr = false
+  export let fillWidth = false
 
   $: dispatch("change", filters)
   $: enrichedSchemaFields = getFields(schemaFields || [])
@@ -177,6 +178,7 @@
                   {panel}
                   {bindings}
                   on:change={event => (filter.value = event.detail)}
+                  {fillWidth}
                 />
               {:else if ["string", "longform", "number", "formula"].includes(filter.type)}
                 <Input disabled={filter.noValue} bind:value={filter.value} />

--- a/packages/server/src/automations/steps/queryRows.js
+++ b/packages/server/src/automations/steps/queryRows.js
@@ -80,7 +80,7 @@ exports.definition = {
         },
         success: {
           type: "boolean",
-          description: "Whether the deletion was successful",
+          description: "Whether the query was successful",
         },
       },
       required: ["rows", "success"],


### PR DESCRIPTION
## Description
Fixes a few automation issues. 

- Bindings were not being shown correctly when a loop block was added
- When opening the binding drawer from the filter drawer in a Query Rows step, the Panel was not the correct width.
- Some incorrect text in the queryRows automation definition that mentioned deleting of rows
- Fixed a type error that was appearing in the console when accessing the bindings drawer. 

Addresses: 
#7906 




