### PR TITLE
Change minio livenessProbe to use native httpGet instead of curl.

### DIFF
--- a/charts/budibase/templates/minio-service-deployment.yaml
+++ b/charts/budibase/templates/minio-service-deployment.yaml
@@ -46,11 +46,9 @@ spec:
         image: minio/minio
         imagePullPolicy: ""
         livenessProbe:
-          exec:
-            command:
-            - curl
-            - -f
-            - http://localhost:9000/minio/health/live
+          httpGet:
+            path: /minio/health/live
+            port: 9000
           failureThreshold: 3
           periodSeconds: 30
           timeoutSeconds: 20


### PR DESCRIPTION
## Description

Fix failing Minio pod livenessProbe due to missing `curl` binary in the minio image.

Addresses:

- https://github.com/Budibase/budibase/issues/12277
