### PR TITLE
MySql - don't parse number array as date

### DIFF
--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -106,7 +106,11 @@ function bindingTypeCoerce(bindings: any[]) {
     }
     // if not a number, see if it is a date - important to do in this order as any
     // integer will be considered a valid date
-    else if (/^\d/.test(binding) && dayjs(binding).isValid() && !binding.includes(",")) {
+    else if (
+      /^\d/.test(binding) &&
+      dayjs(binding).isValid() &&
+      !binding.includes(",")
+    ) {
       bindings[i] = dayjs(binding).toDate()
     }
   }

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -106,7 +106,7 @@ function bindingTypeCoerce(bindings: any[]) {
     }
     // if not a number, see if it is a date - important to do in this order as any
     // integer will be considered a valid date
-    else if (/^\d/.test(binding) && dayjs(binding).isValid()) {
+    else if (/^\d/.test(binding) && dayjs(binding).isValid() && !binding.includes(",")) {
       bindings[i] = dayjs(binding).toDate()
     }
   }

--- a/packages/server/src/integrations/tests/mysql.spec.ts
+++ b/packages/server/src/integrations/tests/mysql.spec.ts
@@ -73,4 +73,49 @@ describe("MySQL Integration", () => {
       expect(response).toEqual([{ deleted: true }])
     })
   })
+
+  describe("binding type coerce", () => {
+    it("ignores non-string types ", async () => {
+      const sql = "select * from users;"
+      const date = new Date()
+      await config.integration.read({
+        sql,
+        bindings: [11, date, ["a", "b", "c"], { id: 1}]
+      })
+      expect(config.integration.client.query).toHaveBeenCalledWith(sql, [11, date, ["a", "b", "c"], { id: 1}])
+    })
+
+    it("parses strings matching a number regex", async () => {
+      const sql = "select * from users;"
+      await config.integration.read({
+        sql,
+        bindings: ["101", "3.14"]
+      })
+      expect(config.integration.client.query).toHaveBeenCalledWith(sql, [101, 3.14])
+    })
+
+    it("parses strings matching a valid date format", async () => {
+      const sql = "select * from users;"
+      await config.integration.read({
+        sql,
+        bindings: ["2001-10-30", "2010-09-01T13:30:59.123Z", "2021-02-05 12:01 PM"]
+      })
+      expect(config.integration.client.query).toHaveBeenCalledWith(sql, [
+        new Date("2001-10-30T00:00:00.000Z"), 
+        new Date("2010-09-01T13:30:59.123Z"),
+        new Date("2021-02-05T12:01:00.000Z")
+      ])
+    })
+
+    it("does not parse string matching a valid array of numbers as date", async () => {
+      const sql = "select * from users;"
+      await config.integration.read({
+        sql,
+        bindings: ["1,2,2017"]
+      })
+      expect(config.integration.client.query).toHaveBeenCalledWith(sql, [
+        "1,2,2017"
+      ])
+    })
+  })
 })

--- a/packages/server/src/integrations/tests/mysql.spec.ts
+++ b/packages/server/src/integrations/tests/mysql.spec.ts
@@ -80,30 +80,42 @@ describe("MySQL Integration", () => {
       const date = new Date()
       await config.integration.read({
         sql,
-        bindings: [11, date, ["a", "b", "c"], { id: 1}]
+        bindings: [11, date, ["a", "b", "c"], { id: 1 }],
       })
-      expect(config.integration.client.query).toHaveBeenCalledWith(sql, [11, date, ["a", "b", "c"], { id: 1}])
+      expect(config.integration.client.query).toHaveBeenCalledWith(sql, [
+        11,
+        date,
+        ["a", "b", "c"],
+        { id: 1 },
+      ])
     })
 
     it("parses strings matching a number regex", async () => {
       const sql = "select * from users;"
       await config.integration.read({
         sql,
-        bindings: ["101", "3.14"]
+        bindings: ["101", "3.14"],
       })
-      expect(config.integration.client.query).toHaveBeenCalledWith(sql, [101, 3.14])
+      expect(config.integration.client.query).toHaveBeenCalledWith(
+        sql,
+        [101, 3.14]
+      )
     })
 
     it("parses strings matching a valid date format", async () => {
       const sql = "select * from users;"
       await config.integration.read({
         sql,
-        bindings: ["2001-10-30", "2010-09-01T13:30:59.123Z", "2021-02-05 12:01 PM"]
+        bindings: [
+          "2001-10-30",
+          "2010-09-01T13:30:59.123Z",
+          "2021-02-05 12:01 PM",
+        ],
       })
       expect(config.integration.client.query).toHaveBeenCalledWith(sql, [
-        new Date("2001-10-30T00:00:00.000Z"), 
+        new Date("2001-10-30T00:00:00.000Z"),
         new Date("2010-09-01T13:30:59.123Z"),
-        new Date("2021-02-05T12:01:00.000Z")
+        new Date("2021-02-05T12:01:00.000Z"),
       ])
     })
 
@@ -111,10 +123,10 @@ describe("MySQL Integration", () => {
       const sql = "select * from users;"
       await config.integration.read({
         sql,
-        bindings: ["1,2,2017"]
+        bindings: ["1,2,2017"],
       })
       expect(config.integration.client.query).toHaveBeenCalledWith(sql, [
-        "1,2,2017"
+        "1,2,2017",
       ])
     })
   })


### PR DESCRIPTION
## Description
Array of numbers are no longer parsed as dates in MySQL.
E.g. `"1,2,2017"` will NOT be converted to `2017-02-01T00:00:00.000Z`

Added some unit tests.

Addresses: 
- https://github.com/Budibase/budibase/issues/7887

## Screenshots
![Screenshot 2022-11-28 at 12 13 44](https://user-images.githubusercontent.com/101575380/204275166-fa21ab1c-a281-409d-b273-0303026671a3.png)

**OLD output**
<img width="254" alt="Screenshot 2022-11-28 at 12 14 05" src="https://user-images.githubusercontent.com/101575380/204275237-0c507aeb-602d-4c31-947a-20e7275da7ab.png">

**NEW output**
<img width="198" alt="Screenshot 2022-11-28 at 12 14 46" src="https://user-images.githubusercontent.com/101575380/204275379-a276cbe0-efa5-4bef-8974-b6387ee94af7.png">




