### PR TITLE
Fix for a couple of automation issues

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -79,6 +79,7 @@
         searchableSchema: true,
       }).schema
     }
+
     try {
       if (isTestModal) {
         let newTestData = { schema }

--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -63,9 +63,6 @@
 
   const getInputData = (testData, blockInputs) => {
     let newInputData = testData || blockInputs
-    if (block.event === "app:trigger" && !newInputData?.fields) {
-      newInputData = cloneDeep(blockInputs)
-    }
     inputData = newInputData
   }
 
@@ -214,8 +211,6 @@
   function saveFilters(key) {
     const filters = LuceneUtils.buildLuceneQuery(tempFilters)
     const defKey = `${key}-def`
-    inputData[key] = filters
-    inputData[defKey] = tempFilters
     onChange({ detail: filters }, key)
     // need to store the builder definition in the automation
     onChange({ detail: tempFilters }, defKey)

--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -50,7 +50,7 @@
   $: tempFilters = filters
   $: stepId = block.stepId
   $: bindings = getAvailableBindings(block, $selectedAutomation?.definition)
-  $: getInputData(testData, cloneDeep(block.inputs))
+  $: getInputData(testData, block.inputs)
   $: tableId = inputData ? inputData.tableId : null
   $: table = tableId
     ? $tables.list.find(table => table._id === inputData.tableId)

--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -50,7 +50,7 @@
   $: tempFilters = filters
   $: stepId = block.stepId
   $: bindings = getAvailableBindings(block, $selectedAutomation?.definition)
-  $: getInputData(testData, block.inputs)
+  $: getInputData(testData, cloneDeep(block.inputs))
   $: tableId = inputData ? inputData.tableId : null
   $: table = tableId
     ? $tables.list.find(table => table._id === inputData.tableId)
@@ -79,7 +79,6 @@
         searchableSchema: true,
       }).schema
     }
-
     try {
       if (isTestModal) {
         let newTestData = { schema }

--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -32,7 +32,6 @@
   import { getSchemaForTable } from "builderStore/dataBinding"
   import { Utils } from "@budibase/frontend-core"
   import { TriggerStepID, ActionStepID } from "constants/backend/automations"
-  import { cloneDeep } from "lodash/fp"
   import { onMount } from "svelte"
 
   export let block

--- a/packages/builder/src/components/automation/SetupPanel/RowSelector.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/RowSelector.svelte
@@ -95,8 +95,11 @@
   }
 
   const onChange = (e, field, type) => {
-    value[field] = coerce(e.detail, type)
-    dispatch("change", value)
+    let newValue = {
+      ...value,
+      [field]: coerce(e.detail, type),
+    }
+    dispatch("change", newValue)
   }
 
   const onChangeSetting = (e, field) => {

--- a/packages/server/src/automations/automationUtils.ts
+++ b/packages/server/src/automations/automationUtils.ts
@@ -107,7 +107,7 @@ export function substituteLoopStep(hbsString: string, substitute: string) {
   let pointer = 0,
     openPointer = 0,
     closedPointer = 0
-  while (pointer < hbsString.length) {
+  while (pointer < hbsString?.length) {
     openPointer = hbsString.indexOf(open, pointer)
     closedPointer = hbsString.indexOf(closed, pointer) + 2
     if (openPointer < 0 || closedPointer < 0) {


### PR DESCRIPTION
## Description

Fixes for a couples of issues (arising from this dicussion https://github.com/Budibase/budibase/discussions/9975)

1. Automation row inputs weren't saving correctly, this was due to a new object comparison that was taking place here: https://github.com/Budibase/budibase/blob/develop/packages/builder/src/builderStore/store/automation/index.js#L139 We were mutating the actual block itself meaning that when onChange was triggered, the automation never got saved. Using cloneDeep to mitigate this. 

2. Some data types (e.g longform) have a null value in their schema, which was causing this loop subsitute check to fail on the backend. 
