### PR TITLE
Give the build more memory as it's failing during the QA API tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "preinstall": "node scripts/syncProPackage.js",
     "setup": "git config submodule.recurse true && git submodule update && node ./hosting/scripts/setup.js && yarn && yarn build && yarn dev",
-    "build": "NODE_OPTIONS=--max-old-space-size=1500 lerna run build --stream",
+    "build": "NODE_OPTIONS=--max-old-space-size=2000 lerna run build --stream",
     "build:dev": "lerna run --stream prebuild && yarn nx run-many --target=build --output-style=dynamic --watch --preserveWatchOutput",
     "check:types": "lerna run check:types",
     "build:sdk": "lerna run --stream build:sdk",


### PR DESCRIPTION
## Description

@Mitch-Budibase is trying to fix our QA tests and hitting a problem where the build fails. The `@budibase/client` build fails with the message: `Killed` and an exit code of `137` and not much more information.

This is a bit of a hail Mary to see if it's a memory problem.
