### PR TITLE
Prompt to create queries

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/data/_components/CreateExternalDatasourceModal/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/_components/CreateExternalDatasourceModal/index.svelte
@@ -22,7 +22,11 @@
     store.stage === null ? modal?.hide() : modal?.show()
 
     if (store.finished) {
-      goto(`./datasource/${store.datasource._id}`)
+      const queryString =
+        store.datasource.plus || store.datasource.source === "REST"
+          ? ""
+          : "?promptQuery=true"
+      goto(`./datasource/${store.datasource._id}${queryString}`)
     }
   }
 

--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/_components/PromptQueryModal.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/_components/PromptQueryModal.svelte
@@ -1,0 +1,61 @@
+<script>
+  import { goto as gotoStore, params as paramsStore } from "@roxi/routify"
+  import { Modal, ModalContent, Body, Heading } from "@budibase/bbui"
+  import FontAwesomeIcon from "components/common/FontAwesomeIcon.svelte"
+
+  const handleOpen = (modal, params) => {
+    if (params["?promptQuery"] && modal?.show) {
+      modal.show()
+      history.replaceState({}, null, window.location.pathname)
+    }
+  }
+
+  let modal
+  $: params = $paramsStore
+  $: goto = $gotoStore
+  $: handleOpen(modal, params)
+</script>
+
+<Modal bind:this={modal}>
+  <ModalContent
+    size="L"
+    cancelText="Cancel"
+    confirmText="Create new query"
+    onConfirm={() => goto(`../../query/new/${params["datasourceId"]}`)}
+    showCloseIcon={false}
+  >
+    <div slot="header" class="header">
+      <FontAwesomeIcon name="fa-solid fa-circle-check" />
+      <Heading size="M">You're ready to query your data!</Heading>
+    </div>
+    <div class="body">
+      <Body>Your database is connected and ready to use.</Body>
+      <Body
+        >Create a query using <span>Create</span>, <span>Read</span>,
+        <span>Update</span>
+        and <span>Delete</span> functions.</Body
+      >
+    </div>
+  </ModalContent>
+</Modal>
+
+<style>
+  .header {
+    display: flex;
+    align-items: center;
+  }
+
+  .header :global(svg) {
+    margin-right: 10px;
+    margin-bottom: 1px;
+    color: #009562;
+  }
+
+  .body :global(p:first-child) {
+    margin-bottom: 16px;
+  }
+
+  .body :global(span) {
+    font-weight: bold;
+  }
+</style>

--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/index.svelte
@@ -9,6 +9,7 @@
   import RestHeadersPanel from "./_components/panels/Headers.svelte"
   import RestAuthenticationPanel from "./_components/panels/Authentication/index.svelte"
   import RestVariablesPanel from "./_components/panels/Variables/index.svelte"
+  import PromptQueryModal from "./_components/PromptQueryModal.svelte"
 
   let selectedPanel = null
   let panelOptions = []
@@ -40,6 +41,8 @@
     }
   }
 </script>
+
+<PromptQueryModal />
 
 <section>
   <Layout noPadding>


### PR DESCRIPTION
## Description
Prompts the user to create a query upon creating a non-datasource+ datasource. It wasn't specified in the ticket, but I opted to exclude REST from this for now, as the copy doesn't seem to take it into account, and the flow is a bit different.

NOTE: Icon differs from the mockups, but design requested it be done this way.

Addresses: 
- https://linear.app/budibase/issue/BUDI-6946/non-ds-modal-and-action-to-create-first-query

## Screenshots

<img width="1000" alt="Screenshot 2023-06-27 at 16 24 20" src="https://github.com/Budibase/budibase/assets/12501626/e2fdda4c-b25d-4a98-8988-bb9725afdb5e">


