### PR TITLE
Allow ndots to be configurable in the Helm chart.

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -252,4 +252,10 @@ spec:
       {{ end }}
       restartPolicy: Always
       serviceAccountName: ""
+      {{ if .Values.services.apps.ndots }}
+      dnsConfig:
+        options:
+          - name: ndots
+            value: {{ .Values.services.apps.ndots | quote }}
+      {{ end }}
 status: {}

--- a/charts/budibase/templates/automation-worker-service-deployment.yaml
+++ b/charts/budibase/templates/automation-worker-service-deployment.yaml
@@ -227,6 +227,7 @@ spec:
         resources:
         {{- toYaml . | nindent 10 }}
         {{ end }}
+        {{ if .Values.services.automationWorkers.command }}
         command:
         {{- toYaml .Values.services.automationWorkers.command | nindent 10 }}
         {{ end }}
@@ -251,6 +252,11 @@ spec:
       {{ end }}
       restartPolicy: Always
       serviceAccountName: ""
-      {{ if .Values.services.automationWorkers.command }}}
+      {{ if .Values.services.automationWorkers.ndots }}
+      dnsConfig:
+        options:
+          - name: ndots
+            value: {{ .Values.services.automationWorkers.ndots | quote }}
+      {{ end }}
 status: {}
 {{- end }}

--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -109,4 +109,10 @@ spec:
       {{- toYaml .Values.services.proxy.args | nindent 8 }}
       {{ end }}
       volumes:
+      {{ if .Values.services.proxy.ndots }}
+      dnsConfig:
+        options:
+          - name: ndots
+            value: {{ .Values.services.proxy.ndots | quote }}
+      {{ end }}
 status: {}

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -238,4 +238,10 @@ spec:
       {{ end }}
       restartPolicy: Always
       serviceAccountName: ""
+      {{ if .Values.services.worker.ndots }}
+      dnsConfig:
+        options:
+          - name: ndots
+            value: {{ .Values.services.worker.ndots | quote }}
+      {{ end }}
 status: {}


### PR DESCRIPTION
## Description

Allows the DNS `ndots` configuration to be changed per-service in our Helm chart.
