### PR TITLE
Fix for removing cron automations immediately after publishing

### DIFF
--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -89,7 +89,9 @@ async function initDeployedApp(prodAppId: any) {
   console.log("Enabled cron triggers for deployed app..")
   // sync the automations back to the dev DB - since there is now cron
   // information attached
-  await sdk.applications.syncApp(dbCore.getDevAppID(prodAppId), { automationOnly: true })
+  await sdk.applications.syncApp(dbCore.getDevAppID(prodAppId), {
+    automationOnly: true,
+  })
 }
 
 async function deployApp(deployment: any, userId: string) {

--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -118,6 +118,8 @@ async function deployApp(deployment: any, userId: string) {
     }
     replication = new dbCore.Replication(config)
     const devDb = context.getDevAppDB()
+    console.log("Compacting development DB")
+    await devDb.compact()
     console.log("Replication object created")
     await replication.replicate(replication.appReplicateOpts())
     console.log("replication complete.. replacing app meta doc")

--- a/packages/server/src/sdk/app/applications/sync.ts
+++ b/packages/server/src/sdk/app/applications/sync.ts
@@ -2,7 +2,7 @@ import env from "../../../environment"
 import { db as dbCore, context } from "@budibase/backend-core"
 import sdk from "../../"
 
-export async function syncApp(appId: string) {
+export async function syncApp(appId: string, opts?: { automationOnly?: boolean }) {
   if (env.DISABLE_AUTO_PROD_APP_SYNC) {
     return {
       message:
@@ -33,7 +33,11 @@ export async function syncApp(appId: string) {
   })
   let error
   try {
-    await replication.replicate(replication.appReplicateOpts())
+    const replOpts = replication.appReplicateOpts()
+    if (opts?.automationOnly) {
+      replOpts.filter = (doc: any) => doc._id.startsWith(dbCore.DocumentType.AUTOMATION)
+    }
+    await replication.replicate()
   } catch (err) {
     error = err
   } finally {

--- a/packages/server/src/sdk/app/applications/sync.ts
+++ b/packages/server/src/sdk/app/applications/sync.ts
@@ -41,7 +41,7 @@ export async function syncApp(
       replOpts.filter = (doc: any) =>
         doc._id.startsWith(dbCore.DocumentType.AUTOMATION)
     }
-    await replication.replicate()
+    await replication.replicate(replOpts)
   } catch (err) {
     error = err
   } finally {

--- a/packages/server/src/sdk/app/applications/sync.ts
+++ b/packages/server/src/sdk/app/applications/sync.ts
@@ -2,7 +2,10 @@ import env from "../../../environment"
 import { db as dbCore, context } from "@budibase/backend-core"
 import sdk from "../../"
 
-export async function syncApp(appId: string, opts?: { automationOnly?: boolean }) {
+export async function syncApp(
+  appId: string,
+  opts?: { automationOnly?: boolean }
+) {
   if (env.DISABLE_AUTO_PROD_APP_SYNC) {
     return {
       message:
@@ -35,7 +38,8 @@ export async function syncApp(appId: string, opts?: { automationOnly?: boolean }
   try {
     const replOpts = replication.appReplicateOpts()
     if (opts?.automationOnly) {
-      replOpts.filter = (doc: any) => doc._id.startsWith(dbCore.DocumentType.AUTOMATION)
+      replOpts.filter = (doc: any) =>
+        doc._id.startsWith(dbCore.DocumentType.AUTOMATION)
     }
     await replication.replicate()
   } catch (err) {


### PR DESCRIPTION
## Description
Fix for #7865 - if you deleted a cron automation immediately after creating/publishing it there was a scenario where prod automations would be out of sync with dev automations and it wouldn't really delete. To get around this, we do an automation sync back to dev DB - meaning that the cron ID is known and can be disabled.

Addresses: 
- #7865

