### PR TITLE
Prevent view queryUI transforms mutating state

### DIFF
--- a/packages/builder/src/stores/builder/viewsV2.js
+++ b/packages/builder/src/stores/builder/viewsV2.js
@@ -6,16 +6,22 @@ import { dataFilters } from "@budibase/shared-core"
 function convertToSearchFilters(view) {
   // convert from SearchFilterGroup type
   if (view?.query) {
-    view.queryUI = view.query
-    view.query = dataFilters.buildQuery(view.query)
+    return {
+      ...view,
+      queryUI: view.query,
+      query: dataFilters.buildQuery(view.query),
+    }
   }
   return view
 }
 
 function convertToSearchFilterGroup(view) {
   if (view?.queryUI) {
-    view.query = view.queryUI
-    delete view.queryUI
+    return {
+      ...view,
+      query: view.queryUI,
+      queryUI: undefined,
+    }
   }
   return view
 }

--- a/packages/frontend-core/src/components/grid/stores/datasources/viewV2.js
+++ b/packages/frontend-core/src/components/grid/stores/datasources/viewV2.js
@@ -3,9 +3,12 @@ import { dataFilters } from "@budibase/shared-core"
 
 function convertToSearchFilters(view) {
   // convert from SearchFilterGroup type
-  if (view.query) {
-    view.queryUI = view.query
-    view.query = dataFilters.buildQuery(view.query)
+  if (view?.query) {
+    return {
+      ...view,
+      queryUI: view.query,
+      query: dataFilters.buildQuery(view.query),
+    }
   }
   return view
 }


### PR DESCRIPTION
## Description
To keep the API happy we need to transform views before saving them to the server, and similarly transform them on the way back as the rest of the frontend has not been updated to expect these new property names.

This was implemented in a way that mutated the real view structures in state, which caused multiple issues. This PR ensures that these transformations to not mutate the real views but copy them instead.

This still needs rewritten at some point as it is very fragile.

## Addresses
- https://linear.app/budibase/issue/BUDI-8732/adding-row-actions-or-changing-column-restrictions-blows-away-applied