### PR TITLE
Supported named keys for json logged objects

### DIFF
--- a/packages/backend-core/src/logging/pino/logger.ts
+++ b/packages/backend-core/src/logging/pino/logger.ts
@@ -94,10 +94,35 @@ if (!env.DISABLE_PINO_LOGGER) {
       }
     }
 
-    const mergingObject = {
-      objects: objects.length ? objects : undefined,
+    const mergingObject: any = {
       err: error,
       ...contextObject,
+    }
+
+    if (objects.length) {
+      // init generic data object for params supplied that don't have a
+      // '_logKey' field. This prints an object using argument index as the key
+      // e.g. { 0: {}, 1: {} }
+      const data: any = {}
+      let dataIndex = 0
+
+      for (let i = 0; i < objects.length; i++) {
+        const object = objects[i]
+        // the object has specified a log key
+        // use this instead of generic key
+        const logKey = object._logKey
+        if (logKey) {
+          delete object._logKey
+          mergingObject[logKey] = object
+        } else {
+          data[dataIndex] = object
+          dataIndex++
+        }
+      }
+
+      if (Object.keys(data).length) {
+        mergingObject.data = data
+      }
     }
 
     return [mergingObject, message]

--- a/packages/backend-core/src/queue/listeners.ts
+++ b/packages/backend-core/src/queue/listeners.ts
@@ -45,7 +45,8 @@ function getLogParams(
   const message = `[BULL] ${eventType}=${event}`
   const err = opts.error
 
-  const data = {
+  const bullLog = {
+    _logKey: "bull",
     eventType,
     event,
     job: opts.job,
@@ -53,7 +54,17 @@ function getLogParams(
     ...extra,
   }
 
-  return [message, err, data]
+  let automationLog
+  if (opts.job?.data?.automation) {
+    automationLog = {
+      _logKey: "automation",
+      trigger: opts.job
+        ? opts.job.data.automation.definition.trigger.event
+        : undefined,
+    }
+  }
+
+  return [message, err, bullLog, automationLog]
 }
 
 enum BullEvent {

--- a/packages/server/src/automations/utils.ts
+++ b/packages/server/src/automations/utils.ts
@@ -17,10 +17,16 @@ const CRON_STEP_ID = definitions.CRON.stepId
 const Runner = new Thread(ThreadType.AUTOMATION)
 
 function loggingArgs(job: AutomationJob) {
-  return {
-    jobId: job.id,
-    trigger: job.data.automation.definition.trigger.event,
-  }
+  return [
+    {
+      _logKey: "automation",
+      trigger: job.data.automation.definition.trigger.event,
+    },
+    {
+      _logKey: "bull",
+      jobId: job.id,
+    },
+  ]
 }
 
 export async function processEvent(job: AutomationJob) {
@@ -29,16 +35,16 @@ export async function processEvent(job: AutomationJob) {
   const task = async () => {
     try {
       // need to actually await these so that an error can be captured properly
-      console.log("automation running", loggingArgs(job))
+      console.log("automation running", ...loggingArgs(job))
 
       const runFn = () => Runner.run(job)
       const result = await quotas.addAutomation(runFn, {
         automationId,
       })
-      console.log("automation completed", loggingArgs(job))
+      console.log("automation completed", ...loggingArgs(job))
       return result
     } catch (err) {
-      console.error(`automation was unable to run`, err, loggingArgs(job))
+      console.error(`automation was unable to run`, err, ...loggingArgs(job))
       return { err }
     }
   }


### PR DESCRIPTION
## Description


When we use a log statement like:
```ts
const foo = {} // some object
const bar = {} // some object
console.log("message", foo, bar)
```

We will output the objects in an `objects` array in the json structure. e.g. for the automation data logged:
<img width="550" alt="Screenshot 2023-05-17 at 22 19 18" src="https://github.com/Budibase/budibase/assets/8755148/88652f99-2dfd-41ef-8bb2-a688089826d4">

However the array format is not supported by datadog for creating queryable facets. Therefore we need to use named fields instead. This has been supported using a new field on logged objects `_logKey`. When no log key is specified we will use a generic `data` field with numeric keys.

For example

```ts
const foo = { _logKey: "foo" } 
const bar = {} 
console.log("message", foo, bar)
```

this would result in a json output like:

```json
{
   "foo": {}
   "data": {
      "0": {} // bar
   }
}
```

