### PR TITLE
Fix qa-core teardown

### DIFF
--- a/qa-core/src/account-api/api/apis/AccountAPI.ts
+++ b/qa-core/src/account-api/api/apis/AccountAPI.ts
@@ -59,9 +59,12 @@ export default class AccountAPI {
     return [response, json]
   }
 
-  async delete(accountID: string) {
+  async delete(accountID: string, opts: APIRequestOpts = { doExpect: true }) {
     const [response, json] = await this.client.del(`/api/accounts/${accountID}`)
-    expect(response).toHaveStatusCode(200)
+
+    if (opts.doExpect) {
+      expect(response).toHaveStatusCode(200)
+    }
     return response
   }
 }

--- a/qa-core/src/jest/globalTeardown.ts
+++ b/qa-core/src/jest/globalTeardown.ts
@@ -10,7 +10,8 @@ const API_OPTS: APIRequestOpts = { doExpect: false }
 async function deleteAccount() {
   // @ts-ignore
   const accountID = global.qa.accountId
-  await accountsApi.accounts.delete(accountID)
+  // can't run 'expect' blocks in teardown
+  await accountsApi.accounts.delete(accountID, { doExpect: false })
 }
 
 async function teardown() {


### PR DESCRIPTION
## Description
The teardown currently produces an error:

```
[20:48:12.852] ERROR (63474): ReferenceError: Jest: Got error running globalTeardown - /Users/rpowell/dev/repos/budibase/qa-core/src/jest/globalTeardown.ts, reason: expect is not defined
    at AccountAPI.<anonymous> (/Users/rpowell/dev/repos/budibase/qa-core/src/account-api/api/apis/AccountAPI.ts:56:13)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/rpowell/dev/repos/budibase/qa-core/src/account-api/api/apis/AccountAPI.ts:5:58)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```


