### PR TITLE
Bug - budi-6076 cannot delete columns in google sheet

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -192,13 +192,13 @@
     editableColumn.name = originalName
   }
 
-  function deleteColumn() {
+  async function deleteColumn() {
     try {
       editableColumn.name = deleteColName
       if (editableColumn.name === $tables.selected.primaryDisplay) {
         notifications.error("You cannot delete the display column")
       } else {
-        tables.deleteField(editableColumn)
+        await tables.deleteField(editableColumn)
         notifications.success(`Column ${editableColumn.name} deleted.`)
         confirmDeleteDialog.hide()
         hide()

--- a/packages/server/__mocks__/node-fetch.ts
+++ b/packages/server/__mocks__/node-fetch.ts
@@ -172,6 +172,9 @@ module FetchMock {
         ),
         ok: true,
       })
+    } else if (url === "https://www.googleapis.com/oauth2/v4/token") {
+      // any valid response
+      return json({})
     } else if (url.includes("failonce.com")) {
       failCount++
       if (failCount === 1) {

--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -308,10 +308,17 @@ class GoogleSheetsIntegration implements DatasourcePlus {
         }
         await sheet.setHeaderRow(headers)
       } else {
-        let newField = Object.keys(table.schema).find(
+        const updatedHeaderValues = [...sheet.headerValues]
+
+        const newField = Object.keys(table.schema).find(
           key => !sheet.headerValues.includes(key)
         )
-        await sheet.setHeaderRow([...sheet.headerValues, newField])
+
+        if (newField) {
+          updatedHeaderValues.push(newField)
+        }
+
+        await sheet.setHeaderRow(updatedHeaderValues)
       }
     } catch (err) {
       console.error("Error updating table in google sheets", err)

--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -13,7 +13,7 @@ import { DataSourceOperation, FieldTypes } from "../constants"
 import { GoogleSpreadsheet } from "google-spreadsheet"
 import env from "../environment"
 import { tenancy, db as dbCore, constants } from "@budibase/backend-core"
-const fetch = require("node-fetch")
+import fetch from "node-fetch"
 
 interface GoogleSheetsConfig {
   spreadsheetId: string
@@ -112,7 +112,7 @@ const SCHEMA: Integration = {
 
 class GoogleSheetsIntegration implements DatasourcePlus {
   private readonly config: GoogleSheetsConfig
-  private client: any
+  private client: GoogleSpreadsheet
   public tables: Record<string, Table> = {}
   public schemaErrors: Record<string, string> = {}
 
@@ -211,7 +211,7 @@ class GoogleSheetsIntegration implements DatasourcePlus {
 
   async buildSchema(datasourceId: string) {
     await this.connect()
-    const sheets = await this.client.sheetsByIndex
+    const sheets = this.client.sheetsByIndex
     const tables: Record<string, Table> = {}
     for (let sheet of sheets) {
       // must fetch rows to determine schema
@@ -294,7 +294,7 @@ class GoogleSheetsIntegration implements DatasourcePlus {
   async updateTable(table?: any) {
     try {
       await this.connect()
-      const sheet = await this.client.sheetsByTitle[table.name]
+      const sheet = this.client.sheetsByTitle[table.name]
       await sheet.loadHeaderRow()
 
       if (table._rename) {
@@ -329,7 +329,7 @@ class GoogleSheetsIntegration implements DatasourcePlus {
   async deleteTable(sheet: any) {
     try {
       await this.connect()
-      const sheetToDelete = await this.client.sheetsByTitle[sheet]
+      const sheetToDelete = this.client.sheetsByTitle[sheet]
       return await sheetToDelete.delete()
     } catch (err) {
       console.error("Error deleting table in google sheets", err)
@@ -340,7 +340,7 @@ class GoogleSheetsIntegration implements DatasourcePlus {
   async create(query: { sheet: string; row: any }) {
     try {
       await this.connect()
-      const sheet = await this.client.sheetsByTitle[query.sheet]
+      const sheet = this.client.sheetsByTitle[query.sheet]
       const rowToInsert =
         typeof query.row === "string" ? JSON.parse(query.row) : query.row
       const row = await sheet.addRow(rowToInsert)
@@ -356,7 +356,7 @@ class GoogleSheetsIntegration implements DatasourcePlus {
   async read(query: { sheet: string }) {
     try {
       await this.connect()
-      const sheet = await this.client.sheetsByTitle[query.sheet]
+      const sheet = this.client.sheetsByTitle[query.sheet]
       const rows = await sheet.getRows()
       const headerValues = sheet.headerValues
       const response = []
@@ -375,7 +375,7 @@ class GoogleSheetsIntegration implements DatasourcePlus {
   async update(query: { sheet: string; rowIndex: number; row: any }) {
     try {
       await this.connect()
-      const sheet = await this.client.sheetsByTitle[query.sheet]
+      const sheet = this.client.sheetsByTitle[query.sheet]
       const rows = await sheet.getRows()
       const row = rows[query.rowIndex]
       if (row) {
@@ -399,7 +399,7 @@ class GoogleSheetsIntegration implements DatasourcePlus {
 
   async delete(query: { sheet: string; rowIndex: number }) {
     await this.connect()
-    const sheet = await this.client.sheetsByTitle[query.sheet]
+    const sheet = this.client.sheetsByTitle[query.sheet]
     const rows = await sheet.getRows()
     const row = rows[query.rowIndex]
     if (row) {

--- a/packages/server/src/integrations/tests/googlesheets.spec.ts
+++ b/packages/server/src/integrations/tests/googlesheets.spec.ts
@@ -1,0 +1,119 @@
+import type { GoogleSpreadsheetWorksheet } from "google-spreadsheet"
+
+jest.mock("google-auth-library")
+const { OAuth2Client } = require("google-auth-library")
+
+const setCredentialsMock = jest.fn()
+const getAccessTokenMock = jest.fn()
+
+OAuth2Client.mockImplementation(() => {
+  return {
+    setCredentials: setCredentialsMock,
+    getAccessToken: getAccessTokenMock,
+  }
+})
+
+jest.mock("google-spreadsheet")
+const { GoogleSpreadsheet } = require("google-spreadsheet")
+
+const sheetsByTitle: { [title: string]: GoogleSpreadsheetWorksheet } = {}
+
+GoogleSpreadsheet.mockImplementation(() => {
+  return {
+    useOAuth2Client: jest.fn(),
+    loadInfo: jest.fn(),
+    sheetsByTitle,
+  }
+})
+
+import { structures } from "@budibase/backend-core/tests"
+import TestConfiguration from "../../tests/utilities/TestConfiguration"
+import GoogleSheetsIntegration from "../googlesheets"
+import { FieldType, Table, TableSchema } from "../../../../types/src/documents"
+
+describe("Google Sheets Integration", () => {
+  let integration: any,
+    config = new TestConfiguration()
+
+  beforeEach(async () => {
+    integration = new GoogleSheetsIntegration.integration({
+      spreadsheetId: "randomId",
+      auth: {
+        appId: "appId",
+        accessToken: "accessToken",
+        refreshToken: "refreshToken",
+      },
+    })
+    await config.init()
+  })
+
+  function createBasicTable(name: string, columns: string[]): Table {
+    return {
+      name,
+      schema: {
+        ...columns.reduce((p, c) => {
+          p[c] = {
+            name: c,
+            type: FieldType.STRING,
+            constraints: {
+              type: "string",
+            },
+          }
+          return p
+        }, {} as TableSchema),
+      },
+    }
+  }
+
+  function createSheet({
+    headerValues,
+  }: {
+    headerValues: string[]
+  }): GoogleSpreadsheetWorksheet {
+    return {
+      // to ignore the unmapped fields
+      ...({} as any),
+      loadHeaderRow: jest.fn(),
+      headerValues,
+      setHeaderRow: jest.fn(),
+    }
+  }
+
+  describe("update table", () => {
+    test("adding a new field will be adding a new header row", async () => {
+      await config.doInContext(structures.uuid(), async () => {
+        const tableColumns = ["name", "description", "new field"]
+        const table = createBasicTable(structures.uuid(), tableColumns)
+
+        const sheet = createSheet({ headerValues: ["name", "description"] })
+        sheetsByTitle[table.name] = sheet
+        await integration.updateTable(table)
+
+        expect(sheet.loadHeaderRow).toBeCalledTimes(1)
+        expect(sheet.setHeaderRow).toBeCalledTimes(1)
+        expect(sheet.setHeaderRow).toBeCalledWith(tableColumns)
+      })
+    })
+
+    test("removing an existing field will not remove the data from the spreadsheet", async () => {
+      await config.doInContext(structures.uuid(), async () => {
+        const tableColumns = ["name"]
+        const table = createBasicTable(structures.uuid(), tableColumns)
+
+        const sheet = createSheet({
+          headerValues: ["name", "description", "location"],
+        })
+        sheetsByTitle[table.name] = sheet
+        await integration.updateTable(table)
+
+        expect(sheet.loadHeaderRow).toBeCalledTimes(1)
+        expect(sheet.setHeaderRow).toBeCalledTimes(1)
+        expect(sheet.setHeaderRow).toBeCalledWith([
+          "name",
+          "description",
+          "location",
+        ])
+      })
+    })
+  })
+})

--- a/packages/server/src/integrations/tests/googlesheets.spec.ts
+++ b/packages/server/src/integrations/tests/googlesheets.spec.ts
@@ -113,6 +113,9 @@ describe("Google Sheets Integration", () => {
           "description",
           "location",
         ])
+
+        // No undefineds are sent
+        expect((sheet.setHeaderRow as any).mock.calls[0][0]).toHaveLength(3)
       })
     })
   })


### PR DESCRIPTION
## Description
Fixing issue that doesn't allow deleting columns on google spreadsheets datasets.
Changes:
1. Fix UI to not swallow errors
2. Fix error on deletion

Addresses: 
- https://github.com/Budibase/budibase/issues/8575

## App Export
- Nor required

## Screenshots
Tested actions:
1. Add a column, add content
2. Delete the column 
3. Add two more columns, add content
4. Remove the "non-last" column

https://user-images.githubusercontent.com/15987277/221567327-a5d8f5c5-4dbb-4fcf-9bf7-094b27584a9c.mov


## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



