### PR TITLE
Create automation on adding new row action

### DIFF
--- a/packages/server/src/api/controllers/rowAction/crud.ts
+++ b/packages/server/src/api/controllers/rowAction/crud.ts
@@ -31,7 +31,12 @@ export async function find(ctx: Ctx<void, RowActionsResponse>) {
     actions: Object.entries(actions).reduce<Record<string, RowActionResponse>>(
       (acc, [key, action]) => ({
         ...acc,
-        [key]: { id: key, tableId: table._id!, ...action },
+        [key]: {
+          id: key,
+          tableId: table._id!,
+          name: action.name,
+          automationId: action.automationId,
+        },
       }),
       {}
     ),
@@ -50,7 +55,9 @@ export async function create(
 
   ctx.body = {
     tableId: table._id!,
-    ...createdAction,
+    id: createdAction.id,
+    name: createdAction.name,
+    automationId: createdAction.automationId,
   }
   ctx.status = 201
 }
@@ -61,13 +68,15 @@ export async function update(
   const table = await getTable(ctx)
   const { actionId } = ctx.params
 
-  const actions = await sdk.rowActions.update(table._id!, actionId, {
+  const action = await sdk.rowActions.update(table._id!, actionId, {
     name: ctx.request.body.name,
   })
 
   ctx.body = {
     tableId: table._id!,
-    ...actions,
+    id: action.id,
+    name: action.name,
+    automationId: action.automationId,
   }
 }
 

--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -136,19 +136,19 @@ describe("/rowsActions", () => {
             name: rowActions[0].name,
             id: responses[0].id,
             tableId,
-            automationId: expect.any(String),
+            automationId: expectAutomationId(),
           },
           [responses[1].id]: {
             name: rowActions[1].name,
             id: responses[1].id,
             tableId,
-            automationId: expect.any(String),
+            automationId: expectAutomationId(),
           },
           [responses[2].id]: {
             name: rowActions[2].name,
             id: responses[2].id,
             tableId,
-            automationId: expect.any(String),
+            automationId: expectAutomationId(),
           },
         },
       })
@@ -191,7 +191,7 @@ describe("/rowsActions", () => {
             name: rowAction.name,
             id: res.id,
             tableId: tableId,
-            automationId: expect.any(String),
+            automationId: expectAutomationId(),
           },
         },
       })

--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -1,7 +1,11 @@
 import _ from "lodash"
 import tk from "timekeeper"
 
-import { CreateRowActionRequest, RowActionResponse } from "@budibase/types"
+import {
+  CreateRowActionRequest,
+  DocumentType,
+  RowActionResponse,
+} from "@budibase/types"
 import * as setup from "./utilities"
 import { generator } from "@budibase/backend-core/tests"
 
@@ -90,6 +94,9 @@ describe("/rowsActions", () => {
             ...rowAction,
             id: res.id,
             tableId: tableId,
+            automationId: expect.stringMatching(
+              `^${DocumentType.AUTOMATION}_.+`
+            ),
           },
         },
       })
@@ -129,9 +136,24 @@ describe("/rowsActions", () => {
 
       expect(await config.api.rowAction.find(tableId)).toEqual({
         actions: {
-          [responses[0].id]: { ...rowActions[0], id: responses[0].id, tableId },
-          [responses[1].id]: { ...rowActions[1], id: responses[1].id, tableId },
-          [responses[2].id]: { ...rowActions[2], id: responses[2].id, tableId },
+          [responses[0].id]: {
+            ...rowActions[0],
+            id: responses[0].id,
+            tableId,
+            automationId: expect.any(String),
+          },
+          [responses[1].id]: {
+            ...rowActions[1],
+            id: responses[1].id,
+            tableId,
+            automationId: expect.any(String),
+          },
+          [responses[2].id]: {
+            ...rowActions[2],
+            id: responses[2].id,
+            tableId,
+            automationId: expect.any(String),
+          },
         },
       })
     })
