### PR TITLE
Search type updates

### DIFF
--- a/packages/backend-core/src/users/users.ts
+++ b/packages/backend-core/src/users/users.ts
@@ -17,8 +17,8 @@ import {
   ContextUser,
   CouchFindOptions,
   DatabaseQueryOpts,
-  SearchQuery,
-  SearchQueryOperators,
+  SearchFilters,
+  SearchFilterOperator,
   SearchUsersRequest,
   User,
 } from "@budibase/types"
@@ -44,11 +44,11 @@ function removeUserPassword(users: User | User[]) {
   return users
 }
 
-export function isSupportedUserSearch(query: SearchQuery) {
+export function isSupportedUserSearch(query: SearchFilters) {
   const allowed = [
-    { op: SearchQueryOperators.STRING, key: "email" },
-    { op: SearchQueryOperators.EQUAL, key: "_id" },
-    { op: SearchQueryOperators.ONE_OF, key: "_id" },
+    { op: SearchFilterOperator.STRING, key: "email" },
+    { op: SearchFilterOperator.EQUAL, key: "_id" },
+    { op: SearchFilterOperator.ONE_OF, key: "_id" },
   ]
   for (let [key, operation] of Object.entries(query)) {
     if (typeof operation !== "object") {

--- a/packages/frontend-core/src/components/FilterBuilder.svelte
+++ b/packages/frontend-core/src/components/FilterBuilder.svelte
@@ -11,7 +11,7 @@
     Label,
     Multiselect,
   } from "@budibase/bbui"
-  import { FieldType, SearchQueryOperators } from "@budibase/types"
+  import { FieldType, SearchFilterOperator } from "@budibase/types"
   import { generate } from "shortid"
   import { LuceneUtils, Constants } from "@budibase/frontend-core"
   import { getContext } from "svelte"
@@ -247,7 +247,7 @@
                 <slot name="binding" {filter} />
               {:else if [FieldType.STRING, FieldType.LONGFORM, FieldType.NUMBER, FieldType.BIGINT, FieldType.FORMULA].includes(filter.type)}
                 <Input disabled={filter.noValue} bind:value={filter.value} />
-              {:else if filter.type === FieldType.ARRAY || (filter.type === FieldType.OPTIONS && filter.operator === SearchQueryOperators.ONE_OF)}
+              {:else if filter.type === FieldType.ARRAY || (filter.type === FieldType.OPTIONS && filter.operator === SearchFilterOperator.ONE_OF)}
                 <Multiselect
                   disabled={filter.noValue}
                   options={getFieldOptions(filter.field)}

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -8,7 +8,7 @@ import {
   PermissionLevel,
   QuotaUsageType,
   SaveTableRequest,
-  SearchQueryOperators,
+  SearchFilterOperator,
   SortOrder,
   SortType,
   StaticQuotaName,
@@ -132,7 +132,7 @@ describe.each([
         primaryDisplay: generator.word(),
         query: [
           {
-            operator: SearchQueryOperators.EQUAL,
+            operator: SearchFilterOperator.EQUAL,
             field: "field",
             value: "value",
           },
@@ -236,7 +236,7 @@ describe.each([
         ...view,
         query: [
           {
-            operator: SearchQueryOperators.EQUAL,
+            operator: SearchFilterOperator.EQUAL,
             field: "newField",
             value: "thatValue",
           },
@@ -263,7 +263,7 @@ describe.each([
         primaryDisplay: generator.word(),
         query: [
           {
-            operator: SearchQueryOperators.EQUAL,
+            operator: SearchFilterOperator.EQUAL,
             field: generator.word(),
             value: generator.word(),
           },
@@ -341,7 +341,7 @@ describe.each([
           tableId: generator.guid(),
           query: [
             {
-              operator: SearchQueryOperators.EQUAL,
+              operator: SearchFilterOperator.EQUAL,
               field: "newField",
               value: "thatValue",
             },
@@ -671,7 +671,7 @@ describe.each([
           name: generator.guid(),
           query: [
             {
-              operator: SearchQueryOperators.EQUAL,
+              operator: SearchFilterOperator.EQUAL,
               field: "two",
               value: "bar2",
             },

--- a/packages/server/src/sdk/app/rows/search/tests/lucene.spec.ts
+++ b/packages/server/src/sdk/app/rows/search/tests/lucene.spec.ts
@@ -160,7 +160,7 @@ describe("internal search", () => {
     const response = await search.paginatedSearch(
       {
         contains: {
-          column: "a",
+          column: ["a"],
           colArr: [1, 2, 3],
         },
       },
@@ -168,7 +168,7 @@ describe("internal search", () => {
     )
     checkLucene(
       response,
-      `(*:* AND column:a AND colArr:(1 AND 2 AND 3))`,
+      `(*:* AND column:(a) AND colArr:(1 AND 2 AND 3))`,
       PARAMS
     )
   })

--- a/packages/shared-core/src/tests/filters.test.ts
+++ b/packages/shared-core/src/tests/filters.test.ts
@@ -1,6 +1,6 @@
 import {
-  SearchQuery,
-  SearchQueryOperators,
+  SearchFilters,
+  SearchFilterOperator,
   FieldType,
   SearchFilter,
 } from "@budibase/types"
@@ -46,8 +46,8 @@ describe("runLuceneQuery", () => {
     },
   ]
 
-  function buildQuery(filters: { [filterKey: string]: any }): SearchQuery {
-    const query: SearchQuery = {
+  function buildQuery(filters: { [filterKey: string]: any }): SearchFilters {
+    const query: SearchFilters = {
       string: {},
       fuzzy: {},
       range: {},
@@ -63,7 +63,7 @@ describe("runLuceneQuery", () => {
     }
 
     for (const filterKey in filters) {
-      query[filterKey as SearchQueryOperators] = filters[filterKey]
+      query[filterKey as SearchFilterOperator] = filters[filterKey]
     }
 
     return query
@@ -265,13 +265,13 @@ describe("buildLuceneQuery", () => {
   it("should parseFloat if the type is a number, but the value is a numeric string", () => {
     const filter: SearchFilter[] = [
       {
-        operator: SearchQueryOperators.EQUAL,
+        operator: SearchFilterOperator.EQUAL,
         field: "customer_id",
         type: FieldType.NUMBER,
         value: "1212",
       },
       {
-        operator: SearchQueryOperators.ONE_OF,
+        operator: SearchFilterOperator.ONE_OF,
         field: "customer_id",
         type: FieldType.NUMBER,
         value: "1000,1212,3400",
@@ -299,13 +299,13 @@ describe("buildLuceneQuery", () => {
   it("should not parseFloat if the type is a number, but the value is a handlebars binding string", () => {
     const filter: SearchFilter[] = [
       {
-        operator: SearchQueryOperators.EQUAL,
+        operator: SearchFilterOperator.EQUAL,
         field: "customer_id",
         type: FieldType.NUMBER,
         value: "{{ customer_id }}",
       },
       {
-        operator: SearchQueryOperators.ONE_OF,
+        operator: SearchFilterOperator.ONE_OF,
         field: "customer_id",
         type: FieldType.NUMBER,
         value: "{{ list_of_customer_ids }}",
@@ -333,19 +333,19 @@ describe("buildLuceneQuery", () => {
   it("should cast string to boolean if the type is boolean", () => {
     const filter: SearchFilter[] = [
       {
-        operator: SearchQueryOperators.EQUAL,
+        operator: SearchFilterOperator.EQUAL,
         field: "a",
         type: FieldType.BOOLEAN,
         value: "not_true",
       },
       {
-        operator: SearchQueryOperators.NOT_EQUAL,
+        operator: SearchFilterOperator.NOT_EQUAL,
         field: "b",
         type: FieldType.BOOLEAN,
         value: "not_true",
       },
       {
-        operator: SearchQueryOperators.EQUAL,
+        operator: SearchFilterOperator.EQUAL,
         field: "c",
         type: FieldType.BOOLEAN,
         value: "true",
@@ -374,19 +374,19 @@ describe("buildLuceneQuery", () => {
   it("should split the string for contains operators", () => {
     const filter: SearchFilter[] = [
       {
-        operator: SearchQueryOperators.CONTAINS,
+        operator: SearchFilterOperator.CONTAINS,
         field: "description",
         type: FieldType.ARRAY,
         value: "Large box,Heavy box,Small box",
       },
       {
-        operator: SearchQueryOperators.NOT_CONTAINS,
+        operator: SearchFilterOperator.NOT_CONTAINS,
         field: "description",
         type: FieldType.ARRAY,
         value: "Large box,Heavy box,Small box",
       },
       {
-        operator: SearchQueryOperators.CONTAINS_ANY,
+        operator: SearchFilterOperator.CONTAINS_ANY,
         field: "description",
         type: FieldType.ARRAY,
         value: "Large box,Heavy box,Small box",

--- a/packages/types/src/api/web/searchFilter.ts
+++ b/packages/types/src/api/web/searchFilter.ts
@@ -1,68 +1,11 @@
 import { FieldType } from "../../documents"
-import { EmptyFilterOption } from "../../sdk"
+import { EmptyFilterOption, SearchFilters } from "../../sdk"
 
 export type SearchFilter = {
-  operator: keyof SearchQuery
+  operator: keyof SearchFilters | "rangeLow" | "rangeHigh"
   onEmptyFilter?: EmptyFilterOption
   field: string
   type?: FieldType
   value: any
   externalType?: string
 }
-
-export enum SearchQueryOperators {
-  STRING = "string",
-  FUZZY = "fuzzy",
-  RANGE = "range",
-  EQUAL = "equal",
-  NOT_EQUAL = "notEqual",
-  EMPTY = "empty",
-  NOT_EMPTY = "notEmpty",
-  ONE_OF = "oneOf",
-  CONTAINS = "contains",
-  NOT_CONTAINS = "notContains",
-  CONTAINS_ANY = "containsAny",
-}
-
-export type SearchQuery = {
-  allOr?: boolean
-  onEmptyFilter?: EmptyFilterOption
-  [SearchQueryOperators.STRING]?: {
-    [key: string]: string
-  }
-  [SearchQueryOperators.FUZZY]?: {
-    [key: string]: string
-  }
-  [SearchQueryOperators.RANGE]?: {
-    [key: string]: {
-      high: number | string
-      low: number | string
-    }
-  }
-  [SearchQueryOperators.EQUAL]?: {
-    [key: string]: any
-  }
-  [SearchQueryOperators.NOT_EQUAL]?: {
-    [key: string]: any
-  }
-  [SearchQueryOperators.EMPTY]?: {
-    [key: string]: any
-  }
-  [SearchQueryOperators.NOT_EMPTY]?: {
-    [key: string]: any
-  }
-  [SearchQueryOperators.ONE_OF]?: {
-    [key: string]: any[]
-  }
-  [SearchQueryOperators.CONTAINS]?: {
-    [key: string]: any[]
-  }
-  [SearchQueryOperators.NOT_CONTAINS]?: {
-    [key: string]: any[]
-  }
-  [SearchQueryOperators.CONTAINS_ANY]?: {
-    [key: string]: any[]
-  }
-}
-
-export type SearchQueryFields = Omit<SearchQuery, "allOr" | "onEmptyFilter">

--- a/packages/types/src/api/web/user.ts
+++ b/packages/types/src/api/web/user.ts
@@ -1,5 +1,5 @@
 import { User } from "../../documents"
-import { SearchQuery } from "./searchFilter"
+import { SearchFilters } from "../../sdk"
 
 export interface SaveUserResponse {
   _id: string
@@ -55,7 +55,7 @@ export interface InviteUsersResponse {
 
 export interface SearchUsersRequest {
   bookmark?: string
-  query?: SearchQuery
+  query?: SearchFilters
   appId?: string
   limit?: number
   paginate?: boolean

--- a/packages/types/src/sdk/search.ts
+++ b/packages/types/src/sdk/search.ts
@@ -3,46 +3,62 @@ import { Row, Table } from "../documents"
 import { SortType } from "../api"
 import { Knex } from "knex"
 
+export enum SearchFilterOperator {
+  STRING = "string",
+  FUZZY = "fuzzy",
+  RANGE = "range",
+  EQUAL = "equal",
+  NOT_EQUAL = "notEqual",
+  EMPTY = "empty",
+  NOT_EMPTY = "notEmpty",
+  ONE_OF = "oneOf",
+  CONTAINS = "contains",
+  NOT_CONTAINS = "notContains",
+  CONTAINS_ANY = "containsAny",
+}
+
 export interface SearchFilters {
   allOr?: boolean
   onEmptyFilter?: EmptyFilterOption
-  string?: {
+  [SearchFilterOperator.STRING]?: {
     [key: string]: string
   }
-  fuzzy?: {
+  [SearchFilterOperator.FUZZY]?: {
     [key: string]: string
   }
-  range?: {
+  [SearchFilterOperator.RANGE]?: {
     [key: string]: {
       high: number | string
       low: number | string
     }
   }
-  equal?: {
+  [SearchFilterOperator.EQUAL]?: {
     [key: string]: any
   }
-  notEqual?: {
+  [SearchFilterOperator.NOT_EQUAL]?: {
     [key: string]: any
   }
-  empty?: {
+  [SearchFilterOperator.EMPTY]?: {
     [key: string]: any
   }
-  notEmpty?: {
+  [SearchFilterOperator.NOT_EMPTY]?: {
     [key: string]: any
   }
-  oneOf?: {
+  [SearchFilterOperator.ONE_OF]?: {
     [key: string]: any[]
   }
-  contains?: {
-    [key: string]: any[] | any
-  }
-  notContains?: {
+  [SearchFilterOperator.CONTAINS]?: {
     [key: string]: any[]
   }
-  containsAny?: {
+  [SearchFilterOperator.NOT_CONTAINS]?: {
+    [key: string]: any[]
+  }
+  [SearchFilterOperator.CONTAINS_ANY]?: {
     [key: string]: any[]
   }
 }
+
+export type SearchQueryFields = Omit<SearchFilters, "allOr" | "onEmptyFilter">
 
 export interface SortJson {
   [key: string]: {

--- a/packages/worker/src/tests/api/users.ts
+++ b/packages/worker/src/tests/api/users.ts
@@ -4,7 +4,7 @@ import {
   InviteUsersRequest,
   User,
   CreateAdminUserRequest,
-  SearchQuery,
+  SearchFilters,
   InviteUsersResponse,
 } from "@budibase/types"
 import structures from "../structures"
@@ -150,7 +150,7 @@ export class UserAPI extends TestAPI {
   }
 
   searchUsers = (
-    { query }: { query?: SearchQuery },
+    { query }: { query?: SearchFilters },
     opts?: { status?: number; noHeaders?: boolean }
   ) => {
     const req = this.request


### PR DESCRIPTION
## Description
This removes the `SearchQuery` which was a duplication of the `SearchFilters` interface - the duplicated types were not correctly getting overlay on each other, causing build errors.

This is to help fix build errors in: https://github.com/Budibase/budibase/actions/runs/8709409951/job/23889008447?pr=13503