### PR TITLE
Fix for nested state update parsing

### DIFF
--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -1035,11 +1035,48 @@ export const getAllStateVariables = () => {
   getAllAssets().forEach(asset => {
     findAllMatchingComponents(asset.props, component => {
       const settings = getComponentSettings(component._component)
-      settings
-        .filter(setting => setting.type === "event")
-        .forEach(setting => {
-          eventSettings.push(component[setting.key])
-        })
+
+      const parseEventSettings = (settings, comp) => {
+        settings
+          .filter(setting => setting.type === "event")
+          .forEach(setting => {
+            eventSettings.push(comp[setting.key])
+          })
+      }
+
+      const parseComponentSettings = (settings, component) => {
+        // Parse the nested button configurations
+        settings
+          .filter(setting => setting.type === "buttonConfiguration")
+          .forEach(setting => {
+            const buttonConfig = component[setting.key]
+
+            if (Array.isArray(buttonConfig)) {
+              buttonConfig.forEach(button => {
+                const nestedSettings = getComponentSettings(button._component)
+                parseEventSettings(nestedSettings, button)
+              })
+            }
+          })
+
+        parseEventSettings(settings, component)
+      }
+
+      // Parse the base component settings
+      parseComponentSettings(settings, component)
+
+      // Parse step configuration
+      const stepSetting = settings.find(
+        setting => setting.type === "stepConfiguration"
+      )
+      const steps = stepSetting ? component[stepSetting.key] : []
+      const stepDefinition = getComponentSettings(
+        "@budibase/standard-components/multistepformblockstep"
+      )
+
+      steps.forEach(step => {
+        parseComponentSettings(stepDefinition, step)
+      })
     })
   })
 
@@ -1067,6 +1104,7 @@ export const getAllStateVariables = () => {
       }
     })
   })
+  console.log("STATE BINDINGS ", Array.from(bindingSet))
   return Array.from(bindingSet)
 }
 

--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -1104,7 +1104,6 @@ export const getAllStateVariables = () => {
       }
     })
   })
-  console.log("STATE BINDINGS ", Array.from(bindingSet))
   return Array.from(bindingSet)
 }
 


### PR DESCRIPTION

## Description

Addresses state update action parsing for nested components. Affected components:
- `ButtonGroup`
- `Formblock`
- `Multistep Formblock`

Settings at the root level were all parsed correctly and made available in the global space. However, the components above all store their state update config at different levels. New parsing flows have been added to accomodate them.

## Addresses
- https://github.com/Budibase/budibase/issues/12784

## Feature branch env
[Feature Branch Link](http://fb-fix-action-state-parsing.fb.qa.budibase.net)