### PR TITLE
Don't apply color picker transition to the screen panel

### DIFF
--- a/packages/bbui/src/ColorPicker/ColorPicker.svelte
+++ b/packages/bbui/src/ColorPicker/ColorPicker.svelte
@@ -132,7 +132,7 @@
   {#if open}
     <div
       use:clickOutside={() => (open = false)}
-      transition:fly={{ y: -20, duration: 200 }}
+      transition:fly|local={{ y: -20, duration: 200 }}
       class="spectrum-Popover spectrum-Popover--bottom spectrum-Picker-popover is-open"
       class:spectrum-Popover--align-right={alignRight}
     >


### PR DESCRIPTION
## Description
Color picker no longer causes the screen panel to appear.

Addresses: 
- https://github.com/Budibase/budibase/issues/8357



