### PR TITLE
Support empty / notEmpty filters for Datetime in External SQL DB

### DIFF
--- a/packages/frontend-core/src/utils/lucene.js
+++ b/packages/frontend-core/src/utils/lucene.js
@@ -121,7 +121,12 @@ export const buildLuceneQuery = filter => {
         query.allOr = true
         return
       }
-      if (type === "datetime" && !isHbs) {
+      if (
+        type === "datetime" &&
+        !isHbs &&
+        operator !== "empty" &&
+        operator !== "notEmpty"
+      ) {
         // Ensure date value is a valid date and parse into correct format
         if (!value) {
           return


### PR DESCRIPTION
## Description
Empty and notEmpty filters for SQL datasources were not being applied.

Tested on MySQL, but should work for Postgres and SQL Server as well.

Addresses: 
- https://github.com/Budibase/budibase/issues/7987

## Screenshots
**Is empty**
![Screenshot 2022-10-03 at 16 08 51](https://user-images.githubusercontent.com/101575380/193611927-333eef79-f05e-475b-82e0-b39c4054ff65.png)

**Is not empty**
![Screenshot 2022-10-03 at 16 11 02](https://user-images.githubusercontent.com/101575380/193612498-7e78978f-d7be-4956-b51e-1fb0db95daff.png)



