### PR TITLE
Fix behaviour of 'when filter empty' for empty and notEmpty filter types.

### DIFF
--- a/packages/backend-core/src/db/lucene.ts
+++ b/packages/backend-core/src/db/lucene.ts
@@ -431,26 +431,28 @@ export class QueryBuilder<T> {
       })
     }
     if (this.#query.empty) {
-      build(this.#query.empty, (key: string) => `(*:* -${key}:["" TO *])`)
-
-      // Because the structure of an empty filter looks like this:
-      //   { empty: { someKey: null } }
-      //
-      // The check inside of `build` does not set `allFiltersEmpty`, which results
-      // in weird behaviour when the empty filter is the only filter. We get around
-      // this by setting `allFiltersEmpty` to false here.
-      allFiltersEmpty = false
+      build(this.#query.empty, (key: string) => {
+        // Because the structure of an empty filter looks like this:
+        //   { empty: { someKey: null } }
+        //
+        // The check inside of `build` does not set `allFiltersEmpty`, which results
+        // in weird behaviour when the empty filter is the only filter. We get around
+        // this by setting `allFiltersEmpty` to false here.
+        allFiltersEmpty = false
+        return `(*:* -${key}:["" TO *])`
+      })
     }
     if (this.#query.notEmpty) {
-      build(this.#query.notEmpty, (key: string) => `${key}:["" TO *]`)
-
-      // Because the structure of a notEmpty filter looks like this:
-      //   { notEmpty: { someKey: null } }
-      //
-      // The check inside of `build` does not set `allFiltersEmpty`, which results
-      // in weird behaviour when the empty filter is the only filter. We get around
-      // this by setting `allFiltersEmpty` to false here.
-      allFiltersEmpty = false
+      build(this.#query.notEmpty, (key: string) => {
+        // Because the structure of a notEmpty filter looks like this:
+        //   { notEmpty: { someKey: null } }
+        //
+        // The check inside of `build` does not set `allFiltersEmpty`, which results
+        // in weird behaviour when the empty filter is the only filter. We get around
+        // this by setting `allFiltersEmpty` to false here.
+        allFiltersEmpty = false
+        return `${key}:["" TO *]`
+      })
     }
     if (this.#query.oneOf) {
       build(this.#query.oneOf, oneOf)

--- a/packages/backend-core/src/db/lucene.ts
+++ b/packages/backend-core/src/db/lucene.ts
@@ -432,9 +432,25 @@ export class QueryBuilder<T> {
     }
     if (this.#query.empty) {
       build(this.#query.empty, (key: string) => `(*:* -${key}:["" TO *])`)
+
+      // Because the structure of an empty filter looks like this:
+      //   { empty: { someKey: null } }
+      //
+      // The check inside of `build` does not set `allFiltersEmpty`, which results
+      // in weird behaviour when the empty filter is the only filter. We get around
+      // this by setting `allFiltersEmpty` to false here.
+      allFiltersEmpty = false
     }
     if (this.#query.notEmpty) {
       build(this.#query.notEmpty, (key: string) => `${key}:["" TO *]`)
+
+      // Because the structure of a notEmpty filter looks like this:
+      //   { notEmpty: { someKey: null } }
+      //
+      // The check inside of `build` does not set `allFiltersEmpty`, which results
+      // in weird behaviour when the empty filter is the only filter. We get around
+      // this by setting `allFiltersEmpty` to false here.
+      allFiltersEmpty = false
     }
     if (this.#query.oneOf) {
       build(this.#query.oneOf, oneOf)

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -252,6 +252,31 @@ describe.each([
         }).toFindNothing())
     })
 
+    describe("empty", () => {
+      it("finds no empty rows", () =>
+        expectQuery({ empty: { name: null } }).toFindNothing())
+
+      it("should not be affected by when filter empty behaviour", () =>
+        expectQuery({
+          empty: { name: null },
+          onEmptyFilter: EmptyFilterOption.RETURN_ALL,
+        }).toFindNothing())
+    })
+
+    describe("notEmpty", () => {
+      it("finds all non-empty rows", () =>
+        expectQuery({ notEmpty: { name: null } }).toContainExactly([
+          { name: "foo" },
+          { name: "bar" },
+        ]))
+
+      it("should not be affected by when filter empty behaviour", () =>
+        expectQuery({
+          notEmpty: { name: null },
+          onEmptyFilter: EmptyFilterOption.RETURN_NONE,
+        }).toContainExactly([{ name: "foo" }, { name: "bar" }]))
+    })
+
     describe("sort", () => {
       it("sorts ascending", () =>
         expectSearch({


### PR DESCRIPTION
## Description

Originally discovered while investigating https://github.com/Budibase/budibase/issues/13583, because `empty` and `notEmpty` filters are passed like so to the search endpoint:

```javascript
// request rows where `someKey` is empty
{ empty: { someKey: null } }
```

```javascript
// request rows where `someKey` is not empty
{ notEmpty: { someKey: null } }
```

The `allFiltersEmpty` variable in `packages/backend-core/src/db/lucene.ts` does not get set to `false` when these are the only filters in the search, a check prevents it.

To fix this, I'm making certain `allFiltersEmpty` is set to `false` when these filters are present, and I have added new tests to ensure this behaviour does not regress.

## Addresses
- https://linear.app/budibase/issue/BUDI-8232/is-empty-filter-condition-causes-no-rows-to-be-returned-if-when-filter

## Launchcontrol

Fix some confusing behaviour when you perform a search that only contains an `empty` or `notEmpty` filter, and you have set the "when filter empty" to "none". Previously, "when filter empty: none" could cause searches to return no rows when there were filters present. This is no longer the case.
