### PR TITLE
CLI - replace docker-compose image as required

### DIFF
--- a/packages/cli/src/hosting/update.ts
+++ b/packages/cli/src/hosting/update.ts
@@ -4,6 +4,8 @@ import {
   downloadDockerCompose,
   handleError,
   getServices,
+  getServiceImage,
+  setServiceImage,
 } from "./utils"
 import { confirmation } from "../questions"
 import compose from "docker-compose"
@@ -23,7 +25,11 @@ export async function update() {
     !isSingle &&
     (await confirmation("Do you wish to update you docker-compose.yaml?"))
   ) {
+    // get current MinIO image
+    const image = await getServiceImage("minio")
     await downloadDockerCompose()
+    // replace MinIO image
+    setServiceImage("minio", image)
   }
   await handleError(async () => {
     const status = await compose.ps()


### PR DESCRIPTION
## Description
Minor fix for CLI - to preserve the MinIO image, meaning that new installations will always use the minio/minio image, whereas older installations can use the RELEASE.2022-10-24T18-35-07Z version which still supports the FS system.

This is on the back of PR: https://github.com/Budibase/budibase/pull/9943 which had to be reverted due to downgrades causing issues for new self hosters.


