### PR TITLE
Fix user metadata update

### DIFF
--- a/packages/server/src/utilities/users.js
+++ b/packages/server/src/utilities/users.js
@@ -7,14 +7,17 @@ const { BUILTIN_ROLE_IDS } = require("@budibase/backend-core/roles")
 exports.getFullUser = async (ctx, userId) => {
   const global = await getGlobalUser(userId)
   let metadata = {}
+
+  // always prefer the user metadata _id and _rev
+  delete global._id
+  delete global._rev
+
   try {
     // this will throw an error if the db doesn't exist, or there is no appId
     const db = getAppDB()
     metadata = await db.get(userId)
   } catch (err) {
-    // it is fine if there is no user metadata, just remove global db info
-    delete global._id
-    delete global._rev
+    // it is fine if there is no user metadata yet
   }
   delete metadata.csrfToken
   return {


### PR DESCRIPTION
## Description
Previously the global user _rev was overriding the metadata _rev, producing a conflict on save. 

Had made an attempt at typing `utilities/users.js` and `utiltiies/global.js`. The main difficulties are the differences between the standard `User` document and the augmented in memory global user after app role processing, where we omit roles and populate a roleId field. I had started to introduce an `AppUser` type to make it clear to consumers what are available in return types, this isn't a simple refactor due to uses of `user` across the above files as well as `controllers/auth.ts` and the groups sdk inside pro, these files sometimes expect the user in both forms at once. This would result in additional refactoring that seemed out of scope for this fix - shelving these changes for a future pr. 

Addresses: 
- https://github.com/Budibase/budibase/issues/8043



