### PR TITLE
Handle NPM pkg released content

### DIFF
--- a/packages/backend-core/.npmignore
+++ b/packages/backend-core/.npmignore
@@ -1,7 +1,4 @@
-node_modules/
-tsconfig.build.json
-tsconfig.json
-jest.config.ts
-jest-testcontainers-config.js
-__mocks__
-scripts
+*
+!dist/*
+dist/tsconfig.build.tsbuildinfo
+!package.json

--- a/packages/backend-core/.npmignore
+++ b/packages/backend-core/.npmignore
@@ -1,4 +1,4 @@
 *
-!dist/*
+!dist/**/*
 dist/tsconfig.build.tsbuildinfo
 !package.json

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -88,5 +88,20 @@
     "ts-node": "10.8.1",
     "tsconfig-paths": "4.0.0",
     "typescript": "4.7.3"
+  },
+  "nx": {
+    "targets": {
+      "build": {
+        "dependsOn": [
+          {
+            "projects": [
+              "@budibase/shared-core",
+              "@budibase/types"
+            ],
+            "target": "build"
+          }
+        ]
+      }
+    }
   }
 }

--- a/packages/shared-core/.npmignore
+++ b/packages/shared-core/.npmignore
@@ -2,4 +2,3 @@
 !dist/*
 dist/tsconfig.build.tsbuildinfo
 !package.json
-!LICENCE

--- a/packages/shared-core/.npmignore
+++ b/packages/shared-core/.npmignore
@@ -1,4 +1,4 @@
 *
-!dist/*
+!dist/**/*
 dist/tsconfig.build.tsbuildinfo
 !package.json

--- a/packages/shared-core/.npmignore
+++ b/packages/shared-core/.npmignore
@@ -1,3 +1,5 @@
-node_modules/
-tsconfig.build.json
-tsconfig.json
+*
+!dist/*
+dist/tsconfig.build.tsbuildinfo
+!package.json
+!LICENCE

--- a/packages/shared-core/package.json
+++ b/packages/shared-core/package.json
@@ -20,5 +20,19 @@
     "concurrently": "^7.6.0",
     "rimraf": "3.0.2",
     "typescript": "4.7.3"
+  },
+  "nx": {
+    "targets": {
+      "build": {
+        "dependsOn": [
+          {
+            "projects": [
+              "@budibase/types"
+            ],
+            "target": "build"
+          }
+        ]
+      }
+    }
   }
 }

--- a/packages/shared-core/package.json
+++ b/packages/shared-core/package.json
@@ -2,14 +2,8 @@
   "name": "@budibase/shared-core",
   "version": "0.0.0",
   "description": "Shared data utils",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./src/index.ts"
-    }
-  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "author": "Budibase",
   "license": "GPL-3.0",
   "scripts": {

--- a/packages/types/.npmignore
+++ b/packages/types/.npmignore
@@ -2,4 +2,3 @@
 !dist/*
 dist/tsconfig.build.tsbuildinfo
 !package.json
-!LICENCE

--- a/packages/types/.npmignore
+++ b/packages/types/.npmignore
@@ -1,0 +1,5 @@
+*
+!dist/*
+dist/tsconfig.build.tsbuildinfo
+!package.json
+!LICENCE

--- a/packages/types/.npmignore
+++ b/packages/types/.npmignore
@@ -1,4 +1,4 @@
 *
-!dist/*
+!dist/**/*
 dist/tsconfig.build.tsbuildinfo
 !package.json

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,14 +2,8 @@
   "name": "@budibase/types",
   "version": "0.0.0",
   "description": "Budibase types",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./src/index.ts"
-    }
-  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "author": "Budibase",
   "license": "GPL-3.0",
   "scripts": {


### PR DESCRIPTION
## Description
Adjusting package.json and .npmignore to contain the required content for types, backend-core and shared-core.

Because the changes in package.json we need to add some nx dependencies in order to not change the tsc configuration

### Types content
<img width="519" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/af769893-4cc4-4c80-a604-6bc6a123e902">
<img width="485" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/7b3315b8-4a2a-4d50-b9ca-6523b73e3ee5">


### Shared-core content
<img width="577" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/df719b43-f489-45d8-9082-ff53821bae4b">

### Backend-core content
<img width="582" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/5a7a2264-727a-41db-912f-1762180eccee">

<img width="515" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/0f5dcd25-f189-43e6-9cb1-f5e1deada1b4">
