### PR TITLE
Clear validation processing when crossing into a side panel component

### DIFF
--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -235,6 +235,7 @@ export const getFrontendStore = () => {
           legalDirectChildren = []
         ) => {
           const type = component._component
+
           if (illegalChildren.includes(type)) {
             return type
           }
@@ -248,10 +249,13 @@ export const getFrontendStore = () => {
             return
           }
 
+          if (type === "@budibase/standard-components/sidepanel") {
+            illegalChildren = []
+          }
+
           const definition = store.actions.components.getDefinition(
             component._component
           )
-
           // Reset whitelist for direct children
           legalDirectChildren = []
           if (definition?.legalDirectChildren?.length) {

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/new/_components/NewComponentPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/components/[componentId]/new/_components/NewComponentPanel.svelte
@@ -52,6 +52,9 @@
     // Build up list of illegal children from ancestors
     let illegalChildren = definition.illegalChildren || []
     path.forEach(ancestor => {
+      if (ancestor._component === `@budibase/standard-components/sidepanel`) {
+        illegalChildren = []
+      }
       const def = store.actions.components.getDefinition(ancestor._component)
       const blacklist = def?.illegalChildren?.map(x => {
         return `@budibase/standard-components/${x}`


### PR DESCRIPTION
## Description

Illegal child components within sidepanels were causing the screen validation to fail.

The process has been updated to reset the validation context when a `sidepanel` is encountered.

Addresses: 

- BUDI-7229


