### PR TITLE
Added fullscreen and geolocation permissions to iframe embed

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/settings/embed.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/settings/embed.svelte
@@ -18,7 +18,7 @@
   $: appUrl = `${window.origin}/embed${app?.url}`
   $: appDeployed = app?.status === AppStatus.DEPLOYED
 
-  $: embed = `<iframe width="800" height="600" frameborder="0" allow="clipboard-write;camera" src="${appUrl}"></iframe>`
+  $: embed = `<iframe width="800" height="600" frameborder="0" allow="clipboard-write;camera;geolocation;fullscreen" src="${appUrl}"></iframe>`
 </script>
 
 <Layout noPadding>


### PR DESCRIPTION
## Description

Added `geolocation` and `fullscreen` permissions to the default application iframe embed code.

These are required for any component/feature that makes use of them in the builder e.g EmbeddedMap