### PR TITLE
Bug - Fix disabling fields on first load

### DIFF
--- a/packages/builder/src/pages/builder/portal/users/groups/[groupId].svelte
+++ b/packages/builder/src/pages/builder/portal/users/groups/[groupId].svelte
@@ -75,9 +75,7 @@
   let loaded = false
   let editModal, deleteModal
 
-  let scimEnabled = false
   $: scimEnabled = $features.isScimEnabled
-
   $: readonly = !$auth.isAdmin || scimEnabled
   $: page = $pageInfo.page
   $: fetchUsers(page, searchTerm)

--- a/packages/builder/src/pages/builder/portal/users/groups/[groupId].svelte
+++ b/packages/builder/src/pages/builder/portal/users/groups/[groupId].svelte
@@ -75,7 +75,8 @@
   let loaded = false
   let editModal, deleteModal
 
-  const scimEnabled = $features.isScimEnabled
+  let scimEnabled = false
+  $: scimEnabled = $features.isScimEnabled
 
   $: readonly = !$auth.isAdmin || scimEnabled
   $: page = $pageInfo.page

--- a/packages/builder/src/pages/builder/portal/users/users/[userId].svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/[userId].svelte
@@ -86,7 +86,8 @@
   let user
   let loaded = false
 
-  const scimEnabled = $features.isScimEnabled
+  let scimEnabled = false
+  $: scimEnabled = $features.isScimEnabled
 
   $: isSSO = !!user?.provider
   $: readonly = !$auth.isAdmin || scimEnabled

--- a/packages/builder/src/pages/builder/portal/users/users/[userId].svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/[userId].svelte
@@ -86,9 +86,7 @@
   let user
   let loaded = false
 
-  let scimEnabled = false
   $: scimEnabled = $features.isScimEnabled
-
   $: isSSO = !!user?.provider
   $: readonly = !$auth.isAdmin || scimEnabled
   $: privileged = user?.admin?.global || user?.builder?.global


### PR DESCRIPTION
## Description
Fixing bug that allowed AD users and groups to be edited when navigating to the edition page directly

Addresses: 
- https://linear.app/budibase/issue/BUDI-6856/fix-disabling-usergroup-edition-in-the-builder-on-first-load

## Screenshots
https://user-images.githubusercontent.com/15987277/232331833-718d82be-8262-4716-810a-fc83a3b6d680.mov

