### PR TITLE
[CI] Don't check submodule refs for oss references

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -204,7 +204,7 @@ jobs:
 
   check-pro-submodule:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'Budibase/budibase'
+    if: inputs.run_as_oss != true  && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'Budibase/budibase')
     steps:
       - name: Checkout repo and submodules
         uses: actions/checkout@v3
@@ -254,7 +254,7 @@ jobs:
 
   check-accountportal-submodule:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'Budibase/budibase'
+    if: inputs.run_as_oss != true  && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'Budibase/budibase')
     steps:
       - name: Checkout repo and submodules
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description
Removing submodule checks on OSS schedule checks. We added these OSS contributor checks a few weeks ago and we are getting some noise of submodule refs not being up to date. These should not be part of these checks, so we are disabling it to reduce noise