### PR TITLE
Cypress views testCypress: Create Views test update

### DIFF
--- a/packages/builder/cypress/integration/createView.spec.js
+++ b/packages/builder/cypress/integration/createView.spec.js
@@ -26,13 +26,15 @@ filterTests(['smoke', 'all'], () => {
         cy.get("input").type("Test View")
         cy.get("button").contains("Create View").click({ force: true })
       })
-      cy.get(interact.TABLE_TITLE_H1).contains("Test View")
-      cy.get(interact.TITLE).then($headers => {
-        expect($headers).to.have.length(3)
-        const headers = Array.from($headers).map(header =>
-          header.textContent.trim()
-        )
-        expect(removeSpacing(headers)).to.deep.eq(["group", "age", "rating"])
+      cy.contains(interact.TABLE_TITLE_H1, "Test View", { timeout: 10000 })
+      cy.get(".table-wrapper").within(() => {
+        cy.get(interact.TITLE).then($headers => {
+          expect($headers).to.have.length(3)
+          const headers = Array.from($headers).map(header =>
+            header.textContent.trim()
+          )
+          expect(removeSpacing(headers)).to.deep.eq(["group", "age", "rating"])
+        })
       })
     })
 
@@ -70,20 +72,22 @@ filterTests(['smoke', 'all'], () => {
       })
 
       cy.wait(1000)
-      cy.get(interact.TITLE).then($headers => {
-        expect($headers).to.have.length(7)
-        const headers = Array.from($headers).map(header =>
-          header.textContent.trim()
-        )
-        expect(removeSpacing(headers)).to.deep.eq([
-          "field",
-          "sum",
-          "min",
-          "max",
-          "count",
-          "sumsqr",
-          "avg",
-        ])
+      cy.get(".table-wrapper").within(() => {
+        cy.get(interact.TITLE).then($headers => {
+          expect($headers).to.have.length(7)
+          const headers = Array.from($headers).map(header =>
+            header.textContent.trim()
+          )
+          expect(removeSpacing(headers)).to.deep.eq([
+            "field",
+            "sum",
+            "min",
+            "max",
+            "count",
+            "sumsqr",
+            "avg",
+          ])
+        })
       })
       cy.get(interact.SPECTRUM_TABLE_CELL).then($values => {
         let values = Array.from($values).map(header => header.textContent.trim())

--- a/packages/builder/cypress/integration/queryLevelTransformers.spec.js
+++ b/packages/builder/cypress/integration/queryLevelTransformers.spec.js
@@ -15,7 +15,7 @@ filterTests(["smoke", "all"], () => {
       cy.selectExternalDatasource(datasource)
       cy.createRestQuery("GET", restUrl, "/breweries")
       cy.reload()
-      cy.contains(".nav-item-content", "/breweries", { timeout: 2000 }).click()
+      cy.contains(".nav-item-content", "/breweries", { timeout: 20000 }).click()
       cy.contains(interact.SPECTRUM_TABS_ITEM, "Transformer", { timeout: 5000 }).click({ force: true })
       // Get Transformer Function from file
       cy.readFile("cypress/support/queryLevelTransformerFunction.js").then(

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -480,7 +480,7 @@ Cypress.Commands.add(
 
     // Configure column
     cy.get(".spectrum-Modal").within(() => {
-      cy.get("input").first().type(columnName).blur()
+      cy.get("input").first().type(columnName)
 
       // Unset table display column
       cy.contains("display column").click({ force: true })

--- a/packages/builder/cypress/support/commands.js
+++ b/packages/builder/cypress/support/commands.js
@@ -413,7 +413,7 @@ Cypress.Commands.add("searchForApplication", appName => {
 // Assumes there are no others
 Cypress.Commands.add("applicationInAppTable", appName => {
   cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 30000 })
-  cy.get(".appTable", { timeout: 5000 }).within(() => {
+  cy.get(".appTable", { timeout: 30000 }).within(() => {
     cy.get(".title").contains(appName).should("exist")
   })
 })
@@ -441,7 +441,7 @@ Cypress.Commands.add("createTable", (tableName, initialTable) => {
   if (!initialTable) {
     cy.navigateToDataSection()
   }
-  cy.get(`[data-cy="new-datasource"]`, { timeout: 2000 }).click()
+  cy.get(`[data-cy="new-datasource"]`, { timeout: 20000 }).click()
   cy.wait(2000)
   cy.get(".item", { timeout: 2000 })
     .contains("Budibase DB")


### PR DESCRIPTION
Updating a couple of tests within createView
- Timing issues
- Ensuring we get the correct element for testing

Also updated QueryLevelTransformers test
- Timing issue
- I've extended the timeout value for when checking the nav item content (passes locally but timed out on the CI run)

Increased timeout values within the following commands:
- applicationInAppTable
- createTable

