### PR TITLE
Display numbers using locale format in tables

### DIFF
--- a/packages/frontend-core/src/components/grid/cells/NumberCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/NumberCell.svelte
@@ -1,3 +1,7 @@
+<script context="module">
+  const NumberFormatter = Intl.NumberFormat()
+</script>
+
 <script>
   import TextCell from "./TextCell.svelte"
 
@@ -9,6 +13,24 @@
     const newValue = isNaN(float) ? null : float
     onChange(newValue)
   }
+
+  const formatNumber = value => {
+    const type = typeof value
+    if (type !== "string" && type !== "number") {
+      return ""
+    }
+    if (type === "string" && !value.trim().length) {
+      return ""
+    }
+    const res = NumberFormatter.format(value)
+    return res === "NaN" ? value : res
+  }
 </script>
 
-<TextCell {...$$props} onChange={numberOnChange} bind:api type="number" />
+<TextCell
+  {...$$props}
+  onChange={numberOnChange}
+  bind:api
+  type="number"
+  format={formatNumber}
+/>

--- a/packages/frontend-core/src/components/grid/cells/TextCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/TextCell.svelte
@@ -52,7 +52,11 @@
 {:else}
   <div class="text-cell" class:number={type === "number"}>
     <div class="value">
-      {value ?? ""}
+      {#if type === "number"}
+        {(value ?? "").toLocaleString()}
+      {:else}
+        {value ?? ""}
+      {/if}
     </div>
   </div>
 {/if}

--- a/packages/frontend-core/src/components/grid/cells/TextCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/TextCell.svelte
@@ -1,3 +1,7 @@
+<script context="module">
+  const NumberFormatter = Intl.NumberFormat()
+</script>
+
 <script>
   import { onMount } from "svelte"
 
@@ -53,7 +57,7 @@
   <div class="text-cell" class:number={type === "number"}>
     <div class="value">
       {#if type === "number"}
-        {(value ?? "").toLocaleString()}
+        {NumberFormatter.format(value ?? "")}
       {:else}
         {value ?? ""}
       {/if}

--- a/packages/frontend-core/src/components/grid/cells/TextCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/TextCell.svelte
@@ -1,7 +1,3 @@
-<script context="module">
-  const NumberFormatter = Intl.NumberFormat()
-</script>
-
 <script>
   import { onMount } from "svelte"
 
@@ -11,11 +7,13 @@
   export let type = "text"
   export let readonly = false
   export let api
+  export let format = null
 
   let input
   let active = false
 
   $: editable = focused && !readonly
+  $: displayValue = format?.(value) ?? value ?? ""
 
   const handleChange = e => {
     onChange(e.target.value)
@@ -56,11 +54,7 @@
 {:else}
   <div class="text-cell" class:number={type === "number"}>
     <div class="value">
-      {#if type === "number"}
-        {NumberFormatter.format(value ?? "")}
-      {:else}
-        {value ?? ""}
-      {/if}
+      {displayValue}
     </div>
   </div>
 {/if}


### PR DESCRIPTION
## Description
Use `toLocaleString` to display numbers using separators in tables.

Before:
![image](https://github.com/user-attachments/assets/88f3615f-104d-4f32-8f56-97a16a2102da)

After:
![image](https://github.com/user-attachments/assets/0fba1f26-6937-42bf-934a-7896693ed231)

Changing to German locale:
![Bildschirmfoto 2024-10-18 um 10 43 18](https://github.com/user-attachments/assets/a84f7238-8364-47d3-a6e2-b1979616e5b9)

## Addresses
- https://github.com/Budibase/budibase/issues/14820
