### PR TITLE
Builder bug fixes

### DIFF
--- a/packages/builder/src/components/common/bindings/DrawerBindableCombobox.svelte
+++ b/packages/builder/src/components/common/bindings/DrawerBindableCombobox.svelte
@@ -22,6 +22,7 @@
 
   const dispatch = createEventDispatcher()
   let bindingDrawer
+  let valid = true
 
   $: readableValue = runtimeToReadableBinding(bindings, value)
   $: tempValue = readableValue
@@ -76,12 +77,15 @@
   <svelte:fragment slot="description">
     Add the objects on the left to enrich your text.
   </svelte:fragment>
-  <Button cta slot="buttons" on:click={handleClose}>Save</Button>
+  <Button cta slot="buttons" on:click={handleClose} disabled={!valid}>
+    Save
+  </Button>
   <svelte:component
     this={panel}
     slot="body"
     value={readableValue}
     close={handleClose}
+    bind:valid
     on:change={event => (tempValue = event.detail)}
     {bindings}
     {allowJS}

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionDrawer.svelte
@@ -118,6 +118,10 @@
   const getAllBindings = (bindings, eventContextBindings, actions) => {
     let allBindings = eventContextBindings.concat(bindings)
 
+    if (!actions) {
+      return []
+    }
+
     // Ensure bindings are generated for all "update state" action keys
     actions
       .filter(action => {

--- a/packages/worker/src/api/controllers/global/configs.ts
+++ b/packages/worker/src/api/controllers/global/configs.ts
@@ -267,7 +267,7 @@ export async function publicSettings(ctx: Ctx) {
 
     // enrich the logo url
     // empty url means deleted
-    if (config.config.logoUrl !== "") {
+    if (config.config.logoUrl && config.config.logoUrl !== "") {
       config.config.logoUrl = objectStore.getGlobalFileUrl(
         "settings",
         "logoUrl",


### PR DESCRIPTION
## Description

- An invalid handlebars expression in the binding panel will now disable the save button and allow the user to correct the expression
- When no logo image is specifically defined, the logoUrl will remain empty allowing the branding to default to the Budibase logo SVG.
- Fixes issues where adding a new button to a screen and clicking `Define Actions` would crash the builder

Addresses: 
- https://github.com/Budibase/budibase/issues/8329
- https://github.com/Budibase/budibase/issues/9444
