### PR TITLE
Clean and populate url for single attachment

### DIFF
--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -155,6 +155,11 @@ export async function inputProcessing(
           delete attachment.url
         })
       }
+    } else if (field.type === FieldType.ATTACHMENT_SINGLE) {
+      const attachment = clonedRow[key]
+      if (attachment?.url) {
+        delete clonedRow[key].url
+      }
     }
 
     if (field.type === FieldType.BB_REFERENCE && value) {
@@ -226,6 +231,16 @@ export async function outputProcessing<T extends Row[] | Row>(
             attachment.url = objectStore.getAppFileUrl(attachment.key)
           }
         })
+      }
+    } else if (column.type === FieldType.ATTACHMENT_SINGLE) {
+      for (let row of enriched) {
+        if (!row[property]) {
+          continue
+        }
+
+        if (!row[property].url) {
+          row[property].url = objectStore.getAppFileUrl(row[property].key)
+        }
       }
     } else if (
       !opts.skipBBReferences &&

--- a/packages/server/src/utilities/schema.ts
+++ b/packages/server/src/utilities/schema.ts
@@ -54,7 +54,7 @@ export function validate(rows: Rows, schema: TableSchema): ValidationResults {
         type: columnType,
         subtype: columnSubtype,
         autocolumn: isAutoColumn,
-      } = schema[columnName]
+      } = schema[columnName] || {}
 
       // If the column had an invalid value we don't want to override it
       if (results.schemaValidation[columnName] === false) {
@@ -147,6 +147,12 @@ export function parse(rows: Rows, schema: TableSchema): Rows {
               utils.unreachable(columnSubtype)
           }
         }
+      } else if (
+        (columnType === FieldType.ATTACHMENTS ||
+          columnType === FieldType.ATTACHMENT_SINGLE) &&
+        typeof columnData === "string"
+      ) {
+        parsedRow[columnName] = parseCsvExport(columnData)
       } else {
         parsedRow[columnName] = columnData
       }


### PR DESCRIPTION
## Description
Do not persist url for single attachment columns. These are populated for display only, and persisting it to db causes issues with features such as import/export