### PR TITLE
Validate time fields

### DIFF
--- a/packages/bbui/src/helpers.js
+++ b/packages/bbui/src/helpers.js
@@ -168,7 +168,11 @@ export const stringifyDate = (
     // Ensure we use the correct offset for the date
     const referenceDate = value.toDate()
     const offset = referenceDate.getTimezoneOffset() * 60000
-    return new Date(value.valueOf() - offset).toISOString().slice(0, -1)
+    const date = new Date(value.valueOf() - offset)
+    if (timeOnly) {
+      return date.toISOString().slice(11, 19)
+    }
+    return date.toISOString().slice(0, -1)
   }
 
   // For date-only fields, construct a manual timestamp string without a time

--- a/packages/server/src/sdk/app/rows/utils.ts
+++ b/packages/server/src/sdk/app/rows/utils.ts
@@ -205,6 +205,10 @@ export async function validate({
       } catch (err) {
         errors[fieldName] = [`Contains invalid JSON`]
       }
+    } else if (type === FieldType.DATETIME && column.timeOnly) {
+      if (row[fieldName] && !row[fieldName].match(/^(\d+)(:[0-5]\d){1,2}$/)) {
+        errors[fieldName] = [`${fieldName} is not a valid time`]
+      }
     } else {
       res = validateJs.single(row[fieldName], constraints)
     }


### PR DESCRIPTION
## Description
Time fields are stored as time strings on the backend. Until now, we were parsing them to timestamps to then deconstruct them to time again. This was causing issues with timezones and similar. Now we are sending back the time string as it is, but we were still sending iso strings from the frontend.

This PR unifies the logic and adds validation


## Addresses
- [[BUDI-8279] Time only issues](https://linear.app/budibase/issue/BUDI-8279/time-only-issues)

## Launchcontrol
Keeping time-only field format consistent