### PR TITLE
Save autofields on bulksaves

### DIFF
--- a/packages/backend-core/src/db/couch/DatabaseImpl.ts
+++ b/packages/backend-core/src/db/couch/DatabaseImpl.ts
@@ -308,8 +308,12 @@ export class DatabaseImpl implements Database {
   }
 
   async bulkDocs(documents: AnyDocument[]) {
+    const now = new Date().toISOString()
     return this.performCall(db => {
-      return () => db.bulk({ docs: documents })
+      return () =>
+        db.bulk({
+          docs: documents.map(d => ({ createdAt: now, ...d, updatedAt: now })),
+        })
     })
   }
 

--- a/packages/backend-core/src/db/couch/tests/DatabaseImpl.spec.ts
+++ b/packages/backend-core/src/db/couch/tests/DatabaseImpl.spec.ts
@@ -1,0 +1,47 @@
+import tk from "timekeeper"
+
+import { DatabaseImpl } from ".."
+
+import { generator, structures } from "../../../../tests"
+
+const initialTime = new Date()
+tk.freeze(initialTime)
+
+describe("DatabaseImpl", () => {
+  const db = new DatabaseImpl(structures.db.id())
+
+  beforeEach(() => {
+    tk.freeze(initialTime)
+  })
+
+  describe("put", () => {
+    it("persists createdAt and updatedAt fields", async () => {
+      const id = generator.guid()
+      await db.put({ _id: id })
+
+      expect(await db.get(id)).toEqual({
+        _id: id,
+        _rev: expect.any(String),
+        createdAt: initialTime.toISOString(),
+        updatedAt: initialTime.toISOString(),
+      })
+    })
+
+    it("updates updated at fields", async () => {
+      const id = generator.guid()
+
+      await db.put({ _id: id })
+      tk.travel(100)
+
+      await db.put({ ...(await db.get(id)), newValue: 123 })
+
+      expect(await db.get(id)).toEqual({
+        _id: id,
+        _rev: expect.any(String),
+        newValue: 123,
+        createdAt: initialTime.toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
+    })
+  })
+})

--- a/packages/backend-core/src/db/couch/tests/DatabaseImpl.spec.ts
+++ b/packages/backend-core/src/db/couch/tests/DatabaseImpl.spec.ts
@@ -44,4 +44,42 @@ describe("DatabaseImpl", () => {
       })
     })
   })
+
+  describe("bulkDocs", () => {
+    it("persists createdAt and updatedAt fields", async () => {
+      const ids = generator.unique(() => generator.guid(), 5)
+      await db.bulkDocs(ids.map(id => ({ _id: id })))
+
+      for (const id of ids) {
+        expect(await db.get(id)).toEqual({
+          _id: id,
+          _rev: expect.any(String),
+          createdAt: initialTime.toISOString(),
+          updatedAt: initialTime.toISOString(),
+        })
+      }
+    })
+
+    it("updates updated at fields", async () => {
+      const ids = generator.unique(() => generator.guid(), 5)
+
+      await db.bulkDocs(ids.map(id => ({ _id: id })))
+      tk.travel(100)
+
+      const docsToUpdate = await Promise.all(
+        ids.map(async id => ({ ...(await db.get(id)), newValue: 123 }))
+      )
+      await db.bulkDocs(docsToUpdate)
+
+      for (const id of ids) {
+        expect(await db.get(id)).toEqual({
+          _id: id,
+          _rev: expect.any(String),
+          newValue: 123,
+          createdAt: initialTime.toISOString(),
+          updatedAt: new Date().toISOString(),
+        })
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Description
We found an issue when writing some tests due to some inconsistencies between `db.put` and `db.bulkPut`.`put` sets `createdAt` and `updatedAt`, but `bulkPut` does not. This PR ensures that we have consistency between both methods.

## Launchcontrol
Persist `createdAt` and `updatedAt` on `bulkPut`