### PR TITLE
MariaDB - avoid using correlated sub-queries

### DIFF
--- a/packages/backend-core/src/sql/sql.ts
+++ b/packages/backend-core/src/sql/sql.ts
@@ -991,10 +991,8 @@ class InternalBuilder {
           this.on(`${toAlias}.${toPrimary}`, "=", `${throughAlias}.${toKey}`)
         })
       }
-      // my-sql needs the where statement to be part of main query, not sub-query
-      if (sqlClient !== SqlClient.MY_SQL) {
-        subQuery = addCorrelatedWhere(subQuery, correlatedTo, correlatedFrom)
-      }
+
+      subQuery = addCorrelatedWhere(subQuery, correlatedTo, correlatedFrom)
 
       const standardWrap = (select: string): Knex.QueryBuilder => {
         subQuery = subQuery.select(`${toAlias}.*`)
@@ -1018,11 +1016,7 @@ class InternalBuilder {
           )
           break
         case SqlClient.MY_SQL:
-          wrapperQuery = addCorrelatedWhere(
-            standardWrap(`json_arrayagg(json_object(${fieldList}))`),
-            isManyToMany ? fromKey! : toKey!,
-            correlatedFrom
-          )
+          wrapperQuery = knex.raw(`json_arrayagg(json_object(${fieldList}))`)
           break
         case SqlClient.ORACLE:
           wrapperQuery = standardWrap(

--- a/packages/backend-core/src/sql/sql.ts
+++ b/packages/backend-core/src/sql/sql.ts
@@ -1031,7 +1031,9 @@ class InternalBuilder {
               .select(`${fromAlias}.*`)
               // @ts-ignore - from alias syntax not TS supported
               .from({
-                [fromAlias]: subQuery.select(`${toAlias}.*`),
+                [fromAlias]: subQuery
+                  .select(`${toAlias}.*`)
+                  .limit(getRelationshipLimit()),
               })} FOR JSON PATH))`
           )
           break

--- a/packages/backend-core/src/sql/sqlTable.ts
+++ b/packages/backend-core/src/sql/sqlTable.ts
@@ -210,14 +210,25 @@ function buildDeleteTable(knex: SchemaBuilder, table: Table): SchemaBuilder {
 
 class SqlTableQueryBuilder {
   private readonly sqlClient: SqlClient
+  private extendedSqlClient: SqlClient | undefined
 
   // pass through client to get flavour of SQL
   constructor(client: SqlClient) {
     this.sqlClient = client
   }
 
-  getSqlClient(): SqlClient {
+  getBaseSqlClient(): SqlClient {
     return this.sqlClient
+  }
+
+  getSqlClient(): SqlClient {
+    return this.extendedSqlClient || this.sqlClient
+  }
+
+  // if working in a database like MySQL with many variants (MariaDB)
+  // we can set another client which overrides the base one
+  setExtendedSqlClient(client: SqlClient) {
+    this.extendedSqlClient = client
   }
 
   /**

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -45,14 +45,14 @@ import { generateRowIdField } from "../../../integrations/utils"
 import { cloneDeep } from "lodash/fp"
 
 describe.each([
-  // ["in-memory", undefined],
-  // ["lucene", undefined],
-  // ["sqs", undefined],
-  // [DatabaseName.POSTGRES, getDatasource(DatabaseName.POSTGRES)],
-  // [DatabaseName.MYSQL, getDatasource(DatabaseName.MYSQL)],
-  // [DatabaseName.SQL_SERVER, getDatasource(DatabaseName.SQL_SERVER)],
+  ["in-memory", undefined],
+  ["lucene", undefined],
+  ["sqs", undefined],
+  [DatabaseName.POSTGRES, getDatasource(DatabaseName.POSTGRES)],
+  [DatabaseName.MYSQL, getDatasource(DatabaseName.MYSQL)],
+  [DatabaseName.SQL_SERVER, getDatasource(DatabaseName.SQL_SERVER)],
   [DatabaseName.MARIADB, getDatasource(DatabaseName.MARIADB)],
-  // [DatabaseName.ORACLE, getDatasource(DatabaseName.ORACLE)],
+  [DatabaseName.ORACLE, getDatasource(DatabaseName.ORACLE)],
 ])("search (%s)", (name, dsProvider) => {
   const isSqs = name === "sqs"
   const isLucene = name === "lucene"

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -77,6 +77,7 @@ describe.each([
     table = await createTable(
       {
         name: { name: "name", type: FieldType.STRING },
+        //@ts-ignore - API accepts this structure, will build out rest of definition
         productCat: {
           type: FieldType.LINK,
           relationshipType: type,
@@ -2297,11 +2298,16 @@ describe.each([
         }
       })
 
-      it("can only pull 500 related rows", async () => {
+      it("can only pull 10 related rows", async () => {
         await withCoreEnv({ SQL_MAX_RELATED_ROWS: "10" }, async () => {
           const response = await expectQuery({}).toContain([{ name: "foo" }])
           expect(response.rows[0].productCat).toBeArrayOfSize(10)
         })
+      })
+
+      it("can pull max rows when env not set (defaults to 500)", async () => {
+        const response = await expectQuery({}).toContain([{ name: "foo" }])
+        expect(response.rows[0].productCat).toBeArrayOfSize(11)
       })
     })
   ;(isSqs || isLucene) &&

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -39,20 +39,20 @@ import tk from "timekeeper"
 import { encodeJSBinding } from "@budibase/string-templates"
 import { dataFilters } from "@budibase/shared-core"
 import { Knex } from "knex"
-import { structures } from "@budibase/backend-core/tests"
+import { generator, structures } from "@budibase/backend-core/tests"
 import { DEFAULT_EMPLOYEE_TABLE_SCHEMA } from "../../../db/defaultData/datasource_bb_default"
 import { generateRowIdField } from "../../../integrations/utils"
 import { cloneDeep } from "lodash/fp"
 
 describe.each([
-  ["in-memory", undefined],
-  ["lucene", undefined],
-  ["sqs", undefined],
-  [DatabaseName.POSTGRES, getDatasource(DatabaseName.POSTGRES)],
-  [DatabaseName.MYSQL, getDatasource(DatabaseName.MYSQL)],
-  [DatabaseName.SQL_SERVER, getDatasource(DatabaseName.SQL_SERVER)],
+  // ["in-memory", undefined],
+  // ["lucene", undefined],
+  // ["sqs", undefined],
+  // [DatabaseName.POSTGRES, getDatasource(DatabaseName.POSTGRES)],
+  // [DatabaseName.MYSQL, getDatasource(DatabaseName.MYSQL)],
+  // [DatabaseName.SQL_SERVER, getDatasource(DatabaseName.SQL_SERVER)],
   [DatabaseName.MARIADB, getDatasource(DatabaseName.MARIADB)],
-  [DatabaseName.ORACLE, getDatasource(DatabaseName.ORACLE)],
+  // [DatabaseName.ORACLE, getDatasource(DatabaseName.ORACLE)],
 ])("search (%s)", (name, dsProvider) => {
   const isSqs = name === "sqs"
   const isLucene = name === "lucene"
@@ -72,7 +72,7 @@ describe.each([
       {
         name: { name: "name", type: FieldType.STRING },
       },
-      "productCategory"
+      generator.guid().substring(0, 10)
     )
     table = await createTable(
       {
@@ -89,7 +89,7 @@ describe.each([
           },
         },
       },
-      "product"
+      generator.guid().substring(0, 10)
     )
     return {
       relatedTable: await config.api.table.get(relatedTable._id!),
@@ -2268,7 +2268,7 @@ describe.each([
 
       it("should be able to filter by relationship using table name", async () => {
         await expectQuery({
-          equal: { ["productCategory.name"]: "foo" },
+          equal: { [`${productCategoryTable.name}.name`]: "foo" },
         }).toContainExactly([
           { name: "foo", productCat: [{ _id: productCatRows[0]._id }] },
         ])

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -42,6 +42,7 @@ import { Knex } from "knex"
 import { structures } from "@budibase/backend-core/tests"
 import { DEFAULT_EMPLOYEE_TABLE_SCHEMA } from "../../../db/defaultData/datasource_bb_default"
 import { generateRowIdField } from "../../../integrations/utils"
+import { cloneDeep } from "lodash/fp"
 
 describe.each([
   ["in-memory", undefined],
@@ -65,6 +66,35 @@ describe.each([
   let client: Knex | undefined
   let table: Table
   let rows: Row[]
+
+  async function basicRelationshipTables(type: RelationshipType) {
+    const relatedTable = await createTable(
+      {
+        name: { name: "name", type: FieldType.STRING },
+      },
+      "productCategory"
+    )
+    table = await createTable(
+      {
+        name: { name: "name", type: FieldType.STRING },
+        productCat: {
+          type: FieldType.LINK,
+          relationshipType: type,
+          name: "productCat",
+          fieldName: "product",
+          tableId: relatedTable._id!,
+          constraints: {
+            type: "array",
+          },
+        },
+      },
+      "product"
+    )
+    return {
+      relatedTable: await config.api.table.get(relatedTable._id!),
+      table,
+    }
+  }
 
   beforeAll(async () => {
     await withCoreEnv({ TENANT_FEATURE_FLAGS: "*:SQS" }, () => config.init())
@@ -201,6 +231,7 @@ describe.each([
     // rows returned by the query will also cause the assertion to fail.
     async toMatchExactly(expectedRows: any[]) {
       const response = await this.performSearch()
+      const cloned = cloneDeep(response)
       const foundRows = response.rows
 
       // eslint-disable-next-line jest/no-standalone-expect
@@ -211,7 +242,7 @@ describe.each([
           expect.objectContaining(this.popRow(expectedRow, foundRows))
         )
       )
-      return response
+      return cloned
     }
 
     // Asserts that the query returns rows matching exactly the set of rows
@@ -219,6 +250,7 @@ describe.each([
     // cause the assertion to fail.
     async toContainExactly(expectedRows: any[]) {
       const response = await this.performSearch()
+      const cloned = cloneDeep(response)
       const foundRows = response.rows
 
       // eslint-disable-next-line jest/no-standalone-expect
@@ -231,7 +263,7 @@ describe.each([
           )
         )
       )
-      return response
+      return cloned
     }
 
     // Asserts that the query returns some property values - this cannot be used
@@ -239,6 +271,7 @@ describe.each([
     // typing for this has to be any, Jest doesn't expose types for matchers like expect.any(...)
     async toMatch(properties: Record<string, any>) {
       const response = await this.performSearch()
+      const cloned = cloneDeep(response)
       const keys = Object.keys(properties) as Array<keyof SearchResponse<Row>>
       for (let key of keys) {
         // eslint-disable-next-line jest/no-standalone-expect
@@ -248,17 +281,18 @@ describe.each([
           expect(response[key]).toEqual(properties[key])
         }
       }
-      return response
+      return cloned
     }
 
     // Asserts that the query doesn't return a property, e.g. pagination parameters.
     async toNotHaveProperty(properties: (keyof SearchResponse<Row>)[]) {
       const response = await this.performSearch()
+      const cloned = cloneDeep(response)
       for (let property of properties) {
         // eslint-disable-next-line jest/no-standalone-expect
         expect(response[property]).toBeUndefined()
       }
-      return response
+      return cloned
     }
 
     // Asserts that the query returns rows matching the set of rows passed in.
@@ -266,6 +300,7 @@ describe.each([
     // assertion to fail.
     async toContain(expectedRows: any[]) {
       const response = await this.performSearch()
+      const cloned = cloneDeep(response)
       const foundRows = response.rows
 
       // eslint-disable-next-line jest/no-standalone-expect
@@ -276,7 +311,7 @@ describe.each([
           )
         )
       )
-      return response
+      return cloned
     }
 
     async toFindNothing() {
@@ -2196,28 +2231,10 @@ describe.each([
       let productCategoryTable: Table, productCatRows: Row[]
 
       beforeAll(async () => {
-        productCategoryTable = await createTable(
-          {
-            name: { name: "name", type: FieldType.STRING },
-          },
-          "productCategory"
+        const { relatedTable } = await basicRelationshipTables(
+          RelationshipType.ONE_TO_MANY
         )
-        table = await createTable(
-          {
-            name: { name: "name", type: FieldType.STRING },
-            productCat: {
-              type: FieldType.LINK,
-              relationshipType: RelationshipType.ONE_TO_MANY,
-              name: "productCat",
-              fieldName: "product",
-              tableId: productCategoryTable._id!,
-              constraints: {
-                type: "array",
-              },
-            },
-          },
-          "product"
-        )
+        productCategoryTable = relatedTable
 
         productCatRows = await Promise.all([
           config.api.row.save(productCategoryTable._id!, { name: "foo" }),
@@ -2260,6 +2277,31 @@ describe.each([
         await expectQuery({
           equal: { ["name"]: "baz" },
         }).toContainExactly([{ name: "baz", productCat: undefined }])
+      })
+    })
+
+  isSql &&
+    describe("big relations", () => {
+      beforeAll(async () => {
+        const { relatedTable } = await basicRelationshipTables(
+          RelationshipType.MANY_TO_ONE
+        )
+        const mainRow = await config.api.row.save(table._id!, {
+          name: "foo",
+        })
+        for (let i = 0; i < 11; i++) {
+          await config.api.row.save(relatedTable._id!, {
+            name: i,
+            product: [mainRow._id!],
+          })
+        }
+      })
+
+      it("can only pull 500 related rows", async () => {
+        await withCoreEnv({ SQL_MAX_RELATED_ROWS: "10" }, async () => {
+          const response = await expectQuery({}).toContain([{ name: "foo" }])
+          expect(response.rows[0].productCat).toBeArrayOfSize(10)
+        })
       })
     })
   ;(isSqs || isLucene) &&

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -241,6 +241,16 @@ class MySQLIntegration extends Sql implements DatasourcePlus {
 
   async connect() {
     this.client = await mysql.createConnection(this.config)
+    const res = await this.internalQuery(
+      {
+        sql: "SELECT VERSION();",
+      },
+      { connect: false }
+    )
+    const version = res?.[0]?.["VERSION()"]
+    if (version?.toLowerCase().includes("mariadb")) {
+      this.setExtendedSqlClient(SqlClient.MARIADB)
+    }
   }
 
   async disconnect() {

--- a/packages/server/src/sdk/app/tables/external/index.ts
+++ b/packages/server/src/sdk/app/tables/external/index.ts
@@ -204,7 +204,9 @@ export async function save(
 
   // add in the new table for relationship purposes
   tables[tableToSave.name] = tableToSave
-  cleanupRelationships(tableToSave, tables, oldTable)
+  if (oldTable) {
+    cleanupRelationships(tableToSave, tables, { oldTable })
+  }
 
   const operation = tableId ? Operation.UPDATE_TABLE : Operation.CREATE_TABLE
   await makeTableRequest(
@@ -259,7 +261,7 @@ export async function destroy(datasourceId: string, table: Table) {
   const operation = Operation.DELETE_TABLE
   if (tables) {
     await makeTableRequest(datasource, operation, table, tables)
-    cleanupRelationships(table, tables)
+    cleanupRelationships(table, tables, { deleting: true })
     delete tables[table.name]
     datasource.entities = tables
   }

--- a/packages/server/src/sdk/app/tables/external/index.ts
+++ b/packages/server/src/sdk/app/tables/external/index.ts
@@ -198,6 +198,7 @@ export async function save(
       }
     }
     generateRelatedSchema(schema, relatedTable, tableToSave, relatedColumnName)
+    tables[relatedTable.name] = relatedTable
     schema.main = true
   }
 
@@ -231,7 +232,10 @@ export async function save(
   // remove the rename prop
   delete tableToSave._rename
 
-  datasource.entities[tableToSave.name] = tableToSave
+  datasource.entities = {
+    ...datasource.entities,
+    ...tables,
+  }
 
   // store it into couch now for budibase reference
   await db.put(populateExternalTableSchemas(datasource))

--- a/packages/server/src/sdk/app/tables/external/utils.ts
+++ b/packages/server/src/sdk/app/tables/external/utils.ts
@@ -22,12 +22,16 @@ export function cleanupRelationships(
   tables: Record<string, Table>,
   oldTable?: Table
 ) {
+  if (!oldTable) {
+    return
+  }
   const tableToIterate = oldTable ? oldTable : table
   // clean up relationships in couch table schemas
   for (let [key, schema] of Object.entries(tableToIterate.schema)) {
     if (
       schema.type === FieldType.LINK &&
-      (!oldTable || table.schema[key] == null)
+      oldTable.schema[key] != null &&
+      table.schema[key] == null
     ) {
       const schemaTableId = schema.tableId
       const relatedTable = Object.values(tables).find(

--- a/packages/server/src/sdk/app/tables/external/utils.ts
+++ b/packages/server/src/sdk/app/tables/external/utils.ts
@@ -20,17 +20,25 @@ import { cloneDeep } from "lodash/fp"
 export function cleanupRelationships(
   table: Table,
   tables: Record<string, Table>,
-  oldTable?: Table
-) {
-  if (!oldTable) {
-    return
-  }
+  opts: { oldTable: Table }
+): void
+export function cleanupRelationships(
+  table: Table,
+  tables: Record<string, Table>,
+  opts: { deleting: boolean }
+): void
+export function cleanupRelationships(
+  table: Table,
+  tables: Record<string, Table>,
+  opts?: { oldTable?: Table; deleting?: boolean }
+): void {
+  const oldTable = opts?.oldTable
   const tableToIterate = oldTable ? oldTable : table
   // clean up relationships in couch table schemas
   for (let [key, schema] of Object.entries(tableToIterate.schema)) {
     if (
       schema.type === FieldType.LINK &&
-      oldTable.schema[key] != null &&
+      (opts?.deleting || oldTable?.schema[key] != null) &&
       table.schema[key] == null
     ) {
       const schemaTableId = schema.tableId

--- a/packages/server/src/tests/utilities/structures.ts
+++ b/packages/server/src/tests/utilities/structures.ts
@@ -600,10 +600,10 @@ export function fullSchemaWithoutLinks({
   allRequired,
 }: {
   allRequired?: boolean
-}) {
-  const schema: {
-    [type in Exclude<FieldType, FieldType.LINK>]: FieldSchema & { type: type }
-  } = {
+}): {
+  [type in Exclude<FieldType, FieldType.LINK>]: FieldSchema & { type: type }
+} {
+  return {
     [FieldType.STRING]: {
       name: "string",
       type: FieldType.STRING,
@@ -741,8 +741,6 @@ export function fullSchemaWithoutLinks({
       },
     },
   }
-
-  return schema
 }
 export function basicAttachment() {
   return {

--- a/packages/types/src/sdk/search.ts
+++ b/packages/types/src/sdk/search.ts
@@ -195,6 +195,7 @@ export enum SqlClient {
   MS_SQL = "mssql",
   POSTGRES = "pg",
   MY_SQL = "mysql2",
+  MARIADB = "mariadb",
   ORACLE = "oracledb",
   SQL_LITE = "sqlite3",
 }


### PR DESCRIPTION
## Description
This is a problem that was raised by our QA MariaDB database which was hitting a limit around how much data can be returned from an aggregate response - the JSON that was being returned was malformed and not performing as expected.

The issue was that we did not apply a limit to MySQL/MariaDB queries as it wasn't possible to limit these without the use of a correlated sub-query, something which is not allowed - information about this [here.](https://mariadb.com/kb/en/subquery-limitations/#:~:text=Subqueries%20in%20the%20FROM%20clause,when%20the%20query%20is%20executed)

To get around this we have used a limit which can be applied within the aggregation itself, avoiding the malformed response. This is not as performant as using a correlated sub-query, but we were very limited in terms of options and this gave us the best set of fixed problems while performing within acceptable limits.