### PR TITLE
Fixing problems when switching between match any and match all

### DIFF
--- a/packages/backend-core/src/db/lucene.ts
+++ b/packages/backend-core/src/db/lucene.ts
@@ -433,6 +433,9 @@ export class QueryBuilder<T> {
         if (!value) {
           return null
         }
+        if (typeof value === "boolean") {
+          return `(*:* AND !${key}:${value})`
+        }
         return `!${key}:${builder.preprocess(value, allPreProcessingOpts)}`
       })
     }

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterEditor.svelte
@@ -20,7 +20,7 @@
   $: datasource = getDatasourceForProvider($currentAsset, componentInstance)
   $: schema = getSchemaForDatasource($currentAsset, datasource)?.schema
   $: schemaFields = Object.values(schema || {})
-  $: text = getText(value.filter(filter => filter.field))
+  $: text = getText(value?.filter(filter => filter.field))
 
   async function saveFilter() {
     dispatch("change", tempValue)

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterEditor.svelte
@@ -20,7 +20,7 @@
   $: datasource = getDatasourceForProvider($currentAsset, componentInstance)
   $: schema = getSchemaForDatasource($currentAsset, datasource)?.schema
   $: schemaFields = Object.values(schema || {})
-  $: text = getText(value)
+  $: text = getText(value.filter(filter => filter.field))
 
   async function saveFilter() {
     dispatch("change", tempValue)


### PR DESCRIPTION
## Description
Fix for two issues:

 - Fixed UI bug where Match any counted an additional filter that didn't exist in the drawer
 - Fixed a lucene search bug for boolean types

Addresses: 
- https://github.com/Budibase/budibase/issues/11018
- https://github.com/Budibase/budibase/issues/11175

## App Export
[FilterTest-export-1688993997698.tar.gz](https://github.com/Budibase/budibase/files/12002122/FilterTest-export-1688993997698.tar.gz)

## Screenshots

![Screenshot 2023-07-10 at 14 00 44](https://github.com/Budibase/budibase/assets/101575380/ebd36612-c772-4a3a-bf70-3a3236b8f944)

Table Block 1:
![Screenshot 2023-07-10 at 14 01 22](https://github.com/Budibase/budibase/assets/101575380/78f284c8-6500-40f4-b37a-1ff7b90c4b3f)

Table Block 2:
![Screenshot 2023-07-10 at 14 01 37](https://github.com/Budibase/budibase/assets/101575380/9df7b680-1161-41e3-863f-bb330b57c41d)

Table Block 3:
![Screenshot 2023-07-10 at 14 01 53](https://github.com/Budibase/budibase/assets/101575380/f768e0f3-f5ab-4ec9-ad6a-0793376df331)


