### PR TITLE
feat: only use requirepass if password's set

### DIFF
--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -80,7 +80,7 @@ ln -s ${DATA_DIR}/.env /worker/.env
 # make these directories in runner, incase of mount
 mkdir -p ${DATA_DIR}/minio
 chown -R couchdb:couchdb ${DATA_DIR}/couch
-if [[ -z "${REDIS_PASSWORD}" ]]; then
+if [[ -z "${REDIS_PASSWORD}" || "${REDIS_PASSWORD}" = "" ]]; then
   redis-server --requirepass $REDIS_PASSWORD > /dev/stdout 2>&1 &
 else
   redis-server > /dev/stdout 2>&1 &

--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -80,7 +80,11 @@ ln -s ${DATA_DIR}/.env /worker/.env
 # make these directories in runner, incase of mount
 mkdir -p ${DATA_DIR}/minio
 chown -R couchdb:couchdb ${DATA_DIR}/couch
-redis-server --requirepass $REDIS_PASSWORD > /dev/stdout 2>&1 &
+if [[ -z "${REDIS_PASSWORD}" ]]; then
+  redis-server --requirepass $REDIS_PASSWORD > /dev/stdout 2>&1 &
+else
+  redis-server > /dev/stdout 2>&1 &
+fi
 /bbcouch-runner.sh &
 
 # only start minio if use s3 isn't passed

--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -80,7 +80,7 @@ ln -s ${DATA_DIR}/.env /worker/.env
 # make these directories in runner, incase of mount
 mkdir -p ${DATA_DIR}/minio
 chown -R couchdb:couchdb ${DATA_DIR}/couch
-if [[ -z "${REDIS_PASSWORD}" || "${REDIS_PASSWORD}" = "" ]]; then
+if [[ -n "${REDIS_PASSWORD}" ]]; then
   redis-server --requirepass $REDIS_PASSWORD > /dev/stdout 2>&1 &
 else
   redis-server > /dev/stdout 2>&1 &


### PR DESCRIPTION
## Description
Avoid using the `requirepass` flag if the user is not setting a `REDIS_PASSWORD` if the `REDIS_PASSWORD`'s value is an empty string. 

## Launchcontrol

Disable `--requirepass` on empty or non-existing `REDIS_PASSWORD`
