### PR TITLE
Extended email duplicate messaging to the create user flow

### DIFF
--- a/packages/builder/src/pages/builder/portal/users/users/_components/PasswordModal.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/_components/PasswordModal.svelte
@@ -3,6 +3,7 @@
   import PasswordCopyTableRenderer from "./PasswordCopyTableRenderer.svelte"
   import { parseToCsv } from "helpers/data/utils"
   import { onMount } from "svelte"
+  import InviteResponseRenderer from "./InviteResponseRenderer.svelte"
 
   export let userData
   export let createUsersResponse
@@ -96,7 +97,7 @@
 </script>
 
 <ModalContent
-  size="M"
+  size="L"
   {title}
   confirmText="Done"
   showCancelButton={false}
@@ -113,6 +114,9 @@
       allowEditColumns={false}
       allowEditRows={false}
       allowSelectRows={false}
+      customRenderers={[
+        { column: "reason", component: InviteResponseRenderer },
+      ]}
     />
   {/if}
   {#if hasSuccess}


### PR DESCRIPTION
## Description

Extends the email duplicate messaging updates to the create user flow modal. 

In the event that any emails being added already exist in other Budibase tenants, the response `Email already in use. Please use a different email.`, will be displayed next to those affected.

[Previous PR](https://github.com/Budibase/budibase/pull/11002)

## Screenshots

![Screenshot 2023-06-26 at 14 46 10](https://github.com/Budibase/budibase/assets/5913006/8bcf4530-10ea-4b4d-942d-704a9b86d8e6)
