### PR TITLE
Prevent showing user exists for password disabled actions

### DIFF
--- a/packages/backend-core/src/middleware/authenticated.ts
+++ b/packages/backend-core/src/middleware/authenticated.ts
@@ -154,7 +154,8 @@ export default function (
         return next()
       }
     } catch (err: any) {
-      console.error("Auth Error", err?.message || err)
+      console.error(`Auth Error: ${err.message}`)
+      console.error(err)
       // invalid token, clear the cookie
       if (err && err.name === "JsonWebTokenError") {
         clearCookie(ctx, Cookie.Auth)

--- a/packages/builder/src/pages/builder/portal/settings/auth/index.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/auth/index.svelte
@@ -368,7 +368,7 @@
         </div>
         {#if !$licensing.enforceableSSO}
           <Tags>
-            <Tag icon="LockClosed">Business plan</Tag>
+            <Tag icon="LockClosed">Enterprise plan</Tag>
           </Tags>
         {/if}
       </div>

--- a/packages/worker/src/api/controllers/global/auth.ts
+++ b/packages/worker/src/api/controllers/global/auth.ts
@@ -62,7 +62,7 @@ export const login = async (ctx: Ctx<LoginRequest>, next: any) => {
 
   const user = await userSdk.getUserByEmail(email)
   if (user && (await userSdk.isPreventPasswordActions(user))) {
-    ctx.throw(400, "Password login is disabled for this user")
+    ctx.throw(403, "Invalid credentials")
   }
 
   return passport.authenticate(

--- a/packages/worker/src/api/routes/global/tests/auth.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/auth.spec.ts
@@ -170,7 +170,7 @@ describe("/api/global/auth", () => {
         async function testSSOUser() {
           const { res } = await config.api.auth.requestPasswordReset(
             sendMailMock,
-            user.email,
+            user.email
           )
           expect(sendMailMock).not.toHaveBeenCalled()
         }

--- a/packages/worker/src/api/routes/global/tests/auth.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/auth.spec.ts
@@ -106,12 +106,12 @@ describe("/api/global/auth", () => {
             tenantId,
             email,
             password,
-            { status: 400 }
+            { status: 403 }
           )
 
           expect(response.body).toEqual({
-            message: "Password login is disabled for this user",
-            status: 400,
+            message: "Invalid credentials",
+            status: 403,
           })
         }
 
@@ -171,17 +171,7 @@ describe("/api/global/auth", () => {
           const { res } = await config.api.auth.requestPasswordReset(
             sendMailMock,
             user.email,
-            { status: 400 }
           )
-
-          expect(res.body).toEqual({
-            message: "Password reset is disabled for this user",
-            status: 400,
-            error: {
-              code: "http",
-              type: "generic",
-            },
-          })
           expect(sendMailMock).not.toHaveBeenCalled()
         }
 

--- a/packages/worker/src/sdk/auth/auth.ts
+++ b/packages/worker/src/sdk/auth/auth.ts
@@ -59,7 +59,7 @@ export const reset = async (email: string) => {
 
   // exit if user has sso
   if (await userSdk.isPreventPasswordActions(user)) {
-    throw new HTTPError("Password reset is disabled for this user", 400)
+    return
   }
 
   // send password reset

--- a/packages/worker/src/tests/api/auth.ts
+++ b/packages/worker/src/tests/api/auth.ts
@@ -61,11 +61,13 @@ export class AuthAPI extends TestAPI {
 
     let code: string | undefined
     if (res.status === 200) {
-      const emailCall = sendMailMock.mock.calls[0][0]
-      const parts = emailCall.html.split(
-        `http://localhost:10000/builder/auth/reset?code=`
-      )
-      code = parts[1].split('"')[0].split("&")[0]
+      if (sendMailMock.mock.calls.length) {
+        const emailCall = sendMailMock.mock.calls[0][0]
+        const parts = emailCall.html.split(
+          `http://localhost:10000/builder/auth/reset?code=`
+        )
+        code = parts[1].split('"')[0].split("&")[0]
+      }
     }
 
     return { code, res }


### PR DESCRIPTION
## Description
Mask the existence of a user when they are prohibited from performing a password action 

Addresses: 
- Feedback from demo

