### PR TITLE
Ensure the Bash automation modal editor is in the correct mode

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -33,6 +33,7 @@
   import {
     bindingsToCompletions,
     jsAutocomplete,
+    hbAutocomplete,
     EditorModes,
   } from "components/common/CodeEditor"
   import FilterDrawer from "components/design/settings/controls/FilterEditor/FilterDrawer.svelte"
@@ -70,7 +71,10 @@
   $: queryLimit = tableId?.includes("datasource") ? "∞" : "1000"
   $: isTrigger = block?.type === "TRIGGER"
   $: isUpdateRow = stepId === ActionStepID.UPDATE_ROW
-
+  $: codeMode =
+    stepId === "EXECUTE_BASH" ? EditorModes.Handlebars : EditorModes.JS
+  $: buildCompletions =
+    stepId === "EXECUTE_BASH" ? hbAutocomplete : jsAutocomplete
   /**
    * TODO - Remove after November 2023
    * *******************************
@@ -497,17 +501,21 @@
                 inputData[key] = e.detail
               }}
               completions={[
-                jsAutocomplete([
-                  ...bindingsToCompletions(bindings, EditorModes.JS),
+                buildCompletions([
+                  ...bindingsToCompletions(bindings, codeMode),
                 ]),
               ]}
-              mode={EditorModes.JS}
+              mode={codeMode}
               height={500}
             />
             <div class="messaging">
               <Icon name="FlashOn" />
               <div class="messaging-wrap">
-                <div>Add available bindings by typing <strong>$</strong></div>
+                <div>
+                  Add available bindings by typing <strong
+                    >{codeMode == EditorModes.JS ? "$" : "{{"}</strong
+                  >
+                </div>
               </div>
             </div>
           </CodeEditorModal>

--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -32,7 +32,6 @@
   import CodeEditor from "components/common/CodeEditor/CodeEditor.svelte"
   import {
     bindingsToCompletions,
-    jsAutocomplete,
     hbAutocomplete,
     EditorModes,
   } from "components/common/CodeEditor"
@@ -73,8 +72,12 @@
   $: isUpdateRow = stepId === ActionStepID.UPDATE_ROW
   $: codeMode =
     stepId === "EXECUTE_BASH" ? EditorModes.Handlebars : EditorModes.JS
-  $: buildCompletions =
-    stepId === "EXECUTE_BASH" ? hbAutocomplete : jsAutocomplete
+
+  $: stepCompletions =
+    codeMode === EditorModes.Handlebars
+      ? [hbAutocomplete([...bindingsToCompletions(bindings, codeMode)])]
+      : []
+
   /**
    * TODO - Remove after November 2023
    * *******************************
@@ -500,12 +503,9 @@
                 onChange({ detail: e.detail }, key)
                 inputData[key] = e.detail
               }}
-              completions={[
-                buildCompletions([
-                  ...bindingsToCompletions(bindings, codeMode),
-                ]),
-              ]}
+              completions={stepCompletions}
               mode={codeMode}
+              autocompleteEnabled={codeMode != EditorModes.JS}
               height={500}
             />
             <div class="messaging">

--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -15,6 +15,7 @@
     Icon,
     Checkbox,
     DatePicker,
+    Detail,
   } from "@budibase/bbui"
   import CreateWebhookModal from "components/automation/Shared/CreateWebhookModal.svelte"
   import { automationStore, selectedAutomation } from "builderStore"
@@ -55,6 +56,7 @@
   let drawer
   let fillWidth = true
   let inputData
+  let codeBindingOpen = false
 
   $: filters = lookForFilters(schemaProperties) || []
   $: tempFilters = filters
@@ -496,6 +498,18 @@
           />
         {:else if value.customType === "code"}
           <CodeEditorModal>
+            {#if codeMode == EditorModes.JS}
+              <ActionButton
+                on:click={() => (codeBindingOpen = !codeBindingOpen)}
+                quiet
+                icon={codeBindingOpen ? "ChevronDown" : "ChevronRight"}
+              >
+                <Detail size="S">Bindings</Detail>
+              </ActionButton>
+              {#if codeBindingOpen}
+                <pre>{JSON.stringify(bindings, null, 2)}</pre>
+              {/if}
+            {/if}
             <CodeEditor
               value={inputData[key]}
               on:change={e => {
@@ -509,14 +523,16 @@
               height={500}
             />
             <div class="messaging">
-              <Icon name="FlashOn" />
-              <div class="messaging-wrap">
-                <div>
-                  Add available bindings by typing <strong
-                    >{codeMode == EditorModes.JS ? "$" : "{{"}</strong
-                  >
+              {#if codeMode == EditorModes.Handlebars}
+                <Icon name="FlashOn" />
+                <div class="messaging-wrap">
+                  <div>
+                    Add available bindings by typing <strong>
+                      &#125;&#125;
+                    </strong>
+                  </div>
                 </div>
-              </div>
+              {/if}
             </div>
           </CodeEditorModal>
         {:else if value.customType === "loopOption"}

--- a/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
+++ b/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
@@ -48,6 +48,7 @@
   export let mode = EditorModes.Handlebars
   export let value = ""
   export let placeholder = null
+  export let autocompleteEnabled = true
 
   // Export a function to expose caret position
   export const getCaretPosition = () => {
@@ -131,12 +132,6 @@
       syntaxHighlighting(oneDarkHighlightStyle, { fallback: true }),
       highlightActiveLineGutter(),
       highlightSpecialChars(),
-      autocompletion({
-        override: [...completions],
-        closeOnBlur: true,
-        icons: false,
-        optionClass: () => "autocomplete-option",
-      }),
       EditorView.lineWrapping,
       EditorView.updateListener.of(v => {
         const docStr = v.state.doc?.toString()
@@ -159,11 +154,16 @@
 
   const buildExtensions = base => {
     const complete = [...base]
-    if (mode.name == "javascript") {
-      complete.push(javascript())
-      complete.push(highlightWhitespace())
-      complete.push(lineNumbers())
-      complete.push(foldGutter())
+
+    if (autocompleteEnabled) {
+      complete.push(
+        autocompletion({
+          override: [...completions],
+          closeOnBlur: true,
+          icons: false,
+          optionClass: () => "autocomplete-option",
+        })
+      )
       complete.push(
         EditorView.inputHandler.of((view, from, to, insert) => {
           if (insert === "$") {
@@ -191,6 +191,13 @@
           return false
         })
       )
+    }
+
+    if (mode.name == "javascript") {
+      complete.push(javascript())
+      complete.push(highlightWhitespace())
+      complete.push(lineNumbers())
+      complete.push(foldGutter())
     }
 
     if (placeholder) {


### PR DESCRIPTION
## Description

Fix for the Bash modal editors in the automation editor.

- Bash Scripting modal is now initialised with the Handlebars/Text mode, as intended.
- JS Scripting bindings have been added back to the top of the modal editor.

The modal correctly displays it respective autocomplete suggestions when pressing `Ctrl + Space`

Addresses: 
- https://github.com/Budibase/budibase/issues/11121

## Screenshots

Bash Modal Editor
![Screenshot 2023-07-14 at 14 21 01](https://github.com/Budibase/budibase/assets/5913006/679d74b2-9edc-4b0a-ac9d-942197f33884)

JS Modal Editor
![Screenshot 2023-07-17 at 11 17 38](https://github.com/Budibase/budibase/assets/5913006/82579d4a-3bff-4853-8188-aa5c1f768124)