### PR TITLE
adding healthcheck to proxy service

### DIFF
--- a/hosting/proxy/nginx.prod.conf
+++ b/hosting/proxy/nginx.prod.conf
@@ -82,6 +82,12 @@ http {
     set $couchdb ${COUCHDB_UPSTREAM_URL};
     set $watchtower ${WATCHTOWER_UPSTREAM_URL};
 
+    location /health {
+      access_log off;
+      add_header 'Content-Type' 'application/json';
+      return 200 '{ "status": "OK" }';
+    }
+
     location /app {
       proxy_pass      $apps;
     }


### PR DESCRIPTION
## Description
Added for customer - we don't currently have a baked in health check for the proxy service specifically.

Built image locally and tested - works as expected.