### PR TITLE
Invalid primary display setting (no relationship columns)

### DIFF
--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -44,14 +44,14 @@ import { DEFAULT_EMPLOYEE_TABLE_SCHEMA } from "../../../db/defaultData/datasourc
 import { generateRowIdField } from "../../../integrations/utils"
 
 describe.each([
-  // ["in-memory", undefined],
-  // ["lucene", undefined],
+  ["in-memory", undefined],
+  ["lucene", undefined],
   ["sqs", undefined],
-  // [DatabaseName.POSTGRES, getDatasource(DatabaseName.POSTGRES)],
-  // [DatabaseName.MYSQL, getDatasource(DatabaseName.MYSQL)],
-  // [DatabaseName.SQL_SERVER, getDatasource(DatabaseName.SQL_SERVER)],
-  // [DatabaseName.MARIADB, getDatasource(DatabaseName.MARIADB)],
-  // [DatabaseName.ORACLE, getDatasource(DatabaseName.ORACLE)],
+  [DatabaseName.POSTGRES, getDatasource(DatabaseName.POSTGRES)],
+  [DatabaseName.MYSQL, getDatasource(DatabaseName.MYSQL)],
+  [DatabaseName.SQL_SERVER, getDatasource(DatabaseName.SQL_SERVER)],
+  [DatabaseName.MARIADB, getDatasource(DatabaseName.MARIADB)],
+  [DatabaseName.ORACLE, getDatasource(DatabaseName.ORACLE)],
 ])("search (%s)", (name, dsProvider) => {
   const isSqs = name === "sqs"
   const isLucene = name === "lucene"

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -2762,55 +2762,56 @@ describe.each([
       })
     })
 
