### PR TITLE
Add user column type to internal tables

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -20,6 +20,7 @@
   import { TableNames, UNEDITABLE_USER_FIELDS } from "constants"
   import {
     FIELDS,
+    DEV_FIELDS,
     RelationshipType,
     ALLOWABLE_STRING_OPTIONS,
     ALLOWABLE_NUMBER_OPTIONS,
@@ -34,6 +35,7 @@
   import { getBindings } from "components/backend/DataTable/formula"
   import JSONSchemaModal from "./JSONSchemaModal.svelte"
   import { ValidColumnNameRegex } from "@budibase/shared-core"
+  import { admin } from "stores/portal"
 
   const AUTO_TYPE = "auto"
   const FORMULA_TYPE = FIELDS.FORMULA.type
@@ -68,6 +70,10 @@
     constraints: fieldDefinitions.STRING.constraints,
     // Initial value for column name in other table for linked records
     fieldName: $tables.selected.name,
+  }
+
+  if ($admin.isDev) {
+    fieldDefinitions = { ...fieldDefinitions, ...cloneDeep(DEV_FIELDS) }
   }
 
   $: if (primaryDisplay) {

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -66,7 +66,7 @@
   let jsonSchemaModal
   let allowedTypes = []
   let editableColumn = {
-    type: "string",
+    type: fieldDefinitions.STRING.type,
     constraints: fieldDefinitions.STRING.constraints,
     // Initial value for column name in other table for linked records
     fieldName: $tables.selected.name,

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -464,8 +464,6 @@
   onMount(() => {
     mounted = true
   })
-
-  $: console.log({ type: editableColumn.type, allowedTypes, typeMapping })
 </script>
 
 <Layout noPadding gap="S">

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -392,7 +392,6 @@
       if (!external || table.sql) {
         fields = [...fields, FIELDS.LINK, FIELDS.ARRAY]
       }
-      // fields = [...fields, ...Object.values(devFieldDefinitions)]
       return fields
     }
   }

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -74,28 +74,6 @@
 
   const typeMapping = {}
 
-  if ($admin.isDev) {
-    fieldDefinitions = {
-      ...fieldDefinitions,
-      ...Object.entries(DEV_FIELDS).reduce((p, [key, field]) => {
-        if (field.subtype) {
-          const composedType = `${field.type}_${field.subtype}`
-          p[key] = {
-            ...field,
-            type: composedType,
-          }
-          typeMapping[composedType] = {
-            type: field.type,
-            subtype: field.subtype,
-          }
-        } else {
-          p[key] = field
-        }
-        return p
-      }, {}),
-    }
-  }
-
   $: if (primaryDisplay) {
     editableColumn.constraints.presence = { allowEmpty: false }
   }
@@ -368,9 +346,35 @@
       ALLOWABLE_NUMBER_TYPES.indexOf(editableColumn.type) !== -1
     ) {
       return ALLOWABLE_NUMBER_OPTIONS
-    } else if (!external) {
+    }
+
+    let devFieldDefinitions = {}
+    if ($admin.isDev) {
+      devFieldDefinitions = Object.entries(DEV_FIELDS).reduce(
+        (p, [key, field]) => {
+          if (field.subtype) {
+            const composedType = `${field.type}_${field.subtype}`
+            p[key] = {
+              ...field,
+              type: composedType,
+            }
+            typeMapping[composedType] = {
+              type: field.type,
+              subtype: field.subtype,
+            }
+          } else {
+            p[key] = field
+          }
+          return p
+        },
+        {}
+      )
+    }
+
+    if (!external) {
       return [
         ...Object.values(fieldDefinitions),
+        ...Object.values(devFieldDefinitions),
         { name: "Auto Column", type: AUTO_TYPE },
       ]
     } else {

--- a/packages/builder/src/constants/backend/index.js
+++ b/packages/builder/src/constants/backend/index.js
@@ -120,9 +120,6 @@ export const FIELDS = {
       presence: false,
     },
   },
-}
-
-export const DEV_FIELDS = {
   USER: {
     name: "User",
     type: "internal",

--- a/packages/builder/src/constants/backend/index.js
+++ b/packages/builder/src/constants/backend/index.js
@@ -122,7 +122,7 @@ export const FIELDS = {
   },
   USER: {
     name: "User",
-    type: "internal",
+    type: "bb_reference",
     subtype: "user",
     icon: "User",
   },

--- a/packages/builder/src/constants/backend/index.js
+++ b/packages/builder/src/constants/backend/index.js
@@ -122,6 +122,15 @@ export const FIELDS = {
   },
 }
 
+export const DEV_FIELDS = {
+  USER: {
+    name: "User",
+    type: "internal",
+    subtype: "user",
+    icon: "User",
+  },
+}
+
 export const AUTO_COLUMN_SUB_TYPES = {
   AUTO_ID: "autoID",
   CREATED_BY: "createdBy",

--- a/packages/frontend-core/src/components/grid/lib/utils.js
+++ b/packages/frontend-core/src/components/grid/lib/utils.js
@@ -19,12 +19,21 @@ const TypeIconMap = {
   formula: "Calculator",
   json: "Brackets",
   bigint: "TagBold",
+  internal: {
+    user: "User",
+  },
 }
 
 export const getColumnIcon = column => {
   if (column.schema.autocolumn) {
     return "MagicWand"
   }
-  const type = column.schema.type
-  return TypeIconMap[type] || "Text"
+  const { type, subtype } = column.schema
+
+  const result =
+    typeof TypeIconMap[type] === "object" && subtype
+      ? TypeIconMap[type][subtype]
+      : TypeIconMap[type]
+
+  return result || "Text"
 }

--- a/packages/server/src/api/controllers/table/utils.ts
+++ b/packages/server/src/api/controllers/table/utils.ts
@@ -422,13 +422,11 @@ export function hasTypeChanged(table: Table, oldTable: Table | undefined) {
   if (!oldTable) {
     return false
   }
-  let key: any
-  let field: any
-  for ([key, field] of Object.entries(oldTable.schema)) {
-    const oldType = field.type
+  for (let [key, field] of Object.entries(oldTable.schema)) {
     if (!table.schema[key]) {
       continue
     }
+    const oldType = field.type
     const newType = table.schema[key].type
     if (oldType !== newType && !areSwitchableTypes(oldType, newType)) {
       return true

--- a/packages/types/src/documents/app/row.ts
+++ b/packages/types/src/documents/app/row.ts
@@ -16,6 +16,7 @@ export enum FieldType {
   INTERNAL = "internal",
   BARCODEQR = "barcodeqr",
   BIGINT = "bigint",
+  BB_REFERENCE = "bb_reference",
 }
 
 export interface RowAttachment {


### PR DESCRIPTION
## Description
Adding a new column type in internal tables for users. We will be building this as a subtype in the backend, so some refactoring was needed to handle this in the frontend.

The frontend is dummy, handling this field as a regular text field. The frontend will be handled in another PR, for this this field is only allowed for dev users

Addresses: 
- [BUDI-7455
](https://linear.app/budibase/issue/BUDI-7455/[users-column-type]-create-user-column-type)

## Screenshots
### Adding a new column
<img width="747" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/11783b1e-fa74-4ea4-a679-d673a3eecc87">

### Editing an existing column
<img width="704" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/e040ed51-b181-4b38-b204-c6c4b8ac3fb7">
