### PR TITLE
Record SQS queries in DataDog.

### DIFF
--- a/packages/server/src/sdk/app/rows/search/sqs.ts
+++ b/packages/server/src/sdk/app/rows/search/sqs.ts
@@ -227,10 +227,10 @@ async function runSqlQuery(
 
     const db = context.getAppDB()
 
-    return await tracer.trace(
-      "sqs.runSqlQuery",
-      async () => await db.sql<Row>(sql, bindings)
-    )
+    return await tracer.trace("sqs.runSqlQuery", async span => {
+      span?.addTags({ sql })
+      return await db.sql<Row>(sql, bindings)
+    })
   }
   const response = await alias.queryWithAliasing(json, processSQLQuery)
   if (opts?.countTotalRows) {

--- a/packages/server/src/sdk/app/rows/search/sqs.ts
+++ b/packages/server/src/sdk/app/rows/search/sqs.ts
@@ -43,6 +43,7 @@ import {
 } from "./filters"
 import { dataFilters, PROTECTED_INTERNAL_COLUMNS } from "@budibase/shared-core"
 import { isSearchingByRowID } from "./utils"
+import tracer from "dd-trace"
 
 const builder = new sql.Sql(SqlClient.SQL_LITE)
 const MISSING_COLUMN_REGEX = new RegExp(`no such column: .+`)
@@ -225,7 +226,11 @@ async function runSqlQuery(
     }
 
     const db = context.getAppDB()
-    return await db.sql<Row>(sql, bindings)
+
+    return await tracer.trace(
+      "sqs.runSqlQuery",
+      async () => await db.sql<Row>(sql, bindings)
+    )
   }
   const response = await alias.queryWithAliasing(json, processSQLQuery)
   if (opts?.countTotalRows) {


### PR DESCRIPTION
## Description

This PR creates span around SQS queries that records the query being run, to help us debug performance problems in production. Query bindings are not recorded as they may be sensitive.
