### PR TITLE
Minor update replacing upgrade terminology for billing notifications

### DIFF
--- a/packages/builder/src/components/portal/licensing/AccountDowngradedModal.svelte
+++ b/packages/builder/src/components/portal/licensing/AccountDowngradedModal.svelte
@@ -8,7 +8,7 @@
   let accountDowngradeModal
 
   $: accountUrl = $admin.accountPortalUrl
-  $: upgradeUrl = `${accountUrl}/portal/upgrade`
+  $: billingUrl = `${accountUrl}/portal/billing`
 
   export function show() {
     accountDowngradeModal.show()
@@ -24,10 +24,10 @@
     title="Your account is now on the Free plan"
     size="M"
     showCancelButton={$auth.user.accountPortalAccess}
-    confirmText={$auth.user.accountPortalAccess ? "Upgrade" : "Confirm"}
+    confirmText={$auth.user.accountPortalAccess ? "Billing" : "Confirm"}
     onConfirm={$auth.user.accountPortalAccess
       ? () => {
-          window.location.href = upgradeUrl
+          window.location.href = billingUrl
         }
       : null}
   >
@@ -35,7 +35,9 @@
       The payment for your subscription has failed and we have downgraded your
       account to the <span class="free-plan">Free plan</span>.
     </Body>
-    <Body>Upgrade to restore full functionality.</Body>
+    <Body>
+      Please update your billing details to restore full functionality.
+    </Body>
     {#if !$auth.user.accountPortalAccess}
       <Body>Please contact the account holder to upgrade.</Body>
     {/if}

--- a/packages/builder/src/components/portal/licensing/PaymentFailedModal.svelte
+++ b/packages/builder/src/components/portal/licensing/PaymentFailedModal.svelte
@@ -11,7 +11,7 @@
 
   const paymentFailedTitle = "Payment failed"
   $: accountUrl = $admin.accountPortalUrl
-  $: upgradeUrl = `${accountUrl}/portal/upgrade`
+  $: billingUrl = `${accountUrl}/portal/billing`
 
   export function show() {
     paymentFailedModal.show()
@@ -33,14 +33,14 @@
     <ModalContent
       title={paymentFailedTitle}
       size="M"
-      confirmText="Upgrade"
+      confirmText="Billing"
       onConfirm={() => {
-        window.location.href = upgradeUrl
+        window.location.href = billingUrl
       }}
     >
       <Body>The payment for your subscription has failed</Body>
       <Body>
-        Please upgrade your billing details before your account gets downgraded
+        Please update your billing details before your account gets downgraded
         to the free plan
       </Body>
       <Body weight={800}>

--- a/packages/builder/src/components/portal/licensing/licensingBanners.js
+++ b/packages/builder/src/components/portal/licensing/licensingBanners.js
@@ -10,15 +10,31 @@ const defaultCacheFn = key => {
   temporalStore.actions.setExpiring(key, {}, oneDayInSeconds)
 }
 
-const defaultAction = key => {
+const upgradeAction = key => {
+  return defaultNavigateAction(
+    key,
+    "Upgrade Plan",
+    `${get(admin).accountPortalUrl}/portal/upgrade`
+  )
+}
+
+const billingAction = key => {
+  return defaultNavigateAction(
+    key,
+    "Billing",
+    `${get(admin).accountPortalUrl}/portal/billing`
+  )
+}
+
+const defaultNavigateAction = (key, actionText, url) => {
   if (!get(auth).user.accountPortalAccess) {
     return {}
   }
   return {
-    extraButtonText: "Upgrade Plan",
+    extraButtonText: actionText,
     extraButtonAction: () => {
       defaultCacheFn(key)
-      window.location.href = `${get(admin).accountPortalUrl}/portal/upgrade`
+      window.location.href = url
     },
   }
 }
@@ -65,7 +81,7 @@ const buildUsageInfoBanner = (
     ? bannerConfig
     : {
         ...bannerConfig,
-        ...defaultAction(cacheKey),
+        ...upgradeAction(cacheKey),
       }
 }
 
@@ -84,7 +100,7 @@ const buildDayPassBanner = () => {
           ? ""
           : "Please contact your account holder to upgrade."
       }`,
-      ...defaultAction(),
+      ...upgradeAction(),
       showCloseButton: false,
     }
   }
@@ -115,11 +131,11 @@ const buildPaymentFailedBanner = () => {
     criteria: () => {
       return get(licensing)?.accountPastDue && !get(licensing).isFreePlan
     },
-    message: `Payment Failed - Please update your billing details or your account will be downgrades in 
+    message: `Payment Failed - Please update your billing details or your account will be downgraded in 
     ${get(licensing)?.pastDueDaysRemaining} day${
       get(licensing)?.pastDueDaysRemaining == 1 ? "" : "s"
     }`,
-    ...defaultAction(),
+    ...billingAction(),
     showCloseButton: false,
     tooltip: get(licensing).pastDueEndDate,
   }


### PR DESCRIPTION
## Description
Terminology updated when displaying notifications relation to payments failing and a customers account being downgraded. In both scenarios the customer will be directed to go to `/portal/billing` instead of `/portal/upgrade`

## Screenshots
Account downgraded

![Screenshot 2022-09-26 at 14 05 42](https://user-images.githubusercontent.com/5913006/192284707-4a5cef82-80d2-4550-b62a-6e777895a7a3.png)

Payment Failed
![Screenshot 2022-09-26 at 14 06 44](https://user-images.githubusercontent.com/5913006/192284802-d038e348-cff5-4f95-9dab-43e7c4255f5e.png)
