### PR TITLE
BUDI-6855 - Allow editing group display names

### DIFF
--- a/packages/worker/src/api/routes/global/tests/scim.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/scim.spec.ts
@@ -585,6 +585,21 @@ describe("scim", () => {
             totalResults: groupCount,
           })
         })
+
+        it("can fetch groups using displayName filters", async () => {
+          const groupToFetch = _.sample(groups)
+          const response = await getScimGroups({
+            params: { filter: `displayName eq "${groupToFetch!.displayName}"` },
+          })
+
+          expect(response).toEqual({
+            Resources: [groupToFetch],
+            itemsPerPage: 1,
+            schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+            startIndex: 1,
+            totalResults: 1,
+          })
+        })
       })
     })
 

--- a/packages/worker/src/api/routes/global/tests/scim.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/scim.spec.ts
@@ -715,6 +715,16 @@ describe("scim", () => {
           status: 404,
         })
       })
+
+      it("should allow excluding members", async () => {
+        const response = await findScimGroup(group.id, {
+          qs: "excludedAttributes=members",
+        })
+
+        const { members, ...expectedResponse } = group
+
+        expect(response).toEqual(expectedResponse)
+      })
     })
 
     describe("DELETE /api/global/scim/v2/groups/:id", () => {

--- a/packages/worker/src/api/routes/global/tests/scim.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/scim.spec.ts
@@ -600,6 +600,25 @@ describe("scim", () => {
             totalResults: 1,
           })
         })
+
+        it("can fetch groups excluding members", async () => {
+          const response = await getScimGroups({
+            params: { excludedAttributes: "members" },
+          })
+
+          expect(response).toEqual({
+            Resources: expect.arrayContaining(
+              groups.map(g => {
+                const { members, ...groupData } = g
+                return groupData
+              })
+            ),
+            itemsPerPage: 25,
+            schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+            startIndex: 1,
+            totalResults: groupCount,
+          })
+        })
       })
     })
 

--- a/packages/worker/src/api/routes/global/tests/scim.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/scim.spec.ts
@@ -619,6 +619,25 @@ describe("scim", () => {
             totalResults: groupCount,
           })
         })
+
+        it("can fetch groups excluding multiple fields", async () => {
+          const response = await getScimGroups({
+            params: { excludedAttributes: "members,displayName" },
+          })
+
+          expect(response).toEqual({
+            Resources: expect.arrayContaining(
+              groups.map(g => {
+                const { members, displayName, ...groupData } = g
+                return groupData
+              })
+            ),
+            itemsPerPage: 25,
+            schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+            startIndex: 1,
+            totalResults: groupCount,
+          })
+        })
       })
     })
 

--- a/packages/worker/src/tests/api/scim/groups.ts
+++ b/packages/worker/src/tests/api/scim/groups.ts
@@ -18,6 +18,7 @@ export class ScimGroupsAPI extends ScimTestAPI {
         startIndex?: number
         pageSize?: number
         filter?: string
+        excludedAttributes?: string
       }
     }
   ) => {
@@ -31,6 +32,9 @@ export class ScimGroupsAPI extends ScimTestAPI {
     }
     if (params?.filter) {
       url += `filter=${params.filter}&`
+    }
+    if (params?.excludedAttributes) {
+      url += `excludedAttributes=${params.excludedAttributes}&`
     }
     const res = await this.call(url, "get", requestSettings)
     return res.body as ScimGroupListResponse

--- a/packages/worker/src/tests/api/scim/groups.ts
+++ b/packages/worker/src/tests/api/scim/groups.ts
@@ -58,9 +58,12 @@ export class ScimGroupsAPI extends ScimTestAPI {
     return res.body as ScimGroupResponse
   }
 
-  find = async (id: string, requestSettings?: Partial<RequestSettings>) => {
+  find = async (
+    id: string,
+    requestSettings?: Partial<RequestSettings> & { qs?: string }
+  ) => {
     const res = await this.call(
-      `/api/global/scim/v2/groups/${id}`,
+      `/api/global/scim/v2/groups/${id}?${requestSettings?.qs}`,
       "get",
       requestSettings
     )


### PR DESCRIPTION
## Description
Testing the following small improvements for a smoother and more reliable SCIM group integration
1. Allow filtering by name (required for updating attributes)
2. Allow excluding members (as stated on the RFC)
3. Do not log when group members update is requested but there are no actual changes

Addresses: 
- https://linear.app/budibase/issue/BUDI-6855/allow-editing-group-display-names
