### PR TITLE
Disable websocket HTTP polling

### DIFF
--- a/packages/builder/src/builderStore/websocket.js
+++ b/packages/builder/src/builderStore/websocket.js
@@ -24,7 +24,7 @@ export const createBuilderWebsocket = () => {
     tables.replaceTable(id, table)
   })
 
-  // Table events
+  // Datasource events
   socket.on("datasource-change", ({ id, datasource }) => {
     datasources.replaceDatasource(id, datasource)
   })

--- a/packages/builder/src/components/start/AppRow.svelte
+++ b/packages/builder/src/components/start/AppRow.svelte
@@ -2,14 +2,12 @@
   import { Heading, Body, Button, Icon } from "@budibase/bbui"
   import { processStringSync } from "@budibase/string-templates"
   import { goto } from "@roxi/routify"
-  import { helpers } from "@budibase/shared-core"
   import { UserAvatar } from "@budibase/frontend-core"
 
   export let app
   export let lockedAction
 
   $: editing = app?.lockedBy != null
-  $: initials = helpers.getUserInitials(app?.lockedBy)
 
   const handleDefaultClick = () => {
     if (window.innerWidth < 640) {

--- a/packages/builder/src/pages/builder/portal/apps/index.svelte
+++ b/packages/builder/src/pages/builder/portal/apps/index.svelte
@@ -355,7 +355,6 @@
     justify-content: flex-start;
     align-items: stretch;
     gap: var(--spacing-xl);
-    overflow: hidden;
   }
 
   .empty-wrapper {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -41,7 +41,6 @@
     "sanitize-html": "^2.7.0",
     "screenfull": "^6.0.1",
     "shortid": "^2.2.15",
-    "socket.io-client": "^4.5.1",
     "svelte": "^3.49.0",
     "svelte-apexcharts": "^1.0.2",
     "svelte-flatpickr": "^3.1.0",

--- a/packages/client/src/websocket.js
+++ b/packages/client/src/websocket.js
@@ -4,7 +4,7 @@ import {
   notificationStore,
 } from "./stores/index.js"
 import { get } from "svelte/store"
-import { io } from "socket.io-client"
+import { createWebsocket } from "@budibase/frontend-core"
 
 let socket
 
@@ -18,20 +18,7 @@ export const initWebsocket = () => {
   }
 
   // Initialise connection
-  const tls = location.protocol === "https:"
-  const proto = tls ? "wss:" : "ws:"
-  const host = location.hostname
-  const port = location.port || (tls ? 443 : 80)
-  socket = io(`${proto}//${host}:${port}`, {
-    path: "/socket/client",
-    // Cap reconnection attempts to 3 (total of 15 seconds before giving up)
-    reconnectionAttempts: 3,
-    // Delay reconnection attempt by 5 seconds
-    reconnectionDelay: 5000,
-    reconnectionDelayMax: 5000,
-    // Timeout after 4 seconds so we never stack requests
-    timeout: 4000,
-  })
+  socket = createWebsocket("/socket/client")
 
   // Event handlers
   socket.on("plugin-update", data => {

--- a/packages/frontend-core/src/utils/websocket.js
+++ b/packages/frontend-core/src/utils/websocket.js
@@ -19,5 +19,8 @@ export const createWebsocket = path => {
     reconnectionDelayMax: 5000,
     // Timeout after 4 seconds so we never stack requests
     timeout: 4000,
+    // Disable polling and rely on websocket only, as HTTP transport
+    // will only work with sticky sessions which we don't have
+    transports: ["websocket"]
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -22932,7 +22932,7 @@ socket.io-adapter@~2.5.2:
   dependencies:
     ws "~8.11.0"
 
-socket.io-client@^4.5.1, socket.io-client@^4.6.1:
+socket.io-client@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.6.1.tgz#80d97d5eb0feca448a0fb6d69a7b222d3d547eab"
   integrity sha512-5UswCV6hpaRsNg5kkEHVcbBIXEYoVbMQaHJBXJCyEQ+CiFPV1NIOY0XOFWG4XR4GZcB8Kn6AsRs/9cy9TbqVMQ==


### PR DESCRIPTION
## Description
This PR disables the HTTP polling transport option for socket.io, to ensure that we never attempt to use it. HTTP polling relies on sticky connections, which we don't have, and having it enabled attempts to perform a handshake which will fail in cloud environments.



