### PR TITLE
Fixes for multiple issues

### DIFF
--- a/packages/bbui/src/Form/Core/EnvDropdown.svelte
+++ b/packages/bbui/src/Form/Core/EnvDropdown.svelte
@@ -25,7 +25,7 @@
   let open = false
 
   //eslint-disable-next-line
-  const STRIP_NAME_REGEX = /(?<=\.)(.*?)(?=\ })/g
+  const STRIP_NAME_REGEX = /(\w+?)(?=\ })/g
 
   // Strips the name out of the value which is {{ env.Variable }} resulting in an array like ["Variable"]
   $: hbsValue = String(value)?.match(STRIP_NAME_REGEX) || []

--- a/packages/builder/src/components/automation/SetupPanel/RowSelector.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/RowSelector.svelte
@@ -70,7 +70,7 @@
       return Number(value)
     }
     if (type === "options") {
-      return [value]
+      return value
     }
     if (type === "array") {
       if (Array.isArray(value)) {

--- a/packages/builder/src/stores/portal/environment.js
+++ b/packages/builder/src/stores/portal/environment.js
@@ -1,6 +1,7 @@
-import { writable } from "svelte/store"
+import { writable, get } from "svelte/store"
 import { API } from "api"
 import { Constants } from "@budibase/frontend-core"
+import { licensing } from "stores/portal"
 
 export function createEnvironmentStore() {
   const { subscribe, update } = writable({
@@ -17,12 +18,14 @@ export function createEnvironmentStore() {
   }
 
   async function loadVariables() {
-    const envVars = await API.fetchEnvironmentVariables()
-    const mappedVars = envVars.variables.map(name => ({ name }))
-    update(store => {
-      store.variables = mappedVars
-      return store
-    })
+    if (get(licensing).environmentVariablesEnabled) {
+      const envVars = await API.fetchEnvironmentVariables()
+      const mappedVars = envVars.variables.map(name => ({ name }))
+      update(store => {
+        store.variables = mappedVars
+        return store
+      })
+    }
   }
 
   async function createVariable(data) {

--- a/qa-core/src/config/internal-api/TestConfiguration/applications.ts
+++ b/qa-core/src/config/internal-api/TestConfiguration/applications.ts
@@ -112,7 +112,7 @@ export default class AppApi {
 
   async delete(appId: string): Promise<Response> {
     const response = await this.api.del(`/applications/${appId}`)
-    expect(response).toHaveStatusCode(204)
+    expect(response).toHaveStatusCode(200)
     return response
   }
 


### PR DESCRIPTION
## Description
Fixes for three issues: 

 - Bad regex was breaking the whole application in safari, updated and tested working correctly in all main browsers
 - Switching between bindings and value inputs in automations breaking due to us coercing the value to an array.
 - We were attempting to load env vars in some locations whern a license wasn't enabled - handling this at the store level

Addresses: 
#8948 





