### PR TITLE
small UX updates to improve user addition and perceived loading of builder

### DIFF
--- a/packages/builder/src/components/deploy/VersionModal.svelte
+++ b/packages/builder/src/components/deploy/VersionModal.svelte
@@ -24,7 +24,10 @@
   let updateModal
 
   $: appId = $store.appId
-  $: updateAvailable = clientPackage.version && $store.version && clientPackage.version !== $store.version
+  $: updateAvailable =
+    clientPackage.version &&
+    $store.version &&
+    clientPackage.version !== $store.version
   $: revertAvailable = $store.revertableVersion != null
 
   const refreshAppPackage = async () => {

--- a/packages/builder/src/components/deploy/VersionModal.svelte
+++ b/packages/builder/src/components/deploy/VersionModal.svelte
@@ -24,7 +24,7 @@
   let updateModal
 
   $: appId = $store.appId
-  $: updateAvailable = clientPackage.version !== $store.version
+  $: updateAvailable = clientPackage.version && $store.version && clientPackage.version !== $store.version
   $: revertAvailable = $store.revertableVersion != null
 
   const refreshAppPackage = async () => {

--- a/packages/builder/src/pages/builder/app/[application]/_components/BuilderSidePanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/_components/BuilderSidePanel.svelte
@@ -25,7 +25,6 @@
   let rendered = false
   let inviting = false
   let searchFocus = false
-  let userSearchInput
 
   let appInvites = []
   let filteredInvites = []

--- a/packages/builder/src/pages/builder/app/[application]/_components/BuilderSidePanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/_components/BuilderSidePanel.svelte
@@ -25,6 +25,7 @@
   let rendered = false
   let inviting = false
   let searchFocus = false
+  let userSearchInput
 
   let appInvites = []
   let filteredInvites = []
@@ -346,7 +347,14 @@
 
   onMount(() => {
     rendered = true
+    searchFocus = true
   })
+
+  function handleKeyDown(evt) {
+    if (evt.key === "Enter" && queryIsEmail && !inviting) {
+      onInviteUser()
+    }
+  }
 
   const userTitle = user => {
     if (user.admin?.global) {
@@ -369,6 +377,8 @@
     return null
   }
 </script>
+
+<svelte:window on:keydown={handleKeyDown} />
 
 <div
   id="builder-side-panel-container"
@@ -403,6 +413,7 @@
         autocomplete="off"
         disabled={inviting}
         value={query}
+        autofocus
         on:input={e => {
           query = e.target.value.trim()
         }}

--- a/packages/builder/src/pages/builder/app/[application]/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/_layout.svelte
@@ -120,89 +120,86 @@
   })
 </script>
 
-{#await promise}
-  <!-- This should probably be some kind of loading state? -->
-  <div class="loading" />
-{:then _}
-  <TourPopover />
+<TourPopover />
 
-  {#if $store.builderSidePanel}
-    <BuilderSidePanel />
-  {/if}
+{#if $store.builderSidePanel}
+  <BuilderSidePanel />
+{/if}
 
-  <div class="root">
-    <div class="top-nav">
-      <div class="topleftnav">
-        <ActionMenu>
-          <div slot="control">
-            <Icon size="M" hoverable name="ShowMenu" />
-          </div>
-          <MenuItem on:click={() => $goto("../../portal/apps")}>
-            Exit to portal
-          </MenuItem>
-          <MenuItem
-            on:click={() => $goto(`../../portal/overview/${application}`)}
-          >
-            Overview
-          </MenuItem>
-          <MenuItem
-            on:click={() =>
-              $goto(`../../portal/overview/${application}/access`)}
-          >
-            Access
-          </MenuItem>
-          <MenuItem
-            on:click={() =>
-              $goto(`../../portal/overview/${application}/automation-history`)}
-          >
-            Automation history
-          </MenuItem>
-          <MenuItem
-            on:click={() =>
-              $goto(`../../portal/overview/${application}/backups`)}
-          >
-            Backups
-          </MenuItem>
+<div class="root">
+  <div class="top-nav">
+    <div class="topleftnav">
+      <ActionMenu>
+        <div slot="control">
+          <Icon size="M" hoverable name="ShowMenu" />
+        </div>
+        <MenuItem on:click={() => $goto("../../portal/apps")}>
+          Exit to portal
+        </MenuItem>
+        <MenuItem
+          on:click={() => $goto(`../../portal/overview/${application}`)}
+        >
+          Overview
+        </MenuItem>
+        <MenuItem
+          on:click={() => $goto(`../../portal/overview/${application}/access`)}
+        >
+          Access
+        </MenuItem>
+        <MenuItem
+          on:click={() =>
+            $goto(`../../portal/overview/${application}/automation-history`)}
+        >
+          Automation history
+        </MenuItem>
+        <MenuItem
+          on:click={() => $goto(`../../portal/overview/${application}/backups`)}
+        >
+          Backups
+        </MenuItem>
 
-          <MenuItem
-            on:click={() =>
-              $goto(`../../portal/overview/${application}/name-and-url`)}
-          >
-            Name and URL
-          </MenuItem>
-          <MenuItem
-            on:click={() =>
-              $goto(`../../portal/overview/${application}/version`)}
-          >
-            Version
-          </MenuItem>
-        </ActionMenu>
-        <Heading size="XS">{$store.name || "App"}</Heading>
-      </div>
-      <div class="topcenternav">
-        <Tabs {selected} size="M">
-          {#each $layout.children as { path, title }}
-            <TourWrap tourStepKey={`builder-${title}-section`}>
-              <Tab
-                quiet
-                selected={$isActive(path)}
-                on:click={topItemNavigate(path)}
-                title={capitalise(title)}
-                id={`builder-${title}-tab`}
-              />
-            </TourWrap>
-          {/each}
-        </Tabs>
-      </div>
-      <div class="toprightnav">
-        <AppActions {application} />
-      </div>
+        <MenuItem
+          on:click={() =>
+            $goto(`../../portal/overview/${application}/name-and-url`)}
+        >
+          Name and URL
+        </MenuItem>
+        <MenuItem
+          on:click={() => $goto(`../../portal/overview/${application}/version`)}
+        >
+          Version
+        </MenuItem>
+      </ActionMenu>
+      <Heading size="XS">{$store.name}</Heading>
     </div>
-    <slot />
+    <div class="topcenternav">
+      <Tabs {selected} size="M">
+        {#each $layout.children as { path, title }}
+          <TourWrap tourStepKey={`builder-${title}-section`}>
+            <Tab
+              quiet
+              selected={$isActive(path)}
+              on:click={topItemNavigate(path)}
+              title={capitalise(title)}
+              id={`builder-${title}-tab`}
+            />
+          </TourWrap>
+        {/each}
+      </Tabs>
+    </div>
+    <div class="toprightnav">
+      <AppActions {application} />
+    </div>
   </div>
-{:catch error}
-  <p>Something went wrong: {error.message}</p>
-{/await}
+  {#await promise}
+    <!-- This should probably be some kind of loading state? -->
+    <div class="loading" />
+  {:then _}
+    <slot />
+  {:catch error}
+    <p>Something went wrong: {error.message}</p>
+  {/await}
+</div>
 
 <style>
   .loading {


### PR DESCRIPTION
## Description
Doesn't need to go in for release - just a couple of small ones I noticed when doing an end to end of the february features, and a little pet peeve I've wanted to fix for a while.

### Progressive builder loading
The entire builder loads from the outside in based on the response from an HTTP request that it doesn't need to wait on. This causes a little bit of a disjoint when you are navigating between portal and builder.

We can render the shell of the builder instantly, and wait for the inner content of the builder to load after that. This improves the initial loading performance and makes the builder look faster - all I've done here is moved some code to render the outer shell and updated the state logic to not `Update available` on first load.

### New User Side Panel
- Autofocus the modal when the side panel opens
- Add an enter keydown handler to allow adding a user with the keyboard

## Screenshots
### Before
https://user-images.githubusercontent.com/11256663/222285700-d26d9fe9-8a82-4287-afc8-799a457812c7.mov


### After
https://user-images.githubusercontent.com/11256663/222285355-d1ce449c-3263-4e95-9fdd-f9593ae73ff5.mov




## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



