### PR TITLE
Public api equals query - support for number strings

### DIFF
--- a/packages/server/src/api/controllers/row/internalSearch.js
+++ b/packages/server/src/api/controllers/row/internalSearch.js
@@ -157,8 +157,11 @@ class QueryBuilder {
     if (escape && originalType === "string") {
       value = `${value}`.replace(/[ #+\-&|!(){}\]^"~*?:\\]/g, "\\$&")
     }
+
     // Wrap in quotes
-    if (hasVersion && wrap) {
+    if (originalType === "string" && !isNaN(value)) {
+      value = `"${value}"`
+    } else if (hasVersion && wrap) {
       value = originalType === "number" ? value : `"${value}"`
     }
     return value


### PR DESCRIPTION
## Description
Lucene query requires numbers to be wrapped in quotes if you are searching for text, e.g. `"123"`

Addresses: 
- https://github.com/Budibase/budibase/issues/8051



