### PR TITLE
Update CouchDB chart from 4.3.0 to 4.5.3.

### DIFF
--- a/charts/budibase/Chart.yaml
+++ b/charts/budibase/Chart.yaml
@@ -17,6 +17,6 @@ version: 0.0.0
 appVersion: 0.0.0
 dependencies:
   - name: couchdb
-    version: 4.3.0
+    version: 4.5.3
     repository: https://apache.github.io/couchdb-helm
     condition: services.couchdb.enabled


### PR DESCRIPTION
## Description

In preparation to hopefully get https://github.com/apache/couchdb-helm/pull/154 merged, I'm upgrading us to the latest version of the CouchDB chart.

From the `NEWS.md` file in the CouchDB chart repo, there aren't any breaking changes between 4.3.0 and 4.5.3. Here's the full list:

> ## 4.5.3
> 
> - Fix ability to define pull secrets using `imagePullSecrets`. 
> 
> ## 4.5.2
>
> - Allow to specify a persistentVolumeClaimRetentionPolicy in both the primary and secondary StatefulSet.
>
> ## 4.5.1
> 
> - Update default CouchDB version to 3.3.3.
> 
> ## 4.5.0
> 
> - Add capability to set pod and container level securityContext settings.
> 
> ## 4.4.1
> 
> - Add possibility to customize `service.targetPort` from values. Set default to 5984.

We override the default CouchDB image, so the change 4.5.1 doesn't affect us. Everything else seems to be adding the option to configure things, so should be a no-op by default.

I tested this change on my home cluster and it worked without issue.