### PR TITLE
Stop Screen Store Double Updating on Screen Change

### DIFF
--- a/packages/client/src/components/Router.svelte
+++ b/packages/client/src/components/Router.svelte
@@ -43,6 +43,7 @@
   }
 
   const onRouteLoading = ({ detail }) => {
+    routeStore.actions.setRouteParams(detail.params || {})
     routeStore.actions.setActiveRoute(detail.route)
   }
 

--- a/packages/client/src/components/Screen.svelte
+++ b/packages/client/src/components/Screen.svelte
@@ -9,9 +9,6 @@
 
   const context = getContext("context")
 
-  // Keep route params up to date
-  $: routeStore.actions.setRouteParams(params || {})
-
   // Get the screen definition for the current route
   $: screenDefinition = $screenStore.activeScreen?.props
 


### PR DESCRIPTION
## Description
The screenStore and the routerStore which partially composes it are updating twice on a screen change. This is due to two separate actions being used to update the active route and the route params of the routerStore. 

Moving the route params update action from the `Screen` component to the same callback where the active route update action is called in the `Router` component fixes this issue as Svelte seems to batch the updates.




