### PR TITLE
Make sure to delete SSO ID doc as well

### DIFF
--- a/packages/worker/src/sdk/tenants/tenants.ts
+++ b/packages/worker/src/sdk/tenants/tenants.ts
@@ -48,10 +48,13 @@ async function removeTenantUsers(tenantId: string) {
   try {
     const allUsers = await getTenantUsers(tenantId)
     const allEmails = allUsers.rows.map((row: any) => row.doc.email)
+    const allSsoIds = allUsers.rows
+      .map((row: any) => row.doc.ssoId)
+      .filter(id => !!id)
 
     // get the id and email doc ids
     let keys = allUsers.rows.map((row: any) => row.id)
-    keys = keys.concat(allEmails)
+    keys = keys.concat(allEmails).concat(allSsoIds)
 
     const platformDb = platform.getPlatformDB()
 


### PR DESCRIPTION
## Description
When an account is deleted, it correctly removes associated CouchDB docs based on email address, but it was leaving behind the SSO doc. 
This has been fixed to make sure that the SSO doc is also deleted.

## Launchcontrol
Minor bug fix relating to Microsoft SSO
