### PR TITLE
Update QueryLevelTransformers Tests

### DIFF
--- a/packages/builder/cypress/integration/queryLevelTransformers.spec.js
+++ b/packages/builder/cypress/integration/queryLevelTransformers.spec.js
@@ -13,9 +13,9 @@ filterTests(["smoke", "all"], () => {
       const datasource = "REST"
       const restUrl = "https://api.openbrewerydb.org/breweries"
       cy.selectExternalDatasource(datasource)
-      cy.createRestQuery("GET", restUrl, "/breweries")
+      cy.createRestQuery("GET", restUrl, "breweries")
       cy.reload()
-      cy.contains(".nav-item-content", "/breweries", { timeout: 20000 }).click()
+      cy.contains(".nav-item-content", "breweries", { timeout: 20000 }).click()
       cy.contains(interact.SPECTRUM_TABS_ITEM, "Transformer", { timeout: 5000 }).click({ force: true })
       // Get Transformer Function from file
       cy.readFile("cypress/support/queryLevelTransformerFunction.js").then(
@@ -44,9 +44,9 @@ filterTests(["smoke", "all"], () => {
       const datasource = "REST"
       const restUrl = "https://api.openbrewerydb.org/breweries"
       cy.selectExternalDatasource(datasource)
-      cy.createRestQuery("GET", restUrl, "/breweries")
+      cy.createRestQuery("GET", restUrl, "breweries")
       cy.reload()
-      cy.contains(".nav-item-content", "/breweries", { timeout: 2000 }).click()
+      cy.contains(".nav-item-content", "breweries", { timeout: 2000 }).click()
       cy.contains(interact.SPECTRUM_TABS_ITEM, "Transformer", { timeout: 5000 }).click({ force: true })
       // Get Transformer Function with Data from file
       cy.readFile(
@@ -75,9 +75,9 @@ filterTests(["smoke", "all"], () => {
       const datasource = "REST"
       const restUrl = "https://api.openbrewerydb.org/breweries"
       cy.selectExternalDatasource(datasource)
-      cy.createRestQuery("GET", restUrl, "/breweries")
+      cy.createRestQuery("GET", restUrl, "breweries")
       cy.reload()
-      cy.contains(".nav-item-content", "/breweries", { timeout: 2000 }).click()
+      cy.contains(".nav-item-content", "breweries", { timeout: 2000 }).click()
       cy.contains(interact.SPECTRUM_TABS_ITEM, "Transformer", { timeout: 5000 }).click({ force: true })
       // Clear the code box and add "test"
       cy.get(interact.CODEMIRROR_TEXTAREA)

--- a/packages/builder/cypress/integration/queryLevelTransformers.spec.js
+++ b/packages/builder/cypress/integration/queryLevelTransformers.spec.js
@@ -77,7 +77,7 @@ filterTests(["smoke", "all"], () => {
       cy.selectExternalDatasource(datasource)
       cy.createRestQuery("GET", restUrl, "breweries")
       cy.reload()
-      cy.contains(".nav-item-content", "breweries", { timeout: 2000 }).click()
+      cy.contains(".nav-item-content", "breweries", { timeout: 10000 }).click()
       cy.contains(interact.SPECTRUM_TABS_ITEM, "Transformer", { timeout: 5000 }).click({ force: true })
       // Clear the code box and add "test"
       cy.get(interact.CODEMIRROR_TEXTAREA)


### PR DESCRIPTION
There was an issue with forward slashes. Resolved and now passing again

Also increasing timeout after page reload
This applies to the following test:
'should run an invalid query within the transformer section'
