### PR TITLE
Fix duplicate enum value.

### DIFF
--- a/packages/worker/src/constants/index.ts
+++ b/packages/worker/src/constants/index.ts
@@ -52,7 +52,7 @@ export enum InternalTemplateBinding {
   RESET_URL = "resetUrl",
   RESET_CODE = "resetCode",
   INVITE_URL = "inviteUrl",
-  INVITE_CODE = "inviteUrl",
+  INVITE_CODE = "inviteCode",
   CONTENTS = "contents",
 }
 


### PR DESCRIPTION
## Description

We have a duplicate binding name in one of our enums that ends up looking like this in the UI:

![image](https://github.com/Budibase/budibase/assets/338027/b414dedf-afb0-4340-b7ff-a4fee81b8eb9)

The bottom one should be `INVITECODE`. This PR fixes that.

## Launchcontrol

Fix the fact that there are 2 template bindings called `INVITEURL`. One of them should have always been `INVITECODE`, and now it is! 🙂 
