### PR TITLE
Force a re-initialisation of table data and paging when importing rows

### DIFF
--- a/packages/builder/src/components/backend/DataTable/DataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/DataTable.svelte
@@ -117,6 +117,12 @@
   const onUpdateRows = () => {
     fetch.refresh()
   }
+
+  // When importing new rows it is better to reinitialise request/paging data.
+  // Not doing so causes inconsistency in paging behaviour and content.
+  const onImportData = () => {
+    fetch.getInitialData()
+  }
 </script>
 
 <div>
@@ -169,7 +175,7 @@
         <ImportButton
           disabled={$tables.selected?._id === "ta_users"}
           tableId={$tables.selected?._id}
-          on:updaterows={onUpdateRows}
+          on:importrows={onImportData}
         />
         <ExportButton
           disabled={!hasRows || !hasCols}

--- a/packages/builder/src/components/backend/DataTable/buttons/ImportButton.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/ImportButton.svelte
@@ -12,5 +12,5 @@
   Import
 </ActionButton>
 <Modal bind:this={modal}>
-  <ImportModal {tableId} on:updaterows />
+  <ImportModal {tableId} on:importrows />
 </Modal>

--- a/packages/builder/src/components/backend/DataTable/modals/ImportModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/ImportModal.svelte
@@ -29,7 +29,7 @@
     }
 
     // Always refresh rows just to be sure
-    dispatch("updaterows")
+    dispatch("importrows")
   }
 </script>
 


### PR DESCRIPTION
## Description

Importing rows will now reinitialise the table data and paging information to ensure the full collection of rows can be browsed.

- This change will place the user back at page 1 of the table they were browsing.
- Sorting and filtering of the data will remain unchanged.

Addresses: 
- https://github.com/Budibase/budibase/issues/8850

## Screenshots

Below outlines the updated flow placing the user back at page 1.

![importRows](https://user-images.githubusercontent.com/5913006/205682218-edc6bef3-d3b0-46d7-a58a-5fd9aa2c46d8.gif)


