### PR TITLE
Pull images separately from tests, enable testcontainers debug logs.

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -161,6 +161,8 @@ jobs:
           docker pull postgres:16.1-bullseye
           docker pull mongo:7.0-jammy
           docker pull mariadb:lts
+          docker pull testcontainers/ryuk:0.3.0
+          docker pull budibase/couchdb
 
       - run: yarn --frozen-lockfile
 

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -138,6 +138,8 @@ jobs:
 
   test-server:
     runs-on: ubuntu-latest
+    env:
+      DEBUG: testcontainers,testcontainers:exec,testcontainers:build,testcontainers:pull
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -151,7 +153,17 @@ jobs:
         with:
           node-version: 20.x
           cache: yarn
+
+      - name: Pull testcontainers images
+        run: |
+          docker pull mcr.microsoft.com/mssql/server:2022-latest
+          docker pull mysql:8.3
+          docker pull postgres:16.1-bullseye
+          docker pull mongo:7.0-jammy
+          docker pull mariadb:lts
+
       - run: yarn --frozen-lockfile
+
       - name: Test server
         run: |
           if ${{ env.USE_NX_AFFECTED }}; then

--- a/packages/server/src/integrations/tests/utils/mssql.ts
+++ b/packages/server/src/integrations/tests/utils/mssql.ts
@@ -1,6 +1,8 @@
 import { Datasource, SourceName } from "@budibase/types"
 import { GenericContainer, Wait, StartedTestContainer } from "testcontainers"
 
+// TODO: remove this comment
+
 let container: StartedTestContainer | undefined
 
 export async function start(): Promise<StartedTestContainer> {

--- a/packages/server/src/integrations/tests/utils/mssql.ts
+++ b/packages/server/src/integrations/tests/utils/mssql.ts
@@ -1,8 +1,6 @@
 import { Datasource, SourceName } from "@budibase/types"
 import { GenericContainer, Wait, StartedTestContainer } from "testcontainers"
 
-// TODO: remove this comment
-
 let container: StartedTestContainer | undefined
 
 export async function start(): Promise<StartedTestContainer> {

--- a/packages/server/src/sdk/app/rows/search/tests/external.spec.ts
+++ b/packages/server/src/sdk/app/rows/search/tests/external.spec.ts
@@ -26,7 +26,7 @@ describe("external search", () => {
   const rows: Row[] = []
 
   beforeAll(async () => {
-    const container = await new GenericContainer("mysql")
+    const container = await new GenericContainer("mysql:8.3")
       .withExposedPorts(3306)
       .withEnvironment({
         MYSQL_ROOT_PASSWORD: "admin",

--- a/qa-core/src/integrations/external-schema/mysql.integration.spec.ts
+++ b/qa-core/src/integrations/external-schema/mysql.integration.spec.ts
@@ -6,7 +6,7 @@ describe("datasource validators", () => {
     let config: any
 
     beforeAll(async () => {
-      const container = await new GenericContainer("mysql")
+      const container = await new GenericContainer("mysql:8.3")
         .withExposedPorts(3306)
         .withEnv("MYSQL_ROOT_PASSWORD", "admin")
         .withEnv("MYSQL_DATABASE", "db")

--- a/qa-core/src/integrations/external-schema/postgres.integration.spec.ts
+++ b/qa-core/src/integrations/external-schema/postgres.integration.spec.ts
@@ -17,7 +17,7 @@ describe("getExternalSchema", () => {
     }
 
     beforeAll(async () => {
-      const container = await new GenericContainer("postgres:13.12")
+      const container = await new GenericContainer("postgres:16.1-bullseye")
         .withExposedPorts(5432)
         .withEnv("POSTGRES_PASSWORD", "password")
         .start()

--- a/qa-core/src/integrations/validators/mongo.integration.spec.ts
+++ b/qa-core/src/integrations/validators/mongo.integration.spec.ts
@@ -26,7 +26,7 @@ describe("datasource validators", () => {
     beforeAll(async () => {
       const user = generator.name()
       const password = generator.hash()
-      const container = await new GenericContainer("mongo")
+      const container = await new GenericContainer("mongo:7.0-jammy")
         .withExposedPorts(27017)
         .withEnv("MONGO_INITDB_ROOT_USERNAME", user)
         .withEnv("MONGO_INITDB_ROOT_PASSWORD", password)

--- a/qa-core/src/integrations/validators/mssql.integration.spec.ts
+++ b/qa-core/src/integrations/validators/mssql.integration.spec.ts
@@ -13,7 +13,7 @@ describe("datasource validators", () => {
 
     beforeAll(async () => {
       const container = await new GenericContainer(
-        "mcr.microsoft.com/mssql/server"
+        "mcr.microsoft.com/mssql/server:2022-latest"
       )
         .withExposedPorts(1433)
         .withEnv("ACCEPT_EULA", "Y")

--- a/qa-core/src/integrations/validators/mysql.integration.spec.ts
+++ b/qa-core/src/integrations/validators/mysql.integration.spec.ts
@@ -7,7 +7,7 @@ describe("datasource validators", () => {
     let port: number
 
     beforeAll(async () => {
-      const container = await new GenericContainer("mysql")
+      const container = await new GenericContainer("mysql:8.3")
         .withExposedPorts(3306)
         .withEnv("MYSQL_ROOT_PASSWORD", "admin")
         .withEnv("MYSQL_DATABASE", "db")

--- a/qa-core/src/integrations/validators/postgres.integration.spec.ts
+++ b/qa-core/src/integrations/validators/postgres.integration.spec.ts
@@ -9,7 +9,7 @@ describe("datasource validators", () => {
     let port: number
 
     beforeAll(async () => {
-      const container = await new GenericContainer("postgres")
+      const container = await new GenericContainer("postgres:16.1-bullseye")
         .withExposedPorts(5432)
         .withEnv("POSTGRES_PASSWORD", "password")
         .start()


### PR DESCRIPTION
## Description

We've seen an increasing amount of flakiness in tests, usually around mssql tests. I have a theory this might be due to pulling images during tests, so this PR does 2 things:

- Enables debug logging for testcontainers in the `packages/server` tests. These logs are quite verbose, but not to an absurd degree. My plan is to leave them on a while in case we see more flakes, and I can have a look to see what's going on.
- Does a `docker pull` for all of the images we use in the `packages/server` tests _before_ the tests run. This is so that we aren't pulling during the tests, as I suspect this uses up time in the timeout and is the cause of the timeouts we see.