### PR TITLE
Enrich related schema fields

### DIFF
--- a/packages/server/src/api/controllers/table/index.ts
+++ b/packages/server/src/api/controllers/table/index.ts
@@ -91,10 +91,9 @@ export async function find(ctx: UserCtx<void, TableResponse>) {
   const tableId = ctx.params.tableId
   const table = await sdk.tables.getTable(tableId)
 
-  const enrichedSchema = await sdk.tables.enrichRelationshipSchema(table)
   const result = sdk.tables.enrichViewSchemas({
     ...table,
-    schema: enrichedSchema,
+    schema: await sdk.tables.enrichRelationshipSchema(table.schema),
   })
   ctx.body = result
 }

--- a/packages/server/src/api/controllers/table/index.ts
+++ b/packages/server/src/api/controllers/table/index.ts
@@ -91,7 +91,9 @@ export async function find(ctx: UserCtx<void, TableResponse>) {
   const tableId = ctx.params.tableId
   const table = await sdk.tables.getTable(tableId)
 
-  ctx.body = sdk.tables.enrichViewSchemas(table)
+  let result = await sdk.tables.enrichRelationshipSchemas(table)
+  result = sdk.tables.enrichViewSchemas(result)
+  ctx.body = result
 }
 
 export async function save(ctx: UserCtx<SaveTableRequest, SaveTableResponse>) {

--- a/packages/server/src/api/controllers/table/index.ts
+++ b/packages/server/src/api/controllers/table/index.ts
@@ -91,8 +91,11 @@ export async function find(ctx: UserCtx<void, TableResponse>) {
   const tableId = ctx.params.tableId
   const table = await sdk.tables.getTable(tableId)
 
-  let result = await sdk.tables.enrichRelationshipSchemas(table)
-  result = sdk.tables.enrichViewSchemas(result)
+  const enrichedSchema = await sdk.tables.enrichRelationshipSchema(table)
+  const result = sdk.tables.enrichViewSchemas({
+    ...table,
+    schema: enrichedSchema,
+  })
   ctx.body = result
 }
 

--- a/packages/server/src/api/controllers/table/index.ts
+++ b/packages/server/src/api/controllers/table/index.ts
@@ -88,7 +88,7 @@ export async function fetch(ctx: UserCtx<void, FetchTablesResponse>) {
   for (const table of [...internal, ...external]) {
     result.push(await sdk.tables.enrichViewSchemas(table))
   }
-  ctx.body = result //
+  ctx.body = result
 }
 
 export async function find(ctx: UserCtx<void, TableResponse>) {

--- a/packages/server/src/api/controllers/table/index.ts
+++ b/packages/server/src/api/controllers/table/index.ts
@@ -84,14 +84,18 @@ export async function fetch(ctx: UserCtx<void, FetchTablesResponse>) {
     }
   })
 
