### PR TITLE
BUDI-6847 - Allow optional names

### DIFF
--- a/packages/types/src/api/web/global/scim/users.ts
+++ b/packages/types/src/api/web/global/scim/users.ts
@@ -19,10 +19,10 @@ export interface ScimUserResponse extends ScimResource {
   }
   userName: string
   displayName?: string
-  name: {
-    formatted: string
-    familyName: string
-    givenName: string
+  name?: {
+    formatted?: string
+    familyName?: string
+    givenName?: string
   }
   active: BooleanString
   emails?: Emails
@@ -41,7 +41,7 @@ export interface ScimCreateUserRequest {
     resourceType: "User"
   }
   displayName?: string
-  name: {
+  name?: {
     formatted: string
     familyName: string
     givenName: string


### PR DESCRIPTION
## Description
Even if the docs say first and last name [are required](https://learn.microsoft.com/en-gb/azure/active-directory/app-provisioning/use-scim-to-provision-users-and-groups#build-a-scim-endpoint), that's not true in practice. This PR is making these fields optional.

Addresses: 
- https://linear.app/budibase/issue/BUDI-6847/allow-empty-name-fields-on-user-scim-creation