### PR TITLE
Plugin url updates

### DIFF
--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -16,7 +16,6 @@
     themeStore,
     appStore,
     devToolsStore,
-    environmentStore,
   } from "stores"
   import NotificationDisplay from "components/overlay/NotificationDisplay.svelte"
   import ConfirmationDisplay from "components/overlay/ConfirmationDisplay.svelte"
@@ -48,8 +47,6 @@
     !$builderStore.inBuilder &&
     $devToolsStore.enabled &&
     !$routeStore.queryParams?.peek
-  $: objectStoreUrl = $environmentStore.cloud ? "https://cdn.budi.live" : ""
-  $: pluginsUrl = `${objectStoreUrl}/plugins`
 
   // Handle no matching route
   $: {
@@ -95,8 +92,7 @@
 <svelte:head>
   {#if $builderStore.usedPlugins?.length}
     {#each $builderStore.usedPlugins as plugin (plugin.hash)}
-      <script
-        src={`${pluginsUrl}/${plugin.jsUrl}?r=${plugin.hash || ""}`}></script>
+      <script src={`${plugin.jsUrl}?r=${plugin.hash || ""}`}></script>
     {/each}
   {/if}
 </svelte:head>

--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -87,6 +87,8 @@
       builderStore.actions.analyticsPing({ source: "app" })
     }
   })
+
+  $: console.log($builderStore.usedPlugins)
 </script>
 
 <svelte:head>

--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -87,8 +87,6 @@
       builderStore.actions.analyticsPing({ source: "app" })
     }
   })
-
-  $: console.log($builderStore.usedPlugins)
 </script>
 
 <svelte:head>

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -50,6 +50,7 @@ import { errors, events, migrations } from "@budibase/backend-core"
 import { App, Layout, Screen, MigrationType } from "@budibase/types"
 import { BASE_LAYOUT_PROP_IDS } from "../../constants/layouts"
 import { groups } from "@budibase/pro"
+import { enrichPluginURLs } from "../../utilities/plugins"
 
 const URL_REGEX_SLASH = /\/|\\/g
 
