### PR TITLE
Handle application/pdf content type in rest integration

### DIFF
--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -150,7 +150,10 @@ class RestIntegration implements IntegrationBase {
           data = data[keys[0]]
         }
         raw = rawXml
-      } else {
+      } else if (contentType.includes("application/pdf")) {
+        data = await response.arrayBuffer(); // Save PDF as ArrayBuffer
+        raw = Buffer.from(data); 
+      else {
         data = await response.text()
         raw = data
       }


### PR DESCRIPTION
## Description
The problem you have here is probably due to the way the code handles different content types. In the code, the content type of the API response is checked and the response is handled accordingly. There are special handlings for JSON and XML content types, while all other content types are treated as text.

In the case of a PDF file returned in raw PDF format, the content type should be application/pdf in most cases. Since the code has no special handling for this content type, it is treated as text, which results in incorrect processing of the binary code.

To fix this problem, you can add a condition to specifically handle application/pdf content type and save the binary code as a buffer. Modify the appropriate part of the code in the parseResponse method as follows.