### PR TITLE
SQL formulas - keeping after fetching

### DIFF
--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -223,14 +223,15 @@ function shouldCopySpecialColumn(
   column: { type: string },
   fetchedColumn: { type: string } | undefined
 ) {
+  const isFormula = column.type === FieldTypes.FORMULA
   const specialTypes = [
     FieldTypes.OPTIONS,
     FieldTypes.LONGFORM,
     FieldTypes.ARRAY,
     FieldTypes.FORMULA,
   ]
-  // column has been deleted, remove
-  if (column && !fetchedColumn) {
+  // column has been deleted, remove - formulas will never exist, always copy
+  if (!isFormula && column && !fetchedColumn) {
     return false
   }
   const fetchedIsNumber =


### PR DESCRIPTION
## Description
Fix for #9790 - formulas never exist in the database and so were always being considered deleted, handling this.

Addresses: 
- #9790



