### PR TITLE
Allow serving old apps on local dev

### DIFF
--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -83,7 +83,7 @@ function getPackageJsonFields(): {
   if (isDev() && !isTest()) {
     try {
       const lerna = getParentFile("lerna.json")
-      localVersion = lerna.version
+      localVersion = `${lerna.version}+local`
     } catch {
       //
     }

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -268,8 +268,8 @@ export const serveClientLibrary = async function (ctx: Ctx) {
     ctx.throw(400, "No app ID provided - cannot fetch client library.")
   }
 
-  const serverLocally = shouldServeLocally(version || "")
-  if (!serverLocally) {
+  const serveLocally = shouldServeLocally(version || "")
+  if (!serveLocally) {
     ctx.body = await objectStore.getReadStream(
       ObjectStoreBuckets.APPS,
       objectStore.clientLibraryPath(appId!)

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -2,11 +2,12 @@ import { InvalidFileExtensions } from "@budibase/shared-core"
 import AppComponent from "./templates/BudibaseApp.svelte"
 import { join } from "../../../utilities/centralPath"
 import * as uuid from "uuid"
-import { devClientVersion, ObjectStoreBuckets } from "../../../constants"
+import { ObjectStoreBuckets } from "../../../constants"
 import { processString } from "@budibase/string-templates"
 import {
   loadHandlebarsFile,
   NODE_MODULES_PATH,
+  shouldServeLocally,
   TOP_LEVEL_PATH,
 } from "../../../utilities/fileSystem"
 import env from "../../../environment"
@@ -257,25 +258,29 @@ export const serveBuilderPreview = async function (ctx: Ctx) {
 export const serveClientLibrary = async function (ctx: Ctx) {
   const version = ctx.request.query.version
 
+  if (Array.isArray(version)) {
+    ctx.throw(400)
+  }
+
   const appId = context.getAppId() || (ctx.request.query.appId as string)
   let rootPath = join(NODE_MODULES_PATH, "@budibase", "client", "dist")
   if (!appId) {
     ctx.throw(400, "No app ID provided - cannot fetch client library.")
   }
-  if (env.isProd() || (env.isDev() && version !== devClientVersion)) {
+
+  const serverLocally = shouldServeLocally(version || "")
+  if (!serverLocally) {
     ctx.body = await objectStore.getReadStream(
       ObjectStoreBuckets.APPS,
       objectStore.clientLibraryPath(appId!)
     )
     ctx.set("Content-Type", "application/javascript")
-  } else if (env.isDev() && version === devClientVersion) {
+  } else {
     // incase running from TS directly
     const tsPath = join(require.resolve("@budibase/client"), "..")
     return send(ctx, "budibase-client.js", {
       root: !fs.existsSync(rootPath) ? tsPath : rootPath,
     })
-  } else {
-    ctx.throw(500, "Unable to retrieve client library.")
   }
 }
 

--- a/packages/server/src/constants/index.ts
+++ b/packages/server/src/constants/index.ts
@@ -152,8 +152,6 @@ export enum AutomationErrors {
   FAILURE_CONDITION = "FAILURE_CONDITION_MET",
 }
 
-export const devClientVersion = "0.0.0"
-
 // pass through the list from the auth/core lib
 export const ObjectStoreBuckets = objectStore.ObjectStoreBuckets
 export const MAX_AUTOMATION_RECURRING_ERRORS = 5

--- a/packages/server/src/utilities/fileSystem/app.ts
+++ b/packages/server/src/utilities/fileSystem/app.ts
@@ -1,8 +1,8 @@
 import { budibaseTempDir } from "../budibaseDir"
 import fs from "fs"
 import { join } from "path"
-import { ObjectStoreBuckets, devClientVersion } from "../../constants"
-import { updateClientLibrary } from "./clientLibrary"
+import { ObjectStoreBuckets } from "../../constants"
+import { shouldServeLocally, updateClientLibrary } from "./clientLibrary"
 import env from "../../environment"
 import { objectStore, context } from "@budibase/backend-core"
 import { TOP_LEVEL_PATH } from "./filesystem"
@@ -40,7 +40,7 @@ export const getComponentLibraryManifest = async (library: string) => {
     const db = context.getAppDB()
     const app = await db.get<App>(DocumentType.APP_METADATA)
 
-    if (app.version === devClientVersion || env.isTest()) {
+    if (shouldServeLocally(app.version) || env.isTest()) {
       const paths = [
         join(TOP_LEVEL_PATH, "packages/client", filename),
         join(process.cwd(), "client", filename),

--- a/packages/server/src/utilities/fileSystem/clientLibrary.ts
+++ b/packages/server/src/utilities/fileSystem/clientLibrary.ts
@@ -1,3 +1,4 @@
+import semver from "semver"
 import path, { join } from "path"
 import { ObjectStoreBuckets } from "../../constants"
 import fs from "fs"
@@ -182,4 +183,20 @@ export async function revertClientLibrary(appId: string) {
   await Promise.all([manifestSrc, manifestUpload, clientUpload])
 
   return JSON.parse(await manifestSrc)
+}
+
+export function shouldServeLocally(version: string) {
+  if (env.isProd() || !env.isDev()) {
+    return false
+  }
+
+  if (version === "0.0.0") {
+    return true
+  }
+
+  const parsedSemver = semver.parse(version)
+  if (parsedSemver?.build?.[0] === "local") {
+    return true
+  }
+  return false
 }


### PR DESCRIPTION
## Description
For a while, when running locally we always used 0.0.0. This meant that we could not run the upgrade/downgrade system locally, and this was changed recently to use the latest version coming from the local `lerna.json` value.
This is now causing serving the client locally, as the server expects 0.0.0 to return the local client.

These changes are adding a `+local` flag to the prerelease locally, and we are serving the build one if this flag is found. We also return the local build if the version is 0.0.0 for backwards compatibility.
These checks also allow us to import production apps (or manually removing the `+local` tag) and to run with older versions locally.