### PR TITLE
CouchDB extend logout timeout

### DIFF
--- a/hosting/couchdb/couch/local.ini
+++ b/hosting/couchdb/couch/local.ini
@@ -3,3 +3,6 @@
 [couchdb]
 database_dir = DATA_DIR/couch/dbs
 view_index_dir = DATA_DIR/couch/views
+
+[chttpd_auth]
+timeout = 7200 ; 2 hours in seconds


### PR DESCRIPTION

## Description
Extending Fauxton timeout from 600s -> 7200s. Allow for 2 hours before logout occurs.

## Feature branch env
[Feature Branch Link](http://fb-fix-couchdb-fauxton-timeout.fb.qa.budibase.net)