### PR TITLE
[Fix] Keep exisitng views when refetching tables

### DIFF
--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -305,8 +305,8 @@ export function shouldCopySpecialColumn(
 }
 
 /**
- * Looks for columns which need to be copied over into the new table definitions, like relationships
- * and options types.
+ * Looks for columns which need to be copied over into the new table definitions, like relationships,
+ * options types and views.
  * @param tableName The name of the table which is being checked.
  * @param table The specific table which is being checked.
  * @param entities All the tables that existed before - the old table definitions.
@@ -325,6 +325,9 @@ function copyExistingPropsOver(
     if (entities[tableName]?.created) {
       table.created = entities[tableName]?.created
     }
+
+    table.views = entities[tableName].views
+
     const existingTableSchema = entities[tableName].schema
     for (let key in existingTableSchema) {
       if (!existingTableSchema.hasOwnProperty(key)) {


### PR DESCRIPTION
## Description
Fixing a bug that, on external datasource refetch, the existing views are dropped.

## Addresses
- [BUDI-7571 - Refetching tables deletes pre-existing views](https://linear.app/budibase/issue/BUDI-7571/refetching-tables-deletes-pre-existing-views)

## Screenshots
https://github.com/Budibase/budibase/assets/15987277/37d27969-d53d-490b-890f-4a38348ebce3

