### PR TITLE
Make a better MySQL healthcheck.

### DIFF
--- a/packages/server/src/integrations/tests/utils/mongodb.ts
+++ b/packages/server/src/integrations/tests/utils/mongodb.ts
@@ -11,7 +11,9 @@ export async function start(): Promise<StartedTestContainer> {
       MONGO_INITDB_ROOT_PASSWORD: "password",
     })
     .withWaitStrategy(
-      Wait.forSuccessfulCommand(`mongosh --eval "db.version()"`)
+      Wait.forSuccessfulCommand(
+        `mongosh --eval "db.version()"`
+      ).withStartupTimeout(10000)
     )
     .start()
 }

--- a/packages/server/src/integrations/tests/utils/mysql.ts
+++ b/packages/server/src/integrations/tests/utils/mysql.ts
@@ -1,9 +1,6 @@
 import { Datasource, SourceName } from "@budibase/types"
 import { GenericContainer, Wait, StartedTestContainer } from "testcontainers"
-import {
-  AbstractWaitStrategy,
-  WaitStrategy,
-} from "testcontainers/build/wait-strategies/wait-strategy"
+import { AbstractWaitStrategy } from "testcontainers/build/wait-strategies/wait-strategy"
 
 let container: StartedTestContainer | undefined
 

--- a/packages/server/src/integrations/tests/utils/mysql.ts
+++ b/packages/server/src/integrations/tests/utils/mysql.ts
@@ -1,26 +1,37 @@
 import { Datasource, SourceName } from "@budibase/types"
 import { GenericContainer, Wait, StartedTestContainer } from "testcontainers"
+import {
+  AbstractWaitStrategy,
+  WaitStrategy,
+} from "testcontainers/build/wait-strategies/wait-strategy"
 
 let container: StartedTestContainer | undefined
+
+class MySQLWaitStrategy extends AbstractWaitStrategy {
+  async waitUntilReady(container: any, boundPorts: any, startTime?: Date) {
+    // Because MySQL first starts itself up, runs an init script, then restarts,
+    // it's possible for the mysqladmin ping to succeed early and then tests to
+    // run against a MySQL that's mid-restart and fail. To get around this, we
+    // wait for logs and then do a ping check.
+
+    const logs = Wait.forLogMessage(
+      "/usr/sbin/mysqld: ready for connections",
+      2
+    )
+    await logs.waitUntilReady(container, boundPorts, startTime)
+
+    const command = Wait.forSuccessfulCommand(
+      `mysqladmin ping -h localhost -P 3306 -u root -ppassword`
+    )
+    await command.waitUntilReady(container)
+  }
+}
 
 export async function start(): Promise<StartedTestContainer> {
   return await new GenericContainer("mysql:8.3")
     .withExposedPorts(3306)
     .withEnvironment({ MYSQL_ROOT_PASSWORD: "password" })
-    .withWaitStrategy(
-      Wait.forSuccessfulCommand(
-        // Because MySQL first starts itself up, runs an init script, then restarts,
-        // it's possible for the mysqladmin ping to succeed early and then tests to
-        // run against a MySQL that's mid-restart and fail. To avoid this, we run
-        // the ping command three times with a small delay between each.
-        `
-          mysqladmin ping -h localhost -P 3306 -u root -ppassword && sleep 1 &&
-          mysqladmin ping -h localhost -P 3306 -u root -ppassword && sleep 1 &&
-          mysqladmin ping -h localhost -P 3306 -u root -ppassword && sleep 1 &&
-          mysqladmin ping -h localhost -P 3306 -u root -ppassword
-        `
-      )
-    )
+    .withWaitStrategy(new MySQLWaitStrategy().withStartupTimeout(10000))
     .start()
 }
 

--- a/packages/server/src/integrations/tests/utils/postgres.ts
+++ b/packages/server/src/integrations/tests/utils/postgres.ts
@@ -8,7 +8,9 @@ export async function start(): Promise<StartedTestContainer> {
     .withExposedPorts(5432)
     .withEnvironment({ POSTGRES_PASSWORD: "password" })
     .withWaitStrategy(
-      Wait.forSuccessfulCommand("pg_isready -h localhost -p 5432")
+      Wait.forSuccessfulCommand(
+        "pg_isready -h localhost -p 5432"
+      ).withStartupTimeout(10000)
     )
     .start()
 }


### PR DESCRIPTION
## Description

We've had test failures lately caused by the MySQL `testcontainer`. It's weird in that the MySQL process is brought up, then some init scripts run, and then the process restarts. Because of this, doing a `mysql ping` will actually pass before the container is truly ready. I put a hack in place to try and get around this, making it have to pass 4 pings with a 1 second gap between each ping, but experience shows this isn't robust.

The new healthcheck does 2 things:

1. Checks for the log message: `/usr/sbin/mysqld: ready for connections` twice.
2. Checks `mysql ping`.

This should be more robust, with the log message check allowing us to skip over the first boot and the `mysql ping` allowing us to be certain the process is ready to accept connections on the second boot.

I've also reinstated the `.withStartupTimeout(10000)` calls on the `testcontainer`s, because the error message on the generic Jest timeout isn't all that helpful in narrowing down the problem.