### PR TITLE
Prevent premature closure of imported users modal.

### DIFF
--- a/packages/bbui/src/Modal/Modal.svelte
+++ b/packages/bbui/src/Modal/Modal.svelte
@@ -8,6 +8,7 @@
 
   export let fixed = false
   export let inline = false
+  export let disableCancel = false
 
   const dispatch = createEventDispatcher()
   let visible = fixed || inline
@@ -38,7 +39,7 @@
   }
 
   export function cancel() {
-    if (!visible) {
+    if (!visible || disableCancel) {
       return
     }
     dispatch("cancel")

--- a/packages/builder/src/pages/builder/portal/users/users/index.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/index.svelte
@@ -373,7 +373,7 @@
   <OnboardingTypeModal {chooseCreationType} />
 </Modal>
 
-<Modal bind:this={passwordModal}>
+<Modal bind:this={passwordModal} disableCancel={true}>
   <PasswordModal
     createUsersResponse={bulkSaveResponse}
     userData={userData.users}


### PR DESCRIPTION
## Description
Prevents premature closure of import users modal. Avoids them accidentally loosing access to generated passwords, as the only way to close that modal now is by clicking done.

Addresses: 
- https://github.com/Budibase/budibase/issues/9956