### PR TITLE
Fix automation looping failing when binding returned an integer.

### DIFF
--- a/packages/server/src/automations/tests/loop.spec.ts
+++ b/packages/server/src/automations/tests/loop.spec.ts
@@ -44,4 +44,12 @@ describe("Attempt to run a basic loop automation", () => {
     })
     expect(resp.steps[2].outputs.iterations).toBe(3)
   })
+
+  it("test a loop with a binding that returns an integer", async () => {
+    const resp = await runLoop({
+      option: LoopStepType.ARRAY,
+      binding: "{{ 1 }}",
+    })
+    expect(resp.steps[2].outputs.iterations).toBe(1)
+  })
 })

--- a/packages/server/src/automations/triggers.ts
+++ b/packages/server/src/automations/triggers.ts
@@ -9,7 +9,7 @@ import * as utils from "./utils"
 import env from "../environment"
 import { context, db as dbCore } from "@budibase/backend-core"
 import { Automation, Row, AutomationData, AutomationJob } from "@budibase/types"
-import { executeSynchronously } from "../threads/automation"
+import { executeInThread } from "../threads/automation"
 
 export const TRIGGER_DEFINITIONS = definitions
 const JOB_OPTS = {
@@ -117,8 +117,7 @@ export async function externalTrigger(
       appId: context.getAppId(),
       automation,
     }
-    const job = { data } as AutomationJob
-    return executeSynchronously(job)
+    return executeInThread({ data } as AutomationJob)
   } else {
     return automationQueue.add(data, JOB_OPTS)
   }

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -43,19 +43,17 @@ const CRON_STEP_ID = triggerDefs.CRON.stepId
 const STOPPED_STATUS = { success: true, status: AutomationStatus.STOPPED }
 
 function getLoopIterations(loopStep: LoopStep) {
-  let binding = loopStep.inputs.binding
+  const binding = loopStep.inputs.binding
   if (!binding) {
     return 0
   }
   try {
-    if (typeof binding === "string") {
-      binding = JSON.parse(binding)
+    const json = typeof binding === "string" ? JSON.parse(binding) : binding
+    if (Array.isArray(json)) {
+      return json.length
     }
   } catch (err) {
     // ignore error - wasn't able to parse
-  }
-  if (Array.isArray(binding)) {
-    return binding.length
   }
   if (typeof binding === "string") {
     return automationUtils.stringSplit(binding).length

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -614,7 +614,7 @@ export function execute(job: Job<AutomationData>, callback: WorkerCallback) {
   })
 }
 
-export function executeSynchronously(job: Job) {
+export async function executeInThread(job: Job<AutomationData>) {
   const appId = job.data.event.appId
   if (!appId) {
     throw new Error("Unable to execute, event doesn't contain app ID.")
@@ -626,10 +626,10 @@ export function executeSynchronously(job: Job) {
     }, job.data.event.timeout || 12000)
   })
 
-  return context.doInAppContext(appId, async () => {
+  return await context.doInAppContext(appId, async () => {
     const envVars = await sdkUtils.getEnvironmentVariables()
     // put into automation thread for whole context
-    return context.doInEnvironmentContext(envVars, async () => {
+    return await context.doInEnvironmentContext(envVars, async () => {
       const automationOrchestrator = new Orchestrator(job)
       return await Promise.race([
         automationOrchestrator.execute(),


### PR DESCRIPTION
## Description

This PR fixes [this bug](https://app.datadoghq.eu/apm/error-tracking/issue/c62c2616-b558-11ee-940c-da7ad0900005?refresh_mode=sliding&tb=%40http.url&view=spans&from_ts=1705943979351&to_ts=1706548779351&live=true).

What's happening is that the loop `binding` field is returning an integer, which before this PR would make it fall through into the branch in `getLoopIterations` that called `splitString`, except we pass an number and not a string so it fails.

This change makes it so that if the binding returns a standalone integer, we use that an a 1-length array.

Additionally I renamed `executeSychronously` because I was confused when I read it and learned it executed asynchronously. I figured out that it means synchronous as in "not using Bull", so I'm hoping the name `executeInThread` is more clear.
