### PR TITLE
MySQL convert bit to boolean

### DIFF
--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -151,6 +151,9 @@ class MySQLIntegration extends Sql implements DatasourcePlus {
         ) {
           return field.string()
         }
+        if (field.type === "BIT" && field.length === 1) {
+          return field.buffer()?.[0]
+        }
         return next()
       },
     }


### PR DESCRIPTION
## Description
Bit was being returned as buffer. Now casting that as a boolean.

Thumbs up to Ben! 👍 👍 
https://www.bennadel.com/blog/3188-casting-bit-fields-to-booleans-using-the-node-js-mysql-driver.htm

Addresses: 
- https://github.com/Budibase/budibase/issues/9215




