### PR TITLE
Fix for error seen when creating blank screen

### DIFF
--- a/packages/builder/src/builderStore/store/screenTemplates/rowListScreen.js
+++ b/packages/builder/src/builderStore/store/screenTemplates/rowListScreen.js
@@ -3,6 +3,9 @@ import { Screen } from "./utils/Screen"
 import { Component } from "./utils/Component"
 
 export default function (datasources) {
+  if (!Array.isArray(datasources)) {
+    return []
+  }
   return datasources.map(datasource => {
     return {
       name: `${datasource.name} - List`,

--- a/packages/builder/src/pages/builder/app/[application]/design/_components/NewScreen/CreateScreenModal.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/_components/NewScreen/CreateScreenModal.svelte
@@ -110,7 +110,7 @@
     if (mode === "table") {
       datasourceModal.show()
     } else if (mode === "blank") {
-      let templates = getTemplates($store, $tables.list)
+      let templates = getTemplates($tables.list)
       const blankScreenTemplate = templates.find(
         t => t.id === "createFromScratch"
       )


### PR DESCRIPTION
## Description

The list of datasources wasn't being passed to the create modal as expected, causing an error.

Removed the $store value from the `getTemplates` call and added some error handling.



