### PR TITLE
Add file/upload size validation option

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ValidationEditor/ValidationDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/ValidationEditor/ValidationDrawer.svelte
@@ -70,7 +70,7 @@
       value: "maxFileSize",
     },
     MaxUploadSize: {
-      label: "Max upload size (MB)",
+      label: "Max total upload size (MB)",
       value: "maxUploadSize",
     },
   }
@@ -388,7 +388,7 @@
     gap: var(--spacing-l);
     display: grid;
     align-items: center;
-    grid-template-columns: 190px 120px 1fr 1fr auto auto;
+    grid-template-columns: 200px 120px 1fr 1fr auto auto;
     border-radius: var(--border-radius-s);
     transition: background-color ease-in-out 130ms;
   }

--- a/packages/builder/src/components/design/settings/controls/ValidationEditor/ValidationDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/ValidationEditor/ValidationDrawer.svelte
@@ -65,6 +65,14 @@
       label: "Must not contain",
       value: "notContains",
     },
+    MaxFileSize: {
+      label: "Max file size (MB)",
+      value: "maxFileSize",
+    },
+    MaxUploadSize: {
+      label: "Max upload size (MB)",
+      value: "maxUploadSize",
+    },
   }
   const ConstraintMap = {
     ["string"]: [
@@ -94,7 +102,11 @@
       Constraints.Equal,
       Constraints.NotEqual,
     ],
-    ["attachment"]: [Constraints.Required],
+    ["attachment"]: [
+      Constraints.Required,
+      Constraints.MaxFileSize,
+      Constraints.MaxUploadSize,
+    ],
     ["link"]: [
       Constraints.Required,
       Constraints.Contains,
@@ -283,7 +295,7 @@
                     disabled={rule.constraint === "required"}
                     on:change={e => (rule.value = e.detail)}
                   />
-                {:else if rule.type !== "array" && ["maxLength", "minLength", "regex", "notRegex", "contains", "notContains"].includes(rule.constraint)}
+                {:else if rule.type !== "array" && ["maxUploadSize", "maxFileSize", "maxLength", "minLength", "regex", "notRegex", "contains", "notContains"].includes(rule.constraint)}
                   <!-- Certain constraints always need string values-->
                   <Input
                     bind:value={rule.value}

--- a/packages/client/src/components/app/forms/validation.js
+++ b/packages/client/src/components/app/forms/validation.js
@@ -241,6 +241,23 @@ const maxLengthHandler = (value, rule) => {
   return value == null || value.length <= limit
 }
 
+// Evaluates a max file size (MB) constraint
+const maxFileSizeHandler = (value, rule) => {
+  const limit = parseType(rule.value, "number")
+  return (
+    value == null ||
+    !value.some(attachment => attachment.size / 1000000 > limit)
+  )
+}
+
+// Evaluates a max total upload size (MB) constraint
+const maxUploadSizeHandler = (value, rule) => {
+  const limit = parseType(rule.value, "number")
+  return (
+    value == null || value.reduce((a, b) => a.size + b.size) / 1000000 <= limit
+  )
+}
+
 // Evaluates a min value constraint
 const minValueHandler = (value, rule) => {
   // Use same type as the value so that things can be compared
@@ -330,6 +347,8 @@ const handlerMap = {
   contains: containsHandler,
   notContains: notContainsHandler,
   json: jsonHandler,
+  maxFileSize: maxFileSizeHandler,
+  maxUploadSize: maxUploadSizeHandler,
 }
 
 /**

--- a/packages/client/src/components/app/forms/validation.js
+++ b/packages/client/src/components/app/forms/validation.js
@@ -254,7 +254,9 @@ const maxFileSizeHandler = (value, rule) => {
 const maxUploadSizeHandler = (value, rule) => {
   const limit = parseType(rule.value, "number")
   return (
-    value == null || value.reduce((a, b) => a.size + b.size) / 1000000 <= limit
+    value == null ||
+    value.reduce((acc, currentItem) => acc + currentItem.size, 0) / 1000000 <=
+      limit
   )
 }
 


### PR DESCRIPTION
## Description
Users wanted to validate the file size of an attachment upload. Whilst this doesn't prevent a user from uploading a file that exceeds the maximum size, it at least prevents the form being submitted. 
Further work could be done at a later stage to prevent 'auto-upload' upon selection of the file if that was wanted.

There are two types:

 - **Max file size**: None of the selected files can exceed the specified MB value
 - **Max upload size**: The sum total of selected files cannot exceed the specific MB value

Addresses: 
- https://github.com/Budibase/budibase/issues/8936

## Screenshots

### Max file size
![Screenshot 2023-04-11 at 13 33 09](https://user-images.githubusercontent.com/101575380/231163356-fcb3b383-e6cd-4a06-aa00-096345a24f66.png)

![att_validation](https://user-images.githubusercontent.com/101575380/231165634-b1709e10-3196-4492-85b7-3e776902bddf.gif)

### Max upload size
![Screenshot 2023-04-11 at 15 16 45](https://user-images.githubusercontent.com/101575380/231191691-d402dcd7-4bef-47b9-9051-f6e167e901d4.png)

![att_validation](https://user-images.githubusercontent.com/101575380/231192227-5017257a-1bab-44c5-9d9b-9819a554ba05.gif)

## Documentation
- [x] I have reviewed the budibase documentation to verify if this feature requires any changes. If changes or new docs are required I have written them.



