### PR TITLE
[Fix] CLI broken with redis errors and hanging

### DIFF
--- a/packages/backend-core/src/cache/tests/docWritethrough.spec.ts
+++ b/packages/backend-core/src/cache/tests/docWritethrough.spec.ts
@@ -6,7 +6,7 @@ import { getDB } from "../../db"
 
 import {
   DocWritethrough,
-  docWritethroughProcessorQueue,
+  DocWritethroughProcessor,
   init,
 } from "../docWritethrough"
 
@@ -15,7 +15,7 @@ import InMemoryQueue from "../../queue/inMemoryQueue"
 const initialTime = Date.now()
 
 async function waitForQueueCompletion() {
-  const queue: InMemoryQueue = docWritethroughProcessorQueue as never
+  const queue: InMemoryQueue = DocWritethroughProcessor.queue as never
   await queue.waitForCompletion()
 }
 
@@ -235,7 +235,7 @@ describe("docWritethrough", () => {
           return acc
         }, {})
       }
-      const queueMessageSpy = jest.spyOn(docWritethroughProcessorQueue, "add")
+      const queueMessageSpy = jest.spyOn(DocWritethroughProcessor.queue, "add")
 
       await config.doInTenant(async () => {
         let patches = await parallelPatch(5)

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -11,6 +11,7 @@
     "types": ["node", "jest"],
     "outDir": "dist",
     "skipLibCheck": true,
+    "baseUrl": ".",
     "paths": {
       "@budibase/types": ["../types/src"],
       "@budibase/backend-core": ["../backend-core/src"],


### PR DESCRIPTION
## Description
The new doc-writethrough class is declared in backend-core, and the queue gets initialised by default. We are having issues with CLI, as it tries to initialise this queue (even if it's not needed) but the redis connection might not exist.

![image](https://github.com/Budibase/budibase/assets/15987277/3f6c343a-f754-4820-9c0f-6ed1133879c1)


Updating this class in order to create the queue when actually required.


## Addresses
- Linear: [BUDI-8100 - Budi CLI Broken with Redis Errors and Hanging
](https://linear.app/budibase/issue/BUDI-8100/budi-cli-broken-with-redis-errors-and-hanging)
- https://github.com/Budibase/budibase/issues/13276

## Launchcontrol
Fix CLI issue with the doc-writethrough initialisation