### PR TITLE
Small Spelling Fix

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/bb_internal/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/bb_internal/index.svelte
@@ -32,7 +32,7 @@
       </header>
       <Body size="M">
         Budibase internal tables are part of your app, so the data will be
-        stored in your apps context.
+        stored in your app's context.
       </Body>
     </Layout>
     <Divider />


### PR DESCRIPTION
## Description
Fixes a small spelling mistake on the internal datasources list in the builder.

"Budibase internal tables are part of your app, so the data will be stored in your apps context."

I speculate "apps" should have been "app's" (possessive) because the internal tables are part of the context _which belongs to_ the app.