### PR TITLE
Chore - Fix community pipelines

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -27,8 +27,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Fetch pro submodule if running in BB
+        run: |
+          if [ "$GITHUB_REPOSITORY" = "Budibase/budibase" ]; then
+            git submodule update --init --recursive
+          else
+            echo "Submodule fetch skipped."
+          fi
         with:
-          submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -48,10 +48,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo and submodules
+        uses: actions/checkout@v3
+        if: github.repository == github.event.pull_request.head.repo.full_name
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+
+      - name: Checkout repo only
+        uses: actions/checkout@v3
+        if: github.repository != github.event.pull_request.head.repo.full_name
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3
         with:
@@ -66,10 +72,16 @@ jobs:
   test-libraries:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo and submodules
+        uses: actions/checkout@v3
+        if: github.repository == github.event.pull_request.head.repo.full_name
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+
+      - name: Checkout repo only
+        uses: actions/checkout@v3
+        if: github.repository != github.event.pull_request.head.repo.full_name
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3
         with:
@@ -86,10 +98,16 @@ jobs:
   test-services:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo and submodules
+        uses: actions/checkout@v3
+        if: github.repository == github.event.pull_request.head.repo.full_name
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+
+      - name: Checkout repo only
+        uses: actions/checkout@v3
+        if: github.repository != github.event.pull_request.head.repo.full_name
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3
         with:
@@ -106,10 +124,16 @@ jobs:
   test-pro:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo and submodules
+        uses: actions/checkout@v3
+        if: github.repository == github.event.pull_request.head.repo.full_name
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+
+      - name: Checkout repo only
+        uses: actions/checkout@v3
+        if: github.repository != github.event.pull_request.head.repo.full_name
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3
         with:
@@ -121,10 +145,16 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo and submodules
+        uses: actions/checkout@v3
+        if: github.repository == github.event.pull_request.head.repo.full_name
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+
+      - name: Checkout repo only
+        uses: actions/checkout@v3
+        if: github.repository != github.event.pull_request.head.repo.full_name
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3
         with:
@@ -144,11 +174,16 @@ jobs:
   check-pro-submodule:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout repo and submodules
         uses: actions/checkout@v3
+        if: github.repository == github.event.pull_request.head.repo.full_name
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+
+      - name: Checkout repo only
+        uses: actions/checkout@v3
+        if: github.repository != github.event.pull_request.head.repo.full_name
 
       - name: Check pro commit
         id: get_pro_commits

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -28,14 +28,14 @@ jobs:
     steps:
       - name: Checkout repo and submodules
         uses: actions/checkout@v3
-        if: github.repository == "Budibase/budibase"
+        if: github.repository == 'Budibase/budibase'
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
 
       - name: Checkout repo only
         uses: actions/checkout@v3
-        if: github.repository != "Budibase/budibase"
+        if: github.repository != 'Budibase/budibase'
 
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -28,14 +28,14 @@ jobs:
     steps:
       - name: Checkout repo and submodules
         uses: actions/checkout@v3
-        if: github.repository == 'Budibase/budibase'
+        if: github.repository == github.event.pull_request.head.repo.full_name
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
 
       - name: Checkout repo only
         uses: actions/checkout@v3
-        if: github.repository != 'Budibase/budibase'
+        if: github.repository != github.event.pull_request.head.repo.full_name
 
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -32,7 +32,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
           if [ "$GITHUB_REPOSITORY" = "Budibase/budibase" ]; then