-  describe("primaryDisplay", () => {
-    beforeAll(async () => {
-      let toRelateTable = await createTable({
-        name: {
-          name: "name",
-          type: FieldType.STRING,
-        },
-      })
-      table = await config.api.table.save(
-        tableForDatasource(datasource, {
-          schema: {
-            name: {
-              name: "name",
-              type: FieldType.STRING,
-            },
-            link: {
-              name: "link",
-              type: FieldType.LINK,
-              relationshipType: RelationshipType.MANY_TO_ONE,
-              tableId: toRelateTable._id!,
-              fieldName: "link",
-            },
+  isSql &&
+    describe("primaryDisplay", () => {
+      beforeAll(async () => {
+        let toRelateTable = await createTable({
+          name: {
+            name: "name",
+            type: FieldType.STRING,
           },
         })
-      )
-      toRelateTable = await config.api.table.get(toRelateTable._id!)
-      await config.api.table.save({
-        ...toRelateTable,
-        primaryDisplay: "link",
+        table = await config.api.table.save(
+          tableForDatasource(datasource, {
+            schema: {
+              name: {
+                name: "name",
+                type: FieldType.STRING,
+              },
+              link: {
+                name: "link",
+                type: FieldType.LINK,
+                relationshipType: RelationshipType.MANY_TO_ONE,
+                tableId: toRelateTable._id!,
+                fieldName: "link",
+              },
+            },
+          })
+        )
+        toRelateTable = await config.api.table.get(toRelateTable._id!)
+        await config.api.table.save({
+          ...toRelateTable,
+          primaryDisplay: "link",
+        })
+        const relatedRows = await Promise.all([
+          config.api.row.save(toRelateTable._id!, { name: "test" }),
+        ])
+        await Promise.all([
+          config.api.row.save(table._id!, {
+            name: "test",
+            link: relatedRows.map(row => row._id),
+          }),
+        ])
       })
-      const relatedRows = await Promise.all([
-        config.api.row.save(toRelateTable._id!, { name: "test" }),
-      ])
-      await Promise.all([
-        config.api.row.save(table._id!, {
-          name: "test",
-          link: relatedRows.map(row => row._id),
-        }),
-      ])
-    })
 
-    it("should be able to query, primary display on related table shouldn't be used", async () => {
-      // this test makes sure that if a relationship has been specified as the primary display on a table
-      // it is ignored and another column is used instead
-      await expectQuery({}).toContain([
-        { name: "test", link: [{ primaryDisplay: "test" }] },
-      ])
+      it("should be able to query, primary display on related table shouldn't be used", async () => {
+        // this test makes sure that if a relationship has been specified as the primary display on a table
+        // it is ignored and another column is used instead
+        await expectQuery({}).toContain([
+          { name: "test", link: [{ primaryDisplay: "test" }] },
+        ])
+      })
     })
-  })
 
   !isLucene &&
     describe("$and", () => {

--- a/packages/server/src/db/linkedRows/index.ts
+++ b/packages/server/src/db/linkedRows/index.ts
@@ -229,12 +229,12 @@ function getPrimaryDisplayValue(row: Row, table?: Table) {
     invalid = INVALID_DISPLAY_COLUMN_TYPE.includes(primaryDisplaySchema.type)
   }
   if (invalid || !primaryDisplay) {
-    const validKey = Object.keys(table?.schema || {}).filter(
+    const validKey = Object.keys(table?.schema || {}).find(
       key =>
         table?.schema[key].type &&
         !INVALID_DISPLAY_COLUMN_TYPE.includes(table?.schema[key].type)
     )
-    return validKey[0] ? row[validKey[0]] : undefined
+    return validKey ? row[validKey] : undefined
   } else {
     return row[primaryDisplay]
   }

--- a/packages/server/src/db/linkedRows/index.ts
+++ b/packages/server/src/db/linkedRows/index.ts
@@ -1,10 +1,10 @@
 import LinkController from "./LinkController"
 import {
   getLinkDocuments,
-  getUniqueByProp,
-  getRelatedTableForField,
-  getLinkedTableIDs,
   getLinkedTable,
+  getLinkedTableIDs,
+  getRelatedTableForField,
+  getUniqueByProp,
 } from "./linkUtils"
 import flatten from "lodash/flatten"
 import { USER_METDATA_PREFIX } from "../utils"
@@ -13,15 +13,24 @@ import { getGlobalUsersFromMetadata } from "../../utilities/global"
 import { processFormulas } from "../../utilities/rowProcessor"
 import { context } from "@budibase/backend-core"
 import {
-  Table,
-  Row,
-  LinkDocumentValue,
-  FieldType,
   ContextUser,
+  FieldType,
+  LinkDocumentValue,
+  Row,
+  Table,
 } from "@budibase/types"
 import sdk from "../../sdk"
 
 export { IncludeDocs, getLinkDocuments, createLinkView } from "./linkUtils"
+
+const INVALID_DISPLAY_COLUMN_TYPE = [
+  FieldType.LINK,
+  FieldType.ATTACHMENTS,
+  FieldType.ATTACHMENT_SINGLE,
+  FieldType.SIGNATURE_SINGLE,
+  FieldType.BB_REFERENCE,
+  FieldType.BB_REFERENCE_SINGLE,
+]
 
 /**
  * This functionality makes sure that when rows with links are created, updated or deleted they are processed
@@ -207,6 +216,34 @@ export async function attachFullLinkedDocs(
 }
 
 /**
+ * Finds a valid value for the primary display, avoiding columns which break things
+ * like relationships (can be circular).
+ * @param row The row to lift a value from for the primary display.
+ * @param table The related table to attempt to work out the primary display column from.
+ */
+function getPrimaryDisplayValue(row: Row, table?: Table) {
+  const primaryDisplay = table?.primaryDisplay
+  let invalid = true
+  if (primaryDisplay) {
+    const primaryDisplaySchema = table?.schema[primaryDisplay]
+    invalid =
+      INVALID_DISPLAY_COLUMN_TYPE.includes(primaryDisplaySchema.type) &&
+      row[primaryDisplay]
+  }
+  if (invalid || !primaryDisplay) {
+    const validKey = Object.keys(table?.schema || {}).filter(
+      key =>
+        table?.schema[key].type &&
+        !INVALID_DISPLAY_COLUMN_TYPE.includes(table?.schema[key].type) &&
+        row[key]
+    )
+    return validKey[0] ? row[validKey[0]] : undefined
+  } else {
+    return row[primaryDisplay]
+  }
+}
+
+/**
  * This function will take the given enriched rows and squash the links to only contain the primary display field.
  * @param table The table from which the rows originated.
  * @param enriched The pre-enriched rows (full docs) which are to be squashed.
@@ -232,9 +269,7 @@ export async function squashLinksToPrimaryDisplay(
         const linkTblId = link.tableId || getRelatedTableForField(table, column)
         const linkedTable = await getLinkedTable(linkTblId!, linkedTables)
         const obj: any = { _id: link._id }
-        if (linkedTable?.primaryDisplay && link[linkedTable.primaryDisplay]) {
-          obj.primaryDisplay = link[linkedTable.primaryDisplay]
-        }
+        obj.primaryDisplay = getPrimaryDisplayValue(link, linkedTable)
         newLinks.push(obj)
       }
       row[column] = newLinks

--- a/packages/server/src/db/linkedRows/index.ts
+++ b/packages/server/src/db/linkedRows/index.ts
@@ -226,16 +226,13 @@ function getPrimaryDisplayValue(row: Row, table?: Table) {
   let invalid = true
   if (primaryDisplay) {
     const primaryDisplaySchema = table?.schema[primaryDisplay]
-    invalid =
-      INVALID_DISPLAY_COLUMN_TYPE.includes(primaryDisplaySchema.type) &&
-      row[primaryDisplay]
+    invalid = INVALID_DISPLAY_COLUMN_TYPE.includes(primaryDisplaySchema.type)
   }
   if (invalid || !primaryDisplay) {
     const validKey = Object.keys(table?.schema || {}).filter(
       key =>
         table?.schema[key].type &&
-        !INVALID_DISPLAY_COLUMN_TYPE.includes(table?.schema[key].type) &&
-        row[key]
+        !INVALID_DISPLAY_COLUMN_TYPE.includes(table?.schema[key].type)
     )
     return validKey[0] ? row[validKey[0]] : undefined
   } else {


### PR DESCRIPTION
## Description
Adding a test case for primary display columns, ignore when it has been set to a relationship, instead use another column which is valid in the table.

This can cause a circular structure to occur as the primary display can be a relationship pointing back at the original table, meaning the full row gets pulled in, causing a loop which breaks things.