### PR TITLE
Allow querying of users table from automation

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/TableSelector.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/TableSelector.svelte
@@ -22,7 +22,7 @@
 <Select
   on:change={onChange}
   bind:value
-  options={filteredTables.filter(table => table._id !== TableNames.USERS)}
+  options={filteredTables}
   getOptionLabel={table => table.name}
   getOptionValue={table => table._id}
 />


### PR DESCRIPTION

## Description
- Fixing an issue where the Users table wasn't shown in the automation Query Rows table selector. 

## Addresses
- #12372 



## Screenshots
<img width="441" alt="Screenshot 2023-11-30 at 08 58 12" src="https://github.com/Budibase/budibase/assets/5665926/1d0891bf-fca6-4910-82d2-773cf5fc261c">

## Feature branch env
[Feature Branch Link](http://fb-fix-automations-query-user-table-fix.fb.qa.budibase.net)