### PR TITLE
Don't return raw query from query execution endpoint - only from preview

### DIFF
--- a/packages/server/src/api/controllers/query/index.ts
+++ b/packages/server/src/api/controllers/query/index.ts
@@ -235,6 +235,10 @@ async function execute(
       })
 
     const { rows, pagination, extra } = await quotas.addQuery(runFn)
+    // remove the raw from execution incase transformer being used to hide data
+    if (extra?.raw) {
+      delete extra.raw
+    }
     if (opts && opts.rowsOnly) {
       ctx.body = rows
     } else {


### PR DESCRIPTION
## Description
Minor fix for #8056 - don't return the raw data for the main query execution - but still return for the builder preview. Useful if you want to use the transformer to limit what data a user can see.