### PR TITLE
Use HBS context over helpers when names overlap (formulas)

### DIFF
--- a/packages/string-templates/src/index.ts
+++ b/packages/string-templates/src/index.ts
@@ -47,7 +47,10 @@ function testObject(object: any) {
   }
 }
 
-function findOverlappingHelpers(context: object) {
+function findOverlappingHelpers(context?: object) {
+  if (!context) {
+    return []
+  }
   const contextKeys = Object.keys(context)
   return contextKeys.filter(key => helperNames.includes(key))
 }

--- a/packages/string-templates/src/index.ts
+++ b/packages/string-templates/src/index.ts
@@ -65,6 +65,7 @@ function createTemplate(
   context?: object
 ) {
   opts = { ...defaultOpts, ...opts }
+  const helpersEnabled = !opts?.noHelpers
 
   // Finalising adds a helper, can't do this with no helpers
   const key = `${string}-${JSON.stringify(opts)}`
@@ -74,7 +75,7 @@ function createTemplate(
     return templateCache[key]
   }
 
-  const overlappingHelpers = !opts?.noHelpers
+  const overlappingHelpers = helpersEnabled
     ? findOverlappingHelpers(context)
     : []
 
@@ -83,9 +84,9 @@ function createTemplate(
     disabledHelpers: overlappingHelpers,
   })
 
-  if (context && !opts?.noHelpers) {
+  if (context && helpersEnabled) {
     if (overlappingHelpers.length > 0) {
-      for (let block of findHBSBlocks(string)) {
+      for (const block of findHBSBlocks(string)) {
         string = string.replace(
           block,
           prefixStrings(block, overlappingHelpers, "./")

--- a/packages/string-templates/src/processors/index.ts
+++ b/packages/string-templates/src/processors/index.ts
@@ -29,9 +29,9 @@ export function preprocess(string: string, opts: ProcessOptions) {
       processor => processor.name !== preprocessor.PreprocessorNames.FINALISE
     )
   }
+
   return process(string, processors, opts)
 }
 export function postprocess(string: string) {
-  let processors = postprocessor.processors
-  return process(string, processors)
+  return process(string, postprocessor.processors)
 }

--- a/packages/string-templates/src/processors/postprocessor.ts
+++ b/packages/string-templates/src/processors/postprocessor.ts
@@ -1,19 +1,21 @@
 import { LITERAL_MARKER } from "../helpers/constants"
 
-export const PostProcessorNames = {
-  CONVERT_LITERALS: "convert-literals",
+export enum PostProcessorNames {
+  CONVERT_LITERALS = "convert-literals",
 }
 
-class Postprocessor {
-  name: string
-  private fn: any
+type PostprocessorFn = (statement: string) => string
 
-  constructor(name: string, fn: any) {
+class Postprocessor {
+  name: PostProcessorNames
+  private readonly fn: PostprocessorFn
+
+  constructor(name: PostProcessorNames, fn: PostprocessorFn) {
     this.name = name
     this.fn = fn
   }
 
-  process(statement: any) {
+  process(statement: string) {
     return this.fn(statement)
   }
 }

--- a/packages/string-templates/src/processors/preprocessor.ts
+++ b/packages/string-templates/src/processors/preprocessor.ts
@@ -1,25 +1,28 @@
 import { HelperNames } from "../helpers"
 import { swapStrings, isAlphaNumeric } from "../utilities"
+import { ProcessOptions } from "../types"
 
 const FUNCTION_CASES = ["#", "else", "/"]
 
-export const PreprocessorNames = {
-  SWAP_TO_DOT: "swap-to-dot-notation",
-  FIX_FUNCTIONS: "fix-functions",
-  FINALISE: "finalise",
-  NORMALIZE_SPACES: "normalize-spaces",
+export enum PreprocessorNames {
+  SWAP_TO_DOT = "swap-to-dot-notation",
+  FIX_FUNCTIONS = "fix-functions",
+  FINALISE = "finalise",
+  NORMALIZE_SPACES = "normalize-spaces",
 }
+
+type PreprocessorFn = (statement: string, opts?: ProcessOptions) => string
 
 class Preprocessor {
   name: string
-  private fn: any
+  private readonly fn: PreprocessorFn
 
-  constructor(name: string, fn: any) {
+  constructor(name: PreprocessorNames, fn: PreprocessorFn) {
     this.name = name
     this.fn = fn
   }
 
-  process(fullString: string, statement: string, opts: Object) {
+  process(fullString: string, statement: string, opts: ProcessOptions) {
     const output = this.fn(statement, opts)
     const idx = fullString.indexOf(statement)
     return swapStrings(fullString, idx, statement.length, output)
@@ -56,11 +59,9 @@ export const processors = [
   }),
   new Preprocessor(
     PreprocessorNames.FINALISE,
-    (
-      statement: string,
-      opts: { noHelpers: any; disabledHelpers?: string[] }
-    ) => {
-      const noHelpers = opts && opts.noHelpers
+    (statement: string, opts?: ProcessOptions) => {
+      const noHelpers = opts?.noHelpers
+      const helpersEnabled = !noHelpers
       let insideStatement = statement.slice(2, statement.length - 2)
       if (insideStatement.charAt(0) === " ") {
         insideStatement = insideStatement.slice(1)
@@ -77,8 +78,8 @@ export const processors = [
       }
       const testHelper = possibleHelper.trim().toLowerCase()
       if (
-        !noHelpers &&
-        !opts.disabledHelpers?.includes(testHelper) &&
+        helpersEnabled &&
+        !opts?.disabledHelpers?.includes(testHelper) &&
         HelperNames().some(option => testHelper === option.toLowerCase())
       ) {
         insideStatement = `(${insideStatement})`

--- a/packages/string-templates/src/processors/preprocessor.ts
+++ b/packages/string-templates/src/processors/preprocessor.ts
@@ -13,12 +13,10 @@ export const PreprocessorNames = {
 class Preprocessor {
   name: string
   private fn: any
-  private helperNames: string[]
 
   constructor(name: string, fn: any) {
     this.name = name
     this.fn = fn
-    this.helperNames = HelperNames()
   }
 
   process(fullString: string, statement: string, opts: Object) {
@@ -81,7 +79,7 @@ export const processors = [
       if (
         !noHelpers &&
         !opts.disabledHelpers?.includes(testHelper) &&
-        this.helperNames.some(option => testHelper === option.toLowerCase())
+        HelperNames().some(option => testHelper === option.toLowerCase())
       ) {
         insideStatement = `(${insideStatement})`
       }

--- a/packages/string-templates/src/processors/preprocessor.ts
+++ b/packages/string-templates/src/processors/preprocessor.ts
@@ -13,10 +13,12 @@ export const PreprocessorNames = {
 class Preprocessor {
   name: string
   private fn: any
+  private helperNames: string[]
 
   constructor(name: string, fn: any) {
     this.name = name
     this.fn = fn
+    this.helperNames = HelperNames()
   }
 
   process(fullString: string, statement: string, opts: Object) {
@@ -56,7 +58,10 @@ export const processors = [
   }),
   new Preprocessor(
     PreprocessorNames.FINALISE,
-    (statement: string, opts: { noHelpers: any }) => {
+    (
+      statement: string,
+      opts: { noHelpers: any; disabledHelpers?: string[] }
+    ) => {
       const noHelpers = opts && opts.noHelpers
       let insideStatement = statement.slice(2, statement.length - 2)
       if (insideStatement.charAt(0) === " ") {
@@ -75,7 +80,8 @@ export const processors = [
       const testHelper = possibleHelper.trim().toLowerCase()
       if (
         !noHelpers &&
-        HelperNames().some(option => testHelper === option.toLowerCase())
+        !opts.disabledHelpers?.includes(testHelper) &&
+        this.helperNames.some(option => testHelper === option.toLowerCase())
       ) {
         insideStatement = `(${insideStatement})`
       }

--- a/packages/string-templates/src/types.ts
+++ b/packages/string-templates/src/types.ts
@@ -5,4 +5,5 @@ export interface ProcessOptions {
   noFinalise?: boolean
   escapeNewlines?: boolean
   onlyFound?: boolean
+  disabledHelpers?: string[]
 }

--- a/packages/string-templates/src/utilities.ts
+++ b/packages/string-templates/src/utilities.ts
@@ -66,3 +66,16 @@ export const btoa = (plainText: string) => {
 export const atob = (base64: string) => {
   return Buffer.from(base64, "base64").toString("utf-8")
 }
+
+export const prefixStrings = (
+  baseString: string,
+  strings: string[],
+  prefix: string
+) => {
+  // Escape any special characters in the strings to avoid regex errors
+  const escapedStrings = strings.map(str =>
+    str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  )
+  const regexPattern = new RegExp(`\\b(${escapedStrings.join("|")})\\b`, "g")
+  return baseString.replace(regexPattern, `${prefix}$1`)
+}

--- a/packages/string-templates/test/helpers.spec.ts
+++ b/packages/string-templates/test/helpers.spec.ts
@@ -483,3 +483,26 @@ describe("uuid", () => {
     expect(output).toMatch(UUID_REGEX)
   })
 })
+
+describe("helper overlap", () => {
+  it("should use context over helpers (regex test helper)", async () => {
+    const output = await processString("{{ test }}", { test: "a" })
+    expect(output).toEqual("a")
+  })
+
+  it("should use helper if no sum in context, return the context value otherwise", async () => {
+    const hbs = "{{ sum 1 2 }}"
+    const output = await processString(hbs, {})
+    expect(output).toEqual("3")
+    const secondaryOutput = await processString(hbs, { sum: "a" })
+    expect(secondaryOutput).toEqual("a")
+  })
+
+  it("should handle multiple cases", async () => {
+    const output = await processString("{{ literal (split test sum) }}", {
+      test: "a-b",
+      sum: "-",
+    })
+    expect(output).toEqual(["a", "b"])
+  })
+})

--- a/packages/string-templates/test/helpers.spec.ts
+++ b/packages/string-templates/test/helpers.spec.ts
@@ -505,4 +505,15 @@ describe("helper overlap", () => {
     })
     expect(output).toEqual(["a", "b"])
   })
+
+  it("should work as expected when no helpers are set", async () => {
+    const output = await processString(
+      "{{ sum }}",
+      {
+        sum: "a",
+      },
+      { noHelpers: true }
+    )
+    expect(output).toEqual("a")
+  })
 })


### PR DESCRIPTION
## Description
This implements a fix for when helpers names and fields in the context overlap - for example if you have a table with a column named `test` - then it will overlap with the test helper for regex.

This fix means that if a helper name overlaps that in context then the helper will become inaccessible - it has been decided this is better as being able to access the columns in your table easily is far more important than accessing the helpers - this is an edge case scenario but when it occurs can be quite confusing.

To do this we prefix any keys in HBS statements which overlap in context/helpers with `./` - this is explained in the handlebars docs here: https://handlebarsjs.com/guide/expressions.html#disambiguating-helpers-calls-and-property-lookup

## Addresses
- https://linear.app/budibase/issue/BUDI-8488/formula-columns-cannot-reference-other-columns-whose-names-clash-with
