### PR TITLE
Fix for FireFox mirrored table column sort

### DIFF
--- a/packages/bbui/src/Table/Table.svelte
+++ b/packages/bbui/src/Table/Table.svelte
@@ -215,7 +215,7 @@
         const nameA = getDisplayName(a)
         const nameB = getDisplayName(b)
         if (orderA !== orderB) {
-          return orderA < orderB ? orderA : orderB
+          return orderA < orderB ? a : b
         }
         return nameA < nameB ? a : b
       })


### PR DESCRIPTION
## Description
The sort was returning the number instead of the object. Interesting that this worked for Chrome, but with the update now works for both Chrome and Firefox.

Addresses: 
- https://github.com/Budibase/budibase/issues/10689

## Screenshots
<img width="869" alt="Screenshot 2023-08-21 at 12 11 01" src="https://github.com/Budibase/budibase/assets/101575380/dff26872-e89e-476b-b556-b29df70cb238">

*Firefox*
<img width="1298" alt="Screenshot 2023-08-21 at 12 11 25" src="https://github.com/Budibase/budibase/assets/101575380/351a4362-65c0-4ed7-af3b-82252638242d">
