### PR TITLE
Fix weird behaviour when adding rows if you have multiple pages of data

### DIFF
--- a/packages/frontend-core/src/components/grid/layout/NewRow.svelte
+++ b/packages/frontend-core/src/components/grid/layout/NewRow.svelte
@@ -103,7 +103,7 @@
 
     // If we don't have a next page then we're at the bottom and can scroll to
     // the max available offset
-    else {
+    if (!$hasNextPage) {
       scroll.update(state => ({
         ...state,
         top: $maxScrollTop,


### PR DESCRIPTION
## Description
Fixes a small issue where the table scroll position is incorrect if you add a row when you have another page of data.
