### PR TITLE
Added error handling for leaflet initialisation errors

### DIFF
--- a/packages/client/src/components/app/embedded-map/EmbeddedMap.svelte
+++ b/packages/client/src/components/app/embedded-map/EmbeddedMap.svelte
@@ -283,27 +283,32 @@
     if (mapInstance) {
       mapInstance.remove()
     }
-    mapInstance = L.map(embeddedMapId, mapOptions)
-    mapMarkerGroup.addTo(mapInstance)
-    candidateMarkerGroup.addTo(mapInstance)
 
-    // Add attribution
-    const cleanAttribution = sanitizeHtml(attribution, {
-      allowedTags: ["a"],
-      allowedAttributes: {
-        a: ["href", "target"],
-      },
-    })
-    L.tileLayer(tileURL, {
-      attribution: "&copy; " + cleanAttribution,
-      zoom,
-    }).addTo(mapInstance)
+    try {
+      mapInstance = L.map(embeddedMapId, mapOptions)
+      mapMarkerGroup.addTo(mapInstance)
+      candidateMarkerGroup.addTo(mapInstance)
 
-    // Add click handler
-    mapInstance.on("click", handleMapClick)
+      // Add attribution
+      const cleanAttribution = sanitizeHtml(attribution, {
+        allowedTags: ["a"],
+        allowedAttributes: {
+          a: ["href", "target"],
+        },
+      })
+      L.tileLayer(tileURL, {
+        attribution: "&copy; " + cleanAttribution,
+        zoom,
+      }).addTo(mapInstance)
 
-    // Reset view
-    resetView()
+      // Add click handler
+      mapInstance.on("click", handleMapClick)
+
+      // Reset view
+      resetView()
+    } catch (e) {
+      console.log("There was a problem with the map", e)
+    }
   }
 
   const handleMapClick = e => {


### PR DESCRIPTION
## Description

Adds a try/catch to the leaflet map initialisation code . In this case, there was a race condition with the component settings being updated, the component reinitialising and the sidebar containing it closing. Under those conditions the initialisation would break the builder.

Addresses: 
- https://github.com/Budibase/budibase/issues/9587