### PR TITLE
Allow primary keys to be foreign key

### DIFF
--- a/packages/builder/src/components/backend/Datasources/CreateEditRelationship.svelte
+++ b/packages/builder/src/components/backend/Datasources/CreateEditRelationship.svelte
@@ -340,9 +340,7 @@
   {:else if isManyToOne && toTable}
     <Select
       label={`Foreign Key (${toTable?.name})`}
-      options={Object.keys(toTable?.schema).filter(
-        field => toTable?.primary.indexOf(field) === -1
-      )}
+      options={Object.keys(toTable?.schema)}
       on:change={() => ($touched.foreign = true)}
       bind:error={errors.foreign}
       bind:value={fromRelationship.fieldName}


### PR DESCRIPTION
## Description
As discussed with @mike12345567 I removed the foreign key relationship filter to allow primary keys to act as foreign keys.
This is to satisfy a fairly common use-case, as per this docs tutorial I'm working on: https://docs.budibase.com/docs/mysql-mariadb

Addresses: 
- https://github.com/Budibase/budibase/issues/6029

## Screenshots
**employees table**
![Screenshot 2023-01-12 at 17 08 21](https://user-images.githubusercontent.com/101575380/212133266-2da8f66c-3739-4ab3-aa96-f5e8f179e7ae.png)

**titles table**
![Screenshot 2023-01-12 at 17 08 44](https://user-images.githubusercontent.com/101575380/212133334-dec111ba-72b4-44c2-8c55-34b4c3e92366.png)

**Define existing relationship - can now use the emp_no column, even though it is primary**
![Screenshot 2023-01-12 at 17 09 19](https://user-images.githubusercontent.com/101575380/212133457-ef86d4f5-5f38-413e-a599-2afec6d9dd4d.png)

**Result**
![Screenshot 2023-01-12 at 17 10 28](https://user-images.githubusercontent.com/101575380/212133722-11aa4eb4-5566-4f3a-80f7-50ddcbe762f5.png)




