### PR TITLE
[BUG] Refresh sql columns on defining relationships

### DIFF
--- a/packages/builder/src/components/backend/DataTable/DataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/DataTable.svelte
@@ -149,10 +149,8 @@
   // When importing new rows it is better to reinitialise request/paging data.
   // Not doing so causes inconsistency in paging behaviour and content.
   const onImportData = () => {
-    fetch.getInitialData(enrichedSchema)
+    fetch.getInitialData()
   }
-
-  $: console.log(enrichedSchema)
 </script>
 
 <div>

--- a/packages/builder/src/components/backend/DataTable/DataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/DataTable.svelte
@@ -136,6 +136,7 @@
   const onUpdateColumns = () => {
     selectedRows = []
     fetch.refresh()
+    tables.fetchTable(id)
   }
 
   // Fetch data whenever rows are modified. Unfortunately we have to lose
@@ -148,8 +149,10 @@
   // When importing new rows it is better to reinitialise request/paging data.
   // Not doing so causes inconsistency in paging behaviour and content.
   const onImportData = () => {
-    fetch.getInitialData()
+    fetch.getInitialData(enrichedSchema)
   }
+
+  $: console.log(enrichedSchema)
 </script>
 
 <div>

--- a/packages/builder/src/stores/backend/tables.js
+++ b/packages/builder/src/stores/backend/tables.js
@@ -22,6 +22,18 @@ export function createTablesStore() {
     }))
   }
 
+  const fetchTable = async tableId => {
+    const table = await API.fetchTableDefinition(tableId)
+
+    store.update(state => {
+      const indexToUpdate = state.list.findIndex(t => t._id === table._id)
+      state.list[indexToUpdate] = table
+      return {
+        ...state,
+      }
+    })
+  }
+
   const select = tableId => {
     store.update(state => ({
       ...state,
@@ -126,6 +138,7 @@ export function createTablesStore() {
   return {
     subscribe: derivedStore.subscribe,
     fetch,
+    fetchTable,
     init: fetch,
     select,
     save,


### PR DESCRIPTION
## Description
Whenever I use Define existing relationship within the Data table view, the new relationship does not immediately appear. 
I must refresh the page. This PR fixes this behaviour, refreshing the columns whenever the columns are updated

Addresses: 
- https://linear.app/budibase/issue/BUDI-6631/define-existing-relationships-doesnt-display-related-pill-values-until

## Screenshots

https://user-images.githubusercontent.com/15987277/229089770-cb65d505-6bd7-451f-915a-0a3f1440b574.mov

