### PR TITLE
Run helm lint during CI checks.

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -76,6 +76,18 @@ jobs:
             yarn check:types
           fi
 
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 18.x
+        uses: azure/setup-helm@v3
+      - run: cd charts/budibase && helm lint .
+
   test-libraries:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

This should prevent problems like the one introduced in https://github.com/Budibase/budibase/pull/12641.

Example failure: https://github.com/Budibase/budibase/actions/runs/7274076454/job/19819260845?pr=12642

