### PR TITLE
Allow SQL formulas using related row information to be used as display columns

### DIFF
--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -391,8 +391,9 @@ export class ExternalRequest {
           }
         }
         relatedRow = processFormulas(linkedTable, relatedRow)
+        const relatedDisplay = display ? relatedRow[display] : undefined
         row[relationship.column][key] = {
-          primaryDisplay: display ? relatedRow[display] : undefined,
+          primaryDisplay: relatedDisplay || "Invalid display column",
           _id: relatedRow._id,
         }
       }

--- a/packages/server/src/integration-test/postgres.spec.ts
+++ b/packages/server/src/integration-test/postgres.spec.ts
@@ -921,6 +921,7 @@ describe("row api - postgres", () => {
             [m2mFieldName]: [
               {
                 _id: row._id,
+                primaryDisplay: "Invalid display column",
               },
             ],
           })
@@ -929,6 +930,7 @@ describe("row api - postgres", () => {
             [m2mFieldName]: [
               {
                 _id: row._id,
+                primaryDisplay: "Invalid display column",
               },
             ],
           })

--- a/packages/server/src/integrations/base/sqlTable.ts
+++ b/packages/server/src/integrations/base/sqlTable.ts
@@ -79,10 +79,17 @@ function generateSchema(
           if (!relatedTable) {
             throw "Referenced table doesn't exist"
           }
-          schema.integer(column.foreignKey).unsigned()
+          const relatedPrimary = relatedTable.primary[0]
+          const externalType = relatedTable.schema[relatedPrimary].externalType
+          if (externalType) {
+            schema.specificType(column.foreignKey, externalType)
+          } else {
+            schema.integer(column.foreignKey).unsigned()
+          }
+
           schema
             .foreign(column.foreignKey)
-            .references(`${tableName}.${relatedTable.primary[0]}`)
+            .references(`${tableName}.${relatedPrimary}`)
         }
         break
     }

--- a/packages/server/src/utilities/rowProcessor/utils.ts
+++ b/packages/server/src/utilities/rowProcessor/utils.ts
@@ -1,11 +1,11 @@
 import {
-  FieldTypes,
-  FormulaTypes,
   AutoFieldDefaultNames,
   AutoFieldSubTypes,
+  FieldTypes,
+  FormulaTypes,
 } from "../../constants"
 import { processStringSync } from "@budibase/string-templates"
-import { FieldSchema, Table, Row } from "@budibase/types"
+import { FieldSchema, FieldType, Row, Table } from "@budibase/types"
 
 /**
  * If the subtype has been lost for any reason this works out what
@@ -50,6 +50,7 @@ export function processFormulas(
     const isStatic = schema.formulaType === FormulaTypes.STATIC
     if (
       schema.type !== FieldTypes.FORMULA ||
+      schema.formula == null ||
       (dynamic && isStatic) ||
       (!dynamic && !isStatic)
     ) {
@@ -57,13 +58,11 @@ export function processFormulas(
     }
     // iterate through rows and process formula
     for (let i = 0; i < rowArray.length; i++) {
-      if (schema.formula) {
-        let row = rowArray[i]
-        let context = contextRows ? contextRows[i] : row
-        rowArray[i] = {
-          ...row,
-          [column]: processStringSync(schema.formula, context),
-        }
+      let row = rowArray[i]
+      let context = contextRows ? contextRows[i] : row
+      rowArray[i] = {
+        ...row,
+        [column]: processStringSync(schema.formula, context),
       }
     }
   }


### PR DESCRIPTION
## Description
Fixing issue with SQL tables and using formulas that contain relationships as display columns. Also cleaning up imports in ExternalRequests a bit.

Also fixes an issue with creating relationships between existing tables, previously the SQL column generation always assumed a unsigned integer for foreign key types, this tries to match up with an existing primary key types.

Addresses: 
- https://github.com/Budibase/budibase/issues/10349