### PR TITLE
Prevent write readonly view column

### DIFF
--- a/packages/server/src/middleware/tests/trimViewRowInfo.spec.ts
+++ b/packages/server/src/middleware/tests/trimViewRowInfo.spec.ts
@@ -144,8 +144,12 @@ describe("trimViewRowInfo middleware", () => {
       name: generator.guid(),
       tableId: table._id!,
       schema: {
-        name: {},
-        address: {},
+        name: {
+          visible: true,
+        },
+        address: {
+          visible: true,
+        },
       },
     })
 

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -104,7 +104,13 @@ export async function remove(viewId: string): Promise<ViewV2> {
 
 export function allowedFields(view: View | ViewV2) {
   return [
-    ...Object.keys(view?.schema || {}),
+    ...Object.keys(view?.schema || {}).filter(key => {
+      if (!isV2(view)) {
+        return true
+      }
+      const fieldSchema = view.schema![key]
+      return fieldSchema.visible && !fieldSchema.readonly
+    }),
     ...dbCore.CONSTANT_EXTERNAL_ROW_COLS,
     ...dbCore.CONSTANT_INTERNAL_ROW_COLS,
   ]


### PR DESCRIPTION
## Description
Honoring the [newly added](https://github.com/Budibase/budibase/pull/13778) readonly columns. If these values are sent via the API, they will be simply ignored. This is the way that currently works for "non-visible" fields. This way we don't need to update client usages such as grid and similar.

## Addresses
- [BUDI-8284 - [Readonly views] Backend support for new column configuration](https://linear.app/budibase/issue/BUDI-8284/[readonly-views]-backend-support-for-new-column-configuration)
