### PR TITLE
Grid fixes

### DIFF
--- a/packages/bbui/src/Form/Core/DatePicker.svelte
+++ b/packages/bbui/src/Form/Core/DatePicker.svelte
@@ -71,6 +71,7 @@
     timeOnly,
     enableTime,
     time24hr,
+    disabled,
   }
 
   const handleChange = event => {

--- a/packages/client/src/components/app/GridBlock.svelte
+++ b/packages/client/src/components/app/GridBlock.svelte
@@ -16,7 +16,7 @@
   export let columns = null
 
   const component = getContext("component")
-  const { styleable, API, builderStore } = getContext("sdk")
+  const { styleable, API, builderStore, notificationStore } = getContext("sdk")
 
   $: columnWhitelist = columns?.map(col => col.name)
   $: schemaOverrides = getSchemaOverrides(columns)
@@ -52,6 +52,8 @@
     showControls={false}
     allowExpandRows={false}
     allowSchemaChanges={false}
+    notifySuccess={notificationStore.actions.success}
+    notifyError={notificationStore.actions.error}
   />
 </div>
 

--- a/packages/frontend-core/src/components/grid/cells/AttachmentCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/AttachmentCell.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount } from "svelte"
   import { getContext } from "svelte"
-  import { Dropzone, notifications } from "@budibase/bbui"
+  import { Dropzone } from "@budibase/bbui"
 
   export let value
   export let focused = false
@@ -11,7 +11,7 @@
   export let invertX = false
   export let invertY = false
 
-  const { API } = getContext("grid")
+  const { API, notifications } = getContext("grid")
   const imageExtensions = ["png", "tiff", "gif", "raw", "jpg", "jpeg"]
 
   let isOpen = false
@@ -40,7 +40,7 @@
   }
 
   const handleFileTooLarge = fileSizeLimit => {
-    notifications.error(
+    $notifications.error(
       `Files cannot exceed ${
         fileSizeLimit / 1000000
       }MB. Please try again with smaller files.`
@@ -55,7 +55,7 @@
     try {
       return await API.uploadBuilderAttachment(data)
     } catch (error) {
-      notifications.error("Failed to upload attachment")
+      $notifications.error("Failed to upload attachment")
       return []
     }
   }

--- a/packages/frontend-core/src/components/grid/controls/BulkDeleteHandler.svelte
+++ b/packages/frontend-core/src/components/grid/controls/BulkDeleteHandler.svelte
@@ -1,8 +1,8 @@
 <script>
-  import { Modal, ModalContent, notifications } from "@budibase/bbui"
+  import { Modal, ModalContent } from "@budibase/bbui"
   import { getContext, onMount } from "svelte"
 
-  const { selectedRows, rows, subscribe } = getContext("grid")
+  const { selectedRows, rows, subscribe, notifications } = getContext("grid")
 
   let modal
 
@@ -15,7 +15,7 @@
   const performDeletion = async () => {
     const count = rowsToDelete.length
     await rows.actions.deleteRows(rowsToDelete)
-    notifications.success(`Deleted ${count} row${count === 1 ? "" : "s"}`)
+    $notifications.success(`Deleted ${count} row${count === 1 ? "" : "s"}`)
   }
 
   onMount(() => subscribe("request-bulk-delete", () => modal?.show()))

--- a/packages/frontend-core/src/components/grid/layout/Grid.svelte
+++ b/packages/frontend-core/src/components/grid/layout/Grid.svelte
@@ -44,6 +44,8 @@
   export let initialSortColumn = null
   export let initialSortOrder = null
   export let initialRowHeight = null
+  export let notifySuccess = null
+  export let notifyError = null
 
   // Unique identifier for DOM nodes inside this instance
   const rand = Math.random()
@@ -89,6 +91,8 @@
     initialSortColumn,
     initialSortOrder,
     initialRowHeight,
+    notifySuccess,
+    notifyError,
   })
 
   // Set context for children to consume

--- a/packages/frontend-core/src/components/grid/layout/NewRow.svelte
+++ b/packages/frontend-core/src/components/grid/layout/NewRow.svelte
@@ -78,6 +78,11 @@
   }
 
   const startAdding = async () => {
+    // Attempt to submit if already adding a row
+    if (visible && !isAdding) {
+      await addRow()
+      return
+    }
     if (visible || !firstColumn) {
       return
     }

--- a/packages/frontend-core/src/components/grid/overlays/MenuOverlay.svelte
+++ b/packages/frontend-core/src/components/grid/overlays/MenuOverlay.svelte
@@ -1,11 +1,5 @@
 <script>
-  import {
-    clickOutside,
-    Menu,
-    MenuItem,
-    Helpers,
-    notifications,
-  } from "@budibase/bbui"
+  import { clickOutside, Menu, MenuItem, Helpers } from "@budibase/bbui"
   import { getContext } from "svelte"
   import { NewRowID } from "../lib/constants"
 
@@ -22,6 +16,7 @@
     dispatch,
     focusedCellAPI,
     focusedRowId,
+    notifications,
   } = getContext("grid")
 
   $: style = makeStyle($menu)
