### PR TITLE
update test report script to read the right jest test file

### DIFF
--- a/qa-core/scripts/testResultsWebhook.js
+++ b/qa-core/scripts/testResultsWebhook.js
@@ -10,7 +10,7 @@ const GITHUB_ACTIONS_RUN_URL = process.env.GITHUB_ACTIONS_RUN_URL
 
 async function generateReport() {
   // read the report file
-  const REPORT_PATH = path.resolve(__dirname, "..", "testReport.json")
+  const REPORT_PATH = path.resolve(__dirname, "..", "testResults.json")
   const report = fs.readFileSync(REPORT_PATH, "utf-8")
   return JSON.parse(report)
 }


### PR DESCRIPTION
## Description
the name of the generated jest test report for our nightly build and the one being read in the script that reads it and posts to discord didn't match up.

Addresses: 
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._

## Documentation
- [ ] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



