### PR TITLE
Fix importing internal tables

### DIFF
--- a/packages/server/src/api/controllers/table/internal.ts
+++ b/packages/server/src/api/controllers/table/internal.ts
@@ -25,6 +25,8 @@ export async function save(
     sourceType: rest.sourceType || TableSourceType.INTERNAL,
   }
 
+  const isImport = !!rows
+
   if (!tableToSave.views) {
     tableToSave.views = {}
   }
@@ -35,6 +37,7 @@ export async function save(
       rowsToImport: rows,
       tableId: ctx.request.body._id,
       renaming,
+      isImport,
     })
 
     return table

--- a/packages/server/src/sdk/app/tables/internal/index.ts
+++ b/packages/server/src/sdk/app/tables/internal/index.ts
@@ -31,7 +31,7 @@ export async function save(
     tableId?: string
     rowsToImport?: Row[]
     renaming?: RenameColumn
-    isImport: boolean
+    isImport?: boolean
   }
 ) {
   const db = context.getAppDB()

--- a/packages/server/src/sdk/app/tables/internal/index.ts
+++ b/packages/server/src/sdk/app/tables/internal/index.ts
@@ -49,7 +49,7 @@ export async function save(
 
   // check for case sensitivity - we don't want to allow duplicated columns
   const duplicateColumn = findDuplicateInternalColumns(table, {
-    internalRowsAllowed: !!opts?.isImport,
+    ignoreProtectedColumnNames: !oldTable && !!opts?.isImport,
   })
   if (duplicateColumn.length) {
     throw new Error(

--- a/packages/server/src/sdk/app/tables/internal/index.ts
+++ b/packages/server/src/sdk/app/tables/internal/index.ts
@@ -31,6 +31,7 @@ export async function save(
     tableId?: string
     rowsToImport?: Row[]
     renaming?: RenameColumn
+    isImport: boolean
   }
 ) {
   const db = context.getAppDB()
@@ -47,7 +48,9 @@ export async function save(
   }
 
   // check for case sensitivity - we don't want to allow duplicated columns
-  const duplicateColumn = findDuplicateInternalColumns(table)
+  const duplicateColumn = findDuplicateInternalColumns(table, {
+    internalRowsAllowed: !!opts?.isImport,
+  })
   if (duplicateColumn.length) {
     throw new Error(
       `Column(s) "${duplicateColumn.join(

--- a/packages/shared-core/src/table.ts
+++ b/packages/shared-core/src/table.ts
@@ -55,7 +55,7 @@ export function canBeSortColumn(type: FieldType): boolean {
 
 export function findDuplicateInternalColumns(
   table: Table,
-  opts?: { internalRowsAllowed: boolean }
+  opts?: { ignoreProtectedColumnNames: boolean }
 ): string[] {
   // maintains the case of keys
   const casedKeys = Object.keys(table.schema)
@@ -72,7 +72,7 @@ export function findDuplicateInternalColumns(
       }
     }
   }
-  if (!opts?.internalRowsAllowed) {
+  if (!opts?.ignoreProtectedColumnNames) {
     for (let internalColumn of CONSTANT_INTERNAL_ROW_COLS) {
       if (casedKeys.find(key => key === internalColumn)) {
         duplicates.push(internalColumn)

--- a/packages/shared-core/src/table.ts
+++ b/packages/shared-core/src/table.ts
@@ -53,7 +53,10 @@ export function canBeSortColumn(type: FieldType): boolean {
   return !!allowSortColumnByType[type]
 }
 
-export function findDuplicateInternalColumns(table: Table): string[] {
+export function findDuplicateInternalColumns(
+  table: Table,
+  opts?: { internalRowsAllowed: boolean }
+): string[] {
   // maintains the case of keys
   const casedKeys = Object.keys(table.schema)
   // get the column names
@@ -69,9 +72,11 @@ export function findDuplicateInternalColumns(table: Table): string[] {
       }
     }
   }
-  for (let internalColumn of CONSTANT_INTERNAL_ROW_COLS) {
-    if (casedKeys.find(key => key === internalColumn)) {
-      duplicates.push(internalColumn)
+  if (!opts?.internalRowsAllowed) {
+    for (let internalColumn of CONSTANT_INTERNAL_ROW_COLS) {
+      if (casedKeys.find(key => key === internalColumn)) {
+        duplicates.push(internalColumn)
+      }
     }
   }
   return duplicates


### PR DESCRIPTION
## Description
With the recent fixes preventing duplicated table ids, internal tables imports are broken. The checks are preventing using protected column names such as `_id`, but the export/import should support it.

## Launchcontrol
Fix importing internal tables with protected column names such as `_id`