### PR TITLE
Localize animation

### DIFF
--- a/packages/bbui/src/Form/Core/Combobox.svelte
+++ b/packages/bbui/src/Form/Core/Combobox.svelte
@@ -82,7 +82,7 @@
   {#if open}
     <div class="overlay" on:mousedown|self={() => (open = false)} />
     <div
-      transition:fly={{ y: -20, duration: 200 }}
+      transition:fly|local={{ y: -20, duration: 200 }}
       class="spectrum-Popover spectrum-Popover--bottom is-open"
     >
       <ul class="spectrum-Menu" role="listbox">


### PR DESCRIPTION
## Description
Fixes bug were the animation of the ComboBox was causing the section tabs to open the page like a drawer.

Addresses: 
- https://linear.app/budibase/issue/BUDI-7275/clicking-on-data-or-automate-tabs-when-a-field-dropdown-is-selected

## Screenshots
![nav_bug](https://github.com/Budibase/budibase/assets/101575380/2516fdd9-b8cb-4cb6-b71c-3a9a84357760)




