### PR TITLE
Persist view related schemas

### DIFF
--- a/packages/server/src/api/controllers/view/viewsV2.ts
+++ b/packages/server/src/api/controllers/view/viewsV2.ts
@@ -3,11 +3,12 @@ import {
   CreateViewRequest,
   Ctx,
   RequiredKeys,
-  ViewUIFieldMetadata,
   UpdateViewRequest,
   ViewResponse,
   ViewResponseEnriched,
   ViewV2,
+  ViewFieldMetadata,
+  RelationSchemaField,
 } from "@budibase/types"
 import { builderSocket, gridSocket } from "../../../websockets"
 
@@ -18,21 +19,41 @@ async function parseSchema(view: CreateViewRequest) {
   const finalViewSchema =
     view.schema &&
     Object.entries(view.schema).reduce((p, [fieldName, schemaValue]) => {
-      const fieldSchema: RequiredKeys<ViewUIFieldMetadata> = {
+      let fieldRelatedSchema:
+        | Record<string, RequiredKeys<RelationSchemaField>>
+        | undefined
+      if (schemaValue.schema) {
+        fieldRelatedSchema = Object.entries(schemaValue.schema).reduce<
+          NonNullable<typeof fieldRelatedSchema>
+        >((acc, [key, fieldSchema]) => {
+          acc[key] = {
+            visible: fieldSchema.visible,
+            readonly: fieldSchema.readonly,
+          }
+          return acc
+        }, {})
+      }
+
+      const fieldSchema: RequiredKeys<
+        ViewFieldMetadata & {
+          schema: typeof fieldRelatedSchema
+        }
+      > = {
         order: schemaValue.order,
         width: schemaValue.width,
         visible: schemaValue.visible,
         readonly: schemaValue.readonly,
         icon: schemaValue.icon,
+        schema: fieldRelatedSchema,
       }
       Object.entries(fieldSchema)
         .filter(([, val]) => val === undefined)
         .forEach(([key]) => {
-          delete fieldSchema[key as keyof ViewUIFieldMetadata]
+          delete fieldSchema[key as keyof ViewFieldMetadata]
         })
       p[fieldName] = fieldSchema
       return p
-    }, {} as Record<string, RequiredKeys<ViewUIFieldMetadata>>)
+    }, {} as Record<string, RequiredKeys<ViewFieldMetadata>>)
   return finalViewSchema
 }
 

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -15,7 +15,7 @@ import {
   Table,
   TableSourceType,
   UpdateViewRequest,
-  ViewUIFieldMetadata,
+  ViewFieldMetadata,
   ViewV2,
   SearchResponse,
   BasicOperator,
@@ -953,7 +953,7 @@ describe.each([
       const updatedTable = await config.api.table.get(table._id!)
       const viewSchema = updatedTable.views![view!.name!].schema as Record<
         string,
-        ViewUIFieldMetadata
+        ViewFieldMetadata
       >
       expect(viewSchema.Price?.visible).toEqual(false)
       expect(viewSchema.Category?.visible).toEqual(true)

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -2,7 +2,7 @@ import {
   RenameColumn,
   TableSchema,
   View,
-  ViewUIFieldMetadata,
+  ViewFieldMetadata,
   ViewV2,
   ViewV2Enriched,
 } from "@budibase/types"
@@ -58,7 +58,7 @@ async function guardViewSchema(
     if (viewSchema[field].readonly) {
       if (
         !(await features.isViewReadonlyColumnsEnabled()) &&
-        !(tableSchemaField as ViewUIFieldMetadata).readonly
+        !(tableSchemaField as ViewFieldMetadata).readonly
       ) {
         throw new HTTPError(`Readonly fields are not enabled`, 400)
       }

--- a/packages/types/src/documents/app/table/schema.ts
+++ b/packages/types/src/documents/app/table/schema.ts
@@ -25,7 +25,16 @@ interface BaseRelationshipFieldMetadata
   tableId: string
   tableRev?: string
   subtype?: AutoFieldSubType.CREATED_BY | AutoFieldSubType.UPDATED_BY
+  schema: RelationFieldSchema
 }
+
+export type RelationFieldSchema = Record<
+  string,
+  {
+    visible?: boolean
+    readonly?: boolean
+  }
+>
 
 // External tables use junction tables, internal tables don't require them
 type ManyToManyJunctionTableMetadata =

--- a/packages/types/src/documents/app/table/schema.ts
+++ b/packages/types/src/documents/app/table/schema.ts
@@ -25,7 +25,7 @@ interface BaseRelationshipFieldMetadata
   tableId: string
   tableRev?: string
   subtype?: AutoFieldSubType.CREATED_BY | AutoFieldSubType.UPDATED_BY
-  schema: RelationFieldSchema
+  schema?: RelationFieldSchema
 }
 
 export type RelationFieldSchema = Record<

--- a/packages/types/src/documents/app/table/schema.ts
+++ b/packages/types/src/documents/app/table/schema.ts
@@ -25,16 +25,13 @@ interface BaseRelationshipFieldMetadata
   tableId: string
   tableRev?: string
   subtype?: AutoFieldSubType.CREATED_BY | AutoFieldSubType.UPDATED_BY
-  schema?: RelationFieldSchema
+  schema?: Record<string, RelationSchemaField>
 }
 
-export type RelationFieldSchema = Record<
-  string,
-  {
-    visible?: boolean
-    readonly?: boolean
-  }
->
+export type RelationSchemaField = {
+  visible?: boolean
+  readonly?: boolean
+}
 
 // External tables use junction tables, internal tables don't require them
 type ManyToManyJunctionTableMetadata =

--- a/packages/types/src/documents/app/view.ts
+++ b/packages/types/src/documents/app/view.ts
@@ -1,5 +1,5 @@
 import { SearchFilter, SortOrder, SortType } from "../../api"
-import { UIFieldMetadata } from "./table"
+import { RelationSchemaField, UIFieldMetadata } from "./table"
 import { Document } from "../document"
 import { DBView } from "../../sdk"
 
@@ -31,11 +31,6 @@ export interface View {
   reduce?: any
   meta?: ViewTemplateOpts
   groupBy?: string
-}
-
-export type RelationSchemaField = {
-  visible?: boolean
-  readonly?: boolean
 }
 
 export type ViewFieldMetadata = UIFieldMetadata & {

--- a/packages/types/src/documents/app/view.ts
+++ b/packages/types/src/documents/app/view.ts
@@ -1,5 +1,5 @@
 import { SearchFilter, SortOrder, SortType } from "../../api"
-import { RelationFieldSchema, UIFieldMetadata } from "./table"
+import { UIFieldMetadata } from "./table"
 import { Document } from "../document"
 import { DBView } from "../../sdk"
 

--- a/packages/types/src/documents/app/view.ts
+++ b/packages/types/src/documents/app/view.ts
@@ -1,5 +1,5 @@
 import { SearchFilter, SortOrder, SortType } from "../../api"
-import { UIFieldMetadata } from "./table"
+import { RelationFieldSchema, UIFieldMetadata } from "./table"
 import { Document } from "../document"
 import { DBView } from "../../sdk"
 
@@ -33,8 +33,14 @@ export interface View {
   groupBy?: string
 }
 
-export type ViewUIFieldMetadata = UIFieldMetadata & {
+export type RelationSchemaField = {
+  visible?: boolean
   readonly?: boolean
+}
+
+export type ViewFieldMetadata = UIFieldMetadata & {
+  readonly?: boolean
+  schema?: Record<string, RelationSchemaField>
 }
 
 export interface ViewV2 {
@@ -49,7 +55,7 @@ export interface ViewV2 {
     order?: SortOrder
     type?: SortType
   }
-  schema?: Record<string, ViewUIFieldMetadata>
+  schema?: Record<string, ViewFieldMetadata>
 }
 
 export type ViewSchema = ViewCountOrSumSchema | ViewStatisticsSchema


### PR DESCRIPTION
## Description
We are going to enable picking certain fields from related fields. These fields (and only these ones) will be used when enriching relations. This is a wide change, this PR only updates the types in order to support the proper configuration at the API level.
1. Add a new field `schema` on relationship metadata. This will persist the field visibility for that given relationship (using the same writable/readonly/hidden strategy used in views)
2. Update the view schema fields metadata to also support this configuration, allowing the views to also store the permission information
3. Updating the view dto mapping to persist these new fields (this is not required for tables as we don't use API dtos and mappers in their save endpoints)

## Launchcontrol
Updating types around relationship fields