### PR TITLE
Types/attaching license to account

### DIFF
--- a/packages/types/src/documents/account/account.ts
+++ b/packages/types/src/documents/account/account.ts
@@ -1,6 +1,7 @@
 import {
   Feature,
   Hosting,
+  License,
   MonthlyQuotaName,
   PlanType,
   PriceDuration,
@@ -48,6 +49,7 @@ export interface Account extends CreateAccount {
   planType?: PlanType
   planTier?: number
   planDuration?: PriceDuration
+  license?: License
   stripeCustomerId?: string
   licenseKey?: string
   licenseKeyActivatedAt?: number

--- a/packages/types/src/documents/account/account.ts
+++ b/packages/types/src/documents/account/account.ts
@@ -48,7 +48,6 @@ export interface Account extends CreateAccount {
   tier: string // deprecated
   planType?: PlanType
   planTier?: number
-  planDuration?: PriceDuration
   license?: License
   stripeCustomerId?: string
   licenseKey?: string


### PR DESCRIPTION
## Description
Attaching the license key to budibase accounts in dynamo. This allows us to keep historical context of the last license and compare it to the new one when updates are performed, so we can sync with hubspot. Also removing `planDuration` as no longer required due to the license being present.

Also removing the `duration`

Addresses: 
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._



