### PR TITLE
Quick fix for builder store initialise on app creation

### DIFF
--- a/packages/builder/src/stores/builder/index.js
+++ b/packages/builder/src/stores/builder/index.js
@@ -92,12 +92,13 @@ const resetBuilderHistory = () => {
 
 export const initialise = async pkg => {
   const { application } = pkg
+  // must be first operation to make sure subsequent requests have correct app ID
+  appStore.syncAppPackage(pkg)
   await Promise.all([
     appStore.syncAppRoutes(),
     componentStore.refreshDefinitions(application?.appId),
   ])
   builderStore.init(application)
-  appStore.syncAppPackage(pkg)
   navigationStore.syncAppNavigation(application?.navigation)
   themeStore.syncAppTheme(application)
   screenStore.syncAppScreens(pkg)


### PR DESCRIPTION
## Description
Fixing an issue where app routing information was requested before the app store was fully brought online, meaning that routing information wasn't always successfully retrieved.