### PR TITLE
Fixing DS+ save rows

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -33,7 +33,7 @@
   import { getBindings } from "components/backend/DataTable/formula"
   import JSONSchemaModal from "./JSONSchemaModal.svelte"
   import { ValidColumnNameRegex } from "@budibase/shared-core"
-  import { FieldSubtype, FieldType } from "@budibase/types"
+  import { FieldType } from "@budibase/types"
   import RelationshipSelector from "components/common/RelationshipSelector.svelte"
 
   const AUTO_TYPE = "auto"
@@ -43,11 +43,7 @@
   const NUMBER_TYPE = FIELDS.NUMBER.type
   const JSON_TYPE = FIELDS.JSON.type
   const DATE_TYPE = FIELDS.DATETIME.type
-  const BB_REFERENCE_TYPE = FieldType.BB_REFERENCE
-  const BB_USER_REFERENCE_TYPE = composeType(
-    BB_REFERENCE_TYPE,
-    FieldSubtype.USER
-  )
+  const USER_REFRENCE_TYPE = FIELDS.BB_REFERENCE_USER.compositeType
 
   const dispatch = createEventDispatcher()
   const PROHIBITED_COLUMN_NAMES = ["type", "_id", "_rev", "tableId"]
@@ -79,33 +75,6 @@
     // Initial value for column name in other table for linked records
     fieldName: $tables.selected.name,
   }
-
-  const bbRefTypeMapping = {}
-
-  function composeType(fieldType, subtype) {
-    return `${fieldType}_${subtype}`
-  }
-
-  // Handling fields with subtypes
-  fieldDefinitions = Object.entries(fieldDefinitions).reduce(
-    (p, [key, field]) => {
-      if (field.type === BB_REFERENCE_TYPE) {
-        const composedType = composeType(field.type, field.subtype)
-        p[key] = {
-          ...field,
-          type: composedType,
-        }
-        bbRefTypeMapping[composedType] = {
-          type: field.type,
-          subtype: field.subtype,
-        }
-      } else {
-        p[key] = field
-      }
-      return p
-    },
-    {}
-  )
 
   $: if (primaryDisplay) {
     editableColumn.constraints.presence = { allowEmpty: false }
@@ -149,12 +118,8 @@
         $tables.selected.primaryDisplay == null ||
         $tables.selected.primaryDisplay === editableColumn.name
 
-      const mapped = Object.entries(bbRefTypeMapping).find(
-        ([_, v]) => v.type === field.type && v.subtype === field.subtype
-      )
-      if (mapped) {
-        editableColumn.type = mapped[0]
-        delete editableColumn.subtype
+      if (editableColumn.type === FieldType.BB_REFERENCE) {
+        editableColumn.type = `${editableColumn.type}_${editableColumn.subtype}`
       }
     } else if (!savingColumn) {
       let highestNumber = 0
@@ -187,8 +152,6 @@
   }
 
   $: initialiseField(field, savingColumn)
-
-  $: isBBReference = !!bbRefTypeMapping[editableColumn.type]
 
   $: checkConstraints(editableColumn)
   $: required = !!editableColumn?.constraints?.presence || primaryDisplay
@@ -265,11 +228,12 @@
 
     let saveColumn = cloneDeep(editableColumn)
 
-    if (bbRefTypeMapping[saveColumn.type]) {
-      saveColumn = {
-        ...saveColumn,
-        ...bbRefTypeMapping[saveColumn.type],
-      }
+    // Handle types on composite types
+    const definition = fieldDefinitions[saveColumn.type.toUpperCase()]
+    if (definition && saveColumn.type === definition.compositeType) {
+      saveColumn.type = definition.type
+      saveColumn.subtype = definition.subtype
+      delete saveColumn.compositeType
     }
 
     if (saveColumn.type === AUTO_TYPE) {
@@ -352,7 +316,7 @@
       editableColumn.relationshipType = RelationshipType.MANY_TO_MANY
     } else if (editableColumn.type === FORMULA_TYPE) {
       editableColumn.formulaType = "dynamic"
-    } else if (editableColumn.type === BB_USER_REFERENCE_TYPE) {
+    } else if (editableColumn.type === USER_REFRENCE_TYPE) {
       editableColumn.relationshipType = RelationshipType.ONE_TO_MANY
     }
   }
@@ -410,13 +374,11 @@
         FIELDS.BOOLEAN,
         FIELDS.FORMULA,
         FIELDS.BIGINT,
+        FIELDS.BB_REFERENCE_USER,
       ]
       // no-sql or a spreadsheet
       if (!external || table.sql) {
         fields = [...fields, FIELDS.LINK, FIELDS.ARRAY]
-      }
-      if (fieldDefinitions.USER) {
-        fields.push(fieldDefinitions.USER)
       }
       return fields
     }
