### PR TITLE
Fix saving huge amounts of unnecessary data in settings

### DIFF
--- a/packages/builder/src/components/design/settings/controls/DataSourceSelect/DataSourceCategory.svelte
+++ b/packages/builder/src/components/design/settings/controls/DataSourceSelect/DataSourceCategory.svelte
@@ -29,7 +29,7 @@
       on:click={() => onSelect(data)}
     >
       <span class="spectrum-Menu-itemLabel">
-        {data.datasource?.name ? `${data.datasource.name} - ` : ""}{data.label}
+        {data.datasourceName ? `${data.datasourceName} - ` : ""}{data.label}
       </span>
       <svg
         class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark spectrum-Menu-itemIcon"

--- a/packages/builder/src/helpers/data/format.js
+++ b/packages/builder/src/helpers/data/format.js
@@ -1,12 +1,14 @@
 export const datasourceSelect = {
-  table: (table, datasources) => ({
-    label: table.name,
-    tableId: table._id,
-    type: "table",
-    datasource: datasources.find(
-      datasource => datasource._id === table.sourceId || table.datasourceId
-    ),
-  }),
+  table: (table, datasources) => {
+    const sourceId = table.sourceId || table.datasourceId
+    const datasource = datasources.find(ds => ds._id === sourceId)
+    return {
+      label: table.name,
+      tableId: table._id,
+      type: "table",
+      datasourceName: datasource?.name,
+    }
+  },
   viewV2: view => ({
     ...view,
     label: view.name,


### PR DESCRIPTION
## Description
This PR fixes an issue which was introduced a few months ago and resulted in us saving the entire datasource definition of a given datasource when you chose a table from that datasource in a component setting.

The feature that introduced this was intended to provide additional information in datasource settings by showing the datasource name, but it was implemented in a way that introduced this issue.

It's important we fix this as not only does it save massive amounts of bloated data which isn't needed, but it's also blocking the upcoming "connected screens" feature.