### PR TITLE
Apply column order for Grid block

### DIFF
--- a/packages/builder/src/components/design/settings/componentSettings.js
+++ b/packages/builder/src/components/design/settings/componentSettings.js
@@ -20,6 +20,7 @@ import ValidationEditor from "./controls/ValidationEditor/ValidationEditor.svelt
 import DrawerBindableInput from "components/common/bindings/DrawerBindableInput.svelte"
 import ColumnEditor from "./controls/ColumnEditor/ColumnEditor.svelte"
 import BasicColumnEditor from "./controls/ColumnEditor/BasicColumnEditor.svelte"
+import GridColumnEditor from "./controls/ColumnEditor/GridColumnEditor.svelte"
 import BarButtonList from "./controls/BarButtonList.svelte"
 import FieldConfiguration from "./controls/FieldConfiguration/FieldConfiguration.svelte"
 
@@ -47,6 +48,7 @@ const componentMap = {
   fieldConfiguration: FieldConfiguration,
   columns: ColumnEditor,
   "columns/basic": BasicColumnEditor,
+  "columns/grid": GridColumnEditor,
   "field/sortable": SortableFieldSelect,
   "field/string": FormFieldSelect,
   "field/number": FormFieldSelect,

--- a/packages/builder/src/components/design/settings/controls/ColumnEditor/ColumnDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/ColumnEditor/ColumnDrawer.svelte
@@ -111,7 +111,7 @@
             {#each columns as column (column.id)}
               <div class="column" animate:flip={{ duration: flipDurationMs }}>
                 <div
-                  hide={!allowReorder || null}
+                  class:hide={!allowReorder}
                   class="handle"
                   aria-label="drag-handle"
                   style={dragDisabled ? "cursor: grab" : "cursor: grabbing"}
@@ -195,7 +195,7 @@
     display: grid;
     place-items: center;
   }
-  .handle[hide] {
+  .handle.hide {
     visibility: hidden;
   }
   .wide {

--- a/packages/builder/src/components/design/settings/controls/ColumnEditor/ColumnDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/ColumnEditor/ColumnDrawer.svelte
@@ -18,6 +18,7 @@
   export let options = []
   export let schema = {}
   export let allowCellEditing = true
+  export let allowReorder = true
 
   const flipDurationMs = 150
   let dragDisabled = true
@@ -110,6 +111,7 @@
             {#each columns as column (column.id)}
               <div class="column" animate:flip={{ duration: flipDurationMs }}>
                 <div
+                  hide={!allowReorder || null}
                   class="handle"
                   aria-label="drag-handle"
                   style={dragDisabled ? "cursor: grab" : "cursor: grabbing"}
@@ -192,6 +194,9 @@
   .handle {
     display: grid;
     place-items: center;
+  }
+  .handle[hide] {
+    visibility: hidden;
   }
   .wide {
     grid-column: 2 / -1;

--- a/packages/builder/src/components/design/settings/controls/ColumnEditor/ColumnEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/ColumnEditor/ColumnEditor.svelte
@@ -13,6 +13,7 @@
   export let componentInstance
   export let value = []
   export let allowCellEditing = true
+  export let allowReorder = true
 
   const dispatch = createEventDispatcher()
 
@@ -85,6 +86,7 @@
     {options}
     {schema}
     {allowCellEditing}
+    {allowReorder}
   />
 </Drawer>
 

--- a/packages/builder/src/components/design/settings/controls/ColumnEditor/GridColumnEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/ColumnEditor/GridColumnEditor.svelte
@@ -1,0 +1,10 @@
+<script>
+  import ColumnEditor from "./ColumnEditor.svelte"
+</script>
+
+<ColumnEditor
+  {...$$props}
+  on:change
+  allowCellEditing={false}
+  allowReorder={false}
+/>

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -5248,7 +5248,7 @@
         "required": true
       },
       {
-        "type": "columns/basic",
+        "type": "columns/grid",
         "label": "Columns",
         "key": "columns",
         "dependsOn": "table"

--- a/packages/client/src/components/app/GridBlock.svelte
+++ b/packages/client/src/components/app/GridBlock.svelte
@@ -23,13 +23,10 @@
 
   const getSchemaOverrides = columns => {
     let overrides = {}
-    let order = 0
     columns?.forEach(column => {
       overrides[column.name] = {
         displayName: column.displayName || column.name,
-        order,
       }
-      order += 1
     })
     return overrides
   }

--- a/packages/client/src/components/app/GridBlock.svelte
+++ b/packages/client/src/components/app/GridBlock.svelte
@@ -27,7 +27,7 @@
     columns?.forEach(column => {
       overrides[column.name] = {
         displayName: column.displayName || column.name,
-        order: order,
+        order,
       }
       order += 1
     })

--- a/packages/client/src/components/app/GridBlock.svelte
+++ b/packages/client/src/components/app/GridBlock.svelte
@@ -23,10 +23,13 @@
 
   const getSchemaOverrides = columns => {
     let overrides = {}
+    let order = 0
     columns?.forEach(column => {
       overrides[column.name] = {
         displayName: column.displayName || column.name,
+        order: order,
       }
+      order += 1
     })
     return overrides
   }


### PR DESCRIPTION
## Description
Configure column draggable re-order in the Design section is now disabled to avoid confusion.

Addresses: 
- https://linear.app/budibase/issue/BUDI-7234/configured-column-order-ignored-by-grid-block

## Screenshots

Grid block:
![Screenshot 2023-07-03 at 11 50 49](https://github.com/Budibase/budibase/assets/101575380/46b7f894-e479-4735-881f-f398c1cfeeb8)

Table block for comparison:
![Screenshot 2023-07-03 at 11 51 24](https://github.com/Budibase/budibase/assets/101575380/498d411d-272e-41b6-a34e-0f7426020fd4)
