### PR TITLE
Add component icon to custom css

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ComponentSettingsPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ComponentSettingsPanel.svelte
@@ -108,6 +108,9 @@
           {componentInstance}
           {componentDefinition}
           {bindings}
+          icon={componentDefinition?.icon}
+          iconTooltip={componentName}
+          componentTitle={title}
         />
       {/if}
       {#if section == "conditions"}

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ComponentSettingsPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ComponentSettingsPanel.svelte
@@ -108,7 +108,6 @@
           {componentInstance}
           {componentDefinition}
           {bindings}
-          icon={componentDefinition?.icon}
           iconTooltip={componentName}
           componentTitle={title}
         />

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/CustomStylesSection.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/CustomStylesSection.svelte
@@ -62,7 +62,6 @@
     <svelte:fragment slot="description">
       <div class="header">
         Your CSS will overwrite styles for:
-        <span />
         {#if icon}
           <AbsTooltip type="info" text={iconTooltip}>
             <Icon

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/CustomStylesSection.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/CustomStylesSection.svelte
@@ -5,6 +5,9 @@
     Drawer,
     Button,
     notifications,
+    AbsTooltip,
+    Icon,
+    Body,
   } from "@budibase/bbui"
   import { selectedScreen, store } from "builderStore"
   import ClientBindingPanel from "components/common/bindings/ClientBindingPanel.svelte"
@@ -15,6 +18,9 @@
   } from "builderStore/dataBinding"
 
   export let componentInstance
+  export let icon
+  export let iconTooltip
+  export let componentTitle
 
   let tempValue
   let drawer
@@ -54,7 +60,20 @@
 {#key componentInstance?._id}
   <Drawer bind:this={drawer} title="Custom CSS">
     <svelte:fragment slot="description">
-      Custom CSS overrides all other component styles.
+      <div class="header">
+        Your CSS will overwrite styles for:
+        <span />
+        {#if icon}
+          <AbsTooltip type="info" text={iconTooltip}>
+            <Icon
+              color={`var(--spectrum-global-color-gray-600)`}
+              size="S"
+              name={icon}
+            />
+          </AbsTooltip>
+          <Body size="S"><b>{componentTitle || ""}</b></Body>
+        {/if}
+      </div>
     </svelte:fragment>
     <Button cta slot="buttons" on:click={save}>Save</Button>
     <svelte:component
@@ -68,3 +87,13 @@
     />
   </Drawer>
 {/key}
+
+<style>
+  .header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--spacing-m);
+  }
+</style>

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/CustomStylesSection.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/CustomStylesSection.svelte
@@ -18,7 +18,7 @@
   } from "builderStore/dataBinding"
 
   export let componentInstance
-  export let icon
+  export let componentDefinition
   export let iconTooltip
   export let componentTitle
 
@@ -29,6 +29,8 @@
     $selectedScreen,
     $store.selectedComponentId
   )
+
+  $: icon = componentDefinition?.icon
 
   const openDrawer = () => {
     tempValue = runtimeToReadableBinding(


### PR DESCRIPTION
## Description
The component icon and component title (from the settings panel) is now displayed in the Custom CSS drawer header.

## Addresses
- https://github.com/Budibase/budibase/issues/6985

## Screenshots (Examples)
![Screenshot 2024-01-09 at 13 04 36](https://github.com/Budibase/budibase/assets/101575380/0ac0b124-bc35-4972-ad50-128201bb5f21)

![Screenshot 2024-01-09 at 13 05 21](https://github.com/Budibase/budibase/assets/101575380/fe484ca4-d815-4c85-b3ca-c311a011a55f)
