### PR TITLE
Honor table and view schema on query

### DIFF
--- a/packages/server/src/api/controllers/row/utils/sqlUtils.ts
+++ b/packages/server/src/api/controllers/row/utils/sqlUtils.ts
@@ -192,10 +192,10 @@ export function buildSqlFieldList(
   function extractRealFields(table: Table, existing: string[] = []) {
     return Object.entries(table.schema)
       .filter(
-        column =>
-          column[1].type !== FieldType.LINK &&
-          column[1].type !== FieldType.FORMULA &&
-          !existing.find((field: string) => field === column[0])
+        ([columnName, column]) =>
+          column.type !== FieldType.LINK &&
+          column.type !== FieldType.FORMULA &&
+          !existing.find((field: string) => field === columnName)
       )
       .map(column => `${table.name}.${column[0]}`)
   }

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -1664,7 +1664,7 @@ describe.each([
   isInternal &&
     describe("attachments and signatures", () => {
       const coreAttachmentEnrichment = async (
-        schema: any,
+        schema: TableSchema,
         field: string,
         attachmentCfg: string | string[]
       ) => {
@@ -1691,7 +1691,7 @@ describe.each([
 
         await withEnv({ SELF_HOSTED: "true" }, async () => {
           return context.doInAppContext(config.getAppId(), async () => {
-            const enriched: Row[] = await outputProcessing(table, [row])
+            const enriched: Row[] = await outputProcessing(testTable, [row])
             const [targetRow] = enriched
             const attachmentEntries = Array.isArray(targetRow[field])
               ? targetRow[field]

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -121,6 +121,7 @@ describe.each([
   })
 
   beforeEach(() => {
+    jest.clearAllMocks()
     mocks.licenses.useCloudFree()
   })
 
@@ -1604,7 +1605,7 @@ describe.each([
           expect(response.rows).toHaveLength(0)
         })
 
-      it("queries the row api passing the view fields only", async () => {
+      it.only("queries the row api passing the view fields only", async () => {
         const searchSpy = jest.spyOn(sdk.rows, "search")
 
         const view = await config.api.viewV2.create({

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1605,7 +1605,7 @@ describe.each([
           expect(response.rows).toHaveLength(0)
         })
 
-      it.only("queries the row api passing the view fields only", async () => {
+      it("queries the row api passing the view fields only", async () => {
         const searchSpy = jest.spyOn(sdk.rows, "search")
 
         const view = await config.api.viewV2.create({

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1602,6 +1602,28 @@ describe.each([
           })
           expect(response.rows).toHaveLength(0)
         })
+
+      it("queries the row api passing the view fields only", async () => {
+        const searchSpy = jest.spyOn(sdk.rows, "search")
+
+        const view = await config.api.viewV2.create({
+          tableId: table._id!,
+          name: generator.guid(),
+          schema: {
+            id: { visible: true },
+            one: { visible: false },
+          },
+        })
+
+        await config.api.viewV2.search(view.id, { query: {} })
+        expect(searchSpy).toHaveBeenCalledTimes(1)
+
+        expect(searchSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fields: ["id"],
+          })
+        )
+        })
     })
 
     describe("permissions", () => {

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -30,6 +30,7 @@ import {
   withEnv as withCoreEnv,
   setEnv as setCoreEnv,
 } from "@budibase/backend-core"
+import sdk from "../../../sdk"
 
 describe.each([
   ["lucene", undefined],
@@ -1623,7 +1624,7 @@ describe.each([
             fields: ["id"],
           })
         )
-        })
+      })
     })
 
     describe("permissions", () => {

--- a/packages/server/src/sdk/app/rows/queryUtils.ts
+++ b/packages/server/src/sdk/app/rows/queryUtils.ts
@@ -31,14 +31,10 @@ export const removeInvalidFilters = (
 
     const filter = result[filterKey]
     for (const columnKey of Object.keys(filter)) {
-      if (
-        !validFields
-          .map(f => f.toLowerCase())
-          .includes(columnKey.toLowerCase()) &&
-        !validFields
-          .map(f => f.toLowerCase())
-          .includes(db.removeKeyNumbering(columnKey).toLowerCase())
-      ) {
+      const possibleKeys = [columnKey, db.removeKeyNumbering(columnKey)].map(
+        c => c.toLowerCase()
+      )
+      if (!validFields.some(f => possibleKeys.includes(f.toLowerCase()))) {
         delete filter[columnKey]
       }
     }

--- a/packages/server/src/sdk/app/rows/queryUtils.ts
+++ b/packages/server/src/sdk/app/rows/queryUtils.ts
@@ -78,9 +78,13 @@ export const getQueryableFields = async (
           Object.keys(relatedTable.schema)
         )
 
-        result.push(...relatedFields.map(f => `${subSchema.name}.${f}`))
-        // should be able to filter by relationship using table name
-        result.push(...relatedFields.map(f => `${relatedTable.name}.${f}`))
+        result.push(
+          ...relatedFields.flatMap(f => [
+            `${subSchema.name}.${f}`,
+            // should be able to filter by relationship using table name
+            `${relatedTable.name}.${f}`,
+          ])
+        )
       } else {
         result.push(field)
       }

--- a/packages/server/src/sdk/app/rows/queryUtils.ts
+++ b/packages/server/src/sdk/app/rows/queryUtils.ts
@@ -62,8 +62,8 @@ export const getQueryableFields = async (
     allowedFields: string[]
   ): Promise<string[]> => {
     const result = []
-    for (const field of Object.keys(table.schema).filter(f =>
-      allowedFields.includes(f)
+    for (const field of Object.keys(table.schema).filter(
+      f => allowedFields.includes(f) && table.schema[f].visible !== false
     )) {
       const subSchema = table.schema[field]
       if (subSchema.type === FieldType.LINK) {

--- a/packages/server/src/sdk/app/rows/queryUtils.ts
+++ b/packages/server/src/sdk/app/rows/queryUtils.ts
@@ -1,0 +1,45 @@
+import { isLogicalSearchOperator, SearchFilters } from "@budibase/types"
+import { cloneDeep } from "lodash/fp"
+
+export const removeInvalidFilters = (
+  filters: SearchFilters,
+  validFields: string[]
+) => {
+  const result = cloneDeep(filters)
+
+  validFields = validFields.map(f => f.toLowerCase())
+  for (const filterKey of Object.keys(result) as (keyof SearchFilters)[]) {
+    if (typeof result[filterKey] !== "object") {
+      continue
+    }
+    if (isLogicalSearchOperator(filterKey)) {
+      const resultingConditions: SearchFilters[] = []
+      for (const condition of result[filterKey].conditions) {
+        const resultingCondition = removeInvalidFilters(condition, validFields)
+        if (Object.keys(resultingCondition).length) {
+          resultingConditions.push(resultingCondition)
+        }
+      }
+      if (resultingConditions.length) {
+        result[filterKey].conditions = resultingConditions
+      } else {
+        delete result[filterKey]
+      }
+      continue
+    }
+
+    const filter = result[filterKey]
+    for (const columnKey of Object.keys(filter)) {
+      if (
+        !validFields.map(f => f.toLowerCase()).includes(columnKey.toLowerCase())
+      ) {
+        delete filter[columnKey]
+      }
+    }
+    if (!Object.keys(filter).length) {
+      delete result[filterKey]
+    }
+  }
+
+  return result
+}

--- a/packages/server/src/sdk/app/rows/queryUtils.ts
+++ b/packages/server/src/sdk/app/rows/queryUtils.ts
@@ -1,3 +1,4 @@
+import { db } from "@budibase/backend-core"
 import { isLogicalSearchOperator, SearchFilters } from "@budibase/types"
 import { cloneDeep } from "lodash/fp"
 
@@ -31,7 +32,12 @@ export const removeInvalidFilters = (
     const filter = result[filterKey]
     for (const columnKey of Object.keys(filter)) {
       if (
-        !validFields.map(f => f.toLowerCase()).includes(columnKey.toLowerCase())
+        !validFields
+          .map(f => f.toLowerCase())
+          .includes(columnKey.toLowerCase()) &&
+        !validFields
+          .map(f => f.toLowerCase())
+          .includes(db.removeKeyNumbering(columnKey).toLowerCase())
       ) {
         delete filter[columnKey]
       }

--- a/packages/server/src/sdk/app/rows/search.ts
+++ b/packages/server/src/sdk/app/rows/search.ts
@@ -73,6 +73,19 @@ export async function search(
     const table = await sdk.tables.getTable(options.tableId)
     options = searchInputMapping(table, options)
 
+    const visibleTableFields = Object.keys(table.schema).filter(
+      f => table.schema[f].visible !== false
+    )
+
+    if (options.fields) {
+      const tableFields = visibleTableFields.map(f => f.toLowerCase())
+      options.fields = options.fields.filter(f =>
+        tableFields.includes(f.toLowerCase())
+      )
+    } else {
+      options.fields = visibleTableFields
+    }
+
     let result: SearchResponse<Row>
     if (isExternalTable) {
       span?.addTags({ searchType: "external" })

--- a/packages/server/src/sdk/app/rows/search.ts
+++ b/packages/server/src/sdk/app/rows/search.ts
@@ -81,7 +81,7 @@ export async function search(
         f => table.schema[f].visible !== false
       )
 
-      const queriableFields = await getQueriableFields(
+      const queriableFields = await getQueryableFields(
         options.fields?.filter(f => tableFields.includes(f)) ?? tableFields,
         table
       )
@@ -131,7 +131,7 @@ export async function fetchView(
   return pickApi(tableId).fetchView(viewName, params)
 }
 
-async function getQueriableFields(
+async function getQueryableFields(
   fields: string[],
   table: Table
 ): Promise<string[]> {

--- a/packages/server/src/sdk/app/rows/search.ts
+++ b/packages/server/src/sdk/app/rows/search.ts
@@ -14,6 +14,7 @@ import sdk from "../../index"
 import { searchInputMapping } from "./search/utils"
 import { db as dbCore } from "@budibase/backend-core"
 import tracer from "dd-trace"
+import { removeInvalidFilters } from "./queryUtils"
 
 export { isValidFilter } from "../../../integrations/utils"
 
@@ -85,6 +86,11 @@ export async function search(
     } else {
       options.fields = visibleTableFields
     }
+
+    options.query = removeInvalidFilters(options.query, [
+      "_id",
+      ...options.fields,
+    ])
 
     let result: SearchResponse<Row>
     if (isExternalTable) {

--- a/packages/server/src/sdk/app/rows/search.ts
+++ b/packages/server/src/sdk/app/rows/search.ts
@@ -76,23 +76,17 @@ export async function search(
     const table = await sdk.tables.getTable(options.tableId)
     options = searchInputMapping(table, options)
 
-    const visibleTableFields = Object.keys(table.schema).filter(
-      f => table.schema[f].visible !== false
-    )
-
-    if (options.fields) {
-      const tableFields = visibleTableFields.map(f => f.toLowerCase())
-      options.fields = options.fields.filter(f =>
-        tableFields.includes(f.toLowerCase())
+    if (options.query) {
+      const tableFields = Object.keys(table.schema).filter(
+        f => table.schema[f].visible !== false
       )
-    } else {
-      options.fields = visibleTableFields
-    }
 
-    options.query = removeInvalidFilters(
-      options.query,
-      await getQueriableFields(options.fields, table)
-    )
+      const queriableFields = await getQueriableFields(
+        options.fields?.filter(f => tableFields.includes(f)) ?? tableFields,
+        table
+      )
+      options.query = removeInvalidFilters(options.query, queriableFields)
+    }
 
     let result: SearchResponse<Row>
     if (isExternalTable) {

--- a/packages/server/src/sdk/app/rows/search/tests/search.spec.ts
+++ b/packages/server/src/sdk/app/rows/search/tests/search.spec.ts
@@ -1,4 +1,11 @@
-import { Datasource, FieldType, Table } from "@budibase/types"
+import {
+  AutoColumnFieldMetadata,
+  AutoFieldSubType,
+  Datasource,
+  FieldType,
+  NumberFieldMetadata,
+  Table,
+} from "@budibase/types"
 
 import TestConfiguration from "../../../../../tests/utilities/TestConfiguration"
 import { search } from "../../../../../sdk/app/rows/search"
@@ -53,15 +60,25 @@ describe.each([
   })
 
   beforeEach(async () => {
+    const idFieldSchema: NumberFieldMetadata | AutoColumnFieldMetadata =
+      isInternal
+        ? {
+            name: "id",
+            type: FieldType.AUTO,
+            subtype: AutoFieldSubType.AUTO_ID,
+            autocolumn: true,
+          }
+        : {
+            name: "id",
+            type: FieldType.NUMBER,
+            autocolumn: true,
+          }
+
     table = await config.api.table.save(
       tableForDatasource(datasource, {
         primary: ["id"],
         schema: {
-          id: {
-            name: "id",
-            type: FieldType.NUMBER,
-            autocolumn: true,
-          },
+          id: idFieldSchema,
           name: {
             name: "name",
             type: FieldType.STRING,
@@ -256,7 +273,7 @@ describe.each([
       [["id", "name", "age"], 3],
       [["name", "age"], 10],
     ])(
-      "cannot query by non search fields",
+      "cannot query by non search fields (fields: %s)",
       async (queryFields, expectedRows) => {
         await config.doInContext(config.appId, async () => {
           const { rows } = await search({

--- a/packages/server/src/sdk/app/rows/search/tests/search.spec.ts
+++ b/packages/server/src/sdk/app/rows/search/tests/search.spec.ts
@@ -205,6 +205,7 @@ describe.each([
       await config.api.table.save({
         ...table,
         schema: {
+          id: table.schema.id,
           name: table.schema.name,
           surname: table.schema.surname,
         },

--- a/packages/server/src/sdk/app/rows/search/tests/search.spec.ts
+++ b/packages/server/src/sdk/app/rows/search/tests/search.spec.ts
@@ -217,57 +217,6 @@ describe.each([
     })
   })
 
-  it("does not allow accessing non-mapped fields", async () => {
-    await config.doInContext(config.appId, async () => {
-      await config.api.table.save({
-        ...table,
-        schema: {
-          id: table.schema.id,
-          name: table.schema.name,
-          surname: table.schema.surname,
-        },
-      })
-      const result = await search({
-        tableId: table._id!,
-        query: {},
-      })
-      expect(result.rows).toHaveLength(10)
-      for (const row of result.rows) {
-        const keys = Object.keys(row)
-        expect(keys).toContain("name")
-        expect(keys).toContain("surname")
-        expect(keys).not.toContain("address")
-        expect(keys).not.toContain("age")
-      }
-    })
-  })
-
-  it("does not allow accessing non-mapped fields even if requested", async () => {
-    await config.doInContext(config.appId, async () => {
-      await config.api.table.save({
-        ...table,
-        schema: {
-          id: table.schema.id,
-          name: table.schema.name,
-          surname: table.schema.surname,
-        },
-      })
-      const result = await search({
-        tableId: table._id!,
-        query: {},
-        fields: ["name", "age"],
-      })
-      expect(result.rows).toHaveLength(10)
-      for (const row of result.rows) {
-        const keys = Object.keys(row)
-        expect(keys).toContain("name")
-        expect(keys).not.toContain("age")
-        expect(keys).not.toContain("surname")
-        expect(keys).not.toContain("address")
-      }
-    })
-  })
-
   !isLucene &&
     it.each([
       [["id", "name", "age"], 3],

--- a/packages/server/src/sdk/app/rows/search/tests/search.spec.ts
+++ b/packages/server/src/sdk/app/rows/search/tests/search.spec.ts
@@ -199,4 +199,53 @@ describe.each([
       }
     })
   })
+
+  it("does not allow accessing non-mapped fields", async () => {
+    await config.doInContext(config.appId, async () => {
+      await config.api.table.save({
+        ...table,
+        schema: {
+          name: table.schema.name,
+          surname: table.schema.surname,
+        },
+      })
+      const result = await search({
+        tableId: table._id!,
+        query: {},
+      })
+      expect(result.rows).toHaveLength(10)
+      for (const row of result.rows) {
+        const keys = Object.keys(row)
+        expect(keys).toContain("name")
+        expect(keys).toContain("surname")
+        expect(keys).not.toContain("address")
+        expect(keys).not.toContain("age")
+      }
+    })
+  })
+
+  it("does not allow accessing non-mapped fields even if requested", async () => {
+    await config.doInContext(config.appId, async () => {
+      await config.api.table.save({
+        ...table,
+        schema: {
+          name: table.schema.name,
+          surname: table.schema.surname,
+        },
+      })
+      const result = await search({
+        tableId: table._id!,
+        query: {},
+        fields: ["name", "age"],
+      })
+      expect(result.rows).toHaveLength(10)
+      for (const row of result.rows) {
+        const keys = Object.keys(row)
+        expect(keys).toContain("name")
+        expect(keys).not.toContain("age")
+        expect(keys).not.toContain("surname")
+        expect(keys).not.toContain("address")
+      }
+    })
+  })
 })

--- a/packages/server/src/sdk/app/rows/search/tests/search.spec.ts
+++ b/packages/server/src/sdk/app/rows/search/tests/search.spec.ts
@@ -229,6 +229,7 @@ describe.each([
       await config.api.table.save({
         ...table,
         schema: {
+          id: table.schema.id,
           name: table.schema.name,
           surname: table.schema.surname,
         },

--- a/packages/server/src/sdk/app/rows/search/tests/search.spec.ts
+++ b/packages/server/src/sdk/app/rows/search/tests/search.spec.ts
@@ -248,4 +248,37 @@ describe.each([
       }
     })
   })
+
+  !isLucene &&
+    it.each([
+      [["id", "name", "age"], 3],
+      [["name", "age"], 10],
+    ])(
+      "cannot query by non search fields",
+      async (queryFields, expectedRows) => {
+        await config.doInContext(config.appId, async () => {
+          const { rows } = await search({
+            tableId: table._id!,
+            query: {
+              $or: {
+                conditions: [
+                  {
+                    $and: {
+                      conditions: [
+                        { range: { id: { low: 2, high: 4 } } },
+                        { range: { id: { low: 3, high: 5 } } },
+                      ],
+                    },
+                  },
+                  { equal: { id: 7 } },
+                ],
+              },
+            },
+            fields: queryFields,
+          })
+
+          expect(rows).toHaveLength(expectedRows)
+        })
+      }
+    )
 })

--- a/packages/server/src/sdk/app/rows/tests/queryUtils.spec.ts
+++ b/packages/server/src/sdk/app/rows/tests/queryUtils.spec.ts
@@ -1,0 +1,96 @@
+import { SearchFilters } from "@budibase/types"
+import { removeInvalidFilters } from "../queryUtils"
+
+describe("query utils", () => {
+  describe("removeInvalidFilters", () => {
+    const fullFilters: SearchFilters = {
+      equal: { one: "foo" },
+      $or: {
+        conditions: [
+          {
+            equal: { one: "foo2", two: "bar" },
+            notEmpty: { one: null },
+            $and: {
+              conditions: [
+                {
+                  equal: { three: "baz" },
+                  notEmpty: { forth: null },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      $and: {
+        conditions: [{ equal: { one: "foo2" }, notEmpty: { one: null } }],
+      },
+    }
+
+    it("can filter empty queries", () => {
+      const filters: SearchFilters = {}
+      const result = removeInvalidFilters(filters, [])
+      expect(result).toEqual({})
+    })
+
+    it("does not trim any valid field", () => {
+      const result = removeInvalidFilters(fullFilters, [
+        "one",
+        "two",
+        "three",
+        "forth",
+      ])
+      expect(result).toEqual(fullFilters)
+    })
+
+    it("trims invalid field", () => {
+      const result = removeInvalidFilters(fullFilters, [
+        "one",
+        "three",
+        "forth",
+      ])
+      expect(result).toEqual({
+        equal: { one: "foo" },
+        $or: {
+          conditions: [
+            {
+              equal: { one: "foo2" },
+              notEmpty: { one: null },
+              $and: {
+                conditions: [
+                  {
+                    equal: { three: "baz" },
+                    notEmpty: { forth: null },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        $and: {
+          conditions: [{ equal: { one: "foo2" }, notEmpty: { one: null } }],
+        },
+      })
+    })
+
+    it("trims invalid field keeping a valid fields", () => {
+      const result = removeInvalidFilters(fullFilters, ["three", "forth"])
+      const expected: SearchFilters = {
+        $or: {
+          conditions: [
+            {
+              $and: {
+                conditions: [
+                  {
+                    equal: { three: "baz" },
+                    notEmpty: { forth: null },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }
+      expect(result).toEqual(expected)
+    })
+  })
+})

--- a/packages/server/src/sdk/app/rows/tests/queryUtils.spec.ts
+++ b/packages/server/src/sdk/app/rows/tests/queryUtils.spec.ts
@@ -92,5 +92,58 @@ describe("query utils", () => {
       }
       expect(result).toEqual(expected)
     })
+
+    it("keeps filter key numering", () => {
+      const prefixedFilters: SearchFilters = {
+        equal: { "1:one": "foo" },
+        $or: {
+          conditions: [
+            {
+              equal: { "2:one": "foo2", "3:two": "bar" },
+              notEmpty: { "4:one": null },
+              $and: {
+                conditions: [
+                  {
+                    equal: { "5:three": "baz", two: "bar2" },
+                    notEmpty: { forth: null },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        $and: {
+          conditions: [{ equal: { "6:one": "foo2" }, notEmpty: { one: null } }],
+        },
+      }
+
+      const result = removeInvalidFilters(prefixedFilters, [
+        "one",
+        "three",
+        "forth",
+      ])
+      expect(result).toEqual({
+        equal: { "1:one": "foo" },
+        $or: {
+          conditions: [
+            {
+              equal: { "2:one": "foo2" },
+              notEmpty: { "4:one": null },
+              $and: {
+                conditions: [
+                  {
+                    equal: { "5:three": "baz" },
+                    notEmpty: { forth: null },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        $and: {
+          conditions: [{ equal: { "6:one": "foo2" }, notEmpty: { one: null } }],
+        },
+      })
+    })
   })
 })

--- a/packages/server/src/sdk/app/rows/tests/queryUtils.spec.ts
+++ b/packages/server/src/sdk/app/rows/tests/queryUtils.spec.ts
@@ -1,5 +1,6 @@
-import { SearchFilters } from "@budibase/types"
-import { removeInvalidFilters } from "../queryUtils"
+import { FieldType, SearchFilters, Table } from "@budibase/types"
+import { getQueryableFields, removeInvalidFilters } from "../queryUtils"
+import { structures } from "../../../../api/routes/tests/utilities"
 
 describe("query utils", () => {
   describe("removeInvalidFilters", () => {
@@ -177,6 +178,21 @@ describe("query utils", () => {
           ],
         },
       })
+    })
+  })
+
+  describe("getQueryableFields", () => {
+    it("allows querying by table schema fields and _id", async () => {
+      const table: Table = {
+        ...structures.basicTable(),
+        schema: {
+          name: { name: "name", type: FieldType.STRING },
+          age: { name: "age", type: FieldType.NUMBER },
+        },
+      }
+
+      const result = await getQueryableFields(["name", "age"], table)
+      expect(result).toEqual(["_id", "name", "age"])
     })
   })
 })

--- a/packages/server/src/sdk/app/rows/tests/queryUtils.spec.ts
+++ b/packages/server/src/sdk/app/rows/tests/queryUtils.spec.ts
@@ -145,5 +145,38 @@ describe("query utils", () => {
         },
       })
     })
+
+    it("handles relationship filters", () => {
+      const prefixedFilters: SearchFilters = {
+        $or: {
+          conditions: [
+            { equal: { "1:other.one": "foo" } },
+            {
+              equal: {
+                "2:other.one": "foo2",
+                "3:other.two": "bar",
+                "4:other.three": "baz",
+              },
+            },
+            { equal: { "another.three": "baz2" } },
+          ],
+        },
+      }
+
+      const result = removeInvalidFilters(prefixedFilters, [
+        "other.one",
+        "other.two",
+        "another.three",
+      ])
+      expect(result).toEqual({
+        $or: {
+          conditions: [
+            { equal: { "1:other.one": "foo" } },
+            { equal: { "2:other.one": "foo2", "3:other.two": "bar" } },
+            { equal: { "another.three": "baz2" } },
+          ],
+        },
+      })
+    })
   })
 })

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -19,7 +19,6 @@ import {
   User,
 } from "@budibase/types"
 import { cloneDeep } from "lodash/fp"
-import { pick } from "lodash"
 import {
   processInputBBReference,
   processInputBBReferences,
@@ -368,9 +367,16 @@ export async function outputProcessing<T extends Row[] | Row>(
     const tableFields = Object.keys(table.schema).filter(
       f => table.schema[f].visible !== false
     )
-    enriched = enriched.map((r: Row) =>
-      pick(r, [...tableFields, ...protectedColumns])
+    const fields = [...tableFields, ...protectedColumns].map(f =>
+      f.toLowerCase()
     )
+    for (const row of enriched) {
+      for (const key of Object.keys(row)) {
+        if (!fields.includes(key.toLowerCase())) {
+          delete row[key]
+        }
+      }
+    }
   }
 
   return (wasArray ? enriched : enriched[0]) as T

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -33,6 +33,7 @@ import {
   PROTECTED_INTERNAL_COLUMNS,
 } from "@budibase/shared-core"
 import { processString } from "@budibase/string-templates"
+import { isUserMetadataTable } from "../../api/controllers/row/utils"
 
 export * from "./utils"
 export * from "./attachments"
@@ -359,16 +360,18 @@ export async function outputProcessing<T extends Row[] | Row>(
     }
   }
 
-  const protectedColumns = isExternal
-    ? PROTECTED_EXTERNAL_COLUMNS
-    : PROTECTED_INTERNAL_COLUMNS
+  if (!isUserMetadataTable(table._id!)) {
+    const protectedColumns = isExternal
+      ? PROTECTED_EXTERNAL_COLUMNS
+      : PROTECTED_INTERNAL_COLUMNS
 
-  const tableFields = Object.keys(table.schema).filter(
-    f => table.schema[f].visible !== false
-  )
-  enriched = enriched.map((r: Row) =>
-    pick(r, [...tableFields, ...protectedColumns])
-  )
+    const tableFields = Object.keys(table.schema).filter(
+      f => table.schema[f].visible !== false
+    )
+    enriched = enriched.map((r: Row) =>
+      pick(r, [...tableFields, ...protectedColumns])
+    )
+  }
 
   return (wasArray ? enriched : enriched[0]) as T
 }

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -19,6 +19,7 @@ import {
   User,
 } from "@budibase/types"
 import { cloneDeep } from "lodash/fp"
+import { pick } from "lodash"
 import {
   processInputBBReference,
   processInputBBReferences,
@@ -26,7 +27,11 @@ import {
   processOutputBBReferences,
 } from "./bbReferenceProcessor"
 import { isExternalTableID } from "../../integrations/utils"
-import { helpers } from "@budibase/shared-core"
+import {
+  helpers,
+  PROTECTED_EXTERNAL_COLUMNS,
+  PROTECTED_INTERNAL_COLUMNS,
+} from "@budibase/shared-core"
 import { processString } from "@budibase/string-templates"
 
 export * from "./utils"
@@ -53,9 +58,9 @@ export async function processAutoColumn(
   row: Row,
   opts?: AutoColumnProcessingOpts
 ) {
-  let noUser = !userId
-  let isUserTable = table._id === InternalTables.USER_METADATA
-  let now = new Date().toISOString()
+  const noUser = !userId
+  const isUserTable = table._id === InternalTables.USER_METADATA
+  const now = new Date().toISOString()
   // if a row doesn't have a revision then it doesn't exist yet
   const creating = !row._rev
   // check its not user table, or whether any of the processing options have been disabled
@@ -111,7 +116,7 @@ async function processDefaultValues(table: Table, row: Row) {
     ctx.user = user
   }
 
-  for (let [key, schema] of Object.entries(table.schema)) {
+  for (const [key, schema] of Object.entries(table.schema)) {
     if ("default" in schema && schema.default != null && row[key] == null) {
       const processed = await processString(schema.default, ctx)
 
@@ -165,10 +170,10 @@ export async function inputProcessing(
   row: Row,
   opts?: AutoColumnProcessingOpts
 ) {
-  let clonedRow = cloneDeep(row)
+  const clonedRow = cloneDeep(row)
 
   const dontCleanseKeys = ["type", "_id", "_rev", "tableId"]
-  for (let [key, value] of Object.entries(clonedRow)) {
+  for (const [key, value] of Object.entries(clonedRow)) {
     const field = table.schema[key]
     // cleanse fields that aren't in the schema
     if (!field) {
@@ -268,13 +273,13 @@ export async function outputProcessing<T extends Row[] | Row>(
   }
 
   // process complex types: attachments, bb references...
-  for (let [property, column] of Object.entries(table.schema)) {
+  for (const [property, column] of Object.entries(table.schema)) {
     if (
       column.type === FieldType.ATTACHMENTS ||
       column.type === FieldType.ATTACHMENT_SINGLE ||
       column.type === FieldType.SIGNATURE_SINGLE
     ) {
-      for (let row of enriched) {
+      for (const row of enriched) {
         if (row[property] == null) {
           continue
         }
@@ -299,7 +304,7 @@ export async function outputProcessing<T extends Row[] | Row>(
       !opts.skipBBReferences &&
       column.type == FieldType.BB_REFERENCE
     ) {
-      for (let row of enriched) {
+      for (const row of enriched) {
         row[property] = await processOutputBBReferences(
           row[property],
           column.subtype
@@ -309,14 +314,14 @@ export async function outputProcessing<T extends Row[] | Row>(
       !opts.skipBBReferences &&
       column.type == FieldType.BB_REFERENCE_SINGLE
     ) {
-      for (let row of enriched) {
+      for (const row of enriched) {
         row[property] = await processOutputBBReference(
           row[property],
           column.subtype
         )
       }
     } else if (column.type === FieldType.DATETIME && column.timeOnly) {
-      for (let row of enriched) {
+      for (const row of enriched) {
         if (row[property] instanceof Date) {
           const hours = row[property].getUTCHours().toString().padStart(2, "0")
           const minutes = row[property]
@@ -343,14 +348,27 @@ export async function outputProcessing<T extends Row[] | Row>(
     )) as Row[]
   }
   // remove null properties to match internal API
-  if (isExternalTableID(table._id!)) {
-    for (let row of enriched) {
-      for (let key of Object.keys(row)) {
+  const isExternal = isExternalTableID(table._id!)
+  if (isExternal) {
+    for (const row of enriched) {
+      for (const key of Object.keys(row)) {
         if (row[key] === null) {
           delete row[key]
         }
       }
     }
   }
+
+  const protectedColumns = isExternal
+    ? PROTECTED_EXTERNAL_COLUMNS
+    : PROTECTED_INTERNAL_COLUMNS
+
+  const tableFields = Object.keys(table.schema).filter(
+    f => table.schema[f].visible !== false
+  )
+  enriched = enriched.map((r: Row) =>
+    pick(r, [...tableFields, ...protectedColumns])
+  )
+
   return (wasArray ? enriched : enriched[0]) as T
 }


### PR DESCRIPTION

## Description
Add the following security checks:
1. For tables without specified columns, generate queries with the column names specified on the table instead of a global select *. Some columns might be hidden to budibase and we don't want to fetch it to ensure they are never exposed.
2. For searches with specified columns (for views, for example) we are trimming any specified column that is not part of the actual view or table schema.
3. For queries with filters, we are trimming any filter that is not present on the allowed table/view column schema. This will prevent using searches to infer some hidden column values.

## Launchcontrol
Improve search row security resilience

## Feature branch env
[Feature Branch Link](http://fb-budi-8547-honor-table-and-view-schema-on-query.fb.qa.budibase.net)