### PR TITLE
Chore: Update livenessprobe timeout, add readinessprobe

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -215,8 +215,21 @@ spec:
           httpGet:
             path: /health
             port: {{ .Values.services.apps.port }}
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.services.apps.port }}
           initialDelaySeconds: 5
           periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 1
+          timeoutSeconds: 3
+
         name: bbapps
         ports:
         - containerPort: {{ .Values.services.apps.port }}

--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -227,7 +227,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
           successThreshold: 1
-          failureThreshold: 1
+          failureThreshold: 3
           timeoutSeconds: 3
 
         name: bbapps

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -205,8 +205,20 @@ spec:
           httpGet:
             path: /health
             port: {{ .Values.services.worker.port }}
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.services.worker.port }}
           initialDelaySeconds: 5
           periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 1
+          timeoutSeconds: 3
         name: bbworker
         ports:
         - containerPort: {{ .Values.services.worker.port }}

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -217,7 +217,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
           successThreshold: 1
-          failureThreshold: 1
+          failureThreshold: 3
           timeoutSeconds: 3
         name: bbworker
         ports:

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -138,7 +138,6 @@ services:
     replicaCount: 1
     logLevel: info
     resources: {}
-    liveness:
 #    nodeDebug: "" # set the value of NODE_DEBUG
 #    annotations:
 #      co.elastic.logs/multiline.type: pattern
@@ -341,20 +340,3 @@ couchdb:
   # This is used to generate FQDNs for peers when joining the CouchDB cluster.
   dns:
     clusterDomainSuffix: cluster.local
-
-  ## Configure liveness and readiness probe values
-  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-  livenessProbe:
-    enabled: true
-    failureThreshold: 3
-    initialDelaySeconds: 0
-    periodSeconds: 10
-    successThreshold: 1
-    timeoutSeconds: 1
-  readinessProbe:
-    enabled: true
-    failureThreshold: 3
-    initialDelaySeconds: 0
-    periodSeconds: 10
-    successThreshold: 1
-    timeoutSeconds: 1

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -138,6 +138,7 @@ services:
     replicaCount: 1
     logLevel: info
     resources: {}
+    liveness:
 #    nodeDebug: "" # set the value of NODE_DEBUG
 #    annotations:
 #      co.elastic.logs/multiline.type: pattern

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -340,3 +340,21 @@ couchdb:
   # This is used to generate FQDNs for peers when joining the CouchDB cluster.
   dns:
     clusterDomainSuffix: cluster.local
+
+  ## Configure liveness and readiness probe values
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  # FOR COUCHDB
+  livenessProbe:
+    enabled: true
+    failureThreshold: 3
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+  readinessProbe:
+    enabled: true
+    failureThreshold: 3
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1


### PR DESCRIPTION
## Description

- Update the liveness probe timeout to 3s to try to resolve restarts 
- Add readiness probe to prevent an unready serviced being sent http traffic to prevent 504s. 

Addresses: 
- Unticketed 

