### PR TITLE
Ensure columns configured in the grid block are always visible

### DIFF
--- a/packages/client/src/components/app/GridBlock.svelte
+++ b/packages/client/src/components/app/GridBlock.svelte
@@ -26,6 +26,7 @@
     columns?.forEach(column => {
       overrides[column.name] = {
         displayName: column.displayName || column.name,
+        visible: true,
       }
     })
     return overrides


### PR DESCRIPTION
## Description
Fixes an issue where if you hid a column in a table in the data section, then this column would never be visible in grid blocks in apps.


