### PR TITLE
Cypress: Auto Screens UI + PostgreSql test skip

### DIFF
--- a/packages/builder/cypress/integration/autoScreensUI.spec.js
+++ b/packages/builder/cypress/integration/autoScreensUI.spec.js
@@ -2,7 +2,7 @@ import filterTests from "../support/filterTests"
 const interact = require('../support/interact')
 
 filterTests(['smoke', 'all'], () => {
-  context("Auto Screens UI", () => {
+  xcontext("Auto Screens UI", () => {
     before(() => {
       cy.login()
       cy.deleteAllApps()

--- a/packages/builder/cypress/integration/datasources/postgreSql.spec.js
+++ b/packages/builder/cypress/integration/datasources/postgreSql.spec.js
@@ -1,7 +1,7 @@
 import filterTests from "../../support/filterTests"
 
 filterTests(["all"], () => {
-  context("PostgreSQL Datasource Testing", () => {
+  xcontext("PostgreSQL Datasource Testing", () => {
     if (Cypress.env("TEST_ENV")) {
       before(() => {
         cy.login()


### PR DESCRIPTION
## Description

As previously discussed with Marty, any further flakey tests (timing issues) with Cypress will be skipped for now but not removed.

- Timing issues are affecting Auto Screens UI & PostgreSql tests
- We will receive coverage of these tests via QA Wolf
- The tests are not removed so we still have reference for generating relative API tests




