### PR TITLE
Don't allow editing trigger data for row action automations

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -869,6 +869,7 @@
                 options={value.enum}
                 getOptionLabel={(x, idx) =>
                   value.pretty ? value.pretty[idx] : x}
+                disabled={value.readonly}
               />
             {:else if value.type === "json"}
               <Editor
@@ -877,6 +878,7 @@
                 mode="json"
                 value={inputData[key]?.value}
                 on:change={e => onChange({ [key]: e.detail })}
+                readOnly={value.readonly}
               />
             {:else if value.type === "boolean"}
               <div style="margin-top: 10px">
@@ -884,6 +886,7 @@
                   text={value.title}
                   value={inputData[key]}
                   on:change={e => onChange({ [key]: e.detail })}
+                  disabled={value.readonly}
                 />
               </div>
             {:else if value.type === "date"}
@@ -897,6 +900,7 @@
                 allowJS={true}
                 updateOnChange={false}
                 drawerLeft="260px"
+                disabled={value.readonly}
               >
                 <DatePicker
                   value={inputData[key]}
@@ -908,6 +912,7 @@
                 on:change={e => onChange({ [key]: e.detail })}
                 value={inputData[key]}
                 options={Object.keys(table?.schema || {})}
+                disabled={value.readonly}
               />
             {:else if value.type === "attachment" || value.type === "signature_single"}
               <div class="attachment-field-wrapper">
@@ -1021,6 +1026,7 @@
                 {isTrigger}
                 value={inputData[key]}
                 on:change={e => onChange({ [key]: e.detail })}
+                disabled={value.readonly}
               />
             {:else if value.customType === "webhookUrl"}
               <WebhookDisplay value={inputData[key]} />

