### PR TITLE
[Fix] Schema panel null references

### DIFF
--- a/packages/builder/src/components/integration/QueryViewerSidePanel/SchemaPanel.svelte
+++ b/packages/builder/src/components/integration/QueryViewerSidePanel/SchemaPanel.svelte
@@ -25,6 +25,6 @@
     name="field"
     headings
     options={SchemaTypeOptionsExpanded}
-    compare={(option, value) => option.type === value.type}
+    compare={(option, value) => option.type === value?.type}
   />
 {/key}

--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -695,7 +695,7 @@
                   menuItems={schemaMenuItems}
                   showMenu={!schemaReadOnly}
                   readOnly={schemaReadOnly}
-                  compare={(option, value) => option.type === value.type}
+                  compare={(option, value) => option.type === value?.type}
                 />
               </Tab>
             {/if}

--- a/packages/builder/src/constants/backend/index.js
+++ b/packages/builder/src/constants/backend/index.js
@@ -253,6 +253,7 @@ export const SchemaTypeOptions = [
   { label: "Number", value: FieldType.NUMBER },
   { label: "Boolean", value: FieldType.BOOLEAN },
   { label: "Datetime", value: FieldType.DATETIME },
+  { label: "JSON", value: FieldType.JSON },
 ]
 
 export const SchemaTypeOptionsExpanded = SchemaTypeOptions.map(el => ({


### PR DESCRIPTION
## Description
Fixing 2 small issues around queries:
1. Selecting "empty" in query schema panel caused js to crash
<img width="440" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/15d58d11-94a6-4515-8b2a-9ed34d2adc53">

2. Selecting "empty" in rest schema panel caused js to crash
<img width="1065" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/90bfe8cd-cfaf-472c-82a3-100168fc73ce">


3. Displaying JSON (instead of nulls) for JSON fields
<img width="444" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/e880defb-649e-4aa5-b445-01749a3478a6">


## Launchcontrol
Fixing some minor builder bugs around query schemas
