### PR TITLE
Default user columns to current user for templates

### DIFF
--- a/packages/builder/src/components/start/CreateAppModal.svelte
+++ b/packages/builder/src/components/start/CreateAppModal.svelte
@@ -118,14 +118,17 @@
       if ($values.url) {
         data.append("url", $values.url.trim())
       }
-      data.append("useTemplate", template != null)
-      if (template) {
-        data.append("templateName", template.name)
-        data.append("templateKey", template.key)
-        data.append("templateFile", $values.file)
+
+      if (template?.fromFile) {
+        data.append("useTemplate", true)
+        data.append("fileToImport", $values.file)
         if ($values.encryptionPassword?.trim()) {
           data.append("encryptionPassword", $values.encryptionPassword.trim())
         }
+      } else if (template) {
+        data.append("useTemplate", true)
+        data.append("templateName", template.name)
+        data.append("templateKey", template.key)
       }
 
       // Create App

--- a/packages/server/scripts/load/utils.js
+++ b/packages/server/scripts/load/utils.js
@@ -29,7 +29,7 @@ exports.createApp = async apiKey => {
   const body = {
     name,
     url: `/${name}`,
-    useTemplate: "true",
+    useTemplate: true,
     templateKey: "app/school-admin-panel",
     templateName: "School Admin Panel",
   }

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -250,9 +250,9 @@ async function performAppCreate(ctx: UserCtx<CreateAppRequest, App>) {
     useTemplate,
     key: templateKey,
   }
-  if (ctx.request.files && ctx.request.files.templateFile) {
+  if (ctx.request.files && ctx.request.files.fileToImport) {
     instanceConfig.file = {
-      ...(ctx.request.files.templateFile as any),
+      ...(ctx.request.files.fileToImport as any),
       password: encryptionPassword,
     }
   } else if (typeof ctx.request.body.file?.path === "string") {

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -748,7 +748,7 @@ export async function duplicateApp(
   const createRequestBody: CreateAppRequest = {
     name: appName,
     url: possibleUrl,
-    useTemplate: true,
+    useTemplate: "true",
     // The app export path
     file: {
       path: tmpPath,

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -284,8 +284,7 @@ async function performAppCreate(ctx: UserCtx<CreateAppRequest, App>) {
     const instance = await createInstance(appId, instanceConfig)
     const db = context.getAppDB()
 
-    const isTemplate = instanceConfig.templateString
-    if (!isTemplate) {
+    if (instanceConfig.useTemplate) {
       await updateUserColumns(appId, db, ctx.user._id!)
     }
 

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -440,13 +440,13 @@ async function creationEvents(request: BBRequest<CreateAppRequest>, app: App) {
   let creationFns: ((app: App) => Promise<void>)[] = []
 
   const { useTemplate, templateKey, file } = request.body
-  if (useTemplate) {
+  if (useTemplate === "true") {
     // from template
     if (templateKey && templateKey !== "undefined") {
       creationFns.push(a => events.app.templateImported(a, templateKey))
     }
     // from file
-    else if (request.files?.templateFile) {
+    else if (request.files?.fileToImport) {
       creationFns.push(a => events.app.fileImported(a))
     }
     // from server file path

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -269,7 +269,7 @@ async function performAppCreate(ctx: UserCtx<CreateAppRequest, App>) {
     const instance = await createInstance(appId, instanceConfig)
     const db = context.getAppDB()
 
-    if (instanceConfig.useTemplate) {
+    if (instanceConfig.useTemplate && !instanceConfig.file) {
       await updateUserColumns(appId, db, ctx.user._id!)
     }
 

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -240,8 +240,15 @@ export async function fetchAppPackage(
 
 async function performAppCreate(ctx: UserCtx<CreateAppRequest, App>) {
   const apps = (await dbCore.getAllApps({ dev: true })) as App[]
-  const { name, url, encryptionPassword, useTemplate, templateKey } =
-    ctx.request.body
+  const { body } = ctx.request
+  const { name, url, encryptionPassword, templateKey } = body
+
+  let useTemplate
+  if (typeof body.useTemplate === "string") {
+    useTemplate = body.useTemplate === "true"
+  } else if (typeof body.useTemplate === "boolean") {
+    useTemplate = body.useTemplate
+  }
 
   checkAppName(ctx, apps, name)
   const appUrl = sdk.applications.getAppUrl({ name, url })
@@ -256,9 +263,9 @@ async function performAppCreate(ctx: UserCtx<CreateAppRequest, App>) {
       ...(ctx.request.files.fileToImport as any),
       password: encryptionPassword,
     }
-  } else if (typeof ctx.request.body.file?.path === "string") {
+  } else if (typeof body.file?.path === "string") {
     instanceConfig.file = {
-      path: ctx.request.body.file?.path,
+      path: body.file?.path,
     }
   }
 

--- a/packages/server/src/api/routes/tests/application.spec.ts
+++ b/packages/server/src/api/routes/tests/application.spec.ts
@@ -139,7 +139,7 @@ describe("/applications", () => {
     it("creates app from template", async () => {
       const app = await config.api.application.create({
         name: utils.newid(),
-        useTemplate: true,
+        useTemplate: "true",
         templateKey: "test",
       })
       expect(app._id).toBeDefined()
@@ -150,7 +150,7 @@ describe("/applications", () => {
     it("creates app from file", async () => {
       const app = await config.api.application.create({
         name: utils.newid(),
-        useTemplate: true,
+        useTemplate: "true",
         fileToImport: "src/api/routes/tests/data/export.txt",
       })
       expect(app._id).toBeDefined()
@@ -170,7 +170,7 @@ describe("/applications", () => {
     it("migrates navigation settings from old apps", async () => {
       const app = await config.api.application.create({
         name: utils.newid(),
-        useTemplate: true,
+        useTemplate: "true",
         fileToImport: "src/api/routes/tests/data/old-app.txt",
       })
       expect(app._id).toBeDefined()

--- a/packages/server/src/api/routes/tests/application.spec.ts
+++ b/packages/server/src/api/routes/tests/application.spec.ts
@@ -141,7 +141,6 @@ describe("/applications", () => {
         name: utils.newid(),
         useTemplate: "true",
         templateKey: "test",
-        templateString: "{}",
       })
       expect(app._id).toBeDefined()
       expect(events.app.created).toHaveBeenCalledTimes(1)

--- a/packages/server/src/api/routes/tests/application.spec.ts
+++ b/packages/server/src/api/routes/tests/application.spec.ts
@@ -139,7 +139,7 @@ describe("/applications", () => {
     it("creates app from template", async () => {
       const app = await config.api.application.create({
         name: utils.newid(),
-        useTemplate: "true",
+        useTemplate: true,
         templateKey: "test",
       })
       expect(app._id).toBeDefined()
@@ -150,7 +150,7 @@ describe("/applications", () => {
     it("creates app from file", async () => {
       const app = await config.api.application.create({
         name: utils.newid(),
-        useTemplate: "true",
+        useTemplate: true,
         fileToImport: "src/api/routes/tests/data/export.txt",
       })
       expect(app._id).toBeDefined()
@@ -170,7 +170,7 @@ describe("/applications", () => {
     it("migrates navigation settings from old apps", async () => {
       const app = await config.api.application.create({
         name: utils.newid(),
-        useTemplate: "true",
+        useTemplate: true,
         fileToImport: "src/api/routes/tests/data/old-app.txt",
       })
       expect(app._id).toBeDefined()

--- a/packages/server/src/api/routes/tests/application.spec.ts
+++ b/packages/server/src/api/routes/tests/application.spec.ts
@@ -21,6 +21,7 @@ import tk from "timekeeper"
 import * as uuid from "uuid"
 import { structures } from "@budibase/backend-core/tests"
 import nock from "nock"
+import path from "path"
 
 describe("/applications", () => {
   let config = setup.getConfig()
@@ -137,10 +138,17 @@ describe("/applications", () => {
     })
 
     it("creates app from template", async () => {
+      nock("https://prod-budi-templates.s3-eu-west-1.amazonaws.com")
+        .get(`/templates/app/agency-client-portal.tar.gz`)
+        .replyWithFile(
+          200,
+          path.resolve(__dirname, "data", "agency-client-portal.tar.gz")
+        )
+
       const app = await config.api.application.create({
         name: utils.newid(),
         useTemplate: "true",
-        templateKey: "test",
+        templateKey: "app/agency-client-portal",
       })
       expect(app._id).toBeDefined()
       expect(events.app.created).toHaveBeenCalledTimes(1)

--- a/packages/server/src/api/routes/tests/application.spec.ts
+++ b/packages/server/src/api/routes/tests/application.spec.ts
@@ -151,7 +151,7 @@ describe("/applications", () => {
       const app = await config.api.application.create({
         name: utils.newid(),
         useTemplate: "true",
-        templateFile: "src/api/routes/tests/data/export.txt",
+        fileToImport: "src/api/routes/tests/data/export.txt",
       })
       expect(app._id).toBeDefined()
       expect(events.app.created).toHaveBeenCalledTimes(1)
@@ -171,7 +171,7 @@ describe("/applications", () => {
       const app = await config.api.application.create({
         name: utils.newid(),
         useTemplate: "true",
-        templateFile: "src/api/routes/tests/data/old-app.txt",
+        fileToImport: "src/api/routes/tests/data/old-app.txt",
       })
       expect(app._id).toBeDefined()
       expect(app.navigation).toBeDefined()

--- a/packages/server/src/api/routes/tests/templates.spec.ts
+++ b/packages/server/src/api/routes/tests/templates.spec.ts
@@ -95,7 +95,7 @@ describe("/templates", () => {
             const app = await config.api.application.create({
               name,
               url,
-              useTemplate: true,
+              useTemplate: "true",
               templateName: "Agency Client Portal",
               templateKey: "app/agency-client-portal",
             })

--- a/packages/server/src/api/routes/tests/templates.spec.ts
+++ b/packages/server/src/api/routes/tests/templates.spec.ts
@@ -95,7 +95,7 @@ describe("/templates", () => {
             const app = await config.api.application.create({
               name,
               url,
-              useTemplate: "true",
+              useTemplate: true,
               templateName: "Agency Client Portal",
               templateKey: "app/agency-client-portal",
             })

--- a/packages/server/src/api/routes/utils/validators.ts
+++ b/packages/server/src/api/routes/utils/validators.ts
@@ -355,9 +355,7 @@ export function applicationValidator(opts = { isCreate: true }) {
     _id: OPTIONAL_STRING,
     _rev: OPTIONAL_STRING,
     url: OPTIONAL_STRING,
-    template: Joi.object({
-      templateString: OPTIONAL_STRING,
-    }),
+    template: Joi.object({}),
   }
 
   const appNameValidator = Joi.string()
@@ -390,9 +388,7 @@ export function applicationValidator(opts = { isCreate: true }) {
       _rev: OPTIONAL_STRING,
       name: appNameValidator,
       url: OPTIONAL_STRING,
-      template: Joi.object({
-        templateString: OPTIONAL_STRING,
-      }).unknown(true),
+      template: Joi.object({}).unknown(true),
       snippets: snippetValidator,
     }).unknown(true)
   )

--- a/packages/server/src/tests/utilities/api/application.ts
+++ b/packages/server/src/tests/utilities/api/application.ts
@@ -17,8 +17,8 @@ export class ApplicationAPI extends TestAPI {
     app: CreateAppRequest,
     expectations?: Expectations
   ): Promise<App> => {
-    const files = app.templateFile ? { templateFile: app.templateFile } : {}
-    delete app.templateFile
+    const files = app.fileToImport ? { fileToImport: app.fileToImport } : {}
+    delete app.fileToImport
     return await this._post<App>("/api/applications", {
       fields: app,
       files,

--- a/packages/server/src/utilities/index.ts
+++ b/packages/server/src/utilities/index.ts
@@ -2,9 +2,6 @@ import env from "../environment"
 import { context } from "@budibase/backend-core"
 import { generateMetadataID } from "../db/utils"
 import { Document } from "@budibase/types"
-import stream from "stream"
-
-const Readable = stream.Readable
 
 export function wait(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -96,15 +93,6 @@ export function escapeDangerousCharacters(string: string) {
     .replace(/[\n]/g, "\\n")
     .replace(/[\r]/g, "\\r")
     .replace(/[\t]/g, "\\t")
-}
-
-export function stringToReadStream(string: string) {
-  return new Readable({
-    read() {
-      this.push(string)
-      this.push(null)
-    },
-  })
 }
 
 export function formatBytes(bytes: string) {

--- a/packages/types/src/api/web/application.ts
+++ b/packages/types/src/api/web/application.ts
@@ -4,7 +4,7 @@ import type { Layout, App, Screen } from "../../documents"
 export interface CreateAppRequest {
   name: string
   url?: string
-  useTemplate?: boolean
+  useTemplate?: string
   templateName?: string
   templateKey?: string
   fileToImport?: string

--- a/packages/types/src/api/web/application.ts
+++ b/packages/types/src/api/web/application.ts
@@ -7,7 +7,7 @@ export interface CreateAppRequest {
   useTemplate?: string
   templateName?: string
   templateKey?: string
-  templateFile?: string
+  fileToImport?: string
   encryptionPassword?: string
   file?: { path: string }
 }

--- a/packages/types/src/api/web/application.ts
+++ b/packages/types/src/api/web/application.ts
@@ -4,7 +4,7 @@ import type { Layout, App, Screen } from "../../documents"
 export interface CreateAppRequest {
   name: string
   url?: string
-  useTemplate?: string
+  useTemplate?: boolean
   templateName?: string
   templateKey?: string
   fileToImport?: string

--- a/packages/types/src/api/web/application.ts
+++ b/packages/types/src/api/web/application.ts
@@ -10,7 +10,6 @@ export interface CreateAppRequest {
   templateFile?: string
   includeSampleData?: boolean
   encryptionPassword?: string
-  templateString?: string
   file?: { path: string }
 }
 

--- a/packages/types/src/api/web/application.ts
+++ b/packages/types/src/api/web/application.ts
@@ -8,7 +8,6 @@ export interface CreateAppRequest {
   templateName?: string
   templateKey?: string
   templateFile?: string
-  includeSampleData?: boolean
   encryptionPassword?: string
   file?: { path: string }
 }


### PR DESCRIPTION
## Description
With the new templates containing user columns, we need a way to set valid values for it. Otherwise, the data will be trimmed on the way out, causing some unexpected behaviours on the template.

This PR ensures that when a new app comes from a template, the user column data will be defaulted to the creator of the app.

Also, updating multiple interface and typings that were not correct and misleading 

## Screenshoots
### Using the following data as a template
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/58c913bb-6564-46a2-9615-962ef595778b">



### Before, using that template, the user column was empty
<img width="1368" alt="image" src="https://github.com/user-attachments/assets/ff0a4a96-c2e7-4b50-b865-d79f46c17f80">

### After, the data gets populated with the user creator
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/444df27e-5af8-4586-8a14-c0131555cf77">

