### PR TITLE
Increase the base Minio storage to 2Gi in Helm chart.

### DIFF
--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -488,7 +488,7 @@ services:
     # do this.
     url: "http://minio-service:9000"
     # -- How much storage to give Minio in its PersistentVolumeClaim.
-    storage: 100Mi
+    storage: 2Gi
     # -- If defined, storageClassName: <storageClass> If set to "-",
     # storageClassName: "", which disables dynamic provisioning If undefined
     # (the default) or set to null, no storageClassName spec is set, choosing


### PR DESCRIPTION
## Description

Increases the default Minio storage from 100Mi to 2Gi for Helm chart users. @likke812 pointed out to us that the default simply doesn't work as it's too low. Given that it doesn't work at all, I'm not worried about changing this default as anyone using this chart for real has almost certainly set their own value or isn't using Minio.

## Addresses
- https://github.com/Budibase/budibase/issues/12483

## Launchcontrol

Increases the base storage for Minio to 2Gi in our Helm chart. @likke812 made us aware that the default of 100Mi is too low, and Minio fails to start as a result. Thank you! 🙏 
