### PR TITLE
Fix public apps still displaying free footer when licensed

### DIFF
--- a/packages/client/src/licensing/utils.js
+++ b/packages/client/src/licensing/utils.js
@@ -1,18 +1,30 @@
 import { authStore } from "../stores/auth.js"
+import { appStore } from "../stores/app.js"
 import { get } from "svelte/store"
 import { Constants } from "@budibase/frontend-core"
 
-const getLicense = () => {
+const getUserLicense = () => {
   const user = get(authStore)
   if (user) {
     return user.license
   }
 }
 
+const getAppLicenseType = () => {
+  const appDef = get(appStore)
+  if (appDef?.licenseType) {
+    return appDef.licenseType
+  }
+}
+
 export const isFreePlan = () => {
-  const license = getLicense()
-  if (license) {
-    return license.plan.type === Constants.PlanType.FREE
+  let licenseType = getAppLicenseType()
+  if (!licenseType) {
+    const license = getUserLicense()
+    licenseType = license?.plan?.type
+  }
+  if (licenseType) {
+    return licenseType === Constants.PlanType.FREE
   } else {
     // safety net - no license means free plan
     return true

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -1,53 +1,54 @@
 import env from "../../environment"
 import {
+  createAllSearchIndex,
   createLinkView,
   createRoutingView,
-  createAllSearchIndex,
 } from "../../db/views/staticViews"
-import { createApp, deleteApp } from "../../utilities/fileSystem"
 import {
+  backupClientLibrary,
+  createApp,
+  deleteApp,
+  revertClientLibrary,
+  updateClientLibrary,
+} from "../../utilities/fileSystem"
+import {
+  AppStatus,
+  DocumentType,
   generateAppID,
+  generateDevAppID,
   getLayoutParams,
   getScreenParams,
-  generateDevAppID,
-  DocumentType,
-  AppStatus,
 } from "../../db/utils"
 import {
-  db as dbCore,
-  roles,
   cache,
-  tenancy,
   context,
+  db as dbCore,
+  env as envCore,
+  ErrorCode,
   events,
   migrations,
   objectStore,
-  ErrorCode,
-  env as envCore,
+  roles,
+  tenancy,
 } from "@budibase/backend-core"
 import { USERS_TABLE_SCHEMA } from "../../constants"
 import {
-  DEFAULT_BB_DATASOURCE_ID,
   buildDefaultDocs,
+  DEFAULT_BB_DATASOURCE_ID,
 } from "../../db/defaultData/datasource_bb_default"
 import { removeAppFromUserRoles } from "../../utilities/workerRequests"
-import { stringToReadStream, isQsTrue } from "../../utilities"
-import { getLocksById, doesUserHaveLock } from "../../utilities/redis"
-import {
-  updateClientLibrary,
-  backupClientLibrary,
-  revertClientLibrary,
-} from "../../utilities/fileSystem"
+import { stringToReadStream } from "../../utilities"
+import { doesUserHaveLock, getLocksById } from "../../utilities/redis"
 import { cleanupAutomations } from "../../automations/utils"
 import { checkAppMetadata } from "../../automations/logging"
 import { getUniqueRows } from "../../utilities/usageQuota/rows"
-import { quotas, groups } from "@budibase/pro"
+import { groups, licensing, quotas } from "@budibase/pro"
 import {
   App,
   Layout,
-  Screen,
   MigrationType,
-  Database,
+  PlanType,
+  Screen,
   UserCtx,
 } from "@budibase/types"
 import { BASE_LAYOUT_PROP_IDS } from "../../constants/layouts"
@@ -207,6 +208,7 @@ export async function fetchAppPackage(ctx: UserCtx) {
   let application = await db.get(DocumentType.APP_METADATA)
   const layouts = await getLayouts()
   let screens = await getScreens()
+  const license = await licensing.getLicense()
 
   // Enrich plugin URLs
   application.usedPlugins = objectStore.enrichPluginURLs(
@@ -227,6 +229,7 @@ export async function fetchAppPackage(ctx: UserCtx) {
 
   ctx.body = {
     application: { ...application, upgradableVersion: envCore.VERSION },
+    licenseType: license?.plan.type || PlanType.FREE,
     screens,
     layouts,
     clientLibPath,


### PR DESCRIPTION
## Description
Adding a license mechanism to the app package call so that public apps can still return what license the app utilises. This is retrieved based on the tenant of the app - we only attach the license type so as to not expose further information than is necessary.

This now means that generally the client library will determine its licensing from the app package, rather than from the user, as this is always going to be available, while the user may not always be found.