### PR TITLE
Fix certain types of popover not working inside modals or side panels

### DIFF
--- a/packages/bbui/src/Popover/Popover.svelte
+++ b/packages/bbui/src/Popover/Popover.svelte
@@ -68,7 +68,10 @@
     <div
       tabindex="0"
       use:positionDropdown={{ anchor, align, maxWidth, useAnchorWidth }}
-      use:clickOutside={handleOutsideClick}
+      use:clickOutside={{
+        callback: handleOutsideClick,
+        anchor,
+      }}
       on:keydown={handleEscape}
       class={"spectrum-Popover is-open " + (tooltipClasses || "")}
       role="presentation"


### PR DESCRIPTION
## Description
This PR fixes a few issues with popovers, modals and side panels. The non working scenarios were:
- Multi-selects inside modals would not close when clicking outside the picker, but in the modal (in prod)
- Any sort of popover inside a side panel would trigger the side panel to close when selected (in dev)

Addresses: 
- #9422 



