### PR TITLE
Hide upgrade button on enterprise plan

### DIFF
--- a/packages/builder/src/pages/builder/portal/_components/UpgradeButton.svelte
+++ b/packages/builder/src/pages/builder/portal/_components/UpgradeButton.svelte
@@ -1,11 +1,11 @@
 <script>
   import { Button } from "@budibase/bbui"
   import { goto } from "@roxi/routify"
-  import { auth, admin } from "stores/portal"
+  import { auth, admin, licensing } from "stores/portal"
   import { isEnabled, TENANT_FEATURE_FLAGS } from "helpers/featureFlags"
 </script>
 
-{#if isEnabled(TENANT_FEATURE_FLAGS.LICENSING)}
+{#if isEnabled(TENANT_FEATURE_FLAGS.LICENSING) && !$licensing.isEnterprisePlan}
   {#if $admin.cloud && $auth?.user?.accountPortalAccess}
     <Button
       cta

--- a/packages/builder/src/stores/portal/licensing.js
+++ b/packages/builder/src/stores/portal/licensing.js
@@ -12,6 +12,7 @@ export const createLicensingStore = () => {
     // the top level license
     license: undefined,
     isFreePlan: true,
+    isEnterprisePlan: true,
     // features
     groupsEnabled: false,
     backupsEnabled: false,
@@ -53,7 +54,9 @@ export const createLicensingStore = () => {
     },
     setLicense: () => {
       const license = get(auth).user.license
-      const isFreePlan = license?.plan.type === Constants.PlanType.FREE
+      const planType = license?.plan.type
+      const isEnterprisePlan = planType === Constants.PlanType.ENTERPRISE
+      const isFreePlan = planType === Constants.PlanType.FREE
       const groupsEnabled = license.features.includes(
         Constants.Features.USER_GROUPS
       )
@@ -74,6 +77,7 @@ export const createLicensingStore = () => {
         return {
           ...state,
           license,
+          isEnterprisePlan,
           isFreePlan,
           groupsEnabled,
           backupsEnabled,


### PR DESCRIPTION
## Description
Don't show the upgrade button on enterprise - as there is nothing to upgrade to 

Before 
![Screenshot 2023-03-02 at 09 27 59](https://user-images.githubusercontent.com/8755148/222387987-18d82b66-529a-4e18-8868-2897914efb4b.png)
![Screenshot 2023-03-02 at 09 28 06](https://user-images.githubusercontent.com/8755148/222387999-e188d340-dc02-46f5-9feb-acb0937a711a.png)

After
![Screenshot 2023-03-02 at 09 28 43](https://user-images.githubusercontent.com/8755148/222387993-a30c884d-50dc-4de9-8df9-2ec3cfe8598d.png)
![Screenshot 2023-03-02 at 09 28 37](https://user-images.githubusercontent.com/8755148/222387996-9f7ec6ab-f7c9-410a-a283-dae3768da9d3.png)




