### PR TITLE
Make sure field state is valid

### DIFF
--- a/packages/client/src/components/app/forms/RelationshipField.svelte
+++ b/packages/client/src/components/app/forms/RelationshipField.svelte
@@ -121,7 +121,12 @@
     if (!Array.isArray(values)) {
       values = [values]
     }
-    return values.map(value => (typeof value === "object" ? value._id : value))
+    values = values.map(value =>
+      typeof value === "object" ? value._id : value
+    )
+    // Make sure field state is valid
+    fieldApi.setValue(values)
+    return values
   }
 
   const getDisplayName = row => {


### PR DESCRIPTION
## Description
Update forms were passing `[{ primaryDisplay: "", _id: "ro_ta..."}]` into the relationship picker, which is an invalid state.

Added code to ensure the field state is always in the form `["ro_ta..."]`

Addresses: 
- https://github.com/Budibase/budibase/issues/11878

## Screenshots
![relationships](https://github.com/Budibase/budibase/assets/101575380/7b289985-6298-4258-8d90-339445b8adcd)




