### PR TITLE
Configs /  Server tests / Failing real email tests updates 

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -11,7 +11,6 @@ on:
     branches:
       - master
       - develop
-      - configs-refactor-and-server-test-fixes
  workflow_dispatch:
 
 env:

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -10,7 +10,8 @@ on:
  pull_request:
     branches:
       - master
-      - develop 
+      - develop
+      - configs-refactor-and-server-test-fixes
  workflow_dispatch:
 
 env:

--- a/packages/backend-core/src/configs/configs.ts
+++ b/packages/backend-core/src/configs/configs.ts
@@ -1,0 +1,224 @@
+import {
+  Config,
+  ConfigType,
+  GoogleConfig,
+  GoogleInnerConfig,
+  OIDCConfig,
+  OIDCInnerConfig,
+  SettingsConfig,
+  SettingsInnerConfig,
+  SMTPConfig,
+  SMTPInnerConfig,
+} from "@budibase/types"
+import { DocumentType, SEPARATOR } from "../constants"
+import { CacheKey, TTL, withCache } from "../cache"
+import * as context from "../context"
+import env from "../environment"
+import environment from "../environment"
+
+// UTILS
+
+/**
+ * Generates a new configuration ID.
+ * @returns {string} The new configuration ID which the config doc can be stored under.
+ */
+export function generateConfigID(type: ConfigType) {
+  return `${DocumentType.CONFIG}${SEPARATOR}${type}`
+}
+
+export async function getConfig<T extends Config>(
+  type: ConfigType
+): Promise<T | undefined> {
+  const db = context.getGlobalDB()
+  try {
+    // await to catch error
+    const config = (await db.get(generateConfigID(type))) as T
+    return config
+  } catch (e: any) {
+    if (e.status === 404) {
+      return
+    }
+    throw e
+  }
+}
+
+export async function save(config: Config) {
+  const db = context.getGlobalDB()
+  return db.put(config)
+}
+
+// SETTINGS
+
+export async function getSettingsConfigDoc(): Promise<SettingsConfig> {
+  let config = await getConfig<SettingsConfig>(ConfigType.SETTINGS)
+
+  if (!config) {
+    config = {
+      _id: generateConfigID(ConfigType.GOOGLE),
+      type: ConfigType.SETTINGS,
+      config: {},
+    }
+  }
+
+  // overridden fields
+  config.config.platformUrl = await getPlatformUrl({
+    tenantAware: true,
+    config: config.config,
+  })
+  config.config.analyticsEnabled = await analyticsEnabled({
+    config: config.config,
+  })
+
+  return config
+}
+
+export async function getSettingsConfig(): Promise<SettingsInnerConfig> {
+  return (await getSettingsConfigDoc()).config
+}
+
+export async function getPlatformUrl(
+  opts: { tenantAware: boolean; config?: SettingsInnerConfig } = {
+    tenantAware: true,
+  }
+) {
+  let platformUrl = env.PLATFORM_URL || "http://localhost:10000"
+
+  if (!env.SELF_HOSTED && env.MULTI_TENANCY && opts.tenantAware) {
+    // cloud and multi tenant - add the tenant to the default platform url
+    const tenantId = context.getTenantId()
+    if (!platformUrl.includes("localhost:")) {
+      platformUrl = platformUrl.replace("://", `://${tenantId}.`)
+    }
+  } else if (env.SELF_HOSTED) {
+    const config = opts?.config
+      ? opts.config
+      : // direct to db to prevent infinite loop
+        (await getConfig<SettingsConfig>(ConfigType.SETTINGS))?.config
+    if (config?.platformUrl) {
+      platformUrl = config.platformUrl
+    }
+  }
+
+  return platformUrl
+}
+
+export const analyticsEnabled = async (opts?: {
+  config?: SettingsInnerConfig
+}) => {
+  // cloud - always use the environment variable
+  if (!env.SELF_HOSTED) {
+    return !!env.ENABLE_ANALYTICS
+  }
+
+  // self host - prefer the settings doc
+  // use cache as events have high throughput
+  const enabledInDB = await withCache(
+    CacheKey.ANALYTICS_ENABLED,
+    TTL.ONE_DAY,
+    async () => {
+      const config = opts?.config
+        ? opts.config
+        : // direct to db to prevent infinite loop
+          (await getConfig<SettingsConfig>(ConfigType.SETTINGS))?.config
+
+      // need to do explicit checks in case the field is not set
+      if (config?.analyticsEnabled === false) {
+        return false
+      } else if (config?.analyticsEnabled === true) {
+        return true
+      }
+    }
+  )
+
+  if (enabledInDB !== undefined) {
+    return enabledInDB
+  }
+
+  // fallback to the environment variable
+  // explicitly check for 0 or false here, undefined or otherwise is treated as true
+  const envEnabled: any = env.ENABLE_ANALYTICS
+  if (envEnabled === 0 || envEnabled === false) {
+    return false
+  } else {
+    return true
+  }
+}
+
+// GOOGLE
+
+async function getGoogleConfigDoc(): Promise<GoogleConfig | undefined> {
+  return await getConfig<GoogleConfig>(ConfigType.GOOGLE)
+}
+
+export async function getGoogleConfig(): Promise<
+  GoogleInnerConfig | undefined
+> {
+  const config = await getGoogleConfigDoc()
+  if (config) {
+    return config.config
+  }
+
+  // Use google fallback configuration from env variables
+  if (environment.GOOGLE_CLIENT_ID && environment.GOOGLE_CLIENT_SECRET) {
+    return {
+      clientID: environment.GOOGLE_CLIENT_ID!,
+      clientSecret: environment.GOOGLE_CLIENT_SECRET!,
+      activated: true,
+    }
+  }
+}
+
+// OIDC
+
+async function getOIDCConfigDoc(): Promise<OIDCConfig | undefined> {
+  return getConfig<OIDCConfig>(ConfigType.OIDC)
+}
+
+export async function getOIDCConfig(): Promise<OIDCInnerConfig | undefined> {
+  const config = (await getOIDCConfigDoc())?.config
+  // default to the 0th config
+  return config?.configs && config.configs[0]
+}
+
+/**
+ * @param configId The config id of the inner config to retrieve
+ */
+export async function getOIDCConfigById(
+  configId: string
+): Promise<OIDCInnerConfig | undefined> {
+  const config = (await getConfig<OIDCConfig>(ConfigType.OIDC))?.config
+  return config && config.configs.filter((c: any) => c.uuid === configId)[0]
+}
+
+// SMTP
+
+export async function getSMTPConfigDoc(): Promise<SMTPConfig | undefined> {
+  return getConfig<SMTPConfig>(ConfigType.SMTP)
+}
+
+export async function getSMTPConfig(
+  isAutomation?: boolean
+): Promise<SMTPInnerConfig | undefined> {
+  const config = await getSMTPConfigDoc()
+  if (config) {
+    return config.config
+  }
+
+  // always allow fallback in self host
+  // in cloud don't allow for automations
+  const allowFallback = env.SELF_HOSTED || !isAutomation
+
+  // Use an SMTP fallback configuration from env variables
+  if (env.SMTP_FALLBACK_ENABLED && allowFallback) {
+    return {
+      port: env.SMTP_PORT,
+      host: env.SMTP_HOST!,
+      secure: false,
+      from: env.SMTP_FROM_ADDRESS!,
+      auth: {
+        user: env.SMTP_USER!,
+        pass: env.SMTP_PASSWORD!,
+      },
+    }
+  }
+}

--- a/packages/backend-core/src/configs/index.ts
+++ b/packages/backend-core/src/configs/index.ts
@@ -1,0 +1,1 @@
+export * from "./configs"

--- a/packages/backend-core/src/configs/tests/configs.spec.ts
+++ b/packages/backend-core/src/configs/tests/configs.spec.ts
@@ -1,0 +1,116 @@
+import { DBTestConfiguration, generator, testEnv } from "../../../tests"
+import { ConfigType } from "@budibase/types"
+import env from "../../environment"
+import * as configs from "../configs"
+
+const DEFAULT_URL = "http://localhost:10000"
+const ENV_URL = "http://env.com"
+
+describe("configs", () => {
+  const config = new DBTestConfiguration()
+
+  const setDbPlatformUrl = async (dbUrl: string) => {
+    const settingsConfig = {
+      _id: configs.generateConfigID(ConfigType.SETTINGS),
+      type: ConfigType.SETTINGS,
+      config: {
+        platformUrl: dbUrl,
+      },
+    }
+    await configs.save(settingsConfig)
+  }
+
+  beforeEach(async () => {
+    config.newTenant()
+  })
+
+  describe("getPlatformUrl", () => {
+    describe("self host", () => {
+      beforeEach(async () => {
+        testEnv.selfHosted()
+      })
+
+      it("gets the default url", async () => {
+        await config.doInTenant(async () => {
+          const url = await configs.getPlatformUrl()
+          expect(url).toBe(DEFAULT_URL)
+        })
+      })
+
+      it("gets the platform url from the environment", async () => {
+        await config.doInTenant(async () => {
+          env._set("PLATFORM_URL", ENV_URL)
+          const url = await configs.getPlatformUrl()
+          expect(url).toBe(ENV_URL)
+        })
+      })
+
+      it("gets the platform url from the database", async () => {
+        await config.doInTenant(async () => {
+          const dbUrl = generator.url()
+          await setDbPlatformUrl(dbUrl)
+          const url = await configs.getPlatformUrl()
+          expect(url).toBe(dbUrl)
+        })
+      })
+    })
+
+    describe("cloud", () => {
+      function getTenantAwareUrl() {
+        return `http://${config.tenantId}.env.com`
+      }
+
+      beforeEach(async () => {
+        testEnv.cloudHosted()
+        testEnv.multiTenant()
+
+        env._set("PLATFORM_URL", ENV_URL)
+      })
+
+      it("gets the platform url from the environment without tenancy", async () => {
+        await config.doInTenant(async () => {
+          const url = await configs.getPlatformUrl({ tenantAware: false })
+          expect(url).toBe(ENV_URL)
+        })
+      })
+
+      it("gets the platform url from the environment with tenancy", async () => {
+        await config.doInTenant(async () => {
+          const url = await configs.getPlatformUrl()
+          expect(url).toBe(getTenantAwareUrl())
+        })
+      })
+
+      it("never gets the platform url from the database", async () => {
+        await config.doInTenant(async () => {
+          await setDbPlatformUrl(generator.url())
+          const url = await configs.getPlatformUrl()
+          expect(url).toBe(getTenantAwareUrl())
+        })
+      })
+    })
+  })
+
+  describe("getSettingsConfig", () => {
+    beforeAll(async () => {
+      testEnv.selfHosted()
+      env._set("PLATFORM_URL", "")
+    })
+
+    it("returns the platform url with an existing config", async () => {
+      await config.doInTenant(async () => {
+        const dbUrl = generator.url()
+        await setDbPlatformUrl(dbUrl)
+        const config = await configs.getSettingsConfig()
+        expect(config.platformUrl).toBe(dbUrl)
+      })
+    })
+
+    it("returns the platform url without an existing config", async () => {
+      await config.doInTenant(async () => {
+        const config = await configs.getSettingsConfig()
+        expect(config.platformUrl).toBe(DEFAULT_URL)
+      })
+    })
+  })
+})

--- a/packages/backend-core/src/db/tests/utils.spec.ts
+++ b/packages/backend-core/src/db/tests/utils.spec.ts
@@ -1,19 +1,13 @@
-import { generator, DBTestConfiguration, testEnv } from "../../../tests"
 import {
   getDevelopmentAppID,
   getProdAppID,
   isDevAppID,
   isProdAppID,
 } from "../conversions"
