### PR TITLE
Postgres sql invalid time value error when saving json as text

### DIFF
--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -58,7 +58,7 @@ function parse(input: any) {
     return null
   }
   if (isIsoDateString(input)) {
-    return new Date(input)
+    return new Date(input.trim())
   }
   return input
 }

--- a/packages/server/src/integrations/tests/sql.spec.ts
+++ b/packages/server/src/integrations/tests/sql.spec.ts
@@ -669,4 +669,17 @@ describe("SQL query builder", () => {
       sql: `insert into \"test\" (\"name\") values ($1) returning *`,
     })
   })
+
+  it("should parse and trim valid string as Date", () => {
+    const dateObj = new Date("2023-09-09T03:21:06.024Z")
+    let query = new Sql(SqlClient.POSTGRES, limit)._query(
+      generateCreateJson(TABLE_NAME, {
+        name: " 2023-09-09T03:21:06.024Z ",
+      })
+    )
+    expect(query).toEqual({
+      bindings: [dateObj],
+      sql: `insert into \"test\" (\"name\") values ($1) returning *`,
+    })
+  })
 })

--- a/packages/server/src/integrations/tests/sql.spec.ts
+++ b/packages/server/src/integrations/tests/sql.spec.ts
@@ -657,4 +657,16 @@ describe("SQL query builder", () => {
       sql: `select * from (select top (@p0) * from [test] order by [test].[id] asc) as [test]`,
     })
   })
+
+  it("should not parse JSON string as Date", () => {
+    let query = new Sql(SqlClient.POSTGRES, limit)._query(
+      generateCreateJson(TABLE_NAME, {
+        name: '{ "created_at":"2023-09-09T03:21:06.024Z" }',
+      })
+    )
+    expect(query).toEqual({
+      bindings: ['{ "created_at":"2023-09-09T03:21:06.024Z" }'],
+      sql: `insert into \"test\" (\"name\") values ($1) returning *`,
+    })
+  })
 })

--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -182,7 +182,7 @@ export function getSqlQuery(query: SqlQuery | string): SqlQuery {
 export const isSQL = helpers.isSQL
 
 export function isIsoDateString(str: string) {
-  if (!/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(str)) {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/.test(str.trim())) {
     return false
   }
   let d = new Date(str)

--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -182,11 +182,12 @@ export function getSqlQuery(query: SqlQuery | string): SqlQuery {
 export const isSQL = helpers.isSQL
 
 export function isIsoDateString(str: string) {
-  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/.test(str.trim())) {
+  const trimmedValue = str.trim()
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/.test(trimmedValue)) {
     return false
   }
-  let d = new Date(str)
-  return d.toISOString() === str
+  let d = new Date(trimmedValue)
+  return d.toISOString() === trimmedValue
 }
 
 /**


### PR DESCRIPTION
## Description
Fix and unit tests for bad regex validation

Addresses: 
- https://linear.app/budibase/issue/BUDI-7476/postgres-sql-invalid-time-value-error-when-saving-json-as-text




