### PR TITLE
fix couchdb image tag to 3.1.1

### DIFF
--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -245,7 +245,7 @@ couchdb:
   ## The CouchDB image
   image:
     repository: couchdb
-    tag: 3.2.1
+    tag: 3.1.1
     pullPolicy: IfNotPresent
 
   ## Experimental integration with Lucene-powered fulltext search


### PR DESCRIPTION
## Description
couchdb image version was set to 3.2.1 in values.yml but should be 3.1.1 according to the bug described in https://github.com/apache/couchdb-helm/issues/33


