### PR TITLE
Fix tests depending on date

### DIFF
--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -44,7 +44,7 @@ describe.each([
   const snippets = [
     {
       name: "WeeksAgo",
-      code: "return function (weeks) {\n  const currentTime = new Date();\n  currentTime.setDate(currentTime.getDate()-(7 * (weeks || 1)));\n  return currentTime.toISOString();\n}",
+      code: `return function (weeks) {\n  const currentTime = new Date(${Date.now()});\n  currentTime.setDate(currentTime.getDate()-(7 * (weeks || 1)));\n  return currentTime.toISOString();\n}`,
     },
   ]
 

--- a/packages/server/src/automations/tests/executeQuery.spec.ts
+++ b/packages/server/src/automations/tests/executeQuery.spec.ts
@@ -88,7 +88,7 @@ describe.each(
     let res = await setup.runStep(setup.actions.EXECUTE_QUERY.stepId, {
       query: { queryId: "wrong_id" },
     })
-    expect(res.response).toEqual("Error: missing")
+    expect(res.response).toEqual("Error: CouchDB error: missing")
     expect(res.success).toEqual(false)
   })
 })


### PR DESCRIPTION
## Description
Fixing some unit tests recently introduced. These depend on datetime and timekeeper, but we can't mock the time in the js runner as it runs as isolation. These changes are tweaking the snippet to use the same time as the mocked value

## Launchcontrol
Fixing some broken unit tests
