### PR TITLE
Support enum types in PostgreSQL and MySQL

### DIFF
--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -17,7 +17,7 @@ import {
 import {
   getSqlQuery,
   buildExternalTableId,
-  convertSqlType,
+  generateColumnDefinition,
   finaliseExternalTables,
   SqlClient,
   checkExternalTables,
@@ -429,15 +429,12 @@ class SqlServerIntegration extends Sql implements DatasourcePlus {
         const hasDefault = def.COLUMN_DEFAULT
         const isAuto = !!autoColumns.find(col => col === name)
         const required = !!requiredColumns.find(col => col === name)
-        schema[name] = {
+        schema[name] = generateColumnDefinition({
           autocolumn: isAuto,
-          name: name,
-          constraints: {
-            presence: required && !isAuto && !hasDefault,
-          },
-          ...convertSqlType(def.DATA_TYPE),
+          name,
+          presence: required && !isAuto && !hasDefault,
           externalType: def.DATA_TYPE,
-        }
+        })
       }
       tables[tableName] = {
         _id: buildExternalTableId(datasourceId, tableName),

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -12,6 +12,7 @@ import {
   SourceName,
   Schema,
   TableSourceType,
+  FieldType,
 } from "@budibase/types"
 import {
   getSqlQuery,
@@ -314,6 +315,17 @@ class MySQLIntegration extends Sql implements DatasourcePlus {
             constraints,
             ...convertSqlType(column.Type),
             externalType: column.Type,
+          }
+          // enum types in MySQL include the values
+          if (column.Type.startsWith("enum")) {
+            const enumValues = column.Type.substring(5, column.Type.length - 1)
+              .split(",")
+              .map(str => str.replace(/^'(.*)'$/, "$1"))
+            schema[columnName].type = FieldType.OPTIONS
+            schema[columnName].constraints = {
+              ...constraints,
+              inclusion: enumValues,
+            }
           }
         }
         if (!tables[tableName]) {

--- a/packages/server/src/integrations/oracle.ts
+++ b/packages/server/src/integrations/oracle.ts
@@ -15,7 +15,7 @@ import {
 import {
   buildExternalTableId,
   checkExternalTables,
-  convertSqlType,
+  generateColumnDefinition,
   finaliseExternalTables,
   getSqlQuery,
   SqlClient,
@@ -250,14 +250,6 @@ class OracleIntegration extends Sql implements DatasourcePlus {
     )
   }
 
-  private internalConvertType(column: OracleColumn) {
-    if (this.isBooleanType(column)) {
-      return { type: FieldTypes.BOOLEAN }
-    }
-
-    return convertSqlType(column.type)
-  }
-
   /**
    * Fetches the tables from the oracle table and assigns them to the datasource.
    * @param datasourceId - datasourceId to fetch
@@ -302,13 +294,15 @@ class OracleIntegration extends Sql implements DatasourcePlus {
           const columnName = oracleColumn.name
           let fieldSchema = table.schema[columnName]
           if (!fieldSchema) {
-            fieldSchema = {
+            fieldSchema = generateColumnDefinition({
               autocolumn: OracleIntegration.isAutoColumn(oracleColumn),
               name: columnName,
-              constraints: {
-                presence: false,
-              },
-              ...this.internalConvertType(oracleColumn),
+              presence: false,
+              externalType: oracleColumn.type,
+            })
+
+            if (this.isBooleanType(oracleColumn)) {
+              fieldSchema.type = FieldTypes.BOOLEAN
             }
 
             table.schema[columnName] = fieldSchema

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -16,7 +16,7 @@ import {
 import {
   getSqlQuery,
   buildExternalTableId,
-  convertSqlType,
+  generateColumnDefinition,
   finaliseExternalTables,
   SqlClient,
   checkExternalTables,
@@ -353,24 +353,13 @@ class PostgresIntegration extends Sql implements DatasourcePlus {
           column.is_generated && column.is_generated !== "NEVER"
         const isAuto: boolean = hasNextVal || identity || isGenerated
         const required = column.is_nullable === "NO"
-        const constraints = {
-          presence: required && !hasDefault && !isGenerated,
-        }
-        tables[tableName].schema[columnName] = {
+        tables[tableName].schema[columnName] = generateColumnDefinition({
           autocolumn: isAuto,
           name: columnName,
-          constraints,
-          ...convertSqlType(column.data_type),
+          presence: required && !hasDefault && !isGenerated,
           externalType: column.data_type,
-        }
-
-        // Add options
-        if (enumValues?.[column.udt_name]) {
-          tables[tableName].schema[columnName].constraints = {
-            ...constraints,
-            inclusion: enumValues[column.udt_name],
-          }
-        }
+          options: enumValues?.[column.udt_name],
+        })
       }
 
       let finalizedTables = finaliseExternalTables(tables, entities)

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -162,6 +162,14 @@ class PostgresIntegration extends Sql implements DatasourcePlus {
   WHERE pg_namespace.nspname = '${this.config.schema}';
   `
 
+  ENUM_VALUES = () => `
+  SELECT t.typname,  
+      e.enumlabel
+  FROM pg_type t 
+  JOIN pg_enum e on t.oid = e.enumtypid  
+  JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace;
+  `
+
   constructor(config: PostgresConfig) {
     super(SqlClient.POSTGRES)
     this.config = config
@@ -303,6 +311,18 @@ class PostgresIntegration extends Sql implements DatasourcePlus {
 
       const tables: { [key: string]: Table } = {}
 
+      // Fetch enum values
+      const enumsResponse = await this.client.query(this.ENUM_VALUES())
+      const enumValues = enumsResponse.rows?.reduce((acc, row) => {
+        if (!acc[row.typname]) {
+          return {
+            [row.typname]: [row.enumlabel],
+          }
+        }
+        acc[row.typname].push(row.enumlabel)
+        return acc
+      }, {})
+
       for (let column of columnsResponse.rows) {
         const tableName: string = column.table_name
         const columnName: string = column.column_name
@@ -342,6 +362,14 @@ class PostgresIntegration extends Sql implements DatasourcePlus {
           constraints,
           ...convertSqlType(column.data_type),
           externalType: column.data_type,
+        }
+
+        // Add options
+        if (enumValues[column.udt_name]) {
+          tables[tableName].schema[columnName].constraints = {
+            ...constraints,
+            inclusion: enumValues[column.udt_name],
+          }
         }
       }
 

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -365,7 +365,7 @@ class PostgresIntegration extends Sql implements DatasourcePlus {
         }
 
         // Add options
-        if (enumValues[column.udt_name]) {
+        if (enumValues?.[column.udt_name]) {
           tables[tableName].schema[columnName].constraints = {
             ...constraints,
             inclusion: enumValues[column.udt_name],

--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -183,12 +183,19 @@ export function breakRowIdField(_id: string | { _id: string }): any[] {
   }
 }
 
-export function convertSqlType(type: string) {
+export function generateColumnDefinition(config: {
+  externalType: string
+  autocolumn: boolean
+  name: string
+  presence: boolean
+  options?: string[]
+}) {
+  let { externalType, autocolumn, name, presence, options } = config
   let foundType = FieldType.STRING
-  const lcType = type.toLowerCase()
+  const lowerCaseType = externalType.toLowerCase()
   let matchingTypes = []
   for (let [external, internal] of Object.entries(SQL_TYPE_MAP)) {
-    if (lcType.includes(external)) {
+    if (lowerCaseType.includes(external)) {
       matchingTypes.push({ external, internal })
     }
   }
@@ -198,10 +205,27 @@ export function convertSqlType(type: string) {
       return acc.external.length >= val.external.length ? acc : val
     }).internal
   }
-  const schema: any = { type: foundType }
+
+  const constraints: {
+    presence: boolean
+    inclusion?: string[]
+  } = {
+    presence,
+  }
+  if (foundType === FieldType.OPTIONS) {
+    constraints.inclusion = options
+  }
+
+  const schema: any = {
+    type: foundType,
+    externalType,
+    autocolumn,
+    name,
+    constraints,
+  }
   if (foundType === FieldType.DATETIME) {
-    schema.dateOnly = SQL_DATE_ONLY_TYPES.includes(lcType)
-    schema.timeOnly = SQL_TIME_ONLY_TYPES.includes(lcType)
+    schema.dateOnly = SQL_DATE_ONLY_TYPES.includes(lowerCaseType)
+    schema.timeOnly = SQL_TIME_ONLY_TYPES.includes(lowerCaseType)
   }
   return schema
 }

--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -67,6 +67,10 @@ const SQL_BOOLEAN_TYPE_MAP = {
   tinyint: FieldType.BOOLEAN,
 }
 
+const SQL_OPTIONS_TYPE_MAP = {
+  "user-defined": FieldType.OPTIONS,
+}
+
 const SQL_MISC_TYPE_MAP = {
   json: FieldType.JSON,
   bigint: FieldType.BIGINT,
@@ -78,6 +82,7 @@ const SQL_TYPE_MAP = {
   ...SQL_STRING_TYPE_MAP,
   ...SQL_BOOLEAN_TYPE_MAP,
   ...SQL_MISC_TYPE_MAP,
+  ...SQL_OPTIONS_TYPE_MAP,
 }
 
 export enum SqlClient {
@@ -187,7 +192,7 @@ export function convertSqlType(type: string) {
       matchingTypes.push({ external, internal })
     }
   }
-  //Set the foundType based the longest match
+  // Set the foundType based the longest match
   if (matchingTypes.length > 0) {
     foundType = matchingTypes.reduce((acc, val) => {
       return acc.external.length >= val.external.length ? acc : val


### PR DESCRIPTION

## Description
Users wanted to import enum types as an option type in Budibase, with the available options already pre-populated.

I did check SQL Server, but there is no enum type for that database.

## Addresses
- https://github.com/Budibase/budibase/issues/3826

## Schemas used

MySQL:
```sql
CREATE TABLE tickets (
    id INT PRIMARY KEY AUTO_INCREMENT,
    title VARCHAR(255) NOT NULL,
    priority ENUM('Low', 'Medium', 'High') NOT NULL
);
```

Postgres:
```sql
CREATE TYPE color AS ENUM ('red', 'green', 'blue', 'yellow');

ALTER TABLE test
ADD COLUMN test_color color;
```

## Screenshots

MySQL:

![Screenshot 2023-12-06 at 11 36 22](https://github.com/Budibase/budibase/assets/101575380/c22f27f6-99da-4f11-a4dd-5690e65cc122)

![Screenshot 2023-12-06 at 11 36 43](https://github.com/Budibase/budibase/assets/101575380/aafc621e-625a-4db0-97dc-a9452f56764c)

Postgres:

![Screenshot 2023-12-06 at 11 37 28](https://github.com/Budibase/budibase/assets/101575380/9b11440a-29bd-4d92-8148-604a615c9197)

![Screenshot 2023-12-06 at 11 37 39](https://github.com/Budibase/budibase/assets/101575380/4953a80e-ca36-4ce3-a8d6-bec02af26215)

*Colours added after fetch*

## Feature branch env
[Feature Branch Link](http://fb-budi-1409-enum-type-in-postgresql.fb.qa.budibase.net)
