### PR TITLE
Multi user column

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -62,8 +62,6 @@
     return `${type}${subtype || ""}`.toUpperCase()
   }
 
-  $: console.warn(fieldDefinitions)
-
   let originalName
   let linkEditDisabled
   let primaryDisplay
@@ -343,6 +341,7 @@
     delete editableColumn.tableId
     delete editableColumn.relationshipType
     delete editableColumn.formulaType
+    delete editableColumn.constraints
 
     // Add in defaults and initial definition
     const definition = fieldDefinitions[type?.toUpperCase()]
@@ -398,6 +397,16 @@
       return ALLOWABLE_NUMBER_OPTIONS
     }
 
+    const userFieldDefinition =
+      fieldDefinitions[
+        makeFieldId(
+          FieldType.BB_REFERENCE,
+          editableColumn.type === FieldType.BB_REFERENCE
+            ? editableColumn.subtype
+            : FieldSubtype.USER
+        )
+      ]
+
     if (!external) {
       return [
         fieldDefinitions.STRING,
@@ -413,9 +422,7 @@
         fieldDefinitions.LINK,
         fieldDefinitions.FORMULA,
         fieldDefinitions.JSON,
-        fieldDefinitions[
-          makeFieldId(FieldType.BB_REFERENCE, FieldSubtype.USER)
-        ],
+        userFieldDefinition,
         { name: "Auto Column", type: AUTO_TYPE },
       ]
     } else {
@@ -429,12 +436,7 @@
         fieldDefinitions.BOOLEAN,
         fieldDefinitions.FORMULA,
         fieldDefinitions.BIGINT,
-        fieldDefinitions[
-          getFieldId({
-            type: FieldType.BB_REFERENCE,
-            subtype: FieldSubtype.USER,
-          })
-        ],
+        userFieldDefinition,
       ]
       // no-sql or a spreadsheet
       if (!external || table.sql) {

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -188,7 +188,9 @@
       )
     }
 
-    allowedTypes = getAllowedTypes()
+    if (!savingColumn) {
+      allowedTypes = getAllowedTypes()
+    }
   }
 
   $: initialiseField(field, savingColumn)

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -43,7 +43,6 @@
   const NUMBER_TYPE = FIELDS.NUMBER.type
   const JSON_TYPE = FIELDS.JSON.type
   const DATE_TYPE = FIELDS.DATETIME.type
-  const USER_REFRENCE_TYPE = FIELDS.BB_REFERENCE_USER.compositeType
 
   const dispatch = createEventDispatcher()
   const PROHIBITED_COLUMN_NAMES = ["type", "_id", "_rev", "tableId"]
@@ -52,7 +51,14 @@
   export let field
 
   let mounted = false
-  let fieldDefinitions = cloneDeep(FIELDS)
+  let fieldDefinitions = Object.entries(FIELDS).reduce(
+    (acc, [fieldName, field]) => {
+      acc[field.compositeType?.toUpperCase() || fieldName] = field
+      return acc
+    },
+    {}
+  )
+
   let originalName
   let linkEditDisabled
   let primaryDisplay
@@ -334,6 +340,9 @@
       editableColumn.constraints = definition.constraints
     }
 
