### PR TITLE
Init doc writethrough processor correctly

### DIFF
--- a/packages/backend-core/src/cache/docWritethrough.ts
+++ b/packages/backend-core/src/cache/docWritethrough.ts
@@ -10,6 +10,7 @@ interface ProcessDocMessage {
 }
 
 const PERSIST_MAX_ATTEMPTS = 100
+let processor: DocWritethroughProcessor | undefined
 
 export const docWritethroughProcessorQueue = createQueue<ProcessDocMessage>(
   JobQueue.DOC_WRITETHROUGH_QUEUE,
@@ -61,8 +62,6 @@ class DocWritethroughProcessor {
   }
 }
 
-export const processor = new DocWritethroughProcessor().init()
-
 export class DocWritethrough {
   private db: Database
   private _docId: string
@@ -83,4 +82,16 @@ export class DocWritethrough {
       data,
     })
   }
+}
+
+export function init(): DocWritethroughProcessor {
+  processor = new DocWritethroughProcessor().init()
+  return processor
+}
+
+export function getProcessor(): DocWritethroughProcessor {
+  if (!processor) {
+    return init()
+  }
+  return processor
 }

--- a/packages/backend-core/src/cache/tests/docWritethrough.spec.ts
+++ b/packages/backend-core/src/cache/tests/docWritethrough.spec.ts
@@ -7,6 +7,7 @@ import { getDB } from "../../db"
 import {
   DocWritethrough,
   docWritethroughProcessorQueue,
+  init,
 } from "../docWritethrough"
 
 import InMemoryQueue from "../../queue/inMemoryQueue"
@@ -19,6 +20,11 @@ async function waitForQueueCompletion() {
 }
 
 describe("docWritethrough", () => {
+
+  beforeAll(() => {
+    init()
+  })
+
   const config = new DBTestConfiguration()
 
   const db = getDB(structures.db.id())

--- a/packages/backend-core/src/cache/tests/docWritethrough.spec.ts
+++ b/packages/backend-core/src/cache/tests/docWritethrough.spec.ts
@@ -20,7 +20,6 @@ async function waitForQueueCompletion() {
 }
 
 describe("docWritethrough", () => {
-
   beforeAll(() => {
     init()
   })

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -7,6 +7,7 @@ import {
   logging,
   tenancy,
   users,
+  cache,
 } from "@budibase/backend-core"
 import fs from "fs"
 import { watch } from "./watch"
@@ -74,6 +75,7 @@ export async function startup(app?: Koa, server?: Server) {
   eventEmitter.emitPort(env.PORT)
   fileSystem.init()
   await redis.init()
+  cache.docWritethrough.init()
   eventInit()
   if (app && server) {
     initialiseWebsockets(app, server)

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -17,6 +17,7 @@ import {
   env as coreEnv,
   timers,
   redis,
+  cache,
 } from "@budibase/backend-core"
 
 db.init()
@@ -90,6 +91,7 @@ export default server.listen(parseInt(env.PORT || "4002"), async () => {
   console.log(`Worker running on ${JSON.stringify(server.address())}`)
   await initPro()
   await redis.clients.init()
+  cache.docWritethrough.init()
   // configure events to use the pro audit log write
   // can't integrate directly into backend-core due to cyclic issues
   await events.processors.init(proSdk.auditLogs.write)


### PR DESCRIPTION
## Description
Initing doc writethrough cache as part of the worker/server init process, as well as part of doc writethrough tests.

Addresses an issue with all users of backend-core attempting to init the writethrough cache.