### PR TITLE
Further fixes for app user grid

### DIFF
--- a/packages/backend-core/src/redis/redis.ts
+++ b/packages/backend-core/src/redis/redis.ts
@@ -28,7 +28,6 @@ const DEFAULT_SELECT_DB = SelectableDatabase.DEFAULT
 // for testing just generate the client once
 let CLOSED = false
 let CLIENTS: { [key: number]: any } = {}
-0
 let CONNECTED = false
 
 // mock redis always connected


### PR DESCRIPTION

## Description
Quick addition - if the object has been deleted but the key is still known, then CouchDB will alert us to the fact that it is deleted, leaving the response in a weird state.

Addresses: #12154

## Feature branch env
[Feature Branch Link](http://fb-fix-12154-further-fix-app-user-grid.fb.qa.budibase.net)
