### PR TITLE
Improving writethrough cache typing and removing useless log statement

### DIFF
--- a/packages/backend-core/src/cache/tests/writethrough.spec.ts
+++ b/packages/backend-core/src/cache/tests/writethrough.spec.ts
@@ -1,14 +1,15 @@
 import { DBTestConfiguration } from "../../../tests/extra"
-import {
-  structures,
-  expectFunctionWasCalledTimesWith,
-  mocks,
-} from "../../../tests"
+import { structures } from "../../../tests"
 import { Writethrough } from "../writethrough"
 import { getDB } from "../../db"
+import { Document } from "@budibase/types"
 import tk from "timekeeper"
 
 tk.freeze(Date.now())
+
+interface ValueDoc extends Document {
+  value: any
+}
 
 const DELAY = 5000
 
@@ -117,7 +118,7 @@ describe("writethrough", () => {
   describe("get", () => {
     it("should be able to retrieve", async () => {
       await config.doInTenant(async () => {
-        const response = await writethrough.get(docId)
+        const response = await writethrough.get<ValueDoc>(docId)
         expect(response.value).toBe(4)
       })
     })

--- a/packages/backend-core/src/cache/writethrough.ts
+++ b/packages/backend-core/src/cache/writethrough.ts
@@ -84,16 +84,16 @@ async function put(
   return { ok: true, id: output._id, rev: output._rev }
 }
 
-async function get(db: Database, id: string): Promise<any> {
+async function get<T extends Document>(db: Database, id: string): Promise<T> {
   const cache = await getCache()
   const cacheKey = makeCacheKey(db, id)
   let cacheItem: CacheItem = await cache.get(cacheKey)
   if (!cacheItem) {
-    const doc = await db.get(id)
+    const doc = await db.get<T>(id)
     cacheItem = makeCacheItem(doc)
     await cache.store(cacheKey, cacheItem)
   }
-  return cacheItem.doc
+  return cacheItem.doc as T
 }
 
 async function remove(db: Database, docOrId: any, rev?: any): Promise<void> {
@@ -123,8 +123,8 @@ export class Writethrough {
     return put(this.db, doc, writeRateMs)
   }
 
-  async get(id: string) {
-    return get(this.db, id)
+  async get<T extends Document>(id: string) {
+    return get<T>(this.db, id)
   }
 
   async remove(docOrId: any, rev?: any) {

--- a/packages/backend-core/src/redis/redlockImpl.ts
+++ b/packages/backend-core/src/redis/redlockImpl.ts
@@ -137,7 +137,6 @@ export async function doWithLock<T>(
     const result = await task()
     return { executed: true, result }
   } catch (e: any) {
-    logWarn(`lock type: ${opts.type} error`, e)
     // lock limit exceeded
     if (e.name === "LockError") {
       if (opts.type === LockType.TRY_ONCE) {


### PR DESCRIPTION
## Description
Improving types around the writethrough cache, exposing the proper typing from the database and removing a log statement which is useless, errors are correctly propagated if they matter (and handled above this level with proper context) or in the 99% scenario it is not a real error (such as try once locks already being held) and a log is just spammy.

There is also a pro component to this: https://github.com/Budibase/budibase-pro/pull/246