### PR TITLE
Move table creation to sdk

### DIFF
--- a/packages/server/src/api/controllers/table/external.ts
+++ b/packages/server/src/api/controllers/table/external.ts
@@ -31,7 +31,7 @@ function getDatasourceId(table: Table) {
   return breakExternalTableId(table._id).datasourceId
 }
 
-export async function save(
+export async function updateTable(
   ctx: UserCtx<SaveTableRequest, SaveTableResponse>,
   renaming?: RenameColumn
 ) {

--- a/packages/server/src/api/controllers/table/index.ts
+++ b/packages/server/src/api/controllers/table/index.ts
@@ -117,7 +117,7 @@ export async function save(ctx: UserCtx<SaveTableRequest, SaveTableResponse>) {
     await events.table.created(savedTable)
   } else {
     const api = pickApi({ table })
-    savedTable = await api.save(ctx, renaming)
+    savedTable = await api.updateTable(ctx, renaming)
     await events.table.updated(savedTable)
   }
   if (renaming) {

--- a/packages/server/src/api/controllers/table/index.ts
+++ b/packages/server/src/api/controllers/table/index.ts
@@ -102,8 +102,8 @@ export async function find(ctx: UserCtx<void, TableResponse>) {
 
 export async function save(ctx: UserCtx<SaveTableRequest, SaveTableResponse>) {
   const appId = ctx.appId
-  const table = ctx.request.body
-  const isImport = table.rows
+  const { rows, ...table } = ctx.request.body
+  const isImport = rows
   const renaming = ctx.request.body._rename
 
   const isCreate = !table._id
@@ -112,7 +112,7 @@ export async function save(ctx: UserCtx<SaveTableRequest, SaveTableResponse>) {
 
   let savedTable: Table
   if (isCreate) {
-    savedTable = await sdk.tables.create(table)
+    savedTable = await sdk.tables.create(table, rows, ctx.user._id)
     savedTable = await sdk.tables.enrichViewSchemas(savedTable)
     await events.table.created(savedTable)
   } else {

--- a/packages/server/src/api/controllers/table/index.ts
+++ b/packages/server/src/api/controllers/table/index.ts
@@ -106,14 +106,18 @@ export async function save(ctx: UserCtx<SaveTableRequest, SaveTableResponse>) {
   const isImport = table.rows
   const renaming = ctx.request.body._rename
 
+  const isCreate = !table._id
+
   checkDefaultFields(table)
 
-  const api = pickApi({ table })
-  let savedTable = await api.save(ctx, renaming)
-  if (!table._id) {
+  let savedTable: Table
+  if (isCreate) {
+    savedTable = await sdk.tables.create(table)
     savedTable = await sdk.tables.enrichViewSchemas(savedTable)
     await events.table.created(savedTable)
   } else {
+    const api = pickApi({ table })
+    savedTable = await api.save(ctx, renaming)
     await events.table.updated(savedTable)
   }
   if (renaming) {

--- a/packages/server/src/api/controllers/table/internal.ts
+++ b/packages/server/src/api/controllers/table/internal.ts
@@ -33,7 +33,7 @@ export async function save(
 
   try {
     const { table } = await sdk.tables.internal.save(tableToSave, {
-      user: ctx.user,
+      userId: ctx.user._id,
       rowsToImport: rows,
       tableId: ctx.request.body._id,
       renaming,
@@ -72,7 +72,7 @@ export async function bulkImport(
   await handleDataImport(table, {
     importRows: rows,
     identifierFields,
-    user: ctx.user,
+    userId: ctx.user._id,
   })
   return table
 }

--- a/packages/server/src/api/controllers/table/internal.ts
+++ b/packages/server/src/api/controllers/table/internal.ts
@@ -12,7 +12,7 @@ import {
 } from "@budibase/types"
 import sdk from "../../../sdk"
 
-export async function save(
+export async function updateTable(
   ctx: UserCtx<SaveTableRequest, SaveTableResponse>,
   renaming?: RenameColumn
 ) {

--- a/packages/server/src/api/controllers/table/internal.ts
+++ b/packages/server/src/api/controllers/table/internal.ts
@@ -25,8 +25,6 @@ export async function updateTable(
     sourceType: rest.sourceType || TableSourceType.INTERNAL,
   }
 
-  const isImport = !!rows
-
   if (!tableToSave.views) {
     tableToSave.views = {}
   }
@@ -37,7 +35,6 @@ export async function updateTable(
       rowsToImport: rows,
       tableId: ctx.request.body._id,
       renaming,
-      isImport,
     })
 
     return table

--- a/packages/server/src/api/controllers/table/tests/utils.spec.ts
+++ b/packages/server/src/api/controllers/table/tests/utils.spec.ts
@@ -41,7 +41,7 @@ describe("utils", () => {
 
         const data = [{ name: "Alice" }, { name: "Bob" }, { name: "Claire" }]
 
-        const result = await importToRows(data, table, config.user)
+        const result = await importToRows(data, table, config.user?._id)
         expect(result).toEqual([
           expect.objectContaining({
             autoId: 1,

--- a/packages/server/src/sdk/app/tables/create.ts
+++ b/packages/server/src/sdk/app/tables/create.ts
@@ -1,0 +1,18 @@
+import { Row, Table } from "@budibase/types"
+
+// import * as external from "./external"
+import * as internal from "./internal"
+import { isExternal } from "./utils"
+
+export async function create(
+  table: Omit<Table, "_id" | "_rev">,
+  rows?: Row[],
+  userId?: string
+): Promise<Table> {
+  if (isExternal({ table })) {
+    // const datasourceId = table.sourceId!
+    throw "not implemented"
+    // return await external.create(table, rows, userId)
+  }
+  return await internal.create(table, rows, userId)
+}

--- a/packages/server/src/sdk/app/tables/create.ts
+++ b/packages/server/src/sdk/app/tables/create.ts
@@ -1,6 +1,6 @@
 import { Row, Table } from "@budibase/types"
 
-// import * as external from "./external"
+import * as external from "./external"
 import * as internal from "./internal"
 import { isExternal } from "./utils"
 
@@ -9,10 +9,11 @@ export async function create(
   rows?: Row[],
   userId?: string
 ): Promise<Table> {
+  let createdTable: Table
   if (isExternal({ table })) {
-    // const datasourceId = table.sourceId!
-    throw "not implemented"
-    // return await external.create(table, rows, userId)
+    createdTable = await external.create(table)
+  } else {
+    createdTable = await internal.create(table, rows, userId)
   }
-  return await internal.create(table, rows, userId)
+  return createdTable
 }

--- a/packages/server/src/sdk/app/tables/index.ts
+++ b/packages/server/src/sdk/app/tables/index.ts
@@ -1,5 +1,6 @@
 import { populateExternalTableSchemas } from "./validation"
 import * as getters from "./getters"
+import * as create from "./create"
 import * as updates from "./update"
 import * as utils from "./utils"
 import { migrate } from "./migration"
@@ -7,6 +8,7 @@ import * as sqs from "./internal/sqs"
 
 export default {
   populateExternalTableSchemas,
+  ...create,
   ...updates,
   ...getters,
   ...utils,

--- a/packages/server/src/sdk/app/tables/internal/index.ts
+++ b/packages/server/src/sdk/app/tables/internal/index.ts
@@ -5,7 +5,6 @@ import {
   ViewStatisticsSchema,
   ViewV2,
   Row,
-  ContextUser,
 } from "@budibase/types"
 import {
   hasTypeChanged,
@@ -27,7 +26,7 @@ import { quotas } from "@budibase/pro"
 export async function save(
   table: Table,
   opts?: {
-    user?: ContextUser
+    userId?: string
     tableId?: string
     rowsToImport?: Row[]
     renaming?: RenameColumn
@@ -63,7 +62,7 @@ export async function save(
   // saving a table is a complex operation, involving many different steps, this
   // has been broken out into a utility to make it more obvious/easier to manipulate
   const tableSaveFunctions = new TableSaveFunctions({
-    user: opts?.user,
+    userId: opts?.userId,
     oldTable,
     importRows: opts?.rowsToImport,
   })

--- a/packages/server/src/sdk/app/tables/internal/index.ts
+++ b/packages/server/src/sdk/app/tables/internal/index.ts
@@ -24,7 +24,11 @@ import * as viewsSdk from "../../views"
 import { generateTableID, getRowParams } from "../../../../db/utils"
 import { quotas } from "@budibase/pro"
 
-export async function create(table: Table, rows?: Row[], userId?: string) {
+export async function create(
+  table: Omit<Table, "_id" | "_rev">,
+  rows?: Row[],
+  userId?: string
+) {
   const tableId = generateTableID()
 
   let tableToSave: Table = {


### PR DESCRIPTION
## Description
Moving table creation to sdk to facilitate further refactors around new table permissions.
The code in here only moves code from the controller to the SDK. The only difference is that we removed the `builderSocket?.emitDatasourceUpdate(ctx, datasource)` from the external table creation. Testing it locally it's not actually used, as we already emit the table change at the controller level, and this is being used for displaying the new tables across active sessions