### PR TITLE
Set `DISABLE_V8_COMPILE_CACHE` on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
   "scripts": {
     "get-past-client-version": "node scripts/getPastClientVersion.js",
     "setup": "git config submodule.recurse true && git submodule update && node ./hosting/scripts/setup.js && yarn && yarn build && yarn dev",
-    "build": "NODE_OPTIONS=--max-old-space-size=1500 lerna run build --stream",
-    "build:apps": "yarn build --scope @budibase/server --scope @budibase/worker",
+    "build": "DISABLE_V8_COMPILE_CACHE=1 NODE_OPTIONS=--max-old-space-size=1500 lerna run build --stream",
+    "build:apps": "DISABLE_V8_COMPILE_CACHE=1 yarn build --scope @budibase/server --scope @budibase/worker",
+    "build:oss": "DISABLE_V8_COMPILE_CACHE=1 NODE_OPTIONS=--max-old-space-size=1500 lerna run build --stream --ignore @budibase/account-portal-server --ignore @budibase/account-portal-ui",
     "build:cli": "yarn build --scope @budibase/cli",
-    "build:oss": "NODE_OPTIONS=--max-old-space-size=1500 lerna run build --stream --ignore @budibase/account-portal-server --ignore @budibase/account-portal-ui",
     "build:account-portal": "NODE_OPTIONS=--max-old-space-size=1500 lerna run build --stream --scope @budibase/account-portal-server --scope @budibase/account-portal-ui",
     "build:dev": "lerna run --stream prebuild && yarn nx run-many --target=build --output-style=dynamic --watch --preserveWatchOutput",
     "check:types": "lerna run --concurrency 2 check:types --ignore @budibase/account-portal-server",


### PR DESCRIPTION
## Description
Setting `DISABLE_V8_COMPILE_CACHE=1` when running builds as it may fix some issues with node 20 and esbuild causing v8 stack traces - we've had several instances recently with Node 20 builds failing with no useful output other than a V8 stacktrace, suggesting an issue with Node rather than Budibase.

Discussed in: https://github.com/nodejs/node/issues/51555