### PR TITLE
Disable schema dumping for Postgres in Budicloud.

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/datasource/[datasourceId]/index.svelte
@@ -12,12 +12,16 @@
   import PromptQueryModal from "./_components/PromptQueryModal.svelte"
   import SettingsPanel from "./_components/panels/Settings.svelte"
   import { helpers } from "@budibase/shared-core"
+  import { admin } from "stores/portal"
+  import { IntegrationTypes } from "constants/backend"
 
   let selectedPanel = null
   let panelOptions = []
 
   $: datasource = $datasources.selected
 
+  $: isCloud = $admin.cloud
+  $: isPostgres = datasource?.source === IntegrationTypes.POSTGRES
   $: getOptions(datasource)
 
   const getOptions = datasource => {
@@ -41,7 +45,13 @@
     }
     // always the last option for SQL
     if (helpers.isSQL(datasource)) {
-      panelOptions.push("Settings")
+      if (isCloud && isPostgres) {
+        // We don't show the settings panel for Postgres on Budicloud because
+        // it requires pg_dump to work and we don't want to enable shell injection
+        // attacks.
+      } else {
+        panelOptions.push("Settings")
+      }
     }
   }
 </script>

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -29,6 +29,7 @@ import { Client, ClientConfig, types } from "pg"
 import { getReadableErrorMessage } from "./base/errorMapping"
 import { exec } from "child_process"
 import { storeTempFile } from "../utilities/fileSystem"
+import { env } from "@budibase/backend-core"
 
 // Return "date" and "timestamp" types as plain strings.
 // This lets us reference the original stored timezone.
@@ -433,6 +434,14 @@ class PostgresIntegration extends Sql implements DatasourcePlus {
   }
 
   async getExternalSchema() {
+    if (!env.SELF_HOSTED) {
+      // This is because it relies on shelling out to pg_dump and we don't want
+      // to enable shell injection attacks.
+      throw new Error(
+        "schema export for Postgres is not supported in Budibase Cloud"
+      )
+    }
+
     const dumpCommandParts = [
       `user=${this.config.user}`,
       `host=${this.config.host}`,


### PR DESCRIPTION
## Description

Schema dumping for Postgres makes use of `pg_dump` and, as written, allows shell injection. For now, I'm disabling this functionality just in cloud because it's not safe to have it available.
