### PR TITLE
Updating SQS server connection address

### DIFF
--- a/hosting/couchdb/runner.v2.sh
+++ b/hosting/couchdb/runner.v2.sh
@@ -70,10 +70,10 @@ sed -i "s#COUCHDB_ERLANG_COOKIE#${COUCHDB_ERLANG_COOKIE}#g" /opt/clouseau/clouse
 /opt/clouseau/bin/clouseau > /dev/stdout 2>&1 &
 
 # Start CouchDB.
-/docker-entrypoint.sh /opt/couchdb/bin/couchdb &
+/docker-entrypoint.sh /opt/couchdb/bin/couchdb > /dev/stdout 2>&1 &
 
-# Start SQS.
-/opt/sqs/sqs --server "http://localhost:5984" --data-dir ${DATA_DIR}/sqs --bind-address=0.0.0.0 &
+# Start SQS. Use 127.0.0.1 instead of localhost to avoid IPv6 issues.
+/opt/sqs/sqs --server "http://127.0.0.1:5984" --data-dir ${DATA_DIR}/sqs --bind-address=0.0.0.0 > /dev/stdout 2>&1 &
 
 # Wait for CouchDB to start up.
 while [[ $(curl -s -w "%{http_code}\n" http://localhost:5984/_up -o /dev/null) -ne 200 ]]; do


### PR DESCRIPTION
## Description
Updating the address used to connect to CouchDB to using 127.0.0.1 rather than localhost to avoid overlap with IPv6 issues. This is an issue that was encountered by @deanhannigan.

I've also made sure that the logs from the SQS service are correctly sent out of the container for easier diagnosis of issues.