### PR TITLE
Datasource+ table fetching API

### DIFF
--- a/packages/server/src/api/controllers/datasource.ts
+++ b/packages/server/src/api/controllers/datasource.ts
@@ -21,7 +21,7 @@ import {
   CreateDatasourceRequest,
   VerifyDatasourceRequest,
   VerifyDatasourceResponse,
-  FetchTablesDatasourceResponse,
+  FetchDatasourceInfoResponse,
   IntegrationBase,
   DatasourcePlus,
 } from "@budibase/types"
@@ -154,8 +154,8 @@ export async function verify(
   }
 }
 
-export async function fetchTables(
-  ctx: UserCtx<void, FetchTablesDatasourceResponse>
+export async function information(
+  ctx: UserCtx<void, FetchDatasourceInfoResponse>
 ) {
   const datasourceId = ctx.params.datasourceId
   const datasource = await sdk.datasources.get(datasourceId, { enriched: true })

--- a/packages/server/src/api/controllers/datasource.ts
+++ b/packages/server/src/api/controllers/datasource.ts
@@ -154,7 +154,7 @@ export async function verify(
   }
 }
 
-export async function tables(
+export async function fetchTables(
   ctx: UserCtx<void, FetchTablesDatasourceResponse>
 ) {
   const datasourceId = ctx.params.datasourceId

--- a/packages/server/src/api/controllers/datasource.ts
+++ b/packages/server/src/api/controllers/datasource.ts
@@ -163,9 +163,9 @@ export async function fetchTables(
   if (!connector.getTableNames) {
     ctx.throw(400, "Table name fetching not supported by datasource")
   }
-  const tables = await connector.getTableNames()
+  const tableNames = await connector.getTableNames()
   ctx.body = {
-    tables,
+    tableNames,
   }
 }
 

--- a/packages/server/src/api/controllers/datasource.ts
+++ b/packages/server/src/api/controllers/datasource.ts
@@ -21,6 +21,7 @@ import {
   CreateDatasourceRequest,
   VerifyDatasourceRequest,
   VerifyDatasourceResponse,
+  FetchTablesDatasourceResponse,
   IntegrationBase,
   DatasourcePlus,
 } from "@budibase/types"
@@ -150,6 +151,21 @@ export async function verify(
   ctx.body = {
     connected: response.connected,
     error: response.error,
+  }
+}
+
+export async function tables(
+  ctx: UserCtx<void, FetchTablesDatasourceResponse>
+) {
+  const datasourceId = ctx.params.datasourceId
+  const datasource = await sdk.datasources.get(datasourceId, { enriched: true })
+  const connector = (await getConnector(datasource)) as DatasourcePlus
+  if (!connector.getTableNames) {
+    ctx.throw(400, "Table name fetching not supported by datasource")
+  }
+  const tables = await connector.getTableNames()
+  ctx.body = {
+    tables,
   }
 }
 

--- a/packages/server/src/api/routes/datasource.ts
+++ b/packages/server/src/api/routes/datasource.ts
@@ -21,9 +21,9 @@ router
     datasourceController.verify
   )
   .get(
-    "/api/datasources/:datasourceId/tables",
+    "/api/datasources/:datasourceId/info",
     authorized(permissions.BUILDER),
-    datasourceController.fetchTables
+    datasourceController.information
   )
   .get(
     "/api/datasources/:datasourceId",

--- a/packages/server/src/api/routes/datasource.ts
+++ b/packages/server/src/api/routes/datasource.ts
@@ -23,7 +23,7 @@ router
   .get(
     "/api/datasources/:datasourceId/tables",
     authorized(permissions.BUILDER),
-    datasourceController.tables
+    datasourceController.fetchTables
   )
   .get(
     "/api/datasources/:datasourceId",

--- a/packages/server/src/api/routes/datasource.ts
+++ b/packages/server/src/api/routes/datasource.ts
@@ -21,6 +21,11 @@ router
     datasourceController.verify
   )
   .get(
+    "/api/datasources/:datasourceId/tables",
+    authorized(permissions.BUILDER),
+    datasourceController.tables
+  )
+  .get(
     "/api/datasources/:datasourceId",
     authorized(
       permissions.PermissionType.TABLE,

--- a/packages/server/src/api/routes/tests/datasource.spec.ts
+++ b/packages/server/src/api/routes/tests/datasource.spec.ts
@@ -87,7 +87,7 @@ describe("/datasources", () => {
         expect(contents.rows.length).toEqual(1)
 
         // update the datasource to remove the variables
-        datasource.config.dynamicVariables = []
+        datasource.config!.dynamicVariables = []
         const res = await request
           .put(`/api/datasources/${datasource._id}`)
           .send(datasource)

--- a/packages/server/src/integration-test/postgres.spec.ts
+++ b/packages/server/src/integration-test/postgres.spec.ts
@@ -1064,7 +1064,7 @@ describe("postgres integrations", () => {
       )
       expect(response.status).toBe(200)
       expect(response.body.tableNames).toBeDefined()
-      expect(response.body.tableNames.indexOf(primaryName)).not.toBe(-10)
+      expect(response.body.tableNames.indexOf(primaryName)).not.toBe(-1)
     })
   })
 })

--- a/packages/server/src/integration-test/postgres.spec.ts
+++ b/packages/server/src/integration-test/postgres.spec.ts
@@ -26,7 +26,7 @@ jest.setTimeout(30000)
 
 jest.unmock("pg")
 
-describe("row api - postgres", () => {
+describe("postgres integrations", () => {
   let makeRequest: MakeRequestResponse,
     postgresDatasource: Datasource,
     primaryPostgresTable: Table,
@@ -440,19 +440,6 @@ describe("row api - postgres", () => {
           })
         )
       })
-    })
-  })
-
-  describe("POST /api/datasources/verify", () => {
-    it("should be able to verify the connection", async () => {
-      const config = pgDatasourceConfig()
-      const response = await makeRequest(
-        "post",
-        "/api/datasources/verify",
-        config
-      )
-      expect(response.status).toBe(200)
-      expect(response.body.connected).toBe(true)
     })
   })
 
