### PR TITLE
Picker only for views

### DIFF
--- a/packages/builder/src/components/backend/DataTable/TableDataTable.svelte
+++ b/packages/builder/src/components/backend/DataTable/TableDataTable.svelte
@@ -18,8 +18,6 @@
   import GridEditColumnModal from "components/backend/DataTable/modals/grid/GridEditColumnModal.svelte"
   import GridUsersTableButton from "components/backend/DataTable/modals/grid/GridUsersTableButton.svelte"
   import { DB_TYPE_EXTERNAL } from "constants/backend"
-  import { isEnabled } from "helpers/featureFlags"
-  import { FeatureFlag } from "@budibase/types"
 
   const userSchemaOverrides = {
     firstName: { displayName: "First name", disabled: true },
@@ -68,7 +66,6 @@
     canDeleteRows={!isUsersTable}
     canEditRows={!isUsersTable || !$appStore.features.disableUserMetadata}
     canEditColumns={!isUsersTable || !$appStore.features.disableUserMetadata}
-    canSetRelationshipSchemas={isEnabled(FeatureFlag.ENRICHED_RELATIONSHIPS)}
     schemaOverrides={isUsersTable ? userSchemaOverrides : null}
     showAvatars={false}
     on:updatedatasource={handleGridTableUpdate}

--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -123,7 +123,7 @@
 
     const table = await cache.actions.getTable(relationshipField.tableId)
     relationshipPanelColumns = Object.entries(
-      relationshipField?.schema || {}
+      relationshipField?.columns || {}
     ).map(([name, column]) => {
       return {
         name: name,

--- a/packages/frontend-core/src/components/grid/stores/datasource.js
+++ b/packages/frontend-core/src/components/grid/stores/datasource.js
@@ -62,12 +62,12 @@ export const deriveStores = context => {
         }
 
         if ($subSchemaMutations[field]) {
-          enrichedSchema[field].schema ??= {}
+          enrichedSchema[field].columns ??= {}
           for (const [fieldName, mutation] of Object.entries(
             $subSchemaMutations[field]
           )) {
-            enrichedSchema[field].schema[fieldName] = {
-              ...enrichedSchema[field].schema[fieldName],
+            enrichedSchema[field].columns[fieldName] = {
+              ...enrichedSchema[field].columns[fieldName],
               ...mutation,
             }
           }
@@ -239,12 +239,12 @@ export const createActions = context => {
         ...$schemaMutations[column],
       }
       if ($subSchemaMutations[column]) {
-        newSchema[column].schema ??= {}
+        newSchema[column].columns ??= {}
         for (const [fieldName, mutation] of Object.entries(
           $subSchemaMutations[column]
         )) {
-          newSchema[column].schema[fieldName] = {
-            ...newSchema[column].schema[fieldName],
+          newSchema[column].columns[fieldName] = {
+            ...newSchema[column].columns[fieldName],
             ...mutation,
           }
         }

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -163,14 +163,10 @@ export async function fetchEnrichedRow(ctx: UserCtx) {
       },
       includeSqlRelationships: IncludeRelationship.INCLUDE,
     })
-    row[fieldName] = await outputProcessing<Row[]>(
-      linkedTable,
-      relatedRows.rows,
-      {
-        squash: true,
-        preserveLinks: true,
-      }
-    )
+    row[fieldName] = await outputProcessing(linkedTable, relatedRows.rows, {
+      squash: true,
+      preserveLinks: true,
+    })
   }
   return row
 }

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -38,7 +38,7 @@ export async function handleRequest<T extends Operation>(
 }
 
 export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
-  const { tableId } = utils.getSourceId(ctx)
+  const { tableId, viewId } = utils.getSourceId(ctx)
 
   const { _id, ...rowData } = ctx.request.body
   const table = await sdk.tables.getTable(tableId)
@@ -77,6 +77,7 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
     outputProcessing(table, row, {
       squash: true,
       preserveLinks: true,
+      fromViewId: viewId,
     }),
     outputProcessing(table, beforeRow, {
       squash: true,

--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -115,10 +115,11 @@ export async function fetch(ctx: any) {
 }
 
 export async function find(ctx: UserCtx<void, GetRowResponse>) {
-  const { tableId } = utils.getSourceId(ctx)
+  const { sourceId } = ctx.params
   const rowId = ctx.params.rowId
 
-  ctx.body = await sdk.rows.find(tableId, rowId)
+  const response = await sdk.rows.find(sourceId, rowId)
+  ctx.body = response
 }
 
 function isDeleteRows(input: any): input is DeleteRows {

--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -71,8 +71,9 @@ export async function patch(
 }
 
 export const save = async (ctx: UserCtx<Row, Row>) => {
-  const { tableId } = utils.getSourceId(ctx)
-  const { sourceId } = ctx.params
+  const { tableId, viewId } = utils.getSourceId(ctx)
+  const sourceId = viewId || tableId
+
   const appId = ctx.appId
   const body = ctx.request.body
 
@@ -116,7 +117,8 @@ export async function fetch(ctx: any) {
 }
 
 export async function find(ctx: UserCtx<void, GetRowResponse>) {
-  const { sourceId } = ctx.params
+  const { tableId, viewId } = utils.getSourceId(ctx)
+  const sourceId = viewId || tableId
   const rowId = ctx.params.rowId
 
   const response = await sdk.rows.find(sourceId, rowId)

--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -71,8 +71,9 @@ export async function patch(
 }
 
 export const save = async (ctx: UserCtx<Row, Row>) => {
-  const appId = ctx.appId
   const { tableId } = utils.getSourceId(ctx)
+  const { sourceId } = ctx.params
+  const appId = ctx.appId
   const body = ctx.request.body
 
   // user metadata doesn't exist yet - don't allow creation
@@ -85,9 +86,9 @@ export const save = async (ctx: UserCtx<Row, Row>) => {
     return patch(ctx as UserCtx<PatchRowRequest, PatchRowResponse>)
   }
   const { row, table, squashed } = tableId.includes("datasource_plus")
-    ? await sdk.rows.save(tableId, ctx.request.body, ctx.user?._id)
+    ? await sdk.rows.save(sourceId, ctx.request.body, ctx.user?._id)
     : await quotas.addRow(() =>
-        sdk.rows.save(tableId, ctx.request.body, ctx.user?._id)
+        sdk.rows.save(sourceId, ctx.request.body, ctx.user?._id)
       )
   ctx.status = 200
   ctx.eventEmitter && ctx.eventEmitter.emitRow(`row:save`, appId, row, table)

--- a/packages/server/src/api/controllers/row/internal.ts
+++ b/packages/server/src/api/controllers/row/internal.ts
@@ -23,7 +23,7 @@ import { getLinkedTableIDs } from "../../../db/linkedRows/linkUtils"
 import { flatten } from "lodash"
 
 export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
-  const { tableId } = utils.getSourceId(ctx)
+  const { tableId, viewId } = utils.getSourceId(ctx)
   const inputs = ctx.request.body
   const isUserTable = tableId === InternalTables.USER_METADATA
   let oldRow
@@ -90,6 +90,7 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   const result = await finaliseRow(table, row, {
     oldTable: dbTable,
     updateFormula: true,
+    fromViewId: viewId,
   })
 
   return { ...result, oldRow }

--- a/packages/server/src/api/controllers/row/staticFormula.ts
+++ b/packages/server/src/api/controllers/row/staticFormula.ts
@@ -154,9 +154,6 @@ export async function finaliseRow(
   if (updateFormula) {
     await updateRelatedFormula(table, enrichedRow)
   }
-  const squashed = await linkRows.squashLinksToPrimaryDisplay(
-    table,
-    enrichedRow
-  )
+  const squashed = await linkRows.squashLinks(table, enrichedRow)
   return { row: enrichedRow, squashed, table }
 }

--- a/packages/server/src/api/controllers/row/staticFormula.ts
+++ b/packages/server/src/api/controllers/row/staticFormula.ts
@@ -123,7 +123,11 @@ export async function updateAllFormulasInTable(table: Table) {
 export async function finaliseRow(
   table: Table,
   row: Row,
-  { oldTable, updateFormula }: { oldTable?: Table; updateFormula: boolean } = {
+  {
+    oldTable,
+    updateFormula,
+    fromViewId,
+  }: { oldTable?: Table; updateFormula: boolean; fromViewId?: string } = {
     updateFormula: true,
   }
 ) {
@@ -154,6 +158,8 @@ export async function finaliseRow(
   if (updateFormula) {
     await updateRelatedFormula(table, enrichedRow)
   }
-  const squashed = await linkRows.squashLinks(table, enrichedRow)
+  const squashed = await linkRows.squashLinks(table, enrichedRow, {
+    fromViewId,
+  })
   return { row: enrichedRow, squashed, table }
 }

--- a/packages/server/src/api/controllers/row/views.ts
+++ b/packages/server/src/api/controllers/row/views.ts
@@ -71,8 +71,11 @@ export async function searchView(
   })
 
   const searchOptions: RequiredKeys<SearchViewRowRequest> &
-    RequiredKeys<Pick<RowSearchParams, "tableId" | "query" | "fields">> = {
+    RequiredKeys<
+      Pick<RowSearchParams, "tableId" | "viewId" | "query" | "fields">
+    > = {
     tableId: view.tableId,
+    viewId: view.id,
     query: enrichedQuery,
     fields: viewFields,
     ...getSortOptions(body, view),

--- a/packages/server/src/api/controllers/table/index.ts
+++ b/packages/server/src/api/controllers/table/index.ts
@@ -95,10 +95,7 @@ export async function find(ctx: UserCtx<void, TableResponse>) {
   const tableId = ctx.params.tableId
   const table = await sdk.tables.getTable(tableId)
 
-  const result = await sdk.tables.enrichViewSchemas({
-    ...table,
-    schema: await sdk.tables.enrichRelationshipSchema(table.schema),
-  })
+  const result = await sdk.tables.enrichViewSchemas(table)
   ctx.body = result
 }
 

--- a/packages/server/src/api/controllers/view/viewsV2.ts
+++ b/packages/server/src/api/controllers/view/viewsV2.ts
@@ -22,8 +22,8 @@ async function parseSchema(view: CreateViewRequest) {
       let fieldRelatedSchema:
         | Record<string, RequiredKeys<RelationSchemaField>>
         | undefined
-      if (schemaValue.schema) {
-        fieldRelatedSchema = Object.entries(schemaValue.schema).reduce<
+      if (schemaValue.columns) {
+        fieldRelatedSchema = Object.entries(schemaValue.columns).reduce<
           NonNullable<typeof fieldRelatedSchema>
         >((acc, [key, fieldSchema]) => {
           acc[key] = {
@@ -36,7 +36,7 @@ async function parseSchema(view: CreateViewRequest) {
 
       const fieldSchema: RequiredKeys<
         ViewFieldMetadata & {
-          schema: typeof fieldRelatedSchema
+          columns: typeof fieldRelatedSchema
         }
       > = {
         order: schemaValue.order,
@@ -44,7 +44,7 @@ async function parseSchema(view: CreateViewRequest) {
         visible: schemaValue.visible,
         readonly: schemaValue.readonly,
         icon: schemaValue.icon,
-        schema: fieldRelatedSchema,
+        columns: fieldRelatedSchema,
       }
       Object.entries(fieldSchema)
         .filter(([, val]) => val === undefined)

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -2619,6 +2619,7 @@ describe.each([
           },
         ],
         ["from original saved row", (row: Row) => row],
+        ["from updated  row", (row: Row) => config.api.row.save(viewId, row)],
       ]
 
       it.each(testScenarios)(

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -2618,7 +2618,7 @@ describe.each([
             return rows.find(r => r._id === row._id!)
           },
         ],
-        // ["from original saved row", (row: Row) => row],
+        ["from original saved row", (row: Row) => row],
       ]
 
       it.each(testScenarios)(

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -2596,7 +2596,7 @@ describe.each([
       })
 
       const testScenarios: [string, (row: Row) => Promise<Row> | Row][] = [
-        // ["get row", (row: Row) => config.api.row.get(viewId, row._id!)],
+        ["get row", (row: Row) => config.api.row.get(viewId, row._id!)],
         // [
         //   "fetch",
         //   async (row: Row) => {
@@ -2690,7 +2690,7 @@ describe.each([
             async () => {
               const otherRows = _.sampleSize(auxData, 5)
 
-              const row = await config.api.row.save(tableId, {
+              const row = await config.api.row.save(viewId, {
                 title: generator.word(),
                 relWithNoSchema: [otherRows[0]],
                 relWithEmptySchema: [otherRows[1]],

--- a/packages/server/src/db/linkedRows/index.ts
+++ b/packages/server/src/db/linkedRows/index.ts
@@ -11,10 +11,9 @@ import { USER_METDATA_PREFIX } from "../utils"
 import partition from "lodash/partition"
 import { getGlobalUsersFromMetadata } from "../../utilities/global"
 import { processFormulas } from "../../utilities/rowProcessor"
-import { context, features } from "@budibase/backend-core"
+import { context } from "@budibase/backend-core"
 import {
   ContextUser,
-  FeatureFlag,
   FieldType,
   LinkDocumentValue,
   Row,
@@ -259,11 +258,7 @@ export async function squashLinksToPrimaryDisplay(
   for (const row of enrichedArray) {
     // this only fetches the table if its not already in array
     const rowTable = await getLinkedTable(row.tableId!, linkedTables)
-    const safeSchema =
-      (rowTable?.schema &&
-        (await sdk.tables.enrichRelationshipSchema(rowTable.schema))) ||
-      {}
-    for (let [column, schema] of Object.entries(safeSchema)) {
+    for (let [column, schema] of Object.entries(rowTable.schema)) {
       if (schema.type !== FieldType.LINK || !Array.isArray(row[column])) {
         continue
       }
@@ -275,16 +270,17 @@ export async function squashLinksToPrimaryDisplay(
         const obj: any = { _id: link._id }
         obj.primaryDisplay = getPrimaryDisplayValue(link, linkedTable)
 
-        const allowRelationshipSchemas = await features.flags.isEnabled(
-          FeatureFlag.ENRICHED_RELATIONSHIPS
-        )
-        if (schema.schema && allowRelationshipSchemas) {
-          for (const relField of Object.entries(schema.schema)
-            .filter(([_, field]) => field.visible !== false)
-            .map(([fieldKey]) => fieldKey)) {
-            obj[relField] = link[relField]
-          }
-        }
+        // TODO
+        // const allowRelationshipSchemas = await features.flags.isEnabled(
+        //   FeatureFlag.ENRICHED_RELATIONSHIPS
+        // )
+        // if (schema.schema && allowRelationshipSchemas) {
+        //   for (const relField of Object.entries(schema.schema)
+        //     .filter(([_, field]) => field.visible !== false)
+        //     .map(([fieldKey]) => fieldKey)) {
+        //     obj[relField] = link[relField]
+        //   }
+        // }
 
         newLinks.push(obj)
       }

--- a/packages/server/src/db/linkedRows/index.ts
+++ b/packages/server/src/db/linkedRows/index.ts
@@ -11,9 +11,10 @@ import { USER_METDATA_PREFIX } from "../utils"
 import partition from "lodash/partition"
 import { getGlobalUsersFromMetadata } from "../../utilities/global"
 import { processFormulas } from "../../utilities/rowProcessor"
-import { context } from "@budibase/backend-core"
+import { context, features } from "@budibase/backend-core"
 import {
   ContextUser,
+  FeatureFlag,
   FieldType,
   LinkDocumentValue,
   Row,
@@ -259,30 +260,12 @@ export async function squashLinks<T = Row[] | Row>(
     fromViewId?: string
   }
 ): Promise<T> {
-  // export function outputRowOptions(
-  //   table: Table,
-  //   viewId: string
-  // ): OutputRowOptions {
-  //   const view = Object.values(table.views || {}).find(
-  //     (v): v is ViewV2 => sdk.views.isV2(v) && v.id === viewId
-  //   )
-  //   const viewSchema = view?.schema || {}
+  const allowRelationshipSchemas = await features.flags.isEnabled(
+    FeatureFlag.ENRICHED_RELATIONSHIPS
+  )
 
-  //   const squashFields: SquashTableFields = {}
-  //   for (const key of Object.keys(viewSchema)) {
-  //     if (viewSchema[key].columns) {
-  //       squashFields[key] = {
-  //         visibleFieldNames: Object.entries(viewSchema[key].columns)
-  //           .filter(([_, c]) => c.visible !== false)
-  //           .map(([columnName]) => columnName),
-  //       }
-  //     }
-  //   }
-
-  //   return { squashNestedFields: squashFields }
-  // }
   let viewSchema: Record<string, ViewFieldMetadata> = {}
-  if (options?.fromViewId) {
+  if (options?.fromViewId && allowRelationshipSchemas) {
     const view = Object.values(table.views || {}).find(
       (v): v is ViewV2 => sdk.views.isV2(v) && v.id === options?.fromViewId
     )

--- a/packages/server/src/db/linkedRows/index.ts
+++ b/packages/server/src/db/linkedRows/index.ts
@@ -247,10 +247,10 @@ function getPrimaryDisplayValue(row: Row, table?: Table) {
  * @param enriched The pre-enriched rows (full docs) which are to be squashed.
  * @returns The rows after having their links squashed to only contain the ID and primary display.
  */
-export async function squashLinksToPrimaryDisplay(
+export async function squashLinks<T = Row[] | Row>(
   table: Table,
-  enriched: Row[] | Row
-) {
+  enriched: T
+): Promise<T> {
   // will populate this as we find them
   const linkedTables = [table]
   const isArray = Array.isArray(enriched)

--- a/packages/server/src/middleware/trimViewRowInfo.ts
+++ b/packages/server/src/middleware/trimViewRowInfo.ts
@@ -28,7 +28,7 @@ export default async (ctx: Ctx<Row, Row>, next: Next) => {
 }
 
 // have to mutate the koa context, can't return
-export async function trimNonViewFields(
+async function trimNonViewFields(
   row: Row,
   view: ViewV2,
   permission: "WRITE" | "READ"

--- a/packages/server/src/sdk/app/rows/external.ts
+++ b/packages/server/src/sdk/app/rows/external.ts
@@ -27,10 +27,11 @@ export async function getRow(
 }
 
 export async function save(
-  tableId: string,
+  tableOrViewId: string,
   inputs: Row,
   userId: string | undefined
 ) {
+  const { tableId, viewId } = tryExtractingTableAndViewId(tableOrViewId)
   const table = await sdk.tables.getTable(tableId)
   const { table: updatedTable, row } = await inputProcessing(
     userId,
@@ -64,6 +65,7 @@ export async function save(
       row: await outputProcessing(table, row, {
         preserveLinks: true,
         squash: true,
+        fromViewId: viewId,
       }),
     }
   } else {

--- a/packages/server/src/sdk/app/rows/external.ts
+++ b/packages/server/src/sdk/app/rows/external.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../utilities/rowProcessor"
 import cloneDeep from "lodash/fp/cloneDeep"
 import isEqual from "lodash/fp/isEqual"
+import { tryExtractingTableAndViewId } from "./utils"
 
 export async function getRow(
   tableId: string,
@@ -70,7 +71,9 @@ export async function save(
   }
 }
 
-export async function find(tableId: string, rowId: string): Promise<Row> {
+export async function find(tableOrViewId: string, rowId: string): Promise<Row> {
+  const { tableId, viewId } = tryExtractingTableAndViewId(tableOrViewId)
+
   const row = await getRow(tableId, rowId, {
     relationships: true,
   })
@@ -84,5 +87,6 @@ export async function find(tableId: string, rowId: string): Promise<Row> {
   return await outputProcessing(table, row, {
     squash: true,
     preserveLinks: true,
+    fromViewId: viewId,
   })
 }

--- a/packages/server/src/sdk/app/rows/internal.ts
+++ b/packages/server/src/sdk/app/rows/internal.ts
@@ -10,6 +10,7 @@ import {
 import * as linkRows from "../../../db/linkedRows"
 import { InternalTables } from "../../../db/utils"
 import { getFullUser } from "../../../utilities/users"
+import { tryExtractingTableAndViewId } from "./utils"
 
 export async function save(
   tableId: string,
@@ -53,11 +54,13 @@ export async function save(
   })
 }
 
-export async function find(tableId: string, rowId: string): Promise<Row> {
+export async function find(tableOrViewId: string, rowId: string): Promise<Row> {
+  const { tableId, viewId } = tryExtractingTableAndViewId(tableOrViewId)
+
   const table = await sdk.tables.getTable(tableId)
   let row = await findRow(tableId, rowId)
 
-  row = await outputProcessing(table, row)
+  row = await outputProcessing(table, row, { squash: true, fromViewId: viewId })
   return row
 }
 

--- a/packages/server/src/sdk/app/rows/internal.ts
+++ b/packages/server/src/sdk/app/rows/internal.ts
@@ -13,10 +13,11 @@ import { getFullUser } from "../../../utilities/users"
 import { tryExtractingTableAndViewId } from "./utils"
 
 export async function save(
-  tableId: string,
+  tableOrViewId: string,
   inputs: Row,
   userId: string | undefined
 ) {
+  const { tableId, viewId } = tryExtractingTableAndViewId(tableOrViewId)
   inputs.tableId = tableId
 
   if (!inputs._rev && !inputs._id) {
@@ -51,6 +52,7 @@ export async function save(
   return finaliseRow(table, row, {
     oldTable: dbTable,
     updateFormula: true,
+    fromViewId: viewId,
   })
 }
 

--- a/packages/server/src/sdk/app/rows/rows.ts
+++ b/packages/server/src/sdk/app/rows/rows.ts
@@ -1,6 +1,10 @@
 import { db as dbCore, context } from "@budibase/backend-core"
 import { Database, Row } from "@budibase/types"
-import { getRowParams } from "../../../db/utils"
+import {
+  extractViewInfoFromID,
+  getRowParams,
+  isViewID,
+} from "../../../db/utils"
 import { isExternalTableID } from "../../../integrations/utils"
 import * as internal from "./internal"
 import * as external from "./external"
@@ -20,7 +24,12 @@ export async function getAllInternalRows(appId?: string) {
   return response.rows.map(row => row.doc) as Row[]
 }
 
-function pickApi(tableId: any) {
+function pickApi(tableOrViewId: string) {
+  let tableId = tableOrViewId
+  if (isViewID(tableOrViewId)) {
+    tableId = extractViewInfoFromID(tableOrViewId).tableId
+  }
+
   if (isExternalTableID(tableId)) {
     return external
   }
@@ -35,6 +44,6 @@ export async function save(
   return pickApi(tableId).save(tableId, row, userId)
 }
 
-export async function find(tableId: string, rowId: string) {
-  return pickApi(tableId).find(tableId, rowId)
+export async function find(tableOrViewId: string, rowId: string) {
+  return pickApi(tableOrViewId).find(tableOrViewId, rowId)
 }

--- a/packages/server/src/sdk/app/rows/rows.ts
+++ b/packages/server/src/sdk/app/rows/rows.ts
@@ -37,11 +37,11 @@ function pickApi(tableOrViewId: string) {
 }
 
 export async function save(
-  tableId: string,
+  tableOrViewId: string,
   row: Row,
   userId: string | undefined
 ) {
-  return pickApi(tableId).save(tableId, row, userId)
+  return pickApi(tableOrViewId).save(tableOrViewId, row, userId)
 }
 
 export async function find(tableOrViewId: string, rowId: string) {

--- a/packages/server/src/sdk/app/rows/search.ts
+++ b/packages/server/src/sdk/app/rows/search.ts
@@ -86,16 +86,21 @@ export async function search(
       options.query = removeInvalidFilters(options.query, queriableFields)
     }
 
+    let outputRowOptions
+    if (options.viewId) {
+      outputRowOptions = sdk.views.outputRowOptions(table, options.viewId)
+    }
+
     let result: SearchResponse<Row>
     if (isExternalTable) {
       span?.addTags({ searchType: "external" })
-      result = await external.search(options, table)
+      result = await external.search(options, table, outputRowOptions)
     } else if (dbCore.isSqsEnabledForTenant()) {
       span?.addTags({ searchType: "sqs" })
-      result = await internal.sqs.search(options, table)
+      result = await internal.sqs.search(options, table, { outputRowOptions })
     } else {
       span?.addTags({ searchType: "lucene" })
-      result = await internal.lucene.search(options, table)
+      result = await internal.lucene.search(options, table, outputRowOptions)
     }
 
     span?.addTags({

--- a/packages/server/src/sdk/app/rows/search.ts
+++ b/packages/server/src/sdk/app/rows/search.ts
@@ -86,21 +86,16 @@ export async function search(
       options.query = removeInvalidFilters(options.query, queriableFields)
     }
 
-    let outputRowOptions
-    if (options.viewId) {
-      outputRowOptions = sdk.views.outputRowOptions(table, options.viewId)
-    }
-
     let result: SearchResponse<Row>
     if (isExternalTable) {
       span?.addTags({ searchType: "external" })
-      result = await external.search(options, table, outputRowOptions)
+      result = await external.search(options, table)
     } else if (dbCore.isSqsEnabledForTenant()) {
       span?.addTags({ searchType: "sqs" })
-      result = await internal.sqs.search(options, table, { outputRowOptions })
+      result = await internal.sqs.search(options, table)
     } else {
       span?.addTags({ searchType: "lucene" })
-      result = await internal.lucene.search(options, table, outputRowOptions)
+      result = await internal.lucene.search(options, table)
     }
 
     span?.addTags({

--- a/packages/server/src/sdk/app/rows/search/external.ts
+++ b/packages/server/src/sdk/app/rows/search/external.ts
@@ -1,6 +1,7 @@
 import {
   IncludeRelationship,
   Operation,
+  OutputRowOptions,
   PaginationJson,
   Row,
   RowSearchParams,
@@ -60,7 +61,8 @@ function getPaginationAndLimitParameters(
 
 export async function search(
   options: RowSearchParams,
-  table: Table
+  table: Table,
+  outputRowOptions?: OutputRowOptions
 ): Promise<SearchResponse<Row>> {
   const { tableId } = options
   const { countRows, paginate, query, ...params } = options
@@ -115,6 +117,7 @@ export async function search(
     let processed = await outputProcessing(table, rows, {
       preserveLinks: true,
       squash: true,
+      squashNestedFields: outputRowOptions?.squashNestedFields,
     })
 
     let hasNextPage = false

--- a/packages/server/src/sdk/app/rows/search/external.ts
+++ b/packages/server/src/sdk/app/rows/search/external.ts
@@ -112,7 +112,7 @@ export async function search(
         : Promise.resolve(undefined),
     ])
 
-    let processed = await outputProcessing<Row[]>(table, rows, {
+    let processed = await outputProcessing(table, rows, {
       preserveLinks: true,
       squash: true,
     })
@@ -260,7 +260,7 @@ export async function fetch(tableId: string): Promise<Row[]> {
     includeSqlRelationships: IncludeRelationship.INCLUDE,
   })
   const table = await sdk.tables.getTable(tableId)
-  return await outputProcessing<Row[]>(table, response.rows, {
+  return await outputProcessing(table, response.rows, {
     preserveLinks: true,
     squash: true,
   })

--- a/packages/server/src/sdk/app/rows/search/external.ts
+++ b/packages/server/src/sdk/app/rows/search/external.ts
@@ -1,7 +1,6 @@
 import {
   IncludeRelationship,
   Operation,
-  OutputRowOptions,
   PaginationJson,
   Row,
   RowSearchParams,
@@ -61,8 +60,7 @@ function getPaginationAndLimitParameters(
 
 export async function search(
   options: RowSearchParams,
-  table: Table,
-  outputRowOptions?: OutputRowOptions
+  table: Table
 ): Promise<SearchResponse<Row>> {
   const { tableId } = options
   const { countRows, paginate, query, ...params } = options
@@ -117,7 +115,7 @@ export async function search(
     let processed = await outputProcessing(table, rows, {
       preserveLinks: true,
       squash: true,
-      squashNestedFields: outputRowOptions?.squashNestedFields,
+      fromViewId: options.viewId,
     })
 
     let hasNextPage = false

--- a/packages/server/src/sdk/app/rows/search/internal/internal.ts
+++ b/packages/server/src/sdk/app/rows/search/internal/internal.ts
@@ -61,7 +61,7 @@ export async function exportRows(
       })
     ).rows.map(row => row.doc!)
 
-    result = await outputProcessing<Row[]>(table, response)
+    result = await outputProcessing(table, response)
   } else if (query) {
     let searchResponse = await sdk.rows.search({
       tableId,

--- a/packages/server/src/sdk/app/rows/search/internal/lucene.ts
+++ b/packages/server/src/sdk/app/rows/search/internal/lucene.ts
@@ -2,7 +2,6 @@ import { PROTECTED_INTERNAL_COLUMNS } from "@budibase/shared-core"
 import { fullSearch, paginatedSearch } from "../utils"
 import { InternalTables } from "../../../../../db/utils"
 import {
-  OutputRowOptions,
   Row,
   RowSearchParams,
   SearchResponse,
@@ -16,8 +15,7 @@ import pick from "lodash/pick"
 
 export async function search(
   options: RowSearchParams,
-  table: Table,
-  outputRowOptions?: OutputRowOptions
+  table: Table
 ): Promise<SearchResponse<Row>> {
   const { tableId } = options
 
@@ -62,7 +60,7 @@ export async function search(
     }
 
     response.rows = await outputProcessing(table, response.rows, {
-      squashNestedFields: outputRowOptions?.squashNestedFields,
+      fromViewId: options.viewId,
     })
   }
 

--- a/packages/server/src/sdk/app/rows/search/internal/lucene.ts
+++ b/packages/server/src/sdk/app/rows/search/internal/lucene.ts
@@ -2,6 +2,7 @@ import { PROTECTED_INTERNAL_COLUMNS } from "@budibase/shared-core"
 import { fullSearch, paginatedSearch } from "../utils"
 import { InternalTables } from "../../../../../db/utils"
 import {
+  OutputRowOptions,
   Row,
   RowSearchParams,
   SearchResponse,
@@ -15,7 +16,8 @@ import pick from "lodash/pick"
 
 export async function search(
   options: RowSearchParams,
-  table: Table
+  table: Table,
+  outputRowOptions?: OutputRowOptions
 ): Promise<SearchResponse<Row>> {
   const { tableId } = options
 
@@ -59,7 +61,9 @@ export async function search(
       response.rows = response.rows.map((r: any) => pick(r, fields))
     }
 
-    response.rows = await outputProcessing(table, response.rows)
+    response.rows = await outputProcessing(table, response.rows, {
+      squashNestedFields: outputRowOptions?.squashNestedFields,
+    })
   }
 
   return response

--- a/packages/server/src/sdk/app/rows/search/internal/lucene.ts
+++ b/packages/server/src/sdk/app/rows/search/internal/lucene.ts
@@ -60,6 +60,7 @@ export async function search(
     }
 
     response.rows = await outputProcessing(table, response.rows, {
+      squash: true,
       fromViewId: options.viewId,
     })
   }

--- a/packages/server/src/sdk/app/rows/search/internal/sqs.ts
+++ b/packages/server/src/sdk/app/rows/search/internal/sqs.ts
@@ -4,7 +4,6 @@ import {
   FieldType,
   isLogicalSearchOperator,
   Operation,
-  OutputRowOptions,
   QueryJson,
   RelationshipFieldMetadata,
   RelationshipsJson,
@@ -284,7 +283,7 @@ function resyncDefinitionsRequired(status: number, message: string) {
 export async function search(
   options: RowSearchParams,
   table: Table,
-  opts?: { retrying?: boolean; outputRowOptions?: OutputRowOptions }
+  opts?: { retrying?: boolean }
 ): Promise<SearchResponse<Row>> {
   let { paginate, query, ...params } = options
 
@@ -383,7 +382,7 @@ export async function search(
     let finalRows = await outputProcessing(table, processed, {
       preserveLinks: true,
       squash: true,
-      squashNestedFields: opts?.outputRowOptions?.squashNestedFields,
+      fromViewId: options.viewId,
     })
 
     // check if we need to pick specific rows out
@@ -411,10 +410,7 @@ export async function search(
     const msg = typeof err === "string" ? err : err.message
     if (!opts?.retrying && resyncDefinitionsRequired(err.status, msg)) {
       await sdk.tables.sqs.syncDefinition()
-      return search(options, table, {
-        retrying: true,
-        outputRowOptions: opts?.outputRowOptions,
-      })
+      return search(options, table, { retrying: true })
     }
     // previously the internal table didn't error when a column didn't exist in search
     if (err.status === 400 && msg?.match(MISSING_COLUMN_REGEX)) {

--- a/packages/server/src/sdk/app/rows/search/internal/sqs.ts
+++ b/packages/server/src/sdk/app/rows/search/internal/sqs.ts
@@ -379,7 +379,7 @@ export async function search(
     }
 
     // get the rows
-    let finalRows = await outputProcessing<Row[]>(table, processed, {
+    let finalRows = await outputProcessing(table, processed, {
       preserveLinks: true,
       squash: true,
     })

--- a/packages/server/src/sdk/app/rows/utils.ts
+++ b/packages/server/src/sdk/app/rows/utils.ts
@@ -17,7 +17,11 @@ import {
 import { makeExternalQuery } from "../../../integrations/base/query"
 import { Format } from "../../../api/controllers/view/exporters"
 import sdk from "../.."
-import { isRelationshipColumn } from "../../../db/utils"
+import {
+  extractViewInfoFromID,
+  isRelationshipColumn,
+  isViewID,
+} from "../../../db/utils"
 import { isSQL } from "../../../integrations/utils"
 
 const SQL_CLIENT_SOURCE_MAP: Record<SourceName, SqlClient | undefined> = {
@@ -316,4 +320,15 @@ function validateTimeOnlyField(
 // type-guard check
 export function isArrayFilter(operator: any): operator is ArrayOperator {
   return Object.values(ArrayOperator).includes(operator)
+}
+
+export function tryExtractingTableAndViewId(tableOrViewId: string) {
+  if (isViewID(tableOrViewId)) {
+    return {
+      tableId: extractViewInfoFromID(tableOrViewId).tableId,
+      viewId: tableOrViewId,
+    }
+  }
+
+  return { tableId: tableOrViewId }
 }

--- a/packages/server/src/sdk/app/tables/getters.ts
+++ b/packages/server/src/sdk/app/tables/getters.ts
@@ -7,13 +7,9 @@ import {
 } from "../../../integrations/utils"
 import {
   Database,
-  FieldType,
   INTERNAL_TABLE_SOURCE_ID,
-  RelationSchemaField,
-  RelationshipFieldMetadata,
   Table,
   TableResponse,
-  TableSchema,
   TableSourceType,
   TableViewsResponse,
 } from "@budibase/types"

--- a/packages/server/src/sdk/app/tables/getters.ts
+++ b/packages/server/src/sdk/app/tables/getters.ts
@@ -146,53 +146,6 @@ export async function getTables(tableIds: string[]): Promise<Table[]> {
   return processTables(tables)
 }
 
-export async function enrichRelationshipSchema(
-  schema: TableSchema
-): Promise<TableSchema> {
-  const tableCache: Record<string, Table> = {}
-
-  async function populateRelTableSchema(field: RelationshipFieldMetadata) {
-    if (!tableCache[field.tableId]) {
-      tableCache[field.tableId] = await sdk.tables.getTable(field.tableId)
-    }
-    const relTable = tableCache[field.tableId]
-
-    const fieldSchema = field.schema || {}
-
-    const resultSchema: Record<string, RelationSchemaField> = {}
-
-    for (const relTableFieldName of Object.keys(relTable.schema)) {
-      const relTableField = relTable.schema[relTableFieldName]
-      if ([FieldType.LINK, FieldType.FORMULA].includes(relTableField.type)) {
-        continue
-      }
-
-      if (relTableField.visible === false) {
-        continue
-      }
-
-      const isVisible = !!fieldSchema[relTableFieldName]?.visible
-      const isReadonly = !!fieldSchema[relTableFieldName]?.readonly
-      resultSchema[relTableFieldName] = {
-        visible: isVisible,
-        readonly: isReadonly,
-      }
-    }
-    field.schema = resultSchema
-  }
-
-  const result: TableSchema = {}
-  for (const fieldName of Object.keys(schema)) {
-    const field = { ...schema[fieldName] }
-    if (field.type === FieldType.LINK) {
-      await populateRelTableSchema(field)
-    }
-
-    result[fieldName] = field
-  }
-  return result
-}
-
 export async function enrichViewSchemas(table: Table): Promise<TableResponse> {
   const views = []
   for (const view of Object.values(table.views ?? [])) {

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -1,7 +1,9 @@
 import {
   FieldType,
+  OutputRowOptions,
   RelationSchemaField,
   RenameColumn,
+  SquashTableFields,
   Table,
   TableSchema,
   View,
@@ -249,4 +251,27 @@ export function syncSchema(
   }
 
   return view
+}
+
+export function outputRowOptions(
+  table: Table,
+  viewId: string
+): OutputRowOptions {
+  const view = Object.values(table.views || {}).find(
+    (v): v is ViewV2 => sdk.views.isV2(v) && v.id === viewId
+  )
+  const viewSchema = view?.schema || {}
+
+  const squashFields: SquashTableFields = {}
+  for (const key of Object.keys(viewSchema)) {
+    if (viewSchema[key].columns) {
+      squashFields[key] = {
+        visibleFieldNames: Object.entries(viewSchema[key].columns)
+          .filter(([_, c]) => c.visible !== false)
+          .map(([columnName]) => columnName),
+      }
+    }
+  }
+
+  return { squashNestedFields: squashFields }
 }

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -202,7 +202,7 @@ export async function enrichSchema(
 
   const viewSchema = view.schema || {}
   const anyViewOrder = Object.values(viewSchema).some(ui => ui.order != null)
-  for (const key of Object.keys(schema)) {
+  for (const key of Object.keys(viewSchema)) {
     // if nothing specified in view, then it is not visible
     const ui = viewSchema[key] || { visible: false }
     schema[key] = {

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -1,9 +1,7 @@
 import {
   FieldType,
-  OutputRowOptions,
   RelationSchemaField,
   RenameColumn,
-  SquashTableFields,
   Table,
   TableSchema,
   View,
@@ -251,27 +249,4 @@ export function syncSchema(
   }
 
   return view
-}
-
-export function outputRowOptions(
-  table: Table,
-  viewId: string
-): OutputRowOptions {
-  const view = Object.values(table.views || {}).find(
-    (v): v is ViewV2 => sdk.views.isV2(v) && v.id === viewId
-  )
-  const viewSchema = view?.schema || {}
-
-  const squashFields: SquashTableFields = {}
-  for (const key of Object.keys(viewSchema)) {
-    if (viewSchema[key].columns) {
-      squashFields[key] = {
-        visibleFieldNames: Object.entries(viewSchema[key].columns)
-          .filter(([_, c]) => c.visible !== false)
-          .map(([columnName]) => columnName),
-      }
-    }
-  }
-
-  return { squashNestedFields: squashFields }
 }

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -202,7 +202,9 @@ export async function enrichSchema(
 
   const viewSchema = view.schema || {}
   const anyViewOrder = Object.values(viewSchema).some(ui => ui.order != null)
-  for (const key of Object.keys(viewSchema)) {
+  for (const key of Object.keys(tableSchema).filter(
+    k => tableSchema[k].visible !== false
+  )) {
     // if nothing specified in view, then it is not visible
     const ui = viewSchema[key] || { visible: false }
     schema[key] = {

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -198,7 +198,7 @@ export async function enrichSchema(
     return result
   }
 
-  let schema: TableSchema = {}
+  let schema: ViewV2Enriched["schema"] = {}
 
   const viewSchema = view.schema || {}
   const anyViewOrder = Object.values(viewSchema).some(ui => ui.order != null)

--- a/packages/server/src/sdk/app/views/tests/views.spec.ts
+++ b/packages/server/src/sdk/app/views/tests/views.spec.ts
@@ -297,12 +297,6 @@ describe("table sdk", () => {
             relationshipType: RelationshipType.ONE_TO_MANY,
             fieldName: "table",
             tableId: "otherTableId",
-            schema: {
-              title: {
-                visible: true,
-                readonly: true,
-              },
-            },
           },
         },
       }
@@ -334,7 +328,15 @@ describe("table sdk", () => {
         tableId,
         schema: {
           name: { visible: true },
-          other: { visible: true },
+          other: {
+            visible: true,
+            columns: {
+              title: {
+                visible: true,
+                readonly: true,
+              },
+            },
+          },
         },
       }
 
@@ -351,7 +353,7 @@ describe("table sdk", () => {
             other: {
               ...table.schema.other,
               visible: true,
-              schema: {
+              columns: {
                 title: {
                   visible: true,
                   readonly: true,

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -35,7 +35,6 @@ import {
 import { processString } from "@budibase/string-templates"
 import { isUserMetadataTable } from "../../api/controllers/row/utils"
 
-
 export * from "./utils"
 export * from "./attachments"
 

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -16,6 +16,7 @@ import {
   IdentityType,
   Row,
   RowAttachment,
+  SquashTableFields,
   Table,
   User,
 } from "@budibase/types"
@@ -247,6 +248,7 @@ export async function outputProcessing<T extends Row[] | Row>(
     preserveLinks?: boolean
     fromRow?: Row
     skipBBReferences?: boolean
+    squashNestedFields?: SquashTableFields
   } = {
     squash: true,
     preserveLinks: false,
@@ -342,8 +344,12 @@ export async function outputProcessing<T extends Row[] | Row>(
   // process formulas after the complex types had been processed
   enriched = await processFormulas(table, enriched, { dynamic: true })
 
-  if (opts.squash) {
-    enriched = await linkRows.squashLinks(table, enriched)
+  if (opts.squash || opts.squashNestedFields) {
+    enriched = await linkRows.squashLinks(
+      table,
+      enriched,
+      opts.squashNestedFields
+    )
   }
   // remove null properties to match internal API
   const isExternal = isExternalTableID(table._id!)

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -343,10 +343,7 @@ export async function outputProcessing<T extends Row[] | Row>(
   enriched = await processFormulas(table, enriched, { dynamic: true })
 
   if (opts.squash) {
-    enriched = (await linkRows.squashLinksToPrimaryDisplay(
-      table,
-      enriched
-    )) as Row[]
+    enriched = await linkRows.squashLinks(table, enriched)
   }
   // remove null properties to match internal API
   const isExternal = isExternalTableID(table._id!)

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -16,7 +16,6 @@ import {
   IdentityType,
   Row,
   RowAttachment,
-  SquashTableFields,
   Table,
   User,
 } from "@budibase/types"
@@ -35,6 +34,7 @@ import {
 } from "@budibase/shared-core"
 import { processString } from "@budibase/string-templates"
 import { isUserMetadataTable } from "../../api/controllers/row/utils"
+
 
 export * from "./utils"
 export * from "./attachments"
@@ -248,7 +248,7 @@ export async function outputProcessing<T extends Row[] | Row>(
     preserveLinks?: boolean
     fromRow?: Row
     skipBBReferences?: boolean
-    squashNestedFields?: SquashTableFields
+    fromViewId?: string
   } = {
     squash: true,
     preserveLinks: false,
@@ -344,12 +344,10 @@ export async function outputProcessing<T extends Row[] | Row>(
   // process formulas after the complex types had been processed
   enriched = await processFormulas(table, enriched, { dynamic: true })
 
-  if (opts.squash || opts.squashNestedFields) {
-    enriched = await linkRows.squashLinks(
-      table,
-      enriched,
-      opts.squashNestedFields
-    )
+  if (opts.squash) {
+    enriched = await linkRows.squashLinks(table, enriched, {
+      fromViewId: opts?.fromViewId,
+    })
   }
   // remove null properties to match internal API
   const isExternal = isExternalTableID(table._id!)

--- a/packages/types/src/documents/app/table/schema.ts
+++ b/packages/types/src/documents/app/table/schema.ts
@@ -25,12 +25,6 @@ interface BaseRelationshipFieldMetadata
   tableId: string
   tableRev?: string
   subtype?: AutoFieldSubType.CREATED_BY | AutoFieldSubType.UPDATED_BY
-  schema?: Record<string, RelationSchemaField>
-}
-
-export type RelationSchemaField = {
-  visible?: boolean
-  readonly?: boolean
 }
 
 // External tables use junction tables, internal tables don't require them

--- a/packages/types/src/documents/app/view.ts
+++ b/packages/types/src/documents/app/view.ts
@@ -38,7 +38,7 @@ export type ViewFieldMetadata = UIFieldMetadata & {
   columns?: Record<string, RelationSchemaField>
 }
 
-type RelationSchemaField = {
+export type RelationSchemaField = {
   visible?: boolean
   readonly?: boolean
 }

--- a/packages/types/src/documents/app/view.ts
+++ b/packages/types/src/documents/app/view.ts
@@ -1,5 +1,5 @@
 import { SearchFilter, SortOrder, SortType } from "../../api"
-import { RelationSchemaField, UIFieldMetadata } from "./table"
+import { UIFieldMetadata } from "./table"
 import { Document } from "../document"
 import { DBView } from "../../sdk"
 
@@ -35,7 +35,12 @@ export interface View {
 
 export type ViewFieldMetadata = UIFieldMetadata & {
   readonly?: boolean
-  schema?: Record<string, RelationSchemaField>
+  columns?: Record<string, RelationSchemaField>
+}
+
+type RelationSchemaField = {
+  visible?: boolean
+  readonly?: boolean
 }
 
 export interface ViewV2 {

--- a/packages/types/src/sdk/row.ts
+++ b/packages/types/src/sdk/row.ts
@@ -5,6 +5,7 @@ import { WithRequired } from "../shared"
 
 export interface SearchParams {
   tableId?: string
+  viewId?: string
   query?: SearchFilters
   paginate?: boolean
   bookmark?: string | number

--- a/packages/types/src/sdk/row.ts
+++ b/packages/types/src/sdk/row.ts
@@ -37,9 +37,3 @@ export enum RowExportFormat {
   JSON = "json",
   JSON_WITH_SCHEMA = "jsonWithSchema",
 }
-
-export interface OutputRowOptions {
-  squashNestedFields: SquashTableFields
-}
-
-export type SquashTableFields = Record<string, { visibleFieldNames: string[] }>

--- a/packages/types/src/sdk/row.ts
+++ b/packages/types/src/sdk/row.ts
@@ -36,3 +36,9 @@ export enum RowExportFormat {
   JSON = "json",
   JSON_WITH_SCHEMA = "jsonWithSchema",
 }
+
+export interface OutputRowOptions {
+  squashNestedFields: SquashTableFields
+}
+
+export type SquashTableFields = Record<string, { visibleFieldNames: string[] }>

--- a/packages/types/src/sdk/view.ts
+++ b/packages/types/src/sdk/view.ts
@@ -1,5 +1,9 @@
-import { TableSchema, ViewV2 } from "../documents"
+import { FieldSchema, RelationSchemaField, ViewV2 } from "../documents"
 
 export interface ViewV2Enriched extends ViewV2 {
-  schema?: TableSchema
+  schema?: {
+    [key: string]: FieldSchema & {
+      columns?: Record<string, RelationSchemaField>
+    }
+  }
 }


### PR DESCRIPTION
## Description
After finding that supporting link enrichment for both table + views was getting our code really messy, given that this is not going to be likely needed (as we will only enrich views for the foreseeable future) I refactored the code to support only enrichment in the views.
I tried breaking it down into smaller PRs, but it was pretty hard to do without constantly rewriting tests.