### PR TITLE
feat: use /storage as data_dir for aas builds

### DIFF
--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -22,7 +22,7 @@ declare -a DOCKER_VARS=("APP_PORT" "APPS_URL" "ARCHITECTURE" "BUDIBASE_ENVIRONME
 
 # Azure App Service customisations
 if [[ "${TARGETBUILD}" = "aas" ]]; then
-    export DATA_DIR="${DATA_DIR:-/home}"
+    export DATA_DIR="${DATA_DIR:-/storage}"
     WEBSITES_ENABLE_APP_SERVICE_STORAGE=true
     /etc/init.d/ssh start
 else


### PR DESCRIPTION
## Description
This is a workaround for the `budibase/budibase-aas` image in order to avoid the API restriction that Azure App Service has for mounting external storage to `/home` when a service is created through their client API.