### PR TITLE
Relationship picker filtering

### DIFF
--- a/packages/builder/src/components/design/settings/componentSettings.js
+++ b/packages/builder/src/components/design/settings/componentSettings.js
@@ -23,6 +23,7 @@ import BasicColumnEditor from "./controls/ColumnEditor/BasicColumnEditor.svelte"
 import GridColumnEditor from "./controls/ColumnEditor/GridColumnEditor.svelte"
 import BarButtonList from "./controls/BarButtonList.svelte"
 import FieldConfiguration from "./controls/FieldConfiguration/FieldConfiguration.svelte"
+import RelationshipFilterEditor from "./controls/RelationshipFilterEditor.svelte"
 
 const componentMap = {
   text: DrawerBindableInput,
@@ -44,6 +45,7 @@ const componentMap = {
   schema: SchemaSelect,
   section: SectionSelect,
   filter: FilterEditor,
+  "filter/relationship": RelationshipFilterEditor,
   url: URLSelect,
   fieldConfiguration: FieldConfiguration,
   columns: ColumnEditor,

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterEditor.svelte
@@ -13,13 +13,14 @@
   export let value = []
   export let componentInstance
   export let bindings = []
+  export let schema = null
 
   let drawer
 
   $: tempValue = value
   $: datasource = getDatasourceForProvider($currentAsset, componentInstance)
-  $: schema = getSchemaForDatasource($currentAsset, datasource)?.schema
-  $: schemaFields = Object.values(schema || {})
+  $: dsSchema = getSchemaForDatasource($currentAsset, datasource)?.schema
+  $: schemaFields = Object.values(schema || dsSchema || {})
   $: text = getText(value?.filter(filter => filter.field))
 
   async function saveFilter() {

--- a/packages/builder/src/components/design/settings/controls/RelationshipFilterEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/RelationshipFilterEditor.svelte
@@ -1,0 +1,35 @@
+<script>
+  import { currentAsset } from "builderStore"
+  import { findClosestMatchingComponent } from "builderStore/componentUtils"
+  import {
+    getDatasourceForProvider,
+    getSchemaForDatasource,
+  } from "builderStore/dataBinding"
+  import { tables } from "stores/backend"
+  import FilterEditor from "./FilterEditor/FilterEditor.svelte"
+
+  export let componentInstance
+
+  // Extract which relationship column we're using
+  $: column = componentInstance.field
+
+  // Find the closest parent form
+  $: form = findClosestMatchingComponent(
+    $currentAsset.props,
+    componentInstance._id,
+    component => component._component.endsWith("/form")
+  )
+
+  // Get that form's schema
+  $: datasource = getDatasourceForProvider($currentAsset, form)
+  $: formSchema = getSchemaForDatasource($currentAsset, datasource)?.schema
+
+  // Get the schema for the relationship field that this picker is using
+  $: columnSchema = formSchema?.[column]
+
+  // Get the schema for the table on the other side of this relationship
+  $: linkedTable = $tables.list.find(x => x._id === columnSchema?.tableId)
+  $: schema = linkedTable?.schema
+</script>
+
+<FilterEditor on:change {...$$props} {schema} />

--- a/packages/builder/src/components/design/settings/controls/ValidationEditor/ValidationEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/ValidationEditor/ValidationEditor.svelte
@@ -8,16 +8,29 @@
   export let componentDefinition
   export let type
 
+  const dispatch = createEventDispatcher()
   let drawer
 
-  const dispatch = createEventDispatcher()
+  $: text = getText(value)
+
   const save = () => {
     dispatch("change", value)
     drawer.hide()
   }
+
+  const getText = rules => {
+    if (!rules?.length) {
+      return "No rules set"
+    } else {
+      return `${rules.length} rule${rules.length === 1 ? "" : "s"} set`
+    }
+  }
 </script>
 
-<ActionButton on:click={drawer.show}>Configure validation</ActionButton>
+<div class="validation-editor">
+  <ActionButton on:click={drawer.show}>{text}</ActionButton>
+</div>
+
 <Drawer bind:this={drawer} title="Validation Rules">
   <svelte:fragment slot="description">
     Configure validation rules for this field.
@@ -31,3 +44,9 @@
     {componentDefinition}
   />
 </Drawer>
+
+<style>
+  .validation-editor :global(.spectrum-ActionButton) {
+    width: 100%;
+  }
+</style>

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -3490,6 +3490,16 @@
         ]
       },
       {
+        "type": "validation/link",
+        "label": "Validation",
+        "key": "validation"
+      },
+      {
+        "type": "filter/relationship",
+        "label": "Filtering",
+        "key": "filter"
+      },
+      {
         "type": "boolean",
         "label": "Autocomplete",
         "key": "autocomplete",
@@ -3500,11 +3510,6 @@
         "label": "Disabled",
         "key": "disabled",
         "defaultValue": false
-      },
-      {
-        "type": "validation/link",
-        "label": "Validation",
-        "key": "validation"
       }
     ]
   },


### PR DESCRIPTION
## Description
This PR adds filtering to the relationship field.

Relationship fields have a new filter setting, which allows you to filter rows that will be listed as options to link to. If you have a relationship between `Employees` and `Deals` and we are creating a new `Deals` row, then the filter options will be for the **other** table, so they will be filter options for the `Employees` table.

This let's us do things like only showing `Employees` who are in the same country as the `Deal` being created.

This setting looks and behaves as normal:
![image](https://github.com/Budibase/budibase/assets/9075550/f7dc2619-732c-4b63-9054-dfe9351384fa)

Let's say I only want to create relationships to people whose name starts with "A":
![image](https://github.com/Budibase/budibase/assets/9075550/2913ff2f-832a-4226-85c1-f253ad8b0d7c)

Here are the available rows:
![image](https://github.com/Budibase/budibase/assets/9075550/85f07bb5-c0bf-4f8d-bbbd-223d48ffc6f3)

One "limitation" with moving to use the `search` endpoint here rather than the "get all rows" endpoint is that we now have a cutoff for how many available rows we can show. I've set this at 100 rows. This means that if you have more than 100 available rows you'll need to configure some sort of filter (or search) to find the row you're looking for. With this change it's possible to let the user bind another form field to the filter of the relationship picker and enter their own dynamic search string, so this really isn't much of an issue. TLDR is that this does not support pagination so you'll need to use some sort of search. I think this is completely reasonable as who would actually sit and scroll through thousands of rows to find the one they want anyway.

I've also updated the validation editor setting to match the new style of the other settings which use buttons - full width and with some descriptive text to say how many validation rules have been enabled:
![image](https://github.com/Budibase/budibase/assets/9075550/2f1a7796-ddbf-462c-bba7-866c6a76619f)

Addresses: 
- https://linear.app/budibase/issue/BUDI-7197/add-filtering-to-relationship-picker
- https://linear.app/budibase/issue/BUDI-7194/add-filtering-to-relationship-picker
- https://github.com/Budibase/budibase/issues/7810