### PR TITLE
Allow a displayName to be passed when creating admin user

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,5 +24,8 @@
   },
   "[svelte]": {
     "editor.defaultFormatter": "svelte.svelte-vscode"
+  },
+  "[handlebars]": {
+    "editor.formatOnSave": false
   }
 }

--- a/packages/backend-core/src/users/db.ts
+++ b/packages/backend-core/src/users/db.ts
@@ -50,6 +50,8 @@ type CreateAdminUserOpts = {
   hashPassword?: boolean
   requirePassword?: boolean
   skipPasswordValidation?: boolean
+  firstName?: string
+  lastName?: string
 }
 type FeatureFns = { isSSOEnforced: FeatureFn; isAppBuildersEnabled: FeatureFn }
 

--- a/packages/backend-core/src/users/db.ts
+++ b/packages/backend-core/src/users/db.ts
@@ -519,6 +519,8 @@ export class UserDB {
         global: true,
       },
       tenantId,
+      firstName: opts?.firstName,
+      lastName: opts?.lastName,
     }
     if (opts?.ssoId) {
       user.ssoId = opts.ssoId

--- a/packages/types/src/api/web/user.ts
+++ b/packages/types/src/api/web/user.ts
@@ -66,6 +66,7 @@ export interface CreateAdminUserRequest {
   password?: string
   tenantId: string
   ssoId?: string
+  displayName?: string
 }
 
 export interface AddSSoUserRequest {

--- a/packages/types/src/api/web/user.ts
+++ b/packages/types/src/api/web/user.ts
@@ -66,7 +66,8 @@ export interface CreateAdminUserRequest {
   password?: string
   tenantId: string
   ssoId?: string
-  displayName?: string
+  familyName?: string
+  givenName?: string
 }
 
 export interface AddSSoUserRequest {

--- a/packages/types/src/documents/global/user.ts
+++ b/packages/types/src/documents/global/user.ts
@@ -22,6 +22,13 @@ export interface UserSSO {
   providerType: SSOProviderType
   oauth2?: OAuth2
   thirdPartyProfile?: SSOProfileJson
+  profile?: {
+    displayName?: string
+    name?: {
+      givenName?: string
+      familyName?: string
+    }
+  }
 }
 
 export type SSOUser = User & UserSSO

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -116,7 +116,7 @@ const parseBooleanParam = (param: any) => {
 export const adminUser = async (
   ctx: Ctx<CreateAdminUserRequest, CreateAdminUserResponse>
 ) => {
-  const { email, password, tenantId, ssoId } = ctx.request.body
+  const { email, password, tenantId, ssoId, displayName } = ctx.request.body
 
   if (await platform.tenants.exists(tenantId)) {
     ctx.throw(403, "Organisation already exists.")
@@ -145,12 +145,19 @@ export const adminUser = async (
       )
     }
 
+    // Get the first and last names from the SSO display name if available
+    const nameParts = (displayName ?? "").split(" ").filter((p: string) => !!p)
+    const firstName = nameParts.length > 0 ? nameParts[0] : ""
+    const lastName = nameParts.length > 1 ? nameParts.slice(1).join(" ") : ""
+
     try {
       const finalUser = await userSdk.db.createAdminUser(email, tenantId, {
         password,
         ssoId,
         hashPassword,
         requirePassword,
+        firstName,
+        lastName,
       })
 
       // events

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -116,7 +116,8 @@ const parseBooleanParam = (param: any) => {
 export const adminUser = async (
   ctx: Ctx<CreateAdminUserRequest, CreateAdminUserResponse>
 ) => {
-  const { email, password, tenantId, ssoId, displayName } = ctx.request.body
+  const { email, password, tenantId, ssoId, givenName, familyName } =
+    ctx.request.body
 
   if (await platform.tenants.exists(tenantId)) {
     ctx.throw(403, "Organisation already exists.")
@@ -145,19 +146,14 @@ export const adminUser = async (
       )
     }
 
-    // Get the first and last names from the SSO display name if available
-    const nameParts = (displayName ?? "").split(" ").filter((p: string) => !!p)
-    const firstName = nameParts.length > 0 ? nameParts[0] : ""
-    const lastName = nameParts.length > 1 ? nameParts.slice(1).join(" ") : ""
-
     try {
       const finalUser = await userSdk.db.createAdminUser(email, tenantId, {
         password,
         ssoId,
         hashPassword,
         requirePassword,
-        firstName,
-        lastName,
+        firstName: givenName,
+        lastName: familyName,
       })
 
       // events

--- a/packages/worker/src/api/routes/global/users.ts
+++ b/packages/worker/src/api/routes/global/users.ts
@@ -16,6 +16,7 @@ function buildAdminInitValidation() {
       password: OPTIONAL_STRING,
       tenantId: Joi.string().required(),
       ssoId: Joi.string(),
+      displayName: OPTIONAL_STRING,
     })
       .required()
       .unknown(false)

--- a/packages/worker/src/api/routes/global/users.ts
+++ b/packages/worker/src/api/routes/global/users.ts
@@ -16,7 +16,8 @@ function buildAdminInitValidation() {
       password: OPTIONAL_STRING,
       tenantId: Joi.string().required(),
       ssoId: Joi.string(),
-      displayName: OPTIONAL_STRING,
+      familyName: OPTIONAL_STRING,
+      givenName: OPTIONAL_STRING,
     })
       .required()
       .unknown(false)


### PR DESCRIPTION
## Description
When you create an admin user, the first and last name properties are empty. Ideally when signing up with SSO, these fields should be populated.

Preview of first and last name being set for a newly created admin account via Google SSO:

![Screenshot 2024-04-18 at 10 21 06](https://github.com/Budibase/budibase/assets/101575380/6aa8cffc-3e31-4ef6-b027-e1d050617b0b)