### PR TITLE
Add GPT-4o and GPT-4o-mini models

### DIFF
--- a/packages/server/src/automations/steps/openai.ts
+++ b/packages/server/src/automations/steps/openai.ts
@@ -16,7 +16,7 @@ enum Model {
   // will only work with api keys that have access to the GPT4 API
   GPT_4 = "gpt-4",
   GPT_4O = "gpt-4o",
-  GPT_4O_MINI = "gpt-4o-mini"
+  GPT_4O_MINI = "gpt-4o-mini",
 }
 
 export const definition: AutomationStepDefinition = {

--- a/packages/server/src/automations/steps/openai.ts
+++ b/packages/server/src/automations/steps/openai.ts
@@ -15,6 +15,8 @@ enum Model {
   GPT_35_TURBO = "gpt-3.5-turbo",
   // will only work with api keys that have access to the GPT4 API
   GPT_4 = "gpt-4",
+  GPT_4O = "gpt-4o",
+  GPT_4O_MINI = "gpt-4o-mini"
 }
 
 export const definition: AutomationStepDefinition = {

--- a/packages/types/src/documents/app/automation/StepInputsOutputs.ts
+++ b/packages/types/src/documents/app/automation/StepInputsOutputs.ts
@@ -141,7 +141,7 @@ enum Model {
   // will only work with api keys that have access to the GPT4 API
   GPT_4 = "gpt-4",
   GPT_4O = "gpt-4o",
-  GPT_4O_MINI = "gpt-4o-mini"
+  GPT_4O_MINI = "gpt-4o-mini",
 }
 
 export type OpenAIStepOutputs = Omit<BaseAutomationOutputs, "response"> & {

--- a/packages/types/src/documents/app/automation/StepInputsOutputs.ts
+++ b/packages/types/src/documents/app/automation/StepInputsOutputs.ts
@@ -140,6 +140,8 @@ enum Model {
   GPT_35_TURBO = "gpt-3.5-turbo",
   // will only work with api keys that have access to the GPT4 API
   GPT_4 = "gpt-4",
+  GPT_4O = "gpt-4o",
+  GPT_4O_MINI = "gpt-4o-mini"
 }
 
 export type OpenAIStepOutputs = Omit<BaseAutomationOutputs, "response"> & {


### PR DESCRIPTION
## Description
The current OpenAI implementation of budibase allows for the GPT 4 (and 3.5 turbo) model. GPT 4 is the most expensive model whilst not the most up-to-date one.
While we wait for a more complex AI provider implementation, I suggest to add at least the 4o and 4o-mini models which are better, newer and much more reasonable priced.


Disclaimer: Not a dev here, just wanted to add something rather than complain. Feel free to kill this PR if it is not up to standards.

## Launchcontrol
Add two more OpenAI models to help save cost.
