### PR TITLE
Remove loop for get account during user bulk import

### DIFF
--- a/packages/worker/src/api/routes/global/tests/auth.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/auth.spec.ts
@@ -126,9 +126,8 @@ describe("/api/global/auth", () => {
           it("should prevent user from logging in", async () => {
             user = await config.createUser()
             const account = structures.accounts.ssoAccount() as CloudAccount
-            mocks.accounts.getAccount.mockReturnValueOnce(
-              Promise.resolve(account)
-            )
+            account.email = user.email
+            mocks.accounts.getAccountByTenantId.mockResolvedValueOnce(account)
 
             await testSSOUser()
           })
@@ -186,9 +185,8 @@ describe("/api/global/auth", () => {
           it("should prevent user from generating password reset email", async () => {
             user = await config.createUser(structures.users.user())
             const account = structures.accounts.ssoAccount() as CloudAccount
-            mocks.accounts.getAccount.mockReturnValueOnce(
-              Promise.resolve(account)
-            )
+            account.email = user.email
+            mocks.accounts.getAccountByTenantId.mockResolvedValueOnce(account)
 
             await testSSOUser()
           })

--- a/packages/worker/src/sdk/users/tests/users.spec.ts
+++ b/packages/worker/src/sdk/users/tests/users.spec.ts
@@ -1,6 +1,6 @@
 import { structures } from "../../../tests"
 import { mocks } from "@budibase/backend-core/tests"
-import { env } from "@budibase/backend-core"
+import { env, context } from "@budibase/backend-core"
 import * as users from "../users"
 import { CloudAccount } from "@budibase/types"
 import { isPreventPasswordActions } from "../users"
@@ -16,32 +16,50 @@ describe("users", () => {
 
   describe("isPreventPasswordActions", () => {
     it("returns false for non sso user", async () => {
-      const user = structures.users.user()
-      const result = await users.isPreventPasswordActions(user)
-      expect(result).toBe(false)
+      await context.doInTenant(structures.tenant.id(), async () => {
+        const user = structures.users.user()
+        const result = await users.isPreventPasswordActions(user)
+        expect(result).toBe(false)
+      })
     })
 
     it("returns true for sso account user", async () => {
-      const user = structures.users.user()
-      mocks.accounts.getAccount.mockReturnValue(
-        Promise.resolve(structures.accounts.ssoAccount() as CloudAccount)
-      )
-      const result = await users.isPreventPasswordActions(user)
-      expect(result).toBe(true)
+      await context.doInTenant(structures.tenant.id(), async () => {
+        const user = structures.users.user()
+        const account = structures.accounts.ssoAccount() as CloudAccount
+        account.email = user.email
+        mocks.accounts.getAccountByTenantId.mockResolvedValueOnce(account)
+        const result = await users.isPreventPasswordActions(user)
+        expect(result).toBe(true)
+      })
+    })
+
+    it("returns false when account doesn't match user email", async () => {
+      await context.doInTenant(structures.tenant.id(), async () => {
+        const user = structures.users.user()
+        const account = structures.accounts.ssoAccount() as CloudAccount
+        mocks.accounts.getAccountByTenantId.mockResolvedValueOnce(account)
+        const result = await users.isPreventPasswordActions(user)
+        expect(result).toBe(false)
+      })
     })
 
     it("returns true for sso user", async () => {
-      const user = structures.users.ssoUser()
-      const result = await users.isPreventPasswordActions(user)
-      expect(result).toBe(true)
+      await context.doInTenant(structures.tenant.id(), async () => {
+        const user = structures.users.ssoUser()
+        const result = await users.isPreventPasswordActions(user)
+        expect(result).toBe(true)
+      })
     })
 
     describe("enforced sso", () => {
       it("returns true for all users when sso is enforced", async () => {
-        const user = structures.users.user()
-        pro.features.isSSOEnforced.mockReturnValue(Promise.resolve(true))
-        const result = await users.isPreventPasswordActions(user)
-        expect(result).toBe(true)
+        await context.doInTenant(structures.tenant.id(), async () => {
+          const user = structures.users.user()
+          pro.features.isSSOEnforced.mockResolvedValueOnce(true)
+          const result = await users.isPreventPasswordActions(user)
+          expect(result).toBe(true)
+        })
       })
     })
 


### PR DESCRIPTION
## Description
There was a loop for reading account during bulk import introduced in enforced sso - add optimisations to only retrieve the account one time. 

Addresses: 
- https://linear.app/budibase/issue/BUDI-6825/csv-user-import-for-cloud-isnt-working



