### PR TITLE
Allow empty queries when searching tables

### DIFF
--- a/packages/frontend-core/src/api/tables.js
+++ b/packages/frontend-core/src/api/tables.js
@@ -40,7 +40,7 @@ export const buildTableEndpoints = API => ({
     sortType,
     paginate,
   }) => {
-    if (!tableId || !query) {
+    if (!tableId) {
       return {
         rows: [],
       }


### PR DESCRIPTION
## Description
The query builder for the new search structure can return a nullish value now. Previously this never happened, so the code did not expect it and would abort search requests if the query was undefined, which broke searching. This PR updates the frontend to allow nullish queries.

## Addresses
- https://linear.app/budibase/issue/BUDI-8707/relationship-field-appears-to-be-filtering-itself

Working relationship picker:
![image](https://github.com/user-attachments/assets/befcc094-eb9f-4cd9-b1b0-4deff6cb445a)
