### PR TITLE
Ensure port input is a string type to support environment variables

### DIFF
--- a/packages/builder/src/components/backend/DatasourceNavigator/TableIntegrationMenu/IntegrationConfigForm.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/TableIntegrationMenu/IntegrationConfigForm.svelte
@@ -177,7 +177,7 @@
           <EnvDropdown
             showModal={() => showModal(configKey)}
             variables={$environment.variables}
-            type={schema[configKey].type}
+            type={configKey === "port" ? "string" : schema[configKey].type}
             on:change
             bind:value={config[configKey]}
             error={$validation.errors[configKey]}


### PR DESCRIPTION
## Description
Need to ensure the port field type is `string`, else it won't display the environment variable (number field will strip strings)

