### PR TITLE
Fix options inclusion constraint regression

### DIFF
--- a/packages/server/src/api/controllers/table/utils.ts
+++ b/packages/server/src/api/controllers/table/utils.ts
@@ -110,19 +110,25 @@ export function importToRows(
   table: Table,
   user: ContextUser | null = null
 ) {
+  let originalTable = table
   let finalData: any = []
   for (let i = 0; i < data.length; i++) {
     let row = data[i]
     row._id = generateRowID(table._id!)
     row.tableId = table._id
+
+    // We use a reference to table here and update it after input processing,
+    // so that we can auto increment auto IDs in imported data properly
     const processed = inputProcessing(user, table, row, {
       noAutoRelationships: true,
     })
     row = processed.row
     table = processed.table
 
-    for (const [fieldName, schema] of Object.entries(table.schema)) {
-      // check whether the options need to be updated for inclusion as part of the data import
+    // However here we must reference the original table, as we want to mutate
+    // the real schema of the table passed in, not the clone used for
+    // incrementing auto IDs
+    for (const [fieldName, schema] of Object.entries(originalTable.schema)) {
       if (
         (schema.type === FieldTypes.OPTIONS ||
           schema.type === FieldTypes.ARRAY) &&


### PR DESCRIPTION
## Description
This PR fixes a recent regression where options inclusions constraints were not being generated when importing data. This meant that importing data with options columns was generating empty schemas.

I originally fixed this bug a few months ago here: https://github.com/Budibase/budibase/pull/9647. This PR had the side effect of breaking auto IDs not incrementing properly when importing data, causing the sample data to always have IDs of 1.

A change was made to restore auto ID functionality here: https://github.com/Budibase/budibase/pull/10141 (master) and here: https://github.com/Budibase/budibase/pull/10162 (develop). Both of these changes effectively undid my original fix, causing inclusion constraints to no longer be generated.

This PR fixes both the original issue while also still allowing auto ID incrementing to work.

The real outcome of all these PRs is the lesson that the way the `importToRows` function works, in combination with a mutated table clone being returned from `inputProcessing` is both confusing and very bug prone.

## Proof
Newly generated app with sample data, showing correct auto IDs:
<img width="212" alt="image" src="https://user-images.githubusercontent.com/9075550/233466653-ff3f14eb-de3b-41b3-8820-c8350d81e0fe.png">

Newly imported CSV, using an options column, showing the inclusion constraint has been generated successfully:
<img width="475" alt="image" src="https://user-images.githubusercontent.com/9075550/233467063-b0045440-5049-47ba-88a6-beb5083835d9.png">


