### PR TITLE
small change to ensure that name of datasources is available in dropd…

### DIFF
--- a/packages/builder/src/components/design/settings/controls/DataSourceSelect/DataSourceCategory.svelte
+++ b/packages/builder/src/components/design/settings/controls/DataSourceSelect/DataSourceCategory.svelte
@@ -29,7 +29,7 @@
       on:click={() => onSelect(data)}
     >
       <span class="spectrum-Menu-itemLabel">
-        {data.label}
+        {data.datasource?.name ? `${data.datasource.name} -` : ""} {data.label}
       </span>
       <svg
         class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon"

--- a/packages/builder/src/components/design/settings/controls/DataSourceSelect/DataSourceCategory.svelte
+++ b/packages/builder/src/components/design/settings/controls/DataSourceSelect/DataSourceCategory.svelte
@@ -29,7 +29,7 @@
       on:click={() => onSelect(data)}
     >
       <span class="spectrum-Menu-itemLabel">
-        {data.datasource?.name ? `${data.datasource.name} -` : ""} {data.label}
+        {data.datasource?.name ? `${data.datasource.name} - ` : ""}{data.label}
       </span>
       <svg
         class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon"

--- a/packages/builder/src/components/design/settings/controls/DataSourceSelect/DataSourceCategory.svelte
+++ b/packages/builder/src/components/design/settings/controls/DataSourceSelect/DataSourceCategory.svelte
@@ -28,8 +28,8 @@
       tabindex="0"
       on:click={() => onSelect(data)}
     >
-      <span class="spectrum-Menu-itemLabel">
-        {data.label}
+      <span class="spectum-Menu-itemLabel">
+        {data.datasource?.name ? `${data.datasource.name} -` : ""} {data.label}
       </span>
       <svg
         class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon"

--- a/packages/builder/src/components/design/settings/controls/DataSourceSelect/DataSourceSelect.svelte
+++ b/packages/builder/src/components/design/settings/controls/DataSourceSelect/DataSourceSelect.svelte
@@ -55,6 +55,7 @@
     label: m.name,
     tableId: m._id,
     type: "table",
+    datasource: $datasources.list.find(ds => ds._id === m.sourceId || m.datasourceId),
   }))
   $: viewsV1 = $viewsStore.list.map(view => ({
     ...view,


### PR DESCRIPTION
…own to prevent dupes

## Description
Just a quick one while I was waiting for a logstash docker image to build. I just added the name of the source to tables in the dropdown menu so duplicate table names across sources are less confusing for the user.

## Addresses
https://linear.app/budibase/issue/BUDI-8227/multiple-tables-with-the-same-name-in-different-datasources-display

## Screenshot
![Screenshot 2024-06-11 at 14 59 02](https://github.com/Budibase/budibase/assets/11256663/1c86360d-4d09-471b-b71c-6f2609dd6340)
