### PR TITLE
Further QA-core fixes

### DIFF
--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -184,12 +184,13 @@ class SqlServerIntegration extends Sql implements DatasourcePlus {
 
   async connect() {
     try {
-      const encrypt = this.config.encrypt
+      // if encrypt is undefined, then default is to encrypt
+      const encrypt = this.config.encrypt === undefined || this.config.encrypt
       const clientCfg: MSSQLConfig & sqlServer.config = {
         ...this.config,
         port: +this.config.port,
         options: {
-          encrypt: encrypt,
+          encrypt,
           enableArithAbort: true,
         },
       }

--- a/qa-core/src/integrations/external-schema/mssql.integration.spec.ts
+++ b/qa-core/src/integrations/external-schema/mssql.integration.spec.ts
@@ -5,7 +5,7 @@ import mssql from "../../../../packages/server/src/integrations/microsoftSqlServ
 jest.unmock("mssql")
 
 describe("getExternalSchema", () => {
-  describe("postgres", () => {
+  describe("mssql", () => {
     let config: any
 
     beforeAll(async () => {


### PR DESCRIPTION
## Description
Quick fix for QA-core tests, when encrypt is undefined for MS-SQL, it… defaults to true, need to be aware of this so can set `trustServerCertificate` correctly. Also fixing the naming of a test.