### PR TITLE
Feature/count creator plan change

### DIFF
--- a/packages/worker/src/api/controllers/global/self.ts
+++ b/packages/worker/src/api/controllers/global/self.ts
@@ -91,6 +91,9 @@ export async function getSelf(ctx: any) {
     id: userId,
   }
 
+  // Adjust creators quotas (prevents wrong creators count if user has changed the plan)
+  await groups.adjustGroupCreatorsQuotas()
+
   // get the main body of the user
   const user = await userSdk.db.getUser(userId)
   ctx.body = await groups.enrichUserRolesFromGroups(user)


### PR DESCRIPTION
## Description

Take a look here to get more information: https://github.com/Budibase/budibase-pro/pull/257

`adjustGroupCreatorsQuotas` is called to prevent wrong creators count if user has changed the plan.
