### PR TITLE
Only uncheck other homescreens if homescreen set

### DIFF
--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -369,7 +369,7 @@ export const getFrontendStore = () => {
             s._id !== screen._id
           )
         })
-        if (otherHomeScreens.length) {
+        if (otherHomeScreens.length && updatedScreen.routing.homeScreen) {
           const patch = screen => {
             screen.routing.homeScreen = false
           }


### PR DESCRIPTION
## Description
Setting onLoad actions was resetting other homescreens. Added check to make sure that you only unset other homescreens if the updated screen is set as home.

Addresses: 
- https://github.com/Budibase/budibase/issues/8796



