### PR TITLE
Fix a small typo in the example values.yaml file.

### DIFF
--- a/charts/budibase/README.md
+++ b/charts/budibase/README.md
@@ -87,6 +87,7 @@ couchdb:
     storageClass: "nfs-client"
   adminPassword: admin
 
+services:
   objectStore:
     storageClass: "nfs-client"
   redis:

--- a/charts/budibase/README.md.gotmpl
+++ b/charts/budibase/README.md.gotmpl
@@ -86,6 +86,7 @@ couchdb:
     storageClass: "nfs-client"
   adminPassword: admin
 
+services:
   objectStore:
     storageClass: "nfs-client"
   redis:


### PR DESCRIPTION

## Description

Noticed this while working on the Kubernetes docs over on docs.budibase.com.

## Feature branch env
[Feature Branch Link](http://fb-fix-typo-in-helm-readme.fb.qa.budibase.net)
