### PR TITLE
Update originalIndex on select

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionDrawer.svelte
@@ -147,6 +147,7 @@
 
   const selectAction = action => () => {
     selectedAction = action
+    originalActionIndex = actions.findIndex(item => item.id === action.id)
   }
 
   const onAddAction = actionType => {


### PR DESCRIPTION
## Description
Fix for issue with actions of the same eventHandlerType not re-drawing the selected action content.

## Addresses
- https://linear.app/budibase/issue/BUDI-7787/bug-regarding-2-seperate-save-row-actions
