### PR TITLE
Allow relationship to be deleted even if missing

### DIFF
--- a/packages/server/src/db/linkedRows/LinkController.ts
+++ b/packages/server/src/db/linkedRows/LinkController.ts
@@ -316,6 +316,7 @@ class LinkController {
       }
       await this._db.put(linkedTable)
     } catch (error: any) {
+      // ignore missing to ensure broken relationship columns can be deleted
       if (error.statusCode !== 404) {
         throw error
       }

--- a/packages/server/src/db/linkedRows/LinkController.ts
+++ b/packages/server/src/db/linkedRows/LinkController.ts
@@ -308,12 +308,18 @@ class LinkController {
         }
       })
     )
-    // remove schema from other table
-    let linkedTable = await this._db.get<Table>(field.tableId)
-    if (field.fieldName) {
-      delete linkedTable.schema[field.fieldName]
+    try {
+      // remove schema from other table, if it exists
+      let linkedTable = await this._db.get<Table>(field.tableId)
+      if (field.fieldName) {
+        delete linkedTable.schema[field.fieldName]
+      }
+      await this._db.put(linkedTable)
+    } catch (error: any) {
+      if (error.statusCode !== 404) {
+        throw error
+      }
     }
-    await this._db.put(linkedTable)
   }
 
   /**

--- a/packages/server/src/db/tests/linkController.spec.js
+++ b/packages/server/src/db/tests/linkController.spec.js
@@ -233,4 +233,19 @@ describe("test the link controller", () => {
     }
     await config.updateTable(table)
   })
+
+  it("should be able to remove a linked field from a table, even if the linked table does not exist", async () => {
+    await createLinkedRow()
+    await createLinkedRow("link2")
+    table1.schema["link"].tableId = "not_found"
+    const controller = await createLinkController(table1, null, table1)
+    await context.doInAppContext(appId, async () => {
+      let before = await controller.getTableLinkDocs()
+      await controller.removeFieldFromTable("link")
+      let after = await controller.getTableLinkDocs()
+      expect(before.length).toEqual(2)
+      // shouldn't delete the other field
+      expect(after.length).toEqual(1)
+    })
+  })
 })


### PR DESCRIPTION
## Description
A user reported a bug relating to relationships in automations, however the root cause was that they had a relationship column that was pointing to a table that no longer existed.

When trying to delete that column, it was failing due to a `missing` error thrown from couch.

Fix added to not throw an error when attempting to update the column on the related table if it's missing.

Addresses: 
- https://github.com/Budibase/budibase/issues/11952



