### PR TITLE
Enrich views

### DIFF
--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -12,7 +12,7 @@
   export let columns
   export let fromRelationshipField
 
-  const { datasource, dispatch, cache, config } = getContext("grid")
+  const { datasource, dispatch, config } = getContext("grid")
 
   $: canSetRelationshipSchemas = $config.canSetRelationshipSchemas
 
@@ -114,29 +114,19 @@
     return { ...c, options }
   })
 
-  let relationshipPanelColumns = []
-  async function fetchRelationshipPanelColumns(relationshipField) {
-    relationshipPanelColumns = []
-    if (!relationshipField) {
-      return
+  $: relationshipPanelColumns = Object.entries(
+    relationshipField?.columns || {}
+  ).map(([name, column]) => {
+    return {
+      name: name,
+      label: name,
+      schema: {
+        type: column.type,
+        visible: column.visible,
+        readonly: column.readonly,
+      },
     }
-
-    const table = await cache.actions.getTable(relationshipField.tableId)
-    relationshipPanelColumns = Object.entries(
-      relationshipField?.columns || {}
-    ).map(([name, column]) => {
-      return {
-        name: name,
-        label: name,
-        schema: {
-          type: table.schema[name].type,
-          visible: column.visible,
-          readonly: column.readonly,
-        },
-      }
-    })
-  }
-  $: fetchRelationshipPanelColumns(relationshipField)
+  })
 
   async function toggleColumn(column, permission) {
     const visible = permission !== FieldPermissions.HIDDEN

--- a/packages/server/src/api/controllers/view/viewsV2.ts
+++ b/packages/server/src/api/controllers/view/viewsV2.ts
@@ -29,6 +29,9 @@ async function parseSchema(view: CreateViewRequest) {
           acc[key] = {
             visible: fieldSchema.visible,
             readonly: fieldSchema.readonly,
+            order: fieldSchema.order,
+            width: fieldSchema.width,
+            icon: fieldSchema.icon,
           }
           return acc
         }, {})

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1278,9 +1278,18 @@ describe.each([
               schema: expect.objectContaining({
                 aux: expect.objectContaining({
                   columns: {
-                    id: { visible: false, readonly: false },
-                    name: { visible: true, readonly: true },
-                    dob: { visible: true, readonly: true },
+                    id: expect.objectContaining({
+                      visible: false,
+                      readonly: false,
+                    }),
+                    name: expect.objectContaining({
+                      visible: true,
+                      readonly: true,
+                    }),
+                    dob: expect.objectContaining({
+                      visible: true,
+                      readonly: true,
+                    }),
                   },
                 }),
               }),
@@ -1323,16 +1332,34 @@ describe.each([
               schema: expect.objectContaining({
                 aux: expect.objectContaining({
                   columns: {
-                    id: { visible: false, readonly: false },
-                    name: { visible: true, readonly: true },
-                    dob: { visible: true, readonly: true },
+                    id: expect.objectContaining({
+                      visible: false,
+                      readonly: false,
+                    }),
+                    name: expect.objectContaining({
+                      visible: true,
+                      readonly: true,
+                    }),
+                    dob: expect.objectContaining({
+                      visible: true,
+                      readonly: true,
+                    }),
                   },
                 }),
                 aux2: expect.objectContaining({
                   columns: {
-                    id: { visible: false, readonly: false },
-                    name: { visible: true, readonly: true },
-                    dob: { visible: true, readonly: true },
+                    id: expect.objectContaining({
+                      visible: false,
+                      readonly: false,
+                    }),
+                    name: expect.objectContaining({
+                      visible: true,
+                      readonly: true,
+                    }),
+                    dob: expect.objectContaining({
+                      visible: true,
+                      readonly: true,
+                    }),
                   },
                 }),
               }),
@@ -1375,16 +1402,34 @@ describe.each([
               schema: expect.objectContaining({
                 aux: expect.objectContaining({
                   columns: {
-                    id: { visible: false, readonly: false },
-                    fullName: { visible: true, readonly: true },
-                    age: { visible: false, readonly: false },
+                    id: expect.objectContaining({
+                      visible: false,
+                      readonly: false,
+                    }),
+                    fullName: expect.objectContaining({
+                      visible: true,
+                      readonly: true,
+                    }),
+                    age: expect.objectContaining({
+                      visible: false,
+                      readonly: false,
+                    }),
                   },
                 }),
                 aux2: expect.objectContaining({
                   columns: {
-                    id: { visible: false, readonly: false },
-                    name: { visible: true, readonly: true },
-                    age: { visible: false, readonly: false },
+                    id: expect.objectContaining({
+                      visible: false,
+                      readonly: false,
+                    }),
+                    name: expect.objectContaining({
+                      visible: true,
+                      readonly: true,
+                    }),
+                    age: expect.objectContaining({
+                      visible: false,
+                      readonly: false,
+                    }),
                   },
                 }),
               }),
@@ -1427,9 +1472,18 @@ describe.each([
                 schema: expect.objectContaining({
                   aux: expect.objectContaining({
                     columns: {
-                      id: { visible: false, readonly: false },
-                      name: { visible: true, readonly: true },
-                      dob: { visible: true, readonly: true },
+                      id: expect.objectContaining({
+                        visible: false,
+                        readonly: false,
+                      }),
+                      name: expect.objectContaining({
+                        visible: true,
+                        readonly: true,
+                      }),
+                      dob: expect.objectContaining({
+                        visible: true,
+                        readonly: true,
+                      }),
                     },
                   }),
                 }),

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -1,5 +1,4 @@
 import {
-  FieldSchema,
   FieldType,
   RelationSchemaField,
   RenameColumn,
@@ -8,6 +7,7 @@ import {
   View,
   ViewFieldMetadata,
   ViewV2,
+  ViewV2ColumnEnriched,
   ViewV2Enriched,
 } from "@budibase/types"
 import { HTTPError } from "@budibase/backend-core"
@@ -177,7 +177,7 @@ export async function enrichSchema(
     }
     const relTable = tableCache[tableId]
 
-    const result: Record<string, FieldSchema & RelationSchemaField> = {}
+    const result: Record<string, ViewV2ColumnEnriched> = {}
 
     for (const relTableFieldName of Object.keys(relTable.schema)) {
       const relTableField = relTable.schema[relTableFieldName]
@@ -189,10 +189,13 @@ export async function enrichSchema(
         continue
       }
 
-      const isVisible = !!viewFields[relTableFieldName]?.visible
-      const isReadonly = !!viewFields[relTableFieldName]?.readonly
+      const viewFieldSchema = viewFields[relTableFieldName]
+      const isVisible = !!viewFieldSchema?.visible
+      const isReadonly = !!viewFieldSchema?.readonly
       result[relTableFieldName] = {
-        ...relTableField,
+        ...viewFieldSchema,
+        type: relTableField.type,
+        name: relTableField.name,
         visible: isVisible,
         readonly: isReadonly,
       }

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -193,8 +193,8 @@ export async function enrichSchema(
       const isVisible = !!viewFieldSchema?.visible
       const isReadonly = !!viewFieldSchema?.readonly
       result[relTableFieldName] = {
+        ...relTableField,
         ...viewFieldSchema,
-        type: relTableField.type,
         name: relTableField.name,
         visible: isVisible,
         readonly: isReadonly,

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -1,4 +1,5 @@
 import {
+  FieldSchema,
   FieldType,
   RelationSchemaField,
   RenameColumn,
@@ -176,7 +177,7 @@ export async function enrichSchema(
     }
     const relTable = tableCache[tableId]
 
-    const result: Record<string, RelationSchemaField> = {}
+    const result: Record<string, FieldSchema & RelationSchemaField> = {}
 
     for (const relTableFieldName of Object.keys(relTable.schema)) {
       const relTableField = relTable.schema[relTableFieldName]
@@ -191,6 +192,7 @@ export async function enrichSchema(
       const isVisible = !!viewFields[relTableFieldName]?.visible
       const isReadonly = !!viewFields[relTableFieldName]?.readonly
       result[relTableFieldName] = {
+        ...relTableField,
         visible: isVisible,
         readonly: isReadonly,
       }
@@ -211,6 +213,7 @@ export async function enrichSchema(
       ...tableSchema[key],
       ...ui,
       order: anyViewOrder ? ui?.order ?? undefined : tableSchema[key].order,
+      columns: undefined,
     }
 
     if (schema[key].type === FieldType.LINK) {

--- a/packages/server/src/sdk/app/views/tests/views.spec.ts
+++ b/packages/server/src/sdk/app/views/tests/views.spec.ts
@@ -355,10 +355,14 @@ describe("table sdk", () => {
               visible: true,
               columns: {
                 title: {
+                  name: "title",
+                  type: "string",
                   visible: true,
                   readonly: true,
                 },
                 age: {
+                  name: "age",
+                  type: "number",
                   visible: false,
                   readonly: false,
                 },

--- a/packages/types/src/documents/app/table/constants.ts
+++ b/packages/types/src/documents/app/table/constants.ts
@@ -10,6 +10,11 @@ export enum AutoReason {
   FOREIGN_KEY = "foreign_key",
 }
 
+export type FieldSubType =
+  | AutoFieldSubType
+  | JsonFieldSubType
+  | BBReferenceFieldSubType
+
 export enum AutoFieldSubType {
   CREATED_BY = "createdBy",
   CREATED_AT = "createdAt",

--- a/packages/types/src/documents/app/view.ts
+++ b/packages/types/src/documents/app/view.ts
@@ -38,8 +38,7 @@ export type ViewFieldMetadata = UIFieldMetadata & {
   columns?: Record<string, RelationSchemaField>
 }
 
-export type RelationSchemaField = {
-  visible?: boolean
+export type RelationSchemaField = UIFieldMetadata & {
   readonly?: boolean
 }
 

--- a/packages/types/src/sdk/view.ts
+++ b/packages/types/src/sdk/view.ts
@@ -1,9 +1,19 @@
-import { FieldSchema, RelationSchemaField, ViewV2 } from "../documents"
+import {
+  FieldSchema,
+  FieldType,
+  RelationSchemaField,
+  ViewV2,
+} from "../documents"
 
 export interface ViewV2Enriched extends ViewV2 {
   schema?: {
     [key: string]: FieldSchema & {
-      columns?: Record<string, FieldSchema & RelationSchemaField>
+      columns?: Record<string, ViewV2ColumnEnriched>
     }
   }
+}
+
+export interface ViewV2ColumnEnriched extends RelationSchemaField {
+  name: string
+  type: FieldType
 }

--- a/packages/types/src/sdk/view.ts
+++ b/packages/types/src/sdk/view.ts
@@ -3,7 +3,7 @@ import { FieldSchema, RelationSchemaField, ViewV2 } from "../documents"
 export interface ViewV2Enriched extends ViewV2 {
   schema?: {
     [key: string]: FieldSchema & {
-      columns?: Record<string, RelationSchemaField>
+      columns?: Record<string, FieldSchema & RelationSchemaField>
     }
   }
 }

--- a/packages/types/src/sdk/view.ts
+++ b/packages/types/src/sdk/view.ts
@@ -1,9 +1,4 @@
-import {
-  FieldSchema,
-  FieldType,
-  RelationSchemaField,
-  ViewV2,
-} from "../documents"
+import { FieldSchema, RelationSchemaField, ViewV2 } from "../documents"
 
 export interface ViewV2Enriched extends ViewV2 {
   schema?: {
@@ -13,7 +8,4 @@ export interface ViewV2Enriched extends ViewV2 {
   }
 }
 
-export interface ViewV2ColumnEnriched extends RelationSchemaField {
-  name: string
-  type: FieldType
-}
+export type ViewV2ColumnEnriched = RelationSchemaField & FieldSchema


### PR DESCRIPTION
## Description
Enriching view field columns' schema types at API level with the type and grid fields (width & order). This will be used to display these relationships on the tables, and it can be reused to avoid some extra API calls.
