### PR TITLE
Set default enum values in automations

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -67,6 +67,15 @@
       newInputData = cloneDeep(blockInputs)
     }
     inputData = newInputData
+    setDefaultEnumValues()
+  }
+
+  const setDefaultEnumValues = () => {
+    for (const [key, value] of schemaProperties) {
+      if (value.type === "string" && value.enum && inputData[key] == null) {
+        inputData[key] = value.enum[0]
+      }
+    }
   }
 
   const onChange = Utils.sequential(async (e, key) => {
@@ -243,6 +252,7 @@
         <Select
           on:change={e => onChange(e, key)}
           value={inputData[key]}
+          placeholder={false}
           options={value.enum}
           getOptionLabel={(x, idx) => (value.pretty ? value.pretty[idx] : x)}
         />


### PR DESCRIPTION
## Description
Previously it was possible to save automations without a *When Filter Empty* options chosen. Whilst it would correctly default to 'Return all rows', it was not clear from screenshots / investigating users apps what the output would be.

Placeholder has also been removed for enum selects -> a value must always be set.

Addresses: 
- https://github.com/Budibase/budibase/issues/9529

## Screenshots
![Screenshot 2023-04-21 at 10 13 13](https://user-images.githubusercontent.com/101575380/233597050-0d2f9264-8e65-4380-9527-0696570023c5.png)

![Screenshot 2023-04-21 at 10 13 44](https://user-images.githubusercontent.com/101575380/233597150-4e2b9a99-dc3f-4a2d-872b-aca3d337328d.png)

![Screenshot 2023-04-21 at 10 14 00](https://user-images.githubusercontent.com/101575380/233597217-3cad2bc9-3921-4ff2-8978-4e3a5a700552.png)


## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



