### PR TITLE
Fix for saving user metadata IDs - convert them to global IDs in user column

### DIFF
--- a/packages/server/src/utilities/rowProcessor/tests/bbReferenceProcessor.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/bbReferenceProcessor.spec.ts
@@ -154,6 +154,15 @@ describe("bbReferenceProcessor", () => {
 
         expect(result).toEqual(null)
       })
+
+      it("should convert user medata IDs to global IDs", async () => {
+        const userId = _.sample(users)!._id!
+        const userMetadataId = backendCore.db.generateUserMetadataID(userId)
+        const result = await config.doInTenant(() =>
+          processInputBBReferences(userMetadataId, FieldSubtype.USER)
+        )
+        expect(result).toBe(userId)
+      })
     })
   })
 


### PR DESCRIPTION
## Description
Quick fix for saving `{{ Current User._id }}` - make sure it is the correct format of ID.