### PR TITLE
fix for boolean values getting stripped when running processObject

### DIFF
--- a/packages/string-templates/src/index.ts
+++ b/packages/string-templates/src/index.ts
@@ -94,7 +94,7 @@ export async function processObject<T extends Record<string, any>>(
   for (const key of Object.keys(object || {})) {
     if (object[key] != null) {
       const val = object[key]
-      let parsedValue
+      let parsedValue = val
       if (typeof val === "string") {
         parsedValue = await processString(object[key], context, opts)
       } else if (typeof val === "object") {

--- a/packages/string-templates/test/basic.spec.ts
+++ b/packages/string-templates/test/basic.spec.ts
@@ -104,6 +104,26 @@ describe("Test that the object processing works correctly", () => {
     }
     expect(error).toBeNull()
   })
+
+  it("should be able to handle booleans", async () => {
+    const output = await processObject(
+      {
+        first: true,
+        second: "true",
+        third: "another string",
+        forth: "with {{ template }}",
+      },
+      {
+        template: "value",
+      }
+    )
+    expect(output).toEqual({
+      first: true,
+      second: "true",
+      third: "another string",
+      forth: "with value",
+    })
+  })
 })
 
 describe("check returning objects", () => {


### PR DESCRIPTION
## Description
I found this when investigating the clearRelationships checkbox not working in the Update Row automation step. 

## Addresses

#13329
[BUDI-8118](https://linear.app/budibase/issue/BUDI-8118/clear-relationships-if-empty-flag-doesnt-work-in-update-row-automation)

## Launchcontrol

Fixes certain values getting stripped when processing object in string templates. The update fixes a problem clearing relationships on the update row automation step, and probably other stuff elsewhere.