### PR TITLE
Static formula document conflict issue

### DIFF
--- a/packages/server/src/api/controllers/row/staticFormula.ts
+++ b/packages/server/src/api/controllers/row/staticFormula.ts
@@ -38,7 +38,13 @@ export async function updateRelatedFormula(
         if (!relatedRows[relatedTableId]) {
           relatedRows[relatedTableId] = []
         }
-        relatedRows[relatedTableId] = relatedRows[relatedTableId].concat(field)
+        // filter down to the rows which are not already included in related
+        const currentIds = relatedRows[relatedTableId].map(row => row._id)
+        const uniqueRelatedRows = field.filter(
+          (row: Row) => !currentIds.includes(row._id)
+        )
+        relatedRows[relatedTableId] =
+          relatedRows[relatedTableId].concat(uniqueRelatedRows)
       }
     }
     for (let tableId of table.relatedFormula) {


### PR DESCRIPTION
## Description
Fix for #9749 - static formulas would sometimes attempt to update the same row multiple times, filter down to just the unique row list which requires updating.

Raised by Conor Webb after hearing about the 409 issue in CouchDB and how it should not be ignored.