### PR TITLE
[Changed] UI change -> Premium plan has audit logs

### DIFF
--- a/packages/builder/src/pages/builder/portal/account/auditLogs/index.svelte
+++ b/packages/builder/src/pages/builder/portal/account/auditLogs/index.svelte
@@ -254,7 +254,7 @@
 
 <LockedFeature
   title={"Audit Logs"}
-  planType={"Enterprise plan"}
+  planType={"Premium plan"}
   description={"View all events that have occurred in your Budibase installation"}
   enabled={$licensing.auditLogsEnabled}
   upgradeButtonClick={async () => {


### PR DESCRIPTION
## Description

Audit logs are allowed from premium. UI has to show that instead of indicating that you have to upgrade to enterprise.

Just a simple change in UI config.