### PR TITLE
Fix long popover for relationship column pickers

### DIFF
--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -219,7 +219,7 @@
     on:close={() => (relationshipFieldName = null)}
     open={relationshipFieldName}
     anchor={relationshipPanelAnchor}
-    align="right-outside"
+    align="left"
   >
     {#if relationshipPanelColumns.length}
       <div class="relationship-header">


### PR DESCRIPTION
## Description
Fixing a UX bug when having too many columns on a relationship field picker


### Before

https://github.com/user-attachments/assets/99c39d53-b71b-4ad1-8f5a-360676fa1e34


### After

https://github.com/user-attachments/assets/3751476c-cdb1-4a41-bdb2-c59d7d9b6a3c

