### PR TITLE
Added flag to ensure onboarding tour isn't cancelled when builder tabs are destroyed.

### DIFF
--- a/packages/builder/src/components/portal/onboarding/TourWrap.svelte
+++ b/packages/builder/src/components/portal/onboarding/TourWrap.svelte
@@ -5,6 +5,7 @@
   import { builderStore } from "stores/builder"
 
   export let stepKeys = []
+  export let endTourOnDestroy = true
 
   let ready = false
   let registered = {}
@@ -54,7 +55,7 @@
 
       // Check if the step is part of an active tour. End the tour if that is the case
       const step = TOURSBYSTEP[stepKey]
-      if (step.tour === tourKeyWatch) {
+      if (step.tour === tourKeyWatch && endTourOnDestroy) {
         builderStore.setTour()
       }
     })

--- a/packages/builder/src/pages/builder/app/[application]/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/_layout.svelte
@@ -34,6 +34,7 @@
   import PreviewOverlay from "./_components/PreviewOverlay.svelte"
   import EnterpriseBasicTrialModal from "components/portal/onboarding/EnterpriseBasicTrialModal.svelte"
   import UpdateAppTopNav from "components/common/UpdateAppTopNav.svelte"
+  import { isEqual } from "lodash"
 
   export let application
 
@@ -46,6 +47,11 @@
   $: selected = capitalise(
     $layout.children.find(layout => $isActive(layout.path))?.title ?? "data"
   )
+
+  let fonts = []
+  $: if (!isEqual($builderStore.fonts || [], fonts)) {
+    fonts = [...$builderStore.fonts]
+  }
 
   async function getPackage() {
     try {
@@ -149,9 +155,12 @@
           />
         </span>
         <Tabs {selected} size="M">
-          {#key $builderStore?.fonts}
+          {#key fonts}
             {#each $layout.children as { path, title }}
-              <TourWrap stepKeys={[`builder-${title}-section`]}>
+              <TourWrap
+                stepKeys={[`builder-${title}-section`]}
+                endTourOnDestroy={false}
+              >
                 <Tab
                   quiet
                   selected={$isActive(path)}


### PR DESCRIPTION
## Description
Ensures the onboarding tour associated with the builder tabs is not killed when the tabs are re-rendered. A [previous fix](https://github.com/Budibase/budibase/pull/13636) for the builder tabs had the unintended effect of ending the onboarding tour. 

Typically when a tour popover target is destroyed, we want the tour to end. We do not require this behaviour for the builder tabs.

- `endTourOnDestroy` flag added to `TourWrap` to allow an exception for the builder tabs. Now when they refresh to accomodate fonts loading, the tour will remain active.

## Launchcontrol
Fix to keep the onboarding tour active when the builder tabs are re-rendered.