### PR TITLE
SQL server relationship fix for tables in schema

### DIFF
--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -313,7 +313,8 @@ class InternalBuilder {
   addRelationships(
     query: KnexQuery,
     fromTable: string,
-    relationships: RelationshipsJson[] | undefined
+    relationships: RelationshipsJson[] | undefined,
+    schema: string | undefined
   ): KnexQuery {
     if (!relationships) {
       return query
@@ -337,9 +338,11 @@ class InternalBuilder {
     }
     for (let [key, relationships] of Object.entries(tableSets)) {
       const { toTable, throughTable } = JSON.parse(key)
+      const toTableWithSchema = schema ? `${schema}.${toTable}` : toTable
+      const throughTableWithSchema = schema ? `${schema}.${throughTable}` : throughTable
       if (!throughTable) {
         // @ts-ignore
-        query = query.leftJoin(toTable, function () {
+        query = query.leftJoin(toTableWithSchema, function () {
           for (let relationship of relationships) {
             const from = relationship.from,
               to = relationship.to
@@ -350,7 +353,7 @@ class InternalBuilder {
       } else {
         query = query
           // @ts-ignore
-          .leftJoin(throughTable, function () {
+          .leftJoin(throughTableWithSchema, function () {
             for (let relationship of relationships) {
               const fromPrimary = relationship.fromPrimary
               const from = relationship.from
@@ -362,7 +365,7 @@ class InternalBuilder {
               )
             }
           })
-          .leftJoin(toTable, function () {
+          .leftJoin(toTableWithSchema, function () {
             for (let relationship of relationships) {
               const toPrimary = relationship.toPrimary
               const to = relationship.to
@@ -456,7 +459,7 @@ class InternalBuilder {
       preQuery = this.addSorting(preQuery, json)
     }
     // handle joins
-    query = this.addRelationships(preQuery, tableName, relationships)
+    query = this.addRelationships(preQuery, tableName, relationships, endpoint.schema)
     return this.addFilters(query, filters, { relationship: true })
   }
 

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -339,7 +339,9 @@ class InternalBuilder {
     for (let [key, relationships] of Object.entries(tableSets)) {
       const { toTable, throughTable } = JSON.parse(key)
       const toTableWithSchema = schema ? `${schema}.${toTable}` : toTable
-      const throughTableWithSchema = schema ? `${schema}.${throughTable}` : throughTable
+      const throughTableWithSchema = schema
+        ? `${schema}.${throughTable}`
+        : throughTable
       if (!throughTable) {
         // @ts-ignore
         query = query.leftJoin(toTableWithSchema, function () {
@@ -459,7 +461,12 @@ class InternalBuilder {
       preQuery = this.addSorting(preQuery, json)
     }
     // handle joins
-    query = this.addRelationships(preQuery, tableName, relationships, endpoint.schema)
+    query = this.addRelationships(
+      preQuery,
+      tableName,
+      relationships,
+      endpoint.schema
+    )
     return this.addFilters(query, filters, { relationship: true })
   }
 

--- a/packages/server/src/integrations/tests/sql.spec.ts
+++ b/packages/server/src/integrations/tests/sql.spec.ts
@@ -54,30 +54,30 @@ function generateDeleteJson(table = TABLE_NAME, filters = {}) {
 function generateRelationshipJson(config: { schema?: string } = {}) {
   return {
     endpoint: {
-      datasourceId: 'Postgres',
-      entityId: 'brands',
-      operation: 'READ',
-      schema: config.schema
+      datasourceId: "Postgres",
+      entityId: "brands",
+      operation: "READ",
+      schema: config.schema,
     },
     resource: {
       fields: [
-        'brands.brand_id',
-        'brands.brand_name',
-        'products.product_id',
-        'products.product_name',
-        'products.brand_id',
-      ]
+        "brands.brand_id",
+        "brands.brand_name",
+        "products.product_id",
+        "products.product_name",
+        "products.brand_id",
+      ],
     },
     filters: {},
     sort: {},
     paginate: {},
     relationships: [
       {
-        from: 'brand_id',
-        to: 'brand_id',
-        tableName: 'products',
-        column: 'products'
-      }
+        from: "brand_id",
+        to: "brand_id",
+        tableName: "products",
+        column: "products",
+      },
     ],
     extra: { idFilter: {} },
   }
@@ -86,34 +86,34 @@ function generateRelationshipJson(config: { schema?: string } = {}) {
 function generateManyRelationshipJson(config: { schema?: string } = {}) {
   return {
     endpoint: {
-      datasourceId: 'Postgres',
-      entityId: 'stores',
-      operation: 'READ',
+      datasourceId: "Postgres",
+      entityId: "stores",
+      operation: "READ",
       schema: config.schema,
     },
     resource: {
       fields: [
-        'stores.store_id',
-        'stores.store_name',
-        'products.product_id',
-        'products.product_name',
-      ]
+        "stores.store_id",
+        "stores.store_name",
+        "products.product_id",
+        "products.product_name",
+      ],
     },
     filters: {},
     sort: {},
     paginate: {},
     relationships: [
       {
-        from: 'store_id',
-        to: 'product_id',
-        tableName: 'products',
-        column: 'products',
-        through: 'stocks',
-        fromPrimary: 'store_id',
-        toPrimary: 'product_id'
-      }
+        from: "store_id",
+        to: "product_id",
+        tableName: "products",
+        column: "products",
+        through: "stocks",
+        fromPrimary: "store_id",
+        toPrimary: "product_id",
+      },
     ],
-    extra: { idFilter: {} }
+    extra: { idFilter: {} },
   }
 }
 
@@ -493,9 +493,7 @@ describe("SQL query builder", () => {
   })
 
   it("should add the schema to the LEFT JOIN", () => {
-    const query = sql._query(
-      generateRelationshipJson({ schema: "production" })
-    )
+    const query = sql._query(generateRelationshipJson({ schema: "production" }))
     expect(query).toEqual({
       bindings: [500, 5000],
       sql: `select "brands"."brand_id" as "brands.brand_id", "brands"."brand_name" as "brands.brand_name", "products"."product_id" as "products.product_id", "products"."product_name" as "products.product_name", "products"."brand_id" as "products.brand_id" from (select * from "production"."brands" limit $1) as "brands" left join "production"."products" on "brands"."brand_id" = "products"."brand_id" limit $2`,
@@ -503,9 +501,7 @@ describe("SQL query builder", () => {
   })
 
   it("should handle if the schema is not present when doing a LEFT JOIN", () => {
-    const query = sql._query(
-      generateRelationshipJson()
-    )
+    const query = sql._query(generateRelationshipJson())
     expect(query).toEqual({
       bindings: [500, 5000],
       sql: `select "brands"."brand_id" as "brands.brand_id", "brands"."brand_name" as "brands.brand_name", "products"."product_id" as "products.product_id", "products"."product_name" as "products.product_name", "products"."brand_id" as "products.brand_id" from (select * from "brands" limit $1) as "brands" left join "products" on "brands"."brand_id" = "products"."brand_id" limit $2`,

--- a/packages/server/src/integrations/tests/sql.spec.ts
+++ b/packages/server/src/integrations/tests/sql.spec.ts
@@ -51,6 +51,72 @@ function generateDeleteJson(table = TABLE_NAME, filters = {}) {
   }
 }
 
+function generateRelationshipJson(config: { schema?: string } = {}) {
+  return {
+    endpoint: {
+      datasourceId: 'Postgres',
+      entityId: 'brands',
+      operation: 'READ',
+      schema: config.schema
+    },
+    resource: {
+      fields: [
+        'brands.brand_id',
+        'brands.brand_name',
+        'products.product_id',
+        'products.product_name',
+        'products.brand_id',
+      ]
+    },
+    filters: {},
+    sort: {},
+    paginate: {},
+    relationships: [
+      {
+        from: 'brand_id',
+        to: 'brand_id',
+        tableName: 'products',
+        column: 'products'
+      }
+    ],
+    extra: { idFilter: {} },
+  }
+}
+
+function generateManyRelationshipJson(config: { schema?: string } = {}) {
+  return {
+    endpoint: {
+      datasourceId: 'Postgres',
+      entityId: 'stores',
+      operation: 'READ',
+      schema: config.schema,
+    },
+    resource: {
+      fields: [
+        'stores.store_id',
+        'stores.store_name',
+        'products.product_id',
+        'products.product_name',
+      ]
+    },
+    filters: {},
+    sort: {},
+    paginate: {},
+    relationships: [
+      {
+        from: 'store_id',
+        to: 'product_id',
+        tableName: 'products',
+        column: 'products',
+        through: 'stocks',
+        fromPrimary: 'store_id',
+        toPrimary: 'product_id'
+      }
+    ],
+    extra: { idFilter: {} }
+  }
+}
+
 describe("SQL query builder", () => {
   const limit = 500
   const client = SqlClient.POSTGRES
@@ -423,6 +489,36 @@ describe("SQL query builder", () => {
     expect(query).toEqual({
       bindings: [10],
       sql: `select * from (select * from \"${TABLE_NAME}\" where \"${TABLE_NAME}\".\"age\"::jsonb ?| array [20,25] and \"${TABLE_NAME}\".\"name\"::jsonb ?| array ['John','Mary'] limit $1) as \"${TABLE_NAME}\"`,
+    })
+  })
+
+  it("should add the schema to the LEFT JOIN", () => {
+    const query = sql._query(
+      generateRelationshipJson({ schema: "production" })
+    )
+    expect(query).toEqual({
+      bindings: [500, 5000],
+      sql: `select "brands"."brand_id" as "brands.brand_id", "brands"."brand_name" as "brands.brand_name", "products"."product_id" as "products.product_id", "products"."product_name" as "products.product_name", "products"."brand_id" as "products.brand_id" from (select * from "production"."brands" limit $1) as "brands" left join "production"."products" on "brands"."brand_id" = "products"."brand_id" limit $2`,
+    })
+  })
+
+  it("should handle if the schema is not present when doing a LEFT JOIN", () => {
+    const query = sql._query(
+      generateRelationshipJson()
+    )
+    expect(query).toEqual({
+      bindings: [500, 5000],
+      sql: `select "brands"."brand_id" as "brands.brand_id", "brands"."brand_name" as "brands.brand_name", "products"."product_id" as "products.product_id", "products"."product_name" as "products.product_name", "products"."brand_id" as "products.brand_id" from (select * from "brands" limit $1) as "brands" left join "products" on "brands"."brand_id" = "products"."brand_id" limit $2`,
+    })
+  })
+
+  it("should add the schema to both the toTable and throughTable in many-to-many join", () => {
+    const query = sql._query(
+      generateManyRelationshipJson({ schema: "production" })
+    )
+    expect(query).toEqual({
+      bindings: [500, 5000],
+      sql: `select "stores"."store_id" as "stores.store_id", "stores"."store_name" as "stores.store_name", "products"."product_id" as "products.product_id", "products"."product_name" as "products.product_name" from (select * from "production"."stores" limit $1) as "stores" left join "production"."stocks" on "stores"."store_id" = "stocks"."store_id" left join "production"."products" on "products"."product_id" = "stocks"."product_id" limit $2`,
     })
   })
 })


### PR DESCRIPTION
## Description
Query was failing when adding relationships to SQL Server tables that were in a schema, because the schema name was not being added in the left join. 
Fixed!
Unit tests added. 
Tested Postgres as well to make sure one->many and many->many still worked as before.

Addresses: 
- https://github.com/Budibase/budibase/issues/9097

## Screenshots
![Screenshot 2022-12-19 at 14 32 38](https://user-images.githubusercontent.com/101575380/208449133-4e021c8a-91d6-49d9-9cbe-3721b72f6cd4.png)

![Screenshot 2022-12-19 at 14 33 08](https://user-images.githubusercontent.com/101575380/208449267-4140b35b-1a51-44ee-bd20-7d0e3758ad46.png)

![Screenshot 2022-12-19 at 14 33 25](https://user-images.githubusercontent.com/101575380/208449338-29d1f653-3278-4ce0-a879-d05d6bbaf2a4.png)



