### PR TITLE
Remove coercion failure logging

### DIFF
--- a/packages/server/src/utilities/rowProcessor/map.ts
+++ b/packages/server/src/utilities/rowProcessor/map.ts
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import { FieldTypes } from "../../constants"
-import { logging } from "@budibase/backend-core"
 
 const parseArrayString = value => {
   if (typeof value === "string") {
@@ -12,7 +11,7 @@ const parseArrayString = value => {
       result = JSON.parse(value.replace(/'/g, '"'))
       return result
     } catch (e) {
-      logging.logWarn("Could not parse row value", e)
+      return value
     }
   }
   return value


### PR DESCRIPTION
## Description
Removing logging of error in coercion - this was creating noise in errors channel.

Addresses: 
- https://linear.app/budibase/issue/BUDI-7035/catch-parsing-error-in-rowprocessor-and-prevent-it-firing-bb-alert