### PR TITLE
Filtering data providers by the new user column type

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -660,7 +660,8 @@
       >Open schema editor</Button
     >
   {:else if editableColumn.type === USER_REFRENCE_TYPE}
-    <Toggle
+    <!-- Disabled temporally -->
+    <!-- <Toggle
       value={editableColumn.relationshipType === RelationshipType.MANY_TO_MANY}
       on:change={e =>
         (editableColumn.relationshipType = e.detail
@@ -669,7 +670,7 @@
       disabled={!isCreating}
       thin
       text="Allow multiple users"
-    />
+    /> -->
   {/if}
   {#if editableColumn.type === AUTO_TYPE || editableColumn.autocolumn}
     <Select

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -162,8 +162,8 @@
       filter.value = []
     } else if (
       previousType !== filter.type &&
-      previousType === FieldType.BB_REFERENCE &&
-      filter.type === FieldType.BB_REFERENCE
+      (previousType === FieldType.BB_REFERENCE ||
+        filter.type === FieldType.BB_REFERENCE)
     ) {
       filter.value = filter.type === "array" ? [] : null
     }

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -288,7 +288,10 @@
                   bind:value={filter.value}
                 />
               {:else if filter.type === FieldType.BB_REFERENCE}
-                <FilterUsers bind:value={filter.value} />
+                <FilterUsers
+                  bind:value={filter.value}
+                  disabled={filter.noValue}
+                />
               {:else}
                 <DrawerBindableInput disabled />
               {/if}

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -185,6 +185,10 @@
 
   const getValidOperatorsForType = filter => {
     const fieldSchema = getSchema(filter)
+    if (!fieldSchema) {
+      return []
+    }
+
     const type =
       fieldSchema.type !== FieldType.BB_REFERENCE
         ? field.type

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -308,7 +308,7 @@
                   bind:value={filter.value}
                   multiselect={getSchema(filter).relationshipType ===
                     RelationshipType.MANY_TO_MANY ||
-                    filter.operator === OperatorOptions.ContainsAny.value}
+                    filter.operator === OperatorOptions.In.value}
                   disabled={filter.noValue}
                 />
               {:else}

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -17,7 +17,9 @@
   import { generate } from "shortid"
   import { LuceneUtils, Constants } from "@budibase/frontend-core"
   import { getFields } from "helpers/searchFields"
+  import { FieldType } from "@budibase/types"
   import { createEventDispatcher, onMount } from "svelte"
+  import FilterUsers from "./FilterUsers.svelte"
 
   export let schemaFields
   export let filters = []
@@ -285,6 +287,8 @@
                   timeOnly={getSchema(filter)?.timeOnly}
                   bind:value={filter.value}
                 />
+              {:else if filter.type === FieldType.BB_REFERENCE}
+                <FilterUsers {filter} />
               {:else}
                 <DrawerBindableInput disabled />
               {/if}

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -306,6 +306,8 @@
               {:else if filter.type === FieldType.BB_REFERENCE}
                 <FilterUsers
                   bind:value={filter.value}
+                  multiselect={filter.operator ===
+                    OperatorOptions.ContainsAny.value}
                   disabled={filter.noValue}
                 />
               {:else}

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -184,25 +184,21 @@
   }
 
   const getValidOperatorsForType = filter => {
+    const fieldSchema = getSchema(filter)
+    const type =
+      fieldSchema.type !== FieldType.BB_REFERENCE
+        ? field.type
+        : {
+            type: fieldSchema.type,
+            multiple:
+              fieldSchema.relationshipType === RelationshipType.MANY_TO_MANY,
+          }
+
     let operators = LuceneUtils.getValidOperatorsForType(
-      filter.type,
+      type,
       filter.field,
       datasource
     )
-
-    const fieldSchema = getSchema(filter)
-    if (
-      fieldSchema.type === FieldType.BB_REFERENCE &&
-      fieldSchema.relationshipType !== RelationshipType.MANY_TO_MANY
-    ) {
-      operators = operators.filter(
-        o =>
-          ![
-            OperatorOptions.Contains.value,
-            OperatorOptions.NotContains.value,
-          ].includes(o.value)
-      )
-    }
 
     return operators
   }

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -288,7 +288,7 @@
                   bind:value={filter.value}
                 />
               {:else if filter.type === FieldType.BB_REFERENCE}
-                <FilterUsers {filter} />
+                <FilterUsers bind:value={filter.value} />
               {:else}
                 <DrawerBindableInput disabled />
               {/if}

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -191,7 +191,6 @@
   }
 
   const getValidOperatorsForType = filter => {
-    const fieldSchema = getSchema(filter)
     if (!filter) {
       return []
     }

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -306,8 +306,9 @@
               {:else if filter.type === FieldType.BB_REFERENCE}
                 <FilterUsers
                   bind:value={filter.value}
-                  multiselect={filter.operator ===
-                    OperatorOptions.ContainsAny.value}
+                  multiselect={getSchema(filter).relationshipType ===
+                    RelationshipType.MANY_TO_MANY ||
+                    filter.operator === OperatorOptions.ContainsAny.value}
                   disabled={filter.noValue}
                 />
               {:else}

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -198,7 +198,7 @@
               fieldSchema.relationshipType === RelationshipType.MANY_TO_MANY,
           }
 
