### PR TITLE
Fix for onboarding initialisation.

### DIFF
--- a/packages/builder/src/components/portal/onboarding/TourPopover.svelte
+++ b/packages/builder/src/components/portal/onboarding/TourPopover.svelte
@@ -15,20 +15,12 @@
   $: tourKey = $store.tourKey
   $: tourStepKey = $store.tourStepKey
 
-  const initTour = targetKey => {
-    if (!targetKey) {
+  const updateTourStep = (targetStepKey, tourKey) => {
+    if (!tourKey) {
       return
     }
-    tourSteps = [...TOURS[targetKey]]
-    tourStepIdx = 0
-    tourStep = { ...tourSteps[tourStepIdx] }
-  }
-
-  $: initTour(tourKey)
-
-  const updateTourStep = targetStepKey => {
     if (!tourSteps?.length) {
-      return
+      tourSteps = [...TOURS[tourKey]]
     }
     tourStepIdx = getCurrentStepIdx(tourSteps, targetStepKey)
     lastStep = tourStepIdx + 1 == tourSteps.length
@@ -36,7 +28,7 @@
     tourStep.onLoad()
   }
 
-  $: updateTourStep(tourStepKey)
+  $: updateTourStep(tourStepKey, tourKey)
 
   const showPopover = (tourStep, tourNodes, popover) => {
     if (!tourStep) {

--- a/packages/builder/src/components/portal/onboarding/TourWrap.svelte
+++ b/packages/builder/src/components/portal/onboarding/TourWrap.svelte
@@ -8,18 +8,26 @@
 
   let currentTourStep
   let ready = false
+  let registered = false
   let handler
 
+  const registerTourNode = (tourKey, stepKey) => {
+    if (ready && !registered && tourKey) {
+      currentTourStep = TOURS[tourKey].find(step => step.id === stepKey)
+      if (!currentTourStep) {
+        console.log("Could not find tour step : ", stepKey)
+        return
+      }
+      const elem = document.querySelector(currentTourStep.query)
+      handler = tourHandler(elem, stepKey)
+      registered = true
+    }
+  }
+
+  $: tourKeyWatch = $store.tourKey
+  $: registerTourNode(tourKeyWatch, tourStepKey, ready)
+
   onMount(() => {
-    if (!$store.tourKey) return
-
-    currentTourStep = TOURS[$store.tourKey].find(
-      step => step.id === tourStepKey
-    )
-    if (!currentTourStep) return
-
-    const elem = document.querySelector(currentTourStep.query)
-    handler = tourHandler(elem, tourStepKey)
     ready = true
   })
   onDestroy(() => {

--- a/packages/builder/src/components/portal/onboarding/TourWrap.svelte
+++ b/packages/builder/src/components/portal/onboarding/TourWrap.svelte
@@ -15,7 +15,6 @@
     if (ready && !registered && tourKey) {
       currentTourStep = TOURS[tourKey].find(step => step.id === stepKey)
       if (!currentTourStep) {
-        console.log("Could not find tour step : ", stepKey)
         return
       }
       const elem = document.querySelector(currentTourStep.query)
@@ -30,6 +29,7 @@
   onMount(() => {
     ready = true
   })
+
   onDestroy(() => {
     if (handler) {
       handler.destroy()


### PR DESCRIPTION
## Description

Recent changes to the builder loading flow meant that tour nodes were attempting to register before the tour configuration had been built and set.

The tour system has been updated to be responsive to changes in the builder tour state. Tour nodes will now wait until they have been rendered on screen, a builder tour key has been set and the current tour step is selected. 

Addresses: 
- https://github.com/Budibase/budibase/issues/10001

