### PR TITLE
Automation: Update row to make a boolean Value "FALSE" does not work #8030

### DIFF
--- a/packages/server/src/automations/steps/updateRow.js
+++ b/packages/server/src/automations/steps/updateRow.js
@@ -66,9 +66,9 @@ exports.run = async function ({ inputs, appId, emitter }) {
   }
   const tableId = inputs.row.tableId
 
-  // clear any falsy properties so that they aren't updated
+  // clear any null or empty string properties so that they aren't updated
   for (let propKey of Object.keys(inputs.row)) {
-    if (!inputs.row[propKey] || inputs.row[propKey] === "") {
+    if (inputs.row[propKey] === null || inputs.row[propKey] === "") {
       delete inputs.row[propKey]
     }
   }

--- a/packages/server/src/automations/steps/updateRow.js
+++ b/packages/server/src/automations/steps/updateRow.js
@@ -66,9 +66,9 @@ exports.run = async function ({ inputs, appId, emitter }) {
   }
   const tableId = inputs.row.tableId
 
-  // clear any null or empty string properties so that they aren't updated
+  // clear any undefined, null or empty string properties so that they aren't updated
   for (let propKey of Object.keys(inputs.row)) {
-    if (inputs.row[propKey] === null || inputs.row[propKey] === "") {
+    if (inputs.row[propKey] == null || inputs.row[propKey] === "") {
       delete inputs.row[propKey]
     }
   }


### PR DESCRIPTION
## Description
Fix for "Automation: Update row to make a boolean Value "FALSE" does not work https://github.com/Budibase/budibase/issues/8030" by changing the data validation to accept FALSE but filter null or empty strings "".

Addresses: 
Automation: Update row to make a boolean Value "FALSE" does not work https://github.com/Budibase/budibase/issues/8030