### PR TITLE
Exclude pro from bb lint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,8 @@
     "dist",
     "public",
     "*.spec.js",
-    "bundle.js"
+    "bundle.js",
+    "packages/pro"
   ],
   "plugins": ["svelte3"],
   "extends": ["eslint:recommended"],


### PR DESCRIPTION
## Description

- Pro is linted separately
- The conflicting lint configuration currently produces an error
