### PR TITLE
Fix query viewer bindings

### DIFF
--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -137,7 +137,12 @@
           queryBindings={query.parameters}
           bindable={false}
           on:change={e => {
-            query.parameters = e.detail
+            query.parameters = e.detail.map(binding => {
+              return {
+                name: binding.name,
+                default: binding.value,
+              }
+            })
           }}
         />
       {/key}

--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -132,7 +132,15 @@
           config={integrationInfo.extra}
         />
       {/if}
-      <BindingBuilder bind:queryBindings={query.parameters} bindable={false} />
+      {#key query.parameters}
+        <BindingBuilder
+          queryBindings={query.parameters}
+          bindable={false}
+          on:change={e => {
+            query.parameters = e.detail
+          }}
+        />
+      {/key}
     {/if}
   </div>
   {#if shouldShowQueryConfig}

--- a/packages/builder/src/components/integration/QueryViewerBindingBuilder.svelte
+++ b/packages/builder/src/components/integration/QueryViewerBindingBuilder.svelte
@@ -2,7 +2,6 @@
   import { Body, Button, Heading, Layout } from "@budibase/bbui"
   import KeyValueBuilder from "components/integration/KeyValueBuilder.svelte"
   import { getUserBindings } from "builderStore/dataBinding"
-  import { createEventDispatcher } from "svelte"
   export let bindable = true
   export let queryBindings = []
 
@@ -12,7 +11,6 @@
     acc[binding.name] = binding.default
     return acc
   }, {})
-  let dispatch = createEventDispatcher()
 
   function newQueryBinding() {
     queryBindings = [...queryBindings, {}]
@@ -46,17 +44,7 @@
       valuePlaceholder="Default"
       bindings={[...userBindings]}
       bindingDrawerLeft="260px"
-      on:change={e => {
-        dispatch(
-          "change",
-          e.detail.map(binding => {
-            return {
-              name: binding.name,
-              default: binding.value,
-            }
-          })
-        )
-      }}
+      on:change
     />
   </div>
 </Layout>

--- a/packages/builder/src/components/integration/QueryViewerBindingBuilder.svelte
+++ b/packages/builder/src/components/integration/QueryViewerBindingBuilder.svelte
@@ -2,6 +2,7 @@
   import { Body, Button, Heading, Layout } from "@budibase/bbui"
   import KeyValueBuilder from "components/integration/KeyValueBuilder.svelte"
   import { getUserBindings } from "builderStore/dataBinding"
+  import { createEventDispatcher } from "svelte"
   export let bindable = true
   export let queryBindings = []
 
@@ -11,6 +12,7 @@
     acc[binding.name] = binding.default
     return acc
   }, {})
+  let dispatch = createEventDispatcher()
 
   function newQueryBinding() {
     queryBindings = [...queryBindings, {}]
@@ -45,12 +47,15 @@
       bindings={[...userBindings]}
       bindingDrawerLeft="260px"
       on:change={e => {
-        queryBindings = e.detail.map(binding => {
-          return {
-            name: binding.name,
-            default: binding.value,
-          }
-        })
+        dispatch(
+          "change",
+          e.detail.map(binding => {
+            return {
+              name: binding.name,
+              default: binding.value,
+            }
+          })
+        )
       }}
     />
   </div>


### PR DESCRIPTION
## Description
Bindings were not updating when switching between datasource queries.
Added a **key** on the *query.parameters* to refresh the binding builder when the query parameters change.

Addresses: 
- https://github.com/Budibase/budibase/issues/8369

## Screenshots
**Fixed**
![query_viewer_binding](https://user-images.githubusercontent.com/101575380/199478806-1b652692-77a6-4e54-8578-0ea873f4109a.gif)



