### PR TITLE
Assume Redis default port number

### DIFF
--- a/packages/backend-core/src/redis/utils.ts
+++ b/packages/backend-core/src/redis/utils.ts
@@ -75,10 +75,12 @@ export function getRedisConnectionDetails() {
   }
   const [host, port] = url.split(":")
 
+  const portNumber = parseInt(port)
   return {
     host,
     password,
-    port: parseInt(port),
+    // assume default port for redis if invalid found
+    port: isNaN(portNumber) ? 6379 : portNumber,
   }
 }
 


### PR DESCRIPTION
## Description
Fix an issue with account portal redis connection, if no Redis port is supplied in URL we should assume the default port number 6379.