### PR TITLE
Misc fixes

### DIFF
--- a/packages/builder/src/components/common/bindings/BindingPanel.svelte
+++ b/packages/builder/src/components/common/bindings/BindingPanel.svelte
@@ -186,8 +186,6 @@
   }
 
   const updateValue = val => {
-    console.log("val", val)
-
     const runtimeExpression = readableToRuntimeBinding(enrichedBindings, val)
     dispatch("change", val)
     requestEval(runtimeExpression, context, snippets)

--- a/packages/builder/src/components/common/bindings/BindingPanel.svelte
+++ b/packages/builder/src/components/common/bindings/BindingPanel.svelte
@@ -236,11 +236,12 @@
   }
 
   const onChangeJSValue = e => {
+    jsValue = encodeJSBinding(e.detail)
     if (!e.detail?.trim()) {
       // Don't bother saving empty values as JS
-      updateValue("")
+      updateValue(null)
     } else {
-      updateValue(encodeJSBinding(e.detail))
+      updateValue(jsValue)
     }
   }
 

--- a/packages/builder/src/components/common/bindings/BindingPanel.svelte
+++ b/packages/builder/src/components/common/bindings/BindingPanel.svelte
@@ -186,6 +186,8 @@
   }
 
   const updateValue = val => {
+    console.log("val", val)
+
     const runtimeExpression = readableToRuntimeBinding(enrichedBindings, val)
     dispatch("change", val)
     requestEval(runtimeExpression, context, snippets)
@@ -236,8 +238,12 @@
   }
 
   const onChangeJSValue = e => {
-    jsValue = encodeJSBinding(e.detail)
-    updateValue(jsValue)
+    if (!e.detail?.trim()) {
+      // Don't bother saving empty values as JS
+      updateValue("")
+    } else {
+      updateValue(encodeJSBinding(e.detail))
+    }
   }
 
   onMount(() => {

--- a/packages/builder/src/components/common/bindings/DrawerBindableInput.svelte
+++ b/packages/builder/src/components/common/bindings/DrawerBindableInput.svelte
@@ -4,10 +4,9 @@
     readableToRuntimeBinding,
     runtimeToReadableBinding,
   } from "dataBinding"
-
   import ClientBindingPanel from "components/common/bindings/ClientBindingPanel.svelte"
   import { createEventDispatcher, setContext } from "svelte"
-  import { isJSBinding } from "@budibase/string-templates"
+  import { isJSBinding, decodeJSBinding } from "@budibase/string-templates"
   import { builderStore } from "stores/builder"
 
   export let panel = ClientBindingPanel
@@ -35,7 +34,12 @@
   $: isJS = isJSBinding(value)
 
   const saveBinding = () => {
-    onChange(tempValue)
+    // Don't bother saving empty JS expressions as JS
+    let val = tempValue
+    if (decodeJSBinding(tempValue)?.trim() === "") {
+      val = null
+    }
+    onChange(val)
     onBlur()
     builderStore.propertyFocus()
     bindingDrawer.hide()

--- a/packages/builder/src/components/common/bindings/DrawerBindableInput.svelte
+++ b/packages/builder/src/components/common/bindings/DrawerBindableInput.svelte
@@ -6,7 +6,7 @@
   } from "dataBinding"
   import ClientBindingPanel from "components/common/bindings/ClientBindingPanel.svelte"
   import { createEventDispatcher, setContext } from "svelte"
-  import { isJSBinding, decodeJSBinding } from "@budibase/string-templates"
+  import { isJSBinding } from "@budibase/string-templates"
   import { builderStore } from "stores/builder"
 
   export let panel = ClientBindingPanel
@@ -34,12 +34,7 @@
   $: isJS = isJSBinding(value)
 
   const saveBinding = () => {
-    // Don't bother saving empty JS expressions as JS
-    let val = tempValue
-    if (decodeJSBinding(tempValue)?.trim() === "") {
-      val = null
-    }
-    onChange(val)
+    onChange(tempValue)
     onBlur()
     builderStore.propertyFocus()
     bindingDrawer.hide()

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ScreenList/DropdownMenu.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ScreenList/DropdownMenu.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { screenStore, componentStore } from "stores/builder"
+  import { screenStore, componentStore, navigationStore } from "stores/builder"
   import ConfirmDialog from "components/common/ConfirmDialog.svelte"
   import {
     ActionMenu,
@@ -12,6 +12,7 @@
   import ScreenDetailsModal from "components/design/ScreenDetailsModal.svelte"
   import sanitizeUrl from "helpers/sanitizeUrl"
   import { makeComponentUnique } from "helpers/components"
+  import { capitalise } from "helpers"
 
   export let screenId
 
@@ -48,6 +49,13 @@
     try {
       // Create the screen
       await screenStore.save(duplicateScreen)
+
+      // Add new screen to navigation
+      await navigationStore.saveLink(
+        duplicateScreen.routing.route,
+        capitalise(duplicateScreen.routing.route.split("/")[1]),
+        duplicateScreen.routing.roleId
+      )
     } catch (error) {
       notifications.error("Error duplicating screen")
     }

--- a/packages/client/src/components/app/NavItem.svelte
+++ b/packages/client/src/components/app/NavItem.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { createEventDispatcher, getContext } from "svelte"
+  import { createEventDispatcher } from "svelte"
   import active from "svelte-spa-router/active"
   import { Icon } from "@budibase/bbui"
 
@@ -13,8 +13,6 @@
   export let navStateStore
 
   const dispatch = createEventDispatcher()
-  const sdk = getContext("sdk")
-  const { linkable } = sdk
 
   let renderKey
 
@@ -46,10 +44,9 @@
       styled
     -->
     <a
-      href={url}
+      href="#{url}"
       on:click={onClickLink}
       use:active={url}
-      use:linkable
       class:active={false}
     >
       {text}
@@ -73,10 +70,9 @@
           {#each subLinks || [] as subLink}
             {#if subLink.internalLink}
               <a
-                href={subLink.url}
+                href="#{subLink.url}"
                 on:click={onClickLink}
                 use:active={subLink.url}
-                use:linkable
               >
                 {subLink.text}
               </a>

--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -238,7 +238,13 @@ const triggerAutomationHandler = async action => {
   }
 }
 const navigationHandler = action => {
-  const { url, peek, externalNewTab } = action.parameters
+  let { url, peek, externalNewTab, type } = action.parameters
+
+  // Ensure in-app navigation starts with a slash
+  if (type === "screen" && url && !url.startsWith("/")) {
+    url = `/${url}`
+  }
+
   routeStore.actions.navigate(url, peek, externalNewTab)
   closeSidePanelHandler()
 }


### PR DESCRIPTION
## Description
Various fixes.

- Duplicating a screen now adds it to the navigation
- The "Navigate to" button action will still work now even if you forget to prefix the URL with a /
- App navigation links function more like normal links and can be opened in new tabs
- Clearing a JS expression will set the field back to empty, rather than still showing "JavaScript function" placeholder with an empty expression

## Addresses
- https://linear.app/budibase/issue/BUDI-8130/duplicating-a-screen-does-not-update-navigation
- https://linear.app/budibase/issue/BUDI-6730/navigate-to-button-action-internal-navigation-requires-a-slash
- https://github.com/Budibase/budibase/issues/13653
- https://github.com/Budibase/budibase/issues/13237