+    editableColumn.type = definition.type
+    editableColumn.subtype = definition.subtype
+
     // Default relationships many to many
     if (editableColumn.type === LINK_TYPE) {
       editableColumn.relationshipType = RelationshipType.MANY_TO_MANY
@@ -394,7 +403,7 @@
         FIELDS.LINK,
         FIELDS.FORMULA,
         FIELDS.JSON,
-        FIELDS.BB_REFERENCE_USER,
+        FIELDS.USER,
         { name: "Auto Column", type: AUTO_TYPE },
       ]
     } else {
@@ -500,7 +509,7 @@
   {/if}
   <Select
     disabled={!typeEnabled}
-    bind:value={editableColumn.type}
+    value={editableColumn.type}
     on:change={handleTypeChange}
     options={allowedTypes}
     getOptionLabel={field => field.name}
@@ -670,7 +679,7 @@
     <Button primary text on:click={openJsonSchemaEditor}
       >Open schema editor</Button
     >
-  {:else if editableColumn.type === USER_REFRENCE_TYPE}
+  {:else if editableColumn.type === FieldType.BB_REFERENCE && [FieldSubtype.USER, FieldSubtype.USERS].includes(editableColumn.subtype)}
     <Toggle
       value={editableColumn.subtype === FieldSubtype.USERS}
       on:change={e =>

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -659,18 +659,16 @@
     <Button primary text on:click={openJsonSchemaEditor}
       >Open schema editor</Button
     >
-  {:else if editableColumn.type === USER_REFRENCE_TYPE}
-    <!-- Disabled temporally -->
-    <!-- <Toggle
-      value={editableColumn.relationshipType === RelationshipType.MANY_TO_MANY}
+    <Toggle
+      value={editableColumn.subtype === FieldSubtype.USERS}
       on:change={e =>
-        (editableColumn.relationshipType = e.detail
-          ? RelationshipType.MANY_TO_MANY
-          : RelationshipType.ONE_TO_MANY)}
+        (editableColumn.subtype = e.detail
+          ? FieldSubtype.USERS
+          : FieldSubtype.USER)}
       disabled={!isCreating}
       thin
       text="Allow multiple users"
-    /> -->
+    />
   {/if}
   {#if editableColumn.type === AUTO_TYPE || editableColumn.autocolumn}
     <Select

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -339,8 +339,6 @@
       editableColumn.relationshipType = RelationshipType.MANY_TO_MANY
     } else if (editableColumn.type === FORMULA_TYPE) {
       editableColumn.formulaType = "dynamic"
-    } else if (editableColumn.type === USER_REFRENCE_TYPE) {
-      editableColumn.relationshipType = RelationshipType.ONE_TO_MANY
     }
   }
 

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -33,7 +33,7 @@
   import { getBindings } from "components/backend/DataTable/formula"
   import JSONSchemaModal from "./JSONSchemaModal.svelte"
   import { ValidColumnNameRegex } from "@budibase/shared-core"
-  import { FieldType } from "@budibase/types"
+  import { FieldType, FieldSubtype } from "@budibase/types"
   import RelationshipSelector from "components/common/RelationshipSelector.svelte"
 
   const AUTO_TYPE = "auto"
@@ -659,6 +659,7 @@
     <Button primary text on:click={openJsonSchemaEditor}
       >Open schema editor</Button
     >
+  {:else if editableColumn.type === USER_REFRENCE_TYPE}
     <Toggle
       value={editableColumn.subtype === FieldSubtype.USERS}
       on:change={e =>

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -507,6 +507,13 @@
     return newError
   }
 
+  function isUsersColumn(column) {
+    return (
+      column.type === FieldType.BB_REFERENCE &&
+      [FieldSubtype.USER, FieldSubtype.USERS].includes(column.subtype)
+    )
+  }
+
   onMount(() => {
     mounted = true
   })
@@ -694,7 +701,7 @@
     <Button primary text on:click={openJsonSchemaEditor}
       >Open schema editor</Button
     >
