### PR TITLE
Chore - Remove zlib npm references

### DIFF
--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -54,8 +54,7 @@
     "sanitize-s3-objectkey": "0.0.1",
     "semver": "7.3.7",
     "tar-fs": "2.1.1",
-    "uuid": "8.3.2",
-    "zlib": "1.0.5"
+    "uuid": "8.3.2"
   },
   "devDependencies": {
     "@jest/test-sequencer": "29.5.0",

--- a/packages/backend-core/src/objectStore/objectStore.ts
+++ b/packages/backend-core/src/objectStore/objectStore.ts
@@ -3,7 +3,7 @@ import AWS from "aws-sdk"
 import stream from "stream"
 import fetch from "node-fetch"
 import tar from "tar-fs"
-const zlib = require("zlib")
+import zlib from "zlib"
 import { promisify } from "util"
 import { join } from "path"
 import fs from "fs"
@@ -415,7 +415,7 @@ export const downloadTarballDirect = async (
     throw new Error(`unexpected response ${response.statusText}`)
   }
 
-  await streamPipeline(response.body, zlib.Unzip(), tar.extract(path))
+  await streamPipeline(response.body, zlib.createUnzip(), tar.extract(path))
 }
 
 export const downloadTarball = async (
@@ -431,7 +431,7 @@ export const downloadTarball = async (
   }
 
   const tmpPath = join(budibaseTempDir(), path)
-  await streamPipeline(response.body, zlib.Unzip(), tar.extract(tmpPath))
+  await streamPipeline(response.body, zlib.createUnzip(), tar.extract(tmpPath))
   if (!env.isTest() && env.SELF_HOSTED) {
     await uploadDirectory(bucketName, tmpPath, path)
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -118,8 +118,7 @@
     "vm2": "3.9.16",
     "worker-farm": "1.7.0",
     "xml2js": "0.5.0",
-    "yargs": "13.2.4",
-    "zlib": "1.0.5"
+    "yargs": "13.2.4"
   },
   "devDependencies": {
     "@babel/core": "7.17.4",

--- a/packages/worker/src/api/index.ts
+++ b/packages/worker/src/api/index.ts
@@ -1,6 +1,6 @@
 import Router from "@koa/router"
 const compress = require("koa-compress")
-const zlib = require("zlib")
+import zlib from "zlib"
 import { routes } from "./routes"
 import { middleware as pro } from "@budibase/pro"
 import { auth, middleware } from "@budibase/backend-core"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1486,14 +1486,15 @@
     pouchdb-promise "^6.0.4"
     through2 "^2.0.0"
 
-"@budibase/pro@2.5.4":
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.5.4.tgz#9368117a41b276ec97d3994e3ec67d9f2570a5bc"
-  integrity sha512-xPNVlRFTcjpWn+oZCvrfgDd9SoslkUgJsS2Bnff+qDoWcTFz30KoOyZPAkSwXxX3Y8FmZRO9csl0AZa9TsUs7A==
+"@budibase/pro@2.5.5-alpha.0":
+  version "2.5.5-alpha.0"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.5.5-alpha.0.tgz#28b075a96efb564328a4972cae9ea6c9a5f3aabc"
+  integrity sha512-98fLnvHWVy7ASEFC98bo6Qdd55SjC7yrJNuf7FUYZbeFwpmwwRxlWnWFTa0ctKWB5p2LToARWBns3TqgnUr/zQ==
   dependencies:
-    "@budibase/backend-core" "2.5.4"
-    "@budibase/string-templates" "2.3.20"
-    "@budibase/types" "2.5.4"
+    "@budibase/backend-core" "2.5.5-alpha.0"
+    "@budibase/shared-core" "2.4.44-alpha.1"
+    "@budibase/string-templates" "2.4.44-alpha.1"
+    "@budibase/types" "2.5.5-alpha.0"
     "@koa/router" "8.0.8"
     bull "4.10.1"
     joi "17.6.0"
@@ -1501,6 +1502,15 @@
     lru-cache "^7.14.1"
     memorystream "^0.3.1"
     node-fetch "^2.6.1"
+    scim-patch "^0.7.0"
+    scim2-parse-filter "^0.2.8"
+
+"@budibase/shared-core@2.4.44-alpha.1":
+  version "2.4.44-alpha.1"
+  resolved "https://registry.yarnpkg.com/@budibase/shared-core/-/shared-core-2.4.44-alpha.1.tgz#3d499e40e7e6c646e13a87cd08e01ba116c2ff1d"
+  integrity sha512-cN8LaDczijtsfWUYiXC4sg9Z+US4020i3Mb8TwCbf8TQyA1b06U5PwPCp+GHVA/wDFqfwcpcE1GXf8GwVuYs7A==
+  dependencies:
+    "@budibase/types" "2.4.44-alpha.1"
 
 "@budibase/standard-components@^0.9.139":
   version "0.9.139"
@@ -1520,10 +1530,10 @@
     svelte-apexcharts "^1.0.2"
     svelte-flatpickr "^3.1.0"
 
-"@budibase/string-templates@2.3.20":
-  version "2.3.20"
-  resolved "https://registry.yarnpkg.com/@budibase/string-templates/-/string-templates-2.3.20.tgz#35f74b6f515e8127cc375ee0a4679b0a7c117588"
-  integrity sha512-wMKau3IzVF6M+dRu99aKV1yMdrrK5lghVm9qYtR1B163SMbHEwC8JmZFGPLIi1XsG0T+vw+xfcemfJ2zcATWwg==
+"@budibase/string-templates@2.4.44-alpha.1":
+  version "2.4.44-alpha.1"
+  resolved "https://registry.yarnpkg.com/@budibase/string-templates/-/string-templates-2.4.44-alpha.1.tgz#6c2aee594d16eac1f173c509e087a817dd3172f0"
+  integrity sha512-4gC2+0kccK0ilLnd0i/dmJzC0Ur7UgSAmV6zbzDDYNL4spU0qSy5VhBh7E3qKieg5RKMMzbpXLMWERpoPLlnqA==
   dependencies:
     "@budibase/handlebars-helpers" "^0.11.8"
     dayjs "^1.10.4"
@@ -1531,6 +1541,11 @@
     handlebars-utils "^1.0.6"
     lodash "^4.17.20"
     vm2 "^3.9.4"
+
+"@budibase/types@2.4.44-alpha.1":
+  version "2.4.44-alpha.1"
+  resolved "https://registry.yarnpkg.com/@budibase/types/-/types-2.4.44-alpha.1.tgz#1679657aa180d9c59afa1dffa611bff0638bd933"
+  integrity sha512-Sq+8HfM75EBMoOvKYFwELdlxmVN6wNZMofDjT/2G+9aF+Zfe5Tzw69C+unmdBgcGGjGCHEYWSz4mF0v8FPAGbg==
 
 "@bull-board/api@3.7.0":
   version "3.7.0"
@@ -21169,7 +21184,7 @@ scim-patch@^0.7.0:
     fast-deep-equal "3.1.3"
     scim2-parse-filter "0.2.8"
 
-scim2-parse-filter@0.2.8:
+scim2-parse-filter@0.2.8, scim2-parse-filter@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/scim2-parse-filter/-/scim2-parse-filter-0.2.8.tgz#12e836514b9a55ae51218dd6e7fbea91daccfa4d"
   integrity sha512-1V+6FIMIiP+gDiFkC3dIw86KfoXhnQRXhfPaiQImeeFukpLtEkTtYq/Vmy1yDgHQcIHQxQQqOWyGLKX0FTvvaA==
@@ -24690,8 +24705,3 @@ z-schema@^5.0.1:
     validator "^13.7.0"
   optionalDependencies:
     commander "^10.0.0"
-
-zlib@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/zlib/-/zlib-1.0.5.tgz#6e7c972fc371c645a6afb03ab14769def114fcc0"
-  integrity sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w==


### PR DESCRIPTION
## Description
Remove references to the zlib npm package that caused some dev issues. This library is 12 years old, and deprecated and  