### PR TITLE
Add event for tracking user collaboration

### DIFF
--- a/packages/backend-core/src/events/publishers/user.ts
+++ b/packages/backend-core/src/events/publishers/user.ts
@@ -3,6 +3,7 @@ import {
   Event,
   User,
   UserCreatedEvent,
+  UserDataCollaborationEvent,
   UserDeletedEvent,
   UserInviteAcceptedEvent,
   UserInvitedEvent,
@@ -173,6 +174,15 @@ async function passwordReset(user: User) {
   await publishEvent(Event.USER_PASSWORD_RESET, properties)
 }
 
+// COLLABORATION
+
+async function dataCollaboration(users: number) {
+  const properties: UserDataCollaborationEvent = {
+    users,
+  }
+  await publishEvent(Event.USER_DATA_COLLABORATION, properties)
+}
+
 export default {
   created,
   updated,
@@ -188,4 +198,5 @@ export default {
   passwordUpdated,
   passwordResetRequested,
   passwordReset,
+  dataCollaboration,
 }

--- a/packages/server/src/websockets/builder.ts
+++ b/packages/server/src/websockets/builder.ts
@@ -1,6 +1,6 @@
 import authorized from "../middleware/authorized"
 import { BaseSocket } from "./websocket"
-import { permissions } from "@budibase/backend-core"
+import { permissions, events } from "@budibase/backend-core"
 import http from "http"
 import Koa from "koa"
 import { Datasource, Table, SocketSession, ContextUser } from "@budibase/types"
@@ -22,6 +22,9 @@ export default class BuilderSocket extends BaseSocket {
       // Reply with all users in current room
       const sessions = await this.getRoomSessions(appId)
       callback({ users: sessions })
+
+      // Track usage
+      await events.user.dataCollaboration(sessions.length)
     })
   }
 

--- a/packages/types/src/sdk/events/event.ts
+++ b/packages/types/src/sdk/events/event.ts
@@ -26,6 +26,9 @@ export enum Event {
   USER_PASSWORD_RESET_REQUESTED = "user:password:reset:requested",
   USER_PASSWORD_RESET = "user:password:reset",
 
+  // USER / COLLABORATION
+  USER_DATA_COLLABORATION = "user:data:collaboration",
+
   // EMAIL
   EMAIL_SMTP_CREATED = "email:smtp:created",
   EMAIL_SMTP_UPDATED = "email:smtp:updated",
@@ -233,6 +236,7 @@ export const AuditedEventFriendlyName: Record<Event, string | undefined> = {
   [Event.USER_PASSWORD_FORCE_RESET]: undefined,
   [Event.USER_GROUP_ONBOARDING]: undefined,
   [Event.USER_ONBOARDING_COMPLETE]: undefined,
+  [Event.USER_DATA_COLLABORATION]: undefined,
 
   // EMAIL
   [Event.EMAIL_SMTP_CREATED]: `Email configuration created`,

--- a/packages/types/src/sdk/events/user.ts
+++ b/packages/types/src/sdk/events/user.ts
@@ -86,3 +86,7 @@ export interface UserPasswordResetEvent extends BaseEvent {
     email: string
   }
 }
+
+export interface UserDataCollaborationEvent extends BaseEvent {
+  users: number
+}


### PR DESCRIPTION
## Description
This PR adds an event to track use of collaboration within the data section.

Event:
```
user:data:collaboration
```
Metadata:
```
{
  users: number
}
```
The event is not audited.