### PR TITLE
Disable component validation for old app imports

### DIFF
--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -331,6 +331,11 @@ async function performAppCreate(ctx: UserCtx) {
         }
       })
 
+      // Keep existing validation setting
+      if (!existing.features?.componentValidation) {
+        newApplication.features!.componentValidation = false
+      }
+
       // Migrate navigation settings and screens if required
       if (existing) {
         const navigation = await migrateAppNavigation()


### PR DESCRIPTION
## Description
Disable component validation for imports of apps which did not have it enabled.

Current behaviour (validation enabled or not):
Old app => new app
false => true
true => true

New behaviour with this PR (validation enabled or not):
Old app => new app
false => false
true => true

Addresses: 
- https://github.com/Budibase/budibase/issues/11381


