### PR TITLE
Don't require password on update if user doesn't have one

### DIFF
--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -4,6 +4,7 @@ jest.mock("nodemailer")
 import { TestConfiguration, mocks, structures } from "../../../../tests"
 const sendMailMock = mocks.email.mock()
 import { events, tenancy, accounts as _accounts } from "@budibase/backend-core"
+import * as userSdk from "../../../../sdk/users"
 
 const accounts = jest.mocked(_accounts)
 
@@ -467,6 +468,20 @@ describe("/api/global/users", () => {
         200,
         config.authHeaders(nonAdmin)
       )
+    })
+
+    describe("sso users", () => {
+      function createSSOUser() {
+        return config.doInTenant(() => {
+          const user = structures.users.ssoUser()
+          return userSdk.save(user, { requirePassword: false })
+        })
+      }
+
+      it("should be able to update an sso user that has no password", async () => {
+        const user = await createSSOUser()
+        await config.api.users.saveUser(user)
+      })
     })
   })
 

--- a/packages/worker/src/sdk/users/users.ts
+++ b/packages/worker/src/sdk/users/users.ts
@@ -131,6 +131,11 @@ const buildUser = async (
 ): Promise<User> => {
   let { password, _id } = user
 
+  // don't require a password if the db user doesn't already have one
+  if (dbUser && !dbUser.password) {
+    opts.requirePassword = false
+  }
+
   let hashedPassword
   if (password) {
     if (await isPreventPasswordActions(user)) {


### PR DESCRIPTION
## Description
Don't require password on update if user doesn't have one - this is required for updating SSO users. 

Previously we didn't perform the password check if the db user existed at all. This was corrected in the previous release, however caused a bug where users who don't have a password  weren't able to update. 

Addresses: 
- https://linear.app/budibase/issue/BUDI-6689/unable-to-update-profile-for-sso-user
- https://github.com/Budibase/budibase/issues/9934


