### PR TITLE
Add string templates handlebars tests

### DIFF
--- a/packages/string-templates/manifest.json
+++ b/packages/string-templates/manifest.json
@@ -126,7 +126,7 @@
         "array"
       ],
       "numArgs": 1,
-      "example": "{{ sum [1, 2, 3] }} -> 6",
+      "example": "{{ sum 1 2 3 }} -> 6",
       "description": "<p>Returns the sum of all numbers in the given array.</p>\n"
     }
   },

--- a/packages/string-templates/manifest.json
+++ b/packages/string-templates/manifest.json
@@ -126,7 +126,7 @@
         "array"
       ],
       "numArgs": 1,
-      "example": "{{ sum 1 2 3 }} -> 6",
+      "example": "{{ sum '[1, 2, 3]' }} -> 6",
       "description": "<p>Returns the sum of all numbers in the given array.</p>\n"
     }
   },

--- a/packages/string-templates/manifest.json
+++ b/packages/string-templates/manifest.json
@@ -126,7 +126,7 @@
         "array"
       ],
       "numArgs": 1,
-      "example": "{{ sum '[1, 2, 3]' }} -> 6",
+      "example": "{{ sum [1, 2, 3] }} -> 6",
       "description": "<p>Returns the sum of all numbers in the given array.</p>\n"
     }
   },

--- a/packages/string-templates/manifest.json
+++ b/packages/string-templates/manifest.json
@@ -1196,7 +1196,7 @@
         "durationType"
       ],
       "numArgs": 2,
-      "example": "{{duration timeLeft \"seconds\"}} -> a few seconds",
+      "example": "{{duration 8 \"seconds\"}} -> a few seconds",
       "description": "<p>Produce a humanized duration left/until given an amount of time and the type of time measurement.</p>\n"
     }
   }

--- a/packages/string-templates/scripts/gen-collection-info.js
+++ b/packages/string-templates/scripts/gen-collection-info.js
@@ -36,7 +36,7 @@ const ADDED_HELPERS = {
     duration: {
       args: ["time", "durationType"],
       numArgs: 2,
-      example: '{{duration timeLeft "seconds"}} -> a few seconds',
+      example: '{{duration 8 "seconds"}} -> a few seconds',
       description:
         "Produce a humanized duration left/until given an amount of time and the type of time measurement.",
     },

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -1,6 +1,9 @@
 const fs = require("fs")
 const { processString } = require("../src/index.cjs")
 
+const tk = require("timekeeper")
+tk.freeze("2021-01-21T12:00:00")
+
 const manifest = JSON.parse(
   fs.readFileSync(require.resolve("../manifest.json"), "utf8")
 )

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -40,6 +40,18 @@ function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") // $& means the whole matched string
 }
 
