### PR TITLE
Default table - in-memory/on-disk representation duplicates

### DIFF
--- a/packages/server/src/sdk/app/tables/internal/sqs.ts
+++ b/packages/server/src/sdk/app/tables/internal/sqs.ts
@@ -14,7 +14,7 @@ import {
   CONSTANT_INTERNAL_ROW_COLS,
   generateJunctionTableID,
 } from "../../../../db/utils"
-import { isEqual } from "lodash"
+import { isEqual, merge } from "lodash"
 import { DEFAULT_TABLES } from "../../../../db/defaultData/datasource_bb_default"
 
 const FieldTypeMap: Record<FieldType, SQLiteType> = {
@@ -130,9 +130,18 @@ async function buildBaseDefinition(): Promise<PreSaveSQLiteDefinition> {
   const defaultTables = DEFAULT_TABLES
   const definition = sql.designDoc.base("tableId")
   for (let table of tables.concat(defaultTables)) {
+    const tableId = table._id!
+    let existing = definition.sql.tables[tableId]
+    let mapped = mapTable(table)
+    // there are multiple definitions for this table (default table overlap)
+    // when there is overlap - we have to make sure we have columns from all definitions
+    // this problem really only applies to sample data tables where they've been expanded
+    if (existing) {
+      mapped[tableId] = merge(mapped[tableId], existing)
+    }
     definition.sql.tables = {
       ...definition.sql.tables,
-      ...mapTable(table),
+      ...mapped,
     }
   }
   return definition


### PR DESCRIPTION
## Description
There is a risk with default tables that the schema may exist in the DB as well as existing in memory - we should prefer the CouchDB representation as this may have been adjusted by the user.

This problem is specific to sample data tables - it doesn't exist outside of this as all tables should only have a single table document/representation of them.