### PR TITLE
Don't add or remove quotas for external DB rows

### DIFF
--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -84,9 +84,11 @@ export const save = async (ctx: UserCtx<Row, Row>) => {
   if (body && body._id) {
     return patch(ctx as UserCtx<PatchRowRequest, PatchRowResponse>)
   }
-  const { row, table, squashed } = await quotas.addRow(() =>
-    sdk.rows.save(tableId, ctx.request.body, ctx.user?._id)
-  )
+  const { row, table, squashed } = tableId.includes("datasource_plus")
+    ? await sdk.rows.save(tableId, ctx.request.body, ctx.user?._id)
+    : await quotas.addRow(() =>
+        sdk.rows.save(tableId, ctx.request.body, ctx.user?._id)
+      )
   ctx.status = 200
   ctx.eventEmitter && ctx.eventEmitter.emitRow(`row:save`, appId, row, table)
   ctx.message = `${table.name} saved successfully`
@@ -152,7 +154,9 @@ async function deleteRows(ctx: UserCtx<DeleteRowRequest>) {
   deleteRequest.rows = await processDeleteRowsRequest(ctx)
 
   const { rows } = await pickApi(tableId).bulkDestroy(ctx)
-  await quotas.removeRows(rows.length)
+  if (!tableId.includes("datasource_plus")) {
+    await quotas.removeRows(rows.length)
+  }
 
   for (let row of rows) {
     ctx.eventEmitter && ctx.eventEmitter.emitRow(`row:delete`, appId, row)
@@ -167,7 +171,9 @@ async function deleteRow(ctx: UserCtx<DeleteRowRequest>) {
   const tableId = utils.getTableId(ctx)
 
   const resp = await pickApi(tableId).destroy(ctx)
-  await quotas.removeRow()
+  if (!tableId.includes("datasource_plus")) {
+    await quotas.removeRow()
+  }
 
   ctx.eventEmitter && ctx.eventEmitter.emitRow(`row:delete`, appId, resp.row)
   gridSocket?.emitRowDeletion(ctx, resp.row)

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -134,6 +134,10 @@ describe.each([
     // error.  This is to account for the fact that parallel writes can result
     // in some quota updates getting lost. We don't have any need to solve this
     // right now, so we just allow for some error.
+    if (expected === 0) {
+      expect(usage).toEqual(0)
+      return
+    }
     expect(usage).toBeGreaterThan(expected * 0.9)
     expect(usage).toBeLessThan(expected * 1.1)
   }
@@ -158,7 +162,7 @@ describe.each([
       })
       expect(row.name).toEqual("Test Contact")
       expect(row._rev).toBeDefined()
-      await assertRowUsage(rowUsage + 1)
+      await assertRowUsage(isInternal ? rowUsage + 1 : rowUsage)
     })
 
     it("fails to create a row for a table that does not exist", async () => {
@@ -230,7 +234,7 @@ describe.each([
           expect(row["Row ID"]).toBeGreaterThan(previousId)
           previousId = row["Row ID"]
         }
-        await assertRowUsage(rowUsage + 10)
+        await assertRowUsage(isInternal ? rowUsage + 10 : rowUsage)
       })
 
     isInternal &&
@@ -751,7 +755,7 @@ describe.each([
         rows: [createdRow],
       })
       expect(res[0]._id).toEqual(createdRow._id)
-      await assertRowUsage(rowUsage - 1)
+      await assertRowUsage(isInternal ? rowUsage - 1 : rowUsage)
     })
 
     it("should be able to bulk delete rows, including a row that doesn't exist", async () => {
@@ -817,7 +821,7 @@ describe.each([
 
       expect(res.length).toEqual(2)
       await config.api.row.get(table._id!, row1._id!, { status: 404 })
-      await assertRowUsage(rowUsage - 2)
+      await assertRowUsage(isInternal ? rowUsage - 2 : rowUsage)
     })
 
     it("should be able to delete a variety of row set types", async () => {
@@ -834,7 +838,7 @@ describe.each([
 
       expect(res.length).toEqual(3)
       await config.api.row.get(table._id!, row1._id!, { status: 404 })
-      await assertRowUsage(rowUsage - 3)
+      await assertRowUsage(isInternal ? rowUsage - 3 : rowUsage)
     })
 
     it("should accept a valid row object and delete the row", async () => {
@@ -845,7 +849,7 @@ describe.each([
 
       expect(res.id).toEqual(row1._id)
       await config.api.row.get(table._id!, row1._id!, { status: 404 })
-      await assertRowUsage(rowUsage - 1)
+      await assertRowUsage(isInternal ? rowUsage - 1 : rowUsage)
     })
 
     it("Should ignore malformed/invalid delete requests", async () => {

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1111,7 +1111,7 @@ describe.each([
         const createdRow = await config.api.row.save(table._id!, {})
         const rowUsage = await getRowUsage()
         await config.api.row.bulkDelete(view.id, { rows: [createdRow] })
-        await assertRowUsage(rowUsage - 1)
+        await assertRowUsage(isInternal ? rowUsage - 1 : rowUsage)
         await config.api.row.get(table._id!, createdRow._id!, {
           status: 404,
         })
@@ -1127,7 +1127,7 @@ describe.each([
 
         await config.api.row.bulkDelete(view.id, { rows: [rows[0], rows[2]] })
 
-        await assertRowUsage(rowUsage - 2)
+        await assertRowUsage(isInternal ? rowUsage - 2 : rowUsage)
 
         await config.api.row.get(table._id!, rows[0]._id!, {
           status: 404,


### PR DESCRIPTION
## Description
As per pricing page, external DB row adds/deletes should not impact quotas:

https://budibase.com/pricing/

![Screenshot 2024-06-12 at 13 30 44](https://github.com/Budibase/budibase/assets/101575380/4e0b1c14-70e8-4881-9248-d8381d804235)

## Addresses
- https://github.com/Budibase/budibase/issues/13158

## Launchcontrol
Bug fix: External DB add/delete rows no longer impact quotas.
