### PR TITLE
Fix flaky user test

### DIFF
--- a/packages/server/src/sdk/users/tests/utils.spec.ts
+++ b/packages/server/src/sdk/users/tests/utils.spec.ts
@@ -84,7 +84,8 @@ describe("syncGlobalUsers", () => {
         await syncGlobalUsers()
 
         const metadata = await rawUserMetadata()
-        expect(metadata).toHaveLength(2)
+
+        expect(metadata).toHaveLength(2 + 1) // ADMIN user created in test bootstrap still in the application
         expect(metadata).toContainEqual(
           expect.objectContaining({
             _id: db.generateUserMetadataID(user1._id!),
@@ -121,7 +122,7 @@ describe("syncGlobalUsers", () => {
         await syncGlobalUsers()
 
         const metadata = await rawUserMetadata()
-        expect(metadata).toHaveLength(1) //ADMIN user created in test bootstrap still in the application
+        expect(metadata).toHaveLength(1) // ADMIN user created in test bootstrap still in the application
       })
     })
   })

--- a/packages/server/src/tests/utilities/TestConfiguration.ts
+++ b/packages/server/src/tests/utilities/TestConfiguration.ts
@@ -301,7 +301,7 @@ export default class TestConfiguration {
       lastName = generator.last(),
       builder = true,
       admin = false,
-      email,
+      email = generator.email(),
       roles,
     } = config
 

--- a/packages/server/src/tests/utilities/TestConfiguration.ts
+++ b/packages/server/src/tests/utilities/TestConfiguration.ts
@@ -91,7 +91,6 @@ export default class TestConfiguration {
   prodApp: any
   prodAppId: any
   user: any
-  globalUserId: any
   userMetadataId: any
   table?: Table
   automation: any
@@ -99,6 +98,10 @@ export default class TestConfiguration {
   tenantId?: string
   api: API
   csrfToken?: string
+
+  private get globalUserId() {
+    return this.user._id
+  }
 
   constructor(openServer = true) {
     if (openServer) {
@@ -139,6 +142,15 @@ export default class TestConfiguration {
 
   getProdAppId() {
     return this.prodAppId
+  }
+
+  getUserDetails() {
+    return {
+      globalId: this.globalUserId,
+      email: this.user.email,
+      firstName: this.user.firstName,
+      lastName: this.user.lastName,
+    }
   }
 
   async doInContext<T>(
@@ -432,7 +444,7 @@ export default class TestConfiguration {
   defaultHeaders(extras = {}, prodApp = false) {
     const tenantId = this.getTenantId()
     const authObj: AuthToken = {
-      userId: this.user.globalUserId,
+      userId: this.globalUserId,
       sessionId: "sessionid",
       tenantId,
     }
@@ -505,8 +517,7 @@ export default class TestConfiguration {
   async newTenant(appName = newid()): Promise<App> {
     this.tenantId = structures.tenant.id()
     this.user = await this.globalUser()
-    this.globalUserId = this.user._id
-    this.userMetadataId = generateUserMetadataID(this.globalUserId)
+    this.userMetadataId = generateUserMetadataID(this.user._id)
 
     this.csrfToken = generator.hash()
     return this.createApp(appName)
@@ -518,7 +529,7 @@ export default class TestConfiguration {
 
   // API
 
-  async generateApiKey(userId = this.user.globalUserId) {
+  async generateApiKey(userId = this.user._id) {
     const db = tenancy.getTenantDB(this.getTenantId())
     const id = dbCore.generateDevInfoID(userId)
     let devInfo: any

--- a/packages/server/src/tests/utilities/TestConfiguration.ts
+++ b/packages/server/src/tests/utilities/TestConfiguration.ts
@@ -515,11 +515,12 @@ export default class TestConfiguration {
   }
 
   async newTenant(appName = newid()): Promise<App> {
+    this.csrfToken = generator.hash()
+
     this.tenantId = structures.tenant.id()
     this.user = await this.globalUser()
     this.userMetadataId = generateUserMetadataID(this.user._id)
 
-    this.csrfToken = generator.hash()
     return this.createApp(appName)
   }
 


### PR DESCRIPTION
## Description
We are having plenty of flakiness on the pipelines, usually on random tests: https://github.com/Budibase/budibase/actions/runs/7985835708/job/21805037961

Doing some research we found out that our testconfig is setting up some default values, that are then used in multiple places. This caused different users, at multiple points, to be created with the same email.