### PR TITLE
Fix for HTTP 400 issue seen in Datadog logs

### DIFF
--- a/packages/server/src/sdk/app/rows/search/sqs.ts
+++ b/packages/server/src/sdk/app/rows/search/sqs.ts
@@ -72,10 +72,14 @@ function buildInternalFieldList(
     }
     if (isRelationship) {
       const linkCol = col as RelationshipFieldMetadata
-      const relatedTable = tables.find(table => table._id === linkCol.tableId)!
+      const relatedTable = tables.find(table => table._id === linkCol.tableId)
       // no relationships provided, don't go more than a layer deep
-      fieldList = fieldList.concat(buildInternalFieldList(relatedTable, tables))
-      addJunctionFields(relatedTable, ["doc1.fieldName", "doc2.fieldName"])
+      if (relatedTable) {
+        fieldList = fieldList.concat(
+          buildInternalFieldList(relatedTable, tables)
+        )
+        addJunctionFields(relatedTable, ["doc1.fieldName", "doc2.fieldName"])
+      }
     } else {
       fieldList.push(`${table._id}.${mapToUserColumn(col.name)}`)
     }


### PR DESCRIPTION
## Description
Fixing an issue seen when browsing through Datadog error logs for app service.

Error was:
```
TypeError: Cannot read properties of undefined (reading '_id')
    at /app/dist/index.js:220316:55
    at Array.map (<anonymous>)
    at buildInternalFieldList (/app/dist/index.js:220316:32)
    at buildInternalFieldList (/app/dist/index.js:220326:36)
    at search6 (/app/dist/index.js:220472:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async search9 (/app/dist/index.js:223097:14)
    at async search10 (/app/dist/index.js:222853:3)
    at async cleanup_default (/app/dist/index.js:183241:20)
    at async /app/node_modules/koa-compress/lib/index.js:38:5
    at async errorHandling (/app/dist/index.js:157411:5)
    at async /app/node_modules/koa-mount/index.js:52:26
    at async userAgent (/app/node_modules/koa-useragent/dist/index.js:12:5)
```