### PR TITLE
Custom ssl config for Elasticsearch datasource

### DIFF
--- a/packages/server/src/integrations/elasticsearch.ts
+++ b/packages/server/src/integrations/elasticsearch.ts
@@ -100,19 +100,19 @@ class ElasticSearchIntegration implements IntegrationBase {
   constructor(config: ElasticsearchConfig) {
     this.config = config
 
-    let newConfig = { 
+    let newConfig = {
       node: this.config.url,
-      ssl: this.config.ssl 
+      ssl: this.config.ssl
         ? {
-          rejectUnauthorized: this.config.rejectUnauthorized,
-          ca: this.config.ca || undefined,
-        }
+            rejectUnauthorized: this.config.rejectUnauthorized,
+            ca: this.config.ca || undefined,
+          }
         : undefined,
     }
 
     if (newConfig.ssl && !newConfig.ssl.ca) {
       delete newConfig.ssl.ca
-    } else if(!newConfig.ssl) {
+    } else if (!newConfig.ssl) {
       delete newConfig.ssl
     }
     this.client = new Client(newConfig)

--- a/packages/server/src/integrations/elasticsearch.ts
+++ b/packages/server/src/integrations/elasticsearch.ts
@@ -5,7 +5,7 @@ import {
   IntegrationBase,
 } from "@budibase/types"
 
-const { Client } = require("@elastic/elasticsearch")
+import { Client, ClientOptions } from "@elastic/elasticsearch"
 
 interface ElasticsearchConfig {
   url: string
@@ -100,22 +100,18 @@ class ElasticSearchIntegration implements IntegrationBase {
   constructor(config: ElasticsearchConfig) {
     this.config = config
 
-    let newConfig = {
+    const clientConfig: ClientOptions = {
       node: this.config.url,
-      ssl: this.config.ssl
-        ? {
-            rejectUnauthorized: this.config.rejectUnauthorized,
-            ca: this.config.ca || undefined,
-          }
-        : undefined,
     }
 
-    if (newConfig.ssl && !newConfig.ssl.ca) {
-      delete newConfig.ssl.ca
-    } else if (!newConfig.ssl) {
-      delete newConfig.ssl
+    if (this.config.ssl) {
+      clientConfig.ssl = {
+        rejectUnauthorized: this.config.rejectUnauthorized,
+        ca: this.config.ca || undefined,
+      }
     }
-    this.client = new Client(newConfig)
+
+    this.client = new Client(clientConfig)
   }
 
   async create(query: { index: string; json: object }) {

--- a/packages/server/src/integrations/elasticsearch.ts
+++ b/packages/server/src/integrations/elasticsearch.ts
@@ -105,16 +105,14 @@ class ElasticSearchIntegration implements IntegrationBase {
       ssl: this.config.ssl 
         ? {
           rejectUnauthorized: this.config.rejectUnauthorized,
-          ca: this.config.ca ? this.config.ca : undefined
+          ca: this.config.ca || undefined,
         }
         : undefined,
     }
 
-    if (newConfig.ssl && !newConfig.ssl.ca)
-    {
+    if (newConfig.ssl && !newConfig.ssl.ca) {
       delete newConfig.ssl.ca
-    } else if(!newConfig.ssl)
-    {
+    } else if(!newConfig.ssl) {
       delete newConfig.ssl
     }
     this.client = new Client(newConfig)


### PR DESCRIPTION
## Description
Implements fields to allow for customization of the SSL object passed to the Elasticsearch javascript client in the Elasticsearch datasource.

This allows Budibase to connect to Elasticsearch instances running using the default docker-compose.yml file from Elastic which generates a self-signed CA and certificate upon start-up.

## Screenshots
![elastic](https://user-images.githubusercontent.com/79575739/197793883-40b8e86c-121a-4536-8cd6-211adcd679bd.jpg)
