### PR TITLE
Fix flaky scim test.

### DIFF
--- a/packages/backend-core/tests/core/utilities/structures/userGroups.ts
+++ b/packages/backend-core/tests/core/utilities/structures/userGroups.ts
@@ -3,7 +3,7 @@ import { generator } from "./generator"
 
 export function userGroup(): UserGroup {
   return {
-    name: generator.word(),
+    name: generator.guid(),
     icon: generator.word(),
     color: generator.word(),
   }


### PR DESCRIPTION
## Description

Group names have to be unique, and `generator.word()` doesn't produce a very wide range of values, sometimes causing tests to fail with identical group names.