### PR TITLE
Prevent collapsed component settings sections reverting on component settings changes.

### DIFF
--- a/packages/bbui/src/DetailSummary/DetailSummary.svelte
+++ b/packages/bbui/src/DetailSummary/DetailSummary.svelte
@@ -1,20 +1,17 @@
 <script>
   import Icon from "../Icon/Icon.svelte"
-  import { createEventDispatcher } from "svelte"
 
   export let name
-  export let show = false
+  export let initiallyShow = false
   export let collapsible = true
 
-  const dispatch = createEventDispatcher()
+  let show = initiallyShow;
+
   const onHeaderClick = () => {
     if (!collapsible) {
       return
     }
     show = !show
-    if (show) {
-      dispatch("open")
-    }
   }
 </script>
 

--- a/packages/bbui/src/DetailSummary/DetailSummary.svelte
+++ b/packages/bbui/src/DetailSummary/DetailSummary.svelte
@@ -5,7 +5,7 @@
   export let initiallyShow = false
   export let collapsible = true
 
-  let show = initiallyShow;
+  let show = initiallyShow
 
   const onHeaderClick = () => {
     if (!collapsible) {

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ComponentSettingsSection.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ComponentSettingsSection.svelte
@@ -19,6 +19,8 @@
   export let includeHidden = false
   export let tag
 
+  let sections = []
+
   $: sections = getSections(
     componentInstance,
     componentDefinition,
@@ -32,10 +34,12 @@
     const generalSettings = settings.filter(
       setting => !setting.section && setting.tag === tag
     )
+
+    // object pointers getting copied here?
     const customSections = settings.filter(
       setting => setting.section && setting.tag === tag
     )
-    let sections = [
+    let newSections = [
       ...(generalSettings?.length
         ? [
             {
@@ -48,12 +52,13 @@
     ]
 
     // Filter out settings which shouldn't be rendered
-    sections.forEach(section => {
-      section.visible = shouldDisplay(instance, section)
-      if (!section.visible) {
+
+    newSections.forEach(newSection => {
+      newSection.visible = shouldDisplay(instance, newSection)
+      if (!newSection.visible) {
         return
       }
-      section.settings.forEach(setting => {
+      newSection.settings.forEach(setting => {
         setting.visible = canRenderControl(
           instance,
           setting,
@@ -61,12 +66,12 @@
           includeHidden
         )
       })
-      section.visible =
-        section.name === "General" ||
-        section.settings.some(setting => setting.visible)
+      newSection.visible =
+        newSection.name === "General" ||
+        newSection.settings.some(setting => setting.visible)
     })
 
-    return sections
+    return newSections
   }
 
   const updateSetting = async (setting, value) => {
@@ -151,7 +156,7 @@
   {#if section.visible}
     <DetailSummary
       name={showSectionTitle ? section.name : ""}
-      show={section.collapsed !== true}
+      initiallyShow={section.collapsed !== true}
     >
       {#if section.info}
         <div class="section-info">

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ComponentSettingsSection.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ComponentSettingsSection.svelte
@@ -19,8 +19,6 @@
   export let includeHidden = false
   export let tag
 
-  let sections = []
-
   $: sections = getSections(
     componentInstance,
     componentDefinition,

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ComponentSettingsSection.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ComponentSettingsSection.svelte
@@ -49,12 +49,12 @@
     ]
 
     // Filter out settings which shouldn't be rendered
-    sections.forEach(newSection => {
-      newSection.visible = shouldDisplay(instance, newSection)
-      if (!newSection.visible) {
+    sections.forEach(section => {
+      section.visible = shouldDisplay(instance, section)
+      if (!section.visible) {
         return
       }
-      newSection.settings.forEach(setting => {
+      section.settings.forEach(setting => {
         setting.visible = canRenderControl(
           instance,
           setting,
@@ -62,9 +62,9 @@
           includeHidden
         )
       })
-      newSection.visible =
-        newSection.name === "General" ||
-        newSection.settings.some(setting => setting.visible)
+      section.visible =
+        section.name === "General" ||
+        section.settings.some(setting => setting.visible)
     })
 
     return sections

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ComponentSettingsSection.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ComponentSettingsSection.svelte
@@ -36,7 +36,7 @@
     const customSections = settings.filter(
       setting => setting.section && setting.tag === tag
     )
-    let newSections = [
+    let sections = [
       ...(generalSettings?.length
         ? [
             {
@@ -49,7 +49,7 @@
     ]
 
     // Filter out settings which shouldn't be rendered
-    newSections.forEach(newSection => {
+    sections.forEach(newSection => {
       newSection.visible = shouldDisplay(instance, newSection)
       if (!newSection.visible) {
         return
@@ -67,7 +67,7 @@
         newSection.settings.some(setting => setting.visible)
     })
 
-    return newSections
+    return sections
   }
 
   const updateSetting = async (setting, value) => {

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ComponentSettingsSection.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ComponentSettingsSection.svelte
@@ -35,7 +35,6 @@
       setting => !setting.section && setting.tag === tag
     )
 
-    // object pointers getting copied here?
     const customSections = settings.filter(
       setting => setting.section && setting.tag === tag
     )
@@ -52,7 +51,6 @@
     ]
 
     // Filter out settings which shouldn't be rendered
-
     newSections.forEach(newSection => {
       newSection.visible = shouldDisplay(instance, newSection)
       if (!newSection.visible) {


### PR DESCRIPTION
## Description
Changing a component setting would uncollapse all collapsed sections, this should prevent that 

## Addresses
https://linear.app/budibase/issue/BUDI-7821/[-builder-]-settings-section-with-collapsed-true-collapses-with-every