### PR TITLE
Fix user pagination not working when viewing users with access to an app

### DIFF
--- a/packages/builder/src/pages/builder/portal/overview/_components/AccessTab.svelte
+++ b/packages/builder/src/pages/builder/portal/overview/_components/AccessTab.svelte
@@ -156,8 +156,8 @@
               page={$usersFetch.pageNumber + 1}
               hasPrevPage={$usersFetch.hasPrevPage}
               hasNextPage={$usersFetch.hasNextPage}
-              goToPrevPage={$usersFetch.loading ? null : fetch.prevPage}
-              goToNextPage={$usersFetch.loading ? null : fetch.nextPage}
+              goToPrevPage={$usersFetch.loading ? null : usersFetch.prevPage}
+              goToNextPage={$usersFetch.loading ? null : usersFetch.nextPage}
             />
           </div>
         </div>


### PR DESCRIPTION
## Description
Fixes a bug preventing pagination working in the table showing users assigned to an app.

Addresses: 
- #8209

The other related issue (#8208) will be solved seprately as it's a larger frontend refactor, and in the meantime all functionality is still possible if you enter a search string.


