### PR TITLE
Allow user to disable hard coded notifications for button actions #7604

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DeleteRow.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DeleteRow.svelte
@@ -27,8 +27,11 @@
   />
 
   <Label small />
-  <Checkbox text="Do not display default notification" bind:value={parameters.notificationOverride} />
-  <br>
+  <Checkbox
+    text="Do not display default notification"
+    bind:value={parameters.notificationOverride}
+  />
+  <br />
   <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
 
   {#if parameters.confirm}

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DeleteRow.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DeleteRow.svelte
@@ -27,6 +27,8 @@
   />
 
   <Label small />
+  <Checkbox text="Do not display default notification" bind:value={parameters.notificationOverride} />
+  <br>
   <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
 
   {#if parameters.confirm}

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DuplicateRow.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DuplicateRow.svelte
@@ -95,6 +95,8 @@
     />
 
     <Label small />
+    <Checkbox text="Do not display default notification" bind:value={parameters.notificationOverride} />
+    <br>
     <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
 
     {#if parameters.confirm}

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DuplicateRow.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DuplicateRow.svelte
@@ -95,8 +95,11 @@
     />
 
     <Label small />
-    <Checkbox text="Do not display default notification" bind:value={parameters.notificationOverride} />
-    <br>
+    <Checkbox
+      text="Do not display default notification"
+      bind:value={parameters.notificationOverride}
+    />
+    <br />
     <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
 
     {#if parameters.confirm}

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/ExecuteQuery.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/ExecuteQuery.svelte
@@ -44,8 +44,11 @@
       getOptionLabel={query => query.name}
       getOptionValue={query => query._id}
     />
-    <Checkbox text="Do not display default notification" bind:value={parameters.notificationOverride} />
-    <br>
+    <Checkbox
+      text="Do not display default notification"
+      bind:value={parameters.notificationOverride}
+    />
+    <br />
     {#if parameters.queryId}
       <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
 

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/ExecuteQuery.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/ExecuteQuery.svelte
@@ -44,7 +44,8 @@
       getOptionLabel={query => query.name}
       getOptionValue={query => query._id}
     />
-
+    <Checkbox text="Do not display default notification" bind:value={parameters.notificationOverride} />
+    <br>
     {#if parameters.queryId}
       <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
 

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/SaveRow.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/SaveRow.svelte
@@ -95,6 +95,8 @@
     />
 
     <Label small />
+    <Checkbox text="Do not display default notification" bind:value={parameters.notificationOverride} />
+    <br>
     <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
 
     {#if parameters.confirm}

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/SaveRow.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/SaveRow.svelte
@@ -95,8 +95,11 @@
     />
 
     <Label small />
-    <Checkbox text="Do not display default notification" bind:value={parameters.notificationOverride} />
-    <br>
+    <Checkbox
+      text="Do not display default notification"
+      bind:value={parameters.notificationOverride}
+    />
+    <br />
     <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
 
     {#if parameters.confirm}

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/TriggerAutomation.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/TriggerAutomation.svelte
@@ -93,6 +93,8 @@
     {/if}
 
     <Label small />
+    <Checkbox text="Do not display default notification" bind:value={parameters.notificationOverride} />
+    <br>
     <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
 
     {#if parameters.confirm}

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/TriggerAutomation.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/TriggerAutomation.svelte
@@ -93,8 +93,11 @@
     {/if}
 
     <Label small />
-    <Checkbox text="Do not display default notification" bind:value={parameters.notificationOverride} />
-    <br>
+    <Checkbox
+      text="Do not display default notification"
+      bind:value={parameters.notificationOverride}
+    />
+    <br />
     <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
 
     {#if parameters.confirm}

--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -17,7 +17,8 @@ import { enrichDataBindings } from "./enrichDataBinding"
 import { Helpers } from "@budibase/bbui"
 
 const saveRowHandler = async (action, context) => {
-  const { fields, providerId, tableId, notificationOverride } = action.parameters
+  const { fields, providerId, tableId, notificationOverride } =
+    action.parameters
   let payload
   if (providerId) {
     payload = { ...context[providerId] }
@@ -34,8 +35,8 @@ const saveRowHandler = async (action, context) => {
   }
   try {
     const row = await API.saveRow(payload)
-    
-    if (!notificationOverride){
+
+    if (!notificationOverride) {
       notificationStore.actions.success("Row saved")
     }
 
@@ -52,7 +53,8 @@ const saveRowHandler = async (action, context) => {
 }
 
 const duplicateRowHandler = async (action, context) => {
-  const { fields, providerId, tableId, notificationOverride } = action.parameters
+  const { fields, providerId, tableId, notificationOverride } =
+    action.parameters
   if (providerId) {
     let payload = { ...context[providerId] }
     if (fields) {
@@ -67,7 +69,7 @@ const duplicateRowHandler = async (action, context) => {
     delete payload._rev
     try {
       const row = await API.saveRow(payload)
-      if (!notificationOverride){
+      if (!notificationOverride) {
         notificationStore.actions.success("Row saved")
       }
 
@@ -89,7 +91,7 @@ const deleteRowHandler = async action => {
   if (tableId && rowId) {
     try {
       await API.deleteRow({ tableId, rowId, revId })
-      if (!notificationOverride){
+      if (!notificationOverride) {
         notificationStore.actions.success("Row deleted")
       }
 
@@ -112,7 +114,7 @@ const triggerAutomationHandler = async action => {
         automationId: action.parameters.automationId,
         fields,
       })
-      if (!notificationOverride){
+      if (!notificationOverride) {
         notificationStore.actions.success("Automation triggered")
       }
     } catch (error) {
@@ -128,7 +130,8 @@ const navigationHandler = action => {
 }
 
 const queryExecutionHandler = async action => {
-  const { datasourceId, queryId, queryParams, notificationOverride } = action.parameters
+  const { datasourceId, queryId, queryParams, notificationOverride } =
+    action.parameters
   try {
     const query = await API.fetchQueryDefinition(queryId)
     if (query?.datasourceId == null) {
@@ -144,7 +147,7 @@ const queryExecutionHandler = async action => {
     // Trigger a notification and invalidate the datasource as long as this
     // was not a readable query
     if (!query.readable) {
-      if (!notificationOverride){
+      if (!notificationOverride) {
         notificationStore.actions.success("Query executed successfully")
       }
       await dataSourceStore.actions.invalidateDataSource(query.datasourceId)


### PR DESCRIPTION
## Description
Added a checkbox to allow the user to disable the default notifications to the following button actions:
* Save row
* Duplicate row
* Trigger automation
* Execute query
* Delete row 

Also adjusted buttonActions.js to reflect the behavior of that checkbox being ticked.

Addresses:
-  #7604

## App Export
[DefaultNotifications-export-1668359428547.tar.gz](https://github.com/Budibase/budibase/files/9997828/DefaultNotifications-export-1668359428547.tar.gz)

## Screenshots
Screenshot of Save row
![image](https://user-images.githubusercontent.com/97764630/201535881-e1c08ffa-1864-4ee3-ba3d-7cf972762c4b.png)

Screenshot of Trigger automation
![image](https://user-images.githubusercontent.com/97764630/201535907-908f374e-8fc5-4236-99b0-f1ab29b214a4.png)

Screenshot of Duplicate row
![image](https://user-images.githubusercontent.com/97764630/201535940-967d3a3c-e23d-4402-80db-1e62982a9992.png)

Screenshot of Delete row
![image](https://user-images.githubusercontent.com/97764630/201535961-8dc77e5c-25b3-4bf3-bd32-a9e2c94e8b24.png)

Video demonstrating buttons with default notifications enabled and disabled
[Link to video](https://user-images.githubusercontent.com/97764630/201535011-0f6e7b55-9ba3-490d-a7b7-dccdc53864db.webm)