@@ -34,7 +29,7 @@
   const deleteRow = () => {
     rows.actions.deleteRows([$focusedRow])
     menu.actions.close()
-    notifications.success("Deleted 1 row")
+    $notifications.success("Deleted 1 row")
   }
 
   const duplicate = async () => {
@@ -48,7 +43,7 @@
 
   const copyToClipboard = async value => {
     await Helpers.copyToClipboard(value)
-    notifications.success("Copied to clipboard")
+    $notifications.success("Copied to clipboard")
   }
 </script>
 

--- a/packages/frontend-core/src/components/grid/stores/columns.js
+++ b/packages/frontend-core/src/components/grid/stores/columns.js
@@ -35,10 +35,20 @@ export const createStores = () => {
     []
   )
 
+  // Checks if we have a certain column by name
+  const hasColumn = column => {
+    const $columns = get(columns)
+    const $sticky = get(stickyColumn)
+    return $columns.some(col => col.name === column) || $sticky?.name === column
+  }
+
   return {
     columns: {
       ...columns,
       subscribe: enrichedColumns.subscribe,
+      actions: {
+        hasColumn,
+      },
     },
     stickyColumn,
     visibleColumns,
@@ -121,6 +131,7 @@ export const deriveStores = context => {
     columns: {
       ...columns,
       actions: {
+        ...columns.actions,
         saveChanges,
         saveTable,
         changePrimaryDisplay,

--- a/packages/frontend-core/src/components/grid/stores/config.js
+++ b/packages/frontend-core/src/components/grid/stores/config.js
@@ -13,6 +13,8 @@ export const createStores = context => {
   const initialRowHeight = getProp("initialRowHeight")
   const schemaOverrides = getProp("schemaOverrides")
   const columnWhitelist = getProp("columnWhitelist")
+  const notifySuccess = getProp("notifySuccess")
+  const notifyError = getProp("notifyError")
 
   return {
     config,
@@ -23,5 +25,7 @@ export const createStores = context => {
     initialRowHeight,
     schemaOverrides,
     columnWhitelist,
+    notifySuccess,
+    notifyError,
   }
 }

--- a/packages/frontend-core/src/components/grid/stores/index.js
+++ b/packages/frontend-core/src/components/grid/stores/index.js
@@ -14,9 +14,11 @@ import * as Clipboard from "./clipboard"
 import * as Config from "./config"
 import * as Sort from "./sort"
 import * as Filter from "./filter"
+import * as Notifications from "./notifications"
 
 const DependencyOrderedStores = [
   Config,
+  Notifications,
   Sort,
   Filter,
   Bounds,

--- a/packages/frontend-core/src/components/grid/stores/notifications.js
+++ b/packages/frontend-core/src/components/grid/stores/notifications.js
@@ -1,0 +1,23 @@
+import { notifications as BBUINotifications } from "@budibase/bbui"
+import { derived } from "svelte/store"
+
+export const createStores = context => {
+  const { notifySuccess, notifyError } = context
+
+  // Normally we would not derive a store in "createStores" as it should be
+  // dependency free, but in this case it's safe as we only depend on grid props
+  // which are guaranteed to be first in the dependency chain
+  const notifications = derived(
+    [notifySuccess, notifyError],
+    ([$notifySuccess, $notifyError]) => {
+      return {
+        success: $notifySuccess || BBUINotifications.success,
+        error: $notifyError || BBUINotifications.error,
+      }
+    }
+  )
+
+  return {
+    notifications,
+  }
+}

--- a/packages/frontend-core/src/components/grid/stores/rows.js
+++ b/packages/frontend-core/src/components/grid/stores/rows.js
@@ -65,7 +65,6 @@ export const deriveStores = context => {
     validation,
     focusedCellId,
     columns,
-    stickyColumn,
     rowChangeCache,
     inProgressChanges,
     previousFocusedRowId,


### PR DESCRIPTION
## Description
Couple of fixes for the grid (and grid block specifically)
- Notifications were not working in the grid block in client apps, as the client library uses a different notification method than the BBUI one used elsewhere. This PR updates the grid to make notification strategies configurable so that it works in any environment
- Fix ctrl/cmd+enter keybind to submit new rows not working
- Show notification in client apps when a required column is not present in the grid. It is possible to get in this situation by configuring columns on your grid block and hiding a required column. This needs to be a notification rather than an inline error, as we do not have the column in the grid, so we can't highlight it with an error as normal. This will look something like:
![image](https://github.com/Budibase/budibase/assets/9075550/32644f7b-8552-48c9-b4aa-11c35e3c9622)
- Fixes an issue with disabled date pickers https://github.com/Budibase/budibase/discussions/11048
