### PR TITLE
Add PR size and team labeler

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -26,6 +26,7 @@ jobs:
   team-labeler:
     runs-on: ubuntu-latest
     name: Label the PR size
+    if: ${{ github.event.action == 'opened' }}
     steps:
       - uses: rodrigoarias/auto-label-per-user@v1.0.0
         with:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,5 +1,9 @@
 name: PR labeler
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types: [opened, synchronize]

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,15 +12,10 @@ jobs:
       - uses: codelytv/pr-size-labeler@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          xs_label: "xs"
           xs_max_size: "10"
-          s_label: "s"
           s_max_size: "100"
-          m_label: "m"
           m_max_size: "500"
-          l_label: "l"
           l_max_size: "1000"
-          xl_label: "xl"
           fail_if_xl: "false"
           files_to_ignore: "yarn.lock"
 

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   size-labeler:
     runs-on: ubuntu-latest
-    name: Label the PR size
     steps:
       - uses: codelytv/pr-size-labeler@v1
         with:
@@ -25,7 +24,6 @@ jobs:
 
   team-labeler:
     runs-on: ubuntu-latest
-    name: Label the PR size
     if: ${{ github.event.action == 'opened' }}
     steps:
       - uses: rodrigoarias/auto-label-per-user@v1.0.0

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,25 @@
+name: PR labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  size-labeler:
+    runs-on: ubuntu-latest
+    name: Label the PR size
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: "xs"
+          xs_max_size: "10"
+          s_label: "s"
+          s_max_size: "100"
+          m_label: "m"
+          m_max_size: "500"
+          l_label: "l"
+          l_max_size: "1000"
+          xl_label: "xl"
+          fail_if_xl: "false"
+          files_to_ignore: "yarn.lock"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -33,8 +33,8 @@ jobs:
           git-token: ${{ secrets.GITHUB_TOKEN }}
           user-team-map: |
             {
-                "adrinr": "firestorm"
-                "samwho": "firestorm"
-                "pclmnt": "firestorm"
+                "adrinr": "firestorm",
+                "samwho": "firestorm",
+                "pclmnt": "firestorm",
                 "mike12345567": "firestorm"
             }

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -23,3 +23,18 @@ jobs:
           xl_label: "xl"
           fail_if_xl: "false"
           files_to_ignore: "yarn.lock"
+
+  team-labeler:
+    runs-on: ubuntu-latest
+    name: Label the PR size
+    steps:
+      - uses: rodrigoarias/auto-label-per-user@v1.0.0
+        with:
+          git-token: ${{ secrets.GITHUB_TOKEN }}
+          user-team-map: |
+            {
+                "adrinr": "firestorm"
+                "samwho": "firestorm"
+                "pclmnt": "firestorm"
+                "mike12345567": "firestorm"
+            }


### PR DESCRIPTION
## Description
Automatically add the following tags:
1. Size, using the action https://github.com/CodelyTV/pr-size-labeler
2. `firestorm` for PRs created by firestorm devs, using https://github.com/rodrigoarias/auto-label-per-user