### PR TITLE
Changes to support processing bindings on both sides of branch condition evaluation

### DIFF
--- a/packages/server/src/automations/tests/utilities/AutomationTestBuilder.ts
+++ b/packages/server/src/automations/tests/utilities/AutomationTestBuilder.ts
@@ -88,13 +88,13 @@ class BaseStepBuilder {
     Object.entries(branchConfig).forEach(([key, branch]) => {
       const stepBuilder = new StepBuilder()
       branch.steps(stepBuilder)
-
+      let branchId = uuidv4()
       branchStepInputs.branches.push({
         name: key,
         condition: branch.condition,
-        id: uuidv4(),
+        id: branchId,
       })
-      branchStepInputs.children![key] = stepBuilder.build()
+      branchStepInputs.children![branchId] = stepBuilder.build()
     })
     const branchStep: AutomationStep = {
       ...definition,

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -32,7 +32,6 @@ import { WorkerCallback } from "./definitions"
 import { context, logging } from "@budibase/backend-core"
 import {
   findHBSBlocks,
-  isJSBinding,
   processObject,
   processStringSync,
 } from "@budibase/string-templates"


### PR DESCRIPTION
## Description
Previously the processing of bindings was only supported on one side of the expression. Updating it so bindings get processed on both sides. Also added tests to support this. 

