### PR TITLE
Fix incorrect couchdb url in helm chart

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -46,7 +46,7 @@ spec:
           {{ if .Values.services.couchdb.url }}
           value: {{ .Values.services.couchdb.url }}
           {{ else }}
-          value: http://{{ .Release.Name }}-svc-couchdb:{{ .Values.services.couchdb.port }}
+          value: http://{{ .Release.Name }}-svc-couchdb.{{ .Release.Namespace }}.svc.{{ .Values.services.dns }}:{{ .Values.services.couchdb.port }}
           {{ end }}
         {{ if .Values.services.couchdb.enabled }}
         - name: COUCH_DB_USER

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -40,7 +40,7 @@ service:
   port: 10000
 
 ingress:
-  enabled: false
+  enabled: true
   aws: false
   nginx: true
   certificateArn: ""

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -44,7 +44,7 @@ ingress:
   aws: false
   nginx: false
   certificateArn: ""
-  className: "nginx"
+  className: ""
   annotations:
     nginx.ingress.kubernetes.io/client-max-body-size: 150M
     nginx.ingress.kubernetes.io/proxy-body-size: 50m
@@ -291,7 +291,6 @@ couchdb:
       - chart-example.local
     path: /
     annotations:
-      []
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     tls:

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -121,7 +121,7 @@ services:
       apps: 'http://app-service.{{ .Release.Namespace }}.svc.{{ .Values.services.dns }}:{{ .Values.services.apps.port }}'
       worker: 'http://worker-service.{{ .Release.Namespace }}.svc.{{ .Values.services.dns }}:{{ .Values.services.worker.port }}'
       minio: 'http://minio-service.{{ .Release.Namespace }}.svc.{{ .Values.services.dns }}:{{ .Values.services.objectStore.port }}'
-      couchdb: 'http://{{ .Release.Name }}-svc-couchdb:{{ .Values.services.couchdb.port }}'
+      couchdb: 'http://{{ .Release.Name }}-svc-couchdb.{{ .Release.Namespace }}.svc.{{ .Values.services.dns }}:{{ .Values.services.couchdb.port }}'
     resources: {}
 #    annotations:
 #      co.elastic.logs/module: nginx

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -291,7 +291,7 @@ couchdb:
     hosts:
       - chart-example.local
     path: /
-    annotations:
+    annotations: []
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     tls:

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -40,12 +40,13 @@ service:
   port: 10000
 
 ingress:
-  enabled: true
+  enabled: false
   aws: false
-  nginx: false
+  nginx: true
   certificateArn: ""
   className: ""
   annotations:
+    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/client-max-body-size: 150M
     nginx.ingress.kubernetes.io/proxy-body-size: 50m
   hosts:

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -42,11 +42,10 @@ service:
 ingress:
   enabled: true
   aws: false
-  nginx: true
+  nginx: false
   certificateArn: ""
-  className: ""
+  className: "nginx"
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/client-max-body-size: 150M
     nginx.ingress.kubernetes.io/proxy-body-size: 50m
   hosts:

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -291,7 +291,8 @@ couchdb:
     hosts:
       - chart-example.local
     path: /
-    annotations: []
+    annotations:
+      []
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     tls:


### PR DESCRIPTION
## Description
The couchdb url prefixed in the deployment is missing the DNS suffix

Addresses: 

## App Export

## Screenshots

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



