### PR TITLE
Fix re-used context in JS runner.

### DIFF
--- a/packages/server/src/api/controllers/script.ts
+++ b/packages/server/src/api/controllers/script.ts
@@ -3,9 +3,10 @@ import { IsolatedVM } from "../../jsRunner/vm"
 
 export async function execute(ctx: Ctx) {
   const { script, context } = ctx.request.body
-  const runner = new IsolatedVM().withContext(context)
-
-  const result = runner.execute(`(function(){\n${script}\n})();`)
+  const vm = new IsolatedVM()
+  const result = vm.withContext(context, () =>
+    vm.execute(`(function(){\n${script}\n})();`)
+  )
   ctx.body = result
 }
 

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -2135,5 +2135,48 @@ describe.each([
         }
       )
     })
+
+    it("should not carry over context between formulas", async () => {
+      const js = Buffer.from(`return $("[text]");`).toString("base64")
+      const table = await config.createTable({
+        name: "table",
+        type: "table",
+        schema: {
+          text: {
+            name: "text",
+            type: FieldType.STRING,
+          },
+          formula: {
+            name: "formula",
+            type: FieldType.FORMULA,
+            formula: `{{ js "${js}"}}`,
+            formulaType: FormulaType.DYNAMIC,
+          },
+        },
+      })
+
+      for (let i = 0; i < 10; i++) {
+        await config.api.row.save(table._id!, { text: `foo${i}` })
+      }
+
+      const { rows } = await config.api.row.search(table._id!)
+      expect(rows).toHaveLength(10)
+
+      const formulaValues = rows.map(r => r.formula)
+      expect(formulaValues).toEqual(
+        expect.arrayContaining([
+          "foo0",
+          "foo1",
+          "foo2",
+          "foo3",
+          "foo4",
+          "foo5",
+          "foo6",
+          "foo7",
+          "foo8",
+          "foo9",
+        ])
+      )
+    })
   })
 })

--- a/packages/server/src/jsRunner/index.ts
+++ b/packages/server/src/jsRunner/index.ts
@@ -24,13 +24,11 @@ export function init() {
         const bbCtx = context.getCurrentContext()!
 
         if (!bbCtx.vm) {
-          const vm = new IsolatedVM({
+          bbCtx.vm = new IsolatedVM({
             memoryLimit: env.JS_RUNNER_MEMORY_LIMIT,
             invocationTimeout: env.JS_PER_INVOCATION_TIMEOUT_MS,
             isolateAccumulatedTimeout: env.JS_PER_REQUEST_TIMEOUT_MS,
           }).withHelpers()
-
-          bbCtx.vm = vm
         }
         const { helpers, ...rest } = ctx
         return bbCtx.vm.withContext(rest, () => bbCtx.vm!.execute(js))

--- a/packages/server/src/jsRunner/vm/builtin-vm.ts
+++ b/packages/server/src/jsRunner/vm/builtin-vm.ts
@@ -15,6 +15,17 @@ export class BuiltInVM implements VM {
     this.span = span
   }
 
+  withContext<T>(context: Record<string, any>, executeWithContext: () => T): T {
+    this.ctx = vm.createContext(context)
+    try {
+      return executeWithContext()
+    } finally {
+      for (const key in context) {
+        delete this.ctx[key]
+      }
+    }
+  }
+
   execute(code: string) {
     const perRequestLimit = env.JS_PER_REQUEST_TIMEOUT_MS
     let track: TrackerFn = f => f()

--- a/packages/server/src/jsRunner/vm/isolated-vm.ts
+++ b/packages/server/src/jsRunner/vm/isolated-vm.ts
@@ -97,11 +97,11 @@ export class IsolatedVM implements VM {
     return this
   }
 
-  withContext<T>(context: Record<string, any>, f: () => T) {
+  withContext<T>(context: Record<string, any>, executeWithContext: () => T) {
     this.addToContext(context)
 
     try {
-      return f()
+      return executeWithContext()
     } finally {
       this.removeFromContext(Object.keys(context))
     }

--- a/packages/server/src/jsRunner/vm/isolated-vm.ts
+++ b/packages/server/src/jsRunner/vm/isolated-vm.ts
@@ -97,10 +97,14 @@ export class IsolatedVM implements VM {
     return this
   }
 
-  withContext(context: Record<string, any>) {
+  withContext<T>(context: Record<string, any>, f: () => T) {
     this.addToContext(context)
 
-    return this
+    try {
+      return f()
+    } finally {
+      this.removeFromContext(Object.keys(context))
+    }
   }
 
   withParsingBson(data: any) {
@@ -221,6 +225,12 @@ export class IsolatedVM implements VM {
           ? value
           : new ivm.ExternalCopy(value).copyInto({ release: true })
       )
+    }
+  }
+
+  private removeFromContext(keys: string[]) {
+    for (let key of keys) {
+      this.jail.deleteSync(key)
     }
   }
 

--- a/packages/server/src/jsRunner/vm/vm2.ts
+++ b/packages/server/src/jsRunner/vm/vm2.ts
@@ -16,10 +16,10 @@ export class VM2 implements VM {
     this.vm.setGlobal("results", this.results)
   }
 
-  withContext<T>(context: Record<string, any>, fn: () => T): T {
+  withContext<T>(context: Record<string, any>, executeWithContext: () => T): T {
     this.vm.setGlobals(context)
     try {
-      return fn()
+      return executeWithContext()
     } finally {
       for (const key in context) {
         this.vm.setGlobal(key, undefined)

--- a/packages/server/src/jsRunner/vm/vm2.ts
+++ b/packages/server/src/jsRunner/vm/vm2.ts
@@ -7,14 +7,24 @@ export class VM2 implements VM {
   vm: vm2.VM
   results: { out: string }
 
-  constructor(context: any) {
+  constructor() {
     this.vm = new vm2.VM({
       timeout: JS_TIMEOUT_MS,
     })
     this.results = { out: "" }
-    this.vm.setGlobals(context)
     this.vm.setGlobal("fetch", fetch)
     this.vm.setGlobal("results", this.results)
+  }
+
+  withContext<T>(context: Record<string, any>, fn: () => T): T {
+    this.vm.setGlobals(context)
+    try {
+      return fn()
+    } finally {
+      for (const key in context) {
+        this.vm.setGlobal(key, undefined)
+      }
+    }
   }
 
   execute(script: string) {

--- a/packages/types/src/sdk/vm.ts
+++ b/packages/types/src/sdk/vm.ts
@@ -1,3 +1,4 @@
 export interface VM {
   execute(code: string): any
+  withContext<T>(context: Record<string, any>, fn: () => T): T
 }

--- a/packages/types/src/sdk/vm.ts
+++ b/packages/types/src/sdk/vm.ts
@@ -1,4 +1,4 @@
 export interface VM {
   execute(code: string): any
-  withContext<T>(context: Record<string, any>, fn: () => T): T
+  withContext<T>(context: Record<string, any>, executeWithContext: () => T): T
 }


### PR DESCRIPTION
## Description
We have an issue with context not correctly being passed into every instance of the JS runner, this should resolve the problem by making sure to add context every time and cleanup after completion.