### PR TITLE
Remove CouchDB pull policy and update Budi CLI to handle couchdb service

### DIFF
--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -98,7 +98,6 @@ services:
   couchdb-service:
     restart: unless-stopped
     image: budibase/couchdb
-    pull_policy: always
     environment:
       - COUCHDB_PASSWORD=${COUCH_DB_PASSWORD}
       - COUCHDB_USER=${COUCH_DB_USER}

--- a/packages/cli/src/hosting/update.ts
+++ b/packages/cli/src/hosting/update.ts
@@ -13,7 +13,12 @@ import { COMPOSE_PATH } from "./makeFiles"
 import { info, success } from "../utils"
 import { start } from "./start"
 
-const BB_COMPOSE_SERVICES = ["app-service", "worker-service", "proxy-service"]
+const BB_COMPOSE_SERVICES = [
+  "app-service",
+  "worker-service",
+  "proxy-service",
+  "couchdb-service",
+]
 const BB_SINGLE_SERVICE = ["budibase"]
 
 export async function update() {


### PR DESCRIPTION
## Description
Updating CouchDB with the Budi CLI, making sure the service is always up to date, as well as removing pull policy.