### PR TITLE
Crud endpoints only for builder

### DIFF
--- a/packages/server/src/api/routes/rowAction.ts
+++ b/packages/server/src/api/routes/rowAction.ts
@@ -2,9 +2,9 @@ import Router from "@koa/router"
 import Joi from "joi"
 import { middleware, permissions } from "@budibase/backend-core"
 import * as rowActionController from "../controllers/rowAction"
-import { authorizedResource } from "../../middleware/authorized"
+import authorized, { authorizedResource } from "../../middleware/authorized"
 
-const { PermissionLevel, PermissionType } = permissions
+const { PermissionLevel, PermissionType, BUILDER } = permissions
 
 function rowActionValidator() {
   return middleware.joiValidator.body(
@@ -30,34 +30,34 @@ const router: Router = new Router()
 router
   .get(
     "/api/tables/:tableId/actions",
-    authorizedResource(PermissionType.TABLE, PermissionLevel.READ, "tableId"),
+    authorized(BUILDER),
     rowActionController.find
   )
   .post(
     "/api/tables/:tableId/actions",
-    authorizedResource(PermissionType.TABLE, PermissionLevel.READ, "tableId"),
+    authorized(BUILDER),
     rowActionValidator(),
     rowActionController.create
   )
   .put(
     "/api/tables/:tableId/actions/:actionId",
-    authorizedResource(PermissionType.TABLE, PermissionLevel.READ, "tableId"),
+    authorized(BUILDER),
     rowActionValidator(),
     rowActionController.update
   )
   .delete(
     "/api/tables/:tableId/actions/:actionId",
-    authorizedResource(PermissionType.TABLE, PermissionLevel.READ, "tableId"),
+    authorized(BUILDER),
     rowActionController.remove
   )
   .post(
     "/api/tables/:tableId/actions/:actionId/permissions/:viewId",
-    authorizedResource(PermissionType.TABLE, PermissionLevel.READ, "tableId"),
+    authorized(BUILDER),
     rowActionController.setViewPermission
   )
   .delete(
     "/api/tables/:tableId/actions/:actionId/permissions/:viewId",
-    authorizedResource(PermissionType.TABLE, PermissionLevel.READ, "tableId"),
+    authorized(BUILDER),
     rowActionController.unsetViewPermission
   )
 

--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -683,6 +683,13 @@ describe("/rowsActions", () => {
     let row: Row
     let rowAction: RowActionResponse
 
+    beforeEach(async () => {
+      row = await config.api.row.save(tableId, {})
+      rowAction = await createRowAction(tableId, createRowActionRequest())
+
+      await config.publish()
+    })
+
     unauthorisedTests((expectations, testConfig) =>
       config.api.rowAction.trigger(
         tableId,
@@ -695,23 +702,10 @@ describe("/rowsActions", () => {
       )
     )
 
-    beforeEach(async () => {
-      row = await config.api.row.save(tableId, {})
-      rowAction = await createRowAction(tableId, createRowActionRequest())
-
-      await config.publish()
-    })
-
     it("can trigger an automation given valid data", async () => {
-      await config.api.rowAction.trigger(
-        tableId,
-        rowAction.id,
-        {
+      await config.api.rowAction.trigger(tableId, rowAction.id, {
           rowId: row._id!,
-        },
-        undefined,
-        { useProdApp: true }
-      )
+      })
 
       const { data: automationLogs } = await config.doInContext(
         config.getProdAppId(),

--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -13,7 +13,6 @@ import { generator } from "@budibase/backend-core/tests"
 import { Expectations } from "../../../tests/utilities/api/base"
 import { roles } from "@budibase/backend-core"
 import { automations } from "@budibase/pro"
-import { trigger } from "src/api/controllers/automation"
 
 const expectAutomationId = () =>
   expect.stringMatching(`^${DocumentType.AUTOMATION}_.+`)

--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -703,7 +703,7 @@ describe("/rowsActions", () => {
 
     it("can trigger an automation given valid data", async () => {
       await config.api.rowAction.trigger(tableId, rowAction.id, {
-          rowId: row._id!,
+        rowId: row._id!,
       })
 
       const { data: automationLogs } = await config.doInContext(

--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -90,6 +90,10 @@ describe("/rowsActions", () => {
           level: PermissionLevel.EXECUTE,
         })
       }
+
+      // replicate changes before checking permissions
+      await config.publish()
+
       await config.withUser(user, async () => {
         await createRowAction(tableId, createRowActionRequest(), {
           status: 403,

--- a/packages/server/src/tests/utilities/api/base.ts
+++ b/packages/server/src/tests/utilities/api/base.ts
@@ -108,7 +108,10 @@ export abstract class TestAPI {
     }
 
     const headersFn = publicUser
-      ? this.config.publicHeaders.bind(this.config)
+      ? (_extras = {}) =>
+          this.config.publicHeaders.bind(this.config)({
+            prodApp: opts?.useProdApp,
+          })
       : (extras = {}) =>
           this.config.defaultHeaders.bind(this.config)(extras, opts?.useProdApp)
 

--- a/packages/server/src/tests/utilities/api/base.ts
+++ b/packages/server/src/tests/utilities/api/base.ts
@@ -40,6 +40,7 @@ export interface RequestOpts {
   >
   expectations?: Expectations
   publicUser?: boolean
+  useProdApp?: boolean
 }
 
 export abstract class TestAPI {
@@ -108,7 +109,8 @@ export abstract class TestAPI {
 
     const headersFn = publicUser
       ? this.config.publicHeaders.bind(this.config)
-      : this.config.defaultHeaders.bind(this.config)
+      : (extras = {}) =>
+          this.config.defaultHeaders.bind(this.config)(extras, opts?.useProdApp)
 
     const app = getServer()
     let req = request(app)[method](url)

--- a/packages/server/src/tests/utilities/api/rowAction.ts
+++ b/packages/server/src/tests/utilities/api/rowAction.ts
@@ -2,6 +2,7 @@ import {
   CreateRowActionRequest,
   RowActionResponse,
   RowActionsResponse,
+  RowActionTriggerRequest,
 } from "@budibase/types"
 import { Expectations, TestAPI } from "./base"
 
@@ -97,6 +98,23 @@ export class RowActionAPI extends TestAPI {
     return await this._delete<RowActionResponse>(
       `/api/tables/${tableId}/actions/${rowActionId}/permissions/${viewId}`,
       {
+        expectations,
+        ...config,
+      }
+    )
+  }
+
+  trigger = async (
+    tableId: string,
+    rowActionId: string,
+    body: RowActionTriggerRequest,
+    expectations?: Expectations,
+    config?: { publicUser?: boolean }
+  ) => {
+    return await this._post<RowActionResponse>(
+      `/api/tables/${tableId}/actions/${rowActionId}/trigger`,
+      {
+        body,
         expectations,
         ...config,
       }

--- a/packages/server/src/tests/utilities/api/rowAction.ts
+++ b/packages/server/src/tests/utilities/api/rowAction.ts
@@ -109,7 +109,7 @@ export class RowActionAPI extends TestAPI {
     rowActionId: string,
     body: RowActionTriggerRequest,
     expectations?: Expectations,
-    config?: { publicUser?: boolean }
+    config?: { publicUser?: boolean; useProdApp?: boolean }
   ) => {
     return await this._post<RowActionResponse>(
       `/api/tables/${tableId}/actions/${rowActionId}/trigger`,

--- a/packages/server/src/tests/utilities/api/rowAction.ts
+++ b/packages/server/src/tests/utilities/api/rowAction.ts
@@ -116,7 +116,7 @@ export class RowActionAPI extends TestAPI {
       {
         body,
         expectations,
-        ...config,
+        ...{ ...config, useProdApp: config?.useProdApp ?? true },
       }
     )
   }


### PR DESCRIPTION
## Description
Add security to the row action endpoints to ensure only builder users are able to call them.