### PR TITLE
Disable revert button when not applicable, fix tooltip clipping

### DIFF
--- a/packages/bbui/src/ActionButton/ActionButton.svelte
+++ b/packages/bbui/src/ActionButton/ActionButton.svelte
@@ -128,5 +128,6 @@
     max-width: 150px;
     transform: translateX(-50%);
     text-align: center;
+    z-index: 100;
   }
 </style>

--- a/packages/builder/src/components/deploy/AppActions.svelte
+++ b/packages/builder/src/components/deploy/AppActions.svelte
@@ -118,7 +118,7 @@
     <div class="version">
       <VersionModal />
     </div>
-    <RevertModal />
+    <RevertModal disabled={filteredApps.length == 0} />
 
     {#if isPublished}
       <div class="publish-popover">

--- a/packages/builder/src/components/deploy/RevertModal.svelte
+++ b/packages/builder/src/components/deploy/RevertModal.svelte
@@ -9,6 +9,8 @@
   import { store } from "builderStore"
   import { API } from "api"
 
+  export let disabled = false
+
   let revertModal
   let appName
 

--- a/packages/builder/src/components/deploy/RevertModal.svelte
+++ b/packages/builder/src/components/deploy/RevertModal.svelte
@@ -36,6 +36,7 @@
   size="M"
   tooltip="Revert changes"
   on:click={revertModal.show}
+  {disabled}
 />
 
 <Modal bind:this={revertModal}>


### PR DESCRIPTION
Addresses: 
- Application revert button was active when the application hadn't been published. Attempting to use the button without a published app resulted in a 400 and an error state. `App has not yet been deployed` is visible in the server errors.
- Also added a z-index fix for `ActionButton` tooltips. The tooltips in the main menu in the builder were being clipped by the new grid layout.

## Screenshots

UI after initiating the revert behaviour without a published application.
<img src="https://github.com/Budibase/budibase/assets/5913006/5795c11f-399d-4d67-af51-3bc93cb0ac15" width="500" />

Tooltips clipped by the new grid layout
![Screenshot 2023-05-15 at 10 43 33](https://github.com/Budibase/budibase/assets/5913006/9d348387-0cb2-4f34-8747-febd42219f5c)

Tooltips with their z-index bumped to 100
![Screenshot 2023-05-15 at 10 43 54](https://github.com/Budibase/budibase/assets/5913006/151d7e0f-5f54-4c35-b140-bd6d96eabc10)
