### PR TITLE
Fix XS icons

### DIFF
--- a/packages/bbui/src/Icon/Icon.svelte
+++ b/packages/bbui/src/Icon/Icon.svelte
@@ -85,4 +85,9 @@
     text-align: center;
     z-index: 1;
   }
+
+  .spectrum-Icon--sizeXS {
+    width: var(--spectrum-global-dimension-size-150);
+    height: var(--spectrum-global-dimension-size-150);
+  }
 </style>


### PR DESCRIPTION
## Description
XS spectrum icons seem to have been removed from the spectrum dependencies. This PR adds the style back in.