### PR TITLE
Update docker-compose.yaml to use our CouchDB image instead of IBM's.

### DIFF
--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -69,7 +69,7 @@ services:
       MINIO_BROWSER: "off"
     command: server /data --console-address ":9001"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test: "timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1"
       interval: 30s
       timeout: 20s
       retries: 3

--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -57,7 +57,6 @@ services:
     depends_on:
       - redis-service
       - minio-service
-      - couch-init
 
   minio-service:
     restart: unless-stopped

--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -98,25 +98,14 @@ services:
 
   couchdb-service:
     restart: unless-stopped
-    image: ibmcom/couchdb3
+    image: budibase/couchdb:v3.2.1
+    pull_policy: always
     environment:
       - COUCHDB_PASSWORD=${COUCH_DB_PASSWORD}
       - COUCHDB_USER=${COUCH_DB_USER}
+      - TARGETBUILD=docker-compose
     volumes:
       - couchdb3_data:/opt/couchdb/data
-
-  couch-init:
-    image: curlimages/curl
-    environment:
-      PUT_CALL: "curl -u ${COUCH_DB_USER}:${COUCH_DB_PASSWORD} -X PUT couchdb-service:5984"
-    depends_on:
-      - couchdb-service
-    command:
-      [
-        "sh",
-        "-c",
-        "sleep 10 && $${PUT_CALL}/_users && $${PUT_CALL}/_replicator; fg;",
-      ]
 
   redis-service:
     restart: unless-stopped

--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -97,7 +97,7 @@ services:
 
   couchdb-service:
     restart: unless-stopped
-    image: budibase/couchdb:v3.2.1
+    image: budibase/couchdb
     pull_policy: always
     environment:
       - COUCHDB_PASSWORD=${COUCH_DB_PASSWORD}


### PR DESCRIPTION
## Description

This required a few changes to the CouchDB image which have been made in others PRs. This was in order to make sure that CouchDB is looking in the right places in the filesystem to make this the smoothest transition it can be.

When users upgrade to this using `budi hosting --update` it should Just Work™.

I was also able to get rid of the `couch-init` service because what it does now happens from within the CouchDB container.

I've also set the `pull_policy` for the CouchDB image to "always" because the label has historically been mutated.

## Addresses
- https://linear.app/budibase/issue/BUDI-7799/sqs-investigate-docker-compose-self-host-migration
- https://github.com/Budibase/budibase/issues/12526
