### PR TITLE
Link to Plugin Repo from Plugin Page

### DIFF
--- a/packages/builder/src/pages/builder/portal/plugins/index.svelte
+++ b/packages/builder/src/pages/builder/portal/plugins/index.svelte
@@ -81,6 +81,17 @@
     <div class="controls">
       <div>
         <Button on:click={modal.show} cta>Add plugin</Button>
+        <div class="secondaryButton">
+          <Button
+            on:click={() =>
+              window
+                .open("https://github.com/Budibase/plugins", "_blank")
+                .focus()}
+            secondary
+          >
+            GitHub repo
+          </Button>
+        </div>
       </div>
       {#if $plugins?.length}
         <div class="filters">
@@ -97,15 +108,17 @@
       {/if}
     </div>
 
-    <Table
-      {schema}
-      data={filteredPlugins}
-      allowEditColumns={false}
-      allowEditRows={false}
-      allowSelectRows={false}
-      allowClickRows={false}
-      {customRenderers}
-    />
+    {#if $plugins?.length}
+      <Table
+        {schema}
+        data={filteredPlugins}
+        allowEditColumns={false}
+        allowEditRows={false}
+        allowSelectRows={false}
+        allowClickRows={false}
+        {customRenderers}
+      />
+    {/if}
   </Layout>
 </Page>
 
@@ -136,5 +149,10 @@
     .controls :global(.spectrum-Search) {
       width: auto;
     }
+  }
+
+  .secondaryButton {
+    display: inline-block;
+    margin-left: 6px;
   }
 </style>


### PR DESCRIPTION
## Description
Adds a link to the plugins repo to the plugins page. Also hides the table when the user has no plugins.

Addresses: 
[#9382](https://github.com/Budibase/budibase/issues/9382)



