### PR TITLE
allow ssl-policy annotation in helm chart

### DIFF
--- a/charts/budibase/templates/alb-ingress.yaml
+++ b/charts/budibase/templates/alb-ingress.yaml
@@ -14,6 +14,9 @@ metadata:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn }} 
     {{- end }}
+    {{- if .Values.ingress.sslPolicy }}
+    alb.ingress.kubernetes.io/actions.ssl-policy: {{ .Values.ingress.sslPolicy }}
+    {{- end }}
     {{- if .Values.ingress.securityGroups }}
     alb.ingress.kubernetes.io/security-groups: {{ .Values.ingress.securityGroups }}
     {{- end }}


### PR DESCRIPTION
Allow the optional specifying of SSL policy to use on the ALB for Kubernetes.
The default policy (if none is specified) supports old TLS versions (e.g. v1).
We would like to specify a more updated policy in our values files e.g. `ELBSecurityPolicy-TLS13-1-2-2021-06`