### PR TITLE
Test helpers running as javascript

### DIFF
--- a/packages/string-templates/manifest.json
+++ b/packages/string-templates/manifest.json
@@ -7,7 +7,7 @@
       "numArgs": 1,
       "example": "{{ abs 12012.1000 }} -> 12012.1",
       "description": "<p>Return the magnitude of <code>a</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "add": {
       "args": [
@@ -17,7 +17,7 @@
       "numArgs": 2,
       "example": "{{ add 1 2 }} -> 3",
       "description": "<p>Return the sum of <code>a</code> plus <code>b</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "avg": {
       "args": [
@@ -26,7 +26,7 @@
       "numArgs": 1,
       "example": "{{ avg 1 2 3 4 5 }} -> 3",
       "description": "<p>Returns the average of all numbers in the given array.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "ceil": {
       "args": [
@@ -35,7 +35,7 @@
       "numArgs": 1,
       "example": "{{ ceil 1.2 }} -> 2",
       "description": "<p>Get the <code>Math.ceil()</code> of the given value.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "divide": {
       "args": [
@@ -45,7 +45,7 @@
       "numArgs": 2,
       "example": "{{ divide 10 5 }} -> 2",
       "description": "<p>Divide <code>a</code> by <code>b</code></p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "floor": {
       "args": [
@@ -54,7 +54,7 @@
       "numArgs": 1,
       "example": "{{ floor 1.2 }} -> 1",
       "description": "<p>Get the <code>Math.floor()</code> of the given value.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "minus": {
       "args": [
@@ -64,7 +64,7 @@
       "numArgs": 2,
       "example": "{{ subtract 10 5 }} -> 5",
       "description": "<p>Return the product of <code>a</code> minus <code>b</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "modulo": {
       "args": [
@@ -74,7 +74,7 @@
       "numArgs": 2,
       "example": "{{ modulo 10 5 }} -> 0",
       "description": "<p>Get the remainder of a division operation.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "multiply": {
       "args": [
@@ -84,7 +84,7 @@
       "numArgs": 2,
       "example": "{{ multiply 10 5 }} -> 50",
       "description": "<p>Multiply number <code>a</code> by number <code>b</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "plus": {
       "args": [
@@ -94,7 +94,7 @@
       "numArgs": 2,
       "example": "{{ plus 10 5 }} -> 15",
       "description": "<p>Add <code>a</code> by <code>b</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "random": {
       "args": [
@@ -104,7 +104,7 @@
       "numArgs": 2,
       "example": "{{ random 0 20 }} -> 10",
       "description": "<p>Generate a random number between two values</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "remainder": {
       "args": [
@@ -114,7 +114,7 @@
       "numArgs": 2,
       "example": "{{ remainder 10 6 }} -> 4",
       "description": "<p>Get the remainder when <code>a</code> is divided by <code>b</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "round": {
       "args": [
@@ -123,7 +123,7 @@
       "numArgs": 1,
       "example": "{{ round 10.3 }} -> 10",
       "description": "<p>Round the given number.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "subtract": {
       "args": [
@@ -133,7 +133,7 @@
       "numArgs": 2,
       "example": "{{ subtract 10 5 }} -> 5",
       "description": "<p>Return the product of <code>a</code> minus <code>b</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "sum": {
       "args": [
@@ -142,7 +142,7 @@
       "numArgs": 1,
       "example": "{{ sum [1, 2, 3] }} -> 6",
       "description": "<p>Returns the sum of all numbers in the given array.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     }
   },
   "array": {
@@ -154,7 +154,7 @@
       "numArgs": 2,
       "example": "{{ after ['a', 'b', 'c', 'd'] 2}} -> ['c', 'd']",
       "description": "<p>Returns all of the items in an array after the specified index. Opposite of <a href=\"#before\">before</a>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "arrayify": {
       "args": [
@@ -163,7 +163,7 @@
       "numArgs": 1,
       "example": "{{ arrayify 'foo' }} -> ['foo']",
       "description": "<p>Cast the given <code>value</code> to an array.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "before": {
       "args": [
@@ -173,7 +173,7 @@
       "numArgs": 2,
       "example": "{{ before ['a', 'b', 'c', 'd'] 3}} -> ['a', 'b']",
       "description": "<p>Return all of the items in the collection before the specified count. Opposite of <a href=\"#after\">after</a>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "eachIndex": {
       "args": [
@@ -183,7 +183,7 @@
       "numArgs": 2,
       "example": "{{#eachIndex [1, 2, 3]}} {{item}} is {{index}} {{/eachIndex}} -> ' 1 is 0  2 is 1  3 is 2 '",
       "description": "<p>Iterates the array, listing an item and the index of it.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "filter": {
       "args": [
@@ -194,7 +194,7 @@
       "numArgs": 3,
       "example": "{{#filter [1, 2, 3] 2}}2 Found{{else}}2 not found{{/filter}} -> 2 Found",
       "description": "<p>Block helper that filters the given array and renders the block for values that evaluate to <code>true</code>, otherwise the inverse block is returned.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "first": {
       "args": [
@@ -204,7 +204,7 @@
       "numArgs": 2,
       "example": "{{first [1, 2, 3, 4] 2}} -> 1,2",
       "description": "<p>Returns the first item, or first <code>n</code> items of an array.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "forEach": {
       "args": [
@@ -214,7 +214,7 @@
       "numArgs": 2,
       "example": "{{#forEach [{ 'name': 'John' }] }} {{ name }} {{/forEach}} -> ' John '",
       "description": "<p>Iterates over each item in an array and exposes the current item in the array as context to the inner block. In addition to the current array item, the helper exposes the following variables to the inner block: - <code>index</code> - <code>total</code> - <code>isFirst</code> - <code>isLast</code> Also, <code>@index</code> is exposed as a private variable, and additional private variables may be defined as hash arguments.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "inArray": {
       "args": [
@@ -225,7 +225,7 @@
       "numArgs": 3,
       "example": "{{#inArray [1, 2, 3] 2}} 2 exists {{else}} 2 does not exist {{/inArray}} -> ' 2 exists '",
       "description": "<p>Block helper that renders the block if an array has the given <code>value</code>. Optionally specify an inverse block to render when the array does not have the given value.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "isArray": {
       "args": [
@@ -234,7 +234,7 @@
       "numArgs": 1,
       "example": "{{isArray [1, 2]}} -> true",
       "description": "<p>Returns true if <code>value</code> is an es5 array.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "itemAt": {
       "args": [
@@ -244,7 +244,7 @@
       "numArgs": 2,
       "example": "{{itemAt [1, 2, 3] 1}} -> 2",
       "description": "<p>Returns the item from <code>array</code> at index <code>idx</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "join": {
       "args": [
@@ -254,7 +254,7 @@
       "numArgs": 2,
       "example": "{{join [1, 2, 3]}} -> 1, 2, 3",
       "description": "<p>Join all elements of array into a string, optionally using a given separator.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "equalsLength": {
       "args": [
@@ -264,7 +264,7 @@
       "numArgs": 2,
       "example": "{{equalsLength [1, 2, 3] 3}} -> true",
       "description": "<p>Returns true if the the length of the given <code>value</code> is equal to the given <code>length</code>. Can be used as a block or inline helper.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "last": {
       "args": [
@@ -274,7 +274,7 @@
       "numArgs": 2,
       "example": "{{last [1, 2, 3]}} -> 3",
       "description": "<p>Returns the last item, or last <code>n</code> items of an array or string. Opposite of <a href=\"#first\">first</a>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "length": {
       "args": [
@@ -283,7 +283,7 @@
       "numArgs": 1,
       "example": "{{length [1, 2, 3]}} -> 3",
       "description": "<p>Returns the length of the given string or array.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "lengthEqual": {
       "args": [
@@ -293,7 +293,7 @@
       "numArgs": 2,
       "example": "{{equalsLength [1, 2, 3] 3}} -> true",
       "description": "<p>Returns true if the the length of the given <code>value</code> is equal to the given <code>length</code>. Can be used as a block or inline helper.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "map": {
       "args": [
@@ -303,7 +303,7 @@
       "numArgs": 2,
       "example": "{{map [1, 2, 3] double}} -> [2, 4, 6]",
       "description": "<p>Returns a new array, created by calling <code>function</code> on each element of the given <code>array</code>. For example,</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "pluck": {
       "args": [
@@ -313,7 +313,7 @@
       "numArgs": 2,
       "example": "{{pluck [{ 'name': 'Bob' }] 'name' }} -> ['Bob']",
       "description": "<p>Map over the given object or array or objects and create an array of values from the given <code>prop</code>. Dot-notation may be used (as a string) to get nested properties.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "reverse": {
       "args": [
@@ -322,7 +322,7 @@
       "numArgs": 1,
       "example": "{{reverse [1, 2, 3]}} -> [3, 2, 1]",
       "description": "<p>Reverse the elements in an array, or the characters in a string.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "some": {
       "args": [
@@ -333,7 +333,7 @@
       "numArgs": 3,
       "example": "{{#some [1, \"b\", 3] isString}} string found {{else}} No string found {{/some}} -> ' string found '",
       "description": "<p>Block helper that returns the block if the callback returns true for some value in the given array.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "sort": {
       "args": [
@@ -343,7 +343,7 @@
       "numArgs": 2,
       "example": "{{ sort ['b', 'a', 'c'] }} -> ['a', 'b', 'c']",
       "description": "<p>Sort the given <code>array</code>. If an array of objects is passed, you may optionally pass a <code>key</code> to sort on as the second argument. You may alternatively pass a sorting function as the second argument.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "sortBy": {
       "args": [
@@ -353,7 +353,7 @@
       "numArgs": 2,
       "example": "{{ sortBy [{'a': 'zzz'}, {'a': 'aaa'}] 'a' }} -> [{'a':'aaa'},{'a':'zzz'}]",
       "description": "<p>Sort an <code>array</code>. If an array of objects is passed, you may optionally pass a <code>key</code> to sort on as the second argument. You may alternatively pass a sorting function as the second argument.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "withAfter": {
       "args": [
@@ -364,7 +364,7 @@
       "numArgs": 3,
       "example": "{{#withAfter [1, 2, 3] 1 }} {{this}} {{/withAfter}} -> ' 2  3 '",
       "description": "<p>Use the items in the array <em>after</em> the specified index as context inside a block. Opposite of <a href=\"#withBefore\">withBefore</a>.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "withBefore": {
       "args": [
@@ -375,7 +375,7 @@
       "numArgs": 3,
       "example": "{{#withBefore [1, 2, 3] 2 }} {{this}} {{/withBefore}} -> ' 1 '",
       "description": "<p>Use the items in the array <em>before</em> the specified index as context inside a block. Opposite of <a href=\"#withAfter\">withAfter</a>.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "withFirst": {
       "args": [
@@ -386,7 +386,7 @@
       "numArgs": 3,
       "example": "{{#withFirst [1, 2, 3] }}{{this}}{{/withFirst}} -> 1",
       "description": "<p>Use the first item in a collection inside a handlebars block expression. Opposite of <a href=\"#withLast\">withLast</a>.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "withGroup": {
       "args": [
@@ -397,7 +397,7 @@
       "numArgs": 3,
       "example": "{{#withGroup [1, 2, 3, 4] 2}}{{#each this}}{{.}}{{/each}}<br>{{/withGroup}} -> 12<br>34<br>",
       "description": "<p>Block helper that groups array elements by given group <code>size</code>.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "withLast": {
       "args": [
@@ -408,7 +408,7 @@
       "numArgs": 3,
       "example": "{{#withLast [1, 2, 3, 4]}}{{this}}{{/withLast}} -> 4",
       "description": "<p>Use the last item or <code>n</code> items in an array as context inside a block. Opposite of <a href=\"#withFirst\">withFirst</a>.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "withSort": {
       "args": [
@@ -419,7 +419,7 @@
       "numArgs": 3,
       "example": "{{#withSort ['b', 'a', 'c']}}{{this}}{{/withSort}} -> abc",
       "description": "<p>Block helper that sorts a collection and exposes the sorted collection as context inside the block.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "unique": {
       "args": [
@@ -429,7 +429,7 @@
       "numArgs": 2,
       "example": "{{#each (unique ['a', 'a', 'c', 'b', 'e', 'e']) }}{{.}}{{/each}} -> acbe",
       "description": "<p>Block helper that return an array with all duplicate values removed. Best used along with a <a href=\"#each\">each</a> helper.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     }
   },
   "number": {
@@ -440,7 +440,7 @@
       "numArgs": 1,
       "example": "{{ bytes 1386 1 }} -> 1.4 kB",
       "description": "<p>Format a number to it&#39;s equivalent in bytes. If a string is passed, it&#39;s length will be formatted and returned. <strong>Examples:</strong> - <code>&#39;foo&#39; =&gt; 3 B</code> - <code>13661855 =&gt; 13.66 MB</code> - <code>825399 =&gt; 825.39 kB</code> - <code>1396 =&gt; 1.4 kB</code></p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "addCommas": {
       "args": [
@@ -449,7 +449,7 @@
       "numArgs": 1,
       "example": "{{ addCommas 1000000 }} -> 1,000,000",
       "description": "<p>Add commas to numbers</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "phoneNumber": {
       "args": [
@@ -458,7 +458,7 @@
       "numArgs": 1,
       "example": "{{ phoneNumber 8005551212 }} -> (800) 555-1212",
       "description": "<p>Convert a string or number to a formatted phone number.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "toAbbr": {
       "args": [
@@ -468,7 +468,7 @@
       "numArgs": 2,
       "example": "{{ toAbbr 10123 2 }} -> 10.12k",
       "description": "<p>Abbreviate numbers to the given number of <code>precision</code>. This for general numbers, not size in bytes.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "toExponential": {
       "args": [
@@ -478,7 +478,7 @@
       "numArgs": 2,
       "example": "{{ toExponential 10123 2 }} -> 1.01e+4",
       "description": "<p>Returns a string representing the given number in exponential notation.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "toFixed": {
       "args": [
@@ -488,7 +488,7 @@
       "numArgs": 2,
       "example": "{{ toFixed 1.1234 2 }} -> 1.12",
       "description": "<p>Formats the given number using fixed-point notation.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "toFloat": {
       "args": [
@@ -496,7 +496,7 @@
       ],
       "numArgs": 1,
       "description": "<p>Convert input to a float.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "toInt": {
       "args": [
@@ -504,7 +504,7 @@
       ],
       "numArgs": 1,
       "description": "<p>Convert input to an integer.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "toPrecision": {
       "args": [
@@ -514,7 +514,7 @@
       "numArgs": 2,
       "example": "{{toPrecision '1.1234' 2}} -> 1.1",
       "description": "<p>Returns a string representing the <code>Number</code> object to the specified precision.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     }
   },
   "url": {
@@ -525,7 +525,7 @@
       "numArgs": 1,
       "example": "{{ encodeURI 'https://myurl?Hello There' }} -> https%3A%2F%2Fmyurl%3FHello%20There",
       "description": "<p>Encodes a Uniform Resource Identifier (URI) component by replacing each instance of certain characters by one, two, three, or four escape sequences representing the UTF-8 encoding of the character.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "escape": {
       "args": [
@@ -534,7 +534,7 @@
       "numArgs": 1,
       "example": "{{ escape 'https://myurl?Hello+There' }} -> https%3A%2F%2Fmyurl%3FHello%2BThere",
       "description": "<p>Escape the given string by replacing characters with escape sequences. Useful for allowing the string to be used in a URL, etc.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "decodeURI": {
       "args": [
@@ -543,7 +543,7 @@
       "numArgs": 1,
       "example": "{{ decodeURI 'https://myurl?Hello%20There' }} -> https://myurl?Hello There",
       "description": "<p>Decode a Uniform Resource Identifier (URI) component.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "urlResolve": {
       "args": [
@@ -553,7 +553,7 @@
       "numArgs": 2,
       "example": "{{ urlResolve 'https://myurl' '/api/test' }} -> https://myurl/api/test",
       "description": "<p>Take a base URL, and a href URL, and resolve them as a browser would for an anchor tag.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "urlParse": {
       "args": [
@@ -562,7 +562,7 @@
       "numArgs": 1,
       "example": "{{ urlParse 'https://myurl/api/test' }}",
       "description": "<p>Parses a <code>url</code> string into an object.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "stripQuerystring": {
       "args": [
@@ -571,7 +571,7 @@
       "numArgs": 1,
       "example": "{{ stripQuerystring 'https://myurl/api/test?foo=bar' }} -> 'https://myurl/api/test'",
       "description": "<p>Strip the query string from the given <code>url</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "stripProtocol": {
       "args": [
@@ -580,7 +580,7 @@
       "numArgs": 1,
       "example": "{{ stripProtocol 'https://myurl/api/test' }} -> '//myurl/api/test'",
       "description": "<p>Strip protocol from a <code>url</code>. Useful for displaying media that may have an &#39;http&#39; protocol on secure connections.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     }
   },
   "string": {
@@ -592,7 +592,7 @@
       "numArgs": 2,
       "example": "{{append 'index' '.html'}} -> index.html",
       "description": "<p>Append the specified <code>suffix</code> to the given string.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "camelcase": {
       "args": [
@@ -601,7 +601,7 @@
       "numArgs": 1,
       "example": "{{camelcase 'foo bar baz'}} ->  fooBarBaz",
       "description": "<p>camelCase the characters in the given <code>string</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "capitalize": {
       "args": [
@@ -610,7 +610,7 @@
       "numArgs": 1,
       "example": "{{capitalize 'foo bar baz'}} ->  Foo bar baz",
       "description": "<p>Capitalize the first word in a sentence.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "capitalizeAll": {
       "args": [
@@ -619,7 +619,7 @@
       "numArgs": 1,
       "example": "{{ capitalizeAll 'foo bar baz'}} ->  Foo Bar Baz",
       "description": "<p>Capitalize all words in a string.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "center": {
       "args": [
@@ -629,7 +629,7 @@
       "numArgs": 2,
       "example": "{{ center 'test' 1}} -> ' test '",
       "description": "<p>Center a string using non-breaking spaces</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "chop": {
       "args": [
@@ -638,7 +638,7 @@
       "numArgs": 1,
       "example": "{{ chop ' ABC '}} -> ABC",
       "description": "<p>Like trim, but removes both extraneous whitespace <strong>and non-word characters</strong> from the beginning and end of a string.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "dashcase": {
       "args": [
@@ -647,7 +647,7 @@
       "numArgs": 1,
       "example": "{{dashcase 'a-b-c d_e'}} -> a-b-c-d-e",
       "description": "<p>dash-case the characters in <code>string</code>. Replaces non-word characters and periods with hyphens.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "dotcase": {
       "args": [
@@ -656,7 +656,7 @@
       "numArgs": 1,
       "example": "{{dotcase 'a-b-c d_e'}} -> a.b.c.d.e",
       "description": "<p>dot.case the characters in <code>string</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "downcase": {
       "args": [
@@ -665,7 +665,7 @@
       "numArgs": 1,
       "example": "{{downcase 'aBcDeF'}} -> abcdef",
       "description": "<p>Lowercase all of the characters in the given string. Alias for <a href=\"#lowercase\">lowercase</a>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "ellipsis": {
       "args": [
@@ -675,7 +675,7 @@
       "numArgs": 2,
       "example": "{{ellipsis 'foo bar baz' 7}} -> foo bar…",
       "description": "<p>Truncates a string to the specified <code>length</code>, and appends it with an elipsis, <code>…</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "hyphenate": {
       "args": [
@@ -684,7 +684,7 @@
       "numArgs": 1,
       "example": "{{hyphenate 'foo bar baz qux'}} -> foo-bar-baz-qux",
       "description": "<p>Replace spaces in a string with hyphens.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "isString": {
       "args": [
@@ -693,7 +693,7 @@
       "numArgs": 1,
       "example": "{{isString 'foo'}} -> true",
       "description": "<p>Return true if <code>value</code> is a string.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "lowercase": {
       "args": [
@@ -702,7 +702,7 @@
       "numArgs": 1,
       "example": "{{lowercase 'Foo BAR baZ'}} -> foo bar baz",
       "description": "<p>Lowercase all characters in the given string.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "occurrences": {
       "args": [
@@ -712,7 +712,7 @@
       "numArgs": 2,
       "example": "{{occurrences 'foo bar foo bar baz' 'foo'}} -> 2",
       "description": "<p>Return the number of occurrences of <code>substring</code> within the given <code>string</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "pascalcase": {
       "args": [
@@ -721,7 +721,7 @@
       "numArgs": 1,
       "example": "{{pascalcase 'foo bar baz'}} -> FooBarBaz",
       "description": "<p>PascalCase the characters in <code>string</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "pathcase": {
       "args": [
@@ -730,7 +730,7 @@
       "numArgs": 1,
       "example": "{{pathcase 'a-b-c d_e'}} -> a/b/c/d/e",
       "description": "<p>path/case the characters in <code>string</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "plusify": {
       "args": [
@@ -739,7 +739,7 @@
       "numArgs": 1,
       "example": "{{plusify 'foo bar baz'}} -> foo+bar+baz",
       "description": "<p>Replace spaces in the given string with pluses.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "prepend": {
       "args": [
@@ -749,7 +749,7 @@
       "numArgs": 2,
       "example": "{{prepend 'bar' 'foo-'}} -> foo-bar",
       "description": "<p>Prepends the given <code>string</code> with the specified <code>prefix</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "remove": {
       "args": [
@@ -759,7 +759,7 @@
       "numArgs": 2,
       "example": "{{remove 'a b a b a b' 'a '}} -> b b b",
       "description": "<p>Remove all occurrences of <code>substring</code> from the given <code>str</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "removeFirst": {
       "args": [
@@ -769,7 +769,7 @@
       "numArgs": 2,
       "example": "{{removeFirst 'a b a b a b' 'a'}} -> ' b a b a b'",
       "description": "<p>Remove the first occurrence of <code>substring</code> from the given <code>str</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "replace": {
       "args": [
@@ -780,7 +780,7 @@
       "numArgs": 3,
       "example": "{{replace 'a b a b a b' 'a' 'z'}} -> z b z b z b",
       "description": "<p>Replace all occurrences of substring <code>a</code> with substring <code>b</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "replaceFirst": {
       "args": [
@@ -791,7 +791,7 @@
       "numArgs": 3,
       "example": "{{replaceFirst 'a b a b a b' 'a' 'z'}} -> z b a b a b",
       "description": "<p>Replace the first occurrence of substring <code>a</code> with substring <code>b</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "sentence": {
       "args": [
@@ -800,7 +800,7 @@
       "numArgs": 1,
       "example": "{{sentence 'hello world. goodbye world.'}} -> Hello world. Goodbye world.",
       "description": "<p>Sentence case the given string</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "snakecase": {
       "args": [
@@ -809,7 +809,7 @@
       "numArgs": 1,
       "example": "{{snakecase 'a-b-c d_e'}} -> a_b_c_d_e",
       "description": "<p>snake_case the characters in the given <code>string</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "split": {
       "args": [
@@ -818,7 +818,7 @@
       "numArgs": 1,
       "example": "{{split 'a,b,c'}} -> ['a', 'b', 'c']",
       "description": "<p>Split <code>string</code> by the given <code>character</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "startsWith": {
       "args": [
@@ -829,7 +829,7 @@
       "numArgs": 3,
       "example": "{{#startsWith 'Goodbye' 'Hello, world!'}}Yep{{else}}Nope{{/startsWith}} -> Nope",
       "description": "<p>Tests whether a string begins with the given prefix.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "titleize": {
       "args": [
@@ -838,7 +838,7 @@
       "numArgs": 1,
       "example": "{{titleize 'this is title case' }} -> This Is Title Case",
       "description": "<p>Title case the given string.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "trim": {
       "args": [
@@ -847,7 +847,7 @@
       "numArgs": 1,
       "example": "{{trim '  ABC  ' }} -> ABC",
       "description": "<p>Removes extraneous whitespace from the beginning and end of a string.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "trimLeft": {
       "args": [
@@ -856,7 +856,7 @@
       "numArgs": 1,
       "example": "{{trimLeft '  ABC ' }} -> 'ABC '",
       "description": "<p>Removes extraneous whitespace from the beginning of a string.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "trimRight": {
       "args": [
@@ -865,7 +865,7 @@
       "numArgs": 1,
       "example": "{{trimRight '  ABC ' }} ->  '  ABC'",
       "description": "<p>Removes extraneous whitespace from the end of a string.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "truncate": {
       "args": [
@@ -876,7 +876,7 @@
       "numArgs": 3,
       "example": "{{truncate 'foo bar baz' 7 }} -> foo bar",
       "description": "<p>Truncate a string to the specified <code>length</code>. Also see <a href=\"#ellipsis\">ellipsis</a>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "truncateWords": {
       "args": [
@@ -887,7 +887,7 @@
       "numArgs": 3,
       "example": "{{truncateWords 'foo bar baz' 1 }} -> foo…",
       "description": "<p>Truncate a string to have the specified number of words. Also see <a href=\"#truncate\">truncate</a>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "upcase": {
       "args": [
@@ -896,7 +896,7 @@
       "numArgs": 1,
       "example": "{{upcase 'aBcDef'}} -> ABCDEF",
       "description": "<p>Uppercase all of the characters in the given string. Alias for <a href=\"#uppercase\">uppercase</a>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "uppercase": {
       "args": [
@@ -906,7 +906,7 @@
       "numArgs": 2,
       "example": "{{uppercase 'aBcDef'}} -> ABCDEF",
       "description": "<p>Uppercase all of the characters in the given string. If used as a block helper it will uppercase the entire block. This helper does not support inverse blocks.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     }
   },
   "comparison": {
@@ -919,7 +919,7 @@
       "numArgs": 3,
       "example": "{{#and great magnificent}}both{{else}}no{{/and}} -> no",
       "description": "<p>Helper that renders the block if <strong>both</strong> of the given values are truthy. If an inverse block is specified it will be rendered when falsy. Works as a block helper, inline helper or subexpression.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "compare": {
       "args": [
@@ -931,7 +931,7 @@
       "numArgs": 4,
       "example": "{{compare 10 '<' 5 }} -> false",
       "description": "<p>Render a block when a comparison of the first and third arguments returns true. The second argument is the [arithemetic operator][operators] to use. You may also optionally specify an inverse block to render when falsy.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "contains": {
       "args": [
@@ -943,7 +943,7 @@
       "numArgs": 4,
       "example": "{{#contains ['a', 'b', 'c'] 'd'}} This will not be rendered. {{else}} This will be rendered. {{/contains}} -> ' This will be rendered. '",
       "description": "<p>Block helper that renders the block if <code>collection</code> has the given <code>value</code>, using strict equality (<code>===</code>) for comparison, otherwise the inverse block is rendered (if specified). If a <code>startIndex</code> is specified and is negative, it is used as the offset from the end of the collection.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "default": {
       "args": [
@@ -953,7 +953,7 @@
       "numArgs": 2,
       "example": "{{default null null 'default'}} -> default",
       "description": "<p>Returns the first value that is not undefined, otherwise the &#39;default&#39; value is returned.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "eq": {
       "args": [
@@ -964,7 +964,7 @@
       "numArgs": 3,
       "example": "{{#eq 3 3}}equal{{else}}not equal{{/eq}} -> equal",
       "description": "<p>Block helper that renders a block if <code>a</code> is <strong>equal to</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. You may optionally use the <code>compare=&#39;&#39;</code> hash argument for the second value.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "gt": {
       "args": [
@@ -975,7 +975,7 @@
       "numArgs": 3,
       "example": "{{#gt 4 3}} greater than{{else}} not greater than{{/gt}} -> ' greater than'",
       "description": "<p>Block helper that renders a block if <code>a</code> is <strong>greater than</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. You may optionally use the <code>compare=&#39;&#39;</code> hash argument for the second value.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "gte": {
       "args": [
@@ -986,7 +986,7 @@
       "numArgs": 3,
       "example": "{{#gte 4 3}} greater than or equal{{else}} not greater than{{/gte}} -> ' greater than or equal'",
       "description": "<p>Block helper that renders a block if <code>a</code> is <strong>greater than or equal to</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. You may optionally use the <code>compare=&#39;&#39;</code> hash argument for the second value.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "has": {
       "args": [
@@ -997,7 +997,7 @@
       "numArgs": 3,
       "example": "{{#has 'foobar' 'foo'}}has it{{else}}doesn't{{/has}} -> has it",
       "description": "<p>Block helper that renders a block if <code>value</code> has <code>pattern</code>. If an inverse block is specified it will be rendered when falsy.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "isFalsey": {
       "args": [
@@ -1007,7 +1007,7 @@
       "numArgs": 2,
       "example": "{{isFalsey '' }} -> true",
       "description": "<p>Returns true if the given <code>value</code> is falsey. Uses the [falsey][] library for comparisons. Please see that library for more information or to report bugs with this helper.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "isTruthy": {
       "args": [
@@ -1017,7 +1017,7 @@
       "numArgs": 2,
       "example": "{{isTruthy '12' }} -> true",
       "description": "<p>Returns true if the given <code>value</code> is truthy. Uses the [falsey][] library for comparisons. Please see that library for more information or to report bugs with this helper.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "ifEven": {
       "args": [
@@ -1027,7 +1027,7 @@
       "numArgs": 2,
       "example": "{{#ifEven 2}} even {{else}} odd {{/ifEven}} -> ' even '",
       "description": "<p>Return true if the given value is an even number.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "ifNth": {
       "args": [
@@ -1038,7 +1038,7 @@
       "numArgs": 3,
       "example": "{{#ifNth 2 10}}remainder{{else}}no remainder{{/ifNth}} -> remainder",
       "description": "<p>Conditionally renders a block if the remainder is zero when <code>b</code> operand is divided by <code>a</code>. If an inverse block is specified it will be rendered when the remainder is <strong>not zero</strong>.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "ifOdd": {
       "args": [
@@ -1048,7 +1048,7 @@
       "numArgs": 2,
       "example": "{{#ifOdd 3}}odd{{else}}even{{/ifOdd}} -> odd",
       "description": "<p>Block helper that renders a block if <code>value</code> is <strong>an odd number</strong>. If an inverse block is specified it will be rendered when falsy.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "is": {
       "args": [
@@ -1059,7 +1059,7 @@
       "numArgs": 3,
       "example": "{{#is 3 3}} is {{else}} is not {{/is}} -> ' is '",
       "description": "<p>Block helper that renders a block if <code>a</code> is <strong>equal to</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. Similar to <a href=\"#eq\">eq</a> but does not do strict equality.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "isnt": {
       "args": [
@@ -1070,7 +1070,7 @@
       "numArgs": 3,
       "example": "{{#isnt 3 3}} isnt {{else}} is {{/isnt}} -> ' is '",
       "description": "<p>Block helper that renders a block if <code>a</code> is <strong>not equal to</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. Similar to <a href=\"#unlesseq\">unlessEq</a> but does not use strict equality for comparisons.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "lt": {
       "args": [
@@ -1080,7 +1080,7 @@
       "numArgs": 2,
       "example": "{{#lt 2 3}} less than {{else}} more than or equal {{/lt}} -> ' less than '",
       "description": "<p>Block helper that renders a block if <code>a</code> is <strong>less than</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. You may optionally use the <code>compare=&#39;&#39;</code> hash argument for the second value.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "lte": {
       "args": [
@@ -1091,7 +1091,7 @@
       "numArgs": 3,
       "example": "{{#lte 2 3}} less than or equal {{else}} more than {{/lte}} -> ' less than or equal '",
       "description": "<p>Block helper that renders a block if <code>a</code> is <strong>less than or equal to</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. You may optionally use the <code>compare=&#39;&#39;</code> hash argument for the second value.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "neither": {
       "args": [
@@ -1102,7 +1102,7 @@
       "numArgs": 3,
       "example": "{{#neither null null}}both falsey{{else}}both not falsey{{/neither}} -> both falsey",
       "description": "<p>Block helper that renders a block if <strong>neither of</strong> the given values are truthy. If an inverse block is specified it will be rendered when falsy.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "not": {
       "args": [
@@ -1112,7 +1112,7 @@
       "numArgs": 2,
       "example": "{{#not undefined }}falsey{{else}}not falsey{{/not}} -> falsey",
       "description": "<p>Returns true if <code>val</code> is falsey. Works as a block or inline helper.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "or": {
       "args": [
@@ -1122,7 +1122,7 @@
       "numArgs": 2,
       "example": "{{#or 1 2 undefined }} at least one truthy {{else}} all falsey {{/or}} -> ' at least one truthy '",
       "description": "<p>Block helper that renders a block if <strong>any of</strong> the given values is truthy. If an inverse block is specified it will be rendered when falsy.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "unlessEq": {
       "args": [
@@ -1133,7 +1133,7 @@
       "numArgs": 3,
       "example": "{{#unlessEq 2 1 }} not equal {{else}} equal {{/unlessEq}} -> ' not equal '",
       "description": "<p>Block helper that always renders the inverse block <strong>unless <code>a</code> is equal to <code>b</code></strong>.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "unlessGt": {
       "args": [
@@ -1144,7 +1144,7 @@
       "numArgs": 3,
       "example": "{{#unlessGt 20 1 }} not greater than {{else}} greater than {{/unlessGt}} -> ' greater than '",
       "description": "<p>Block helper that always renders the inverse block <strong>unless <code>a</code> is greater than <code>b</code></strong>.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "unlessLt": {
       "args": [
@@ -1155,7 +1155,7 @@
       "numArgs": 3,
       "example": "{{#unlessLt 20 1 }}greater than or equal{{else}}less than{{/unlessLt}} -> greater than or equal",
       "description": "<p>Block helper that always renders the inverse block <strong>unless <code>a</code> is less than <code>b</code></strong>.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "unlessGteq": {
       "args": [
@@ -1166,7 +1166,7 @@
       "numArgs": 3,
       "example": "{{#unlessGteq 20 1 }} less than {{else}}greater than or equal to{{/unlessGteq}} -> greater than or equal to",
       "description": "<p>Block helper that always renders the inverse block <strong>unless <code>a</code> is greater than or equal to <code>b</code></strong>.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "unlessLteq": {
       "args": [
@@ -1177,7 +1177,7 @@
       "numArgs": 3,
       "example": "{{#unlessLteq 20 1 }} greater than {{else}} less than or equal to {{/unlessLteq}} -> ' greater than '",
       "description": "<p>Block helper that always renders the inverse block <strong>unless <code>a</code> is less than or equal to <code>b</code></strong>.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     }
   },
   "object": {
@@ -1187,7 +1187,7 @@
       ],
       "numArgs": 1,
       "description": "<p>Extend the context with the properties of other objects. A shallow merge is performed to avoid mutating the context.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "forIn": {
       "args": [
@@ -1196,7 +1196,7 @@
       ],
       "numArgs": 2,
       "description": "<p>Block helper that iterates over the properties of an object, exposing each key and value on the context.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "forOwn": {
       "args": [
@@ -1205,7 +1205,7 @@
       ],
       "numArgs": 2,
       "description": "<p>Block helper that iterates over the <strong>own</strong> properties of an object, exposing each key and value on the context.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "toPath": {
       "args": [
@@ -1213,7 +1213,7 @@
       ],
       "numArgs": 1,
       "description": "<p>Take arguments and, if they are string or number, convert them to a dot-delineated object property path.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "get": {
       "args": [
@@ -1223,7 +1223,7 @@
       ],
       "numArgs": 3,
       "description": "<p>Use property paths (<code>a.b.c</code>) to get a value or nested value from the context. Works as a regular helper or block helper.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "getObject": {
       "args": [
@@ -1232,7 +1232,7 @@
       ],
       "numArgs": 2,
       "description": "<p>Use property paths (<code>a.b.c</code>) to get an object from the context. Differs from the <code>get</code> helper in that this helper will return the actual object, including the given property key. Also, this helper does not work as a block helper.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "hasOwn": {
       "args": [
@@ -1241,7 +1241,7 @@
       ],
       "numArgs": 2,
       "description": "<p>Return true if <code>key</code> is an own, enumerable property of the given <code>context</code> object.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "isObject": {
       "args": [
@@ -1249,7 +1249,7 @@
       ],
       "numArgs": 1,
       "description": "<p>Return true if <code>value</code> is an object.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "JSONparse": {
       "args": [
@@ -1257,7 +1257,7 @@
       ],
       "numArgs": 1,
       "description": "<p>Parses the given string using <code>JSON.parse</code>.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "JSONstringify": {
       "args": [
@@ -1265,7 +1265,7 @@
       ],
       "numArgs": 1,
       "description": "<p>Stringify an object using <code>JSON.stringify</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "merge": {
       "args": [
@@ -1274,7 +1274,7 @@
       ],
       "numArgs": 2,
       "description": "<p>Deeply merge the properties of the given <code>objects</code> with the context object.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     },
     "parseJSON": {
       "args": [
@@ -1282,7 +1282,7 @@
       ],
       "numArgs": 1,
       "description": "<p>Parses the given string using <code>JSON.parse</code>.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "pick": {
       "args": [
@@ -1292,7 +1292,7 @@
       ],
       "numArgs": 3,
       "description": "<p>Pick properties from the context object.</p>\n",
-      "isBlock": true
+      "requiresBlock": true
     },
     "stringify": {
       "args": [
@@ -1300,7 +1300,7 @@
       ],
       "numArgs": 1,
       "description": "<p>Stringify an object using <code>JSON.stringify</code>.</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     }
   },
   "uuid": {
@@ -1309,7 +1309,7 @@
       "numArgs": 0,
       "example": "{{ uuid }} -> f34ebc66-93bd-4f7c-b79b-92b5569138bc",
       "description": "<p>Generates a UUID, using the V4 method (identical to the browser crypto.randomUUID function).</p>\n",
-      "isBlock": false
+      "requiresBlock": false
     }
   },
   "date": {

--- a/packages/string-templates/manifest.json
+++ b/packages/string-templates/manifest.json
@@ -163,7 +163,7 @@
         "options"
       ],
       "numArgs": 2,
-      "example": "{{#eachIndex [1, 2, 3]}} {{item}} is {{index}} {{/eachIndex}}",
+      "example": "{{#eachIndex [1, 2, 3]}} {{item}} is {{index}} {{/eachIndex}} -> ' 1 is 0  2 is 1  3 is 2 '",
       "description": "<p>Iterates the array, listing an item and the index of it.</p>\n"
     },
     "filter": {
@@ -173,7 +173,7 @@
         "options"
       ],
       "numArgs": 3,
-      "example": "{{#filter [1, 2, 3] 2}}2 Found{{else}}2 not found{{/filter}}",
+      "example": "{{#filter [1, 2, 3] 2}}2 Found{{else}}2 not found{{/filter}} -> 2 Found",
       "description": "<p>Block helper that filters the given array and renders the block for values that evaluate to <code>true</code>, otherwise the inverse block is returned.</p>\n"
     },
     "first": {
@@ -190,7 +190,7 @@
         "array"
       ],
       "numArgs": 1,
-      "example": "{{#forEach [{ 'name': 'John' }] }} {{ name }} {{/forEach}}",
+      "example": "{{#forEach [{ 'name': 'John' }] }} {{ name }} {{/forEach}} -> ' John '",
       "description": "<p>Iterates over each item in an array and exposes the current item in the array as context to the inner block. In addition to the current array item, the helper exposes the following variables to the inner block: - <code>index</code> - <code>total</code> - <code>isFirst</code> - <code>isLast</code> Also, <code>@index</code> is exposed as a private variable, and additional private variables may be defined as hash arguments.</p>\n"
     },
     "inArray": {
@@ -327,7 +327,7 @@
         "options"
       ],
       "numArgs": 3,
-      "example": "{{ withAfter [1, 2, 3] 1 }} {{this}} {{/withAfter}}",
+      "example": "{{#withAfter [1, 2, 3] 1 }} {{this}} {{/withAfter}} -> ' 2  3 '",
       "description": "<p>Use the items in the array <em>after</em> the specified index as context inside a block. Opposite of <a href=\"#withBefore\">withBefore</a>.</p>\n"
     },
     "withBefore": {
@@ -337,7 +337,7 @@
         "options"
       ],
       "numArgs": 3,
-      "example": "{{ withBefore [1, 2, 3] 2 }} {{this}} {{/withBefore}}",
+      "example": "{{#withBefore [1, 2, 3] 2 }} {{this}} {{/withBefore}} -> ' 1 '",
       "description": "<p>Use the items in the array <em>before</em> the specified index as context inside a block. Opposite of <a href=\"#withAfter\">withAfter</a>.</p>\n"
     },
     "withFirst": {
@@ -462,7 +462,7 @@
         "precision"
       ],
       "numArgs": 2,
-      "example": "{{toPrecision '1.1234' 2}}",
+      "example": "{{toPrecision '1.1234' 2}} -> 1.1",
       "description": "<p>Returns a string representing the <code>Number</code> object to the specified precision.</p>\n"
     }
   },
@@ -825,7 +825,7 @@
         "options"
       ],
       "numArgs": 3,
-      "example": "{{#and great magnificent}}both{{else}}no{{/and}}",
+      "example": "{{#and great magnificent}}both{{else}}no{{/and}} -> no",
       "description": "<p>Helper that renders the block if <strong>both</strong> of the given values are truthy. If an inverse block is specified it will be rendered when falsy. Works as a block helper, inline helper or subexpression.</p>\n"
     },
     "compare": {
@@ -847,7 +847,7 @@
         "options"
       ],
       "numArgs": 4,
-      "example": "{{#contains ['a', 'b', 'c'] 'd'}} This will not be rendered. {{else}} This will be rendered. {{/contains}}",
+      "example": "{{#contains ['a', 'b', 'c'] 'd'}} This will not be rendered. {{else}} This will be rendered. {{/contains}} -> ' This will be rendered. '",
       "description": "<p>Block helper that renders the block if <code>collection</code> has the given <code>value</code>, using strict equality (<code>===</code>) for comparison, otherwise the inverse block is rendered (if specified). If a <code>startIndex</code> is specified and is negative, it is used as the offset from the end of the collection.</p>\n"
     },
     "default": {

--- a/packages/string-templates/manifest.json
+++ b/packages/string-templates/manifest.json
@@ -6,7 +6,8 @@
       ],
       "numArgs": 1,
       "example": "{{ abs 12012.1000 }} -> 12012.1",
-      "description": "<p>Return the magnitude of <code>a</code>.</p>\n"
+      "description": "<p>Return the magnitude of <code>a</code>.</p>\n",
+      "isBlock": false
     },
     "add": {
       "args": [
@@ -15,7 +16,8 @@
       ],
       "numArgs": 2,
       "example": "{{ add 1 2 }} -> 3",
-      "description": "<p>Return the sum of <code>a</code> plus <code>b</code>.</p>\n"
+      "description": "<p>Return the sum of <code>a</code> plus <code>b</code>.</p>\n",
+      "isBlock": false
     },
     "avg": {
       "args": [
@@ -23,7 +25,8 @@
       ],
       "numArgs": 1,
       "example": "{{ avg 1 2 3 4 5 }} -> 3",
-      "description": "<p>Returns the average of all numbers in the given array.</p>\n"
+      "description": "<p>Returns the average of all numbers in the given array.</p>\n",
+      "isBlock": false
     },
     "ceil": {
       "args": [
@@ -31,7 +34,8 @@
       ],
       "numArgs": 1,
       "example": "{{ ceil 1.2 }} -> 2",
-      "description": "<p>Get the <code>Math.ceil()</code> of the given value.</p>\n"
+      "description": "<p>Get the <code>Math.ceil()</code> of the given value.</p>\n",
+      "isBlock": false
     },
     "divide": {
       "args": [
@@ -40,7 +44,8 @@
       ],
       "numArgs": 2,
       "example": "{{ divide 10 5 }} -> 2",
-      "description": "<p>Divide <code>a</code> by <code>b</code></p>\n"
+      "description": "<p>Divide <code>a</code> by <code>b</code></p>\n",
+      "isBlock": false
     },
     "floor": {
       "args": [
@@ -48,7 +53,8 @@
       ],
       "numArgs": 1,
       "example": "{{ floor 1.2 }} -> 1",
-      "description": "<p>Get the <code>Math.floor()</code> of the given value.</p>\n"
+      "description": "<p>Get the <code>Math.floor()</code> of the given value.</p>\n",
+      "isBlock": false
     },
     "minus": {
       "args": [
@@ -57,7 +63,8 @@
       ],
       "numArgs": 2,
       "example": "{{ subtract 10 5 }} -> 5",
-      "description": "<p>Return the product of <code>a</code> minus <code>b</code>.</p>\n"
+      "description": "<p>Return the product of <code>a</code> minus <code>b</code>.</p>\n",
+      "isBlock": false
     },
     "modulo": {
       "args": [
@@ -66,7 +73,8 @@
       ],
       "numArgs": 2,
       "example": "{{ modulo 10 5 }} -> 0",
-      "description": "<p>Get the remainder of a division operation.</p>\n"
+      "description": "<p>Get the remainder of a division operation.</p>\n",
+      "isBlock": false
     },
     "multiply": {
       "args": [
@@ -75,7 +83,8 @@
       ],
       "numArgs": 2,
       "example": "{{ multiply 10 5 }} -> 50",
-      "description": "<p>Multiply number <code>a</code> by number <code>b</code>.</p>\n"
+      "description": "<p>Multiply number <code>a</code> by number <code>b</code>.</p>\n",
+      "isBlock": false
     },
     "plus": {
       "args": [
@@ -84,7 +93,8 @@
       ],
       "numArgs": 2,
       "example": "{{ plus 10 5 }} -> 15",
-      "description": "<p>Add <code>a</code> by <code>b</code>.</p>\n"
+      "description": "<p>Add <code>a</code> by <code>b</code>.</p>\n",
+      "isBlock": false
     },
     "random": {
       "args": [
@@ -93,7 +103,8 @@
       ],
       "numArgs": 2,
       "example": "{{ random 0 20 }} -> 10",
-      "description": "<p>Generate a random number between two values</p>\n"
+      "description": "<p>Generate a random number between two values</p>\n",
+      "isBlock": false
     },
     "remainder": {
       "args": [
@@ -102,7 +113,8 @@
       ],
       "numArgs": 2,
       "example": "{{ remainder 10 6 }} -> 4",
-      "description": "<p>Get the remainder when <code>a</code> is divided by <code>b</code>.</p>\n"
+      "description": "<p>Get the remainder when <code>a</code> is divided by <code>b</code>.</p>\n",
+      "isBlock": false
     },
     "round": {
       "args": [
@@ -110,7 +122,8 @@
       ],
       "numArgs": 1,
       "example": "{{ round 10.3 }} -> 10",
-      "description": "<p>Round the given number.</p>\n"
+      "description": "<p>Round the given number.</p>\n",
+      "isBlock": false
     },
     "subtract": {
       "args": [
@@ -119,7 +132,8 @@
       ],
       "numArgs": 2,
       "example": "{{ subtract 10 5 }} -> 5",
-      "description": "<p>Return the product of <code>a</code> minus <code>b</code>.</p>\n"
+      "description": "<p>Return the product of <code>a</code> minus <code>b</code>.</p>\n",
+      "isBlock": false
     },
     "sum": {
       "args": [
@@ -127,7 +141,8 @@
       ],
       "numArgs": 1,
       "example": "{{ sum [1, 2, 3] }} -> 6",
-      "description": "<p>Returns the sum of all numbers in the given array.</p>\n"
+      "description": "<p>Returns the sum of all numbers in the given array.</p>\n",
+      "isBlock": false
     }
   },
   "array": {
@@ -138,7 +153,8 @@
       ],
       "numArgs": 2,
       "example": "{{ after ['a', 'b', 'c', 'd'] 2}} -> ['c', 'd']",
-      "description": "<p>Returns all of the items in an array after the specified index. Opposite of <a href=\"#before\">before</a>.</p>\n"
+      "description": "<p>Returns all of the items in an array after the specified index. Opposite of <a href=\"#before\">before</a>.</p>\n",
+      "isBlock": false
     },
     "arrayify": {
       "args": [
@@ -146,7 +162,8 @@
       ],
       "numArgs": 1,
       "example": "{{ arrayify 'foo' }} -> ['foo']",
-      "description": "<p>Cast the given <code>value</code> to an array.</p>\n"
+      "description": "<p>Cast the given <code>value</code> to an array.</p>\n",
+      "isBlock": false
     },
     "before": {
       "args": [
@@ -155,7 +172,8 @@
       ],
       "numArgs": 2,
       "example": "{{ before ['a', 'b', 'c', 'd'] 3}} -> ['a', 'b']",
-      "description": "<p>Return all of the items in the collection before the specified count. Opposite of <a href=\"#after\">after</a>.</p>\n"
+      "description": "<p>Return all of the items in the collection before the specified count. Opposite of <a href=\"#after\">after</a>.</p>\n",
+      "isBlock": false
     },
     "eachIndex": {
       "args": [
@@ -164,7 +182,8 @@
       ],
       "numArgs": 2,
       "example": "{{#eachIndex [1, 2, 3]}} {{item}} is {{index}} {{/eachIndex}} -> ' 1 is 0  2 is 1  3 is 2 '",
-      "description": "<p>Iterates the array, listing an item and the index of it.</p>\n"
+      "description": "<p>Iterates the array, listing an item and the index of it.</p>\n",
+      "isBlock": true
     },
     "filter": {
       "args": [
@@ -174,7 +193,8 @@
       ],
       "numArgs": 3,
       "example": "{{#filter [1, 2, 3] 2}}2 Found{{else}}2 not found{{/filter}} -> 2 Found",
-      "description": "<p>Block helper that filters the given array and renders the block for values that evaluate to <code>true</code>, otherwise the inverse block is returned.</p>\n"
+      "description": "<p>Block helper that filters the given array and renders the block for values that evaluate to <code>true</code>, otherwise the inverse block is returned.</p>\n",
+      "isBlock": true
     },
     "first": {
       "args": [
@@ -183,15 +203,18 @@
       ],
       "numArgs": 2,
       "example": "{{first [1, 2, 3, 4] 2}} -> 1,2",
-      "description": "<p>Returns the first item, or first <code>n</code> items of an array.</p>\n"
+      "description": "<p>Returns the first item, or first <code>n</code> items of an array.</p>\n",
+      "isBlock": false
     },
     "forEach": {
       "args": [
-        "array"
+        "array",
+        "options"
       ],
-      "numArgs": 1,
+      "numArgs": 2,
       "example": "{{#forEach [{ 'name': 'John' }] }} {{ name }} {{/forEach}} -> ' John '",
-      "description": "<p>Iterates over each item in an array and exposes the current item in the array as context to the inner block. In addition to the current array item, the helper exposes the following variables to the inner block: - <code>index</code> - <code>total</code> - <code>isFirst</code> - <code>isLast</code> Also, <code>@index</code> is exposed as a private variable, and additional private variables may be defined as hash arguments.</p>\n"
+      "description": "<p>Iterates over each item in an array and exposes the current item in the array as context to the inner block. In addition to the current array item, the helper exposes the following variables to the inner block: - <code>index</code> - <code>total</code> - <code>isFirst</code> - <code>isLast</code> Also, <code>@index</code> is exposed as a private variable, and additional private variables may be defined as hash arguments.</p>\n",
+      "isBlock": true
     },
     "inArray": {
       "args": [
@@ -201,7 +224,8 @@
       ],
       "numArgs": 3,
       "example": "{{#inArray [1, 2, 3] 2}} 2 exists {{else}} 2 does not exist {{/inArray}} -> ' 2 exists '",
-      "description": "<p>Block helper that renders the block if an array has the given <code>value</code>. Optionally specify an inverse block to render when the array does not have the given value.</p>\n"
+      "description": "<p>Block helper that renders the block if an array has the given <code>value</code>. Optionally specify an inverse block to render when the array does not have the given value.</p>\n",
+      "isBlock": true
     },
     "isArray": {
       "args": [
@@ -209,7 +233,8 @@
       ],
       "numArgs": 1,
       "example": "{{isArray [1, 2]}} -> true",
-      "description": "<p>Returns true if <code>value</code> is an es5 array.</p>\n"
+      "description": "<p>Returns true if <code>value</code> is an es5 array.</p>\n",
+      "isBlock": false
     },
     "itemAt": {
       "args": [
@@ -218,7 +243,8 @@
       ],
       "numArgs": 2,
       "example": "{{itemAt [1, 2, 3] 1}} -> 2",
-      "description": "<p>Returns the item from <code>array</code> at index <code>idx</code>.</p>\n"
+      "description": "<p>Returns the item from <code>array</code> at index <code>idx</code>.</p>\n",
+      "isBlock": false
     },
     "join": {
       "args": [
@@ -227,17 +253,18 @@
       ],
       "numArgs": 2,
       "example": "{{join [1, 2, 3]}} -> 1, 2, 3",
-      "description": "<p>Join all elements of array into a string, optionally using a given separator.</p>\n"
+      "description": "<p>Join all elements of array into a string, optionally using a given separator.</p>\n",
+      "isBlock": false
     },
     "equalsLength": {
       "args": [
         "value",
-        "length",
-        "options"
+        "length"
       ],
-      "numArgs": 3,
+      "numArgs": 2,
       "example": "{{equalsLength [1, 2, 3] 3}} -> true",
-      "description": "<p>Returns true if the the length of the given <code>value</code> is equal to the given <code>length</code>. Can be used as a block or inline helper.</p>\n"
+      "description": "<p>Returns true if the the length of the given <code>value</code> is equal to the given <code>length</code>. Can be used as a block or inline helper.</p>\n",
+      "isBlock": true
     },
     "last": {
       "args": [
@@ -246,7 +273,8 @@
       ],
       "numArgs": 2,
       "example": "{{last [1, 2, 3]}} -> 3",
-      "description": "<p>Returns the last item, or last <code>n</code> items of an array or string. Opposite of <a href=\"#first\">first</a>.</p>\n"
+      "description": "<p>Returns the last item, or last <code>n</code> items of an array or string. Opposite of <a href=\"#first\">first</a>.</p>\n",
+      "isBlock": false
     },
     "length": {
       "args": [
@@ -254,17 +282,18 @@
       ],
       "numArgs": 1,
       "example": "{{length [1, 2, 3]}} -> 3",
-      "description": "<p>Returns the length of the given string or array.</p>\n"
+      "description": "<p>Returns the length of the given string or array.</p>\n",
+      "isBlock": false
     },
     "lengthEqual": {
       "args": [
         "value",
-        "length",
-        "options"
+        "length"
       ],
-      "numArgs": 3,
+      "numArgs": 2,
       "example": "{{equalsLength [1, 2, 3] 3}} -> true",
-      "description": "<p>Returns true if the the length of the given <code>value</code> is equal to the given <code>length</code>. Can be used as a block or inline helper.</p>\n"
+      "description": "<p>Returns true if the the length of the given <code>value</code> is equal to the given <code>length</code>. Can be used as a block or inline helper.</p>\n",
+      "isBlock": true
     },
     "map": {
       "args": [
@@ -273,7 +302,8 @@
       ],
       "numArgs": 2,
       "example": "{{map [1, 2, 3] double}} -> [2, 4, 6]",
-      "description": "<p>Returns a new array, created by calling <code>function</code> on each element of the given <code>array</code>. For example,</p>\n"
+      "description": "<p>Returns a new array, created by calling <code>function</code> on each element of the given <code>array</code>. For example,</p>\n",
+      "isBlock": false
     },
     "pluck": {
       "args": [
@@ -282,7 +312,8 @@
       ],
       "numArgs": 2,
       "example": "{{pluck [{ 'name': 'Bob' }] 'name' }} -> ['Bob']",
-      "description": "<p>Map over the given object or array or objects and create an array of values from the given <code>prop</code>. Dot-notation may be used (as a string) to get nested properties.</p>\n"
+      "description": "<p>Map over the given object or array or objects and create an array of values from the given <code>prop</code>. Dot-notation may be used (as a string) to get nested properties.</p>\n",
+      "isBlock": false
     },
     "reverse": {
       "args": [
@@ -290,7 +321,8 @@
       ],
       "numArgs": 1,
       "example": "{{reverse [1, 2, 3]}} -> [3, 2, 1]",
-      "description": "<p>Reverse the elements in an array, or the characters in a string.</p>\n"
+      "description": "<p>Reverse the elements in an array, or the characters in a string.</p>\n",
+      "isBlock": false
     },
     "some": {
       "args": [
@@ -300,7 +332,8 @@
       ],
       "numArgs": 3,
       "example": "{{#some [1, \"b\", 3] isString}} string found {{else}} No string found {{/some}} -> ' string found '",
-      "description": "<p>Block helper that returns the block if the callback returns true for some value in the given array.</p>\n"
+      "description": "<p>Block helper that returns the block if the callback returns true for some value in the given array.</p>\n",
+      "isBlock": true
     },
     "sort": {
       "args": [
@@ -309,7 +342,8 @@
       ],
       "numArgs": 2,
       "example": "{{ sort ['b', 'a', 'c'] }} -> ['a', 'b', 'c']",
-      "description": "<p>Sort the given <code>array</code>. If an array of objects is passed, you may optionally pass a <code>key</code> to sort on as the second argument. You may alternatively pass a sorting function as the second argument.</p>\n"
+      "description": "<p>Sort the given <code>array</code>. If an array of objects is passed, you may optionally pass a <code>key</code> to sort on as the second argument. You may alternatively pass a sorting function as the second argument.</p>\n",
+      "isBlock": false
     },
     "sortBy": {
       "args": [
@@ -318,7 +352,8 @@
       ],
       "numArgs": 2,
       "example": "{{ sortBy [{'a': 'zzz'}, {'a': 'aaa'}] 'a' }} -> [{'a':'aaa'},{'a':'zzz'}]",
-      "description": "<p>Sort an <code>array</code>. If an array of objects is passed, you may optionally pass a <code>key</code> to sort on as the second argument. You may alternatively pass a sorting function as the second argument.</p>\n"
+      "description": "<p>Sort an <code>array</code>. If an array of objects is passed, you may optionally pass a <code>key</code> to sort on as the second argument. You may alternatively pass a sorting function as the second argument.</p>\n",
+      "isBlock": false
     },
     "withAfter": {
       "args": [
@@ -328,7 +363,8 @@
       ],
       "numArgs": 3,
       "example": "{{#withAfter [1, 2, 3] 1 }} {{this}} {{/withAfter}} -> ' 2  3 '",
-      "description": "<p>Use the items in the array <em>after</em> the specified index as context inside a block. Opposite of <a href=\"#withBefore\">withBefore</a>.</p>\n"
+      "description": "<p>Use the items in the array <em>after</em> the specified index as context inside a block. Opposite of <a href=\"#withBefore\">withBefore</a>.</p>\n",
+      "isBlock": true
     },
     "withBefore": {
       "args": [
@@ -338,7 +374,8 @@
       ],
       "numArgs": 3,
       "example": "{{#withBefore [1, 2, 3] 2 }} {{this}} {{/withBefore}} -> ' 1 '",
-      "description": "<p>Use the items in the array <em>before</em> the specified index as context inside a block. Opposite of <a href=\"#withAfter\">withAfter</a>.</p>\n"
+      "description": "<p>Use the items in the array <em>before</em> the specified index as context inside a block. Opposite of <a href=\"#withAfter\">withAfter</a>.</p>\n",
+      "isBlock": true
     },
     "withFirst": {
       "args": [
@@ -348,7 +385,8 @@
       ],
       "numArgs": 3,
       "example": "{{#withFirst [1, 2, 3] }}{{this}}{{/withFirst}} -> 1",
-      "description": "<p>Use the first item in a collection inside a handlebars block expression. Opposite of <a href=\"#withLast\">withLast</a>.</p>\n"
+      "description": "<p>Use the first item in a collection inside a handlebars block expression. Opposite of <a href=\"#withLast\">withLast</a>.</p>\n",
+      "isBlock": true
     },
     "withGroup": {
       "args": [
@@ -358,7 +396,8 @@
       ],
       "numArgs": 3,
       "example": "{{#withGroup [1, 2, 3, 4] 2}}{{#each this}}{{.}}{{/each}}<br>{{/withGroup}} -> 12<br>34<br>",
-      "description": "<p>Block helper that groups array elements by given group <code>size</code>.</p>\n"
+      "description": "<p>Block helper that groups array elements by given group <code>size</code>.</p>\n",
+      "isBlock": true
     },
     "withLast": {
       "args": [
@@ -368,7 +407,8 @@
       ],
       "numArgs": 3,
       "example": "{{#withLast [1, 2, 3, 4]}}{{this}}{{/withLast}} -> 4",
-      "description": "<p>Use the last item or <code>n</code> items in an array as context inside a block. Opposite of <a href=\"#withFirst\">withFirst</a>.</p>\n"
+      "description": "<p>Use the last item or <code>n</code> items in an array as context inside a block. Opposite of <a href=\"#withFirst\">withFirst</a>.</p>\n",
+      "isBlock": true
     },
     "withSort": {
       "args": [
@@ -378,7 +418,8 @@
       ],
       "numArgs": 3,
       "example": "{{#withSort ['b', 'a', 'c']}}{{this}}{{/withSort}} -> abc",
-      "description": "<p>Block helper that sorts a collection and exposes the sorted collection as context inside the block.</p>\n"
+      "description": "<p>Block helper that sorts a collection and exposes the sorted collection as context inside the block.</p>\n",
+      "isBlock": true
     },
     "unique": {
       "args": [
@@ -387,7 +428,8 @@
       ],
       "numArgs": 2,
       "example": "{{#each (unique ['a', 'a', 'c', 'b', 'e', 'e']) }}{{.}}{{/each}} -> acbe",
-      "description": "<p>Block helper that return an array with all duplicate values removed. Best used along with a <a href=\"#each\">each</a> helper.</p>\n"
+      "description": "<p>Block helper that return an array with all duplicate values removed. Best used along with a <a href=\"#each\">each</a> helper.</p>\n",
+      "isBlock": true
     }
   },
   "number": {
@@ -397,7 +439,8 @@
       ],
       "numArgs": 1,
       "example": "{{ bytes 1386 1 }} -> 1.4 kB",
-      "description": "<p>Format a number to it&#39;s equivalent in bytes. If a string is passed, it&#39;s length will be formatted and returned. <strong>Examples:</strong> - <code>&#39;foo&#39; =&gt; 3 B</code> - <code>13661855 =&gt; 13.66 MB</code> - <code>825399 =&gt; 825.39 kB</code> - <code>1396 =&gt; 1.4 kB</code></p>\n"
+      "description": "<p>Format a number to it&#39;s equivalent in bytes. If a string is passed, it&#39;s length will be formatted and returned. <strong>Examples:</strong> - <code>&#39;foo&#39; =&gt; 3 B</code> - <code>13661855 =&gt; 13.66 MB</code> - <code>825399 =&gt; 825.39 kB</code> - <code>1396 =&gt; 1.4 kB</code></p>\n",
+      "isBlock": false
     },
     "addCommas": {
       "args": [
@@ -405,7 +448,8 @@
       ],
       "numArgs": 1,
       "example": "{{ addCommas 1000000 }} -> 1,000,000",
-      "description": "<p>Add commas to numbers</p>\n"
+      "description": "<p>Add commas to numbers</p>\n",
+      "isBlock": false
     },
     "phoneNumber": {
       "args": [
@@ -413,7 +457,8 @@
       ],
       "numArgs": 1,
       "example": "{{ phoneNumber 8005551212 }} -> (800) 555-1212",
-      "description": "<p>Convert a string or number to a formatted phone number.</p>\n"
+      "description": "<p>Convert a string or number to a formatted phone number.</p>\n",
+      "isBlock": false
     },
     "toAbbr": {
       "args": [
@@ -422,7 +467,8 @@
       ],
       "numArgs": 2,
       "example": "{{ toAbbr 10123 2 }} -> 10.12k",
-      "description": "<p>Abbreviate numbers to the given number of <code>precision</code>. This for general numbers, not size in bytes.</p>\n"
+      "description": "<p>Abbreviate numbers to the given number of <code>precision</code>. This for general numbers, not size in bytes.</p>\n",
+      "isBlock": false
     },
     "toExponential": {
       "args": [
@@ -431,7 +477,8 @@
       ],
       "numArgs": 2,
       "example": "{{ toExponential 10123 2 }} -> 1.01e+4",
-      "description": "<p>Returns a string representing the given number in exponential notation.</p>\n"
+      "description": "<p>Returns a string representing the given number in exponential notation.</p>\n",
+      "isBlock": false
     },
     "toFixed": {
       "args": [
@@ -440,21 +487,24 @@
       ],
       "numArgs": 2,
       "example": "{{ toFixed 1.1234 2 }} -> 1.12",
-      "description": "<p>Formats the given number using fixed-point notation.</p>\n"
+      "description": "<p>Formats the given number using fixed-point notation.</p>\n",
+      "isBlock": false
     },
     "toFloat": {
       "args": [
         "number"
       ],
       "numArgs": 1,
-      "description": "<p>Convert input to a float.</p>\n"
+      "description": "<p>Convert input to a float.</p>\n",
+      "isBlock": false
     },
     "toInt": {
       "args": [
         "number"
       ],
       "numArgs": 1,
-      "description": "<p>Convert input to an integer.</p>\n"
+      "description": "<p>Convert input to an integer.</p>\n",
+      "isBlock": false
     },
     "toPrecision": {
       "args": [
@@ -463,7 +513,8 @@
       ],
       "numArgs": 2,
       "example": "{{toPrecision '1.1234' 2}} -> 1.1",
-      "description": "<p>Returns a string representing the <code>Number</code> object to the specified precision.</p>\n"
+      "description": "<p>Returns a string representing the <code>Number</code> object to the specified precision.</p>\n",
+      "isBlock": false
     }
   },
   "url": {
@@ -473,7 +524,8 @@
       ],
       "numArgs": 1,
       "example": "{{ encodeURI 'https://myurl?Hello There' }} -> https%3A%2F%2Fmyurl%3FHello%20There",
-      "description": "<p>Encodes a Uniform Resource Identifier (URI) component by replacing each instance of certain characters by one, two, three, or four escape sequences representing the UTF-8 encoding of the character.</p>\n"
+      "description": "<p>Encodes a Uniform Resource Identifier (URI) component by replacing each instance of certain characters by one, two, three, or four escape sequences representing the UTF-8 encoding of the character.</p>\n",
+      "isBlock": false
     },
     "escape": {
       "args": [
@@ -481,7 +533,8 @@
       ],
       "numArgs": 1,
       "example": "{{ escape 'https://myurl?Hello+There' }} -> https%3A%2F%2Fmyurl%3FHello%2BThere",
-      "description": "<p>Escape the given string by replacing characters with escape sequences. Useful for allowing the string to be used in a URL, etc.</p>\n"
+      "description": "<p>Escape the given string by replacing characters with escape sequences. Useful for allowing the string to be used in a URL, etc.</p>\n",
+      "isBlock": false
     },
     "decodeURI": {
       "args": [
@@ -489,7 +542,8 @@
       ],
       "numArgs": 1,
       "example": "{{ decodeURI 'https://myurl?Hello%20There' }} -> https://myurl?Hello There",
-      "description": "<p>Decode a Uniform Resource Identifier (URI) component.</p>\n"
+      "description": "<p>Decode a Uniform Resource Identifier (URI) component.</p>\n",
+      "isBlock": false
     },
     "urlResolve": {
       "args": [
@@ -498,7 +552,8 @@
       ],
       "numArgs": 2,
       "example": "{{ urlResolve 'https://myurl' '/api/test' }} -> https://myurl/api/test",
-      "description": "<p>Take a base URL, and a href URL, and resolve them as a browser would for an anchor tag.</p>\n"
+      "description": "<p>Take a base URL, and a href URL, and resolve them as a browser would for an anchor tag.</p>\n",
+      "isBlock": false
     },
     "urlParse": {
       "args": [
@@ -506,7 +561,8 @@
       ],
       "numArgs": 1,
       "example": "{{ urlParse 'https://myurl/api/test' }}",
-      "description": "<p>Parses a <code>url</code> string into an object.</p>\n"
+      "description": "<p>Parses a <code>url</code> string into an object.</p>\n",
+      "isBlock": false
     },
     "stripQuerystring": {
       "args": [
@@ -514,7 +570,8 @@
       ],
       "numArgs": 1,
       "example": "{{ stripQuerystring 'https://myurl/api/test?foo=bar' }} -> 'https://myurl/api/test'",
-      "description": "<p>Strip the query string from the given <code>url</code>.</p>\n"
+      "description": "<p>Strip the query string from the given <code>url</code>.</p>\n",
+      "isBlock": false
     },
     "stripProtocol": {
       "args": [
@@ -522,7 +579,8 @@
       ],
       "numArgs": 1,
       "example": "{{ stripProtocol 'https://myurl/api/test' }} -> '//myurl/api/test'",
-      "description": "<p>Strip protocol from a <code>url</code>. Useful for displaying media that may have an &#39;http&#39; protocol on secure connections.</p>\n"
+      "description": "<p>Strip protocol from a <code>url</code>. Useful for displaying media that may have an &#39;http&#39; protocol on secure connections.</p>\n",
+      "isBlock": false
     }
   },
   "string": {
@@ -533,7 +591,8 @@
       ],
       "numArgs": 2,
       "example": "{{append 'index' '.html'}} -> index.html",
-      "description": "<p>Append the specified <code>suffix</code> to the given string.</p>\n"
+      "description": "<p>Append the specified <code>suffix</code> to the given string.</p>\n",
+      "isBlock": false
     },
     "camelcase": {
       "args": [
@@ -541,7 +600,8 @@
       ],
       "numArgs": 1,
       "example": "{{camelcase 'foo bar baz'}} ->  fooBarBaz",
-      "description": "<p>camelCase the characters in the given <code>string</code>.</p>\n"
+      "description": "<p>camelCase the characters in the given <code>string</code>.</p>\n",
+      "isBlock": false
     },
     "capitalize": {
       "args": [
@@ -549,7 +609,8 @@
       ],
       "numArgs": 1,
       "example": "{{capitalize 'foo bar baz'}} ->  Foo bar baz",
-      "description": "<p>Capitalize the first word in a sentence.</p>\n"
+      "description": "<p>Capitalize the first word in a sentence.</p>\n",
+      "isBlock": false
     },
     "capitalizeAll": {
       "args": [
@@ -557,7 +618,8 @@
       ],
       "numArgs": 1,
       "example": "{{ capitalizeAll 'foo bar baz'}} ->  Foo Bar Baz",
-      "description": "<p>Capitalize all words in a string.</p>\n"
+      "description": "<p>Capitalize all words in a string.</p>\n",
+      "isBlock": false
     },
     "center": {
       "args": [
@@ -566,7 +628,8 @@
       ],
       "numArgs": 2,
       "example": "{{ center 'test' 1}} -> ' test '",
-      "description": "<p>Center a string using non-breaking spaces</p>\n"
+      "description": "<p>Center a string using non-breaking spaces</p>\n",
+      "isBlock": false
     },
     "chop": {
       "args": [
@@ -574,7 +637,8 @@
       ],
       "numArgs": 1,
       "example": "{{ chop ' ABC '}} -> ABC",
-      "description": "<p>Like trim, but removes both extraneous whitespace <strong>and non-word characters</strong> from the beginning and end of a string.</p>\n"
+      "description": "<p>Like trim, but removes both extraneous whitespace <strong>and non-word characters</strong> from the beginning and end of a string.</p>\n",
+      "isBlock": false
     },
     "dashcase": {
       "args": [
@@ -582,7 +646,8 @@
       ],
       "numArgs": 1,
       "example": "{{dashcase 'a-b-c d_e'}} -> a-b-c-d-e",
-      "description": "<p>dash-case the characters in <code>string</code>. Replaces non-word characters and periods with hyphens.</p>\n"
+      "description": "<p>dash-case the characters in <code>string</code>. Replaces non-word characters and periods with hyphens.</p>\n",
+      "isBlock": false
     },
     "dotcase": {
       "args": [
@@ -590,7 +655,8 @@
       ],
       "numArgs": 1,
       "example": "{{dotcase 'a-b-c d_e'}} -> a.b.c.d.e",
-      "description": "<p>dot.case the characters in <code>string</code>.</p>\n"
+      "description": "<p>dot.case the characters in <code>string</code>.</p>\n",
+      "isBlock": false
     },
     "downcase": {
       "args": [
@@ -598,7 +664,8 @@
       ],
       "numArgs": 1,
       "example": "{{downcase 'aBcDeF'}} -> abcdef",
-      "description": "<p>Lowercase all of the characters in the given string. Alias for <a href=\"#lowercase\">lowercase</a>.</p>\n"
+      "description": "<p>Lowercase all of the characters in the given string. Alias for <a href=\"#lowercase\">lowercase</a>.</p>\n",
+      "isBlock": false
     },
     "ellipsis": {
       "args": [
@@ -607,7 +674,8 @@
       ],
       "numArgs": 2,
       "example": "{{ellipsis 'foo bar baz' 7}} -> foo bar…",
-      "description": "<p>Truncates a string to the specified <code>length</code>, and appends it with an elipsis, <code>…</code>.</p>\n"
+      "description": "<p>Truncates a string to the specified <code>length</code>, and appends it with an elipsis, <code>…</code>.</p>\n",
+      "isBlock": false
     },
     "hyphenate": {
       "args": [
@@ -615,7 +683,8 @@
       ],
       "numArgs": 1,
       "example": "{{hyphenate 'foo bar baz qux'}} -> foo-bar-baz-qux",
-      "description": "<p>Replace spaces in a string with hyphens.</p>\n"
+      "description": "<p>Replace spaces in a string with hyphens.</p>\n",
+      "isBlock": false
     },
     "isString": {
       "args": [
@@ -623,7 +692,8 @@
       ],
       "numArgs": 1,
       "example": "{{isString 'foo'}} -> true",
-      "description": "<p>Return true if <code>value</code> is a string.</p>\n"
+      "description": "<p>Return true if <code>value</code> is a string.</p>\n",
+      "isBlock": false
     },
     "lowercase": {
       "args": [
@@ -631,7 +701,8 @@
       ],
       "numArgs": 1,
       "example": "{{lowercase 'Foo BAR baZ'}} -> foo bar baz",
-      "description": "<p>Lowercase all characters in the given string.</p>\n"
+      "description": "<p>Lowercase all characters in the given string.</p>\n",
+      "isBlock": false
     },
     "occurrences": {
       "args": [
@@ -640,7 +711,8 @@
       ],
       "numArgs": 2,
       "example": "{{occurrences 'foo bar foo bar baz' 'foo'}} -> 2",
-      "description": "<p>Return the number of occurrences of <code>substring</code> within the given <code>string</code>.</p>\n"
+      "description": "<p>Return the number of occurrences of <code>substring</code> within the given <code>string</code>.</p>\n",
+      "isBlock": false
     },
     "pascalcase": {
       "args": [
@@ -648,7 +720,8 @@
       ],
       "numArgs": 1,
       "example": "{{pascalcase 'foo bar baz'}} -> FooBarBaz",
-      "description": "<p>PascalCase the characters in <code>string</code>.</p>\n"
+      "description": "<p>PascalCase the characters in <code>string</code>.</p>\n",
+      "isBlock": false
     },
     "pathcase": {
       "args": [
@@ -656,7 +729,8 @@
       ],
       "numArgs": 1,
       "example": "{{pathcase 'a-b-c d_e'}} -> a/b/c/d/e",
-      "description": "<p>path/case the characters in <code>string</code>.</p>\n"
+      "description": "<p>path/case the characters in <code>string</code>.</p>\n",
+      "isBlock": false
     },
     "plusify": {
       "args": [
@@ -664,7 +738,8 @@
       ],
       "numArgs": 1,
       "example": "{{plusify 'foo bar baz'}} -> foo+bar+baz",
-      "description": "<p>Replace spaces in the given string with pluses.</p>\n"
+      "description": "<p>Replace spaces in the given string with pluses.</p>\n",
+      "isBlock": false
     },
     "prepend": {
       "args": [
@@ -673,7 +748,8 @@
       ],
       "numArgs": 2,
       "example": "{{prepend 'bar' 'foo-'}} -> foo-bar",
-      "description": "<p>Prepends the given <code>string</code> with the specified <code>prefix</code>.</p>\n"
+      "description": "<p>Prepends the given <code>string</code> with the specified <code>prefix</code>.</p>\n",
+      "isBlock": false
     },
     "remove": {
       "args": [
@@ -682,7 +758,8 @@
       ],
       "numArgs": 2,
       "example": "{{remove 'a b a b a b' 'a '}} -> b b b",
-      "description": "<p>Remove all occurrences of <code>substring</code> from the given <code>str</code>.</p>\n"
+      "description": "<p>Remove all occurrences of <code>substring</code> from the given <code>str</code>.</p>\n",
+      "isBlock": false
     },
     "removeFirst": {
       "args": [
@@ -691,7 +768,8 @@
       ],
       "numArgs": 2,
       "example": "{{removeFirst 'a b a b a b' 'a'}} -> ' b a b a b'",
-      "description": "<p>Remove the first occurrence of <code>substring</code> from the given <code>str</code>.</p>\n"
+      "description": "<p>Remove the first occurrence of <code>substring</code> from the given <code>str</code>.</p>\n",
+      "isBlock": false
     },
     "replace": {
       "args": [
@@ -701,7 +779,8 @@
       ],
       "numArgs": 3,
       "example": "{{replace 'a b a b a b' 'a' 'z'}} -> z b z b z b",
-      "description": "<p>Replace all occurrences of substring <code>a</code> with substring <code>b</code>.</p>\n"
+      "description": "<p>Replace all occurrences of substring <code>a</code> with substring <code>b</code>.</p>\n",
+      "isBlock": false
     },
     "replaceFirst": {
       "args": [
@@ -711,7 +790,8 @@
       ],
       "numArgs": 3,
       "example": "{{replaceFirst 'a b a b a b' 'a' 'z'}} -> z b a b a b",
-      "description": "<p>Replace the first occurrence of substring <code>a</code> with substring <code>b</code>.</p>\n"
+      "description": "<p>Replace the first occurrence of substring <code>a</code> with substring <code>b</code>.</p>\n",
+      "isBlock": false
     },
     "sentence": {
       "args": [
@@ -719,7 +799,8 @@
       ],
       "numArgs": 1,
       "example": "{{sentence 'hello world. goodbye world.'}} -> Hello world. Goodbye world.",
-      "description": "<p>Sentence case the given string</p>\n"
+      "description": "<p>Sentence case the given string</p>\n",
+      "isBlock": false
     },
     "snakecase": {
       "args": [
@@ -727,7 +808,8 @@
       ],
       "numArgs": 1,
       "example": "{{snakecase 'a-b-c d_e'}} -> a_b_c_d_e",
-      "description": "<p>snake_case the characters in the given <code>string</code>.</p>\n"
+      "description": "<p>snake_case the characters in the given <code>string</code>.</p>\n",
+      "isBlock": false
     },
     "split": {
       "args": [
@@ -735,7 +817,8 @@
       ],
       "numArgs": 1,
       "example": "{{split 'a,b,c'}} -> ['a', 'b', 'c']",
-      "description": "<p>Split <code>string</code> by the given <code>character</code>.</p>\n"
+      "description": "<p>Split <code>string</code> by the given <code>character</code>.</p>\n",
+      "isBlock": false
     },
     "startsWith": {
       "args": [
@@ -745,7 +828,8 @@
       ],
       "numArgs": 3,
       "example": "{{#startsWith 'Goodbye' 'Hello, world!'}}Yep{{else}}Nope{{/startsWith}} -> Nope",
-      "description": "<p>Tests whether a string begins with the given prefix.</p>\n"
+      "description": "<p>Tests whether a string begins with the given prefix.</p>\n",
+      "isBlock": true
     },
     "titleize": {
       "args": [
@@ -753,7 +837,8 @@
       ],
       "numArgs": 1,
       "example": "{{titleize 'this is title case' }} -> This Is Title Case",
-      "description": "<p>Title case the given string.</p>\n"
+      "description": "<p>Title case the given string.</p>\n",
+      "isBlock": false
     },
     "trim": {
       "args": [
@@ -761,7 +846,8 @@
       ],
       "numArgs": 1,
       "example": "{{trim '  ABC  ' }} -> ABC",
-      "description": "<p>Removes extraneous whitespace from the beginning and end of a string.</p>\n"
+      "description": "<p>Removes extraneous whitespace from the beginning and end of a string.</p>\n",
+      "isBlock": false
     },
     "trimLeft": {
       "args": [
@@ -769,7 +855,8 @@
       ],
       "numArgs": 1,
       "example": "{{trimLeft '  ABC ' }} -> 'ABC '",
-      "description": "<p>Removes extraneous whitespace from the beginning of a string.</p>\n"
+      "description": "<p>Removes extraneous whitespace from the beginning of a string.</p>\n",
+      "isBlock": false
     },
     "trimRight": {
       "args": [
@@ -777,7 +864,8 @@
       ],
       "numArgs": 1,
       "example": "{{trimRight '  ABC ' }} ->  '  ABC'",
-      "description": "<p>Removes extraneous whitespace from the end of a string.</p>\n"
+      "description": "<p>Removes extraneous whitespace from the end of a string.</p>\n",
+      "isBlock": false
     },
     "truncate": {
       "args": [
@@ -787,7 +875,8 @@
       ],
       "numArgs": 3,
       "example": "{{truncate 'foo bar baz' 7 }} -> foo bar",
-      "description": "<p>Truncate a string to the specified <code>length</code>. Also see <a href=\"#ellipsis\">ellipsis</a>.</p>\n"
+      "description": "<p>Truncate a string to the specified <code>length</code>. Also see <a href=\"#ellipsis\">ellipsis</a>.</p>\n",
+      "isBlock": false
     },
     "truncateWords": {
       "args": [
@@ -797,7 +886,8 @@
       ],
       "numArgs": 3,
       "example": "{{truncateWords 'foo bar baz' 1 }} -> foo…",
-      "description": "<p>Truncate a string to have the specified number of words. Also see <a href=\"#truncate\">truncate</a>.</p>\n"
+      "description": "<p>Truncate a string to have the specified number of words. Also see <a href=\"#truncate\">truncate</a>.</p>\n",
+      "isBlock": false
     },
     "upcase": {
       "args": [
@@ -805,7 +895,8 @@
       ],
       "numArgs": 1,
       "example": "{{upcase 'aBcDef'}} -> ABCDEF",
-      "description": "<p>Uppercase all of the characters in the given string. Alias for <a href=\"#uppercase\">uppercase</a>.</p>\n"
+      "description": "<p>Uppercase all of the characters in the given string. Alias for <a href=\"#uppercase\">uppercase</a>.</p>\n",
+      "isBlock": false
     },
     "uppercase": {
       "args": [
@@ -814,7 +905,8 @@
       ],
       "numArgs": 2,
       "example": "{{uppercase 'aBcDef'}} -> ABCDEF",
-      "description": "<p>Uppercase all of the characters in the given string. If used as a block helper it will uppercase the entire block. This helper does not support inverse blocks.</p>\n"
+      "description": "<p>Uppercase all of the characters in the given string. If used as a block helper it will uppercase the entire block. This helper does not support inverse blocks.</p>\n",
+      "isBlock": true
     }
   },
   "comparison": {
@@ -826,7 +918,8 @@
       ],
       "numArgs": 3,
       "example": "{{#and great magnificent}}both{{else}}no{{/and}} -> no",
-      "description": "<p>Helper that renders the block if <strong>both</strong> of the given values are truthy. If an inverse block is specified it will be rendered when falsy. Works as a block helper, inline helper or subexpression.</p>\n"
+      "description": "<p>Helper that renders the block if <strong>both</strong> of the given values are truthy. If an inverse block is specified it will be rendered when falsy. Works as a block helper, inline helper or subexpression.</p>\n",
+      "isBlock": true
     },
     "compare": {
       "args": [
@@ -837,7 +930,8 @@
       ],
       "numArgs": 4,
       "example": "{{compare 10 '<' 5 }} -> false",
-      "description": "<p>Render a block when a comparison of the first and third arguments returns true. The second argument is the [arithemetic operator][operators] to use. You may also optionally specify an inverse block to render when falsy.</p>\n"
+      "description": "<p>Render a block when a comparison of the first and third arguments returns true. The second argument is the [arithemetic operator][operators] to use. You may also optionally specify an inverse block to render when falsy.</p>\n",
+      "isBlock": true
     },
     "contains": {
       "args": [
@@ -848,7 +942,8 @@
       ],
       "numArgs": 4,
       "example": "{{#contains ['a', 'b', 'c'] 'd'}} This will not be rendered. {{else}} This will be rendered. {{/contains}} -> ' This will be rendered. '",
-      "description": "<p>Block helper that renders the block if <code>collection</code> has the given <code>value</code>, using strict equality (<code>===</code>) for comparison, otherwise the inverse block is rendered (if specified). If a <code>startIndex</code> is specified and is negative, it is used as the offset from the end of the collection.</p>\n"
+      "description": "<p>Block helper that renders the block if <code>collection</code> has the given <code>value</code>, using strict equality (<code>===</code>) for comparison, otherwise the inverse block is rendered (if specified). If a <code>startIndex</code> is specified and is negative, it is used as the offset from the end of the collection.</p>\n",
+      "isBlock": true
     },
     "default": {
       "args": [
@@ -857,7 +952,8 @@
       ],
       "numArgs": 2,
       "example": "{{default null null 'default'}} -> default",
-      "description": "<p>Returns the first value that is not undefined, otherwise the &#39;default&#39; value is returned.</p>\n"
+      "description": "<p>Returns the first value that is not undefined, otherwise the &#39;default&#39; value is returned.</p>\n",
+      "isBlock": false
     },
     "eq": {
       "args": [
@@ -867,7 +963,8 @@
       ],
       "numArgs": 3,
       "example": "{{#eq 3 3}}equal{{else}}not equal{{/eq}} -> equal",
-      "description": "<p>Block helper that renders a block if <code>a</code> is <strong>equal to</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. You may optionally use the <code>compare=&#39;&#39;</code> hash argument for the second value.</p>\n"
+      "description": "<p>Block helper that renders a block if <code>a</code> is <strong>equal to</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. You may optionally use the <code>compare=&#39;&#39;</code> hash argument for the second value.</p>\n",
+      "isBlock": true
     },
     "gt": {
       "args": [
@@ -877,7 +974,8 @@
       ],
       "numArgs": 3,
       "example": "{{#gt 4 3}} greater than{{else}} not greater than{{/gt}} -> ' greater than'",
-      "description": "<p>Block helper that renders a block if <code>a</code> is <strong>greater than</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. You may optionally use the <code>compare=&#39;&#39;</code> hash argument for the second value.</p>\n"
+      "description": "<p>Block helper that renders a block if <code>a</code> is <strong>greater than</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. You may optionally use the <code>compare=&#39;&#39;</code> hash argument for the second value.</p>\n",
+      "isBlock": true
     },
     "gte": {
       "args": [
@@ -887,7 +985,8 @@
       ],
       "numArgs": 3,
       "example": "{{#gte 4 3}} greater than or equal{{else}} not greater than{{/gte}} -> ' greater than or equal'",
-      "description": "<p>Block helper that renders a block if <code>a</code> is <strong>greater than or equal to</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. You may optionally use the <code>compare=&#39;&#39;</code> hash argument for the second value.</p>\n"
+      "description": "<p>Block helper that renders a block if <code>a</code> is <strong>greater than or equal to</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. You may optionally use the <code>compare=&#39;&#39;</code> hash argument for the second value.</p>\n",
+      "isBlock": true
     },
     "has": {
       "args": [
@@ -897,7 +996,8 @@
       ],
       "numArgs": 3,
       "example": "{{#has 'foobar' 'foo'}}has it{{else}}doesn't{{/has}} -> has it",
-      "description": "<p>Block helper that renders a block if <code>value</code> has <code>pattern</code>. If an inverse block is specified it will be rendered when falsy.</p>\n"
+      "description": "<p>Block helper that renders a block if <code>value</code> has <code>pattern</code>. If an inverse block is specified it will be rendered when falsy.</p>\n",
+      "isBlock": true
     },
     "isFalsey": {
       "args": [
@@ -906,7 +1006,8 @@
       ],
       "numArgs": 2,
       "example": "{{isFalsey '' }} -> true",
-      "description": "<p>Returns true if the given <code>value</code> is falsey. Uses the [falsey][] library for comparisons. Please see that library for more information or to report bugs with this helper.</p>\n"
+      "description": "<p>Returns true if the given <code>value</code> is falsey. Uses the [falsey][] library for comparisons. Please see that library for more information or to report bugs with this helper.</p>\n",
+      "isBlock": false
     },
     "isTruthy": {
       "args": [
@@ -915,7 +1016,8 @@
       ],
       "numArgs": 2,
       "example": "{{isTruthy '12' }} -> true",
-      "description": "<p>Returns true if the given <code>value</code> is truthy. Uses the [falsey][] library for comparisons. Please see that library for more information or to report bugs with this helper.</p>\n"
+      "description": "<p>Returns true if the given <code>value</code> is truthy. Uses the [falsey][] library for comparisons. Please see that library for more information or to report bugs with this helper.</p>\n",
+      "isBlock": false
     },
     "ifEven": {
       "args": [
@@ -924,7 +1026,8 @@
       ],
       "numArgs": 2,
       "example": "{{#ifEven 2}} even {{else}} odd {{/ifEven}} -> ' even '",
-      "description": "<p>Return true if the given value is an even number.</p>\n"
+      "description": "<p>Return true if the given value is an even number.</p>\n",
+      "isBlock": true
     },
     "ifNth": {
       "args": [
@@ -934,7 +1037,8 @@
       ],
       "numArgs": 3,
       "example": "{{#ifNth 2 10}}remainder{{else}}no remainder{{/ifNth}} -> remainder",
-      "description": "<p>Conditionally renders a block if the remainder is zero when <code>b</code> operand is divided by <code>a</code>. If an inverse block is specified it will be rendered when the remainder is <strong>not zero</strong>.</p>\n"
+      "description": "<p>Conditionally renders a block if the remainder is zero when <code>b</code> operand is divided by <code>a</code>. If an inverse block is specified it will be rendered when the remainder is <strong>not zero</strong>.</p>\n",
+      "isBlock": true
     },
     "ifOdd": {
       "args": [
@@ -943,7 +1047,8 @@
       ],
       "numArgs": 2,
       "example": "{{#ifOdd 3}}odd{{else}}even{{/ifOdd}} -> odd",
-      "description": "<p>Block helper that renders a block if <code>value</code> is <strong>an odd number</strong>. If an inverse block is specified it will be rendered when falsy.</p>\n"
+      "description": "<p>Block helper that renders a block if <code>value</code> is <strong>an odd number</strong>. If an inverse block is specified it will be rendered when falsy.</p>\n",
+      "isBlock": true
     },
     "is": {
       "args": [
@@ -953,7 +1058,8 @@
       ],
       "numArgs": 3,
       "example": "{{#is 3 3}} is {{else}} is not {{/is}} -> ' is '",
-      "description": "<p>Block helper that renders a block if <code>a</code> is <strong>equal to</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. Similar to <a href=\"#eq\">eq</a> but does not do strict equality.</p>\n"
+      "description": "<p>Block helper that renders a block if <code>a</code> is <strong>equal to</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. Similar to <a href=\"#eq\">eq</a> but does not do strict equality.</p>\n",
+      "isBlock": true
     },
     "isnt": {
       "args": [
@@ -963,7 +1069,8 @@
       ],
       "numArgs": 3,
       "example": "{{#isnt 3 3}} isnt {{else}} is {{/isnt}} -> ' is '",
-      "description": "<p>Block helper that renders a block if <code>a</code> is <strong>not equal to</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. Similar to <a href=\"#unlesseq\">unlessEq</a> but does not use strict equality for comparisons.</p>\n"
+      "description": "<p>Block helper that renders a block if <code>a</code> is <strong>not equal to</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. Similar to <a href=\"#unlesseq\">unlessEq</a> but does not use strict equality for comparisons.</p>\n",
+      "isBlock": true
     },
     "lt": {
       "args": [
@@ -972,7 +1079,8 @@
       ],
       "numArgs": 2,
       "example": "{{#lt 2 3}} less than {{else}} more than or equal {{/lt}} -> ' less than '",
-      "description": "<p>Block helper that renders a block if <code>a</code> is <strong>less than</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. You may optionally use the <code>compare=&#39;&#39;</code> hash argument for the second value.</p>\n"
+      "description": "<p>Block helper that renders a block if <code>a</code> is <strong>less than</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. You may optionally use the <code>compare=&#39;&#39;</code> hash argument for the second value.</p>\n",
+      "isBlock": true
     },
     "lte": {
       "args": [
@@ -982,7 +1090,8 @@
       ],
       "numArgs": 3,
       "example": "{{#lte 2 3}} less than or equal {{else}} more than {{/lte}} -> ' less than or equal '",
-      "description": "<p>Block helper that renders a block if <code>a</code> is <strong>less than or equal to</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. You may optionally use the <code>compare=&#39;&#39;</code> hash argument for the second value.</p>\n"
+      "description": "<p>Block helper that renders a block if <code>a</code> is <strong>less than or equal to</strong> <code>b</code>. If an inverse block is specified it will be rendered when falsy. You may optionally use the <code>compare=&#39;&#39;</code> hash argument for the second value.</p>\n",
+      "isBlock": true
     },
     "neither": {
       "args": [
@@ -992,7 +1101,8 @@
       ],
       "numArgs": 3,
       "example": "{{#neither null null}}both falsey{{else}}both not falsey{{/neither}} -> both falsey",
-      "description": "<p>Block helper that renders a block if <strong>neither of</strong> the given values are truthy. If an inverse block is specified it will be rendered when falsy.</p>\n"
+      "description": "<p>Block helper that renders a block if <strong>neither of</strong> the given values are truthy. If an inverse block is specified it will be rendered when falsy.</p>\n",
+      "isBlock": true
     },
     "not": {
       "args": [
@@ -1001,7 +1111,8 @@
       ],
       "numArgs": 2,
       "example": "{{#not undefined }}falsey{{else}}not falsey{{/not}} -> falsey",
-      "description": "<p>Returns true if <code>val</code> is falsey. Works as a block or inline helper.</p>\n"
+      "description": "<p>Returns true if <code>val</code> is falsey. Works as a block or inline helper.</p>\n",
+      "isBlock": true
     },
     "or": {
       "args": [
@@ -1010,7 +1121,8 @@
       ],
       "numArgs": 2,
       "example": "{{#or 1 2 undefined }} at least one truthy {{else}} all falsey {{/or}} -> ' at least one truthy '",
-      "description": "<p>Block helper that renders a block if <strong>any of</strong> the given values is truthy. If an inverse block is specified it will be rendered when falsy.</p>\n"
+      "description": "<p>Block helper that renders a block if <strong>any of</strong> the given values is truthy. If an inverse block is specified it will be rendered when falsy.</p>\n",
+      "isBlock": true
     },
     "unlessEq": {
       "args": [
@@ -1020,7 +1132,8 @@
       ],
       "numArgs": 3,
       "example": "{{#unlessEq 2 1 }} not equal {{else}} equal {{/unlessEq}} -> ' not equal '",
-      "description": "<p>Block helper that always renders the inverse block <strong>unless <code>a</code> is equal to <code>b</code></strong>.</p>\n"
+      "description": "<p>Block helper that always renders the inverse block <strong>unless <code>a</code> is equal to <code>b</code></strong>.</p>\n",
+      "isBlock": true
     },
     "unlessGt": {
       "args": [
@@ -1030,7 +1143,8 @@
       ],
       "numArgs": 3,
       "example": "{{#unlessGt 20 1 }} not greater than {{else}} greater than {{/unlessGt}} -> ' greater than '",
-      "description": "<p>Block helper that always renders the inverse block <strong>unless <code>a</code> is greater than <code>b</code></strong>.</p>\n"
+      "description": "<p>Block helper that always renders the inverse block <strong>unless <code>a</code> is greater than <code>b</code></strong>.</p>\n",
+      "isBlock": true
     },
     "unlessLt": {
       "args": [
@@ -1040,7 +1154,8 @@
       ],
       "numArgs": 3,
       "example": "{{#unlessLt 20 1 }}greater than or equal{{else}}less than{{/unlessLt}} -> greater than or equal",
-      "description": "<p>Block helper that always renders the inverse block <strong>unless <code>a</code> is less than <code>b</code></strong>.</p>\n"
+      "description": "<p>Block helper that always renders the inverse block <strong>unless <code>a</code> is less than <code>b</code></strong>.</p>\n",
+      "isBlock": true
     },
     "unlessGteq": {
       "args": [
@@ -1050,7 +1165,8 @@
       ],
       "numArgs": 3,
       "example": "{{#unlessGteq 20 1 }} less than {{else}}greater than or equal to{{/unlessGteq}} -> greater than or equal to",
-      "description": "<p>Block helper that always renders the inverse block <strong>unless <code>a</code> is greater than or equal to <code>b</code></strong>.</p>\n"
+      "description": "<p>Block helper that always renders the inverse block <strong>unless <code>a</code> is greater than or equal to <code>b</code></strong>.</p>\n",
+      "isBlock": true
     },
     "unlessLteq": {
       "args": [
@@ -1060,7 +1176,8 @@
       ],
       "numArgs": 3,
       "example": "{{#unlessLteq 20 1 }} greater than {{else}} less than or equal to {{/unlessLteq}} -> ' greater than '",
-      "description": "<p>Block helper that always renders the inverse block <strong>unless <code>a</code> is less than or equal to <code>b</code></strong>.</p>\n"
+      "description": "<p>Block helper that always renders the inverse block <strong>unless <code>a</code> is less than or equal to <code>b</code></strong>.</p>\n",
+      "isBlock": true
     }
   },
   "object": {
@@ -1069,7 +1186,8 @@
         "objects"
       ],
       "numArgs": 1,
-      "description": "<p>Extend the context with the properties of other objects. A shallow merge is performed to avoid mutating the context.</p>\n"
+      "description": "<p>Extend the context with the properties of other objects. A shallow merge is performed to avoid mutating the context.</p>\n",
+      "isBlock": false
     },
     "forIn": {
       "args": [
@@ -1077,7 +1195,8 @@
         "options"
       ],
       "numArgs": 2,
-      "description": "<p>Block helper that iterates over the properties of an object, exposing each key and value on the context.</p>\n"
+      "description": "<p>Block helper that iterates over the properties of an object, exposing each key and value on the context.</p>\n",
+      "isBlock": true
     },
     "forOwn": {
       "args": [
@@ -1085,14 +1204,16 @@
         "options"
       ],
       "numArgs": 2,
-      "description": "<p>Block helper that iterates over the <strong>own</strong> properties of an object, exposing each key and value on the context.</p>\n"
+      "description": "<p>Block helper that iterates over the <strong>own</strong> properties of an object, exposing each key and value on the context.</p>\n",
+      "isBlock": true
     },
     "toPath": {
       "args": [
         "prop"
       ],
       "numArgs": 1,
-      "description": "<p>Take arguments and, if they are string or number, convert them to a dot-delineated object property path.</p>\n"
+      "description": "<p>Take arguments and, if they are string or number, convert them to a dot-delineated object property path.</p>\n",
+      "isBlock": false
     },
     "get": {
       "args": [
@@ -1101,7 +1222,8 @@
         "options"
       ],
       "numArgs": 3,
-      "description": "<p>Use property paths (<code>a.b.c</code>) to get a value or nested value from the context. Works as a regular helper or block helper.</p>\n"
+      "description": "<p>Use property paths (<code>a.b.c</code>) to get a value or nested value from the context. Works as a regular helper or block helper.</p>\n",
+      "isBlock": true
     },
     "getObject": {
       "args": [
@@ -1109,7 +1231,8 @@
         "context"
       ],
       "numArgs": 2,
-      "description": "<p>Use property paths (<code>a.b.c</code>) to get an object from the context. Differs from the <code>get</code> helper in that this helper will return the actual object, including the given property key. Also, this helper does not work as a block helper.</p>\n"
+      "description": "<p>Use property paths (<code>a.b.c</code>) to get an object from the context. Differs from the <code>get</code> helper in that this helper will return the actual object, including the given property key. Also, this helper does not work as a block helper.</p>\n",
+      "isBlock": false
     },
     "hasOwn": {
       "args": [
@@ -1117,28 +1240,32 @@
         "context"
       ],
       "numArgs": 2,
-      "description": "<p>Return true if <code>key</code> is an own, enumerable property of the given <code>context</code> object.</p>\n"
+      "description": "<p>Return true if <code>key</code> is an own, enumerable property of the given <code>context</code> object.</p>\n",
+      "isBlock": false
     },
     "isObject": {
       "args": [
         "value"
       ],
       "numArgs": 1,
-      "description": "<p>Return true if <code>value</code> is an object.</p>\n"
+      "description": "<p>Return true if <code>value</code> is an object.</p>\n",
+      "isBlock": false
     },
     "JSONparse": {
       "args": [
         "string"
       ],
       "numArgs": 1,
-      "description": "<p>Parses the given string using <code>JSON.parse</code>.</p>\n"
+      "description": "<p>Parses the given string using <code>JSON.parse</code>.</p>\n",
+      "isBlock": true
     },
     "JSONstringify": {
       "args": [
         "obj"
       ],
       "numArgs": 1,
-      "description": "<p>Stringify an object using <code>JSON.stringify</code>.</p>\n"
+      "description": "<p>Stringify an object using <code>JSON.stringify</code>.</p>\n",
+      "isBlock": false
     },
     "merge": {
       "args": [
@@ -1146,14 +1273,16 @@
         "objects"
       ],
       "numArgs": 2,
-      "description": "<p>Deeply merge the properties of the given <code>objects</code> with the context object.</p>\n"
+      "description": "<p>Deeply merge the properties of the given <code>objects</code> with the context object.</p>\n",
+      "isBlock": false
     },
     "parseJSON": {
       "args": [
         "string"
       ],
       "numArgs": 1,
-      "description": "<p>Parses the given string using <code>JSON.parse</code>.</p>\n"
+      "description": "<p>Parses the given string using <code>JSON.parse</code>.</p>\n",
+      "isBlock": true
     },
     "pick": {
       "args": [
@@ -1162,14 +1291,16 @@
         "options"
       ],
       "numArgs": 3,
-      "description": "<p>Pick properties from the context object.</p>\n"
+      "description": "<p>Pick properties from the context object.</p>\n",
+      "isBlock": true
     },
     "stringify": {
       "args": [
         "obj"
       ],
       "numArgs": 1,
-      "description": "<p>Stringify an object using <code>JSON.stringify</code>.</p>\n"
+      "description": "<p>Stringify an object using <code>JSON.stringify</code>.</p>\n",
+      "isBlock": false
     }
   },
   "uuid": {
@@ -1177,7 +1308,8 @@
       "args": [],
       "numArgs": 0,
       "example": "{{ uuid }} -> f34ebc66-93bd-4f7c-b79b-92b5569138bc",
-      "description": "<p>Generates a UUID, using the V4 method (identical to the browser crypto.randomUUID function).</p>\n"
+      "description": "<p>Generates a UUID, using the V4 method (identical to the browser crypto.randomUUID function).</p>\n",
+      "isBlock": false
     }
   },
   "date": {

--- a/packages/string-templates/manifest.json
+++ b/packages/string-templates/manifest.json
@@ -264,7 +264,7 @@
       "numArgs": 2,
       "example": "{{equalsLength [1, 2, 3] 3}} -> true",
       "description": "<p>Returns true if the the length of the given <code>value</code> is equal to the given <code>length</code>. Can be used as a block or inline helper.</p>\n",
-      "requiresBlock": true
+      "requiresBlock": false
     },
     "last": {
       "args": [
@@ -293,7 +293,7 @@
       "numArgs": 2,
       "example": "{{equalsLength [1, 2, 3] 3}} -> true",
       "description": "<p>Returns true if the the length of the given <code>value</code> is equal to the given <code>length</code>. Can be used as a block or inline helper.</p>\n",
-      "requiresBlock": true
+      "requiresBlock": false
     },
     "map": {
       "args": [
@@ -906,7 +906,7 @@
       "numArgs": 2,
       "example": "{{uppercase 'aBcDef'}} -> ABCDEF",
       "description": "<p>Uppercase all of the characters in the given string. If used as a block helper it will uppercase the entire block. This helper does not support inverse blocks.</p>\n",
-      "requiresBlock": true
+      "requiresBlock": false
     }
   },
   "comparison": {
@@ -931,7 +931,7 @@
       "numArgs": 4,
       "example": "{{compare 10 '<' 5 }} -> false",
       "description": "<p>Render a block when a comparison of the first and third arguments returns true. The second argument is the [arithemetic operator][operators] to use. You may also optionally specify an inverse block to render when falsy.</p>\n",
-      "requiresBlock": true
+      "requiresBlock": false
     },
     "contains": {
       "args": [

--- a/packages/string-templates/package.json
+++ b/packages/string-templates/package.json
@@ -25,7 +25,7 @@
     "manifest": "node ./scripts/gen-collection-info.js"
   },
   "dependencies": {
-    "@budibase/handlebars-helpers": "^0.13.0",
+    "@budibase/handlebars-helpers": "^0.13.1",
     "dayjs": "^1.10.8",
     "handlebars": "^4.7.6",
     "lodash.clonedeep": "^4.5.0",

--- a/packages/string-templates/scripts/gen-collection-info.js
+++ b/packages/string-templates/scripts/gen-collection-info.js
@@ -115,7 +115,8 @@ function getCommentInfo(file, func) {
     docs.example = docs.example.replace("product", "multiply")
   }
   docs.description = blocks[0].trim()
-  docs.requiresBlock = docs.tags.some(el => el.title === "block")
+  docs.acceptsBlock = docs.tags.some(el => el.title === "block")
+  docs.acceptsInline = docs.tags.some(el => el.title === "inline")
   return docs
 }
 
@@ -160,7 +161,7 @@ function run() {
         numArgs: args.length,
         example: jsDocInfo.example || undefined,
         description: jsDocInfo.description,
-        requiresBlock: jsDocInfo.requiresBlock,
+        requiresBlock: jsDocInfo.acceptsBlock && !jsDocInfo.acceptsInline,
       })
     }
     outputJSON[collection] = collectionInfo

--- a/packages/string-templates/scripts/gen-collection-info.js
+++ b/packages/string-templates/scripts/gen-collection-info.js
@@ -10,8 +10,8 @@ const marked = require("marked")
  * https://github.com/budibase/handlebars-helpers
  */
 const { join } = require("path")
+const path = require("path")
 
-const DIRECTORY = join(__dirname, "..", "..", "..")
 const COLLECTIONS = [
   "math",
   "array",
@@ -128,7 +128,7 @@ function run() {
   const foundNames = []
   for (let collection of COLLECTIONS) {
     const collectionFile = fs.readFileSync(
-      `${DIRECTORY}/node_modules/${HELPER_LIBRARY}/lib/${collection}.js`,
+      `${path.dirname(require.resolve(HELPER_LIBRARY))}/lib/${collection}.js`,
       "utf8"
     )
     const collectionInfo = {}

--- a/packages/string-templates/scripts/gen-collection-info.js
+++ b/packages/string-templates/scripts/gen-collection-info.js
@@ -115,6 +115,7 @@ function getCommentInfo(file, func) {
     docs.example = docs.example.replace("product", "multiply")
   }
   docs.description = blocks[0].trim()
+  docs.isBlock = docs.tags.some(el => el.title === "block")
   return docs
 }
 
@@ -159,6 +160,7 @@ function run() {
         numArgs: args.length,
         example: jsDocInfo.example || undefined,
         description: jsDocInfo.description,
+        isBlock: jsDocInfo.isBlock,
       })
     }
     outputJSON[collection] = collectionInfo

--- a/packages/string-templates/scripts/gen-collection-info.js
+++ b/packages/string-templates/scripts/gen-collection-info.js
@@ -115,7 +115,7 @@ function getCommentInfo(file, func) {
     docs.example = docs.example.replace("product", "multiply")
   }
   docs.description = blocks[0].trim()
-  docs.isBlock = docs.tags.some(el => el.title === "block")
+  docs.requiresBlock = docs.tags.some(el => el.title === "block")
   return docs
 }
 
@@ -160,7 +160,7 @@ function run() {
         numArgs: args.length,
         example: jsDocInfo.example || undefined,
         description: jsDocInfo.description,
-        isBlock: jsDocInfo.isBlock,
+        requiresBlock: jsDocInfo.requiresBlock,
       })
     }
     outputJSON[collection] = collectionInfo

--- a/packages/string-templates/src/helpers/date.js
+++ b/packages/string-templates/src/helpers/date.js
@@ -115,7 +115,7 @@ module.exports.duration = (str, pattern, format) => {
   setLocale(config.str, config.pattern)
 
   const duration = dayjs.duration(config.str, config.pattern)
-  if (!isOptions(format)) {
+  if (format && !isOptions(format)) {
     return duration.format(format)
   } else {
     return duration.humanize()

--- a/packages/string-templates/src/helpers/list.js
+++ b/packages/string-templates/src/helpers/list.js
@@ -27,6 +27,7 @@ module.exports.getHelperList = () => {
   return helpers
 }
 
+// Some helpers depend on handlebars injecting some parameters. This function adjust the helpers when required
 function adjustJsHelpers(helpers) {
   const result = { ...helpers }
 

--- a/packages/string-templates/src/helpers/list.js
+++ b/packages/string-templates/src/helpers/list.js
@@ -21,6 +21,17 @@ module.exports.getHelperList = () => {
   for (let key of Object.keys(externalHandlebars.addedHelpers)) {
     helpers[key] = externalHandlebars.addedHelpers[key]
   }
+
+  helpers = adjustJsHelpers(helpers)
   Object.freeze(helpers)
   return helpers
+}
+
+function adjustJsHelpers(helpers) {
+  const result = { ...helpers }
+
+  result.avg = function (...params) {
+    return helpers.avg(...params, {})
+  }
+  return result
 }

--- a/packages/string-templates/src/helpers/list.js
+++ b/packages/string-templates/src/helpers/list.js
@@ -15,24 +15,14 @@ module.exports.getHelperList = () => {
   }
   for (let collection of constructed) {
     for (let [key, func] of Object.entries(collection)) {
-      helpers[key] = func
+      // Handlebars injects the hbs options to the helpers by default. We are adding an empty {} as a last parameter to simulate it
+      helpers[key] = (...props) => func(...props, {})
     }
   }
   for (let key of Object.keys(externalHandlebars.addedHelpers)) {
     helpers[key] = externalHandlebars.addedHelpers[key]
   }
 
-  helpers = adjustJsHelpers(helpers)
   Object.freeze(helpers)
   return helpers
-}
-
-// Some helpers depend on handlebars injecting some parameters. This function adjust the helpers when required
-function adjustJsHelpers(helpers) {
-  const result = { ...helpers }
-
-  result.avg = function (...params) {
-    return helpers.avg(...params, {})
-  }
-  return result
 }

--- a/packages/string-templates/src/helpers/list.js
+++ b/packages/string-templates/src/helpers/list.js
@@ -3,6 +3,8 @@ const helperList = require("@budibase/handlebars-helpers")
 
 let helpers = undefined
 
+const helpersToRemove = ["sortBy"]
+
 module.exports.getHelperList = () => {
   if (helpers) {
     return helpers
@@ -23,6 +25,9 @@ module.exports.getHelperList = () => {
     helpers[key] = externalHandlebars.addedHelpers[key]
   }
 
+  for (const toRemove of helpersToRemove) {
+    delete helpers[toRemove]
+  }
   Object.freeze(helpers)
   return helpers
 }

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -121,7 +121,6 @@ describe("manifest", () => {
         })
 
         let convertedJs = convertToJS(hbs)
-        convertedJs = convertedJs.replace(/\n/g, "\n")
 
         let result = processJS(convertedJs, context)
         result = result.replace(/&nbsp;/g, " ")

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -58,7 +58,8 @@ const examples = collections.reduce((acc, collection) => {
           }
         }
       }
-      return [name, { hbs, js }]
+      const hasHbsBody = details.isBlock
+      return [name, { hbs, js, hasHbsBody }]
     })
     .filter(x => !!x)
 
@@ -108,7 +109,9 @@ describe("manifest", () => {
 
   describe("can be parsed and run as js", () => {
     describe.each(Object.keys(examples))("%s", collection => {
-      it.each(examples[collection])("%s", async (_, { hbs, js }) => {
+      it.each(
+        examples[collection].filter(([_, { hasHbsBody }]) => !hasHbsBody)
+      )("%s", async (_, { hbs, js }) => {
         const context = {
           double: i => i * 2,
           isString: x => typeof x === "string",

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -24,6 +24,7 @@ const {
 } = require("../src/index.cjs")
 
 const tk = require("timekeeper")
+const { getHelperList } = require("../src/helpers")
 
 tk.freeze("2021-01-21T12:00:00")
 
@@ -108,9 +109,15 @@ describe("manifest", () => {
   })
 
   describe("can be parsed and run as js", () => {
-    describe.each(Object.keys(examples))("%s", collection => {
+    const jsHelpers = getHelperList()
+    const jsExamples = Object.keys(examples).reduce((acc, v) => {
+      acc[v] = examples[v].filter(([key]) => jsHelpers[key])
+      return acc
+    }, {})
+
+    describe.each(Object.keys(jsExamples))("%s", collection => {
       it.each(
-        examples[collection].filter(
+        jsExamples[collection].filter(
           ([_, { requiresHbsBody }]) => !requiresHbsBody
         )
       )("%s", async (_, { hbs, js }) => {

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -58,8 +58,8 @@ const examples = collections.reduce((acc, collection) => {
           }
         }
       }
-      const hasHbsBody = details.isBlock
-      return [name, { hbs, js, hasHbsBody }]
+      const requiresHbsBody = details.requiresBlock
+      return [name, { hbs, js, requiresHbsBody }]
     })
     .filter(x => !!x)
 
@@ -110,7 +110,9 @@ describe("manifest", () => {
   describe("can be parsed and run as js", () => {
     describe.each(Object.keys(examples))("%s", collection => {
       it.each(
-        examples[collection].filter(([_, { hasHbsBody }]) => !hasHbsBody)
+        examples[collection].filter(
+          ([_, { requiresHbsBody }]) => !requiresHbsBody
+        )
       )("%s", async (_, { hbs, js }) => {
         const context = {
           double: i => i * 2,

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -58,7 +58,7 @@ const examples = collections.reduce((acc, collection) => {
           }
         }
       }
-      return [name, hbs, js]
+      return [name, { hbs, js }]
     })
     .filter(x => !!x)
 
@@ -87,7 +87,7 @@ function tryParseJson(str) {
 describe("manifest", () => {
   describe("examples are valid", () => {
     describe.each(Object.keys(examples))("%s", collection => {
-      it.each(examples[collection])("%s", async (_, hbs, js) => {
+      it.each(examples[collection])("%s", async (_, { hbs, js }) => {
         const context = {
           double: i => i * 2,
           isString: x => typeof x === "string",
@@ -108,7 +108,7 @@ describe("manifest", () => {
 
   describe("can be parsed and run as js", () => {
     describe.each(Object.keys(examples))("%s", collection => {
-      it.each(examples[collection])("%s", async (_, hbs, js) => {
+      it.each(examples[collection])("%s", async (_, { hbs, js }) => {
         const context = {
           double: i => i * 2,
           isString: x => typeof x === "string",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,10 +2031,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@budibase/handlebars-helpers@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@budibase/handlebars-helpers/-/handlebars-helpers-0.13.0.tgz#224333d14e3900b7dacf48286af1e624a9fd62ea"
-  integrity sha512-g8+sFrMNxsIDnK+MmdUICTVGr6ReUFtnPp9hJX0VZwz1pN3Ynolpk/Qbu6rEWAvoU1sEqY1mXr9uo/+kEfeGbQ==
+"@budibase/handlebars-helpers@^0.13.1":
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/@budibase/handlebars-helpers/-/handlebars-helpers-0.13.1.tgz#d02e73c0df8305cd675e70dc37f8427eb0842080"
+  integrity sha512-v4RbXhr3igvK3i2pj5cNltu/4NMxdPIzcUt/o0RoInhesNH1VSLRdweSFr6/Y34fsCR5jHZ6vltdcz2RgrTKgw==
   dependencies:
     get-object "^0.2.0"
     get-value "^3.0.1"


### PR DESCRIPTION
## Description
Test and fix handlebars helpers running as javascript.
Many helpers rely on having handlebars blocks, and it does not make much sense to have it converted to js, given that there are native ways to achieve most of them. Because of this, we are just removing them from the js section (and we should not allow its conversion)

Requires https://github.com/Budibase/handlebars-helpers/pull/20 to be merged and published
