### PR TITLE
FIX: Error when deleting selected rows that have attachment

### DIFF
--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -617,6 +617,7 @@ const getDeviceBindings = () => {
 /**
  * Gets all selected rows bindings for tables in the current asset.
  * TODO: remove in future because we don't need a separate store for this
+ * DEPRECATED
  */
 const getSelectedRowsBindings = asset => {
   let bindings = []
@@ -632,8 +633,8 @@ const getSelectedRowsBindings = asset => {
         runtimeBinding: `${safeState}.${makePropSafe(table._id)}.${makePropSafe(
           "selectedRows"
         )}`,
-        readableBinding: `${table._instanceName}.Selected rows`,
-        category: "Selected rows",
+        readableBinding: `${table._instanceName}.Selected Row IDs (DEPRECATED)`,
+        category: "Selected Row IDs (DEPRECATED)",
         icon: "ViewRow",
         display: { name: table._instanceName },
       }))
@@ -649,8 +650,8 @@ const getSelectedRowsBindings = asset => {
         runtimeBinding: `${safeState}.${makePropSafe(
           block._id + "-table"
         )}.${makePropSafe("selectedRows")}`,
-        readableBinding: `${block._instanceName}.Selected rows`,
-        category: "Selected rows",
+        readableBinding: `${block._instanceName}.Selected Row IDs (DEPRECATED)`,
+        category: "Selected Row IDs (DEPRECATED)",
         icon: "ViewRow",
         display: { name: block._instanceName },
       }))

--- a/packages/builder/src/builderStore/dataBinding.js
+++ b/packages/builder/src/builderStore/dataBinding.js
@@ -633,8 +633,8 @@ const getSelectedRowsBindings = asset => {
         runtimeBinding: `${safeState}.${makePropSafe(table._id)}.${makePropSafe(
           "selectedRows"
         )}`,
-        readableBinding: `${table._instanceName}.Selected Row IDs (DEPRECATED)`,
-        category: "Selected Row IDs (DEPRECATED)",
+        readableBinding: `${table._instanceName}.Selected Row IDs (deprecated)`,
+        category: "Selected Row IDs (deprecated)",
         icon: "ViewRow",
         display: { name: table._instanceName },
       }))
@@ -650,8 +650,8 @@ const getSelectedRowsBindings = asset => {
         runtimeBinding: `${safeState}.${makePropSafe(
           block._id + "-table"
         )}.${makePropSafe("selectedRows")}`,
-        readableBinding: `${block._instanceName}.Selected Row IDs (DEPRECATED)`,
-        category: "Selected Row IDs (DEPRECATED)",
+        readableBinding: `${block._instanceName}.Selected Row IDs (deprecated)`,
+        category: "Selected Row IDs (deprecated)",
         icon: "ViewRow",
         display: { name: block._instanceName },
       }))

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -4719,10 +4719,22 @@
         ]
       }
     ],
-    "context": {
-      "type": "schema",
-      "scope": "local"
-    }
+    "context": [
+      {
+        "type": "schema",
+        "scope": "local"
+      },
+      {
+        "type": "static",
+        "values": [
+          {
+            "label": "Selected Rows",
+            "key": "selectedRows",
+            "type": "array"
+          }
+        ]
+      }
+    ]
   },
   "daterangepicker": {
     "name": "Date Range",

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -5622,37 +5622,50 @@
         ]
       }
     ],
