### PR TITLE
add startupProbe;Probes into values.yaml

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -201,25 +201,24 @@ spec:
 
         image: budibase/apps:{{ .Values.globals.appVersion | default .Chart.AppVersion }}
         imagePullPolicy: Always
+        {{- if .Values.services.apps.startupProbe }}
+        {{- with .Values.services.apps.startupProbe }}
+        startupProbe:
+            {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.services.apps.livenessProbe }}
+        {{- with .Values.services.apps.livenessProbe }}
         livenessProbe:
-          httpGet:
-            path: /health
-            port: {{ .Values.services.apps.port }}
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          successThreshold: 1
-          failureThreshold: 3
-          timeoutSeconds: 3
+            {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.services.apps.readinessProbe }}
+        {{- with .Values.services.apps.readinessProbe }}
         readinessProbe:
-          httpGet:
-            path: /health
-            port: {{ .Values.services.apps.port }}
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          successThreshold: 1
-          failureThreshold: 3
-          timeoutSeconds: 3
-
+            {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
         name: bbapps
         ports:
         - containerPort: {{ .Values.services.apps.port }}

--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -40,24 +40,24 @@ spec:
       - image: budibase/proxy:{{ .Values.globals.appVersion | default .Chart.AppVersion }}
         imagePullPolicy: Always
         name: proxy-service
+        {{- if .Values.services.proxy.startupProbe }}
+        {{- with .Values.services.proxy.startupProbe }}
+        startupProbe:
+            {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.services.proxy.livenessProbe }}
+        {{- with .Values.services.proxy.livenessProbe }}
         livenessProbe:
-          httpGet:
-            path: /health
-            port: {{ .Values.services.proxy.port }}
-          initialDelaySeconds: 0
-          periodSeconds: 5
-          successThreshold: 1
-          failureThreshold: 2
-          timeoutSeconds: 3
+            {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.services.proxy.readinessProbe }}
+        {{- with .Values.services.proxy.readinessProbe }}
         readinessProbe:
-          httpGet:
-            path: /health
-            port: {{ .Values.services.proxy.port }}
-          initialDelaySeconds: 0
-          periodSeconds: 5
-          successThreshold: 1
-          failureThreshold: 2
-          timeoutSeconds: 3
+            {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
         ports:
         - containerPort: {{ .Values.services.proxy.port }}
         env:

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -190,24 +190,24 @@ spec:
         {{ end }}
         image: budibase/worker:{{ .Values.globals.appVersion | default .Chart.AppVersion }}
         imagePullPolicy: Always
+        {{- if .Values.services.worker.startupProbe }}
+        {{- with .Values.services.worker.startupProbe }}
+        startupProbe:
+            {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.services.worker.livenessProbe }}
+        {{- with .Values.services.worker.livenessProbe }}
         livenessProbe:
-          httpGet:
-            path: /health
-            port: {{ .Values.services.worker.port }}
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          successThreshold: 1
-          failureThreshold: 3
-          timeoutSeconds: 3
+            {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.services.worker.readinessProbe }}
+        {{- with .Values.services.worker.readinessProbe }}
         readinessProbe:
