### PR TITLE
Always try to migrate navigation settings when importing apps

### DIFF
--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -304,7 +304,7 @@ const performAppCreate = async (ctx: any) => {
     })
 
     // Migrate navigation settings and screens if required
-    if (existing && !existing.navigation) {
+    if (existing) {
       const navigation = await migrateAppNavigation()
       if (navigation) {
         newApplication.navigation = navigation
@@ -601,7 +601,7 @@ const migrateAppNavigation = async () => {
   // Migrate all screens, removing custom layouts
   for (let screen of screens) {
     if (!screen.layoutId) {
-      return
+      continue
     }
     const layout = layouts.find(layout => layout._id === screen.layoutId)
     screen.layoutId = undefined
@@ -615,7 +615,7 @@ const migrateAppNavigation = async () => {
   const layout = layouts?.find(
     (layout: Layout) => layout._id === BASE_LAYOUT_PROP_IDS.PRIVATE
   )
-  if (layout) {
+  if (layout && !existing.navigation) {
     let navigationSettings: any = {
       navigation: "Top",
       title: name,


### PR DESCRIPTION
## Description
This PR updates app import to always attempt to migrate navigation settings and detach custom layouts, even if navigation settings have already been migrated.

This ensures that an edge case of the following:
- An old app was exported prior to the new design UI (before July 2022)
- This app was imported after the new design UI, but before the feature was added to automatically migrate navigation settings
- This app was not manually migrated, or only partially migrated manually
- This app was then exported again, and imported again
- This app was now not being migrated upon import, as navigation settings already exist

This PR will always attempt to migrate navigation settings (if required, without overwriting existing ones) and also always check for screens which need detached from custom layouts.

Addresses: 
- https://github.com/Budibase/budibase/issues/7966
