### PR TITLE
Fix how version is processed in helm chart

### DIFF
--- a/.github/workflows/deploy-cloud.yaml
+++ b/.github/workflows/deploy-cloud.yaml
@@ -55,7 +55,7 @@ jobs:
           config-files: values.production.yaml
           chart-path: charts/budibase
           namespace: budibase
-          values: globals.appVersion=${{ env.RELEASE_VERSION }},services.couchdb.url=${{ secrets.PRODUCTION_COUCHDB_URL }},services.couchdb.password=${{ secrets.PRODUCTION_COUCHDB_PASSWORD }}
+          values: globals.appVersion=v${{ env.RELEASE_VERSION }},services.couchdb.url=${{ secrets.PRODUCTION_COUCHDB_URL }},services.couchdb.password=${{ secrets.PRODUCTION_COUCHDB_PASSWORD }}
           name: budibase-prod
 
       - name: Discord Webhook Action

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -107,7 +107,7 @@ jobs:
           git pull
           mkdir sync
           echo "Packaging chart to sync dir"
-          helm package charts/budibase --version 0.0.0-master --app-version "$RELEASE_VERSION" --destination sync
+          helm package charts/budibase --version 0.0.0-master --app-version v"$RELEASE_VERSION" --destination sync
           echo "Packaging successful"
           git checkout gh-pages
           echo "Indexing helm repo"         

--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -199,11 +199,12 @@ spec:
           value: {{ .Values.services.tlsRejectUnauthorized }}
         {{ end }}
 
-        {{ if .Values.globals.appVersion }}
-        image: budibase/apps:v{{ .Values.globals.appVersion }}
-        {{ else }}
-        image: budibase/apps:v{{ .Chart.AppVersion }}
-        {{ end }}
+        image: >-
+          {{- if .Values.globals.appVersion }}
+          budibase/apps:{{ .Values.globals.appVersion }}
+          {{- else }}
+          budibase/apps:{{ .Chart.AppVersion }}
+          {{- end }}
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -37,11 +37,12 @@ spec:
 {{ end }}
     spec:
       containers:
-        {{ if .Values.globals.appVersion }}
-        image: budibase/proxy:v{{ .Values.globals.appVersion }}
-        {{ else }}
-        image: budibase/proxy:v{{ .Chart.AppVersion }}
-        {{ end }}
+        image: >-
+          {{- if .Values.globals.appVersion }}
+          budibase/proxy:{{ .Values.globals.appVersion }}
+          {{- else }}
+          budibase/proxy:{{ .Chart.AppVersion }}
+          {{- end }}
         imagePullPolicy: Always
         name: proxy-service
         ports:

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -188,12 +188,12 @@ spec:
         - name: NODE_TLS_REJECT_UNAUTHORIZED
           value: {{ .Values.services.tlsRejectUnauthorized }}
         {{ end }}
-
-        {{ if .Values.globals.appVersion }}
-        image: budibase/worker:v{{ .Values.globals.appVersion }}
-        {{ else }}
-        image: budibase/worker:v{{ .Chart.AppVersion }}
-        {{ end }}
+        image: >-
+          {{- if .Values.globals.appVersion }}
+          budibase/worker:{{ .Values.globals.appVersion }}
+          {{- else }}
+          budibase/worker:{{ .Chart.AppVersion }}
+          {{- end }}
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## Description

**Syntax error**
Correct a syntax error for: `It is forbidden to specify block composed value at the same line as key` by 
> The error usually occurs when you have a key-value pair in your YAML file where the value is a block composed value (e.g., a multi-line string, an array, or a map), but the value starts on the same line as the key.


**Versioning**
Remove the default `v` substitution for the app version, as this may not always be correct e.g. `develop`, `latest` 

Addresses: 
Fix for: https://github.com/Budibase/budibase-deploys/actions/runs/4679063752/jobs/8288583078
