### PR TITLE
Return all rows if oneOf value is falsey

### DIFF
--- a/packages/backend-core/src/db/lucene.ts
+++ b/packages/backend-core/src/db/lucene.ts
@@ -343,6 +343,9 @@ export class QueryBuilder<T> {
     }
 
     const oneOf = (key: string, value: any) => {
+      if (!value) {
+        return `*:*`
+      }
       if (!Array.isArray(value)) {
         if (typeof value === "string") {
           value = value.split(",")

--- a/packages/backend-core/src/db/tests/lucene.spec.ts
+++ b/packages/backend-core/src/db/tests/lucene.spec.ts
@@ -114,6 +114,25 @@ describe("lucene", () => {
       expect(resp.rows.length).toBe(2)
     })
 
+    it("should return all rows when doing a one of search against falsey value", async () => {
+      const builder = new QueryBuilder(dbName, INDEX_NAME)
+      builder.addOneOf("property", null)
+      let resp = await builder.run()
+      expect(resp.rows.length).toBe(3)
+
+      builder.addOneOf("property", undefined)
+      resp = await builder.run()
+      expect(resp.rows.length).toBe(3)
+
+      builder.addOneOf("property", "")
+      resp = await builder.run()
+      expect(resp.rows.length).toBe(3)
+
+      builder.addOneOf("property", [])
+      resp = await builder.run()
+      expect(resp.rows.length).toBe(0)
+    })
+
     it("should be able to perform a contains search", async () => {
       const builder = new QueryBuilder(dbName, INDEX_NAME)
       builder.addContains("property", ["word"])


### PR DESCRIPTION
## Description
The **Is in** filter wasn't working with the `Return all table rows` setting in automations. This was because it considered falsey values to be an empty collection.

Code updated so that if a value is falsey (undefined, null, "") all rows will be returned.

If an empty array is provide `[]` then no rows will be returned.

Addresses: 
- https://github.com/Budibase/budibase/issues/10632

## Screenshots
<img width="1247" alt="Screenshot 2023-05-18 at 12 49 47" src="https://github.com/Budibase/budibase/assets/101575380/d5c6969a-2027-4024-8b02-74d3494945a5">

**Return all rows if filter empty**
<img width="1089" alt="Screenshot 2023-05-18 at 12 50 13" src="https://github.com/Budibase/budibase/assets/101575380/db2c182b-76dc-4dee-97b9-73676bb2876c">

**Return no rows if filter empty**
<img width="1089" alt="Screenshot 2023-05-18 at 12 50 45" src="https://github.com/Budibase/budibase/assets/101575380/16a8015c-1609-4a5a-b975-2cdfbdb85a2d">


