### PR TITLE
Page load actions now fire on parameter change as well as on mount

### DIFF
--- a/packages/client/src/components/Screen.svelte
+++ b/packages/client/src/components/Screen.svelte
@@ -1,5 +1,6 @@
 <script>
   import { screenStore, routeStore, builderStore } from "stores"
+  import { get } from "svelte/store"
   import Component from "./Component.svelte"
   import Provider from "./context/Provider.svelte"
   import { onMount, getContext } from "svelte"
@@ -15,23 +16,29 @@
   // Get the screen definition for the current route
   $: screenDefinition = $screenStore.activeScreen?.props
 
+  $: runOnLoadActions(params)
+
+  // Enrich and execute any on load actions.
+  // We manually construct the full context here as this component is the
+  // one that provides the url context, so it is not available in $context yet
+  const runOnLoadActions = params => {
+    const screenState = get(screenStore)
+
+    if (screenState.activeScreen?.onLoad && !get(builderStore).inBuilder) {
+      const actions = enrichButtonActions(screenState.activeScreen.onLoad, {
+        ...get(context),
+        url: params,
+      })
+      if (actions !== null) {
+        actions()
+      }
+    }
+  }
+
   onMount(() => {
     // Mark the router as loaded whenever the screen mounts
     if (!$routeStore.routerLoaded) {
       routeStore.actions.setRouterLoaded()
-    }
-
-    // Enrich and execute and on load actions.
-    // We manually construct the full context here as this component is the
-    // one that provides the url context, so it is not available in $context yet
-    if ($screenStore.activeScreen?.onLoad && !$builderStore.inBuilder) {
-      const actions = enrichButtonActions($screenStore.activeScreen.onLoad, {
-        ...$context,
-        url: params,
-      })
-      if (actions != null) {
-        actions()
-      }
     }
   })
 </script>

--- a/packages/client/src/components/Screen.svelte
+++ b/packages/client/src/components/Screen.svelte
@@ -29,7 +29,7 @@
         ...get(context),
         url: params,
       })
-      if (actions !== null) {
+      if (actions != null) {
         actions()
       }
     }


### PR DESCRIPTION
## Description
Navigating to the same screen with a different set of params e.g. `/resource/1` -> `/resource/2` was not triggering "on screen load" actions as expected.

We were relying on `svelte-spa-router` to remount the screen component, but the router doesn't remount a component if only the parameters change, as mentioned [here](https://github.com/ItalyPaleAle/svelte-spa-router/issues/148#issuecomment-706716065).

This change fixes the issue by making the function that triggers the "on screen load" actions react to changes in `svelete-spa-router` params instead of relying on the `onMount` lifecycle function.

Addresses: 
- https://github.com/Budibase/budibase/issues/7067



