### PR TITLE
Renamed proxy docker image tag from proxy-service to budibase/proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "build:specs": "lerna run specs",
     "build:docker": "lerna run build:docker && npm run build:docker:proxy && cd hosting/scripts/linux/ && ./release-to-docker-hub.sh $BUDIBASE_RELEASE_VERSION && cd -",
     "build:docker:pre": "lerna run build && lerna run predocker",
-    "build:docker:proxy": "docker build hosting/proxy -t proxy-service",
+    "build:docker:proxy": "docker build hosting/proxy -t budibase/proxy",
     "build:docker:selfhost": "lerna run build:docker && cd hosting/scripts/linux/ && ./release-to-docker-hub.sh latest && cd -",
     "build:docker:develop": "node scripts/pinVersions && lerna run build:docker && npm run build:docker:proxy && cd hosting/scripts/linux/ && ./release-to-docker-hub.sh develop && cd -",
     "build:docker:airgap": "node hosting/scripts/airgapped/airgappedDockerBuild",


### PR DESCRIPTION
## Description

Discovered this with @aptkingston. The `build:docker:proxy` step was mistakenly naming the docker proxy image `proxy-service` instead of `budibase/proxy`.

The dev compose was recently updated to allow users to specify their proxy address and to now use `budibase/proxy` as the container image.

With this change the proxy image will now be rebuilt with the correct tag and the new config changes will work as expected.