### PR TITLE
Validate link field names cannot overlap with table field names.

### DIFF
--- a/packages/server/src/api/routes/tests/table.spec.ts
+++ b/packages/server/src/api/routes/tests/table.spec.ts
@@ -189,6 +189,44 @@ describe.each([
         )
       }
     )
+
+    it("should block creation of a link field that atttempts to overwrite a normal field", async () => {
+      const table1 = await config.api.table.save(
+        tableForDatasource(datasource, {
+          schema: {
+            name: {
+              name: "name",
+              type: FieldType.STRING,
+            },
+          },
+        })
+      )
+
+      await config.api.table.save(
+        tableForDatasource(datasource, {
+          schema: {
+            name: {
+              name: "name",
+              type: FieldType.STRING,
+            },
+            otherName: {
+              name: "otherName",
+              type: FieldType.LINK,
+              tableId: table1._id!,
+              // this is wrong because it tries to overwrite another field
+              fieldName: "name",
+              relationshipType: RelationshipType.ONE_TO_MANY,
+            },
+          },
+        }),
+        {
+          status: 400,
+          body: {
+            message: `Cannot use "name" as a field name for a link field, it is already used as a field name on the table`,
+          },
+        }
+      )
+    })
   })
 
   describe("update", () => {

--- a/packages/server/src/sdk/app/tables/external/index.ts
+++ b/packages/server/src/sdk/app/tables/external/index.ts
@@ -29,6 +29,7 @@ import { getTable } from "../getters"
 import { populateExternalTableSchemas } from "../validation"
 import datasourceSdk from "../../datasources"
 import * as viewSdk from "../../views"
+import { checkLinkFields } from "../utils"
 
 const DEFAULT_PRIMARY_COLUMN = "id"
 
@@ -50,6 +51,8 @@ function validate(table: Table, oldTable?: Table) {
   if (hasTypeChanged(table, oldTable)) {
     throw new Error("A column type has changed.")
   }
+
+  checkLinkFields(table)
 
   const autoSubTypes = Object.values(AutoFieldSubType)
   // check for auto columns, they are not allowed

--- a/packages/server/src/sdk/app/tables/internal/index.ts
+++ b/packages/server/src/sdk/app/tables/internal/index.ts
@@ -23,6 +23,7 @@ import { checkAutoColumns } from "./utils"
 import * as viewsSdk from "../../views"
 import { getRowParams } from "../../../../db/utils"
 import { quotas } from "@budibase/pro"
+import { checkLinkFields } from "../utils"
 
 export async function save(
   table: Table,
@@ -59,6 +60,7 @@ export async function save(
 
   // check that subtypes have been maintained
   table = checkAutoColumns(table, oldTable)
+  checkLinkFields(table)
 
   // saving a table is a complex operation, involving many different steps, this
   // has been broken out into a utility to make it more obvious/easier to manipulate

--- a/packages/server/src/sdk/app/tables/utils.ts
+++ b/packages/server/src/sdk/app/tables/utils.ts
@@ -1,6 +1,6 @@
-import { Table, TableSourceType } from "@budibase/types"
+import { FieldType, Table, TableSourceType } from "@budibase/types"
 import { isExternalTableID } from "../../../integrations/utils"
-import { docIds } from "@budibase/backend-core"
+import { docIds, HTTPError } from "@budibase/backend-core"
 
 export function isExternal(opts: { table?: Table; tableId?: string }): boolean {
   if (opts.table && opts.table.sourceType === TableSourceType.EXTERNAL) {
@@ -13,4 +13,21 @@ export function isExternal(opts: { table?: Table; tableId?: string }): boolean {
 
 export function isTable(table: any): table is Table {
   return table._id && docIds.isTableId(table._id)
+}
+
+export function checkLinkFields(table: Table) {
+  for (const key of Object.keys(table.schema)) {
+    const schema = table.schema[key]
+    if (schema.type !== FieldType.LINK) {
+      continue
+    }
+
+    const fieldNameSchema = table.schema[schema.fieldName]
+    if (fieldNameSchema !== undefined) {
+      throw new HTTPError(
+        `Cannot use "${schema.fieldName}" as a field name for a link field, it is already used as a field name on the table`,
+        400
+      )
+    }
+  }
 }

--- a/packages/server/src/sdk/app/tables/utils.ts
+++ b/packages/server/src/sdk/app/tables/utils.ts
@@ -23,7 +23,7 @@ export function checkLinkFields(table: Table) {
     }
 
     const fieldNameSchema = table.schema[schema.fieldName]
-    if (fieldNameSchema !== undefined) {
+    if (key !== schema.fieldName && fieldNameSchema !== undefined) {
       throw new HTTPError(
         `Cannot use "${schema.fieldName}" as a field name for a link field, it is already used as a field name on the table`,
         400


### PR DESCRIPTION
## Description

Noticed this while creating a view test case: if the `fieldName` of a link field overlaps with a field name on the table itself all sorts of horrendous errors occur. So I'm checking for it on table creation to make sure users get a nice error message when it happens.
