### PR TITLE
BUG - Multiple User Crossover Bug

### DIFF
--- a/packages/backend-core/src/auth/auth.ts
+++ b/packages/backend-core/src/auth/auth.ts
@@ -199,7 +199,6 @@ export async function platformLogout(opts: PlatformLogoutOpts) {
   } else {
     // clear cookies
     clearCookie(ctx, Cookie.Auth)
-    clearCookie(ctx, Cookie.CurrentApp)
   }
 
   const sessionIds = sessions.map(({ sessionId }) => sessionId)

--- a/packages/backend-core/src/constants/misc.ts
+++ b/packages/backend-core/src/constants/misc.ts
@@ -4,7 +4,6 @@ export enum UserStatus {
 }
 
 export enum Cookie {
-  CurrentApp = "budibase:currentapp",
   Auth = "budibase:auth",
   Init = "budibase:init",
   ACCOUNT_RETURN_URL = "budibase:account:returnurl",

--- a/packages/builder/src/pages/builder/_layout.svelte
+++ b/packages/builder/src/pages/builder/_layout.svelte
@@ -79,7 +79,7 @@
       }
 
       // Validate tenant if in a multi-tenant env
-      if (useAccountPortal && multiTenancyEnabled) {
+      if (multiTenancyEnabled) {
         await validateTenantId()
       }
     } catch (error) {

--- a/packages/server/src/middleware/tests/currentapp.spec.js
+++ b/packages/server/src/middleware/tests/currentapp.spec.js
@@ -158,27 +158,22 @@ describe("Current app middleware", () => {
   })
 
   describe("check functionality when logged in", () => {
-    async function checkExpected(setCookie) {
+    async function checkExpected() {
       config.setUser()
       await config.executeMiddleware()
-      let { utils } = require("@budibase/backend-core")
-      if (setCookie) {
-        expect(utils.setCookie).toHaveBeenCalled()
-      } else {
-        expect(utils.setCookie).not.toHaveBeenCalled()
-      }
+
       expect(config.ctx.roleId).toEqual("PUBLIC")
       expect(config.ctx.user.role._id).toEqual("PUBLIC")
       expect(config.ctx.appId).toEqual("app_test")
       expect(config.next).toHaveBeenCalled()
     }
 
-    it("should be able to setup an app token when cookie not setup", async () => {
+    it("should be able to setup an app token on a first call", async () => {
       mockAuthWithCookie()
-      await checkExpected(true)
+      await checkExpected()
     })
 
-    it("should perform correct when no cookie exists", async () => {
+    it("should perform correct on a first call", async () => {
       mockReset()
       jest.mock("@budibase/backend-core", () => {
         const core = jest.requireActual("@budibase/backend-core")
@@ -206,38 +201,7 @@ describe("Current app middleware", () => {
           },
         }
       })
-      await checkExpected(true)
-    })
-
-    it("lastly check what occurs when cookie doesn't need updated", async () => {
-      mockReset()
-      jest.mock("@budibase/backend-core", () => {
-        const core = jest.requireActual("@budibase/backend-core")
-        return {
-          ...core,
-          db: {
-            ...core.db,
-            dbExists: () => true,
-          },
-          utils: {
-            getAppIdFromCtx: () => {
-              return "app_test"
-            },
-            setCookie: jest.fn(),
-            getCookie: () => ({ appId: "app_test", roleId: "PUBLIC" }),
-          },
-          cache: {
-            user: {
-              getUser: async id => {
-                return {
-                  _id: "us_uuid1",
-                }
-              },
-            },
-          },
-        }
-      })
-      await checkExpected(false)
+      await checkExpected()
     })
   })
 })

--- a/packages/server/src/tests/utilities/TestConfiguration.ts
+++ b/packages/server/src/tests/utilities/TestConfiguration.ts
@@ -330,21 +330,13 @@ class TestConfiguration {
         sessionId: "sessionid",
         tenantId: this.getTenantId(),
       }
-      const app = {
-        roleId: roleId,
-        appId,
-      }
       const authToken = auth.jwt.sign(authObj, coreEnv.JWT_SECRET)
-      const appToken = auth.jwt.sign(app, coreEnv.JWT_SECRET)
 
       // returning necessary request headers
       await cache.user.invalidateUser(userId)
       return {
         Accept: "application/json",
-        Cookie: [
-          `${constants.Cookie.Auth}=${authToken}`,
-          `${constants.Cookie.CurrentApp}=${appToken}`,
-        ],
+        Cookie: [`${constants.Cookie.Auth}=${authToken}`],
         [constants.Header.APP_ID]: appId,
       }
     })
@@ -359,18 +351,11 @@ class TestConfiguration {
       sessionId: "sessionid",
       tenantId,
     }
-    const app = {
-      roleId: roles.BUILTIN_ROLE_IDS.ADMIN,
-      appId: this.appId,
-    }
     const authToken = auth.jwt.sign(authObj, coreEnv.JWT_SECRET)
-    const appToken = auth.jwt.sign(app, coreEnv.JWT_SECRET)
+
     const headers: any = {
       Accept: "application/json",
-      Cookie: [
-        `${constants.Cookie.Auth}=${authToken}`,
-        `${constants.Cookie.CurrentApp}=${appToken}`,
-      ],
+      Cookie: [`${constants.Cookie.Auth}=${authToken}`],
       [constants.Header.CSRF_TOKEN]: this.defaultUserValues.csrfToken,
       Host: this.tenantHost(),
       ...extras,

--- a/packages/worker/src/api/controllers/global/auth.ts
+++ b/packages/worker/src/api/controllers/global/auth.ts
@@ -50,11 +50,6 @@ async function passportCallback(
   setCookie(ctx, token, Cookie.Auth, { sign: false })
   // set the token in a header as well for APIs
   ctx.set(Header.TOKEN, token)
-  // get rid of any app cookies on login
-  // have to check test because this breaks cypress
-  if (!env.isTest()) {
-    clearCookie(ctx, Cookie.CurrentApp)
-  }
 }
 
 export const login = async (ctx: Ctx<LoginRequest>, next: any) => {

--- a/packages/worker/src/api/controllers/global/self.ts
+++ b/packages/worker/src/api/controllers/global/self.ts
@@ -2,7 +2,6 @@ import * as userSdk from "../../../sdk/users"
 import {
   featureFlags,
   tenancy,
-  constants,
   db as dbCore,
   utils,
   encryption,
@@ -11,7 +10,7 @@ import {
 import env from "../../../environment"
 import { groups } from "@budibase/pro"
 import { UpdateSelfRequest, UpdateSelfResponse, UserCtx } from "@budibase/types"
-const { getCookie, clearCookie, newid } = utils
+const { newid } = utils
 
 function newTestApiKey() {
   return env.ENCRYPTED_TEST_PUBLIC_API_KEY
@@ -71,16 +70,6 @@ export async function fetchAPIKey(ctx: any) {
   ctx.body = cleanupDevInfo(devInfo)
 }
 
-const checkCurrentApp = (ctx: any) => {
-  const appCookie = getCookie(ctx, constants.Cookie.CurrentApp)
-  if (appCookie && !tenancy.isUserInAppTenant(appCookie.appId)) {
-    // there is a currentapp cookie from another tenant
-    // remove the cookie as this is incompatible with the builder
-    // due to builder and admin permissions being removed
-    clearCookie(ctx, constants.Cookie.CurrentApp)
-  }
-}
-
 /**
  * Add the attributes that are session based to the current user.
  */
@@ -100,8 +89,6 @@ export async function getSelf(ctx: any) {
   ctx.params = {
     id: userId,
   }
-
-  checkCurrentApp(ctx)
 
   // get the main body of the user
   const user = await userSdk.getUser(userId)


### PR DESCRIPTION
## Description
Removing any usage of the cookie `app:currentapp`. We have better ways to infer the current app, and having a cookie with a wildcard (as we have now) causes issues with cross subdomains references.

Addresses: 
- https://linear.app/budibase/issue/BUDI-6729/multiple-user-crossover-bug

## App Export
- Not required

## Screenshots
New behaviour when trying to access an app cross subdomains:
<img width="835" alt="image" src="https://user-images.githubusercontent.com/15987277/228833217-0b884e3d-e3cb-41f7-b2cb-579b914c1fc5.png">


## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



