### PR TITLE
add optional annotations to pods for logging format

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   annotations:
     kompose.cmd: kompose convert
     kompose.version: 1.21.0 (992df58d8)
+{{ if .Values.globals.logAnnotations }}
+{{ toYaml .Values.globals.logAnnotations | indent 4 }}
+{{ end }}
   creationTimestamp: null
   labels:
     io.kompose.service: app-service

--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   annotations:
     kompose.cmd: kompose convert
     kompose.version: 1.21.0 (992df58d8)
+{{ if .Values.globals.logAnnotations }}
+{{ toYaml .Values.globals.logAnnotations | indent 4 }}
+{{ end }}
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: budibase-proxy

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   annotations:
     kompose.cmd: kompose convert
     kompose.version: 1.21.0 (992df58d8)
+{{ if .Values.globals.logAnnotations }}
+{{ toYaml .Values.globals.logAnnotations | indent 4 }}
+{{ end }}
   creationTimestamp: null
   labels:
     io.kompose.service: worker-service

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -22,6 +22,12 @@ serviceAccount:
 
 podAnnotations: {}
 
+# logAnnotations:
+#   co.elastic.logs/multiline.type: pattern
+#   co.elastic.logs/multiline.pattern: '^[[:space:]]'
+#   co.elastic.logs/multiline.negate: false
+#   co.elastic.logs/multiline.match: after
+
 podSecurityContext:
   {}
   # fsGroup: 2000


### PR DESCRIPTION
## Description
For sending logs to elastic we need to tell filebeat about the format of our log files. For k8s this is done via annotations on the pods i.e.
```
   co.elastic.logs/multiline.type: pattern
   co.elastic.logs/multiline.pattern: '^[[:space:]]'
   co.elastic.logs/multiline.negate: false
   co.elastic.logs/multiline.match: after
```
To cater for this we need to allow these values to be set within the `values.yaml` file for our helm chart. If `logAnnotations` exists in the `values.yaml` file then the annotations are added to the app, worker and proxy deployments as shown below:
```
{{ if .Values.globals.logAnnotations }}
{{ toYaml .Values.globals.logAnnotations | indent 4 }}
{{ end }}
```
Opinions welcome and should we add to redis and minio pods?




