### PR TITLE
Hide delete button for built-in roles, and prevent duplicate roles

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/EditRoles.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/EditRoles.svelte
@@ -17,11 +17,20 @@
   $: selectedRoleId = selectedRole._id
   $: otherRoles = editableRoles.filter(role => role._id !== selectedRoleId)
   $: isCreating = selectedRoleId == null || selectedRoleId === ""
+
+  $: hasUniqueRoleName = !otherRoles
+    ?.map(role => role.name)
+    ?.includes(selectedRole.name)
+
   $: valid =
     selectedRole.name &&
     selectedRole.inherits &&
     selectedRole.permissionId &&
     !builtInRoles.includes(selectedRole.name)
+
+  $: shouldDisableRoleInput =
+    builtInRoles.includes(selectedRole.name) &&
+    selectedRole.name?.toLowerCase() === selectedRoleId?.toLowerCase()
 
   const fetchBasePermissions = async () => {
     try {
@@ -99,7 +108,7 @@
   title="Edit Roles"
   confirmText={isCreating ? "Create" : "Save"}
   onConfirm={saveRole}
-  disabled={!valid}
+  disabled={!valid || !hasUniqueRoleName}
 >
   {#if errors.length}
     <ErrorsBox {errors} />
@@ -119,7 +128,8 @@
     <Input
       label="Name"
       bind:value={selectedRole.name}
-      disabled={builtInRoles.includes(selectedRole.name)}
+      disabled={shouldDisableRoleInput}
+      error={!hasUniqueRoleName ? "Select a unique role name." : null}
     />
     <Select
       label="Inherits Role"
@@ -127,7 +137,7 @@
       options={selectedRole._id === "BASIC" ? $roles : otherRoles}
       getOptionValue={role => role._id}
       getOptionLabel={role => role.name}
-      disabled={builtInRoles.includes(selectedRole.name)}
+      disabled={shouldDisableRoleInput}
     />
     <Select
       label="Base Permissions"
@@ -135,7 +145,7 @@
       options={basePermissions}
       getOptionValue={x => x._id}
       getOptionLabel={x => x.name}
-      disabled={builtInRoles.includes(selectedRole.name)}
+      disabled={shouldDisableRoleInput}
     />
   {/if}
   <div slot="footer">

--- a/packages/builder/src/components/backend/DataTable/modals/EditRoles.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/EditRoles.svelte
@@ -37,7 +37,6 @@
     const id = event?.detail
     const role = $roles.find(role => role._id === id)
     if (role) {
-      console.log("INH ", role.inherits)
       selectedRole = {
         ...role,
         inherits: role.inherits ?? "",
@@ -125,7 +124,7 @@
     <Select
       label="Inherits Role"
       bind:value={selectedRole.inherits}
-      options={$roles}
+      options={selectedRole._id === "BASIC" ? $roles : otherRoles}
       getOptionValue={role => role._id}
       getOptionLabel={role => role.name}
       disabled={builtInRoles.includes(selectedRole.name)}

--- a/packages/builder/src/components/backend/DataTable/modals/EditRoles.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/EditRoles.svelte
@@ -37,6 +37,7 @@
     const id = event?.detail
     const role = $roles.find(role => role._id === id)
     if (role) {
+      console.log("INH ", role.inherits)
       selectedRole = {
         ...role,
         inherits: role.inherits ?? "",
@@ -124,7 +125,7 @@
     <Select
       label="Inherits Role"
       bind:value={selectedRole.inherits}
-      options={otherRoles}
+      options={$roles}
       getOptionValue={role => role._id}
       getOptionLabel={role => role.name}
       disabled={builtInRoles.includes(selectedRole.name)}
@@ -139,7 +140,7 @@
     />
   {/if}
   <div slot="footer">
-    {#if !isCreating}
+    {#if !isCreating && !builtInRoles.includes(selectedRole.name)}
       <Button warning on:click={deleteRole}>Delete</Button>
     {/if}
   </div>


### PR DESCRIPTION
## Description
 - You can no longer attempt to delete built-in roles.
 - You can no longer create two roles with the same name
 - Added validation and fixed bug where the input boxes could be disabled within the *Create new role* selection
 - Inherits role for "Basic" shows "Public" instead of *null*

Addresses: 
- https://github.com/Budibase/budibase/issues/8163

## Screenshots
**No delete button for in-built roles. Inherits from 'public'.**
<img width="371" alt="Screenshot 2022-10-06 at 19 26 39" src="https://user-images.githubusercontent.com/101575380/194390483-f6576e2f-c921-4978-b488-196d3b78f224.png">

**Cannot create a new role with duplicate role name**
<img width="371" alt="Screenshot 2022-10-06 at 19 27 21" src="https://user-images.githubusercontent.com/101575380/194390595-b700f82e-2fa2-473b-a42d-eb6dbc68512f.png">

**Cannot edit role to have duplicate role name**
<img width="371" alt="Screenshot 2022-10-06 at 19 27 55" src="https://user-images.githubusercontent.com/101575380/194390700-c605963f-1d1e-4ccb-95ef-9e3de0cd415c.png">

**No validation error when role name matches selected role**
<img width="371" alt="Screenshot 2022-10-06 at 19 32 57" src="https://user-images.githubusercontent.com/101575380/194391628-a69091f4-d166-43d6-9ff0-79f16b49317d.png">

