### PR TITLE
Frontend - allow prohibited columns, case sensitive

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -495,11 +495,7 @@
       newError.name = `Column name cannot start with an underscore.`
     } else if (fieldInfo.name && !fieldInfo.name.match(ValidColumnNameRegex)) {
       newError.name = `Illegal character; must be alpha-numeric.`
-    } else if (
-      prohibited.some(
-        name => fieldInfo?.name?.toLowerCase() === name.toLowerCase()
-      )
-    ) {
+    } else if (prohibited.some(name => fieldInfo?.name === name)) {
       newError.name = `${prohibited.join(
         ", "
       )} are not allowed as column names - case insensitive.`


### PR DESCRIPTION
## Description
Quick fix to allow case sensitive versions of the prohibited columns, this is allowed on the backend and many apps like this exist, there isn't really any reason to disallow this anymore.