### PR TITLE
Fix tables showing up multiple times for Oracle in the datasource info endpoint.

### DIFF
--- a/packages/server/src/api/routes/tests/datasource.spec.ts
+++ b/packages/server/src/api/routes/tests/datasource.spec.ts
@@ -25,7 +25,6 @@ import {
 import { tableForDatasource } from "../../../tests/utilities/structures"
 import nock from "nock"
 import { Knex } from "knex"
-import { uuid } from "@budibase/backend-core/tests/core/utilities/structures"
 
 describe("/datasources", () => {
   const config = setup.getConfig()
@@ -443,9 +442,9 @@ describe("/datasources", () => {
       })
     })
 
-    describe.only("info", () => {
+    describe("info", () => {
       it("should fetch information about a datasource with a single table", async () => {
-        const tableName = uuid()
+        const tableName = generator.guid()
         await client.schema.createTable(tableName, table => {
           table.increments("id").primary()
           table.string("name")
@@ -456,7 +455,12 @@ describe("/datasources", () => {
       })
 
       it("should fetch information about a datasource with multiple tables", async () => {
-        const tableNames = [uuid(), uuid(), uuid(), uuid()]
+        const tableNames = [
+          generator.guid(),
+          generator.guid(),
+          generator.guid(),
+          generator.guid(),
+        ]
         for (const tableName of tableNames) {
           await client.schema.createTable(tableName, table => {
             table.increments("id").primary()

--- a/packages/server/src/api/routes/tests/datasource.spec.ts
+++ b/packages/server/src/api/routes/tests/datasource.spec.ts
@@ -444,6 +444,10 @@ describe("/datasources", () => {
 
     describe("info", () => {
       it("should fetch information about a datasource with a single table", async () => {
+        const existingTableNames = (
+          await config.api.datasource.info(datasource)
+        ).tableNames
+
         const tableName = generator.guid()
         await client.schema.createTable(tableName, table => {
           table.increments("id").primary()
@@ -451,10 +455,17 @@ describe("/datasources", () => {
         })
 
         const info = await config.api.datasource.info(datasource)
-        expect(info.tableNames).toEqual([tableName])
+        expect(info.tableNames).toEqual(
+          expect.arrayContaining([tableName, ...existingTableNames])
+        )
+        expect(info.tableNames).toHaveLength(existingTableNames.length + 1)
       })
 
       it("should fetch information about a datasource with multiple tables", async () => {
+        const existingTableNames = (
+          await config.api.datasource.info(datasource)
+        ).tableNames
+
         const tableNames = [
           generator.guid(),
           generator.guid(),
@@ -469,7 +480,12 @@ describe("/datasources", () => {
         }
 
         const info = await config.api.datasource.info(datasource)
-        expect(info.tableNames).toEqual(expect.arrayContaining(tableNames))
+        expect(info.tableNames).toEqual(
+          expect.arrayContaining([...tableNames, ...existingTableNames])
+        )
+        expect(info.tableNames).toHaveLength(
+          existingTableNames.length + tableNames.length
+        )
       })
     })
   })

--- a/packages/server/src/integrations/oracle.ts
+++ b/packages/server/src/integrations/oracle.ts
@@ -423,7 +423,11 @@ class OracleIntegration extends Sql implements DatasourcePlus {
     const columnsResponse = await this.internalQuery<OracleColumnsResponse>({
       sql: OracleIntegration.COLUMNS_SQL,
     })
-    return (columnsResponse.rows || []).map(row => row.TABLE_NAME)
+    const tableNames = new Set<string>()
+    for (const row of columnsResponse.rows || []) {
+      tableNames.add(row.TABLE_NAME)
+    }
+    return Array.from(tableNames)
   }
 
   async testConnection() {


### PR DESCRIPTION
## Description

Fairly simple fix, the function in the Oracle integration that was getting table names was doing it from a query designed to list out columns. So each table was being listed N times, where N was the number of columns it had. De-duped these using a `Set<string>` and it works as expected.