### PR TITLE
Added a 'None' option for sorting columns in data components.

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -3543,7 +3543,8 @@
       {
         "type": "field/sortable",
         "label": "Sort column",
-        "key": "sortColumn"
+        "key": "sortColumn",
+        "placeholder": "None"
       },
       {
         "type": "select",
@@ -4322,7 +4323,8 @@
           {
             "type": "field/sortable",
             "label": "Sort by",
-            "key": "sortColumn"
+            "key": "sortColumn",
+            "placeholder": "None"
           },
           {
             "type": "select",
@@ -4566,7 +4568,8 @@
       {
         "type": "field/sortable",
         "label": "Sort column",
-        "key": "sortColumn"
+        "key": "sortColumn",
+        "placeholder": "None"
       },
       {
         "type": "select",
@@ -4734,7 +4737,8 @@
       {
         "type": "field/sortable",
         "label": "Sort column",
-        "key": "sortColumn"
+        "key": "sortColumn",
+        "placeholder": "None"
       },
       {
         "type": "select",


### PR DESCRIPTION
## Description

Added the ability to clear sorting config options from:
- Repeater Blocks
- Card Blocks
- Dataproviders
- Table Blocks

A `None` option has been added to the related sort column pickers.

Addresses: 
- https://github.com/Budibase/budibase/issues/5395

## Screenshots
![Screenshot 2023-06-22 at 11 40 24](https://github.com/Budibase/budibase/assets/5913006/ea1f6686-4ed6-4613-bb67-03dafda95158)
