### PR TITLE
Sort tables in data section + show full screen URLs on hover

### DIFF
--- a/packages/builder/src/components/backend/TableNavigator/TableNavigator.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/TableNavigator.svelte
@@ -6,7 +6,8 @@
   import NavItem from "components/common/NavItem.svelte"
   import { goto, isActive } from "@roxi/routify"
 
-  const alphabetical = (a, b) => a.name?.toLowerCase() > b.name?.toLowerCase()
+  const alphabetical = (a, b) =>
+    a.name?.toLowerCase() > b.name?.toLowerCase() ? 1 : -1
 
   export let sourceId
 

--- a/packages/builder/src/components/common/NavItem.svelte
+++ b/packages/builder/src/components/common/NavItem.svelte
@@ -17,6 +17,7 @@
   export let highlighted = false
   export let rightAlignIcon = false
   export let id
+  export let showTooltip = false
 
   const scrollApi = getContext("scroll")
   const dispatch = createEventDispatcher()
@@ -84,7 +85,7 @@
         <Icon color={iconColor} size="S" name={icon} />
       </div>
     {/if}
-    <div class="text">{text}</div>
+    <div class="text" title={showTooltip ? text : null}>{text}</div>
     {#if withActions}
       <div class="actions">
         <slot />

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/screens/_components/ScreenListPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/screens/_components/ScreenListPanel.svelte
@@ -59,6 +59,7 @@
       text={screen.routing.route}
       on:click={() => store.actions.screens.select(screen._id)}
       rightAlignIcon
+      showTooltip
     >
       <ScreenDropdownMenu screenId={screen._id} />
       <RoleIndicator slot="right" roleId={screen.routing.roleId} />


### PR DESCRIPTION
## Description
Couple of small improvements.
- Alphabetically sort the tables list in the data section #10394
![image](https://github.com/Budibase/budibase/assets/9075550/2e3f1850-78bb-409c-aaa7-e3123b77c433)
- Show full screen URL when hovering #8610
![image](https://github.com/Budibase/budibase/assets/9075550/ff335a9f-4b1c-4be0-bc5e-bf98dbb1c522)




