### PR TITLE
add name for backup before publish

### DIFF
--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -115,6 +115,7 @@ async function deployApp(deployment: any, userId: string) {
         AppBackupTrigger.PUBLISH,
         {
           createdBy: userId,
+          name: 'Backup before publish',
         }
       )
     }


### PR DESCRIPTION
## Description
without name, all publish backup will fail with error 
```
App backup error : {"stack":"InvalidHeader: Header x-amz-meta-name contains invalid value
```

## Screenshots
![image](https://user-images.githubusercontent.com/4613808/201395077-33147e06-397e-4f34-8087-d60d74abad6f.png)



