### PR TITLE
Remove unused field verificationSent

### DIFF
--- a/packages/backend-core/tests/core/utilities/structures/accounts.ts
+++ b/packages/backend-core/tests/core/utilities/structures/accounts.ts
@@ -23,7 +23,6 @@ export const account = (partial: Partial<Account> = {}): Account => {
     hosting: Hosting.SELF,
     createdAt: Date.now(),
     verified: true,
-    verificationSent: true,
     tier: "FREE", // DEPRECATED
     authType: AuthType.PASSWORD,
     name: generator.name(),

--- a/packages/types/src/documents/account/account.ts
+++ b/packages/types/src/documents/account/account.ts
@@ -40,7 +40,6 @@ export interface Account extends CreateAccount {
   createdAt: number
   // registration
   verified: boolean
-  verificationSent: boolean
   // licensing
   tier: string // deprecated
   planType?: PlanType


### PR DESCRIPTION
## Description
`verificationSent` is not used, and will not be used in updated flow.

## Addresses
- https://github.com/Budibase/account-portal/pull/546
- https://linear.app/budibase/issue/GROW-355/worker-create-account
