### PR TITLE
Don't extend dataprovider queries when no extensions are in use

### DIFF
--- a/packages/client/src/components/app/DataProvider.svelte
+++ b/packages/client/src/components/app/DataProvider.svelte
@@ -126,6 +126,9 @@
   }
 
   const extendQuery = (defaultQuery, extensions) => {
+    if (!Object.keys(extensions).length) {
+      return
+    }
     const extended = {
       [LogicalOperator.AND]: {
         conditions: [

--- a/packages/client/src/components/app/DataProvider.svelte
+++ b/packages/client/src/components/app/DataProvider.svelte
@@ -127,7 +127,7 @@
 
   const extendQuery = (defaultQuery, extensions) => {
     if (!Object.keys(extensions).length) {
-      return
+      return defaultQuery
     }
     const extended = {
       [LogicalOperator.AND]: {


### PR DESCRIPTION
## Description
Fixes an issue where we wrap all data provider filters in an extraneous `$and` operator, and forcefully set `onEmptyFilter` to none. This is not needed unless we actually want to use a filter extension, which we usually do not.

## Addresses
- https://linear.app/budibase/issue/BUDI-8740/data-provider-filters-return-all-rows-when-filters-are-empty-fails