### PR TITLE
Add not nullable constraints to SQL tables

### DIFF
--- a/packages/server/src/integrations/base/sqlTable.ts
+++ b/packages/server/src/integrations/base/sqlTable.ts
@@ -129,7 +129,12 @@ function generateSchema(
         break
     }
 
-    if (columnBuilder && column.constraints?.presence) {
+    const { presence } = column.constraints || {}
+    const isRequired =
+      typeof presence === "boolean"
+        ? presence
+        : !!presence?.allowEmpty === false
+    if (columnBuilder && isRequired) {
       columnBuilder.notNullable()
     }
   }


### PR DESCRIPTION
## Description
When creating/updating SQL tables and columns, we are not setting any constraints at the DB level. We always rely on BB checks at the server level. However, having null data on the DB but treated as non-nullable can cause multiple issues.
As nullable/non-nullable is not type-related, we can add this constraint to the external DB in order to prevent inconsistencies. This will also help when changing from non-nullable to nullable with data not in the expected shape.

## Launchcontrol
Setting non-nullable constraints in SQL datasources.