### PR TITLE
Publish to docker before pushing to npm

### DIFF
--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -54,6 +54,14 @@ jobs:
       - run: yarn build --configuration=production
       - run: yarn build:sdk
 
+      - name: Build/release Docker images
+        run: |
+          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+          yarn build:docker:develop
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}
+
       - name: Reset pro dependencies
         run: node scripts/resetProDependencies.js
 
@@ -68,14 +76,6 @@ jobs:
           git commit -a -m 'Release process'
           echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} >> .npmrc 
           yarn release:develop
-
-      - name: Build/release Docker images
-        run: |
-          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-          yarn build:docker:develop
-        env:
-          DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}
 
   release-helm-chart:
     needs: [release-images]

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -60,6 +60,19 @@ jobs:
       - run: yarn build --configuration=production
       - run: yarn build:sdk
 
+      - name: "Get Previous tag"
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+
+      - name: Build/release Docker images
+        run: |
+          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+          yarn build:docker
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}
+          BUDIBASE_RELEASE_VERSION: ${{ steps.previoustag.outputs.tag }}
+
       - name: Reset pro dependencies
         run: node scripts/resetProDependencies.js
 
@@ -75,19 +88,6 @@ jobs:
           git commit -a -m 'Release process'
           echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} >> .npmrc
           yarn release
-
-      - name: "Get Previous tag"
-        id: previoustag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
-
-      - name: Build/release Docker images
-        run: |
-          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-          yarn build:docker
-        env:
-          DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}
-          BUDIBASE_RELEASE_VERSION: ${{ steps.previoustag.outputs.tag }}
 
   release-helm-chart:
     needs: [release-images]


### PR DESCRIPTION
## Description
As we are now reverting the package dependencies to 0.0.1 to handle pro issues (https://github.com/Budibase/budibase/pull/10717), we want to change the docker deploy to avoid pointing to wrong packages. This assures that the docker is using the right versions