### PR TITLE
Making `meta` required in `QueryJson`

### DIFF
--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -121,7 +121,7 @@ async function removeManyToManyRelationships(
       filters,
       meta: {
         table,
-      }
+      },
     })
   } else {
     return []
@@ -138,7 +138,7 @@ async function removeOneToManyRelationships(rowId: string, table: Table) {
       filters,
       meta: {
         table,
-      }
+      },
     })
   } else {
     return []
@@ -256,7 +256,7 @@ export class ExternalRequest<T extends Operation> {
       filters: buildFilters(rowId, {}, table),
       meta: {
         table,
-      }
+      },
     })
     if (Array.isArray(response) && response.length > 0) {
       return response[0]
@@ -406,7 +406,7 @@ export class ExternalRequest<T extends Operation> {
         },
         meta: {
           table,
-        }
+        },
       })
       // this is the response from knex if no rows found
       const rows: Row[] =
@@ -485,7 +485,7 @@ export class ExternalRequest<T extends Operation> {
             filters: buildFilters(id, {}, linkTable),
             meta: {
               table,
-            }
+            },
           })
         )
       } else {

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -119,6 +119,9 @@ async function removeManyToManyRelationships(
       endpoint: getEndpoint(tableId, Operation.DELETE),
       body: { [colName]: null },
       filters,
+      meta: {
+        table,
+      }
     })
   } else {
     return []
@@ -133,6 +136,9 @@ async function removeOneToManyRelationships(rowId: string, table: Table) {
     return getDatasourceAndQuery({
       endpoint: getEndpoint(tableId, Operation.UPDATE),
       filters,
+      meta: {
+        table,
+      }
     })
   } else {
     return []
@@ -248,6 +254,9 @@ export class ExternalRequest<T extends Operation> {
     const response = await getDatasourceAndQuery({
       endpoint: getEndpoint(table._id!, Operation.READ),
       filters: buildFilters(rowId, {}, table),
+      meta: {
+        table,
+      }
     })
     if (Array.isArray(response) && response.length > 0) {
       return response[0]
@@ -395,6 +404,9 @@ export class ExternalRequest<T extends Operation> {
             [fieldName]: row[lookupField],
           },
         },
+        meta: {
+          table,
+        }
       })
       // this is the response from knex if no rows found
       const rows: Row[] =
@@ -425,6 +437,7 @@ export class ExternalRequest<T extends Operation> {
     // if we're creating (in a through table) need to wipe the existing ones first
     const promises = []
     const related = await this.lookupRelations(mainTableId, row)
+    const table = this.getTable(mainTableId)
     for (let relationship of relationships) {
       const { key, tableId, isUpdate, id, ...rest } = relationship
       const body: { [key: string]: any } = processObjectSync(rest, row, {})
@@ -470,6 +483,9 @@ export class ExternalRequest<T extends Operation> {
             // if we're doing many relationships then we're writing, only one response
             body,
             filters: buildFilters(id, {}, linkTable),
+            meta: {
+              table,
+            }
           })
         )
       } else {

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -437,7 +437,7 @@ export class ExternalRequest<T extends Operation> {
     // if we're creating (in a through table) need to wipe the existing ones first
     const promises = []
     const related = await this.lookupRelations(mainTableId, row)
-    const table = this.getTable(mainTableId)
+    const table = this.getTable(mainTableId)!
     for (let relationship of relationships) {
       const { key, tableId, isUpdate, id, ...rest } = relationship
       const body: { [key: string]: any } = processObjectSync(rest, row, {})

--- a/packages/server/src/api/controllers/table/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/table/ExternalRequest.ts
@@ -22,6 +22,7 @@ export async function makeTableRequest(
       operation,
     },
     meta: {
+      table,
       tables,
     },
     table,

--- a/packages/server/src/api/routes/tests/queries/generic-sql.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/generic-sql.spec.ts
@@ -756,7 +756,7 @@ describe.each(
           },
         },
         meta: {
-          table: config.table,
+          table: config.table!,
         },
       })
       expect(res).toHaveLength(1)

--- a/packages/server/src/api/routes/tests/queries/generic-sql.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/generic-sql.spec.ts
@@ -755,6 +755,9 @@ describe.each(
             name: "two",
           },
         },
