### PR TITLE
Fix searching by bindings when those bindings have been stored in the `view.query` field.

### DIFF
--- a/packages/server/src/api/controllers/row/views.ts
+++ b/packages/server/src/api/controllers/row/views.ts
@@ -8,6 +8,7 @@ import {
 } from "@budibase/types"
 import sdk from "../../../sdk"
 import { context } from "@budibase/backend-core"
+import * as utils from "./utils"
 
 export async function searchView(
   ctx: UserCtx<SearchViewRowRequest, SearchRowResponse>

--- a/packages/server/src/api/controllers/row/views.ts
+++ b/packages/server/src/api/controllers/row/views.ts
@@ -8,7 +8,6 @@ import {
 } from "@budibase/types"
 import sdk from "../../../sdk"
 import { context } from "@budibase/backend-core"
-import * as utils from "./utils"
 
 export async function searchView(
   ctx: UserCtx<SearchViewRowRequest, SearchRowResponse>

--- a/packages/server/src/sdk/app/rows/search.ts
+++ b/packages/server/src/sdk/app/rows/search.ts
@@ -81,6 +81,10 @@ export async function search(
       options.query = {}
     }
 
+    if (context) {
+      options.query = await enrichSearchContext(options.query, context)
+    }
+
     // need to make sure filters in correct shape before checking for view
     options = searchInputMapping(table, options)
 
@@ -100,6 +104,7 @@ export async function search(
       const sqsEnabled = await features.flags.isEnabled("SQS")
       const supportsLogicalOperators =
         isExternalTableID(view.tableId) || sqsEnabled
+
       if (!supportsLogicalOperators) {
         // In the unlikely event that a Grouped Filter is in a non-SQS environment
         // It needs to be ignored entirely
@@ -136,10 +141,6 @@ export async function search(
           options.query.onEmptyFilter = query.onEmptyFilter
         }
       }
-    }
-
-    if (context) {
-      options.query = await enrichSearchContext(options.query, context)
     }
 
     options.query = dataFilters.cleanupQuery(options.query)


### PR DESCRIPTION
## Description

This was a tricky one to track down and fix. What was happening is that the code that handles and-ing together a `view.query` with the query passed in from the search endpoint wasn't evaluating bindings correctly.

The story for binding evaluation in search queries is actually quite complicated, especially when they're user bindings. We have special code in place to ensure any user IDs passed in our the global variant (`us_...`) instead of the user metadata variant (`ro_ta_users_us...`). This is fundamentally what wasn't being correctly applied.
