### PR TITLE
Added value prop to the schema deprecation notifications

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -333,7 +333,7 @@
               : null}>{value.title || (key === "row" ? "Table" : key)}</Label
           >
         {/if}
-        {#if value.type === "string" && value.enum && canShowField(key)}
+        {#if value.type === "string" && value.enum && canShowField(key, value)}
           <Select
             on:change={e => onChange(e, key)}
             value={inputData[key]}


### PR DESCRIPTION
## Description

When checking the schema deprecation status for fields in automations, no value is being passed to `canShowField` when processing string values. In this scenario an exception is thrown which crashes the builder.

- https://github.com/Budibase/budibase/pull/10787
