### PR TITLE
Extend available labels for feature branch deployments

### DIFF
--- a/.github/workflows/deploy-featurebranch.yml
+++ b/.github/workflows/deploy-featurebranch.yml
@@ -3,26 +3,50 @@ name: deploy-featurebranch
 on:
   pull_request:
     types: [
-        labeled,
-        # default types below (https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)
-        opened,
-        synchronize,
-        reopened,
-      ]
+      labeled,
+      # default types below (https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)
+      opened,
+      synchronize,
+      reopened,
+    ]
 
 jobs:
   release:
     if: |
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'Budibase/budibase') &&
-      contains(github.event.pull_request.labels.*.name, 'feature-branch')
+      (
+        contains(github.event.pull_request.labels.*.name, 'feature-branch') ||
+        contains(github.event.pull_request.labels.*.name, 'feature-branch-pro') ||
+        contains(github.event.pull_request.labels.*.name, 'feature-branch-team') ||
+        contains(github.event.pull_request.labels.*.name, 'feature-branch-business') ||
+        contains(github.event.pull_request.labels.*.name, 'feature-branch-enterprise')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set PAYLOAD_LICENSE_TYPE
+        id: set_license_type
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'feature-branch') }}" == "true" ]]; then
+            echo "PAYLOAD_LICENSE_TYPE=free" >> $GITHUB_ENV
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'feature-branch-pro') }}" == "true" ]]; then
+            echo "PAYLOAD_LICENSE_TYPE=pro" >> $GITHUB_ENV
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'feature-branch-team') }}" == "true" ]]; then
+            echo "PAYLOAD_LICENSE_TYPE=team" >> $GITHUB_ENV
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'feature-branch-business') }}" == "true" ]]; then
+            echo "PAYLOAD_LICENSE_TYPE=business" >> $GITHUB_ENV
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'feature-branch-enterprise') }}" == "true" ]]; then
+            echo "PAYLOAD_LICENSE_TYPE=enterprise" >> $GITHUB_ENV
+          else
+            echo "PAYLOAD_LICENSE_TYPE=free" >> $GITHUB_ENV
+          fi
+
       - uses: passeidireto/trigger-external-workflow-action@main
         env:
           PAYLOAD_BRANCH: ${{ github.head_ref }}
           PAYLOAD_PR_NUMBER: ${{ github.event.pull_request.number }}
-          PAYLOAD_LICENSE_TYPE: "free"
+          PAYLOAD_LICENSE_TYPE: ${{ env.PAYLOAD_LICENSE_TYPE }}
         with:
           repository: budibase/budibase-deploys
           event: featurebranch-qa-deploy


### PR DESCRIPTION
## Description
We're expanding the options of the feature branch labels that are used to trigger the deployments of feature branches. The new available labels are:

- `feature-branch-pro`
- `feature-branch-team`
- `feature-branch-business`
- `feature-branch-enterprise`

