### PR TITLE
Revert "pinning MinIO versions"

### DIFF
--- a/hosting/docker-compose.dev.yaml
+++ b/hosting/docker-compose.dev.yaml
@@ -6,8 +6,7 @@ services:
   minio-service:
     container_name: budi-minio-dev
     restart: on-failure
-    # Last version that supports the "fs" backend
-    image: minio/minio:RELEASE.2022-10-24T18-35-07Z
+    image: minio/minio
     volumes:
       - minio_data:/data
     ports:

--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -59,8 +59,7 @@ services:
 
   minio-service:
     restart: unless-stopped
-    # Last version that supports the "fs" backend
-    image: minio/minio:RELEASE.2022-10-24T18-35-07Z
+    image: minio/minio
     volumes:
       - minio_data:/data
     environment:

--- a/scripts/install-minio.sh
+++ b/scripts/install-minio.sh
@@ -2,9 +2,9 @@
 if [[ $TARGETARCH == arm* ]] ;
 then
   echo "INSTALLING ARM64 MINIO"
-  wget https://dl.min.io/server/minio/release/linux-arm64/archive/minio.RELEASE.2022-10-24T18-35-07Z
+  wget https://dl.min.io/server/minio/release/linux-arm64/minio
 else
   echo "INSTALLING AMD64 MINIO"
-  wget https://dl.min.io/server/minio/release/linux-amd64/minio.RELEASE.2022-10-24T18-35-07Z
+  wget https://dl.min.io/server/minio/release/linux-amd64/minio
 fi
 chmod +x minio


### PR DESCRIPTION
Reverts Budibase/budibase#9943

This cannot be added for now - need to have a think about how to support this, discussed on Discord, we cannot pin a specific version of docker-compose as any installs after October 2022 will be broken.