### PR TITLE
Redis query command doesn't accept spaced values

### DIFF
--- a/packages/server/src/integrations/redis.ts
+++ b/packages/server/src/integrations/redis.ts
@@ -165,10 +165,22 @@ class RedisIntegration {
       // commands split line by line
       const commands = query.json.trim().split("\n")
       let pipelineCommands = []
+      let tokenised
 
       // process each command separately
       for (let command of commands) {
-        const tokenised = command.trim().split(" ")
+        const valueToken = command.trim().match(/".*"/)
+        if (valueToken?.[0]) {
+          tokenised = [
+            ...command
+              .substring(0, command.indexOf(valueToken[0]) - 1)
+              .trim()
+              .split(" "),
+            valueToken?.[0],
+          ]
+        } else {
+          tokenised = command.trim().split(" ")
+        }
         // Pipeline only accepts lower case commands
         tokenised[0] = tokenised[0].toLowerCase()
         pipelineCommands.push(tokenised)

--- a/packages/server/src/integrations/tests/redis.spec.ts
+++ b/packages/server/src/integrations/tests/redis.spec.ts
@@ -85,4 +85,21 @@ describe("Redis Integration", () => {
       ["get", "foo"],
     ])
   })
+
+  it("calls the pipeline method with double quoted phrase values", async () => {
+    const body = {
+      json: 'SET foo "What a wonderful world!"\nGET foo',
+    }
+
+    // ioredis-mock doesn't support pipelines
+    config.integration.client.pipeline = jest.fn(() => ({
+      exec: jest.fn(() => [[]]),
+    }))
+
+    await config.integration.command(body)
+    expect(config.integration.client.pipeline).toHaveBeenCalledWith([
+      ["set", "foo", '"What a wonderful world!"'],
+      ["get", "foo"],
+    ])
+  })
 })


### PR DESCRIPTION
## Description
The redis command code was splitting on whitespace, however this didn't factor in phrase values that include spaces. Now matching for string values and excluding them from the token split.
Unit test added.

## Addresses
- https://github.com/Budibase/budibase/issues/9622


## Screenshots
![Screenshot 2023-11-09 at 17 02 23](https://github.com/Budibase/budibase/assets/101575380/20c4e543-f5a9-4a62-b66c-9f2f42b1195f)

![Screenshot 2023-11-09 at 17 02 40](https://github.com/Budibase/budibase/assets/101575380/cc95eb89-2779-4e80-8d06-69efe773ba56)
