### PR TITLE
Revert flatpickr version to fix bug in 3.3.2

### DIFF
--- a/packages/bbui/package.json
+++ b/packages/bbui/package.json
@@ -84,7 +84,7 @@
     "@spectrum-css/vars": "3.0.1",
     "dayjs": "^1.10.4",
     "easymde": "^2.16.1",
-    "svelte-flatpickr": "^3.3.2",
+    "svelte-flatpickr": "3.2.3",
     "svelte-portal": "^1.0.0"
   },
   "resolutions": {

--- a/packages/frontend-core/src/components/grid/cells/DateCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/DateCell.svelte
@@ -13,10 +13,10 @@
   let flatpickr
   let isOpen
 
-  // adding the 0- will turn a string like 00:00:00 into a valid ISO
+  // Adding the 0- will turn a string like 00:00:00 into a valid ISO
   // date, but will make actual ISO dates invalid
-  $: time = new Date(`0-${value}`)
-  $: timeOnly = !isNaN(time) || schema?.timeOnly
+  $: isTimeValue = !isNaN(new Date(`0-${value}`))
+  $: timeOnly = isTimeValue || schema?.timeOnly
   $: dateOnly = schema?.dateOnly
   $: format = timeOnly
     ? "HH:mm:ss"
@@ -24,6 +24,19 @@
     ? "MMM D YYYY"
     : "MMM D YYYY, HH:mm"
   $: editable = focused && !readonly
+  $: displayValue = getDisplayValue(value, format, timeOnly, isTimeValue)
+
+  const getDisplayValue = (value, format, timeOnly, isTimeValue) => {
+    if (!value) {
+      return ""
+    }
+    // Parse full date strings
+    if (!timeOnly || !isTimeValue) {
+      return dayjs(value).format(format)
+    }
+    // Otherwise must be a time string
+    return dayjs(`0-${value}`).format(format)
+  }
 
   // Ensure we close flatpickr when unselected
   $: {
@@ -49,7 +62,7 @@
 <div class="container">
   <div class="value">
     {#if value}
-      {dayjs(timeOnly ? time : value).format(format)}
+      {displayValue}
     {/if}
   </div>
   {#if editable}

--- a/yarn.lock
+++ b/yarn.lock
@@ -22951,7 +22951,14 @@ svelte-dnd-action@^0.9.8:
   resolved "https://registry.yarnpkg.com/svelte-dnd-action/-/svelte-dnd-action-0.9.22.tgz#003eee9dddb31d8c782f6832aec8b1507fff194d"
   integrity sha512-lOQJsNLM1QWv5mdxIkCVtk6k4lHCtLgfE59y8rs7iOM6erchbLC9hMEFYSveZz7biJV0mpg7yDSs4bj/RT/YkA==
 
-svelte-flatpickr@^3.1.0, svelte-flatpickr@^3.2.3, svelte-flatpickr@^3.3.2:
+svelte-flatpickr@3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/svelte-flatpickr/-/svelte-flatpickr-3.2.3.tgz#db5dd7ad832ef83262b45e09737955ad3d591fc8"
+  integrity sha512-PNkqK4Napx8nTvCwkaUXdnKo8dISThaxEOK+szTUXcY6H0dQM0TSyuoMaVWY2yX7pM+PN5cpCQCcVe8YvTRFSw==
+  dependencies:
+    flatpickr "^4.5.2"
+
+svelte-flatpickr@^3.1.0, svelte-flatpickr@^3.2.3:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/svelte-flatpickr/-/svelte-flatpickr-3.3.2.tgz#f08bcde83d439cb30df6fd07b974d87371f130c1"
   integrity sha512-VNJLYyLRDplI63oWX5hJylzAJc2VhTh3z9SNecfjtuPZmP6FZPpg9Fw7rXpkEV2DPovIWj2PtaVxB6Kp9r423w==


### PR DESCRIPTION
## Description
This PR fixes a bug in svelte-flatpickr v3.3.2 in which time-only dates throw errors. Reverting to v3.2.3 fixes this issue.
I've also improved the display of time-only fields inside the Grid, as previously they could flash "Invalid date" due to the inconsistent nature of the value prop that flatpickr uses.

This is being merged to develop rather than master because develop already contains further changes to these same fields and I'd prefer to avoid the conflicts. This is a nasty enough issue but is hopefully rare enough that is not affecting many users, so delaying release slightly should be ok.

Addresses: 
- #10609 

