### PR TITLE
View UI ability to pick relationships on columns

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -84,7 +84,7 @@
   }
   let relationshipOpts1 = Object.values(PrettyRelationshipDefinitions)
   let relationshipOpts2 = Object.values(PrettyRelationshipDefinitions)
-  let relationshipMap = {
+  const relationshipMap = {
     [RelationshipType.ONE_TO_MANY]: {
       part1: PrettyRelationshipDefinitions.MANY,
       part2: PrettyRelationshipDefinitions.ONE,
@@ -98,7 +98,7 @@
       part2: PrettyRelationshipDefinitions.MANY,
     },
   }
-  let autoColumnInfo = getAutoColumnInformation()
+  const autoColumnInfo = getAutoColumnInformation()
   let optionsValid = true
 
   $: rowGoldenSample = RowUtils.generateGoldenSample($rows)

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingButton.svelte
@@ -2,16 +2,29 @@
   import { getContext } from "svelte"
   import { ActionButton, Popover } from "@budibase/bbui"
   import ColumnsSettingContent from "./ColumnsSettingContent.svelte"
+  import { FieldPermissions } from "../../../constants"
 
   export let allowViewReadonlyColumns = false
 
-  const { columns } = getContext("grid")
+  const { columns, datasource } = getContext("grid")
 
   let open = false
   let anchor
 
   $: anyRestricted = $columns.filter(col => !col.visible || col.readonly).length
   $: text = anyRestricted ? `Columns (${anyRestricted} restricted)` : "Columns"
+
+  $: permissions =
+    $datasource.type === "viewV2"
+      ? [
+          FieldPermissions.WRITABLE,
+          FieldPermissions.READONLY,
+          FieldPermissions.HIDDEN,
+        ]
+      : [FieldPermissions.WRITABLE, FieldPermissions.HIDDEN]
+  $: disabledPermissions = allowViewReadonlyColumns
+    ? []
+    : [FieldPermissions.READONLY]
 </script>
 
 <div bind:this={anchor}>
@@ -28,5 +41,9 @@
 </div>
 
 <Popover bind:open {anchor} align="left">
-  <ColumnsSettingContent columns={$columns} {allowViewReadonlyColumns} />
+  <ColumnsSettingContent
+    columns={$columns}
+    {permissions}
+    {disabledPermissions}
+  />
 </Popover>

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -4,10 +4,13 @@
   import { getColumnIcon } from "../lib/utils"
   import ToggleActionButtonGroup from "./ToggleActionButtonGroup.svelte"
   import { helpers } from "@budibase/shared-core"
+  import { FieldType } from "@budibase/types"
 
   export let allowViewReadonlyColumns = false
 
   const { columns, datasource, dispatch } = getContext("grid")
+
+  $: allowRelationshipSchemas = true // TODO
 
   const toggleColumn = async (column, permission) => {
     const visible = permission !== PERMISSION_OPTIONS.HIDDEN
@@ -94,11 +97,16 @@
           {column.label}
         </div>
       </div>
-      <ToggleActionButtonGroup
-        on:click={e => toggleColumn(column, e.detail)}
-        value={columnToPermissionOptions(column)}
-        options={column.options}
-      />
+      <div class="column-options">
+        <ToggleActionButtonGroup
+          on:click={e => toggleColumn(column, e.detail)}
+          value={columnToPermissionOptions(column)}
+          options={column.options}
+        />
+        {#if allowRelationshipSchemas && column.schema.type === FieldType.LINK}
+          <Icon size="S" name="ChevronRight" />
+        {/if}
+      </div>
     {/each}
   </div>
 </div>
@@ -130,5 +138,9 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+  }
+  .column-options {
+    display: flex;
+    gap: var(--spacing-s);
   }
 </style>

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -183,7 +183,7 @@
           value={columnToPermissionOptions(column)}
           options={column.options}
         />
-        {#if allowRelationshipSchemas && column.schema.type === FieldType.LINK}
+        {#if allowRelationshipSchemas && column.schema.type === FieldType.LINK && columnToPermissionOptions(column) !== FieldPermissions.HIDDEN}
           <div class="relationship-columns">
             <ActionButton
               on:click={e => {

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -145,14 +145,21 @@
     const visible = permission !== FieldPermissions.HIDDEN
     const readonly = permission === FieldPermissions.READONLY
 
-    await datasource.actions.addSchemaMutation(
-      column.name,
-      {
+    if (!fromRelationshipField) {
+      await datasource.actions.addSchemaMutation(column.name, {
         visible,
         readonly,
-      },
-      fromRelationshipField?.name
-    )
+      })
+    } else {
+      await datasource.actions.addSubSchemaMutation(
+        column.name,
+        fromRelationshipField.name,
+        {
+          visible,
+          readonly,
+        }
+      )
+    }
     try {
       await datasource.actions.saveSchemaMutations()
     } catch (e) {

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -125,10 +125,6 @@
                     label: schema.name,
                     schema,
                   }))
-                console.warn({
-                  columns,
-                  relationshipPanelColumns,
-                })
                 relationshipPanelAnchor = e.currentTarget
                 relationshipPanelOpen = !relationshipPanelOpen
               }}

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -225,6 +225,7 @@
 
 {#if allowRelationshipSchemas}
   <Popover
+    on:close={() => (relationshipFieldName = null)}
     open={!!relationshipField}
     anchor={relationshipPanelAnchor}
     align="right-outside"

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -91,6 +91,34 @@
 
     return PERMISSION_OPTIONS.WRITABLE
   }
+
+  function onRelationshipOpen(column, domElement) {
+    const relTable = $tables.list.find(
+      table => table._id === column.schema.tableId
+    )
+    relationshipPanelColumns = Object.values(relTable?.schema || {})
+      .filter(
+        schema => ![FieldType.LINK, FieldType.FORMULA].includes(schema.type)
+      )
+      .map(column => {
+        const isPrimaryDisplay = relTable.primaryDisplay === column.name
+        return {
+          name: column.name,
+          label: column.name,
+          primaryDisplay: isPrimaryDisplay,
+          schema: {
+            ...column,
+            visible: !!isPrimaryDisplay,
+          },
+        }
+      })
+      .sort((a, b) =>
+        a.primaryDisplay === b.primaryDisplay ? 0 : a.primaryDisplay ? -1 : 1
+      )
+
+    relationshipPanelAnchor = domElement
+    relationshipPanelOpen = !relationshipPanelOpen
+  }
 </script>
 
 <div class="content">
@@ -111,23 +139,7 @@
         {#if allowRelationshipSchemas && column.schema.type === FieldType.LINK}
           <div class="relationship-columns">
             <ActionButton
-              on:click={e => {
-                const relTable = $tables.list.find(
-                  table => table._id === column.schema.tableId
-                )
-                relationshipPanelColumns = Object.values(relTable?.schema || {})
-                  .filter(
-                    schema =>
-                      ![FieldType.LINK, FieldType.FORMULA].includes(schema.type)
-                  )
-                  .map(schema => ({
-                    name: schema.name,
-                    label: schema.name,
-                    schema,
-                  }))
-                relationshipPanelAnchor = e.currentTarget
-                relationshipPanelOpen = !relationshipPanelOpen
-              }}
+              on:click={e => onRelationshipOpen(column, e.currentTarget)}
               size="S"
               icon="ChevronRight"
               quiet

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -11,6 +11,7 @@
   export let permissions = [FieldPermissions.WRITABLE, FieldPermissions.HIDDEN]
   export let disabledPermissions = []
   export let columns
+  export let fromRelationshipField
 
   const { datasource, dispatch } = getContext("grid")
   $: permissionsObj = permissions.reduce(
@@ -27,15 +28,20 @@
   let relationshipPanelOpen = false
   let relationshipPanelAnchor
   let relationshipPanelColumns = []
+  let relationshipField
 
   const toggleColumn = async (column, permission) => {
     const visible = permission !== FieldPermissions.HIDDEN
     const readonly = permission === FieldPermissions.READONLY
 
-    await datasource.actions.addSchemaMutation(column.name, {
-      visible,
-      readonly,
-    })
+    await datasource.actions.addSchemaMutation(
+      column.name,
+      {
+        visible,
+        readonly,
+      },
+      fromRelationshipField?.name
+    )
     try {
       await datasource.actions.saveSchemaMutations()
     } catch (e) {
@@ -168,6 +174,7 @@
 
     relationshipPanelAnchor = domElement
     relationshipPanelOpen = !relationshipPanelOpen
+    relationshipField = column
   }
 </script>
 
@@ -210,6 +217,7 @@
     <svelte:self
       columns={relationshipPanelColumns}
       permissions={[FieldPermissions.READONLY, FieldPermissions.HIDDEN]}
+      fromRelationshipField={relationshipField}
     />
   </Popover>
 {/if}

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -1,14 +1,15 @@
 <script>
   import { getContext } from "svelte"
-  import { Icon, notifications } from "@budibase/bbui"
+  import { Icon, notifications, ActionButton } from "@budibase/bbui"
   import { getColumnIcon } from "../lib/utils"
   import ToggleActionButtonGroup from "./ToggleActionButtonGroup.svelte"
   import { helpers } from "@budibase/shared-core"
   import { FieldType } from "@budibase/types"
 
   export let allowViewReadonlyColumns = false
+  export let columns
 
-  const { columns, datasource, dispatch } = getContext("grid")
+  const { datasource, dispatch } = getContext("grid")
 
   $: allowRelationshipSchemas = true // TODO
 
@@ -37,7 +38,7 @@
     HIDDEN: "hidden",
   }
 
-  $: displayColumns = $columns.map(c => {
+  $: displayColumns = columns.map(c => {
     const isRequired = helpers.schema.isRequired(c.schema.constraints)
     const requiredTooltip = isRequired && "Required columns must be writable"
     const editEnabled =
@@ -104,7 +105,14 @@
           options={column.options}
         />
         {#if allowRelationshipSchemas && column.schema.type === FieldType.LINK}
-          <Icon size="S" name="ChevronRight" />
+          <div class="relationship-columns">
+            <ActionButton
+              on:click={() => dispatch("click", "")}
+              size="S"
+              icon="ChevronRight"
+              quiet
+            />
+          </div>
         {/if}
       </div>
     {/each}
@@ -112,6 +120,11 @@
 </div>
 
 <style>
+  .relationship-columns :global(.spectrum-ActionButton) {
+    width: 28px;
+    height: 28px;
+  }
+
   .content {
     padding: 12px 12px;
     display: flex;
@@ -141,6 +154,6 @@
   }
   .column-options {
     display: flex;
-    gap: var(--spacing-s);
+    gap: var(--spacing-xs);
   }
 </style>

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -116,6 +116,7 @@
 
   let relationshipPanelColumns = []
   $: {
+    relationshipPanelColumns = []
     if (relationshipField) {
       cache.actions.getTable(relationshipField.tableId).then(table => {
         relationshipPanelColumns = Object.entries(
@@ -141,8 +142,6 @@
               : 1
           )
       })
-    } else {
-      relationshipPanelColumns = []
     }
   }
 
@@ -218,7 +217,7 @@
 {#if allowRelationshipSchemas}
   <Popover
     on:close={() => (relationshipFieldName = null)}
-    open={!!relationshipField}
+    open={!!relationshipPanelColumns}
     anchor={relationshipPanelAnchor}
     align="right-outside"
   >

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -51,16 +51,44 @@
     const isRequired =
       c.primaryDisplay || helpers.schema.isRequired(c.schema.constraints)
 
+    const defaultPermission = permissions[0]
     const requiredTooltips = {
-      [FieldPermissions.WRITABLE]:
-        (c.primaryDisplay && "Display column must be writable") ||
-        (isRequired && "Required columns must be writable"),
-      [FieldPermissions.READONLY]:
-        (c.primaryDisplay && "Display column cannot be read-only") ||
-        (isRequired && "Required columns cannot be read-only"),
-      [FieldPermissions.HIDDEN]:
-        (c.primaryDisplay && "Display column cannot be hidden") ||
-        (isRequired && "Required columns cannot be hidden"),
+      [FieldPermissions.WRITABLE]: (() => {
+        if (defaultPermission === FieldPermissions.WRITABLE) {
+          if (c.primaryDisplay) {
+            return "Display column must be writable"
+          }
+          if (isRequired) {
+            return "Required columns must be writable"
+          }
+        }
+      })(),
+      [FieldPermissions.READONLY]: (() => {
+        if (defaultPermission === FieldPermissions.WRITABLE) {
+          if (c.primaryDisplay) {
+            return "Display column cannot be read-only"
+          }
+          if (isRequired) {
+            return "Required columns cannot be read-only"
+          }
+        }
+        if (defaultPermission === FieldPermissions.READONLY) {
+          if (c.primaryDisplay) {
+            return "Display column must be read-only"
+          }
+          if (isRequired) {
+            return "Required columns must be read-only"
+          }
+        }
+      })(),
+      [FieldPermissions.HIDDEN]: (() => {
+        if (c.primaryDisplay) {
+          return "Display column cannot be hidden"
+        }
+        if (isRequired) {
+          return "Required columns cannot be hidden"
+        }
+      })(),
     }
 
     const options = []
@@ -79,7 +107,7 @@
     if ((permission = permissionsObj[FieldPermissions.READONLY])) {
       const tooltip =
         (requiredTooltips[FieldPermissions.READONLY] || "Read-only") +
-        (permission.disabled && " (premium feature)")
+        (permission.disabled ? " (premium feature)" : "")
       options.push({
         icon: "Visibility",
         value: FieldPermissions.READONLY,

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -115,35 +115,31 @@
   })
 
   let relationshipPanelColumns = []
-  $: {
+  async function fetchRelationshipPanelColumns(relationshipField) {
     relationshipPanelColumns = []
-    if (relationshipField) {
-      cache.actions.getTable(relationshipField.tableId).then(table => {
-        relationshipPanelColumns = Object.entries(
-          relationshipField?.schema || {}
-        )
-          .map(([name, column]) => {
-            return {
-              name: name,
-              label: name,
-              primaryDisplay: name === table.primaryDisplay,
-              schema: {
-                type: table.schema[name].type,
-                visible: column.visible,
-                readonly: column.readonly,
-              },
-            }
-          })
-          .sort((a, b) =>
-            a.primaryDisplay === b.primaryDisplay
-              ? 0
-              : a.primaryDisplay
-              ? -1
-              : 1
-          )
-      })
+    if (!relationshipField) {
+      return
     }
+
+    const table = await cache.actions.getTable(relationshipField.tableId)
+    relationshipPanelColumns = Object.entries(relationshipField?.schema || {})
+      .map(([name, column]) => {
+        return {
+          name: name,
+          label: name,
+          primaryDisplay: name === table.primaryDisplay,
+          schema: {
+            type: table.schema[name].type,
+            visible: column.visible,
+            readonly: column.readonly,
+          },
+        }
+      })
+      .sort((a, b) =>
+        a.primaryDisplay === b.primaryDisplay ? 0 : a.primaryDisplay ? -1 : 1
+      )
   }
+  $: fetchRelationshipPanelColumns(relationshipField)
 
   async function toggleColumn(column, permission) {
     const visible = permission !== FieldPermissions.HIDDEN
@@ -217,7 +213,7 @@
 {#if allowRelationshipSchemas}
   <Popover
     on:close={() => (relationshipFieldName = null)}
-    open={!!relationshipPanelColumns}
+    open={!!relationshipField}
     anchor={relationshipPanelAnchor}
     align="right-outside"
   >

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -159,6 +159,7 @@
               schema =>
                 ![FieldType.LINK, FieldType.FORMULA].includes(schema.type)
             )
+            .filter(schema => schema.visible !== false)
             .map(column => {
               const isPrimaryDisplay = relTable.primaryDisplay === column.name
               const isReadonly = !!(

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -115,13 +115,16 @@
                 const relTable = $tables.list.find(
                   table => table._id === column.schema.tableId
                 )
-                relationshipPanelColumns = Object.values(
-                  relTable?.schema || {}
-                ).map(schema => ({
-                  name: schema.name,
-                  label: schema.name,
-                  schema,
-                }))
+                relationshipPanelColumns = Object.values(relTable?.schema || {})
+                  .filter(
+                    schema =>
+                      ![FieldType.LINK, FieldType.FORMULA].includes(schema.type)
+                  )
+                  .map(schema => ({
+                    name: schema.name,
+                    label: schema.name,
+                    schema,
+                  }))
                 console.warn({
                   columns,
                   relationshipPanelColumns,

--- a/packages/frontend-core/src/components/grid/stores/cache.js
+++ b/packages/frontend-core/src/components/grid/stores/cache.js
@@ -4,35 +4,40 @@ export const createActions = context => {
   // Cache for the primary display columns of different tables.
   // If we ever need to cache table definitions for other purposes then we can
   // expand this to be a more generic cache.
-  let primaryDisplayCache = {}
+  let tableCache = {}
 
-  const resetPrimaryDisplayCache = () => {
-    primaryDisplayCache = {}
+  const resetCache = () => {
+    tableCache = {}
   }
 
-  const getPrimaryDisplayForTableId = async tableId => {
+  const fetchTable = async tableId => {
     // If we've never encountered this tableId before then store a promise that
     // resolves to the primary display so that subsequent invocations before the
     // promise completes can reuse this promise
-    if (!primaryDisplayCache[tableId]) {
-      primaryDisplayCache[tableId] = new Promise(resolve => {
-        API.fetchTableDefinition(tableId).then(def => {
-          const display = def?.primaryDisplay || def?.schema?.[0]?.name
-          primaryDisplayCache[tableId] = display
-          resolve(display)
-        })
-      })
+    if (!tableCache[tableId]) {
+      tableCache[tableId] = API.fetchTableDefinition(tableId)
     }
-
     // We await the result so that we account for both promises and primitives
-    return await primaryDisplayCache[tableId]
+    return await tableCache[tableId]
+  }
+
+  const getPrimaryDisplayForTableId = async tableId => {
+    const table = await fetchTable(tableId)
+    const display = table?.primaryDisplay || table?.schema?.[0]?.name
+    return display
+  }
+
+  const getTable = async tableId => {
+    const table = await fetchTable(tableId)
+    return table
   }
 
   return {
     cache: {
       actions: {
         getPrimaryDisplayForTableId,
-        resetPrimaryDisplayCache,
+        getTable,
+        resetCache,
       },
     },
   }
@@ -43,5 +48,5 @@ export const initialise = context => {
 
   // Wipe the caches whenever the datasource changes to ensure we aren't
   // storing any stale information
-  datasource.subscribe(cache.actions.resetPrimaryDisplayCache)
+  datasource.subscribe(cache.actions.resetCache)
 }

--- a/packages/frontend-core/src/components/grid/stores/datasource.js
+++ b/packages/frontend-core/src/components/grid/stores/datasource.js
@@ -168,34 +168,38 @@ export const createActions = context => {
   }
 
   // Adds a schema mutation for a single field
-  const addSchemaMutation = (field, mutation, fromNestedField) => {
+  const addSchemaMutation = (field, mutation) => {
     if (!field || !mutation) {
       return
     }
-    if (fromNestedField) {
-      subSchemaMutations.update($subSchemaMutations => {
-        return {
-          ...$subSchemaMutations,
-          [fromNestedField]: {
-            ...$subSchemaMutations[fromNestedField],
-            [field]: {
-              ...($subSchemaMutations[fromNestedField] || {})[field],
-              ...mutation,
-            },
-          },
-        }
-      })
-    } else {
-      schemaMutations.update($schemaMutations => {
-        return {
-          ...$schemaMutations,
+    schemaMutations.update($schemaMutations => {
+      return {
+        ...$schemaMutations,
+        [field]: {
+          ...$schemaMutations[field],
+          ...mutation,
+        },
+      }
+    })
+  }
+
+  // Adds a nested schema mutation for a single field
+  const addSubSchemaMutation = (field, fromField, mutation) => {
+    if (!field || !fromField || !mutation) {
+      return
+    }
+    subSchemaMutations.update($subSchemaMutations => {
+      return {
+        ...$subSchemaMutations,
+        [fromField]: {
+          ...$subSchemaMutations[fromField],
           [field]: {
-            ...$schemaMutations[field],
+            ...($subSchemaMutations[fromField] || {})[field],
             ...mutation,
           },
-        }
-      })
-    }
+        },
+      }
+    })
   }
 
   // Adds schema mutations for multiple fields at once
@@ -304,6 +308,7 @@ export const createActions = context => {
         canUseColumn,
         changePrimaryDisplay,
         addSchemaMutation,
+        addSubSchemaMutation,
         addSchemaMutations,
         saveSchemaMutations,
         resetSchemaMutations,

--- a/packages/frontend-core/src/components/grid/stores/datasource.js
+++ b/packages/frontend-core/src/components/grid/stores/datasource.js
@@ -147,17 +147,27 @@ export const createActions = context => {
   }
 
   // Adds a schema mutation for a single field
-  const addSchemaMutation = (field, mutation) => {
+  const addSchemaMutation = (field, mutation, fromNestedField) => {
     if (!field || !mutation) {
       return
     }
     schemaMutations.update($schemaMutations => {
-      return {
-        ...$schemaMutations,
-        [field]: {
-          ...$schemaMutations[field],
+      if (fromNestedField) {
+        const result = { ...$schemaMutations }
+        result[fromNestedField] ??= { schema: {} }
+        result[fromNestedField].schema[field] = {
+          ...result[fromNestedField].schema[field],
           ...mutation,
-        },
+        }
+        return result
+      } else {
+        return {
+          ...$schemaMutations,
+          [field]: {
+            ...$schemaMutations[field],
+            ...mutation,
+          },
+        }
       }
     })
   }

--- a/packages/frontend-core/src/constants.js
+++ b/packages/frontend-core/src/constants.js
@@ -161,3 +161,9 @@ export const TypeIconMap = {
 export const OptionColours = [...new Array(12).keys()].map(idx => {
   return `hsla(${((idx + 1) * 222) % 360}, 90%, 75%, 0.3)`
 })
+
+export const FieldPermissions = {
+  WRITABLE: "writable",
+  READONLY: "readonly",
+  HIDDEN: "hidden",
+}


### PR DESCRIPTION
## Description
Frontend part of new relationship picker. It will be only one level down (no nested relationships)

## Screenshots
### In tables
https://github.com/user-attachments/assets/4d1654f4-da35-463e-b35c-fefae04d69ba

### In views
https://github.com/user-attachments/assets/e0fd6886-7d36-45d6-be00-32a53b041c88

### Link and formula fields are not display and field types icons are used
<img width="564" alt="image" src="https://github.com/user-attachments/assets/400a34a7-ec93-409d-a98d-028468d7ab9a">

### Tooltips
#### Relation display field
<img width="569" alt="image" src="https://github.com/user-attachments/assets/21a4d771-9fef-4114-9c84-30b02ef5f82a">
<img width="595" alt="image" src="https://github.com/user-attachments/assets/42c4ea1c-fff6-46d3-9035-57a9ab4361e5">


#### Required fields
<img width="333" alt="image" src="https://github.com/user-attachments/assets/c36ab339-cd29-4abe-a197-a8b24ebea9ac">

<img width="369" alt="image" src="https://github.com/user-attachments/assets/c3ef7a0f-1415-4287-902e-1663e29d4b7a">




