### PR TITLE
Remove redundant yarn setup on pro bootstrap

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,5 +3,4 @@ if [ -d "packages/pro/packages" ]; then
 
   yarn
   lerna bootstrap
-  yarn setup
 fi


### PR DESCRIPTION
## Description
Removing the `yarn setup` in the `bootstrap.sh` script. the script will already run
- `yarn` 
- `lerna bootstrap` 

The setup subsequently runs:
- `yarn && yarn bootstrap && yarn build`

The only extra step here being the build, which shouldn't be necessary at this point

Addresses: 
- no ticket


