### PR TITLE
Ignore key action if posthog survey is focused

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ComponentList/ComponentKeyHandler.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ComponentList/ComponentKeyHandler.svelte
@@ -137,8 +137,12 @@
     const activeTag = document.activeElement?.tagName.toLowerCase()
     const inCodeEditor =
       document.activeElement?.classList?.contains("cm-content")
+    const inPosthogSurvey =
+      document.activeElement?.classList?.[0]?.startsWith("PostHogSurvey")
     if (
-      (inCodeEditor || ["input", "textarea"].indexOf(activeTag) !== -1) &&
+      (inCodeEditor ||
+        inPosthogSurvey ||
+        ["input", "textarea"].indexOf(activeTag) !== -1) &&
       e.key !== "Escape"
     ) {
       return


### PR DESCRIPTION
## Description
The design section prevents default behaviour for the backspace. Fix added to make sure the Posthog surveys are an exception.

## Screenshots
![Screenshot 2024-04-11 at 15 10 11](https://github.com/Budibase/budibase/assets/101575380/fd213263-9f66-4660-88a5-2bee2343a332)
*Make sure backspace works as expected here*

## Launchcontrol
Minor bug fix - NPS survey
