### PR TITLE
Support custom validation rules for ejected block fields

### DIFF
--- a/packages/client/src/components/app/blocks/CardsBlock.svelte
+++ b/packages/client/src/components/app/blocks/CardsBlock.svelte
@@ -88,7 +88,7 @@
     <BlockComponent
       type="form"
       bind:id={formId}
-      props={{ dataSource, disableValidation: true }}
+      props={{ dataSource, disableSchemaValidation: true }}
     >
       {#if title || enrichedSearchColumns?.length || showTitleButton}
         <BlockComponent

--- a/packages/client/src/components/app/blocks/TableBlock.svelte
+++ b/packages/client/src/components/app/blocks/TableBlock.svelte
@@ -147,7 +147,7 @@
       bind:id={formId}
       props={{
         dataSource,
-        disableValidation: true,
+        disableSchemaValidation: true,
         editAutoColumns: true,
         size,
       }}

--- a/packages/client/src/components/app/forms/Form.svelte
+++ b/packages/client/src/components/app/forms/Form.svelte
@@ -14,7 +14,7 @@
 
   // Not exposed as a builder setting. Used internally to disable validation
   // for fields rendered in things like search blocks.
-  export let disableValidation = false
+  export let disableSchemaValidation = false
 
   // Not exposed as a builder setting. Used internally to allow searching on
   // auto columns.
@@ -103,7 +103,7 @@
       {schema}
       {table}
       {initialValues}
-      {disableValidation}
+      {disableSchemaValidation}
       {editAutoColumns}
       {currentStep}
     >

--- a/packages/client/src/components/app/forms/InnerForm.svelte
+++ b/packages/client/src/components/app/forms/InnerForm.svelte
@@ -11,7 +11,7 @@
   export let size
   export let schema
   export let table
-  export let disableValidation = false
+  export let disableSchemaValidation = false
   export let editAutoColumns = false
 
   // We export this store so that when we remount the inner form we can still
@@ -156,17 +156,16 @@
       if (!field) {
         return
       }
-
       // Create validation function based on field schema
-      const schemaConstraints = schema?.[field]?.constraints
-      const validator = disableValidation
+      const schemaConstraints = disableSchemaValidation
         ? null
-        : createValidatorFromConstraints(
-            schemaConstraints,
-            validationRules,
-            field,
-            table
-          )
+        : schema?.[field]?.constraints
+      const validator = createValidatorFromConstraints(
+        schemaConstraints,
+        validationRules,
+        field,
+        table
+      )
 
       // Sanitise the default value to ensure it doesn't contain invalid data
       defaultValue = sanitiseValue(defaultValue, schema?.[field], type)
@@ -332,15 +331,15 @@
       const { value, error } = fieldState
 
       // Create new validator
-      const schemaConstraints = schema?.[field]?.constraints
-      const validator = disableValidation
+      const schemaConstraints = disableSchemaValidation
         ? null
-        : createValidatorFromConstraints(
-            schemaConstraints,
-            validationRules,
-            field,
-            table
-          )
+        : schema?.[field]?.constraints
+      const validator = createValidatorFromConstraints(
+        schemaConstraints,
+        validationRules,
+        field,
+        table
+      )
 
       // Update validator
       fieldInfo.update(state => {


### PR DESCRIPTION
## Description
As a user I wanted to add validation to search fields of an ejected table block, for a custom searching scenario.
This was not possible because table and card blocks were disabling validation for search fields. This makes sense because you wouldn't normally want search fields to be validated, however once the block is ejected and a user adds a custom validation rule, they would expect that rule to be enforced.

I have changed the `disableValidation` prop to `disableSchemaValidation`. This means that search fields in blocks won't trigger any schema level validation, but if a user ejects the block and adds their own validation rule then that will be respected.

## Addresses
- https://github.com/Budibase/budibase/issues/12783

## Screenshots
![Screenshot 2024-01-17 at 10 22 50](https://github.com/Budibase/budibase/assets/101575380/2dcb85ef-40f8-4339-a76b-8637bdb1bdd9)
*Table block with search fields - no validation errors are triggered from the schema*

![Screenshot 2024-01-17 at 10 23 56](https://github.com/Budibase/budibase/assets/101575380/39cbf49f-e20e-4db5-a65f-e7e077ea8a8d)
*Table block ejected, and custom validation rule added to the 'Email' search field*

![Screenshot 2024-01-17 at 10 24 45](https://github.com/Budibase/budibase/assets/101575380/71b015fc-ea7e-46e4-8169-0e2770a5448e)
*Custom validation on search field is now respected.*