### PR TITLE
Persist refs ids as CSV

### DIFF
--- a/packages/backend-core/tests/core/utilities/structures/shared.ts
+++ b/packages/backend-core/tests/core/utilities/structures/shared.ts
@@ -1,12 +1,13 @@
 import { User } from "@budibase/types"
 import { generator } from "./generator"
 import { uuid } from "./common"
+import { tenant } from "."
 
 export const newEmail = () => {
   return `${uuid()}@test.com`
 }
 
-export const user = (userProps?: any): User => {
+export const user = (userProps?: Partial<User>): User => {
   return {
     email: newEmail(),
     password: "test",
@@ -14,6 +15,7 @@ export const user = (userProps?: any): User => {
     firstName: generator.first(),
     lastName: generator.last(),
     pictureUrl: "http://test.com",
+    tenantId: tenant.id(),
     ...userProps,
   }
 }

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -396,6 +396,9 @@
       if (!external || table.sql) {
         fields = [...fields, FIELDS.LINK, FIELDS.ARRAY]
       }
+      if (fieldDefinitions.USER) {
+        fields.push(fieldDefinitions.USER)
+      }
       return fields
     }
   }

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -168,7 +168,7 @@ export const addSampleData = async (ctx: UserCtx) => {
     // Check if default datasource exists before creating it
     await sdk.datasources.get(DEFAULT_BB_DATASOURCE_ID)
   } catch (err: any) {
-    const defaultDbDocs = buildDefaultDocs()
+    const defaultDbDocs = await buildDefaultDocs()
 
     // add in the default db data docs - tables, datasource, rows and links
     await db.bulkDocs([...defaultDbDocs])

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -92,7 +92,7 @@ export async function save(ctx: UserCtx) {
   }
 
   const table = await sdk.tables.getTable(tableId)
-  const { table: updatedTable, row } = inputProcessing(
+  const { table: updatedTable, row } = await inputProcessing(
     ctx.user?._id,
     cloneDeep(table),
     inputs

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -93,7 +93,7 @@ export async function save(ctx: UserCtx) {
 
   const table = await sdk.tables.getTable(tableId)
   const { table: updatedTable, row } = inputProcessing(
-    ctx.user,
+    ctx.user?._id,
     cloneDeep(table),
     inputs
   )

--- a/packages/server/src/api/controllers/row/internal.ts
+++ b/packages/server/src/api/controllers/row/internal.ts
@@ -59,7 +59,7 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   const tableClone = cloneDeep(dbTable)
 
   // this returns the table and row incase they have been updated
-  let { table, row } = inputProcessing(ctx.user, tableClone, combinedRow)
+  let { table, row } = inputProcessing(ctx.user?._id, tableClone, combinedRow)
   const validateResult = await sdk.rows.utils.validate({
     row,
     table,
@@ -106,7 +106,7 @@ export async function save(ctx: UserCtx) {
   // need to copy the table so it can be differenced on way out
   const tableClone = cloneDeep(dbTable)
 
-  let { table, row } = inputProcessing(ctx.user, tableClone, inputs)
+  let { table, row } = inputProcessing(ctx.user?._id, tableClone, inputs)
 
   const validateResult = await sdk.rows.utils.validate({
     row,

--- a/packages/server/src/api/controllers/row/internal.ts
+++ b/packages/server/src/api/controllers/row/internal.ts
@@ -59,7 +59,11 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   const tableClone = cloneDeep(dbTable)
 
   // this returns the table and row incase they have been updated
-  let { table, row } = inputProcessing(ctx.user?._id, tableClone, combinedRow)
+  let { table, row } = await inputProcessing(
+    ctx.user?._id,
+    tableClone,
+    combinedRow
+  )
   const validateResult = await sdk.rows.utils.validate({
     row,
     table,
@@ -106,7 +110,7 @@ export async function save(ctx: UserCtx) {
   // need to copy the table so it can be differenced on way out
   const tableClone = cloneDeep(dbTable)
 
-  let { table, row } = inputProcessing(ctx.user?._id, tableClone, inputs)
+  let { table, row } = await inputProcessing(ctx.user?._id, tableClone, inputs)
 
   const validateResult = await sdk.rows.utils.validate({
     row,

--- a/packages/server/src/api/controllers/table/tests/utils.spec.ts
+++ b/packages/server/src/api/controllers/table/tests/utils.spec.ts
@@ -42,7 +42,7 @@ describe("utils", () => {
 
         const data = [{ name: "Alice" }, { name: "Bob" }, { name: "Claire" }]
 
-        const result = importToRows(data, table, config.user)
+        const result = await importToRows(data, table, config.user)
         expect(result).toEqual([
           expect.objectContaining({
             autoId: 1,
@@ -89,7 +89,7 @@ describe("utils", () => {
 
         const data = [{ name: "Alice" }, { name: "Bob" }, { name: "Claire" }]
 
-        const result = importToRows(data, table)
+        const result = await importToRows(data, table)
         expect(result).toHaveLength(3)
       })
     })

--- a/packages/server/src/api/controllers/table/utils.ts
+++ b/packages/server/src/api/controllers/table/utils.ts
@@ -113,7 +113,7 @@ export function importToRows(
 
     // We use a reference to table here and update it after input processing,
     // so that we can auto increment auto IDs in imported data properly
-    const processed = inputProcessing(user, table, row, {
+    const processed = inputProcessing(user?._id, table, row, {
       noAutoRelationships: true,
     })
     row = processed.row

--- a/packages/server/src/api/controllers/table/utils.ts
+++ b/packages/server/src/api/controllers/table/utils.ts
@@ -99,7 +99,7 @@ export function makeSureTableUpToDate(table: any, tableToSave: any) {
   return tableToSave
 }
 
-export function importToRows(
+export async function importToRows(
   data: any[],
   table: Table,
   user: ContextUser | null = null
@@ -113,7 +113,7 @@ export function importToRows(
 
     // We use a reference to table here and update it after input processing,
     // so that we can auto increment auto IDs in imported data properly
-    const processed = inputProcessing(user?._id, table, row, {
+    const processed = await inputProcessing(user?._id, table, row, {
       noAutoRelationships: true,
     })
     row = processed.row
@@ -158,7 +158,7 @@ export async function handleDataImport(
   const db = context.getAppDB()
   const data = parse(rows, schema)
 
-  let finalData: any = importToRows(data, table, user)
+  let finalData: any = await importToRows(data, table, user)
 
   //Set IDs of finalData to match existing row if an update is expected
   if (identifierFields.length > 0) {

--- a/packages/server/src/db/defaultData/datasource_bb_default.ts
+++ b/packages/server/src/db/defaultData/datasource_bb_default.ts
@@ -34,9 +34,9 @@ function syncLastIds(table: Table, rowCount: number) {
   })
 }
 
-function tableImport(table: Table, data: Row[]) {
+async function tableImport(table: Table, data: Row[]) {
   const cloneTable = cloneDeep(table)
-  const rowDocs = importToRows(data, cloneTable)
+  const rowDocs = await importToRows(data, cloneTable)
   syncLastIds(cloneTable, rowDocs.length)
   return { rows: rowDocs, table: cloneTable }
 }
@@ -601,20 +601,20 @@ export const DEFAULT_EXPENSES_TABLE_SCHEMA: Table = {
   },
 }
 
-export function buildDefaultDocs() {
-  const inventoryData = tableImport(
+export async function buildDefaultDocs() {
+  const inventoryData = await tableImport(
     DEFAULT_INVENTORY_TABLE_SCHEMA,
     inventoryImport
   )
 
-  const employeeData = tableImport(
+  const employeeData = await tableImport(
     DEFAULT_EMPLOYEE_TABLE_SCHEMA,
     employeeImport
   )
 
-  const jobData = tableImport(DEFAULT_JOBS_TABLE_SCHEMA, jobsImport)
+  const jobData = await tableImport(DEFAULT_JOBS_TABLE_SCHEMA, jobsImport)
 
-  const expensesData = tableImport(
+  const expensesData = await tableImport(
     DEFAULT_EXPENSES_TABLE_SCHEMA,
     expensesImport
   )

--- a/packages/server/src/integrations/base/sqlTable.ts
+++ b/packages/server/src/integrations/base/sqlTable.ts
@@ -41,6 +41,7 @@ function generateSchema(
       case FieldTypes.OPTIONS:
       case FieldTypes.LONGFORM:
       case FieldTypes.BARCODEQR:
+      case FieldTypes.BB_REFERENCE:
         schema.text(key)
         break
       case FieldTypes.NUMBER:

--- a/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
+++ b/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
@@ -1,6 +1,27 @@
+import { cache } from "@budibase/backend-core"
+import { utils } from "@budibase/shared-core"
 import { FieldSubtype } from "@budibase/types"
 
-export async function processOutputBBReferences(
+export async function processInputBBReferences(
   value: string,
   subtype: FieldSubtype
-) {}
+) {
+  const result = []
+  const ids = value.split(",").map((id: string) => id.trim())
+
+  switch (subtype) {
+    case FieldSubtype.USER:
+      for (const id of ids) {
+        result.push(await cache.user.getUser(id))
+      }
+      break
+    default:
+      utils.unreachable(subtype)
+  }
+
+  if (result.length > 1) {
+    return result
+  }
+
+  return result[0]
+}

--- a/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
+++ b/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
@@ -1,0 +1,6 @@
+import { FieldSubtype } from "@budibase/types"
+
+export async function processOutputBBReferences(
+  value: string,
+  subtype: FieldSubtype
+) {}

--- a/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
+++ b/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
@@ -20,9 +20,16 @@ export async function processInputBBReferences(
       }
 
       for (const id of result) {
-        const user = await cache.user.getUser(id)
-        if (!user) {
-          throw new InvalidBBRefError(id, FieldSubtype.USER)
+        try {
+          const user = await cache.user.getUser(id)
+          if (!user) {
+            throw new InvalidBBRefError(id, FieldSubtype.USER)
+          }
+        } catch (err: any) {
+          if (err != null && err.status === 404 && err.error === "not_found") {
+            throw new InvalidBBRefError(id, FieldSubtype.USER)
+          }
+          throw err
         }
       }
       break

--- a/packages/server/src/utilities/rowProcessor/errors.ts
+++ b/packages/server/src/utilities/rowProcessor/errors.ts
@@ -1,0 +1,7 @@
+import { FieldSubtype } from "@budibase/types"
+
+export class InvalidBBRefError extends Error {
+  constructor(id: string, subtype: FieldSubtype) {
+    super(`Id "${id}" is not valid for the subtype "${subtype}"`)
+  }
+}

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -5,8 +5,8 @@ import { ObjectStoreBuckets } from "../../constants"
 import { context, db as dbCore, objectStore } from "@budibase/backend-core"
 import { InternalTables } from "../../db/utils"
 import { TYPE_TRANSFORM_MAP } from "./map"
-import { Row, RowAttachment, Table, ContextUser } from "@budibase/types"
-const { cloneDeep } = require("lodash/fp")
+import { Row, RowAttachment, Table } from "@budibase/types"
+import { cloneDeep } from "lodash/fp"
 export * from "./utils"
 
 type AutoColumnProcessingOpts = {
@@ -48,12 +48,12 @@ function getRemovedAttachmentKeys(
  * for automatic ID purposes.
  */
 export function processAutoColumn(
-  user: ContextUser | null,
+  userId: string | null | undefined,
   table: Table,
   row: Row,
   opts?: AutoColumnProcessingOpts
 ) {
-  let noUser = !user || !user.userId
+  let noUser = !userId
   let isUserTable = table._id === InternalTables.USER_METADATA
   let now = new Date().toISOString()
   // if a row doesn't have a revision then it doesn't exist yet
@@ -70,8 +70,8 @@ export function processAutoColumn(
     }
     switch (schema.subtype) {
       case AutoFieldSubTypes.CREATED_BY:
-        if (creating && shouldUpdateUserFields && user) {
-          row[key] = [user.userId]
+        if (creating && shouldUpdateUserFields && userId) {
+          row[key] = [userId]
         }
         break
       case AutoFieldSubTypes.CREATED_AT:
@@ -80,8 +80,8 @@ export function processAutoColumn(
         }
         break
       case AutoFieldSubTypes.UPDATED_BY:
-        if (shouldUpdateUserFields && user) {
-          row[key] = [user.userId]
+        if (shouldUpdateUserFields && userId) {
+          row[key] = [userId]
         }
         break
       case AutoFieldSubTypes.UPDATED_AT:
@@ -131,7 +131,7 @@ export function coerce(row: any, type: string) {
  * @returns {object} the row which has been prepared to be written to the DB.
  */
 export function inputProcessing(
-  user: ContextUser | null,
+  userId: string | null | undefined,
   table: Table,
   row: Row,
   opts?: AutoColumnProcessingOpts
@@ -174,7 +174,7 @@ export function inputProcessing(
   }
 
   // handle auto columns - this returns an object like {table, row}
-  return processAutoColumn(user, table, clonedRow, opts)
+  return processAutoColumn(userId, table, clonedRow, opts)
 }
 
 /**

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -168,7 +168,7 @@ export async function inputProcessing(
       }
     }
 
-    if (field.type === FieldTypes.BB_REFERENCE) {
+    if (field.type === FieldTypes.BB_REFERENCE && value) {
       clonedRow[key] = await processInputBBReferences(
         value,
         field.subtype as FieldSubtype

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -130,7 +130,7 @@ export function coerce(row: any, type: string) {
  * @param {object} opts some input processing options (like disabling auto-column relationships).
  * @returns {object} the row which has been prepared to be written to the DB.
  */
-export function inputProcessing(
+export async function inputProcessing(
   userId: string | null | undefined,
   table: Table,
   row: Row,

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -7,7 +7,7 @@ import { InternalTables } from "../../db/utils"
 import { TYPE_TRANSFORM_MAP } from "./map"
 import { FieldSubtype, Row, RowAttachment, Table } from "@budibase/types"
 import { cloneDeep } from "lodash/fp"
-import { processOutputBBReferences } from "./bbReferenceProcessor"
+import { processInputBBReferences } from "./bbReferenceProcessor"
 export * from "./utils"
 
 type AutoColumnProcessingOpts = {
@@ -169,7 +169,7 @@ export async function inputProcessing(
     }
 
     if (field.type === FieldTypes.BB_REFERENCE) {
-      clonedRow[key] = await processOutputBBReferences(
+      clonedRow[key] = await processInputBBReferences(
         value,
         field.subtype as FieldSubtype
       )

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -5,8 +5,9 @@ import { ObjectStoreBuckets } from "../../constants"
 import { context, db as dbCore, objectStore } from "@budibase/backend-core"
 import { InternalTables } from "../../db/utils"
 import { TYPE_TRANSFORM_MAP } from "./map"
-import { Row, RowAttachment, Table } from "@budibase/types"
+import { FieldSubtype, Row, RowAttachment, Table } from "@budibase/types"
 import { cloneDeep } from "lodash/fp"
+import { processOutputBBReferences } from "./bbReferenceProcessor"
 export * from "./utils"
 
 type AutoColumnProcessingOpts = {
@@ -165,6 +166,13 @@ export async function inputProcessing(
           delete attachment.url
         })
       }
+    }
+
+    if (field.type === FieldTypes.BB_REFERENCE) {
+      clonedRow[key] = await processOutputBBReferences(
+        value,
+        field.subtype as FieldSubtype
+      )
     }
   }
 

--- a/packages/server/src/utilities/rowProcessor/tests/bbReferenceProcessor.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/bbReferenceProcessor.spec.ts
@@ -1,0 +1,62 @@
+import * as backendCore from "@budibase/backend-core"
+import { FieldSubtype, User } from "@budibase/types"
+import { processInputBBReferences } from "../bbReferenceProcessor"
+import { generator, structures } from "@budibase/backend-core/tests"
+
+jest.mock("@budibase/backend-core", (): typeof backendCore => {
+  const actual = jest.requireActual("@budibase/backend-core")
+  return {
+    ...actual,
+    cache: {
+      ...actual.cache,
+      user: {
+        getUser: jest.fn(),
+        invalidateUser: jest.fn(),
+      },
+    },
+  }
+})
+
+describe("bbReferenceProcessor", () => {
+  const mockedCacheGetUser = backendCore.cache.user.getUser as jest.Mock
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe("processInputBBReferences", () => {
+    describe("subtype user", () => {
+      it("fetches by user id", async () => {
+        const input = generator.guid()
+
+        const userFromCache = structures.users.user()
+        mockedCacheGetUser.mockResolvedValueOnce(userFromCache)
+
+        const result = await processInputBBReferences(input, FieldSubtype.USER)
+
+        expect(result).toEqual(userFromCache)
+        expect(mockedCacheGetUser).toBeCalledTimes(1)
+        expect(mockedCacheGetUser).toBeCalledWith(input)
+      })
+
+      it("fetches by user id when send as csv", async () => {
+        const users: Record<string, User> = {}
+        for (let i = 0; i < 5; i++) {
+          const userId = generator.guid()
+          const user = structures.users.user({ _id: userId, userId })
+          mockedCacheGetUser.mockResolvedValueOnce(user)
+          users[userId] = user
+        }
+
+        const input = Object.keys(users).join(" ,  ")
+        const result = await processInputBBReferences(input, FieldSubtype.USER)
+
+        expect(result).toEqual(Object.values(users))
+        expect(mockedCacheGetUser).toBeCalledTimes(5)
+        Object.keys(users).forEach(userId => {
+          expect(mockedCacheGetUser).toBeCalledWith(userId)
+        })
+      })
+    })
+  })
+})

--- a/packages/server/src/utilities/rowProcessor/tests/bbReferenceProcessor.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/bbReferenceProcessor.spec.ts
@@ -43,6 +43,11 @@ describe("bbReferenceProcessor", () => {
       it("throws an error given an invalid id", async () => {
         const userId = generator.guid()
 
+        mockedCacheGetUser.mockRejectedValue({
+          status: 404,
+          error: "not_found",
+        })
+
         await expect(
           processInputBBReferences(userId, FieldSubtype.USER)
         ).rejects.toThrowError(new InvalidBBRefError(userId, FieldSubtype.USER))

--- a/packages/server/src/utilities/rowProcessor/tests/inputProcessing.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/inputProcessing.spec.ts
@@ -4,7 +4,7 @@ import { FieldType, FieldTypeSubtypes, Table } from "@budibase/types"
 import * as bbReferenceProcessor from "../bbReferenceProcessor"
 
 jest.mock("../bbReferenceProcessor", (): typeof bbReferenceProcessor => ({
-  processOutputBBReferences: jest.fn(),
+  processInputBBReferences: jest.fn(),
 }))
 
 describe("rowProcessor - inputProcessing", () => {
@@ -48,13 +48,13 @@ describe("rowProcessor - inputProcessing", () => {
     const user = structures.users.user()
 
     ;(
-      bbReferenceProcessor.processOutputBBReferences as jest.Mock
+      bbReferenceProcessor.processInputBBReferences as jest.Mock
     ).mockResolvedValue(user)
 
     const { row } = await inputProcessing(userId, table, newRow)
 
-    expect(bbReferenceProcessor.processOutputBBReferences).toBeCalledTimes(1)
-    expect(bbReferenceProcessor.processOutputBBReferences).toBeCalledWith(
+    expect(bbReferenceProcessor.processInputBBReferences).toBeCalledTimes(1)
+    expect(bbReferenceProcessor.processInputBBReferences).toBeCalledWith(
       "123",
       "user"
     )
@@ -96,7 +96,7 @@ describe("rowProcessor - inputProcessing", () => {
 
     const { row } = await inputProcessing(userId, table, newRow)
 
-    expect(bbReferenceProcessor.processOutputBBReferences).not.toBeCalled()
+    expect(bbReferenceProcessor.processInputBBReferences).not.toBeCalled()
     expect(row).toEqual({ ...newRow, user: undefined })
   })
 
@@ -134,7 +134,7 @@ describe("rowProcessor - inputProcessing", () => {
 
     const { row } = await inputProcessing(userId, table, newRow)
 
-    expect(bbReferenceProcessor.processOutputBBReferences).not.toBeCalled()
+    expect(bbReferenceProcessor.processInputBBReferences).not.toBeCalled()
     expect(row).toEqual({
       name: "Jack",
       user: 123,

--- a/packages/server/src/utilities/rowProcessor/tests/inputProcessing.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/inputProcessing.spec.ts
@@ -1,0 +1,67 @@
+import TestConfiguration from "../../../tests/utilities/TestConfiguration"
+import { inputProcessing } from ".."
+import { generator, structures } from "@budibase/backend-core/tests"
+import { FieldType, FieldTypeSubtypes, Table } from "@budibase/types"
+import * as bbReferenceProcessor from "../bbReferenceProcessor"
+
+const config = new TestConfiguration()
+
+jest.mock("../bbReferenceProcessor", (): typeof bbReferenceProcessor => ({
+  processOutputBBReferences: jest.fn(),
+}))
+
+describe("rowProcessor - inputProcessing", () => {
+  beforeAll(async () => {
+    await config.init()
+  })
+
+  it("populate user BB references", async () => {
+    const userId = generator.guid()
+
+    const table: Table = {
+      _id: generator.guid(),
+      name: "TestTable",
+      type: "table",
+      schema: {
+        name: {
+          type: FieldType.STRING,
+          name: "name",
+          constraints: {
+            presence: true,
+            type: "string",
+          },
+        },
+        user: {
+          type: FieldType.BB_REFERENCE,
+          subtype: FieldTypeSubtypes.BB_REFERENCE.USER,
+          name: "user",
+          constraints: {
+            presence: true,
+            type: "string",
+          },
+        },
+      },
+    }
+
+    const newRow = {
+      name: "Jack",
+      user: "123",
+    }
+
+    const user = structures.users.user()
+
+    ;(
+      bbReferenceProcessor.processOutputBBReferences as jest.Mock
+    ).mockResolvedValue(user)
+
+    const { row } = await inputProcessing(userId, table, newRow)
+
+    expect(bbReferenceProcessor.processOutputBBReferences).toBeCalledTimes(1)
+    expect(bbReferenceProcessor.processOutputBBReferences).toBeCalledWith(
+      "123",
+      "user"
+    )
+
+    expect(row).toEqual({ ...newRow, user })
+  })
+})

--- a/packages/server/src/utilities/rowProcessor/tests/inputProcessing.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/inputProcessing.spec.ts
@@ -62,7 +62,7 @@ describe("rowProcessor - inputProcessing", () => {
     expect(row).toEqual({ ...newRow, user })
   })
 
-  it("it does not processe BB references if on the schema but it is not populated", async () => {
+  it("it does not process BB references if on the schema but it is not populated", async () => {
     const userId = generator.guid()
 
     const table: Table = {
@@ -100,7 +100,49 @@ describe("rowProcessor - inputProcessing", () => {
     expect(row).toEqual({ ...newRow, user: undefined })
   })
 
-  it("it does not processe BB references if not in the schema", async () => {
+  it.each([undefined, null, ""])(
+    "it does not process BB references the field is $%",
+    async userValue => {
+      const userId = generator.guid()
+
+      const table: Table = {
+        _id: generator.guid(),
+        name: "TestTable",
+        type: "table",
+        schema: {
+          name: {
+            type: FieldType.STRING,
+            name: "name",
+            constraints: {
+              presence: true,
+              type: "string",
+            },
+          },
+          user: {
+            type: FieldType.BB_REFERENCE,
+            subtype: FieldTypeSubtypes.BB_REFERENCE.USER,
+            name: "user",
+            constraints: {
+              presence: false,
+              type: "string",
+            },
+          },
+        },
+      }
+
+      const newRow = {
+        name: "Jack",
+        user: userValue,
+      }
+
+      const { row } = await inputProcessing(userId, table, newRow)
+
+      expect(bbReferenceProcessor.processInputBBReferences).not.toBeCalled()
+      expect(row).toEqual(newRow)
+    }
+  )
+
+  it("it does not process BB references if not in the schema", async () => {
     const userId = generator.guid()
 
     const table: Table = {

--- a/packages/server/src/utilities/rowProcessor/tests/inputProcessing.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/inputProcessing.spec.ts
@@ -1,20 +1,13 @@
-import TestConfiguration from "../../../tests/utilities/TestConfiguration"
 import { inputProcessing } from ".."
 import { generator, structures } from "@budibase/backend-core/tests"
 import { FieldType, FieldTypeSubtypes, Table } from "@budibase/types"
 import * as bbReferenceProcessor from "../bbReferenceProcessor"
-
-const config = new TestConfiguration()
 
 jest.mock("../bbReferenceProcessor", (): typeof bbReferenceProcessor => ({
   processOutputBBReferences: jest.fn(),
 }))
 
 describe("rowProcessor - inputProcessing", () => {
-  beforeAll(async () => {
-    await config.init()
-  })
-
   beforeEach(() => {
     jest.resetAllMocks()
   })

--- a/packages/types/src/documents/app/row.ts
+++ b/packages/types/src/documents/app/row.ts
@@ -34,3 +34,13 @@ export interface Row extends Document {
   _viewId?: string
   [key: string]: any
 }
+
+export enum FieldSubtype {
+  USER = "user",
+}
+
+export const FieldTypeSubtypes = {
+  BB_REFERENCE: {
+    USER: FieldSubtype.USER,
+  },
+}


### PR DESCRIPTION
## Description
Handling validation on storing user bb references. On row creation/update we will validate that the provided user ids are valid ones.
This field will accept:
1. User id
2. Comma-separated user ids
3. User object
4. Array of user object

Addresses: 
- [BUDI-7456
](https://linear.app/budibase/issue/BUDI-7456/[users-column-type]-saving-of-user-column-data)

## Screenshots
https://github.com/Budibase/budibase/assets/15987277/090006ca-8c5c-4e18-a3a5-a1efefa141de

