### PR TITLE
Ignore SQS 500s on cleanup

### DIFF
--- a/packages/backend-core/src/db/couch/DatabaseImpl.ts
+++ b/packages/backend-core/src/db/couch/DatabaseImpl.ts
@@ -328,7 +328,14 @@ export class DatabaseImpl implements Database {
   async sqlDiskCleanup(): Promise<void> {
     const dbName = this.name
     const url = `/${dbName}/_cleanup`
-    return await this._sqlQuery<void>(url, "POST")
+    try {
+      await this._sqlQuery<void>(url, "POST")
+    } catch (err: any) {
+      // hack for now - SQS throws a 500 when there is nothing to clean-up
+      if (err.status !== 500) {
+        throw err
+      }
+    }
   }
 
   // removes a document from sqlite


### PR DESCRIPTION
## Description
Capturing any 500s which occur from SQS cleanup - it appears to 500 if there is nothing to do.