### PR TITLE
Remove the word 'lucene' from runLuceneQuery and buildLuceneQuery.

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -343,7 +343,7 @@
   }
 
   function saveFilters(key) {
-    const filters = LuceneUtils.buildLuceneQuery(tempFilters)
+    const filters = LuceneUtils.buildQuery(tempFilters)
     const defKey = `${key}-def`
     onChange({ detail: filters }, key)
     // need to store the builder definition in the automation

--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -41,7 +41,7 @@
     EditorModes,
   } from "components/common/CodeEditor"
   import FilterBuilder from "components/design/settings/controls/FilterEditor/FilterBuilder.svelte"
-  import { LuceneUtils, Utils } from "@budibase/frontend-core"
+  import { QueryUtils, Utils } from "@budibase/frontend-core"
   import {
     getSchemaForDatasourcePlus,
     getEnvironmentBindings,
@@ -343,7 +343,7 @@
   }
 
   function saveFilters(key) {
-    const filters = LuceneUtils.buildQuery(tempFilters)
+    const filters = QueryUtils.buildQuery(tempFilters)
     const defKey = `${key}-def`
     onChange({ detail: filters }, key)
     // need to store the builder definition in the automation

--- a/packages/builder/src/components/backend/DataTable/modals/ExportModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/ExportModal.svelte
@@ -49,7 +49,7 @@
     exportFormat = Array.isArray(options) ? options[0]?.key : []
   }
 
-  $: luceneFilter = LuceneUtils.buildLuceneQuery(appliedFilters)
+  $: luceneFilter = LuceneUtils.buildQuery(appliedFilters)
   $: exportOpDisplay = buildExportOpDisplay(
     sorting,
     filterDisplay,

--- a/packages/builder/src/components/backend/DataTable/modals/ExportModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/ExportModal.svelte
@@ -49,7 +49,7 @@
     exportFormat = Array.isArray(options) ? options[0]?.key : []
   }
 
-  $: luceneFilter = QueryUtils.buildQuery(appliedFilters)
+  $: query = QueryUtils.buildQuery(appliedFilters)
   $: exportOpDisplay = buildExportOpDisplay(
     sorting,
     filterDisplay,
@@ -139,7 +139,7 @@
           tableId: view,
           format: exportFormat,
           search: {
-            query: luceneFilter,
+            query,
             sort: sorting?.sortColumn,
             sortOrder: sorting?.sortOrder,
             paginate: false,

--- a/packages/builder/src/components/backend/DataTable/modals/ExportModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/ExportModal.svelte
@@ -8,7 +8,7 @@
   } from "@budibase/bbui"
   import download from "downloadjs"
   import { API } from "api"
-  import { LuceneUtils } from "@budibase/frontend-core"
+  import { QueryUtils } from "@budibase/frontend-core"
   import { utils } from "@budibase/shared-core"
   import { ROW_EXPORT_FORMATS } from "constants/backend"
 
@@ -49,7 +49,7 @@
     exportFormat = Array.isArray(options) ? options[0]?.key : []
   }
 
