### PR TITLE
Prefer default config for google sheets in cloud, don't use env vars for regular auth

### DIFF
--- a/packages/backend-core/src/configs/configs.ts
+++ b/packages/backend-core/src/configs/configs.ts
@@ -157,7 +157,9 @@ export async function getGoogleConfig(): Promise<
   return config?.config
 }
 
-export async function getGoogleDatasourceConfig(): Promise<GoogleInnerConfig | undefined> {
+export async function getGoogleDatasourceConfig(): Promise<
+  GoogleInnerConfig | undefined
+> {
   if (!env.SELF_HOSTED) {
     // always use the env vars in cloud
     return getDefaultGoogleConfig()

--- a/packages/backend-core/src/configs/configs.ts
+++ b/packages/backend-core/src/configs/configs.ts
@@ -154,11 +154,27 @@ export async function getGoogleConfig(): Promise<
   GoogleInnerConfig | undefined
 > {
   const config = await getGoogleConfigDoc()
-  if (config) {
-    return config.config
+  return config?.config
+}
+
+export async function getGoogleDatasourceConfig(): Promise<GoogleInnerConfig | undefined> {
+  if (!env.SELF_HOSTED) {
+    // always use the env vars in cloud
+    return getDefaultGoogleConfig()
   }
 
-  // Use google fallback configuration from env variables
+  // prefer the config in self-host
+  let config = await getGoogleConfig()
+
+  // fallback to env vars
+  if (!config || !config.activated) {
+    config = getDefaultGoogleConfig()
+  }
+
+  return config
+}
+
+export function getDefaultGoogleConfig(): GoogleInnerConfig | undefined {
   if (environment.GOOGLE_CLIENT_ID && environment.GOOGLE_CLIENT_SECRET) {
     return {
       clientID: environment.GOOGLE_CLIENT_ID!,

--- a/packages/backend-core/src/middleware/passport/datasource/google.ts
+++ b/packages/backend-core/src/middleware/passport/datasource/google.ts
@@ -12,7 +12,8 @@ type Passport = {
 }
 
 async function fetchGoogleCreds() {
-  const config = await configs.getGoogleConfig()
+  let config = await configs.getGoogleDatasourceConfig()
+
   if (!config) {
     throw new Error("No google configuration found")
   }

--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -172,7 +172,7 @@ class GoogleSheetsIntegration implements DatasourcePlus {
   async connect() {
     try {
       // Initialise oAuth client
-      let googleConfig = await configs.getGoogleConfig()
+      let googleConfig = await configs.getGoogleDatasourceConfig()
       if (!googleConfig) {
         throw new HTTPError("Google config not found", 400)
       }


### PR DESCRIPTION
## Description
- This pr introduced a change where fetching google configs defaulted to env vars when the config was not found https://github.com/Budibase/budibase/pull/9785
- This behaviour should only be performed for datasource auth and not the regular auth mechanism
- Additionally, always prefer the env var config in cloud for google sheets 