### PR TITLE
allow passwordless redis

### DIFF
--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -95,7 +95,7 @@ const environment = {
   GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
   SALT_ROUNDS: process.env.SALT_ROUNDS,
   REDIS_URL: process.env.REDIS_URL || "localhost:6379",
-  REDIS_PASSWORD: process.env.REDIS_PASSWORD || "budibase",
+  REDIS_PASSWORD: process.env.REDIS_PASSWORD,
   REDIS_CLUSTERED: process.env.REDIS_CLUSTERED,
   MOCK_REDIS: process.env.MOCK_REDIS,
   MINIO_ACCESS_KEY: process.env.MINIO_ACCESS_KEY,

--- a/packages/server/src/api/routes/public/index.ts
+++ b/packages/server/src/api/routes/public/index.ts
@@ -42,13 +42,16 @@ if (!env.isTest()) {
         host: REDIS_OPTS.host,
         port: REDIS_OPTS.port,
       },
-      password:
-        REDIS_OPTS.opts.password || REDIS_OPTS.opts.redisOptions.password,
+    }
+
+    if (REDIS_OPTS.opts?.password || REDIS_OPTS.opts.redisOptions?.password) {
+      // @ts-ignore
+      options.password = REDIS_OPTS.opts.password || REDIS_OPTS.opts.redisOptions.password
     }
 
     if (!env.REDIS_CLUSTERED) {
-      // Can't set direct redis db in clustered env
       // @ts-ignore
+      // Can't set direct redis db in clustered env
       options.database = 1
     }
   }

--- a/packages/server/src/api/routes/public/index.ts
+++ b/packages/server/src/api/routes/public/index.ts
@@ -46,7 +46,8 @@ if (!env.isTest()) {
 
     if (REDIS_OPTS.opts?.password || REDIS_OPTS.opts.redisOptions?.password) {
       // @ts-ignore
-      options.password = REDIS_OPTS.opts.password || REDIS_OPTS.opts.redisOptions.password
+      options.password =
+        REDIS_OPTS.opts.password || REDIS_OPTS.opts.redisOptions.password
     }
 
     if (!env.REDIS_CLUSTERED) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1486,15 +1486,15 @@
     pouchdb-promise "^6.0.4"
     through2 "^2.0.0"
 
-"@budibase/pro@2.6.6":
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.6.6.tgz#337027168d17a44717c2648b3209a0e2daddcf7d"
-  integrity sha512-RldUn/WjN7eaYRxL4KBufK1yhVIycJOzoncD+BPgRKstuuuYzPultGZcpNsQQiJkAhNR6QXhG+ovvCUiA+AX6g==
+"@budibase/pro@2.6.7":
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-2.6.7.tgz#884b33f3a3e3f2e548fd7519d32b40dc98803400"
+  integrity sha512-f7g+0So7hr7tHHEF28cz550imYpq/CqRNzhMQpUwmzgbdTlOdVej3PWPNK9+MuBlNea3J9b2WQsjS9TkGZfTlA==
   dependencies:
-    "@budibase/backend-core" "2.6.6"
+    "@budibase/backend-core" "2.6.7"
     "@budibase/shared-core" "2.5.9"
     "@budibase/string-templates" "2.5.9"
-    "@budibase/types" "2.6.6"
+    "@budibase/types" "2.6.7"
     "@koa/router" "8.0.8"
     bull "4.10.1"
     joi "17.6.0"


### PR DESCRIPTION
## Description
Came from a request from a customer.

Currently it is not possible to use budibase with a passwordless redis, since the environment variable is always defaulted to `"budibase"` in backend-core.

Made an update to allow empty `REDIS_PASSWORD` to be respected.