### PR TITLE
ensure secrets are not replaced on every helm run

### DIFF
--- a/charts/budibase/templates/secrets.yaml
+++ b/charts/budibase/templates/secrets.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.globals.createSecrets -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (include "budibase.fullname" .) }}
+{{- if .Values.globals.createSecrets }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,8 +11,15 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
+  {{- if $existingSecret }}
+  internalApiKey: {{ index $existingSecret.data "internalApiKey" }}
+  jwtSecret: {{ index $existingSecret.data "jwtSecret" }}
+  objectStoreAccess: {{ index $existingSecret.data "objectStoreAccess" }}
+  objectStoreSecret: {{ index $existingSecret.data "objectStoreSecret" }}
+  {{- else }}
   internalApiKey: {{ template "budibase.defaultsecret" .Values.globals.internalApiKey }}
   jwtSecret: {{ template "budibase.defaultsecret" .Values.globals.jwtSecret }}
   objectStoreAccess: {{ template "budibase.defaultsecret" .Values.services.objectStore.accessKey }}
   objectStoreSecret: {{ template "budibase.defaultsecret" .Values.services.objectStore.secretKey }}
-{{- end -}}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
## Description
Fix for https://github.com/Budibase/budibase/pull/11594

- Prevent the helm chart from updating it's own secrets on upgrade, which leaves the real secrets out of sync with what's in helm
- Reported by a customer


