### PR TITLE
Trim data on automation sdk

### DIFF
--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -1,4 +1,9 @@
-import { Automation, Webhook, WebhookActionType } from "@budibase/types"
+import {
+  Automation,
+  RequiredKeys,
+  Webhook,
+  WebhookActionType,
+} from "@budibase/types"
 import { generateAutomationID, getAutomationParams } from "../../../db/utils"
 import { deleteEntityMetadata } from "../../../utilities"
 import { MetadataTypes } from "../../../constants"
@@ -76,17 +81,20 @@ export async function fetch() {
       include_docs: true,
     })
   )
-  return response.rows.map(row => row.doc)
+  return response.rows
+    .map(row => row.doc)
+    .filter(doc => !!doc)
+    .map(trimUnexpectedObjectFields)
 }
 
 export async function get(automationId: string) {
   const db = getDb()
   const result = await db.get<Automation>(automationId)
-  return result
+  return trimUnexpectedObjectFields(result)
 }
 
 export async function create(automation: Automation) {
-  automation = { ...automation }
+  automation = trimUnexpectedObjectFields({ ...automation })
   const db = getDb()
 
   // Respect existing IDs if recreating a deleted automation
@@ -111,8 +119,7 @@ export async function create(automation: Automation) {
 }
 
 export async function update(automation: Automation) {
-  automation = { ...automation }
-
+  automation = trimUnexpectedObjectFields({ ...automation })
   if (!automation._id || !automation._rev) {
     throw new HTTPError("_id or _rev fields missing", 400)
   }
@@ -245,4 +252,24 @@ async function checkForWebhooks({ oldAuto, newAuto }: any) {
     }
   }
   return newAuto
+}
+
+function trimUnexpectedObjectFields(automation: Automation): Automation {
+  const result: RequiredKeys<Automation> = {
+    _id: automation._id,
+    _rev: automation._rev,
+    definition: automation.definition,
+    screenId: automation.screenId,
+    uiTree: automation.uiTree,
+    appId: automation.appId,
+    live: automation.live,
+    name: automation.name,
+    internal: automation.internal,
+    type: automation.type,
+    disabled: automation.disabled,
+    testData: automation.testData,
+    createdAt: automation.createdAt,
+    updatedAt: automation.updatedAt,
+  }
+  return result
 }

--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -254,7 +254,7 @@ async function checkForWebhooks({ oldAuto, newAuto }: any) {
   return newAuto
 }
 
-function trimUnexpectedObjectFields(automation: Automation): Automation {
+function trimUnexpectedObjectFields<T extends Automation>(automation: T): T {
   const result: RequiredKeys<Automation> = {
     _id: automation._id,
     _rev: automation._rev,
@@ -271,5 +271,5 @@ function trimUnexpectedObjectFields(automation: Automation): Automation {
     createdAt: automation.createdAt,
     updatedAt: automation.updatedAt,
   }
-  return result
+  return result as T
 }

--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -94,7 +94,7 @@ export async function get(automationId: string) {
 }
 
 export async function create(automation: Automation) {
-  automation = trimUnexpectedObjectFields({ ...automation })
+  automation = trimUnexpectedObjectFields(automation)
   const db = getDb()
 
   // Respect existing IDs if recreating a deleted automation
@@ -119,7 +119,7 @@ export async function create(automation: Automation) {
 }
 
 export async function update(automation: Automation) {
-  automation = trimUnexpectedObjectFields({ ...automation })
+  automation = trimUnexpectedObjectFields(automation)
   if (!automation._id || !automation._rev) {
     throw new HTTPError("_id or _rev fields missing", 400)
   }

--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -255,7 +255,7 @@ async function checkForWebhooks({ oldAuto, newAuto }: any) {
 }
 
 function trimUnexpectedObjectFields<T extends Automation>(automation: T): T {
-  const result: RequiredKeys<Automation> = {
+  const allRequired: RequiredKeys<Automation> = {
     _id: automation._id,
     _rev: automation._rev,
     definition: automation.definition,
@@ -270,6 +270,12 @@ function trimUnexpectedObjectFields<T extends Automation>(automation: T): T {
     testData: automation.testData,
     createdAt: automation.createdAt,
     updatedAt: automation.updatedAt,
+  }
+  const result = { ...allRequired } as T
+  for (const key in result) {
+    if (!Object.prototype.hasOwnProperty.call(automation, key)) {
+      delete result[key]
+    }
   }
   return result as T
 }

--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -255,6 +255,7 @@ async function checkForWebhooks({ oldAuto, newAuto }: any) {
 }
 
 function trimUnexpectedObjectFields<T extends Automation>(automation: T): T {
+  // This will ensure all the automation fields (and nothing else) is mapped to the result
   const allRequired: RequiredKeys<Automation> = {
     _id: automation._id,
     _rev: automation._rev,


### PR DESCRIPTION
## Description
Updating automation crud to not allow storing or retrieving any data that is not expected based its interface. This will automatically trim any unexpected data, otherwise any data sent via the requests can be persisted, adding noise to the database

## Launchcontrol
Ensure persisted automation data is the expected one