### PR TITLE
ensure /app prefix gets stripped from website templates

### DIFF
--- a/packages/builder/src/pages/builder/portal/apps/index.svelte
+++ b/packages/builder/src/pages/builder/portal/apps/index.svelte
@@ -167,7 +167,7 @@
   const autoCreateApp = async () => {
     try {
       // Auto name app if has same name
-      let appName = template.key
+      let appName = template.key.replace("app/", "")
       const appsWithSameName = $apps.filter(app =>
         app.name?.startsWith(appName)
       )


### PR DESCRIPTION
## Description
A validation error was being thrown on new app creation from the templates on the website. The `name` contained the prefix of `app/` which was causing the error due to the forward slash.

Addresses: 
- https://github.com/Budibase/budibase/issues/8533

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._



