### PR TITLE
Change email support logic in help dropdown.

### DIFF
--- a/packages/builder/src/components/common/HelpMenu.svelte
+++ b/packages/builder/src/components/common/HelpMenu.svelte
@@ -4,7 +4,8 @@
   import { licensing } from "stores/portal"
   import { isEnabled, TENANT_FEATURE_FLAGS } from "helpers/featureFlags"
 
-  $: isPremiumUser = $licensing.license && !$licensing.isFreePlan
+  $: isBusinessAndAbove =
+    $licensing.isBusinessPlan || $licensing.isEnterprisePlan
 
   let show
   let hide
@@ -55,22 +56,22 @@
       <div class="divider" />
       {#if isEnabled(TENANT_FEATURE_FLAGS.LICENSING)}
         <a
-          href={isPremiumUser
+          href={isBusinessAndAbove
             ? "mailto:support@budibase.com"
             : "/builder/portal/account/usage"}
         >
-          <div class="premiumLinkContent" class:disabled={!isPremiumUser}>
+          <div class="premiumLinkContent" class:disabled={!isBusinessAndAbove}>
             <div class="icon">
               <FontAwesomeIcon name="fa-solid fa-envelope" />
             </div>
             <Body size="S">Email support</Body>
           </div>
-          {#if !isPremiumUser}
+          {#if !isBusinessAndAbove}
             <div class="premiumBadge">
               <div class="icon">
                 <FontAwesomeIcon name="fa-solid fa-lock" />
               </div>
-              <Body size="XS">Premium</Body>
+              <Body size="XS">Business</Body>
             </div>
           {/if}
         </a>


### PR DESCRIPTION
## Description
Changed email support logic in the help dropdown within the portal from premium to business and above.

Addresses: 
- https://linear.app/budibase/issue/BUDI-7320/amend-email-support-disabled-logic-in-help-dropdown

## Screenshots
<img width="287" alt="Screenshot 2023-07-21 at 14 03 54" src="https://github.com/Budibase/budibase/assets/126772285/a9af95ab-e5ac-4786-99c2-63370b9a2f9f">