-import { generateAppID, getPlatformUrl, getScopedConfig } from "../utils"
-import * as context from "../../context"
-import { Config } from "../../constants"
-import env from "../../environment"
+import { generateAppID } from "../utils"
 
 describe("utils", () => {
-  const config = new DBTestConfiguration()
-
-  describe("app ID manipulation", () => {
+  describe("generateAppID", () => {
     function getID() {
       const appId = generateAppID()
       const split = appId.split("_")
@@ -64,129 +58,6 @@ describe("utils", () => {
     it("should be able to confirm dev app ID is not prod", () => {
       const { devAppId } = getID()
       expect(isProdAppID(devAppId)).toEqual(false)
-    })
-  })
-
-  const DEFAULT_URL = "http://localhost:10000"
-  const ENV_URL = "http://env.com"
-
-  const setDbPlatformUrl = async (dbUrl: string) => {
-    const db = context.getGlobalDB()
-    await db.put({
-      _id: "config_settings",
-      type: Config.SETTINGS,
-      config: {
-        platformUrl: dbUrl,
-      },
-    })
-  }
-
-  const clearSettingsConfig = async () => {
-    await config.doInTenant(async () => {
-      const db = context.getGlobalDB()
-      try {
-        const config = await db.get("config_settings")
-        await db.remove("config_settings", config._rev)
-      } catch (e: any) {
-        if (e.status !== 404) {
-          throw e
-        }
-      }
-    })
-  }
-
-  describe("getPlatformUrl", () => {
-    describe("self host", () => {
-      beforeEach(async () => {
-        testEnv.selfHosted()
-        await clearSettingsConfig()
-      })
-
-      it("gets the default url", async () => {
-        await config.doInTenant(async () => {
-          const url = await getPlatformUrl()
-          expect(url).toBe(DEFAULT_URL)
-        })
-      })
-
-      it("gets the platform url from the environment", async () => {
-        await config.doInTenant(async () => {
-          env._set("PLATFORM_URL", ENV_URL)
-          const url = await getPlatformUrl()
-          expect(url).toBe(ENV_URL)
-        })
-      })
-
-      it("gets the platform url from the database", async () => {
-        await config.doInTenant(async () => {
-          const dbUrl = generator.url()
-          await setDbPlatformUrl(dbUrl)
-          const url = await getPlatformUrl()
-          expect(url).toBe(dbUrl)
-        })
-      })
-    })
-
-    describe("cloud", () => {
-      const TENANT_AWARE_URL = `http://${config.tenantId}.env.com`
-
-      beforeEach(async () => {
-        testEnv.cloudHosted()
-        testEnv.multiTenant()
-
-        env._set("PLATFORM_URL", ENV_URL)
-        await clearSettingsConfig()
-      })
-
-      it("gets the platform url from the environment without tenancy", async () => {
-        await config.doInTenant(async () => {
-          const url = await getPlatformUrl({ tenantAware: false })
-          expect(url).toBe(ENV_URL)
-        })
-      })
-
-      it("gets the platform url from the environment with tenancy", async () => {
-        await config.doInTenant(async () => {
-          const url = await getPlatformUrl()
-          expect(url).toBe(TENANT_AWARE_URL)
-        })
-      })
-
-      it("never gets the platform url from the database", async () => {
-        await config.doInTenant(async () => {
-          await setDbPlatformUrl(generator.url())
-          const url = await getPlatformUrl()
-          expect(url).toBe(TENANT_AWARE_URL)
-        })
-      })
-    })
-  })
-
-  describe("getScopedConfig", () => {
-    describe("settings config", () => {
-      beforeEach(async () => {
-        env._set("SELF_HOSTED", 1)
-        env._set("PLATFORM_URL", "")
-        await clearSettingsConfig()
-      })
-
-      it("returns the platform url with an existing config", async () => {
-        await config.doInTenant(async () => {
-          const dbUrl = generator.url()
-          await setDbPlatformUrl(dbUrl)
-          const db = context.getGlobalDB()
-          const config = await getScopedConfig(db, { type: Config.SETTINGS })
-          expect(config.platformUrl).toBe(dbUrl)
-        })
-      })
-
-      it("returns the platform url without an existing config", async () => {
-        await config.doInTenant(async () => {
-          const db = context.getGlobalDB()
-          const config = await getScopedConfig(db, { type: Config.SETTINGS })
-          expect(config.platformUrl).toBe(DEFAULT_URL)
-        })
-      })
     })
   })
 })

--- a/packages/backend-core/src/db/utils.ts
+++ b/packages/backend-core/src/db/utils.ts
@@ -9,12 +9,11 @@ import {
   InternalTable,
   APP_PREFIX,
 } from "../constants"
-import { getTenantId, getGlobalDB, getGlobalDBName } from "../context"
+import { getTenantId, getGlobalDBName } from "../context"
 import { doWithDB, directCouchAllDbs } from "./db"
 import { getAppMetadata } from "../cache/appMetadata"
 import { isDevApp, isDevAppID, getProdAppID } from "./conversions"
-import * as events from "../events"
-import { App, Database, ConfigType, isSettingsConfig } from "@budibase/types"
+import { App, Database } from "@budibase/types"
 
 /**
  * Generates a new app ID.
@@ -393,32 +392,6 @@ export async function dbExists(dbName: any) {
 }
 
 /**
- * Generates a new configuration ID.
- * @returns {string} The new configuration ID which the config doc can be stored under.
- */
-export const generateConfigID = ({ type, workspace, user }: any) => {
-  const scope = [type, workspace, user].filter(Boolean).join(SEPARATOR)
-
-  return `${DocumentType.CONFIG}${SEPARATOR}${scope}`
-}
-
-/**
- * Gets parameters for retrieving configurations.
- */
-export const getConfigParams = (
-  { type, workspace, user }: any,
-  otherProps = {}
-) => {
-  const scope = [type, workspace, user].filter(Boolean).join(SEPARATOR)
-
-  return {
-    ...otherProps,
-    startkey: `${DocumentType.CONFIG}${SEPARATOR}${scope}`,
-    endkey: `${DocumentType.CONFIG}${SEPARATOR}${scope}${UNICODE_MAX}`,
-  }
-}
-
-/**
  * Generates a new dev info document ID - this is scoped to a user.
  * @returns {string} The new dev info ID which info for dev (like api key) can be stored under.
  */
@@ -439,109 +412,6 @@ export const generatePluginID = (name: string) => {
  */
 export const getPluginParams = (pluginId?: string | null, otherProps = {}) => {
   return getDocParams(DocumentType.PLUGIN, pluginId, otherProps)
-}
-
-/**
- * Returns the most granular configuration document from the DB based on the type, workspace and userID passed.
- * @param {Object} db - db instance to query
- * @param {Object} scopes - the type, workspace and userID scopes of the configuration.
- * @returns The most granular configuration document based on the scope.
- */
-export const getScopedFullConfig = async function (
-  db: any,
-  { type, user, workspace }: any
-) {
-  const response = await db.allDocs(
-    getConfigParams(
-      { type, user, workspace },
-      {
-        include_docs: true,
-      }
-    )
-  )
-
-  function determineScore(row: any) {
-    const config = row.doc
-
-    // Config is specific to a user and a workspace
-    if (config._id.includes(generateConfigID({ type, user, workspace }))) {
-      return 4
-    } else if (config._id.includes(generateConfigID({ type, user }))) {
-      // Config is specific to a user only
-      return 3
-    } else if (config._id.includes(generateConfigID({ type, workspace }))) {
-      // Config is specific to a workspace only
-      return 2
-    } else if (config._id.includes(generateConfigID({ type }))) {
-      // Config is specific to a type only
-      return 1
-    }
-    return 0
-  }
-
-  // Find the config with the most granular scope based on context
-  let scopedConfig = response.rows.sort(
-    (a: any, b: any) => determineScore(a) - determineScore(b)
-  )[0]
-
-  // custom logic for settings doc
-  if (type === ConfigType.SETTINGS) {
-    if (!scopedConfig || !scopedConfig.doc) {
-      // defaults
-      scopedConfig = {
-        doc: {
-          _id: generateConfigID({ type, user, workspace }),
-          type: ConfigType.SETTINGS,
-          config: {
-            platformUrl: await getPlatformUrl({ tenantAware: true }),
-            analyticsEnabled: await events.analytics.enabled(),
-          },
-        },
-      }
-    }
-
-    // will always be true - use assertion function to get type access
-    if (isSettingsConfig(scopedConfig.doc)) {
-      // overrides affected by environment
-      scopedConfig.doc.config.platformUrl = await getPlatformUrl({
-        tenantAware: true,
-      })
-      scopedConfig.doc.config.analyticsEnabled =
-        await events.analytics.enabled()
-    }
-  }
-
-  return scopedConfig && scopedConfig.doc
-}
-
-export const getPlatformUrl = async (opts = { tenantAware: true }) => {
-  let platformUrl = env.PLATFORM_URL || "http://localhost:10000"
-
-  if (!env.SELF_HOSTED && env.MULTI_TENANCY && opts.tenantAware) {
-    // cloud and multi tenant - add the tenant to the default platform url
-    const tenantId = getTenantId()
-    if (!platformUrl.includes("localhost:")) {
-      platformUrl = platformUrl.replace("://", `://${tenantId}.`)
-    }
-  } else if (env.SELF_HOSTED) {
-    const db = getGlobalDB()
-    // get the doc directly instead of with getScopedConfig to prevent loop
-    let settings
-    try {
-      settings = await db.get(generateConfigID({ type: ConfigType.SETTINGS }))
-    } catch (e: any) {
-      if (e.status !== 404) {
-        throw e
-      }
-    }
-
-    // self hosted - check for platform url override
-    if (settings && settings.config && settings.config.platformUrl) {
-      platformUrl = settings.config.platformUrl
-    }
-  }
-
-  return platformUrl
 }
 
 export function pagination(
@@ -576,9 +446,4 @@ export function pagination(
     hasNextPage,
     nextPage,
   }
-}
-
-export async function getScopedConfig(db: any, params: any) {
-  const configDoc = await getScopedFullConfig(db, params)
-  return configDoc && configDoc.config ? configDoc.config : configDoc
 }

--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -28,6 +28,8 @@ const DefaultBucketName = {
   PLUGINS: "plugins",
 }
 
+const selfHosted = !!parseInt(process.env.SELF_HOSTED || "")
+
 const environment = {
   isTest,
   isJest,
@@ -58,7 +60,7 @@ const environment = {
     process.env.ACCOUNT_PORTAL_URL || "https://account.budibase.app",
   ACCOUNT_PORTAL_API_KEY: process.env.ACCOUNT_PORTAL_API_KEY || "",
   DISABLE_ACCOUNT_PORTAL: process.env.DISABLE_ACCOUNT_PORTAL,
-  SELF_HOSTED: !!parseInt(process.env.SELF_HOSTED || ""),
+  SELF_HOSTED: selfHosted,
   COOKIE_DOMAIN: process.env.COOKIE_DOMAIN,
   PLATFORM_URL: process.env.PLATFORM_URL || "",
   POSTHOG_TOKEN: process.env.POSTHOG_TOKEN,
@@ -91,6 +93,14 @@ const environment = {
   SMTP_HOST: process.env.SMTP_HOST,
   SMTP_PORT: parseInt(process.env.SMTP_PORT || ""),
   SMTP_FROM_ADDRESS: process.env.SMTP_FROM_ADDRESS,
+  /**
+   * Enable to allow an admin user to login using a password.
+   * This can be useful to prevent lockout when configuring SSO.
+   * However, this should be turned OFF by default for security purposes.
+   */
+  ENABLE_SSO_MAINTENANCE_MODE: selfHosted
+    ? process.env.ENABLE_SSO_MAINTENANCE_MODE
+    : false,
   _set(key: any, value: any) {
     process.env[key] = value
     // @ts-ignore

--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -84,6 +84,13 @@ const environment = {
   DEPLOYMENT_ENVIRONMENT:
     process.env.DEPLOYMENT_ENVIRONMENT || "docker-compose",
   ENABLE_4XX_HTTP_LOGGING: process.env.ENABLE_4XX_HTTP_LOGGING || true,
+  // smtp
+  SMTP_FALLBACK_ENABLED: process.env.SMTP_FALLBACK_ENABLED,
+  SMTP_USER: process.env.SMTP_USER,
+  SMTP_PASSWORD: process.env.SMTP_PASSWORD,
+  SMTP_HOST: process.env.SMTP_HOST,
+  SMTP_PORT: parseInt(process.env.SMTP_PORT || ""),
+  SMTP_FROM_ADDRESS: process.env.SMTP_FROM_ADDRESS,
   _set(key: any, value: any) {
     process.env[key] = value
     // @ts-ignore

--- a/packages/backend-core/src/events/analytics.ts
+++ b/packages/backend-core/src/events/analytics.ts
@@ -1,55 +1,6 @@
-import env from "../environment"
-import * as context from "../context"
-import * as dbUtils from "../db/utils"
-import { Config } from "../constants"
-import { withCache, TTL, CacheKey } from "../cache"
+import * as configs from "../configs"
 
+// wrapper utility function
 export const enabled = async () => {
-  // cloud - always use the environment variable
-  if (!env.SELF_HOSTED) {
-    return !!env.ENABLE_ANALYTICS
-  }
-
-  // self host - prefer the settings doc
-  // use cache as events have high throughput
-  const enabledInDB = await withCache(
-    CacheKey.ANALYTICS_ENABLED,
-    TTL.ONE_DAY,
-    async () => {
-      const settings = await getSettingsDoc()
-
-      // need to do explicit checks in case the field is not set
-      if (settings?.config?.analyticsEnabled === false) {
-        return false
-      } else if (settings?.config?.analyticsEnabled === true) {
-        return true
-      }
-    }
-  )
-
-  if (enabledInDB !== undefined) {
-    return enabledInDB
-  }
-
-  // fallback to the environment variable
-  // explicitly check for 0 or false here, undefined or otherwise is treated as true
-  const envEnabled: any = env.ENABLE_ANALYTICS
-  if (envEnabled === 0 || envEnabled === false) {
-    return false
-  } else {
-    return true
-  }
-}
-
-const getSettingsDoc = async () => {
-  const db = context.getGlobalDB()
-  let settings
-  try {
-    settings = await db.get(dbUtils.generateConfigID({ type: Config.SETTINGS }))
-  } catch (e: any) {
-    if (e.status !== 404) {
-      throw e
-    }
-  }
-  return settings
+  return configs.analyticsEnabled()
 }

--- a/packages/backend-core/src/events/identification.ts
+++ b/packages/backend-core/src/events/identification.ts
@@ -10,7 +10,6 @@ import {
   isCloudAccount,
   isSSOAccount,
   TenantGroup,
-  SettingsConfig,
   CloudAccount,
   UserIdentity,
   InstallationGroup,

--- a/packages/backend-core/src/events/identification.ts
+++ b/packages/backend-core/src/events/identification.ts
@@ -19,10 +19,9 @@ import {
   isSSOUser,
 } from "@budibase/types"
 import { processors } from "./processors"
-import * as dbUtils from "../db/utils"
-import { Config } from "../constants"
 import { newid } from "../utils"
 import * as installation from "../installation"
+import * as configs from "../configs"
 import { withCache, TTL, CacheKey } from "../cache/generic"
 
 const pkg = require("../../package.json")
@@ -270,9 +269,7 @@ const getUniqueTenantId = async (tenantId: string): Promise<string> => {
   return context.doInTenant(tenantId, () => {
     return withCache(CacheKey.UNIQUE_TENANT_ID, TTL.ONE_DAY, async () => {
       const db = context.getGlobalDB()
-      const config: SettingsConfig = await dbUtils.getScopedFullConfig(db, {
-        type: Config.SETTINGS,
-      })
+      const config = await configs.getSettingsConfigDoc()
 
       let uniqueTenantId: string
       if (config.config.uniqueTenantId) {

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -1,3 +1,4 @@
+export * as configs from "./configs"
 export * as events from "./events"
 export * as migrations from "./migrations"
 export * as users from "./users"

--- a/packages/backend-core/src/middleware/authenticated.ts
+++ b/packages/backend-core/src/middleware/authenticated.ts
@@ -115,7 +115,8 @@ export default function (
           authenticated = true
         } catch (err: any) {
           authenticated = false
-          console.error("Auth Error", err?.message || err)
+          console.error(`Auth Error: ${err.message}`)
+          console.error(err)
           // remove the cookie as the user does not exist anymore
           clearCookie(ctx, Cookie.Auth)
         }

--- a/packages/backend-core/src/middleware/errorHandling.ts
+++ b/packages/backend-core/src/middleware/errorHandling.ts
@@ -11,6 +11,7 @@ export async function errorHandling(ctx: any, next: any) {
 
     if (status > 499 || env.ENABLE_4XX_HTTP_LOGGING) {
       ctx.log.error(err)
+      console.trace(err)
     }
 
     const error = errors.getPublicError(err)

--- a/packages/backend-core/src/middleware/passport/sso/google.ts
+++ b/packages/backend-core/src/middleware/passport/sso/google.ts
@@ -2,12 +2,11 @@ import { ssoCallbackUrl } from "../utils"
 import * as sso from "./sso"
 import {
   ConfigType,
-  GoogleConfig,
-  Database,
   SSOProfile,
   SSOAuthDetails,
   SSOProviderType,
   SaveSSOUserFunction,
+  GoogleInnerConfig,
 } from "@budibase/types"
 const GoogleStrategy = require("passport-google-oauth").OAuth2Strategy
 
@@ -45,7 +44,7 @@ export function buildVerifyFn(saveUserFn: SaveSSOUserFunction) {
  * @returns Dynamically configured Passport Google Strategy
  */
 export async function strategyFactory(
-  config: GoogleConfig["config"],
+  config: GoogleInnerConfig,
   callbackUrl: string,
   saveUserFn: SaveSSOUserFunction
 ) {
@@ -73,9 +72,6 @@ export async function strategyFactory(
   }
 }
 
-export async function getCallbackUrl(
-  db: Database,
-  config: { callbackURL?: string }
-) {
-  return ssoCallbackUrl(db, config, ConfigType.GOOGLE)
+export async function getCallbackUrl(config: GoogleInnerConfig) {
+  return ssoCallbackUrl(ConfigType.GOOGLE, config)
 }

--- a/packages/backend-core/src/middleware/passport/sso/oidc.ts
+++ b/packages/backend-core/src/middleware/passport/sso/oidc.ts
@@ -4,7 +4,6 @@ import { ssoCallbackUrl } from "../utils"
 import {
   ConfigType,
   OIDCInnerConfig,
-  Database,
   SSOProfile,
   OIDCStrategyConfiguration,
   SSOAuthDetails,
@@ -157,9 +156,6 @@ export async function fetchStrategyConfig(
   }
 }
 
-export async function getCallbackUrl(
-  db: Database,
-  config: { callbackURL?: string }
-) {
-  return ssoCallbackUrl(db, config, ConfigType.OIDC)
+export async function getCallbackUrl() {
+  return ssoCallbackUrl(ConfigType.OIDC)
 }

--- a/packages/backend-core/src/middleware/passport/utils.ts
+++ b/packages/backend-core/src/middleware/passport/utils.ts
@@ -1,6 +1,6 @@
-import { isMultiTenant, getTenantId } from "../../context"
-import { getScopedConfig } from "../../db"
-import { ConfigType, Database } from "@budibase/types"
+import { getTenantId, isMultiTenant } from "../../context"
+import * as configs from "../../configs"
+import { ConfigType, GoogleInnerConfig } from "@budibase/types"
 
 /**
  * Utility to handle authentication errors.
@@ -19,17 +19,14 @@ export function authError(done: Function, message: string, err?: any) {
 }
 
 export async function ssoCallbackUrl(
-  db: Database,
-  config?: { callbackURL?: string },
-  type?: ConfigType
+  type: ConfigType,
+  config?: GoogleInnerConfig
 ) {
   // incase there is a callback URL from before
-  if (config && config.callbackURL) {
-    return config.callbackURL
+  if (config && (config as GoogleInnerConfig).callbackURL) {
+    return (config as GoogleInnerConfig).callbackURL as string
   }
-  const publicConfig = await getScopedConfig(db, {
-    type: ConfigType.SETTINGS,
-  })
+  const settingsConfig = await configs.getSettingsConfig()
 
   let callbackUrl = `/api/global/auth`
   if (isMultiTenant()) {
@@ -37,5 +34,5 @@ export async function ssoCallbackUrl(
   }
   callbackUrl += `/${type}/callback`
 
-  return `${publicConfig.platformUrl}${callbackUrl}`
+  return `${settingsConfig.platformUrl}${callbackUrl}`
 }

--- a/packages/backend-core/tests/utilities/mocks/licenses.ts
+++ b/packages/backend-core/tests/utilities/mocks/licenses.ts
@@ -70,6 +70,10 @@ export const useBackups = () => {
   return useFeature(Feature.APP_BACKUPS)
 }
 
+export const useEnforceableSSO = () => {
+  return useFeature(Feature.ENFORCEABLE_SSO)
+}
+
 export const useGroups = () => {
   return useFeature(Feature.USER_GROUPS)
 }

--- a/packages/backend-core/tests/utilities/structures/sso.ts
+++ b/packages/backend-core/tests/utilities/structures/sso.ts
@@ -69,6 +69,7 @@ export function oidcConfig(): OIDCInnerConfig {
     configUrl: "http://someconfigurl",
     clientID: generator.string(),
     clientSecret: generator.string(),
+    scopes: [],
   }
 }
 

--- a/packages/builder/src/pages/builder/auth/login.svelte
+++ b/packages/builder/src/pages/builder/auth/login.svelte
@@ -79,67 +79,71 @@
           <OIDCButton oidcIcon={$oidc.logo} oidcName={$oidc.name} />
           <GoogleButton />
         </FancyForm>
-        <Divider />
       {/if}
-      <FancyForm bind:this={form}>
-        <FancyInput
-          label="Your work email"
-          value={formData.username}
-          on:change={e => {
-            formData = {
-              ...formData,
-              username: e.detail,
-            }
-          }}
-          validate={() => {
-            let fieldError = {
-              username: !formData.username
-                ? "Please enter a valid email"
-                : undefined,
-            }
-            errors = handleError({ ...errors, ...fieldError })
-          }}
-          error={errors.username}
-        />
-        <FancyInput
-          label="Password"
-          value={formData.password}
-          type="password"
-          on:change={e => {
-            formData = {
-              ...formData,
-              password: e.detail,
-            }
-          }}
-          validate={() => {
-            let fieldError = {
-              password: !formData.password
-                ? "Please enter your password"
-                : undefined,
-            }
-            errors = handleError({ ...errors, ...fieldError })
-          }}
-          error={errors.password}
-        />
-      </FancyForm>
+      {#if !$organisation.isSSOEnforced}
+        <Divider />
+        <FancyForm bind:this={form}>
+          <FancyInput
+            label="Your work email"
+            value={formData.username}
+            on:change={e => {
+              formData = {
+                ...formData,
+                username: e.detail,
+              }
+            }}
+            validate={() => {
+              let fieldError = {
+                username: !formData.username
+                  ? "Please enter a valid email"
+                  : undefined,
+              }
+              errors = handleError({ ...errors, ...fieldError })
+            }}
+            error={errors.username}
+          />
+          <FancyInput
+            label="Password"
+            value={formData.password}
+            type="password"
+            on:change={e => {
+              formData = {
+                ...formData,
+                password: e.detail,
+              }
+            }}
+            validate={() => {
+              let fieldError = {
+                password: !formData.password
+                  ? "Please enter your password"
+                  : undefined,
+              }
+              errors = handleError({ ...errors, ...fieldError })
+            }}
+            error={errors.password}
+          />
+        </FancyForm>
+      {/if}
     </Layout>
-    <Layout gap="XS" noPadding justifyItems="center">
-      <Button
-        size="L"
-        cta
-        disabled={Object.keys(errors).length > 0}
-        on:click={login}
-      >
-        Log in to {company}
-      </Button>
-    </Layout>
-    <Layout gap="XS" noPadding justifyItems="center">
-      <div class="user-actions">
-        <ActionButton size="L" quiet on:click={() => $goto("./forgot")}>
-          Forgot password?
-        </ActionButton>
-      </div>
-    </Layout>
+    {#if !$organisation.isSSOEnforced}
+      <Layout gap="XS" noPadding justifyItems="center">
+        <Button
+          size="L"
+          cta
+          disabled={Object.keys(errors).length > 0}
+          on:click={login}
+        >
+          Log in to {company}
+        </Button>
+      </Layout>
+      <Layout gap="XS" noPadding justifyItems="center">
+        <div class="user-actions">
+          <ActionButton size="L" quiet on:click={() => $goto("./forgot")}>
+            Forgot password?
+          </ActionButton>
+        </div>
+      </Layout>
+    {/if}
 
     {#if cloud}
       <Body size="xs" textAlign="center">

--- a/packages/builder/src/pages/builder/portal/settings/organisation.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/organisation.svelte
@@ -24,6 +24,7 @@
   }
 
   const values = writable({
+    isSSOEnforced: $organisation.isSSOEnforced,
     company: $organisation.company,
     platformUrl: $organisation.platformUrl,
     analyticsEnabled: $organisation.analyticsEnabled,
@@ -54,6 +55,7 @@
       }
 
       const config = {
+        isSSOEnforced: $values.isSSOEnforced,
         company: $values.company ?? "",
         platformUrl: $values.platformUrl ?? "",
         analyticsEnabled: $values.analyticsEnabled,

--- a/packages/builder/src/stores/portal/licensing.js
+++ b/packages/builder/src/stores/portal/licensing.js
@@ -63,6 +63,9 @@ export const createLicensingStore = () => {
       const environmentVariablesEnabled = license.features.includes(
         Constants.Features.ENVIRONMENT_VARIABLES
       )
+      const enforceableSSO = license.features.includes(
+        Constants.Features.ENFORCEABLE_SSO
+      )
 
       store.update(state => {
         return {
@@ -72,6 +75,7 @@ export const createLicensingStore = () => {
           groupsEnabled,
           backupsEnabled,
           environmentVariablesEnabled,
+          enforceableSSO,
         }
       })
     },

--- a/packages/builder/src/stores/portal/organisation.js
+++ b/packages/builder/src/stores/portal/organisation.js
@@ -11,6 +11,7 @@ const DEFAULT_CONFIG = {
   google: undefined,
   oidcCallbackUrl: "",
   googleCallbackUrl: "",
+  isSSOEnforced: false,
 }
 
 export function createOrganisationStore() {
@@ -19,8 +20,8 @@ export function createOrganisationStore() {
 
   async function init() {
     const tenantId = get(auth).tenantId
-    const tenant = await API.getTenantConfig(tenantId)
-    set({ ...DEFAULT_CONFIG, ...tenant.config, _rev: tenant._rev })
+    const settingsConfigDoc = await API.getTenantConfig(tenantId)
+    set({ ...DEFAULT_CONFIG, ...settingsConfigDoc.config })
   }
 
   async function save(config) {
@@ -33,7 +34,6 @@ export function createOrganisationStore() {
     await API.saveConfig({
       type: "settings",
       config: { ...get(store), ...config },
-      _rev: get(store)._rev,
     })
     await init()
   }

--- a/packages/frontend-core/src/constants.js
+++ b/packages/frontend-core/src/constants.js
@@ -115,6 +115,7 @@ export const Features = {
   USER_GROUPS: "userGroups",
   BACKUPS: "appBackups",
   ENVIRONMENT_VARIABLES: "environmentVariables",
+  ENFORCEABLE_SSO: "enforceableSSO",
 }
 
 // Role IDs

--- a/packages/server/src/api/controllers/cloud.ts
+++ b/packages/server/src/api/controllers/cloud.ts
@@ -58,7 +58,7 @@ export async function exportApps(ctx: Ctx) {
 }
 
 async function checkHasBeenImported() {
-  if (!env.SELF_HOSTED || env.MULTI_TENANCY) {
+  if (!env.SELF_HOSTED) {
     return true
   }
   const apps = await dbCore.getAllApps({ all: true })
@@ -72,7 +72,7 @@ export async function hasBeenImported(ctx: Ctx) {
 }
 
 export async function importApps(ctx: Ctx) {
-  if (!env.SELF_HOSTED || env.MULTI_TENANCY) {
+  if (!env.SELF_HOSTED) {
     ctx.throw(400, "Importing only allowed in self hosted environments.")
   }
   const beenImported = await checkHasBeenImported()

--- a/packages/server/src/api/routes/tests/utilities/TestFunctions.ts
+++ b/packages/server/src/api/routes/tests/utilities/TestFunctions.ts
@@ -2,7 +2,6 @@ import * as rowController from "../../../controllers/row"
 import * as appController from "../../../controllers/application"
 import { AppStatus } from "../../../../db/utils"
 import { roles, tenancy, context } from "@budibase/backend-core"
-import { TENANT_ID } from "../../../../tests/utilities/structures"
 import env from "../../../../environment"
 import { db } from "@budibase/backend-core"
 import Nano from "@budibase/nano"
@@ -33,7 +32,7 @@ export const getAllTableRows = async (config: any) => {
 }
 
 export const clearAllApps = async (
-  tenantId = TENANT_ID,
+  tenantId: string,
   exceptions: Array<string> = []
 ) => {
   await tenancy.doInTenant(tenantId, async () => {

--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -11,8 +11,7 @@ import { OAuth2Client } from "google-auth-library"
 import { buildExternalTableId } from "./utils"
 import { DataSourceOperation, FieldTypes } from "../constants"
 import { GoogleSpreadsheet } from "google-spreadsheet"
-import env from "../environment"
-import { tenancy, db as dbCore, constants } from "@budibase/backend-core"
+import { configs, HTTPError } from "@budibase/backend-core"
 const fetch = require("node-fetch")
 
 interface GoogleSheetsConfig {
@@ -173,16 +172,9 @@ class GoogleSheetsIntegration implements DatasourcePlus {
   async connect() {
     try {
       // Initialise oAuth client
-      const db = tenancy.getGlobalDB()
-      let googleConfig = await dbCore.getScopedConfig(db, {
-        type: constants.Config.GOOGLE,
-      })
-
+      let googleConfig = await configs.getGoogleConfig()
       if (!googleConfig) {
-        googleConfig = {
-          clientID: env.GOOGLE_CLIENT_ID,
-          clientSecret: env.GOOGLE_CLIENT_SECRET,
-        }
+        throw new HTTPError("Google config not found", 400)
       }
 
       const oauthClient = new OAuth2Client({

--- a/packages/server/src/migrations/functions/backfill/global/configs.ts
+++ b/packages/server/src/migrations/functions/backfill/global/configs.ts
@@ -1,4 +1,9 @@
-import { events, db as dbUtils } from "@budibase/backend-core"
+import {
+  events,
+  DocumentType,
+  SEPARATOR,
+  UNICODE_MAX,
+} from "@budibase/backend-core"
 import {
   Config,
   isSMTPConfig,
@@ -9,15 +14,16 @@ import {
 } from "@budibase/types"
 import env from "./../../../../environment"
 
+export const getConfigParams = () => {
+  return {
+    include_docs: true,
+    startkey: `${DocumentType.CONFIG}${SEPARATOR}`,
+    endkey: `${DocumentType.CONFIG}${SEPARATOR}${UNICODE_MAX}`,
+  }
+}
+
 const getConfigs = async (globalDb: any): Promise<Config[]> => {
-  const response = await globalDb.allDocs(
-    dbUtils.getConfigParams(
-      {},
-      {
-        include_docs: true,
-      }
-    )
-  )
+  const response = await globalDb.allDocs(getConfigParams())
   return response.rows.map((row: any) => row.doc)
 }
 

--- a/packages/server/src/migrations/functions/tests/userEmailViewCasing.spec.js
+++ b/packages/server/src/migrations/functions/tests/userEmailViewCasing.spec.js
@@ -8,9 +8,8 @@ jest.mock("@budibase/backend-core", () => {
     }
   }
 })
-const { tenancy, db: dbCore } = require("@budibase/backend-core")
+const { context, db: dbCore } = require("@budibase/backend-core")
 const TestConfig = require("../../../tests/utilities/TestConfiguration")
-const { TENANT_ID } = require("../../../tests/utilities/structures")
 
 // mock email view creation
 
@@ -26,8 +25,8 @@ describe("run", () => {
     afterAll(config.end)
 
     it("runs successfully", async () => {
-      await tenancy.doInTenant(TENANT_ID, async () => {
-        const globalDb = tenancy.getGlobalDB()
+      await config.doInTenant(async () => {
+        const globalDb = context.getGlobalDB()
         await migration.run(globalDb)
         expect(dbCore.createNewUserEmailView).toHaveBeenCalledTimes(1)
       })

--- a/packages/server/src/migrations/tests/helpers.ts
+++ b/packages/server/src/migrations/tests/helpers.ts
@@ -1,7 +1,7 @@
 // Mimic configs test configuration from worker, creation configs directly in database
 
 import * as structures from "./structures"
-import { db } from "@budibase/backend-core"
+import { configs } from "@budibase/backend-core"
 import { Config } from "@budibase/types"
 
 export const saveSettingsConfig = async (globalDb: any) => {
@@ -25,7 +25,7 @@ export const saveSmtpConfig = async (globalDb: any) => {
 }
 
 const saveConfig = async (config: Config, globalDb: any) => {
-  config._id = db.generateConfigID({ type: config.type })
+  config._id = configs.generateConfigID(config.type)
 
   let response
   try {

--- a/packages/server/src/migrations/tests/structures.ts
+++ b/packages/server/src/migrations/tests/structures.ts
@@ -20,6 +20,7 @@ export const oidc = (conf?: OIDCConfig): OIDCConfig => {
           name: "Active Directory",
           uuid: utils.newid(),
           activated: true,
+          scopes: [],
           ...conf,
         },
       ],

--- a/packages/server/src/tests/jestEnv.ts
+++ b/packages/server/src/tests/jestEnv.ts
@@ -8,3 +8,4 @@ process.env.BUDIBASE_DIR = tmpdir("budibase-unittests")
 process.env.LOG_LEVEL = process.env.LOG_LEVEL || "error"
 process.env.ENABLE_4XX_HTTP_LOGGING = "0"
 process.env.MOCK_REDIS = "1"
+process.env.PLATFORM_URL = "http://localhost:10000"

--- a/packages/server/src/tests/utilities/TestConfiguration.ts
+++ b/packages/server/src/tests/utilities/TestConfiguration.ts
@@ -21,7 +21,6 @@ import {
   basicScreen,
   basicLayout,
   basicWebhook,
-  TENANT_ID,
 } from "./structures"
 import {
   constants,
@@ -41,8 +40,8 @@ import { generateUserMetadataID } from "../../db/utils"
 import { startup } from "../../startup"
 import supertest from "supertest"
 import {
+  App,
   AuthToken,
-  Database,
   Datasource,
   Row,
   SourceName,
@@ -63,7 +62,7 @@ class TestConfiguration {
   started: boolean
   appId: string | null
   allApps: any[]
-  app: any
+  app?: App
   prodApp: any
   prodAppId: any
   user: any
@@ -73,7 +72,7 @@ class TestConfiguration {
   linkedTable: any
   automation: any
   datasource: any
-  tenantId: string | null
+  tenantId?: string
   defaultUserValues: DefaultUserValues
 
   constructor(openServer = true) {
@@ -89,7 +88,6 @@ class TestConfiguration {
     }
     this.appId = null
     this.allApps = []
-    this.tenantId = null
     this.defaultUserValues = this.populateDefaultUserValues()
   }
 
@@ -154,19 +152,10 @@ class TestConfiguration {
 
   // use a new id as the name to avoid name collisions
   async init(appName = newid()) {
-    this.defaultUserValues = this.populateDefaultUserValues()
-    if (context.isMultiTenant()) {
-      this.tenantId = structures.tenant.id()
-    }
-
     if (!this.started) {
       await startup()
     }
-    this.user = await this.globalUser()
-    this.globalUserId = this.user._id
-    this.userMetadataId = generateUserMetadataID(this.globalUserId)
-
-    return this.createApp(appName)
+    return this.newTenant(appName)
   }
 
   end() {
@@ -182,24 +171,22 @@ class TestConfiguration {
   }
 
   // MODES
-  #setMultiTenancy = (value: boolean) => {
+  setMultiTenancy = (value: boolean) => {
     env._set("MULTI_TENANCY", value)
     coreEnv._set("MULTI_TENANCY", value)
   }
 
-  #setSelfHosted = (value: boolean) => {
+  setSelfHosted = (value: boolean) => {
     env._set("SELF_HOSTED", value)
     coreEnv._set("SELF_HOSTED", value)
   }
 
   modeCloud = () => {
-    this.#setSelfHosted(false)
-    this.#setMultiTenancy(true)
+    this.setSelfHosted(false)
   }
 
   modeSelf = () => {
-    this.#setSelfHosted(true)
-    this.#setMultiTenancy(false)
+    this.setSelfHosted(true)
   }
 
   // UTILS
@@ -354,6 +341,8 @@ class TestConfiguration {
     })
   }
 
+  // HEADERS
+
   defaultHeaders(extras = {}) {
     const tenantId = this.getTenantId()
     const authObj: AuthToken = {
@@ -374,6 +363,7 @@ class TestConfiguration {
         `${constants.Cookie.CurrentApp}=${appToken}`,
       ],
       [constants.Header.CSRF_TOKEN]: this.defaultUserValues.csrfToken,
+      Host: this.tenantHost(),
       ...extras,
     }
 
@@ -381,10 +371,6 @@ class TestConfiguration {
       headers[constants.Header.APP_ID] = this.appId
     }
     return headers
-  }
-
-  getTenantId() {
-    return this.tenantId || TENANT_ID
   }
 
   publicHeaders({ prodApp = true } = {}) {
@@ -397,9 +383,7 @@ class TestConfiguration {
       headers[constants.Header.APP_ID] = appId
     }
 
-    if (this.tenantId) {
-      headers[constants.Header.TENANT_ID] = this.tenantId
-    }
+    headers[constants.Header.TENANT_ID] = this.getTenantId()
 
     return headers
   }
@@ -411,6 +395,34 @@ class TestConfiguration {
     prodApp = true,
   } = {}) {
     return this.login({ email, roleId, builder, prodApp })
+  }
+
+  // TENANCY
+
+  tenantHost() {
+    const tenantId = this.getTenantId()
+    const platformHost = new URL(coreEnv.PLATFORM_URL).host.split(":")[0]
+    return `${tenantId}.${platformHost}`
+  }
+
+  getTenantId() {
+    if (!this.tenantId) {
+      throw new Error("no test tenant id - init has not been called")
+    }
+    return this.tenantId
+  }
+
+  async newTenant(appName = newid()): Promise<App> {
+    this.defaultUserValues = this.populateDefaultUserValues()
+    this.tenantId = structures.tenant.id()
+    this.user = await this.globalUser()
+    this.globalUserId = this.user._id
+    this.userMetadataId = generateUserMetadataID(this.globalUserId)
+    return this.createApp(appName)
+  }
+
+  doInTenant(task: any) {
+    return context.doInTenant(this.getTenantId(), task)
   }
 
   // API
@@ -432,7 +444,7 @@ class TestConfiguration {
   }
 
   // APP
-  async createApp(appName: string) {
+  async createApp(appName: string): Promise<App> {
     // create dev app
     // clear any old app
     this.appId = null
@@ -442,7 +454,7 @@ class TestConfiguration {
         null,
         controllers.app.create
       )
-      this.appId = this.app.appId
+      this.appId = this.app?.appId!
     })
     return await context.doInAppContext(this.appId, async () => {
       // create production app

--- a/packages/server/src/tests/utilities/structures.ts
+++ b/packages/server/src/tests/utilities/structures.ts
@@ -13,8 +13,6 @@ import {
 
 const { v4: uuidv4 } = require("uuid")
 
-export const TENANT_ID = "default"
-
 export function basicTable() {
   return {
     name: "TestTable",

--- a/packages/types/src/api/web/global/configs.ts
+++ b/packages/types/src/api/web/global/configs.ts
@@ -1,0 +1,23 @@
+import { SettingsConfig, SettingsInnerConfig } from "../../../documents"
+
+/**
+ * Settings that aren't stored in the database - enriched at runtime.
+ */
+export interface PublicSettingsInnerConfig extends SettingsInnerConfig {
+  google: boolean
+  oidc: boolean
+  oidcCallbackUrl: string
+  googleCallbackUrl: string
+}
+
+export interface GetPublicSettingsResponse extends SettingsConfig {
+  config: PublicSettingsInnerConfig
+}
+
+export interface PublicOIDCConfig {
+  logo?: string
+  name?: string
+  uuid?: string
+}
+
+export type GetPublicOIDCConfigResponse = PublicOIDCConfig[]

--- a/packages/types/src/api/web/global/index.ts
+++ b/packages/types/src/api/web/global/index.ts
@@ -1,2 +1,3 @@
 export * from "./environmentVariables"
 export * from "./events"
+export * from "./configs"

--- a/packages/types/src/documents/global/config.ts
+++ b/packages/types/src/documents/global/config.ts
@@ -39,7 +39,9 @@ export interface GoogleInnerConfig {
   clientID: string
   clientSecret: string
   activated: boolean
-  // deprecated / read only
+  /**
+   * @deprecated read only
+   */
   callbackURL?: string
 }
 

--- a/packages/types/src/documents/global/config.ts
+++ b/packages/types/src/documents/global/config.ts
@@ -29,6 +29,7 @@ export interface SettingsInnerConfig {
   logoUrlEtag?: string
   uniqueTenantId?: string
   analyticsEnabled?: boolean
+  isSSOEnforced?: boolean
 }
 
 export interface SettingsConfig extends Config {

--- a/packages/types/src/documents/global/config.ts
+++ b/packages/types/src/documents/global/config.ts
@@ -5,32 +5,42 @@ export interface Config extends Document {
   config: any
 }
 
-export interface SMTPConfig extends Config {
-  config: {
-    port: number
-    host: string
-    from: string
-    subject: string
-    secure: boolean
+export interface SMTPInnerConfig {
+  port: number
+  host: string
+  from: string
+  subject?: string
+  secure: boolean
+  auth?: {
+    user: string
+    pass: string
   }
+  connectionTimeout?: any
+}
+
+export interface SMTPConfig extends Config {
+  config: SMTPInnerConfig
+}
+
+export interface SettingsInnerConfig {
+  platformUrl?: string
+  company?: string
+  logoUrl?: string // Populated on read
+  logoUrlEtag?: string
+  uniqueTenantId?: string
+  analyticsEnabled?: boolean
 }
 
 export interface SettingsConfig extends Config {
-  config: {
-    company: string
-    // Populated on read
-    logoUrl?: string
-    logoUrlEtag?: boolean
-    platformUrl: string
-    uniqueTenantId?: string
-    analyticsEnabled?: boolean
-  }
+  config: SettingsInnerConfig
 }
 
 export interface GoogleInnerConfig {
   clientID: string
   clientSecret: string
   activated: boolean
+  // deprecated / read only
+  callbackURL?: string
 }
 
 export interface GoogleConfig extends Config {
@@ -55,6 +65,7 @@ export interface OIDCInnerConfig {
   name: string
   uuid: string
   activated: boolean
+  scopes: string[]
 }
 
 export interface OIDCConfig extends Config {

--- a/packages/types/src/sdk/licensing/feature.ts
+++ b/packages/types/src/sdk/licensing/feature.ts
@@ -2,4 +2,5 @@ export enum Feature {
   USER_GROUPS = "userGroups",
   APP_BACKUPS = "appBackups",
   ENVIRONMENT_VARIABLES = "environmentVariables",
+  ENFORCEABLE_SSO = "enforceableSSO",
 }

--- a/packages/worker/src/api/controllers/global/auth.ts
+++ b/packages/worker/src/api/controllers/global/auth.ts
@@ -61,8 +61,8 @@ export const login = async (ctx: Ctx<LoginRequest>, next: any) => {
   const email = ctx.request.body.username
 
   const user = await userSdk.getUserByEmail(email)
-  if (user && (await userSdk.isPreventSSOPasswords(user))) {
-    ctx.throw(400, "SSO user cannot login using password")
+  if (user && (await userSdk.isPreventPasswordActions(user))) {
+    ctx.throw(400, "Password login is disabled for this user")
   }
 
   return passport.authenticate(

--- a/packages/worker/src/api/controllers/global/auth.ts
+++ b/packages/worker/src/api/controllers/global/auth.ts
@@ -2,10 +2,9 @@ import {
   auth as authCore,
   constants,
   context,
-  db as dbCore,
   events,
-  tenancy,
   utils as utilsCore,
+  configs,
 } from "@budibase/backend-core"
 import {
   ConfigType,
@@ -15,6 +14,7 @@ import {
   SSOUser,
   PasswordResetRequest,
   PasswordResetUpdateRequest,
+  GoogleInnerConfig,
 } from "@budibase/types"
 import env from "../../../environment"
 
@@ -163,8 +163,8 @@ export const datasourceAuth = async (ctx: any, next: any) => {
 
 // GOOGLE SSO
 
-export async function googleCallbackUrl(config?: { callbackURL?: string }) {
-  return ssoCallbackUrl(tenancy.getGlobalDB(), config, ConfigType.GOOGLE)
+export async function googleCallbackUrl(config?: GoogleInnerConfig) {
+  return ssoCallbackUrl(ConfigType.GOOGLE, config)
 }
 
 /**
@@ -172,12 +172,10 @@ export async function googleCallbackUrl(config?: { callbackURL?: string }) {
  * On a successful login, you will be redirected to the googleAuth callback route.
  */
 export const googlePreAuth = async (ctx: any, next: any) => {
-  const db = tenancy.getGlobalDB()
-
-  const config = await dbCore.getScopedConfig(db, {
-    type: ConfigType.GOOGLE,
-    workspace: ctx.query.workspace,
-  })
+  const config = await configs.getGoogleConfig()
+  if (!config) {
+    return ctx.throw(400, "Google config not found")
+  }
   let callbackUrl = await googleCallbackUrl(config)
   const strategy = await google.strategyFactory(
     config,
@@ -193,12 +191,10 @@ export const googlePreAuth = async (ctx: any, next: any) => {
 }
 
 export const googleCallback = async (ctx: any, next: any) => {
-  const db = tenancy.getGlobalDB()
-
-  const config = await dbCore.getScopedConfig(db, {
-    type: ConfigType.GOOGLE,
-    workspace: ctx.query.workspace,
-  })
+  const config = await configs.getGoogleConfig()
+  if (!config) {
+    return ctx.throw(400, "Google config not found")
+  }
   const callbackUrl = await googleCallbackUrl(config)
   const strategy = await google.strategyFactory(
     config,
@@ -221,25 +217,20 @@ export const googleCallback = async (ctx: any, next: any) => {
 
 // OIDC SSO
 
-export async function oidcCallbackUrl(config?: { callbackURL?: string }) {
-  return ssoCallbackUrl(tenancy.getGlobalDB(), config, ConfigType.OIDC)
+export async function oidcCallbackUrl() {
+  return ssoCallbackUrl(ConfigType.OIDC)
 }
 
 export const oidcStrategyFactory = async (ctx: any, configId: any) => {
-  const db = tenancy.getGlobalDB()
-  const config = await dbCore.getScopedConfig(db, {
-    type: ConfigType.OIDC,
-    group: ctx.query.group,
-  })
+  const config = await configs.getOIDCConfig()
+  if (!config) {
+    return ctx.throw(400, "OIDC config not found")
+  }
 
-  const chosenConfig = config.configs.filter((c: any) => c.uuid === configId)[0]
-  let callbackUrl = await oidcCallbackUrl(chosenConfig)
+  let callbackUrl = await oidcCallbackUrl()
 
   //Remote Config
-  const enrichedConfig = await oidc.fetchStrategyConfig(
-    chosenConfig,
-    callbackUrl
-  )
+  const enrichedConfig = await oidc.fetchStrategyConfig(config, callbackUrl)
   return oidc.strategyFactory(enrichedConfig, userSdk.save)
 }
 
@@ -247,23 +238,23 @@ export const oidcStrategyFactory = async (ctx: any, configId: any) => {
  * The initial call that OIDC authentication makes to take you to the configured OIDC login screen.
  * On a successful login, you will be redirected to the oidcAuth callback route.
  */
-export const oidcPreAuth = async (ctx: any, next: any) => {
+export const oidcPreAuth = async (ctx: Ctx, next: any) => {
   const { configId } = ctx.params
+  if (!configId) {
+    ctx.throw(400, "OIDC config id is required")
+  }
   const strategy = await oidcStrategyFactory(ctx, configId)
 
   setCookie(ctx, configId, Cookie.OIDC_CONFIG)
 
-  const db = tenancy.getGlobalDB()
-  const config = await dbCore.getScopedConfig(db, {
-    type: ConfigType.OIDC,
-    group: ctx.query.group,
-  })
-
-  const chosenConfig = config.configs.filter((c: any) => c.uuid === configId)[0]
+  const config = await configs.getOIDCConfigById(configId)
+  if (!config) {
+    return ctx.throw(400, "OIDC config not found")
+  }
 
   let authScopes =
-    chosenConfig.scopes?.length > 0
-      ? chosenConfig.scopes
+    config.scopes?.length > 0
+      ? config.scopes
       : ["profile", "email", "offline_access"]
 
   return passport.authenticate(strategy, {

--- a/packages/worker/src/api/controllers/global/configs.ts
+++ b/packages/worker/src/api/controllers/global/configs.ts
@@ -2,37 +2,30 @@ import * as email from "../../../utilities/email"
 import env from "../../../environment"
 import { googleCallbackUrl, oidcCallbackUrl } from "./auth"
 import {
-  events,
   cache,
-  objectStore,
-  tenancy,
+  configs,
   db as dbCore,
   env as coreEnv,
+  events,
+  objectStore,
+  tenancy,
 } from "@budibase/backend-core"
 import { checkAnyUserExists } from "../../../utilities/users"
 import {
-  Database,
-  Config as ConfigDoc,
+  Config,
   ConfigType,
-  SSOType,
-  GoogleConfig,
-  OIDCConfig,
-  SettingsConfig,
+  Ctx,
+  GetPublicOIDCConfigResponse,
+  GetPublicSettingsResponse,
   isGoogleConfig,
   isOIDCConfig,
   isSettingsConfig,
   isSMTPConfig,
-  Ctx,
   UserCtx,
 } from "@budibase/types"
 
-const getEventFns = async (db: Database, config: ConfigDoc) => {
+const getEventFns = async (config: Config, existing?: Config) => {
   const fns = []
-
-  let existing
-  if (config._id) {
-    existing = await db.get(config._id)
-  }
 
   if (!existing) {
     if (isSMTPConfig(config)) {
@@ -125,21 +118,21 @@ const getEventFns = async (db: Database, config: ConfigDoc) => {
   return fns
 }
 
-export async function save(ctx: UserCtx) {
-  const db = tenancy.getGlobalDB()
-  const { type, workspace, user, config } = ctx.request.body
-  let eventFns = await getEventFns(db, ctx.request.body)
+export async function save(ctx: UserCtx<Config>) {
+  const body = ctx.request.body
+  const type = body.type
+  const config = body.config
+
+  const existingConfig = await configs.getConfig(type)
+  let eventFns = await getEventFns(ctx.request.body, existingConfig)
+
   // Config does not exist yet
-  if (!ctx.request.body._id) {
-    ctx.request.body._id = dbCore.generateConfigID({
-      type,
-      workspace,
-      user,
-    })
+  if (!existingConfig) {
+    body._id = configs.generateConfigID(type)
   }
   try {
     // verify the configuration
-    switch (type) {
+    switch (config.type) {
       case ConfigType.SMTP:
         await email.verifyConfig(config)
         break
@@ -149,7 +142,7 @@ export async function save(ctx: UserCtx) {
   }
 
   try {
-    const response = await db.put(ctx.request.body)
+    const response = await configs.save(body)
     await cache.bustCache(cache.CacheKey.CHECKLIST)
     await cache.bustCache(cache.CacheKey.ANALYTICS_ENABLED)
 
@@ -167,44 +160,11 @@ export async function save(ctx: UserCtx) {
   }
 }
 
-export async function fetch(ctx: UserCtx) {
-  const db = tenancy.getGlobalDB()
-  const response = await db.allDocs(
-    dbCore.getConfigParams(
-      { type: ctx.params.type },
-      {
-        include_docs: true,
-      }
-    )
-  )
-  ctx.body = response.rows.map(row => row.doc)
-}
-
-/**
- * Gets the most granular config for a particular configuration type.
- * The hierarchy is type -> workspace -> user.
- */
 export async function find(ctx: UserCtx) {
-  const db = tenancy.getGlobalDB()
-
-  const { userId, workspaceId } = ctx.query
-  if (workspaceId && userId) {
-    const workspace = await db.get(workspaceId as string)
-    const userInWorkspace = workspace.users.some(
-      (workspaceUser: any) => workspaceUser === userId
-    )
-    if (!ctx.user!.admin && !userInWorkspace) {
-      ctx.throw(400, `User is not in specified workspace: ${workspace}.`)
-    }
-  }
-
   try {
     // Find the config with the most granular scope based on context
-    const scopedConfig = await dbCore.getScopedFullConfig(db, {
-      type: ctx.params.type,
-      user: userId,
-      workspace: workspaceId,
-    })
+    const type = ctx.params.type
+    const scopedConfig = await configs.getConfig(type)
 
     if (scopedConfig) {
       ctx.body = scopedConfig
@@ -217,85 +177,64 @@ export async function find(ctx: UserCtx) {
   }
 }
 
-export async function publicOidc(ctx: Ctx) {
-  const db = tenancy.getGlobalDB()
+export async function publicOidc(ctx: Ctx<void, GetPublicOIDCConfigResponse>) {
   try {
     // Find the config with the most granular scope based on context
-    const oidcConfig: OIDCConfig = await dbCore.getScopedFullConfig(db, {
-      type: ConfigType.OIDC,
-    })
+    const config = await configs.getOIDCConfig()
 
-    if (!oidcConfig) {
-      ctx.body = {}
+    if (!config) {
+      ctx.body = []
     } else {
-      ctx.body = oidcConfig.config.configs.map(config => ({
-        logo: config.logo,
-        name: config.name,
-        uuid: config.uuid,
-      }))
+      ctx.body = [
+        {
+          logo: config.logo,
+          name: config.name,
+          uuid: config.uuid,
+        },
+      ]
     }
   } catch (err: any) {
     ctx.throw(err.status, err)
   }
 }
 
-export async function publicSettings(ctx: Ctx) {
-  const db = tenancy.getGlobalDB()
-
+export async function publicSettings(
+  ctx: Ctx<void, GetPublicSettingsResponse>
+) {
   try {
-    // Find the config with the most granular scope based on context
-    const publicConfig = await dbCore.getScopedFullConfig(db, {
-      type: ConfigType.SETTINGS,
-    })
-
-    const googleConfig = await dbCore.getScopedFullConfig(db, {
-      type: ConfigType.GOOGLE,
-    })
-
-    const oidcConfig = await dbCore.getScopedFullConfig(db, {
-      type: ConfigType.OIDC,
-    })
-
-    let config
-    if (!publicConfig) {
-      config = {
-        config: {},
-      }
-    } else {
-      config = publicConfig
-    }
-
-    // enrich the logo url
-    // empty url means deleted
-    if (config.config.logoUrl && config.config.logoUrl !== "") {
-      config.config.logoUrl = objectStore.getGlobalFileUrl(
+    // settings
+    const config = await configs.getSettingsConfig()
+    // enrich the logo url - empty url means deleted
+    if (config.logoUrl && config.logoUrl !== "") {
+      config.logoUrl = objectStore.getGlobalFileUrl(
         "settings",
         "logoUrl",
-        config.config.logoUrlEtag
+        config.logoUrlEtag
       )
     }
 
-    // google button flag
-    if (googleConfig && googleConfig.config) {
-      // activated by default for configs pre-activated flag
-      config.config.google =
-        googleConfig.config.activated == null || googleConfig.config.activated
-    } else {
-      config.config.google = false
+    // google
+    const googleConfig = await configs.getGoogleConfig()
+    const preActivated = googleConfig?.activated == null
+    const google = preActivated || !!googleConfig?.activated
+    const _googleCallbackUrl = await googleCallbackUrl(googleConfig)
+
+    // oidc
+    const oidcConfig = await configs.getOIDCConfig()
+    const oidc = oidcConfig?.activated || false
+    const _oidcCallbackUrl = await oidcCallbackUrl()
+
+    ctx.body = {
+      type: ConfigType.SETTINGS,
+      _id: configs.generateConfigID(ConfigType.SETTINGS),
+      config: {
+        ...config,
+        google,
+        oidc,
+        oidcCallbackUrl: _oidcCallbackUrl,
+        googleCallbackUrl: _googleCallbackUrl,
+      },
     }
-
-    // callback urls
-    config.config.oidcCallbackUrl = await oidcCallbackUrl()
-    config.config.googleCallbackUrl = await googleCallbackUrl()
-
-    // oidc button flag
-    if (oidcConfig && oidcConfig.config) {
-      config.config.oidc = oidcConfig.config.configs[0].activated
-    } else {
-      config.config.oidc = false
-    }
-
-    ctx.body = config
   } catch (err: any) {
     ctx.throw(err.status, err)
   }
@@ -319,12 +258,11 @@ export async function upload(ctx: UserCtx) {
   })
 
   // add to configuration structure
-  // TODO: right now this only does a global level
-  const db = tenancy.getGlobalDB()
-  let cfgStructure = await dbCore.getScopedFullConfig(db, { type })
-  if (!cfgStructure) {
-    cfgStructure = {
-      _id: dbCore.generateConfigID({ type }),
+  let config = await configs.getConfig(type)
+  if (!config) {
+    config = {
+      _id: configs.generateConfigID(type),
+      type,
       config: {},
     }
   }
@@ -332,14 +270,14 @@ export async function upload(ctx: UserCtx) {
   // save the Etag for cache bursting
   const etag = result.ETag
   if (etag) {
-    cfgStructure.config[`${name}Etag`] = etag.replace(/"/g, "")
+    config.config[`${name}Etag`] = etag.replace(/"/g, "")
   }
 
   // save the file key
-  cfgStructure.config[`${name}`] = key
+  config.config[`${name}`] = key
 
   // write back to db
-  await db.put(cfgStructure)
+  await configs.save(config)
 
   ctx.body = {
     message: "File has been uploaded and url stored to config.",
@@ -360,7 +298,6 @@ export async function destroy(ctx: UserCtx) {
 }
 
 export async function configChecklist(ctx: Ctx) {
-  const db = tenancy.getGlobalDB()
   const tenantId = tenancy.getTenantId()
 
   try {
@@ -375,19 +312,13 @@ export async function configChecklist(ctx: Ctx) {
         }
 
         // They have set up SMTP
-        const smtpConfig = await dbCore.getScopedFullConfig(db, {
-          type: ConfigType.SMTP,
-        })
+        const smtpConfig = await configs.getSMTPConfig()
 
         // They have set up Google Auth
-        const googleConfig = await dbCore.getScopedFullConfig(db, {
-          type: ConfigType.GOOGLE,
-        })
+        const googleConfig = await configs.getGoogleConfig()
 
         // They have set up OIDC
-        const oidcConfig = await dbCore.getScopedFullConfig(db, {
-          type: ConfigType.OIDC,
-        })
+        const oidcConfig = await configs.getOIDCConfig()
 
         // They have set up a global user
         const userExists = await checkAnyUserExists()

--- a/packages/worker/src/api/routes/global/configs.ts
+++ b/packages/worker/src/api/routes/global/configs.ts
@@ -104,13 +104,7 @@ router
     controller.save
   )
   .delete("/api/global/configs/:id/:rev", auth.adminOnly, controller.destroy)
-  .get("/api/global/configs", controller.fetch)
   .get("/api/global/configs/checklist", controller.configChecklist)
-  .get(
-    "/api/global/configs/all/:type",
-    buildConfigGetValidation(),
-    controller.fetch
-  )
   .get("/api/global/configs/public", controller.publicSettings)
   .get("/api/global/configs/public/oidc", controller.publicOidc)
   .get("/api/global/configs/:type", buildConfigGetValidation(), controller.find)

--- a/packages/worker/src/api/routes/global/tests/auth.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/auth.spec.ts
@@ -110,7 +110,7 @@ describe("/api/global/auth", () => {
           )
 
           expect(response.body).toEqual({
-            message: "SSO user cannot login using password",
+            message: "Password login is disabled for this user",
             status: 400,
           })
         }
@@ -175,7 +175,7 @@ describe("/api/global/auth", () => {
           )
 
           expect(res.body).toEqual({
-            message: "SSO user cannot reset password",
+            message: "Password reset is disabled for this user",
             status: 400,
             error: {
               code: "http",

--- a/packages/worker/src/api/routes/global/tests/configs.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/configs.spec.ts
@@ -2,7 +2,8 @@
 jest.mock("nodemailer")
 import { TestConfiguration, structures, mocks } from "../../../../tests"
 mocks.email.mock()
-import { Config, events } from "@budibase/backend-core"
+import { events } from "@budibase/backend-core"
+import { GetPublicSettingsResponse, Config, ConfigType } from "@budibase/types"
 
 describe("configs", () => {
   const config = new TestConfiguration()
@@ -19,22 +20,29 @@ describe("configs", () => {
     await config.afterAll()
   })
 
-  describe("post /api/global/configs", () => {
-    const saveConfig = async (conf: any, _id?: string, _rev?: string) => {
-      const data = {
-        ...conf,
-        _id,
-        _rev,
-      }
-
-      const res = await config.api.configs.saveConfig(data)
-
-      return {
-        ...data,
-        ...res.body,
-      }
+  const saveConfig = async (conf: Config, _id?: string, _rev?: string) => {
+    const data = {
+      ...conf,
+      _id,
+      _rev,
     }
+    const res = await config.api.configs.saveConfig(data)
+    return {
+      ...data,
+      ...res.body,
+    }
+  }
 
+  const saveSettingsConfig = async (
+    conf?: any,
+    _id?: string,
+    _rev?: string
+  ) => {
+    const settingsConfig = structures.configs.settings(conf)
+    return saveConfig(settingsConfig, _id, _rev)
+  }
+
+  describe("POST /api/global/configs", () => {
     describe("google", () => {
       const saveGoogleConfig = async (
         conf?: any,
@@ -49,20 +57,20 @@ describe("configs", () => {
         it("should create activated google config", async () => {
           await saveGoogleConfig()
           expect(events.auth.SSOCreated).toBeCalledTimes(1)
-          expect(events.auth.SSOCreated).toBeCalledWith(Config.GOOGLE)
+          expect(events.auth.SSOCreated).toBeCalledWith(ConfigType.GOOGLE)
           expect(events.auth.SSODeactivated).not.toBeCalled()
           expect(events.auth.SSOActivated).toBeCalledTimes(1)
-          expect(events.auth.SSOActivated).toBeCalledWith(Config.GOOGLE)
-          await config.deleteConfig(Config.GOOGLE)
+          expect(events.auth.SSOActivated).toBeCalledWith(ConfigType.GOOGLE)
+          await config.deleteConfig(ConfigType.GOOGLE)
         })
 
         it("should create deactivated google config", async () => {
           await saveGoogleConfig({ activated: false })
           expect(events.auth.SSOCreated).toBeCalledTimes(1)
-          expect(events.auth.SSOCreated).toBeCalledWith(Config.GOOGLE)
+          expect(events.auth.SSOCreated).toBeCalledWith(ConfigType.GOOGLE)
           expect(events.auth.SSOActivated).not.toBeCalled()
           expect(events.auth.SSODeactivated).not.toBeCalled()
-          await config.deleteConfig(Config.GOOGLE)
+          await config.deleteConfig(ConfigType.GOOGLE)
         })
       })
 
@@ -76,11 +84,11 @@ describe("configs", () => {
             googleConf._rev
           )
           expect(events.auth.SSOUpdated).toBeCalledTimes(1)
-          expect(events.auth.SSOUpdated).toBeCalledWith(Config.GOOGLE)
+          expect(events.auth.SSOUpdated).toBeCalledWith(ConfigType.GOOGLE)
           expect(events.auth.SSOActivated).not.toBeCalled()
           expect(events.auth.SSODeactivated).toBeCalledTimes(1)
-          expect(events.auth.SSODeactivated).toBeCalledWith(Config.GOOGLE)
-          await config.deleteConfig(Config.GOOGLE)
+          expect(events.auth.SSODeactivated).toBeCalledWith(ConfigType.GOOGLE)
+          await config.deleteConfig(ConfigType.GOOGLE)
         })
 
         it("should update google config to activated", async () => {
@@ -92,11 +100,11 @@ describe("configs", () => {
             googleConf._rev
           )
           expect(events.auth.SSOUpdated).toBeCalledTimes(1)
-          expect(events.auth.SSOUpdated).toBeCalledWith(Config.GOOGLE)
+          expect(events.auth.SSOUpdated).toBeCalledWith(ConfigType.GOOGLE)
           expect(events.auth.SSODeactivated).not.toBeCalled()
           expect(events.auth.SSOActivated).toBeCalledTimes(1)
-          expect(events.auth.SSOActivated).toBeCalledWith(Config.GOOGLE)
-          await config.deleteConfig(Config.GOOGLE)
+          expect(events.auth.SSOActivated).toBeCalledWith(ConfigType.GOOGLE)
+          await config.deleteConfig(ConfigType.GOOGLE)
         })
       })
     })
@@ -115,20 +123,20 @@ describe("configs", () => {
         it("should create activated OIDC config", async () => {
           await saveOIDCConfig()
           expect(events.auth.SSOCreated).toBeCalledTimes(1)
-          expect(events.auth.SSOCreated).toBeCalledWith(Config.OIDC)
+          expect(events.auth.SSOCreated).toBeCalledWith(ConfigType.OIDC)
           expect(events.auth.SSODeactivated).not.toBeCalled()
           expect(events.auth.SSOActivated).toBeCalledTimes(1)
-          expect(events.auth.SSOActivated).toBeCalledWith(Config.OIDC)
-          await config.deleteConfig(Config.OIDC)
+          expect(events.auth.SSOActivated).toBeCalledWith(ConfigType.OIDC)
+          await config.deleteConfig(ConfigType.OIDC)
         })
 
         it("should create deactivated OIDC config", async () => {
           await saveOIDCConfig({ activated: false })
           expect(events.auth.SSOCreated).toBeCalledTimes(1)
-          expect(events.auth.SSOCreated).toBeCalledWith(Config.OIDC)
+          expect(events.auth.SSOCreated).toBeCalledWith(ConfigType.OIDC)
           expect(events.auth.SSOActivated).not.toBeCalled()
           expect(events.auth.SSODeactivated).not.toBeCalled()
-          await config.deleteConfig(Config.OIDC)
+          await config.deleteConfig(ConfigType.OIDC)
         })
       })
 
@@ -142,11 +150,11 @@ describe("configs", () => {
             oidcConf._rev
           )
           expect(events.auth.SSOUpdated).toBeCalledTimes(1)
-          expect(events.auth.SSOUpdated).toBeCalledWith(Config.OIDC)
+          expect(events.auth.SSOUpdated).toBeCalledWith(ConfigType.OIDC)
           expect(events.auth.SSOActivated).not.toBeCalled()
           expect(events.auth.SSODeactivated).toBeCalledTimes(1)
-          expect(events.auth.SSODeactivated).toBeCalledWith(Config.OIDC)
-          await config.deleteConfig(Config.OIDC)
+          expect(events.auth.SSODeactivated).toBeCalledWith(ConfigType.OIDC)
+          await config.deleteConfig(ConfigType.OIDC)
         })
 
         it("should update OIDC config to activated", async () => {
@@ -158,11 +166,11 @@ describe("configs", () => {
             oidcConf._rev
           )
           expect(events.auth.SSOUpdated).toBeCalledTimes(1)
-          expect(events.auth.SSOUpdated).toBeCalledWith(Config.OIDC)
+          expect(events.auth.SSOUpdated).toBeCalledWith(ConfigType.OIDC)
           expect(events.auth.SSODeactivated).not.toBeCalled()
           expect(events.auth.SSOActivated).toBeCalledTimes(1)
-          expect(events.auth.SSOActivated).toBeCalledWith(Config.OIDC)
-          await config.deleteConfig(Config.OIDC)
+          expect(events.auth.SSOActivated).toBeCalledWith(ConfigType.OIDC)
+          await config.deleteConfig(ConfigType.OIDC)
         })
       })
     })
@@ -179,11 +187,11 @@ describe("configs", () => {
 
       describe("create", () => {
         it("should create SMTP config", async () => {
-          await config.deleteConfig(Config.SMTP)
+          await config.deleteConfig(ConfigType.SMTP)
           await saveSMTPConfig()
           expect(events.email.SMTPUpdated).not.toBeCalled()
           expect(events.email.SMTPCreated).toBeCalledTimes(1)
-          await config.deleteConfig(Config.SMTP)
+          await config.deleteConfig(ConfigType.SMTP)
         })
       })
 
@@ -194,24 +202,15 @@ describe("configs", () => {
           await saveSMTPConfig(smtpConf.config, smtpConf._id, smtpConf._rev)
           expect(events.email.SMTPCreated).not.toBeCalled()
           expect(events.email.SMTPUpdated).toBeCalledTimes(1)
-          await config.deleteConfig(Config.SMTP)
+          await config.deleteConfig(ConfigType.SMTP)
         })
       })
     })
 
     describe("settings", () => {
-      const saveSettingsConfig = async (
-        conf?: any,
-        _id?: string,
-        _rev?: string
-      ) => {
-        const settingsConfig = structures.configs.settings(conf)
-        return saveConfig(settingsConfig, _id, _rev)
-      }
-
       describe("create", () => {
         it("should create settings config with default settings", async () => {
-          await config.deleteConfig(Config.SETTINGS)
+          await config.deleteConfig(ConfigType.SETTINGS)
 
           await saveSettingsConfig()
 
@@ -222,7 +221,7 @@ describe("configs", () => {
 
         it("should create settings config with non-default settings", async () => {
           config.selfHosted()
-          await config.deleteConfig(Config.SETTINGS)
+          await config.deleteConfig(ConfigType.SETTINGS)
           const conf = {
             company: "acme",
             logoUrl: "http://example.com",
@@ -241,7 +240,7 @@ describe("configs", () => {
       describe("update", () => {
         it("should update settings config", async () => {
           config.selfHosted()
-          await config.deleteConfig(Config.SETTINGS)
+          await config.deleteConfig(ConfigType.SETTINGS)
           const settingsConfig = await saveSettingsConfig()
           settingsConfig.config.company = "acme"
           settingsConfig.config.logoUrl = "http://example.com"
@@ -262,14 +261,43 @@ describe("configs", () => {
     })
   })
 
-  it("should return the correct checklist status based on the state of the budibase installation", async () => {
-    await config.saveSmtpConfig()
+  describe("GET /api/global/configs/checklist", () => {
+    it("should return the correct checklist", async () => {
+      await config.saveSmtpConfig()
 
-    const res = await config.api.configs.getConfigChecklist()
-    const checklist = res.body
+      const res = await config.api.configs.getConfigChecklist()
+      const checklist = res.body
 
-    expect(checklist.apps.checked).toBeFalsy()
-    expect(checklist.smtp.checked).toBeTruthy()
-    expect(checklist.adminUser.checked).toBeTruthy()
+      expect(checklist.apps.checked).toBeFalsy()
+      expect(checklist.smtp.checked).toBeTruthy()
+      expect(checklist.adminUser.checked).toBeTruthy()
+    })
+  })
+
+  describe("GET /api/global/configs/public", () => {
+    it("should return the expected public settings", async () => {
+      await saveSettingsConfig()
+
+      const res = await config.api.configs.getPublicSettings()
+      const body = res.body as GetPublicSettingsResponse
+
+      const expected = {
+        _id: "config_settings",
+        type: "settings",
+        config: {
+          company: "Budibase",
+          logoUrl: "",
+          analyticsEnabled: false,
+          google: true,
+          googleCallbackUrl: `http://localhost:10000/api/global/auth/${config.tenantId}/google/callback`,
+          isSSOEnforced: false,
+          oidc: false,
+          oidcCallbackUrl: `http://localhost:10000/api/global/auth/${config.tenantId}/oidc/callback`,
+          platformUrl: "http://localhost:10000",
+        },
+      }
+      delete body._rev
+      expect(body).toEqual(expected)
+    })
   })
 })

--- a/packages/worker/src/api/routes/global/tests/realEmail.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/realEmail.spec.ts
@@ -1,3 +1,4 @@
+jest.unmock("node-fetch")
 import { TestConfiguration } from "../../../../tests"
 import { EmailTemplatePurpose } from "../../../../constants"
 const nodemailer = require("nodemailer")

--- a/packages/worker/src/environment.ts
+++ b/packages/worker/src/environment.ts
@@ -26,8 +26,6 @@ function parseIntSafe(number: any) {
   }
 }
 
-const selfHosted = !!parseInt(process.env.SELF_HOSTED || "")
-
 const environment = {
   // auth
   MINIO_ACCESS_KEY: process.env.MINIO_ACCESS_KEY,
@@ -51,7 +49,7 @@ const environment = {
   CLUSTER_PORT: process.env.CLUSTER_PORT,
   // flags
   NODE_ENV: process.env.NODE_ENV,
-  SELF_HOSTED: selfHosted,
+  SELF_HOSTED: !!parseInt(process.env.SELF_HOSTED || ""),
   LOG_LEVEL: process.env.LOG_LEVEL,
   MULTI_TENANCY: process.env.MULTI_TENANCY,
   DISABLE_ACCOUNT_PORTAL: process.env.DISABLE_ACCOUNT_PORTAL,
@@ -71,14 +69,6 @@ const environment = {
    * Mock the email service in use - links to ethereal hosted emails are logged instead.
    */
   ENABLE_EMAIL_TEST_MODE: process.env.ENABLE_EMAIL_TEST_MODE,
-  /**
-   * Enable to allow an admin user to login using a password.
-   * This can be useful to prevent lockout when configuring SSO.
-   * However, this should be turned OFF by default for security purposes.
-   */
-  ENABLE_SSO_MAINTENANCE_MODE: selfHosted
-    ? process.env.ENABLE_SSO_MAINTENANCE_MODE
-    : false,
   _set(key: any, value: any) {
     process.env[key] = value
     // @ts-ignore

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -13,7 +13,13 @@ import { Event } from "@sentry/types/dist/event"
 import Application from "koa"
 import { bootstrap } from "global-agent"
 import * as db from "./db"
-import { auth, logging, events, middleware } from "@budibase/backend-core"
+import {
+  auth,
+  logging,
+  events,
+  middleware,
+  env as coreEnv,
+} from "@budibase/backend-core"
 db.init()
 import Koa from "koa"
 import koaBody from "koa-body"
@@ -25,7 +31,7 @@ const koaSession = require("koa-session")
 const logger = require("koa-pino-logger")
 import destroyable from "server-destroy"
 
-if (env.ENABLE_SSO_MAINTENANCE_MODE) {
+if (coreEnv.ENABLE_SSO_MAINTENANCE_MODE) {
   console.warn(
     "Warning: ENABLE_SSO_MAINTENANCE_MODE is set. It is recommended this flag is disabled if maintenance is not in progress"
   )

--- a/packages/worker/src/sdk/auth/auth.ts
+++ b/packages/worker/src/sdk/auth/auth.ts
@@ -58,8 +58,8 @@ export const reset = async (email: string) => {
   }
 
   // exit if user has sso
-  if (await userSdk.isPreventSSOPasswords(user)) {
-    throw new HTTPError("SSO user cannot reset password", 400)
+  if (await userSdk.isPreventPasswordActions(user)) {
+    throw new HTTPError("Password reset is disabled for this user", 400)
   }
 
   // send password reset

--- a/packages/worker/src/sdk/users/tests/users.spec.ts
+++ b/packages/worker/src/sdk/users/tests/users.spec.ts
@@ -1,24 +1,48 @@
 import { structures } from "../../../tests"
-import * as users from "../users"
-import env from "../../../environment"
 import { mocks } from "@budibase/backend-core/tests"
+import { env } from "@budibase/backend-core"
+import * as users from "../users"
 import { CloudAccount } from "@budibase/types"
+import { isPreventPasswordActions } from "../users"
+
+jest.mock("@budibase/pro")
+import * as _pro from "@budibase/pro"
+const pro = jest.mocked(_pro, true)
 
 describe("users", () => {
-  describe("isPreventSSOPasswords", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("isPreventPasswordActions", () => {
+    it("returns false for non sso user", async () => {
+      const user = structures.users.user()
+      const result = await users.isPreventPasswordActions(user)
+      expect(result).toBe(false)
+    })
+
     it("returns true for sso account user", async () => {
       const user = structures.users.user()
       mocks.accounts.getAccount.mockReturnValue(
         Promise.resolve(structures.accounts.ssoAccount() as CloudAccount)
       )
-      const result = await users.isPreventSSOPasswords(user)
+      const result = await users.isPreventPasswordActions(user)
       expect(result).toBe(true)
     })
 
     it("returns true for sso user", async () => {
       const user = structures.users.ssoUser()
-      const result = await users.isPreventSSOPasswords(user)
+      const result = await users.isPreventPasswordActions(user)
       expect(result).toBe(true)
+    })
+
+    describe("enforced sso", () => {
+      it("returns true for all users when sso is enforced", async () => {
+        const user = structures.users.user()
+        pro.features.isSSOEnforced.mockReturnValue(Promise.resolve(true))
+        const result = await users.isPreventPasswordActions(user)
+        expect(result).toBe(true)
+      })
     })
 
     describe("sso maintenance mode", () => {
@@ -33,7 +57,7 @@ describe("users", () => {
       describe("non-admin user", () => {
         it("returns true", async () => {
           const user = structures.users.ssoUser()
-          const result = await users.isPreventSSOPasswords(user)
+          const result = await users.isPreventPasswordActions(user)
           expect(result).toBe(true)
         })
       })
@@ -43,7 +67,7 @@ describe("users", () => {
           const user = structures.users.ssoUser({
             user: structures.users.adminUser(),
           })
-          const result = await users.isPreventSSOPasswords(user)
+          const result = await users.isPreventPasswordActions(user)
           expect(result).toBe(false)
         })
       })

--- a/packages/worker/src/sdk/users/users.ts
+++ b/packages/worker/src/sdk/users/users.ts
@@ -14,6 +14,7 @@ import {
   users as usersCore,
   utils,
   ViewName,
+  env as coreEnv,
 } from "@budibase/backend-core"
 import {
   AccountMetadata,
@@ -34,7 +35,7 @@ import {
 } from "@budibase/types"
 import { sendEmail } from "../../utilities/email"
 import { EmailTemplatePurpose } from "../../constants"
-import { groups as groupsSdk } from "@budibase/pro"
+import * as pro from "@budibase/pro"
 import * as accountSdk from "../accounts"
 
 const PAGE_LIMIT = 8
@@ -122,8 +123,8 @@ const buildUser = async (
 
   let hashedPassword
   if (password) {
-    if (await isPreventSSOPasswords(user)) {
-      throw new HTTPError("SSO user cannot set password", 400)
+    if (await isPreventPasswordActions(user)) {
+      throw new HTTPError("Password change is disabled for this user", 400)
     }
     hashedPassword = opts.hashPassword ? await utils.hash(password) : password
   } else if (dbUser) {
@@ -188,11 +189,16 @@ const validateUniqueUser = async (email: string, tenantId: string) => {
   }
 }
 
-export async function isPreventSSOPasswords(user: User) {
+export async function isPreventPasswordActions(user: User) {
   // when in maintenance mode we allow sso users with the admin role
   // to perform any password action - this prevents lockout
-  if (env.ENABLE_SSO_MAINTENANCE_MODE && user.admin?.global) {
+  if (coreEnv.ENABLE_SSO_MAINTENANCE_MODE && user.admin?.global) {
     return false
+  }
+
+  // SSO is enforced for all users
+  if (await pro.features.isSSOEnforced()) {
+    return true
   }
 
   // Check local sso
@@ -278,7 +284,7 @@ export const save = async (
 
     if (userGroups.length > 0) {
       for (let groupId of userGroups) {
-        groupPromises.push(groupsSdk.addUsers(groupId, [_id]))
+        groupPromises.push(pro.groups.addUsers(groupId, [_id]))
       }
     }
   }
@@ -456,7 +462,7 @@ export const bulkCreate = async (
     const groupPromises = []
     const createdUserIds = saved.map(user => user._id)
     for (let groupId of groups) {
-      groupPromises.push(groupsSdk.addUsers(groupId, createdUserIds))
+      groupPromises.push(pro.groups.addUsers(groupId, createdUserIds))
     }
     await Promise.all(groupPromises)
   }

--- a/packages/worker/src/tests/api/configs.ts
+++ b/packages/worker/src/tests/api/configs.ts
@@ -14,6 +14,14 @@ export class ConfigAPI extends TestAPI {
       .expect("Content-Type", /json/)
   }
 
+  getPublicSettings = () => {
+    return this.request
+      .get(`/api/global/configs/public`)
+      .set(this.config.defaultHeaders())
+      .expect(200)
+      .expect("Content-Type", /json/)
+  }
+
   saveConfig = (data: any) => {
     return this.request
       .post(`/api/global/configs`)

--- a/packages/worker/src/tests/api/email.ts
+++ b/packages/worker/src/tests/api/email.ts
@@ -13,6 +13,7 @@ export class EmailAPI extends TestAPI {
         email: "test@test.com",
         purpose,
         tenantId: this.config.getTenantId(),
+        userId: this.config.user?._id!,
       })
       .set(this.config.defaultHeaders())
       .expect("Content-Type", /json/)

--- a/packages/worker/src/tests/structures/configs.ts
+++ b/packages/worker/src/tests/structures/configs.ts
@@ -1,9 +1,15 @@
-import { Config } from "../../constants"
 import { utils } from "@budibase/backend-core"
+import {
+  SettingsConfig,
+  ConfigType,
+  SMTPConfig,
+  GoogleConfig,
+  OIDCConfig,
+} from "@budibase/types"
 
-export function oidc(conf?: any) {
+export function oidc(conf?: any): OIDCConfig {
   return {
-    type: Config.OIDC,
+    type: ConfigType.OIDC,
     config: {
       configs: [
         {
@@ -21,9 +27,9 @@ export function oidc(conf?: any) {
   }
 }
 
-export function google(conf?: any) {
+export function google(conf?: any): GoogleConfig {
   return {
-    type: Config.GOOGLE,
+    type: ConfigType.GOOGLE,
     config: {
       clientID: "clientId",
       clientSecret: "clientSecret",
@@ -33,9 +39,9 @@ export function google(conf?: any) {
   }
 }
 
-export function smtp(conf?: any) {
+export function smtp(conf?: any): SMTPConfig {
   return {
-    type: Config.SMTP,
+    type: ConfigType.SMTP,
     config: {
       port: 12345,
       host: "smtptesthost.com",
@@ -47,12 +53,13 @@ export function smtp(conf?: any) {
   }
 }
 
-export function smtpEthereal() {
+export function smtpEthereal(): SMTPConfig {
   return {
-    type: Config.SMTP,
+    type: ConfigType.SMTP,
     config: {
       port: 587,
       host: "smtp.ethereal.email",
+      from: "testfrom@test.com",
       secure: false,
       auth: {
         user: "wyatt.zulauf29@ethereal.email",
@@ -63,9 +70,9 @@ export function smtpEthereal() {
   }
 }
 
-export function settings(conf?: any) {
+export function settings(conf?: any): SettingsConfig {
   return {
-    type: Config.SETTINGS,
+    type: ConfigType.SETTINGS,
     config: {
       platformUrl: "http://localhost:10000",
       logoUrl: "",

--- a/packages/worker/src/tests/structures/configs.ts
+++ b/packages/worker/src/tests/structures/configs.ts
@@ -55,8 +55,8 @@ export function smtpEthereal() {
       host: "smtp.ethereal.email",
       secure: false,
       auth: {
-        user: "don.bahringer@ethereal.email",
-        pass: "yCKSH8rWyUPbnhGYk9",
+        user: "wyatt.zulauf29@ethereal.email",
+        pass: "tEwDtHBWWxusVWAPfa",
       },
       connectionTimeout: 1000, // must be less than the jest default of 5000
     },

--- a/packages/worker/src/utilities/templates.ts
+++ b/packages/worker/src/utilities/templates.ts
@@ -1,6 +1,5 @@
-import { db as dbCore, tenancy } from "@budibase/backend-core"
+import { tenancy, configs } from "@budibase/backend-core"
 import {
-  Config,
   InternalTemplateBinding,
   LOGO_URL,
   EmailTemplatePurpose,
@@ -10,20 +9,16 @@ const BASE_COMPANY = "Budibase"
 
 export async function getSettingsTemplateContext(
   purpose: EmailTemplatePurpose,
-  code?: string
+  code?: string | null
 ) {
-  const db = tenancy.getGlobalDB()
-  // TODO: use more granular settings in the future if required
-  let settings =
-    (await dbCore.getScopedConfig(db, { type: Config.SETTINGS })) || {}
+  let settings = await configs.getSettingsConfig()
   const URL = settings.platformUrl
   const context: any = {
     [InternalTemplateBinding.LOGO_URL]:
       checkSlashesInUrl(`${URL}/${settings.logoUrl}`) || LOGO_URL,
     [InternalTemplateBinding.PLATFORM_URL]: URL,
     [InternalTemplateBinding.COMPANY]: settings.company || BASE_COMPANY,
-    [InternalTemplateBinding.DOCS_URL]:
-      settings.docsUrl || "https://docs.budibase.com/",
+    [InternalTemplateBinding.DOCS_URL]: "https://docs.budibase.com/",
     [InternalTemplateBinding.LOGIN_URL]: checkSlashesInUrl(
       tenancy.addTenantToUrl(`${URL}/login`)
     ),


### PR DESCRIPTION
## Description
- Started some of this while updating public settings config for enforced sso - breaking into own changeset 

Configs
- Move all config (google, oidc, settings, smtp etc) reading and writing out of utils and into a dedicated module
- Add type support for all functions
- Consolidate defaulting logic for when config wasn't available which was done in multiple places
- Remove circular dependencies between analytics and configs
- Update usages inside budibase with new configs module
- Removes a lot of direct access to context and db that has now been abstracted away 
- Add new types to configs highlighted by refactor
- Add api types for oidc and settings responses

Server
- Remove default tenant id from server tests to increase reliability and reduce conflicts

Email tests
- An error was being swallowed causing the tests to never run properly
- Update the test with new credentials that work + integrate with configs module

Reduces circular deps from 21
![image](https://user-images.githubusercontent.com/8755148/221127995-e1d3b6aa-834d-458d-af53-fdcf595ddf1f.png)

to 16:
![Screenshot 2023-02-24 at 08 16 13](https://user-images.githubusercontent.com/8755148/221127617-47e74d8e-e77f-4208-a50f-fb16c53ff116.png)
