### PR TITLE
Fix relationships disappearing

### DIFF
--- a/packages/server/src/api/routes/tests/datasource.spec.ts
+++ b/packages/server/src/api/routes/tests/datasource.spec.ts
@@ -5,10 +5,11 @@ import { context, events } from "@budibase/backend-core"
 import sdk from "../../../sdk"
 
 import tk from "timekeeper"
-import { generator, mocks } from "@budibase/backend-core/tests"
+import { mocks } from "@budibase/backend-core/tests"
 import {
   Datasource,
   FieldSchema,
+  FieldSubtype,
   FieldType,
   QueryPreview,
   RelationshipType,
@@ -250,7 +251,7 @@ describe("/datasources", () => {
 
       const simpleTable = await config.api.table.save(
         tableForDatasource(datasource, {
-          name: generator.guid(),
+          name: "simple",
           schema: {
             name: {
               name: "name",
@@ -259,86 +260,82 @@ describe("/datasources", () => {
           },
         })
       )
-      const fullSchema: { [type in FieldType]: FieldSchema & { type: type } } =
-        {
-          [FieldType.STRING]: {
-            name: "string",
-            type: FieldType.STRING,
-          },
-          // [FieldType.LONGFORM]: {
-          //   name: "longform",
-          //   type: FieldType.LONGFORM,
-          // },
-          // [FieldType.OPTIONS]: {
-          //   name: "options",
-          //   type: FieldType.OPTIONS,
-          // },
-          [FieldType.NUMBER]: {
-            name: "number",
-            type: FieldType.NUMBER,
-          },
-          [FieldType.BOOLEAN]: {
-            name: "boolean",
-            type: FieldType.BOOLEAN,
-          },
-          // [FieldType.ARRAY]: {
-          //   name: "array",
-          //   type: FieldType.ARRAY,
-          // },
-          [FieldType.DATETIME]: {
-            name: "datetime",
-            type: FieldType.DATETIME,
-          },
-          // [FieldType.ATTACHMENTS]: {
-          //   name: "attachments",
-          //   type: FieldType.ATTACHMENTS,
-          // },
-          // [FieldType.ATTACHMENT_SINGLE]: {
-          //   name: "attachment_single",
-          //   type: FieldType.ATTACHMENT_SINGLE,
-          // },
-          // [FieldType.LINK]: {
-          //   name: "link",
-          //   type: FieldType.LINK,
-          //   tableId: simpleTable._id!,
-          //   relationshipType: RelationshipType.ONE_TO_MANY,
-          //   fieldName: "link",
-          //   foreignKey: "fk",
-          // },
-          // [FieldType.FORMULA]: {
-          //   name: "formula",
-          //   type: FieldType.FORMULA,
-          //   formula: "any formula",
-          // },
-          // [FieldType.AUTO]: {
-          //   name: "auto",
-          //   type: FieldType.AUTO,
-          // },
-          // [FieldType.JSON]: {
-          //   name: "json",
-          //   type: FieldType.JSON,
-          // },
-          // [FieldType.INTERNAL]: {
-          //   name: "internal",
-          //   type: FieldType.INTERNAL,
-          // },
-          [FieldType.BARCODEQR]: {
-            name: "barcodeqr",
-            type: FieldType.BARCODEQR,
-          },
-          // [FieldType.BIGINT]: {
-          //   name: "bigint",
-          //   type: FieldType.BIGINT,
-          // },
-          // [FieldType.BB_REFERENCE]: {
-          //   name: "bb_reference",
-          //   type: FieldType.BB_REFERENCE,
-          // },
-        }
 
-      const fullTable = await config.api.table.save(
+      type SupportedTypes =
+        | FieldType.STRING
+        | FieldType.BARCODEQR
+        | FieldType.LONGFORM
+        | FieldType.OPTIONS
+        | FieldType.DATETIME
+        | FieldType.NUMBER
+        | FieldType.BOOLEAN
+        | FieldType.FORMULA
+        | FieldType.BIGINT
+        | FieldType.BB_REFERENCE
+        | FieldType.LINK
+        | FieldType.ARRAY
+
+      const fullSchema: {
+        [type in SupportedTypes]: FieldSchema & { type: type }
+      } = {
+        [FieldType.STRING]: {
+          name: "string",
+          type: FieldType.STRING,
+        },
+        [FieldType.LONGFORM]: {
+          name: "longform",
+          type: FieldType.LONGFORM,
+        },
+        [FieldType.OPTIONS]: {
+          name: "options",
+          type: FieldType.OPTIONS,
+        },
+        [FieldType.NUMBER]: {
+          name: "number",
+          type: FieldType.NUMBER,
+        },
+        [FieldType.BOOLEAN]: {
+          name: "boolean",
+          type: FieldType.BOOLEAN,
+        },
+        [FieldType.ARRAY]: {
+          name: "array",
+          type: FieldType.ARRAY,
+        },
+        [FieldType.DATETIME]: {
+          name: "datetime",
+          type: FieldType.DATETIME,
+        },
+        [FieldType.LINK]: {
+          name: "link",
+          type: FieldType.LINK,
+          tableId: simpleTable._id!,
+          relationshipType: RelationshipType.ONE_TO_MANY,
+          fieldName: "link",
+        },
+        [FieldType.FORMULA]: {
+          name: "formula",
+          type: FieldType.FORMULA,
+          formula: "any formula",
+        },
+        [FieldType.BARCODEQR]: {
+          name: "barcodeqr",
+          type: FieldType.BARCODEQR,
+        },
+        [FieldType.BIGINT]: {
+          name: "bigint",
+          type: FieldType.BIGINT,
+        },
+        [FieldType.BB_REFERENCE]: {
+          name: "bb_reference",
+          type: FieldType.BB_REFERENCE,
+          subtype: FieldSubtype.USERS,
+        },
+      }
+
+      await config.api.table.save(
         tableForDatasource(datasource, {
-          name: generator.guid(),
+          name: "full",
           schema: fullSchema,
         })
       )
@@ -362,9 +359,6 @@ describe("/datasources", () => {
                   (acc, [fieldName, field]) => {
                     acc[fieldName] = expect.objectContaining({
                       ...field,
-                      externalType: expect.not.stringMatching(
-                        new RegExp(`^${field.externalType || ""}$`)
-                      ),
                     })
                     return acc
                   },

--- a/packages/server/src/api/routes/tests/datasource.spec.ts
+++ b/packages/server/src/api/routes/tests/datasource.spec.ts
@@ -261,7 +261,7 @@ describe("/datasources", () => {
         })
       )
 
-      type SupportedTypes =
+      type SupportedSqlTypes =
         | FieldType.STRING
         | FieldType.BARCODEQR
         | FieldType.LONGFORM
@@ -276,7 +276,7 @@ describe("/datasources", () => {
         | FieldType.ARRAY
 
       const fullSchema: {
-        [type in SupportedTypes]: FieldSchema & { type: type }
+        [type in SupportedSqlTypes]: FieldSchema & { type: type }
       } = {
         [FieldType.STRING]: {
           name: "string",

--- a/packages/server/src/api/routes/tests/datasource.spec.ts
+++ b/packages/server/src/api/routes/tests/datasource.spec.ts
@@ -5,9 +5,19 @@ import { context, events } from "@budibase/backend-core"
 import sdk from "../../../sdk"
 
 import tk from "timekeeper"
-import { mocks } from "@budibase/backend-core/tests"
-import { QueryPreview, SourceName } from "@budibase/types"
+import { generator, mocks } from "@budibase/backend-core/tests"
+import {
+  Datasource,
+  FieldSchema,
+  FieldType,
+  QueryPreview,
+  RelationshipType,
+  SourceName,
+  Table,
+  TableSchema,
+} from "@budibase/types"
 import { DatabaseName, getDatasource } from "../../../integrations/tests/utils"
+import { tableForDatasource } from "../../../tests/utilities/structures"
 
 tk.freeze(mocks.date.MOCK_DATE)
 
@@ -225,7 +235,7 @@ describe("/datasources", () => {
     })
   })
 
-  describe.only.each([
+  describe.each([
     [DatabaseName.POSTGRES, getDatasource(DatabaseName.POSTGRES)],
     [DatabaseName.MYSQL, getDatasource(DatabaseName.MYSQL)],
     [DatabaseName.SQL_SERVER, getDatasource(DatabaseName.SQL_SERVER)],
@@ -235,13 +245,140 @@ describe("/datasources", () => {
       datasource = await config.api.datasource.create(await dsProvider)
     })
 
-    it("aa", async () => {
+    it("fetching schema will not drop tables or columns", async () => {
       const datasourceId = datasource!._id!
+
+      const simpleTable = await config.api.table.save(
+        tableForDatasource(datasource, {
+          name: generator.guid(),
+          schema: {
+            name: {
+              name: "name",
+              type: FieldType.STRING,
+            },
+          },
+        })
+      )
+      const fullSchema: { [type in FieldType]: FieldSchema & { type: type } } =
+        {
+          [FieldType.STRING]: {
+            name: "string",
+            type: FieldType.STRING,
+          },
+          // [FieldType.LONGFORM]: {
+          //   name: "longform",
+          //   type: FieldType.LONGFORM,
+          // },
+          // [FieldType.OPTIONS]: {
+          //   name: "options",
+          //   type: FieldType.OPTIONS,
+          // },
+          [FieldType.NUMBER]: {
+            name: "number",
+            type: FieldType.NUMBER,
+          },
+          // [FieldType.BOOLEAN]: {
+          //   name: "boolean",
+          //   type: FieldType.BOOLEAN,
+          // },
+          // [FieldType.ARRAY]: {
+          //   name: "array",
+          //   type: FieldType.ARRAY,
+          // },
+          // [FieldType.DATETIME]: {
+          //   name: "datetime",
+          //   type: FieldType.DATETIME,
+          // },
+          // [FieldType.ATTACHMENTS]: {
+          //   name: "attachments",
+          //   type: FieldType.ATTACHMENTS,
+          // },
+          // [FieldType.ATTACHMENT_SINGLE]: {
+          //   name: "attachment_single",
+          //   type: FieldType.ATTACHMENT_SINGLE,
+          // },
+          // [FieldType.LINK]: {
+          //   name: "link",
+          //   type: FieldType.LINK,
+          //   tableId: simpleTable._id!,
+          //   relationshipType: RelationshipType.ONE_TO_MANY,
+          //   fieldName: "link",
+          //   foreignKey: "fk",
+          // },
+          // [FieldType.FORMULA]: {
+          //   name: "formula",
+          //   type: FieldType.FORMULA,
+          //   formula: "any formula",
+          // },
+          // [FieldType.AUTO]: {
+          //   name: "auto",
+          //   type: FieldType.AUTO,
+          // },
+          // [FieldType.JSON]: {
+          //   name: "json",
+          //   type: FieldType.JSON,
+          // },
+          // [FieldType.INTERNAL]: {
+          //   name: "internal",
+          //   type: FieldType.INTERNAL,
+          // },
+          // [FieldType.BARCODEQR]: {
+          //   name: "barcodeqr",
+          //   type: FieldType.BARCODEQR,
+          // },
+          // [FieldType.BIGINT]: {
+          //   name: "bigint",
+          //   type: FieldType.BIGINT,
+          // },
+          // [FieldType.BB_REFERENCE]: {
+          //   name: "bb_reference",
+          //   type: FieldType.BB_REFERENCE,
+          // },
+        }
+
+      const fullTable = await config.api.table.save(
+        tableForDatasource(datasource, {
+          name: generator.guid(),
+          schema: fullSchema,
+        })
+      )
+
       const persisted = await config.api.datasource.get(datasourceId)
       await config.api.datasource.fetchSchema(datasourceId)
 
       const updated = await config.api.datasource.get(datasourceId)
-      expect(updated).toEqual(persisted)
+      const expected: Datasource = {
+        ...persisted,
+        entities:
+          persisted?.entities &&
+          Object.entries(persisted.entities).reduce<Record<string, Table>>(
+            (acc, [tableName, table]) => {
+              acc[tableName] = {
+                ...table,
+                primaryDisplay: expect.not.stringMatching(
+                  new RegExp(`^${table.primaryDisplay || ""}$`)
+                ),
+                schema: Object.entries(table.schema).reduce<TableSchema>(
+                  (acc, [fieldName, field]) => {
+                    acc[fieldName] = expect.objectContaining({
+                      ...field,
+                      externalType: expect.not.stringMatching(
+                        new RegExp(`^${field.externalType || ""}$`)
+                      ),
+                    })
+                    return acc
+                  },
+                  {}
+                ),
+              }
+              return acc
+            },
+            {}
+          ),
+
+        _rev: expect.any(String),
+      }
+      expect(updated).toEqual(expected)
     })
   })
 })

--- a/packages/server/src/api/routes/tests/datasource.spec.ts
+++ b/packages/server/src/api/routes/tests/datasource.spec.ts
@@ -281,6 +281,9 @@ describe("/datasources", () => {
         [FieldType.STRING]: {
           name: "string",
           type: FieldType.STRING,
+          constraints: {
+            presence: true,
+          },
         },
         [FieldType.LONGFORM]: {
           name: "longform",
@@ -289,6 +292,9 @@ describe("/datasources", () => {
         [FieldType.OPTIONS]: {
           name: "options",
           type: FieldType.OPTIONS,
+          constraints: {
+            presence: { allowEmpty: false },
+          },
         },
         [FieldType.NUMBER]: {
           name: "number",
@@ -305,6 +311,8 @@ describe("/datasources", () => {
         [FieldType.DATETIME]: {
           name: "datetime",
           type: FieldType.DATETIME,
+          dateOnly: true,
+          timeOnly: false,
         },
         [FieldType.LINK]: {
           name: "link",

--- a/packages/server/src/api/routes/tests/datasource.spec.ts
+++ b/packages/server/src/api/routes/tests/datasource.spec.ts
@@ -7,6 +7,7 @@ import sdk from "../../../sdk"
 import tk from "timekeeper"
 import { mocks } from "@budibase/backend-core/tests"
 import { QueryPreview, SourceName } from "@budibase/types"
+import { DatabaseName, getDatasource } from "../../../integrations/tests/utils"
 
 tk.freeze(mocks.date.MOCK_DATE)
 
@@ -221,6 +222,26 @@ describe("/datasources", () => {
         const dbDatasource: any = await sdk.datasources.get(datasource._id)
         expect(dbDatasource.config.password).toBe("testing")
       })
+    })
+  })
+
+  describe.only.each([
+    [DatabaseName.POSTGRES, getDatasource(DatabaseName.POSTGRES)],
+    [DatabaseName.MYSQL, getDatasource(DatabaseName.MYSQL)],
+    [DatabaseName.SQL_SERVER, getDatasource(DatabaseName.SQL_SERVER)],
+    [DatabaseName.MARIADB, getDatasource(DatabaseName.MARIADB)],
+  ])("fetch schema (%s)", (_, dsProvider) => {
+    beforeAll(async () => {
+      datasource = await config.api.datasource.create(await dsProvider)
+    })
+
+    it("aa", async () => {
+      const datasourceId = datasource!._id!
+      const persisted = await config.api.datasource.get(datasourceId)
+      await config.api.datasource.fetchSchema(datasourceId)
+
+      const updated = await config.api.datasource.get(datasourceId)
+      expect(updated).toEqual(persisted)
     })
   })
 })

--- a/packages/server/src/api/routes/tests/datasource.spec.ts
+++ b/packages/server/src/api/routes/tests/datasource.spec.ts
@@ -277,18 +277,18 @@ describe("/datasources", () => {
             name: "number",
             type: FieldType.NUMBER,
           },
-          // [FieldType.BOOLEAN]: {
-          //   name: "boolean",
-          //   type: FieldType.BOOLEAN,
-          // },
+          [FieldType.BOOLEAN]: {
+            name: "boolean",
+            type: FieldType.BOOLEAN,
+          },
           // [FieldType.ARRAY]: {
           //   name: "array",
           //   type: FieldType.ARRAY,
           // },
-          // [FieldType.DATETIME]: {
-          //   name: "datetime",
-          //   type: FieldType.DATETIME,
-          // },
+          [FieldType.DATETIME]: {
+            name: "datetime",
+            type: FieldType.DATETIME,
+          },
           // [FieldType.ATTACHMENTS]: {
           //   name: "attachments",
           //   type: FieldType.ATTACHMENTS,
@@ -322,10 +322,10 @@ describe("/datasources", () => {
           //   name: "internal",
           //   type: FieldType.INTERNAL,
           // },
-          // [FieldType.BARCODEQR]: {
-          //   name: "barcodeqr",
-          //   type: FieldType.BARCODEQR,
-          // },
+          [FieldType.BARCODEQR]: {
+            name: "barcodeqr",
+            type: FieldType.BARCODEQR,
+          },
           // [FieldType.BIGINT]: {
           //   name: "bigint",
           //   type: FieldType.BIGINT,

--- a/packages/server/src/api/routes/tests/table.spec.ts
+++ b/packages/server/src/api/routes/tests/table.spec.ts
@@ -34,7 +34,7 @@ describe.each([
   [DatabaseName.SQL_SERVER, getDatasource(DatabaseName.SQL_SERVER)],
   [DatabaseName.MARIADB, getDatasource(DatabaseName.MARIADB)],
 ])("/tables (%s)", (_, dsProvider) => {
-  let isInternal: boolean
+  const isInternal: boolean = !dsProvider
   let datasource: Datasource | undefined
   let config = setup.getConfig()
 
@@ -44,9 +44,7 @@ describe.each([
     await config.init()
     if (dsProvider) {
       datasource = await config.api.datasource.create(await dsProvider)
-      isInternal = false
     } else {
-      isInternal = true
     }
   })
 

--- a/packages/server/src/api/routes/tests/table.spec.ts
+++ b/packages/server/src/api/routes/tests/table.spec.ts
@@ -44,7 +44,6 @@ describe.each([
     await config.init()
     if (dsProvider) {
       datasource = await config.api.datasource.create(await dsProvider)
-    } else {
     }
   })
 

--- a/packages/server/src/integrations/utils/utils.ts
+++ b/packages/server/src/integrations/utils/utils.ts
@@ -8,7 +8,7 @@ import {
 } from "@budibase/types"
 import { DocumentType, SEPARATOR } from "../../db/utils"
 import { InvalidColumns, DEFAULT_BB_DATASOURCE_ID } from "../../constants"
-import { SWITCHABLE_TYPES, helpers } from "@budibase/shared-core"
+import { helpers } from "@budibase/shared-core"
 import env from "../../environment"
 import { Knex } from "knex"
 

--- a/packages/server/src/integrations/utils/utils.ts
+++ b/packages/server/src/integrations/utils/utils.ts
@@ -4,6 +4,7 @@ import {
   Datasource,
   FieldType,
   TableSourceType,
+  FieldSchema,
 } from "@budibase/types"
 import { DocumentType, SEPARATOR } from "../../db/utils"
 import { InvalidColumns, DEFAULT_BB_DATASOURCE_ID } from "../../constants"
@@ -260,14 +261,14 @@ export function generateColumnDefinition(config: {
     constraints.inclusion = options
   }
 
-  const schema: any = {
+  const schema: FieldSchema = {
     type: foundType,
     externalType,
     autocolumn,
     name,
     constraints,
   }
-  if (foundType === FieldType.DATETIME) {
+  if (schema.type === FieldType.DATETIME) {
     schema.dateOnly = SQL_DATE_ONLY_TYPES.includes(lowerCaseType)
     schema.timeOnly = SQL_TIME_ONLY_TYPES.includes(lowerCaseType)
   }

--- a/packages/server/src/integrations/utils/utils.ts
+++ b/packages/server/src/integrations/utils/utils.ts
@@ -353,6 +353,7 @@ function copyExistingPropsOver(
 
       // If the db column type changed to a non-compatible one, we want to re-fetch it
       if (
+        updatedColumnType &&
         updatedColumnType !== existingColumnType &&
         !SWITCHABLE_TYPES[updatedColumnType]?.includes(existingColumnType)
       ) {
@@ -384,7 +385,7 @@ function copyExistingPropsOver(
         ...existingTableSchema[key],
         externalType:
           existingTableSchema[key].externalType ||
-          table.schema[key].externalType,
+          table.schema[key]?.externalType,
       }
     }
   }

--- a/packages/server/src/sdk/app/tables/tests/validation.spec.ts
+++ b/packages/server/src/sdk/app/tables/tests/validation.spec.ts
@@ -125,7 +125,7 @@ describe("validation and update of external table schemas", () => {
   }
 
   it("should correctly set utilised foreign keys to autocolumns", () => {
-    const response = populateExternalTableSchemas(cloneDeep(SCHEMA) as any)
+    const response = populateExternalTableSchemas(cloneDeep(SCHEMA))
     const foreignKey = getForeignKeyColumn(response)
     expect(foreignKey.autocolumn).toBe(true)
     expect(foreignKey.autoReason).toBe(AutoReason.FOREIGN_KEY)
@@ -133,7 +133,7 @@ describe("validation and update of external table schemas", () => {
   })
 
   it("should correctly unset foreign keys when no longer used", () => {
-    const setResponse = populateExternalTableSchemas(cloneDeep(SCHEMA) as any)
+    const setResponse = populateExternalTableSchemas(cloneDeep(SCHEMA))
     const beforeFk = getForeignKeyColumn(setResponse)
     delete setResponse.entities!.client.schema.project
     delete setResponse.entities!.project.schema.client

--- a/packages/server/src/sdk/app/tables/validation.ts
+++ b/packages/server/src/sdk/app/tables/validation.ts
@@ -40,14 +40,14 @@ function checkForeignKeysAreAutoColumns(datasource: Datasource) {
       const shouldBeForeign = foreignKeys.find(
         options => options.tableId === table._id && options.key === column.name
       )
-      if (column.autocolumn) {
-        continue
-      }
       // don't change already auto-columns to it, e.g. primary keys that are foreign
-      if (shouldBeForeign) {
+      if (shouldBeForeign && !column.autocolumn) {
         column.autocolumn = true
         column.autoReason = AutoReason.FOREIGN_KEY
-      } else if (column.autoReason === AutoReason.FOREIGN_KEY) {
+      } else if (
+        !shouldBeForeign &&
+        column.autoReason === AutoReason.FOREIGN_KEY
+      ) {
         delete column.autocolumn
         delete column.autoReason
       }

--- a/packages/server/src/sdk/app/tables/validation.ts
+++ b/packages/server/src/sdk/app/tables/validation.ts
@@ -40,8 +40,11 @@ function checkForeignKeysAreAutoColumns(datasource: Datasource) {
       const shouldBeForeign = foreignKeys.find(
         options => options.tableId === table._id && options.key === column.name
       )
+      if (column.autocolumn) {
+        continue
+      }
       // don't change already auto-columns to it, e.g. primary keys that are foreign
-      if (shouldBeForeign && !column.autocolumn) {
+      if (shouldBeForeign) {
         column.autocolumn = true
         column.autoReason = AutoReason.FOREIGN_KEY
       } else if (column.autoReason === AutoReason.FOREIGN_KEY) {

--- a/packages/server/src/tests/utilities/api/datasource.ts
+++ b/packages/server/src/tests/utilities/api/datasource.ts
@@ -5,6 +5,7 @@ import {
   UpdateDatasourceResponse,
   UpdateDatasourceRequest,
   QueryJson,
+  BuildSchemaFromSourceResponse,
 } from "@budibase/types"
 import { Expectations, TestAPI } from "./base"
 
@@ -68,5 +69,14 @@ export class DatasourceAPI extends TestAPI {
       body: query,
       expectations,
     })
+  }
+
+  fetchSchema = async (id: string, expectations?: Expectations) => {
+    return await this._post<BuildSchemaFromSourceResponse>(
+      `/api/datasources/${id}/schema`,
+      {
+        expectations,
+      }
+    )
   }
 }

--- a/packages/types/src/documents/app/datasource.ts
+++ b/packages/types/src/documents/app/datasource.ts
@@ -13,9 +13,7 @@ export interface Datasource extends Document {
   config?: Record<string, any>
   plus?: boolean
   isSQL?: boolean
-  entities?: {
-    [key: string]: Table
-  }
+  entities?: Record<string, Table>
 }
 
 export enum RestAuthType {

--- a/packages/types/src/documents/app/table/schema.ts
+++ b/packages/types/src/documents/app/table/schema.ts
@@ -91,6 +91,7 @@ export interface DateFieldMetadata extends Omit<BaseFieldSchema, "subtype"> {
   type: FieldType.DATETIME
   ignoreTimezones?: boolean
   timeOnly?: boolean
+  dateOnly?: boolean
   subtype?: AutoFieldSubType.CREATED_AT | AutoFieldSubType.UPDATED_AT
 }
 


### PR DESCRIPTION
## Description
We recently introduced a change where we were persisting existing schema changes to avoid dropping column settings. This caused some issues with columns non-persisted externally when fetching schema from source, such as links or formulas.

This PR is fixing this issue, adding a test that will check that we are not dropping unexpected data when synching from schema

## Addresses
- [BUDI-8181 - Relationships keep disappearing when re-fetching MySQL tables](https://linear.app/budibase/issue/BUDI-8181/relationships-keep-disappearing-when-re-fetching-mysql-tables)
- https://github.com/Budibase/budibase/issues/13523

## Launchcontrol
Fixing some links and formulas dropping when re-fetching from schema