### PR TITLE
Fix block component keying

### DIFF
--- a/packages/client/src/components/Block.svelte
+++ b/packages/client/src/components/Block.svelte
@@ -8,27 +8,28 @@
 
   let structureLookupMap = {}
 
-  const registerBlockComponent = (id, order, parentId, instance) => {
+  const registerBlockComponent = (id, parentId, order, instance) => {
     // Ensure child map exists
     if (!structureLookupMap[parentId]) {
       structureLookupMap[parentId] = {}
     }
     // Add this instance in this order, overwriting any existing instance in
     // this order in case of repeaters
-    structureLookupMap[parentId][order] = instance
+    structureLookupMap[parentId][id] = { order, instance }
   }
 
-  const unregisterBlockComponent = (order, parentId) => {
+  const unregisterBlockComponent = (id, parentId) => {
     // Ensure child map exists
     if (!structureLookupMap[parentId]) {
       return
     }
-    delete structureLookupMap[parentId][order]
+    delete structureLookupMap[parentId][id]
   }
 
   const eject = () => {
     // Start the new structure with the root component
-    let definition = structureLookupMap[$component.id][0]
+    let definition = Object.values(structureLookupMap[$component.id])[0]
+      .instance
 
     // Copy styles from block to root component
     definition._styles = {
@@ -49,10 +50,12 @@
   const attachChildren = (rootComponent, map) => {
     // Transform map into children array
     let id = rootComponent._id
-    const children = Object.entries(map[id] || {}).map(([order, instance]) => ({
-      order,
-      instance,
-    }))
+    const children = Object.values(map[id] || {}).map(
+      ({ order, instance }) => ({
+        order,
+        instance,
+      })
+    )
     if (!children.length) {
       return
     }

--- a/packages/client/src/components/Block.svelte
+++ b/packages/client/src/components/Block.svelte
@@ -53,12 +53,7 @@
   const attachChildren = (rootComponent, map) => {
     // Transform map into children array
     let id = rootComponent._id
-    const children = Object.values(map[id] || {}).map(
-      ({ order, instance }) => ({
-        order,
-        instance,
-      })
-    )
+    const children = Object.values(map[id] || {})
     if (!children.length) {
       return
     }

--- a/packages/client/src/components/Block.svelte
+++ b/packages/client/src/components/Block.svelte
@@ -29,7 +29,7 @@
   const eject = () => {
     // Start the new structure with the root component
     const rootMap = structureLookupMap[$component.id] || {}
-    let definition = { ...Object.values(rootMap)[0]?.instance }
+    let definition = Object.values(rootMap)[0]?.instance
     if (!definition) {
       return
     }

--- a/packages/client/src/components/Block.svelte
+++ b/packages/client/src/components/Block.svelte
@@ -28,8 +28,11 @@
 
   const eject = () => {
     // Start the new structure with the root component
-    let definition = Object.values(structureLookupMap[$component.id])[0]
-      .instance
+    const rootMap = structureLookupMap[$component.id] || {}
+    let definition = { ...Object.values(rootMap)[0]?.instance }
+    if (!definition) {
+      return
+    }
 
     // Copy styles from block to root component
     definition._styles = {

--- a/packages/client/src/components/BlockComponent.svelte
+++ b/packages/client/src/components/BlockComponent.svelte
@@ -23,6 +23,8 @@
   // Create a fake component instance so that we can use the core Component
   // to render this part of the block, taking advantage of binding enrichment
   $: id = `${block.id}-${context ?? rand}`
+  $: parentId = $component?.id
+  $: inBuilder = $builderStore.inBuilder
   $: instance = {
     _component: `@budibase/standard-components/${type}`,
     _id: id,
@@ -38,14 +40,14 @@
   // Register this block component if we're inside the builder so it can be
   // ejected later
   $: {
-    if ($builderStore.inBuilder) {
-      block.registerComponent(id, order ?? 0, $component?.id, instance)
+    if (inBuilder) {
+      block.registerComponent(id, parentId, order ?? 0, instance)
     }
   }
 
   onDestroy(() => {
-    if ($builderStore.inBuilder) {
-      block.unregisterComponent(order ?? 0, $component?.id)
+    if (inBuilder) {
+      block.unregisterComponent(id, parentId)
     }
   })
 </script>

--- a/packages/client/src/components/app/blocks/CardsBlock.svelte
+++ b/packages/client/src/components/app/blocks/CardsBlock.svelte
@@ -126,7 +126,7 @@
             order={1}
           >
             {#if enrichedSearchColumns?.length}
-              {#each enrichedSearchColumns as column, idx}
+              {#each enrichedSearchColumns as column, idx (column.name)}
                 <BlockComponent
                   type={column.componentType}
                   props={{

--- a/packages/client/src/components/app/blocks/TableBlock.svelte
+++ b/packages/client/src/components/app/blocks/TableBlock.svelte
@@ -169,7 +169,7 @@
             order={1}
           >
             {#if enrichedSearchColumns?.length}
-              {#each enrichedSearchColumns as column, idx}
+              {#each enrichedSearchColumns as column, idx (column.name)}
                 <BlockComponent
                   type={column.componentType}
                   props={{


### PR DESCRIPTION
## Description
Fixes a couple of issues with blocks:
- Blocks identified their child `BlockComponents` by using their `order` as part of an identifier. We depend on this indentifier to properly unregister them from their parent `Block` component instance when unmounting, but `order` can change at runtime, meaning we were not properly unregistering them. This meant that block ejection could sometimes contain duplicate components which would crash the builder. This PR updates keying to only consider the component ID, which is a constant.
- Search fields (used in `TableBlock` and `CardsBlock`) were not keyed by anything. This meant that when changing the setting in the builder, it appeared as though you sometimes removed the wrong field (even though a refresh would reveal the correct fields).

Addresses: 
- https://linear.app/budibase/issue/BUDI-7280/selecting-and-de-selecting-search-fields-on-a-table-block-before

