### PR TITLE
In-memory support for logical operators

### DIFF
--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -2697,7 +2697,7 @@ describe.each([
       })
     })
 
-  isSql &&
+  !isLucene &&
     describe("$and", () => {
       beforeAll(async () => {
         table = await createTable({
@@ -2771,7 +2771,7 @@ describe.each([
       })
     })
 
-  isSql &&
+  !isLucene &&
     describe("$or", () => {
       beforeAll(async () => {
         table = await createTable({

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -678,7 +678,7 @@ export const runQuery = (docs: Record<string, any>[], query: SearchFilters) => {
 
   const and = match(
     LogicalOperator.AND,
-    (docValue: Record<string, any>, conditions: any) => {
+    (docValue: Record<string, any>, conditions: SearchFilters[]) => {
       if (!conditions.length) {
         return false
       }
@@ -693,7 +693,7 @@ export const runQuery = (docs: Record<string, any>[], query: SearchFilters) => {
   )
   const or = match(
     LogicalOperator.OR,
-    (docValue: Record<string, any>, conditions: any) => {
+    (docValue: Record<string, any>, conditions: SearchFilters[]) => {
       if (!conditions.length) {
         return false
       }


### PR DESCRIPTION
## Description
Adding support for conditional types for in-memory rows.

## Addresses
- [BUDI-8506 - In memory support for logical operators](https://linear.app/budibase/issue/BUDI-8506/in-memory-support-for-logical-operators)

## Launchcontrol
Allowing conditional filtering for in-memory at the API level