### PR TITLE
Chore: Account deletion via API

### DIFF
--- a/packages/worker/src/api/controllers/system/tenants.ts
+++ b/packages/worker/src/api/controllers/system/tenants.ts
@@ -5,7 +5,7 @@ export async function destroy(ctx: UserCtx) {
   const user = ctx.user!
   const tenantId = ctx.params.tenantId
 
-  if (tenantId !== user.tenantId) {
+  if (!ctx.internal && tenantId !== user.tenantId) {
     ctx.throw(403, "Tenant ID does not match current user")
   }
 


### PR DESCRIPTION
## Description

Updates: 
- Allow tenant deletion api to work when internal api key is supplies

See: https://github.com/Budibase/account-portal/pull/292

Addresses: 
- [BUDI-6794](https://linear.app/budibase/issue/BUDI-6794/account-deletion-via-api)


