### PR TITLE
Support filtering views

### DIFF
--- a/packages/server/src/api/controllers/row/views.ts
+++ b/packages/server/src/api/controllers/row/views.ts
@@ -5,12 +5,10 @@ import {
   SearchViewRowRequest,
   RequiredKeys,
   RowSearchParams,
-  SearchFilterKey,
-  LogicalOperator,
 } from "@budibase/types"
 import { dataFilters } from "@budibase/shared-core"
 import sdk from "../../../sdk"
-import { db, context } from "@budibase/backend-core"
+import { context } from "@budibase/backend-core"
 import { enrichSearchContext } from "./utils"
 
 export async function searchView(
@@ -36,33 +34,15 @@ export async function searchView(
   // that could let users find rows they should not be allowed to access.
   let query = dataFilters.buildQuery(view.query || [])
   if (body.query) {
-    // Extract existing fields
-    const existingFields =
-      view.query
-        ?.filter(filter => filter.field)
-        .map(filter => db.removeKeyNumbering(filter.field)) || []
-
     // Delete extraneous search params that cannot be overridden
     delete body.query.allOr
     delete body.query.onEmptyFilter
 
-    // Carry over filters for unused fields
-    Object.keys(body.query).forEach(key => {
-      const operator = key as SearchFilterKey
-
-      Object.keys(body.query[operator] || {}).forEach(field => {
-        if (!existingFields.includes(db.removeKeyNumbering(field))) {
-          if (
-            operator === LogicalOperator.AND ||
-            operator === LogicalOperator.OR
-          ) {
-            // TODO
-          } else {
-            query[operator]![field] = body.query[operator]![field]
-          }
-        }
-      })
-    })
+    query = {
+      $and: {
+        conditions: [query, body.query],
+      },
+    }
   }
 
   await context.ensureSnippetContext(true)

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1486,6 +1486,39 @@ describe.each([
         )
       })
 
+      it("can filter a view without a view filter", async () => {
+        const one = await config.api.row.save(table._id!, {
+          one: "foo",
+          two: "bar",
+        })
+        await config.api.row.save(table._id!, {
+          one: "foo2",
+          two: "bar2",
+        })
+
+        const view = await config.api.viewV2.create({
+          tableId: table._id!,
+          name: generator.guid(),
+          schema: {
+            id: { visible: true },
+            one: { visible: false },
+            two: { visible: true },
+          },
+        })
+
+        const response = await config.api.viewV2.search(view.id, {
+          query: {
+            equal: {
+              two: "bar",
+            },
+          },
+        })
+        expect(response.rows).toHaveLength(1)
+        expect(response.rows).toEqual([
+          expect.objectContaining({ _id: one._id }),
+        ])
+      })
+
       it("cannot bypass a view filter", async () => {
         await config.api.row.save(table._id!, {
           one: "foo",

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1485,6 +1485,43 @@ describe.each([
           }
         )
       })
+
+      it("cannot bypass a view filter", async () => {
+        await config.api.row.save(table._id!, {
+          one: "foo",
+          two: "bar",
+        })
+        await config.api.row.save(table._id!, {
+          one: "foo2",
+          two: "bar2",
+        })
+
+        const view = await config.api.viewV2.create({
+          tableId: table._id!,
+          name: generator.guid(),
+          query: [
+            {
+              operator: BasicOperator.EQUAL,
+              field: "two",
+              value: "bar2",
+            },
+          ],
+          schema: {
+            id: { visible: true },
+            one: { visible: false },
+            two: { visible: true },
+          },
+        })
+
+        const response = await config.api.viewV2.search(view.id, {
+          query: {
+            equal: {
+              two: "bar",
+            },
+          },
+        })
+        expect(response.rows).toHaveLength(0)
+      })
     })
 
     describe("permissions", () => {

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1528,76 +1528,76 @@ describe.each([
         })
 
       !isLucene &&
-      it("can filter a view without a view filter", async () => {
-        const one = await config.api.row.save(table._id!, {
-          one: "foo",
-          two: "bar",
-        })
-        await config.api.row.save(table._id!, {
-          one: "foo2",
-          two: "bar2",
-        })
+        it("can filter a view without a view filter", async () => {
+          const one = await config.api.row.save(table._id!, {
+            one: "foo",
+            two: "bar",
+          })
+          await config.api.row.save(table._id!, {
+            one: "foo2",
+            two: "bar2",
+          })
 
-        const view = await config.api.viewV2.create({
-          tableId: table._id!,
-          name: generator.guid(),
-          schema: {
-            id: { visible: true },
-            one: { visible: false },
-            two: { visible: true },
-          },
-        })
-
-        const response = await config.api.viewV2.search(view.id, {
-          query: {
-            equal: {
-              two: "bar",
+          const view = await config.api.viewV2.create({
+            tableId: table._id!,
+            name: generator.guid(),
+            schema: {
+              id: { visible: true },
+              one: { visible: false },
+              two: { visible: true },
             },
-          },
+          })
+
+          const response = await config.api.viewV2.search(view.id, {
+            query: {
+              equal: {
+                two: "bar",
+              },
+            },
+          })
+          expect(response.rows).toHaveLength(1)
+          expect(response.rows).toEqual([
+            expect.objectContaining({ _id: one._id }),
+          ])
         })
-        expect(response.rows).toHaveLength(1)
-        expect(response.rows).toEqual([
-          expect.objectContaining({ _id: one._id }),
-        ])
-      })
 
       !isLucene &&
-      it("cannot bypass a view filter", async () => {
-        await config.api.row.save(table._id!, {
-          one: "foo",
-          two: "bar",
-        })
-        await config.api.row.save(table._id!, {
-          one: "foo2",
-          two: "bar2",
-        })
+        it("cannot bypass a view filter", async () => {
+          await config.api.row.save(table._id!, {
+            one: "foo",
+            two: "bar",
+          })
+          await config.api.row.save(table._id!, {
+            one: "foo2",
+            two: "bar2",
+          })
 
-        const view = await config.api.viewV2.create({
-          tableId: table._id!,
-          name: generator.guid(),
-          query: [
-            {
-              operator: BasicOperator.EQUAL,
-              field: "two",
-              value: "bar2",
+          const view = await config.api.viewV2.create({
+            tableId: table._id!,
+            name: generator.guid(),
+            query: [
+              {
+                operator: BasicOperator.EQUAL,
+                field: "two",
+                value: "bar2",
+              },
+            ],
+            schema: {
+              id: { visible: true },
+              one: { visible: false },
+              two: { visible: true },
             },
-          ],
-          schema: {
-            id: { visible: true },
-            one: { visible: false },
-            two: { visible: true },
-          },
-        })
+          })
 
-        const response = await config.api.viewV2.search(view.id, {
-          query: {
-            equal: {
-              two: "bar",
+          const response = await config.api.viewV2.search(view.id, {
+            query: {
+              equal: {
+                two: "bar",
+              },
             },
-          },
+          })
+          expect(response.rows).toHaveLength(0)
         })
-        expect(response.rows).toHaveLength(0)
-      })
     })
 
     describe("permissions", () => {

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1486,6 +1486,48 @@ describe.each([
         )
       })
 
+      isLucene &&
+        it("in lucene, cannot override a view filter", async () => {
+          await config.api.row.save(table._id!, {
+            one: "foo",
+            two: "bar",
+          })
+          const two = await config.api.row.save(table._id!, {
+            one: "foo2",
+            two: "bar2",
+          })
+
+          const view = await config.api.viewV2.create({
+            tableId: table._id!,
+            name: generator.guid(),
+            query: [
+              {
+                operator: BasicOperator.EQUAL,
+                field: "two",
+                value: "bar2",
+              },
+            ],
+            schema: {
+              id: { visible: true },
+              one: { visible: false },
+              two: { visible: true },
+            },
+          })
+
+          const response = await config.api.viewV2.search(view.id, {
+            query: {
+              equal: {
+                two: "bar",
+              },
+            },
+          })
+          expect(response.rows).toHaveLength(1)
+          expect(response.rows).toEqual([
+            expect.objectContaining({ _id: two._id }),
+          ])
+        })
+
+      !isLucene &&
       it("can filter a view without a view filter", async () => {
         const one = await config.api.row.save(table._id!, {
           one: "foo",
@@ -1519,6 +1561,7 @@ describe.each([
         ])
       })
 
+      !isLucene &&
       it("cannot bypass a view filter", async () => {
         await config.api.row.save(table._id!, {
           one: "foo",

--- a/packages/server/src/sdk/app/rows/search/internal/sqs.ts
+++ b/packages/server/src/sdk/app/rows/search/internal/sqs.ts
@@ -2,7 +2,7 @@ import {
   Datasource,
   DocumentType,
   FieldType,
-  LogicalOperator,
+  isLogicalSearchOperator,
   Operation,
   QueryJson,
   RelationshipFieldMetadata,
@@ -141,10 +141,7 @@ function cleanupFilters(
 
   const prefixFilters = (filters: SearchFilters) => {
     for (const filterKey of Object.keys(filters) as (keyof SearchFilters)[]) {
-      if (
-        filterKey === LogicalOperator.AND ||
-        filterKey === LogicalOperator.OR
-      ) {
+      if (isLogicalSearchOperator(filterKey)) {
         for (const condition of filters[filterKey]!.conditions) {
           prefixFilters(condition)
         }

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -18,6 +18,7 @@ import {
   BasicOperator,
   RangeOperator,
   LogicalOperator,
+  isLogicalSearchOperator,
 } from "@budibase/types"
 import dayjs from "dayjs"
 import { OperatorOptions, SqlNumberTypeRangeMap } from "./constants"
@@ -359,10 +360,7 @@ export const buildQuery = (filter: SearchFilter[]) => {
           high: value,
         }
       }
-    } else if (
-      queryOperator === LogicalOperator.AND ||
-      queryOperator === LogicalOperator.OR
-    ) {
+    } else if (isLogicalSearchOperator(queryOperator)) {
       // TODO
     } else if (query[queryOperator] && operator !== "onEmptyFilter") {
       if (type === "boolean") {
@@ -464,10 +462,9 @@ export const runQuery = (docs: Record<string, any>[], query: SearchFilters) => {
     ) =>
     (doc: Record<string, any>) => {
       for (const [key, testValue] of Object.entries(query[type] || {})) {
-        const valueToCheck =
-          type === LogicalOperator.AND || type === LogicalOperator.OR
-            ? doc
-            : deepGet(doc, removeKeyNumbering(key))
+        const valueToCheck = isLogicalSearchOperator(type)
+          ? doc
+          : deepGet(doc, removeKeyNumbering(key))
         const result = test(valueToCheck, testValue)
         if (query.allOr && result) {
           return true

--- a/packages/types/src/sdk/search.ts
+++ b/packages/types/src/sdk/search.ts
@@ -28,6 +28,12 @@ export enum LogicalOperator {
   OR = "$or",
 }
 
+export function isLogicalSearchOperator(
+  value: string
+): value is LogicalOperator {
+  return value === LogicalOperator.AND || value === LogicalOperator.OR
+}
+
 export type SearchFilterOperator =
   | BasicOperator
   | ArrayOperator


### PR DESCRIPTION
## Description
The current logic of views is that a view has a filter for a specific field, this cannot be overridden. This causes frontend inconsistencies, as we allow filtering for specific values, but they are being ignored without a proper messaging.
With the new improved filtering, we can pile up both filters.


## Screenshots
Given we have the following view...
![image](https://github.com/user-attachments/assets/d4b6c5e9-b0a8-40a5-a334-eed1366daa59)
![image](https://github.com/user-attachments/assets/88aa9a30-918a-4439-9a16-d356be0cc667)


Before, filtering for the `Postcode` field is being ignored (still both results):
![image](https://github.com/user-attachments/assets/0fce2cfd-5d6d-4768-85ec-1ccddccad77b)
![image](https://github.com/user-attachments/assets/88aa9a30-918a-4439-9a16-d356be0cc667)


After, we can filter over the view data:
![image](https://github.com/user-attachments/assets/06db907b-05fe-464b-891b-f97db12ac6ec)


But we cannot get data that is meant to be filtered out by the view itself (only the 2 rows filtered by the view):
![image](https://github.com/user-attachments/assets/d08d5bc4-4216-4e3b-99b3-df361be8e340)

