### PR TITLE
Reduce duplication in search.spec.ts

### DIFF
--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -210,61 +210,61 @@ describe.each([
       )
     },
     rows: [
-      { dob: new Date("2020-01-01").toISOString() },
-      { dob: new Date("2020-01-10").toISOString() },
+      { dob: "2020-01-01T00:00:00.000Z" },
+      { dob: "2020-01-10T00:00:00.000Z" },
     ],
     tests: [
       {
-        query: { equal: { dob: new Date("2020-01-01").toISOString() } },
-        expectToFind: [{ dob: new Date("2020-01-01").toISOString() }],
+        query: { equal: { dob: "2020-01-01T00:00:00.000Z" } },
+        expectToFind: [{ dob: "2020-01-01T00:00:00.000Z" }],
       },
       {
-        query: { equal: { dob: new Date("2020-01-02").toISOString() } },
+        query: { equal: { dob: "2020-01-02T00:00:00.000Z" } },
         expectToFind: [],
       },
       {
-        query: { notEqual: { dob: new Date("2020-01-01").toISOString() } },
-        expectToFind: [{ dob: new Date("2020-01-10").toISOString() }],
+        query: { notEqual: { dob: "2020-01-01T00:00:00.000Z" } },
+        expectToFind: [{ dob: "2020-01-10T00:00:00.000Z" }],
       },
       {
-        query: { oneOf: { dob: [new Date("2020-01-01").toISOString()] } },
-        expectToFind: [{ dob: new Date("2020-01-01").toISOString() }],
+        query: { oneOf: { dob: ["2020-01-01T00:00:00.000Z"] } },
+        expectToFind: [{ dob: "2020-01-01T00:00:00.000Z" }],
       },
       {
         query: {
           range: {
             dob: {
-              low: new Date("2020-01-01").toISOString(),
-              high: new Date("2020-01-05").toISOString(),
+              low: "2020-01-01T00:00:00.000Z",
+              high: "2020-01-05T00:00:00.000Z",
             },
           },
         },
-        expectToFind: [{ dob: new Date("2020-01-01").toISOString() }],
+        expectToFind: [{ dob: "2020-01-01T00:00:00.000Z" }],
       },
       {
         query: {
           range: {
             dob: {
-              low: new Date("2020-01-01").toISOString(),
-              high: new Date("2020-01-10").toISOString(),
+              low: "2020-01-01T00:00:00.000Z",
+              high: "2020-01-10T00:00:00.000Z",
             },
           },
         },
         expectToFind: [
-          { dob: new Date("2020-01-01").toISOString() },
-          { dob: new Date("2020-01-10").toISOString() },
+          { dob: "2020-01-01T00:00:00.000Z" },
+          { dob: "2020-01-10T00:00:00.000Z" },
         ],
       },
       {
         query: {
           range: {
             dob: {
-              low: new Date("2020-01-05").toISOString(),
-              high: new Date("2020-01-10").toISOString(),
+              low: "2020-01-05T00:00:00.000Z",
+              high: "2020-01-10T00:00:00.000Z",
             },
           },
         },
-        expectToFind: [{ dob: new Date("2020-01-10").toISOString() }],
+        expectToFind: [{ dob: "2020-01-10T00:00:00.000Z" }],
       },
     ],
   })

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -7,7 +7,6 @@ import {
   EmptyFilterOption,
   FieldType,
   RowSearchParams,
-  SortOrder,
   Table,
 } from "@budibase/types"
 
@@ -32,7 +31,6 @@ describe.each([
   const config = setup.getConfig()
 
   let envCleanup: (() => void) | undefined
-  let table: Table
   let datasource: Datasource | undefined
 
   beforeAll(async () => {


### PR DESCRIPTION
## Description

The search tests were starting to get quite repetitive, and I was noticing that the name of each test wasn't always very helpful:

![CleanShot 2024-04-11 at 11 59 37@2x](https://github.com/Budibase/budibase/assets/338027/0acc79ad-8f17-4efe-8aaa-5d0c8c51ad19)

So this PR attempts to reduce duplication as well as making the test names more descriptive (though still messier than I'm happy with):

![CleanShot 2024-04-11 at 12 00 11@2x](https://github.com/Budibase/budibase/assets/338027/44203192-cb00-402a-ae9c-830c375dd7cc)

