### PR TITLE
Remove tooltip from automation undo redo control

### DIFF
--- a/packages/builder/src/components/common/UndoRedoControl.svelte
+++ b/packages/builder/src/components/common/UndoRedoControl.svelte
@@ -38,14 +38,12 @@
     hoverable
     on:click={store.undo}
     disabled={!$store.canUndo}
-    tooltip="Undo latest change"
   />
   <Icon
     name="Redo"
     hoverable
     on:click={store.redo}
     disabled={!$store.canRedo}
-    tooltip="Redo latest undo"
   />
 </div>
 


### PR DESCRIPTION
## Description
Remove tooltip from automation undo redo control.

Addresses: 
- https://linear.app/budibase/issue/BUDI-7498/undo-redo-tooltip-is-cut-off-in-automations-section

