### PR TITLE
Potential fix for automation log issue

### DIFF
--- a/packages/backend-core/src/queue/listeners.ts
+++ b/packages/backend-core/src/queue/listeners.ts
@@ -40,6 +40,12 @@ function logging(queue: Queue, jobQueue: JobQueue) {
     case JobQueue.APP_BACKUP:
       eventType = "app-backup-event"
       break
+    case JobQueue.AUDIT_LOG:
+      eventType = "audit-log-event"
+      break
+    case JobQueue.SYSTEM_EVENT_QUEUE:
+      eventType = "system-event"
+      break
   }
   if (process.env.NODE_DEBUG?.includes("bull")) {
     queue

--- a/packages/server/src/environment.ts
+++ b/packages/server/src/environment.ts
@@ -34,8 +34,6 @@ function parseIntSafe(number?: string) {
   }
 }
 
-let inThread = false
-
 const environment = {
   // important - prefer app port to generic port
   PORT: process.env.APP_PORT || process.env.PORT,
@@ -95,12 +93,8 @@ const environment = {
   isProd: () => {
     return !isDev()
   },
-  // used to check if already in a thread, don't thread further
-  setInThread: () => {
-    inThread = true
-  },
   isInThread: () => {
-    return inThread
+    return process.env.FORKED_PROCESS
   },
 }
 

--- a/packages/server/src/threads/index.ts
+++ b/packages/server/src/threads/index.ts
@@ -39,6 +39,12 @@ export class Thread {
       const workerOpts: any = {
         autoStart: true,
         maxConcurrentWorkers: this.count,
+        workerOptions: {
+          env: {
+            ...process.env,
+            FORKED_PROCESS: "1",
+          },
+        },
       }
       if (opts.timeoutMs) {
         this.timeoutMs = opts.timeoutMs

--- a/packages/server/src/threads/utils.ts
+++ b/packages/server/src/threads/utils.ts
@@ -25,11 +25,9 @@ function makeVariableKey(queryId: string, variable: string) {
 
 export function threadSetup() {
   // don't run this if not threading
-  if (env.isTest() || env.DISABLE_THREADING) {
+  if (env.isTest() || env.DISABLE_THREADING || !env.isInThread()) {
     return
   }
-  // when thread starts, make sure it is recorded
-  env.setInThread()
   db.init()
 }
 


### PR DESCRIPTION
## Description
Fixing some un-identified listeners, queue messages not being correctly printed, also improving the mechanism for detecting if in the main thread or not.

We were getting a few `undefined` messages as part of the queue listeners, this attempts to rectify that, as well as adding a new environment variable that can be used to detect if a thread is a fork. The default already was `process.env` so spreading it in and adding the extra environment variable shouldn't cause a problem.
