### PR TITLE
Enable DataDog test instrumentation.

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -179,6 +179,13 @@ jobs:
       - run: yarn --frozen-lockfile
 
       - name: Test server
+        env:
+          DD_CIVISIBILITY_AGENTLESS_ENABLED: true
+          DD_API_KEY: "${{ secrets.DATADOG_API_KEY }}"
+          DD_SITE: "datadoghq.eu"
+          NODE_OPTIONS: "-r dd-trace/ci/init"
+          DD_ENV: "ci"
+          DD_SERVICE: "budibase/packages/server"
         run: |
           if ${{ env.USE_NX_AFFECTED }}; then
             yarn test --scope=@budibase/server --since=${{ env.NX_BASE_BRANCH }}

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -1683,3 +1683,5 @@ describe.each([
     })
   })
 })
+
+// todo: remove me


### PR DESCRIPTION
This should allow us to track our tests in DataDog at an individual test case level.

https://docs.datadoghq.com/tests/