### PR TITLE
Add Fetch Row Button Action

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/FetchRow.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/FetchRow.svelte
@@ -1,0 +1,40 @@
+<script>
+  import { Select, Label } from "@budibase/bbui"
+  import { tables } from "stores/backend"
+  import DrawerBindableInput from "components/common/bindings/DrawerBindableInput.svelte"
+
+  export let parameters
+  export let bindings = []
+
+  $: tableOptions = $tables.list || []
+</script>
+
+<div class="root">
+  <Label>Table</Label>
+  <Select
+    bind:value={parameters.tableId}
+    options={tableOptions}
+    getOptionLabel={table => table.name}
+    getOptionValue={table => table._id}
+  />
+
+  <Label small>Row ID</Label>
+  <DrawerBindableInput
+    {bindings}
+    title="Row ID to Fetch"
+    value={parameters.rowId}
+    on:change={value => (parameters.rowId = value.detail)}
+  />
+</div>
+
+<style>
+  .root {
+    display: grid;
+    column-gap: var(--spacing-l);
+    row-gap: var(--spacing-s);
+    grid-template-columns: 60px 1fr;
+    align-items: center;
+    max-width: 800px;
+    margin: 0 auto;
+  }
+</style>

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/index.js
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/index.js
@@ -1,3 +1,4 @@
+export { default as FetchRow } from "./FetchRow.svelte"
 export { default as NavigateTo } from "./NavigateTo.svelte"
 export { default as SaveRow } from "./SaveRow.svelte"
 export { default as DeleteRow } from "./DeleteRow.svelte"

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/manifest.json
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/manifest.json
@@ -28,6 +28,17 @@
       "component": "DeleteRow"
     },
     {
+      "name": "Fetch Row",
+      "type": "data",
+      "component": "FetchRow",
+      "context": [
+        {
+          "label": "Fetched row",
+          "value": "row"
+        }
+      ]
+    },
+    {
       "name": "Navigate To",
       "type": "application",
       "component": "NavigateTo"

--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -87,16 +87,12 @@ const duplicateRowHandler = async (action, context) => {
   }
 }
 
-const fetchRowHandler = async (action) => {
+const fetchRowHandler = async action => {
   const { tableId, rowId } = action.parameters
 
   if (tableId && rowId) {
     try {
       const row = await API.fetchRow({ tableId, rowId })
-      console.log(row)
-      await dataSourceStore.actions.invalidateDataSource(row.tableId, {
-        invalidateRelationships: true,
-      })
 
       return { row }
     } catch (error) {

--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -87,6 +87,24 @@ const duplicateRowHandler = async (action, context) => {
   }
 }
 
+const fetchRowHandler = async (action) => {
+  const { tableId, rowId } = action.parameters
+
+  if (tableId && rowId) {
+    try {
+      const row = await API.fetchRow({ tableId, rowId })
+      console.log(row)
+      await dataSourceStore.actions.invalidateDataSource(row.tableId, {
+        invalidateRelationships: true,
+      })
+
+      return { row }
+    } catch (error) {
+      return false
+    }
+  }
+}
+
 const deleteRowHandler = async action => {
   const { tableId, revId, rowId, notificationOverride } = action.parameters
   if (tableId && rowId) {
@@ -341,6 +359,7 @@ const CloseSidePanelHandler = () => {
 }
 
 const handlerMap = {
+  ["Fetch Row"]: fetchRowHandler,
   ["Save Row"]: saveRowHandler,
   ["Duplicate Row"]: duplicateRowHandler,
   ["Delete Row"]: deleteRowHandler,


### PR DESCRIPTION
[Solves #9405](https://github.com/Budibase/budibase/issues/9405)

We discussed as a team the most of the problems outlined in the above ticket could be solved by nesting data providers.

There were certain scenarios where the hydrated relationship data might be needed within a button event or something similar, and to solve this use case we added an action that when provided with an `_id` will fetch a row.