### PR TITLE
Replace uses of test.com with example.com

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,7 +43,8 @@
         "no-useless-escape": "off",
         "no-undef": "off",
         "no-prototype-builtins": "off",
-        "local-rules/no-budibase-imports": "error"
+        "local-rules/no-budibase-imports": "error",
+        "local-rules/no-test-com": "error"
       }
     },
     {
@@ -53,7 +54,7 @@
         "packages/frontend-core/**/*"
       ],
       "rules": {
-        "no-console": ["error", { "allow": ["warn", "error", "debug"] } ]
+        "no-console": ["error", { "allow": ["warn", "error", "debug"] }]
       }
     }
   ],

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -18,4 +18,37 @@ module.exports = {
       }
     },
   },
+  "no-test-com": {
+    meta: {
+      type: "problem",
+      docs: {
+        description:
+          "disallow the use of 'test.com' in strings and replace it with 'example.com'",
+        category: "Possible Errors",
+        recommended: false,
+      },
+      schema: [], // no options
+      fixable: "code", // Indicates that this rule supports automatic fixing
+    },
+    create: function (context) {
+      return {
+        Literal(node) {
+          if (
+            typeof node.value === "string" &&
+            node.value.includes("test.com")
+          ) {
+            context.report({
+              node,
+              message:
+                "test.com is a privately owned domain and could point anywhere, use example.com instead.",
+              fix: function (fixer) {
+                const newText = node.raw.replace(/test\.com/g, "example.com")
+                return fixer.replaceText(node, newText)
+              },
+            })
+          }
+        },
+      }
+    },
+  },
 }

