### PR TITLE
Fixing options type import with CSV

### DIFF
--- a/packages/server/src/api/controllers/public/utils.ts
+++ b/packages/server/src/api/controllers/public/utils.ts
@@ -22,7 +22,7 @@ export async function addRev(
 }
 
 /**
- * Performs a case insensitive search on the provided documents, using the
+ * Performs a case in-sensitive search on the provided documents, using the
  * provided key and value. This will be a string based search, using the
  * startsWith function.
  */

--- a/packages/server/src/api/controllers/table/utils.ts
+++ b/packages/server/src/api/controllers/table/utils.ts
@@ -245,7 +245,7 @@ class TableSaveFunctions {
   // after saving
   async after(table: any) {
     table = await handleSearchIndexes(table)
-    await handleDataImport(this.user, table, this.dataImport)
+    table = await handleDataImport(this.user, table, this.dataImport)
     return table
   }
 


### PR DESCRIPTION
## Description
Fixing a regression of CSV table creation - normally if a CSV was used to create a table with an options column all of the options would be filled in but this had been broken.

This was an issue noted by @aptkingston who utilised this feature regularly.