### PR TITLE
Create migration context functions

### DIFF
--- a/packages/backend-core/src/context/mainContext.ts
+++ b/packages/backend-core/src/context/mainContext.ts
@@ -99,6 +99,8 @@ function updateContext(updates: ContextMap): ContextMap {
 }
 
 async function newContext<T>(updates: ContextMap, task: () => T) {
+  guardMigration()
+
   // see if there already is a context setup
   let context: ContextMap = updateContext(updates)
   return Context.run(context, task)
@@ -186,13 +188,22 @@ export async function doInIdentityContext<T>(
   return newContext(context, task)
 }
 
+function guardMigration() {
+  const context = Context.get()
+  if (context?.isMigrating) {
+    throw new Error(
+      "The context cannot be change, a migration is currently running"
+    )
+  }
+}
+
 export async function doInAppMigrationContext<T>(
   appId: string,
   task: () => T
 ): Promise<T> {
-    return _doInAppContext(appId, task, {
-      isMigrating: true,
-    })
+  return _doInAppContext(appId, task, {
+    isMigrating: true,
+  })
 }
 
 export function getIdentity(): IdentityContext | undefined {

--- a/packages/backend-core/src/context/mainContext.ts
+++ b/packages/backend-core/src/context/mainContext.ts
@@ -190,15 +190,9 @@ export async function doInAppMigrationContext<T>(
   appId: string,
   task: () => T
 ): Promise<T> {
-  try {
     return _doInAppContext(appId, task, {
       isMigrating: true,
     })
-  } finally {
-    updateContext({
-      isMigrating: undefined,
-    })
-  }
 }
 
 export function getIdentity(): IdentityContext | undefined {

--- a/packages/backend-core/src/context/mainContext.ts
+++ b/packages/backend-core/src/context/mainContext.ts
@@ -145,23 +145,19 @@ export async function doInTenant<T>(
 }
 
 export async function doInAppContext<T>(
-  appId: string | null,
+  appId: string,
   task: () => T
 ): Promise<T> {
-  if (!appId && !env.isTest()) {
+  if (!appId) {
     throw new Error("appId is required")
   }
 
-  let updates: ContextMap
-  if (!appId) {
-    updates = { appId: "" }
-  } else {
-    const tenantId = getTenantIDFromAppID(appId)
-    updates = { appId }
-    if (tenantId) {
-      updates.tenantId = tenantId
-    }
+  const tenantId = getTenantIDFromAppID(appId)
+  const updates: ContextMap = { appId }
+  if (tenantId) {
+    updates.tenantId = tenantId
   }
+
   return newContext(updates, task)
 }
 
@@ -180,6 +176,27 @@ export async function doInIdentityContext<T>(
     context.tenantId = identity.tenantId
   }
   return newContext(context, task)
+}
+
+export async function doInAppMigrationContext<T>(
+  appId: string,
+  task: () => T
+): Promise<T> {
+  if (!appId && !env.isTest()) {
+    throw new Error("appId is required")
+  }
+
+  let updates: ContextMap
+  if (!appId) {
+    updates = { appId: "" }
+  } else {
+    const tenantId = getTenantIDFromAppID(appId)
+    updates = { appId }
+    if (tenantId) {
+      updates.tenantId = tenantId
+    }
+  }
+  return newContext(updates, task)
 }
 
 export function getIdentity(): IdentityContext | undefined {

--- a/packages/backend-core/src/context/mainContext.ts
+++ b/packages/backend-core/src/context/mainContext.ts
@@ -192,7 +192,7 @@ function guardMigration() {
   const context = Context.get()
   if (context?.isMigrating) {
     throw new Error(
-      "The context cannot be change, a migration is currently running"
+      "The context cannot be changed, a migration is currently running"
     )
   }
 }

--- a/packages/backend-core/src/context/tests/index.spec.ts
+++ b/packages/backend-core/src/context/tests/index.spec.ts
@@ -179,5 +179,23 @@ describe("context", () => {
         expect(context).toEqual(expected)
       })
     })
+
+    it("the context is not modified outside the delegate", async () => {
+      const appId = db.generateAppID()
+
+      expect(Context.get()).toBeUndefined()
+
+      await context.doInAppMigrationContext(appId, () => {
+        const context = Context.get()
+
+        const expected: ContextMap = {
+          appId,
+          isMigrating: true,
+        }
+        expect(context).toEqual(expected)
+      })
+
+      expect(Context.get()).toBeUndefined()
+    })
   })
 })

