### PR TITLE
Fix automation JS scripts

### DIFF
--- a/packages/server/src/api/controllers/script.ts
+++ b/packages/server/src/api/controllers/script.ts
@@ -1,12 +1,12 @@
 import ScriptRunner from "../../utilities/scriptRunner"
-import { BBContext } from "@budibase/types"
+import { Ctx } from "@budibase/types"
 
-export async function execute(ctx: BBContext) {
+export async function execute(ctx: Ctx) {
   const { script, context } = ctx.request.body
   const runner = new ScriptRunner(script, context)
   ctx.body = runner.execute()
 }
 
-export async function save(ctx: BBContext) {
+export async function save(ctx: Ctx) {
   ctx.throw(501, "Not currently implemented")
 }

--- a/packages/server/src/automations/tests/executeScript.spec.js
+++ b/packages/server/src/automations/tests/executeScript.spec.js
@@ -9,34 +9,40 @@ describe("test the execute script action", () => {
   afterAll(setup.afterAll)
 
   it("should be able to execute a script", async () => {
-    let res = await setup.runStep(
-      setup.actions.EXECUTE_SCRIPT.stepId,
-      (inputs = {
-        code: "return 1 + 1",
-      })
-    )
+    const res = await setup.runStep(setup.actions.EXECUTE_SCRIPT.stepId, {
+      code: "return 1 + 1",
+    })
     expect(res.value).toEqual(2)
     expect(res.success).toEqual(true)
   })
 
   it("should handle a null value", async () => {
-    let res = await setup.runStep(
-      setup.actions.EXECUTE_SCRIPT.stepId,
-      (inputs = {
-        code: null,
-      })
-    )
+    const res = await setup.runStep(setup.actions.EXECUTE_SCRIPT.stepId, {
+      code: null,
+    })
     expect(res.response.message).toEqual("Invalid inputs")
     expect(res.success).toEqual(false)
   })
 
-  it("should be able to handle an error gracefully", async () => {
-    let res = await setup.runStep(
+  it("should be able to get a value from context", async () => {
+    const res = await setup.runStep(
       setup.actions.EXECUTE_SCRIPT.stepId,
-      (inputs = {
-        code: "return something.map(x => x.name)",
-      })
+      {
+        code: "return steps.map(d => d.value)",
+      },
+      {
+        steps: [{ value: 0 }, { value: 1 }],
+      }
     )
+    expect(res.value).toEqual([0, 1])
+    expect(res.response).toBeUndefined()
+    expect(res.success).toEqual(true)
+  })
+
+  it("should be able to handle an error gracefully", async () => {
+    const res = await setup.runStep(setup.actions.EXECUTE_SCRIPT.stepId, {
+      code: "return something.map(x => x.name)",
+    })
     expect(res.response).toEqual("ReferenceError: something is not defined")
     expect(res.success).toEqual(false)
   })

--- a/packages/server/src/utilities/scriptRunner.ts
+++ b/packages/server/src/utilities/scriptRunner.ts
@@ -1,4 +1,4 @@
-import ivm, { Context, Script } from "isolated-vm"
+import ivm from "isolated-vm"
 
 const JS_TIMEOUT_MS = 1000
 
@@ -9,8 +9,7 @@ class ScriptRunner {
     const code = `let fn = () => {\n${script}\n}; results.out = fn();`
     this.vm = new IsolatedVM({ memoryLimit: 8 })
     this.vm.context = {
-      data: context.data,
-      params: context.params,
+      ...context,
       results: { out: "" },
     }
     this.vm.code = code


### PR DESCRIPTION
## Description
Quick fix, the context in the `scriptRunner` wasn't generic, this passes through all props from the context rather than just `data` and `params` as transformers would use.