@@ -426,8 +388,9 @@
     if (!fieldToCheck) {
       return
     }
+
     // most types need this, just make sure its always present
-    if (fieldToCheck && !fieldToCheck.constraints) {
+    if (!fieldToCheck.constraints) {
       fieldToCheck.constraints = {}
     }
     // some string types may have been built by server, may not always have constraints
@@ -507,7 +470,7 @@
     on:change={handleTypeChange}
     options={allowedTypes}
     getOptionLabel={field => field.name}
-    getOptionValue={field => field.type}
+    getOptionValue={field => field.compositeType || field.type}
     getOptionIcon={field => field.icon}
     isOptionEnabled={option => {
       if (option.type == AUTO_TYPE) {
@@ -671,7 +634,7 @@
     <Button primary text on:click={openJsonSchemaEditor}
       >Open schema editor</Button
     >
-  {:else if isBBReference}
+  {:else if editableColumn.type === USER_REFRENCE_TYPE}
     <Toggle
       value={editableColumn.relationshipType === RelationshipType.MANY_TO_MANY}
       on:change={e =>

--- a/packages/builder/src/constants/backend/index.js
+++ b/packages/builder/src/constants/backend/index.js
@@ -120,10 +120,11 @@ export const FIELDS = {
       presence: false,
     },
   },
-  USER: {
+  BB_REFERENCE_USER: {
     name: "User",
     type: "bb_reference",
     subtype: "user",
+    compositeType: "bb_reference_user", // Used for working with the subtype on CreateEditColumn as is it was a primary type
     icon: "User",
   },
 }

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -132,8 +132,7 @@ export async function find(ctx: UserCtx): Promise<Row> {
     ctx.throw(404)
   }
 
-  const table = await sdk.tables.getTable(tableId)
-  return await outputProcessing(table, row)
+  return row
 }
 
 export async function destroy(ctx: UserCtx) {

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -49,20 +49,20 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   const tableId = utils.getTableId(ctx)
   const { _id, ...rowData } = ctx.request.body
 
-  const validateResult = await sdk.rows.utils.validate({
-    row: rowData,
-    tableId,
-  })
-  if (!validateResult.valid) {
-    throw { validation: validateResult.errors }
-  }
-
   const table = await sdk.tables.getTable(tableId)
   const { row: dataToUpdate } = await inputProcessing(
     ctx.user?._id,
     cloneDeep(table),
     rowData
   )
+
+  const validateResult = await sdk.rows.utils.validate({
+    row: dataToUpdate,
+    tableId,
+  })
+  if (!validateResult.valid) {
+    throw { validation: validateResult.errors }
+  }
 
   const response = await handleRequest(Operation.UPDATE, tableId, {
     id: breakRowIdField(_id),
@@ -81,13 +81,6 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
 export async function save(ctx: UserCtx) {
   const inputs = ctx.request.body
   const tableId = utils.getTableId(ctx)
-  const validateResult = await sdk.rows.utils.validate({
-    row: inputs,
-    tableId,
-  })
-  if (!validateResult.valid) {
-    throw { validation: validateResult.errors }
-  }
 
   const table = await sdk.tables.getTable(tableId)
   const { table: updatedTable, row } = await inputProcessing(
@@ -95,6 +88,14 @@ export async function save(ctx: UserCtx) {
     cloneDeep(table),
     inputs
   )
+
+  const validateResult = await sdk.rows.utils.validate({
+    row,
+    tableId,
+  })
+  if (!validateResult.valid) {
+    throw { validation: validateResult.errors }
+  }
 
   const response = await handleRequest(Operation.CREATE, tableId, {
     row,

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -18,7 +18,10 @@ import {
 import sdk from "../../../sdk"
 import * as utils from "./utils"
 import { dataFilters } from "@budibase/shared-core"
-import { inputProcessing } from "../../../utilities/rowProcessor"
+import {
+  inputProcessing,
+  outputProcessing,
+} from "../../../utilities/rowProcessor"
 import { cloneDeep, isEqual } from "lodash"
 
 export async function handleRequest(
@@ -121,7 +124,8 @@ export async function find(ctx: UserCtx): Promise<Row> {
     ctx.throw(404)
   }
 
-  return row
+  const table = await sdk.tables.getTable(tableId)
+  return await outputProcessing(table, row)
 }
 
 export async function destroy(ctx: UserCtx) {

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -115,11 +115,9 @@ export async function save(ctx: UserCtx) {
     return {
       ...response,
       row,
-      // row: await outputProcessing(table, row),
     }
   } else {
     return response
-    // return outputProcessing(table, response)
   }
 }
 

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -56,14 +56,21 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   if (!validateResult.valid) {
     throw { validation: validateResult.errors }
   }
+
+  const table = await sdk.tables.getTable(tableId)
+  const { row: dataToUpdate } = await inputProcessing(
+    ctx.user?._id,
+    cloneDeep(table),
+    rowData
+  )
+
   const response = await handleRequest(Operation.UPDATE, tableId, {
     id: breakRowIdField(_id),
-    row: rowData,
+    row: dataToUpdate,
   })
   const row = await sdk.rows.external.getRow(tableId, _id, {
     relationships: true,
   })
-  const table = await sdk.tables.getTable(tableId)
   return {
     ...response,
     row,
@@ -107,9 +114,11 @@ export async function save(ctx: UserCtx) {
     return {
       ...response,
       row,
+      // row: await outputProcessing(table, row),
     }
   } else {
     return response
+    // return outputProcessing(table, response)
   }
 }
 

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -133,7 +133,11 @@ export async function find(ctx: UserCtx): Promise<Row> {
   }
 
   const table = await sdk.tables.getTable(tableId)
-  return await outputProcessing(table, row)
+  // Preserving links, as the outputProcessing does not support external rows yet and we don't need it in this use case
+  return await outputProcessing(table, row, {
+    squash: false,
+    preserveLinks: true,
+  })
 }
 
 export async function destroy(ctx: UserCtx) {

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -73,7 +73,7 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   })
   return {
     ...response,
-    row,
+    row: await outputProcessing(table, row),
     table,
   }
 }
@@ -114,7 +114,7 @@ export async function save(ctx: UserCtx) {
     })
     return {
       ...response,
-      row,
+      row: await outputProcessing(table, row),
     }
   } else {
     return response
@@ -132,7 +132,8 @@ export async function find(ctx: UserCtx): Promise<Row> {
     ctx.throw(404)
   }
 
-  return row
+  const table = await sdk.tables.getTable(tableId)
+  return await outputProcessing(table, row)
 }
 
 export async function destroy(ctx: UserCtx) {

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -1753,5 +1753,139 @@ describe.each([
         _rev: expect.any(String),
       })
     })
+
+    it("fetch all will populate the BB references", async () => {
+      const [user1, user2, user3] = _.sampleSize(users, 3)
+
+      const rows: {
+        name: string
+        description: string
+        user?: User[]
+        users?: User[]
+        tableId: string
+      }[] = [
+        {
+          ...basicRow(tableId),
+          name: generator.name(),
+          description: generator.name(),
+          users: [user1, user2],
+        },
+        {
+          ...basicRow(tableId),
+          name: generator.name(),
+          description: generator.name(),
+          user: [user1],
+          users: [user1, user3],
+        },
+        {
+          ...basicRow(tableId),
+          name: generator.name(),
+          description: generator.name(),
+          users: [user3],
+        },
+      ]
+
+      await config.api.row.save(tableId, rows[0])
+      await config.api.row.save(tableId, rows[1])
+      await config.api.row.save(tableId, rows[2])
+
+      const res = await config.api.row.fetch(tableId)
+
+      expect(res).toEqual(
+        expect.arrayContaining(
+          rows.map(r => ({
+            name: r.name,
+            description: r.description,
+            type: "row",
+            tableId,
+            user: r.user?.map(u => ({
+              _id: u._id,
+              email: u.email,
+              firstName: u.firstName,
+              lastName: u.lastName,
+              primaryDisplay: u.email,
+            })),
+            users: r.users?.map(u => ({
+              _id: u._id,
+              email: u.email,
+              firstName: u.firstName,
+              lastName: u.lastName,
+              primaryDisplay: u.email,
+            })),
+            _id: expect.any(String),
+            _rev: expect.any(String),
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          }))
+        )
+      )
+    })
+
+    it("search all will populate the BB references", async () => {
+      const [user1, user2, user3] = _.sampleSize(users, 3)
+
+      const rows: {
+        name: string
+        description: string
+        user?: User[]
+        users?: User[]
+        tableId: string
+      }[] = [
+        {
+          ...basicRow(tableId),
+          name: generator.name(),
+          description: generator.name(),
+          users: [user1, user2],
+        },
+        {
+          ...basicRow(tableId),
+          name: generator.name(),
+          description: generator.name(),
+          user: [user1],
+          users: [user1, user3],
+        },
+        {
+          ...basicRow(tableId),
+          name: generator.name(),
+          description: generator.name(),
+          users: [user3],
+        },
+      ]
+
+      await config.api.row.save(tableId, rows[0])
+      await config.api.row.save(tableId, rows[1])
+      await config.api.row.save(tableId, rows[2])
+
+      const res = await config.api.row.search(tableId)
+
+      expect(res).toEqual({
+        rows: expect.arrayContaining(
+          rows.map(r => ({
+            name: r.name,
+            description: r.description,
+            type: "row",
+            tableId,
+            user: r.user?.map(u => ({
+              _id: u._id,
+              email: u.email,
+              firstName: u.firstName,
+              lastName: u.lastName,
+              primaryDisplay: u.email,
+            })),
+            users: r.users?.map(u => ({
+              _id: u._id,
+              email: u.email,
+              firstName: u.firstName,
+              lastName: u.lastName,
+              primaryDisplay: u.email,
+            })),
+            _id: expect.any(String),
+            _rev: expect.any(String),
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          }))
+        ),
+      })
+    })
   })
 })

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -1518,8 +1518,16 @@ describe.each([
   describe("bb reference fields", () => {
     let tableId: string
     let users: User[]
+
     beforeAll(async () => {
       const tableConfig = generateTableConfig()
+
+      if (config.datasource) {
+        tableConfig.sourceId = config.datasource._id
+        if (config.datasource.plus) {
+          tableConfig.type = "external"
+        }
+      }
       const table = await config.api.table.create({
         ...tableConfig,
         schema: {
@@ -1559,10 +1567,11 @@ describe.each([
       expect(row).toEqual({
         name: rowData.name,
         description: rowData.description,
-        type: "row",
         tableId,
         _id: expect.any(String),
         _rev: expect.any(String),
+        id: isInternal ? undefined : expect.any(Number),
+        type: isInternal ? "row" : undefined,
       })
     })
 
@@ -1579,7 +1588,6 @@ describe.each([
       expect(row).toEqual({
         name: rowData.name,
         description: rowData.description,
-        type: "row",
         tableId,
         user: [
           {
@@ -1592,6 +1600,8 @@ describe.each([
         ],
         _id: expect.any(String),
         _rev: expect.any(String),
+        id: isInternal ? undefined : expect.any(Number),
+        type: isInternal ? "row" : undefined,
       })
     })
 
@@ -1608,7 +1618,6 @@ describe.each([
       expect(row).toEqual({
         name: rowData.name,
         description: rowData.description,
-        type: "row",
         tableId,
         users: selectedUsers.map(u => ({
           _id: u._id,
@@ -1619,6 +1628,8 @@ describe.each([
         })),
         _id: expect.any(String),
         _rev: expect.any(String),
+        id: isInternal ? undefined : expect.any(Number),
+        type: isInternal ? "row" : undefined,
       })
     })
 
@@ -1634,14 +1645,13 @@ describe.each([
       expect(retrieved).toEqual({
         name: rowData.name,
         description: rowData.description,
-        type: "row",
         tableId,
         user: undefined,
         users: undefined,
         _id: row._id,
         _rev: expect.any(String),
-        createdAt: timestamp,
-        updatedAt: timestamp,
+        id: isInternal ? undefined : expect.any(Number),
+        ...defaultRowFields,
       })
     })
 
@@ -1661,7 +1671,6 @@ describe.each([
       expect(retrieved).toEqual({
         name: rowData.name,
         description: rowData.description,
-        type: "row",
         tableId,
         user: [user1].map(u => ({
           _id: u._id,
@@ -1679,8 +1688,8 @@ describe.each([
         })),
         _id: row._id,
         _rev: expect.any(String),
-        createdAt: timestamp,
-        updatedAt: timestamp,
+        id: isInternal ? undefined : expect.any(Number),
+        ...defaultRowFields,
       })
     })
 
@@ -1703,7 +1712,6 @@ describe.each([
       expect(updatedRow).toEqual({
         name: rowData.name,
         description: rowData.description,
-        type: "row",
         tableId,
         user: [
           {
@@ -1723,6 +1731,8 @@ describe.each([
         })),
         _id: row._id,
         _rev: expect.any(String),
+        id: isInternal ? undefined : expect.any(Number),
+        type: isInternal ? "row" : undefined,
       })
     })
 
@@ -1745,12 +1755,13 @@ describe.each([
       expect(updatedRow).toEqual({
         name: rowData.name,
         description: rowData.description,
-        type: "row",
         tableId,
-        user: null,
-        users: null,
+        user: isInternal ? null : undefined,
+        users: isInternal ? null : undefined,
         _id: row._id,
         _rev: expect.any(String),
+        id: isInternal ? undefined : expect.any(Number),
+        type: isInternal ? "row" : undefined,
       })
     })
 
@@ -1796,7 +1807,6 @@ describe.each([
           rows.map(r => ({
             name: r.name,
             description: r.description,
-            type: "row",
             tableId,
             user: r.user?.map(u => ({
               _id: u._id,
@@ -1814,8 +1824,8 @@ describe.each([
             })),
             _id: expect.any(String),
             _rev: expect.any(String),
-            createdAt: timestamp,
-            updatedAt: timestamp,
+            id: isInternal ? undefined : expect.any(Number),
+            ...defaultRowFields,
           }))
         )
       )
@@ -1863,7 +1873,6 @@ describe.each([
           rows.map(r => ({
             name: r.name,
             description: r.description,
-            type: "row",
             tableId,
             user: r.user?.map(u => ({
               _id: u._id,
@@ -1881,10 +1890,16 @@ describe.each([
             })),
             _id: expect.any(String),
             _rev: expect.any(String),
-            createdAt: timestamp,
-            updatedAt: timestamp,
+            id: isInternal ? undefined : expect.any(Number),
+            ...defaultRowFields,
           }))
         ),
+        ...(isInternal
+          ? {}
+          : {
+              hasNextPage: false,
+              bookmark: null,
+            }),
       })
     })
   })

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -1612,6 +1612,71 @@ describe.each([
       })
     })
 
+    it("can retrieve rows with no populated BB references", async () => {
+      const rowData = {
+        ...basicRow(tableId),
+        name: generator.name(),
+        description: generator.name(),
+      }
+      const row = await config.api.row.save(tableId, rowData)
+
+      const { body: retrieved } = await config.api.row.get(tableId, row._id!)
+      expect(retrieved).toEqual({
+        name: rowData.name,
+        description: rowData.description,
+        type: "row",
+        tableId,
+        user: undefined,
+        users: undefined,
+        _id: row._id,
+        _rev: expect.any(String),
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      })
+    })
+
+    it("can retrieve rows with populated BB references", async () => {
+      const [user1, user2] = [
+        await config.createUser(),
+        await config.createUser(),
+      ]
+
+      const rowData = {
+        ...basicRow(tableId),
+        name: generator.name(),
+        description: generator.name(),
+        users: [user1, user2],
+        user: [user1],
+      }
+      const row = await config.api.row.save(tableId, rowData)
+
+      const { body: retrieved } = await config.api.row.get(tableId, row._id!)
+      expect(retrieved).toEqual({
+        name: rowData.name,
+        description: rowData.description,
+        type: "row",
+        tableId,
+        user: [user1].map(u => ({
+          _id: u._id,
+          email: u.email,
+          firstName: u.firstName,
+          lastName: u.lastName,
+          primaryDisplay: u.email,
+        })),
+        users: [user1, user2].map(u => ({
+          _id: u._id,
+          email: u.email,
+          firstName: u.firstName,
+          lastName: u.lastName,
+          primaryDisplay: u.email,
+        })),
+        _id: row._id,
+        _rev: expect.any(String),
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      })
+    })
+
     it("can update an existing populated row", async () => {
       const [user1, user2, user3] = [
         await config.createUser(),

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -1539,7 +1539,7 @@ describe.each([
       tableId = table._id!
     })
 
-    it("can save and retrieve when BB reference fields are empty", async () => {
+    it("can save a row when BB reference fields are empty", async () => {
       const rowData = {
         ...basicRow(tableId),
         name: generator.name(),
@@ -1557,7 +1557,7 @@ describe.each([
       })
     })
 
-    it("can save and retrieve a row with a single BB reference field", async () => {
+    it("can save a row with a single BB reference field", async () => {
       const user = await config.createUser()
       const rowData = {
         ...basicRow(tableId),
@@ -1586,13 +1586,13 @@ describe.each([
       })
     })
 
-    it("can save and retrieve a row with a multiple BB reference field", async () => {
+    it("can save a row with a multiple BB reference field", async () => {
       const users = [await config.createUser(), await config.createUser()]
       const rowData = {
         ...basicRow(tableId),
         name: generator.name(),
         description: generator.name(),
-        user: users,
+        users: users,
       }
       const row = await config.api.row.save(tableId, rowData)
 
@@ -1601,7 +1601,7 @@ describe.each([
         description: rowData.description,
         type: "row",
         tableId,
-        user: users.map(u => ({
+        users: users.map(u => ({
           _id: u._id,
           email: u.email,
           firstName: u.firstName,
@@ -1609,6 +1609,52 @@ describe.each([
           primaryDisplay: u.email,
         })),
         _id: expect.any(String),
+        _rev: expect.any(String),
+      })
+    })
+
+    it("can update an existing populated row", async () => {
+      const [user1, user2, user3] = [
+        await config.createUser(),
+        await config.createUser(),
+        await config.createUser(),
+      ]
+
+      const rowData = {
+        ...basicRow(tableId),
+        name: generator.name(),
+        description: generator.name(),
+        users: [user1, user2],
+      }
+      const row = await config.api.row.save(tableId, rowData)
+
+      const updatedRow = await config.api.row.save(tableId, {
+        ...row,
+        user: [user3],
+        users: [user3, user2],
+      })
+      expect(updatedRow).toEqual({
+        name: rowData.name,
+        description: rowData.description,
+        type: "row",
+        tableId,
+        user: [
+          {
+            _id: user3._id,
+            email: user3.email,
+            firstName: user3.firstName,
+            lastName: user3.lastName,
+            primaryDisplay: user3.email,
+          },
+        ],
+        users: [user3, user2].map(u => ({
+          _id: u._id,
+          email: u.email,
+          firstName: u.firstName,
+          lastName: u.lastName,
+          primaryDisplay: u.email,
+        })),
+        _id: row._id,
         _rev: expect.any(String),
       })
     })

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -26,7 +26,6 @@ import {
   mocks,
   structures,
 } from "@budibase/backend-core/tests"
-import { async } from "validate.js"
 
 const timestamp = new Date("2023-01-26T11:48:57.597Z").toISOString()
 tk.freeze(timestamp)
@@ -1654,6 +1653,37 @@ describe.each([
           lastName: u.lastName,
           primaryDisplay: u.email,
         })),
+        _id: row._id,
+        _rev: expect.any(String),
+      })
+    })
+
+    it("can wipe an existing populated BB references in row", async () => {
+      const [user1, user2] = [
+        await config.createUser(),
+        await config.createUser(),
+      ]
+
+      const rowData = {
+        ...basicRow(tableId),
+        name: generator.name(),
+        description: generator.name(),
+        users: [user1, user2],
+      }
+      const row = await config.api.row.save(tableId, rowData)
+
+      const updatedRow = await config.api.row.save(tableId, {
+        ...row,
+        user: null,
+        users: null,
+      })
+      expect(updatedRow).toEqual({
+        name: rowData.name,
+        description: rowData.description,
+        type: "row",
+        tableId,
+        user: null,
+        users: null,
         _id: row._id,
         _rev: expect.any(String),
       })

--- a/packages/server/src/sdk/app/rows/external.ts
+++ b/packages/server/src/sdk/app/rows/external.ts
@@ -1,8 +1,6 @@
 import { IncludeRelationship, Operation, Row } from "@budibase/types"
 import { handleRequest } from "../../../api/controllers/row/external"
 import { breakRowIdField } from "../../../integrations/utils"
-import { outputProcessing } from "../../../utilities/rowProcessor"
-import sdk from "../../../sdk"
 
 export async function getRow(
   tableId: string,
@@ -15,9 +13,5 @@ export async function getRow(
       ? IncludeRelationship.INCLUDE
       : IncludeRelationship.EXCLUDE,
   })) as Row[]
-  const row = response ? response[0] : response
-
-  const table = await sdk.tables.getTable(tableId)
-  const enrichedRow = await outputProcessing(table, row)
-  return enrichedRow
+  return response ? response[0] : response
 }

--- a/packages/server/src/sdk/app/rows/external.ts
+++ b/packages/server/src/sdk/app/rows/external.ts
@@ -1,6 +1,8 @@
 import { IncludeRelationship, Operation, Row } from "@budibase/types"
 import { handleRequest } from "../../../api/controllers/row/external"
 import { breakRowIdField } from "../../../integrations/utils"
+import { outputProcessing } from "../../../utilities/rowProcessor"
+import sdk from "../../../sdk"
 
 export async function getRow(
   tableId: string,
@@ -13,5 +15,9 @@ export async function getRow(
       ? IncludeRelationship.INCLUDE
       : IncludeRelationship.EXCLUDE,
   })) as Row[]
-  return response ? response[0] : response
+  const row = response ? response[0] : response
+
+  const table = await sdk.tables.getTable(tableId)
+  const enrichedRow = await outputProcessing(table, row)
+  return enrichedRow
 }

--- a/packages/server/src/sdk/app/rows/search/external.ts
+++ b/packages/server/src/sdk/app/rows/search/external.ts
@@ -17,7 +17,6 @@ import { utils } from "@budibase/shared-core"
 import { ExportRowsParams, ExportRowsResult } from "../search"
 import { HTTPError, db } from "@budibase/backend-core"
 import pick from "lodash/pick"
-import { outputProcessing } from "../../../../utilities/rowProcessor"
 
 export async function search(options: SearchParams) {
   const { tableId } = options
@@ -75,9 +74,6 @@ export async function search(options: SearchParams) {
       const fields = [...options.fields, ...db.CONSTANT_EXTERNAL_ROW_COLS]
       rows = rows.map((r: any) => pick(r, fields))
     }
-
-    const table = await sdk.tables.getTable(tableId)
-    rows = await outputProcessing(table, rows)
 
     // need wrapper object for bookmarks etc when paginating
     return { rows, hasNextPage, bookmark: bookmark && bookmark + 1 }

--- a/packages/server/src/sdk/app/rows/search/external.ts
+++ b/packages/server/src/sdk/app/rows/search/external.ts
@@ -17,6 +17,7 @@ import { utils } from "@budibase/shared-core"
 import { ExportRowsParams, ExportRowsResult } from "../search"
 import { HTTPError, db } from "@budibase/backend-core"
 import pick from "lodash/pick"
+import { outputProcessing } from "../../../../utilities/rowProcessor"
 
 export async function search(options: SearchParams) {
   const { tableId } = options
@@ -74,6 +75,9 @@ export async function search(options: SearchParams) {
       const fields = [...options.fields, ...db.CONSTANT_EXTERNAL_ROW_COLS]
       rows = rows.map((r: any) => pick(r, fields))
     }
+
+    const table = await sdk.tables.getTable(tableId)
+    rows = await outputProcessing(table, rows)
 
     // need wrapper object for bookmarks etc when paginating
     return { rows, hasNextPage, bookmark: bookmark && bookmark + 1 }

--- a/packages/server/src/sdk/tests/rows/row.spec.ts
+++ b/packages/server/src/sdk/tests/rows/row.spec.ts
@@ -7,9 +7,14 @@ import { HTTPError } from "@budibase/backend-core"
 import { Operation } from "@budibase/types"
 
 const mockDatasourcesGet = jest.fn()
+const mockTableGet = jest.fn()
 sdk.datasources.get = mockDatasourcesGet
+sdk.tables.getTable = mockTableGet
 
 jest.mock("../../../api/controllers/row/ExternalRequest")
+jest.mock("../../../utilities/rowProcessor", () => ({
+  outputProcessing: jest.fn((_, rows) => rows),
+}))
 
 jest.mock("../../../api/controllers/view/exporters", () => ({
   ...jest.requireActual("../../../api/controllers/view/exporters"),

--- a/packages/server/src/tests/utilities/api/row.ts
+++ b/packages/server/src/tests/utilities/api/row.ts
@@ -122,4 +122,16 @@ export class RowAPI extends TestAPI {
       .expect(expectStatus)
     return request
   }
+
+  search = async (
+    sourceId: string,
+    { expectStatus } = { expectStatus: 200 }
+  ): Promise<Row[]> => {
+    const request = this.request
+      .post(`/api/${sourceId}/search`)
+      .set(this.config.defaultHeaders())
+      .expect(expectStatus)
+
+    return (await request).body
+  }
 }

--- a/packages/server/src/tests/utilities/api/row.ts
+++ b/packages/server/src/tests/utilities/api/row.ts
@@ -44,12 +44,12 @@ export class RowAPI extends TestAPI {
   }
 
   save = async (
-    sourceId: string,
+    tableId: string,
     row: SaveRowRequest,
     { expectStatus } = { expectStatus: 200 }
   ): Promise<Row> => {
     const resp = await this.request
-      .post(`/api/${sourceId}/rows`)
+      .post(`/api/${tableId}/rows`)
       .send(row)
       .set(this.config.defaultHeaders())
       .expect("Content-Type", /json/)

--- a/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
+++ b/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
@@ -6,7 +6,7 @@ import { InvalidBBRefError } from "./errors"
 export async function processInputBBReferences(
   value: string | string[] | { _id: string } | { _id: string }[],
   subtype: FieldSubtype
-): Promise<string | undefined> {
+): Promise<string | null> {
   const referenceIds: string[] = []
 
   if (Array.isArray(value)) {
@@ -39,7 +39,7 @@ export async function processInputBBReferences(
       throw utils.unreachable(subtype)
   }
 
-  return referenceIds.join(",") || undefined
+  return referenceIds.join(",") || null
 }
 
 export async function processOutputBBReferences(

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -200,7 +200,10 @@ export async function inputProcessing(
 export async function outputProcessing<T extends Row[] | Row>(
   table: Table,
   rows: T,
-  opts = { squash: true }
+  opts: { squash?: boolean; preserveLinks?: boolean } = {
+    squash: true,
+    preserveLinks: false,
+  }
 ): Promise<T> {
   let safeRows: Row[]
   let wasArray = true
@@ -211,7 +214,9 @@ export async function outputProcessing<T extends Row[] | Row>(
     safeRows = rows
   }
   // attach any linked row information
-  let enriched = await linkRows.attachFullLinkedDocs(table, safeRows)
+  let enriched = !opts.preserveLinks
+    ? await linkRows.attachFullLinkedDocs(table, safeRows)
+    : safeRows
 
   // process formulas
   enriched = processFormulas(table, enriched, { dynamic: true }) as Row[]

--- a/packages/server/src/utilities/rowProcessor/tests/bbReferenceProcessor.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/bbReferenceProcessor.spec.ts
@@ -139,20 +139,20 @@ describe("bbReferenceProcessor", () => {
         expect(cacheGetUsersSpy).toBeCalledWith(userIds)
       })
 
-      it("empty strings will return undefined", async () => {
+      it("empty strings will return null", async () => {
         const result = await config.doInTenant(() =>
           processInputBBReferences("", FieldSubtype.USER)
         )
 
-        expect(result).toEqual(undefined)
+        expect(result).toEqual(null)
       })
 
-      it("empty arrays will return undefined", async () => {
+      it("empty arrays will return null", async () => {
         const result = await config.doInTenant(() =>
           processInputBBReferences([], FieldSubtype.USER)
         )
 
-        expect(result).toEqual(undefined)
+        expect(result).toEqual(null)
       })
     })
   })


### PR DESCRIPTION
## Description
Fixing DS+ user field type, ensuring that the fields are saved as retrieved properly.
Also refactoring the `CreateEditColumn.svelte` file in order to remove hardcodings and make the fields more extensible and rely only on the field configuration.
Added tests for the row API