### PR TITLE
BUDI-6684 - SCIM frontend configuration

### DIFF
--- a/packages/builder/src/pages/builder/portal/settings/auth/index.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/auth/index.svelte
@@ -31,6 +31,7 @@
   const ConfigTypes = {
     Google: "google",
     OIDC: "oidc",
+    SCIM: "scim",
   }
 
   const HasSpacesRegex = /[\\"\s]/
@@ -160,6 +161,8 @@
     providers.oidc?.config?.configs[0].clientSecret
   )
 
+  $: scimEnabled = true
+
   const onFileSelected = e => {
     let fileName = e.target.files[0].name
     image = e.target.files[0]
@@ -253,6 +256,19 @@
     originalGoogleDoc = cloneDeep(providers.google)
   }
 
+  async function saveSCIM() {
+    try {
+      const res = await saveConfig({
+        type: "scim",
+        enabled: scimEnabled,
+      })
+      notifications.success(`Settings saved`)
+    } catch (e) {
+      notifications.error(e.message)
+      return
+    }
+  }
+
   let defaultScopes = ["profile", "email", "offline_access"]
 
   const refreshScopes = idx => {
@@ -342,6 +358,14 @@
     } else {
       originalOidcDoc = cloneDeep(oidcDoc)
       providers.oidc = oidcDoc
+    }
+
+    try {
+      const scimConfig = await API.getConfig(ConfigTypes.SCIM)
+      scimEnabled = scimConfig?.enabled
+    } catch (error) {
+      console.error(error)
+      notifications.error("Error fetching SCIM config")
     }
   })
 </script>
@@ -606,10 +630,27 @@
         </Tags>
       </div>
     </Layout>
+
     <div>
       <Button disabled={oidcSaveButtonDisabled} cta on:click={() => saveOIDC()}>
         Save
       </Button>
+    </div>
+
+    <Divider />
+    <Layout gap="XS" noPadding>
+      <div class="provider-title">
+        <Heading size="S">SCIM</Heading>
+      </div>
+      <Body size="S">Sync users with your identity provider.</Body>
+      <div class="form-row">
+        <Label size="L">Activated</Label>
+        <Toggle text="" bind:value={scimEnabled} />
+      </div>
+    </Layout>
+
+    <div>
+      <Button cta on:click={saveSCIM}>Save</Button>
     </div>
   {/if}
 </Layout>

--- a/packages/builder/src/pages/builder/portal/settings/auth/index.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/auth/index.svelte
@@ -614,8 +614,10 @@
       </Button>
     </div>
   {/if}
-  <Divider />
-  <Scim />
+  {#if $licensing.scimEnabled}
+    <Divider />
+    <Scim />
+  {/if}
 </Layout>
 
 <style>

--- a/packages/builder/src/pages/builder/portal/settings/auth/index.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/auth/index.svelte
@@ -27,11 +27,11 @@
   import { onMount } from "svelte"
   import { API } from "api"
   import { organisation, admin, licensing } from "stores/portal"
+  import Scim from "./scim.svelte"
 
   const ConfigTypes = {
     Google: "google",
     OIDC: "oidc",
-    SCIM: "scim",
   }
 
   const HasSpacesRegex = /[\\"\s]/
@@ -161,8 +161,6 @@
     providers.oidc?.config?.configs[0].clientSecret
   )
 
-  $: scimEnabled = true
-
   const onFileSelected = e => {
     let fileName = e.target.files[0].name
     image = e.target.files[0]
@@ -256,19 +254,6 @@
     originalGoogleDoc = cloneDeep(providers.google)
   }
 
-  async function saveSCIM() {
-    try {
-      const res = await saveConfig({
-        type: "scim",
-        enabled: scimEnabled,
-      })
-      notifications.success(`Settings saved`)
-    } catch (e) {
-      notifications.error(e.message)
-      return
-    }
-  }
-
   let defaultScopes = ["profile", "email", "offline_access"]
 
   const refreshScopes = idx => {
@@ -358,14 +343,6 @@
     } else {
       originalOidcDoc = cloneDeep(oidcDoc)
       providers.oidc = oidcDoc
-    }
-
-    try {
-      const scimConfig = await API.getConfig(ConfigTypes.SCIM)
-      scimEnabled = scimConfig?.enabled
-    } catch (error) {
-      console.error(error)
-      notifications.error("Error fetching SCIM config")
     }
   })
 </script>
@@ -638,20 +615,7 @@
     </div>
 
     <Divider />
