### PR TITLE
Fix requiring double keypress to create new rows

### DIFF
--- a/packages/frontend-core/src/components/grid/overlays/KeyboardManager.svelte
+++ b/packages/frontend-core/src/components/grid/overlays/KeyboardManager.svelte
@@ -40,16 +40,18 @@
       }
     }
 
+    // Handle certain key presses regardless of selection state
+    if (e.key === "Enter" && (e.ctrlKey || e.metaKey) && $config.canAddRows) {
+      e.preventDefault()
+      dispatch("add-row-inline")
+      return
+    }
+
     // If nothing selected avoid processing further key presses
     if (!$focusedCellId) {
       if (e.key === "Tab" || e.key?.startsWith("Arrow")) {
         e.preventDefault()
         focusFirstCell()
-      } else if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
-        if ($config.canAddRows) {
-          e.preventDefault()
-          dispatch("add-row-inline")
-        }
       } else if (e.key === "Delete" || e.key === "Backspace") {
         if (Object.keys($selectedRows).length && $config.canDeleteRows) {
           dispatch("request-bulk-delete")


### PR DESCRIPTION
## Description
Fix requiring double keypress to create new rows. Now pressing `ctrl/cmd+enter` will always attempt to create a new row regardless of whether you're editing a field or not.

## Addresses
- https://linear.app/budibase/issue/BUDI-8056/double-tap-of-keyboard-required-when-saving-rows