### PR TITLE
Disable CLA bot on non-master PR merges

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,6 +4,8 @@ on:
     types: [created]
   pull_request_target:
     types: [opened,closed,synchronize]
+    branches:
+      - master
 
 jobs:
   CLAssistant:


### PR DESCRIPTION
## Description
Only check CLA on PRs to master - there are some branch to branch PRs which are triggering the CLA bot for some reason, causing failures - removing the possibility of this.