### PR TITLE
Explictly check for google datasource configured

### DIFF
--- a/packages/backend-core/src/configs/configs.ts
+++ b/packages/backend-core/src/configs/configs.ts
@@ -162,7 +162,7 @@ export async function getGoogleConfig(): Promise<
 export async function getGoogleDatasourceConfig(): Promise<
   GoogleInnerConfig | undefined
 > {
-  if (!env.isDev() && !env.SELF_HOSTED) {
+  if (!env.SELF_HOSTED) {
     // always use the env vars in cloud
     return getDefaultGoogleConfig()
   }

--- a/packages/backend-core/src/configs/tests/configs.spec.ts
+++ b/packages/backend-core/src/configs/tests/configs.spec.ts
@@ -1,4 +1,4 @@
-import { DBTestConfiguration, generator, testEnv } from "../../../tests"
+import { DBTestConfiguration, generator, testEnv, structures } from "../../../tests"
 import { ConfigType } from "@budibase/types"
 import env from "../../environment"
 import * as configs from "../configs"
@@ -110,6 +110,74 @@ describe("configs", () => {
       await config.doInTenant(async () => {
         const config = await configs.getSettingsConfig()
         expect(config.platformUrl).toBe(DEFAULT_URL)
+      })
+    })
+  })
+
+  describe("getGoogleDatasourceConfig", () => {
+
+    function setEnvVars() {
+      env.GOOGLE_CLIENT_SECRET = "test"
+      env.GOOGLE_CLIENT_ID = "test"
+    }
+
+    function unsetEnvVars() {
+      env.GOOGLE_CLIENT_SECRET = undefined
+      env.GOOGLE_CLIENT_ID = undefined
+    }
+
+    describe("cloud", () => {
+      beforeEach(() => {
+        testEnv.cloudHosted()
+      })
+
+      it("returns from env vars", async () => {
+        await config.doInTenant(async () => {
+          setEnvVars()
+          const config = await configs.getGoogleDatasourceConfig()
+          unsetEnvVars()
+
+          expect(config).toEqual({
+            activated: true,
+            clientID: "test",
+            clientSecret: "test",
+          })
+        })
+      })
+
+      it("returns undefined when no env vars are configured", async () => {
+        await config.doInTenant(async () => {
+          const config = await configs.getGoogleDatasourceConfig()
+          expect(config).toBeUndefined()
+        })
+      })
+    })
+
+    describe("self host", () => {
+      beforeEach(() => {
+        testEnv.selfHosted()
+      })
+
+      it("returns from config", async () => {
+        await config.doInTenant(async () => {
+          const googleDoc = structures.sso.googleConfigDoc()
+          await configs.save(googleDoc)
+          const config = await configs.getGoogleDatasourceConfig()
+          expect(config).toEqual(googleDoc.config)
+        })
+      })
+
+      it("falls back to env vars when config is disabled", async () => {
+        await config.doInTenant(async () => {
+          setEnvVars()
+          const config = await configs.getGoogleDatasourceConfig()
+          unsetEnvVars()
+          expect(config).toEqual({
+            activated: true,
+            clientID: "test",
+            clientSecret: "test",
+          })
+        })
       })
     })
   })

--- a/packages/backend-core/src/configs/tests/configs.spec.ts
+++ b/packages/backend-core/src/configs/tests/configs.spec.ts
@@ -1,4 +1,9 @@
-import { DBTestConfiguration, generator, testEnv, structures } from "../../../tests"
+import {
+  DBTestConfiguration,
+  generator,
+  testEnv,
+  structures,
+} from "../../../tests"
 import { ConfigType } from "@budibase/types"
 import env from "../../environment"
 import * as configs from "../configs"
