### PR TITLE
Update accounts.cloud.internal.spec.ts - Delete Account by ID

### DIFF
--- a/qa-core/src/account-api/tests/accounts/accounts.cloud.internal.spec.ts
+++ b/qa-core/src/account-api/tests/accounts/accounts.cloud.internal.spec.ts
@@ -15,9 +15,8 @@ describe("Account Internal Operations", () => {
 
   it("performs account deletion by ID", async () => {
     // Deleting by unknown id doesn't work
-    const accountId = generator.string()
-    const encodedAccountId = encodeURIComponent(accountId)
-    await config.api.accounts.delete(encodedAccountId, { status: 404 })
+    const accountId = generator.guid()
+    await config.api.accounts.delete(accountId, { status: 404 })
 
     // Create new account
     const [_, account] = await config.api.accounts.create({

--- a/qa-core/src/account-api/tests/accounts/accounts.cloud.internal.spec.ts
+++ b/qa-core/src/account-api/tests/accounts/accounts.cloud.internal.spec.ts
@@ -16,7 +16,8 @@ describe("Account Internal Operations", () => {
   it("performs account deletion by ID", async () => {
     // Deleting by unknown id doesn't work
     const accountId = generator.string()
-    await config.api.accounts.delete(accountId, { status: 404 })
+    const encodedAccountId = encodeURIComponent(accountId)
+    await config.api.accounts.delete(encodedAccountId, { status: 404 })
 
     // Create new account
     const [_, account] = await config.api.accounts.create({


### PR DESCRIPTION
## Description

We use a randomly generated string for the `accountId`.

It would seem that when an `accountId` includes a percentage sign (%) at the end, that issues arise (400 returned instead of 404 in this case).

I have included a `encodeURIComponent` for the `accountId` after it has been generated.

Example
When I manually set the `accountId` to `%accountId` the test passes.
When i manually set the `accountId` to `accountId%` the test fails

After including `encodeURIComponent` and passing `accountId%` the test passes

UPDATE
-using generator.guid to generate a unique string that won't affect the URL
