### PR TITLE
Replace Builder Back Button With Menu

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/_layout.svelte
@@ -1,7 +1,16 @@
 <script>
   import { store, automationStore } from "builderStore"
   import { roles, flags } from "stores/backend"
-  import { Icon, Tabs, Tab, Heading, notifications } from "@budibase/bbui"
+  import { apps } from "stores/portal"
+  import {
+    ActionMenu,
+    MenuItem,
+    Icon,
+    Tabs,
+    Tab,
+    Heading,
+    notifications,
+  } from "@budibase/bbui"
   import RevertModal from "components/deploy/RevertModal.svelte"
   import VersionModal from "components/deploy/VersionModal.svelte"
   import DeployNavigation from "components/deploy/DeployNavigation.svelte"
@@ -54,6 +63,9 @@
     })
   }
 
+  $: isPublished =
+    $apps.find(app => app.devId === application)?.status === "published"
+
   onMount(async () => {
     if (!hasSynced && application) {
       try {
@@ -83,12 +95,43 @@
   <div class="root">
     <div class="top-nav">
       <div class="topleftnav">
-        <Icon
-          size="M"
-          name="ArrowLeft"
-          hoverable
-          on:click={() => $goto("../../portal/apps")}
-        />
+        <ActionMenu>
+          <div slot="control">
+            <Icon size="M" hoverable name="ShowMenu" />
+          </div>
+          <MenuItem on:click={() => $goto("../../portal/apps")}>
+            Exit to portal
+          </MenuItem>
+          <MenuItem
+            on:click={() => $goto(`../../portal/overview/${application}`)}
+          >
+            Overview
+          </MenuItem>
+          <MenuItem
+            on:click={() =>
+              $goto(`../../portal/overview/${application}?tab=Access`)}
+          >
+            Access
+          </MenuItem>
+          {#if isPublished}
+            <MenuItem
+              on:click={() =>
+                $goto(
+                  `../../portal/overview/${application}?tab=${encodeURIComponent(
+                    "Automation History"
+                  )}`
+                )}
+            >
+              Automation history
+            </MenuItem>
+          {/if}
+          <MenuItem
+            on:click={() =>
+              $goto(`../../portal/overview/${application}?tab=Settings`)}
+          >
+            Settings
+          </MenuItem>
+        </ActionMenu>
         <Heading size="XS">{$store.name || "App"}</Heading>
       </div>
       <div class="topcenternav">


### PR DESCRIPTION
## Description
Replaces the back button in builder with a menu that contains various links to the app overview.

The link to "Automation History" will appear conditionally if the app is published, as that tab isn't available for unpublished apps.

I don't believe backups have been implemented yet, so I omitted that link.

Note that there's currently what I assume to be a bug that stops `ActionMenu` components from closing when clicked while open. This is affecting other uses of the component and not just this, so probably worth fixing in a separate PR.

Addresses: 
- https://github.com/Budibase/budibase/issues/6973

## Screenshots
|Closed|Open|
|---|---|
|<img width="1178" alt="Screenshot 2022-10-13 at 15 57 22" src="https://user-images.githubusercontent.com/12501626/195632650-9d4a3239-fc1c-47bf-bdf8-f741dbda7cfe.png">|<img width="1180" alt="Screenshot 2022-10-13 at 15 57 29" src="https://user-images.githubusercontent.com/12501626/195632711-557b3a0a-dce9-4764-9325-f4fe76bbd8b6.png">|



