### PR TITLE
Log errors on jest retry

### DIFF
--- a/packages/worker/src/api/routes/global/tests/scim.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/scim.spec.ts
@@ -11,7 +11,7 @@ import { TestConfiguration } from "../../../../tests"
 import { events } from "@budibase/backend-core"
 
 // this test can 409 - retries reduce issues with this
-jest.retryTimes(2)
+jest.retryTimes(2, { logErrorsBeforeRetry: true })
 jest.setTimeout(30000)
 
 mocks.licenses.useScimIntegration()


### PR DESCRIPTION
## Description
We recently added jest.retry, and we got some weird use case: https://github.com/Budibase/budibase/actions/runs/6377786841/job/17308317391

The first run fails (legitly probably), and the rerun will fail as it is expecting a clean environment. 
Adding the log flag will display the original errors, making the flakiness more visible and possible to fix