### PR TITLE
Change Database to Service Name in Oracle config

### DIFF
--- a/packages/builder/src/components/backend/DatasourceNavigator/TableIntegrationMenu/IntegrationConfigForm.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/TableIntegrationMenu/IntegrationConfigForm.svelte
@@ -74,6 +74,14 @@
     }
     return capitalise(name)
   }
+
+  function getDisplayError(error, configKey) {
+    return error?.replace(
+      new RegExp(`${configKey}`, "i"),
+      getDisplayName(configKey)
+    )
+  }
+
   function getFieldGroupKeys(fieldGroup) {
     return Object.entries(schema[fieldGroup].fields || {})
       .filter(el => filter(el))
@@ -147,7 +155,7 @@
             type={schema[configKey].type}
             on:change
             bind:value={config[configKey]}
-            error={$validation.errors[configKey]}
+            error={getDisplayError($validation.errors[configKey], configKey)}
           />
         </div>
       {:else if schema[configKey].type === "fieldGroup"}
@@ -180,7 +188,7 @@
             type={configKey === "port" ? "string" : schema[configKey].type}
             on:change
             bind:value={config[configKey]}
-            error={$validation.errors[configKey]}
+            error={getDisplayError($validation.errors[configKey], configKey)}
             environmentVariablesEnabled={$licensing.environmentVariablesEnabled}
             {handleUpgradePanel}
           />

--- a/packages/server/src/integrations/oracle.ts
+++ b/packages/server/src/integrations/oracle.ts
@@ -67,6 +67,7 @@ const SCHEMA: Integration = {
     database: {
       type: DatasourceFieldType.STRING,
       required: true,
+      display: "Service Name",
     },
     user: {
       type: DatasourceFieldType.STRING,


### PR DESCRIPTION
## Description
When going through an Oracle setup with @jonnymccullagh we realised that the **Database** field is really the **Service Name** field. 

Database is a different concept in Oracle. 
https://dba.stackexchange.com/questions/75960/oracle-service-name-vs-database-name

For backwards compatibility I'm using the display name, however I had to make a slight tweak to get the validation to use the display name as well.

Addresses: 
- https://linear.app/budibase/issue/BUDI-6667/change-oracle-db-name-to-service-name

## Screenshots
![Screenshot 2023-03-09 at 15 56 23](https://user-images.githubusercontent.com/101575380/224080091-71d0a26d-901e-4e3f-b54b-d3156b7942a8.png)

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



