### PR TITLE
Allow removing custom datasource CRUD operations

### DIFF
--- a/packages/backend-core/src/plugin/utils.js
+++ b/packages/backend-core/src/plugin/utils.js
@@ -67,12 +67,8 @@ function validateDatasource(schema) {
       description: joi.string().required(),
       datasource: joi.object().pattern(joi.string(), fieldValidator).required(),
       query: joi
-        .object({
-          create: queryValidator,
-          read: queryValidator,
-          update: queryValidator,
-          delete: queryValidator,
-        })
+        .object()
+        .pattern(joi.string(), queryValidator)
         .unknown(true)
         .required(),
       extra: joi.object().pattern(


### PR DESCRIPTION
## Description
As the title says - this is a valid configuration that the validator didn't allow - i've confirmed it doesn't break anything, Budibase can handle this fully. Also this means that custom datasource query verbs are correctly validated.