### PR TITLE
User table validation messaging

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditUser.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditUser.svelte
@@ -70,7 +70,11 @@
               .map(([key, error]) => ({ dataPath: key, message: error }))
               .flat()
           }
-        } else if (error.status === 400) {
+        } else if (error.status === 400 && response?.validationErrors) {
+          errors = Object.keys(response.validationErrors).map(field => ({
+            message: `${field} ${response.validationErrors[field][0]}`,
+          }))
+        } else {
           errors = [{ message: response?.message || "Unknown error" }]
         }
       } else {


### PR DESCRIPTION
## Description
Validation messages received when when updating the User table are now displayed in full. 

Addresses: 
- https://github.com/Budibase/budibase/issues/8298

## Screenshots

![Screenshot 2022-10-28 at 15 41 40](https://user-images.githubusercontent.com/5913006/198657596-41e71470-640c-4500-a987-1c40e765ee59.png)


