### PR TITLE
Allow the specifying of custom command and args values in Helm chart.

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -244,4 +244,12 @@ spec:
       {{ end }}
       restartPolicy: Always
       serviceAccountName: ""
+      {{ if .Values.services.apps.command }}
+      command:
+      {{- toYaml .Values.services.apps.command | nindent 8 }}
+      {{ end }}
+      {{ if .Values.services.apps.args }}
+      args:
+      {{- toYaml .Values.services.apps.args | nindent 8 }}
+      {{ end }}
 status: {}

--- a/charts/budibase/templates/automation-worker-service-deployment.yaml
+++ b/charts/budibase/templates/automation-worker-service-deployment.yaml
@@ -244,5 +244,13 @@ spec:
       {{ end }}
       restartPolicy: Always
       serviceAccountName: ""
+      {{ if .Values.services.automationWorkers.command }}}
+      command:
+      {{- toYaml .Values.services.automationWorkers.command | nindent 8 }}
+      {{ end }}
+      {{ if .Values.services.automationWorkers.args }}
+      args:
+      {{- toYaml .Values.services.automationWorkers.args | nindent 8 }}
+      {{ end }}
 status: {}
 {{- end }}

--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -100,5 +100,13 @@ spec:
       {{ end }}
       restartPolicy: Always
       serviceAccountName: ""
+      {{ if .Values.services.proxy.command }}
+      command:
+      {{- toYaml .Values.services.proxy.command | nindent 8 }}
+      {{ end }}
+      {{ if .Values.services.proxy.args }}
+      args:
+      {{- toYaml .Values.services.proxy.args | nindent 8 }}
+      {{ end }}
       volumes:
 status: {}

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -230,4 +230,12 @@ spec:
       {{ end }}
       restartPolicy: Always
       serviceAccountName: ""
+      {{ if .Values.services.worker.command }}
+      command:
+      {{- toYaml .Values.services.worker.command | nindent 8 }}
+      {{ end }}
+      {{ if .Values.services.worker.args }}
+      args:
+      {{- toYaml .Values.services.worker.args | nindent 8 }}
+      {{ end }}
 status: {}


### PR DESCRIPTION
## Description

This will allow us, and users of the chart, to pass custom command line flags to the Node process should we want to.
