### PR TITLE
Fix issues with looping in automations

### DIFF
--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -317,7 +317,7 @@ class Orchestrator {
           }
 
           // The "Loop" binding in the front end is "fake", so replace it here so the context can understand it
-          // Pretty hacky because we need to account for the row objec
+          // Pretty hacky because we need to account for the row object
           for (let [key, value] of Object.entries(originalStepInput)) {
             if (typeof value === "object") {
               for (let [innerKey, innerValue] of Object.entries(
@@ -461,8 +461,6 @@ class Orchestrator {
         })
         this._context.steps[loopStepNumber] = tempOutput
 
-        console.log(loopStepNumber)
-        console.log(this._context)
         loopSteps = undefined
         wasLoopStep = true
       }

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -252,7 +252,7 @@ class Orchestrator {
     let loopStepNumber: any = undefined
     let loopSteps: LoopStep[] | undefined = []
     let metadata
-
+    let wasLoopStep = false
     // check if this is a recurring automation,
     if (isProdAppID(this._appId) && isRecurring(automation)) {
       metadata = await this.getMetadata()
@@ -267,6 +267,7 @@ class Orchestrator {
       let input,
         iterations = 1,
         iterationCount = 0
+
       if (step.stepId === LOOP_STEP_ID) {
         loopStep = step
         loopStepNumber = stepCount
@@ -277,10 +278,8 @@ class Orchestrator {
         input = await processObject(loopStep.inputs, this._context)
         iterations = getLoopIterations(loopStep as LoopStep, input)
       }
-
       for (let index = 0; index < iterations; index++) {
         let originalStepInput = cloneDeep(step.inputs)
-
         // Handle if the user has set a max iteration count or if it reaches the max limit set by us
         if (loopStep && input.binding) {
           let newInput = await processObject(
@@ -313,13 +312,12 @@ class Orchestrator {
           } else {
             item = loopStep.inputs.binding
           }
-
           this._context.steps[loopStepNumber] = {
             currentItem: item[index],
           }
 
           // The "Loop" binding in the front end is "fake", so replace it here so the context can understand it
-          // Pretty hacky because we need to account for the row object
+          // Pretty hacky because we need to account for the row objec
           for (let [key, value] of Object.entries(originalStepInput)) {
             if (typeof value === "object") {
               for (let [innerKey, innerValue] of Object.entries(
@@ -331,6 +329,16 @@ class Orchestrator {
                       innerValue,
                       `steps.${loopStepNumber}`
                     )
+                } else if (typeof value === "object") {
+                  for (let [innerObject, innerValue] of Object.entries(
+                    originalStepInput[key][innerKey]
+                  )) {
+                    originalStepInput[key][innerKey][innerObject] =
+                      automationUtils.substituteLoopStep(
+                        innerValue,
+                        `steps.${loopStepNumber}`
+                      )
+                  }
                 }
               }
             } else {
@@ -386,6 +394,7 @@ class Orchestrator {
         let stepFn = await this.getStepFunctionality(step.stepId)
         let inputs = await processObject(originalStepInput, this._context)
         inputs = automationUtils.cleanInputValues(inputs, step.schema.inputs)
+
         try {
           // appId is always passed
           const outputs = await stepFn({
@@ -394,6 +403,7 @@ class Orchestrator {
             emitter: this._emitter,
             context: this._context,
           })
+
           this._context.steps[stepCount] = outputs
           // if filter causes us to stop execution don't break the loop, set a var
           // so that we can finish iterating through the steps and record that it stopped
@@ -419,6 +429,7 @@ class Orchestrator {
           console.error(`Automation error - ${step.stepId} - ${err}`)
           return err
         }
+
         if (loopStep) {
           iterationCount++
           if (index === iterations - 1) {
@@ -429,6 +440,13 @@ class Orchestrator {
         }
       }
 
+      // Delete the step after the loop step as it's irrelevant, since information is included
+      // in the loop step
+      if (wasLoopStep) {
+        this._context.steps.splice(loopStepNumber + 1, 1)
+        wasLoopStep = false
+      }
+      console.log()
       if (loopSteps && loopSteps.length) {
         let tempOutput = {
           success: true,
@@ -441,9 +459,12 @@ class Orchestrator {
           outputs: tempOutput,
           inputs: step.inputs,
         })
+        this._context.steps[loopStepNumber] = tempOutput
 
-        this._context.steps.splice(loopStepNumber, 0, tempOutput)
+        console.log(loopStepNumber)
+        console.log(this._context)
         loopSteps = undefined
+        wasLoopStep = true
       }
     }
 

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -446,7 +446,7 @@ class Orchestrator {
         this._context.steps.splice(loopStepNumber + 1, 1)
         wasLoopStep = false
       }
-      console.log()
+
       if (loopSteps && loopSteps.length) {
         let tempOutput = {
           success: true,


### PR DESCRIPTION
## Description
Fixes two issues with loop blocks in automations

- Issue where the loop's current item was't being parsed correctly when passed into a query rows filter
- When the loop block was inserted in a particular position, the bindings in the automation backend weren't in the correct position, therefore making thje bindings incorrect (i.e `steps.3.value` would have needed to be `steps.4.value` on the front-end to work correctly

Addresses: 
#7906 





