### PR TITLE
Null safety

### DIFF
--- a/packages/client/src/components/Component.svelte
+++ b/packages/client/src/components/Component.svelte
@@ -174,11 +174,11 @@
   // Determine whether we should render a skeleton loader for this component
   $: showSkeleton =
     $loading &&
-    definition.name !== "Screenslot" &&
+    definition?.name !== "Screenslot" &&
     children.length === 0 &&
     !instance._blockElementHasChildren &&
-    !definition.block &&
-    definition.skeleton !== false
+    !definition?.block &&
+    definition?.skeleton !== false
 
   // Update component context
   $: store.set({


### PR DESCRIPTION
## Description
`TypeError: Cannot read properties of undefined (reading 'name')`. Should be fixed with the null-safety. The *definition* in other parts of the file were already using this null check.

Addresses: 
- https://github.com/Budibase/budibase/discussions/9365

## Screenshots
![image](https://user-images.githubusercontent.com/101575380/218978851-7c57eb3a-d988-4b6f-9e93-06391a579b92.png)




