### PR TITLE
Environment variable type coercion fix

### DIFF
--- a/packages/worker/src/environment.ts
+++ b/packages/worker/src/environment.ts
@@ -67,7 +67,8 @@ const env = {
   ENCRYPTED_TEST_PUBLIC_API_KEY: process.env.ENCRYPTED_TEST_PUBLIC_API_KEY,
   _set(key: any, value: any) {
     process.env[key] = value
-    module.exports[key] = value
+    // @ts-ignore
+    env[key] = value
   },
   isDev,
   isTest,
@@ -82,7 +83,7 @@ if (!env.APPS_URL) {
 }
 
 // clean up any environment variable edge cases
-for (let [key, value] of Object.entries(module.exports)) {
+for (let [key, value] of Object.entries(env)) {
   // handle the edge case of "0" to disable an environment variable
   if (value === "0") {
     // @ts-ignore


### PR DESCRIPTION
## Description
Noticed when spinning up a new K8s install, the multi tenant flag was always coming through as `"0"`. (true)
Adding this fix for the worker environment file 



