### PR TITLE
Fix for user enrichment call (updating to @budibase/nano fork)

### DIFF
--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@budibase/types": "^2.2.2",
+    "@budibase/nano": "^10.1.0",
     "@shopify/jest-koa-mocks": "5.0.1",
     "@techpass/passport-openidconnect": "0.3.2",
     "aws-sdk": "2.1030.0",
@@ -35,7 +36,6 @@
     "koa-passport": "4.1.4",
     "lodash": "4.17.21",
     "lodash.isarguments": "3.1.0",
-    "nano": "^10.1.0",
     "node-fetch": "2.6.7",
     "passport-google-oauth": "2.0.0",
     "passport-jwt": "4.0.0",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@budibase/types": "^2.2.2",
-    "@budibase/nano": "^10.1.0",
+    "@budibase/nano": "10.1.1",
     "@shopify/jest-koa-mocks": "5.0.1",
     "@techpass/passport-openidconnect": "0.3.2",
     "aws-sdk": "2.1030.0",

--- a/packages/backend-core/src/db/couch/DatabaseImpl.ts
+++ b/packages/backend-core/src/db/couch/DatabaseImpl.ts
@@ -1,4 +1,4 @@
-import Nano from "nano"
+import Nano from "@budibase/nano"
 import {
   AllDocsResponse,
   AnyDocument,

--- a/packages/backend-core/yarn.lock
+++ b/packages/backend-core/yarn.lock
@@ -470,10 +470,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/nano@^10.1.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/@budibase/nano/-/nano-10.1.0.tgz#fb571c245bf8424697937622fe0fc3c5d553c063"
-  integrity sha512-mQCAlWA76vNqa5KM4j+wwF9RVyM9vuHwccQu/w/Un13jXiPL83Tmwo0eAXtlm+AtLthtQl5NfojqF+zCofepeA==
+"@budibase/nano@10.1.1":
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/@budibase/nano/-/nano-10.1.1.tgz#36ccda4d9bb64b5ee14dd2b27a295b40739b1038"
+  integrity sha512-kbMIzMkjVtl+xI0UPwVU0/pn8/ccxTyfzwBz6Z+ZiN2oUSb0fJCe0qwA6o8dxwSa8nZu4MbGAeMJl3CJndmWtA==
   dependencies:
     "@types/tough-cookie" "^4.0.2"
     axios "^1.1.3"

--- a/packages/backend-core/yarn.lock
+++ b/packages/backend-core/yarn.lock
@@ -470,6 +470,18 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@budibase/nano@^10.1.0":
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/@budibase/nano/-/nano-10.1.0.tgz#fb571c245bf8424697937622fe0fc3c5d553c063"
+  integrity sha512-mQCAlWA76vNqa5KM4j+wwF9RVyM9vuHwccQu/w/Un13jXiPL83Tmwo0eAXtlm+AtLthtQl5NfojqF+zCofepeA==
+  dependencies:
+    "@types/tough-cookie" "^4.0.2"
+    axios "^1.1.3"
+    http-cookie-agent "^4.0.2"
+    node-abort-controller "^3.0.1"
+    qs "^6.11.0"
+    tough-cookie "^4.1.2"
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -4021,18 +4033,6 @@ msgpackr@^1.5.2:
   integrity sha512-mWScyHTtG6TjivXX9vfIy2nBtRupaiAj0HQ2mtmpmYujAmqZmaaEVPaSZ1NKLMvicaMLFzEaMk0ManxMRg8rMQ==
   optionalDependencies:
     msgpackr-extract "^2.1.2"
-
-nano@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/nano/-/nano-10.1.0.tgz#afdd5a7440e62f09a8e23f41fcea328d27383922"
-  integrity sha512-COeN2TpLcHuSN44QLnPmfZCoCsKAg8/aelPOVqqm/2/MvRHDEA11/Kld5C4sLzDlWlhFZ3SO2WGJGevCsvcEzQ==
-  dependencies:
-    "@types/tough-cookie" "^4.0.2"
-    axios "^1.1.3"
-    http-cookie-agent "^4.0.2"
-    node-abort-controller "^3.0.1"
-    qs "^6.11.0"
-    tough-cookie "^4.1.2"
 
 napi-macros@~2.0.0:
   version "2.0.0"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -13,11 +13,11 @@
   },
   "jest": {},
   "devDependencies": {
-    "@types/json5": "^2.2.0",
+    "@budibase/nano": "10.1.1",
+    "@types/json5": "2.2.0",
     "@types/koa": "2.13.4",
     "@types/node": "14.18.20",
     "@types/pouchdb": "6.4.0",
-    "@budibase/nano": "10.1.0",
     "rimraf": "3.0.2",
     "typescript": "4.7.3"
   }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -17,7 +17,7 @@
     "@types/koa": "2.13.4",
     "@types/node": "14.18.20",
     "@types/pouchdb": "6.4.0",
