### PR TITLE
Don't encode twice

### DIFF
--- a/packages/builder/src/helpers/data/utils.js
+++ b/packages/builder/src/helpers/data/utils.js
@@ -17,6 +17,10 @@ export function breakQueryString(qs) {
   return paramObj
 }
 
+function isEncoded(str) {
+  return typeof str == "string" && decodeURIComponent(str) !== str
+}
+
 export function buildQueryString(obj) {
   let str = ""
   if (obj) {
@@ -35,7 +39,7 @@ export function buildQueryString(obj) {
         value = value.replace(binding, marker)
         bindingMarkers[marker] = binding
       })
-      let encoded = encodeURIComponent(value || "")
+      let encoded = isEncoded(value) ? value : encodeURIComponent(value || "")
       Object.entries(bindingMarkers).forEach(([marker, binding]) => {
         encoded = encoded.replace(marker, binding)
       })

--- a/packages/builder/src/helpers/tests/dataUtils.test.js
+++ b/packages/builder/src/helpers/tests/dataUtils.test.js
@@ -39,4 +39,11 @@ describe("check query string utils", () => {
     expect(broken.key1).toBe(obj2.key1)
     expect(broken.key2).toBe(obj2.key2)
   })
+
+  it("should not encode a URL more than once when building the query string", () => {
+    const queryString = buildQueryString({
+      values: "a%2Cb%2Cc",
+    })
+    expect(queryString).toBe("values=a%2Cb%2Cc")
+  })
 })


### PR DESCRIPTION
## Description
`buildQueryString` would encode already encoded URL params. Added a check to ensure the encoding is only done once.

## Addresses
- https://github.com/Budibase/budibase/issues/13038
