### PR TITLE
Display error when populated from the backend

### DIFF
--- a/packages/builder/src/pages/builder/portal/users/groups/[groupId].svelte
+++ b/packages/builder/src/pages/builder/portal/users/groups/[groupId].svelte
@@ -130,7 +130,11 @@
     try {
       await groups.actions.save(group)
     } catch (error) {
-      notifications.error(`Failed to save user group`)
+      if (error.message) {
+        notifications.error(error.message)
+      } else {
+        notifications.error(`Failed to save user group`)
+      }
     }
   }
 

--- a/packages/builder/src/pages/builder/portal/users/groups/index.svelte
+++ b/packages/builder/src/pages/builder/portal/users/groups/index.svelte
@@ -66,6 +66,8 @@
     } catch (error) {
       if (error.status === 400) {
         notifications.error(error.message)
+      } else if (error.message) {
+        notifications.error(error.message)
       } else {
         notifications.error(`Failed to save group`)
       }

--- a/packages/worker/src/tests/structures/groups.ts
+++ b/packages/worker/src/tests/structures/groups.ts
@@ -1,10 +1,25 @@
+import { generator } from "@budibase/backend-core/tests"
+import { db } from "@budibase/backend-core"
+import { UserGroupRoles } from "@budibase/types"
+
 export const UserGroup = () => {
+  const appsCount = generator.integer({ min: 0, max: 3 })
+  const roles = Array.from({ length: appsCount }).reduce(
+    (p: UserGroupRoles, v) => {
+      return {
+        ...p,
+        [db.generateAppID()]: generator.pickone(["ADMIN", "POWER", "BASIC"]),
+      }
+    },
+    {}
+  )
+
   let group = {
     apps: [],
-    color: "var(--spectrum-global-color-blue-600)",
-    icon: "UserGroup",
-    name: "New group",
-    roles: { app_uuid1: "ADMIN", app_uuid2: "POWER" },
+    color: generator.color(),
+    icon: generator.word(),
+    name: generator.word({ length: 2 }),
+    roles: roles,
     users: [],
   }
   return group


### PR DESCRIPTION
## Description
Ensuring we don't have duplicate group names, either on creation or edition time

Addresses: 
- https://github.com/Budibase/budibase/issues/8819

## Screenshots
<img width="624" alt="image" src="https://user-images.githubusercontent.com/15987277/236792082-c43520b3-d55d-4754-9135-44dc792ae8c4.png">
<img width="600" alt="image" src="https://user-images.githubusercontent.com/15987277/236792535-e95c470d-1ef7-4160-8c4f-86c49a1bf4a9.png">
