### PR TITLE
Split columns and UI on the fields

### DIFF
--- a/packages/server/src/api/controllers/view/viewsV2.ts
+++ b/packages/server/src/api/controllers/view/viewsV2.ts
@@ -2,14 +2,28 @@ import sdk from "../../../sdk"
 import {
   CreateViewRequest,
   Ctx,
+  UIFieldMetadata,
   UpdateViewRequest,
   ViewResponse,
   ViewV2,
+  RequiredKeys,
 } from "@budibase/types"
 
 export async function create(ctx: Ctx<CreateViewRequest, ViewResponse>) {
   const view = ctx.request.body
   const { tableId } = view
+
+  const schemaUI =
+    view.schema &&
+    Object.entries(view.schema).reduce((p, [fieldName, schemaValue]) => {
+      p[fieldName] = {
+        order: schemaValue.order,
+        width: schemaValue.width,
+        visible: schemaValue.visible,
+        icon: schemaValue.icon,
+      }
+      return p
+    }, {} as Record<string, RequiredKeys<UIFieldMetadata>>)
 
   const parsedView: Omit<ViewV2, "id" | "version"> = {
     name: view.name,
@@ -17,7 +31,7 @@ export async function create(ctx: Ctx<CreateViewRequest, ViewResponse>) {
     query: view.query,
     sort: view.sort,
     columns: view.schema && Object.keys(view.schema),
-    schemaUI: view.schema,
+    schemaUI,
   }
   const result = await sdk.views.create(tableId, parsedView)
   ctx.status = 201

--- a/packages/server/src/api/controllers/view/viewsV2.ts
+++ b/packages/server/src/api/controllers/view/viewsV2.ts
@@ -4,13 +4,22 @@ import {
   Ctx,
   UpdateViewRequest,
   ViewResponse,
+  ViewV2,
 } from "@budibase/types"
 
 export async function create(ctx: Ctx<CreateViewRequest, ViewResponse>) {
   const view = ctx.request.body
   const { tableId } = view
 
-  const result = await sdk.views.create(tableId, view)
+  const parsedView: Omit<ViewV2, "id" | "version"> = {
+    name: view.name,
+    tableId: view.tableId,
+    query: view.query,
+    sort: view.sort,
+    columns: view.schema && Object.keys(view.schema),
+    schemaUI: view.schema,
+  }
+  const result = await sdk.views.create(tableId, parsedView)
   ctx.status = 201
   ctx.body = {
     data: result,

--- a/packages/server/src/api/controllers/view/viewsV2.ts
+++ b/packages/server/src/api/controllers/view/viewsV2.ts
@@ -18,16 +18,18 @@ async function parseSchemaUI(ctx: Ctx, view: CreateViewRequest) {
     newObj: Record<string, any>,
     existingObj: Record<string, any>
   ) {
-    for (const [key, value] of Object.entries(newObj)) {
-      if (typeof value === "object") {
-        if (hasOverrides(value, existingObj[key] || {})) {
-          return true
-        }
-      } else if (value !== existingObj[key]) {
+    const result = Object.entries(newObj).some(([key, value]) => {
+      const isObject = typeof value === "object"
+      const existing = existingObj[key]
+      if (isObject && hasOverrides(value, existing || {})) {
         return true
       }
-    }
-    return false
+      if (!isObject && value !== existing) {
+        return true
+      }
+    })
+
+    return result
   }
 
   const table = await sdk.tables.getTable(view.tableId)

--- a/packages/server/src/api/controllers/view/viewsV2.ts
+++ b/packages/server/src/api/controllers/view/viewsV2.ts
@@ -92,7 +92,19 @@ export async function update(ctx: Ctx<UpdateViewRequest, ViewResponse>) {
 
   const { tableId } = view
 
-  const result = await sdk.views.update(tableId, view)
+  const schemaUI = await parseSchemaUI(ctx, view)
+  const parsedView: ViewV2 = {
+    id: view.id,
+    name: view.name,
+    version: view.version,
+    tableId: view.tableId,
+    query: view.query,
+    sort: view.sort,
+    columns: view.schema && Object.keys(view.schema),
+    schemaUI,
+  }
+
+  const result = await sdk.views.update(tableId, parsedView)
   ctx.body = {
     data: result,
   }

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -1033,7 +1033,7 @@ describe("/rows", () => {
       }
 
       const view = await config.api.viewV2.create({
-        columns: ["name"],
+        schema: { name: {} },
       })
       const response = await config.api.viewV2.search(view.id)
 
@@ -1102,7 +1102,7 @@ describe("/rows", () => {
         const table = await config.createTable(userTable())
         const view = await config.api.viewV2.create({
           tableId: table._id!,
-          columns: {
+          schema: {
             name: { visible: true },
             surname: { visible: true },
             address: { visible: true },
@@ -1150,7 +1150,7 @@ describe("/rows", () => {
         const tableId = table._id!
         const view = await config.api.viewV2.create({
           tableId,
-          columns: {
+          schema: {
             name: { visible: true },
             address: { visible: true },
           },
@@ -1203,7 +1203,7 @@ describe("/rows", () => {
         const tableId = table._id!
         const view = await config.api.viewV2.create({
           tableId,
-          columns: {
+          schema: {
             name: { visible: true },
             address: { visible: true },
           },
@@ -1231,7 +1231,7 @@ describe("/rows", () => {
         const tableId = table._id!
         const view = await config.api.viewV2.create({
           tableId,
-          columns: {
+          schema: {
             name: { visible: true },
             address: { visible: true },
           },

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -983,7 +983,7 @@ describe("/rows", () => {
       }
 
       const view = await config.api.viewV2.create({
-        columns: { name: { visible: true } },
+        columns: ["name"],
       })
       const response = await config.api.viewV2.search(view.id)
 

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -95,15 +95,15 @@ describe("/v2/views", () => {
         name: generator.name(),
         tableId: config.table!._id!,
         schema: {
-          name: {
-            name: "name",
-            type: FieldType.STRING,
+          Price: {
+            name: "Price",
+            type: FieldType.NUMBER,
             visible: true,
             order: 1,
             width: 100,
           },
-          lastname: {
-            name: "lastname",
+          Category: {
+            name: "Category",
             type: FieldType.STRING,
             visible: false,
             icon: "ic",
@@ -116,20 +116,68 @@ describe("/v2/views", () => {
       expect(await config.api.viewV2.get(createdView.id)).toEqual({
         ...newView,
         schema: undefined,
-        columns: ["name", "lastname"],
+        columns: ["Price", "Category"],
         schemaUI: {
-          name: {
+          Price: {
             visible: true,
             order: 1,
             width: 100,
           },
-          lastname: {
+          Category: {
             visible: false,
             icon: "ic",
           },
         },
         id: createdView.id,
         version: 2,
+      })
+    })
+
+    it("throw an exception if the schema overrides a non UI field", async () => {
+      const newView: CreateViewRequest = {
+        name: generator.name(),
+        tableId: config.table!._id!,
+        schema: {
+          Price: {
+            name: "Price",
+            type: FieldType.NUMBER,
+            visible: true,
+          },
+          Category: {
+            name: "Category",
+            type: FieldType.STRING,
+            constraints: {
+              type: "string",
+              presence: true,
+            },
+          },
+        },
+      }
+
+      await config.api.viewV2.create(newView, {
+        expectStatus: 400,
+      })
+    })
+
+    it("will not throw an exception if the schema is 'deleting' non UI fields", async () => {
+      const newView: CreateViewRequest = {
+        name: generator.name(),
+        tableId: config.table!._id!,
+        schema: {
+          Price: {
+            name: "Price",
+            type: FieldType.NUMBER,
+            visible: true,
+          },
+          Category: {
+            name: "Category",
+            type: FieldType.STRING,
+          },
+        },
+      }
+
+      await config.api.viewV2.create(newView, {
+        expectStatus: 201,
       })
     })
   })

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1,6 +1,7 @@
 import * as setup from "./utilities"
 import {
   CreateViewRequest,
+  FieldSchema,
   FieldType,
   SortOrder,
   SortType,
@@ -42,8 +43,6 @@ describe("/v2/views", () => {
     },
     schema: {
       name: {
-        name: "name",
-        type: FieldType.STRING,
         visible: true,
       },
     },
@@ -108,7 +107,7 @@ describe("/v2/views", () => {
             visible: false,
             icon: "ic",
           },
-        },
+        } as Record<string, FieldSchema>,
       }
 
       const createdView = await config.api.viewV2.create(newView)
@@ -151,7 +150,7 @@ describe("/v2/views", () => {
               presence: true,
             },
           },
-        },
+        } as Record<string, FieldSchema>,
       }
 
       await config.api.viewV2.create(newView, {
@@ -173,7 +172,7 @@ describe("/v2/views", () => {
             name: "Category",
             type: FieldType.STRING,
           },
-        },
+        } as Record<string, FieldSchema>,
       }
 
       await config.api.viewV2.create(newView, {
@@ -316,7 +315,7 @@ describe("/v2/views", () => {
             visible: false,
             icon: "ic",
           },
-        },
+        } as Record<string, FieldSchema>,
       })
 
       expect(await config.api.viewV2.get(view.id)).toEqual({
@@ -357,7 +356,7 @@ describe("/v2/views", () => {
                 presence: true,
               },
             },
-          },
+          } as Record<string, FieldSchema>,
         },
         {
           expectStatus: 400,
@@ -379,7 +378,7 @@ describe("/v2/views", () => {
               name: "Category",
               type: FieldType.STRING,
             },
-          },
+          } as Record<string, FieldSchema>,
         },
         {
           expectStatus: 200,

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -40,7 +40,8 @@ describe("/v2/views", () => {
       order: SortOrder.DESCENDING,
       type: SortType.STRING,
     },
-    columns: {
+    columns: ["name"],
+    schemaUI: {
       name: {
         visible: true,
       },

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -298,6 +298,94 @@ describe("/v2/views", () => {
         status: 400,
       })
     })
+
+    it("updates only UI schema overrides", async () => {
+      await config.api.viewV2.update({
+        ...view,
+        schema: {
+          Price: {
+            name: "Price",
+            type: FieldType.NUMBER,
+            visible: true,
+            order: 1,
+            width: 100,
+          },
+          Category: {
+            name: "Category",
+            type: FieldType.STRING,
+            visible: false,
+            icon: "ic",
+          },
+        },
+      })
+
+      expect(await config.api.viewV2.get(view.id)).toEqual({
+        ...view,
+        schema: undefined,
+        columns: ["Price", "Category"],
+        schemaUI: {
+          Price: {
+            visible: true,
+            order: 1,
+            width: 100,
+          },
+          Category: {
+            visible: false,
+            icon: "ic",
+          },
+        },
+        id: view.id,
+        version: 2,
+      })
+    })
+
+    it("throw an exception if the schema overrides a non UI field", async () => {
+      await config.api.viewV2.update(
+        {
+          ...view,
+          schema: {
+            Price: {
+              name: "Price",
+              type: FieldType.NUMBER,
+              visible: true,
+            },
+            Category: {
+              name: "Category",
+              type: FieldType.STRING,
+              constraints: {
+                type: "string",
+                presence: true,
+              },
+            },
+          },
+        },
+        {
+          expectStatus: 400,
+        }
+      )
+    })
+
+    it("will not throw an exception if the schema is 'deleting' non UI fields", async () => {
+      await config.api.viewV2.update(
+        {
+          ...view,
+          schema: {
+            Price: {
+              name: "Price",
+              type: FieldType.NUMBER,
+              visible: true,
+            },
+            Category: {
+              name: "Category",
+              type: FieldType.STRING,
+            },
+          },
+        },
+        {
+          expectStatus: 200,
+        }
+      )
+    })
   })
 
   describe("delete", () => {

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -90,7 +90,7 @@ describe("/v2/views", () => {
       })
     })
 
-    it("persist schema overrides", async () => {
+    it("persist only UI schema overrides", async () => {
       const newView: CreateViewRequest = {
         name: generator.name(),
         tableId: config.table!._id!,
@@ -99,11 +99,14 @@ describe("/v2/views", () => {
             name: "name",
             type: FieldType.STRING,
             visible: true,
+            order: 1,
+            width: 100,
           },
           lastname: {
             name: "lastname",
             type: FieldType.STRING,
             visible: false,
+            icon: "ic",
           },
         },
       }
@@ -116,14 +119,13 @@ describe("/v2/views", () => {
         columns: ["name", "lastname"],
         schemaUI: {
           name: {
-            name: "name",
-            type: FieldType.STRING,
             visible: true,
+            order: 1,
+            width: 100,
           },
           lastname: {
-            name: "lastname",
-            type: FieldType.STRING,
             visible: false,
+            icon: "ic",
           },
         },
         id: createdView.id,

--- a/packages/server/src/middleware/tests/trimViewRowInfo.spec.ts
+++ b/packages/server/src/middleware/tests/trimViewRowInfo.spec.ts
@@ -129,7 +129,7 @@ describe("trimViewRowInfo middleware", () => {
       id: viewId,
       name: generator.guid(),
       tableId: table._id!,
-      columns: { name: { visible: true }, address: { visible: true } },
+      columns: ["name", "address"],
     })
 
     const data = getRandomData()

--- a/packages/server/src/sdk/app/rows/search/tests/external.spec.ts
+++ b/packages/server/src/sdk/app/rows/search/tests/external.spec.ts
@@ -13,7 +13,7 @@ jest.unmock("mysql2/promise")
 
 jest.setTimeout(30000)
 
-describe("external", () => {
+describe.skip("external", () => {
   const config = new TestConfiguration()
 
   let externalDatasource: Datasource

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -1,11 +1,5 @@
 import { HTTPError, context } from "@budibase/backend-core"
-import {
-  FieldSchema,
-  TableSchema,
-  UIFieldMetadata,
-  View,
-  ViewV2,
-} from "@budibase/types"
+import { FieldSchema, TableSchema, View, ViewV2 } from "@budibase/types"
 
 import sdk from "../../../sdk"
 import * as utils from "../../../db/utils"

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -1,5 +1,11 @@
 import { HTTPError, context } from "@budibase/backend-core"
-import { TableSchema, UIFieldMetadata, View, ViewV2 } from "@budibase/types"
+import {
+  FieldSchema,
+  TableSchema,
+  UIFieldMetadata,
+  View,
+  ViewV2,
+} from "@budibase/types"
 
 import sdk from "../../../sdk"
 import * as utils from "../../../db/utils"
@@ -73,37 +79,34 @@ export function enrichSchema(view: View | ViewV2, tableSchema: TableSchema) {
     return view
   }
 
+  let schema = { ...tableSchema }
+  if (view.schemaUI) {
+    const viewOverridesEntries = Object.entries(view.schemaUI)
+    const viewSetsOrder = viewOverridesEntries.some(([_, v]) => v.order)
+    for (const [fieldName, schemaUI] of viewOverridesEntries) {
+      schema[fieldName] = {
+        ...schema[fieldName],
+        ...schemaUI,
+        order: viewSetsOrder
+          ? schemaUI.order || undefined
+          : schema[fieldName].order,
+      }
+    }
+  }
+
+  if (view?.columns?.length) {
+    const pickedSchema: Record<string, FieldSchema> = {}
+    for (const fieldName of view.columns) {
+      if (!schema[fieldName]) {
+        continue
+      }
+      pickedSchema[fieldName] = { ...schema[fieldName] }
+    }
+    schema = pickedSchema
+  }
+
   return {
     ...view,
-    schema:
-      !view?.columns || !Object.entries(view?.columns).length
-        ? tableSchema
-        : enrichViewV2Schema(tableSchema, view.columns),
+    schema: schema,
   }
-}
-
-function enrichViewV2Schema(
-  tableSchema: TableSchema,
-  viewOverrides: Record<string, UIFieldMetadata>
-) {
-  const result: TableSchema = {}
-  const viewOverridesEntries = Object.entries(viewOverrides)
-  const viewSetsOrder = viewOverridesEntries.some(([_, v]) => v.order)
-  for (const [columnName, columnUIMetadata] of viewOverridesEntries) {
-    if (!columnUIMetadata.visible) {
-      continue
-    }
-
-    if (!tableSchema[columnName]) {
-      continue
-    }
-
-    const tableFieldSchema = tableSchema[columnName]
-    if (viewSetsOrder) {
-      delete tableFieldSchema.order
-    }
-
-    result[columnName] = merge(tableFieldSchema, columnUIMetadata)
-  }
-  return result
 }

--- a/packages/server/src/sdk/app/views/tests/views.spec.ts
+++ b/packages/server/src/sdk/app/views/tests/views.spec.ts
@@ -102,18 +102,14 @@ describe("table sdk", () => {
       })
     })
 
-    it("if view schema only defines visiblility, should only fetch the selected fields", async () => {
+    it("if view schema only defines columns, should only fetch the selected fields", async () => {
       const tableId = basicTable._id!
       const view: ViewV2 = {
         version: 2,
         id: generator.guid(),
         name: generator.guid(),
         tableId,
-        columns: {
-          name: { visible: true },
-          id: { visible: true },
-          description: { visible: false },
-        },
+        columns: ["name", "id"],
       }
 
       const res = enrichSchema(view, basicTable.schema)
@@ -151,7 +147,7 @@ describe("table sdk", () => {
         id: generator.guid(),
         name: generator.guid(),
         tableId,
-        columns: { unnexisting: { visible: true }, name: { visible: true } },
+        columns: ["unnexisting", "name"],
       }
 
       const res = enrichSchema(view, basicTable.schema)
@@ -175,16 +171,17 @@ describe("table sdk", () => {
       )
     })
 
-    it("if view schema only defines visiblility, should only fetch the selected fields", async () => {
+    it("if the view schema overrides the schema UI, the table schema should be overridden", async () => {
       const tableId = basicTable._id!
       const view: ViewV2 = {
         version: 2,
         id: generator.guid(),
         name: generator.guid(),
         tableId,
-        columns: {
-          name: { visible: true },
-          id: { visible: true },
+        columns: ["name", "id", "description"],
+        schemaUI: {
+          name: { visible: true, width: 100 },
+          id: { visible: true, width: 20 },
           description: { visible: false },
         },
       }
@@ -200,7 +197,7 @@ describe("table sdk", () => {
               name: "name",
               order: 2,
               visible: true,
-              width: 80,
+              width: 100,
               constraints: {
                 type: "string",
               },
@@ -210,8 +207,18 @@ describe("table sdk", () => {
               name: "id",
               order: 1,
               visible: true,
+              width: 20,
               constraints: {
                 type: "number",
+              },
+            },
+            description: {
+              type: "string",
+              name: "description",
+              visible: false,
+              width: 200,
+              constraints: {
+                type: "string",
               },
             },
           },
@@ -219,14 +226,15 @@ describe("table sdk", () => {
       )
     })
 
-    it("if view defines order, the table schema order should be ignored", async () => {
+    it("if the view defines order, the table schema order should be ignored", async () => {
       const tableId = basicTable._id!
       const view: ViewV2 = {
         version: 2,
         id: generator.guid(),
         name: generator.guid(),
         tableId,
-        columns: {
+        columns: ["name", "id", "description"],
+        schemaUI: {
           name: { visible: true, order: 1 },
           id: { visible: true },
           description: { visible: false, order: 2 },
@@ -255,6 +263,16 @@ describe("table sdk", () => {
               visible: true,
               constraints: {
                 type: "number",
+              },
+            },
+            description: {
+              type: "string",
+              name: "description",
+              order: 2,
+              visible: false,
+              width: 200,
+              constraints: {
+                type: "string",
               },
             },
           },

--- a/packages/server/src/tests/utilities/api/viewV2.ts
+++ b/packages/server/src/tests/utilities/api/viewV2.ts
@@ -3,6 +3,7 @@ import TestConfiguration from "../TestConfiguration"
 import { TestAPI } from "./base"
 import { generator } from "@budibase/backend-core/tests"
 import { Response } from "superagent"
+import sdk from "../../../sdk"
 
 export class ViewV2API extends TestAPI {
   constructor(config: TestConfiguration) {
@@ -60,6 +61,12 @@ export class ViewV2API extends TestAPI {
       .delete(`/api/v2/views/${viewId}`)
       .set(this.config.defaultHeaders())
       .expect(expectStatus)
+  }
+
+  get = async (viewId: string) => {
+    return await this.config.doInContext(this.config.appId, () =>
+      sdk.views.get(viewId)
+    )
   }
 
   search = async (

--- a/packages/server/src/tests/utilities/api/viewV2.ts
+++ b/packages/server/src/tests/utilities/api/viewV2.ts
@@ -1,4 +1,10 @@
-import { CreateViewRequest, SortOrder, SortType, ViewV2 } from "@budibase/types"
+import {
+  CreateViewRequest,
+  SortOrder,
+  SortType,
+  UpdateViewRequest,
+  ViewV2,
+} from "@budibase/types"
 import TestConfiguration from "../TestConfiguration"
 import { TestAPI } from "./base"
 import { generator } from "@budibase/backend-core/tests"
@@ -34,7 +40,7 @@ export class ViewV2API extends TestAPI {
   }
 
   update = async (
-    view: ViewV2,
+    view: UpdateViewRequest,
     {
       expectStatus,
       handleResponse,

--- a/packages/types/src/api/web/app/view.ts
+++ b/packages/types/src/api/web/app/view.ts
@@ -9,4 +9,7 @@ export interface CreateViewRequest
   schema?: Record<string, FieldSchema>
 }
 
-export type UpdateViewRequest = ViewV2
+export interface UpdateViewRequest
+  extends Omit<ViewV2, "columns" | "schemaUI"> {
+  schema?: Record<string, FieldSchema>
+}

--- a/packages/types/src/api/web/app/view.ts
+++ b/packages/types/src/api/web/app/view.ts
@@ -1,9 +1,12 @@
-import { TableSchema, ViewV2 } from "../../../documents"
+import { ViewV2, FieldSchema } from "../../../documents"
 
 export interface ViewResponse {
   data: ViewV2
 }
 
-export type CreateViewRequest = Omit<ViewV2, "version" | "id">
+export interface CreateViewRequest
+  extends Omit<ViewV2, "version" | "id" | "columns" | "schemaUI"> {
+  schema?: Record<string, FieldSchema>
+}
 
 export type UpdateViewRequest = ViewV2

--- a/packages/types/src/api/web/app/view.ts
+++ b/packages/types/src/api/web/app/view.ts
@@ -1,4 +1,4 @@
-import { ViewV2, FieldSchema } from "../../../documents"
+import { ViewV2, UIFieldMetadata } from "../../../documents"
 
 export interface ViewResponse {
   data: ViewV2
@@ -6,10 +6,10 @@ export interface ViewResponse {
 
 export interface CreateViewRequest
   extends Omit<ViewV2, "version" | "id" | "columns" | "schemaUI"> {
-  schema?: Record<string, FieldSchema>
+  schema?: Record<string, UIFieldMetadata>
 }
 
 export interface UpdateViewRequest
   extends Omit<ViewV2, "columns" | "schemaUI"> {
-  schema?: Record<string, FieldSchema>
+  schema?: Record<string, UIFieldMetadata>
 }

--- a/packages/types/src/documents/app/view.ts
+++ b/packages/types/src/documents/app/view.ts
@@ -25,7 +25,8 @@ export interface ViewV2 {
     order?: SortOrder
     type?: SortType
   }
-  columns?: Record<string, UIFieldMetadata>
+  columns?: string[]
+  schemaUI?: Record<string, UIFieldMetadata>
 }
 
 export type ViewSchema = ViewCountOrSumSchema | ViewStatisticsSchema

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./documents"
 export * from "./sdk"
 export * from "./api"
+export * from "./shared"

--- a/packages/types/src/shared/typeUtils.ts
+++ b/packages/types/src/shared/typeUtils.ts
@@ -3,3 +3,7 @@ export type DeepPartial<T> = {
 }
 
 export type ISO8601 = string
+
+export type RequiredKeys<T> = {
+  [K in keyof Required<T>]: T[K]
+}


### PR DESCRIPTION
## Description
After discussing the usage for the grid, we are splitting the column security (what fields the view will retrieve) and the UI (which ones are visible, width, etc.).

Both create and update endpoint will be checking the view schemas vs the table schemas, ensuring that every field defined in there matches the table schema, allowing only UI changes