### PR TITLE
Fixing server to handle both gzip and x-gzip mimetypes for app imports

### DIFF
--- a/packages/server/src/sdk/app/backups/imports.ts
+++ b/packages/server/src/sdk/app/backups/imports.ts
@@ -120,6 +120,9 @@ async function updateAutomations(prodAppId: string, db: PouchDB.Database) {
  * @returns {Object} Returns a fs read stream which can be loaded into the database.
  */
 async function getTemplateStream(template: TemplateType) {
+  if (template.file && template.file.type !== "text/plain") {
+    throw new Error("Cannot import a non-text based file.")
+  }
   if (template.file) {
     return fs.createReadStream(template.file.path)
   } else if (template.key) {
@@ -156,7 +159,7 @@ export async function importApp(
 ) {
   let prodAppId = dbCore.getProdAppID(appId)
   let dbStream: any
-  const isTar = template.file && template.file.type === "application/gzip"
+  const isTar = template.file && template?.file?.type?.endsWith("gzip")
   const isDirectory =
     template.file && fs.lstatSync(template.file.path).isDirectory()
   if (template.file && (isTar || isDirectory)) {


### PR DESCRIPTION
## Description
Fixing an issue with some browsers sending the gzip type as x-gzip rather than gzip, which caused the processing to fail.

On Windows/OSX if you send a multipart form-data request with a tar.gz in it, the content-type of the file will be denoted as `application/x-gzip`. If you do this in a Linux environment, it will use the new proper standard of `application/gzip`. The incorrect type caused the server to hang and the request to not be logged.
