### PR TITLE
Configurable test log levels and common error handling

### DIFF
--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -82,6 +82,7 @@ const environment = {
   SESSION_UPDATE_PERIOD: process.env.SESSION_UPDATE_PERIOD,
   DEPLOYMENT_ENVIRONMENT:
     process.env.DEPLOYMENT_ENVIRONMENT || "docker-compose",
+  LOG_4XX: process.env.LOG_4XX,
   _set(key: any, value: any) {
     process.env[key] = value
     // @ts-ignore

--- a/packages/backend-core/src/middleware/errorHandling.ts
+++ b/packages/backend-core/src/middleware/errorHandling.ts
@@ -1,0 +1,28 @@
+import { APIError } from "@budibase/types"
+import * as errors from "../errors"
+import env from "../environment"
+
+export async function errorHandling(ctx: any, next: any) {
+  try {
+    await next()
+  } catch (err: any) {
+    const status = err.status || err.statusCode || 500
+    ctx.status = status
+
+    if (status > 499 || env.LOG_4XX) {
+      ctx.log.error(err)
+    }
+
+    const error = errors.getPublicError(err)
+    const body: APIError = {
+      message: err.message,
+      status: status,
+      validationErrors: err.validation,
+      error,
+    }
+
+    ctx.body = body
+  }
+}
+
+export default errorHandling

--- a/packages/backend-core/src/middleware/index.ts
+++ b/packages/backend-core/src/middleware/index.ts
@@ -1,7 +1,7 @@
 export * as jwt from "./passport/jwt"
 export * as local from "./passport/local"
-export * as google from "./passport/google"
-export * as oidc from "./passport/oidc"
+export * as google from "./passport/sso/google"
+export * as oidc from "./passport/sso/oidc"
 import * as datasourceGoogle from "./passport/datasource/google"
 export const datasource = {
   google: datasourceGoogle,
@@ -16,4 +16,5 @@ export { default as adminOnly } from "./adminOnly"
 export { default as builderOrAdmin } from "./builderOrAdmin"
 export { default as builderOnly } from "./builderOnly"
 export { default as logging } from "./logging"
+export { default as errorHandling } from "./errorHandling"
 export * as joiValidator from "./joi-validator"

--- a/packages/backend-core/tests/jestEnv.ts
+++ b/packages/backend-core/tests/jestEnv.ts
@@ -1,23 +1,5 @@
-import env from "../src/environment"
-import { mocks } from "./utilities"
-
-// must explicitly enable fetch mock
-mocks.fetch.enable()
-
-// mock all dates to 2020-01-01T00:00:00.000Z
-// use tk.reset() to use real dates in individual tests
-import tk from "timekeeper"
-tk.freeze(mocks.date.MOCK_DATE)
-
-env._set("SELF_HOSTED", "1")
-env._set("NODE_ENV", "jest")
-
-if (!process.env.DEBUG) {
-  global.console.log = jest.fn() // console.log are ignored in tests
-}
-
-if (!process.env.CI) {
-  // set a longer timeout in dev for debugging
-  // 100 seconds
-  jest.setTimeout(100000)
-}
+process.env.SELF_HOSTED = "1"
+process.env.MULTI_TENANCY = "1"
+process.env.NODE_ENV = "jest"
+process.env.MOCK_REDIS = "1"
+process.env.LOG_LEVEL = process.env.LOG_LEVEL || "error"

--- a/packages/backend-core/tests/jestSetup.ts
+++ b/packages/backend-core/tests/jestSetup.ts
@@ -1,4 +1,23 @@
+import "./logging"
 import env from "../src/environment"
-import { testContainerUtils } from "./utilities"
+import { mocks, testContainerUtils } from "./utilities"
+
+// must explicitly enable fetch mock
+mocks.fetch.enable()
+
+// mock all dates to 2020-01-01T00:00:00.000Z
+// use tk.reset() to use real dates in individual tests
+import tk from "timekeeper"
+tk.freeze(mocks.date.MOCK_DATE)
+
+if (!process.env.DEBUG) {
+  console.log = jest.fn() // console.log are ignored in tests
+}
+
+if (!process.env.CI) {
+  // set a longer timeout in dev for debugging
+  // 100 seconds
+  jest.setTimeout(100000)
+}
 
 testContainerUtils.setupEnv(env)

--- a/packages/backend-core/tests/logging.ts
+++ b/packages/backend-core/tests/logging.ts
@@ -1,0 +1,34 @@
+export enum LogLevel {
+  TRACE = "trace",
+  DEBUG = "debug",
+  INFO = "info",
+  WARN = "warn",
+  ERROR = "error",
+}
+
+const LOG_INDEX: { [key in LogLevel]: number } = {
+  [LogLevel.TRACE]: 1,
+  [LogLevel.DEBUG]: 2,
+  [LogLevel.INFO]: 3,
+  [LogLevel.WARN]: 4,
+  [LogLevel.ERROR]: 5,
+}
+
+const setIndex = LOG_INDEX[process.env.LOG_LEVEL as LogLevel]
+
+if (setIndex > LOG_INDEX.trace) {
+  global.console.trace = jest.fn()
+}
+
+if (setIndex > LOG_INDEX.debug) {
+  global.console.debug = jest.fn()
+}
+
+if (setIndex > LOG_INDEX.info) {
+  global.console.info = jest.fn()
+  global.console.log = jest.fn()
+}
+
+if (setIndex > LOG_INDEX.warn) {
+  global.console.warn = jest.fn()
+}

--- a/packages/server/src/tests/jestEnv.ts
+++ b/packages/server/src/tests/jestEnv.ts
@@ -1,9 +1,9 @@
-import env from "../environment"
 import { tmpdir } from "os"
 
-env._set("SELF_HOSTED", "1")
-env._set("NODE_ENV", "jest")
-env._set("MULTI_TENANCY", "1")
+process.env.SELF_HOSTED = "1"
+process.env.NODE_ENV = "jest"
+process.env.MULTI_TENANCY = "1"
 // @ts-ignore
-env._set("BUDIBASE_DIR", tmpdir("budibase-unittests"))
-env._set("LOG_LEVEL", "silent")
+process.env.BUDIBASE_DIR = tmpdir("budibase-unittests")
+process.env.LOG_LEVEL = process.env.LOG_LEVEL || "error"
+process.env.MOCK_REDIS = "1"

--- a/packages/server/src/tests/jestSetup.ts
+++ b/packages/server/src/tests/jestSetup.ts
@@ -1,3 +1,4 @@
+import "./logging"
 import env from "../environment"
 import { env as coreEnv } from "@budibase/backend-core"
 import { testContainerUtils } from "@budibase/backend-core/tests"

--- a/packages/server/src/tests/logging.ts
+++ b/packages/server/src/tests/logging.ts
@@ -1,0 +1,34 @@
+export enum LogLevel {
+  TRACE = "trace",
+  DEBUG = "debug",
+  INFO = "info",
+  WARN = "warn",
+  ERROR = "error",
+}
+
+const LOG_INDEX: { [key in LogLevel]: number } = {
+  [LogLevel.TRACE]: 1,
+  [LogLevel.DEBUG]: 2,
+  [LogLevel.INFO]: 3,
+  [LogLevel.WARN]: 4,
+  [LogLevel.ERROR]: 5,
+}
+
+const setIndex = LOG_INDEX[process.env.LOG_LEVEL as LogLevel]
+
+if (setIndex > LOG_INDEX.trace) {
+  global.console.trace = jest.fn()
+}
+
+if (setIndex > LOG_INDEX.debug) {
+  global.console.debug = jest.fn()
+}
+
+if (setIndex > LOG_INDEX.info) {
+  global.console.info = jest.fn()
+  global.console.log = jest.fn()
+}
+
+if (setIndex > LOG_INDEX.warn) {
+  global.console.warn = jest.fn()
+}

--- a/packages/types/src/api/web/errors.ts
+++ b/packages/types/src/api/web/errors.ts
@@ -2,4 +2,5 @@ export interface APIError {
   message: string
   status: number
   error?: any
+  validationErrors?: any
 }

--- a/packages/worker/src/api/routes/system/tests/migrations.spec.ts
+++ b/packages/worker/src/api/routes/system/tests/migrations.spec.ts
@@ -30,7 +30,7 @@ describe("/api/system/migrations", () => {
         headers: {},
         status: 403,
       })
-      expect(res.text).toBe("Unauthorized - no public worker access")
+      expect(res.body).toEqual({ message: "Unauthorized", status: 403 })
       expect(migrateFn).toBeCalledTimes(0)
     })
 
@@ -47,7 +47,7 @@ describe("/api/system/migrations", () => {
         headers: {},
         status: 403,
       })
-      expect(res.text).toBe("Unauthorized - no public worker access")
+      expect(res.body).toEqual({ message: "Unauthorized", status: 403 })
     })
 
     it("returns definitions", async () => {

--- a/packages/worker/src/middleware/tests/tenancy.spec.ts
+++ b/packages/worker/src/middleware/tests/tenancy.spec.ts
@@ -24,7 +24,7 @@ describe("tenancy middleware", () => {
   })
 
   it("should get tenant id from header", async () => {
-    const tenantId = structures.uuid()
+    const tenantId = structures.tenant.id()
     const headers = {
       [constants.Header.TENANT_ID]: tenantId,
     }
@@ -35,7 +35,7 @@ describe("tenancy middleware", () => {
   })
 
   it("should get tenant id from query param", async () => {
-    const tenantId = structures.uuid()
+    const tenantId = structures.tenant.id()
     const res = await config.request.get(
       `/api/global/configs/checklist?tenantId=${tenantId}`
     )
@@ -43,7 +43,7 @@ describe("tenancy middleware", () => {
   })
 
   it("should get tenant id from subdomain", async () => {
-    const tenantId = structures.uuid()
+    const tenantId = structures.tenant.id()
     const headers = {
       host: `${tenantId}.localhost:10000`,
     }
@@ -67,7 +67,7 @@ describe("tenancy middleware", () => {
   it("should throw when no tenant id is found", async () => {
     const res = await config.request.get(`/api/global/configs/checklist`)
     expect(res.status).toBe(403)
-    expect(res.text).toBe("Tenant id not set")
+    expect(res.body).toEqual({ message: "Tenant id not set", status: 403 })
     expect(res.headers[constants.Header.TENANT_ID]).toBe(undefined)
   })
 })

--- a/packages/worker/src/tests/jestEnv.ts
+++ b/packages/worker/src/tests/jestEnv.ts
@@ -1,7 +1,7 @@
 process.env.SELF_HOSTED = "0"
 process.env.NODE_ENV = "jest"
 process.env.JWT_SECRET = "test-jwtsecret"
-process.env.LOG_LEVEL = "silent"
+process.env.LOG_LEVEL = process.env.LOG_LEVEL || "error"
 process.env.MULTI_TENANCY = "1"
 process.env.MINIO_URL = "http://localhost"
 process.env.MINIO_ACCESS_KEY = "test"

--- a/packages/worker/src/tests/jestSetup.ts
+++ b/packages/worker/src/tests/jestSetup.ts
@@ -1,5 +1,6 @@
-import { mocks, testContainerUtils } from "@budibase/backend-core/tests"
+import "./logging"
 
+import { mocks, testContainerUtils } from "@budibase/backend-core/tests"
 import env from "../environment"
 import { env as coreEnv } from "@budibase/backend-core"
 
@@ -10,10 +11,6 @@ mocks.fetch.enable()
 // use tk.reset() to use real dates in individual tests
 const tk = require("timekeeper")
 tk.freeze(mocks.date.MOCK_DATE)
-
-if (!process.env.DEBUG) {
-  global.console.log = jest.fn() // console.log are ignored in tests
-}
 
 if (!process.env.CI) {
   // set a longer timeout in dev for debugging

--- a/packages/worker/src/tests/logging.ts
+++ b/packages/worker/src/tests/logging.ts
@@ -1,0 +1,34 @@
+export enum LogLevel {
+  TRACE = "trace",
+  DEBUG = "debug",
+  INFO = "info",
+  WARN = "warn",
+  ERROR = "error",
+}
+
+const LOG_INDEX: { [key in LogLevel]: number } = {
+  [LogLevel.TRACE]: 1,
+  [LogLevel.DEBUG]: 2,
+  [LogLevel.INFO]: 3,
+  [LogLevel.WARN]: 4,
+  [LogLevel.ERROR]: 5,
+}
+
+const setIndex = LOG_INDEX[process.env.LOG_LEVEL as LogLevel]
+
+if (setIndex > LOG_INDEX.trace) {
+  global.console.trace = jest.fn()
+}
+
+if (setIndex > LOG_INDEX.debug) {
+  global.console.debug = jest.fn()
+}
+
+if (setIndex > LOG_INDEX.info) {
+  global.console.info = jest.fn()
+  global.console.log = jest.fn()
+}
+
+if (setIndex > LOG_INDEX.warn) {
+  global.console.warn = jest.fn()
+}


### PR DESCRIPTION
## Description

### Error handling

- Add common middleware `errorHandling` 
   - Add to the top of router configuration
   - This ensures all http errors will have a consistent structure
- By default log errors for any error that:
   - Does not have a status
   - is less than 499
- For debugging, add additional flag `LOG_4XX` which will log 404s, 400s, 403 etc.  

### Test log levels
- Add better integration with the existing `LOG_LEVEL` environment variable
- Apply standard rules for log levels to visibility of `console.error`, `console.warn` etc. 
- Set test runs to `error` by default   

Addresses: 
- https://linear.app/budibase/issue/BUDI-6558/configurable-test-log-levels-and-common-error-handling

See also: 
- https://github.com/Budibase/budibase-pro/pull/110


