### PR TITLE
Optimise client library performance with skeleton loaders

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionDrawer.svelte
@@ -13,7 +13,6 @@
   import { generate } from "shortid"
   import { getEventContextBindings } from "builderStore/dataBinding"
   import { currentAsset, store } from "builderStore"
-  import { selectedScreen } from "../../../../../builderStore"
 
   const flipDurationMs = 150
   const EVENT_TYPE_KEY = "##eventHandlerType"

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionDrawer.svelte
@@ -13,6 +13,7 @@
   import { generate } from "shortid"
   import { getEventContextBindings } from "builderStore/dataBinding"
   import { currentAsset, store } from "builderStore"
+  import { selectedScreen } from "../../../../../builderStore"
 
   const flipDurationMs = 150
   const EVENT_TYPE_KEY = "##eventHandlerType"
@@ -74,8 +75,18 @@
   }
 
   const deleteAction = index => {
+    // Check if we're deleting the selected action
+    const selectedIndex = actions.indexOf(selectedAction)
+    const isSelected = index === selectedIndex
+
+    // Delete the action
     actions.splice(index, 1)
     actions = actions
+
+    // Select a new action if we deleted the selected one
+    if (isSelected) {
+      selectedAction = actions?.length ? actions[0] : null
+    }
   }
 
   const toggleActionList = () => {

--- a/packages/client/src/components/Component.svelte
+++ b/packages/client/src/components/Component.svelte
@@ -171,6 +171,16 @@
   $: pad = pad || (interactive && hasChildren && inDndPath)
   $: $dndIsDragging, (pad = false)
 
+  // Determine whether we should render a skeleton loader in lieu of this
+  // component
+  $: showSkeleton =
+    $loading &&
+    definition.name !== "Screenslot" &&
+    children.length === 0 &&
+    !instance._blockElementHasChildren &&
+    !definition.block &&
+    definition.skeleton !== false
+
   // Update component context
   $: store.set({
     id,
@@ -473,14 +483,6 @@
       componentStore.actions.unregisterInstance(id)
     }
   })
-
-  $: showSkeleton =
-    $loading &&
-    definition.name !== "Screenslot" &&
-    children.length === 0 &&
-    !instance._blockElementHasChildren &&
-    !definition.block &&
-    definition.skeleton !== false
 </script>
 
 {#if showSkeleton}

--- a/packages/client/src/components/Component.svelte
+++ b/packages/client/src/components/Component.svelte
@@ -171,8 +171,7 @@
   $: pad = pad || (interactive && hasChildren && inDndPath)
   $: $dndIsDragging, (pad = false)
 
-  // Determine whether we should render a skeleton loader in lieu of this
-  // component
+  // Determine whether we should render a skeleton loader for this component
   $: showSkeleton =
     $loading &&
     definition.name !== "Screenslot" &&

--- a/packages/client/src/components/app/forms/Form.svelte
+++ b/packages/client/src/components/app/forms/Form.svelte
@@ -1,7 +1,8 @@
 <script>
-  import { getContext } from "svelte"
+  import { getContext, setContext } from "svelte"
   import InnerForm from "./InnerForm.svelte"
   import { Helpers } from "@budibase/bbui"
+  import { writable } from "svelte/store"
 
   export let dataSource
   export let theme
@@ -20,10 +21,17 @@
   const context = getContext("context")
   const { API, fetchDatasourceSchema } = getContext("sdk")
 
+  // Forms also use loading context as they require loading a schema
+  const parentLoading = getContext("loading")
+  const loading = writable(true)
+  setContext("loading", loading)
+
+  let loaded = false
   let schema
   let table
 
   $: fetchSchema(dataSource)
+  $: loading.set($parentLoading || !loaded)
 
   // Returns the closes data context which isn't a built in context
   const getInitialValues = (type, dataSource, context) => {
@@ -55,30 +63,32 @@
     }
     const res = await fetchDatasourceSchema(dataSource)
     schema = res || {}
+    if (!loaded) {
+      loaded = true
+    }
   }
 
   $: initialValues = getInitialValues(actionType, dataSource, $context)
   $: resetKey = Helpers.hashString(
-    !!schema +
-      JSON.stringify(initialValues) +
-      JSON.stringify(dataSource) +
-      disabled
+    JSON.stringify(initialValues) + JSON.stringify(dataSource) + disabled
   )
 </script>
 
