### PR TITLE
Removing version error breaking CLI

### DIFF
--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -69,10 +69,10 @@ function findVersion() {
   try {
     const packageJsonFile = findFileInAncestors("package.json", process.cwd())
     const content = readFileSync(packageJsonFile!, "utf-8")
-    const version = JSON.parse(content).version
-    return version
+    return JSON.parse(content).version
   } catch {
-    throw new Error("Cannot find a valid version in its package.json")
+    // throwing an error here is confusing/causes backend-core to be hard to import
+    return undefined
   }
 }
 


### PR DESCRIPTION
## Description
Fix for CLI startup complaining about version not being found.

Current CLI version when installed via CLI shows the following message:
```
Error - Failed to run CLI command - please report with the following message:
Error - Error: Cannot find a valid version in its package.json
```

Removed this error from backend-core as it makes the library much harder to import/use.