### PR TITLE
Reject requests to /:appId/:path* that don't have a valid appId

### DIFF
--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -126,12 +126,17 @@ export const deleteObjects = async function (ctx: Ctx) {
 }
 
 export const serveApp = async function (ctx: Ctx) {
+  const { appId } = ctx.params
+  if (!appId || !appId.startsWith(DocumentType.APP)) {
+    ctx.throw(404)
+  }
+
   const bbHeaderEmbed =
     ctx.request.get("x-budibase-embed")?.toLowerCase() === "true"
 
-  //Public Settings
   const { config } = await configs.getSettingsConfigDoc()
   const branding = await pro.branding.getBrandingConfig(config)
+
   // incase running direct from TS
   let appHbsPath = join(__dirname, "app.hbs")
   if (!fs.existsSync(appHbsPath)) {


### PR DESCRIPTION
## Description

We get a couple hundred requests a day to URLs that aren't apps, things like `apple-touch-icon.png` and `app-ads.txt`, that cause 500s and exceptions to be tracked in DataDog. These aren't a real problem, so instead of a 500 we're going to serve a 404 if we get a request without a valid appId.
