### PR TITLE
Disallow prohibited columns

### DIFF
--- a/packages/backend-core/src/db/constants.ts
+++ b/packages/backend-core/src/db/constants.ts
@@ -1,14 +1,5 @@
-export const CONSTANT_INTERNAL_ROW_COLS = [
-  "_id",
-  "_rev",
-  "type",
-  "createdAt",
-  "updatedAt",
-  "tableId",
-] as const
-
-export const CONSTANT_EXTERNAL_ROW_COLS = ["_id", "_rev", "tableId"] as const
-
-export function isInternalColumnName(name: string): boolean {
-  return (CONSTANT_INTERNAL_ROW_COLS as readonly string[]).includes(name)
-}
+export {
+  CONSTANT_INTERNAL_ROW_COLS,
+  CONSTANT_EXTERNAL_ROW_COLS,
+  isInternalColumnName,
+} from "@budibase/shared-core"

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -54,7 +54,6 @@
   const DATE_TYPE = FieldType.DATETIME
 
   const dispatch = createEventDispatcher()
-  const PROHIBITED_COLUMN_NAMES = ["type", "_id", "_rev", "tableId"]
   const { dispatch: gridDispatch, rows } = getContext("grid")
 
   export let field

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -17,6 +17,8 @@
     SWITCHABLE_TYPES,
     ValidColumnNameRegex,
     helpers,
+    CONSTANT_INTERNAL_ROW_COLS,
+    CONSTANT_EXTERNAL_ROW_COLS,
   } from "@budibase/shared-core"
   import { createEventDispatcher, getContext, onMount } from "svelte"
   import { cloneDeep } from "lodash/fp"
@@ -487,20 +489,27 @@
       })
     }
     const newError = {}
+    const prohibited = externalTable
+      ? CONSTANT_EXTERNAL_ROW_COLS
+      : CONSTANT_INTERNAL_ROW_COLS
     if (!externalTable && fieldInfo.name?.startsWith("_")) {
       newError.name = `Column name cannot start with an underscore.`
     } else if (fieldInfo.name && !fieldInfo.name.match(ValidColumnNameRegex)) {
       newError.name = `Illegal character; must be alpha-numeric.`
-    } else if (PROHIBITED_COLUMN_NAMES.some(name => fieldInfo.name === name)) {
-      newError.name = `${PROHIBITED_COLUMN_NAMES.join(
+    } else if (
+      prohibited.some(
+        name => fieldInfo?.name?.toLowerCase() === name.toLowerCase()
+      )
+    ) {
+      newError.name = `${prohibited.join(
         ", "
-      )} are not allowed as column names`
+      )} are not allowed as column names - case insensitive.`
     } else if (inUse($tables.selected, fieldInfo.name, originalName)) {
       newError.name = `Column name already in use.`
     }
 
     if (fieldInfo.type === FieldType.AUTO && !fieldInfo.subtype) {
-      newError.subtype = `Auto Column requires a type`
+      newError.subtype = `Auto Column requires a type.`
     }
 
     if (fieldInfo.fieldName && fieldInfo.tableId) {

--- a/packages/server/src/api/routes/tests/table.spec.ts
+++ b/packages/server/src/api/routes/tests/table.spec.ts
@@ -276,6 +276,31 @@ describe.each([
         })
     })
 
