### PR TITLE
Integration testing fixes

### DIFF
--- a/packages/backend-core/src/migrations/definitions.ts
+++ b/packages/backend-core/src/migrations/definitions.ts
@@ -36,9 +36,5 @@ export const DEFINITIONS: MigrationDefinition[] = [
   {
     type: MigrationType.GLOBAL,
     name: MigrationName.GLOBAL_INFO_SYNC_USERS,
-  },
-  {
-    type: MigrationType.GLOBAL,
-    name: MigrationName.SYNC_USERS,
-  },
+  }
 ]

--- a/packages/builder/src/components/portal/licensing/constants.js
+++ b/packages/builder/src/components/portal/licensing/constants.js
@@ -15,7 +15,3 @@ export const StripeStatus = {
   ACTIVE: "active",
 }
 
-export const PlanModel = {
-  PER_USER: "perUser",
-  DAY_PASS: "dayPass",
-}

--- a/packages/builder/src/constants/index.js
+++ b/packages/builder/src/constants/index.js
@@ -67,3 +67,8 @@ export const OnboardingType = {
   EMAIL: "email",
   PASSWORD: "password",
 }
+
+export const PlanModel = {
+  PER_USER: "perUser",
+  DAY_PASS: "dayPass",
+}

--- a/packages/builder/src/pages/builder/portal/account/upgrade.svelte
+++ b/packages/builder/src/pages/builder/portal/account/upgrade.svelte
@@ -128,7 +128,7 @@
           />
         </div>
       </div>
-      <ButtonGroup>
+      <ButtonGroup gap="M">
         <Button cta on:click={activate} disabled={activateDisabled}>
           Activate
         </Button>

--- a/packages/builder/src/pages/builder/portal/account/usage.svelte
+++ b/packages/builder/src/pages/builder/portal/account/usage.svelte
@@ -13,6 +13,7 @@
   import { admin, auth, licensing } from "stores/portal"
   import { Constants } from "@budibase/frontend-core"
   import { DashCard, Usage } from "components/usage"
+  import { PlanModel } from "constants"
 
   let staticUsage = []
   let monthlyUsage = []
@@ -25,8 +26,21 @@
   const upgradeUrl = `${$admin.accountPortalUrl}/portal/upgrade`
   const manageUrl = `${$admin.accountPortalUrl}/portal/billing`
 
-  const WARN_USAGE = ["Queries", "Automations", "Rows", "Day Passes"]
-  const EXCLUDE_QUOTAS = ["Queries"]
+  const WARN_USAGE = ["Queries", "Automations", "Rows", "Day Passes", "Users"]
+
+  const EXCLUDE_QUOTAS = {
+    Queries: () => true,
+    Users: license => {
+      return license.plan.model !== PlanModel.PER_USER
+    },
+    "Day Passes": license => {
+      return license.plan.model !== PlanModel.DAY_PASS
+    },
+  }
+
+  function excludeQuota(name) {
+    return EXCLUDE_QUOTAS[name] && EXCLUDE_QUOTAS[name](license)
+  }
 
   $: quotaUsage = $licensing.quotaUsage
   $: license = $auth.user?.license
@@ -39,7 +53,7 @@
     monthlyUsage = []
     if (quotaUsage.monthly) {
       for (let [key, value] of Object.entries(license.quotas.usage.monthly)) {
-        if (EXCLUDE_QUOTAS.includes(value.name)) {
+        if (excludeQuota(value.name)) {
           continue
         }
         const used = quotaUsage.monthly.current[key]
@@ -58,7 +72,7 @@
   const setStaticUsage = () => {
     staticUsage = []
     for (let [key, value] of Object.entries(license.quotas.usage.static)) {
-      if (EXCLUDE_QUOTAS.includes(value.name)) {
+      if (excludeQuota(value.name)) {
         continue
       }
       const used = quotaUsage.usageQuota[key]
@@ -84,7 +98,7 @@
   }
 
   const planTitle = () => {
-    return capitalise(license?.plan.type)
+    return `${capitalise(license?.plan.type)} Plan`
   }
 
   const getDaysRemaining = timestamp => {

--- a/packages/server/src/migrations/functions/usageQuotas/syncUsers.ts
+++ b/packages/server/src/migrations/functions/usageQuotas/syncUsers.ts
@@ -3,10 +3,7 @@ import { quotas } from "@budibase/pro"
 import { QuotaUsageType, StaticQuotaName } from "@budibase/types"
 
 export const run = async () => {
-  // get user
   const userCount = await users.getUserCount()
-
-  // sync app count
   console.log(`Syncing user count: ${userCount}`)
   await quotas.setUsage(userCount, StaticQuotaName.USERS, QuotaUsageType.STATIC)
 }

--- a/packages/server/src/migrations/index.ts
+++ b/packages/server/src/migrations/index.ts
@@ -83,13 +83,6 @@ export const buildMigrations = () => {
         })
         break
       }
-      case MigrationName.SYNC_USERS: {
-        serverMigrations.push({
-          ...definition,
-          fn: syncUsers.run,
-        })
-        break
-      }
     }
   }
 

--- a/packages/types/src/sdk/migrations.ts
+++ b/packages/types/src/sdk/migrations.ts
@@ -47,7 +47,6 @@ export enum MigrationName {
   TABLE_SETTINGS_LINKS_TO_ACTIONS = "table_settings_links_to_actions",
   // increment this number to re-activate this migration
   SYNC_QUOTAS = "sync_quotas_1",
-  SYNC_USERS = "sync_users",
 }
 
 export interface MigrationDefinition {


### PR DESCRIPTION
## Description

Related:
- https://github.com/Budibase/account-portal/pull/316
- https://github.com/Budibase/budibase-pro/pull/170

Usage page:
- Add users to warn usage, so we see a red bar when it is at 100%
- Show day passes when on day pass plan and users when on per user plan

User count sync:
- Don't sync user count to quotas as migration - this results in a time period where license requests may or may not have the value on new installs. Corresponding pr in pro syncs the user count for the first time on license retrieval if not already set


