### PR TITLE
Sign up flow changes feedback

### DIFF
--- a/packages/builder/src/components/common/VerificationPromptBanner.svelte
+++ b/packages/builder/src/components/common/VerificationPromptBanner.svelte
@@ -1,0 +1,102 @@
+<script>
+  import { notifications, Button, Icon, Body } from "@budibase/bbui"
+  import { admin, auth } from "stores/portal"
+
+  $: user = $auth.user
+  let loading = false
+  let complete = false
+
+  const resetPassword = async () => {
+    if (loading || complete) return
+    loading = true
+
+    try {
+      await fetch(`${$admin.accountPortalUrl}/api/auth/reset`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email: user.email }),
+      })
+
+      complete = true
+    } catch (e) {
+      notifications.error("There was an issue sending your validation email.")
+    } finally {
+      loading = false
+    }
+  }
+</script>
+
+{#if user?.account?.verified === false}
+  <section class="banner">
+    <div class="icon">
+      <Icon name="Info" />
+    </div>
+    <div class="copy">
+      <Body size="S">
+        Please verify your account. We've sent the verification link to <span
+          class="email">{user.email}</span
+        ></Body
+      >
+    </div>
+    <div class="button" class:disabled={loading || complete}>
+      <Button on:click={resetPassword}
+        >{complete ? "Email sent" : "Resend email"}</Button
+      >
+    </div>
+  </section>
+{/if}
+
+<style>
+  .banner {
+    flex-shrink: 0;
+    display: flex;
+    background-color: var(--grey-2);
+    height: 48px;
+    align-items: center;
+    padding: 0 15px;
+  }
+
+  .icon {
+    margin-right: 15px;
+    color: var(--ink);
+    display: flex;
+  }
+
+  .copy {
+    flex-grow: 1;
+    overflow: hidden;
+  }
+
+  .copy :global(p) {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .email {
+    font-weight: 600;
+  }
+
+  .button {
+    margin-left: 15px;
+  }
+
+  .button :global(button) {
+    color: var(--ink);
+    background-color: var(--grey-3);
+    border: none;
+  }
+
+  .button :global(button):hover {
+    background-color: var(--grey-4);
+  }
+
+  .disabled :global(button) {
+    pointer-events: none;
+    color: var(--ink);
+    background-color: var(--grey-4);
+    border: none;
+  }
+</style>

--- a/packages/builder/src/pages/builder/_layout.svelte
+++ b/packages/builder/src/pages/builder/_layout.svelte
@@ -3,7 +3,6 @@
   import { admin, auth, licensing } from "stores/portal"
   import { onMount } from "svelte"
   import { CookieUtils, Constants } from "@budibase/frontend-core"
-  import { banner, BANNER_TYPES } from "@budibase/bbui"
   import { API } from "api"
   import Branding from "./Branding.svelte"
 
@@ -17,32 +16,6 @@
   $: user = $auth.user
 
   $: useAccountPortal = cloud && !$admin.disableAccountPortal
-  let showVerificationPrompt = false
-
-  const checkVerification = user => {
-    if (!showVerificationPrompt && user?.account?.verified === false) {
-      showVerificationPrompt = true
-      banner.queue([
-        {
-          message: `Please verify your account. We've sent the verification link to ${user.email}`,
-          type: BANNER_TYPES.NEUTRAL,
-          showCloseButton: false,
-          extraButtonAction: () => {
-            fetch(`${$admin.accountPortalUrl}/api/auth/reset`, {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({ email: user.email }),
-            })
-          },
-          extraButtonText: "Resend email",
-        },
-      ])
-    }
-  }
-
-  $: checkVerification(user)
 
   const validateTenantId = async () => {
     const host = window.location.host

--- a/packages/builder/src/pages/builder/app/[application]/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/_layout.svelte
@@ -22,6 +22,7 @@
   import { isActive, goto, layout, redirect } from "@roxi/routify"
   import { capitalise } from "helpers"
   import { onMount, onDestroy } from "svelte"
+  import VerificationPromptBanner from "components/common/VerificationPromptBanner.svelte"
   import CommandPalette from "components/commandPalette/CommandPalette.svelte"
   import TourWrap from "components/portal/onboarding/TourWrap.svelte"
   import TourPopover from "components/portal/onboarding/TourPopover.svelte"
@@ -136,6 +137,7 @@
 {/if}
 
 <div class="root" class:blur={$store.showPreview}>
+  <VerificationPromptBanner />
   <div class="top-nav">
     {#if $store.initialised}
       <div class="topleftnav">

--- a/packages/builder/src/pages/builder/portal/_layout.svelte
+++ b/packages/builder/src/pages/builder/portal/_layout.svelte
@@ -8,6 +8,7 @@
   import Logo from "./_components/Logo.svelte"
   import UserDropdown from "./_components/UserDropdown.svelte"
   import HelpMenu from "components/common/HelpMenu.svelte"
+  import VerificationPromptBanner from "components/common/VerificationPromptBanner.svelte"
   import { sdk } from "@budibase/shared-core"
 
   let loaded = false
@@ -55,6 +56,7 @@
   {:else}
     <HelpMenu />
     <div class="container">
+      <VerificationPromptBanner />
       <div class="nav">
         <div class="branding">
           <Logo />


### PR DESCRIPTION
## Description
Budibase changes to address issues with [this ticket](https://linear.app/budibase/issue/BUDI-7302/[p1]-this-first[email-validation]-customize-sign-up-flow) as pointed out by @aptkingston (in a comment on the same ticket).

- The verification banner as specified is a bit different design wise from the bbui banner component, so instead of adding a bunch of optionality to that component I thought it best to just create a new one for this use case.

- Banners were breaking certain sections of the website, namely the app builder section and the portal as they were mounted outside of the flexbox based layout these pages use. This will remain a problem for any banner displayed using the global bbui banner, but the verification prompt banner is now displayed within these two layouts and they will shrink accordingly.


corresponding account portal pr: https://github.com/Budibase/account-portal/pull/403

