### PR TITLE
Qa/real couch integration tests

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -23,6 +23,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    services:
+      couchdb:
+        image: ibmcom/couchdb3
+        env:
+          COUCHDB_PASSWORD: budibase          
+          COUCHDB_USER: budibase
+        ports:
+          - 4567:5984
+
     strategy:
       matrix:
         node-version: [14.x]
@@ -52,13 +61,6 @@ jobs:
         files: ./packages/server/coverage/clover.xml
         name: codecov-umbrella
         verbose: true 
-
-    # TODO: parallelise this
-    - name: Cypress run
-      uses: cypress-io/github-action@v2
-      with:
-        install: false
-        command: yarn test:e2e:ci
 
     - name: QA Core Integration Tests
       run: | 

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -51,16 +51,16 @@ jobs:
     - run: yarn bootstrap
     - run: yarn lint
     - run: yarn build
-    - run: yarn test
-      env:
-        CI: true
-        name: Budibase CI
-    - uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-        files: ./packages/server/coverage/clover.xml
-        name: codecov-umbrella
-        verbose: true 
+    # - run: yarn test
+    #   env:
+    #     CI: true
+    #     name: Budibase CI
+    # - uses: codecov/codecov-action@v1
+    #   with:
+    #     token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+    #     files: ./packages/server/coverage/clover.xml
+    #     name: codecov-umbrella
+    #     verbose: true 
 
     - name: QA Core Integration Tests
       run: | 

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -27,7 +27,7 @@ jobs:
       couchdb:
         image: ibmcom/couchdb3
         env:
-          COUCHDB_PASSWORD: budibase          
+          COUCHDB_PASSWORD: budibase
           COUCHDB_USER: budibase
         ports:
           - 4567:5984

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -51,16 +51,16 @@ jobs:
     - run: yarn bootstrap
     - run: yarn lint
     - run: yarn build
-    # - run: yarn test
-    #   env:
-    #     CI: true
-    #     name: Budibase CI
-    # - uses: codecov/codecov-action@v1
-    #   with:
-    #     token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-    #     files: ./packages/server/coverage/clover.xml
-    #     name: codecov-umbrella
-    #     verbose: true 
+    - run: yarn test
+      env:
+        CI: true
+        name: Budibase CI
+    - uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+        files: ./packages/server/coverage/clover.xml
+        name: codecov-umbrella
+        verbose: true 
 
     - name: QA Core Integration Tests
       run: | 

--- a/packages/builder/cypress/setup.js
+++ b/packages/builder/cypress/setup.js
@@ -1,16 +1,14 @@
 const cypressConfig = require("../cypress.json")
-const path = require("path")
-
-const tmpdir = path.join(require("os").tmpdir(), ".budibase")
 
 // normal development system
 const SERVER_PORT = cypressConfig.env.PORT
 const WORKER_PORT = cypressConfig.env.WORKER_PORT
 
-process.env.NODE_ENV = "cypress"
+if (!process.env.NODE_ENV) {
+  process.env.NODE_ENV = "cypress"
+}
 process.env.ENABLE_ANALYTICS = "0"
 process.env.JWT_SECRET = cypressConfig.env.JWT_SECRET
-process.env.COUCH_URL = `leveldb://${tmpdir}/.data/`
 process.env.SELF_HOSTED = 1
 process.env.WORKER_URL = `http://localhost:${WORKER_PORT}/`
 process.env.APPS_URL = `http://localhost:${SERVER_PORT}/`

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -1,5 +1,5 @@
 const core = require("@budibase/backend-core")