-    "context": {
-      "type": "static",
-      "suffix": "provider",
-      "values": [
-        {
-          "label": "Rows",
-          "key": "rows",
-          "type": "array"
-        },
-        {
-          "label": "Extra Info",
-          "key": "info",
-          "type": "string"
-        },
-        {
-          "label": "Rows Length",
-          "key": "rowsLength",
-          "type": "number"
-        },
-        {
-          "label": "Schema",
-          "key": "schema",
-          "type": "object"
-        },
-        {
-          "label": "Page Number",
-          "key": "pageNumber",
-          "type": "number"
-        }
-      ]
-    }
+    "context": [
+      {
+        "type": "static",
+        "suffix": "provider",
+        "values": [
+          {
+            "label": "Rows",
+            "key": "rows",
+            "type": "array"
+          },
+          {
+            "label": "Extra Info",
+            "key": "info",
+            "type": "string"
+          },
+          {
+            "label": "Rows Length",
+            "key": "rowsLength",
+            "type": "number"
+          },
+          {
+            "label": "Schema",
+            "key": "schema",
+            "type": "object"
+          },
+          {
+            "label": "Page Number",
+            "key": "pageNumber",
+            "type": "number"
+          }
+        ]
+      },
+      {
+        "type": "static",
+        "suffix": "table",
+        "values": [
+          {
+            "label": "Selected Rows",
+            "key": "selectedRows",
+            "type": "array"
+          }
+        ]
+      }
+    ]
   },
   "cardsblock": {
     "block": true,

--- a/packages/client/src/components/app/table/Table.svelte
+++ b/packages/client/src/components/app/table/Table.svelte
@@ -3,6 +3,7 @@
   import { Table } from "@budibase/bbui"
   import SlotRenderer from "./SlotRenderer.svelte"
   import { canBeSortColumn } from "@budibase/shared-core"
+  import Provider from "../../context/Provider.svelte"
 
   export let dataProvider
   export let columns
@@ -53,6 +54,11 @@
     if (rowIds.length) {
       selectedRows = selectedRows.filter(row => rowIds.includes(row._id))
     }
+  }
+
+  // Build our data context
+  $: dataContext = {
+    selectedRows,
   }
 
   const getFields = (
@@ -156,27 +162,29 @@
 </script>
 
 <div use:styleable={$component.styles} class={size}>
-  <Table
-    {data}
-    {schema}
-    {loading}
-    {rowCount}
-    {quiet}
-    {compact}
-    {customRenderers}
-    allowSelectRows={allowSelectRows && table}
-    bind:selectedRows
-    allowEditRows={false}
-    allowEditColumns={false}
-    showAutoColumns={true}
-    disableSorting
-    autoSortColumns={!columns?.length}
-    on:sort={onSort}
-    on:click={handleClick}
-    placeholderText={noRowsMessage || "No rows found"}
-  >
-    <slot />
-  </Table>
+  <Provider data={dataContext}>
+    <Table
+      {data}
+      {schema}
+      {loading}
+      {rowCount}
+      {quiet}
+      {compact}
+      {customRenderers}
+      allowSelectRows={allowSelectRows && table}
+      bind:selectedRows
+      allowEditRows={false}
+      allowEditColumns={false}
+      showAutoColumns={true}
+      disableSorting
+      autoSortColumns={!columns?.length}
+      on:sort={onSort}
+      on:click={handleClick}
+      placeholderText={noRowsMessage || "No rows found"}
+    >
+      <slot />
+    </Table>
+  </Provider>
   {#if allowSelectRows && selectedRows.length}
     <div class="row-count">
       {selectedRows.length} row{selectedRows.length === 1 ? "" : "s"} selected

--- a/packages/client/src/stores/rowSelection.js
+++ b/packages/client/src/stores/rowSelection.js
@@ -5,7 +5,7 @@ const createRowSelectionStore = () => {
 
   function updateSelection(componentId, tableId, selectedRows) {
     store.update(state => {
-      state[componentId] = { tableId: tableId, selectedRows: selectedRows }
+      state[componentId] = { tableId, selectedRows }
       return state
     })
   }


### PR DESCRIPTION
## Description
Table (and Table block) rows that have attachment columns can now be deleted via the new **Selected rows** binding which can be found under those settings.

The old binding has been updated to read *Selected Row IDs (DEPRECATED)* to indicate that it should no longer be used. It can be deleted in five minor versions time as per support policy.

## Addresses
- https://linear.app/budibase/issue/BUDI-7996/error-when-deleting-selected-rows-that-have-attachment-columns

## Screenshots

**BEFORE**
![old binding](https://github.com/Budibase/budibase/assets/101575380/308d650a-aca5-445d-99cb-f8bab0e3dfb8)

![old delete](https://github.com/Budibase/budibase/assets/101575380/4eabfce8-5a36-42cd-aed4-e4565174f110)

**AFTER**
![deprecated label](https://github.com/Budibase/budibase/assets/101575380/746cc813-9814-4874-8154-8487587ddaf1)
*The old binding will work as before, but the label has been updated to warn the user*

![new binding](https://github.com/Budibase/budibase/assets/101575380/0f71fd36-4836-466f-8ad6-297412e98654)
*New selected rows binding is now found under the Table block/Table bindings*

![full bindings](https://github.com/Budibase/budibase/assets/101575380/22f5ffa7-d484-445f-a716-1ce8b5586cab)
*Full row data is now provided, not just the _ids*

![delete rows](https://github.com/Budibase/budibase/assets/101575380/05e51738-3711-4bb4-85d6-12157df10763)
*Delete rows bug now fixed with the new binding*