### PR TITLE
Enable dd-trace logging in QA to try and figure out why user info isn't being added to traces.

### DIFF
--- a/packages/server/src/ddApm.ts
+++ b/packages/server/src/ddApm.ts
@@ -3,5 +3,9 @@ import apm from "dd-trace"
 // enable APM if configured
 if (process.env.DD_APM_ENABLED) {
   console.log("Starting dd-trace")
-  apm.init()
+  apm.init({
+    // @ts-ignore for some reason dd-trace types don't include this options,
+    // even though it's spoken about in the docs.
+    debug: process.env.DD_ENV === "qa",
+  })
 }


### PR DESCRIPTION
## Description

Not seeing user info on traces, not sure why. Hoping that enabling the logs in QA will help.
