### PR TITLE
Fix table block search

### DIFF
--- a/packages/server/src/api/controllers/row/internalSearch.js
+++ b/packages/server/src/api/controllers/row/internalSearch.js
@@ -159,7 +159,7 @@ class QueryBuilder {
     }
 
     // Wrap in quotes
-    if (originalType === "string" && !isNaN(value)) {
+    if (originalType === "string" && !isNaN(value) && !escape) {
       value = `"${value}"`
     } else if (hasVersion && wrap) {
       value = originalType === "number" ? value : `"${value}"`


### PR DESCRIPTION
## Description
Don't wrap text type numbers with quotes if fuzzy or string search, e.g. `2*` or `2~`



