### PR TITLE
Fix release single image CI

### DIFF
--- a/hosting/couchdb/Dockerfile
+++ b/hosting/couchdb/Dockerfile
@@ -5,8 +5,11 @@ ENV COUCHDB_PASSWORD admin
 EXPOSE 5984
 
 RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common wget unzip curl && \
+    wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - && \
     apt-add-repository 'deb http://security.debian.org/debian-security bullseye-security/updates main' && \
-    apt-get update && apt-get install -y --no-install-recommends openjdk-11-jre && \
+    apt-add-repository 'deb http://archive.debian.org/debian stretch-backports main' && \
+    apt-add-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ && \
+    apt-get update && apt-get install -y --no-install-recommends adoptopenjdk-8-hotspot && \
     rm -rf /var/lib/apt/lists/
 
 # setup clouseau

--- a/hosting/couchdb/Dockerfile
+++ b/hosting/couchdb/Dockerfile
@@ -5,8 +5,8 @@ ENV COUCHDB_PASSWORD admin
 EXPOSE 5984
 
 RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common wget unzip curl && \
-    apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main' && \
-    apt-get update && apt-get install -y --no-install-recommends openjdk-8-jre && \
+    apt-add-repository 'deb http://security.debian.org/debian-security bullseye-security/updates main' && \
+    apt-get update && apt-get install -y --no-install-recommends openjdk-11-jre && \
     rm -rf /var/lib/apt/lists/
 
 # setup clouseau

--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -32,7 +32,7 @@ COPY --from=build /worker /worker
 # install base dependencies
 RUN apt-get update && \
   apt-get install -y --no-install-recommends software-properties-common nginx uuid-runtime redis-server && \
-  apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main' && \
+  apt-add-repository 'deb http://security.debian.org/debian-security bullseye-security/updates main' && \
   apt-get update
 
 # install other dependencies, nodejs, oracle requirements, jdk8, redis, nginx


### PR DESCRIPTION
Trying to fix https://github.com/Budibase/budibase/actions/runs/4798193920

this should fix [release-singleimage.yml](https://github.com/Budibase/budibase/blob/develop/.github/workflows/release-singleimage.yml) because

## Description
_The Problem is that the Workflow fails, and therefore is not pushed to the DockerHub_

Addresses: 
- `<Enter the Link to the issue(s) this PR addresses>` (sorry, did not create an issue first.)
- [blog about similar issue](https://the-codeslinger.com/2020/03/26/debian-bullseye-the-repository-does-not-have-a-release-file/)
- [Question to the error thrown by the workflow (not by me)](https://serverfault.com/questions/1074688/security-debian-org-does-not-have-a-release-file-on-with-debian-docker-images)

## Screenshots
![_Picture of run_](http://upload.oppisoft.de/x/HIvWd92xRYnSRJpIv9XHc.png)

## Documentation
- before re-running the Action, a `yarn publish:docker:couch` is required to apply the changes by pushing the CouchDB image to the DockerHub because [this Dockerfile](https://github.com/Budibase/budibase/blob/develop/hosting/single/Dockerfile) is based on the Image
- [x] I have reviewed the budibase documentation to verify if this feature requires any changes. If changes or new docs are required, I have written them.

I have read the CLA Document and I hereby sign the CLA