-          httpGet:
-            path: /health
-            port: {{ .Values.services.worker.port }}
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          successThreshold: 1
-          failureThreshold: 3
-          timeoutSeconds: 3
+            {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
         name: bbworker
         ports:
         - containerPort: {{ .Values.services.worker.port }}

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -119,15 +119,37 @@ services:
     port: 10000
     replicaCount: 1
     upstreams:
-      apps: 'http://app-service.{{ .Release.Namespace }}.svc.{{ .Values.services.dns }}:{{ .Values.services.apps.port }}'
-      worker: 'http://worker-service.{{ .Release.Namespace }}.svc.{{ .Values.services.dns }}:{{ .Values.services.worker.port }}'
-      minio: 'http://minio-service.{{ .Release.Namespace }}.svc.{{ .Values.services.dns }}:{{ .Values.services.objectStore.port }}'
-      couchdb: 'http://{{ .Release.Name }}-svc-couchdb:{{ .Values.services.couchdb.port }}'
+      apps: "http://app-service.{{ .Release.Namespace }}.svc.{{ .Values.services.dns }}:{{ .Values.services.apps.port }}"
+      worker: "http://worker-service.{{ .Release.Namespace }}.svc.{{ .Values.services.dns }}:{{ .Values.services.worker.port }}"
+      minio: "http://minio-service.{{ .Release.Namespace }}.svc.{{ .Values.services.dns }}:{{ .Values.services.objectStore.port }}"
+      couchdb: "http://{{ .Release.Name }}-svc-couchdb:{{ .Values.services.couchdb.port }}"
     resources: {}
-#    annotations:
-#      co.elastic.logs/module: nginx
-#      co.elastic.logs/fileset.stdout: access
-#      co.elastic.logs/fileset.stderr: error
+    startupProbe:
+      httpGet:
+        path: /health
+        port: 10000
+        scheme: HTTP
+      failureThreshold: 30
+      periodSeconds: 3
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: 10000
+        scheme: HTTP
+      enabled: true
+      periodSeconds: 3
+      failureThreshold: 1
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: 10000
+        scheme: HTTP
+      failureThreshold: 3
+      periodSeconds: 5
+  #    annotations:
+  #      co.elastic.logs/module: nginx
+  #      co.elastic.logs/fileset.stdout: access
+  #      co.elastic.logs/fileset.stderr: error
 
   apps:
     port: 4002
@@ -135,23 +157,67 @@ services:
     logLevel: info
     httpLogging: 1
     resources: {}
-#    nodeDebug: "" # set the value of NODE_DEBUG
-#    annotations:
-#      co.elastic.logs/multiline.type: pattern
-#      co.elastic.logs/multiline.pattern: '^[[:space:]]'
-#      co.elastic.logs/multiline.negate: false
-#      co.elastic.logs/multiline.match: after
+    startupProbe:
+      httpGet:
+        path: /health
+        port: 4002
+        scheme: HTTP
+      failureThreshold: 30
+      periodSeconds: 3
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: 4002
+        scheme: HTTP
+      enabled: true
+      periodSeconds: 3
+      failureThreshold: 1
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: 4002
+        scheme: HTTP
+      failureThreshold: 3
+      periodSeconds: 5
+  #    nodeDebug: "" # set the value of NODE_DEBUG
+  #    annotations:
+  #      co.elastic.logs/multiline.type: pattern
+  #      co.elastic.logs/multiline.pattern: '^[[:space:]]'
+  #      co.elastic.logs/multiline.negate: false
+  #      co.elastic.logs/multiline.match: after
   worker:
     port: 4003
     replicaCount: 1
     logLevel: info
     httpLogging: 1
     resources: {}
-#    annotations:
-#      co.elastic.logs/multiline.type: pattern
-#      co.elastic.logs/multiline.pattern: '^[[:space:]]'
-#      co.elastic.logs/multiline.negate: false
-#      co.elastic.logs/multiline.match: after
+    startupProbe:
+      httpGet:
+        path: /health
+        port: 4003
+        scheme: HTTP
+      failureThreshold: 30
+      periodSeconds: 3
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: 4003
+        scheme: HTTP
+      enabled: true
+      periodSeconds: 3
+      failureThreshold: 1
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: 4003
+        scheme: HTTP
+      failureThreshold: 3
+      periodSeconds: 5
+  #    annotations:
+  #      co.elastic.logs/multiline.type: pattern
+  #      co.elastic.logs/multiline.pattern: '^[[:space:]]'
+  #      co.elastic.logs/multiline.negate: false
+  #      co.elastic.logs/multiline.match: after
 
   couchdb:
     enabled: true


### PR DESCRIPTION
## Description
PR to update the readiness/liveness probes we have in our helm chart by adding a `startupProbe` so that we check the container has fully started before we begin the liveness checks.
- Replaced the existing liveness/readiness lines for app-service and worker service with variables to pull these values (if present) from the `values.yaml` file 
- Added liveness/readiness lines to the proxy service 
- Added a section for startUp probe to the 3 services to give time for the container to become ready to take traffic
- Added examples into the `values.yaml` file

Tested the helm chart with the accompanying `values.yaml` using `helm template` and the output produced is what I expected.

Feedback on the values for the probes is welcome as I will now to moving to create a PR in the deploys repo to test this on QA. 

