### PR TITLE
allow arrow key navigation in the components panel

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/new/_components/NewComponentPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/new/_components/NewComponentPanel.svelte
@@ -182,12 +182,13 @@
   }
 
   const handleKeyDown = e => {
-    if (e.key === "Tab") {
+    if (e.key === "Tab" || e.key === "ArrowDown" || e.key === "ArrowUp") {
       // Cycle selected components on tab press
       if (selectedIndex == null) {
         selectedIndex = 0
       } else {
-        selectedIndex = (selectedIndex + 1) % componentList.length
+        const direction = e.key === "ArrowUp" ? -1 : 1
+        selectedIndex = (selectedIndex + direction) % componentList.length
       }
       e.preventDefault()
       e.stopPropagation()


### PR DESCRIPTION
## Description
Just one I run into a lot. I open the component selection panel, and try to use the arrow keys to navigate, which is not possible.

I feel like `Tab` isn't that intuitive compared to using the arrow keys to navigate up and down the component selection menu.

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



