### PR TITLE
Time constraints

### DIFF
--- a/packages/backend-core/src/docIds/ids.ts
+++ b/packages/backend-core/src/docIds/ids.ts
@@ -19,6 +19,14 @@ export const generateAppID = (tenantId?: string | null) => {
 }
 
 /**
+ * Generates a new table ID.
+ * @returns The new table ID which the table doc can be stored under.
+ */
+export function generateTableID() {
+  return `${DocumentType.TABLE}${SEPARATOR}${newid()}`
+}
+
+/**
  * Gets a new row ID for the specified table.
  * @param tableId The table which the row is being created for.
  * @param id If an ID is to be used then the UUID can be substituted for this.

--- a/packages/bbui/src/helpers.js
+++ b/packages/bbui/src/helpers.js
@@ -170,7 +170,8 @@ export const stringifyDate = (
     const offset = referenceDate.getTimezoneOffset() * 60000
     const date = new Date(value.valueOf() - offset)
     if (timeOnly) {
-      return date.toISOString().slice(11, 19)
+      // Extract HH:mm
+      return date.toISOString().slice(11, 16)
     }
     return date.toISOString().slice(0, -1)
   }

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -586,13 +586,17 @@
       bind:constraints={editableColumn.constraints}
       bind:optionColors={editableColumn.optionColors}
     />
-  {:else if editableColumn.type === FieldType.DATETIME && !editableColumn.autocolumn}
+  {:else if editableColumn.type === DATE_TYPE && !editableColumn.autocolumn}
     <div class="split-label">
       <div class="label-length">
         <Label size="M">Earliest</Label>
       </div>
       <div class="input-length">
-        <DatePicker bind:value={editableColumn.constraints.datetime.earliest} />
+        <DatePicker
+          bind:value={editableColumn.constraints.datetime.earliest}
+          enableTime={!editableColumn.dateOnly}
+          timeOnly={editableColumn.timeOnly}
+        />
       </div>
     </div>
 
@@ -601,7 +605,11 @@
         <Label size="M">Latest</Label>
       </div>
       <div class="input-length">
-        <DatePicker bind:value={editableColumn.constraints.datetime.latest} />
+        <DatePicker
+          bind:value={editableColumn.constraints.datetime.latest}
+          enableTime={!editableColumn.dateOnly}
+          timeOnly={editableColumn.timeOnly}
+        />
       </div>
     </div>
     {#if datasource?.source !== SourceName.ORACLE && datasource?.source !== SourceName.SQL_SERVER && !editableColumn.dateOnly}

--- a/packages/server/src/db/utils.ts
+++ b/packages/server/src/db/utils.ts
@@ -77,7 +77,7 @@ export function getTableParams(tableId?: Optional, otherProps = {}) {
  * @returns The new table ID which the table doc can be stored under.
  */
 export function generateTableID() {
-  return `${DocumentType.TABLE}${SEPARATOR}${newid()}`
+  return dbCore.generateTableID()
 }
 
 /**

--- a/packages/server/src/sdk/app/rows/tests/utils.spec.ts
+++ b/packages/server/src/sdk/app/rows/tests/utils.spec.ts
@@ -6,6 +6,7 @@ import {
 } from "@budibase/types"
 import { generateTableID } from "../../../../db/utils"
 import { validate } from "../utils"
+import { generator } from "@budibase/backend-core/tests"
 
 describe("validate", () => {
   describe("time only", () => {
@@ -24,7 +25,7 @@ describe("validate", () => {
       },
     })
 
-    it("should accept empty fields", async () => {
+    it("should accept empty values", async () => {
       const row = {}
       const table = getTable()
       const output = await validate({ table, tableId: table._id!, row })
@@ -32,9 +33,38 @@ describe("validate", () => {
       expect(output.errors).toEqual({})
     })
 
+    it("should accept valid times with HH:mm format", async () => {
+      const row = {
+        time: `${generator.hour()}:${generator.minute()}`,
+      }
+      const table = getTable()
+      const output = await validate({ table, tableId: table._id!, row })
+      expect(output.valid).toBe(true)
+    })
+
+    it("should accept valid times with HH:mm:ss format", async () => {
+      const row = {
+        time: `${generator.hour()}:${generator.minute()}:${generator.second()}`,
+      }
+      const table = getTable()
+      const output = await validate({ table, tableId: table._id!, row })
+      expect(output.valid).toBe(true)
+    })
+
     describe("required", () => {
-      it("should reject empty fields", async () => {
+      it("should reject empty values", async () => {
         const row = {}
+        const table = getTable()
+        table.schema.time.constraints = {
+          presence: true,
+        }
+        const output = await validate({ table, tableId: table._id!, row })
+        expect(output.valid).toBe(false)
+        expect(output.errors).toEqual({ time: ["can't be blank"] })
+      })
+
+      it.each([undefined, null])("should reject %s values", async time => {
+        const row = { time }
         const table = getTable()
         table.schema.time.constraints = {
           presence: true,

--- a/packages/server/src/sdk/app/rows/tests/utils.spec.ts
+++ b/packages/server/src/sdk/app/rows/tests/utils.spec.ts
@@ -1,0 +1,48 @@
+import {
+  FieldType,
+  INTERNAL_TABLE_SOURCE_ID,
+  Table,
+  TableSourceType,
+} from "@budibase/types"
+import { generateTableID } from "../../../../db/utils"
+import { validate } from "../utils"
+
+describe("validate", () => {
+  describe("time only", () => {
+    const getTable = (): Table => ({
+      type: "table",
+      _id: generateTableID(),
+      name: "table",
+      sourceId: INTERNAL_TABLE_SOURCE_ID,
+      sourceType: TableSourceType.INTERNAL,
+      schema: {
+        time: {
+          name: "time",
+          type: FieldType.DATETIME,
+          timeOnly: true,
+        },
+      },
+    })
+
+    it("should accept empty fields", async () => {
+      const row = {}
+      const table = getTable()
+      const output = await validate({ table, tableId: table._id!, row })
+      expect(output.valid).toBe(true)
+      expect(output.errors).toEqual({})
+    })
+
+    describe("required", () => {
+      it("should reject empty fields", async () => {
+        const row = {}
+        const table = getTable()
+        table.schema.time.constraints = {
+          presence: true,
+        }
+        const output = await validate({ table, tableId: table._id!, row })
+        expect(output.valid).toBe(false)
+        expect(output.errors).toEqual({ time: ["can't be blank"] })
+      })
+    })
+  })
+})

--- a/packages/server/src/sdk/app/rows/tests/utils.spec.ts
+++ b/packages/server/src/sdk/app/rows/tests/utils.spec.ts
@@ -183,6 +183,26 @@ describe("validate", () => {
             time: ["must be no later than 15:00"],
           })
         })
+
+        describe("range crossing midnight", () => {
+          const table = getTable()
+          table.schema.time.constraints = {
+            presence: true,
+            datetime: {
+              earliest: "15:00",
+              latest: "10:00",
+            },
+          }
+
+          it.each(["10:00", "15:00", `9:${minute()}`, "16:34"])(
+            "should accept values in range (%s)",
+            async time => {
+              const row = { time }
+              const output = await validate({ table, tableId: table._id!, row })
+              expect(output.valid).toBe(true)
+            }
+          )
+        })
       })
     })
 

--- a/packages/server/src/sdk/app/rows/tests/utils.spec.ts
+++ b/packages/server/src/sdk/app/rows/tests/utils.spec.ts
@@ -194,12 +194,24 @@ describe("validate", () => {
             },
           }
 
-          it.each(["10:00", "15:00", `9:${minute()}`, "16:34"])(
+          it.each(["10:00", "15:00", `9:${minute()}`, "16:34", "00:00"])(
             "should accept values in range (%s)",
             async time => {
               const row = { time }
               const output = await validate({ table, tableId: table._id!, row })
               expect(output.valid).toBe(true)
+            }
+          )
+
+          it.each(["10:01", "14:59:59", `12:${minute()}`])(
+            "should reject values out range (%s)",
+            async time => {
+              const row = { time }
+              const output = await validate({ table, tableId: table._id!, row })
+              expect(output.valid).toBe(false)
+              expect(output.errors).toEqual({
+                time: ["must be no later than 10:00"],
+              })
             }
           )
         })

--- a/packages/server/src/sdk/app/rows/utils.ts
+++ b/packages/server/src/sdk/app/rows/utils.ts
@@ -224,13 +224,16 @@ function validateTimeOnlyField(
 ) {
   let res
   if (value && !value.match(/^(\d+)(:[0-5]\d){1,2}$/)) {
-    res = [`${fieldName} is not a valid time`]
-  }
-  if (constraints) {
+    res = [`"${fieldName}" is not a valid time`]
+  } else if (constraints) {
     let castedValue = value
     const stringTimeToDateISOString = (value: string) => {
-      const [hour, minute] = value.split(":").map((x: string) => +x)
-      return dayjs().hour(hour).minute(minute).toISOString()
+      const [hour, minute, second] = value.split(":").map((x: string) => +x)
+      let date = dayjs("2000-01-01T00:00:00.000Z").hour(hour).minute(minute)
+      if (!isNaN(second)) {
+        date = date.second(second)
+      }
+      return date.toISOString()
     }
 
     if (castedValue) {

--- a/packages/server/src/sdk/app/rows/utils.ts
+++ b/packages/server/src/sdk/app/rows/utils.ts
@@ -227,31 +227,46 @@ function validateTimeOnlyField(
     res = [`"${fieldName}" is not a valid time`]
   } else if (constraints) {
     let castedValue = value
-    const stringTimeToDateISOString = (value: string) => {
+    const stringTimeToDate = (value: string) => {
       const [hour, minute, second] = value.split(":").map((x: string) => +x)
       let date = dayjs("2000-01-01T00:00:00.000Z").hour(hour).minute(minute)
       if (!isNaN(second)) {
         date = date.second(second)
       }
-      return date.toISOString()
+      return date
     }
 
     if (castedValue) {
-      castedValue = stringTimeToDateISOString(castedValue)
+      castedValue = stringTimeToDate(castedValue)
     }
     let castedConstraints = cloneDeep(constraints)
+
+    let earliest, latest
     if (castedConstraints.datetime?.earliest) {
-      castedConstraints.datetime.earliest = stringTimeToDateISOString(
-        castedConstraints.datetime?.earliest
-      )
+      earliest = stringTimeToDate(castedConstraints.datetime?.earliest)
     }
     if (castedConstraints.datetime?.latest) {
-      castedConstraints.datetime.latest = stringTimeToDateISOString(
-        castedConstraints.datetime?.latest
-      )
+      latest = stringTimeToDate(castedConstraints.datetime?.latest)
     }
 
-    let jsValidation = validateJs.single(castedValue, castedConstraints)
+    if (earliest && latest && earliest.isAfter(latest)) {
+      latest = latest.add(1, "day")
+      if (earliest.isAfter(castedValue)) {
+        castedValue = castedValue.add(1, "day")
+      }
+    }
+
+    if (earliest || latest) {
+      castedConstraints.datetime = {
+        earliest: earliest?.toISOString() || "",
+        latest: latest?.toISOString() || "",
+      }
+    }
+
+    let jsValidation = validateJs.single(
+      castedValue?.toISOString(),
+      castedConstraints
+    )
     jsValidation = jsValidation?.map((m: string) =>
       m
         ?.replace(

--- a/packages/server/src/sdk/app/rows/utils.ts
+++ b/packages/server/src/sdk/app/rows/utils.ts
@@ -242,11 +242,24 @@ function validateTimeOnlyField(
     let castedConstraints = cloneDeep(constraints)
 
     let earliest, latest
+    let easliestTimeString: string, latestTimeString: string
     if (castedConstraints.datetime?.earliest) {
-      earliest = stringTimeToDate(castedConstraints.datetime?.earliest)
+      easliestTimeString = castedConstraints.datetime.earliest
+      if (dayjs(castedConstraints.datetime.earliest).isValid()) {
+        easliestTimeString = dayjs(castedConstraints.datetime.earliest).format(
+          "HH:mm"
+        )
+      }
+      earliest = stringTimeToDate(easliestTimeString)
     }
     if (castedConstraints.datetime?.latest) {
-      latest = stringTimeToDate(castedConstraints.datetime?.latest)
+      latestTimeString = castedConstraints.datetime.latest
+      if (dayjs(castedConstraints.datetime.latest).isValid()) {
+        latestTimeString = dayjs(castedConstraints.datetime.latest).format(
+          "HH:mm"
+        )
+      }
+      latest = stringTimeToDate(latestTimeString)
     }
 
     if (earliest && latest && earliest.isAfter(latest)) {
@@ -271,11 +284,11 @@ function validateTimeOnlyField(
       m
         ?.replace(
           castedConstraints.datetime?.earliest || "",
-          constraints.datetime?.earliest || ""
+          easliestTimeString || ""
         )
         .replace(
           castedConstraints.datetime?.latest || "",
-          constraints.datetime?.latest || ""
+          latestTimeString || ""
         )
     )
     if (jsValidation) {


### PR DESCRIPTION

## Description
Support time only constraints. Currently they can be configured but they were never working.
Added tests to support both existing configs saved as full datetime and time strings

## Addresses
- [[BUDI-8279] Time only issues](https://linear.app/budibase/issue/BUDI-8279/time-only-issues)

## Screenshots
### Range validation
<img width="741" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/28a9da6c-eaa7-4595-b49e-32e55486574c">
<img width="335" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/a7d22064-48f7-4d88-a435-be535697e35a">



### Earliest validation
<img width="741" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/c5c597c9-0445-45f8-8437-702d8554b92b">
<img width="335" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/30edef3c-3991-4c71-b22c-7f8160a34f4c">




### Latest
<img width="741" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/608104d1-d9c2-43c0-a57e-7f9f16f4ee9d">
<img width="335" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/75c3d402-3602-4ad4-beab-fc1c72d3f01f">



## Launchcontrol
Validate time-only constraints

## Feature branch env
[Feature Branch Link](http://fb-budi-8279-time-constrains.fb.qa.budibase.net)
