### PR TITLE
Removing Redis SCAN operation from app services

### DIFF
--- a/packages/backend-core/src/redis/index.ts
+++ b/packages/backend-core/src/redis/index.ts
@@ -214,6 +214,31 @@ export = class RedisWrapper {
     }
   }
 
+  async bulkGet(keys: string[]) {
+    const db = this._db
+    const prefixedKeys = keys.map(key => addDbPrefix(db, key))
+    let response = await this.getClient().mget(prefixedKeys)
+    if (Array.isArray(response)) {
+      let final: any = {}
+      let count = 0
+      for (let result of response) {
+        if (result) {
+          let parsed
+          try {
+            parsed = JSON.parse(result)
+          } catch (err) {
+            parsed = result
+          }
+          final[keys[count]] = parsed
+        }
+        count++
+      }
+      return final
+    } else {
+      throw new Error(`Invalid response: ${response}`)
+    }
+  }
+
   async store(key: string, value: any, expirySeconds: number | null = null) {
     const db = this._db
     if (typeof value === "object") {

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -32,7 +32,7 @@ const {
 import { USERS_TABLE_SCHEMA } from "../../constants"
 import { removeAppFromUserRoles } from "../../utilities/workerRequests"
 import { clientLibraryPath, stringToReadStream } from "../../utilities"
-import { getAllLocks } from "../../utilities/redis"
+import { getLocksById } from "../../utilities/redis"
 import {
   updateClientLibrary,
   backupClientLibrary,
@@ -45,11 +45,10 @@ import { cleanupAutomations } from "../../automations/utils"
 import { context } from "@budibase/backend-core"
 import { checkAppMetadata } from "../../automations/logging"
 import { getUniqueRows } from "../../utilities/usageQuota/rows"
-import { quotas } from "@budibase/pro"
+import { quotas, groups } from "@budibase/pro"
 import { errors, events, migrations } from "@budibase/backend-core"
 import { App, Layout, Screen, MigrationType } from "@budibase/types"
 import { BASE_LAYOUT_PROP_IDS } from "../../constants/layouts"
-import { groups } from "@budibase/pro"
 import { enrichPluginURLs } from "../../utilities/plugins"
 
 const URL_REGEX_SLASH = /\/|\\/g
@@ -172,16 +171,16 @@ export const fetch = async (ctx: any) => {
   const all = ctx.query && ctx.query.status === AppStatus.ALL
   const apps = await getAllApps({ dev, all })
 
+  const appIds = apps
+    .filter((app: any) => app.status === "development")
+    .map((app: any) => app.appId)
   // get the locks for all the dev apps
   if (dev || all) {
-    const locks = await getAllLocks()
+    const locks = await getLocksById(appIds)
     for (let app of apps) {
-      if (app.status !== "development") {
-        continue
-      }
-      const lock = locks.find((lock: any) => lock.appId === app.appId)
+      const lock = locks[app.appId]
       if (lock) {
-        app.lockedBy = lock.user
+        app.lockedBy = lock
       } else {
         // make sure its definitely not present
         delete app.lockedBy

--- a/packages/server/src/api/routes/tests/application.spec.js
+++ b/packages/server/src/api/routes/tests/application.spec.js
@@ -1,7 +1,7 @@
 jest.mock("../../../utilities/redis", () => ({
   init: jest.fn(),
-  getAllLocks: () => {
-    return []
+  getLocksById: () => {
+    return {}
   },
   doesUserHaveLock: () => {
     return true

--- a/packages/server/src/utilities/redis.js
+++ b/packages/server/src/utilities/redis.js
@@ -34,12 +34,8 @@ exports.doesUserHaveLock = async (devAppId, user) => {
   return expected === userId
 }
 
-exports.getAllLocks = async () => {
-  const locks = await devAppClient.scan()
-  return locks.map(lock => ({
-    appId: lock.key,
-    user: lock.value,
-  }))
+exports.getLocksById = async appIds => {
+  return await devAppClient.bulkGet(appIds)
 }
 
 exports.updateLock = async (devAppId, user) => {


### PR DESCRIPTION
## Description
Switching from `scan` for app locks to `mget` - which is a fast O(N) operation that only retrieves what we need.

The only scan operation left in the system is handled by the worker around sessions - I would like to remove this ideally but due to the way sessions are keyed it is a little difficult currently (sessions utilise a UUID which we cannot know without searching through Redis - however it is a much less common operation the scan for sessions).