### PR TITLE
Re-add invite modal

### DIFF
--- a/packages/builder/src/pages/builder/portal/manage/users/_components/InvitedModal.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/users/_components/InvitedModal.svelte
@@ -50,7 +50,7 @@
   }
 </script>
 
-<ModalContent showCancelButton={false} {title} confirmText="Done">
+<ModalContent size="M" showCancelButton={false} {title} confirmText="Done">
   {#if hasSuccess}
     <Body size="XS">
       Your users should now receive an email invite to get access to their
@@ -70,6 +70,3 @@
     />
   {/if}
 </ModalContent>
-
-<style>
-</style>

--- a/packages/builder/src/pages/builder/portal/manage/users/index.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/users/index.svelte
@@ -7,7 +7,6 @@
     Table,
     Layout,
     Modal,
-    ModalContent,
     Search,
     notifications,
     Pagination,
@@ -23,6 +22,7 @@
   import { goto } from "@roxi/routify"
   import OnboardingTypeModal from "./_components/OnboardingTypeModal.svelte"
   import PasswordModal from "./_components/PasswordModal.svelte"
+  import InvitedModal from "./_components/InvitedModal.svelte"
   import ImportUsersModal from "./_components/ImportUsersModal.svelte"
   import { get } from "svelte/store"
   import { Constants, Utils, fetchData } from "@budibase/frontend-core"
@@ -67,6 +67,8 @@
       sortable: false,
     },
   }
+  $: userData = []
+  $: inviteUsersResponse = { successful: [], unsuccessful: [] }
   $: {
     enrichedUsers = $fetch.rows?.map(user => {
       let userGroups = []
@@ -112,8 +114,7 @@
       groups: userData.groups,
     }))
     try {
-      const res = await users.invite(payload)
-      notifications.success(res.message)
+      inviteUsersResponse = await users.invite(payload)
       inviteConfirmationModal.show()
     } catch (error) {
       notifications.error("Error inviting user")
@@ -273,16 +274,7 @@
 </Modal>
 
 <Modal bind:this={inviteConfirmationModal}>
-  <ModalContent
-    showCancelButton={false}
-    title="Invites sent!"
-    confirmText="Done"
-  >
-    <Body size="S">
-      Your users should now recieve an email invite to get access to their
-      Budibase account
-    </Body>
-  </ModalContent>
+  <InvitedModal {inviteUsersResponse} />
 </Modal>
 
 <Modal bind:this={onboardingTypeModal}>

--- a/packages/types/src/api/web/user.ts
+++ b/packages/types/src/api/web/user.ts
@@ -57,3 +57,8 @@ export interface CreateAdminUserRequest {
   password: string
   tenantId: string
 }
+
+export interface InviteUserRequest {
+  email: string
+  userInfo: any
+}

--- a/packages/types/src/api/web/user.ts
+++ b/packages/types/src/api/web/user.ts
@@ -57,8 +57,3 @@ export interface CreateAdminUserRequest {
   password: string
   tenantId: string
 }
-
-export interface InviteUserRequest {
-  email: string
-  userInfo: any
-}


### PR DESCRIPTION
## Description
@Rory-Powell had added an `InvitedModal` to handle bad email invites. I believe it simply got lost in a bad merge. Re-adding via a cherry pick.

Addresses: 
- https://github.com/Budibase/budibase/issues/8033

## Screenshots
![Screenshot 2022-12-02 at 11 58 13](https://user-images.githubusercontent.com/101575380/205287903-c7e33efd-93fc-4b8c-8296-2d66189ab2cc.png)




