### PR TITLE
Fix sort column settings

### DIFF
--- a/packages/builder/src/components/design/settings/controls/SortableFieldSelect.svelte
+++ b/packages/builder/src/components/design/settings/controls/SortableFieldSelect.svelte
@@ -20,9 +20,7 @@
 
   const getSortableFields = schema => {
     return Object.entries(schema || {})
-      .filter(
-        entry => !UNSORTABLE_TYPES.includes(entry[1].type) && entry[1].sortable
-      )
+      .filter(entry => !UNSORTABLE_TYPES.includes(entry[1].type))
       .map(entry => entry[0])
   }
 


### PR DESCRIPTION
## Description
This PR fixes a recent regression that prevented any fields being available to use as the sort column setting for any component.



