### PR TITLE
Add uiMetadata to viewV2

### DIFF
--- a/packages/server/src/api/controllers/view/viewsV2.ts
+++ b/packages/server/src/api/controllers/view/viewsV2.ts
@@ -107,6 +107,7 @@ export async function create(ctx: Ctx<CreateViewRequest, ViewResponse>) {
     sort: view.sort,
     schema,
     primaryDisplay: view.primaryDisplay,
+    uiMetadata: view.uiMetadata,
   }
   const result = await sdk.views.create(tableId, parsedView)
   ctx.status = 201
@@ -143,6 +144,7 @@ export async function update(ctx: Ctx<UpdateViewRequest, ViewResponse>) {
     sort: view.sort,
     schema,
     primaryDisplay: view.primaryDisplay,
+    uiMetadata: view.uiMetadata,
   }
 
   const result = await sdk.views.update(tableId, parsedView)

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -177,6 +177,9 @@ describe.each([
               visible: true,
             },
           },
+          uiMetadata: {
+            foo: "bar",
+          },
         }
         const res = await config.api.viewV2.create(newView)
 
@@ -639,6 +642,9 @@ describe.each([
               visible: true,
               readonly: true,
             },
+          },
+          uiMetadata: {
+            foo: "bar",
           },
         }
         await config.api.viewV2.update(updatedData)

--- a/packages/types/src/documents/app/view.ts
+++ b/packages/types/src/documents/app/view.ts
@@ -74,6 +74,7 @@ export interface ViewV2 {
     type?: SortType
   }
   schema?: ViewV2Schema
+  uiMetadata?: Record<string, any>
 }
 
 export type ViewV2Schema = Record<string, ViewFieldMetadata>


### PR DESCRIPTION
## Description
Tiny PR to add a UI metadata property to views. This is needed for the new view calculations feature. It's totally opt-in and is untouched by the server so is completely safe to merge into master without feature flags.