### PR TITLE
Correct types accepted / returned through the view API.

### DIFF
--- a/packages/server/src/api/controllers/view/viewsV2.ts
+++ b/packages/server/src/api/controllers/view/viewsV2.ts
@@ -41,7 +41,7 @@ async function parseSchema(view: CreateViewRequest) {
 
 export async function get(ctx: Ctx<void, ViewResponse>) {
   ctx.body = {
-    data: await sdk.views.get(ctx.params.viewId, { enriched: true }),
+    data: await sdk.views.get(ctx.params.viewId),
   }
 }
 

--- a/packages/server/src/api/controllers/view/viewsV2.ts
+++ b/packages/server/src/api/controllers/view/viewsV2.ts
@@ -6,6 +6,7 @@ import {
   UIFieldMetadata,
   UpdateViewRequest,
   ViewResponse,
+  ViewResponseEnriched,
   ViewV2,
 } from "@budibase/types"
 import { builderSocket, gridSocket } from "../../../websockets"
@@ -39,9 +40,9 @@ async function parseSchema(view: CreateViewRequest) {
   return finalViewSchema
 }
 
-export async function get(ctx: Ctx<void, ViewResponse>) {
+export async function get(ctx: Ctx<void, ViewResponseEnriched>) {
   ctx.body = {
-    data: await sdk.views.get(ctx.params.viewId),
+    data: await sdk.views.getEnriched(ctx.params.viewId),
   }
 }
 

--- a/packages/server/src/sdk/app/tables/getters.ts
+++ b/packages/server/src/sdk/app/tables/getters.ts
@@ -142,7 +142,9 @@ export function enrichViewSchemas(table: Table): TableResponse {
   return {
     ...table,
     views: Object.values(table.views ?? [])
-      .map(v => sdk.views.enrichSchema(v, table.schema))
+      .map(v =>
+        sdk.views.isV2(v) ? sdk.views.enrichSchema(v, table.schema) : v
+      )
       .reduce((p, v) => {
         p[v.name!] = v
         return p

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -8,7 +8,6 @@ import {
 import { db as dbCore } from "@budibase/backend-core"
 import { cloneDeep } from "lodash"
 
-import sdk from "../../../sdk"
 import * as utils from "../../../db/utils"
 import { isExternalTableID } from "../../../integrations/utils"
 
@@ -64,10 +63,6 @@ export function enrichSchema(
   view: ViewV2,
   tableSchema: TableSchema
 ): ViewV2Enriched {
-  if (!sdk.views.isV2(view)) {
-    return view
-  }
-
   let schema = cloneDeep(tableSchema)
   const anyViewOrder = Object.values(view.schema || {}).some(
     ui => ui.order != null

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -1,4 +1,10 @@
-import { RenameColumn, TableSchema, View, ViewV2 } from "@budibase/types"
+import {
+  RenameColumn,
+  TableSchema,
+  View,
+  ViewV2,
+  ViewV2Enriched,
+} from "@budibase/types"
 import { db as dbCore } from "@budibase/backend-core"
 import { cloneDeep } from "lodash"
 
@@ -16,12 +22,14 @@ function pickApi(tableId: any) {
   return internal
 }
 
-export async function get(
-  viewId: string,
-  opts?: { enriched: boolean }
-): Promise<ViewV2> {
+export async function get(viewId: string): Promise<ViewV2> {
   const { tableId } = utils.extractViewInfoFromID(viewId)
-  return pickApi(tableId).get(viewId, opts)
+  return pickApi(tableId).get(viewId)
+}
+
+export async function getEnriched(viewId: string): Promise<ViewV2Enriched> {
+  const { tableId } = utils.extractViewInfoFromID(viewId)
+  return pickApi(tableId).getEnriched(viewId)
 }
 
 export async function create(
@@ -52,7 +60,10 @@ export function allowedFields(view: View | ViewV2) {
   ]
 }
 
-export function enrichSchema(view: View | ViewV2, tableSchema: TableSchema) {
+export function enrichSchema(
+  view: ViewV2,
+  tableSchema: TableSchema
+): ViewV2Enriched {
   if (!sdk.views.isV2(view)) {
     return view
   }

--- a/packages/server/src/sdk/app/views/internal.ts
+++ b/packages/server/src/sdk/app/views/internal.ts
@@ -1,26 +1,30 @@
-import { ViewV2 } from "@budibase/types"
+import { ViewV2, ViewV2Enriched } from "@budibase/types"
 import { context, HTTPError } from "@budibase/backend-core"
 
 import sdk from "../../../sdk"
 import * as utils from "../../../db/utils"
 import { enrichSchema, isV2 } from "."
 
-export async function get(
-  viewId: string,
-  opts?: { enriched: boolean }
-): Promise<ViewV2> {
+export async function get(viewId: string): Promise<ViewV2> {
   const { tableId } = utils.extractViewInfoFromID(viewId)
   const table = await sdk.tables.getTable(tableId)
-  const views = Object.values(table.views!)
-  const found = views.find(v => isV2(v) && v.id === viewId)
+  const views = Object.values(table.views!).filter(isV2)
+  const found = views.find(v => v.id === viewId)
   if (!found) {
     throw new Error("No view found")
   }
-  if (opts?.enriched) {
-    return enrichSchema(found, table.schema) as ViewV2
-  } else {
-    return found as ViewV2
+  return found
+}
+
+export async function getEnriched(viewId: string): Promise<ViewV2Enriched> {
+  const { tableId } = utils.extractViewInfoFromID(viewId)
+  const table = await sdk.tables.getTable(tableId)
+  const views = Object.values(table.views!).filter(isV2)
+  const found = views.find(v => v.id === viewId)
+  if (!found) {
+    throw new Error("No view found")
   }
+  return enrichSchema(found, table.schema)
 }
 
 export async function create(

--- a/packages/server/src/tests/utilities/api/viewV2.ts
+++ b/packages/server/src/tests/utilities/api/viewV2.ts
@@ -4,9 +4,9 @@ import {
   ViewV2,
   SearchViewRowRequest,
   PaginatedSearchRowResponse,
-  ViewV2Enriched,
 } from "@budibase/types"
 import { Expectations, TestAPI } from "./base"
+import sdk from "../../../sdk"
 
 export class ViewV2API extends TestAPI {
   create = async (
@@ -44,10 +44,10 @@ export class ViewV2API extends TestAPI {
     return await this._delete(`/api/v2/views/${viewId}`, { expectations: exp })
   }
 
-  get = async (viewId: string, expectations?: Expectations) => {
-    return await this._get<ViewV2Enriched>(`/api/v2/views/${viewId}`, {
-      expectations,
-    })
+  get = async (viewId: string) => {
+    return await this.config.doInContext(this.config.getAppId(), () =>
+      sdk.views.get(viewId)
+    )
   }
 
   search = async (

--- a/packages/server/src/tests/utilities/api/viewV2.ts
+++ b/packages/server/src/tests/utilities/api/viewV2.ts
@@ -4,9 +4,9 @@ import {
   ViewV2,
   SearchViewRowRequest,
   PaginatedSearchRowResponse,
+  ViewV2Enriched,
 } from "@budibase/types"
 import { Expectations, TestAPI } from "./base"
-import sdk from "../../../sdk"
 
 export class ViewV2API extends TestAPI {
   create = async (
@@ -44,10 +44,10 @@ export class ViewV2API extends TestAPI {
     return await this._delete(`/api/v2/views/${viewId}`, { expectations: exp })
   }
 
-  get = async (viewId: string) => {
-    return await this.config.doInContext(this.config.appId, () =>
-      sdk.views.get(viewId)
-    )
+  get = async (viewId: string, expectations?: Expectations) => {
+    return await this._get<ViewV2Enriched>(`/api/v2/views/${viewId}`, {
+      expectations,
+    })
   }
 
   search = async (

--- a/packages/types/src/api/web/app/table.ts
+++ b/packages/types/src/api/web/app/table.ts
@@ -3,16 +3,11 @@ import {
   Row,
   Table,
   TableRequest,
-  TableSchema,
   View,
-  ViewV2,
+  ViewV2Enriched,
 } from "../../../documents"
 
-interface ViewV2Response extends ViewV2 {
-  schema: TableSchema
-}
-
-export type TableViewsResponse = { [key: string]: View | ViewV2Response }
+export type TableViewsResponse = { [key: string]: View | ViewV2Enriched }
 
 export interface TableResponse extends Table {
   views?: TableViewsResponse

--- a/packages/types/src/api/web/app/view.ts
+++ b/packages/types/src/api/web/app/view.ts
@@ -1,14 +1,13 @@
-import { ViewV2, UIFieldMetadata } from "../../../documents"
+import { ViewV2, ViewV2Enriched } from "../../../documents"
 
 export interface ViewResponse {
   data: ViewV2
 }
 
-export interface CreateViewRequest
-  extends Omit<ViewV2, "version" | "id" | "schema"> {
-  schema?: Record<string, UIFieldMetadata>
+export interface ViewResponseEnriched {
+  data: ViewV2Enriched
 }
 
-export interface UpdateViewRequest extends Omit<ViewV2, "schema"> {
-  schema?: Record<string, UIFieldMetadata>
-}
+export interface CreateViewRequest extends Omit<ViewV2, "version" | "id"> {}
+
+export interface UpdateViewRequest extends ViewV2 {}

--- a/packages/types/src/documents/app/view.ts
+++ b/packages/types/src/documents/app/view.ts
@@ -1,5 +1,5 @@
 import { SearchFilter, SortOrder, SortType } from "../../api"
-import { UIFieldMetadata } from "./table"
+import { TableSchema, UIFieldMetadata } from "./table"
 import { Document } from "../document"
 import { DBView } from "../../sdk"
 
@@ -46,6 +46,10 @@ export interface ViewV2 {
     type?: SortType
   }
   schema?: Record<string, UIFieldMetadata>
+}
+
+export interface ViewV2Enriched extends ViewV2 {
+  schema?: TableSchema
 }
 
 export type ViewSchema = ViewCountOrSumSchema | ViewStatisticsSchema


### PR DESCRIPTION
## Description

While working on https://github.com/Budibase/budibase/pull/13419 I ran into a problem caused by the `ViewV2` type not quite being correct. It's being used to represent both the request type and response type from various endpoints, but it's only correct for requests. Responses are sometimes "enriched" and have a wider variety of stuff in them.

This PR fixes that.