### PR TITLE
Remove debug message from upgrade page ui (self host)

### DIFF
--- a/packages/builder/src/pages/builder/portal/settings/upgrade.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/upgrade.svelte
@@ -91,7 +91,6 @@
   })
 </script>
 
-{"is adming" + $auth.isAdmin}
 {#if $auth.isAdmin}
   <DeleteLicenseKeyModal
     bind:this={deleteLicenseKeyModal}


### PR DESCRIPTION
## Description
Fix a visual bug on the self host upgrade page. 

## Screenshots
Removing:
`is admingtrue`
<img width="798" alt="Screenshot 2022-10-13 at 09 26 59" src="https://user-images.githubusercontent.com/8755148/195544335-a93a9055-127b-45df-bf40-ba75320c1328.png">




