### PR TITLE
Fix notification message from display the wrong phrasing

### DIFF
--- a/packages/builder/src/stores/builder/automations.js
+++ b/packages/builder/src/stores/builder/automations.js
@@ -146,13 +146,13 @@ const automationActions = store => ({
       await store.actions.save(automation)
       notifications.success(
         `Automation ${
-          automation.disabled ? "enabled" : "disabled"
+          automation.disabled ? "disabled" : "enabled"
         } successfully`
       )
     } catch (error) {
       notifications.error(
         `Error ${
-          automation && automation.disabled ? "enabling" : "disabling"
+          automation && automation.disabled ? "disabling" : "enabling"
         } automation`
       )
     }


### PR DESCRIPTION
## Description
Enable and disabled were displaying the wrong way round. Amended so it outputs the correct message at the right time.

## Launchcontrol

Minor fix to automation notification message.