--- a/packages/backend-core/src/utils/tests/utils.spec.ts
+++ b/packages/backend-core/src/utils/tests/utils.spec.ts
@@ -44,11 +44,11 @@ describe("utils", () => {
 
     it("gets appId from url", async () => {
       await config.doInTenant(async () => {
-        const url = "http://test.com"
+        const url = "http://example.com"
         env._set("PLATFORM_URL", url)
 
         const ctx = structures.koa.newContext()
-        ctx.host = `${config.tenantId}.test.com`
+        ctx.host = `${config.tenantId}.example.com`
 
         const expected = db.generateAppID(config.tenantId)
         const app = structures.apps.app(expected)
@@ -89,7 +89,7 @@ describe("utils", () => {
       const ctx = structures.koa.newContext()
       const expected = db.generateAppID()
       ctx.request.headers = {
-        referer: `http://test.com/builder/app/${expected}/design/screen_123/screens`,
+        referer: `http://example.com/builder/app/${expected}/design/screen_123/screens`,
       }
 
       const actual = await utils.getAppIdFromCtx(ctx)
@@ -100,7 +100,7 @@ describe("utils", () => {
       const ctx = structures.koa.newContext()
       const appId = db.generateAppID()
       ctx.request.headers = {
-        referer: `http://test.com/foo/app/${appId}/bar`,
+        referer: `http://example.com/foo/app/${appId}/bar`,
       }
 
       const actual = await utils.getAppIdFromCtx(ctx)

--- a/packages/backend-core/tests/core/utilities/structures/common.ts
+++ b/packages/backend-core/tests/core/utilities/structures/common.ts
@@ -3,5 +3,5 @@ import { v4 as uuid } from "uuid"
 export { v4 as uuid } from "uuid"
 
 export const email = () => {
-  return `${uuid()}@test.com`
+  return `${uuid()}@example.com`
 }

--- a/packages/backend-core/tests/core/utilities/structures/sso.ts
+++ b/packages/backend-core/tests/core/utilities/structures/sso.ts
@@ -61,7 +61,7 @@ export function ssoProfile(user?: User): SSOProfile {
     },
     _json: {
       email: user.email,
-      picture: "http://test.com",
+      picture: "http://example.com",
     },
     provider: generator.string(),
   }

--- a/packages/backend-core/tests/core/utilities/structures/users.ts
+++ b/packages/backend-core/tests/core/utilities/structures/users.ts
@@ -25,7 +25,7 @@ export const user = (userProps?: Partial<Omit<User, "userId">>): User => {
     roles: { app_test: "admin" },
     firstName: generator.first(),
     lastName: generator.last(),
-    pictureUrl: "http://test.com",
+    pictureUrl: "http://example.com",
     tenantId: tenant.id(),
     ...userProps,
   }

--- a/packages/server/__mocks__/@sendgrid/mail.ts
+++ b/packages/server/__mocks__/@sendgrid/mail.ts
@@ -11,7 +11,7 @@ module SendgridMock {
     }
 
     async send(msg: any) {
-      if (msg.to === "invalid@test.com") {
+      if (msg.to === "invalid@example.com") {
         throw "Invalid"
       }
       return msg

--- a/packages/server/__mocks__/aws-sdk.ts
+++ b/packages/server/__mocks__/aws-sdk.ts
@@ -60,7 +60,7 @@ module AwsMock {
 
     // @ts-ignore
     this.getSignedUrl = (operation, params) => {
-      return `http://test.com/${params.Bucket}/${params.Key}`
+      return `http://example.com/${params.Bucket}/${params.Key}`
     }
 
     // @ts-ignore

--- a/packages/server/__mocks__/node-fetch.ts
+++ b/packages/server/__mocks__/node-fetch.ts
@@ -36,8 +36,8 @@ module FetchMock {
 
     if (url.includes("/api/global")) {
       const user = {
-        email: "test@test.com",
-        _id: "us_test@test.com",
+        email: "test@example.com",
+        _id: "us_test@example.com",
         status: "active",
         roles: {},
         builder: {
@@ -58,7 +58,7 @@ module FetchMock {
           url: "/app1",
         },
       })
-    } else if (url.includes("test.com")) {
+    } else if (url.includes("example.com")) {
       return json({
         body: opts.body,
         url,

--- a/packages/server/specs/openapi.json
+++ b/packages/server/specs/openapi.json
@@ -367,7 +367,7 @@
         "value": {
           "data": {
             "_id": "us_693a73206518477283a8d5ae31103252",
-            "email": "test@test.com",
+            "email": "test@example.com",
             "roles": {
               "app_957b12f943d348faa61db7e18e088d0f": "BASIC"
             },
@@ -397,7 +397,7 @@
           "data": [
             {
               "_id": "us_693a73206518477283a8d5ae31103252",
-              "email": "test@test.com",
+              "email": "test@example.com",
               "roles": {
                 "app_957b12f943d348faa61db7e18e088d0f": "BASIC"
               },

--- a/packages/server/specs/openapi.yaml
+++ b/packages/server/specs/openapi.yaml
@@ -256,7 +256,7 @@ components:
       value:
         data:
           _id: us_693a73206518477283a8d5ae31103252
-          email: test@test.com
+          email: test@example.com
           roles:
             app_957b12f943d348faa61db7e18e088d0f: BASIC
           builder:
@@ -278,7 +278,7 @@ components:
       value:
         data:
           - _id: us_693a73206518477283a8d5ae31103252
-            email: test@test.com
+            email: test@example.com
             roles:
               app_957b12f943d348faa61db7e18e088d0f: BASIC
             builder:

--- a/packages/server/specs/resources/user.ts
+++ b/packages/server/specs/resources/user.ts
@@ -3,7 +3,7 @@ import Resource from "./utils/Resource"
 
 const user = {
   _id: "us_693a73206518477283a8d5ae31103252",
-  email: "test@test.com",
+  email: "test@example.com",
   roles: {
     app_957b12f943d348faa61db7e18e088d0f: "BASIC",
   },

--- a/packages/server/src/api/routes/tests/appSync.spec.ts
+++ b/packages/server/src/api/routes/tests/appSync.spec.ts
@@ -12,7 +12,7 @@ describe("/api/applications/:appId/sync", () => {
     app = await config.init()
     // create some users which we will use throughout the tests
     await config.createUser({
-      email: "sync1@test.com",
+      email: "sync1@example.com",
       roles: {
         [app._id!]: roles.BUILTIN_ROLE_IDS.BASIC,
       },

--- a/packages/server/src/api/routes/tests/datasource.spec.ts
+++ b/packages/server/src/api/routes/tests/datasource.spec.ts
@@ -77,7 +77,7 @@ describe("/datasources", () => {
         const { datasource, query } = await config.dynamicVariableDatasource()
         // preview once to cache variables
         await preview(datasource, {
-          path: "www.test.com",
+          path: "www.example.com",
           queryString: "test={{ variable3 }}",
         })
         // check variables in cache

--- a/packages/server/src/api/routes/tests/static.spec.js
+++ b/packages/server/src/api/routes/tests/static.spec.js
@@ -80,7 +80,7 @@ describe("/static", () => {
           .set(config.defaultHeaders())
           .expect("Content-Type", /json/)
           .expect(200)
-        expect(res.body.signedUrl).toEqual("http://test.com/foo/bar")
+        expect(res.body.signedUrl).toEqual("http://example.com/foo/bar")
         expect(res.body.publicUrl).toEqual(
           `https://${bucket}.s3.eu-west-1.amazonaws.com/${key}`
         )

--- a/packages/server/src/api/routes/tests/utilities/index.ts
+++ b/packages/server/src/api/routes/tests/utilities/index.ts
@@ -9,7 +9,7 @@ function user() {
     _id: "user",
     _rev: "rev",
     createdAt: Date.now(),
-    email: "test@test.com",
+    email: "test@example.com",
     roles: {},
     tenantId: "default",
     status: "active",

--- a/packages/server/src/automations/tests/discord.spec.js
+++ b/packages/server/src/automations/tests/discord.spec.js
@@ -11,7 +11,7 @@ describe("test the outgoing webhook action", () => {
     await config.init()
     inputs = {
       username: "joe_bloggs",
-      url: "http://www.test.com",
+      url: "http://www.example.com",
     }
   })
 
@@ -19,7 +19,7 @@ describe("test the outgoing webhook action", () => {
 
   it("should be able to run the action", async () => {
     const res = await setup.runStep(setup.actions.discord.stepId, inputs)
-    expect(res.response.url).toEqual("http://www.test.com")
+    expect(res.response.url).toEqual("http://www.example.com")
     expect(res.response.method).toEqual("post")
     expect(res.success).toEqual(true)
   })

--- a/packages/server/src/automations/tests/make.spec.ts
+++ b/packages/server/src/automations/tests/make.spec.ts
@@ -12,9 +12,9 @@ describe("test the outgoing webhook action", () => {
   it("should be able to run the action", async () => {
     const res = await runStep(actions.integromat.stepId, {
       value1: "test",
-      url: "http://www.test.com",
+      url: "http://www.example.com",
     })
-    expect(res.response.url).toEqual("http://www.test.com")
+    expect(res.response.url).toEqual("http://www.example.com")
     expect(res.response.method).toEqual("post")
     expect(res.success).toEqual(true)
   })
@@ -30,9 +30,9 @@ describe("test the outgoing webhook action", () => {
       body: {
         value: payload,
       },
-      url: "http://www.test.com",
+      url: "http://www.example.com",
     })
-    expect(res.response.url).toEqual("http://www.test.com")
+    expect(res.response.url).toEqual("http://www.example.com")
     expect(res.response.method).toEqual("post")
     expect(res.response.body).toEqual(payload)
     expect(res.success).toEqual(true)
@@ -45,7 +45,7 @@ describe("test the outgoing webhook action", () => {
       body: {
         value: payload,
       },
-      url: "http://www.test.com",
+      url: "http://www.example.com",
     })
     expect(res.httpStatus).toEqual(400)
     expect(res.response).toEqual("Invalid payload JSON")

--- a/packages/server/src/automations/tests/outgoingWebhook.spec.js
+++ b/packages/server/src/automations/tests/outgoingWebhook.spec.js
@@ -11,7 +11,7 @@ describe("test the outgoing webhook action", () => {
     await config.init()
     inputs = {
       requestMethod: "POST",
-      url: "www.test.com",
+      url: "www.example.com",
       requestBody: JSON.stringify({
         a: 1,
       }),
@@ -26,7 +26,7 @@ describe("test the outgoing webhook action", () => {
       inputs
     )
     expect(res.success).toEqual(true)
-    expect(res.response.url).toEqual("http://www.test.com")
+    expect(res.response.url).toEqual("http://www.example.com")
     expect(res.response.method).toEqual("POST")
     expect(JSON.parse(res.response.body).a).toEqual(1)
   })

--- a/packages/server/src/automations/tests/sendSmtpEmail.spec.ts
+++ b/packages/server/src/automations/tests/sendSmtpEmail.spec.ts
@@ -33,7 +33,7 @@ describe("test the outgoing webhook action", () => {
     jest
       .spyOn(workerRequests, "sendSmtpEmail")
       .mockImplementationOnce(async () =>
-        generateResponse("user1@test.com", "admin@test.com")
+        generateResponse("user1@example.com", "admin@example.com")
       )
     const invite = {
       startTime: new Date(),
@@ -43,8 +43,8 @@ describe("test the outgoing webhook action", () => {
       url: "url",
     }
     inputs = {
-      to: "user1@test.com",
-      from: "admin@test.com",
+      to: "user1@example.com",
+      from: "admin@example.com",
       subject: "hello",
       contents: "testing",
       cc: "cc",
@@ -61,8 +61,8 @@ describe("test the outgoing webhook action", () => {
     expect(res.success).toEqual(true)
     expect(workerRequests.sendSmtpEmail).toHaveBeenCalledTimes(1)
     expect(workerRequests.sendSmtpEmail).toHaveBeenCalledWith({
-      to: "user1@test.com",
-      from: "admin@test.com",
+      to: "user1@example.com",
+      from: "admin@example.com",
       subject: "hello",
       contents: "testing",
       cc: "cc",

--- a/packages/server/src/automations/tests/zapier.spec.ts
+++ b/packages/server/src/automations/tests/zapier.spec.ts
@@ -12,9 +12,9 @@ describe("test the outgoing webhook action", () => {
   it("should be able to run the action", async () => {
     const res = await runStep(actions.zapier.stepId, {
       value1: "test",
-      url: "http://www.test.com",
+      url: "http://www.example.com",
     })
-    expect(res.response.url).toEqual("http://www.test.com")
+    expect(res.response.url).toEqual("http://www.example.com")
     expect(res.response.method).toEqual("post")
     expect(res.success).toEqual(true)
   })
@@ -30,9 +30,9 @@ describe("test the outgoing webhook action", () => {
       body: {
         value: payload,
       },
-      url: "http://www.test.com",
+      url: "http://www.example.com",
     })
-    expect(res.response.url).toEqual("http://www.test.com")
+    expect(res.response.url).toEqual("http://www.example.com")
     expect(res.response.method).toEqual("post")
     expect(res.response.body).toEqual(
       `{"platform":"budibase","value1":1,"value2":2,"value3":3,"value4":4,"value5":5,"name":"Adam","age":9}`
@@ -47,7 +47,7 @@ describe("test the outgoing webhook action", () => {
       body: {
         value: payload,
       },
-      url: "http://www.test.com",
+      url: "http://www.example.com",
     })
     expect(res.httpStatus).toEqual(400)
     expect(res.response).toEqual("Invalid payload JSON")

--- a/packages/server/src/migrations/tests/structures.ts
+++ b/packages/server/src/migrations/tests/structures.ts
@@ -46,7 +46,7 @@ export const smtp = (conf?: SMTPConfig): SMTPConfig => {
     config: {
       port: 12345,
       host: "smtptesthost.com",
-      from: "testfrom@test.com",
+      from: "testfrom@example.com",
       subject: "Hello!",
       secure: false,
       ...conf,

--- a/packages/server/src/sdk/app/applications/tests/sync.spec.ts
+++ b/packages/server/src/sdk/app/applications/tests/sync.spec.ts
@@ -94,8 +94,8 @@ function buildRoles() {
 }
 
 describe("app user/group sync", () => {
-  const groupEmail = "test2@test.com",
-    normalEmail = "test@test.com"
+  const groupEmail = "test2@example.com",
+    normalEmail = "test@example.com"
   async function checkEmail(
     email: string,
     opts?: { group?: boolean; notFound?: boolean }
@@ -131,7 +131,7 @@ describe("app user/group sync", () => {
   })
 
   it("should be able to handle builder users", async () => {
-    await createUser("test3@test.com", {}, true)
-    await checkEmail("test3@test.com")
+    await createUser("test3@example.com", {}, true)
+    await checkEmail("test3@example.com")
   })
 })

--- a/packages/server/src/sdk/app/rows/search/tests/utils.spec.ts
+++ b/packages/server/src/sdk/app/rows/search/tests/utils.spec.ts
@@ -76,7 +76,7 @@ describe.each([tableWithUserCol, tableWithUsersCol])(
     })
 
     it("shouldn't change any other input", () => {
-      const email = "test@test.com"
+      const email = "test@example.com"
       const params: SearchParams = {
         tableId,
         query: {

--- a/packages/string-templates/test/examples/table.json
+++ b/packages/string-templates/test/examples/table.json
@@ -2,7 +2,7 @@
   "user":{
     "_id":"ro_ta_users_us_b0bc7ba0ce304294accc1ced8165dd23",
     "_rev":"1-e9199d92e7286005a9c11c614fdbcc51",
-    "email":"test2@test.com",
+    "email":"test2@example.com",
     "status":"active",
     "roleId":"PUBLIC",
     "test-Created By_text":"",

--- a/packages/string-templates/test/helpers.spec.js
+++ b/packages/string-templates/test/helpers.spec.js
@@ -448,7 +448,7 @@ describe("Cover a few complex use cases", () => {
   it("getting a nice date from the user", async () => {
     const input = { text: `{{ date user.subscriptionDue "DD-MM" }}` }
     const context = JSON.parse(
-      `{"user":{"email":"test@test.com","roleId":"ADMIN","type":"user","tableId":"ta_users","subscriptionDue":"2021-01-12T12:00:00.000Z","_id":"ro_ta_users_us_test@test.com","_rev":"2-24cc794985eb54183ecb93e148563f3d"}}`
+      `{"user":{"email":"test@example.com","roleId":"ADMIN","type":"user","tableId":"ta_users","subscriptionDue":"2021-01-12T12:00:00.000Z","_id":"ro_ta_users_us_test@example.com","_rev":"2-24cc794985eb54183ecb93e148563f3d"}}`
     )
     const output = await processObject(input, context)
     expect(output.text).toBe("12-01")

--- a/packages/worker/scripts/load/heavyUse.js
+++ b/packages/worker/scripts/load/heavyUse.js
@@ -23,27 +23,27 @@ const USERS = [
     password: "test",
   },
   {
-    email: "loadtest2@test.com",
+    email: "loadtest2@example.com",
     password: "test",
   },
   {
-    email: "loadtest3@test.com",
+    email: "loadtest3@example.com",
     password: "test",
   },
   {
-    email: "loadtest4@test.com",
+    email: "loadtest4@example.com",
     password: "test",
   },
   {
-    email: "loadtest5@test.com",
+    email: "loadtest5@example.com",
     password: "test",
   },
   {
-    email: "loadtest6@test.com",
+    email: "loadtest6@example.com",
     password: "test",
   },
   {
-    email: "loadtest7@test.com",
+    email: "loadtest7@example.com",
     password: "test",
   },
 ]

--- a/packages/worker/src/api/routes/global/tests/auth.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/auth.spec.ts
@@ -80,7 +80,7 @@ describe("/api/global/auth", () => {
 
       it("should return 403 when user doesn't exist", async () => {
         const tenantId = config.tenantId!
-        const email = "invaliduser@test.com"
+        const email = "invaliduser@example.com"
         const password = "password"
 
         const response = await config.api.auth.login(

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -490,7 +490,7 @@ describe("/api/global/users", () => {
     it("should not be able to update email address", async () => {
       const email = structures.email()
       const user = await config.createUser(structures.users.user({ email }))
-      user.email = "new@test.com"
+      user.email = "new@example.com"
 
       const response = await config.api.users.saveUser(user, 400)
 

--- a/packages/worker/src/tests/api/email.ts
+++ b/packages/worker/src/tests/api/email.ts
@@ -10,7 +10,7 @@ export class EmailAPI extends TestAPI {
     return this.request
       .post(`/api/global/email/send`)
       .send({
-        email: "test@test.com",
+        email: "test@example.com",
         purpose,
         tenantId: this.config.getTenantId(),
         userId: this.config.user?._id!,

--- a/packages/worker/src/tests/structures/configs.ts
+++ b/packages/worker/src/tests/structures/configs.ts
@@ -45,7 +45,7 @@ export function smtp(conf?: any): SMTPConfig {
     config: {
       port: 12345,
       host: "smtptesthost.com",
-      from: "testfrom@test.com",
+      from: "testfrom@example.com",
       subject: "Hello!",
       secure: false,
       ...conf,
@@ -59,7 +59,7 @@ export function smtpEthereal(): SMTPConfig {
     config: {
       port: 587,
       host: "smtp.ethereal.email",
-      from: "testfrom@test.com",
+      from: "testfrom@example.com",
       secure: false,
       auth: {
         user: "wyatt.zulauf29@ethereal.email",


### PR DESCRIPTION
## Description

The domain `test.com` is privately owned and could, in theory, point anywhere. If we accidentally were to issue requests to it from our tests it's unclear what might happen. It's much safer to use `example.com`, which is owned by IANA and is part of the RFC2606 reserved domains.

This PR replaces all uses of `test.com` with `example.com` and introduces a lint rule to prevent future uses of `test.com`.

Related PR: https://github.com/Budibase/budibase-pro/pull/262
