### PR TITLE
Fixing CLI logging

### DIFF
--- a/packages/cli/src/environment.ts
+++ b/packages/cli/src/environment.ts
@@ -1,3 +1,4 @@
+process.env.DISABLE_PINO_LOGGER = "1"
 process.env.NO_JS = "1"
 process.env.JS_BCRYPT = "1"
 process.env.DISABLE_JWT_WARNING = "1"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 // have to import this before anything else
-import "./init"
 import "./environment"
 import { getCommands } from "./options"
 import { Command } from "commander"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-process.env.DISABLE_PINO_LOGGER = "1"
+// have to import this before anything else
+import "./init"
 import "./environment"
 import { getCommands } from "./options"
 import { Command } from "commander"

--- a/packages/cli/start.sh
+++ b/packages/cli/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 dir="$(dirname -- "$(readlink -f "${BASH_SOURCE}")")"
-${dir}/node_modules/ts-node/dist/bin.js ${dir}/src/index.ts $@
+${dir}/../../node_modules/ts-node/dist/bin.js ${dir}/src/index.ts $@


### PR DESCRIPTION
## Description
Was checking another issue - noticed CLI logging was running through pino again - looks weird when we get an error, fixing this. With typescript the initial index doesn't get ran until after all else has been imported, so including all environment variables as the very first thing executed - by importing as the very first file.
