### PR TITLE
[BUDI-8390] Fix primary key appearing twice in the SQL ORDER BY clause.

### DIFF
--- a/packages/backend-core/src/sql/sql.ts
+++ b/packages/backend-core/src/sql/sql.ts
@@ -449,8 +449,12 @@ class InternalBuilder {
         query = query.orderBy(`${aliased}.${key}`, direction, nulls)
       }
     }
-    // always add sorting by the primary key - make sure result is deterministic
-    query = query.orderBy(`${aliased}.${primaryKey[0]}`)
+
+    // add sorting by the primary key if the result isn't isn't already sorted
+    // by it, to make sure result is deterministic
+    if (!sort || sort[primaryKey[0]] === undefined) {
+      query = query.orderBy(`${aliased}.${primaryKey[0]}`)
+    }
     return query
   }
 

--- a/packages/backend-core/src/sql/sql.ts
+++ b/packages/backend-core/src/sql/sql.ts
@@ -450,8 +450,8 @@ class InternalBuilder {
       }
     }
 
-    // add sorting by the primary key if the result isn't isn't already sorted
-    // by it, to make sure result is deterministic
+    // add sorting by the primary key if the result isn't already sorted by it,
+    // to make sure result is deterministic
     if (!sort || sort[primaryKey[0]] === undefined) {
       query = query.orderBy(`${aliased}.${primaryKey[0]}`)
     }


### PR DESCRIPTION
## Description

To ensure that the order of results from our search endpoint are deterministic, we have historically always added the primary key into the ORDER BY clause for our search queries. This caused problems if you specified in your search query that you wanted to sort by the primary key, because we would add the primary key twice into the SQL ORDER BY clause, and this results in an SQL error. This PR changes it such that we only add the primary key sort if it is not in the search request sort already.

## Addresses
- https://linear.app/budibase/issue/BUDI-8390/receiving-a-column-has-been-specified-more-than-once-in-the-order-by
