### PR TITLE
Add return types to mongodb integration

### DIFF
--- a/packages/server/src/integrations/mongodb.ts
+++ b/packages/server/src/integrations/mongodb.ts
@@ -7,6 +7,7 @@ import {
   ConnectionInfo,
 } from "@budibase/types"
 import {
+  Document,
   MongoClient,
   ObjectId,
   Filter,
@@ -15,6 +16,10 @@ import {
   UpdateOptions,
   OperationOptions,
   MongoClientOptions,
+  DeleteResult,
+  UpdateResult,
+  InsertOneResult,
+  InsertManyResult,
 } from "mongodb"
 import environment from "../environment"
 
@@ -458,7 +463,9 @@ class MongoIntegration implements IntegrationBase {
     }
   }
 
-  async create(query: MongoDBQuery) {
+  async create(
+    query: MongoDBQuery
+  ): Promise<InsertOneResult | InsertManyResult> {
     try {
       await this.connect()
       const db = this.client.db(this.config.db)
@@ -488,7 +495,7 @@ class MongoIntegration implements IntegrationBase {
     }
   }
 
-  async read(query: MongoDBQuery) {
+  async read(query: MongoDBQuery): Promise<NonNullable<unknown>> {
     try {
       await this.connect()
       const db = this.client.db(this.config.db)
@@ -504,7 +511,7 @@ class MongoIntegration implements IntegrationBase {
           }
         }
         case "findOne": {
-          return await collection.findOne(json)
+          return (await collection.findOne(json)) || {}
         }
         case "findOneAndUpdate": {
           if (typeof query.json === "string") {
@@ -544,7 +551,7 @@ class MongoIntegration implements IntegrationBase {
     }
   }
 
-  async update(query: MongoDBQuery) {
+  async update(query: MongoDBQuery): Promise<UpdateResult> {
     try {
       await this.connect()
       const db = this.client.db(this.config.db)
@@ -588,7 +595,7 @@ class MongoIntegration implements IntegrationBase {
     }
   }
 
-  async delete(query: MongoDBQuery) {
+  async delete(query: MongoDBQuery): Promise<DeleteResult> {
     try {
       await this.connect()
       const db = this.client.db(this.config.db)
@@ -633,7 +640,7 @@ class MongoIntegration implements IntegrationBase {
     json: object
     steps: any[]
     extra: { [key: string]: string }
-  }) {
+  }): Promise<Document[]> {
     try {
       await this.connect()
       const db = this.client.db(this.config.db)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2235,13 +2235,6 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@datadog/native-appsec@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-6.0.0.tgz#da753f8566ec5180ad9e83014cb44984b4bc878e"
-  integrity sha512-e7vH5usFoqov7FraPcA99fe80t2/qm4Cmno1T3iBhYlhyO6HD01ArDsCZ/sUvNIUR1ujxtbr8Z9WRGJ0qQ/FDA==
-  dependencies:
-    node-gyp-build "^3.9.0"
-
 "@datadog/native-appsec@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-7.0.0.tgz#a380174dd49aef2d9bb613a0ec8ead6dc7822095"
@@ -9036,46 +9029,6 @@ dc-polyfill@^0.1.2:
   resolved "https://registry.yarnpkg.com/dc-polyfill/-/dc-polyfill-0.1.3.tgz#fe9eefc86813439dd46d6f9ad9582ec079c39720"
   integrity sha512-Wyk5n/5KUj3GfVKV2jtDbtChC/Ff9fjKsBcg4ZtYW1yQe3DXNHcGURvmoxhqQdfOQ9TwyMjnfyv1lyYcOkFkFA==
 
-dd-trace@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-5.0.0.tgz#1e9848d6b6212ca67f8a3d62ce1f9ecd93fb5ebb"
-  integrity sha512-MmbM05l0qFeM73kDyyQAHWvyeZl2m6FYlv3hgtBU8GSpFmNu/33llyYp4TDpoEJ7hqd5LWT7mKKQFq8lRbTH3w==
-  dependencies:
-    "@datadog/native-appsec" "6.0.0"
-    "@datadog/native-iast-rewriter" "2.2.2"
-    "@datadog/native-iast-taint-tracking" "1.6.4"
-    "@datadog/native-metrics" "^2.0.0"
-    "@datadog/pprof" "5.0.0"
-    "@datadog/sketches-js" "^2.1.0"
-    "@opentelemetry/api" "^1.0.0"
-    "@opentelemetry/core" "^1.14.0"
-    crypto-randomuuid "^1.0.0"
-    dc-polyfill "^0.1.2"
-    ignore "^5.2.4"
-    import-in-the-middle "^1.7.1"
-    int64-buffer "^0.1.9"
-    ipaddr.js "^2.1.0"
-    istanbul-lib-coverage "3.2.0"
-    jest-docblock "^29.7.0"
-    koalas "^1.0.2"
-    limiter "1.1.5"
-    lodash.kebabcase "^4.1.1"
-    lodash.pick "^4.4.0"
-    lodash.sortby "^4.7.0"
-    lodash.uniq "^4.5.0"
-    lru-cache "^7.14.0"
-    methods "^1.1.2"
-    module-details-from-path "^1.0.3"
-    msgpack-lite "^0.1.26"
-    node-abort-controller "^3.1.1"
-    opentracing ">=0.12.1"
-    path-to-regexp "^0.1.2"
-    pprof-format "^2.0.7"
-    protobufjs "^7.2.5"
-    retry "^0.13.1"
-    semver "^7.5.4"
-    tlhunter-sorted-set "^0.1.0"
-
 dd-trace@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-5.2.0.tgz#6ca2d76ece95f08d98468d7782c22f24192afa53"
@@ -12464,7 +12417,7 @@ import-from@^3.0.0:
   dependencies:
     resolve-from "^5.0.0"
 
-import-in-the-middle@^1.7.1, import-in-the-middle@^1.7.3:
+import-in-the-middle@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.7.3.tgz#ffa784cdd57a47d2b68d2e7dd33070ff06baee43"
   integrity sha512-R2I11NRi0lI3jD2+qjqyVlVEahsejw7LDnYEbGb47QEFjczE3bZYsmWheCTQA+LFs2DzOQxR7Pms7naHW1V4bQ==
@@ -14927,11 +14880,6 @@ lodash.isstring@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
 
-lodash.kebabcase@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
-  integrity sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==
-
 lodash.keys@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
@@ -14962,7 +14910,7 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
-lodash.pick@^4.0.0, lodash.pick@^4.4.0:
+lodash.pick@^4.0.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==


### PR DESCRIPTION
## Description
`findOne` is the odd one out in that it can return **null**, whereas all other methods return some object. 
This was causing a null pointer later on.
I've added return types to ensure the query response is always non-null.

## Addresses
- https://linear.app/budibase/issue/BUDI-8026/cannot-convert-undefined-or-null-to-object-when-running-query-against
