### PR TITLE
Fix for onEmptyFilter getting stuck on internal datasource filters.

### DIFF
--- a/packages/frontend-core/src/components/FilterBuilder.svelte
+++ b/packages/frontend-core/src/components/FilterBuilder.svelte
@@ -67,6 +67,12 @@
 
   const removeFilter = id => {
     filters = filters.filter(field => field.id !== id)
+
+    // Clear all filters when no fields are specified
+    let [first] = filters
+    if (filters.length == 1 && first?.onEmptyFilter) {
+      filters = []
+    }
   }
 
   const duplicateFilter = id => {

--- a/packages/frontend-core/src/components/FilterBuilder.svelte
+++ b/packages/frontend-core/src/components/FilterBuilder.svelte
@@ -69,8 +69,7 @@
     filters = filters.filter(field => field.id !== id)
 
     // Clear all filters when no fields are specified
-    let [first] = filters
-    if (filters.length == 1 && first?.onEmptyFilter) {
+    if (filters.length === 1 && filters[0].onEmptyFilter) {
       filters = []
     }
   }


### PR DESCRIPTION
## Description
The `onEmptyFilter` filter gets stuck in the filter list when all filter fields are removed. If you had previously set this filter to `none` it will cause the filter to always return zero rows. The only way to get around it is to refresh or add in fields to make the `onEmptyFilter` UI visible again.

## Addresses
Clears the `onEmptyFilter` when all field filters have been removed. This ensures that all rows continue to be returned when no fields are specified.

## Steps

1. Pick an internal datasource in the `Data` section and open the filter menu
2. Add a field to the search and the change the `When filter empty` to `Return no rows`
3. Remove the field entry and save the filter.
4. Despite all field filters being removed and the `When filter empty` option being hidden, the `onEmptyFilter` is still present in the filter UX and will cause no rows to appear.

The same behaviour can be seen when filtering datasources on components in the builder.

## Screenshots
![Screenshot 2024-04-19 at 12 59 41](https://github.com/Budibase/budibase/assets/5913006/0fc01118-7cec-4237-ac15-a531401a3bf5)

## Launchcontrol

Minor fix to ensure onEmptyFilter is cleared from datasource filters when no fields are specified.