### PR TITLE
fix AWS datasource when endpoint is unspecified

### DIFF
--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -304,7 +304,7 @@ export const getSignedUploadURL = async function (ctx: Ctx) {
     try {
       const s3 = new AWS.S3({
         region: awsRegion,
-        endpoint: datasource?.config?.endpoint as string,
+        endpoint: datasource?.config?.endpoint || undefined,
         accessKeyId: datasource?.config?.accessKeyId as string,
         secretAccessKey: datasource?.config?.secretAccessKey as string,
         apiVersion: "2006-03-01",


### PR DESCRIPTION
## Description
S3 uploads are broken in cases where the S3 datasource doesn't have an endpoint value set. The S3 client should be able to infer the proper endpoint from other config values when it's not specified. This has potentially been broken by an update to the client where it's just using the empty string passed as an endpoint.

This solution allows the endpoint to be passed to the client as undefined rather than an empty string, meaning the client will use the appropriate endpoint for the context.

## Addresses
https://linear.app/budibase/issue/BUDI-8550/s3-upload-signed-url-missing-aws-endpoint-when-not-explicitly-set

## Launchcontrol
Fix the S3 Upload component
