### PR TITLE
Fix/gsheets test

### DIFF
--- a/packages/backend-core/src/configs/configs.ts
+++ b/packages/backend-core/src/configs/configs.ts
@@ -179,7 +179,7 @@ export async function getGoogleDatasourceConfig(): Promise<
 }
 
 export function getDefaultGoogleConfig(): GoogleInnerConfig | undefined {
-  if (env.isTest() || (environment.GOOGLE_CLIENT_ID && environment.GOOGLE_CLIENT_SECRET)) {
+  if (environment.GOOGLE_CLIENT_ID && environment.GOOGLE_CLIENT_SECRET) {
     return {
       clientID: environment.GOOGLE_CLIENT_ID!,
       clientSecret: environment.GOOGLE_CLIENT_SECRET!,

--- a/packages/backend-core/src/configs/configs.ts
+++ b/packages/backend-core/src/configs/configs.ts
@@ -179,7 +179,7 @@ export async function getGoogleDatasourceConfig(): Promise<
 }
 
 export function getDefaultGoogleConfig(): GoogleInnerConfig | undefined {
-  if (environment.GOOGLE_CLIENT_ID && environment.GOOGLE_CLIENT_SECRET) {
+  if (env.isTest() || (environment.GOOGLE_CLIENT_ID && environment.GOOGLE_CLIENT_SECRET)) {
     return {
       clientID: environment.GOOGLE_CLIENT_ID!,
       clientSecret: environment.GOOGLE_CLIENT_SECRET!,

--- a/packages/server/src/integrations/tests/googlesheets.spec.ts
+++ b/packages/server/src/integrations/tests/googlesheets.spec.ts
@@ -30,7 +30,6 @@ import { structures } from "@budibase/backend-core/tests"
 import TestConfiguration from "../../tests/utilities/TestConfiguration"
 import GoogleSheetsIntegration from "../googlesheets"
 import { FieldType, Table, TableSchema } from "../../../../types/src/documents"
-import environment from "../../environment"
 
 describe("Google Sheets Integration", () => {
   let integration: any,

--- a/packages/server/src/integrations/tests/googlesheets.spec.ts
+++ b/packages/server/src/integrations/tests/googlesheets.spec.ts
@@ -35,6 +35,10 @@ describe("Google Sheets Integration", () => {
   let integration: any,
     config = new TestConfiguration()
 
+  beforeAll(() => {
+    config.setGoogleAuth("test")
+  })
+
   beforeEach(async () => {
     integration = new GoogleSheetsIntegration.integration({
       spreadsheetId: "randomId",

--- a/packages/server/src/integrations/tests/googlesheets.spec.ts
+++ b/packages/server/src/integrations/tests/googlesheets.spec.ts
@@ -30,6 +30,7 @@ import { structures } from "@budibase/backend-core/tests"
 import TestConfiguration from "../../tests/utilities/TestConfiguration"
 import GoogleSheetsIntegration from "../googlesheets"
 import { FieldType, Table, TableSchema } from "../../../../types/src/documents"
+import environment from "../../environment"
 
 describe("Google Sheets Integration", () => {
   let integration: any,

--- a/packages/server/src/tests/utilities/TestConfiguration.ts
+++ b/packages/server/src/tests/utilities/TestConfiguration.ts
@@ -181,6 +181,13 @@ class TestConfiguration {
     coreEnv._set("SELF_HOSTED", value)
   }
 
+  setGoogleAuth = (value: string) => {
+    env._set("GOOGLE_CLIENT_ID", value)
+    env._set("GOOGLE_CLIENT_SECRET", value)
+    coreEnv._set("GOOGLE_CLIENT_ID", value)
+    coreEnv._set("GOOGLE_CLIENT_SECRET", value)
+  }
+
   modeCloud = () => {
     this.setSelfHosted(false)
   }


### PR DESCRIPTION
## Description
Gsheets tests failing due to the following code to fetch the gsheets config, where the google env variables have not been set up:
```
export function getDefaultGoogleConfig(): GoogleInnerConfig | undefined {
  if (environment.GOOGLE_CLIENT_ID && environment.GOOGLE_CLIENT_SECRET) {
    return {
      clientID: environment.GOOGLE_CLIENT_ID!,
      clientSecret: environment.GOOGLE_CLIENT_SECRET!,
      activated: true,
    }
  }
}
```
Added the option to switch these variables on in the `TestConfiguration` so that the test returns the config.