### PR TITLE
Allow all external table deletion

### DIFF
--- a/packages/builder/src/components/backend/TableNavigator/popovers/EditTablePopover.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/popovers/EditTablePopover.svelte
@@ -28,7 +28,6 @@
   let deleteTableName
 
   $: externalTable = table?.sourceType === DB_TYPE_EXTERNAL
-  $: allowDeletion = !externalTable || table?.created
 
   function showDeleteModal() {
     templateScreens = $screenStore.screens.filter(
@@ -56,7 +55,7 @@
         $goto(`./datasource/${table.datasourceId}`)
       }
     } catch (error) {
-      notifications.error("Error deleting table")
+      notifications.error(`Error deleting table - ${error.message}`)
     }
   }
 
@@ -86,17 +85,15 @@
   }
 </script>
 
-{#if allowDeletion}
-  <ActionMenu>
-    <div slot="control" class="icon">
-      <Icon s hoverable name="MoreSmallList" />
-    </div>
-    {#if !externalTable}
-      <MenuItem icon="Edit" on:click={editorModal.show}>Edit</MenuItem>
-    {/if}
-    <MenuItem icon="Delete" on:click={showDeleteModal}>Delete</MenuItem>
-  </ActionMenu>
-{/if}
+<ActionMenu>
+  <div slot="control" class="icon">
+    <Icon s hoverable name="MoreSmallList" />
+  </div>
+  {#if !externalTable}
+    <MenuItem icon="Edit" on:click={editorModal.show}>Edit</MenuItem>
+  {/if}
+  <MenuItem icon="Delete" on:click={showDeleteModal}>Delete</MenuItem>
+</ActionMenu>
 
 <Modal bind:this={editorModal} on:show={initForm}>
   <ModalContent

--- a/packages/server/src/api/controllers/table/external.ts
+++ b/packages/server/src/api/controllers/table/external.ts
@@ -61,9 +61,6 @@ export async function destroy(ctx: UserCtx) {
   const tableToDelete: TableRequest = await sdk.tables.getTable(
     ctx.params.tableId
   )
-  if (!tableToDelete || !tableToDelete.created) {
-    ctx.throw(400, "Cannot delete tables which weren't created in Budibase.")
-  }
   const datasourceId = getDatasourceId(tableToDelete)
   try {
     const { datasource, table } = await sdk.tables.external.destroy(


### PR DESCRIPTION
## Description
Allowing deletion of external tables, whether they were created in Budibase or not.

Previously if tables were fetching from a DB they could not be deleted, this restriction has been lifted as it has caused confusion and we already have enough warnings about what will be deleted.

![image](https://github.com/Budibase/budibase/assets/4407001/266452a6-bbfb-48b8-b163-b645e82271a2)

Addresses:
https://linear.app/budibase/issue/BUDI-6846/allow-manual-db-deletion-from-inside-budibase
https://github.com/Budibase/budibase/issues/10211
