### PR TITLE
Fix filter drawer visibility in component popovers

### DIFF
--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterEditor.svelte
@@ -59,6 +59,7 @@
   bind:this={drawer}
   title="Filtering"
   on:drawerHide
+  on:drawerShow
   on:drawerShow={() => {
     // Reset to the currently available value.
     localFilters = Helpers.cloneDeep(value)


### PR DESCRIPTION
## Description
Fix the drawerShow event not being broadcast, preventing component popovers from hiding properly when opening drawers from within a component popover.

## Addresses
- https://linear.app/budibase/issue/BUDI-8748/form-block-filtering-options-dont-hide-when-opening-the-bindings
