### PR TITLE
Use permission sdk on middleware

### DIFF
--- a/packages/backend-core/src/db/db.ts
+++ b/packages/backend-core/src/db/db.ts
@@ -11,7 +11,11 @@ export function getDB(dbName?: string, opts?: any): Database {
 // we have to use a callback for this so that we can close
 // the DB when we're done, without this manual requests would
 // need to close the database when done with it to avoid memory leaks
-export async function doWithDB(dbName: string, cb: any, opts = {}) {
+export async function doWithDB<T>(
+  dbName: string,
+  cb: (db: Database) => Promise<T>,
+  opts = {}
+) {
   const db = getDB(dbName, opts)
   // need this to be async so that we can correctly close DB after all
   // async operations have been completed

--- a/packages/backend-core/src/security/roles.ts
+++ b/packages/backend-core/src/security/roles.ts
@@ -253,7 +253,7 @@ export function checkForRoleResourceArray(
  * Given an app ID this will retrieve all of the roles that are currently within that app.
  * @return {Promise<object[]>} An array of the role objects that were found.
  */
-export async function getAllRoles(appId?: string) {
+export async function getAllRoles(appId?: string): Promise<RoleDoc[]> {
   if (appId) {
     return doWithDB(appId, internal)
   } else {

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -1,11 +1,12 @@
 import tk from "timekeeper"
 import { outputProcessing } from "../../../utilities/rowProcessor"
 import * as setup from "./utilities"
-import { context, tenancy } from "@budibase/backend-core"
+import { context, roles, tenancy } from "@budibase/backend-core"
 import { quotas } from "@budibase/pro"
 import {
   FieldType,
   MonthlyQuotaName,
+  PermissionLevel,
   QuotaUsageType,
   Row,
   SortOrder,
@@ -16,6 +17,7 @@ import {
 import {
   expectAnyInternalColsAttributes,
   generator,
+  mocks,
   structures,
 } from "@budibase/backend-core/tests"
 
@@ -37,6 +39,7 @@ describe("/rows", () => {
   })
 
   beforeEach(async () => {
+    mocks.licenses.useCloudFree()
     table = await config.createTable()
     row = basicRow(table._id!)
   })
@@ -1312,6 +1315,85 @@ describe("/rows", () => {
           totalRows: 10,
           hasNextPage: false,
           bookmark: expect.any(String),
+        })
+      })
+
+      describe("permissions", () => {
+        let viewId: string
+        let tableId: string
+
+        beforeAll(async () => {
+          const table = await config.createTable(userTable())
+          const rows = []
+          for (let i = 0; i < 10; i++) {
+            rows.push(await config.createRow({ tableId: table._id }))
+          }
+
+          const createViewResponse = await config.api.viewV2.create()
+
+          tableId = table._id!
+          viewId = createViewResponse.id
+        })
+
+        beforeEach(() => {
+          mocks.licenses.useViewPermissions()
+        })
+
+        it("does not allow public users to fetch by default", async () => {
+          await config.publish()
+          await config.api.viewV2.search(viewId, undefined, {
+            expectStatus: 403,
+            usePublicUser: true,
+          })
+        })
+
+        it("allow public users to fetch when permissions are explicit", async () => {
+          await config.api.permission.set({
+            roleId: roles.BUILTIN_ROLE_IDS.PUBLIC,
+            level: PermissionLevel.READ,
+            resourceId: viewId,
+          })
+          await config.publish()
+
+          const response = await config.api.viewV2.search(viewId, undefined, {
+            usePublicUser: true,
+          })
+
+          expect(response.body.rows).toHaveLength(10)
+        })
+
+        it("allow public users to fetch when permissions are inherited", async () => {
+          await config.api.permission.set({
+            roleId: roles.BUILTIN_ROLE_IDS.PUBLIC,
+            level: PermissionLevel.READ,
+            resourceId: tableId,
+          })
+          await config.publish()
+
+          const response = await config.api.viewV2.search(viewId, undefined, {
+            usePublicUser: true,
+          })
+
+          expect(response.body.rows).toHaveLength(10)
+        })
+
+        it("respects inherited permissions, not allowing not public views from public tables", async () => {
+          await config.api.permission.set({
+            roleId: roles.BUILTIN_ROLE_IDS.PUBLIC,
+            level: PermissionLevel.READ,
+            resourceId: tableId,
+          })
+          await config.api.permission.set({
+            roleId: roles.BUILTIN_ROLE_IDS.POWER,
+            level: PermissionLevel.READ,
+            resourceId: viewId,
+          })
+          await config.publish()
+
+          await config.api.viewV2.search(viewId, undefined, {
+            usePublicUser: true,
+            expectStatus: 403,
+          })
         })
       })
     })

--- a/packages/server/src/sdk/app/backups/exports.ts
+++ b/packages/server/src/sdk/app/backups/exports.ts
@@ -60,7 +60,7 @@ function tarFilesToTmp(tmpDir: string, files: string[]) {
 export async function exportDB(
   dbName: string,
   opts: DBDumpOpts = {}
-): Promise<DBDumpOpts> {
+): Promise<string> {
   const exportOpts = {
     filter: opts?.filter,
     batch_size: 1000,


### PR DESCRIPTION
## Description
Change middleware to use permission SDK in order to unify logic around permissions, such as inheritance.
Doing so, the permissions endpoint and the auth middleware will be always align on its business logic

Addresses: 
- [BUDI-7393
](https://linear.app/budibase/issue/BUDI-7393/commercial-updates-views)