### PR TITLE
When sending a file attachment in email fetch it directly from our object store

### DIFF
--- a/packages/backend-core/src/objectStore/objectStore.ts
+++ b/packages/backend-core/src/objectStore/objectStore.ts
@@ -535,8 +535,7 @@ export function extractBucketAndPath(
 ): { bucket: string; path: string } | null {
   const baseUrl = url.split("?")[0]
 
-  // eslint-disable-next-line no-useless-escape
-  const regex = /^\/files\/signed\/(?<bucket>[^/]+)\/(?<path>.+)$/
+  const regex = new RegExp(`^${signedFilePrefix}/(?<bucket>[^/]+)/(?<path>.+)$`)
   const match = baseUrl.match(regex)
 
   if (match && match.groups) {

--- a/packages/backend-core/src/objectStore/objectStore.ts
+++ b/packages/backend-core/src/objectStore/objectStore.ts
@@ -524,3 +524,20 @@ export async function getReadStream(
   }
   return client.getObject(params).createReadStream()
 }
+
+/*
+Given a signed url like 'files/signed/tmp-files-attachments/app_123456/myfile.txt' extract
+the bucket and the path from it
+*/
+export function extractBucketAndPath(url: string): {
+  bucket: string
+  path: string
+} {
+  const baseUrl = url.split("?")[0]
+  const parts = baseUrl.split("/")
+  parts.shift()
+  const bucket = parts[2]
+  const path = parts.slice(3).join("/")
+
+  return { bucket, path }
+}

--- a/packages/backend-core/src/objectStore/objectStore.ts
+++ b/packages/backend-core/src/objectStore/objectStore.ts
@@ -527,24 +527,22 @@ export async function getReadStream(
 }
 
 /*
-Given a signed url like 'files/signed/tmp-files-attachments/app_123456/myfile.txt' extract
+Given a signed url like '/files/signed/tmp-files-attachments/app_123456/myfile.txt' extract
 the bucket and the path from it
 */
 export function extractBucketAndPath(
   url: string
 ): { bucket: string; path: string } | null {
   const baseUrl = url.split("?")[0]
-  if (!baseUrl.startsWith(signedFilePrefix)) {
-    return null
+
+  // eslint-disable-next-line no-useless-escape
+  const regex = /^\/files\/signed\/(?<bucket>[^/]+)\/(?<path>.+)$/
+  const match = baseUrl.match(regex)
+
+  if (match && match.groups) {
+    const { bucket, path } = match.groups
+    return { bucket, path }
   }
 
-  const parts = baseUrl.split("/")
-  if (parts.length < 5) {
-    return null
-  }
-
-  const bucket = parts[3]
-  const path = parts.slice(4).join("/")
-
-  return { bucket, path }
+  return null
 }

--- a/packages/backend-core/src/objectStore/objectStore.ts
+++ b/packages/backend-core/src/objectStore/objectStore.ts
@@ -529,15 +529,23 @@ export async function getReadStream(
 Given a signed url like 'files/signed/tmp-files-attachments/app_123456/myfile.txt' extract
 the bucket and the path from it
 */
-export function extractBucketAndPath(url: string): {
-  bucket: string
-  path: string
-} {
+export function extractBucketAndPath(
+  url: string
+): { bucket: string; path: string } | null {
   const baseUrl = url.split("?")[0]
+
+  if (!baseUrl.startsWith("/files/signed/")) {
+    return null
+  }
+
   const parts = baseUrl.split("/")
-  parts.shift()
-  const bucket = parts[2]
-  const path = parts.slice(3).join("/")
+
+  if (parts.length < 5) {
+    return null
+  }
+
+  const bucket = parts[3]
+  const path = parts.slice(4).join("/")
 
   return { bucket, path }
 }

--- a/packages/backend-core/src/objectStore/objectStore.ts
+++ b/packages/backend-core/src/objectStore/objectStore.ts
@@ -533,13 +533,11 @@ export function extractBucketAndPath(
   url: string
 ): { bucket: string; path: string } | null {
   const baseUrl = url.split("?")[0]
-
   if (!baseUrl.startsWith("/files/signed/")) {
     return null
   }
 
   const parts = baseUrl.split("/")
-
   if (parts.length < 5) {
     return null
   }

--- a/packages/backend-core/src/objectStore/objectStore.ts
+++ b/packages/backend-core/src/objectStore/objectStore.ts
@@ -19,6 +19,7 @@ const streamPipeline = promisify(stream.pipeline)
 const STATE = {
   bucketCreationPromises: {},
 }
+const signedFilePrefix = "/files/signed"
 
 type ListParams = {
   ContinuationToken?: string
@@ -337,7 +338,7 @@ export function getPresignedUrl(
     const signedUrl = new URL(url)
     const path = signedUrl.pathname
     const query = signedUrl.search
-    return `/files/signed${path}${query}`
+    return `${signedFilePrefix}${path}${query}`
   }
 }
 
@@ -533,7 +534,7 @@ export function extractBucketAndPath(
   url: string
 ): { bucket: string; path: string } | null {
   const baseUrl = url.split("?")[0]
-  if (!baseUrl.startsWith("/files/signed/")) {
+  if (!baseUrl.startsWith(signedFilePrefix)) {
     return null
   }
 

--- a/packages/worker/src/api/routes/global/tests/realEmail.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/realEmail.spec.ts
@@ -2,7 +2,7 @@ jest.unmock("node-fetch")
 jest.unmock("aws-sdk")
 import { TestConfiguration } from "../../../../tests"
 import { EmailTemplatePurpose } from "../../../../constants"
-import { objectStoreTestProviders, mocks } from "@budibase/backend-core/tests"
+import { objectStoreTestProviders } from "@budibase/backend-core/tests"
 import { objectStore } from "@budibase/backend-core"
 import tk from "timekeeper"
 import { EmailAttachment } from "@budibase/types"
@@ -18,6 +18,7 @@ describe("/api/global/email", () => {
   const config = new TestConfiguration()
 
   beforeAll(async () => {
+    tk.reset()
     await objectStoreTestProviders.minio.start()
     await config.beforeAll()
   })
@@ -99,7 +100,6 @@ describe("/api/global/email", () => {
   })
 
   it("should be able to send an email with attachments", async () => {
-    tk.reset()
     let bucket = "testbucket"
     let filename = "test.txt"
     await objectStore.upload({
@@ -117,7 +117,6 @@ describe("/api/global/email", () => {
       url: presignedUrl,
       filename,
     }
-    tk.freeze(mocks.date.MOCK_DATE)
     await sendRealEmail(EmailTemplatePurpose.WELCOME, [attachmentObject])
   })
 })

--- a/packages/worker/src/api/routes/global/tests/realEmail.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/realEmail.spec.ts
@@ -114,7 +114,7 @@ describe("/api/global/email", () => {
     )
 
     let attachmentObject = {
-      url: env.MINIO_URL + presignedUrl.split("files/signed")[1],
+      url: presignedUrl,
       filename,
     }
     tk.freeze(mocks.date.MOCK_DATE)

--- a/packages/worker/src/api/routes/global/tests/realEmail.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/realEmail.spec.ts
@@ -3,7 +3,7 @@ jest.unmock("aws-sdk")
 import { TestConfiguration } from "../../../../tests"
 import { EmailTemplatePurpose } from "../../../../constants"
 import { objectStoreTestProviders, mocks } from "@budibase/backend-core/tests"
-import { objectStore, env } from "@budibase/backend-core"
+import { objectStore } from "@budibase/backend-core"
 import tk from "timekeeper"
 import { EmailAttachment } from "@budibase/types"
 

--- a/packages/worker/src/utilities/email.ts
+++ b/packages/worker/src/utilities/email.ts
@@ -170,7 +170,6 @@ export async function sendEmail(
         const isFullyFormedUrl =
           attachment.url.startsWith("http://") ||
           attachment.url.startsWith("https://")
-
         if (isFullyFormedUrl) {
           const response = await fetch(attachment.url)
           if (!response.ok) {

--- a/packages/worker/src/utilities/email.ts
+++ b/packages/worker/src/utilities/email.ts
@@ -4,12 +4,7 @@ import { getTemplateByPurpose, EmailTemplates } from "../constants/templates"
 import { getSettingsTemplateContext } from "./templates"
 import { processString } from "@budibase/string-templates"
 import { User, SendEmailOpts, SMTPInnerConfig } from "@budibase/types"
-import {
-  configs,
-  cache,
-  context as appContext,
-  objectStore,
-} from "@budibase/backend-core"
+import { configs, cache, objectStore } from "@budibase/backend-core"
 import ical from "ical-generator"
 import fetch from "node-fetch"
 import path from "path"
@@ -190,7 +185,11 @@ export async function sendEmail(
           }
         } else {
           const url = attachment.url
-          const { bucket, path } = objectStore.extractBucketAndPath(url)
+          const result = objectStore.extractBucketAndPath(url)
+          if (result === null) {
+            throw new Error("Invalid signed URL")
+          }
+          const { bucket, path } = result
           const readStream = await objectStore.getReadStream(bucket, path)
           const fallbackFilename = path.split("/").pop() || ""
           return {


### PR DESCRIPTION
## Description
Previously we were fetching the signed url directly and attaching the body of the response to the nodemailer object, this was proving problematic in environments where we could not be sure of the platform URL. So updated this section of the code to fetch the object directly from the object store and attaching the readStream from it to the nodemailer object. 

This strategy also allows for a combination of fully formed links and the signed url string that gets returned for our external query connector.  