-    "nano": "10.1.0",
+    "@budibase/nano": "10.1.0",
     "rimraf": "3.0.2",
     "typescript": "4.7.3"
   }

--- a/packages/types/src/sdk/db.ts
+++ b/packages/types/src/sdk/db.ts
@@ -1,5 +1,5 @@
 import PouchDB from "pouchdb"
-import Nano from "nano"
+import Nano from "@budibase/nano"
 import { AllDocsResponse, AnyDocument, Document } from "../"
 
 export type PouchOptions = {

--- a/packages/types/yarn.lock
+++ b/packages/types/yarn.lock
@@ -2,6 +2,18 @@
 # yarn lockfile v1
 
 
+"@budibase/nano@10.1.0":
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/@budibase/nano/-/nano-10.1.0.tgz#fb571c245bf8424697937622fe0fc3c5d553c063"
+  integrity sha512-mQCAlWA76vNqa5KM4j+wwF9RVyM9vuHwccQu/w/Un13jXiPL83Tmwo0eAXtlm+AtLthtQl5NfojqF+zCofepeA==
+  dependencies:
+    "@types/tough-cookie" "^4.0.2"
+    axios "^1.1.3"
+    http-cookie-agent "^4.0.2"
+    node-abort-controller "^3.0.1"
+    qs "^6.11.0"
+    tough-cookie "^4.1.2"
+
 "@types/accepts@*":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
@@ -482,18 +494,6 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
-nano@10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/nano/-/nano-10.1.0.tgz#afdd5a7440e62f09a8e23f41fcea328d27383922"
-  integrity sha512-COeN2TpLcHuSN44QLnPmfZCoCsKAg8/aelPOVqqm/2/MvRHDEA11/Kld5C4sLzDlWlhFZ3SO2WGJGevCsvcEzQ==
-  dependencies:
-    "@types/tough-cookie" "^4.0.2"
-    axios "^1.1.3"
-    http-cookie-agent "^4.0.2"
-    node-abort-controller "^3.0.1"
-    qs "^6.11.0"
-    tough-cookie "^4.1.2"
 
 node-abort-controller@^3.0.1:
   version "3.0.1"

--- a/packages/types/yarn.lock
+++ b/packages/types/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@budibase/nano@10.1.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/@budibase/nano/-/nano-10.1.0.tgz#fb571c245bf8424697937622fe0fc3c5d553c063"
-  integrity sha512-mQCAlWA76vNqa5KM4j+wwF9RVyM9vuHwccQu/w/Un13jXiPL83Tmwo0eAXtlm+AtLthtQl5NfojqF+zCofepeA==
+"@budibase/nano@10.1.1":
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/@budibase/nano/-/nano-10.1.1.tgz#36ccda4d9bb64b5ee14dd2b27a295b40739b1038"
+  integrity sha512-kbMIzMkjVtl+xI0UPwVU0/pn8/ccxTyfzwBz6Z+ZiN2oUSb0fJCe0qwA6o8dxwSa8nZu4MbGAeMJl3CJndmWtA==
   dependencies:
     "@types/tough-cookie" "^4.0.2"
     axios "^1.1.3"
@@ -87,7 +87,7 @@
   resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-1.8.2.tgz#7315b4c4c54f82d13fa61c228ec5c2ea5cc9e0e1"
   integrity sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==
 
-"@types/json5@^2.2.0":
+"@types/json5@2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-2.2.0.tgz#afff29abf9182a7d4a7e39105ca051f11c603d13"
   integrity sha512-NrVug5woqbvNZ0WX+Gv4R+L4TGddtmFek2u8RtccAgFZWtS9QXF2xCXY22/M4nzkaKF0q9Fc6M/5rxLDhfwc/A==


### PR DESCRIPTION
## Description
Fix for #9029 - this should fix the issue users have been experiencing with user enrichment calls in apps, essentially it utilises a fork of the nano library we use to interact with CouchDB, which has been updated to use a POST request rather than a GET request as it supports a larger set of data being sent as query parameters.

Post mortem will follow going into greater detail around the diagnose of this. This is also the most minimal fix possible to get this out - but will need to perform some further updates to `@budibase/nano` to improve its error outputs and fix any other functions which also utilise `GET` requests with a query string, that could instead use `POST` requests.

Addresses: 
- #9029