### PR TITLE
Remove PAYLOAD_DEPLOY to enable invisible license rollouts

### DIFF
--- a/.github/workflows/deploy-featurebranch.yml
+++ b/.github/workflows/deploy-featurebranch.yml
@@ -23,7 +23,6 @@ jobs:
           PAYLOAD_BRANCH: ${{ github.head_ref }}
           PAYLOAD_PR_NUMBER: ${{ github.event.pull_request.number }}
           PAYLOAD_LICENSE_TYPE: "free"
-          PAYLOAD_DEPLOY: true
         with:
           repository: budibase/budibase-deploys
           event: featurebranch-qa-deploy


### PR DESCRIPTION
## Description
We're making the rollout mechanism for new feature branches vs new license types invisible to the end user. The `PAYLOAD_DEPLOY` is no longer relevant to this flow.
