### PR TITLE
Collaboration fixes

### DIFF
--- a/packages/backend-core/src/constants/misc.ts
+++ b/packages/backend-core/src/constants/misc.ts
@@ -16,6 +16,7 @@ export enum Header {
   LICENSE_KEY = "x-budibase-license-key",
   API_VER = "x-budibase-api-version",
   APP_ID = "x-budibase-app-id",
+  SESSION_ID = "x-budibase-session-id",
   TYPE = "x-budibase-type",
   PREVIEW_ROLE = "x-budibase-role",
   TENANT_ID = "x-budibase-tenant-id",

--- a/packages/builder/src/builderStore/websocket.js
+++ b/packages/builder/src/builderStore/websocket.js
@@ -15,24 +15,22 @@ export const createBuilderWebsocket = appId => {
   socket.on("connect_error", err => {
     console.log("Failed to connect to builder websocket:", err.message)
   })
+  socket.on("disconnect", () => {
+    userStore.actions.reset()
+  })
 
   // User events
-  socket.on(SocketEvent.UserUpdate, userStore.actions.updateUser)
-  socket.on(SocketEvent.UserDisconnect, userStore.actions.removeUser)
+  socket.onOther(SocketEvent.UserUpdate, userStore.actions.updateUser)
+  socket.onOther(SocketEvent.UserDisconnect, userStore.actions.removeUser)
 
   // Table events
-  socket.on(BuilderSocketEvent.TableChange, ({ id, table }) => {
+  socket.onOther(BuilderSocketEvent.TableChange, ({ id, table }) => {
     tables.replaceTable(id, table)
   })
 
   // Datasource events
-  socket.on(BuilderSocketEvent.DatasourceChange, ({ id, datasource }) => {
+  socket.onOther(BuilderSocketEvent.DatasourceChange, ({ id, datasource }) => {
     datasources.replaceDatasource(id, datasource)
-  })
-
-  // Clean up user store on disconnect
-  socket.on("disconnect", () => {
-    userStore.actions.reset()
   })
 
   return socket

--- a/packages/builder/src/components/backend/DataTable/DataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/DataTable.svelte
@@ -37,6 +37,7 @@
     allowDeleteRows={!isUsersTable}
     schemaOverrides={isUsersTable ? userSchemaOverrides : null}
     showAvatars={false}
+    on:updatetable={e => tables.replaceTable(id, e.detail)}
   >
     <svelte:fragment slot="controls">
       {#if isInternal}

--- a/packages/builder/src/components/backend/DataTable/RowFieldControl.svelte
+++ b/packages/builder/src/components/backend/DataTable/RowFieldControl.svelte
@@ -81,6 +81,7 @@
   <Label>{label}</Label>
   <Editor
     editorHeight="250"
+    editorWidth="320"
     mode="json"
     on:change={({ detail }) => (value = detail.value)}
     value={stringVal}

--- a/packages/builder/src/stores/backend/tables.js
+++ b/packages/builder/src/stores/backend/tables.js
@@ -62,7 +62,7 @@ export function createTablesStore() {
     }
 
     const savedTable = await API.saveTable(updatedTable)
-    replaceTable(table._id, savedTable)
+    replaceTable(savedTable._id, savedTable)
     await datasources.fetch()
     select(savedTable._id)
     return savedTable

--- a/packages/client/src/websocket.js
+++ b/packages/client/src/websocket.js
@@ -18,7 +18,9 @@ export const initWebsocket = () => {
   }
 
   // Initialise connection
-  socket = createWebsocket("/socket/client", false)
+  socket = createWebsocket("/socket/client", {
+    heartbeat: false,
+  })
 
   // Event handlers
   socket.on("plugin-update", data => {

--- a/packages/frontend-core/src/api/index.js
+++ b/packages/frontend-core/src/api/index.js
@@ -1,3 +1,4 @@
+import { Helpers } from "@budibase/bbui"
 import { ApiVersion } from "../constants"
 import { buildAnalyticsEndpoints } from "./analytics"
 import { buildAppEndpoints } from "./app"
@@ -29,6 +30,14 @@ import { buildBackupsEndpoints } from "./backups"
 import { buildEnvironmentVariableEndpoints } from "./environmentVariables"
 import { buildEventEndpoints } from "./events"
 import { buildAuditLogsEndpoints } from "./auditLogs"
+
+/**
+ * Random identifier to uniquely identify a session in a tab. This is
+ * used to determine the originator of calls to the API, which is in
+ * turn used to determine who caused a websocket message to be sent, so
+ * that we can ignore events caused by ourselves.
+ */
+export const APISessionID = Helpers.uuid()
 
 const defaultAPIClientConfig = {
   /**
@@ -116,6 +125,7 @@ export const createAPIClient = config => {
 
     // Build headers
     let headers = { Accept: "application/json" }
+    headers["x-budibase-session-id"] = APISessionID
     if (!external) {
       headers["x-budibase-api-version"] = ApiVersion
     }

--- a/packages/frontend-core/src/components/grid/lib/websocket.js
+++ b/packages/frontend-core/src/components/grid/lib/websocket.js
@@ -26,15 +26,15 @@ export const createGridWebsocket = context => {
   })
 
   // User events
-  socket.on(SocketEvent.UserUpdate, user => {
+  socket.onOther(SocketEvent.UserUpdate, user => {
     users.actions.updateUser(user)
   })
-  socket.on(SocketEvent.UserDisconnect, user => {
+  socket.onOther(SocketEvent.UserDisconnect, user => {
     users.actions.removeUser(user)
   })
 
   // Row events
-  socket.on(GridSocketEvent.RowChange, async data => {
+  socket.onOther(GridSocketEvent.RowChange, async data => {
     if (data.id) {
       rows.actions.replaceRow(data.id, data.row)
     } else if (data.row.id) {
@@ -44,7 +44,7 @@ export const createGridWebsocket = context => {
   })
 
   // Table events
-  socket.on(GridSocketEvent.TableChange, data => {
+  socket.onOther(GridSocketEvent.TableChange, data => {
     // Only update table if one exists. If the table was deleted then we don't
     // want to know - let the builder navigate away
     if (data.table) {

--- a/packages/frontend-core/src/components/grid/stores/columns.js
+++ b/packages/frontend-core/src/components/grid/stores/columns.js
@@ -46,7 +46,7 @@ export const createStores = () => {
 }
 
 export const deriveStores = context => {
-  const { table, columns, stickyColumn, API } = context
+  const { table, columns, stickyColumn, API, dispatch } = context
 
   // Updates the tables primary display column
   const changePrimaryDisplay = async column => {
@@ -89,6 +89,10 @@ export const deriveStores = context => {
   const saveTable = async newTable => {
     // Update local state
     table.set(newTable)
+
+    // Broadcast change to external state can be updated, as this change
+    // will not be received by the builder websocket because we caused it ourselves
+    dispatch("updatetable", newTable)
 
     // Update server
     await API.saveTable(newTable)

--- a/packages/frontend-core/src/components/grid/stores/rows.js
+++ b/packages/frontend-core/src/components/grid/stores/rows.js
@@ -214,8 +214,7 @@ export const deriveStores = context => {
   const addRow = async (row, idx, bubble = false) => {
     try {
       // Create row
-      let newRow = await API.saveRow({ ...row, tableId: get(tableId) })
-      newRow = await fetchRow(newRow._id)
+      const newRow = await API.saveRow({ ...row, tableId: get(tableId) })
 
       // Update state
       if (idx != null) {

--- a/packages/frontend-core/src/components/grid/stores/rows.js
+++ b/packages/frontend-core/src/components/grid/stores/rows.js
@@ -436,6 +436,9 @@ export const deriveStores = context => {
 
   // Checks if we have a row with a certain ID
   const hasRow = id => {
+    if (id === NewRowID) {
+      return true
+    }
     return get(rowLookupMap)[id] != null
   }
 

--- a/packages/frontend-core/src/utils/websocket.js
+++ b/packages/frontend-core/src/utils/websocket.js
@@ -52,8 +52,6 @@ export const createWebsocket = (path, options = DefaultOptions) => {
     socket.on(event, data => {
       if (data?.apiSessionId !== APISessionID) {
         callback(data)
-      } else {
-        console.log("ignore", event, data)
       }
     })
   }

--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -50,7 +50,7 @@ export const save = async (ctx: any) => {
   if (body && body._id) {
     return patch(ctx)
   }
-  const { row, table } = await quotas.addRow(() =>
+  const { row, table, squashed } = await quotas.addRow(() =>
     quotas.addQuery(() => pickApi(tableId).save(ctx), {
       datasourceId: tableId,
     })
@@ -58,8 +58,9 @@ export const save = async (ctx: any) => {
   ctx.status = 200
   ctx.eventEmitter && ctx.eventEmitter.emitRow(`row:save`, appId, row, table)
   ctx.message = `${table.name} saved successfully`
-  ctx.body = row
-  gridSocket?.emitRowUpdate(ctx, row)
+  // prefer squashed for response
+  ctx.body = row || squashed
+  gridSocket?.emitRowUpdate(ctx, row || squashed)
 }
 export async function fetchView(ctx: any) {
   const tableId = utils.getTableId(ctx)

--- a/packages/server/src/api/controllers/row/staticFormula.ts
+++ b/packages/server/src/api/controllers/row/staticFormula.ts
@@ -7,6 +7,7 @@ import {
 import { FieldTypes, FormulaTypes } from "../../../constants"
 import { context } from "@budibase/backend-core"
 import { Table, Row } from "@budibase/types"
+import * as linkRows from "../../../db/linkedRows"
 const { isEqual } = require("lodash")
 const { cloneDeep } = require("lodash/fp")
 
@@ -166,5 +167,9 @@ export async function finaliseRow(
   if (updateFormula) {
     await updateRelatedFormula(table, enrichedRow)
   }
-  return { row: enrichedRow, table }
+  const squashed = await linkRows.squashLinksToPrimaryDisplay(
+    table,
+    enrichedRow
+  )
+  return { row: enrichedRow, squashed, table }
 }

--- a/packages/server/src/db/linkedRows/index.ts
+++ b/packages/server/src/db/linkedRows/index.ts
@@ -189,11 +189,13 @@ export async function attachFullLinkedDocs(table: Table, rows: Row[]) {
  */
 export async function squashLinksToPrimaryDisplay(
   table: Table,
-  enriched: Row[]
+  enriched: Row[] | Row
 ) {
   // will populate this as we find them
   const linkedTables = [table]
-  for (let row of enriched) {
+  const isArray = Array.isArray(enriched)
+  let enrichedArray = !isArray ? [enriched] : enriched
+  for (let row of enrichedArray) {
     // this only fetches the table if its not already in array
     const rowTable = await getLinkedTable(row.tableId!, linkedTables)
     for (let [column, schema] of Object.entries(rowTable?.schema || {})) {
@@ -213,5 +215,5 @@ export async function squashLinksToPrimaryDisplay(
       row[column] = newLinks
     }
   }
-  return enriched
+  return isArray ? enrichedArray : enrichedArray[0]
 }

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -216,7 +216,10 @@ export async function outputProcessing(
     }
   }
   if (opts.squash) {
-    enriched = await linkRows.squashLinksToPrimaryDisplay(table, enriched)
+    enriched = (await linkRows.squashLinksToPrimaryDisplay(
+      table,
+      enriched
+    )) as Row[]
   }
   return wasArray ? enriched : enriched[0]
 }

--- a/packages/server/src/websockets/builder.ts
+++ b/packages/server/src/websockets/builder.ts
@@ -46,29 +46,32 @@ export default class BuilderSocket extends BaseSocket {
   }
 
   emitTableUpdate(ctx: any, table: Table) {
-    this.io
-      .in(ctx.appId)
-      .emit(BuilderSocketEvent.TableChange, { id: table._id, table })
-    gridSocket?.emitTableUpdate(table)
+    this.emitToRoom(ctx, ctx.appId, BuilderSocketEvent.TableChange, {
+      id: table._id,
+      table,
+    })
+    gridSocket?.emitTableUpdate(ctx, table)
   }
 
   emitTableDeletion(ctx: any, id: string) {
-    this.io
-      .in(ctx.appId)
-      .emit(BuilderSocketEvent.TableChange, { id, table: null })
-    gridSocket?.emitTableDeletion(id)
+    this.emitToRoom(ctx, ctx.appId, BuilderSocketEvent.TableChange, {
+      id,
+      table: null,
+    })
+    gridSocket?.emitTableDeletion(ctx, id)
   }
 
   emitDatasourceUpdate(ctx: any, datasource: Datasource) {
-    this.io.in(ctx.appId).emit(BuilderSocketEvent.DatasourceChange, {
+    this.emitToRoom(ctx, ctx.appId, BuilderSocketEvent.DatasourceChange, {
       id: datasource._id,
       datasource,
     })
   }
 
   emitDatasourceDeletion(ctx: any, id: string) {
-    this.io
-      .in(ctx.appId)
-      .emit(BuilderSocketEvent.DatasourceChange, { id, datasource: null })
+    this.emitToRoom(ctx, ctx.appId, BuilderSocketEvent.DatasourceChange, {
+      id,
+      datasource: null,
+    })
   }
 }

--- a/packages/server/src/websockets/grid.ts
+++ b/packages/server/src/websockets/grid.ts
@@ -31,21 +31,25 @@ export default class GridSocket extends BaseSocket {
 
   emitRowUpdate(ctx: any, row: Row) {
     const tableId = getTableId(ctx)
-    this.io.in(tableId).emit(GridSocketEvent.RowChange, { id: row._id, row })
+    this.emitToRoom(ctx, tableId, GridSocketEvent.RowChange, {
+      id: row._id,
+      row,
+    })
   }
 
   emitRowDeletion(ctx: any, id: string) {
     const tableId = getTableId(ctx)
-    this.io.in(tableId).emit(GridSocketEvent.RowChange, { id, row: null })
+    this.emitToRoom(ctx, tableId, GridSocketEvent.RowChange, { id, row: null })
   }
 
-  emitTableUpdate(table: Table) {
-    this.io
-      .in(table._id!)
-      .emit(GridSocketEvent.TableChange, { id: table._id, table })
+  emitTableUpdate(ctx: any, table: Table) {
+    this.emitToRoom(ctx, table._id!, GridSocketEvent.TableChange, {
+      id: table._id,
+      table,
+    })
   }
 
-  emitTableDeletion(id: string) {
-    this.io.in(id).emit(GridSocketEvent.TableChange, { id, table: null })
+  emitTableDeletion(ctx: any, id: string) {
+    this.emitToRoom(ctx, id, GridSocketEvent.TableChange, { id, table: null })
   }
 }

--- a/packages/server/src/websockets/websocket.ts
+++ b/packages/server/src/websockets/websocket.ts
@@ -3,7 +3,7 @@ import http from "http"
 import Koa from "koa"
 import Cookies from "cookies"
 import { userAgent } from "koa-useragent"
-import { auth, redis } from "@budibase/backend-core"
+import { auth, Header, redis } from "@budibase/backend-core"
 import currentApp from "../middleware/currentapp"
 import { createAdapter } from "@socket.io/redis-adapter"
 import { Socket } from "socket.io"
@@ -270,5 +270,14 @@ export class BaseSocket {
   // Emit an event to all sockets
   emit(event: string, payload: any) {
     this.io.sockets.emit(event, payload)
+  }
+
+  // Emit an event to everyone in a room, including metadata of whom
+  // the originator of the request was
+  emitToRoom(ctx: any, room: string, event: string, payload: any) {
+    this.io.in(room).emit(event, {
+      ...payload,
+      apiSessionId: ctx.headers?.[Header.SESSION_ID],
+    })
   }
 }

--- a/packages/worker/src/api/controllers/global/configs.ts
+++ b/packages/worker/src/api/controllers/global/configs.ts
@@ -11,7 +11,6 @@ import {
   tenancy,
 } from "@budibase/backend-core"
 import { checkAnyUserExists } from "../../../utilities/users"
-import { getLicensedConfig } from "../../../utilities/configs"
 import {
   Config,
   ConfigType,


### PR DESCRIPTION
## Description
This PR contains a few fixes after testing collaboration with many developers.

Changes:
- Ensure everything works as intended even when websockets are disabled
- Fix new tables not appearing without websocket enabled
- Fix other users changes causing you to lose focus from a cell when creating new rows
- Fix relationships not appearing after making changes (thanks @mike12345567)
- Fix first row creation in empty tables creating 2 rows
- Fix duplicating row action creating duplicate IDs
- Fix JSON editor overflow row edit modal
- Fix grid and backend store state getting out of sync

A lot of those fixes were enabled by refactoring websockets so that clients now ignore all events triggered by themselves. This is not trivial because we initiate changes by an API request rather than sending data up the websocket, otherwise it would be trivial to emit to everyone else other than yourself. The motivation for this was that the websocket was so fast that the websocket message would be received before the client even thought that the API request it just sent had completed.

This feature works as follows:
- All instances of the builder have a "session ID", which is just a random ID that is generated in memory and constant until you refresh the page. The ID is unique for each tab opened.
- This ID is sent up with all requests as a header
- When websocket messages are triggered by API events, the originating session ID is sent back down in the message
- Clients have a new utility function `socket.onOther` rather than `socket.on` which will only trigger on events made by others, by ignoring messages you originate from their own session ID



