### PR TITLE
External datasource ordering

### DIFF
--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/CreateDatasourceModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/CreateDatasourceModal.svelte
@@ -11,7 +11,7 @@
   import { onMount } from "svelte"
   import ICONS from "../icons"
   import { API } from "api"
-  import { IntegrationTypes } from "constants/backend"
+  import { IntegrationTypes, DatasourceTypes } from "constants/backend"
   import CreateTableModal from "components/backend/TableNavigator/modals/CreateTableModal.svelte"
   import DatasourceConfigModal from "components/backend/DatasourceNavigator/modals/DatasourceConfigModal.svelte"
   import GoogleDatasourceConfigModal from "components/backend/DatasourceNavigator/modals/GoogleDatasourceConfigModal.svelte"
@@ -31,6 +31,7 @@
   $: customIntegrations = Object.entries(integrations).filter(
     entry => entry[1].custom
   )
+  $: sortedIntegrations = sortIntegrations(integrations)
 
   checkShowImport()
 
@@ -99,6 +100,28 @@
     }
     integrations = newIntegrations
   }
+
+  function sortIntegrations(integrations) {
+    let integrationsArray = Object.entries(integrations)
+    integrationsArray.sort((a, b) => {
+      function getTypeOrder(schema) {
+        if (schema.type === DatasourceTypes.API) {
+          return 1
+        }
+        if (schema.type === DatasourceTypes.RELATIONAL) {
+          return 2
+        }
+        return schema.type?.charCodeAt(0)
+      }
+      let typeOrderA = getTypeOrder(a[1])
+      let typeOrderB = getTypeOrder(b[1])
+      if (typeOrderA === typeOrderB) {
+        return a[1].friendlyName?.localeCompare(b[1].friendlyName)
+      }
+      return typeOrderA < typeOrderB ? -1 : 1
+    })
+    return integrationsArray
+  }
 </script>
 
 <Modal bind:this={internalTableModal}>
@@ -157,7 +180,7 @@
     <Layout noPadding gap="XS">
       <Body size="S">Connect to an external datasource</Body>
       <div class="item-list">
-        {#each Object.entries(integrations).filter(([key, val]) => key !== IntegrationTypes.INTERNAL && !val.custom) as [integrationType, schema]}
+        {#each sortedIntegrations.filter(([key, val]) => key !== IntegrationTypes.INTERNAL && !val.custom) as [integrationType, schema]}
           <DatasourceCard
             on:selected={evt => selectIntegration(evt.detail)}
             {schema}

--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/CreateDatasourceModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/CreateDatasourceModal.svelte
@@ -103,16 +103,17 @@
 
   function sortIntegrations(integrations) {
     let integrationsArray = Object.entries(integrations)
-    integrationsArray.sort((a, b) => {
-      function getTypeOrder(schema) {
-        if (schema.type === DatasourceTypes.API) {
-          return 1
-        }
-        if (schema.type === DatasourceTypes.RELATIONAL) {
-          return 2
-        }
-        return schema.type?.charCodeAt(0)
+    function getTypeOrder(schema) {
+      if (schema.type === DatasourceTypes.API) {
+        return 1
       }
+      if (schema.type === DatasourceTypes.RELATIONAL) {
+        return 2
+      }
+      return schema.type?.charCodeAt(0)
+    }
+
+    integrationsArray.sort((a, b) => {
       let typeOrderA = getTypeOrder(a[1])
       let typeOrderB = getTypeOrder(b[1])
       if (typeOrderA === typeOrderB) {

--- a/packages/builder/src/constants/backend/index.js
+++ b/packages/builder/src/constants/backend/index.js
@@ -261,3 +261,12 @@ export const BannedSearchTypes = [
   "json",
   "jsonarray",
 ]
+
+export const DatasourceTypes = {
+  RELATIONAL: "Relational",
+  NON_RELATIONAL: "Non-relational",
+  SPREADSHEET: "Spreadsheet",
+  OBJECT_STORE: "Object store",
+  GRAPH: "Graph",
+  API: "API"
+}

--- a/packages/builder/src/constants/backend/index.js
+++ b/packages/builder/src/constants/backend/index.js
@@ -268,5 +268,5 @@ export const DatasourceTypes = {
   SPREADSHEET: "Spreadsheet",
   OBJECT_STORE: "Object store",
   GRAPH: "Graph",
-  API: "API"
+  API: "API",
 }

--- a/packages/server/src/integrations/snowflake.ts
+++ b/packages/server/src/integrations/snowflake.ts
@@ -15,7 +15,7 @@ const SCHEMA: Integration = {
   description:
     "Snowflake is a solution for data warehousing, data lakes, data engineering, data science, data application development, and securely sharing and consuming shared data.",
   friendlyName: "Snowflake",
-  type: "Non-relational",
+  type: "Relational",
   datasource: {
     account: {
       type: "string",

--- a/packages/server/src/integrations/snowflake.ts
+++ b/packages/server/src/integrations/snowflake.ts
@@ -15,7 +15,7 @@ const SCHEMA: Integration = {
   description:
     "Snowflake is a solution for data warehousing, data lakes, data engineering, data science, data application development, and securely sharing and consuming shared data.",
   friendlyName: "Snowflake",
-  type: "Relational",
+  type: "Non-relational",
   datasource: {
     account: {
       type: "string",


### PR DESCRIPTION
## Description
External datasources are now sorted by friendlyName alphabetically and by the following type ordering:
1. API
2. Relational
3. Remaining types ordered alphabetically

No change to how custom datasources are sorted.

Addresses: 
- https://github.com/Budibase/budibase/issues/8103

## Screenshots
<img width="455" alt="Screenshot 2022-12-17 at 13 39 28" src="https://user-images.githubusercontent.com/101575380/208244755-235f4460-c744-42d3-a11e-cf56749e0887.png">




