### PR TITLE
Use couch 3.3.3 for single image

### DIFF
--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -38,7 +38,7 @@ COPY packages/worker/pm2.config.js packages/worker/pm2.config.js
 COPY packages/string-templates packages/string-templates
 
 
-FROM budibase/couchdb as runner
+FROM budibase/couchdb:v3.3.3 as runner
 ARG TARGETARCH
 ENV TARGETARCH $TARGETARCH
 #TARGETBUILD can be set to single (for single docker image) or aas (for azure app service)


### PR DESCRIPTION
## Description
Updating the image to use the couchdb image 3.3.3. We don't want to update the latest tag of this image yet until we study the real implications on the couchdb side