### PR TITLE
Disable string-templates JS runner if not set in backend-services

### DIFF
--- a/packages/string-templates/src/helpers/javascript.js
+++ b/packages/string-templates/src/helpers/javascript.js
@@ -1,4 +1,4 @@
-const { atob } = require("../utilities")
+const { atob, isBackendService, isJSAllowed } = require("../utilities")
 const cloneDeep = require("lodash.clonedeep")
 const { LITERAL_MARKER } = require("../helpers/constants")
 const { getJsHelperList } = require("./list")
@@ -7,6 +7,9 @@ const { getJsHelperList } = require("./list")
 // This setter is used in the entrypoint (either index.js or index.mjs).
 let runJS
 module.exports.setJSRunner = runner => (runJS = runner)
+module.exports.removeJSRunner = () => {
+  runJS = undefined
+}
 
 let onErrorLog
 module.exports.setOnErrorLog = delegate => (onErrorLog = delegate)
@@ -39,7 +42,7 @@ const getContextValue = (path, context) => {
 
 // Evaluates JS code against a certain context
 module.exports.processJS = (handlebars, context) => {
-  if (process && process.env.NO_JS) {
+  if (!isJSAllowed() || (isBackendService() && !runJS)) {
     throw new Error("JS disabled in environment.")
   }
   try {

--- a/packages/string-templates/src/index.js
+++ b/packages/string-templates/src/index.js
@@ -2,7 +2,7 @@ const vm = require("vm")
 const handlebars = require("handlebars")
 const { registerAll, registerMinimum } = require("./helpers/index")
 const processors = require("./processors")
-const { atob, btoa, isBackendService, isJSAllowed } = require("./utilities")
+const { atob, btoa, isBackendService } = require("./utilities")
 const manifest = require("../manifest.json")
 const {
   FIND_HBS_REGEX,

--- a/packages/string-templates/src/utilities.js
+++ b/packages/string-templates/src/utilities.js
@@ -4,6 +4,14 @@ module.exports.FIND_HBS_REGEX = /{{([^{].*?)}}/g
 module.exports.FIND_ANY_HBS_REGEX = /{?{{([^{].*?)}}}?/g
 module.exports.FIND_TRIPLE_HBS_REGEX = /{{{([^{].*?)}}}/g
 
+module.exports.isBackendService = () => {
+  return typeof window === "undefined"
+}
+
+module.exports.isJSAllowed = () => {
+  return process && !process.env.NO_JS
+}
+
 // originally this could be done with a single regex using look behinds
 // but safari does not support this feature
 // original regex: /(?<!{){{[^{}]+}}(?!})/g

--- a/packages/string-templates/test/vm.spec.js
+++ b/packages/string-templates/test/vm.spec.js
@@ -1,0 +1,27 @@
+jest.mock("../src/utilities", () => {
+  const utilities = jest.requireActual("../src/utilities")
+  return {
+    ...utilities,
+    isBackendService: jest.fn().mockReturnValue(true),
+  }
+})
+const { defaultJSSetup, processStringSync, encodeJSBinding } = require("../src")
+const { isBackendService } = require("../src/utilities")
+const mockedBackendService = jest.mocked(isBackendService)
+
+const binding = encodeJSBinding("return 1")
+describe("confirm VM is available when expected and when not", () => {
+  it("shouldn't have JS available in a backend service by default", () => {
+    defaultJSSetup()
+    const result = processStringSync(binding, {})
+    // shouldn't process at all
+    expect(result).toBe(binding)
+  })
+
+  it("should have JS available in frontend environments", () => {
+    mockedBackendService.mockReturnValue(false)
+    defaultJSSetup()
+    const result = processStringSync(binding, {})
+    expect(result).toBe(1)
+  })
+})


### PR DESCRIPTION
## Description
Disabling VM by default in string-templates, backend services *MUST* set their JS runner specifically rather than assuming the VM library by default.

Test case confirms that backend services will not have VM configured, and makes sure VM is still configured in frontend to maintain the polyfill required.