### PR TITLE
Fix fun flake in MySQL / MariaDB.

### DIFF
--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -819,7 +819,10 @@ describe.each([
         const table = await config.api.table.save(tableRequest)
 
         const stringValue = generator.word()
-        const naturalValue = generator.integer({ min: 0, max: 1000 })
+
+        // MySQL and MariaDB auto-increment fields have a minimum value of 1. If
+        // you try to save a row with a value of 0 it will use 1 instead.
+        const naturalValue = generator.integer({ min: 1, max: 1000 })
 
         const existing = await config.api.row.save(table._id!, {
           string: stringValue,


### PR DESCRIPTION
## Description

This was a fun one to track down and debug.

It appears that autoincrement fields in MySQL and MariaDB have a minimum value of 1. If you try to store 0 as the first value, it will store 1 instead. This was causing this test to fail 1 in every 1000 attempts because we generate a random value between 0 and 1000 to store in this column. If it's 0, MySQL stores it as 1 instead and the assertion fails.
