### PR TITLE
Unify icons usage in builder

### DIFF
--- a/packages/builder/src/constants/backend/index.js
+++ b/packages/builder/src/constants/backend/index.js
@@ -5,6 +5,8 @@ import {
   AutoFieldSubType,
   Hosting,
 } from "@budibase/types"
+import { Constants } from "@budibase/frontend-core"
+const { TypeIconMap } = Constants
 
 export { RelationshipType } from "@budibase/types"
 
@@ -22,7 +24,7 @@ export const FIELDS = {
   STRING: {
     name: "Text",
     type: FieldType.STRING,
-    icon: "Text",
+    icon: TypeIconMap[FieldType.STRING],
     constraints: {
       type: "string",
       length: {},
@@ -32,7 +34,7 @@ export const FIELDS = {
   BARCODEQR: {
     name: "Barcode/QR",
     type: FieldType.BARCODEQR,
-    icon: "Camera",
+    icon: TypeIconMap[FieldType.BARCODEQR],
     constraints: {
       type: "string",
       length: {},
@@ -42,7 +44,7 @@ export const FIELDS = {
   LONGFORM: {
     name: "Long Form Text",
     type: FieldType.LONGFORM,
-    icon: "TextAlignLeft",
+    icon: TypeIconMap[FieldType.LONGFORM],
     constraints: {
       type: "string",
       length: {},
@@ -52,7 +54,7 @@ export const FIELDS = {
   OPTIONS: {
     name: "Options",
     type: FieldType.OPTIONS,
-    icon: "Dropdown",
+    icon: TypeIconMap[FieldType.OPTIONS],
     constraints: {
       type: "string",
       presence: false,
@@ -62,7 +64,7 @@ export const FIELDS = {
   ARRAY: {
     name: "Multi-select",
     type: FieldType.ARRAY,
-    icon: "Duplicate",
+    icon: TypeIconMap[FieldType.ARRAY],
     constraints: {
       type: "array",
       presence: false,
@@ -72,7 +74,7 @@ export const FIELDS = {
   NUMBER: {
     name: "Number",
     type: FieldType.NUMBER,
-    icon: "123",
+    icon: TypeIconMap[FieldType.NUMBER],
     constraints: {
       type: "number",
       presence: false,
@@ -82,12 +84,12 @@ export const FIELDS = {
   BIGINT: {
     name: "BigInt",
     type: FieldType.BIGINT,
-    icon: "TagBold",
+    icon: TypeIconMap[FieldType.BIGINT],
   },
   BOOLEAN: {
     name: "Boolean",
     type: FieldType.BOOLEAN,
-    icon: "Boolean",
+    icon: TypeIconMap[FieldType.BOOLEAN],
     constraints: {
       type: "boolean",
       presence: false,
@@ -96,7 +98,7 @@ export const FIELDS = {
   DATETIME: {
     name: "Date/Time",
     type: FieldType.DATETIME,
-    icon: "Calendar",
+    icon: TypeIconMap[FieldType.DATETIME],
     constraints: {
       type: "string",
       length: {},
@@ -110,7 +112,7 @@ export const FIELDS = {
   ATTACHMENT: {
     name: "Attachment",
     type: FieldType.ATTACHMENT,
-    icon: "Folder",
+    icon: TypeIconMap[FieldType.ATTACHMENT],
     constraints: {
       type: "array",
       presence: false,
@@ -119,7 +121,7 @@ export const FIELDS = {
   LINK: {
     name: "Relationship",
     type: FieldType.LINK,
-    icon: "Link",
+    icon: TypeIconMap[FieldType.LINK],
     constraints: {
       type: "array",
       presence: false,
@@ -128,19 +130,19 @@ export const FIELDS = {
   AUTO: {
     name: "Auto Column",
     type: FieldType.AUTO,
-    icon: "MagicWand",
+    icon: TypeIconMap[FieldType.AUTO],
     constraints: {},
   },
   FORMULA: {
     name: "Formula",
     type: FieldType.FORMULA,
-    icon: "Calculator",
+    icon: TypeIconMap[FieldType.FORMULA],
     constraints: {},
   },
   JSON: {
     name: "JSON",
     type: FieldType.JSON,
-    icon: "Brackets",
+    icon: TypeIconMap[FieldType.JSON],
     constraints: {
       type: "object",
       presence: false,
@@ -150,13 +152,13 @@ export const FIELDS = {
     name: "User",
     type: FieldType.BB_REFERENCE,
     subtype: FieldSubtype.USER,
-    icon: "User",
+    icon: TypeIconMap[FieldType.USER],
   },
   USERS: {
     name: "Users",
     type: FieldType.BB_REFERENCE,
     subtype: FieldSubtype.USERS,
-    icon: "User",
+    icon: TypeIconMap[FieldType.USERS],
     constraints: {
       type: "array",
     },

--- a/packages/builder/src/constants/backend/index.js
+++ b/packages/builder/src/constants/backend/index.js
@@ -6,6 +6,7 @@ import {
   Hosting,
 } from "@budibase/types"
 import { Constants } from "@budibase/frontend-core"
+
 const { TypeIconMap } = Constants
 
 export { RelationshipType } from "@budibase/types"

--- a/packages/builder/src/stores/builder/tests/sortedIntegrations.test.js
+++ b/packages/builder/src/stores/builder/tests/sortedIntegrations.test.js
@@ -6,7 +6,10 @@ import { derived } from "svelte/store"
 import { integrations } from "stores/builder/integrations"
 
 vi.mock("svelte/store", () => ({
-  derived: vi.fn(() => {}),
+  derived: vi.fn(),
+  writable: vi.fn(() => ({
+    subscribe: vi.fn(),
+  })),
 }))
 
 vi.mock("stores/builder/integrations", () => ({ integrations: vi.fn() }))

--- a/packages/frontend-core/src/components/grid/lib/utils.js
+++ b/packages/frontend-core/src/components/grid/lib/utils.js
@@ -1,30 +1,10 @@
-import { FieldType, FieldTypeSubtypes } from "@budibase/types"
+import { TypeIconMap } from "../../../constants"
 
 export const getColor = (idx, opacity = 0.3) => {
   if (idx == null || idx === -1) {
     idx = 0
   }
   return `hsla(${((idx + 1) * 222) % 360}, 90%, 75%, ${opacity})`
-}
-
-const TypeIconMap = {
-  [FieldType.STRING]: "Text",
-  [FieldType.OPTIONS]: "Dropdown",
-  [FieldType.DATETIME]: "Date",
-  [FieldType.BARCODEQR]: "Camera",
-  [FieldType.LONGFORM]: "TextAlignLeft",
-  [FieldType.ARRAY]: "Dropdown",
-  [FieldType.NUMBER]: "123",
-  [FieldType.BOOLEAN]: "Boolean",
-  [FieldType.ATTACHMENT]: "AppleFiles",
-  [FieldType.LINK]: "DataCorrelated",
-  [FieldType.FORMULA]: "Calculator",
-  [FieldType.JSON]: "Brackets",
-  [FieldType.BIGINT]: "TagBold",
-  [FieldType.BB_REFERENCE]: {
-    [FieldTypeSubtypes.BB_REFERENCE.USER]: "User",
-    [FieldTypeSubtypes.BB_REFERENCE.USERS]: "UserGroup",
-  },
 }
 
 export const getColumnIcon = column => {

--- a/packages/frontend-core/src/constants.js
+++ b/packages/frontend-core/src/constants.js
@@ -121,7 +121,7 @@ export const TypeIconMap = {
   [FieldType.DATETIME]: "Date",
   [FieldType.BARCODEQR]: "Camera",
   [FieldType.LONGFORM]: "TextAlignLeft",
-  [FieldType.ARRAY]: "Dropdown",
+  [FieldType.ARRAY]: "Duplicate",
   [FieldType.NUMBER]: "123",
   [FieldType.BOOLEAN]: "Boolean",
   [FieldType.ATTACHMENT]: "AppleFiles",

--- a/packages/frontend-core/src/constants.js
+++ b/packages/frontend-core/src/constants.js
@@ -4,6 +4,7 @@
 export { OperatorOptions, SqlNumberTypeRangeMap } from "@budibase/shared-core"
 export { Feature as Features } from "@budibase/types"
 import { BpmCorrelationKey } from "@budibase/shared-core"
+import { FieldType, FieldTypeSubtypes } from "@budibase/types"
 
 // Cookie names
 export const Cookies = {
@@ -112,4 +113,26 @@ export const EventPublishType = {
 export const ContextScopes = {
   Local: "local",
   Global: "global",
+}
+
+export const TypeIconMap = {
+  [FieldType.STRING]: "Text",
+  [FieldType.OPTIONS]: "Dropdown",
+  [FieldType.DATETIME]: "Date",
+  [FieldType.BARCODEQR]: "Camera",
+  [FieldType.LONGFORM]: "TextAlignLeft",
+  [FieldType.ARRAY]: "Dropdown",
+  [FieldType.NUMBER]: "123",
+  [FieldType.BOOLEAN]: "Boolean",
+  [FieldType.ATTACHMENT]: "AppleFiles",
+  [FieldType.LINK]: "DataCorrelated",
+  [FieldType.FORMULA]: "Calculator",
+  [FieldType.JSON]: "Brackets",
+  [FieldType.BIGINT]: "TagBold",
+  [FieldType.USER]: "User",
+  [FieldType.USERS]: "UserGroup",
+  [FieldType.BB_REFERENCE]: {
+    [FieldTypeSubtypes.BB_REFERENCE.USER]: "User",
+    [FieldTypeSubtypes.BB_REFERENCE.USERS]: "UserGroup",
+  },
 }

--- a/packages/frontend-core/src/constants.js
+++ b/packages/frontend-core/src/constants.js
@@ -129,6 +129,7 @@ export const TypeIconMap = {
   [FieldType.FORMULA]: "Calculator",
   [FieldType.JSON]: "Brackets",
   [FieldType.BIGINT]: "TagBold",
+  [FieldType.AUTO]: "MagicWand",
   [FieldType.USER]: "User",
   [FieldType.USERS]: "UserGroup",
   [FieldType.BB_REFERENCE]: {

--- a/packages/frontend-core/src/constants.js
+++ b/packages/frontend-core/src/constants.js
@@ -118,7 +118,7 @@ export const ContextScopes = {
 export const TypeIconMap = {
   [FieldType.STRING]: "Text",
   [FieldType.OPTIONS]: "Dropdown",
-  [FieldType.DATETIME]: "Date",
+  [FieldType.DATETIME]: "Calendar",
   [FieldType.BARCODEQR]: "Camera",
   [FieldType.LONGFORM]: "TextAlignLeft",
   [FieldType.ARRAY]: "Duplicate",


### PR DESCRIPTION
## Description
We have some duplicated icon logic between column configuration icons and header icons. These changes unify this logic, making sure they are always in sync.

Fixing inconsistencies between grid header and the column config
1. Date time: unified to using the full calendar, used in the column confi
![image](https://github.com/Budibase/budibase/assets/15987277/1cfe8ba2-0c8f-4283-8bf0-7a2ba2540e39)

2. Attachment: unified to use the grid header one
![image](https://github.com/Budibase/budibase/assets/15987277/cf076060-ba7b-48cf-88f4-effcb6f61476)

3. Multiselect: unified to use the grid header one
![image](https://github.com/Budibase/budibase/assets/15987277/db4d909e-7a9e-45a6-a5c7-57818840e14d)

4. Relationship: unified to use the grid header one
![image](https://github.com/Budibase/budibase/assets/15987277/337acdd0-b71f-4c0b-9bd7-179aa14d54cd)

