### PR TITLE
set couchDB chart version to 3.1.1

### DIFF
--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -245,7 +245,7 @@ couchdb:
   ## The CouchDB image
   image:
     repository: couchdb
-    tag: 3.2.1
+    tag: 3.1.1
     pullPolicy: IfNotPresent
 
   ## Experimental integration with Lucene-powered fulltext search


### PR DESCRIPTION
## Description
Noticed some issues with the couchDB chart version on EKS and others reported by users. Pinning to 3.1.1 to avoid k8s problems for now.

Addresses: 
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



