### PR TITLE
Support deleting license key from self host install

### DIFF
--- a/packages/builder/src/components/portal/licensing/DeleteLicenseKeyModal.svelte
+++ b/packages/builder/src/components/portal/licensing/DeleteLicenseKeyModal.svelte
@@ -1,0 +1,31 @@
+<script>
+  import { Modal, ModalContent, Body } from "@budibase/bbui"
+
+  let modal
+
+  export let onConfirm
+
+  export function show() {
+    modal.show()
+  }
+
+  export function hide() {
+    modal.hide()
+  }
+</script>
+
+<Modal bind:this={modal} on:hide={modal}>
+  <ModalContent
+    title="Confirm deletion"
+    size="S"
+    showCancelButton={true}
+    confirmText={"Confirm"}
+    {onConfirm}
+  >
+    <Body size="S">Are you sure you want to delete this license key?</Body>
+    <Body size="S">This license key cannot be re-activated.</Body>
+  </ModalContent>
+</Modal>
+
+<style>
+</style>

--- a/packages/builder/src/pages/builder/portal/manage/groups/index.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/groups/index.svelte
@@ -9,7 +9,7 @@
     Tags,
     notifications,
   } from "@budibase/bbui"
-  import { groups, auth, licensing } from "stores/portal"
+  import { groups, auth, licensing, admin } from "stores/portal"
   import { onMount } from "svelte"
   import CreateEditGroupModal from "./_components/CreateEditGroupModal.svelte"
   import UserGroupsRow from "./_components/UserGroupsRow.svelte"
@@ -53,6 +53,8 @@
 
   onMount(async () => {
     try {
+      // always load latest
+      await licensing.init()
       if ($licensing.groupsEnabled) {
         await groups.actions.init()
       }
@@ -77,7 +79,7 @@
       {/if}
     </div>
     <Body>Easily assign and manage your users access with User Groups</Body>
-    {#if !$auth.accountPortalAccess}
+    {#if !$auth.accountPortalAccess && $admin.cloud}
       <Body>Contact your account holder to upgrade</Body>
     {/if}
   </Layout>
@@ -90,7 +92,7 @@
     {:else}
       <Button
         newStyles
-        disabled={!$auth.accountPortalAccess}
+        disabled={!$auth.accountPortalAccess && $admin.cloud}
         on:click={$licensing.goToUpgradePage()}
       >
         Upgrade

--- a/packages/builder/src/pages/builder/portal/settings/upgrade.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/upgrade.svelte
@@ -13,6 +13,7 @@
   import { auth, admin } from "stores/portal"
   import { redirect } from "@roxi/routify"
   import { processStringSync } from "@budibase/string-templates"
+  import DeleteLicenseKeyModal from "../../../../components/portal/licensing/DeleteLicenseKeyModal.svelte"
   import { API } from "api"
   import { onMount } from "svelte"
 
@@ -26,6 +27,7 @@
   let licenseKeyDisabled = false
   let licenseKeyType = "text"
   let licenseKey = ""
+  let deleteLicenseKeyModal
 
   // Make sure page can't be visited directly in cloud
   $: {
@@ -40,6 +42,20 @@
       await auth.getSelf()
       await setLicenseInfo()
       notifications.success("Successfully activated")
+    } catch (e) {
+      notifications.error(e.message)
+    }
+  }
+
+  const destroy = async () => {
+    try {
+      await API.deleteLicenseKey({ licenseKey })
+      await auth.getSelf()
+      await setLicenseInfo()
+      // reset the form
+      licenseKey = ""
+      licenseKeyDisabled = false
+      notifications.success("Successfully deleted")
     } catch (e) {
       notifications.error(e.message)
     }
@@ -76,6 +92,10 @@
 </script>
 
 {#if $auth.isAdmin}
+  <DeleteLicenseKeyModal
+    bind:this={deleteLicenseKeyModal}
+    onConfirm={destroy}
+  />
   <Layout noPadding>
     <Layout gap="XS" noPadding>
       <Heading size="M">Upgrade</Heading>
@@ -109,10 +129,19 @@
           />
         </div>
       </div>
-      <div>
-        <Button cta on:click={activate} disabled={activateDisabled}
-          >Activate</Button
-        >
+      <div class="button-container">
+        <div class="action-button">
+          <Button cta on:click={activate} disabled={activateDisabled}
+            >Activate</Button
+          >
+        </div>
+        <div class="action-button">
+          {#if licenseInfo?.licenseKey}
+            <Button warning on:click={() => deleteLicenseKeyModal.show()}
+              >Delete</Button
+            >
+          {/if}
+        </div>
       </div>
     </Layout>
     <Divider size="S" />
@@ -151,5 +180,11 @@
     grid-template-columns: 100px 1fr;
     grid-gap: var(--spacing-l);
     align-items: center;
+  }
+  .action-button {
+    margin-right: 10px;
+  }
+  .button-container {
+    display: flex;
   }
 </style>

--- a/packages/frontend-core/src/api/licensing.js
+++ b/packages/frontend-core/src/api/licensing.js
@@ -10,6 +10,15 @@ export const buildLicensingEndpoints = API => ({
   },
 
   /**
+   * Delete a self hosted license key
+   */
+  deleteLicenseKey: async () => {
+    return API.delete({
+      url: `/api/global/license/info`,
+    })
+  },
+
+  /**
    * Get the license info - metadata about the license including the
    * obfuscated license key.
    */

--- a/packages/worker/src/api/controllers/global/license.ts
+++ b/packages/worker/src/api/controllers/global/license.ts
@@ -24,6 +24,11 @@ export const getInfo = async (ctx: any) => {
   ctx.status = 200
 }
 
+export const deleteInfo = async (ctx: any) => {
+  await licensing.deleteLicenseInfo()
+  ctx.status = 200
+}
+
 export const getQuotaUsage = async (ctx: any) => {
   ctx.body = await quotas.getQuotaUsage()
 }

--- a/packages/worker/src/api/routes/global/license.ts
+++ b/packages/worker/src/api/routes/global/license.ts
@@ -7,6 +7,7 @@ router
   .post("/api/global/license/activate", controller.activate)
   .post("/api/global/license/refresh", controller.refresh)
   .get("/api/global/license/info", controller.getInfo)
+  .delete("/api/global/license/info", controller.deleteInfo)
   .get("/api/global/license/usage", controller.getQuotaUsage)
 
 export = router


### PR DESCRIPTION
## Description
When an account is deleted the associated license key will also be deleted. 
To support this use case we need to be able to delete the license key from the self hosted install also. 

Also update groups upgrade UX to not disable upgrade button in self host - there is no `user.account` in self host and the sessions are detached, any user has the ability to use their API key to upgrade the installation.  

Related PR: https://github.com/Budibase/budibase-pro/pull/58

## Test Steps
Test as a part of
https://github.com/Budibase/account-portal/issues/176

## Screenshots
https://user-images.githubusercontent.com/8755148/191990305-8184e441-581a-4de3-9e28-640a9fe0456a.mov





