### PR TITLE
Use CDN when fetching plugins in cloud

### DIFF
--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -16,6 +16,7 @@
     themeStore,
     appStore,
     devToolsStore,
+    environmentStore,
   } from "stores"
   import NotificationDisplay from "components/overlay/NotificationDisplay.svelte"
   import ConfirmationDisplay from "components/overlay/ConfirmationDisplay.svelte"
@@ -47,6 +48,8 @@
     !$builderStore.inBuilder &&
     $devToolsStore.enabled &&
     !$routeStore.queryParams?.peek
+  $: objectStoreUrl = $environmentStore.cloud ? "https://cdn.budi.live" : ""
+  $: pluginsUrl = `${objectStoreUrl}/plugins`
 
   // Handle no matching route
   $: {
@@ -92,7 +95,8 @@
 <svelte:head>
   {#if $builderStore.usedPlugins?.length}
     {#each $builderStore.usedPlugins as plugin (plugin.hash)}
-      <script src={`/plugins/${plugin.jsUrl}?r=${plugin.hash || ""}`}></script>
+      <script
+        src={`${pluginsUrl}/${plugin.jsUrl}?r=${plugin.hash || ""}`}></script>
     {/each}
   {/if}
 </svelte:head>


### PR DESCRIPTION
## Description
PR from @aptkingston to enable budi CDN support for production setups in S3. I'll run a migration once this is merged to nest all the existing plugins under the `/plugins` directory.

Addresses: 
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._



