### PR TITLE
Fix client initialisation and fix navigation links being hidden

### DIFF
--- a/packages/client/src/components/app/Layout.svelte
+++ b/packages/client/src/components/app/Layout.svelte
@@ -3,6 +3,7 @@
   import { writable } from "svelte/store"
   import { Heading, Icon, clickOutside } from "@budibase/bbui"
   import { FieldTypes } from "constants"
+  import { Constants } from "@budibase/frontend-core"
   import active from "svelte-spa-router/active"
 
   const sdk = getContext("sdk")
@@ -103,7 +104,8 @@
     let validLinks = (allLinks || []).filter(link => link.text && link.url)
     // Filter to only links allowed by the current role
     return validLinks.filter(link => {
-      return userRoleHierarchy?.find(roleId => roleId === link.roleId)
+      const role = link.roleId || Constants.Roles.BASIC
+      return userRoleHierarchy?.find(roleId => roleId === role)
     })
   }
 

--- a/packages/client/src/components/devtools/DevToolsHeader.svelte
+++ b/packages/client/src/components/devtools/DevToolsHeader.svelte
@@ -25,7 +25,6 @@
         value: roleId,
       })
     }
-    devToolsStore.actions.changeRole(SELF_ROLE)
     return list
   }
 

--- a/packages/client/src/stores/devTools.js
+++ b/packages/client/src/stores/devTools.js
@@ -2,6 +2,7 @@ import { createLocalStorageStore } from "@budibase/frontend-core"
 import { initialise } from "./initialise"
 import { authStore } from "./auth"
 import { API } from "../api"
+import { get } from "svelte/store"
 
 const initialState = {
   visible: false,
@@ -27,9 +28,15 @@ const createDevToolStore = () => {
   }
 
   const changeRole = async role => {
+    if (role === "self") {
+      role = null
+    }
+    if (role === get(store).role) {
+      return
+    }
     store.update(state => ({
       ...state,
-      role: role === "self" ? null : role,
+      role,
     }))
     API.invalidateCache()
     await authStore.actions.fetchUser()

--- a/packages/client/src/stores/initialise.js
+++ b/packages/client/src/stores/initialise.js
@@ -3,7 +3,6 @@ import { appStore } from "./app"
 import { orgStore } from "./org"
 
 export async function initialise() {
-  console.log("initialise!")
   await routeStore.actions.fetchRoutes()
   await appStore.actions.fetchAppDefinition()
   await orgStore.actions.init()

--- a/packages/client/src/stores/initialise.js
+++ b/packages/client/src/stores/initialise.js
@@ -3,6 +3,7 @@ import { appStore } from "./app"
 import { orgStore } from "./org"
 
 export async function initialise() {
+  console.log("initialise!")
   await routeStore.actions.fetchRoutes()
   await appStore.actions.fetchAppDefinition()
   await orgStore.actions.init()


### PR DESCRIPTION
## Description
This PR contains 2 fixes for recent client library regressions.

- Fix initialising client library 3 times when loading an app. This was caused by redundant calls to update the client library active role, and by not skipping changes when the role does not change.
- Navigation links without a role set have always been considered as basic. This seems to have been accidentally changed, meaning those links would now always be hidden (for all users). I've updated this to ensure links without an explicit role are treated as basic and show up as expected.


