### PR TITLE
Remove no available js helpers

### DIFF
--- a/packages/builder/src/components/common/bindings/BindingPicker.svelte
+++ b/packages/builder/src/components/common/bindings/BindingPicker.svelte
@@ -50,7 +50,7 @@
       (!search ||
         helper.label.match(searchRgx) ||
         helper.description.match(searchRgx)) &&
-      (mode.name !== "javascript" || !helper.requiresBlock)
+      (mode.name !== "javascript" || helper.allowsJs)
     )
   })
 

--- a/packages/builder/src/components/common/bindings/BindingPicker.svelte
+++ b/packages/builder/src/components/common/bindings/BindingPicker.svelte
@@ -47,9 +47,10 @@
     })
   $: filteredHelpers = helpers?.filter(helper => {
     return (
-      !search ||
-      helper.label.match(searchRgx) ||
-      helper.description.match(searchRgx)
+      (!search ||
+        helper.label.match(searchRgx) ||
+        helper.description.match(searchRgx)) &&
+      (mode.name !== "javascript" || !helper.requiresBlock)
     )
   })
 

--- a/packages/builder/src/constants/completions.js
+++ b/packages/builder/src/constants/completions.js
@@ -11,6 +11,7 @@ export function handlebarsCompletions() {
       label: helperName,
       displayText: helperName,
       description: helperConfig.description,
+      requiresBlock: helperConfig.requiresBlock,
     }))
   )
 }

--- a/packages/builder/src/constants/completions.js
+++ b/packages/builder/src/constants/completions.js
@@ -11,7 +11,7 @@ export function handlebarsCompletions() {
       label: helperName,
       displayText: helperName,
       description: helperConfig.description,
-      requiresBlock: helperConfig.requiresBlock,
+      allowsJs: !helperConfig.requiresBlock,
     }))
   )
 }

--- a/packages/builder/src/constants/completions.js
+++ b/packages/builder/src/constants/completions.js
@@ -1,4 +1,4 @@
-import { getManifest } from "@budibase/string-templates"
+import { getManifest, helpersToRemoveForJs } from "@budibase/string-templates"
 
 export function handlebarsCompletions() {
   const manifest = getManifest()
@@ -11,7 +11,9 @@ export function handlebarsCompletions() {
       label: helperName,
       displayText: helperName,
       description: helperConfig.description,
-      allowsJs: !helperConfig.requiresBlock,
+      allowsJs:
+        !helperConfig.requiresBlock &&
+        !helpersToRemoveForJs.includes(helperName),
     }))
   )
 }

