### PR TITLE
Allow screen redirect after modal close

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/CloseScreenModal.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/CloseScreenModal.svelte
@@ -1,16 +1,31 @@
 <script>
-  import { Body } from "@budibase/bbui"
+  import { Label, Body } from "@budibase/bbui"
+  import DrawerBindableInput from "components/common/bindings/DrawerBindableInput.svelte"
+
+  export let parameters
+  export let bindings = []
 </script>
 
+<Body size="S">Navigate To screen, or leave blank.</Body>
+<br />
 <div class="root">
-  <Body size="S">This action doesn't require any additional settings.</Body>
-  <Body size="S">
-    This action won't do anything if there isn't a screen modal open.
-  </Body>
+  <Label small>Screen</Label>
+  <DrawerBindableInput
+    title="Destination URL"
+    placeholder="/screen"
+    value={parameters.url}
+    on:change={value => (parameters.url = value.detail)}
+    {bindings}
+  />
 </div>
 
 <style>
   .root {
+    display: grid;
+    align-items: center;
+    gap: var(--spacing-m);
+    grid-template-columns: auto 1fr;
+    max-width: 400px;
     margin: 0 auto;
   }
 </style>

--- a/packages/client/src/components/overlay/PeekScreenDisplay.svelte
+++ b/packages/client/src/components/overlay/PeekScreenDisplay.svelte
@@ -45,6 +45,9 @@
       },
       [MessageTypes.CLOSE_SCREEN_MODAL]: () => {
         peekStore.actions.hidePeek()
+        if (message.data?.url) {
+          routeStore.actions.navigate(message.data.url)
+        }
       },
       [MessageTypes.INVALIDATE_DATASOURCE]: () => {
         proxyInvalidation(message.data)

--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -226,28 +226,9 @@ const changeFormStepHandler = async (action, context) => {
 
 const closeScreenModalHandler = action => {
   let { url } = action.parameters
-  if (url) {
-    window.parent.addEventListener("message", event => {
-      const location = event.target.location
-      //remove any trailing slash
-      if (url.charAt(url.length - 1) === "/") {
-        url = url.substring(0, url.length - 1)
-      }
-      //need to reload if hash route has not changed
-      let shouldReload =
-        `#${url.substring(0, url.lastIndexOf("/"))}` ===
-        location.hash?.substring(0, location.hash.lastIndexOf("/"))
-
-      window.parent.location.href = `${location.origin}${location.pathname}#${url}`
-      if (shouldReload) {
-        window.parent.location.reload()
-      }
-    })
-  }
-
   // Emit this as a window event, so parent screens which are iframing us in
   // can close the modal
-  window.parent.postMessage({ type: "close-screen-modal" })
+  window.parent.postMessage({ type: "close-screen-modal", url })
 }
 
 const updateStateHandler = action => {

--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -224,7 +224,27 @@ const changeFormStepHandler = async (action, context) => {
   )
 }
 
-const closeScreenModalHandler = () => {
+const closeScreenModalHandler = action => {
+  let { url } = action.parameters
+  if (url) {
+    window.parent.addEventListener("message", event => {
+      const location = event.target.location
+      //remove any trailing slash
+      if (url.charAt(url.length - 1) === "/") {
+        url = url.substring(0, url.length - 1)
+      }
+      //need to reload if hash route has not changed
+      let shouldReload =
+        `#${url.substring(0, url.lastIndexOf("/"))}` ===
+        location.hash?.substring(0, location.hash.lastIndexOf("/"))
+
+      window.parent.location.href = `${location.origin}${location.pathname}#${url}`
+      if (shouldReload) {
+        window.parent.location.reload()
+      }
+    })
+  }
+
   // Emit this as a window event, so parent screens which are iframing us in
   // can close the modal
   window.parent.postMessage({ type: "close-screen-modal" })


### PR DESCRIPTION
## Description
Some scenarios require screen navigation after modal close. 

For example: updating a form field in the parent window from a modal screen via URL variable. (App state can't be used in this scenario). Use case here: https://github.com/Budibase/budibase/discussions/6181

I couldn't get the navigation to work through the routeStore. I think it's because the router, even after the modal is closed, is still in the context of the "peeked" screen. That's why I'm setting the `location.href` of the parent window. 

Addresses: 
- https://github.com/Budibase/budibase/issues/5629

## Screenshots
**No screen**
<img width="915" alt="Screenshot 2022-09-28 at 14 07 10" src="https://user-images.githubusercontent.com/101575380/192786344-dbb8a9b4-6206-4169-b8a6-a2c45f37faaf.png">
![modal](https://user-images.githubusercontent.com/101575380/192786494-5e545212-5b50-434d-89da-c3953684a9a1.gif)

**Different screen**
<img width="915" alt="Screenshot 2022-09-28 at 14 09 18" src="https://user-images.githubusercontent.com/101575380/192786771-56850ad5-b0ce-4b10-b619-90d688a5c596.png">
![modal](https://user-images.githubusercontent.com/101575380/192786876-adf2ad37-be33-4e0d-b053-277a9d8fb324.gif)

**Reload same screen**
<img width="915" alt="Screenshot 2022-09-28 at 14 10 33" src="https://user-images.githubusercontent.com/101575380/192787026-a57861ec-1e6a-42ed-bf3b-ebc5e1b652bd.png">
![modal](https://user-images.githubusercontent.com/101575380/192787117-4b359d51-efb4-4ec4-bff5-6903b015c652.gif)
