### PR TITLE
AAS enable app service storage

### DIFF
--- a/hosting/scripts/build-target-paths.sh
+++ b/hosting/scripts/build-target-paths.sh
@@ -4,6 +4,7 @@ echo ${TARGETBUILD} > /buildtarget.txt
 if [[ "${TARGETBUILD}" = "aas" ]]; then
     # Azure AppService uses /home for persisent data & SSH on port 2222
     DATA_DIR=/home
+    WEBSITES_ENABLE_APP_SERVICE_STORAGE=true
     mkdir -p $DATA_DIR/{search,minio,couch}
     mkdir -p $DATA_DIR/couch/{dbs,views}
     chown -R couchdb:couchdb $DATA_DIR/couch/

--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -19,6 +19,7 @@ declare -a DOCKER_VARS=("APP_PORT" "APPS_URL" "ARCHITECTURE" "BUDIBASE_ENVIRONME
 # Azure App Service customisations
 if [[ "${TARGETBUILD}" = "aas" ]]; then
     DATA_DIR=/home
+    WEBSITES_ENABLE_APP_SERVICE_STORAGE=true
     /etc/init.d/ssh start
 else
     DATA_DIR=${DATA_DIR:-/data}


### PR DESCRIPTION
## Description
As per [discussion](https://github.com/Budibase/budibase/discussions/5886#discussioncomment-3770091) it appears as though the default for WEBSITES_ENABLE_APP_SERVICE_STORAGE is false. So attempting to set this variable so that it is true when the container service runs it. 
Hopefully this helps get closer to the Minio issue described by PekkaJalonen




