### PR TITLE
Fix for group picker in the portal user details section

### DIFF
--- a/packages/builder/src/components/settings/UserGroupPicker.svelte
+++ b/packages/builder/src/components/settings/UserGroupPicker.svelte
@@ -18,7 +18,7 @@
     return list.map(item => {
       return {
         ...item,
-        selected: selected.find(x => x === item._id) != null,
+        selected: selected?.find(x => x === item._id) != null,
       }
     })
   }


### PR DESCRIPTION
## Description

Minor fix for the `Add to groups` button in the user details page in the portal. The picker currently tries to iterate over the optional `userGroups` parameter on the user but will crash the builder if it is unset.

Addresses: 

- [BUDI-6658]



