### PR TITLE
Remove docs section from PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,18 +1,16 @@
 ## Description
+
 _Describe the problem or feature in addition to a link to the relevant github issues._
 
-Addresses: 
+Addresses:
+
 - `<Enter the Link to the issue(s) this PR addresses>`
 - ...more if required
 
 ## App Export
+
 - If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.
 
 ## Screenshots
+
 _If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._
-
-## Documentation
-- [ ] I have reviewed the budibase documentatation to verify if this feature requires any changes. If changes or new docs are required I have written them.
-
-
-


### PR DESCRIPTION
## Description
The documentation section of a PR is no longer needed, as docs will be added after merge and tracked in Linear.




