### PR TITLE
Global Bindings fixes and updates

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -5602,7 +5602,38 @@
           }
         ]
       }
-    ]
+    ],
+    "context": {
+      "type": "static",
+      "suffix": "provider",
+      "values": [
+        {
+          "label": "Rows",
+          "key": "rows",
+          "type": "array"
+        },
+        {
+          "label": "Extra Info",
+          "key": "info",
+          "type": "string"
+        },
+        {
+          "label": "Rows Length",
+          "key": "rowsLength",
+          "type": "number"
+        },
+        {
+          "label": "Schema",
+          "key": "schema",
+          "type": "object"
+        },
+        {
+          "label": "Page Number",
+          "key": "pageNumber",
+          "type": "number"
+        }
+      ]
+    }
   },
   "cardsblock": {
     "block": true,
@@ -6151,6 +6182,10 @@
       {
         "type": "form",
         "suffix": "form"
+      },
+      {
+        "type": "schema",
+        "suffix": "repeater"
       },
       {
         "type": "static",

--- a/packages/client/src/components/app/DataProvider.svelte
+++ b/packages/client/src/components/app/DataProvider.svelte
@@ -71,7 +71,7 @@
     datasource: dataSource || {},
     schema,
     rowsLength: $fetch.rows.length,
-
+    pageNumber: $fetch.pageNumber + 1,
     // Undocumented properties. These aren't supposed to be used in builder
     // bindings, but are used internally by other components
     id: $component?.id,

--- a/packages/client/src/components/app/Repeater.svelte
+++ b/packages/client/src/components/app/Repeater.svelte
@@ -9,6 +9,7 @@
   export let hAlign
   export let vAlign
   export let gap
+  export let nested = false
 
   const { Provider, ContextScopes } = getContext("sdk")
   const component = getContext("component")
@@ -22,7 +23,10 @@
     <Placeholder />
   {:else if rows.length > 0}
     {#each rows as row, index}
-      <Provider data={{ ...row, index }} scope={ContextScopes.Local}>
+      <Provider
+        data={{ ...row, index }}
+        scope={nested ? ContextScopes.Global : ContextScopes.Local}
+      >
         <slot />
       </Provider>
     {/each}

--- a/packages/client/src/components/app/Repeater.svelte
+++ b/packages/client/src/components/app/Repeater.svelte
@@ -2,6 +2,7 @@
   import { getContext } from "svelte"
   import Placeholder from "./Placeholder.svelte"
   import Container from "./Container.svelte"
+  import { ContextScopes } from "constants"
 
   export let dataProvider
   export let noRowsMessage
@@ -9,9 +10,9 @@
   export let hAlign
   export let vAlign
   export let gap
-  export let nested = false
+  export let scope = ContextScopes.Local
 
-  const { Provider, ContextScopes } = getContext("sdk")
+  const { Provider } = getContext("sdk")
   const component = getContext("component")
 
   $: rows = dataProvider?.rows ?? []
@@ -23,10 +24,7 @@
     <Placeholder />
   {:else if rows.length > 0}
     {#each rows as row, index}
-      <Provider
-        data={{ ...row, index }}
-        scope={nested ? ContextScopes.Global : ContextScopes.Local}
-      >
+      <Provider data={{ ...row, index }} {scope}>
         <slot />
       </Provider>
     {/each}

--- a/packages/client/src/components/app/blocks/TableBlock.svelte
+++ b/packages/client/src/components/app/blocks/TableBlock.svelte
@@ -231,6 +231,7 @@
           paginate,
           limit: rowCount,
         }}
+        context="provider"
         order={1}
       >
         <BlockComponent

--- a/packages/client/src/components/app/blocks/form/FormBlockWrapper.svelte
+++ b/packages/client/src/components/app/blocks/form/FormBlockWrapper.svelte
@@ -55,6 +55,7 @@
           noRowsMessage: noRowsMessage || "We couldn't find a row to display",
           direction: "column",
           hAlign: "center",
+          nested: true,
         }}
       >
         <slot />

--- a/packages/client/src/components/app/blocks/form/FormBlockWrapper.svelte
+++ b/packages/client/src/components/app/blocks/form/FormBlockWrapper.svelte
@@ -10,6 +10,7 @@
   export let noRowsMessage
 
   const component = getContext("component")
+  const { ContextScopes } = getContext("sdk")
 
   $: providerId = `${$component.id}-provider`
   $: dataProvider = `{{ literal ${safe(providerId)} }}`
@@ -55,7 +56,7 @@
           noRowsMessage: noRowsMessage || "We couldn't find a row to display",
           direction: "column",
           hAlign: "center",
-          nested: true,
+          scope: ContextScopes.Global,
         }}
       >
         <slot />


### PR DESCRIPTION
## Description

- Exposed new Global bindings for the Tableblock: `Rows`, `Extra Info`, `Rows Length`, `Schema`, `Page Number`
- `PageNumber` binding fix - General fix for the binding context data in the DataProvider component. An existing issue.
- Added a `scope` prop to the `Repeater` to allow block components to surface their row data globally.
  - In general, repeaters within blocks will only return 1 row so adding it globally makes sense.
  - The default repeater behaviour remains the same. Row data/context is scoped locally to each repeater row.
- Formblock/Multistep Formblock - allow access to internal row data
  - Used the new repeater flag to switch the internal repeater context to global

## Addresses
- https://github.com/Budibase/budibase/pull/11830
