### PR TITLE
Move automation code away from controller

### DIFF
--- a/packages/server/src/api/controllers/automation.ts
+++ b/packages/server/src/api/controllers/automation.ts
@@ -1,5 +1,5 @@
 import * as triggers from "../../automations/triggers"
-import { getAutomationParams, DocumentType } from "../../db/utils"
+import { DocumentType } from "../../db/utils"
 import { updateTestHistory, removeDeprecated } from "../../automations/utils"
 import { setTestFlag, clearTestFlag } from "../../utilities/redis"
 import { context, cache, events, db as dbCore } from "@budibase/backend-core"
@@ -74,18 +74,11 @@ export async function update(ctx: UserCtx) {
 }
 
 export async function fetch(ctx: UserCtx) {
-  const db = context.getAppDB()
-  const response = await db.allDocs(
-    getAutomationParams(null, {
-      include_docs: true,
-    })
-  )
-  ctx.body = response.rows.map(row => row.doc)
+  ctx.body = await sdk.automations.fetch()
 }
 
 export async function find(ctx: UserCtx) {
-  const db = context.getAppDB()
-  ctx.body = await db.get(ctx.params.id)
+  ctx.body = await sdk.automations.get(ctx.params.id)
 }
 
 export async function destroy(ctx: UserCtx<void, DeleteAutomationResponse>) {

--- a/packages/server/src/api/controllers/automation.ts
+++ b/packages/server/src/api/controllers/automation.ts
@@ -1,12 +1,6 @@
 import * as triggers from "../../automations/triggers"
 import { getAutomationParams, DocumentType } from "../../db/utils"
-import {
-  checkForWebhooks,
-  updateTestHistory,
-  removeDeprecated,
-} from "../../automations/utils"
-import { deleteEntityMetadata } from "../../utilities"
-import { MetadataTypes } from "../../constants"
+import { updateTestHistory, removeDeprecated } from "../../automations/utils"
 import { setTestFlag, clearTestFlag } from "../../utilities/redis"
 import { context, cache, events, db as dbCore } from "@budibase/backend-core"
 import { automations, features } from "@budibase/pro"
@@ -37,38 +31,6 @@ function getTriggerDefinitions() {
  *                       *
  *************************/
 
-async function cleanupAutomationMetadata(automationId: string) {
-  await deleteEntityMetadata(MetadataTypes.AUTOMATION_TEST_INPUT, automationId)
-  await deleteEntityMetadata(
-    MetadataTypes.AUTOMATION_TEST_HISTORY,
-    automationId
-  )
-}
-
-function cleanAutomationInputs(automation: Automation) {
-  if (automation == null) {
-    return automation
-  }
-  let steps = automation.definition.steps
-  let trigger = automation.definition.trigger
-  let allSteps = [...steps, trigger]
-  // live is not a property used anymore
-  if (automation.live != null) {
-    delete automation.live
-  }
-  for (let step of allSteps) {
-    if (step == null) {
-      continue
-    }
-    for (let inputName of Object.keys(step.inputs)) {
-      if (!step.inputs[inputName] || step.inputs[inputName] === "") {
-        delete step.inputs[inputName]
-      }
-    }
-  }
-  return automation
-}
-
 export async function create(
   ctx: UserCtx<Automation, { message: string; automation: Automation }>
 ) {
@@ -81,48 +43,17 @@ export async function create(
     return
   }
 
-  const response = await sdk.automations.create(automation)
+  const createdAutomation = await sdk.automations.create(automation)
 
   ctx.status = 200
   ctx.body = {
     message: "Automation created successfully",
-    automation: response,
+    automation: createdAutomation,
   }
   builderSocket?.emitAutomationUpdate(ctx, automation)
 }
 
-export function getNewSteps(oldAutomation: Automation, automation: Automation) {
-  const oldStepIds = oldAutomation.definition.steps.map(s => s.id)
-  return automation.definition.steps.filter(s => !oldStepIds.includes(s.id))
-}
-
-export function getDeletedSteps(
-  oldAutomation: Automation,
-  automation: Automation
-) {
-  const stepIds = automation.definition.steps.map(s => s.id)
-  return oldAutomation.definition.steps.filter(s => !stepIds.includes(s.id))
-}
-
-export async function handleStepEvents(
-  oldAutomation: Automation,
-  automation: Automation
-) {
-  // new steps
-  const newSteps = getNewSteps(oldAutomation, automation)
-  for (let step of newSteps) {
-    await events.automation.stepCreated(automation, step)
-  }
-
-  // old steps
-  const deletedSteps = getDeletedSteps(oldAutomation, automation)
-  for (let step of deletedSteps) {
-    await events.automation.stepDeleted(automation, step)
-  }
-}
-
 export async function update(ctx: UserCtx) {
-  const db = context.getAppDB()
   let automation = ctx.request.body
   automation.appId = ctx.appId
 
@@ -132,42 +63,12 @@ export async function update(ctx: UserCtx) {
     return
   }
 
-  const oldAutomation = await db.get<Automation>(automation._id)
-  automation = cleanAutomationInputs(automation)
-  automation = await checkForWebhooks({
-    oldAuto: oldAutomation,
-    newAuto: automation,
-  })
-  const response = await db.put(automation)
-  automation._rev = response.rev
-
-  const oldAutoTrigger =
-    oldAutomation && oldAutomation.definition.trigger
-      ? oldAutomation.definition.trigger
-      : undefined
-  const newAutoTrigger =
-    automation && automation.definition.trigger
-      ? automation.definition.trigger
-      : {}
-  // trigger has been updated, remove the test inputs
-  if (oldAutoTrigger && oldAutoTrigger.id !== newAutoTrigger.id) {
-    await events.automation.triggerUpdated(automation)
-    await deleteEntityMetadata(
-      MetadataTypes.AUTOMATION_TEST_INPUT,
-      automation._id!
-    )
-  }
-
-  await handleStepEvents(oldAutomation, automation)
+  const updatedAutomation = await sdk.automations.update(automation)
 
   ctx.status = 200
   ctx.body = {
     message: `Automation ${automation._id} updated successfully.`,
-    automation: {
-      ...automation,
-      _rev: response.rev,
-      _id: response.id,
-    },
+    automation: updatedAutomation,
   }
   builderSocket?.emitAutomationUpdate(ctx, automation)
 }
@@ -188,16 +89,9 @@ export async function find(ctx: UserCtx) {
 }
 
 export async function destroy(ctx: UserCtx<void, DeleteAutomationResponse>) {
-  const db = context.getAppDB()
   const automationId = ctx.params.id
-  const oldAutomation = await db.get<Automation>(automationId)
-  await checkForWebhooks({
-    oldAuto: oldAutomation,
-  })
-  // delete metadata first
-  await cleanupAutomationMetadata(automationId)
-  ctx.body = await db.remove(automationId, ctx.params.rev)
-  await events.automation.deleted(oldAutomation)
+
+  ctx.body = await sdk.automations.remove(automationId, ctx.params.rev)
   builderSocket?.emitAutomationDeletion(ctx, automationId)
 }
 

--- a/packages/server/src/api/routes/tests/automation.spec.ts
+++ b/packages/server/src/api/routes/tests/automation.spec.ts
@@ -267,8 +267,7 @@ describe("/automations", () => {
     }
 
     it("updates a automations name", async () => {
-      let automation = newAutomation()
-      await config.createAutomation(automation)
+      const automation = await config.createAutomation(newAutomation())
       automation.name = "Updated Name"
       jest.clearAllMocks()
 
@@ -294,8 +293,7 @@ describe("/automations", () => {
     })
 
     it("updates a automations name using POST request", async () => {
-      let automation = newAutomation()
-      await config.createAutomation(automation)
+      const automation = await config.createAutomation(newAutomation())
       automation.name = "Updated Name"
       jest.clearAllMocks()
 
@@ -392,8 +390,7 @@ describe("/automations", () => {
   describe("fetch", () => {
     it("return all the automations for an instance", async () => {
       await clearAllAutomations(config)
-      const autoConfig = basicAutomation()
-      await config.createAutomation(autoConfig)
+      const autoConfig = await config.createAutomation(basicAutomation())
       const res = await request
         .get(`/api/automations`)
         .set(config.defaultHeaders())

--- a/packages/server/src/api/routes/tests/automation.spec.ts
+++ b/packages/server/src/api/routes/tests/automation.spec.ts
@@ -154,7 +154,7 @@ describe("/automations", () => {
           tableId: table._id,
         },
       }
-      automation.appId = config.appId
+      automation.appId = config.getAppId()
       automation = await config.createAutomation(automation)
       await setup.delay(500)
       const res = await testAutomation(config, automation, {

--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -1,0 +1,57 @@
+import { context, events } from "@budibase/backend-core"
+import { Automation } from "@budibase/types"
+import { checkForWebhooks } from "src/automations/utils"
+import { generateAutomationID } from "src/db/utils"
+
+function getDb() {
+  return context.getAppDB()
+}
+
+function cleanAutomationInputs(automation: Automation) {
+  if (automation == null) {
+    return automation
+  }
+  let steps = automation.definition.steps
+  let trigger = automation.definition.trigger
+  let allSteps = [...steps, trigger]
+  // live is not a property used anymore
+  if (automation.live != null) {
+    delete automation.live
+  }
+  for (let step of allSteps) {
+    if (step == null) {
+      continue
+    }
+    for (let inputName of Object.keys(step.inputs)) {
+      if (!step.inputs[inputName] || step.inputs[inputName] === "") {
+        delete step.inputs[inputName]
+      }
+    }
+  }
+  return automation
+}
+
+export async function create(automation: Automation) {
+  automation = { ...automation }
+  const db = getDb()
+
+  // Respect existing IDs if recreating a deleted automation
+  if (!automation._id) {
+    automation._id = generateAutomationID()
+  }
+
+  automation.type = "automation"
+  automation = cleanAutomationInputs(automation)
+  automation = await checkForWebhooks({
+    newAuto: automation,
+  })
+  const response = await db.put(automation)
+  await events.automation.created(automation)
+  for (let step of automation.definition.steps) {
+    await events.automation.stepCreated(automation, step)
+  }
+  automation._rev = response.rev
+  automation._id = response.id
+
+  return automation
+}

--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -1,9 +1,9 @@
 import { context, events, HTTPError } from "@budibase/backend-core"
 import { Automation } from "@budibase/types"
-import { checkForWebhooks } from "src/automations/utils"
-import { MetadataTypes } from "src/constants"
-import { generateAutomationID, getAutomationParams } from "src/db/utils"
-import { deleteEntityMetadata } from "src/utilities"
+import { checkForWebhooks } from "../../../automations/utils"
+import { MetadataTypes } from "../../../constants"
+import { generateAutomationID, getAutomationParams } from "../../../db/utils"
+import { deleteEntityMetadata } from "../../../utilities"
 
 function getDb() {
   return context.getAppDB()

--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -1,7 +1,9 @@
-import { context, events } from "@budibase/backend-core"
+import { context, events, HTTPError } from "@budibase/backend-core"
 import { Automation } from "@budibase/types"
 import { checkForWebhooks } from "src/automations/utils"
+import { MetadataTypes } from "src/constants"
 import { generateAutomationID } from "src/db/utils"
+import { deleteEntityMetadata } from "src/utilities"
 
 function getDb() {
   return context.getAppDB()
@@ -31,6 +33,36 @@ function cleanAutomationInputs(automation: Automation) {
   return automation
 }
 
+async function handleStepEvents(
+  oldAutomation: Automation,
+  automation: Automation
+) {
+  const getNewSteps = (oldAutomation: Automation, automation: Automation) => {
+    const oldStepIds = oldAutomation.definition.steps.map(s => s.id)
+    return automation.definition.steps.filter(s => !oldStepIds.includes(s.id))
+  }
+
+  const getDeletedSteps = (
+    oldAutomation: Automation,
+    automation: Automation
+  ) => {
+    const stepIds = automation.definition.steps.map(s => s.id)
+    return oldAutomation.definition.steps.filter(s => !stepIds.includes(s.id))
+  }
+
+  // new steps
+  const newSteps = getNewSteps(oldAutomation, automation)
+  for (let step of newSteps) {
+    await events.automation.stepCreated(automation, step)
+  }
+
+  // old steps
+  const deletedSteps = getDeletedSteps(oldAutomation, automation)
+  for (let step of deletedSteps) {
+    await events.automation.stepDeleted(automation, step)
+  }
+}
+
 export async function create(automation: Automation) {
   automation = { ...automation }
   const db = getDb()
@@ -54,4 +86,69 @@ export async function create(automation: Automation) {
   automation._id = response.id
 
   return automation
+}
+
+export async function update(automation: Automation) {
+  automation = { ...automation }
+
+  if (!automation._id || !automation._rev) {
+    throw new HTTPError("_id or _rev fields missing", 400)
+  }
+
+  const db = getDb()
+
+  const oldAutomation = await db.get<Automation>(automation._id)
+  automation = cleanAutomationInputs(automation)
+  automation = await checkForWebhooks({
+    oldAuto: oldAutomation,
+    newAuto: automation,
+  })
+  const response = await db.put(automation)
+  automation._rev = response.rev
+
+  const oldAutoTrigger =
+    oldAutomation && oldAutomation.definition.trigger
+      ? oldAutomation.definition.trigger
+      : undefined
+  const newAutoTrigger =
+    automation && automation.definition.trigger
+      ? automation.definition.trigger
+      : undefined
+  // trigger has been updated, remove the test inputs
+  if (oldAutoTrigger && oldAutoTrigger.id !== newAutoTrigger?.id) {
+    await events.automation.triggerUpdated(automation)
+    await deleteEntityMetadata(
+      MetadataTypes.AUTOMATION_TEST_INPUT,
+      automation._id!
+    )
+  }
+
+  await handleStepEvents(oldAutomation, automation)
+
+  return {
+    ...automation,
+    _rev: response.rev,
+    _id: response.id,
+  }
+}
+
+export async function remove(automationId: string, rev: string) {
+  const db = context.getAppDB()
+  const existing = await db.get<Automation>(automationId)
+  await checkForWebhooks({
+    oldAuto: existing,
+  })
+
+  // delete metadata first
+  await deleteEntityMetadata(MetadataTypes.AUTOMATION_TEST_INPUT, automationId)
+  await deleteEntityMetadata(
+    MetadataTypes.AUTOMATION_TEST_HISTORY,
+    automationId
+  )
+
+  const result = await db.remove(automationId, rev)
+
+  await events.automation.deleted(existing)
+
+  return result
 }

--- a/packages/server/src/sdk/app/automations/index.ts
+++ b/packages/server/src/sdk/app/automations/index.ts
@@ -1,7 +1,9 @@
+import * as crud from "./crud"
 import * as webhook from "./webhook"
 import * as utils from "./utils"
 
 export default {
+  ...crud,
   webhook,
   utils,
 }

--- a/packages/server/src/tests/utilities/structures.ts
+++ b/packages/server/src/tests/utilities/structures.ts
@@ -159,7 +159,7 @@ export function automationTrigger(
 }
 
 export function newAutomation({ steps, trigger }: any = {}) {
-  const automation: any = basicAutomation()
+  const automation = basicAutomation()
 
   if (trigger) {
     automation.definition.trigger = trigger


### PR DESCRIPTION
## Description
Move automation crud logic from the controller into the SDK. This will be used for the row actions, and it will be easier to reuse avoiding duplicates.
No logic should be changed in here, just moving code around.

## Addresses
- [BUDI-8430 - Row action API - auto-create automation](https://linear.app/budibase/issue/BUDI-8430/row-action-api-auto-create-automation)