### PR TITLE
SQS prepared statement support

### DIFF
--- a/packages/backend-core/src/db/couch/DatabaseImpl.ts
+++ b/packages/backend-core/src/db/couch/DatabaseImpl.ts
@@ -12,6 +12,7 @@ import {
   isDocument,
   RowResponse,
   RowValue,
+  SqlQueryBinding,
 } from "@budibase/types"
 import { getCouchInfo } from "./connections"
 import { directCouchUrlCall } from "./utils"
@@ -248,14 +249,20 @@ export class DatabaseImpl implements Database {
     })
   }
 
-  async sql<T extends Document>(sql: string): Promise<T[]> {
+  async sql<T extends Document>(
+    sql: string,
+    parameters?: SqlQueryBinding
+  ): Promise<T[]> {
     const dbName = this.name
     const url = `/${dbName}/${SQLITE_DESIGN_DOC_ID}`
     const response = await directCouchUrlCall({
       url: `${this.couchInfo.sqlUrl}/${url}`,
       method: "POST",
       cookie: this.couchInfo.cookie,
-      body: sql,
+      body: {
+        query: sql,
+        args: parameters,
+      },
     })
     if (response.status > 300) {
       throw new Error(await response.text())

--- a/packages/backend-core/src/db/instrumentation.ts
+++ b/packages/backend-core/src/db/instrumentation.ts
@@ -13,6 +13,7 @@ import {
   DatabaseQueryOpts,
   Document,
   RowValue,
+  SqlQueryBinding,
 } from "@budibase/types"
 import tracer from "dd-trace"
 import { Writable } from "stream"
@@ -150,10 +151,13 @@ export class DDInstrumentedDatabase implements Database {
     })
   }
 
-  sql<T extends Document>(sql: string): Promise<T[]> {
+  sql<T extends Document>(
+    sql: string,
+    parameters?: SqlQueryBinding
+  ): Promise<T[]> {
     return tracer.trace("db.sql", span => {
       span?.addTags({ db_name: this.name })
-      return this.db.sql(sql)
+      return this.db.sql(sql, parameters)
     })
   }
 }

--- a/packages/server/src/sdk/app/rows/search/sqs.ts
+++ b/packages/server/src/sdk/app/rows/search/sqs.ts
@@ -11,7 +11,6 @@ import {
   SortOrder,
   SortType,
   Table,
-  SqlQuery,
 } from "@budibase/types"
 import SqlQueryBuilder from "../../../../integrations/base/sql"
 import { SqlClient } from "../../../../integrations/utils"

--- a/packages/server/src/sdk/app/rows/search/sqs.ts
+++ b/packages/server/src/sdk/app/rows/search/sqs.ts
@@ -11,6 +11,7 @@ import {
   SortOrder,
   SortType,
   Table,
+  SqlQuery,
 } from "@budibase/types"
 import SqlQueryBuilder from "../../../../integrations/base/sql"
 import { SqlClient } from "../../../../integrations/utils"
@@ -156,21 +157,21 @@ export async function search(
   try {
     const query = builder._query(request, {
       disableReturning: true,
-      disableBindings: true,
     })
 
     if (Array.isArray(query)) {
       throw new Error("SQS cannot currently handle multiple queries")
     }
 
-    let sql = query.sql
+    let sql = query.sql,
+      bindings = query.bindings
 
     // quick hack for docIds
     sql = sql.replace(/`doc1`.`rowId`/g, "`doc1.rowId`")
     sql = sql.replace(/`doc2`.`rowId`/g, "`doc2.rowId`")
 
     const db = context.getAppDB()
-    const rows = await db.sql<Row>(sql)
+    const rows = await db.sql<Row>(sql, bindings)
 
     return {
       rows: await sqlOutputProcessing(

--- a/packages/types/src/sdk/db.ts
+++ b/packages/types/src/sdk/db.ts
@@ -4,6 +4,7 @@ import {
   AnyDocument,
   Document,
   RowValue,
+  SqlQueryBinding,
   ViewTemplateOpts,
 } from "../"
 import { Writable } from "stream"
@@ -143,7 +144,10 @@ export interface Database {
     opts?: DatabasePutOpts
   ): Promise<Nano.DocumentInsertResponse>
   bulkDocs(documents: AnyDocument[]): Promise<Nano.DocumentBulkResponse[]>
-  sql<T extends Document>(sql: string): Promise<T[]>
+  sql<T extends Document>(
+    sql: string,
+    parameters?: SqlQueryBinding
+  ): Promise<T[]>
   allDocs<T extends Document | RowValue>(
     params: DatabaseQueryOpts
   ): Promise<AllDocsResponse<T>>


### PR DESCRIPTION
## Description
Adding support for SQS prepared statement API - this is supported via the `args` parameter of the SQS search API.

This is supported in the latest release of the Budibase CouchDB SQS image (ARM and x86).

Addresses: https://linear.app/budibase/issue/BUDI-7660/sqs-prepared-statement-support
