### PR TITLE
Support existing view configurations

### DIFF
--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
@@ -49,12 +49,15 @@
 
     const requiredTooltip = isRequired && "Required columns must be writable"
 
+    const editEnabled =
+      !isRequired ||
+      columnToPermissionOptions(c) !== PERMISSION_OPTIONS.WRITABLE
     const options = [
       {
         icon: "Edit",
         value: PERMISSION_OPTIONS.WRITABLE,
-        tooltip: requiredTooltip || "Writable",
-        disabled: isRequired,
+        tooltip: (!editEnabled && requiredTooltip) || "Writable",
+        disabled: !editEnabled,
       },
     ]
     if ($datasource.type === "viewV2") {

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -841,51 +841,52 @@ describe.each([
       )
     })
 
-    it("updating schema will only validate modified field", async () => {
-      let view = await config.api.viewV2.create({
-        tableId: table._id!,
-        name: generator.guid(),
-        schema: {
-          id: { visible: true },
-          Price: {
-            visible: true,
-          },
-          Category: { visible: true },
-        },
-      })
-
-      // Update the view to an invalid state
-      const tableToUpdate = await config.api.table.get(table._id!)
-      ;(tableToUpdate.views![view.name] as ViewV2).schema!.id.visible = false
-      await db.getDB(config.appId!).put(tableToUpdate)
-
-      view = await config.api.viewV2.get(view.id)
-      await config.api.viewV2.update({
-        ...view,
-        schema: {
-          ...view.schema,
-          Price: {
-            visible: false,
-          },
-        },
-      })
-
-      expect(await config.api.viewV2.get(view.id)).toEqual(
-        expect.objectContaining({
+    isInternal &&
+      it("updating schema will only validate modified field", async () => {
+        let view = await config.api.viewV2.create({
+          tableId: table._id!,
+          name: generator.guid(),
           schema: {
-            id: expect.objectContaining({
-              visible: false,
-            }),
-            Price: expect.objectContaining({
-              visible: false,
-            }),
-            Category: expect.objectContaining({
+            id: { visible: true },
+            Price: {
               visible: true,
-            }),
+            },
+            Category: { visible: true },
           },
         })
-      )
-    })
+
+        // Update the view to an invalid state
+        const tableToUpdate = await config.api.table.get(table._id!)
+        ;(tableToUpdate.views![view.name] as ViewV2).schema!.id.visible = false
+        await db.getDB(config.appId!).put(tableToUpdate)
+
+        view = await config.api.viewV2.get(view.id)
+        await config.api.viewV2.update({
+          ...view,
+          schema: {
+            ...view.schema,
+            Price: {
+              visible: false,
+            },
+          },
+        })
+
+        expect(await config.api.viewV2.get(view.id)).toEqual(
+          expect.objectContaining({
+            schema: {
+              id: expect.objectContaining({
+                visible: false,
+              }),
+              Price: expect.objectContaining({
+                visible: false,
+              }),
+              Category: expect.objectContaining({
+                visible: true,
+              }),
+            },
+          })
+        )
+      })
   })
 
   describe("delete", () => {

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -22,7 +22,7 @@ import { generator, mocks } from "@budibase/backend-core/tests"
 import { DatabaseName, getDatasource } from "../../../integrations/tests/utils"
 import merge from "lodash/merge"
 import { quotas } from "@budibase/pro"
-import { roles } from "@budibase/backend-core"
+import { db, roles } from "@budibase/backend-core"
 
 describe.each([
   ["internal", undefined],
@@ -836,6 +836,52 @@ describe.each([
               visible: true,
               readonly: false,
             },
+          },
+        })
+      )
+    })
+
+    it("updating schema will only validate modified field", async () => {
+      let view = await config.api.viewV2.create({
+        tableId: table._id!,
+        name: generator.guid(),
+        schema: {
+          id: { visible: true },
+          Price: {
+            visible: true,
+          },
+          Category: { visible: true },
+        },
+      })
+
+      // Update the view to an invalid state
+      const tableToUpdate = await config.api.table.get(table._id!)
+      ;(tableToUpdate.views![view.name] as ViewV2).schema!.id.visible = false
+      await db.getDB(config.appId!).put(tableToUpdate)
+
+      view = await config.api.viewV2.get(view.id)
+      await config.api.viewV2.update({
+        ...view,
+        schema: {
+          ...view.schema,
+          Price: {
+            visible: false,
+          },
+        },
+      })
+
+      expect(await config.api.viewV2.get(view.id)).toEqual(
+        expect.objectContaining({
+          schema: {
+            id: expect.objectContaining({
+              visible: false,
+            }),
+            Price: expect.objectContaining({
+              visible: false,
+            }),
+            Category: expect.objectContaining({
+              visible: true,
+            }),
           },
         })
       )

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -77,7 +77,7 @@ async function guardViewSchema(
 
     if (!viewSchemaField?.visible) {
       throw new HTTPError(
-        `You can't hide "${field.name} because it is a required field."`,
+        `You can't hide "${field.name}" because it is a required field.`,
         400
       )
     }


### PR DESCRIPTION
## Description
With the new hidden validation, we can have some stale views where required columns are hidden in views. Not allowing editing them means that these views would be unusable. This PR does the following changes:
1. On the API, don't validate configs that did not change (this will allow editing views with multiple "broken" fields)
2. In the frontend, allow setting these fields as writable (in order to fix it)


## Screenshots
VIN column is required, but the view was already created as "hidden"


https://github.com/Budibase/budibase/assets/15987277/5ac048bd-4ef4-43c1-928c-b46dc0309c25

