### PR TITLE
Update tracking of collaboration events to only count unique users

### DIFF
--- a/packages/server/src/websockets/builder.ts
+++ b/packages/server/src/websockets/builder.ts
@@ -18,13 +18,19 @@ export default class BuilderSocket extends BaseSocket {
     // Initial identification of selected app
     socket?.on(BuilderSocketEvent.SelectApp, async ({ appId }, callback) => {
       await this.joinRoom(socket, appId)
-
-      // Reply with all users in current room
       const sessions = await this.getRoomSessions(appId)
-      callback({ users: sessions })
 
-      // Track usage
-      await events.user.dataCollaboration(sessions.length)
+      // Track collaboration usage by unique users
+      let userIdMap: any = {}
+      sessions?.forEach(session => {
+        if (session._id) {
+          userIdMap[session._id] = true
+        }
+      })
+      await events.user.dataCollaboration(Object.keys(userIdMap).length)
+
+      // Reply with all current sessions
+      callback({ users: sessions })
     })
   }
 


### PR DESCRIPTION
## Description
Small update to how we track usage of collaboration. The current implementation is only counting the total number of sessions, which means the same user with 2 tabs will trigger an event with a payload of 2. This PR only counts unique users, regardless of the session count.

I've also moved where we fire the callback so that it might work in cloud envs, but not sure about that part.

