### PR TITLE
Fix for attachment URL update on import - large number of attachments

### DIFF
--- a/packages/server/src/api/routes/tests/analytics.spec.js
+++ b/packages/server/src/api/routes/tests/analytics.spec.js
@@ -1,5 +1,5 @@
 const setup = require("./utilities")
-const { events, constants, db } = require("@budibase/backend-core")
+const { events, constants } = require("@budibase/backend-core")
 
 describe("/static", () => {
   let request = setup.getRequest()

--- a/packages/server/src/sdk/app/backups/imports.ts
+++ b/packages/server/src/sdk/app/backups/imports.ts
@@ -43,7 +43,7 @@ function rewriteAttachmentUrl(appId: string, attachment: RowAttachment) {
   }
 }
 
-async function updateAttachmentColumns(prodAppId: string, db: Database) {
+export async function updateAttachmentColumns(prodAppId: string, db: Database) {
   // iterate through attachment documents and update them
   const tables = await sdk.tables.getAllInternalTables(db)
   let updatedRows: Row[] = []

--- a/packages/server/src/sdk/app/rows/attachments.ts
+++ b/packages/server/src/sdk/app/rows/attachments.ts
@@ -1,0 +1,60 @@
+import { CouchFindOptions, Table, Row } from "@budibase/types"
+import { db as dbCore } from "@budibase/backend-core"
+import { DocumentType, SEPARATOR } from "../../../db/utils"
+import { FieldTypes } from "../../../constants"
+
+// default limit - seems to work well for performance
+export const FIND_LIMIT = 25
+
+function generateAttachmentFindParams(
+  tableId: string,
+  attachmentCols: string[],
+  bookmark: null | string
+) {
+  const params: CouchFindOptions = {
+    selector: {
+      _id: {
+        $regex: `^${DocumentType.ROW}${SEPARATOR}${tableId}`,
+      },
+    },
+    limit: FIND_LIMIT,
+  }
+  attachmentCols.forEach(col => (params.selector[col] = { $exists: true }))
+  if (bookmark) {
+    params.bookmark = bookmark
+  }
+  return params
+}
+
+export async function getRowsWithAttachments(appId: string, table: Table) {
+  // iterate through attachment documents and update them
+  const db = dbCore.getDB(appId)
+  const attachmentCols: string[] = []
+  for (let [key, column] of Object.entries(table.schema)) {
+    if (column.type === FieldTypes.ATTACHMENT) {
+      attachmentCols.push(key)
+    }
+  }
+  // no attachment columns, nothing to do
+  if (attachmentCols.length === 0) {
+    return { rows: [], columns: [] }
+  }
+  let bookmark: null | string = null,
+    rowsLength = 0,
+    rowList: Row[] = []
+  do {
+    const params = generateAttachmentFindParams(
+      table._id!,
+      attachmentCols,
+      bookmark
+    )
+    // use the CouchDB Mango query API to lookup rows that have attachments
+    const resp = await dbCore.directCouchFind(db.name, params)
+    bookmark = resp.bookmark
+    rowsLength = resp.rows.length
+    const rows = resp.rows
+    rowList = rowList.concat(rows)
+  } while (rowsLength === FIND_LIMIT)
+  // write back the updated attachments
+  return { rows: rowList, columns: attachmentCols }
+}

--- a/packages/server/src/sdk/app/rows/index.ts
+++ b/packages/server/src/sdk/app/rows/index.ts
@@ -1,0 +1,5 @@
+import * as attachments from "./attachments"
+
+export default {
+  ...attachments,
+}

--- a/packages/server/src/sdk/app/rows/index.ts
+++ b/packages/server/src/sdk/app/rows/index.ts
@@ -1,5 +1,7 @@
 import * as attachments from "./attachments"
+import * as rows from "./rows"
 
 export default {
   ...attachments,
+  ...rows,
 }

--- a/packages/server/src/sdk/app/rows/rows.ts
+++ b/packages/server/src/sdk/app/rows/rows.ts
@@ -1,0 +1,18 @@
+import { db as dbCore, context } from "@budibase/backend-core"
+import { Database, Row } from "@budibase/types"
+import { getRowParams } from "../../../db/utils"
+
+export async function getAllInternalRows(appId?: string) {
+  let db: Database
+  if (appId) {
+    db = dbCore.getDB(appId)
+  } else {
+    db = context.getAppDB()
+  }
+  const response = await db.allDocs(
+    getRowParams(null, null, {
+      include_docs: true,
+    })
+  )
+  return response.rows.map(row => row.doc) as Row[]
+}

--- a/packages/server/src/sdk/index.ts
+++ b/packages/server/src/sdk/index.ts
@@ -2,6 +2,7 @@ import { default as backups } from "./app/backups"
 import { default as tables } from "./app/tables"
 import { default as automations } from "./app/automations"
 import { default as applications } from "./app/applications"
+import { default as rows } from "./app/rows"
 import { default as users } from "./users"
 
 const sdk = {
@@ -9,6 +10,7 @@ const sdk = {
   tables,
   automations,
   applications,
+  rows,
   users,
 }
 

--- a/packages/server/src/sdk/tests/attachments.spec.ts
+++ b/packages/server/src/sdk/tests/attachments.spec.ts
@@ -1,0 +1,79 @@
+import newid from "../../db/newid"
+
+const attachment = {
+  size: 73479,
+  name: "2022-12-14 11_11_44-.png",
+  url: "/prod-budi-app-assets/app_bbb/attachments/a.png",
+  extension: "png",
+  key: "app_bbb/attachments/a.png",
+}
+
+const row = {
+  _id: "ro_ta_aaa",
+  photo: [attachment],
+  otherCol: "string",
+}
+
+const table = {
+  _id: "ta_aaa",
+  name: "photos",
+  schema: {
+    photo: {
+      type: "attachment",
+      name: "photo",
+    },
+    otherCol: {
+      type: "string",
+      name: "otherCol",
+    },
+  },
+}
+
+jest.mock("@budibase/backend-core", () => {
+  const core = jest.requireActual("@budibase/backend-core")
+  return {
+    ...core,
+    db: {
+      ...core.db,
+      directCouchFind: jest.fn(),
+    },
+  }
+})
+
+import { db as dbCore } from "@budibase/backend-core"
+import sdk from "../index"
+
+describe("should be able to re-write attachment URLs", () => {
+  it("it should update URLs on a number of rows over the limit", async () => {
+    const db = dbCore.getDB("app_aaa")
+    await db.put(table)
+    const limit = 30
+    let rows = []
+    for (let i = 0; i < limit; i++) {
+      const rowToWrite = {
+        ...row,
+        _id: `${row._id}_${newid()}`,
+      }
+      const { rev } = await db.put(rowToWrite)
+      rows.push({
+        ...rowToWrite,
+        _rev: rev,
+      })
+    }
+
+    dbCore.directCouchFind
+      // @ts-ignore
+      .mockReturnValueOnce({ rows: rows.slice(0, 25), bookmark: "aaa" })
+      .mockReturnValueOnce({ rows: rows.slice(25, limit), bookmark: "bbb" })
+    await sdk.backups.updateAttachmentColumns(db.name, db)
+    const finalRows = await sdk.rows.getAllInternalRows(db.name)
+    for (let rowToCheck of finalRows) {
+      expect(rowToCheck.otherCol).toBe(row.otherCol)
+      expect(rowToCheck.photo[0].url).not.toBe(row.photo[0].url)
+      expect(rowToCheck.photo[0].url).toBe(
+        `/prod-budi-app-assets/${db.name}/attachments/a.png`
+      )
+      expect(rowToCheck.photo[0].key).toBe(`${db.name}/attachments/a.png`)
+    }
+  })
+})


### PR DESCRIPTION
## Description
Fix for #9249 - there was an issue with the updating of attachment URLs when importing an app/backup, this resolves it by utilising pagination in the CouchDB find API, making sure to iterate through all documents when there is a larger number.

Addresses: 
- #9249