### PR TITLE
Fix flaky test

### DIFF
--- a/packages/worker/src/api/routes/global/tests/scim.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/scim.spec.ts
@@ -1,6 +1,6 @@
 import tk from "timekeeper"
 import _ from "lodash"
-import { mocks, structures } from "@budibase/backend-core/tests"
+import { generator, mocks, structures } from "@budibase/backend-core/tests"
 import {
   ScimCreateUserRequest,
   ScimGroupResponse,
@@ -575,8 +575,15 @@ describe("scim", () => {
         beforeAll(async () => {
           groups = []
 
-          for (let i = 0; i < groupCount; i++) {
-            const body = structures.scim.createGroupRequest()
+          const groupNames = generator.unique(
+            () => generator.word(),
+            groupCount
+          )
+
+          for (const groupName of groupNames) {
+            const body = structures.scim.createGroupRequest({
+              displayName: groupName,
+            })
             groups.push(await config.api.scimGroupsAPI.post({ body }))
           }
 

--- a/packages/worker/src/api/routes/global/tests/scim.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/scim.spec.ts
@@ -14,9 +14,14 @@ import { events } from "@budibase/backend-core"
 jest.retryTimes(2, { logErrorsBeforeRetry: true })
 jest.setTimeout(30000)
 
-mocks.licenses.useScimIntegration()
-
 describe("scim", () => {
+  beforeAll(async () => {
+    tk.freeze(mocks.date.MOCK_DATE)
+    mocks.licenses.useScimIntegration()
+
+    await config.setSCIMConfig(true)
+  })
+
   beforeEach(async () => {
     jest.resetAllMocks()
     tk.freeze(mocks.date.MOCK_DATE)


### PR DESCRIPTION
## Description
Fixing flaky scim test. There is a test that it creates 25 scim groups randomly at the setup, and from time to time we are getting 409 as some of these names might be repeated, given that we are using random generated names.
Changing the setup to ensure uniqueness

These failing pipelines will be fixed:

- https://github.com/Budibase/budibase/actions/runs/7345702459/job/19999268757
- https://github.com/Budibase/budibase/actions/runs/7336376609/job/19975601067
