### PR TITLE
CLI dependency issue

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,7 @@
     "chalk": "4.1.0",
     "cli-progress": "3.11.2",
     "commander": "7.1.0",
-    "docker-compose": "0.23.6",
+    "docker-compose": "0.23.12",
     "dotenv": "16.0.1",
     "download": "8.0.0",
     "find-free-port": "^2.0.0",

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -1235,10 +1235,12 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-docker-compose@0.23.6:
-  version "0.23.6"
-  resolved "https://registry.yarnpkg.com/docker-compose/-/docker-compose-0.23.6.tgz#bd21e17d599f17fcf7a4b5d607cff0358a9c378b"
-  integrity sha512-y3Q8MkwG862rNqkvEQG59/7Fi2/fzs3NYDCvqUAAD+z0WGs2qcJ9hRcn34hWgWv9ouPkFqe3Vwca0h+4bIIRWw==
+docker-compose@0.23.12:
+  version "0.23.12"
+  resolved "https://registry.yarnpkg.com/docker-compose/-/docker-compose-0.23.12.tgz#fa883b98be08f6926143d06bf9e522ef7ed3210c"
+  integrity sha512-KFbSMqQBuHjTGZGmYDOCO0L4SaML3BsWTId5oSUyaBa22vALuFHNv+UdDWs3HcMylHWKsxCbLB7hnM/nCosWZw==
+  dependencies:
+    yaml "^1.10.2"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -3688,6 +3690,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yaml@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
## Description
Fixing an issue with the CLI dependencies, the version of docker-compose we were using didn't support ES6 imports, despite appearing as if it did, upgrading to a version this is properly supported.