### PR TITLE
Change Automations CodeEditorModal to update on close

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -1078,13 +1078,8 @@
                   >
                     <CodeEditor
                       value={inputData[key]}
-                      on:blur={e => {
+                      on:change={e => {
                         // need to pass without the value inside
-                        inputData[key] = e.detail
-                      }}
-                      on:insert={e => {
-                        // Blur events only happen once after inserting a binding
-                        // State will now update on insert
                         inputData[key] = e.detail
                       }}
                       completions={stepCompletions}

--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -1065,7 +1065,12 @@
                 value={inputData[key]}
               />
             {:else if value.customType === "code"}
-              <CodeEditorModal>
+              <CodeEditorModal
+                on:hide={() => {
+                  // Push any pending changes when the window closes
+                  onChange({ [key]: inputData[key] })
+                }}
+              >
                 <div class:js-editor={editingJs}>
                   <div
                     class:js-code={editingJs}
@@ -1075,7 +1080,11 @@
                       value={inputData[key]}
                       on:blur={e => {
                         // need to pass without the value inside
-                        onChange({ [key]: e.detail })
+                        inputData[key] = e.detail
+                      }}
+                      on:insert={e => {
+                        // Blur events only happen once after inserting a binding
+                        // State will now update on insert
                         inputData[key] = e.detail
                       }}
                       completions={stepCompletions}

--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -1073,7 +1073,7 @@
                   >
                     <CodeEditor
                       value={inputData[key]}
-                      on:change={e => {
+                      on:blur={e => {
                         // need to pass without the value inside
                         onChange({ [key]: e.detail })
                         inputData[key] = e.detail

--- a/packages/builder/src/components/automation/SetupPanel/CodeEditorModal.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/CodeEditorModal.svelte
@@ -11,7 +11,7 @@
   }
 </script>
 
-<Modal bind:this={modal}>
+<Modal bind:this={modal} on:hide>
   <ModalContent
     size="XL"
     title="Edit Code"

--- a/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
+++ b/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
@@ -140,6 +140,7 @@
           }
         : undefined,
     })
+    dispatch("insert", editor.state.doc.toString())
   }
 
   // Match decoration for HBS bindings

--- a/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
+++ b/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
@@ -140,7 +140,6 @@
           }
         : undefined,
     })
-    dispatch("insert", editor.state.doc.toString())
   }
 
   // Match decoration for HBS bindings


### PR DESCRIPTION
## Description

The `on change` behaviour was too chatty for the code editor causing issues with the UX. The API update behaviour has now been changed to only fire when the modal itself closes. This should greatly improve the editor experience.

## Addresses
- https://linear.app/budibase/issue/BUDI-8587/unpredictable-behaviour-when-typing-quickly-in-js-scripting-automation
