### PR TITLE
Don't sync automation logs from prod to dev app

### DIFF
--- a/packages/backend-core/src/db/Replication.ts
+++ b/packages/backend-core/src/db/Replication.ts
@@ -57,6 +57,9 @@ class Replication {
   appReplicateOpts() {
     return {
       filter: (doc: any) => {
+        if (doc._id && doc._id.startsWith(DocumentType.AUTOMATION_LOG)) {
+          return false
+        }
         return doc._id !== DocumentType.APP_METADATA
       },
     }

--- a/packages/server/src/api/routes/tests/application.spec.ts
+++ b/packages/server/src/api/routes/tests/application.spec.ts
@@ -325,7 +325,7 @@ describe("/applications", () => {
     })
   })
 
-  describe("app sync", () => {
+  describe("POST /api/applications/:appId/sync", () => {
     it("should not sync automation logs", async () => {
       // setup the apps
       await config.createApp("testing-auto-logs")
@@ -344,19 +344,15 @@ describe("/applications", () => {
         .expect(200)
 
       // does exist in prod
-      await context.doInAppContext(config.getProdAppId(), async () => {
-        const logs = await config.getAutomationLogs()
-        expect(logs.data.length).toBe(1)
-      })
+      const prodLogs = await config.getAutomationLogs()
+      expect(prodLogs.data.length).toBe(1)
 
       // delete prod app so we revert to dev log search
       await config.unpublish()
 
       // doesn't exist in dev
-      await context.doInAppContext(config.getAppId(), async () => {
-        const logs = await config.getAutomationLogs()
-        expect(logs.data.length).toBe(0)
-      })
+      const devLogs = await config.getAutomationLogs()
+      expect(devLogs.data.length).toBe(0)
     })
   })
 })

--- a/packages/server/src/api/routes/tests/application.spec.ts
+++ b/packages/server/src/api/routes/tests/application.spec.ts
@@ -14,7 +14,7 @@ jest.mock("../../../utilities/redis", () => ({
 import { clearAllApps, checkBuilderEndpoint } from "./utilities/TestFunctions"
 import * as setup from "./utilities"
 import { AppStatus } from "../../../db/utils"
-import { events, utils } from "@budibase/backend-core"
+import { events, utils, context } from "@budibase/backend-core"
 import env from "../../../environment"
 
 jest.setTimeout(15000)
@@ -322,6 +322,41 @@ describe("/applications", () => {
         .expect(200)
       expect(events.app.deleted).toBeCalledTimes(1)
       expect(events.app.unpublished).toBeCalledTimes(1)
+    })
+  })
+
+  describe("app sync", () => {
+    it("should not sync automation logs", async () => {
+      // setup the apps
+      await config.createApp("testing-auto-logs")
+      const automation = await config.createAutomation()
+      await config.publish()
+      await context.doInAppContext(config.getProdAppId(), () => {
+        return config.createAutomationLog(automation)
+      })
+
+      // do the sync
+      const appId = config.getAppId()
+      await request
+        .post(`/api/applications/${appId}/sync`)
+        .set(config.defaultHeaders())
+        .expect("Content-Type", /json/)
+        .expect(200)
+
+      // does exist in prod
+      await context.doInAppContext(config.getProdAppId(), async () => {
+        const logs = await config.getAutomationLogs()
+        expect(logs.data.length).toBe(1)
+      })
+
+      // delete prod app so we revert to dev log search
+      await config.unpublish()
+
+      // doesn't exist in dev
+      await context.doInAppContext(config.getAppId(), async () => {
+        const logs = await config.getAutomationLogs()
+        expect(logs.data.length).toBe(0)
+      })
     })
   })
 })

--- a/packages/server/src/tests/utilities/TestConfiguration.ts
+++ b/packages/server/src/tests/utilities/TestConfiguration.ts
@@ -21,7 +21,7 @@ import {
   basicScreen,
   basicLayout,
   basicWebhook,
-  basicAutomationLog,
+  basicAutomationResults,
 } from "./structures"
 import {
   constants,
@@ -728,15 +728,17 @@ class TestConfiguration {
     return await context.doInAppContext(this.getProdAppId(), async () => {
       return await pro.sdk.automations.logs.storeLog(
         automation,
-        basicAutomationLog(automation._id!)
+        basicAutomationResults(automation._id!)
       )
     })
   }
 
   async getAutomationLogs() {
-    const now = new Date()
-    return await pro.sdk.automations.logs.logSearch({
-      startDate: new Date(now.getTime() - 100000).toISOString(),
+    return context.doInAppContext(this.appId, async () => {
+      const now = new Date()
+      return await pro.sdk.automations.logs.logSearch({
+        startDate: new Date(now.getTime() - 100000).toISOString(),
+      })
     })
   }
 

--- a/packages/server/src/tests/utilities/TestConfiguration.ts
+++ b/packages/server/src/tests/utilities/TestConfiguration.ts
@@ -21,6 +21,7 @@ import {
   basicScreen,
   basicLayout,
   basicWebhook,
+  basicAutomationLog,
 } from "./structures"
 import {
   constants,
@@ -48,6 +49,7 @@ import {
   Table,
   SearchFilters,
   UserRoles,
+  Automation,
 } from "@budibase/types"
 import { BUILTIN_ROLE_IDS } from "@budibase/backend-core/src/security/roles"
 
@@ -718,6 +720,24 @@ class TestConfiguration {
       },
     })
     return { datasource, query: basedOnQuery }
+  }
+
+  // AUTOMATION LOG
+
+  async createAutomationLog(automation: Automation) {
+    return await context.doInAppContext(this.getProdAppId(), async () => {
+      return await pro.sdk.automations.logs.storeLog(
+        automation,
+        basicAutomationLog(automation._id!)
+      )
+    })
+  }
+
+  async getAutomationLogs() {
+    const now = new Date()
+    return await pro.sdk.automations.logs.logSearch({
+      startDate: new Date(now.getTime() - 100000).toISOString(),
+    })
   }
 
   // QUERY

--- a/packages/server/src/tests/utilities/structures.ts
+++ b/packages/server/src/tests/utilities/structures.ts
@@ -9,6 +9,8 @@ import {
 import {
   Automation,
   AutomationActionStepId,
+  AutomationResults,
+  AutomationStatus,
   AutomationStep,
   AutomationStepType,
   AutomationTrigger,
@@ -239,6 +241,21 @@ export function collectAutomation(tableId?: string): Automation {
     },
   }
   return automation as Automation
+}
+
+export function basicAutomationLog(automationId: string): AutomationResults {
+  return {
+    automationId,
+    status: AutomationStatus.SUCCESS,
+    trigger: "trigger",
+    steps: [
+      {
+        stepId: AutomationActionStepId.SERVER_LOG,
+        inputs: {},
+        outputs: {},
+      },
+    ],
+  }
 }
 
 export function basicRow(tableId: string) {

--- a/packages/server/src/tests/utilities/structures.ts
+++ b/packages/server/src/tests/utilities/structures.ts
@@ -243,7 +243,9 @@ export function collectAutomation(tableId?: string): Automation {
   return automation as Automation
 }
 
-export function basicAutomationLog(automationId: string): AutomationResults {
+export function basicAutomationResults(
+  automationId: string
+): AutomationResults {
   return {
     automationId,
     status: AutomationStatus.SUCCESS,


### PR DESCRIPTION
## Description
Adding a test case for the removal of automation logs from app sync, as well as adding to the publish/sync filter a check to not carry over automation logs.

This was causing memory issues in very large apps containing say 300K+ automation logs and there isn't much (if any) benefit to syncing.

Addresses: 
- https://linear.app/budibase/issue/BUDI-7188/remove-syncing-of-automation-history-from-production-to-development