### PR TITLE
Make SSL and non-SSL nginx configs match

### DIFF
--- a/hosting/letsencrypt/nginx-ssl.conf
+++ b/hosting/letsencrypt/nginx-ssl.conf
@@ -2,15 +2,17 @@ server {
     listen       443 ssl default_server;
     listen  [::]:443 ssl default_server;
     server_name  _;
-    ssl_certificate /etc/letsencrypt/live/CUSTOM_DOMAIN/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/CUSTOM_DOMAIN/privkey.pem;
-    include /etc/letsencrypt/options-ssl-nginx.conf;
-    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
-
+    error_log            /dev/stderr warn;
+    access_log           /dev/stdout main;
     client_max_body_size 1000m;
     ignore_invalid_headers off;
     proxy_buffering off;
     # port_in_redirect off;
+
+    ssl_certificate /etc/letsencrypt/live/CUSTOM_DOMAIN/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/CUSTOM_DOMAIN/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
     location ^~ /.well-known/acme-challenge/ {
         default_type "text/plain";
@@ -47,6 +49,24 @@ server {
         rewrite ^/worker/(.*)$ /$1 break;
     }
 
+    location /api/backups/ {
+        # calls to export apps are limited
+        limit_req zone=ratelimit burst=20 nodelay;
+
+        # 1800s timeout for app export requests
+        proxy_read_timeout 1800s;
+        proxy_connect_timeout 1800s;
+        proxy_send_timeout 1800s;
+
+        proxy_http_version 1.1;
+        proxy_set_header    Connection          $connection_upgrade;
+        proxy_set_header    Upgrade             $http_upgrade;
+        proxy_set_header    X-Real-IP           $remote_addr;
+        proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+
+        proxy_pass      http://127.0.0.1:4001;
+    }
+
     location /api/ {
         # calls to the API are rate limited with bursting
         limit_req zone=ratelimit burst=20 nodelay;
@@ -70,16 +90,47 @@ server {
         rewrite ^/db/(.*)$ /$1 break;
     }
 
+    location /socket/ {
+        proxy_http_version  1.1;
+        proxy_set_header    Upgrade     $http_upgrade;
+        proxy_set_header    Connection  'upgrade';
+        proxy_set_header    Host        $host;
+        proxy_cache_bypass  $http_upgrade;
+        proxy_pass          http://127.0.0.1:4001;
+    }
+
     location / {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
 
         proxy_connect_timeout 300;
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         chunked_transfer_encoding off;
+        
         proxy_pass      http://127.0.0.1:9000;
+    }
+
+    location /files/signed/ {
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # IMPORTANT: Signed urls will inspect the host header of the request.
+        # Normally a signed url will need to be generated with a specified client host in mind.
+        # To support dynamic hosts, e.g. some unknown self-hosted installation url,
+        # use a predefined host header. The host 'minio-service' is also used at the time of url signing.
+        proxy_set_header Host minio-service;
+
+        proxy_connect_timeout 300;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        chunked_transfer_encoding off;
+
+        proxy_pass      http://127.0.0.1:9000;
+        rewrite ^/files/signed/(.*)$ /$1 break;
     }
 
     client_header_timeout 60;

--- a/hosting/single/nginx/nginx-default-site.conf
+++ b/hosting/single/nginx/nginx-default-site.conf
@@ -86,46 +86,46 @@ server {
     }
 
     location /socket/ {
-      proxy_http_version  1.1;
-      proxy_set_header    Upgrade     $http_upgrade;
-      proxy_set_header    Connection  'upgrade';
-      proxy_set_header    Host        $host;
-      proxy_cache_bypass  $http_upgrade;
-      proxy_pass          http://127.0.0.1:4001;
+        proxy_http_version  1.1;
+        proxy_set_header    Upgrade     $http_upgrade;
+        proxy_set_header    Connection  'upgrade';
+        proxy_set_header    Host        $host;
+        proxy_cache_bypass  $http_upgrade;
+        proxy_pass          http://127.0.0.1:4001;
     }
 
     location / {
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
 
-      proxy_connect_timeout 300;
-      proxy_http_version 1.1;
-      proxy_set_header Connection "";
-      chunked_transfer_encoding off;
+        proxy_connect_timeout 300;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        chunked_transfer_encoding off;
 
-      proxy_pass      http://127.0.0.1:9000;
+        proxy_pass      http://127.0.0.1:9000;
     }
 
     location /files/signed/ {
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
 
-      # IMPORTANT: Signed urls will inspect the host header of the request.
-      # Normally a signed url will need to be generated with a specified client host in mind.
-      # To support dynamic hosts, e.g. some unknown self-hosted installation url,
-      # use a predefined host header. The host 'minio-service' is also used at the time of url signing.
-      proxy_set_header Host minio-service;
+        # IMPORTANT: Signed urls will inspect the host header of the request.
+        # Normally a signed url will need to be generated with a specified client host in mind.
+        # To support dynamic hosts, e.g. some unknown self-hosted installation url,
+        # use a predefined host header. The host 'minio-service' is also used at the time of url signing.
+        proxy_set_header Host minio-service;
 
-      proxy_connect_timeout 300;
-      proxy_http_version 1.1;
-      proxy_set_header Connection "";
-      chunked_transfer_encoding off;
+        proxy_connect_timeout 300;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        chunked_transfer_encoding off;
 
-      proxy_pass      http://127.0.0.1:9000;
-      rewrite ^/files/signed/(.*)$ /$1 break;
+        proxy_pass      http://127.0.0.1:9000;
+        rewrite ^/files/signed/(.*)$ /$1 break;
     }
 
     client_header_timeout 60;


### PR DESCRIPTION
The nginx config for SSL didn't match the one for non-SSL, so things didn't work as expected. 
Copied the default one to the SSL one, re-adding the few directives/parameters required to make SSL work.

Also standardized indentation for the default nginx config; some blocks had only two spaces, but everywhere it was 4. Now it's 4 everywhere.

## Description
The nginx config that's used when enabling SSL is missing some `location` blocks, and it causes the apps to not load.
Addresses: 
- #10741 

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



