### PR TITLE
Minor change to floor usage metrics to avoid misleading 100 quota messages

### DIFF
--- a/packages/builder/src/components/portal/licensing/DayPassWarningModal.svelte
+++ b/packages/builder/src/components/portal/licensing/DayPassWarningModal.svelte
@@ -12,7 +12,10 @@
 
   $: daysRemaining = $licensing.quotaResetDaysRemaining
   $: quotaResetDate = $licensing.quotaResetDate
-  $: dayPassesUsed = $licensing.usageMetrics?.dayPasses
+  $: dayPassesUsed =
+    $licensing.usageMetrics?.dayPasses > 100
+      ? 100
+      : $licensing.usageMetrics?.dayPasses
   $: dayPassesTitle =
     dayPassesUsed >= 100
       ? "You have run out of Day Passes"

--- a/packages/builder/src/stores/portal/licensing.js
+++ b/packages/builder/src/stores/portal/licensing.js
@@ -87,7 +87,7 @@ export const createLicensingStore = () => {
           return keys.reduce((acc, key) => {
             const quotaLimit = license[key].value
             const quotaUsed = (quota[key] / quotaLimit) * 100
-            acc[key] = quotaLimit > -1 ? Math.round(quotaUsed) : -1
+            acc[key] = quotaLimit > -1 ? Math.floor(quotaUsed) : -1
             return acc
           }, {})
         }


### PR DESCRIPTION
## Description
In scenarios where quotas had reached the top end of a large quota e.g. 4995/5000, banners and messaging would report at 100%. This fix simply floors the metrics to avoid it. 
Also ensuring that the quota display in the day pass modal caps at 100%
