### PR TITLE
Fix nested button actions

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -270,6 +270,7 @@
           {
             "type": "buttonConfiguration",
             "key": "buttons",
+            "nested": true,
             "defaultValue": [
               {
                 "type": "cta",


### PR DESCRIPTION
## Description
This PR adds the nested flag to the button group component settings to prevent early enrichment of actions.

Alternative solution to https://github.com/Budibase/budibase/pull/12989.

## Addresses
- https://linear.app/budibase/issue/BUDI-7964/save-row-action-payload-not-useable-within-a-button-group
- https://github.com/Budibase/budibase/issues/12965