### PR TITLE
Fix @budibase/types typescript types

### DIFF
--- a/packages/shared-core/package.json
+++ b/packages/shared-core/package.json
@@ -34,6 +34,16 @@
             "target": "build"
           }
         ]
+      },
+      "dev": {
+        "dependsOn": [
+          {
+            "projects": [
+              "@budibase/types"
+            ],
+            "target": "build"
+          }
+        ]
       }
     }
   }

--- a/packages/shared-core/package.json
+++ b/packages/shared-core/package.json
@@ -22,5 +22,19 @@
   "devDependencies": {
     "rimraf": "3.0.2",
     "typescript": "5.2.2"
+  },
+  "nx": {
+    "targets": {
+      "build": {
+        "dependsOn": [
+          {
+            "projects": [
+              "@budibase/types"
+            ],
+            "target": "build"
+          }
+        ]
+      }
+    }
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Budibase types",
   "main": "dist/index.js",
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "author": "Budibase",
   "license": "GPL-3.0",
   "scripts": {


### PR DESCRIPTION
## Description
We found an issue with some typescript types, caused by @budibase/types type definitions pointing to the src folder. This is not being uploaded in the npm package, so it causes type issues.
Pointing them to the existing `dist` built types fixes it, leaving the same dev experience within the monorepo.