### PR TITLE
Splitting worker and server tests runners

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -30,8 +30,8 @@ jobs:
         with:
           root-reserve-mb: 35000
           swap-size-mb: 1024
-          remove-android: 'true'
-          remove-dotnet: 'true'
+          remove-android: "true"
+          remove-dotnet: "true"
       - name: Checkout repo and submodules
         uses: actions/checkout@v3
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'Budibase/budibase'
@@ -121,7 +121,7 @@ jobs:
           name: codecov-umbrella
           verbose: true
 
-  test-services:
+  test-worker:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo and submodules
@@ -143,12 +143,48 @@ jobs:
           node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
-      - name: Test worker and server
+      - name: Test worker
         run: |
           if ${{ env.USE_NX_AFFECTED }}; then
-            yarn test --scope=@budibase/worker --scope=@budibase/server --since=${{ env.NX_BASE_BRANCH }}
+            yarn test --scope=@budibase/worker --since=${{ env.NX_BASE_BRANCH }}
           else
-            yarn test --scope=@budibase/worker --scope=@budibase/server
+            yarn test --scope=@budibase/worker
+          fi
+
+      - uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN || github.token }} # not required for public repos
+          name: codecov-umbrella
+          verbose: true
+
+  test-server:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo and submodules
+        uses: actions/checkout@v3
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'Budibase/budibase'
+        with:
+          submodules: true
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          fetch-depth: 0
+      - name: Checkout repo only
+        uses: actions/checkout@v3
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'Budibase/budibase'
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: "yarn"
+      - run: yarn --frozen-lockfile
+      - name: Test server
+        run: |
+          if ${{ env.USE_NX_AFFECTED }}; then
+            yarn test --scope=@budibase/server --since=${{ env.NX_BASE_BRANCH }}
+          else
+            yarn test --scope=@budibase/server
           fi
 
       - uses: codecov/codecov-action@v3

--- a/packages/server/scripts/test.sh
+++ b/packages/server/scripts/test.sh
@@ -3,9 +3,8 @@ set -e
 
 if [[ -n $CI ]]
 then
-  # --runInBand performs better in ci where resources are limited
+  # Running in ci, where resources are limited
   export NODE_OPTIONS="--max-old-space-size=4096"
-  node ../../node_modules/jest/bin/jest.js --version
   echo "jest --coverage --maxWorkers=2 --forceExit --workerIdleMemoryLimit=2000MB --bail"
   jest --coverage --maxWorkers=2 --forceExit --workerIdleMemoryLimit=2000MB --bail
 else

--- a/packages/worker/scripts/test.sh
+++ b/packages/worker/scripts/test.sh
@@ -3,9 +3,9 @@ set -e
 
 if [[ -n $CI ]]
 then
-  # --runInBand performs better in ci where resources are limited
-  echo "jest --coverage --runInBand --forceExit --bail"
-  jest --coverage --runInBand --forceExit --bail
+  # Running in ci, where resources are limited
+  echo "jest --coverage --maxWorkers=2  --forceExit --bail"
+  jest --coverage --maxWorkers=2  --forceExit --bail
 else
   # --maxWorkers performs better in development
   echo "jest --coverage --maxWorkers=2 --forceExit"


### PR DESCRIPTION
## Description
These tests are the flakiest given it's heavy resource usage and conflicting with the limited GitHub runners. Splitting each one into its own pipeline will hopefully fix flakiness and speed up processes