### PR TITLE
Fix for attachment cleanup on internal table delete.

### DIFF
--- a/packages/server/src/api/controllers/table/internal.ts
+++ b/packages/server/src/api/controllers/table/internal.ts
@@ -142,15 +142,15 @@ export async function destroy(ctx: any) {
   const tableToDelete = await db.get(ctx.params.tableId)
 
   // Delete all rows for that table
-  const rows = await db.allDocs(
+  const rowsData = await db.allDocs(
     getRowParams(ctx.params.tableId, null, {
       include_docs: true,
     })
   )
   await db.bulkDocs(
-    rows.rows.map((row: any) => ({ ...row.doc, _deleted: true }))
+    rowsData.rows.map((row: any) => ({ ...row.doc, _deleted: true }))
   )
-  await quotas.removeRows(rows.rows.length, {
+  await quotas.removeRows(rowsData.rows.length, {
     tableId: ctx.params.tableId,
   })
 
@@ -179,7 +179,9 @@ export async function destroy(ctx: any) {
     oldTable: null,
     deletion: true,
   })
-  await cleanupAttachments(tableToDelete, { rows })
+  await cleanupAttachments(tableToDelete, {
+    rows: rowsData.rows.map((row: any) => row.doc),
+  })
   return tableToDelete
 }
 


### PR DESCRIPTION
## Description
When deleting an internal table with an attachment column, the attachment cleanup process throws an exception when processing the files for deletion.

Rows, links and other data are removed successfully, but the files from the now deleted table are orphaned in the `attachments` folder for the application.

## Screenshots

![output](https://user-images.githubusercontent.com/5913006/201540353-82e86ef2-055c-4280-8bdc-d6934f97fac9.gif)



