### PR TITLE
Hide the 'Define Relationships' button when an integration does not support relationships

### DIFF
--- a/packages/builder/src/components/backend/DataTable/DataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/DataTable.svelte
@@ -28,15 +28,15 @@
   $: isInternal = $tables.selected?.type !== "external"
 
   $: datasource = $datasources.list.find(datasource => {
-    return datasource._id === $tables.selected.sourceId
+    return datasource._id === $tables.selected?.sourceId
   })
+
+  $: relationshipsEnabled = relationshipSupport(datasource)
 
   const relationshipSupport = datasource => {
     const integration = $integrations[datasource?.source]
     return !isInternal && integration?.relationships !== false
   }
-
-  $: relationshipsEnabled = relationshipSupport(datasource)
 
   const handleGridTableUpdate = async e => {
     tables.replaceTable(id, e.detail)

--- a/packages/builder/src/components/backend/DataTable/DataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/DataTable.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { datasources, tables } from "stores/backend"
+  import { datasources, tables, integrations } from "stores/backend"
   import EditRolesButton from "./buttons/EditRolesButton.svelte"
   import { TableNames } from "constants"
   import { Grid } from "@budibase/frontend-core"
@@ -26,6 +26,17 @@
   $: id = $tables.selected?._id
   $: isUsersTable = id === TableNames.USERS
   $: isInternal = $tables.selected?.type !== "external"
+
+  $: datasource = $datasources.list.find(datasource => {
+    return datasource._id === $tables.selected.sourceId
+  })
+
+  const relationshipSupport = datasource => {
+    const integration = $integrations[datasource?.source]
+    return !isInternal && integration?.relationships !== false
+  }
+
+  $: relationshipsEnabled = relationshipSupport(datasource)
 
   const handleGridTableUpdate = async e => {
     tables.replaceTable(id, e.detail)
@@ -58,7 +69,7 @@
         <GridCreateViewButton />
       {/if}
       <GridManageAccessButton />
-      {#if !isInternal}
+      {#if relationshipsEnabled}
         <GridRelationshipButton />
       {/if}
       {#if isUsersTable}


### PR DESCRIPTION
## Description

The `Define Relationships` button in data tables will now be hidden when relationships are unsupported by the integration type.

This is a general modification but currently only applies to `Google Sheets` datasources.  

Addresses: 
- https://github.com/Budibase/budibase/issues/10970
