### PR TITLE
Update CouchDB image from 3.2.1 to 3.3.3.

### DIFF
--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -641,7 +641,7 @@ couchdb:
     # @ignore
     repository: budibase/couchdb
     # @ignore
-    tag: v3.2.1
+    tag: v3.3.3
     # @ignore
     pullPolicy: Always
 


### PR DESCRIPTION
## Description

In preparation for the SQS release, default to using CouchDB 3.3.3 in the Helm chart. This release is backwards compatible with 3.2.1.
