### PR TITLE
Fix hard crash when an automation error exists

### DIFF
--- a/packages/builder/src/pages/builder/portal/apps/index.svelte
+++ b/packages/builder/src/pages/builder/portal/apps/index.svelte
@@ -85,7 +85,7 @@
   }
 
   const automationErrorMessage = appId => {
-    const app = enrichedApps.find(app => app.devId === appId)
+    const app = $enrichedApps.find(app => app.devId === appId)
     const errors = automationErrors[appId]
     return `${app.name} - Automation error (${errorCount(errors)})`
   }


### PR DESCRIPTION
## Description
This PR fixes a hard page crash due to a recently introduced bug. Currently the page will crash if you have a recent automation error, which shows this warning: 
![image](https://github.com/Budibase/budibase/assets/9075550/75e24063-166c-454f-ba3a-151112d72f85)

This small changes fixes the crash.

Pretty important to roll this out ASAP as it completely blocks usage of Budibase if you have an automation error.