### PR TITLE
User/Auth context now being passed to dynamic variable request updates

### DIFF
--- a/packages/server/src/threads/query.ts
+++ b/packages/server/src/threads/query.ts
@@ -58,7 +58,6 @@ class QueryRunner {
 
   async execute(): Promise<any> {
     let { datasource, fields, queryVerb, transformer } = this
-
     let datasourceClone = cloneDeep(datasource)
     let fieldsClone = cloneDeep(fields)
 
@@ -181,6 +180,7 @@ class QueryRunner {
         parameters,
         transformer: query.transformer,
         queryId,
+        ctx: this.ctx,
       },
       { noRecursiveQuery: true }
     ).execute()


### PR DESCRIPTION
## Description

Auth and User context is now being passed to REST requests when updating dynamic variables.

Requests depending on retrying requests in order to update dynamic variables were failing as a result.

Addresses: 
- https://github.com/Budibase/budibase/issues/8794