### PR TITLE
Remove unnecessary save button for automation steps

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/ActionModal.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/ActionModal.svelte
@@ -17,12 +17,12 @@
 
   export let blockIdx
   export let lastStep
+  export let modal
 
   let syncAutomationsEnabled = $licensing.syncAutomationsEnabled
   let triggerAutomationRunEnabled = $licensing.triggerAutomationRunEnabled
   let collectBlockAllowedSteps = [TriggerStepID.APP, TriggerStepID.WEBHOOK]
   let selectedAction
-  let actionVal
   let actions = Object.entries($automationStore.blockDefinitions.ACTION)
   let lockedFeatures = [
     ActionStepID.COLLECT,
@@ -91,19 +91,17 @@
     return acc
   }, {})
 
-  const selectAction = action => {
-    actionVal = action
+  const selectAction = async action => {
     selectedAction = action.name
-  }
 
-  async function addBlockToAutomation() {
     try {
       const newBlock = automationStore.actions.constructBlock(
         "ACTION",
-        actionVal.stepId,
-        actionVal
+        action.stepId,
+        action
       )
       await automationStore.actions.addBlockToAutomation(newBlock, blockIdx + 1)
+      modal.hide()
     } catch (error) {
       notifications.error("Error saving automation")
     }
@@ -114,10 +112,10 @@
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <ModalContent
   title="Add automation step"
-  confirmText="Save"
   size="L"
+  showConfirmButton={false}
+  showCancelButton={false}
   disabled={!selectedAction}
-  onConfirm={addBlockToAutomation}
 >
   <Layout noPadding gap="XS">
     <Detail size="S">Apps</Detail>

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
@@ -206,7 +206,7 @@
 {/if}
 
 <Modal bind:this={actionModal} width="30%">
-  <ActionModal {lastStep} {blockIdx} />
+  <ActionModal modal={actionModal} {lastStep} {blockIdx} />
 </Modal>
 
 <Modal bind:this={webhookModal} width="30%">

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/TestDataModal.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/TestDataModal.svelte
@@ -81,7 +81,7 @@
   // Check the schema to see if required fields have been entered
   $: isError =
     !isTriggerValid(trigger) ||
-    !trigger.schema.outputs.required.every(
+    !trigger.schema.outputs.required?.every(
       required => $memoTestData?.[required] || required !== "row"
     )
 


### PR DESCRIPTION
## Description
Remove the unnecessary save button while adding a new step into an automation. The current modal has no other input than selecting the step type, and if added by mistake it can be easily removed. Because of this, removing this extra click gives a much better UX

## Addresses
- [BUDI-8452 - Row action frontend (data UI)](https://linear.app/budibase/issue/BUDI-8452/row-action-frontend-data-ui)




## Screenshots
### Before

https://github.com/user-attachments/assets/148fa7df-4eb2-4b58-9dd2-d922fcbcd782



### After

https://github.com/user-attachments/assets/b8e3cd88-81f5-4618-8d94-f6d83ea9596d




## Launchcontrol
Remove the save button while saving new automation steps.