### PR TITLE
Added multiselect/array options support to the view contains filter

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/FilterModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/FilterModal.svelte
@@ -97,7 +97,7 @@
   }
 
   function fieldOptions(field) {
-    return schema[field]?.type === "options"
+    return schema[field]?.type === "options" || schema[field]?.type === "array"
       ? schema[field]?.constraints.inclusion
       : [true, false]
   }


### PR DESCRIPTION
## Description
 When attempting to filter a view with a Multiselect column, the only options provided are "True" and "False". The `array` type has been included when loading field options

## Screenshots

Before 

<img width="500" alt="Screenshot 2022-11-13 at 19 13 23" src="https://user-images.githubusercontent.com/5913006/201539822-0e0d0b22-73da-46ea-b865-bed65daa2309.png">

With the fix in place, showing all available options in the mulitselect

<img width="500" alt="Screenshot 2022-11-13 at 19 13 04" src="https://user-images.githubusercontent.com/5913006/201539855-0d4872b6-9b47-4eff-a8c0-b1ec60262bf2.png">




