### PR TITLE
Fix flaky table test.

### DIFF
--- a/packages/server/src/api/routes/tests/table.spec.ts
+++ b/packages/server/src/api/routes/tests/table.spec.ts
@@ -368,10 +368,12 @@ describe("/tables", () => {
         .set(config.defaultHeaders())
         .expect("Content-Type", /json/)
         .expect(200)
-      const fetchedTable = res.body[0]
-      expect(fetchedTable.name).toEqual(testTable.name)
-      expect(fetchedTable.type).toEqual("table")
-      expect(fetchedTable.sourceType).toEqual("internal")
+
+      const table = res.body.find((t: Table) => t._id === testTable._id)
+      expect(table).toBeDefined()
+      expect(table.name).toEqual(testTable.name)
+      expect(table.type).toEqual("table")
+      expect(table.sourceType).toEqual("internal")
     })
 
     it("should apply authorization to endpoint", async () => {


### PR DESCRIPTION
## Description

This test was expecting the result of `/api/tables` to contain a specific table as the first result. This isn't guaranteed due to the parallel nature of our tests. I've modified it to search the results for the table in question.

## Addresses
- https://linear.app/budibase/issue/BUDI-8027/solve-flaky-test-issues

