### PR TITLE
Relationship picker improvments

### DIFF
--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -337,13 +337,20 @@ export class ExternalRequest {
       if (!linkedTable || !row[relationship.column]) {
         continue
       }
+
       const display = linkedTable.primaryDisplay
       for (let key of Object.keys(row[relationship.column])) {
         const related: Row = row[relationship.column][key]
-        row[relationship.column][key] = {
+        const squashed: Record<string, any> = {
           primaryDisplay: display ? related[display] : undefined,
           _id: related._id,
         }
+        for (let key of linkedTable.primary!) {
+          if (related[key]) {
+            squashed['data'] = related
+          }
+        }
+        row[relationship.column][key] = squashed
       }
     }
     return row


### PR DESCRIPTION
Aims to solve [#9405](https://github.com/Budibase/budibase/issues/9405)

After discussing the issue, we came to the conclusion that a lot of the issues raised could be solved by simply nesting repeater blocks or data provider components, which would allow access to the raw columns of a table without the end-user needing to be able to parse the `_id` field or know how it is composed. 

For convenience though, we thought it might be a good idea to expose some of the fields of the related field on the relationship document so that multiple queries aren't needed, I opted to just add a new `data` property that contains the related row, the relationship document now looks like this:

```
{"primaryDisplay":1,"_id":"%5B1%5D","data":{"author_id":1,"id":1,"title":"Book 1","_id":"%5B1%5D","tableId":"datasource_plus_21955135edc14379a87530dc50904b07__books","_rev":"rev"}}]
```