### PR TITLE
Return 401 instead of 403

### DIFF
--- a/packages/server/src/api/routes/tests/permissions.spec.ts
+++ b/packages/server/src/api/routes/tests/permissions.spec.ts
@@ -203,7 +203,7 @@ describe("/permission", () => {
       // replicate changes before checking permissions
       await config.publish()
 
-      await config.api.viewV2.publicSearch(view.id, undefined, { status: 403 })
+      await config.api.viewV2.publicSearch(view.id, undefined, { status: 401 })
     })
 
     it("should ignore the view permissions if the flag is not on", async () => {
@@ -221,7 +221,7 @@ describe("/permission", () => {
       await config.publish()
 
       await config.api.viewV2.publicSearch(view.id, undefined, {
-        status: 403,
+        status: 401,
       })
     })
 
@@ -250,8 +250,8 @@ describe("/permission", () => {
         .send(basicRow(table._id))
         .set(config.publicHeaders())
         .expect("Content-Type", /json/)
-        .expect(403)
-      expect(res.status).toEqual(403)
+        .expect(401)
+      expect(res.status).toEqual(401)
     })
   })
 

--- a/packages/server/src/api/routes/tests/utilities/TestFunctions.ts
+++ b/packages/server/src/api/routes/tests/utilities/TestFunctions.ts
@@ -151,7 +151,7 @@ export const checkPermissionsEndpoint = async ({
   await exports
     .createRequest(config.request, method, url, body)
     .set(failHeader)
-    .expect(403)
+    .expect(401)
 }
 
 export const getDB = () => {

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1490,7 +1490,7 @@ describe.each([
       it("does not allow public users to fetch by default", async () => {
         await config.publish()
         await config.api.viewV2.publicSearch(view.id, undefined, {
-          status: 403,
+          status: 401,
         })
       })
 
@@ -1534,7 +1534,7 @@ describe.each([
         await config.publish()
 
         await config.api.viewV2.publicSearch(view.id, undefined, {
-          status: 403,
+          status: 401,
         })
       })
     })

--- a/packages/server/src/middleware/authorized.ts
+++ b/packages/server/src/middleware/authorized.ts
@@ -96,7 +96,7 @@ const authorized =
     }
 
     if (!ctx.user) {
-      return ctx.throw(403, "No user info found")
+      return ctx.throw(401, "No user info found")
     }
 
     // get the resource roles
@@ -148,7 +148,7 @@ const authorized =
 
     // check authenticated
     if (!ctx.isAuthenticated) {
-      return ctx.throw(403, "Session not authenticated")
+      return ctx.throw(401, "Session not authenticated")
     }
 
     // check general builder stuff, this middleware is a good way

--- a/packages/server/src/middleware/tests/authorized.spec.ts
+++ b/packages/server/src/middleware/tests/authorized.spec.ts
@@ -105,7 +105,7 @@ describe("Authorization middleware", () => {
     it("throws when no user data is present in context", async () => {
       await config.executeMiddleware()
 
-      expect(config.throw).toHaveBeenCalledWith(403, "No user info found")
+      expect(config.throw).toHaveBeenCalledWith(401, "No user info found")
     })
 
     it("passes on to next() middleware if user is an admin", async () => {
@@ -157,7 +157,7 @@ describe("Authorization middleware", () => {
 
       await config.executeMiddleware()
       expect(config.throw).toHaveBeenCalledWith(
-        403,
+        401,
         "Session not authenticated"
       )
     })


### PR DESCRIPTION
## Description
We are currently throwing 403 (forbidden) for non-authenticated requests, and this is not REST standard. If there is no user info and the endpoint is protected, we should return 401 (unauthorized).

Changing the middleware to return 401 in these cases.

## Launchcontrol
Return 401s for unauthenticated server requests