### PR TITLE
Add namespace to Helm chart templates

### DIFF
--- a/charts/budibase/Chart.yaml
+++ b/charts/budibase/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/Budibase/budibase
   - https://budibase.com
 type: application
-version: 0.2.11
+version: 0.2.12
 appVersion: 1.0.214
 dependencies:
   - name: couchdb

--- a/charts/budibase/Chart.yaml
+++ b/charts/budibase/Chart.yaml
@@ -11,8 +11,8 @@ sources:
   - https://github.com/Budibase/budibase
   - https://budibase.com
 type: application
-version: 0.2.12
-appVersion: 1.0.214
+version: 0.0.0
+appVersion: 0.0.0
 dependencies:
   - name: couchdb
     version: 3.6.1

--- a/charts/budibase/Chart.yaml
+++ b/charts/budibase/Chart.yaml
@@ -11,7 +11,9 @@ sources:
   - https://github.com/Budibase/budibase
   - https://budibase.com
 type: application
+# populates on packaging
 version: 0.0.0
+# populates on packaging
 appVersion: 0.0.0
 dependencies:
   - name: couchdb

--- a/charts/budibase/README.md
+++ b/charts/budibase/README.md
@@ -32,8 +32,8 @@ The command deploys Budibase on the Kubernetes cluster in the default configurat
 
 ## Uninstalling the Chart
 
-To uninstall/delete the `my-release` deployment:
+To uninstall/delete the `budi-release` deployment:
 
 ```console
-$ helm delete my-release
+$ helm delete budi-release
 ```

--- a/charts/budibase/templates/alb-ingress.yaml
+++ b/charts/budibase/templates/alb-ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-budibase
+  namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing

--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     io.kompose.service: app-service
   name: app-service
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.services.apps.replicaCount }}
   selector:

--- a/charts/budibase/templates/app-service-service.yaml
+++ b/charts/budibase/templates/app-service-service.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     io.kompose.service: app-service
   name: app-service
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: {{ .Values.services.apps.port | quote }}

--- a/charts/budibase/templates/couchdb-backup.yaml
+++ b/charts/budibase/templates/couchdb-backup.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: couchdb-backup
   name: couchdb-backup
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1 
   selector:

--- a/charts/budibase/templates/hpa.yaml
+++ b/charts/budibase/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "budibase.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "budibase.labels" . | nindent 4 }}
 spec:

--- a/charts/budibase/templates/ingress.yaml
+++ b/charts/budibase/templates/ingress.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "budibase.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/budibase/templates/minio-data-persistentvolumeclaim.yaml
+++ b/charts/budibase/templates/minio-data-persistentvolumeclaim.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     io.kompose.service: minio-data
   name: minio-data
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
   - ReadWriteOnce

--- a/charts/budibase/templates/minio-service-deployment.yaml
+++ b/charts/budibase/templates/minio-service-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     io.kompose.service: minio-service
   name: minio-service
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/charts/budibase/templates/minio-service-service.yaml
+++ b/charts/budibase/templates/minio-service-service.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     io.kompose.service: minio-service
   name: minio-service
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: {{ .Values.services.objectStore.port | quote }}

--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: budibase-proxy
   name: proxy-service
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.services.proxy.replicaCount }}
   selector:

--- a/charts/budibase/templates/proxy-service-service.yaml
+++ b/charts/budibase/templates/proxy-service-service.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: budibase-proxy
   name: proxy-service
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: {{ .Values.services.proxy.port | quote }}

--- a/charts/budibase/templates/redis-data-persistentvolumeclaim.yaml
+++ b/charts/budibase/templates/redis-data-persistentvolumeclaim.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     io.kompose.service: redis-data
   name: redis-data
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
   - ReadWriteOnce

--- a/charts/budibase/templates/redis-service-deployment.yaml
+++ b/charts/budibase/templates/redis-service-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     io.kompose.service: redis-service
   name: redis-service
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.services.redis.replicaCount }}
   selector:

--- a/charts/budibase/templates/redis-service-service.yaml
+++ b/charts/budibase/templates/redis-service-service.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     io.kompose.service: redis-service
   name: redis-service
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: {{ .Values.services.redis.port | quote }}

--- a/charts/budibase/templates/secrets.yaml
+++ b/charts/budibase/templates/secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "budibase.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "budibase.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/budibase/templates/service.yaml
+++ b/charts/budibase/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "budibase.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "budibase.labels" . | nindent 4 }}
 spec:

--- a/charts/budibase/templates/serviceaccount.yaml
+++ b/charts/budibase/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "budibase.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "budibase.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/budibase/templates/tests/test-connection.yaml
+++ b/charts/budibase/templates/tests/test-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "budibase.fullname" . }}-test-connection"
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "budibase.labels" . | nindent 4 }}
   annotations:

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     io.kompose.service: worker-service
   name: worker-service
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.services.worker.replicaCount }}
 

--- a/charts/budibase/templates/worker-service-service.yaml
+++ b/charts/budibase/templates/worker-service-service.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     io.kompose.service: worker-service
   name: worker-service
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: {{ .Values.services.worker.port | quote }}


### PR DESCRIPTION
## Description

We are trying to use this Helm chart for deployment using *ArgoCD*. However, since all templates are lacking `metadata.namespace`, we are required to change how we define namespaces for the deployment of this chart alone.

Following best practice as visible in the [ingress-nginx](https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx) and [kube-prometheus-stack](https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack) template sections (though *kube-prometheus-stack* actually uses a helper), adding the `metadata.namespace` reference everywhere required will ensure that the default way of deploying *Budibase* will work, also using ArgoCD.

The only possible issue I've found, is that it seems that the dependency `couchdb` does not take the `namespace` provided. I assume that is something that needs to be fixed upstream, if at all necessary. The `ingress-nginx` dependency takes the namespace like a champ :) 

Addresses: 
- #7062

## How it is tested:

For a dry-run test, to verify that the manifests can be generated:

```bash
helm install -n anewbudins budibase charts/budibase --set ingress.nginx=true,services.couchdb.enabled=true --dry-run
helm install -n anewbudins budibase charts/budibase --set ingress.nginx=false,services.couchdb.enabled=false --dry-run
```

Linting:

```bash
helm lint charts/budibase --with-subcharts
```

## Side note

I also saw that the `charts/budibase/README.md` file was using one reference to install budibase, and a different reference to remove it. I also fixed that, so that the two name references match.
