### PR TITLE
Update dd-trace to 4.20.0.

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -65,7 +65,7 @@
     "cookies": "0.8.0",
     "csvtojson": "2.0.10",
     "curlconverter": "3.21.0",
-    "dd-trace": "3.13.2",
+    "dd-trace": "4.20.0",
     "dotenv": "8.2.0",
     "form-data": "4.0.0",
     "global-agent": "3.0.0",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -48,7 +48,7 @@
     "bcrypt": "5.1.0",
     "bcryptjs": "2.4.3",
     "bull": "4.10.1",
-    "dd-trace": "3.13.2",
+    "dd-trace": "4.20.0",
     "dotenv": "8.6.0",
     "global-agent": "3.0.0",
     "ical-generator": "4.1.0",


### PR DESCRIPTION
This is a little bit of a Hail Mary because we're also seeing this bug: https://github.com/DataDog/dd-trace-js/issues/3866#issuecomment-1858912462. I'm skeptical this will work, but I think it's worth a try. Plus updating stuff is good practice.

I didn't go to the latest, 4.21.0, because of this: https://github.com/DataDog/dd-trace-js/issues/3887.