### PR TITLE
Fix for ARM64v8 single image build

### DIFF
--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -19,8 +19,8 @@ ADD packages/worker .
 RUN node /pinVersions.js && yarn && yarn build && /cleanup.sh
 
 FROM couchdb:3.2.1
-# TARGETARCH can be amd64 or arm e.g. docker build --build-arg TARGETARCH=amd64
-ARG TARGETARCH=amd64
+ARG TARGETARCH
+ENV TARGETARCH $TARGETARCH
 #TARGETBUILD can be set to single (for single docker image) or aas (for azure app service)
 # e.g. docker build --build-arg TARGETBUILD=aas ....
 ARG TARGETBUILD=single

--- a/scripts/install-minio.sh
+++ b/scripts/install-minio.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 if [[ $TARGETARCH == arm* ]] ;
 then
+  echo "INSTALLING ARM64 MINIO"
   wget https://dl.min.io/server/minio/release/linux-arm64/minio
 else
+  echo "INSTALLING AMD64 MINIO"
   wget https://dl.min.io/server/minio/release/linux-amd64/minio
 fi
 chmod +x minio


### PR DESCRIPTION
## Description
Fixing issue #8079 - making sure TARGETARCH gets correctly exported to environment to pick correct MINIO bundle.

Addresses: 
- #8079