### PR TITLE
feat: Adding Elestio as self-hosting platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Or use Budibase Cloud if you don't need to self-host, and would like to get star
 - [Kubernetes](https://docs.budibase.com/docs/kubernetes-k8s)
 - [Digital Ocean](https://docs.budibase.com/docs/digitalocean)
 - [Portainer](https://docs.budibase.com/docs/portainer)
+- [Elestio](https://elest.io/open-source/budibase)
 
 
 ### [Get started with Budibase Cloud](https://budibase.com)


### PR DESCRIPTION
## Description
Elestio has been provided an option of fully managing Budibase on infrastructure of your choice. Hence this PR adds it as an option to self-host it among others.

Addresses: 
- closes #11998 

## Screenshots
![Elestio](https://user-images.githubusercontent.com/53310847/273512107-5019d248-0f34-46b2-b71d-18618efc61c7.png)

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



