### PR TITLE
Fix docker-compose/docker compose error in Budibase CLI

### DIFF
--- a/packages/cli/src/hosting/utils.ts
+++ b/packages/cli/src/hosting/utils.ts
@@ -54,11 +54,9 @@ export async function downloadDockerCompose() {
 
 export async function checkDockerConfigured() {
   const error =
-    "docker/docker-compose has not been installed, please follow instructions at: https://docs.budibase.com/docs/docker-compose"
+    "docker has not been installed, please follow instructions at: https://docs.budibase.com/docs/docker-compose"
   const docker = await lookpath("docker")
-  const compose = await lookpath("docker-compose")
-  const composeV2 = await lookpath("docker compose")
-  if (!docker || (!compose && !composeV2)) {
+  if (!docker) {
     throw error
   }
 }


### PR DESCRIPTION
## Description
Getting rid of previous check for docker-compose/docker compose as due to recent changes there is no alias for the docker compose command anymore to find.

## Addresses
- https://github.com/Budibase/budibase/issues/13535
- https://linear.app/budibase/issue/BUDI-8185/budi-hosting-init-failing
