### PR TITLE
Fixing conflicting external references

### DIFF
--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           node-version: 14.x
 
-      - run: yarn
+      - run: yarn install --frozen-lockfile
       - name: Update versions
         run: |
           version=$(cat lerna.json \

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           node-version: 14.x
 
-      - run: yarn
+      - run: yarn install --frozen-lockfile
       - name: Update versions
         run: |
           version=$(cat lerna.json \

--- a/packages/worker/project.json
+++ b/packages/worker/project.json
@@ -17,6 +17,7 @@
             "output": "."
           }
         ],
+        "external": ["graphql/*", "deasync", "mock-aws-s3", "nock"],
         "format": ["cjs"],
         "esbuildOptions": {
           "outExtension": {


### PR DESCRIPTION
## Description
In some cases, the nx/esbuild is not automatically detecting the externals. This adds the specific conflicting externals to avoid this conflicts while investigating the wider issue