### PR TITLE
Text Overflowing Notifications

### DIFF
--- a/packages/bbui/src/Notification/Notification.svelte
+++ b/packages/bbui/src/Notification/Notification.svelte
@@ -25,7 +25,7 @@
     </svg>
   {/if}
   <div class="spectrum-Toast-body" class:actionBody={!!action}>
-    <div class="spectrum-Toast-content">{message || ""}</div>
+    <div class="wrap spectrum-Toast-content">{message || ""}</div>
     {#if action}
       <ActionButton quiet emphasized on:click={action}>
         <div style="color: white; font-weight: 600;">{actionMessage}</div>
@@ -53,6 +53,10 @@
 </div>
 
 <style>
+  .wrap {
+    overflow-wrap: anywhere;
+  }
+
   .spectrum-Toast {
     pointer-events: all;
   }


### PR DESCRIPTION
## Description
Strings without whitespace were overflowing out of the notification component as it's a fixed width, forcing line breaks fixes this.


|Before|After|
|---|---|
|<img width="933" alt="Screenshot 2022-11-29 at 16 01 21" src="https://user-images.githubusercontent.com/12501626/204579916-4ae6804c-ec28-4a62-a7d1-5bddc779f829.png">|<img width="905" alt="Screenshot 2022-11-29 at 15 48 21" src="https://user-images.githubusercontent.com/12501626/204579938-c5d1a7b0-29cf-4282-9537-d4b375db7f4e.png">|


Addresses: 
https://github.com/Budibase/budibase/issues/8801





