### PR TITLE
Feature branch deployment job expects boolean as payload

### DIFF
--- a/.github/workflows/deploy-featurebranch.yml
+++ b/.github/workflows/deploy-featurebranch.yml
@@ -23,7 +23,7 @@ jobs:
           PAYLOAD_BRANCH: ${{ github.head_ref }}
           PAYLOAD_PR_NUMBER: ${{ github.event.pull_request.number }}
           PAYLOAD_LICENSE_TYPE: "free"
-          PAYLOAD_DEPLOY: "true"
+          PAYLOAD_DEPLOY: true
         with:
           repository: budibase/budibase-deploys
           event: featurebranch-qa-deploy


### PR DESCRIPTION
## Description
The `PAYLOAD_DEPLOY` should be a a boolean instead of a string. When using a string the downstream job fails to run half of the pipeline. 

