### PR TITLE
Set appId, userId and tenantId as baggage items in DataDog APM.

### DIFF
--- a/packages/server/src/middleware/currentapp.ts
+++ b/packages/server/src/middleware/currentapp.ts
@@ -23,7 +23,7 @@ export default async (ctx: UserCtx, next: any) => {
 
   if (requestAppId) {
     const span = tracer.scope().active()
-    span?.addTags({ app_id: requestAppId })
+    span?.setBaggageItem("app_id", requestAppId)
   }
 
   // deny access to application preview
@@ -74,6 +74,14 @@ export default async (ctx: UserCtx, next: any) => {
   // nothing more to do
   if (!appId) {
     return next()
+  }
+
+  if (ctx.user) {
+    const span = tracer.scope().active()
+    if (ctx.user._id) {
+      span?.setBaggageItem("user_id", ctx.user._id)
+    }
+    span?.setBaggageItem("tenant_id", ctx.user.tenantId)
   }
 
   const userId = ctx.user ? generateUserMetadataID(ctx.user._id!) : undefined

--- a/packages/server/src/middleware/currentapp.ts
+++ b/packages/server/src/middleware/currentapp.ts
@@ -23,7 +23,7 @@ export default async (ctx: UserCtx, next: any) => {
 
   if (requestAppId) {
     const span = tracer.scope().active()
-    span?.setBaggageItem("app_id", requestAppId)
+    span?.setBaggageItem("appId", requestAppId)
   }
 
   // deny access to application preview
@@ -79,9 +79,9 @@ export default async (ctx: UserCtx, next: any) => {
   if (ctx.user) {
     const span = tracer.scope().active()
     if (ctx.user._id) {
-      span?.setBaggageItem("user_id", ctx.user._id)
+      span?.setBaggageItem("userId", ctx.user._id)
     }
-    span?.setBaggageItem("tenant_id", ctx.user.tenantId)
+    span?.setBaggageItem("tenantId", ctx.user.tenantId)
   }
 
   const userId = ctx.user ? generateUserMetadataID(ctx.user._id!) : undefined


### PR DESCRIPTION
## Description

A "baggage item" on a span in DataDog is a tag that will propagate to all child spans. I think for appId, userId, and tenantId, this is worth doing. 

DataDog warn that overusing baggage items can cause an increase in network load, because they do get transferred remotely with distributed tracing, but I think these three shouldn't be too bad.
