### PR TITLE
Enum columns unexpectedly breaking fix

### DIFF
--- a/packages/server/src/integration-test/mysql.spec.ts
+++ b/packages/server/src/integration-test/mysql.spec.ts
@@ -284,18 +284,18 @@ describe("mysql integrations", () => {
 
   describe("POST /api/datasources/:datasourceId/schema", () => {
     let tableName: string
-  
+
     beforeEach(async () => {
       tableName = uniqueTableName()
-    });
-  
+    })
+
     afterEach(async () => {
       await rawQuery(rawDatasource, `DROP TABLE IF EXISTS \`${tableName}\``)
     })
-  
+
     it("recognises enum columns as options", async () => {
-      const enumColumnName = 'status'
-  
+      const enumColumnName = "status"
+
       const createTableQuery = `
         CREATE TABLE \`${tableName}\` (
           \`order_id\` INT AUTO_INCREMENT PRIMARY KEY,
@@ -303,19 +303,18 @@ describe("mysql integrations", () => {
           \`${enumColumnName}\` ENUM('pending', 'processing', 'shipped', 'delivered', 'cancelled')
         );
       `
-  
+
       await rawQuery(rawDatasource, createTableQuery)
-  
+
       const response = await makeRequest(
         "post",
         `/api/datasources/${datasource._id}/schema`
       )
-  
+
       const table = response.body.datasource.entities[tableName]
-  
+
       expect(table).toBeDefined()
       expect(table.schema[enumColumnName].type).toEqual(FieldType.OPTIONS)
-    });
-  });
-  
+    })
+  })
 })

--- a/packages/server/src/integration-test/mysql.spec.ts
+++ b/packages/server/src/integration-test/mysql.spec.ts
@@ -17,7 +17,6 @@ import {
   rawQuery,
 } from "../integrations/tests/utils"
 import { generator } from "@budibase/backend-core/tests"
-import { log } from "console";
 // @ts-ignore
 fetch.mockSearch()
 

--- a/packages/server/src/integration-test/mysql.spec.ts
+++ b/packages/server/src/integration-test/mysql.spec.ts
@@ -17,6 +17,7 @@ import {
   rawQuery,
 } from "../integrations/tests/utils"
 import { generator } from "@budibase/backend-core/tests"
+import { log } from "console";
 // @ts-ignore
 fetch.mockSearch()
 
@@ -281,4 +282,41 @@ describe("mysql integrations", () => {
       ])
     })
   })
+
+  describe("POST /api/datasources/:datasourceId/schema", () => {
+    let tableName: string
+  
+    beforeEach(async () => {
+      tableName = uniqueTableName()
+    });
+  
+    afterEach(async () => {
+      await rawQuery(rawDatasource, `DROP TABLE IF EXISTS \`${tableName}\``)
+    })
+  
+    it("recognises enum columns as options", async () => {
+      const enumColumnName = 'status'
+  
+      const createTableQuery = `
+        CREATE TABLE \`${tableName}\` (
+          \`order_id\` INT AUTO_INCREMENT PRIMARY KEY,
+          \`customer_name\` VARCHAR(100) NOT NULL,
+          \`${enumColumnName}\` ENUM('pending', 'processing', 'shipped', 'delivered', 'cancelled')
+        );
+      `
+  
+      await rawQuery(rawDatasource, createTableQuery)
+  
+      const response = await makeRequest(
+        "post",
+        `/api/datasources/${datasource._id}/schema`
+      )
+  
+      const table = response.body.datasource.entities[tableName]
+  
+      expect(table).toBeDefined()
+      expect(table.schema[enumColumnName].type).toEqual(FieldType.OPTIONS)
+    });
+  });
+  
 })

--- a/packages/server/src/integration-test/postgres.spec.ts
+++ b/packages/server/src/integration-test/postgres.spec.ts
@@ -1122,6 +1122,31 @@ describe("postgres integrations", () => {
         [tableName]: "Table contains invalid columns.",
       })
     })
