### PR TITLE
Add TARGETBUILD to single image build script

### DIFF
--- a/scripts/build-single-image.sh
+++ b/scripts/build-single-image.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 yarn build --scope @budibase/server --scope @budibase/worker
 version=$(./scripts/getCurrentVersion.sh)
-docker build -f hosting/single/Dockerfile -t budibase:latest --build-arg BUDIBASE_VERSION=$version .
+docker build -f hosting/single/Dockerfile -t budibase:latest --build-arg BUDIBASE_VERSION=$version --build-arg TARGETBUILD=single .


### PR DESCRIPTION
## Description
Adds a `TARGETBUILD` build argument in the `docker build` command of the single image.

## Addresses
Single image builds without the `TARGETBUILD` directive are likely to cause issues to deployments in environments other than `docker compose`

## App Export
N/A
## Screenshots
N/A