### PR TITLE
Fix existing relationship modal size

### DIFF
--- a/packages/builder/src/components/backend/Datasources/CreateEditRelationship.svelte
+++ b/packages/builder/src/components/backend/Datasources/CreateEditRelationship.svelte
@@ -373,6 +373,7 @@
   confirmText="Save"
   onConfirm={saveRelationship}
   disabled={!valid}
+  size="L"
 >
   <div class="headings">
     <Detail>Tables</Detail>

--- a/packages/builder/src/components/common/RelationshipSelector.svelte
+++ b/packages/builder/src/components/common/RelationshipSelector.svelte
@@ -17,7 +17,7 @@
 </script>
 
 <div class="relationship-container">
-  <div class="relationship-part">
+  <div class="relationship-type">
     <Select
       disabled={linkEditDisabled}
       bind:value={relationshipPart1}
@@ -39,7 +39,7 @@
   </div>
 </div>
 <div class="relationship-container">
-  <div class="relationship-part">
+  <div class="relationship-type">
     <Select
       disabled={linkEditDisabled}
       bind:value={relationshipPart2}
@@ -79,6 +79,10 @@
   }
 
   .relationship-part {
-    flex-basis: 60%;
+    flex-basis: 70%;
+  }
+
+  .relationship-type {
+    flex-basis: 30%;
   }
 </style>


### PR DESCRIPTION
## Description
Fix for #12909 - the relationship modal was too small, cutting table names and making it hard to use, expanding the modal to be easier to use on normal screens.

![image](https://github.com/Budibase/budibase/assets/4407001/0b3f6ce4-8bc6-4fd6-a1e8-1aaa241a6de8)

Addresses #12909 and https://linear.app/budibase/issue/BUDI-7961/define-relationship-modal-in-the-data-section-is-too-narrow