### PR TITLE
Support updating names

### DIFF
--- a/packages/server/src/api/controllers/table/index.ts
+++ b/packages/server/src/api/controllers/table/index.ts
@@ -116,6 +116,9 @@ export async function save(ctx: UserCtx<SaveTableRequest, SaveTableResponse>) {
   } else {
     await events.table.updated(savedTable)
   }
+  if (renaming) {
+    await sdk.views.renameLinkedViews(savedTable, renaming)
+  }
   if (isImport) {
     await events.table.imported(savedTable)
   }

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1204,18 +1204,18 @@ describe.each([
           )
           await config.api.table.save({
             ...table,
-              schema: {
+            schema: {
               ...table.schema,
-                aux: {
-                  name: "aux",
-                  relationshipType: RelationshipType.ONE_TO_MANY,
-                  type: FieldType.LINK,
-                  tableId: auxTable._id!,
-                  fieldName: "fk_aux",
+              aux: {
+                name: "aux",
+                relationshipType: RelationshipType.ONE_TO_MANY,
+                type: FieldType.LINK,
+                tableId: auxTable._id!,
+                fieldName: "fk_aux",
                 constraints: { type: "array" },
-                },
               },
-            })
+            },
+          })
           // Refetch auxTable
           auxTable = await config.api.table.get(auxTable._id!)
 

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1238,11 +1238,11 @@ describe.each([
 
         const renameColumn = async (table: Table, renaming: RenameColumn) => {
           const newSchema = { ...table.schema }
-          ;(newSchema[renaming.updated] = {
+          newSchema[renaming.updated] = {
             ...table.schema[renaming.old],
             name: renaming.updated,
-          }),
-            delete newSchema[renaming.old]
+          }
+          delete newSchema[renaming.old]
 
           await config.api.table.save({
             ...table,

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1177,7 +1177,9 @@ describe.each([
             }
           )
         })
+      })
 
+      describe("foreign relationship columns", () => {
         it("updating a column will update link columns configuration", async () => {
           let auxTable = await config.api.table.save(
             saveTableRequest({

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1199,18 +1199,25 @@ describe.each([
 
           const table = await config.api.table.save(
             saveTableRequest({
+              schema: {},
+            })
+          )
+          await config.api.table.save({
+            ...table,
               schema: {
+              ...table.schema,
                 aux: {
                   name: "aux",
                   relationshipType: RelationshipType.ONE_TO_MANY,
                   type: FieldType.LINK,
                   tableId: auxTable._id!,
                   fieldName: "fk_aux",
-                  constraints: { presence: true },
+                constraints: { type: "array" },
                 },
               },
             })
-          )
+          // Refetch auxTable
+          auxTable = await config.api.table.get(auxTable._id!)
 
           const view = await config.api.viewV2.create({
             name: "view a",
@@ -1226,8 +1233,6 @@ describe.each([
             },
           })
 
-          // Refetch autTable
-          auxTable = await config.api.table.get(auxTable._id!)
           await config.api.table.save({
             ...auxTable,
             schema: {

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -254,21 +254,18 @@ export function syncSchema(
 }
 
 export async function renameLinkedViews(table: Table, renaming: RenameColumn) {
-  const relatedTableIds = new Set<string>()
+  const relatedTables: Record<string, Table> = {}
 
   for (const field of Object.values(table.schema)) {
     if (field.type !== FieldType.LINK) {
       continue
     }
 
-    relatedTableIds.add(field.tableId)
+    relatedTables[field.tableId] ??= await sdk.tables.getTable(field.tableId)
     break
   }
 
-  const relatedTables = await sdk.tables.getTables(
-    Array.from(relatedTableIds.values())
-  )
-  for (const relatedTable of relatedTables) {
+  for (const relatedTable of Object.values(relatedTables)) {
     let toSave = false
     const viewsV2 = Object.values(relatedTable.views || {}).filter(
       sdk.views.isV2

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -1,7 +1,6 @@
 import {
   FieldType,
   RelationSchemaField,
-  RelationshipFieldMetadata,
   RenameColumn,
   Table,
   TableSchema,
@@ -255,18 +254,20 @@ export function syncSchema(
 }
 
 export async function renameLinkedViews(table: Table, renaming: RenameColumn) {
-  const relatedLinks: Record<string, RelationshipFieldMetadata[]> = {}
+  const relatedTableIds = new Set<string>()
 
   for (const field of Object.values(table.schema)) {
     if (field.type !== FieldType.LINK) {
       continue
     }
 
-    relatedLinks[field.tableId] ??= []
-    relatedLinks[field.tableId].push(field)
+    relatedTableIds.add(field.tableId)
+    break
   }
 
-  const relatedTables = await sdk.tables.getTables(Object.keys(relatedLinks))
+  const relatedTables = await sdk.tables.getTables(
+    Array.from(relatedTableIds.values())
+  )
   for (const relatedTable of relatedTables) {
     let toSave = false
     const viewsV2 = Object.values(relatedTable.views || {}).filter(

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -282,7 +282,7 @@ export async function renameLinkedViews(table: Table, renaming: RenameColumn) {
 
         return tableField.tableId === table._id
       })) {
-        const columns = view.schema && view.schema[relField]?.columns
+        const columns = view.schema?.[relField]?.columns
 
         if (columns && columns[renaming.old]) {
           columns[renaming.updated] = columns[renaming.old]

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -262,7 +262,6 @@ export async function renameLinkedViews(table: Table, renaming: RenameColumn) {
     }
 
     relatedTables[field.tableId] ??= await sdk.tables.getTable(field.tableId)
-    break
   }
 
   for (const relatedTable of Object.values(relatedTables)) {

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -276,7 +276,7 @@ export async function renameLinkedViews(table: Table, renaming: RenameColumn) {
     for (const view of viewsV2) {
       for (const relField of Object.keys(view.schema || {}).filter(f => {
         const tableField = relatedTable.schema[f]
-        if (tableField.type !== FieldType.LINK) {
+        if (!tableField || tableField.type !== FieldType.LINK) {
           return false
         }
 


### PR DESCRIPTION
## Description
The new link fields relationships stores the name of the columns to define which fields are returned with link data. Because we don't have any immutable identifier, this data can get stale for some views when a column is renamed.
This PRs ensures that, on column rename, any view referring to that column will also be renamed. The applied method is not the most efficient one, as it needs to analyse many possible views. But given that this action can only happen on the builder, it should be fine.


https://github.com/user-attachments/assets/beb400a9-9673-4ee3-9353-df2226a9ce2a



## Launchcontrol
Handle view relationship fields while renaming columns