### PR TITLE
Add max height to popover when rendering above anchor

### DIFF
--- a/packages/bbui/src/Actions/position_dropdown.js
+++ b/packages/bbui/src/Actions/position_dropdown.js
@@ -31,6 +31,7 @@ export default function positionDropdown(element, opts) {
       styles.top = anchorBounds.top
     } else if (window.innerHeight - anchorBounds.bottom < 100) {
       styles.top = anchorBounds.top - elementBounds.height - offset
+      styles.maxHeight = 240
     } else {
       styles.top = anchorBounds.bottom + offset
       styles.maxHeight = window.innerHeight - anchorBounds.bottom - 20


### PR DESCRIPTION
## Description
Adds a max height to options picker whenever they position themselves above their anchors.

Addresses: 
- #9819 
- #9909

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



