### PR TITLE
is empty lucene query with OR fix

### DIFF
--- a/packages/backend-core/src/db/lucene.ts
+++ b/packages/backend-core/src/db/lucene.ts
@@ -417,7 +417,7 @@ export class QueryBuilder<T> {
       })
     }
     if (this.query.empty) {
-      build(this.query.empty, (key: string) => `!${key}:["" TO *]`)
+      build(this.query.empty, (key: string) => `(*:* -${key}:["" TO *])`)
     }
     if (this.query.notEmpty) {
       build(this.query.notEmpty, (key: string) => `${key}:["" TO *]`)

--- a/packages/server/src/api/routes/tests/internalSearch.spec.js
+++ b/packages/server/src/api/routes/tests/internalSearch.spec.js
@@ -105,7 +105,7 @@ describe("internal search", () => {
         "column": "",
       },
     }, PARAMS)
-    checkLucene(response, `*:* AND !column:["" TO *]`, PARAMS)
+    checkLucene(response, `*:* AND (*:* -column:["" TO *])`, PARAMS)
   })
 
   it("test notEmpty query", async () => {


### PR DESCRIPTION
## Description
As per StackOverflow, we were missing the `*:*` from our query, although this was only an issue in a query with an OR statement.

Addresses: 
- https://linear.app/budibase/issue/BUDI-6956/match-any-filters-not-working-as-expected

## Screenshots
![Screenshot 2023-04-28 at 16 22 01](https://user-images.githubusercontent.com/101575380/235188223-5834746a-a45e-4be1-9d47-c73b0ea33bac.png)




