### PR TITLE
Fix automation filtering on number fields

### DIFF
--- a/packages/server/src/automations/steps/queryRows.ts
+++ b/packages/server/src/automations/steps/queryRows.ts
@@ -13,6 +13,7 @@ import {
   SearchFilters,
   Table,
 } from "@budibase/types"
+import { db as dbCore } from "@budibase/backend-core"
 
 enum SortOrder {
   ASCENDING = "ascending",
@@ -117,7 +118,11 @@ function typeCoercion(filters: SearchFilters, table: Table) {
     const searchParam = filters[key]
     if (typeof searchParam === "object") {
       for (let [property, value] of Object.entries(searchParam)) {
-        const column = table.schema[property]
+        // We need to strip numerical prefixes here, so that we can look up
+        // the correct field name in the schema
+        const columnName = dbCore.removeKeyNumbering(property)
+        const column = table.schema[columnName]
+
         // convert string inputs
         if (!column || typeof value !== "string") {
           continue


### PR DESCRIPTION
## Description
This PR fixes an issue where the "query rows" automation step does not work when filtering on number fields using a binding. This was broken because it did not account for the numerical key prefixing we use in our filter expression structures.

Addresses: 
- #6049 

I went to update the tests to account for this, but then realised the tests are actually pointless because the actual search operation is completely mocked, so an additional test for this edge case would provide no value.


