### PR TITLE
Use NX affected

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -18,7 +18,8 @@ env:
   BRANCH: ${{ github.event.pull_request.head.ref }}
   BASE_BRANCH: ${{ github.event.pull_request.base.ref}}
   PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-  NX_BASE_BRANCH: origin/${{ github.base_ref || 'master'}}
+  NX_BASE_BRANCH: origin/${{ github.base_ref }}
+  USE_NX_AFFECTED: ${{ github.event_name == 'pull_request' && github.base_ref != 'master'}}
 
 jobs:
   lint:
@@ -66,9 +67,21 @@ jobs:
       - run: yarn --frozen-lockfile
 
       # Run build all the projects
-      - run: yarn build --since=${{ env.NX_BASE_BRANCH }}
+      - name: Build
+        run: |
+          if [[ ${{ env.USE_NX_AFFECTED }} ]]; then
+            yarn build --since=${{ env.NX_BASE_BRANCH }}
+          else
+            yarn build
+          fi
       # Check the types of the projects built via esbuild
-      - run: yarn check:types --since=${{ env.NX_BASE_BRANCH }}
+      - name: Check types
+        run: |
+          if [[ ${{ env.USE_NX_AFFECTED }} ]]; then
+            yarn check:types --since=${{ env.NX_BASE_BRANCH }}
+          else
+            yarn check:types
+          fi
 
   test-libraries:
     runs-on: ubuntu-latest
@@ -92,7 +105,13 @@ jobs:
           node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
-      - run: yarn test --ignore=@budibase/worker --ignore=@budibase/server --ignore=@budibase/pro --since=${{ env.NX_BASE_BRANCH }}
+      - name: Test
+        run: |
+          if [[ ${{ env.USE_NX_AFFECTED }} ]]; then
+            yarn test --ignore=@budibase/worker --ignore=@budibase/server --ignore=@budibase/pro --since=${{ env.NX_BASE_BRANCH }}
+          else
+            yarn test --ignore=@budibase/worker --ignore=@budibase/server --ignore=@budibase/pro
+          fi
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
@@ -122,7 +141,13 @@ jobs:
           cache: "yarn"
       - run: yarn --frozen-lockfile
       - name: Test worker and server
-        run: yarn test --scope=@budibase/worker --scope=@budibase/server --since=${{ env.NX_BASE_BRANCH }}
+        run: |
+          if [[ ${{ env.USE_NX_AFFECTED }} ]]; then
+            yarn test --scope=@budibase/worker --scope=@budibase/server --since=${{ env.NX_BASE_BRANCH }}
+          else
+            yarn test --scope=@budibase/worker --scope=@budibase/server
+          fi
+
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN || github.token }} # not required for public repos
@@ -146,7 +171,13 @@ jobs:
           node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
-      - run: yarn test --scope=@budibase/pro --since=${{ env.NX_BASE_BRANCH }}
+      - name: Test
+        run: |
+          if [[ ${{ env.USE_NX_AFFECTED }} ]]; then
+            yarn test --scope=@budibase/pro --since=${{ env.NX_BASE_BRANCH }}
+          else
+            yarn test --scope=@budibase/pro
+          fi
 
   integration-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -18,6 +18,7 @@ env:
   BRANCH: ${{ github.event.pull_request.head.ref }}
   BASE_BRANCH: ${{ github.event.pull_request.base.ref}}
   PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+  NX_BASE_BRANCH: ${{ github.base_ref || "origin/master"}}
 
 jobs:
   lint:
@@ -61,9 +62,9 @@ jobs:
           cache: "yarn"
       - run: yarn --frozen-lockfile
       # Run build all the projects
-      - run: yarn build
+      - run: yarn build --since=${{ NX_BASE_BRANCH }}
       # Check the types of the projects built via esbuild
-      - run: yarn check:types
+      - run: yarn check:types --since=${{ NX_BASE_BRANCH }}
 
   test-libraries:
     runs-on: ubuntu-latest
@@ -84,7 +85,7 @@ jobs:
           node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
-      - run: yarn test --ignore=@budibase/worker --ignore=@budibase/server --ignore=@budibase/pro
+      - run: yarn test --ignore=@budibase/worker --ignore=@budibase/server --ignore=@budibase/pro --since=${{ NX_BASE_BRANCH }}
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
@@ -111,7 +112,7 @@ jobs:
           cache: "yarn"
       - run: yarn --frozen-lockfile
       - name: Test worker and server