+    it("shouldn't allow duplicate column names", async () => {
+      const saveTableRequest: SaveTableRequest = {
+        ...basicTable(),
+      }
+      saveTableRequest.schema["Type"] = { type: FieldType.STRING, name: "Type" }
+      await config.api.table.save(saveTableRequest, {
+        status: 400,
+        body: {
+          message:
+            'Column "type" is duplicated - make sure there are no duplicate columns names, this is case insensitive.',
+        },
+      })
+      saveTableRequest.schema = {
+        foo: { type: FieldType.STRING, name: "foo" },
+        FOO: { type: FieldType.STRING, name: "FOO" },
+      }
+      await config.api.table.save(saveTableRequest, {
+        status: 400,
+        body: {
+          message:
+            'Column "foo" is duplicated - make sure there are no duplicate columns names, this is case insensitive.',
+        },
+      })
+    })
+
     it("should add a new column for an internal DB table", async () => {
       const saveTableRequest: SaveTableRequest = {
         ...basicTable(),

--- a/packages/server/src/api/routes/tests/table.spec.ts
+++ b/packages/server/src/api/routes/tests/table.spec.ts
@@ -289,18 +289,17 @@ describe.each([
           status: 400,
           body: {
             message:
-              'Column "type" is duplicated - make sure there are no duplicate columns names, this is case insensitive.',
+              'Column(s) "type" are duplicated - check for other columns with these name (case in-sensitive)',
           },
         })
-        saveTableRequest.schema = {
-          foo: { type: FieldType.STRING, name: "foo" },
-          FOO: { type: FieldType.STRING, name: "FOO" },
-        }
+        saveTableRequest.schema.foo = { type: FieldType.STRING, name: "foo" }
+        saveTableRequest.schema.FOO = { type: FieldType.STRING, name: "FOO" }
+
         await config.api.table.save(saveTableRequest, {
           status: 400,
           body: {
             message:
-              'Column "foo" is duplicated - make sure there are no duplicate columns names, this is case insensitive.',
+              'Column(s) "type, foo" are duplicated - check for other columns with these name (case in-sensitive)',
           },
         })
       })

--- a/packages/server/src/api/routes/tests/table.spec.ts
+++ b/packages/server/src/api/routes/tests/table.spec.ts
@@ -276,30 +276,34 @@ describe.each([
         })
     })
 
