### PR TITLE
Correct types for application updating.

### DIFF
--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -52,6 +52,8 @@ import {
   FetchAppPackageResponse,
   DuplicateAppRequest,
   DuplicateAppResponse,
+  UpdateAppRequest,
+  UpdateAppResponse,
 } from "@budibase/types"
 import { BASE_LAYOUT_PROP_IDS } from "../../constants/layouts"
 import sdk from "../../sdk"
@@ -450,7 +452,7 @@ export async function create(ctx: UserCtx<CreateAppRequest, App>) {
 // This endpoint currently operates as a PATCH rather than a PUT
 // Thus name and url fields are handled only if present
 export async function update(
-  ctx: UserCtx<{ name?: string; url?: string }, App>
+  ctx: UserCtx<UpdateAppRequest, UpdateAppResponse>
 ) {
   const apps = (await dbCore.getAllApps({ dev: true })) as App[]
   // validation

--- a/packages/server/src/tests/utilities/api/application.ts
+++ b/packages/server/src/tests/utilities/api/application.ts
@@ -5,6 +5,8 @@ import {
   type FetchAppDefinitionResponse,
   type FetchAppPackageResponse,
   DuplicateAppResponse,
+  UpdateAppRequest,
+  UpdateAppResponse,
 } from "@budibase/types"
 import { Expectations, TestAPI } from "./base"
 import { AppStatus } from "../../../db/utils"
@@ -109,11 +111,11 @@ export class ApplicationAPI extends TestAPI {
 
   update = async (
     appId: string,
-    app: { name?: string; url?: string },
+    app: UpdateAppRequest,
     expectations?: Expectations
-  ): Promise<App> => {
+  ): Promise<UpdateAppResponse> => {
     return await this._put<App>(`/api/applications/${appId}`, {
-      fields: app,
+      body: app,
       expectations,
     })
   }

--- a/packages/types/src/api/web/application.ts
+++ b/packages/types/src/api/web/application.ts
@@ -44,3 +44,6 @@ export interface PublishResponse {
   status: string
   appUrl: string
 }
+
+export interface UpdateAppRequest extends Partial<App> {}
+export interface UpdateAppResponse extends App {}


### PR DESCRIPTION
## Description

Just a small one making the types for the `PUT /api/application/:appId` endpoint more correct so it's easier to use the `ApplicationAPI` class to update snippets.