@@ -1039,6 +1026,45 @@ describe("row api - postgres", () => {
 
         expect(res.body).toHaveLength(rowsCount)
       })
+    })
+  })
+
+  describe("POST /api/datasources/verify", () => {
+    it("should be able to verify the connection", async () => {
+      const config = pgDatasourceConfig()
+      const response = await makeRequest(
+        "post",
+        "/api/datasources/verify",
+        config
+      )
+      expect(response.status).toBe(200)
+      expect(response.body.connected).toBe(true)
+    })
+
+    it("should state an invalid datasource cannot connect", async () => {
+      const config = pgDatasourceConfig()
+      config.datasource.config.password = "wrongpassword"
+      const response = await makeRequest(
+        "post",
+        "/api/datasources/verify",
+        config
+      )
+      expect(response.status).toBe(200)
+      expect(response.body.connected).toBe(false)
+      expect(response.body.error).toBeDefined()
+    })
+  })
+
+  describe("GET /api/datasources/:datasourceId/tables", () => {
+    it("should fetch tables within postgres datasource", async () => {
+      const primaryName = primaryPostgresTable.name
+      const response = await makeRequest(
+        "get",
+        `/api/datasources/${postgresDatasource._id}/tables`
+      )
+      expect(response.status).toBe(200)
+      expect(response.body.tableNames).toBeDefined()
+      expect(response.body.tableNames.indexOf(primaryName)).not.toBe(-10)
     })
   })
 })

--- a/packages/server/src/integration-test/postgres.spec.ts
+++ b/packages/server/src/integration-test/postgres.spec.ts
@@ -52,8 +52,8 @@ describe("row api - postgres", () => {
     makeRequest = generateMakeRequest(apiKey, true)
   })
 
