### PR TITLE
Don't attempt account portal build if OSS

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -64,10 +64,11 @@ jobs:
       - run: yarn --frozen-lockfile
 
       # Run build all the projects
-      - name: Build
-        run: |
-          yarn build:oss
-          yarn build:account-portal
+      - name: Build OSS
+        run: yarn build:oss
+      - name: Build account portal
+        run: yarn build:account-portal
+        if: inputs.run_as_oss != true
       # Check the types of the projects built via esbuild
       - name: Check types
         run: |


### PR DESCRIPTION
## Description
Fixing issue with OSS build, if the user is OSS don't attempt the account portal build.

Issue discovered by @mikesealey 