### PR TITLE
Fix for environment variable MS-SQL ports

### DIFF
--- a/packages/backend-core/tests/utilities/mocks/licenses.ts
+++ b/packages/backend-core/tests/utilities/mocks/licenses.ts
@@ -74,6 +74,10 @@ export const useGroups = () => {
   return useFeature(Feature.USER_GROUPS)
 }
 
+export const useEnvironmentVariables = () => {
+  return useFeature(Feature.ENVIRONMENT_VARIABLES)
+}
+
 // QUOTAS
 
 export const setAutomationLogsQuota = (value: number) => {

--- a/packages/server/src/api/controllers/datasource.ts
+++ b/packages/server/src/api/controllers/datasource.ts
@@ -14,7 +14,6 @@ import { invalidateDynamicVariables } from "../../threads/utils"
 import { db as dbCore, context, events } from "@budibase/backend-core"
 import { UserCtx, Datasource, Row } from "@budibase/types"
 import sdk from "../../sdk"
-import { mergeConfigs } from "../../sdk/app/datasources/datasources"
 
 export async function fetch(ctx: UserCtx) {
   // Get internal tables

--- a/packages/server/src/integrations/index.ts
+++ b/packages/server/src/integrations/index.ts
@@ -67,6 +67,15 @@ if (
   INTEGRATIONS[SourceName.ORACLE] = oracle.integration
 }
 
+export async function getDefinition(source: SourceName): Promise<Integration> {
+  // check if its integrated, faster
+  if (DEFINITIONS[source]) {
+    return DEFINITIONS[source]
+  }
+  const allDefinitions = await getDefinitions()
+  return allDefinitions[source]
+}
+
 export async function getDefinitions() {
   const pluginSchemas: { [key: string]: Integration } = {}
   if (env.SELF_HOSTED) {

--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -108,9 +108,6 @@ class SqlServerIntegration extends Sql implements DatasourcePlus {
   constructor(config: MSSQLConfig) {
     super(SqlClient.MS_SQL)
     this.config = config
-    if (typeof this.config?.port === "string") {
-      this.config.port = parseInt(this.config.port)
-    }
     const clientCfg = {
       ...this.config,
       options: {

--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -26,7 +26,7 @@ interface MSSQLConfig {
   user: string
   password: string
   server: string
-  port: number
+  port: number | string
   database: string
   schema: string
   encrypt?: boolean
@@ -108,6 +108,9 @@ class SqlServerIntegration extends Sql implements DatasourcePlus {
   constructor(config: MSSQLConfig) {
     super(SqlClient.MS_SQL)
     this.config = config
+    if (typeof this.config?.port === "string") {
+      this.config.port = parseInt(this.config.port)
+    }
     const clientCfg = {
       ...this.config,
       options: {


### PR DESCRIPTION
## Description
Fix issue with MS-SQL, port needs to be a number for the `node-mssql` package, with env vars it isn't anymore.

To fix this, added to the datasource SDK get functionality to check the types against the required integration types.



