### PR TITLE
pinning couchDB version for closeau compatibility

### DIFF
--- a/charts/budibase/Chart.yaml
+++ b/charts/budibase/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.2.11
 appVersion: 1.0.214
 dependencies:
   - name: couchdb
-    version: 3.6.1
+    version: 3.3.4
     repository: https://apache.github.io/couchdb-helm
     condition: services.couchdb.enabled
   - name: ingress-nginx


### PR DESCRIPTION
## Description
Reported by a customer originally.

As described in https://github.com/apache/couchdb-helm/issues/33#issuecomment-1336110776, it appears there's a problem with closeau and later versions of the couchDB helm chart. We did not notice this because our envs that use the K8S couch (preprod, release) have not updated the CouchDB chart version in a while, as that would cause a full redeploy. In production we don't use the couchDB chart as we have a custom setup, so it wasn't present there either. I'm pinning the chart here to a known and working version to enable self hosted K8S deployments to work as expected.



