### PR TITLE
Fix form block crash on no data tables

### DIFF
--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -949,13 +949,11 @@ export const buildFormSchema = (component, asset) => {
   if (component._component.endsWith("formblock")) {
     let schema = {}
     const datasource = getDatasourceForProvider(asset, component)
+    const info = getSchemaForDatasource(component, datasource)
 
-    // Return if an app has no data tables
-    if (!datasource) {
+    if (!info?.schema) {
       return schema
     }
-
-    const info = getSchemaForDatasource(component, datasource)
 
     if (!component.fields) {
       Object.values(info.schema)

--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -948,12 +948,17 @@ export const buildFormSchema = (component, asset) => {
 
   if (component._component.endsWith("formblock")) {
     let schema = {}
-
     const datasource = getDatasourceForProvider(asset, component)
+
+    // Return if an app has no data tables
+    if (!datasource) {
+      return schema
+    }
+
     const info = getSchemaForDatasource(component, datasource)
 
     if (!component.fields) {
-      Object.values(info?.schema)
+      Object.values(info.schema)
         .filter(
           ({ autocolumn, name }) =>
             !autocolumn && !["_rev", "_id"].includes(name)

--- a/packages/builder/src/components/design/settings/controls/FieldConfiguration/FieldConfiguration.svelte
+++ b/packages/builder/src/components/design/settings/controls/FieldConfiguration/FieldConfiguration.svelte
@@ -36,7 +36,8 @@
     )
   }
 
-  $: datasource = getDatasourceForProvider($currentAsset, componentInstance)
+  $: datasource =
+    getDatasourceForProvider($currentAsset, componentInstance) || {}
   $: resourceId = datasource.resourceId || datasource.tableId
 
   $: if (!isEqual(value, cachedValue)) {

--- a/packages/builder/src/components/design/settings/controls/FieldConfiguration/FieldConfiguration.svelte
+++ b/packages/builder/src/components/design/settings/controls/FieldConfiguration/FieldConfiguration.svelte
@@ -36,9 +36,8 @@
     )
   }
 
-  $: datasource =
-    getDatasourceForProvider($currentAsset, componentInstance) || {}
-  $: resourceId = datasource.resourceId || datasource.tableId
+  $: datasource = getDatasourceForProvider($currentAsset, componentInstance)
+  $: resourceId = datasource?.resourceId || datasource?.tableId
 
   $: if (!isEqual(value, cachedValue)) {
     cachedValue = cloneDeep(value)


### PR DESCRIPTION
## Description
Null pointer fix - the `getDatasourceForProvider` function was returning undefined if an app had no data tables, and only queries. 
Now returning an empty object instead.


Addresses: 
- https://linear.app/budibase/issue/BUDI-7603/page-stops-responding-after-clicking-on-component-in-design




