### PR TITLE
Reduced log level of array parsing on row import

### DIFF
--- a/packages/server/src/utilities/rowProcessor/map.ts
+++ b/packages/server/src/utilities/rowProcessor/map.ts
@@ -12,7 +12,7 @@ const parseArrayString = value => {
       result = JSON.parse(value.replace(/'/g, '"'))
       return result
     } catch (e) {
-      logging.logAlert("Could not parse row value", e)
+      logging.logWarn("Could not parse row value", e)
     }
   }
   return value


### PR DESCRIPTION
## Description

The log level for this was set to `bb-alert` and has been reduced to a `bb-warning`.
The array parse attempt is already caught here and the import will then resort to default import behaviours thereafter.


