### PR TITLE
Dropping swagger API docker image version to 3.0.46

### DIFF
--- a/packages/sdk/scripts/generate-sdk.sh
+++ b/packages/sdk/scripts/generate-sdk.sh
@@ -19,7 +19,7 @@ docker run --rm \
   -v ${PWD}/generated:/generated \
   -v ${PWD}/config.json:/config.json \
   -u $(id -u):$(id -g) \
-  swaggerapi/swagger-codegen-cli-v3 generate \
+  swaggerapi/swagger-codegen-cli-v3:3.0.46 generate \
   -i /openapi.yml \
   -l javascript \
   -o /generated \


### PR DESCRIPTION
## Description
Fixing swagger API version, updating to use old 3.0.46 as version 3.047 does not appear to running correctly.