--- a/packages/string-templates/src/conversion/index.js
+++ b/packages/string-templates/src/conversion/index.js
@@ -1,4 +1,4 @@
-const { getHelperList } = require("../helpers")
+const { getJsHelperList } = require("../helpers")
 
 function getLayers(fullBlock) {
   let layers = []
@@ -109,7 +109,7 @@ module.exports.convertHBSBlock = (block, blockNumber) => {
   const layers = getLayers(block)
 
   let value = null
-  const list = getHelperList()
+  const list = getJsHelperList()
   for (let layer of layers) {
     const parts = splitBySpace(layer)
     if (value || parts.length > 1 || list[parts[0]]) {

--- a/packages/string-templates/src/helpers/index.js
+++ b/packages/string-templates/src/helpers/index.js
@@ -7,7 +7,7 @@ const {
   HelperFunctionBuiltin,
   LITERAL_MARKER,
 } = require("./constants")
-const { getHelperList } = require("./list")
+const { getJsHelperList } = require("./list")
 
 const HTML_SWAPS = {
   "<": "&lt;",
@@ -97,4 +97,4 @@ module.exports.unregisterAll = handlebars => {
   externalHandlebars.unregisterAll(handlebars)
 }
 
-module.exports.getHelperList = getHelperList
+module.exports.getJsHelperList = getJsHelperList

--- a/packages/string-templates/src/helpers/javascript.js
+++ b/packages/string-templates/src/helpers/javascript.js
@@ -1,7 +1,7 @@
 const { atob } = require("../utilities")
 const cloneDeep = require("lodash.clonedeep")
 const { LITERAL_MARKER } = require("../helpers/constants")
-const { getHelperList } = require("./list")
+const { getJsHelperList } = require("./list")
 
 // The method of executing JS scripts depends on the bundle being built.
 // This setter is used in the entrypoint (either index.cjs or index.mjs).
@@ -49,7 +49,7 @@ module.exports.processJS = (handlebars, context) => {
     // app context.
     const sandboxContext = {
       $: path => getContextValue(path, cloneDeep(context)),
-      helpers: getHelperList(),
+      helpers: getJsHelperList(),
     }
 
     // Create a sandbox with our context and run the JS

--- a/packages/string-templates/src/helpers/list.js
+++ b/packages/string-templates/src/helpers/list.js
@@ -5,7 +5,7 @@ let helpers = undefined
 
 const helpersToRemove = ["sortBy"]
 
-module.exports.getHelperList = () => {
+module.exports.getJsHelperList = () => {
   if (helpers) {
     return helpers
   }

--- a/packages/string-templates/src/helpers/list.js
+++ b/packages/string-templates/src/helpers/list.js
@@ -3,7 +3,8 @@ const helperList = require("@budibase/handlebars-helpers")
 
 let helpers = undefined
 
-const helpersToRemove = ["sortBy"]
+const helpersToRemoveForJs = ["sortBy"]
+module.exports.helpersToRemoveForJs = helpersToRemoveForJs
 
 module.exports.getJsHelperList = () => {
   if (helpers) {
@@ -25,7 +26,7 @@ module.exports.getJsHelperList = () => {
     helpers[key] = externalHandlebars.addedHelpers[key]
   }
 
-  for (const toRemove of helpersToRemove) {
+  for (const toRemove of helpersToRemoveForJs) {
     delete helpers[toRemove]
   }
   Object.freeze(helpers)

--- a/packages/string-templates/src/index.cjs
+++ b/packages/string-templates/src/index.cjs
@@ -20,6 +20,7 @@ module.exports.findHBSBlocks = templates.findHBSBlocks
 module.exports.convertToJS = templates.convertToJS
 module.exports.setJSRunner = templates.setJSRunner
 module.exports.FIND_ANY_HBS_REGEX = templates.FIND_ANY_HBS_REGEX
+module.exports.helpersToRemoveForJs = templates.helpersToRemoveForJs
 
 if (!process.env.NO_JS) {
   const { VM } = require("vm2")

--- a/packages/string-templates/src/index.js
+++ b/packages/string-templates/src/index.js
@@ -10,6 +10,7 @@ const {
 } = require("./utilities")
 const { convertHBSBlock } = require("./conversion")
 const javascript = require("./helpers/javascript")
+const { helpersToRemoveForJs } = require("./helpers/list")
 
 const hbsInstance = handlebars.create()
 registerAll(hbsInstance)
@@ -394,3 +395,4 @@ module.exports.convertToJS = hbs => {
 }
 
 module.exports.FIND_ANY_HBS_REGEX = FIND_ANY_HBS_REGEX
+module.exports.helpersToRemoveForJs = helpersToRemoveForJs

--- a/packages/string-templates/src/index.mjs
+++ b/packages/string-templates/src/index.mjs
@@ -21,6 +21,7 @@ export const findHBSBlocks = templates.findHBSBlocks
 export const convertToJS = templates.convertToJS
 export const setJSRunner = templates.setJSRunner
 export const FIND_ANY_HBS_REGEX = templates.FIND_ANY_HBS_REGEX
+export const helpersToRemoveForJs = templates.helpersToRemoveForJs
 
 if (process && !process.env.NO_JS) {
   /**

--- a/packages/string-templates/test/manifest.spec.js
+++ b/packages/string-templates/test/manifest.spec.js
@@ -24,7 +24,7 @@ const {
 } = require("../src/index.cjs")
 
 const tk = require("timekeeper")
-const { getHelperList } = require("../src/helpers")
+const { getJsHelperList } = require("../src/helpers")
 
 tk.freeze("2021-01-21T12:00:00")
 
@@ -109,7 +109,7 @@ describe("manifest", () => {
   })
 
   describe("can be parsed and run as js", () => {
-    const jsHelpers = getHelperList()
+    const jsHelpers = getJsHelperList()
     const jsExamples = Object.keys(examples).reduce((acc, v) => {
       acc[v] = examples[v].filter(([key]) => jsHelpers[key])
       return acc


### PR DESCRIPTION
## Description
We have some hbs helpers, such as `sortBy`, that need to be excluded for js usage. We already excluded them on [this PR](https://github.com/Budibase/budibase/pull/12904). This new PR will get sure we don't display it on the builder

## Screenshots
### Helpers are available in js...
<img width="698" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/2899c223-ef77-4dfa-be5e-26d605259d17">

### except the ones that require hbs blocks...
<img width="683" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/e9c91014-8adf-4bb5-b914-3cfbc62d8b50">

### and the ones excluded, such as `sortBy`.
<img width="675" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/16da7250-ae81-4cb4-a189-c7b6330f4aec">

### All of them are available for hbs
<img width="690" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/5e958177-ce55-4844-b455-dadf40fece79">
<img width="690" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/759e2413-5761-4cff-a02d-dc571ec8b1a0">
<img width="704" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/b7959ff5-8f9a-4ebd-bc1e-206308f35800">


