### PR TITLE
Fix running worker directly from ts

### DIFF
--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -4,6 +4,9 @@
     "composite": true,
     "baseUrl": "."
   },
+  "ts-node": {
+    "require": ["tsconfig-paths/register"]
+  },
   "include": ["src/**/*", "__mocks__/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Description
Configuring ts paths when running the worker via ts-node. Not having this means that it will be picking up the dist folders, forcing us to build them all and to keep them up to date. Using the paths will give us a better dev experience.

Current error:
![image](https://github.com/Budibase/budibase/assets/15987277/8cfd65c7-bf0f-4293-b368-7a1d02e00361)
