### PR TITLE
Add section setting to field group

### DIFF
--- a/packages/builder/src/components/design/settings/controls/SectionSelect.svelte
+++ b/packages/builder/src/components/design/settings/controls/SectionSelect.svelte
@@ -17,6 +17,10 @@
       name: "Sidebar with Main",
       icon: "ColumnTwoC",
     },
+    oneColumn: {
+      name: "One column",
+      icon: "LoupeView",
+    },
     twoColumns: {
       name: "Two columns",
       icon: "ColumnTwoA",

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -2355,7 +2355,11 @@
         "type": "section",
         "label": "Type",
         "key": "type",
-        "defaultValue": "oneColumn"
+        "defaultValue": "oneColumn",
+        "dependsOn": {
+          "setting": "labelPosition",
+          "value": "above"
+        }
       }
     ]
   },

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -2350,6 +2350,12 @@
             "value": "above"
           }
         ]
+      },
+      {
+        "type": "section",
+        "label": "Type",
+        "key": "type",
+        "defaultValue": "oneColumn"
       }
     ]
   },

--- a/packages/client/src/components/app/Section.svelte
+++ b/packages/client/src/components/app/Section.svelte
@@ -11,6 +11,7 @@
   let layoutMap = {
     mainSidebar: 2,
     sidebarMain: 2,
+    oneColumn: 1,
     twoColumns: 2,
     threeColumns: 3,
   }
@@ -53,6 +54,9 @@
   }
   .sidebarMain {
     grid-template-columns: 1fr 3fr;
+  }
+  .oneColumn {
+    grid-template-columns: 1fr;
   }
   .twoColumns {
     grid-template-columns: 1fr 1fr;

--- a/packages/client/src/components/app/forms/FieldGroup.svelte
+++ b/packages/client/src/components/app/forms/FieldGroup.svelte
@@ -1,7 +1,9 @@
 <script>
   import { getContext, setContext } from "svelte"
+  import Section from "../Section.svelte"
 
   export let labelPosition = "above"
+  export let type = "oneColumn"
 
   const { styleable } = getContext("sdk")
   const component = getContext("component")
@@ -13,7 +15,9 @@
     class="spectrum-Form"
     class:spectrum-Form--labelsAbove={labelPosition === "above"}
   >
-    <slot />
+    <Section {type}>
+      <slot />
+    </Section>
   </div>
 </div>
 

--- a/packages/client/src/components/app/forms/FieldGroup.svelte
+++ b/packages/client/src/components/app/forms/FieldGroup.svelte
@@ -16,7 +16,16 @@
     class:spectrum-Form--labelsAbove={labelPosition === "above"}
   >
     <Section {type}>
-      <slot />
+      {#if type === "oneColumn"}
+        <div
+          class="spectrum-Form"
+          class:spectrum-Form--labelsAbove={labelPosition === "above"}
+        >
+          <slot />
+        </div>
+      {:else}
+        <slot />
+      {/if}
     </Section>
   </div>
 </div>

--- a/packages/client/src/components/app/forms/FieldGroup.svelte
+++ b/packages/client/src/components/app/forms/FieldGroup.svelte
@@ -15,18 +15,13 @@
     class="spectrum-Form"
     class:spectrum-Form--labelsAbove={labelPosition === "above"}
   >
-    <Section {type}>
-      {#if type === "oneColumn"}
-        <div
-          class="spectrum-Form"
-          class:spectrum-Form--labelsAbove={labelPosition === "above"}
-        >
-          <slot />
-        </div>
-      {:else}
+    {#if labelPosition === "above" && type !== "oneColumn"}
+      <Section {type}>
         <slot />
-      {/if}
-    </Section>
+      </Section>
+    {:else}
+      <slot />
+    {/if}
   </div>
 </div>
 


### PR DESCRIPTION
## Description
As a user, I want a convenient way to layout my form fields. At the moment you need to use multiple containers and play around with width settings if you want form fields to be displayed in a row.
Sections cannot be added within a form, therefore I have updated the field group component to include a section so that you have more quick and easy layout options for your form fields.

Also the CSS was killing me for the left aligned labels. In the end I was able to make it appear nicely for "One Column" mode, but in other modes only the "Above" label is suitable (similar to a form without the field group).

Addresses: 
- https://github.com/Budibase/budibase/discussions/6158#discussioncomment-6343676

## Screenshots
**One Column (default)**
![Screenshot 2023-07-03 at 14 02 08](https://github.com/Budibase/budibase/assets/101575380/1846b290-9e7f-4f4c-9518-52103884e5a2)

**Two Column**
![Screenshot 2023-07-03 at 14 02 29](https://github.com/Budibase/budibase/assets/101575380/cf6a8e6c-e7ec-4560-b46c-cece10bc30e5)

**Three Column**
![Screenshot 2023-07-03 at 14 02 47](https://github.com/Budibase/budibase/assets/101575380/ba5563f8-6912-4f98-a850-f6e9d480ce5c)

**Main with Sidebar**
![Screenshot 2023-07-03 at 14 03 06](https://github.com/Budibase/budibase/assets/101575380/472e3475-d5ac-4774-9186-fea5503c3095)

**Sidebar with Main**
![Screenshot 2023-07-03 at 14 03 25](https://github.com/Budibase/budibase/assets/101575380/65951a75-4713-40e2-8098-532e8b45b77a)

**Left aligned labels**
![Screenshot 2023-07-03 at 14 54 51](https://github.com/Budibase/budibase/assets/101575380/8308113c-05c1-45e6-a6d3-e889a85409a3)

## Documentation
- [x] I have reviewed the budibase documentation to verify if this feature requires any changes. If changes or new docs are required I have written them.