-    <Layout gap="XS" noPadding>
-      <div class="provider-title">
-        <Heading size="S">SCIM</Heading>
-      </div>
-      <Body size="S">Sync users with your identity provider.</Body>
-      <div class="form-row">
-        <Label size="L">Activated</Label>
-        <Toggle text="" bind:value={scimEnabled} />
-      </div>
-    </Layout>
-
-    <div>
-      <Button cta on:click={saveSCIM}>Save</Button>
-    </div>
+    <Scim />
   {/if}
 </Layout>
 

--- a/packages/builder/src/pages/builder/portal/settings/auth/index.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/auth/index.svelte
@@ -613,10 +613,9 @@
         Save
       </Button>
     </div>
-
-    <Divider />
-    <Scim />
   {/if}
+  <Divider />
+  <Scim />
 </Layout>
 
 <style>

--- a/packages/builder/src/pages/builder/portal/settings/auth/scim.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/auth/scim.svelte
@@ -13,6 +13,7 @@
   } from "@budibase/bbui"
   import { onMount } from "svelte"
   import { API } from "api"
+  import { organisation } from "stores/portal"
 
   const configType = "scim"
 
@@ -54,7 +55,10 @@
   }
 
   const settings = [
-    { title: "Provisioning URL", value: "url" },
+    {
+      title: "Provisioning URL",
+      value: `${$organisation.platformUrl}/api/global/scim/v2`,
+    },
     { title: "Provisioning Token", value: "token" },
   ]
 </script>

--- a/packages/builder/src/pages/builder/portal/settings/auth/scim.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/auth/scim.svelte
@@ -20,16 +20,9 @@
   $: scimEnabled = false
   $: apiKey = null
 
