### PR TITLE
Remove objects from setUser call. We can add them later if we need them.

### DIFF
--- a/packages/backend-core/src/middleware/authenticated.ts
+++ b/packages/backend-core/src/middleware/authenticated.ts
@@ -172,11 +172,8 @@ export default function (
         tracer.setUser({
           id: user?._id,
           tenantId: user?.tenantId,
-          admin: user?.admin,
-          builder: user?.builder,
           budibaseAccess: user?.budibaseAccess,
           status: user?.status,
-          roles: user?.roles,
         })
       }
 


### PR DESCRIPTION
## Description

The user data on spans looks like this:

![CleanShot 2024-01-05 at 18 14 33](https://github.com/Budibase/budibase/assets/338027/ee1a3f95-7510-4a5e-94d4-0c408585c732)

I'm just removing the ones that are objects who have had `.toString()` called on them for now. If we find that information would be useful to have in traces we can add it back in the correct way.