### PR TITLE
Quick fix to app package licensing fetch

### DIFF
--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -208,7 +208,7 @@ export async function fetchAppPackage(ctx: UserCtx) {
   let application = await db.get(DocumentType.APP_METADATA)
   const layouts = await getLayouts()
   let screens = await getScreens()
-  const license = await licensing.getLicense()
+  const license = await licensing.getCachedLicense()
 
   // Enrich plugin URLs
   application.usedPlugins = objectStore.enrichPluginURLs(

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -208,7 +208,7 @@ export async function fetchAppPackage(ctx: UserCtx) {
   let application = await db.get(DocumentType.APP_METADATA)
   const layouts = await getLayouts()
   let screens = await getScreens()
-  const license = await licensing.getCachedLicense()
+  const license = await licensing.cache.getCachedLicense()
 
   // Enrich plugin URLs
   application.usedPlugins = objectStore.enrichPluginURLs(


### PR DESCRIPTION
## Description
Quick fix suggested by @Rory-Powell to make use of the cached license when fetching the app package.