### PR TITLE
Add an extra JS execution time limit check to prevent creating unnecessary VM context.

### DIFF
--- a/packages/backend-core/src/timers/timers.ts
+++ b/packages/backend-core/src/timers/timers.ts
@@ -50,7 +50,7 @@ export class ExecutionTimeTracker {
     return this.totalTimeMs
   }
 
-  private checkLimit() {
+  checkLimit() {
     if (this.totalTimeMs > this.limitMs) {
       throw new ExecutionTimeoutError(
         `Execution time limit of ${this.limitMs}ms exceeded: ${this.totalTimeMs}ms`

--- a/packages/server/src/jsRunner.ts
+++ b/packages/server/src/jsRunner.ts
@@ -18,13 +18,16 @@ export function init() {
             bbCtx.jsExecutionTracker =
               timers.ExecutionTimeTracker.withLimit(perRequestLimit)
           }
-          track = bbCtx.jsExecutionTracker.track.bind(bbCtx.jsExecutionTracker)
           span?.addTags({
             js: {
               limitMS: bbCtx.jsExecutionTracker.limitMs,
               elapsedMS: bbCtx.jsExecutionTracker.elapsedMS,
             },
           })
+          // We call checkLimit() here to prevent paying the cost of creating
+          // a new VM context below when we don't need to.
+          bbCtx.jsExecutionTracker.checkLimit()
+          track = bbCtx.jsExecutionTracker.track.bind(bbCtx.jsExecutionTracker)
         }
       }
 


### PR DESCRIPTION
## Description

Looking into potential problems with our per-request JS execution limits, I took a look at some APM traces that included JS running. They look like this:

![CleanShot 2024-01-04 at 10 10 40@2x](https://github.com/Budibase/budibase/assets/338027/cacdc89e-8508-4bcf-b634-79f359fd2013)

And if we zoom in:

![CleanShot 2024-01-04 at 10 11 34@2x](https://github.com/Budibase/budibase/assets/338027/b5c7662d-4285-498e-8eab-334cece300a5)

Each `runJS` span is a single cell being evaluated. I've zoomed in on the point where we hit the per-request limit, which we can see we annotate on the span:

![CleanShot 2024-01-04 at 10 12 13@2x](https://github.com/Budibase/budibase/assets/338027/8970ab4c-7596-4be4-b88d-91f274ec48ac)

What confused me was that from then on, we still got some fairly long `runJS` blocks, usually around 50ms. This is much longer than I'd expect, given that the runtime tracker should throw an error almost immediately upon comparing the elapsedMS and limitMS.

My theory here is that this cost comes from creating the VM context, though why it only seems to happen sometimes is not clear to me. Either way, I'm adding an extra check slightly earlier in `runJS` to see if that helps.
