### PR TITLE
Disallow adding row action automations

### DIFF
--- a/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
@@ -20,7 +20,7 @@
     .map(automation => ({
       ...automation,
       displayName:
-        $automationStore.automationDisplayData[automation._id].displayName ||
+        $automationStore.automationDisplayData[automation._id]?.displayName ||
         automation.name,
     }))
     .sort((a, b) => {

--- a/packages/builder/src/components/automation/AutomationPanel/CreateAutomationModal.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/CreateAutomationModal.svelte
@@ -21,7 +21,9 @@
 
   $: nameError =
     nameTouched && !name ? "Please specify a name for the automation." : null
-  $: triggers = Object.entries($automationStore.blockDefinitions.TRIGGER)
+  $: triggers = Object.entries(
+    $automationStore.blockDefinitions.CREATABLE_TRIGGER
+  )
 
   async function createAutomation() {
     try {

--- a/packages/builder/src/components/backend/DataTable/buttons/grid/GridCreateAutomationButton.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/GridCreateAutomationButton.svelte
@@ -13,7 +13,7 @@
 
   const { datasource } = getContext("grid")
 
-  $: triggers = $automationStore.blockDefinitions.TRIGGER
+  $: triggers = $automationStore.blockDefinitions.CREATABLE_TRIGGER
 
   $: table = $tables.list.find(table => table._id === $datasource.tableId)
 

--- a/packages/server/src/api/controllers/automation.ts
+++ b/packages/server/src/api/controllers/automation.ts
@@ -1,10 +1,7 @@
 import * as triggers from "../../automations/triggers"
 import { sdk as coreSdk } from "@budibase/shared-core"
 import { DocumentType } from "../../db/utils"
-import {
-  updateTestHistory,
-  removeInvalidDefinitions,
-} from "../../automations/utils"
+import { updateTestHistory, removeDeprecated } from "../../automations/utils"
 import { setTestFlag, clearTestFlag } from "../../utilities/redis"
 import { context, cache, events, db as dbCore } from "@budibase/backend-core"
 import { automations, features } from "@budibase/pro"
@@ -23,11 +20,11 @@ import { builderSocket } from "../../websockets"
 import env from "../../environment"
 
 async function getActionDefinitions() {
-  return removeInvalidDefinitions(await actionDefs())
+  return removeDeprecated(await actionDefs())
 }
 
 function getTriggerDefinitions() {
-  return removeInvalidDefinitions(triggers.TRIGGER_DEFINITIONS)
+  return removeDeprecated(triggers.TRIGGER_DEFINITIONS)
 }
 
 /*************************

--- a/packages/server/src/api/controllers/automation.ts
+++ b/packages/server/src/api/controllers/automation.ts
@@ -1,7 +1,10 @@
 import * as triggers from "../../automations/triggers"
 import { sdk as coreSdk } from "@budibase/shared-core"
 import { DocumentType } from "../../db/utils"
-import { updateTestHistory, removeDeprecated } from "../../automations/utils"
+import {
+  updateTestHistory,
+  removeInvalidDefinitions,
+} from "../../automations/utils"
 import { setTestFlag, clearTestFlag } from "../../utilities/redis"
 import { context, cache, events, db as dbCore } from "@budibase/backend-core"
 import { automations, features } from "@budibase/pro"
@@ -20,11 +23,11 @@ import { builderSocket } from "../../websockets"
 import env from "../../environment"
 
 async function getActionDefinitions() {
-  return removeDeprecated(await actionDefs())
+  return removeInvalidDefinitions(await actionDefs())
 }
 
 function getTriggerDefinitions() {
-  return removeDeprecated(triggers.TRIGGER_DEFINITIONS)
+  return removeInvalidDefinitions(triggers.TRIGGER_DEFINITIONS)
 }
 
 /*************************

--- a/packages/server/src/api/routes/tests/automation.spec.ts
+++ b/packages/server/src/api/routes/tests/automation.spec.ts
@@ -14,6 +14,7 @@ import sdk from "../../../sdk"
 import { Automation, FieldType, Table } from "@budibase/types"
 import { mocks } from "@budibase/backend-core/tests"
 import { FilterConditions } from "../../../automations/steps/filter"
+import { removeInvalidDefinitions } from "../../../automations/utils"
 
 const MAX_RETRIES = 4
 let {
@@ -69,14 +70,15 @@ describe("/automations", () => {
         .expect("Content-Type", /json/)
         .expect(200)
 
-      let definitionsLength = Object.keys(BUILTIN_ACTION_DEFINITIONS).length
-      definitionsLength-- // OUTGOING_WEBHOOK is deprecated
+      let definitionsLength = Object.keys(
+        removeInvalidDefinitions(BUILTIN_ACTION_DEFINITIONS)
+      ).length
 
       expect(Object.keys(res.body.action).length).toBeGreaterThanOrEqual(
         definitionsLength
       )
       expect(Object.keys(res.body.trigger).length).toEqual(
-        Object.keys(TRIGGER_DEFINITIONS).length
+        Object.keys(removeInvalidDefinitions(TRIGGER_DEFINITIONS)).length
       )
     })
   })

--- a/packages/server/src/api/routes/tests/automation.spec.ts
+++ b/packages/server/src/api/routes/tests/automation.spec.ts
@@ -14,7 +14,7 @@ import sdk from "../../../sdk"
 import { Automation, FieldType, Table } from "@budibase/types"
 import { mocks } from "@budibase/backend-core/tests"
 import { FilterConditions } from "../../../automations/steps/filter"
-import { removeInvalidDefinitions } from "../../../automations/utils"
+import { removeDeprecated } from "../../../automations/utils"
 
 const MAX_RETRIES = 4
 let {
@@ -71,14 +71,14 @@ describe("/automations", () => {
         .expect(200)
 
       let definitionsLength = Object.keys(
-        removeInvalidDefinitions(BUILTIN_ACTION_DEFINITIONS)
+        removeDeprecated(BUILTIN_ACTION_DEFINITIONS)
       ).length
 
       expect(Object.keys(res.body.action).length).toBeGreaterThanOrEqual(
         definitionsLength
       )
       expect(Object.keys(res.body.trigger).length).toEqual(
-        Object.keys(removeInvalidDefinitions(TRIGGER_DEFINITIONS)).length
+        Object.keys(removeDeprecated(TRIGGER_DEFINITIONS)).length
       )
     })
   })

--- a/packages/server/src/automations/utils.ts
+++ b/packages/server/src/automations/utils.ts
@@ -9,10 +9,8 @@ import { cloneDeep } from "lodash/fp"
 import { quotas } from "@budibase/pro"
 import {
   Automation,
-  AutomationActionStepId,
   AutomationJob,
   AutomationStepSchema,
-  AutomationTriggerStepId,
 } from "@budibase/types"
 import { automationsEnabled } from "../features"
 import { helpers, REBOOT_CRON } from "@budibase/shared-core"

--- a/packages/server/src/automations/utils.ts
+++ b/packages/server/src/automations/utils.ts
@@ -3,11 +3,17 @@ import { definitions } from "./triggerInfo"
 import { automationQueue } from "./bullboard"
 import { updateEntityMetadata } from "../utilities"
 import { MetadataTypes } from "../constants"
-import { db as dbCore, context, utils } from "@budibase/backend-core"
+import { context, db as dbCore, utils } from "@budibase/backend-core"
 import { getAutomationMetadataParams } from "../db/utils"
 import { cloneDeep } from "lodash/fp"
 import { quotas } from "@budibase/pro"
-import { Automation, AutomationJob } from "@budibase/types"
+import {
+  Automation,
+  AutomationActionStepId,
+  AutomationJob,
+  AutomationStepSchema,
+  AutomationTriggerStepId,
+} from "@budibase/types"
 import { automationsEnabled } from "../features"
 import { helpers, REBOOT_CRON } from "@budibase/shared-core"
 import tracer from "dd-trace"
@@ -111,10 +117,16 @@ export async function updateTestHistory(
   )
 }
 
-export function removeDeprecated(definitions: any) {
+export function removeInvalidDefinitions(
+  definitions: Record<string, AutomationStepSchema>
+) {
+  const disallowedStepIds: (
+    | AutomationTriggerStepId
+    | AutomationActionStepId
+  )[] = [AutomationTriggerStepId.ROW_ACTION]
   const base = cloneDeep(definitions)
   for (let key of Object.keys(base)) {
-    if (base[key].deprecated) {
+    if (base[key].deprecated || disallowedStepIds.includes(base[key].stepId)) {
       delete base[key]
     }
   }

--- a/packages/server/src/automations/utils.ts
+++ b/packages/server/src/automations/utils.ts
@@ -117,16 +117,12 @@ export async function updateTestHistory(
   )
 }
 
-export function removeInvalidDefinitions(
+export function removeDeprecated(
   definitions: Record<string, AutomationStepSchema>
 ) {
-  const disallowedStepIds: (
-    | AutomationTriggerStepId
-    | AutomationActionStepId
-  )[] = [AutomationTriggerStepId.ROW_ACTION]
   const base = cloneDeep(definitions)
   for (let key of Object.keys(base)) {
-    if (base[key].deprecated || disallowedStepIds.includes(base[key].stepId)) {
+    if (base[key].deprecated) {
       delete base[key]
     }
   }

--- a/packages/server/src/sdk/app/automations/crud.ts
+++ b/packages/server/src/sdk/app/automations/crud.ts
@@ -87,10 +87,10 @@ export async function fetch() {
       include_docs: true,
     })
   )
-  return response.rows
-    .map(row => row.doc)
-    .filter(doc => !!doc)
-    .map(trimUnexpectedObjectFields)
+  const automations: PersistedAutomation[] = response.rows
+    .filter(row => !!row.doc)
+    .map(row => row.doc!)
+  return automations.map(trimUnexpectedObjectFields)
 }
 
 export async function get(automationId: string) {

--- a/packages/server/src/sdk/app/automations/utils.ts
+++ b/packages/server/src/sdk/app/automations/utils.ts
@@ -29,8 +29,7 @@ export async function getBuilderData(
   const rowActionNameCache: Record<string, TableRowActions> = {}
   async function getRowActionName(tableId: string, rowActionId: string) {
     if (!rowActionNameCache[tableId]) {
-      const rowActions = await sdk.rowActions.get(tableId)
-      rowActionNameCache[tableId] = rowActions
+      rowActionNameCache[tableId] = await sdk.rowActions.get(tableId)
     }
 
     return rowActionNameCache[tableId].actions[rowActionId]?.name
@@ -45,9 +44,11 @@ export async function getBuilderData(
     }
 
     const { tableId, rowActionId } = automation.definition.trigger.inputs
+    if (!tableId || !rowActionId) {
+      continue
+    }
 
     const tableName = await getTableName(tableId)
-
     const rowActionName = await getRowActionName(tableId, rowActionId)
 
     result[automation._id!] = {

--- a/packages/types/src/documents/app/automation.ts
+++ b/packages/types/src/documents/app/automation.ts
@@ -174,9 +174,7 @@ export interface AutomationStepSchema {
   deprecated?: boolean
   stepId: AutomationTriggerStepId | AutomationActionStepId
   blockToLoop?: string
-  inputs: {
-    [key: string]: any
-  }
+  inputs: Record<string, any>
   schema: {
     inputs: InputOutputBlock
     outputs: InputOutputBlock


### PR DESCRIPTION
## Description
Fixes some issues with row actions which were allowing them to be added from the automation section (which is not allowed) as well as breaking app access once they were added - this hides them properly so they can't be added as well as fixing the issue when they exist.