+
+    it("recognises enum columns as options", async () => {
+      const tableName = `orders_${generator.guid().replaceAll("-", "").substring(0, 6)}`
+      const enumColumnName = 'status'
+      
+      await rawQuery(rawDatasource, `
+        CREATE TYPE order_status AS ENUM ('pending', 'processing', 'shipped', 'delivered', 'cancelled');
+        
+        CREATE TABLE ${tableName} (
+          order_id SERIAL PRIMARY KEY,
+          customer_name VARCHAR(100) NOT NULL,
+          ${enumColumnName} order_status
+        );
+      `)
+  
+      const response = await makeRequest(
+        "post",
+        `/api/datasources/${datasource._id}/schema`
+      )
+  
+      const table = response.body.datasource.entities[tableName]
+  
+      expect(table).toBeDefined();
+      expect(table.schema[enumColumnName].type).toEqual(FieldType.OPTIONS)
+    })
   })
 
   describe("Integration compatibility with postgres search_path", () => {

--- a/packages/server/src/integration-test/postgres.spec.ts
+++ b/packages/server/src/integration-test/postgres.spec.ts
@@ -1124,10 +1124,15 @@ describe("postgres integrations", () => {
     })
 
     it("recognises enum columns as options", async () => {
-      const tableName = `orders_${generator.guid().replaceAll("-", "").substring(0, 6)}`
-      const enumColumnName = 'status'
-      
-      await rawQuery(rawDatasource, `
+      const tableName = `orders_${generator
+        .guid()
+        .replaceAll("-", "")
+        .substring(0, 6)}`
+      const enumColumnName = "status"
+
+      await rawQuery(
+        rawDatasource,
+        `
         CREATE TYPE order_status AS ENUM ('pending', 'processing', 'shipped', 'delivered', 'cancelled');
         
         CREATE TABLE ${tableName} (
@@ -1135,16 +1140,17 @@ describe("postgres integrations", () => {
           customer_name VARCHAR(100) NOT NULL,
           ${enumColumnName} order_status
         );
-      `)
-  
+      `
+      )
+
       const response = await makeRequest(
         "post",
         `/api/datasources/${datasource._id}/schema`
       )
-  
+
       const table = response.body.datasource.entities[tableName]
-  
-      expect(table).toBeDefined();
+
+      expect(table).toBeDefined()
       expect(table.schema[enumColumnName].type).toEqual(FieldType.OPTIONS)
     })
   })

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -329,14 +329,12 @@ class PostgresIntegration extends Sql implements DatasourcePlus {
 
       // Fetch enum values
       const enumsResponse = await this.client.query(this.ENUM_VALUES())
+      // output array, allows for more than 1 single-select to be used at a time
       const enumValues = enumsResponse.rows?.reduce((acc, row) => {
-        if (!acc[row.typname]) {
           return {
-            [row.typname]: [row.enumlabel],
-          }
-        }
-        acc[row.typname].push(row.enumlabel)
-        return acc
+              ...acc,
+              [row.typname]: [...(acc[row.typname] || []), row.enumlabel]
+          };
       }, {})
 
       for (let column of columnsResponse.rows) {

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -331,10 +331,10 @@ class PostgresIntegration extends Sql implements DatasourcePlus {
       const enumsResponse = await this.client.query(this.ENUM_VALUES())
       // output array, allows for more than 1 single-select to be used at a time
       const enumValues = enumsResponse.rows?.reduce((acc, row) => {
-          return {
-              ...acc,
-              [row.typname]: [...(acc[row.typname] || []), row.enumlabel]
-          };
+        return {
+          ...acc,
+          [row.typname]: [...(acc[row.typname] || []), row.enumlabel],
+        }
       }, {})
 
       for (let column of columnsResponse.rows) {

--- a/packages/server/src/integrations/utils/utils.ts
+++ b/packages/server/src/integrations/utils/utils.ts
@@ -102,6 +102,7 @@ const SQL_OPTIONS_TYPE_MAP: Record<string, PrimitiveTypes> = {
 const SQL_MISC_TYPE_MAP: Record<string, PrimitiveTypes> = {
   json: FieldType.JSON,
   bigint: FieldType.BIGINT,
+  enum: FieldType.OPTIONS,
 }
 
 const SQL_TYPE_MAP: Record<string, PrimitiveTypes> = {


### PR DESCRIPTION
## Description
- Fixed issue with enums not using the correct type for MySQL and Postgres datasources.
- Added tests to check that these fields are typed correctly in the future for these datasources.

## Addresses
- https://github.com/Budibase/budibase/issues/13729

## Launchcontrol
Fixed issue with MySQL and Postgres datasources that cause a specific field type to not show up correctly within the Budibase UI.