### PR TITLE
Fix - Add skiplibcheck on @budibase/types

### DIFF
--- a/packages/string-templates/tsconfig.json
+++ b/packages/string-templates/tsconfig.json
@@ -7,7 +7,6 @@
     "emitDeclarationOnly": true,
     "outDir": "dist",
     "esModuleInterop": true,
-    "types": ["node"],
-    "skipLibCheck": true
+    "types": ["node"]
   }
 }

--- a/packages/string-templates/tsconfig.json
+++ b/packages/string-templates/tsconfig.json
@@ -7,6 +7,7 @@
     "emitDeclarationOnly": true,
     "outDir": "dist",
     "esModuleInterop": true,
-    "types": ["node"]
+    "types": ["node"],
+    "skipLibCheck": true
   }
 }

--- a/packages/types/tsconfig-base.build.json
+++ b/packages/types/tsconfig-base.build.json
@@ -7,7 +7,8 @@
     "resolveJsonModule": true,
     "incremental": true,
     "sourceMap": true,
-    "declaration": true
+    "declaration": true,
+    "skipLibCheck": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.spec.js"]


### PR DESCRIPTION
## Description
Adding `skipLibCheck` to string-templates to fix the build error on release
<img width="1098" alt="image" src="https://user-images.githubusercontent.com/15987277/232029843-2e4a9653-1177-4f6c-bfeb-596fc268aa0e.png">


Refs:
- https://stackoverflow.com/questions/68833139/cannot-export-buffer-only-local-declarations-can-be-exported-from-a-module
- https://github.com/pouchdb/pouchdb/issues/8544
