### PR TITLE
Clear edit column modal on close/hide

### DIFF
--- a/packages/builder/src/components/backend/DataTable/Table.svelte
+++ b/packages/builder/src/components/backend/DataTable/Table.svelte
@@ -8,6 +8,7 @@
   import CreateEditRow from "./modals/CreateEditRow.svelte"
   import CreateEditUser from "./modals/CreateEditUser.svelte"
   import CreateEditColumn from "./modals/CreateEditColumn.svelte"
+  import { cloneDeep } from "lodash/fp"
   import {
     TableNames,
     UNEDITABLE_USER_FIELDS,
@@ -110,7 +111,7 @@
   }
 
   const editColumn = field => {
-    editableColumn = schema?.[field]
+    editableColumn = cloneDeep(schema?.[field])
     if (editableColumn) {
       editColumnModal.show()
     }


### PR DESCRIPTION
## Description
Editing a multi-select options and not saving was causing issues. Now clearing state when closing/hiding the edit column modal.

Addresses: 
- https://github.com/Budibase/budibase/issues/7341

## Screenshots
![modal](https://user-images.githubusercontent.com/101575380/194348749-0f96b02e-c8ad-47b2-bb41-c89d50f55a69.gif)



