### PR TITLE
Fix Clouseau `dir` setting in Kube and docker-compose.

### DIFF
--- a/hosting/couchdb/runner.sh
+++ b/hosting/couchdb/runner.sh
@@ -37,10 +37,11 @@ elif [[ "${TARGETBUILD}" = "docker-compose" ]]; then
     # image.
     sed -i "s#^database_dir.*\$##g" /opt/couchdb/etc/local.ini
     sed -i "s#^view_index_dir.*\$##g" /opt/couchdb/etc/local.ini
+    sed -i "s#^dir=.*\$#dir=/opt/couchdb/data#g" /opt/clouseau/clouseau.ini
 elif [[ -n $KUBERNETES_SERVICE_HOST ]]; then
     # In Kubernetes the directory /opt/couchdb/data has a persistent volume
     # mount for storing database data.
-    sed -i "s#DATA_DIR#/opt/couchdb/data#g" /opt/clouseau/clouseau.ini
+    sed -i "s#^dir=.*\$#dir=/opt/couchdb/data#g" /opt/clouseau/clouseau.ini
 
     # We remove the database_dir and view_index_dir settings from the local.ini
     # in Kubernetes because it will default to /opt/couchdb/data which is what


### PR DESCRIPTION
## Description

I realise my previous changes didn't correctly maintain the directory that the IBM image stores Clouseau data. It stores it in `/opt/couchdb/data` directly alongside the CouchDB data.

As far as I can tell from my local testing, Clouseau reindexes if it finds it has no data saved to disk already, so this change should be fine.