### PR TITLE
Pino logging tweaks

### DIFF
--- a/packages/backend-core/src/logging/pino/logger.ts
+++ b/packages/backend-core/src/logging/pino/logger.ts
@@ -35,9 +35,9 @@ if (!env.DISABLE_PINO_LOGGER) {
 
   const destinations: pino.DestinationStream[] = []
 
-  if (env.isDev()) {
-    destinations.push(pinoPretty({ singleLine: true }))
-  }
+  destinations.push(
+    env.isDev() ? pinoPretty({ singleLine: true }) : process.stdout
+  )
 
   if (env.SELF_HOSTED) {
     destinations.push(localFileDestination())

--- a/packages/backend-core/src/logging/pino/logger.ts
+++ b/packages/backend-core/src/logging/pino/logger.ts
@@ -19,8 +19,14 @@ if (!env.DISABLE_PINO_LOGGER) {
         return { level: label.toUpperCase() }
       },
       bindings: () => {
-        return {
-          service: env.SERVICE_NAME,
+        if (env.SELF_HOSTED) {
+          // "service" is being injected in datadog using the pod names,
+          // so we should leave it blank to allow the default behaviour if it's not running self-hosted
+          return {
+            service: env.SERVICE_NAME,
+          }
+        } else {
+          return {}
         }
       },
     },


### PR DESCRIPTION
## Description
1. Log service name only when running self-host. "service" is being injected by DataDog using the pod names, so we should leave it blank to allow the default behaviour if it's not running self-hosted.
2. Honoring min levels
3. Also setting up the default stdout when not running in dev