### PR TITLE
Add teardown logic for multitenancy

### DIFF
--- a/qa-core/src/account-api/api/apis/AccountAPI.ts
+++ b/qa-core/src/account-api/api/apis/AccountAPI.ts
@@ -58,4 +58,10 @@ export default class AccountAPI {
     }
     return [response, json]
   }
+
+  async delete(accountID: string) {
+    const [response, json] = await this.client.del(`/api/accounts/${accountID}`)
+    expect(response).toHaveStatusCode(200)
+    return response
+  }
 }

--- a/qa-core/src/jest/globalSetup.ts
+++ b/qa-core/src/jest/globalSetup.ts
@@ -2,7 +2,7 @@ import { DEFAULT_TENANT_ID, logging } from "@budibase/backend-core"
 import { AccountInternalAPI } from "../account-api"
 import * as fixtures from "../internal-api/fixtures"
 import { BudibaseInternalAPI } from "../internal-api"
-import { CreateAccountRequest, Feature } from "@budibase/types"
+import { Account, CreateAccountRequest, Feature } from "@budibase/types"
 import env from "../environment"
 import { APIRequestOpts } from "../types"
 
@@ -18,13 +18,13 @@ const API_OPTS: APIRequestOpts = { doExpect: false }
 // @ts-ignore
 global.qa = {}
 
-async function createAccount() {
+async function createAccount(): Promise<[CreateAccountRequest, Account]> {
   const account = fixtures.accounts.generateAccount()
   await accountsApi.accounts.validateEmail(account.email, API_OPTS)
   await accountsApi.accounts.validateTenantId(account.tenantId, API_OPTS)
   const [res, newAccount] = await accountsApi.accounts.create(account, API_OPTS)
   await updateLicense(newAccount.accountId)
-  return account
+  return [account, newAccount]
 }
 
 const UNLIMITED = { value: -1 }
@@ -85,9 +85,11 @@ async function setup() {
   console.log(`Environment: ${JSON.stringify(env)}`)
 
   if (env.multiTenancy) {
-    const account = await createAccount()
+    const [account, newAccount] = await createAccount()
     // @ts-ignore
     global.qa.tenantId = account.tenantId
+    // @ts-ignore
+    global.qa.accountId = newAccount.accountId
     await loginAsAccount(account)
   } else {
     // @ts-ignore

--- a/qa-core/src/jest/globalTeardown.ts
+++ b/qa-core/src/jest/globalTeardown.ts
@@ -1,7 +1,24 @@
+import { AccountInternalAPI } from "../account-api"
+import { BudibaseInternalAPI } from "../internal-api"
+import { APIRequestOpts } from "../types"
+
+const accountsApi = new AccountInternalAPI({})
+const internalApi = new BudibaseInternalAPI({})
+
+const API_OPTS: APIRequestOpts = { doExpect: false }
+
+async function deleteAccount() {
+  // @ts-ignore
+  const accountID = global.qa.accountId
+  await accountsApi.accounts.delete(accountID)
+}
+
 async function teardown() {
   console.log("\nGLOBAL TEARDOWN STARTING")
-
-  // TODO: Delete account and apps after test run
+  const env = await internalApi.environment.getEnvironment(API_OPTS)
+  if (env.multiTenancy) {
+    await deleteAccount()
+  }
 
   console.log("GLOBAL TEARDOWN COMPLETE")
 }


### PR DESCRIPTION
## Description
Adds a function to the teardown process that calls the endpoint that will delete the account & tenant for a test. The intention is to be able to run tests in production environments without adding too much fake data. 

Addresses: 
- https://linear.app/budibase/issue/QA-23/add-test-clean-up