### PR TITLE
Update exec.js

### DIFF
--- a/packages/cli/src/exec.js
+++ b/packages/cli/src/exec.js
@@ -22,6 +22,6 @@ exports.runPkgCommand = async (command, dir = "./") => {
     throw new Error("Must have yarn or npm installed to run build.")
   }
   const npmCmd = command === "install" ? `npm ${command}` : `npm run ${command}`
-  const cmd = yarn ? `yarn ${command}` : npmCmd
+  const cmd = yarn ? `yarn ${command} --ignore-engines` : npmCmd
   await exports.exec(cmd, dir)
 }


### PR DESCRIPTION
## Description
I had an issue where the datasource plugin wouldn't work because of node engine incompatibility, and after a quick search on google I found that --ignore-engines is the option to use for ignoring this kind of error and it worked! So I want to make this a built-in feature so there's no need for me to manually do this.

## Screenshots
![screenshot](https://i.imgur.com/SLM4QVK.png)


