### PR TITLE
Postgres schemas with a hyphen

### DIFF
--- a/packages/server/scripts/integrations/postgres/init.sql
+++ b/packages/server/scripts/integrations/postgres/init.sql
@@ -1,6 +1,6 @@
 SELECT 'CREATE DATABASE main'
 WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'main')\gexec
-CREATE SCHEMA test;
+CREATE SCHEMA "test-1";
 CREATE TYPE person_job AS ENUM ('qa', 'programmer', 'designer');
 CREATE TABLE Persons (
     PersonID SERIAL PRIMARY KEY,
@@ -39,7 +39,7 @@ CREATE TABLE Products_Tasks (
             REFERENCES Tasks(TaskID),
     PRIMARY KEY (ProductID, TaskID)
 );
-CREATE TABLE test.table1 (
+CREATE TABLE "test-1".table1 (
   id SERIAL PRIMARY KEY,
   Name varchar(255)
 );
@@ -60,7 +60,7 @@ INSERT INTO Products_Tasks (ProductID, TaskID) VALUES (1, 1);
 INSERT INTO Products_Tasks (ProductID, TaskID) VALUES (2, 1);
 INSERT INTO Products_Tasks (ProductID, TaskID) VALUES (3, 1);
 INSERT INTO Products_Tasks (ProductID, TaskID) VALUES (1, 2);
-INSERT INTO test.table1 (Name) VALUES ('Test');
+INSERT INTO "test-1".table1 (Name) VALUES ('Test');
 INSERT INTO CompositeTable (KeyPartOne, KeyPartTwo, Name) VALUES ('aaa', 'bbb', 'Michael');
 INSERT INTO CompositeTable (KeyPartOne, KeyPartTwo, Name) VALUES ('bbb', 'ccc', 'Andrew');
 INSERT INTO CompositeTable (KeyPartOne, KeyPartTwo, Name) VALUES ('ddd', '', 'OneKey');

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -210,7 +210,7 @@ class PostgresIntegration extends Sql implements DatasourcePlus {
     if (!this.config.schema) {
       this.config.schema = "public"
     }
-    await this.client.query(`SET search_path TO ${this.config.schema}`)
+    await this.client.query(`SET search_path TO "${this.config.schema}"`)
     this.COLUMNS_SQL = `select * from information_schema.columns where table_schema = '${this.config.schema}'`
     this.open = true
   }


### PR DESCRIPTION
## Description
Quick fix for utilising a hyphen in a Postgres schema - this needed to be escaped correctly.

Addresses: 
- https://linear.app/budibase/issue/BUDI-7346/not-able-to-connect-to-postgres-schema-with-a-hyphen
- https://github.com/Budibase/budibase/issues/11410