### PR TITLE
Revert "Allow TEMPLATES_BUCKET_NAME to be configured in the Helm chart."

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -106,8 +106,6 @@ spec:
           value: {{ .Values.services.objectStore.globalBucketName | quote }}
         - name: BACKUPS_BUCKET_NAME
           value: {{ .Values.services.objectStore.backupsBucketName | quote }}
-        - name: TEMPLATES_BUCKET_NAME
-          value: {{ .Values.services.objectStore.templatesBucketName | quote }}
         - name: PORT
           value: {{ .Values.services.apps.port | quote }}
         {{ if .Values.services.worker.publicApiRateLimitPerSecond }}

--- a/charts/budibase/templates/automation-worker-service-deployment.yaml
+++ b/charts/budibase/templates/automation-worker-service-deployment.yaml
@@ -107,8 +107,6 @@ spec:
           value: {{ .Values.services.objectStore.globalBucketName | quote }}
         - name: BACKUPS_BUCKET_NAME
           value: {{ .Values.services.objectStore.backupsBucketName | quote }}
-        - name: TEMPLATES_BUCKET_NAME
-          value: {{ .Values.services.objectStore.templatesBucketName | quote }}
         - name: PORT
           value: {{ .Values.services.automationWorkers.port | quote }}
         {{ if .Values.services.worker.publicApiRateLimitPerSecond }}

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -106,8 +106,6 @@ spec:
           value: {{ .Values.services.objectStore.globalBucketName | quote }}
         - name: BACKUPS_BUCKET_NAME
           value: {{ .Values.services.objectStore.backupsBucketName | quote }}
-        - name: TEMPLATES_BUCKET_NAME
-          value: {{ .Values.services.objectStore.templatesBucketName | quote }}
         - name: PORT
           value: {{ .Values.services.worker.port | quote }}
         - name: MULTI_TENANCY


### PR DESCRIPTION
Reverts Budibase/budibase#12650

Looking at the code, it doesn't seem like setting TEMPLATES_BUCKET_NAME actually does anything useful. We hardcode the template bucket in the code.