### PR TITLE
Add readonly view config

### DIFF
--- a/packages/builder/src/components/backend/DataTable/ViewV2DataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/ViewV2DataTable.svelte
@@ -28,6 +28,7 @@
     showAvatars={false}
     on:updatedatasource={handleGridViewUpdate}
     isCloud={$admin.cloud}
+    allowReadonlyColumns
   >
     <svelte:fragment slot="filter">
       <GridFilterButton />

--- a/packages/builder/src/components/backend/DataTable/ViewV2DataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/ViewV2DataTable.svelte
@@ -1,6 +1,6 @@
 <script>
   import { viewsV2 } from "stores/builder"
-  import { admin } from "stores/portal"
+  import { admin, licensing } from "stores/portal"
   import { Grid } from "@budibase/frontend-core"
   import { API } from "api"
   import GridCreateEditRowModal from "components/backend/DataTable/modals/grid/GridCreateEditRowModal.svelte"
@@ -28,7 +28,8 @@
     showAvatars={false}
     on:updatedatasource={handleGridViewUpdate}
     isCloud={$admin.cloud}
-    allowReadonlyColumns
+    showReadonlyColumnsOptions
+    canSetReadonlyColumns={$licensing.isViewReadonlyColumnsEnabled}
   >
     <svelte:fragment slot="filter">
       <GridFilterButton />

--- a/packages/builder/src/components/backend/DataTable/ViewV2DataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/ViewV2DataTable.svelte
@@ -28,8 +28,7 @@
     showAvatars={false}
     on:updatedatasource={handleGridViewUpdate}
     isCloud={$admin.cloud}
-    showReadonlyColumnsOptions
-    canSetReadonlyColumns={$licensing.isViewReadonlyColumnsEnabled}
+    allowViewReadonlyColumns={$licensing.isViewReadonlyColumnsEnabled}
   >
     <svelte:fragment slot="filter">
       <GridFilterButton />

--- a/packages/builder/src/stores/portal/licensing.js
+++ b/packages/builder/src/stores/portal/licensing.js
@@ -138,6 +138,11 @@ export const createLicensingStore = () => {
       const isViewPermissionsEnabled = license.features.includes(
         Constants.Features.VIEW_PERMISSIONS
       )
+
+      const isViewReadonlyColumnsEnabled = license.features.includes(
+        Constants.Features.VIEW_READONLY_COLUMNS
+      )
+
       store.update(state => {
         return {
           ...state,
@@ -157,6 +162,7 @@ export const createLicensingStore = () => {
           triggerAutomationRunEnabled,
           isViewPermissionsEnabled,
           perAppBuildersEnabled,
+          isViewReadonlyColumnsEnabled,
         }
       })
     },

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
@@ -69,6 +69,10 @@
       return PERMISSION_OPTIONS.HIDDEN
     }
 
+    if (column.readonly) {
+      return PERMISSION_OPTIONS.READONLY
+    }
+
     return PERMISSION_OPTIONS.WRITABLE
   }
 </script>

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
@@ -1,11 +1,11 @@
 <script>
   import { getContext } from "svelte"
   import { ActionButton, Popover, Icon, notifications } from "@budibase/bbui"
-  import { licensing } from "stores/portal"
   import { getColumnIcon } from "../lib/utils"
   import ToggleActionButtonGroup from "./ToggleActionButtonGroup.svelte"
 
-  export let allowReadonlyColumns = false
+  export let showReadonlyColumnsOptions = false
+  export let canSetReadonlyColumns = false
 
   const { columns, datasource, stickyColumn, dispatch } = getContext("grid")
 
@@ -35,8 +35,6 @@
     return restricted ? `Columns (${restricted} restricted)` : "Columns"
   }
 
