### PR TITLE
RelationshipField - load default and handle proper searching with user API

### DIFF
--- a/packages/backend-core/src/users/users.ts
+++ b/packages/backend-core/src/users/users.ts
@@ -14,13 +14,14 @@ import {
 } from "../db"
 import {
   BulkDocsResponse,
+  ContextUser,
+  SearchQuery,
+  SearchQueryOperators,
   SearchUsersRequest,
   User,
-  ContextUser,
 } from "@budibase/types"
-import { getGlobalDB } from "../context"
 import * as context from "../context"
-import { user as userCache } from "../cache"
+import { getGlobalDB } from "../context"
 
 type GetOpts = { cleanup?: boolean }
 
@@ -37,6 +38,27 @@ function removeUserPassword(users: User | User[]) {
     return users
   }
   return users
+}
+
+export const isSupportedUserSearch = (query: SearchQuery) => {
+  const allowed = [
+    { op: SearchQueryOperators.STRING, key: "email" },
+    { op: SearchQueryOperators.EQUAL, key: "_id" },
+  ]
+  for (let [key, operation] of Object.entries(query)) {
+    if (typeof operation !== "object") {
+      return false
+    }
+    const fields = Object.keys(operation || {})
+    const allowedOperation = allowed.find(
+      allow =>
+        allow.op === key && fields.length === 1 && fields[0] === allow.key
+    )
+    if (!allowedOperation && fields.length > 0) {
+      return false
+    }
+  }
+  return true
 }
 
 export const bulkGetGlobalUsersById = async (
@@ -211,8 +233,8 @@ export const searchGlobalUsersByEmail = async (
 
 const PAGE_LIMIT = 8
 export const paginatedUsers = async ({
-  page,
-  email,
+  bookmark,
+  query,
   appId,
 }: SearchUsersRequest = {}) => {
   const db = getGlobalDB()
@@ -222,18 +244,20 @@ export const paginatedUsers = async ({
     limit: PAGE_LIMIT + 1,
   }
   // add a startkey if the page was specified (anchor)
-  if (page) {
-    opts.startkey = page
+  if (bookmark) {
+    opts.startkey = bookmark
   }
   // property specifies what to use for the page/anchor
   let userList: User[],
     property = "_id",
     getKey
-  if (appId) {
+  if (query?.equal?._id) {
+    userList = [await getById(query.equal._id)]
+  } else if (appId) {
     userList = await searchGlobalUsersByApp(appId, opts)
     getKey = (doc: any) => getGlobalUserByAppPage(appId, doc)
-  } else if (email) {
-    userList = await searchGlobalUsersByEmail(email, opts)
+  } else if (query?.string?.email) {
+    userList = await searchGlobalUsersByEmail(query?.string?.email, opts)
     property = "email"
   } else {
     // no search, query allDocs

--- a/packages/backend-core/src/users/users.ts
+++ b/packages/backend-core/src/users/users.ts
@@ -50,11 +50,15 @@ export const isSupportedUserSearch = (query: SearchQuery) => {
       return false
     }
     const fields = Object.keys(operation || {})
+    // this filter doesn't contain options - ignore
+    if (fields.length === 0) {
+      continue
+    }
     const allowedOperation = allowed.find(
       allow =>
         allow.op === key && fields.length === 1 && fields[0] === allow.key
     )
-    if (!allowedOperation && fields.length > 0) {
+    if (!allowedOperation) {
       return false
     }
   }

--- a/packages/builder/src/pages/builder/portal/account/auditLogs/index.svelte
+++ b/packages/builder/src/pages/builder/portal/account/auditLogs/index.svelte
@@ -123,7 +123,10 @@
     prevUserSearch = search
     try {
       userPageInfo.loading()
-      await users.search({ userPage, email: search })
+      await users.search({
+        bookmark: userPage,
+        query: { string: { email: search } },
+      })
       userPageInfo.fetched($users.hasNextPage, $users.nextPage)
     } catch (error) {
       notifications.error("Error getting user list")

--- a/packages/builder/src/pages/builder/portal/users/groups/_components/EditUserPicker.svelte
+++ b/packages/builder/src/pages/builder/portal/users/groups/_components/EditUserPicker.svelte
@@ -31,7 +31,10 @@
     prevSearch = search
     try {
       pageInfo.loading()
-      await users.search({ page, email: search })
+      await users.search({
+        bookmark: page,
+        query: { string: { email: search } },
+      })
       pageInfo.fetched($users.hasNextPage, $users.nextPage)
     } catch (error) {
       notifications.error("Error getting user list")

--- a/packages/client/src/components/app/forms/RelationshipField.svelte
+++ b/packages/client/src/components/app/forms/RelationshipField.svelte
@@ -25,7 +25,6 @@
   let tableDefinition
   let searchTerm
   let open
-  let hasFetchedDefaultValue
 
   $: type =
     datasourceType === "table" ? FieldTypes.LINK : FieldTypes.BB_REFERENCE
@@ -117,11 +116,10 @@
     if (allRowsFetched || !primaryDisplay) {
       return
     }
-    if (defaultVal && !hasFetchedDefaultValue) {
+    if (defaultVal && !optionsObj[defaultVal]) {
       await fetch.update({
         query: { equal: { _id: defaultVal } },
       })
-      hasFetchedDefaultValue = true
     }
     await fetch.update({
       query: { string: { [primaryDisplay]: searchTerm } },

--- a/packages/client/src/components/app/forms/RelationshipField.svelte
+++ b/packages/client/src/components/app/forms/RelationshipField.svelte
@@ -123,7 +123,7 @@
     }
     if (defaultVal) {
       await fetch.update({
-        query: {equal: {_id: defaultValue}}
+        query: { equal: { _id: defaultValue } },
       })
       fetchedDefault = $fetch.rows?.[0]
     }

--- a/packages/client/src/components/app/forms/RelationshipField.svelte
+++ b/packages/client/src/components/app/forms/RelationshipField.svelte
@@ -121,10 +121,6 @@
       await fetch.update({
         query: { equal: { _id: defaultVal } },
       })
-      const defaultRow = $fetch.rows?.[0]
-      if (defaultRow) {
-        optionsObj[defaultRow._id] = defaultRow
-      }
       hasFetchedDefaultValue = true
     }
     await fetch.update({

--- a/packages/client/src/components/app/forms/RelationshipField.svelte
+++ b/packages/client/src/components/app/forms/RelationshipField.svelte
@@ -25,6 +25,7 @@
   let tableDefinition
   let searchTerm
   let open
+  let hasFetchedDefaultValue
 
   $: type =
     datasourceType === "table" ? FieldTypes.LINK : FieldTypes.BB_REFERENCE
@@ -116,7 +117,7 @@
     if (allRowsFetched || !primaryDisplay) {
       return
     }
-    if (defaultVal) {
+    if (defaultVal && !hasFetchedDefaultValue) {
       await fetch.update({
         query: { equal: { _id: defaultVal } },
       })
@@ -124,6 +125,7 @@
       if (defaultRow) {
         optionsObj[defaultRow._id] = defaultRow
       }
+      hasFetchedDefaultValue = true
     }
     await fetch.update({
       query: { string: { [primaryDisplay]: searchTerm } },

--- a/packages/client/src/components/app/forms/RelationshipField.svelte
+++ b/packages/client/src/components/app/forms/RelationshipField.svelte
@@ -118,7 +118,7 @@
     }
     if (defaultVal) {
       await fetch.update({
-        query: { equal: { _id: defaultValue } },
+        query: { equal: { _id: defaultVal } },
       })
       const defaultRow = $fetch.rows?.[0]
       if (defaultRow) {

--- a/packages/client/src/components/app/forms/RelationshipField.svelte
+++ b/packages/client/src/components/app/forms/RelationshipField.svelte
@@ -25,7 +25,6 @@
   let tableDefinition
   let searchTerm
   let open
-  let fetchedDefault
 
   $: type =
     datasourceType === "table" ? FieldTypes.LINK : FieldTypes.BB_REFERENCE
@@ -76,8 +75,8 @@
     }
   }
 
-  $: enrichedOptions = enrichOptions(optionsObj, $fetch.rows, fetchedDefault)
-  const enrichOptions = (optionsObj, fetchResults, fetchedDefault) => {
+  $: enrichedOptions = enrichOptions(optionsObj, $fetch.rows)
+  const enrichOptions = (optionsObj, fetchResults) => {
     const result = (fetchResults || [])?.reduce((accumulator, row) => {
       if (!accumulator[row._id]) {
         accumulator[row._id] = row
@@ -85,11 +84,7 @@
       return accumulator
     }, optionsObj)
 
-    const final = Object.values(result)
-    if (fetchedDefault && !final.find(row => row._id === fetchedDefault._id)) {
-      final.push(fetchedDefault)
-    }
-    return final
+    return Object.values(result)
   }
   $: {
     // We don't want to reorder while the dropdown is open, to avoid UX jumps
@@ -125,7 +120,10 @@
       await fetch.update({
         query: { equal: { _id: defaultValue } },
       })
-      fetchedDefault = $fetch.rows?.[0]
+      const defaultRow = $fetch.rows?.[0]
+      if (defaultRow) {
+        optionsObj[defaultRow._id] = defaultRow
+      }
     }
     await fetch.update({
       query: { string: { [primaryDisplay]: searchTerm } },

--- a/packages/client/src/components/app/forms/RelationshipField.svelte
+++ b/packages/client/src/components/app/forms/RelationshipField.svelte
@@ -4,7 +4,6 @@
   import { getContext } from "svelte"
   import Field from "./Field.svelte"
   import { FieldTypes } from "../../../constants"
-  import { onMount } from "svelte"
 
   const { API } = getContext("sdk")
 

--- a/packages/frontend-core/src/api/user.js
+++ b/packages/frontend-core/src/api/user.js
@@ -10,25 +10,30 @@ export const buildUserEndpoints = API => ({
 
   /**
    * Gets a list of users in the current tenant.
-   * @param {string} page The page to retrieve
-   * @param {string} search The starts with string to search username/email by.
+   * @param {string} bookmark The page to retrieve
+   * @param {object} query search filters for lookup by user (all operators not supported).
    * @param {string} appId Facilitate app/role based user searching
-   * @param {boolean} paginated Allow the disabling of pagination
+   * @param {boolean} paginate Allow the disabling of pagination
+   * @param {number} limit How many users to retrieve in a single search
    */
-  searchUsers: async ({ paginated, page, email, appId } = {}) => {
+  searchUsers: async ({ paginate, bookmark, query, appId, limit } = {}) => {
     const opts = {}
-    if (page) {
-      opts.page = page
+    if (bookmark) {
+      opts.bookmark = bookmark
     }
-    if (email) {
-      opts.email = email
+    if (query) {
+      opts.query = query
     }
     if (appId) {
       opts.appId = appId
     }
-    if (typeof paginated === "boolean") {
-      opts.paginated = paginated
+    if (typeof paginate === "boolean") {
+      opts.paginate = paginate
     }
+    if (limit) {
+      opts.limit = limit
+    }
+    console.log(opts)
     return await API.post({
       url: `/api/global/users/search`,
       body: opts,

--- a/packages/frontend-core/src/api/user.js
+++ b/packages/frontend-core/src/api/user.js
@@ -33,7 +33,6 @@ export const buildUserEndpoints = API => ({
     if (limit) {
       opts.limit = limit
     }
-    console.log(opts)
     return await API.post({
       url: `/api/global/users/search`,
       body: opts,

--- a/packages/frontend-core/src/components/grid/cells/BBReferenceCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/BBReferenceCell.svelte
@@ -27,7 +27,7 @@
     const email = Object.values(searchParams.query.string)[0]
 
     const results = await API.searchUsers({
-      email,
+      query: { string: { email } },
     })
 
     // Mapping to the expected data within RelationshipCell

--- a/packages/frontend-core/src/fetch/UserFetch.js
+++ b/packages/frontend-core/src/fetch/UserFetch.js
@@ -32,9 +32,9 @@ export default class UserFetch extends DataFetch {
     const { cursor, query } = get(this.store)
     let finalQuery
     // convert old format to new one - we now allow use of the lucene format
-    const { appId, paginated, ...rest} = query
-    if (!LuceneUtils.isLuceneFilter(query) && rest.email) {
-      finalQuery = { string: { email: rest.email }}
+    const { appId, paginated, ...rest } = query
+    if (!LuceneUtils.hasFilters(query) && rest.email) {
+      finalQuery = { string: { email: rest.email } }
     } else {
       finalQuery = rest
     }

--- a/packages/frontend-core/src/fetch/UserFetch.js
+++ b/packages/frontend-core/src/fetch/UserFetch.js
@@ -1,6 +1,7 @@
 import { get } from "svelte/store"
 import DataFetch from "./DataFetch.js"
 import { TableNames } from "../constants"
+import { LuceneUtils } from "../utils"
 
 export default class UserFetch extends DataFetch {
   constructor(opts) {
@@ -27,16 +28,25 @@ export default class UserFetch extends DataFetch {
   }
 
   async getData() {
+    const { limit, paginate } = this.options
     const { cursor, query } = get(this.store)
+    let finalQuery
+    // convert old format to new one - we now allow use of the lucene format
+    const { appId, paginated, ...rest} = query
+    if (!LuceneUtils.isLuceneFilter(query) && rest.email) {
+      finalQuery = { string: { email: rest.email }}
+    } else {
+      finalQuery = rest
+    }
     try {
-      // "query" normally contains a lucene query, but users uses a non-standard
-      // search endpoint so we use query uniquely here
-      const res = await this.API.searchUsers({
-        page: cursor,
-        email: query.email,
-        appId: query.appId,
-        paginated: query.paginated,
-      })
+      const opts = {
+        bookmark: cursor,
+        query: finalQuery,
+        appId: appId,
+        paginate: paginated || paginate,
+        limit,
+      }
+      const res = await this.API.searchUsers(opts)
       return {
         rows: res?.data || [],
         hasNextPage: res?.hasNextPage || false,

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -15,7 +15,7 @@ import {
   QuotaUsageType,
   RelationshipType,
   Row,
-  SaveTableRequest,
+  SaveTableRequest, SearchQueryOperators,
   SortOrder,
   SortType,
   StaticQuotaName,
@@ -1141,7 +1141,7 @@ describe.each([
         )
 
         const createViewResponse = await config.createView({
-          query: [{ operator: "equal", field: "age", value: 40 }],
+          query: [{ operator: SearchQueryOperators.EQUAL, field: "age", value: 40 }],
           schema: viewSchema,
         })
 

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -15,7 +15,8 @@ import {
   QuotaUsageType,
   RelationshipType,
   Row,
-  SaveTableRequest, SearchQueryOperators,
+  SaveTableRequest,
+  SearchQueryOperators,
   SortOrder,
   SortType,
   StaticQuotaName,
@@ -1141,7 +1142,9 @@ describe.each([
         )
 
         const createViewResponse = await config.createView({
-          query: [{ operator: SearchQueryOperators.EQUAL, field: "age", value: 40 }],
+          query: [
+            { operator: SearchQueryOperators.EQUAL, field: "age", value: 40 },
+          ],
           schema: viewSchema,
         })
 

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -3,6 +3,7 @@ import {
   CreateViewRequest,
   FieldSchema,
   FieldType,
+  SearchQueryOperators,
   SortOrder,
   SortType,
   Table,
@@ -10,8 +11,8 @@ import {
   UpdateViewRequest,
   ViewV2,
 } from "@budibase/types"
-import { generator } from "@budibase/backend-core/tests"
-import { generateDatasourceID } from "../../../db/utils"
+import {generator} from "@budibase/backend-core/tests"
+import {generateDatasourceID} from "../../../db/utils"
 
 function priceTable(): Table {
   return {
@@ -89,7 +90,7 @@ describe.each([
         name: generator.name(),
         tableId: table._id!,
         primaryDisplay: generator.word(),
-        query: [{ operator: "equal", field: "field", value: "value" }],
+        query: [{ operator: SearchQueryOperators.EQUAL, field: "field", value: "value" }],
         sort: {
           field: "fieldToSort",
           order: SortOrder.DESCENDING,
@@ -184,7 +185,7 @@ describe.each([
       const tableId = table._id!
       await config.api.viewV2.update({
         ...view,
-        query: [{ operator: "equal", field: "newField", value: "thatValue" }],
+        query: [{ operator: SearchQueryOperators.EQUAL, field: "newField", value: "thatValue" }],
       })
 
       expect((await config.api.table.get(tableId)).views).toEqual({
@@ -207,7 +208,7 @@ describe.each([
         primaryDisplay: generator.word(),
         query: [
           {
-            operator: "equal",
+            operator: SearchQueryOperators.EQUAL,
             field: generator.word(),
             value: generator.word(),
           },
@@ -279,7 +280,7 @@ describe.each([
         {
           ...view,
           tableId: generator.guid(),
-          query: [{ operator: "equal", field: "newField", value: "thatValue" }],
+          query: [{ operator: SearchQueryOperators.EQUAL, field: "newField", value: "thatValue" }],
         },
         { expectStatus: 404 }
       )

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -11,8 +11,8 @@ import {
   UpdateViewRequest,
   ViewV2,
 } from "@budibase/types"
-import {generator} from "@budibase/backend-core/tests"
-import {generateDatasourceID} from "../../../db/utils"
+import { generator } from "@budibase/backend-core/tests"
+import { generateDatasourceID } from "../../../db/utils"
 
 function priceTable(): Table {
   return {
@@ -90,7 +90,13 @@ describe.each([
         name: generator.name(),
         tableId: table._id!,
         primaryDisplay: generator.word(),
-        query: [{ operator: SearchQueryOperators.EQUAL, field: "field", value: "value" }],
+        query: [
+          {
+            operator: SearchQueryOperators.EQUAL,
+            field: "field",
+            value: "value",
+          },
+        ],
         sort: {
           field: "fieldToSort",
           order: SortOrder.DESCENDING,
@@ -185,7 +191,13 @@ describe.each([
       const tableId = table._id!
       await config.api.viewV2.update({
         ...view,
-        query: [{ operator: SearchQueryOperators.EQUAL, field: "newField", value: "thatValue" }],
+        query: [
+          {
+            operator: SearchQueryOperators.EQUAL,
+            field: "newField",
+            value: "thatValue",
+          },
+        ],
       })
 
       expect((await config.api.table.get(tableId)).views).toEqual({
@@ -280,7 +292,13 @@ describe.each([
         {
           ...view,
           tableId: generator.guid(),
-          query: [{ operator: SearchQueryOperators.EQUAL, field: "newField", value: "thatValue" }],
+          query: [
+            {
+              operator: SearchQueryOperators.EQUAL,
+              field: "newField",
+              value: "thatValue",
+            },
+          ],
         },
         { expectStatus: 404 }
       )

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -9,8 +9,8 @@ import {
   SortDirection,
   SortType,
 } from "@budibase/types"
-import {OperatorOptions, SqlNumberTypeRangeMap} from "./constants"
-import {deepGet} from "./helpers"
+import { OperatorOptions, SqlNumberTypeRangeMap } from "./constants"
+import { deepGet } from "./helpers"
 
 const HBS_REGEX = /{{([^{].*?)}}/g
 
@@ -239,18 +239,6 @@ export const buildLuceneQuery = (filter: SearchFilter[]) => {
   return query
 }
 
-// type unknown
-export const isLuceneFilter = (search: any) => {
-  if (typeof search !== "object") {
-    return false
-  }
-  const operators = Object.values(SearchQueryOperators) as string[]
-  const anySearchKey = Object.keys(search).find(key => {
-    return operators.includes(key) && typeof search[key] === "object"
-  })
-  return !!anySearchKey
-}
-
 /**
  * Performs a client-side lucene search on an array of data
  * @param docs the data
@@ -286,18 +274,26 @@ export const runLuceneQuery = (docs: any[], query?: SearchQuery) => {
     }
 
   // Process a string match (fails if the value does not start with the string)
-  const stringMatch = match(SearchQueryOperators.STRING, (docValue: string, testValue: string) => {
-    return (
-      !docValue || !docValue?.toLowerCase().startsWith(testValue?.toLowerCase())
-    )
-  })
+  const stringMatch = match(
+    SearchQueryOperators.STRING,
+    (docValue: string, testValue: string) => {
+      return (
+        !docValue ||
+        !docValue?.toLowerCase().startsWith(testValue?.toLowerCase())
+      )
+    }
+  )
 
   // Process a fuzzy match (treat the same as starts with when running locally)
-  const fuzzyMatch = match(SearchQueryOperators.FUZZY, (docValue: string, testValue: string) => {
-    return (
-      !docValue || !docValue?.toLowerCase().startsWith(testValue?.toLowerCase())
-    )
-  })
+  const fuzzyMatch = match(
+    SearchQueryOperators.FUZZY,
+    (docValue: string, testValue: string) => {
+      return (
+        !docValue ||
+        !docValue?.toLowerCase().startsWith(testValue?.toLowerCase())
+      )
+    }
+  )
 
   // Process a range match
   const rangeMatch = match(
@@ -332,29 +328,41 @@ export const runLuceneQuery = (docs: any[], query?: SearchQuery) => {
   )
 
   // Process an empty match (fails if the value is not empty)
-  const emptyMatch = match(SearchQueryOperators.EMPTY, (docValue: string | null) => {
-    return docValue != null && docValue !== ""
-  })
+  const emptyMatch = match(
+    SearchQueryOperators.EMPTY,
+    (docValue: string | null) => {
+      return docValue != null && docValue !== ""
+    }
+  )
 
   // Process a not-empty match (fails is the value is empty)
-  const notEmptyMatch = match(SearchQueryOperators.NOT_EMPTY, (docValue: string | null) => {
-    return docValue == null || docValue === ""
-  })
+  const notEmptyMatch = match(
+    SearchQueryOperators.NOT_EMPTY,
+    (docValue: string | null) => {
+      return docValue == null || docValue === ""
+    }
+  )
 
   // Process an includes match (fails if the value is not included)
-  const oneOf = match(SearchQueryOperators.ONE_OF, (docValue: any, testValue: any) => {
-    if (typeof testValue === "string") {
-      testValue = testValue.split(",")
-      if (typeof docValue === "number") {
-        testValue = testValue.map((item: string) => parseFloat(item))
+  const oneOf = match(
+    SearchQueryOperators.ONE_OF,
+    (docValue: any, testValue: any) => {
+      if (typeof testValue === "string") {
+        testValue = testValue.split(",")
+        if (typeof docValue === "number") {
+          testValue = testValue.map((item: string) => parseFloat(item))
+        }
       }
+      return !testValue?.includes(docValue)
     }
-    return !testValue?.includes(docValue)
-  })
+  )
 
-  const containsAny = match(SearchQueryOperators.CONTAINS_ANY, (docValue: any, testValue: any) => {
-    return !docValue?.includes(...testValue)
-  })
+  const containsAny = match(
+    SearchQueryOperators.CONTAINS_ANY,
+    (docValue: any, testValue: any) => {
+      return !docValue?.includes(...testValue)
+    }
+  )
 
   const contains = match(
     SearchQueryOperators.CONTAINS,
@@ -446,7 +454,7 @@ export const hasFilters = (query?: SearchQuery) => {
     if (skipped.includes(key) || typeof value !== "object") {
       continue
     }
-    if (Object.keys(value).length !== 0) {
+    if (Object.keys(value || {}).length !== 0) {
       return true
     }
   }

--- a/packages/types/src/api/web/searchFilter.ts
+++ b/packages/types/src/api/web/searchFilter.ts
@@ -10,43 +10,57 @@ export type SearchFilter = {
   externalType?: string
 }
 
+export enum SearchQueryOperators {
+  STRING = "string",
+  FUZZY = "fuzzy",
+  RANGE = "range",
+  EQUAL = "equal",
+  NOT_EQUAL = "notEqual",
+  EMPTY = "empty",
+  NOT_EMPTY = "notEmpty",
+  ONE_OF = "oneOf",
+  CONTAINS = "contains",
+  NOT_CONTAINS = "notContains",
+  CONTAINS_ANY = "containsAny",
+}
+
 export type SearchQuery = {
   allOr?: boolean
   onEmptyFilter?: EmptyFilterOption
-  string?: {
+  [SearchQueryOperators.STRING]?: {
     [key: string]: string
   }
-  fuzzy?: {
+  [SearchQueryOperators.FUZZY]?: {
     [key: string]: string
   }
-  range?: {
+  [SearchQueryOperators.RANGE]?: {
     [key: string]: {
       high: number | string
       low: number | string
     }
   }
-  equal?: {
+  [SearchQueryOperators.EQUAL]?: {
     [key: string]: any
   }
-  notEqual?: {
+  [SearchQueryOperators.NOT_EQUAL]?: {
     [key: string]: any
   }
-  empty?: {
+  [SearchQueryOperators.EMPTY]?: {
     [key: string]: any
   }
-  notEmpty?: {
+  [SearchQueryOperators.NOT_EMPTY]?: {
     [key: string]: any
   }
-  oneOf?: {
+  [SearchQueryOperators.ONE_OF]?: {
     [key: string]: any[]
   }
-  contains?: {
+  [SearchQueryOperators.CONTAINS]?: {
     [key: string]: any[]
   }
-  notContains?: {
+  [SearchQueryOperators.NOT_CONTAINS]?: {
     [key: string]: any[]
   }
-  containsAny?: {
+  [SearchQueryOperators.CONTAINS_ANY]?: {
     [key: string]: any[]
   }
 }

--- a/packages/types/src/api/web/user.ts
+++ b/packages/types/src/api/web/user.ts
@@ -1,4 +1,5 @@
 import { User } from "../../documents"
+import { SearchQuery } from "./searchFilter"
 
 export interface SaveUserResponse {
   _id: string
@@ -51,10 +52,10 @@ export interface InviteUsersResponse {
 }
 
 export interface SearchUsersRequest {
-  page?: string
-  email?: string
+  bookmark?: string
+  query?: SearchQuery
   appId?: string
-  paginated?: boolean
+  paginate?: boolean
 }
 
 export interface CreateAdminUserRequest {

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -197,7 +197,12 @@ export const getAppUsers = async (ctx: Ctx<SearchUsersRequest>) => {
 export const search = async (ctx: Ctx<SearchUsersRequest>) => {
   const body = ctx.request.body
 
-  if (body.paginated === false) {
+  // TODO: for now only one supported search key, string.email
+  if (body?.query && !userSdk.core.isSupportedUserSearch(body.query)) {
+    ctx.throw(501, "Can only search by string.email or equal._id")
+  }
+
+  if (body.paginate === false) {
     await getAppUsers(ctx)
   } else {
     const paginated = await userSdk.core.paginatedUsers(body)

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -544,6 +544,36 @@ describe("/api/global/users", () => {
     })
   })
 
+  describe("POST /api/global/users/search", () => {
+    it("should be able to search by email", async () => {
+      const user = await config.createUser()
+      const response = await config.api.users.searchUsers({
+        query: { string: { email: user.email } },
+      })
+      expect(response.body.data.length).toBe(1)
+      expect(response.body.data[0].email).toBe(user.email)
+    })
+
+    it("should be able to search by _id", async () => {
+      const user = await config.createUser()
+      const response = await config.api.users.searchUsers({
+        query: { equal: { _id: user._id } },
+      })
+      expect(response.body.data.length).toBe(1)
+      expect(response.body.data[0]._id).toBe(user._id)
+    })
+
+    it("should throw an error when unimplemented options used", async () => {
+      const user = await config.createUser()
+      await config.api.users.searchUsers(
+        {
+          query: { equal: { firstName: user.firstName } },
+        },
+        501
+      )
+    })
+  })
+
   describe("DELETE /api/global/users/:userId", () => {
     it("should be able to destroy a basic user", async () => {
       const user = await config.createUser()

--- a/packages/worker/src/tests/api/users.ts
+++ b/packages/worker/src/tests/api/users.ts
@@ -4,6 +4,7 @@ import {
   InviteUsersRequest,
   User,
   CreateAdminUserRequest,
+  SearchQuery,
 } from "@budibase/types"
 import structures from "../structures"
 import { generator } from "@budibase/backend-core/tests"
@@ -129,6 +130,15 @@ export class UserAPI extends TestAPI {
     return this.request
       .delete(`/api/global/users/${userId}`)
       .set(this.config.defaultHeaders())
+      .expect("Content-Type", /json/)
+      .expect(status ? status : 200)
+  }
+
+  searchUsers = ({ query }: { query?: SearchQuery }, status = 200) => {
+    return this.request
+      .post("/api/global/users/search")
+      .set(this.config.defaultHeaders())
+      .send({ query })
       .expect("Content-Type", /json/)
       .expect(status ? status : 200)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -21750,7 +21750,7 @@ vlq@^0.2.2:
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
   integrity sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==
 
-vm2@^3.9.19:
+vm2@^3.9.19, vm2@^3.9.8:
   version "3.9.19"
   resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.19.tgz#be1e1d7a106122c6c492b4d51c2e8b93d3ed6a4a"
   integrity sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==


### PR DESCRIPTION

## Description
The way that the relationship field expected to be able to search users was broken - it uses Lucene syntax to search which the user API did not support. I have updated the search API to allow this, but only certain supported keys, it will throw a 501 if anything that is unexpected is provided.

It can now search by the `email` and the `_id` of the user - this will be expanded once SQS is finished.

Also the relationship field component did not account for the default value not being in the paginated results, so you would get a `null` in the field if the value was not found. Solving this by on load checking for the default value and if there is one, attempting to search for it using the `equal._id` search operation. Hopefully this should solve this for both relationships and users.

## Feature branch env
[Feature Branch Link](http://fb-fix-user-search-api.fb.qa.budibase.net)