### PR TITLE
Fix empty display column on CSV import

### DIFF
--- a/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
@@ -105,7 +105,10 @@
   title="Create Table"
   confirmText="Create"
   onConfirm={saveTable}
-  disabled={error || !name || (rows.length && !allValid)}
+  disabled={error ||
+    !name ||
+    (rows.length && !allValid) ||
+    displayColumn == null}
 >
   <Input
     thin

--- a/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
@@ -107,8 +107,7 @@
   onConfirm={saveTable}
   disabled={error ||
     !name ||
-    (rows.length && !allValid) ||
-    displayColumn == null}
+    (rows.length && (!allValid || displayColumn == null))}
 >
   <Input
     thin


### PR DESCRIPTION
## Description
If you do not select a display column when importing a CSV (below)
<img width="545" alt="Screenshot 2023-02-11 at 13 08 46" src="https://user-images.githubusercontent.com/11256663/218259735-ec851ca6-38cd-44b5-a289-1313c5ff0218.png">

- All columns are shown as the table display column
- you cannot edit the table display column from the UI for any of these columns. 
 
This PR ensures that you must set a display column when importing any table from CSV before importing or the create buton should be disabled, should fix the issue for users who do not set their display column.

Addresses: 
- https://github.com/Budibase/budibase/issues/9660

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.

This bug affects this tutorial https://docs.budibase.com/docs/build-a-crud-app