+        meta: {
+          table: config.table,
+        },
       })
       expect(res).toHaveLength(1)
       expect(res[0]).toEqual({

--- a/packages/server/src/api/routes/tests/queries/generic-sql.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/generic-sql.spec.ts
@@ -755,9 +755,6 @@ describe.each(
             name: "two",
           },
         },
-        meta: {
-          table: config.table!,
-        },
       })
       expect(res).toHaveLength(1)
       expect(res[0]).toEqual({

--- a/packages/server/src/integrations/tests/sql.spec.ts
+++ b/packages/server/src/integrations/tests/sql.spec.ts
@@ -9,6 +9,14 @@ import {
 } from "@budibase/types"
 
 const TABLE_NAME = "test"
+const TABLE: Table = {
+  type: "table",
+  sourceType: TableSourceType.EXTERNAL,
+  sourceId: "SOURCE_ID",
+  schema: {},
+  name: TABLE_NAME,
+  primary: ["id"],
+}
 
 function endpoint(table: any, operation: any) {
   return {
@@ -25,6 +33,10 @@ function generateReadJson({
   sort,
   paginate,
 }: any = {}): QueryJson {
+  const tableObj = { ...TABLE }
+  if (table) {
+    tableObj.name = table
+  }
   return {
     endpoint: endpoint(table || TABLE_NAME, "READ"),
     resource: {
@@ -34,14 +46,7 @@ function generateReadJson({
     sort: sort || {},
     paginate: paginate || {},
     meta: {
-      table: {
-        type: "table",
-        sourceType: TableSourceType.EXTERNAL,
-        sourceId: "SOURCE_ID",
-        schema: {},
-        name: table || TABLE_NAME,
-        primary: ["id"],
-      } as any,
+      table: tableObj,
     },
   }
 }
@@ -49,6 +54,9 @@ function generateReadJson({
 function generateCreateJson(table = TABLE_NAME, body = {}): QueryJson {
   return {
     endpoint: endpoint(table, "CREATE"),
+    meta: {
+      table: TABLE,
+    },
     body,
   }
 }
@@ -70,6 +78,9 @@ function generateUpdateJson({
 function generateDeleteJson(table = TABLE_NAME, filters = {}): QueryJson {
   return {
     endpoint: endpoint(table, "DELETE"),
+    meta: {
+      table: TABLE,
+    },
     filters,
   }
 }
@@ -102,6 +113,9 @@ function generateRelationshipJson(config: { schema?: string } = {}): QueryJson {
       },
     ],
     extra: { idFilter: {} },
+    meta: {
+      table: TABLE,
+    },
   }
 }
 

--- a/packages/server/src/integrations/tests/sql.spec.ts
+++ b/packages/server/src/integrations/tests/sql.spec.ts
@@ -66,7 +66,15 @@ function generateUpdateJson({
   body = {},
   filters = {},
   meta = {},
+}: {
+  table: string
+  body?: any
+  filters?: any
+  meta?: any
 }): QueryJson {
+  if (!meta.table) {
+    meta.table = table
+  }
   return {
     endpoint: endpoint(table, "UPDATE"),
     filters,

--- a/packages/server/src/integrations/tests/sqlAlias.spec.ts
+++ b/packages/server/src/integrations/tests/sqlAlias.spec.ts
@@ -4,12 +4,24 @@ import {
   QueryJson,
   SourceName,
   SqlQuery,
+  Table,
+  TableSourceType,
 } from "@budibase/types"
 import { join } from "path"
 import Sql from "../base/sql"
 import { SqlClient } from "../utils"
 import { generator } from "@budibase/backend-core/tests"
 import sdk from "../../sdk"
+
+// this doesn't exist strictly
+const TABLE: Table = {
+  type: "table",
+  sourceType: TableSourceType.EXTERNAL,
+  sourceId: "SOURCE_ID",
+  schema: {},
+  name: "tableName",
+  primary: ["id"],
+}
 
 const AliasTables = sdk.rows.AliasTables
 
@@ -221,6 +233,9 @@ describe("Captures of real examples", () => {
         endpoint: { datasourceId: "", entityId: "", operation: op },
         resource: {
           fields,
+        },
+        meta: {
+          table: TABLE,
         },
       }
     }

--- a/packages/server/src/tests/utilities/api/datasource.ts
+++ b/packages/server/src/tests/utilities/api/datasource.ts
@@ -60,7 +60,10 @@ export class DatasourceAPI extends TestAPI {
     })
   }
 
-  query = async (query: QueryJson, expectations?: Expectations) => {
+  query = async (
+    query: Omit<QueryJson, "meta">,
+    expectations?: Expectations
+  ) => {
     return await this._post<any>(`/api/datasources/query`, {
       body: query,
       expectations,

--- a/packages/types/src/sdk/search.ts
+++ b/packages/types/src/sdk/search.ts
@@ -90,7 +90,7 @@ export interface QueryJson {
   paginate?: PaginationJson
   body?: Row | Row[]
   table?: Table
-  meta?: {
+  meta: {
     table?: Table
     tables?: Record<string, Table>
     renamed?: RenameColumn

--- a/packages/types/src/sdk/search.ts
+++ b/packages/types/src/sdk/search.ts
@@ -91,7 +91,7 @@ export interface QueryJson {
   body?: Row | Row[]
   table?: Table
   meta: {
-    table?: Table
+    table: Table
     tables?: Record<string, Table>
     renamed?: RenameColumn
   }


### PR DESCRIPTION
## Description
As title, we have a `meta` property of our `QueryJson` which is used to carry meta information about the query being made, this is now required, only really required updating test cases which unit test aspects of this system.

Also makes the `table` prop of meta required.