### PR TITLE
[Fixed] Solve a problem with joi validator middleware

### DIFF
--- a/packages/backend-core/src/middleware/joi-validator.ts
+++ b/packages/backend-core/src/middleware/joi-validator.ts
@@ -29,10 +29,12 @@ function validate(
 
     const { error } = schema.validate(params)
     if (error) {
-      ctx.throw(400, `Invalid ${property} - ${error.message}`)
-      return
+      ctx.status = 400
+      ctx.body = `Invalid ${property} - ${error.message}`
+      ctx.throw(ctx.status, ctx.body)
+    } else {
+      return next()
     }
-    return next()
   }
 }
 


### PR DESCRIPTION
## Description

The current implementation of joi validator has a problem; with the current implementation the error code and message are not given in the validation.

Without the change in this PR, we get `404` instead `400`:

```
Error: expect(received).toBe(expected) // Object.is equality

Expected: 400
Received: 404
    at (...)/tests/stripe.spec.ts:63:31
Expected :400
Actual   :404
```

I've added `400` error and body to the validation.

Addresses: 

https://linear.app/budibase/issue/BUDI-6925/update-plan-inside-account-portal

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.