### PR TITLE
Improving binary column support

### DIFF
--- a/packages/server/src/api/controllers/row/utils/basic.ts
+++ b/packages/server/src/api/controllers/row/utils/basic.ts
@@ -73,12 +73,15 @@ export function basicProcessing({
   // filter the row down to what is actually the row (not joined)
   for (let field of Object.values(table.schema)) {
     const fieldName = field.name
-    const value = extractFieldValue({
+    let value = extractFieldValue({
       row,
       tableName: table.name,
       fieldName,
       isLinked,
     })
+    if (value instanceof Buffer) {
+      value = value.toString()
+    }
     // all responses include "select col as table.col" so that overlaps are handled
     if (value != null) {
       thisRow[fieldName] = value

--- a/packages/server/src/integrations/utils/utils.ts
+++ b/packages/server/src/integrations/utils/utils.ts
@@ -192,6 +192,11 @@ export function generateRowIdField(keyProps: any[] = []) {
   if (!Array.isArray(keyProps)) {
     keyProps = [keyProps]
   }
+  for (let index in keyProps) {
+    if (keyProps[index] instanceof Buffer) {
+      keyProps[index] = keyProps[index].toString()
+    }
+  }
   // this conserves order and types
   // we have to swap the double quotes to single quotes for use in HBS statements
   // when using the literal helper the double quotes can break things


### PR DESCRIPTION
## Description
Adding support for buffers in a few places - this helps with BYTE type columns in SQL.

Added a quick/dirty test case for this, these sort of scenarios are a little harder to test as if you can't create the column through Budibase it needs to be done as a raw query to the DB (meaning support for this can only be checked per DB).

This is only a partial fix, but should help binary columns work a bit better.

Partially addresses: https://github.com/Budibase/budibase/issues/13646