### PR TITLE
Fix - Allow deleting attachment column with empty values

### DIFF
--- a/packages/server/src/utilities/rowProcessor/attachments.ts
+++ b/packages/server/src/utilities/rowProcessor/attachments.ts
@@ -43,7 +43,7 @@ export class AttachmentCleanup {
         if ((columnRemoved && !renaming) || opts.deleting) {
           rows.forEach(row => {
             files = files.concat(
-              row[key].map((attachment: any) => attachment.key)
+              (row[key] || []).map((attachment: any) => attachment.key)
             )
           })
         }

--- a/packages/server/src/utilities/rowProcessor/tests/attachments.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/attachments.spec.ts
@@ -115,4 +115,17 @@ describe("attachment cleanup", () => {
     await AttachmentCleanup.rowUpdate(table(), { row: row(), oldRow: row() })
     expect(mockedDeleteFiles).not.toBeCalled()
   })
+
+  it("should be able to cleanup a column and not throw when attachments are undefined", async () => {
+    const originalTable = table()
+    delete originalTable.schema["attach"]
+    await AttachmentCleanup.tableUpdate(
+      originalTable,
+      [{ attach: undefined }],
+      {
+        oldTable: table(),
+      }
+    )
+    expect(mockedDeleteFiles).not.toBeCalled()
+  })
 })

--- a/packages/server/src/utilities/rowProcessor/tests/attachments.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/attachments.spec.ts
@@ -121,7 +121,21 @@ describe("attachment cleanup", () => {
     delete originalTable.schema["attach"]
     await AttachmentCleanup.tableUpdate(
       originalTable,
-      [{ attach: undefined }],
+      [row("file 1"), { attach: undefined }, row("file 2")],
+      {
+        oldTable: table(),
+      }
+    )
+    expect(mockedDeleteFiles).toBeCalledTimes(1)
+    expect(mockedDeleteFiles).toBeCalledWith(BUCKET, ["file 1", "file 2"])
+  })
+
+  it("should be able to cleanup a column and not throw when ALL attachments are undefined", async () => {
+    const originalTable = table()
+    delete originalTable.schema["attach"]
+    await AttachmentCleanup.tableUpdate(
+      originalTable,
+      [{}, { attach: undefined }],
       {
         oldTable: table(),
       }


### PR DESCRIPTION
## Description
We we are trying to remove an attachment column we are deleting the actual attached files. If a single row does not have an attached file for that column, the process fails not allowing to delete the column.
This fixes, allowing to delete this column deleting the expected files

<img width="666" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/9e95b0fe-f0da-4561-a237-71be2dc13ad2">


## Launchcontrol
Fix deleting attachment columns with empty values