-    it("shouldn't allow duplicate column names", async () => {
-      const saveTableRequest: SaveTableRequest = {
-        ...basicTable(),
-      }
-      saveTableRequest.schema["Type"] = { type: FieldType.STRING, name: "Type" }
-      await config.api.table.save(saveTableRequest, {
-        status: 400,
-        body: {
-          message:
-            'Column "type" is duplicated - make sure there are no duplicate columns names, this is case insensitive.',
-        },
+    isInternal &&
+      it("shouldn't allow duplicate column names", async () => {
+        const saveTableRequest: SaveTableRequest = {
+          ...basicTable(),
+        }
+        saveTableRequest.schema["Type"] = {
+          type: FieldType.STRING,
+          name: "Type",
+        }
+        await config.api.table.save(saveTableRequest, {
+          status: 400,
+          body: {
+            message:
+              'Column "type" is duplicated - make sure there are no duplicate columns names, this is case insensitive.',
+          },
+        })
+        saveTableRequest.schema = {
+          foo: { type: FieldType.STRING, name: "foo" },
+          FOO: { type: FieldType.STRING, name: "FOO" },
+        }
+        await config.api.table.save(saveTableRequest, {
+          status: 400,
+          body: {
+            message:
+              'Column "foo" is duplicated - make sure there are no duplicate columns names, this is case insensitive.',
+          },
+        })
       })
-      saveTableRequest.schema = {
-        foo: { type: FieldType.STRING, name: "foo" },
-        FOO: { type: FieldType.STRING, name: "FOO" },
-      }
-      await config.api.table.save(saveTableRequest, {
-        status: 400,
-        body: {
-          message:
-            'Column "foo" is duplicated - make sure there are no duplicate columns names, this is case insensitive.',
-        },
-      })
-    })
 
     it("should add a new column for an internal DB table", async () => {
       const saveTableRequest: SaveTableRequest = {

--- a/packages/server/src/sdk/app/tables/internal/index.ts
+++ b/packages/server/src/sdk/app/tables/internal/index.ts
@@ -16,7 +16,7 @@ import { EventType, updateLinks } from "../../../../db/linkedRows"
 import { cloneDeep } from "lodash/fp"
 import isEqual from "lodash/isEqual"
 import { runStaticFormulaChecks } from "../../../../api/controllers/table/bulkFormula"
-import { context, db as dbCore } from "@budibase/backend-core"
+import { context } from "@budibase/backend-core"
 import { findDuplicateInternalColumns } from "@budibase/shared-core"
 import { getTable } from "../getters"
 import { checkAutoColumns } from "./utils"
@@ -48,9 +48,11 @@ export async function save(
 
   // check for case sensitivity - we don't want to allow duplicated columns
   const duplicateColumn = findDuplicateInternalColumns(table)
-  if (duplicateColumn) {
+  if (duplicateColumn.length) {
     throw new Error(
-      `Column "${duplicateColumn}" is duplicated - make sure there are no duplicate columns names, this is case insensitive.`
+      `Column(s) "${duplicateColumn.join(
+        ", "
+      )}" are duplicated - check for other columns with these name (case in-sensitive)`
     )
   }
 

--- a/packages/shared-core/src/constants/index.ts
+++ b/packages/shared-core/src/constants/index.ts
@@ -1,5 +1,6 @@
 export * from "./api"
 export * from "./fields"
+export * from "./rows"
 
 export const OperatorOptions = {
   Equals: {

--- a/packages/shared-core/src/constants/rows.ts
+++ b/packages/shared-core/src/constants/rows.ts
@@ -1,0 +1,14 @@
+export const CONSTANT_INTERNAL_ROW_COLS = [
+  "_id",
+  "_rev",
+  "type",
+  "createdAt",
+  "updatedAt",
+  "tableId",
+] as const
+
+export const CONSTANT_EXTERNAL_ROW_COLS = ["_id", "_rev", "tableId"] as const
+
+export function isInternalColumnName(name: string): boolean {
+  return (CONSTANT_INTERNAL_ROW_COLS as readonly string[]).includes(name)
+}

--- a/packages/shared-core/src/table.ts
+++ b/packages/shared-core/src/table.ts
@@ -1,4 +1,5 @@
-import { FieldType } from "@budibase/types"
+import { FieldType, Table } from "@budibase/types"
+import { CONSTANT_INTERNAL_ROW_COLS } from "./constants"
 
 const allowDisplayColumnByType: Record<FieldType, boolean> = {
   [FieldType.STRING]: true,
@@ -50,4 +51,23 @@ export function canBeDisplayColumn(type: FieldType): boolean {
 
 export function canBeSortColumn(type: FieldType): boolean {
   return !!allowSortColumnByType[type]
+}
+
+export function findDuplicateInternalColumns(table: Table): string | undefined {
+  // get the column names
+  const columnNames = Object.keys(table.schema)
+    .concat(CONSTANT_INTERNAL_ROW_COLS)
+    .map(colName => colName.toLowerCase())
+  // there are duplicates
+  const set = new Set(columnNames)
+  let foundDuplicate: string | undefined
+  if (set.size !== columnNames.length) {
+    for (let key of set.keys()) {
+      const count = columnNames.filter(name => name === key).length
+      if (count > 1) {
+        foundDuplicate = key
+      }
+    }
+  }
+  return foundDuplicate
 }

--- a/packages/shared-core/src/table.ts
+++ b/packages/shared-core/src/table.ts
@@ -53,21 +53,21 @@ export function canBeSortColumn(type: FieldType): boolean {
   return !!allowSortColumnByType[type]
 }
 
-export function findDuplicateInternalColumns(table: Table): string | undefined {
+export function findDuplicateInternalColumns(table: Table): string[] {
   // get the column names
   const columnNames = Object.keys(table.schema)
     .concat(CONSTANT_INTERNAL_ROW_COLS)
     .map(colName => colName.toLowerCase())
   // there are duplicates
   const set = new Set(columnNames)
-  let foundDuplicate: string | undefined
+  let duplicates: string[] = []
   if (set.size !== columnNames.length) {
     for (let key of set.keys()) {
       const count = columnNames.filter(name => name === key).length
       if (count > 1) {
-        foundDuplicate = key
+        duplicates.push(key)
       }
     }
   }
-  return foundDuplicate
+  return duplicates
 }


### PR DESCRIPTION
## Description
As the title - this was already done, but it was case sensitive. Budibase columns are case in-sensitive, meaning that the prohibited columns could still be added as long as they were a different casing - this has been rectified, backend validation added and test cases for it added.
