### PR TITLE
Make looping arrow point in right direction

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
@@ -180,7 +180,7 @@
               onSelect(block)
             }}
           >
-            <Icon name={showLooping ? "ChevronDown" : "ChevronUp"} />
+            <Icon name={showLooping ? "ChevronUp" : "ChevronDown"} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description
Automation looping section arrows now point in the same direction as other blocks for consistency.

Addresses: 
- https://github.com/Budibase/budibase/issues/7784

## Screenshots
![Screenshot 2022-12-15 at 11 12 29](https://user-images.githubusercontent.com/101575380/207844972-99054282-ba96-4630-8190-8f57a475da65.png)

![Screenshot 2022-12-15 at 11 12 45](https://user-images.githubusercontent.com/101575380/207845036-59c58447-3a0c-47d1-977e-8dc971593c7f.png)

![Screenshot 2022-12-15 at 11 12 58](https://user-images.githubusercontent.com/101575380/207845079-0164077f-dc72-4fe5-a427-b0e0feb9088d.png)
