### PR TITLE
Attempt to fix Postgres test cases

### DIFF
--- a/packages/server/src/integrations/tests/utils/postgres.ts
+++ b/packages/server/src/integrations/tests/utils/postgres.ts
@@ -9,9 +9,7 @@ const isMac = process.platform === "darwin"
 export async function getDsConfig(): Promise<Datasource> {
   try {
     if (!container) {
-      // postgres 15-bullseye safer bet on Linux
-      const version = isMac ? undefined : "15-bullseye"
-      container = await new GenericContainer("postgres", version)
+      container = await new GenericContainer("postgres", "latest")
         .withExposedPorts(5432)
         .withEnv("POSTGRES_PASSWORD", "password")
         .withWaitStrategy(


### PR DESCRIPTION
## Description
Attempting to fix Postgres test cases in CI, failing consistently right now as the DB isn't starting up correctly - on Linux we were using `15-bullseye` due to some issues with the latest image on Linux, these seem to be resolved, giving a go in CI with latest.