### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -10,11 +10,6 @@ on:
       # Exclude all pre-releases
       - "!v*[0-9]+.[0-9]+.[0-9]+-*"
   workflow_dispatch:
-    inputs:
-      tags:
-        description: "Release tag"
-        required: true
-        type: boolean
 
 env:
   # Posthog token used by ui at build time

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -9,7 +9,6 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
       # Exclude all pre-releases
       - "!v*[0-9]+.[0-9]+.[0-9]+-*"
-  workflow_dispatch:
 
 env:
   # Posthog token used by ui at build time

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -28,12 +28,13 @@ jobs:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           fetch-depth: 0
 
-      - name: Fail if branch is not master
-        if: github.ref != 'refs/heads/master'
+      - name: Fail if tag is not master
         run: |
-          echo "Ref is not master, you must run this job from master."
-          // Change to "exit 1" when merged. Left to 0 to not fail all the pipelines and not to cause noise
-          exit 0
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/develop; then
+            echo "Tag is not in master. This pipeline can only execute tags that are present on the master branch"
+            exit 1
+          fi
+
 
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Fail if tag is not master
         run: |
-          if ! git merge-base --is-ancestor ${{ github.sha }} origin/develop; then
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/master; then
             echo "Tag is not in master. This pipeline can only execute tags that are present on the master branch"
             exit 1
           fi


### PR DESCRIPTION
## Description
Changing the pipeline to check that the tag is in master instead of checking the sha ref, given the workflow changes. Having the release triggered by the tag does not populate the git sha