### PR TITLE
Ensure view names are properly encoded to handle certain special chars

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateViewModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateViewModal.svelte
@@ -10,6 +10,7 @@
   $: views = $tables.list.flatMap(table => Object.keys(table.views || {}))
 
   const saveView = async () => {
+    name = name?.trim()
     if (views.includes(name)) {
       notifications.error(`View exists with name ${name}`)
       return
@@ -21,7 +22,7 @@
         field,
       })
       notifications.success(`View ${name} created`)
-      $goto(`../../view/${name}`)
+      $goto(`../../view/${encodeURIComponent(name)}`)
     } catch (error) {
       notifications.error("Error creating view")
     }

--- a/packages/builder/src/components/backend/TableNavigator/TableNavigator.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/TableNavigator.svelte
@@ -36,9 +36,8 @@
           indentLevel={2}
           icon="Remove"
           text={viewName}
-          selected={$isActive("./view/:viewName") &&
-            $views.selected?.name === viewName}
-          on:click={() => $goto(`./view/${viewName}`)}
+          selected={$isActive("./view") && $views.selected?.name === viewName}
+          on:click={() => $goto(`./view/${encodeURIComponent(viewName)}`)}
         >
           <EditViewPopover
             view={{ name: viewName, ...table.views[viewName] }}

--- a/packages/builder/src/components/backend/TableNavigator/popovers/EditViewPopover.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/popovers/EditViewPopover.svelte
@@ -33,7 +33,8 @@
 
   async function deleteView() {
     try {
-      const isSelected = $params.viewName === $views.selectedViewName
+      const isSelected =
+        decodeURIComponent($params.viewName) === $views.selectedViewName
       const name = view.name
       const id = view.tableId
       await views.delete(name)

--- a/packages/builder/src/pages/builder/app/[application]/data/view/[viewName]/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/view/[viewName]/_layout.svelte
@@ -12,6 +12,7 @@
     fallbackUrl: "../",
     store: views,
     routify,
+    decode: decodeURIComponent,
   })
 
   onDestroy(stopSyncing)

--- a/packages/builder/src/pages/builder/app/[application]/data/view/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/view/index.svelte
@@ -6,9 +6,9 @@
   onMount(async () => {
     const { list, selected } = $views
     if (selected) {
-      $redirect(`./${selected?.name}`)
+      $redirect(`./${encodeURIComponent(selected?.name)}`)
     } else if (list?.length) {
-      $redirect(`./${list[0].name}`)
+      $redirect(`./${encodeURIComponent(list[0].name)}`)
     } else {
       $redirect("../")
     }

--- a/packages/frontend-core/src/api/views.js
+++ b/packages/frontend-core/src/api/views.js
@@ -16,8 +16,8 @@ export const buildViewEndpoints = API => ({
       params.set("group", groupBy)
     }
     const QUERY_VIEW_URL = field
-      ? `/api/views/${name}?${params}`
-      : `/api/views/${name}`
+      ? `/api/views/${encodeURIComponent(name)}?${params}`
+      : `/api/views/${encodeURIComponent(name)}`
     return await API.get({ url: QUERY_VIEW_URL })
   },
 
@@ -53,7 +53,7 @@ export const buildViewEndpoints = API => ({
    */
   deleteView: async viewName => {
     return await API.delete({
-      url: `/api/views/${viewName}`,
+      url: `/api/views/${encodeURIComponent(viewName)}`,
     })
   },
 })

--- a/packages/server/src/api/controllers/row/internal.ts
+++ b/packages/server/src/api/controllers/row/internal.ts
@@ -187,7 +187,7 @@ export async function save(ctx: UserCtx) {
 }
 
 export async function fetchView(ctx: Ctx) {
-  const viewName = ctx.params.viewName
+  const viewName = decodeURIComponent(ctx.params.viewName)
 
   // if this is a table view being looked for just transfer to that
   if (viewName.startsWith(DocumentType.TABLE)) {

--- a/packages/server/src/api/controllers/view/index.ts
+++ b/packages/server/src/api/controllers/view/index.ts
@@ -113,7 +113,7 @@ async function handleViewEvents(existingView: View, newView: View) {
 
 export async function destroy(ctx: BBContext) {
   const db = context.getAppDB()
-  const viewName = decodeURI(ctx.params.viewName)
+  const viewName = decodeURIComponent(ctx.params.viewName)
   const view = await deleteView(viewName)
   const table = await db.get(view.meta.tableId)
   delete table.views[viewName]
@@ -124,7 +124,7 @@ export async function destroy(ctx: BBContext) {
 }
 
 export async function exportView(ctx: BBContext) {
-  const viewName = decodeURI(ctx.query.view as string)
+  const viewName = decodeURIComponent(ctx.query.view as string)
   const view = await getView(viewName)
 
   const format = ctx.query.format as string


### PR DESCRIPTION
## Description
This PR fixes a few issues with special characters in view names. This is not a proper solution for view names in general as certain special characters are just incompatible with couch view names altogether (`?` being the most broken it appears), but this at least handles the most common use cases of characters like spaces.

This at least brings develop back up to par with master in terms of handling spaces etc, and makes the encoding/decoding of view names more consistent in general.

- Always encode view names when sending them to the server as URL params
- Always decode view names on the server when handling requests
- View names are always encoded when used in URLs in the builder
- View name URL params are always decoded before being written to state in the builder
- `$isActive` from routify seems to use a regex under the hood, and actually throws an error if you attempt to check if a URL is active which contains unescaped regex special chars such as `(`. This is really a bug on their part, but I've accounted for it by updating our usages of `$isActive` on view pages.
- Trim whitespace when creating view names to avoid one bricking scenario at least

Future work should be done to either enforce an alphanumeric character set for view names or, much better again, generate IDs and use those as view identifiers under the hood.

Addresses: 
- https://github.com/Budibase/budibase/issues/9141



