### PR TITLE
Update concurrency settings for release and prerelease

### DIFF
--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -1,5 +1,7 @@
 name: Budibase Prerelease
-concurrency: release-prerelease
+concurrency:
+  group: release-prerelease
+  cancel-in-progress: false
 
 on:
   push:

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -1,5 +1,7 @@
 name: Budibase Release
-concurrency: release
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 on:
   push:

--- a/.github/workflows/tag-prerelease.yml
+++ b/.github/workflows/tag-prerelease.yml
@@ -1,5 +1,7 @@
 name: Tag prerelease
-concurrency: release-prerelease
+concurrency:
+  group: tag-prerelease
+  cancel-in-progress: false
 
 on:
   push:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,5 +1,7 @@
 name: Tag release
-concurrency: release-prerelease
+concurrency:
+  group: tag-release
+  cancel-in-progress: false
 
 on:
   push:


### PR DESCRIPTION
- Unique concurrency groups for each tag / release job
- Specifically set `cancel-in-progress: false` to try to fix apparent bug