### PR TITLE
"Create screen" component context option

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ComponentList/ComponentKeyHandler.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ComponentList/ComponentKeyHandler.svelte
@@ -5,6 +5,7 @@
     componentStore,
     selectedComponent,
     componentTreeNodesStore,
+    screenStore,
   } from "stores/builder"
   import { findComponent, getChildIdsForComponent } from "helpers/components"
   import { goto, isActive } from "@roxi/routify"
@@ -47,6 +48,14 @@
     },
     ["Ctrl+Enter"]: () => {
       $goto(`./:componentId/new`)
+    },
+    ["CloneNodeToScreen"]: async component => {
+      const newScreen = await screenStore.createScreenFromComponent(component)
+      if (newScreen) {
+        notifications.success("Created screen successfully")
+      } else {
+        notifications.error("Error creating screen from selection.")
+      }
     },
     ["Delete"]: component => {
       // Don't show confirmation for the screen itself

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ComponentList/getComponentContextMenuItems.js
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ComponentList/getComponentContextMenuItems.js
@@ -78,6 +78,13 @@ const getContextMenuItems = (component, componentCollapsed) => {
       callback: () => keyboardEvent("v", true),
     },
     {
+      icon: "WebPage",
+      name: "Create screen",
+      visible: true,
+      disabled: false,
+      callback: () => keyboardEvent("CloneNodeToScreen", false),
+    },
+    {
       icon: "Export",
       name: "Eject block",
       keyBind: "Ctrl+E",

--- a/packages/builder/src/pages/builder/app/[application]/design/_components/NewScreen/CreateScreenModal.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/_components/NewScreen/CreateScreenModal.svelte
@@ -12,7 +12,6 @@
     builderStore,
   } from "stores/builder"
   import { auth } from "stores/portal"
-  import { get } from "svelte/store"
   import getTemplates from "templates"
   import { Roles } from "constants/backend"
   import { capitalise } from "helpers"
@@ -53,11 +52,13 @@
 
       for (let screen of screens) {
         // Check we aren't clashing with an existing URL
-        if (hasExistingUrl(screen.routing.route)) {
+        if (
+          screenStore.hasExistingUrl(screen.routing.route, screenAccessRole)
+        ) {
           let suffix = 2
-          let candidateUrl = makeCandidateUrl(screen, suffix)
-          while (hasExistingUrl(candidateUrl)) {
-            candidateUrl = makeCandidateUrl(screen, ++suffix)
+          let candidateUrl = screenStore.makeCandidateUrl(screen, suffix)
+          while (screenStore.hasExistingUrl(candidateUrl, screenAccessRole)) {
+            candidateUrl = screenStore.makeCandidateUrl(screen, ++suffix)
           }
           screen.routing.route = candidateUrl
         }
@@ -88,32 +89,6 @@
     } catch (error) {
       console.error(error)
       notifications.error("Error creating screens")
-    }
-  }
-
-  // Checks if any screens exist in the store with the given route and
-  // currently selected role
-  const hasExistingUrl = url => {
-    const roleId = screenAccessRole
-    const screens = get(screenStore).screens.filter(
-      s => s.routing.roleId === roleId
-    )
-    return !!screens.find(s => s.routing?.route === url)
-  }
-
-  // Constructs a candidate URL for a new screen, suffixing the base of the
-  // screen's URL with a given suffix.
-  // e.g. "/sales/:id" => "/sales-1/:id"
-  const makeCandidateUrl = (screen, suffix) => {
-    let url = screen.routing?.route || ""
-    if (url.startsWith("/")) {
-      url = url.slice(1)
-    }
-    if (!url.includes("/")) {
-      return `/${url}-${suffix}`
-    } else {
-      const split = url.split("/")
-      return `/${split[0]}-${suffix}/${split.slice(1).join("/")}`
     }
   }
 

--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -46,11 +46,24 @@
   // Provide contexts
   setContext("sdk", SDK)
   setContext("component", writable({ id: null, ancestors: [] }))
-  setContext("context", createContextStore())
+
+  const globalContext = createContextStore()
+  setContext("context", globalContext)
 
   let dataLoaded = false
   let permissionError = false
   let embedNoScreens = false
+  let cachedActiveScreenId
+
+  // Clear component context entries from the global context
+  // when the active page changes.
+  const purgeGlobalComponentContext = screenId => {
+    if (!screenId || cachedActiveScreenId == screenId) return
+    cachedActiveScreenId = screenId
+    globalContext.actions.clearComponentContext()
+  }
+
+  $: purgeGlobalComponentContext($screenStore?.activeScreen?._id)
 
   // Determine if we should show devtools or not
   $: showDevTools = $devToolsEnabled && !$routeStore.queryParams?.peek

--- a/packages/client/src/stores/context.js
+++ b/packages/client/src/stores/context.js
@@ -60,12 +60,45 @@ export const createContextStore = parentContext => {
     observers.forEach(cb => cb(key))
   }
 
+  /**
+   * Purge the global context of any component entries
+   *
+   * rowSelection (Legacy) - used by the old Table component.
+   */
+  const clearComponentContext = () => {
+    context.update(ctx => {
+      const {
+        device,
+        snippets,
+        user,
+        user_RefreshDatasource,
+        state,
+        query,
+        url,
+        rowSelection,
+      } = {
+        ...ctx,
+      }
+      return {
+        device,
+        snippets,
+        user,
+        user_RefreshDatasource,
+        state,
+        query,
+        url,
+        rowSelection,
+      }
+    })
+  }
+
   return {
     subscribe: totalContext.subscribe,
     actions: {
       provideData,
       provideAction,
       observeChanges,
+      clearComponentContext,
     },
   }
 }


### PR DESCRIPTION
## Description
A `Create screen` option has been added to the component context menu in the builder. Selecting the option will:
- Generate a brand new screen with the `Basic` role
- Clone the selected component and place it in the the screen.
- The default screen path will be `/new-screen`. If you create multiple screens in a row a suffix will be appended to avoid collision e.g. `/new-screen-2`

## Addresses
- `Fix` - component context options were being cached between screens. When pasting or cloning into new screens, it wasn't immediately clear what elements had become broken due to broken context references until full page refresh. The component options will now clear when the active screen is changed.
- Minor refactoring of the screen store to centralise some screen autogeneration functionality.

## Screenshots
![Screenshot 2024-07-26 at 14 58 07](https://github.com/user-attachments/assets/fd3b74a1-0774-4ada-9976-894f879665cb)

## Launchcontrol
Create a new screen from a selected component