### PR TITLE
Chore - Rely on release tag as source os truth

### DIFF
--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -34,7 +34,6 @@ jobs:
             exit 1
           fi
 
-
       - uses: actions/setup-node@v1
         with:
           node-version: 14.x
@@ -58,9 +57,12 @@ jobs:
           echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} >> .npmrc
           yarn release
 
-      - name: "Get Previous tag"
-        id: previoustag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+      - name: "Get Current tag"
+        id: currenttag
+        run: |
+          version=v$(./scripts/getCurrentVersion.sh)
+          echo 'Using tag $version'
+          echo "::set-output name=tag::$resversionult"
 
       - name: Build/release Docker images
         run: |
@@ -69,7 +71,7 @@ jobs:
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_API_KEY }}
-          BUDIBASE_RELEASE_VERSION: ${{ steps.previoustag.outputs.tag }}
+          BUDIBASE_RELEASE_VERSION: ${{ steps.currenttag.outputs.tag }}
 
   release-helm-chart:
     needs: [release-images]

--- a/scripts/getCurrentVersion.sh
+++ b/scripts/getCurrentVersion.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+version=$(cat lerna.json \
+  | grep version \
+  | head -1 \
+  | awk -F: '{gsub(/"/,"",$2);gsub(/[[:space:]]*/,"",$2); print $2}' \
+  | sed 's/[",]//g')
+echo $version

--- a/scripts/updateVersions.sh
+++ b/scripts/updateVersions.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-version=$(cat lerna.json \
-  | grep version \
-  | head -1 \
-  | awk -F: '{gsub(/"/,"",$2);gsub(/[[:space:]]*/,"",$2); print $2}' \
-  | sed 's/[",]//g')
+version=$(./scripts/getCurrentVersion.sh)
 echo "Setting version $version"
 yarn lerna exec "yarn version --no-git-tag-version --new-version=$version"
 echo "Updating dependencies"


### PR DESCRIPTION
## Description
Removing the usage checking the latest tag, as it might cause race conditions between actions running. Instead, we want to use the version defined in the lerna.json, as this is our source of truth