### PR TITLE
Changing client library to be retrieved via pre-signed URL for Cloud

### DIFF
--- a/packages/backend-core/src/objectStore/buckets/app.ts
+++ b/packages/backend-core/src/objectStore/buckets/app.ts
@@ -13,23 +13,16 @@ export function clientLibraryPath(appId: string) {
  * due to issues with the domain we were unable to continue doing this - keeping
  * incase we are able to switch back to CDN path again in future.
  */
-export function clientLibraryCDNUrl(appId: string, version: string) {
+export function cloudClientLibraryUrl(appId: string, version: string) {
   let file = clientLibraryPath(appId)
-  if (env.CLOUDFRONT_CDN) {
-    // append app version to bust the cache
-    if (version) {
-      file += `?v=${version}`
-    }
-    // don't need to use presigned for client with cloudfront
-    // file is public
-    return cloudfront.getUrl(file)
-  } else {
-    return objectStore.getPresignedUrl(env.APPS_BUCKET_NAME, file)
-  }
+  return objectStore.getPresignedUrl(env.APPS_BUCKET_NAME, file)
 }
 
 export function clientLibraryUrl(appId: string, version: string) {
   let tenantId, qsParams: { appId: string; version: string; tenantId?: string }
+  if (env.isProd() && !env.SELF_HOSTED) {
+    return cloudClientLibraryUrl(appId, version)
+  }
   try {
     tenantId = getTenantId()
   } finally {

--- a/packages/backend-core/src/objectStore/buckets/app.ts
+++ b/packages/backend-core/src/objectStore/buckets/app.ts
@@ -13,7 +13,7 @@ export function clientLibraryPath(appId: string) {
  * due to issues with the domain we were unable to continue doing this - keeping
  * incase we are able to switch back to CDN path again in future.
  */
-export function cloudClientLibraryUrl(appId: string, version: string) {
+function cloudClientLibraryUrl(appId: string) {
   let file = clientLibraryPath(appId)
   return objectStore.getPresignedUrl(env.APPS_BUCKET_NAME, file)
 }
@@ -21,7 +21,7 @@ export function cloudClientLibraryUrl(appId: string, version: string) {
 export function clientLibraryUrl(appId: string, version: string) {
   let tenantId, qsParams: { appId: string; version: string; tenantId?: string }
   if (env.isProd() && !env.SELF_HOSTED) {
-    return cloudClientLibraryUrl(appId, version)
+    return cloudClientLibraryUrl(appId)
   }
   try {
     tenantId = getTenantId()


### PR DESCRIPTION
## Description
Bringing back the old mechanism of returning the client library through a pre-signed URL, rather than always serving through the service.

An attempt to address some of the periods of very slow S3 performance we have been experiencing recently.