### PR TITLE
Allow cluster internal traffic to hit the nginx status endpoint.

### DIFF
--- a/hosting/proxy/nginx.prod.conf
+++ b/hosting/proxy/nginx.prod.conf
@@ -257,6 +257,7 @@ http {
 
     access_log off;
     allow 127.0.0.1;
+    allow 10.0.0.0/8;
     deny all;
 
     location /nginx_status {


### PR DESCRIPTION
## Description

DataDog is currently unable to hit the nginx status endpoint because it doesn't originate from the loopback address. Adding `10.0.0.0/8` to the allow list for port 81 on our nginx pod to rectify this.
