### PR TITLE
Modified planTitle function to accommodate old plans

### DIFF
--- a/packages/builder/src/helpers/planTitle.js
+++ b/packages/builder/src/helpers/planTitle.js
@@ -1,27 +1,27 @@
 import { PlanType } from "@budibase/types"
 
 export function getFormattedPlanName(userPlanType) {
-  let planName;
+  let planName
   switch (userPlanType) {
     case PlanType.PRO:
-      planName = "Pro";
-      break;
+      planName = "Pro"
+      break
     case PlanType.TEAM:
-      planName = "Team";
-      break;
+      planName = "Team"
+      break
     case PlanType.PREMIUM:
     case PlanType.PREMIUM_PLUS:
-      planName = "Premium";
-      break;
+      planName = "Premium"
+      break
     case PlanType.BUSINESS:
-      planName = "Business";
-      break;
+      planName = "Business"
+      break
     case PlanType.ENTERPRISE_BASIC:
     case PlanType.ENTERPRISE:
-      planName = "Enterprise";
-      break;
+      planName = "Enterprise"
+      break
     default:
-      planName = "Free"; // Default to "Free" if the type is not explicitly handled
+      planName = "Free" // Default to "Free" if the type is not explicitly handled
   }
   return `${planName} Plan`
 }

--- a/packages/builder/src/helpers/planTitle.js
+++ b/packages/builder/src/helpers/planTitle.js
@@ -1,11 +1,27 @@
 import { PlanType } from "@budibase/types"
 
 export function getFormattedPlanName(userPlanType) {
-  let planName = "Free"
-  if (userPlanType === PlanType.PREMIUM_PLUS) {
-    planName = "Premium"
-  } else if (userPlanType === PlanType.ENTERPRISE_BASIC) {
-    planName = "Enterprise"
+  let planName;
+  switch (userPlanType) {
+    case PlanType.PRO:
+      planName = "Pro";
+      break;
+    case PlanType.TEAM:
+      planName = "Team";
+      break;
+    case PlanType.PREMIUM:
+    case PlanType.PREMIUM_PLUS:
+      planName = "Premium";
+      break;
+    case PlanType.BUSINESS:
+      planName = "Business";
+      break;
+    case PlanType.ENTERPRISE_BASIC:
+    case PlanType.ENTERPRISE:
+      planName = "Enterprise";
+      break;
+    default:
+      planName = "Free"; // Default to "Free" if the type is not explicitly handled
   }
   return `${planName} Plan`
 }


### PR DESCRIPTION
## Description
Added missing logic to accommodate for older plans. This allows the displaying of these older plan names as well as the new plan names.