### PR TITLE
Add LICENSE_TYPE

### DIFF
--- a/.github/workflows/deploy-featurebranch.yml
+++ b/.github/workflows/deploy-featurebranch.yml
@@ -22,6 +22,7 @@ jobs:
         env:
           PAYLOAD_BRANCH: ${{ github.head_ref }}
           PAYLOAD_PR_NUMBER: ${{ github.event.pull_request.number }}
+          PAYLOAD_LICENSE_TYPE: "free"
         with:
           repository: budibase/budibase-deploys
           event: featurebranch-qa-deploy


### PR DESCRIPTION
## Description
Passes a `LICENSE_TYPE` to the workflow dispatch for the feature branches action.  

## Addresses
- fixes failed pipelines as a result of a license generation error
