### PR TITLE
Fix a very rare flake in row.spec.ts.

### DIFF
--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -1460,17 +1460,12 @@ describe.each([
         delete tableRequest.schema.id
 
         const table = await config.api.table.save(tableRequest)
+        const toCreate = generator
+          .unique(() => generator.integer({ min: 0, max: 10000 }), 10)
+          .map(number => ({ number, string: generator.word({ length: 30 }) }))
 
         const rows = await Promise.all(
-          generator
-            .unique(
-              () => ({
-                string: generator.word({ length: 30 }),
-                number: generator.integer({ min: 0, max: 10000 }),
-              }),
-              10
-            )
-            .map(d => config.api.row.save(table._id!, d))
+          toCreate.map(d => config.api.row.save(table._id!, d))
         )
 
         const res = await config.api.row.exportRows(table._id!, {


### PR DESCRIPTION
## Description

This one is fun because some attempt was obviously made to make these objects unique but the problem is, with external data sources, we only take the first column in a primary key so it was possible to create an object that had the same number column but different string columns making this an exceptionally rare flake.