### PR TITLE
Remove auto naming of columns

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -172,22 +172,6 @@
         }
       }
     }
-    if (!savingColumn && !originalName) {
-      let highestNumber = 0
-      Object.keys(table.schema).forEach(columnName => {
-        const columnNumber = extractColumnNumber(columnName)
-        if (columnNumber > highestNumber) {
-          highestNumber = columnNumber
-        }
-        return highestNumber
-      })
-
-      if (highestNumber >= 1) {
-        editableColumn.name = `Column 0${highestNumber + 1}`
-      } else {
-        editableColumn.name = "Column 01"
-      }
-    }
 
     if (!savingColumn) {
       editableColumn.fieldId = makeFieldId(
@@ -387,11 +371,6 @@
   function hideDeleteDialog() {
     confirmDeleteDialog.hide()
     deleteColName = ""
-  }
-
-  function extractColumnNumber(columnName) {
-    const match = columnName.match(/Column (\d+)/)
-    return match ? parseInt(match[1]) : 0
   }
 
   function getAllowedTypes() {

--- a/packages/builder/src/components/backend/TableNavigator/popovers/EditTablePopover.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/popovers/EditTablePopover.svelte
@@ -17,7 +17,7 @@
 
   export let table
 
-  let editorModal
+  let editorModal, editTableNameModal
   let confirmDeleteDialog
   let error = ""
 
@@ -101,18 +101,21 @@
 
 <Modal bind:this={editorModal} on:show={initForm}>
   <ModalContent
+    bind:this={editTableNameModal}
     title="Edit Table"
     confirmText="Save"
     onConfirm={save}
     disabled={updatedName === originalName || error}
   >
-    <Input
-      label="Table Name"
-      thin
-      bind:value={updatedName}
-      on:input={checkValid}
-      {error}
-    />
+    <form on:submit|preventDefault={() => editTableNameModal.confirm()}>
+      <Input
+        label="Table Name"
+        thin
+        bind:value={updatedName}
+        on:input={checkValid}
+        {error}
+      />
+    </form>
   </ModalContent>
 </Modal>
 <ConfirmDialog

--- a/yarn.lock
+++ b/yarn.lock
@@ -6290,6 +6290,11 @@
     js-yaml "^3.10.0"
     tslib "^2.4.0"
 
+"@zerodevx/svelte-json-view@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@zerodevx/svelte-json-view/-/svelte-json-view-1.0.7.tgz#abf3efa71dedcb3e9d16bc9cc61d5ea98c8d00b1"
+  integrity sha512-yW0MV+9BCKOwzt3h86y3xDqYdI5st+Rxk+L5pa0Utq7nlPD+VvxyhL7R1gJoLxQvWwjyAvY/fyUCFTdwDyI14w==
+
 "@zkochan/js-yaml@0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz#975f0b306e705e28b8068a07737fa46d3fc04826"


### PR DESCRIPTION
## Description
You can now immediately start entering a column name, and do not have to replace the placeholder.

Also made a small update to the edit table name modal so that pressing the 'Enter' key will submit the form and rename the table.

## Addresses
- https://github.com/Budibase/budibase/issues/12802

## Screenshots
![Screenshot 2024-01-19 at 11 11 39](https://github.com/Budibase/budibase/assets/101575380/ed2141e3-2437-424f-883d-7f999a159e0b)
