### PR TITLE
Budi 7481 initial form step binding drawer can crash

### DIFF
--- a/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
+++ b/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
@@ -235,7 +235,7 @@
     const baseExtensions = buildBaseExtensions()
 
     editor = new EditorView({
-      doc: value,
+      doc: value?.toString(),
       extensions: buildExtensions(baseExtensions),
       parent: textarea,
     })

--- a/packages/client/src/components/app/forms/S3Upload.svelte
+++ b/packages/client/src/components/app/forms/S3Upload.svelte
@@ -17,6 +17,13 @@
   let fieldApi
   let localFiles = []
 
+  $: {
+    // If the field state is reset, clear the local files
+    if (!fieldState?.value?.length) {
+      localFiles = []
+    }
+  }
+
   const { API, notificationStore, uploadStore } = getContext("sdk")
   const component = getContext("component")
 


### PR DESCRIPTION
## Description
 - Fix to ensure a string is passed into the new EditorView
 - Fix to allow the S3 Upload Field to be cleared

Addresses: 
- https://linear.app/budibase/issue/BUDI-7481/initial-form-step-binding-drawer-can-crash




