### PR TITLE
Fix formatting on alb-ingress.yml

### DIFF
--- a/charts/budibase/templates/alb-ingress.yaml
+++ b/charts/budibase/templates/alb-ingress.yaml
@@ -14,9 +14,9 @@ metadata:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn }} 
     {{- end }}
-    {{ - if .Values.ingress.securityGroups }}
+    {{- if .Values.ingress.securityGroups }}
     alb.ingress.kubernetes.io/security-groups: {{ .Values.ingress.securityGroups }}
-    {{ - end }}
+    {{- end }}
 spec:
   rules:
     - http:


### PR DESCRIPTION
## Description
Fix formatting on alb-ingress.yml

Addresses: 
-  Build issue on master: https://github.com/Budibase/budibase/actions/runs/4074054361/jobs/7018746784

```
Error: UPGRADE FAILED: parse error at (budibase/templates/alb-ingress.yaml:17): "-"
```

