### PR TITLE
Support both presence constraint variants

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ValidationEditor/ValidationDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/ValidationEditor/ValidationDrawer.svelte
@@ -164,7 +164,8 @@
     // Required constraint
     if (
       field === dataSourceSchema?.table?.primaryDisplay ||
-      constraints.presence?.allowEmpty === false
+      constraints.presence?.allowEmpty === false ||
+      constraints.presence === true
     ) {
       rules.push({
         constraint: "required",

--- a/packages/client/src/components/app/forms/validation.js
+++ b/packages/client/src/components/app/forms/validation.js
@@ -23,7 +23,8 @@ export const createValidatorFromConstraints = (
     // Required constraint
     if (
       field === table?.primaryDisplay ||
-      schemaConstraints.presence?.allowEmpty === false
+      schemaConstraints.presence?.allowEmpty === false ||
+      schemaConstraints.presence === true
     ) {
       rules.push({
         type: schemaConstraints.type == "array" ? "array" : "string",


### PR DESCRIPTION
## Description
Required fields were not being mapped from PostgreSQL tables. 

I noticed that in the `FieldConstraints` interface (https://github.com/Budibase/budibase/blob/master/packages/types/src/documents/app/table/schema.ts#L120) the presence constraint could either be an object or a boolean, therefore I have updated the validation code to factor in both variants.

## Addresses
- https://github.com/Budibase/budibase/issues/11773

## Screenshots
![Screenshot 2023-12-19 at 10 57 21](https://github.com/Budibase/budibase/assets/101575380/c00e6c96-7765-4b24-8439-85487e840f7a)

![Screenshot 2023-12-19 at 10 57 55](https://github.com/Budibase/budibase/assets/101575380/78c0edb8-5488-4448-9ace-05aae3278be5)

![Screenshot 2023-12-19 at 10 58 17](https://github.com/Budibase/budibase/assets/101575380/315b6b5c-3647-4df3-b991-c26c7b7bca4b)

