### PR TITLE
Qa 16 get qa core tests ready for split runs

### DIFF
--- a/qa-core/README.md
+++ b/qa-core/README.md
@@ -3,20 +3,32 @@
 The QA Core API tests are a jest suite that run directly against the budibase backend APIs.
 
 ## Auto Setup
+
 You can run the whole test suite with one command, that spins up the budibase server and runs the jest tests:
 
-`yarn api:test` 
+`yarn api:test`
 
 ## Setup Server Only
+
 You can also just stand up the budibase server alone.
 
-`yarn api:server:setup` 
+`yarn api:server:setup`
 
 ## Run Tests
+
 If you configured the server using the previous command, you can run the whole test suite by using:
 
-`yarn test` 
+`yarn test`
 
 for watch mode, where the tests will run on every change:
 
-`yarn test:watch` 
+`yarn test:watch`
+
+To run tests locally against a cloud service you can use the command:
+`yarn run api:test:local`
+
+To run the tests in CI, it assumes the correct environment variables are set, and the server is already running. Use the command:
+`yarn run api:test:ci`
+
+To run the nightly tests against the QA environment, use the command:
+`yarn run api:test:nightly`

--- a/qa-core/package.json
+++ b/qa-core/package.json
@@ -13,13 +13,15 @@
     "test:watch": "env-cmd jest --watch",
     "test:debug": "DEBUG=1 jest",
     "test:notify": "node scripts/testResultsWebhook",
-    "test:ci": "jest --runInBand --json --outputFile=testResults.json",
+    "test:ci": "jest --runInBand --testPathIgnorePatterns=\\\"\\/dataSources\\/\\\"",
     "docker:up": "docker-compose up -d",
     "docker:down": "docker-compose down",
     "api:server:setup": "npm run docker:up && env-cmd ts-node ../packages/builder/ts/setup.ts",
     "api:server:setup:ci": "env-cmd node ../packages/builder/setup.js",
     "api:test:ci": "start-server-and-test api:server:setup:ci http://localhost:4100/builder test",
-    "api:test": "start-server-and-test api:server:setup http://localhost:4100/builder test"
+    "api:test": "start-server-and-test api:server:setup http://localhost:4100/builder test",
+    "api:test:local": "env-cmd jest --runInBand --testPathIgnorePatterns=\\\"\\/dataSources\\/\\\"",
+    "api:test:local:withDataSources": "env-cmd jest --runInBand"
   },
   "jest": {
     "preset": "ts-jest",

--- a/qa-core/package.json
+++ b/qa-core/package.json
@@ -21,7 +21,7 @@
     "api:test:ci": "start-server-and-test api:server:setup:ci http://localhost:4100/builder test",
     "api:test": "start-server-and-test api:server:setup http://localhost:4100/builder test",
     "api:test:local": "env-cmd jest --runInBand --testPathIgnorePatterns=\\\"\\/dataSources\\/\\\"",
-    "api:test:withDataSources": "env-cmd jest --runInBand --outputFile=testResults.json"
+    "api:test:nightly": "env-cmd jest --runInBand --outputFile=testResults.json"
   },
   "jest": {
     "preset": "ts-jest",

--- a/qa-core/package.json
+++ b/qa-core/package.json
@@ -21,7 +21,7 @@
     "api:test:ci": "start-server-and-test api:server:setup:ci http://localhost:4100/builder test",
     "api:test": "start-server-and-test api:server:setup http://localhost:4100/builder test",
     "api:test:local": "env-cmd jest --runInBand --testPathIgnorePatterns=\\\"\\/dataSources\\/\\\"",
-    "api:test:local:withDataSources": "env-cmd jest --runInBand"
+    "api:test:withDataSources": "env-cmd jest --runInBand"
   },
   "jest": {
     "preset": "ts-jest",

--- a/qa-core/package.json
+++ b/qa-core/package.json
@@ -13,7 +13,7 @@
     "test:watch": "env-cmd jest --watch",
     "test:debug": "DEBUG=1 jest",
     "test:notify": "node scripts/testResultsWebhook",
-    "test:ci": "jest --runInBand --testPathIgnorePatterns=\\\"\\/dataSources\\/\\\"",
+    "test:ci": "jest --runInBand --json --outputFile=testResults.json --testPathIgnorePatterns=\\\"\\/dataSources\\/\\\"",
     "docker:up": "docker-compose up -d",
     "docker:down": "docker-compose down",
     "api:server:setup": "npm run docker:up && env-cmd ts-node ../packages/builder/ts/setup.ts",
@@ -21,7 +21,7 @@
     "api:test:ci": "start-server-and-test api:server:setup:ci http://localhost:4100/builder test",
     "api:test": "start-server-and-test api:server:setup http://localhost:4100/builder test",
     "api:test:local": "env-cmd jest --runInBand --testPathIgnorePatterns=\\\"\\/dataSources\\/\\\"",
-    "api:test:withDataSources": "env-cmd jest --runInBand"
+    "api:test:withDataSources": "env-cmd jest --runInBand --outputFile=testResults.json"
   },
   "jest": {
     "preset": "ts-jest",

--- a/qa-core/src/tests/internal-api/dataSources/example.spec.ts
+++ b/qa-core/src/tests/internal-api/dataSources/example.spec.ts
@@ -1,0 +1,36 @@
+import TestConfiguration from "../../../config/internal-api/TestConfiguration"
+import { App } from "@budibase/types"
+import InternalAPIClient from "../../../config/internal-api/TestConfiguration/InternalAPIClient"
+import AccountsAPIClient from "../../../config/internal-api/TestConfiguration/accountsAPIClient"
+import { generateApp } from "../../../config/internal-api/fixtures/applications"
+import { Screen } from "@budibase/types"
+import generateScreen from "../../../config/internal-api/fixtures/screens"
+
+describe("Internal API - Data Sources", () => {
+  const api = new InternalAPIClient()
+  const accountsAPI = new AccountsAPIClient()
+  const config = new TestConfiguration<Screen>(api, accountsAPI)
+  const appConfig = new TestConfiguration<App>(api, accountsAPI)
+
+  beforeAll(async () => {
+    await config.setupAccountAndTenant()
+  })
+
+  afterAll(async () => {
+    await config.afterAll()
+  })
+
+  it("Create an app with a data source", async () => {
+    // Create app
+    const app = await appConfig.applications.create(generateApp())
+
+    // Create Screen
+    const roleArray = ["BASIC", "POWER", "ADMIN", "PUBLIC"]
+    appConfig.applications.api.appId = app.appId
+    for (let role in roleArray) {
+      const [response, screen] = await config.screen.create(
+        generateScreen(roleArray[role])
+      )
+    }
+  })
+})


### PR DESCRIPTION
## Description
Currently there is only one command to run tests in CI and it expects to be able to run all the tests. This will create false errors when the tests run against an Env without access to pre-setup data sources (like QA env). This PR adds some commands to better split the tests each command runs .

## Addresses: 
- [QA-16](https://linear.app/budibase/issue/QA-16/get-qa-core-tests-ready-for-split-runs)


## Documentation
-  I have reviewed the budibase documentation to verify if this feature requires any changes and updated the README for the `qa-core` folder.