@@ -172,6 +194,7 @@ describe("/rowsActions", () => {
             id: res.id,
             tableId: tableId,
             ...rowAction,
+            automationId: expect.any(String),
           },
         },
       })

--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -110,8 +110,8 @@ describe("/rowsActions", () => {
 
       expect(res).toEqual(
         expect.objectContaining({
-        name: "action  name",
-      })
+          name: "action  name",
+        })
       )
 
       expect(await config.api.rowAction.find(tableId)).toEqual({
@@ -232,6 +232,17 @@ describe("/rowsActions", () => {
       const action = await createRowAction(tableId, createRowActionRequest())
 
       await createRowAction(otherTable._id!, { name: action.name })
+    })
+
+    it("an automation is created when creating a new row action", async () => {
+      const action1 = await createRowAction(tableId, createRowActionRequest())
+      const action2 = await createRowAction(tableId, createRowActionRequest())
+
+      for (const automationId of [action1.automationId, action2.automationId]) {
+        expect(
+          await config.api.automation.get(automationId, { status: 200 })
+        ).toEqual(expect.objectContaining({ _id: automationId }))
+      }
     })
   })
 

--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -440,5 +440,26 @@ describe("/rowsActions", () => {
         status: 400,
       })
     })
+
+    it("deletes the linked automation", async () => {
+      const actions: RowActionResponse[] = []
+      for (const rowAction of createRowActionRequests(3)) {
+        actions.push(await createRowAction(tableId, rowAction))
+      }
+
+      const actionToDelete = _.sample(actions)!
+      await config.api.rowAction.delete(tableId, actionToDelete.id, {
+        status: 204,
+      })
+
+      await config.api.automation.get(actionToDelete.automationId, {
+        status: 404,
+      })
+      for (const action of actions.filter(a => a.id !== actionToDelete.id)) {
+        await config.api.automation.get(action.automationId, {
+          status: 200,
+        })
+      }
+    })
   })
 })

