### PR TITLE
Clean BBReferenceProcessor code

### DIFF
--- a/packages/server/src/api/controllers/row/utils/basic.ts
+++ b/packages/server/src/api/controllers/row/utils/basic.ts
@@ -104,7 +104,10 @@ export function basicProcessing({
 
 export function fixArrayTypes(row: Row, table: Table) {
   for (let [fieldName, schema] of Object.entries(table.schema)) {
-    if (schema.type === FieldType.ARRAY && typeof row[fieldName] === "string") {
+    if (
+      [FieldType.ARRAY, FieldType.BB_REFERENCE].includes(schema.type) &&
+      typeof row[fieldName] === "string"
+    ) {
       try {
         row[fieldName] = JSON.parse(row[fieldName])
       } catch (err) {

--- a/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
+++ b/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
@@ -108,14 +108,9 @@ interface UserReferenceInfo {
 }
 
 export async function processOutputBBReference(
-  value: string,
+  value: string | null | undefined,
   subtype: BBReferenceFieldSubType.USER
 ): Promise<UserReferenceInfo | undefined> {
-  if (value === null || value === undefined) {
-    // Already processed or nothing to process
-    return value || undefined
-  }
-
   if (!value) {
     return undefined
   }
@@ -148,14 +143,12 @@ export async function processOutputBBReference(
 }
 
 export async function processOutputBBReferences(
-  value: string,
+  value: string | null | undefined,
   subtype: BBReferenceFieldSubType
 ): Promise<UserReferenceInfo[] | undefined> {
-  if (value === null || value === undefined) {
-    // Already processed or nothing to process
-    return value || undefined
+  if (!value) {
+    return undefined
   }
-
   const ids =
     typeof value === "string" ? value.split(",").filter(id => !!id) : value
 

--- a/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
+++ b/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
@@ -10,99 +10,93 @@ import { InvalidBBRefError } from "./errors"
 
 const ROW_PREFIX = DocumentType.ROW + SEPARATOR
 
-export function processInputBBReferences(
+export async function processInputBBReference(
   value: string | { _id: string },
-  type: FieldType.BB_REFERENCE_SINGLE
-): Promise<string | null>
-export function processInputBBReferences(
-  value: string | string[] | { _id: string } | { _id: string }[],
-  type: FieldType.BB_REFERENCE,
-  subtype: BBReferenceFieldSubType
-): Promise<string | null>
+  subtype: BBReferenceFieldSubType.USER
+): Promise<string | null> {
+  if (value && Array.isArray(value)) {
+    throw "BB_REFERENCE_SINGLE cannot be an array"
+  }
+  let id = typeof value === "string" ? value : value?._id
 
-export async function processInputBBReferences(
-  value: string | string[] | { _id: string } | { _id: string }[],
-  type: FieldType.BB_REFERENCE | FieldType.BB_REFERENCE_SINGLE,
-  subtype?: BBReferenceFieldSubType
-): Promise<string | string[] | null> {
-  switch (type) {
-    case FieldType.BB_REFERENCE: {
-      let referenceIds: string[] = []
+  if (!id) {
+    return null
+  }
 
-      if (Array.isArray(value)) {
-        referenceIds.push(
-          ...value.map(idOrDoc =>
-            typeof idOrDoc === "string" ? idOrDoc : idOrDoc._id
-          )
-        )
-      } else if (typeof value !== "string") {
-        referenceIds.push(value._id)
-      } else {
-        referenceIds.push(
-          ...value
-            .split(",")
-            .filter(x => x)
-            .map((id: string) => id.trim())
-        )
+  switch (subtype) {
+    case BBReferenceFieldSubType.USER: {
+      if (id.startsWith(ROW_PREFIX)) {
+        id = dbCore.getGlobalIDFromUserMetadataID(id)
       }
 
-      // make sure all reference IDs are correct global user IDs
-      // they may be user metadata references (start with row prefix)
-      // and these need to be converted to global IDs
-      referenceIds = referenceIds.map(id => {
-        if (id?.startsWith(ROW_PREFIX)) {
-          return dbCore.getGlobalIDFromUserMetadataID(id)
-        } else {
-          return id
+      try {
+        await cache.user.getUser(id)
+        return id
+      } catch (e: any) {
+        if (e.statusCode === 404) {
+          throw new InvalidBBRefError(id, BBReferenceFieldSubType.USER)
         }
-      })
-
-      switch (subtype) {
-        case undefined:
-          throw "Subtype must be defined"
-        case BBReferenceFieldSubType.USER:
-        case BBReferenceFieldSubType.USERS: {
-          const { notFoundIds } = await cache.user.getUsers(referenceIds)
-
-          if (notFoundIds?.length) {
-            throw new InvalidBBRefError(
-              notFoundIds[0],
-              BBReferenceFieldSubType.USER
-            )
-          }
-
-          if (!referenceIds?.length) {
-            return null
-          }
-
-          if (subtype === BBReferenceFieldSubType.USERS) {
-            return referenceIds
-          }
-
-          return referenceIds.join(",")
-        }
-        default:
-          throw utils.unreachable(subtype)
+        throw e
       }
-    }
-    case FieldType.BB_REFERENCE_SINGLE: {
-      if (value && Array.isArray(value)) {
-        throw "BB_REFERENCE_SINGLE cannot be an array"
-      }
-
-      const id = typeof value === "string" ? value : value._id
-
-      const user = await cache.user.getUser(id)
-
-      if (!user) {
-        throw new InvalidBBRefError(id, BBReferenceFieldSubType.USER)
-      }
-
-      return user._id!
     }
 
     default:
-      throw utils.unreachable(type)
+      throw utils.unreachable(subtype)
+  }
+}
+export async function processInputBBReferences(
+  value: string | string[] | { _id: string }[],
+  subtype: BBReferenceFieldSubType
+): Promise<string[] | null> {
+  if (!value || !value[0]) {
+    return null
+  }
+
+  let referenceIds
+  if (typeof value === "string") {
+    referenceIds = value
+      .split(",")
+      .map(u => u.trim())
+      .filter(u => !!u)
+  } else {
+    referenceIds = value.map(idOrDoc =>
+      typeof idOrDoc === "string" ? idOrDoc : idOrDoc._id
+    )
+  }
+
+  // make sure all reference IDs are correct global user IDs
+  // they may be user metadata references (start with row prefix)
+  // and these need to be converted to global IDs
+  referenceIds = referenceIds.map(id => {
+    if (id?.startsWith(ROW_PREFIX)) {
+      return dbCore.getGlobalIDFromUserMetadataID(id)
+    } else {
+      return id
+    }
+  })
+
+  switch (subtype) {
+    case undefined:
+      throw "Subtype must be defined"
+    case BBReferenceFieldSubType.USER:
+    case BBReferenceFieldSubType.USERS: {
+      const { notFoundIds } = await cache.user.getUsers(referenceIds)
+
+      if (notFoundIds?.length) {
+        throw new InvalidBBRefError(
+          notFoundIds[0],
+          BBReferenceFieldSubType.USER
+        )
+      }
+
+      if (!referenceIds?.length) {
+        return null
+      }
+
+      return referenceIds
+    }
+    default:
+      throw utils.unreachable(subtype)
   }
 }
 

--- a/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
+++ b/packages/server/src/utilities/rowProcessor/bbReferenceProcessor.ts
@@ -121,7 +121,7 @@ export async function processOutputBBReference(
   }
 
   switch (subtype) {
-    case BBReferenceFieldSubType.USER:
+    case BBReferenceFieldSubType.USER: {
       let user
       try {
         user = await cache.user.getUser(value as string)
@@ -141,6 +141,7 @@ export async function processOutputBBReference(
         firstName: user.firstName,
         lastName: user.lastName,
       }
+    }
     default:
       throw utils.unreachable(subtype)
   }

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -14,6 +14,7 @@ import { cloneDeep } from "lodash/fp"
 import {
   processInputBBReference,
   processInputBBReferences,
+  processOutputBBReference,
   processOutputBBReferences,
 } from "./bbReferenceProcessor"
 import { isExternalTableID } from "../../integrations/utils"
@@ -258,7 +259,7 @@ export async function outputProcessing<T extends Row[] | Row>(
       column.type == FieldType.BB_REFERENCE_SINGLE
     ) {
       for (let row of enriched) {
-        row[property] = await processOutputBBReferences(
+        row[property] = await processOutputBBReference(
           row[property],
           column.subtype
         )

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -12,6 +12,7 @@ import {
 } from "@budibase/types"
 import { cloneDeep } from "lodash/fp"
 import {
+  processInputBBReference,
   processInputBBReferences,
   processOutputBBReferences,
 } from "./bbReferenceProcessor"
@@ -161,13 +162,9 @@ export async function inputProcessing(
         delete clonedRow[key].url
       }
     } else if (field.type === FieldType.BB_REFERENCE && value) {
-      clonedRow[key] = await processInputBBReferences(
-        value,
-        field.type,
-        field.subtype
-      )
+      clonedRow[key] = await processInputBBReferences(value, field.subtype)
     } else if (field.type === FieldType.BB_REFERENCE_SINGLE && value) {
-      clonedRow[key] = await processInputBBReferences(value, field.type)
+      clonedRow[key] = await processInputBBReference(value, field.subtype)
     }
   }
 

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -250,7 +250,6 @@ export async function outputProcessing<T extends Row[] | Row>(
       for (let row of enriched) {
         row[property] = await processOutputBBReferences(
           row[property],
-          column.type,
           column.subtype
         )
       }
@@ -261,7 +260,7 @@ export async function outputProcessing<T extends Row[] | Row>(
       for (let row of enriched) {
         row[property] = await processOutputBBReferences(
           row[property],
-          column.type
+          column.subtype
         )
       }
     }

--- a/packages/server/src/utilities/rowProcessor/tests/bbReferenceProcessor.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/bbReferenceProcessor.spec.ts
@@ -1,6 +1,6 @@
 import _ from "lodash"
 import * as backendCore from "@budibase/backend-core"
-import { BBReferenceFieldSubType, FieldType, User } from "@budibase/types"
+import { BBReferenceFieldSubType, User } from "@budibase/types"
 import {
   processInputBBReference,
   processInputBBReferences,

--- a/packages/server/src/utilities/rowProcessor/tests/inputProcessing.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/inputProcessing.spec.ts
@@ -10,7 +10,9 @@ import {
 import * as bbReferenceProcessor from "../bbReferenceProcessor"
 
 jest.mock("../bbReferenceProcessor", (): typeof bbReferenceProcessor => ({
+  processInputBBReference: jest.fn(),
   processInputBBReferences: jest.fn(),
+  processOutputBBReference: jest.fn(),
   processOutputBBReferences: jest.fn(),
 }))
 
@@ -19,7 +21,64 @@ describe("rowProcessor - inputProcessing", () => {
     jest.resetAllMocks()
   })
 
-  it("processes BB references if on the schema and it's populated", async () => {
+  const processInputBBReferenceMock =
+    bbReferenceProcessor.processInputBBReference as jest.Mock
+  const processInputBBReferencesMock =
+    bbReferenceProcessor.processInputBBReferences as jest.Mock
+
+  it("processes single BB references if on the schema and it's populated", async () => {
+    const userId = generator.guid()
+
+    const table: Table = {
+      _id: generator.guid(),
+      name: "TestTable",
+      type: "table",
+      sourceId: INTERNAL_TABLE_SOURCE_ID,
+      sourceType: TableSourceType.INTERNAL,
+      schema: {
+        name: {
+          type: FieldType.STRING,
+          name: "name",
+          constraints: {
+            presence: true,
+            type: "string",
+          },
+        },
+        user: {
+          type: FieldType.BB_REFERENCE_SINGLE,
+          subtype: BBReferenceFieldSubType.USER,
+          name: "user",
+          constraints: {
+            presence: true,
+            type: "string",
+          },
+        },
+      },
+    }
+
+    const newRow = {
+      name: "Jack",
+      user: "123",
+    }
+
+    const user = structures.users.user()
+
+    processInputBBReferenceMock.mockResolvedValue(user)
+
+    const { row } = await inputProcessing(userId, table, newRow)
+
+    expect(bbReferenceProcessor.processInputBBReference).toHaveBeenCalledTimes(
+      1
+    )
+    expect(bbReferenceProcessor.processInputBBReference).toHaveBeenCalledWith(
+      "123",
+      "user"
+    )
+
+    expect(row).toEqual({ ...newRow, user })
+  })
+
+  it("processes multiple BB references if on the schema and it's populated", async () => {
     const userId = generator.guid()
 
     const table: Table = {
@@ -56,9 +115,7 @@ describe("rowProcessor - inputProcessing", () => {
 
     const user = structures.users.user()
 
-    ;(
-      bbReferenceProcessor.processInputBBReferences as jest.Mock
-    ).mockResolvedValue(user)
+    processInputBBReferencesMock.mockResolvedValue(user)
 
     const { row } = await inputProcessing(userId, table, newRow)
 
@@ -67,7 +124,6 @@ describe("rowProcessor - inputProcessing", () => {
     )
     expect(bbReferenceProcessor.processInputBBReferences).toHaveBeenCalledWith(
       "123",
-      "bb_reference",
       "user"
     )
 

--- a/packages/server/src/utilities/rowProcessor/tests/outputProcessing.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/outputProcessing.spec.ts
@@ -11,7 +11,9 @@ import { generator, structures } from "@budibase/backend-core/tests"
 import * as bbReferenceProcessor from "../bbReferenceProcessor"
 
 jest.mock("../bbReferenceProcessor", (): typeof bbReferenceProcessor => ({
+  processInputBBReference: jest.fn(),
   processInputBBReferences: jest.fn(),
+  processOutputBBReference: jest.fn(),
   processOutputBBReferences: jest.fn(),
 }))
 
@@ -20,10 +22,12 @@ describe("rowProcessor - outputProcessing", () => {
     jest.resetAllMocks()
   })
 
+  const processOutputBBReferenceMock =
+    bbReferenceProcessor.processOutputBBReference as jest.Mock
   const processOutputBBReferencesMock =
     bbReferenceProcessor.processOutputBBReferences as jest.Mock
 
-  it("fetches bb user references given a populated field", async () => {
+  it("fetches single user references given a populated field", async () => {
     const table: Table = {
       _id: generator.guid(),
       name: "TestTable",
@@ -40,7 +44,7 @@ describe("rowProcessor - outputProcessing", () => {
           },
         },
         user: {
-          type: FieldType.BB_REFERENCE,
+          type: FieldType.BB_REFERENCE_SINGLE,
           subtype: BBReferenceFieldSubType.USER,
           name: "user",
           constraints: {
@@ -57,18 +61,66 @@ describe("rowProcessor - outputProcessing", () => {
     }
 
     const user = structures.users.user()
-    processOutputBBReferencesMock.mockResolvedValue(user)
+    processOutputBBReferenceMock.mockResolvedValue(user)
 
     const result = await outputProcessing(table, row, { squash: false })
 
     expect(result).toEqual({ name: "Jack", user })
+
+    expect(bbReferenceProcessor.processOutputBBReference).toHaveBeenCalledTimes(
+      1
+    )
+    expect(bbReferenceProcessor.processOutputBBReference).toHaveBeenCalledWith(
+      "123",
+      BBReferenceFieldSubType.USER
+    )
+  })
+
+  it("fetches users references given a populated field", async () => {
+    const table: Table = {
+      _id: generator.guid(),
+      name: "TestTable",
+      type: "table",
+      sourceId: INTERNAL_TABLE_SOURCE_ID,
+      sourceType: TableSourceType.INTERNAL,
+      schema: {
+        name: {
+          type: FieldType.STRING,
+          name: "name",
+          constraints: {
+            presence: true,
+            type: "string",
+          },
+        },
+        users: {
+          type: FieldType.BB_REFERENCE,
+          subtype: BBReferenceFieldSubType.USER,
+          name: "users",
+          constraints: {
+            presence: false,
+            type: "string",
+          },
+        },
+      },
+    }
+
+    const row = {
+      name: "Jack",
+      users: "123",
+    }
+
+    const users = [structures.users.user()]
+    processOutputBBReferencesMock.mockResolvedValue(users)
+
+    const result = await outputProcessing(table, row, { squash: false })
+
+    expect(result).toEqual({ name: "Jack", users })
 
     expect(
       bbReferenceProcessor.processOutputBBReferences
     ).toHaveBeenCalledTimes(1)
     expect(bbReferenceProcessor.processOutputBBReferences).toHaveBeenCalledWith(
       "123",
-      FieldType.BB_REFERENCE,
       BBReferenceFieldSubType.USER
     )
   })


### PR DESCRIPTION
## Description
Refactoring BBReferenceProcessor to handle single and multiple references separately. Now, both systems have different data shapes (single id vs array), so having the code all together was keeping it hard to follow