### PR TITLE
Set the CouchDB credentials in a safer way inside of runner.sh.

### DIFF
--- a/hosting/couchdb/runner.sh
+++ b/hosting/couchdb/runner.sh
@@ -76,6 +76,6 @@ done
 
 # CouchDB needs the `_users` and `_replicator` databases to exist before it will
 # function correctly, so we create them here.
-curl -X PUT http://${COUCHDB_USER}:${COUCHDB_PASSWORD}@localhost:5984/_users
-curl -X PUT http://${COUCHDB_USER}:${COUCHDB_PASSWORD}@localhost:5984/_replicator
+curl -X PUT -u "${COUCHDB_USER}:${COUCHDB_PASSWORD}" http://localhost:5984/_users
+curl -X PUT -u "${COUCHDB_USER}:${COUCHDB_PASSWORD}" http://localhost:5984/_replicator
 sleep infinity


### PR DESCRIPTION
## Description

The way that we passed `COUCHDB_USER` and `COUCHDB_PASSWORD` in `curl` invocations prior to this PR could cause problems on start up:

```
$ docker run -e COUCHDB_PASSWORD='foo{[/' -t couchdb
...

curl: (3) nested brace in URL position 18:
http://admin:foo{[/@localhost:5984/_users
                 ^
curl: (3) nested brace in URL position 18:
http://admin:foo{[/@localhost:5984/_replicator
```

Passing it in `-u` and with quotes around it protects it from bash-unsafe and URL-unsafe characters.

```
$ docker run -e COUCHDB_PASSWORD='foo{[/' -t couchdb
...

127.0.0.1 admin PUT /_users 201 ok 26
127.0.0.1 admin PUT /_replicator 201 ok 6
```