### PR TITLE
fix typo in prompt user modal default text

### DIFF
--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -384,7 +384,7 @@ const confirmTextMap = {
   ["Save Row"]: "Are you sure you want to save this row?",
   ["Execute Query"]: "Are you sure you want to execute this query?",
   ["Trigger Automation"]: "Are you sure you want to trigger this automation?",
-  ["Prompt User"]: "Are you sure you want to contiune?",
+  ["Prompt User"]: "Are you sure you want to continue?",
 }
 
 /**


### PR DESCRIPTION
## Description
just fixing a typo in the prompt user action modal default text

Addresses: 
https://linear.app/budibase/issue/BUDI-6955/typo-in-default-prompt-user-action-message

## Screenshots
<img width="469" alt="image" src="https://user-images.githubusercontent.com/110921612/234907925-28c8e9cd-6e6d-4dd1-b885-c3e731146b4e.png">
<img width="469" alt="image" src="https://user-images.githubusercontent.com/110921612/234908105-fbb69b66-6796-41f8-80fb-020ddade0dc2.png">






