### PR TITLE
Attempt to fix flakey 409s when deleting screens that are linked in the nav

### DIFF
--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -312,7 +312,7 @@ export const getFrontendStore = () => {
         const screensToDelete = Array.isArray(screens) ? screens : [screens]
 
         // Build array of promises to speed up bulk deletions
-        const promises = []
+        let promises = []
         let deleteUrls = []
         screensToDelete.forEach(screen => {
           // Delete the screen
@@ -326,8 +326,8 @@ export const getFrontendStore = () => {
           deleteUrls.push(screen.routing.route)
         })
 
-        promises.push(store.actions.links.delete(deleteUrls))
         await Promise.all(promises)
+        await store.actions.links.delete(deleteUrls)
         const deletedIds = screensToDelete.map(screen => screen._id)
         const routesResponse = await API.fetchAppRoutes()
         store.update(state => {


### PR DESCRIPTION
## Description
This PR attempts to fix an intermittent issue of sometimes receiving 409s when deleting screens. I think the reason for this may be due to our use of `Promise.all`, where the promises contained all update the same app doc - I think the RNG order of this was causing conflicts in the server due to race conditions depending on the order received. I'm attempting to fix this by staggering some promises.

Addresses: 
- https://github.com/Budibase/budibase/issues/9149
- Also raised again recently by QA Wolf



