### PR TITLE
Add search filter api validation

### DIFF
--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -2770,6 +2770,7 @@ describe.each([
         }).toFindNothing()
       })
 
+      !isInMemory &&
       it("validates conditions that are not objects", async () => {
         await expect(
           expectQuery({
@@ -2782,6 +2783,7 @@ describe.each([
         )
       })
 
+      !isInMemory &&
       it("validates $and without conditions", async () => {
         await expect(
           expectQuery({

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -2769,6 +2769,37 @@ describe.each([
           },
         }).toFindNothing()
       })
+
+      it("validates conditions that are not objects", async () => {
+        await expect(
+          expectQuery({
+            $and: {
+              conditions: [{ equal: { age: 10 } }, "invalidCondition" as any],
+            },
+          }).toFindNothing()
+        ).rejects.toThrow(
+          'Invalid body - "query.$and.conditions[1]" must be of type object'
+        )
+      })
+
+      it("validates $and without conditions", async () => {
+        await expect(
+          expectQuery({
+            $and: {
+              conditions: [
+                { equal: { age: 10 } },
+                {
+                  $and: {
+                    conditions: undefined as any,
+                  },
+                },
+              ],
+            },
+          }).toFindNothing()
+        ).rejects.toThrow(
+          'Invalid body - "query.$and.conditions[1].$and.conditions" is required'
+        )
+      })
     })
 
   !isLucene &&

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -2771,37 +2771,37 @@ describe.each([
       })
 
       !isInMemory &&
-      it("validates conditions that are not objects", async () => {
-        await expect(
-          expectQuery({
-            $and: {
-              conditions: [{ equal: { age: 10 } }, "invalidCondition" as any],
-            },
-          }).toFindNothing()
-        ).rejects.toThrow(
-          'Invalid body - "query.$and.conditions[1]" must be of type object'
-        )
-      })
+        it("validates conditions that are not objects", async () => {
+          await expect(
+            expectQuery({
+              $and: {
+                conditions: [{ equal: { age: 10 } }, "invalidCondition" as any],
+              },
+            }).toFindNothing()
+          ).rejects.toThrow(
+            'Invalid body - "query.$and.conditions[1]" must be of type object'
+          )
+        })
 
       !isInMemory &&
-      it("validates $and without conditions", async () => {
-        await expect(
-          expectQuery({
-            $and: {
-              conditions: [
-                { equal: { age: 10 } },
-                {
-                  $and: {
-                    conditions: undefined as any,
+        it("validates $and without conditions", async () => {
+          await expect(
+            expectQuery({
+              $and: {
+                conditions: [
+                  { equal: { age: 10 } },
+                  {
+                    $and: {
+                      conditions: undefined as any,
+                    },
                   },
-                },
-              ],
-            },
-          }).toFindNothing()
-        ).rejects.toThrow(
-          'Invalid body - "query.$and.conditions[1].$and.conditions" is required'
-        )
-      })
+                ],
+              },
+            }).toFindNothing()
+          ).rejects.toThrow(
+            'Invalid body - "query.$and.conditions[1].$and.conditions" is required'
+          )
+        })
     })
 
   !isLucene &&

--- a/packages/server/src/api/routes/utils/validators.ts
+++ b/packages/server/src/api/routes/utils/validators.ts
@@ -1,6 +1,6 @@
 import { auth, permissions } from "@budibase/backend-core"
 import { DataSourceOperation } from "../../../constants"
-import { Table, WebhookActionType } from "@budibase/types"
+import { SearchFilters, Table, WebhookActionType } from "@budibase/types"
 import Joi, { CustomValidator } from "joi"
 import { ValidSnippetNameRegex, helpers } from "@budibase/shared-core"
 import sdk from "../../../sdk"
@@ -84,7 +84,7 @@ export function datasourceValidator() {
 }
 
 function filterObject() {
-  return Joi.object({
+  const filtersValidators: Record<keyof SearchFilters, any> = {
     string: Joi.object().optional(),
     fuzzy: Joi.object().optional(),
     range: Joi.object().optional(),
@@ -96,7 +96,8 @@ function filterObject() {
     contains: Joi.object().optional(),
     notContains: Joi.object().optional(),
     allOr: Joi.boolean().optional(),
-  }).unknown(true)
+  }
+  return Joi.object(filtersValidators).unknown(true)
 }
 
 export function internalSearchValidator() {

--- a/packages/server/src/api/routes/utils/validators.ts
+++ b/packages/server/src/api/routes/utils/validators.ts
@@ -1,6 +1,11 @@
 import { auth, permissions } from "@budibase/backend-core"
 import { DataSourceOperation } from "../../../constants"
-import { SearchFilters, Table, WebhookActionType } from "@budibase/types"
+import {
+  EmptyFilterOption,
+  SearchFilters,
+  Table,
+  WebhookActionType,
+} from "@budibase/types"
 import Joi, { CustomValidator } from "joi"
 import { ValidSnippetNameRegex, helpers } from "@budibase/shared-core"
 import sdk from "../../../sdk"
@@ -97,6 +102,9 @@ function filterObject() {
     notContains: Joi.object().optional(),
     containsAny: Joi.object().optional(),
     allOr: Joi.boolean().optional(),
+    onEmptyFilter: Joi.string()
+      .optional()
+      .valid(...Object.values(EmptyFilterOption)),
     fuzzyOr: Joi.disallow(),
     documentType: Joi.disallow(),
   }

--- a/packages/server/src/api/routes/utils/validators.ts
+++ b/packages/server/src/api/routes/utils/validators.ts
@@ -97,6 +97,8 @@ function filterObject() {
     notContains: Joi.object().optional(),
     containsAny: Joi.object().optional(),
     allOr: Joi.boolean().optional(),
+    fuzzyOr: Joi.disallow(),
+    documentType: Joi.disallow(),
   }
   return Joi.object(filtersValidators).unknown(true)
 }

--- a/packages/server/src/api/routes/utils/validators.ts
+++ b/packages/server/src/api/routes/utils/validators.ts
@@ -89,6 +89,11 @@ export function datasourceValidator() {
 }
 
 function filterObject() {
+  const conditionalFilteringObject = () =>
+    Joi.object({
+      conditions: Joi.array().items(Joi.link("#schema")).required(),
+    })
+
   const filtersValidators: Record<keyof SearchFilters, any> = {
     string: Joi.object().optional(),
     fuzzy: Joi.object().optional(),
@@ -105,10 +110,12 @@ function filterObject() {
     onEmptyFilter: Joi.string()
       .optional()
       .valid(...Object.values(EmptyFilterOption)),
-    fuzzyOr: Joi.disallow(),
-    documentType: Joi.disallow(),
+    $and: conditionalFilteringObject(),
+    $or: conditionalFilteringObject(),
+    fuzzyOr: Joi.forbidden(),
+    documentType: Joi.forbidden(),
   }
-  return Joi.object(filtersValidators).unknown(true)
+  return Joi.object(filtersValidators).unknown(true).id("schema")
 }
 
 export function internalSearchValidator() {

--- a/packages/server/src/api/routes/utils/validators.ts
+++ b/packages/server/src/api/routes/utils/validators.ts
@@ -95,6 +95,7 @@ function filterObject() {
     oneOf: Joi.object().optional(),
     contains: Joi.object().optional(),
     notContains: Joi.object().optional(),
+    containsAny: Joi.object().optional(),
     allOr: Joi.boolean().optional(),
   }
   return Joi.object(filtersValidators).unknown(true)


### PR DESCRIPTION
## Description
Add search filter API validation

## Addresses
- [BUDI-8509 - Search API validation for filters with logical operators
](https://linear.app/budibase/issue/BUDI-8509/search-api-validation-for-filters-with-logical-operators)

## Launchcontrol
Add search filter API validation