### PR TITLE
[BUG] Don't drop views when updating its table configuration

### DIFF
--- a/packages/server/src/api/controllers/table/index.ts
+++ b/packages/server/src/api/controllers/table/index.ts
@@ -14,7 +14,6 @@ import { events } from "@budibase/backend-core"
 import {
   BulkImportRequest,
   BulkImportResponse,
-  DocumentType,
   FetchTablesResponse,
   MigrateRequest,
   MigrateResponse,
@@ -25,7 +24,6 @@ import {
   TableResponse,
   TableSourceType,
   UserCtx,
-  SEPARATOR,
 } from "@budibase/types"
 import sdk from "../../../sdk"
 import { jsonFromCsvString } from "../../../utilities/csv"

--- a/packages/server/src/api/controllers/table/index.ts
+++ b/packages/server/src/api/controllers/table/index.ts
@@ -75,9 +75,10 @@ export async function save(ctx: UserCtx<SaveTableRequest, SaveTableResponse>) {
   const table = ctx.request.body
   const isImport = table.rows
 
-  const savedTable = await pickApi({ table }).save(ctx)
+  let savedTable = await pickApi({ table }).save(ctx)
   if (!table._id) {
     await events.table.created(savedTable)
+    savedTable = sdk.tables.enrichViewSchemas(savedTable)
   } else {
     await events.table.updated(savedTable)
   }

--- a/packages/server/src/api/controllers/table/internal.ts
+++ b/packages/server/src/api/controllers/table/internal.ts
@@ -18,12 +18,16 @@ export async function save(ctx: UserCtx<SaveTableRequest, SaveTableResponse>) {
     _rename?: RenameColumn
   } = {
     _id: generateTableID(),
-    views: {},
     ...rest,
     // Ensure these fields are populated, even if not sent in the request
     type: rest.type || "table",
     sourceType: rest.sourceType || TableSourceType.INTERNAL,
   }
+
+  if (!tableToSave.views) {
+    tableToSave.views = {}
+  }
+
   const renaming = tableToSave._rename
   delete tableToSave._rename
 

--- a/packages/server/src/api/controllers/table/internal.ts
+++ b/packages/server/src/api/controllers/table/internal.ts
@@ -18,10 +18,11 @@ export async function save(ctx: UserCtx<SaveTableRequest, SaveTableResponse>) {
     _rename?: RenameColumn
   } = {
     _id: generateTableID(),
-    ...rest,
-    type: "table",
-    sourceType: TableSourceType.INTERNAL,
     views: {},
+    ...rest,
+    // Ensure these fields are populated, even if not sent in the request
+    type: rest.type || "table",
+    sourceType: rest.sourceType || TableSourceType.INTERNAL,
   }
   const renaming = tableToSave._rename
   delete tableToSave._rename

--- a/packages/server/src/api/routes/tests/table.spec.ts
+++ b/packages/server/src/api/routes/tests/table.spec.ts
@@ -21,7 +21,7 @@ import * as uuid from "uuid"
 
 import tk from "timekeeper"
 import { mocks } from "@budibase/backend-core/tests"
-import { TableToBuild } from "src/tests/utilities/TestConfiguration"
+import { TableToBuild } from "../../../tests/utilities/TestConfiguration"
 
 tk.freeze(mocks.date.MOCK_DATE)
 

--- a/packages/server/src/api/routes/tests/table.spec.ts
+++ b/packages/server/src/api/routes/tests/table.spec.ts
@@ -348,6 +348,7 @@ describe("/tables", () => {
 
   describe("fetch", () => {
     let testTable: Table
+    const enrichViewSchemasMock = jest.spyOn(sdk.tables, "enrichViewSchemas")
 
     beforeEach(async () => {
       testTable = await config.createTable(testTable)
@@ -355,6 +356,10 @@ describe("/tables", () => {
 
     afterEach(() => {
       delete testTable._rev
+    })
+
+    afterAll(() => {
+      enrichViewSchemasMock.mockRestore()
     })
 
     it("returns all the tables for that instance in the response body", async () => {
@@ -405,7 +410,7 @@ describe("/tables", () => {
 
     it("should enrich the view schemas for viewsV2", async () => {
       const tableId = config.table!._id!
-      jest.spyOn(sdk.tables, "enrichViewSchemas").mockImplementation(t => ({
+      enrichViewSchemasMock.mockImplementation(t => ({
         ...t,
         views: {
           view1: {
@@ -413,7 +418,7 @@ describe("/tables", () => {
             name: "view1",
             schema: {},
             id: "new_view_id",
-            tableId,
+            tableId: t._id!,
           },
         },
       }))
@@ -480,11 +485,7 @@ describe("/tables", () => {
     let testTable: Table
 
     beforeEach(async () => {
-      testTable = await config.createTable(testTable)
-    })
-
-    afterEach(() => {
-      delete testTable._rev
+      testTable = await config.createTable()
     })
 
     it("returns a success response when a table is deleted.", async () => {

--- a/packages/server/src/api/routes/tests/table.spec.ts
+++ b/packages/server/src/api/routes/tests/table.spec.ts
@@ -5,6 +5,7 @@ import {
   FieldType,
   INTERNAL_TABLE_SOURCE_ID,
   InternalTable,
+  NumberFieldMetadata,
   RelationshipType,
   Row,
   SaveTableRequest,
@@ -83,7 +84,7 @@ describe("/tables", () => {
           },
         },
         views: {
-          view1: {
+          "table view": {
             id: "viewId",
             version: 2,
             name: "table view",
@@ -96,9 +97,29 @@ describe("/tables", () => {
       const expected: Table = {
         ...tableData,
         type: "table",
+        views: {
+          "table view": {
+            ...tableData.views!["table view"],
+            schema: {
+              autoId: {
+                autocolumn: true,
+                constraints: {
+                  presence: false,
+                  type: "number",
+                },
+                name: "id",
+                type: FieldType.NUMBER,
+                subtype: AutoFieldSubType.AUTO_ID,
+                visible: false,
+              } as NumberFieldMetadata,
+            },
+          },
+        },
         sourceType: TableSourceType.INTERNAL,
         sourceId: expect.any(String),
         _rev: expect.stringMatching(/^1-.+/),
+        _id: expect.any(String),
+        createdAt: mocks.date.MOCK_DATE.toISOString(),
         updatedAt: mocks.date.MOCK_DATE.toISOString(),
       }
       expect(testTable).toEqual(expected)

--- a/packages/server/src/sdk/app/tables/internal/index.ts
+++ b/packages/server/src/sdk/app/tables/internal/index.ts
@@ -75,11 +75,13 @@ export async function save(
     if (!tableView) continue
 
     if (viewsSdk.isV2(tableView)) {
-      table.views[view] = viewsSdk.syncSchema(
-        oldTable!.views![view] as ViewV2,
-        table.schema,
-        renaming
-      )
+      if (oldTable?.views && oldTable.views[view]) {
+        table.views[view] = viewsSdk.syncSchema(
+          oldTable.views[view] as ViewV2,
+          table.schema,
+          renaming
+        )
+      }
       continue
     }
 

--- a/packages/server/src/tests/utilities/TestConfiguration.ts
+++ b/packages/server/src/tests/utilities/TestConfiguration.ts
@@ -84,7 +84,7 @@ type DefaultUserValues = {
   csrfToken: string
 }
 
-interface TableToBuild extends Omit<Table, "sourceId" | "sourceType"> {
+export interface TableToBuild extends Omit<Table, "sourceId" | "sourceType"> {
   sourceId?: string
   sourceType?: TableSourceType
 }

--- a/packages/server/src/tests/utilities/TestConfiguration.ts
+++ b/packages/server/src/tests/utilities/TestConfiguration.ts
@@ -911,3 +911,5 @@ export default class TestConfiguration {
     return await this._req(config, null, layoutController.save)
   }
 }
+
+module.exports = TestConfiguration

--- a/packages/server/src/tests/utilities/TestConfiguration.ts
+++ b/packages/server/src/tests/utilities/TestConfiguration.ts
@@ -89,7 +89,7 @@ export interface TableToBuild extends Omit<Table, "sourceId" | "sourceType"> {
   sourceType?: TableSourceType
 }
 
-class TestConfiguration {
+export default class TestConfiguration {
   server: any
   request: supertest.SuperTest<supertest.Test> | undefined
   started: boolean
@@ -911,5 +911,3 @@ class TestConfiguration {
     return await this._req(config, null, layoutController.save)
   }
 }
-
-export = TestConfiguration


### PR DESCRIPTION
## Description
We recently introduced a bug that, on table update, its views are dropped. This PR fixes it and adds tests around it

## Addresses
- [BUDI-7784 - [BUG] When adding a new column to a table with views, those views are deleted](https://linear.app/budibase/issue/BUDI-7784/[bug]-when-adding-a-new-column-to-a-table-with-views-those-views-are)