-  {:else if editableColumn.type === FieldType.BB_REFERENCE && [FieldSubtype.USER, FieldSubtype.USERS].includes(editableColumn.subtype) && datasource?.source !== SourceName.GOOGLE_SHEETS}
+  {:else if isUsersColumn(editableColumn) && datasource?.source !== SourceName.GOOGLE_SHEETS}
     <Toggle
       value={editableColumn.subtype === FieldSubtype.USERS}
       on:change={e =>

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -33,7 +33,7 @@
   import { getBindings } from "components/backend/DataTable/formula"
   import JSONSchemaModal from "./JSONSchemaModal.svelte"
   import { ValidColumnNameRegex } from "@budibase/shared-core"
-  import { FieldType, FieldSubtype } from "@budibase/types"
+  import { FieldType, FieldSubtype, SourceName } from "@budibase/types"
   import RelationshipSelector from "components/common/RelationshipSelector.svelte"
 
   const AUTO_TYPE = "auto"
@@ -596,7 +596,7 @@
         <DatePicker bind:value={editableColumn.constraints.datetime.latest} />
       </div>
     </div>
-    {#if datasource?.source !== "ORACLE" && datasource?.source !== "SQL_SERVER" && !editableColumn.dateOnly}
+    {#if datasource?.source !== SourceName.ORACLE && datasource?.source !== SourceName.SQL_SERVER && !editableColumn.dateOnly}
       <div>
         <div class="row">
           <Label>Time zones</Label>
@@ -700,7 +700,7 @@
     <Button primary text on:click={openJsonSchemaEditor}
       >Open schema editor</Button
     >
-  {:else if editableColumn.type === FieldType.BB_REFERENCE && [FieldSubtype.USER, FieldSubtype.USERS].includes(editableColumn.subtype)}
+  {:else if editableColumn.type === FieldType.BB_REFERENCE && [FieldSubtype.USER, FieldSubtype.USERS].includes(editableColumn.subtype) && datasource?.source !== SourceName.GOOGLE_SHEETS}
     <Toggle
       value={editableColumn.subtype === FieldSubtype.USERS}
       on:change={e =>

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -381,7 +381,20 @@
 
     if (!external) {
       return [
-        ...Object.values(fieldDefinitions),
+        FIELDS.STRING,
+        FIELDS.BARCODEQR,
+        FIELDS.LONGFORM,
+        FIELDS.OPTIONS,
+        FIELDS.ARRAY,
+        FIELDS.NUMBER,
+        FIELDS.BIGINT,
+        FIELDS.BOOLEAN,
+        FIELDS.DATETIME,
+        FIELDS.ATTACHMENT,
+        FIELDS.LINK,
+        FIELDS.FORMULA,
+        FIELDS.JSON,
+        FIELDS.BB_REFERENCE_USER,
         { name: "Auto Column", type: AUTO_TYPE },
       ]
     } else {

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -20,7 +20,6 @@
   import { FieldType } from "@budibase/types"
   import { createEventDispatcher, onMount } from "svelte"
   import FilterUsers from "./FilterUsers.svelte"
-  import { RelationshipType } from "constants/backend"
 
   export let schemaFields
   export let filters = []

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -126,6 +126,7 @@
     // Update type based on field
     const fieldSchema = enrichedSchemaFields.find(x => x.name === filter.field)
     filter.type = fieldSchema?.type
+    filter.subtype = fieldSchema?.subtype
 
     // Update external type based on field
     filter.externalType = getSchema(filter)?.externalType
@@ -196,7 +197,7 @@
     }
 
     return LuceneUtils.getValidOperatorsForType(
-      filter.type,
+      { type: filter.type, subtype: filter.subtype },
       filter.field,
       datasource
     )

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -302,9 +302,10 @@
               {:else if filter.type === FieldType.BB_REFERENCE}
                 <FilterUsers
                   bind:value={filter.value}
-                  multiselect={getSchema(filter).relationshipType ===
-                    RelationshipType.MANY_TO_MANY ||
-                    filter.operator === OperatorOptions.In.value}
+                  multiselect={[
+                    OperatorOptions.In.value,
+                    OperatorOptions.ContainsAny.value,
+                  ].includes(filter.operator)}
                   disabled={filter.noValue}
                 />
               {:else}

--- a/packages/builder/src/constants/backend/index.js
+++ b/packages/builder/src/constants/backend/index.js
@@ -133,6 +133,9 @@ export const FIELDS = {
     type: FieldType.BB_REFERENCE,
     subtype: FieldSubtype.USERS,
     icon: "User",
+    constraints: {
+      type: "array",
+    },
   },
 }
 

--- a/packages/builder/src/constants/backend/index.js
+++ b/packages/builder/src/constants/backend/index.js
@@ -122,12 +122,19 @@ export const FIELDS = {
       presence: false,
     },
   },
-  BB_REFERENCE_USER: {
+  USER: {
     name: "User",
     type: FieldType.BB_REFERENCE,
     subtype: FieldSubtype.USER,
-    compositeType: `${FieldType.BB_REFERENCE}_${FieldSubtype.USER}`, // Used for working with the subtype on CreateEditColumn as is it was a primary type
     icon: "User",
+    compositeType: `${FieldType.BB_REFERENCE}_${FieldSubtype.USER}`, // Used for working with the subtype on CreateEditColumn as is it was a primary type
+  },
+  USERS: {
+    name: "Users",
+    type: FieldType.BB_REFERENCE,
+    subtype: FieldSubtype.USERS,
+    icon: "User",
+    compositeType: `${FieldType.BB_REFERENCE}_${FieldSubtype.USERS}`,
   },
 }
 

--- a/packages/builder/src/constants/backend/index.js
+++ b/packages/builder/src/constants/backend/index.js
@@ -1,7 +1,9 @@
+import { FieldType, FieldSubtype } from "@budibase/types"
+
 export const FIELDS = {
   STRING: {
     name: "Text",
-    type: "string",
+    type: FieldType.STRING,
     icon: "Text",
     constraints: {
       type: "string",
@@ -11,7 +13,7 @@ export const FIELDS = {
   },
   BARCODEQR: {
     name: "Barcode/QR",
-    type: "barcodeqr",
+    type: FieldType.BARCODEQR,
     icon: "Camera",
     constraints: {
       type: "string",
@@ -21,7 +23,7 @@ export const FIELDS = {
   },
   LONGFORM: {
     name: "Long Form Text",
-    type: "longform",
+    type: FieldType.LONGFORM,
     icon: "TextAlignLeft",
     constraints: {
       type: "string",
@@ -31,7 +33,7 @@ export const FIELDS = {
   },
   OPTIONS: {
     name: "Options",
-    type: "options",
+    type: FieldType.OPTIONS,
     icon: "Dropdown",
     constraints: {
       type: "string",
@@ -41,7 +43,7 @@ export const FIELDS = {
   },
   ARRAY: {
     name: "Multi-select",
-    type: "array",
+    type: FieldType.ARRAY,
     icon: "Duplicate",
     constraints: {
       type: "array",
@@ -51,7 +53,7 @@ export const FIELDS = {
   },
   NUMBER: {
     name: "Number",
-    type: "number",
+    type: FieldType.NUMBER,
     icon: "123",
     constraints: {
       type: "number",
@@ -61,12 +63,12 @@ export const FIELDS = {
   },
   BIGINT: {
     name: "BigInt",
-    type: "bigint",
+    type: FieldType.BIGINT,
     icon: "TagBold",
   },
   BOOLEAN: {
     name: "Boolean",
-    type: "boolean",
+    type: FieldType.BOOLEAN,
     icon: "Boolean",
     constraints: {
       type: "boolean",
@@ -75,7 +77,7 @@ export const FIELDS = {
   },
   DATETIME: {
     name: "Date/Time",
-    type: "datetime",
+    type: FieldType.DATETIME,
     icon: "Calendar",
     constraints: {
       type: "string",
@@ -89,7 +91,7 @@ export const FIELDS = {
   },
   ATTACHMENT: {
     name: "Attachment",
-    type: "attachment",
+    type: FieldType.ATTACHMENT,
     icon: "Folder",
     constraints: {
       type: "array",
@@ -98,7 +100,7 @@ export const FIELDS = {
   },
   LINK: {
     name: "Relationship",
-    type: "link",
+    type: FieldType.LINK,
     icon: "Link",
     constraints: {
       type: "array",
@@ -107,13 +109,13 @@ export const FIELDS = {
   },
   FORMULA: {
     name: "Formula",
-    type: "formula",
+    type: FieldType.FORMULA,
     icon: "Calculator",
     constraints: {},
   },
   JSON: {
     name: "JSON",
-    type: "json",
+    type: FieldType.JSON,
     icon: "Brackets",
     constraints: {
       type: "object",
@@ -122,9 +124,9 @@ export const FIELDS = {
   },
   BB_REFERENCE_USER: {
     name: "User",
-    type: "bb_reference",
-    subtype: "user",
-    compositeType: "bb_reference_user", // Used for working with the subtype on CreateEditColumn as is it was a primary type
+    type: FieldType.BB_REFERENCE,
+    subtype: FieldSubtype.USER,
+    compositeType: `${FieldType.BB_REFERENCE}_${FieldSubtype.USER}`, // Used for working with the subtype on CreateEditColumn as is it was a primary type
     icon: "User",
   },
 }

--- a/packages/builder/src/constants/backend/index.js
+++ b/packages/builder/src/constants/backend/index.js
@@ -127,14 +127,12 @@ export const FIELDS = {
     type: FieldType.BB_REFERENCE,
     subtype: FieldSubtype.USER,
     icon: "User",
-    compositeType: `${FieldType.BB_REFERENCE}_${FieldSubtype.USER}`, // Used for working with the subtype on CreateEditColumn as is it was a primary type
   },
   USERS: {
     name: "Users",
     type: FieldType.BB_REFERENCE,
     subtype: FieldSubtype.USERS,
     icon: "User",
-    compositeType: `${FieldType.BB_REFERENCE}_${FieldSubtype.USERS}`,
   },
 }
 

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ConditionalUIDrawer.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ConditionalUIDrawer.svelte
@@ -118,7 +118,7 @@
   }
 
   const getOperatorOptions = condition => {
-    return LuceneUtils.getValidOperatorsForType(condition.valueType)
+    return LuceneUtils.getValidOperatorsForType({ type: condition.valueType })
   }
 
   const onOperatorChange = (condition, newOperator) => {
@@ -137,9 +137,9 @@
     condition.referenceValue = null
 
     // Ensure a valid operator is set
-    const validOperators = LuceneUtils.getValidOperatorsForType(newType).map(
-      x => x.value
-    )
+    const validOperators = LuceneUtils.getValidOperatorsForType({
+      type: newType,
+    }).map(x => x.value)
     if (!validOperators.includes(condition.operator)) {
       condition.operator =
         validOperators[0] ?? Constants.OperatorOptions.Equals.value

--- a/packages/client/src/components/app/dynamic-filter/FilterModal.svelte
+++ b/packages/client/src/components/app/dynamic-filter/FilterModal.svelte
@@ -63,7 +63,7 @@
 
     // Ensure a valid operator is set
     const validOperators = LuceneUtils.getValidOperatorsForType(
-      expression.type,
+      { type: expression.type },
       expression.field,
       datasource
     ).map(x => x.value)
@@ -125,7 +125,7 @@
           <Select
             disabled={!filter.field}
             options={LuceneUtils.getValidOperatorsForType(
-              filter.type,
+              { type: filter.type, subtype: filter.subtype },
               filter.field,
               datasource
             )}

--- a/packages/frontend-core/src/components/grid/cells/BBReferenceCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/BBReferenceCell.svelte
@@ -1,7 +1,7 @@
 <script>
   import { getContext } from "svelte"
   import RelationshipCell from "./RelationshipCell.svelte"
-  import { FieldSubtype } from "@budibase/types"
+  import { FieldSubtype, RelationshipType } from "@budibase/types"
 
   export let api
 
@@ -12,10 +12,14 @@
     ...$$props.schema,
     // This is not really used, just adding some content to be able to render the relationship cell
     tableId: "external",
+    relationshipType:
+      subtype === FieldSubtype.USER
+        ? RelationshipType.ONE_TO_MANY
+        : RelationshipType.MANY_TO_MANY,
   }
 
   async function searchFunction(searchParams) {
-    if (subtype !== FieldSubtype.USER) {
+    if (subtype !== FieldSubtype.USER && subtype !== FieldSubtype.USERS) {
       throw `Search for '${subtype}' not implemented`
     }
 

--- a/packages/frontend-core/src/components/grid/lib/utils.js
+++ b/packages/frontend-core/src/components/grid/lib/utils.js
@@ -21,6 +21,7 @@ const TypeIconMap = {
   bigint: "TagBold",
   bb_reference: {
     user: "User",
+    users: "UserGroup",
   },
 }
 

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -1566,15 +1566,13 @@ describe.each([
       () => ({
         user: {
           name: "user",
-          relationshipType: RelationshipType.ONE_TO_MANY,
           type: FieldType.BB_REFERENCE,
           subtype: FieldTypeSubtypes.BB_REFERENCE.USER,
         },
         users: {
           name: "users",
           type: FieldType.BB_REFERENCE,
-          subtype: FieldTypeSubtypes.BB_REFERENCE.USER,
-          relationshipType: RelationshipType.MANY_TO_MANY,
+          subtype: FieldTypeSubtypes.BB_REFERENCE.USERS,
         },
       }),
       () => config.createUser(),

--- a/packages/server/src/integrations/base/sqlTable.ts
+++ b/packages/server/src/integrations/base/sqlTable.ts
@@ -1,9 +1,16 @@
 import { Knex, knex } from "knex"
-import { Operation, QueryJson, RenameColumn, Table } from "@budibase/types"
+import {
+  FieldSubtype,
+  Operation,
+  QueryJson,
+  RenameColumn,
+  Table,
+} from "@budibase/types"
 import { breakExternalTableId } from "../utils"
 import SchemaBuilder = Knex.SchemaBuilder
 import CreateTableBuilder = Knex.CreateTableBuilder
 import { FieldTypes, RelationshipType } from "../../constants"
+import { utils } from "@budibase/shared-core"
 
 function generateSchema(
   schema: CreateTableBuilder,
@@ -42,7 +49,17 @@ function generateSchema(
       case FieldTypes.LONGFORM:
       case FieldTypes.BARCODEQR:
       case FieldTypes.BB_REFERENCE:
-        schema.text(key)
+        const subtype = column.subtype as FieldSubtype
+        switch (subtype) {
+          case FieldSubtype.USER:
+            schema.text(key)
+            break
+          case FieldSubtype.USERS:
+            schema.json(key)
+            break
+          default:
+            throw utils.unreachable(subtype)
+        }
         break
       case FieldTypes.NUMBER:
         // if meta is specified then this is a junction table entry

--- a/packages/server/src/integrations/base/sqlTable.ts
+++ b/packages/server/src/integrations/base/sqlTable.ts
@@ -48,6 +48,8 @@ function generateSchema(
       case FieldTypes.OPTIONS:
       case FieldTypes.LONGFORM:
       case FieldTypes.BARCODEQR:
+        schema.text(key)
+        break
       case FieldTypes.BB_REFERENCE:
         const subtype = column.subtype as FieldSubtype
         switch (subtype) {

--- a/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
+++ b/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
@@ -28,18 +28,17 @@ export async function processInputBBReferences(
 
   switch (subtype) {
     case FieldSubtype.USER:
+    case FieldSubtype.USERS:
       const { notFoundIds } = await cache.user.getUsers(referenceIds)
 
       if (notFoundIds?.length) {
         throw new InvalidBBRefError(notFoundIds[0], FieldSubtype.USER)
       }
+      return referenceIds.join(",") || null
 
-      break
     default:
       throw utils.unreachable(subtype)
   }
-
-  return referenceIds.join(",") || null
 }
 
 export async function processOutputBBReferences(
@@ -55,6 +54,7 @@ export async function processOutputBBReferences(
 
   switch (subtype) {
     case FieldSubtype.USER:
+    case FieldSubtype.USERS:
       const { users } = await cache.user.getUsers(ids)
       if (!users.length) {
         return undefined

--- a/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
+++ b/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
@@ -3,10 +3,10 @@ import { utils } from "@budibase/shared-core"
 import { FieldSubtype } from "@budibase/types"
 import { InvalidBBRefError } from "./errors"
 
-export async function processInputBBReferences(
+export async function processInputBBReferences<T extends FieldSubtype>(
   value: string | string[] | { _id: string } | { _id: string }[],
   subtype: FieldSubtype
-): Promise<string | null> {
+): Promise<string | string[] | null> {
   const referenceIds: string[] = []
 
   if (Array.isArray(value)) {
@@ -34,6 +34,11 @@ export async function processInputBBReferences(
       if (notFoundIds?.length) {
         throw new InvalidBBRefError(notFoundIds[0], FieldSubtype.USER)
       }
+
+      if (subtype === FieldSubtype.USERS) {
+        return referenceIds
+      }
+
       return referenceIds.join(",") || null
 
     default:
@@ -42,15 +47,16 @@ export async function processInputBBReferences(
 }
 
 export async function processOutputBBReferences(
-  value: string,
+  value: string | string[],
   subtype: FieldSubtype
 ) {
-  if (typeof value !== "string") {
+  if (value === null || value === undefined) {
     // Already processed or nothing to process
     return value || undefined
   }
 
-  const ids = value.split(",").filter(id => !!id)
+  const ids =
+    typeof value === "string" ? value.split(",").filter(id => !!id) : value
 
   switch (subtype) {
     case FieldSubtype.USER:

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -6,6 +6,7 @@ import {
   SearchFilter,
   SearchQuery,
   SearchQueryFields,
+  FieldSubtype,
 } from "@budibase/types"
 import { OperatorOptions, SqlNumberTypeRangeMap } from "./constants"
 import { deepGet } from "./helpers"
@@ -17,7 +18,7 @@ const HBS_REGEX = /{{([^{].*?)}}/g
  * @param type the data type
  */
 export const getValidOperatorsForType = (
-  type: FieldType,
+  fieldType: { type: FieldType; subtype?: FieldSubtype },
   field: string,
   datasource: Datasource & { tableId: any } // TODO: is this table id ever populated?
 ) => {
@@ -44,6 +45,7 @@ export const getValidOperatorsForType = (
     value: string
     label: string
   }[] = []
+  const { type, subtype } = fieldType
   if (type === FieldType.STRING) {
     ops = stringOps
   } else if (type === FieldType.NUMBER || type === FieldType.BIGINT) {
@@ -60,8 +62,10 @@ export const getValidOperatorsForType = (
     ops = numOps
   } else if (type === FieldType.FORMULA) {
     ops = stringOps.concat([Op.MoreThan, Op.LessThan])
-  } else if (type === FieldType.BB_REFERENCE) {
+  } else if (type === FieldType.BB_REFERENCE && subtype == FieldSubtype.USER) {
     ops = [Op.Equals, Op.NotEquals, Op.Empty, Op.NotEmpty, Op.In]
+  } else if (type === FieldType.BB_REFERENCE && subtype == FieldSubtype.USERS) {
+    ops = [Op.Contains, Op.NotContains, Op.ContainsAny, Op.Empty, Op.NotEmpty]
   }
 
   // Only allow equal/not equal for _id in SQL tables

--- a/packages/types/src/documents/app/row.ts
+++ b/packages/types/src/documents/app/row.ts
@@ -37,10 +37,12 @@ export interface Row extends Document {
 
 export enum FieldSubtype {
   USER = "user",
+  USERS = "users",
 }
 
 export const FieldTypeSubtypes = {
   BB_REFERENCE: {
     USER: FieldSubtype.USER,
+    USESR: FieldSubtype.USERS,
   },
 }

--- a/packages/types/src/documents/app/row.ts
+++ b/packages/types/src/documents/app/row.ts
@@ -43,6 +43,6 @@ export enum FieldSubtype {
 export const FieldTypeSubtypes = {
   BB_REFERENCE: {
     USER: FieldSubtype.USER,
-    USESR: FieldSubtype.USERS,
+    USERS: FieldSubtype.USERS,
   },
 }


### PR DESCRIPTION
## Description
Rethinking and reenabling multi-user column. This column was changed from being stored as a CSV to being an array, allowing complex filtering operations.

Addresses: 
- [BUDI-7589 - User column - multi-user filtering support](https://linear.app/budibase/issue/BUDI-7589/user-column-multi-user-filtering-support)

## Screenshots
### Filtering by user (single column)
<img width="954" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/1333178c-a168-4dd0-ad6d-963b40ac7c99">

### Filtering by users (multiple column)
<img width="963" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/085d301b-dacb-4afc-973e-d06737e01c07">

