### PR TITLE
Fixing null in user column form field if using user metadata IDs

### DIFF
--- a/packages/backend-core/src/constants/db.ts
+++ b/packages/backend-core/src/constants/db.ts
@@ -1,5 +1,10 @@
 import { prefixed, DocumentType } from "@budibase/types"
-export { SEPARATOR, UNICODE_MAX, DocumentType } from "@budibase/types"
+export {
+  SEPARATOR,
+  UNICODE_MAX,
+  DocumentType,
+  InternalTable,
+} from "@budibase/types"
 
 /**
  * Can be used to create a few different forms of querying a view.
@@ -28,10 +33,6 @@ export const DeprecatedViews = {
     // removed due to inaccuracy in view doc filter logic
     "by_email",
   ],
-}
-
-export enum InternalTable {
-  USER_METADATA = "ta_users",
 }
 
 export const StaticDatabases = {

--- a/packages/client/src/components/app/forms/BBReferenceField.svelte
+++ b/packages/client/src/components/app/forms/BBReferenceField.svelte
@@ -1,17 +1,31 @@
 <script>
   import RelationshipField from "./RelationshipField.svelte"
   import { sdk } from "@budibase/shared-core"
+
+  export let defaultValue
+
+  function updateUserIDs(value) {
+    if (Array.isArray(value)) {
+      return value.map(val => sdk.users.getGlobalUserID(val))
+    } else {
+      return sdk.users.getGlobalUserID(value)
+    }
+  }
+
+  function updateReferences(value) {
+    if (sdk.users.containsUserID(value)) {
+      return updateUserIDs(value)
+    }
+    return value
+  }
 </script>
 
 <RelationshipField
   {...$$props}
   datasourceType={"user"}
   primaryDisplay={"email"}
-  valueConversion={value => {
-    if (Array.isArray(value)) {
-      return value.map(val => sdk.users.getGlobalUserID(val))
-    } else {
-      return sdk.users.getGlobalUserID(value)
-    }
+  defaultValue={updateReferences(defaultValue)}
+  onChange={value => {
+    return updateReferences(value)
   }}
 />

--- a/packages/client/src/components/app/forms/BBReferenceField.svelte
+++ b/packages/client/src/components/app/forms/BBReferenceField.svelte
@@ -25,7 +25,4 @@
   datasourceType={"user"}
   primaryDisplay={"email"}
   defaultValue={updateReferences(defaultValue)}
-  onChange={value => {
-    return updateReferences(value)
-  }}
 />

--- a/packages/client/src/components/app/forms/BBReferenceField.svelte
+++ b/packages/client/src/components/app/forms/BBReferenceField.svelte
@@ -1,9 +1,17 @@
 <script>
   import RelationshipField from "./RelationshipField.svelte"
+  import { sdk } from "@budibase/shared-core"
 </script>
 
 <RelationshipField
   {...$$props}
   datasourceType={"user"}
   primaryDisplay={"email"}
+  valueConversion={value => {
+    if (Array.isArray(value)) {
+      return value.map(val => sdk.users.getGlobalUserID(val))
+    } else {
+      return sdk.users.getGlobalUserID(value)
+    }
+  }}
 />

--- a/packages/client/src/components/app/forms/RelationshipField.svelte
+++ b/packages/client/src/components/app/forms/RelationshipField.svelte
@@ -18,7 +18,6 @@
   export let filter
   export let datasourceType = "table"
   export let primaryDisplay
-  export let valueConversion
 
   let fieldState
   let fieldApi
@@ -162,7 +161,7 @@
     const changed = fieldApi.setValue(value)
     if (onChange && changed) {
       onChange({
-        value: valueConversion ? valueConversion(value) : value,
+        value,
       })
     }
   }
@@ -179,9 +178,7 @@
   {field}
   {disabled}
   {validation}
-  defaultValue={valueConversion
-    ? valueConversion(expandedDefaultValue)
-    : expandedDefaultValue}
+  defaultValue={expandedDefaultValue}
   {type}
   bind:fieldState
   bind:fieldApi

--- a/packages/client/src/components/app/forms/RelationshipField.svelte
+++ b/packages/client/src/components/app/forms/RelationshipField.svelte
@@ -18,6 +18,7 @@
   export let filter
   export let datasourceType = "table"
   export let primaryDisplay
+  export let valueConversion
 
   let fieldState
   let fieldApi
@@ -160,7 +161,9 @@
   const handleChange = value => {
     const changed = fieldApi.setValue(value)
     if (onChange && changed) {
-      onChange({ value })
+      onChange({
+        value: valueConversion ? valueConversion(value) : value,
+      })
     }
   }
 
@@ -176,7 +179,9 @@
   {field}
   {disabled}
   {validation}
-  defaultValue={expandedDefaultValue}
+  defaultValue={valueConversion
+    ? valueConversion(expandedDefaultValue)
+    : expandedDefaultValue}
   {type}
   bind:fieldState
   bind:fieldApi

--- a/packages/shared-core/src/sdk/documents/users.ts
+++ b/packages/shared-core/src/sdk/documents/users.ts
@@ -1,4 +1,10 @@
-import { ContextUser, User } from "@budibase/types"
+import {
+  ContextUser,
+  DocumentType,
+  SEPARATOR,
+  User,
+  InternalTable,
+} from "@budibase/types"
 import { getProdAppID } from "./applications"
 
 // checks if a user is specifically a builder, given an app ID
@@ -66,4 +72,15 @@ export function hasAdminPermissions(user?: User | ContextUser): boolean {
     return false
   }
   return !!user.admin?.global
+}
+
+export function getGlobalUserID(userId?: string): string | undefined {
+  if (typeof userId !== "string") {
+    return userId
+  }
+  const prefix = `${DocumentType.ROW}${SEPARATOR}${InternalTable.USER_METADATA}${SEPARATOR}`
+  if (!userId.startsWith(prefix)) {
+    return userId
+  }
+  return userId.split(prefix)[1]
 }

--- a/packages/shared-core/src/sdk/documents/users.ts
+++ b/packages/shared-core/src/sdk/documents/users.ts
@@ -84,3 +84,10 @@ export function getGlobalUserID(userId?: string): string | undefined {
   }
   return userId.split(prefix)[1]
 }
+
+export function containsUserID(value: string | undefined): boolean {
+  if (typeof value !== "string") {
+    return false
+  }
+  return value.includes(`${DocumentType.USER}${SEPARATOR}`)
+}

--- a/packages/types/src/documents/document.ts
+++ b/packages/types/src/documents/document.ts
@@ -58,6 +58,10 @@ export const DocumentTypesToImport: DocumentType[] = [
   DocumentType.LAYOUT,
 ]
 
+export enum InternalTable {
+  USER_METADATA = "ta_users",
+}
+
 // these documents don't really exist, they are part of other
 // documents or enriched into existence as part of get requests
 export enum VirtualDocumentType {


### PR DESCRIPTION
## Description
Converting user IDs where necessary to global user IDs in the frontend, correcting the null entry when using current user IDs, or other user IDs, as a default value for a user column form type.

Before:
![image](https://github.com/Budibase/budibase/assets/4407001/2de23601-f113-4d75-a651-09ac97873f0f)

After:
![image](https://github.com/Budibase/budibase/assets/4407001/02159dca-6759-4a45-aeb7-c632a1d21209)
