### PR TITLE
helm prestop hook for proxy

### DIFF
--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -40,6 +40,10 @@ spec:
       - image: budibase/proxy:{{ .Values.globals.appVersion | default .Chart.AppVersion }}
         imagePullPolicy: Always
         name: proxy-service
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh","-c","nginx -s quit; while killall -0 nginx; do sleep 1; done"]
         {{- if .Values.services.proxy.startupProbe }}
         {{- with .Values.services.proxy.startupProbe }}
         startupProbe:


### PR DESCRIPTION
The official Nginx Ingress controller, by default, has interruptions in service when its pods are restarted or redeployed. This can result in dropped connections if the ingress pods are terminated. Nginx handles signals a little bit differently than Kubernetes expects.

When Kubernetes sends a SIGTERM to the nginx-ingress-controller pod, Nginx will enact a fast shutdown. If the controller is processing any requests during this time, they will be interrupted, resulting in dropped connections. 
Instead we want to give Nginx a SIGQUIT signal, which will prompt a graceful shutdown. Nginx will wait for connections to terminate before exiting, while not accepting any new connections.

The preStop hook allows the pod to call any command before the termination signal. For this case, we want to pre-emptively send Nginx the SIGQUIT signal, so that the controller will gracefully terminate connections.

References:
https://medium.com/codecademy-engineering/kubernetes-nginx-and-zero-downtime-in-production-2c910c6a5ed8
https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/