### PR TITLE
Enable threading in development for queries and automations

### DIFF
--- a/packages/server/scripts/dev/manage.js
+++ b/packages/server/scripts/dev/manage.js
@@ -38,7 +38,6 @@ async function init() {
     SELF_HOSTED: "1",
     DISABLE_ACCOUNT_PORTAL: "1",
     MULTI_TENANCY: "",
-    DISABLE_THREADING: "1",
     SERVICE: "app-service",
     DEPLOYMENT_ENVIRONMENT: "development",
     BB_ADMIN_USER_EMAIL: "",

--- a/packages/server/src/environment.ts
+++ b/packages/server/src/environment.ts
@@ -100,11 +100,6 @@ const environment = {
   LOG_JS_ERRORS: process.env.LOG_JS_ERRORS,
 }
 
-// threading can cause memory issues with node-ts in development
-if (coreEnv.isDev() && environment.DISABLE_THREADING == null) {
-  environment._set("DISABLE_THREADING", "1")
-}
-
 // clean up any environment variable edge cases
 for (let [key, value] of Object.entries(environment)) {
   // handle the edge case of "0" to disable an environment variable


### PR DESCRIPTION
## Description
As title, in production we run automations and queries in threads so that we can manage timeouts and memory usage of these. In development we previously didn't run them as it caused memory issues in older node versions with `node-ts` - however this isn't a problem with esbuild.

We had an issue recently where JS wasn't working as expected in threaded environments, this could have been avoided by making sure that development works the same way that production works.
