### PR TITLE
Simplify Camunda account-portal local dev setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "dev:noserver": "yarn run kill-builder && lerna run --stream dev:stack:up --ignore @budibase/account-portal-server && lerna run --stream dev --ignore @budibase/backend-core --ignore @budibase/server --ignore @budibase/worker --ignore=@budibase/account-portal-ui --ignore @budibase/account-portal-server",
     "dev:server": "yarn run kill-server && lerna run --stream dev --scope @budibase/worker --scope @budibase/server",
     "dev:accountportal": "yarn kill-accountportal && lerna run dev --stream --scope @budibase/account-portal-ui --scope @budibase/account-portal-server",
+    "dev:camunda": "./scripts/deploy-camunda.sh",
     "dev:all": "yarn run kill-all && lerna run --stream dev",
     "dev:built": "yarn run kill-all && cd packages/server && yarn dev:stack:up && cd ../../ && lerna run --stream dev:built",
     "dev:docker": "yarn build --scope @budibase/server --scope @budibase/worker && docker-compose -f hosting/docker-compose.build.yaml -f hosting/docker-compose.dev.yaml --env-file hosting/.env up --build --scale proxy-service=0",

--- a/scripts/deploy-camunda.sh
+++ b/scripts/deploy-camunda.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+yarn global add zbctl
+export ZEEBE_ADDRESS='localhost:26500'
+
+cd ../budibase-bpm
+
+is_camunda_ready() {
+    if (zbctl --insecure status 2>/dev/null) | grep -q 'Healthy'; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+docker-compose up -d
+echo "waiting for Camunda to be ready..."
+
+while is_camunda_ready -eq 0; do sleep 1; done
+
+cd src/main/resources/models
+
+echo "deploy processes..."
+zbctl deploy resource offboarding.bpmn --insecure
+zbctl deploy resource onboarding.bpmn --insecure
+
+cd ../../../../../budibase/packages/account-portal/packages/server 
+
+yarn worker:run & cd ../../../.. && yarn dev:accountportal
+
+
+


### PR DESCRIPTION
## Description
Simplifies account-portal and Camunda process development. The `yarn dev:camunda` command does the following:

- Install `zbctl` if needed
- Spin up Camunda (the **budibase-bpm** repo must be cloned to the same folder as **budibase** core repo)
- Wait for Zeebe to spin up
- Deploy the Camunda processes needed for account portal
- Run the workers needed for the Camunda processes
- Run `yarn dev:accountportal` 

## Addresses
- https://linear.app/budibase/issue/GROW-382/simplify-dev-run-in-account-portal

## Launchcontrol
Dev script
