### PR TITLE
Fix for builder relationship picker 

### DIFF
--- a/packages/frontend-core/src/components/FilterBuilder.svelte
+++ b/packages/frontend-core/src/components/FilterBuilder.svelte
@@ -31,7 +31,7 @@
     if (
       tables.find(
         table =>
-          table._id === datasource.tableId &&
+          table._id === datasource?.tableId &&
           table.sourceId === DEFAULT_BB_DATASOURCE_ID
       ) &&
       !schemaFields.some(field => field.name === "_id")


### PR DESCRIPTION
## Description

Minor change to account for `datasource` not being fully initialised as the FilterBuilder loads

## Addresses
- https://linear.app/budibase/issue/BUDI-8411/relationship-picker-filtering-is-broken
