### PR TITLE
Default source to Github

### DIFF
--- a/packages/builder/src/pages/builder/portal/manage/plugins/_components/AddPluginModal.svelte
+++ b/packages/builder/src/pages/builder/portal/manage/plugins/_components/AddPluginModal.svelte
@@ -26,7 +26,7 @@
     [PluginSource.FILE]: [opt("File Upload")],
   }
   let file
-  let source = PluginSource.URL
+  let source = PluginSource.GITHUB
   let dynamicValues = {}
 
   let validation


### PR DESCRIPTION
## Description
Github URL is used 99% of the time when adding plugins. Changed to be the option selected by default.

## Screenshots
![Screenshot 2023-01-11 at 15 18 19](https://user-images.githubusercontent.com/101575380/211843951-6572eb16-0241-429a-8cf3-0a8218927a73.png)




