### PR TITLE
Add another special case for the docker-compose variant of our CouchDB image.

### DIFF
--- a/hosting/couchdb/runner.sh
+++ b/hosting/couchdb/runner.sh
@@ -30,6 +30,13 @@ elif [[ "${TARGETBUILD}" = "single" ]]; then
     # mount, so we use that for all persistent data.
     sed -i "s#DATA_DIR#/data#g" /opt/clouseau/clouseau.ini
     sed -i "s#DATA_DIR#/data#g" /opt/couchdb/etc/local.ini
+elif [[ "${TARGETBUILD}" = "docker-compose" ]]; then
+    # We remove the database_dir and view_index_dir settings from the local.ini
+    # in docker-compose because it will default to /opt/couchdb/data which is what
+    # our docker-compose was using prior to us switching to using our own CouchDB
+    # image.
+    sed -i "s#^database_dir.*\$##g" /opt/couchdb/etc/local.ini
+    sed -i "s#^view_index_dir.*\$##g" /opt/couchdb/etc/local.ini
 elif [[ -n $KUBERNETES_SERVICE_HOST ]]; then
     # In Kubernetes the directory /opt/couchdb/data has a persistent volume
     # mount for storing database data.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,8 @@
     "pkg": "pkg . --out-path build --no-bytecode --public --public-packages \"*\" -C GZip",
     "build": "yarn prebuild && yarn rename && yarn tsc && yarn pkg && yarn postbuild",
     "check:types": "tsc -p tsconfig.json --noEmit --paths null",
-    "postbuild": "rm -rf prebuilds 2> /dev/null"
+    "postbuild": "rm -rf prebuilds 2> /dev/null",
+    "start": "ts-node ./src/index.ts"
   },
   "pkg": {
     "targets": [


### PR DESCRIPTION
## Description

This is in preparation for switching our docker-compose users over from `ibmcom/couchdb3` to `budibase/couchdb`. Because `ibmcom/couchdb3` uses the default data directory, and we mount a volume there in the `docker-compose.yaml`, this change makes the `budibase/couchdb` image also use the defaults when it detects it's running under docker-compose.

This will need a corresponding change to `hosting/docker-compose.yaml` that changes the image and also sets the environment variable `TARGETBUILD=docker-compose`.

In the long term, I think this approach to configuring CouchDB isn't going to scale nicely. It's already quite confusing. It would be nicer to find a way to make the image very neutral/default and then inject custom config in each environment.

This will require republishing `budibase/couchdb:v3.2.1`.
