### PR TITLE
Disable google auth if no config found

### DIFF
--- a/packages/worker/src/api/controllers/global/configs.ts
+++ b/packages/worker/src/api/controllers/global/configs.ts
@@ -287,7 +287,7 @@ export async function publicSettings(
 
     // google
     const googleConfig = await configs.getGoogleConfig()
-    const preActivated = googleConfig?.activated == null
+    const preActivated = googleConfig && googleConfig.activated == null
     const google = preActivated || !!googleConfig?.activated
     const _googleCallbackUrl = await googleCallbackUrl(googleConfig)
 

--- a/packages/worker/src/api/routes/global/tests/configs.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/configs.spec.ts
@@ -288,7 +288,7 @@ describe("configs", () => {
           company: "Budibase",
           logoUrl: "",
           analyticsEnabled: false,
-          google: true,
+          google: false,
           googleCallbackUrl: `http://localhost:10000/api/global/auth/${config.tenantId}/google/callback`,
           isSSOEnforced: false,
           oidc: false,


### PR DESCRIPTION
## Description
Fix for #9937 - Google config was pre-activated always, even if no google config had been created.

Addresses: 
- #9937


