### PR TITLE
Fix CSV encoding issue

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/ExportModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/ExportModal.svelte
@@ -130,7 +130,10 @@
         notifications.error("Export Failed")
       }
       if (response) {
-        download(response, `export.${exportFormat}`)
+        download(
+          new Blob([response], { type: "text/plain" }),
+          `export.${exportFormat}`
+        )
         notifications.success("Export Successful")
       }
     } else {

--- a/packages/builder/src/components/backend/DataTable/modals/ExportModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/ExportModal.svelte
@@ -92,13 +92,20 @@
     },
   }
 
+  function downloadWithBlob(data, filename) {
+    download(new Blob([data], { type: "text/plain" }), filename)
+  }
+
   async function exportView() {
     try {
       const data = await API.exportView({
         viewName: view,
         format: exportFormat,
       })
-      download(data, `export.${exportFormat === "csv" ? "csv" : "json"}`)
+      downloadWithBlob(
+        data,
+        `export.${exportFormat === "csv" ? "csv" : "json"}`
+      )
     } catch (error) {
       notifications.error(`Unable to export ${exportFormat.toUpperCase()} data`)
     }
@@ -111,7 +118,7 @@
         rows: selectedRows.map(row => row._id),
         format: exportFormat,
       })
-      download(data, `export.${exportFormat}`)
+      downloadWithBlob(data, `export.${exportFormat}`)
     } else if (filters || sorting) {
       let response
       try {
@@ -130,10 +137,7 @@
         notifications.error("Export Failed")
       }
       if (response) {
-        download(
-          new Blob([response], { type: "text/plain" }),
-          `export.${exportFormat}`
-        )
+        downloadWithBlob(response, `export.${exportFormat}`)
         notifications.success("Export Successful")
       }
     } else {


### PR DESCRIPTION
## Description
When exporting rows from a BudibaseDB table that contain “special” characters, the resulting export.csv file is not UTF-8 encoded.

Addresses: 
- https://github.com/Budibase/budibase/issues/9627

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
No UI changes here


## Documentation
- [x] I have reviewed the budibase documentation to verify if this feature requires any changes. If changes or new docs are required, I have written them.



