### PR TITLE
Fix does not contain filter in Lucene, when using match any filter

### DIFF
--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -1,0 +1,53 @@
+name: "deploy-preprod"
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  deploy-to-legacy-preprod-env:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Get Previous tag'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Pull values.yaml from budibase-infra
+        run: |
+          curl -H "Authorization: token ${{ secrets.GH_PERSONAL_TOKEN }}" \
+          -H 'Accept: application/vnd.github.v3.raw' \
+          -o values.preprod.yaml \
+          -L https://api.github.com/repos/budibase/budibase-infra/contents/kubernetes/budibase-preprod/values.yaml
+          wc -l values.preprod.yaml
+
+      - name: Deploy to Preprod Environment
+        uses: budibase/helm@v1.8.0
+        with:
+          release: budibase-preprod
+          namespace: budibase
+          chart: charts/budibase
+          token: ${{ github.token }}
+          helm: helm3
+          values: |
+            globals: 
+              appVersion: ${{ steps.previoustag.outputs.tag }}
+            ingress:
+              enabled: true
+              nginx: true
+          value-files: >-
+            [
+              "values.preprod.yaml"
+            ]
+
+      - name: Discord Webhook Action
+        uses: tsickert/discord-webhook@v4.0.0
+        with:
+          webhook-url: ${{ secrets.PROD_DEPLOY_WEBHOOK_URL }}
+          content: "Preprod Deployment Complete: ${{ steps.previoustag.outputs.tag }} deployed to Budibase Pre-prod."
+          embed-title: ${{ steps.previoustag.outputs.tag }}

--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -45,6 +45,8 @@ jobs:
             [
               "values.preprod.yaml"
             ]
+        env:
+          KUBECONFIG_FILE: '${{ secrets.PREPROD_KUBECONFIG }}'
 
       - name: Discord Webhook Action
         uses: tsickert/discord-webhook@v4.0.0

--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -7,6 +7,7 @@ jobs:
   deploy-to-legacy-preprod-env:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: 'Get Previous tag'
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -119,6 +119,9 @@ jobs:
         env:
           RELEASE_VERSION: ${{ steps.previoustag.outputs.tag }}
 
+  deploy-to-legacy-preprod-env:
+    uses: ./.github/workflows/deploy-preprod.yml
+    secrets: inherit
 
   # Trigger deploy to new EKS preprod environment
   trigger-deploy-to-preprod-env:

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -120,6 +120,7 @@ jobs:
           RELEASE_VERSION: ${{ steps.previoustag.outputs.tag }}
 
   deploy-to-legacy-preprod-env:
