### PR TITLE
Fix component settings which have no labels appearing as undefined in conditional UI

### DIFF
--- a/packages/builder/src/builderStore/componentUtils.js
+++ b/packages/builder/src/builderStore/componentUtils.js
@@ -163,7 +163,12 @@ export const getComponentSettings = componentType => {
     def.settings
       ?.filter(setting => setting.section)
       .forEach(section => {
-        settings = settings.concat(section.settings || [])
+        settings = settings.concat(
+          (section.settings || []).map(setting => ({
+            ...setting,
+            section: section.name,
+          }))
+        )
       })
   }
   componentSettingCache[componentType] = settings

--- a/packages/builder/src/components/design/settings/controls/PropertyControl.svelte
+++ b/packages/builder/src/components/design/settings/controls/PropertyControl.svelte
@@ -8,6 +8,7 @@
   import { onDestroy } from "svelte"
 
   export let label = ""
+  export let labelHidden = false
   export let componentInstance = {}
   export let control = null
   export let key = ""
@@ -75,7 +76,7 @@
 </script>
 
 <div class="property-control" class:highlighted={highlighted && nullishValue}>
-  {#if type !== "boolean" && label}
+  {#if type !== "boolean" && label && !labelHidden}
     <div class="label">
       <Label>{label}</Label>
     </div>

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ComponentSettingsSection.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ComponentSettingsSection.svelte
@@ -132,6 +132,7 @@
             type={setting.type}
             control={getComponentForSetting(setting)}
             label={setting.label}
+            labelHidden={setting.labelHidden}
             key={setting.key}
             value={componentInstance[setting.key]}
             defaultValue={setting.defaultValue}

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ConditionalUIDrawer.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ConditionalUIDrawer.svelte
@@ -62,7 +62,7 @@
     type: "text",
   })
   $: settingOptions = settings.map(setting => ({
-    label: setting.label,
+    label: makeLabel(setting),
     value: setting.key,
   }))
   $: conditions.forEach(link => {
@@ -70,6 +70,18 @@
       link.id = generate()
     }
   })
+
+  const makeLabel = setting => {
+    if (setting.section) {
+      let label = setting.section
+      if (setting.label) {
+        return `${label} - ${setting.label}`
+      }
+      return label
+    } else {
+      return setting.label
+    }
+  }
 
   const getSettingDefinition = key => {
     return settings.find(setting => setting.key === key)

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ConditionalUIDrawer.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/_components/settings/ConditionalUIDrawer.svelte
@@ -72,14 +72,11 @@
   })
 
   const makeLabel = setting => {
-    if (setting.section) {
-      let label = setting.section
-      if (setting.label) {
-        return `${label} - ${setting.label}`
-      }
-      return label
+    const { section, label } = setting
+    if (section) {
+      return label ? `${section} - ${label}` : section
     } else {
-      return setting.label
+      return label
     }
   }
 

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -4380,6 +4380,8 @@
         "name": "On row click",
         "settings": [
           {
+            "label": "Behaviour",
+            "labelHidden": true,
             "type": "radio",
             "key": "clickBehaviour",
             "sendEvents": true,
@@ -4397,6 +4399,8 @@
             ]
           },
           {
+            "label": "Actions",
+            "labelHidden": true,
             "type": "event",
             "key": "onClick",
             "nested": true,
@@ -4433,7 +4437,7 @@
           {
             "type": "radio",
             "key": "titleButtonClickBehaviour",
-            "label": "On Click",
+            "label": "Behaviour",
             "dependsOn": "showTitleButton",
             "defaultValue": "actions",
             "info": "New row side panel is only compatible with internal or SQL tables",
@@ -4450,6 +4454,8 @@
           },
           {
             "type": "event",
+            "label": "On click",
+            "labelHidden": true,
             "key": "onClickTitleButton",
             "nested": true,
             "dependsOn": {


### PR DESCRIPTION
## Description
Fixes an issue where certain settings were appearing as `undefined` in the conditional UI drawer. The cause for this was that certain settings lack a `label` entry, as they are nested inside their own settings section.

In the conditional UI drawer, settings will now appear showing the section they're nested within, as well as their label. This helps properly identify settings which may have identical labels, but be inside different settings sections. For example:

![image](https://user-images.githubusercontent.com/9075550/225559568-1163275c-4c61-4420-82ea-cbac83743291.png)



Addresses: 
- https://github.com/Budibase/budibase/issues/10045

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



