### PR TITLE
don't start minio with s3

### DIFF
--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -77,7 +77,12 @@ mkdir -p ${DATA_DIR}/minio
 chown -R couchdb:couchdb ${DATA_DIR}/couch
 redis-server --requirepass $REDIS_PASSWORD > /dev/stdout 2>&1 &
 /bbcouch-runner.sh &
-/minio/minio server --console-address ":9001" ${DATA_DIR}/minio > /dev/stdout 2>&1 &
+
+# only start minio if use s3 isn't passed
+if [[ -z "${USE_S3}"]]; then
+  /minio/minio server --console-address ":9001" ${DATA_DIR}/minio > /dev/stdout 2>&1 &
+fi
+
 /etc/init.d/nginx restart
 if [[ ! -z "${CUSTOM_DOMAIN}" ]]; then
     # Add monthly cron job to renew certbot certificate


### PR DESCRIPTION
## Description
Just a follow up to my previous PR - if `USE_S3` is on we shouldn't start the minio server at all as it won't be used.