-  $: isViewReadonlyColumnsEnabled = $licensing.isViewReadonlyColumnsEnabled
-
   const PERMISSION_OPTIONS = {
     WRITABLE: "writable",
     READONLY: "readonly",
@@ -51,10 +49,10 @@
   $: READONLY_OPTION = {
     icon: "Visibility",
     value: PERMISSION_OPTIONS.READONLY,
-    tooltip: isViewReadonlyColumnsEnabled
+    tooltip: canSetReadonlyColumns
       ? "Read only"
       : "Read only (premium feature)",
-    disabled: !isViewReadonlyColumnsEnabled,
+    disabled: !canSetReadonlyColumns,
   }
   const HIDDEN_OPTION = {
     icon: "VisibilityOff",
@@ -62,7 +60,7 @@
     tooltip: "Hidden",
   }
 
-  $: options = allowReadonlyColumns
+  $: options = showReadonlyColumnsOptions
     ? [EDIT_OPTION, READONLY_OPTION, HIDDEN_OPTION]
     : [EDIT_OPTION, HIDDEN_OPTION]
 

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
@@ -4,8 +4,7 @@
   import { getColumnIcon } from "../lib/utils"
   import ToggleActionButtonGroup from "./ToggleActionButtonGroup.svelte"
 
-  export let showReadonlyColumnsOptions = false
-  export let canSetReadonlyColumns = false
+  export let allowViewReadonlyColumns = false
 
   const { columns, datasource, stickyColumn, dispatch } = getContext("grid")
 
@@ -43,10 +42,10 @@
   $: READONLY_OPTION = {
     icon: "Visibility",
     value: PERMISSION_OPTIONS.READONLY,
-    tooltip: canSetReadonlyColumns
+    tooltip: allowViewReadonlyColumns
       ? "Read only"
       : "Read only (premium feature)",
-    disabled: !canSetReadonlyColumns,
+    disabled: !allowViewReadonlyColumns,
   }
   const HIDDEN_OPTION = {
     icon: "VisibilityOff",
@@ -54,9 +53,10 @@
     tooltip: "Hidden",
   }
 
-  $: options = showReadonlyColumnsOptions
-    ? [EDIT_OPTION, READONLY_OPTION, HIDDEN_OPTION]
-    : [EDIT_OPTION, HIDDEN_OPTION]
+  $: options =
+    $datasource.type === "viewV2"
+      ? [EDIT_OPTION, READONLY_OPTION, HIDDEN_OPTION]
+      : [EDIT_OPTION, HIDDEN_OPTION]
 
   function columnToPermissionOptions(column) {
     if (!column.visible) {

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
@@ -12,8 +12,9 @@
   let open = false
   let anchor
 
-  $: anyHidden = $columns.some(col => !col.visible)
-  $: text = getText($columns)
+  $: restrictedColumns = $columns.filter(col => !col.visible || col.readonly)
+  $: anyRestricted = restrictedColumns.length
+  $: text = anyRestricted ? `Columns (${anyRestricted} restricted)` : "Columns"
 
   const toggleColumn = async (column, permission) => {
     const visible = permission !== PERMISSION_OPTIONS.HIDDEN
@@ -26,13 +27,6 @@
       notifications.error(e.message)
     }
     dispatch(visible ? "show-column" : "hide-column")
-  }
-
-  const getText = columns => {
-    const restricted = columns.filter(
-      col => !col.visible || col.readonly
-    ).length
-    return restricted ? `Columns (${restricted} restricted)` : "Columns"
   }
 
   const PERMISSION_OPTIONS = {
@@ -83,7 +77,7 @@
     quiet
     size="M"
     on:click={() => (open = !open)}
-    selected={open || anyHidden}
+    selected={open || anyRestricted}
     disabled={!$columns.length}
   >
     {text}

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
@@ -29,8 +29,10 @@
   }
 
   const getText = columns => {
-    const hidden = columns.filter(col => !col.visible).length
-    return hidden ? `Columns (${hidden} restricted)` : "Columns"
+    const restricted = columns.filter(
+      col => !col.visible || col.readonly
+    ).length
+    return restricted ? `Columns (${restricted} restricted)` : "Columns"
   }
 
   $: isViewReadonlyColumnsEnabled = $licensing.isViewReadonlyColumnsEnabled

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
@@ -1,6 +1,7 @@
 <script>
   import { getContext } from "svelte"
   import { ActionButton, Popover, Icon, notifications } from "@budibase/bbui"
+  import { licensing } from "stores/portal"
   import { getColumnIcon } from "../lib/utils"
   import ToggleActionButtonGroup from "./ToggleActionButtonGroup.svelte"
 
@@ -32,6 +33,8 @@
     return hidden ? `Columns (${hidden} restricted)` : "Columns"
   }
 
+  $: isViewReadonlyColumnsEnabled = $licensing.isViewReadonlyColumnsEnabled
+
   const PERMISSION_OPTIONS = {
     WRITABLE: "writable",
     READONLY: "readonly",
@@ -43,10 +46,13 @@
     value: PERMISSION_OPTIONS.WRITABLE,
     tooltip: "Writable",
   }
-  const READONLY_OPTION = {
+  $: READONLY_OPTION = {
     icon: "Visibility",
     value: PERMISSION_OPTIONS.READONLY,
-    tooltip: "Read only",
+    tooltip: isViewReadonlyColumnsEnabled
+      ? "Read only"
+      : "Read only (premium feature)",
+    disabled: !isViewReadonlyColumnsEnabled,
   }
   const HIDDEN_OPTION = {
     icon: "VisibilityOff",

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
@@ -92,7 +92,7 @@
         <ToggleActionButtonGroup
           disabled
           value={PERMISSION_OPTIONS.WRITABLE}
-          {options}
+          options={options.map(o => ({ ...o, disabled: true }))}
         />
       {/if}
       {#each $columns as column}

--- a/packages/frontend-core/src/components/grid/controls/ToggleActionButtonGroup.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ToggleActionButtonGroup.svelte
@@ -7,7 +7,6 @@
 
   export let value
   export let options
-  export let disabled
 </script>
 
 <div class="permissionPicker">
@@ -15,7 +14,7 @@
     <AbsTooltip text={option.tooltip} type={TooltipType.Info}>
       <ActionButton
         on:click={() => dispatch("click", option.value)}
-        {disabled}
+        disabled={option.disabled}
         size="S"
         icon={option.icon}
         quiet

--- a/packages/frontend-core/src/components/grid/layout/Grid.svelte
+++ b/packages/frontend-core/src/components/grid/layout/Grid.svelte
@@ -57,7 +57,8 @@
   export let buttons = null
   export let darkMode
   export let isCloud = null
-  export let allowReadonlyColumns = false
+  export let showReadonlyColumnsOptions = false
+  export let canSetReadonlyColumns = false
 
   // Unique identifier for DOM nodes inside this instance
   const gridID = `grid-${Math.random().toString().slice(2)}`
@@ -154,7 +155,10 @@
       <div class="controls-left">
         <slot name="filter" />
         <SortButton />
-        <ColumnsSettingButton {allowReadonlyColumns} />
+        <ColumnsSettingButton
+          {showReadonlyColumnsOptions}
+          {canSetReadonlyColumns}
+        />
         <SizeButton />
         <slot name="controls" />
       </div>

--- a/packages/frontend-core/src/components/grid/layout/Grid.svelte
+++ b/packages/frontend-core/src/components/grid/layout/Grid.svelte
@@ -57,6 +57,7 @@
   export let buttons = null
   export let darkMode
   export let isCloud = null
+  export let allowReadonlyColumns = false
 
   // Unique identifier for DOM nodes inside this instance
   const gridID = `grid-${Math.random().toString().slice(2)}`
@@ -153,7 +154,7 @@
       <div class="controls-left">
         <slot name="filter" />
         <SortButton />
-        <ColumnsSettingButton />
+        <ColumnsSettingButton {allowReadonlyColumns} />
         <SizeButton />
         <slot name="controls" />
       </div>

--- a/packages/frontend-core/src/components/grid/layout/Grid.svelte
+++ b/packages/frontend-core/src/components/grid/layout/Grid.svelte
@@ -57,8 +57,7 @@
   export let buttons = null
   export let darkMode
   export let isCloud = null
-  export let showReadonlyColumnsOptions = false
-  export let canSetReadonlyColumns = false
+  export let allowViewReadonlyColumns = false
 
   // Unique identifier for DOM nodes inside this instance
   const gridID = `grid-${Math.random().toString().slice(2)}`
@@ -155,10 +154,7 @@
       <div class="controls-left">
         <slot name="filter" />
         <SortButton />
-        <ColumnsSettingButton
-          {showReadonlyColumnsOptions}
-          {canSetReadonlyColumns}
-        />
+        <ColumnsSettingButton {allowViewReadonlyColumns} />
         <SizeButton />
         <slot name="controls" />
       </div>

--- a/packages/frontend-core/src/components/grid/stores/columns.js
+++ b/packages/frontend-core/src/components/grid/stores/columns.js
@@ -146,6 +146,7 @@ export const initialise = context => {
             schema: fieldSchema,
             width: fieldSchema.width || oldColumn?.width || DefaultColumnWidth,
             visible: fieldSchema.visible ?? true,
+            readonly: fieldSchema.readonly,
             order: fieldSchema.order ?? oldColumn?.order,
             primaryDisplay: field === primaryDisplay,
           }

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -424,7 +424,7 @@ describe.each([
         await config.api.viewV2.create(newView, {
           status: 400,
           body: {
-            message: "Readonly fields are not enabled for your tenant",
+            message: "Readonly fields are not enabled",
             status: 400,
           },
         })
@@ -690,7 +690,7 @@ describe.each([
       await config.api.viewV2.update(view, {
         status: 400,
         body: {
-          message: "Readonly fields are not enabled for your tenant",
+          message: "Readonly fields are not enabled",
         },
       })
     })

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -55,10 +55,7 @@ async function guardViewSchema(
 
     if (viewSchema[field].readonly) {
       if (!(await features.isViewReadonlyColumnsEnabled())) {
-        throw new HTTPError(
-          `Readonly fields are not enabled for your tenant`,
-          400
-        )
+        throw new HTTPError(`Readonly fields are not enabled`, 400)
       }
 
       if (isRequired(tableSchemaField.constraints)) {


### PR DESCRIPTION
## Description
Allow readonly columns configuration on views. This is a paid feature, it will be only enabled for users with the right license but still visible to everybody else.
No actual frontend implementation is developed at this point, just the capability of setting this config value

## Addresses
- [BUDI-8281 - [Readonly views] Update view column UI](https://linear.app/budibase/issue/BUDI-8281/[readonly-views]-update-view-column-ui)

## Screenshots
### Free user view
<img width="476" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/7a99ad34-13bd-48d5-ab8b-31d58ca0b076">
<img width="476" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/8e5fafb9-b8bc-4ac2-9cad-6c69143d4db6">


### Feature available
<img width="476" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/06acbc96-1be6-4e9e-8ec7-07a60bfe9956">
<img width="476" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/ea0aa1d0-87ef-46ac-9dfb-f5f574a4b483">
<img width="476" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/46292436-de40-4e22-a101-1b3f722ae79d">

### Downgraded user using the feature (for security reasons it will still behave as readonly, but it will not be able to set any other value as readonly)
<img width="476" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/b657751f-64dc-4e82-bc4b-7e4351d016ec">


