### PR TITLE
Fix for exporting/importing apps with different attachment columns

### DIFF
--- a/packages/backend-core/src/migrations/migrations.ts
+++ b/packages/backend-core/src/migrations/migrations.ts
@@ -86,7 +86,11 @@ export const runMigration = async (
     count++
     const lengthStatement = length > 1 ? `[${count}/${length}]` : ""
 
-    const db = getDB(dbName)
+    const db = getDB(dbName, { skip_setup: true })
+    // DB doesn't exist - no-op required
+    if (!(await db.exists())) {
+      continue
+    }
     try {
       const doc = await getMigrationsDoc(db)
 

--- a/packages/backend-core/src/migrations/migrations.ts
+++ b/packages/backend-core/src/migrations/migrations.ts
@@ -86,7 +86,7 @@ export const runMigration = async (
     count++
     const lengthStatement = length > 1 ? `[${count}/${length}]` : ""
 
-    const db = getDB(dbName, { skip_setup: true })
+    const db = getDB(dbName)
 
     try {
       const doc = await getMigrationsDoc(db)

--- a/packages/backend-core/src/migrations/migrations.ts
+++ b/packages/backend-core/src/migrations/migrations.ts
@@ -17,7 +17,6 @@ import {
   MigrationNoOpOptions,
   App,
 } from "@budibase/types"
-import env from "../environment"
 
 export const getMigrationsDoc = async (db: any) => {
   // get the migrations doc
@@ -88,11 +87,7 @@ export const runMigration = async (
     const lengthStatement = length > 1 ? `[${count}/${length}]` : ""
 
     const db = getDB(dbName, { skip_setup: true })
-    // DB doesn't exist - no-op required
-    const dbExists = await db.exists()
-    if (!env.isTest() && !dbExists) {
-      continue
-    }
+
     try {
       const doc = await getMigrationsDoc(db)
 

--- a/packages/backend-core/src/migrations/migrations.ts
+++ b/packages/backend-core/src/migrations/migrations.ts
@@ -17,6 +17,7 @@ import {
   MigrationNoOpOptions,
   App,
 } from "@budibase/types"
+import env from "../environment"
 
 export const getMigrationsDoc = async (db: any) => {
   // get the migrations doc
@@ -88,7 +89,8 @@ export const runMigration = async (
 
     const db = getDB(dbName, { skip_setup: true })
     // DB doesn't exist - no-op required
-    if (!(await db.exists())) {
+    const dbExists = await db.exists()
+    if (!env.isTest() && !dbExists) {
       continue
     }
     try {

--- a/packages/server/src/sdk/app/backups/constants.ts
+++ b/packages/server/src/sdk/app/backups/constants.ts
@@ -1,2 +1,3 @@
 export const DB_EXPORT_FILE = "db.txt"
 export const GLOBAL_DB_EXPORT_FILE = "global.txt"
+export const STATIC_APP_FILES = ["manifest.json", "budibase-client.js"]

--- a/packages/server/src/sdk/app/backups/exports.ts
+++ b/packages/server/src/sdk/app/backups/exports.ts
@@ -7,10 +7,15 @@ import {
   TABLE_ROW_PREFIX,
   USER_METDATA_PREFIX,
 } from "../../../db/utils"
-import { DB_EXPORT_FILE, GLOBAL_DB_EXPORT_FILE } from "./constants"
+import {
+  DB_EXPORT_FILE,
+  GLOBAL_DB_EXPORT_FILE,
+  STATIC_APP_FILES,
+} from "./constants"
 import fs from "fs"
 import { join } from "path"
 import env from "../../../environment"
+
 const uuid = require("uuid/v4")
 const tar = require("tar")
 const MemoryStream = require("memorystream")
@@ -91,14 +96,25 @@ export async function exportApp(appId: string, config?: ExportOpts) {
   const prodAppId = dbCore.getProdAppID(appId)
   const appPath = `${prodAppId}/`
   // export bucket contents
-  let tmpPath
+  let tmpPath = createTempFolder(uuid())
   if (!env.isTest()) {
-    tmpPath = await objectStore.retrieveDirectory(
-      ObjectStoreBuckets.APPS,
-      appPath
-    )
-  } else {
-    tmpPath = createTempFolder(uuid())
+    // write just the static files
+    if (config?.excludeRows) {
+      for (let path of STATIC_APP_FILES) {
+        const contents = await objectStore.retrieve(
+          ObjectStoreBuckets.APPS,
+          join(appPath, path)
+        )
+        fs.writeFileSync(join(tmpPath, path), contents)
+      }
+    }
+    // get all of the files
+    else {
+      tmpPath = await objectStore.retrieveDirectory(
+        ObjectStoreBuckets.APPS,
+        appPath
+      )
+    }
   }
   const downloadedPath = join(tmpPath, appPath)
   if (fs.existsSync(downloadedPath)) {

--- a/packages/server/src/sdk/app/rows/attachments.ts
+++ b/packages/server/src/sdk/app/rows/attachments.ts
@@ -13,13 +13,13 @@ function generateAttachmentFindParams(
 ) {
   const params: CouchFindOptions = {
     selector: {
+      $or: attachmentCols.map(col => ({ [col]: { $exists: true } })),
       _id: {
         $regex: `^${DocumentType.ROW}${SEPARATOR}${tableId}`,
       },
     },
     limit: FIND_LIMIT,
   }
-  attachmentCols.forEach(col => (params.selector[col] = { $exists: true }))
   if (bookmark) {
     params.bookmark = bookmark
   }


### PR DESCRIPTION
## Description
Fix for #9739 - there was an issue with the mango syntax, when working with multi attachment columns it was using an AND comparator instead of OR, it should be searching for rows that contain any attachment column, not all attachment columns.

Also includes a fix for #9738 - exclude rows could be specified but attachments would still be included, this was an oversight, have flipped it so that it only extracts the required static app files from object store when data is not required.

Addresses: 
- #9739
- #9738