### PR TITLE
Fix readable/runtime conversion with helpers

### DIFF
--- a/packages/builder/src/dataBinding.js
+++ b/packages/builder/src/dataBinding.js
@@ -1235,8 +1235,8 @@ const shouldReplaceBinding = (currentValue, from, convertTo, binding) => {
     // Don't replace if the value already matches the readable binding
     return currentValue.indexOf(binding.readableBinding) === -1
   } else if (convertingToReadable) {
-    // if the runtime and readable bindings are very similar, all we can do is check runtime is there
-    return currentValue.indexOf(binding.runtimeBinding) !== -1
+    // if the runtime and readable bindings are very similar we have to assume it should be replaced
+    return true
   }
   // remove all the spaces, if the input is surrounded by spaces e.g. [ Auto ID ] then
   // this makes sure it is detected

--- a/packages/builder/src/dataBinding.js
+++ b/packages/builder/src/dataBinding.js
@@ -29,7 +29,6 @@ import { JSONUtils, Constants } from "@budibase/frontend-core"
 import ActionDefinitions from "components/design/settings/controls/ButtonActionEditor/manifest.json"
 import { environment, licensing } from "stores/portal"
 import { convertOldFieldFormat } from "components/design/settings/controls/FieldConfiguration/utils"
-import { helpersToCompletion } from "components/common/CodeEditor"
 
 const { ContextScopes } = Constants
 

--- a/packages/builder/src/dataBinding.js
+++ b/packages/builder/src/dataBinding.js
@@ -1211,6 +1211,9 @@ const shouldReplaceBinding = (currentValue, from, convertTo, binding) => {
   if (!currentValue?.includes(from)) {
     return false
   }
+  // some cases we have the same binding for readable/runtime, specific logic for this
+  const sameBindings = binding.runtimeBinding.includes(binding.readableBinding)
+  const convertingToReadable = convertTo === "readableBinding"
   const helperNames = Object.keys(getJsHelperList())
   const matchedHelperNames = helperNames.filter(
     name => name.includes(from) && currentValue.includes(name)
@@ -1228,9 +1231,12 @@ const shouldReplaceBinding = (currentValue, from, convertTo, binding) => {
     }
   }
 
-  if (convertTo === "readableBinding") {
-    // Dont replace if the value already matches the readable binding
+  if (convertingToReadable && !sameBindings) {
+    // Don't replace if the value already matches the readable binding
     return currentValue.indexOf(binding.readableBinding) === -1
+  } else if (convertingToReadable) {
+    // if the runtime and readable bindings are very similar, all we can do is check runtime is there
+    return currentValue.indexOf(binding.runtimeBinding) !== -1
   }
   // remove all the spaces, if the input is surrounded by spaces e.g. [ Auto ID ] then
   // this makes sure it is detected

--- a/packages/string-templates/src/index.ts
+++ b/packages/string-templates/src/index.ts
@@ -16,7 +16,7 @@ import { setJSRunner, removeJSRunner } from "./helpers/javascript"
 import manifest from "./manifest.json"
 import { ProcessOptions } from "./types"
 
-export { helpersToRemoveForJs } from "./helpers/list"
+export { helpersToRemoveForJs, getJsHelperList } from "./helpers/list"
 export { FIND_ANY_HBS_REGEX } from "./utilities"
 export { setJSRunner, setOnErrorLog } from "./helpers/javascript"
 export { iifeWrapper } from "./iife"


### PR DESCRIPTION
## Description
Adding edge case handling to the binding readable/runtime conversion, checking if it is trying to replace a binding which a substring of a helper name, which causes the helper to become un-usable.

If we have a table that contains a column `id` and we attempt to add a formula, which simply contains the formula `{{ uuid }}` - it will save it as `{{ uu[id] }}` due to the conversion, which will not work - screenshots depicting this below.
![image](https://github.com/Budibase/budibase/assets/4407001/b03df7e1-57f9-4dcf-b459-b979b3ee7ce7)
![image](https://github.com/Budibase/budibase/assets/4407001/41e37bde-584a-4b49-b27d-940a990ee4c7)

This is resolved with this change.
