### PR TITLE
Help popout email support license validation check

### DIFF
--- a/packages/builder/src/components/common/HelpMenu.svelte
+++ b/packages/builder/src/components/common/HelpMenu.svelte
@@ -52,7 +52,7 @@
         <div class="icon">
           <FontAwesomeIcon name="fa-solid fa-play" />
         </div>
-        <Body size="S">Budibase University {isPremiumAndAbove}</Body>
+        <Body size="S">Budibase University</Body>
       </a>
       <div class="divider" />
       {#if isEnabled(TENANT_FEATURE_FLAGS.LICENSING)}

--- a/packages/builder/src/components/common/HelpMenu.svelte
+++ b/packages/builder/src/components/common/HelpMenu.svelte
@@ -2,11 +2,10 @@
   import FontAwesomeIcon from "./FontAwesomeIcon.svelte"
   import { Popover, Heading, Body } from "@budibase/bbui"
   import { isEnabled, TENANT_FEATURE_FLAGS } from "helpers/featureFlags"
-  import { auth } from "stores/portal"
-  import { emailSupportCheck } from "helpers/planTitle"
+  import { licensing } from "stores/portal"
+  import { isPremiumAndAbove } from "helpers/planTitle"
 
-  $: license = $auth.user?.license
-  $: isPremiumAndAbove = emailSupportCheck(license?.plan.type)
+  $: premiumOrAboveLicense = isPremiumAndAbove($licensing?.license.plan.type)
 
   let show
   let hide
@@ -57,17 +56,20 @@
       <div class="divider" />
       {#if isEnabled(TENANT_FEATURE_FLAGS.LICENSING)}
         <a
-          href={isPremiumAndAbove
+          href={premiumOrAboveLicense
             ? "mailto:support@budibase.com"
             : "/builder/portal/account/usage"}
         >
-          <div class="premiumLinkContent" class:disabled={!isPremiumAndAbove}>
+          <div
+            class="premiumLinkContent"
+            class:disabled={!premiumOrAboveLicense}
+          >
             <div class="icon">
               <FontAwesomeIcon name="fa-solid fa-envelope" />
             </div>
             <Body size="S">Email support</Body>
           </div>
-          {#if !isPremiumAndAbove}
+          {#if !premiumOrAboveLicense}
             <div class="premiumBadge">
               <div class="icon">
                 <FontAwesomeIcon name="fa-solid fa-lock" />

--- a/packages/builder/src/components/common/HelpMenu.svelte
+++ b/packages/builder/src/components/common/HelpMenu.svelte
@@ -3,9 +3,9 @@
   import { Popover, Heading, Body } from "@budibase/bbui"
   import { isEnabled, TENANT_FEATURE_FLAGS } from "helpers/featureFlags"
   import { licensing } from "stores/portal"
-  import { isPremiumAndAbove } from "helpers/planTitle"
+  import { isPremiumOrAbove } from "helpers/planTitle"
 
-  $: premiumOrAboveLicense = isPremiumAndAbove($licensing?.license.plan.type)
+  $: premiumOrAboveLicense = isPremiumOrAbove($licensing?.license.plan.type)
 
   let show
   let hide

--- a/packages/builder/src/components/common/HelpMenu.svelte
+++ b/packages/builder/src/components/common/HelpMenu.svelte
@@ -1,11 +1,12 @@
 <script>
   import FontAwesomeIcon from "./FontAwesomeIcon.svelte"
   import { Popover, Heading, Body } from "@budibase/bbui"
-  import { licensing } from "stores/portal"
   import { isEnabled, TENANT_FEATURE_FLAGS } from "helpers/featureFlags"
+  import { auth } from "stores/portal"
+  import { emailSupportCheck } from "helpers/planTitle"
 
-  $: isBusinessAndAbove =
-    $licensing.isBusinessPlan || $licensing.isEnterprisePlan
+  $: license = $auth.user?.license
+  $: isPremiumAndAbove = emailSupportCheck(license?.plan.type)
 
   let show
   let hide
@@ -51,27 +52,27 @@
         <div class="icon">
           <FontAwesomeIcon name="fa-solid fa-play" />
         </div>
-        <Body size="S">Budibase University</Body>
+        <Body size="S">Budibase University {isPremiumAndAbove}</Body>
       </a>
       <div class="divider" />
       {#if isEnabled(TENANT_FEATURE_FLAGS.LICENSING)}
         <a
-          href={isBusinessAndAbove
+          href={isPremiumAndAbove
             ? "mailto:support@budibase.com"
             : "/builder/portal/account/usage"}
         >
-          <div class="premiumLinkContent" class:disabled={!isBusinessAndAbove}>
+          <div class="premiumLinkContent" class:disabled={!isPremiumAndAbove}>
             <div class="icon">
               <FontAwesomeIcon name="fa-solid fa-envelope" />
             </div>
             <Body size="S">Email support</Body>
           </div>
-          {#if !isBusinessAndAbove}
+          {#if !isPremiumAndAbove}
             <div class="premiumBadge">
               <div class="icon">
                 <FontAwesomeIcon name="fa-solid fa-lock" />
               </div>
-              <Body size="XS">Business</Body>
+              <Body size="XS">Premium</Body>
             </div>
           {/if}
         </a>

--- a/packages/builder/src/helpers/planTitle.js
+++ b/packages/builder/src/helpers/planTitle.js
@@ -25,3 +25,9 @@ export function getFormattedPlanName(userPlanType) {
   }
   return `${planName} Plan`
 }
+
+export function emailSupportCheck(userPlanType) {
+  const isPremiumAndAbove = ![PlanType.PRO, PlanType.TEAM, PlanType.FREE].includes(userPlanType);
+
+  return isPremiumAndAbove;
+}

--- a/packages/builder/src/helpers/planTitle.js
+++ b/packages/builder/src/helpers/planTitle.js
@@ -27,7 +27,5 @@ export function getFormattedPlanName(userPlanType) {
 }
 
 export function isPremiumAndAbove(userPlanType) {
-  const isPremiumAndAbove = ![PlanType.PRO, PlanType.TEAM, PlanType.FREE].includes(userPlanType);
-
-  return isPremiumAndAbove;
+  return ![PlanType.PRO, PlanType.TEAM, PlanType.FREE].includes(userPlanType);
 }

--- a/packages/builder/src/helpers/planTitle.js
+++ b/packages/builder/src/helpers/planTitle.js
@@ -26,6 +26,6 @@ export function getFormattedPlanName(userPlanType) {
   return `${planName} Plan`
 }
 
-export function isPremiumAndAbove(userPlanType) {
+export function isPremiumOrAbove(userPlanType) {
   return ![PlanType.PRO, PlanType.TEAM, PlanType.FREE].includes(userPlanType);
 }

--- a/packages/builder/src/helpers/planTitle.js
+++ b/packages/builder/src/helpers/planTitle.js
@@ -26,7 +26,7 @@ export function getFormattedPlanName(userPlanType) {
   return `${planName} Plan`
 }
 
-export function emailSupportCheck(userPlanType) {
+export function isPremiumAndAbove(userPlanType) {
   const isPremiumAndAbove = ![PlanType.PRO, PlanType.TEAM, PlanType.FREE].includes(userPlanType);
 
   return isPremiumAndAbove;

--- a/packages/builder/src/helpers/planTitle.js
+++ b/packages/builder/src/helpers/planTitle.js
@@ -27,5 +27,5 @@ export function getFormattedPlanName(userPlanType) {
 }
 
 export function isPremiumOrAbove(userPlanType) {
-  return ![PlanType.PRO, PlanType.TEAM, PlanType.FREE].includes(userPlanType);
+  return ![PlanType.PRO, PlanType.TEAM, PlanType.FREE].includes(userPlanType)
 }


### PR DESCRIPTION
## Description
This pr fixes the help menu email support option. Currently its set to business, this changes it so it only shows locked for plans like team, pro and free account types. Additionally it also now displays the correct text if the user doesn't have email support available to them. Premium instead of Business which was shown previously.


## Screenshots
**Before**
<img width="301" alt="Screenshot 2024-02-26 at 09 15 45" src="https://github.com/Budibase/budibase/assets/126772285/28527111-4355-4de5-9b8f-5beaa9c0acc4">

**After**
<img width="302" alt="Screenshot 2024-02-26 at 09 21 19" src="https://github.com/Budibase/budibase/assets/126772285/79fd981c-262a-4ccc-a5ca-7e2f32f646ce">

## Launchcontrol
Small logic amend to help popup, this allows email support access for the correct plan types.
