### PR TITLE
fix roleId being undefined leading to group role overriding incorrectly

### DIFF
--- a/packages/server/src/utilities/global.ts
+++ b/packages/server/src/utilities/global.ts
@@ -35,8 +35,6 @@ export function updateAppRole(
     user.roleId = roles.BUILTIN_ROLE_IDS.ADMIN
   } else if (!user.roleId && !user?.userGroups?.length) {
     user.roleId = roles.BUILTIN_ROLE_IDS.PUBLIC
-  } else if (user?.userGroups?.length) {
-    user.roleId = undefined
   }
 
   delete user.roles


### PR DESCRIPTION
## Description
Fixes an issue where when a user was in a user group, it would set the roleId to undefined - hence the group role would always take precedence. A user role will now always override a group role. 

The removed branch was leftover from the initial groups work, where role assignment worked slightly differently.  

