### PR TITLE
Relationships disappearing when adding new columns fix

### DIFF
--- a/packages/builder/src/stores/backend/tables.js
+++ b/packages/builder/src/stores/backend/tables.js
@@ -81,12 +81,13 @@ export function createTablesStore() {
     replaceTable(savedTable._id, savedTable)
     select(savedTable._id)
     // make sure tables up to date (related)
-    const tableIdsToFetch = []
+    let tableIdsToFetch = []
     for (let column of Object.values(updatedTable?.schema || {})) {
       if (column.type === FIELDS.LINK.type) {
         tableIdsToFetch.push(column.tableId)
       }
     }
+    tableIdsToFetch = [...new Set(tableIdsToFetch)]
     // too many tables to fetch, just get all
     if (tableIdsToFetch.length > 3) {
       await fetch()
@@ -114,7 +115,6 @@ export function createTablesStore() {
     indexes,
   }) => {
     let draft = cloneDeep(get(derivedStore).selected)
-    console.log(draft)
 
     // delete the original if renaming
     // need to handle if the column had no name, empty string

--- a/packages/builder/src/stores/backend/tables.js
+++ b/packages/builder/src/stores/backend/tables.js
@@ -81,13 +81,18 @@ export function createTablesStore() {
     replaceTable(savedTable._id, savedTable)
     select(savedTable._id)
     // make sure tables up to date (related)
-    const tableUpdates = []
+    const tableIdsToFetch = []
     for (let column of Object.values(updatedTable?.schema || {})) {
       if (column.type === FIELDS.LINK.type) {
-        tableUpdates.push(singleFetch(column.tableId))
+        tableIdsToFetch.push(column.tableId)
       }
     }
-    await Promise.all(tableUpdates)
+    // too many tables to fetch, just get all
+    if (tableIdsToFetch.length > 3) {
+      await fetch()
+    } else {
+      await Promise.all(tableIdsToFetch.map(id => singleFetch(id)))
+    }
     return savedTable
   }
 

--- a/packages/builder/src/stores/backend/tables.js
+++ b/packages/builder/src/stores/backend/tables.js
@@ -1,7 +1,7 @@
 import { get, writable, derived } from "svelte/store"
 import { cloneDeep } from "lodash/fp"
 import { API } from "api"
-import { SWITCHABLE_TYPES } from "constants/backend"
+import { SWITCHABLE_TYPES, FIELDS } from "constants/backend"
 
 export function createTablesStore() {
   const store = writable({
@@ -19,6 +19,23 @@ export function createTablesStore() {
       ...state,
       list: tables,
     }))
+  }
+
+  const singleFetch = async tableId => {
+    const table = await API.getTable(tableId)
+    store.update(state => {
+      const list = []
+      // update the list, keep order accurate
+      for (let tbl of state.list) {
+        if (table._id === tbl._id) {
+          list.push(table)
+        } else {
+          list.push(tbl)
+        }
+      }
+      state.list = list
+      return state
+    })
   }
 
   const select = tableId => {
@@ -63,6 +80,14 @@ export function createTablesStore() {
     const savedTable = await API.saveTable(updatedTable)
     replaceTable(savedTable._id, savedTable)
     select(savedTable._id)
+    // make sure tables up to date (related)
+    const tableUpdates = []
+    for (let column of Object.values(updatedTable?.schema || {})) {
+      if (column.type === FIELDS.LINK.type) {
+        tableUpdates.push(singleFetch(column.tableId))
+      }
+    }
+    await Promise.all(tableUpdates)
     return savedTable
   }
 
@@ -84,6 +109,7 @@ export function createTablesStore() {
     indexes,
   }) => {
     let draft = cloneDeep(get(derivedStore).selected)
+    console.log(draft)
 
     // delete the original if renaming
     // need to handle if the column had no name, empty string

--- a/packages/frontend-core/src/api/tables.js
+++ b/packages/frontend-core/src/api/tables.js
@@ -82,12 +82,22 @@ export const buildTableEndpoints = API => ({
       },
     })
   },
+
   /**
-   * Gets a list o tables.
+   * Gets a list of tables.
    */
   getTables: async () => {
     return await API.get({
       url: "/api/tables",
+    })
+  },
+
+  /**
+   * Get a single table based on table ID.
+   */
+  getTable: async tableId => {
+    return await API.get({
+      url: `/api/tables/${tableId}`,
     })
   },
 

--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -1,4 +1,4 @@
-import { SqlQuery, Table, SearchFilters } from "@budibase/types"
+import { SqlQuery, Table, SearchFilters, Datasource } from "@budibase/types"
 import { DocumentType, SEPARATOR } from "../db/utils"
 import {
   FieldTypes,
@@ -184,7 +184,9 @@ export function getSqlQuery(query: SqlQuery | string): SqlQuery {
   }
 }
 
-export const isSQL = helpers.isSQL
+export function isSQL(datasource: Datasource) {
+  return helpers.isSQL(datasource)
+}
 
 export function isIsoDateString(str: string) {
   const trimmedValue = str.trim()


### PR DESCRIPTION
## Description
When a relationship is added it creates schema changes in both related tables, however the svelte store is only updated for the table you created the relationship in, rather than both tables. I've added some functionality to make sure that when adding/updating tables all related tables are also fetched to make sure the local state is correct.

Addresses:
- https://linear.app/budibase/issue/BUDI-7508/relationship-fields-disappears-from-the-data-area-when-a-new-column-is
- https://github.com/Budibase/budibase/issues/11807



