### PR TITLE
Make sure setEnrichedUsers is called when tenantOwnerLoaded

### DIFF
--- a/packages/builder/src/pages/builder/portal/users/users/index.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/index.svelte
@@ -100,7 +100,7 @@
   $: pendingSchema = getPendingSchema(schema)
   $: userData = []
   $: inviteUsersResponse = { successful: [], unsuccessful: [] }
-  $: setEnrichedUsers($fetch.rows)
+  $: setEnrichedUsers($fetch.rows, tenantOwnerLoaded)
 
   const setEnrichedUsers = async rows => {
     if (!tenantOwnerLoaded) {


### PR DESCRIPTION
## Description
Issue found in QA that wasn't found locally because of differences in race-conditions.

Need to make sure that when the tenant owner query is complete that the users are enriched and set.
