### PR TITLE
BUDI-6788 - Prevent deleting users that are ad

### DIFF
--- a/packages/builder/src/pages/builder/portal/users/users/index.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/index.svelte
@@ -54,7 +54,7 @@
   ]
   let userData = []
 
-  $: readonly = !$auth.isAdmin
+  $: readonly = !$auth.isAdmin || $licensing.scimEnabled
   $: debouncedUpdateFetch(searchEmail)
   $: schema = {
     email: {


### PR DESCRIPTION
## Description
Disable user selection when AD is sync, as it is only used to multi-delete users

![image](https://user-images.githubusercontent.com/15987277/228183862-b4e3aaf8-5d3e-41a1-9b2f-b29ab8dbeca7.png)
