### PR TITLE
Fix #11353

### DIFF
--- a/packages/builder/src/pages/builder/portal/settings/version.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/version.svelte
@@ -63,8 +63,7 @@
       )
       const githubResponse = await githubCheck.json()
 
-      //Get tag and remove the v infront of the tage name e.g. v1.0.0 is 1.0.0
-      githubVersion = githubResponse.tag_name.slice(1)
+      githubVersion = githubResponse.tag_name
 
       //Get the release date and output it in the local time format
       githubPublishedDate = new Date(githubResponse.published_at)


### PR DESCRIPTION
## Description
Removes the slice as the v prefix has been removed

Addresses: 
#11353 

## Screenshots
![image](https://github.com/Budibase/budibase/assets/97764630/8cc1a441-b79e-4cdc-8559-743b3424e8e9)

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



