### PR TITLE
Removed right from field group label select.

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -2342,10 +2342,6 @@
             "value": "left"
           },
           {
-            "label": "Right",
-            "value": "right"
-          },
-          {
             "label": "Above",
             "value": "above"
           }


### PR DESCRIPTION
## Description
Removed the right label from the field group component as it served no purpose and didn't change anything.

Addresses: 
- https://linear.app/budibase/issue/BUDI-7321/remove-right-from-field-group-labels-select