### PR TITLE
Fix local development of multi-tenancy apps

### DIFF
--- a/packages/backend-core/src/context/mainContext.ts
+++ b/packages/backend-core/src/context/mainContext.ts
@@ -134,7 +134,7 @@ export async function doInContext(appId: string, task: any): Promise<any> {
 }
 
 export async function doInTenant<T>(
-  tenantId: string | null,
+  tenantId: string | undefined,
   task: () => T
 ): Promise<T> {
   // make sure default always selected in single tenancy

--- a/packages/backend-core/src/tenancy/tenancy.ts
+++ b/packages/backend-core/src/tenancy/tenancy.ts
@@ -39,7 +39,7 @@ const ALL_STRATEGIES = Object.values(TenantResolutionStrategy)
 export const getTenantIDFromCtx = (
   ctx: BBContext,
   opts: GetTenantIdOptions
-): string | null => {
+): string | undefined => {
   // exit early if not multi-tenant
   if (!isMultiTenant()) {
     return DEFAULT_TENANT_ID
@@ -144,5 +144,5 @@ export const getTenantIDFromCtx = (
     ctx.throw(403, "Tenant id not set")
   }
 
-  return null
+  return undefined
 }

--- a/packages/backend-core/src/tenancy/tests/tenancy.spec.ts
+++ b/packages/backend-core/src/tenancy/tests/tenancy.spec.ts
@@ -157,12 +157,12 @@ describe("getTenantIDFromCtx", () => {
           TenantResolutionStrategy.PATH,
         ],
       }
-      expect(getTenantIDFromCtx(ctx, mockOpts)).toBeNull()
+      expect(getTenantIDFromCtx(ctx, mockOpts)).toBeUndefined()
       expect(ctx.throw).toBeCalledTimes(1)
       expect(ctx.throw).toBeCalledWith(403, "Tenant id not set")
     })
 
-    it("returns null if allowNoTenant is true", () => {
+    it("returns undefined if allowNoTenant is true", () => {
       const ctx = createCtx({})
       mockOpts = {
         allowNoTenant: true,
@@ -172,7 +172,7 @@ describe("getTenantIDFromCtx", () => {
           TenantResolutionStrategy.PATH,
         ],
       }
-      expect(getTenantIDFromCtx(ctx, mockOpts)).toBeNull()
+      expect(getTenantIDFromCtx(ctx, mockOpts)).toBeUndefined()
     })
   })
 

--- a/packages/backend-core/src/utils/utils.ts
+++ b/packages/backend-core/src/utils/utils.ts
@@ -31,8 +31,8 @@ export async function resolveAppUrl(ctx: Ctx) {
   const appUrl = ctx.path.split("/")[2]
   let possibleAppUrl = `/${appUrl.toLowerCase()}`
 
-  let tenantId: string | null = context.getTenantId()
-  if (env.MULTI_TENANCY) {
+  let tenantId: string | undefined = context.getTenantId()
+  if (!env.isDev() && env.MULTI_TENANCY) {
     // always use the tenant id from the subdomain in multi tenancy
     // this ensures the logged-in user tenant id doesn't overwrite
     // e.g. in the case of viewing a public app while already logged-in to another tenant
@@ -41,7 +41,7 @@ export async function resolveAppUrl(ctx: Ctx) {
     })
   }
 
-  // search prod apps for a url that matches
+  // search prod apps for an url that matches
   const apps: App[] = await context.doInTenant(
     tenantId,
     () => getAllApps({ dev: false }) as Promise<App[]>


### PR DESCRIPTION
## Description
Fix for multi-tenancy issue in local development, couldn't load apps as it requires a tenant ID in the subdomain when in multi-tenancy mode which isn't possible in development - this makes sure that local development can work by using the users cookie instead.