### PR TITLE
Fix all or property

### DIFF
--- a/packages/shared-core/src/utils.ts
+++ b/packages/shared-core/src/utils.ts
@@ -172,7 +172,7 @@ export const processSearchFilters = (
         .sort((a, b) => {
           return a.localeCompare(b)
         })
-        .filter(key => key in filter)
+        .filter(key => filter[key])
 
       if (filterPropertyKeys.length == 1) {
         const key = filterPropertyKeys[0],


### PR DESCRIPTION
## Description
Fixing filter "behaviour". This has been broken and it always behaves as "all", even if "any" is selected

https://github.com/user-attachments/assets/8894f2fe-5559-45a0-9bcf-aa2ba61bcac3


## Launchcontrol
Fixing filter "behaviour"