### PR TITLE
Updating filter fields to use relationship name rather than related table name

### DIFF
--- a/packages/frontend-core/src/utils/searchFields.js
+++ b/packages/frontend-core/src/utils/searchFields.js
@@ -2,7 +2,6 @@ import { BannedSearchTypes } from "../constants"
 
 export function getTableFields(tables, linkField) {
   const table = tables.find(table => table._id === linkField.tableId)
-  // TODO: mdrury - add support for this with SQS at some point
   if (!table || !table.sql) {
     return []
   }
@@ -11,7 +10,7 @@ export function getTableFields(tables, linkField) {
   })
   return linkFields.map(field => ({
     ...field,
-    name: `${table.name}.${field.name}`,
+    name: `${linkField.name}.${field.name}`,
   }))
 }
 

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -9,20 +9,20 @@ import { db as dbCore, utils } from "@budibase/backend-core"
 import * as setup from "./utilities"
 import {
   AutoFieldSubType,
+  BBReferenceFieldSubType,
   Datasource,
   EmptyFilterOption,
-  BBReferenceFieldSubType,
   FieldType,
+  RelationshipType,
+  Row,
   RowSearchParams,
   SearchFilters,
+  SearchResponse,
   SortOrder,
   SortType,
   Table,
   TableSchema,
   User,
-  Row,
-  RelationshipType,
-  SearchResponse,
 } from "@budibase/types"
 import _ from "lodash"
 import tk from "timekeeper"
@@ -2081,6 +2081,28 @@ describe.each([
         await expectQuery({
           equal: { ["name"]: "baz" },
         }).toContainExactly([{ name: "baz", productCat: undefined }])
+      })
+    })
+
+  isInternal &&
+    describe("no column error backwards compat", () => {
+      beforeAll(async () => {
+        table = await createTable({
+          name: {
+            name: "name",
+            type: FieldType.STRING,
+          },
+        })
+      })
+
+      it("shouldn't error when column doesn't exist", async () => {
+        await expectSearch({
+          query: {
+            string: {
+              "1:something": "a",
+            },
+          },
+        }).toMatch({ rows: [] })
       })
     })
 

--- a/packages/server/src/sdk/app/rows/search/sqs.ts
+++ b/packages/server/src/sdk/app/rows/search/sqs.ts
@@ -340,8 +340,7 @@ export async function search(
       await sdk.tables.sqs.syncDefinition()
       return search(options, table)
     }
-    // previously the internal table didn't error when
-    console.log(JSON.stringify(err))
+    // previously the internal table didn't error when a column didn't exist in search
     if (err.status === 400 && msg?.match(MISSING_COLUMN_REGEX)) {
       return { rows: [] }
     }

--- a/packages/server/src/sdk/app/rows/search/sqs.ts
+++ b/packages/server/src/sdk/app/rows/search/sqs.ts
@@ -39,7 +39,10 @@ import {
 import { dataFilters } from "@budibase/shared-core"
 
 const builder = new sql.Sql(SqlClient.SQL_LITE)
-const NO_SUCH_COLUMN_REGEX = new RegExp(`no such colum.+${USER_COLUMN_PREFIX}`)
+const MISSING_COLUMN_REGEX = new RegExp(`no such column: .+`)
+const USER_COLUMN_PREFIX_REGEX = new RegExp(
+  `no such column: .+${USER_COLUMN_PREFIX}`
+)
 
 function buildInternalFieldList(
   table: Table,
@@ -331,11 +334,16 @@ export async function search(
   } catch (err: any) {
     const msg = typeof err === "string" ? err : err.message
     const syncAndRepeat =
-      (err.status === 400 && msg?.match(NO_SUCH_COLUMN_REGEX)) ||
+      (err.status === 400 && msg?.match(USER_COLUMN_PREFIX_REGEX)) ||
       (err.status === 404 && msg?.includes(SQLITE_DESIGN_DOC_ID))
     if (syncAndRepeat) {
       await sdk.tables.sqs.syncDefinition()
       return search(options, table)
+    }
+    // previously the internal table didn't error when
+    console.log(JSON.stringify(err))
+    if (err.status === 400 && msg?.match(MISSING_COLUMN_REGEX)) {
+      return { rows: [] }
     }
     throw new Error(`Unable to search by SQL - ${msg}`, { cause: err })
   }


### PR DESCRIPTION
## Description
Using the relationship name rather than the table name - the relationship may have a different name to the related table, this makes it a bit more sensible.