### PR TITLE
nfs for cloud run

### DIFF
--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -18,12 +18,20 @@ declare -a DOCKER_VARS=("APP_PORT" "APPS_URL" "ARCHITECTURE" "BUDIBASE_ENVIRONME
 [[ -z "${WORKER_URL}" ]] && export WORKER_URL=http://localhost:4002
 [[ -z "${APPS_URL}" ]] && export APPS_URL=http://localhost:4001
 #  export CUSTOM_DOMAIN=budi001.custom.com
+
 # Azure App Service customisations
 if [[ "${TARGETBUILD}" = "aas" ]]; then
     DATA_DIR=/home
     /etc/init.d/ssh start
 else
     DATA_DIR=${DATA_DIR:-/data}
+fi
+
+# Mount NFS or GCP Filestore if env vars exist for it
+if [[ -z ${FILESHARE_IP} && -z ${FILESHARE_NAME} ]]; then
+    echo "Mount file share ${FILESHARE_IP}:/${FILESHARE_NAME} to ${DATA_DIR}"
+    mount -o nolock ${FILESHARE_IP}:/${FILESHARE_NAME} ${DATA_DIR}
+    echo "Mounting completed."
 fi
 
 if [ -f "${DATA_DIR}/.env" ]; then


### PR DESCRIPTION
GCP provides NFS storage as a service (filestore). This PR adds a conditional to the single image runner.sh so that if the NFS variables exist at runtime then we mount the NFS share to the /data directory.
This could be re-used if Azure ever provide NFS as a service.