### PR TITLE
Fix Help Menu

### DIFF
--- a/packages/bbui/src/Actions/position_dropdown.js
+++ b/packages/bbui/src/Actions/position_dropdown.js
@@ -10,7 +10,7 @@ export default function positionDropdown(element, opts) {
 
   // Updates the position of the dropdown
   const updatePosition = opts => {
-    const { anchor, align, maxWidth, useAnchorWidth, offset = 5 } = opts
+    const { anchor, align, maxHeight, maxWidth, useAnchorWidth, offset = 5 } = opts
     if (!anchor) {
       return
     }
@@ -31,10 +31,10 @@ export default function positionDropdown(element, opts) {
       styles.top = anchorBounds.top
     } else if (window.innerHeight - anchorBounds.bottom < 100) {
       styles.top = anchorBounds.top - elementBounds.height - offset
-      styles.maxHeight = 240
+      styles.maxHeight = maxHeight || 240
     } else {
       styles.top = anchorBounds.bottom + offset
-      styles.maxHeight = window.innerHeight - anchorBounds.bottom - 20
+      styles.maxHeight = maxHeight || window.innerHeight - anchorBounds.bottom - 20
     }
 
     // Determine horizontal styles

--- a/packages/bbui/src/Actions/position_dropdown.js
+++ b/packages/bbui/src/Actions/position_dropdown.js
@@ -10,7 +10,14 @@ export default function positionDropdown(element, opts) {
 
   // Updates the position of the dropdown
   const updatePosition = opts => {
-    const { anchor, align, maxHeight, maxWidth, useAnchorWidth, offset = 5 } = opts
+    const {
+      anchor,
+      align,
+      maxHeight,
+      maxWidth,
+      useAnchorWidth,
+      offset = 5,
+    } = opts
     if (!anchor) {
       return
     }
@@ -34,7 +41,8 @@ export default function positionDropdown(element, opts) {
       styles.maxHeight = maxHeight || 240
     } else {
       styles.top = anchorBounds.bottom + offset
-      styles.maxHeight = maxHeight || window.innerHeight - anchorBounds.bottom - 20
+      styles.maxHeight =
+        maxHeight || window.innerHeight - anchorBounds.bottom - 20
     }
 
     // Determine horizontal styles

--- a/packages/bbui/src/Popover/Popover.svelte
+++ b/packages/bbui/src/Popover/Popover.svelte
@@ -75,7 +75,7 @@
         anchor,
       }}
       on:keydown={handleEscape}
-      class='spectrum-Popover is-open'
+      class="spectrum-Popover is-open"
       role="presentation"
       style="height: {customHeight}"
       transition:fly|local={{ y: -20, duration: 200 }}

--- a/packages/bbui/src/Popover/Popover.svelte
+++ b/packages/bbui/src/Popover/Popover.svelte
@@ -14,6 +14,7 @@
   export let align = "right"
   export let portalTarget
   export let maxWidth
+  export let maxHeight
   export let open = false
   export let useAnchorWidth = false
   export let dismissible = true
@@ -64,6 +65,7 @@
       use:positionDropdown={{
         anchor,
         align,
+        maxHeight,
         maxWidth,
         useAnchorWidth,
         offset,
@@ -73,7 +75,7 @@
         anchor,
       }}
       on:keydown={handleEscape}
-      class={`spectrum-Popover is-open ${$$props.class}`}
+      class='spectrum-Popover is-open'
       role="presentation"
       style="height: {customHeight}"
       transition:fly|local={{ y: -20, duration: 200 }}

--- a/packages/bbui/src/Popover/Popover.svelte
+++ b/packages/bbui/src/Popover/Popover.svelte
@@ -73,7 +73,7 @@
         anchor,
       }}
       on:keydown={handleEscape}
-      class="spectrum-Popover is-open"
+      class={`spectrum-Popover is-open ${$$props.class}`}
       role="presentation"
       style="height: {customHeight}"
       transition:fly|local={{ y: -20, duration: 200 }}

--- a/packages/builder/src/components/common/HelpMenu.svelte
+++ b/packages/builder/src/components/common/HelpMenu.svelte
@@ -14,7 +14,7 @@
 <div bind:this={popoverAnchor} class="help">
   <button class="openMenu" on:click={show}>Help</button>
   <Popover
-    class="helpMenuPopoverOverride"
+    maxHeight={1000}
     bind:show
     bind:hide
     anchor={popoverAnchor}
@@ -85,9 +85,6 @@
 </div>
 
 <style>
-  :global(.helpMenuPopoverOverride) {
-    max-height: none !important;
-  }
   .help {
     z-index: 2;
     position: absolute;

--- a/packages/builder/src/components/common/HelpMenu.svelte
+++ b/packages/builder/src/components/common/HelpMenu.svelte
@@ -85,6 +85,9 @@
 </div>
 
 <style>
+  :global(.helpMenuPopoverOverride) {
+    max-height: none !important;
+  }
   .help {
     z-index: 2;
     position: absolute;

--- a/packages/builder/src/components/common/HelpMenu.svelte
+++ b/packages/builder/src/components/common/HelpMenu.svelte
@@ -13,12 +13,7 @@
 
 <div bind:this={popoverAnchor} class="help">
   <button class="openMenu" on:click={show}>Help</button>
-  <Popover
-    maxHeight={1000}
-    bind:show
-    bind:hide
-    anchor={popoverAnchor}
-  >
+  <Popover maxHeight={1000} bind:show bind:hide anchor={popoverAnchor}>
     <nav class="helpMenu">
       <div class="header">
         <Heading size="XS">Help resources</Heading>


### PR DESCRIPTION
@AndyWhann pointed out there was an issue with the help menu cutting off the email button.

This is caused by a hard max-height being enforced by the popover, so I added an override. I'm unsure if there's a cleaner way to do this, if so please let me know.