### PR TITLE
Fix settings doc id in new installs

### DIFF
--- a/packages/backend-core/src/configs/configs.ts
+++ b/packages/backend-core/src/configs/configs.ts
@@ -54,7 +54,7 @@ export async function getSettingsConfigDoc(): Promise<SettingsConfig> {
 
   if (!config) {
     config = {
-      _id: generateConfigID(ConfigType.GOOGLE),
+      _id: generateConfigID(ConfigType.SETTINGS),
       type: ConfigType.SETTINGS,
       config: {},
     }


### PR DESCRIPTION
## Description
- default settings doc was being saved with google id because of typo
- this prevented google save because incorrect validation being applied

Addresses: 
- Issue raised by QA


