### PR TITLE
Fix for Button group styling

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -6101,23 +6101,6 @@
       {
         "tag": "style",
         "type": "select",
-        "label": "Size",
-        "key": "size",
-        "options": [
-          {
-            "label": "Medium",
-            "value": "spectrum--medium"
-          },
-          {
-            "label": "Large",
-            "value": "spectrum--large"
-          }
-        ],
-        "defaultValue": "spectrum--medium"
-      },
-      {
-        "tag": "style",
-        "type": "select",
         "label": "Button position",
         "key": "buttonPosition",
         "options": [
@@ -6131,6 +6114,23 @@
           }
         ],
         "defaultValue": "bottom"
+      },
+      {
+        "tag": "style",
+        "type": "select",
+        "label": "Size",
+        "key": "size",
+        "options": [
+          {
+            "label": "Medium",
+            "value": "spectrum--medium"
+          },
+          {
+            "label": "Large",
+            "value": "spectrum--large"
+          }
+        ],
+        "defaultValue": "spectrum--medium"
       }
     ],
     "actions": [

--- a/packages/client/src/components/app/ButtonGroup.svelte
+++ b/packages/client/src/components/app/ButtonGroup.svelte
@@ -29,7 +29,7 @@
           type,
           quiet,
           disabled,
-          size,
+          size: size || "M",
         }}
       />
     {/each}


### PR DESCRIPTION
## Description

- Ensures default sizing for all Buttons within button groups. The default value was undefined which was causing some styling issues.
- Ordering of the style props for Formblock /Multistep Formblock now consistent.

## Addresses
- https://github.com/Budibase/budibase/issues/12800