-        run: yarn test --scope=@budibase/worker --scope=@budibase/server
+        run: yarn test --scope=@budibase/worker --scope=@budibase/server --since=${{ NX_BASE_BRANCH }}
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN || github.token }} # not required for public repos
@@ -134,7 +135,7 @@ jobs:
           node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
-      - run: yarn test --scope=@budibase/pro
+      - run: yarn test --scope=@budibase/pro --since=${{ NX_BASE_BRANCH }}
 
   integration-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -18,7 +18,7 @@ env:
   BRANCH: ${{ github.event.pull_request.head.ref }}
   BASE_BRANCH: ${{ github.event.pull_request.base.ref}}
   PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-  NX_BASE_BRANCH: ${{ github.base_ref || 'master'}}
+  NX_BASE_BRANCH: origin/${{ github.base_ref || 'master'}}
 
 jobs:
   lint:

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -138,6 +138,7 @@ jobs:
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          fetch-depth: 0
 
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3
@@ -166,7 +167,7 @@ jobs:
           node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
-      - run: yarn build --projects=@budibase/server,@budibase/worker,@budibase/client
+      - run: yarn build --scope @budibase/server --scope @budibase/worker --scope @budibase/client
       - name: Run tests
         run: |
           cd qa-core

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -173,7 +173,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-          fetch-depth: 0
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
 
       - name: Check pro commit

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -69,7 +69,7 @@ jobs:
       # Run build all the projects
       - name: Build
         run: |
-          if [[ ${{ env.USE_NX_AFFECTED }} ]]; then
+          if ${{ env.USE_NX_AFFECTED }}; then
             yarn build --since=${{ env.NX_BASE_BRANCH }}
           else
             yarn build
@@ -77,7 +77,7 @@ jobs:
       # Check the types of the projects built via esbuild
       - name: Check types
         run: |
-          if [[ ${{ env.USE_NX_AFFECTED }} ]]; then
+          if ${{ env.USE_NX_AFFECTED }}; then
             yarn check:types --since=${{ env.NX_BASE_BRANCH }}
           else
             yarn check:types
@@ -107,7 +107,7 @@ jobs:
       - run: yarn --frozen-lockfile
       - name: Test
         run: |
-          if [[ ${{ env.USE_NX_AFFECTED }} ]]; then
+          if ${{ env.USE_NX_AFFECTED }}; then
             yarn test --ignore=@budibase/worker --ignore=@budibase/server --ignore=@budibase/pro --since=${{ env.NX_BASE_BRANCH }}
           else
             yarn test --ignore=@budibase/worker --ignore=@budibase/server --ignore=@budibase/pro
@@ -142,7 +142,7 @@ jobs:
       - run: yarn --frozen-lockfile
       - name: Test worker and server
         run: |
-          if [[ ${{ env.USE_NX_AFFECTED }} ]]; then
+          if ${{ env.USE_NX_AFFECTED }}; then
             yarn test --scope=@budibase/worker --scope=@budibase/server --since=${{ env.NX_BASE_BRANCH }}
           else
             yarn test --scope=@budibase/worker --scope=@budibase/server
@@ -173,7 +173,7 @@ jobs:
       - run: yarn --frozen-lockfile
       - name: Test
         run: |
-          if [[ ${{ env.USE_NX_AFFECTED }} ]]; then
+          if ${{ env.USE_NX_AFFECTED }}; then
             yarn test --scope=@budibase/pro --since=${{ env.NX_BASE_BRANCH }}
           else
             yarn test --scope=@budibase/pro

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -18,7 +18,7 @@ env:
   BRANCH: ${{ github.event.pull_request.head.ref }}
   BASE_BRANCH: ${{ github.event.pull_request.base.ref}}
   PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-  NX_BASE_BRANCH: ${{ github.base_ref || origin/master}}
+  NX_BASE_BRANCH: ${{ github.base_ref || 'origin/master'}}
 
 jobs:
   lint:

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -61,6 +61,8 @@ jobs:
           node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
+      - name: Fetch remote references
+        run: git fetch origin "+refs/heads/*:refs/remotes/origin/*"
       # Run build all the projects
       - run: yarn build --since=${{ env.NX_BASE_BRANCH }}
       # Check the types of the projects built via esbuild
@@ -85,6 +87,8 @@ jobs:
           node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
+      - name: Fetch remote references
+        run: git fetch origin "+refs/heads/*:refs/remotes/origin/*"
       - run: yarn test --ignore=@budibase/worker --ignore=@budibase/server --ignore=@budibase/pro --since=${{ env.NX_BASE_BRANCH }}
       - uses: codecov/codecov-action@v3
         with:
