### PR TITLE
Logging type updates to fix account portal build

### DIFF
--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -64,6 +64,7 @@
     "@types/jest": "27.5.1",
     "@types/koa": "2.13.4",
     "@types/koa-pino-logger": "3.0.0",
+    "@types/pino-http": "5.8.1",
     "@types/lodash": "4.14.180",
     "@types/node": "14.18.20",
     "@types/node-fetch": "2.6.1",

--- a/packages/backend-core/src/logging.ts
+++ b/packages/backend-core/src/logging.ts
@@ -1,6 +1,8 @@
 import { Header } from "./constants"
 import env from "./environment"
 const correlator = require("correlation-id")
+import { Options } from "pino-http"
+import { IncomingMessage } from "http"
 
 const NonErrors = ["AccountError"]
 
@@ -33,14 +35,14 @@ export function logWarn(message: string) {
   console.warn(`bb-warn: ${message}`)
 }
 
-export function pinoSettings() {
+export function pinoSettings(): Options {
   return {
     prettyPrint: {
       levelFirst: true,
     },
     level: env.LOG_LEVEL || "error",
     autoLogging: {
-      ignore: (req: { url: string }) => req.url.includes("/health"),
+      ignore: (req: IncomingMessage) => !!req.url?.includes("/health"),
     },
   }
 }

--- a/packages/backend-core/yarn.lock
+++ b/packages/backend-core/yarn.lock
@@ -1239,7 +1239,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.20.tgz#268f028b36eaf51181c3300252f605488c4f0650"
   integrity sha512-Q8KKwm9YqEmUBRsqJ2GWJDtXltBDxTdC4m5vTdXBolu2PeQh8LX+f6BTwU+OuXPu37fLxoN6gidqBmnky36FXA==
 
-"@types/pino-http@*":
+"@types/pino-http@*", "@types/pino-http@5.8.1":
   version "5.8.1"
   resolved "https://registry.yarnpkg.com/@types/pino-http/-/pino-http-5.8.1.tgz#ebb194750ad2f9245c3028b5d2c4e6d64f685ba9"
   integrity sha512-A9MW6VCnx5ii7s+Fs5aFIw+aSZcBCpsZ/atpxamu8tTsvWFacxSf2Hrn1Ohn1jkVRB/LiPGOapRXcFawDBnDnA==


### PR DESCRIPTION
## Description
Add type defs to `pinoSettings` in backend-core. account-portal imports the type aware sources for koa-pino-logger and was failing, this isn't an issue in budibase where `require` is used for the pino import. 

Addresses: 
Build error here: https://github.com/Budibase/account-portal/actions/runs/3896971437/jobs/6654124640



