### PR TITLE
Startup fixes + remove bucket default names

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -79,11 +79,11 @@ spec:
         - name: MINIO_URL
           value: {{ .Values.services.objectStore.url }}
         - name: PLUGIN_BUCKET_NAME
-          value: {{ .Values.services.objectStore.pluginBucketName | default "plugins" | quote }}
+          value: {{ .Values.services.objectStore.pluginBucketName | quote }}
         - name: APPS_BUCKET_NAME
-          value: {{ .Values.services.objectStore.appsBucketName | default "apps" | quote }}
+          value: {{ .Values.services.objectStore.appsBucketName | quote }}
         - name: GLOBAL_CLOUD_BUCKET_NAME
-          value: {{ .Values.services.objectStore.globalBucketName | default "global" | quote }}
+          value: {{ .Values.services.objectStore.globalBucketName | quote }}
         - name: PORT
           value: {{ .Values.services.apps.port | quote }}
         {{ if .Values.services.worker.publicApiRateLimitPerSecond }}

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -78,11 +78,11 @@ spec:
         - name: MINIO_URL
           value: {{ .Values.services.objectStore.url }}
         - name: PLUGIN_BUCKET_NAME
-          value: {{ .Values.services.objectStore.pluginBucketName | default "plugins" | quote }}
+          value: {{ .Values.services.objectStore.pluginBucketName | quote }}
         - name: APPS_BUCKET_NAME
-          value: {{ .Values.services.objectStore.appsBucketName | default "apps" | quote }}
+          value: {{ .Values.services.objectStore.appsBucketName | quote }}
         - name: GLOBAL_CLOUD_BUCKET_NAME
-          value: {{ .Values.services.objectStore.globalBucketName | default "global" | quote }}
+          value: {{ .Values.services.objectStore.globalBucketName | quote }}
         - name: PORT
           value: {{ .Values.services.worker.port | quote }}
         - name: MULTI_TENANCY

--- a/packages/backend-core/src/redis/redlock.ts
+++ b/packages/backend-core/src/redis/redlock.ts
@@ -55,7 +55,12 @@ export const doWithLock = async (opts: LockOptions, task: any) => {
   let lock
   try {
     // aquire lock
-    let name: string = `${tenancy.getTenantId()}_${opts.name}`
+    let name: string
+    if (opts.systemLock) {
+      name = opts.name
+    } else {
+      name = `${tenancy.getTenantId()}_${opts.name}`
+    }
     if (opts.nameSuffix) {
       name = name + `_${opts.nameSuffix}`
     }

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -122,7 +122,6 @@ module.exports = server.listen(env.PORT || 0, async () => {
   eventEmitter.emitPort(env.PORT)
   fileSystem.init()
   await redis.init()
-  await initPro()
 
   // run migrations on startup if not done via http
   // not recommended in a clustered environment
@@ -180,8 +179,11 @@ module.exports = server.listen(env.PORT || 0, async () => {
   // check for version updates
   await installation.checkInstallVersion()
 
-  // done last - this will never complete
-  await automations.init()
+  // done last - these will never complete
+  let promises = []
+  promises.push(automations.init())
+  promises.push(initPro())
+  await Promise.all(promises)
 })
 
 const shutdown = () => {

--- a/packages/server/src/automations/triggers.js
+++ b/packages/server/src/automations/triggers.js
@@ -116,8 +116,8 @@ exports.externalTrigger = async function (
 
 exports.rebootTrigger = async () => {
   // reboot cron option is only available on the main thread at
-  // startup and only usable in self host
-  if (env.isInThread() || !env.SELF_HOSTED) {
+  // startup and only usable in self host and single tenant environments
+  if (env.isInThread() || !env.SELF_HOSTED || env.MULTI_TENANCY) {
     return
   }
   // iterate through all production apps, find the reboot crons

--- a/packages/server/src/migrations/index.ts
+++ b/packages/server/src/migrations/index.ts
@@ -97,6 +97,7 @@ const migrateWithLock = async (options?: MigrationOptions) => {
       type: LockType.TRY_ONCE,
       name: LockName.MIGRATIONS,
       ttl: 1000 * 60 * 15, // auto expire the migration lock after 15 minutes
+      systemLock: true,
     },
     async () => {
       await migrations.runMigrations(MIGRATIONS, options)

--- a/packages/types/src/sdk/locks.ts
+++ b/packages/types/src/sdk/locks.ts
@@ -28,4 +28,8 @@ export interface LockOptions {
    * The suffix to add to the lock name for additional uniqueness
    */
   nameSuffix?: string
+  /**
+   * This is a system-wide lock - don't use tenancy in lock key
+   */
+  systemLock?: boolean
 }

--- a/packages/worker/src/migrations/index.ts
+++ b/packages/worker/src/migrations/index.ts
@@ -53,6 +53,7 @@ const migrateWithLock = async (options?: MigrationOptions) => {
       type: LockType.TRY_ONCE,
       name: LockName.MIGRATIONS,
       ttl: 1000 * 60 * 15, // auto expire the migration lock after 15 minutes
+      systemLock: true,
     },
     async () => {
       await migrations.runMigrations(MIGRATIONS, options)


### PR DESCRIPTION
## Description

Fixes for

**Migrations not running**
- The `initPro` call results in a never ending promise, as with automations init. 
- This prevented migration and the rest of the startup not running
- Add this to a promises array instead, and await it along with the automations init at the very end of startup

**Reboot trigger tenancy error**
- When running in `SELF = 1` and `MULTI_TENANCY = 1`, the `getAllApps` call produces an error that crashes startup

**Migrations lock error**
- When running in `SELF = 1` and `MULTI_TENANCY = 1`, the migrations fails to determine tenant id and produces an error that crashes startup. 
- Configure this lock as a `systemLock` instead to bypass tenancy 

**Default bucket names (k8s)**
- Remove the default bucket names in k8s. These are defaulted application side where the correct apps bucket name is used 