### PR TITLE
adjust service annotation locations

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -20,8 +20,8 @@ spec:
       annotations:
         kompose.cmd: kompose convert
         kompose.version: 1.21.0 (992df58d8)
-{{ if .Values.globals.appServiceAnnotations }}
-{{ toYaml .Values.globals.appServiceAnnotations | indent 4 }}
+{{ if .Values.services.apps.appServiceAnnotations }}
+{{- toYaml .Values.services.apps.appServiceAnnotations | indent 8 -}}
 {{ end }}
       creationTimestamp: null
       labels:

--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -20,8 +20,8 @@ spec:
       annotations:
         kompose.cmd: kompose convert
         kompose.version: 1.21.0 (992df58d8)
-{{ if .Values.services.apps.appServiceAnnotations }}
-{{- toYaml .Values.services.apps.appServiceAnnotations | indent 8 -}}
+{{ if .Values.services.apps.annotations }}
+{{- toYaml .Values.services.apps.annotations | indent 8 -}}
 {{ end }}
       creationTimestamp: null
       labels:

--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -20,8 +20,8 @@ spec:
       annotations:
         kompose.cmd: kompose convert
         kompose.version: 1.21.0 (992df58d8)
-{{ if .Values.services.proxy.proxyServiceAnnotations }}
-{{- toYaml .Values.services.proxy.proxyServiceAnnotations | indent 8 -}}
+{{ if .Values.services.proxy.annotations }}
+{{- toYaml .Values.services.proxy.annotations | indent 8 -}}
 {{ end }}
       creationTimestamp: null
       labels:

--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -20,8 +20,8 @@ spec:
       annotations:
         kompose.cmd: kompose convert
         kompose.version: 1.21.0 (992df58d8)
-{{ if .Values.globals.proxyServiceAnnotations }}
-{{ toYaml .Values.globals.proxyServiceAnnotations | indent 4 }}
+{{ if .Values.services.proxy.proxyServiceAnnotations }}
+{{- toYaml .Values.services.proxy.proxyServiceAnnotations | indent 8 -}}
 {{ end }}
       creationTimestamp: null
       labels:

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -21,8 +21,8 @@ spec:
       annotations:
         kompose.cmd: kompose convert
         kompose.version: 1.21.0 (992df58d8)
-{{ if .Values.services.worker.workerServiceAnnotations }}
-{{- toYaml .Values.services.worker.workerServiceAnnotations | indent 8 -}}
+{{ if .Values.services.worker.annotations }}
+{{- toYaml .Values.services.worker.annotations | indent 8 -}}
 {{ end }}
       creationTimestamp: null
       labels:

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -21,8 +21,8 @@ spec:
       annotations:
         kompose.cmd: kompose convert
         kompose.version: 1.21.0 (992df58d8)
-{{ if .Values.globals.workerServiceAnnotations }}
-{{ toYaml .Values.globals.workerServiceAnnotations | indent 4 }}
+{{ if .Values.services.worker.workerServiceAnnotations }}
+{{- toYaml .Values.services.worker.workerServiceAnnotations | indent 8 -}}
 {{ end }}
       creationTimestamp: null
       labels:

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -124,7 +124,7 @@ services:
       minio: 'http://minio-service.{{ .Release.Namespace }}.svc.{{ .Values.services.dns }}:{{ .Values.services.objectStore.port }}'
       couchdb: 'http://{{ .Release.Name }}-svc-couchdb:{{ .Values.services.couchdb.port }}'
     resources: {}
-#    proxyServiceAnnotations:
+#    annotations:
 #      co.elastic.logs/module: nginx
 #      co.elastic.logs/fileset.stdout: access
 #      co.elastic.logs/fileset.stderr: error
@@ -135,7 +135,7 @@ services:
     logLevel: info
     resources: {}
 #    nodeDebug: "" # set the value of NODE_DEBUG
-#    appServiceAnnotations:
+#    annotations:
 #      co.elastic.logs/multiline.type: pattern
 #      co.elastic.logs/multiline.pattern: '^[[:space:]]'
 #      co.elastic.logs/multiline.negate: false
@@ -144,7 +144,7 @@ services:
     port: 4003
     replicaCount: 1
     resources: {}
-#    workerServiceAnnotations:
+#    annotations:
 #      co.elastic.logs/multiline.type: pattern
 #      co.elastic.logs/multiline.pattern: '^[[:space:]]'
 #      co.elastic.logs/multiline.negate: false

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -22,23 +22,6 @@ serviceAccount:
 
 podAnnotations: {}
 
-# appServiceAnnotations:
-#   co.elastic.logs/multiline.type: pattern
-#   co.elastic.logs/multiline.pattern: '^[[:space:]]'
-#   co.elastic.logs/multiline.negate: false
-#   co.elastic.logs/multiline.match: after
-
-# workerServiceAnnotations:
-#   co.elastic.logs/multiline.type: pattern
-#   co.elastic.logs/multiline.pattern: '^[[:space:]]'
-#   co.elastic.logs/multiline.negate: false
-#   co.elastic.logs/multiline.match: after
-
-# proxyServiceAnnotations:
-#  co.elastic.logs/module: nginx
-#  co.elastic.logs/fileset.stdout: access
-#  co.elastic.logs/fileset.stderr: error
-
 podSecurityContext:
   {}
   # fsGroup: 2000
@@ -141,6 +124,10 @@ services:
       minio: 'http://minio-service.{{ .Release.Namespace }}.svc.{{ .Values.services.dns }}:{{ .Values.services.objectStore.port }}'
       couchdb: 'http://{{ .Release.Name }}-svc-couchdb:{{ .Values.services.couchdb.port }}'
     resources: {}
+#    proxyServiceAnnotations:
+#      co.elastic.logs/module: nginx
+#      co.elastic.logs/fileset.stdout: access
+#      co.elastic.logs/fileset.stderr: error
 
   apps:
     port: 4002
@@ -148,11 +135,20 @@ services:
     logLevel: info
     resources: {}
 #    nodeDebug: "" # set the value of NODE_DEBUG
-
+#    appServiceAnnotations:
+#      co.elastic.logs/multiline.type: pattern
+#      co.elastic.logs/multiline.pattern: '^[[:space:]]'
+#      co.elastic.logs/multiline.negate: false
+#      co.elastic.logs/multiline.match: after
   worker:
     port: 4003
     replicaCount: 1
     resources: {}
+#    workerServiceAnnotations:
+#      co.elastic.logs/multiline.type: pattern
+#      co.elastic.logs/multiline.pattern: '^[[:space:]]'
+#      co.elastic.logs/multiline.negate: false
+#      co.elastic.logs/multiline.match: after
 
   couchdb:
     enabled: true


### PR DESCRIPTION
My previous attempts at this were lacking. This time I have tested with the `helm template` command.
I moved the annotations under the deployment > spec > template (with an indent of 8) where I think they belong. `helm template` shows this substitution is into the correct place but I still need to test against QA when this is on the develop branch.

Similarly I moved the annotations location in the `values.yaml` file so they appear under: services > servicename > annotations 
which feels like a more intuitive place to have them. 