### PR TITLE
Fix Form Block Create Mode Bindings Causing Error When Ejected

### DIFF
--- a/packages/client/src/components/app/blocks/FormBlock.svelte
+++ b/packages/client/src/components/app/blocks/FormBlock.svelte
@@ -85,13 +85,8 @@
       valueType: "Binding",
     },
   ]
-  // If we're using an "update" form, use the real data provider. If we're
-  // using a create form, we just want a fake array so that our repeater
-  // will actually render the form, but data doesn't matter.
-  $: dataProvider =
-    actionType !== "Create"
-      ? `{{ literal ${safe(providerId)} }}`
-      : { rows: [{}] }
+
+  $: dataProvider = `{{ literal ${safe(providerId)} }}`
   $: renderDeleteButton = showDeleteButton && actionType === "Update"
   $: renderSaveButton = showSaveButton && actionType !== "View"
   $: renderButtons = renderDeleteButton || renderSaveButton


### PR DESCRIPTION
Looking this [issue](https://github.com/Budibase/budibase/issues/8468). Bit of a weird one, actually nothing to do with DnD I think:

[Line throwing the error](https://github.com/Budibase/budibase/blob/develop/packages/builder/src/builderStore/dataBinding.js#L1006)

Moving or highlighting the repeater of an ejected create mode form block causes the page to crash.

I believe some component only visible to the user when the component is ejected, possibly the provider selector of the repeater, is trying to parse the object passed to the repeater as a binding; this is causing an error since it's not a string. 

The block works fine when not ejected because this field isn't visible, and the component itself accepts objects just fine.

Changing the form block to pass a binding string instead of an object to the repeater fixes the issue, my knowledge of handlebars isn't great so there might well be a much cleaner way to handle this, but for the life of me I couldn't find a way to pass an object literal 🤷 

Addresses:

https://github.com/Budibase/budibase/issues/8493
https://github.com/Budibase/budibase/issues/8468
