### PR TITLE
[Fix] Populate apps from groups while fetching apps

### DIFF
--- a/packages/server/src/sdk/app/applications/applications.ts
+++ b/packages/server/src/sdk/app/applications/applications.ts
@@ -1,13 +1,14 @@
 import { AppStatus } from "../../../db/utils"
-import { App, ContextUser } from "@budibase/types"
+import { App, ContextUser, User } from "@budibase/types"
 import { getLocksById } from "../../../utilities/redis"
 import { enrichApps } from "../../users/sessions"
 import { checkAppMetadata } from "../../../automations/logging"
 import { db as dbCore, users } from "@budibase/backend-core"
+import { groups } from "@budibase/pro"
 
-export function filterAppList(user: ContextUser, apps: App[]) {
+export function filterAppList(user: User, apps: App[]) {
   let appList: string[] = []
-  const roleApps = Object.keys(user.roles || {})
+  const roleApps = Object.keys(user.roles)
   if (users.hasAppBuilderPermissions(user)) {
     appList = user.builder?.apps || []
     appList = appList.concat(roleApps)
@@ -23,7 +24,12 @@ export async function fetch(status: AppStatus, user: ContextUser) {
   const dev = status === AppStatus.DEV
   const all = status === AppStatus.ALL
   let apps = (await dbCore.getAllApps({ dev, all })) as App[]
-  apps = filterAppList(user, apps)
+
+  const enrichedUser = await groups.enrichUserRolesFromGroups({
+    ...user,
+    roles: user.roles || {},
+  })
+  apps = filterAppList(enrichedUser, apps)
 
   const appIds = apps
     .filter((app: any) => app.status === "development")


### PR DESCRIPTION
## Description
Fix populating apps from user groups. Currently, they are not checked when requesting available apps, so a user will not have the apps defined by their groups on their home page

Addresses: 
- [BUDI-7480](https://linear.app/budibase/issue/BUDI-7480/group-members-cant-see-group-apps-in-portal)



