### PR TITLE
Fix fetching tag on release

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -45,8 +45,8 @@ jobs:
           BUMP_TYPE=${BUMP_TYPE_INPUT:-"patch"}
           ./versionCommit.sh $BUMP_TYPE
 
-
-          new_version=$(./getCurrentVersion.sh)
+          cd ..
+          new_version=$(./scripts/getCurrentVersion.sh)
           echo "version=$new_version" >> $GITHUB_OUTPUT
 
   trigger-release:


### PR DESCRIPTION

## Description
Fixing the release process, passing the right tag to the release pipeline

The [current pipeline](https://github.com/Budibase/budibase/actions/runs/6784374394/job/18440545354) is failing silently, but failing on the [release pipeline](https://github.com/Budibase/budibase-deploys/actions/runs/6784380580)
![image](https://github.com/Budibase/budibase/assets/15987277/084e5d85-8a40-48fd-a5e3-eaf050454cb8)

## Feature branch env
[Feature Branch Link](http://fb-fix-release-trigger.fb.qa.budibase.net)