### PR TITLE
Confirmation prompts breaking button action flows.

### DIFF
--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -478,7 +478,7 @@ export const enrichButtonActions = (actions, context) => {
                     actions.slice(i + 1),
                     newContext
                   )
-                  resolve(await next())
+                  resolve(typeof next === "function" ? await next() : true)
                 } else {
                   resolve(false)
                 }


### PR DESCRIPTION
## Description

If the last button action is configured to request confirmation, the action flow will quietly fail and disable the button.

#### To reproduce: 
- Add a button and create a `Delete Row` action on it
- Configure it to delete a row with a valid row _id and table.
- Select `Require confirmation`
- Save and preview
- Click the button with the configured action

#### Expected:
- The confirmation prompt will display
- After clicking confirm, the delete will proceed as configured and the button can be reused.

#### Result:
- The row will delete but the flow will quietly fail and the button will disable.
- There will be an error log in the console.
- You need to refresh the screen to reuse the button.
