### PR TITLE
fix for fonts in production

### DIFF
--- a/packages/builder/index.html
+++ b/packages/builder/index.html
@@ -5,10 +5,10 @@
 	<meta charset='utf8'>
 	<meta name='viewport' content='width=device-width'>
 	<title>Budibase</title>
-	<link href="/fonts/source-sans-pro/400.css" rel="stylesheet" />
-	<link href="/fonts/source-sans-pro/600.css" rel="stylesheet" />
-	<link href="/fonts/source-sans-pro/700.css" rel="stylesheet" />
-	<link href="/fonts/remixicon.css" rel="stylesheet" />
+	<link href="/builder/fonts/source-sans-pro/400.css" rel="stylesheet" />
+	<link href="/builder/fonts/source-sans-pro/600.css" rel="stylesheet" />
+	<link href="/builder/fonts/source-sans-pro/700.css" rel="stylesheet" />
+	<link href="/builder/fonts/remixicon.css" rel="stylesheet" />
 </head>
 
 <body id="app">


### PR DESCRIPTION
## Description
in dev the fonts get appended with `/builder` causing the source sans pro font not to load in prod - reverting back to `/builder` so the font displays