-  ctx.body = [...internal, ...external].map(sdk.tables.enrichViewSchemas)
+  const result: FetchTablesResponse = []
+  for (const table of [...internal, ...external]) {
+    result.push(await sdk.tables.enrichViewSchemas(table))
+  }
+  ctx.body = result //
 }
 
 export async function find(ctx: UserCtx<void, TableResponse>) {
   const tableId = ctx.params.tableId
   const table = await sdk.tables.getTable(tableId)
 
-  const result = sdk.tables.enrichViewSchemas({
+  const result = await sdk.tables.enrichViewSchemas({
     ...table,
     schema: await sdk.tables.enrichRelationshipSchema(table.schema),
   })
@@ -109,7 +113,7 @@ export async function save(ctx: UserCtx<SaveTableRequest, SaveTableResponse>) {
   const api = pickApi({ table })
   let savedTable = await api.save(ctx, renaming)
   if (!table._id) {
-    savedTable = sdk.tables.enrichViewSchemas(savedTable)
+    savedTable = await sdk.tables.enrichViewSchemas(savedTable)
     await events.table.created(savedTable)
   } else {
     await events.table.updated(savedTable)

--- a/packages/server/src/sdk/app/tables/getters.ts
+++ b/packages/server/src/sdk/app/tables/getters.ts
@@ -173,9 +173,6 @@ export async function enrichRelationshipSchema(
       field.schema[relTableFieldName] = {
         visible: isReadonly,
         readonly: isReadonly,
-        // @ts-ignore this would require a big refactor around field typings, having document types and api dtos
-        primaryDisplay: isPrimaryDisplay,
-        type: relTableField.type,
       }
     }
   }

--- a/packages/server/src/sdk/app/tables/getters.ts
+++ b/packages/server/src/sdk/app/tables/getters.ts
@@ -9,6 +9,7 @@ import {
   Database,
   FieldType,
   INTERNAL_TABLE_SOURCE_ID,
+  RelationSchemaField,
   RelationshipFieldMetadata,
   Table,
   TableResponse,
@@ -156,6 +157,8 @@ export async function enrichRelationshipSchema(
     }
     const relTable = tableCache[field.tableId]
 
+    const resultSchema: Record<string, RelationSchemaField> = {}
+
     for (const relTableFieldName of Object.keys(relTable.schema)) {
       const relTableField = relTable.schema[relTableFieldName]
       if (relTableField.type === FieldType.LINK) {
@@ -166,15 +169,16 @@ export async function enrichRelationshipSchema(
         continue
       }
 
-      field.schema ??= {}
       const isPrimaryDisplay = relTableFieldName === relTable.primaryDisplay
       const isReadonly =
-        isPrimaryDisplay || !!field.schema[relTableFieldName]?.readonly
-      field.schema[relTableFieldName] = {
+        isPrimaryDisplay ||
+        !!(field.schema && field.schema[relTableFieldName]?.readonly)
+      resultSchema[relTableFieldName] = {
         visible: isReadonly,
         readonly: isReadonly,
       }
     }
+    field.schema = resultSchema
   }
 
   const result: TableSchema = {}

--- a/packages/server/src/sdk/app/tables/getters.ts
+++ b/packages/server/src/sdk/app/tables/getters.ts
@@ -170,10 +170,11 @@ export async function enrichRelationshipSchemas(
       const isReadonly =
         isPrimaryDisplay || !!field.schema[relTableFieldName]?.readonly
       field.schema[relTableFieldName] = {
-        primaryDisplay: isPrimaryDisplay,
-        type: relTableField.type,
         visible: isReadonly,
         readonly: isReadonly,
+        // @ts-ignore this would require a big refactor around field typings, having document types and api dtos
+        primaryDisplay: isPrimaryDisplay,
+        type: relTableField.type,
       }
     }
   }

--- a/packages/server/src/sdk/app/tables/getters.ts
+++ b/packages/server/src/sdk/app/tables/getters.ts
@@ -12,6 +12,7 @@ import {
   RelationshipFieldMetadata,
   Table,
   TableResponse,
+  TableSchema,
   TableSourceType,
   TableViewsResponse,
 } from "@budibase/types"
@@ -144,9 +145,9 @@ export async function getTables(tableIds: string[]): Promise<Table[]> {
   return processTables(tables)
 }
 
-export async function enrichRelationshipSchemas(
+export async function enrichRelationshipSchema(
   table: Table
-): Promise<TableResponse> {
+): Promise<TableSchema> {
   const tableCache: Record<string, Table> = {}
 
   async function populateRelTableSchema(field: RelationshipFieldMetadata) {
@@ -179,14 +180,14 @@ export async function enrichRelationshipSchemas(
     }
   }
 
-  const result: TableResponse = { ...table, schema: {}, views: {} }
+  const result: TableSchema = {}
   for (const fieldName of Object.keys(table.schema)) {
     const field = { ...table.schema[fieldName] }
     if (field.type === FieldType.LINK) {
       await populateRelTableSchema(field)
     }
 
-    result.schema[fieldName] = field
+    result[fieldName] = field
   }
   return result
 }

--- a/packages/server/src/sdk/app/tables/getters.ts
+++ b/packages/server/src/sdk/app/tables/getters.ts
@@ -146,7 +146,7 @@ export async function getTables(tableIds: string[]): Promise<Table[]> {
 }
 
 export async function enrichRelationshipSchema(
-  table: Table
+  schema: TableSchema
 ): Promise<TableSchema> {
   const tableCache: Record<string, Table> = {}
 
@@ -178,8 +178,8 @@ export async function enrichRelationshipSchema(
   }
 
   const result: TableSchema = {}
-  for (const fieldName of Object.keys(table.schema)) {
-    const field = { ...table.schema[fieldName] }
+  for (const fieldName of Object.keys(schema)) {
+    const field = { ...schema[fieldName] }
     if (field.type === FieldType.LINK) {
       await populateRelTableSchema(field)
     }

--- a/packages/server/src/sdk/app/tables/tests/tables.spec.ts
+++ b/packages/server/src/sdk/app/tables/tests/tables.spec.ts
@@ -75,7 +75,7 @@ describe("table sdk", () => {
       const view1 = getTable()
       const view2 = getTable()
       const view3 = getTable()
-      const res = sdk.tables.enrichViewSchemas({
+      const res = await sdk.tables.enrichViewSchemas({
         ...basicTable,
         views: {
           [view1.name]: view1,

--- a/packages/server/src/sdk/app/views/external.ts
+++ b/packages/server/src/sdk/app/views/external.ts
@@ -33,7 +33,7 @@ export async function getEnriched(viewId: string): Promise<ViewV2Enriched> {
   if (!found) {
     throw new Error("No view found")
   }
-  return enrichSchema(found, table.schema)
+  return await enrichSchema(found, table.schema)
 }
 
 export async function create(

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -153,11 +153,12 @@ export function allowedFields(view: View | ViewV2) {
   ]
 }
 
-export function enrichSchema(
+export async function enrichSchema(
   view: ViewV2,
   tableSchema: TableSchema
-): ViewV2Enriched {
+): Promise<ViewV2Enriched> {
   let schema = cloneDeep(tableSchema)
+
   const anyViewOrder = Object.values(view.schema || {}).some(
     ui => ui.order != null
   )
@@ -170,6 +171,8 @@ export function enrichSchema(
       order: anyViewOrder ? ui?.order ?? undefined : schema[key].order,
     }
   }
+
+  schema = await sdk.tables.enrichRelationshipSchema(schema)
 
   return {
     ...view,

--- a/packages/server/src/sdk/app/views/internal.ts
+++ b/packages/server/src/sdk/app/views/internal.ts
@@ -24,7 +24,7 @@ export async function getEnriched(viewId: string): Promise<ViewV2Enriched> {
   if (!found) {
     throw new Error("No view found")
   }
-  return enrichSchema(found, table.schema)
+  return await enrichSchema(found, table.schema)
 }
 
 export async function create(

--- a/packages/server/src/sdk/app/views/tests/views.spec.ts
+++ b/packages/server/src/sdk/app/views/tests/views.spec.ts
@@ -60,7 +60,7 @@ describe("table sdk", () => {
     },
   }
 
-  describe("enrichViewSchemas", () => {
+  describe("enrichSchema", () => {
     it("should fetch the default schema if not overridden", async () => {
       const tableId = basicTable._id!
       const view: ViewV2 = {


### PR DESCRIPTION
## Description
We are going to enable picking certain fields from related fields. These fields (and only these ones) will be used when enriching relations.
This PR handles the backend with the required changes needed to allow the builder settings. This will enrich the tables on retrieval to do the following:
1. Enrich all the relations to contain a schema with all the non-hidden files (non-hidden from the table)
2. Retrieve the persisted permission for these relation schemas if set and store in the actual relation

## Launchcontrol
Enrich table response types