### PR TITLE
Configuration for Google Auth and OIDC Redirect URLs #9892

### DIFF
--- a/packages/worker/src/api/controllers/global/auth.ts
+++ b/packages/worker/src/api/controllers/global/auth.ts
@@ -285,4 +285,3 @@ export const oidcCallback = async (ctx: any, next: any) => {
     }
   )(ctx, next)
 }
-

--- a/packages/worker/src/api/controllers/global/auth.ts
+++ b/packages/worker/src/api/controllers/global/auth.ts
@@ -204,13 +204,16 @@ export const googleCallback = async (ctx: any, next: any) => {
 
   return passport.authenticate(
     strategy,
-    { successRedirect: "/", failureRedirect: "/error" },
+    {
+      successRedirect: env.PASSPORT_GOOGLEAUTH_SUCCESS_REDIRECT,
+      failureRedirect: env.PASSPORT_GOOGLEAUTH_FAILURE_REDIRECT,
+    },
     async (err: any, user: SSOUser, info: any) => {
       await passportCallback(ctx, user, err, info)
       await context.identity.doInUserContext(user, ctx, async () => {
         await events.auth.login("google-internal", user.email)
       })
-      ctx.redirect("/")
+      ctx.redirect(env.PASSPORT_GOOGLEAUTH_SUCCESS_REDIRECT)
     }
   )(ctx, next)
 }
@@ -269,13 +272,17 @@ export const oidcCallback = async (ctx: any, next: any) => {
 
   return passport.authenticate(
     strategy,
-    { successRedirect: "/", failureRedirect: "/error" },
+    {
+      successRedirect: env.PASSPORT_OIDCAUTH_SUCCESS_REDIRECT,
+      failureRedirect: env.PASSPORT_OIDCAUTH_FAILURE_REDIRECT,
+    },
     async (err: any, user: SSOUser, info: any) => {
       await passportCallback(ctx, user, err, info)
       await context.identity.doInUserContext(user, ctx, async () => {
         await events.auth.login("oidc", user.email)
       })
-      ctx.redirect("/")
+      ctx.redirect(env.PASSPORT_OIDCAUTH_SUCCESS_REDIRECT)
     }
   )(ctx, next)
 }
+

--- a/packages/worker/src/environment.ts
+++ b/packages/worker/src/environment.ts
@@ -109,4 +109,3 @@ for (let [key, value] of Object.entries(environment)) {
 }
 
 export default environment
-

--- a/packages/worker/src/environment.ts
+++ b/packages/worker/src/environment.ts
@@ -66,6 +66,15 @@ const environment = {
    * Mock the email service in use - links to ethereal hosted emails are logged instead.
    */
   ENABLE_EMAIL_TEST_MODE: process.env.ENABLE_EMAIL_TEST_MODE,
+  PASSPORT_GOOGLEAUTH_SUCCESS_REDIRECT:
+    process.env.PASSPORT_GOOGLEAUTH_SUCCESS_REDIRECT || "/",
+  PASSPORT_GOOGLEAUTH_FAILURE_REDIRECT:
+    process.env.PASSPORT_GOOGLEAUTH_FAILURE_REDIRECT || "/error",
+  PASSPORT_OIDCAUTH_SUCCESS_REDIRECT:
+    process.env.PASSPORT_OIDCAUTH_SUCCESS_REDIRECT || "/",
+  PASSPORT_OIDCAUTH_FAILURE_REDIRECT:
+    process.env.PASSPORT_OIDCAUTH_FAILURE_REDIRECT || "/error",
+
   _set(key: any, value: any) {
     process.env[key] = value
     // @ts-ignore
@@ -100,3 +109,4 @@ for (let [key, value] of Object.entries(environment)) {
 }
 
 export default environment
+


### PR DESCRIPTION
## Description
Redirect URLs for google auth and OIDC are hardcoded in ./packages/worker/src/api/controllers/global/auth.ts. This forces to hosting env to use a dedicated hostname and not allow customization of "success" and "error" redirect locations. This PR includes changes that allow the configuration of "success" and "error" through environment variables without affecting existing behavior.

Addresses:

- `https://github.com/Budibase/budibase/issues/9344`

## Documentation
- [X] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



