### PR TITLE
Disable eject option for blocks in the component tree when ejectable set to false in manifest

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ComponentList/ComponentDropdownMenu.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ComponentList/ComponentDropdownMenu.svelte
@@ -7,6 +7,7 @@
   $: definition = store.actions.components.getDefinition(component?._component)
   $: noPaste = !$store.componentToPaste
   $: isBlock = definition?.block === true
+  $: canEject = !(definition?.ejectable === false)
 
   const keyboardEvent = (key, ctrlKey = false) => {
     document.dispatchEvent(
@@ -32,7 +33,7 @@
   >
     Delete
   </MenuItem>
-  {#if isBlock}
+  {#if isBlock && canEject}
     <MenuItem
       icon="Export"
       keyBind="Ctrl+E"

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ComponentList/ComponentKeyHandler.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ComponentList/ComponentKeyHandler.svelte
@@ -32,8 +32,15 @@
       await store.actions.components.paste(component, "below")
     },
     ["Ctrl+e"]: component => {
-      componentToEject = component
-      confirmEjectDialog.show()
+      const definition = store.actions.components.getDefinition(
+        component._component
+      )
+      const isBlock = definition?.block === true
+      const canEject = !(definition?.ejectable === false)
+      if (isBlock && canEject) {
+        componentToEject = component
+        confirmEjectDialog.show()
+      }
     },
     ["Ctrl+Enter"]: () => {
       $goto(`./:componentId/new`)


### PR DESCRIPTION
## Description

- General fix to remove the `Eject Block` option from the context menu if `ejectable` is set to `false` in the component definition. 
- Added type check to the `ctrl-e` keyboard shortcut to only show the eject modal for ejectable block components. Previously there was no type check and the modal would open for `all types`.

## Addresses
[Original Multistep Ticket](https://github.com/Budibase/budibase/pull/12585)

