### PR TITLE
patching sub dep for loader-utils to patch security vulnerability

### DIFF
--- a/packages/bbui/package.json
+++ b/packages/bbui/package.json
@@ -85,5 +85,8 @@
     "svelte-flatpickr": "^3.2.3",
     "svelte-portal": "^1.0.0"
   },
+  "resolutions": {
+    "loader-utils": "1.4.1"
+  },
   "gitHead": "d1836a898cab3f8ab80ee6d8f42be1a9eed7dcdc"
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -59,5 +59,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-visualizer": "^5.5.4"
   },
+  "resolutions": {
+    "loader-utils": "1.4.1"
+  },
   "gitHead": "d1836a898cab3f8ab80ee6d8f42be1a9eed7dcdc"
 }


### PR DESCRIPTION
## Description
`yarn audit` reported a critical security vulnerabiltiy in `loader-utils` - a very old version of which is being used in one of our sub dependencies, `rollup-plugin-postcss`.

<img width="576" alt="Screenshot 2022-11-09 at 13 59 10" src="https://user-images.githubusercontent.com/11256663/200849457-0ec47c92-af99-4ddc-800e-ac2125cf4150.png">

Since `rollup-plugin-postcss` is no longer maintained, I've opted to override the `loader-utils` dependency with the patched version using the `resolutions` key in `package.json`. This solves the issue.

Addresses: 
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._



