### PR TITLE
Null safety

### DIFF
--- a/packages/server/src/integrations/mongodb.ts
+++ b/packages/server/src/integrations/mongodb.ts
@@ -383,7 +383,7 @@ class MongoIntegration implements IntegrationBase {
   createObjectIds(json: any): object {
     const self = this
     function interpolateObjectIds(json: any) {
-      for (let field of Object.keys(json)) {
+      for (let field of Object.keys(json || {})) {
         if (json[field] instanceof Object) {
           json[field] = self.createObjectIds(json[field])
         }


### PR DESCRIPTION
## Description
Not sure why this is only an issue from v2.7, but have added null-safety. 
The **find** method now returns all rows when no body is provided as expected.

Addresses: 
- https://github.com/Budibase/budibase/issues/11005



