### PR TITLE
ipv6 script executable

### DIFF
--- a/hosting/proxy/Dockerfile
+++ b/hosting/proxy/Dockerfile
@@ -6,6 +6,7 @@ FROM nginx:latest
 ENV NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
 COPY .generated-nginx.prod.conf /etc/nginx/templates/nginx.conf.template
 COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
+RUN chmod +x /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
 
 # Error handling
 COPY error.html /usr/share/nginx/html/error.html


### PR DESCRIPTION
## Description
The aim is to allow ipv6 and ipv4-only docker-compose installations to work. We had a [previous PR](https://github.com/Budibase/budibase/pull/8249) that overwrites the ipv6 detect for nginx. 
But I forgot to make it executable.


