### PR TITLE
Fix relationship cell containing reference to deleted code

### DIFF
--- a/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/RelationshipCell.svelte
@@ -198,7 +198,6 @@
 
   // Toggles whether a row is included in the relationship or not
   const toggleRow = async row => {
-    hideRelationshipFields()
     if (fieldValue?.some(x => x._id === row._id)) {
       // If the row is already included, remove it and update the candidate
       // row to be the same position if possible


### PR DESCRIPTION
## Description
Fixes a leftover reference that should have been deleted. Causes a crash when adding or removing a value in a relationship cell.
