### PR TITLE
Fix run dev:all 

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,6 +7,7 @@
     "packages/account-portal/packages/*"
   ],
   "useNx": true,
+  "concurrency": 20,
   "command": {
     "publish": {
       "ignoreChanges": [


### PR DESCRIPTION
## Description
Increasing lerna concurrency in order to run all the dev scripts properly. Without this, we are running into issues where `yarn dev:all` is not running the worker