### PR TITLE
pinning MinIO versions

### DIFF
--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -59,7 +59,8 @@ services:
 
   minio-service:
     restart: unless-stopped
-    image: minio/minio
+    # Last version that supports the "fs" backend
+    image: minio/minio:RELEASE.2022-10-24T18-35-07Z
     volumes:
       - minio_data:/data
     environment:

--- a/scripts/install-minio.sh
+++ b/scripts/install-minio.sh
@@ -2,9 +2,9 @@
 if [[ $TARGETARCH == arm* ]] ;
 then
   echo "INSTALLING ARM64 MINIO"
-  wget https://dl.min.io/server/minio/release/linux-arm64/minio
+  wget https://dl.min.io/server/minio/release/linux-arm64/archive/minio.RELEASE.2022-10-24T18-35-07Z
 else
   echo "INSTALLING AMD64 MINIO"
-  wget https://dl.min.io/server/minio/release/linux-amd64/minio
+  wget https://dl.min.io/server/minio/release/linux-amd64/minio.RELEASE.2022-10-24T18-35-07Z
 fi
 chmod +x minio


### PR DESCRIPTION
## Description
Due to changes in the minIO file system, older users of budibase who were using the old MinIO file system will face issues if they use the latest version of MinIO with a budibase instance that was configured with MinIO pre `RELEASE.2022-10-24T18-35-07Z`. 

I've updated the single image download script to pull this version from the archive, and for the docker-compose config to be pinned to the last compatible version also.



