### PR TITLE
Add logic to prevent panel and modals from closing when screen load actions are available

### DIFF
--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -51,6 +51,7 @@
   let dataLoaded = false
   let permissionError = false
   let embedNoScreens = false
+  let onLoadCheck = false
 
   // Determine if we should show devtools or not
   $: showDevTools = $devToolsEnabled && !$routeStore.queryParams?.peek
@@ -106,12 +107,24 @@
     }
     const handleHashChange = () => {
       const { open: sidePanelOpen } = $sidePanelStore
-      if (sidePanelOpen) {
+      // only close if the sidepanel is open and theres no onload side panel actions on the screen.
+      if (
+        sidePanelOpen &&
+        !$screenStore.activeScreen.onLoad?.some(
+          item => item["##eventHandlerType"] === "Open Side Panel"
+        )
+      ) {
         sidePanelStore.actions.close()
       }
 
       const { open: modalOpen } = $modalStore
-      if (modalOpen) {
+      // only close if the modal is open and theres onload modals actions on the screen.
+      if (
+        modalOpen &&
+        !$screenStore.activeScreen.onLoad?.some(
+          item => item["##eventHandlerType"] === "Open Modal"
+        )
+      ) {
         modalStore.actions.close()
       }
     }

--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -51,7 +51,6 @@
   let dataLoaded = false
   let permissionError = false
   let embedNoScreens = false
-  let onLoadCheck = false
 
   // Determine if we should show devtools or not
   $: showDevTools = $devToolsEnabled && !$routeStore.queryParams?.peek


### PR DESCRIPTION
## Description
Prevent modal /sidepanel from closing when on-screen load actions are setup to open them

## Addresses
- https://github.com/Budibase/budibase/issues/14159 

## Screenshots
![20240716_130343](https://github.com/user-attachments/assets/a6d0d1a9-af81-4c1d-b4c4-ec6eb6c3a3d6)

## Launchcontrol
Prevents modals/side-panels from immediately closing whenever on screen load actions are opening them.