### PR TITLE
Removing Cypress Tests - No Longer Required

### DIFF
--- a/packages/builder/cypress/integration/adminAndManagement/accountPortals.spec.js
+++ b/packages/builder/cypress/integration/adminAndManagement/accountPortals.spec.js
@@ -2,7 +2,7 @@ import filterTests from "../../support/filterTests"
 const interact = require('../../support/interact')
 
 filterTests(["smoke", "all"], () => {
-  context("Account Portals", () => {
+  xcontext("Account Portals", () => {
 
     const bbUserEmail = "bbuser@test.com"
 
@@ -44,7 +44,7 @@ filterTests(["smoke", "all"], () => {
       //cy.logoutNoAppGrid()
     })
 
-    it("should verify Standard Portal", () => {
+    xit("should verify Standard Portal", () => {
       // Development access should be disabled (Admin access is already disabled)
       cy.login()
       cy.setUserRole("bbuser", "App User")

--- a/packages/builder/cypress/integration/appPublishWorkflow.spec.js
+++ b/packages/builder/cypress/integration/appPublishWorkflow.spec.js
@@ -10,64 +10,64 @@ filterTests(['all'], () => {
       cy.createApp("Cypress Tests", false)
     })
 
-    it("Should reflect the unpublished status correctly", () => {
+    xit("Should reflect the unpublished status correctly", () => {
       cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 5000 })
 
       cy.get(interact.APP_TABLE_STATUS, { timeout: 3000 }).eq(0)
-      .within(() => {
-        cy.contains("Unpublished")
-        cy.get(interact.GLOBESTRIKE).should("exist")
-      })
+        .within(() => {
+          cy.contains("Unpublished")
+          cy.get(interact.GLOBESTRIKE).should("exist")
+        })
 
       cy.get(interact.APP_TABLE_ROW_ACTION).eq(0)
-      .within(() => {
-        cy.get(interact.SPECTRUM_BUTTON_TEMPLATE).contains("Edit").click({ force: true })
-      })
+        .within(() => {
+          cy.get(interact.SPECTRUM_BUTTON_TEMPLATE).contains("Edit").click({ force: true })
+        })
 
       cy.get(interact.DEPLOYMENT_TOP_NAV_GLOBESTRIKE).should("exist")
       cy.get(interact.DEPLOYMENT_TOP_GLOBE).should("not.exist")
     })
 
-    it("Should publish an application and correctly reflect that", () => {
+    xit("Should publish an application and correctly reflect that", () => {
       //Assuming the previous test was run and the unpublished app is open in edit mode.
-      cy.get(interact.TOPRIGHTNAV_BUTTON_SPECTRUM).contains("Publish").click({ force : true })
+      cy.get(interact.TOPRIGHTNAV_BUTTON_SPECTRUM).contains("Publish").click({ force: true })
 
       cy.get(interact.DEPLOY_APP_MODAL).should("be.visible")
-      .within(() => {
-        cy.get(interact.SPECTRUM_BUTTON).contains("Publish").click({ force : true })
-      });
+        .within(() => {
+          cy.get(interact.SPECTRUM_BUTTON).contains("Publish").click({ force: true })
+        });
 
       //Verify that the app url is presented correctly to the user
       cy.get(interact.DEPLOY_SUCCESS_MODAL, { timeout: 1000 })
-      .should("be.visible")
-      .within(() => {
-        let appUrl = Cypress.config().baseUrl + '/app/cypress-tests'
-        cy.get(interact.DEPLOY_APP_URL_INPUT).should('have.value', appUrl)
-        cy.get(interact.SPECTRUM_BUTTON).contains("Done").click({ force: true })
-      })
+        .should("be.visible")
+        .within(() => {
+          let appUrl = Cypress.config().baseUrl + '/app/cypress-tests'
+          cy.get(interact.DEPLOY_APP_URL_INPUT).should('have.value', appUrl)
+          cy.get(interact.SPECTRUM_BUTTON).contains("Done").click({ force: true })
+        })
 
       cy.visit(`${Cypress.config().baseUrl}/builder`)
 
       cy.get(interact.APP_TABLE_STATUS, { timeout: 3000 }).eq(0)
-      .within(() => {
-        cy.contains("Published")
-        cy.get(interact.GLOBE).should("exist")
-      })
+        .within(() => {
+          cy.contains("Published")
+          cy.get(interact.GLOBE).should("exist")
+        })
 
       cy.get(interact.APP_TABLE_ROW_ACTION).eq(0)
-      .within(() => {
-        cy.get(interact.SPECTRUM_BUTTON).contains("Manage")
-        cy.get(interact.SPECTRUM_BUTTON).contains("Edit").click({ force: true })
-      })
+        .within(() => {
+          cy.get(interact.SPECTRUM_BUTTON).contains("Manage")
+          cy.get(interact.SPECTRUM_BUTTON).contains("Edit").click({ force: true })
+        })
 
       cy.get(interact.DEPLOYMENT_TOP_GLOBE).should("exist").click({ force: true })
 
       cy.get(interact.PUBLISH_POPOVER_MENU).should("be.visible")
-      .within(() => {
-        cy.get(interact.PUBLISH_POPOVER_ACTION).should("exist")
-        cy.get("button").contains("View app").should("exist")
-        cy.get(interact.PUBLISH_POPOVER_MESSAGE).should("have.text", "Last published a few seconds ago")
-      })
+        .within(() => {
+          cy.get(interact.PUBLISH_POPOVER_ACTION).should("exist")
+          cy.get("button").contains("View app").should("exist")
+          cy.get(interact.PUBLISH_POPOVER_MESSAGE).should("have.text", "Last published a few seconds ago")
+        })
     })
 
     it("Should unpublish an application using the link and reflect the status change", () => {
@@ -76,27 +76,28 @@ filterTests(['all'], () => {
       cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 5000 })
 
       cy.get(interact.APP_TABLE_STATUS).eq(0)
-      .within(() => {
-        cy.contains("Published")
-        cy.get("svg[aria-label='Globe']").should("exist")
-      })
+        .within(() => {
+          cy.contains("Published")
+          cy.get("svg[aria-label='Globe']").should("exist")
+        })
 
       cy.get(interact.APP_TABLE).eq(0)
-      .within(() => {
-        cy.get(interact.APP_TABLE_APP_NAME).click({ force: true })
-      })
-      
+        .within(() => {
+          cy.get(interact.APP_TABLE_APP_NAME).click({ force: true })
+        })
+
       cy.get(interact.DEPLOYMENT_TOP_GLOBE).should("exist").click({ force: true })
-      
+
       cy.get("[data-cy='publish-popover-menu']")
-      .within(() => {
-        cy.get(interact.PUBLISH_POPOVER_ACTION).click({ force: true })
-      })
+        .within(() => {
+          cy.get(interact.PUBLISH_POPOVER_ACTION).click({ force: true })
+        })
 
       cy.get(interact.UNPUBLISH_MODAL).should("be.visible")
-      .within(() => {
-        cy.get(interact.CONFIRM_WRAP_BUTTON).click({ force: true }
-      )})
+        .within(() => {
+          cy.get(interact.CONFIRM_WRAP_BUTTON).click({ force: true }
+          )
+        })
 
       cy.visit(`${Cypress.config().baseUrl}/builder`, { timeout: 6000 })
       cy.wait(500)

--- a/packages/builder/cypress/integration/createView.spec.js
+++ b/packages/builder/cypress/integration/createView.spec.js
@@ -2,7 +2,7 @@ import filterTests from "../support/filterTests"
 const interact = require('../support/interact')
 
 filterTests(['smoke', 'all'], () => {
-  context("Create a View", () => {
+  xcontext("Create a View", () => {
     before(() => {
       cy.login()
       cy.createTestApp()
@@ -20,7 +20,7 @@ filterTests(['smoke', 'all'], () => {
       cy.addRow(["Teachers", 36, 3])
     })
 
-    it("creates a view", () => {
+    xit("creates a view", () => {
       cy.contains("Create view").click()
       cy.get(interact.MODAL_INNER_WRAPPER).within(() => {
         cy.get("input").type("Test View")
@@ -38,7 +38,7 @@ filterTests(['smoke', 'all'], () => {
       })
     })
 
-    it("filters the view by age over 10", () => {
+    xit("filters the view by age over 10", () => {
       cy.contains("Filter").click()
       cy.contains("Add Filter").click()
 
@@ -58,7 +58,7 @@ filterTests(['smoke', 'all'], () => {
       })
     })
 
-    it("creates a stats calculation view based on age", () => {
+    xit("creates a stats calculation view based on age", () => {
       cy.wait(1000)
       cy.contains("Calculate").click()
       cy.get(interact.MODAL_INNER_WRAPPER).within(() => {
@@ -95,7 +95,7 @@ filterTests(['smoke', 'all'], () => {
       })
     })
 
-    it("groups the view by group", () => {
+    xit("groups the view by group", () => {
       cy.contains("Group by").click()
       cy.get(interact.MODAL_INNER_WRAPPER).within(() => {
         cy.get(interact.SPECTRUM_PICKER_LABEL).eq(0).click()
@@ -127,7 +127,7 @@ filterTests(['smoke', 'all'], () => {
       })
     })
 
-    it("renames a view", () => {
+    xit("renames a view", () => {
       cy.contains(interact.NAV_ITEM, "Test View")
         .find(".actions .icon.open-popover")
         .click({ force: true })


### PR DESCRIPTION
The following files now have tests skipped:

- accountPortal (Completely skipped)
- appPublishWorkflow (Some tests skipped)
- createView (Completely Skipped)



