### PR TITLE
Fix for auto-generated screens - buttons navigating correctly

### DIFF
--- a/packages/client/src/components/app/blocks/FormBlock.svelte
+++ b/packages/client/src/components/app/blocks/FormBlock.svelte
@@ -48,6 +48,9 @@
     },
     {
       "##eventHandlerType": "Close Screen Modal",
+      parameters: {
+        url: actionUrl,
+      },
     },
     {
       "##eventHandlerType": "Navigate To",
@@ -68,6 +71,9 @@
     },
     {
       "##eventHandlerType": "Close Screen Modal",
+      parameters: {
+        url: actionUrl,
+      },
     },
     {
       "##eventHandlerType": "Navigate To",

--- a/packages/client/src/components/app/blocks/FormBlock.svelte
+++ b/packages/client/src/components/app/blocks/FormBlock.svelte
@@ -48,9 +48,6 @@
     },
     {
       "##eventHandlerType": "Close Screen Modal",
-      parameters: {
-        url: actionUrl,
-      },
     },
     {
       "##eventHandlerType": "Navigate To",
@@ -71,9 +68,6 @@
     },
     {
       "##eventHandlerType": "Close Screen Modal",
-      parameters: {
-        url: actionUrl,
-      },
     },
     {
       "##eventHandlerType": "Navigate To",

--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -225,7 +225,10 @@ const changeFormStepHandler = async (action, context) => {
 }
 
 const closeScreenModalHandler = action => {
-  let { url } = action.parameters
+  let url
+  if (action?.parameters) {
+    url = action.parameters.url
+  }
   // Emit this as a window event, so parent screens which are iframing us in
   // can close the modal
   window.parent.postMessage({ type: "close-screen-modal", url })


### PR DESCRIPTION
## Description
Fix for #8491 - auto generated screens use the form block now which had an issue with the close screen event not providing a URL.

Addresses: 
- #8491