### PR TITLE
Row action automation display in frontend

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
@@ -14,7 +14,9 @@
     notifications,
     Label,
     AbsTooltip,
+    InlineAlert,
   } from "@budibase/bbui"
+  import { AutomationTriggerStepId } from "@budibase/types"
   import AutomationBlockSetup from "../../SetupPanel/AutomationBlockSetup.svelte"
   import CreateWebhookModal from "components/automation/Shared/CreateWebhookModal.svelte"
   import ActionModal from "./ActionModal.svelte"
@@ -48,6 +50,8 @@
   $: isAppAction = block?.stepId === TriggerStepID.APP
   $: isAppAction && setPermissions(role)
   $: isAppAction && getPermissions(automationId)
+
+  $: isRowAction = block?.stepId === AutomationTriggerStepId.ROW_ACTION
 
   async function setPermissions(role) {
     if (!role || !automationId) {
@@ -183,6 +187,12 @@
           {block}
           {webhookModal}
         />
+        {#if isRowAction && isTrigger}
+          <InlineAlert
+            header="Automation trigger"
+            message="This trigger is tied to the row action TODO on your TODO"
+          />
+        {/if}
         {#if lastStep}
           <Button on:click={() => testDataModal.show()} cta>
             Finish and test automation

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
@@ -51,6 +51,8 @@
   $: isAppAction && setPermissions(role)
   $: isAppAction && getPermissions(automationId)
 
+  $: triggerInfo = $selectedAutomationDisplayData?.triggerInfo
+
   async function setPermissions(role) {
     if (!role || !automationId) {
       return
@@ -185,10 +187,10 @@
           {block}
           {webhookModal}
         />
-        {#if isTrigger && $selectedAutomationDisplayData?.triggerInfo}
+        {#if isTrigger && triggerInfo}
           <InlineAlert
-            header={$selectedAutomationDisplayData.triggerInfo.title}
-            message={$selectedAutomationDisplayData.triggerInfo.description}
+            header={triggerInfo.type}
+            message={`This trigger is tied to the row action ${triggerInfo.rowAction.name} on your ${triggerInfo.table.name} table`}
           />
         {/if}
         {#if lastStep}

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
@@ -3,6 +3,7 @@
     automationStore,
     selectedAutomation,
     permissions,
+    selectedAutomationDisplayData,
   } from "stores/builder"
   import {
     Icon,
@@ -16,7 +17,6 @@
     AbsTooltip,
     InlineAlert,
   } from "@budibase/bbui"
-  import { AutomationTriggerStepId } from "@budibase/types"
   import AutomationBlockSetup from "../../SetupPanel/AutomationBlockSetup.svelte"
   import CreateWebhookModal from "components/automation/Shared/CreateWebhookModal.svelte"
   import ActionModal from "./ActionModal.svelte"
@@ -50,8 +50,6 @@
   $: isAppAction = block?.stepId === TriggerStepID.APP
   $: isAppAction && setPermissions(role)
   $: isAppAction && getPermissions(automationId)
-
-  $: isRowAction = block?.stepId === AutomationTriggerStepId.ROW_ACTION
 
   async function setPermissions(role) {
     if (!role || !automationId) {
@@ -187,10 +185,10 @@
           {block}
           {webhookModal}
         />
-        {#if isRowAction && isTrigger}
+        {#if isTrigger && $selectedAutomationDisplayData?.triggerInfo}
           <InlineAlert
-            header="Automation trigger"
-            message="This trigger is tied to the row action TODO on your TODO"
+            header={$selectedAutomationDisplayData.triggerInfo.title}
+            message={$selectedAutomationDisplayData.triggerInfo.description}
           />
         {/if}
         {#if lastStep}

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/TestDataModal.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/TestDataModal.svelte
@@ -81,7 +81,7 @@
   // Check the schema to see if required fields have been entered
   $: isError =
     !isTriggerValid(trigger) ||
-    !trigger.schema.outputs.required?.every(
+    !(trigger.schema.outputs.required || []).every(
       required => $memoTestData?.[required] || required !== "row"
     )
 

--- a/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
@@ -17,6 +17,12 @@
         automation.name.toLowerCase().includes(searchString.toLowerCase())
       )
     })
+    .map(automation => ({
+      ...automation,
+      name:
+        $automationStore.automationDisplayData[automation._id].displayName ||
+        automation.name,
+    }))
     .sort((a, b) => {
       const lowerA = a.name.toLowerCase()
       const lowerB = b.name.toLowerCase()

--- a/packages/builder/src/stores/builder/automations.js
+++ b/packages/builder/src/stores/builder/automations.js
@@ -59,7 +59,7 @@ const automationActions = store => ({
   },
   fetch: async () => {
     const responses = await Promise.all([
-      API.getAutomations(),
+      API.getAutomations({ enrich: true }),
       API.getAutomationDefinitions(),
     ])
     store.update(state => {

--- a/packages/builder/src/stores/builder/automations.js
+++ b/packages/builder/src/stores/builder/automations.js
@@ -15,6 +15,7 @@ const initialAutomationState = {
     ACTION: [],
   },
   selectedAutomationId: null,
+  automationDisplayData: {},
 }
 
 // If this functions, remove the actions elements
@@ -58,18 +59,19 @@ const automationActions = store => ({
     return response
   },
   fetch: async () => {
-    const responses = await Promise.all([
+    const [automationResponse, definitions] = await Promise.all([
       API.getAutomations({ enrich: true }),
       API.getAutomationDefinitions(),
     ])
     store.update(state => {
-      state.automations = responses[0]
+      state.automations = automationResponse.automations
       state.automations.sort((a, b) => {
         return a.name < b.name ? -1 : 1
       })
+      state.automationDisplayData = automationResponse.builderData
       state.blockDefinitions = {
-        TRIGGER: responses[1].trigger,
-        ACTION: responses[1].action,
+        TRIGGER: definitions.trigger,
+        ACTION: definitions.action,
       }
       return state
     })
@@ -386,3 +388,13 @@ export const selectedAutomation = derived(automationStore, $automationStore => {
     x => x._id === $automationStore.selectedAutomationId
   )
 })
+
+export const selectedAutomationDisplayData = derived(
+  [automationStore, selectedAutomation],
+  ([$automationStore, $selectedAutomation]) => {
+    if (!$selectedAutomation._id) {
+      return null
+    }
+    return $automationStore.automationDisplayData[$selectedAutomation._id]
+  }
+)

--- a/packages/builder/src/stores/builder/index.js
+++ b/packages/builder/src/stores/builder/index.js
@@ -11,6 +11,7 @@ import {
   automationStore,
   selectedAutomation,
   automationHistoryStore,
+  selectedAutomationDisplayData,
 } from "./automations.js"
 import { userStore, userSelectedResourceMap, isOnlyUser } from "./users.js"
 import { deploymentStore } from "./deployments.js"
@@ -44,6 +45,7 @@ export {
   previewStore,
   automationStore,
   selectedAutomation,
+  selectedAutomationDisplayData,
   automationHistoryStore,
   sortedScreens,
   userStore,

--- a/packages/frontend-core/src/api/automations.js
+++ b/packages/frontend-core/src/api/automations.js
@@ -26,9 +26,13 @@ export const buildAutomationEndpoints = API => ({
   /**
    * Gets a list of all automations.
    */
-  getAutomations: async () => {
+  getAutomations: async ({ enrich }) => {
+    let url = "/api/automations?"
+    if (enrich) {
+      url += "enrich=true"
+    }
     return await API.get({
-      url: "/api/automations",
+      url,
     })
   },
 

--- a/packages/frontend-core/src/api/automations.js
+++ b/packages/frontend-core/src/api/automations.js
@@ -27,12 +27,13 @@ export const buildAutomationEndpoints = API => ({
    * Gets a list of all automations.
    */
   getAutomations: async ({ enrich }) => {
-    let url = "/api/automations?"
+    const params = new URLSearchParams()
     if (enrich) {
-      url += "enrich=true"
+      params.set("enrich", true)
     }
+
     return await API.get({
-      url,
+      url: `/api/automations?${params.toString()}`,
     })
   },
 

--- a/packages/server/src/api/controllers/automation.ts
+++ b/packages/server/src/api/controllers/automation.ts
@@ -80,7 +80,9 @@ export async function fetch(ctx: UserCtx<void, FetchAutomationResponse>) {
   const automations = await sdk.automations.fetch()
   ctx.body = { automations }
   if (enrich) {
-    ctx.body.builderData = await sdk.automations.getBuilderData(automations)
+    ctx.body.builderData = await sdk.automations.utils.getBuilderData(
+      automations
+    )
   }
 }
 

--- a/packages/server/src/api/controllers/automation.ts
+++ b/packages/server/src/api/controllers/automation.ts
@@ -75,7 +75,8 @@ export async function update(ctx: UserCtx) {
 }
 
 export async function fetch(ctx: UserCtx<void, FetchAutomationResponse>) {
-  const enrich = ctx.request.query["enrich"] === "true"
+  const query = ctx.request.query || {}
+  const enrich = query["enrich"] === "true"
 
   const automations = await sdk.automations.fetch()
   ctx.body = { automations }

--- a/packages/server/src/api/controllers/automation.ts
+++ b/packages/server/src/api/controllers/automation.ts
@@ -11,6 +11,7 @@ import {
   AutomationResults,
   UserCtx,
   DeleteAutomationResponse,
+  FetchAutomationResponse,
 } from "@budibase/types"
 import { getActionDefinitions as actionDefs } from "../../automations/actions"
 import sdk from "../../sdk"
@@ -73,14 +74,13 @@ export async function update(ctx: UserCtx) {
   builderSocket?.emitAutomationUpdate(ctx, automation)
 }
 
-export async function fetch(ctx: UserCtx) {
+export async function fetch(ctx: UserCtx<void, FetchAutomationResponse>) {
   const enrich = ctx.request.query["enrich"] === "true"
 
   const automations = await sdk.automations.fetch()
+  ctx.body = { automations }
   if (enrich) {
-    ctx.body = await sdk.automations.enrichDisplayData(automations)
-  } else {
-    ctx.body = automations
+    ctx.body.builderData = await sdk.automations.getBuilderData(automations)
   }
 }
 

--- a/packages/server/src/api/controllers/automation.ts
+++ b/packages/server/src/api/controllers/automation.ts
@@ -75,8 +75,8 @@ export async function update(ctx: UserCtx) {
 }
 
 export async function fetch(ctx: UserCtx<void, FetchAutomationResponse>) {
-  const query = ctx.request.query || {}
-  const enrich = query["enrich"] === "true"
+  const query: { enrich?: string } = ctx.request.query || {}
+  const enrich = query.enrich === "true"
 
   const automations = await sdk.automations.fetch()
   ctx.body = { automations }

--- a/packages/server/src/api/controllers/automation.ts
+++ b/packages/server/src/api/controllers/automation.ts
@@ -74,7 +74,14 @@ export async function update(ctx: UserCtx) {
 }
 
 export async function fetch(ctx: UserCtx) {
-  ctx.body = await sdk.automations.fetch()
+  const enrich = ctx.request.query["enrich"] === "true"
+
+  const automations = await sdk.automations.fetch()
+  if (enrich) {
+    ctx.body = await sdk.automations.enrichDisplayData(automations)
+  } else {
+    ctx.body = automations
+  }
 }
 
 export async function find(ctx: UserCtx) {

--- a/packages/server/src/api/routes/tests/automation.spec.ts
+++ b/packages/server/src/api/routes/tests/automation.spec.ts
@@ -398,7 +398,9 @@ describe("/automations", () => {
         .expect("Content-Type", /json/)
         .expect(200)
 
-      expect(res.body[0]).toEqual(expect.objectContaining(autoConfig))
+      expect(res.body.automations[0]).toEqual(
+        expect.objectContaining(autoConfig)
+      )
     })
 
     it("should apply authorization to endpoint", async () => {

--- a/packages/server/src/api/routes/tests/utilities/TestFunctions.ts
+++ b/packages/server/src/api/routes/tests/utilities/TestFunctions.ts
@@ -54,7 +54,7 @@ export const clearAllApps = async (
 }
 
 export const clearAllAutomations = async (config: TestConfiguration) => {
-  const automations = await config.getAllAutomations()
+  const { automations } = await config.getAllAutomations()
   for (let auto of automations) {
     await context.doInAppContext(config.getAppId(), async () => {
       await config.deleteAutomation(auto)

--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -1,10 +1,4 @@
-import {
-  Automation,
-  AutomationBuilderData,
-  AutomationTriggerStepId,
-  Webhook,
-  WebhookActionType,
-} from "@budibase/types"
+import { Automation, Webhook, WebhookActionType } from "@budibase/types"
 import { generateAutomationID, getAutomationParams } from "../../../db/utils"
 import { deleteEntityMetadata } from "../../../utilities"
 import { MetadataTypes } from "../../../constants"
@@ -287,28 +281,4 @@ function guardInvalidUpdatesAndThrow(
       }
     })
   }
-}
-
-export async function getBuilderData(
-  automations: Automation[]
-): Promise<Record<string, AutomationBuilderData>> {
-  const result: Record<string, AutomationBuilderData> = {}
-  for (const automation of automations) {
-    const isRowAction =
-      automation.definition.trigger.stepId ===
-      AutomationTriggerStepId.ROW_ACTION
-    if (!isRowAction) {
-      result[automation._id!] = { displayName: automation.name }
-      continue
-    }
-
-    result[automation._id!] = {
-      displayName: `TODO: ${automation.name}`,
-      triggerInfo: {
-        title: "Automation trigger",
-        description: "This trigger is tied to the row action TODO on your TODO",
-      },
-    }
-  }
-  return result
 }

--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -1,5 +1,6 @@
 import {
   Automation,
+  AutomationBuilderData,
   AutomationTriggerStepId,
   Webhook,
   WebhookActionType,
@@ -288,14 +289,26 @@ function guardInvalidUpdatesAndThrow(
   }
 }
 
-export async function enrichDisplayData(automations: Automation[]) {
-  const rowActionAutomations = automations.filter(
-    ({ definition }) =>
-      definition.trigger.stepId === AutomationTriggerStepId.ROW_ACTION
-  )
+export async function getBuilderData(
+  automations: Automation[]
+): Promise<Record<string, AutomationBuilderData>> {
+  const result: Record<string, AutomationBuilderData> = {}
+  for (const automation of automations) {
+    const isRowAction =
+      automation.definition.trigger.stepId ===
+      AutomationTriggerStepId.ROW_ACTION
+    if (!isRowAction) {
+      result[automation._id!] = { displayName: automation.name }
+      continue
+    }
 
-  for (const automation of rowActionAutomations) {
-    automation.name = `TODO: ${automation.name}`
+    result[automation._id!] = {
+      displayName: `TODO: ${automation.name}`,
+      triggerInfo: {
+        title: "Automation trigger",
+        description: "This trigger is tied to the row action TODO on your TODO",
+      },
+    }
   }
-  return automations
+  return result
 }

--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -17,7 +17,7 @@ import {
 import { definitions } from "../../../automations/triggerInfo"
 import automations from "."
 
-interface PersistedAutomation extends Automation {
+export interface PersistedAutomation extends Automation {
   _id: string
   _rev: string
 }

--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -1,4 +1,9 @@
-import { Automation, Webhook, WebhookActionType } from "@budibase/types"
+import {
+  Automation,
+  AutomationTriggerStepId,
+  Webhook,
+  WebhookActionType,
+} from "@budibase/types"
 import { generateAutomationID, getAutomationParams } from "../../../db/utils"
 import { deleteEntityMetadata } from "../../../utilities"
 import { MetadataTypes } from "../../../constants"
@@ -81,7 +86,7 @@ export async function fetch() {
       include_docs: true,
     })
   )
-  return response.rows.map(row => row.doc)
+  return response.rows.map(row => row.doc).filter(doc => !!doc)
 }
 
 export async function get(automationId: string) {
@@ -254,6 +259,7 @@ async function checkForWebhooks({ oldAuto, newAuto }: any) {
   }
   return newAuto
 }
+
 function guardInvalidUpdatesAndThrow(
   automation: Automation,
   oldAutomation: Automation
@@ -280,4 +286,16 @@ function guardInvalidUpdatesAndThrow(
       }
     })
   }
+}
+
+export async function enrichDisplayData(automations: Automation[]) {
+  const rowActionAutomations = automations.filter(
+    ({ definition }) =>
+      definition.trigger.stepId === AutomationTriggerStepId.ROW_ACTION
+  )
+
+  for (const automation of rowActionAutomations) {
+    automation.name = `TODO: ${automation.name}`
+  }
+  return automations
 }

--- a/packages/server/src/sdk/app/automations/utils.ts
+++ b/packages/server/src/sdk/app/automations/utils.ts
@@ -54,8 +54,12 @@ export async function getBuilderData(
     result[automation._id!] = {
       displayName: `${tableName}: ${automation.name}`,
       triggerInfo: {
-        title: "Automation trigger",
-        description: `This trigger is tied to the row action ${rowActionName} on your ${tableName} table`,
+        type: "Automation trigger",
+        table: { id: tableId, name: tableName },
+        rowAction: {
+          id: rowActionId,
+          name: rowActionName,
+        },
       },
     }
   }

--- a/packages/server/src/sdk/app/automations/utils.ts
+++ b/packages/server/src/sdk/app/automations/utils.ts
@@ -1,7 +1,48 @@
-import { Automation, AutomationActionStepId } from "@budibase/types"
+import {
+  Automation,
+  AutomationActionStepId,
+  AutomationBuilderData,
+  AutomationTriggerStepId,
+} from "@budibase/types"
+import sdk from "src/sdk"
 
 export function checkForCollectStep(automation: Automation) {
   return automation.definition.steps.some(
     (step: any) => step.stepId === AutomationActionStepId.COLLECT
   )
+}
+
+export async function getBuilderData(
+  automations: Automation[]
+): Promise<Record<string, AutomationBuilderData>> {
+  const tableNameCache: Record<string, string> = {}
+  async function getTableName(tableId: string) {
+    if (!tableNameCache[tableId]) {
+      const table = await sdk.tables.getTable(tableId)
+      tableNameCache[tableId] = table.name
+    }
+
+    return tableNameCache[tableId]
+  }
+
+  const result: Record<string, AutomationBuilderData> = {}
+  for (const automation of automations) {
+    const { trigger } = automation.definition
+    const isRowAction = trigger.stepId === AutomationTriggerStepId.ROW_ACTION
+    if (!isRowAction) {
+      result[automation._id!] = { displayName: automation.name }
+      continue
+    }
+
+    const tableName = await getTableName(trigger.inputs.tableId)
+
+    result[automation._id!] = {
+      displayName: `${tableName}: ${automation.name}`,
+      triggerInfo: {
+        title: "Automation trigger",
+        description: `This trigger is tied to the row action TODO on your ${tableName} table`,
+      },
+    }
+  }
+  return result
 }

--- a/packages/server/src/sdk/app/automations/utils.ts
+++ b/packages/server/src/sdk/app/automations/utils.ts
@@ -3,6 +3,7 @@ import {
   AutomationActionStepId,
   AutomationBuilderData,
   AutomationTriggerStepId,
+  TableRowActions,
 } from "@budibase/types"
 import sdk from "src/sdk"
 
@@ -25,6 +26,16 @@ export async function getBuilderData(
     return tableNameCache[tableId]
   }
 
+  const rowActionNameCache: Record<string, TableRowActions> = {}
+  async function getRowActionName(tableId: string, rowActionId: string) {
+    if (!rowActionNameCache[tableId]) {
+      const rowActions = await sdk.rowActions.get(tableId)
+      rowActionNameCache[tableId] = rowActions
+    }
+
+    return rowActionNameCache[tableId].actions[rowActionId]?.name
+  }
+
   const result: Record<string, AutomationBuilderData> = {}
   for (const automation of automations) {
     const { trigger } = automation.definition
@@ -34,13 +45,17 @@ export async function getBuilderData(
       continue
     }
 
-    const tableName = await getTableName(trigger.inputs.tableId)
+    const { tableId, rowActionId } = trigger.inputs
+
+    const tableName = await getTableName(tableId)
+
+    const rowActionName = await getRowActionName(tableId, rowActionId)
 
     result[automation._id!] = {
       displayName: `${tableName}: ${automation.name}`,
       triggerInfo: {
         title: "Automation trigger",
-        description: `This trigger is tied to the row action TODO on your ${tableName} table`,
+        description: `This trigger is tied to the row action ${rowActionName} on your ${tableName} table`,
       },
     }
   }

--- a/packages/server/src/sdk/app/automations/utils.ts
+++ b/packages/server/src/sdk/app/automations/utils.ts
@@ -5,7 +5,7 @@ import {
   AutomationTriggerStepId,
   TableRowActions,
 } from "@budibase/types"
-import sdk from "src/sdk"
+import sdk from "../../../sdk"
 
 export function checkForCollectStep(automation: Automation) {
   return automation.definition.steps.some(

--- a/packages/server/src/sdk/app/automations/utils.ts
+++ b/packages/server/src/sdk/app/automations/utils.ts
@@ -5,7 +5,6 @@ import {
   AutomationTriggerStepId,
   TableRowActions,
 } from "@budibase/types"
-import sdk from "../../../sdk"
 
 export function checkForCollectStep(automation: Automation) {
   return automation.definition.steps.some(
@@ -16,6 +15,8 @@ export function checkForCollectStep(automation: Automation) {
 export async function getBuilderData(
   automations: Automation[]
 ): Promise<Record<string, AutomationBuilderData>> {
+  const sdk = (await import("../../../sdk")).default
+
   const tableNameCache: Record<string, string> = {}
   async function getTableName(tableId: string) {
     if (!tableNameCache[tableId]) {

--- a/packages/server/src/sdk/app/rowActions.ts
+++ b/packages/server/src/sdk/app/rowActions.ts
@@ -54,6 +54,10 @@ export async function create(tableId: string, rowAction: { name: string }) {
     throw new Error("Could not get the current appId")
   }
 
+  const newRowActionId = `${
+    VirtualDocumentType.ROW_ACTION
+  }${SEPARATOR}${utils.newid()}`
+
   const automation = await automations.create({
     name: `${tableName}: ${action.name}`,
     appId,
@@ -68,6 +72,7 @@ export async function create(tableId: string, rowAction: { name: string }) {
         stepId: AutomationTriggerStepId.ROW_ACTION,
         inputs: {
           tableId,
+          rowActionId: newRowActionId,
         },
         schema: {
           inputs: {
@@ -88,16 +93,15 @@ export async function create(tableId: string, rowAction: { name: string }) {
     },
   })
 
-  const newId = `${VirtualDocumentType.ROW_ACTION}${SEPARATOR}${utils.newid()}`
-  doc.actions[newId] = {
+  doc.actions[newRowActionId] = {
     name: action.name,
     automationId: automation._id!,
   }
   await db.put(doc)
 
   return {
-    id: newId,
-    ...doc.actions[newId],
+    id: newRowActionId,
+    ...doc.actions[newRowActionId],
   }
 }
 

--- a/packages/server/src/sdk/app/rowActions.ts
+++ b/packages/server/src/sdk/app/rowActions.ts
@@ -11,7 +11,6 @@ import {
   VirtualDocumentType,
 } from "@budibase/types"
 import automations from "./automations"
-import tables from "./tables"
 
 function ensureUniqueAndThrow(
   doc: TableRowActions,
@@ -45,8 +44,6 @@ export async function create(tableId: string, rowAction: { name: string }) {
     doc = { _id: rowActionsId, actions: {} }
   }
 
-  const { name: tableName } = await tables.getTable(tableId)
-
   ensureUniqueAndThrow(doc, action.name)
 
   const appId = context.getAppId()
@@ -59,7 +56,7 @@ export async function create(tableId: string, rowAction: { name: string }) {
   }${SEPARATOR}${utils.newid()}`
 
   const automation = await automations.create({
-    name: `${tableName}: ${action.name}`,
+    name: action.name,
     appId,
     definition: {
       trigger: {

--- a/packages/types/src/api/web/automation.ts
+++ b/packages/types/src/api/web/automation.ts
@@ -6,8 +6,15 @@ export interface DeleteAutomationResponse extends DocumentDestroyResponse {}
 export interface AutomationBuilderData {
   displayName: string
   triggerInfo?: {
-    title: string
-    description: string
+    type: string
+    table: {
+      id: string
+      name: string
+    }
+    rowAction: {
+      id: string
+      name: string
+    }
   }
 }
 

--- a/packages/types/src/api/web/automation.ts
+++ b/packages/types/src/api/web/automation.ts
@@ -1,3 +1,17 @@
 import { DocumentDestroyResponse } from "@budibase/nano"
+import { Automation } from "../../documents"
 
 export interface DeleteAutomationResponse extends DocumentDestroyResponse {}
+
+export interface AutomationBuilderData {
+  displayName: string
+  triggerInfo?: {
+    title: string
+    description: string
+  }
+}
+
+export interface FetchAutomationResponse {
+  automations: Automation[]
+  builderData?: Record<string, AutomationBuilderData> // The key will be the automationId
+}


### PR DESCRIPTION
## Description
Displaying row action information, such as table name next to action name and trigger information banners. This required changing the fetch automation endpoint in order to make it more extensible without polluting the database objects or having copies of reference names

## Addresses
- [BUDI-8430 - Row action API - auto-create automation
](https://linear.app/budibase/issue/BUDI-8430/row-action-api-auto-create-automation)

## Screenshots
<img width="1162" alt="image" src="https://github.com/user-attachments/assets/4295e5e4-7a64-40af-bf9c-8967f5a7a7fb">