@@ -208,9 +209,12 @@ export const fetchAppDefinition = async (ctx: any) => {
 
 export const fetchAppPackage = async (ctx: any) => {
   const db = context.getAppDB()
-  const application = await db.get(DocumentType.APP_METADATA)
+  let application = await db.get(DocumentType.APP_METADATA)
   const layouts = await getLayouts()
   let screens = await getScreens()
+
+  // Enrich plugin URLs
+  application.usedPlugins = enrichPluginURLs(application.usedPlugins)
 
   // Only filter screens if the user is not a builder
   if (!(ctx.user.builder && ctx.user.builder.global)) {

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -1,3 +1,6 @@
+import { Plugin } from "@budibase/types"
+import { enrichPluginURLs } from "../../../utilities/plugins"
+
 require("svelte/register")
 
 const send = require("koa-send")
@@ -22,6 +25,7 @@ const fs = require("fs")
 const {
   downloadTarballDirect,
 } = require("../../../utilities/fileSystem/utilities")
+const { isMultiTenant } = require("@budibase/backend-core/tenancy")
 
 async function prepareUpload({ s3Key, bucket, metadata, file }: any) {
   const response = await upload({
@@ -107,12 +111,13 @@ export const serveApp = async function (ctx: any) {
 
   if (!env.isJest()) {
     const App = require("./templates/BudibaseApp.svelte").default
+    const plugins = enrichPluginURLs(appInfo.usedPlugins)
     const { head, html, css } = App.render({
       title: appInfo.name,
       production: env.isProd(),
       appId,
       clientLibPath: clientLibraryPath(appId, appInfo.version, ctx),
-      usedPlugins: appInfo.usedPlugins,
+      usedPlugins: plugins,
     })
 
     const appHbs = loadHandlebarsFile(`${__dirname}/templates/app.hbs`)

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -1,4 +1,3 @@
-import { Plugin } from "@budibase/types"
 import { enrichPluginURLs } from "../../../utilities/plugins"
 
 require("svelte/register")
@@ -25,7 +24,6 @@ const fs = require("fs")
 const {
   downloadTarballDirect,
 } = require("../../../utilities/fileSystem/utilities")
-const { isMultiTenant } = require("@budibase/backend-core/tenancy")
 
 async function prepareUpload({ s3Key, bucket, metadata, file }: any) {
   const response = await upload({

--- a/packages/server/src/api/controllers/static/templates/BudibaseApp.svelte
+++ b/packages/server/src/api/controllers/static/templates/BudibaseApp.svelte
@@ -88,9 +88,7 @@
   <!-- But before loadBudibase is called -->
   {#if usedPlugins?.length}
     {#each usedPlugins as plugin}
-      <script
-        type="application/javascript"
-        src={`/plugins/${plugin.jsUrl}`}></script>
+      <script type="application/javascript" src={plugin.jsUrl}></script>
     {/each}
   {/if}
   <script type="application/javascript">

--- a/packages/server/src/utilities/plugins.js
+++ b/packages/server/src/utilities/plugins.js
@@ -1,0 +1,20 @@
+import env from "../environment"
+import { plugins as ProPlugins } from "@budibase/pro"
+
+export const enrichPluginURLs = plugins => {
+  if (!plugins || !plugins.length) {
+    return []
+  }
+  return plugins.map(plugin => {
+    const cloud = !env.SELF_HOSTED
+    // In self host we need to prefix the path, as "plugins" is not part of the
+    // bucket path. In cloud, "plugins" is already part of the bucket path.
+    let jsUrl = cloud ? "https://cdn.budi.live/" : "/plugins/"
+    jsUrl += ProPlugins.getBucketPath(plugin.name)
+    jsUrl += "plugin.min.js"
+    return {
+      ...plugin,
+      jsUrl,
+    }
+  })
+}

--- a/packages/server/src/utilities/plugins.js
+++ b/packages/server/src/utilities/plugins.js
@@ -1,5 +1,6 @@
-import env from "../environment"
-import { plugins as ProPlugins } from "@budibase/pro"
+const env = require("../environment")
+const { plugins: ProPlugins } = require("@budibase/pro")
+const { objectStore } = require("@budibase/backend-core")
 
 export const enrichPluginURLs = plugins => {
   if (!plugins || !plugins.length) {
@@ -7,14 +8,14 @@ export const enrichPluginURLs = plugins => {
   }
   return plugins.map(plugin => {
     const cloud = !env.SELF_HOSTED
-    // In self host we need to prefix the path, as "plugins" is not part of the
-    // bucket path. In cloud, "plugins" is already part of the bucket path.
-    let jsUrl = cloud ? "https://cdn.budi.live/" : "/plugins/"
+    const bucket = objectStore.ObjectStoreBuckets.PLUGINS
+    const jsFileName = "plugin.min.js"
+
+    // In self host we need to prefix the path, as the bucket name is not part
+    // of the bucket path. In cloud, it's already part of the bucket path.
+    let jsUrl = cloud ? "https://cdn.budi.live/" : `/${bucket}/`
     jsUrl += ProPlugins.getBucketPath(plugin.name)
-    jsUrl += "plugin.min.js"
-    return {
-      ...plugin,
-      jsUrl,
-    }
+    jsUrl += jsFileName
+    return { ...plugin, jsUrl }
   })
 }

--- a/packages/server/src/utilities/plugins.js
+++ b/packages/server/src/utilities/plugins.js
@@ -2,7 +2,7 @@ const env = require("../environment")
 const { plugins: ProPlugins } = require("@budibase/pro")
 const { objectStore } = require("@budibase/backend-core")
 
-export const enrichPluginURLs = plugins => {
+exports.enrichPluginURLs = plugins => {
   if (!plugins || !plugins.length) {
     return []
   }


### PR DESCRIPTION
## Description
Corresponding pro PR: https://github.com/Budibase/budibase-pro/pull/69

This PR updates how the URLs for fetching plugins are generated. The URLs are now generated at runtime when requested by the client. This ensures we do not need to migrate any existing plugin or app docs. As the URLs are now fully generated server-side, including accounting for the CDN when running in the cloud, all frontend logic for determining URLs has been removed.

A utility function has been handed to handle the enrichment of these JS URLs as it is required in multiple places.

There might be other locations where enrichment is required which I've missed, so please point any out.



