### PR TITLE
Setup OSS checks

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -12,6 +12,13 @@ on:
       - master
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      run_as_oss:
+        type: boolean
+        required: false
+        description: Force running checks as if it was an OSS contributor
+        default: false
 
 env:
   BRANCH: ${{ github.event.pull_request.head.ref }}
@@ -19,7 +26,7 @@ env:
   PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
   NX_BASE_BRANCH: origin/${{ github.base_ref }}
   USE_NX_AFFECTED: ${{ github.event_name == 'pull_request' }}
-  IS_OSS_CONTRIBUTOR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'Budibase/budibase' }}
+  IS_OSS_CONTRIBUTOR: ${{ inputs.run_as_oss == 'true' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'Budibase/budibase') }}
 
 jobs:
   lint:

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -26,7 +26,7 @@ env:
   PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
   NX_BASE_BRANCH: origin/${{ github.base_ref }}
   USE_NX_AFFECTED: ${{ github.event_name == 'pull_request' }}
-  IS_OSS_CONTRIBUTOR: ${{ inputs.run_as_oss == 'true' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'Budibase/budibase') }}
+  IS_OSS_CONTRIBUTOR: ${{ inputs.run_as_oss == true || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'Budibase/budibase') }}
 
 jobs:
   lint:

--- a/.github/workflows/check-oss-contributor.yml
+++ b/.github/workflows/check-oss-contributor.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Notify error
         uses: tsickert/discord-webhook@v5.3.0
         with:
-          webhook-url: ${{ secrets.PROD_DEPLOY_WEBHOOK_URL }}
+          webhook-url: ${{ secrets.OSS_CHECKS_WEBHOOK_URL }}
           embed-title: 🚨 OSS checks failed in master
           embed-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           embed-description: |

--- a/.github/workflows/check-oss-contributor.yml
+++ b/.github/workflows/check-oss-contributor.yml
@@ -33,4 +33,7 @@ jobs:
         with:
           webhook-url: ${{ secrets.PROD_DEPLOY_WEBHOOK_URL }}
           embed-title: "[TEST] OSS checks failed in master"
-          content: "The OSS build is failing on master. SHA: ${{ steps.set_sha.outputs.sha }}, link: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          embed-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          embed-description: |
+            🚨 The OSS build is failing on master ⚠️
+            Git sha: `${{ steps.set_sha.outputs.sha }}`

--- a/.github/workflows/check-oss-contributor.yml
+++ b/.github/workflows/check-oss-contributor.yml
@@ -32,8 +32,7 @@ jobs:
         uses: tsickert/discord-webhook@v5.3.0
         with:
           webhook-url: ${{ secrets.PROD_DEPLOY_WEBHOOK_URL }}
-          embed-title: "[TEST] OSS checks failed in master"
+          embed-title: 🚨 OSS checks failed in master
           embed-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           embed-description: |
-            🚨 The OSS build is failing on master ⚠️
             Git sha: `${{ steps.set_sha.outputs.sha }}`

--- a/.github/workflows/check-oss-contributor.yml
+++ b/.github/workflows/check-oss-contributor.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 8,16 * * 1-5" # on weekdays at 8am and 4pm
+  push:
+    branches:
+      - chore/run_oss_checks # TODO: remove
 
 jobs:
   run:

--- a/.github/workflows/check-oss-contributor.yml
+++ b/.github/workflows/check-oss-contributor.yml
@@ -3,9 +3,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 8,16 * * 1-5" # on weekdays at 8am and 4pm
-  push:
-    branches:
-      - chore/run_oss_checks # TODO: remove
 
 jobs:
   run-checks:
@@ -16,8 +13,8 @@ jobs:
     secrets: inherit
 
   notify-error:
-    # needs: ["run-checks"]
-    if: ${{ always() }}
+    needs: ["run-checks"]
+    if: ${{ failure() }}
     name: Notify error
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-oss-contributor.yml
+++ b/.github/workflows/check-oss-contributor.yml
@@ -1,0 +1,13 @@
+name: OSS contributor checks
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8,16 * * 1-5" # on weekdays at 8am and 4pm
+
+jobs:
+  run:
+    name: Publish server and worker docker images
+    uses: ./.github/workflows/budibase_ci.yml
+    with:
+      run_as_oss: true
+    secrets: inherit

--- a/.github/workflows/check-oss-contributor.yml
+++ b/.github/workflows/check-oss-contributor.yml
@@ -8,9 +8,29 @@ on:
       - chore/run_oss_checks # TODO: remove
 
 jobs:
-  run:
+  run-checks:
     name: Publish server and worker docker images
     uses: ./.github/workflows/budibase_ci.yml
     with:
       run_as_oss: true
     secrets: inherit
+
+  notify-error:
+    needs: ["run-checks"]
+    if: ${{ failure() }}
+    name: Notify error
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set commit SHA
+        id: set_sha
+        run: echo "::set-output name=sha::$(git rev-parse --short ${{ github.sha }})"
+
+      - name: Notify error
+        uses: tsickert/discord-webhook@v5.3.0
+        with:
+          webhook-url: ${{ secrets.PROD_DEPLOY_WEBHOOK_URL }}
+          embed-title: "[TEST] OSS checks failed in master"
+          content: "The OSS build is failing on master. SHA: ${{ steps.set_sha.outputs.sha }}, link: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/check-oss-contributor.yml
+++ b/.github/workflows/check-oss-contributor.yml
@@ -16,8 +16,8 @@ jobs:
     secrets: inherit
 
   notify-error:
-    needs: ["run-checks"]
-    if: ${{ failure() }}
+    # needs: ["run-checks"]
+    if: ${{ always() }}
     name: Notify error
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-featurebranch.yml
+++ b/.github/workflows/deploy-featurebranch.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   release:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'Budibase/budibase'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description
Setting up recurrent checks that will run the CI pipeline simulating they are OSS. This will allow detecting pipeline and build issues for users without the pro submodules. This is setup to run on weekdays at 8am and 4pm, notifying to #engineering if it fails.

![image](https://github.com/Budibase/budibase/assets/15987277/9bfb6fb2-7020-4a88-8579-2488d6746f1e)


Also, disabling FB releases for opensource, as the way we handle the action call is making it error
