### PR TITLE
allow all user bindings in SQL queries

### DIFF
--- a/packages/server/src/threads/query.ts
+++ b/packages/server/src/threads/query.ts
@@ -89,7 +89,7 @@ class QueryRunner {
     let query
     // handle SQL injections by interpolating the variables
     if (isSQL(datasourceClone)) {
-      query = interpolateSQL(fieldsClone, enrichedParameters, integration)
+      query = interpolateSQL(fieldsClone, enrichedContext, integration)
     } else {
       query = enrichQueryFields(fieldsClone, enrichedContext)
     }


### PR DESCRIPTION
## Description
Updating the SQL interpolation to allow `user` context bindings so things like oauth tokens and user email addresses can be used as bindings purely in the backend and do not require them to be sent down from the UI or API.

This was raised by a customer who needed this functionality for security reasons.

Addresses: 
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._



