### PR TITLE
Allow MSSQL ntlm configuration

### DIFF
--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -28,7 +28,8 @@ const DEFAULT_SCHEMA = "dbo"
 import { ConfidentialClientApplication } from "@azure/msal-node"
 
 enum MSSQLConfigAuthType {
-  ACTIVE_DIRECTORY = "Active Directory",
+  AZURE_ACTIVE_DIRECTORY = "Azure Active Directory",
+  LOCAL_ACTIVE_DIRECTORY = "Local Active Directory",
 }
 
 interface MSSQLConfig {
@@ -93,13 +94,18 @@ const SCHEMA: Integration = {
     authType: {
       type: DatasourceFieldType.SELECT,
       display: "Advanced auth",
-      config: { options: [MSSQLConfigAuthType.ACTIVE_DIRECTORY] },
+      config: {
+        options: [
+          MSSQLConfigAuthType.AZURE_ACTIVE_DIRECTORY,
+          MSSQLConfigAuthType.LOCAL_ACTIVE_DIRECTORY,
+        ],
+      },
     },
     adConfig: {
       type: DatasourceFieldType.FIELD_GROUP,
       default: true,
       display: "Configure Active Directory",
-      hidden: "'{{authType}}' !== 'Active Directory'",
+      hidden: `'{{authType}}' !== '${MSSQLConfigAuthType.AZURE_ACTIVE_DIRECTORY}'`,
       config: {
         openByDefault: true,
         nestedFields: true,
@@ -199,7 +205,7 @@ class SqlServerIntegration extends Sql implements DatasourcePlus {
       }
       delete clientCfg.encrypt
 
-      if (this.config.authType === MSSQLConfigAuthType.ACTIVE_DIRECTORY) {
+      if (this.config.authType === MSSQLConfigAuthType.AZURE_ACTIVE_DIRECTORY) {
         const { clientId, tenantId, clientSecret } = this.config.adConfig!
         const clientApp = new ConfidentialClientApplication({
           auth: {

--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -31,7 +31,7 @@ import { utils } from "@budibase/shared-core"
 
 enum MSSQLConfigAuthType {
   AZURE_ACTIVE_DIRECTORY = "Azure Active Directory",
-  LOCAL_ACTIVE_DIRECTORY = "Local Active Directory",
+  NTLM = "NTLM",
 }
 
 interface BasicMSSQLConfig {
@@ -54,9 +54,9 @@ interface AzureADMSSQLConfig extends BasicMSSQLConfig {
   }
 }
 
-interface LocalADMSSQLConfig extends BasicMSSQLConfig {
-  authType: MSSQLConfigAuthType.LOCAL_ACTIVE_DIRECTORY
-  localADConfig: {
+interface NTLMMSSQLConfig extends BasicMSSQLConfig {
+  authType: MSSQLConfigAuthType.NTLM
+  ntlmConfig: {
     domain: string
     trustServerCertificate: boolean
   }
@@ -65,7 +65,7 @@ interface LocalADMSSQLConfig extends BasicMSSQLConfig {
 type MSSQLConfig =
   | (BasicMSSQLConfig & { authType: undefined })
   | AzureADMSSQLConfig
-  | LocalADMSSQLConfig
+  | NTLMMSSQLConfig
 
 const SCHEMA: Integration = {
   docs: "https://github.com/tediousjs/node-mssql",
@@ -116,7 +116,7 @@ const SCHEMA: Integration = {
       config: {
         options: [
           MSSQLConfigAuthType.AZURE_ACTIVE_DIRECTORY,
-          MSSQLConfigAuthType.LOCAL_ACTIVE_DIRECTORY,
+          MSSQLConfigAuthType.NTLM,
         ],
       },
     },
@@ -147,11 +147,11 @@ const SCHEMA: Integration = {
         },
       },
     },
-    localADConfig: {
+    ntlmConfig: {
       type: DatasourceFieldType.FIELD_GROUP,
       default: true,
-      display: "Configure Local Active Directory",
-      hidden: `'{{authType}}' !== '${MSSQLConfigAuthType.LOCAL_ACTIVE_DIRECTORY}'`,
+      display: "Configure NTLM",
+      hidden: `'{{authType}}' !== '${MSSQLConfigAuthType.NTLM}'`,
       config: {
         openByDefault: true,
         nestedFields: true,
@@ -268,8 +268,8 @@ class SqlServerIntegration extends Sql implements DatasourcePlus {
             },
           }
           break
-        case MSSQLConfigAuthType.LOCAL_ACTIVE_DIRECTORY:
-          const { domain, trustServerCertificate } = this.config.localADConfig
+        case MSSQLConfigAuthType.NTLM:
+          const { domain, trustServerCertificate } = this.config.ntlmConfig
           clientCfg.authentication = {
             type: "ntml",
             options: {

--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -57,8 +57,8 @@ interface AzureADMSSQLConfig extends BasicMSSQLConfig {
 interface NTLMMSSQLConfig extends BasicMSSQLConfig {
   authType: MSSQLConfigAuthType.NTLM
   ntlmConfig: {
-    domain: string
-    trustServerCertificate: boolean
+    domain?: string
+    trustServerCertificate?: boolean
   }
 }
 
@@ -159,12 +159,12 @@ const SCHEMA: Integration = {
       fields: {
         domain: {
           type: DatasourceFieldType.STRING,
-          required: true,
+          required: false,
           display: "Domain",
         },
         trustServerCertificate: {
           type: DatasourceFieldType.BOOLEAN,
-          required: true,
+          required: false,
           display: "Trust server certificate",
         },
       },
@@ -271,7 +271,7 @@ class SqlServerIntegration extends Sql implements DatasourcePlus {
         case MSSQLConfigAuthType.NTLM:
           const { domain, trustServerCertificate } = this.config.ntlmConfig
           clientCfg.authentication = {
-            type: "ntml",
+            type: "ntlm",
             options: {
               domain,
             },


### PR DESCRIPTION
## Description
Setting a new configuration to allow using NTLM authentication on MSSQL datasources: https://tediousjs.github.io/tedious/api-connection.html

Addresses: 
- [BUDI-7265 - MS-SQL NTLM support](https://linear.app/budibase/issue/BUDI-7265/ms-sql-ntlm-support)

## Screenshots
<img width="612" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/7e5b2986-d7bb-4bb4-857a-2de27b375d9e">


## Documentation
TODO when it has been tested and approved



