### PR TITLE
Remove password validation for admin user environment variables

### DIFF
--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -166,6 +166,8 @@ const environment = {
   DISABLE_JWT_WARNING: process.env.DISABLE_JWT_WARNING,
   BLACKLIST_IPS: process.env.BLACKLIST_IPS,
   SERVICE_TYPE: "unknown",
+  PASSWORD_MIN_LENGTH: process.env.PASSWORD_MIN_LENGTH,
+  PASSWORD_MAX_LENGTH: process.env.PASSWORD_MAX_LENGTH,
   /**
    * Enable to allow an admin user to login using a password.
    * This can be useful to prevent lockout when configuring SSO.

--- a/packages/backend-core/src/security/auth.ts
+++ b/packages/backend-core/src/security/auth.ts
@@ -1,7 +1,7 @@
-import { env } from ".."
+import env from "../environment"
 
-export const PASSWORD_MIN_LENGTH = +(process.env.PASSWORD_MIN_LENGTH || 8)
-export const PASSWORD_MAX_LENGTH = +(process.env.PASSWORD_MAX_LENGTH || 512)
+export const PASSWORD_MIN_LENGTH = +(env.PASSWORD_MIN_LENGTH || 8)
+export const PASSWORD_MAX_LENGTH = +(env.PASSWORD_MAX_LENGTH || 512)
 
 export function validatePassword(
   password: string

--- a/packages/backend-core/src/users/db.ts
+++ b/packages/backend-core/src/users/db.ts
@@ -48,7 +48,7 @@ type CreateAdminUserOpts = {
   ssoId?: string
   hashPassword?: boolean
   requirePassword?: boolean
-  noPasswordValidation?: boolean
+  skipPasswordValidation?: boolean
 }
 type FeatureFns = { isSSOEnforced: FeatureFn; isAppBuildersEnabled: FeatureFn }
 
@@ -118,7 +118,7 @@ export class UserDB {
         throw new HTTPError("Password change is disabled for this user", 400)
       }
 
-      if (!opts.noPasswordValidation) {
+      if (!opts.skipPasswordValidation) {
         const passwordValidation = validatePassword(password)
         if (!passwordValidation.valid) {
           throw new HTTPError(passwordValidation.error, 400)
@@ -521,7 +521,7 @@ export class UserDB {
     return await UserDB.save(user, {
       hashPassword: opts?.hashPassword,
       requirePassword: opts?.requirePassword,
-      noPasswordValidation: opts?.noPasswordValidation,
+      skipPasswordValidation: opts?.skipPasswordValidation,
     })
   }
 

--- a/packages/backend-core/src/users/db.ts
+++ b/packages/backend-core/src/users/db.ts
@@ -44,6 +44,12 @@ type GroupFns = {
   getBulk: GroupGetFn
   getGroupBuilderAppIds: GroupBuildersFn
 }
+type CreateAdminUserOpts = {
+  ssoId?: string
+  hashPassword?: boolean
+  requirePassword?: boolean
+  noPasswordValidation?: boolean
+}
 type FeatureFns = { isSSOEnforced: FeatureFn; isAppBuildersEnabled: FeatureFn }
 
 const bulkDeleteProcessing = async (dbUser: User) => {
@@ -112,9 +118,11 @@ export class UserDB {
         throw new HTTPError("Password change is disabled for this user", 400)
       }
 
-      const passwordValidation = validatePassword(password)
-      if (!passwordValidation.valid) {
-        throw new HTTPError(passwordValidation.error, 400)
+      if (!opts.noPasswordValidation) {
+        const passwordValidation = validatePassword(password)
+        if (!passwordValidation.valid) {
+          throw new HTTPError(passwordValidation.error, 400)
+        }
       }
 
       hashedPassword = opts.hashPassword ? await hash(password) : password
@@ -489,7 +497,7 @@ export class UserDB {
     email: string,
     password: string,
     tenantId: string,
-    opts?: { ssoId?: string; hashPassword?: boolean; requirePassword?: boolean }
+    opts?: CreateAdminUserOpts
   ) {
     const user: User = {
       email: email,
@@ -513,6 +521,7 @@ export class UserDB {
     return await UserDB.save(user, {
       hashPassword: opts?.hashPassword,
       requirePassword: opts?.requirePassword,
+      noPasswordValidation: opts?.noPasswordValidation,
     })
   }
 

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -138,7 +138,11 @@ export async function startup(app?: Koa, server?: Server) {
             bbAdminEmail,
             bbAdminPassword,
             tenantId,
-            { hashPassword: true, requirePassword: true }
+            {
+              hashPassword: true,
+              requirePassword: true,
+              noPasswordValidation: true,
+            }
           )
           // Need to set up an API key for automated integration tests
           if (env.isTest()) {

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -141,7 +141,7 @@ export async function startup(app?: Koa, server?: Server) {
             {
               hashPassword: true,
               requirePassword: true,
-              noPasswordValidation: true,
+              skipPasswordValidation: true,
             }
           )
           // Need to set up an API key for automated integration tests

--- a/packages/types/src/sdk/user.ts
+++ b/packages/types/src/sdk/user.ts
@@ -2,4 +2,5 @@ export interface SaveUserOpts {
   hashPassword?: boolean
   requirePassword?: boolean
   currentUserId?: string
+  noPasswordValidation?: boolean
 }

--- a/packages/types/src/sdk/user.ts
+++ b/packages/types/src/sdk/user.ts
@@ -2,5 +2,5 @@ export interface SaveUserOpts {
   hashPassword?: boolean
   requirePassword?: boolean
   currentUserId?: string
-  noPasswordValidation?: boolean
+  skipPasswordValidation?: boolean
 }


### PR DESCRIPTION
## Description
Adding an option to disable password validation when creating an admin user - this means that the environment variables used for BB_ADMIN creation can have any length of password (not breaking change).

There was a breaking change that affected plugin development environments and stopped images starting when the `BB_ADMIN...` environment variables were set due to the new password validation rules.