-{#key resetKey}
-  <InnerForm
-    {dataSource}
-    {theme}
-    {size}
-    {disabled}
-    {actionType}
-    {schema}
-    {table}
-    {initialValues}
-    {disableValidation}
-    {editAutoColumns}
-  >
-    <slot />
-  </InnerForm>
-{/key}
+{#if loaded}
+  {#key resetKey}
+    <InnerForm
+      {dataSource}
+      {theme}
+      {size}
+      {disabled}
+      {actionType}
+      {schema}
+      {table}
+      {initialValues}
+      {disableValidation}
+      {editAutoColumns}
+    >
+      <slot />
+    </InnerForm>
+  {/key}
+{/if}

--- a/packages/client/src/components/app/forms/Form.svelte
+++ b/packages/client/src/components/app/forms/Form.svelte
@@ -70,25 +70,26 @@
 
   $: initialValues = getInitialValues(actionType, dataSource, $context)
   $: resetKey = Helpers.hashString(
-    JSON.stringify(initialValues) + JSON.stringify(dataSource) + disabled
+    loaded +
+      JSON.stringify(initialValues) +
+      JSON.stringify(dataSource) +
+      disabled
   )
 </script>
 
-{#if loaded}
-  {#key resetKey}
-    <InnerForm
-      {dataSource}
-      {theme}
-      {size}
-      {disabled}
-      {actionType}
-      {schema}
-      {table}
-      {initialValues}
-      {disableValidation}
-      {editAutoColumns}
-    >
-      <slot />
-    </InnerForm>
-  {/key}
-{/if}
+{#key resetKey}
+  <InnerForm
+    {dataSource}
+    {theme}
+    {size}
+    {disabled}
+    {actionType}
+    {schema}
+    {table}
+    {initialValues}
+    {disableValidation}
+    {editAutoColumns}
+  >
+    <slot />
+  </InnerForm>
+{/key}

--- a/packages/frontend-core/src/fetch/DataFetch.js
+++ b/packages/frontend-core/src/fetch/DataFetch.js
@@ -45,6 +45,9 @@ export default class DataFetch {
 
       // Pagination config
       paginate: true,
+
+      // Behaviour
+      fetchOnCreation: true,
     }
 
     // State of the fetch
@@ -102,7 +105,9 @@ export default class DataFetch {
     }
 
     // Initially fetch data but don't bother waiting for the result
-    this.getInitialData()
+    if (this.options.fetchOnCreation) {
+      this.getInitialData()
+    }
   }
 
   /**

--- a/packages/frontend-core/src/fetch/DataFetch.js
+++ b/packages/frontend-core/src/fetch/DataFetch.js
@@ -45,9 +45,6 @@ export default class DataFetch {
 
       // Pagination config
       paginate: true,
-
-      // Behaviour
-      fetchOnCreation: true,
     }
 
     // State of the fetch
@@ -105,9 +102,7 @@ export default class DataFetch {
     }
 
     // Initially fetch data but don't bother waiting for the result
-    if (this.options.fetchOnCreation) {
-      this.getInitialData()
-    }
+    this.getInitialData()
   }
 
   /**


### PR DESCRIPTION
## Description
This is a collection of fixes and improvements which attempt to restore some client library optimisations which we sacrificed in order to develop the skeleton loader feature. As that feature fundamentally changes how everything is rendered (and specifically, renders data providers and form components before their data is ready) it introduced a number of edge case bugs depending on how your components were ordered.

These fixes will hopefully fix the majority of issues and reduce some of the exessive API load which was being generated.

I'd like to stress that this will only fix the majority of issues and not fully restore the optimisations we had prior to the skeleton loaders. If we are rendering everything before data is ready then there are just some optimisations that will no longer work, so redundant API calls will just have to be something we accept if we want this feature.

Brief changelog:
- Update form field default value determination so that resetting forms after their schema loads does not cause a field value update unless required
- Update data providers to wait for parent data providers to load before loading their own data. This prevents wasted API calls in the event that nested providers use data from parent providers, such as for filtering which is common
- Use the new `loading` context inside forms, so that components nested inside forms will only render skeletons until the form schema as loaded. This is required as forms cannot dynamically update their schema and require a full reset, so currently we are fully resetting data providers nested inside forms, causing bugs as well as wasted API calls
- Optimise data providers to avoid updates as much as possible
- Included a fix for an issue with button actions

We won't be able to fully remove all redundant API calls without introducing debouncing (which introduces lag to the UI of course), so there are still some cases which will be inefficient. An example is when using a form field as a filter on a data provider, and providing a default value setting to that field. In this scenario, the data provider will initially render without a value for this field, but will then immediately refresh itself as soon as the form field mounts and notifies the form of its existence and default value. This scenario is highlighted in one of the issues raised recently.

Addresses: 
- #9064
- #9104
- #9164
- #9166
- #9069
- #9258


