### PR TITLE
Feature: Helm Chart support extra env vars using K8s Secrets reference

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -202,6 +202,13 @@ spec:
         - name: {{ .name }}
           value: {{ .value | quote }}
         {{- end }}
+        {{- range .Values.services.apps.extraEnvFromSecret}}
+        - name: {{ .name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .secretName }}
+              key: {{ .secretKey | quote }}
+        {{- end}}
         image: budibase/apps:{{ .Values.globals.appVersion | default .Chart.AppVersion }}
         imagePullPolicy: Always
         {{- if .Values.services.apps.startupProbe }}

--- a/charts/budibase/templates/automation-worker-service-deployment.yaml
+++ b/charts/budibase/templates/automation-worker-service-deployment.yaml
@@ -201,6 +201,13 @@ spec:
         - name: {{ .name }}
           value: {{ .value | quote }}
         {{- end }}
+        {{- range .Values.services.automationWorkers.extraEnvFromSecret}}
+        - name: {{ .name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .secretName }}
+              key: {{ .secretKey | quote }}
+        {{- end}}
 
         image: budibase/apps:{{ .Values.globals.appVersion | default .Chart.AppVersion }}
         imagePullPolicy: Always

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -188,6 +188,13 @@ spec:
         - name: {{ .name }}
           value: {{ .value | quote }}
         {{- end }}
+        {{- range .Values.services.worker.extraEnvFromSecret}}
+        - name: {{ .name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .secretName }}
+              key: {{ .secretKey | quote }}
+        {{- end}}
         image: budibase/worker:{{ .Values.globals.appVersion | default .Chart.AppVersion }}
         imagePullPolicy: Always
         {{- if .Values.services.worker.startupProbe }}

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -240,6 +240,13 @@ services:
     # -- Extra environment variables to set for apps pods. Takes a list of
     # name=value pairs.
     extraEnv: []
+    # -- Name of the K8s Secret in the same namespace which contains the extra environment variables.
+    # This can be used to avoid storing sensitive information in the values.yaml file.
+    extraEnvFromSecret: []
+    #  - name: MY_SECRET_KEY
+    #    secretName : my-secret
+    #    secretKey: my-secret-key
+
     # -- Startup probe configuration for apps pods. You shouldn't need to
     # change this, but if you want to you can find more information here:
     # <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/>
@@ -323,6 +330,13 @@ services:
     # -- Extra environment variables to set for automation worker pods. Takes a list of
     # name=value pairs.
     extraEnv: []
+    # -- Name of the K8s Secret in the same namespace which contains the extra environment variables.
+    # This can be used to avoid storing sensitive information in the values.yaml file.
+    extraEnvFromSecret: []
+    #  - name: MY_SECRET_KEY
+    #    secretName : my-secret
+    #    secretKey: my-secret-key
+
     # -- Startup probe configuration for automation worker pods. You shouldn't
     # need to change this, but if you want to you can find more information
     # here:
@@ -408,6 +422,13 @@ services:
     # -- Extra environment variables to set for worker pods. Takes a list of
     # name=value pairs.
     extraEnv: []
+    # -- Name of the K8s Secret in the same namespace which contains the extra environment variables.
+    # This can be used to avoid storing sensitive information in the values.yaml file.
+    extraEnvFromSecret: []
+    #  - name: MY_SECRET_KEY
+    #    secretName : my-secret
+    #    secretKey: my-secret-key
+
     # -- Startup probe configuration for worker pods. You shouldn't need to
     # change this, but if you want to you can find more information here:
     # <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/>


### PR DESCRIPTION
## Description
- The idea of this feature is already mentioned in the linked issue.
- TLDR: there should be a way to provide environment variables to the respective containers without having them in plain text in the values, in this proposal, using K8s Secrets as a reference

## Addresses
- Issue #13846 