### PR TITLE
BUDI-6683 - Accept application/SCIM+json

### DIFF
--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -56,7 +56,7 @@ app.keys = ["secret", "key"]
 
 // set up top level koa middleware
 app.use(handleScimBody)
-app.use(koaBody({ multipart: true, jsonStrict: false }))
+app.use(koaBody({ multipart: true }))
 
 app.use(koaSession(app))
 app.use(middleware.logging)

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -35,6 +35,7 @@ const { userAgent } = require("koa-useragent")
 
 import destroyable from "server-destroy"
 import { initPro } from "./initPro"
+import { handleScimBody } from "./middleware/handleScimBody"
 
 // configure events to use the pro audit log write
 // can't integrate directly into backend-core due to cyclic issues
@@ -54,7 +55,9 @@ const app: Application = new Koa()
 app.keys = ["secret", "key"]
 
 // set up top level koa middleware
-app.use(koaBody({ multipart: true }))
+app.use(handleScimBody)
+app.use(koaBody({ multipart: true, jsonStrict: false }))
+
 app.use(koaSession(app))
 app.use(middleware.logging)
 app.use(logger(logging.pinoSettings()))

--- a/packages/worker/src/middleware/handleScimBody.ts
+++ b/packages/worker/src/middleware/handleScimBody.ts
@@ -8,5 +8,5 @@ export const handleScimBody = (ctx: Ctx, next: any) => {
     ctx.req.headers["content-type"] = "application/json"
   }
 
-  next()
+  return next()
 }

--- a/packages/worker/src/middleware/handleScimBody.ts
+++ b/packages/worker/src/middleware/handleScimBody.ts
@@ -1,0 +1,12 @@
+import { Ctx } from "@budibase/types"
+
+export const handleScimBody = (ctx: Ctx, next: any) => {
+  var type = ctx.req.headers["content-type"] || ""
+  type = type.split(";")[0]
+
+  if (type === "application/scim+json") {
+    ctx.req.headers["content-type"] = "application/json"
+  }
+
+  next()
+}

--- a/packages/worker/src/tests/api/scim/users.ts
+++ b/packages/worker/src/tests/api/scim/users.ts
@@ -28,6 +28,11 @@ export class ScimUsersAPI extends TestAPI {
     const { expect, setHeaders } = { ...defaultConfig, ...requestSettings }
     let request = this.request[method](url).expect(expect)
 
+    request = request.set(
+      "content-type",
+      "application/scim+json; charset=utf-8"
+    )
+
     if (method !== "delete") {
       request = request.expect("Content-Type", /json/)
     }


### PR DESCRIPTION
## Description
Override content type for `application/scim+json` requests. `koa-body`, which we use, does not support it. We could create a PR to that library (as it seems a one-liner in there), but meanwhile this workaround works as expected