### PR TITLE
Refresh data when adding columns

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/grid/GridCreateColumnModal.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/grid/GridCreateColumnModal.svelte
@@ -2,7 +2,12 @@
   import { getContext } from "svelte"
   import CreateEditColumn from "components/backend/DataTable/modals/CreateEditColumn.svelte"
 
-  const { datasource } = getContext("grid")
+  const { datasource, rows } = getContext("grid")
+
+  const onUpdate = async () => {
+    await datasource.actions.refreshDefinition()
+    await rows.actions.refreshData()
+  }
 </script>
 
-<CreateEditColumn on:updatecolumns={datasource.actions.refreshDefinition} />
+<CreateEditColumn on:updatecolumns={onUpdate} />


### PR DESCRIPTION
## Description
This PR refreshes data in grids when adding columns. We actually already do this when editing columns, we just don't when adding which is an oversight.

Before:

https://github.com/user-attachments/assets/d3d4f89f-80d9-43ed-a29a-bdf4fcf1087c

After:

https://github.com/user-attachments/assets/9ac4ab6c-8ce7-4928-b722-163996655ea7

