### PR TITLE
Fix SQL table `_id` filtering

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -232,6 +232,7 @@
             {filters}
             {bindings}
             {schemaFields}
+            datasource={{ type: "table", tableId }}
             panel={AutomationBindingPanel}
             fillWidth
             on:change={e => (tempFilters = e.detail)}

--- a/packages/builder/src/components/backend/DataTable/DataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/DataTable.svelte
@@ -190,6 +190,7 @@
             {filters}
             on:change={onFilter}
             disabled={!hasCols}
+            tableId={id}
           />
         {/key}
       </div>

--- a/packages/builder/src/components/backend/DataTable/buttons/TableFilterButton.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/TableFilterButton.svelte
@@ -6,6 +6,7 @@
   export let schema
   export let filters
   export let disabled = false
+  export let tableId
 
   const dispatch = createEventDispatcher()
 
@@ -37,6 +38,7 @@
         allowBindings={false}
         {filters}
         {schemaFields}
+        datasource={{ type: "table", tableId }}
         on:change={e => (tempValue = e.detail)}
       />
     </div>

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -41,11 +41,7 @@
 
   $: parseFilters(filters)
   $: dispatch("change", enrichFilters(rawFilters, matchAny))
-  $: enrichedSchemaFields = getFields(
-    schemaFields || [],
-    { allowLinks: true },
-    tableId
-  )
+  $: enrichedSchemaFields = getFields(schemaFields || [], { allowLinks: true })
   $: fieldOptions = enrichedSchemaFields.map(field => field.name) || []
   $: valueTypeOptions = allowBindings ? ["Value", "Binding"] : ["Value"]
 

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -25,7 +25,7 @@
   export let panel = ClientBindingPanel
   export let allowBindings = true
   export let fillWidth = false
-  export let tableId
+  export let datasource
 
   const dispatch = createEventDispatcher()
   const { OperatorOptions } = Constants
@@ -115,7 +115,11 @@
 
   const santizeOperator = filter => {
     // Ensure a valid operator is selected
-    const operators = getValidOperatorsForType(filter.type).map(x => x.value)
+    const operators = getValidOperatorsForType(
+      filter.type,
+      filter.field,
+      datasource
+    ).map(x => x.value)
     if (!operators.includes(filter.operator)) {
       filter.operator = operators[0] ?? OperatorOptions.Equals.value
     }
@@ -197,7 +201,11 @@
               />
               <Select
                 disabled={!filter.field}
-                options={getValidOperatorsForType(filter.type)}
+                options={getValidOperatorsForType(
+                  filter.type,
+                  filter.field,
+                  datasource
+                )}
                 bind:value={filter.operator}
                 on:change={() => onOperatorChange(filter)}
                 placeholder={null}

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterEditor.svelte
@@ -36,7 +36,6 @@
     filters={value}
     {bindings}
     {schemaFields}
-    tableId={dataSource.tableId}
     on:change={e => (tempValue = e.detail)}
   />
 </Drawer>

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterEditor.svelte
@@ -17,8 +17,8 @@
   let drawer
 
   $: tempValue = value
-  $: dataSource = getDatasourceForProvider($currentAsset, componentInstance)
-  $: schema = getSchemaForDatasource($currentAsset, dataSource)?.schema
+  $: datasource = getDatasourceForProvider($currentAsset, componentInstance)
+  $: schema = getSchemaForDatasource($currentAsset, datasource)?.schema
   $: schemaFields = Object.values(schema || {})
 
   async function saveFilter() {
@@ -36,6 +36,7 @@
     filters={value}
     {bindings}
     {schemaFields}
+    {datasource}
     on:change={e => (tempValue = e.detail)}
   />
 </Drawer>

--- a/packages/builder/src/helpers/searchFields.js
+++ b/packages/builder/src/helpers/searchFields.js
@@ -16,11 +16,7 @@ export function getTableFields(linkField) {
   }))
 }
 
