### PR TITLE
Search tests for FieldType.OPTIONS

### DIFF
--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -508,7 +508,7 @@ describe.each([
     })
   })
 
-  describe("array of strings", () => {
+  describe.each([FieldType.ARRAY, FieldType.OPTIONS])("%s", () => {
     beforeAll(async () => {
       await createTable({
         numbers: {


### PR DESCRIPTION
## Description

Another nice and easy one adding tests for the `FieldType.OPTIONS` type by re-using the `FieldType.ARRAY` tests.