### PR TITLE
Ensure that the DB always returns Documents, and other type changes.

### DIFF
--- a/packages/backend-core/src/constants/db.ts
+++ b/packages/backend-core/src/constants/db.ts
@@ -28,7 +28,7 @@ export enum ViewName {
   APP_BACKUP_BY_TRIGGER = "by_trigger",
 }
 
-export const DeprecatedViews = {
+export const DeprecatedViews: Record<string, string[]> = {
   [ViewName.USER_BY_EMAIL]: [
     // removed due to inaccuracy in view doc filter logic
     "by_email",

--- a/packages/backend-core/src/db/couch/DatabaseImpl.ts
+++ b/packages/backend-core/src/db/couch/DatabaseImpl.ts
@@ -175,12 +175,14 @@ export class DatabaseImpl implements Database {
     return this.updateOutput(() => db.bulk({ docs: documents }))
   }
 
-  async allDocs<T>(params: DatabaseQueryOpts): Promise<AllDocsResponse<T>> {
+  async allDocs<T extends Document>(
+    params: DatabaseQueryOpts
+  ): Promise<AllDocsResponse<T>> {
     const db = await this.checkSetup()
     return this.updateOutput(() => db.list(params))
   }
 
-  async query<T>(
+  async query<T extends Document>(
     viewName: string,
     params: DatabaseQueryOpts
   ): Promise<AllDocsResponse<T>> {

--- a/packages/backend-core/src/db/views.ts
+++ b/packages/backend-core/src/db/views.ts
@@ -7,7 +7,12 @@ import {
 } from "../constants"
 import { getGlobalDB } from "../context"
 import { doWithDB } from "./"
-import { AllDocsResponse, Database, DatabaseQueryOpts } from "@budibase/types"
+import {
+  AllDocsResponse,
+  Database,
+  DatabaseQueryOpts,
+  Document,
+} from "@budibase/types"
 import env from "../environment"
 
 const DESIGN_DB = "_design/database"
@@ -109,7 +114,7 @@ export interface QueryViewOptions {
   arrayResponse?: boolean
 }
 
-export async function queryViewRaw<T>(
+export async function queryViewRaw<T extends Document>(
   viewName: ViewName,
   params: DatabaseQueryOpts,
   db: Database,
@@ -137,18 +142,16 @@ export async function queryViewRaw<T>(
   }
 }
 
-export const queryView = async <T>(
+export const queryView = async <T extends Document>(
   viewName: ViewName,
   params: DatabaseQueryOpts,
   db: Database,
   createFunc: any,
   opts?: QueryViewOptions
-): Promise<T[] | T | undefined> => {
+): Promise<T[] | T> => {
   const response = await queryViewRaw<T>(viewName, params, db, createFunc, opts)
   const rows = response.rows
-  const docs = rows.map((row: any) =>
-    params.include_docs ? row.doc : row.value
-  )
+  const docs = rows.map(row => (params.include_docs ? row.doc! : row.value))
 
   // if arrayResponse has been requested, always return array regardless of length
   if (opts?.arrayResponse) {
@@ -198,11 +201,11 @@ export const createPlatformUserView = async () => {
   await createPlatformView(viewJs, ViewName.PLATFORM_USERS_LOWERCASE)
 }
 
-export const queryPlatformView = async <T>(
+export const queryPlatformView = async <T extends Document>(
   viewName: ViewName,
   params: DatabaseQueryOpts,
   opts?: QueryViewOptions
-): Promise<T[] | T | undefined> => {
+): Promise<T[] | T> => {
   const CreateFuncByName: any = {
     [ViewName.ACCOUNT_BY_EMAIL]: createPlatformAccountEmailView,
     [ViewName.PLATFORM_USERS_LOWERCASE]: createPlatformUserView,
@@ -220,7 +223,7 @@ const CreateFuncByName: any = {
   [ViewName.USER_BY_APP]: createUserAppView,
 }
 
-export const queryGlobalView = async <T>(
+export const queryGlobalView = async <T extends Document>(
   viewName: ViewName,
   params: DatabaseQueryOpts,
   db?: Database,
@@ -231,10 +234,10 @@ export const queryGlobalView = async <T>(
     db = getGlobalDB()
   }
   const createFn = CreateFuncByName[viewName]
-  return queryView(viewName, params, db!, createFn, opts)
+  return queryView<T>(viewName, params, db!, createFn, opts)
 }
 
-export async function queryGlobalViewRaw<T>(
+export async function queryGlobalViewRaw<T extends Document>(
   viewName: ViewName,
   params: DatabaseQueryOpts,
   opts?: QueryViewOptions

--- a/packages/backend-core/src/users/db.ts
+++ b/packages/backend-core/src/users/db.ts
@@ -413,15 +413,13 @@ export class UserDB {
     }
 
     // Get users and delete
-    const allDocsResponse: AllDocsResponse<User> = await db.allDocs({
+    const allDocsResponse = await db.allDocs<User>({
       include_docs: true,
       keys: userIds,
     })
-    const usersToDelete: User[] = allDocsResponse.rows.map(
-      (user: RowResponse<User>) => {
-        return user.doc
-      }
-    )
+    const usersToDelete = allDocsResponse.rows.map(user => {
+      return user.doc!
+    })
 
     // Delete from DB
     const toDelete = usersToDelete.map(user => ({

--- a/packages/backend-core/src/users/users.ts
+++ b/packages/backend-core/src/users/users.ts
@@ -151,7 +151,7 @@ export const searchGlobalUsersByApp = async (
     include_docs: true,
   })
   params.startkey = opts && opts.startkey ? opts.startkey : params.startkey
-  let response = await queryGlobalView(ViewName.USER_BY_APP, params)
+  let response = await queryGlobalView<User>(ViewName.USER_BY_APP, params)
 
   if (!response) {
     response = []

--- a/packages/server/src/api/controllers/layout.ts
+++ b/packages/server/src/api/controllers/layout.ts
@@ -30,12 +30,12 @@ export async function destroy(ctx: BBContext) {
     layoutRev = ctx.params.layoutRev
 
   const layoutsUsedByScreens = (
-    await db.allDocs(
+    await db.allDocs<any>(
       getScreenParams(null, {
         include_docs: true,
       })
     )
-  ).rows.map(element => element.doc.layoutId)
+  ).rows.map(element => element.doc!.layoutId)
   if (layoutsUsedByScreens.includes(layoutId)) {
     ctx.throw(400, "Cannot delete a layout that's being used by a screen")
   }

--- a/packages/server/src/api/controllers/layout.ts
+++ b/packages/server/src/api/controllers/layout.ts
@@ -1,7 +1,7 @@
 import { EMPTY_LAYOUT } from "../../constants/layouts"
 import { generateLayoutID, getScreenParams } from "../../db/utils"
 import { events, context } from "@budibase/backend-core"
-import { BBContext } from "@budibase/types"
+import { BBContext, Layout } from "@budibase/types"
 
 export async function save(ctx: BBContext) {
   const db = context.getAppDB()
@@ -30,7 +30,7 @@ export async function destroy(ctx: BBContext) {
     layoutRev = ctx.params.layoutRev
 
   const layoutsUsedByScreens = (
-    await db.allDocs<any>(
+    await db.allDocs<Layout>(
       getScreenParams(null, {
         include_docs: true,
       })

--- a/packages/server/src/api/controllers/permission.ts
+++ b/packages/server/src/api/controllers/permission.ts
@@ -25,12 +25,12 @@ const SUPPORTED_LEVELS = CURRENTLY_SUPPORTED_LEVELS
 
 // utility function to stop this repetition - permissions always stored under roles
 async function getAllDBRoles(db: Database) {
-  const body = await db.allDocs(
+  const body = await db.allDocs<Role>(
     getRoleParams(null, {
       include_docs: true,
     })
   )
-  return body.rows.map(row => row.doc)
+  return body.rows.map(row => row.doc!)
 }
 
 async function updatePermissionOnRole(
@@ -79,7 +79,7 @@ async function updatePermissionOnRole(
     ) {
       rolePermissions[resourceId] =
         typeof rolePermissions[resourceId] === "string"
-          ? [rolePermissions[resourceId]]
+          ? [rolePermissions[resourceId] as unknown as string]
           : []
     }
     // handle the removal/updating the role which has this permission first

--- a/packages/server/src/api/controllers/role.ts
+++ b/packages/server/src/api/controllers/role.ts
@@ -6,7 +6,13 @@ import {
   Header,
 } from "@budibase/backend-core"
 import { getUserMetadataParams, InternalTables } from "../../db/utils"
-import { Database, Role, UserCtx, UserRoles } from "@budibase/types"
+import {
+  Database,
+  Role,
+  UserCtx,
+  UserMetadata,
+  UserRoles,
+} from "@budibase/types"
 import { sdk as sharedSdk } from "@budibase/shared-core"
 import sdk from "../../sdk"
 
@@ -115,12 +121,12 @@ export async function destroy(ctx: UserCtx) {
   const role = await db.get<Role>(roleId)
   // first check no users actively attached to role
   const users = (
-    await db.allDocs(
+    await db.allDocs<UserMetadata>(
       getUserMetadataParams(undefined, {
         include_docs: true,
       })
     )
-  ).rows.map(row => row.doc)
+  ).rows.map(row => row.doc!)
   const usersWithRole = users.filter(user => user.roleId === roleId)
   if (usersWithRole.length !== 0) {
     ctx.throw(400, "Cannot delete role when it is in use.")

--- a/packages/server/src/api/controllers/row/internal.ts
+++ b/packages/server/src/api/controllers/row/internal.ts
@@ -233,17 +233,16 @@ export async function fetchEnrichedRow(ctx: UserCtx) {
   const tableId = utils.getTableId(ctx)
   const rowId = ctx.params.rowId as string
   // need table to work out where links go in row, as well as the link docs
-  let response = await Promise.all([
+  const [table, row, links] = await Promise.all([
     sdk.tables.getTable(tableId),
     utils.findRow(ctx, tableId, rowId),
     linkRows.getLinkDocuments({ tableId, rowId, fieldName }),
   ])
-  const table = response[0] as Table
-  const row = response[1] as Row
-  const linkVals = response[2] as LinkDocumentValue[]
+  const linkVals = links as LinkDocumentValue[]
+
   // look up the actual rows based on the ids
   const params = getMultiIDParams(linkVals.map(linkVal => linkVal.id))
-  let linkedRows = (await db.allDocs(params)).rows.map(row => row.doc)
+  let linkedRows = (await db.allDocs<Row>(params)).rows.map(row => row.doc!)
 
   // get the linked tables
   const linkTableIds = getLinkedTableIDs(table as Table)

--- a/packages/server/src/api/controllers/row/staticFormula.ts
+++ b/packages/server/src/api/controllers/row/staticFormula.ts
@@ -86,12 +86,12 @@ export async function updateAllFormulasInTable(table: Table) {
   const db = context.getAppDB()
   // start by getting the raw rows (which will be written back to DB after update)
   let rows = (
-    await db.allDocs(
+    await db.allDocs<Row>(
       getRowParams(table._id, null, {
         include_docs: true,
       })
     )
-  ).rows.map(row => row.doc)
+  ).rows.map(row => row.doc!)
   // now enrich the rows, note the clone so that we have the base state of the
   // rows so that we don't write any of the enriched information back
   let enrichedRows = await outputProcessing(table, cloneDeep(rows), {

--- a/packages/server/src/api/controllers/table/utils.ts
+++ b/packages/server/src/api/controllers/table/utils.ts
@@ -333,29 +333,33 @@ export async function checkForViewUpdates(
   columnRename?: RenameColumn
 ) {
   const views = await getViews()
-  const tableViews = views.filter(view => view.meta.tableId === table._id)
+  const tableViews = views.filter(view => view.meta?.tableId === table._id)
 
   // Check each table view to see if impacted by this table action
   for (let view of tableViews) {
     let needsUpdated = false
+    const viewMetadata = view.meta as any
+    if (!viewMetadata) {
+      continue
+    }
 
     // First check for renames, otherwise check for deletions
     if (columnRename) {
       // Update calculation field if required
-      if (view.meta.field === columnRename.old) {
-        view.meta.field = columnRename.updated
+      if (viewMetadata.field === columnRename.old) {
+        viewMetadata.field = columnRename.updated
         needsUpdated = true
       }
 
       // Update group by field if required
-      if (view.meta.groupBy === columnRename.old) {
-        view.meta.groupBy = columnRename.updated
+      if (viewMetadata.groupBy === columnRename.old) {
+        viewMetadata.groupBy = columnRename.updated
         needsUpdated = true
       }
 
       // Update filters if required
-      if (view.meta.filters) {
-        view.meta.filters.forEach((filter: any) => {
+      if (viewMetadata.filters) {
+        viewMetadata.filters.forEach((filter: any) => {
           if (filter.key === columnRename.old) {
             filter.key = columnRename.updated
             needsUpdated = true
@@ -365,26 +369,26 @@ export async function checkForViewUpdates(
     } else if (deletedColumns) {
       deletedColumns.forEach((column: string) => {
         // Remove calculation statement if required
-        if (view.meta.field === column) {
-          delete view.meta.field
-          delete view.meta.calculation
-          delete view.meta.groupBy
+        if (viewMetadata.field === column) {
+          delete viewMetadata.field
+          delete viewMetadata.calculation
+          delete viewMetadata.groupBy
           needsUpdated = true
         }
 
         // Remove group by field if required
-        if (view.meta.groupBy === column) {
-          delete view.meta.groupBy
+        if (viewMetadata.groupBy === column) {
+          delete viewMetadata.groupBy
           needsUpdated = true
         }
 
         // Remove filters referencing deleted field if required
-        if (view.meta.filters && view.meta.filters.length) {
-          const initialLength = view.meta.filters.length
-          view.meta.filters = view.meta.filters.filter((filter: any) => {
+        if (viewMetadata.filters && viewMetadata.filters.length) {
+          const initialLength = viewMetadata.filters.length
+          viewMetadata.filters = viewMetadata.filters.filter((filter: any) => {
             return filter.key !== column
           })
-          if (initialLength !== view.meta.filters.length) {
+          if (initialLength !== viewMetadata.filters.length) {
             needsUpdated = true
           }
         }
@@ -397,15 +401,16 @@ export async function checkForViewUpdates(
         (field: any) => field.name == view.groupBy
       )
       const newViewTemplate = viewTemplate(
-        view.meta,
+        viewMetadata,
         groupByField?.type === FieldTypes.ARRAY
       )
-      await saveView(null, view.name, newViewTemplate)
-      if (!newViewTemplate.meta.schema) {
-        newViewTemplate.meta.schema = table.schema
+      const viewName = view.name!
+      await saveView(null, viewName, newViewTemplate)
+      if (!newViewTemplate.meta?.schema) {
+        newViewTemplate.meta!.schema = table.schema
       }
-      if (table.views?.[view.name]) {
-        table.views[view.name] = newViewTemplate.meta as View
+      if (table.views?.[viewName]) {
+        table.views[viewName] = newViewTemplate.meta as View
       }
     }
   }

--- a/packages/server/src/api/controllers/view/utils.ts
+++ b/packages/server/src/api/controllers/view/utils.ts
@@ -53,12 +53,12 @@ export async function getViews() {
     }
   } else {
     const views = (
-      await db.allDocs(
+      await db.allDocs<any>(
         getMemoryViewParams({
           include_docs: true,
         })
       )
-    ).rows.map(row => row.doc)
+    ).rows.map(row => row.doc!)
     for (let viewDoc of views) {
       response.push({
         name: viewDoc.name,

--- a/packages/server/src/api/controllers/view/utils.ts
+++ b/packages/server/src/api/controllers/view/utils.ts
@@ -8,13 +8,13 @@ import {
 import env from "../../../environment"
 import { context } from "@budibase/backend-core"
 import viewBuilder from "./viewBuilder"
-import { Database } from "@budibase/types"
+import { Database, DBView, DesignDocument, InMemoryView } from "@budibase/types"
 
 export async function getView(viewName: string) {
   const db = context.getAppDB()
   if (env.SELF_HOSTED) {
-    const designDoc = await db.get<any>("_design/database")
-    return designDoc.views[viewName]
+    const designDoc = await db.get<DesignDocument>("_design/database")
+    return designDoc.views?.[viewName]
   } else {
     // This is a table view, don't read the view from the DB
     if (viewName.startsWith(DocumentType.TABLE + SEPARATOR)) {
@@ -22,7 +22,7 @@ export async function getView(viewName: string) {
     }
 
     try {
-      const viewDoc = await db.get<any>(generateMemoryViewID(viewName))
+      const viewDoc = await db.get<InMemoryView>(generateMemoryViewID(viewName))
       return viewDoc.view
     } catch (err: any) {
       // Return null when PouchDB doesn't found the view
@@ -35,25 +35,28 @@ export async function getView(viewName: string) {
   }
 }
 
-export async function getViews() {
+export async function getViews(): Promise<DBView[]> {
   const db = context.getAppDB()
-  const response = []
+  const response: DBView[] = []
   if (env.SELF_HOSTED) {
-    const designDoc = await db.get<any>("_design/database")
-    for (let name of Object.keys(designDoc.views)) {
+    const designDoc = await db.get<DesignDocument>("_design/database")
+    for (let name of Object.keys(designDoc.views || {})) {
       // Only return custom views, not built ins
       const viewNames = Object.values(ViewName) as string[]
       if (viewNames.indexOf(name) !== -1) {
         continue
       }
-      response.push({
-        name,
-        ...designDoc.views[name],
-      })
+      const view = designDoc.views?.[name]
+      if (view) {
+        response.push({
+          name,
+          ...view,
+        })
+      }
     }
   } else {
     const views = (
-      await db.allDocs<any>(
+      await db.allDocs<InMemoryView>(
         getMemoryViewParams({
           include_docs: true,
         })
@@ -72,11 +75,11 @@ export async function getViews() {
 export async function saveView(
   originalName: string | null,
   viewName: string,
-  viewTemplate: any
+  viewTemplate: DBView
 ) {
   const db = context.getAppDB()
   if (env.SELF_HOSTED) {
-    const designDoc = await db.get<any>("_design/database")
+    const designDoc = await db.get<DesignDocument>("_design/database")
     designDoc.views = {
       ...designDoc.views,
       [viewName]: viewTemplate,
@@ -89,17 +92,17 @@ export async function saveView(
   } else {
     const id = generateMemoryViewID(viewName)
     const originalId = originalName ? generateMemoryViewID(originalName) : null
-    const viewDoc: any = {
+    const viewDoc: InMemoryView = {
       _id: id,
       view: viewTemplate,
       name: viewName,
-      tableId: viewTemplate.meta.tableId,
+      tableId: viewTemplate.meta!.tableId,
     }
     try {
-      const old = await db.get<any>(id)
+      const old = await db.get<InMemoryView>(id)
       if (originalId) {
-        const originalDoc = await db.get<any>(originalId)
-        await db.remove(originalDoc._id, originalDoc._rev)
+        const originalDoc = await db.get<InMemoryView>(originalId)
+        await db.remove(originalDoc._id!, originalDoc._rev)
       }
       if (old && old._rev) {
         viewDoc._rev = old._rev
@@ -114,52 +117,65 @@ export async function saveView(
 export async function deleteView(viewName: string) {
   const db = context.getAppDB()
   if (env.SELF_HOSTED) {
-    const designDoc = await db.get<any>("_design/database")
-    const view = designDoc.views[viewName]
-    delete designDoc.views[viewName]
+    const designDoc = await db.get<DesignDocument>("_design/database")
+    const view = designDoc.views?.[viewName]
+    delete designDoc.views?.[viewName]
     await db.put(designDoc)
     return view
   } else {
     const id = generateMemoryViewID(viewName)
-    const viewDoc = await db.get<any>(id)
-    await db.remove(viewDoc._id, viewDoc._rev)
+    const viewDoc = await db.get<InMemoryView>(id)
+    await db.remove(viewDoc._id!, viewDoc._rev)
     return viewDoc.view
   }
 }
 
 export async function migrateToInMemoryView(db: Database, viewName: string) {
   // delete the view initially
-  const designDoc = await db.get<any>("_design/database")
+  const designDoc = await db.get<DesignDocument>("_design/database")
+  const meta = designDoc.views?.[viewName].meta
+  if (!meta) {
+    throw new Error("Unable to migrate view - no metadata")
+  }
   // run the view back through the view builder to update it
-  const view = viewBuilder(designDoc.views[viewName].meta)
-  delete designDoc.views[viewName]
+  const view = viewBuilder(meta)
+  delete designDoc.views?.[viewName]
   await db.put(designDoc)
-  await exports.saveView(db, null, viewName, view)
+  await saveView(null, viewName, view)
 }
 
 export async function migrateToDesignView(db: Database, viewName: string) {
-  let view = await db.get<any>(generateMemoryViewID(viewName))
-  const designDoc = await db.get<any>("_design/database")
-  designDoc.views[viewName] = viewBuilder(view.view.meta)
+  let view = await db.get<InMemoryView>(generateMemoryViewID(viewName))
+  const designDoc = await db.get<DesignDocument>("_design/database")
+  const meta = view.view.meta
+  if (!meta) {
+    throw new Error("Unable to migrate view - no metadata")
+  }
+  if (!designDoc.views) {
+    designDoc.views = {}
+  }
+  designDoc.views[viewName] = viewBuilder(meta)
   await db.put(designDoc)
-  await db.remove(view._id, view._rev)
+  await db.remove(view._id!, view._rev)
 }
 
 export async function getFromDesignDoc(db: Database, viewName: string) {
-  const designDoc = await db.get<any>("_design/database")
-  let view = designDoc.views[viewName]
+  const designDoc = await db.get<DesignDocument>("_design/database")
+  let view = designDoc.views?.[viewName]
   if (view == null) {
     throw { status: 404, message: "Unable to get view" }
   }
   return view
 }
 
-export async function getFromMemoryDoc(db: Database, viewName: string) {
-  let view = await db.get<any>(generateMemoryViewID(viewName))
+export async function getFromMemoryDoc(
+  db: Database,
+  viewName: string
+): Promise<DBView> {
+  let view = await db.get<InMemoryView>(generateMemoryViewID(viewName))
   if (view) {
-    view = view.view
+    return view.view
   } else {
     throw { status: 404, message: "Unable to get view" }
   }
-  return view
 }

--- a/packages/server/src/api/controllers/view/viewBuilder.ts
+++ b/packages/server/src/api/controllers/view/viewBuilder.ts
@@ -1,13 +1,4 @@
-import { ViewFilter } from "@budibase/types"
-
-type ViewTemplateOpts = {
-  field: string
-  tableId: string
-  groupBy: string
-  filters: ViewFilter[]
-  calculation: string
-  groupByMulti: boolean
-}
+import { ViewFilter, ViewTemplateOpts, DBView } from "@budibase/types"
 
 const TOKEN_MAP: Record<string, string> = {
   EQUALS: "===",
@@ -146,7 +137,7 @@ function parseEmitExpression(field: string, groupBy: string) {
 export default function (
   { field, tableId, groupBy, filters = [], calculation }: ViewTemplateOpts,
   groupByMulti?: boolean
-) {
+): DBView {
   // first filter can't have a conjunction
   if (filters && filters.length > 0 && filters[0].conjunction) {
     delete filters[0].conjunction

--- a/packages/server/src/api/controllers/view/views.ts
+++ b/packages/server/src/api/controllers/view/views.ts
@@ -47,8 +47,11 @@ export async function save(ctx: Ctx) {
 
   // add views to table document
   if (!table.views) table.views = {}
-  if (!view.meta.schema) {
-    view.meta.schema = table.schema
+  if (!view.meta?.schema) {
+    view.meta = {
+      ...view.meta!,
+      schema: table.schema,
+    }
   }
   table.views[viewName] = { ...view.meta, name: viewName }
   if (originalName) {
@@ -125,10 +128,13 @@ export async function destroy(ctx: Ctx) {
   const db = context.getAppDB()
   const viewName = decodeURIComponent(ctx.params.viewName)
   const view = await deleteView(viewName)
+  if (!view || !view.meta) {
+    ctx.throw(400, "Unable to delete view - no metadata/view not found.")
+  }
   const table = await sdk.tables.getTable(view.meta.tableId)
   delete table.views![viewName]
   await db.put(table)
-  await events.view.deleted(view)
+  await events.view.deleted(view as View)
 
   ctx.body = view
   builderSocket?.emitTableUpdate(ctx, table)
@@ -147,7 +153,7 @@ export async function exportView(ctx: Ctx) {
     )
   }
 
-  if (view) {
+  if (view && view.meta) {
     ctx.params.viewName = viewName
     // Fetch view rows
     ctx.query = {

--- a/packages/server/src/automations/triggers.ts
+++ b/packages/server/src/automations/triggers.ts
@@ -20,10 +20,10 @@ const JOB_OPTS = {
 
 async function getAllAutomations() {
   const db = context.getAppDB()
-  let automations = await db.allDocs(
+  let automations = await db.allDocs<Automation>(
     getAutomationParams(null, { include_docs: true })
   )
-  return automations.rows.map(row => row.doc)
+  return automations.rows.map(row => row.doc!)
 }
 
 async function queueRelevantRowAutomations(
@@ -45,19 +45,19 @@ async function queueRelevantRowAutomations(
 
     for (let automation of automations) {
       let automationDef = automation.definition
-      let automationTrigger = automationDef ? automationDef.trigger : {}
+      let automationTrigger = automationDef?.trigger
       // don't queue events which are for dev apps, only way to test automations is
       // running tests on them, in production the test flag will never
       // be checked due to lazy evaluation (first always false)
       if (
         !env.ALLOW_DEV_AUTOMATIONS &&
         isDevAppID(event.appId) &&
-        !(await checkTestFlag(automation._id))
+        !(await checkTestFlag(automation._id!))
       ) {
         continue
       }
       if (
-        automationTrigger.inputs &&
+        automationTrigger?.inputs &&
         automationTrigger.inputs.tableId === event.row.tableId
       ) {
         await automationQueue.add({ automation, event }, JOB_OPTS)

--- a/packages/server/src/db/inMemoryView.ts
+++ b/packages/server/src/db/inMemoryView.ts
@@ -1,5 +1,5 @@
 import newid from "./newid"
-import { Row, View, Document } from "@budibase/types"
+import { Row, Document, DBView } from "@budibase/types"
 
 // bypass the main application db config
 // use in memory pouchdb directly
@@ -7,7 +7,7 @@ import { db as dbCore } from "@budibase/backend-core"
 const Pouch = dbCore.getPouch({ inMemory: true })
 
 export async function runView(
-  view: View,
+  view: DBView,
   calculation: string,
   group: boolean,
   data: Row[]

--- a/packages/server/src/db/linkedRows/index.ts
+++ b/packages/server/src/db/linkedRows/index.ts
@@ -14,7 +14,14 @@ import partition from "lodash/partition"
 import { getGlobalUsersFromMetadata } from "../../utilities/global"
 import { processFormulas } from "../../utilities/rowProcessor"
 import { context } from "@budibase/backend-core"
-import { Table, Row, LinkDocumentValue, FieldType } from "@budibase/types"
+import {
+  Table,
+  Row,
+  LinkDocumentValue,
+  FieldType,
+  LinkDocument,
+  ContextUser,
+} from "@budibase/types"
 import sdk from "../../sdk"
 
 export { IncludeDocs, getLinkDocuments, createLinkView } from "./linkUtils"
@@ -73,18 +80,18 @@ async function getFullLinkedDocs(links: LinkDocumentValue[]) {
   const db = context.getAppDB()
   const linkedRowIds = links.map(link => link.id)
   const uniqueRowIds = [...new Set(linkedRowIds)]
-  let dbRows = (await db.allDocs(getMultiIDParams(uniqueRowIds))).rows.map(
-    row => row.doc
+  let dbRows = (await db.allDocs<Row>(getMultiIDParams(uniqueRowIds))).rows.map(
+    row => row.doc!
   )
   // convert the unique db rows back to a full list of linked rows
   const linked = linkedRowIds
     .map(id => dbRows.find(row => row && row._id === id))
-    .filter(row => row != null)
+    .filter(row => row != null) as Row[]
   // need to handle users as specific cases
   let [users, other] = partition(linked, linkRow =>
-    linkRow._id.startsWith(USER_METDATA_PREFIX)
+    linkRow._id!.startsWith(USER_METDATA_PREFIX)
   )
-  users = await getGlobalUsersFromMetadata(users)
+  users = await getGlobalUsersFromMetadata(users as ContextUser[])
   return [...other, ...users]
 }
 
@@ -176,7 +183,7 @@ export async function attachFullLinkedDocs(
   // clear any existing links that could be dupe'd
   rows = clearRelationshipFields(table, rows)
   // now get the docs and combine into the rows
-  let linked = []
+  let linked: Row[] = []
   if (linksWithoutFromRow.length > 0) {
     linked = await getFullLinkedDocs(linksWithoutFromRow)
   }
@@ -189,7 +196,7 @@ export async function attachFullLinkedDocs(
       if (opts?.fromRow && opts?.fromRow?._id === link.id) {
         linkedRow = opts.fromRow!
       } else {
-        linkedRow = linked.find(row => row._id === link.id)
+        linkedRow = linked.find(row => row._id === link.id)!
       }
       if (linkedRow) {
         const linkedTableId =

--- a/packages/server/src/sdk/app/applications/import.ts
+++ b/packages/server/src/sdk/app/applications/import.ts
@@ -91,7 +91,7 @@ async function getImportableDocuments(db: Database) {
   // map the responses to the document itself
   let documents: Document[] = []
   for (let response of await Promise.all(docPromises)) {
-    documents = documents.concat(response.rows.map(row => row.doc))
+    documents = documents.concat(response.rows.map(row => row.doc!))
   }
   // remove the _rev, stops it being written
   documents.forEach(doc => {

--- a/packages/server/src/sdk/app/applications/sync.ts
+++ b/packages/server/src/sdk/app/applications/sync.ts
@@ -81,7 +81,7 @@ async function syncUsersToApp(
 
 export async function syncUsersToAllApps(userIds: string[]) {
   // list of users, if one has been deleted it will be undefined in array
-  const users = (await getRawGlobalUsers(userIds)) as User[]
+  const users = await getRawGlobalUsers(userIds)
   const groups = await proSdk.groups.fetch()
   const finalUsers: (User | DeletedUser)[] = []
   for (let userId of userIds) {

--- a/packages/server/src/sdk/app/applications/sync.ts
+++ b/packages/server/src/sdk/app/applications/sync.ts
@@ -3,7 +3,11 @@ import { db as dbCore, context, logging, roles } from "@budibase/backend-core"
 import { User, ContextUser, UserGroup } from "@budibase/types"
 import { sdk as proSdk } from "@budibase/pro"
 import sdk from "../../"
-import { getGlobalUsers, processUser } from "../../../utilities/global"
+import {
+  getGlobalUsers,
+  getRawGlobalUsers,
+  processUser,
+} from "../../../utilities/global"
 import { generateUserMetadataID, InternalTables } from "../../../db/utils"
 
 type DeletedUser = { _id: string; deleted: boolean }
@@ -77,9 +81,7 @@ async function syncUsersToApp(
 
 export async function syncUsersToAllApps(userIds: string[]) {
   // list of users, if one has been deleted it will be undefined in array
-  const users = (await getGlobalUsers(userIds, {
-    noProcessing: true,
-  })) as User[]
+  const users = (await getRawGlobalUsers(userIds)) as User[]
   const groups = await proSdk.groups.fetch()
   const finalUsers: (User | DeletedUser)[] = []
   for (let userId of userIds) {

--- a/packages/server/src/sdk/app/datasources/datasources.ts
+++ b/packages/server/src/sdk/app/datasources/datasources.ts
@@ -51,12 +51,12 @@ export async function fetch(opts?: {
 
   // Get external datasources
   const datasources = (
-    await db.allDocs(
+    await db.allDocs<Datasource>(
       getDatasourceParams(null, {
         include_docs: true,
       })
     )
-  ).rows.map(row => row.doc)
+  ).rows.map(row => row.doc!)
 
   const allDatasources: Datasource[] = await sdk.datasources.removeSecrets([
     bbInternalDb,
@@ -271,5 +271,5 @@ export async function getExternalDatasources(): Promise<Datasource[]> {
     })
   )
 
-  return externalDatasources.rows.map(r => r.doc)
+  return externalDatasources.rows.map(r => r.doc!)
 }

--- a/packages/server/src/sdk/app/rows/search/internal.ts
+++ b/packages/server/src/sdk/app/rows/search/internal.ts
@@ -185,8 +185,8 @@ export async function fetchView(
       group: !!group,
     })
   } else {
-    const tableId = viewInfo.meta.tableId
-    const data = await fetchRaw(tableId)
+    const tableId = viewInfo.meta!.tableId
+    const data = await fetchRaw(tableId!)
     response = await inMemoryViews.runView(
       viewInfo,
       calculation as string,
@@ -200,7 +200,7 @@ export async function fetchView(
     response.rows = response.rows.map(row => row.doc)
     let table: Table
     try {
-      table = await sdk.tables.getTable(viewInfo.meta.tableId)
+      table = await sdk.tables.getTable(viewInfo.meta!.tableId)
     } catch (err) {
       throw new Error("Unable to retrieve view table.")
     }

--- a/packages/server/src/sdk/app/tables/getters.ts
+++ b/packages/server/src/sdk/app/tables/getters.ts
@@ -48,7 +48,7 @@ export async function getAllInternalTables(db?: Database): Promise<Table[]> {
   if (!db) {
     db = context.getAppDB()
   }
-  const internalTables = await db.allDocs<Table[]>(
+  const internalTables = await db.allDocs<Table>(
     getTableParams(null, {
       include_docs: true,
     })
@@ -124,7 +124,7 @@ export async function getTables(tableIds: string[]): Promise<Table[]> {
   }
   if (internalTableIds.length) {
     const db = context.getAppDB()
-    const internalTableDocs = await db.allDocs<Table[]>(
+    const internalTableDocs = await db.allDocs<Table>(
       getMultiIDParams(internalTableIds)
     )
     tables = tables.concat(internalTableDocs.rows.map(row => row.doc!))

--- a/packages/server/src/utilities/global.ts
+++ b/packages/server/src/utilities/global.ts
@@ -71,69 +71,67 @@ export async function processUser(
   return user
 }
 
-export async function getCachedSelf(ctx: UserCtx, appId: string) {
+export async function getCachedSelf(
+  ctx: UserCtx,
+  appId: string
+): Promise<ContextUser> {
   // this has to be tenant aware, can't depend on the context to find it out
   // running some middlewares before the tenancy causes context to break
   const user = await cache.user.getUser(ctx.user?._id!)
   return processUser(user, { appId })
 }
 
-export async function getRawGlobalUser(userId: string) {
+export async function getRawGlobalUser(userId: string): Promise<User> {
   const db = tenancy.getGlobalDB()
   return db.get<User>(getGlobalIDFromUserMetadataID(userId))
 }
 
-export async function getGlobalUser(userId: string) {
+export async function getGlobalUser(userId: string): Promise<ContextUser> {
   const appId = context.getAppId()
   let user = await getRawGlobalUser(userId)
   return processUser(user, { appId })
 }
 
-export async function getGlobalUsers(
-  userIds?: string[],
-  opts?: { noProcessing?: boolean }
-) {
-  const appId = context.getAppId()
+export async function getRawGlobalUsers(userIds?: string[]): Promise<User[]> {
   const db = tenancy.getGlobalDB()
-  let globalUsers
+  let globalUsers: User[]
   if (userIds) {
-    globalUsers = (await db.allDocs(getMultiIDParams(userIds))).rows.map(
-      row => row.doc
+    globalUsers = (await db.allDocs<User>(getMultiIDParams(userIds))).rows.map(
+      row => row.doc!
     )
   } else {
     globalUsers = (
-      await db.allDocs(
+      await db.allDocs<User>(
         dbCore.getGlobalUserParams(null, {
           include_docs: true,
         })
       )
-    ).rows.map(row => row.doc)
+    ).rows.map(row => row.doc!)
   }
-  globalUsers = globalUsers
+  return globalUsers
     .filter(user => user != null)
     .map(user => {
       delete user.password
       delete user.forceResetPassword
       return user
     })
+}
 
-  if (opts?.noProcessing || !appId) {
-    return globalUsers
-  } else {
-    // pass in the groups, meaning we don't actually need to retrieve them for
-    // each user individually
-    const allGroups = await groups.fetch()
-    return Promise.all(
-      globalUsers.map(user => processUser(user, { groups: allGroups }))
-    )
-  }
+export async function getGlobalUsers(
+  userIds?: string[]
+): Promise<ContextUser[]> {
+  const users = await getRawGlobalUsers(userIds)
+  const allGroups = await groups.fetch()
+  return Promise.all(
+    users.map(user => processUser(user, { groups: allGroups }))
+  )
 }
 
 export async function getGlobalUsersFromMetadata(users: ContextUser[]) {
   const globalUsers = await getGlobalUsers(users.map(user => user._id!))
   return users.map(user => {
     const globalUser = globalUsers.find(
-      globalUser => globalUser && user._id?.includes(globalUser._id)
+      globalUser => globalUser && user._id?.includes(globalUser._id!)
     )
     return {
       ...globalUser,

--- a/packages/server/src/utilities/routing/index.ts
+++ b/packages/server/src/utilities/routing/index.ts
@@ -1,9 +1,9 @@
 import { createRoutingView } from "../../db/views/staticViews"
 import { ViewName, getQueryIndex, UNICODE_MAX } from "../../db/utils"
 import { context } from "@budibase/backend-core"
-import { ScreenRouting } from "@budibase/types"
+import { ScreenRouting, Document } from "@budibase/types"
 
-type ScreenRoutesView = {
+interface ScreenRoutesView extends Document {
   id: string
   routing: ScreenRouting
 }

--- a/packages/types/src/documents/app/layout.ts
+++ b/packages/types/src/documents/app/layout.ts
@@ -2,4 +2,5 @@ import { Document } from "../document"
 
 export interface Layout extends Document {
   props: any
+  layoutId?: string
 }

--- a/packages/types/src/documents/app/user.ts
+++ b/packages/types/src/documents/app/user.ts
@@ -1,6 +1,6 @@
-import { Document } from "../document"
+import { User } from "../global"
+import { Row } from "./row"
+import { ContextUser } from "../../sdk"
 
-export interface UserMetadata extends Document {
-  roleId: string
-  email?: string
-}
+export type UserMetadata = User & Row
+export type ContextUserMetadata = ContextUser & Row

--- a/packages/types/src/documents/app/view.ts
+++ b/packages/types/src/documents/app/view.ts
@@ -1,5 +1,24 @@
 import { SearchFilter, SortOrder, SortType } from "../../api"
 import { UIFieldMetadata } from "./table"
+import { Document } from "../document"
+import { DBView } from "../../sdk"
+
+export type ViewTemplateOpts = {
+  field: string
+  tableId: string
+  groupBy: string
+  filters: ViewFilter[]
+  schema: any
+  calculation: string
+  groupByMulti?: boolean
+}
+
+export interface InMemoryView extends Document {
+  view: DBView
+  name: string
+  tableId: string
+  groupBy?: string
+}
 
 export interface View {
   name?: string
@@ -10,7 +29,7 @@ export interface View {
   calculation?: ViewCalculation
   map?: string
   reduce?: any
-  meta?: Record<string, any>
+  meta?: ViewTemplateOpts
 }
 
 export interface ViewV2 {

--- a/packages/types/src/documents/pouch.ts
+++ b/packages/types/src/documents/pouch.ts
@@ -1,17 +1,19 @@
+import { Document } from "../"
+
 export interface RowValue {
   rev: string
   deleted: boolean
 }
 
-export interface RowResponse<T> {
+export interface RowResponse<T extends Document> {
   id: string
   key: string
   error: string
   value: T | RowValue
-  doc?: T | any
+  doc?: T
 }
 
-export interface AllDocsResponse<T> {
+export interface AllDocsResponse<T extends Document> {
   offset: number
   total_rows: number
   rows: RowResponse<T>[]

--- a/packages/types/src/sdk/db.ts
+++ b/packages/types/src/sdk/db.ts
@@ -1,5 +1,5 @@
 import Nano from "@budibase/nano"
-import { AllDocsResponse, AnyDocument, Document } from "../"
+import { AllDocsResponse, AnyDocument, Document, ViewTemplateOpts } from "../"
 import { Writable } from "stream"
 
 export enum SearchIndex {
@@ -18,6 +18,37 @@ export type PouchOptions = {
 export enum SortOption {
   ASCENDING = "asc",
   DESCENDING = "desc",
+}
+
+export type IndexAnalyzer = {
+  name: string
+  default?: string
+  fields?: Record<string, string>
+}
+
+export type DBView = {
+  name?: string
+  map: string
+  reduce?: string
+  meta?: ViewTemplateOpts
+  groupBy?: string
+}
+
+export interface DesignDocument extends Document {
+  // we use this static reference for all design documents
+  _id: "_design/database"
+  language?: string
+  // CouchDB views
+  views?: {
+    [viewName: string]: DBView
+  }
+  // Lucene indexes
+  indexes?: {
+    [indexName: string]: {
+      index: string
+      analyzer?: string | IndexAnalyzer
+    }
+  }
 }
 
 export type CouchFindOptions = {

--- a/packages/types/src/sdk/db.ts
+++ b/packages/types/src/sdk/db.ts
@@ -101,8 +101,10 @@ export interface Database {
     opts?: DatabasePutOpts
   ): Promise<Nano.DocumentInsertResponse>
   bulkDocs(documents: AnyDocument[]): Promise<Nano.DocumentBulkResponse[]>
-  allDocs<T>(params: DatabaseQueryOpts): Promise<AllDocsResponse<T>>
-  query<T>(
+  allDocs<T extends Document>(
+    params: DatabaseQueryOpts
+  ): Promise<AllDocsResponse<T>>
+  query<T extends Document>(
     viewName: string,
     params: DatabaseQueryOpts
   ): Promise<AllDocsResponse<T>>

--- a/packages/worker/src/constants/templates/index.ts
+++ b/packages/worker/src/constants/templates/index.ts
@@ -56,12 +56,12 @@ export async function getTemplates({
   id,
 }: { ownerId?: string; type?: string; id?: string } = {}) {
   const db = tenancy.getGlobalDB()
-  const response = await db.allDocs(
+  const response = await db.allDocs<Template>(
     dbCore.getTemplateParams(ownerId || GLOBAL_OWNER, id, {
       include_docs: true,
     })
   )
-  let templates = response.rows.map(row => row.doc)
+  let templates = response.rows.map(row => row.doc!)
   // should only be one template with ID
   if (id) {
     return templates[0]
@@ -73,6 +73,6 @@ export async function getTemplates({
 }
 
 export async function getTemplateByPurpose(type: string, purpose: string) {
-  const templates = await getTemplates({ type })
+  const templates = (await getTemplates({ type })) as Template[]
   return templates.find((template: Template) => template.purpose === purpose)
 }

--- a/packages/worker/src/utilities/email.ts
+++ b/packages/worker/src/utilities/email.ts
@@ -99,8 +99,6 @@ async function buildEmail(
   if (!base || !body || !core) {
     throw "Unable to build email, missing base components"
   }
-  base = base.contents
-  body = body.contents
 
   let name = user ? user.name : undefined
   if (user && !name && user.firstName) {
@@ -114,15 +112,10 @@ async function buildEmail(
     user: user || {},
   }
 
-  // Prepend the core template
-  const fullBody = core + body
-
-  body = await processString(fullBody, context)
-
   // this should now be the core email HTML
-  return processString(base, {
+  return processString(base.contents, {
     ...context,
-    body,
+    body: await processString(core + body?.contents, context),
   })
 }
 


### PR DESCRIPTION
## Description

The key change here is that the generic type returned from DB functions now enforces that `T extends Document`. This will make it more difficult to mis-use these functions, and will force us to correctly type information that comes out of the database (currently a source of `any` in our codebase).

## Feature branch env
[Feature Branch Link](http://fb-better-types-in-global-users.fb.qa.budibase.net)