### PR TITLE
Parse field type configuration for invalid characters

### DIFF
--- a/packages/builder/src/components/design/settings/componentSettings.js
+++ b/packages/builder/src/components/design/settings/componentSettings.js
@@ -56,7 +56,7 @@ const componentMap = {
   "field/link": FormFieldSelect,
   "field/array": FormFieldSelect,
   "field/json": FormFieldSelect,
-  "field/barcode/qr": FormFieldSelect,
+  "field/barcodeqr": FormFieldSelect,
   // Some validation types are the same as others, so not all types are
   // explicitly listed here. e.g. options uses string validation
   "validation/string": ValidationEditor,

--- a/packages/builder/src/components/design/settings/controls/FormFieldSelect.svelte
+++ b/packages/builder/src/components/design/settings/controls/FormFieldSelect.svelte
@@ -25,16 +25,21 @@
   const getOptions = (schema, type) => {
     let entries = Object.entries(schema ?? {})
     let types = []
-    if (type === "field/options" || type === "field/barcode/qr") {
+    if (type === "field/options") {
       // allow options to be used on both options and string fields
       types = [type, "field/string"]
     } else {
       types = [type]
     }
 
-    types = types.map(type => type.slice(type.indexOf("/") + 1))
+    types = types.map(type => {
+      let fieldTypeRaw = type.slice(type.indexOf("/") + 1)
+      let fieldTypeParsed = fieldTypeRaw.replace("/", "")
+      return fieldTypeParsed
+    })
 
     entries = entries.filter(entry => types.includes(entry[1].type))
+
     return entries.map(entry => entry[0])
   }
 </script>

--- a/packages/builder/src/components/design/settings/controls/FormFieldSelect.svelte
+++ b/packages/builder/src/components/design/settings/controls/FormFieldSelect.svelte
@@ -32,11 +32,7 @@
       types = [type]
     }
 
-    types = types.map(type => {
-      let fieldTypeRaw = type.slice(type.indexOf("/") + 1)
-      let fieldTypeParsed = fieldTypeRaw.replace("/", "")
-      return fieldTypeParsed
-    })
+    types = types.map(type => type.slice(type.indexOf("/") + 1))
 
     entries = entries.filter(entry => types.includes(entry[1].type))
 

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -3241,7 +3241,7 @@
     },
     "settings": [
       {
-        "type": "field/barcode/qr",
+        "type": "field/barcodeqr",
         "label": "Field",
         "key": "field",
         "required": true


### PR DESCRIPTION
## Description

The field type configuration for the barcode reader was not being parsed correctly. The field `type` string is now stripped of any invalid characters.

Addresses: 
- https://github.com/Budibase/budibase/issues/9523


