### PR TITLE
Ensure non string types are ignored when searching for HBS blocks

### DIFF
--- a/packages/string-templates/src/index.js
+++ b/packages/string-templates/src/index.js
@@ -323,6 +323,9 @@ module.exports.doesContainStrings = (template, strings) => {
  * @return {string[]} The found HBS blocks.
  */
 module.exports.findHBSBlocks = string => {
+  if (!string || typeof string !== "string") {
+    return []
+  }
   let regexp = new RegExp(FIND_ANY_HBS_REGEX)
   let matches = string.match(regexp)
   if (matches == null) {


### PR DESCRIPTION
## Description
This PR fixes an issue where errors would be thrown when attempting to find HBS blocks in non string types. This seemed to be a rare edge case, but was reproducible with certain looping automation setups.

If a value is not a string, it's safe to assume it will not contain HBS blocks.



