### PR TITLE
single image nginx logs to stdout

### DIFF
--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -61,7 +61,8 @@ ADD hosting/single/nginx/nginx.conf /etc/nginx
 ADD hosting/single/nginx/nginx-default-site.conf /etc/nginx/sites-enabled/default
 RUN mkdir -p /var/log/nginx && \
   touch /var/log/nginx/error.log && \
-  touch /var/run/nginx.pid
+  touch /var/run/nginx.pid && \
+  usermod -a -G tty www-data
 
 WORKDIR /
 RUN mkdir -p scripts/integrations/oracle

--- a/hosting/single/nginx/nginx-default-site.conf
+++ b/hosting/single/nginx/nginx-default-site.conf
@@ -2,7 +2,8 @@ server {
     listen       80 default_server;
     listen  [::]:80 default_server;
     server_name  _;
-
+    error_log            /dev/stderr warn;
+    access_log           /dev/stdout main;
     client_max_body_size 1000m;
     ignore_invalid_headers off;
     proxy_buffering off;

--- a/hosting/single/nginx/nginx.conf
+++ b/hosting/single/nginx/nginx.conf
@@ -1,5 +1,5 @@
 user                 www-data www-data;
-error_log            /var/log/nginx/error.log;
+error_log            /dev/stderr warn;
 pid                  /var/run/nginx.pid;
 worker_processes     auto;
 worker_rlimit_nofile 8192;


### PR DESCRIPTION
## Description
I had this change in another [PR](https://github.com/Budibase/budibase/pull/8064/) that is now obsolete so re-adding the missing bits here and I will close the old PR.
- Nginx user needs to be added to the `tty` group to allow permissions to write to /dev/stdout 
- Set nginx log location to /dev/stdout /dev/stderr
