### PR TITLE
Squash the oldRow prop in the external row controller

### DIFF
--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -72,15 +72,23 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   const row = await sdk.rows.external.getRow(tableId, updatedId, {
     relationships: true,
   })
-  const enrichedRow = await outputProcessing(table, row, {
-    squash: true,
-    preserveLinks: true,
-  })
+
+  const [enrichedRow, oldRow] = await Promise.all([
+    outputProcessing(table, row, {
+      squash: true,
+      preserveLinks: true,
+    }),
+    outputProcessing(table, beforeRow, {
+      squash: true,
+      preserveLinks: true,
+    }),
+  ])
+
   return {
     ...response,
     row: enrichedRow,
     table,
-    oldRow: beforeRow,
+    oldRow,
   }
 }
 

--- a/packages/server/src/automations/triggers.ts
+++ b/packages/server/src/automations/triggers.ts
@@ -66,7 +66,11 @@ async function queueRelevantRowAutomations(
         automationTrigger?.inputs &&
         automationTrigger.inputs.tableId === event.row.tableId
       ) {
-        await automationQueue.add({ automation, event }, JOB_OPTS)
+        try {
+          await automationQueue.add({ automation, event }, JOB_OPTS)
+        } catch (e) {
+          console.error("Failed to queue automation", e)
+        }
       }
     }
   })

--- a/packages/server/src/automations/triggers.ts
+++ b/packages/server/src/automations/triggers.ts
@@ -2,13 +2,12 @@ import emitter from "../events/index"
 import { getAutomationParams, isDevAppID } from "../db/utils"
 import { coerce } from "../utilities/rowProcessor"
 import { definitions } from "./triggerInfo"
-import { logging } from "@budibase/backend-core"
 // need this to call directly, so we can get a response
 import { automationQueue } from "./bullboard"
 import { checkTestFlag } from "../utilities/redis"
 import * as utils from "./utils"
 import env from "../environment"
-import { context, db as dbCore } from "@budibase/backend-core"
+import { context, logging, db as dbCore } from "@budibase/backend-core"
 import {
   Automation,
   Row,

--- a/packages/server/src/automations/triggers.ts
+++ b/packages/server/src/automations/triggers.ts
@@ -2,6 +2,7 @@ import emitter from "../events/index"
 import { getAutomationParams, isDevAppID } from "../db/utils"
 import { coerce } from "../utilities/rowProcessor"
 import { definitions } from "./triggerInfo"
+import { logging } from "@budibase/backend-core"
 // need this to call directly, so we can get a response
 import { automationQueue } from "./bullboard"
 import { checkTestFlag } from "../utilities/redis"
@@ -69,7 +70,7 @@ async function queueRelevantRowAutomations(
         try {
           await automationQueue.add({ automation, event }, JOB_OPTS)
         } catch (e) {
-          console.error("Failed to queue automation", e)
+          logging.logAlert("Failed to queue automation", e)
         }
       }
     }


### PR DESCRIPTION
## Description
I ran into an issue when testing update triggers for an external database with relationships. When the update event was triggered and the server attempted to queue the automation, it got stuck into a cyclical loop trying to serialise the `oldRow` prop.

## Addresses
- Squashes the `oldRow` event property so that it can be serialised when queuing an automation.
- Adds a try/catch for development to ensure issues encountered when queuing automations won't kill the local server.

## Launchcontrol

Minor fix to ensure oldRow is squashed for external sources.