--- a/packages/builder/src/stores/builder/automations.js
+++ b/packages/builder/src/stores/builder/automations.js
@@ -308,7 +308,9 @@ const automationActions = store => ({
     if (!automation) {
       return
     }
-    delete newAutomation.definition.stepNames[blockId]
+    if (newAutomation.definition.stepNames) {
+      delete newAutomation.definition.stepNames[blockId]
+    }
 
     await store.actions.save(newAutomation)
   },

--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -11,7 +11,7 @@ import {
 import { definitions } from "../../../automations/triggerInfo"
 import automations from "."
 
-type PersistedAutomation = Automation & {
+interface PersistedAutomation extends Automation {
   _id: string
   _rev: string
 }

--- a/packages/server/src/sdk/app/automations/tests/index.spec.ts
+++ b/packages/server/src/sdk/app/automations/tests/index.spec.ts
@@ -1,0 +1,54 @@
+import _ from "lodash/fp"
+import { Automation } from "@budibase/types"
+import automationSdk from "../"
+import { structures } from "../../../../api/routes/tests/utilities"
+import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
+
+describe("automation sdk", () => {
+  const config = new TestConfiguration()
+
+  beforeAll(async () => {
+    await config.init()
+  })
+
+  describe("update", () => {
+    it("can update input fields", async () => {
+      await config.doInContext(config.getAppId(), async () => {
+        const automation: Automation = structures.newAutomation()
+        const keyToUse = _.sample(
+          Object.keys(automation.definition.trigger.inputs)
+        )!
+        automation.definition.trigger.inputs[keyToUse] = "anyValue"
+
+        const response = await automationSdk.create(automation)
+
+        const update = { ...response }
+        update.definition.trigger.inputs[keyToUse] = "anyUpdatedValue"
+        const result = await automationSdk.update(update)
+        expect(result.definition.trigger.inputs[keyToUse]).toEqual(
+          "anyUpdatedValue"
+        )
+      })
+    })
+
+    it("cannot update readonly fields", async () => {
+      await config.doInContext(config.getAppId(), async () => {
+        const automation: Automation = { ...structures.newAutomation() }
+        automation.definition.trigger.schema.inputs.properties[
+          "readonlyProperty"
+        ] = {
+          readonly: true,
+        }
+        automation.definition.trigger.inputs["readonlyProperty"] = "anyValue"
+
+        const response = await automationSdk.create(automation)
+
+        const update = { ...response }
+        update.definition.trigger.inputs["readonlyProperty"] = "anyUpdatedValue"
+        await expect(automationSdk.update(update)).rejects.toThrow(
+          "Field readonlyProperty is readonly and it cannot be modified"
+        )
+      })
+    })
+  })
+})

--- a/packages/server/src/sdk/app/automations/tests/index.spec.ts
+++ b/packages/server/src/sdk/app/automations/tests/index.spec.ts
@@ -1,4 +1,4 @@
-import _ from "lodash/fp"
+import { sample } from "lodash/fp"
 import { Automation } from "@budibase/types"
 import automationSdk from "../"
 import { structures } from "../../../../api/routes/tests/utilities"
@@ -12,39 +12,40 @@ describe("automation sdk", () => {
   })
 
   describe("update", () => {
-    it("can update input fields", async () => {
+    it.each([
+      ["trigger", (a: Automation) => a.definition.trigger],
+      ["step", (a: Automation) => a.definition.steps[0]],
+    ])("can update input fields (for a %s)", async (_, getStep) => {
       await config.doInContext(config.getAppId(), async () => {
-        const automation: Automation = structures.newAutomation()
-        const keyToUse = _.sample(
-          Object.keys(automation.definition.trigger.inputs)
-        )!
-        automation.definition.trigger.inputs[keyToUse] = "anyValue"
+        const automation = structures.newAutomation()
+
+        const keyToUse = sample(Object.keys(getStep(automation).inputs))!
+        getStep(automation).inputs[keyToUse] = "anyValue"
 
         const response = await automationSdk.create(automation)
 
         const update = { ...response }
-        update.definition.trigger.inputs[keyToUse] = "anyUpdatedValue"
+        getStep(update).inputs[keyToUse] = "anyUpdatedValue"
         const result = await automationSdk.update(update)
-        expect(result.definition.trigger.inputs[keyToUse]).toEqual(
-          "anyUpdatedValue"
-        )
+        expect(getStep(result).inputs[keyToUse]).toEqual("anyUpdatedValue")
       })
     })
 
-    it("cannot update readonly fields", async () => {
+    it.each([
+      ["trigger", (a: Automation) => a.definition.trigger],
+      ["step", (a: Automation) => a.definition.steps[0]],
+    ])("cannot update readonly fields (for a %s)", async (_, getStep) => {
       await config.doInContext(config.getAppId(), async () => {
-        const automation: Automation = { ...structures.newAutomation() }
-        automation.definition.trigger.schema.inputs.properties[
-          "readonlyProperty"
-        ] = {
+        const automation = structures.newAutomation()
+        getStep(automation).schema.inputs.properties["readonlyProperty"] = {
           readonly: true,
         }
-        automation.definition.trigger.inputs["readonlyProperty"] = "anyValue"
+        getStep(automation).inputs["readonlyProperty"] = "anyValue"
 
         const response = await automationSdk.create(automation)
 
         const update = { ...response }
-        update.definition.trigger.inputs["readonlyProperty"] = "anyUpdatedValue"
+        getStep(update).inputs["readonlyProperty"] = "anyUpdatedValue"
         await expect(automationSdk.update(update)).rejects.toThrow(
           "Field readonlyProperty is readonly and it cannot be modified"
         )

--- a/packages/server/src/sdk/app/rowActions.ts
+++ b/packages/server/src/sdk/app/rowActions.ts
@@ -60,7 +60,7 @@ export async function create(tableId: string, rowAction: { name: string }) {
     definition: {
       trigger: {
         type: AutomationStepType.TRIGGER,
-        id: "TODO id",
+        id: "trigger",
         tagline: "TODO tagline",
         name: "Row Action",
         description: "TODO description",

--- a/packages/server/src/sdk/app/rowActions.ts
+++ b/packages/server/src/sdk/app/rowActions.ts
@@ -76,6 +76,7 @@ export async function create(tableId: string, rowAction: { name: string }) {
                 type: AutomationIOType.STRING,
                 customType: AutomationCustomIOType.TABLE,
                 title: "Table",
+                readonly: true,
               },
             },
             required: ["tableId"],

--- a/packages/types/src/documents/app/automation.ts
+++ b/packages/types/src/documents/app/automation.ts
@@ -153,6 +153,7 @@ interface BaseIOStructure {
     [key: string]: BaseIOStructure
   }
   required?: string[]
+  readonly?: true
 }
 
 export interface InputOutputBlock {


### PR DESCRIPTION
## Description
Don't allow editing trigger data for row action automations

## Addresses
- [BUDI-8430 - Row action API - auto-create automation](https://linear.app/budibase/issue/BUDI-8430/row-action-api-auto-create-automation)

## App Export
[row actions-export-1721382029639.tar.gz](https://github.com/user-attachments/files/16310236/row.actions-export-1721382029639.tar.gz)


## Screenshots
### Editing row action trigger, table selector is readonly
<img width="1469" alt="image" src="https://github.com/user-attachments/assets/7caba4d4-30df-4c89-8470-4a6c2e1fe4df">

### Other automation types are still editable
<img width="1469" alt="image" src="https://github.com/user-attachments/assets/01a9cc5f-ddc9-4115-af7f-96e1f3ce351f">
