### PR TITLE
Make user role type more representative of reality.

### DIFF
--- a/packages/types/src/documents/global/userGroup.ts
+++ b/packages/types/src/documents/global/userGroup.ts
@@ -24,7 +24,7 @@ export interface GroupUser {
 }
 
 export interface UserGroupRoles {
-  [key: string]: string
+  [key: string]: string | undefined
 }
 
 export interface SearchGroupRequest {}

--- a/packages/types/src/sdk/events/userGroup.ts
+++ b/packages/types/src/sdk/events/userGroup.ts
@@ -48,7 +48,7 @@ export interface GroupAddedOnboardingEvent extends BaseEvent {
 }
 
 export interface GroupPermissionsEditedEvent extends BaseEvent {
-  permissions: Record<string, string>
+  permissions: Record<string, string | undefined>
   groupId: string
   audited: {
     name: string


### PR DESCRIPTION
## Description

If this type had been like this from the start, https://github.com/Budibase/budibase-pro/pull/272 wouldn't have happened.

I feel like it's very strange of TypeScript to take your word for it when you write trivially incorrect code like this:

![image](https://github.com/Budibase/budibase/assets/338027/b241d382-72d9-44b7-92e6-fd82c063a657)
