### PR TITLE
Fix table slots providing global context rather than local context

### DIFF
--- a/packages/client/src/components/app/table/SlotRenderer.svelte
+++ b/packages/client/src/components/app/table/SlotRenderer.svelte
@@ -3,9 +3,9 @@
 
   export let row
 
-  const { Provider } = getContext("sdk")
+  const { Provider, ContextScopes } = getContext("sdk")
 </script>
 
-<Provider data={row}>
+<Provider data={row} scope={ContextScopes.Local}>
   <slot />
 </Provider>


### PR DESCRIPTION
## Description
Tables were providing global context to the custom column slot instead of local. This was causing a few different issues with duplicated binding values.

## Addresses
- https://linear.app/budibase/issue/BUDI-7985/the-save-row-action-attached-to-a-nested-button-within-a-table-only
- https://linear.app/budibase/issue/BUDI-7983/buttons-in-table-reference-wrong-row
