### PR TITLE
Init jsrunners on threads

### DIFF
--- a/packages/server/src/threads/utils.ts
+++ b/packages/server/src/threads/utils.ts
@@ -2,6 +2,7 @@ import { QueryVariable } from "./definitions"
 import env from "../environment"
 import * as db from "../db"
 import { redis, db as dbCore } from "@budibase/backend-core"
+import * as jsRunner from "../jsRunner"
 
 const VARIABLE_TTL_SECONDS = 3600
 let client: any
@@ -29,7 +30,9 @@ export function threadSetup() {
     console.debug(`[${env.FORKED_PROCESS_NAME}] thread setup skipped`)
     return
   }
+
   console.debug(`[${env.FORKED_PROCESS_NAME}] thread setup running`)
+  jsRunner.init()
   db.init()
 }
 

--- a/packages/string-templates/src/index.js
+++ b/packages/string-templates/src/index.js
@@ -1,3 +1,4 @@
+const vm = require("vm")
 const handlebars = require("handlebars")
 const { registerAll, registerMinimum } = require("./helpers/index")
 const processors = require("./processors")
@@ -402,3 +403,19 @@ const errors = require("./errors")
 module.exports.JsErrorTimeout = errors.JsErrorTimeout
 
 module.exports.helpersToRemoveForJs = helpersToRemoveForJs
+
+if (process && !process.env.NO_JS) {
+  /**
+   * Use polyfilled vm to run JS scripts in a browser Env
+   */
+  javascript.setJSRunner((js, context) => {
+    context = {
+      ...context,
+      alert: undefined,
+      setInterval: undefined,
+      setTimeout: undefined,
+    }
+    vm.createContext(context)
+    return vm.runInNewContext(js, context, { timeout: 1000 })
+  })
+}

--- a/packages/string-templates/src/index.mjs
+++ b/packages/string-templates/src/index.mjs
@@ -1,4 +1,3 @@
-import vm from "vm"
 import templates from "./index.js"
 
 /**
@@ -23,21 +22,5 @@ export const setJSRunner = templates.setJSRunner
 export const setOnErrorLog = templates.setOnErrorLog
 export const FIND_ANY_HBS_REGEX = templates.FIND_ANY_HBS_REGEX
 export const helpersToRemoveForJs = templates.helpersToRemoveForJs
-
-if (process && !process.env.NO_JS) {
-  /**
-   * Use polyfilled vm to run JS scripts in a browser Env
-   */
-  setJSRunner((js, context) => {
-    context = {
-      ...context,
-      alert: undefined,
-      setInterval: undefined,
-      setTimeout: undefined,
-    }
-    vm.createContext(context)
-    return vm.runInNewContext(js, context, { timeout: 1000 })
-  })
-}
 
 export * from "./errors.js"


### PR DESCRIPTION
## Description
Fix js runners on threads.
We recently removed the cjs entry point from string-templates that was initialising the [default jsRunner](https://github.com/Budibase/budibase/pull/12994/files#diff-76dacfd78f387fc3aa342b9af9e7e66e364fa05e53769471272e86a36e6e9d58). This had some impacts on places where it was not strictly initialised (like in our worker threads) so it was failings. We are adding back the default jsRunner and initialising the worker thread properly.

| Before | After |
|--------|--------|
| ![image](https://github.com/Budibase/budibase/assets/15987277/3382aac2-8e07-47ce-8fc8-b94ec6dac370) | ![image](https://github.com/Budibase/budibase/assets/15987277/bddb0d22-113c-4525-8e5d-39553dbef18b) | 




