### PR TITLE
Create datasource on the second step

### DIFF
--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/GoogleDatasourceConfigModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/GoogleDatasourceConfigModal.svelte
@@ -29,6 +29,8 @@
   let datasource = cloneDeep(integration)
   datasource.config.continueSetupId = continueSetupId
 
+  let { schema } = datasource
+
   $: isGoogleConfigured = !!$organisation.googleDatasourceConfigured
 
   onMount(async () => {
@@ -164,7 +166,7 @@
       <Body size="S">Add the URL of the sheet you want to connect.</Body>
 
       <IntegrationConfigForm
-        schema={datasource.schema}
+        {schema}
         bind:datasource
         creating={true}
         on:valid={e => (isValid = e.detail)}


### PR DESCRIPTION
## Description
Creating the datasource on the 2nd step of the wizard (after connect). If the modal is closed after that, being because the sheets had been selected, skipped, or simply the modal close, we want to redirect to the edit page

## Screenshots
### Closing the modal wizard on the connection step, just closes the modal
https://github.com/Budibase/budibase/assets/15987277/75db630c-11fe-48b6-9a58-0307b7e44c34


### Closing the modal wizard after the connection step navigates to the edition page
https://github.com/Budibase/budibase/assets/15987277/827763a9-1f90-4dd6-8f92-bb9660eae928

