### PR TITLE
pin node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,5 +108,8 @@
     "@budibase/string-templates": "0.0.0",
     "@budibase/types": "0.0.0"
   },
+  "engines": {
+    "node": ">=14.0.0 <15.0.0"
+  },
   "dependencies": {}
 }


### PR DESCRIPTION
## Description
Actually throw if you try to install budibase on a non-supported version of node. Tested locally with a higher node version just to make sure:
![Screenshot 2023-07-26 at 16 14 33](https://github.com/Budibase/budibase/assets/11256663/9190042f-2b0e-44cd-b1d8-8dbff313b512)



Addresses: 
- https://linear.app/budibase/issue/BUDI-7334/add-check-for-node-version-in-development
