### PR TITLE
Bump CI default unit test timeout to 10s

### DIFF
--- a/packages/server/src/tests/jestSetup.ts
+++ b/packages/server/src/tests/jestSetup.ts
@@ -10,7 +10,9 @@ if (!process.env.DEBUG) {
 if (!process.env.CI) {
   // set a longer timeout in dev for debugging
   // 100 seconds
-  jest.setTimeout(100000)
+  jest.setTimeout(100 * 1000)
+} else {
+  jest.setTimeout(10 * 1000)
 }
 
 testContainerUtils.setupEnv(env, coreEnv)

--- a/packages/worker/src/tests/jestSetup.ts
+++ b/packages/worker/src/tests/jestSetup.ts
@@ -18,7 +18,9 @@ if (!process.env.DEBUG) {
 if (!process.env.CI) {
   // set a longer timeout in dev for debugging
   // 100 seconds
-  jest.setTimeout(100000)
+  jest.setTimeout(100 * 1000)
+} else {
+  jest.setTimeout(10 * 1000)
 }
 
 testContainerUtils.setupEnv(env, coreEnv)


### PR DESCRIPTION
## Description
Bump CI default unit test timeout to 10s

Addresses: 
- Intermittent timeout issues on CI and release runs e..g: https://github.com/Budibase/budibase/actions/runs/4117279294/jobs/7108394255



