### PR TITLE
BUDI-6945 - Setup url on wizard

### DIFF
--- a/packages/backend-core/src/middleware/passport/datasource/google.ts
+++ b/packages/backend-core/src/middleware/passport/datasource/google.ts
@@ -88,7 +88,7 @@ export async function postAuth(
         }
       )
 
-      ctx.redirect(`${baseUrl}/new?type=google&action=continue&id=${id}`)
+      ctx.redirect(`${baseUrl}/new?action=google_continue&id=${id}`)
     }
   )(ctx, next)
 }

--- a/packages/backend-core/src/middleware/passport/datasource/google.ts
+++ b/packages/backend-core/src/middleware/passport/datasource/google.ts
@@ -1,10 +1,10 @@
 import * as google from "../sso/google"
 import { Cookie } from "../../../constants"
 import { clearCookie, getCookie } from "../../../utils"
-import { doWithDB } from "../../../db"
 import * as configs from "../../../configs"
-import { BBContext, Database, SSOProfile } from "@budibase/types"
+import { BBContext, SSOProfile } from "@budibase/types"
 import { ssoSaveUserNoOp } from "../sso/sso"
+import { cache, utils } from "../../../"
 const GoogleStrategy = require("passport-google-oauth").OAuth2Strategy
 
 type Passport = {
@@ -36,8 +36,8 @@ export async function preAuth(
     ssoSaveUserNoOp
   )
 
-  if (!ctx.query.appId || !ctx.query.datasourceId) {
-    ctx.throw(400, "appId and datasourceId query params not present.")
+  if (!ctx.query.appId) {
+    ctx.throw(400, "appId query param not present.")
   }
 
   return passport.authenticate(strategy, {
@@ -69,7 +69,7 @@ export async function postAuth(
       (
         accessToken: string,
         refreshToken: string,
-        profile: SSOProfile,
+        _profile: SSOProfile,
         done: Function
       ) => {
         clearCookie(ctx, Cookie.DatasourceAuth)
@@ -79,23 +79,16 @@ export async function postAuth(
     { successRedirect: "/", failureRedirect: "/error" },
     async (err: any, tokens: string[]) => {
       const baseUrl = `/builder/app/${authStateCookie.appId}/data`
-      // update the DB for the datasource with all the user info
-      await doWithDB(authStateCookie.appId, async (db: Database) => {
-        let datasource
-        try {
-          datasource = await db.get(authStateCookie.datasourceId)
-        } catch (err: any) {
-          if (err.status === 404) {
-            ctx.redirect(baseUrl)
-          }
+
+      const id = utils.newid()
+      await cache.store(
+        `datasource:creation:${authStateCookie.appId}:google:${id}`,
+        {
+          tokens,
         }
-        if (!datasource.config) {
-          datasource.config = {}
-        }
-        datasource.config.auth = { type: "google", ...tokens }
-        await db.put(datasource)
-        ctx.redirect(`${baseUrl}/datasource/${authStateCookie.datasourceId}`)
-      })
+      )
+
+      ctx.redirect(`${baseUrl}/new?type=google&action=continue&id=${id}`)
     }
   )(ctx, next)
 }

--- a/packages/backend-core/src/middleware/passport/datasource/google.ts
+++ b/packages/backend-core/src/middleware/passport/datasource/google.ts
@@ -88,7 +88,7 @@ export async function postAuth(
         }
       )
 
-      ctx.redirect(`${baseUrl}/new?action=google_continue&id=${id}`)
+      ctx.redirect(`${baseUrl}/new?continue_google_setup=${id}`)
     }
   )(ctx, next)
 }

--- a/packages/builder/src/components/backend/DatasourceNavigator/_components/GoogleButton.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/_components/GoogleButton.svelte
@@ -3,8 +3,6 @@
   import { store } from "builderStore"
   import { auth } from "stores/portal"
 
-  export let preAuthStep
-  export let datasource
   export let disabled
   export let samePage
 
@@ -15,18 +13,8 @@
   class:disabled
   {disabled}
   on:click={async () => {
-    let ds = datasource
     let appId = $store.appId
-    if (!ds) {
-      const resp = await preAuthStep()
-      if (resp.datasource && resp.appId) {
-        ds = resp.datasource
-        appId = resp.appId
-      } else {
-        ds = resp
-      }
-    }
-    const url = `/api/global/auth/${tenantId}/datasource/google?datasourceId=${ds._id}&appId=${appId}`
+    const url = `/api/global/auth/${tenantId}/datasource/google?appId=${appId}`
     if (samePage) {
       window.location = url
     } else {

--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/GoogleDatasourceConfigModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/GoogleDatasourceConfigModal.svelte
@@ -1,5 +1,11 @@
 <script>
-  import { ModalContent, Body, Layout, Link } from "@budibase/bbui"
+  import {
+    ModalContent,
+    Body,
+    Layout,
+    Link,
+    notifications,
+  } from "@budibase/bbui"
   import { IntegrationNames, IntegrationTypes } from "constants/backend"
   import GoogleButton from "../_components/GoogleButton.svelte"
   import { organisation } from "stores/portal"
@@ -9,9 +15,10 @@
   import IntegrationConfigForm from "../TableIntegrationMenu/IntegrationConfigForm.svelte"
 
   export let integration
-  export let continueSetup = false
+  export let continueSetupId = false
 
   let datasource = cloneDeep(integration)
+  datasource.config.continueSetupId = continueSetupId
 
   $: isGoogleConfigured = !!$organisation.googleDatasourceConfigured
 
@@ -25,7 +32,7 @@
     SET_URL: "Set_url",
   }
 
-  let step = continueSetup
+  let step = continueSetupId
     ? GoogleDatasouceConfigStep.SET_URL
     : GoogleDatasouceConfigStep.AUTH
 
@@ -38,7 +45,7 @@
       onConfirm: async () => {
         const resp = await validateDatasourceConfig(datasource)
         if (!resp.connected) {
-          displayError(`Unable to connect - ${resp.error}`)
+          notifications.error(`Unable to connect - ${resp.error}`)
         }
 
         return false

--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/GoogleDatasourceConfigModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/GoogleDatasourceConfigModal.svelte
@@ -33,7 +33,7 @@
         ]} integration.</Body
       >
     </Layout>
-    <GoogleButton preAuthStep={() => save(datasource, true)} />
+    <GoogleButton preAuthStep={() => save(datasource, true)} samePage />
   {:else if isGoogleConfigured === false}
     <Body size="S"
       >Google authentication is not enabled, please complete Google SSO

--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/GoogleDatasourceConfigModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/GoogleDatasourceConfigModal.svelte
@@ -3,7 +3,6 @@
   import { IntegrationNames } from "constants/backend"
   import cloneDeep from "lodash/cloneDeepWith"
   import GoogleButton from "../_components/GoogleButton.svelte"
-  import { saveDatasource as save } from "builderStore/datasource"
   import { organisation } from "stores/portal"
   import { onMount } from "svelte"
 
@@ -33,7 +32,7 @@
         ]} integration.</Body
       >
     </Layout>
-    <GoogleButton preAuthStep={() => save(datasource, true)} samePage />
+    <GoogleButton samePage />
   {:else if isGoogleConfigured === false}
     <Body size="S"
       >Google authentication is not enabled, please complete Google SSO

--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/GoogleDatasourceConfigModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/GoogleDatasourceConfigModal.svelte
@@ -22,6 +22,7 @@
   title={`Connect to ${IntegrationNames[datasource.type]}`}
   cancelText="Back"
   size="L"
+  showConfirmButton={false}
 >
   <!-- check true and false directly, don't render until flag is set -->
   {#if isGoogleConfigured === true}

--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/GoogleDatasourceConfigModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/GoogleDatasourceConfigModal.svelte
@@ -1,43 +1,55 @@
 <script>
   import { ModalContent, Body, Layout, Link } from "@budibase/bbui"
-  import { IntegrationNames } from "constants/backend"
-  import cloneDeep from "lodash/cloneDeepWith"
+  import { IntegrationNames, IntegrationTypes } from "constants/backend"
   import GoogleButton from "../_components/GoogleButton.svelte"
   import { organisation } from "stores/portal"
   import { onMount } from "svelte"
 
-  export let integration
+  export let continueSetup = false
 
-  // kill the reference so the input isn't saved
-  let datasource = cloneDeep(integration)
   $: isGoogleConfigured = !!$organisation.googleDatasourceConfigured
 
   onMount(async () => {
     await organisation.init()
   })
+  const integrationName = IntegrationNames[IntegrationTypes.GOOGLE_SHEETS]
+
+  export const GoogleDatasouceConfigStep = {
+    AUTH: "Auth",
+    SET_URL: "Set_url",
+  }
+
+  let step = continueSetup
+    ? GoogleDatasouceConfigStep.SET_URL
+    : GoogleDatasouceConfigStep.AUTH
 </script>
 
 <ModalContent
-  title={`Connect to ${IntegrationNames[datasource.type]}`}
+  title={`Connect to ${integrationName}`}
   cancelText="Back"
   size="L"
   showConfirmButton={false}
 >
-  <!-- check true and false directly, don't render until flag is set -->
-  {#if isGoogleConfigured === true}
-    <Layout noPadding>
+  {#if step === GoogleDatasouceConfigStep.AUTH}
+    <!-- check true and false directly, don't render until flag is set -->
+    {#if isGoogleConfigured === true}
+      <Layout noPadding>
+        <Body size="S"
+          >Authenticate with your google account to use the {integrationName} integration.</Body
+        >
+      </Layout>
+      <GoogleButton samePage />
+    {:else if isGoogleConfigured === false}
       <Body size="S"
-        >Authenticate with your google account to use the {IntegrationNames[
-          datasource.type
-        ]} integration.</Body
+        >Google authentication is not enabled, please complete Google SSO
+        configuration.</Body
       >
+      <Link href="/builder/portal/settings/auth">Configure Google SSO</Link>
+    {/if}
+  {/if}
+  {#if step === GoogleDatasouceConfigStep.SET_URL}
+    <Layout noPadding>
+      <Body size="S">Add the URL of the sheet you want to connect</Body>
     </Layout>
-    <GoogleButton samePage />
-  {:else if isGoogleConfigured === false}
-    <Body size="S"
-      >Google authentication is not enabled, please complete Google SSO
-      configuration.</Body
-    >
-    <Link href="/builder/portal/settings/auth">Configure Google SSO</Link>
   {/if}
 </ModalContent>

--- a/packages/builder/src/pages/builder/app/[application]/data/new.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/new.svelte
@@ -131,21 +131,25 @@
     return integrationsArray
   }
 
-  const fetchIntegrations = async () => {
-    const unsortedIntegrations = await API.getIntegrations()
-    integrations = sortIntegrations(unsortedIntegrations)
-  }
-
-  $: fetchIntegrations()
-
+  let isGoogleContinueAction
   onMount(() => {
     const urlParams = new URLSearchParams(window.location.search)
     const action = urlParams.get("action")
-    if (action === "google_continue") {
-      continueGoogleSetup = true
-      externalDatasourceModal.show()
-    }
+
+    isGoogleContinueAction = action === "google_continue"
   })
+
+  const fetchIntegrations = async () => {
+    const unsortedIntegrations = await API.getIntegrations()
+    integrations = sortIntegrations(unsortedIntegrations)
+    console.log(integrations[IntegrationTypes.GOOGLE_SHEETS])
+
+    if (isGoogleContinueAction) {
+      handleIntegrationSelect(IntegrationTypes.GOOGLE_SHEETS)
+    }
+  }
+
+  $: fetchIntegrations()
 </script>
 
 <Modal bind:this={internalTableModal}>
@@ -158,8 +162,11 @@
     continueGoogleSetup = false
   }}
 >
-  {#if integration?.auth?.type === "google" || continueGoogleSetup}
-    <GoogleDatasourceConfigModal continueSetup={continueGoogleSetup} />
+  {#if integration?.auth?.type === "google"}
+    <GoogleDatasourceConfigModal
+      continueSetup={isGoogleContinueAction}
+      {integration}
+    />
   {:else}
     <DatasourceConfigModal {integration} />
   {/if}

--- a/packages/builder/src/pages/builder/app/[application]/data/new.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/new.svelte
@@ -17,6 +17,7 @@
   import IntegrationIcon from "components/backend/DatasourceNavigator/IntegrationIcon.svelte"
   import ICONS from "components/backend/DatasourceNavigator/icons/index.js"
   import FontAwesomeIcon from "components/common/FontAwesomeIcon.svelte"
+  import { onMount } from "svelte"
 
   let internalTableModal
   let externalDatasourceModal
@@ -24,6 +25,7 @@
   let integration = null
   let disabled = false
   let promptUpload = false
+  let continueGoogleSetup
 
   $: hasData = $datasources.list.length > 1 || $tables.list.length > 1
   $: hasDefaultData =
@@ -135,15 +137,29 @@
   }
 
   $: fetchIntegrations()
+
+  onMount(() => {
+    const urlParams = new URLSearchParams(window.location.search)
+    const action = urlParams.get("action")
+    if (action === "google_continue") {
+      continueGoogleSetup = true
+      externalDatasourceModal.show()
+    }
+  })
 </script>
 
 <Modal bind:this={internalTableModal}>
   <CreateTableModal {promptUpload} afterSave={handleInternalTableSave} />
 </Modal>
 
-<Modal bind:this={externalDatasourceModal}>
-  {#if integration?.auth?.type === "google"}
-    <GoogleDatasourceConfigModal {integration} />
+<Modal
+  bind:this={externalDatasourceModal}
+  on:hide={() => {
+    continueGoogleSetup = false
+  }}
+>
+  {#if integration?.auth?.type === "google" || continueGoogleSetup}
+    <GoogleDatasourceConfigModal continueSetup={continueGoogleSetup} />
   {:else}
     <DatasourceConfigModal {integration} />
   {/if}

--- a/packages/builder/src/pages/builder/app/[application]/data/new.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/new.svelte
@@ -139,7 +139,6 @@
   const fetchIntegrations = async () => {
     const unsortedIntegrations = await API.getIntegrations()
     integrations = sortIntegrations(unsortedIntegrations)
-    console.log(integrations[IntegrationTypes.GOOGLE_SHEETS])
 
     if (continueGoogleSetup) {
       handleIntegrationSelect(IntegrationTypes.GOOGLE_SHEETS)

--- a/packages/builder/src/pages/builder/app/[application]/data/new.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/new.svelte
@@ -25,7 +25,6 @@
   let integration = null
   let disabled = false
   let promptUpload = false
-  let continueGoogleSetup
 
   $: hasData = $datasources.list.length > 1 || $tables.list.length > 1
   $: hasDefaultData =
@@ -131,12 +130,10 @@
     return integrationsArray
   }
 
-  let isGoogleContinueAction
+  let continueGoogleSetup
   onMount(() => {
     const urlParams = new URLSearchParams(window.location.search)
-    const action = urlParams.get("action")
-
-    isGoogleContinueAction = action === "google_continue"
+    continueGoogleSetup = urlParams.get("continue_google_setup")
   })
 
   const fetchIntegrations = async () => {
@@ -144,7 +141,7 @@
     integrations = sortIntegrations(unsortedIntegrations)
     console.log(integrations[IntegrationTypes.GOOGLE_SHEETS])
 
-    if (isGoogleContinueAction) {
+    if (continueGoogleSetup) {
       handleIntegrationSelect(IntegrationTypes.GOOGLE_SHEETS)
     }
   }
@@ -159,12 +156,12 @@
 <Modal
   bind:this={externalDatasourceModal}
   on:hide={() => {
-    continueGoogleSetup = false
+    continueGoogleSetup = null
   }}
 >
   {#if integration?.auth?.type === "google"}
     <GoogleDatasourceConfigModal
-      continueSetup={isGoogleContinueAction}
+      continueSetupId={continueGoogleSetup}
       {integration}
     />
   {:else}

--- a/packages/server/src/api/controllers/datasource.ts
+++ b/packages/server/src/api/controllers/datasource.ts
@@ -11,7 +11,7 @@ import { BuildSchemaErrors, InvalidColumns } from "../../constants"
 import { getIntegration } from "../../integrations"
 import { getDatasourceAndQuery } from "./row/utils"
 import { invalidateDynamicVariables } from "../../threads/utils"
-import { db as dbCore, context, events } from "@budibase/backend-core"
+import { db as dbCore, context, events, cache } from "@budibase/backend-core"
 import {
   UserCtx,
   Datasource,
@@ -25,6 +25,7 @@ import {
   FetchDatasourceInfoResponse,
   IntegrationBase,
   DatasourcePlus,
+  SourceName,
 } from "@budibase/types"
 import sdk from "../../sdk"
 import { builderSocket } from "../../websockets"

--- a/packages/server/src/api/controllers/datasource.ts
+++ b/packages/server/src/api/controllers/datasource.ts
@@ -29,6 +29,7 @@ import {
 } from "@budibase/types"
 import sdk from "../../sdk"
 import { builderSocket } from "../../websockets"
+import { setupCreationAuth as googleSetupCreationAuth } from "src/integrations/googlesheets"
 
 function getErrorTables(errors: any, errorType: string) {
   return Object.entries(errors)
@@ -307,6 +308,12 @@ export async function update(ctx: UserCtx<any, UpdateDatasourceResponse>) {
   builderSocket?.emitDatasourceUpdate(ctx, datasource)
 }
 
+const preSaveAction: Partial<Record<SourceName, any>> = {
+  [SourceName.GOOGLE_SHEETS]: async (datasource: Datasource) => {
+    await googleSetupCreationAuth(datasource.config as any)
+  },
+}
+
 export async function save(
   ctx: UserCtx<CreateDatasourceRequest, CreateDatasourceResponse>
 ) {
@@ -326,6 +333,10 @@ export async function save(
     schemaError = error
     datasource.entities = tables
     setDefaultDisplayColumns(datasource)
+  }
+
+  if (preSaveAction[datasource.source]) {
+    await preSaveAction[datasource.source](datasource)
   }
 
   const dbResp = await db.put(datasource)

--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -72,7 +72,7 @@ const SCHEMA: Integration = {
   },
   datasource: {
     spreadsheetId: {
-      display: "Google Sheet URL",
+      display: "Spreadsheet URL",
       type: DatasourceFieldType.STRING,
       required: true,
     },

--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -1,5 +1,6 @@
 import {
   ConnectionInfo,
+  Datasource,
   DatasourceFeature,
   DatasourceFieldType,
   DatasourcePlus,
@@ -19,13 +20,15 @@ import { OAuth2Client } from "google-auth-library"
 import { buildExternalTableId, finaliseExternalTables } from "./utils"
 import { GoogleSpreadsheet, GoogleSpreadsheetRow } from "google-spreadsheet"
 import fetch from "node-fetch"
-import { configs, HTTPError } from "@budibase/backend-core"
+import { cache, configs, context, HTTPError } from "@budibase/backend-core"
 import { dataFilters } from "@budibase/shared-core"
 import { GOOGLE_SHEETS_PRIMARY_KEY } from "../constants"
+import sdk from "../sdk"
 
 interface GoogleSheetsConfig {
   spreadsheetId: string
   auth: OAuthClientConfig
+  continueSetupId?: string
 }
 
 interface OAuthClientConfig {
@@ -147,6 +150,7 @@ class GoogleSheetsIntegration implements DatasourcePlus {
 
   async testConnection(): Promise<ConnectionInfo> {
     try {
+      await setupCreationAuth(this.config)
       await this.connect()
       return { connected: true }
     } catch (e: any) {
@@ -563,6 +567,18 @@ class GoogleSheetsIntegration implements DatasourcePlus {
     } else {
       throw new Error("Row does not exist.")
     }
+  }
+}
+
+export async function setupCreationAuth(datasouce: GoogleSheetsConfig) {
+  if (datasouce.continueSetupId) {
+    const appId = context.getAppId()
+    const tokens = await cache.get(
+      `datasource:creation:${appId}:google:${datasouce.continueSetupId}`
+    )
+
+    datasouce.auth = tokens.tokens
+    delete datasouce.continueSetupId
   }
 }
 

--- a/packages/worker/src/api/controllers/global/auth.ts
+++ b/packages/worker/src/api/controllers/global/auth.ts
@@ -140,7 +140,6 @@ export const datasourcePreAuth = async (ctx: any, next: any) => {
     {
       provider,
       appId: ctx.query.appId,
-      datasourceId: ctx.query.datasourceId,
     },
     Cookie.DatasourceAuth
   )


### PR DESCRIPTION
## Description
Changes already approved on the following PR: https://github.com/Budibase/budibase/pull/10746

Changing new google datasource onboarding to have the following behaviour:
1. Start asking for the google auth
2. If auth successful, store the tokens in redis and redirect to the setup wizard
3. On setup completed, persist the datasource using the persisted tokens

Doing so we don't persist any datasource data until the datasource data is completed  and we don't expose any tokens to the client

Addresses: 
- https://linear.app/budibase/issue/BUDI-6945/google-sheets-fetch-all-worksheets-when-we-have-spreadsheet-url

## Screenshots

https://github.com/Budibase/budibase/assets/15987277/922d4527-e566-4442-9e9b-3f8c787e2705

