### PR TITLE
Optimise the performance of Writethrough.put.

### DIFF
--- a/packages/backend-core/src/cache/writethrough.ts
+++ b/packages/backend-core/src/cache/writethrough.ts
@@ -56,11 +56,8 @@ async function put(
         const writeDb = async (toWrite: any) => {
           // doc should contain the _id and _rev
           const response = await db.put(toWrite, { force: true })
-          output = {
-            ...doc,
-            _id: response.id,
-            _rev: response.rev,
-          }
+          output._id = response.id
+          output._rev = response.rev
         }
         try {
           await writeDb(doc)


### PR DESCRIPTION
## Description

This one is a bit more speculative than https://github.com/Budibase/budibase/pull/12580 but as far as I can tell, this full object copy via the spread operator is not necessary.

I did run some tests locally to show that the spread operator takes time proportional to the size of the object, and it appears that it does. However, I had to use very large objects for it to be a noticeable amount of time.

## Profile showing this to be slow

![CleanShot 2023-12-14 at 16 21 43@2x](https://github.com/Budibase/budibase/assets/338027/3cf564f4-18ea-429b-9e6e-aac547fe7e4e)

