### PR TITLE
Stop data query binding drawer value from being cleared.

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/ExecuteQuery.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/ExecuteQuery.svelte
@@ -73,9 +73,12 @@
       {#if query?.parameters?.length > 0}
         <div class="params">
           <BindingBuilder
-            bind:customParams={parameters.queryParams}
+            customParams={parameters.queryParams}
             queryBindings={query.parameters}
             bind:bindings
+            on:change={v => {
+              parameters.queryParams = { ...v.detail }
+            }}
           />
           <IntegrationQueryEditor
             height={200}

--- a/packages/builder/src/components/design/settings/controls/DataSourceSelect.svelte
+++ b/packages/builder/src/components/design/settings/controls/DataSourceSelect.svelte
@@ -143,13 +143,12 @@
   }
 
   const openQueryParamsDrawer = () => {
-    tmpQueryParams = value.queryParams
+    tmpQueryParams = { ...value.queryParams }
     drawer.show()
   }
 
   const getQueryValue = queries => {
-    value = queries.find(q => q._id === value._id) || value
-    return value
+    return queries.find(q => q._id === value._id) || value
   }
 
   const saveQueryParams = () => {
@@ -176,7 +175,10 @@
         <Layout noPadding gap="XS">
           {#if getQueryParams(value).length > 0}
             <BindingBuilder
-              bind:customParams={tmpQueryParams}
+              customParams={tmpQueryParams}
+              on:change={v => {
+                tmpQueryParams = { ...v.detail }
+              }}
               queryBindings={getQueryParams(value)}
               bind:bindings
             />

--- a/packages/builder/src/components/integration/QueryBindingBuilder.svelte
+++ b/packages/builder/src/components/integration/QueryBindingBuilder.svelte
@@ -5,6 +5,9 @@
     runtimeToReadableBinding,
   } from "builderStore/dataBinding"
   import DrawerBindableInput from "components/common/bindings/DrawerBindableInput.svelte"
+  import { createEventDispatcher } from "svelte"
+
+  const dispatch = createEventDispatcher()
 
   export let bindable = true
   export let queryBindings = []
@@ -20,7 +23,10 @@
   // The readable binding in the UI gets converted to a UUID value that the client understands
   // for parsing, then converted back so we can display it the readable form in the UI
   function onBindingChange(param, valueToParse) {
-    customParams[param] = readableToRuntimeBinding(bindings, valueToParse)
+    dispatch("change", {
+      ...customParams,
+      [param]: readableToRuntimeBinding(bindings, valueToParse),
+    })
   }
 </script>
 


### PR DESCRIPTION
## Description

A function used in the `DataSourceSelect` was inadvertently clearing the query binding values in the UI.

- The value remains populated on load and when the `cog` icon is clicked next to the `Data` setting.
- The behaviour in the `Execute Query` button action was updated to accommodate the fix

Addresses: 
- BUDI-7090

## Screenshots

A `DataProvider` component configured with a Query data source. Click on the cog to see the affected drawer.
![Screenshot 2023-07-24 at 17 51 29](https://github.com/Budibase/budibase/assets/5913006/6aa09cdd-94df-42db-94df-40204484b800)
