### PR TITLE
Stop the `postgres` container after the Postgres integration tests run.

### DIFF
--- a/packages/server/src/integration-test/postgres.spec.ts
+++ b/packages/server/src/integration-test/postgres.spec.ts
@@ -43,6 +43,10 @@ describe("postgres integrations", () => {
     )
   })
 
+  afterAll(async () => {
+    await databaseTestProviders.postgres.stopContainer()
+  })
+
   beforeEach(async () => {
     async function createAuxTable(prefix: string) {
       return await config.createTable({

--- a/packages/server/src/integrations/tests/utils/postgres.ts
+++ b/packages/server/src/integrations/tests/utils/postgres.ts
@@ -36,3 +36,10 @@ export async function getDsConfig(): Promise<Datasource> {
     },
   }
 }
+
+export async function stopContainer() {
+  if (container) {
+    await container.stop()
+    container = undefined
+  }
+}


### PR DESCRIPTION
## Description

I noticed when running `yarn jest src/integration-test/postgres.spec.ts` from within `packages/server` that `jest` will hang indefinitely after the tests have completed. This appears to be because of the `postgres` container still running, because adding in an `afterAll` block that stops the container explicitly fixes the problem.

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



