### PR TITLE
Current user ID user column search mapping

### DIFF
--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -191,7 +191,7 @@
   }
 
   const getValidOperatorsForType = filter => {
-    if (!filter.field) {
+    if (!filter?.field) {
       return []
     }
 

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterDrawer.svelte
@@ -191,7 +191,7 @@
   }
 
   const getValidOperatorsForType = filter => {
-    if (!filter) {
+    if (!filter.field) {
       return []
     }
 

--- a/packages/server/src/sdk/app/rows/search/external.ts
+++ b/packages/server/src/sdk/app/rows/search/external.ts
@@ -16,6 +16,7 @@ import { cleanExportRows } from "../utils"
 import { utils } from "@budibase/shared-core"
 import { ExportRowsParams, ExportRowsResult } from "../search"
 import { HTTPError, db } from "@budibase/backend-core"
+import { searchInputMapping } from "./utils"
 import pick from "lodash/pick"
 import { outputProcessing } from "../../../../utilities/rowProcessor"
 
@@ -50,7 +51,10 @@ export async function search(options: SearchParams) {
       [params.sort]: { direction },
     }
   }
+
   try {
+    const table = await sdk.tables.getTable(tableId)
+    options = searchInputMapping(table, options)
     let rows = (await handleRequest(Operation.READ, tableId, {
       filters: query,
       sort,
@@ -76,7 +80,6 @@ export async function search(options: SearchParams) {
       rows = rows.map((r: any) => pick(r, fields))
     }
 
-    const table = await sdk.tables.getTable(tableId)
     rows = await outputProcessing(table, rows, { preserveLinks: true })
 
     // need wrapper object for bookmarks etc when paginating

--- a/packages/server/src/sdk/app/rows/search/internal.ts
+++ b/packages/server/src/sdk/app/rows/search/internal.ts
@@ -29,6 +29,7 @@ import {
 } from "../../../../api/controllers/view/utils"
 import sdk from "../../../../sdk"
 import { ExportRowsParams, ExportRowsResult } from "../search"
+import { searchInputMapping } from "./utils"
 import pick from "lodash/pick"
 
 export async function search(options: SearchParams) {
@@ -47,9 +48,9 @@ export async function search(options: SearchParams) {
     disableEscaping: options.disableEscaping,
   }
 
-  let table
+  let table = await sdk.tables.getTable(tableId)
+  options = searchInputMapping(table, options)
   if (params.sort && !params.sortType) {
-    table = await sdk.tables.getTable(tableId)
     const schema = table.schema
     const sortField = schema[params.sort]
     params.sortType = sortField.type === "number" ? "number" : "string"
@@ -68,7 +69,6 @@ export async function search(options: SearchParams) {
     if (tableId === InternalTables.USER_METADATA) {
       response.rows = await getGlobalUsersFromMetadata(response.rows)
     }
-    table = table || (await sdk.tables.getTable(tableId))
 
     if (options.fields) {
       const fields = [...options.fields, ...db.CONSTANT_INTERNAL_ROW_COLS]

--- a/packages/server/src/sdk/app/rows/search/tests/utils.spec.ts
+++ b/packages/server/src/sdk/app/rows/search/tests/utils.spec.ts
@@ -37,13 +37,16 @@ describe("searchInputMapping", () => {
   })
 
   it("shouldn't change any other input", () => {
+    const email = "test@test.com"
     const params: SearchParams = {
       tableId,
       query: {
         equal: {
-          "1:user": "test@test.com",
+          "1:user": email,
         },
       },
     }
+    const output = searchInputMapping(tableWithUserCol, params)
+    expect(output.query.equal!["1:user"]).toBe(email)
   })
 })

--- a/packages/server/src/sdk/app/rows/search/tests/utils.spec.ts
+++ b/packages/server/src/sdk/app/rows/search/tests/utils.spec.ts
@@ -1,0 +1,49 @@
+import { searchInputMapping } from "../utils"
+import { db as dbCore } from "@budibase/backend-core"
+import {
+  FieldType,
+  FieldTypeSubtypes,
+  Table,
+  SearchParams,
+} from "@budibase/types"
+
+const tableId = "ta_a"
+const tableWithUserCol: Table = {
+  _id: tableId,
+  name: "table",
+  schema: {
+    user: {
+      name: "user",
+      type: FieldType.BB_REFERENCE,
+      subtype: FieldTypeSubtypes.BB_REFERENCE.USER,
+    },
+  },
+}
+
+describe("searchInputMapping", () => {
+  it("should be able to map ro_ to global user IDs", () => {
+    const globalUserId = dbCore.generateGlobalUserID()
+    const userMedataId = dbCore.generateUserMetadataID(globalUserId)
+    const params: SearchParams = {
+      tableId,
+      query: {
+        equal: {
+          "1:user": userMedataId,
+        },
+      },
+    }
+    const output = searchInputMapping(tableWithUserCol, params)
+    expect(output.query.equal!["1:user"]).toBe(globalUserId)
+  })
+
+  it("shouldn't change any other input", () => {
+    const params: SearchParams = {
+      tableId,
+      query: {
+        equal: {
+          "1:user": "test@test.com",
+        },
+      },
+    }
+  })
+})

--- a/packages/server/src/sdk/app/rows/search/tests/utils.spec.ts
+++ b/packages/server/src/sdk/app/rows/search/tests/utils.spec.ts
@@ -21,9 +21,10 @@ const tableWithUserCol: Table = {
 }
 
 describe("searchInputMapping", () => {
+  const globalUserId = dbCore.generateGlobalUserID()
+  const userMedataId = dbCore.generateUserMetadataID(globalUserId)
+
   it("should be able to map ro_ to global user IDs", () => {
-    const globalUserId = dbCore.generateGlobalUserID()
-    const userMedataId = dbCore.generateUserMetadataID(globalUserId)
     const params: SearchParams = {
       tableId,
       query: {
@@ -34,6 +35,22 @@ describe("searchInputMapping", () => {
     }
     const output = searchInputMapping(tableWithUserCol, params)
     expect(output.query.equal!["1:user"]).toBe(globalUserId)
+  })
+
+  it("should handle array of user IDs", () => {
+    const params: SearchParams = {
+      tableId,
+      query: {
+        oneOf: {
+          "1:user": [userMedataId, globalUserId],
+        },
+      },
+    }
+    const output = searchInputMapping(tableWithUserCol, params)
+    expect(output.query.oneOf!["1:user"]).toStrictEqual([
+      globalUserId,
+      globalUserId,
+    ])
   })
 
   it("shouldn't change any other input", () => {
@@ -48,5 +65,13 @@ describe("searchInputMapping", () => {
     }
     const output = searchInputMapping(tableWithUserCol, params)
     expect(output.query.equal!["1:user"]).toBe(email)
+  })
+
+  it("shouldn't error if no query supplied", () => {
+    const params: any = {
+      tableId,
+    }
+    const output = searchInputMapping(tableWithUserCol, params)
+    expect(output.query).toBeUndefined()
   })
 })

--- a/packages/server/src/sdk/app/rows/search/utils.ts
+++ b/packages/server/src/sdk/app/rows/search/utils.ts
@@ -57,6 +57,8 @@ function userColumnMapping(column: string, options: SearchParams) {
   })
 }
 
+// maps through the search parameters to check if any of the inputs are invalid
+// based on the table schema, converts them to something that is valid.
 export function searchInputMapping(table: Table, options: SearchParams) {
   for (let [key, column] of Object.entries(table.schema)) {
     switch (column.type) {

--- a/packages/server/src/sdk/app/rows/search/utils.ts
+++ b/packages/server/src/sdk/app/rows/search/utils.ts
@@ -29,7 +29,7 @@ function findColumnInQueries(
 }
 
 function userColumnMapping(column: string, options: SearchParams) {
-  findColumnInQueries(column, options, (filterValue: any): string => {
+  findColumnInQueries(column, options, (filterValue: any): any => {
     const isArray = Array.isArray(filterValue),
       isString = typeof filterValue === "string"
     if (!isString && !isArray) {

--- a/packages/server/src/sdk/app/rows/search/utils.ts
+++ b/packages/server/src/sdk/app/rows/search/utils.ts
@@ -1,0 +1,53 @@
+import {
+  FieldType,
+  FieldTypeSubtypes,
+  SearchParams,
+  Table,
+  DocumentType,
+  SEPARATOR,
+} from "@budibase/types"
+import { db as dbCore } from "@budibase/backend-core"
+
+function findColumnInQueries(
+  column: string,
+  options: SearchParams,
+  callback: <T>(filter: T) => T
+) {
+  for (let filterBlock of Object.values(options.query)) {
+    if (typeof filterBlock !== "object") {
+      continue
+    }
+    for (let [key, filter] of Object.entries(filterBlock)) {
+      if (key.endsWith(column)) {
+        filterBlock[key] = callback(filter)
+      }
+    }
+  }
+}
+
+function userColumnMapping(column: string, options: SearchParams) {
+  findColumnInQueries(column, options, (filterValue: any): string => {
+    if (typeof filterValue !== "string") {
+      return filterValue
+    }
+    const rowPrefix = DocumentType.ROW + SEPARATOR
+    // TODO: at some point in future might want to handle mapping emails to IDs
+    if (filterValue.startsWith(rowPrefix)) {
+      return dbCore.getGlobalIDFromUserMetadataID(filterValue)
+    }
+    return filterValue
+  })
+}
+
+export function searchInputMapping(table: Table, options: SearchParams) {
+  for (let [key, column] of Object.entries(table.schema)) {
+    switch (column.type) {
+      case FieldType.BB_REFERENCE:
+        if (column.subtype === FieldTypeSubtypes.BB_REFERENCE.USER) {
+          userColumnMapping(key, options)
+        }
+        break
+    }
+  }
+  return options
+}

--- a/packages/server/src/sdk/app/rows/search/utils.ts
+++ b/packages/server/src/sdk/app/rows/search/utils.ts
@@ -11,7 +11,7 @@ import { db as dbCore } from "@budibase/backend-core"
 function findColumnInQueries(
   column: string,
   options: SearchParams,
-  callback: <T>(filter: T) => T
+  callback: (filter: any) => any
 ) {
   for (let filterBlock of Object.values(options.query)) {
     if (typeof filterBlock !== "object") {

--- a/packages/server/src/sdk/app/rows/search/utils.ts
+++ b/packages/server/src/sdk/app/rows/search/utils.ts
@@ -60,6 +60,9 @@ function userColumnMapping(column: string, options: SearchParams) {
 // maps through the search parameters to check if any of the inputs are invalid
 // based on the table schema, converts them to something that is valid.
 export function searchInputMapping(table: Table, options: SearchParams) {
+  if (!table?.schema) {
+    return options
+  }
   for (let [key, column] of Object.entries(table.schema)) {
     switch (column.type) {
       case FieldType.BB_REFERENCE:

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -14,7 +14,6 @@ const HBS_REGEX = /{{([^{].*?)}}/g
 
 /**
  * Returns the valid operator options for a certain data type
- * @param type the data type
  */
 export const getValidOperatorsForType = (
   type: FieldType,


### PR DESCRIPTION
## Description
Adding a mapping layer to search queries so that we can map search inputs based on the table schema if desired - primarily for the user column.

By default the `{{ Current User._id }}` will return the table within the app, the user metadata table, which is not the global user ID. We have to map these IDs, this functionality allows us to lookup the schema of a column and then decide if the mapping is needed. This could be expanded to cover other user attributes, like email.