### PR TITLE
Cypress Test Skips & createAutomation Update

### DIFF
--- a/packages/builder/cypress/integration/createApp.spec.js
+++ b/packages/builder/cypress/integration/createApp.spec.js
@@ -10,7 +10,7 @@ filterTests(['smoke', 'all'], () => {
     })
 
     if (!(Cypress.env("TEST_ENV"))) {
-      it("should show the new user UI/UX", () => {
+      it.skip("should show the new user UI/UX", () => {
         cy.visit(`${Cypress.config().baseUrl}/builder/portal/apps/create`, { timeout: 5000 }) //added /portal/apps/create
         cy.wait(1000)
         cy.get(interact.CREATE_APP_BUTTON, { timeout: 10000 }).contains('Start from scratch').should("exist")
@@ -83,7 +83,7 @@ filterTests(['smoke', 'all'], () => {
       })
     })
 
-    it("should create the first application from scratch", () => {
+    it.skip("should create the first application from scratch", () => {
       const appName = "Cypress Tests"
       cy.createApp(appName, false)
 
@@ -93,7 +93,7 @@ filterTests(['smoke', 'all'], () => {
       cy.deleteApp(appName)
     })
 
-    it("should create the first application from scratch with a default name", () => {
+    it.skip("should create the first application from scratch with a default name", () => {
       cy.updateUserInformation("", "")
       cy.createApp("", false)
       cy.applicationInAppTable("My app")

--- a/packages/builder/cypress/integration/createAutomation.spec.js
+++ b/packages/builder/cypress/integration/createAutomation.spec.js
@@ -24,7 +24,7 @@ filterTests(['smoke', 'all'], () => {
       cy.wait(500)
       cy.contains("dog").click()
       // Create action
-      cy.get('[aria-label="AddCircle"]', { timeout: 2000 }).eq(1).click()
+      cy.get('[aria-label="AddCircle"]', { timeout: 2000 }).click()
       cy.get(interact.MODAL_INNER_WRAPPER).within(() => {
         cy.wait(1000)
         cy.contains("Create Row").trigger('mouseover').click().click()

--- a/packages/builder/cypress/integration/createScreen.spec.js
+++ b/packages/builder/cypress/integration/createScreen.spec.js
@@ -9,7 +9,7 @@ filterTests(["smoke", "all"], () => {
       cy.navigateToFrontend()
     })
 
-    it("Should successfully create a screen", () => {
+    it.skip("Should successfully create a screen", () => {
       cy.createScreen("test")
       cy.get(interact.BODY).within(() => {
         cy.contains("/test").should("exist")
@@ -23,7 +23,7 @@ filterTests(["smoke", "all"], () => {
       })
     })
 
-    it("should delete all screens then create first screen via button", () => {
+    it.skip("should delete all screens then create first screen via button", () => {
       cy.deleteAllScreens()
       
       cy.contains("Create first screen").click()

--- a/packages/builder/cypress/integration/revertApp.spec.js
+++ b/packages/builder/cypress/integration/revertApp.spec.js
@@ -2,7 +2,7 @@ import filterTests from "../support/filterTests"
 const interact = require('../support/interact')
 
 filterTests(['smoke', 'all'], () => {
-    context("Revert apps", () => {
+    xcontext("Revert apps", () => {
         before(() => {
         cy.login()
         cy.createTestApp()


### PR DESCRIPTION
**Skipping Screen Tests**

There are 4 tests in this file
- Skipped create and delete screen tests (covered by API)
- Update URL test remains (will eventually be covered via E2E with QA Wolf)
- Create and filter screens by access level test remains (This is due for API coverage within another ticket)

**Skipping createApp Tests & createAutomation Test Fix**
- Skipping createApp tests covered via API Automation.
- Updated the createAutomation test to fix an issue with the nightly build

**Skip revertApp Cypress Spec File**
- Covered via API Automation


