### PR TITLE
Remove an implicit any from removeInvalidFilters.

### DIFF
--- a/packages/server/src/sdk/app/rows/queryUtils.ts
+++ b/packages/server/src/sdk/app/rows/queryUtils.ts
@@ -16,11 +16,11 @@ export const removeInvalidFilters = (
 
   validFields = validFields.map(f => f.toLowerCase())
   for (const filterKey of Object.keys(result) as (keyof SearchFilters)[]) {
-    const filter = result[filterKey]
-    if (!filter || typeof filter !== "object") {
-      continue
-    }
     if (isLogicalSearchOperator(filterKey)) {
+      const filter = result[filterKey]
+      if (!filter || typeof filter !== "object") {
+        continue
+      }
       const resultingConditions: SearchFilters[] = []
       for (const condition of filter.conditions) {
         const resultingCondition = removeInvalidFilters(condition, validFields)
@@ -33,6 +33,11 @@ export const removeInvalidFilters = (
       } else {
         delete result[filterKey]
       }
+      continue
+    }
+
+    const filter = result[filterKey]
+    if (!filter || typeof filter !== "object") {
       continue
     }
 

--- a/packages/types/src/sdk/search.ts
+++ b/packages/types/src/sdk/search.ts
@@ -68,6 +68,8 @@ type RangeFilter = Record<
   [InternalSearchFilterOperator.COMPLEX_ID_OPERATOR]?: never
 }
 
+type LogicalFilter = { conditions: SearchFilters[] }
+
 export type AnySearchFilter = BasicFilter | ArrayFilter | RangeFilter
 
 export interface SearchFilters {
@@ -92,12 +94,8 @@ export interface SearchFilters {
   // specific document type (such as just rows)
   documentType?: DocumentType
 
-  [LogicalOperator.AND]?: {
-    conditions: SearchFilters[]
-  }
-  [LogicalOperator.OR]?: {
-    conditions: SearchFilters[]
-  }
+  [LogicalOperator.AND]?: LogicalFilter
+  [LogicalOperator.OR]?: LogicalFilter
 }
 
 export type SearchFilterKey = keyof Omit<


### PR DESCRIPTION
## Description

Restructures `removeInvalidFilters` to get rid of an implicit `any` that was floating around.
