### PR TITLE
Improving public API documentation for row search

### DIFF
--- a/packages/server/specs/openapi.json
+++ b/packages/server/specs/openapi.json
@@ -1792,7 +1792,7 @@
               },
               "contains": {
                 "type": "object",
-                "description": "Searches for a value, or set of values in an array column types (such as a multi-select), if an array of search options is provided then it must match all.",
+                "description": "Searches for a value, or set of values in array column types (such as a multi-select). If an array of search options is provided then it must match all.",
                 "example": {
                   "arrayColumn": [
                     "a",
@@ -1802,7 +1802,7 @@
               },
               "notContains": {
                 "type": "object",
-                "description": "As with the contains search, only functions for array column types, but searches for columns missing the supplied values.",
+                "description": "The logical inverse of contains. Only works on array column types. If an array of values is passed, the row must not match any of them to be returned in the response.",
                 "example": {
                   "arrayColumn": [
                     "a",
@@ -1812,7 +1812,7 @@
               },
               "containsAny": {
                 "type": "object",
-                "description": "As with the contains search, only functions for array column types, but searches for any of the provided values when given an array.",
+                "description": "As with the contains search, only works on array column types and searches for any of the provided values when given an array.",
                 "example": {
                   "arrayColumn": [
                     "a",

--- a/packages/server/specs/openapi.json
+++ b/packages/server/specs/openapi.json
@@ -853,6 +853,7 @@
                         "array",
                         "datetime",
                         "attachment",
+                        "attachment_single",
                         "link",
                         "formula",
                         "auto",
@@ -1059,6 +1060,7 @@
                             "array",
                             "datetime",
                             "attachment",
+                            "attachment_single",
                             "link",
                             "formula",
                             "auto",
@@ -1276,6 +1278,7 @@
                               "array",
                               "datetime",
                               "attachment",
+                              "attachment_single",
                               "link",
                               "formula",
                               "auto",
@@ -1752,7 +1755,7 @@
               },
               "fuzzy": {
                 "type": "object",
-                "description": "A fuzzy search, only supported by internal tables."
+                "description": "Searches for a sub-string within a string column, e.g. searching for 'dib' will match 'Budibase'."
               },
               "range": {
                 "type": "object",
@@ -1786,6 +1789,36 @@
               "oneOf": {
                 "type": "object",
                 "description": "Searches for rows which have a column value that is any of the specified values. The format of this must be columnName -> [value1, value2]."
+              },
+              "contains": {
+                "type": "object",
+                "description": "Searches for a value, or set of values in an array column types (such as a multi-select), if an array of search options is provided then it must match all.",
+                "example": {
+                  "arrayColumn": [
+                    "a",
+                    "b"
+                  ]
+                }
+              },
+              "notContains": {
+                "type": "object",
+                "description": "As with the contains search, only functions for array column types, but searches for columns missing the supplied values.",
+                "example": {
+                  "arrayColumn": [
+                    "a",
+                    "b"
+                  ]
+                }
+              },
+              "containsAny": {
+                "type": "object",
+                "description": "As with the contains search, only functions for array column types, but searches for any of the provided values when given an array.",
+                "example": {
+                  "arrayColumn": [
+                    "a",
+                    "b"
+                  ]
+                }
               }
             }
           },

--- a/packages/server/specs/openapi.yaml
+++ b/packages/server/specs/openapi.yaml
@@ -1530,25 +1530,26 @@ components:
                 [value1, value2].
             contains:
               type: object
-              description: Searches for a value, or set of values in an array column types
-                (such as a multi-select), if an array of search options is
-                provided then it must match all.
+              description: Searches for a value, or set of values in array column types (such
+                as a multi-select). If an array of search options is provided
+                then it must match all.
               example:
                 arrayColumn:
                   - a
                   - b
             notContains:
               type: object
-              description: As with the contains search, only functions for array column types,
-                but searches for columns missing the supplied values.
+              description: The logical inverse of contains. Only works on array column types.
+                If an array of values is passed, the row must not match any of
+                them to be returned in the response.
               example:
                 arrayColumn:
                   - a
                   - b
             containsAny:
               type: object
-              description: As with the contains search, only functions for array column types,
-                but searches for any of the provided values when given an array.
+              description: As with the contains search, only works on array column types and
+                searches for any of the provided values when given an array.
               example:
                 arrayColumn:
                   - a

--- a/packages/server/specs/openapi.yaml
+++ b/packages/server/specs/openapi.yaml
@@ -775,6 +775,7 @@ components:
                       - array
                       - datetime
                       - attachment
+                      - attachment_single
                       - link
                       - formula
                       - auto
@@ -940,6 +941,7 @@ components:
                           - array
                           - datetime
                           - attachment
+                          - attachment_single
                           - link
                           - formula
                           - auto
@@ -1112,6 +1114,7 @@ components:
                             - array
                             - datetime
                             - attachment
+                            - attachment_single
                             - link
                             - formula
                             - auto
@@ -1492,7 +1495,8 @@ components:
                 description: The value to search for in the column.
             fuzzy:
               type: object
-              description: A fuzzy search, only supported by internal tables.
+              description: Searches for a sub-string within a string column, e.g. searching
+                for 'dib' will match 'Budibase'.
             range:
               type: object
               description: Searches within a range, the format of this must be in the format
@@ -1524,6 +1528,31 @@ components:
               description: Searches for rows which have a column value that is any of the
                 specified values. The format of this must be columnName ->
                 [value1, value2].
+            contains:
+              type: object
+              description: Searches for a value, or set of values in an array column types
+                (such as a multi-select), if an array of search options is
+                provided then it must match all.
+              example:
+                arrayColumn:
+                  - a
+                  - b
+            notContains:
+              type: object
+              description: As with the contains search, only functions for array column types,
+                but searches for columns missing the supplied values.
+              example:
+                arrayColumn:
+                  - a
+                  - b
+            containsAny:
+              type: object
+              description: As with the contains search, only functions for array column types,
+                but searches for any of the provided values when given an array.
+              example:
+                arrayColumn:
+                  - a
+                  - b
         paginate:
           type: boolean
           description: Enables pagination, by default this is disabled.

--- a/packages/server/specs/resources/misc.ts
+++ b/packages/server/specs/resources/misc.ts
@@ -27,7 +27,8 @@ export default new Resource().setSchemas({
           },
           fuzzy: {
             type: "object",
-            description: "A fuzzy search, only supported by internal tables.",
+            description:
+              "Searches for a sub-string within a string column, e.g. searching for 'dib' will match 'Budibase'.",
           },
           range: {
             type: "object",
@@ -66,6 +67,30 @@ export default new Resource().setSchemas({
             type: "object",
             description:
               "Searches for rows which have a column value that is any of the specified values. The format of this must be columnName -> [value1, value2].",
+          },
+          contains: {
+            type: "object",
+            description:
+              "Searches for a value, or set of values in an array column types (such as a multi-select), if an array of search options is provided then it must match all.",
+            example: {
+              arrayColumn: ["a", "b"],
+            },
+          },
+          notContains: {
+            type: "object",
+            description:
+              "As with the contains search, only functions for array column types, but searches for columns missing the supplied values.",
+            example: {
+              arrayColumn: ["a", "b"],
+            },
+          },
+          containsAny: {
+            type: "object",
+            description:
+              "As with the contains search, only functions for array column types, but searches for any of the provided values when given an array.",
+            example: {
+              arrayColumn: ["a", "b"],
+            },
           },
         },
       },

--- a/packages/server/specs/resources/misc.ts
+++ b/packages/server/specs/resources/misc.ts
@@ -71,7 +71,7 @@ export default new Resource().setSchemas({
           contains: {
             type: "object",
             description:
-              "Searches for a value, or set of values in an array column types (such as a multi-select), if an array of search options is provided then it must match all.",
+              "Searches for a value, or set of values in array column types (such as a multi-select). If an array of search options is provided then it must match all.",
             example: {
               arrayColumn: ["a", "b"],
             },
@@ -79,7 +79,7 @@ export default new Resource().setSchemas({
           notContains: {
             type: "object",
             description:
-              "As with the contains search, only functions for array column types, but searches for columns missing the supplied values.",
+              "The logical inverse of contains. Only works on array column types. If an array of values is passed, the row must not match any of them to be returned in the response.",
             example: {
               arrayColumn: ["a", "b"],
             },
@@ -87,7 +87,7 @@ export default new Resource().setSchemas({
           containsAny: {
             type: "object",
             description:
-              "As with the contains search, only functions for array column types, but searches for any of the provided values when given an array.",
+              "As with the contains search, only works on array column types and searches for any of the provided values when given an array.",
             example: {
               arrayColumn: ["a", "b"],
             },

--- a/packages/server/src/definitions/openapi.ts
+++ b/packages/server/src/definitions/openapi.ts
@@ -717,17 +717,17 @@ export interface components {
         /** @description Searches for rows which have a column value that is any of the specified values. The format of this must be columnName -> [value1, value2]. */
         oneOf?: { [key: string]: unknown };
         /**
-         * @description Searches for a value, or set of values in an array column types (such as a multi-select), if an array of search options is provided then it must match all.
+         * @description Searches for a value, or set of values in array column types (such as a multi-select). If an array of search options is provided then it must match all.
          * @example [object Object]
          */
         contains?: { [key: string]: unknown };
         /**
-         * @description As with the contains search, only functions for array column types, but searches for columns missing the supplied values.
+         * @description The logical inverse of contains. Only works on array column types. If an array of values is passed, the row must not match any of them to be returned in the response.
          * @example [object Object]
          */
         notContains?: { [key: string]: unknown };
         /**
-         * @description As with the contains search, only functions for array column types, but searches for any of the provided values when given an array.
+         * @description As with the contains search, only works on array column types and searches for any of the provided values when given an array.
          * @example [object Object]
          */
         containsAny?: { [key: string]: unknown };

--- a/packages/server/src/definitions/openapi.ts
+++ b/packages/server/src/definitions/openapi.ts
@@ -273,6 +273,7 @@ export interface components {
                 | "array"
                 | "datetime"
                 | "attachment"
+                | "attachment_single"
                 | "link"
                 | "formula"
                 | "auto"
@@ -381,6 +382,7 @@ export interface components {
                   | "array"
                   | "datetime"
                   | "attachment"
+                  | "attachment_single"
                   | "link"
                   | "formula"
                   | "auto"
@@ -491,6 +493,7 @@ export interface components {
                   | "array"
                   | "datetime"
                   | "attachment"
+                  | "attachment_single"
                   | "link"
                   | "formula"
                   | "auto"
@@ -693,7 +696,7 @@ export interface components {
          * @example [object Object]
          */
         string?: { [key: string]: string };
-        /** @description A fuzzy search, only supported by internal tables. */
+        /** @description Searches for a sub-string within a string column, e.g. searching for 'dib' will match 'Budibase'. */
         fuzzy?: { [key: string]: unknown };
         /**
          * @description Searches within a range, the format of this must be in the format of an object with a "low" and "high" property.
@@ -713,6 +716,21 @@ export interface components {
         notEmpty?: { [key: string]: unknown };
         /** @description Searches for rows which have a column value that is any of the specified values. The format of this must be columnName -> [value1, value2]. */
         oneOf?: { [key: string]: unknown };
+        /**
+         * @description Searches for a value, or set of values in an array column types (such as a multi-select), if an array of search options is provided then it must match all.
+         * @example [object Object]
+         */
+        contains?: { [key: string]: unknown };
+        /**
+         * @description As with the contains search, only functions for array column types, but searches for columns missing the supplied values.
+         * @example [object Object]
+         */
+        notContains?: { [key: string]: unknown };
+        /**
+         * @description As with the contains search, only functions for array column types, but searches for any of the provided values when given an array.
+         * @example [object Object]
+         */
+        containsAny?: { [key: string]: unknown };
       };
       /** @description Enables pagination, by default this is disabled. */
       paginate?: boolean;


### PR DESCRIPTION
## Description
When looking through the search parameters to build up information about validating search inputs better on the API (https://linear.app/budibase/issue/BUDI-8165/validate-search-api-parameters-based-on-table-schema) found the public docs weren't fully up to date - fixing this.

Also generating to include the new attachment single type.