### PR TITLE
BUDI-7010 - Export controller as post

### DIFF
--- a/packages/builder/src/components/start/ExportAppModal.svelte
+++ b/packages/builder/src/components/start/ExportAppModal.svelte
@@ -51,11 +51,7 @@
         notifications.error("Error exporting the app.")
       }
     } catch (error) {
-      let message = "Error downloading the exported app"
-      if (error.message) {
-        message += `: ${error.message}`
-      }
-      notifications.error("Error downloading the exported app", message)
+      notifications.error(error.message ?? "Error downloading the exported app")
     }
   }
 </script>

--- a/packages/builder/src/components/start/ExportAppModal.svelte
+++ b/packages/builder/src/components/start/ExportAppModal.svelte
@@ -16,9 +16,8 @@
 
   const exportApp = async () => {
     const id = published ? app.prodId : app.devId
-    const appName = encodeURIComponent(app.name)
-    const url = `/api/backups/export?appId=${id}&appname=${appName}&excludeRows=${excludeRows}`
-    await downloadFile(url)
+    const url = `/api/backups/export?appId=${id}`
+    await downloadFile(url, { excludeRows })
   }
 
   export async function downloadFile(url, body) {

--- a/packages/builder/src/components/start/ExportAppModal.svelte
+++ b/packages/builder/src/components/start/ExportAppModal.svelte
@@ -51,7 +51,7 @@
         notifications.error("Error exporting the app.")
       }
     } catch (error) {
-      notifications.error(error.message ?? "Error downloading the exported app")
+      notifications.error(error.message || "Error downloading the exported app")
     }
   }
 </script>

--- a/packages/builder/src/components/start/ExportAppModal.svelte
+++ b/packages/builder/src/components/start/ExportAppModal.svelte
@@ -20,7 +20,7 @@
     await downloadFile(url, { excludeRows })
   }
 
-  export async function downloadFile(url, body) {
+  async function downloadFile(url, body) {
     try {
       const response = await fetch(url, {
         method: "POST",

--- a/packages/server/src/api/routes/backup.ts
+++ b/packages/server/src/api/routes/backup.ts
@@ -5,7 +5,7 @@ import { permissions } from "@budibase/backend-core"
 
 const router: Router = new Router()
 
-router.get(
+router.post(
   "/api/backups/export",
   authorized(permissions.BUILDER),
   controller.exportAppDump


### PR DESCRIPTION
## Description
Refactoring the export functionality to work via post, so we can extend it to accept password values in the body, making it safer

Addresses: 
- [BUDI-7010](https://linear.app/budibase/issue/BUDI-7010/encrypt-app-exports)