### PR TITLE
Added FontAwesome icons used by EasyMDE

### DIFF
--- a/packages/bbui/src/Markdown/SpectrumMDE.svelte
+++ b/packages/bbui/src/Markdown/SpectrumMDE.svelte
@@ -87,7 +87,7 @@
     border-color: var(--spectrum-global-color-gray-400);
   }
   /* Toolbar button color */
-  :global(.EasyMDEContainer .editor-toolbar button i) {
+  :global(.EasyMDEContainer .editor-toolbar button) {
     color: var(--spectrum-global-color-gray-800);
   }
   /* Separator between toolbar buttons*/

--- a/packages/builder/src/components/common/FontAwesomeIcon.svelte
+++ b/packages/builder/src/components/common/FontAwesomeIcon.svelte
@@ -9,6 +9,18 @@
     faFileArrowUp,
     faChevronLeft,
     faCircleInfo,
+    faBold,
+    faItalic,
+    faHeading,
+    faQuoteLeft,
+    faListUl,
+    faListOl,
+    faLink,
+    faImage,
+    faEye,
+    faColumns,
+    faArrowsAlt,
+    faQuestionCircle,
   } from "@fortawesome/free-solid-svg-icons"
   import { faGithub, faDiscord } from "@fortawesome/free-brands-svg-icons"
 
@@ -22,7 +34,22 @@
     faEnvelope,
     faFileArrowUp,
     faChevronLeft,
-    faCircleInfo
+    faCircleInfo,
+
+    // -- Required for easyMDE use in the builder.
+    faBold,
+    faItalic,
+    faHeading,
+    faQuoteLeft,
+    faListUl,
+    faListOl,
+    faLink,
+    faImage,
+    faEye,
+    faColumns,
+    faArrowsAlt,
+    faQuestionCircle
+    // --
   )
   dom.watch()
 </script>


### PR DESCRIPTION
## Description

All FontAwesome icons used by EasyMDE were being overridden by the `dom.watch()` function in the builder. 

All of the required icons have now been explicitly added.

Addresses: 
- https://github.com/Budibase/budibase/issues/5947