### PR TITLE
Fixing #10155 - some options errors were being swallowed and in gener…

### DIFF
--- a/packages/builder/src/components/backend/DataTable/RowFieldControl.svelte
+++ b/packages/builder/src/components/backend/DataTable/RowFieldControl.svelte
@@ -42,7 +42,13 @@
 </script>
 
 {#if type === "options" && meta.constraints.inclusion.length !== 0}
-  <Select {label} bind:value options={meta.constraints.inclusion} sort {error} />
+  <Select
+    {label}
+    bind:value
+    options={meta.constraints.inclusion}
+    sort
+    {error}
+  />
 {:else if type === "datetime"}
   <DatePicker
     {error}

--- a/packages/builder/src/components/backend/DataTable/RowFieldControl.svelte
+++ b/packages/builder/src/components/backend/DataTable/RowFieldControl.svelte
@@ -42,7 +42,7 @@
 </script>
 
 {#if type === "options" && meta.constraints.inclusion.length !== 0}
-  <Select {label} bind:value options={meta.constraints.inclusion} sort />
+  <Select {label} bind:value options={meta.constraints.inclusion} sort {error} />
 {:else if type === "datetime"}
   <DatePicker
     {error}

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditRow.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditRow.svelte
@@ -27,21 +27,22 @@
       notifications.success("Row saved successfully")
       dispatch("updaterows")
     } catch (error) {
-      if (error.handled) {
-        const response = error.json
-        if (response?.errors) {
-          errors = response.errors
-        } else if (response?.validationErrors) {
-          const mappedErrors = {}
-          for (let field in response.validationErrors) {
-            mappedErrors[
-              field
-            ] = `${field} ${response.validationErrors[field][0]}`
-          }
-          errors = mappedErrors
+      const response = error.json
+      if (error.handled && response?.errors) {
+        console.error("FIRST")
+        errors = response.errors
+      } else if (error.handled && response?.validationErrors) {
+        console.error(response.validationErrors)
+        const mappedErrors = {}
+        for (let field in response.validationErrors) {
+          mappedErrors[
+            field
+          ] = `${field} ${response.validationErrors[field][0]}`
         }
+        errors = mappedErrors
+        console.log(errors)
       } else {
-        notifications.error("Failed to save row")
+        notifications.error(`Failed to save row - ${error.message}`)
       }
       // Prevent modal closing if there were errors
       return false

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditRow.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditRow.svelte
@@ -29,10 +29,8 @@
     } catch (error) {
       const response = error.json
       if (error.handled && response?.errors) {
-        console.error("FIRST")
         errors = response.errors
       } else if (error.handled && response?.validationErrors) {
-        console.error(response.validationErrors)
         const mappedErrors = {}
         for (let field in response.validationErrors) {
           mappedErrors[
@@ -40,7 +38,6 @@
           ] = `${field} ${response.validationErrors[field][0]}`
         }
         errors = mappedErrors
-        console.log(errors)
       } else {
         notifications.error(`Failed to save row - ${error.message}`)
       }

--- a/packages/server/scripts/integrations/postgres/init.sql
+++ b/packages/server/scripts/integrations/postgres/init.sql
@@ -7,6 +7,7 @@ CREATE TABLE Persons (
     LastName varchar(255),
     FirstName varchar(255),
     Address varchar(255),
+    Age INT NOT NULL,
     City varchar(255) DEFAULT 'Belfast',
     Type person_job
 );
@@ -42,8 +43,8 @@ CREATE TABLE test.table1 (
   id SERIAL PRIMARY KEY,
   Name varchar(255)
 );
-INSERT INTO Persons (FirstName, LastName, Address, City, Type) VALUES ('Mike', 'Hughes', '123 Fake Street', 'Belfast', 'qa');
-INSERT INTO Persons (FirstName, LastName, Address, City, Type) VALUES ('John', 'Smith', '64 Updown Road', 'Dublin', 'programmer');
+INSERT INTO Persons (FirstName, LastName, Address, City, Type, Age) VALUES ('Mike', 'Hughes', '123 Fake Street', 'Belfast', 'qa', 20);
+INSERT INTO Persons (FirstName, LastName, Address, City, Type, Age) VALUES ('John', 'Smith', '64 Updown Road', 'Dublin', 'programmer', 30);
 INSERT INTO Tasks (ExecutorID, QaID, TaskName, Completed) VALUES (1, 2, 'assembling', TRUE);
 INSERT INTO Tasks (ExecutorID, QaID, TaskName, Completed) VALUES (2, 1, 'processing', FALSE);
 INSERT INTO Products (ProductName) VALUES ('Computers');

--- a/packages/server/scripts/integrations/postgres/init.sql
+++ b/packages/server/scripts/integrations/postgres/init.sql
@@ -7,7 +7,6 @@ CREATE TABLE Persons (
     LastName varchar(255),
     FirstName varchar(255),
     Address varchar(255),
-    Age INT NOT NULL,
     City varchar(255) DEFAULT 'Belfast',
     Type person_job
 );
@@ -43,8 +42,8 @@ CREATE TABLE test.table1 (
   id SERIAL PRIMARY KEY,
   Name varchar(255)
 );
-INSERT INTO Persons (FirstName, LastName, Address, City, Type, Age) VALUES ('Mike', 'Hughes', '123 Fake Street', 'Belfast', 'qa', 20);
-INSERT INTO Persons (FirstName, LastName, Address, City, Type, Age) VALUES ('John', 'Smith', '64 Updown Road', 'Dublin', 'programmer', 30);
+INSERT INTO Persons (FirstName, LastName, Address, City, Type) VALUES ('Mike', 'Hughes', '123 Fake Street', 'Belfast', 'qa');
+INSERT INTO Persons (FirstName, LastName, Address, City, Type) VALUES ('John', 'Smith', '64 Updown Road', 'Dublin', 'programmer');
 INSERT INTO Tasks (ExecutorID, QaID, TaskName, Completed) VALUES (1, 2, 'assembling', TRUE);
 INSERT INTO Tasks (ExecutorID, QaID, TaskName, Completed) VALUES (2, 1, 'processing', FALSE);
 INSERT INTO Products (ProductName) VALUES ('Computers');


### PR DESCRIPTION
## Description
Fixing #10155 - some options errors were being swallowed, as well as errors coming from the underlying database that we can't handle being swallowed.

In general the UI assumed that we handled all data errors, so they were all marked as handled, but in reality a lot of them didn't have any case for being handled, so should just present a error notification instead.

## Screenshots
![image](https://user-images.githubusercontent.com/4407001/230149100-b5b9659f-e59b-4b29-a3b9-2ea7a2663ba9.png)
![image](https://user-images.githubusercontent.com/4407001/230149241-ff455311-0779-422e-992a-cdc3fc6fbedb.png)