### PR TITLE
Set user ID correctly.

### DIFF
--- a/packages/backend-core/src/middleware/authenticated.ts
+++ b/packages/backend-core/src/middleware/authenticated.ts
@@ -170,7 +170,7 @@ export default function (
 
       if (user) {
         tracer.setUser({
-          id: user?.id,
+          id: user?._id,
           tenantId: user?.tenantId,
           admin: user?.admin,
           builder: user?.builder,


### PR DESCRIPTION
## Description

Looking at the [dd-trace-js code](https://github.com/DataDog/dd-trace-js/blob/cfc243638ed8142e1fcf90f8d56ee11631c0c521/packages/dd-trace/src/appsec/sdk/set_user.js#L13-L16), I believe the `setUser` call does nothing if the `id` isn't set properly.