### PR TITLE
Fix build issue with integration tests when running on forks

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -194,7 +194,8 @@ jobs:
           node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
-      - run: yarn build --scope @budibase/server --scope @budibase/worker --scope @budibase/client
+      - name: Build packages
+        run: yarn build --scope @budibase/server --scope @budibase/worker --scope @budibase/client --scope @budibase/backend-core
       - name: Run tests
         run: |
           cd qa-core


### PR DESCRIPTION
## Description
Building backend-core on action to allow integration tests to run on forks

Failing pipeline: https://github.com/Budibase/budibase/actions/runs/5925034809/job/16063672834?pr=11566