### PR TITLE
Check schema exists for custom options multi picker

### DIFF
--- a/packages/client/src/components/app/forms/InnerForm.svelte
+++ b/packages/client/src/components/app/forms/InnerForm.svelte
@@ -131,7 +131,7 @@
   const getDefault = (defaultValue, schema, type) => {
     // Remove any values not present in the field schema
     // Convert any values supplied to string
-    if (Array.isArray(defaultValue) && type == "array") {
+    if (Array.isArray(defaultValue) && type == "array" && schema) {
       return defaultValue.reduce((acc, entry) => {
         let processedOption = String(entry)
         let schemaOptions = schema.constraints.inclusion


### PR DESCRIPTION
## Description
Null pointer was caused when the user selected **Custom** as the options source in a multi-picker.
Fixed! 

Addresses: 
- https://github.com/Budibase/budibase/issues/8526




