### PR TITLE
Fix for JS helpers

### DIFF
--- a/packages/builder/src/components/common/bindings/utils.js
+++ b/packages/builder/src/components/common/bindings/utils.js
@@ -24,7 +24,7 @@ export function addJSBinding(value, caretPos, binding, { helper } = {}) {
   if (!helper) {
     binding = `$("${binding}")`
   } else {
-    binding = `helper.${binding}()`
+    binding = `helpers.${binding}()`
   }
   if (caretPos.start) {
     value =

--- a/packages/string-templates/test/javascript.spec.js
+++ b/packages/string-templates/test/javascript.spec.js
@@ -129,3 +129,15 @@ describe("Test the JavaScript helper", () => {
     expect(output).toBe("Error while executing JS")
   })
 })
+
+describe("check JS helpers", () => {
+  it("should error if using the format helper. not helpers.", () => {
+    const output = processJS(`return helper.toInt(4.3)`)
+    expect(output).toBe("Error while executing JS")
+  })
+
+  it("should be able to use toInt", () => {
+    const output = processJS(`return helpers.toInt(4.3)`)
+    expect(output).toBe(4)
+  })
+})


### PR DESCRIPTION
## Description
Minor fix for #8843 - the binding input drawer was using the format helper. rather than helpers. when generating JS helpers.

Addresses: 
- #8843