### PR TITLE
More grid tweaks

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/grid/GridCreateEditRowModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/grid/GridCreateEditRowModal.svelte
@@ -1,13 +1,18 @@
 <script>
   import CreateEditRow from "../../modals/CreateEditRow.svelte"
   import { getContext, onMount } from "svelte"
-  import { Modal } from "@budibase/bbui"
+  import { Modal, notifications } from "@budibase/bbui"
   import { cloneDeep } from "lodash/fp"
 
   const { subscribe, rows } = getContext("grid")
 
   let modal
   let row
+
+  const deleteRow = e => {
+    rows.actions.deleteRows([e.detail])
+    notifications.success("Deleted 1 row")
+  }
 
   onMount(() =>
     subscribe("add-row", () => {
@@ -24,5 +29,9 @@
 </script>
 
 <Modal bind:this={modal}>
-  <CreateEditRow {row} on:updaterows={e => rows.actions.refreshRow(e.detail)} />
+  <CreateEditRow
+    {row}
+    on:updaterows={e => rows.actions.refreshRow(e.detail)}
+    on:deleteRows={deleteRow}
+  />
 </Modal>

--- a/packages/frontend-core/src/components/grid/cells/DataCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/DataCell.svelte
@@ -48,8 +48,8 @@
   }
 
   const cellAPI = {
-    focus: () => api?.focus(),
-    blur: () => api?.blur(),
+    focus: () => api?.focus?.(),
+    blur: () => api?.blur?.(),
     isActive: () => api?.isActive?.() ?? false,
     onKeyDown: (...params) => api?.onKeyDown(...params),
     isReadonly: () => readonly,

--- a/packages/frontend-core/src/components/grid/cells/GutterCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/GutterCell.svelte
@@ -113,11 +113,15 @@
   }
   .expand {
     opacity: 0;
-    pointer-events: none;
     margin-right: 4px;
+  }
+  .expand :global(.spectrum-Icon) {
+    pointer-events: none;
   }
   .expand.visible {
     opacity: 1;
+  }
+  .expand.visible :global(.spectrum-Icon) {
     pointer-events: all;
   }
 </style>

--- a/packages/frontend-core/src/components/grid/cells/HeaderCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/HeaderCell.svelte
@@ -93,6 +93,16 @@
     columns.actions.changePrimaryDisplay(column.name)
     open = false
   }
+
+  const hideColumn = () => {
+    columns.update(state => {
+      const index = state.findIndex(col => col.name === column.name)
+      state[index].visible = false
+      return state.slice()
+    })
+    columns.actions.saveChanges()
+    open = false
+  }
 </script>
 
 <div
@@ -184,6 +194,7 @@
     <MenuItem disabled={!canMoveRight} icon="ChevronRight" on:click={moveRight}>
       Move right
     </MenuItem>
+    <MenuItem icon="VisibilityOff" on:click={hideColumn}>Hide column</MenuItem>
   </Menu>
 </Popover>
 

--- a/packages/frontend-core/src/components/grid/controls/HideColumnsButton.svelte
+++ b/packages/frontend-core/src/components/grid/controls/HideColumnsButton.svelte
@@ -57,7 +57,7 @@
     <div class="columns">
       {#if $stickyColumn}
         <Toggle disabled size="S" value={true} />
-        <span>{$stickyColumn.name}</span>
+        <span>{$stickyColumn.label}</span>
       {/if}
       {#each $columns as column}
         <Toggle
@@ -65,7 +65,7 @@
           value={column.visible}
           on:change={e => toggleVisibility(column, e.detail)}
         />
-        <span>{column.name}</span>
+        <span>{column.label}</span>
       {/each}
     </div>
     <div class="buttons">

--- a/packages/frontend-core/src/components/grid/controls/HideColumnsButton.svelte
+++ b/packages/frontend-core/src/components/grid/controls/HideColumnsButton.svelte
@@ -2,7 +2,7 @@
   import { getContext } from "svelte"
   import { ActionButton, Popover, Toggle } from "@budibase/bbui"
 
-  const { columns } = getContext("grid")
+  const { columns, stickyColumn } = getContext("grid")
 
   let open = false
   let anchor
@@ -55,6 +55,10 @@
 <Popover bind:open {anchor} align="left">
   <div class="content">
     <div class="columns">
+      {#if $stickyColumn}
+        <Toggle disabled size="S" value={true} />
+        <span>{$stickyColumn.name}</span>
+      {/if}
       {#each $columns as column}
         <Toggle
           size="S"

--- a/packages/frontend-core/src/components/grid/overlays/KeyboardManager.svelte
+++ b/packages/frontend-core/src/components/grid/overlays/KeyboardManager.svelte
@@ -46,6 +46,7 @@
       }
       return
     } else if (e.key === "Tab") {
+      e.preventDefault()
       api?.blur?.()
       changeFocusedColumn(1)
       return


### PR DESCRIPTION
## Description
Few other tweaks to the Grid UI after further review.

Changes:
- Fix legacy delete row button inside the edit row modal doing nothing
- Add option to hide column inside header cell dropdown
![image](https://user-images.githubusercontent.com/9075550/234219414-a00cea78-a6ea-43e0-add6-7f6bd04c7dca.png)
- Fix pressing tab in certain browsers causing the next cell to be focused and highlighted, preventing navigation with keyboard
- Fix checkbox causing a console error due to not exposing a blur method
- Add primary display column as a permanent, visible, disabled option at the top of the hide columns button, keeping in line with our theme of disabling unavailable options rather than hiding them and helping show that the primary display column cannot be hidden
![image](https://user-images.githubusercontent.com/9075550/234220813-7576789b-99f7-46af-9f3b-774995181421.png)
- Use friendly names for columns in the hide columns button
![image](https://user-images.githubusercontent.com/9075550/234220928-e47dd429-f201-4491-ad8c-0689287241f4.png)
- Fix hidden gutter expand icons still having a hover cursor





