### PR TITLE
Allow suppressing block row creation alerts

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -4490,6 +4490,16 @@
               "setting": "clickBehaviour",
               "value": "details"
             }
+          },
+          {
+            "type": "boolean",
+            "label": "Do not display default save notification",
+            "key": "notificationOverride",
+            "defaultValue": false,
+            "dependsOn": {
+              "setting": "clickBehaviour",
+              "value": "details"
+            }
           }
         ]
       },
@@ -5126,6 +5136,16 @@
               "setting": "actionType",
               "value": "View",
               "invert": true
+            }
+          },
+          {
+            "type": "boolean",
+            "label": "Do not display default save notification",
+            "key": "notificationOverride",
+            "defaultValue": false,
+            "dependsOn": {
+              "setting": "showSaveButton",
+              "value": true
             }
           }
         ]

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -4493,7 +4493,7 @@
           },
           {
             "type": "boolean",
-            "label": "Hide save alert",
+            "label": "Hide notifications",
             "key": "notificationOverride",
             "defaultValue": false,
             "dependsOn": {
@@ -5140,7 +5140,7 @@
           },
           {
             "type": "boolean",
-            "label": "Hide save alert",
+            "label": "Hide notifications",
             "key": "notificationOverride",
             "defaultValue": false,
             "dependsOn": {

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -4493,7 +4493,7 @@
           },
           {
             "type": "boolean",
-            "label": "Do not display default save notification",
+            "label": "Hide save alert",
             "key": "notificationOverride",
             "defaultValue": false,
             "dependsOn": {
@@ -5140,7 +5140,7 @@
           },
           {
             "type": "boolean",
-            "label": "Do not display default save notification",
+            "label": "Hide save alert",
             "key": "notificationOverride",
             "defaultValue": false,
             "dependsOn": {

--- a/packages/client/src/components/app/blocks/TableBlock.svelte
+++ b/packages/client/src/components/app/blocks/TableBlock.svelte
@@ -30,6 +30,7 @@
   export let sidePanelShowDelete
   export let sidePanelSaveLabel
   export let sidePanelDeleteLabel
+  export let notificationOverride
 
   const { fetchDatasourceSchema, API } = getContext("sdk")
   const stateKey = `ID_${generate()}`
@@ -253,6 +254,7 @@
               fields: sidePanelFields || normalFields,
               title: editTitle,
               labelPosition: "left",
+              notificationOverride,
             }}
           />
         </BlockComponent>
@@ -277,6 +279,7 @@
               fields: sidePanelFields || normalFields,
               title: "Create Row",
               labelPosition: "left",
+              notificationOverride,
             }}
           />
         </BlockComponent>

--- a/packages/client/src/components/app/blocks/form/FormBlock.svelte
+++ b/packages/client/src/components/app/blocks/form/FormBlock.svelte
@@ -19,6 +19,7 @@
   export let rowId
   export let actionUrl
   export let noRowsMessage
+  export let notificationOverride
 
   const { fetchDatasourceSchema } = getContext("sdk")
 
@@ -87,6 +88,7 @@
     showDeleteButton,
     schema,
     repeaterId,
+    notificationOverride,
   }
 
   const fetchSchema = async () => {

--- a/packages/client/src/components/app/blocks/form/InnerFormBlock.svelte
+++ b/packages/client/src/components/app/blocks/form/InnerFormBlock.svelte
@@ -17,6 +17,7 @@
   export let showDeleteButton
   export let schema
   export let repeaterId
+  export let notificationOverride
 
   const FieldTypeToComponentMap = {
     string: "stringfield",
@@ -46,6 +47,7 @@
       parameters: {
         providerId: formId,
         tableId: dataSource?.tableId,
+        notificationOverride,
       },
     },
     {


### PR DESCRIPTION
## Description
Adds a setting to suppress row creation alerts for the form and table block.

Addresses: 
- https://linear.app/budibase/issue/BUDI-5433/allow-disabling-success-notifications-for-blocks


