### PR TITLE
Fix/elastic search delete

### DIFF
--- a/packages/bbui/src/Form/Core/EnvDropdown.svelte
+++ b/packages/bbui/src/Form/Core/EnvDropdown.svelte
@@ -247,10 +247,6 @@
     width: 100%;
   }
 
-  .no-variables-height {
-    height: 100px;
-  }
-
   .no-variables-text {
     padding: var(--spacing-m);
     color: var(--spectrum-global-color-gray-600);

--- a/packages/server/src/integrations/elasticsearch.ts
+++ b/packages/server/src/integrations/elasticsearch.ts
@@ -164,12 +164,12 @@ class ElasticSearchIntegration implements IntegrationBase {
     }
   }
 
-  async delete(query: { id: string; index: string; }) {
+  async delete(query: { id: string; index: string }) {
     const { id, index } = query
     try {
       const result = await this.client.delete({
         id,
-        index
+        index,
       })
       return result.body
     } catch (err) {

--- a/packages/server/src/integrations/elasticsearch.ts
+++ b/packages/server/src/integrations/elasticsearch.ts
@@ -80,11 +80,11 @@ const SCHEMA: Integration = {
     delete: {
       type: QueryType.FIELDS,
       fields: {
-        index: {
+        id: {
           type: DatasourceFieldType.STRING,
           required: true,
         },
-        id: {
+        index: {
           type: DatasourceFieldType.STRING,
           required: true,
         },
@@ -164,9 +164,13 @@ class ElasticSearchIntegration implements IntegrationBase {
     }
   }
 
-  async delete(query: object) {
+  async delete(query: { id: string; index: string; }) {
+    const { id, index } = query
     try {
-      const result = await this.client.delete(query)
+      const result = await this.client.delete({
+        id,
+        index
+      })
       return result.body
     } catch (err) {
       console.error("Error deleting from elasticsearch", err)


### PR DESCRIPTION
## Description
Wasn't able to successfully delete a document after switching from an Update. The json field was kept around and throwing an illegal argument error, so the change forces the delete method to only use **id** and **index** as params.

Had to remove a css selector for linting reasons in EnvDropdown. 

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



