### PR TITLE
Chore - building packages via esbuild and consume from builder

### DIFF
--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "prebuild": "rimraf dist/",
     "prepack": "cp package.json dist",
-    "build": "node ./scripts/build.js && tsc -p tsconfig.build.json --emitDeclarationOnly",
+    "build": "node ./scripts/build.js && tsc -p tsconfig.build.json --emitDeclarationOnly --paths null",
     "build:dev": "yarn prebuild && tsc --build --watch --preserveWatchOutput",
     "check:types": "tsc -p tsconfig.json --noEmit --paths null",
     "test": "bash scripts/test.sh",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "prebuild": "rimraf dist/",
     "prepack": "cp package.json dist",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "node ./scripts/build.js && tsc -p tsconfig.build.json --emitDeclarationOnly",
     "build:dev": "yarn prebuild && tsc --build --watch --preserveWatchOutput",
     "check:types": "tsc -p tsconfig.json --noEmit --paths null",
     "test": "bash scripts/test.sh",

--- a/packages/backend-core/plugins.ts
+++ b/packages/backend-core/plugins.ts
@@ -1,1 +1,0 @@
-export * from "./src/plugin"

--- a/packages/backend-core/scripts/build.js
+++ b/packages/backend-core/scripts/build.js
@@ -1,0 +1,8 @@
+#!/usr/bin/node
+const { join } = require("path")
+const fs = require("fs")
+const coreBuild = require("../../../scripts/build")
+
+coreBuild("./src/plugin/index.ts", "./dist/plugins.js")
+coreBuild("./src/index.ts", "./dist/index.js")
+coreBuild("./tests/index.ts", "./dist/tests.js")

--- a/packages/backend-core/scripts/build.js
+++ b/packages/backend-core/scripts/build.js
@@ -1,6 +1,4 @@
 #!/usr/bin/node
-const { join } = require("path")
-const fs = require("fs")
 const coreBuild = require("../../../scripts/build")
 
 coreBuild("./src/plugin/index.ts", "./dist/plugins.js")

--- a/packages/backend-core/tsconfig.build.json
+++ b/packages/backend-core/tsconfig.build.json
@@ -12,7 +12,11 @@
     "declaration": true,
     "types": ["node", "jest"],
     "outDir": "dist",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "paths": {
+      "@budibase/types": ["../types/src"],
+      "@budibase/shared-core": ["../shared-core/src"]
+    }
   },
   "include": ["**/*.js", "**/*.ts"],
   "exclude": [

--- a/packages/backend-core/tsconfig.json
+++ b/packages/backend-core/tsconfig.json
@@ -1,12 +1,4 @@
 {
   "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "composite": true,
-    "baseUrl": ".",
-    "paths": {
-      "@budibase/types": ["../types/src"],
-      "@budibase/shared-core": ["../shared-core/src"]
-    }
-  },
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/bbui/package.json
+++ b/packages/bbui/package.json
@@ -98,8 +98,7 @@
           {
             "projects": [
               "@budibase/string-templates",
-              "@budibase/shared-core",
-              "@budibase/types"
+              "@budibase/shared-core"
             ],
             "target": "build"
           }

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -133,9 +133,7 @@
         "dependsOn": [
           {
             "projects": [
-              "@budibase/shared-core",
-              "@budibase/string-templates",
-              "@budibase/types"
+              "@budibase/string-templates"
             ],
             "target": "build"
           }
@@ -145,9 +143,7 @@
         "dependsOn": [
           {
             "projects": [
-              "@budibase/shared-core",
-              "@budibase/string-templates",
-              "@budibase/types"
+              "@budibase/string-templates"
             ],
             "target": "build"
           }
@@ -157,9 +153,7 @@
         "dependsOn": [
           {
             "projects": [
-              "@budibase/shared-core",
-              "@budibase/string-templates",
-              "@budibase/types"
+              "@budibase/string-templates"
             ],
             "target": "build"
           }

--- a/packages/builder/vite.config.js
+++ b/packages/builder/vite.config.js
@@ -127,6 +127,14 @@ export default defineConfig(({ mode }) => {
           find: "helpers",
           replacement: path.resolve("./src/helpers"),
         },
+        {
+          find: "@budibase/types",
+          replacement: path.resolve("../types/src"),
+        },
+        {
+          find: "@budibase/shared-core",
+          replacement: path.resolve("../shared-core/src"),
+        },
       ],
     },
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,20 +63,5 @@
     "renamer": "^4.0.0",
     "ts-node": "^10.9.1",
     "typescript": "4.7.3"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "dependsOn": [
-          {
-            "projects": [
-              "@budibase/backend-core",
-              "@budibase/string-templates"
-            ],
-            "target": "build"
-          }
-        ]
-      }
-    }
   }
 }

