### PR TITLE
Bug warnings stale bot

### DIFF
--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -2,7 +2,7 @@ name: Close stale issues and PRs # https://github.com/actions/stale
 on:
   workflow_dispatch:
   schedule:
-    - cron: '*/30 * * * *' # Every 30 mins
+    - cron: "*/30 * * * *" # Every 30 mins
 
 jobs:
   stale:
@@ -10,20 +10,33 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
-          # stale rules
-          days-before-stale: 60
+          # stale rules for PRs
           days-before-pr-stale: 7
           stale-issue-label: stale
-          stale-issue-message: "This issue has been automatically marked as stale because it has not had any activity for 60 days."
-
-          # close rules
-          # days after being marked as stale to close
-          days-before-close: 30
-          close-issue-label: closed-stale
-          close-issue-message: This issue has been automatically closed it has not had any activity in 90 days."
-          days-before-pr-close: 7
-
-          # exemptions
           exempt-pr-labels: pinned,security,roadmap
 
+          days-before-pr-close: 7
 
+      - uses: actions/stale@v8
+        with:
+          # stale rules for high priority bugs
+          days-before-stale: 30
+          only-issue-labels: bug,High priority
+          stale-issue-label: warn
+
+      - uses: actions/stale@v8
+        with:
+          # stale rules for medium priority bugs
+          days-before-stale: 90
+          only-issue-labels: bug,Medium priority
+          stale-issue-label: warn
+
+      - uses: actions/stale@v8
+        with:
+          # stale rules for all bugs
+          days-before-stale: 180
+          stale-issue-label: stale
+          only-issue-labels: bug
+          stale-issue-message: "This issue has been automatically marked as stale because it has not had any activity for six months."
+
+          days-before-close: 30

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
+          operations-per-run: 1
           # stale rules for PRs
           days-before-pr-stale: 7
           stale-issue-label: stale
@@ -19,6 +20,7 @@ jobs:
 
       - uses: actions/stale@v8
         with:
+          operations-per-run: 3
           # stale rules for high priority bugs
           days-before-stale: 30
           only-issue-labels: bug,High priority
@@ -26,6 +28,7 @@ jobs:
 
       - uses: actions/stale@v8
         with:
+          operations-per-run: 3
           # stale rules for medium priority bugs
           days-before-stale: 90
           only-issue-labels: bug,Medium priority
@@ -33,6 +36,7 @@ jobs:
 
       - uses: actions/stale@v8
         with:
+          operations-per-run: 3
           # stale rules for all bugs
           days-before-stale: 180
           stale-issue-label: stale


### PR DESCRIPTION

## Description
- Tag high priority bugs with 'warn' after one month
- Tag medium priority bugs with 'warn' after three months
- Tag any bug with 'stale' after six months, and auto-close after 30 days.




## Feature branch env
[Feature Branch Link](http://fb-chore-stale-bot.fb.qa.budibase.net)