### PR TITLE
Switching back to old MinIO install method

### DIFF
--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -77,7 +77,7 @@ mkdir -p ${DATA_DIR}/minio
 chown -R couchdb:couchdb ${DATA_DIR}/couch
 redis-server --requirepass $REDIS_PASSWORD > /dev/stdout 2>&1 &
 /bbcouch-runner.sh &
-minio server --console-address ":9001" ${DATA_DIR}/minio > /dev/stdout 2>&1 &
+/minio/minio server --console-address ":9001" ${DATA_DIR}/minio > /dev/stdout 2>&1 &
 /etc/init.d/nginx restart
 if [[ ! -z "${CUSTOM_DOMAIN}" ]]; then
     # Add monthly cron job to renew certbot certificate

--- a/scripts/install-minio.sh
+++ b/scripts/install-minio.sh
@@ -2,9 +2,9 @@
 if [[ $TARGETARCH == arm* ]] ;
 then
   echo "INSTALLING ARM64 MINIO"
-  wget wget https://dl.min.io/server/minio/release/linux-arm64/archive/minio.deb -O minio.deb
+  wget https://dl.min.io/server/minio/release/linux-arm64/minio
 else
   echo "INSTALLING AMD64 MINIO"
-  wget wget https://dl.min.io/server/minio/release/linux-amd64/archive/minio.deb -O minio.deb
+  wget https://dl.min.io/server/minio/release/linux-amd64/minio
 fi
-dpkg -i minio.deb
+chmod +x minio


### PR DESCRIPTION
## Description
As title, in the single image there appears to be issues with the new MinIO installation method, switching back to old mechanism - appears to only affect apps made in older versions of the single image.

Addresses: https://github.com/Budibase/budibase/issues/12281