### PR TITLE
Allow authtype undefined by default

### DIFF
--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -63,7 +63,7 @@ interface NTLMMSSQLConfig extends BasicMSSQLConfig {
 }
 
 type MSSQLConfig =
-  | (BasicMSSQLConfig & { authType: undefined })
+  | (BasicMSSQLConfig & { authType?: undefined })
   | AzureADMSSQLConfig
   | NTLMMSSQLConfig
 


### PR DESCRIPTION
## Description
With the recent refactor, we allowed the mssql auth type to be undefined. Even so, the field was mandatory on the typings. Making the field totally optional will fix the failing typing issues on qa-core

![image](https://github.com/Budibase/budibase/assets/15987277/cf47a948-e540-462e-9887-1b369b10263c)
