### PR TITLE
Remove prebuild from dev:builder watchers

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "kill-builder": "kill-port 3000",
     "kill-server": "kill-port 4001 4002",
     "kill-all": "yarn run kill-builder && yarn run kill-server",
-    "dev": "yarn run kill-all && lerna run --stream dev:builder",
+    "dev": "yarn run kill-all && lerna run --parallel prebuild && lerna run --stream dev:builder",
     "dev:noserver": "yarn run kill-builder && lerna run --stream dev:stack:up && lerna run --stream dev:builder --ignore @budibase/backend-core --ignore @budibase/server --ignore @budibase/worker",
     "dev:server": "yarn run kill-server && lerna run --stream dev:builder --scope @budibase/worker --scope @budibase/server",
     "dev:built": "yarn run kill-all && cd packages/server && yarn dev:stack:up && cd ../../ && lerna run --stream dev:built",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,7 +26,7 @@
     "dev:stack:up": "node scripts/dev/manage.js up",
     "dev:stack:down": "node scripts/dev/manage.js down",
     "dev:stack:nuke": "node scripts/dev/manage.js nuke",
-    "dev:builder": "yarn run dev:stack:up && rimraf dist/ && nodemon",
+    "dev:builder": "yarn run dev:stack:up && nodemon",
     "dev:built": "yarn run dev:stack:up && yarn run run:docker",
     "specs": "ts-node specs/generate.ts && openapi-typescript specs/openapi.yaml --output src/definitions/openapi.ts",
     "initialise": "node scripts/initialise.js",

--- a/packages/shared-core/package.json
+++ b/packages/shared-core/package.json
@@ -10,7 +10,7 @@
     "prebuild": "rimraf dist/",
     "build": "node ../../scripts/build.js && tsc -p tsconfig.build.json --emitDeclarationOnly --paths null",
     "build:dev": "yarn prebuild && tsc --build --watch --preserveWatchOutput",
-    "dev:builder": "yarn prebuild && tsc -p tsconfig.json --watch --preserveWatchOutput",
+    "dev:builder": "tsc -p tsconfig.json --watch --preserveWatchOutput",
     "check:types": "tsc -p tsconfig.json --noEmit --paths null"
   },
   "dependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -10,7 +10,7 @@
     "prebuild": "rimraf dist/",
     "build": "node ../../scripts/build.js && tsc -p tsconfig.build.json --emitDeclarationOnly",
     "build:dev": "yarn prebuild && tsc --build --watch --preserveWatchOutput",
-    "dev:builder": "yarn prebuild && tsc -p tsconfig.json --watch --preserveWatchOutput",
+    "dev:builder": "tsc -p tsconfig.json --watch --preserveWatchOutput",
     "check:types": "tsc -p tsconfig.json --noEmit --paths null"
   },
   "jest": {},

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -22,7 +22,7 @@
     "predocker": "yarn build && cp ../../yarn.lock ./dist/",
     "build:docker": "yarn predocker && docker build . -t worker-service --label version=$BUDIBASE_RELEASE_VERSION",
     "dev:stack:init": "node ./scripts/dev/manage.js init",
-    "dev:builder": "npm run dev:stack:init && rimraf dist/ && nodemon",
+    "dev:builder": "npm run dev:stack:init && nodemon",
     "dev:built": "yarn run dev:stack:init && yarn run run:docker",
     "test": "bash scripts/test.sh",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Description
Updating the yarn dev process to not include a removal of the dist directory as part of the streamed watchers - this seems to create a problem for shared core and moving this up a level to a parallel run before the watchers massively improves stability.