### PR TITLE
Fix qa-core global teardown

### DIFF
--- a/qa-core/src/account-api/api/apis/AccountAPI.ts
+++ b/qa-core/src/account-api/api/apis/AccountAPI.ts
@@ -59,11 +59,13 @@ export default class AccountAPI {
     return [response, json]
   }
 
-  async delete(accountID: string, opts: APIRequestOpts = { doExpect: true }) {
-    const [response, json] = await this.client.del(`/api/accounts/${accountID}`)
-
-    if (opts.doExpect) {
-      expect(response).toHaveStatusCode(200)
+  async delete(accountID: string) {
+    const [response, json] = await this.client.del(`/api/accounts/${accountID}`, {
+      internal: true,
+    })
+    // can't use expect here due to use in global teardown
+    if (response.status !== 204) {
+      throw new Error(`Could not delete accountId=${accountID}`)
     }
     return response
   }

--- a/qa-core/src/jest/globalTeardown.ts
+++ b/qa-core/src/jest/globalTeardown.ts
@@ -11,7 +11,7 @@ async function deleteAccount() {
   // @ts-ignore
   const accountID = global.qa.accountId
   // can't run 'expect' blocks in teardown
-  await accountsApi.accounts.delete(accountID, { doExpect: false })
+  await accountsApi.accounts.delete(accountID)
 }
 
 async function teardown() {


### PR DESCRIPTION
## Description
Fixing issue with teardown:
```
[12:14:00.788] WARN (2179817): DELETE /api/accounts/5d8d34bd-bb0c-4d5b-8be1-a2557963288c - 403 {"data":{"0":{"response":{"message":"Unauthorized","status":403}}}}
```


