### PR TITLE
Fix Bug Preventing Deleting Multiple Apps in a Row

### DIFF
--- a/packages/builder/src/components/deploy/DeleteModal.svelte
+++ b/packages/builder/src/components/deploy/DeleteModal.svelte
@@ -38,6 +38,7 @@
       await API.deleteApp(appId)
       appsStore.load()
       notifications.success("App deleted successfully")
+      deleting = false
       onDeleteSuccess()
     } catch (err) {
       notifications.error("Error deleting app")


### PR DESCRIPTION
## Bug
Sometimes users are unable to delete multiple apps in a row, even once the app name is entered into the confirmation field, the button to delete the app remains disabled.

## Repro
- Create an app called `App`.
- Duplicate `App`, call it `App Copy 1`.
- Duplicate `App`, call it `App Copy 2`.

Your apps lists should look like so:
![Screenshot 2024-07-18 at 13 34 52](https://github.com/user-attachments/assets/05966668-9a63-45f8-bdc3-1d0df1967c21)

- Delete `App Copy 1`. This should work. 
- Notice `App Copy 2` is now in the position `App Copy 1` occupied before it was deleted.
- Attempt to delete `App Copy 2`. The button to confirm deletion should remain disabled even after filling in the app name.

## Fix
This happens because the state of the delete modal is being maintained between app deletions, and on a successful delete the `deleting` flag was never reset. Meaning any app that ends up in the same position as a previously deleted app in the apps list can't be deleted until the page is reset.

Setting the `deleting` flag back to false on a successful delete fixes this issue.
