### PR TITLE
Fix converting UUID from HBS to js

### DIFF
--- a/packages/string-templates/src/conversion/index.js
+++ b/packages/string-templates/src/conversion/index.js
@@ -112,7 +112,7 @@ module.exports.convertHBSBlock = (block, blockNumber) => {
   const list = getHelperList()
   for (let layer of layers) {
     const parts = splitBySpace(layer)
-    if (value || parts.length > 1) {
+    if (value || parts.length > 1 || list[parts[0]]) {
       // first of layer should always be the helper
       const helper = parts.splice(0, 1)
       if (list[helper]) {

--- a/packages/string-templates/test/hbsToJs.spec.js
+++ b/packages/string-templates/test/hbsToJs.spec.js
@@ -127,4 +127,12 @@ describe("Test that the string processing works correctly", () => {
       "return `average: ${var1} add: ${var2}`;",
     ])
   })
+
+  it("should handle uuids", () => {
+    const response = convertToJS("This is: {{ uuid }}")
+    checkLines(response, [
+      "const var1 = helpers.uuid();",
+      "return `This is: ${var1}`;",
+    ])
+  })
 })


### PR DESCRIPTION
## Description
Converting the uuid helper from hbs to js is not working as expected. This PR is adding a test for it and fixing it

## Screenshots
### Handlebars

![image](https://github.com/Budibase/budibase/assets/15987277/3973ba3c-5cbe-48bc-963d-188e0901a16d)

### JS conversion
| Before | After |
|--------|--------|
| ![image](https://github.com/Budibase/budibase/assets/15987277/ce67429b-a88e-46f5-a6d9-644b677db82a) |  ![image](https://github.com/Budibase/budibase/assets/15987277/5c3e6a21-b9f6-4b35-9077-cc7f317420f3) |
