### PR TITLE
Added text colour option to tag component via manifest

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -1138,6 +1138,12 @@
         "showInBar": true
       },
       {
+        "type": "color",
+        "label": "Text Color",
+        "key": "textColor",
+        "showInBar": true
+      },
+      {
         "type": "boolean",
         "label": "Allow delete",
         "key": "closable"

--- a/packages/client/src/components/app/Tag.svelte
+++ b/packages/client/src/components/app/Tag.svelte
@@ -35,7 +35,7 @@
         ...styles?.normal,
         "background-color": color,
         "border-color": color,
-        color: textColor ? textColor : "white",
+        color: textColor || "white",
         "--spectrum-clearbutton-medium-icon-color": "white",
       },
     }

--- a/packages/client/src/components/app/Tag.svelte
+++ b/packages/client/src/components/app/Tag.svelte
@@ -6,6 +6,7 @@
   export let onClick
   export let text = ""
   export let color
+  export let textColor
   export let closable = false
   export let size = "M"
 
@@ -14,7 +15,7 @@
 
   // Add color styles to main styles object, otherwise the styleable helper
   // overrides the color when it's passed as inline style.
-  $: styles = enrichStyles($component.styles, color)
+  $: styles = enrichStyles($component.styles, color, textColor)
   $: componentText = getComponentText(text, $builderStore, $component)
 
   const getComponentText = (text, builderState, componentState) => {
@@ -24,7 +25,7 @@
     return text || componentState.name || "Placeholder text"
   }
 
-  const enrichStyles = (styles, color) => {
+  const enrichStyles = (styles, color, textColor) => {
     if (!color) {
       return styles
     }
@@ -34,7 +35,7 @@
         ...styles?.normal,
         "background-color": color,
         "border-color": color,
-        color: "white",
+        color: textColor ? textColor : "black",
         "--spectrum-clearbutton-medium-icon-color": "white",
       },
     }

--- a/packages/client/src/components/app/Tag.svelte
+++ b/packages/client/src/components/app/Tag.svelte
@@ -35,7 +35,7 @@
         ...styles?.normal,
         "background-color": color,
         "border-color": color,
-        color: textColor ? textColor : "black",
+        color: textColor ? textColor : "white",
         "--spectrum-clearbutton-medium-icon-color": "white",
       },
     }


### PR DESCRIPTION
## Description
When using certain colours it was nearly impossible to see what the text inside a tag was. An impossible one would have been white as the custom color select. When this was selected it was a white background with white text which just appears as invisible text.

## Addresses
- Raised by Joe internally

## Screenshots
**Before**
<img width="1509" alt="Screenshot 2024-03-08 at 08 39 57" src="https://github.com/Budibase/budibase/assets/126772285/e336b29b-6864-42a2-baf9-d57da84364a3">

**After**
<img width="1306" alt="Screenshot 2024-03-08 at 08 36 26" src="https://github.com/Budibase/budibase/assets/126772285/ec4fbacf-e9ab-4cf8-818a-62fb1faed724">

## Launchcontrol
Small addition to the tag component, allowing for custom colour text selection to avoid clashes with background colours.
