### PR TITLE
Optimise getLinkDocuments

### DIFF
--- a/packages/server/src/db/linkedRows/linkUtils.ts
+++ b/packages/server/src/db/linkedRows/linkUtils.ts
@@ -56,7 +56,7 @@ export async function getLinkDocuments(args: {
   try {
     let linkRows = (await db.query(getQueryIndex(ViewName.LINK), params)).rows
     // filter to get unique entries
-    const foundIds: string[] = []
+    const foundIds = new Set()
     linkRows = linkRows.filter(link => {
       // make sure anything unique is the correct key
       if (
@@ -65,9 +65,9 @@ export async function getLinkDocuments(args: {
       ) {
         return false
       }
-      const unique = foundIds.indexOf(link.id) === -1
+      const unique = !foundIds.has(link.id)
       if (unique) {
-        foundIds.push(link.id)
+        foundIds.add(link.id)
       }
       return unique
     })


### PR DESCRIPTION
## Description

Took a look at the Budicloud profiling over the weekend and `getLinkDocuments` was a significant portion of CPU usage.

![CleanShot 2023-12-18 at 09 22 27@2x](https://github.com/Budibase/budibase/assets/338027/7396523b-8485-44ba-ba7a-d9b3758e8080)

I suspect it's the `foundIds` scan inside the filter loop, so I've replaced that with a `Set`.