### PR TITLE
Fix for app action fields and don't clone testData

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -108,7 +108,13 @@
   /****************************************************/
 
   const getInputData = (testData, blockInputs) => {
-    let newInputData = cloneDeep(testData || blockInputs)
+    // Test data is not cloned for reactivity
+    let newInputData = testData || cloneDeep(blockInputs)
+
+    // Ensures the app action fields are populated
+    if (block.event === "app:trigger" && !newInputData?.fields) {
+      newInputData = cloneDeep(blockInputs)
+    }
 
     /**
      * TODO - Remove after November 2023


### PR DESCRIPTION
## Description
A recent bug fix had an unintended side effect of causing an issue with app action triggers with fields not being set.

Worked with @andz-bb to resolve the new bug issue without breaking his original fix.

Addresses: 
- https://linear.app/budibase/issue/BUDI-7359/automation-with-app-action-trigger-breaks-when-it-has-a-field-added




