### PR TITLE
Allow enter key to continue during screen creation

### DIFF
--- a/packages/bbui/src/Modal/ModalContent.svelte
+++ b/packages/bbui/src/Modal/ModalContent.svelte
@@ -40,7 +40,7 @@
     loading = false
   }
 
-  async function confirm() {
+  export async function confirm() {
     loading = true
     if (!onConfirm || (await onConfirm()) !== keepOpen) {
       hide()

--- a/packages/builder/src/components/design/ScreenDetailsModal.svelte
+++ b/packages/builder/src/components/design/ScreenDetailsModal.svelte
@@ -13,6 +13,7 @@
   const appPrefix = "/app"
   let touched = false
   let error
+  let modal
 
   $: appUrl = screenUrl
     ? `${window.location.origin}${appPrefix}${screenUrl}`
@@ -50,6 +51,7 @@
 </script>
 
 <ModalContent
+  bind:this={modal}
   size="M"
   title={"Screen details"}
   {confirmText}
@@ -58,15 +60,17 @@
   cancelText={"Back"}
   disabled={!screenUrl || error || !touched}
 >
-  <Input
-    label="Enter a URL for the new screen"
-    {error}
-    bind:value={screenUrl}
-    on:change={routeChanged}
-  />
-  <div class="app-server" title={appUrl}>
-    {appUrl}
-  </div>
+  <form on:submit|preventDefault={() => modal.confirm()}>
+    <Input
+      label="Enter a URL for the new screen"
+      {error}
+      bind:value={screenUrl}
+      on:change={routeChanged}
+    />
+    <div class="app-server" title={appUrl}>
+      {appUrl}
+    </div>
+  </form>
 </ModalContent>
 
 <style>


### PR DESCRIPTION
## Description
You can now go through the create screen modal flow without using the mouse, unless you change the default role.
The enter key now "presses" the continue button.

## Addresses
- https://github.com/Budibase/budibase/issues/12761

## Screenshots
https://github.com/Budibase/budibase/assets/101575380/a1c10ee7-96a6-4e0a-a7d8-50e5706a70cd


