### PR TITLE
Display relationship fields

### DIFF
--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -469,6 +469,10 @@
   .values.wrap .badge:hover::before {
     opacity: 0.7;
   }
+  .values.wrap .badge.extra-info {
+    cursor: pointer;
+  }
+
   .badge span {
     overflow: hidden;
     white-space: nowrap;
@@ -544,12 +548,14 @@
   .relationship-fields {
     margin: var(--spacing-m) var(--spacing-l);
     display: grid;
-    grid-template-columns: auto auto;
+    grid-template-columns: minmax(auto, 75%) auto;
     grid-row-gap: var(--spacing-m);
     grid-column-gap: var(--cell-spacing);
   }
 
-  .values.wrap .badge.extra-info {
-    cursor: pointer;
+  .relationship-field-name {
+    text-transform: uppercase;
+    color: var(--spectrum-global-color-gray-600);
+    font-size: var(--font-size-xs);
   }
 </style>

--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -42,6 +42,20 @@
     }
   }
 
+  $: relationFields = fieldValue?.reduce((acc, f) => {
+    const fields = {}
+    for (const [column] of Object.entries(schema?.columns || {}).filter(
+      ([key, column]) =>
+        column.visible !== false && f[key] !== null && f[key] !== undefined
+    )) {
+      fields[column] = f[column]
+    }
+    if (Object.keys(fields).length) {
+      acc[f._id] = fields
+    }
+    return acc
+  }, {})
+
   const parseValue = value => {
     if (Array.isArray(value) && value.every(x => x?._id)) {
       return value
@@ -223,20 +237,7 @@
   }
 
   const displayRelationshipFields = relationship => {
-    const fields = {}
-    for (const column of Object.entries(schema.columns)
-      .filter(
-        ([key, column]) =>
-          column.visible !== false &&
-          relationship[key] !== null &&
-          relationship[key] !== undefined
-      )
-      .map(([key]) => key)) {
-      fields[column] = relationship[column]
-    }
-    if (Object.keys(fields).length) {
-      relationshipFields = fields
-    }
+    relationshipFields = relationFields[relationship._id]
   }
 
   const hideRelationshipFields = () => {

--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -56,6 +56,12 @@
     return acc
   }, {})
 
