### PR TITLE
Enable truncating of internal database table

### DIFF
--- a/packages/builder/src/components/backend/DataTable/TableDataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/TableDataTable.svelte
@@ -16,6 +16,7 @@
   import GridRelationshipButton from "components/backend/DataTable/buttons/grid/GridRelationshipButton.svelte"
   import GridEditColumnModal from "components/backend/DataTable/modals/grid/GridEditColumnModal.svelte"
   import GridUsersTableButton from "components/backend/DataTable/modals/grid/GridUsersTableButton.svelte"
+  import GridTruncateButton from "components/backend/DataTable/buttons/grid/GridTruncateButton.svelte"
 
   const userSchemaOverrides = {
     firstName: { displayName: "First name", disabled: true },
@@ -91,6 +92,9 @@
         <GridEditUserModal />
       {:else}
         <GridCreateEditRowModal />
+      {/if}
+      {#if isInternal}
+        <GridTruncateButton />
       {/if}
     </svelte:fragment>
     <svelte:fragment slot="edit-column">

--- a/packages/builder/src/components/backend/DataTable/buttons/TruncateButton.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/TruncateButton.svelte
@@ -1,0 +1,21 @@
+<script>
+  import { ActionButton } from "@budibase/bbui"
+  import ConfirmDialog from "components/common/ConfirmDialog.svelte";
+  import { createEventDispatcher } from "svelte";
+
+  export let disabled
+
+  let modal
+  let dispatch = createEventDispatcher();
+</script>
+
+<ActionButton icon="DataRemove" quiet on:click={modal.show} {disabled}>
+  Truncate
+</ActionButton>
+<ConfirmDialog
+  bind:this={modal}
+  body={`Are you sure you wish to truncate the table? Your data will be deleted and this action cannot be undone.`}
+  okText="Truncate table"
+  title="Confirm Truncate"
+  onOk={() => dispatch("truncate")}
+/>

--- a/packages/builder/src/components/backend/DataTable/buttons/grid/GridTruncateButton.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/GridTruncateButton.svelte
@@ -1,0 +1,13 @@
+<script>
+  import TruncateButton from "../TruncateButton.svelte"
+  import { getContext } from "svelte"
+
+  export let disabled = false
+
+  const { rows } = getContext("grid")
+</script>
+
+<TruncateButton
+  {disabled}
+  on:truncate={rows.actions.deleteAllRows}
+/>

--- a/packages/frontend-core/src/components/grid/stores/rows.js
+++ b/packages/frontend-core/src/components/grid/stores/rows.js
@@ -403,6 +403,12 @@ export const createActions = context => {
     handleRemoveRows(rowsToDelete)
   }
 
+  // Deletes all rows
+  const deleteAllRows = async () => {
+    const allRows = get(rows)
+    await deleteRows(allRows)
+  }
+
   // Local handler to process new rows inside the fetch, and append any new
   // rows to state that we haven't encountered before
   const handleNewRows = (newRows, resetRows) => {
@@ -469,6 +475,7 @@ export const createActions = context => {
         updateValue,
         updateRow,
         deleteRows,
+        deleteAllRows,
         hasRow,
         loadNextPage,
         refreshRow,


### PR DESCRIPTION
## Description
Adds a button to truncate internal databases

Addresses: 
- #12125

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
**Confirmation modal**
![image](https://github.com/Budibase/budibase/assets/1907152/6da685ea-cc89-42ab-86c1-c50e8e7e2e36)

**Toolbar button**
![image](https://github.com/Budibase/budibase/assets/1907152/c93eef00-c195-42cc-9761-59cd808bc8e7)


## Documentation
- [X] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them. (I couldn't find docs about the data toolbar buttons)



