### PR TITLE
fix issue with multiple loops breaking automation context

### DIFF
--- a/packages/server/src/automations/tests/scenarios/scenarios.spec.ts
+++ b/packages/server/src/automations/tests/scenarios/scenarios.spec.ts
@@ -362,6 +362,32 @@ describe("Automation Scenarios", () => {
         }
       )
     })
+
+    it("should run an automation where a loop is used twice to ensure context correctness further down the tree", async () => {
+      const builder = createAutomationBuilder({
+        name: "Test Trigger with Loop and Create Row",
+      })
+
+      const results = await builder
+        .appAction({ fields: {} })
+        .loop({
+          option: LoopStepType.ARRAY,
+          binding: [1, 2, 3],
+        })
+        .serverLog({ text: "Message {{loop.currentItem}}" })
+        .serverLog({ text: "{{steps.1.iterations}}" })
+        .loop({
+          option: LoopStepType.ARRAY,
+          binding: [1, 2, 3],
+        })
+        .serverLog({ text: "{{loop.currentItem}}" })
+        .serverLog({ text: "{{steps.3.iterations}}" })
+        .run()
+
+      // We want to ensure that bindings are corr
+      expect(results.steps[1].outputs.message).toContain("- 3")
+      expect(results.steps[3].outputs.message).toContain("- 3")
+    })
   })
 
   describe("Row Automations", () => {

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -451,7 +451,7 @@ class Orchestrator {
       })
       this.context.steps[this.context.steps.length] = tempOutput
       this.context.steps = this.context.steps.filter(
-        item => !item.hasOwnProperty("currentItem")
+        item => !item.hasOwnProperty.call("currentItem")
       )
 
       this.loopStepOutputs = []

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -451,7 +451,7 @@ class Orchestrator {
       })
       this.context.steps[this.context.steps.length] = tempOutput
       this.context.steps = this.context.steps.filter(
-        item => !item.hasOwnProperty.call("currentItem")
+        item => !item.hasOwnProperty.call(item, "currentItem")
       )
 
       this.loopStepOutputs = []

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -449,7 +449,11 @@ class Orchestrator {
         outputs: tempOutput,
         inputs: steps[stepToLoopIndex].inputs,
       })
-      this.context.steps[currentIndex + 1] = tempOutput
+      this.context.steps[this.context.steps.length] = tempOutput
+      this.context.steps = this.context.steps.filter(
+        item => !item.hasOwnProperty("currentItem")
+      )
+
       this.loopStepOutputs = []
     }
 
@@ -569,8 +573,8 @@ class Orchestrator {
       this.loopStepOutputs.push(outputs)
     } else {
       this.updateExecutionOutput(step.id, step.stepId, step.inputs, outputs)
+      this.context.steps[this.context.steps.length] = outputs
     }
-    this.context.steps[this.context.steps.length] = outputs
   }
 }
 


### PR DESCRIPTION
## Description
Fixes an issue where if you had multiple loop steps at different points in your automation it could break context. This was because the "currentItem" that gets added to context wasn't being cleaned up post loop finish.

## Launchcontrol

- Fixes an issue where multiple loop steps where causing bindings to be unavailable