### PR TITLE
Automation UX updates for name sidebar and test output panel

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -66,6 +66,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@spectrum-css/page": "^3.0.1",
     "@spectrum-css/vars": "^3.0.1",
+    "@zerodevx/svelte-json-view": "^1.0.7",
     "codemirror": "^5.59.0",
     "dayjs": "^1.10.8",
     "downloadjs": "1.4.7",

--- a/packages/builder/src/components/automation/AutomationBuilder/TestDisplay.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/TestDisplay.svelte
@@ -1,7 +1,8 @@
 <script>
-  import { Icon, Divider, Tabs, Tab, TextArea, Label } from "@budibase/bbui"
+  import { Icon, Divider, Tabs, Tab, Label } from "@budibase/bbui"
   import FlowItemHeader from "./FlowChart/FlowItemHeader.svelte"
   import { ActionStepID } from "constants/backend/automations"
+  import { JsonView } from "@zerodevx/svelte-json-view"
 
   export let automation
   export let testResults
@@ -12,13 +13,6 @@
 
   function prepTestResults(results) {
     return results?.steps.filter(x => x.stepId !== ActionStepID.LOOP || [])
-  }
-
-  function textArea(results, message) {
-    if (!results) {
-      return message
-    }
-    return JSON.stringify(results, null, 2)
   }
 
   $: filteredResults = prepTestResults(testResults)
@@ -71,26 +65,34 @@
           {/if}
 
           <div class="tabs">
-            <Tabs noHorizPadding selected="Input">
+            <Tabs quiet noHorizPadding selected="Input">
               <Tab title="Input">
