### PR TITLE
Prevent issues with dev:docker without submodules

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -9,10 +9,7 @@
   },
   "targetDefaults": {
     "build": {
-      "inputs": [
-        "{workspaceRoot}/scripts/build.js",
-        "{workspaceRoot}/lerna.json"
-      ]
+      "inputs": ["{workspaceRoot}/scripts/*", "{workspaceRoot}/lerna.json"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "dev:camunda": "./scripts/deploy-camunda.sh",
     "dev:all": "yarn run kill-all && lerna run --stream dev",
     "dev:built": "yarn run kill-all && cd packages/server && yarn dev:stack:up && cd ../../ && lerna run --stream dev:built",
-    "dev:docker": "yarn build --scope @budibase/server --scope @budibase/worker && docker-compose -f hosting/docker-compose.build.yaml -f hosting/docker-compose.dev.yaml --env-file hosting/.env up --build --scale proxy-service=0",
+    "dev:docker": "./scripts/devDocker.sh",
     "test": "REUSE_CONTAINERS=1 lerna run --concurrency 1 --stream test --stream",
     "lint:eslint": "eslint packages --max-warnings=0",
     "lint:prettier": "prettier --check \"packages/**/*.{js,ts,svelte}\" && prettier --write \"examples/**/*.{js,ts,svelte}\"",

--- a/scripts/devDocker.sh
+++ b/scripts/devDocker.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Check if the pro submodule is loaded
+if [ ! -d "./packages/pro/src" ]; then
+  echo "Submodule is not loaded. This is only allowed with loaded submodules."
+  exit 1
+fi
+
+yarn build --scope @budibase/server --scope @budibase/worker
+docker-compose -f hosting/docker-compose.build.yaml -f hosting/docker-compose.dev.yaml --env-file hosting/.env up --build --scale proxy-service=0
+
+

--- a/scripts/devDocker.sh
+++ b/scripts/devDocker.sh
@@ -2,7 +2,7 @@
 
 # Check if the pro submodule is loaded
 if [ ! -d "./packages/pro/src" ]; then
-  echo "Submodule is not loaded. This is only allowed with loaded submodules."
+  echo "[ERROR] Submodule is not loaded. This is only allowed with loaded submodules."
   exit 1
 fi
 


### PR DESCRIPTION
## Description
We created a script `dev:docker` that runs with the local code but uses the same dockerfiles we use for QA and pro. We did this to get a closer dev experience.
Our dockerfiles work assuming we have the pro submodule loaded, because any `dev:docker` run without that submodule will fail.
As we are using these dockerfiles for production, we don't want to play with them, and this command does not add too much value to OSS contributors. Because of this, we are just not allowing `dev:docker` to run without the submodule.

![image](https://github.com/Budibase/budibase/assets/15987277/4640e7b8-3116-47f5-bf26-5a4e3971c526)
