### PR TITLE
Add the row to the default value context.

### DIFF
--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -780,6 +780,47 @@ describe.each([
             expect(row.age).toEqual(25)
           })
 
+          it("can reference another field in binding", async () => {
+            const table = await config.api.table.save(
+              saveTableRequest({
+                schema: {
+                  num: {
+                    name: "num",
+                    type: FieldType.NUMBER,
+                  },
+                  age: {
+                    name: "age",
+                    type: FieldType.NUMBER,
+                    default: `{{ add num 1 }}`,
+                  },
+                },
+              })
+            )
+            const row = await config.api.row.save(table._id!, { num: 1 })
+            expect(row.age).toEqual(2)
+          })
+
+          it("cannot reference another default value field in binding", async () => {
+            const table = await config.api.table.save(
+              saveTableRequest({
+                schema: {
+                  num: {
+                    name: "num",
+                    type: FieldType.NUMBER,
+                    default: "1",
+                  },
+                  age: {
+                    name: "age",
+                    type: FieldType.NUMBER,
+                    default: `{{ add num 1 }}`,
+                  },
+                },
+              })
+            )
+            const row = await config.api.row.save(table._id!, { num: 1 })
+            expect(row.age2).toBeUndefined()
+          })
+
           describe("invalid default value", () => {
             beforeAll(async () => {
               table = await config.api.table.save(

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -119,7 +119,7 @@ export async function processAutoColumn(
 }
 
 async function processDefaultValues(table: Table, row: Row) {
-  const ctx: { ["Current User"]?: User; user?: User } = {}
+  const ctx: Row & { ["Current User"]?: User; user?: User } = { ...row }
 
   const identity = context.getIdentity()
   if (identity?._id && identity.type === IdentityType.USER) {


### PR DESCRIPTION
## Description

When using bindings or JS for default value calculations, prior to this PR we didn't have access to the other values on the row. This is because the row had not been added to the context used to evaluate the bindings.
