### PR TITLE
Budi 5262 - Support pg client cert

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/index.svelte
@@ -22,6 +22,7 @@
   import ImportRestQueriesModal from "components/backend/DatasourceNavigator/modals/ImportRestQueriesModal.svelte"
   import { API } from "api"
   import { DatasourceFeature } from "@budibase/types"
+  import Spinner from "components/common/Spinner.svelte"
 
   const querySchema = {
     name: {},
@@ -129,7 +130,12 @@
           cta
           on:click={saveDatasource}
         >
-          Save
+          <div class="save-button-content">
+            {#if loading}
+              <Spinner size="10">Save</Spinner>
+            {/if}
+            Save
+          </div>
         </Button>
       </div>
       <IntegrationConfigForm
@@ -224,5 +230,11 @@
     display: flex;
     flex-direction: column;
     gap: var(--spacing-m);
+  }
+
+  .save-button-content {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s);
   }
 </style>

--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/index.svelte
@@ -33,6 +33,7 @@
   let isValid = true
   let integration, baseDatasource, datasource
   let queryList
+  let loading = false
 
   $: baseDatasource = $datasources.selected
   $: queryList = $queries.list.filter(
@@ -65,9 +66,11 @@
   }
 
   const saveDatasource = async () => {
+    loading = true
     if (integration.features[DatasourceFeature.CONNECTION_CHECKING]) {
       const valid = await validateConfig()
       if (!valid) {
+        loading = false
         return false
       }
     }
@@ -82,6 +85,8 @@
       baseDatasource = cloneDeep(datasource)
     } catch (err) {
       notifications.error(`Error saving datasource: ${err}`)
+    } finally {
+      loading = false
     }
   }
 
@@ -119,7 +124,11 @@
       <Divider />
       <div class="config-header">
         <Heading size="S">Configuration</Heading>
-        <Button disabled={!changed || !isValid} cta on:click={saveDatasource}>
+        <Button
+          disabled={!changed || !isValid || loading}
+          cta
+          on:click={saveDatasource}
+        >
           Save
         </Button>
       </div>

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -42,6 +42,8 @@ interface PostgresConfig {
   schema: string
   ssl?: boolean
   ca?: string
+  clientKey?: string
+  clientCert?: string
   rejectUnauthorized?: boolean
 }
 
@@ -98,6 +100,19 @@ const SCHEMA: Integration = {
       required: false,
     },
     ca: {
+      display: "Server CA",
+      type: DatasourceFieldType.LONGFORM,
+      default: false,
+      required: false,
+    },
+    clientKey: {
+      display: "Client key",
+      type: DatasourceFieldType.LONGFORM,
+      default: false,
+      required: false,
+    },
+    clientCert: {
+      display: "Client cert",
       type: DatasourceFieldType.LONGFORM,
       default: false,
       required: false,
@@ -150,6 +165,8 @@ class PostgresIntegration extends Sql implements DatasourcePlus {
         ? {
             rejectUnauthorized: this.config.rejectUnauthorized,
             ca: this.config.ca,
+            key: this.config.clientKey,
+            cert: this.config.clientCert,
           }
         : undefined,
     }

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -20,7 +20,7 @@ import Sql from "./base/sql"
 import { PostgresColumn } from "./base/types"
 import { escapeDangerousCharacters } from "../utilities"
 
-import { Client, types } from "pg"
+import { Client, ClientConfig, types } from "pg"
 
 // Return "date" and "timestamp" types as plain strings.
 // This lets us reference the original stored timezone.
@@ -144,7 +144,7 @@ class PostgresIntegration extends Sql implements DatasourcePlus {
     super(SqlClient.POSTGRES)
     this.config = config
 
-    let newConfig = {
+    let newConfig: ClientConfig = {
       ...this.config,
       ssl: this.config.ssl
         ? {


### PR DESCRIPTION
## Description
Support Postgres client certificates. Docs: [34.19.2. Client Certificates](https://www.postgresql.org/docs/current/libpq-ssl.html)

Also tweaked the save button to show the loading state while saving:
![image](https://github.com/Budibase/budibase/assets/15987277/6d0891a4-e9a0-43d0-b609-236b19d0e981)




Addresses: 
- [BUDI-5262
](https://linear.app/budibase/issue/BUDI-5262/not-able-to-connect-to-gcp-postgres-ssl-client-cert-client-key-server)

## Screenshots
Having a PG instance with client certificates set up...
### Not setting up SSL
![image](https://github.com/Budibase/budibase/assets/15987277/7a425c6a-847f-4d76-9909-e11442564256)

### Enabling SSL but missing certificates
![image](https://github.com/Budibase/budibase/assets/15987277/08e832b9-5b32-466b-b32f-c45744e2533f)

### All configured
![image](https://github.com/Budibase/budibase/assets/15987277/d358ca49-c469-45cc-936f-10ed6129e1e6)