--- a/packages/backend-core/src/context/tests/index.spec.ts
+++ b/packages/backend-core/src/context/tests/index.spec.ts
@@ -247,7 +247,7 @@ describe("context", () => {
             await otherContextCall()
           })
         ).rejects.toThrowError(
-          "The context cannot be change, a migration is currently running"
+          "The context cannot be changed, a migration is currently running"
         )
       }
     )

--- a/packages/backend-core/src/context/tests/index.spec.ts
+++ b/packages/backend-core/src/context/tests/index.spec.ts
@@ -1,6 +1,10 @@
 import { testEnv } from "../../../tests/extra"
 import * as context from "../"
 import { DEFAULT_TENANT_ID } from "../../constants"
+import { structures } from "../../../tests"
+import { db } from "../.."
+import Context from "../Context"
+import { ContextMap } from "../types"
 
 describe("context", () => {
   describe("doInTenant", () => {
@@ -142,6 +146,38 @@ describe("context", () => {
     it("returns false when not set", () => {
       const isScim = context.isScim()
       expect(isScim).toBe(false)
+    })
+  })
+
+  describe("doInAppMigrationContext", () => {
+    it("the context is set correctly", async () => {
+      const appId = db.generateAppID()
+
+      await context.doInAppMigrationContext(appId, () => {
+        const context = Context.get()
+
+        const expected: ContextMap = {
+          appId,
+          isMigrating: true,
+        }
+        expect(context).toEqual(expected)
+      })
+    })
+
+    it("the context is set correctly when running in a tenant id", async () => {
+      const tenantId = structures.tenant.id()
+      const appId = db.generateAppID(tenantId)
+
+      await context.doInAppMigrationContext(appId, () => {
+        const context = Context.get()
+
+        const expected: ContextMap = {
+          appId,
+          isMigrating: true,
+          tenantId,
+        }
+        expect(context).toEqual(expected)
+      })
     })
   })
 })

--- a/packages/backend-core/src/context/types.ts
+++ b/packages/backend-core/src/context/types.ts
@@ -8,4 +8,5 @@ export type ContextMap = {
   environmentVariables?: Record<string, string>
   isScim?: boolean
   automationId?: string
+  isMigrating?: boolean
 }

--- a/packages/server/src/tests/utilities/TestConfiguration.ts
+++ b/packages/server/src/tests/utilities/TestConfiguration.ts
@@ -137,6 +137,10 @@ class TestConfiguration {
   }
 
   getAppId() {
+    if (!this.appId) {
+      throw "appId has not been initialised properly"
+    }
+
     return this.appId
   }
 
@@ -510,7 +514,7 @@ class TestConfiguration {
     // create dev app
     // clear any old app
     this.appId = null
-    this.app = await context.doInAppContext(null, async () => {
+    this.app = await context.doInTenant(this.tenantId!, async () => {
       const app = await this._req(
         { name: appName },
         null,
@@ -519,7 +523,7 @@ class TestConfiguration {
       this.appId = app.appId!
       return app
     })
-    return await context.doInAppContext(this.appId, async () => {
+    return await context.doInAppContext(this.getAppId(), async () => {
       // create production app
       this.prodApp = await this.publish()
 
@@ -817,7 +821,7 @@ class TestConfiguration {
   }
 
   async getAutomationLogs() {
-    return context.doInAppContext(this.appId, async () => {
+    return context.doInAppContext(this.getAppId(), async () => {
       const now = new Date()
       return await pro.sdk.automations.logs.logSearch({
         startDate: new Date(now.getTime() - 100000).toISOString(),


### PR DESCRIPTION
## Description
Creating a new context.doInAppMigrationContext function that will be used for the new backend migrations. This function will be marking the context as migrating, and it will not allow starting any new context. We want to protect ourselves from any migration running in multiple databases or doing multiple db save, so we will be forcing this new function to be used in any migration script.