### PR TITLE
Fix issue with REST bindings not being shown in drawer

### DIFF
--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -120,7 +120,7 @@ export const toBindingsArray = (valueMap, prefix, category) => {
     return []
   }
   return Object.keys(valueMap).reduce((acc, binding) => {
-    if (!binding || !valueMap[binding]) {
+    if (!binding) {
       return acc
     }
 


### PR DESCRIPTION
## Description
Fixes #9045 

Bindings weren't being shown in the drawer correctly, to fix I removed the falsy check within the bindings generation - valueMap's value should be allowed to be null