### PR TITLE
making bucketnames configurable in helm chart

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -83,7 +83,7 @@ spec:
         - name: APPS_BUCKET_NAME
           value: {{ .Values.services.objectStore.appsBucketName | default "apps" | quote }}
         - name: GLOBAL_CLOUD_BUCKET_NAME
-          value: {{ .Values.services.objectStore.globalCloudBucketName | default "global" | quote }}
+          value: {{ .Values.services.objectStore.globalBucketName | default "global" | quote }}
         - name: PORT
           value: {{ .Values.services.apps.port | quote }}
         {{ if .Values.services.worker.publicApiRateLimitPerSecond }}

--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -80,6 +80,10 @@ spec:
           value: {{ .Values.services.objectStore.url }}
         - name: PLUGIN_BUCKET_NAME
           value: {{ .Values.services.objectStore.pluginBucketName | default "plugins" | quote }}
+        - name: APPS_BUCKET_NAME
+          value: {{ .Values.services.objectStore.appsBucketName | default "apps" | quote }}
+        - name: GLOBAL_CLOUD_BUCKET_NAME
+          value: {{ .Values.services.objectStore.globalCloudBucketName | default "global" | quote }}
         - name: PORT
           value: {{ .Values.services.apps.port | quote }}
         {{ if .Values.services.worker.publicApiRateLimitPerSecond }}

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -82,7 +82,7 @@ spec:
         - name: APPS_BUCKET_NAME
           value: {{ .Values.services.objectStore.appsBucketName | default "apps" | quote }}
         - name: GLOBAL_CLOUD_BUCKET_NAME
-          value: {{ .Values.services.objectStore.globalCloudBucketName | default "global" | quote }}
+          value: {{ .Values.services.objectStore.globalBucketName | default "global" | quote }}
         - name: PORT
           value: {{ .Values.services.worker.port | quote }}
         - name: MULTI_TENANCY

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -79,6 +79,10 @@ spec:
           value: {{ .Values.services.objectStore.url }}
         - name: PLUGIN_BUCKET_NAME
           value: {{ .Values.services.objectStore.pluginBucketName | default "plugins" | quote }}
+        - name: APPS_BUCKET_NAME
+          value: {{ .Values.services.objectStore.appsBucketName | default "apps" | quote }}
+        - name: GLOBAL_CLOUD_BUCKET_NAME
+          value: {{ .Values.services.objectStore.globalCloudBucketName | default "global" | quote }}
         - name: PORT
           value: {{ .Values.services.worker.port | quote }}
         - name: MULTI_TENANCY


### PR DESCRIPTION
## Description
Allowing the control of bucketnames through kubernetes variables to enable external s3 support for both self hosted users and our internal environment.

Addresses: 
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._



