### PR TITLE
Fixes for table and view editing

### DIFF
--- a/packages/builder/src/components/backend/TableNavigator/popovers/EditTablePopover.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/popovers/EditTablePopover.svelte
@@ -1,6 +1,7 @@
 <script>
   import { goto } from "@roxi/routify"
   import { store } from "builderStore"
+  import { cloneDeep } from "lodash/fp"
   import { tables, datasources } from "stores/backend"
   import {
     ActionMenu,
@@ -18,7 +19,10 @@
   let editorModal
   let confirmDeleteDialog
   let error = ""
-  let originalName = table.name
+
+  let originalName
+  let updatedName
+
   let templateScreens
   let willBeDeleted
   let deleteTableName
@@ -59,7 +63,9 @@
   }
 
   async function save() {
-    await tables.save(table)
+    const updatedTable = cloneDeep(table)
+    updatedTable.name = updatedName
+    await tables.save(updatedTable)
     notifications.success("Table renamed successfully")
   }
 
@@ -69,6 +75,11 @@
       originalName === tableName
         ? `Table with name ${tableName} already exists. Please choose another name.`
         : ""
+  }
+
+  const initForm = () => {
+    originalName = table.name + ""
+    updatedName = table.name + ""
   }
 </script>
 
@@ -84,17 +95,17 @@
   </ActionMenu>
 {/if}
 
-<Modal bind:this={editorModal}>
+<Modal bind:this={editorModal} on:show={initForm}>
   <ModalContent
     title="Edit Table"
     confirmText="Save"
     onConfirm={save}
-    disabled={table.name === originalName || error}
+    disabled={updatedName === originalName || error}
   >
     <Input
       label="Table Name"
       thin
-      bind:value={table.name}
+      bind:value={updatedName}
       on:input={checkValid}
       {error}
     />

--- a/packages/builder/src/components/backend/TableNavigator/popovers/EditViewPopover.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/popovers/EditViewPopover.svelte
@@ -1,6 +1,7 @@
 <script>
   import { goto } from "@roxi/routify"
   import { views } from "stores/backend"
+  import { cloneDeep } from "lodash/fp"
   import ConfirmDialog from "components/common/ConfirmDialog.svelte"
   import {
     notifications,
@@ -15,13 +16,17 @@
   export let view
 
   let editorModal
-  let originalName = view.name
+  let originalName
+  let updatedName
   let confirmDeleteDialog
 
   async function save() {
+    const updatedView = cloneDeep(view)
+    updatedView.name = updatedName
+
     await views.save({
       originalName,
-      ...view,
+      ...updatedView,
     })
     notifications.success("View renamed successfully")
   }
@@ -37,6 +42,11 @@
       notifications.error("Error deleting view")
     }
   }
+
+  const initForm = () => {
+    updatedName = view.name + ""
+    originalName = view.name + ""
+  }
 </script>
 
 <ActionMenu>
@@ -46,9 +56,9 @@
   <MenuItem icon="Edit" on:click={editorModal.show}>Edit</MenuItem>
   <MenuItem icon="Delete" on:click={confirmDeleteDialog.show}>Delete</MenuItem>
 </ActionMenu>
-<Modal bind:this={editorModal}>
+<Modal bind:this={editorModal} on:show={initForm}>
   <ModalContent title="Edit View" onConfirm={save} confirmText="Save">
-    <Input label="View Name" thin bind:value={view.name} />
+    <Input label="View Name" thin bind:value={updatedName} />
   </ModalContent>
 </Modal>
 <ConfirmDialog


### PR DESCRIPTION
## Description

Some fixes to correct some issues around editing table and view names. Typically centred around stale or mutated state.

- Renaming a view would create a duplicate with the updated name. This would continue with every name change
- Renaming a view back to its original name would throw and exception.
- Altering the table name in the form would mutate the table name held in state. If a user cancelled a name change, they could unintentionally persist any changes if they were to alter any views.

## Screenshots

Duplicating views

![duplicatingViews](https://user-images.githubusercontent.com/5913006/204771788-98e3250b-e7e8-48c4-bc36-d53819d9ba70.gif)

Rename Causing Exception

![renameCrashViews](https://user-images.githubusercontent.com/5913006/204771905-e933eaa7-403e-4b12-a7c1-b1e91492a7c2.gif)

Table Name Mutated

![tableNameMutate](https://user-images.githubusercontent.com/5913006/204771938-ee6fbf58-87e0-4fe5-afb3-27c52d04f017.gif)
