### PR TITLE
Fix automation history first load in multi-tenant environments

### DIFF
--- a/packages/builder/src/api.js
+++ b/packages/builder/src/api.js
@@ -5,12 +5,16 @@ import {
 } from "@budibase/frontend-core"
 import { store } from "./builderStore"
 import { get } from "svelte/store"
-import { auth } from "./stores/portal"
+import { auth, overview } from "./stores/portal"
 
 export const API = createAPIClient({
   attachHeaders: headers => {
     // Attach app ID header from store
-    headers["x-budibase-app-id"] = get(store).appId
+    let appId = get(store).appId
+    if (!appId) {
+      appId = get(overview).selectedAppId
+    }
+    headers["x-budibase-app-id"] = appId
 
     // Add csrf token if authenticated
     const user = get(auth).user

--- a/packages/builder/src/api.js
+++ b/packages/builder/src/api.js
@@ -5,12 +5,12 @@ import {
 } from "@budibase/frontend-core"
 import { store } from "./builderStore"
 import { get } from "svelte/store"
-import { auth, overview } from "./stores/portal"
+import { auth } from "./stores/portal"
 
 export const API = createAPIClient({
   attachHeaders: headers => {
     // Attach app ID header from store
-    let appId = get(store).appId || get(overview).selectedAppId
+    let appId = get(store).appId
     if (appId) {
       headers["x-budibase-app-id"] = appId
     }

--- a/packages/builder/src/api.js
+++ b/packages/builder/src/api.js
@@ -10,11 +10,10 @@ import { auth, overview } from "./stores/portal"
 export const API = createAPIClient({
   attachHeaders: headers => {
     // Attach app ID header from store
-    let appId = get(store).appId
-    if (!appId) {
-      appId = get(overview).selectedAppId
+    let appId = get(store).appId || get(overview).selectedAppId
+    if (appId) {
+      headers["x-budibase-app-id"] = appId
     }
-    headers["x-budibase-app-id"] = appId
 
     // Add csrf token if authenticated
     const user = get(auth).user

--- a/packages/builder/src/pages/builder/portal/overview/[appId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/portal/overview/[appId]/_layout.svelte
@@ -33,7 +33,7 @@
   import * as routify from "@roxi/routify"
   import { onDestroy } from "svelte"
 
-  // Keep URL and state in sync for selected screen ID
+  // Keep URL and state in sync for selected app ID
   const stopSyncing = syncURLToState({
     urlParam: "appId",
     stateKey: "selectedAppId",
@@ -111,6 +111,10 @@
   onDestroy(() => {
     stopSyncing()
     store.actions.reset()
+    overview.update(state => ({
+      ...state,
+      selectedAppId: null,
+    }))
   })
 </script>
 

--- a/packages/builder/src/pages/builder/portal/overview/[appId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/portal/overview/[appId]/_layout.svelte
@@ -47,6 +47,7 @@
   let deletionModal
   let exportPublishedVersion = false
   let deletionConfirmationAppName
+  let loaded = false
 
   $: app = $overview.selectedApp
   $: appId = $overview.selectedAppId
@@ -56,10 +57,12 @@
   $: lockedByYou = $auth.user.email === app?.lockedBy?.email
 
   const initialiseApp = async appId => {
+    loaded = false
     try {
       const pkg = await API.fetchAppPackage(appId)
       await store.actions.initialise(pkg)
       await API.syncApp(appId)
+      loaded = true
     } catch (error) {
       notifications.error("Error initialising app overview")
       $goto("../../")
@@ -111,10 +114,6 @@
   onDestroy(() => {
     stopSyncing()
     store.actions.reset()
-    overview.update(state => ({
-      ...state,
-      selectedAppId: null,
-    }))
   })
 </script>
 
@@ -232,7 +231,9 @@
             active={$isActive("./version")}
           />
         </SideNav>
-        <slot />
+        {#if loaded}
+          <slot />
+        {/if}
       </Content>
     </Layout>
   </Page>


### PR DESCRIPTION
## Description
Fix for #10403 - when app overview loads, sometimes old store doesn't get a valid app ID.

Addresses: 
- https://github.com/Budibase/budibase/issues/10403
- https://linear.app/budibase/issue/BUDI-6920/automation-history-fails-in-cloud-with-http-500