### PR TITLE
Shared-core dev:builder - rebuild as part of watch correctly

### DIFF
--- a/packages/shared-core/package.json
+++ b/packages/shared-core/package.json
@@ -32,7 +32,18 @@
             "target": "build"
           }
         ]
+      },
+      "dev:builder": {
+        "dependsOn": [
+          {
+            "projects": [
+              "@budibase/types"
+            ],
+            "target": "build"
+          }
+        ]
       }
+
     }
   }
 }

--- a/packages/shared-core/tsconfig.build.json
+++ b/packages/shared-core/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "moduleResolution": "node",
+    "module": "commonjs",
     "lib": ["es2020"],
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
## Description
Getting shared-core to build consistently as part of the yarn dev command.