### PR TITLE
Added unhandledRejection error handling to koa app

### DIFF
--- a/packages/server/src/koa.ts
+++ b/packages/server/src/koa.ts
@@ -69,6 +69,10 @@ export default function createKoaApp() {
     server.destroy()
   }
 
+  process.on("unhandledRejection", err => {
+    logging.logAlert("Unhandled rejection.", err)
+  })
+
   process.on("uncaughtException", err => {
     // @ts-ignore
     // don't worry about this error, comes from zlib isn't important


### PR DESCRIPTION
## Description

Uncaught promise rejections in the Google Sheets integration would eventually be caught in the `uncaughtException` handler in the koa app. This would then terminate the server.

This fix adds general handling for uncaught rejections in the koa app and logs any events to `bb-alert`

## Addresses
- https://github.com/Budibase/node-google-spreadsheet/pull/2

## Launchcontrol
Add handling for `uncaughtRejection` in the koa app.