### PR TITLE
Fix for row import failure caused by empty attachment parsing.

### DIFF
--- a/packages/server/src/api/routes/tests/row.spec.js
+++ b/packages/server/src/api/routes/tests/row.spec.js
@@ -212,6 +212,7 @@ describe("/rows", () => {
           attachmentNull: attachment,
           attachmentUndefined: attachment,
           attachmentEmpty: attachment,
+          attachmentEmptyArrayStr: attachment
         },
       })
 
@@ -239,6 +240,7 @@ describe("/rows", () => {
         attachmentNull: null,
         attachmentUndefined: undefined,
         attachmentEmpty: "",
+        attachmentEmptyArrayStr: "[]",
       }
 
       const id = (await config.createRow(row))._id
@@ -268,6 +270,7 @@ describe("/rows", () => {
       expect(saved.attachmentNull).toEqual([])
       expect(saved.attachmentUndefined).toBe(undefined)
       expect(saved.attachmentEmpty).toEqual([])
+      expect(saved.attachmentEmptyArrayStr).toEqual([])
     })
   })
 

--- a/packages/server/src/utilities/rowProcessor/map.ts
+++ b/packages/server/src/utilities/rowProcessor/map.ts
@@ -67,12 +67,14 @@ export const TYPE_TRANSFORM_MAP: any = {
     },
   },
   [FieldTypes.ATTACHMENT]: {
-    "": [],
     [null]: [],
     [undefined]: undefined,
     parse: attachments => {
       if (typeof attachments === "string") {
-        let result = attachments
+        if (attachments === "") {
+          return []
+        }
+        let result
         try {
           result = JSON.parse(attachments)
         } catch (e) {
@@ -80,6 +82,7 @@ export const TYPE_TRANSFORM_MAP: any = {
         }
         return result
       }
+      return attachments
     },
   },
   [FieldTypes.BOOLEAN]: {

--- a/packages/server/src/utilities/rowProcessor/map.ts
+++ b/packages/server/src/utilities/rowProcessor/map.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { FieldTypes } from "../../constants"
+import { logging } from "@budibase/backend-core"
 
 /**
  * A map of how we convert various properties in rows to each other based on the row type.
@@ -78,7 +79,7 @@ export const TYPE_TRANSFORM_MAP: any = {
         try {
           result = JSON.parse(attachments)
         } catch (e) {
-          console.error("Could not parse attachments", e)
+          logging.logAlert("Could not parse attachments", e)
         }
         return result
       }

--- a/packages/server/src/utilities/rowProcessor/map.ts
+++ b/packages/server/src/utilities/rowProcessor/map.ts
@@ -70,17 +70,17 @@ export const TYPE_TRANSFORM_MAP: any = {
     "": [],
     [null]: [],
     [undefined]: undefined,
-    parse: (attachments) => {
-      if(typeof attachments === "string"){
+    parse: attachments => {
+      if (typeof attachments === "string") {
         let result = attachments
         try {
           result = JSON.parse(attachments)
         } catch (e) {
           console.error("Could not parse attachments", e)
         }
-        return result;
+        return result
       }
-    }
+    },
   },
   [FieldTypes.BOOLEAN]: {
     "": null,

--- a/packages/server/src/utilities/rowProcessor/map.ts
+++ b/packages/server/src/utilities/rowProcessor/map.ts
@@ -70,6 +70,17 @@ export const TYPE_TRANSFORM_MAP: any = {
     "": [],
     [null]: [],
     [undefined]: undefined,
+    parse: (attachments) => {
+      if(typeof attachments === "string"){
+        let result = attachments
+        try {
+          result = JSON.parse(attachments)
+        } catch (e) {
+          console.error("Could not parse attachments", e)
+        }
+        return result;
+      }
+    }
   },
   [FieldTypes.BOOLEAN]: {
     "": null,


### PR DESCRIPTION
## Description

When we export rows with no attachments, the field value contains a string representation of an empty array `"[]"`.
On import back into the system, this value is not accommodate and it will cause the row import to fail.

Addresses: 
- Empty attachment string value causing row import to fail.


