### PR TITLE
Add traces to track running arbitrary JS.

### DIFF
--- a/packages/backend-core/src/timers/timers.ts
+++ b/packages/backend-core/src/timers/timers.ts
@@ -30,7 +30,7 @@ export class ExecutionTimeTracker {
     return new ExecutionTimeTracker(limitMs)
   }
 
-  constructor(private limitMs: number) {}
+  constructor(readonly limitMs: number) {}
 
   private totalTimeMs = 0
 
@@ -44,6 +44,10 @@ export class ExecutionTimeTracker {
       this.totalTimeMs += Number(end - start) / 1e6
       this.checkLimit()
     }
+  }
+
+  get elapsedMS() {
+    return this.totalTimeMs
   }
 
   private checkLimit() {

--- a/packages/server/src/jsRunner.ts
+++ b/packages/server/src/jsRunner.ts
@@ -2,35 +2,44 @@ import vm from "vm"
 import env from "./environment"
 import { setJSRunner } from "@budibase/string-templates"
 import { context, timers } from "@budibase/backend-core"
+import tracer from "dd-trace"
 
 type TrackerFn = <T>(f: () => T) => T
 
 export function init() {
   setJSRunner((js: string, ctx: vm.Context) => {
-    const perRequestLimit = env.JS_PER_REQUEST_TIME_LIMIT_MS
-    let track: TrackerFn = f => f()
-    if (perRequestLimit) {
-      const bbCtx = context.getCurrentContext()
-      if (bbCtx) {
-        if (!bbCtx.jsExecutionTracker) {
-          bbCtx.jsExecutionTracker =
-            timers.ExecutionTimeTracker.withLimit(perRequestLimit)
+    return tracer.trace("runJS", {}, span => {
+      const perRequestLimit = env.JS_PER_REQUEST_TIME_LIMIT_MS
+      let track: TrackerFn = f => f()
+      if (perRequestLimit) {
+        const bbCtx = context.getCurrentContext()
+        if (bbCtx) {
+          if (!bbCtx.jsExecutionTracker) {
+            bbCtx.jsExecutionTracker =
+              timers.ExecutionTimeTracker.withLimit(perRequestLimit)
+          }
+          track = bbCtx.jsExecutionTracker.track.bind(bbCtx.jsExecutionTracker)
+          span?.addTags({
+            js: {
+              limitMS: bbCtx.jsExecutionTracker.limitMs,
+              elapsedMS: bbCtx.jsExecutionTracker.elapsedMS,
+            },
+          })
         }
-        track = bbCtx.jsExecutionTracker.track.bind(bbCtx.jsExecutionTracker)
       }
-    }
 
-    ctx = {
-      ...ctx,
-      alert: undefined,
-      setInterval: undefined,
-      setTimeout: undefined,
-    }
-    vm.createContext(ctx)
-    return track(() =>
-      vm.runInNewContext(js, ctx, {
-        timeout: env.JS_PER_EXECUTION_TIME_LIMIT_MS,
-      })
-    )
+      ctx = {
+        ...ctx,
+        alert: undefined,
+        setInterval: undefined,
+        setTimeout: undefined,
+      }
+      vm.createContext(ctx)
+      return track(() =>
+        vm.runInNewContext(js, ctx, {
+          timeout: env.JS_PER_EXECUTION_TIME_LIMIT_MS,
+        })
+      )
+    })
   })
 }


### PR DESCRIPTION
## Description

Can't believe I forgot to do this. We still have requests spending a long time in processing formulas, and I want to make sure it's not some obscure bug in the JS runner execution time tracking.