-  async function saveConfig(config) {
-    // Delete unsupported fields
-    delete config.createdAt
-    delete config.updatedAt
-    return API.saveConfig(config)
-  }
-
   async function saveSCIM() {
     try {
-      await saveConfig({
+      await API.saveConfig({
         type: configType,
         enabled: scimEnabled,
       })

--- a/packages/builder/src/pages/builder/portal/settings/auth/scim.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/auth/scim.svelte
@@ -13,11 +13,12 @@
   } from "@budibase/bbui"
   import { onMount } from "svelte"
   import { API } from "api"
-  import { organisation } from "stores/portal"
+  import { organisation, auth } from "stores/portal"
 
   const configType = "scim"
 
   $: scimEnabled = true
+  $: apiKey = null
 
   async function saveConfig(config) {
     // Delete unsupported fields
@@ -39,7 +40,7 @@
     }
   }
 
-  onMount(async () => {
+  async function fetchConfig() {
     try {
       const scimConfig = await API.getConfig(configType)
       scimEnabled = scimConfig?.enabled
@@ -47,6 +48,18 @@
       console.error(error)
       notifications.error("Error fetching SCIM config")
     }
+  }
+
+  async function fetchAPIKey() {
+    try {
+      apiKey = await auth.fetchAPIKey()
+    } catch (err) {
+      notifications.error("Unable to fetch API key")
+    }
+  }
+
+  onMount(async () => {
+    await Promise.all(fetchConfig(), fetchAPIKey())
   })
 
   const copyToClipboard = async value => {
@@ -54,12 +67,12 @@
     notifications.success("Copied")
   }
 
-  const settings = [
+  $: settings = [
     {
       title: "Provisioning URL",
       value: `${$organisation.platformUrl}/api/global/scim/v2`,
     },
-    { title: "Provisioning Token", value: "token" },
+    { title: "Provisioning Token", value: apiKey },
   ]
 </script>
 

--- a/packages/builder/src/pages/builder/portal/settings/auth/scim.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/auth/scim.svelte
@@ -17,7 +17,7 @@
 
   const configType = "scim"
 
-  $: scimEnabled = true
+  $: scimEnabled = false
   $: apiKey = null
 
   async function saveConfig(config) {

--- a/packages/builder/src/pages/builder/portal/settings/auth/scim.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/auth/scim.svelte
@@ -7,6 +7,9 @@
     Layout,
     Body,
     Toggle,
+    Input,
+    Icon,
+    Helpers,
   } from "@budibase/bbui"
   import { onMount } from "svelte"
   import { API } from "api"
@@ -44,6 +47,16 @@
       notifications.error("Error fetching SCIM config")
     }
   })
+
+  const copyToClipboard = async value => {
+    await Helpers.copyToClipboard(value)
+    notifications.success("Copied")
+  }
+
+  const settings = [
+    { title: "Provisioning URL", value: "url" },
+    { title: "Provisioning Token", value: "token" },
+  ]
 </script>
 
 <Layout gap="XS" noPadding>
@@ -55,8 +68,78 @@
     <Label size="L">Activated</Label>
     <Toggle text="" bind:value={scimEnabled} />
   </div>
+  {#if scimEnabled}
+    {#each settings as setting}
+      <div class="form-row">
+        <Label size="L" tooltip={""}>{setting.title}</Label>
+        <div class="inputContainer">
+          <div class="input">
+            <Input value={setting.value} readonly={true} />
+          </div>
+
+          <div class="copy" on:click={() => copyToClipboard(setting.value)}>
+            <Icon size="S" name="Copy" />
+          </div>
+        </div>
+      </div>
+    {/each}
+  {/if}
 </Layout>
 
 <div>
   <Button cta on:click={saveSCIM}>Save</Button>
 </div>
+
+<!-- TODO: DRY -->
+<style>
+  .form-row {
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    grid-gap: var(--spacing-l);
+    align-items: center;
+  }
+
+  input[type="file"] {
+    display: none;
+  }
+  .sso-link-icon {
+    padding-top: 4px;
+    margin-left: 3px;
+  }
+  .sso-link {
+    margin-top: 12px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+  .enforce-sso-title {
+    margin-right: 10px;
+  }
+  .enforce-sso-heading-container {
+    display: flex;
+    flex-direction: row;
+    align-items: start;
+  }
+  .provider-title {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--spacing-m);
+  }
+  .provider-title span {
+    flex: 1 1 auto;
+  }
+  .inputContainer {
+    display: flex;
+    flex-direction: row;
+  }
+  .input {
+    flex: 1;
+  }
+  .copy {
+    display: flex;
+    align-items: center;
+    margin-left: 10px;
+  }
+</style>

--- a/packages/builder/src/pages/builder/portal/settings/auth/scim.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/auth/scim.svelte
@@ -1,0 +1,62 @@
+<script>
+  import {
+    Button,
+    Heading,
+    Label,
+    notifications,
+    Layout,
+    Body,
+    Toggle,
+  } from "@budibase/bbui"
+  import { onMount } from "svelte"
+  import { API } from "api"
+
+  const configType = "scim"
+
+  $: scimEnabled = true
+
+  async function saveConfig(config) {
+    // Delete unsupported fields
+    delete config.createdAt
+    delete config.updatedAt
+    return API.saveConfig(config)
+  }
+
+  async function saveSCIM() {
+    try {
+      await saveConfig({
+        type: configType,
+        enabled: scimEnabled,
+      })
+      notifications.success(`Settings saved`)
+    } catch (e) {
+      notifications.error(e.message)
+      return
+    }
+  }
+
+  onMount(async () => {
+    try {
+      const scimConfig = await API.getConfig(configType)
+      scimEnabled = scimConfig?.enabled
+    } catch (error) {
+      console.error(error)
+      notifications.error("Error fetching SCIM config")
+    }
+  })
+</script>
+
+<Layout gap="XS" noPadding>
+  <div class="provider-title">
+    <Heading size="S">SCIM</Heading>
+  </div>
+  <Body size="S">Sync users with your identity provider.</Body>
+  <div class="form-row">
+    <Label size="L">Activated</Label>
+    <Toggle text="" bind:value={scimEnabled} />
+  </div>
+</Layout>
+
+<div>
+  <Button cta on:click={saveSCIM}>Save</Button>
+</div>

--- a/packages/types/src/documents/global/config.ts
+++ b/packages/types/src/documents/global/config.ts
@@ -108,4 +108,5 @@ export enum ConfigType {
   GOOGLE = "google",
   OIDC = "oidc",
   OIDC_LOGOS = "logos_oidc",
+  SCIM = "scim",
 }


### PR DESCRIPTION
## Description
Adding config to toggle on and off the SCIM config + displaying the settings

Remaining work (in further PRs):
1. Use the new `scim.enabled` config everywhere the current flag is used
2. DRY classes

Addresses: 
- https://linear.app/budibase/issue/BUDI-6684/scim-frontend-configuration

## App Export
- Not required

## Screenshots
### When feature flag is enabled
https://user-images.githubusercontent.com/15987277/227536030-8894704c-7a99-4656-a5d1-1e106215a941.mov


### When feature flag is disabled
<img width="731" alt="image" src="https://user-images.githubusercontent.com/15987277/226683662-58f54c42-38d7-4db4-b90b-3643e933ca76.png">




