### PR TITLE
BUDI-7240 - Refetch relationships

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -186,7 +186,10 @@
         saveColumn.type === LINK_TYPE &&
         saveColumn.relationshipType === RelationshipTypes.MANY_TO_MANY
       ) {
-        dispatch("updatetables")
+        // Fetching the new tables
+        tables.fetch()
+        // Fetching the new relationships
+        datasources.fetch()
       }
       if (originalName) {
         notifications.success("Column updated successfully")

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -182,6 +182,12 @@
         indexes,
       })
       dispatch("updatecolumns")
+      if (
+        saveColumn.type === LINK_TYPE &&
+        saveColumn.relationshipType === RelationshipTypes.MANY_TO_MANY
+      ) {
+        dispatch("updatetables")
+      }
       if (originalName) {
         notifications.success("Column updated successfully")
       } else {

--- a/packages/builder/src/components/backend/DataTable/modals/grid/GridCreateColumnModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/grid/GridCreateColumnModal.svelte
@@ -1,7 +1,6 @@
 <script>
   import { getContext, onMount } from "svelte"
   import { Modal } from "@budibase/bbui"
-  import { tables } from "stores/backend"
   import CreateEditColumn from "components/backend/DataTable/modals/CreateEditColumn.svelte"
 
   const { rows, subscribe } = getContext("grid")
@@ -12,10 +11,5 @@
 </script>
 
 <Modal bind:this={modal}>
-  <CreateEditColumn
-    on:updatecolumns={rows.actions.refreshTableDefinition}
-    on:updatetables={() => {
-      tables.fetch()
-    }}
-  />
+  <CreateEditColumn on:updatecolumns={rows.actions.refreshTableDefinition} />
 </Modal>

--- a/packages/builder/src/components/backend/DataTable/modals/grid/GridCreateColumnModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/grid/GridCreateColumnModal.svelte
@@ -1,6 +1,7 @@
 <script>
   import { getContext, onMount } from "svelte"
   import { Modal } from "@budibase/bbui"
+  import { tables } from "stores/backend"
   import CreateEditColumn from "components/backend/DataTable/modals/CreateEditColumn.svelte"
 
   const { rows, subscribe } = getContext("grid")
@@ -11,5 +12,10 @@
 </script>
 
 <Modal bind:this={modal}>
-  <CreateEditColumn on:updatecolumns={rows.actions.refreshTableDefinition} />
+  <CreateEditColumn
+    on:updatecolumns={rows.actions.refreshTableDefinition}
+    on:updatetables={() => {
+      tables.fetch()
+    }}
+  />
 </Modal>


### PR DESCRIPTION
## Description
Fixing a bug caused by the relationships info and columns not being fetched properly after adding new ones

Addresses: 
- [BUDI-7240](https://linear.app/budibase/issue/BUDI-7240/adding-relationships-and-not-refreshing-keeps-datasources-in-bad-state)
