### PR TITLE
Re-sync SQS definitions consistently

### DIFF
--- a/packages/server/src/sdk/app/rows/search/sqs.ts
+++ b/packages/server/src/sdk/app/rows/search/sqs.ts
@@ -249,7 +249,7 @@ function resyncDefinitionsRequired(status: number, message: string) {
 export async function search(
   options: RowSearchParams,
   table: Table,
-  opts?: { retry?: boolean }
+  opts?: { retries?: number }
 ): Promise<SearchResponse<Row>> {
   let { paginate, query, ...params } = options
 
@@ -374,9 +374,10 @@ export async function search(
     return response
   } catch (err: any) {
     const msg = typeof err === "string" ? err : err.message
-    if (!opts?.retry && resyncDefinitionsRequired(err.status, msg)) {
+    const firstTry = !opts?.retries || opts.retries === 0
+    if (firstTry && resyncDefinitionsRequired(err.status, msg)) {
       await sdk.tables.sqs.syncDefinition()
-      return search(options, table, { retry: true })
+      return search(options, table, { retries: 1 })
     }
     // previously the internal table didn't error when a column didn't exist in search
     if (err.status === 400 && msg?.match(MISSING_COLUMN_REGEX)) {

--- a/packages/server/src/sdk/app/rows/search/sqs.ts
+++ b/packages/server/src/sdk/app/rows/search/sqs.ts
@@ -45,13 +45,10 @@ import {
   getTableIDList,
 } from "./filters"
 import { dataFilters } from "@budibase/shared-core"
-import { DEFAULT_TABLE_IDS } from "../../../../constants"
 
 const builder = new sql.Sql(SqlClient.SQL_LITE)
 const MISSING_COLUMN_REGEX = new RegExp(`no such column: .+`)
-const USER_COLUMN_PREFIX_REGEX = new RegExp(
-  `no such column: .+${USER_COLUMN_PREFIX}`
-)
+const MISSING_TABLE_REGX = new RegExp(`no such table: .+`)
 
 function buildInternalFieldList(
   table: Table,
@@ -241,9 +238,9 @@ function resyncDefinitionsRequired(status: number, message: string) {
   // pre data_ prefix on column names, need to resync
   return (
     // there are tables missing - try a resync
-    (status === 400 && message.includes("no such table: ")) ||
+    (status === 400 && message.match(MISSING_TABLE_REGX)) ||
     // there are columns missing - try a resync
-    (status === 400 && message.includes("no such column: ")) ||
+    (status === 400 && message.match(MISSING_COLUMN_REGEX)) ||
     // no design document found, needs a full sync
     (status === 404 && message?.includes(SQLITE_DESIGN_DOC_ID))
   )


### PR DESCRIPTION
## Description
Resync if it is found that a table or column is missing, this was previously done for specific cases but have expanded to cover all, but only retry once (not get into an infinite loop).