### PR TITLE
Give db operation spans better names.

### DIFF
--- a/packages/backend-core/src/db/couch/DatabaseImpl.ts
+++ b/packages/backend-core/src/db/couch/DatabaseImpl.ts
@@ -37,7 +37,7 @@ export function DatabaseWithConnection(
   opts?: DatabaseOpts
 ) {
   const db = new DatabaseImpl(dbName, opts, connection)
-  return new DDInstrumentedDatabase(db, "couchdb")
+  return new DDInstrumentedDatabase(db)
 }
 
 export class DatabaseImpl implements Database {

--- a/packages/backend-core/src/db/db.ts
+++ b/packages/backend-core/src/db/db.ts
@@ -3,7 +3,7 @@ import { CouchFindOptions, Database, DatabaseOpts } from "@budibase/types"
 import { DDInstrumentedDatabase } from "./instrumentation"
 
 export function getDB(dbName: string, opts?: DatabaseOpts): Database {
-  return new DDInstrumentedDatabase(new DatabaseImpl(dbName, opts), "couchdb")
+  return new DDInstrumentedDatabase(new DatabaseImpl(dbName, opts))
 }
 
 // we have to use a callback for this so that we can close

--- a/packages/backend-core/src/db/instrumentation.ts
+++ b/packages/backend-core/src/db/instrumentation.ts
@@ -18,31 +18,28 @@ import tracer from "dd-trace"
 import { Writable } from "stream"
 
 export class DDInstrumentedDatabase implements Database {
-  constructor(
-    private readonly db: Database,
-    private readonly resource: string
-  ) {}
+  constructor(private readonly db: Database) {}
 
   get name(): string {
     return this.db.name
   }
 
   exists(): Promise<boolean> {
-    return tracer.trace("exists", { resource: this.resource }, span => {
+    return tracer.trace("db.exists", span => {
       span?.addTags({ db_name: this.name })
       return this.db.exists()
     })
   }
 
   checkSetup(): Promise<DocumentScope<any>> {
-    return tracer.trace("checkSetup", { resource: this.resource }, span => {
+    return tracer.trace("db.checkSetup", span => {
       span?.addTags({ db_name: this.name })
       return this.db.checkSetup()
     })
   }
 
   get<T extends Document>(id?: string | undefined): Promise<T> {
-    return tracer.trace("get", { resource: this.resource }, span => {
+    return tracer.trace("db.get", span => {
       span?.addTags({ db_name: this.name, doc_id: id })
       return this.db.get(id)
     })
@@ -52,7 +49,7 @@ export class DDInstrumentedDatabase implements Database {
     ids: string[],
     opts?: { allowMissing?: boolean | undefined } | undefined
   ): Promise<T[]> {
-    return tracer.trace("getMultiple", { resource: this.resource }, span => {
+    return tracer.trace("db.getMultiple", span => {
       span?.addTags({
         db_name: this.name,
         num_docs: ids.length,
@@ -66,7 +63,7 @@ export class DDInstrumentedDatabase implements Database {
     id: string | Document,
     rev?: string | undefined
   ): Promise<DocumentDestroyResponse> {
-    return tracer.trace("remove", { resource: this.resource }, span => {
+    return tracer.trace("db.remove", span => {
       span?.addTags({ db_name: this.name, doc_id: id })
       return this.db.remove(id, rev)
     })
@@ -76,14 +73,14 @@ export class DDInstrumentedDatabase implements Database {
     document: AnyDocument,
     opts?: DatabasePutOpts | undefined
   ): Promise<DocumentInsertResponse> {
-    return tracer.trace("put", { resource: this.resource }, span => {
+    return tracer.trace("db.put", span => {
       span?.addTags({ db_name: this.name, doc_id: document._id })
       return this.db.put(document, opts)
     })
   }
 
   bulkDocs(documents: AnyDocument[]): Promise<DocumentBulkResponse[]> {
-    return tracer.trace("bulkDocs", { resource: this.resource }, span => {
+    return tracer.trace("db.bulkDocs", span => {
       span?.addTags({ db_name: this.name, num_docs: documents.length })
       return this.db.bulkDocs(documents)
     })
@@ -92,7 +89,7 @@ export class DDInstrumentedDatabase implements Database {
   allDocs<T extends Document>(
     params: DatabaseQueryOpts
   ): Promise<AllDocsResponse<T>> {
-    return tracer.trace("allDocs", { resource: this.resource }, span => {
+    return tracer.trace("db.allDocs", span => {
       span?.addTags({ db_name: this.name })
       return this.db.allDocs(params)
     })
@@ -102,56 +99,56 @@ export class DDInstrumentedDatabase implements Database {
     viewName: string,
     params: DatabaseQueryOpts
   ): Promise<AllDocsResponse<T>> {
-    return tracer.trace("query", { resource: this.resource }, span => {
+    return tracer.trace("db.query", span => {
       span?.addTags({ db_name: this.name, view_name: viewName })
       return this.db.query(viewName, params)
     })
   }
 
   destroy(): Promise<void | OkResponse> {
-    return tracer.trace("destroy", { resource: this.resource }, span => {
+    return tracer.trace("db.destroy", span => {
       span?.addTags({ db_name: this.name })
       return this.db.destroy()
     })
   }
 
   compact(): Promise<void | OkResponse> {
-    return tracer.trace("compact", { resource: this.resource }, span => {
+    return tracer.trace("db.compact", span => {
       span?.addTags({ db_name: this.name })
       return this.db.compact()
     })
   }
 
   dump(stream: Writable, opts?: DatabaseDumpOpts | undefined): Promise<any> {
-    return tracer.trace("dump", { resource: this.resource }, span => {
+    return tracer.trace("db.dump", span => {
       span?.addTags({ db_name: this.name })
       return this.db.dump(stream, opts)
     })
   }
 
   load(...args: any[]): Promise<any> {
-    return tracer.trace("load", { resource: this.resource }, span => {
+    return tracer.trace("db.load", span => {
       span?.addTags({ db_name: this.name })
       return this.db.load(...args)
     })
   }
 
   createIndex(...args: any[]): Promise<any> {
-    return tracer.trace("createIndex", { resource: this.resource }, span => {
+    return tracer.trace("db.createIndex", span => {
       span?.addTags({ db_name: this.name })
       return this.db.createIndex(...args)
     })
   }
 
   deleteIndex(...args: any[]): Promise<any> {
-    return tracer.trace("deleteIndex", { resource: this.resource }, span => {
+    return tracer.trace("db.deleteIndex", span => {
       span?.addTags({ db_name: this.name })
       return this.db.deleteIndex(...args)
     })
   }
 
   getIndexes(...args: any[]): Promise<any> {
-    return tracer.trace("getIndexes", { resource: this.resource }, span => {
+    return tracer.trace("db.getIndexes", span => {
       span?.addTags({ db_name: this.name })
       return this.db.getIndexes(...args)
     })


### PR DESCRIPTION
## Description

When going to query these spans in DataDog metrics explorer I noticed I hadn't understood exactly how they work. `trace.put` was the DB put operations. I think this is a bit confusing, so I'm prepending `db.` to all of the names, e.g. `trace.db.put` will be the metric name.

I also removed the resource tag because I was misusing it.