### PR TITLE
Datasource validation - use nullable to avoid type error

### DIFF
--- a/packages/builder/src/helpers/validation/yup/index.js
+++ b/packages/builder/src/helpers/validation/yup/index.js
@@ -28,15 +28,13 @@ export const createValidationStore = () => {
     let propertyValidator
     switch (type) {
       case "number":
-        propertyValidator = number().transform(value =>
-          isNaN(value) ? undefined : value
-        )
+        propertyValidator = number().nullable()
         break
       case "email":
-        propertyValidator = string().email()
+        propertyValidator = string().email().nullable()
         break
       default:
-        propertyValidator = string()
+        propertyValidator = string().nullable()
     }
 
     if (required) {

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -64,7 +64,6 @@ const SCHEMA: Integration = {
     database: {
       type: DatasourceFieldType.STRING,
       required: true,
-      default: "db",
     },
     ssl: {
       type: DatasourceFieldType.OBJECT,

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -64,6 +64,7 @@ const SCHEMA: Integration = {
     database: {
       type: DatasourceFieldType.STRING,
       required: true,
+      default: "db",
     },
     ssl: {
       type: DatasourceFieldType.OBJECT,


### PR DESCRIPTION
## Description
Originally I thought *nullable* was the same as *optional*, but it actually removes the typing constraint, but maintains the *required* constraint.

Addresses: 
- https://github.com/Budibase/budibase/issues/6538

## Screenshots
**Before**
![Screenshot 2022-10-27 at 14 49 26](https://user-images.githubusercontent.com/101575380/198302622-617ed36e-70b8-4985-9890-d6286c4a2438.png)

**After**
![Screenshot 2022-10-27 at 14 48 37](https://user-images.githubusercontent.com/101575380/198302437-db489e15-bb67-4fc8-81ab-78bf5b4def82.png)
