### PR TITLE
Cypress Build Update

### DIFF
--- a/packages/builder/cypress/integration/appPublishWorkflow.spec.js
+++ b/packages/builder/cypress/integration/appPublishWorkflow.spec.js
@@ -30,7 +30,6 @@ filterTests(['all'], () => {
 
     it("Should publish an application and correctly reflect that", () => {
       //Assuming the previous test was run and the unpublished app is open in edit mode.
-      cy.closeModal()
       cy.get(interact.TOPRIGHTNAV_BUTTON_SPECTRUM).contains("Publish").click({ force : true })
 
       cy.get(interact.DEPLOY_APP_MODAL).should("be.visible")
@@ -86,8 +85,7 @@ filterTests(['all'], () => {
       .within(() => {
         cy.get(interact.APP_TABLE_APP_NAME).click({ force: true })
       })
-
-      cy.closeModal()
+      
       cy.get(interact.DEPLOYMENT_TOP_GLOBE).should("exist").click({ force: true })
       
       cy.get("[data-cy='publish-popover-menu']")

--- a/packages/builder/cypress/integration/createBinding.spec.js
+++ b/packages/builder/cypress/integration/createBinding.spec.js
@@ -9,9 +9,10 @@ filterTests(['smoke', 'all'], () => {
     })
 
     it("should add a current user binding", () => {
-      cy.searchAndAddComponent("Paragraph").then(() => {
+      cy.searchAndAddComponent("Paragraph").then(componentId => {
         addSettingBinding("text", ["Current User", "_id"], "Current User._id")
       })
+      cy.deleteComponentByName("New Paragraph")
     })
 
     it("should handle an invalid binding", () => {
@@ -21,6 +22,7 @@ filterTests(['smoke', 'all'], () => {
           .type("{{}{{}{{} Current User._id {}}{}}")
           .blur()
         cy.getComponent(componentId).should("have.text", "{{{ [user].[_id] }}")
+        cy.deleteComponentByName("New Paragraph")
       })
     })
 

--- a/packages/builder/cypress/integration/datasources/rest.spec.js
+++ b/packages/builder/cypress/integration/datasources/rest.spec.js
@@ -1,7 +1,7 @@
 import filterTests from "../../support/filterTests"
 
 filterTests(["smoke", "all"], () => {
-  context("REST Datasource Testing", () => {
+  xcontext("REST Datasource Testing", () => {
     before(() => {
       cy.login()
       cy.createTestApp()

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -440,8 +440,8 @@ Cypress.Commands.add("createTable", (tableName, initialTable) => {
   // Creates an internal Budibase DB table
   if (!initialTable) {
     cy.navigateToDataSection()
-    cy.get(`[data-cy="new-datasource"]`, { timeout: 2000 }).click()
   }
+  cy.get(`[data-cy="new-datasource"]`, { timeout: 2000 }).click()
   cy.wait(2000)
   cy.get(".item", { timeout: 2000 })
     .contains("Budibase DB")
@@ -458,6 +458,9 @@ Cypress.Commands.add("createTable", (tableName, initialTable) => {
   })
   // Ensure modal has closed and table is created
   cy.get(".spectrum-Modal", { timeout: 2000 }).should("not.exist")
+  cy.get(".nav-item", { timeout: 2000 })
+    .contains("Budibase DB")
+    .click({ force: true })
   cy.get(".spectrum-Tabs-content", { timeout: 2000 }).should(
     "contain",
     tableName
@@ -525,7 +528,7 @@ Cypress.Commands.add("addRowMultiValue", values => {
 })
 
 Cypress.Commands.add("selectTable", tableName => {
-  cy.expandBudibaseConnection()
+  cy.get(".nav-item").contains("Budibase DB").click()
   cy.contains(".nav-item", tableName).click()
 })
 
@@ -574,6 +577,18 @@ Cypress.Commands.add("searchAndAddComponent", component => {
     cy.getComponent(componentId, { timeout: 3000 }).should("exist")
     return cy.wrap(componentId)
   })
+})
+
+Cypress.Commands.add("deleteComponentByName", componentName => {
+  cy.get(".body")
+    .eq(0)
+    .contains(componentName)
+    .siblings(".actions")
+    .within(() => {
+      cy.get(".spectrum-Icon").click({ force: true })
+    })
+  cy.get(".spectrum-Menu").contains("Delete").click()
+  cy.get(".spectrum-Dialog").contains("Delete Component").click()
 })
 
 Cypress.Commands.add("addComponent", (category, component) => {


### PR DESCRIPTION
Few changes to assist with the nightly build

appPublishWorkflow
- Removing closeModal function calls (no longer needed)

createBinding
- Update to remove a component from some of the tests
- New command for this also

REST
- Skipping these tests -> there are only 2 and will be replaced via API

Commands
- Additional changes to support the nightly build
- mainly navigation based due to recent code changes to the product

