### PR TITLE
Fallback to push branch name for pro install script

### DIFF
--- a/scripts/pro/install.sh
+++ b/scripts/pro/install.sh
@@ -19,6 +19,7 @@ if [[ -d "budibase-pro" ]]; then
   cd budibase-pro
 
   if [[ -z "${BRANCH}" ]]; then
+    echo Using GITHUB_REF_NAME: $GITHUB_REF_NAME
     export BRANCH=$GITHUB_REF_NAME
   fi
 

--- a/scripts/pro/install.sh
+++ b/scripts/pro/install.sh
@@ -18,6 +18,10 @@ git clone https://$PERSONAL_ACCESS_TOKEN@github.com/Budibase/budibase-pro.git
 if [[ -d "budibase-pro" ]]; then
   cd budibase-pro
 
+  if [[ -z "${BRANCH}" ]]; then
+    export BRANCH=$GITHUB_REF_NAME
+  fi
+
   # Try to checkout the matching pro branch
   git checkout $BRANCH
 


### PR DESCRIPTION
## Description
If the branch name is missing, fallback to the Github ref name.



