### PR TITLE
Fix issue with invalid IDs leading to inability to emit rows when bulk deleting

### DIFF
--- a/packages/server/src/api/controllers/public/utils.ts
+++ b/packages/server/src/api/controllers/public/utils.ts
@@ -1,11 +1,12 @@
 import { context } from "@budibase/backend-core"
 import { isExternalTableID } from "../../../integrations/utils"
 import { APP_PREFIX, DocumentType } from "../../../db/utils"
+import { Row } from "@budibase/types"
 
 export async function addRev(
   body: { _id?: string; _rev?: string },
   tableId?: string
-) {
+): Promise<Row> {
   if (!body._id || (tableId && isExternalTableID(tableId))) {
     return body
   }

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -128,7 +128,10 @@ export async function bulkDestroy(ctx: UserCtx) {
     )
   }
   const responses = await Promise.all(promises)
-  return { response: { ok: true }, rows: responses.map(resp => resp.row) }
+  const finalRows = responses
+    .map(resp => resp.row)
+    .filter(row => row && row._id)
+  return { response: { ok: true }, rows: finalRows }
 }
 
 export async function fetchEnrichedRow(ctx: UserCtx) {

--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -131,7 +131,10 @@ async function processDeleteRowsRequest(ctx: UserCtx<DeleteRowRequest>) {
       : fixRow(processedRow, ctx.params)
   })
 
-  return await Promise.all(processedRows)
+  const responses = await Promise.allSettled(processedRows)
+  return responses
+    .filter(resp => resp.status === "fulfilled")
+    .map(resp => (resp as PromiseFulfilledResult<Row>).value)
 }
 
 async function deleteRows(ctx: UserCtx<DeleteRowRequest>) {

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -636,6 +636,17 @@ describe.each([
       expect(res[0]._id).toEqual(createdRow._id)
       await assertRowUsage(rowUsage - 1)
     })
+
+    it("should be able to bulk delete rows, including a row that doesn't exist", async () => {
+      const createdRow = await config.createRow()
+
+      const res = await config.api.row.bulkDelete(table._id!, {
+        rows: [createdRow, { _id: "2" }],
+      })
+
+      expect(res[0]._id).toEqual(createdRow._id)
+      expect(res.length).toEqual(1)
+    })
   })
 
   describe("validate", () => {


### PR DESCRIPTION
## Description
The way that bulk deleting rows works in SQL means that if you provide invalid IDs, nothing happens, it will not error. There has been an issue for a while now where this causes problems when attempting to emit these invalid rows to the websockets, the following stack trace demonstrates this:

![image](https://github.com/Budibase/budibase/assets/4407001/8dd2a97b-f5b1-4133-8d2a-49e64662295b)

According to DataDog this issue has been present for 3 months.

## Addresses
https://github.com/Budibase/budibase/issues/13199
