### PR TITLE
Handle errors in grid when adding a new row

### DIFF
--- a/packages/frontend-core/src/components/grid/stores/rows.js
+++ b/packages/frontend-core/src/components/grid/stores/rows.js
@@ -245,16 +245,7 @@ export const deriveStores = context => {
         focusedCellId.set(`${rowId}-${erroredColumns[0]}`)
       }
     } else {
-      // Some other error - just update the current cell
-      if (get(focusedCellId)) {
-        validation.actions.setError(
-          get(focusedCellId),
-          error?.message || "Error"
-        )
-      } else {
-        get(notifications).error(error?.message || "An unknown error occurred")
-      }
-      validation.actions.setError(get(focusedCellId), error?.message || "Error")
+      get(notifications).error(error?.message || "An unknown error occurred")
     }
   }
 

--- a/packages/frontend-core/src/components/grid/stores/rows.js
+++ b/packages/frontend-core/src/components/grid/stores/rows.js
@@ -246,6 +246,14 @@ export const deriveStores = context => {
       }
     } else {
       // Some other error - just update the current cell
+      if (get(focusedCellId)) {
+        validation.actions.setError(
+          get(focusedCellId),
+          error?.message || "Error"
+        )
+      } else {
+        get(notifications).error(error?.message || "An unknown error occurred")
+      }
       validation.actions.setError(get(focusedCellId), error?.message || "Error")
     }
   }


### PR DESCRIPTION
## Description
Handles a case where errors weren't being displayed due to non existence of a Focused Cell ID. We have to show an actual notification in this instance instead of an inline Grid error. 