### PR TITLE
App import issue (invalid attachments)

### DIFF
--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -308,16 +308,21 @@ export async function downloadAttachment(ctx: UserCtx) {
   if (attachments.length === 1) {
     const attachment = attachments[0]
     ctx.attachment(attachment.name)
-    ctx.body = await objectStore.getReadStream(
-      objectStore.ObjectStoreBuckets.APPS,
-      attachment.key
-    )
+    if (attachment.key) {
+      ctx.body = await objectStore.getReadStream(
+        objectStore.ObjectStoreBuckets.APPS,
+        attachment.key
+      )
+    }
   } else {
     const passThrough = new stream.PassThrough()
     const archive = archiver.create("zip")
     archive.pipe(passThrough)
 
     for (const attachment of attachments) {
+      if (!attachment.key) {
+        continue
+      }
       const attachmentStream = await objectStore.getReadStream(
         objectStore.ObjectStoreBuckets.APPS,
         attachment.key

--- a/packages/server/src/sdk/app/backups/imports.ts
+++ b/packages/server/src/sdk/app/backups/imports.ts
@@ -34,7 +34,7 @@ type TemplateType = {
 
 function rewriteAttachmentUrl(appId: string, attachment: RowAttachment) {
   // URL looks like: /prod-budi-app-assets/appId/attachments/file.csv
-  const urlParts = attachment.key.split("/")
+  const urlParts = attachment.key?.split("/") || []
   // remove the app ID
   urlParts.shift()
   // add new app ID

--- a/packages/server/src/utilities/rowProcessor/attachments.ts
+++ b/packages/server/src/utilities/rowProcessor/attachments.ts
@@ -44,8 +44,8 @@ export class AttachmentCleanup {
     if (type === FieldType.ATTACHMENTS && Array.isArray(rowData)) {
       return rowData
         .filter(attachment => attachment.key)
-        .map(attachment => attachment.key)
-    } else if ("key" in rowData) {
+        .map(attachment => attachment.key!)
+    } else if ("key" in rowData && rowData.key) {
       return [rowData.key]
     }
 

--- a/packages/types/src/documents/app/row.ts
+++ b/packages/types/src/documents/app/row.ts
@@ -131,7 +131,7 @@ export interface RowAttachment {
   size: number
   name: string
   extension: string
-  key: string
+  key?: string
   // Populated on read
   url?: string
 }


### PR DESCRIPTION
## Description
Fixing an issue with app import - old attachments which have an invalid state can cause the app to fail to import.

Unsure how to build a test for this, but I have updated the types to correctly show the state of attachments, that the `key` structure can be undefined, which helped find all the places this would be impactful.

## Addresses
- https://github.com/Budibase/budibase/issues/14375