-  $: luceneFilter = LuceneUtils.buildQuery(appliedFilters)
+  $: luceneFilter = QueryUtils.buildQuery(appliedFilters)
   $: exportOpDisplay = buildExportOpDisplay(
     sorting,
     filterDisplay,

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ConditionalUIDrawer.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/ConditionalUIDrawer.svelte
@@ -12,7 +12,7 @@
   import { dndzone } from "svelte-dnd-action"
   import { generate } from "shortid"
   import DrawerBindableInput from "components/common/bindings/DrawerBindableInput.svelte"
-  import { LuceneUtils, Constants } from "@budibase/frontend-core"
+  import { QueryUtils, Constants } from "@budibase/frontend-core"
   import { selectedComponent, componentStore } from "stores/builder"
   import { getComponentForSetting } from "components/design/settings/componentSettings"
   import PropertyControl from "components/design/settings/controls/PropertyControl.svelte"
@@ -119,7 +119,7 @@
   }
 
   const getOperatorOptions = condition => {
-    return LuceneUtils.getValidOperatorsForType({ type: condition.valueType })
+    return QueryUtils.getValidOperatorsForType({ type: condition.valueType })
   }
 
   const onOperatorChange = (condition, newOperator) => {
@@ -138,7 +138,7 @@
     condition.referenceValue = null
 
     // Ensure a valid operator is set
-    const validOperators = LuceneUtils.getValidOperatorsForType({
+    const validOperators = QueryUtils.getValidOperatorsForType({
       type: newType,
     }).map(x => x.value)
     if (!validOperators.includes(condition.operator)) {

--- a/packages/client/src/components/app/DataProvider.svelte
+++ b/packages/client/src/components/app/DataProvider.svelte
@@ -1,7 +1,7 @@
 <script>
   import { getContext } from "svelte"
   import { Pagination, ProgressCircle } from "@budibase/bbui"
-  import { fetchData, LuceneUtils } from "@budibase/frontend-core"
+  import { fetchData, QueryUtils } from "@budibase/frontend-core"
 
   export let dataSource
   export let filter
@@ -19,7 +19,7 @@
 
   // We need to manage our lucene query manually as we want to allow components
   // to extend it
-  $: defaultQuery = LuceneUtils.buildQuery(filter)
+  $: defaultQuery = QueryUtils.buildQuery(filter)
   $: query = extendQuery(defaultQuery, queryExtensions)
   $: fetch = createFetch(dataSource)
   $: fetch.update({

--- a/packages/client/src/components/app/DataProvider.svelte
+++ b/packages/client/src/components/app/DataProvider.svelte
@@ -19,7 +19,7 @@
 
   // We need to manage our lucene query manually as we want to allow components
   // to extend it
-  $: defaultQuery = LuceneUtils.buildLuceneQuery(filter)
+  $: defaultQuery = LuceneUtils.buildQuery(filter)
   $: query = extendQuery(defaultQuery, queryExtensions)
   $: fetch = createFetch(dataSource)
   $: fetch.update({

--- a/packages/client/src/components/app/dynamic-filter/DynamicFilter.svelte
+++ b/packages/client/src/components/app/dynamic-filter/DynamicFilter.svelte
@@ -36,7 +36,7 @@
   // Add query extension to data provider
   $: {
     if (filters?.length) {
-      const queryExtension = LuceneUtils.buildLuceneQuery(filters)
+      const queryExtension = LuceneUtils.buildQuery(filters)
       addExtension?.($component.id, queryExtension)
     } else {
       removeExtension?.($component.id)

--- a/packages/client/src/components/app/dynamic-filter/DynamicFilter.svelte
+++ b/packages/client/src/components/app/dynamic-filter/DynamicFilter.svelte
@@ -3,7 +3,7 @@
   import { getContext, onDestroy } from "svelte"
   import { ModalContent, Modal } from "@budibase/bbui"
   import FilterModal from "./FilterModal.svelte"
-  import { LuceneUtils } from "@budibase/frontend-core"
+  import { QueryUtils } from "@budibase/frontend-core"
   import Button from "../Button.svelte"
 
   export let dataProvider
@@ -36,7 +36,7 @@
   // Add query extension to data provider
   $: {
     if (filters?.length) {
-      const queryExtension = LuceneUtils.buildQuery(filters)
+      const queryExtension = QueryUtils.buildQuery(filters)
       addExtension?.($component.id, queryExtension)
     } else {
       removeExtension?.($component.id)

--- a/packages/client/src/sdk.js
+++ b/packages/client/src/sdk.js
@@ -31,7 +31,7 @@ import { enrichButtonActions } from "./utils/buttonActions.js"
 import { processStringSync, makePropSafe } from "@budibase/string-templates"
 import {
   fetchData,
-  LuceneUtils,
+  QueryUtils,
   Constants,
   RowUtils,
   memo,
@@ -65,7 +65,7 @@ export default {
   getAction,
   fetchDatasourceSchema,
   fetchData,
-  LuceneUtils,
+  QueryUtils,
   ContextScopes: Constants.ContextScopes,
   getAPIKey,
   enrichButtonActions,

--- a/packages/client/src/utils/conditions.js
+++ b/packages/client/src/utils/conditions.js
@@ -33,8 +33,8 @@ export const getActiveConditions = conditions => {
       value: condition.referenceValue,
     }
 
-    const query = LuceneUtils.buildLuceneQuery([luceneCondition])
-    const result = LuceneUtils.runLuceneQuery([luceneCondition], query)
+    const query = LuceneUtils.buildQuery([luceneCondition])
+    const result = LuceneUtils.runQuery([luceneCondition], query)
     return result.length > 0
   })
 }

--- a/packages/client/src/utils/conditions.js
+++ b/packages/client/src/utils/conditions.js
@@ -1,4 +1,4 @@
-import { LuceneUtils } from "@budibase/frontend-core"
+import { QueryUtils } from "@budibase/frontend-core"
 
 export const getActiveConditions = conditions => {
   if (!conditions?.length) {
@@ -33,8 +33,8 @@ export const getActiveConditions = conditions => {
       value: condition.referenceValue,
     }
 
-    const query = LuceneUtils.buildQuery([luceneCondition])
-    const result = LuceneUtils.runQuery([luceneCondition], query)
+    const query = QueryUtils.buildQuery([luceneCondition])
+    const result = QueryUtils.runQuery([luceneCondition], query)
     return result.length > 0
   })
 }

--- a/packages/frontend-core/src/components/FilterBuilder.svelte
+++ b/packages/frontend-core/src/components/FilterBuilder.svelte
@@ -13,7 +13,7 @@
   } from "@budibase/bbui"
   import { FieldType, SearchFilterOperator } from "@budibase/types"
   import { generate } from "shortid"
-  import { LuceneUtils, Constants } from "@budibase/frontend-core"
+  import { QueryUtils, Constants } from "@budibase/frontend-core"
   import { getContext } from "svelte"
   import FilterUsers from "./FilterUsers.svelte"
   import { getFields } from "../utils/searchFields"
@@ -112,7 +112,7 @@
       return []
     }
 
-    return LuceneUtils.getValidOperatorsForType(
+    return QueryUtils.getValidOperatorsForType(
       filter,
       filter.field || filter.name,
       datasource

--- a/packages/frontend-core/src/fetch/DataFetch.js
+++ b/packages/frontend-core/src/fetch/DataFetch.js
@@ -3,8 +3,7 @@ import { cloneDeep } from "lodash/fp"
 import { LuceneUtils } from "../utils"
 import { convertJSONSchemaToTableSchema } from "../utils/json"
 
-const { buildLuceneQuery, luceneLimit, runLuceneQuery, luceneSort } =
-  LuceneUtils
+const { buildQuery, luceneLimit, runQuery, luceneSort } = LuceneUtils
 
 /**
  * Parent class which handles the implementation of fetching data from an
@@ -180,7 +179,7 @@ export default class DataFetch {
     // Build the lucene query
     let query = this.options.query
     if (!query) {
-      query = buildLuceneQuery(filter)
+      query = buildQuery(filter)
     }
 
     // Update store
@@ -229,7 +228,7 @@ export default class DataFetch {
 
     // If we don't support searching, do a client search
     if (!this.features.supportsSearch && clientSideSearching) {
-      rows = runLuceneQuery(rows, query)
+      rows = runQuery(rows, query)
     }
 
     // If we don't support sorting, do a client-side sort

--- a/packages/frontend-core/src/fetch/DataFetch.js
+++ b/packages/frontend-core/src/fetch/DataFetch.js
@@ -1,9 +1,9 @@
 import { writable, derived, get } from "svelte/store"
 import { cloneDeep } from "lodash/fp"
-import { LuceneUtils } from "../utils"
+import { QueryUtils } from "../utils"
 import { convertJSONSchemaToTableSchema } from "../utils/json"
 
-const { buildQuery, luceneLimit, runQuery, luceneSort } = LuceneUtils
+const { buildQuery, luceneLimit, runQuery, luceneSort } = QueryUtils
 
 /**
  * Parent class which handles the implementation of fetching data from an

--- a/packages/frontend-core/src/fetch/DataFetch.js
+++ b/packages/frontend-core/src/fetch/DataFetch.js
@@ -3,7 +3,7 @@ import { cloneDeep } from "lodash/fp"
 import { QueryUtils } from "../utils"
 import { convertJSONSchemaToTableSchema } from "../utils/json"
 
-const { buildQuery, luceneLimit, runQuery, luceneSort } = QueryUtils
+const { buildQuery, limit: queryLimit, runQuery, sort } = QueryUtils
 
 /**
  * Parent class which handles the implementation of fetching data from an
@@ -176,7 +176,7 @@ export default class DataFetch {
       }
     }
 
-    // Build the lucene query
+    // Build the query
     let query = this.options.query
     if (!query) {
       query = buildQuery(filter)
@@ -233,12 +233,12 @@ export default class DataFetch {
 
     // If we don't support sorting, do a client-side sort
     if (!this.features.supportsSort && clientSideSorting) {
-      rows = luceneSort(rows, sortColumn, sortOrder, sortType)
+      rows = sort(rows, sortColumn, sortOrder, sortType)
     }
 
     // If we don't support pagination, do a client-side limit
     if (!this.features.supportsPagination && clientSideLimiting) {
-      rows = luceneLimit(rows, limit)
+      rows = queryLimit(rows, limit)
     }
 
     return {

--- a/packages/frontend-core/src/fetch/UserFetch.js
+++ b/packages/frontend-core/src/fetch/UserFetch.js
@@ -1,7 +1,7 @@
 import { get } from "svelte/store"
 import DataFetch from "./DataFetch.js"
 import { TableNames } from "../constants"
-import { LuceneUtils } from "../utils"
+import { QueryUtils } from "../utils"
 
 export default class UserFetch extends DataFetch {
   constructor(opts) {
@@ -33,7 +33,7 @@ export default class UserFetch extends DataFetch {
     let finalQuery
     // convert old format to new one - we now allow use of the lucene format
     const { appId, paginated, ...rest } = query
-    if (!LuceneUtils.hasFilters(query) && rest.email != null) {
+    if (!QueryUtils.hasFilters(query) && rest.email != null) {
       finalQuery = { string: { email: rest.email } }
     } else {
       finalQuery = rest

--- a/packages/frontend-core/src/utils/index.js
+++ b/packages/frontend-core/src/utils/index.js
@@ -1,4 +1,4 @@
-export { dataFilters as LuceneUtils } from "@budibase/shared-core"
+export { dataFilters as QueryUtils } from "@budibase/shared-core"
 export * as JSONUtils from "./json"
 export * as CookieUtils from "./cookies"
 export * as RoleUtils from "./roles"

--- a/packages/server/src/api/controllers/row/views.ts
+++ b/packages/server/src/api/controllers/row/views.ts
@@ -31,7 +31,7 @@ export async function searchView(
   // Enrich saved query with ephemeral query params.
   // We prevent searching on any fields that are saved as part of the query, as
   // that could let users find rows they should not be allowed to access.
-  let query = dataFilters.buildLuceneQuery(view.query || [])
+  let query = dataFilters.buildQuery(view.query || [])
   if (body.query) {
     // Extract existing fields
     const existingFields =

--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -566,7 +566,7 @@ class GoogleSheetsIntegration implements DatasourcePlus {
           query.filters.equal[`_${GOOGLE_SHEETS_PRIMARY_KEY}`] = id
         }
       }
-      let filtered = dataFilters.runLuceneQuery(rows, query.filters)
+      let filtered = dataFilters.runQuery(rows, query.filters)
       if (hasFilters && query.paginate) {
         filtered = filtered.slice(offset, offset + limit)
       }

--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -585,7 +585,7 @@ class GoogleSheetsIntegration implements DatasourcePlus {
           })
         }
         const [sortField, sortInfo] = Object.entries(query.sort)[0]
-        response = dataFilters.luceneSort(
+        response = dataFilters.sort(
           response,
           sortField,
           sortInfo.direction,

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -451,7 +451,7 @@ export const runQuery = (docs: any[], query?: SearchFilters) => {
  * @param sortOrder the sort order ("ascending" or "descending")
  * @param sortType the type of sort ("string" or "number")
  */
-export const luceneSort = (
+export const sort = (
   docs: any[],
   sort: string,
   sortOrder: SortDirection,
@@ -481,7 +481,7 @@ export const luceneSort = (
  * @param docs the data
  * @param limit the number of docs to limit to
  */
-export const luceneLimit = (docs: any[], limit: string) => {
+export const limit = (docs: any[], limit: string) => {
   const numLimit = parseFloat(limit)
   if (isNaN(numLimit)) {
     return docs

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -138,10 +138,10 @@ export const removeKeyNumbering = (key: string): string => {
 }
 
 /**
- * Builds a lucene JSON query from the filter structure generated in the builder
+ * Builds a JSON query from the filter structure generated in the builder
  * @param filter the builder filter structure
  */
-export const buildLuceneQuery = (filter: SearchFilter[]) => {
+export const buildQuery = (filter: SearchFilter[]) => {
   let query: SearchFilters = {
     string: {},
     fuzzy: {},
@@ -260,11 +260,11 @@ export const buildLuceneQuery = (filter: SearchFilter[]) => {
 }
 
 /**
- * Performs a client-side lucene search on an array of data
+ * Performs a client-side search on an array of data
  * @param docs the data
- * @param query the JSON lucene query
+ * @param query the JSON query
  */
-export const runLuceneQuery = (docs: any[], query?: SearchFilters) => {
+export const runQuery = (docs: any[], query?: SearchFilters) => {
   if (!docs || !Array.isArray(docs)) {
     return []
   }

--- a/packages/shared-core/src/tests/filters.test.ts
+++ b/packages/shared-core/src/tests/filters.test.ts
@@ -4,9 +4,9 @@ import {
   FieldType,
   SearchFilter,
 } from "@budibase/types"
-import { buildLuceneQuery, runLuceneQuery } from "../filters"
+import { buildQuery, runQuery } from "../filters"
 
-describe("runLuceneQuery", () => {
+describe("runQuery", () => {
   const docs = [
     {
       order_id: 1,
@@ -70,14 +70,14 @@ describe("runLuceneQuery", () => {
   }
 
   it("should return input docs if no search query is provided", () => {
-    expect(runLuceneQuery(docs)).toBe(docs)
+    expect(runQuery(docs)).toBe(docs)
   })
 
   it("should return matching rows for equal filter", () => {
     const query = buildQuery({
       equal: { order_status: 4 },
     })
-    expect(runLuceneQuery(docs, query).map(row => row.order_id)).toEqual([1, 2])
+    expect(runQuery(docs, query).map(row => row.order_id)).toEqual([1, 2])
   })
 
   it("should return matching row for notEqual filter", () => {
@@ -85,12 +85,12 @@ describe("runLuceneQuery", () => {
       notEqual: { order_status: 4 },
     })
 
-    expect(runLuceneQuery(docs, query).map(row => row.order_id)).toEqual([3])
+    expect(runQuery(docs, query).map(row => row.order_id)).toEqual([3])
   })
 
   it("should return starts with matching rows for fuzzy and string filters", () => {
     expect(
-      runLuceneQuery(
+      runQuery(
         docs,
         buildQuery({
           fuzzy: { description: "sm" },
@@ -98,7 +98,7 @@ describe("runLuceneQuery", () => {
       ).map(row => row.description)
     ).toEqual(["Small box"])
     expect(
-      runLuceneQuery(
+      runQuery(
         docs,
         buildQuery({
           string: { description: "SM" },
@@ -117,7 +117,7 @@ describe("runLuceneQuery", () => {
       },
     })
 
-    expect(runLuceneQuery(docs, query).map(row => row.order_id)).toEqual([3])
+    expect(runQuery(docs, query).map(row => row.order_id)).toEqual([3])
   })
 
   it("should return rows with numeric strings within a range filter", () => {
@@ -129,7 +129,7 @@ describe("runLuceneQuery", () => {
         },
       },
     })
-    expect(runLuceneQuery(docs, query).map(row => row.order_id)).toEqual([3])
+    expect(runQuery(docs, query).map(row => row.order_id)).toEqual([3])
   })
 
   it("should return rows with ISO date strings within a range filter", () => {
@@ -142,7 +142,7 @@ describe("runLuceneQuery", () => {
       },
     })
 
-    expect(runLuceneQuery(docs, query).map(row => row.order_id)).toEqual([2])
+    expect(runQuery(docs, query).map(row => row.order_id)).toEqual([2])
   })
 
   it("should return return all docs if an invalid doc value is passed into a range filter", async () => {
@@ -170,7 +170,7 @@ describe("runLuceneQuery", () => {
       },
     })
 
-    expect(runLuceneQuery(docs, query)).toEqual(docs)
+    expect(runQuery(docs, query)).toEqual(docs)
   })
 
   it("should return rows with matches on empty filter", () => {
@@ -180,7 +180,7 @@ describe("runLuceneQuery", () => {
       },
     })
 
-    expect(runLuceneQuery(docs, query).map(row => row.order_id)).toEqual([1])
+    expect(runQuery(docs, query).map(row => row.order_id)).toEqual([1])
   })
 
   it("should return rows with matches on notEmpty filter", () => {
@@ -190,7 +190,7 @@ describe("runLuceneQuery", () => {
       },
     })
 
-    expect(runLuceneQuery(docs, query).map(row => row.order_id)).toEqual([2, 3])
+    expect(runQuery(docs, query).map(row => row.order_id)).toEqual([2, 3])
   })
 
   it.each([[523, 259], "523,259"])(
@@ -202,7 +202,7 @@ describe("runLuceneQuery", () => {
         },
       })
 
-      expect(runLuceneQuery(docs, query).map(row => row.customer_id)).toEqual([
+      expect(runQuery(docs, query).map(row => row.customer_id)).toEqual([
         259, 523,
       ])
     }
@@ -218,7 +218,7 @@ describe("runLuceneQuery", () => {
       contains: { description: ["box"] },
     })
 
-    expect(runLuceneQuery(docs, query).map(row => row.order_id)).toEqual(
+    expect(runQuery(docs, query).map(row => row.order_id)).toEqual(
       expectedResult
     )
   })
@@ -230,7 +230,7 @@ describe("runLuceneQuery", () => {
       oneOf: { label: ["FRAGILE"] },
     })
 
-    expect(runLuceneQuery(docs, query).map(row => row.order_id)).toEqual([1, 2])
+    expect(runQuery(docs, query).map(row => row.order_id)).toEqual([1, 2])
   })
 
   it("should handle when a value is null or undefined", () => {
@@ -240,14 +240,14 @@ describe("runLuceneQuery", () => {
       oneOf: { label: ["FRAGILE"] },
     })
 
-    expect(runLuceneQuery(docs, query).map(row => row.order_id)).toEqual([2])
+    expect(runQuery(docs, query).map(row => row.order_id)).toEqual([2])
   })
 })
 
-describe("buildLuceneQuery", () => {
+describe("buildQuery", () => {
   it("should return a basic search query template if the input is not an array", () => {
     const filter: any = "NOT_AN_ARRAY"
-    expect(buildLuceneQuery(filter)).toEqual({
+    expect(buildQuery(filter)).toEqual({
       string: {},
       fuzzy: {},
       range: {},
@@ -277,7 +277,7 @@ describe("buildLuceneQuery", () => {
         value: "1000,1212,3400",
       },
     ]
-    expect(buildLuceneQuery(filter)).toEqual({
+    expect(buildQuery(filter)).toEqual({
       string: {},
       fuzzy: {},
       range: {},
@@ -311,7 +311,7 @@ describe("buildLuceneQuery", () => {
         value: "{{ list_of_customer_ids }}",
       },
     ]
-    expect(buildLuceneQuery(filter)).toEqual({
+    expect(buildQuery(filter)).toEqual({
       string: {},
       fuzzy: {},
       range: {},
@@ -351,7 +351,7 @@ describe("buildLuceneQuery", () => {
         value: "true",
       },
     ]
-    expect(buildLuceneQuery(filter)).toEqual({
+    expect(buildQuery(filter)).toEqual({
       string: {},
       fuzzy: {},
       range: {},
@@ -392,7 +392,7 @@ describe("buildLuceneQuery", () => {
         value: "Large box,Heavy box,Small box",
       },
     ]
-    expect(buildLuceneQuery(filter)).toEqual({
+    expect(buildQuery(filter)).toEqual({
       string: {},
       fuzzy: {},
       range: {},


### PR DESCRIPTION
## Description

These functions never actually used Lucene, never had anything Lucene-specific about them. They were just named this way because our internal table search used Lucene under the hood. This is changing with SQS, so we're renaming these functions to remove confusion.
