### PR TITLE
Fix usage of custom locks

### DIFF
--- a/packages/backend-core/src/redis/redlockImpl.ts
+++ b/packages/backend-core/src/redis/redlockImpl.ts
@@ -85,7 +85,7 @@ export const doWithLock = async <T>(
   opts: LockOptions,
   task: () => Promise<T>
 ): Promise<RedlockExecution<T>> => {
-  const redlock = await getClient(opts.type)
+  const redlock = await getClient(opts.type, opts.customOptions)
   let lock
   try {
     // determine lock name


### PR DESCRIPTION
## Description

Recently support for custom lock options was implemented, however the customer options are not being used due to an optional param that has not been forwarded. This results in falling back to the default lock configuration. 

In the case of the account portal where a custom lock configuration is being used, we are seeing a high volume of:

```
bb-alert: accountId=cd83da38-3006-4a58-8a49-1936b5d45090 Could not handle QuotaUsageEvent
Exceeded 10 attempts to lock the resource "lock:cheeks_quota_usage_event".
```

This is due to the low delay between the retries, which has been bumped significantly for this lock. 