### PR TITLE
UI fixes from bug grooming

### DIFF
--- a/charts/budibase/templates/automation-worker-service-hpa.yaml
+++ b/charts/budibase/templates/automation-worker-service-hpa.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "budibase.fullname" . }}-apps
+  name: {{ include "budibase.fullname" . }}-automation-worker
   labels:
     {{- include "budibase.labels" . | nindent 4 }}
 spec:

--- a/packages/builder/src/pages/builder/app/[application]/settings/backups/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/settings/backups/index.svelte
@@ -98,14 +98,22 @@
     })
   }
 
-  async function fetchBackups(filters, page, dateRange) {
-    const response = await backups.searchBackups({
+  async function fetchBackups(filters, page, dateRange = []) {
+    const body = {
       appId: $appStore.appId,
       ...filters,
       page,
-      startDate: dateRange[0],
-      endDate: dateRange[1],
-    })
+    }
+
+    const [startDate, endDate] = dateRange
+    if (startDate) {
+      body.startDate = startDate
+    }
+    if (endDate) {
+      body.endDate = endDate
+    }
+
+    const response = await backups.searchBackups(body)
     pageInfo.fetched(response.hasNextPage, response.nextPage)
 
     // flatten so we have an easier structure to use for the table schema
@@ -120,7 +128,7 @@
       })
       await fetchBackups(filterOpt, page)
       notifications.success(response.message)
-    } catch {
+    } catch (err) {
       notifications.error("Unable to create backup")
     }
   }


### PR DESCRIPTION
## Description
Some fixes picked up from bug grooming. Backups had a UI issue causing error messages in the frontend, and we had duplicated names for our HA config in k8s

## Addresses
- https://linear.app/budibase/issue/BUDI-8224/[qa-wolf]-cannot-restore-application-from-backup
- https://linear.app/budibase/issue/BUDI-8223/[qa-wolf]-unable-to-create-backup
- https://linear.app/budibase/issue/BUDI-8219/helm-chart-has-same-hpa-name-for-automation-worker-service-and-app