-// const env = require("../environment")
+const env = require("../environment")
 
 exports.init = () => {
   const dbConfig = {
@@ -7,10 +7,10 @@ exports.init = () => {
     find: true,
   }
 
-  // if (env.isTest()) {
-  //   dbConfig.inMemory = true
-  //   dbConfig.allDbs = true
-  // }
+  if (env.isTest() && !env.COUCH_DB_URL) {
+    dbConfig.inMemory = true
+    dbConfig.allDbs = true
+  }
 
   core.init({ db: dbConfig })
 }

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -1,5 +1,5 @@
 const core = require("@budibase/backend-core")
-const env = require("../environment")
+// const env = require("../environment")
 
 exports.init = () => {
   const dbConfig = {
@@ -7,10 +7,10 @@ exports.init = () => {
     find: true,
   }
 
-  if (env.isTest()) {
-    dbConfig.inMemory = true
-    dbConfig.allDbs = true
-  }
+  // if (env.isTest()) {
+  //   dbConfig.inMemory = true
+  //   dbConfig.allDbs = true
+  // }
 
   core.init({ db: dbConfig })
 }

--- a/packages/worker/src/db/index.js
+++ b/packages/worker/src/db/index.js
@@ -1,11 +1,11 @@
 const core = require("@budibase/backend-core")
-// const env = require("../environment")
+const env = require("../environment")
 
 exports.init = () => {
   const dbConfig = {}
-  // if (env.isTest()) {
-  //   dbConfig.inMemory = true
-  //   dbConfig.allDbs = true
-  // }
+  if (env.isTest() && !env.COUCH_DB_URL) {
+    dbConfig.inMemory = true
+    dbConfig.allDbs = true
+  }
   core.init({ db: dbConfig })
 }

--- a/packages/worker/src/db/index.js
+++ b/packages/worker/src/db/index.js
@@ -1,11 +1,11 @@
 const core = require("@budibase/backend-core")
-const env = require("../environment")
+// const env = require("../environment")
 
 exports.init = () => {
   const dbConfig = {}
-  if (env.isTest()) {
-    dbConfig.inMemory = true
-    dbConfig.allDbs = true
-  }
+  // if (env.isTest()) {
+  //   dbConfig.inMemory = true
+  //   dbConfig.allDbs = true
+  // }
   core.init({ db: dbConfig })
 }

--- a/qa-core/.env
+++ b/qa-core/.env
@@ -2,3 +2,5 @@ BB_ADMIN_USER_EMAIL=qa@budibase.com
 BB_ADMIN_USER_PASSWORD=budibase
 ENCRYPTED_TEST_PUBLIC_API_KEY=a65722f06bee5caeadc5d7ca2f543a43-d610e627344210c643bb726f
 COUCH_DB_URL=http://budibase:budibase@localhost:4567
+COUCH_DB_USER=budibase
+COUCH_DB_PASSWORD=budibase

--- a/qa-core/.env
+++ b/qa-core/.env
@@ -1,3 +1,4 @@
 BB_ADMIN_USER_EMAIL=qa@budibase.com
 BB_ADMIN_USER_PASSWORD=budibase
 ENCRYPTED_TEST_PUBLIC_API_KEY=a65722f06bee5caeadc5d7ca2f543a43-d610e627344210c643bb726f
+COUCH_DB_URL=http://budibase:budibase@localhost:4567

--- a/qa-core/docker-compose.yaml
+++ b/qa-core/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: "3.8"
+services:
+  qa-core-couchdb:
+    # platform: linux/amd64
+    container_name: budi-couchdb-qa
+    restart: on-failure
+    image: ibmcom/couchdb3
+    environment:
+      - COUCHDB_PASSWORD=${COUCH_DB_PASSWORD}
+      - COUCHDB_USER=${COUCH_DB_USER}
+    ports:
+      - "4567:5984"

--- a/qa-core/package.json
+++ b/qa-core/package.json
@@ -12,7 +12,9 @@
     "test": "jest --runInBand",
     "test:watch": "jest --watch",
     "test:debug": "DEBUG=1 jest",
-    "api:server:setup": "env-cmd ts-node ../packages/builder/cypress/ts/setup.ts",
+    "docker:up": "docker-compose up -d",
+    "docker:down": "docker-compose down",
+    "api:server:setup": "npm run docker:up && env-cmd ts-node ../packages/builder/cypress/ts/setup.ts",
     "api:server:setup:ci": "env-cmd node ../packages/builder/cypress/setup.js",
     "api:test:ci": "start-server-and-test api:server:setup:ci http://localhost:4100/builder test",
     "api:test": "start-server-and-test api:server:setup http://localhost:4100/builder test"

--- a/qa-core/src/tests/public-api/tables/rows.spec.ts
+++ b/qa-core/src/tests/public-api/tables/rows.spec.ts
@@ -41,6 +41,7 @@ describe("Public API - /rows endpoints", () => {
       },
     })
     expect(response).toHaveStatusCode(200)
+    expect(rows.length).toEqual(1)
     expect(rows[0]._id).toEqual(config.context._id)
     expect(rows[0].tableId).toEqual(config.context.tableId)
     expect(rows[0].testColumn).toEqual(config.context.testColumn)


### PR DESCRIPTION
## Description
Due to the inability for us to test things like search, this PR introduces running a real couchDB for testing against in CI. I've made use of the `services` key in github actions, which allows you to spin up some docker containers for testing.

Don't merge this please - I'm just trying to test end to end to get it working in CI, and there's some commented code there that will affect cypress and the other tests. 

Also removes the cypress run from CI - which should reduce build times. This test will be covered with API tests anyway, and the work QA wolf is doing will provide further coverage.

Addresses: 
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._



