### PR TITLE
Change release pipelines to rely on tags

### DIFF
--- a/.github/workflows/deploy-cloud.yaml
+++ b/.github/workflows/deploy-cloud.yaml
@@ -2,23 +2,29 @@ name: Budibase Deploy Production
 
 on:
  workflow_dispatch:
-  inputs:
-    version:
-      description: Budibase release version. For example - 1.0.0
-      required: false
 
 jobs:
   release:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Fail if branch is not master
-        if: github.ref != 'refs/heads/master' 
-        run: | 
-          echo "Ref is not master, you must run this job from master."
-          exit 1
+      - name: Fail if not a tag
+        run: |
+          if [[ $GITHUB_REF != refs/tags/* ]]; then 
+            echo "Workflow Dispatch can only be run on tags" 
+            exit 1 
+          fi
 
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Fail if tag is not in master
+        run: |
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/master; then
+            echo "Tag is not in master. This pipeline can only execute tags that are present on the master branch"
+            exit 1
+          fi
 
       - name: Pull values.yaml from budibase-infra
         run: | 
@@ -31,11 +37,7 @@ jobs:
       - name: Get the latest budibase release version
         id: version
         run: | 
-          if [ -z "${{ github.event.inputs.version }}" ]; then
-            release_version=$(cat lerna.json | jq -r '.version')
-          else
-            release_version=${{ github.event.inputs.version }}
-          fi
+          release_version=$(cat lerna.json | jq -r '.version')
           echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
       
       - name: Configure AWS Credentials

--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -1,17 +1,30 @@
 name: "deploy-preprod"
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: Budibase release version. For example - 1.0.0
-        required: false
   workflow_call:
 
 jobs:
   deploy-to-legacy-preprod-env:
     runs-on: ubuntu-latest
     steps:
+      - name: Fail if not a tag
+        run: |
+          if [[ $GITHUB_REF != refs/tags/* ]]; then 
+            echo "Workflow Dispatch can only be run on tags" 
+            exit 1 
+          fi
+
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Fail if tag is not in master
+        run: |
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/master; then
+            echo "Tag is not in master. This pipeline can only execute tags that are present on the master branch"
+            exit 1
+          fi
+      
 
       - name: Get the latest budibase release version
         id: version

--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -16,12 +16,7 @@ jobs:
       - name: Get the latest budibase release version
         id: version
         run: |
-          if [ -z "${{ github.event.inputs.version }}" ]; then
-            git pull
-            release_version=$(cat lerna.json | jq -r '.version')
-          else
-            release_version=${{ github.event.inputs.version }}
-          fi
+          release_version=$(cat lerna.json | jq -r '.version')
           echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -22,6 +22,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Fail if not a tag
+        run: |
+          if [[ $GITHUB_REF != refs/tags/* ]]; then 
+            echo "Workflow Dispatch can only be run on tags" 
+            exit 1 
+          fi
+
       - uses: actions/checkout@v2
         with:
           submodules: true

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -27,7 +27,7 @@ jobs:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           fetch-depth: 0
 
-      - name: Fail if tag is not master
+      - name: Fail if tag is not in master
         run: |
           if ! git merge-base --is-ancestor ${{ github.sha }} origin/master; then
             echo "Tag is not in master. This pipeline can only execute tags that are present on the master branch"

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -134,7 +134,6 @@ jobs:
       - name: Get the latest budibase release version
         id: version
         run: |
-          git pull
           release_version=$(cat lerna.json | jq -r '.version')
           echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
 

--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -86,7 +86,6 @@ jobs:
           git config user.name "Budibase Helm Bot"
           git config user.email "<>"
           git reset --hard
-          git pull
           mkdir sync
           echo "Packaging chart to sync dir"
           helm package charts/budibase --version "$RELEASE_VERSION" --app-version "$RELEASE_VERSION" --destination sync

--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -8,15 +8,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Fail if branch is not master
-        if: github.ref != 'refs/heads/master'
+      - name: Fail if not a tag
         run: |
-          echo "Ref is not master, you must run this job from master."
-          exit 1
+          if [[ $GITHUB_REF != refs/tags/* ]]; then 
+            echo "Workflow Dispatch can only be run on tags" 
+            exit 1 
+          fi
 
       - uses: actions/checkout@v2
         with: 
           fetch_depth: 0
+
+      - name: Fail if tag is not in master
+        run: |
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/master; then
+            echo "Tag is not in master. This pipeline can only execute tags that are present on the master branch"
+            exit 1
+          fi
 
       - name: Use Node.js 14.x
         uses: actions/setup-node@v1

--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -86,6 +86,7 @@ jobs:
           git config user.name "Budibase Helm Bot"
           git config user.email "<>"
           git reset --hard
+          git fetch
           mkdir sync
           echo "Packaging chart to sync dir"
           helm package charts/budibase --version "$RELEASE_VERSION" --app-version "$RELEASE_VERSION" --destination sync

--- a/.github/workflows/release-singleimage.yml
+++ b/.github/workflows/release-singleimage.yml
@@ -15,13 +15,24 @@ jobs:
       matrix:
         node-version: [14.x]
     steps:
-      - name: Fail if branch is not master
-        if: github.ref != 'refs/heads/master'
-        run: | 
-          echo "Ref is not master, you must run this job from master."
-          exit 1
+      - name: Fail if not a tag
+        run: |
+          if [[ $GITHUB_REF != refs/tags/* ]]; then 
+            echo "Workflow Dispatch can only be run on tags" 
+            exit 1 
+          fi
       - name: "Checkout"
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Fail if tag is not in master
+        run: |
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/master; then
+            echo "Tag is not in master. This pipeline can only execute tags that are present on the master branch"
+            exit 1
+          fi
+          
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
## Description
Until now we had the release process relying on branch push hook. Because of this, we were pulling at some point to ensure we got the latest code.
Now these pipelines have been split into 2 steps, and the release will always run from a particular tag. These `git pulls` are unnecessary and causing issues.


Changing pipelines to rely on the tags and secure them