### PR TITLE
Add height to BB logo in core email template

### DIFF
--- a/packages/worker/src/constants/templates/core.hbs
+++ b/packages/worker/src/constants/templates/core.hbs
@@ -16,8 +16,8 @@
               cellspacing="0"
             >
               <img
-                width="32px"
-                height="32px"
+                width="32"
+                height="32"
                 style="margin-right:16px; vertical-align: middle;"
                 alt="Budibase Logo"
                 src="https://i.imgur.com/Xhdt1YP.png"

--- a/packages/worker/src/constants/templates/core.hbs
+++ b/packages/worker/src/constants/templates/core.hbs
@@ -17,6 +17,7 @@
             >
               <img
                 width="32px"
+                height="32px"
                 style="margin-right:16px; vertical-align: middle;"
                 alt="Budibase Logo"
                 src="https://i.imgur.com/Xhdt1YP.png"


### PR DESCRIPTION
## Description
Quick attempt at fix for #10274 - some email clients don't respect width, add both height and width. This shouldn't cause any issues in other clients as it is a square image and cannot distort.

Also some clients don't like when a unit is specified for width/height so removing the px: https://stackoverflow.com/questions/20989897/image-style-height-and-width-not-taken-in-outlook-mails.

I've had the dis-pleasure and writing email HTML before so have come against similar issues in the past.