### PR TITLE
Fix Grid component undefined primary array

### DIFF
--- a/packages/builder/src/components/design/settings/controls/GridColumnConfiguration/getColumns.js
+++ b/packages/builder/src/components/design/settings/controls/GridColumnConfiguration/getColumns.js
@@ -114,7 +114,7 @@ const getColumns = ({
     primary,
     sortable,
     updateSortable: newDraggableList => {
-      onChange(toGridFormat(newDraggableList.concat(primary)))
+      onChange(toGridFormat(newDraggableList.concat(primary || [])))
     },
     update: newEntry => {
       const newDraggableList = draggableList.map(entry => {


### PR DESCRIPTION
## Description

Minor issue when the value `undefined` is being concatenated into the columns list. When processing the list entries for the draggable columns list, errors get thrown in the console for the erroneous entry. Allowing the `primary` array to default to `[]` solved the issue.
