### PR TITLE
Publish helm chart with correct app version, publish on develop

### DIFF
--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -1,5 +1,5 @@
 name: Budibase Prerelease
-concurrency: release-prerelease
+#concurrency: release-prerelease
 
 on: 
  push:

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -26,7 +26,7 @@ env:
   FEATURE_PREVIEW_URL: https://budirelease.live
       
 jobs:
-  release:
+  release-images:
     runs-on: ubuntu-latest 
 
     steps:
@@ -44,18 +44,11 @@ jobs:
         run: yarn install:pro develop
 
       - run: yarn 
-      - run: yarn bootstrap 
+      - run: yarn bootstrap
       - run: yarn lint 
       - run: yarn build
       - run: yarn build:sdk
       - run: yarn test
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
 
       - name: Publish budibase packages to NPM
         env:
@@ -76,12 +69,6 @@ jobs:
           DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}
 
-      - name: Get the latest budibase release version
-        id: version
-        run: | 
-          release_version=$(cat lerna.json | jq -r '.version')
-          echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
-
       - name: Tag and release Proxy service docker image
         run: | 
           docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
@@ -92,6 +79,26 @@ jobs:
           DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}
           RELEASE_TAG: k8s-release
+
+  deploy-to-release-env:
+    needs: [release-images]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get the current budibase release version
+        id: version
+        run: |
+          release_version=$(cat lerna.json | jq -r '.version')
+          echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
 
       - name: Pull values.yaml from budibase-infra
         run: | 
@@ -151,16 +158,11 @@ jobs:
           embed-title: ${{ env.RELEASE_VERSION }}
 
   release-helm-chart:
+#    needs: [release-images]
     runs-on: ubuntu-latest
 
     steps:
-#      - name: Fail if branch is not develop
-#        if: github.ref != 'refs/heads/develop'
-#        run: |
-#          echo "Ref is not develop, you must run this job from develop."
-#          exit 1
       - uses: actions/checkout@v2
-
       - name: Setup Helm
         uses: azure/setup-helm@v1
         id: helm-install
@@ -187,19 +189,19 @@ jobs:
           git commit -m "Helm Release: develop"
           git push
 
-  deploy-develop-to-qa:
-#    needs: [release, release-helm-chart]
+  trigger-deploy-to-qa:
     needs: [release-helm-chart]
     runs-on: ubuntu-latest
     steps:
-#      - name: Fail if branch is not develop
-#        if: github.ref != 'refs/heads/develop'
-#        run: |
-#          echo "Ref is not develop, you must run this job from develop."
-#          exit 1
+      - name: Get the current budibase release version
+        id: version
+        run: |
+          release_version=$(cat lerna.json | jq -r '.version')
+          echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
+
       - uses: passeidireto/trigger-external-workflow-action@main
         env:
-          PAYLOAD_VERSION: "develop"
+          PAYLOAD_VERSION: ${{ env.RELEASE_VERSION }}
         with:
           repository: budibase/budibase-deploys
           event: deploy-develop-to-qa

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -158,7 +158,7 @@ jobs:
           embed-title: ${{ env.RELEASE_VERSION }}
 
   release-helm-chart:
-#    needs: [release-images]
+    needs: [release-images]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -174,8 +174,9 @@ jobs:
           git reset --hard
           git pull
           mkdir sync
-          echo "Packing chart to sync dir"
+          echo "Packaging chart to sync dir"
           helm package charts/budibase 0.0.0-develop --app-version develop --destination sync
+          echo "Packaging successful"
           git checkout gh-pages
           mv *.tgz docs
           echo "Indexing helm repo"         

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -159,7 +159,7 @@ jobs:
 #        run: |
 #          echo "Ref is not develop, you must run this job from develop."
 #          exit 1
-#      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
       - name: Setup Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -203,6 +203,6 @@ jobs:
         env:
           PAYLOAD_VERSION: "develop"
         with:
-          repository: budibase/budibase/deploys
+          repository: budibase/budibase-deploys
           event: deploy-develop-to-qa
           github_pat: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -175,7 +175,7 @@ jobs:
           git pull
           mkdir sync
           echo "Packaging chart to sync dir"
-          helm package charts/budibase 0.0.0-develop --app-version develop --destination sync
+          helm package charts/budibase --version 0.0.0-develop --app-version develop --destination sync
           echo "Packaging successful"
           git checkout gh-pages
           mv *.tgz docs

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -203,4 +203,4 @@ jobs:
         with:
           repository: budibase/budibase-deploys
           event: deploy-develop-to-qa
-          github_pat: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          github_pat: ${{ secrets.GH_PERSONAL_TOKEN }}

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -165,14 +165,14 @@ jobs:
         uses: azure/setup-helm@v1
         id: helm-install
 
+      # due to helm repo index issue: https://github.com/helm/helm/issues/7363
+      # we need to create new package in a different dir, merge the index and move the package back
       - name: Build and release helm chart
         run: |
           git config user.name "Budibase Helm Bot"
           git config user.email "<>"
           git reset --hard
           git pull
-#          due to helm repo index issue: https://github.com/helm/helm/issues/7363
-#          we need to create new package in a different dir, merge the index and move the package back
           mkdir sync
           echo "Packing chart to sync dir"
           helm package charts/budibase 0.0.0-develop --app-version develop --destination sync
@@ -180,7 +180,6 @@ jobs:
           mv *.tgz docs
           echo "Indexing helm repo"         
           helm repo index --merge docs/index.yaml sync
