### PR TITLE
Automations substitute 'loop' in step bindings fixes

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -120,7 +120,7 @@
         allSteps[idx]?.stepId === ActionStepID.LOOP &&
         allSteps.find(x => x.blockToLoop === block.id)
 
-      // If the previous block was a loop block, decerement the index so the following
+      // If the previous block was a loop block, decrement the index so the following
       // steps are in the correct order
       if (wasLoopBlock) {
         loopBlockCount++

--- a/packages/server/src/automations/automationUtils.js
+++ b/packages/server/src/automations/automationUtils.js
@@ -82,24 +82,34 @@ exports.getError = err => {
 }
 
 exports.substituteLoopStep = (hbsString, substitute) => {
-  let blocks = []
   let checkForJS = isJSBinding(hbsString)
+  let substitutedHbsString = ""
+  let open = checkForJS ? `$("` : "{{"
+  let closed = checkForJS ? `")` : "}}"
   if (checkForJS) {
     hbsString = decodeJSBinding(hbsString)
-    blocks.push(hbsString)
-  } else {
-    blocks = findHBSBlocks(hbsString)
   }
-  for (let block of blocks) {
-    block = block.replace(/loop/, substitute)
-    if (checkForJS) {
-      hbsString = encodeJSBinding(block)
-    } else {
-      hbsString = block
+  let pointer = 0,
+    openPointer = 0,
+    closedPointer = 0
+  while (pointer < hbsString.length) {
+    openPointer = hbsString.indexOf(open, pointer)
+    closedPointer = hbsString.indexOf(closed, pointer) + 2
+    if (openPointer < 0 || closedPointer < 0) {
+      substitutedHbsString += hbsString.substring(pointer)
+      break
     }
+    let before = hbsString.substring(pointer, openPointer)
+    let block = hbsString
+      .substring(openPointer, closedPointer)
+      .replace(/loop/, substitute)
+    substitutedHbsString += before + block
+    pointer = closedPointer
   }
-
-  return hbsString
+  if (checkForJS) {
+    substitutedHbsString = encodeJSBinding(substitutedHbsString)
+  }
+  return substitutedHbsString
 }
 
 exports.stringSplit = value => {

--- a/packages/server/src/automations/automationUtils.js
+++ b/packages/server/src/automations/automationUtils.js
@@ -1,6 +1,5 @@
 const { getTable } = require("../api/controllers/table/utils")
 const {
-  findHBSBlocks,
   decodeJSBinding,
   isJSBinding,
   encodeJSBinding,

--- a/packages/server/src/automations/unitTests/automationUtils.spec.js
+++ b/packages/server/src/automations/unitTests/automationUtils.spec.js
@@ -1,0 +1,17 @@
+const automationUtils = require("../automationUtils")
+
+describe("automationUtils", () => {
+    test("substituteLoopStep should allow multiple loop binding substitutes", () => {
+        expect(automationUtils.substituteLoopStep(
+            `{{ loop.currentItem._id }} {{ loop.currentItem._id }} {{ loop.currentItem._id }}`, 
+            "step.2"))
+        .toBe(`{{ step.2.currentItem._id }} {{ step.2.currentItem._id }} {{ step.2.currentItem._id }}`)
+    })
+
+    test("substituteLoopStep should handle not subsituting outside of curly braces", () => {
+        expect(automationUtils.substituteLoopStep(
+            `loop {{ loop.currentItem._id }}loop loop{{ loop.currentItem._id }}loop`, 
+            "step.2"))
+        .toBe(`loop {{ step.2.currentItem._id }}loop loop{{ step.2.currentItem._id }}loop`)
+    })
+})


### PR DESCRIPTION
## Description
Originally there was an issue with correctly outputting HTML contents to email body, but this issue applied to any bindings that use looping.
In addition, I noticed that the binding substitutions only applied to the last bindings and not all bindings in the statement. 
Fixes added with a couple of unit tests.

Addresses: 
- https://github.com/Budibase/budibase/issues/8202



