### PR TITLE
Chart title color theme

### DIFF
--- a/packages/client/src/components/app/charts/ApexOptionsBuilder.js
+++ b/packages/client/src/components/app/charts/ApexOptionsBuilder.js
@@ -61,7 +61,7 @@ export class ApexOptionsBuilder {
   }
 
   title(title) {
-    return this.setOption(["title", "text"], title)
+    return this.setOption(["title"], title)
   }
 
   colors(colors) {

--- a/packages/client/src/components/app/charts/BarChart.svelte
+++ b/packages/client/src/components/app/charts/BarChart.svelte
@@ -81,7 +81,12 @@
     // Initialise default chart
     let builder = new ApexOptionsBuilder()
       .type("bar")
-      .title(title)
+      .title({
+        text: title,
+        style: {
+          color: "var(--spectrum-glo" + "bal-color-gray-800)",
+        },
+      })
       .width(width)
       .height(height)
       .xLabel(xAxisLabel)

--- a/packages/client/src/components/app/charts/CandleStickChart.svelte
+++ b/packages/client/src/components/app/charts/CandleStickChart.svelte
@@ -68,7 +68,12 @@
     // Initialise default chart
     let builder = new ApexOptionsBuilder()
       .type("candlestick")
-      .title(title)
+      .title({
+        text: title,
+        style: {
+          color: "var(--spectrum-glo" + "bal-color-gray-800)",
+        },
+      })
       .width(width)
       .height(height)
       .xLabel(xAxisLabel)

--- a/packages/client/src/components/app/charts/LineChart.svelte
+++ b/packages/client/src/components/app/charts/LineChart.svelte
@@ -89,7 +89,12 @@
 
     // Initialise default chart
     let builder = new ApexOptionsBuilder()
-      .title(title)
+      .title({
+        text: title,
+        style: {
+          color: "var(--spectrum-glo" + "bal-color-gray-800)",
+        },
+      })
       .type(area ? "area" : "line")
       .width(width)
       .height(height)

--- a/packages/client/src/components/app/charts/PieChart.svelte
+++ b/packages/client/src/components/app/charts/PieChart.svelte
@@ -68,7 +68,12 @@
 
     // Initialise default chart
     let builder = new ApexOptionsBuilder()
-      .title(title)
+      .title({
+        text: title,
+        style: {
+          color: "var(--spectrum-glo" + "bal-color-gray-800)",
+        },
+      })
       .type(donut ? "donut" : "pie")
       .width(width)
       .height(height)


### PR DESCRIPTION
## Description
Chart title colour now updates when theme is changed.

Addresses: 
- https://github.com/Budibase/budibase/issues/8403

## Screenshots
**NORD**
![Screenshot 2022-10-26 at 15 59 20](https://user-images.githubusercontent.com/101575380/198061854-48dfb2bb-27e4-4829-b479-e88d2f2d45b6.png)

**LIGHTEST**
![Screenshot 2022-10-26 at 15 59 42](https://user-images.githubusercontent.com/101575380/198061935-d3219bdb-5acb-482e-8f78-9cdcd9e7af65.png)

**DARKEST**
![Screenshot 2022-10-26 at 16 00 02](https://user-images.githubusercontent.com/101575380/198062007-ec1c7cde-f329-48e7-86d2-ebc6ba0a4998.png)

