### PR TITLE
Multifield Input Autoselect All Fields

### DIFF
--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -25,7 +25,7 @@ import {
   DB_TYPE_INTERNAL,
   DB_TYPE_EXTERNAL,
 } from "constants/backend"
-import { getSchemaForDatasource } from 'builderStore/dataBinding'
+import { getSchemaForDatasource } from "builderStore/dataBinding"
 
 const INITIAL_FRONTEND_STATE = {
   apps: [],

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -1042,15 +1042,19 @@ export const getFrontendStore = () => {
           if (component[name] === value) {
             return false
           }
-          if (name === "dataSource") {
+
+          const settings = getComponentSettings(component._component)
+          const updatedSetting = settings.find(setting => setting.key === name)
+
+          if (
+            updatedSetting.type === "dataSource" ||
+            updatedSetting.type === "table"
+          ) {
             const { list: allTables } = get(tables)
             const { schema } = allTables.find(
               ({ _id }) => _id === value.tableId
             )
             const columnNames = Object.keys(schema)
-
-            const settings = getComponentSettings(component._component)
-
             const multifieldKeysToSelectAll = settings
               .filter(setting => {
                 return setting.type === "multifield" && setting.selectAllFields

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -523,7 +523,9 @@ export const getFrontendStore = () => {
         // Generate default props
         let props = { ...presetProps }
         settings.forEach(setting => {
-          if (setting.defaultValue !== undefined) {
+          if (setting.type === "multifield" && setting.selectAllFields) {
+            props[setting.key] = Object.keys(defaultDatasource.schema)
+          } else if (setting.defaultValue !== undefined) {
             props[setting.key] = setting.defaultValue
           }
         })
@@ -1040,6 +1042,26 @@ export const getFrontendStore = () => {
           if (component[name] === value) {
             return false
           }
+          if (name === "dataSource") {
+            const { list: allTables } = get(tables)
+            const { schema } = allTables.find(
+              ({ _id }) => _id === value.tableId
+            )
+            const columnNames = Object.keys(schema)
+
+            const settings = getComponentSettings(component._component)
+
+            const multifieldKeysToSelectAll = settings
+              .filter(setting => {
+                return setting.type === "multifield" && setting.selectAllFields
+              })
+              .map(setting => setting.key)
+
+            multifieldKeysToSelectAll.forEach(key => {
+              component[key] = columnNames
+            })
+          }
+
           component[name] = value
         })
       },

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -25,6 +25,7 @@ import {
   DB_TYPE_INTERNAL,
   DB_TYPE_EXTERNAL,
 } from "constants/backend"
+import { getSchemaForDatasource } from 'builderStore/dataBinding'
 
 const INITIAL_FRONTEND_STATE = {
   apps: [],
@@ -524,7 +525,7 @@ export const getFrontendStore = () => {
         let props = { ...presetProps }
         settings.forEach(setting => {
           if (setting.type === "multifield" && setting.selectAllFields) {
-            props[setting.key] = Object.keys(defaultDatasource.schema)
+            props[setting.key] = Object.keys(defaultDatasource.schema || {})
           } else if (setting.defaultValue !== undefined) {
             props[setting.key] = setting.defaultValue
           }
@@ -1050,11 +1051,8 @@ export const getFrontendStore = () => {
             updatedSetting.type === "dataSource" ||
             updatedSetting.type === "table"
           ) {
-            const { list: allTables } = get(tables)
-            const { schema } = allTables.find(
-              ({ _id }) => _id === value.tableId
-            )
-            const columnNames = Object.keys(schema)
+            const { schema } = getSchemaForDatasource(null, value)
+            const columnNames = Object.keys(schema || {})
             const multifieldKeysToSelectAll = settings
               .filter(setting => {
                 return setting.type === "multifield" && setting.selectAllFields

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -5108,7 +5108,8 @@
           {
             "type": "multifield",
             "label": "Fields",
-            "key": "fields"
+            "key": "fields",
+            "selectAllFields": true
           },
           {
             "type": "select",

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -5262,7 +5262,8 @@
             "type": "multifield",
             "label": "Fields",
             "key": "detailFields",
-            "nested": true
+            "nested": true,
+            "selectAllFields": true
           }
         ]
       }


### PR DESCRIPTION
## Description
Adds an optional flag to auto populate multifield inputs with columns. As well as being generally handy this helps resolve a UX issue Mihail pointed out where the Row Explorer block seems broken unless the user selects fields to display, and it's not necessarily obvious that needs to be done.


