### PR TITLE
Fix relationship popover click behaviour

### DIFF
--- a/packages/frontend-core/src/components/grid/overlays/GridPopover.svelte
+++ b/packages/frontend-core/src/components/grid/overlays/GridPopover.svelte
@@ -44,6 +44,7 @@
   {wrap}
   portalTarget="#{gridID} .grid-popover-container"
   offset={0}
+  clickOutsideOverride
 >
   <div
     class="grid-popover-contents"


### PR DESCRIPTION
## Description
Fixing a small UX bug with the recently introduced popover showing the relationship fields. This new popup is absorbing outside clicks, and it causes issues when trying to remove a relationship.


### Two clicks required to remove a relationship
#### Before
https://github.com/user-attachments/assets/f2b12627-1ab5-42ad-8aed-e62ec3693485

#### After

https://github.com/user-attachments/assets/80d9776a-2d6f-471d-bda7-ba90b399d3f7


