### PR TITLE
Removed cloud flag restriction on auth branding pages

### DIFF
--- a/packages/builder/src/pages/builder/portal/settings/branding.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/branding.svelte
@@ -277,20 +277,18 @@
           allowClear={true}
         />
       </div>
-      {#if !isCloud}
-        <div class="field">
-          <Label size="L">Title</Label>
-          <Input
-            on:change={e => {
-              let clone = { ...config }
-              clone.platformTitle = e.detail ? e.detail : ""
-              config = clone
-            }}
-            value={config.platformTitle || ""}
-            disabled={!brandingEnabled || saving}
-          />
-        </div>
-      {/if}
+      <div class="field">
+        <Label size="L">Title</Label>
+        <Input
+          on:change={e => {
+            let clone = { ...config }
+            clone.platformTitle = e.detail ? e.detail : ""
+            config = clone
+          }}
+          value={config.platformTitle || ""}
+          disabled={!brandingEnabled || saving}
+        />
+      </div>
       <div>
         <Toggle
           text={"Remove Budibase brand from emails"}
@@ -305,54 +303,52 @@
       </div>
     </div>
 
-    {#if !isCloud}
-      <Divider />
-      <Layout gap="XS" noPadding>
-        <Heading size="S">Login page</Heading>
-        <Body />
-      </Layout>
-      <div class="login">
-        <div class="fields">
-          <div class="field">
-            <Label size="L">Header</Label>
-            <Input
-              on:change={e => {
-                let clone = { ...config }
-                clone.loginHeading = e.detail ? e.detail : ""
-                config = clone
-              }}
-              value={config.loginHeading || ""}
-              disabled={!brandingEnabled || saving}
-            />
-          </div>
+    <Divider />
+    <Layout gap="XS" noPadding>
+      <Heading size="S">Login page</Heading>
+      <Body />
+    </Layout>
+    <div class="login">
+      <div class="fields">
+        <div class="field">
+          <Label size="L">Header</Label>
+          <Input
+            on:change={e => {
+              let clone = { ...config }
+              clone.loginHeading = e.detail ? e.detail : ""
+              config = clone
+            }}
+            value={config.loginHeading || ""}
+            disabled={!brandingEnabled || saving}
+          />
+        </div>
 
-          <div class="field">
-            <Label size="L">Button</Label>
-            <Input
-              on:change={e => {
-                let clone = { ...config }
-                clone.loginButton = e.detail ? e.detail : ""
-                config = clone
-              }}
-              value={config.loginButton || ""}
-              disabled={!brandingEnabled || saving}
-            />
-          </div>
-          <div>
-            <Toggle
-              text={"Remove customer testimonials"}
-              on:change={e => {
-                let clone = { ...config }
-                clone.testimonialsEnabled = !e.detail
-                config = clone
-              }}
-              value={!config.testimonialsEnabled}
-              disabled={!brandingEnabled || saving}
-            />
-          </div>
+        <div class="field">
+          <Label size="L">Button</Label>
+          <Input
+            on:change={e => {
+              let clone = { ...config }
+              clone.loginButton = e.detail ? e.detail : ""
+              config = clone
+            }}
+            value={config.loginButton || ""}
+            disabled={!brandingEnabled || saving}
+          />
+        </div>
+        <div>
+          <Toggle
+            text={"Remove customer testimonials"}
+            on:change={e => {
+              let clone = { ...config }
+              clone.testimonialsEnabled = !e.detail
+              config = clone
+            }}
+            value={!config.testimonialsEnabled}
+            disabled={!brandingEnabled || saving}
+          />
         </div>
       </div>
-    {/if}
+    </div>
     <Divider />
     <Layout gap="XS" noPadding>
       <Heading size="S">Application previews</Heading>


### PR DESCRIPTION
## Description

Branding options for premium cloud users unlocked for the tenant authentication page.

Config options in cloud branding for `<your_tenant>.budibase.app` to allow:
- Enabling/Disabling of the customer testimonials.
- Custom page/tab title
- Custom login heading
- Custom login button text

Addresses: 
- https://github.com/Budibase/budibase/discussions/10530

## Screenshots

Login features enabled for cloud premium user in the branding section:

![Screenshot 2023-06-26 at 16 34 39](https://github.com/Budibase/budibase/assets/5913006/1ed7723e-bdf0-46ff-936d-eb51abf02460)

Customised tenant auth screen.

![Screenshot 2023-06-26 at 16 24 09](https://github.com/Budibase/budibase/assets/5913006/2f4e9954-64b8-4a6d-8712-fd48a8aec89d)