-                <TextArea
-                  minHeight="160px"
-                  disabled
-                  value={textArea(filteredResults?.[idx]?.inputs, "No input")}
-                />
+                <div class="wrap">
+                  {#if filteredResults?.[idx]?.inputs}
+                    <JsonView depth={2} json={filteredResults?.[idx]?.inputs} />
+                  {:else}
+                    No input
+                  {/if}
+                </div>
               </Tab>
               <Tab title="Output">
-                <TextArea
-                  minHeight="160px"
-                  disabled
-                  value={textArea(filteredResults?.[idx]?.outputs, "No output")}
-                />
+                <div class="wrap">
+                  {#if filteredResults?.[idx]?.inputs}
+                    <JsonView
+                      depth={2}
+                      json={filteredResults?.[idx]?.outputs}
+                    />
+                  {:else}
+                    No input
+                  {/if}
+                </div>
               </Tab>
             </Tabs>
           </div>
         {/if}
       {/if}
     </div>
+
     {#if blocks.length - 1 !== idx}
       <div class="separator" />
     {/if}
@@ -104,6 +106,33 @@
     overflow: auto;
   }
 
+  .wrap {
+    font-family: monospace;
+    background-color: var(
+      --spectrum-textfield-m-background-color,
+      var(--spectrum-global-color-gray-50)
+    );
+    border: 1px solid var(--spectrum-global-color-gray-300);
+    font-size: 12px;
+    max-height: 160px; /* Adjusted max-height */
+    height: 160px;
+    --jsonPaddingLeft: 20px;
+    --jsonborderleft: 20px;
+    overflow: auto;
+    overflow: overlay;
+    overflow-x: hidden;
+    padding-left: var(--spacing-s);
+    padding-top: var(--spacing-xl);
+    border-radius: 4px;
+  }
+
+  .wrap::-webkit-scrollbar {
+    width: 7px; /* width of the scrollbar */
+  }
+
+  .wrap::-webkit-scrollbar-track {
+    background: transparent; /* transparent track */
+  }
   .tabs {
     display: flex;
     flex-direction: column;

--- a/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
@@ -30,6 +30,8 @@
       return lowerA > lowerB ? 1 : -1
     })
 
+  $: showNoResults = searchString && !filteredAutomations.length
+
   onMount(async () => {
     try {
       await automationStore.actions.fetch()
@@ -53,18 +55,18 @@
     />
   </div>
   <div class="side-bar-nav">
-    {#if filteredAutomations.length}
-      {#each filteredAutomations as automation}
-        <NavItem
-          text={automation.name}
-          selected={automation._id === selectedAutomationId}
-          on:click={() => selectAutomation(automation._id)}
-          selectedBy={$userSelectedResourceMap[automation._id]}
-        >
-          <EditAutomationPopover {automation} />
-        </NavItem>
-      {/each}
-    {:else}
+    {#each filteredAutomations as automation}
+      <NavItem
+        text={automation.name}
+        selected={automation._id === selectedAutomationId}
+        on:click={() => selectAutomation(automation._id)}
+        selectedBy={$userSelectedResourceMap[automation._id]}
+      >
+        <EditAutomationPopover {automation} />
+      </NavItem>
+    {/each}
+
+    {#if showNoResults}
       <Layout paddingY="none" paddingX="L">
         <div class="no-results">
           There aren't any automations matching that name

--- a/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
@@ -1,6 +1,6 @@
 <script>
   import CreateAutomationModal from "./CreateAutomationModal.svelte"
-  import { Modal, notifications } from "@budibase/bbui"
+  import { Modal, notifications, Layout } from "@budibase/bbui"
   import NavHeader from "components/common/NavHeader.svelte"
   import { onMount } from "svelte"
   import {
@@ -53,16 +53,24 @@
     />
   </div>
   <div class="side-bar-nav">
-    {#each filteredAutomations as automation}
-      <NavItem
-        text={automation.name}
-        selected={automation._id === selectedAutomationId}
-        on:click={() => selectAutomation(automation._id)}
-        selectedBy={$userSelectedResourceMap[automation._id]}
-      >
-        <EditAutomationPopover {automation} />
-      </NavItem>
-    {/each}
+    {#if filteredAutomations.length}
+      {#each filteredAutomations as automation}
+        <NavItem
+          text={automation.name}
+          selected={automation._id === selectedAutomationId}
+          on:click={() => selectAutomation(automation._id)}
+          selectedBy={$userSelectedResourceMap[automation._id]}
+        >
+          <EditAutomationPopover {automation} />
+        </NavItem>
+      {/each}
+    {:else}
+      <Layout paddingY="none" paddingX="L">
+        <div class="no-results">
+          There aren't any automations matching that name
+        </div>
+      </Layout>
+    {/if}
   </div>
 </div>
 
@@ -88,7 +96,6 @@
   }
 
   .side-bar-controls {
-    flex: 0 0 60px;
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
@@ -96,13 +103,13 @@
     gap: var(--spacing-l);
     padding: 0 var(--spacing-l);
   }
-  .side-bar-controls :global(.spectrum-Icon) {
-    color: var(--spectrum-global-color-gray-700);
-  }
-
   .side-bar-nav {
     flex: 1 1 auto;
     overflow: auto;
     overflow-x: hidden;
+  }
+
+  .no-results {
+    color: var(--spectrum-global-color-gray-600);
   }
 </style>

--- a/packages/server/src/automations/steps/filter.ts
+++ b/packages/server/src/automations/steps/filter.ts
@@ -99,7 +99,7 @@ export async function run({ inputs }: AutomationStepInput) {
     } else {
       result = false
     }
-    return { success: true, result }
+    return { success: true, result, refValue: field, comparisonValue: value }
   } catch (err) {
     return { success: false, result: false }
   }


### PR DESCRIPTION

## Description
This PR implements two features. 

- Implement search functionality and sorting for automations in the left pane.
    - Automations are sorted alphabetically in the left pane
    -  You. an client side search your list of automations
    
<img width="248" alt="image" src="https://github.com/Budibase/budibase/assets/5665926/ab3decd5-1ee3-453a-b598-2f2f7d729a0e">

<img width="267" alt="image" src="https://github.com/Budibase/budibase/assets/5665926/33a8857e-7e7b-489f-962f-ff7892fd64d8">

 - Improve the JSON display of automation test output
    - Pulled in a new library for this called `[svelte-json-view](https://www.npmjs.com/package/@zerodevx/svelte-json-view)` 
that provides a nice viewer for the JSON , where you can expand / minimise properties etc with syntax highlighting. 
 
<img width="420" alt="image" src="https://github.com/Budibase/budibase/assets/5665926/3a32b716-9e4e-4815-96b6-95f71646476b">
<img width="409" alt="image" src="https://github.com/Budibase/budibase/assets/5665926/429617d7-6217-400b-b760-91abf6cfd55c">


## Feature branch env
[Feature Branch Link](http://fb-feat-automation-ux.fb.qa.budibase.net)