### PR TITLE
Deprecate legacyHttpParser, fix rest tests

### DIFF
--- a/packages/server/src/api/controllers/query/index.ts
+++ b/packages/server/src/api/controllers/query/index.ts
@@ -56,6 +56,7 @@ const _import = async (ctx: any) => {
       config: {
         url: info.url,
         defaultHeaders: [],
+        rejectUnauthorized: true,
       },
       name: info.name,
     }

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -78,15 +78,10 @@ const SCHEMA: Integration = {
       default: {},
     },
     rejectUnauthorized: {
+      display: "Reject Unauthorized",
       type: DatasourceFieldType.BOOLEAN,
       default: true,
       required: false,
-    },
-    legacyHttpParser: {
-      display: "Legacy HTTP Support",
-      type: DatasourceFieldType.BOOLEAN,
-      required: false,
-      default: false,
     },
   },
   query: {
@@ -397,6 +392,7 @@ class RestIntegration implements IntegrationBase {
       })
     }
 
+    // Deprecated by rejectUnauthorized
     if (this.config.legacyHttpParser) {
       // https://github.com/nodejs/node/issues/43798
       input.extraHttpOptions = { insecureHTTPParser: true }


### PR DESCRIPTION
## Description
Follow up from: https://github.com/Budibase/budibase/pull/7716

Fix some tests + deprecate legacyHttpParser in favour of reject unauthorized


