### PR TITLE
Use `knex` instead of `rawQuery` everywhere, remove `rawQuery` from codebase.

### DIFF
--- a/packages/server/src/api/routes/tests/queries/generic-sql.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/generic-sql.spec.ts
@@ -10,37 +10,11 @@ import * as setup from "../utilities"
 import {
   DatabaseName,
   getDatasource,
-  rawQuery,
+  knexClient,
 } from "../../../../integrations/tests/utils"
 import { Expectations } from "src/tests/utilities/api/base"
 import { events } from "@budibase/backend-core"
-
-const createTableSQL: Record<string, string> = {
-  [SourceName.POSTGRES]: `
-    CREATE TABLE test_table (
-        id serial PRIMARY KEY,
-        name VARCHAR ( 50 ) NOT NULL,
-        birthday TIMESTAMP,
-        number INT
-    );`,
-  [SourceName.MYSQL]: `
-    CREATE TABLE test_table (
-        id INT AUTO_INCREMENT PRIMARY KEY,
-        name VARCHAR(50) NOT NULL,
-        birthday TIMESTAMP,
-        number INT
-    );`,
-  [SourceName.SQL_SERVER]: `
-    CREATE TABLE test_table (
-        id INT IDENTITY(1,1) PRIMARY KEY,
-        name NVARCHAR(50) NOT NULL,
-        birthday DATETIME,
-        number INT
-    );`,
-}
-
-const insertSQL = `INSERT INTO test_table (name) VALUES ('one'), ('two'), ('three'), ('four'), ('five')`
-const dropTableSQL = `DROP TABLE test_table;`
+import { Knex } from "knex"
 
 describe.each(
   [
@@ -53,6 +27,7 @@ describe.each(
   const config = setup.getConfig()
   let rawDatasource: Datasource
   let datasource: Datasource
+  let client: Knex
 
   async function createQuery(
     query: Partial<Query>,
@@ -82,21 +57,34 @@ describe.each(
     rawDatasource = await dsProvider
     datasource = await config.api.datasource.create(rawDatasource)
 
-    // The Datasource API does not return the password, but we need
-    // it later to connect to the underlying database, so we fill it
-    // back in here.
+    // The Datasource API doesn ot return the password, but we need it later to
+    // connect to the underlying database, so we fill it back in here.
     datasource.config!.password = rawDatasource.config!.password
 
-    await rawQuery(datasource, createTableSQL[datasource.source])
-    await rawQuery(datasource, insertSQL)
+    client = await knexClient(rawDatasource)
+
+    await client.schema.createTable("test_table", table => {
+      table.increments("id").primary()
+      table.string("name")
+      table.timestamp("birthday")
+      table.integer("number")
+    })
+
+    await client("test_table").insert([
+      { name: "one" },
+      { name: "two" },
+      { name: "three" },
+      { name: "four" },
+      { name: "five" },
+    ])
 
     jest.clearAllMocks()
   })
 
   afterEach(async () => {
     const ds = await config.api.datasource.get(datasource._id!)
-    config.api.datasource.delete(ds)
-    await rawQuery(datasource, dropTableSQL)
+    await config.api.datasource.delete(ds)
+    await client.schema.dropTable("test_table")
   })
 
   afterAll(async () => {
@@ -207,7 +195,7 @@ describe.each(
           },
         })
 
-        await config.publish()
+        await config.api.application.publish(config.getAppId())
         const prodQuery = await config.api.query.getProd(query._id!)
 
         expect(prodQuery._id).toEqual(query._id)
@@ -429,11 +417,11 @@ describe.each(
           },
         ])
 
-        const rows = await rawQuery(
-          datasource,
-          "SELECT * FROM test_table WHERE name = 'baz'"
-        )
+        const rows = await client("test_table").where({ name: "baz" }).select()
         expect(rows).toHaveLength(1)
+        for (const row of rows) {
+          expect(row).toMatchObject({ name: "baz" })
+        }
       })
 
       it("should not allow handlebars as parameters", async () => {
@@ -490,11 +478,14 @@ describe.each(
 
           expect(result.data).toEqual([{ created: true }])
 
-          const rows = await rawQuery(
-            datasource,
-            `SELECT * FROM test_table WHERE birthday = '${date.toISOString()}'`
-          )
+          const rows = await client("test_table")
+            .where({ birthday: datetimeStr })
+            .select()
           expect(rows).toHaveLength(1)
+
+          for (const row of rows) {
+            expect(new Date(row.birthday)).toEqual(date)
+          }
         }
       )
 
@@ -522,10 +513,9 @@ describe.each(
 
           expect(result.data).toEqual([{ created: true }])
 
-          const rows = await rawQuery(
-            datasource,
-            `SELECT * FROM test_table WHERE name = '${notDateStr}'`
-          )
+          const rows = await client("test_table")
+            .where({ name: notDateStr })
+            .select()
           expect(rows).toHaveLength(1)
         }
       )
