### PR TITLE
Disable creation of createdAt and createdBy auto columns when default values is enabled.

### DIFF
--- a/packages/backend-core/src/features/index.ts
+++ b/packages/backend-core/src/features/index.ts
@@ -266,6 +266,6 @@ export class FlagSet<V extends Flag<any>, T extends { [key: string]: V }> {
 // All of the machinery in this file is to make sure that flags have their
 // default values set correctly and their types flow through the system.
 export const flags = new FlagSet({
-  DEFAULT_VALUES: Flag.boolean(false),
+  DEFAULT_VALUES: Flag.boolean(env.isDev()),
   SQS: Flag.boolean(false),
 })

--- a/packages/builder/src/helpers/utils.js
+++ b/packages/builder/src/helpers/utils.js
@@ -7,10 +7,22 @@ import {
   FIELDS,
   isAutoColumnUserRelationship,
 } from "constants/backend"
+import { isEnabled } from "helpers/featureFlags"
 
 export function getAutoColumnInformation(enabled = true) {
   let info = {}
-  for (let [key, subtype] of Object.entries(AUTO_COLUMN_SUB_TYPES)) {
+  for (const [key, subtype] of Object.entries(AUTO_COLUMN_SUB_TYPES)) {
+    // Because it's possible to replicate the functionality of CREATED_AT and
+    // CREATED_BY columns, we disable their creation when the DEFAULT_VALUES
+    // feature flag is enabled.
+    if (isEnabled("DEFAULT_VALUES")) {
+      if (
+        subtype === AUTO_COLUMN_SUB_TYPES.CREATED_AT ||
+        subtype === AUTO_COLUMN_SUB_TYPES.CREATED_BY
+      ) {
+        continue
+      }
+    }
     info[subtype] = { enabled, name: AUTO_COLUMN_DISPLAY_NAMES[key] }
   }
   return info


### PR DESCRIPTION
## Description

Because it's possible to replicate the functionality of CREATED_AT and CREATED_BY columns, we disable their creation when the DEFAULT_VALUES feature flag is enabled.