### PR TITLE
remove link/relationship option from external data sources when creating new columns

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -337,7 +337,6 @@
         FIELDS.BOOLEAN,
         FIELDS.ARRAY,
         FIELDS.FORMULA,
-        FIELDS.LINK,
       ]
     }
   }


### PR DESCRIPTION
## Description
Bug raised in https://github.com/Budibase/budibase/issues/9727

The user here sent me a video detailing the problem, which was not a bug with relationships functionality for SQL, but the fact that a many to many relationship was configured between two tables using the following flow, which should not be supported:
- Create column
- Choose relationship
- Choose many to many to another table
- This will cause unexpected behaviour due to the table being SQL. The way this is to be configured is through the "Define existing relationship" UI which will maintain the correct referential integrity between the tables.

Addresses: 
- https://github.com/Budibase/budibase/issues/9727

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



