### PR TITLE
Fix/qa core pg

### DIFF
--- a/qa-core/src/integrations/external-schema/postgres.integration.spec.ts
+++ b/qa-core/src/integrations/external-schema/postgres.integration.spec.ts
@@ -18,7 +18,7 @@ describe("getExternalSchema", () => {
 
     beforeAll(async () => {
       // This is left on propose without a tag, so if a new version introduces a breaking change we will be notified
-      const container = await new GenericContainer("postgres")
+      const container = await new GenericContainer("postgres:13.12")
         .withExposedPorts(5432)
         .withEnv("POSTGRES_PASSWORD", "password")
         .start()

--- a/qa-core/src/integrations/external-schema/postgres.integration.spec.ts
+++ b/qa-core/src/integrations/external-schema/postgres.integration.spec.ts
@@ -17,7 +17,6 @@ describe("getExternalSchema", () => {
     }
 
     beforeAll(async () => {
-      // This is left on propose without a tag, so if a new version introduces a breaking change we will be notified
       const container = await new GenericContainer("postgres:13.12")
         .withExposedPorts(5432)
         .withEnv("POSTGRES_PASSWORD", "password")


### PR DESCRIPTION
## Description
QA core integration tests are failing because the pg_dump version on the host is not compatible with the latest version of postgres being pulled by testcontainers. Added the tag to pin it so QA core tests can get back up and running