### PR TITLE
Dynamic filter contains option

### DIFF
--- a/packages/backend-core/src/db/lucene.ts
+++ b/packages/backend-core/src/db/lucene.ts
@@ -309,7 +309,7 @@ export class QueryBuilder<T> {
         return null
       }
       if (!Array.isArray(value)) {
-        return `${key}:/${value?.toLowerCase()}/`
+        return `${key}:/.*${value?.toLowerCase()}.*/`
       }
       let statement = `${builder.preprocess(value[0], { escape: true })}`
       for (let i = 1; i < value.length; i++) {

--- a/packages/backend-core/src/db/lucene.ts
+++ b/packages/backend-core/src/db/lucene.ts
@@ -309,7 +309,7 @@ export class QueryBuilder<T> {
         return null
       }
       if (!Array.isArray(value)) {
-        return `${key}:${value}`
+        return `${key}:/${value?.toLowerCase()}/`
       }
       let statement = `${builder.preprocess(value[0], { escape: true })}`
       for (let i = 1; i < value.length; i++) {

--- a/packages/backend-core/src/db/lucene.ts
+++ b/packages/backend-core/src/db/lucene.ts
@@ -309,7 +309,7 @@ export class QueryBuilder<T> {
         return null
       }
       if (!Array.isArray(value)) {
-        return `${key}:/.*${value?.toLowerCase()}.*/`
+        return `${key}:${value}`
       }
       let statement = `${builder.preprocess(value[0], { escape: true })}`
       for (let i = 1; i < value.length; i++) {
@@ -318,6 +318,18 @@ export class QueryBuilder<T> {
         })}`
       }
       return `${key}:(${statement})`
+    }
+
+    const fuzzy = (key: string, value: any) => {
+      if (!value) {
+        return null
+      }
+      value = builder.preprocess(value, {
+        escape: true,
+        lowercase: true,
+        type: "fuzzy",
+      })
+      return `${key}:/.*${value}.*/`
     }
 
     const notContains = (key: string, value: any) => {
@@ -408,17 +420,7 @@ export class QueryBuilder<T> {
       })
     }
     if (this.#query.fuzzy) {
-      build(this.#query.fuzzy, (key: string, value: any) => {
-        if (!value) {
-          return null
-        }
-        value = builder.preprocess(value, {
-          escape: true,
-          lowercase: true,
-          type: "fuzzy",
-        })
-        return `${key}:${value}~`
-      })
+      build(this.#query.fuzzy, fuzzy)
     }
     if (this.#query.equal) {
       build(this.#query.equal, equal)

--- a/packages/backend-core/src/db/lucene.ts
+++ b/packages/backend-core/src/db/lucene.ts
@@ -243,7 +243,7 @@ export class QueryBuilder<T> {
     }
     // Escape characters
     if (!this.#noEscaping && escape && originalType === "string") {
-      value = `${value}`.replace(/[ #+\-&|!(){}\]^"~*?:\\]/g, "\\$&")
+      value = `${value}`.replace(/[ \/#+\-&|!(){}\]^"~*?:\\]/g, "\\$&")
     }
 
     // Wrap in quotes

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -22,6 +22,7 @@ export const getValidOperatorsForType = (
     Op.Empty,
     Op.NotEmpty,
     Op.In,
+    Op.Contains,
   ]
   const numOps = [
     Op.Equals,

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -22,7 +22,6 @@ export const getValidOperatorsForType = (
     Op.Empty,
     Op.NotEmpty,
     Op.In,
-    Op.Contains,
   ]
   const numOps = [
     Op.Equals,
@@ -55,13 +54,8 @@ export const getValidOperatorsForType = (
     ops = stringOps.concat([Op.MoreThan, Op.LessThan])
   }
 
-  // Filter out "like" for internal tables
-  const externalTable = datasource?.tableId?.includes("datasource_plus")
-  if (datasource?.type === "table" && !externalTable) {
-    ops = ops.filter(x => x !== Op.Like)
-  }
-
   // Only allow equal/not equal for _id in SQL tables
+  const externalTable = datasource?.tableId?.includes("datasource_plus")
   if (field === "_id" && externalTable) {
     ops = [Op.Equals, Op.NotEquals, Op.In]
   }


### PR DESCRIPTION
## Description
Updated the **Like** filter for the Internal DB lucene search to use regex that matches the equivalent syntax of the like statements in SQL.

There were issues raised in the past and it was removed in the end:
 - https://github.com/Budibase/budibase/issues/3386
 - https://github.com/Budibase/budibase/pull/9030

But I can't see any reason not to use regex here?

Addresses: 
- https://github.com/Budibase/budibase/issues/5995

## Screenshots

**Table block filters**
![Screenshot 2023-04-20 at 18 19 22](https://user-images.githubusercontent.com/101575380/233440978-c2a83f22-9d24-4be9-a8ea-d7592fda7eba.png)

![Screenshot 2023-04-20 at 18 19 47](https://user-images.githubusercontent.com/101575380/233441053-d071c3bf-2bca-41b2-b31e-290114464507.png)

**Dynamic filter**
![Screenshot 2023-04-20 at 18 23 20](https://user-images.githubusercontent.com/101575380/233441722-5fc8f39b-34c5-45a8-88a4-1d7eacfbaa81.png)

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



