### PR TITLE
Fix tenant creation on user save

### DIFF
--- a/packages/worker/src/sdk/users/users.ts
+++ b/packages/worker/src/sdk/users/users.ts
@@ -264,6 +264,7 @@ export const save = async (
     builtUser._rev = response.rev
 
     await eventHelpers.handleSaveEvents(builtUser, dbUser)
+    await addTenant(tenantId, _id, email)
     await cache.user.invalidateUser(response.id)
 
     // let server know to sync user


### PR DESCRIPTION
## Description
Fix a bug that prevents
- platform user doc creation
- tenants doc update
on admin user creation. 

The tests do start to fail when this is re-added however. Since the tests are currently disabled I'd like to add this to fix the integrity of the DB in qa - when the following is merged to `develop` the tests should work again: https://github.com/Budibase/budibase/pull/9670

