### PR TITLE
appOverview Cypress Test Update

### DIFF
--- a/packages/builder/cypress/integration/adminAndManagement/userManagement.spec.js
+++ b/packages/builder/cypress/integration/adminAndManagement/userManagement.spec.js
@@ -2,20 +2,20 @@ import filterTests from "../../support/filterTests"
 const interact = require('../../support/interact')
 
 filterTests(["smoke", "all"], () => {
-  context("User Management", () => {
+  xcontext("User Management", () => {
     before(() => {
       cy.login()
       cy.deleteApp("Cypress Tests")
       cy.createApp("Cypress Tests", false)
     })
 
-    it("should create a user via basic onboarding", () => {
+    xit("should create a user via basic onboarding", () => {
       cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 5000})
       cy.createUser("bbuser@test.com")
       cy.get(interact.SPECTRUM_TABLE).should("contain", "bbuser")
     })
 
-    it("should confirm App User role for a New User", () => {
+    xit("should confirm App User role for a New User", () => {
       cy.contains("bbuser").click()
       cy.get(".spectrum-Form-itemField").eq(3).should('contain', 'App User')
 
@@ -166,7 +166,7 @@ filterTests(["smoke", "all"], () => {
         })
     })
 
-    it("Should edit user details within user details page", () => {
+    xit("Should edit user details within user details page", () => {
       // Add First name
       cy.get(interact.FIELD, { timeout: 1000 }).eq(1).within(() => {
         cy.wait(500)
@@ -190,7 +190,7 @@ filterTests(["smoke", "all"], () => {
       })
     })
 
-    it("should reset the users password", () => {
+    xit("should reset the users password", () => {
       cy.get(".title").within(() => {
         cy.get(interact.SPECTRUM_ICON).click({ force: true })
       })
@@ -230,7 +230,7 @@ filterTests(["smoke", "all"], () => {
       cy.login()
       })
 
-    it("should delete a user", () => {
+    xit("should delete a user", () => {
       cy.deleteUser("bbuser@test.com")
       cy.get(interact.SPECTRUM_TABLE, { timeout: 4000 }).should("not.have.text", "bbuser")
     })

--- a/packages/builder/cypress/integration/appOverview.spec.js
+++ b/packages/builder/cypress/integration/appOverview.spec.js
@@ -140,7 +140,8 @@ filterTests(["all"], () => {
         })
 
       cy.visit(`${Cypress.config().baseUrl}/builder`)
-      cy.get(".appTable .app-row-actions button")
+      cy.wait(1000)
+      cy.get(".appTable .app-row-actions button", { timeout: 10000 })
         .contains("Manage")
         .eq(0)
         .click({ force: true })


### PR DESCRIPTION
The test 'Should reflect an application that has been unpublished' failed on last nights build. This is likely a timing issue.
I have included a wait and timeout within the test. It passes locally, just not on the nightly build.

Skipping the full User Management test file
- We have coverage of these tests via QA Wolf

