### PR TITLE
Make auto ID row creation in parallel more robust.

### DIFF
--- a/packages/server/src/sdk/app/rows/tests/internal.spec.ts
+++ b/packages/server/src/sdk/app/rows/tests/internal.spec.ts
@@ -145,6 +145,7 @@ describe("sdk >> rows >> internal", () => {
                 lastID: 1,
               },
             },
+            _rev: expect.stringMatching("2-.*"),
           },
           row: {
             ...row,

--- a/packages/server/src/sdk/app/rows/tests/internal.spec.ts
+++ b/packages/server/src/sdk/app/rows/tests/internal.spec.ts
@@ -190,7 +190,6 @@ describe("sdk >> rows >> internal", () => {
             type: FieldType.AUTO,
             subtype: AutoFieldSubType.AUTO_ID,
             autocolumn: true,
-            lastID: 0,
           },
         },
       })
@@ -200,7 +199,7 @@ describe("sdk >> rows >> internal", () => {
           await internalSdk.save(table._id!, row, config.getUser()._id)
         }
         await Promise.all(
-          makeRows(10).map(row =>
+          makeRows(20).map(row =>
             internalSdk.save(table._id!, row, config.getUser()._id)
           )
         )
@@ -210,19 +209,21 @@ describe("sdk >> rows >> internal", () => {
       })
 
       const persistedRows = await config.getRows(table._id!)
-      expect(persistedRows).toHaveLength(20)
+      expect(persistedRows).toHaveLength(30)
       expect(persistedRows).toEqual(
         expect.arrayContaining(
-          Array.from({ length: 20 }).map((_, i) =>
+          Array.from({ length: 30 }).map((_, i) =>
             expect.objectContaining({ id: i + 1 })
           )
         )
       )
 
       const persistedTable = await config.getTable(table._id)
-      expect((table.schema.id as AutoColumnFieldMetadata).lastID).toBe(0)
+      expect(
+        (table.schema.id as AutoColumnFieldMetadata).lastID
+      ).toBeUndefined()
       expect((persistedTable.schema.id as AutoColumnFieldMetadata).lastID).toBe(
-        20
+        30
       )
     })
   })

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -1,6 +1,6 @@
 import * as linkRows from "../../db/linkedRows"
 import { processFormulas, fixAutoColumnSubType } from "./utils"
