### PR TITLE
Fix font paths so they work in both dev and prod

### DIFF
--- a/packages/builder/vite.config.js
+++ b/packages/builder/vite.config.js
@@ -64,11 +64,11 @@ export default defineConfig(({ mode }) => {
         targets: [
           {
             src: "../../node_modules/@fontsource/source-sans-pro",
-            dest: "fonts",
+            dest: isProduction ? "fonts" : "builder/fonts",
           },
           {
             src: "../../node_modules/remixicon/fonts/*",
-            dest: "fonts",
+            dest: isProduction ? "fonts" : "builder/fonts",
           },
         ],
       }),


### PR DESCRIPTION
## Description
There was a hotfix for font paths in prod, and this broke them in dev.
This PR updates the vite config to place the fonts in a different path in both dev and prod, accounting for the base URL we use in dev.

In dev we fetch them from `/builder/builder/fonts/...` (double prefix).
In prod we fetch them from `/builder/fonts/...` (single prefix).

We need to prefix with `/builder` so that it is correctly routed and served from the builder bundle in the server package, but svelte automatically prefixes paths in `index.html` with your `base` URL path defined in the vite config in dev. This leads to requesting assets using a double prefix. We can account for this by updating the directory we copy fonts to.
