### PR TITLE
Bug - #7220 removing user from auth does not remove from app

### DIFF
--- a/packages/server/src/api/controllers/user.ts
+++ b/packages/server/src/api/controllers/user.ts
@@ -189,16 +189,11 @@ export async function removeUserFromApp(ctx: BBContext) {
       try {
         metadata = await db.get(metadataId)
       } catch (err) {
+        console.warn(`User cannot be found in the app`, { userId, appId })
         return
       }
 
-      let combined = {
-        ...metadata,
-        status: constants.UserStatus.INACTIVE,
-        metadata: rolesCore.BUILTIN_ROLE_IDS.PUBLIC,
-      }
-
-      await db.put(combined)
+      await db.remove(metadata)
     })
   }
   ctx.body = {

--- a/packages/server/src/api/controllers/user.ts
+++ b/packages/server/src/api/controllers/user.ts
@@ -28,9 +28,10 @@ export async function syncUser(ctx: Ctx) {
     }
   }
 
-  let previousApps = isUser(previousUser)
-    ? Object.keys(previousUser.roles).map(appId => appId)
-    : []
+  let previousApps =
+    previousUser && isUser(previousUser)
+      ? Object.keys(previousUser.roles).map(appId => appId)
+      : []
 
   const roles = deleting ? {} : user.roles
   // remove props which aren't useful to metadata

--- a/packages/server/src/api/controllers/user.ts
+++ b/packages/server/src/api/controllers/user.ts
@@ -4,19 +4,21 @@ import { getGlobalUsers, getRawGlobalUser } from "../../utilities/global"
 import { getFullUser } from "../../utilities/users"
 import {
   context,
-  constants,
   roles as rolesCore,
   db as dbCore,
 } from "@budibase/backend-core"
-import { BBContext, Ctx, User } from "@budibase/types"
+import { BBContext, Ctx, isUser, User } from "@budibase/types"
 import sdk from "../../sdk"
 
