### PR TITLE
Fix Google Sheets pagination.

### DIFF
--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -551,11 +551,16 @@ export class GoogleSheetsIntegration implements DatasourcePlus {
       await this.connect()
       const hasFilters = dataFilters.hasFilters(query.filters)
       const limit = query.paginate?.limit || 100
-      const page: number =
-        typeof query.paginate?.page === "number"
-          ? query.paginate.page
-          : parseInt(query.paginate?.page || "1")
-      const offset = (page - 1) * limit
+      let offset = query.paginate?.offset || 0
+
+      let page = query.paginate?.page
+      if (typeof page === "string") {
+        page = parseInt(page)
+      }
+      if (page !== undefined) {
+        offset = page * limit
+      }
+
       const sheet = this.client.sheetsByTitle[query.sheet]
       let rows: GoogleSpreadsheetRow[] = []
       if (query.paginate && !hasFilters) {

--- a/packages/server/src/integrations/tests/googlesheets.spec.ts
+++ b/packages/server/src/integrations/tests/googlesheets.spec.ts
@@ -5,7 +5,6 @@ import TestConfiguration from "../../tests/utilities/TestConfiguration"
 import {
   Datasource,
   FieldType,
-  Row,
   SourceName,
   Table,
   TableSourceType,


### PR DESCRIPTION
## Description

Pagination was broken for Google Sheets because at some point we must have stopped using the `query.pagination.page` param and instead started passing `limit` and `offset` directly (I vaguely remember us doing this as part of the SQS work.)

I've updated the code to support the passing of either limit/page or limit/offset, and added a test to prevent regression.

## Launchcontrol

- Fixes an issue with pagination in the Google Sheets integration.