### PR TITLE
Tiny fix for memo stores

### DIFF
--- a/packages/frontend-core/src/utils/memo.js
+++ b/packages/frontend-core/src/utils/memo.js
@@ -4,7 +4,7 @@ import { writable, get, derived } from "svelte/store"
 // subscribed children will only fire when a new value is actually set
 export const memo = initialValue => {
   const store = writable(initialValue)
-  let currentJSON = null
+  let currentJSON = JSON.stringify(null)
 
   const tryUpdateValue = newValue => {
     const newJSON = JSON.stringify(newValue)

--- a/packages/frontend-core/src/utils/memo.js
+++ b/packages/frontend-core/src/utils/memo.js
@@ -4,7 +4,7 @@ import { writable, get, derived } from "svelte/store"
 // subscribed children will only fire when a new value is actually set
 export const memo = initialValue => {
   const store = writable(initialValue)
-  let currentJSON = JSON.stringify(null)
+  let currentJSON = JSON.stringify(initialValue)
 
   const tryUpdateValue = newValue => {
     const newJSON = JSON.stringify(newValue)


### PR DESCRIPTION
## Description
Memos were recently optimised but this PR fixes a tiny issue where the initial value is not stringified, meaning reading from a memo before it has been updated will result in an unexpected null value which may not be handled properly by the calling code.
