### PR TITLE
Add `loadEnvFiles: false` to lerna config for run command 

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -11,6 +11,9 @@
         "# We ignore every JSON file, except for built-in-modules, built-ins and plugins defined in babel-preset-env/data.",
         "@(!(built-in-modules|built-ins|plugins|package)).json"
       ]
+    },
+    "run": {
+      "loadEnvFiles": false
     }
   }
 }


### PR DESCRIPTION
## Description
As a part of the lerna / nx bump we now load any `.env` files present in the file system for commands ran via `lerna run`. This can break unit tests locally based on the state of env files. 

Add `loadEnvFiles: false` globally to any lerna run commands to revert to the previous behaviour.


