### PR TITLE
Make use of 405 when appropriate

### DIFF
--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -38,6 +38,7 @@ async function initRoutes(app: Koa) {
 
   // api routes
   app.use(api.router.routes())
+  app.use(api.router.allowedMethods())
 }
 
 async function initPro() {


### PR DESCRIPTION
## Description
Public API now throws a 405 when the method is not allowed.

## Addresses
- https://github.com/Budibase/budibase/issues/11228

## Screenshots
<img width="689" alt="Screenshot 2024-02-29 at 17 09 11" src="https://github.com/Budibase/budibase/assets/101575380/4f2b2f92-b2c0-4cad-84ea-a7dbffee92ce">

*Valid*

<img width="689" alt="Screenshot 2024-02-29 at 17 09 27" src="https://github.com/Budibase/budibase/assets/101575380/8ebc4b0d-f1a6-4d24-91ef-ac80ee20a259">

*Method not allowed*
