### PR TITLE
Do not allow empty group names on builder

### DIFF
--- a/packages/builder/src/pages/builder/portal/users/groups/_components/CreateEditGroupModal.svelte
+++ b/packages/builder/src/pages/builder/portal/users/groups/_components/CreateEditGroupModal.svelte
@@ -9,15 +9,23 @@
 
   export let group
   export let saveGroup
+
+  let nameError
 </script>
 
 <ModalContent
-  onConfirm={() => saveGroup(group)}
+  onConfirm={() => {
+    if (!group.name?.trim()) {
+      nameError = "Group name cannot be empty"
+      return false
+    }
+    saveGroup(group)
+  }}
   size="M"
   title={group?._rev ? "Edit group" : "Create group"}
   confirmText="Save"
 >
-  <Input bind:value={group.name} label="Name" />
+  <Input bind:value={group.name} label="Name" error={nameError} />
   <div class="modal-format">
     <div class="modal-inner">
       <Body size="XS">Icon</Body>

--- a/packages/worker/src/api/routes/global/tests/groups.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/groups.spec.ts
@@ -24,6 +24,14 @@ describe("/api/global/groups", () => {
       expect(events.group.updated).not.toBeCalled()
       expect(events.group.permissionsEdited).not.toBeCalled()
     })
+
+    it("should not allow undefined names", async () => {
+      const group = { ...structures.groups.UserGroup(), name: undefined } as any
+      const response = await config.api.groups.saveGroup(group, { expect: 400 })
+      expect(JSON.parse(response.text).message).toEqual(
+        'Invalid body - "name" is required'
+      )
+    })
   })
 
   describe("update", () => {

--- a/packages/worker/src/api/routes/global/tests/groups.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/groups.spec.ts
@@ -32,6 +32,22 @@ describe("/api/global/groups", () => {
         'Invalid body - "name" is required'
       )
     })
+
+    it("should not allow empty names", async () => {
+      const group = { ...structures.groups.UserGroup(), name: "" }
+      const response = await config.api.groups.saveGroup(group, { expect: 400 })
+      expect(JSON.parse(response.text).message).toEqual(
+        'Invalid body - "name" is not allowed to be empty'
+      )
+    })
+
+    it("should not allow whitespace names", async () => {
+      const group = { ...structures.groups.UserGroup(), name: "   " }
+      const response = await config.api.groups.saveGroup(group, { expect: 400 })
+      expect(JSON.parse(response.text).message).toEqual(
+        'Invalid body - "name" is not allowed to be empty'
+      )
+    })
   })
 
   describe("update", () => {

--- a/packages/worker/src/api/routes/global/tests/groups.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/groups.spec.ts
@@ -13,6 +13,7 @@ describe("/api/global/groups", () => {
   })
 
   beforeEach(async () => {
+    jest.resetAllMocks()
     mocks.licenses.useGroups()
   })
 
@@ -46,6 +47,14 @@ describe("/api/global/groups", () => {
       const response = await config.api.groups.saveGroup(group, { expect: 400 })
       expect(JSON.parse(response.text).message).toEqual(
         'Invalid body - "name" is not allowed to be empty'
+      )
+    })
+
+    it("should trim names", async () => {
+      const group = { ...structures.groups.UserGroup(), name: "   group name " }
+      await config.api.groups.saveGroup(group)
+      expect(events.group.created).toBeCalledWith(
+        expect.objectContaining({ name: "group name" })
       )
     })
   })

--- a/packages/worker/src/tests/api/groups.ts
+++ b/packages/worker/src/tests/api/groups.ts
@@ -7,13 +7,13 @@ export class GroupsAPI extends TestAPI {
     super(config)
   }
 
-  saveGroup = (group: UserGroup) => {
+  saveGroup = (group: UserGroup, { expect } = { expect: 200 }) => {
     return this.request
       .post(`/api/global/groups`)
       .send(group)
       .set(this.config.defaultHeaders())
       .expect("Content-Type", /json/)
-      .expect(200)
+      .expect(expect)
   }
 
   deleteGroup = (id: string, rev: string) => {


### PR DESCRIPTION
## Description
Check user group creation/edition to not allow empty or whitespace names, both in the API or in the builder

Addresses: 
- https://github.com/Budibase/budibase/issues/8819

## Screenshots
<img width="731" alt="image" src="https://user-images.githubusercontent.com/15987277/236808750-b6578125-e20b-48ca-bce8-a9bc91f02108.png">





