### PR TITLE
fix small typo

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -785,7 +785,7 @@
         "barStyle": "picker",
         "options": [
           {
-            "label": "Extra amall",
+            "label": "Extra small",
             "value": "XS"
           },
           {


### PR DESCRIPTION
## Description
Small typo in size select of Header component

Addresses: 
- #10246 

## Screenshots
![image](https://user-images.githubusercontent.com/1907152/230960320-86a482e1-5971-4c99-9cc0-9fdf20947b21.png)




