### PR TITLE
Hotfix - Plugin dist in backendcore

### DIFF
--- a/packages/backend-core/scripts/build.js
+++ b/packages/backend-core/scripts/build.js
@@ -1,4 +1,5 @@
 #!/usr/bin/node
 const coreBuild = require("../../../scripts/build")
 
+coreBuild("./src/plugin/index.ts", "./dist/plugins.js")
 coreBuild("./src/index.ts", "./dist/index.js")


### PR DESCRIPTION
## Description
Add missing plugins.js back to backend-core npm package
![image](https://github.com/Budibase/budibase/assets/15987277/7b665d3b-0188-49b3-a70d-f050a07bda8a)
