### PR TITLE
Add budi cdn to CSP media-src directive

### DIFF
--- a/hosting/proxy/nginx.prod.conf
+++ b/hosting/proxy/nginx.prod.conf
@@ -60,7 +60,7 @@ http {
     set $csp_frame "frame-src 'self' https:";
     set $csp_img "img-src http: https: data: blob:";
     set $csp_manifest "manifest-src 'self'";
-    set $csp_media "media-src 'self' https://js.intercomcdn.com";
+    set $csp_media "media-src 'self' https://js.intercomcdn.com https://cdn.budi.live"; 
     set $csp_worker "worker-src 'none'";
 
     error_page 502 503 504 /error.html;


### PR DESCRIPTION
## Description
A user was trying to play media from an attachment field in their Budibase DB on cloud but they were unable to load it in from cdn.budi.live due to it not being allowed in the media-src CSP directive. This allows attachment files from cdn.budi.live to be used in the app.

Addresses: 
https://github.com/Budibase/budibase/discussions/9869#discussioncomment-5216985

## App Export
n/a

## Screenshots
n/a

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



