### PR TITLE
Fix release pro script

### DIFF
--- a/scripts/pro/release.sh
+++ b/scripts/pro/release.sh
@@ -88,8 +88,7 @@ yarn clean -y && yarn bootstrap
 
 # Commit and push changes
 git add packages/server/package.json
-git add packages/server/yarn.lock
 git add packages/worker/package.json
-git add packages/worker/yarn.lock
+git add yarn.lock
 git commit -m "Update pro version to $VERSION" -n
 git push


### PR DESCRIPTION
## Description
With the new usage of yarn workspaces, the yarn.lock file was moved to the root. The release pro process updates the existing yarn.locks with the latest version. This PR changes the location of this lock file

<img width="635" alt="image" src="https://user-images.githubusercontent.com/15987277/231878726-2409da9c-8bf3-45e2-8330-d750c876e98b.png">
