### PR TITLE
Enable no-floating-promises in eslint.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,6 +36,9 @@
     {
       "files": ["**/*.ts"],
       "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        "project": ["./packages/*/tsconfig.json"]
+      },
       "plugins": ["@typescript-eslint"],
       "extends": ["eslint:recommended"],
       "globals": {
@@ -54,7 +57,7 @@
             "ignoreRestSiblings": true
           }
         ],
-        "local-rules/no-budibase-imports": "error"
+        "@typescript-eslint/no-floating-promises": "error"
       }
     },
     {


### PR DESCRIPTION
## Description

Enables `@typescript-eslint/no-floating-promises` in our `.eslint.json` config.

To run lint, you can do the following from the root of the repo:

```
yarn eslint packages
```

This PR exists to show that using `parserOptions.project: ["./packages/*/tsconfig.json"]` causes the massive memory use described in https://github.com/typescript-eslint/typescript-eslint/issues/1192. The error for this can be seen in our lint CI step: https://github.com/Budibase/budibase/actions/runs/9014652931/job/24767745529?pr=13642.
