### PR TITLE
Do not force include primary display

### DIFF
--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -122,22 +122,19 @@
     }
 
     const table = await cache.actions.getTable(relationshipField.tableId)
-    relationshipPanelColumns = Object.entries(relationshipField?.schema || {})
-      .map(([name, column]) => {
-        return {
-          name: name,
-          label: name,
-          primaryDisplay: name === table.primaryDisplay,
-          schema: {
-            type: table.schema[name].type,
-            visible: column.visible,
-            readonly: column.readonly,
-          },
-        }
-      })
-      .sort((a, b) =>
-        a.primaryDisplay === b.primaryDisplay ? 0 : a.primaryDisplay ? -1 : 1
-      )
+    relationshipPanelColumns = Object.entries(
+      relationshipField?.schema || {}
+    ).map(([name, column]) => {
+      return {
+        name: name,
+        label: name,
+        schema: {
+          type: table.schema[name].type,
+          visible: column.visible,
+          readonly: column.readonly,
+        },
+      }
+    })
   }
   $: fetchRelationshipPanelColumns(relationshipField)
 

--- a/packages/server/src/sdk/app/tables/getters.ts
+++ b/packages/server/src/sdk/app/tables/getters.ts
@@ -157,6 +157,8 @@ export async function enrichRelationshipSchema(
     }
     const relTable = tableCache[field.tableId]
 
+    const fieldSchema = field.schema || {}
+
     const resultSchema: Record<string, RelationSchemaField> = {}
 
     for (const relTableFieldName of Object.keys(relTable.schema)) {
@@ -169,10 +171,7 @@ export async function enrichRelationshipSchema(
         continue
       }
 
-      const isPrimaryDisplay = relTableFieldName === relTable.primaryDisplay
-      const isReadonly =
-        isPrimaryDisplay ||
-        !!(field.schema && field.schema[relTableFieldName]?.readonly)
+      const isReadonly = !!fieldSchema[relTableFieldName]?.readonly
       resultSchema[relTableFieldName] = {
         visible: isReadonly,
         readonly: isReadonly,

--- a/packages/server/src/sdk/app/views/tests/views.spec.ts
+++ b/packages/server/src/sdk/app/views/tests/views.spec.ts
@@ -315,6 +315,12 @@ describe("table sdk", () => {
             relationshipType: RelationshipType.ONE_TO_MANY,
             fieldName: "table",
             tableId: "otherTableId",
+            schema: {
+              title: {
+                visible: true,
+                readonly: true,
+              },
+            },
           },
         },
       }


### PR DESCRIPTION
## Description
Do not force include primary display. The primary display column will be used as enrichment as `primaryDisplay` field (as it is now, to avoid breaking changes on the api), but the actual field (being `name`, `title` or whatever it might be) it can be included or not, being up to the user configuration
