### PR TITLE
Properly clean up row actions on table deletion.

### DIFF
--- a/packages/backend-core/src/db/couch/DatabaseImpl.ts
+++ b/packages/backend-core/src/db/couch/DatabaseImpl.ts
@@ -211,6 +211,17 @@ export class DatabaseImpl implements Database {
     })
   }
 
+  async tryGet<T extends Document>(id?: string): Promise<T | undefined> {
+    try {
+      return await this.get<T>(id)
+    } catch (err: any) {
+      if (err.statusCode === 404) {
+        return undefined
+      }
+      throw err
+    }
+  }
+
   async getMultiple<T extends Document>(
     ids: string[],
     opts?: { allowMissing?: boolean; excludeDocs?: boolean }

--- a/packages/backend-core/src/db/instrumentation.ts
+++ b/packages/backend-core/src/db/instrumentation.ts
@@ -42,6 +42,13 @@ export class DDInstrumentedDatabase implements Database {
     })
   }
 
+  tryGet<T extends Document>(id?: string | undefined): Promise<T | undefined> {
+    return tracer.trace("db.tryGet", span => {
+      span?.addTags({ db_name: this.name, doc_id: id })
+      return this.db.tryGet(id)
+    })
+  }
+
   getMultiple<T extends Document>(
     ids: string[],
     opts?: { allowMissing?: boolean | undefined } | undefined

--- a/packages/server/src/api/controllers/rowAction/crud.ts
+++ b/packages/server/src/api/controllers/rowAction/crud.ts
@@ -21,14 +21,15 @@ export async function find(ctx: Ctx<void, RowActionsResponse>) {
   const table = await getTable(ctx)
   const tableId = table._id!
 
-  if (!(await sdk.rowActions.docExists(tableId))) {
+  const rowActions = await sdk.rowActions.getAll(tableId)
+  if (!rowActions) {
     ctx.body = {
       actions: {},
     }
     return
   }
 
-  const { actions } = await sdk.rowActions.getAll(tableId)
+  const { actions } = rowActions
   const result: RowActionsResponse = {
     actions: Object.entries(actions).reduce<Record<string, RowActionResponse>>(
       (acc, [key, action]) => ({

--- a/packages/server/src/api/controllers/table/index.ts
+++ b/packages/server/src/api/controllers/table/index.ts
@@ -139,6 +139,7 @@ export async function save(ctx: UserCtx<SaveTableRequest, SaveTableResponse>) {
 export async function destroy(ctx: UserCtx) {
   const appId = ctx.appId
   const tableId = ctx.params.tableId
+  await sdk.rowActions.deleteAll(tableId)
   const deletedTable = await pickApi({ tableId }).destroy(ctx)
   await events.table.deleted(deletedTable)
   ctx.eventEmitter &&

--- a/packages/server/src/sdk/app/automations/utils.ts
+++ b/packages/server/src/sdk/app/automations/utils.ts
@@ -26,13 +26,13 @@ export async function getBuilderData(
     return tableNameCache[tableId]
   }
 
-  const rowActionNameCache: Record<string, TableRowActions> = {}
+  const rowActionNameCache: Record<string, TableRowActions | undefined> = {}
   async function getRowActionName(tableId: string, rowActionId: string) {
     if (!rowActionNameCache[tableId]) {
       rowActionNameCache[tableId] = await sdk.rowActions.getAll(tableId)
     }
 
-    return rowActionNameCache[tableId].actions[rowActionId]?.name
+    return rowActionNameCache[tableId]?.actions[rowActionId]?.name
   }
 
   const result: Record<string, AutomationBuilderData> = {}
@@ -50,6 +50,10 @@ export async function getBuilderData(
 
     const tableName = await getTableName(tableId)
     const rowActionName = await getRowActionName(tableId, rowActionId)
+
+    if (!rowActionName) {
+      throw new Error(`Row action not found: ${rowActionId}`)
+    }
 
     result[automation._id!] = {
       displayName: `${tableName}: ${automation.name}`,

--- a/packages/server/src/sdk/app/rowActions.ts
+++ b/packages/server/src/sdk/app/rowActions.ts
@@ -103,13 +103,17 @@ export async function get(tableId: string, rowActionId: string) {
 export async function getAll(tableId: string) {
   const db = context.getAppDB()
   const rowActionsId = generateRowActionsID(tableId)
-  return await db.get<TableRowActions>(rowActionsId)
+  return await db.tryGet<TableRowActions>(rowActionsId)
 }
 
 export async function deleteAll(tableId: string) {
   const db = context.getAppDB()
 
   const doc = await getAll(tableId)
+  if (!doc) {
+    return
+  }
+
   const automationIds = Object.values(doc.actions).map(a => a.automationId)
   const automations = await db.getMultiple<Automation>(automationIds)
 
@@ -238,9 +242,8 @@ export async function run(tableId: any, rowActionId: any, rowId: string) {
     throw new HTTPError("Table not found", 404)
   }
 
-  const { actions } = await getAll(tableId)
-
-  const rowAction = actions[rowActionId]
+  const rowActions = await getAll(tableId)
+  const rowAction = rowActions?.actions[rowActionId]
   if (!rowAction) {
     throw new HTTPError("Row action not found", 404)
   }

--- a/packages/server/src/sdk/app/rowActions.ts
+++ b/packages/server/src/sdk/app/rowActions.ts
@@ -1,5 +1,6 @@
 import { context, docIds, HTTPError, utils } from "@budibase/backend-core"
 import {
+  Automation,
   AutomationTriggerStepId,
   SEPARATOR,
   TableRowActions,
@@ -103,6 +104,20 @@ export async function getAll(tableId: string) {
   const db = context.getAppDB()
   const rowActionsId = generateRowActionsID(tableId)
   return await db.get<TableRowActions>(rowActionsId)
+}
+
+export async function deleteAll(tableId: string) {
+  const db = context.getAppDB()
+
+  const doc = await getAll(tableId)
+  const automationIds = Object.values(doc.actions).map(a => a.automationId)
+  const automations = await db.getMultiple<Automation>(automationIds)
+
+  for (const automation of automations) {
+    await sdk.automations.remove(automation._id!, automation._rev!)
+  }
+
+  await db.remove(doc)
 }
 
 export async function docExists(tableId: string) {

--- a/packages/server/src/tests/utilities/api/automation.ts
+++ b/packages/server/src/tests/utilities/api/automation.ts
@@ -1,4 +1,4 @@
-import { Automation } from "@budibase/types"
+import { Automation, FetchAutomationResponse } from "@budibase/types"
 import { Expectations, TestAPI } from "./base"
 
 export class AutomationAPI extends TestAPI {
@@ -14,6 +14,26 @@ export class AutomationAPI extends TestAPI {
     )
     return result
   }
+
+  fetch = async (
+    expectations?: Expectations
+  ): Promise<FetchAutomationResponse> => {
+    return await this._get<FetchAutomationResponse>(`/api/automations`, {
+      expectations,
+    })
+  }
+
+  fetchEnriched = async (
+    expectations?: Expectations
+  ): Promise<FetchAutomationResponse> => {
+    return await this._get<FetchAutomationResponse>(
+      `/api/automations?enrich=true`,
+      {
+        expectations,
+      }
+    )
+  }
+
   post = async (
     body: Automation,
     expectations?: Expectations

--- a/packages/types/src/sdk/db.ts
+++ b/packages/types/src/sdk/db.ts
@@ -129,7 +129,12 @@ export interface Database {
   name: string
 
   exists(): Promise<boolean>
+  /**
+   * @deprecated the plan is to get everything using `tryGet` instead, then rename
+   * `tryGet` to `get`.
+   */
   get<T extends Document>(id?: string): Promise<T>
+  tryGet<T extends Document>(id?: string): Promise<T | undefined>
   exists(docId: string): Promise<boolean>
   getMultiple<T extends Document>(
     ids: string[],


### PR DESCRIPTION
## Description

@ConorWebb96 found a bug where deleting a table that has row actions associated with it will cause several other endpoints to start returning errors, rendering the app unusable.

This happens because when a table is deleted, its row actions become orphaned and reference a table that no longer exists. Other things fetch these actions and then attempt to fetch the table, resulting in errors.

This PRs deletes all row actions associated with a table when the table is deleted.
