### PR TITLE
Ignore 409 errors on user syncs

### DIFF
--- a/packages/server/src/events/docUpdates/syncUsers.ts
+++ b/packages/server/src/events/docUpdates/syncUsers.ts
@@ -26,6 +26,10 @@ export default function process(updateCb?: UpdateCallback) {
       // if something not found - no changes to perform
       if (err?.status === 404) {
         return
+      }
+      // The user has already been sync in another process
+      else if (err?.status === 409) {
+        return
       } else {
         logging.logAlert("Failed to perform user/group app sync", err)
       }


### PR DESCRIPTION
## Description
Ignore noisy alerts caused by 409 while user synching

Addresses: 
- [BUDI-7054](https://linear.app/budibase/issue/BUDI-7054/handle-409-errors-specifically-in-syncuserstoallapps-call)