### PR TITLE
Fixes around user limit banner reappearing and copy adjustment

### DIFF
--- a/packages/builder/src/components/portal/licensing/licensingBanners.js
+++ b/packages/builder/src/components/portal/licensing/licensingBanners.js
@@ -147,6 +147,9 @@ const buildUsersAboveLimitBanner = EXPIRY_KEY => {
   return {
     key: EXPIRY_KEY,
     type: BANNER_TYPES.WARNING,
+    onChange: () => {
+      defaultCacheFn(EXPIRY_KEY)
+    },
     criteria: () => {
       return userLicensing.warnUserLimit
     },

--- a/packages/builder/src/pages/builder/portal/users/users/index.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/index.svelte
@@ -261,7 +261,7 @@
       header={`Users will soon be limited to ${staticUserLimit}`}
       message={`Our free plan is going to be limited to ${staticUserLimit} users in ${$licensing.userLimitDays}.
     
-    This means any users exceeding the limit will de-activated.
+    This means any users exceeding the limit will be de-activated.
 
     De-activated users will not able to access the builder or any published apps until you upgrade to one of our paid plans.
     `}

--- a/packages/builder/src/pages/builder/portal/users/users/index.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/index.svelte
@@ -261,7 +261,7 @@
       header={`Users will soon be limited to ${staticUserLimit}`}
       message={`Our free plan is going to be limited to ${staticUserLimit} users in ${$licensing.userLimitDays}.
     
-    This means any users exceeding the limit have been de-activated.
+    This means any users exceeding the limit will de-activated.
 
     De-activated users will not able to access the builder or any published apps until you upgrade to one of our paid plans.
     `}


### PR DESCRIPTION
## Description
As title, this fixes:

- An issue where the User above limit warning banner would reappear even if the close button was clicked
- Fixed copy in the users section