### PR TITLE
Readonly columns in forms in the client

### DIFF
--- a/packages/client/src/components/app/forms/InnerForm.svelte
+++ b/packages/client/src/components/app/forms/InnerForm.svelte
@@ -206,7 +206,7 @@
           error: initialError,
           disabled:
             disabled || fieldDisabled || (isAutoColumn && !editAutoColumns),
-          readonly: readonly || fieldReadOnly,
+          readonly: readonly || fieldReadOnly || schema?.[field]?.readonly,
           defaultValue,
           validator,
           lastUpdate: Date.now(),


### PR DESCRIPTION
## Description
With the new "readonly" setting, forms should not allow editing its value when the field is "readonly". For this, we will ignore whatever is set in the config and force a readonly if this is set in the schema.
This way we don't attach the "readonly" to the screen, and if the user decides that a column is not longer readonly (making it editable) the views will behave according to the changes.

## Addresses
- [BUDI-8285 - [Readonly views] Client side read-only columns](https://linear.app/budibase/issue/BUDI-8285/[readonly-views]-client-side-read-only-columns)

## Screenshots
Given the following config:
<img width="600" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/b3a4676f-8f8c-4355-aa0c-5e7cab777583">

### Multistep Form block
https://github.com/Budibase/budibase/assets/15987277/9cfb0552-fa26-4cbc-834b-099e8a38a267



### Custom Form
https://github.com/Budibase/budibase/assets/15987277/ea6a72d9-4c8c-47df-8301-9f837a448688


### Form block
https://github.com/Budibase/budibase/assets/15987277/504baad8-12bb-4f80-a43f-d10f6fe246f4

