### PR TITLE
Chore - Respect esbuild config paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "devDependencies": {
     "@esbuild-plugins/node-resolve": "^0.2.2",
+    "@esbuild-plugins/tsconfig-paths": "^0.1.2",
     "@nx/esbuild": "16.2.1",
     "@nx/js": "16.2.1",
     "@rollup/plugin-json": "^4.0.2",

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -8,7 +8,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "incremental": true,
-    "types": ["node", "jest"],
+    "types": ["node"],
     "outDir": "dist/src",
     "skipLibCheck": true,
     "baseUrl": ".",

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -8,7 +8,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "incremental": true,
-    "types": ["node"],
+    "types": ["node", "jest"],
     "outDir": "dist/src",
     "skipLibCheck": true,
     "baseUrl": ".",

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -5,8 +5,7 @@
     "declaration": true,
     "sourceMap": true,
     "baseUrl": ".",
-    "outDir": "dist",
-    "types": ["node", "jest"]
+    "outDir": "dist"
   },
   "ts-node": {
     "require": ["tsconfig-paths/register"],

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -6,13 +6,7 @@
     "sourceMap": true,
     "baseUrl": ".",
     "outDir": "dist",
-    "paths": {
-      "@budibase/types": ["../types/src"],
-      "@budibase/backend-core": ["../backend-core/src"],
-      "@budibase/backend-core/*": ["../backend-core/*"],
-      "@budibase/shared-core": ["../shared-core/src"],
-      "@budibase/pro": ["../pro/packages/pro/src"]
-    }
+    "types": ["node", "jest"]
   },
   "ts-node": {
     "require": ["tsconfig-paths/register"],

--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -4,13 +4,7 @@
     "composite": true,
     "declaration": true,
     "sourceMap": true,
-    "baseUrl": ".",
-    "paths": {
-      "@budibase/types": ["../types/src"],
-      "@budibase/backend-core": ["../backend-core/src"],
-      "@budibase/backend-core/*": ["../backend-core/*"],
-      "@budibase/pro": ["../pro/packages/pro/src"]
-    }
+    "baseUrl": "."
   },
   "ts-node": {
     "require": ["tsconfig-paths/register"],

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -9,6 +9,9 @@ const path = require("path")
 const { build } = require("esbuild")
 
 const { default: NodeResolve } = require("@esbuild-plugins/node-resolve")
+const {
+  default: TsconfigPathsPlugin,
+} = require("@esbuild-plugins/tsconfig-paths")
 
 var argv = require("minimist")(process.argv.slice(2))
 
@@ -23,6 +26,7 @@ function runBuild(entry, outfile) {
     sourcemap: isDev,
     tsconfig,
     plugins: [
+      TsconfigPathsPlugin({ tsconfig }),
       NodeResolve({
         extensions: [".ts", ".js"],
         onResolved: resolved => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2047,6 +2047,15 @@
     escape-string-regexp "^4.0.0"
     resolve "^1.19.0"
 
+"@esbuild-plugins/tsconfig-paths@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@esbuild-plugins/tsconfig-paths/-/tsconfig-paths-0.1.2.tgz#1955de0a124ecf4364717a2fadbfbea876955232"
+  integrity sha512-TusFR26Y+Ze+Zm+NdfqZTSG4XyrXKxIaAfYCL3jASEI/gHjSdoCujATjzNWaaXs6Sk6Bv2D7NLr4Jdz1gysy/Q==
+  dependencies:
+    debug "^4.3.1"
+    find-up "^5.0.0"
+    strip-json-comments "^3.1.1"
+
 "@esbuild/android-arm64@0.16.17":
   version "0.16.17"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz#cf91e86df127aa3d141744edafcba0abdc577d23"
@@ -12085,6 +12094,14 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 findit2@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/findit2/-/findit2-2.2.3.tgz#58a466697df8a6205cdfdbf395536b8bd777a5f6"
@@ -17012,6 +17029,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lodash-es@^4.17.11:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
@@ -19371,7 +19395,7 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.1.0:
+p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -19405,6 +19429,13 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-map-series@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Description
We found an issue that if a package (lets say `backend-core`) was built, when building the server via esbuild, that dist folder was used instead of using the tsconfig.paths defined. This broke our dev experience.
This PR is solving this by using the `tsconfig-paths` esbuild plugin