### PR TITLE
Null safety

### DIFF
--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -254,8 +254,8 @@
               {:else if filter.type === "datetime"}
                 <DatePicker
                   disabled={filter.noValue}
-                  enableTime={!getSchema(filter).dateOnly}
-                  timeOnly={getSchema(filter).timeOnly}
+                  enableTime={!getSchema(filter)?.dateOnly}
+                  timeOnly={getSchema(filter)?.timeOnly}
                   bind:value={filter.value}
                 />
               {:else}


### PR DESCRIPTION
## Description
Had originally fixed this for relationship date filters, however the null check had to be added for the scenario in which your switch from a relationship filter in a table to another datasource.

The filter appears as *null* on the switch, but doesn't crash. Just needs to be set or removed.

Addresses: 
- https://github.com/Budibase/budibase/issues/9406

## Screenshots
![Screenshot 2023-02-20 at 10 40 59](https://user-images.githubusercontent.com/101575380/220082798-28a86819-1306-4a45-b95b-6f2eed53d5fe.png)

![Screenshot 2023-02-20 at 10 41 19](https://user-images.githubusercontent.com/101575380/220082877-3df1126b-ad9b-4975-93fa-d618bdcc9270.png)

