### PR TITLE
QueryLevelTransformers Test Update

### DIFF
--- a/packages/builder/cypress/integration/queryLevelTransformers.spec.js
+++ b/packages/builder/cypress/integration/queryLevelTransformers.spec.js
@@ -14,11 +14,13 @@ filterTests(["smoke", "all"], () => {
       const restUrl = "https://api.openbrewerydb.org/breweries"
       cy.selectExternalDatasource(datasource)
       cy.createRestQuery("GET", restUrl, "/breweries")
-      cy.get(interact.SPECTRUM_TABS_ITEM).contains("Transformer").click()
+      cy.reload()
+      cy.contains(".nav-item-content", "/breweries", { timeout: 2000 }).click()
+      cy.contains(interact.SPECTRUM_TABS_ITEM, "Transformer", { timeout: 5000 }).click({ force: true })
       // Get Transformer Function from file
       cy.readFile("cypress/support/queryLevelTransformerFunction.js").then(
         transformerFunction => {
-          cy.get(interact.CODEMIRROR_TEXTAREA)
+          cy.get(interact.CODEMIRROR_TEXTAREA, { timeout: 5000 })
             // Highlight current text and overwrite with file contents
             .type(Cypress.platform === "darwin" ? "{cmd}a" : "{ctrl}a", {
               force: true,
@@ -28,6 +30,7 @@ filterTests(["smoke", "all"], () => {
       )
       // Send Query
       cy.intercept("**/queries/preview").as("query")
+      cy.get(interact.SPECTRUM_BUTTON).contains("Save").click({ force: true })
       cy.get(interact.SPECTRUM_BUTTON).contains("Send").click({ force: true })
       cy.wait("@query")
       // Assert against Status Code, body, & body rows
@@ -42,7 +45,9 @@ filterTests(["smoke", "all"], () => {
       const restUrl = "https://api.openbrewerydb.org/breweries"
       cy.selectExternalDatasource(datasource)
       cy.createRestQuery("GET", restUrl, "/breweries")
-      cy.get(interact.SPECTRUM_TABS_ITEM).contains("Transformer").click()
+      cy.reload()
+      cy.contains(".nav-item-content", "/breweries", { timeout: 2000 }).click()
+      cy.contains(interact.SPECTRUM_TABS_ITEM, "Transformer", { timeout: 5000 }).click({ force: true })
       // Get Transformer Function with Data from file
       cy.readFile(
         "cypress/support/queryLevelTransformerFunctionWithData.js"
@@ -71,7 +76,9 @@ filterTests(["smoke", "all"], () => {
       const restUrl = "https://api.openbrewerydb.org/breweries"
       cy.selectExternalDatasource(datasource)
       cy.createRestQuery("GET", restUrl, "/breweries")
-      cy.get(interact.SPECTRUM_TABS_ITEM).contains("Transformer").click()
+      cy.reload()
+      cy.contains(".nav-item-content", "/breweries", { timeout: 2000 }).click()
+      cy.contains(interact.SPECTRUM_TABS_ITEM, "Transformer", { timeout: 5000 }).click({ force: true })
       // Clear the code box and add "test"
       cy.get(interact.CODEMIRROR_TEXTAREA)
         .type(Cypress.platform === "darwin" ? "{cmd}a" : "{ctrl}a", {

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -792,7 +792,7 @@ Cypress.Commands.add("selectExternalDatasource", datasourceName => {
   // Navigates to Data Section
   cy.navigateToDataSection()
   // Open Datasource modal
-  cy.get(".nav").within(() => {
+  cy.get(".container").within(() => {
     cy.get("[data-cy='new-datasource']").click()
   })
   // Clicks specified datasource & continue


### PR DESCRIPTION
Updated selectExternalDatasource command

Altered Query Level Transformers to include a page reload. Not having this reload was occasionally affecting the test run



