### PR TITLE
Prevent static formulas conflict

### DIFF
--- a/packages/server/src/api/controllers/row/staticFormula.js
+++ b/packages/server/src/api/controllers/row/staticFormula.js
@@ -62,6 +62,7 @@ exports.updateRelatedFormula = async (table, enrichedRows) => {
               })
             )
           )
+          break
         }
       }
     }
@@ -124,7 +125,6 @@ exports.finaliseRow = async (
     dynamic: false,
     contextRows: enrichedRow,
   })
-
   // don't worry about rev, tables handle rev/lastID updates
   // if another row has been written since processing this will
   // handle the auto ID clash


### PR DESCRIPTION
## Description
Duplicate updates were being made to the same row. Break added so that the update is only done once if there are any static formulas present.

Addresses: 
- https://github.com/Budibase/budibase/issues/6124

## App Export
[doc-export-1668775062551.tar.gz](https://github.com/Budibase/budibase/files/10041287/doc-export-1668775062551.tar.gz)

## Screenshots
<img width="661" alt="Screenshot 2022-11-18 at 12 38 55" src="https://user-images.githubusercontent.com/101575380/202706863-a6acb380-23a9-4515-bf42-cc91567f8316.png">

<img width="661" alt="Screenshot 2022-11-18 at 12 39 24" src="https://user-images.githubusercontent.com/101575380/202706958-f7429c33-cb46-44f1-9e26-dc7b54034bf4.png">

<img width="1021" alt="Screenshot 2022-11-18 at 12 39 42" src="https://user-images.githubusercontent.com/101575380/202707041-f8dc8649-fbf3-4e31-b9e4-0632bc147bb4.png">



