### PR TITLE
Lowercase values for Oracle LIKE

### DIFF
--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -156,7 +156,7 @@ class InternalBuilder {
         const rawFnc = `${fnc}Raw`
         // @ts-ignore
         query = query[rawFnc](`LOWER(${likeKey(this.client, key)}) LIKE ?`, [
-          `%${value}%`,
+          `%${value.toLowerCase()}%`,
         ])
       }
     }
@@ -202,7 +202,7 @@ class InternalBuilder {
           let statement = ""
           for (let i in value) {
             if (typeof value[i] === "string") {
-              value[i] = `%"${value[i]}"%`
+              value[i] = `%"${value[i].toLowerCase()}"%`
             } else {
               value[i] = `%${value[i]}%`
             }
@@ -238,7 +238,7 @@ class InternalBuilder {
           const rawFnc = `${fnc}Raw`
           // @ts-ignore
           query = query[rawFnc](`LOWER(${likeKey(this.client, key)}) LIKE ?`, [
-            `${value}%`,
+            `${value.toLowerCase()}%`,
           ])
         }
       })


### PR DESCRIPTION
## Description
Oracle LIKE statements are case sensitive, so needed to lowercase the comparison value as well. 

Addresses: 
- https://linear.app/budibase/issue/BUDI-6793/oracle-db-starts-with-filter-always-requires-lower-case-value



