### PR TITLE
Add empty text property to all blocks

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -4966,6 +4966,17 @@
         "defaultValue": "spectrum--medium"
       },
       {
+        "type": "text",
+        "label": "Empty text",
+        "key": "noRowsMessage",
+        "defaultValue": "We couldn't find a row to display",
+        "dependsOn": {
+          "setting": "actionType",
+          "value": "Create",
+          "invert": true
+        }
+      },
+      {
         "section": true,
         "name": "Fields",
         "settings": [

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -4547,6 +4547,12 @@
         "key": "paginate"
       },
       {
+        "type": "text",
+        "label": "Empty text",
+        "key": "noRowsMessage",
+        "defaultValue": "No rows found"
+      },
+      {
         "section": true,
         "name": "Cards",
         "settings": [

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -5085,6 +5085,12 @@
         "defaultValue": "426px"
       },
       {
+        "type": "text",
+        "label": "Empty text",
+        "key": "noRowsMessage",
+        "defaultValue": "No data"
+      },
+      {
         "section": true,
         "name": "Cards",
         "settings": [

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -3662,6 +3662,12 @@
         "info": "Row selection is only compatible with internal or SQL tables"
       },
       {
+        "type": "text",
+        "label": "Empty text",
+        "key": "noRowsMessage",
+        "defaultValue": "No rows found"
+      },
+      {
         "section": true,
         "name": "On Row Click",
         "settings": [
@@ -4374,6 +4380,12 @@
             "label": "Filtering",
             "key": "filter",
             "nested": true
+          },
+          {
+            "type": "text",
+            "label": "Empty text",
+            "key": "noRowsMessage",
+            "defaultValue": "No rows found"
           },
           {
             "type": "searchfield",

--- a/packages/client/src/components/app/blocks/CardsBlock.svelte
+++ b/packages/client/src/components/app/blocks/CardsBlock.svelte
@@ -29,6 +29,7 @@
   export let cardButtonText
   export let cardButtonOnClick
   export let linkColumn
+  export let noRowsMessage = "No rows found"
 
   const { fetchDatasourceSchema } = getContext("sdk")
 
@@ -180,7 +181,7 @@
             hAlign: "stretch",
             vAlign: "top",
             gap: "M",
-            noRowsMessage: "No rows found",
+            noRowsMessage,
           }}
           styles={{
             custom: `display: grid;\ngrid-template-columns: repeat(auto-fill, minmax(min(${cardWidth}px, 100%), 1fr));`,

--- a/packages/client/src/components/app/blocks/CardsBlock.svelte
+++ b/packages/client/src/components/app/blocks/CardsBlock.svelte
@@ -29,7 +29,7 @@
   export let cardButtonText
   export let cardButtonOnClick
   export let linkColumn
-  export let noRowsMessage = "No rows found"
+  export let noRowsMessage
 
   const { fetchDatasourceSchema } = getContext("sdk")
 
@@ -181,7 +181,7 @@
             hAlign: "stretch",
             vAlign: "top",
             gap: "M",
-            noRowsMessage,
+            noRowsMessage: noRowsMessage || "No rows found",
           }}
           styles={{
             custom: `display: grid;\ngrid-template-columns: repeat(auto-fill, minmax(min(${cardWidth}px, 100%), 1fr));`,

--- a/packages/client/src/components/app/blocks/RowExplorer.svelte
+++ b/packages/client/src/components/app/blocks/RowExplorer.svelte
@@ -16,7 +16,7 @@
   export let detailFields
   export let detailTitle
 
-  export let noRowsMessage = "No data"
+  export let noRowsMessage
 
   const stateKey = generate()
 
@@ -107,7 +107,7 @@
           dataProvider: `{{ literal ${safe(listDataProviderId)} }}`,
           direction: "column",
           gap: "S",
-          noRowsMessage,
+          noRowsMessage: noRowsMessage || "No data",
         }}
       >
         <BlockComponent

--- a/packages/client/src/components/app/blocks/RowExplorer.svelte
+++ b/packages/client/src/components/app/blocks/RowExplorer.svelte
@@ -16,6 +16,8 @@
   export let detailFields
   export let detailTitle
 
+  export let noRowsMessage = "No data"
+
   const stateKey = generate()
 
   let listDataProviderId
@@ -105,7 +107,7 @@
           dataProvider: `{{ literal ${safe(listDataProviderId)} }}`,
           direction: "column",
           gap: "S",
-          noRowsMessage: "No data",
+          noRowsMessage,
         }}
       >
         <BlockComponent

--- a/packages/client/src/components/app/blocks/TableBlock.svelte
+++ b/packages/client/src/components/app/blocks/TableBlock.svelte
@@ -25,6 +25,7 @@
   export let titleButtonText
   export let titleButtonClickBehaviour
   export let onClickTitleButton
+  export let noRowsMessage = "No rows found"
 
   const { fetchDatasourceSchema, API } = getContext("sdk")
   const stateKey = `ID_${generate()}`
@@ -221,6 +222,7 @@
             allowSelectRows,
             size,
             onClick: rowClickActions,
+            noRowsMessage,
           }}
         />
       </BlockComponent>

