### PR TITLE
Reduced the Modal z-index to 1001

### DIFF
--- a/packages/bbui/src/Modal/Modal.svelte
+++ b/packages/bbui/src/Modal/Modal.svelte
@@ -10,7 +10,7 @@
   export let inline = false
   export let disableCancel = false
   export let autoFocus = true
-  export let zIndex = 99999
+  export let zIndex = 1001
 
   const dispatch = createEventDispatcher()
   let visible = fixed || inline


### PR DESCRIPTION
## Description

The Modal component z-index was changed from `999` to `99999` to accommodate modals displaying when the BindingDrawer was on screen. 

This caused issues for other areas of the product with Modals and modal workflows as some content was being pushed back.

The BindingDrawer z-index is `1000` so I've set the Modal back down to `1001`. This fixes the original issue and just avoids other display issues across the product.

## Addresses
- This was originally addressed here
- https://github.com/Budibase/budibase/pull/14436

## Screenshots
The theme select popover appears underneath the modal
![Screenshot 2024-08-29 at 12 36 31](https://github.com/user-attachments/assets/f075f3aa-aa26-441b-8fc7-07a174f739cb)


Notifications were stuck behind the Modal overlay.
![screen_stuck](https://github.com/user-attachments/assets/accfb72b-3a4b-4060-a427-b05064113c86)
