### PR TITLE
Expose /nginx_status on the proxy image for DataDog collection.

### DIFF
--- a/hosting/proxy/nginx.prod.conf
+++ b/hosting/proxy/nginx.prod.conf
@@ -249,4 +249,30 @@ http {
     gzip_comp_level 6;
     gzip_types text/plain text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
   }
+
+  # From https://docs.datadoghq.com/integrations/nginx/?tab=kubernetes
+  server {
+    listen 81;
+    server_name localhost;
+
+    access_log off;
+    allow 127.0.0.1;
+    deny all;
+
+    location /nginx_status {
+      # Choose your status module
+
+      # freely available with open source NGINX
+      stub_status;
+
+      # for open source NGINX < version 1.7.5
+      # stub_status on;
+
+      # available only with NGINX Plus
+      # status;
+
+      # ensures the version information can be retrieved
+      server_tokens on;
+    }
+  }
 }


### PR DESCRIPTION
## Description

I noticed that we aren't collecting proxy metrics in DataDog, so this is the first step on the way to doing that. It exposes a `/nginx_status` endpoint that exposes metrics that DataDog will be able to collect, and it locks that endpoint down to localhost only following the DataDog example in their docs.
