### PR TITLE
Fix nullish check bug causing options fields to break on mobile sometimes

### DIFF
--- a/packages/bbui/src/Actions/position_dropdown.js
+++ b/packages/bbui/src/Actions/position_dropdown.js
@@ -64,7 +64,7 @@ export default function positionDropdown(element, opts) {
 
     // Apply styles
     Object.entries(styles).forEach(([style, value]) => {
-      if (value) {
+      if (value != null) {
         element.style[style] = `${value.toFixed(0)}px`
       } else {
         element.style[style] = null


### PR DESCRIPTION
## Description
Fixes a bad nullish check in the dropdown positioning logic which meant that there were certain situations (most often on mobile) where dropdowns did not appear.

Addresses: 
- #10654 


