### PR TITLE
Smart locking mechanism for redis locks without TTL

### DIFF
--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -72,7 +72,7 @@
     "@types/tar-fs": "2.0.1",
     "@types/uuid": "8.3.4",
     "chance": "1.1.8",
-    "ioredis-mock": "8.7.0",
+    "ioredis-mock": "8.9.0",
     "jest": "29.6.2",
     "jest-environment-node": "29.6.2",
     "jest-serial-runner": "1.2.1",

--- a/packages/backend-core/src/redis/redlockImpl.ts
+++ b/packages/backend-core/src/redis/redlockImpl.ts
@@ -5,6 +5,7 @@ import * as context from "../context"
 import env from "../environment"
 import { logWarn } from "../logging"
 import { Duration } from "../utils"
+import { timers } from ".."
 
 async function getClient(
   type: LockType,
@@ -118,7 +119,7 @@ export async function doWithLock<T>(
 
     if (!opts.ttl) {
       // No TTL is provided, so we keep extending the lock while the task is running
-      interval = setInterval(async () => {
+      interval = timers.set(async () => {
         await lock?.extend(ttl / 2)
       }, ttl / 2)
     }
@@ -146,7 +147,7 @@ export async function doWithLock<T>(
       await lock.unlock()
     }
     if (interval) {
-      clearInterval(interval)
+      timers.clear(interval)
     }
   }
 }

--- a/packages/backend-core/src/redis/redlockImpl.ts
+++ b/packages/backend-core/src/redis/redlockImpl.ts
@@ -118,8 +118,8 @@ export async function doWithLock<T>(
 
     if (!opts.ttl) {
       // No TTL is provided, so we keep extending the lock while the task is running
-      interval = setInterval(() => {
-        lock?.extend(ttl / 2)
+      interval = setInterval(async () => {
+        await lock?.extend(ttl / 2)
       }, ttl / 2)
     }
 

--- a/packages/backend-core/src/redis/redlockImpl.ts
+++ b/packages/backend-core/src/redis/redlockImpl.ts
@@ -71,7 +71,7 @@ const OPTIONS: Record<keyof typeof LockType, Redlock.Options> = {
 }
 
 export async function newRedlock(opts: Redlock.Options = {}) {
-  let options = { ...OPTIONS, ...opts }
+  const options = { ...OPTIONS.DEFAULT, ...opts }
   const redisWrapper = await getLockClient()
   const client = redisWrapper.getClient()
   return new Redlock([client], options)

--- a/packages/backend-core/src/redis/redlockImpl.ts
+++ b/packages/backend-core/src/redis/redlockImpl.ts
@@ -131,7 +131,7 @@ export async function doWithLock<T>(
         timeout = setTimeout(async () => {
           let isExpired = false
           try {
-            lock = await lock!.extend(1000)
+            lock = await lock!.extend(opts.ttl)
           } catch (err: any) {
             isExpired = err.message.includes("Cannot extend lock on resource")
             if (isExpired) {

--- a/packages/backend-core/src/redis/redlockImpl.ts
+++ b/packages/backend-core/src/redis/redlockImpl.ts
@@ -111,14 +111,15 @@ export async function doWithLock<T>(
   try {
     const name = getLockName(opts)
 
-    let ttl = opts.ttl || Duration.fromSeconds(15).toMs()
+    let ttl = opts.ttl || Duration.fromSeconds(30).toMs()
 
     // create the lock
     lock = await redlock.lock(name, ttl)
 
     if (!opts.ttl) {
+      // No TTL is provided, so we keep extending the lock while the task is running
       interval = setInterval(() => {
-        lock!.extend(ttl)
+        lock?.extend(ttl / 2)
       }, ttl / 2)
     }
 

--- a/packages/backend-core/src/redis/redlockImpl.ts
+++ b/packages/backend-core/src/redis/redlockImpl.ts
@@ -101,7 +101,7 @@ function getLockName(opts: LockOptions) {
   return name
 }
 
-export const autoExtendPollingMs = Duration.fromSeconds(10).toMs()
+export const AUTO_EXTEND_POLLING_MS = Duration.fromSeconds(10).toMs()
 
 export async function doWithLock<T>(
   opts: LockOptions,
@@ -114,7 +114,7 @@ export async function doWithLock<T>(
     const name = getLockName(opts)
 
     const ttl =
-      opts.type === LockType.AUTO_EXTEND ? autoExtendPollingMs : opts.ttl
+      opts.type === LockType.AUTO_EXTEND ? AUTO_EXTEND_POLLING_MS : opts.ttl
 
     // create the lock
     lock = await redlock.lock(name, ttl)

--- a/packages/backend-core/src/redis/redlockImpl.ts
+++ b/packages/backend-core/src/redis/redlockImpl.ts
@@ -13,13 +13,7 @@ async function getClient(
   if (type === LockType.CUSTOM) {
     return newRedlock(opts)
   }
-  if (
-    env.isTest() &&
-    type !== LockType.TRY_ONCE &&
-    type !== LockType.AUTO_EXTEND
-  ) {
-    return newRedlock(OPTIONS.TEST)
-  }
+
   switch (type) {
     case LockType.TRY_ONCE: {
       return newRedlock(OPTIONS.TRY_ONCE)
@@ -42,18 +36,13 @@ async function getClient(
   }
 }
 
-const OPTIONS: Record<keyof typeof LockType | "TEST", Redlock.Options> = {
+const OPTIONS: Record<keyof typeof LockType, Redlock.Options> = {
   TRY_ONCE: {
     // immediately throws an error if the lock is already held
     retryCount: 0,
   },
   TRY_TWICE: {
     retryCount: 1,
-  },
-  TEST: {
-    // higher retry count in unit tests
-    // due to high contention.
-    retryCount: 100,
   },
   DEFAULT: {
     // the expected clock drift; for more details

--- a/packages/backend-core/src/redis/redlockImpl.ts
+++ b/packages/backend-core/src/redis/redlockImpl.ts
@@ -169,11 +169,7 @@ export async function doWithLock<T>(
       throw e
     }
   } finally {
-    if (timeout) {
-      clearTimeout(timeout)
-    }
-    if (lock) {
-      await lock.unlock()
-    }
+    clearTimeout(timeout)
+    await lock?.unlock()
   }
 }

--- a/packages/backend-core/src/redis/redlockImpl.ts
+++ b/packages/backend-core/src/redis/redlockImpl.ts
@@ -126,7 +126,7 @@ export async function doWithLock<T>(
     lock = await redlock.lock(name, opts.ttl)
 
     if (opts.type === LockType.AUTO_EXTEND) {
-      // No TTL is provided, so we keep extending the lock while the task is running
+      // We keep extending the lock while the task is running
       const extendInIntervals = (): void => {
         timeout = setTimeout(async () => {
           let isExpired = false

--- a/packages/backend-core/src/redis/tests/redlockImpl.spec.ts
+++ b/packages/backend-core/src/redis/tests/redlockImpl.spec.ts
@@ -1,18 +1,8 @@
 import { LockName, LockType } from "@budibase/types"
 import { doWithLock } from "../redlockImpl"
 import { DBTestConfiguration } from "../../../tests"
-import { Duration } from "../../utils"
 
 describe("redlockImpl", () => {
-  beforeEach(() => {
-    jest.useFakeTimers()
-  })
-
-  afterEach(() => {
-    jest.runOnlyPendingTimers()
-    jest.useRealTimers()
-  })
-
   describe("doWithLock", () => {
     it("should execute the task and return the result", async () => {
       const mockTask = jest.fn().mockResolvedValue("mockResult")
@@ -21,16 +11,14 @@ describe("redlockImpl", () => {
       const testOpts = {
         name: LockName.PERSIST_WRITETHROUGH,
         type: LockType.AUTO_EXTEND,
-        ttl: 30000,
+        ttl: 5,
       }
 
       // Call the function with the mock lock and task
       const config = new DBTestConfiguration()
       const result = await config.doInTenant(() =>
         doWithLock(testOpts, async () => {
-          jest.advanceTimersByTime(Duration.fromSeconds(10).toMs())
-          jest.advanceTimersByTime(Duration.fromSeconds(10).toMs())
-          jest.advanceTimersByTime(Duration.fromSeconds(10).toMs())
+          await new Promise<void>(r => setTimeout(() => r(), 10))
           return mockTask()
         })
       )

--- a/packages/backend-core/src/redis/tests/redlockImpl.spec.ts
+++ b/packages/backend-core/src/redis/tests/redlockImpl.spec.ts
@@ -8,7 +8,7 @@ tk.reset()
 describe("redlockImpl", () => {
   describe("doWithLock", () => {
     const config = new DBTestConfiguration()
-    const lockTtl = 30
+    const lockTtl = 25
 
     function runLockWithExecutionTime({
       opts,
@@ -28,7 +28,7 @@ describe("redlockImpl", () => {
     }
 
     it.each(Object.values(LockType))(
-      "should return the task value",
+      "should return the task value and release the lock",
       async (lockType: LockType) => {
         const expectedResult = generator.guid()
         const mockTask = jest.fn().mockResolvedValue(expectedResult)
@@ -64,7 +64,7 @@ describe("redlockImpl", () => {
       const result = await runLockWithExecutionTime({
         opts,
         task: mockTask,
-        executionTimeMs: lockTtl * 2,
+        executionTimeMs: lockTtl * 3,
       })
 
       expect(result.executed).toBe(true)

--- a/packages/backend-core/src/redis/tests/redlockImpl.spec.ts
+++ b/packages/backend-core/src/redis/tests/redlockImpl.spec.ts
@@ -1,5 +1,5 @@
 import { LockName, LockType, LockOptions } from "@budibase/types"
-import { autoExtendPollingMs, doWithLock } from "../redlockImpl"
+import { AUTO_EXTEND_POLLING_MS, doWithLock } from "../redlockImpl"
 import { DBTestConfiguration, generator } from "../../../tests"
 
 describe("redlockImpl", () => {
@@ -9,7 +9,7 @@ describe("redlockImpl", () => {
 
   describe("doWithLock", () => {
     const config = new DBTestConfiguration()
-    const lockTtl = autoExtendPollingMs
+    const lockTtl = AUTO_EXTEND_POLLING_MS
 
     function runLockWithExecutionTime({
       opts,

--- a/packages/backend-core/src/redis/tests/redlockImpl.spec.ts
+++ b/packages/backend-core/src/redis/tests/redlockImpl.spec.ts
@@ -8,7 +8,7 @@ tk.reset()
 describe("redlockImpl", () => {
   describe("doWithLock", () => {
     const config = new DBTestConfiguration()
-    const lockTtl = 25
+    const lockTtl = 50
 
     function runLockWithExecutionTime({
       opts,

--- a/packages/backend-core/src/redis/tests/redlockImpl.spec.ts
+++ b/packages/backend-core/src/redis/tests/redlockImpl.spec.ts
@@ -22,6 +22,7 @@ describe("redlockImpl", () => {
     }) {
       return config.doInTenant(() =>
         doWithLock(opts, async () => {
+          // Run in multiple intervals until hitting the expected time
           const interval = lockTtl / 10
           for (let i = executionTimeMs; i > 0; i -= interval) {
             await jest.advanceTimersByTimeAsync(interval)

--- a/packages/backend-core/src/redis/tests/redlockImpl.spec.ts
+++ b/packages/backend-core/src/redis/tests/redlockImpl.spec.ts
@@ -1,32 +1,98 @@
-import { LockName, LockType } from "@budibase/types"
+import { LockName, LockType, LockOptions } from "@budibase/types"
+import tk from "timekeeper"
 import { doWithLock } from "../redlockImpl"
-import { DBTestConfiguration } from "../../../tests"
+import { DBTestConfiguration, generator } from "../../../tests"
+
+tk.reset()
 
 describe("redlockImpl", () => {
   describe("doWithLock", () => {
-    it("should execute the task and return the result", async () => {
-      const mockTask = jest.fn().mockResolvedValue("mockResult")
+    const config = new DBTestConfiguration()
+    const lockTtl = 30
 
-      // Define test options
-      const testOpts = {
-        name: LockName.PERSIST_WRITETHROUGH,
-        type: LockType.AUTO_EXTEND,
-        ttl: 5,
-      }
-
-      // Call the function with the mock lock and task
-      const config = new DBTestConfiguration()
-      const result = await config.doInTenant(() =>
-        doWithLock(testOpts, async () => {
-          await new Promise<void>(r => setTimeout(() => r(), 10))
-          return mockTask()
+    function runLockWithExecutionTime({
+      opts,
+      task,
+      executionTimeMs,
+    }: {
+      opts: LockOptions
+      task: () => Promise<string>
+      executionTimeMs: number
+    }) {
+      return config.doInTenant(() =>
+        doWithLock(opts, async () => {
+          await new Promise<void>(r => setTimeout(() => r(), executionTimeMs))
+          return task()
         })
       )
+    }
 
-      // Assert the result and verify function calls
+    it.each(Object.values(LockType))(
+      "should return the task value",
+      async (lockType: LockType) => {
+        const expectedResult = generator.guid()
+        const mockTask = jest.fn().mockResolvedValue(expectedResult)
+
+        const opts = {
+          name: LockName.PERSIST_WRITETHROUGH,
+          type: lockType,
+          ttl: lockTtl,
+        }
+
+        const result = await runLockWithExecutionTime({
+          opts,
+          task: mockTask,
+          executionTimeMs: 0,
+        })
+
+        expect(result.executed).toBe(true)
+        expect(result.executed && result.result).toBe(expectedResult)
+        expect(mockTask).toHaveBeenCalledTimes(1)
+      }
+    )
+
+    it("should extend when type is autoextend", async () => {
+      const expectedResult = generator.guid()
+      const mockTask = jest.fn().mockResolvedValue(expectedResult)
+
+      const opts = {
+        name: LockName.PERSIST_WRITETHROUGH,
+        type: LockType.AUTO_EXTEND,
+        ttl: lockTtl,
+      }
+
+      const result = await runLockWithExecutionTime({
+        opts,
+        task: mockTask,
+        executionTimeMs: lockTtl * 2,
+      })
+
       expect(result.executed).toBe(true)
-      expect(result.executed && result.result).toBe("mockResult")
+      expect(result.executed && result.result).toBe(expectedResult)
       expect(mockTask).toHaveBeenCalledTimes(1)
     })
+
+    it.each(Object.values(LockType).filter(t => t !== LockType.AUTO_EXTEND))(
+      "should timeout when type is %s",
+      async (lockType: LockType) => {
+        const mockTask = jest.fn().mockResolvedValue("mockResult")
+
+        const opts = {
+          name: LockName.PERSIST_WRITETHROUGH,
+          type: lockType,
+          ttl: lockTtl,
+        }
+
+        await expect(
+          runLockWithExecutionTime({
+            opts,
+            task: mockTask,
+            executionTimeMs: lockTtl * 2,
+          })
+        ).rejects.toThrowError(
+          `Unable to fully release the lock on resource \"lock:${config.tenantId}_persist_writethrough\".`
+        )
+      }
+    )
   })
 })

--- a/packages/backend-core/src/redis/tests/redlockImpl.spec.ts
+++ b/packages/backend-core/src/redis/tests/redlockImpl.spec.ts
@@ -1,0 +1,44 @@
+import { LockName, LockType } from "@budibase/types"
+import { doWithLock } from "../redlockImpl"
+import { DBTestConfiguration } from "../../../tests"
+import { Duration } from "../../utils"
+
+describe("redlockImpl", () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+  })
+
+  describe("doWithLock", () => {
+    it("should execute the task and return the result", async () => {
+      const mockTask = jest.fn().mockResolvedValue("mockResult")
+
+      // Define test options
+      const testOpts = {
+        name: LockName.PERSIST_WRITETHROUGH,
+        type: LockType.AUTO_EXTEND,
+        ttl: 30000,
+      }
+
+      // Call the function with the mock lock and task
+      const config = new DBTestConfiguration()
+      const result = await config.doInTenant(() =>
+        doWithLock(testOpts, async () => {
+          jest.advanceTimersByTime(Duration.fromSeconds(10).toMs())
+          jest.advanceTimersByTime(Duration.fromSeconds(10).toMs())
+          jest.advanceTimersByTime(Duration.fromSeconds(10).toMs())
+          return mockTask()
+        })
+      )
+
+      // Assert the result and verify function calls
+      expect(result.executed).toBe(true)
+      expect(result.executed && result.result).toBe("mockResult")
+      expect(mockTask).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/server/specs/openapi.json
+++ b/packages/server/specs/openapi.json
@@ -2152,7 +2152,7 @@
     "/applications/{appId}/publish": {
       "post": {
         "operationId": "appPublish",
-        "summary": "Unpublish an application",
+        "summary": "Publish an application",
         "tags": [
           "applications"
         ],

--- a/packages/server/specs/openapi.yaml
+++ b/packages/server/specs/openapi.yaml
@@ -1761,7 +1761,7 @@ paths:
   "/applications/{appId}/publish":
     post:
       operationId: appPublish
-      summary: Unpublish an application
+      summary: Publish an application
       tags:
         - applications
       parameters:

--- a/packages/types/src/sdk/locks.ts
+++ b/packages/types/src/sdk/locks.ts
@@ -22,7 +22,7 @@ export enum LockName {
   QUOTA_USAGE_EVENT = "quota_usage_event",
 }
 
-export interface LockOptions {
+export type LockOptions = {
   /**
    * The lock type determines which client to use
    */
@@ -37,10 +37,6 @@ export interface LockOptions {
    */
   name: LockName
   /**
-   * The ttl to auto-expire the lock if not unlocked manually
-   */
-  ttl: number
-  /**
    * The individual resource to lock. This is useful for locking around very specific identifiers, e.g. a document that is prone to conflicts
    */
   resource?: string
@@ -48,4 +44,15 @@ export interface LockOptions {
    * This is a system-wide lock - don't use tenancy in lock key
    */
   systemLock?: boolean
-}
+} & (
+  | {
+      /**
+       * The ttl to auto-expire the lock if not unlocked manually
+       */
+      ttl: number
+      type: Exclude<LockType, LockType.AUTO_EXTEND>
+    }
+  | {
+      type: LockType.AUTO_EXTEND
+    }
+)

--- a/packages/types/src/sdk/locks.ts
+++ b/packages/types/src/sdk/locks.ts
@@ -54,5 +54,6 @@ export type LockOptions = {
     }
   | {
       type: LockType.AUTO_EXTEND
+      onExtend?: () => void
     }
 )

--- a/packages/types/src/sdk/locks.ts
+++ b/packages/types/src/sdk/locks.ts
@@ -36,9 +36,9 @@ export interface LockOptions {
    */
   name: LockName
   /**
-   * The ttl to auto-expire the lock if not unlocked manually
+   * The ttl to auto-expire the lock if not unlocked manually. If undefined, the lock will be autoextending while the process is running.
    */
-  ttl: number
+  ttl?: number
   /**
    * The individual resource to lock. This is useful for locking around very specific identifiers, e.g. a document that is prone to conflicts
    */

--- a/packages/types/src/sdk/locks.ts
+++ b/packages/types/src/sdk/locks.ts
@@ -10,6 +10,7 @@ export enum LockType {
   DEFAULT = "default",
   DELAY_500 = "delay_500",
   CUSTOM = "custom",
+  AUTO_EXTEND = "auto_extend",
 }
 
 export enum LockName {
@@ -36,9 +37,9 @@ export interface LockOptions {
    */
   name: LockName
   /**
-   * The ttl to auto-expire the lock if not unlocked manually. If undefined, the lock will be autoextending while the process is running.
+   * The ttl to auto-expire the lock if not unlocked manually.
    */
-  ttl?: number
+  ttl: number
   /**
    * The individual resource to lock. This is useful for locking around very specific identifiers, e.g. a document that is prone to conflicts
    */

--- a/packages/types/src/sdk/locks.ts
+++ b/packages/types/src/sdk/locks.ts
@@ -37,7 +37,7 @@ export interface LockOptions {
    */
   name: LockName
   /**
-   * The ttl to auto-expire the lock if not unlocked manually.
+   * The ttl to auto-expire the lock if not unlocked manually
    */
   ttl: number
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -12667,16 +12667,16 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
-ioredis-mock@8.7.0:
-  version "8.7.0"
-  resolved "https://registry.yarnpkg.com/ioredis-mock/-/ioredis-mock-8.7.0.tgz#9877a85e0d233e1b49123d1c6e320df01e9a1d36"
-  integrity sha512-BJcSjkR3sIMKbH93fpFzwlWi/jl1kd5I3vLvGQxnJ/W/6bD2ksrxnyQN186ljAp3Foz4p1ivViDE3rZeKEAluA==
+ioredis-mock@8.9.0:
+  version "8.9.0"
+  resolved "https://registry.yarnpkg.com/ioredis-mock/-/ioredis-mock-8.9.0.tgz#5d694c4b81d3835e4291e0b527f947e260981779"
+  integrity sha512-yIglcCkI1lvhwJVoMsR51fotZVsPsSk07ecTCgRTRlicG0Vq3lke6aAaHklyjmRNRsdYAgswqC2A0bPtQK4LSw==
   dependencies:
     "@ioredis/as-callback" "^3.0.0"
     "@ioredis/commands" "^1.2.0"
     fengari "^0.1.4"
     fengari-interop "^0.1.3"
-    semver "^7.3.8"
+    semver "^7.5.4"
 
 ioredis@5.3.2:
   version "5.3.2"


### PR DESCRIPTION
## Description
Currently, we have some long running processes (such as migrations) that require locking, but we don't know for how long. Because of this we are locking these process with pretty long timeouts, but this can cause the following issues:
1. We might underestimate the task and lock less than the required time
2. If the process crash, the TTL will need to expire in order to be able to be repeated

This PR is allowing an extra configuration to our redis lock implementation that will allow long locks following the steps below:
1. Create the lock with the expected TTL (this could be any in this case)
2. Execute the task asynchronously
3. In parallel, periodically on TTL/2, extend the lock by TTL (it does not really extend the remaining ttl, it sets the TTL based on the current time)

This has the following benefits:

- If the process keeps running, the lock will be extended periodically
- If the process crashes, the lock will be released



## Feature branch env
[Feature Branch Link](http://fb-chore-allow-redis-without-ttl.fb.qa.budibase.net)