### PR TITLE
Rename automation worker container.

### DIFF
--- a/charts/budibase/templates/automation-worker-service-deployment.yaml
+++ b/charts/budibase/templates/automation-worker-service-deployment.yaml
@@ -216,7 +216,7 @@ spec:
             {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- end }}
-        name: bbapps
+        name: bbautomationworker
         ports:
         - containerPort: {{ .Values.services.automationWorkers.port }}
         {{ with .Values.services.automationWorkers.resources }}


### PR DESCRIPTION
## Description

From `bbapps` to `bbautomationworker` to differentiate it from the apps pods.
