### PR TITLE
Ensure we don't allow views to update other fields

### DIFF
--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -43,34 +43,7 @@ export async function handleRequest(
 }
 
 export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
-  const tableId = ctx.params.tableId
-  let { _id: id, _viewId, ...rowData } = ctx.request.body
-
-  const table = await sdk.tables.getTable(tableId)
-  if (_viewId) {
-    rowData = await sdk.rows.utils.trimViewFields(_viewId, table, rowData)
-  }
-
-  const validateResult = await sdk.rows.utils.validate({
-    row: rowData,
-    tableId,
-  })
-  if (!validateResult.valid) {
-    throw { validation: validateResult.errors }
-  }
-  const response = await handleRequest(Operation.UPDATE, tableId, {
-    id: breakRowIdField(id),
-    row: rowData,
-  })
-
-  const row = await sdk.rows.external.getRow(tableId, id, {
-    relationships: true,
-  })
-  return {
-    ...response,
-    row,
-    table,
-  }
+  return sdk.rows.external.patch(ctx.params.tableId, ctx.request.body)
 }
 
 export async function save(ctx: UserCtx) {

--- a/packages/server/src/api/controllers/row/internal.ts
+++ b/packages/server/src/api/controllers/row/internal.ts
@@ -25,7 +25,9 @@ import {
 } from "@budibase/types"
 import sdk from "../../../sdk"
 
-export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
+export async function patch(
+  ctx: UserCtx<PatchRowRequest, PatchRowResponse>
+): Promise<Row> {
   let { _viewId, ...data } = ctx.request.body
   const tableId = data.tableId
   const isUserTable = tableId === InternalTables.USER_METADATA

--- a/packages/server/src/api/controllers/row/internal.ts
+++ b/packages/server/src/api/controllers/row/internal.ts
@@ -33,7 +33,10 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   const dbTable = await sdk.tables.getTable(tableId)
 
   if (_viewId) {
-    data = await sdk.rows.utils.trimViewFields(_viewId, dbTable, data)
+    data = {
+      ...(await sdk.rows.utils.trimViewFields(_viewId, dbTable, data)),
+      _id: data._id,
+    }
   }
 
   try {

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -449,6 +449,8 @@ describe("/rows", () => {
 
         const [row] = searchResponse.body.rows as Row[]
 
+        expect(row._viewId).toBeDefined()
+
         const res = await config.api.row.patch(table._id!, {
           ...row,
           description: "Updated Description",
@@ -462,6 +464,7 @@ describe("/rows", () => {
           _rev: expect.anything(),
           createdAt: expect.anything(),
           updatedAt: expect.anything(),
+          _viewId: undefined,
         })
       })
 
@@ -474,6 +477,7 @@ describe("/rows", () => {
 
         const [row] = searchResponse.body.rows as Row[]
 
+        expect(row._viewId).toBeDefined()
         const res = await config.api.row.patch(table._id!, {
           ...row,
           name: "Updated Name",
@@ -515,6 +519,7 @@ describe("/rows", () => {
           _rev: expect.anything(),
           createdAt: expect.anything(),
           updatedAt: expect.anything(),
+          _viewId: undefined,
         })
         expect(savedRow.body.description).not.toEqual("Updated Description")
       })

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -503,8 +503,8 @@ describe("/rows", () => {
 
         const res = await config.api.row.patch(table._id!, {
           ...row,
-          name: undefined,
-          description: undefined,
+          name: null,
+          description: null,
         } as PatchRowRequest)
 
         const savedRow = await loadRow(res.body._id, table._id!)

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -440,6 +440,58 @@ describe("/rows", () => {
       await assertRowUsage(rowUsage)
       await assertQueryUsage(queryUsage)
     })
+
+    describe("view row", () => {
+      it("should update only the fields that are supplied", async () => {
+        const existing = await config.createRow()
+        const view = await config.api.viewV2.create()
+        const searchResponse = await config.api.viewV2.search(view.id)
+
+        const [row] = searchResponse.body.rows as Row[]
+
+        const res = await config.api.row.patch(table._id!, {
+          ...row,
+          description: "Updated Description",
+        } as PatchRowRequest)
+
+        const savedRow = await loadRow(res.body._id, table._id!)
+
+        expect(savedRow.body).toEqual({
+          ...existing,
+          description: "Updated Description",
+          _rev: expect.anything(),
+          createdAt: expect.anything(),
+          updatedAt: expect.anything(),
+        })
+      })
+
+      it("should not edit fields that don't belong to the view", async () => {
+        const existing = await config.createRow()
+        const view = await config.api.viewV2.create({
+          columns: { name: { visible: true } },
+        })
+        const searchResponse = await config.api.viewV2.search(view.id)
+
+        const [row] = searchResponse.body.rows as Row[]
+
+        const res = await config.api.row.patch(table._id!, {
+          ...row,
+          name: "Updated Name",
+          description: "Updated Description",
+        } as PatchRowRequest)
+
+        const savedRow = await loadRow(res.body._id, table._id!)
+
+        expect(savedRow.body).toEqual({
+          ...existing,
+          name: "Updated Name",
+          _rev: expect.anything(),
+          createdAt: expect.anything(),
+          updatedAt: expect.anything(),
+        })
+        expect(savedRow.body.description).not.toEqual("Updated Description")
+      })
+    })
   })
 
   describe("destroy", () => {

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -491,6 +491,33 @@ describe("/rows", () => {
         })
         expect(savedRow.body.description).not.toEqual("Updated Description")
       })
+
+      it("should allow remove fields that belong to the view", async () => {
+        const existing = await config.createRow()
+        const view = await config.api.viewV2.create({
+          columns: { name: { visible: true } },
+        })
+        const searchResponse = await config.api.viewV2.search(view.id)
+
+        const [row] = searchResponse.body.rows as Row[]
+
+        const res = await config.api.row.patch(table._id!, {
+          ...row,
+          name: undefined,
+          description: undefined,
+        } as PatchRowRequest)
+
+        const savedRow = await loadRow(res.body._id, table._id!)
+
+        expect(savedRow.body).toEqual({
+          ...existing,
+          name: undefined,
+          _rev: expect.anything(),
+          createdAt: expect.anything(),
+          updatedAt: expect.anything(),
+        })
+        expect(savedRow.body.description).not.toEqual("Updated Description")
+      })
     })
   })
 

--- a/packages/server/src/sdk/app/rows/external.ts
+++ b/packages/server/src/sdk/app/rows/external.ts
@@ -1,6 +1,34 @@
 import { IncludeRelationship, Operation, Row } from "@budibase/types"
+import sdk from "../../../sdk"
 import { handleRequest } from "../../../api/controllers/row/external"
 import { breakRowIdField } from "../../../integrations/utils"
+
+export async function patch(tableId: string, data: Row): Promise<Row> {
+  let { _viewId, _id: id, ...rowData } = data
+
+  const table = await sdk.tables.getTable(tableId)
+  if (_viewId) {
+    rowData = await sdk.rows.utils.trimViewFields(_viewId, table, rowData)
+  }
+
+  const validateResult = await sdk.rows.utils.validate({
+    row: rowData,
+    tableId,
+  })
+  if (!validateResult.valid) {
+    throw { validation: validateResult.errors }
+  }
+  const response = await handleRequest(Operation.UPDATE, tableId, {
+    id: breakRowIdField(id!),
+    row: rowData,
+  })
+  const row = await getRow(tableId, id!, { relationships: true })
+  return {
+    ...response,
+    row,
+    table,
+  }
+}
 
 export async function getRow(
   tableId: string,

--- a/packages/server/src/sdk/app/rows/tests/external.spec.ts
+++ b/packages/server/src/sdk/app/rows/tests/external.spec.ts
@@ -1,0 +1,93 @@
+import { generator } from "@budibase/backend-core/tests"
+import { FieldType, Operation, Row, Table } from "@budibase/types"
+import { patch } from "../external"
+
+jest.mock("../../../../sdk", () => ({
+  tables: { getTable: jest.fn() },
+  rows: { utils: { trimViewFields: jest.fn(), validate: jest.fn() } },
+}))
+jest.mock("../../../../api/controllers/row/external")
+import sdk from "../../../../sdk"
+import { handleRequest } from "../../../../api/controllers/row/external"
+
+const mockGetTable = sdk.tables.getTable as jest.MockedFunction<
+  typeof sdk.tables.getTable
+>
+const mockTrimViewFields = sdk.rows.utils.trimViewFields as jest.MockedFunction<
+  typeof sdk.rows.utils.trimViewFields
+>
+const mockRowsValidate = sdk.rows.utils.validate as jest.MockedFunction<
+  typeof sdk.rows.utils.validate
+>
+const mockHandleRequest = handleRequest as jest.MockedFunction<
+  typeof handleRequest
+>
+
+describe("external", () => {
+  const table: Table = {
+    name: generator.word(),
+    type: "table",
+    schema: {
+      name: {
+        name: "name",
+        type: FieldType.STRING,
+      },
+      age: {
+        name: "age",
+        type: FieldType.NUMBER,
+      },
+      address: {
+        name: "address",
+        type: FieldType.STRING,
+      },
+    },
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe("patch", () => {
+    beforeAll(() => {
+      mockGetTable.mockResolvedValue(table)
+    })
+
+    it("patching a row from a table will submit the requested fields", async () => {
+      const tableId = generator.guid()
+      const patchData: Row = {
+        _id: generator.guid(),
+        name: generator.name(),
+        age: generator.age(),
+        address: generator.address(),
+      }
+
+      const trimmedRow: Row = {
+        name: patchData.name,
+        age: patchData.age,
+      }
+      mockTrimViewFields.mockResolvedValue(trimmedRow)
+      mockRowsValidate.mockResolvedValue({ valid: true, errors: [] })
+
+      await patch(tableId, patchData)
+
+      expect(mockHandleRequest).toHaveBeenCalledTimes(2)
+      expect(mockHandleRequest).toHaveBeenCalledWith(
+        Operation.UPDATE,
+        tableId,
+        {
+          id: [patchData._id],
+          row: {
+            name: patchData.name,
+            age: patchData.age,
+            address: patchData.address,
+          },
+        }
+      )
+      expect(mockHandleRequest).toHaveBeenCalledWith(
+        Operation.READ,
+        tableId,
+        expect.anything()
+      )
+    })
+  })
+})

--- a/packages/server/src/sdk/app/rows/tests/utils.spec.ts
+++ b/packages/server/src/sdk/app/rows/tests/utils.spec.ts
@@ -1,0 +1,61 @@
+import { generator } from "@budibase/backend-core/tests"
+import { FieldType, Table, ViewV2 } from "@budibase/types"
+jest.mock("../../../../sdk", () => ({
+  views: { get: jest.fn() },
+}))
+
+import sdk from "../../../../sdk"
+import { trimViewFields } from "../utils"
+
+const mockGetView = sdk.views.get as jest.MockedFunction<typeof sdk.views.get>
+
+describe("utils", () => {
+  const table: Table = {
+    name: generator.word(),
+    type: "table",
+    schema: {
+      name: {
+        name: "name",
+        type: FieldType.STRING,
+      },
+      age: {
+        name: "age",
+        type: FieldType.NUMBER,
+      },
+      address: {
+        name: "address",
+        type: FieldType.STRING,
+      },
+    },
+  }
+  const view: ViewV2 = {
+    version: 2,
+    id: generator.guid(),
+    name: generator.guid(),
+    tableId: generator.guid(),
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe("trimViewFields", () => {
+    beforeEach(() => {
+      mockGetView.mockResolvedValue(view)
+    })
+
+    it("when no columns are defined, same data is returned", async () => {
+      const viewId = generator.guid()
+      const data = {
+        _id: generator.guid(),
+        name: generator.name(),
+        age: generator.age(),
+        address: generator.address(),
+      }
+
+      const result = await trimViewFields(viewId, table, data)
+
+      expect(result).toBe(data)
+    })
+  })
+})

--- a/packages/server/src/sdk/app/rows/utils.ts
+++ b/packages/server/src/sdk/app/rows/utils.ts
@@ -2,12 +2,10 @@ import cloneDeep from "lodash/cloneDeep"
 import pick from "lodash/pick"
 import validateJs from "validate.js"
 import { FieldType, Row, Table, TableSchema } from "@budibase/types"
-import { db } from "@budibase/backend-core"
 import { FieldTypes } from "../../../constants"
 import { makeExternalQuery } from "../../../integrations/base/query"
 import { Format } from "../../../api/controllers/view/exporters"
 import sdk from "../.."
-import { isExternalTable } from "../../../integrations/utils"
 
 export async function getDatasourceAndQuery(json: any) {
   const datasourceId = json.endpoint.datasourceId
@@ -149,10 +147,6 @@ export async function trimViewFields<T>(
     return data
   }
 
-  const rowDataFields = isExternalTable(table._id!)
-    ? db.CONSTANT_EXTERNAL_ROW_COLS
-    : db.CONSTANT_INTERNAL_ROW_COLS
-
   const { schema } = sdk.views.enrichSchema(view!, table.schema)
-  return pick(data, [...Object.keys(schema), ...rowDataFields]) as T
+  return pick(data, Object.keys(schema)) as T
 }

--- a/packages/server/src/sdk/app/rows/utils.ts
+++ b/packages/server/src/sdk/app/rows/utils.ts
@@ -1,5 +1,4 @@
 import cloneDeep from "lodash/cloneDeep"
-import pick from "lodash/pick"
 import validateJs from "validate.js"
 import { FieldType, Row, Table, TableSchema } from "@budibase/types"
 import { FieldTypes } from "../../../constants"
@@ -137,7 +136,7 @@ export async function validate({
   return { valid: Object.keys(errors).length === 0, errors }
 }
 
-export async function trimViewFields<T>(
+export async function trimViewFields<T extends Row>(
   viewId: string,
   table: Table,
   data: T
@@ -148,5 +147,10 @@ export async function trimViewFields<T>(
   }
 
   const { schema } = sdk.views.enrichSchema(view!, table.schema)
-  return pick(data, Object.keys(schema)) as T
+  const result: Record<string, any> = {}
+  for (const key of Object.keys(schema)) {
+    result[key] = data[key] !== null ? data[key] : undefined
+  }
+
+  return result as T
 }

--- a/packages/server/src/sdk/app/rows/utils.ts
+++ b/packages/server/src/sdk/app/rows/utils.ts
@@ -1,10 +1,13 @@
 import cloneDeep from "lodash/cloneDeep"
+import pick from "lodash/pick"
 import validateJs from "validate.js"
 import { FieldType, Row, Table, TableSchema } from "@budibase/types"
+import { db } from "@budibase/backend-core"
 import { FieldTypes } from "../../../constants"
 import { makeExternalQuery } from "../../../integrations/base/query"
 import { Format } from "../../../api/controllers/view/exporters"
 import sdk from "../.."
+import { isExternalTable } from "../../../integrations/utils"
 
 export async function getDatasourceAndQuery(json: any) {
   const datasourceId = json.endpoint.datasourceId
@@ -134,4 +137,22 @@ export async function validate({
     if (res) errors[fieldName] = res
   }
   return { valid: Object.keys(errors).length === 0, errors }
+}
+
+export async function trimViewFields<T>(
+  viewId: string,
+  table: Table,
+  data: T
+): Promise<T> {
+  const view = await sdk.views.get(viewId)
+  if (!view?.columns || !Object.keys(view.columns).length) {
+    return data
+  }
+
+  const rowDataFields = isExternalTable(table._id!)
+    ? db.CONSTANT_EXTERNAL_ROW_COLS
+    : db.CONSTANT_INTERNAL_ROW_COLS
+
+  const { schema } = sdk.views.enrichSchema(view!, table.schema)
+  return pick(data, [...Object.keys(schema), ...rowDataFields]) as T
 }

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -2,7 +2,7 @@ import * as linkRows from "../../db/linkedRows"
 import { FieldTypes, AutoFieldSubTypes } from "../../constants"
 import { processFormulas, fixAutoColumnSubType } from "./utils"
 import { ObjectStoreBuckets } from "../../constants"
-import { context, db as dbCore, objectStore } from "@budibase/backend-core"
+import { context, db, db as dbCore, objectStore } from "@budibase/backend-core"
 import { InternalTables } from "../../db/utils"
 import { TYPE_TRANSFORM_MAP } from "./map"
 import { Row, RowAttachment, Table, ContextUser } from "@budibase/types"
@@ -138,7 +138,10 @@ export function inputProcessing(
 ) {
   let clonedRow = cloneDeep(row)
 
-  const dontCleanseKeys = ["type", "_id", "_rev", "tableId"]
+  const dontCleanseKeys: string[] = [
+    ...db.CONSTANT_EXTERNAL_ROW_COLS,
+    ...db.CONSTANT_INTERNAL_ROW_COLS,
+  ]
   for (let [key, value] of Object.entries(clonedRow)) {
     const field = table.schema[key]
     // cleanse fields that aren't in the schema


### PR DESCRIPTION
## Description
Implement view2.0 row patch, not allowing editing fields not belonging to the view.
Ideally, the same approach of moving the patch should be done for the internal db, but given its dependencies with other controllers it requires a much bigger refactor. Because of this controller "unit tests" will cover the use cases