### PR TITLE
Fix for SQL many-to-many configuration via relationship modal

### DIFF
--- a/hosting/docker-compose.dev.yaml
+++ b/hosting/docker-compose.dev.yaml
@@ -42,25 +42,16 @@ services:
 
   couchdb-service:
     # platform: linux/amd64
-    container_name: budi-couchdb-dev
+    container_name: budi-couchdb3-dev
     restart: on-failure
-    image: ibmcom/couchdb3
+    image: budibase/couchdb
     environment:
       - COUCHDB_PASSWORD=${COUCH_DB_PASSWORD}
       - COUCHDB_USER=${COUCH_DB_USER}
     ports:
       - "${COUCH_DB_PORT}:5984"
     volumes:
-      - couchdb3_data:/opt/couchdb/data
-  
-  couch-init:
-    container_name: budi-couchdb-init-dev
-    image: curlimages/curl
-    environment:
-      PUT_CALL: "curl -u ${COUCH_DB_USER}:${COUCH_DB_PASSWORD} -X PUT couchdb-service:5984"
-    depends_on:
-      - couchdb-service
-    command: ["sh","-c","sleep 10 && $${PUT_CALL}/_users && $${PUT_CALL}/_replicator; fg;"]
+      - couchdb_data:/data
 
   redis-service:
     container_name: budi-redis-dev
@@ -73,7 +64,7 @@ services:
       - redis_data:/data
 
 volumes:
-  couchdb3_data:
+  couchdb_data:
     driver: local
   minio_data:
     driver: local

--- a/packages/builder/src/components/backend/Datasources/CreateEditRelationship.svelte
+++ b/packages/builder/src/components/backend/Datasources/CreateEditRelationship.svelte
@@ -152,7 +152,7 @@
           fromTable,
           throughTable,
           fromTable.primary[0],
-          throughFromKey
+          throughToKey
         ),
       throughToKey:
         errorChecker.manyForeignKeySet(throughToKey) ||
@@ -160,7 +160,7 @@
           toTable,
           throughTable,
           toTable.primary[0],
-          throughToKey
+          throughFromKey
         ),
       fromForeign:
         errorChecker.foreignKeySet(fromForeign) ||
@@ -391,24 +391,14 @@
         options={Object.keys(getTable(throughId)?.schema)}
         bind:value={throughToKey}
         bind:error={errors.throughToKey}
-        on:change={e =>
-          changed(() => {
-            if (throughFromKey === e.detail) {
-              throughFromKey = null
-            }
-          })}
+        on:change={changed}
       />
       <Select
         label={`Foreign Key (${getTable(toId)?.name})`}
         options={Object.keys(getTable(throughId)?.schema)}
         bind:value={throughFromKey}
         bind:error={errors.throughFromKey}
-        on:change={e =>
-          changed(() => {
-            if (throughToKey === e.detail) {
-              throughToKey = null
-            }
-          })}
+        on:change={changed}
       />
     {/if}
   {:else if isManyToOne && toId}

--- a/packages/server/scripts/integrations/postgres/emp-territory.sql
+++ b/packages/server/scripts/integrations/postgres/emp-territory.sql
@@ -1,0 +1,32 @@
+SELECT 'CREATE DATABASE main'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'main')\gexec
+CREATE SCHEMA test;
+CREATE TABLE territories (
+    territory_id character varying(20) PRIMARY KEY,
+    territory_description character varying(60) NOT NULL
+);
+CREATE TABLE employees (
+    employee_id smallint PRIMARY KEY,
+    last_name character varying(20) NOT NULL,
+    first_name character varying(10) NOT NULL,
+    title character varying(30),
+    title_of_courtesy character varying(25),
+    birth_date date,
+    hire_date date,
+    address character varying(60),
+    city character varying(15),
+    region character varying(15),
+    postal_code character varying(10),
+    country character varying(15),
+    home_phone character varying(24),
+    extension character varying(4),
+    photo bytea,
+    notes text,
+    reports_to smallint REFERENCES employees(employee_id),
+    photo_path character varying(255)
+);
+CREATE TABLE employee_territories (
+    employee_id smallint REFERENCES employees(employee_id),
+    territory_id character varying(20) REFERENCES territories(territory_id),
+    CONSTRAINT pk_employee_territories PRIMARY KEY (employee_id, territory_id)
+);


### PR DESCRIPTION
## Description
Fix for #9654 - the error checking was looking at the through fields flipped, which caused many to many relationships to throw an error. Also I've updated the dev compose file on master so that switching between develop and master is smoother.

I've also included the SQL that was used to exhibit this error as it is an example of something that we haven't tested before now.

Addresses: 
- #9654


