### PR TITLE
Fix cypress accountPortals.spec

### DIFF
--- a/packages/builder/src/pages/builder/apps/index.svelte
+++ b/packages/builder/src/pages/builder/apps/index.svelte
@@ -133,7 +133,7 @@
             </Body>
           </Layout>
           <Divider />
-          {#if $licensing.usageMetrics.dayPasses >= 100}
+          {#if $licensing.usageMetrics?.dayPasses >= 100}
             <div>
               <Layout gap="S" justifyItems="center">
                 <img class="spaceman" alt="spaceman" src={Spaceman} />


### PR DESCRIPTION
## Description
- Fix for failing cypress test
- Add optional chaining to `$licensing.usageMetrics?.dayPasses` when loading the user portal




