### PR TITLE
Ban user column to be used as display column

### DIFF
--- a/packages/frontend-core/src/components/grid/cells/HeaderCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/HeaderCell.svelte
@@ -1,6 +1,6 @@
 <script>
   import { getContext, onMount, tick } from "svelte"
-  import { FieldType, FieldSubtype } from "@budibase/types"
+  import { FieldType } from "@budibase/types"
   import GridCell from "./GridCell.svelte"
   import { Icon, Popover, Menu, MenuItem, clickOutside } from "@budibase/bbui"
   import { getColumnIcon } from "../lib/utils"
@@ -24,6 +24,15 @@
     definition,
     datasource,
   } = getContext("grid")
+
+  const bannedDisplayColumnTypes = [
+    FieldType.LINK,
+    FieldType.ARRAY,
+    FieldType.ATTACHMENT,
+    FieldType.BOOLEAN,
+    FieldType.JSON,
+    FieldType.BB_REFERENCE,
+  ]
 
   let anchor
   let open = false
@@ -140,28 +149,6 @@
     })
   }
 
-  const canBeDisplayColumn = column => {
-    const bannedDisplayColumnTypes = [
-      "link",
-      "array",
-      "attachment",
-      "boolean",
-      "json",
-    ]
-    if (bannedDisplayColumnTypes.includes(column.schema.type)) {
-      return false
-    }
-
-    if (
-      column.schema.type === FieldType.BB_REFERENCE &&
-      column.schema.subtype === FieldSubtype.USERS
-    ) {
-      return false
-    }
-
-    return true
-  }
-
   onMount(() => subscribe("close-edit-column", cancelEdit))
 </script>
 
@@ -246,7 +233,8 @@
       <MenuItem
         icon="Label"
         on:click={makeDisplayColumn}
-        disabled={idx === "sticky" || !canBeDisplayColumn(column)}
+        disabled={idx === "sticky" ||
+          bannedDisplayColumnTypes.includes(column.schema.type)}
       >
         Use as display column
       </MenuItem>

--- a/packages/frontend-core/src/components/grid/cells/HeaderCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/HeaderCell.svelte
@@ -1,5 +1,6 @@
 <script>
   import { getContext, onMount, tick } from "svelte"
+  import { FieldType, FieldSubtype } from "@budibase/types"
   import GridCell from "./GridCell.svelte"
   import { Icon, Popover, Menu, MenuItem, clickOutside } from "@budibase/bbui"
   import { getColumnIcon } from "../lib/utils"
@@ -23,14 +24,6 @@
     definition,
     datasource,
   } = getContext("grid")
-
-  const bannedDisplayColumnTypes = [
-    "link",
-    "array",
-    "attachment",
-    "boolean",
-    "json",
-  ]
 
   let anchor
   let open = false
@@ -147,6 +140,28 @@
     })
   }
 
+  const canBeDisplayColumn = column => {
+    const bannedDisplayColumnTypes = [
+      "link",
+      "array",
+      "attachment",
+      "boolean",
+      "json",
+    ]
+    if (bannedDisplayColumnTypes.includes(column.schema.type)) {
+      return false
+    }
+
+    if (
+      column.schema.type === FieldType.BB_REFERENCE &&
+      column.schema.subtype === FieldSubtype.USERS
+    ) {
+      return false
+    }
+
+    return true
+  }
+
   onMount(() => subscribe("close-edit-column", cancelEdit))
 </script>
 
@@ -231,8 +246,7 @@
       <MenuItem
         icon="Label"
         on:click={makeDisplayColumn}
-        disabled={idx === "sticky" ||
-          bannedDisplayColumnTypes.includes(column.schema.type)}
+        disabled={idx === "sticky" || !canBeDisplayColumn(column)}
       >
         Use as display column
       </MenuItem>

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -219,7 +219,7 @@ export async function outputProcessing<T extends Row[] | Row>(
     ? await linkRows.attachFullLinkedDocs(table, safeRows)
     : safeRows
 
-  // set the attachments URLs
+  // process complex types: attachements, bb references...
   for (let [property, column] of Object.entries(table.schema)) {
     if (column.type === FieldTypes.ATTACHMENT) {
       for (let row of enriched) {
@@ -240,7 +240,7 @@ export async function outputProcessing<T extends Row[] | Row>(
     }
   }
 
-  // process formulas
+  // process formulas after the complex types had been processed
   enriched = processFormulas(table, enriched, { dynamic: true }) as Row[]
 
   if (opts.squash) {

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -219,9 +219,6 @@ export async function outputProcessing<T extends Row[] | Row>(
     ? await linkRows.attachFullLinkedDocs(table, safeRows)
     : safeRows
 
-  // process formulas
-  enriched = processFormulas(table, enriched, { dynamic: true }) as Row[]
-
   // set the attachments URLs
   for (let [property, column] of Object.entries(table.schema)) {
     if (column.type === FieldTypes.ATTACHMENT) {
@@ -242,6 +239,10 @@ export async function outputProcessing<T extends Row[] | Row>(
       }
     }
   }
+
+  // process formulas
+  enriched = processFormulas(table, enriched, { dynamic: true }) as Row[]
+
   if (opts.squash) {
     enriched = (await linkRows.squashLinksToPrimaryDisplay(
       table,


### PR DESCRIPTION
## Description
Disabling user columns to be set as a display column. They add plenty of complexity, and there are workarounds using formulas instead

## Screenshots
<img width="885" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/9cd8f5b7-1bde-452c-b1c3-a22fce4330b5">
