### PR TITLE
Updating createAutomation.spec.js

### DIFF
--- a/packages/builder/cypress/integration/createAutomation.spec.js
+++ b/packages/builder/cypress/integration/createAutomation.spec.js
@@ -12,7 +12,7 @@ filterTests(['smoke', 'all'], () => {
       cy.createTestTableWithData()
       cy.wait(2000)
       cy.contains("Automate").click()
-      cy.get(interact.ADD_BUTTON_SPECTRUM).click()
+      cy.get(interact.SPECTRUM_BUTTON_TEMPLATE).contains("Add automation").click({ force: true })
       cy.get(interact.MODAL_INNER_WRAPPER).within(() => {
         cy.get("input").type("Add Row")
         cy.contains("Row Created").click({ force: true })


### PR DESCRIPTION
The + symbol button for creating an automation has been removed. It has been replaced with a button which says 'Add automation'.

I have updated the create automation test to now click on this button when creating a new automation. This test was failing due to the other button no longer existing.

