### PR TITLE
Fix key value updates in patch

### DIFF
--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -62,7 +62,7 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   })
 
   // The id might have been changed, so the refetching would fail. Recalculating the id just in case
-  const updatedId = generateIdForRow({ _id, ...dataToUpdate }, table)
+  const updatedId = generateIdForRow(ctx.request.body, table)
   const row = await sdk.rows.external.getRow(tableId, updatedId, {
     relationships: true,
   })

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -25,6 +25,7 @@ import {
   outputProcessing,
 } from "../../../utilities/rowProcessor"
 import { cloneDeep } from "lodash"
+import { generateIdForRow } from "./utils"
 
 export async function handleRequest<T extends Operation>(
   operation: T,
@@ -59,7 +60,9 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
     id: breakRowIdField(_id),
     row: dataToUpdate,
   })
-  const row = await sdk.rows.external.getRow(tableId, _id, {
+
+  const updatedId = generateIdForRow(dataToUpdate, table)
+  const row = await sdk.rows.external.getRow(tableId, updatedId, {
     relationships: true,
   })
   const enrichedRow = await outputProcessing(table, row, {

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -61,7 +61,8 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
     row: dataToUpdate,
   })
 
-  const updatedId = generateIdForRow(dataToUpdate, table)
+  // The id might have been changed, so the refetching would fail. Recalculating the id just in case
+  const updatedId = generateIdForRow({ _id, ...dataToUpdate }, table)
   const row = await sdk.rows.external.getRow(tableId, updatedId, {
     relationships: true,
   })

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -56,13 +56,18 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
     throw { validation: validateResult.errors }
   }
 
+  const beforeRow = await sdk.rows.external.getRow(tableId, _id, {
+    relationships: true,
+  })
+
   const response = await handleRequest(Operation.UPDATE, tableId, {
     id: breakRowIdField(_id),
     row: dataToUpdate,
   })
 
   // The id might have been changed, so the refetching would fail. Recalculating the id just in case
-  const updatedId = generateIdForRow(ctx.request.body, table)
+  const updatedId =
+    generateIdForRow({ ...beforeRow, ...dataToUpdate }, table) || _id
   const row = await sdk.rows.external.getRow(tableId, updatedId, {
     relationships: true,
   })


### PR DESCRIPTION
## Description
Budibase's patch endpoint performs the patch operation and returns the updated row. We found an issue with composite keys (and affects patching any id value in SQL). When updating a value that affects the id, this value will be updated and we will try to get the latest row value, using the provided id. As this id just got updated, the fetch will always return undefined.
For this, we are now recalculating the id based on the updated values, ensuring we use the up to date key.

## Addresses
- [BUDI-7422 - Composite keys cause issues whenever trying to bulk delete records.](https://linear.app/budibase/issue/BUDI-7422/composite-keys-cause-issues-whenever-trying-to-bulk-delete-records)

## Launchcontrol
Fixing patch issues when updating values that are part of the identiy row