### PR TITLE
Prevent the key user being used in rest queries

### DIFF
--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -206,7 +206,7 @@
       throw bindingError
     }
 
-    if (forbiddenBindings.test(query?.fields?.requestBody ?? "")) {
+    if (forbiddenBindings.test(query.fields.requestBody ?? "")) {
       throw bindingError
     }
 
@@ -216,7 +216,7 @@
       }
     })
 
-    Object.values(query?.fields?.headers).forEach(headerValue => {
+    Object.values(query.fields.headers).forEach(headerValue => {
       if (forbiddenBindings.test(headerValue)) {
         throw bindingError
       }

--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -196,8 +196,34 @@
     }
   }
 
+  const validateQuery = async () => {
+    const forbiddenBindings = /{{\s?user\s?}}/g
+    const bindingError = new Error("'user' is a protected binding and cannot be used");
+
+    if (forbiddenBindings.test(url)) {
+      throw bindingError;
+    }
+
+    if (forbiddenBindings.test(query?.fields?.requestBody ?? "")) {
+      throw bindingError;
+    }
+
+    Object.values(requestBindings).forEach((bindingValue) => {
+      if (forbiddenBindings.test(bindingValue)) {
+        throw bindingError;
+      }
+    })
+
+    Object.values(query?.fields?.headers).forEach((headerValue) => {
+      if (forbiddenBindings.test(headerValue)) {
+        throw bindingError;
+      }
+    })
+  }
+
   async function runQuery() {
     try {
+      await validateQuery();
       response = await queries.preview(buildQuery())
       if (response.rows.length === 0) {
         notifications.info("Request did not return any data")

--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -197,7 +197,7 @@
   }
 
   const validateQuery = async () => {
-    const forbiddenBindings = /{{\s?user\s?}}/g
+    const forbiddenBindings = /{{\s?user(\.(\w|\$)*\s?|\s?)}}/g
     const bindingError = new Error(
       "'user' is a protected binding and cannot be used"
     )

--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -198,32 +198,34 @@
 
   const validateQuery = async () => {
     const forbiddenBindings = /{{\s?user\s?}}/g
-    const bindingError = new Error("'user' is a protected binding and cannot be used");
+    const bindingError = new Error(
+      "'user' is a protected binding and cannot be used"
+    )
 
     if (forbiddenBindings.test(url)) {
-      throw bindingError;
+      throw bindingError
     }
 
     if (forbiddenBindings.test(query?.fields?.requestBody ?? "")) {
-      throw bindingError;
+      throw bindingError
     }
 
-    Object.values(requestBindings).forEach((bindingValue) => {
+    Object.values(requestBindings).forEach(bindingValue => {
       if (forbiddenBindings.test(bindingValue)) {
-        throw bindingError;
+        throw bindingError
       }
     })
 
-    Object.values(query?.fields?.headers).forEach((headerValue) => {
+    Object.values(query?.fields?.headers).forEach(headerValue => {
       if (forbiddenBindings.test(headerValue)) {
-        throw bindingError;
+        throw bindingError
       }
     })
   }
 
   async function runQuery() {
     try {
-      await validateQuery();
+      await validateQuery()
       response = await queries.preview(buildQuery())
       if (response.rows.length === 0) {
         notifications.info("Request did not return any data")


### PR DESCRIPTION

## Description
Users get unexpected behaviour/failures if they attempt to create and consume a binding called "user". This is used internally by budibase on the backend, so anything they define will be overwritten. This change will warn the user that the binding name cannot be used.

Addresses: 
- https://linear.app/budibase/issue/BUDI-7471/prevent-the-key-user-being-used-as-a-binding-in-rest-queries

## Feature branch env
[Feature Branch Link](http://fb-prevent-the-key-user-being-used-in-rest-queries.fb.qa.budibase.net)