### PR TITLE
Better datasource default hosts

### DIFF
--- a/packages/server/src/integrations/couchdb.ts
+++ b/packages/server/src/integrations/couchdb.ts
@@ -9,6 +9,7 @@ import {
   QueryType,
 } from "@budibase/types"
 import { db as dbCore } from "@budibase/backend-core"
+import { HOST_ADDRESS } from "./utils"
 
 interface CouchDBConfig {
   url: string
@@ -28,7 +29,7 @@ const SCHEMA: Integration = {
     url: {
       type: DatasourceFieldType.STRING,
       required: true,
-      default: "http://localhost:5984",
+      default: `http://${HOST_ADDRESS}:5984`,
     },
     database: {
       type: DatasourceFieldType.STRING,

--- a/packages/server/src/integrations/elasticsearch.ts
+++ b/packages/server/src/integrations/elasticsearch.ts
@@ -8,6 +8,7 @@ import {
 } from "@budibase/types"
 
 import { Client, ClientOptions } from "@elastic/elasticsearch"
+import { HOST_ADDRESS } from "./utils"
 
 interface ElasticsearchConfig {
   url: string
@@ -29,7 +30,7 @@ const SCHEMA: Integration = {
     url: {
       type: DatasourceFieldType.STRING,
       required: true,
-      default: "http://localhost:9200",
+      default: `http://${HOST_ADDRESS}:9200`,
     },
     ssl: {
       type: DatasourceFieldType.BOOLEAN,

--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -22,6 +22,7 @@ import {
   finaliseExternalTables,
   SqlClient,
   checkExternalTables,
+  HOST_ADDRESS,
 } from "./utils"
 import Sql from "./base/sql"
 import { MSSQLTablesResponse, MSSQLColumn } from "./base/types"
@@ -88,7 +89,6 @@ const SCHEMA: Integration = {
     user: {
       type: DatasourceFieldType.STRING,
       required: true,
-      default: "localhost",
     },
     password: {
       type: DatasourceFieldType.PASSWORD,
@@ -96,7 +96,7 @@ const SCHEMA: Integration = {
     },
     server: {
       type: DatasourceFieldType.STRING,
-      default: "localhost",
+      default: HOST_ADDRESS,
     },
     port: {
       type: DatasourceFieldType.NUMBER,

--- a/packages/server/src/integrations/mongodb.ts
+++ b/packages/server/src/integrations/mongodb.ts
@@ -22,6 +22,7 @@ import {
   InsertManyResult,
 } from "mongodb"
 import environment from "../environment"
+import { HOST_ADDRESS } from "./utils"
 
 export interface MongoDBConfig {
   connectionString: string
@@ -51,7 +52,7 @@ const getSchema = () => {
       connectionString: {
         type: DatasourceFieldType.STRING,
         required: true,
-        default: "mongodb://localhost:27017",
+        default: `mongodb://${HOST_ADDRESS}:27017`,
         display: "Connection string",
       },
       db: {

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -21,6 +21,7 @@ import {
   generateColumnDefinition,
   finaliseExternalTables,
   checkExternalTables,
+  HOST_ADDRESS,
 } from "./utils"
 import dayjs from "dayjs"
 import { NUMBER_REGEX } from "../utilities"
@@ -49,7 +50,7 @@ const SCHEMA: Integration = {
   datasource: {
     host: {
       type: DatasourceFieldType.STRING,
-      default: "localhost",
+      default: HOST_ADDRESS,
       required: true,
     },
     port: {

--- a/packages/server/src/integrations/oracle.ts
+++ b/packages/server/src/integrations/oracle.ts
@@ -22,6 +22,7 @@ import {
   finaliseExternalTables,
   getSqlQuery,
   SqlClient,
+  HOST_ADDRESS,
 } from "./utils"
 import Sql from "./base/sql"
 import {
@@ -63,7 +64,7 @@ const SCHEMA: Integration = {
   datasource: {
     host: {
       type: DatasourceFieldType.STRING,
-      default: "localhost",
+      default: HOST_ADDRESS,
       required: true,
     },
     port: {

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -21,6 +21,7 @@ import {
   finaliseExternalTables,
   SqlClient,
   checkExternalTables,
+  HOST_ADDRESS,
 } from "./utils"
 import Sql from "./base/sql"
 import { PostgresColumn } from "./base/types"
@@ -72,7 +73,7 @@ const SCHEMA: Integration = {
   datasource: {
     host: {
       type: DatasourceFieldType.STRING,
-      default: "localhost",
+      default: HOST_ADDRESS,
       required: true,
     },
     port: {

--- a/packages/server/src/integrations/redis.ts
+++ b/packages/server/src/integrations/redis.ts
@@ -6,6 +6,7 @@ import {
   QueryType,
 } from "@budibase/types"
 import Redis from "ioredis"
+import { HOST_ADDRESS } from "./utils"
 
 interface RedisConfig {
   host: string
@@ -28,7 +29,7 @@ const SCHEMA: Integration = {
     host: {
       type: DatasourceFieldType.STRING,
       required: true,
-      default: "localhost",
+      default: HOST_ADDRESS,
     },
     port: {
       type: DatasourceFieldType.NUMBER,

--- a/packages/server/src/integrations/utils.ts
+++ b/packages/server/src/integrations/utils.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_BB_DATASOURCE_ID,
 } from "../constants"
 import { helpers } from "@budibase/shared-core"
+import env from "../environment"
 
 const DOUBLE_SEPARATOR = `${SEPARATOR}${SEPARATOR}`
 const ROW_ID_REGEX = /^\[.*]$/g
@@ -91,6 +92,14 @@ export enum SqlClient {
   MY_SQL = "mysql2",
   ORACLE = "oracledb",
 }
+
+const isCloud = env.isProd() && !env.SELF_HOSTED
+const isSelfHost = env.isProd() && env.SELF_HOSTED
+export const HOST_ADDRESS = isSelfHost
+  ? "host.docker.internal"
+  : isCloud
+  ? ""
+  : "localhost"
 
 export function isExternalTableID(tableId: string) {
   return tableId.includes(DocumentType.DATASOURCE)


### PR DESCRIPTION
## Description
An issue which comes up relatively often is that localhost is not a valid option for a datasource in our cloud and our self host environments. Fixing this so it only shows this in development.

This quickly helps to address a common support issue, that people are not aware of the `host.docker.internal` network address that should be used in docker containers to connect back to the host.

It also removes any default from the cloud, as localhost will never work, and we really don't know where the database will be hosted - ideally we could probably validate this further in the frontend to say that localhost will never work for the cloud.