### PR TITLE
Add embed config to single image nginx config

### DIFF
--- a/hosting/single/nginx/nginx-default-site.conf
+++ b/hosting/single/nginx/nginx-default-site.conf
@@ -22,6 +22,16 @@ server {
         proxy_pass      http://127.0.0.1:4001;
     }
 
+    location /embed {
+        rewrite /embed/(.*) /app/$1  break;
+        proxy_pass       http://127.0.0.1:4001;
+        proxy_redirect   off;
+        proxy_set_header Host                    $host;
+        proxy_set_header x-budibase-embed        "true";
+        add_header       x-budibase-embed        "true";
+        add_header       Content-Security-Policy "frame-ancestors *";
+    }
+
     location = / {
         proxy_pass      http://127.0.0.1:4001;
     }


### PR DESCRIPTION
## Description
Adds the embed route to the single image nginx config, which was left out in the initial PR.