--- a/packages/client/src/components/app/blocks/TableBlock.svelte
+++ b/packages/client/src/components/app/blocks/TableBlock.svelte
@@ -25,7 +25,7 @@
   export let titleButtonText
   export let titleButtonClickBehaviour
   export let onClickTitleButton
-  export let noRowsMessage = "No rows found"
+  export let noRowsMessage
 
   const { fetchDatasourceSchema, API } = getContext("sdk")
   const stateKey = `ID_${generate()}`
@@ -222,7 +222,7 @@
             allowSelectRows,
             size,
             onClick: rowClickActions,
-            noRowsMessage,
+            noRowsMessage: noRowsMessage || "No rows found",
           }}
         />
       </BlockComponent>

--- a/packages/client/src/components/app/blocks/form/FormBlock.svelte
+++ b/packages/client/src/components/app/blocks/form/FormBlock.svelte
@@ -16,6 +16,7 @@
   export let showDeleteButton
   export let rowId
   export let actionUrl
+  export let noRowsMessage = "We couldn't find a row to display"
 
   const { fetchDatasourceSchema } = getContext("sdk")
 
@@ -89,7 +90,7 @@
         bind:id={repeaterId}
         props={{
           dataProvider,
-          noRowsMessage: "We couldn't find a row to display",
+          noRowsMessage,
           direction: "column",
           hAlign: "center",
         }}

--- a/packages/client/src/components/app/blocks/form/FormBlock.svelte
+++ b/packages/client/src/components/app/blocks/form/FormBlock.svelte
@@ -16,7 +16,7 @@
   export let showDeleteButton
   export let rowId
   export let actionUrl
-  export let noRowsMessage = "We couldn't find a row to display"
+  export let noRowsMessage
 
   const { fetchDatasourceSchema } = getContext("sdk")
 
@@ -90,7 +90,7 @@
         bind:id={repeaterId}
         props={{
           dataProvider,
-          noRowsMessage,
+          noRowsMessage: noRowsMessage || "We couldn't find a row to display",
           direction: "column",
           hAlign: "center",
         }}

--- a/packages/client/src/components/app/table/Table.svelte
+++ b/packages/client/src/components/app/table/Table.svelte
@@ -13,6 +13,7 @@
   export let allowSelectRows
   export let compact
   export let onClick
+  export let noRowsMessage = "No rows found"
 
   const component = getContext("component")
   const { styleable, getAction, ActionTypes, rowSelectionStore } =
@@ -144,6 +145,7 @@
     autoSortColumns={!columns?.length}
     on:sort={onSort}
     on:click={handleClick}
+    placeholderText={noRowsMessage}
   >
     <slot />
   </Table>

--- a/packages/client/src/components/app/table/Table.svelte
+++ b/packages/client/src/components/app/table/Table.svelte
@@ -13,7 +13,7 @@
   export let allowSelectRows
   export let compact
   export let onClick
-  export let noRowsMessage = "No rows found"
+  export let noRowsMessage
 
   const component = getContext("component")
   const { styleable, getAction, ActionTypes, rowSelectionStore } =
@@ -145,7 +145,7 @@
     autoSortColumns={!columns?.length}
     on:sort={onSort}
     on:click={handleClick}
-    placeholderText={noRowsMessage}
+    placeholderText={noRowsMessage || "No rows found"}
   >
     <slot />
   </Table>


### PR DESCRIPTION
## Description
Users wanted to customise the *No rows founds* message in the following:

 - Row Explorer
 - Form Block
 - Table Block
 - Table
 - Cards Block

Addresses: 
- https://github.com/Budibase/budibase/issues/7299

## App Export
[Data Provider message-export-1681816189015.tar.gz](https://github.com/Budibase/budibase/files/11261013/Data.Provider.message-export-1681816189015.tar.gz)

## Screenshots

**Row Explorer**
![Screenshot 2023-04-18 at 12 11 43](https://user-images.githubusercontent.com/101575380/232759824-1d4097ad-1624-473f-9de5-1e15b11ab7a5.png)

![Screenshot 2023-04-18 at 12 12 06](https://user-images.githubusercontent.com/101575380/232759916-479a5b1a-ecf2-43e0-bb31-6259e56f6934.png)

**Cards Block**
![Screenshot 2023-04-18 at 12 13 24](https://user-images.githubusercontent.com/101575380/232760168-cc09495c-8a13-473b-854a-39570c497eea.png)

**Table Block**
![Screenshot 2023-04-18 at 12 14 04](https://user-images.githubusercontent.com/101575380/232760331-cbf67332-98a6-4028-a27e-0be91f46ee24.png)

**Form Block**
![Screenshot 2023-04-18 at 12 14 52](https://user-images.githubusercontent.com/101575380/232760497-8354f7a4-ec8a-47fe-ad03-87961bacdd0a.png)

*Setting only shows when Update/View is selected*

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



