### PR TITLE
Git ignore changes to improve searching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-builder/*
 .data/
 .temp/
 packages/server/runtime_apps/
@@ -41,8 +40,11 @@ bower_components
 build/Release
 
 # Dependency directories
-/node_modules/
 jspm_packages/
+*.min.js
+*.map
+node_modules/
+dist/
 
 # TypeScript v1 declaration files
 typings/


### PR DESCRIPTION
Some changes to the .gitignore that personally improve my dev experience, and possibly that of others depending on their setup.

If any of these would have unintended side effects/affect the build process in some way please let me know.

Currently I can't fuzzy find files in the builder package in vim from the root of the directory because builder/* is in the .gitignore, and fzf/ag fuzzy finder setup I have respects the current dirs .gitignore. I'm not sure why builder would be here in the first place, there could very well be a good reason.

Also added rules to catch stuff like minified js files, maps, dist folders and node_modules. None of this stuff was getting included by git anyway, but the these files were showing up in silver searcher results, and because they're all one line files the previews were tens of thousands of lines long and using my entire terminal line history.

