### PR TITLE
Fixes an issue where id and revision weren't passed to row action automations

### DIFF
--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -698,6 +698,8 @@ describe("/rowsActions", () => {
             inputs: null,
             outputs: {
               fields: {},
+              id: rowId,
+              revision: (await config.api.row.get(tableId, rowId))._rev,
               row: await config.api.row.get(tableId, rowId),
               table: {
                 ...(await config.api.table.get(tableId)),

--- a/packages/server/src/sdk/app/rowActions.ts
+++ b/packages/server/src/sdk/app/rowActions.ts
@@ -220,6 +220,8 @@ export async function run(tableId: any, rowActionId: any, rowId: string) {
     automation,
     {
       fields: {
+        id: row._id,
+        revision: row._rev,
         row,
         table,
       },


### PR DESCRIPTION
## Description
`id` and `revision` weren't being populated for a row action automation trigger. 

## Addresses
https://linear.app/budibase/issue/BUDI-8690/automation-update-row-step-creates-a-row
