### PR TITLE
Fix Import Validations

### DIFF
--- a/packages/builder/src/components/backend/TableNavigator/TableDataImport.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/TableDataImport.svelte
@@ -94,6 +94,11 @@
 
     validateHash = newValidateHash
   }
+
+  const handleChange = (name, e) => {
+    schema[name].type = e.detail
+    schema[name].constraints = FIELDS[e.detail.toUpperCase()].constraints
+  }
 </script>
 
 <div class="dropzone">
@@ -118,12 +123,12 @@
 </div>
 {#if rows.length > 0 && !error}
   <div class="schema-fields">
-    {#each Object.values(schema) as column}
+    {#each Object.entries(schema) as [name, column]}
       <div class="field">
         <span>{column.name}</span>
         <Select
           bind:value={column.type}
-          on:change={e => (column.type = e.detail)}
+          on:change={e => handleChange(name, e)}
           options={typeOptions}
           placeholder={null}
           getOptionLabel={option => option.label}


### PR DESCRIPTION
We previously weren't updating the constraints of the schema when a new field type was selected in the import modal. This meant that every field had the string type validation applied to it. This should fix that issue.