### PR TITLE
Single image build - maximise space

### DIFF
--- a/.github/workflows/release-singleimage.yml
+++ b/.github/workflows/release-singleimage.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 35000
+          root-reserve-mb: 30000
           swap-size-mb: 1024
           remove-android: 'true'
           remove-dotnet: 'true'


### PR DESCRIPTION
## Description
It seems we are having issues with the maximise space action that we use for the single image, it is unable to allocate the required space. Attempting to solve this by decreasing the allocated size slightly to see if this is the issue.

This is required as the 18GB available in a Github runner is simply not enough for us to run the single image build within.