### PR TITLE
Remove form field default value settings from being updated by conditions

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ConditionalUIDrawer.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ConditionalUIDrawer.svelte
@@ -61,10 +61,12 @@
     key: "_css",
     type: "text",
   })
-  $: settingOptions = settings.map(setting => ({
-    label: makeLabel(setting),
-    value: setting.key,
-  }))
+  $: settingOptions = settings
+    .filter(setting => setting.supportsConditions !== false)
+    .map(setting => ({
+      label: makeLabel(setting),
+      value: setting.key,
+    }))
   $: conditions.forEach(link => {
     if (!link.id) {
       link.id = generate()

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ConditionalUISection.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ConditionalUISection.svelte
@@ -36,10 +36,7 @@
 </script>
 
 <DetailSummary name={"Conditions"} collapsible={false}>
-  <div class="conditionCount">{conditionText}</div>
-  <div>
-    <ActionButton on:click={openDrawer}>Configure conditions</ActionButton>
-  </div>
+  <ActionButton on:click={openDrawer}>{conditionText}</ActionButton>
 </DetailSummary>
 <Drawer bind:this={drawer} title="Conditions">
   <svelte:fragment slot="description">
@@ -48,10 +45,3 @@
   <Button cta slot="buttons" on:click={() => save()}>Save</Button>
   <ConditionalUIDrawer slot="body" bind:conditions={tempValue} {bindings} />
 </Drawer>
-
-<style>
-  .conditionCount {
-    font-weight: 600;
-    margin-top: -5px;
-  }
-</style>

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -2539,7 +2539,8 @@
       {
         "type": "text",
         "label": "Default value",
-        "key": "defaultValue"
+        "key": "defaultValue",
+        "supportsConditions": false
       },
       {
         "type": "event",
@@ -2629,7 +2630,8 @@
       {
         "type": "text",
         "label": "Default value",
-        "key": "defaultValue"
+        "key": "defaultValue",
+        "supportsConditions": false
       },
       {
         "type": "event",
@@ -2685,7 +2687,8 @@
       {
         "type": "text",
         "label": "Default value",
-        "key": "defaultValue"
+        "key": "defaultValue",
+        "supportsConditions": false
       },
       {
         "type": "event",
@@ -2736,7 +2739,8 @@
       {
         "type": "text",
         "label": "Default value",
-        "key": "defaultValue"
+        "key": "defaultValue",
+        "supportsConditions": false
       },
       {
         "type": "event",
@@ -2841,7 +2845,8 @@
       {
         "type": "text",
         "label": "Default value",
-        "key": "defaultValue"
+        "key": "defaultValue",
+        "supportsConditions": false
       },
       {
         "type": "boolean",
@@ -2960,7 +2965,8 @@
       {
         "type": "text",
         "label": "Default value",
-        "key": "defaultValue"
+        "key": "defaultValue",
+        "supportsConditions": false
       },
       {
         "type": "event",
@@ -3143,7 +3149,8 @@
       {
         "type": "text",
         "label": "Default value",
-        "key": "defaultValue"
+        "key": "defaultValue",
+        "supportsConditions": false
       },
       {
         "type": "event",
@@ -3200,7 +3207,8 @@
       {
         "type": "text",
         "label": "Default value",
-        "key": "defaultValue"
+        "key": "defaultValue",
+        "supportsConditions": false
       },
       {
         "type": "event",
@@ -3301,7 +3309,8 @@
       {
         "type": "text",
         "label": "Default value",
-        "key": "defaultValue"
+        "key": "defaultValue",
+        "supportsConditions": false
       },
       {
         "type": "event",
@@ -3355,7 +3364,8 @@
       {
         "type": "text",
         "label": "Default value",
-        "key": "defaultValue"
+        "key": "defaultValue",
+        "supportsConditions": false
       },
       {
         "type": "boolean",
@@ -3622,7 +3632,8 @@
       {
         "type": "text",
         "label": "Default value",
-        "key": "defaultValue"
+        "key": "defaultValue",
+        "supportsConditions": false
       },
       {
         "type": "event",
@@ -3689,7 +3700,8 @@
       {
         "type": "text",
         "label": "Default value",
-        "key": "defaultValue"
+        "key": "defaultValue",
+        "supportsConditions": false
       },
       {
         "type": "event",


### PR DESCRIPTION
## Description
The "default value" setting for form fields will no longer appear as an option when updating settings via conditions. This has been changed for all field types.

Setting is now hidden:
![image](https://github.com/Budibase/budibase/assets/9075550/f3b9c3c5-52e1-4e1b-81d5-6f799a06bec1)

Also updated the conditions button to be in line with all our other buttons in settings:
![image](https://github.com/Budibase/budibase/assets/9075550/8527a938-72fc-4341-a765-97e642afdd67)
![image](https://github.com/Budibase/budibase/assets/9075550/8951af0b-36d0-4d6e-bbf9-6e0e72443a31)

Addresses: 
- https://linear.app/budibase/issue/BUDI-7464/remove-the-option-to-conditionally-update-default-value