@@ -660,10 +650,7 @@ describe.each(
           },
         ])
 
-        const rows = await rawQuery(
-          datasource,
-          "SELECT * FROM test_table WHERE id = 1"
-        )
+        const rows = await client("test_table").where({ id: 1 }).select()
         expect(rows).toEqual([
           { id: 1, name: "foo", birthday: null, number: null },
         ])
@@ -731,10 +718,7 @@ describe.each(
           },
         ])
 
-        const rows = await rawQuery(
-          datasource,
-          "SELECT * FROM test_table WHERE id = 1"
-        )
+        const rows = await client("test_table").where({ id: 1 }).select()
         expect(rows).toHaveLength(0)
       })
     })

--- a/packages/server/src/api/routes/tests/queries/generic-sql.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/generic-sql.spec.ts
@@ -63,6 +63,7 @@ describe.each(
 
     client = await knexClient(rawDatasource)
 
+    await client.schema.dropTableIfExists("test_table")
     await client.schema.createTable("test_table", table => {
       table.increments("id").primary()
       table.string("name")
@@ -84,7 +85,6 @@ describe.each(
   afterEach(async () => {
     const ds = await config.api.datasource.get(datasource._id!)
     await config.api.datasource.delete(ds)
-    await client.schema.dropTable("test_table")
   })
 
   afterAll(async () => {

--- a/packages/server/src/integration-test/mysql.spec.ts
+++ b/packages/server/src/integration-test/mysql.spec.ts
@@ -18,13 +18,12 @@ function uniqueTableName(length?: number): string {
 const config = setup.getConfig()!
 
 describe("mysql integrations", () => {
-  let rawDatasource: Datasource
   let datasource: Datasource
   let client: Knex
 
   beforeAll(async () => {
     await config.init()
-    rawDatasource = await getDatasource(DatabaseName.MYSQL)
+    const rawDatasource = await getDatasource(DatabaseName.MYSQL)
     datasource = await config.api.datasource.create(rawDatasource)
     client = await knexClient(rawDatasource)
   })

--- a/packages/server/src/integration-test/postgres.spec.ts
+++ b/packages/server/src/integration-test/postgres.spec.ts
@@ -14,7 +14,7 @@ const config = setup.getConfig()!
 describe("postgres integrations", () => {
   let rawDatasource: Datasource
   let datasource: Datasource
-  let client: Knex<any, unknown[]>
+  let client: Knex
 
   beforeAll(async () => {
     await config.init()

--- a/packages/server/src/integration-test/postgres.spec.ts
+++ b/packages/server/src/integration-test/postgres.spec.ts
@@ -1,9 +1,3 @@
-import fetch from "node-fetch"
-import {
-  generateMakeRequest,
-  MakeRequestResponse,
-} from "../api/routes/public/tests/utils"
-
 import * as setup from "../api/routes/tests/utilities"
 import { Datasource, FieldType } from "@budibase/types"
 import _ from "lodash"
@@ -11,29 +5,22 @@ import { generator } from "@budibase/backend-core/tests"
 import {
   DatabaseName,
   getDatasource,
-  rawQuery,
+  knexClient,
 } from "../integrations/tests/utils"
-
-// @ts-ignore
-fetch.mockSearch()
+import { Knex } from "knex"
 
 const config = setup.getConfig()!
 
-jest.mock("../websockets")
-
 describe("postgres integrations", () => {
-  let makeRequest: MakeRequestResponse,
-    rawDatasource: Datasource,
-    datasource: Datasource
+  let rawDatasource: Datasource
+  let datasource: Datasource
+  let client: Knex<any, unknown[]>
 
   beforeAll(async () => {
     await config.init()
-    const apiKey = await config.generateApiKey()
-
-    makeRequest = generateMakeRequest(apiKey, true)
-
     rawDatasource = await getDatasource(DatabaseName.POSTGRES)
     datasource = await config.api.datasource.create(rawDatasource)
+    client = await knexClient(rawDatasource)
   })
 
   afterAll(config.end)
@@ -46,11 +33,13 @@ describe("postgres integrations", () => {
     })
 
     afterEach(async () => {
-      await rawQuery(rawDatasource, `DROP TABLE IF EXISTS "${tableName}"`)
+      await client.schema.dropTableIfExists(tableName)
     })
 
     it("recognises when a table has no primary key", async () => {
-      await rawQuery(rawDatasource, `CREATE TABLE "${tableName}" (id SERIAL)`)
+      await client.schema.createTable(tableName, table => {
+        table.increments("id", { primaryKey: false })
+      })
 
       const response = await config.api.datasource.fetchSchema({
         datasourceId: datasource._id!,
@@ -62,10 +51,9 @@ describe("postgres integrations", () => {
     })
 
     it("recognises when a table is using a reserved column name", async () => {
-      await rawQuery(
-        rawDatasource,
-        `CREATE TABLE "${tableName}" (_id SERIAL PRIMARY KEY) `
-      )
+      await client.schema.createTable(tableName, table => {
+        table.increments("_id").primary()
+      })
 
       const response = await config.api.datasource.fetchSchema({
         datasourceId: datasource._id!,
@@ -81,20 +69,15 @@ describe("postgres integrations", () => {
         .guid()
         .replaceAll("-", "")
         .substring(0, 6)}`
-      const enumColumnName = "status"
 
-      await rawQuery(
-        rawDatasource,
-        `
-        CREATE TYPE order_status AS ENUM ('pending', 'processing', 'shipped', 'delivered', 'cancelled');
-        
-        CREATE TABLE ${tableName} (
-          order_id SERIAL PRIMARY KEY,
-          customer_name VARCHAR(100) NOT NULL,
-          ${enumColumnName} order_status
-        );
-      `
-      )
+      await client.schema.createTable(tableName, table => {
+        table.increments("order_id").primary()
+        table.string("customer_name").notNullable()
+        table.enum("status", ["pending", "processing", "shipped"], {
+          useNative: true,
+          enumName: `${tableName}_status`,
+        })
+      })
 
       const response = await config.api.datasource.fetchSchema({
         datasourceId: datasource._id!,
@@ -103,13 +86,14 @@ describe("postgres integrations", () => {
       const table = response.datasource.entities?.[tableName]
 
       expect(table).toBeDefined()
-      expect(table?.schema[enumColumnName].type).toEqual(FieldType.OPTIONS)
+      expect(table?.schema["status"].type).toEqual(FieldType.OPTIONS)
     })
   })
 
   describe("Integration compatibility with postgres search_path", () => {
     let rawDatasource: Datasource,
       datasource: Datasource,
+      client: Knex<any, unknown[]>,
       schema1: string,
       schema2: string
 
@@ -118,54 +102,55 @@ describe("postgres integrations", () => {
       schema2 = generator.guid().replaceAll("-", "")
 
       rawDatasource = await getDatasource(DatabaseName.POSTGRES)
-      const dbConfig = rawDatasource.config!
+      client = await knexClient(rawDatasource)
 
-      await rawQuery(rawDatasource, `CREATE SCHEMA "${schema1}";`)
-      await rawQuery(rawDatasource, `CREATE SCHEMA "${schema2}";`)
+      await client.schema.createSchema(schema1)
+      await client.schema.createSchema(schema2)
 
-      const pathConfig: any = {
-        ...rawDatasource,
-        config: {
-          ...dbConfig,
-          schema: `${schema1}, ${schema2}`,
-        },
-      }
-      datasource = await config.api.datasource.create(pathConfig)
+      rawDatasource.config!.schema = `${schema1}, ${schema2}`
+
+      client = await knexClient(rawDatasource)
+      datasource = await config.api.datasource.create(rawDatasource)
     })
 
     afterEach(async () => {
-      await rawQuery(rawDatasource, `DROP SCHEMA "${schema1}" CASCADE;`)
-      await rawQuery(rawDatasource, `DROP SCHEMA "${schema2}" CASCADE;`)
+      await client.schema.dropSchema(schema1, true)
+      await client.schema.dropSchema(schema2, true)
     })
 
     it("discovers tables from any schema in search path", async () => {
-      await rawQuery(
-        rawDatasource,
-        `CREATE TABLE "${schema1}".table1 (id1 SERIAL PRIMARY KEY);`
-      )
-      await rawQuery(
-        rawDatasource,
-        `CREATE TABLE "${schema2}".table2 (id2 SERIAL PRIMARY KEY);`
-      )
-      const response = await makeRequest("post", "/api/datasources/info", {
-        datasource: datasource,
+      await client.schema.createTable(`${schema1}.table1`, table => {
+        table.increments("id1").primary()
       })
-      expect(response.status).toBe(200)
-      expect(response.body.tableNames).toBeDefined()
-      expect(response.body.tableNames).toEqual(
+
+      await client.schema.createTable(`${schema2}.table2`, table => {
+        table.increments("id2").primary()
+      })
+
+      const response = await config.api.datasource.info(datasource)
+      expect(response.tableNames).toBeDefined()
+      expect(response.tableNames).toEqual(
         expect.arrayContaining(["table1", "table2"])
       )
     })
 
     it("does not mix columns from different tables", async () => {
       const repeated_table_name = "table_same_name"
-      await rawQuery(
-        rawDatasource,
-        `CREATE TABLE "${schema1}".${repeated_table_name} (id SERIAL PRIMARY KEY, val1 TEXT);`
+
+      await client.schema.createTable(
+        `${schema1}.${repeated_table_name}`,
+        table => {
+          table.increments("id").primary()
+          table.string("val1")
+        }
       )
-      await rawQuery(
-        rawDatasource,
-        `CREATE TABLE "${schema2}".${repeated_table_name} (id2 SERIAL PRIMARY KEY, val2 TEXT);`
+
+      await client.schema.createTable(
+        `${schema2}.${repeated_table_name}`,
+        table => {
+          table.increments("id2").primary()
+          table.string("val2")
+        }
       )
 
       const response = await config.api.datasource.fetchSchema({
@@ -182,15 +167,11 @@ describe("postgres integrations", () => {
 
   describe("check custom column types", () => {
     beforeAll(async () => {
-      await rawQuery(
-        rawDatasource,
-        `CREATE TABLE binaryTable (
-          id BYTEA PRIMARY KEY,
-          column1 TEXT,
-          column2 INT
-        );
-      `
-      )
+      await client.schema.createTable("binaryTable", table => {
+        table.binary("id").primary()
+        table.string("column1")
+        table.integer("column2")
+      })
     })
 
     it("should handle binary columns", async () => {
@@ -198,7 +179,7 @@ describe("postgres integrations", () => {
         datasourceId: datasource._id!,
       })
       expect(response.datasource.entities).toBeDefined()
-      const table = response.datasource.entities?.["binarytable"]
+      const table = response.datasource.entities?.["binaryTable"]
       expect(table).toBeDefined()
       expect(table?.schema.id.externalType).toBe("bytea")
       const row = await config.api.row.save(table?._id!, {
@@ -214,14 +195,10 @@ describe("postgres integrations", () => {
 
   describe("check fetching null/not null table", () => {
     beforeAll(async () => {
-      await rawQuery(
-        rawDatasource,
-        `CREATE TABLE nullableTable (
-          order_id SERIAL PRIMARY KEY,
-          order_number INT NOT NULL
-        );
-      `
-      )
+      await client.schema.createTable("nullableTable", table => {
+        table.increments("order_id").primary()
+        table.integer("order_number").notNullable()
+      })
     })
 
     it("should be able to change the table to allow nullable and refetch this", async () => {
@@ -230,25 +207,24 @@ describe("postgres integrations", () => {
       })
       const entities = response.datasource.entities
       expect(entities).toBeDefined()
-      const nullableTable = entities?.["nullabletable"]
+      const nullableTable = entities?.["nullableTable"]
       expect(nullableTable).toBeDefined()
       expect(
         nullableTable?.schema["order_number"].constraints?.presence
       ).toEqual(true)
+
       // need to perform these calls raw to the DB so that the external state of the DB differs to what Budibase
       // is aware of - therefore we can try to fetch and make sure BB updates correctly
-      await rawQuery(
-        rawDatasource,
-        `ALTER TABLE nullableTable
-             ALTER COLUMN order_number DROP NOT NULL;
-        `
-      )
+      await client.schema.alterTable("nullableTable", table => {
+        table.setNullable("order_number")
+      })
+
       const responseAfter = await config.api.datasource.fetchSchema({
         datasourceId: datasource._id!,
       })
       const entitiesAfter = responseAfter.datasource.entities
       expect(entitiesAfter).toBeDefined()
-      const nullableTableAfter = entitiesAfter?.["nullabletable"]
+      const nullableTableAfter = entitiesAfter?.["nullableTable"]
       expect(nullableTableAfter).toBeDefined()
       expect(
         nullableTableAfter?.schema["order_number"].constraints?.presence

--- a/packages/server/src/integration-test/postgres.spec.ts
+++ b/packages/server/src/integration-test/postgres.spec.ts
@@ -93,7 +93,7 @@ describe("postgres integrations", () => {
   describe("Integration compatibility with postgres search_path", () => {
     let rawDatasource: Datasource,
       datasource: Datasource,
-      client: Knex<any, unknown[]>,
+      client: Knex,
       schema1: string,
       schema2: string
 

--- a/packages/server/src/integration-test/postgres.spec.ts
+++ b/packages/server/src/integration-test/postgres.spec.ts
@@ -12,13 +12,12 @@ import { Knex } from "knex"
 const config = setup.getConfig()!
 
 describe("postgres integrations", () => {
-  let rawDatasource: Datasource
   let datasource: Datasource
   let client: Knex
 
   beforeAll(async () => {
     await config.init()
-    rawDatasource = await getDatasource(DatabaseName.POSTGRES)
+    const rawDatasource = await getDatasource(DatabaseName.POSTGRES)
     datasource = await config.api.datasource.create(rawDatasource)
     client = await knexClient(rawDatasource)
   })
@@ -91,17 +90,16 @@ describe("postgres integrations", () => {
   })
 
   describe("Integration compatibility with postgres search_path", () => {
-    let rawDatasource: Datasource,
-      datasource: Datasource,
-      client: Knex,
-      schema1: string,
-      schema2: string
+    let datasource: Datasource
+    let client: Knex
+    let schema1: string
+    let schema2: string
 
     beforeEach(async () => {
       schema1 = generator.guid().replaceAll("-", "")
       schema2 = generator.guid().replaceAll("-", "")
 
-      rawDatasource = await getDatasource(DatabaseName.POSTGRES)
+      const rawDatasource = await getDatasource(DatabaseName.POSTGRES)
       client = await knexClient(rawDatasource)
 
       await client.schema.createSchema(schema1)

--- a/packages/server/src/integrations/tests/utils/index.ts
+++ b/packages/server/src/integrations/tests/utils/index.ts
@@ -65,6 +65,23 @@ export async function rawQuery(ds: Datasource, sql: string): Promise<any> {
   }
 }
 
+export async function knexClient(ds: Datasource) {
+  switch (ds.source) {
+    case SourceName.POSTGRES: {
+      return postgres.knexClient(ds)
+    }
+    case SourceName.MYSQL: {
+      return mysql.knexClient(ds)
+    }
+    case SourceName.SQL_SERVER: {
+      return mssql.knexClient(ds)
+    }
+    default: {
+      throw new Error(`Unsupported source: ${ds.source}`)
+    }
+  }
+}
+
 export async function startContainer(container: GenericContainer) {
   const imageName = (container as any).imageName.string as string
   const key = imageName.replaceAll("/", "-").replaceAll(":", "-")

--- a/packages/server/src/integrations/tests/utils/index.ts
+++ b/packages/server/src/integrations/tests/utils/index.ts
@@ -48,23 +48,6 @@ export async function getDatasources(
   return Promise.all(sourceNames.map(sourceName => providers[sourceName]()))
 }
 
-export async function rawQuery(ds: Datasource, sql: string): Promise<any> {
-  switch (ds.source) {
-    case SourceName.POSTGRES: {
-      return postgres.rawQuery(ds, sql)
-    }
-    case SourceName.MYSQL: {
-      return mysql.rawQuery(ds, sql)
-    }
-    case SourceName.SQL_SERVER: {
-      return mssql.rawQuery(ds, sql)
-    }
-    default: {
-      throw new Error(`Unsupported source: ${ds.source}`)
-    }
-  }
-}
-
 export async function knexClient(ds: Datasource) {
   switch (ds.source) {
     case SourceName.POSTGRES: {

--- a/packages/server/src/integrations/tests/utils/mariadb.ts
+++ b/packages/server/src/integrations/tests/utils/mariadb.ts
@@ -1,9 +1,9 @@
 import { Datasource, SourceName } from "@budibase/types"
 import { GenericContainer, Wait } from "testcontainers"
 import { AbstractWaitStrategy } from "testcontainers/build/wait-strategies/wait-strategy"
-import { rawQuery } from "./mysql"
 import { generator, testContainerUtils } from "@budibase/backend-core/tests"
 import { startContainer } from "."
+import { knexClient } from "./mysql"
 
 let ports: Promise<testContainerUtils.Port[]>
 
@@ -55,7 +55,8 @@ export async function getDatasource(): Promise<Datasource> {
   }
 
   const database = generator.guid().replaceAll("-", "")
-  await rawQuery(datasource, `CREATE DATABASE \`${database}\``)
+  const client = await knexClient(datasource)
+  await client.raw(`CREATE DATABASE \`${database}\``)
   datasource.config.database = database
   return datasource
 }

--- a/packages/server/src/integrations/tests/utils/mssql.ts
+++ b/packages/server/src/integrations/tests/utils/mssql.ts
@@ -3,6 +3,7 @@ import { GenericContainer, Wait } from "testcontainers"
 import mssql from "mssql"
 import { generator, testContainerUtils } from "@budibase/backend-core/tests"
 import { startContainer } from "."
+import knex from "knex"
 
 let ports: Promise<testContainerUtils.Port[]>
 
@@ -71,4 +72,18 @@ export async function rawQuery(ds: Datasource, sql: string) {
   } finally {
     await pool.close()
   }
+}
+
+export async function knexClient(ds: Datasource) {
+  if (!ds.config) {
+    throw new Error("Datasource config is missing")
+  }
+  if (ds.source !== SourceName.SQL_SERVER) {
+    throw new Error("Datasource source is not MSSQL")
+  }
+
+  return knex({
+    client: "mssql",
+    connection: ds.config,
+  })
 }

--- a/packages/server/src/integrations/tests/utils/mssql.ts
+++ b/packages/server/src/integrations/tests/utils/mssql.ts
@@ -7,7 +7,7 @@ import knex from "knex"
 
 let ports: Promise<testContainerUtils.Port[]>
 
-export async function getDatasource(): Promise<Datasource> {
+export async function GetDatasource(): Promise<Datasource> {
   if (!ports) {
     ports = startContainer(
       new GenericContainer("mcr.microsoft.com/mssql/server:2022-latest")

--- a/packages/server/src/integrations/tests/utils/mysql.ts
+++ b/packages/server/src/integrations/tests/utils/mysql.ts
@@ -88,7 +88,7 @@ export async function knexClient(ds: Datasource) {
   }
 
   return knex({
-    client: "mysql",
+    client: "mysql2",
     connection: ds.config,
   })
 }

--- a/packages/server/src/integrations/tests/utils/mysql.ts
+++ b/packages/server/src/integrations/tests/utils/mysql.ts
@@ -1,7 +1,6 @@
 import { Datasource, SourceName } from "@budibase/types"
 import { GenericContainer, Wait } from "testcontainers"
 import { AbstractWaitStrategy } from "testcontainers/build/wait-strategies/wait-strategy"
-import mysql from "mysql2/promise"
 import { generator, testContainerUtils } from "@budibase/backend-core/tests"
 import { startContainer } from "."
 import knex from "knex"
@@ -57,26 +56,10 @@ export async function getDatasource(): Promise<Datasource> {
   }
 
   const database = generator.guid().replaceAll("-", "")
-  await rawQuery(datasource, `CREATE DATABASE \`${database}\``)
+  const client = await knexClient(datasource)
+  await client.raw(`CREATE DATABASE \`${database}\``)
   datasource.config!.database = database
   return datasource
-}
-
-export async function rawQuery(ds: Datasource, sql: string) {
-  if (!ds.config) {
-    throw new Error("Datasource config is missing")
-  }
-  if (ds.source !== SourceName.MYSQL) {
-    throw new Error("Datasource source is not MySQL")
-  }
-
-  const connection = await mysql.createConnection(ds.config)
-  try {
-    const [rows] = await connection.query(sql)
-    return rows
-  } finally {
-    connection.end()
-  }
 }
 
 export async function knexClient(ds: Datasource) {

--- a/packages/server/src/integrations/tests/utils/mysql.ts
+++ b/packages/server/src/integrations/tests/utils/mysql.ts
@@ -4,6 +4,7 @@ import { AbstractWaitStrategy } from "testcontainers/build/wait-strategies/wait-
 import mysql from "mysql2/promise"
 import { generator, testContainerUtils } from "@budibase/backend-core/tests"
 import { startContainer } from "."
+import knex from "knex"
 
 let ports: Promise<testContainerUtils.Port[]>
 
@@ -76,4 +77,18 @@ export async function rawQuery(ds: Datasource, sql: string) {
   } finally {
     connection.end()
   }
+}
+
+export async function knexClient(ds: Datasource) {
+  if (!ds.config) {
+    throw new Error("Datasource config is missing")
+  }
+  if (ds.source !== SourceName.MYSQL) {
+    throw new Error("Datasource source is not MySQL")
+  }
+
+  return knex({
+    client: "mysql",
+    connection: ds.config,
+  })
 }

--- a/packages/server/src/integrations/tests/utils/postgres.ts
+++ b/packages/server/src/integrations/tests/utils/postgres.ts
@@ -3,6 +3,7 @@ import { GenericContainer, Wait } from "testcontainers"
 import pg from "pg"
 import { generator, testContainerUtils } from "@budibase/backend-core/tests"
 import { startContainer } from "."
+import knex from "knex"
 
 let ports: Promise<testContainerUtils.Port[]>
 
@@ -65,4 +66,18 @@ export async function rawQuery(ds: Datasource, sql: string) {
   } finally {
     await client.end()
   }
+}
+
+export async function knexClient(ds: Datasource) {
+  if (!ds.config) {
+    throw new Error("Datasource config is missing")
+  }
+  if (ds.source !== SourceName.POSTGRES) {
+    throw new Error("Datasource source is not Postgres")
+  }
+
+  return knex({
+    client: "pg",
+    connection: ds.config,
+  })
 }

--- a/packages/server/src/integrations/tests/utils/postgres.ts
+++ b/packages/server/src/integrations/tests/utils/postgres.ts
@@ -1,6 +1,5 @@
 import { Datasource, SourceName } from "@budibase/types"
 import { GenericContainer, Wait } from "testcontainers"
-import pg from "pg"
 import { generator, testContainerUtils } from "@budibase/backend-core/tests"
 import { startContainer } from "."
 import knex from "knex"
@@ -44,28 +43,11 @@ export async function getDatasource(): Promise<Datasource> {
   }
 
   const database = generator.guid().replaceAll("-", "")
-  await rawQuery(datasource, `CREATE DATABASE "${database}"`)
+  const client = await knexClient(datasource)
+  await client.raw(`CREATE DATABASE "${database}"`)
   datasource.config!.database = database
 
   return datasource
-}
-
-export async function rawQuery(ds: Datasource, sql: string) {
-  if (!ds.config) {
-    throw new Error("Datasource config is missing")
-  }
-  if (ds.source !== SourceName.POSTGRES) {
-    throw new Error("Datasource source is not Postgres")
-  }
-
-  const client = new pg.Client(ds.config)
-  await client.connect()
-  try {
-    const { rows } = await client.query(sql)
-    return rows
-  } finally {
-    await client.end()
-  }
 }
 
 export async function knexClient(ds: Datasource) {


### PR DESCRIPTION
## Description

This PR moves our tests to using `knex` in favour of our custom `rawQuery`. `knex` has a `knex.raw()` method we can use if we need to issue raw SQL, and those instances should be few and far between. `knex`'s DSL for running queries should be preferred everywhere.
