### PR TITLE
add scanner beep on successful qr/barcode scan

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -3173,6 +3173,46 @@
         "defaultValue": false
       },
       {
+        "type": "boolean",
+        "label": "Play sound on scan",
+        "key": "beepOnScan",
+        "defaultValue": false
+      },
+      {
+        "type": "select",
+        "label": "Sound pitch",
+        "key": "beepFrequency",
+        "dependsOn": "beepOnScan",
+        "defaultValue": 2637,
+        "options": [
+          {
+            "label": "Low",
+            "value": 2096
+          },
+          {
+            "label": "Regular",
+            "value": 2637
+          },
+          {
+            "label": "High",
+            "value": 3136
+          },
+          { "label": "Custom", "value": "custom" }
+        ]
+      },
+      {
+        "type": "number",
+        "label": "Sound frequency (Hz)",
+        "key": "customFrequency",
+        "defaultValue": 1046,
+        "min": 20,
+        "max": 8000,
+        "dependsOn": {
+          "setting": "beepFrequency",
+          "value": "custom"
+        }
+      },
+      {
         "type": "validation/string",
         "label": "Validation",
         "key": "validation"

--- a/packages/client/src/components/app/forms/CodeScanner.svelte
+++ b/packages/client/src/components/app/forms/CodeScanner.svelte
@@ -8,6 +8,10 @@
   export let disabled = false
   export let allowManualEntry = false
   export let scanButtonText = "Scan code"
+  export let beepOnScan = false
+  export let beepFrequency = 2637
+  export let customFrequency = 1046
+
   const dispatch = createEventDispatcher()
 
   let videoEle
@@ -21,8 +25,13 @@
     fps: 25,
     qrbox: { width: 250, height: 250 },
   }
+  const audioCtx = new (window.AudioContext || window.webkitAudioContext)()
+
   const onScanSuccess = decodedText => {
     if (value != decodedText) {
+      if (beepOnScan) {
+        beep()
+      }
       dispatch("change", decodedText)
     }
   }
@@ -83,6 +92,27 @@
       html5QrCode = undefined
     }
     camModal.hide()
+  }
+
+  const beep = () => {
+    const oscillator = audioCtx.createOscillator()
+    const gainNode = audioCtx.createGain()
+
+    oscillator.connect(gainNode)
+    gainNode.connect(audioCtx.destination)
+
+    const frequency =
+      beepFrequency === "custom" ? customFrequency : beepFrequency
+    oscillator.frequency.value = frequency
+    oscillator.type = "square"
+
+    const duration = 420
+    const endTime = audioCtx.currentTime + duration / 1000
+    gainNode.gain.setValueAtTime(1, audioCtx.currentTime)
+    gainNode.gain.exponentialRampToValueAtTime(0.001, endTime)
+
+    oscillator.start()
+    oscillator.stop(endTime)
   }
 </script>
 

--- a/packages/client/src/components/app/forms/CodeScannerField.svelte
+++ b/packages/client/src/components/app/forms/CodeScannerField.svelte
@@ -11,6 +11,9 @@
   export let onChange
   export let allowManualEntry
   export let scanButtonText
+  export let beepOnScan
+  export let beepFrequency
+  export let customFrequency
 
   let fieldState
   let fieldApi
@@ -42,6 +45,9 @@
       disabled={fieldState.disabled}
       {allowManualEntry}
       scanButtonText={scanText}
+      {beepOnScan}
+      {beepFrequency}
+      {customFrequency}
     />
   {/if}
 </Field>


### PR DESCRIPTION
## Description
One of our customers relies heavily on the QR scanner component. They really wanted some audible feedback when the scan has worked so I have added a simple beep. It's switched off by default but the sound can be turned on and the frequency can be adjusted. No audio files or dependencies required!

Addresses:
#10968 - a business client was very keen for this

## Screenshots
These settings are a bit extra but they're hidden when not needed
<img width="317" alt="overengineered" src="https://github.com/Budibase/budibase/assets/110921612/7c007660-0b09-44f4-8e9e-5079acbf09d8">

## Documentation
- [x] I have reviewed the budibase documentation to verify if this feature requires any changes. If changes or new docs are required I have written them.



