### PR TITLE
Fix failing test due testcontainer conflicts

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Pull testcontainers images
         run: |
-          docker pull mcr.microsoft.com/mssql/server:2022-latest &
+          docker pull mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04 &
           docker pull mysql:8.3 &
           docker pull postgres:16.1-bullseye &
           docker pull mongo:7.0-jammy &

--- a/nx.json
+++ b/nx.json
@@ -10,7 +10,18 @@
   },
   "targetDefaults": {
     "build": {
-      "inputs": ["{workspaceRoot}/scripts/*", "{workspaceRoot}/lerna.json"]
+      "inputs": [
+        "{workspaceRoot}/scripts/*",
+        "{workspaceRoot}/lerna.json",
+        "{workspaceRoot}/.github/workflows/*"
+      ]
+    },
+    "test": {
+      "inputs": [
+        "{workspaceRoot}/scripts/*",
+        "{workspaceRoot}/lerna.json",
+        "{workspaceRoot}/.github/workflows/*"
+      ]
     }
   },
   "namedInputs": {

--- a/packages/server/src/integrations/tests/utils/mssql.ts
+++ b/packages/server/src/integrations/tests/utils/mssql.ts
@@ -9,7 +9,9 @@ let ports: Promise<testContainerUtils.Port[]>
 export async function getDatasource(): Promise<Datasource> {
   if (!ports) {
     ports = startContainer(
-      new GenericContainer("mcr.microsoft.com/mssql/server:2022-latest")
+      new GenericContainer(
+        "mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04"
+      )
         .withExposedPorts(1433)
         .withEnvironment({
           ACCEPT_EULA: "Y",
@@ -22,7 +24,7 @@ export async function getDatasource(): Promise<Datasource> {
         })
         .withWaitStrategy(
           Wait.forSuccessfulCommand(
-            "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P Password_123 -q 'SELECT 1'"
+            "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password_123 -q 'SELECT 1'"
           )
         )
     )

--- a/packages/server/src/integrations/tests/utils/mssql.ts
+++ b/packages/server/src/integrations/tests/utils/mssql.ts
@@ -22,7 +22,7 @@ export async function getDatasource(): Promise<Datasource> {
         })
         .withWaitStrategy(
           Wait.forSuccessfulCommand(
-            "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password_123 -q 'SELECT 1'"
+            "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P Password_123 -q 'SELECT 1'"
           )
         )
     )


### PR DESCRIPTION
## Description
Fixing mssql testcontainer wait strategy. The image has been updated and the script was broken, not allowing starting the containers properly. Changing the tag to not the latest fixes it temporarily.