### PR TITLE
Readonly columns in grid

### DIFF
--- a/packages/frontend-core/src/components/grid/cells/DataCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/DataCell.svelte
@@ -33,7 +33,8 @@
     column.schema.autocolumn ||
     column.schema.disabled ||
     column.schema.type === "formula" ||
-    (!$config.canEditRows && !row._isNewRow)
+    (!$config.canEditRows && !row._isNewRow) ||
+    column.schema.readonly
 
   // Register this cell API if the row is focused
   $: {


### PR DESCRIPTION
## Description
Don't allow cell editions on grid when the column is marked as readonly

## Addresses
- [BUDI-8285 - [Readonly views] Client side read-only columns](https://linear.app/budibase/issue/BUDI-8285/[readonly-views]-client-side-read-only-columns)

## Screenshots
https://github.com/Budibase/budibase/assets/15987277/559ad52c-930e-4e1d-85ae-ab1d646c2201

