### PR TITLE
Send more logs to stdout

### DIFF
--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -61,8 +61,8 @@ ADD hosting/single/nginx/nginx.conf /etc/nginx
 ADD hosting/single/nginx/nginx-default-site.conf /etc/nginx/sites-enabled/default
 RUN mkdir -p /var/log/nginx && \
   touch /var/log/nginx/error.log && \
-  touch /var/run/nginx.pid
-
+  touch /var/run/nginx.pid && \
+  usermod -a -G tty www-data
 WORKDIR /
 RUN mkdir -p scripts/integrations/oracle
 ADD packages/server/scripts/integrations/oracle scripts/integrations/oracle

--- a/hosting/single/nginx/nginx-default-site.conf
+++ b/hosting/single/nginx/nginx-default-site.conf
@@ -2,7 +2,8 @@ server {
     listen       80 default_server;
     listen  [::]:80 default_server;
     server_name  _;
-
+    error_log            /dev/stderr warn;
+    access_log           /dev/stdout main;
     client_max_body_size 1000m;
     ignore_invalid_headers off;
     proxy_buffering off;

--- a/hosting/single/nginx/nginx.conf
+++ b/hosting/single/nginx/nginx.conf
@@ -1,5 +1,5 @@
 user                 www-data www-data;
-error_log            /var/log/nginx/error.log;
+error_log            /dev/stderr warn;
 pid                  /var/run/nginx.pid;
 worker_processes     auto;
 worker_rlimit_nofile 8192;

--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -65,9 +65,9 @@ mkdir -p ${DATA_DIR}/couch/{dbs,views}
 mkdir -p ${DATA_DIR}/minio
 mkdir -p ${DATA_DIR}/search
 chown -R couchdb:couchdb ${DATA_DIR}/couch
-redis-server --requirepass $REDIS_PASSWORD &
-/opt/clouseau/bin/clouseau &
-/minio/minio server ${DATA_DIR}/minio &
+redis-server --requirepass $REDIS_PASSWORD > /dev/stdout 2>&1 &
+/opt/clouseau/bin/clouseau > /dev/stdout 2>&1 &
+/minio/minio server ${DATA_DIR}/minio > /dev/stdout 2>&1 &
 /docker-entrypoint.sh /opt/couchdb/bin/couchdb &
 /etc/init.d/nginx restart
 if [[ ! -z "${CUSTOM_DOMAIN}" ]]; then
@@ -80,10 +80,10 @@ fi
 
 /etc/init.d/nginx restart
 pushd app
-pm2 start --name app "yarn run:docker"
+pm2 start -o /dev/stdout -e /dev/stderr --name app "yarn run:docker" 
 popd
 pushd worker
-pm2 start --name worker "yarn run:docker"
+pm2 start -o /dev/stdout -e /dev/stderr --name worker "yarn run:docker"
 popd
 sleep 10
 curl -X PUT ${COUCH_DB_URL}/_users


### PR DESCRIPTION
## Description
The aim of these changes is to send more logs to stdout/stderr rather than log files within the container. 
- Nginx was fairly easy by adding the www-data user to the tty group and amending the nginx conf files to log to /dev/stdout 
- For redis, clouseau and minio I added `> /dev/stdout 2>&1 &` in `runner.sh` but somewhat difficult to test
- PM2 should take the parameters `-o` and `-e` but I don't see anything from that when tailing the docker logs for the container. 

