### PR TITLE
Prevent changing date or time only when fetched

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -604,27 +604,29 @@
         <DatePicker bind:value={editableColumn.constraints.datetime.latest} />
       </div>
     </div>
-    {#if datasource?.source !== SourceName.ORACLE && datasource?.source !== SourceName.SQL_SERVER && !editableColumn.dateOnly}
-      <div>
-        <div class="row">
-          <Label>Time zones</Label>
-          <AbsTooltip
-            position="top"
-            type="info"
-            text={isCreating
-              ? null
-              : "We recommend not changing how timezones are handled for existing columns, as existing data will not be updated"}
-          >
-            <Icon size="XS" name="InfoOutline" />
-          </AbsTooltip>
+    {#if !editableColumn.timeOnly}
+      {#if datasource?.source !== SourceName.ORACLE && datasource?.source !== SourceName.SQL_SERVER && !editableColumn.dateOnly}
+        <div>
+          <div class="row">
+            <Label>Time zones</Label>
+            <AbsTooltip
+              position="top"
+              type="info"
+              text={isCreating
+                ? null
+                : "We recommend not changing how timezones are handled for existing columns, as existing data will not be updated"}
+            >
+              <Icon size="XS" name="InfoOutline" />
+            </AbsTooltip>
+          </div>
+          <Toggle
+            bind:value={editableColumn.ignoreTimezones}
+            text="Ignore time zones"
+          />
         </div>
-        <Toggle
-          bind:value={editableColumn.ignoreTimezones}
-          text="Ignore time zones"
-        />
-      </div>
+      {/if}
+      <Toggle bind:value={editableColumn.dateOnly} text="Date only" />
     {/if}
-    <Toggle bind:value={editableColumn.dateOnly} text="Date only" />
   {:else if editableColumn.type === FieldType.NUMBER && !editableColumn.autocolumn}
     <div class="split-label">
       <div class="label-length">

--- a/packages/server/src/sdk/app/tables/external/index.ts
+++ b/packages/server/src/sdk/app/tables/external/index.ts
@@ -77,7 +77,7 @@ function validate(table: Table, oldTable?: Table) {
     if (column.type === FieldType.DATETIME) {
       const oldColumn = oldTable?.schema[key] as typeof column
 
-      if (column.timeOnly !== oldColumn.timeOnly) {
+      if (oldColumn && column.timeOnly !== oldColumn.timeOnly) {
         throw new Error(
           `Column "${key}" can not change from time to datetime or viceversa.`
         )

--- a/packages/server/src/sdk/app/tables/external/index.ts
+++ b/packages/server/src/sdk/app/tables/external/index.ts
@@ -73,6 +73,16 @@ function validate(table: Table, oldTable?: Table) {
         `Column "${key}" has subtype "${column.subtype}" - this is not supported.`
       )
     }
+
+    if (column.type === FieldType.DATETIME) {
+      const oldColumn = oldTable?.schema[key] as typeof column
+
+      if (column.timeOnly !== oldColumn.timeOnly) {
+        throw new Error(
+          `Column "${key}" can not change from time to datetime or viceversa.`
+        )
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Description
Time only columns use time format on the databases, that are not always compatible with datetime stamps ISOs. Trying to save date times to time columns or vice-versa would fail, so we don't want to allow time-only columns to be changed to be used as date/datetime.

## Addresses
- [[BUDI-8279] Time only issues](https://linear.app/budibase/issue/BUDI-8279/time-only-issues)

## Screenshots
<img width="431" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/75ab6c44-3f4f-4e00-b6b0-20c2f7b519c4">

## Launchcontrol
Prevent time-only fields to be changed to date
