### PR TITLE
Fix time-only form fields for internal db

### DIFF
--- a/packages/client/src/components/app/blocks/FormBlockComponent.svelte
+++ b/packages/client/src/components/app/blocks/FormBlockComponent.svelte
@@ -69,9 +69,13 @@
         }
       },
       [FieldType.DATETIME]: (_field, schema) => {
-        return {
+        const props = {
           valueAsTimestamp: !schema?.timeOnly,
         }
+        if (schema?.dateOnly) {
+          props.enableTime = false
+        }
+        return props
       },
     }
 

--- a/packages/client/src/components/app/blocks/FormBlockComponent.svelte
+++ b/packages/client/src/components/app/blocks/FormBlockComponent.svelte
@@ -68,6 +68,11 @@
           maximum: schema?.constraints?.length?.maximum,
         }
       },
+      [FieldType.DATETIME]: (_field, schema) => {
+        return {
+          valueAsTimestamp: !schema?.timeOnly,
+        }
+      },
     }
 
     const fieldSchema = getFieldSchema(field)

--- a/packages/client/src/components/app/forms/DateTimeField.svelte
+++ b/packages/client/src/components/app/forms/DateTimeField.svelte
@@ -16,15 +16,37 @@
   export let onChange
   export let span
   export let helpText = null
+  export let valueAsTimestamp = false
 
   let fieldState
   let fieldApi
 
   const handleChange = e => {
-    const changed = fieldApi.setValue(e.detail)
-    if (onChange && changed) {
-      onChange({ value: e.detail })
+    let value = e.detail
+    if (timeOnly && valueAsTimestamp) {
+      if (!isValidDate(value)) {
+        // Handle time only fields that are timestamps under the hood
+        value = timeToDateISOString(value)
+      }
     }
+
+    const changed = fieldApi.setValue(value)
+    if (onChange && changed) {
+      onChange({ value })
+    }
+  }
+
+  const isValidDate = value => !isNaN(new Date(value))
+
+  const timeToDateISOString = value => {
+    let [hours, minutes] = value.split(":").map(Number)
+
+    const date = new Date()
+    date.setHours(hours)
+    date.setMinutes(minutes)
+    date.setSeconds(0)
+    date.setMilliseconds(0)
+    return date.toISOString()
   }
 </script>
 


### PR DESCRIPTION
## Description
We recently fixed some issues related to time-only fields, storing these as time strings instead of date times. This is now conflicting with the datetime values with time-only frontend, as the API is still expecting a iso datetime.
For this, the field will know if the actual value to store is a datetime or a time-only, parsing it accordingly.

As this is a frontend implementation concern, the API will still expect the right formats for each field depending of its configuration.

Also, date-only fields will hide the time by default (it can still be added back manually)


https://github.com/Budibase/budibase/assets/15987277/f0414eea-c1f5-4222-a078-c0b2499c9e5a




## Addresses
- https://github.com/Budibase/budibase/issues/13839

## Launchcontrol
Fixing time-only form fields for internal db