### PR TITLE
Fix datasource deletion (when selected) causing builder crash

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/_layout.svelte
@@ -23,5 +23,7 @@
 </script>
 
 {#key $params.datasourceId}
-  <slot />
+  {#if $datasources.selected}
+    <slot />
+  {/if}
 {/key}

--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/index.svelte
@@ -12,16 +12,25 @@
   import PromptQueryModal from "./_components/PromptQueryModal.svelte"
   import SettingsPanel from "./_components/panels/Settings.svelte"
   import { helpers } from "@budibase/shared-core"
+  import { goto } from "@roxi/routify"
 
   let selectedPanel = null
   let panelOptions = []
 
   // datasources.selected can return null temporarily on datasource deletion
-  $: datasource = $datasources.selected || {}
+  $: datasource = $datasources.selected
+  $: {
+    if (!datasource) {
+      $goto("./datasource")
+    }
+  }
 
   $: getOptions(datasource)
 
   const getOptions = datasource => {
+    if (!datasource) {
+      return
+    }
     if (datasource.plus) {
       // Google Sheets' integration definition specifies `relationships: false` as it doesn't support relationships like other plus datasources
       panelOptions =
@@ -49,51 +58,53 @@
 
 <PromptQueryModal />
 
-<section>
-  <Layout noPadding>
-    <Layout gap="XS" noPadding>
-      <header>
-        <svelte:component
-          this={ICONS[datasource.source]}
-          height="26"
-          width="26"
-        />
-        <Heading size="M">{$datasources.selected?.name}</Heading>
-      </header>
-    </Layout>
-    <EditDatasourceConfig {datasource} />
-    <div class="tabs">
-      <Tabs size="L" noPadding noHorizPadding selected={selectedPanel}>
-        {#each panelOptions as panelOption}
-          <Tab
-            title={panelOption}
-            on:click={() => (selectedPanel = panelOption)}
+{#if datasource}
+  <section>
+    <Layout noPadding>
+      <Layout gap="XS" noPadding>
+        <header>
+          <svelte:component
+            this={ICONS[datasource.source]}
+            height="26"
+            width="26"
           />
-        {/each}
-      </Tabs>
-    </div>
+          <Heading size="M">{$datasources.selected?.name}</Heading>
+        </header>
+      </Layout>
+      <EditDatasourceConfig {datasource} />
+      <div class="tabs">
+        <Tabs size="L" noPadding noHorizPadding selected={selectedPanel}>
+          {#each panelOptions as panelOption}
+            <Tab
+              title={panelOption}
+              on:click={() => (selectedPanel = panelOption)}
+            />
+          {/each}
+        </Tabs>
+      </div>
 
-    {#if selectedPanel === null}
-      <Body>loading...</Body>
-    {:else if selectedPanel === "Tables"}
-      <TablesPanel {datasource} />
-    {:else if selectedPanel === "Relationships"}
-      <RelationshipsPanel {datasource} />
-    {:else if selectedPanel === "Queries"}
-      <QueriesPanel {datasource} />
-    {:else if selectedPanel === "Headers"}
-      <RestHeadersPanel {datasource} />
-    {:else if selectedPanel === "Authentication"}
-      <RestAuthenticationPanel {datasource} />
-    {:else if selectedPanel === "Variables"}
-      <RestVariablesPanel {datasource} />
-    {:else if selectedPanel === "Settings"}
-      <SettingsPanel {datasource} />
-    {:else}
-      <Body>Something went wrong</Body>
-    {/if}
-  </Layout>
-</section>
+      {#if selectedPanel === null}
+        <Body>loading...</Body>
+      {:else if selectedPanel === "Tables"}
+        <TablesPanel {datasource} />
+      {:else if selectedPanel === "Relationships"}
+        <RelationshipsPanel {datasource} />
+      {:else if selectedPanel === "Queries"}
+        <QueriesPanel {datasource} />
+      {:else if selectedPanel === "Headers"}
+        <RestHeadersPanel {datasource} />
+      {:else if selectedPanel === "Authentication"}
+        <RestAuthenticationPanel {datasource} />
+      {:else if selectedPanel === "Variables"}
+        <RestVariablesPanel {datasource} />
+      {:else if selectedPanel === "Settings"}
+        <SettingsPanel {datasource} />
+      {:else}
+        <Body>Something went wrong</Body>
+      {/if}
+    </Layout>
+  </section>
+{/if}
 
 <style>
   section {

--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/index.svelte
@@ -12,18 +12,11 @@
   import PromptQueryModal from "./_components/PromptQueryModal.svelte"
   import SettingsPanel from "./_components/panels/Settings.svelte"
   import { helpers } from "@budibase/shared-core"
-  import { goto } from "@roxi/routify"
 
   let selectedPanel = null
   let panelOptions = []
 
-  // datasources.selected can return null temporarily on datasource deletion
   $: datasource = $datasources.selected
-  $: {
-    if (!datasource) {
-      $goto("./datasource")
-    }
-  }
 
   $: getOptions(datasource)
 
@@ -58,53 +51,51 @@
 
 <PromptQueryModal />
 
-{#if datasource}
-  <section>
-    <Layout noPadding>
-      <Layout gap="XS" noPadding>
-        <header>
-          <svelte:component
-            this={ICONS[datasource.source]}
-            height="26"
-            width="26"
-          />
-          <Heading size="M">{$datasources.selected?.name}</Heading>
-        </header>
-      </Layout>
-      <EditDatasourceConfig {datasource} />
-      <div class="tabs">
-        <Tabs size="L" noPadding noHorizPadding selected={selectedPanel}>
-          {#each panelOptions as panelOption}
-            <Tab
-              title={panelOption}
-              on:click={() => (selectedPanel = panelOption)}
-            />
-          {/each}
-        </Tabs>
-      </div>
-
-      {#if selectedPanel === null}
-        <Body>loading...</Body>
-      {:else if selectedPanel === "Tables"}
-        <TablesPanel {datasource} />
-      {:else if selectedPanel === "Relationships"}
-        <RelationshipsPanel {datasource} />
-      {:else if selectedPanel === "Queries"}
-        <QueriesPanel {datasource} />
-      {:else if selectedPanel === "Headers"}
-        <RestHeadersPanel {datasource} />
-      {:else if selectedPanel === "Authentication"}
-        <RestAuthenticationPanel {datasource} />
-      {:else if selectedPanel === "Variables"}
-        <RestVariablesPanel {datasource} />
-      {:else if selectedPanel === "Settings"}
-        <SettingsPanel {datasource} />
-      {:else}
-        <Body>Something went wrong</Body>
-      {/if}
+<section>
+  <Layout noPadding>
+    <Layout gap="XS" noPadding>
+      <header>
+        <svelte:component
+          this={ICONS[datasource.source]}
+          height="26"
+          width="26"
+        />
+        <Heading size="M">{$datasources.selected?.name}</Heading>
+      </header>
     </Layout>
-  </section>
-{/if}
+    <EditDatasourceConfig {datasource} />
+    <div class="tabs">
+      <Tabs size="L" noPadding noHorizPadding selected={selectedPanel}>
+        {#each panelOptions as panelOption}
+          <Tab
+            title={panelOption}
+            on:click={() => (selectedPanel = panelOption)}
+          />
+        {/each}
+      </Tabs>
+    </div>
+
+    {#if selectedPanel === null}
+      <Body>loading...</Body>
+    {:else if selectedPanel === "Tables"}
+      <TablesPanel {datasource} />
+    {:else if selectedPanel === "Relationships"}
+      <RelationshipsPanel {datasource} />
+    {:else if selectedPanel === "Queries"}
+      <QueriesPanel {datasource} />
+    {:else if selectedPanel === "Headers"}
+      <RestHeadersPanel {datasource} />
+    {:else if selectedPanel === "Authentication"}
+      <RestAuthenticationPanel {datasource} />
+    {:else if selectedPanel === "Variables"}
+      <RestVariablesPanel {datasource} />
+    {:else if selectedPanel === "Settings"}
+      <SettingsPanel {datasource} />
+    {:else}
+      <Body>Something went wrong</Body>
+    {/if}
+  </Layout>
+</section>
 
 <style>
   section {

--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/index.svelte
@@ -21,9 +21,6 @@
   $: getOptions(datasource)
 
   const getOptions = datasource => {
-    if (!datasource) {
-      return
-    }
     if (datasource.plus) {
       // Google Sheets' integration definition specifies `relationships: false` as it doesn't support relationships like other plus datasources
       panelOptions =


### PR DESCRIPTION

## Description
Quick fix for datasource deletion, due to the datasource defaulting to an empty object it appeared like a datasource had been set and the UI would attempt to render with this empty state. When not selected move off of the selected datasource page instead and handle the datasource not being selected.

Addresses: https://linear.app/budibase/issue/BUDI-7630/error-in-console-when-deleting-a-datasource-navigation-then-breaks

## Feature branch env
[Feature Branch Link](http://fb-fix-budi-7630-fix-datasource-deletion.fb.qa.budibase.net)