-export async function syncUser(ctx: BBContext) {
+export async function syncUser(ctx: Ctx) {
   let deleting = false,
     user: User | any
   const userId = ctx.params.id
+
+  const previousUser = ctx.request.body?.previousUser
+
   try {
-    user = await getRawGlobalUser(userId)
+    user = (await getRawGlobalUser(userId)) as User
   } catch (err: any) {
     if (err && err.status === 404) {
       user = {}
@@ -25,6 +27,11 @@ export async function syncUser(ctx: BBContext) {
       throw err
     }
   }
+
+  let previousApps = isUser(previousUser)
+    ? Object.keys(previousUser.roles).map(appId => appId)
+    : []
+
   const roles = deleting ? {} : user.roles
   // remove props which aren't useful to metadata
   delete user.password
@@ -40,8 +47,9 @@ export async function syncUser(ctx: BBContext) {
       .filter(entry => entry[1] !== rolesCore.BUILTIN_ROLE_IDS.PUBLIC)
       .map(([appId]) => appId)
   }
-  for (let prodAppId of prodAppIds) {
+  for (let prodAppId of new Set([...prodAppIds, ...previousApps])) {
     const roleId = roles[prodAppId]
+    const deleteFromApp = !roleId
     const devAppId = dbCore.getDevelopmentAppID(prodAppId)
     for (let appId of [prodAppId, devAppId]) {
       if (!(await dbCore.dbExists(appId))) {
@@ -54,24 +62,24 @@ export async function syncUser(ctx: BBContext) {
         try {
           metadata = await db.get(metadataId)
         } catch (err) {
-          if (deleting) {
+          if (deleteFromApp) {
             return
           }
           metadata = {
             tableId: InternalTables.USER_METADATA,
           }
         }
+
+        if (deleteFromApp) {
+          await db.remove(metadata)
+          return
+        }
+
         // assign the roleId for the metadata doc
         if (roleId) {
           metadata.roleId = roleId
         }
-        let combined = !deleting
-          ? sdk.users.combineMetadataAndUser(user, metadata)
-          : {
-              ...metadata,
-              status: constants.UserStatus.INACTIVE,
-              metadata: rolesCore.BUILTIN_ROLE_IDS.PUBLIC,
-            }
+        let combined = sdk.users.combineMetadataAndUser(user, metadata)
         // if its null then there was no updates required
         if (combined) {
           await db.put(combined)
@@ -172,31 +180,4 @@ export async function getFlags(ctx: BBContext) {
     doc = { _id: docId }
   }
   ctx.body = doc
-}
-
-export async function removeUserFromApp(ctx: Ctx) {
-  const { id: userId, prodAppId } = ctx.params
-
-  const devAppId = dbCore.getDevelopmentAppID(prodAppId)
-  for (let appId of [prodAppId, devAppId]) {
-    if (!(await dbCore.dbExists(appId))) {
-      continue
-    }
-    await context.doInAppContext(appId, async () => {
-      const db = context.getAppDB()
-      const metadataId = generateUserMetadataID(userId)
-      let metadata
-      try {
-        metadata = await db.get(metadataId)
-      } catch (err) {
-        console.warn(`User cannot be found in the app`, { userId, appId })
-        return
-      }
-
-      await db.remove(metadata)
-    })
-  }
-  ctx.body = {
-    message: `User ${userId} deleted from ${prodAppId} and ${devAppId}.`,
-  }
 }

--- a/packages/server/src/api/controllers/user.ts
+++ b/packages/server/src/api/controllers/user.ts
@@ -7,10 +7,10 @@ import {
   roles as rolesCore,
   db as dbCore,
 } from "@budibase/backend-core"
-import { BBContext, Ctx, isUser, User } from "@budibase/types"
+import { BBContext, Ctx, SyncUserRequest, User } from "@budibase/types"
 import sdk from "../../sdk"
 
-export async function syncUser(ctx: Ctx) {
+export async function syncUser(ctx: Ctx<SyncUserRequest>) {
   let deleting = false,
     user: User | any
   const userId = ctx.params.id
@@ -28,10 +28,9 @@ export async function syncUser(ctx: Ctx) {
     }
   }
 
-  let previousApps =
-    previousUser && isUser(previousUser)
-      ? Object.keys(previousUser.roles).map(appId => appId)
-      : []
+  let previousApps = previousUser
+    ? Object.keys(previousUser.roles).map(appId => appId)
+    : []
 
   const roles = deleting ? {} : user.roles
   // remove props which aren't useful to metadata

--- a/packages/server/src/api/controllers/user.ts
+++ b/packages/server/src/api/controllers/user.ts
@@ -8,7 +8,7 @@ import {
   roles as rolesCore,
   db as dbCore,
 } from "@budibase/backend-core"
-import { BBContext, User } from "@budibase/types"
+import { BBContext, Ctx, User } from "@budibase/types"
 import sdk from "../../sdk"
 
 export async function syncUser(ctx: BBContext) {
@@ -174,7 +174,7 @@ export async function getFlags(ctx: BBContext) {
   ctx.body = doc
 }
 
-export async function removeUserFromApp(ctx: BBContext) {
+export async function removeUserFromApp(ctx: Ctx) {
   const { id: userId, prodAppId } = ctx.params
 
   const devAppId = dbCore.getDevelopmentAppID(prodAppId)

--- a/packages/server/src/api/controllers/user.ts
+++ b/packages/server/src/api/controllers/user.ts
@@ -197,6 +197,6 @@ export async function removeUserFromApp(ctx: Ctx) {
     })
   }
   ctx.body = {
-    message: `User ${userId} deleted from ${prodAppId} and ${"devapp"}.`,
+    message: `User ${userId} deleted from ${prodAppId} and ${devAppId}.`,
   }
 }

--- a/packages/server/src/api/routes/tests/user.spec.js
+++ b/packages/server/src/api/routes/tests/user.spec.js
@@ -171,9 +171,28 @@ describe("/users", () => {
         .expect("Content-Type", /json/)
       expect(res.body.message).toEqual('User synced.')
     })
+
+
+    it("should sync the user when a previous user is specified", async () => {
+      const app1 = await config.createApp('App 1')
+      const app2 = await config.createApp('App 2')
+
+      let user = await config.createUser(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        false,
+        true,
+        { [app1.appId]: 'ADMIN' })
+      let res = await request
+        .post(`/api/users/metadata/sync/${user._id}`)
+        .set(config.defaultHeaders())
+        .send({ previousUser: { ...user, roles: { ...user.roles, [app2.appId]: 'BASIC' } } })
+        .expect(200)
+        .expect("Content-Type", /json/)
+
+      expect(res.body.message).toEqual('User synced.')
+    })
   })
-
-
-
-
 })

--- a/packages/server/src/api/routes/user.ts
+++ b/packages/server/src/api/routes/user.ts
@@ -47,10 +47,5 @@ router
     authorized(PermissionType.USER, PermissionLevel.READ),
     controller.getFlags
   )
-  .delete(
-    "/api/users/metadata/:id/app/:prodAppId",
-    authorized(PermissionType.USER, PermissionLevel.WRITE),
-    controller.removeUserFromApp
-  )
 
 export default router

--- a/packages/server/src/api/routes/user.ts
+++ b/packages/server/src/api/routes/user.ts
@@ -47,5 +47,10 @@ router
     authorized(PermissionType.USER, PermissionLevel.READ),
     controller.getFlags
   )
+  .delete(
+    "/api/users/metadata/:id/app/:prodAppId",
+    authorized(PermissionType.USER, PermissionLevel.WRITE),
+    controller.removeUserFromApp
+  )
 
 export default router

--- a/packages/server/src/middleware/currentapp.ts
+++ b/packages/server/src/middleware/currentapp.ts
@@ -25,6 +25,7 @@ export default async (ctx: BBContext, next: any) => {
   if (!appCookie && !requestAppId) {
     return next()
   }
+
   // check the app exists referenced in cookie
   if (appCookie) {
     const appId = appCookie.appId
@@ -51,7 +52,7 @@ export default async (ctx: BBContext, next: any) => {
 
   let appId: string | undefined,
     roleId = roles.BUILTIN_ROLE_IDS.PUBLIC
-  if (!ctx.user) {
+  if (!ctx.user?._id) {
     // not logged in, try to set a cookie for public apps
     appId = requestAppId
   } else if (requestAppId != null) {
@@ -96,7 +97,7 @@ export default async (ctx: BBContext, next: any) => {
     // need to judge this only based on the request app ID,
     if (
       env.MULTI_TENANCY &&
-      ctx.user &&
+      ctx.user?._id &&
       requestAppId &&
       !tenancy.isUserInAppTenant(requestAppId, ctx.user)
     ) {

--- a/packages/types/src/api/web/user.ts
+++ b/packages/types/src/api/web/user.ts
@@ -57,3 +57,7 @@ export interface CreateAdminUserRequest {
   password: string
   tenantId: string
 }
+
+export interface SyncUserRequest {
+  previousUser?: User
+}

--- a/packages/types/src/documents/global/user.ts
+++ b/packages/types/src/documents/global/user.ts
@@ -70,6 +70,6 @@ export interface AdminUser extends User {
   }
 }
 
-export function isUser(user: User | ThirdPartyUser): user is User {
+export function isUser(user: any): user is User {
   return !!(user as User).roles
 }

--- a/packages/types/src/documents/global/user.ts
+++ b/packages/types/src/documents/global/user.ts
@@ -69,3 +69,7 @@ export interface AdminUser extends User {
     global: boolean
   }
 }
+
+export function isUser(user: User | ThirdPartyUser): user is User {
+  return !!(user as User).roles
+}

--- a/packages/types/src/documents/global/user.ts
+++ b/packages/types/src/documents/global/user.ts
@@ -70,6 +70,6 @@ export interface AdminUser extends User {
   }
 }
 
-export function isUser(user: any): user is User {
+export function isUser(user: object): user is User {
   return !!(user as User).roles
 }

--- a/packages/types/src/sdk/koa.ts
+++ b/packages/types/src/sdk/koa.ts
@@ -41,7 +41,7 @@ export interface UserCtx<RequestBody = any, ResponseBody = any>
 }
 
 /**
- * Deprecated: Use UserCtx / Ctx appropriately
+ * @deprecated: Use UserCtx / Ctx appropriately
  * Authenticated context.
  */
 export interface BBContext extends Ctx {

--- a/packages/worker/src/sdk/users/users.ts
+++ b/packages/worker/src/sdk/users/users.ts
@@ -31,6 +31,7 @@ import {
   SearchUsersRequest,
   User,
   ThirdPartyUser,
+  isUser,
 } from "@budibase/types"
 import { sendEmail } from "../../utilities/email"
 import { EmailTemplatePurpose } from "../../constants"
@@ -188,10 +189,6 @@ const validateUniqueUser = async (email: string, tenantId: string) => {
   }
 }
 
-function instanceOfUser(user: User | ThirdPartyUser): user is User {
-  return !!(user as User).roles
-}
-
 export const save = async (
   user: User | ThirdPartyUser,
   opts: SaveUserOpts = {}
@@ -262,7 +259,7 @@ export const save = async (
   }
 
   let appsToRemove: string[] = []
-  if (dbUser && instanceOfUser(user)) {
+  if (dbUser && isUser(user)) {
     const newRoles = Object.keys(user.roles)
     const existingRoles = Object.keys(dbUser.roles)
 

--- a/packages/worker/src/sdk/users/users.ts
+++ b/packages/worker/src/sdk/users/users.ts
@@ -258,17 +258,6 @@ export const save = async (
     }
   }
 
-  let appsToRemove: string[] = []
-  if (dbUser && isUser(user)) {
-    const newRoles = Object.keys(user.roles)
-    const existingRoles = Object.keys(dbUser.roles)
-
-    appsToRemove = existingRoles.filter(r => !newRoles.includes(r))
-    if (appsToRemove.length) {
-      console.log("Deleting access to apps", { appsToRemove })
-    }
-  }
-
   try {
     // save the user to db
     let response = await db.put(builtUser)
@@ -278,12 +267,8 @@ export const save = async (
     await addTenant(tenantId, _id, email)
     await cache.user.invalidateUser(response.id)
 
-    for (const appId of appsToRemove) {
-      await apps.removeUserFromApp(_id, appId)
-    }
-
     // let server know to sync user
-    await apps.syncUserInApps(_id)
+    await apps.syncUserInApps(_id, dbUser)
 
     await Promise.all(groupPromises)
 

--- a/packages/worker/src/sdk/users/users.ts
+++ b/packages/worker/src/sdk/users/users.ts
@@ -574,7 +574,7 @@ export const destroy = async (id: string, currentUser: any) => {
   await cache.user.invalidateUser(userId)
   await sessions.invalidateSessions(userId, { reason: "deletion" })
   // let server know to sync user
-  await apps.syncUserInApps(userId)
+  await apps.syncUserInApps(userId, dbUser)
 }
 
 const bulkDeleteProcessing = async (dbUser: User) => {
@@ -584,7 +584,7 @@ const bulkDeleteProcessing = async (dbUser: User) => {
   await cache.user.invalidateUser(userId)
   await sessions.invalidateSessions(userId, { reason: "bulk-deletion" })
   // let server know to sync user
-  await apps.syncUserInApps(userId)
+  await apps.syncUserInApps(userId, dbUser)
 }
 
 export const invite = async (

--- a/packages/worker/src/utilities/appService.ts
+++ b/packages/worker/src/utilities/appService.ts
@@ -2,7 +2,7 @@ import fetch from "node-fetch"
 import { constants, tenancy } from "@budibase/backend-core"
 import { checkSlashesInUrl } from "../utilities"
 import env from "../environment"
-import { User } from "@budibase/types"
+import { SyncUserRequest, User } from "@budibase/types"
 
 async function makeAppRequest(url: string, method: string, body: any) {
   if (env.isTest()) {
@@ -22,10 +22,14 @@ async function makeAppRequest(url: string, method: string, body: any) {
 }
 
 export async function syncUserInApps(userId: string, previousUser?: User) {
+  const body: SyncUserRequest = {
+    previousUser,
+  }
+
   const response = await makeAppRequest(
     `/api/users/metadata/sync/${userId}`,
     "POST",
-    { previousUser }
+    body
   )
   if (response && response.status !== 200) {
     throw "Unable to sync user."

--- a/packages/worker/src/utilities/appService.ts
+++ b/packages/worker/src/utilities/appService.ts
@@ -2,6 +2,7 @@ import fetch from "node-fetch"
 import { constants, tenancy } from "@budibase/backend-core"
 import { checkSlashesInUrl } from "../utilities"
 import env from "../environment"
+import { User } from "@budibase/types"
 
 async function makeAppRequest(url: string, method: string, body: any) {
   if (env.isTest()) {
@@ -20,24 +21,13 @@ async function makeAppRequest(url: string, method: string, body: any) {
   return fetch(checkSlashesInUrl(env.APPS_URL + url), request)
 }
 
-export async function syncUserInApps(userId: string) {
+export async function syncUserInApps(userId: string, previousUser?: User) {
   const response = await makeAppRequest(
     `/api/users/metadata/sync/${userId}`,
     "POST",
-    {}
+    { previousUser }
   )
   if (response && response.status !== 200) {
     throw "Unable to sync user."
-  }
-}
-
-export async function removeUserFromApp(userId: string, appId: string) {
-  const response = await makeAppRequest(
-    `/api/users/metadata/${userId}/app/${appId}`,
-    "DELETE",
-    undefined
-  )
-  if (response && response.status !== 200) {
-    throw "Unable to delete user from app."
   }
 }

--- a/packages/worker/src/utilities/appService.ts
+++ b/packages/worker/src/utilities/appService.ts
@@ -30,3 +30,14 @@ export async function syncUserInApps(userId: string) {
     throw "Unable to sync user."
   }
 }
+
+export async function removeUserFromApp(userId: string, appId: string) {
+  const response = await makeAppRequest(
+    `/api/users/metadata/${userId}/app/${appId}`,
+    "DELETE",
+    undefined
+  )
+  if (response && response.status !== 200) {
+    throw "Unable to delete user from app."
+  }
+}


### PR DESCRIPTION
## Description
Removing a user from the access tab does not remove the user within the app

Addresses: 
- #7220: This bug was discovered while investigating a related bug, not 100% the one described in the bug ticket

## App Export
- Not required, it can be reproduced with an empty app

## Screenshots
https://user-images.githubusercontent.com/15987277/212298953-af265e5b-60e2-4842-84a6-fc06903279be.mov




