### PR TITLE
Fix single image

### DIFF
--- a/.github/workflows/release-singleimage.yml
+++ b/.github/workflows/release-singleimage.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           root-reserve-mb: 30000
           swap-size-mb: 1024
-          remove-android: 'true'
-          remove-dotnet: 'true'
+          remove-android: "true"
+          remove-dotnet: "true"
       - name: Fail if not a tag
         run: |
           if [[ $GITHUB_REF != refs/tags/* ]]; then 
@@ -48,7 +48,7 @@ jobs:
       - name: Update versions
         run: ./scripts/updateVersions.sh
       - name: Run Yarn Build
-        run: yarn build:docker:pre
+        run: yarn build
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -12,14 +12,14 @@ RUN chmod +x /cleanup.sh
 WORKDIR /app
 ADD packages/server .
 COPY yarn.lock .
-RUN yarn install --production=true --network-timeout 100000
+RUN yarn install --production=true --network-timeout 1000000
 RUN /cleanup.sh
 
 # build worker
 WORKDIR /worker
 ADD packages/worker .
 COPY yarn.lock .
-RUN yarn install --production=true --network-timeout 100000
+RUN yarn install --production=true --network-timeout 1000000
 RUN /cleanup.sh
 
 FROM budibase/couchdb


### PR DESCRIPTION
## Description
Fixing single image build after changes for v2.
Previously we had some `predocker` scripts, that were copying some files such as yarn.lock and the client folder. This is not now required, as nx is handling it for us

## Feature branch env
[Feature Branch Link](http://fb-fix-single-image.fb.qa.budibase.net)
