### PR TITLE
Bug: Fixed save query button not showing when function is equal read

### DIFF
--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -41,7 +41,7 @@
   $: integrationInfo = datasourceType ? $integrations[datasourceType] : null
   $: queryConfig = integrationInfo?.query
   $: shouldShowQueryConfig = queryConfig && query.queryVerb
-  $: readQuery = query.queryVerb === "read" || query.readable
+  $: readQuery = query.queryVerb === "" || query.readable
   $: queryInvalid = !query.name || (readQuery && data.length === 0)
 
   //Cast field in query preview response to number if specified by schema

--- a/packages/client/yarn.lock
+++ b/packages/client/yarn.lock
@@ -671,15 +671,9 @@ has@^1.0.3:
     function-bind "^1.1.1"
 
 html5-qrcode@^2.2.1:
-<<<<<<< HEAD
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/html5-qrcode/-/html5-qrcode-2.2.4.tgz#99e4b36fbd8fbc4956036cf3f21ea3e98c3463d1"
-  integrity sha512-X8wVVsHpNb35tl7KcoCGAboc6Nep2VyT3CIMjFvrfWrHbHTC0yYTjE+DhO/VcswY2MfHy1uB7b1G9+L13gM6dQ==
-=======
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/html5-qrcode/-/html5-qrcode-2.2.3.tgz#5acb826860365e7c7ab91e1e14528ea16a502e8a"
   integrity sha512-9CtEz5FVT56T76entiQxyrASzBWl8Rm30NHiQH8T163Eml5LS14BoZlYel9igxbikOt7O8KhvrT3awN1Y2HMqw==
->>>>>>> 50f0a0509d79dcee7a0f12608054279d65662b10
 
 htmlparser2@^6.0.0:
   version "6.1.0"


### PR DESCRIPTION
## Description
When creating a new query, if the name is not written, the Save Button is disabled. This sounds good but when the selected function is read, even if the query name is written, the save query button still appears disabled.

Addresses: 
-  [https://github.com/Budibase/budibase/issues/8523](https://github.com/Budibase/budibase/issues/8523)


## Files touched 
- packages/builder/src/components/integration/QueryViewer.svelte

## Screenshots
Before:
<img width="545" alt="Screen Shot 2022-11-08 at 11 54 15 PM" src="https://user-images.githubusercontent.com/30754017/200693878-87dcecc6-0580-425b-acd7-9d6069ce01c4.png">
After: 
<img width="545" alt="Screen Shot 2022-11-08 at 11 54 02 PM" src="https://user-images.githubusercontent.com/30754017/200693939-52b33524-9cd5-4f4c-9c57-3d69a309c03e.png">







