### PR TITLE
Overview published status updating after app sync

### DIFF
--- a/packages/builder/src/pages/builder/portal/overview/[appId]/overview.svelte
+++ b/packages/builder/src/pages/builder/portal/overview/[appId]/overview.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { onMount } from "svelte"
   import DashCard from "components/common/DashCard.svelte"
   import { AppStatus } from "constants"
   import { goto } from "@roxi/routify"

--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -104,6 +104,7 @@ export async function fetchDeployments(ctx: any) {
     }
     ctx.body = Object.values(deployments.history).reverse()
   } catch (err) {
+    console.error(err)
     ctx.body = []
   }
 }


### PR DESCRIPTION
## Description

The request to fetch the application deployments was not waiting for the app package to be fetched in the page layout.
Depending on the timing, this would either result in a successful request with the db context having the appropriate app, or the appId would be missing and the db request would fail silently. 

The page now waits until the application context is fully loaded and the context error will now be surfaced if this were to happen again.

Addresses: 
- https://github.com/Budibase/budibase/issues/10233

