### PR TITLE
Copy paste error in the Helm chart.

### DIFF
--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -213,6 +213,7 @@ spec:
         resources:
         {{- toYaml . | nindent 10 }}
         {{ end }}
+        {{ if .Values.services.worker.command }}
         command:
         {{- toYaml .Values.services.worker.command | nindent 10 }}
         {{ end }}
@@ -237,5 +238,4 @@ spec:
       {{ end }}
       restartPolicy: Always
       serviceAccountName: ""
-      {{ if .Values.services.worker.command }}
 status: {}


### PR DESCRIPTION
## Description

My bad, missed this. The helm chart deployed to `0.0.0-develop` is broken atm.