@@ -111,6 +115,8 @@ jobs:
           node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
+      - name: Fetch remote references
+        run: git fetch origin "+refs/heads/*:refs/remotes/origin/*"
       - name: Test worker and server
         run: yarn test --scope=@budibase/worker --scope=@budibase/server --since=${{ env.NX_BASE_BRANCH }}
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -18,7 +18,7 @@ env:
   BRANCH: ${{ github.event.pull_request.head.ref }}
   BASE_BRANCH: ${{ github.event.pull_request.base.ref}}
   PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-  NX_BASE_BRANCH: ${{ github.base_ref || "origin/master"}}
+  NX_BASE_BRANCH: ${{ github.base_ref || origin/master}}
 
 jobs:
   lint:

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -62,9 +62,9 @@ jobs:
           cache: "yarn"
       - run: yarn --frozen-lockfile
       # Run build all the projects
-      - run: yarn build --since=${{ NX_BASE_BRANCH }}
+      - run: yarn build --since=${{ env.NX_BASE_BRANCH }}
       # Check the types of the projects built via esbuild
-      - run: yarn check:types --since=${{ NX_BASE_BRANCH }}
+      - run: yarn check:types --since=${{ env.NX_BASE_BRANCH }}
 
   test-libraries:
     runs-on: ubuntu-latest
@@ -85,7 +85,7 @@ jobs:
           node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
-      - run: yarn test --ignore=@budibase/worker --ignore=@budibase/server --ignore=@budibase/pro --since=${{ NX_BASE_BRANCH }}
+      - run: yarn test --ignore=@budibase/worker --ignore=@budibase/server --ignore=@budibase/pro --since=${{ env.NX_BASE_BRANCH }}
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
@@ -112,7 +112,7 @@ jobs:
           cache: "yarn"
       - run: yarn --frozen-lockfile
       - name: Test worker and server
-        run: yarn test --scope=@budibase/worker --scope=@budibase/server --since=${{ NX_BASE_BRANCH }}
+        run: yarn test --scope=@budibase/worker --scope=@budibase/server --since=${{ env.NX_BASE_BRANCH }}
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN || github.token }} # not required for public repos
@@ -135,7 +135,7 @@ jobs:
           node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
-      - run: yarn test --scope=@budibase/pro --since=${{ NX_BASE_BRANCH }}
+      - run: yarn test --scope=@budibase/pro --since=${{ env.NX_BASE_BRANCH }}
 
   integration-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -18,7 +18,7 @@ env:
   BRANCH: ${{ github.event.pull_request.head.ref }}
   BASE_BRANCH: ${{ github.event.pull_request.base.ref}}
   PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-  NX_BASE_BRANCH: ${{ github.base_ref || 'origin/master'}}
+  NX_BASE_BRANCH: origin/${{ github.base_ref || 'master'}}
 
 jobs:
   lint:

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -18,7 +18,7 @@ env:
   BRANCH: ${{ github.event.pull_request.head.ref }}
   BASE_BRANCH: ${{ github.event.pull_request.base.ref}}
   PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-  NX_BASE_BRANCH: origin/${{ github.base_ref || 'master'}}
+  NX_BASE_BRANCH: ${{ github.base_ref || 'master'}}
 
 jobs:
   lint:
@@ -62,7 +62,7 @@ jobs:
           cache: "yarn"
       - run: yarn --frozen-lockfile
       - name: Fetch remote references
-        run: git fetch origin "+refs/heads/*:refs/remotes/origin/*"
+        run: git fetch origin ${{ env.NX_BASE_BRANCH }}
       # Run build all the projects
       - run: yarn build --since=${{ env.NX_BASE_BRANCH }}
       # Check the types of the projects built via esbuild
@@ -88,7 +88,7 @@ jobs:
           cache: "yarn"
       - run: yarn --frozen-lockfile
       - name: Fetch remote references
-        run: git fetch origin "+refs/heads/*:refs/remotes/origin/*"
+        run: git fetch origin ${{ env.NX_BASE_BRANCH }}
       - run: yarn test --ignore=@budibase/worker --ignore=@budibase/server --ignore=@budibase/pro --since=${{ env.NX_BASE_BRANCH }}
       - uses: codecov/codecov-action@v3
         with:
@@ -116,7 +116,7 @@ jobs:
           cache: "yarn"
       - run: yarn --frozen-lockfile
       - name: Fetch remote references
