### PR TITLE
Fix to accomodate automations without triggers

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowChart.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowChart.svelte
@@ -54,6 +54,7 @@
   </div>
   <div class="controls">
     <div
+      class:disabled={!$selectedAutomation?.definition?.trigger}
       on:click={() => {
         testDataModal.show()
       }}
@@ -80,6 +81,7 @@
           automation._id,
           automation.disabled
         )}
+        disabled={!$selectedAutomation?.definition?.trigger}
         value={!automation.disabled}
       />
     </div>

--- a/packages/builder/src/components/automation/AutomationPanel/AutomationNavItem.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationNavItem.svelte
@@ -54,7 +54,7 @@
             name: "Edit",
             keyBind: null,
             visible: true,
-            disabled: false,
+            disabled: !automation.definition.trigger,
             callback: updateAutomationDialog.show,
           },
           {
@@ -62,7 +62,9 @@
             name: "Duplicate",
             keyBind: null,
             visible: true,
-            disabled: automation.definition.trigger.name === "Webhook",
+            disabled:
+              !automation.definition.trigger ||
+              automation.definition.trigger?.name === "Webhook",
             callback: duplicateAutomation,
           },
         ]
@@ -74,7 +76,7 @@
       name: automation.disabled ? "Activate" : "Pause",
       keyBind: null,
       visible: true,
-      disabled: false,
+      disabled: !automation.definition.trigger,
       callback: () => {
         automationStore.actions.toggleDisabled(
           automation._id,

--- a/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
@@ -30,12 +30,13 @@
     })
 
   $: groupedAutomations = filteredAutomations.reduce((acc, auto) => {
-    acc[auto.definition.trigger.event] ??= {
-      icon: auto.definition.trigger.icon,
-      name: (auto.definition.trigger?.name || "").toUpperCase(),
+    const catName = auto.definition?.trigger?.event || "No Trigger"
+    acc[catName] ??= {
+      icon: auto.definition?.trigger?.icon || "AlertCircle",
+      name: (auto.definition?.trigger?.name || "No Trigger").toUpperCase(),
       entries: [],
     }
-    acc[auto.definition.trigger.event].entries.push(auto)
+    acc[catName].entries.push(auto)
     return acc
   }, {})
 


### PR DESCRIPTION
## Description

In the unlikely scenario that an automation somehow doesn't have its `trigger` specified, the builder would throw an error. This fix allows the builder to better react in this situation and group these automations under a `No Trigger` category in the automation screen. Anything that requires an explicit trigger to be specified is now blocked if it isn't configured

## Addresses
- https://github.com/Budibase/budibase/issues/14262

## Screenshots
Automations without a trigger grouped under the "No Trigger" category
<img width="300" src="https://github.com/user-attachments/assets/393a6f89-99b6-4355-9181-14d1479485d7" />

Actions disabled for automations without a trigger.
![Screenshot 2024-07-30 at 12 08 03](https://github.com/user-attachments/assets/81f58954-f650-4974-bdff-5c7b0b498302)

Disabled context menu entries
![Screenshot 2024-07-30 at 12 10 41](https://github.com/user-attachments/assets/3120fe6c-6720-4d0c-823a-0aea57f7b0cd)

## Launchcontrol
Fix to accommodate automations if they do not have a trigger configured.