-export function getFields(
-  fields,
-  { allowLinks } = { allowLinks: true },
-  tableId
-) {
+export function getFields(fields, { allowLinks } = { allowLinks: true }) {
   let filteredFields = fields.filter(
     field => !BannedSearchTypes.includes(field.type)
   )
@@ -34,9 +30,5 @@ export function getFields(
   const staticFormulaFields = fields.filter(
     field => field.type === "formula" && field.formulaType === "static"
   )
-  const table = get(tables).list.find(table => table._id === tableId)
-  if (table?.type === "external" && table?.sql) {
-    filteredFields = filteredFields.filter(field => field.name !== "_id")
-  }
   return filteredFields.concat(staticFormulaFields)
 }

--- a/packages/client/src/components/app/dynamic-filter/DynamicFilter.svelte
+++ b/packages/client/src/components/app/dynamic-filter/DynamicFilter.svelte
@@ -21,6 +21,7 @@
     schema
 
   $: dataProviderId = dataProvider?.id
+  $: datasource = dataProvider?.datasource
   $: addExtension = getAction(
     dataProviderId,
     ActionTypes.AddDataProviderQueryExtension
@@ -29,7 +30,7 @@
     dataProviderId,
     ActionTypes.RemoveDataProviderQueryExtension
   )
-  $: fetchSchema(dataProvider || {})
+  $: fetchSchema(datasource)
   $: schemaFields = getSchemaFields(schema, allowedFields)
 
   // Add query extension to data provider
@@ -42,8 +43,7 @@
     }
   }
 
-  async function fetchSchema(dataProvider) {
-    const datasource = dataProvider?.datasource
+  async function fetchSchema(datasource) {
     if (datasource) {
       schema = await fetchDatasourceSchema(datasource, {
         enrichRelationships: true,
@@ -102,7 +102,7 @@
 
   <Modal bind:this={modal}>
     <ModalContent title="Edit filters" size="XL" onConfirm={updateQuery}>
-      <FilterModal bind:filters={tmpFilters} {schemaFields} />
+      <FilterModal bind:filters={tmpFilters} {schemaFields} {datasource} />
     </ModalContent>
   </Modal>
 {/if}

--- a/packages/client/src/components/app/dynamic-filter/FilterModal.svelte
+++ b/packages/client/src/components/app/dynamic-filter/FilterModal.svelte
@@ -15,6 +15,7 @@
 
   export let schemaFields
   export let filters = []
+  export let datasource
 
   const context = getContext("context")
   const BannedTypes = ["link", "attachment", "json"]
@@ -59,7 +60,9 @@
 
     // Ensure a valid operator is set
     const validOperators = LuceneUtils.getValidOperatorsForType(
-      expression.type
+      expression.type,
+      expression.field,
+      datasource
     ).map(x => x.value)
     if (!validOperators.includes(expression.operator)) {
       expression.operator =
@@ -118,7 +121,11 @@
           />
           <Select
             disabled={!filter.field}
-            options={LuceneUtils.getValidOperatorsForType(filter.type)}
+            options={LuceneUtils.getValidOperatorsForType(
+              filter.type,
+              filter.field,
+              datasource
+            )}
             bind:value={filter.operator}
             on:change={e => onOperatorChange(filter, e.detail)}
             placeholder={null}


### PR DESCRIPTION
## Description
This PR fixes some issues with filtering. Previously the `_id` field was removed from filtering altogether as it was believed that it did not work. This was incorrect, and the issue at that time was actually caused by the previous changes to prefix filter fields with numbers to allow multiple filters on the same field.

This PR:
- Adds back `_id` as a filter option for SQL tables
- Fixes filtering so that `_id` filters work for SQL tables. This supports multiple filters as well, and the "match any" behaviour.
- Restricts which operators are available for `_id` in SQL tables (only equals, not equals)
- Removes the "like" operator for internal tables (it is actually just "starts with" at the moment so is redundant)
- Updates data, design, automate and client to all respect these rules. There are still some differences between available fields depending where you filter because we have little consistency between how schemas are generated.

Addresses: 
- https://github.com/Budibase/budibase/issues/8334
- https://github.com/Budibase/budibase/issues/3386

This does not fix https://github.com/Budibase/budibase/issues/9015, in the sense that it is still impossible to do an "is in" with `_id` on a SQL table, but we cannot support that functionality without substantial additional work. This PR at least removes the "is in" operator to make it clear that it is not supported.

### Screenshots
SQL table with a working ID filter, showing only the available operators:
![image](https://user-images.githubusercontent.com/9075550/207320544-63d11158-6499-43ba-9e21-8228c39ff829.png)

Internal table with "like" removed:
![image](https://user-images.githubusercontent.com/9075550/207320657-29053eeb-3e55-4010-8f82-9e1d8b63dd16.png)




