### PR TITLE
Allow TEMPLATES_BUCKET_NAME to be configured in the Helm chart.

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -106,6 +106,8 @@ spec:
           value: {{ .Values.services.objectStore.globalBucketName | quote }}
         - name: BACKUPS_BUCKET_NAME
           value: {{ .Values.services.objectStore.backupsBucketName | quote }}
+        - name: TEMPLATES_BUCKET_NAME
+          value: {{ .values.services.objectStore.templatesBucketName | quote }}
         - name: PORT
           value: {{ .Values.services.apps.port | quote }}
         {{ if .Values.services.worker.publicApiRateLimitPerSecond }}

--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -107,7 +107,7 @@ spec:
         - name: BACKUPS_BUCKET_NAME
           value: {{ .Values.services.objectStore.backupsBucketName | quote }}
         - name: TEMPLATES_BUCKET_NAME
-          value: {{ .values.services.objectStore.templatesBucketName | quote }}
+          value: {{ .Values.services.objectStore.templatesBucketName | quote }}
         - name: PORT
           value: {{ .Values.services.apps.port | quote }}
         {{ if .Values.services.worker.publicApiRateLimitPerSecond }}

--- a/charts/budibase/templates/automation-worker-service-deployment.yaml
+++ b/charts/budibase/templates/automation-worker-service-deployment.yaml
@@ -108,7 +108,7 @@ spec:
         - name: BACKUPS_BUCKET_NAME
           value: {{ .Values.services.objectStore.backupsBucketName | quote }}
         - name: TEMPLATES_BUCKET_NAME
-          value: {{ .values.services.objectStore.templatesBucketName | quote }}
+          value: {{ .Values.services.objectStore.templatesBucketName | quote }}
         - name: PORT
           value: {{ .Values.services.automationWorkers.port | quote }}
         {{ if .Values.services.worker.publicApiRateLimitPerSecond }}

--- a/charts/budibase/templates/automation-worker-service-deployment.yaml
+++ b/charts/budibase/templates/automation-worker-service-deployment.yaml
@@ -107,6 +107,8 @@ spec:
           value: {{ .Values.services.objectStore.globalBucketName | quote }}
         - name: BACKUPS_BUCKET_NAME
           value: {{ .Values.services.objectStore.backupsBucketName | quote }}
+        - name: TEMPLATES_BUCKET_NAME
+          value: {{ .values.services.objectStore.templatesBucketName | quote }}
         - name: PORT
           value: {{ .Values.services.automationWorkers.port | quote }}
         {{ if .Values.services.worker.publicApiRateLimitPerSecond }}

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -106,6 +106,8 @@ spec:
           value: {{ .Values.services.objectStore.globalBucketName | quote }}
         - name: BACKUPS_BUCKET_NAME
           value: {{ .Values.services.objectStore.backupsBucketName | quote }}
+        - name: TEMPLATES_BUCKET_NAME
+          value: {{ .values.services.objectStore.templatesBucketName | quote }}
         - name: PORT
           value: {{ .Values.services.worker.port | quote }}
         - name: MULTI_TENANCY

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -107,7 +107,7 @@ spec:
         - name: BACKUPS_BUCKET_NAME
           value: {{ .Values.services.objectStore.backupsBucketName | quote }}
         - name: TEMPLATES_BUCKET_NAME
-          value: {{ .values.services.objectStore.templatesBucketName | quote }}
+          value: {{ .Values.services.objectStore.templatesBucketName | quote }}
         - name: PORT
           value: {{ .Values.services.worker.port | quote }}
         - name: MULTI_TENANCY


### PR DESCRIPTION
## Description

Looks like this was either missed or the bucket was added and the Helm chart forgotten about.

## Addresses
- https://linear.app/budibase/issue/GROW-87/configuration-of-environment-variable-templates-bucket-name-is-missing
