### PR TITLE
Generate option inclusion constraint

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ComponentSettingsSection.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ComponentSettingsSection.svelte
@@ -147,8 +147,8 @@
               options: setting.options || [],
 
               // Number fields
-              min: setting.min || null,
-              max: setting.max || null,
+              min: setting.min ?? null,
+              max: setting.max ?? null,
             }}
             {bindings}
             {componentBindings}

--- a/packages/server/src/api/controllers/table/utils.ts
+++ b/packages/server/src/api/controllers/table/utils.ts
@@ -110,6 +110,7 @@ function createOptionsSchema(table: any, rows: any[]) {
             .filter(value => value != null && value !== "")
         ),
       ]
+      table.schema[field].constraints.inclusion.sort()
     }
   }
   return table

--- a/packages/server/src/api/controllers/table/utils.ts
+++ b/packages/server/src/api/controllers/table/utils.ts
@@ -95,6 +95,26 @@ export function makeSureTableUpToDate(table: any, tableToSave: any) {
   return tableToSave
 }
 
+function createOptionsSchema(table: any, rows: any[]) {
+  if (!table || !rows?.length) {
+    return table
+  }
+  let field: any
+  let column: any
+  for ([field, column] of Object.entries(table.schema)) {
+    if (column.type === FieldTypes.OPTIONS) {
+      table.schema[field].constraints.inclusion = [
+        ...new Set(
+          rows
+            .map(row => row[field])
+            .filter(value => value != null && value !== "")
+        ),
+      ]
+    }
+  }
+  return table
+}
+
 export function importToRows(data: any, table: any, user: any = {}) {
   let finalData: any = []
   for (let i = 0; i < data.length; i++) {
@@ -225,6 +245,8 @@ class TableSaveFunctions {
   async before(table: any) {
     if (this.oldTable) {
       table = makeSureTableUpToDate(this.oldTable, table)
+    } else {
+      table = createOptionsSchema(table, this.importRows)
     }
     table = checkStaticTables(table)
     return table


### PR DESCRIPTION
## Description
This PR fixes a longstanding issue where options inclusion constraints (i.e. the actual "options" for an options field) are not generated when creating a table from CSV. Currently if you do this, the options field has no "options" in its schema - meaning it's useless and you need to add them all manually.

Also snuck in a tiny fix mentioned by a user on Discord, fixing 0 being treated as null for number setting min and max constraints.

## Technical stuff
The diff might look weird and you might wonder how this fixes anything. The issue was the line `table = processed.table`. This was overriding the real table param and preventing mutation in place from working, so the solution was to delete this line. It was not needed anyway as all table schema mutation is done in place, so the `table` reference was already pointing to the most up to date version. 

The other additions are simply preventing null/empty values going into the schema, and sorting the schema. 

## Screenshots
Video showing the current functionality (no options are generated):

https://user-images.githubusercontent.com/9075550/218050548-cd331ec9-441e-41cb-b121-08a67546d0e9.mp4

Video showing new functionality (options are generated and sorted):

https://user-images.githubusercontent.com/9075550/218051292-7c9ec0dd-e54d-4b81-b17c-b5a3a58b3b93.mp4

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



