### PR TITLE
Deselect row in client table after deletion

### DIFF
--- a/packages/bbui/src/Table/Table.svelte
+++ b/packages/bbui/src/Table/Table.svelte
@@ -349,7 +349,8 @@
                 <SelectEditRenderer
                   data={row}
                   selected={selectedRows.findIndex(
-                    selectedRow => selectedRow._id === row._id
+                    selectedRow =>
+                      selectedRow._id === row._id || selectedRow === row._id
                   ) !== -1}
                   onEdit={e => editRow(e, row)}
                   {allowSelectRows}

--- a/packages/bbui/src/Table/Table.svelte
+++ b/packages/bbui/src/Table/Table.svelte
@@ -219,24 +219,6 @@
     dispatch("editrow", cloneDeep(row))
   }
 
-  //TODO - toggle all
-  const toggleSelectAll = e => {
-    const select = !!e.detail
-    if (select) {
-      // Add any rows which are not already in selected rows
-      rows.forEach(row => {
-        if (selectedRows.findIndex(x => x._id === row._id) === -1) {
-          selectedRows.push(row)
-        }
-      })
-    } else {
-      // Remove any rows from selected rows that are in the current data set
-      selectedRows = selectedRows.filter(el =>
-        rows.every(f => f._id !== el._id)
-      )
-    }
-  }
-
   const computeCellStyles = schema => {
     let styles = {}
     Object.keys(schema || {}).forEach(field => {
@@ -281,7 +263,7 @@
               {#if allowSelectRows}
                 <Checkbox
                   bind:value={checkboxStatus}
-                  on:change={toggleSelectAll}
+                  on:change={e => dispatch("toggleselectall", e.detail)}
                 />
               {:else}
                 Edit

--- a/packages/bbui/src/Table/Table.svelte
+++ b/packages/bbui/src/Table/Table.svelte
@@ -219,19 +219,7 @@
     dispatch("editrow", cloneDeep(row))
   }
 
-  const toggleSelectRow = row => {
-    if (!allowSelectRows) {
-      return
-    }
-    if (selectedRows.some(selectedRow => selectedRow._id === row._id)) {
-      selectedRows = selectedRows.filter(
-        selectedRow => selectedRow._id !== row._id
-      )
-    } else {
-      selectedRows = [...selectedRows, row]
-    }
-  }
-
+  //TODO - toggle all
   const toggleSelectAll = e => {
     const select = !!e.detail
     if (select) {
@@ -354,7 +342,7 @@
                 class:noBorderCheckbox={!showHeaderBorder}
                 class="spectrum-Table-cell spectrum-Table-cell--divider spectrum-Table-cell--edit"
                 on:click={e => {
-                  toggleSelectRow(row)
+                  dispatch("toggleselectrow", row)
                   e.stopPropagation()
                 }}
               >
@@ -377,7 +365,7 @@
                 on:click={() => {
                   if (!schema[field]?.preventSelectRow) {
                     dispatch("click", row)
-                    toggleSelectRow(row)
+                    dispatch("toggleselectrow", row)
                   }
                 }}
               >

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DeleteRow.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DeleteRow.svelte
@@ -2,11 +2,21 @@
   import { Select, Label, Checkbox, Input } from "@budibase/bbui"
   import { tables } from "stores/backend"
   import DrawerBindableInput from "components/common/bindings/DrawerBindableInput.svelte"
+  import { currentAsset } from "builderStore"
+  import { findAllMatchingComponents } from "builderStore/componentUtils"
 
   export let parameters
   export let bindings = []
 
   $: tableOptions = $tables.list || []
+  $: tableComponents = findAllMatchingComponents(
+    $currentAsset?.props,
+    component => component._component.endsWith("table")
+  ).map(table => table._id)
+  $: tableBlocks = findAllMatchingComponents($currentAsset?.props, component =>
+    component._component.endsWith("tableblock")
+  ).map(block => `${block._id}-table`)
+  $: componentOptions = tableComponents.concat(tableBlocks)
 </script>
 
 <div class="root">
@@ -16,6 +26,7 @@
     options={tableOptions}
     getOptionLabel={table => table.name}
     getOptionValue={table => table._id}
+    on:change={(parameters.tableComponents = componentOptions)}
   />
 
   <Label small>Row ID</Label>

--- a/packages/client/src/components/app/table/Table.svelte
+++ b/packages/client/src/components/app/table/Table.svelte
@@ -132,6 +132,44 @@
   onDestroy(() => {
     rowSelectionStore.actions.updateSelection($component.id, [])
   })
+
+  const toggleSelectRow = row => {
+    let tempSelectedRows = []
+    if (!allowSelectRows) {
+      return
+    }
+    if (
+      selectedRows.some(
+        selectedRow => (selectedRow._id || selectedRow) === row._id
+      )
+    ) {
+      tempSelectedRows = selectedRows.filter(
+        selectedRow => (selectedRow._id || selectedRow) !== row._id
+      )
+    } else {
+      tempSelectedRows = [...selectedRows, row]
+    }
+    rowSelectionStore.actions.updateSelection(
+      $component.id,
+      tableId,
+      tempSelectedRows.map(row => row._id || row)
+    )
+  }
+
+  const toggleSelectAll = e => {
+    const select = e.detail
+    let tempSelectedRows = []
+    if (select) {
+      data.forEach(row => {
+        tempSelectedRows.push(row)
+      })
+    }
+    rowSelectionStore.actions.updateSelection(
+      $component.id,
+      tableId,
+      tempSelectedRows.map(row => row._id || row)
+    )
+  }
 </script>
 
 <div use:styleable={$component.styles} class={size}>
@@ -153,28 +191,9 @@
     on:sort={onSort}
     on:click={onClick}
     on:toggleselectrow={e => {
-      let tempSelectedRows = []
-      if (!allowSelectRows) {
-        return
-      }
-      const row = e.detail
-      if (
-        selectedRows.some(
-          selectedRow => (selectedRow._id || selectedRow) === row._id
-        )
-      ) {
-        tempSelectedRows = selectedRows.filter(
-          selectedRow => (selectedRow._id || selectedRow) !== row._id
-        )
-      } else {
-        tempSelectedRows = [...selectedRows, row]
-      }
-      rowSelectionStore.actions.updateSelection(
-        $component.id,
-        tableId,
-        tempSelectedRows.map(row => row._id || row)
-      )
+      toggleSelectRow(e.detail)
     }}
+    on:toggleselectall={e => toggleSelectAll(e)}
   >
     <slot />
   </Table>

--- a/packages/client/src/components/app/table/Table.svelte
+++ b/packages/client/src/components/app/table/Table.svelte
@@ -181,6 +181,7 @@
     {quiet}
     {compact}
     {customRenderers}
+    customToggleRowHandlers={true}
     allowSelectRows={allowSelectRows && table}
     bind:selectedRows
     allowEditRows={false}


### PR DESCRIPTION
## Description
You can now delete a selected row in the client table without it remaining selected and causing errors in deleting subsequent rows.

This was trickier than I initially thought it would be. The problem I ran into was that the *bbui* table was keeping track of the selected rows, but I wanted to use the rowSelectionStore to keep track of the selected rows so that I could clear it upon the **Delete Row** action. 
So I moved the toggle row functionality into the client table, but left the original toggle functionality for other types of tables such as data table.

Addresses: 
- https://github.com/Budibase/budibase/issues/7760

## App Export
[ConditionalUI-export-1668706178904.tar.gz](https://github.com/Budibase/budibase/files/10034061/ConditionalUI-export-1668706178904.tar.gz)

## Screenshots
![delete_bug](https://user-images.githubusercontent.com/101575380/202516865-0e3f6155-9227-468a-845e-8f03810b3eeb.gif)




