### PR TITLE
Removing filtering from user column picker

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -5674,11 +5674,6 @@
         "key": "validation"
       },
       {
-        "type": "filter/relationship",
-        "label": "Filtering",
-        "key": "filter"
-      },
-      {
         "type": "boolean",
         "label": "Search",
         "key": "autocomplete",


### PR DESCRIPTION
## Description
Removing the option to add a filter to the dataset of a user column picker, as there is no current API for searching this.