-import { objectStore, utils } from "@budibase/backend-core"
+import { context, objectStore, utils } from "@budibase/backend-core"
 import { InternalTables } from "../../db/utils"
 import { TYPE_TRANSFORM_MAP } from "./map"
 import {
@@ -9,6 +9,7 @@ import {
   Row,
   RowAttachment,
   Table,
+  isAutoColumnField,
 } from "@budibase/types"
 import { cloneDeep } from "lodash/fp"
 import {
@@ -25,7 +26,44 @@ type AutoColumnProcessingOpts = {
   noAutoRelationships?: boolean
 }
 
-const BASE_AUTO_ID = 1
+// Returns the next auto ID for a column in a table. On success, the table will
+// be updated which is why it gets returned. The nextID returned is guaranteed
+// to be given only to you, and if you don't use it it's gone forever (a gap
+// will be left in the auto ID sequence).
+//
+// This function can throw if it fails to generate an auto ID after so many
+// attempts.
+async function getNextAutoId(
+  table: Table,
+  column: string
+): Promise<{ table: Table; nextID: number }> {
+  const db = context.getAppDB()
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const schema = table.schema[column]
+    if (!isAutoColumnField(schema)) {
+      throw new Error(`Column ${column} is not an auto column`)
+    }
+    schema.lastID = (schema.lastID || 0) + 1
+    try {
+      const resp = await db.put(table)
+      table._rev = resp.rev
+      return { table, nextID: schema.lastID }
+    } catch (e: any) {
+      if (e.status !== 409) {
+        throw e
+      }
+      // We wait for a random amount of time before retrying. The randomness
+      // makes it less likely for multiple requests modifying this table to
+      // collide.
+      await new Promise(resolve =>
+        setTimeout(resolve, Math.random() * 1.2 ** attempt * 1000)
+      )
+      table = await db.get(table._id)
+    }
+  }
+
+  throw new Error("Failed to generate an auto ID")
+}
 
 /**
  * This will update any auto columns that are found on the row/table with the correct information based on
@@ -37,7 +75,7 @@ const BASE_AUTO_ID = 1
  * @returns The updated row and table, the table may need to be updated
  * for automatic ID purposes.
  */
-export function processAutoColumn(
+export async function processAutoColumn(
   userId: string | null | undefined,
   table: Table,
   row: Row,
@@ -79,8 +117,9 @@ export function processAutoColumn(
         break
       case AutoFieldSubType.AUTO_ID:
         if (creating) {
-          schema.lastID = !schema.lastID ? BASE_AUTO_ID : schema.lastID + 1
-          row[key] = schema.lastID
+          const { table: newTable, nextID } = await getNextAutoId(table, key)
+          table = newTable
+          row[key] = nextID
         }
         break
     }

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -10,6 +10,7 @@ import {
   RowAttachment,
   Table,
   isAutoColumnField,
+  isAutoColumnNumberField,
 } from "@budibase/types"
 import { cloneDeep } from "lodash/fp"
 import {
@@ -40,7 +41,7 @@ async function getNextAutoId(
   const db = context.getAppDB()
   for (let attempt = 0; attempt < 5; attempt++) {
     const schema = table.schema[column]
-    if (!isAutoColumnField(schema)) {
+    if (!isAutoColumnField(schema) && !isAutoColumnNumberField(schema)) {
       throw new Error(`Column ${column} is not an auto column`)
     }
     schema.lastID = (schema.lastID || 0) + 1

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -9,8 +9,6 @@ import {
   Row,
   RowAttachment,
   Table,
-  isAutoColumnField,
-  isAutoColumnNumberField,
 } from "@budibase/types"
 import { cloneDeep } from "lodash/fp"
 import {
@@ -41,7 +39,7 @@ async function getNextAutoId(
   const db = context.getAppDB()
   for (let attempt = 0; attempt < 5; attempt++) {
     const schema = table.schema[column]
-    if (!isAutoColumnField(schema) && !isAutoColumnNumberField(schema)) {
+    if (schema.type !== FieldType.NUMBER && schema.type !== FieldType.AUTO) {
       throw new Error(`Column ${column} is not an auto column`)
     }
     schema.lastID = (schema.lastID || 0) + 1

--- a/packages/types/src/documents/app/table/schema.ts
+++ b/packages/types/src/documents/app/table/schema.ts
@@ -219,15 +219,3 @@ export function isAttachmentField(
 ): field is AttachmentFieldMetadata {
   return field.type === FieldType.ATTACHMENTS
 }
-
-export function isAutoColumnField(
-  field: FieldSchema
-): field is AutoColumnFieldMetadata {
-  return field.type === FieldType.AUTO
-}
-
-export function isAutoColumnNumberField(
-  field: FieldSchema
-): field is NumberFieldMetadata {
-  return field.type === FieldType.NUMBER
-}

--- a/packages/types/src/documents/app/table/schema.ts
+++ b/packages/types/src/documents/app/table/schema.ts
@@ -225,3 +225,9 @@ export function isAutoColumnField(
 ): field is AutoColumnFieldMetadata {
   return field.type === FieldType.AUTO
 }
+
+export function isAutoColumnNumberField(
+  field: FieldSchema
+): field is NumberFieldMetadata {
+  return field.type === FieldType.NUMBER
+}

--- a/packages/types/src/documents/app/table/schema.ts
+++ b/packages/types/src/documents/app/table/schema.ts
@@ -219,3 +219,9 @@ export function isAttachmentField(
 ): field is AttachmentFieldMetadata {
   return field.type === FieldType.ATTACHMENTS
 }
+
+export function isAutoColumnField(
+  field: FieldSchema
+): field is AutoColumnFieldMetadata {
+  return field.type === FieldType.AUTO
+}

--- a/packages/types/src/sdk/locks.ts
+++ b/packages/types/src/sdk/locks.ts
@@ -21,7 +21,6 @@ export enum LockName {
   PERSIST_WRITETHROUGH = "persist_writethrough",
   QUOTA_USAGE_EVENT = "quota_usage_event",
   APP_MIGRATION = "app_migrations",
-  PROCESS_AUTO_COLUMNS = "process_auto_columns",
   PROCESS_USER_INVITE = "process_user_invite",
 }
 


### PR DESCRIPTION
## Description

I've noticed a few times in tests that if you create rows with auto ID columns in parallel, you quite often get `409 Conflict` errors.

The reason this happens is because we store the next ID for a new row on the table document itself. When you create a new row, it takes that ID, increments it, saves it back, then uses it in the row. When creating rows in parallel, this read-save-use process is quite likely to conflict.

To make this more robust, I've introduced a function called `getNextAutoId` that will attempt to increment the next ID on the table and save it. If it gets a conflict, it will try again up to 5 times. When it succeeds, the next ID is returned. If it doesn't succeed in 5 attempts an error is thrown.

Because this is attempted 5 times and is done per-column, it makes it much less likely for a 409 to be returned to the user.