### PR TITLE
Migrate users of switchToSelfHosted to config.withEnv

### DIFF
--- a/packages/server/src/api/routes/tests/apikeys.spec.js
+++ b/packages/server/src/api/routes/tests/apikeys.spec.js
@@ -13,7 +13,7 @@ describe("/api/keys", () => {
 
   describe("fetch", () => {
     it("should allow fetching", async () => {
-      await setup.switchToSelfHosted(async () => {
+      await config.withEnv({ SELF_HOSTED: "true" }, async () => {
         const res = await request
           .get(`/api/keys`)
           .set(config.defaultHeaders())
@@ -34,7 +34,7 @@ describe("/api/keys", () => {
 
   describe("update", () => {
     it("should allow updating a value", async () => {
-      await setup.switchToSelfHosted(async () => {
+      await config.withEnv({ SELF_HOSTED: "true" }, async () => {
         const res = await request
           .put(`/api/keys/TEST`)
           .send({

--- a/packages/server/src/api/routes/tests/application.spec.ts
+++ b/packages/server/src/api/routes/tests/application.spec.ts
@@ -248,4 +248,13 @@ describe("/applications", () => {
       expect(devLogs.data.length).toBe(0)
     })
   })
+
+  describe("permissions", () => {
+    it("should only return apps a user has access to", async () => {
+      const user = await config.createUser()
+
+      const apps = await config.api.application.fetch()
+      expect(apps.length).toBeGreaterThan(0)
+    })
+  })
 })

--- a/packages/server/src/api/routes/tests/queries/query.seq.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/query.seq.spec.ts
@@ -157,7 +157,7 @@ describe("/queries", () => {
     })
 
     it("should find a query in cloud", async () => {
-      await setup.switchToSelfHosted(async () => {
+      await config.withEnv({ SELF_HOSTED: "true" }, async () => {
         const query = await config.createQuery()
         const res = await request
           .get(`/api/queries/${query._id}`)

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -882,8 +882,7 @@ describe.each([
           ],
           tableId: table._id,
         })
-        // the environment needs configured for this
-        await setup.switchToSelfHosted(async () => {
+        await config.withEnv({ SELF_HOSTED: "true" }, async () => {
           return context.doInAppContext(config.getAppId(), async () => {
             const enriched = await outputProcessing(table, [row])
             expect((enriched as Row[])[0].attachment[0].url).toBe(

--- a/packages/server/src/api/routes/tests/utilities/index.ts
+++ b/packages/server/src/api/routes/tests/utilities/index.ts
@@ -77,21 +77,3 @@ export function getConfig() {
   }
   return config!
 }
-
-export async function switchToSelfHosted(func: any) {
-  // self hosted stops any attempts to Dynamo
-  env._set("NODE_ENV", "production")
-  env._set("SELF_HOSTED", true)
-  let error
-  try {
-    await func()
-  } catch (err) {
-    error = err
-  }
-  env._set("NODE_ENV", "jest")
-  env._set("SELF_HOSTED", false)
-  // don't throw error until after reset
-  if (error) {
-    throw error
-  }
-}


### PR DESCRIPTION
## Description

I found the `switchToSelfHosted` utility function on my travels and noticed it's essentially doing the same job as `config.withEnv`, so I migrated the few uses of it I found and deleted it.
