### PR TITLE
[Fix] Wrong string literals (new plans)

### DIFF
--- a/packages/builder/src/pages/builder/portal/account/auditLogs/index.svelte
+++ b/packages/builder/src/pages/builder/portal/account/auditLogs/index.svelte
@@ -257,7 +257,7 @@
 
 <LockedFeature
   title={"Audit Logs"}
-  planType={"Business plan"}
+  planType={"Enterprise plan"}
   description={"View all events that have occurred in your Budibase installation"}
   enabled={$licensing.auditLogsEnabled}
   upgradeButtonClick={async () => {

--- a/packages/builder/src/pages/builder/portal/account/usage.svelte
+++ b/packages/builder/src/pages/builder/portal/account/usage.svelte
@@ -15,6 +15,7 @@
   import { DashCard, Usage } from "components/usage"
   import { PlanModel } from "constants"
   import { sdk } from "@budibase/shared-core"
+  import { PlanType } from "@budibase/types"
 
   let staticUsage = []
   let monthlyUsage = []
@@ -106,7 +107,14 @@
   }
 
   const planTitle = () => {
-    return `${capitalise(license?.plan.type)} Plan`
+    const planType = license?.plan.type
+    let planName = license?.plan.type
+    if (planType === PlanType.PREMIUM_PLUS) {
+      planName = "Premium"
+    } else if (planType === PlanType.ENTERPRISE_BASIC) {
+      planName = "Enterprise"
+    }
+    return `${capitalise(planName)} Plan`
   }
 
   const getDaysRemaining = timestamp => {

--- a/packages/builder/src/pages/builder/portal/settings/auth/index.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/auth/index.svelte
@@ -283,7 +283,7 @@
         </div>
         {#if !$licensing.enforceableSSO}
           <Tags>
-            <Tag icon="LockClosed">Enterprise</Tag>
+            <Tag icon="LockClosed">Enterprise plan</Tag>
           </Tags>
         {/if}
       </div>

--- a/packages/builder/src/pages/builder/portal/settings/environment/index.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/environment/index.svelte
@@ -59,7 +59,7 @@
 
 <LockedFeature
   title={"Environment Variables"}
-  planType={"Business plan"}
+  planType={"Enterprise plan"}
   description={"Add and manage environment variables for development and production"}
   enabled={$licensing.environmentVariablesEnabled}
   upgradeButtonClick={async () => {


### PR DESCRIPTION
## Description

- Avoid BUSINESS plan usage in string literals.
- Change PREMIUM_PLUS by PREMIUM
- Change ENTERPRISE_BASIC by ENTERPRISE

## Addresses

https://linear.app/budibase/issue/GROW-263/wrong-string-literals-used-in-account-portal
