### PR TITLE
OracleDB development machine fix

### DIFF
--- a/packages/server/src/integrations/index.ts
+++ b/packages/server/src/integrations/index.ts
@@ -57,7 +57,11 @@ const INTEGRATIONS: { [key: string]: any } = {
 }
 
 // optionally add oracle integration if the oracle binary can be installed
-if (process.arch && !process.arch.startsWith("arm")) {
+if (
+  process.arch &&
+  !process.arch.startsWith("arm") &&
+  oracle.integration.isInstalled()
+) {
   DEFINITIONS[SourceName.ORACLE] = oracle.schema
   INTEGRATIONS[SourceName.ORACLE] = oracle.integration
 }

--- a/packages/server/src/integrations/oracle.ts
+++ b/packages/server/src/integrations/oracle.ts
@@ -15,17 +15,22 @@ import {
   getSqlQuery,
   SqlClient,
 } from "./utils"
-import oracledb, {
+import Sql from "./base/sql"
+import { FieldTypes } from "../constants"
+import {
   BindParameters,
   Connection,
   ConnectionAttributes,
   ExecuteOptions,
   Result,
 } from "oracledb"
-import Sql from "./base/sql"
-import { FieldTypes } from "../constants"
-
-oracledb.outFormat = oracledb.OUT_FORMAT_OBJECT
+let oracledb: any
+try {
+  oracledb = require("oracledb")
+  oracledb.outFormat = oracledb.OUT_FORMAT_OBJECT
+} catch (err) {
+  console.log("ORACLEDB is not installed")
+}
 
 interface OracleConfig {
   host: string
@@ -181,6 +186,10 @@ class OracleIntegration extends Sql implements DatasourcePlus {
 
   getStringConcat(parts: string[]): string {
     return parts.join(" || ")
+  }
+
+  static isInstalled() {
+    return oracledb != null
   }
 
   /**


### PR DESCRIPTION
## Description
Quick fix for development machines, when running Budibase development stack on systems that are not oracle compatible it would fail to start due to the lack of dependency.