### PR TITLE
Migrate forced releases from QA arc runners to hosted

### DIFF
--- a/.github/workflows/force-release.yml
+++ b/.github/workflows/force-release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   ensure-is-master-tag:
     name: Ensure is a master tag
-    runs-on: qa-arc-runner-set
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout monorepo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description
QA arc runners are being sunset. We're moving all CI workloads to hosted runners.
