### PR TITLE
Fixes for view permissions not being enabled

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/ManageAccessModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/ManageAccessModal.svelte
@@ -1,6 +1,7 @@
 <script>
   import { PermissionSource } from "@budibase/types"
   import { roles, permissions as permissionsStore } from "stores/backend"
+  import { licensing } from "stores/portal"
   import {
     Label,
     Input,
@@ -19,6 +20,7 @@
   export let permissions
 
   const inheritedRoleId = "inherited"
+  $: brandingEnabled = $licensing.isViewPermissionsEnabled
 
   async function changePermission(level, role) {
     try {
@@ -111,7 +113,7 @@
     {#each Object.keys(computedPermissions) as level}
       <Input value={capitalise(level)} disabled />
       <Select
-        disabled={requiresPlanToModify}
+        disabled={!brandingEnabled}
         placeholder={false}
         value={computedPermissions[level].selectedValue}
         on:change={e => changePermission(level, e.detail)}

--- a/packages/builder/src/components/backend/DataTable/modals/ManageAccessModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/ManageAccessModal.svelte
@@ -97,15 +97,18 @@
 
 <ModalContent showCancelButton={false} confirmText="Done">
   <span slot="header">
-    Manage Access
-    {#if requiresPlanToModify}
-      <span class="lock-tag">
-        <Tags>
-          <Tag icon="LockClosed">{capitalise(requiresPlanToModify)}</Tag>
-        </Tags>
-      </span>
-    {/if}
+    <div class="access-header">
+      Manage Access
+      {#if requiresPlanToModify}
+        <span class="lock-tag">
+          <Tags>
+            <Tag icon="LockClosed">{capitalise(requiresPlanToModify)}</Tag>
+          </Tags>
+        </span>
+      {/if}
+    </div>
   </span>
+
   <Body size="S">Specify the minimum access level role for this data.</Body>
   <div class="row">
     <Label extraSmall grey>Level</Label>
@@ -149,6 +152,12 @@
 
   .inheriting-resources {
     display: flex;
+    gap: var(--spacing-s);
+  }
+
+  .access-header {
+    display: flex;
+    align-items: center;
     gap: var(--spacing-s);
   }
 </style>

--- a/packages/server/src/sdk/app/permissions/index.ts
+++ b/packages/server/src/sdk/app/permissions/index.ts
@@ -61,11 +61,7 @@ export async function getInheritablePermissions(
 export async function allowsExplicitPermissions(resourceId: string) {
   if (isViewID(resourceId)) {
     const allowed = await features.isViewPermissionEnabled()
-    const minPlan = !allowed
-      ? env.SELF_HOSTED
-        ? PlanType.BUSINESS
-        : PlanType.PREMIUM
-      : undefined
+    const minPlan = !allowed ? PlanType.BUSINESS : undefined
 
     return {
       allowed,


### PR DESCRIPTION
## Description
Fixes 3 issues

- Ability to change permissions on a view was disabled as we weren't checking the license
- Remove discrepancy in self host / cloud for minimum plan. Business plan only. 
- Adds a class to align the header

