### PR TITLE
Cypress Suite Updates

### DIFF
--- a/packages/builder/cypress/integration/adminAndManagement/accountPortals.spec.js
+++ b/packages/builder/cypress/integration/adminAndManagement/accountPortals.spec.js
@@ -3,17 +3,17 @@ const interact = require('../../support/interact')
 
 filterTests(["smoke", "all"], () => {
   context("Account Portals", () => {
-    
+
     const bbUserEmail = "bbuser@test.com"
-    
+
     before(() => {
       cy.login()
       cy.deleteApp("Cypress Tests")
       cy.createApp("Cypress Tests", false)
-      
+
       // Create new user
       cy.wait(500)
-      cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 5000})
+      cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 5000 })
       cy.createUser(bbUserEmail)
       cy.contains("bbuser").click()
       cy.wait(500)
@@ -25,18 +25,18 @@ filterTests(["smoke", "all"], () => {
       cy.get(interact.SPECTRUM_MENU).within(() => {
         cy.get(interact.SPECTRUM_MENU_ITEM).contains("Force password reset").click({ force: true })
       })
-      
+
       cy.get(interact.SPECTRUM_DIALOG_GRID)
-      .find(interact.SPECTRUM_TEXTFIELD_INPUT).invoke('val').as('pwd')
+        .find(interact.SPECTRUM_TEXTFIELD_INPUT).invoke('val').as('pwd')
 
       cy.get(interact.SPECTRUM_BUTTON).contains("Reset password").click({ force: true })
-      
+
       // Login as new user and set password
       cy.logOut()
       cy.get('@pwd').then((pwd) => {
         cy.login(bbUserEmail, pwd)
       })
-      
+
       for (let i = 0; i < 2; i++) {
         cy.get(interact.SPECTRUM_TEXTFIELD_INPUT).eq(i).type("test")
       }
@@ -58,15 +58,15 @@ filterTests(["smoke", "all"], () => {
 
       cy.logoutNoAppGrid()
     })
-    
-    it("should verify Admin Portal", () => {
-        cy.login()
-        // Configure user role
-        cy.setUserRole("bbuser", "Admin")
-        bbUserLogin()
 
-        // Verify available options for Admin portal
-        cy.get(interact.SPECTRUM_SIDENAV)
+    xit("should verify Admin Portal", () => {
+      cy.login()
+      // Configure user role
+      cy.setUserRole("bbuser", "Admin")
+      bbUserLogin()
+
+      // Verify available options for Admin portal
+      cy.get(interact.SPECTRUM_SIDENAV)
         .should('contain', 'Apps')
         //.and('contain', 'Usage')
         .and('contain', 'Users')
@@ -75,12 +75,12 @@ filterTests(["smoke", "all"], () => {
         .and('contain', 'Organisation')
         .and('contain', 'Theming')
         .and('contain', 'Update')
-        //.and('contain', 'Upgrade')
+      //.and('contain', 'Upgrade')
 
-        cy.logOut()
+      cy.logOut()
     })
 
-    it("should verify Development Portal", () => {
+    xit("should verify Development Portal", () => {
       // Only Development access should be enabled
       cy.login()
       cy.setUserRole("bbuser", "Developer")
@@ -98,7 +98,7 @@ filterTests(["smoke", "all"], () => {
         .and('not.contain', 'Update')
         .and('not.contain', 'Upgrade')
 
-        cy.logOut()
+      cy.logOut()
     })
 
     const bbUserLogin = () => {

--- a/packages/builder/cypress/integration/appOverview.spec.js
+++ b/packages/builder/cypress/integration/appOverview.spec.js
@@ -9,7 +9,7 @@ filterTests(["all"], () => {
       cy.createApp("Cypress Tests")
     })
 
-    it("Should be accessible from the applications list", () => {
+    xit("Should be accessible from the applications list", () => {
       cy.visit(`${Cypress.config().baseUrl}/builder`)
       cy.get(".appTable .title")
         .eq(0)
@@ -27,7 +27,7 @@ filterTests(["all"], () => {
     })
 
     // Find a more suitable place for this.
-    it("Should allow unlocking in the app list", () => {
+    xit("Should allow unlocking in the app list", () => {
       cy.visit(`${Cypress.config().baseUrl}/builder`)
 
       cy.get(".appTable .lock-status").eq(0).contains("Locked by you").click()
@@ -38,7 +38,7 @@ filterTests(["all"], () => {
       cy.get(".lock-status").should("not.be.visible")
     })
 
-    it("Should allow unlocking in the app overview screen", () => {
+    xit("Should allow unlocking in the app overview screen", () => {
       cy.visit(`${Cypress.config().baseUrl}/builder`)
 
       cy.get(".appTable .app-row-actions button")
@@ -58,7 +58,7 @@ filterTests(["all"], () => {
       cy.get(".lock-status").should("not.be.visible")
     })
 
-    it("Should reflect the deploy state of an app that hasn't been published.", () => {
+    xit("Should reflect the deploy state of an app that hasn't been published.", () => {
       cy.visit(`${Cypress.config().baseUrl}/builder`)
 
       cy.get(".appTable .app-row-actions button")
@@ -81,7 +81,7 @@ filterTests(["all"], () => {
       })
     })
 
-    it("Should reflect the app deployment state", () => {
+    xit("Should reflect the app deployment state", () => {
       cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 5000 })
       cy.get(".appTable .app-row-actions button")
         .contains("Edit")
@@ -117,7 +117,7 @@ filterTests(["all"], () => {
       })
     })
 
-    it("Should reflect an application that has been unpublished", () => {
+    xit("Should reflect an application that has been unpublished", () => {
       cy.visit(`${Cypress.config().baseUrl}/builder`)
       cy.get(".appTable .app-row-actions button")
         .contains("Edit")
@@ -154,7 +154,7 @@ filterTests(["all"], () => {
       })
     })
 
-    it("Should allow the editing of the application icon and colour", () => {
+    xit("Should allow the editing of the application icon and colour", () => {
       cy.visit(`${Cypress.config().baseUrl}/builder`)
       cy.get(".appTable .app-row-actions button")
         .contains("Manage")
@@ -196,7 +196,7 @@ filterTests(["all"], () => {
       })
     })
 
-    it("Should reflect the last time the application was edited", () => {
+    xit("Should reflect the last time the application was edited", () => {
       cy.visit(`${Cypress.config().baseUrl}/builder`)
       cy.get(".appTable .app-row-actions button")
         .contains("Manage")
@@ -221,7 +221,7 @@ filterTests(["all"], () => {
       })
     })
 
-    it("Should reflect application version is up-to-date", () => {
+    xit("Should reflect application version is up-to-date", () => {
       cy.visit(`${Cypress.config().baseUrl}/builder`)
       cy.get(".appTable .app-row-actions button")
         .contains("Manage")
@@ -302,7 +302,7 @@ filterTests(["all"], () => {
       })
     })
 
-    it("Should allow editing of the app details.", () => {
+    xit("Should allow editing of the app details.", () => {
       cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 5000 })
       cy.get(".appTable .app-row-actions button")
         .contains("Manage")
@@ -373,13 +373,13 @@ filterTests(["all"], () => {
             .contains("Copy App ID")
             .click({ force: true })
         })
-      
+
       cy.get(".spectrum-Toast-content")
-      .contains("App ID copied to clipboard.")
-      .should("be.visible")
+        .contains("App ID copied to clipboard.")
+        .should("be.visible")
     })
 
-    it("Should allow unpublishing of the application via the Unpublish link", () => {
+    xit("Should allow unpublishing of the application via the Unpublish link", () => {
       cy.visit(`${Cypress.config().baseUrl}/builder`)
       cy.get(".appTable .app-row-actions button")
         .contains("Manage")
@@ -388,7 +388,7 @@ filterTests(["all"], () => {
 
       cy.get(`[data-cy="app-status"]`).within(() => {
         cy.contains("Unpublish").click({ force: true })
-        })
+      })
 
       cy.get("[data-cy='unpublish-modal']")
         .should("be.visible")
@@ -399,11 +399,11 @@ filterTests(["all"], () => {
       cy.get(".overview-tab [data-cy='app-status']").within(() => {
         cy.get(".status-display").contains("Unpublished")
         cy.get(".status-display .icon svg[aria-label='GlobeStrike']")
-        .should("exist")
+          .should("exist")
       })
     })
 
-    it("Should allow deleting of the application", () => {
+    xit("Should allow deleting of the application", () => {
       cy.visit(`${Cypress.config().baseUrl}/builder`)
       cy.get(".appTable .app-row-actions button")
         .contains("Manage")

--- a/packages/builder/cypress/integration/createAutomation.spec.js
+++ b/packages/builder/cypress/integration/createAutomation.spec.js
@@ -2,13 +2,13 @@ import filterTests from "../support/filterTests"
 const interact = require('../support/interact')
 
 filterTests(['smoke', 'all'], () => {
-  context("Create a automation", () => {
+  xcontext("Create a automation", () => {
     before(() => {
       cy.login()
       cy.createTestApp()
     })
 
-    it("should create a automation", () => {
+    xit("should create a automation", () => {
       cy.createTestTableWithData()
       cy.wait(2000)
       cy.contains("Automate").click()

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -461,10 +461,7 @@ Cypress.Commands.add("createTable", (tableName, initialTable) => {
   cy.get(".nav-item", { timeout: 2000 })
     .contains("Budibase DB")
     .click({ force: true })
-  cy.get(".spectrum-Tabs-content", { timeout: 2000 }).should(
-    "contain",
-    tableName
-  )
+  cy.get(".nav-item-content", { timeout: 2000 }).should("contain", tableName)
 })
 
 Cypress.Commands.add("createTestTableWithData", () => {


### PR DESCRIPTION
**Updating createTable command**
Changing an ID when asserting a table exists
- This change will fix the broken tests within the Cypress build

**Skipping Cypress Tests - No longer needed**
Skipping Cypress tests associated with the following:

- Account Portals
- App Overview
- Create Automation

We now have E2E coverage of these tests via QA Wolf
