### PR TITLE
Fix Client Modal Component `Ignore clicks outside` Setting

### DIFF
--- a/packages/client/src/components/app/Modal.svelte
+++ b/packages/client/src/components/app/Modal.svelte
@@ -56,7 +56,7 @@
   <Modal
     on:cancel={handleModalClose}
     bind:this={modal}
-    disableCancel={$builderStore.inBuilder}
+    disableCancel={$builderStore.inBuilder || ignoreClicksOutside}
     zIndex={2}
   >
     <div use:styleable={$component.styles} class={`modal-content ${size}`}>


### PR DESCRIPTION
## Description
https://linear.app/budibase/issue/BUDI-8425/modal-component-closes-on-click-outside-ignoring-the-settings

The `ignoreClickOutside` prop for modal components in the client was not wired up correctly, so the `Ignore clicks outside` checkbox wasn't doing anything, this should be fixed and working as intended now.