### PR TITLE
set global retry times on QA core tests

### DIFF
--- a/qa-core/src/jest/jestSetup.ts
+++ b/qa-core/src/jest/jestSetup.ts
@@ -1,4 +1,5 @@
 import { logging } from "@budibase/backend-core"
 logging.LOG_CONTEXT = false
 
+jest.retryTimes(2)
 jest.setTimeout(60000)


### PR DESCRIPTION
## Description
Noticed that a majority of the failing QA core CI tests in our scheduled run fail due to issues like network flakiness, rather than the tests themselves. I've added a global retry to run them again one more time if they fail, which ideally should give us more stability and reduce false positives.