+function tryParseJson(str) {
+  if (typeof str !== "string") {
+    return
+  }
+
+  try {
+    return JSON.parse(str.replace(/\'/g, '"'))
+  } catch (e) {
+    return
+  }
+}
+
 describe("manifest", () => {
   describe("examples are valid", () => {
     describe.each(Object.keys(examples))("%s", collection => {
@@ -67,18 +79,15 @@ describe("manifest", () => {
         let result = await processString(hbs, context)
         // Trim 's
         js = js.replace(/^\'|\'$/g, "")
-        try {
-          let parsedExpected
-          if (
-            Array.isArray((parsedExpected = JSON.parse(js.replace(/\'/g, '"'))))
-          ) {
+        if ((parsedExpected = tryParseJson(js))) {
+          if (Array.isArray(parsedExpected)) {
             if (typeof parsedExpected[0] === "object") {
               js = JSON.stringify(parsedExpected)
             } else {
               js = parsedExpected.join(",")
             }
           }
-        } catch {}
+        }
         result = result.replace(/&nbsp;/g, " ")
         expect(result).toEqual(js)
       })

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -50,6 +50,7 @@ describe("manifest", () => {
 
         const context = {
           double: i => i * 2,
+          isString: x => typeof x === "string",
         }
 
         const arrays = hbs.match(/\[[^/\]]+\]/)

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -6,6 +6,14 @@ jest.mock("@budibase/handlebars-helpers/lib/math", () => {
     random: () => 10,
   }
 })
+jest.mock("@budibase/handlebars-helpers/lib/uuid", () => {
+  const actual = jest.requireActual("@budibase/handlebars-helpers/lib/uuid")
+
+  return {
+    ...actual,
+    uuid: () => "f34ebc66-93bd-4f7c-b79b-92b5569138bc",
+  }
+})
 
 const fs = require("fs")
 const { processString } = require("../src/index.cjs")

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -27,7 +27,7 @@ describe("manifest", () => {
       const example = manifest[collection][func].example
 
       let [hbs, js] = example.split("->").map(x => x.trim())
-      hbs = hbs.replace(/'\[1, 2, 3\]'/, "array")
+      hbs = hbs.replace(/\[1, 2, 3\]/, "array")
 
       expect(await processString(hbs, { array: [1, 2, 3] })).toEqual(js)
     })

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -1,3 +1,12 @@
+jest.mock("@budibase/handlebars-helpers/lib/math", () => {
+  const actual = jest.requireActual("@budibase/handlebars-helpers/lib/math")
+
+  return {
+    ...actual,
+    random: () => 10,
+  }
+})
+
 const fs = require("fs")
 const { processString } = require("../src/index.cjs")
 

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -72,7 +72,11 @@ describe("manifest", () => {
           if (
             Array.isArray((parsedExpected = JSON.parse(js.replace(/\'/g, '"'))))
           ) {
-            js = parsedExpected.join(",")
+            if (typeof parsedExpected[0] === "object") {
+              js = JSON.stringify(parsedExpected)
+            } else {
+              js = parsedExpected.join(",")
+            }
           }
         } catch {}
         result = result.replace(/&nbsp;/g, " ")

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -27,9 +27,20 @@ describe("manifest", () => {
       const example = manifest[collection][func].example
 
       let [hbs, js] = example.split("->").map(x => x.trim())
-      hbs = hbs.replace(/\[1, 2, 3\]/, "array")
+      hbs = hbs.replace(/\[1, 2, 3\]/, "array3")
+      hbs = hbs.replace(/\[1, 2, 3, 4\]/, "array4")
 
-      expect(await processString(hbs, { array: [1, 2, 3] })).toEqual(js)
+      if (js === undefined) {
+        // The function has no return value
+        return
+      }
+
+      expect(
+        await processString(hbs, {
+          array3: [1, 2, 3],
+          array4: [1, 2, 3, 4],
+        })
+      ).toEqual(js)
     })
   })
 })

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -32,12 +32,14 @@ describe("manifest", () => {
 
       let [hbs, js] = example.split("->").map(x => x.trim())
 
-      const context = {}
+      const context = {
+        double: i => i * 2,
+      }
 
       const arrays = hbs.match(/\[[^/\]]+\]/)
       arrays.forEach((arrayString, i) => {
         hbs = hbs.replace(new RegExp(escapeRegExp(arrayString)), `array${i}`)
-        context[`array${i}`] = JSON.parse(arrayString)
+        context[`array${i}`] = JSON.parse(arrayString.replace(/\'/g, '"'))
       })
 
       if (js === undefined) {
@@ -46,6 +48,14 @@ describe("manifest", () => {
       }
 
       const result = await processString(hbs, context)
+      try {
+        let parsedExpected
+        if (
+          Array.isArray((parsedExpected = JSON.parse(js.replace(/\'/g, '"'))))
+        ) {
+          js = parsedExpected.join(",")
+        }
+      } catch {}
       expect(result).toEqual(js)
     })
   })

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -26,9 +26,10 @@ describe("manifest", () => {
     it.each(examples)("%s - %s", async (collection, func) => {
       const example = manifest[collection][func].example
 
-      const [hbs, js] = example.split("->").map(x => x.trim())
+      let [hbs, js] = example.split("->").map(x => x.trim())
+      hbs = hbs.replace(/'\[1, 2, 3\]'/, "array")
 
-      expect(await processString(hbs)).toEqual(js)
+      expect(await processString(hbs, { array: [1, 2, 3] })).toEqual(js)
     })
   })
 })

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -1,0 +1,22 @@
+const fs = require("fs")
+const { processString } = require("../src/index.cjs")
+
+const manifest = JSON.parse(
+  fs.readFileSync(require.resolve("../manifest.json"), "utf8")
+)
+
+const examples = Object.keys(manifest).flatMap(collection =>
+  Object.keys(manifest[collection]).map(fnc => [collection, fnc])
+)
+
+describe("manifest", () => {
+  describe("examples are valid", () => {
+    it.each(examples)("%s - %s", async (collection, func) => {
+      const example = manifest[collection][func].example
+
+      const [hbs, js] = example.split("->").map(x => x.trim())
+
+      expect(await processString(hbs)).toEqual(js)
+    })
+  })
+})

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -25,14 +25,10 @@ const manifest = JSON.parse(
   fs.readFileSync(require.resolve("../manifest.json"), "utf8")
 )
 
-const functionsToExclude = { string: ["raw"] }
-
 const collections = Object.keys(manifest)
 const examples = collections.reduce((acc, collection) => {
   const functions = Object.keys(manifest[collection]).filter(
-    fnc =>
-      !functionsToExclude[collection]?.includes(fnc) &&
-      manifest[collection][fnc].example
+    fnc => manifest[collection][fnc].example
   )
   if (functions.length) {
     acc[collection] = functions


### PR DESCRIPTION
## Description
Following https://github.com/Budibase/handlebars-helpers/pull/17, we want to test that our usage of `handlebars-helpers` is working fine with our `string-templates`. We are copying the same pattern, running all the tests based on it's documentation.

Depends on:
- https://github.com/Budibase/handlebars-helpers/pull/17
- https://github.com/Budibase/handlebars-helpers/pull/18

## Addresses
- [BUDI-7883 - Improve budibase/handlebars-helpers and esbuild](https://linear.app/budibase/issue/BUDI-7883/improve-budibasehandlebars-helpers-and-esbuild)