### PR TITLE
Only add repeater id to Card block URL if needed

### DIFF
--- a/packages/client/src/components/app/blocks/CardsBlock.svelte
+++ b/packages/client/src/components/app/blocks/CardsBlock.svelte
@@ -69,7 +69,10 @@
     }
     const col = linkColumn || "_id"
     const split = url.split("/:")
-    return `${split[0]}/{{ ${safe(repeaterId)}.${safe(col)} }}`
+    if (split.length > 1) {
+      return `${split[0]}/{{ ${safe(repeaterId)}.${safe(col)} }}`
+    }
+    return url
   }
 
   // Load the datasource schema so we can determine column types


### PR DESCRIPTION
## Description
Allows non-id URLs to be used in card block link titles

## Addresses
- https://github.com/Budibase/budibase/issues/10150