-            git submodule update --init --recursive
+            GIT_TERMINAL_PROMPT=0 git -c "http.extraheader=Authorization: Bearer $PERSONAL_ACCESS_TOKEN"  git submodule update --init --recursive
           else
             echo "Submodule fetch skipped."
           fi

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -26,16 +26,17 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Fetch pro submodule if running in BB
-        env:
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        run: |
-          if [ "$GITHUB_REPOSITORY" = "Budibase/budibase" ]; then
-            GIT_TERMINAL_PROMPT=0 git -c "http.extraheader=Authorization: Bearer $PERSONAL_ACCESS_TOKEN"  git submodule update --init --recursive
-          else
-            echo "Submodule fetch skipped."
-          fi
+      - name: Checkout repo and submodules
+        uses: actions/checkout@v3
+        if: ${{ github.repository == "Budibase/budibase" }}
+        with:
+          submodules: true
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+
+      - name: Checkout repo only
+        uses: actions/checkout@v3
+        if: ${{ github.repository != "Budibase/budibase" }}
+
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Fetch pro submodule if running in BB
+        env:
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
           if [ "$GITHUB_REPOSITORY" = "Budibase/budibase" ]; then
             git submodule update --init --recursive

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -169,17 +169,13 @@ jobs:
 
   check-pro-submodule:
     runs-on: ubuntu-latest
+    if: github.repository == github.event.pull_request.head.repo.full_name
     steps:
       - name: Checkout repo and submodules
         uses: actions/checkout@v3
-        if: github.repository == github.event.pull_request.head.repo.full_name
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
-
-      - name: Checkout repo only
-        uses: actions/checkout@v3
-        if: github.repository != github.event.pull_request.head.repo.full_name
 
       - name: Check pro commit
         id: get_pro_commits

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -34,8 +34,6 @@ jobs:
           else
             echo "Submodule fetch skipped."
           fi
-        with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -28,14 +28,14 @@ jobs:
     steps:
       - name: Checkout repo and submodules
         uses: actions/checkout@v3
-        if: ${{ github.repository == "Budibase/budibase" }}
+        if: github.repository == "Budibase/budibase"
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
 
       - name: Checkout repo only
         uses: actions/checkout@v3
-        if: ${{ github.repository != "Budibase/budibase" }}
+        if: github.repository != "Budibase/budibase"
 
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
-
       - name: Checkout repo only
         uses: actions/checkout@v3
         if: github.repository != github.event.pull_request.head.repo.full_name
@@ -54,10 +53,10 @@ jobs:
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
-
       - name: Checkout repo only
         uses: actions/checkout@v3
         if: github.repository != github.event.pull_request.head.repo.full_name
+
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3
         with:
@@ -78,10 +77,10 @@ jobs:
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
-
       - name: Checkout repo only
         uses: actions/checkout@v3
         if: github.repository != github.event.pull_request.head.repo.full_name
+
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3
         with:
@@ -104,10 +103,10 @@ jobs:
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
-
       - name: Checkout repo only
         uses: actions/checkout@v3
         if: github.repository != github.event.pull_request.head.repo.full_name
+
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3
         with:
@@ -123,17 +122,14 @@ jobs:
 
   test-pro:
     runs-on: ubuntu-latest
+    if: github.repository == github.event.pull_request.head.repo.full_name
     steps:
       - name: Checkout repo and submodules
         uses: actions/checkout@v3
-        if: github.repository == github.event.pull_request.head.repo.full_name
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
 
-      - name: Checkout repo only
-        uses: actions/checkout@v3
-        if: github.repository != github.event.pull_request.head.repo.full_name
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3
         with:
@@ -151,10 +147,10 @@ jobs:
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
-
       - name: Checkout repo only
         uses: actions/checkout@v3
         if: github.repository != github.event.pull_request.head.repo.full_name
+
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Description
Since the usage of the submodules for the pro package, on CI pipeline we are fetching it using a git token stored in a secret. This is causing OS contributions to fail, as their forks don't have access to the repo secrets.

This PR is changing the CI pipeline to not checkout the submodules if the pipeline is running from a fork

- [Action while running from the budibase repo](https://github.com/Budibase/budibase/actions/runs/5411761394)
- [Action while running from an incoming fork](https://github.com/Budibase/budibase/actions/runs/5411733663)