### PR TITLE
deprecates Section component

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/new/_components/componentStructure.json
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/new/_components/componentStructure.json
@@ -14,7 +14,7 @@
   {
     "name": "Layout",
     "icon": "ClassicGridView",
-    "children": ["container", "section", "sidepanel", "modal"]
+    "children": ["container", "sidepanel", "modal"]
   },
   {
     "name": "Data",

--- a/packages/client/src/components/app/deprecated/Section.svelte
+++ b/packages/client/src/components/app/deprecated/Section.svelte
@@ -1,6 +1,6 @@
 <script>
   import { getContext } from "svelte"
-  import Placeholder from "./Placeholder.svelte"
+  import Placeholder from "../Placeholder.svelte"
 
   const { styleable, builderStore } = getContext("sdk")
   const component = getContext("component")

--- a/packages/client/src/components/app/forms/FieldGroup.svelte
+++ b/packages/client/src/components/app/forms/FieldGroup.svelte
@@ -1,6 +1,6 @@
 <script>
   import { getContext, setContext } from "svelte"
-  import Section from "../Section.svelte"
+  import Section from "../deprecated/Section.svelte"
 
   export let labelPosition = "above"
   export let type = "oneColumn"

--- a/packages/client/src/components/app/index.js
+++ b/packages/client/src/components/app/index.js
@@ -14,7 +14,6 @@ export { default as Placeholder } from "./Placeholder.svelte"
 
 // User facing components
 export { default as container } from "./container/Container.svelte"
-export { default as section } from "./Section.svelte"
 export { default as dataprovider } from "./DataProvider.svelte"
 export { default as divider } from "./Divider.svelte"
 export { default as screenslot } from "./ScreenSlot.svelte"
@@ -50,3 +49,4 @@ export { default as navigation } from "./deprecated/Navigation.svelte"
 export { default as cardhorizontal } from "./deprecated/CardHorizontal.svelte"
 export { default as stackedlist } from "./deprecated/StackedList.svelte"
 export { default as card } from "./deprecated/Card.svelte"
+export { default as section } from "./deprecated/Section.svelte"


### PR DESCRIPTION
## Description
Deprecates `Section` component. 

Since Grid layout, there isn't a lot of need for a section component. There were a couple of known-bugs that came up with it, but there's little use in fixing them when the grid layout achieves the same end-result (and more).

Deletes "Section" from componentStructure.json
moves component into deprecated folder
Updates filepath to deprecated folder

