### PR TITLE
Fix for multi tenant favourites

### DIFF
--- a/packages/worker/src/api/controllers/global/self.ts
+++ b/packages/worker/src/api/controllers/global/self.ts
@@ -114,9 +114,16 @@ export const syncAppFavourites = async (processedAppIds: string[]) => {
   if (processedAppIds.length === 0) {
     return []
   }
-  const apps = await fetchAppsByIds(processedAppIds)
+
+  const tenantId = tenancy.getTenantId()
+  const appPrefix =
+    tenantId === tenancy.DEFAULT_TENANT_ID
+      ? dbCore.APP_DEV_PREFIX
+      : `${dbCore.APP_DEV_PREFIX}${tenantId}_`
+
+  const apps = await fetchAppsByIds(processedAppIds, appPrefix)
   return apps?.reduce((acc: string[], app) => {
-    const id = app.appId.replace(dbCore.APP_DEV_PREFIX, "")
+    const id = app.appId.replace(appPrefix, "")
     if (processedAppIds.includes(id)) {
       acc.push(id)
     }
@@ -124,9 +131,14 @@ export const syncAppFavourites = async (processedAppIds: string[]) => {
   }, [])
 }
 
-export const fetchAppsByIds = async (processedAppIds: string[]) => {
+export const fetchAppsByIds = async (
+  processedAppIds: string[],
+  appPrefix: string
+) => {
   return await dbCore.getAppsByIDs(
-    processedAppIds.map(appId => `${dbCore.APP_DEV_PREFIX}${appId}`)
+    processedAppIds.map(appId => {
+      return `${appPrefix}${appId}`
+    })
   )
 }
 


### PR DESCRIPTION
## Description

The app prefix when syncing app favourites didn't take into account running in both single tenant and multi tenant modes.

Both should now have functioning favourites