### PR TITLE
Custom roles breaking app access when not published

### DIFF
--- a/packages/backend-core/src/security/roles.ts
+++ b/packages/backend-core/src/security/roles.ts
@@ -140,9 +140,13 @@ export function lowerBuiltinRoleID(roleId1?: string, roleId2?: string): string {
  * Gets the role object, this is mainly useful for two purposes, to check if the level exists and
  * to check if the role inherits any others.
  * @param {string|null} roleId The level ID to lookup.
+ * @param {object|null} opts options for the function, like whether to halt errors, instead return public.
  * @returns {Promise<Role|object|null>} The role object, which may contain an "inherits" property.
  */
-export async function getRole(roleId?: string): Promise<RoleDoc | undefined> {
+export async function getRole(
+  roleId?: string,
+  opts?: { defaultPublic?: boolean }
+): Promise<RoleDoc | undefined> {
   if (!roleId) {
     return undefined
   }
@@ -161,6 +165,9 @@ export async function getRole(roleId?: string): Promise<RoleDoc | undefined> {
     // finalise the ID
     role._id = getExternalRoleID(role._id)
   } catch (err) {
+    if (opts?.defaultPublic) {
+      return cloneDeep(BUILTIN_ROLES.PUBLIC)
+    }
     // only throw an error if there is no role at all
     if (Object.keys(role).length === 0) {
       throw err

--- a/packages/backend-core/src/security/roles.ts
+++ b/packages/backend-core/src/security/roles.ts
@@ -165,7 +165,7 @@ export async function getRole(
     // finalise the ID
     role._id = getExternalRoleID(role._id)
   } catch (err) {
-    if (opts?.defaultPublic) {
+    if (!isBuiltin(roleId) && opts?.defaultPublic) {
       return cloneDeep(BUILTIN_ROLES.PUBLIC)
     }
     // only throw an error if there is no role at all

--- a/packages/server/src/api/controllers/role.ts
+++ b/packages/server/src/api/controllers/role.ts
@@ -4,7 +4,7 @@ import {
   getUserMetadataParams,
   InternalTables,
 } from "../../db/utils"
-import { BBContext, Database } from "@budibase/types"
+import { UserCtx, Database } from "@budibase/types"
 
 const UpdateRolesOptions = {
   CREATED: "created",
@@ -38,15 +38,15 @@ async function updateRolesOnUserTable(
   }
 }
 
-export async function fetch(ctx: BBContext) {
+export async function fetch(ctx: UserCtx) {
   ctx.body = await roles.getAllRoles()
 }
 
-export async function find(ctx: BBContext) {
+export async function find(ctx: UserCtx) {
   ctx.body = await roles.getRole(ctx.params.roleId)
 }
 
-export async function save(ctx: BBContext) {
+export async function save(ctx: UserCtx) {
   const db = context.getAppDB()
   let { _id, name, inherits, permissionId } = ctx.request.body
   let isCreate = false
@@ -72,7 +72,7 @@ export async function save(ctx: BBContext) {
   ctx.message = `Role '${role.name}' created successfully.`
 }
 
-export async function destroy(ctx: BBContext) {
+export async function destroy(ctx: UserCtx) {
   const db = context.getAppDB()
   const roleId = ctx.params.roleId
   const role = await db.get(roleId)

--- a/packages/server/src/api/controllers/routing.ts
+++ b/packages/server/src/api/controllers/routing.ts
@@ -1,6 +1,6 @@
 import { getRoutingInfo } from "../../utilities/routing"
 import { roles } from "@budibase/backend-core"
-import { BBContext } from "@budibase/types"
+import { UserCtx } from "@budibase/types"
 
 const URL_SEPARATOR = "/"
 
@@ -56,11 +56,11 @@ async function getRoutingStructure() {
   return { routes: routing.json }
 }
 
-export async function fetch(ctx: BBContext) {
+export async function fetch(ctx: UserCtx) {
   ctx.body = await getRoutingStructure()
 }
 
-export async function clientFetch(ctx: BBContext) {
+export async function clientFetch(ctx: UserCtx) {
   const routing = await getRoutingStructure()
   let roleId = ctx.user?.role?._id
   const roleIds = (await roles.getUserRoleHierarchy(roleId, {

--- a/packages/server/src/middleware/currentapp.ts
+++ b/packages/server/src/middleware/currentapp.ts
@@ -96,15 +96,15 @@ export default async (ctx: UserCtx, next: any) => {
       const userId = ctx.user
         ? generateUserMetadataID(ctx.user._id!)
         : undefined
-      ctx.user = {
+      let role = (ctx.user = {
         ...ctx.user!,
         // override userID with metadata one
         _id: userId,
         userId,
         globalId,
         roleId,
-        role: await roles.getRole(roleId),
-      }
+        role: await roles.getRole(roleId, { defaultPublic: true }),
+      })
     }
 
     return next()

--- a/packages/server/src/middleware/currentapp.ts
+++ b/packages/server/src/middleware/currentapp.ts
@@ -96,7 +96,7 @@ export default async (ctx: UserCtx, next: any) => {
       const userId = ctx.user
         ? generateUserMetadataID(ctx.user._id!)
         : undefined
-      let role = (ctx.user = {
+      ctx.user = {
         ...ctx.user!,
         // override userID with metadata one
         _id: userId,
@@ -104,7 +104,7 @@ export default async (ctx: UserCtx, next: any) => {
         globalId,
         roleId,
         role: await roles.getRole(roleId, { defaultPublic: true }),
-      })
+      }
     }
 
     return next()


### PR DESCRIPTION
## Description
Fix for custom roles that have not been published causing users to be unable to access an app completely. They should instead be treated as public users as their role isn't valid.

Addresses: 
- https://github.com/Budibase/budibase/issues/10438
- https://linear.app/budibase/issue/BUDI-7026/when-custom-role-doesnt-exist-in-production-app-assigned-users-should