### PR TITLE
Fix syntax for ellipsis helper

### DIFF
--- a/packages/string-templates/manifest.json
+++ b/packages/string-templates/manifest.json
@@ -625,7 +625,7 @@
         "length"
       ],
       "numArgs": 2,
-      "example": "{{ellipsis 'foo bar baz', 7}} -> foo bar…",
+      "example": "{{ellipsis 'foo bar baz' 7}} -> foo bar…",
       "description": "<p>Truncates a string to the specified <code>length</code>, and appends it with an elipsis, <code>…</code>.</p>\n"
     },
     "hyphenate": {


### PR DESCRIPTION
## Description
Problem: The suggested ellipsis syntax breaks the handlebars expression due to an additional comma.

Solution: Removed the comma from the help text,

## Screenshots
![Screenshot 2022-10-29 115701](https://user-images.githubusercontent.com/19203795/198825325-96dade30-e284-4d91-8e75-9aefe1fbdae5.png)


