### PR TITLE
Generate bindings for unsaved "Update State" actions

### DIFF
--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -509,21 +509,24 @@ const getSelectedRowsBindings = asset => {
   return bindings
 }
 
+export const makeStateBinding = key => {
+  return {
+    type: "context",
+    runtimeBinding: `${makePropSafe("state")}.${makePropSafe(key)}`,
+    readableBinding: `State.${key}`,
+    category: "State",
+    icon: "AutomatedSegment",
+    display: { name: key },
+  }
+}
+
 /**
  * Gets all state bindings that are globally available.
  */
 const getStateBindings = () => {
   let bindings = []
   if (get(store).clientFeatures?.state) {
-    const safeState = makePropSafe("state")
-    bindings = getAllStateVariables().map(key => ({
-      type: "context",
-      runtimeBinding: `${safeState}.${makePropSafe(key)}`,
-      readableBinding: `State.${key}`,
-      category: "State",
-      icon: "AutomatedSegment",
-      display: { name: key },
-    }))
+    bindings = getAllStateVariables().map(makeStateBinding)
   }
   return bindings
 }

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/UpdateState.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/UpdateState.svelte
@@ -2,7 +2,10 @@
   import { Select, Label, Combobox, Checkbox, Body } from "@budibase/bbui"
   import { onMount } from "svelte"
   import DrawerBindableInput from "components/common/bindings/DrawerBindableInput.svelte"
-  import { getAllStateVariables } from "builderStore/dataBinding"
+  import {
+    getAllStateVariables,
+    makeStateBinding,
+  } from "builderStore/dataBinding"
 
   export let parameters
   export let bindings = []
@@ -18,6 +21,15 @@
       value: "delete",
     },
   ]
+
+  $: enrichedBindings = getEnrichedBindings(bindings, parameters.key)
+
+  // Checks if the binding list contains a state binding for this action's key,
+  // and appends it if not
+  const getEnrichedBindings = (bindings, key) => {
+    const hasKey = !!bindings.find(x => x.runtimeBinding === `[state].[${key}]`)
+    return hasKey || !key ? bindings : [...bindings, makeStateBinding(key)]
+  }
 
   onMount(() => {
     if (!parameters.type) {
@@ -38,7 +50,7 @@
   {#if parameters.type === "set"}
     <Label small>Value</Label>
     <DrawerBindableInput
-      {bindings}
+      bindings={enrichedBindings}
       value={parameters.value}
       on:change={e => (parameters.value = e.detail)}
     />

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/UpdateState.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/UpdateState.svelte
@@ -27,8 +27,11 @@
   // Checks if the binding list contains a state binding for this action's key,
   // and appends it if not
   const getEnrichedBindings = (bindings, key) => {
-    const hasKey = !!bindings.find(x => x.runtimeBinding === `[state].[${key}]`)
-    return hasKey || !key ? bindings : [...bindings, makeStateBinding(key)]
+    const ownBinding = makeStateBinding(key)
+    const hasKey = !!bindings.find(binding => {
+      return binding.runtimeBinding === ownBinding.runtimeBinding
+    })
+    return hasKey || !key ? bindings : [...bindings, ownBinding]
   }
 
   onMount(() => {

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/UpdateState.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/UpdateState.svelte
@@ -2,10 +2,7 @@
   import { Select, Label, Combobox, Checkbox, Body } from "@budibase/bbui"
   import { onMount } from "svelte"
   import DrawerBindableInput from "components/common/bindings/DrawerBindableInput.svelte"
-  import {
-    getAllStateVariables,
-    makeStateBinding,
-  } from "builderStore/dataBinding"
+  import { getAllStateVariables } from "builderStore/dataBinding"
 
   export let parameters
   export let bindings = []
@@ -21,18 +18,6 @@
       value: "delete",
     },
   ]
-
-  $: enrichedBindings = getEnrichedBindings(bindings, parameters.key)
-
-  // Checks if the binding list contains a state binding for this action's key,
-  // and appends it if not
-  const getEnrichedBindings = (bindings, key) => {
-    const ownBinding = makeStateBinding(key)
-    const hasKey = bindings.some(binding => {
-      return binding.runtimeBinding === ownBinding.runtimeBinding
-    })
-    return hasKey || !key ? bindings : [...bindings, ownBinding]
-  }
 
   onMount(() => {
     if (!parameters.type) {
@@ -53,7 +38,7 @@
   {#if parameters.type === "set"}
     <Label small>Value</Label>
     <DrawerBindableInput
-      bindings={enrichedBindings}
+      {bindings}
       value={parameters.value}
       on:change={e => (parameters.value = e.detail)}
     />

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/UpdateState.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/UpdateState.svelte
@@ -28,7 +28,7 @@
   // and appends it if not
   const getEnrichedBindings = (bindings, key) => {
     const ownBinding = makeStateBinding(key)
-    const hasKey = !!bindings.find(binding => {
+    const hasKey = bindings.some(binding => {
       return binding.runtimeBinding === ownBinding.runtimeBinding
     })
     return hasKey || !key ? bindings : [...bindings, ownBinding]


### PR DESCRIPTION
## Description
This PR ensures that bindings are generated for all state entries, including newly created and unsaved ones, and makes them available to all button actions.

Good write up is documented in https://github.com/Budibase/budibase/pull/9505.

Addresses: 
- #9502


