### PR TITLE
Allow user table changes in existing apps again

### DIFF
--- a/packages/builder/src/builderStore/store/frontend.js
+++ b/packages/builder/src/builderStore/store/frontend.js
@@ -64,6 +64,7 @@ const INITIAL_FRONTEND_STATE = {
   },
   features: {
     componentValidation: false,
+    disableUserMetadata: false,
   },
   errors: [],
   hasAppPackage: false,

--- a/packages/builder/src/components/backend/DataTable/TableDataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/TableDataTable.svelte
@@ -36,7 +36,6 @@
     return datasource._id === $tables.selected?.sourceId
   })
   $: relationshipsEnabled = relationshipSupport(tableDatasource)
-  $: editable = !(isUsersTable && $store.features.disableUserMetadata)
 
   const relationshipSupport = datasource => {
     const integration = $integrations[datasource?.source]
@@ -60,22 +59,22 @@
   <Grid
     {API}
     datasource={gridDatasource}
-    canAddRows={editable}
-    canDeleteRows={editable}
-    canEditRows={editable}
-    canEditColumns={editable}
+    canAddRows={!isUsersTable}
+    canDeleteRows={!isUsersTable}
+    canEditRows={!isUsersTable || !$store.features.disableUserMetadata}
+    canEditColumns={!isUsersTable || !$store.features.disableUserMetadata}
     schemaOverrides={isUsersTable ? userSchemaOverrides : null}
     showAvatars={false}
     on:updatedatasource={handleGridTableUpdate}
   >
     <svelte:fragment slot="filter">
-      {#if !editable}
+      {#if isUsersTable && $store.features.disableUserMetadata}
         <GridUsersTableButton />
       {/if}
       <GridFilterButton />
     </svelte:fragment>
     <svelte:fragment slot="controls">
-      {#if editable}
+      {#if !isUsersTable}
         <GridCreateViewButton />
       {/if}
       <GridManageAccessButton />

--- a/packages/builder/src/components/backend/DataTable/TableDataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/TableDataTable.svelte
@@ -4,6 +4,7 @@
   import { TableNames } from "constants"
   import { Grid } from "@budibase/frontend-core"
   import { API } from "api"
+  import { store } from "builderStore"
   import GridAddColumnModal from "components/backend/DataTable/modals/grid/GridCreateColumnModal.svelte"
   import GridCreateEditRowModal from "components/backend/DataTable/modals/grid/GridCreateEditRowModal.svelte"
   import GridEditUserModal from "components/backend/DataTable/modals/grid/GridEditUserModal.svelte"
@@ -17,11 +18,11 @@
   import GridUsersTableButton from "components/backend/DataTable/modals/grid/GridUsersTableButton.svelte"
 
   const userSchemaOverrides = {
-    firstName: { displayName: "First name" },
-    lastName: { displayName: "Last name" },
-    email: { displayName: "Email" },
-    roleId: { displayName: "Role" },
-    status: { displayName: "Status" },
+    firstName: { displayName: "First name", disabled: true },
+    lastName: { displayName: "Last name", disabled: true },
+    email: { displayName: "Email", disabled: true },
+    roleId: { displayName: "Role", disabled: true },
+    status: { displayName: "Status", disabled: true },
   }
 
   $: id = $tables.selected?._id
@@ -35,6 +36,7 @@
     return datasource._id === $tables.selected?.sourceId
   })
   $: relationshipsEnabled = relationshipSupport(tableDatasource)
+  $: editable = !(isUsersTable && $store.features.disableUserMetadata)
 
   const relationshipSupport = datasource => {
     const integration = $integrations[datasource?.source]
@@ -58,22 +60,22 @@
   <Grid
     {API}
     datasource={gridDatasource}
-    canAddRows={!isUsersTable}
-    canDeleteRows={!isUsersTable}
-    canEditRows={!isUsersTable}
-    canEditColumns={!isUsersTable}
+    canAddRows={editable}
+    canDeleteRows={editable}
+    canEditRows={editable}
+    canEditColumns={editable}
     schemaOverrides={isUsersTable ? userSchemaOverrides : null}
     showAvatars={false}
     on:updatedatasource={handleGridTableUpdate}
   >
     <svelte:fragment slot="filter">
-      {#if isUsersTable}
+      {#if !editable}
         <GridUsersTableButton />
       {/if}
       <GridFilterButton />
     </svelte:fragment>
     <svelte:fragment slot="controls">
-      {#if !isUsersTable}
+      {#if editable}
         <GridCreateViewButton />
       {/if}
       <GridManageAccessButton />

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -289,6 +289,7 @@ async function performAppCreate(ctx: UserCtx) {
       },
       features: {
         componentValidation: true,
+        disableUserMetadata: true,
       },
     }
 

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -311,9 +311,12 @@ async function performAppCreate(ctx: UserCtx) {
         }
       })
 
-      // Keep existing validation setting
+      // Keep existing feature flags
       if (!existing.features?.componentValidation) {
         newApplication.features!.componentValidation = false
+      }
+      if (!existing.features?.disableUserMetadata) {
+        newApplication.features!.disableUserMetadata = false
       }
 
       // Migrate navigation settings and screens if required

--- a/packages/types/src/documents/app/app.ts
+++ b/packages/types/src/documents/app/app.ts
@@ -66,4 +66,5 @@ export interface AppIcon {
 
 export interface AppFeatures {
   componentValidation?: boolean
+  disableUserMetadata?: boolean
 }


### PR DESCRIPTION
## Description
This PR restores the ability to fully edit the user table inside existing apps, while keeping it readonly inside new applications. Old apps that are exported and imported again keep their existing state, i.e. you will still be able to edit the user table if that app allowed it when exported.

The new flag `disableUserMetadata` has to be negative since we want the non-existing case to mean editing *is* allowed. So the new flag signifies disabling editing by its prescence.

### Existing app
Notice the lack of the "why is my table readonly" button, and the ability to create columns.
![image](https://github.com/Budibase/budibase/assets/9075550/3b6c52be-0d2c-4b46-8b39-445335f0f53e)
![image](https://github.com/Budibase/budibase/assets/9075550/aac4744e-edcb-4335-a5e8-8e69aa2b0eb2)

### New app
Notice the users table is now readonly, and the message is displayed.
![image](https://github.com/Budibase/budibase/assets/9075550/d6aed87f-8bde-4391-bdc2-1c81c14ac289)
![image](https://github.com/Budibase/budibase/assets/9075550/a75bc44f-7c95-4e0c-b500-9d4cb5eb7ed0)

### Imported old app
Notice user table editing is still allowed, as it was in the original app when exported.
![image](https://github.com/Budibase/budibase/assets/9075550/69320df6-9545-4550-9601-136798fd7d62)

Addresses: 
- https://linear.app/budibase/issue/BUDI-7604/enable-editing-of-user-metadata-for-existing-apps