### PR TITLE
Fix relationship picker auto focusing search text

### DIFF
--- a/packages/client/src/components/app/forms/RelationshipField.svelte
+++ b/packages/client/src/components/app/forms/RelationshipField.svelte
@@ -83,7 +83,7 @@
       primaryDisplay !== "_id" &&
       fieldState?.value?.length &&
       !selectedOptions?.length &&
-      $fetch.rows?.length > 100
+      $fetch.rows?.length >= 100
     ) {
       API.searchTable({
         paginate: false,

--- a/packages/client/src/components/app/forms/RelationshipField.svelte
+++ b/packages/client/src/components/app/forms/RelationshipField.svelte
@@ -82,7 +82,8 @@
     if (
       primaryDisplay !== "_id" &&
       fieldState?.value?.length &&
-      !selectedOptions?.length
+      !selectedOptions?.length &&
+      $fetch.rows?.length > 100
     ) {
       API.searchTable({
         paginate: false,
@@ -231,7 +232,6 @@
       {#if autocomplete}
         <div class="search">
           <Input
-            autofocus
             quiet
             type="text"
             bind:value={searchString}


### PR DESCRIPTION
## Description
Removed autofocus on relationship picker search field. 

Also added in a performance fix to ensure a search isn't called when the number of relationships is within the 100 limit.

Addresses: 
- https://github.com/Budibase/budibase/issues/11853



