### PR TITLE
Fix to accommodate filtering updates for GoogleSheets

### DIFF
--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -566,23 +566,19 @@ class GoogleSheetsIntegration implements DatasourcePlus {
           query.filters.equal[`_${GOOGLE_SHEETS_PRIMARY_KEY}`] = id
         }
       }
-      let filtered = dataFilters.runQuery(
-        rows,
-        query.filters || {},
-        (row: GoogleSpreadsheetRow, headerKey: string) => {
-          return row.get(headerKey)
-        }
-      )
+
       if (hasFilters && query.paginate) {
-        filtered = filtered.slice(offset, offset + limit)
+        rows = rows.slice(offset, offset + limit)
       }
       const headerValues = sheet.headerValues
       let response = []
-      for (let row of filtered) {
+      for (let row of rows) {
         response.push(
-          this.buildRowObject(headerValues, row.toObject(), row._rowNumber)
+          this.buildRowObject(headerValues, row.toObject(), row.rowNumber)
         )
       }
+
+      response = dataFilters.runQuery(response, query.filters || {})
 
       if (query.sort) {
         if (Object.keys(query.sort).length !== 1) {

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -471,15 +471,8 @@ export const search = (
  * Performs a client-side search on an array of data
  * @param docs the data
  * @param query the JSON query
- * @param findInDoc optional fn when trying to extract a value
- * from custom doc type e.g. Google Sheets
- *
  */
-export const runQuery = (
-  docs: Record<string, any>[],
-  query: SearchFilters,
-  findInDoc: Function = deepGet
-) => {
+export const runQuery = (docs: Record<string, any>[], query: SearchFilters) => {
   if (!docs || !Array.isArray(docs)) {
     return []
   }
@@ -503,11 +496,8 @@ export const runQuery = (
       test: (docValue: any, testValue: any) => boolean
     ) =>
     (doc: Record<string, any>) => {
-      for (const [key, testValue] of Object.entries(query[type] || {})) {
-        const valueToCheck = isLogicalSearchOperator(type)
-          ? doc
-          : findInDoc(doc, removeKeyNumbering(key))
-        const result = test(valueToCheck, testValue)
+      for (const testValue of Object.values(query[type] || {})) {
+        const result = test(doc, testValue)
         if (query.allOr && result) {
           return true
         } else if (!query.allOr && !result) {

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -22,7 +22,7 @@ import {
 } from "@budibase/types"
 import dayjs from "dayjs"
 import { OperatorOptions, SqlNumberTypeRangeMap } from "./constants"
-import { schema } from "./helpers"
+import { deepGet, schema } from "./helpers"
 import { isPlainObject, isEmpty } from "lodash"
 import { decodeNonAscii } from "./helpers/schema"
 
@@ -496,8 +496,11 @@ export const runQuery = (docs: Record<string, any>[], query: SearchFilters) => {
       test: (docValue: any, testValue: any) => boolean
     ) =>
     (doc: Record<string, any>) => {
-      for (const testValue of Object.values(query[type] || {})) {
-        const result = test(doc, testValue)
+      for (const [key, testValue] of Object.entries(query[type] || {})) {
+        const valueToCheck = isLogicalSearchOperator(type)
+          ? doc
+          : deepGet(doc, removeKeyNumbering(key))
+        const result = test(valueToCheck, testValue)
         if (query.allOr && result) {
           return true
         } else if (!query.allOr && !result) {

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -22,7 +22,7 @@ import {
 } from "@budibase/types"
 import dayjs from "dayjs"
 import { OperatorOptions, SqlNumberTypeRangeMap } from "./constants"
-import { deepGet, schema } from "./helpers"
+import { schema } from "./helpers"
 import { isPlainObject, isEmpty } from "lodash"
 import { decodeNonAscii } from "./helpers/schema"
 


### PR DESCRIPTION
## Description

There was a minor issue with the GoogleSheets integration filtering. When it tried to extract a comparison value for a grouped filter, it would default to a `GoogleSheetsRow` object and fail to extract properly. This fix eliminates that issues by serialising the `GoogleSheetsRow` beforehand.