### PR TITLE
MSSQL schema conflicts

### DIFF
--- a/packages/server/scripts/integrations/mssql/docker-compose.yaml
+++ b/packages/server/scripts/integrations/mssql/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
   # user: sa
   # database: master
   mssql:
+    # platform: linux/amd64
     image: bb/mssql
     build:
       context: .

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -472,14 +472,13 @@ class InternalBuilder {
   ): Knex.QueryBuilder {
     const tableName = endpoint.entityId
     const tableAlias = aliases?.[tableName]
-    let table: string | Record<string, string> = tableName
-    if (tableAlias) {
-      table = { [tableAlias]: tableName }
-    }
-    let query = knex(table)
-    if (endpoint.schema) {
-      query = query.withSchema(endpoint.schema)
-    }
+
+    const query = knex(
+      this.tableNameWithSchema(tableName, {
+        alias: tableAlias,
+        schema: endpoint.schema,
+      })
+    )
     return query
   }
 


### PR DESCRIPTION
## Description
Knex has an issue when using `.withSchema` and table aliasing. For this, we are creating the table statement manually, reusing our existing tooling.

## Addresses
- [BUDI-8179 - [MSSQL] changing the default dbo schema to anything else makes the table unavailable when using the other schema to fetch the table](https://linear.app/budibase/issue/BUDI-8179/[mssql]-changing-the-default-dbo-schema-to-anything-else-makes-the)

## Launchcontrol
Fixing MSSQL datasources with non default schemas