### PR TITLE
Adding current user global ID binding

### DIFF
--- a/packages/builder/src/dataBinding.js
+++ b/packages/builder/src/dataBinding.js
@@ -30,6 +30,7 @@ import ActionDefinitions from "components/design/settings/controls/ButtonActionE
 import { environment, licensing } from "stores/portal"
 import { convertOldFieldFormat } from "components/design/settings/controls/FieldConfiguration/utils"
 import { FIELDS } from "constants/backend"
+import { FieldType } from "@budibase/types"
 
 const { ContextScopes } = Constants
 
@@ -555,6 +556,9 @@ const getComponentBindingCategory = (component, context, def) => {
 export const getUserBindings = () => {
   let bindings = []
   const { schema } = getSchemaForDatasourcePlus(TableNames.USERS)
+  // add props that are not in the user metadata table schema
+  // but will be there for logged-in user
+  schema["globalId"] = { type: FieldType.STRING }
   const keys = Object.keys(schema).sort()
   const safeUser = makePropSafe("user")
 

--- a/packages/server/src/api/controllers/auth.ts
+++ b/packages/server/src/api/controllers/auth.ts
@@ -1,7 +1,7 @@
 import { outputProcessing } from "../../utilities/rowProcessor"
 import { InternalTables } from "../../db/utils"
 import { getFullUser } from "../../utilities/users"
-import { roles, context } from "@budibase/backend-core"
+import { roles, context, db as dbCore } from "@budibase/backend-core"
 import { ContextUser, Row, UserCtx } from "@budibase/types"
 import sdk from "../../sdk"
 import { processUser } from "../../utilities/global"
@@ -27,6 +27,8 @@ export async function fetchSelf(ctx: UserCtx) {
 
   const appId = context.getAppId()
   let user: ContextUser = await getFullUser(userId)
+  // add globalId of user
+  user.globalId = dbCore.getGlobalIDFromUserMetadataID(userId)
   // this shouldn't be returned by the app self
   delete user.roles
   // forward the csrf token from the session


### PR DESCRIPTION
## Description
Adding a global binding for `globalId` which is retrieved as part of the self call - making sure this is available as a binding (this is not in the user metadata table, just for bindings).

Useful feature suggested by Ronan.