### PR TITLE
Date filter freeze fix

### DIFF
--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -101,7 +101,7 @@
   }
 
   const getSchema = filter => {
-    return schemaFields.find(field => field.name === filter.field)
+    return enrichedSchemaFields.find(field => field.name === filter.field)
   }
 
   const santizeTypes = filter => {

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -243,6 +243,19 @@ class InternalBuilder {
     }
     if (filters.range) {
       iterate(filters.range, (key, value) => {
+        const isEmptyObject = (val: any) => {
+          return (
+            val &&
+            Object.keys(val).length === 0 &&
+            Object.getPrototypeOf(val) === Object.prototype
+          )
+        }
+        if (isEmptyObject(value.low)) {
+          value.low = ""
+        }
+        if (isEmptyObject(value.high)) {
+          value.high = ""
+        }
         if (value.low && value.high) {
           // Use a between operator if we have 2 valid range values
           const fnc = allOr ? "orWhereBetween" : "whereBetween"

--- a/packages/server/src/integrations/tests/sql.spec.ts
+++ b/packages/server/src/integrations/tests/sql.spec.ts
@@ -553,4 +553,42 @@ describe("SQL query builder", () => {
       sql: `select * from (select top (@p0) * from [${tableName}] where LOWER([${tableName}].[name]) LIKE @p1) as [${tableName}]`,
     })
   })
+
+  it("should ignore high range value if it is an empty object", () => {
+    const query = sql._query(
+      generateReadJson({
+        filters: {
+          range: {
+            dob: {
+              low: "2000-01-01 00:00:00",
+              high: {},
+            },
+          },
+        },
+      })
+    )
+    expect(query).toEqual({
+      bindings: ["2000-01-01 00:00:00", 500],
+      sql: `select * from (select * from \"${TABLE_NAME}\" where \"${TABLE_NAME}\".\"dob\" > $1 limit $2) as \"${TABLE_NAME}\"`,
+    })
+  })
+
+  it("should ignore low range value if it is an empty object", () => {
+    const query = sql._query(
+      generateReadJson({
+        filters: {
+          range: {
+            dob: {
+              low: {},
+              high: "2010-01-01 00:00:00",
+            },
+          },
+        },
+      })
+    )
+    expect(query).toEqual({
+      bindings: ["2010-01-01 00:00:00", 500],
+      sql: `select * from (select * from \"${TABLE_NAME}\" where \"${TABLE_NAME}\".\"dob\" < $1 limit $2) as \"${TABLE_NAME}\"`,
+    })
+  })
 })


### PR DESCRIPTION
## Description
When doing a SQL filter on a date, the app was crashing because the schema fields were not including the relationship fields.
In addition, found a bug were `{}` was being passed as a value into the range. This was causing query issues. 
Wasn't able to find exactly what/were the invalid date (0000 or 9999) was being converted to an empty object - think it may have been in Knex. 
I updated the `sql.ts` code to handle empty objects. 

Addresses: 
- https://github.com/Budibase/budibase/issues/9406

## Screenshots
![Screenshot 2023-02-09 at 19 26 02](https://user-images.githubusercontent.com/101575380/217916906-85da1959-ffd9-4761-958a-29fb330e78eb.png)

![Screenshot 2023-02-09 at 19 26 20](https://user-images.githubusercontent.com/101575380/217916962-69839db1-7914-4800-a253-96acdbc70d05.png)

![Screenshot 2023-02-09 at 19 26 47](https://user-images.githubusercontent.com/101575380/217917062-30436b83-62a2-43cd-acc9-7908d9c8f0fe.png)



