### PR TITLE
Standardise width of design section side panels to fix drawer width issues

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/layouts/[layoutId]/_components/LayoutSettingsPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/layouts/[layoutId]/_components/LayoutSettingsPanel.svelte
@@ -35,7 +35,7 @@
   }
 </script>
 
-<Panel title={$selectedLayout?.name} icon="Experience" borderLeft>
+<Panel title={$selectedLayout?.name} icon="Experience" borderLeft wide>
   <Layout paddingX="L" paddingY="XL" gap="S">
     <Banner type="warning" showCloseButton={false}>
       Custom layouts are being deprecated. They will be removed in a future

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/navigation/_components/NavigationInfoPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/navigation/_components/NavigationInfoPanel.svelte
@@ -9,7 +9,7 @@
   }
 </script>
 
-<Panel borderLeft title="Navigation" icon="InfoOutline">
+<Panel borderLeft title="Navigation" icon="InfoOutline" wide>
   <Layout paddingX="L" paddingY="XL" gap="S">
     {#if $selectedScreen.layoutId}
       <Banner

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/screens/_components/ScreenSettingsPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/screens/_components/ScreenSettingsPanel.svelte
@@ -149,6 +149,7 @@
   title={$selectedScreen.routing.route}
   icon={$selectedScreen.routing.route === "/" ? "Home" : "WebPage"}
   borderLeft
+  wide
 >
   <Layout gap="S" paddingX="L" paddingY="XL">
     {#if $selectedScreen.layoutId}

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/theme/_components/ThemeInfoPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/theme/_components/ThemeInfoPanel.svelte
@@ -3,7 +3,7 @@
   import { Body, Layout } from "@budibase/bbui"
 </script>
 
-<Panel borderLeft title="Theme" icon="InfoOutline">
+<Panel borderLeft title="Theme" icon="InfoOutline" wide>
   <Layout paddingX="L" paddingY="XL">
     <Body size="S">
       Your theme is set across all the screens within your app.


### PR DESCRIPTION
## Description
Currently only the component settings panel is flagged as "wide" whereas the screen, theme and navigation panels are not. Not only does this cause the preview width to jump when swapping between, it causes a gap between the action drawer and the screen settings panel.

This PR ensures all panels are marked as wide to fix that issue and keep things consistent.

