### PR TITLE
Production app user updates

### DIFF
--- a/packages/backend-core/src/events/identification.ts
+++ b/packages/backend-core/src/events/identification.ts
@@ -86,6 +86,7 @@ const getCurrentIdentity = async (): Promise<Identity> => {
       installationId,
       tenantId,
       environment,
+      realTenantId: context.getTenantId(),
       hostInfo: userContext.hostInfo,
     }
   } else {

--- a/packages/server/src/utilities/global.ts
+++ b/packages/server/src/utilities/global.ts
@@ -122,11 +122,8 @@ export async function getGlobalUsers(
       delete user.forceResetPassword
       return user
     })
-  if (!appId) {
-    return globalUsers
-  }
 
-  if (opts?.noProcessing) {
+  if (opts?.noProcessing || !appId) {
     return globalUsers
   } else {
     // pass in the groups, meaning we don't actually need to retrieve them for


### PR DESCRIPTION
## Description
Fixing an issue with the tenant ID not being found in self host (default) for identification purposes, stopping doc update queue from activating and working as expected.

Also - making the fallback sync cover both the production app (if exists) and the development app - this means that the cleanup should occur for any users that aren't supposed to be there (eventually this will be removed, but for now need this for cleaning).