### PR TITLE
Updating binding tests to test single column

### DIFF
--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -262,11 +262,11 @@ describe.each([
         { name: "serverDate", appointment: serverTime.toISOString() },
         {
           name: "single user, session user",
-          single_user: JSON.stringify([currentUser]),
+          single_user: JSON.stringify(currentUser),
         },
         {
           name: "single user",
-          single_user: JSON.stringify([globalUsers[0]]),
+          single_user: JSON.stringify(globalUsers[0]),
         },
         {
           name: "multi user",
@@ -398,7 +398,7 @@ describe.each([
       }).toContainExactly([
         {
           name: "single user, session user",
-          single_user: [{ _id: config.getUser()._id }],
+          single_user: { _id: config.getUser()._id },
         },
       ])
     })
@@ -447,11 +447,11 @@ describe.each([
       }).toContainExactly([
         {
           name: "single user, session user",
-          single_user: [{ _id: config.getUser()._id }],
+          single_user: { _id: config.getUser()._id },
         },
         {
           name: "single user",
-          single_user: [{ _id: globalUsers[0]._id }],
+          single_user: { _id: globalUsers[0]._id },
         },
       ])
     })
@@ -467,7 +467,7 @@ describe.each([
       }).toContainExactly([
         {
           name: "single user",
-          single_user: [{ _id: globalUsers[0]._id }],
+          single_user: { _id: globalUsers[0]._id },
         },
       ])
     })

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -26,11 +26,11 @@ tk.freeze(serverTime)
 
 describe.each([
   ["lucene", undefined],
-  // ["sqs", undefined],
-  // [DatabaseName.POSTGRES, getDatasource(DatabaseName.POSTGRES)],
-  // [DatabaseName.MYSQL, getDatasource(DatabaseName.MYSQL)],
-  // [DatabaseName.SQL_SERVER, getDatasource(DatabaseName.SQL_SERVER)],
-  // [DatabaseName.MARIADB, getDatasource(DatabaseName.MARIADB)],
+  ["sqs", undefined],
+  [DatabaseName.POSTGRES, getDatasource(DatabaseName.POSTGRES)],
+  [DatabaseName.MYSQL, getDatasource(DatabaseName.MYSQL)],
+  [DatabaseName.SQL_SERVER, getDatasource(DatabaseName.SQL_SERVER)],
+  [DatabaseName.MARIADB, getDatasource(DatabaseName.MARIADB)],
 ])("/api/:sourceId/search (%s)", (name, dsProvider) => {
   const isSqs = name === "sqs"
   const isLucene = name === "lucene"

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -301,7 +301,7 @@ describe.each([
         appointment: { name: "appointment", type: FieldType.DATETIME },
         single_user: {
           name: "single_user",
-          type: FieldType.BB_REFERENCE,
+          type: FieldType.BB_REFERENCE_SINGLE,
           subtype: BBReferenceFieldSubType.USER,
         },
         multi_user: {

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -324,19 +324,22 @@ describe.each([
           name: "deprecated_single_user",
           type: FieldType.BB_REFERENCE,
           subtype: BBReferenceFieldSubType.USER,
-          constraints: {
-            type: "array",
-          },
         },
         multi_user: {
           name: "multi_user",
           type: FieldType.BB_REFERENCE,
           subtype: BBReferenceFieldSubType.USER,
+          constraints: {
+            type: "array",
+          },
         },
         deprecated_multi_user: {
           name: "deprecated_multi_user",
           type: FieldType.BB_REFERENCE,
           subtype: BBReferenceFieldSubType.USERS,
+          constraints: {
+            type: "array",
+          },
         },
       })
       await createRows(rows(config.getUser()))

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -307,7 +307,7 @@ describe.each([
         multi_user: {
           name: "multi_user",
           type: FieldType.BB_REFERENCE,
-          subtype: BBReferenceFieldSubType.USERS,
+          subtype: BBReferenceFieldSubType.USER,
         },
       })
       await createRows(rows(config.getUser()))

--- a/packages/server/src/integrations/base/sql.ts
+++ b/packages/server/src/integrations/base/sql.ts
@@ -26,6 +26,7 @@ import {
   INTERNAL_TABLE_SOURCE_ID,
 } from "@budibase/types"
 import environment from "../../environment"
+import { helpers } from "@budibase/shared-core"
 
 type QueryFunction = (query: SqlQuery | SqlQuery[], operation: Operation) => any
 
@@ -786,8 +787,7 @@ class SqlQueryBuilder extends SqlTableQueryBuilder {
     return (
       field.type === FieldType.JSON ||
       (field.type === FieldType.BB_REFERENCE &&
-        // Handling old single user type
-        field.constraints?.type === "array")
+        !helpers.schema.isDeprecatedSingleUserColumn(field))
     )
   }
 

--- a/packages/server/src/integrations/base/sqlTable.ts
+++ b/packages/server/src/integrations/base/sqlTable.ts
@@ -11,7 +11,7 @@ import {
   TableSourceType,
 } from "@budibase/types"
 import { breakExternalTableId, getNativeSql, SqlClient } from "../utils"
-import { utils } from "@budibase/shared-core"
+import { helpers, utils } from "@budibase/shared-core"
 import SchemaBuilder = Knex.SchemaBuilder
 import CreateTableBuilder = Knex.CreateTableBuilder
 
@@ -85,7 +85,12 @@ function generateSchema(
         break
       case FieldType.ARRAY:
       case FieldType.BB_REFERENCE:
-        schema.json(key)
+        if (helpers.schema.isDeprecatedSingleUserColumn(column)) {
+          // This is still required for unit testing, in order to create "deprecated" schemas
+          schema.text(key)
+        } else {
+          schema.json(key)
+        }
         break
       case FieldType.LINK:
         // this side of the relationship doesn't need any SQL work

--- a/packages/server/src/sdk/app/rows/search.ts
+++ b/packages/server/src/sdk/app/rows/search.ts
@@ -12,7 +12,7 @@ import { NoEmptyFilterStrings } from "../../../constants"
 import * as sqs from "./search/sqs"
 import env from "../../../environment"
 import { ExportRowsParams, ExportRowsResult } from "./search/types"
-import { dataFilters } from "@budibase/shared-core"
+import { dataFilters, helpers } from "@budibase/shared-core"
 import sdk from "../../index"
 import { searchInputMapping } from "./search/utils"
 
@@ -79,7 +79,9 @@ export async function search(
   }
 
   const table = await sdk.tables.getTable(options.tableId)
-  options = searchInputMapping(table, options)
+  options = searchInputMapping(table, options, {
+    isSql: !!table.sql || !!env.SQS_SEARCH_ENABLE,
+  })
 
   if (isExternalTable) {
     return external.search(options, table)

--- a/packages/server/src/sdk/app/rows/search.ts
+++ b/packages/server/src/sdk/app/rows/search.ts
@@ -12,7 +12,7 @@ import { NoEmptyFilterStrings } from "../../../constants"
 import * as sqs from "./search/sqs"
 import env from "../../../environment"
 import { ExportRowsParams, ExportRowsResult } from "./search/types"
-import { dataFilters, helpers } from "@budibase/shared-core"
+import { dataFilters } from "@budibase/shared-core"
 import sdk from "../../index"
 import { searchInputMapping } from "./search/utils"
 

--- a/packages/server/src/sdk/app/rows/search/utils.ts
+++ b/packages/server/src/sdk/app/rows/search/utils.ts
@@ -96,7 +96,7 @@ function userColumnMapping(
 export function searchInputMapping(
   table: Table,
   options: RowSearchParams,
-  datasourceOptions: { isSql?: boolean }
+  datasourceOptions: { isSql?: boolean } = {}
 ) {
   if (!table?.schema) {
     return options

--- a/packages/server/src/sdk/app/rows/search/utils.ts
+++ b/packages/server/src/sdk/app/rows/search/utils.ts
@@ -71,21 +71,22 @@ function userColumnMapping(
       }
     }
 
-    if (isDeprecatedSingleUserColumn && filterValue && isString && isSql) {
+    let wrapper = (s: string) => s
+    if (isDeprecatedSingleUserColumn && filterValue && isSql) {
       // Decreated single users are stored as stringified arrays of a single value
-      return JSON.stringify([processString(filterValue)])
+      wrapper = (s: string) => JSON.stringify([s])
     }
 
     if (isArray) {
       return filterValue.map(el => {
         if (typeof el === "string") {
-          return processString(el)
+          return wrapper(processString(el))
         } else {
           return el
         }
       })
     } else {
-      return processString(filterValue)
+      return wrapper(processString(filterValue))
     }
   })
 }

--- a/packages/server/src/utilities/schema.ts
+++ b/packages/server/src/utilities/schema.ts
@@ -139,8 +139,10 @@ export function parse(rows: Rows, schema: TableSchema): Rows {
           ? new Date(columnData).toISOString()
           : columnData
       } else if (columnType === FieldType.BB_REFERENCE) {
-        const parsedValues =
-          (!!columnData && parseCsvExport<{ _id: string }[]>(columnData)) || []
+        let parsedValues: { _id: string }[] = columnData || []
+        if (columnData) {
+          parsedValues = parseCsvExport<{ _id: string }[]>(columnData)
+        }
 
         parsedRow[columnName] = parsedValues?.map(u => u._id)
       } else if (columnType === FieldType.BB_REFERENCE_SINGLE) {

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -9,10 +9,11 @@ import {
   SearchFilterOperator,
   SortDirection,
   SortType,
+  FieldConstraints,
 } from "@budibase/types"
 import dayjs from "dayjs"
 import { OperatorOptions, SqlNumberTypeRangeMap } from "./constants"
-import { deepGet } from "./helpers"
+import { deepGet, schema } from "./helpers"
 
 const HBS_REGEX = /{{([^{].*?)}}/g
 
@@ -24,6 +25,7 @@ export const getValidOperatorsForType = (
     type: FieldType
     subtype?: BBReferenceFieldSubType
     formulaType?: FormulaType
+    constraints?: FieldConstraints
   },
   field?: string,
   datasource?: Datasource & { tableId: any }
@@ -68,7 +70,10 @@ export const getValidOperatorsForType = (
     ops = numOps
   } else if (type === FieldType.FORMULA && formulaType === FormulaType.STATIC) {
     ops = stringOps.concat([Op.MoreThan, Op.LessThan])
-  } else if (type === FieldType.BB_REFERENCE_SINGLE) {
+  } else if (
+    type === FieldType.BB_REFERENCE_SINGLE ||
+    schema.isDeprecatedSingleUserColumn(fieldType)
+  ) {
     ops = [Op.Equals, Op.NotEquals, Op.Empty, Op.NotEmpty, Op.In]
   } else if (type === FieldType.BB_REFERENCE) {
     ops = [Op.Contains, Op.NotContains, Op.ContainsAny, Op.Empty, Op.NotEmpty]

--- a/packages/shared-core/src/helpers/schema.ts
+++ b/packages/shared-core/src/helpers/schema.ts
@@ -4,7 +4,9 @@ import {
   FieldType,
 } from "@budibase/types"
 
-export function isDeprecatedSingleUserColumn(schema: FieldSchema) {
+export function isDeprecatedSingleUserColumn(
+  schema: Pick<FieldSchema, "type" | "subtype" | "constraints">
+) {
   const result =
     schema.type === FieldType.BB_REFERENCE &&
     schema.subtype === BBReferenceFieldSubType.USER &&


### PR DESCRIPTION
## Description
Fix broken test after merging master into the feature branch. Changed to actually test the new single user column type.

With the recent changes, user column will be always treated as a list, so some filters such as `equal` are not valid anymore. Also added tests to ensure that the deprecated config is still supported