### PR TITLE
Tell a user if their JS failed due to a timeout.

### DIFF
--- a/packages/string-templates/src/helpers/javascript.js
+++ b/packages/string-templates/src/helpers/javascript.js
@@ -56,6 +56,7 @@ module.exports.processJS = (handlebars, context) => {
     const res = { data: runJS(js, sandboxContext) }
     return `{{${LITERAL_MARKER} js_result-${JSON.stringify(res)}}}`
   } catch (error) {
+    console.log(`JS error: ${typeof error} ${JSON.stringify(error)}`)
     if (error.code === "ERR_SCRIPT_EXECUTION_TIMEOUT") {
       return "Timed out while executing JS"
     }

--- a/packages/string-templates/src/helpers/javascript.js
+++ b/packages/string-templates/src/helpers/javascript.js
@@ -56,6 +56,9 @@ module.exports.processJS = (handlebars, context) => {
     const res = { data: runJS(js, sandboxContext) }
     return `{{${LITERAL_MARKER} js_result-${JSON.stringify(res)}}}`
   } catch (error) {
+    if (error.code === "ERR_SCRIPT_EXECUTION_TIMEOUT") {
+      return "Timed out while executing JS"
+    }
     return "Error while executing JS"
   }
 }

--- a/packages/string-templates/test/javascript.spec.js
+++ b/packages/string-templates/test/javascript.spec.js
@@ -114,7 +114,7 @@ describe("Test the JavaScript helper", () => {
 
   it("should timeout after one second", () => {
     const output = processJS(`while (true) {}`)
-    expect(output).toBe("Error while executing JS")
+    expect(output).toBe("Timed out while executing JS")
   })
 
   it("should prevent access to the process global", () => {


### PR DESCRIPTION
## Description

If a JS execution times out, let the user know instead of using the generic "Error while executing JS".
