### PR TITLE
Minor Smoke Build Changes

### DIFF
--- a/packages/builder/cypress/integration/adminAndManagement/userManagement.spec.js
+++ b/packages/builder/cypress/integration/adminAndManagement/userManagement.spec.js
@@ -20,7 +20,9 @@ filterTests(["smoke", "all"], () => {
       cy.get(".spectrum-Form-itemField").eq(3).should('contain', 'App User')
 
       // User should not have app access
-      cy.get(interact.LIST_ITEMS, { timeout: 500 }).should("contain", "No apps")
+      cy.get(".spectrum-Heading").contains("Apps").parent().within(() => {
+        cy.get(interact.LIST_ITEMS, { timeout: 500 }).should("contain", "This user has access to no apps")
+      })
     })
 
     if (Cypress.env("TEST_ENV")) {

--- a/packages/builder/cypress/integration/autoScreensUI.spec.js
+++ b/packages/builder/cypress/integration/autoScreensUI.spec.js
@@ -54,6 +54,7 @@ filterTests(['smoke', 'all'], () => {
       cy.createDatasourceScreen([initialTable, secondTable])
       // Confirm screens have been auto generated
       // Previously generated tables are suffixed with numbers - as expected
+      cy.wait(1000)
       cy.get(interact.BODY).should('contain', 'cypress-tests-2')
         .and('contain', 'cypress-tests-2/:id')
         .and('contain', 'cypress-tests-2/new/row')


### PR DESCRIPTION
A few changes to maintain what we have for the nightly smoke build

autoScreensUI
- Adding a 1 second wait. This seems essential now for the smoke run on CI. Was difficult to reduce the error locally but definitely timing related

userManagement
- Reworking how we confirm a user has no applications
- The text has also changed - updated it too





