### PR TITLE
Make generated passwords longer

### DIFF
--- a/packages/builder/src/pages/builder/portal/users/users/_components/AddUserModal.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/_components/AddUserModal.svelte
@@ -16,7 +16,7 @@
 
   export let showOnboardingTypeModal
 
-  const password = generatePassword()
+  const password = generatePassword(12)
   let disabled
   let userGroups = []
 
@@ -44,7 +44,7 @@
       {
         email: "",
         role: "appUser",
-        password: generatePassword(),
+        password: generatePassword(12),
         forceResetPassword: true,
         error: null,
       },
@@ -69,8 +69,12 @@
     return userData[index].error == null
   }
 
-  function generatePassword() {
-    return crypto.getRandomValues(new BigUint64Array(1))[0].toString(36)
+  function generatePassword(length) {
+    const array = new Uint8Array(length)
+    window.crypto.getRandomValues(array)
+    return Array.from(array, byte => byte.toString(36).padStart(2, "0"))
+      .join("")
+      .slice(0, length)
   }
 
   const onConfirm = () => {

--- a/packages/builder/src/pages/builder/portal/users/users/_components/AddUserModal.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/_components/AddUserModal.svelte
@@ -71,10 +71,7 @@
 
   // Minimum password length is 12 characters, but Math random will generate at most 11 characters, so add another 5.
   function generatePassword() {
-    return (
-      Math.random().toString(36).substring(2, 22) +
-      Math.random().toString(36).substring(2, 7)
-    )
+    return crypto.getRandomValues(new BigUint64Array(1))[0].toString(36)
   }
 
   const onConfirm = () => {

--- a/packages/builder/src/pages/builder/portal/users/users/_components/AddUserModal.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/_components/AddUserModal.svelte
@@ -69,7 +69,6 @@
     return userData[index].error == null
   }
 
-  // Minimum password length is 12 characters, but Math random will generate at most 11 characters, so add another 5.
   function generatePassword() {
     return crypto.getRandomValues(new BigUint64Array(1))[0].toString(36)
   }

--- a/packages/builder/src/pages/builder/portal/users/users/_components/AddUserModal.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/_components/AddUserModal.svelte
@@ -16,7 +16,7 @@
 
   export let showOnboardingTypeModal
 
-  const password = Math.random().toString(36).substring(2, 22)
+  const password = generatePassword()
   let disabled
   let userGroups = []
 
@@ -44,7 +44,7 @@
       {
         email: "",
         role: "appUser",
-        password: Math.random().toString(36).substring(2, 22),
+        password: generatePassword(),
         forceResetPassword: true,
         error: null,
       },
@@ -67,6 +67,14 @@
       userData[index].error = "Please enter an email address"
     }
     return userData[index].error == null
+  }
+
+  // Minimum password length is 12 characters, but Math random will generate at most 11 characters, so add another 5.
+  function generatePassword() {
+    return (
+      Math.random().toString(36).substring(2, 22) +
+      Math.random().toString(36).substring(2, 7)
+    )
   }
 
   const onConfirm = () => {

--- a/packages/builder/src/pages/builder/portal/users/users/index.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/index.svelte
@@ -216,7 +216,7 @@
       const newUser = {
         email: email,
         role: usersRole,
-        password: crypto.getRandomValues(new BigUint64Array(1))[0].toString(36),
+        password: generatePassword(12),
         forceResetPassword: true,
       }
 
@@ -286,6 +286,14 @@
     } catch (error) {
       notifications.error("Error deleting users")
     }
+  }
+
+  const generatePassword = length => {
+    const array = new Uint8Array(length)
+    window.crypto.getRandomValues(array)
+    return Array.from(array, byte => byte.toString(36).padStart(2, "0"))
+      .join("")
+      .slice(0, length)
   }
 
   onMount(async () => {

--- a/packages/builder/src/pages/builder/portal/users/users/index.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/index.svelte
@@ -216,7 +216,6 @@
       const newUser = {
         email: email,
         role: usersRole,
-        // Minimum password length is 12 characters, but Math random will generate at most 11 characters, so add another 5.
         password: crypto.getRandomValues(new BigUint64Array(1))[0].toString(36),
         forceResetPassword: true,
       }

--- a/packages/builder/src/pages/builder/portal/users/users/index.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/index.svelte
@@ -216,7 +216,10 @@
       const newUser = {
         email: email,
         role: usersRole,
-        password: Math.random().toString(36).substring(2, 22),
+        // Minimum password length is 12 characters, but Math random will generate at most 11 characters, so add another 5.
+        password:
+          Math.random().toString(36).substring(2, 22) +
+          Math.random().toString(36).substring(2, 7),
         forceResetPassword: true,
       }
 

--- a/packages/builder/src/pages/builder/portal/users/users/index.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/index.svelte
@@ -217,9 +217,7 @@
         email: email,
         role: usersRole,
         // Minimum password length is 12 characters, but Math random will generate at most 11 characters, so add another 5.
-        password:
-          Math.random().toString(36).substring(2, 22) +
-          Math.random().toString(36).substring(2, 7),
+        password: crypto.getRandomValues(new BigUint64Array(1))[0].toString(36),
         forceResetPassword: true,
       }
 

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -296,10 +296,9 @@ export const onboardUsers = async (
 
   let createdPasswords: Record<string, string> = {}
   const users: User[] = ctx.request.body.map(invite => {
-    // Minimum password length is 12 characters, but Math random will generate at most 11 characters, so add another 5.
-    const password =
-      Math.random().toString(36).substring(2, 22) +
-      Math.random().toString(36).substring(2, 7)
+    const password = crypto
+      .getRandomValues(new BigUint64Array(1))[0]
+      .toString(36)
     createdPasswords[invite.email] = password
 
     return {

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -41,6 +41,14 @@ import { BpmStatusKey, BpmStatusValue } from "@budibase/shared-core"
 
 const MAX_USERS_UPLOAD_LIMIT = 1000
 
+const generatePassword = (length: number) => {
+  const array = new Uint8Array(length)
+  crypto.getRandomValues(array)
+  return Array.from(array, byte => byte.toString(36).padStart(2, "0"))
+    .join("")
+    .slice(0, length)
+}
+
 export const save = async (ctx: UserCtx<User, SaveUserResponse>) => {
   try {
     const currentUserId = ctx.user?._id
@@ -296,9 +304,7 @@ export const onboardUsers = async (
 
   let createdPasswords: Record<string, string> = {}
   const users: User[] = ctx.request.body.map(invite => {
-    const password = crypto
-      .getRandomValues(new BigUint64Array(1))[0]
-      .toString(36)
+    const password = generatePassword(12)
     createdPasswords[invite.email] = password
 
     return {

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -296,7 +296,10 @@ export const onboardUsers = async (
 
   let createdPasswords: Record<string, string> = {}
   const users: User[] = ctx.request.body.map(invite => {
-    let password = Math.random().toString(36).substring(2, 22)
+    // Minimum password length is 12 characters, but Math random will generate at most 11 characters, so add another 5.
+    const password =
+      Math.random().toString(36).substring(2, 22) +
+      Math.random().toString(36).substring(2, 7)
     createdPasswords[invite.email] = password
 
     return {


### PR DESCRIPTION
## Description
Bug fix were backend validation was being hit because the generated passwords weren't long enough.

## Screenshots
![longer password](https://github.com/user-attachments/assets/7ad82bfa-990a-4e89-a7ae-c37b50f72477)

## Launchcontrol
Minor bug fix relating to auto-generated passwords.
