### PR TITLE
Prevent stale bot using default 60 days

### DIFF
--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
+          days-before-stale: 330
           operations-per-run: 1
           # stale rules for PRs
           days-before-pr-stale: 7


### PR DESCRIPTION
## Description
If you don't provide a `days-before-stale` attribute then the default of 60 will be used. 
Setting this to 330 in the PR stale bot, as the other bot runs handle the stale tags.

## Screenshots

![Screenshot 2023-12-01 at 13 32 00](https://github.com/Budibase/budibase/assets/101575380/d9c85cbd-f97f-4505-a1ee-95d45abf6994)

This was unintended because of the default value in the first stale bot run.