### PR TITLE
Fix how attachment URLs are handled

### DIFF
--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -241,7 +241,7 @@ export async function outputProcessing<T extends Row[] | Row>(
           continue
         }
         row[property].forEach((attachment: RowAttachment) => {
-          attachment.url = objectStore.getAppFileUrl(attachment.key)
+          attachment.url ??= objectStore.getAppFileUrl(attachment.key)
         })
       }
     } else if (


### PR DESCRIPTION
## Description
Datasources used to be (as of around three weeks ago) able to provide attachments with remote URLs. This behaviour is necessary for custom Datasource+ plugins (which work since #11868) to handle attachments.

The fix is exceedingly simple: only use the storage bucket's URL if the attachment data doesn't already contain one.

## Documentation
- [x] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.



