### PR TITLE
Quick automation CRON test fix

### DIFF
--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -102,7 +102,7 @@ class Orchestrator {
   }
 
   cleanupTriggerOutputs(stepId: string, triggerOutput: TriggerOutput) {
-    if (stepId === CRON_STEP_ID) {
+    if (stepId === CRON_STEP_ID && !triggerOutput.timestamp) {
       triggerOutput.timestamp = Date.now()
     }
     return triggerOutput


### PR DESCRIPTION
## Description
As per https://linear.app/budibase/issue/BUDI-7447/finish-and-test-automation-for-cron-trigger-ignores-test-timestamp - automation CRONs didn't allow use of the input timestamp, which wasn't helpful for testing automations.
