### PR TITLE
add role field to snowflake datasource connection

### DIFF
--- a/packages/server/src/integrations/snowflake.ts
+++ b/packages/server/src/integrations/snowflake.ts
@@ -29,6 +29,9 @@ const SCHEMA: Integration = {
       type: "password",
       required: true,
     },
+    role: {
+      type: "string",
+    },
     warehouse: {
       type: "string",
       required: true,


### PR DESCRIPTION
## Description
Allow the user to select a role for their Snowflake queries. Currently you can only use the specified user's default role.

Addresses: 
- #10667 

## Screenshots
### No role specified (same as current Budibase behaviour)
![SCR-20230523-hob-2](https://github.com/Budibase/budibase/assets/110921612/13fa341b-105c-44a0-a500-fdd8dd6664b6)
#### Uses user's default role
![SCR-20230523-ho1](https://github.com/Budibase/budibase/assets/110921612/48498c8c-f901-4444-a8e5-d24ecc84c5fe)

### Specifying a different role (new functionality)
![SCR-20230523-hor-2](https://github.com/Budibase/budibase/assets/110921612/01c99c6d-64bd-417d-8f1e-6b02e1a14e66)
#### Uses specified role instead of default
![SCR-20230523-hnm](https://github.com/Budibase/budibase/assets/110921612/a24dc16f-d169-415a-bfa0-fa78bbd42e6a)


## Documentation
- [x] I have reviewed the Budibase documentation to verify if this feature requires any changes. If changes or new docs are required I have written them.



