### PR TITLE
Only allow admins to access audit logs screen

### DIFF
--- a/packages/builder/src/stores/portal/menu.js
+++ b/packages/builder/src/stores/portal/menu.js
@@ -75,14 +75,12 @@ export const menu = derived([admin, auth], ([$admin, $auth]) => {
         title: "Usage",
         href: "/builder/portal/account/usage",
       },
-
     ]
     if ($auth.isAdmin) {
-      accountSubPages.push(
-        {
-          title: "Audit Logs",
-          href: "/builder/portal/account/auditLogs",
-        })
+      accountSubPages.push({
+        title: "Audit Logs",
+        href: "/builder/portal/account/auditLogs",
+      })
     }
     if ($admin.cloud && $auth?.user?.accountPortalAccess) {
       accountSubPages.push({

--- a/packages/builder/src/stores/portal/menu.js
+++ b/packages/builder/src/stores/portal/menu.js
@@ -75,11 +75,15 @@ export const menu = derived([admin, auth], ([$admin, $auth]) => {
         title: "Usage",
         href: "/builder/portal/account/usage",
       },
-      {
-        title: "Audit Logs",
-        href: "/builder/portal/account/auditLogs",
-      },
+
     ]
+    if ($auth.isAdmin) {
+      accountSubPages.push(
+        {
+          title: "Audit Logs",
+          href: "/builder/portal/account/auditLogs",
+        })
+    }
     if ($admin.cloud && $auth?.user?.accountPortalAccess) {
       accountSubPages.push({
         title: "Upgrade",


### PR DESCRIPTION
## Description
Fixes an issue where the audit logs menu item was visible to admin users. Once they clicked it they got logged out as they had no permissions. 


