### PR TITLE
When `return all table rows` is selected the is in filter returns nothing instead of all rows

### DIFF
--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -809,6 +809,20 @@ describe.each([
           },
         }).toContainExactly([{ name: "foo" }, { name: "bar" }])
       })
+
+      it("empty arrays returns all when onEmptyFilter is set to return 'all'", async () => {
+        await expectQuery({
+          onEmptyFilter: EmptyFilterOption.RETURN_ALL,
+          oneOf: { name: [] },
+        }).toContainExactly([{ name: "foo" }, { name: "bar" }])
+      })
+
+      it("empty arrays returns all when onEmptyFilter is set to return 'none'", async () => {
+        await expectQuery({
+          onEmptyFilter: EmptyFilterOption.RETURN_NONE,
+          oneOf: { name: [] },
+        }).toContainExactly([])
+      })
     })
 
     describe("fuzzy", () => {

--- a/packages/server/src/constants/index.ts
+++ b/packages/server/src/constants/index.ts
@@ -24,16 +24,6 @@ export enum FilterTypes {
   ONE_OF = "oneOf",
 }
 
-export const NoEmptyFilterStrings = [
-  FilterTypes.STRING,
-  FilterTypes.FUZZY,
-  FilterTypes.EQUAL,
-  FilterTypes.NOT_EQUAL,
-  FilterTypes.CONTAINS,
-  FilterTypes.NOT_CONTAINS,
-  FilterTypes.CONTAINS_ANY,
-]
-
 export const CanSwitchTypes = [
   [FieldType.JSON, FieldType.ARRAY],
   [

--- a/packages/server/src/sdk/app/rows/search.ts
+++ b/packages/server/src/sdk/app/rows/search.ts
@@ -2,14 +2,12 @@ import {
   EmptyFilterOption,
   Row,
   RowSearchParams,
-  SearchFilters,
   SearchResponse,
   SortOrder,
 } from "@budibase/types"
 import { isExternalTableID } from "../../../integrations/utils"
 import * as internal from "./search/internal"
 import * as external from "./search/external"
-import { NoEmptyFilterStrings } from "../../../constants"
 import * as sqs from "./search/sqs"
 import { ExportRowsParams, ExportRowsResult } from "./search/types"
 import { dataFilters } from "@budibase/shared-core"
@@ -32,44 +30,11 @@ function pickApi(tableId: any) {
   return internal
 }
 
-function isEmptyArray(value: any) {
-  return Array.isArray(value) && value.length === 0
-}
-
-// don't do a pure falsy check, as 0 is included
-// https://github.com/Budibase/budibase/issues/10118
-export function removeEmptyFilters(filters: SearchFilters) {
-  for (let filterField of NoEmptyFilterStrings) {
-    if (!filters[filterField]) {
-      continue
-    }
-
-    for (let filterType of Object.keys(filters)) {
-      if (filterType !== filterField) {
-        continue
-      }
-      // don't know which one we're checking, type could be anything
-      const value = filters[filterType] as unknown
-      if (typeof value === "object") {
-        for (let [key, value] of Object.entries(
-          filters[filterType] as object
-        )) {
-          if (value == null || value === "" || isEmptyArray(value)) {
-            // @ts-ignore
-            delete filters[filterField][key]
-          }
-        }
-      }
-    }
-  }
-  return filters
-}
-
 export async function search(
   options: RowSearchParams
 ): Promise<SearchResponse<Row>> {
   const isExternalTable = isExternalTableID(options.tableId)
-  options.query = removeEmptyFilters(options.query || {})
+  options.query = dataFilters.cleanupQuery(options.query || {})
   options.query = dataFilters.fixupFilterArrays(options.query)
   if (
     !dataFilters.hasFilters(options.query) &&

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -106,7 +106,7 @@ export const NoEmptyFilterStrings = [
   OperatorOptions.NotEquals.value,
   OperatorOptions.Contains.value,
   OperatorOptions.NotContains.value,
-  OperatorOptions.NotContains.value,
+  OperatorOptions.ContainsAny.value,
   OperatorOptions.In.value,
 ] as (keyof SearchQueryFields)[]
 

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -106,29 +106,47 @@ export const NoEmptyFilterStrings = [
   OperatorOptions.NotEquals.value,
   OperatorOptions.Contains.value,
   OperatorOptions.NotContains.value,
+  OperatorOptions.NotContains.value,
+  OperatorOptions.In.value,
 ] as (keyof SearchQueryFields)[]
 
 /**
  * Removes any fields that contain empty strings that would cause inconsistent
  * behaviour with how backend tables are filtered (no value means no filter).
+ *
+ * don't do a pure falsy check, as 0 is included
+ * https://github.com/Budibase/budibase/issues/10118
  */
-const cleanupQuery = (query: SearchFilters) => {
+export const cleanupQuery = (query: SearchFilters) => {
   if (!query) {
     return query
   }
   for (let filterField of NoEmptyFilterStrings) {
-    const operator = filterField as SearchFilterOperator
-    if (!query[operator]) {
+    if (!query[filterField]) {
       continue
     }
 
-    for (let [key, value] of Object.entries(query[operator]!)) {
-      if (value == null || value === "") {
-        delete query[operator]![key]
+    for (let filterType of Object.keys(query)) {
+      if (filterType !== filterField) {
+        continue
+      }
+      // don't know which one we're checking, type could be anything
+      const value = query[filterType] as unknown
+      if (typeof value === "object") {
+        for (let [key, value] of Object.entries(query[filterType] as object)) {
+          if (value == null || value === "" || isEmptyArray(value)) {
+            // @ts-ignore
+            delete query[filterField][key]
+          }
+        }
       }
     }
   }
   return query
+}
+
+function isEmptyArray(value: any) {
+  return Array.isArray(value) && value.length === 0
 }
 
 /**


### PR DESCRIPTION
## Description
Remove `is in` filter when there is no values in the filtered info

## Addresses
- [BUDI-8449 - When return all table rows is selected the Is in filter returns nothing instead of all rows
](https://linear.app/budibase/issue/BUDI-8449/when-return-all-table-rows-is-selected-the-is-in-filter-returns)
- https://github.com/Budibase/budibase/issues/14136

## Screenshots
### Filtering with a valid filter
<img width="907" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/8437d531-1763-48c4-80bd-0064d04b17fd">

### Filtering with an empty value filter (and return all fallback)
<img width="880" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/fae97232-2378-40e6-85c3-c70e2cb6e183">

### Filtering with an empty value filter (and return none fallback)
<img width="919" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/b2aa12e9-1557-4da9-96c1-3e6efeb7c805">

### Filtering with an non-matching value filter
<img width="870" alt="image" src="https://github.com/Budibase/budibase/assets/15987277/de1db1d8-baff-44e6-91b5-dc6923ea90af">



## Launchcontrol
Honour `onEmptyFilter` selection when `is in` filter is set without proper values
