### PR TITLE
fix sql error message for qa-core

### DIFF
--- a/qa-core/src/integrations/validators/mysql.integration.spec.ts
+++ b/qa-core/src/integrations/validators/mysql.integration.spec.ts
@@ -63,7 +63,7 @@ describe("datasource validators", () => {
       expect(result).toEqual({
         connected: false,
         error:
-          "Access denied for user 'root'@'172.17.0.1' (using password: YES)",
+          "Access denied for the specified user. User does not have the necessary privileges or the provided credentials are incorrect. Please verify the credentials, and ensure that the user has appropriate permissions.",
       })
     })
   })


### PR DESCRIPTION
## Description
Fixes the mismatched error message shown in: https://github.com/Budibase/budibase-deploys/actions/runs/5409048027/jobs/9828734607

However I was unable to reproduce the `Failed to connect to localhost:1433 - Could not connect (sequence) ` locally. Hopefully by fixing the above error it might fix those ones as well? 



