### PR TITLE
stop chrome autofilling login when adding environment variable

### DIFF
--- a/packages/bbui/src/Form/Core/TextField.svelte
+++ b/packages/bbui/src/Form/Core/TextField.svelte
@@ -13,6 +13,7 @@
   export let quiet = false
   export let align
   export let autofocus = false
+  export let autocomplete = null
 
   const dispatch = createEventDispatcher()
 
@@ -103,6 +104,7 @@
     class="spectrum-Textfield-input"
     style={align ? `text-align: ${align};` : ""}
     inputmode={type === "number" ? "decimal" : "text"}
+    {autocomplete}
   />
 </div>
 

--- a/packages/bbui/src/Form/Input.svelte
+++ b/packages/bbui/src/Form/Input.svelte
@@ -14,6 +14,7 @@
   export let updateOnChange = true
   export let quiet = false
   export let autofocus
+  export let autocomplete
 
   const dispatch = createEventDispatcher()
   const onChange = e => {
@@ -33,6 +34,7 @@
     {type}
     {quiet}
     {autofocus}
+    {autocomplete}
     on:change={onChange}
     on:click
     on:input

--- a/packages/builder/src/components/portal/environment/CreateEditVariableModal.svelte
+++ b/packages/builder/src/components/portal/environment/CreateEditVariableModal.svelte
@@ -71,6 +71,7 @@
         }
       }}
       value={productionValue}
+      autocomplete="new-password"
     />
   </div>
   <div>
@@ -83,6 +84,7 @@
       disabled={useProductionValue}
       label="Value"
       value={useProductionValue ? productionValue : developmentValue}
+      autocomplete="new-password"
     />
     <Checkbox bind:value={useProductionValue} text="Use production value" />
   </div>


### PR DESCRIPTION
## Description
Chrome was autofilling account email and password when adding a new environment variable.

Addresses: 
closes #9569 

## Screenshots
![fix recording](https://user-images.githubusercontent.com/110921612/217324634-f9c9cdd2-bc31-40c0-bcb2-527fe971e6b7.gif)


## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



