### PR TITLE
Fix for 'Navigate To' URL options and path trimming.

### DIFF
--- a/packages/builder/src/components/common/bindings/DrawerBindableCombobox.svelte
+++ b/packages/builder/src/components/common/bindings/DrawerBindableCombobox.svelte
@@ -68,6 +68,7 @@
     on:blur={() => dispatch("blur")}
     {placeholder}
     {error}
+    options={allOptions}
   />
   {#if !disabled}
     <div class="icon" on:click={bindingDrawer.show}>

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/NavigateTo.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/NavigateTo.svelte
@@ -43,7 +43,9 @@
       title="Destination"
       placeholder="/screen"
       value={parameters.url}
-      on:change={value => (parameters.url = value.detail)}
+      on:change={value => {
+        parameters.url = value.detail ? value.detail.trim() : value.detail
+      }}
       {bindings}
       options={urlOptions}
       appendBindingsAsOptions={false}
@@ -55,7 +57,9 @@
       title="Destination"
       placeholder="/url"
       value={parameters.url}
-      on:change={value => (parameters.url = value.detail)}
+      on:change={value => {
+        parameters.url = value.detail ? value.detail.trim() : value.detail
+      }}
       {bindings}
     />
     <div />


### PR DESCRIPTION
## Description

- All available app screens will load in the dropdown when configuring a `Navigate To` button action.
- Paths configured for use in the `Navigate To` action are now trimmed

Addresses: 
- BUDI-7180

## Screenshots

![Screenshot 2023-07-03 at 15 02 54](https://github.com/Budibase/budibase/assets/5913006/d74f425a-df96-4ee3-9dab-cb2c9176d0a8)
