### PR TITLE
[Bug] Incorrect handling of short passwords in user invitation

### DIFF
--- a/packages/types/src/sdk/locks.ts
+++ b/packages/types/src/sdk/locks.ts
@@ -22,6 +22,7 @@ export enum LockName {
   QUOTA_USAGE_EVENT = "quota_usage_event",
   APP_MIGRATION = "app_migrations",
   PROCESS_AUTO_COLUMNS = "process_auto_columns",
+  PROCESS_USER_INVITE = "process_user_invite",
 }
 
 export type LockOptions = {

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -425,6 +425,6 @@ export const inviteAccept = async (
       ctx.throw(400, err)
     }
     console.warn("Error inviting user", err)
-    ctx.throw(400, "Unable to create new user, invitation invalid.")
+    ctx.throw(400, err || "Unable to create new user, invitation invalid.")
   }
 }

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -12,6 +12,8 @@ import {
   InviteUserRequest,
   InviteUsersRequest,
   InviteUsersResponse,
+  LockName,
+  LockType,
   MigrationType,
   SaveUserResponse,
   SearchUsersRequest,
@@ -27,6 +29,7 @@ import {
   platform,
   tenancy,
   db,
+  locks,
 } from "@budibase/backend-core"
 import { checkAnyUserExists } from "../../../utilities/users"
 import { isEmailConfigured } from "../../../utilities/email"
@@ -380,45 +383,55 @@ export const inviteAccept = async (
 ) => {
   const { inviteCode, password, firstName, lastName } = ctx.request.body
   try {
-    // info is an extension of the user object that was stored by global
-    const { email, info }: any = await cache.invite.getCode(inviteCode)
-    await cache.invite.deleteCode(inviteCode)
-    const user = await tenancy.doInTenant(info.tenantId, async () => {
-      let request: any = {
-        firstName,
-        lastName,
-        password,
-        email,
-        admin: { global: info?.admin?.global || false },
-        roles: info.apps,
-        tenantId: info.tenantId,
-      }
-      let builder: { global: boolean; apps?: string[] } = {
-        global: info?.builder?.global || false,
-      }
+    await locks.doWithLock(
+      {
+        type: LockType.AUTO_EXTEND,
+        name: LockName.PROCESS_USER_INVITE,
+        resource: inviteCode,
+      },
+      async () => {
+        // info is an extension of the user object that was stored by global
+        const { email, info } = await cache.invite.getCode(inviteCode)
+        const user = await tenancy.doInTenant(info.tenantId, async () => {
+          let request: any = {
+            firstName,
+            lastName,
+            password,
+            email,
+            admin: { global: info?.admin?.global || false },
+            roles: info.apps,
+            tenantId: info.tenantId,
+          }
+          const builder: { global: boolean; apps?: string[] } = {
+            global: info?.builder?.global || false,
+          }
 
-      if (info?.builder?.apps) {
-        builder.apps = info.builder.apps
-        request.builder = builder
-      }
-      delete info.apps
-      request = {
-        ...request,
-        ...info,
-      }
+          if (info?.builder?.apps) {
+            builder.apps = info.builder.apps
+            request.builder = builder
+          }
+          delete info.apps
+          request = {
+            ...request,
+            ...info,
+          }
 
-      const saved = await userSdk.db.save(request)
-      const db = tenancy.getGlobalDB()
-      const user = await db.get<User>(saved._id)
-      await events.user.inviteAccepted(user)
-      return saved
-    })
+          const saved = await userSdk.db.save(request)
+          const db = tenancy.getGlobalDB()
+          const user = await db.get<User>(saved._id)
+          await events.user.inviteAccepted(user)
+          return saved
+        })
 
-    ctx.body = {
-      _id: user._id!,
-      _rev: user._rev!,
-      email: user.email,
-    }
+        await cache.invite.deleteCode(inviteCode)
+
+        ctx.body = {
+          _id: user._id!,
+          _rev: user._rev!,
+          email: user.email,
+        }
+      }
+    )
   } catch (err: any) {
     if (err.code === ErrorCode.USAGE_LIMIT_EXCEEDED) {
       // explicitly re-throw limit exceeded errors

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -417,9 +417,7 @@ export const inviteAccept = async (
           }
 
           const saved = await userSdk.db.save(request)
-          const db = tenancy.getGlobalDB()
-          const user = await db.get<User>(saved._id)
-          await events.user.inviteAccepted(user)
+          await events.user.inviteAccepted(saved)
           return saved
         })
 

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -388,6 +388,7 @@ export const inviteAccept = async (
         type: LockType.AUTO_EXTEND,
         name: LockName.PROCESS_USER_INVITE,
         resource: inviteCode,
+        systemLock: true,
       },
       async () => {
         // info is an extension of the user object that was stored by global


### PR DESCRIPTION
## Description
We are facing a problem when inviting a user and there is some creation error. The latest password limits are making this occur more. When a user submits the invite form, we mark the invite code as used. If there is a problem during the creation, such as a data validation issue, the same form can not be submitted as the codes are not valid anymore.

This PR does the following:

1. Invalidate the invite code only when the user has been created properly
2. Use a lock to prevent concurrent processes to use the same invite
3. Return the verbose error message, instead of a generic "unable to create the user"
4. Remove some unnecessary db calls

## Addresses
- [BUDI-7896 - Incorrect Handling of Short Passwords in User Invitation Process](https://linear.app/budibase/issue/BUDI-7896/bug-incorrect-handling-of-short-passwords-in-user-invitation-process)

## Screenshots

https://github.com/Budibase/budibase/assets/15987277/8730ee0b-2095-4df4-af67-2e53cced6555




