### PR TITLE
Make sure a duplicate BlockComponent can't be registered

### DIFF
--- a/packages/client/src/components/Block.svelte
+++ b/packages/client/src/components/Block.svelte
@@ -13,6 +13,13 @@
     if (!structureLookupMap[parentId]) {
       structureLookupMap[parentId] = {}
     }
+    //If the instance already exists, delete the previous
+    for (const [key, value] of Object.entries(structureLookupMap[parentId])) {
+      if (value?._id === instance?._id) {
+        delete structureLookupMap[parentId][key]
+        break
+      }
+    }
     // Add this instance in this order, overwriting any existing instance in
     // this order in case of repeaters
     structureLookupMap[parentId][order] = instance


### PR DESCRIPTION
## Description
Duplicate *Create row* buttons were being registered which was causing a crash. 

I did have a go at changing the `registerComponent` code in **BlockComponent.svelte** to use *onMount* instead of being reactive, but this didn't handle re-ordering/rendering.

The solution I settled on was to ensure that when `registerBlockComponent` is called, any potential duplicates are removed first. 

Addresses: 
- https://linear.app/budibase/issue/BUDI-7280/selecting-and-de-selecting-search-fields-on-a-table-block-before

## Screenshots
![fix](https://github.com/Budibase/budibase/assets/101575380/11f865ff-15ec-4e62-883f-5395394300cf)




