### PR TITLE
Adding price duration to BB account and redlock updates

### DIFF
--- a/packages/types/src/documents/account/account.ts
+++ b/packages/types/src/documents/account/account.ts
@@ -3,6 +3,7 @@ import {
   Hosting,
   MonthlyQuotaName,
   PlanType,
+  PriceDuration,
   Quotas,
   StaticQuotaName,
 } from "../../sdk"
@@ -46,6 +47,7 @@ export interface Account extends CreateAccount {
   tier: string // deprecated
   planType?: PlanType
   planTier?: number
+  planDuration?: PriceDuration
   stripeCustomerId?: string
   licenseKey?: string
   licenseKeyActivatedAt?: number

--- a/packages/types/src/sdk/locks.ts
+++ b/packages/types/src/sdk/locks.ts
@@ -4,11 +4,14 @@ export enum LockType {
    * No retries will take place and no error will be thrown.
    */
   TRY_ONCE = "try_once",
+  DEFAULT = "default",
+  DELAY_500 = "delay_500",
 }
 
 export enum LockName {
   MIGRATIONS = "migrations",
   TRIGGER_QUOTA = "trigger_quota",
+  SYNC_ACCOUNT_LICENSE = "sync_account_license",
 }
 
 export interface LockOptions {


### PR DESCRIPTION
## Description
Supporting work for hubspot events in this PR: https://github.com/Budibase/account-portal/pull/196

Adding the plan duration (Monthly/Annually) to the billing account - this allows us to determine if users have churned and find the price for the stripe plan that they are moving to, which in turn enables us to calculate the deal total in hubspot.

Also includes some redlock changes from the free trial work so that we can use it to lock the license sync call, preventing a race condition with several stripe webhooks firing in close succession.

Addresses: 
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._



