### PR TITLE
Add nestedSchemaFields to RestQueryViewer

### DIFF
--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -60,6 +60,7 @@
   let authConfigId
   let dynamicVariables, addVariableModal, varBinding, globalDynamicBindings
   let restBindings = getRestBindings()
+  let nestedSchemaFields = {}
 
   $: staticVariables = datasource?.config?.staticVariables || {}
 
@@ -160,6 +161,7 @@
     newQuery.fields.authConfigId = authConfigId
     newQuery.fields.disabledHeaders = restUtils.flipHeaderState(enabledHeaders)
     newQuery.schema = schema || {}
+    newQuery.nestedSchemaFields = nestedSchemaFields || {}
 
     return newQuery
   }
@@ -238,6 +240,7 @@
           }
         }
         schema = response.schema
+        nestedSchemaFields = response.nestedSchemaFields
         notifications.success("Request sent successfully")
       }
     } catch (error) {


### PR DESCRIPTION
## Description
Missed this in the original PR - need to set `nestedSchemaFields` in the `RestQueryViewer`.

## Screenshots
![Screenshot 2024-02-21 at 16 47 54](https://github.com/Budibase/budibase/assets/101575380/dc275a62-8b3a-489b-b7b5-c03220e5b90e)

