### PR TITLE
Fix preprod stale deploy

### DIFF
--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -17,6 +17,7 @@ jobs:
         id: version
         run: |
           if [ -z "${{ github.event.inputs.version }}" ]; then
+            git pull
             release_version=$(cat lerna.json | jq -r '.version')
           else
             release_version=${{ github.event.inputs.version }}

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Get the latest budibase release version
         id: version
         run: |
+          git pull
           release_version=$(cat lerna.json | jq -r '.version')
           echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
 


### PR DESCRIPTION
## Description
Fixing an issue where the release pipeline is triggering preprod deploy for the previous verison. This is due to `actions/checkout` performing the checkout on the SHA the job was triggered with, hence not pulling the updated version first. 


