### PR TITLE
Fetch attachment URL in public API retrieve row

### DIFF
--- a/packages/server/src/api/controllers/row/internal.ts
+++ b/packages/server/src/api/controllers/row/internal.ts
@@ -189,11 +189,12 @@ export async function fetchEnrichedRow(ctx: UserCtx) {
   const tableId = utils.getTableId(ctx)
   const rowId = ctx.params.rowId as string
   // need table to work out where links go in row, as well as the link docs
-  const [table, row, links] = await Promise.all([
+  const [table, links] = await Promise.all([
     sdk.tables.getTable(tableId),
-    utils.findRow(ctx, tableId, rowId),
     linkRows.getLinkDocuments({ tableId, rowId, fieldName }),
   ])
+  let row = await utils.findRow(ctx, tableId, rowId)
+  row = await outputProcessing(table, row)
   const linkVals = links as LinkDocumentValue[]
 
   // look up the actual rows based on the ids


### PR DESCRIPTION
## Description
Public API retrieve endpoint did not do `outputProcessing` on the row. Now it does, which allows the attachment URL to be accessed.

## Addresses
- https://github.com/Budibase/budibase/issues/10852

## Screenshots
<img width="680" alt="Screenshot 2024-02-29 at 16 39 06" src="https://github.com/Budibase/budibase/assets/101575380/899ca7f1-3e5a-419c-a615-497818a9586f">
