### PR TITLE
Fix to show Formula column type picker again

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -682,7 +682,7 @@
       {errors}
     />
   {:else if editableColumn.type === FORMULA_TYPE}
-    {#if !table.sql}
+    {#if !externalTable}
       <div class="split-label">
         <div class="label-length">
           <Label size="M">Formula Type</Label>

--- a/packages/builder/src/dataBinding.js
+++ b/packages/builder/src/dataBinding.js
@@ -29,7 +29,7 @@ import { JSONUtils, Constants } from "@budibase/frontend-core"
 import ActionDefinitions from "components/design/settings/controls/ButtonActionEditor/manifest.json"
 import { environment, licensing } from "stores/portal"
 import { convertOldFieldFormat } from "components/design/settings/controls/FieldConfiguration/utils"
-import { FIELDS } from "constants/backend"
+import { FIELDS, DB_TYPE_INTERNAL } from "constants/backend"
 import { FieldType } from "@budibase/types"
 
 const { ContextScopes } = Constants
@@ -991,7 +991,7 @@ export const getSchemaForDatasource = (asset, datasource, options) => {
     }
 
     // Determine if we should add ID and rev to the schema
-    const isInternal = table && !table.sql
+    const isInternal = table && table?.sourceType === DB_TYPE_INTERNAL
     const isDSPlus = ["table", "link", "viewV2"].includes(datasource.type)
 
     // ID is part of the readable schema for all tables


### PR DESCRIPTION
## Description
Recent SQS changes have altered the way in which internal tables set the value `table.sql`. There were a couple of areas in the UI that used this to determine if a data source was internal.

## Addresses
  - Fix for the hidden `Formula` column type picker. This should be visible for Internal tables only as they support both `Static` formulas and the default, `Dynamic`.
    - This also ensures that the picker won't mistakenly appear for Google Sheets, which doesn't support `Static` formulas.
  - Fix to ensure internal sources get the `_rev` binding in the builder. The `!table.sql` check was excluding it from list.
    - `_rev` binding will be included for `table`, `link` and `viewV2` sources.
    - This also excludes the `_rev` binding for Google Sheets sources.

## Screenshots
This picker was inadvertently hidden when configuring a Formula column in an internal table.
![Screenshot 2024-07-22 at 12 42 59](https://github.com/user-attachments/assets/1694c489-8033-4de5-b7e3-8686efb99fbd)

## Launchcontrol
Fix to show the Formula column type again for internal tables.