### PR TITLE
Configurable session expiry

### DIFF
--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -179,6 +179,7 @@ const environment = {
   ...getPackageJsonFields(),
   DISABLE_PINO_LOGGER: process.env.DISABLE_PINO_LOGGER,
   OFFLINE_MODE: process.env.OFFLINE_MODE,
+  SESSION_EXPIRY_SECONDS: process.env.SESSION_EXPIRY_SECONDS,
   _set(key: any, value: any) {
     process.env[key] = value
     // @ts-ignore

--- a/packages/backend-core/src/security/sessions.ts
+++ b/packages/backend-core/src/security/sessions.ts
@@ -1,8 +1,8 @@
-const redis = require("../redis/init")
-const { v4: uuidv4 } = require("uuid")
-const { logWarn } = require("../logging")
-
+import * as redis from "../redis/init"
+import { v4 as uuidv4 } from "uuid"
+import { logWarn } from "../logging"
 import env from "../environment"
+import { Duration } from "../utils"
 import {
   Session,
   ScannedSession,
@@ -10,8 +10,10 @@ import {
   CreateSession,
 } from "@budibase/types"
 
-// a week in seconds
-const EXPIRY_SECONDS = 86400 * 7
+// a week expiry is the default
+const EXPIRY_SECONDS = env.SESSION_EXPIRY_SECONDS
+  ? parseInt(env.SESSION_EXPIRY_SECONDS)
+  : Duration.fromDays(7).toSeconds()
 
 function makeSessionID(userId: string, sessionId: string) {
   return `${userId}/${sessionId}`

--- a/packages/server/src/environment.ts
+++ b/packages/server/src/environment.ts
@@ -60,6 +60,7 @@ const environment = {
   PLUGINS_DIR: process.env.PLUGINS_DIR || "/plugins",
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,
   MAX_IMPORT_SIZE_MB: process.env.MAX_IMPORT_SIZE_MB,
+  SESSION_EXPIRY_SECONDS: process.env.SESSION_EXPIRY_SECONDS,
   // flags
   ALLOW_DEV_AUTOMATIONS: process.env.ALLOW_DEV_AUTOMATIONS,
   DISABLE_THREADING: process.env.DISABLE_THREADING,

--- a/packages/worker/src/environment.ts
+++ b/packages/worker/src/environment.ts
@@ -55,6 +55,7 @@ const environment = {
   CHECKLIST_CACHE_TTL: parseIntSafe(process.env.CHECKLIST_CACHE_TTL) || 3600,
   SESSION_UPDATE_PERIOD: process.env.SESSION_UPDATE_PERIOD,
   ENCRYPTED_TEST_PUBLIC_API_KEY: process.env.ENCRYPTED_TEST_PUBLIC_API_KEY,
+  SESSION_EXPIRY_SECONDS: process.env.SESSION_EXPIRY_SECONDS,
   /**
    * Mock the email service in use - links to ethereal hosted emails are logged instead.
    */


### PR DESCRIPTION
## Description
Adding a 'SESSION_EXPIRY_SECONDS' environment variable which can be set on the services to configure how long before an idle user is logged out.