### PR TITLE
Fix Table Creation With No Import

### DIFF
--- a/packages/builder/src/components/backend/TableNavigator/TableDataImport.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/TableDataImport.svelte
@@ -14,7 +14,7 @@
 
   export let rows = []
   export let schema = {}
-  export let allValid = false
+  export let allValid = true
   export let displayColumn = null
 
   const typeOptions = [

--- a/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
@@ -33,7 +33,7 @@
   let autoColumns = getAutoColumnInformation()
   let schema = {}
   let rows = []
-  let allValid = false
+  let allValid = true
   let displayColumn = null
 
   function getAutoColumns() {
@@ -99,7 +99,7 @@
   title="Create Table"
   confirmText="Create"
   onConfirm={saveTable}
-  disabled={error || !name || !allValid}
+  disabled={error || !name || (rows.length && !allValid)}
 >
   <Input
     data-cy="table-name-input"


### PR DESCRIPTION
Oversight by me on the previous JSON import PR, the validation on the button to create the table basically always assumed you were importing data; this PR fixes that.