### PR TITLE
Fix for fetching Internal DB Views in QA cloud

### DIFF
--- a/packages/server/src/db/inMemoryView.ts
+++ b/packages/server/src/db/inMemoryView.ts
@@ -25,9 +25,8 @@ export async function runView(
       }))
     )
     let fn = (doc: Document, emit: any) => emit(doc._id)
-    ;(0, eval)(
-      "fn = " + view?.map?.replace("function (doc)", "function (doc, emit)")
-    )
+    // BUDI-7060 -> indirect eval call appears to cause issues in cloud
+    eval("fn = " + view?.map?.replace("function (doc)", "function (doc, emit)"))
     const queryFns: any = {
       meta: view.meta,
       map: fn,


### PR DESCRIPTION
## Description

The indirect call to `eval` in `inMemoryViews.ts` was causing view fetches in the QA cloud system to fail.
Reverting back to a direct call fixes the issue.

Addresses: 
- BUDI-7060


