### PR TITLE
Backend-core plugin import support

### DIFF
--- a/packages/backend-core/plugins.ts
+++ b/packages/backend-core/plugins.ts
@@ -1,0 +1,1 @@
+export * from "./src/plugin"


### PR DESCRIPTION
## Description
Fix for Budibase plugin skeleton, which utilises the old import style.

This does not need to be released, simply merged so the NPM version of backend-core is compliant with the skeleton style of `@budibase/backend-core/plugins`.