### PR TITLE
Manually inject DataDog trace context to log messages.

### DIFF
--- a/packages/backend-core/src/logging/pino/logger.ts
+++ b/packages/backend-core/src/logging/pino/logger.ts
@@ -5,6 +5,8 @@ import { IdentityType } from "@budibase/types"
 import env from "../../environment"
 import * as context from "../../context"
 import * as correlation from "../correlation"
+import tracer from "dd-trace"
+import { formats } from "dd-trace/ext"
 
 import { localFileDestination } from "../system"
 
@@ -113,6 +115,11 @@ if (!env.DISABLE_PINO_LOGGER) {
       identityId: identity?._id,
       identityType: identity?.type,
       correlationId: correlation.getId(),
+    }
+
+    const span = tracer.scope().active()
+    if (span) {
+      tracer.inject(span.context(), formats.LOG, contextObject)
     }
 
     const mergingObject: any = {


### PR DESCRIPTION
## Description

Following the guide here: https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/nodejs/#manual-injection.

I'm not sure why, but setting `DD_LOGS_INJECTION=true` isn't injecting a trace ID into our log messages, which means we don't have traces and logs linking up together. Having this would give us more information to work with when looking at tracers, so I'd like to get it working.
