### PR TITLE
Quick fix for roles binding in JS

### DIFF
--- a/packages/builder/src/dataBinding.js
+++ b/packages/builder/src/dataBinding.js
@@ -728,7 +728,7 @@ const getRoleBindings = () => {
   return (get(rolesStore) || []).map(role => {
     return {
       type: "context",
-      runtimeBinding: `trim "${role._id}"`,
+      runtimeBinding: `'${role._id}'`,
       readableBinding: `Role.${role.name}`,
       category: "Role",
       icon: "UserGroup",

--- a/packages/string-templates/src/helpers/javascript.ts
+++ b/packages/string-templates/src/helpers/javascript.ts
@@ -33,7 +33,12 @@ const removeSquareBrackets = (value: string) => {
 // Our context getter function provided to JS code as $.
 // Extracts a value from context.
 const getContextValue = (path: string, context: any) => {
+  const literalStringRegex = /^(["'`]).*\1$/
   let data = context
+  // check if it's a literal string - just return path if its quoted
+  if (literalStringRegex.test(path)) {
+    return path.substring(1, path.length - 1)
+  }
   path.split(".").forEach(key => {
     if (data == null || typeof data !== "object") {
       return null

--- a/packages/string-templates/test/javascript.spec.ts
+++ b/packages/string-templates/test/javascript.spec.ts
@@ -149,4 +149,11 @@ describe("Javascript", () => {
       expect(output).toMatch(UUID_REGEX)
     })
   })
+
+  describe("JS literal strings", () => {
+    it("should be able to handle a literal string that is quoted (like role IDs)", () => {
+      const output = processJS(`return $("'Custom'")`)
+      expect(output).toBe("Custom")
+    })
+  })
 })


### PR DESCRIPTION
## Description
Quick fix for using the roles option within the builder - this was broken in JS which was a bit of a pain - this works properly now and allows more compat between HBS and JS.

## Addresses
- https://github.com/Budibase/budibase/issues/10062
- https://linear.app/budibase/issue/BUDI-6768/custom-roles-expand-to-invalid-syntax-in-javascript-editor