### PR TITLE
Added presence check for the entities object when fetching tables

### DIFF
--- a/packages/builder/src/components/backend/Datasources/TableImportSelection/tableSelectionStore.js
+++ b/packages/builder/src/components/backend/Datasources/TableImportSelection/tableSelectionStore.js
@@ -10,9 +10,8 @@ export const createTableSelectionStore = (integration, datasource) => {
 
   datasources.getTableNames(datasource).then(tableNames => {
     tableNamesStore.set(tableNames)
-
     selectedTableNamesStore.set(
-      tableNames.filter(tableName => datasource.entities[tableName])
+      tableNames.filter(tableName => datasource.entities?.[tableName])
     )
 
     loadingStore.set(false)


### PR DESCRIPTION
## Description

Added optional chaining when fetching datasource tables to accommodate when `entities` may not be set.

Addresses: 
- https://github.com/Budibase/budibase/issues/11160