-#         cleanup the sync dir before commit
           mv -f sync/* docs
           rm -rf sync
           echo "Pushing new helm release"

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -186,8 +186,6 @@ jobs:
           git add -A
           git commit -m "Helm Release: develop"
           git push
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-develop-to-qa:
 #    needs: [release, release-helm-chart]
@@ -205,4 +203,4 @@ jobs:
         with:
           repository: budibase/budibase-deploys
           event: deploy-develop-to-qa
-          github_pat: ${{ secrets.GITHUB_TOKEN }}
+          github_pat: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -171,10 +171,16 @@ jobs:
           git config user.email "<>"
           git reset --hard
           git pull
-          helm package charts/budibase 0.0.0-develop --app-version develop
+#          due to helm repo index issue: https://github.com/helm/helm/issues/7363
+#          we need to create new package in a different dir, merge the index and move the package back
+          mkdir sync
+          helm package charts/budibase 0.0.0-develop --app-version develop --destination sync
           git checkout gh-pages
           mv *.tgz docs
-          helm repo index docs
+          helm repo index --merge docs/index.yaml sync
+#         cleanup the sync dir before commit
+          mv -f sync/* docs
+          rm -rf sync
           git add -A
           git commit -m "Helm Release: ${{ env.RELEASE_VERSION }}"
           git push

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -184,7 +184,7 @@ jobs:
           rm -rf sync
           echo "Pushing new helm release"
           git add -A
-          git commit -m "Helm Release: ${{ env.RELEASE_VERSION }}"
+          git commit -m "Helm Release: develop"
           git push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -203,4 +203,4 @@ jobs:
         with:
           repository: budibase/budibase-deploys
           event: deploy-develop-to-qa
-          github_pat: ${{ secrets.GH_PERSONAL_TOKEN }}
+          github_pat: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -188,3 +188,21 @@ jobs:
           git push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-develop-to-qa:
+#    needs: [release, release-helm-chart]
+    needs: [release-helm-chart]
+    runs-on: ubuntu-latest
+    steps:
+#      - name: Fail if branch is not develop
+#        if: github.ref != 'refs/heads/develop'
+#        run: |
+#          echo "Ref is not develop, you must run this job from develop."
+#          exit 1
+      - uses: passeidireto/trigger-external-workflow-action@main
+        env:
+          PAYLOAD_VERSION: "develop"
+        with:
+          repository: budibase/budibase/deploys
+          event: deploy-develop-to-qa
+          github_pat: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -178,7 +178,6 @@ jobs:
           helm package charts/budibase --version 0.0.0-develop --app-version develop --destination sync
           echo "Packaging successful"
           git checkout gh-pages
-          mv *.tgz docs
           echo "Indexing helm repo"         
           helm repo index --merge docs/index.yaml sync
           mv -f sync/* docs

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -174,13 +174,16 @@ jobs:
 #          due to helm repo index issue: https://github.com/helm/helm/issues/7363
 #          we need to create new package in a different dir, merge the index and move the package back
           mkdir sync
+          echo "Packing chart to sync dir"
           helm package charts/budibase 0.0.0-develop --app-version develop --destination sync
           git checkout gh-pages
           mv *.tgz docs
+          echo "Indexing helm repo"         
           helm repo index --merge docs/index.yaml sync
 #         cleanup the sync dir before commit
           mv -f sync/* docs
           rm -rf sync
+          echo "Pushing new helm release"
           git add -A
           git commit -m "Helm Release: ${{ env.RELEASE_VERSION }}"
           git push

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -149,3 +149,34 @@ jobs:
           webhook-url: ${{ secrets.PROD_DEPLOY_WEBHOOK_URL }}
           content: "Release Env Deployment Complete: ${{ env.RELEASE_VERSION }} deployed to Budibase Release Env."
           embed-title: ${{ env.RELEASE_VERSION }}
+
+  release-helm-chart:
+    runs-on: ubuntu-latest
+
+    steps:
+#      - name: Fail if branch is not develop
+#        if: github.ref != 'refs/heads/develop'
+#        run: |
+#          echo "Ref is not develop, you must run this job from develop."
+#          exit 1
+#      - uses: actions/checkout@v2
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v1
+        id: helm-install
+
+      - name: Build and release helm chart
+        run: |
+          git config user.name "Budibase Helm Bot"
+          git config user.email "<>"
+          git reset --hard
+          git pull
+          helm package charts/budibase 0.0.0-develop --app-version develop
+          git checkout gh-pages
+          mv *.tgz docs
+          helm repo index docs
+          git add -A
+          git commit -m "Helm Release: ${{ env.RELEASE_VERSION }}"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -73,7 +73,7 @@ jobs:
           git config user.email "<>"
           git reset --hard
           git pull
-          helm package charts/budibase
+          helm package charts/budibase --version "$RELEASE_VERSION" --app-version "$RELEASE_VERSION"
           git checkout gh-pages
           mv *.tgz docs
           helm repo index docs

--- a/charts/budibase/Chart.yaml
+++ b/charts/budibase/Chart.yaml
@@ -11,8 +11,10 @@ sources:
   - https://github.com/Budibase/budibase
   - https://budibase.com
 type: application
-version: 0.2.11
-appVersion: 1.0.214
+# populates on packaging
+version: 0.0.0
+# populates on packaging
+appVersion: 0.0.0
 dependencies:
   - name: couchdb
     version: 3.6.1


### PR DESCRIPTION
## Description

Update the release-develop workflow to add another step for publishing the `develop` version of the chart. 
Additionally update the main chart publishing to include the release version as both the chart and application version. 



