### PR TITLE
Bypass password onboarding for enforced sso

### DIFF
--- a/packages/builder/src/constants/index.js
+++ b/packages/builder/src/constants/index.js
@@ -62,3 +62,8 @@ export const PluginSource = {
   GITHUB: "Github",
   FILE: "File Upload",
 }
+
+export const OnboardingType = {
+  EMAIL: "email",
+  PASSWORD: "password",
+}

--- a/packages/builder/src/pages/builder/portal/users/users/_components/OnboardingTypeModal.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/_components/OnboardingTypeModal.svelte
@@ -1,9 +1,8 @@
 <script>
   import { ModalContent, Body, Layout, Icon } from "@budibase/bbui"
+  import { OnboardingType } from "../../../../../../constants"
 
   export let chooseCreationType
-  let emailOnboardingKey = "emailOnboarding"
-  let basicOnboaridngKey = "basicOnboarding"
 
   let selectedOnboardingType
 </script>
@@ -20,9 +19,9 @@
   <Layout noPadding gap="S">
     <div
       class="onboarding-type item"
-      class:selected={selectedOnboardingType == emailOnboardingKey}
+      class:selected={selectedOnboardingType == OnboardingType.EMAIL}
       on:click={() => {
-        selectedOnboardingType = emailOnboardingKey
+        selectedOnboardingType = OnboardingType.EMAIL
       }}
     >
       <div class="content onboarding-type-wrap">
@@ -32,7 +31,7 @@
         </div>
       </div>
       <div style="color: var(--spectrum-global-color-green-600); float: right">
-        {#if selectedOnboardingType == emailOnboardingKey}
+        {#if selectedOnboardingType == OnboardingType.EMAIL}
           <div class="checkmark-spacing">
             <Icon size="S" name="CheckmarkCircle" />
           </div>
@@ -42,9 +41,9 @@
 
     <div
       class="onboarding-type item"
-      class:selected={selectedOnboardingType == basicOnboaridngKey}
+      class:selected={selectedOnboardingType == OnboardingType.PASSWORD}
       on:click={() => {
-        selectedOnboardingType = basicOnboaridngKey
+        selectedOnboardingType = OnboardingType.PASSWORD
       }}
     >
       <div class="content onboarding-type-wrap">
@@ -54,7 +53,7 @@
         </div>
       </div>
       <div style="color: var(--spectrum-global-color-green-600); float: right">
-        {#if selectedOnboardingType == basicOnboaridngKey}
+        {#if selectedOnboardingType == OnboardingType.PASSWORD}
           <div class="checkmark-spacing">
             <Icon size="S" name="CheckmarkCircle" />
           </div>

--- a/packages/worker/src/api/routes/global/users.ts
+++ b/packages/worker/src/api/routes/global/users.ts
@@ -50,8 +50,8 @@ function buildInviteAcceptValidation() {
   // prettier-ignore
   return auth.joiValidator.body(Joi.object({
     inviteCode: Joi.string().required(),
-    password: Joi.string().required(),
-    firstName: Joi.string().required(),
+    password: Joi.string().optional(),
+    firstName: Joi.string().optional(),
     lastName: Joi.string().optional(),
   }).required().unknown(true))
 }

--- a/packages/worker/src/sdk/users/users.ts
+++ b/packages/worker/src/sdk/users/users.ts
@@ -140,7 +140,12 @@ const buildUser = async (
     hashedPassword = opts.hashPassword ? await utils.hash(password) : password
   } else if (dbUser) {
     hashedPassword = dbUser.password
-  } else if (opts.requirePassword) {
+  }
+
+  // passwords are never required if sso is enforced
+  const requirePasswords =
+    opts.requirePassword && !(await pro.features.isSSOEnforced())
+  if (!hashedPassword && requirePasswords) {
     throw "Password must be specified."
   }
 

--- a/packages/worker/src/utilities/redis.ts
+++ b/packages/worker/src/utilities/redis.ts
@@ -47,7 +47,7 @@ async function getACode(db: string, code: string, deleteCode = true) {
   const client = await getClient(db)
   const value = await client.get(code)
   if (!value) {
-    throw "Invalid code."
+    throw new Error("Invalid code.")
   }
   if (deleteCode) {
     await client.delete(code)


### PR DESCRIPTION
## Description

When SSO is enforced:
- Bypass the choose onboarding type modal
   - Automatically send email instead 
- Auto create the user when they click the email link
   - No firstname, lastname or password recorded 
   - Profile is synced from sso when they sign in
- Don't auto login, go to auth page instead where sso provider is active

## Screenshots

https://user-images.githubusercontent.com/8755148/222266336-68a7728c-f65c-4a3b-bcd8-7de2971b3b1e.mov






