### PR TITLE
Fix browser crash under certain circumstances with forms

### DIFF
--- a/packages/client/src/components/app/forms/Form.svelte
+++ b/packages/client/src/components/app/forms/Form.svelte
@@ -63,7 +63,7 @@
     // Look up the component tree and find something that is provided by an
     // ancestor that matches our datasource. This is for backwards compatibility
     // as previously we could use the "closest" context.
-    for (let id of path.reverse().slice(1)) {
+    for (let id of path.toReversed().slice(1)) {
       // Check for matching view datasource
       if (
         dataSource.type === "viewV2" &&


### PR DESCRIPTION
## Description
This is an extremely nasty bug that was very hard to find, and caused your browser to lock up. It's existed for a very long time and may explain some of the random browser lock up issues we sometimes see.

The core issue was that we were mutating an array in-place while reversing it, and under certain circumstances this lead to an endless loop.

## Addresses
- https://linear.app/budibase/issue/BUDI-8688/builder-crashes-in-preview-with-modal-data-provider-repeater-form