### PR TITLE
FIX: cannot delete a renamed column with a mysql datasource

### DIFF
--- a/packages/server/src/integrations/base/sqlTable.ts
+++ b/packages/server/src/integrations/base/sqlTable.ts
@@ -225,7 +225,7 @@ class SqlTableQueryBuilder {
             : `\`${json.table.name}\``
           const externalType = json.table.schema[updatedColumn].externalType!
           return {
-            sql: `ALTER TABLE ${tableName} CHANGE COLUMN \`${json.meta.renamed.old}\` \`${updatedColumn}\` ${externalType};`,
+            sql: `alter table ${tableName} change column \`${json.meta.renamed.old}\` \`${updatedColumn}\` ${externalType};`,
             bindings: [],
           }
         }

--- a/packages/server/src/integrations/base/sqlTable.ts
+++ b/packages/server/src/integrations/base/sqlTable.ts
@@ -135,7 +135,8 @@ function generateSchema(
   // need to check if any columns have been deleted
   if (oldTable) {
     const deletedColumns = Object.entries(oldTable.schema).filter(
-      ([key, column]) => isIgnoredType(column.type) && table.schema[key] == null
+      ([key, column]) =>
+        !isIgnoredType(column.type) && table.schema[key] == null
     )
     deletedColumns.forEach(([key, column]) => {
       if (renamed?.old === key || isIgnoredType(column.type)) {

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -12,7 +12,6 @@ import {
   SourceName,
   Schema,
   TableSourceType,
-  FieldType,
 } from "@budibase/types"
 import {
   getSqlQuery,

--- a/packages/server/src/integrations/oracle.ts
+++ b/packages/server/src/integrations/oracle.ts
@@ -421,7 +421,7 @@ class OracleIntegration extends Sql implements DatasourcePlus {
 
   async query(json: QueryJson) {
     const operation = this._operation(json)
-    const input = this._query(json, { disableReturning: true })
+    const input = this._query(json, { disableReturning: true }) as SqlQuery
     if (Array.isArray(input)) {
       const responses = []
       for (let query of input) {

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -419,7 +419,7 @@ class PostgresIntegration extends Sql implements DatasourcePlus {
 
   async query(json: QueryJson) {
     const operation = this._operation(json).toLowerCase()
-    const input = this._query(json)
+    const input = this._query(json) as SqlQuery
     if (Array.isArray(input)) {
       const responses = []
       for (let query of input) {


### PR DESCRIPTION
## Description
Knex wasn't handling the renaming of a MySQL table column. Added a raw query for this scenario.

Also fixed another bug I noticed where you couldn't delete a SQL column. This was simply an incorrect boolean check on `isIgnoredType`.

Unit tests added.

## Addresses
- https://github.com/Budibase/budibase/issues/5769

