### PR TITLE
Fix issues with multi tenant app IDs in groups UI

### DIFF
--- a/packages/builder/src/pages/builder/portal/manage/groups/[groupId].svelte
+++ b/packages/builder/src/pages/builder/portal/manage/groups/[groupId].svelte
@@ -42,7 +42,7 @@
   $: group = $groups.find(x => x._id === groupId)
   $: filtered = $users.data
   $: groupApps = $apps.filter(app =>
-    groups.actions.getGroupAppIds(group).includes(`app_${app.appId}`)
+    groups.actions.getGroupAppIds(group).includes(apps.getProdAppID(app.appId))
   )
   $: {
     if (loaded && !group?._id) {
@@ -70,7 +70,7 @@
   }
 
   const getRoleLabel = appId => {
-    const roleId = group?.roles?.[`app_${appId}`]
+    const roleId = group?.roles?.[apps.getProdAppID(appId)]
     const role = $roles.find(x => x._id === roleId)
     return role?.name || "Custom role"
   }
@@ -197,7 +197,7 @@
                 <StatusLight
                   square
                   color={RoleUtils.getRoleColour(
-                    group.roles[`app_${app.appId}`]
+                    group.roles[apps.getProdAppID(app.appId)]
                   )}
                 >
                   {getRoleLabel(app.appId)}

--- a/packages/builder/src/pages/builder/portal/overview/_components/AssignmentModal.svelte
+++ b/packages/builder/src/pages/builder/portal/overview/_components/AssignmentModal.svelte
@@ -39,7 +39,6 @@
   $: fixedAppId = apps.getProdAppID(app.devId)
   $: availableUsers = getAvailableUsers($usersFetch.rows, appUsers, data)
   $: availableGroups = getAvailableGroups($groups, app.appId, search, data)
-  $: console.log(availableGroups)
   $: valid = data?.length && !data?.some(x => !x.id?.length || !x.role?.length)
   $: optionSections = {
     ...($licensing.groupsEnabled &&
@@ -115,7 +114,7 @@
     return (allGroups || []).filter(group => {
       // Filter out assigned groups
       const appIds = groups.actions.getGroupAppIds(group)
-      if (appIds.includes(`app_${appId}`)) {
+      if (appIds.includes(apps.getProdAppID(appId))) {
         return false
       }
 


### PR DESCRIPTION
## Description
This PR fixes a couple of issues with the groups UI which were only happening in multi tenant environments, due to app ID structure being different.

Fixes:
- Group details pages always says "no apps assigned"
- Role colours not being accurate (if apps were appearing)
- Already assigned user groups not being filtered out in group assignment modal
- Remove console log

Caught by @MihailHadzhiev2022 :+1: 




