### PR TITLE
Fix Grid Block Toggle Causing the label editing menu to open

### DIFF
--- a/packages/builder/src/components/design/settings/controls/GridColumnConfiguration/FieldSetting.svelte
+++ b/packages/builder/src/components/design/settings/controls/GridColumnConfiguration/FieldSetting.svelte
@@ -49,7 +49,15 @@
     <div class="field-label">{item.label || item.field}</div>
   </div>
   <div class="list-item-right">
-    <Toggle on:change={onToggle(item)} text="" value={item.active} thin />
+    <Toggle
+      on:click={e => {
+        e.stopPropagation()
+      }}
+      on:change={onToggle(item)}
+      text=""
+      value={item.active}
+      thin
+    />
   </div>
 </div>
 


### PR DESCRIPTION
## Description
Clicking the grid block configuration toggle buttons caused the menu to edit the label to pop up. Stopping event propagation fixes this.

https://linear.app/budibase/issue/BUDI-7819/grid-block-toggle-columns-causes-pop-over-to-appear