### PR TITLE
Remove second conflicting yarn build

### DIFF
--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -62,7 +62,6 @@ jobs:
       - name: Build/release Docker images
         run: | 
           docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-          yarn build
           yarn build:docker:develop
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
## Description
Attempt to remove the second conflicting `yarn build` in the pipeline. The first `yarn build` was added 7 months ago, the 2nd and conflicting one, 12 months ago. This means that it might not be needed to run