### PR TITLE
Fix: unable to upgrade plan

### DIFF
--- a/packages/builder/src/pages/builder/portal/_components/LockedFeature.svelte
+++ b/packages/builder/src/pages/builder/portal/_components/LockedFeature.svelte
@@ -1,10 +1,12 @@
 <script>
   import {
+    AbsTooltip,
     Layout,
     Heading,
     Body,
     Button,
     Divider,
+    Icon,
     Tags,
     Tag,
   } from "@budibase/bbui"
@@ -15,6 +17,8 @@
   export let description
   export let enabled
   export let upgradeButtonClick
+
+  $: upgradeDisabled = !$auth.accountPortalAccess && $admin.cloud
 </script>
 
 <Layout noPadding>
@@ -36,8 +40,9 @@
   {:else}
     <div class="buttons">
       <Button
-        primary
-        disabled={!$auth.accountPortalAccess && $admin.cloud}
+        primary={!upgradeDisabled}
+        secondary={upgradeDisabled}
+        disabled={upgradeDisabled}
         on:click={async () => upgradeButtonClick()}
       >
         Upgrade
@@ -51,6 +56,16 @@
       >
         View Plans
       </Button>
+      {#if upgradeDisabled}
+        <AbsTooltip
+          text={"Please contact the account holder to upgrade"}
+          position={"right"}
+        >
+          <div class="icon" on:focus>
+            <Icon name="InfoOutline" size="L" disabled hoverable />
+          </div>
+        </AbsTooltip>
+      {/if}
     </div>
   {/if}
 </Layout>
@@ -67,7 +82,11 @@
     justify-content: flex-start;
     gap: var(--spacing-m);
   }
-
+  .icon {
+    position: relative;
+    display: flex;
+    justify-content: center;
+  }
   .buttons {
     display: flex;
     flex-direction: row;

--- a/packages/builder/src/pages/builder/portal/users/users/index.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/index.svelte
@@ -127,7 +127,10 @@
         name: user.firstName ? user.firstName + " " + user.lastName : "",
         userGroups,
         __selectable:
-          role.value === Constants.BudibaseRoles.Owner ? false : undefined,
+          role.value === Constants.BudibaseRoles.Owner ||
+          $auth.user?.email === user.email
+            ? false
+            : true,
         apps: [...new Set(Object.keys(user.roles))],
         access: role.sortOrder,
       }
@@ -392,7 +395,7 @@
     allowSelectRows={!readonly}
     {customRenderers}
     loading={!$fetch.loaded || !groupsLoaded}
-    defaultSortColumn={"access"}
+    defaultSortColumn={"__selectable"}
   />
 
   <div class="pagination">


### PR DESCRIPTION
## Description
Now disabling the upgrade plan button for non account holders.

Also removed the ability to select yourself in the users table.

## Addresses
- https://linear.app/budibase/issue/BUDI-8616/[qa-wolf]-unable-to-upgrade-plan

## Screenshots
![dont allow admins to select themselves](https://github.com/user-attachments/assets/93f3abd7-573a-4686-9213-18c2ea6bcc0b)

*Logged in as test2@test.com*

<img width="886" alt="Screenshot 2024-09-05 at 22 32 33" src="https://github.com/user-attachments/assets/add53179-eeb6-4e29-820f-1cad82f6dd18">

*Logged in as a non account holder*
