### PR TITLE
Do not set sort column if display is formula

### DIFF
--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -683,7 +683,7 @@ export class ExternalRequest {
     )
     //if the sort column is a formula, remove it
     for (let sortColumn of Object.keys(sort || {})) {
-      if (table.schema[sortColumn].type === "formula") {
+      if (table.schema[sortColumn]?.type === "formula") {
         delete sort?.[sortColumn]
       }
     }

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -681,6 +681,12 @@ export class ExternalRequest {
       config,
       table
     )
+    //if the sort column is a formula, remove it
+    for (let sortColumn of Object.keys(sort || {})) {
+      if (table.schema[sortColumn].type === "formula") {
+        delete sort?.[sortColumn]
+      }
+    }
     filters = buildFilters(id, filters || {}, table)
     const relationships = this.buildRelationships(table)
     // clean up row on ingress using schema


### PR DESCRIPTION
## Description
SQL Order By clause was failing because formulas are dynamic (not actually present in the underlying table) for external DBs. 
Now checking that if the formula is dynamic, then don't try to order the columns. In this rare case the user will have to manually choose a sort column if they want their data to be sorted at all.

Addresses: 
- https://github.com/Budibase/budibase/issues/9377



