### PR TITLE
Prevent special characters being used in new internal DB column

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -304,7 +304,7 @@
     const newError = {}
     if (!external && fieldInfo.name?.startsWith("_")) {
       newError.name = `Column name cannot start with an underscore.`
-    } else if (fieldInfo.name?.match(/[-!*+?^"{}()~/[\]\\]/g)) {
+    } else if (fieldInfo.name?.match(/[-!*+?:^"{}()~/[\]\\]/g)) {
       newError.name = `Illegal character; cannot be: + - ! ( ) { } [ ] ^ " ~ * ? : \\ /`
     } else if (PROHIBITED_COLUMN_NAMES.some(name => fieldInfo.name === name)) {
       newError.name = `${PROHIBITED_COLUMN_NAMES.join(

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -304,7 +304,7 @@
     const newError = {}
     if (!external && fieldInfo.name?.startsWith("_")) {
       newError.name = `Column name cannot start with an underscore.`
-    } else if (fieldInfo.name?.match(/[\-!*+?^"{}()~\/[\]\\]/g)) {
+    } else if (fieldInfo.name?.match(/[-!*+?^"{}()~/[\]\\]/g)) {
       newError.name = `Illegal character; cannot be: + - ! ( ) { } [ ] ^ " ~ * ? : \\ /`
     } else if (PROHIBITED_COLUMN_NAMES.some(name => fieldInfo.name === name)) {
       newError.name = `${PROHIBITED_COLUMN_NAMES.join(

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -304,6 +304,8 @@
     const newError = {}
     if (!external && fieldInfo.name?.startsWith("_")) {
       newError.name = `Column name cannot start with an underscore.`
+    } else if (fieldInfo.name?.match(/[\-!*+?^"{}()~\/[\]\\]/g)) {
+      newError.name = `Illegal character; cannot be: + - ! ( ) { } [ ] ^ " ~ * ? : \\ /`
     } else if (PROHIBITED_COLUMN_NAMES.some(name => fieldInfo.name === name)) {
       newError.name = `${PROHIBITED_COLUMN_NAMES.join(
         ", "

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -304,8 +304,8 @@
     const newError = {}
     if (!external && fieldInfo.name?.startsWith("_")) {
       newError.name = `Column name cannot start with an underscore.`
-    } else if (fieldInfo.name?.match(/[-!*+?:^"{}()~/[\]\\]/g)) {
-      newError.name = `Illegal character; cannot be: + - ! ( ) { } [ ] ^ " ~ * ? : \\ /`
+    } else if (fieldInfo.name && !fieldInfo.name.match(/^[a-zA-Z0-9\s]*$/g)) {
+      newError.name = `Illegal character; must be alpha-numeric.`
     } else if (PROHIBITED_COLUMN_NAMES.some(name => fieldInfo.name === name)) {
       newError.name = `${PROHIBITED_COLUMN_NAMES.join(
         ", "


### PR DESCRIPTION
## Description
Joe created a row with a forward slash in it, which buggered the table rows upon sorting.
The couchdb index could be updated to handle this, however it is easier to prevent new internal DB columns being created with illegal lucene characters.

Addresses: 
- https://github.com/Budibase/budibase/issues/8594
- https://github.com/Budibase/budibase/issues/8621

## Screenshots
![Screenshot 2022-11-08 at 17 16 48](https://user-images.githubusercontent.com/101575380/200631774-5cfeaa9f-0c80-479a-ad08-57e7fa166816.png)