+    needs: [release-images]
     uses: ./.github/workflows/deploy-preprod.yml
     secrets: inherit
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.8",
+  "version": "2.4.9",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.10",
+  "version": "2.4.11",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.9",
+  "version": "2.4.10",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.7",
+  "version": "2.4.8",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/backend-core",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "Budibase backend core libraries used in server and worker",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,7 +24,7 @@
   "dependencies": {
     "@budibase/nano": "10.1.2",
     "@budibase/pouchdb-replication-stream": "1.2.10",
-    "@budibase/types": "^2.4.7",
+    "@budibase/types": "^2.4.8",
     "@shopify/jest-koa-mocks": "5.0.1",
     "@techpass/passport-openidconnect": "0.3.2",
     "aws-cloudfront-sign": "2.2.0",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/backend-core",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Budibase backend core libraries used in server and worker",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,7 +24,7 @@
   "dependencies": {
     "@budibase/nano": "10.1.2",
     "@budibase/pouchdb-replication-stream": "1.2.10",
-    "@budibase/types": "^2.4.8",
+    "@budibase/types": "^2.4.9",
     "@shopify/jest-koa-mocks": "5.0.1",
     "@techpass/passport-openidconnect": "0.3.2",
     "aws-cloudfront-sign": "2.2.0",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/backend-core",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Budibase backend core libraries used in server and worker",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,7 +24,7 @@
   "dependencies": {
     "@budibase/nano": "10.1.2",
     "@budibase/pouchdb-replication-stream": "1.2.10",
-    "@budibase/types": "^2.4.10",
+    "@budibase/types": "^2.4.11",
     "@shopify/jest-koa-mocks": "5.0.1",
     "@techpass/passport-openidconnect": "0.3.2",
     "aws-cloudfront-sign": "2.2.0",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/backend-core",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "description": "Budibase backend core libraries used in server and worker",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,7 +24,7 @@
   "dependencies": {
     "@budibase/nano": "10.1.2",
     "@budibase/pouchdb-replication-stream": "1.2.10",
-    "@budibase/types": "^2.4.9",
+    "@budibase/types": "^2.4.10",
     "@shopify/jest-koa-mocks": "5.0.1",
     "@techpass/passport-openidconnect": "0.3.2",
     "aws-cloudfront-sign": "2.2.0",

--- a/packages/backend-core/src/db/lucene.ts
+++ b/packages/backend-core/src/db/lucene.ts
@@ -199,6 +199,10 @@ export class QueryBuilder<T> {
     return this
   }
 
+  setAllOr() {
+    this.query.allOr = true
+  }
+
   handleSpaces(input: string) {
     if (this.noEscaping) {
       return input

--- a/packages/backend-core/src/db/lucene.ts
+++ b/packages/backend-core/src/db/lucene.ts
@@ -236,6 +236,36 @@ export class QueryBuilder<T> {
     return value
   }
 
+  isMultiCondition() {
+    let count = 0
+    for (let filters of Object.values(this.query)) {
+      // not contains is one massive filter in allOr mode
+      if (typeof filters === "object") {
+        count += Object.keys(filters).length
+      }
+    }
+    return count > 1
+  }
+
+  compressFilters(filters: Record<string, string[]>) {
+    const compressed: typeof filters = {}
+    for (let key of Object.keys(filters)) {
+      const finalKey = removeKeyNumbering(key)
+      if (compressed[finalKey]) {
+        compressed[finalKey] = compressed[finalKey].concat(filters[key])
+      } else {
+        compressed[finalKey] = filters[key]
+      }
+    }
+    // add prefixes back
+    const final: typeof filters = {}
+    let count = 1
+    for (let [key, value] of Object.entries(compressed)) {
+      final[`${count++}:${key}`] = value
+    }
+    return final
+  }
+
   buildSearchQuery() {
     const builder = this
     let allOr = this.query && this.query.allOr
@@ -272,9 +302,9 @@ export class QueryBuilder<T> {
     }
 
     const notContains = (key: string, value: any) => {
-      // @ts-ignore
-      const allPrefix = allOr === "" ? "*:* AND" : ""
-      return allPrefix + "NOT " + contains(key, value)
+      const allPrefix = allOr ? "*:* AND " : ""
+      const mode = allOr ? "AND" : undefined
+      return allPrefix + "NOT " + contains(key, value, mode)
     }
 
     const containsAny = (key: string, value: any) => {
@@ -299,21 +329,32 @@ export class QueryBuilder<T> {
       return `${key}:(${orStatement})`
     }
 
-    function build(structure: any, queryFn: any) {
+    function build(
+      structure: any,
+      queryFn: (key: string, value: any) => string | null,
+      opts?: { returnBuilt?: boolean; mode?: string }
+    ) {
+      let built = ""
       for (let [key, value] of Object.entries(structure)) {
         // check for new format - remove numbering if needed
         key = removeKeyNumbering(key)
         key = builder.preprocess(builder.handleSpaces(key), {
           escape: true,
         })
-        const expression = queryFn(key, value)
+        let expression = queryFn(key, value)
         if (expression == null) {
           continue
         }
-        if (query.length > 0) {
-          query += ` ${allOr ? "OR" : "AND"} `
+        if (built.length > 0 || query.length > 0) {
+          const mode = opts?.mode ? opts.mode : allOr ? "OR" : "AND"
+          built += ` ${mode} `
         }
-        query += expression
+        built += expression
+      }
+      if (opts?.returnBuilt) {
+        return built
+      } else {
+        query += built
       }
     }
 
@@ -384,14 +425,14 @@ export class QueryBuilder<T> {
       build(this.query.contains, contains)
     }
     if (this.query.notContains) {
-      build(this.query.notContains, notContains)
+      build(this.compressFilters(this.query.notContains), notContains)
     }
     if (this.query.containsAny) {
       build(this.query.containsAny, containsAny)
     }
     // make sure table ID is always added as an AND
     if (tableId) {
-      query = `(${query})`
+      query = this.isMultiCondition() ? `(${query})` : query
       allOr = false
       build({ tableId }, equal)
     }

--- a/packages/bbui/package.json
+++ b/packages/bbui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/bbui",
   "description": "A UI solution used in the different Budibase projects.",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "license": "MPL-2.0",
   "svelte": "src/index.js",
   "module": "dist/bbui.es.js",
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@adobe/spectrum-css-workflow-icons": "1.2.1",
-    "@budibase/string-templates": "^2.4.10",
+    "@budibase/string-templates": "^2.4.11",
     "@spectrum-css/accordion": "3.0.24",
     "@spectrum-css/actionbutton": "1.0.1",
     "@spectrum-css/actiongroup": "1.0.1",

--- a/packages/bbui/package.json
+++ b/packages/bbui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/bbui",
   "description": "A UI solution used in the different Budibase projects.",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "license": "MPL-2.0",
   "svelte": "src/index.js",
   "module": "dist/bbui.es.js",
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@adobe/spectrum-css-workflow-icons": "1.2.1",
-    "@budibase/string-templates": "^2.4.7",
+    "@budibase/string-templates": "^2.4.8",
     "@spectrum-css/accordion": "3.0.24",
     "@spectrum-css/actionbutton": "1.0.1",
     "@spectrum-css/actiongroup": "1.0.1",

--- a/packages/bbui/package.json
+++ b/packages/bbui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/bbui",
   "description": "A UI solution used in the different Budibase projects.",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "license": "MPL-2.0",
   "svelte": "src/index.js",
   "module": "dist/bbui.es.js",
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@adobe/spectrum-css-workflow-icons": "1.2.1",
-    "@budibase/string-templates": "^2.4.9",
+    "@budibase/string-templates": "^2.4.10",
     "@spectrum-css/accordion": "3.0.24",
     "@spectrum-css/actionbutton": "1.0.1",
     "@spectrum-css/actiongroup": "1.0.1",

--- a/packages/bbui/package.json
+++ b/packages/bbui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/bbui",
   "description": "A UI solution used in the different Budibase projects.",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "license": "MPL-2.0",
   "svelte": "src/index.js",
   "module": "dist/bbui.es.js",
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@adobe/spectrum-css-workflow-icons": "1.2.1",
-    "@budibase/string-templates": "^2.4.8",
+    "@budibase/string-templates": "^2.4.9",
     "@spectrum-css/accordion": "3.0.24",
     "@spectrum-css/actionbutton": "1.0.1",
     "@spectrum-css/actiongroup": "1.0.1",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/builder",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "license": "GPL-3.0",
   "private": true,
   "scripts": {
@@ -58,10 +58,10 @@
     }
   },
   "dependencies": {
-    "@budibase/bbui": "^2.4.9",
-    "@budibase/client": "^2.4.9",
-    "@budibase/frontend-core": "^2.4.9",
-    "@budibase/string-templates": "^2.4.9",
+    "@budibase/bbui": "^2.4.10",
+    "@budibase/client": "^2.4.10",
+    "@budibase/frontend-core": "^2.4.10",
+    "@budibase/string-templates": "^2.4.10",
     "@fortawesome/fontawesome-svg-core": "^6.2.1",
     "@fortawesome/free-brands-svg-icons": "^6.2.1",
     "@fortawesome/free-solid-svg-icons": "^6.2.1",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/builder",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "license": "GPL-3.0",
   "private": true,
   "scripts": {
@@ -58,10 +58,10 @@
     }
   },
   "dependencies": {
-    "@budibase/bbui": "^2.4.10",
-    "@budibase/client": "^2.4.10",
-    "@budibase/frontend-core": "^2.4.10",
-    "@budibase/string-templates": "^2.4.10",
+    "@budibase/bbui": "^2.4.11",
+    "@budibase/client": "^2.4.11",
+    "@budibase/frontend-core": "^2.4.11",
+    "@budibase/string-templates": "^2.4.11",
     "@fortawesome/fontawesome-svg-core": "^6.2.1",
     "@fortawesome/free-brands-svg-icons": "^6.2.1",
     "@fortawesome/free-solid-svg-icons": "^6.2.1",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/builder",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "license": "GPL-3.0",
   "private": true,
   "scripts": {
@@ -58,10 +58,10 @@
     }
   },
   "dependencies": {
-    "@budibase/bbui": "^2.4.8",
-    "@budibase/client": "^2.4.8",
-    "@budibase/frontend-core": "^2.4.8",
-    "@budibase/string-templates": "^2.4.8",
+    "@budibase/bbui": "^2.4.9",
+    "@budibase/client": "^2.4.9",
+    "@budibase/frontend-core": "^2.4.9",
+    "@budibase/string-templates": "^2.4.9",
     "@fortawesome/fontawesome-svg-core": "^6.2.1",
     "@fortawesome/free-brands-svg-icons": "^6.2.1",
     "@fortawesome/free-solid-svg-icons": "^6.2.1",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/builder",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "license": "GPL-3.0",
   "private": true,
   "scripts": {
@@ -58,10 +58,10 @@
     }
   },
   "dependencies": {
-    "@budibase/bbui": "^2.4.7",
-    "@budibase/client": "^2.4.7",
-    "@budibase/frontend-core": "^2.4.7",
-    "@budibase/string-templates": "^2.4.7",
+    "@budibase/bbui": "^2.4.8",
+    "@budibase/client": "^2.4.8",
+    "@budibase/frontend-core": "^2.4.8",
+    "@budibase/string-templates": "^2.4.8",
     "@fortawesome/fontawesome-svg-core": "^6.2.1",
     "@fortawesome/free-brands-svg-icons": "^6.2.1",
     "@fortawesome/free-solid-svg-icons": "^6.2.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/cli",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Budibase CLI, for developers, self hosting and migrations.",
   "main": "dist/index.js",
   "bin": {
@@ -29,9 +29,9 @@
     "outputPath": "build"
   },
   "dependencies": {
-    "@budibase/backend-core": "^2.4.8",
-    "@budibase/string-templates": "^2.4.8",
-    "@budibase/types": "^2.4.8",
+    "@budibase/backend-core": "^2.4.9",
+    "@budibase/string-templates": "^2.4.9",
+    "@budibase/types": "^2.4.9",
     "axios": "0.21.2",
     "chalk": "4.1.0",
     "cli-progress": "3.11.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/cli",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "Budibase CLI, for developers, self hosting and migrations.",
   "main": "dist/index.js",
   "bin": {
@@ -29,9 +29,9 @@
     "outputPath": "build"
   },
   "dependencies": {
-    "@budibase/backend-core": "^2.4.7",
-    "@budibase/string-templates": "^2.4.7",
-    "@budibase/types": "^2.4.7",
+    "@budibase/backend-core": "^2.4.8",
+    "@budibase/string-templates": "^2.4.8",
+    "@budibase/types": "^2.4.8",
     "axios": "0.21.2",
     "chalk": "4.1.0",
     "cli-progress": "3.11.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/cli",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "description": "Budibase CLI, for developers, self hosting and migrations.",
   "main": "dist/index.js",
   "bin": {
@@ -29,9 +29,9 @@
     "outputPath": "build"
   },
   "dependencies": {
-    "@budibase/backend-core": "^2.4.9",
-    "@budibase/string-templates": "^2.4.9",
-    "@budibase/types": "^2.4.9",
+    "@budibase/backend-core": "^2.4.10",
+    "@budibase/string-templates": "^2.4.10",
+    "@budibase/types": "^2.4.10",
     "axios": "0.21.2",
     "chalk": "4.1.0",
     "cli-progress": "3.11.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/cli",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Budibase CLI, for developers, self hosting and migrations.",
   "main": "dist/index.js",
   "bin": {
@@ -29,9 +29,9 @@
     "outputPath": "build"
   },
   "dependencies": {
-    "@budibase/backend-core": "^2.4.10",
-    "@budibase/string-templates": "^2.4.10",
-    "@budibase/types": "^2.4.10",
+    "@budibase/backend-core": "^2.4.11",
+    "@budibase/string-templates": "^2.4.11",
+    "@budibase/types": "^2.4.11",
     "axios": "0.21.2",
     "chalk": "4.1.0",
     "cli-progress": "3.11.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/client",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "license": "MPL-2.0",
   "module": "dist/budibase-client.js",
   "main": "dist/budibase-client.js",
@@ -19,9 +19,9 @@
     "dev:builder": "rollup -cw"
   },
   "dependencies": {
-    "@budibase/bbui": "^2.4.9",
-    "@budibase/frontend-core": "^2.4.9",
-    "@budibase/string-templates": "^2.4.9",
+    "@budibase/bbui": "^2.4.10",
+    "@budibase/frontend-core": "^2.4.10",
+    "@budibase/string-templates": "^2.4.10",
     "@spectrum-css/button": "^3.0.3",
     "@spectrum-css/card": "^3.0.3",
     "@spectrum-css/divider": "^1.0.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/client",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "license": "MPL-2.0",
   "module": "dist/budibase-client.js",
   "main": "dist/budibase-client.js",
@@ -19,9 +19,9 @@
     "dev:builder": "rollup -cw"
   },
   "dependencies": {
-    "@budibase/bbui": "^2.4.8",
-    "@budibase/frontend-core": "^2.4.8",
-    "@budibase/string-templates": "^2.4.8",
+    "@budibase/bbui": "^2.4.9",
+    "@budibase/frontend-core": "^2.4.9",
+    "@budibase/string-templates": "^2.4.9",
     "@spectrum-css/button": "^3.0.3",
     "@spectrum-css/card": "^3.0.3",
     "@spectrum-css/divider": "^1.0.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/client",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "license": "MPL-2.0",
   "module": "dist/budibase-client.js",
   "main": "dist/budibase-client.js",
@@ -19,9 +19,9 @@
     "dev:builder": "rollup -cw"
   },
   "dependencies": {
-    "@budibase/bbui": "^2.4.7",
-    "@budibase/frontend-core": "^2.4.7",
-    "@budibase/string-templates": "^2.4.7",
+    "@budibase/bbui": "^2.4.8",
+    "@budibase/frontend-core": "^2.4.8",
+    "@budibase/string-templates": "^2.4.8",
     "@spectrum-css/button": "^3.0.3",
     "@spectrum-css/card": "^3.0.3",
     "@spectrum-css/divider": "^1.0.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/client",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "license": "MPL-2.0",
   "module": "dist/budibase-client.js",
   "main": "dist/budibase-client.js",
@@ -19,9 +19,9 @@
     "dev:builder": "rollup -cw"
   },
   "dependencies": {
-    "@budibase/bbui": "^2.4.10",
-    "@budibase/frontend-core": "^2.4.10",
-    "@budibase/string-templates": "^2.4.10",
+    "@budibase/bbui": "^2.4.11",
+    "@budibase/frontend-core": "^2.4.11",
+    "@budibase/string-templates": "^2.4.11",
     "@spectrum-css/button": "^3.0.3",
     "@spectrum-css/card": "^3.0.3",
     "@spectrum-css/divider": "^1.0.3",

--- a/packages/frontend-core/package.json
+++ b/packages/frontend-core/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@budibase/frontend-core",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "description": "Budibase frontend core libraries used in builder and client",
   "author": "Budibase",
   "license": "MPL-2.0",
   "svelte": "src/index.js",
   "dependencies": {
-    "@budibase/bbui": "^2.4.9",
+    "@budibase/bbui": "^2.4.10",
     "lodash": "^4.17.21",
     "svelte": "^3.46.2"
   }

--- a/packages/frontend-core/package.json
+++ b/packages/frontend-core/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@budibase/frontend-core",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "Budibase frontend core libraries used in builder and client",
   "author": "Budibase",
   "license": "MPL-2.0",
   "svelte": "src/index.js",
   "dependencies": {
-    "@budibase/bbui": "^2.4.7",
+    "@budibase/bbui": "^2.4.8",
     "lodash": "^4.17.21",
     "svelte": "^3.46.2"
   }

--- a/packages/frontend-core/package.json
+++ b/packages/frontend-core/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@budibase/frontend-core",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Budibase frontend core libraries used in builder and client",
   "author": "Budibase",
   "license": "MPL-2.0",
   "svelte": "src/index.js",
   "dependencies": {
-    "@budibase/bbui": "^2.4.10",
+    "@budibase/bbui": "^2.4.11",
     "lodash": "^4.17.21",
     "svelte": "^3.46.2"
   }

--- a/packages/frontend-core/package.json
+++ b/packages/frontend-core/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@budibase/frontend-core",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Budibase frontend core libraries used in builder and client",
   "author": "Budibase",
   "license": "MPL-2.0",
   "svelte": "src/index.js",
   "dependencies": {
-    "@budibase/bbui": "^2.4.8",
+    "@budibase/bbui": "^2.4.9",
     "lodash": "^4.17.21",
     "svelte": "^3.46.2"
   }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/sdk",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "Budibase Public API SDK",
   "author": "Budibase",
   "license": "MPL-2.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/sdk",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "description": "Budibase Public API SDK",
   "author": "Budibase",
   "license": "MPL-2.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/sdk",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Budibase Public API SDK",
   "author": "Budibase",
   "license": "MPL-2.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/sdk",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Budibase Public API SDK",
   "author": "Budibase",
   "license": "MPL-2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,7 +45,7 @@
     "@apidevtools/swagger-parser": "10.0.3",
     "@budibase/backend-core": "^2.4.9",
     "@budibase/client": "^2.4.9",
-    "@budibase/pro": "2.4.8",
+    "@budibase/pro": "2.4.9",
     "@budibase/string-templates": "^2.4.9",
     "@budibase/types": "^2.4.9",
     "@bull-board/api": "3.7.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/server",
   "email": "hi@budibase.com",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "description": "Budibase Web Server",
   "main": "src/index.ts",
   "repository": {
@@ -43,11 +43,11 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@apidevtools/swagger-parser": "10.0.3",
-    "@budibase/backend-core": "^2.4.9",
-    "@budibase/client": "^2.4.9",
+    "@budibase/backend-core": "^2.4.10",
+    "@budibase/client": "^2.4.10",
     "@budibase/pro": "2.4.9",
-    "@budibase/string-templates": "^2.4.9",
-    "@budibase/types": "^2.4.9",
+    "@budibase/string-templates": "^2.4.10",
+    "@budibase/types": "^2.4.10",
     "@bull-board/api": "3.7.0",
     "@bull-board/koa": "3.9.4",
     "@elastic/elasticsearch": "7.10.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/server",
   "email": "hi@budibase.com",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Budibase Web Server",
   "main": "src/index.ts",
   "repository": {
@@ -43,11 +43,11 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@apidevtools/swagger-parser": "10.0.3",
-    "@budibase/backend-core": "^2.4.8",
-    "@budibase/client": "^2.4.8",
+    "@budibase/backend-core": "^2.4.9",
+    "@budibase/client": "^2.4.9",
     "@budibase/pro": "2.4.8",
-    "@budibase/string-templates": "^2.4.8",
-    "@budibase/types": "^2.4.8",
+    "@budibase/string-templates": "^2.4.9",
+    "@budibase/types": "^2.4.9",
     "@bull-board/api": "3.7.0",
     "@bull-board/koa": "3.9.4",
     "@elastic/elasticsearch": "7.10.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,7 +45,7 @@
     "@apidevtools/swagger-parser": "10.0.3",
     "@budibase/backend-core": "^2.4.11",
     "@budibase/client": "^2.4.11",
-    "@budibase/pro": "2.4.10",
+    "@budibase/pro": "2.4.11",
     "@budibase/string-templates": "^2.4.11",
     "@budibase/types": "^2.4.11",
     "@bull-board/api": "3.7.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,7 +45,7 @@
     "@apidevtools/swagger-parser": "10.0.3",
     "@budibase/backend-core": "^2.4.10",
     "@budibase/client": "^2.4.10",
-    "@budibase/pro": "2.4.9",
+    "@budibase/pro": "2.4.10",
     "@budibase/string-templates": "^2.4.10",
     "@budibase/types": "^2.4.10",
     "@bull-board/api": "3.7.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/server",
   "email": "hi@budibase.com",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Budibase Web Server",
   "main": "src/index.ts",
   "repository": {
@@ -43,11 +43,11 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@apidevtools/swagger-parser": "10.0.3",
-    "@budibase/backend-core": "^2.4.10",
-    "@budibase/client": "^2.4.10",
+    "@budibase/backend-core": "^2.4.11",
+    "@budibase/client": "^2.4.11",
     "@budibase/pro": "2.4.10",
-    "@budibase/string-templates": "^2.4.10",
-    "@budibase/types": "^2.4.10",
+    "@budibase/string-templates": "^2.4.11",
+    "@budibase/types": "^2.4.11",
     "@bull-board/api": "3.7.0",
     "@bull-board/koa": "3.9.4",
     "@elastic/elasticsearch": "7.10.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/server",
   "email": "hi@budibase.com",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "Budibase Web Server",
   "main": "src/index.ts",
   "repository": {
@@ -43,11 +43,11 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@apidevtools/swagger-parser": "10.0.3",
-    "@budibase/backend-core": "^2.4.7",
-    "@budibase/client": "^2.4.7",
+    "@budibase/backend-core": "^2.4.8",
+    "@budibase/client": "^2.4.8",
     "@budibase/pro": "2.4.6",
-    "@budibase/string-templates": "^2.4.7",
-    "@budibase/types": "^2.4.7",
+    "@budibase/string-templates": "^2.4.8",
+    "@budibase/types": "^2.4.8",
     "@bull-board/api": "3.7.0",
     "@bull-board/koa": "3.9.4",
     "@elastic/elasticsearch": "7.10.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,7 +45,7 @@
     "@apidevtools/swagger-parser": "10.0.3",
     "@budibase/backend-core": "^2.4.8",
     "@budibase/client": "^2.4.8",
-    "@budibase/pro": "2.4.6",
+    "@budibase/pro": "2.4.8",
     "@budibase/string-templates": "^2.4.8",
     "@budibase/types": "^2.4.8",
     "@bull-board/api": "3.7.0",

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -1278,14 +1278,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@2.4.10":
-  version "2.4.10"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-2.4.10.tgz#1736643ccb6e4d9c2fd22b1d6d0eea1fbe35199a"
-  integrity sha512-MdEwsoAPg1EoNjLfeX0QNUJrpZIsOx8kL92iui8L4Lfv009SV26ndQXe96f/1w/kEqMBvErQiSfl87AVjq3uPw==
+"@budibase/backend-core@2.4.11":
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-2.4.11.tgz#df8a5667ffd8d51157559c4883e6e11aa21d18a4"
+  integrity sha512-f9Fojnsvp9e/LneTxj4p5zPb5XAlh5UhizhgZHAo5oBQJgpeTVaPDRBm9jEvBNG1k/kRi1wpkiwiU6Jxrmbw/A==
   dependencies:
     "@budibase/nano" "10.1.2"
     "@budibase/pouchdb-replication-stream" "1.2.10"
-    "@budibase/types" "^2.4.10"
+    "@budibase/types" "^2.4.11"
     "@shopify/jest-koa-mocks" "5.0.1"
     "@techpass/passport-openidconnect" "0.3.2"
     aws-cloudfront-sign "2.2.0"
@@ -1417,14 +1417,14 @@
     pouchdb-promise "^6.0.4"
     through2 "^2.0.0"
 
-"@budibase/pro@2.4.10":
-  version "2.4.10"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.4.10.tgz#5d4da85bc802540d9d92a4321471a7b65f2031f5"
-  integrity sha512-wRKCyBbKo78ovScdhbpDc4Ras2VPgdukFSUvUv5YvjBHdU1xinu2qHxP5EJG/Q83UAzIoLilWYZqmKvEE1Zi3Q==
+"@budibase/pro@2.4.11":
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.4.11.tgz#6b554b68f4641d972b96f4677e6ede635a401f8a"
+  integrity sha512-RWzPSg+8S8nqJ/DCtgsRf/h+V8ARAjnCpllsYD/1pfzupLbsr2PE3DDBsNkFY8nUPxk00NMa7aZ0kK4/UiCpFg==
   dependencies:
-    "@budibase/backend-core" "2.4.10"
+    "@budibase/backend-core" "2.4.11"
     "@budibase/string-templates" "2.3.20"
-    "@budibase/types" "2.4.10"
+    "@budibase/types" "2.4.11"
     "@koa/router" "8.0.8"
     bull "4.10.1"
     joi "17.6.0"
@@ -1463,10 +1463,10 @@
     lodash "^4.17.20"
     vm2 "^3.9.4"
 
-"@budibase/types@2.4.10", "@budibase/types@^2.4.10":
-  version "2.4.10"
-  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.10.tgz#39d5eb77d3628707145b312fc365f9e10012d35b"
-  integrity sha512-rfMwYmeaCU6tgp/ZLRSURheRReKvWIyhq/T66sVr+sOVNSLc64mNmuuBG4VBAzrc6xKPufy9R0srYMFlicVc3g==
+"@budibase/types@2.4.11", "@budibase/types@^2.4.11":
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.11.tgz#6f4793403fbe02f122fb59b488b54255ceaf0104"
+  integrity sha512-16PQ7EHVZx+6HlFjr4+RaEjkCXWVNLpSaVH1GuYDko5i+LTQ3aPt3l9u31XoFRZwGDSCMJk97wVuSMrh1zg1Og==
 
 "@bull-board/api@3.7.0":
   version "3.7.0"

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -1278,14 +1278,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@2.4.9":
-  version "2.4.9"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-2.4.9.tgz#a5d6846d1c665e0f5c965bf9ac686d5cc74fb6ac"
-  integrity sha512-gp30brn+7TWpjTJniO3n2cXKBKJDJM/WkmUbTX5V+8ynONbU5qSHiHmdHdLWq/ypZaOcFbKxM3fZQsMiJ0CAMQ==
+"@budibase/backend-core@2.4.10":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-2.4.10.tgz#1736643ccb6e4d9c2fd22b1d6d0eea1fbe35199a"
+  integrity sha512-MdEwsoAPg1EoNjLfeX0QNUJrpZIsOx8kL92iui8L4Lfv009SV26ndQXe96f/1w/kEqMBvErQiSfl87AVjq3uPw==
   dependencies:
     "@budibase/nano" "10.1.2"
     "@budibase/pouchdb-replication-stream" "1.2.10"
-    "@budibase/types" "^2.4.9"
+    "@budibase/types" "^2.4.10"
     "@shopify/jest-koa-mocks" "5.0.1"
     "@techpass/passport-openidconnect" "0.3.2"
     aws-cloudfront-sign "2.2.0"
@@ -1417,14 +1417,14 @@
     pouchdb-promise "^6.0.4"
     through2 "^2.0.0"
 
-"@budibase/pro@2.4.9":
-  version "2.4.9"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.4.9.tgz#7e10725d574136691594dfb4e24724edc8b1bbe5"
-  integrity sha512-5cb5q+VPFCXCXL+Ao8gsrMSJmJ57w73q76dLa9+h9b9AjKAX2Ib0zaduJ3OvRJTqfYvH7bMAD9wpIWEyPc+aXA==
+"@budibase/pro@2.4.10":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.4.10.tgz#5d4da85bc802540d9d92a4321471a7b65f2031f5"
+  integrity sha512-wRKCyBbKo78ovScdhbpDc4Ras2VPgdukFSUvUv5YvjBHdU1xinu2qHxP5EJG/Q83UAzIoLilWYZqmKvEE1Zi3Q==
   dependencies:
-    "@budibase/backend-core" "2.4.9"
+    "@budibase/backend-core" "2.4.10"
     "@budibase/string-templates" "2.3.20"
-    "@budibase/types" "2.4.9"
+    "@budibase/types" "2.4.10"
     "@koa/router" "8.0.8"
     bull "4.10.1"
     joi "17.6.0"
@@ -1463,10 +1463,10 @@
     lodash "^4.17.20"
     vm2 "^3.9.4"
 
-"@budibase/types@2.4.9", "@budibase/types@^2.4.9":
-  version "2.4.9"
-  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.9.tgz#5660cfcbc9508cb3823070f0369fd876644da896"
-  integrity sha512-jBEBS3IryPJSX3yURGUFWV6iAcZk7Nmpz5eOsnJcILoGqXPQ897t/R/eT+k9vsE+lqGkaJtUOQIpOd3r4ZfLOQ==
+"@budibase/types@2.4.10", "@budibase/types@^2.4.10":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.10.tgz#39d5eb77d3628707145b312fc365f9e10012d35b"
+  integrity sha512-rfMwYmeaCU6tgp/ZLRSURheRReKvWIyhq/T66sVr+sOVNSLc64mNmuuBG4VBAzrc6xKPufy9R0srYMFlicVc3g==
 
 "@bull-board/api@3.7.0":
   version "3.7.0"

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -1278,14 +1278,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@2.4.6":
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-2.4.6.tgz#19717251ec11a391b18987aa732cf0ec2351f774"
-  integrity sha512-oTuW5B6GG6//vXohOAQ7Go2npv98VT8YuvOF0iQC4OeFGNpguu4azDG0I/6dCDNfR006HlR3lgO+0IvW3IXDTA==
+"@budibase/backend-core@2.4.8":
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-2.4.8.tgz#914d4c591a0f315c6d6efeac9b16e2725fa8b7c9"
+  integrity sha512-SikVhgj4MSWNtET5G9r2BUkazP+mQxoTB+2EoBVra/rst/PYK1QA8U0CkpqPz4dII4/Wf1r7JoSlyFNTknK9ag==
   dependencies:
     "@budibase/nano" "10.1.2"
     "@budibase/pouchdb-replication-stream" "1.2.10"
-    "@budibase/types" "^2.4.6"
+    "@budibase/types" "^2.4.8"
     "@shopify/jest-koa-mocks" "5.0.1"
     "@techpass/passport-openidconnect" "0.3.2"
     aws-cloudfront-sign "2.2.0"
@@ -1417,14 +1417,14 @@
     pouchdb-promise "^6.0.4"
     through2 "^2.0.0"
 
-"@budibase/pro@2.4.6":
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.4.6.tgz#2e8f4c186e99a7f846fd38b8bf519b46761675d8"
-  integrity sha512-fkGf5m7YGXp6QA4eDl15fflnojFj8zd+cvIHIya8ymmxvonUglxZPwa6eYzj/CDurg5tifE1s9vvqoLJ9NjrnA==
+"@budibase/pro@2.4.8":
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.4.8.tgz#57e3eacde4d68b4e4a6dc3ca8ad44ce63f99bd46"
+  integrity sha512-JaRdy6DTpECzOY1fir0qrtKn1cw7uYYvS40Dd+IgNULsVpTf1CekOEFggRJGlI+v2gwjN8yCyTeW+ZBfF7GNwQ==
   dependencies:
-    "@budibase/backend-core" "2.4.6"
+    "@budibase/backend-core" "2.4.8"
     "@budibase/string-templates" "2.3.20"
-    "@budibase/types" "2.4.6"
+    "@budibase/types" "2.4.8"
     "@koa/router" "8.0.8"
     bull "4.10.1"
     joi "17.6.0"
@@ -1463,10 +1463,10 @@
     lodash "^4.17.20"
     vm2 "^3.9.4"
 
-"@budibase/types@2.4.6", "@budibase/types@^2.4.6":
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.6.tgz#1c528c4d7ca0ed81447a292a2b5569eab55b7f6a"
-  integrity sha512-2Y1OnrSbqDTKmyyhaHMgrQaIrkj+eNk52AuNa8mMF5ToVEmKs5W6ZJcoMVM07GgMRTf1OZUjXspm9Y5XMDOHTQ==
+"@budibase/types@2.4.8", "@budibase/types@^2.4.8":
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.8.tgz#0020f6afb0627e295f14233ac287c68d23a7ca14"
+  integrity sha512-tn4jznyWBHNRGlwRUrln7U1Z0R19BSOgGhLXj1UtNOWT8k2xxNmXaP/JWynwrpLkZFuHIZfOV/YIaVL+SyxjFA==
 
 "@bull-board/api@3.7.0":
   version "3.7.0"

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -1278,14 +1278,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@2.4.8":
-  version "2.4.8"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-2.4.8.tgz#914d4c591a0f315c6d6efeac9b16e2725fa8b7c9"
-  integrity sha512-SikVhgj4MSWNtET5G9r2BUkazP+mQxoTB+2EoBVra/rst/PYK1QA8U0CkpqPz4dII4/Wf1r7JoSlyFNTknK9ag==
+"@budibase/backend-core@2.4.9":
+  version "2.4.9"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-2.4.9.tgz#a5d6846d1c665e0f5c965bf9ac686d5cc74fb6ac"
+  integrity sha512-gp30brn+7TWpjTJniO3n2cXKBKJDJM/WkmUbTX5V+8ynONbU5qSHiHmdHdLWq/ypZaOcFbKxM3fZQsMiJ0CAMQ==
   dependencies:
     "@budibase/nano" "10.1.2"
     "@budibase/pouchdb-replication-stream" "1.2.10"
-    "@budibase/types" "^2.4.8"
+    "@budibase/types" "^2.4.9"
     "@shopify/jest-koa-mocks" "5.0.1"
     "@techpass/passport-openidconnect" "0.3.2"
     aws-cloudfront-sign "2.2.0"
@@ -1417,14 +1417,14 @@
     pouchdb-promise "^6.0.4"
     through2 "^2.0.0"
 
-"@budibase/pro@2.4.8":
-  version "2.4.8"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.4.8.tgz#57e3eacde4d68b4e4a6dc3ca8ad44ce63f99bd46"
-  integrity sha512-JaRdy6DTpECzOY1fir0qrtKn1cw7uYYvS40Dd+IgNULsVpTf1CekOEFggRJGlI+v2gwjN8yCyTeW+ZBfF7GNwQ==
+"@budibase/pro@2.4.9":
+  version "2.4.9"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.4.9.tgz#7e10725d574136691594dfb4e24724edc8b1bbe5"
+  integrity sha512-5cb5q+VPFCXCXL+Ao8gsrMSJmJ57w73q76dLa9+h9b9AjKAX2Ib0zaduJ3OvRJTqfYvH7bMAD9wpIWEyPc+aXA==
   dependencies:
-    "@budibase/backend-core" "2.4.8"
+    "@budibase/backend-core" "2.4.9"
     "@budibase/string-templates" "2.3.20"
-    "@budibase/types" "2.4.8"
+    "@budibase/types" "2.4.9"
     "@koa/router" "8.0.8"
     bull "4.10.1"
     joi "17.6.0"
@@ -1463,10 +1463,10 @@
     lodash "^4.17.20"
     vm2 "^3.9.4"
 
-"@budibase/types@2.4.8", "@budibase/types@^2.4.8":
-  version "2.4.8"
-  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.8.tgz#0020f6afb0627e295f14233ac287c68d23a7ca14"
-  integrity sha512-tn4jznyWBHNRGlwRUrln7U1Z0R19BSOgGhLXj1UtNOWT8k2xxNmXaP/JWynwrpLkZFuHIZfOV/YIaVL+SyxjFA==
+"@budibase/types@2.4.9", "@budibase/types@^2.4.9":
+  version "2.4.9"
+  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.9.tgz#5660cfcbc9508cb3823070f0369fd876644da896"
+  integrity sha512-jBEBS3IryPJSX3yURGUFWV6iAcZk7Nmpz5eOsnJcILoGqXPQ897t/R/eT+k9vsE+lqGkaJtUOQIpOd3r4ZfLOQ==
 
 "@bull-board/api@3.7.0":
   version "3.7.0"

--- a/packages/string-templates/package.json
+++ b/packages/string-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/string-templates",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "Handlebars wrapper for Budibase templating.",
   "main": "src/index.cjs",
   "module": "dist/bundle.mjs",

--- a/packages/string-templates/package.json
+++ b/packages/string-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/string-templates",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Handlebars wrapper for Budibase templating.",
   "main": "src/index.cjs",
   "module": "dist/bundle.mjs",

--- a/packages/string-templates/package.json
+++ b/packages/string-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/string-templates",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "description": "Handlebars wrapper for Budibase templating.",
   "main": "src/index.cjs",
   "module": "dist/bundle.mjs",

--- a/packages/string-templates/package.json
+++ b/packages/string-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/string-templates",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Handlebars wrapper for Budibase templating.",
   "main": "src/index.cjs",
   "module": "dist/bundle.mjs",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/types",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Budibase types",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/types",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "Budibase types",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/types",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "description": "Budibase types",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@budibase/types",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Budibase types",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/worker",
   "email": "hi@budibase.com",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "description": "Budibase background service",
   "main": "src/index.ts",
   "repository": {
@@ -36,10 +36,10 @@
   "author": "Budibase",
   "license": "GPL-3.0",
   "dependencies": {
-    "@budibase/backend-core": "^2.4.9",
+    "@budibase/backend-core": "^2.4.10",
     "@budibase/pro": "2.4.9",
-    "@budibase/string-templates": "^2.4.9",
-    "@budibase/types": "^2.4.9",
+    "@budibase/string-templates": "^2.4.10",
+    "@budibase/types": "^2.4.10",
     "@koa/router": "8.0.8",
     "@sentry/node": "6.17.7",
     "@techpass/passport-openidconnect": "0.3.2",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -37,7 +37,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@budibase/backend-core": "^2.4.9",
-    "@budibase/pro": "2.4.8",
+    "@budibase/pro": "2.4.9",
     "@budibase/string-templates": "^2.4.9",
     "@budibase/types": "^2.4.9",
     "@koa/router": "8.0.8",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -37,7 +37,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@budibase/backend-core": "^2.4.10",
-    "@budibase/pro": "2.4.9",
+    "@budibase/pro": "2.4.10",
     "@budibase/string-templates": "^2.4.10",
     "@budibase/types": "^2.4.10",
     "@koa/router": "8.0.8",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/worker",
   "email": "hi@budibase.com",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "Budibase background service",
   "main": "src/index.ts",
   "repository": {
@@ -36,10 +36,10 @@
   "author": "Budibase",
   "license": "GPL-3.0",
   "dependencies": {
-    "@budibase/backend-core": "^2.4.7",
+    "@budibase/backend-core": "^2.4.8",
     "@budibase/pro": "2.4.6",
-    "@budibase/string-templates": "^2.4.7",
-    "@budibase/types": "^2.4.7",
+    "@budibase/string-templates": "^2.4.8",
+    "@budibase/types": "^2.4.8",
     "@koa/router": "8.0.8",
     "@sentry/node": "6.17.7",
     "@techpass/passport-openidconnect": "0.3.2",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -37,7 +37,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@budibase/backend-core": "^2.4.11",
-    "@budibase/pro": "2.4.10",
+    "@budibase/pro": "2.4.11",
     "@budibase/string-templates": "^2.4.11",
     "@budibase/types": "^2.4.11",
     "@koa/router": "8.0.8",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -37,7 +37,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@budibase/backend-core": "^2.4.8",
-    "@budibase/pro": "2.4.6",
+    "@budibase/pro": "2.4.8",
     "@budibase/string-templates": "^2.4.8",
     "@budibase/types": "^2.4.8",
     "@koa/router": "8.0.8",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/worker",
   "email": "hi@budibase.com",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Budibase background service",
   "main": "src/index.ts",
   "repository": {
@@ -36,10 +36,10 @@
   "author": "Budibase",
   "license": "GPL-3.0",
   "dependencies": {
-    "@budibase/backend-core": "^2.4.10",
+    "@budibase/backend-core": "^2.4.11",
     "@budibase/pro": "2.4.10",
-    "@budibase/string-templates": "^2.4.10",
-    "@budibase/types": "^2.4.10",
+    "@budibase/string-templates": "^2.4.11",
+    "@budibase/types": "^2.4.11",
     "@koa/router": "8.0.8",
     "@sentry/node": "6.17.7",
     "@techpass/passport-openidconnect": "0.3.2",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@budibase/worker",
   "email": "hi@budibase.com",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Budibase background service",
   "main": "src/index.ts",
   "repository": {
@@ -36,10 +36,10 @@
   "author": "Budibase",
   "license": "GPL-3.0",
   "dependencies": {
-    "@budibase/backend-core": "^2.4.8",
+    "@budibase/backend-core": "^2.4.9",
     "@budibase/pro": "2.4.8",
-    "@budibase/string-templates": "^2.4.8",
-    "@budibase/types": "^2.4.8",
+    "@budibase/string-templates": "^2.4.9",
+    "@budibase/types": "^2.4.9",
     "@koa/router": "8.0.8",
     "@sentry/node": "6.17.7",
     "@techpass/passport-openidconnect": "0.3.2",

--- a/packages/worker/yarn.lock
+++ b/packages/worker/yarn.lock
@@ -475,14 +475,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@2.4.6":
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-2.4.6.tgz#19717251ec11a391b18987aa732cf0ec2351f774"
-  integrity sha512-oTuW5B6GG6//vXohOAQ7Go2npv98VT8YuvOF0iQC4OeFGNpguu4azDG0I/6dCDNfR006HlR3lgO+0IvW3IXDTA==
+"@budibase/backend-core@2.4.8":
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-2.4.8.tgz#914d4c591a0f315c6d6efeac9b16e2725fa8b7c9"
+  integrity sha512-SikVhgj4MSWNtET5G9r2BUkazP+mQxoTB+2EoBVra/rst/PYK1QA8U0CkpqPz4dII4/Wf1r7JoSlyFNTknK9ag==
   dependencies:
     "@budibase/nano" "10.1.2"
     "@budibase/pouchdb-replication-stream" "1.2.10"
-    "@budibase/types" "^2.4.6"
+    "@budibase/types" "^2.4.8"
     "@shopify/jest-koa-mocks" "5.0.1"
     "@techpass/passport-openidconnect" "0.3.2"
     aws-cloudfront-sign "2.2.0"
@@ -564,14 +564,14 @@
     pouchdb-promise "^6.0.4"
     through2 "^2.0.0"
 
-"@budibase/pro@2.4.6":
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.4.6.tgz#2e8f4c186e99a7f846fd38b8bf519b46761675d8"
-  integrity sha512-fkGf5m7YGXp6QA4eDl15fflnojFj8zd+cvIHIya8ymmxvonUglxZPwa6eYzj/CDurg5tifE1s9vvqoLJ9NjrnA==
+"@budibase/pro@2.4.8":
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.4.8.tgz#57e3eacde4d68b4e4a6dc3ca8ad44ce63f99bd46"
+  integrity sha512-JaRdy6DTpECzOY1fir0qrtKn1cw7uYYvS40Dd+IgNULsVpTf1CekOEFggRJGlI+v2gwjN8yCyTeW+ZBfF7GNwQ==
   dependencies:
-    "@budibase/backend-core" "2.4.6"
+    "@budibase/backend-core" "2.4.8"
     "@budibase/string-templates" "2.3.20"
-    "@budibase/types" "2.4.6"
+    "@budibase/types" "2.4.8"
     "@koa/router" "8.0.8"
     bull "4.10.1"
     joi "17.6.0"
@@ -592,10 +592,10 @@
     lodash "^4.17.20"
     vm2 "^3.9.4"
 
-"@budibase/types@2.4.6", "@budibase/types@^2.4.6":
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.6.tgz#1c528c4d7ca0ed81447a292a2b5569eab55b7f6a"
-  integrity sha512-2Y1OnrSbqDTKmyyhaHMgrQaIrkj+eNk52AuNa8mMF5ToVEmKs5W6ZJcoMVM07GgMRTf1OZUjXspm9Y5XMDOHTQ==
+"@budibase/types@2.4.8", "@budibase/types@^2.4.8":
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.8.tgz#0020f6afb0627e295f14233ac287c68d23a7ca14"
+  integrity sha512-tn4jznyWBHNRGlwRUrln7U1Z0R19BSOgGhLXj1UtNOWT8k2xxNmXaP/JWynwrpLkZFuHIZfOV/YIaVL+SyxjFA==
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"

--- a/packages/worker/yarn.lock
+++ b/packages/worker/yarn.lock
@@ -475,14 +475,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@2.4.9":
-  version "2.4.9"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-2.4.9.tgz#a5d6846d1c665e0f5c965bf9ac686d5cc74fb6ac"
-  integrity sha512-gp30brn+7TWpjTJniO3n2cXKBKJDJM/WkmUbTX5V+8ynONbU5qSHiHmdHdLWq/ypZaOcFbKxM3fZQsMiJ0CAMQ==
+"@budibase/backend-core@2.4.10":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-2.4.10.tgz#1736643ccb6e4d9c2fd22b1d6d0eea1fbe35199a"
+  integrity sha512-MdEwsoAPg1EoNjLfeX0QNUJrpZIsOx8kL92iui8L4Lfv009SV26ndQXe96f/1w/kEqMBvErQiSfl87AVjq3uPw==
   dependencies:
     "@budibase/nano" "10.1.2"
     "@budibase/pouchdb-replication-stream" "1.2.10"
-    "@budibase/types" "^2.4.9"
+    "@budibase/types" "^2.4.10"
     "@shopify/jest-koa-mocks" "5.0.1"
     "@techpass/passport-openidconnect" "0.3.2"
     aws-cloudfront-sign "2.2.0"
@@ -564,14 +564,14 @@
     pouchdb-promise "^6.0.4"
     through2 "^2.0.0"
 
-"@budibase/pro@2.4.9":
-  version "2.4.9"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.4.9.tgz#7e10725d574136691594dfb4e24724edc8b1bbe5"
-  integrity sha512-5cb5q+VPFCXCXL+Ao8gsrMSJmJ57w73q76dLa9+h9b9AjKAX2Ib0zaduJ3OvRJTqfYvH7bMAD9wpIWEyPc+aXA==
+"@budibase/pro@2.4.10":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.4.10.tgz#5d4da85bc802540d9d92a4321471a7b65f2031f5"
+  integrity sha512-wRKCyBbKo78ovScdhbpDc4Ras2VPgdukFSUvUv5YvjBHdU1xinu2qHxP5EJG/Q83UAzIoLilWYZqmKvEE1Zi3Q==
   dependencies:
-    "@budibase/backend-core" "2.4.9"
+    "@budibase/backend-core" "2.4.10"
     "@budibase/string-templates" "2.3.20"
-    "@budibase/types" "2.4.9"
+    "@budibase/types" "2.4.10"
     "@koa/router" "8.0.8"
     bull "4.10.1"
     joi "17.6.0"
@@ -592,10 +592,10 @@
     lodash "^4.17.20"
     vm2 "^3.9.4"
 
-"@budibase/types@2.4.9", "@budibase/types@^2.4.9":
-  version "2.4.9"
-  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.9.tgz#5660cfcbc9508cb3823070f0369fd876644da896"
-  integrity sha512-jBEBS3IryPJSX3yURGUFWV6iAcZk7Nmpz5eOsnJcILoGqXPQ897t/R/eT+k9vsE+lqGkaJtUOQIpOd3r4ZfLOQ==
+"@budibase/types@2.4.10", "@budibase/types@^2.4.10":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.10.tgz#39d5eb77d3628707145b312fc365f9e10012d35b"
+  integrity sha512-rfMwYmeaCU6tgp/ZLRSURheRReKvWIyhq/T66sVr+sOVNSLc64mNmuuBG4VBAzrc6xKPufy9R0srYMFlicVc3g==
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"

--- a/packages/worker/yarn.lock
+++ b/packages/worker/yarn.lock
@@ -475,14 +475,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@2.4.10":
-  version "2.4.10"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-2.4.10.tgz#1736643ccb6e4d9c2fd22b1d6d0eea1fbe35199a"
-  integrity sha512-MdEwsoAPg1EoNjLfeX0QNUJrpZIsOx8kL92iui8L4Lfv009SV26ndQXe96f/1w/kEqMBvErQiSfl87AVjq3uPw==
+"@budibase/backend-core@2.4.11":
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-2.4.11.tgz#df8a5667ffd8d51157559c4883e6e11aa21d18a4"
+  integrity sha512-f9Fojnsvp9e/LneTxj4p5zPb5XAlh5UhizhgZHAo5oBQJgpeTVaPDRBm9jEvBNG1k/kRi1wpkiwiU6Jxrmbw/A==
   dependencies:
     "@budibase/nano" "10.1.2"
     "@budibase/pouchdb-replication-stream" "1.2.10"
-    "@budibase/types" "^2.4.10"
+    "@budibase/types" "^2.4.11"
     "@shopify/jest-koa-mocks" "5.0.1"
     "@techpass/passport-openidconnect" "0.3.2"
     aws-cloudfront-sign "2.2.0"
@@ -564,14 +564,14 @@
     pouchdb-promise "^6.0.4"
     through2 "^2.0.0"
 
-"@budibase/pro@2.4.10":
-  version "2.4.10"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.4.10.tgz#5d4da85bc802540d9d92a4321471a7b65f2031f5"
-  integrity sha512-wRKCyBbKo78ovScdhbpDc4Ras2VPgdukFSUvUv5YvjBHdU1xinu2qHxP5EJG/Q83UAzIoLilWYZqmKvEE1Zi3Q==
+"@budibase/pro@2.4.11":
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.4.11.tgz#6b554b68f4641d972b96f4677e6ede635a401f8a"
+  integrity sha512-RWzPSg+8S8nqJ/DCtgsRf/h+V8ARAjnCpllsYD/1pfzupLbsr2PE3DDBsNkFY8nUPxk00NMa7aZ0kK4/UiCpFg==
   dependencies:
-    "@budibase/backend-core" "2.4.10"
+    "@budibase/backend-core" "2.4.11"
     "@budibase/string-templates" "2.3.20"
-    "@budibase/types" "2.4.10"
+    "@budibase/types" "2.4.11"
     "@koa/router" "8.0.8"
     bull "4.10.1"
     joi "17.6.0"
@@ -592,10 +592,10 @@
     lodash "^4.17.20"
     vm2 "^3.9.4"
 
-"@budibase/types@2.4.10", "@budibase/types@^2.4.10":
-  version "2.4.10"
-  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.10.tgz#39d5eb77d3628707145b312fc365f9e10012d35b"
-  integrity sha512-rfMwYmeaCU6tgp/ZLRSURheRReKvWIyhq/T66sVr+sOVNSLc64mNmuuBG4VBAzrc6xKPufy9R0srYMFlicVc3g==
+"@budibase/types@2.4.11", "@budibase/types@^2.4.11":
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.11.tgz#6f4793403fbe02f122fb59b488b54255ceaf0104"
+  integrity sha512-16PQ7EHVZx+6HlFjr4+RaEjkCXWVNLpSaVH1GuYDko5i+LTQ3aPt3l9u31XoFRZwGDSCMJk97wVuSMrh1zg1Og==
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"

--- a/packages/worker/yarn.lock
+++ b/packages/worker/yarn.lock
@@ -475,14 +475,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/backend-core@2.4.8":
-  version "2.4.8"
-  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-2.4.8.tgz#914d4c591a0f315c6d6efeac9b16e2725fa8b7c9"
-  integrity sha512-SikVhgj4MSWNtET5G9r2BUkazP+mQxoTB+2EoBVra/rst/PYK1QA8U0CkpqPz4dII4/Wf1r7JoSlyFNTknK9ag==
+"@budibase/backend-core@2.4.9":
+  version "2.4.9"
+  resolved "https://registry.yarnpkg.com/@budibase/backend-core/-/backend-core-2.4.9.tgz#a5d6846d1c665e0f5c965bf9ac686d5cc74fb6ac"
+  integrity sha512-gp30brn+7TWpjTJniO3n2cXKBKJDJM/WkmUbTX5V+8ynONbU5qSHiHmdHdLWq/ypZaOcFbKxM3fZQsMiJ0CAMQ==
   dependencies:
     "@budibase/nano" "10.1.2"
     "@budibase/pouchdb-replication-stream" "1.2.10"
-    "@budibase/types" "^2.4.8"
+    "@budibase/types" "^2.4.9"
     "@shopify/jest-koa-mocks" "5.0.1"
     "@techpass/passport-openidconnect" "0.3.2"
     aws-cloudfront-sign "2.2.0"
@@ -564,14 +564,14 @@
     pouchdb-promise "^6.0.4"
     through2 "^2.0.0"
 
-"@budibase/pro@2.4.8":
-  version "2.4.8"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.4.8.tgz#57e3eacde4d68b4e4a6dc3ca8ad44ce63f99bd46"
-  integrity sha512-JaRdy6DTpECzOY1fir0qrtKn1cw7uYYvS40Dd+IgNULsVpTf1CekOEFggRJGlI+v2gwjN8yCyTeW+ZBfF7GNwQ==
+"@budibase/pro@2.4.9":
+  version "2.4.9"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.4.9.tgz#7e10725d574136691594dfb4e24724edc8b1bbe5"
+  integrity sha512-5cb5q+VPFCXCXL+Ao8gsrMSJmJ57w73q76dLa9+h9b9AjKAX2Ib0zaduJ3OvRJTqfYvH7bMAD9wpIWEyPc+aXA==
   dependencies:
-    "@budibase/backend-core" "2.4.8"
+    "@budibase/backend-core" "2.4.9"
     "@budibase/string-templates" "2.3.20"
-    "@budibase/types" "2.4.8"
+    "@budibase/types" "2.4.9"
     "@koa/router" "8.0.8"
     bull "4.10.1"
     joi "17.6.0"
@@ -592,10 +592,10 @@
     lodash "^4.17.20"
     vm2 "^3.9.4"
 
-"@budibase/types@2.4.8", "@budibase/types@^2.4.8":
-  version "2.4.8"
-  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.8.tgz#0020f6afb0627e295f14233ac287c68d23a7ca14"
-  integrity sha512-tn4jznyWBHNRGlwRUrln7U1Z0R19BSOgGhLXj1UtNOWT8k2xxNmXaP/JWynwrpLkZFuHIZfOV/YIaVL+SyxjFA==
+"@budibase/types@2.4.9", "@budibase/types@^2.4.9":
+  version "2.4.9"
+  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.9.tgz#5660cfcbc9508cb3823070f0369fd876644da896"
+  integrity sha512-jBEBS3IryPJSX3yURGUFWV6iAcZk7Nmpz5eOsnJcILoGqXPQ897t/R/eT+k9vsE+lqGkaJtUOQIpOd3r4ZfLOQ==
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"


### PR DESCRIPTION
## Description
Raised on Linear: https://linear.app/budibase/issue/BUDI-6720/bug-filters-match-any-filter-doesnt-work-as-expected

This was a weird issue - specifically the `NOT` keyword has weird interactions with `OR` syntax - the fix is relatively minor, essentially combining the different does not contain operations where possible, then utilising de-morgans law to invert the condition, e.g. rather than `NOT contains(...) OR NOT contains(....)` do `NOT (contains(...) AND contains(...))`. The issue is that the `NOT` operator only removes entries from your results, it does not perform a search, whereas performing the actual contains searches, then filtering those out of all the results for the table gives a better result.