### PR TITLE
SQL filtering: Always escape key in LIKE statements 

### DIFF
--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -232,7 +232,9 @@ class InternalBuilder {
         } else {
           const rawFnc = `${fnc}Raw`
           // @ts-ignore
-          query = query[rawFnc](`LOWER(${likeKey(this.client, key)}) LIKE ?`, [`${value}%`])
+          query = query[rawFnc](`LOWER(${likeKey(this.client, key)}) LIKE ?`, [
+            `${value}%`,
+          ])
         }
       })
     }

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -23,9 +23,6 @@ const MIN_ISO_DATE = "0000-00-00T00:00:00.000Z"
 const MAX_ISO_DATE = "9999-00-00T00:00:00.000Z"
 
 function likeKey(client: string, key: string): string {
-  if (!key.includes(" ")) {
-    return key
-  }
   let start: string, end: string
   switch (client) {
     case SqlClient.MY_SQL:
@@ -235,7 +232,7 @@ class InternalBuilder {
         } else {
           const rawFnc = `${fnc}Raw`
           // @ts-ignore
-          query = query[rawFnc](`LOWER(${key}) LIKE ?`, [`${value}%`])
+          query = query[rawFnc](`LOWER(${likeKey(this.client, key)}) LIKE ?`, [`${value}%`])
         }
       })
     }

--- a/packages/server/src/integrations/tests/sql.spec.ts
+++ b/packages/server/src/integrations/tests/sql.spec.ts
@@ -535,7 +535,7 @@ describe("SQL query builder", () => {
       sql: `select * from (select * from \`${tableName}\` where LOWER(\`${tableName}\`.\`name\`) LIKE ? limit ?) as \`${tableName}\``,
     })
   })
-  
+
   it("should handle table names with dashes when performing a LIKE in SQL Server", () => {
     const tableName = "Table-Name-With-Dashes"
     const query = new Sql(SqlClient.MS_SQL, limit)._query(

--- a/packages/server/src/integrations/tests/sql.spec.ts
+++ b/packages/server/src/integrations/tests/sql.spec.ts
@@ -352,7 +352,7 @@ describe("SQL query builder", () => {
     )
     expect(query).toEqual({
       bindings: [10, "%20%", "%25%", `%"John"%`, `%"Mary"%`],
-      sql: `select * from (select top (@p0) * from [${TABLE_NAME}] where (LOWER(${TABLE_NAME}.age) LIKE @p1 AND LOWER(${TABLE_NAME}.age) LIKE @p2) and (LOWER(${TABLE_NAME}.name) LIKE @p3 AND LOWER(${TABLE_NAME}.name) LIKE @p4)) as [${TABLE_NAME}]`,
+      sql: `select * from (select top (@p0) * from [${TABLE_NAME}] where (LOWER([${TABLE_NAME}].[age]) LIKE @p1 AND LOWER([${TABLE_NAME}].[age]) LIKE @p2) and (LOWER([${TABLE_NAME}].[name]) LIKE @p3 AND LOWER([${TABLE_NAME}].[name]) LIKE @p4)) as [${TABLE_NAME}]`,
     })
   })
 
@@ -403,7 +403,7 @@ describe("SQL query builder", () => {
     )
     expect(query).toEqual({
       bindings: [10, "%20%", `%"John"%`],
-      sql: `select * from (select top (@p0) * from [${TABLE_NAME}] where NOT (LOWER(${TABLE_NAME}.age) LIKE @p1) and NOT (LOWER(${TABLE_NAME}.name) LIKE @p2)) as [${TABLE_NAME}]`,
+      sql: `select * from (select top (@p0) * from [${TABLE_NAME}] where NOT (LOWER([${TABLE_NAME}].[age]) LIKE @p1) and NOT (LOWER([${TABLE_NAME}].[name]) LIKE @p2)) as [${TABLE_NAME}]`,
     })
   })
 
@@ -454,7 +454,7 @@ describe("SQL query builder", () => {
     )
     expect(query).toEqual({
       bindings: [10, "%20%", "%25%", `%"John"%`, `%"Mary"%`],
-      sql: `select * from (select top (@p0) * from [${TABLE_NAME}] where (LOWER(${TABLE_NAME}.age) LIKE @p1 OR LOWER(${TABLE_NAME}.age) LIKE @p2) and (LOWER(${TABLE_NAME}.name) LIKE @p3 OR LOWER(${TABLE_NAME}.name) LIKE @p4)) as [${TABLE_NAME}]`,
+      sql: `select * from (select top (@p0) * from [${TABLE_NAME}] where (LOWER([${TABLE_NAME}].[age]) LIKE @p1 OR LOWER([${TABLE_NAME}].[age]) LIKE @p2) and (LOWER([${TABLE_NAME}].[name]) LIKE @p3 OR LOWER([${TABLE_NAME}].[name]) LIKE @p4)) as [${TABLE_NAME}]`,
     })
   })
 
@@ -515,6 +515,42 @@ describe("SQL query builder", () => {
     expect(query).toEqual({
       bindings: [500, 5000],
       sql: `select "stores"."store_id" as "stores.store_id", "stores"."store_name" as "stores.store_name", "products"."product_id" as "products.product_id", "products"."product_name" as "products.product_name" from (select * from "production"."stores" limit $1) as "stores" left join "production"."stocks" on "stores"."store_id" = "stocks"."store_id" left join "production"."products" on "products"."product_id" = "stocks"."product_id" limit $2`,
+    })
+  })
+
+  it("should handle table names with dashes when performing a LIKE in MySQL", () => {
+    const tableName = "Table-Name-With-Dashes"
+    const query = new Sql(SqlClient.MY_SQL, limit)._query(
+      generateReadJson({
+        table: tableName,
+        filters: {
+          string: {
+            name: "John",
+          },
+        },
+      })
+    )
+    expect(query).toEqual({
+      bindings: ["John%", limit],
+      sql: `select * from (select * from \`${tableName}\` where LOWER(\`${tableName}\`.\`name\`) LIKE ? limit ?) as \`${tableName}\``,
+    })
+  })
+  
+  it("should handle table names with dashes when performing a LIKE in SQL Server", () => {
+    const tableName = "Table-Name-With-Dashes"
+    const query = new Sql(SqlClient.MS_SQL, limit)._query(
+      generateReadJson({
+        table: tableName,
+        filters: {
+          string: {
+            name: "John",
+          },
+        },
+      })
+    )
+    expect(query).toEqual({
+      bindings: [limit, "John%"],
+      sql: `select * from (select top (@p0) * from [${tableName}] where LOWER([${tableName}].[name]) LIKE @p1) as [${tableName}]`,
     })
   })
 })


### PR DESCRIPTION
## Description
LIKE statements were failing for tables with dashes in the name. This bug was reproducible in SQL Server and MySQL.

This is because of this snippet in the **likeKey** function:
```js
if (!key.includes(" ")) {
  return key
}
```
I simply removed this because as far as I understand there is no drawback to always escaping key. 
E.g. `table.column` is valid, but `[table].[column]` is also valid and also supports `[table-name].[column]`

Addresses: 
- https://github.com/Budibase/budibase/issues/9150



