### PR TITLE
Move more tests out of `sql.spec.ts`

### DIFF
--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -485,6 +485,25 @@ describe.each([
         )
         expect(response.message).toBe("Cannot create new user entry.")
       })
+
+    it("should not mis-parse date string out of JSON", async () => {
+      const table = await config.api.table.save(
+        saveTableRequest({
+          schema: {
+            name: {
+              type: FieldType.STRING,
+              name: "name",
+            },
+          },
+        })
+      )
+
+      const row = await config.api.row.save(table._id!, {
+        name: `{ "foo": "2023-01-26T11:48:57.000Z" }`,
+      })
+
+      expect(row.name).toEqual(`{ "foo": "2023-01-26T11:48:57.000Z" }`)
+    })
   })
 
   describe("get", () => {

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -1027,7 +1027,7 @@ describe.each([
       const NULL_TIME__ID = `null_time__id`
 
       beforeAll(async () => {
-        await createTable({
+        table = await createTable({
           timeid: { name: "timeid", type: FieldType.STRING },
           time: { name: "time", type: FieldType.DATETIME, timeOnly: true },
         })

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -1309,6 +1309,25 @@ describe.each([
               { auto: 2 },
               { auto: 1 },
             ]))
+
+          // This is important for pagination. The order of results must always
+          // be stable or pagination will break. We don't want the user to need
+          // to specify an order for pagination to work.
+          it("is stable without a sort specified", async () => {
+            let { rows } = await config.api.row.search(table._id!, {
+              tableId: table._id!,
+              query: {},
+            })
+
+            for (let i = 0; i < 10; i++) {
+              const response = await config.api.row.search(table._id!, {
+                tableId: table._id!,
+                limit: 1,
+                query: {},
+              })
+              expect(response.rows).toEqual(rows)
+            }
+          })
         })
 
       // TODO(samwho): fix for SQS

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -1385,8 +1385,7 @@ describe.each([
   })
 
   // This will never work for Lucene.
-  // TODO(samwho): fix for SQS
-  !isInternal &&
+  !isLucene &&
     describe("relations", () => {
       let otherTable: Table
       let rows: Row[]

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -17,6 +17,7 @@ import {
   TableSchema,
   User,
   Row,
+  RelationshipType,
 } from "@budibase/types"
 import _ from "lodash"
 import tk from "timekeeper"
@@ -73,7 +74,7 @@ describe.each([
   })
 
   async function createTable(schema: TableSchema) {
-    table = await config.api.table.save(
+    return await config.api.table.save(
       tableForDatasource(datasource, { schema })
     )
   }
@@ -186,7 +187,7 @@ describe.each([
 
   describe("boolean", () => {
     beforeAll(async () => {
-      await createTable({
+      table = await createTable({
         isTrue: { name: "isTrue", type: FieldType.BOOLEAN },
       })
       await createRows([{ isTrue: true }, { isTrue: false }])
@@ -316,7 +317,7 @@ describe.each([
           })
       )
 
-      await createTable({
+      table = await createTable({
         name: { name: "name", type: FieldType.STRING },
         appointment: { name: "appointment", type: FieldType.DATETIME },
         single_user: {
@@ -592,7 +593,7 @@ describe.each([
 
   describe.each([FieldType.STRING, FieldType.LONGFORM])("%s", () => {
     beforeAll(async () => {
-      await createTable({
+      table = await createTable({
         name: { name: "name", type: FieldType.STRING },
       })
       await createRows([{ name: "foo" }, { name: "bar" }])
@@ -790,7 +791,7 @@ describe.each([
 
   describe("numbers", () => {
     beforeAll(async () => {
-      await createTable({
+      table = await createTable({
         age: { name: "age", type: FieldType.NUMBER },
       })
       await createRows([{ age: 1 }, { age: 10 }])
@@ -899,7 +900,7 @@ describe.each([
     const JAN_10TH = "2020-01-10T00:00:00.000Z"
 
     beforeAll(async () => {
-      await createTable({
+      table = await createTable({
         dob: { name: "dob", type: FieldType.DATETIME },
       })
 
@@ -1011,7 +1012,7 @@ describe.each([
 
   describe.each([FieldType.ARRAY, FieldType.OPTIONS])("%s", () => {
     beforeAll(async () => {
-      await createTable({
+      table = await createTable({
         numbers: {
           name: "numbers",
           type: FieldType.ARRAY,
@@ -1091,7 +1092,7 @@ describe.each([
     const BIG = "9223372036854775807"
 
     beforeAll(async () => {
-      await createTable({
+      table = await createTable({
         num: { name: "num", type: FieldType.BIGINT },
       })
       await createRows([{ num: SMALL }, { num: MEDIUM }, { num: BIG }])
@@ -1182,7 +1183,7 @@ describe.each([
   isInternal &&
     describe("auto", () => {
       beforeAll(async () => {
-        await createTable({
+        table = await createTable({
           auto: {
             name: "auto",
             type: FieldType.AUTO,
@@ -1366,7 +1367,7 @@ describe.each([
 
   describe("field name 1:name", () => {
     beforeAll(async () => {
-      await createTable({
+      table = await createTable({
         "1:name": { name: "1:name", type: FieldType.STRING },
       })
       await createRows([{ "1:name": "bar" }, { "1:name": "foo" }])
@@ -1382,4 +1383,52 @@ describe.each([
         expectQuery({ equal: { "1:1:name": "none" } }).toFindNothing())
     })
   })
+
+  // This will never work for Lucene.
+  // TODO(samwho): fix for SQS
+  !isInternal &&
+    describe("relations", () => {
+      let otherTable: Table
+      let rows: Row[]
+
+      beforeAll(async () => {
+        otherTable = await createTable({
+          one: { name: "one", type: FieldType.STRING },
+        })
+        table = await createTable({
+          two: { name: "two", type: FieldType.STRING },
+          other: {
+            type: FieldType.LINK,
+            relationshipType: RelationshipType.ONE_TO_MANY,
+            name: "other",
+            fieldName: "other",
+            tableId: otherTable._id!,
+            constraints: {
+              type: "array",
+            },
+          },
+        })
+
+        rows = await Promise.all([
+          config.api.row.save(otherTable._id!, { one: "foo" }),
+          config.api.row.save(otherTable._id!, { one: "bar" }),
+        ])
+
+        await Promise.all([
+          config.api.row.save(table._id!, {
+            two: "foo",
+            other: [rows[0]._id],
+          }),
+          config.api.row.save(table._id!, {
+            two: "bar",
+            other: [rows[1]._id],
+          }),
+        ])
+      })
+
+      it("can search through relations", () =>
+        expectQuery({
+          equal: { [`${otherTable.name}.one`]: "foo" },
+        }).toContainExactly([{ two: "foo", other: [{ _id: rows[0]._id }] }]))
+    })
 })

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -712,6 +712,20 @@ describe.each([
         expectQuery({
           range: { name: { low: "g", high: "h" } },
         }).toFindNothing())
+
+      !isLucene &&
+        it("ignores low if it's an empty object", () =>
+          expectQuery({
+            // @ts-ignore
+            range: { name: { low: {}, high: "z" } },
+          }).toContainExactly([{ name: "foo" }, { name: "bar" }]))
+
+      !isLucene &&
+        it("ignores high if it's an empty object", () =>
+          expectQuery({
+            // @ts-ignore
+            range: { name: { low: "a", high: {} } },
+          }).toContainExactly([{ name: "foo" }, { name: "bar" }]))
     })
 
     describe("empty", () => {

--- a/packages/server/src/integrations/tests/sql.spec.ts
+++ b/packages/server/src/integrations/tests/sql.spec.ts
@@ -190,44 +190,6 @@ describe("SQL query builder", () => {
     })
   })
 
-  it("should ignore high range value if it is an empty object", () => {
-    const query = sql._query(
-      generateReadJson({
-        filters: {
-          range: {
-            dob: {
-              low: "2000-01-01 00:00:00",
-              high: {},
-            },
-          },
-        },
-      })
-    )
-    expect(query).toEqual({
-      bindings: ["2000-01-01 00:00:00", 500],
-      sql: `select * from (select * from "${TABLE_NAME}" where "${TABLE_NAME}"."dob" >= $1 limit $2) as "${TABLE_NAME}"`,
-    })
-  })
-
-  it("should ignore low range value if it is an empty object", () => {
-    const query = sql._query(
-      generateReadJson({
-        filters: {
-          range: {
-            dob: {
-              low: {},
-              high: "2010-01-01 00:00:00",
-            },
-          },
-        },
-      })
-    )
-    expect(query).toEqual({
-      bindings: ["2010-01-01 00:00:00", 500],
-      sql: `select * from (select * from "${TABLE_NAME}" where "${TABLE_NAME}"."dob" <= $1 limit $2) as "${TABLE_NAME}"`,
-    })
-  })
-
   it("should lowercase the values for Oracle LIKE statements", () => {
     let query = new Sql(SqlClient.ORACLE, limit)._query(
       generateReadJson({

--- a/packages/server/src/integrations/tests/sql.spec.ts
+++ b/packages/server/src/integrations/tests/sql.spec.ts
@@ -235,21 +235,6 @@ describe("SQL query builder", () => {
     })
   })
 
-  it("should sort SQL Server tables by the primary key if no sort data is provided", () => {
-    let query = new Sql(SqlClient.MS_SQL, limit)._query(
-      generateReadJson({
-        sort: {},
-        paginate: {
-          limit: 10,
-        },
-      })
-    )
-    expect(query).toEqual({
-      bindings: [10],
-      sql: `select * from (select top (@p0) * from [test] order by [test].[id] asc) as [test]`,
-    })
-  })
-
   it("should not parse JSON string as Date", () => {
     let query = new Sql(SqlClient.POSTGRES, limit)._query(
       generateCreateJson(TABLE_NAME, {

--- a/packages/server/src/sdk/app/rows/search/sqs.ts
+++ b/packages/server/src/sdk/app/rows/search/sqs.ts
@@ -55,8 +55,8 @@ function buildInternalFieldList(
   return fieldList
 }
 
-function tableInFilter(name: string) {
-  return `:${name}.`
+function tableNameInFieldRegex(tableName: string) {
+  return new RegExp(`^${tableName}.|:${tableName}.`, "g")
 }
 
 function cleanupFilters(filters: SearchFilters, tables: Table[]) {
@@ -72,15 +72,13 @@ function cleanupFilters(filters: SearchFilters, tables: Table[]) {
       // relationship, switch to table ID
       const tableRelated = tables.find(
         table =>
-          table.originalName && key.includes(tableInFilter(table.originalName))
+          table.originalName &&
+          key.match(tableNameInFieldRegex(table.originalName))
       )
       if (tableRelated && tableRelated.originalName) {
-        filter[
-          key.replace(
-            tableInFilter(tableRelated.originalName),
-            tableInFilter(tableRelated._id!)
-          )
-        ] = filter[key]
+        // only replace the first, not replaceAll
+        filter[key.replace(tableRelated.originalName, tableRelated._id!)] =
+          filter[key]
         delete filter[key]
       }
     }

--- a/packages/server/src/tests/utilities/structures.ts
+++ b/packages/server/src/tests/utilities/structures.ts
@@ -37,7 +37,7 @@ export function tableForDatasource(
 ): Table {
   return merge(
     {
-      name: generator.guid(),
+      name: generator.guid().substring(0, 10),
       type: "table",
       sourceType: datasource
         ? TableSourceType.EXTERNAL

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -150,12 +150,6 @@ export async function inputProcessing(
       clonedRow[key] = coerce(value, field.type)
     }
 
-    if (field.type === FieldType.DATETIME) {
-      if (typeof clonedRow[key] === "string") {
-        clonedRow[key] = clonedRow[key].trim()
-      }
-    }
-
     // remove any attachment urls, they are generated on read
     if (field.type === FieldType.ATTACHMENTS) {
       const attachments = clonedRow[key]

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -150,6 +150,12 @@ export async function inputProcessing(
       clonedRow[key] = coerce(value, field.type)
     }
 
+    if (field.type === FieldType.DATETIME) {
+      if (typeof clonedRow[key] === "string") {
+        clonedRow[key] = clonedRow[key].trim()
+      }
+    }
+
     // remove any attachment urls, they are generated on read
     if (field.type === FieldType.ATTACHMENTS) {
       const attachments = clonedRow[key]


### PR DESCRIPTION
## Description

This continues the work of https://github.com/Budibase/budibase/pull/13734 in moving more and more tests out of `sql.spec.ts` and into various integration test files.