+  $: showRelationshipFields =
+    relationshipFields &&
+    Object.keys(relationshipFields).length &&
+    focused &&
+    !isOpen
+
   const parseValue = value => {
     if (Array.isArray(value) && value.every(x => x?._id)) {
       return value
@@ -351,8 +357,8 @@
   </GridPopover>
 {/if}
 
-{#if relationshipFields && !focused}
-  <GridPopover {open} {anchor}>
+{#if relationshipFields}
+  <GridPopover open={showRelationshipFields} {anchor}>
     <div class="relationship-fields">
       {#each Object.entries(relationshipFields) as [fieldName, fieldValue]}
         <div class="relationship-field-name">
@@ -460,6 +466,9 @@
     bottom: 0;
     border-radius: var(--cell-padding);
   }
+  .values.wrap .badge:hover::before {
+    opacity: 0.7;
+  }
   .badge span {
     overflow: hidden;
     white-space: nowrap;
@@ -540,10 +549,7 @@
     grid-column-gap: var(--cell-spacing);
   }
 
-  .values:not(.wrap) .badge.extra-info {
+  .values.wrap .badge.extra-info {
     cursor: pointer;
-  }
-  .values:not(.wrap) .badge.extra-info:hover::before {
-    opacity: 0.7;
   }
 </style>

--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -223,11 +223,19 @@
   }
 
   const displayRelationshipFields = relationship => {
+    const fields = {}
     for (const column of Object.entries(schema.columns)
-      .filter(([_, column]) => column.visible !== false)
+      .filter(
+        ([key, column]) =>
+          column.visible !== false &&
+          relationship[key] !== null &&
+          relationship[key] !== undefined
+      )
       .map(([key]) => key)) {
-      relationshipFields ??= {}
-      relationshipFields[column] = relationship[column]
+      fields[column] = relationship[column]
+    }
+    if (Object.keys(fields).length) {
+      relationshipFields = fields
     }
   }
 

--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -223,11 +223,11 @@
   }
 
   const displayRelationshipFields = relationship => {
-    {
-      const { _id, primaryDisplay, ...fields } = relationship
-      if (Object.keys(fields).length) {
-        relationshipFields = fields
-      }
+    for (const column of Object.entries(schema.columns)
+      .filter(([_, column]) => column.visible !== false)
+      .map(([key]) => key)) {
+      relationshipFields ??= {}
+      relationshipFields[column] = relationship[column]
     }
   }
 

--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -548,7 +548,7 @@
   .relationship-fields {
     margin: var(--spacing-m) var(--spacing-l);
     display: grid;
-    grid-template-columns: minmax(auto, 75%) auto;
+    grid-template-columns: minmax(auto, 75%) minmax(auto, 25%);
     grid-row-gap: var(--spacing-m);
     grid-column-gap: var(--cell-spacing);
   }

--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -548,7 +548,7 @@
   .relationship-fields {
     margin: var(--spacing-m) var(--spacing-l);
     display: grid;
-    grid-template-columns: minmax(auto, 75%) minmax(auto, 25%);
+    grid-template-columns: minmax(auto, 70%) minmax(auto, 30%);
     grid-row-gap: var(--spacing-m);
     grid-column-gap: var(--cell-spacing);
   }
@@ -557,5 +557,12 @@
     text-transform: uppercase;
     color: var(--spectrum-global-color-gray-600);
     font-size: var(--font-size-xs);
+  }
+  .relationship-field-value {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
   }
 </style>

--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -522,10 +522,10 @@
   }
 
   .relationship-fields {
-    margin: var(--cell-padding);
+    margin: var(--spacing-m) var(--spacing-l);
     display: grid;
     grid-template-columns: auto auto;
-    grid-row-gap: var(--cell-spacing);
+    grid-row-gap: var(--spacing-m);
     grid-column-gap: var(--cell-spacing);
   }
 </style>

--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -448,7 +448,8 @@
   .badge {
     flex: 0 0 auto;
     padding: 0 var(--cell-padding);
-    position: relative;
+    background: var(--color);
+    border-radius: var(--cell-padding);
     user-select: none;
     display: flex;
     align-items: center;
@@ -456,18 +457,8 @@
     height: 20px;
     max-width: 100%;
   }
-  .badge::before {
-    background: var(--color);
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    border-radius: var(--cell-padding);
-  }
-  .values.wrap .badge:hover::before {
-    opacity: 0.7;
+  .values.wrap .badge:hover {
+    filter: brightness(1.25);
   }
   .values.wrap .badge.extra-info {
     cursor: pointer;

--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -273,6 +273,7 @@
         {#if relationship[primaryDisplay] || relationship.primaryDisplay}
           <div
             class="badge"
+            class:extra-info={!!relationFields[relationship._id]}
             on:mouseover={() => displayRelationshipFields(relationship)}
             on:focus={() => {}}
             on:mouseleave={() => hideRelationshipFields()}
@@ -441,14 +442,23 @@
   .badge {
     flex: 0 0 auto;
     padding: 0 var(--cell-padding);
-    background: var(--color);
-    border-radius: var(--cell-padding);
+    position: relative;
     user-select: none;
     display: flex;
     align-items: center;
     gap: var(--cell-spacing);
     height: 20px;
     max-width: 100%;
+  }
+  .badge::before {
+    background: var(--color);
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    border-radius: var(--cell-padding);
   }
   .badge span {
     overflow: hidden;
@@ -528,5 +538,12 @@
     grid-template-columns: auto auto;
     grid-row-gap: var(--spacing-m);
     grid-column-gap: var(--cell-spacing);
+  }
+
+  .values:not(.wrap) .badge.extra-info {
+    cursor: pointer;
+  }
+  .values:not(.wrap) .badge.extra-info:hover::before {
+    opacity: 0.7;
   }
 </style>

--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -514,7 +514,7 @@
   }
 
   .relationship-fields {
-    padding: var(--spacing-s);
+    margin: var(--cell-padding);
     display: grid;
     grid-template-columns: auto auto;
     grid-row-gap: var(--cell-spacing);

--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -29,6 +29,7 @@
   let searching = false
   let container
   let anchor
+  let relationshipFields
 
   $: fieldValue = parseValue(value)
   $: oneRowOnly = schema?.relationshipType === "one-to-many"
@@ -221,6 +222,19 @@
     return value
   }
 
+  const displayRelationshipFields = relationship => {
+    {
+      const { _id, primaryDisplay, ...fields } = relationship
+      if (Object.keys(fields).length) {
+        relationshipFields = fields
+      }
+    }
+  }
+
+  const hideRelationshipFields = () => {
+    relationshipFields = undefined
+  }
+
   onMount(() => {
     api = {
       focus: open,
@@ -248,7 +262,12 @@
     >
       {#each fieldValue || [] as relationship}
         {#if relationship[primaryDisplay] || relationship.primaryDisplay}
-          <div class="badge">
+          <div
+            class="badge"
+            on:mouseover={() => displayRelationshipFields(relationship)}
+            on:focus={() => {}}
+            on:mouseleave={() => hideRelationshipFields()}
+          >
             <span>
               {readable(
                 relationship[primaryDisplay] || relationship.primaryDisplay
@@ -318,6 +337,21 @@
           {/each}
         </div>
       {/if}
+    </div>
+  </GridPopover>
+{/if}
+
+{#if relationshipFields && !isOpen}
+  <GridPopover {open} {anchor}>
+    <div class="relationship-fields">
+      {#each Object.entries(relationshipFields) as [fieldName, fieldValue]}
+        <div class="relationship-field-name">
+          {fieldName}
+        </div>
+        <div class="relationship-field-value">
+          {fieldValue}
+        </div>
+      {/each}
     </div>
   </GridPopover>
 {/if}
@@ -477,5 +511,13 @@
   }
   .search :global(.spectrum-Form-item) {
     flex: 1 1 auto;
+  }
+
+  .relationship-fields {
+    padding: var(--spacing-s);
+    display: grid;
+    grid-template-columns: auto auto;
+    grid-row-gap: var(--cell-spacing);
+    grid-column-gap: var(--cell-spacing);
   }
 </style>

--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -273,6 +273,7 @@
     <div
       class="values"
       class:wrap={editable || contentLines > 1}
+      class:disabled={!focused}
       on:wheel={e => (focused ? e.stopPropagation() : null)}
     >
       {#each fieldValue || [] as relationship}
@@ -357,8 +358,8 @@
   </GridPopover>
 {/if}
 
-{#if relationshipFields}
-  <GridPopover open={showRelationshipFields} {anchor}>
+{#if showRelationshipFields}
+  <GridPopover {anchor} minWidth={300} maxWidth={400}>
     <div class="relationship-fields">
       {#each Object.entries(relationshipFields) as [fieldName, fieldValue]}
         <div class="relationship-field-name">
@@ -425,6 +426,9 @@
     overflow: hidden;
     padding: var(--cell-padding);
     flex-wrap: nowrap;
+  }
+  .values.disabled {
+    pointer-events: none;
   }
   .values.wrap {
     flex-wrap: wrap;
@@ -539,9 +543,9 @@
   .relationship-fields {
     margin: var(--spacing-m) var(--spacing-l);
     display: grid;
-    grid-template-columns: minmax(auto, 70%) minmax(auto, 30%);
+    grid-template-columns: minmax(auto, 50%) auto;
     grid-row-gap: var(--spacing-m);
-    grid-column-gap: var(--cell-spacing);
+    grid-column-gap: var(--spacing-m);
   }
 
   .relationship-field-name {

--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -341,7 +341,7 @@
   </GridPopover>
 {/if}
 
-{#if relationshipFields && !isOpen}
+{#if relationshipFields && !focused}
   <GridPopover {open} {anchor}>
     <div class="relationship-fields">
       {#each Object.entries(relationshipFields) as [fieldName, fieldValue]}

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -216,7 +216,7 @@ export async function enrichSchema(
     if (schema[key].type === FieldType.LINK) {
       schema[key].columns = await populateRelTableSchema(
         schema[key].tableId,
-        viewSchema[key].columns || {}
+        viewSchema[key]?.columns || {}
       )
     }
   }


### PR DESCRIPTION
## Description
Given that we introduced the ability to pick field relations, we want to display them on the grid. This will be used to give feedback to the user about the updates they have made.

## Screenshots
### Relationships with all data visible, with some long texts in both column and data

https://github.com/user-attachments/assets/8d202b8e-e3f3-42ef-acfe-1d92003b1c69







### All the relationships will show in the same position for each cell

https://github.com/user-attachments/assets/62dc78b3-60b4-4ddc-861c-023fcafd30cf






### Having some relationships with no-related data populated
See `a4`, the pill just does not display 

https://github.com/user-attachments/assets/525b302d-cacd-4ee5-abf7-d7d1873f6351









### Relationship fields will only display when focused (but not editing), to avoid too much noise


https://github.com/user-attachments/assets/7b4f5bc7-77d5-478c-a62f-4a8458ca2463


















## Launchcontrol
Display relationship fields 