### PR TITLE
Chore - Ensure .env is created properly for dev

### DIFF
--- a/packages/server/scripts/dev/manage.js
+++ b/packages/server/scripts/dev/manage.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 const compose = require("docker-compose")
 const path = require("path")
-const fs = require("fs")
+const { parsed: existingConfig } = require("dotenv").config()
+const updateDotEnv = require("update-dotenv")
 
 // This script wraps docker-compose allowing you to manage your dev infrastructure with simple commands.
 const CONFIG = {
@@ -17,45 +18,41 @@ const Commands = {
 }
 
 async function init() {
-  const envFilePath = path.join(process.cwd(), ".env")
-  if (!fs.existsSync(envFilePath)) {
-    const envFileJson = {
-      PORT: 4001,
-      MINIO_URL: "http://localhost:4004",
-      COUCH_DB_URL: "http://budibase:budibase@localhost:4005",
-      REDIS_URL: "localhost:6379",
-      WORKER_URL: "http://localhost:4002",
-      INTERNAL_API_KEY: "budibase",
-      ACCOUNT_PORTAL_URL: "http://localhost:10001",
-      ACCOUNT_PORTAL_API_KEY: "budibase",
-      PLATFORM_URL: "http://localhost:10000",
-      JWT_SECRET: "testsecret",
-      ENCRYPTION_KEY: "testsecret",
-      REDIS_PASSWORD: "budibase",
-      MINIO_ACCESS_KEY: "budibase",
-      MINIO_SECRET_KEY: "budibase",
-      COUCH_DB_PASSWORD: "budibase",
-      COUCH_DB_USER: "budibase",
-      SELF_HOSTED: 1,
-      DISABLE_ACCOUNT_PORTAL: 1,
-      MULTI_TENANCY: "",
-      DISABLE_THREADING: 1,
-      SERVICE: "app-service",
-      DEPLOYMENT_ENVIRONMENT: "development",
-      BB_ADMIN_USER_EMAIL: "",
-      BB_ADMIN_USER_PASSWORD: "",
-      PLUGINS_DIR: "",
-      TENANT_FEATURE_FLAGS: "*:LICENSING,*:USER_GROUPS,*:ONBOARDING_TOUR",
-      HTTP_MIGRATIONS: "0",
-      HTTP_LOGGING: "0",
-      VERSION: "0.0.0+local",
-    }
-    let envFile = ""
-    Object.keys(envFileJson).forEach(key => {
-      envFile += `${key}=${envFileJson[key]}\n`
-    })
-    fs.writeFileSync(envFilePath, envFile)
+  let config = {
+    PORT: "4001",
+    MINIO_URL: "http://localhost:4004",
+    COUCH_DB_URL: "http://budibase:budibase@localhost:4005",
+    REDIS_URL: "localhost:6379",
+    WORKER_URL: "http://localhost:4002",
+    INTERNAL_API_KEY: "budibase",
+    ACCOUNT_PORTAL_URL: "http://localhost:10001",
+    ACCOUNT_PORTAL_API_KEY: "budibase",
+    PLATFORM_URL: "http://localhost:10000",
+    JWT_SECRET: "testsecret",
+    ENCRYPTION_KEY: "testsecret",
+    REDIS_PASSWORD: "budibase",
+    MINIO_ACCESS_KEY: "budibase",
+    MINIO_SECRET_KEY: "budibase",
+    COUCH_DB_PASSWORD: "budibase",
+    COUCH_DB_USER: "budibase",
+    SELF_HOSTED: "1",
+    DISABLE_ACCOUNT_PORTAL: "1",
+    MULTI_TENANCY: "",
+    DISABLE_THREADING: "1",
+    SERVICE: "app-service",
+    DEPLOYMENT_ENVIRONMENT: "development",
+    BB_ADMIN_USER_EMAIL: "",
+    BB_ADMIN_USER_PASSWORD: "",
+    PLUGINS_DIR: "",
+    TENANT_FEATURE_FLAGS: "*:LICENSING,*:USER_GROUPS,*:ONBOARDING_TOUR",
+    HTTP_MIGRATIONS: "0",
+    HTTP_LOGGING: "0",
+    VERSION: "0.0.0+local",
   }
+
+  config = { ...config, ...existingConfig }
+
+  await updateDotEnv(config)
 }
 
 async function up() {

--- a/packages/worker/scripts/dev/manage.js
+++ b/packages/worker/scripts/dev/manage.js
@@ -1,44 +1,40 @@
 #!/usr/bin/env node
-const path = require("path")
-const fs = require("fs")
+const { parsed: existingConfig } = require("dotenv").config()
+const updateDotEnv = require("update-dotenv")
 
 async function init() {
-  const envFilePath = path.join(process.cwd(), ".env")
-  if (!fs.existsSync(envFilePath)) {
-    const envFileJson = {
-      SELF_HOSTED: 1,
-      PORT: 4002,
-      CLUSTER_PORT: 10000,
-      JWT_SECRET: "testsecret",
-      INTERNAL_API_KEY: "budibase",
-      MINIO_ACCESS_KEY: "budibase",
-      MINIO_SECRET_KEY: "budibase",
-      REDIS_URL: "localhost:6379",
-      REDIS_PASSWORD: "budibase",
-      MINIO_URL: "http://localhost:4004",
-      COUCH_DB_URL: "http://budibase:budibase@localhost:4005",
-      COUCH_DB_USERNAME: "budibase",
-      COUCH_DB_PASSWORD: "budibase",
-      // empty string is false
-      MULTI_TENANCY: "",
-      DISABLE_ACCOUNT_PORTAL: 1,
-      ACCOUNT_PORTAL_URL: "http://localhost:10001",
-      ACCOUNT_PORTAL_API_KEY: "budibase",
-      PLATFORM_URL: "http://localhost:10000",
-      APPS_URL: "http://localhost:4001",
-      SERVICE: "worker-service",
-      DEPLOYMENT_ENVIRONMENT: "development",
-      TENANT_FEATURE_FLAGS: "*:LICENSING,*:USER_GROUPS,*:ONBOARDING_TOUR",
-      ENABLE_EMAIL_TEST_MODE: 1,
-      HTTP_LOGGING: 0,
-      VERSION: "0.0.0+local",
-    }
-    let envFile = ""
-    Object.keys(envFileJson).forEach(key => {
-      envFile += `${key}=${envFileJson[key]}\n`
-    })
-    fs.writeFileSync(envFilePath, envFile)
+  let config = {
+    SELF_HOSTED: "1",
+    PORT: "4002",
+    CLUSTER_PORT: "10000",
+    JWT_SECRET: "testsecret",
+    INTERNAL_API_KEY: "budibase",
+    MINIO_ACCESS_KEY: "budibase",
+    MINIO_SECRET_KEY: "budibase",
+    REDIS_URL: "localhost:6379",
+    REDIS_PASSWORD: "budibase",
+    MINIO_URL: "http://localhost:4004",
+    COUCH_DB_URL: "http://budibase:budibase@localhost:4005",
+    COUCH_DB_USERNAME: "budibase",
+    COUCH_DB_PASSWORD: "budibase",
+    // empty string is false
+    MULTI_TENANCY: "",
+    DISABLE_ACCOUNT_PORTAL: "1",
+    ACCOUNT_PORTAL_URL: "http://localhost:10001",
+    ACCOUNT_PORTAL_API_KEY: "budibase",
+    PLATFORM_URL: "http://localhost:10000",
+    APPS_URL: "http://localhost:4001",
+    SERVICE: "worker-service",
+    DEPLOYMENT_ENVIRONMENT: "development",
+    TENANT_FEATURE_FLAGS: "*:LICENSING,*:USER_GROUPS,*:ONBOARDING_TOUR",
+    ENABLE_EMAIL_TEST_MODE: "1",
+    HTTP_LOGGING: "0",
+    VERSION: "0.0.0+local",
   }
+
+  config = { ...config, ...existingConfig }
+
+  await updateDotEnv(config)
 }
 
 // if more than init required use this to determine the command type


### PR DESCRIPTION
## Description
The current dev .env file is checked on dev run, checking if the .env file exists. If it does, nothing gets created. This is causing the following issues:
1. If another process (for example `yarn mode:account`) creates this file before the dev command, this file gets created but without the expected dev content
2. If a new value is added on the dev default values, it never gets applied until the `.env` file is manually deleted

This PR is changing the dev script to add any missing key, but respecting the existing values in the `.env` file