### PR TITLE
Enrich on squashing

### DIFF
--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -2427,137 +2427,137 @@ describe.each([
     })
   })
 
-  describe("relationships", () => {
-    let tableId: string
+  // Upserting isn't yet supported in MSSQL or Oracle, see:
+  //   https://github.com/knex/knex/pull/6050
+  !isMSSQL &&
+    !isOracle &&
+    describe("relationships", () => {
+      let tableId: string
 
-    let auxData: Row[] = []
+      let auxData: Row[] = []
 
-    beforeAll(async () => {
-      const aux2Table = await config.api.table.save(saveTableRequest())
-      const aux2Data = await config.api.row.save(aux2Table._id!, {})
+      beforeAll(async () => {
+        const aux2Table = await config.api.table.save(saveTableRequest())
+        const aux2Data = await config.api.row.save(aux2Table._id!, {})
 
-      const auxTable = await config.api.table.save(
-        saveTableRequest({
-          primaryDisplay: "name",
-          schema: {
-            name: {
-              name: "name",
-              type: FieldType.STRING,
-              constraints: { presence: true },
+        const auxTable = await config.api.table.save(
+          saveTableRequest({
+            primaryDisplay: "name",
+            schema: {
+              name: {
+                name: "name",
+                type: FieldType.STRING,
+                constraints: { presence: true },
+              },
+              age: {
+                name: "age",
+                type: FieldType.NUMBER,
+                constraints: { presence: true },
+              },
+              address: {
+                name: "address",
+                type: FieldType.STRING,
+                constraints: { presence: true },
+                visible: false,
+              },
+              link: {
+                name: "link",
+                type: FieldType.LINK,
+                tableId: aux2Table._id!,
+                relationshipType: RelationshipType.MANY_TO_MANY,
+                fieldName: "fk_aux",
+                constraints: { presence: true },
+              },
+              formula: {
+                name: "formula",
+                type: FieldType.FORMULA,
+                formula: "{{ any }}",
+                constraints: { presence: true },
+              },
             },
-            age: {
-              name: "age",
-              type: FieldType.NUMBER,
-              constraints: { presence: true },
-            },
-            address: {
-              name: "address",
-              type: FieldType.STRING,
-              constraints: { presence: true },
-              visible: false,
-            },
-            link: {
-              name: "link",
-              type: FieldType.LINK,
-              tableId: aux2Table._id!,
-              relationshipType: RelationshipType.MANY_TO_MANY,
-              fieldName: "fk_aux",
-              constraints: { presence: true },
-            },
-            formula: {
-              name: "formula",
-              type: FieldType.FORMULA,
-              formula: "{{ any }}",
-              constraints: { presence: true },
-            },
-          },
-        })
-      )
-      const auxTableId = auxTable._id!
-
-      for (const name of generator.unique(() => generator.name(), 10)) {
-        auxData.push(
-          await config.api.row.save(auxTableId, {
-            name,
-            age: generator.age(),
-            address: generator.address(),
-            link: [aux2Data],
           })
         )
-      }
+        const auxTableId = auxTable._id!
 
-      const table = await config.api.table.save(
-        saveTableRequest({
-          schema: {
-            title: {
-              name: "title",
-              type: FieldType.STRING,
-              constraints: { presence: true },
-            },
-            relWithNoSchema: {
-              name: "relWithNoSchema",
-              relationshipType: RelationshipType.ONE_TO_MANY,
-              type: FieldType.LINK,
-              tableId: auxTableId,
-              fieldName: "fk_relWithNoSchema",
-              constraints: { presence: true },
-            },
-            relWithEmptySchema: {
-              name: "relWithEmptySchema",
-              relationshipType: RelationshipType.ONE_TO_MANY,
-              type: FieldType.LINK,
-              tableId: auxTableId,
-              fieldName: "fk_relWithEmptySchema",
-              constraints: { presence: true },
-              schema: {},
-            },
-            relWithFullSchema: {
-              name: "relWithFullSchema",
-              relationshipType: RelationshipType.ONE_TO_MANY,
-              type: FieldType.LINK,
-              tableId: auxTableId,
-              fieldName: "fk_relWithFullSchema",
-              constraints: { presence: true },
-              schema: Object.keys(auxTable.schema).reduce(
-                (acc, c) => ({ ...acc, [c]: { visible: true } }),
-                {}
-              ),
-            },
-            relWithHalfSchema: {
-              name: "relWithHalfSchema",
-              relationshipType: RelationshipType.ONE_TO_MANY,
-              type: FieldType.LINK,
-              tableId: auxTableId,
-              fieldName: "fk_relWithHalfSchema",
-              constraints: { presence: true },
-              schema: {
-                name: { visible: true },
-                age: { visible: false, readonly: true },
+        for (const name of generator.unique(() => generator.name(), 10)) {
+          auxData.push(
+            await config.api.row.save(auxTableId, {
+              name,
+              age: generator.age(),
+              address: generator.address(),
+              link: [aux2Data],
+            })
+          )
+        }
+
+        const table = await config.api.table.save(
+          saveTableRequest({
+            schema: {
+              title: {
+                name: "title",
+                type: FieldType.STRING,
+                constraints: { presence: true },
+              },
+              relWithNoSchema: {
+                name: "relWithNoSchema",
+                relationshipType: RelationshipType.ONE_TO_MANY,
+                type: FieldType.LINK,
+                tableId: auxTableId,
+                fieldName: "fk_relWithNoSchema",
+                constraints: { presence: true },
+              },
+              relWithEmptySchema: {
+                name: "relWithEmptySchema",
+                relationshipType: RelationshipType.ONE_TO_MANY,
+                type: FieldType.LINK,
+                tableId: auxTableId,
+                fieldName: "fk_relWithEmptySchema",
+                constraints: { presence: true },
+                schema: {},
+              },
+              relWithFullSchema: {
+                name: "relWithFullSchema",
+                relationshipType: RelationshipType.ONE_TO_MANY,
+                type: FieldType.LINK,
+                tableId: auxTableId,
+                fieldName: "fk_relWithFullSchema",
+                constraints: { presence: true },
+                schema: Object.keys(auxTable.schema).reduce(
+                  (acc, c) => ({ ...acc, [c]: { visible: true } }),
+                  {}
+                ),
+              },
+              relWithHalfSchema: {
+                name: "relWithHalfSchema",
+                relationshipType: RelationshipType.ONE_TO_MANY,
+                type: FieldType.LINK,
+                tableId: auxTableId,
+                fieldName: "fk_relWithHalfSchema",
+                constraints: { presence: true },
+                schema: {
+                  name: { visible: true },
+                  age: { visible: false, readonly: true },
+                },
+              },
+              relWithIllegalSchema: {
+                name: "relWithIllegalSchema",
+                relationshipType: RelationshipType.ONE_TO_MANY,
+                type: FieldType.LINK,
+                tableId: auxTableId,
+                fieldName: "fk_relWithIllegalSchema",
+                constraints: { presence: true },
+                schema: {
+                  name: { visible: true },
+                  address: { visible: true },
+                  unexisting: { visible: true },
+                },
               },
             },
-            relWithIllegalSchema: {
-              name: "relWithIllegalSchema",
-              relationshipType: RelationshipType.ONE_TO_MANY,
-              type: FieldType.LINK,
-              tableId: auxTableId,
-              fieldName: "fk_relWithIllegalSchema",
-              constraints: { presence: true },
-              schema: {
-                name: { visible: true },
-                address: { visible: true },
-                unexisting: { visible: true },
-              },
-            },
-          },
-        })
-      )
-      tableId = table._id!
-    })
+          })
+        )
+        tableId = table._id!
+      })
 
-    // Upserting isn't yet supported in MSSQL or Oracle, see:
-    //   https://github.com/knex/knex/pull/6050
-    !isMSSQL &&
-      !isOracle &&
       it.each([
         ["get row", (row: Row) => config.api.row.get(tableId, row._id!)],
         [
@@ -2648,7 +2648,7 @@ describe.each([
           )
         }
       )
-  })
+    })
 
   describe("Formula fields", () => {
     let table: Table

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -83,6 +83,7 @@ describe.each([
   [DatabaseName.ORACLE, getDatasource(DatabaseName.ORACLE)],
 ])("/rows (%s)", (providerType, dsProvider) => {
   const isInternal = dsProvider === undefined
+  const isLucene = providerType === "lucene"
   const isSqs = providerType === "sqs"
   const isMSSQL = providerType === DatabaseName.SQL_SERVER
   const isOracle = providerType === DatabaseName.ORACLE
@@ -365,7 +366,7 @@ describe.each([
         expect(ids).toEqual(expect.arrayContaining(sequence))
       })
 
-    isInternal &&
+    isLucene &&
       it("row values are coerced", async () => {
         const str: FieldSchema = {
           type: FieldType.STRING,

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -2533,60 +2533,65 @@ describe.each([
       tableId = table._id!
     })
 
-    it("can retrieve rows with populated relationships", async () => {
-      const otherRows = _.sampleSize(auxData, 5)
+    it.each([
+      ["get row", (rowId: string) => config.api.row.get(tableId, rowId)],
+    ])(
+      "can retrieve rows with populated relationships (via %s)",
+      async (__, retrieveDelegate) => {
+        const otherRows = _.sampleSize(auxData, 5)
 
-      const row = await config.api.row.save(tableId, {
-        title: generator.word(),
-        relWithNoSchema: [otherRows[0]],
-        relWithEmptySchema: [otherRows[1]],
-        relWithFullSchema: [otherRows[2]],
-        relWithHalfSchema: [otherRows[3]],
-        relWithIllegalSchema: [otherRows[4]],
-      })
-
-      const retrieved = await config.api.row.get(tableId, row._id!)
-      expect(retrieved).toEqual(
-        expect.objectContaining({
-          title: row.title,
-          relWithNoSchema: [
-            {
-              _id: otherRows[0]._id,
-              primaryDisplay: otherRows[0].name,
-            },
-          ],
-          relWithEmptySchema: [
-            {
-              _id: otherRows[1]._id,
-              primaryDisplay: otherRows[1].name,
-            },
-          ],
-          relWithFullSchema: [
-            {
-              _id: otherRows[2]._id,
-              primaryDisplay: otherRows[2].name,
-              name: otherRows[2].name,
-              age: otherRows[2].age,
-              id: otherRows[2].id,
-            },
-          ],
-          relWithHalfSchema: [
-            {
-              _id: otherRows[3]._id,
-              primaryDisplay: otherRows[3].name,
-              name: otherRows[3].name,
-            },
-          ],
-          relWithIllegalSchema: [
-            {
-              _id: otherRows[4]._id,
-              primaryDisplay: otherRows[4].name,
-              name: otherRows[4].name,
-            },
-          ],
+        const row = await config.api.row.save(tableId, {
+          title: generator.word(),
+          relWithNoSchema: [otherRows[0]],
+          relWithEmptySchema: [otherRows[1]],
+          relWithFullSchema: [otherRows[2]],
+          relWithHalfSchema: [otherRows[3]],
+          relWithIllegalSchema: [otherRows[4]],
         })
-      )
-    })
+
+        const retrieved = await retrieveDelegate(row._id!)
+        expect(retrieved).toEqual(
+          expect.objectContaining({
+            title: row.title,
+            relWithNoSchema: [
+              {
+                _id: otherRows[0]._id,
+                primaryDisplay: otherRows[0].name,
+              },
+            ],
+            relWithEmptySchema: [
+              {
+                _id: otherRows[1]._id,
+                primaryDisplay: otherRows[1].name,
+              },
+            ],
+            relWithFullSchema: [
+              {
+                _id: otherRows[2]._id,
+                primaryDisplay: otherRows[2].name,
+                name: otherRows[2].name,
+                age: otherRows[2].age,
+                id: otherRows[2].id,
+              },
+            ],
+            relWithHalfSchema: [
+              {
+                _id: otherRows[3]._id,
+                primaryDisplay: otherRows[3].name,
+                name: otherRows[3].name,
+              },
+            ],
+            relWithIllegalSchema: [
+              {
+                _id: otherRows[4]._id,
+                primaryDisplay: otherRows[4].name,
+                name: otherRows[4].name,
+              },
+            ],
+          })
+        )
+      }
+    )
   })
 
   describe("Formula fields", () => {

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -2554,96 +2554,98 @@ describe.each([
       tableId = table._id!
     })
 
-    it.each([
-      ["get row", (row: Row) => config.api.row.get(tableId, row._id!)],
-      [
-        "fetch",
-        async (row: Row) => {
-          const rows = await config.api.row.fetch(tableId)
-          return rows.find(r => r._id === row._id)
-        },
-      ],
-      [
-        "search",
-        async (row: Row) => {
-          const { rows } = await config.api.row.search(tableId)
-          return rows.find(r => r._id === row._id)
-        },
-      ],
-      [
-        "from view",
-        async (row: Row) => {
-          const table = await config.api.table.get(tableId)
-          const view = await config.api.viewV2.create({
-            name: generator.guid(),
-            tableId,
-            schema: Object.keys(table.schema).reduce(
-              (acc, c) => ({ ...acc, [c]: { visible: true } }),
-              {}
-            ),
-          })
-          const { rows } = await config.api.viewV2.search(view.id)
-          return rows.find(r => r._id === row._id!)
-        },
-      ],
-      ["from original saved row", (row: Row) => row],
-    ])(
-      "can retrieve rows with populated relationships (via %s)",
-      async (__, retrieveDelegate) => {
-        const otherRows = _.sampleSize(auxData, 5)
+    !isMSSQL &&
+      !isOracle &&
+      it.each([
+        ["get row", (row: Row) => config.api.row.get(tableId, row._id!)],
+        [
+          "fetch",
+          async (row: Row) => {
+            const rows = await config.api.row.fetch(tableId)
+            return rows.find(r => r._id === row._id)
+          },
+        ],
+        [
+          "search",
+          async (row: Row) => {
+            const { rows } = await config.api.row.search(tableId)
+            return rows.find(r => r._id === row._id)
+          },
+        ],
+        [
+          "from view",
+          async (row: Row) => {
+            const table = await config.api.table.get(tableId)
+            const view = await config.api.viewV2.create({
+              name: generator.guid(),
+              tableId,
+              schema: Object.keys(table.schema).reduce(
+                (acc, c) => ({ ...acc, [c]: { visible: true } }),
+                {}
+              ),
+            })
+            const { rows } = await config.api.viewV2.search(view.id)
+            return rows.find(r => r._id === row._id!)
+          },
+        ],
+        ["from original saved row", (row: Row) => row],
+      ])(
+        "can retrieve rows with populated relationships (via %s)",
+        async (__, retrieveDelegate) => {
+          const otherRows = _.sampleSize(auxData, 5)
 
-        const row = await config.api.row.save(tableId, {
-          title: generator.word(),
-          relWithNoSchema: [otherRows[0]],
-          relWithEmptySchema: [otherRows[1]],
-          relWithFullSchema: [otherRows[2]],
-          relWithHalfSchema: [otherRows[3]],
-          relWithIllegalSchema: [otherRows[4]],
-        })
-
-        const retrieved = await retrieveDelegate(row)
-        expect(retrieved).toEqual(
-          expect.objectContaining({
-            title: row.title,
-            relWithNoSchema: [
-              {
-                _id: otherRows[0]._id,
-                primaryDisplay: otherRows[0].name,
-              },
-            ],
-            relWithEmptySchema: [
-              {
-                _id: otherRows[1]._id,
-                primaryDisplay: otherRows[1].name,
-              },
-            ],
-            relWithFullSchema: [
-              {
-                _id: otherRows[2]._id,
-                primaryDisplay: otherRows[2].name,
-                name: otherRows[2].name,
-                age: otherRows[2].age,
-                id: otherRows[2].id,
-              },
-            ],
-            relWithHalfSchema: [
-              {
-                _id: otherRows[3]._id,
-                primaryDisplay: otherRows[3].name,
-                name: otherRows[3].name,
-              },
-            ],
-            relWithIllegalSchema: [
-              {
-                _id: otherRows[4]._id,
-                primaryDisplay: otherRows[4].name,
-                name: otherRows[4].name,
-              },
-            ],
+          const row = await config.api.row.save(tableId, {
+            title: generator.word(),
+            relWithNoSchema: [otherRows[0]],
+            relWithEmptySchema: [otherRows[1]],
+            relWithFullSchema: [otherRows[2]],
+            relWithHalfSchema: [otherRows[3]],
+            relWithIllegalSchema: [otherRows[4]],
           })
-        )
-      }
-    )
+
+          const retrieved = await retrieveDelegate(row)
+          expect(retrieved).toEqual(
+            expect.objectContaining({
+              title: row.title,
+              relWithNoSchema: [
+                {
+                  _id: otherRows[0]._id,
+                  primaryDisplay: otherRows[0].name,
+                },
+              ],
+              relWithEmptySchema: [
+                {
+                  _id: otherRows[1]._id,
+                  primaryDisplay: otherRows[1].name,
+                },
+              ],
+              relWithFullSchema: [
+                {
+                  _id: otherRows[2]._id,
+                  primaryDisplay: otherRows[2].name,
+                  name: otherRows[2].name,
+                  age: otherRows[2].age,
+                  id: otherRows[2].id,
+                },
+              ],
+              relWithHalfSchema: [
+                {
+                  _id: otherRows[3]._id,
+                  primaryDisplay: otherRows[3].name,
+                  name: otherRows[3].name,
+                },
+              ],
+              relWithIllegalSchema: [
+                {
+                  _id: otherRows[4]._id,
+                  primaryDisplay: otherRows[4].name,
+                  name: otherRows[4].name,
+                },
+              ],
+            })
+          )
+        }
+      )
   })
 
   describe("Formula fields", () => {

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -2535,6 +2535,36 @@ describe.each([
 
     it.each([
       ["get row", (rowId: string) => config.api.row.get(tableId, rowId)],
+      [
+        "fetch",
+        async (rowId: string) => {
+          const rows = await config.api.row.fetch(tableId)
+          return rows.find(r => r._id === rowId)
+        },
+      ],
+      [
+        "search",
+        async (rowId: string) => {
+          const { rows } = await config.api.row.search(tableId)
+          return rows.find(r => r._id === rowId)
+        },
+      ],
+      [
+        "from view",
+        async (rowId: string) => {
+          const table = await config.api.table.get(tableId)
+          const view = await config.api.viewV2.create({
+            name: generator.guid(),
+            tableId,
+            schema: Object.keys(table.schema).reduce(
+              (acc, c) => ({ ...acc, [c]: { visible: true } }),
+              {}
+            ),
+          })
+          const { rows } = await config.api.viewV2.search(view.id)
+          return rows.find(r => r._id === rowId)
+        },
+      ],
     ])(
       "can retrieve rows with populated relationships (via %s)",
       async (__, retrieveDelegate) => {

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -2554,6 +2554,8 @@ describe.each([
       tableId = table._id!
     })
 
+    // Upserting isn't yet supported in MSSQL or Oracle, see:
+    //   https://github.com/knex/knex/pull/6050
     !isMSSQL &&
       !isOracle &&
       it.each([

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -2534,24 +2534,24 @@ describe.each([
     })
 
     it.each([
-      ["get row", (rowId: string) => config.api.row.get(tableId, rowId)],
+      ["get row", (row: Row) => config.api.row.get(tableId, row._id!)],
       [
         "fetch",
-        async (rowId: string) => {
+        async (row: Row) => {
           const rows = await config.api.row.fetch(tableId)
-          return rows.find(r => r._id === rowId)
+          return rows.find(r => r._id === row._id)
         },
       ],
       [
         "search",
-        async (rowId: string) => {
+        async (row: Row) => {
           const { rows } = await config.api.row.search(tableId)
-          return rows.find(r => r._id === rowId)
+          return rows.find(r => r._id === row._id)
         },
       ],
       [
         "from view",
-        async (rowId: string) => {
+        async (row: Row) => {
           const table = await config.api.table.get(tableId)
           const view = await config.api.viewV2.create({
             name: generator.guid(),
@@ -2562,9 +2562,10 @@ describe.each([
             ),
           })
           const { rows } = await config.api.viewV2.search(view.id)
-          return rows.find(r => r._id === rowId)
+          return rows.find(r => r._id === row._id!)
         },
       ],
+      ["from original saved row", (row: Row) => row],
     ])(
       "can retrieve rows with populated relationships (via %s)",
       async (__, retrieveDelegate) => {
@@ -2579,7 +2580,7 @@ describe.each([
           relWithIllegalSchema: [otherRows[4]],
         })
 
-        const retrieved = await retrieveDelegate(row._id!)
+        const retrieved = await retrieveDelegate(row)
         expect(retrieved).toEqual(
           expect.objectContaining({
             title: row.title,

--- a/packages/server/src/db/linkedRows/index.ts
+++ b/packages/server/src/db/linkedRows/index.ts
@@ -272,7 +272,8 @@ export async function squashLinksToPrimaryDisplay(
         const obj: any = { _id: link._id }
         obj.primaryDisplay = getPrimaryDisplayValue(link, linkedTable)
 
-        if (schema.schema) {
+        const allowRelationshipSchemas = true // TODO
+        if (schema.schema && allowRelationshipSchemas) {
           for (const relField of Object.entries(schema.schema)
             .filter(([_, field]) => field.visible !== false)
             .map(([fieldKey]) => fieldKey)) {

--- a/packages/server/src/sdk/app/tables/getters.ts
+++ b/packages/server/src/sdk/app/tables/getters.ts
@@ -171,9 +171,10 @@ export async function enrichRelationshipSchema(
         continue
       }
 
+      const isVisible = !!fieldSchema[relTableFieldName]?.visible
       const isReadonly = !!fieldSchema[relTableFieldName]?.readonly
       resultSchema[relTableFieldName] = {
-        visible: isReadonly,
+        visible: isVisible,
         readonly: isReadonly,
       }
     }

--- a/packages/server/src/sdk/app/tables/getters.ts
+++ b/packages/server/src/sdk/app/tables/getters.ts
@@ -163,7 +163,7 @@ export async function enrichRelationshipSchema(
 
     for (const relTableFieldName of Object.keys(relTable.schema)) {
       const relTableField = relTable.schema[relTableFieldName]
-      if (relTableField.type === FieldType.LINK) {
+      if ([FieldType.LINK, FieldType.FORMULA].includes(relTableField.type)) {
         continue
       }
 

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -3,6 +3,7 @@ import { fixAutoColumnSubType, processFormulas } from "./utils"
 import {
   cache,
   context,
+  db,
   HTTPError,
   objectStore,
   utils,
@@ -349,11 +350,19 @@ export async function outputProcessing<T extends Row[] | Row>(
   }
   // remove null properties to match internal API
   const isExternal = isExternalTableID(table._id!)
-  if (isExternal) {
+  if (isExternal || db.isSqsEnabledForTenant()) {
     for (const row of enriched) {
       for (const key of Object.keys(row)) {
         if (row[key] === null) {
           delete row[key]
+        } else if (row[key] && table.schema[key]?.type === FieldType.LINK) {
+          for (const link of row[key] || []) {
+            for (const linkKey of Object.keys(link)) {
+              if (link[linkKey] === null) {
+                delete link[linkKey]
+              }
+            }
+          }
         }
       }
     }

--- a/packages/server/src/utilities/rowProcessor/tests/outputProcessing.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/outputProcessing.spec.ts
@@ -10,6 +10,14 @@ import { outputProcessing } from ".."
 import { generator, structures } from "@budibase/backend-core/tests"
 import * as bbReferenceProcessor from "../bbReferenceProcessor"
 
+jest.mock("@budibase/backend-core", () => ({
+  ...jest.requireActual("@budibase/backend-core"),
+  db: {
+    ...jest.requireActual("@budibase/backend-core").db,
+    isSqsEnabledForTenant: () => true,
+  },
+}))
+
 jest.mock("../bbReferenceProcessor", (): typeof bbReferenceProcessor => ({
   processInputBBReference: jest.fn(),
   processInputBBReferences: jest.fn(),


### PR DESCRIPTION
## Description
Enabling squashing using the new relationships schemas. The new changes allow setting the schemas on relationships, so this PR ensures that we are mapping the expected fields on the row responses.
This PR includes the testing of the different retrieval methods, and sets SQS testing for the `row.spec` API tests.
This is enrichment it will be feature flagged for V3.

Includes:
- [BUDI-8563 View join column test cases](https://linear.app/budibase/issue/BUDI-8563/view-join-column-test-cases)

## Launchcontrol
Honor relationship schema on row retrieval