### PR TITLE
Disable specific dates and support ranges

### DIFF
--- a/packages/bbui/src/Form/Core/DatePicker.svelte
+++ b/packages/bbui/src/Form/Core/DatePicker.svelte
@@ -18,6 +18,7 @@
   export let ignoreTimezones = false
   export let time24hr = false
   export let range = false
+  export let disabledDates = []
   const dispatch = createEventDispatcher()
   const flatpickrId = `${uuid()}-wrapper`
   let open = false
@@ -53,6 +54,7 @@
     mode: range ? "range" : "single",
     appendTo,
     disableMobile: "true",
+    disable: disabledDates,
     onReady: () => {
       let timestamp = resolveTimeStamp(value)
       if (timeOnly && timestamp) {

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -3200,6 +3200,18 @@
         "defaultValue": false
       },
       {
+        "type": "boolean",
+        "label": "Range mode",
+        "key": "range",
+        "defaultValue": false
+      },
+      {
+        "type": "field/datetime",
+        "label": "To field",
+        "key": "toField",
+        "dependsOn": "range"
+      },
+      {
         "type": "text",
         "label": "Default value",
         "key": "defaultValue"

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -3205,6 +3205,11 @@
         "key": "defaultValue"
       },
       {
+        "type": "text",
+        "label": "Disabled dates",
+        "key": "disabledDates"
+      },
+      {
         "type": "event",
         "label": "On Change",
         "key": "onChange",
@@ -3785,7 +3790,6 @@
         "defaultValue": false,
         "info": "Row selection is only compatible with internal or SQL tables"
       },
-
       {
         "section": true,
         "name": "On Row Click",

--- a/packages/client/src/components/app/forms/DateTimeField.svelte
+++ b/packages/client/src/components/app/forms/DateTimeField.svelte
@@ -12,6 +12,7 @@
   export let ignoreTimezones = false
   export let validation
   export let defaultValue
+  export let disabledDates
   export let onChange
 
   let fieldState
@@ -22,6 +23,13 @@
     if (onChange && changed) {
       onChange({ value: e.detail })
     }
+  }
+
+  const parseDisabledDates = disabledDates => {
+    if (typeof disabledDates === "string") {
+      return disabledDates.split(",")
+    }
+    return disabledDates || []
   }
 </script>
 
@@ -48,6 +56,7 @@
       {time24hr}
       {ignoreTimezones}
       {placeholder}
+      disabledDates={parseDisabledDates(disabledDates)}
     />
   {/if}
 </Field>


### PR DESCRIPTION
## Description
Attempting to solve this use-case: https://github.com/Budibase/budibase/discussions/8402
When you want to allow users to choose a *Start* and *End* date, but not allow them to create a range that intersects disabled dates.

### Disabled dates
Consider a table with holidays that you want to disable from the date picker calendar:
![Screenshot 2022-12-15 at 14 10 41](https://user-images.githubusercontent.com/101575380/207882480-ec9caa8a-2502-4027-ab90-29b6179e329d.png)

You can use the *Disabled dates* field to disable these dates. In this case the following handlebars expression is being used: `{{ pluck DisabledDates Data Provider.Rows 'Holiday' }}`

![Screenshot 2022-12-15 at 14 12 12](https://user-images.githubusercontent.com/101575380/207882808-d04ea2da-7c0f-4444-9fd5-5ac3c22caa2b.png)

![Screenshot 2022-12-15 at 14 12 31](https://user-images.githubusercontent.com/101575380/207882871-bf108291-c66b-4f7d-9352-4b78acaa684c.png)

### Date range
There was some code already in here to handle a little bit of the flatpickr range mode, however I wasn't able to find anywhere that actually used it, but if there is some other use of the functionality I need to test then let me know!

Added a check box for *Range mode*. When ticked, you can select a date field as the *To* (end) date.
![Screenshot 2022-12-15 at 14 15 17](https://user-images.githubusercontent.com/101575380/207883508-ef964f3a-41d0-406c-8d3c-a0b93e573e4e.png)

![Screenshot 2022-12-15 at 14 16 06](https://user-images.githubusercontent.com/101575380/207883665-0583a74a-48a0-4cfd-af06-ba7d5d6b2142.png)

This is probably a bit unorthodox as it involves registering two form fields in one component, but here's an example form:
![Screenshot 2022-12-15 at 14 20 47](https://user-images.githubusercontent.com/101575380/207884693-742f80a8-c723-4245-8572-5eebb787802c.png)

![Screenshot 2022-12-15 at 14 19 35](https://user-images.githubusercontent.com/101575380/207884446-b3a85ccd-8707-4178-b01a-d6995bc5cc86.png)

![Screenshot 2022-12-15 at 14 21 42](https://user-images.githubusercontent.com/101575380/207884967-8efd1d93-0456-4597-b8b1-f5cc035b0dc0.png)

Unticking the range mode will revert to using the *Start* date only.

Addresses: 
- https://github.com/Budibase/budibase/issues/8415

## App Export
[Date Picker Range-export.tar.gz](https://github.com/Budibase/budibase/files/10237642/Date.Picker.Range-export-1671113331331.tar.gz)




