### PR TITLE
Download images rather than returning binary responses from REST queries

### DIFF
--- a/packages/builder/src/components/backend/Datasources/ConfigEditor/stores/validatedConfig.js
+++ b/packages/builder/src/components/backend/Datasources/ConfigEditor/stores/validatedConfig.js
@@ -86,8 +86,9 @@ export const createValidatedConfigStore = (integration, config) => {
     ([$configStore, $errorsStore, $selectedValidatorsStore]) => {
       const validatedConfig = []
 
+      const allowedRestKeys = ["rejectUnauthorized", "downloadImages"]
       Object.entries(integration.datasource).forEach(([key, properties]) => {
-        if (integration.name === "REST" && key !== "rejectUnauthorized") {
+        if (integration.name === "REST" && !allowedRestKeys.includes(key)) {
           return
         }
 

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -1,22 +1,22 @@
 import {
-  Integration,
   DatasourceFieldType,
-  QueryType,
-  PaginationConfig,
+  HttpMethod,
+  Integration,
   IntegrationBase,
+  PaginationConfig,
   PaginationValues,
-  RestQueryFields as RestQuery,
-  RestConfig,
+  QueryType,
   RestAuthType,
   RestBasicAuthConfig,
   RestBearerAuthConfig,
-  HttpMethod,
+  RestConfig,
+  RestQueryFields as RestQuery,
 } from "@budibase/types"
 import get from "lodash/get"
 import * as https from "https"
 import qs from "querystring"
-import fetch from "node-fetch"
 import type { Response } from "node-fetch"
+import fetch from "node-fetch"
 import { formatBytes } from "../utilities"
 import { performance } from "perf_hooks"
 import FormData from "form-data"
@@ -87,6 +87,12 @@ const SCHEMA: Integration = {
       default: true,
       required: false,
     },
+    downloadImages: {
+      display: "Download images",
+      type: DatasourceFieldType.BOOLEAN,
+      default: true,
+      required: false,
+    },
   },
   query: {
     create: {
@@ -139,7 +145,8 @@ class RestIntegration implements IntegrationBase {
       filename: string | undefined
 
     const { contentType, contentDisposition } = getAttachmentHeaders(
-      response.headers
+      response.headers,
+      { downloadImages: this.config.downloadImages }
     )
     if (
       contentDisposition.includes("filename") ||

--- a/packages/server/src/integrations/tests/restUtils.spec.ts
+++ b/packages/server/src/integrations/tests/restUtils.spec.ts
@@ -1,13 +1,13 @@
 import { getAttachmentHeaders } from "../utils/restUtils"
 import type { Headers } from "node-fetch"
 
-function headers(dispositionValue: string) {
+function headers(dispositionValue: string, contentType?: string) {
   return {
     get: (name: string) => {
       if (name.toLowerCase() === "content-disposition") {
         return dispositionValue
       } else {
-        return "application/pdf"
+        return contentType || "application/pdf"
       }
     },
     set: () => {},
@@ -34,5 +34,15 @@ describe("getAttachmentHeaders", () => {
       headers(`inline; filename="report.pdf"`)
     )
     expect(contentDisposition).toBe(`inline; filename="report.pdf"`)
+  })
+
+  it("should handle an image", () => {
+    const { contentDisposition } = getAttachmentHeaders(
+      headers("", "image/png"),
+      {
+        downloadImages: true,
+      }
+    )
+    expect(contentDisposition).toBe(`attachment; filename="image.png"`)
   })
 })

--- a/packages/server/src/integrations/utils/restUtils.ts
+++ b/packages/server/src/integrations/utils/restUtils.ts
@@ -1,6 +1,9 @@
 import type { Headers } from "node-fetch"
 
-export function getAttachmentHeaders(headers: Headers) {
+export function getAttachmentHeaders(
+  headers: Headers,
+  opts?: { downloadImages?: boolean }
+) {
   const contentType = headers.get("content-type") || ""
   let contentDisposition = headers.get("content-disposition") || ""
 
@@ -25,7 +28,7 @@ export function getAttachmentHeaders(headers: Headers) {
   }
   // for images which don't supply a content disposition, make one up, as binary
   // data for images in REST responses isn't really useful, we should always download them
-  else if (contentType.startsWith("image/")) {
+  else if (opts?.downloadImages && contentType.startsWith("image/")) {
     const format = contentType.split("/")[1]
     return {
       contentDisposition: `attachment; filename="image.${format}"`,

--- a/packages/server/src/integrations/utils/restUtils.ts
+++ b/packages/server/src/integrations/utils/restUtils.ts
@@ -23,6 +23,15 @@ export function getAttachmentHeaders(headers: Headers) {
       }
     }
   }
+  // for images which don't supply a content disposition, make one up, as binary
+  // data for images in REST responses isn't really useful, we should always download them
+  else if (contentType.startsWith("image/")) {
+    const format = contentType.split("/")[1]
+    return {
+      contentDisposition: `attachment; filename="image.${format}"`,
+      contentType,
+    }
+  }
 
   return { contentDisposition, contentType }
 }

--- a/packages/types/src/documents/app/datasource.ts
+++ b/packages/types/src/documents/app/datasource.ts
@@ -46,6 +46,7 @@ export interface DynamicVariable {
 export interface RestConfig {
   url: string
   rejectUnauthorized: boolean
+  downloadImages?: boolean
   defaultHeaders: {
     [key: string]: any
   }


### PR DESCRIPTION
## Description
Fixing an issue with images and REST queries, these traditionally have only come back as binary data to Budibase, but this isn't very useful, its very difficult to convert these into something that can be used. Instead we will now download images into temporary attachments as we do for other types with a real content-disposition.

There is a slight risk with this of breaking someone's existing setup if they had somehow worked out how to use the binary response, however this is relatively unlikely.

To mitigate the risk I've made it so that this behaviour is only enabled for new datasources, however its easy to turn this on for old REST datasources as well, using the new download images option.

## Addresses
- https://github.com/Budibase/budibase/issues/9461
- https://linear.app/budibase/issue/BUDI-6353/generating-image-from-api

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
Old datasource, with binary
![image](https://github.com/Budibase/budibase/assets/4407001/9e646ab2-0eda-4b85-8008-6d01215ffe1d)

New datasource, with file download
![image](https://github.com/Budibase/budibase/assets/4407001/514e98f9-9dd4-4786-a6f9-29cd711c3d30)

Settings
![image](https://github.com/Budibase/budibase/assets/4407001/e5e9e930-3647-4101-acdd-46a350d19b48)