-    let operators = LuceneUtils.getValidOperatorsForType(
+    const operators = LuceneUtils.getValidOperatorsForType(
       type,
       filter.field,
       datasource

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterUsers.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterUsers.svelte
@@ -1,12 +1,12 @@
 <script>
-  import { Select } from "@budibase/bbui"
+  import { Select, Multiselect } from "@budibase/bbui"
   import { fetchData } from "@budibase/frontend-core"
 
   import { API } from "api"
 
   export let value = null
   export let disabled
-  export let multiple = false
+  export let multiselect = false
 
   $: fetch = fetchData({
     API,
@@ -29,10 +29,13 @@
     }
   }
 
-  $: selectedValue = multiple || !value ? value : value[0]
+  $: selectedValue = multiselect || !value ? value : value[0]
+
+  $: component = multiselect ? Multiselect : Select
 </script>
 
-<Select
+<svelte:component
+  this={component}
   value={selectedValue}
   autocomplete
   on:change={onChange}

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterUsers.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterUsers.svelte
@@ -20,25 +20,13 @@
 
   $: options = $fetch.rows
 
-  function onChange(e) {
-    const val = e.detail
-    if (!val) {
-      value = val
-    } else {
-      value = Array.isArray(val) ? val : [val]
-    }
-  }
-
-  $: selectedValue = multiselect || !value ? value : value[0]
-
   $: component = multiselect ? Multiselect : Select
 </script>
 
 <svelte:component
   this={component}
-  value={selectedValue}
+  bind:value
   autocomplete
-  on:change={onChange}
   {options}
   getOptionLabel={option => option.email}
   getOptionValue={option => option._id}

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterUsers.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterUsers.svelte
@@ -1,0 +1,28 @@
+<script>
+  import { Select } from "@budibase/bbui"
+  import { fetchData } from "@budibase/frontend-core"
+
+  import { API } from "api"
+
+  export let filter
+
+  $: fetch = fetchData({
+    API,
+    datasource: {
+      type: "user",
+    },
+    options: {
+      limit: 100,
+    },
+  })
+
+  $: options = $fetch.rows
+</script>
+
+<Select
+  autocomplete
+  bind:value={filter.value}
+  {options}
+  getOptionLabel={option => option.email}
+  getOptionValue={option => option._id}
+/>

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterUsers.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterUsers.svelte
@@ -5,6 +5,7 @@
   import { API } from "api"
 
   export let value = null
+  export let multiple = false
 
   $: fetch = fetchData({
     API,
@@ -17,11 +18,21 @@
   })
 
   $: options = $fetch.rows
+
+  function onChange(e) {
+    const val = e.detail
+    if (!val) {
+      value = val
+    } else {
+      value = Array.isArray(val) ? val : [val]
+    }
+  }
 </script>
 
 <Select
+  value={multiple ? value : value[0]}
   autocomplete
-  bind:value
+  on:change={onChange}
   {options}
   getOptionLabel={option => option.email}
   getOptionValue={option => option._id}

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterUsers.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterUsers.svelte
@@ -5,6 +5,7 @@
   import { API } from "api"
 
   export let value = null
+  export let disabled
   export let multiple = false
 
   $: fetch = fetchData({
@@ -38,4 +39,5 @@
   {options}
   getOptionLabel={option => option.email}
   getOptionValue={option => option._id}
+  {disabled}
 />

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterUsers.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterUsers.svelte
@@ -4,7 +4,7 @@
 
   import { API } from "api"
 
-  export let filter
+  export let value = null
 
   $: fetch = fetchData({
     API,
@@ -21,7 +21,7 @@
 
 <Select
   autocomplete
-  bind:value={filter.value}
+  bind:value
   {options}
   getOptionLabel={option => option.email}
   getOptionValue={option => option._id}

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterUsers.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterUsers.svelte
@@ -27,10 +27,12 @@
       value = Array.isArray(val) ? val : [val]
     }
   }
+
+  $: selectedValue = multiple || !value ? value : value[0]
 </script>
 
 <Select
-  value={multiple ? value : value[0]}
+  value={selectedValue}
   autocomplete
   on:change={onChange}
   {options}

--- a/packages/server/scripts/integrations/postgres/docker-compose.yml
+++ b/packages/server/scripts/integrations/postgres/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 services:
   db:
     container_name: postgres
-    image: postgres
+    image: postgres:15
     restart: unless-stopped
     environment:
       POSTGRES_USER: root
@@ -25,4 +25,4 @@ services:
       - "5050:80"
 
 volumes:
- pg_data:
+  pg_data:

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -74,7 +74,7 @@ export const getValidOperatorsForType = (
     if (type.multiple) {
       ops = [Op.Contains, Op.NotContains, Op.ContainsAny, Op.Empty, Op.NotEmpty]
     } else {
-      ops = [Op.Equals, Op.NotEquals, Op.Empty, Op.NotEmpty, Op.ContainsAny]
+      ops = [Op.Equals, Op.NotEquals, Op.Empty, Op.NotEmpty, Op.In]
     }
   }
 

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -44,21 +44,21 @@ export const getValidOperatorsForType = (
     value: string
     label: string
   }[] = []
-  if (type === "string") {
+  if (type === FieldType.STRING) {
     ops = stringOps
-  } else if (type === "number" || type === "bigint") {
+  } else if (type === FieldType.NUMBER || type === FieldType.BIGINT) {
     ops = numOps
-  } else if (type === "options") {
+  } else if (type === FieldType.OPTIONS) {
     ops = [Op.Equals, Op.NotEquals, Op.Empty, Op.NotEmpty, Op.In]
-  } else if (type === "array") {
+  } else if (type === FieldType.ARRAY) {
     ops = [Op.Contains, Op.NotContains, Op.Empty, Op.NotEmpty, Op.ContainsAny]
-  } else if (type === "boolean") {
+  } else if (type === FieldType.BOOLEAN) {
     ops = [Op.Equals, Op.NotEquals, Op.Empty, Op.NotEmpty]
-  } else if (type === "longform") {
+  } else if (type === FieldType.LONGFORM) {
     ops = stringOps
-  } else if (type === "datetime") {
+  } else if (type === FieldType.DATETIME) {
     ops = numOps
-  } else if (type === "formula") {
+  } else if (type === FieldType.FORMULA) {
     ops = stringOps.concat([Op.MoreThan, Op.LessThan])
   }
 

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -60,6 +60,8 @@ export const getValidOperatorsForType = (
     ops = numOps
   } else if (type === FieldType.FORMULA) {
     ops = stringOps.concat([Op.MoreThan, Op.LessThan])
+  } else if (type === FieldType.BB_REFERENCE) {
+    ops = [Op.Equals, Op.NotEquals, Op.Empty, Op.NotEmpty, Op.In]
   }
 
   // Only allow equal/not equal for _id in SQL tables

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -61,7 +61,15 @@ export const getValidOperatorsForType = (
   } else if (type === FieldType.FORMULA) {
     ops = stringOps.concat([Op.MoreThan, Op.LessThan])
   } else if (type === FieldType.BB_REFERENCE) {
-    ops = [Op.Equals, Op.NotEquals, Op.Empty, Op.NotEmpty, Op.In]
+    ops = [
+      Op.Equals,
+      Op.NotEquals,
+      Op.Empty,
+      Op.NotEmpty,
+      Op.Contains,
+      Op.NotContains,
+      Op.ContainsAny,
+    ]
   }
 
   // Only allow equal/not equal for _id in SQL tables

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -72,7 +72,8 @@ export const getValidOperatorsForType = (
     ops = stringOps.concat([Op.MoreThan, Op.LessThan])
   } else if (!isFieldType(type) && type.type === FieldType.BB_REFERENCE) {
     if (type.multiple) {
-      ops = [Op.Contains, Op.NotContains, Op.ContainsAny, Op.Empty, Op.NotEmpty]
+      // Temporally disabled
+      ops = []
     } else {
       ops = [Op.Equals, Op.NotEquals, Op.Empty, Op.NotEmpty, Op.In]
     }


### PR DESCRIPTION
## Description
Building filters in order to support the new user column type

Addresses: 
- [BUDI-7583 - Filtering data provider with a `user column` does not work, the type of filter does not show and only blank.](https://linear.app/budibase/issue/BUDI-7583/filtering-data-provider-with-a-user-column-does-not-work-the-type-of)

## Screenshots
![image](https://github.com/Budibase/budibase/assets/15987277/dae12aeb-bd40-4a28-af8b-6a061f48bfcb)
