### PR TITLE
Add header background on query page when scrolling

### DIFF
--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -337,11 +337,12 @@
     padding: 8px 10px 8px 16px;
     display: flex;
     border-bottom: 2px solid transparent;
-    transition: border-bottom 130ms ease-out;
+    transition: border-bottom 130ms ease-out, background 130ms ease-out;
   }
 
   .header.scrolling {
     border-bottom: var(--border-light);
+    background: var(--background);
   }
 
   .body {


### PR DESCRIPTION
## Description
Tiny change to add a background to the query page header (as well as the existing border) when scrolling.

Before:
![image](https://github.com/Budibase/budibase/assets/9075550/318fdff3-6318-4565-99db-4652f65f4294)

After:
![image](https://github.com/Budibase/budibase/assets/9075550/7e274290-2e1e-4064-b09d-557a252f9d7a)

It matches the reset of the page and makes the scroll more obvious:
![image](https://github.com/Budibase/budibase/assets/9075550/ce9e715c-b834-45c8-8fa9-7d3d32320ec3)

