### PR TITLE
Fix - Budi 6789 import data empty date is not allowed

### DIFF
--- a/packages/server/src/api/controllers/row/internal.ts
+++ b/packages/server/src/api/controllers/row/internal.ts
@@ -37,7 +37,7 @@ import {
   Table,
 } from "@budibase/types"
 
-const { cleanExportRows } = require("./utils")
+import { cleanExportRows } from "./utils"
 
 const CALCULATION_TYPES = {
   SUM: "sum",
@@ -391,6 +391,9 @@ export async function exportRows(ctx: UserCtx) {
   const table = await db.get(ctx.params.tableId)
   const rowIds = ctx.request.body.rows
   let format = ctx.query.format
+  if (typeof format !== "string") {
+    ctx.throw(400, "Format parameter is not valid")
+  }
   const { columns, query } = ctx.request.body
 
   let result

--- a/packages/server/src/api/controllers/row/utils.ts
+++ b/packages/server/src/api/controllers/row/utils.ts
@@ -137,8 +137,8 @@ export function cleanExportRows(
     delete schema[column]
   })
 
-  // Intended to avoid 'undefined' in export
   if (format === Format.CSV) {
+    // Intended to append empty values in export
     const schemaKeys = Object.keys(schema)
     for (let key of schemaKeys) {
       if (columns?.length && columns.indexOf(key) > 0) {
@@ -146,7 +146,7 @@ export function cleanExportRows(
       }
       for (let row of cleanRows) {
         if (row[key] == null) {
-          row[key] = ""
+          row[key] = undefined
         }
       }
     }

--- a/packages/server/src/api/controllers/table/index.ts
+++ b/packages/server/src/api/controllers/table/index.ts
@@ -10,7 +10,7 @@ import { getDatasourceParams } from "../../../db/utils"
 import { context, events } from "@budibase/backend-core"
 import { Table, UserCtx } from "@budibase/types"
 import sdk from "../../../sdk"
-import csv from "csvtojson"
+import { jsonFromCsvString } from "../../../utilities/csv"
 
 function pickApi({ tableId, table }: { tableId?: string; table?: Table }) {
   if (table && !tableId) {
@@ -104,7 +104,7 @@ export async function bulkImport(ctx: UserCtx) {
 export async function csvToJson(ctx: UserCtx) {
   const { csvString } = ctx.request.body
 
-  const result = await csv().fromString(csvString)
+  const result = await jsonFromCsvString(csvString)
 
   ctx.status = 200
   ctx.body = result

--- a/packages/server/src/api/controllers/view/exporters.ts
+++ b/packages/server/src/api/controllers/view/exporters.ts
@@ -10,7 +10,9 @@ export function csv(headers: string[], rows: Row[]) {
         val =
           typeof val === "object" && !(val instanceof Date)
             ? `"${JSON.stringify(val).replace(/"/g, "'")}"`
-            : `"${val}"`
+            : val !== undefined
+            ? `"${val}"`
+            : ""
         return val.trim()
       })
       .join(",")}`

--- a/packages/server/src/utilities/csv.ts
+++ b/packages/server/src/utilities/csv.ts
@@ -1,6 +1,19 @@
 import csv from "csvtojson"
 
 export async function jsonFromCsvString(csvString: string) {
-  const result = await csv().fromString(csvString)
+  const castedWithEmptyStrings = await csv().fromString(csvString)
+  if (!castedWithEmptyStrings.length) {
+    return []
+  }
+
+  // By default the csvtojson library casts empty values as empty strings. This is causing issues on conversion.
+  // ignoreEmpty will remove the key completly if empty, so creating this empty object will ensure we return the values with the keys but empty values
+  const emptyObject = Object.keys(castedWithEmptyStrings[0]).reduce(
+    (p, v) => ({ ...p, [v]: undefined }),
+    {}
+  )
+
+  let result = await csv({ ignoreEmpty: true }).fromString(csvString)
+  result = result.map(r => ({ ...emptyObject, ...r }))
   return result
 }

--- a/packages/server/src/utilities/csv.ts
+++ b/packages/server/src/utilities/csv.ts
@@ -1,0 +1,6 @@
+import csv from "csvtojson"
+
+export async function jsonFromCsvString(csvString: string) {
+  const result = await csv().fromString(csvString)
+  return result
+}

--- a/packages/server/src/utilities/csv.ts
+++ b/packages/server/src/utilities/csv.ts
@@ -1,19 +1,22 @@
 import csv from "csvtojson"
 
 export async function jsonFromCsvString(csvString: string) {
-  const castedWithEmptyStrings = await csv().fromString(csvString)
-  if (!castedWithEmptyStrings.length) {
-    return []
-  }
+  const castedWithEmptyValues = await csv({ ignoreEmpty: true }).fromString(
+    csvString
+  )
 
   // By default the csvtojson library casts empty values as empty strings. This is causing issues on conversion.
   // ignoreEmpty will remove the key completly if empty, so creating this empty object will ensure we return the values with the keys but empty values
-  const emptyObject = Object.keys(castedWithEmptyStrings[0]).reduce(
-    (p, v) => ({ ...p, [v]: undefined }),
-    {}
-  )
+  const result = await csv({ ignoreEmpty: false }).fromString(csvString)
+  result.forEach((r, i) => {
+    for (const [key] of Object.entries(r).filter(
+      ([key, value]) => value === ""
+    )) {
+      if (castedWithEmptyValues[i][key] === undefined) {
+        r[key] = null
+      }
+    }
+  })
 
-  let result = await csv({ ignoreEmpty: true }).fromString(csvString)
-  result = result.map(r => ({ ...emptyObject, ...r }))
   return result
 }

--- a/packages/server/src/utilities/schema.ts
+++ b/packages/server/src/utilities/schema.ts
@@ -4,6 +4,9 @@ interface SchemaColumn {
   readonly name: string
   readonly type: FieldTypes
   readonly autocolumn?: boolean
+  readonly constraints?: {
+    presence: boolean
+  }
 }
 
 interface Schema {
@@ -76,6 +79,11 @@ export function validate(rows: Rows, schema: Schema): ValidationResults {
       // If the columnType is not a string, then it's not present in the schema, and should be added to the invalid columns array
       if (typeof columnType !== "string") {
         results.invalidColumns.push(columnName)
+      } else if (
+        columnData == null &&
+        !schema[columnName].constraints?.presence
+      ) {
+        results.schemaValidation[columnName] = true
       } else if (
         // If there's no data for this field don't bother with further checks
         // If the field is already marked as invalid there's no need for further checks

--- a/packages/server/src/utilities/tests/csv.spec.ts
+++ b/packages/server/src/utilities/tests/csv.spec.ts
@@ -11,6 +11,23 @@ describe("csv", () => {
         { id: "1", title: "aaa" },
         { id: "2", title: "bbb" },
       ])
+      result.forEach(r => expect(Object.keys(r)).toEqual(["id", "title"]))
+    })
+
+    test("empty values are casted as undefined", async () => {
+      const csvString =
+        '"id","optional","title"\n1,,"aaa"\n2,"value","bbb"\n3,,"ccc"'
+
+      const result = await jsonFromCsvString(csvString)
+
+      expect(result).toEqual([
+        { id: "1", optional: undefined, title: "aaa" },
+        { id: "2", optional: "value", title: "bbb" },
+        { id: "3", optional: undefined, title: "ccc" },
+      ])
+      result.forEach(r =>
+        expect(Object.keys(r)).toEqual(["id", "optional", "title"])
+      )
     })
   })
 })

--- a/packages/server/src/utilities/tests/csv.spec.ts
+++ b/packages/server/src/utilities/tests/csv.spec.ts
@@ -1,0 +1,16 @@
+import { jsonFromCsvString } from "../csv"
+
+describe("csv", () => {
+  describe("jsonFromCsvString", () => {
+    test("multiple lines csv can be casted", async () => {
+      const csvString = '"id","title"\n"1","aaa"\n"2","bbb"'
+
+      const result = await jsonFromCsvString(csvString)
+
+      expect(result).toEqual([
+        { id: "1", title: "aaa" },
+        { id: "2", title: "bbb" },
+      ])
+    })
+  })
+})

--- a/packages/server/src/utilities/tests/csv.spec.ts
+++ b/packages/server/src/utilities/tests/csv.spec.ts
@@ -21,9 +21,9 @@ describe("csv", () => {
       const result = await jsonFromCsvString(csvString)
 
       expect(result).toEqual([
-        { id: "1", optional: undefined, title: "aaa" },
+        { id: "1", optional: null, title: "aaa" },
         { id: "2", optional: "value", title: "bbb" },
-        { id: "3", optional: undefined, title: "ccc" },
+        { id: "3", optional: null, title: "ccc" },
       ])
       result.forEach(r =>
         expect(Object.keys(r)).toEqual(["id", "optional", "title"])


### PR DESCRIPTION
## Description
Fix import and export CSV to handle empty values. New behaviour:
1. On exporting empty values, the csv will contain empty values instead of empty strings
2. On importing CSVs with empty values, these will be respected instead of casting them as empty strings

This casting to empty string was causing issues when casting optional types values, fe. datetimes

Addresses: 
- https://github.com/Budibase/budibase/issues/10131
