### PR TITLE
Add env var for tls-reject-unauthorised to helm chart

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -158,6 +158,10 @@ spec:
         {{ end }}
         - name: CDN_URL
           value: {{ .Values.globals.cdnUrl }}
+        {{ if .Values.services.tlsRejectUnauthorized }}
+        - name: NODE_TLS_REJECT_UNAUTHORIZED
+          value: {{ .Values.services.tlsRejectUnauthorized }}
+        {{ end }}
 
         image: budibase/apps:{{ .Values.globals.appVersion }}
         imagePullPolicy: Always

--- a/charts/budibase/templates/minio-service-deployment.yaml
+++ b/charts/budibase/templates/minio-service-deployment.yaml
@@ -42,6 +42,11 @@ spec:
             secretKeyRef:
               name: {{ template "budibase.fullname" . }}
               key: objectStoreSecret
+        {{ if .Values.services.tlsRejectUnauthorized }}
+        - name: NODE_TLS_REJECT_UNAUTHORIZED
+          value: {{ .Values.services.tlsRejectUnauthorized }}
+        {{ end }}
+
         image: minio/minio
         imagePullPolicy: ""
         livenessProbe:

--- a/charts/budibase/templates/minio-service-deployment.yaml
+++ b/charts/budibase/templates/minio-service-deployment.yaml
@@ -42,10 +42,6 @@ spec:
             secretKeyRef:
               name: {{ template "budibase.fullname" . }}
               key: objectStoreSecret
-        {{ if .Values.services.tlsRejectUnauthorized }}
-        - name: NODE_TLS_REJECT_UNAUTHORIZED
-          value: {{ .Values.services.tlsRejectUnauthorized }}
-        {{ end }}
 
         image: minio/minio
         imagePullPolicy: ""

--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -50,4 +50,9 @@ spec:
       restartPolicy: Always
       serviceAccountName: ""
       volumes:
+      env:
+        {{ if .Values.services.tlsRejectUnauthorized }}
+        - name: NODE_TLS_REJECT_UNAUTHORIZED
+          value: {{ .Values.services.tlsRejectUnauthorized }}
+        {{ end }}
 status: {}

--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -50,9 +50,4 @@ spec:
       restartPolicy: Always
       serviceAccountName: ""
       volumes:
-      env:
-        {{ if .Values.services.tlsRejectUnauthorized }}
-        - name: NODE_TLS_REJECT_UNAUTHORIZED
-          value: {{ .Values.services.tlsRejectUnauthorized }}
-        {{ end }}
 status: {}

--- a/charts/budibase/templates/redis-service-deployment.yaml
+++ b/charts/budibase/templates/redis-service-deployment.yaml
@@ -60,10 +60,6 @@ spec:
       - name: redis-data
         persistentVolumeClaim:
           claimName: redis-data
-      env:
-      {{ if .Values.services.tlsRejectUnauthorized }}
-        - name: NODE_TLS_REJECT_UNAUTHORIZED
-          value: {{ .Values.services.tlsRejectUnauthorized }}
-      {{ end }}
+
 status: {}
 {{- end }}

--- a/charts/budibase/templates/redis-service-deployment.yaml
+++ b/charts/budibase/templates/redis-service-deployment.yaml
@@ -60,5 +60,10 @@ spec:
       - name: redis-data
         persistentVolumeClaim:
           claimName: redis-data
+      env:
+      {{ if .Values.services.tlsRejectUnauthorized }}
+        - name: NODE_TLS_REJECT_UNAUTHORIZED
+          value: {{ .Values.services.tlsRejectUnauthorized }}
+      {{ end }}
 status: {}
 {{- end }}

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -149,6 +149,10 @@ spec:
         {{ end }}
         - name: CDN_URL
           value: {{ .Values.globals.cdnUrl }}
+        {{ if .Values.services.tlsRejectUnauthorized }}
+        - name: NODE_TLS_REJECT_UNAUTHORIZED
+          value: {{ .Values.services.tlsRejectUnauthorized }}
+        {{ end }}
 
         image: budibase/worker:{{ .Values.globals.appVersion }}
         imagePullPolicy: Always

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -110,6 +110,7 @@ globals:
 services:
   budibaseVersion: latest
   dns: cluster.local
+  # tlsRejectUnauthorized: 0
 
   proxy:
     port: 10000


### PR DESCRIPTION
## Description
Problem reported by @simoncramer who needed an environment variable set for `NODE_TLS_REJECT_UNAUTHORIZED` to ignore intermediate certificate errors when connecting a BB app to an API endpoint. The variable is optional in the helm chart but can be added by adding ` tlsRejectUnauthorized: 0` line into the `services:` section of the `values.yaml`
e.g.

```
services:
  budibaseVersion: latest
  dns: cluster.local
  tlsRejectUnauthorized: 0
```

Addresses: 
- https://github.com/Budibase/budibase/discussions/8808#discussioncomment-4262077

