### PR TITLE
Parallel single image build with docker manifest

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release:
-    runs-on: [self-hosted, dev]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Fail if not a tag

--- a/.github/workflows/release-singleimage.yml
+++ b/.github/workflows/release-singleimage.yml
@@ -6,14 +6,18 @@ on:
 env:
   CI: true
   PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-  REGISTRY_URL: registry.hub.docker.com
+  REGISTRY_IMAGE: budibase/budibase
 jobs:
-  build-amd64-arm64:
-    name: "build-amd64-arm64"
-    runs-on: [self-hosted, dev]
+  build-multiarch:
+    name: "build-multiarch"
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version:
+          - 14.x
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
       - name: Fail if not a tag
         run: |
@@ -67,17 +71,61 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           tags: budibase/budibase,budibase/budibase:v${{ env.RELEASE_VERSION }}
           file: ./hosting/single/Dockerfile
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build-multiarch
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_API_KEY }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
 
   build-aas:
     name: "build-aas"
-    runs-on: [self-hosted, dev]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version:
+          - 14.x
     steps:
       - name: Fail if not a tag
         run: |
@@ -101,8 +149,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v1
       - name: Setup Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
## Description
Removing the usage of the self hosted runners (unavailable in public repo) and attempting to get working using a Docker manifest in parallel.

Built following this documentation: https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners