### PR TITLE
MySQL cyclic JSON conversion issue with primary display columns

### DIFF
--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -19,6 +19,7 @@ import {
   breakRowIdField,
   convertRowId,
   generateRowIdField,
+  getPrimaryDisplay,
   isRowId,
   isSQL,
 } from "../../../integrations/utils"
@@ -391,7 +392,10 @@ export class ExternalRequest {
           }
         }
         relatedRow = processFormulas(linkedTable, relatedRow)
-        const relatedDisplay = display ? relatedRow[display] : undefined
+        let relatedDisplay
+        if (display) {
+          relatedDisplay = getPrimaryDisplay(relatedRow[display])
+        }
         row[relationship.column][key] = {
           primaryDisplay: relatedDisplay || "Invalid display column",
           _id: relatedRow._id,

--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -328,3 +328,22 @@ export function finaliseExternalTables(
     .reduce((r, [k, v]) => ({ ...r, [k]: v }), {})
   return { tables: finalTables, errors }
 }
+
+/**
+ * Checks if the provided input is an object, but specifically not a date type object.
+ * Used during coercion of types and relationship handling, dates are considered valid
+ * and can be used as a display field, but objects and arrays cannot.
+ * @param test
+ */
+export function getPrimaryDisplay(test: any): string | undefined {
+  if (test instanceof Date) {
+    return test.toISOString()
+  }
+  if (Array.isArray(test) && test[0] && typeof test[0] !== "object") {
+    return test.join(", ")
+  }
+  if (typeof test === "object") {
+    return undefined
+  }
+  return test as string
+}

--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -333,17 +333,22 @@ export function finaliseExternalTables(
  * Checks if the provided input is an object, but specifically not a date type object.
  * Used during coercion of types and relationship handling, dates are considered valid
  * and can be used as a display field, but objects and arrays cannot.
- * @param test
+ * @param testValue an unknown type which this function will attempt to extract
+ * a valid primary display string from.
  */
-export function getPrimaryDisplay(test: any): string | undefined {
-  if (test instanceof Date) {
-    return test.toISOString()
+export function getPrimaryDisplay(testValue: unknown): string | undefined {
+  if (testValue instanceof Date) {
+    return testValue.toISOString()
   }
-  if (Array.isArray(test) && test[0] && typeof test[0] !== "object") {
-    return test.join(", ")
+  if (
+    Array.isArray(testValue) &&
+    testValue[0] &&
+    typeof testValue[0] !== "object"
+  ) {
+    return testValue.join(", ")
   }
-  if (typeof test === "object") {
+  if (typeof testValue === "object") {
     return undefined
   }
-  return test as string
+  return testValue as string
 }


### PR DESCRIPTION
## Description
Fix for circular issue with primary display fields on SQL tables introduced in most recent update - if somehow the primary display field is set to a relationship field there was a chance of cyclic structure occurring which Koa could not convert to JSON.

Addresses: 
- https://linear.app/budibase/issue/BUDI-7101/custom-mysql-update-with-date-like-value-saves-as-date-instead-of-text
- https://github.com/Budibase/budibase/issues/10834