### PR TITLE
Type updates for plan changed event

### DIFF
--- a/packages/backend-core/src/events/publishers/license.ts
+++ b/packages/backend-core/src/events/publishers/license.ts
@@ -3,30 +3,28 @@ import {
   Event,
   LicenseActivatedEvent,
   LicensePlanChangedEvent,
-  LicenseTierChangedEvent,
   PlanType,
   Account,
   LicensePortalOpenedEvent,
   LicenseCheckoutSuccessEvent,
   LicenseCheckoutOpenedEvent,
   LicensePaymentFailedEvent,
-  LicensePaymentRecoveredEvent,
+  LicensePaymentRecoveredEvent, PriceDuration,
 } from "@budibase/types"
 
-async function tierChanged(account: Account, from: number, to: number) {
-  const properties: LicenseTierChangedEvent = {
-    accountId: account.accountId,
-    to,
-    from,
-  }
-  await publishEvent(Event.LICENSE_TIER_CHANGED, properties)
-}
-
-async function planChanged(account: Account, from: PlanType, to: PlanType) {
+async function planChanged(
+  account: Account,
+  from: PlanType,
+  to: PlanType,
+  quantity: number | undefined,
+  duration: PriceDuration | undefined
+) {
   const properties: LicensePlanChangedEvent = {
     accountId: account.accountId,
     to,
     from,
+    quantity,
+    duration
   }
   await publishEvent(Event.LICENSE_PLAN_CHANGED, properties)
 }
@@ -74,7 +72,6 @@ async function paymentRecovered(account: Account) {
 }
 
 export default {
-  tierChanged,
   planChanged,
   activated,
   checkoutOpened,

--- a/packages/backend-core/src/events/publishers/license.ts
+++ b/packages/backend-core/src/events/publishers/license.ts
@@ -9,7 +9,8 @@ import {
   LicenseCheckoutSuccessEvent,
   LicenseCheckoutOpenedEvent,
   LicensePaymentFailedEvent,
-  LicensePaymentRecoveredEvent, PriceDuration,
+  LicensePaymentRecoveredEvent,
+  PriceDuration,
 } from "@budibase/types"
 
 async function planChanged(
@@ -24,7 +25,7 @@ async function planChanged(
     to,
     from,
     quantity,
-    duration
+    duration,
   }
   await publishEvent(Event.LICENSE_PLAN_CHANGED, properties)
 }

--- a/packages/backend-core/tests/core/utilities/mocks/events.ts
+++ b/packages/backend-core/tests/core/utilities/mocks/events.ts
@@ -123,7 +123,6 @@ beforeAll(async () => {
   jest.spyOn(events.plugin, "imported")
   jest.spyOn(events.plugin, "deleted")
 
-  jest.spyOn(events.license, "tierChanged")
   jest.spyOn(events.license, "planChanged")
   jest.spyOn(events.license, "activated")
   jest.spyOn(events.license, "checkoutOpened")

--- a/packages/backend-core/tests/core/utilities/structures/licenses.ts
+++ b/packages/backend-core/tests/core/utilities/structures/licenses.ts
@@ -7,9 +7,22 @@ import {
   PlanType,
   PriceDuration,
   PurchasedPlan,
+  PurchasedPrice,
   Quotas,
   Subscription,
 } from "@budibase/types"
+
+export function price(): PurchasedPrice {
+  return {
+    amount: 10000,
+    amountMonthly: 10000,
+    currency: "usd",
+    duration: PriceDuration.MONTHLY,
+    priceId: "price_123",
+    dayPasses: undefined,
+    isPerUser: true,
+  }
+}
 
 export const plan = (type: PlanType = PlanType.FREE): PurchasedPlan => {
   return {
@@ -17,6 +30,7 @@ export const plan = (type: PlanType = PlanType.FREE): PurchasedPlan => {
     usesInvoicing: false,
     minUsers: 1,
     model: PlanModel.PER_USER,
+    price: price(),
   }
 }
 

--- a/packages/types/src/documents/account/account.ts
+++ b/packages/types/src/documents/account/account.ts
@@ -39,6 +39,7 @@ export interface Account extends CreateAccount {
   // licensing
   tier: string // deprecated
   planType?: PlanType
+  /** @deprecated */
   planTier?: number
   license?: License
   installId?: string

--- a/packages/types/src/sdk/events/event.ts
+++ b/packages/types/src/sdk/events/event.ts
@@ -138,7 +138,6 @@ export enum Event {
 
   // LICENSE
   LICENSE_PLAN_CHANGED = "license:plan:changed",
-  LICENSE_TIER_CHANGED = "license:tier:changed",
   LICENSE_ACTIVATED = "license:activated",
   LICENSE_PAYMENT_FAILED = "license:payment:failed",
   LICENSE_PAYMENT_RECOVERED = "license:payment:recovered",
@@ -328,7 +327,6 @@ export const AuditedEventFriendlyName: Record<Event, string | undefined> = {
 
   // LICENSE - NOT AUDITED
   [Event.LICENSE_PLAN_CHANGED]: undefined,
-  [Event.LICENSE_TIER_CHANGED]: undefined,
   [Event.LICENSE_ACTIVATED]: undefined,
   [Event.LICENSE_PAYMENT_FAILED]: undefined,
   [Event.LICENSE_PAYMENT_RECOVERED]: undefined,

--- a/packages/types/src/sdk/events/license.ts
+++ b/packages/types/src/sdk/events/license.ts
@@ -1,15 +1,15 @@
-import { PlanType } from "../licensing"
-
-export interface LicenseTierChangedEvent {
-  accountId: string
-  from: number
-  to: number
-}
+import { PlanType, PriceDuration } from "../licensing"
 
 export interface LicensePlanChangedEvent {
   accountId: string
   from: PlanType
   to: PlanType
+  // may not be on historical events
+  // free plans won't have a duration
+  duration: PriceDuration | undefined
+  // may not be on historical events
+  // free plans won't have a quantity
+  quantity: number | undefined
 }
 
 export interface LicenseActivatedEvent {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1486,15 +1486,15 @@
     pouchdb-promise "^6.0.4"
     through2 "^2.0.0"
 
-"@budibase/pro@2.5.6-alpha.38":
-  version "2.5.6-alpha.38"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.5.6-alpha.38.tgz#09e8dfbb6cefe856b5c01845a5a5c02a406faedf"
-  integrity sha512-CBZv6V+163USHPN0SuEIrXeGA+9gB1QNmHrMEPSmwlOCZbNW2dhniz00EVSuVh3ypHSjDECgozasDJTNRhiufQ==
+"@budibase/pro@2.5.6-alpha.39":
+  version "2.5.6-alpha.39"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.5.6-alpha.39.tgz#31ff637f01936cc55a21cb39c01c26afb42a7c54"
+  integrity sha512-Y33wjTLJ8P1KuYdz9T0QRrFxuvCNG9J6gkzp4lPZvrYr1RLFbvDIyz2wVMe5A0379EsYzTxuca7sXNvY21np/g==
   dependencies:
-    "@budibase/backend-core" "2.5.6-alpha.38"
+    "@budibase/backend-core" "2.5.6-alpha.39"
     "@budibase/shared-core" "2.4.44-alpha.1"
     "@budibase/string-templates" "2.4.44-alpha.1"
-    "@budibase/types" "2.5.6-alpha.38"
+    "@budibase/types" "2.5.6-alpha.39"
     "@koa/router" "8.0.8"
     bull "4.10.1"
     joi "17.6.0"


### PR DESCRIPTION
## Description

Addresses: 
- https://linear.app/budibase/issue/BUDI-6892/handle-license-events-for-per-user-model

Changes
- Remove the tier changed event - no longer necessary
- Add quantity and duration to plan changed event
- Deprecate the plan tier field on accounts


Related: 
- https://github.com/Budibase/account-portal/pull/323
