### PR TITLE
Support navigate to link in new tab

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/NavigateTo.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/NavigateTo.svelte
@@ -39,7 +39,6 @@
     on:change={() => (parameters.url = "")}
   />
   {#if parameters.type === "screen"}
-    <Label small>Screen</Label>
     <DrawerBindableCombobox
       title="Destination"
       placeholder="/screen"
@@ -52,7 +51,6 @@
     <div />
     <Checkbox text="Open screen in modal" bind:value={parameters.peek} />
   {:else}
-    <Label small>URL</Label>
     <DrawerBindableInput
       title="Destination"
       placeholder="/url"

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/NavigateTo.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/NavigateTo.svelte
@@ -1,26 +1,68 @@
 <script>
-  import { Label, Checkbox } from "@budibase/bbui"
+  import { store } from "builderStore"
+  import { onMount } from "svelte"
+  import { Label, Checkbox, Select } from "@budibase/bbui"
   import DrawerBindableInput from "components/common/bindings/DrawerBindableInput.svelte"
+  import DrawerBindableCombobox from "components/common/bindings/DrawerBindableCombobox.svelte"
 
   export let parameters
   export let bindings = []
+
+  $: urlOptions = $store.screens
+    .map(screen => screen.routing?.route)
+    .filter(x => x != null)
+
+  const typeOptions = [
+    {
+      label: "Screen",
+      value: "screen",
+    },
+    {
+      label: "URL",
+      value: "url",
+    },
+  ]
+
+  onMount(() => {
+    if (!parameters.type) {
+      parameters.type = "screen"
+    }
+  })
 </script>
 
 <div class="root">
-  <Label small>Screen or URL</Label>
-  <DrawerBindableInput
-    title="Destination URL"
-    placeholder="/route"
-    value={parameters.url}
-    on:change={value => (parameters.url = value.detail)}
-    {bindings}
+  <Label small>Destination</Label>
+  <Select
+    placeholder={null}
+    bind:value={parameters.type}
+    options={typeOptions}
+    on:change={value => (parameters.url = "")}
   />
-  <div />
-  <Checkbox text="Open screen in modal" bind:value={parameters.peek} />
-  <Checkbox
-    text="Open external link in new tab"
-    bind:value={parameters.externalNewTab}
-  />
+  {#if parameters.type === "screen"}
+    <Label small>Screen</Label>
+    <DrawerBindableCombobox
+      title="Destination"
+      placeholder="/screen"
+      value={parameters.url}
+      on:change={value => (parameters.url = value.detail)}
+      {bindings}
+      options={urlOptions}
+      appendBindingsAsOptions={false}
+    />
+    <div />
+    <Checkbox text="Open screen in modal" bind:value={parameters.peek} />
+  {:else}
+    <Label small>URL</Label>
+    <DrawerBindableInput
+      title="Destination"
+      placeholder="/url"
+      value={parameters.url}
+      on:change={value => (parameters.url = value.detail)}
+      {bindings}
+    />
+    <div />
+    <Checkbox text="New Tab" bind:value={parameters.externalNewTab} />
+  {/if}
 </div>
 
 <style>

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/NavigateTo.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/NavigateTo.svelte
@@ -7,16 +7,20 @@
 </script>
 
 <div class="root">
-  <Label small>Screen</Label>
+  <Label small>Screen or URL</Label>
   <DrawerBindableInput
     title="Destination URL"
-    placeholder="/screen"
+    placeholder="/route"
     value={parameters.url}
     on:change={value => (parameters.url = value.detail)}
     {bindings}
   />
   <div />
   <Checkbox text="Open screen in modal" bind:value={parameters.peek} />
+  <Checkbox
+    text="Open external link in new tab"
+    bind:value={parameters.externalNewTab}
+  />
 </div>
 
 <style>
@@ -24,7 +28,7 @@
     display: grid;
     align-items: center;
     gap: var(--spacing-m);
-    grid-template-columns: auto 1fr;
+    grid-template-columns: auto;
     max-width: 400px;
     margin: 0 auto;
   }

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/NavigateTo.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/NavigateTo.svelte
@@ -36,7 +36,7 @@
     placeholder={null}
     bind:value={parameters.type}
     options={typeOptions}
-    on:change={value => (parameters.url = "")}
+    on:change={() => (parameters.url = "")}
   />
   {#if parameters.type === "screen"}
     <Label small>Screen</Label>

--- a/packages/client/src/stores/routes.js
+++ b/packages/client/src/stores/routes.js
@@ -66,22 +66,27 @@ const createRouteStore = () => {
       return state
     })
   }
-  const navigate = (url, peek) => {
+  const navigate = (url, peek, externalNewTab) => {
     if (get(builderStore).inBuilder) {
       return
     }
     if (url) {
       // If we're already peeking, don't peek again
       const isPeeking = get(store).queryParams?.peek
-      if (peek && !isPeeking) {
+      const external = !url.startsWith("/")
+      if (peek && !isPeeking && !external) {
         peekStore.actions.showPeek(url)
-      } else {
-        const external = !url.startsWith("/")
-        if (external) {
-          window.location.href = url
-        } else {
-          push(url)
+      } else if (external) {
+        if (url.startsWith("www")) {
+          url = `https://${url}`
         }
+        if (externalNewTab) {
+          window.open(url, "_blank")
+        } else {
+          window.location.href = url
+        }
+      } else {
+        push(url)
       }
     }
   }

--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -140,8 +140,8 @@ const triggerAutomationHandler = async action => {
 }
 
 const navigationHandler = action => {
-  const { url, peek } = action.parameters
-  routeStore.actions.navigate(url, peek)
+  const { url, peek, externalNewTab } = action.parameters
+  routeStore.actions.navigate(url, peek, externalNewTab)
 }
 
 const queryExecutionHandler = async action => {


### PR DESCRIPTION
## Description
Users wanted to be able to use the **Navigate To** action to open an external URL in a new tab.

Also fixed a couple of minor issues:
 - external URLs can no longer be opened within a modal (it never worked)
 - if the **http** protocol is missing from an external URL then add it (this tripped up a user in the past)

Addresses: 
- https://github.com/Budibase/budibase/issues/9286
- https://github.com/Budibase/budibase/issues/6243

## Screenshots
![Screenshot 2023-02-28 at 11 49 35](https://user-images.githubusercontent.com/101575380/221845894-16b197df-c1c8-4b7a-92a4-22c0fd9f2d0c.png)

![Screenshot 2023-02-28 at 11 49 55](https://user-images.githubusercontent.com/101575380/221846023-c36a4f50-f769-41f0-8207-1baccf07f29c.png)

![Screenshot 2023-02-28 at 11 50 05](https://user-images.githubusercontent.com/101575380/221846084-b46527dc-802f-44c0-b150-815d6f10a2d5.png)

## Documentation
- [x] I have reviewed the budibase documentation to verify if this feature requires any changes. If changes or new docs are required I have written them.



