### PR TITLE
Use helm .Chart.AppVersion instead of specifying value

### DIFF
--- a/.github/workflows/deploy-cloud.yaml
+++ b/.github/workflows/deploy-cloud.yaml
@@ -55,7 +55,7 @@ jobs:
           config-files: values.production.yaml
           chart-path: charts/budibase
           namespace: budibase
-          values: services.couchdb.url=${{ secrets.PRODUCTION_COUCHDB_URL }},services.couchdb.password=${{ secrets.PRODUCTION_COUCHDB_PASSWORD }}
+          values: globals.appVersion=${{ env.RELEASE_VERSION }},services.couchdb.url=${{ secrets.PRODUCTION_COUCHDB_URL }},services.couchdb.password=${{ secrets.PRODUCTION_COUCHDB_PASSWORD }}
           name: budibase-prod
 
       - name: Discord Webhook Action

--- a/.github/workflows/deploy-cloud.yaml
+++ b/.github/workflows/deploy-cloud.yaml
@@ -55,7 +55,7 @@ jobs:
           config-files: values.production.yaml
           chart-path: charts/budibase
           namespace: budibase
-          values: globals.appVersion=v${{ env.RELEASE_VERSION }},services.couchdb.url=${{ secrets.PRODUCTION_COUCHDB_URL }},services.couchdb.password=${{ secrets.PRODUCTION_COUCHDB_PASSWORD }}
+          values: services.couchdb.url=${{ secrets.PRODUCTION_COUCHDB_URL }},services.couchdb.password=${{ secrets.PRODUCTION_COUCHDB_PASSWORD }}
           name: budibase-prod
 
       - name: Discord Webhook Action

--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -205,7 +205,11 @@ spec:
           value: {{ .Values.services.tlsRejectUnauthorized }}
         {{ end }}
 
+        {{ if .Values.globals.appVersion }}
+        image: budibase/apps:v{{ .Values.globals.appVersion }}
+        {{ else }}
         image: budibase/apps:v{{ .Chart.AppVersion }}
+        {{ end }}
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -205,7 +205,7 @@ spec:
           value: {{ .Values.services.tlsRejectUnauthorized }}
         {{ end }}
 
-        image: budibase/apps:{{ .Values.globals.appVersion }}
+        image: budibase/apps:v{{ .Chart.AppVersion }}
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -37,7 +37,7 @@ spec:
 {{ end }}
     spec:
       containers:
-      - image: budibase/proxy:{{ .Values.globals.appVersion }}
+      - image: budibase/proxy:v{{ .Chart.AppVersion }}
         imagePullPolicy: Always
         name: proxy-service
         ports:

--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -37,7 +37,11 @@ spec:
 {{ end }}
     spec:
       containers:
-      - image: budibase/proxy:v{{ .Chart.AppVersion }}
+        {{ if .Values.globals.appVersion }}
+        image: budibase/proxy:v{{ .Values.globals.appVersion }}
+        {{ else }}
+        image: budibase/proxy:v{{ .Chart.AppVersion }}
+        {{ end }}
         imagePullPolicy: Always
         name: proxy-service
         ports:

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -195,7 +195,11 @@ spec:
           value: {{ .Values.services.tlsRejectUnauthorized }}
         {{ end }}
 
+        {{ if .Values.globals.appVersion }}
+        image: budibase/worker:v{{ .Values.globals.appVersion }}
+        {{ else }}
         image: budibase/worker:v{{ .Chart.AppVersion }}
+        {{ end }}
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -195,7 +195,7 @@ spec:
           value: {{ .Values.services.tlsRejectUnauthorized }}
         {{ end }}
 
-        image: budibase/worker:{{ .Values.globals.appVersion }}
+        image: budibase/worker:v{{ .Chart.AppVersion }}
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -74,6 +74,7 @@ tolerations: []
 affinity: {}
 
 globals:
+  appVersion: "" # Use as an override to .Chart.AppVersion
   budibaseEnv: PRODUCTION
   tenantFeatureFlags: "*:LICENSING,*:USER_GROUPS,*:ONBOARDING_TOUR"
   enableAnalytics: "1"

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -74,7 +74,6 @@ tolerations: []
 affinity: {}
 
 globals:
-  appVersion: "latest"
   budibaseEnv: PRODUCTION
   tenantFeatureFlags: "*:LICENSING,*:USER_GROUPS,*:ONBOARDING_TOUR"
   enableAnalytics: "1"

--- a/scripts/releaseHelmChart.js
+++ b/scripts/releaseHelmChart.js
@@ -2,15 +2,8 @@ const yaml = require("js-yaml")
 const fs = require("fs")
 const path = require("path")
 
-const UpgradeTypes = {
-	MAJOR: "major",
-	MINOR: "minor",
-	PATCH: "patch"
-}
-
 const CHART_PATH = path.join(__dirname, "../", "charts", "budibase", "Chart.yaml")
 const UPGRADE_VERSION = process.env.BUDIBASE_RELEASE_VERSION
-const UPGRADE_TYPE = process.env.HELM_CHART_UPGRADE_TYPE || UpgradeTypes.PATCH
 
 if (!UPGRADE_VERSION) {
 	throw new Error("BUDIBASE_RELEASE_VERSION env var must be set.")


### PR DESCRIPTION
## Description
Use the `.Chart.AppVersion` built into the chart for the image tags for server, worker and proxy. This ensures the image version is always correct for the infrastructure in use, rather than defaulting to `latest` by default. 

This also makes consuming the chart easier for the new preprod environment, as unlike develop where we have a consistent `develop` tag in docker-hub, we do not have this in preprod. We instead have a chart published under `0.0.0-master` that we can reference instead, which will now auto inherit the app version the chart was published with. 

