### PR TITLE
View joins - allow related required columns' visibility to be changed

### DIFF
--- a/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
+++ b/packages/frontend-core/src/components/grid/controls/ColumnsSettingContent.svelte
@@ -125,7 +125,7 @@
         subtype: column.subtype,
         visible: column.visible,
         readonly: column.readonly,
-        constraints: column.constraints, // This is needed to properly display "users" column
+        icon: column.icon,
       },
     }
   })

--- a/packages/frontend-core/src/components/grid/lib/utils.js
+++ b/packages/frontend-core/src/components/grid/lib/utils.js
@@ -19,6 +19,10 @@ export const getCellID = (rowId, fieldName) => {
 }
 
 export const getColumnIcon = column => {
+  if (column.schema.icon) {
+    return column.schema.icon
+  }
+
   if (column.schema.autocolumn) {
     return "MagicWand"
   }

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -1,4 +1,5 @@
 import {
+  BBReferenceFieldSubType,
   CalculationType,
   canGroupBy,
   FeatureFlag,
@@ -7,6 +8,7 @@ import {
   PermissionLevel,
   RelationSchemaField,
   RenameColumn,
+  RequiredKeys,
   Table,
   TableSchema,
   View,
@@ -325,13 +327,18 @@ export async function enrichSchema(
       const viewFieldSchema = viewFields[relTableFieldName]
       const isVisible = !!viewFieldSchema?.visible
       const isReadonly = !!viewFieldSchema?.readonly
-      result[relTableFieldName] = {
-        ...relTableField,
-        ...viewFieldSchema,
-        name: relTableField.name,
+      const enrichedFieldSchema: RequiredKeys<ViewV2ColumnEnriched> = {
         visible: isVisible,
         readonly: isReadonly,
+        order: viewFieldSchema?.order,
+        width: viewFieldSchema?.width,
+
+        icon: relTableField.icon,
+        type: relTableField.type,
+        subtype: relTableField.subtype,
       }
+      }
+      result[relTableFieldName] = enrichedFieldSchema
     }
     return result
   }

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -337,6 +337,14 @@ export async function enrichSchema(
         type: relTableField.type,
         subtype: relTableField.subtype,
       }
+      if (
+        !enrichedFieldSchema.icon &&
+        relTableField.type === FieldType.BB_REFERENCE &&
+        relTableField.subtype === BBReferenceFieldSubType.USER &&
+        !helpers.schema.isDeprecatedSingleUserColumn(relTableField)
+      ) {
+        // Forcing the icon, otherwise we would need to pass the constraints to show the proper icon
+        enrichedFieldSchema.icon = "UserGroup"
       }
       result[relTableFieldName] = enrichedFieldSchema
     }

--- a/packages/server/src/sdk/app/views/tests/views.spec.ts
+++ b/packages/server/src/sdk/app/views/tests/views.spec.ts
@@ -355,13 +355,11 @@ describe("table sdk", () => {
               visible: true,
               columns: {
                 title: {
-                  name: "title",
                   type: "string",
                   visible: true,
                   readonly: true,
                 },
                 age: {
-                  name: "age",
                   type: "number",
                   visible: false,
                   readonly: false,

--- a/packages/types/src/sdk/view.ts
+++ b/packages/types/src/sdk/view.ts
@@ -1,4 +1,10 @@
-import { FieldSchema, RelationSchemaField, ViewV2 } from "../documents"
+import {
+  FieldSchema,
+  FieldSubType,
+  FieldType,
+  RelationSchemaField,
+  ViewV2,
+} from "../documents"
 
 export interface ViewV2Enriched extends ViewV2 {
   schema?: {
@@ -8,4 +14,7 @@ export interface ViewV2Enriched extends ViewV2 {
   }
 }
 
-export type ViewV2ColumnEnriched = RelationSchemaField & FieldSchema
+export interface ViewV2ColumnEnriched extends RelationSchemaField {
+  type: FieldType
+  subtype?: FieldSubType
+}


### PR DESCRIPTION
## Description
Return only required fields on enriched view column schema. Otherwise we might have some side effects that we need to handle in the frontend, such as allowing required fields to be visible (that it does not apply for related fields)

## Screenshots
Some required on `aux` tables
<img width="1329" alt="image" src="https://github.com/user-attachments/assets/2b2cccd5-60f8-4725-b8f3-a623fed43245">

Can be edited on the related field views
<img width="1174" alt="image" src="https://github.com/user-attachments/assets/2cdda3f3-c546-48b6-85b1-d59a47ccd6b5">



