### PR TITLE
fix #14408 - Delete Screen modal shows behind builder

### DIFF
--- a/packages/bbui/src/Modal/Modal.svelte
+++ b/packages/bbui/src/Modal/Modal.svelte
@@ -10,7 +10,7 @@
   export let inline = false
   export let disableCancel = false
   export let autoFocus = true
-  export let zIndex = 999
+  export let zIndex = 99999
 
   const dispatch = createEventDispatcher()
   let visible = fixed || inline


### PR DESCRIPTION
## Description
Fixes: #14408 

## Screenshots
Tested 2 familiar instances:
<img width="1560" alt="budibase-binding-hidden-delete-modal" src="https://github.com/user-attachments/assets/760a4275-9565-4a5b-b9ad-1bbd2645c9e6">
<img width="1560" alt="budibase-conditional-hidden-delete-modal" src="https://github.com/user-attachments/assets/7fd55f6f-0814-44c8-ae51-98ed5c529511">

## Launchcontrol
It allows for screen deletion to overlay opened bindings or conditions on the design screen.