-        run: git fetch origin "+refs/heads/*:refs/remotes/origin/*"
+        run: git fetch origin ${{ env.NX_BASE_BRANCH }}
       - name: Test worker and server
         run: yarn test --scope=@budibase/worker --scope=@budibase/server --since=${{ env.NX_BASE_BRANCH }}
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -51,9 +51,12 @@ jobs:
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          fetch-depth: 0
       - name: Checkout repo only
         uses: actions/checkout@v3
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'Budibase/budibase'
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3
@@ -61,8 +64,7 @@ jobs:
           node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
-      - name: Fetch remote references
-        run: git fetch origin ${{ env.NX_BASE_BRANCH }}
+
       # Run build all the projects
       - run: yarn build --since=${{ env.NX_BASE_BRANCH }}
       # Check the types of the projects built via esbuild
@@ -77,9 +79,12 @@ jobs:
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          fetch-depth: 0
       - name: Checkout repo only
         uses: actions/checkout@v3
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'Budibase/budibase'
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3
@@ -87,8 +92,6 @@ jobs:
           node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
-      - name: Fetch remote references
-        run: git fetch origin ${{ env.NX_BASE_BRANCH }}
       - run: yarn test --ignore=@budibase/worker --ignore=@budibase/server --ignore=@budibase/pro --since=${{ env.NX_BASE_BRANCH }}
       - uses: codecov/codecov-action@v3
         with:
@@ -105,9 +108,12 @@ jobs:
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          fetch-depth: 0
       - name: Checkout repo only
         uses: actions/checkout@v3
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'Budibase/budibase'
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3
@@ -115,8 +121,6 @@ jobs:
           node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
-      - name: Fetch remote references
-        run: git fetch origin ${{ env.NX_BASE_BRANCH }}
       - name: Test worker and server
         run: yarn test --scope=@budibase/worker --scope=@budibase/server --since=${{ env.NX_BASE_BRANCH }}
       - uses: codecov/codecov-action@v3

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "preinstall": "node scripts/syncProPackage.js",
     "setup": "git config submodule.recurse true && git submodule update && node ./hosting/scripts/setup.js && yarn && yarn build && yarn dev",
     "bootstrap": "./scripts/link-dependencies.sh && echo '***BOOTSTRAP ONLY REQUIRED FOR USE WITH ACCOUNT PORTAL***'",
-    "build": "yarn nx run-many -t=build",
+    "build": "lerna run build --stream",
     "build:dev": "lerna run --stream prebuild && yarn nx run-many --target=build --output-style=dynamic --watch --preserveWatchOutput",
     "check:types": "lerna run check:types",
     "backend:bootstrap": "./scripts/scopeBackend.sh && yarn run bootstrap",


### PR DESCRIPTION
## Description
Taking advantage of nx via lerna, using its "[affected](https://nx.dev/concepts/affected)" utils. Affected allows you to run certain commands only if there is any code change in its dependency chain.

This is currently our dependency graph:
<img width="1153" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/90a8cb27-ec9f-4bd6-9f62-281d439dfe0f">

Any modification in a package will be detected along the chain, running only the required commands.
Examples:
1. Changes on a pipeline or in qa-core. No packages were affected, so no need to run build/test/etc.
2. Changes in the worker. Nothing depends on the worker, so only the worker scripts will run
3. Changes in @budibase/types. Almost everything depends on these packages. All scripts will run except `SDK` and `string-templates` 
<img width="1148" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/d67a4222-80ff-4fde-b681-d8fcfa2f15c3">
5. 


This will not only make our pipeline quicker and hopefully help reduce the issues with flakiness, but it will also make us more aware of the full chain. In the future, we can move files across different packages to make our chain more efficient


### How will this affect the current pipelines
These changes will only take effect on PRs, excluding PRs to master. This was set as a "safety" mechanism to catch any issue if we were to "badly" detect affections. Any PR to master will still run all the checks, so these changes are safe. In the future we can revisit this to increase the "affect" usage.

The "affect" will always be compared to the base branch, so chained PRs will have minimal checks to run

- PR pipeline (tests "ran" in 5 seconds): https://github.com/Budibase/budibase/actions/runs/5812795519/job/15758948619?pr=11467
<img width="804" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/12dca06e-8739-451e-b8a4-f8c4310dbb5c">

- Push pipeline (no affect usage): https://github.com/Budibase/budibase/actions/runs/5818608000/job/15775368610

