### PR TITLE
Fix google sheets import

### DIFF
--- a/packages/builder/src/components/backend/Datasources/TableImportSelection/tableSelectionStore.js
+++ b/packages/builder/src/components/backend/Datasources/TableImportSelection/tableSelectionStore.js
@@ -10,7 +10,11 @@ export const createTableSelectionStore = (integration, datasource) => {
 
   datasources.getTableNames(datasource).then(tableNames => {
     tableNamesStore.set(tableNames)
-    selectedTableNamesStore.set(tableNames.filter(t => datasource.entities[t]))
+
+    selectedTableNamesStore.set(
+      tableNames.filter(tableName => datasource.entities[tableName])
+    )
+
     loadingStore.set(false)
   })
 

--- a/packages/builder/src/stores/backend/datasources.js
+++ b/packages/builder/src/stores/backend/datasources.js
@@ -144,8 +144,7 @@ export function createDatasourcesStore() {
 
     const response = await API.createDatasource({
       datasource,
-      fetchSchema:
-        integration.plus && integration.name !== IntegrationTypes.GOOGLE_SHEETS,
+      fetchSchema: integration.plus,
     })
 
     return updateDatasource(response)


### PR DESCRIPTION
Google sheets table fetching was failing because we weren't fetching the `entities` property for google sheets datasources. Not fetching this was necessary at some point, but not any more, so we can just remove the check and always fetch for datasource plus.