### PR TITLE
Fix regression that prevented custom placeholders from working

### DIFF
--- a/packages/bbui/src/Form/Core/Select.svelte
+++ b/packages/bbui/src/Form/Core/Select.svelte
@@ -42,9 +42,13 @@
   }
 
   const getFieldText = (value, options, placeholder) => {
-    // Always use placeholder if no value
     if (value == null || value === "") {
-      return placeholder !== false ? "Choose an option" : ""
+      // Explicit false means use no placeholder and allow an empty fields
+      if (placeholder === false) {
+        return ""
+      }
+      // Otherwise we use the placeholder if possible
+      return placeholder || "Choose an option"
     }
 
     return getFieldAttribute(getOptionLabel, value, options)


### PR DESCRIPTION
## Description
Fixes a regression in the last release that stopped options placeholders from working.

Addresses: 
- https://github.com/Budibase/budibase/issues/9993

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



