### PR TITLE
Show settings bar for all components

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -84,7 +84,6 @@
     "description": "This component contains things within itself",
     "icon": "Selection",
     "hasChildren": true,
-    "showSettingsBar": true,
     "size": {
       "width": 400,
       "height": 200
@@ -283,7 +282,6 @@
     "description": "A basic html button that is ready for styling",
     "icon": "Button",
     "editable": true,
-    "showSettingsBar": true,
     "size": {
       "width": 105,
       "height": 35
@@ -420,7 +418,6 @@
       "section"
     ],
     "hasChildren": true,
-    "showSettingsBar": true,
     "size": {
       "width": 400,
       "height": 100
@@ -683,7 +680,6 @@
     "illegalChildren": [
       "section"
     ],
-    "showSettingsBar": true,
     "editable": true,
     "size": {
       "width": 400,
@@ -809,7 +805,6 @@
     "illegalChildren": [
       "section"
     ],
-    "showSettingsBar": true,
     "editable": true,
     "size": {
       "width": 400,
@@ -931,7 +926,6 @@
   "tag": {
     "name": "Tag",
     "icon": "Label",
-    "showSettingsBar": true,
     "size": {
       "width": 100,
       "height": 25
@@ -1189,7 +1183,6 @@
     "name": "Link",
     "description": "A basic link component for internal and external links",
     "icon": "Link",
-    "showSettingsBar": true,
     "editable": true,
     "size": {
       "width": 200,
@@ -3927,7 +3920,6 @@
   "dynamicfilter": {
     "name": "Dynamic Filter",
     "icon": "Filter",
-    "showSettingsBar": true,
     "size": {
       "width": 100,
       "height": 35
@@ -4797,7 +4789,6 @@
       "section"
     ],
     "hasChildren": true,
-    "showSettingsBar": true,
     "size": {
       "width": 400,
       "height": 100

--- a/packages/client/src/components/preview/SettingsBar.svelte
+++ b/packages/client/src/components/preview/SettingsBar.svelte
@@ -16,7 +16,7 @@
   let measured = false
 
   $: definition = $componentStore.selectedComponentDefinition
-  $: showBar = definition?.showSettingsBar && !$dndIsDragging
+  $: showBar = definition?.showSettingsBar !== false && !$dndIsDragging
   $: {
     if (!showBar) {
       measured = false

--- a/packages/client/src/components/preview/SettingsBar.svelte
+++ b/packages/client/src/components/preview/SettingsBar.svelte
@@ -16,14 +16,14 @@
   let measured = false
 
   $: definition = $componentStore.selectedComponentDefinition
-  $: showBar = definition?.showSettingsBar !== false && !$dndIsDragging
+  $: showBar =
+    definition?.showSettingsBar !== false && !$dndIsDragging && definition
   $: {
     if (!showBar) {
       measured = false
     }
   }
   $: settings = getBarSettings(definition)
-
   $: isScreen =
     $builderStore.selectedComponentId === $builderStore.screen?.props?._id
 

--- a/packages/client/src/components/preview/SettingsBar.svelte
+++ b/packages/client/src/components/preview/SettingsBar.svelte
@@ -24,6 +24,9 @@
   }
   $: settings = getBarSettings(definition)
 
+  $: isScreen =
+    $builderStore.selectedComponentId === $builderStore.screen?.props?._id
+
   const getBarSettings = definition => {
     let allSettings = []
     definition?.settings?.forEach(setting => {
@@ -152,26 +155,30 @@
       {:else if setting.type === "color"}
         <SettingsColorPicker prop={setting.key} />
       {/if}
-      {#if setting.barSeparator !== false}
+      {#if setting.barSeparator !== false && (settings.length != idx + 1 || !isScreen)}
         <div class="divider" />
       {/if}
     {/each}
-    <SettingsButton
-      icon="Duplicate"
-      on:click={() => {
-        builderStore.actions.duplicateComponent(
-          $builderStore.selectedComponentId
-        )
-      }}
-      title="Duplicate component"
-    />
-    <SettingsButton
-      icon="Delete"
-      on:click={() => {
-        builderStore.actions.deleteComponent($builderStore.selectedComponentId)
-      }}
-      title="Delete component"
-    />
+    {#if !isScreen}
+      <SettingsButton
+        icon="Duplicate"
+        on:click={() => {
+          builderStore.actions.duplicateComponent(
+            $builderStore.selectedComponentId
+          )
+        }}
+        title="Duplicate component"
+      />
+      <SettingsButton
+        icon="Delete"
+        on:click={() => {
+          builderStore.actions.deleteComponent(
+            $builderStore.selectedComponentId
+          )
+        }}
+        title="Delete component"
+      />
+    {/if}
   </div>
 {/if}
 


### PR DESCRIPTION
## Description

The component settings bar will now appear when selecting any component in your screen. The minimum set of actions that will appear in the bar is, `delete` and `duplicate`

The property `showSettingsBar` has been cleared from the manifest but will still be honoured if explicitly set to `false`

Also, when selecting the screen itself, the `delete` and `duplicate` component actions are now hidden in the menu

Addresses: 
- https://github.com/Budibase/budibase/issues/6336

## Screenshots

![output](https://user-images.githubusercontent.com/5913006/202489091-98c36932-1c99-4486-af1e-6eab6352b381.gif)


