### PR TITLE
Update CLI to check for docker-compose or docker compose plugin installation

### DIFF
--- a/packages/cli/src/hosting/utils.ts
+++ b/packages/cli/src/hosting/utils.ts
@@ -57,7 +57,8 @@ export async function checkDockerConfigured() {
     "docker/docker-compose has not been installed, please follow instructions at: https://docs.budibase.com/docs/docker-compose"
   const docker = await lookpath("docker")
   const compose = await lookpath("docker-compose")
-  if (!docker || !compose) {
+  const composeV2 = await lookpath("docker compose")
+  if (!docker || (!compose && !composeV2)) {
     throw error
   }
 }


### PR DESCRIPTION
## Description
Quick fix for #11982 - check for both deprecated docker-compose and docker compose V2.

Addresses: 
- #11982