### PR TITLE
Check manyRelationships length

### DIFF
--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -818,7 +818,10 @@ export class ExternalRequest {
     // can't really use response right now
     const response = await getDatasourceAndQuery(json)
     // handle many to many relationships now if we know the ID (could be auto increment)
-    if (operation !== Operation.READ && processed.manyRelationships) {
+    if (
+      operation !== Operation.READ &&
+      processed.manyRelationships?.length > 0
+    ) {
       await this.handleManyRelationships(
         table._id || "",
         response[0],


### PR DESCRIPTION
## Description
Noticed that the boolean check for `processed.manyRelationships` could never be false as it was initialised to an empty array.

Now checking the length to ensure `handleManyRelationships` is not called when saving a  One -> Many scenario, but without any relationships

Addresses: 
- https://github.com/Budibase/budibase/issues/11904



