### PR TITLE
MySQL BigInt as string

### DIFF
--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -146,7 +146,8 @@ class MySQLIntegration extends Sql implements DatasourcePlus {
         if (
           field.type == "DATETIME" ||
           field.type === "DATE" ||
-          field.type === "TIMESTAMP"
+          field.type === "TIMESTAMP" ||
+          field.type == "LONGLONG"
         ) {
           return field.string()
         }


### PR DESCRIPTION
## Description
MySQL as a data source distorts BigInt datatype because of int53 problem of JavaScript. The patch interprets BigInt as a string.

Addresses: 
- #8781