### PR TITLE
Disable screen validation

### DIFF
--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -245,7 +245,10 @@ export const getFrontendStore = () => {
         }
       },
       save: async screen => {
-        store.actions.screens.validate(screen)
+        /* 
+          Temporarily disabled to accomodate migration issues.
+          store.actions.screens.validate(screen)
+        */
         const state = get(store)
         const creatingNewScreen = screen._id === undefined
         const savedScreen = await API.saveScreen(screen)


### PR DESCRIPTION
## Description

Temporarily disabling screen validation. Current approach locks users with invalid screen configuration to alter their screens.

Addresses: 
- https://github.com/Budibase/budibase/issues/8478