### PR TITLE
Fix for ButtonGroup Bindings.

### DIFF
--- a/packages/builder/src/components/design/settings/controls/DraggableList/DraggableList.svelte
+++ b/packages/builder/src/components/design/settings/controls/DraggableList/DraggableList.svelte
@@ -12,7 +12,6 @@
   export let listItemKey
   export let draggable = true
   export let focus
-  export let bindings = []
 
   let zoneType = generate()
 
@@ -127,7 +126,6 @@
           anchor={anchors[draggableItem.id]}
           item={draggableItem.item}
           {...listTypeProps}
-          {bindings}
           on:change={onItemChanged}
         />
       </div>

--- a/packages/builder/src/components/design/settings/controls/GridColumnConfiguration/GridColumnConfiguration.svelte
+++ b/packages/builder/src/components/design/settings/controls/GridColumnConfiguration/GridColumnConfiguration.svelte
@@ -64,7 +64,9 @@
   items={columns.sortable}
   listItemKey={"_id"}
   listType={FieldSetting}
-  {bindings}
+  listTypeProps={{
+    bindings,
+  }}
 />
 
 <style>


### PR DESCRIPTION
## Description
Fix for ButtonGroup bindings in the builder. 

## Addresses 
- The `bindings` prop was being overridden and cleared for components using the `DraggableList` for nested settings in the builder.
- The `GridColumnConfiguration` has been updated to pass its bindings via the `listTypeProps` prop instead.

## Launchcontrol
Fix for ButtonGroup binding config.