### PR TITLE
Publish src code in the npm package

### DIFF
--- a/packages/backend-core/.npmignore
+++ b/packages/backend-core/.npmignore
@@ -2,3 +2,5 @@
 !dist/**/*
 dist/tsconfig.build.tsbuildinfo
 !package.json
+!src/**
+!tests/**

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -4,13 +4,6 @@
   "description": "Budibase backend core libraries used in server and worker",
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "tests": [
-        "./dist/tests/index.d.ts"
-      ]
-    }
-  },
   "exports": {
     ".": "./dist/index.js",
     "./tests": "./dist/tests/index.js",


### PR DESCRIPTION
## Description
Revert code around test typing in backend-core to support account-portal. These changes add back the src and the tests folder, that is used in jest when used as an npm dependency