### PR TITLE
Allow Is in for _id SQL

### DIFF
--- a/packages/frontend-core/src/utils/lucene.js
+++ b/packages/frontend-core/src/utils/lucene.js
@@ -54,7 +54,7 @@ export const getValidOperatorsForType = (type, field, datasource) => {
 
   // Only allow equal/not equal for _id in SQL tables
   if (field === "_id" && externalTable) {
-    ops = [Op.Equals, Op.NotEquals]
+    ops = [Op.Equals, Op.NotEquals, Op.In]
   }
 
   return ops


### PR DESCRIPTION
## Description
Allow **Is in** filter on **_id** field so that Relationship Picker can be used as the input of a Data Provider filter. (See tutorial)

Addresses: 
- https://github.com/Budibase/budibase/issues/9015