--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -11,6 +11,11 @@ import {
 import { definitions } from "../../../automations/triggerInfo"
 import automations from "."
 
+interface PersistedAutomation extends Automation {
+  _id: string
+  _rev: string
+}
+
 function getDb() {
   return context.getAppDB()
 }
@@ -71,7 +76,7 @@ async function handleStepEvents(
 
 export async function fetch() {
   const db = getDb()
-  const response = await db.allDocs<Automation>(
+  const response = await db.allDocs<PersistedAutomation>(
     getAutomationParams(null, {
       include_docs: true,
     })
@@ -81,7 +86,7 @@ export async function fetch() {
 
 export async function get(automationId: string) {
   const db = getDb()
-  const result = await db.get<Automation>(automationId)
+  const result = await db.get<PersistedAutomation>(automationId)
   return result
 }
 

--- a/packages/server/src/sdk/app/rowActions.ts
+++ b/packages/server/src/sdk/app/rowActions.ts
@@ -91,7 +91,7 @@ export async function create(tableId: string, rowAction: { name: string }) {
 
   return {
     id: newId,
-    ...action,
+    ...doc.actions[newId],
   }
 }
 
@@ -135,20 +135,24 @@ export async function update(
 
   return {
     id: rowActionId,
-    ...action,
+    ...actionsDoc.actions[rowActionId],
   }
 }
 
 export async function remove(tableId: string, rowActionId: string) {
   const actionsDoc = await get(tableId)
 
-  if (!actionsDoc.actions[rowActionId]) {
+  const rowAction = actionsDoc.actions[rowActionId]
+  if (!rowAction) {
     throw new HTTPError(
       `Row action '${rowActionId}' not found in '${tableId}'`,
       400
     )
   }
 
+  const { automationId } = rowAction
+  const automation = await automations.get(automationId)
+  await automations.remove(automation._id, automation._rev)
   delete actionsDoc.actions[rowActionId]
 
   const db = context.getAppDB()

--- a/packages/server/src/sdk/app/rowActions.ts
+++ b/packages/server/src/sdk/app/rowActions.ts
@@ -49,9 +49,14 @@ export async function create(tableId: string, rowAction: { name: string }) {
 
   ensureUniqueAndThrow(doc, action.name)
 
+  const appId = context.getAppId()
+  if (!appId) {
+    throw new Error("Could not get the current appId")
+  }
+
   const automation = await automations.create({
     name: `${tableName}: ${action.name}`,
-    appId: context.getAppId()!,
+    appId,
     definition: {
       trigger: {
         type: AutomationStepType.TRIGGER,

--- a/packages/server/src/sdk/app/rowActions.ts
+++ b/packages/server/src/sdk/app/rowActions.ts
@@ -125,7 +125,10 @@ export async function update(
 
   ensureUniqueAndThrow(actionsDoc, action.name, rowActionId)
 
-  actionsDoc.actions[rowActionId] = action
+  actionsDoc.actions[rowActionId] = {
+    automationId: actionsDoc.actions[rowActionId].automationId,
+    ...action,
+  }
 
   const db = context.getAppDB()
   await db.put(actionsDoc)

--- a/packages/server/src/tests/utilities/api/automation.ts
+++ b/packages/server/src/tests/utilities/api/automation.ts
@@ -1,0 +1,17 @@
+import { Automation } from "@budibase/types"
+import { Expectations, TestAPI } from "./base"
+
+export class AutomationAPI extends TestAPI {
+  get = async (
+    automationId: string,
+    expectations?: Expectations
+  ): Promise<Automation> => {
+    const result = await this._get<Automation>(
+      `/api/automations/${automationId}`,
+      {
+        expectations,
+      }
+    )
+    return result
+  }
+}

--- a/packages/server/src/tests/utilities/api/index.ts
+++ b/packages/server/src/tests/utilities/api/index.ts
@@ -14,6 +14,7 @@ import { QueryAPI } from "./query"
 import { RoleAPI } from "./role"
 import { TemplateAPI } from "./template"
 import { RowActionAPI } from "./rowAction"
+import { AutomationAPI } from "./automation"
 
 export default class API {
   table: TableAPI
@@ -31,6 +32,7 @@ export default class API {
   roles: RoleAPI
   templates: TemplateAPI
   rowAction: RowActionAPI
+  automation: AutomationAPI
 
   constructor(config: TestConfiguration) {
     this.table = new TableAPI(config)
@@ -48,5 +50,6 @@ export default class API {
     this.roles = new RoleAPI(config)
     this.templates = new TemplateAPI(config)
     this.rowAction = new RowActionAPI(config)
+    this.automation = new AutomationAPI(config)
   }
 }

--- a/packages/types/src/api/web/app/rowAction.ts
+++ b/packages/types/src/api/web/app/rowAction.ts
@@ -7,6 +7,7 @@ export interface UpdateRowActionRequest extends RowActionData {}
 export interface RowActionResponse extends RowActionData {
   id: string
   tableId: string
+  automationId: string
 }
 
 export interface RowActionsResponse {

--- a/packages/types/src/documents/app/automation.ts
+++ b/packages/types/src/documents/app/automation.ts
@@ -45,6 +45,7 @@ export enum AutomationTriggerStepId {
   WEBHOOK = "WEBHOOK",
   APP = "APP",
   CRON = "CRON",
+  ROW_ACTION = "ROW_ACTION",
 }
 
 export enum AutomationStepType {

--- a/packages/types/src/documents/app/rowAction.ts
+++ b/packages/types/src/documents/app/rowAction.ts
@@ -6,6 +6,7 @@ export interface TableRowActions extends Document {
     string,
     {
       name: string
+      automationId: string
     }
   >
 }


### PR DESCRIPTION
## Description
Adding a new automation with `row action` type when adding a new row action. This automation will be deleted when the original row action is deleted.
No UI changes at all exist on this PR. There are some TODO left, that for the time being are not being used at all. I will be analysing its usage, as I think they some of them are obsolete fields that can be removed.

## Addresses
- [BUDI-8430 - Row action API - auto-create automation](https://linear.app/budibase/issue/BUDI-8430/row-action-api-auto-create-automation)