### PR TITLE
Fix additional scrollbar appearing when hiding binding panels

### DIFF
--- a/packages/builder/src/components/common/bindings/BindingPanel.svelte
+++ b/packages/builder/src/components/common/bindings/BindingPanel.svelte
@@ -371,6 +371,7 @@
 <style>
   .binding-panel {
     height: 100%;
+    overflow: hidden;
   }
   .binding-panel,
   .tabs {


### PR DESCRIPTION
## Description
Tiny fix for a recent leftover from fixing drawer overflow. This just removes an additional scrollbar that currently appears if you hide any side bars when editing bindings.

