### PR TITLE
Fix for ensure Table Block Delete button displays when creating an auto generated screen.

### DIFF
--- a/packages/builder/src/builderStore/store/screenTemplates/rowListScreen.js
+++ b/packages/builder/src/builderStore/store/screenTemplates/rowListScreen.js
@@ -33,6 +33,8 @@ const generateTableBlock = datasource => {
       showTitleButton: true,
       titleButtonText: "Create row",
       titleButtonClickBehaviour: "new",
+      sidePanelSaveLabel: "Save",
+      sidePanelDeleteLabel: "Delete"
     })
     .instanceName(`${datasource.label} - Table block`)
   return tableBlock

--- a/packages/builder/src/builderStore/store/screenTemplates/rowListScreen.js
+++ b/packages/builder/src/builderStore/store/screenTemplates/rowListScreen.js
@@ -34,7 +34,7 @@ const generateTableBlock = datasource => {
       titleButtonText: "Create row",
       titleButtonClickBehaviour: "new",
       sidePanelSaveLabel: "Save",
-      sidePanelDeleteLabel: "Delete"
+      sidePanelDeleteLabel: "Delete",
     })
     .instanceName(`${datasource.label} - Table block`)
   return tableBlock

--- a/packages/client/src/components/app/blocks/TableBlock.svelte
+++ b/packages/client/src/components/app/blocks/TableBlock.svelte
@@ -249,7 +249,7 @@
             props={{
               dataSource,
               saveButtonLabel: sidePanelSaveLabel || "Save", //always show
-              deleteButtonLabel: deleteLabel, //respect config
+              deleteButtonLabel: deleteLabel == "" ? "" : "Delete",
               actionType: "Update",
               rowId: `{{ ${safe("state")}.${safe(stateKey)} }}`,
               fields: sidePanelFields || normalFields,

--- a/packages/client/src/components/app/blocks/TableBlock.svelte
+++ b/packages/client/src/components/app/blocks/TableBlock.svelte
@@ -45,8 +45,21 @@
   let enrichedSearchColumns
   let schemaLoaded = false
 
-  // Accommodate old config to ensure delete button does not reappear
-  $: deleteLabel = sidePanelShowDelete === false ? "" : sidePanelDeleteLabel
+  $: deleteLabel = setDeleteLabel(sidePanelDeleteLabel, sidePanelShowDelete)
+
+  const setDeleteLabel = sidePanelDeleteLabel => {
+    // Accommodate old config to ensure delete button does not reappear
+    let labelText = sidePanelShowDelete === false ? "" : sidePanelDeleteLabel
+
+    // Empty text is considered hidden.
+    if (labelText?.trim() === "") {
+      return ""
+    }
+
+    // Default to "Delete" if the value is unset
+    return labelText || "Delete"
+  }
+
   $: isDSPlus = dataSource?.type === "table" || dataSource?.type === "viewV2"
   $: fetchSchema(dataSource)
   $: enrichSearchColumns(searchColumns, schema).then(
@@ -249,7 +262,7 @@
             props={{
               dataSource,
               saveButtonLabel: sidePanelSaveLabel || "Save", //always show
-              deleteButtonLabel: deleteLabel == "" ? "" : "Delete",
+              deleteButtonLabel: deleteLabel,
               actionType: "Update",
               rowId: `{{ ${safe("state")}.${safe(stateKey)} }}`,
               fields: sidePanelFields || normalFields,


### PR DESCRIPTION
## Description

Fixes an issue where config required to display the `Delete` button in the table block is missing initially. 
- Suitable label defaults are now added when generating auto screens
- In the event that these are missing, the delete button will remain visible until the `Delete button` field is explicitly cleared 

Addresses: 
- https://github.com/Budibase/budibase/issues/11774



