### PR TITLE
Fix for datasource reset on formblock. Added 'resetOn' behaviour to the component manifest

### DIFF
--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -1250,9 +1250,7 @@ export const getFrontendStore = () => {
             setting => name === setting.resetOn
           )
           resetFields?.forEach(setting => {
-            if (component[setting.key]) {
-              component[setting.key] = null
-            }
+            component[setting.key] = null
           })
 
           if (

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -1250,7 +1250,6 @@ export const getFrontendStore = () => {
             setting => name === setting.resetOn
           )
           resetFields?.forEach(setting => {
-            console.log(setting.key, component)
             if (component[setting.key]) {
               component[setting.key] = null
             }

--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -1246,6 +1246,16 @@ export const getFrontendStore = () => {
           const settings = getComponentSettings(component._component)
           const updatedSetting = settings.find(setting => setting.key === name)
 
+          const resetFields = settings.filter(
+            setting => name === setting.resetOn
+          )
+          resetFields?.forEach(setting => {
+            console.log(setting.key, component)
+            if (component[setting.key]) {
+              component[setting.key] = null
+            }
+          })
+
           if (
             updatedSetting?.type === "dataSource" ||
             updatedSetting?.type === "table"

--- a/packages/builder/src/components/design/settings/controls/FieldConfiguration/FieldConfiguration.svelte
+++ b/packages/builder/src/components/design/settings/controls/FieldConfiguration/FieldConfiguration.svelte
@@ -34,9 +34,10 @@
   }
 
   $: datasource = getDatasourceForProvider($currentAsset, componentInstance)
+  $: resourceId = datasource.resourceId || datasource.tableId
 
-  $: if (!isEqual(value, cachedValue)) {
-    cachedValue = value
+  $: if (!isEqual(value, cachedValue) || resourceId) {
+    cachedValue = cloneDeep(value)
     schema = getSchema($currentAsset, datasource)
   }
 

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -4745,7 +4745,8 @@
             "dependsOn": {
               "setting": "clickBehaviour",
               "value": "details"
-            }
+            },
+            "resetOn": "dataSource"
           },
           {
             "label": "Save button",
@@ -5397,6 +5398,7 @@
             "type": "fieldConfiguration",
             "key": "fields",
             "nested": true,
+            "resetOn": "dataSource",
             "selectAllFields": true
           },
           {

--- a/packages/client/src/components/app/blocks/TableBlock.svelte
+++ b/packages/client/src/components/app/blocks/TableBlock.svelte
@@ -275,7 +275,7 @@
               dataSource,
               showSaveButton: true,
               showDeleteButton: false,
-              saveButtonLabel: sidePanelSaveLabel,
+              saveButtonLabel: sidePanelSaveLabel || "Save", //always show
               actionType: "Create",
               fields: sidePanelFields || normalFields,
               title: "Create Row",

--- a/packages/client/src/components/app/blocks/form/InnerFormBlock.svelte
+++ b/packages/client/src/components/app/blocks/form/InnerFormBlock.svelte
@@ -211,17 +211,19 @@
           {/if}
         </BlockComponent>
       {/if}
-      <BlockComponent type="fieldgroup" props={{ labelPosition }} order={1}>
-        {#each fields as field, idx}
-          {#if getComponentForField(field) && field.active}
-            <BlockComponent
-              type={getComponentForField(field)}
-              props={getPropsForField(field)}
-              order={idx}
-            />
-          {/if}
-        {/each}
-      </BlockComponent>
+      {#key fields}
+        <BlockComponent type="fieldgroup" props={{ labelPosition }} order={1}>
+          {#each fields as field, idx}
+            {#if getComponentForField(field) && field.active}
+              <BlockComponent
+                type={getComponentForField(field)}
+                props={getPropsForField(field)}
+                order={idx}
+              />
+            {/if}
+          {/each}
+        </BlockComponent>
+      {/key}
     </BlockComponent>
   </BlockComponent>
 {:else}


### PR DESCRIPTION
## Description

Fixes for FormBlock issues:
- Field configuration correctly updates available fields in the component settings panel when switching between data sources.
- Existing field configuration is now cleared after switching datasources
- Missing save button on TableBlock create new row form.

Update: 
- Added a `resetOn` property to the component manifest. The property takes the string name of another property in the component definition. When executing an update, any configured `resetOn` values will be cleared.
- The `resetOn` property also ensures reactive changes to the config create a single entry to the builder undo/redo history.

