### PR TITLE
Add a check to stringSplit that gives a nicer error message if a non-string is passed.

### DIFF
--- a/packages/server/src/automations/automationUtils.ts
+++ b/packages/server/src/automations/automationUtils.ts
@@ -131,6 +131,9 @@ export function stringSplit(value: string | string[]) {
   if (value == null || Array.isArray(value)) {
     return value || []
   }
+  if (typeof value !== "string") {
+    throw new Error(`Unable to split value of type ${typeof value}: ${value}`)
+  }
   if (value.split("\n").length > 1) {
     value = value.split("\n")
   } else {

--- a/packages/server/src/automations/automationUtils.ts
+++ b/packages/server/src/automations/automationUtils.ts
@@ -128,18 +128,20 @@ export function substituteLoopStep(hbsString: string, substitute: string) {
 }
 
 export function stringSplit(value: string | string[]) {
-  if (value == null || Array.isArray(value)) {
-    return value || []
+  if (value == null) {
+    return []
+  }
+  if (Array.isArray(value)) {
+    return value
   }
   if (typeof value !== "string") {
     throw new Error(`Unable to split value of type ${typeof value}: ${value}`)
   }
-  if (value.split("\n").length > 1) {
-    value = value.split("\n")
-  } else {
-    value = value.split(",")
+  const splitOnNewLine = value.split("\n")
+  if (splitOnNewLine.length > 1) {
+    return splitOnNewLine
   }
-  return value
+  return value.split(",")
 }
 
 export function typecastForLooping(loopStep: LoopStep, input: LoopInput) {


### PR DESCRIPTION
## Description

We're seeing an error in production where an automation is passing a non-string into `stringSplit` and it fails with the error:

```
TypeError: value.split is not a function
```

This PR checks for non-strings and produces a nicer error when it happens so we can figure out what's happening.