@@ -115,7 +120,6 @@ describe("configs", () => {
   })
 
   describe("getGoogleDatasourceConfig", () => {
-
     function setEnvVars() {
       env.GOOGLE_CLIENT_SECRET = "test"
       env.GOOGLE_CLIENT_ID = "test"

--- a/packages/backend-core/tests/utilities/structures/sso.ts
+++ b/packages/backend-core/tests/utilities/structures/sso.ts
@@ -1,4 +1,6 @@
 import {
+  ConfigType,
+  GoogleConfig,
   GoogleInnerConfig,
   JwtClaims,
   OAuth2,
@@ -10,10 +12,10 @@ import {
   User,
 } from "@budibase/types"
 import { generator } from "./generator"
-import { uuid, email } from "./common"
+import { email, uuid } from "./common"
 import * as shared from "./shared"
-import _ from "lodash"
 import { user } from "./shared"
+import _ from "lodash"
 
 export function OAuth(): OAuth2 {
   return {
@@ -105,5 +107,13 @@ export function googleConfig(): GoogleInnerConfig {
     activated: true,
     clientID: generator.string(),
     clientSecret: generator.string(),
+  }
+}
+
+export function googleConfigDoc(): GoogleConfig {
+  return {
+    _id: "config_google",
+    type: ConfigType.GOOGLE,
+    config: googleConfig(),
   }
 }

--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/GoogleDatasourceConfigModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/GoogleDatasourceConfigModal.svelte
@@ -12,7 +12,7 @@
 
   // kill the reference so the input isn't saved
   let datasource = cloneDeep(integration)
-  $: isGoogleConfigured = !!$organisation.google
+  $: isGoogleConfigured = !!$organisation.googleDatasourceConfigured
 
   onMount(async () => {
     await organisation.init()

--- a/packages/builder/src/stores/portal/organisation.js
+++ b/packages/builder/src/stores/portal/organisation.js
@@ -19,6 +19,7 @@ const DEFAULT_CONFIG = {
   company: "Budibase",
   oidc: undefined,
   google: undefined,
+  googleDatasourceConfigured: undefined,
   oidcCallbackUrl: "",
   googleCallbackUrl: "",
   isSSOEnforced: false,
@@ -39,6 +40,7 @@ export function createOrganisationStore() {
     const storeConfig = _.cloneDeep(get(store))
     delete storeConfig.oidc
     delete storeConfig.google
+    delete storeConfig.googleDatasourceConfigured
     delete storeConfig.oidcCallbackUrl
     delete storeConfig.googleCallbackUrl
     await API.saveConfig({

--- a/packages/types/src/api/web/global/configs.ts
+++ b/packages/types/src/api/web/global/configs.ts
@@ -5,6 +5,7 @@ import { SettingsConfig, SettingsInnerConfig } from "../../../documents"
  */
 export interface PublicSettingsInnerConfig extends SettingsInnerConfig {
   google: boolean
+  googleDatasourceConfigured: boolean
   oidc: boolean
   oidcCallbackUrl: string
   googleCallbackUrl: string

--- a/packages/worker/src/api/controllers/global/configs.ts
+++ b/packages/worker/src/api/controllers/global/configs.ts
@@ -332,7 +332,8 @@ export async function publicSettings(
 
     // google
     const googleConfig = await configs.getGoogleConfig()
-    const googleDatasourceConfigured = !!(await configs.getGoogleDatasourceConfig())
+    const googleDatasourceConfigured =
+      !!(await configs.getGoogleDatasourceConfig())
     const preActivated = googleConfig && googleConfig.activated == null
     const google = preActivated || !!googleConfig?.activated
     const _googleCallbackUrl = await googleCallbackUrl(googleConfig)

--- a/packages/worker/src/api/controllers/global/configs.ts
+++ b/packages/worker/src/api/controllers/global/configs.ts
@@ -332,6 +332,7 @@ export async function publicSettings(
 
     // google
     const googleConfig = await configs.getGoogleConfig()
+    const googleDatasourceConfigured = !!(await configs.getGoogleDatasourceConfig())
     const preActivated = googleConfig && googleConfig.activated == null
     const google = preActivated || !!googleConfig?.activated
     const _googleCallbackUrl = await googleCallbackUrl(googleConfig)
@@ -352,6 +353,7 @@ export async function publicSettings(
         ...config,
         ...branding,
         google,
+        googleDatasourceConfigured,
         oidc,
         isSSOEnforced,
         oidcCallbackUrl: _oidcCallbackUrl,

--- a/packages/worker/src/api/routes/global/tests/configs.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/configs.spec.ts
@@ -290,6 +290,7 @@ describe("configs", () => {
           logoUrl: "",
           analyticsEnabled: false,
           google: false,
+          googleDatasourceConfigured: false,
           googleCallbackUrl: `http://localhost:10000/api/global/auth/${config.tenantId}/google/callback`,
           isSSOEnforced: false,
           oidc: false,


### PR DESCRIPTION
## Description
Use the specific helper for `getGoogleDatasourceConfig` for determining the existence of the config, rather than relying on the db google config only. 

also remove `isDev` check so that local dev mimics production in this case. 

Addresses: 
- Adhoc issue

