### PR TITLE
Run rowAction from table only if allowed

### DIFF
--- a/packages/builder/src/components/backend/DataTable/buttons/grid/GridRowActionsButton.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/GridRowActionsButton.svelte
@@ -95,7 +95,7 @@
             {#if isView}
               <span>
                 <Toggle
-                  value={action.allowedViews?.includes(viewId)}
+                  value={action.allowedSources?.includes(viewId)}
                   on:change={e => toggleAction(action, e.detail)}
                 />
               </span>

--- a/packages/builder/src/pages/builder/app/[application]/data/table/[tableId]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/table/[tableId]/index.svelte
@@ -63,13 +63,15 @@
   $: rowActions.refreshRowActions(id)
 
   const makeRowActionButtons = actions => {
-    return (actions || []).map(action => ({
-      text: action.name,
-      onClick: async row => {
-        await rowActions.trigger(id, action.id, row._id)
-        notifications.success("Row action triggered successfully")
-      },
-    }))
+    return (actions || [])
+      .filter(action => action.allowedSources?.includes(id))
+      .map(action => ({
+        text: action.name,
+        onClick: async row => {
+          await rowActions.trigger(id, action.id, row._id)
+          notifications.success("Row action triggered successfully")
+        },
+      }))
   }
 
   const relationshipSupport = datasource => {

--- a/packages/builder/src/stores/builder/rowActions.js
+++ b/packages/builder/src/stores/builder/rowActions.js
@@ -131,11 +131,12 @@ const derivedStore = derived(store, $store => {
   Object.keys($store || {}).forEach(tableId => {
     map[tableId] = $store[tableId]
     for (let action of $store[tableId]) {
-      for (let viewId of action.allowedSources || []) {
-        if (!map[viewId]) {
-          map[viewId] = []
-        }
-        map[viewId].push(action)
+      const otherSources = (action.allowedSources || []).filter(
+        sourceId => sourceId !== tableId
+      )
+      for (let source of otherSources) {
+        map[source] ??= []
+        map[source].push(action)
       }
     }
   })

--- a/packages/builder/src/stores/builder/rowActions.js
+++ b/packages/builder/src/stores/builder/rowActions.js
@@ -129,6 +129,7 @@ const derivedStore = derived(store, $store => {
 
   // Generate an entry for every view as well
   Object.keys($store || {}).forEach(tableId => {
+    // We need to have all the actions for the table in order to be displayed in the crud section
     map[tableId] = $store[tableId]
     for (let action of $store[tableId]) {
       const otherSources = (action.allowedSources || []).filter(

--- a/packages/builder/src/stores/builder/rowActions.js
+++ b/packages/builder/src/stores/builder/rowActions.js
@@ -131,7 +131,7 @@ const derivedStore = derived(store, $store => {
   Object.keys($store || {}).forEach(tableId => {
     map[tableId] = $store[tableId]
     for (let action of $store[tableId]) {
-      for (let viewId of action.allowedViews || []) {
+      for (let viewId of action.allowedSources || []) {
         if (!map[viewId]) {
           map[viewId] = []
         }


### PR DESCRIPTION
## Description
Changing rowAction runs from table on by default. Also, implementing the store, API and component changes to work fine if disabled.
Waiting for the backend PR to be merged to master and to `v3-ui` in order to simplify this review:
- https://github.com/Budibase/budibase/pull/14707

## Addresses
- [BUDI-8429 - Row action view security](https://linear.app/budibase/issue/BUDI-8429/row-action-view-security)