### PR TITLE
Set DISABLE_ACCOUNT_PORTAL=1 by default in local dev

### DIFF
--- a/packages/server/scripts/dev/manage.js
+++ b/packages/server/scripts/dev/manage.js
@@ -36,7 +36,7 @@ async function init() {
       COUCH_DB_PASSWORD: "budibase",
       COUCH_DB_USER: "budibase",
       SELF_HOSTED: 1,
-      DISABLE_ACCOUNT_PORTAL: "",
+      DISABLE_ACCOUNT_PORTAL: 1,
       MULTI_TENANCY: "",
       DISABLE_THREADING: 1,
       SERVICE: "app-service",

--- a/packages/worker/scripts/dev/manage.js
+++ b/packages/worker/scripts/dev/manage.js
@@ -21,7 +21,7 @@ async function init() {
       COUCH_DB_PASSWORD: "budibase",
       // empty string is false
       MULTI_TENANCY: "",
-      DISABLE_ACCOUNT_PORTAL: "",
+      DISABLE_ACCOUNT_PORTAL: 1,
       ACCOUNT_PORTAL_URL: "http://localhost:10001",
       ACCOUNT_PORTAL_API_KEY: "budibase",
       PLATFORM_URL: "http://localhost:10000",


### PR DESCRIPTION
## Description
Set DISABLE_ACCOUNT_PORTAL=1 by default in local dev

Addresses: 
Error seen in local dev:
```
@budibase/server:       "message": "request to http://localhost:10001/api/users/us_749a6c5c77364da8981f9ba4974f3351/activity failed, reason: connect ECONNREFUSED 127.0.0.1:10001",
```

