### PR TITLE
Handle mysql id decoding in relationships for automations

### DIFF
--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -286,9 +286,7 @@ module External {
           if (isNaN(id)) {
             id = decodeURIComponent(row[key]).match(/\[(.*?)\]/)?.[1]
           }
-          newRow[field.foreignKey || linkTablePrimary] = breakRowIdField(
-            id
-          )[0]
+          newRow[field.foreignKey || linkTablePrimary] = breakRowIdField(id)[0]
         }
         // many to many
         else if (field.through) {

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -283,7 +283,7 @@ module External {
         // one to many
         if (isOneSide(field)) {
           let id = row[key][0]
-          if (isNaN(id)) {
+          if (typeof row[key] === "string") {
             id = decodeURIComponent(row[key]).match(/\[(.*?)\]/)?.[1]
           }
           newRow[field.foreignKey || linkTablePrimary] = breakRowIdField(id)[0]

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -282,8 +282,12 @@ module External {
         const linkTablePrimary = linkTable.primary[0]
         // one to many
         if (isOneSide(field)) {
+          let id = row[key][0]
+          if (isNaN(id)) {
+            id = decodeURIComponent(row[key]).match(/\[(.*?)\]/)?.[1]
+          }
           newRow[field.foreignKey || linkTablePrimary] = breakRowIdField(
-            row[key][0]
+            id
           )[0]
         }
         // many to many

--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -38,7 +38,7 @@ export async function patch(ctx: any): Promise<any> {
       }
     )
     if (!row) {
-      ctx.throw(404, "Row not found!")
+      ctx.throw(404, "Row not found")
     }
     ctx.status = 200
     ctx.eventEmitter &&

--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -37,6 +37,9 @@ export async function patch(ctx: any): Promise<any> {
         datasourceId: tableId,
       }
     )
+    if (!row) {
+      ctx.throw(404, "Row not found!")
+    }
     ctx.status = 200
     ctx.eventEmitter &&
       ctx.eventEmitter.emitRow(`row:update`, appId, row, table)

--- a/qa-core/src/config/internal-api/fixtures/types/unpublishAppResponse.ts
+++ b/qa-core/src/config/internal-api/fixtures/types/unpublishAppResponse.ts
@@ -1,7 +1,7 @@
 export interface UnpublishAppResponse {
-    data: {
-        ok: boolean
-    },
-    ok: boolean,
-    status: number
+  data: {
+    ok: boolean
+  }
+  ok: boolean
+  status: number
 }


### PR DESCRIPTION
## Description
ID can be encoded string, so need to decode if needed.
Also added a minor fix when trying to patch a non-existent row. 

Addresses: 
- https://github.com/Budibase/budibase/issues/6048



