### PR TITLE
Hotfix - Increase writethrough cache timeout

### DIFF
--- a/packages/backend-core/src/cache/writethrough.ts
+++ b/packages/backend-core/src/cache/writethrough.ts
@@ -47,7 +47,7 @@ async function put(
         type: LockType.TRY_ONCE,
         name: LockName.PERSIST_WRITETHROUGH,
         resource: key,
-        ttl: 1000,
+        ttl: 15000,
       },
       async () => {
         const writeDb = async (toWrite: any) => {
@@ -71,6 +71,7 @@ async function put(
         }
       }
     )
+
     if (!lockResponse.executed) {
       logWarn(`Ignoring redlock conflict in write-through cache`)
     }


### PR DESCRIPTION
## Description
Increase the redlock TTL of writethrough cache. It's currently set at 1 second, and some users are reporting that it's timing out. This might be occurring in instances running on slow machines or with heavy CPU usage.

The issue was just "cosmetic", as the current usages of `writethrough` have eventual consistency and the right data will be retried.

This started happening because of this [PR](https://github.com/Budibase/budibase/pull/9835), configuring the redlock.

Addresses: 
- https://github.com/Budibase/budibase/issues/10270


