### PR TITLE
Prevent edits and deletions for row action automations

### DIFF
--- a/packages/builder/src/components/automation/AutomationPanel/AutomationNavItem.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationNavItem.svelte
@@ -89,7 +89,7 @@
   on:contextmenu={openContextMenu}
   {icon}
   iconColor={"var(--spectrum-global-color-gray-900)"}
-  text={automation.name}
+  text={automation.displayName}
   selected={automation._id === $selectedAutomation?._id}
   hovering={automation._id === $contextMenuStore.id}
   on:click={() => automationStore.actions.select(automation._id)}

--- a/packages/builder/src/components/automation/AutomationPanel/AutomationNavItem.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationNavItem.svelte
@@ -35,47 +35,53 @@
   }
 
   const getContextMenuItems = () => {
-    return [
-      {
-        icon: "Delete",
-        name: "Delete",
-        keyBind: null,
-        visible: true,
-        disabled: false,
-        callback: confirmDeleteDialog.show,
+    const isRowAction = automation.definition.trigger.name === "Row Action"
+    const result = []
+    if (!isRowAction) {
+      result.push(
+        ...[
+          {
+            icon: "Delete",
+            name: "Delete",
+            keyBind: null,
+            visible: true,
+            disabled: false,
+            callback: confirmDeleteDialog.show,
+          },
+          {
+            icon: "Edit",
+            name: "Edit",
+            keyBind: null,
+            visible: true,
+            disabled: false,
+            callback: updateAutomationDialog.show,
+          },
+          {
+            icon: "Duplicate",
+            name: "Duplicate",
+            keyBind: null,
+            visible: true,
+            disabled: automation.definition.trigger.name === "Webhook",
+            callback: duplicateAutomation,
+          },
+        ]
+      )
+    }
+
+    result.push({
+      icon: automation.disabled ? "CheckmarkCircle" : "Cancel",
+      name: automation.disabled ? "Activate" : "Pause",
+      keyBind: null,
+      visible: true,
+      disabled: false,
+      callback: () => {
+        automationStore.actions.toggleDisabled(
+          automation._id,
+          automation.disabled
+        )
       },
-      {
-        icon: "Edit",
-        name: "Edit",
-        keyBind: null,
-        visible: true,
-        disabled: false,
-        callback: updateAutomationDialog.show,
-      },
-      {
-        icon: "Duplicate",
-        name: "Duplicate",
-        keyBind: null,
-        visible: true,
-        disabled:
-          automation.definition.trigger.name === "Webhook" ||
-          automation.definition.trigger.name === "Row Action",
-        callback: duplicateAutomation,
-      },
-      {
-        icon: automation.disabled ? "CheckmarkCircle" : "Cancel",
-        name: automation.disabled ? "Activate" : "Pause",
-        keyBind: null,
-        visible: true,
-        disabled: false,
-        callback: () => {
-          automationStore.actions.toggleDisabled(
-            automation._id,
-            automation.disabled
-          )
-        },
-      },
-    ]
+    })
+    return result
   }
 
   const openContextMenu = e => {

--- a/packages/builder/src/components/automation/AutomationPanel/AutomationNavItem.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationNavItem.svelte
@@ -57,7 +57,9 @@
         name: "Duplicate",
         keyBind: null,
         visible: true,
-        disabled: automation.definition.trigger.name === "Webhook",
+        disabled:
+          automation.definition.trigger.name === "Webhook" ||
+          automation.definition.trigger.name === "Row Action",
         callback: duplicateAutomation,
       },
       {

--- a/packages/builder/src/components/automation/AutomationPanel/AutomationNavItem.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationNavItem.svelte
@@ -6,6 +6,7 @@
     contextMenuStore,
   } from "stores/builder"
   import { notifications, Icon } from "@budibase/bbui"
+  import { sdk } from "@budibase/shared-core"
   import ConfirmDialog from "components/common/ConfirmDialog.svelte"
   import UpdateAutomationModal from "components/automation/AutomationPanel/UpdateAutomationModal.svelte"
   import NavItem from "components/common/NavItem.svelte"
@@ -35,7 +36,7 @@
   }
 
   const getContextMenuItems = () => {
-    const isRowAction = automation.definition.trigger.name === "Row Action"
+    const isRowAction = sdk.automations.isRowAction(automation)
     const result = []
     if (!isRowAction) {
       result.push(

--- a/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
@@ -19,13 +19,13 @@
     })
     .map(automation => ({
       ...automation,
-      name:
+      displayName:
         $automationStore.automationDisplayData[automation._id].displayName ||
         automation.name,
     }))
     .sort((a, b) => {
-      const lowerA = a.name.toLowerCase()
-      const lowerB = b.name.toLowerCase()
+      const lowerA = a.displayName.toLowerCase()
+      const lowerB = b.displayName.toLowerCase()
       return lowerA > lowerB ? 1 : -1
     })
 

--- a/packages/builder/src/stores/builder/automations.js
+++ b/packages/builder/src/stores/builder/automations.js
@@ -104,19 +104,8 @@ const automationActions = store => ({
   },
   save: async automation => {
     const response = await API.updateAutomation(automation)
-    store.update(state => {
-      const updatedAutomation = response.automation
-      const existingIdx = state.automations.findIndex(
-        existing => existing._id === automation._id
-      )
-      if (existingIdx !== -1) {
-        state.automations.splice(existingIdx, 1, updatedAutomation)
-        return state
-      } else {
-        state.automations = [...state.automations, updatedAutomation]
-      }
-      return state
-    })
+
+    await store.actions.fetch()
     return response.automation
   },
   delete: async automation => {

--- a/packages/server/src/api/controllers/automation.ts
+++ b/packages/server/src/api/controllers/automation.ts
@@ -99,7 +99,7 @@ export async function destroy(ctx: UserCtx<void, DeleteAutomationResponse>) {
   if (
     automation.definition.trigger.stepId === AutomationTriggerStepId.ROW_ACTION
   ) {
-    ctx.throw("Row actions cannot be deleted", 403)
+    ctx.throw("Row actions cannot be deleted", 400)
   }
 
   ctx.body = await sdk.automations.remove(automationId, ctx.params.rev)

--- a/packages/server/src/api/controllers/automation.ts
+++ b/packages/server/src/api/controllers/automation.ts
@@ -1,4 +1,5 @@
 import * as triggers from "../../automations/triggers"
+import { sdk as coreSdk } from "@budibase/shared-core"
 import { DocumentType } from "../../db/utils"
 import { updateTestHistory, removeDeprecated } from "../../automations/utils"
 import { setTestFlag, clearTestFlag } from "../../utilities/redis"
@@ -12,7 +13,6 @@ import {
   UserCtx,
   DeleteAutomationResponse,
   FetchAutomationResponse,
-  AutomationTriggerStepId,
 } from "@budibase/types"
 import { getActionDefinitions as actionDefs } from "../../automations/actions"
 import sdk from "../../sdk"
@@ -96,9 +96,7 @@ export async function destroy(ctx: UserCtx<void, DeleteAutomationResponse>) {
   const automationId = ctx.params.id
 
   const automation = await sdk.automations.get(ctx.params.id)
-  if (
-    automation.definition.trigger.stepId === AutomationTriggerStepId.ROW_ACTION
-  ) {
+  if (coreSdk.automations.isRowAction(automation)) {
     ctx.throw("Row actions cannot be deleted", 400)
   }
 

--- a/packages/server/src/api/controllers/automation.ts
+++ b/packages/server/src/api/controllers/automation.ts
@@ -12,6 +12,7 @@ import {
   UserCtx,
   DeleteAutomationResponse,
   FetchAutomationResponse,
+  AutomationTriggerStepId,
 } from "@budibase/types"
 import { getActionDefinitions as actionDefs } from "../../automations/actions"
 import sdk from "../../sdk"
@@ -93,6 +94,13 @@ export async function find(ctx: UserCtx) {
 
 export async function destroy(ctx: UserCtx<void, DeleteAutomationResponse>) {
   const automationId = ctx.params.id
+
+  const automation = await sdk.automations.get(ctx.params.id)
+  if (
+    automation.definition.trigger.stepId === AutomationTriggerStepId.ROW_ACTION
+  ) {
+    ctx.throw("Row actions cannot be renamed", 403)
+  }
 
   ctx.body = await sdk.automations.remove(automationId, ctx.params.rev)
   builderSocket?.emitAutomationDeletion(ctx, automationId)

--- a/packages/server/src/api/controllers/automation.ts
+++ b/packages/server/src/api/controllers/automation.ts
@@ -97,7 +97,7 @@ export async function destroy(ctx: UserCtx<void, DeleteAutomationResponse>) {
 
   const automation = await sdk.automations.get(ctx.params.id)
   if (coreSdk.automations.isRowAction(automation)) {
-    ctx.throw("Row actions cannot be deleted", 400)
+    ctx.throw("Row actions automations cannot be deleted", 422)
   }
 
   ctx.body = await sdk.automations.remove(automationId, ctx.params.rev)

--- a/packages/server/src/api/controllers/automation.ts
+++ b/packages/server/src/api/controllers/automation.ts
@@ -99,7 +99,7 @@ export async function destroy(ctx: UserCtx<void, DeleteAutomationResponse>) {
   if (
     automation.definition.trigger.stepId === AutomationTriggerStepId.ROW_ACTION
   ) {
-    ctx.throw("Row actions cannot be renamed", 403)
+    ctx.throw("Row actions cannot be deleted", 403)
   }
 
   ctx.body = await sdk.automations.remove(automationId, ctx.params.rev)

--- a/packages/server/src/api/routes/tests/automation.spec.ts
+++ b/packages/server/src/api/routes/tests/automation.spec.ts
@@ -433,7 +433,7 @@ describe("/automations", () => {
         .delete(`/api/automations/${automation._id}/${automation._rev}`)
         .set(config.defaultHeaders())
         .expect("Content-Type", /json/)
-        .expect(403, { message: "Row actions cannot be deleted", status: 403 })
+        .expect(400, { message: "Row actions cannot be deleted", status: 400 })
 
       expect(events.automation.deleted).not.toHaveBeenCalled()
     })

--- a/packages/server/src/api/routes/tests/automation.spec.ts
+++ b/packages/server/src/api/routes/tests/automation.spec.ts
@@ -425,6 +425,19 @@ describe("/automations", () => {
       expect(events.automation.deleted).toHaveBeenCalledTimes(1)
     })
 
+    it("cannot delete a row action automation", async () => {
+      const automation = await config.createAutomation(
+        setup.structures.rowActionAutomation()
+      )
+      await request
+        .delete(`/api/automations/${automation._id}/${automation._rev}`)
+        .set(config.defaultHeaders())
+        .expect("Content-Type", /json/)
+        .expect(403, { message: "Row actions cannot be deleted", status: 403 })
+
+      expect(events.automation.deleted).not.toHaveBeenCalled()
+    })
+
     it("should apply authorization to endpoint", async () => {
       const automation = await config.createAutomation()
       await checkBuilderEndpoint({

--- a/packages/server/src/api/routes/tests/automation.spec.ts
+++ b/packages/server/src/api/routes/tests/automation.spec.ts
@@ -433,7 +433,10 @@ describe("/automations", () => {
         .delete(`/api/automations/${automation._id}/${automation._rev}`)
         .set(config.defaultHeaders())
         .expect("Content-Type", /json/)
-        .expect(400, { message: "Row actions cannot be deleted", status: 400 })
+        .expect(422, {
+          message: "Row actions automations cannot be deleted",
+          status: 422,
+        })
 
       expect(events.automation.deleted).not.toHaveBeenCalled()
     })

--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -1,4 +1,9 @@
-import { Automation, Webhook, WebhookActionType } from "@budibase/types"
+import {
+  Automation,
+  AutomationTriggerStepId,
+  Webhook,
+  WebhookActionType,
+} from "@budibase/types"
 import { generateAutomationID, getAutomationParams } from "../../../db/utils"
 import { deleteEntityMetadata } from "../../../utilities"
 import { MetadataTypes } from "../../../constants"
@@ -117,7 +122,6 @@ export async function create(automation: Automation) {
 
 export async function update(automation: Automation) {
   automation = { ...automation }
-
   if (!automation._id || !automation._rev) {
     throw new HTTPError("_id or _rev fields missing", 400)
   }
@@ -281,4 +285,14 @@ function guardInvalidUpdatesAndThrow(
       }
     })
   }
+
+  if (isRowAction(automation) && automation.name !== oldAutomation.name) {
+    throw new Error("Row actions cannot be renamed")
+  }
+}
+
+function isRowAction(automation: Automation) {
+  const result =
+    automation.definition.trigger.stepId === AutomationTriggerStepId.ROW_ACTION
+  return result
 }

--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -1,9 +1,5 @@
-import {
-  Automation,
-  AutomationTriggerStepId,
-  Webhook,
-  WebhookActionType,
-} from "@budibase/types"
+import { Automation, Webhook, WebhookActionType } from "@budibase/types"
+import { sdk } from "@budibase/shared-core"
 import { generateAutomationID, getAutomationParams } from "../../../db/utils"
 import { deleteEntityMetadata } from "../../../utilities"
 import { MetadataTypes } from "../../../constants"
@@ -286,13 +282,10 @@ function guardInvalidUpdatesAndThrow(
     })
   }
 
-  if (isRowAction(automation) && automation.name !== oldAutomation.name) {
+  if (
+    sdk.automations.isRowAction(automation) &&
+    automation.name !== oldAutomation.name
+  ) {
     throw new Error("Row actions cannot be renamed")
   }
-}
-
-function isRowAction(automation: Automation) {
-  const result =
-    automation.definition.trigger.stepId === AutomationTriggerStepId.ROW_ACTION
-  return result
 }

--- a/packages/server/src/sdk/app/automations/utils.ts
+++ b/packages/server/src/sdk/app/automations/utils.ts
@@ -2,9 +2,9 @@ import {
   Automation,
   AutomationActionStepId,
   AutomationBuilderData,
-  AutomationTriggerStepId,
   TableRowActions,
 } from "@budibase/types"
+import { sdk as coreSdk } from "@budibase/shared-core"
 
 export function checkForCollectStep(automation: Automation) {
   return automation.definition.steps.some(
@@ -39,14 +39,13 @@ export async function getBuilderData(
 
   const result: Record<string, AutomationBuilderData> = {}
   for (const automation of automations) {
-    const { trigger } = automation.definition
-    const isRowAction = trigger.stepId === AutomationTriggerStepId.ROW_ACTION
+    const isRowAction = coreSdk.automations.isRowAction(automation)
     if (!isRowAction) {
       result[automation._id!] = { displayName: automation.name }
       continue
     }
 
-    const { tableId, rowActionId } = trigger.inputs
+    const { tableId, rowActionId } = automation.definition.trigger.inputs
 
     const tableName = await getTableName(tableId)
 

--- a/packages/server/src/tests/utilities/structures.ts
+++ b/packages/server/src/tests/utilities/structures.ts
@@ -158,7 +158,10 @@ export function automationTrigger(
   }
 }
 
-export function newAutomation({ steps, trigger }: any = {}) {
+export function newAutomation({
+  steps,
+  trigger,
+}: { steps?: AutomationStep[]; trigger?: AutomationTrigger } = {}) {
   const automation = basicAutomation()
 
   if (trigger) {
@@ -173,6 +176,16 @@ export function newAutomation({ steps, trigger }: any = {}) {
     automation.definition.steps = [automationStep()]
   }
 
+  return automation
+}
+
+export function rowActionAutomation() {
+  const automation = newAutomation({
+    trigger: {
+      ...automationTrigger(),
+      stepId: AutomationTriggerStepId.ROW_ACTION,
+    },
+  })
   return automation
 }
 

--- a/packages/shared-core/src/sdk/documents/automations.ts
+++ b/packages/shared-core/src/sdk/documents/automations.ts
@@ -1,0 +1,7 @@
+import { Automation, AutomationTriggerStepId } from "@budibase/types"
+
+export function isRowAction(automation: Automation) {
+  const result =
+    automation.definition.trigger.stepId === AutomationTriggerStepId.ROW_ACTION
+  return result
+}

--- a/packages/shared-core/src/sdk/documents/index.ts
+++ b/packages/shared-core/src/sdk/documents/index.ts
@@ -1,2 +1,3 @@
 export * as applications from "./applications"
+export * as automations from "./automations"
 export * as users from "./users"


### PR DESCRIPTION
## Description
Prevent deleting and editing row actions via the frontend (and via the API)

## Addresses
- [BUDI-8430 - Row action API - auto-create automation](https://linear.app/budibase/issue/BUDI-8430/row-action-api-auto-create-automation)

## Screenshots
<img width="1215" alt="image" src="https://github.com/user-attachments/assets/67f8011b-79da-4924-998c-6f126a73c893">

<img width="1215" alt="image" src="https://github.com/user-attachments/assets/4b0f42c0-18ac-4cdb-b6ce-75ff41dbb61f">

<img width="1215" alt="image" src="https://github.com/user-attachments/assets/df65fd88-7d0d-4375-9100-e96e985a1e2b">
