### PR TITLE
Fix looping issue with subsequent loop steps

### DIFF
--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -419,7 +419,7 @@ class Orchestrator {
 
       // Delete the step after the loop step as it's irrelevant, since information is included
       // in the loop step
-      if (wasLoopStep) {
+      if (wasLoopStep && !loopStep) {
         this._context.steps.splice(loopStepNumber + 1, 1)
         wasLoopStep = false
       }
@@ -438,8 +438,7 @@ class Orchestrator {
         })
         this._context.steps[loopStepNumber] = tempOutput
 
-        loopSteps = undefined
-        wasLoopStep = true
+        loopSteps = []
       }
     }
 

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -438,6 +438,7 @@ class Orchestrator {
         })
         this._context.steps[loopStepNumber] = tempOutput
 
+        wasLoopStep = true
         loopSteps = []
       }
     }


### PR DESCRIPTION
## Description
When there were two loop steps subsequent to the other, the executionOutput of the automation would be incorrect, and loop outputs would be recorded as a step, instead of an item within a step. 

Fixes: #9123 

<img width="1759" alt="image" src="https://user-images.githubusercontent.com/5665926/210779103-4b0eef1e-078e-47a6-bb5e-ef644bf5d0bd.png">

you can see that the final non looped step is represented correctly in the test output. Compared to the example in the linked issue. 

