### PR TITLE
Prevent test container name conflicts

### DIFF
--- a/packages/server/src/integrations/tests/utils/index.ts
+++ b/packages/server/src/integrations/tests/utils/index.ts
@@ -77,7 +77,7 @@ export async function startContainer(container: GenericContainer) {
   container = container
     .withReuse()
     .withLabels({ "com.budibase": "true" })
-    .withName(key)
+    .withName(`${key}_testcontainer`)
 
   let startedContainer: StartedTestContainer | undefined = undefined
   let lastError = undefined


### PR DESCRIPTION
## Description
The latest testcontainer implementation resuses containers, and it uses the image name for it. This creates running containers with names such as `postgres` with random ports. On the other side, we have multiple docker-compose to spin up instances for dev, and we use the same names and the standard ports for each image. This causes conflicts when running both.
This PR just renames the docker-container ones to avoid these conflicts

## Launchcontrol
Rename reusable testcontainers to avoid conflicts with other running containers