### PR TITLE
Fix mariadb healthcheck.

### DIFF
--- a/packages/server/src/integrations/tests/utils/mariadb.ts
+++ b/packages/server/src/integrations/tests/utils/mariadb.ts
@@ -18,7 +18,7 @@ class MariaDBWaitStrategy extends AbstractWaitStrategy {
     await logs.waitUntilReady(container, boundPorts, startTime)
 
     const command = Wait.forSuccessfulCommand(
-      `mysqladmin ping -h localhost -P 3306 -u root -ppassword`
+      `/usr/local/bin/healthcheck.sh --innodb_initialized`
     )
     await command.waitUntilReady(container)
   }


### PR DESCRIPTION
## Description

The image `mariadb:lts` was updated ~10 hours ago and, with it, the `mysqladmin` binary was removed. We were relying on this to healthcheck the image.

Fortunately, we weren't the only ones and the fix is here: https://github.com/MariaDB/mariadb-docker/issues/512#issuecomment-1608976749.