### PR TITLE
Fix view join parser for non-array values any "many" types

### DIFF
--- a/packages/frontend-core/src/utils/relatedColumns.js
+++ b/packages/frontend-core/src/utils/relatedColumns.js
@@ -24,9 +24,9 @@ const columnTypeManyParser = {
       return parsed
     }
 
-    return value?.map(v => parseDate(v))
+    return value.map(v => parseDate(v))
   },
-  [FieldType.BOOLEAN]: value => value?.map(v => !!v),
+  [FieldType.BOOLEAN]: value => value.map(v => !!v),
   [FieldType.BB_REFERENCE_SINGLE]: value => [
     ...new Map(value.map(i => [i._id, i])).values(),
   ],
@@ -80,14 +80,10 @@ export function getRelatedTableValues(row, field, fromField) {
     result = row[field.related.field]?.[0]?.[field.related.subField]
   } else {
     const parser = columnTypeManyParser[field.type] || (value => value)
-
-    result = parser(
-      row[field.related.field]
-        ?.flatMap(r => r[field.related.subField])
-        ?.filter(i => i !== undefined && i !== null),
-      field
-    )
-
+    const value = row[field.related.field]
+      ?.flatMap(r => r[field.related.subField])
+      ?.filter(i => i !== undefined && i !== null)
+    result = parser(value || [], field)
     if (
       [
         FieldType.STRING,


### PR DESCRIPTION
## Description
Fixes a crash when viewing certain types of view join columns with non-array values.

## Addresses
- https://linear.app/budibase/issue/BUDI-8737/one-of-my-views-is-borked
