### PR TITLE
Fetch environment info early in the client app initialisation process

### DIFF
--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -1,5 +1,11 @@
 import ClientApp from "./components/ClientApp.svelte"
-import { componentStore, builderStore, appStore, devToolsStore } from "./stores"
+import {
+  componentStore,
+  builderStore,
+  appStore,
+  devToolsStore,
+  environmentStore,
+} from "./stores"
 import loadSpectrumIcons from "@budibase/bbui/spectrum-icons-rollup.js"
 import { get } from "svelte/store"
 import { initWebsocket } from "./websocket.js"
@@ -15,7 +21,7 @@ loadSpectrumIcons()
 
 let app
 
-const loadBudibase = () => {
+const loadBudibase = async () => {
   // Update builder store with any builder flags
   builderStore.set({
     inBuilder: !!window["##BUDIBASE_IN_BUILDER##"],
@@ -35,6 +41,9 @@ const loadBudibase = () => {
   // Set app ID - this window flag is set by both the preview and the real
   // server rendered app HTML
   appStore.actions.setAppId(window["##BUDIBASE_APP_ID##"])
+
+  // Fetch environment info
+  await environmentStore.actions.fetchEnvironment()
 
   // Enable dev tools or not. We need to be using a dev app and not inside
   // the builder preview to enable them.

--- a/packages/client/src/stores/initialise.js
+++ b/packages/client/src/stores/initialise.js
@@ -1,9 +1,7 @@
 import { routeStore } from "./routes"
 import { appStore } from "./app"
-import { environmentStore } from "./environment"
 
 export async function initialise() {
   await routeStore.actions.fetchRoutes()
   await appStore.actions.fetchAppDefinition()
-  await environmentStore.actions.fetchEnvironment()
 }


### PR DESCRIPTION
## Description
This PR fixes a couple of issues in cloud. Currently there is a race condition which means that plugin bundle URLs and the plugin websocket are both not correctly used if the environment information has not been properly loaded, which is usually has not.

This PR fetches the env info early in the client initialisation, allowing those depdendent features to be properly aware of their environment.