--- a/packages/shared-core/package.json
+++ b/packages/shared-core/package.json
@@ -14,7 +14,7 @@
   "license": "GPL-3.0",
   "scripts": {
     "prebuild": "rimraf dist/",
-    "build": "node ../../scripts/build.js && tsc -p tsconfig.build.json --emitDeclarationOnly",
+    "build": "node ../../scripts/build.js && tsc -p tsconfig.build.json --emitDeclarationOnly --paths null",
     "build:dev": "yarn prebuild && tsc --build --watch --preserveWatchOutput",
     "dev:builder": "yarn prebuild && tsc -p tsconfig.json --watch --preserveWatchOutput",
     "check:types": "tsc -p tsconfig.json --noEmit --paths null"

--- a/packages/shared-core/package.json
+++ b/packages/shared-core/package.json
@@ -14,7 +14,7 @@
   "license": "GPL-3.0",
   "scripts": {
     "prebuild": "rimraf dist/",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "node ../../scripts/build.js && tsc -p tsconfig.build.json --emitDeclarationOnly",
     "build:dev": "yarn prebuild && tsc --build --watch --preserveWatchOutput",
     "dev:builder": "yarn prebuild && tsc -p tsconfig.json --watch --preserveWatchOutput",
     "check:types": "tsc -p tsconfig.json --noEmit --paths null"

--- a/packages/shared-core/tsconfig.build.json
+++ b/packages/shared-core/tsconfig.build.json
@@ -12,7 +12,10 @@
     "declaration": true,
     "types": ["node"],
     "outDir": "dist",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "paths": {
+      "@budibase/types": ["../../types/src"]
+    }
   },
   "include": ["**/*.js", "**/*.ts"],
   "exclude": [

--- a/packages/shared-core/tsconfig.build.json
+++ b/packages/shared-core/tsconfig.build.json
@@ -14,7 +14,7 @@
     "outDir": "dist",
     "skipLibCheck": true,
     "paths": {
-      "@budibase/types": ["../../types/src"]
+      "@budibase/types": ["../types/src"]
     }
   },
   "include": ["**/*.js", "**/*.ts"],

--- a/packages/shared-core/tsconfig.json
+++ b/packages/shared-core/tsconfig.json
@@ -1,13 +1,4 @@
 {
   "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "rootDir": "./src",
-    "composite": true,
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
-    "paths": {
-      "@budibase/types": ["../../types/src"]
-    }
-  },
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -14,7 +14,7 @@
   "license": "GPL-3.0",
   "scripts": {
     "prebuild": "rimraf dist/",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "node ../../scripts/build.js && tsc -p tsconfig.build.json --emitDeclarationOnly",
     "build:dev": "yarn prebuild && tsc --build --watch --preserveWatchOutput",
     "dev:builder": "yarn prebuild && tsc -p tsconfig.json --watch --preserveWatchOutput",
     "check:types": "tsc -p tsconfig.json --noEmit --paths null"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -59,8 +59,6 @@ function runBuild(entry, outfile) {
     ],
   }
 
-  const { compilerOptions } = tsconfigPathPluginContent
-
   build({
     ...sharedConfig,
     platform: "node",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -60,15 +60,10 @@ function runBuild(entry, outfile) {
   }
 
   const { compilerOptions } = tsconfigPathPluginContent
-  const format =
-    compilerOptions.target === "es6" && compilerOptions.module !== "commonjs"
-      ? "esm"
-      : undefined
 
   build({
     ...sharedConfig,
     platform: "node",
-    format,
     outfile,
   }).then(result => {
     glob(`${process.cwd()}/src/**/*.hbs`, {}, (err, files) => {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -59,9 +59,16 @@ function runBuild(entry, outfile) {
     ],
   }
 
+  const { compilerOptions } = tsconfigPathPluginContent
+  const format =
+    compilerOptions.target === "es6" && compilerOptions.module !== "commonjs"
+      ? "esm"
+      : undefined
+
   build({
     ...sharedConfig,
     platform: "node",
+    format,
     outfile,
   }).then(result => {
     glob(`${process.cwd()}/src/**/*.hbs`, {}, (err, files) => {


### PR DESCRIPTION
## Description
Changing the way we build `backend-core`, `shared-core` and `types` to use esbuild with all the bundled dependencies.
Also changing the builder to consume directly `shared-core` and `types` as a module, so it does not need to be compiled in any specific way.

We are building all the packages as cjs, so any external consumer should be able to run it. The changes in the builder will allow us to build using the packages' source code instead of the built version.

Tested scenarios:
1. Build all from a clean install ✅
2. Run dev from a clean install ✅
3. Run dev via docker from a clean install ✅