### PR TITLE
Fix for errant date conversion in MySQL queries

### DIFF
--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -91,7 +91,7 @@ const SCHEMA: Integration = {
   },
 }
 
-function bindingTypeCoerce(bindings: any[]) {
+export function bindingTypeCoerce(bindings: any[]) {
   for (let i = 0; i < bindings.length; i++) {
     const binding = bindings[i]
     if (typeof binding !== "string") {
@@ -109,7 +109,12 @@ function bindingTypeCoerce(bindings: any[]) {
       dayjs(binding).isValid() &&
       !binding.includes(",")
     ) {
-      bindings[i] = dayjs(binding).toDate()
+      let value: any
+      value = new Date(binding)
+      if (isNaN(value)) {
+        value = binding
+      }
+      bindings[i] = value
     }
   }
   return bindings

--- a/packages/server/src/integrations/tests/mysql.spec.ts
+++ b/packages/server/src/integrations/tests/mysql.spec.ts
@@ -1,4 +1,4 @@
-import { default as MySQLIntegration } from "../mysql"
+import { default as MySQLIntegration, bindingTypeCoerce } from "../mysql"
 jest.mock("mysql2")
 
 class TestConfiguration {
@@ -129,5 +129,23 @@ describe("MySQL Integration", () => {
         "1,2,2017",
       ])
     })
+  })
+})
+
+describe("bindingTypeCoercion", () => {
+  it("shouldn't coerce something that looks like a date", () => {
+    const response = bindingTypeCoerce(["202205-1500"])
+    expect(response[0]).toBe("202205-1500")
+  })
+
+  it("should coerce an actual date", () => {
+    const date = new Date("2023-06-13T14:24:22.620Z")
+    const response = bindingTypeCoerce(["2023-06-13T14:24:22.620Z"])
+    expect(response[0]).toEqual(date)
+  })
+
+  it("should coerce numbers", () => {
+    const response = bindingTypeCoerce(["0"])
+    expect(response[0]).toEqual(0)
   })
 })


### PR DESCRIPTION
## Description
Fixes #6346 - issue with date parsing, adding in some testing around it.

Addresses: 
- https://linear.app/budibase/issue/BUDI-7101/custom-mysql-update-with-date-like-value-saves-as-date-instead-of-text