### PR TITLE
Reenable `no-undef`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,9 +37,11 @@
       "excludedFiles": ["qa-core/**"],
       "parser": "@typescript-eslint/parser",
       "extends": ["eslint:recommended"],
+      "globals": {
+        "NodeJS": true
+      },
       "rules": {
         "no-unused-vars": "off",
-        "no-undef": "off",
         "no-prototype-builtins": "off",
         "local-rules/no-budibase-imports": "error"
       }
@@ -53,9 +55,11 @@
       "env": {
         "jest/globals": true
       },
+      "globals": {
+        "NodeJS": true
+      },
       "rules": {
         "no-unused-vars": "off",
-        "no-undef": "off",
         "no-prototype-builtins": "off",
         "local-rules/no-test-com": "error",
         "local-rules/email-domain-example-com": "error",

--- a/packages/backend-core/src/db/searchIndexes/searchIndexes.ts
+++ b/packages/backend-core/src/db/searchIndexes/searchIndexes.ts
@@ -34,12 +34,12 @@ export async function createUserIndex() {
         }
         let idxKey = prev != null ? `${prev}.${key}` : key
         if (typeof input[key] === "string") {
+          // @ts-expect-error index is available in a CouchDB map function
           // eslint-disable-next-line no-undef
-          // @ts-ignore
           index(idxKey, input[key].toLowerCase(), { facet: true })
         } else if (typeof input[key] !== "object") {
+          // @ts-expect-error index is available in a CouchDB map function
           // eslint-disable-next-line no-undef
-          // @ts-ignore
           index(idxKey, input[key], { facet: true })
         } else {
           idx(input[key], idxKey)

--- a/packages/backend-core/src/queue/inMemoryQueue.ts
+++ b/packages/backend-core/src/queue/inMemoryQueue.ts
@@ -39,7 +39,7 @@ class InMemoryQueue implements Partial<Queue> {
   _opts?: QueueOptions
   _messages: JobMessage[]
   _queuedJobIds: Set<string>
-  _emitter: EventEmitter
+  _emitter: NodeJS.EventEmitter
   _runCount: number
   _addCount: number
 

--- a/packages/server/src/db/views/staticViews.ts
+++ b/packages/server/src/db/views/staticViews.ts
@@ -30,8 +30,8 @@ export async function createLinkView() {
       if (doc.type === "link") {
         let doc1 = doc.doc1
         let doc2 = doc.doc2
+        // @ts-expect-error emit is available in a CouchDB map function
         // eslint-disable-next-line no-undef
-        // @ts-ignore
         emit([doc1.tableId, doc1.rowId], {
           id: doc2.rowId,
           thisId: doc1.rowId,
@@ -39,8 +39,8 @@ export async function createLinkView() {
         })
         // if linking to same table can't emit twice
         if (doc1.tableId !== doc2.tableId) {
+          // @ts-expect-error emit is available in a CouchDB map function
           // eslint-disable-next-line no-undef
-          // @ts-ignore
           emit([doc2.tableId, doc2.rowId], {
             id: doc1.rowId,
             thisId: doc2.rowId,
@@ -101,8 +101,8 @@ export async function createAllSearchIndex() {
           if (Array.isArray(input[key])) {
             for (let val of input[key]) {
               if (typeof val !== "object") {
+                // @ts-expect-error index is available in a CouchDB map function
                 // eslint-disable-next-line no-undef
-                // @ts-ignore
                 index(idxKey, val, { store: true })
               }
             }
@@ -110,12 +110,12 @@ export async function createAllSearchIndex() {
             continue
           }
           if (typeof input[key] === "string") {
+            // @ts-expect-error index is available in a CouchDB map function
             // eslint-disable-next-line no-undef
-            // @ts-ignore
             index(idxKey, input[key].toLowerCase(), { store: true })
           } else if (typeof input[key] !== "object") {
+            // @ts-expect-error index is available in a CouchDB map function
             // eslint-disable-next-line no-undef
-            // @ts-ignore
             index(idxKey, input[key], { store: true })
           } else {
             idx(input[key], idxKey)
@@ -123,8 +123,8 @@ export async function createAllSearchIndex() {
         }
       }
       if (doc._id!.startsWith("ro_")) {
+        // @ts-expect-error index is available in a CouchDB map function
         // eslint-disable-next-line no-undef
-        // @ts-ignore
         index("default", doc._id)
         idx(doc)
       }

--- a/packages/server/src/jsRunner/bundles/snippets.ts
+++ b/packages/server/src/jsRunner/bundles/snippets.ts
@@ -12,12 +12,15 @@ export default new Proxy(
       // See https://esbuild.github.io/content-types/#direct-eval for info on
       // why eval is being called this way.
       // Snippets are cached and reused once they have been evaluated.
-      // @ts-ignore
+      // @ts-expect-error snippetDefinitions and snippetCache are injected to the global scope
+      // eslint-disable-next-line no-undef
       if (!(name in snippetCache)) {
-        // @ts-ignore
+        // @ts-expect-error snippetDefinitions and snippetCache are injected to the global scope
+        // eslint-disable-next-line no-undef
         snippetCache[name] = [eval][0](iifeWrapper(snippetDefinitions[name]))
       }
-      // @ts-ignore
+      // @ts-expect-error snippetDefinitions and snippetCache are injected to the global scope
+      // eslint-disable-next-line no-undef
       return snippetCache[name]
     },
   }

--- a/packages/server/src/jsRunner/vm/isolated-vm.ts
+++ b/packages/server/src/jsRunner/vm/isolated-vm.ts
@@ -170,7 +170,8 @@ export class IsolatedVM implements VM {
       }
 
       decode(...input: any) {
-        // @ts-ignore
+        // @ts-expect-error - this is going to run in the isolate, where this function will be available
+        // eslint-disable-next-line no-undef
         return textDecoderCb({
           constructorArgs: this.constructorArgs,
           functionArgs: input,

--- a/packages/string-templates/package.json
+++ b/packages/string-templates/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@budibase/handlebars-helpers": "^0.13.1",
     "dayjs": "^1.10.8",
-    "handlebars": "^4.7.6",
+    "handlebars": "^4.7.8",
     "lodash.clonedeep": "^4.5.0"
   },
   "devDependencies": {

--- a/packages/string-templates/src/helpers/Helper.ts
+++ b/packages/string-templates/src/helpers/Helper.ts
@@ -1,3 +1,5 @@
+import Handlebars from "handlebars"
+
 export default class Helper {
   private name: any
   private fn: any

--- a/packages/string-templates/src/helpers/external.ts
+++ b/packages/string-templates/src/helpers/external.ts
@@ -3,6 +3,7 @@ import helpers from "@budibase/handlebars-helpers"
 
 import { date, duration } from "./date"
 import { HelperFunctionBuiltin } from "./constants"
+import Handlebars from "handlebars"
 
 /**
  * full list of supported helpers can be found here:

--- a/packages/string-templates/src/helpers/index.ts
+++ b/packages/string-templates/src/helpers/index.ts
@@ -1,5 +1,5 @@
 import Helper from "./Helper"
-import { SafeString } from "handlebars"
+import Handlebars from "handlebars"
 import * as externalHandlebars from "./external"
 import { processJS } from "./javascript"
 import {
@@ -28,7 +28,7 @@ function isObject(value: string | any[]) {
 const HELPERS = [
   // external helpers
   new Helper(HelperFunctionNames.OBJECT, (value: any) => {
-    return new SafeString(JSON.stringify(value))
+    return new Handlebars.SafeString(JSON.stringify(value))
   }),
   // javascript helper
   new Helper(HelperFunctionNames.JS, processJS, false),
@@ -38,7 +38,7 @@ const HELPERS = [
     (value: string, inputs: { __opts: any }) => {
       const { __opts } = inputs
       if (isObject(value)) {
-        return new SafeString(JSON.stringify(value))
+        return new Handlebars.SafeString(JSON.stringify(value))
       }
       // null/undefined values produce bad results
       if (__opts && __opts.onlyFound && value == null) {
@@ -55,7 +55,7 @@ const HELPERS = [
       if (__opts && __opts.escapeNewlines) {
         text = value.replace(/\n/g, "\\n")
       }
-      text = new SafeString(text.replace(/&amp;/g, "&"))
+      text = new Handlebars.SafeString(text.replace(/&amp;/g, "&"))
       if (text == null || typeof text !== "string") {
         return text
       }

--- a/packages/string-templates/src/index.ts
+++ b/packages/string-templates/src/index.ts
@@ -1,5 +1,5 @@
 import { Context, createContext, runInNewContext } from "vm"
-import { create } from "handlebars"
+import { create, TemplateDelegate } from "handlebars"
 import { registerAll, registerMinimum } from "./helpers/index"
 import { preprocess, postprocess } from "./processors"
 import {
@@ -47,7 +47,7 @@ function testObject(object: any) {
 /**
  * Creates a HBS template function for a given string, and optionally caches it.
  */
-const templateCache: Record<string, HandlebarsTemplateDelegate<any>> = {}
+const templateCache: Record<string, TemplateDelegate<any>> = {}
 function createTemplate(string: string, opts?: ProcessOptions) {
   opts = { ...defaultOpts, ...opts }
 

--- a/packages/types/src/sdk/db.ts
+++ b/packages/types/src/sdk/db.ts
@@ -7,6 +7,7 @@ import {
   ViewTemplateOpts,
 } from "../"
 import { Writable } from "stream"
+import PouchDB from "pouchdb-find"
 
 export enum SearchIndex {
   ROWS = "rows",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12046,13 +12046,25 @@ handlebars-utils@^1.0.6:
     kind-of "^6.0.0"
     typeof-article "^0.1.1"
 
-handlebars@^4.7.6, handlebars@^4.7.7:
+handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
+handlebars@^4.7.8:
+  version "4.7.8"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
+  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.2"
     source-map "^0.6.1"
     wordwrap "^1.0.0"
   optionalDependencies:


### PR DESCRIPTION
## Description

Crusade to get back to the full set of recommended eslint rules, this one seems very crucial to avoid making mistakes: https://eslint.org/docs/latest/rules/no-undef. 

I wonder why we disabled it in the first place.