### PR TITLE
Handle dateonly types as date only ISO

### DIFF
--- a/packages/bbui/src/helpers.js
+++ b/packages/bbui/src/helpers.js
@@ -177,7 +177,7 @@ export const stringifyDate = (
     const year = value.year()
     const month = `${value.month() + 1}`.padStart(2, "0")
     const day = `${value.date()}`.padStart(2, "0")
-    return `${year}-${month}-${day}T00:00:00.000`
+    return `${year}-${month}-${day}`
   }
 
   // Otherwise use a normal ISO string with time and timezone

--- a/packages/server/src/utilities/rowProcessor/utils.ts
+++ b/packages/server/src/utilities/rowProcessor/utils.ts
@@ -105,6 +105,9 @@ export function processDates<T extends Row | Row[]>(
     if (schema.type !== FieldType.DATETIME) {
       continue
     }
+    if (schema.dateOnly) {
+      continue
+    }
     if (!schema.timeOnly && !schema.ignoreTimezones) {
       datesWithTZ.push(column)
     }

--- a/packages/server/src/utilities/schema.ts
+++ b/packages/server/src/utilities/schema.ts
@@ -134,7 +134,11 @@ export function parse(rows: Rows, schema: TableSchema): Rows {
       if (columnType === FieldType.NUMBER) {
         // If provided must be a valid number
         parsedRow[columnName] = columnData ? Number(columnData) : columnData
-      } else if (columnType === FieldType.DATETIME && !columnSchema.timeOnly) {
+      } else if (
+        columnType === FieldType.DATETIME &&
+        !columnSchema.timeOnly &&
+        !columnSchema.dateOnly
+      ) {
         // If provided must be a valid date
         parsedRow[columnName] = columnData
           ? new Date(columnData).toISOString()


### PR DESCRIPTION
## Description
We are currenty handling date only fields in the frontend as date only, but passing the long date string to the backend. This increases the complexity while handling what data to shape/cast, and it's creating some bugs.
The [datetime ISO](https://www.w3.org/TR/NOTE-datetime) already supports date only formatting, and it does not make much sense to handle timezones and similar.
We are changing the date only to be treated as such.

## Addresses
- [BUDI-7221 - (Backend) Wants to use a Date only type in MySQL](https://linear.app/budibase/issue/BUDI-7221/backend-wants-to-use-a-date-only-type-in-mysql)
- https://github.com/Budibase/budibase/pull/13747

## Launchcontrol
Changed the way we handle date only columns