### PR TITLE
Reset pro dependencies before the npm push

### DIFF
--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -54,6 +54,9 @@ jobs:
       - run: yarn build --configuration=production
       - run: yarn build:sdk
 
+      - name: Reset pro dependencies
+        run: node scripts/resetProDependencies.js
+
       - name: Publish budibase packages to NPM
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -60,6 +60,9 @@ jobs:
       - run: yarn build --configuration=production
       - run: yarn build:sdk
 
+      - name: Reset pro dependencies
+        run: node scripts/resetProDependencies.js
+
       - name: Publish budibase packages to NPM
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/resetProDependencies.js
+++ b/scripts/resetProDependencies.js
@@ -1,0 +1,38 @@
+const fs = require("fs")
+const path = require("path")
+const { execSync } = require("child_process")
+
+// Get the list of workspaces with mismatched dependencies
+const output = execSync("yarn --silent workspaces info --json", {
+  encoding: "utf-8",
+})
+const data = JSON.parse(output)
+
+const packageJsonPath = path.join(
+  data["@budibase/pro"].location,
+  "package.json"
+)
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"))
+
+let hasChanges = false
+
+const dependencies = data["@budibase/pro"].workspaceDependencies
+dependencies.forEach(dependency => {
+  if (packageJson.dependencies?.[dependency]) {
+    packageJson.dependencies[dependency] = "0.0.1"
+    hasChanges = true
+  }
+  if (packageJson.devDependencies?.[dependency]) {
+    packageJson.devDependencies[dependency] = "0.0.1"
+    hasChanges = true
+  }
+  if (packageJson.peerDependencies?.[dependency]) {
+    packageJson.peerDependencies[dependency] = "0.0.1"
+    hasChanges = true
+  }
+})
+
+// Write changes to package.json if there are any
+if (hasChanges) {
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + "\n")
+}


### PR DESCRIPTION
## Description
Fixing an issue caused by running the monorepo as open source contributor.
They will be pulling the pro packages that will have versions of @budibase/whatever as dependency. Because locally we have 0.0.1, it will pull these versions. This will cause conflicts between both versions of packages being located in different folders.

These changes will ensure that pro can only work within the monorepo, linking with the expected packages.