-  beforeEach(async () => {
-    postgresDatasource = await config.createDatasource({
+  function pgDatasourceConfig() {
+    return {
       datasource: {
         type: "datasource",
         source: SourceName.POSTGRES,
@@ -70,7 +70,11 @@ describe("row api - postgres", () => {
           ca: false,
         },
       },
-    })
+    }
+  }
+
+  beforeEach(async () => {
+    postgresDatasource = await config.createDatasource(pgDatasourceConfig())
 
     async function createAuxTable(prefix: string) {
       return await config.createTable({
@@ -436,6 +440,19 @@ describe("row api - postgres", () => {
           })
         )
       })
+    })
+  })
+
+  describe("POST /api/datasources/verify", () => {
+    it("should be able to verify the connection", async () => {
+      const config = pgDatasourceConfig()
+      const response = await makeRequest(
+        "post",
+        "/api/datasources/verify",
+        config
+      )
+      expect(response.status).toBe(200)
+      expect(response.body.connected).toBe(true)
     })
   })
 

--- a/packages/server/src/integration-test/postgres.spec.ts
+++ b/packages/server/src/integration-test/postgres.spec.ts
@@ -1055,12 +1055,12 @@ describe("postgres integrations", () => {
     })
   })
 
-  describe("GET /api/datasources/:datasourceId/tables", () => {
-    it("should fetch tables within postgres datasource", async () => {
+  describe("GET /api/datasources/:datasourceId/info", () => {
+    it("should fetch information about postgres datasource", async () => {
       const primaryName = primaryPostgresTable.name
       const response = await makeRequest(
         "get",
-        `/api/datasources/${postgresDatasource._id}/tables`
+        `/api/datasources/${postgresDatasource._id}/info`
       )
       expect(response.status).toBe(200)
       expect(response.body.tableNames).toBeDefined()

--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -240,6 +240,11 @@ class GoogleSheetsIntegration implements DatasourcePlus {
     }
   }
 
+  getTableNames(): Promise<string[]> {
+    // TODO: implement
+    return Promise.resolve([])
+  }
+
   getTableSchema(title: string, headerValues: string[], id?: string) {
     // base table
     const table: Table = {

--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -63,10 +63,13 @@ const SCHEMA: Integration = {
   relationships: false,
   docs: "https://developers.google.com/sheets/api/quickstart/nodejs",
   description:
-    "Create and collaborate on online spreadsheets in real-time and from any device. ",
+    "Create and collaborate on online spreadsheets in real-time and from any device.",
   friendlyName: "Google Sheets",
   type: "Spreadsheet",
-  features: [DatasourceFeature.CONNECTION_CHECKING],
+  features: [
+    DatasourceFeature.CONNECTION_CHECKING,
+    DatasourceFeature.FETCH_TABLE_NAMES,
+  ],
   datasource: {
     spreadsheetId: {
       display: "Google Sheet URL",

--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -243,9 +243,10 @@ class GoogleSheetsIntegration implements DatasourcePlus {
     }
   }
 
-  getTableNames(): Promise<string[]> {
-    // TODO: implement
-    return Promise.resolve([])
+  async getTableNames(): Promise<string[]> {
+    await this.connect()
+    const sheets = this.client.sheetsByIndex
+    return sheets.map(s => s.title)
   }
 
   getTableSchema(title: string, headerValues: string[], id?: string) {

--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -148,7 +148,6 @@ class GoogleSheetsIntegration implements DatasourcePlus {
   async testConnection(): Promise<ConnectionInfo> {
     try {
       await this.connect()
-      await this.client.loadInfo()
       return { connected: true }
     } catch (e: any) {
       return {

--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -40,7 +40,10 @@ const SCHEMA: Integration = {
     "Microsoft SQL Server is a relational database management system developed by Microsoft. ",
   friendlyName: "MS SQL Server",
   type: "Relational",
-  features: [DatasourceFeature.CONNECTION_CHECKING],
+  features: [
+    DatasourceFeature.CONNECTION_CHECKING,
+    DatasourceFeature.FETCH_TABLE_NAMES,
+  ],
   datasource: {
     user: {
       type: DatasourceFieldType.STRING,

--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -20,7 +20,6 @@ import {
 } from "./utils"
 import Sql from "./base/sql"
 import { MSSQLTablesResponse, MSSQLColumn } from "./base/types"
-
 const sqlServer = require("mssql")
 const DEFAULT_SCHEMA = "dbo"
 
@@ -282,6 +281,20 @@ class SqlServerIntegration extends Sql implements DatasourcePlus {
     const final = finaliseExternalTables(tables, entities)
     this.tables = final.tables
     this.schemaErrors = final.errors
+  }
+
+  async queryTableNames() {
+    let tableInfo: MSSQLTablesResponse[] = await this.runSQL(this.TABLES_SQL)
+    const schema = this.config.schema || DEFAULT_SCHEMA
+    return tableInfo
+      .filter((record: any) => record.TABLE_SCHEMA === schema)
+      .map((record: any) => record.TABLE_NAME)
+      .filter((name: string) => this.MASTER_TABLES.indexOf(name) === -1)
+  }
+
+  async getTableNames() {
+    await this.connect()
+    return this.queryTableNames()
   }
 
   async read(query: SqlQuery | string) {

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -36,7 +36,10 @@ const SCHEMA: Integration = {
   type: "Relational",
   description:
     "MySQL Database Service is a fully managed database service to deploy cloud-native applications. ",
-  features: [DatasourceFeature.CONNECTION_CHECKING],
+  features: [
+    DatasourceFeature.CONNECTION_CHECKING,
+    DatasourceFeature.FETCH_TABLE_NAMES,
+  ],
   datasource: {
     host: {
       type: DatasourceFieldType.STRING,

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -214,20 +214,11 @@ class MySQLIntegration extends Sql implements DatasourcePlus {
 
   async buildSchema(datasourceId: string, entities: Record<string, Table>) {
     const tables: { [key: string]: Table } = {}
-    const database = this.config.database
     await this.connect()
 
     try {
       // get the tables first
-      const tablesResp: Record<string, string>[] = await this.internalQuery(
-        { sql: "SHOW TABLES;" },
-        { connect: false }
-      )
-      const tableNames: string[] = tablesResp.map(
-        (obj: any) =>
-          obj[`Tables_in_${database}`] ||
-          obj[`Tables_in_${database.toLowerCase()}`]
-      )
+      const tableNames = await this.queryTableNames()
       for (let tableName of tableNames) {
         const primaryKeys = []
         const schema: TableSchema = {}
@@ -272,6 +263,28 @@ class MySQLIntegration extends Sql implements DatasourcePlus {
     const final = finaliseExternalTables(tables, entities)
     this.tables = final.tables
     this.schemaErrors = final.errors
+  }
+
+  async queryTableNames() {
+    const database = this.config.database
+    const tablesResp: Record<string, string>[] = await this.internalQuery(
+      { sql: "SHOW TABLES;" },
+      { connect: false }
+    )
+    return tablesResp.map(
+      (obj: any) =>
+        obj[`Tables_in_${database}`] ||
+        obj[`Tables_in_${database.toLowerCase()}`]
+    )
+  }
+
+  async getTableNames() {
+    await this.connect()
+    try {
+      return this.queryTableNames()
+    } finally {
+      await this.disconnect()
+    }
   }
 
   async create(query: SqlQuery | string) {

--- a/packages/server/src/integrations/oracle.ts
+++ b/packages/server/src/integrations/oracle.ts
@@ -50,7 +50,10 @@ const SCHEMA: Integration = {
   type: "Relational",
   description:
     "Oracle Database is an object-relational database management system developed by Oracle Corporation",
-  features: [DatasourceFeature.CONNECTION_CHECKING],
+  features: [
+    DatasourceFeature.CONNECTION_CHECKING,
+    DatasourceFeature.FETCH_TABLE_NAMES,
+  ],
   datasource: {
     host: {
       type: DatasourceFieldType.STRING,

--- a/packages/server/src/integrations/oracle.ts
+++ b/packages/server/src/integrations/oracle.ts
@@ -330,11 +330,7 @@ class OracleIntegration extends Sql implements DatasourcePlus {
     const columnsResponse = await this.internalQuery<OracleColumnsResponse>({
       sql: this.COLUMNS_SQL,
     })
-    if (!columnsResponse.rows) {
-      return []
-    } else {
-      return columnsResponse.rows.map(row => row.TABLE_NAME)
-    }
+    return (columnsResponse.rows || []).map(row => row.TABLE_NAME)
   }
 
   async testConnection() {

--- a/packages/server/src/integrations/oracle.ts
+++ b/packages/server/src/integrations/oracle.ts
@@ -323,6 +323,17 @@ class OracleIntegration extends Sql implements DatasourcePlus {
     this.schemaErrors = final.errors
   }
 
+  async getTableNames() {
+    const columnsResponse = await this.internalQuery<OracleColumnsResponse>({
+      sql: this.COLUMNS_SQL,
+    })
+    if (!columnsResponse.rows) {
+      return []
+    } else {
+      return columnsResponse.rows.map(row => row.TABLE_NAME)
+    }
+  }
+
   async testConnection() {
     const response: ConnectionInfo = {
       connected: false,

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -52,7 +52,10 @@ const SCHEMA: Integration = {
   type: "Relational",
   description:
     "PostgreSQL, also known as Postgres, is a free and open-source relational database management system emphasizing extensibility and SQL compliance.",
-  features: [DatasourceFeature.CONNECTION_CHECKING],
+  features: [
+    DatasourceFeature.CONNECTION_CHECKING,
+    DatasourceFeature.FETCH_TABLE_NAMES,
+  ],
   datasource: {
     host: {
       type: DatasourceFieldType.STRING,

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -311,6 +311,17 @@ class PostgresIntegration extends Sql implements DatasourcePlus {
     }
   }
 
+  async getTableNames() {
+    try {
+      await this.openConnection()
+      const columnsResponse: { rows: PostgresColumn[] } =
+        await this.client.query(this.COLUMNS_SQL)
+      return columnsResponse.rows.map(row => row.table_name)
+    } finally {
+      await this.closeConnection()
+    }
+  }
+
   async create(query: SqlQuery | string) {
     const response = await this.internalQuery(getSqlQuery(query))
     return response.rows.length ? response.rows : [{ created: true }]

--- a/packages/server/src/integrations/tests/googlesheets.spec.ts
+++ b/packages/server/src/integrations/tests/googlesheets.spec.ts
@@ -144,4 +144,15 @@ describe("Google Sheets Integration", () => {
       })
     })
   })
+
+  describe("testConnection", () => {
+    it("can test successful connections", async () => {
+      await config.doInContext(structures.uuid(), async () => {
+        const res = await integration.testConnection()
+
+        expect(mockGoogleIntegration.loadInfo).toBeCalledTimes(1)
+        expect(res).toEqual({ connected: true })
+      })
+    })
+  })
 })

--- a/packages/server/src/integrations/tests/googlesheets.spec.ts
+++ b/packages/server/src/integrations/tests/googlesheets.spec.ts
@@ -18,15 +18,14 @@ const { GoogleSpreadsheet } = require("google-spreadsheet")
 
 const sheetsByTitle: { [title: string]: GoogleSpreadsheetWorksheet } = {}
 const sheetsByIndex: GoogleSpreadsheetWorksheet[] = []
+const mockGoogleIntegration = {
+  useOAuth2Client: jest.fn(),
+  loadInfo: jest.fn(),
+  sheetsByTitle,
+  sheetsByIndex,
+}
 
-GoogleSpreadsheet.mockImplementation(() => {
-  return {
-    useOAuth2Client: jest.fn(),
-    loadInfo: jest.fn(),
-    sheetsByTitle,
-    sheetsByIndex,
-  }
-})
+GoogleSpreadsheet.mockImplementation(() => mockGoogleIntegration)
 
 import { structures } from "@budibase/backend-core/tests"
 import TestConfiguration from "../../tests/utilities/TestConfiguration"
@@ -55,6 +54,8 @@ describe("Google Sheets Integration", () => {
       },
     })
     await config.init()
+
+    jest.clearAllMocks()
   })
 
   function createBasicTable(name: string, columns: string[]): Table {
@@ -137,6 +138,8 @@ describe("Google Sheets Integration", () => {
         }
 
         const res = await integration.getTableNames()
+
+        expect(mockGoogleIntegration.loadInfo).toBeCalledTimes(1)
         expect(res).toEqual(sheetNames)
       })
     })

--- a/packages/types/src/api/web/app/datasource.ts
+++ b/packages/types/src/api/web/app/datasource.ts
@@ -23,7 +23,7 @@ export interface VerifyDatasourceResponse {
   error?: string
 }
 
-export interface FetchTablesDatasourceResponse {
+export interface FetchDatasourceInfoResponse {
   tableNames: string[]
 }
 

--- a/packages/types/src/api/web/app/datasource.ts
+++ b/packages/types/src/api/web/app/datasource.ts
@@ -23,6 +23,10 @@ export interface VerifyDatasourceResponse {
   error?: string
 }
 
+export interface FetchTablesDatasourceResponse {
+  tables: string[]
+}
+
 export interface UpdateDatasourceRequest extends Datasource {
   datasource: Datasource
 }

--- a/packages/types/src/api/web/app/datasource.ts
+++ b/packages/types/src/api/web/app/datasource.ts
@@ -24,7 +24,7 @@ export interface VerifyDatasourceResponse {
 }
 
 export interface FetchTablesDatasourceResponse {
-  tables: string[]
+  tableNames: string[]
 }
 
 export interface UpdateDatasourceRequest extends Datasource {

--- a/packages/types/src/sdk/datasources.ts
+++ b/packages/types/src/sdk/datasources.ts
@@ -75,6 +75,7 @@ export enum FilterType {
 
 export enum DatasourceFeature {
   CONNECTION_CHECKING = "connection",
+  FETCH_TABLE_NAMES = "fetch_table_names",
 }
 
 export interface StepDefinition {

--- a/packages/types/src/sdk/datasources.ts
+++ b/packages/types/src/sdk/datasources.ts
@@ -150,4 +150,5 @@ export interface DatasourcePlus extends IntegrationBase {
   getBindingIdentifier(): string
   getStringConcat(parts: string[]): string
   buildSchema(datasourceId: string, entities: Record<string, Table>): any
+  getTableNames(): Promise<string[]>
 }


### PR DESCRIPTION
## Description
This introduces a new API endpoint for datasource+ types, which allows retrieving the list of tables which are available within the datasource.

This does not attempt to retrieve any information about the schema of each of the tables, as this is strictly for determining which tables are of interest - we should not retrieve any information beyond what is required to confirm with the user the tables they need.

I've also introduced a new feature flag which can be used for determining whether or not the datasource supports the table fetching feature - this can be assumed for all datasource+ databases, but this could change in future (some DS+ might not be able to do this).

I've also added some more test cases for this, using the new API endpoint `GET /api/datasources/:datasourceId/tables` as well as some basic test cases for the connection verification API `/api/datasources/verify` - these will run as part of CI against Postgres.