### PR TITLE
add cloudfront to script csp to fix cloud plugins

### DIFF
--- a/hosting/proxy/nginx.prod.conf
+++ b/hosting/proxy/nginx.prod.conf
@@ -51,7 +51,7 @@ http {
     proxy_buffering off;
 
     set $csp_default "default-src 'self'";
-    set $csp_script "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.budibase.net https://cdn.budi.live https://js.intercomcdn.com https://widget.intercom.io";
+    set $csp_script "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.budibase.net https://cdn.budi.live https://js.intercomcdn.com https://widget.intercom.io https://d2l5prqdbvm3op.cloudfront.net";
     set $csp_style "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com https://rsms.me https://maxcdn.bootstrapcdn.com";
     set $csp_object "object-src 'none'";
     set $csp_base_uri "base-uri 'self'";


### PR DESCRIPTION
## Description
Add the new cloudfront CDN domain to the script-src CSP


Addresses: 
Plugin downloads being blocked in cloud following CDN domain change


## Screenshots
<img width="606" alt="image" src="https://github.com/Budibase/budibase/assets/110921612/6ea21660-381a-41bd-9833-4e9108d14870">

## Documentation
- [x] I have reviewed the Budibase documentation to verify if this feature requires any changes. If changes or new docs are required I have written them.



