### PR TITLE
Make the new throwing behaviour of `processStringSync` opt-in.

### DIFF
--- a/packages/builder/src/components/common/bindings/BindingPanel.svelte
+++ b/packages/builder/src/components/common/bindings/BindingPanel.svelte
@@ -145,10 +145,16 @@
   const debouncedEval = Utils.debounce((expression, context, snippets) => {
     try {
       expressionError = null
-      expressionResult = processStringSync(expression || "", {
-        ...context,
-        snippets,
-      })
+      expressionResult = processStringSync(
+        expression || "",
+        {
+          ...context,
+          snippets,
+        },
+        {
+          noThrow: false,
+        }
+      )
     } catch (err) {
       expressionResult = null
       expressionError = err

--- a/packages/server/src/jsRunner/tests/jsRunner.spec.ts
+++ b/packages/server/src/jsRunner/tests/jsRunner.spec.ts
@@ -41,11 +41,11 @@ describe("jsRunner (using isolated-vm)", () => {
   })
 
   it("should prevent sandbox escape", async () => {
-    await expect(
-      processJS(`return this.constructor.constructor("return process.env")()`)
-    ).rejects.toThrow(
-      "error while running user-supplied JavaScript: ReferenceError: process is not defined"
-    )
+    expect(
+      await processJS(
+        `return this.constructor.constructor("return process.env")()`
+      )
+    ).toEqual("ReferenceError: process is not defined")
   })
 
   describe("helpers", () => {

--- a/packages/server/src/utilities/rowProcessor/utils.ts
+++ b/packages/server/src/utilities/rowProcessor/utils.ts
@@ -1,5 +1,5 @@
 import { AutoFieldDefaultNames } from "../../constants"
-import { processStringSync, UserScriptError } from "@budibase/string-templates"
+import { processStringSync } from "@budibase/string-templates"
 import {
   AutoColumnFieldMetadata,
   FieldSchema,
@@ -81,14 +81,7 @@ export async function processFormulas<T extends Row | Row[]>(
             ...row,
             [column]: tracer.trace("processStringSync", {}, span => {
               span?.addTags({ table_id: table._id, column, static: isStatic })
-              try {
-                return processStringSync(formula, context)
-              } catch (err: any) {
-                if (err.code === UserScriptError.code) {
-                  return err.userScriptError.toString()
-                }
-                throw err
-              }
+              return processStringSync(formula, context)
             }),
           }
         }

--- a/packages/string-templates/src/helpers/javascript.ts
+++ b/packages/string-templates/src/helpers/javascript.ts
@@ -95,6 +95,8 @@ export function processJS(handlebars: string, context: any) {
   } catch (error: any) {
     onErrorLog && onErrorLog(error)
 
+    const { noThrow = true } = context.__opts || {}
+
     // The error handling below is quite messy, because it has fallen to
     // string-templates to handle a variety of types of error specific to usages
     // above it in the stack. It would be nice some day to refactor this to
@@ -123,11 +125,17 @@ export function processJS(handlebars: string, context: any) {
     // This is to catch the error that happens if a user-supplied JS script
     // throws for reasons introduced by the user.
     if (error.code === UserScriptError.code) {
+      if (noThrow) {
+        return error.userScriptError.toString()
+      }
       throw error
     }
 
     if (error.name === "SyntaxError") {
-      return error.toString()
+      if (noThrow) {
+        return error.toString()
+      }
+      throw error
     }
 
     return "Error while executing JS"

--- a/packages/string-templates/src/index.ts
+++ b/packages/string-templates/src/index.ts
@@ -179,7 +179,11 @@ export function processObjectSync(
   for (let key of Object.keys(object || {})) {
     let val = object[key]
     if (typeof val === "string") {
-      object[key] = processStringSync(object[key], context, opts)
+      try {
+        object[key] = processStringSync(object[key], context, opts)
+      } catch (error: any) {
+        object[key] = error.toString()
+      }
     } else if (typeof val === "object") {
       object[key] = processObjectSync(object[key], context, opts)
     }

--- a/packages/string-templates/src/index.ts
+++ b/packages/string-templates/src/index.ts
@@ -123,7 +123,7 @@ function createTemplate(
 export async function processObject<T extends Record<string, any>>(
   object: T,
   context: object,
-  opts?: { noHelpers?: boolean; escapeNewlines?: boolean; onlyFound?: boolean }
+  opts?: ProcessOptions
 ): Promise<T> {
   testObject(object)
 
@@ -173,17 +173,13 @@ export async function processString(
 export function processObjectSync(
   object: { [x: string]: any },
   context: any,
-  opts: any
+  opts?: ProcessOptions
 ): object | Array<any> {
   testObject(object)
   for (let key of Object.keys(object || {})) {
     let val = object[key]
     if (typeof val === "string") {
-      try {
-        object[key] = processStringSync(object[key], context, opts)
-      } catch (error: any) {
-        object[key] = error.toString()
-      }
+      object[key] = processStringSync(object[key], context, opts)
     } else if (typeof val === "object") {
       object[key] = processObjectSync(object[key], context, opts)
     }
@@ -235,9 +231,6 @@ export function processStringSync(
       return process(string)
     }
   } catch (err: any) {
-    if (err.code === UserScriptError.code) {
-      throw err
-    }
     return input
   }
 }

--- a/packages/string-templates/src/index.ts
+++ b/packages/string-templates/src/index.ts
@@ -231,7 +231,11 @@ export function processStringSync(
       return process(string)
     }
   } catch (err: any) {
-    return input
+    const { noThrow = true } = opts
+    if (noThrow) {
+      return input
+    }
+    throw err
   }
 }
 

--- a/packages/string-templates/src/index.ts
+++ b/packages/string-templates/src/index.ts
@@ -231,7 +231,7 @@ export function processStringSync(
       return process(string)
     }
   } catch (err: any) {
-    const { noThrow = true } = opts
+    const { noThrow = true } = opts || {}
     if (noThrow) {
       return input
     }

--- a/packages/string-templates/src/types.ts
+++ b/packages/string-templates/src/types.ts
@@ -3,6 +3,7 @@ export interface ProcessOptions {
   noEscaping?: boolean
   noHelpers?: boolean
   noFinalise?: boolean
+  noThrow?: boolean
   escapeNewlines?: boolean
   onlyFound?: boolean
   disabledHelpers?: string[]


### PR DESCRIPTION
## Description

Because there's only really one place that needs an actual exception to be thrown from `processStringSync` when JS execution fails (the binding panel when you're editing them), I've changed this behaviour to be opt-in. Everywhere else will get a string back containing the error message.