### PR TITLE
Fix to clear empty lastName string when accepting an invite to budibase

### DIFF
--- a/packages/builder/src/stores/portal/users.js
+++ b/packages/builder/src/stores/portal/users.js
@@ -34,7 +34,7 @@ export function createUsersStore() {
       inviteCode,
       password,
       firstName,
-      lastName,
+      lastName: !lastName?.trim() ? undefined : lastName,
     })
   }
 


### PR DESCRIPTION
Description
When entering details on the accept invitation screen, if a user entered a last name and then cleared the field, an empty string would be passed to the api causing it to fail.

This fix ensures that empty strings are cleared before submission. 

Previous PR was on the wrong base branch.