### PR TITLE
Set `--enable-source-maps` when running Node.

### DIFF
--- a/packages/server/nodemon.json
+++ b/packages/server/nodemon.json
@@ -9,5 +9,5 @@
   ],
   "ext": "js,ts,json",
   "ignore": ["src/**/*.spec.ts", "src/**/*.spec.js", "../*/dist/**/*"],
-  "exec": "yarn build && node ./dist/index.js"
+  "exec": "yarn build && node --enable-source-maps ./dist/index.js"
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -18,7 +18,7 @@
     "test": "bash scripts/test.sh",
     "test:memory": "jest --maxWorkers=2 --logHeapUsage --forceExit",
     "test:watch": "jest --watch",
-    "run:docker": "node dist/index.js",
+    "run:docker": "node --enable-source-maps dist/index.js",
     "run:docker:cluster": "pm2-runtime start pm2.config.js",
     "dev:stack:up": "node scripts/dev/manage.js up",
     "dev:stack:down": "node scripts/dev/manage.js down",

--- a/packages/worker/nodemon.json
+++ b/packages/worker/nodemon.json
@@ -9,5 +9,5 @@
   ],
   "ext": "js,ts,json",
   "ignore": ["src/**/*.spec.ts", "src/**/*.spec.js", "../*/dist/**/*"],
-  "exec": "yarn build && node dist/index.js"
+  "exec": "yarn build && node --enable-source-maps dist/index.js"
 }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -17,7 +17,7 @@
     "postbuild": "copyfiles -f ../../yarn.lock ./dist/",
     "check:types": "tsc -p tsconfig.json --noEmit --paths null",
     "build:dev": "yarn prebuild && tsc --build --watch --preserveWatchOutput",
-    "run:docker": "node dist/index.js",
+    "run:docker": "node --enable-source-maps dist/index.js",
     "debug": "yarn build && node --expose-gc --inspect=9223 dist/index.js",
     "run:docker:cluster": "pm2-runtime start pm2.config.js",
     "dev:stack:init": "node ./scripts/dev/manage.js init",


### PR DESCRIPTION
## Description

Docs: https://nodejs.org/docs/latest-v18.x/api/cli.html#--enable-source-maps

This will make stack traces much easier to read, and crucially it will allow DataDog to more accurately report on where problems are occurring in our code.

The docs do point out that this has a performance impact when printing out stack traces, and there are some bugs from the Node 14 days complaining that this was a significant performance impact, but I'd like to try it. If it's really bad, we can turn it back off.