### PR TITLE
Data section frontend for the user column

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -346,53 +346,32 @@
   }
 
   function getRelationshipOptions(field) {
-    if (!field) {
+    if (!field || !field.tableId) {
       return null
     }
-
-    if (field.type === FieldType.LINK) {
-      if (!field.tableId) {
-        return null
-      }
-      const linkTable = tableOptions?.find(table => table._id === field.tableId)
-      if (!linkTable) {
-        return null
-      }
-      const thisName = truncate(table.name, { length: 14 }),
-        linkName = truncate(linkTable.name, { length: 14 })
-      return [
-        {
-          name: `Many ${thisName} rows → many ${linkName} rows`,
-          alt: `Many ${table.name} rows → many ${linkTable.name} rows`,
-          value: RelationshipType.MANY_TO_MANY,
-        },
-        {
-          name: `One ${linkName} row → many ${thisName} rows`,
-          alt: `One ${linkTable.name} rows → many ${table.name} rows`,
-          value: RelationshipType.ONE_TO_MANY,
-        },
-        {
-          name: `One ${thisName} row → many ${linkName} rows`,
-          alt: `One ${table.name} rows → many ${linkTable.name} rows`,
-          value: RelationshipType.MANY_TO_ONE,
-        },
-      ]
-    } else if (field.type === BB_USER_REFERENCE_TYPE) {
-      return [
-        {
-          name: `Single user`,
-          alt: `Single user`,
-          value: RelationshipType.ONE_TO_MANY,
-        },
-        {
-          name: `Multiple users`,
-          alt: `Multiple users`,
-          value: RelationshipType.MANY_TO_ONE,
-        },
-      ]
-    } else {
+    const linkTable = tableOptions?.find(table => table._id === field.tableId)
+    if (!linkTable) {
       return null
     }
+    const thisName = truncate(table.name, { length: 14 }),
+      linkName = truncate(linkTable.name, { length: 14 })
+    return [
+      {
+        name: `Many ${thisName} rows → many ${linkName} rows`,
+        alt: `Many ${table.name} rows → many ${linkTable.name} rows`,
+        value: RelationshipType.MANY_TO_MANY,
+      },
+      {
+        name: `One ${linkName} row → many ${thisName} rows`,
+        alt: `One ${linkTable.name} rows → many ${table.name} rows`,
+        value: RelationshipType.ONE_TO_MANY,
+      },
+      {
+        name: `One ${thisName} row → many ${linkName} rows`,
+        alt: `One ${table.name} rows → many ${linkTable.name} rows`,
+        value: RelationshipType.MANY_TO_ONE,
+      },
+    ]
   }
 
   function getAllowedTypes() {
@@ -700,14 +679,15 @@
       >Open schema editor</Button
     >
   {:else if isBBReference}
-    <RadioGroup
-      disabled={linkEditDisabled}
-      label="Define the relationship"
-      bind:value={editableColumn.relationshipType}
-      options={relationshipOptions}
-      getOptionLabel={option => option.name}
-      getOptionValue={option => option.value}
-      getOptionTitle={option => option.alt}
+    <Toggle
+      value={editableColumn.relationshipType === RelationshipType.MANY_TO_MANY}
+      on:change={e =>
+        (editableColumn.relationshipType = e.detail
+          ? RelationshipType.MANY_TO_MANY
+          : RelationshipType.ONE_TO_MANY)}
+      disabled={!isCreating}
+      thin
+      text="Allow multiple users"
     />
   {/if}
   {#if editableColumn.type === AUTO_TYPE || editableColumn.autocolumn}

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -46,7 +46,7 @@
   const DATE_TYPE = FIELDS.DATETIME.type
   const BB_REFERENCE_TYPE = FieldType.BB_REFERENCE
   const BB_USER_REFERENCE_TYPE = composeType(
-    FieldType.BB_REFERENCE,
+    BB_REFERENCE_TYPE,
     FieldSubtype.USER
   )
 
@@ -107,8 +107,6 @@
     {}
   )
 
-  $: isBBReference = !!bbRefTypeMapping[editableColumn.type]
-
   $: if (primaryDisplay) {
     editableColumn.constraints.presence = { allowEmpty: false }
   }
@@ -152,6 +150,8 @@
   }
 
   $: initialiseField(field, savingColumn)
+
+  $: isBBReference = !!bbRefTypeMapping[editableColumn.type]
 
   $: checkConstraints(editableColumn)
   $: required = !!editableColumn?.constraints?.presence || primaryDisplay

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -346,51 +346,52 @@
   }
 
   function getRelationshipOptions(field) {
-    switch (field.type) {
-      case FieldType.LINK:
-        if (!field || !field.tableId) {
-          return null
-        }
-        const linkTable = tableOptions?.find(
-          table => table._id === field.tableId
-        )
-        if (!linkTable) {
-          return null
-        }
-        const thisName = truncate(table.name, { length: 14 }),
-          linkName = truncate(linkTable.name, { length: 14 })
-        return [
-          {
-            name: `Many ${thisName} rows → many ${linkName} rows`,
-            alt: `Many ${table.name} rows → many ${linkTable.name} rows`,
-            value: RelationshipType.MANY_TO_MANY,
-          },
-          {
-            name: `One ${linkName} row → many ${thisName} rows`,
-            alt: `One ${linkTable.name} rows → many ${table.name} rows`,
-            value: RelationshipType.ONE_TO_MANY,
-          },
-          {
-            name: `One ${thisName} row → many ${linkName} rows`,
-            alt: `One ${table.name} rows → many ${linkTable.name} rows`,
-            value: RelationshipType.MANY_TO_ONE,
-          },
-        ]
-      case BB_USER_REFERENCE_TYPE:
-        return [
-          {
-            name: `Single user`,
-            alt: `Single user`,
-            value: RelationshipType.ONE_TO_MANY,
-          },
-          {
-            name: `Multiple users`,
-            alt: `Multiple users`,
-            value: RelationshipType.MANY_TO_ONE,
-          },
-        ]
-      default:
+    if (!field) {
+      return null
+    }
+
+    if (field.type === FieldType.LINK) {
+      if (!field.tableId) {
         return null
+      }
+      const linkTable = tableOptions?.find(table => table._id === field.tableId)
+      if (!linkTable) {
+        return null
+      }
+      const thisName = truncate(table.name, { length: 14 }),
+        linkName = truncate(linkTable.name, { length: 14 })
+      return [
+        {
+          name: `Many ${thisName} rows → many ${linkName} rows`,
+          alt: `Many ${table.name} rows → many ${linkTable.name} rows`,
+          value: RelationshipType.MANY_TO_MANY,
+        },
+        {
+          name: `One ${linkName} row → many ${thisName} rows`,
+          alt: `One ${linkTable.name} rows → many ${table.name} rows`,
+          value: RelationshipType.ONE_TO_MANY,
+        },
+        {
+          name: `One ${thisName} row → many ${linkName} rows`,
+          alt: `One ${table.name} rows → many ${linkTable.name} rows`,
+          value: RelationshipType.MANY_TO_ONE,
+        },
+      ]
+    } else if (field.type === BB_USER_REFERENCE_TYPE) {
+      return [
+        {
+          name: `Single user`,
+          alt: `Single user`,
+          value: RelationshipType.ONE_TO_MANY,
+        },
+        {
+          name: `Multiple users`,
+          alt: `Multiple users`,
+          value: RelationshipType.MANY_TO_ONE,
+        },
+      ]
+    } else {
+      return null
     }
   }
 

--- a/packages/frontend-core/src/components/grid/cells/BBReferenceCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/BBReferenceCell.svelte
@@ -8,6 +8,7 @@
 
   const schema = {
     ...$$props.schema,
+    // This is not really used, just adding some content to be able to render the relationship cell
     tableId: "external",
   }
 

--- a/packages/frontend-core/src/components/grid/cells/BBReferenceCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/BBReferenceCell.svelte
@@ -1,16 +1,36 @@
 <script>
+  import { getContext } from "svelte"
   import RelationshipCell from "./RelationshipCell.svelte"
   import { FieldSubtype } from "@budibase/types"
-  import { TableNames } from "../../../constants"
 
-  const subtypeToTable = {
-    [FieldSubtype.USER]: TableNames.USERS,
-  }
+  const { API } = getContext("grid")
+  const { subtype } = $$props.schema
 
   const schema = {
     ...$$props.schema,
-    tableId: subtypeToTable[$$props.schema.subtype],
+    tableId: "external",
+  }
+
+  async function searchFunction(searchParams) {
+    if (subtype !== FieldSubtype.USER) {
+      throw `Search for '${subtype}' not implemented`
+    }
+
+    const results = await API.searchUsers({
+      ...searchParams,
+    })
+    return {
+      ...results,
+      data: undefined,
+      rows: results.data,
+    }
   }
 </script>
 
-<RelationshipCell {...$$props} {schema} />
+<RelationshipCell
+  {...$$props}
+  {schema}
+  {searchFunction}
+  primaryDisplay={"email"}
+  relationshipType={"many-to-one"}
+/>

--- a/packages/frontend-core/src/components/grid/cells/BBReferenceCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/BBReferenceCell.svelte
@@ -1,0 +1,16 @@
+<script>
+  import RelationshipCell from "./RelationshipCell.svelte"
+  import { TableNames } from "constants"
+  // import { FieldSubtype } from "@budibase/types"
+
+  const subtypeToTable = {
+    ["user"]: TableNames.USERS,
+  }
+
+  const schema = {
+    ...$$props.schema,
+    tableId: subtypeToTable[$$props.schema.subtype],
+  }
+</script>
+
+<RelationshipCell {...$$props} {schema} />

--- a/packages/frontend-core/src/components/grid/cells/BBReferenceCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/BBReferenceCell.svelte
@@ -1,10 +1,10 @@
 <script>
   import RelationshipCell from "./RelationshipCell.svelte"
-  import { TableNames } from "constants"
-  // import { FieldSubtype } from "@budibase/types"
+  import { FieldSubtype } from "@budibase/types"
+  import { TableNames } from "../../../constants"
 
   const subtypeToTable = {
-    ["user"]: TableNames.USERS,
+    [FieldSubtype.USER]: TableNames.USERS,
   }
 
   const schema = {

--- a/packages/frontend-core/src/components/grid/cells/BBReferenceCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/BBReferenceCell.svelte
@@ -32,5 +32,4 @@
   {schema}
   {searchFunction}
   primaryDisplay={"email"}
-  relationshipType={"many-to-one"}
 />

--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -30,6 +30,8 @@
   export let invertX = false
   export let invertY = false
   export let contentLines = 1
+  export let searchFunction = API.searchTable
+  export let primaryDisplay
 
   const { API, dispatch } = getContext("grid")
   const color = getColor(0)
@@ -38,7 +40,6 @@
   let searchResults
   let searchString
   let lastSearchString
-  let primaryDisplay
   let candidateIndex
   let lastSearchId
   let searching = false
@@ -96,7 +97,7 @@
     lastSearchId = Math.random()
     searching = true
     const thisSearchId = lastSearchId
-    const results = await API.searchTable({
+    const results = await searchFunction({
       paginate: false,
       tableId: schema.tableId,
       limit: 20,

--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -260,14 +260,16 @@
       on:wheel={e => (focused ? e.stopPropagation() : null)}
     >
       {#each value || [] as relationship}
-        {#if relationship.primaryDisplay}
+        {#if relationship[primaryDisplay] || relationship.primaryDisplay}
           <div class="badge">
             <span
               on:click={editable
                 ? () => showRelationship(relationship._id)
                 : null}
             >
-              {readable(relationship.primaryDisplay)}
+              {readable(
+                relationship[primaryDisplay] || relationship.primaryDisplay
+              )}
             </span>
             {#if editable}
               <Icon

--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -21,6 +21,8 @@
   import { Icon, Input, ProgressCircle, clickOutside } from "@budibase/bbui"
   import { debounce } from "../../../utils/utils"
 
+  const { API, dispatch } = getContext("grid")
+
   export let value
   export let api
   export let readonly
@@ -33,7 +35,6 @@
   export let searchFunction = API.searchTable
   export let primaryDisplay
 
-  const { API, dispatch } = getContext("grid")
   const color = getColor(0)
 
   let isOpen = false

--- a/packages/frontend-core/src/components/grid/lib/renderers.js
+++ b/packages/frontend-core/src/components/grid/lib/renderers.js
@@ -9,6 +9,7 @@ import BooleanCell from "../cells/BooleanCell.svelte"
 import FormulaCell from "../cells/FormulaCell.svelte"
 import JSONCell from "../cells/JSONCell.svelte"
 import AttachmentCell from "../cells/AttachmentCell.svelte"
+import BBReferenceCell from "../cells/BBReferenceCell.svelte"
 
 const TypeComponentMap = {
   text: TextCell,
@@ -23,6 +24,7 @@ const TypeComponentMap = {
   link: RelationshipCell,
   formula: FormulaCell,
   json: JSONCell,
+  bb_reference: BBReferenceCell,
 }
 export const getCellRenderer = column => {
   return TypeComponentMap[column?.schema?.type] || TextCell

--- a/packages/frontend-core/src/components/grid/lib/utils.js
+++ b/packages/frontend-core/src/components/grid/lib/utils.js
@@ -19,7 +19,7 @@ const TypeIconMap = {
   formula: "Calculator",
   json: "Brackets",
   bigint: "TagBold",
-  internal: {
+  bb_reference: {
     user: "User",
   },
 }


### PR DESCRIPTION
## Description
Frontend for the data section of the user column type.
The approach of these changes were the following:
1. Reuse the link grid cell type, to avoid duplicating front end logic, but trying not to do any massive refactor to that content. For this I used overrides
2. Make use of the field subtypes of the new field type `bb_reference` on the type selector. For this I created the logic around "composite types"

## Screenshots
### Creating a user column
<img width="634" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/5cc38a96-96fe-476f-9441-1e87eb3dbd52">

### Editing a user cell
![image](https://github.com/Budibase/budibase/assets/15987277/834982a7-6c95-482e-9320-e8efcfe40612)
![image](https://github.com/Budibase/budibase/assets/15987277/3889ff75-2d72-45ed-861c-0c956b2f6faa)

### Editing a user column
<img width="510" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/085508bf-6185-4424-b11b-ca8704cf6dee">

