### PR TITLE
Prevent duplicated names on row actions

### DIFF
--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -203,6 +203,16 @@ describe("/rowsActions", () => {
         }
       )
     })
+
+    it("can reuse row action names between different tables", async () => {
+      const otherTable = await config.api.table.save(
+        setup.structures.basicTable()
+      )
+
+      const action = await createRowAction(tableId, createRowActionRequest())
+
+      await createRowAction(otherTable._id!, { name: action.name })
+    })
   })
 
   describe("find", () => {
@@ -326,6 +336,23 @@ describe("/rowsActions", () => {
         action.id,
         createRowActionRequest(),
         { status: 400 }
+      )
+    })
+
+    it("can not use existing row action names (for the same table)", async () => {
+      const action1 = await createRowAction(tableId, createRowActionRequest())
+      const action2 = await createRowAction(tableId, createRowActionRequest())
+
+      await config.api.rowAction.update(
+        tableId,
+        action1.id,
+        { name: action2.name },
+        {
+          status: 409,
+          body: {
+            message: "A row action with the same name already exists.",
+          },
+        }
       )
     })
   })

--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -355,6 +355,14 @@ describe("/rowsActions", () => {
         }
       )
     })
+
+    it("does not throw with name conflicts for the same row action", async () => {
+      const action1 = await createRowAction(tableId, createRowActionRequest())
+
+      await config.api.rowAction.update(tableId, action1.id, {
+        name: action1.name,
+      })
+    })
   })
 
   describe("delete", () => {

--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -95,6 +95,31 @@ describe("/rowsActions", () => {
       })
     })
 
+    it("trims row action names", async () => {
+      const name = "   action  name  "
+      const res = await createRowAction(
+        tableId,
+        { name },
+        {
+          status: 201,
+        }
+      )
+
+      expect(res).toEqual({
+        id: expect.stringMatching(/^row_action_\w+/),
+        tableId: tableId,
+        name: "action  name",
+      })
+
+      expect(await config.api.rowAction.find(tableId)).toEqual({
+        actions: {
+          [res.id]: expect.objectContaining({
+            name: "action  name",
+          }),
+        },
+      })
+    })
+
     it("can create multiple row actions for the same table", async () => {
       const rowActions = createRowActionRequests(3)
       const responses: RowActionResponse[] = []
@@ -219,6 +244,33 @@ describe("/rowsActions", () => {
               ...actionData,
               name: updatedName,
             },
+          }),
+        })
+      )
+    })
+
+    it("trims row action names", async () => {
+      const rowAction = await createRowAction(
+        tableId,
+        createRowActionRequest(),
+        {
+          status: 201,
+        }
+      )
+
+      const res = await config.api.rowAction.update(tableId, rowAction.id, {
+        ...rowAction,
+        name: "   action  name  ",
+      })
+
+      expect(res).toEqual(expect.objectContaining({ name: "action  name" }))
+
+      expect(await config.api.rowAction.find(tableId)).toEqual(
+        expect.objectContaining({
+          actions: expect.objectContaining({
+            [rowAction.id]: expect.objectContaining({
+              name: "action  name",
+            }),
           }),
         })
       )

--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -176,6 +176,33 @@ describe("/rowsActions", () => {
         },
       })
     })
+
+    it("can not create multiple row actions with the same name (for the same table)", async () => {
+      const action = await createRowAction(tableId, {
+        name: "Row action name  ",
+      })
+
+      await createRowAction(
+        tableId,
+        { name: action.name },
+        {
+          status: 409,
+          body: {
+            message: "A row action with the same name already exists.",
+          },
+        }
+      )
+      await createRowAction(
+        tableId,
+        { name: "row action name" },
+        {
+          status: 409,
+          body: {
+            message: "A row action with the same name already exists.",
+          },
+        }
+      )
+    })
   })
 
   describe("find", () => {

--- a/packages/server/src/sdk/app/rowActions.ts
+++ b/packages/server/src/sdk/app/rowActions.ts
@@ -8,6 +8,8 @@ import {
 } from "@budibase/types"
 
 export async function create(tableId: string, rowAction: { name: string }) {
+  const action = { name: rowAction.name.trim() }
+
   const db = context.getAppDB()
   const rowActionsId = generateRowActionsID(tableId)
   let doc: TableRowActions
@@ -22,12 +24,12 @@ export async function create(tableId: string, rowAction: { name: string }) {
   }
 
   const newId = `${VirtualDocumentType.ROW_ACTION}${SEPARATOR}${utils.newid()}`
-  doc.actions[newId] = rowAction
+  doc.actions[newId] = action
   await db.put(doc)
 
   return {
     id: newId,
-    ...rowAction,
+    ...action,
   }
 }
 
@@ -49,6 +51,7 @@ export async function update(
   rowActionId: string,
   rowAction: { name: string }
 ) {
+  const action = { name: rowAction.name.trim() }
   const actionsDoc = await get(tableId)
 
   if (!actionsDoc.actions[rowActionId]) {
@@ -57,14 +60,14 @@ export async function update(
       400
     )
   }
-  actionsDoc.actions[rowActionId] = rowAction
+  actionsDoc.actions[rowActionId] = action
 
   const db = context.getAppDB()
   await db.put(actionsDoc)
 
   return {
     id: rowActionId,
-    ...rowAction,
+    ...action,
   }
 }
 

--- a/packages/server/src/sdk/app/rowActions.ts
+++ b/packages/server/src/sdk/app/rowActions.ts
@@ -7,6 +7,16 @@ import {
   VirtualDocumentType,
 } from "@budibase/types"
 
+function ensureUnique(doc: TableRowActions, newName: string) {
+  if (
+    Object.values(doc.actions).find(
+      a => a.name.toLowerCase() === newName.toLowerCase()
+    )
+  ) {
+    throw new HTTPError("A row action with the same name already exists.", 409)
+  }
+}
+
 export async function create(tableId: string, rowAction: { name: string }) {
   const action = { name: rowAction.name.trim() }
 
@@ -22,6 +32,8 @@ export async function create(tableId: string, rowAction: { name: string }) {
 
     doc = { _id: rowActionsId, actions: {} }
   }
+
+  ensureUnique(doc, action.name)
 
   const newId = `${VirtualDocumentType.ROW_ACTION}${SEPARATOR}${utils.newid()}`
   doc.actions[newId] = action


### PR DESCRIPTION
## Description
Prevent duplicated names for row actions for the same table

## Addresses
- [BUDI-8428 - Row action API (storage and retrieval)
](https://linear.app/budibase/issue/BUDI-8428/row-action-api-storage-and-retrieval)