### PR TITLE
Fixed typo of label for number type column.

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -523,7 +523,7 @@
   {:else if editableColumn.type === "number" && !editableColumn.autocolumn}
     <div class="split-label">
       <div class="label-length">
-        <Label size="M">Max Value</Label>
+        <Label size="M">Min Value</Label>
       </div>
       <div class="input-length">
         <Input


### PR DESCRIPTION
## Description
Fixed label typo for number type column on column create + edit.

**Before**
![image](https://github.com/Budibase/budibase/assets/126772285/830a3e50-c24b-4e12-a050-0d9e8f33bccd)

**After**
<img width="343" alt="Screenshot 2023-09-11 at 07 55 31" src="https://github.com/Budibase/budibase/assets/126772285/691f27df-1a89-4c2b-8693-326f6412384e">