### PR TITLE
Some iOS 13 Support

### DIFF
--- a/packages/client/src/components/app/charts/ApexOptionsBuilder.js
+++ b/packages/client/src/components/app/charts/ApexOptionsBuilder.js
@@ -1,37 +1,39 @@
 export class ApexOptionsBuilder {
-  formatters = {
-    ["Default"]: val => (isNaN(val) ? val : Math.round(val * 100) / 100),
-    ["Thousands"]: val => `${Math.round(val / 1000)}K`,
-    ["Millions"]: val => `${Math.round(val / 1000000)}M`,
-  }
-  options = {
-    series: [],
-    legend: {
-      show: false,
-      position: "top",
-      horizontalAlign: "right",
-      showForSingleSeries: true,
-      showForNullSeries: true,
-      showForZeroSeries: true,
-    },
-    chart: {
-      toolbar: {
+  constructor() {
+    this.formatters = {
+      ["Default"]: val => (isNaN(val) ? val : Math.round(val * 100) / 100),
+      ["Thousands"]: val => `${Math.round(val / 1000)}K`,
+      ["Millions"]: val => `${Math.round(val / 1000000)}M`,
+    }
+    this.options = {
+      series: [],
+      legend: {
         show: false,
+        position: "top",
+        horizontalAlign: "right",
+        showForSingleSeries: true,
+        showForNullSeries: true,
+        showForZeroSeries: true,
       },
-      zoom: {
-        enabled: false,
+      chart: {
+        toolbar: {
+          show: false,
+        },
+        zoom: {
+          enabled: false,
+        },
       },
-    },
-    xaxis: {
-      labels: {
-        formatter: this.formatters.Default,
+      xaxis: {
+        labels: {
+          formatter: this.formatters.Default,
+        },
       },
-    },
-    yaxis: {
-      labels: {
-        formatter: this.formatters.Default,
+      yaxis: {
+        labels: {
+          formatter: this.formatters.Default,
+        },
       },
-    },
+    }
   }
 
   setOption(path, value) {

--- a/packages/frontend-core/src/fetch/DataFetch.js
+++ b/packages/frontend-core/src/fetch/DataFetch.js
@@ -14,52 +14,52 @@ import { convertJSONSchemaToTableSchema } from "../utils/json"
  * For other types of datasource, this class is overridden and extended.
  */
 export default class DataFetch {
-  // API client
-  API = null
-
-  // Feature flags
-  featureStore = writable({
-    supportsSearch: false,
-    supportsSort: false,
-    supportsPagination: false,
-  })
-
-  // Config
-  options = {
-    datasource: null,
-    limit: 10,
-
-    // Search config
-    filter: null,
-    query: null,
-
-    // Sorting config
-    sortColumn: null,
-    sortOrder: "ascending",
-    sortType: null,
-
-    // Pagination config
-    paginate: true,
-  }
-
-  // State of the fetch
-  store = writable({
-    rows: [],
-    info: null,
-    schema: null,
-    loading: false,
-    loaded: false,
-    query: null,
-    pageNumber: 0,
-    cursor: null,
-    cursors: [],
-  })
-
   /**
    * Constructs a new DataFetch instance.
    * @param opts the fetch options
    */
   constructor(opts) {
+    // API client
+    this.API = null
+
+    // Feature flags
+    this.featureStore = writable({
+      supportsSearch: false,
+      supportsSort: false,
+      supportsPagination: false,
+    })
+
+    // Config
+    this.options = {
+      datasource: null,
+      limit: 10,
+
+      // Search config
+      filter: null,
+      query: null,
+
+      // Sorting config
+      sortColumn: null,
+      sortOrder: "ascending",
+      sortType: null,
+
+      // Pagination config
+      paginate: true,
+    }
+
+    // State of the fetch
+    this.store = writable({
+      rows: [],
+      info: null,
+      schema: null,
+      loading: false,
+      loaded: false,
+      query: null,
+      pageNumber: 0,
+      cursor: null,
+      cursors: [],
+    })
+
     // Merge options with their default values
     this.API = opts?.API
     this.options = {


### PR DESCRIPTION
## Description
Users were having issues using Budibase in iOS12 and 13. 

Basically this was caused by JavaScript ES2020 support issues below iOS15. **Long story short - upgrade to iOS15.**

I played around with reducing the `es2020` in the tsconfig files, but it was causing issues so I abandoned that, but it means I wasn't able to get the builder working for iOS13 as I came across this same issue: https://stackoverflow.com/questions/68484843/angular-error-promisereactionjob-in-ios

**In the end, the only thing I could do was to allow public apps to be viewed within iOS13. 
iOS12 is a no go.** 

Addresses: 
- https://github.com/Budibase/budibase/issues/5994

## Screenshots
**Before**
![Screenshot 2022-10-05 at 15 51 40](https://user-images.githubusercontent.com/101575380/194092964-02159679-6968-445e-a69d-416b692ddf7d.png)

**Public app after:**
![Screenshot 2022-10-05 at 15 57 28](https://user-images.githubusercontent.com/101575380/194092865-b161e88e-64d7-4345-bd91-d84b76e79b17.png)
