### PR TITLE
Fix for formula display columns issue in SQL Server

### DIFF
--- a/packages/frontend-core/src/components/grid/cells/HeaderCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/HeaderCell.svelte
@@ -26,7 +26,6 @@
     "array",
     "attachment",
     "boolean",
-    "formula",
     "json",
   ]
 

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -315,7 +315,7 @@ class InternalBuilder {
   addSorting(query: KnexQuery, json: QueryJson): KnexQuery {
     let { sort, paginate } = json
     const table = json.meta?.table
-    if (sort) {
+    if (sort && Object.keys(sort || {}).length > 0) {
       for (let [key, value] of Object.entries(sort)) {
         const direction =
           value.direction === SortDirection.ASCENDING ? "asc" : "desc"

--- a/packages/server/src/integrations/tests/sql.spec.ts
+++ b/packages/server/src/integrations/tests/sql.spec.ts
@@ -26,6 +26,12 @@ function generateReadJson({
     filters: filters || {},
     sort: sort || {},
     paginate: paginate || {},
+    meta: {
+      table: {
+        name: table || TABLE_NAME,
+        primary: ["id"],
+      },
+    },
   }
 }
 
@@ -634,6 +640,21 @@ describe("SQL query builder", () => {
     expect(query).toEqual({
       bindings: [`%jo%`, limit],
       sql: `select * from (select * from (select * from \"test\" where LOWER(\"test\".\"name\") LIKE :1) where rownum <= :2) \"test\"`,
+    })
+  })
+
+  it("should sort SQL Server tables by the primary key if no sort data is provided", () => {
+    let query = new Sql(SqlClient.MS_SQL, limit)._query(
+      generateReadJson({
+        sort: {},
+        paginate: {
+          limit: 10,
+        },
+      })
+    )
+    expect(query).toEqual({
+      bindings: [10],
+      sql: `select * from (select top (@p0) * from [test] order by [test].[id] asc) as [test]`,
     })
   })
 })


### PR DESCRIPTION
## Description
When using a formula column in SQL Server, fetch tables was causing the table to break because SQL server needs to have a sort order assigned when doing a **fetch** statement.

Addresses: 
- https://github.com/Budibase/budibase/issues/11423



