### PR TITLE
Don't add PR message on XL PRs

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -21,6 +21,7 @@ jobs:
           l_max_size: "1000"
           fail_if_xl: "false"
           files_to_ignore: "yarn.lock"
+          message_if_xl: ""
 
   team-labeler:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Don't add the PR message below on XL PRs. Based on the action code: 
![image](https://github.com/user-attachments/assets/8e4bb6a6-f335-438b-a5d2-ad2515904348)

Current message to get rid of:
![image](https://github.com/user-attachments/assets/536d3d90-bfe9-4457-8dbd-7bdf51e37ea1)
