### PR TITLE
Honor schema on view search

### DIFF
--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -8,7 +8,6 @@ import { gridSocket } from "../../../websockets"
 import sdk from "../../../sdk"
 import * as exporters from "../view/exporters"
 import { apiFileReturn } from "../../../utilities/fileSystem"
-import _ from "lodash"
 
 function pickApi(tableId: any) {
   if (isExternalTable(tableId)) {
@@ -156,7 +155,7 @@ export async function searchView(ctx: Ctx<void, SearchResponse>) {
   }
 
   ctx.status = 200
-  let { rows } = await quotas.addQuery(
+  const { rows } = await quotas.addQuery(
     () =>
       sdk.rows.search({
         tableId: view.tableId,
@@ -164,16 +163,12 @@ export async function searchView(ctx: Ctx<void, SearchResponse>) {
         sort: view.sort?.field,
         sortOrder: view.sort?.order,
         sortType: view.sort?.type,
+        fields: view.columns,
       }),
     {
       datasourceId: view.tableId,
     }
   )
-
-  const { columns } = view
-  if (columns) {
-    rows = rows.map(r => _.pick(r, columns))
-  }
 
   ctx.body = { rows }
 }

--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -154,6 +154,16 @@ export async function searchView(ctx: Ctx<void, SearchResponse>) {
     ctx.throw(404, `View ${viewId} not found`)
   }
 
+  if (view.version !== 2) {
+    ctx.throw(400, `This method only supports viewsV2`)
+  }
+
+  const table = await sdk.tables.getTable(view?.tableId)
+
+  const viewFields =
+    view.columns?.length &&
+    Object.keys(sdk.views.enrichSchema(view, table.schema).schema)
+
   ctx.status = 200
   ctx.body = await quotas.addQuery(
     () =>
@@ -163,7 +173,7 @@ export async function searchView(ctx: Ctx<void, SearchResponse>) {
         sort: view.sort?.field,
         sortOrder: view.sort?.order,
         sortType: view.sort?.type,
-        fields: view.columns,
+        fields: viewFields,
       }),
     {
       datasourceId: view.tableId,

--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -161,8 +161,10 @@ export async function searchView(ctx: Ctx<void, SearchResponse>) {
   const table = await sdk.tables.getTable(view?.tableId)
 
   const viewFields =
-    view.columns?.length &&
-    Object.keys(sdk.views.enrichSchema(view, table.schema).schema)
+    (view.columns &&
+      Object.entries(view.columns).length &&
+      Object.keys(sdk.views.enrichSchema(view, table.schema).schema)) ||
+    undefined
 
   ctx.status = 200
   ctx.body = await quotas.addQuery(

--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -8,6 +8,7 @@ import { gridSocket } from "../../../websockets"
 import sdk from "../../../sdk"
 import * as exporters from "../view/exporters"
 import { apiFileReturn } from "../../../utilities/fileSystem"
+import _ from "lodash"
 
 function pickApi(tableId: any) {
   if (isExternalTable(tableId)) {
@@ -155,7 +156,7 @@ export async function searchView(ctx: Ctx<void, SearchResponse>) {
   }
 
   ctx.status = 200
-  ctx.body = await quotas.addQuery(
+  let { rows } = await quotas.addQuery(
     () =>
       sdk.rows.search({
         tableId: view.tableId,
@@ -168,6 +169,13 @@ export async function searchView(ctx: Ctx<void, SearchResponse>) {
       datasourceId: view.tableId,
     }
   )
+
+  const { columns } = view
+  if (columns) {
+    rows = rows.map(r => _.pick(r, columns))
+  }
+
+  ctx.body = { rows }
 }
 
 export async function validate(ctx: Ctx) {

--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -155,7 +155,7 @@ export async function searchView(ctx: Ctx<void, SearchResponse>) {
   }
 
   ctx.status = 200
-  const { rows } = await quotas.addQuery(
+  ctx.body = await quotas.addQuery(
     () =>
       sdk.rows.search({
         tableId: view.tableId,
@@ -169,8 +169,6 @@ export async function searchView(ctx: Ctx<void, SearchResponse>) {
       datasourceId: view.tableId,
     }
   )
-
-  ctx.body = { rows }
 }
 
 export async function validate(ctx: Ctx) {

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -841,5 +841,29 @@ describe("/rows", () => {
         rows: expected.map(name => expect.objectContaining({ name })),
       })
     })
+
+    it("when schema is defined, no other columns are returnd", async () => {
+      const table = await config.createTable(userTable())
+      const rows = []
+      for (let i = 0; i < 10; i++) {
+        rows.push(
+          await config.createRow({
+            tableId: table._id,
+            name: generator.name(),
+            age: generator.age(),
+          })
+        )
+      }
+
+      const createViewResponse = await config.api.viewV2.create({
+        columns: ["name"],
+      })
+      const response = await config.api.viewV2.search(createViewResponse.id)
+
+      expect(response.body.rows).toHaveLength(10)
+      expect(response.body.rows).toEqual(
+        expect.arrayContaining(rows.map(r => ({ name: r.name })))
+      )
+    })
   })
 })

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -856,7 +856,7 @@ describe("/rows", () => {
       }
 
       const createViewResponse = await config.api.viewV2.create({
-        columns: ["name"],
+        columns: { name: { visible: true } },
       })
       const response = await config.api.viewV2.search(createViewResponse.id)
 

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -842,7 +842,7 @@ describe("/rows", () => {
       })
     })
 
-    it("when schema is defined, no other columns are returnd", async () => {
+    it("when schema is defined, no other columns are returned", async () => {
       const table = await config.createTable(userTable())
       const rows = []
       for (let i = 0; i < 10; i++) {
@@ -864,6 +864,15 @@ describe("/rows", () => {
       expect(response.body.rows).toEqual(
         expect.arrayContaining(rows.map(r => ({ name: r.name })))
       )
+    })
+
+    it("views without data can be returned", async () => {
+      const table = await config.createTable(userTable())
+
+      const createViewResponse = await config.api.viewV2.create()
+      const response = await config.api.viewV2.search(createViewResponse.id)
+
+      expect(response.body.rows).toHaveLength(0)
     })
   })
 })

--- a/packages/server/src/sdk/app/rows/search.ts
+++ b/packages/server/src/sdk/app/rows/search.ts
@@ -34,13 +34,15 @@ function pickApi(tableId: any) {
 
 export async function search(options: SearchParams): Promise<{
   rows: any[]
+  hasNextPage?: boolean
+  bookmark?: number | null
 }> {
-  let { rows } = await pickApi(options.tableId).search(options)
+  const result = await pickApi(options.tableId).search(options)
 
   if (options.fields) {
-    rows = rows.map((r: any) => _.pick(r, options.fields!))
+    result.rows = result.rows.map((r: any) => _.pick(r, options.fields!))
   }
-  return { rows }
+  return result
 }
 
 export interface ExportRowsParams {

--- a/packages/server/src/sdk/app/rows/search.ts
+++ b/packages/server/src/sdk/app/rows/search.ts
@@ -3,6 +3,7 @@ import { isExternalTable } from "../../../integrations/utils"
 import * as internal from "./search/internal"
 import * as external from "./search/external"
 import { Format } from "../../../api/controllers/view/exporters"
+import _ from "lodash"
 
 export interface SearchParams {
   tableId: string
@@ -15,6 +16,7 @@ export interface SearchParams {
   sortType?: SortType
   version?: string
   disableEscaping?: boolean
+  fields?: string[]
 }
 
 export interface ViewParams {
@@ -33,7 +35,12 @@ function pickApi(tableId: any) {
 export async function search(options: SearchParams): Promise<{
   rows: any[]
 }> {
-  return pickApi(options.tableId).search(options)
+  let { rows } = await pickApi(options.tableId).search(options)
+
+  if (options.fields) {
+    rows = rows.map((r: any) => _.pick(r, options.fields!))
+  }
+  return { rows }
 }
 
 export interface ExportRowsParams {


### PR DESCRIPTION
## Description
Use schema to return view data, not returning any other data. This is required to ensure we don't expose unexpected data.

In the future we could change this to not filter on memory, using views instead