### PR TITLE
Reset rows and tick before updating schema when swapping table ID in grids

### DIFF
--- a/packages/frontend-core/src/components/grid/stores/rows.js
+++ b/packages/frontend-core/src/components/grid/stores/rows.js
@@ -2,6 +2,7 @@ import { writable, derived, get } from "svelte/store"
 import { fetchData } from "../../../fetch/fetchData"
 import { notifications } from "@budibase/bbui"
 import { NewRowID, RowPageSize } from "../lib/constants"
+import { tick } from "svelte"
 
 const initialSortState = {
   column: null,
@@ -124,12 +125,21 @@ export const deriveStores = context => {
     })
 
     // Subscribe to changes of this fetch model
-    unsubscribe = newFetch.subscribe($fetch => {
+    unsubscribe = newFetch.subscribe(async $fetch => {
       if ($fetch.loaded && !$fetch.loading) {
         hasNextPage.set($fetch.hasNextPage)
         const $instanceLoaded = get(instanceLoaded)
         const resetRows = $fetch.resetKey !== lastResetKey
+        const previousResetKey = lastResetKey
         lastResetKey = $fetch.resetKey
+
+        // If resetting rows due to a table change, wipe data and wait for
+        // derived stores to compute. This prevents stale data being passed
+        // to cells when we save the new schema.
+        if (!$instanceLoaded && previousResetKey) {
+          rows.set([])
+          await tick()
+        }
 
         // Reset state properties when dataset changes
         if (!$instanceLoaded || resetRows) {


### PR DESCRIPTION
## Description
Fixes an issue where swapping between 2 tables that had the same column name but different types would throw an error. This only happened with incompatible type formats, such as a text value in one table becoming a relationship value in another.


