### PR TITLE
Fix for js binding auto complete

### DIFF
--- a/packages/builder/src/components/common/CodeEditor/index.js
+++ b/packages/builder/src/components/common/CodeEditor/index.js
@@ -286,7 +286,13 @@ export const hbInsert = (value, from, to, text) => {
   return parsedInsert
 }
 
-export function jsInsert(value, from, to, text, { helper, disableWrapping }) {
+export function jsInsert(
+  value,
+  from,
+  to,
+  text,
+  { helper, disableWrapping } = {}
+) {
   let parsedInsert = ""
 
   const left = from ? value.substring(0, from) : ""


### PR DESCRIPTION
## Description

This issue affected the js autocomplete behaviour. It was attempting to destructure an undefined option. The value has now been defaulted to an empty object.

## Addresses
- https://linear.app/budibase/issue/BUDI-7991/auto-completion-in-bindings-is-broken