### PR TITLE
Fix for an issue found with custom role naming

### DIFF
--- a/packages/backend-core/src/security/roles.ts
+++ b/packages/backend-core/src/security/roles.ts
@@ -435,7 +435,9 @@ export function getExternalRoleID(roleId: string, version?: string) {
     roleId.startsWith(DocumentType.ROLE) &&
     (isBuiltin(roleId) || version === RoleIDVersion.NAME)
   ) {
-    return roleId.split(`${DocumentType.ROLE}${SEPARATOR}`)[1]
+    const parts = roleId.split(SEPARATOR)
+    parts.shift()
+    return parts.join(SEPARATOR)
   }
   return roleId
 }

--- a/packages/server/src/api/routes/tests/role.spec.js
+++ b/packages/server/src/api/routes/tests/role.spec.js
@@ -161,7 +161,7 @@ describe("/roles", () => {
 
     it("should not fetch higher level accessible roles when a custom role header is provided", async () => {
       await createRole({
-        name: `CUSTOM_ROLE`,
+        name: `custom_role_1`,
         inherits: roles.BUILTIN_ROLE_IDS.BASIC,
         permissionId: permissions.BuiltinPermissionID.READ_ONLY,
         version: "name",
@@ -170,11 +170,11 @@ describe("/roles", () => {
         .get("/api/roles/accessible")
         .set({
           ...config.defaultHeaders(),
-          "x-budibase-role": "CUSTOM_ROLE",
+          "x-budibase-role": "custom_role_1",
         })
         .expect(200)
       expect(res.body.length).toBe(3)
-      expect(res.body[0]).toBe("CUSTOM_ROLE")
+      expect(res.body[0]).toBe("custom_role_1")
       expect(res.body[1]).toBe("BASIC")
       expect(res.body[2]).toBe("PUBLIC")
     })


### PR DESCRIPTION
## Description
Silly bug for if a role name contained `role_` - this would break the ID, correcting this and updating an existing test to cover this check.
