### PR TITLE
Role validation - allow permissionId to be optional

### DIFF
--- a/packages/backend-core/src/security/permissions.ts
+++ b/packages/backend-core/src/security/permissions.ts
@@ -1,4 +1,8 @@
-import { PermissionLevel, PermissionType } from "@budibase/types"
+import {
+  PermissionLevel,
+  PermissionType,
+  BuiltinPermissionID,
+} from "@budibase/types"
 import flatten from "lodash/flatten"
 import cloneDeep from "lodash/fp/cloneDeep"
 
@@ -55,14 +59,6 @@ export function getAllowedLevels(userPermLevel: PermissionLevel): string[] {
     default:
       return []
   }
-}
-
-export enum BuiltinPermissionID {
-  PUBLIC = "public",
-  READ_ONLY = "read_only",
-  WRITE = "write",
-  ADMIN = "admin",
-  POWER = "power",
 }
 
 export const BUILTIN_PERMISSIONS: {

--- a/packages/backend-core/src/security/roles.ts
+++ b/packages/backend-core/src/security/roles.ts
@@ -1,5 +1,4 @@
 import semver from "semver"
-import { BuiltinPermissionID, PermissionLevel } from "./permissions"
 import {
   prefixRoleID,
   getRoleParams,
@@ -14,6 +13,8 @@ import {
   RoleUIMetadata,
   Database,
   App,
+  BuiltinPermissionID,
+  PermissionLevel,
 } from "@budibase/types"
 import cloneDeep from "lodash/fp/cloneDeep"
 import { RoleColor, helpers } from "@budibase/shared-core"
@@ -50,7 +51,7 @@ export class Role implements RoleDoc {
   _id: string
   _rev?: string
   name: string
-  permissionId: string
+  permissionId: BuiltinPermissionID
   inherits?: string | string[]
   version?: string
   permissions: Record<string, PermissionLevel[]> = {}
@@ -59,7 +60,7 @@ export class Role implements RoleDoc {
   constructor(
     id: string,
     name: string,
-    permissionId: string,
+    permissionId: BuiltinPermissionID,
     uiMetadata?: RoleUIMetadata
   ) {
     this._id = id

--- a/packages/backend-core/src/security/tests/permissions.spec.ts
+++ b/packages/backend-core/src/security/tests/permissions.spec.ts
@@ -1,6 +1,7 @@
 import cloneDeep from "lodash/cloneDeep"
 import * as permissions from "../permissions"
 import { BUILTIN_ROLE_IDS } from "../roles"
+import { BuiltinPermissionID } from "@budibase/types"
 
 describe("levelToNumber", () => {
   it("should return 0 for EXECUTE", () => {
@@ -77,7 +78,7 @@ describe("doesHaveBasePermission", () => {
     const rolesHierarchy = [
       {
         roleId: BUILTIN_ROLE_IDS.ADMIN,
-        permissionId: permissions.BuiltinPermissionID.ADMIN,
+        permissionId: BuiltinPermissionID.ADMIN,
       },
     ]
     expect(
@@ -91,7 +92,7 @@ describe("doesHaveBasePermission", () => {
     const rolesHierarchy = [
       {
         roleId: BUILTIN_ROLE_IDS.PUBLIC,
-        permissionId: permissions.BuiltinPermissionID.PUBLIC,
+        permissionId: BuiltinPermissionID.PUBLIC,
       },
     ]
     expect(
@@ -129,7 +130,7 @@ describe("getBuiltinPermissions", () => {
 describe("getBuiltinPermissionByID", () => {
   it("returns correct permission object for valid ID", () => {
     const expectedPermission = {
-      _id: permissions.BuiltinPermissionID.PUBLIC,
+      _id: BuiltinPermissionID.PUBLIC,
       name: "Public",
       permissions: [
         new permissions.Permission(

--- a/packages/server/src/api/controllers/role.ts
+++ b/packages/server/src/api/controllers/role.ts
@@ -137,6 +137,10 @@ export async function save(ctx: UserCtx<SaveRoleRequest, SaveRoleResponse>) {
     permissionId = PermissionLevel.WRITE
   }
 
+  if (!permissionId) {
+    ctx.throw(400, "Role requires permissionId to be specified.")
+  }
+
   const role = new roles.Role(_id, name, permissionId, {
     displayName: uiMetadata?.displayName || name,
     description: uiMetadata?.description || "Custom role",

--- a/packages/server/src/api/controllers/role.ts
+++ b/packages/server/src/api/controllers/role.ts
@@ -19,6 +19,7 @@ import {
   UserMetadata,
   DocumentType,
   PermissionLevel,
+  BuiltinPermissionID,
 } from "@budibase/types"
 import { RoleColor, sdk as sharedSdk, helpers } from "@budibase/shared-core"
 import sdk from "../../sdk"
@@ -134,7 +135,9 @@ export async function save(ctx: UserCtx<SaveRoleRequest, SaveRoleResponse>) {
   }
   // assume write permission level for newly created roles
   if (isCreate && !permissionId) {
-    permissionId = PermissionLevel.WRITE
+    permissionId = BuiltinPermissionID.WRITE
+  } else if (!permissionId && dbRole?.permissionId) {
+    permissionId = dbRole.permissionId
   }
 
   if (!permissionId) {

--- a/packages/server/src/api/controllers/role.ts
+++ b/packages/server/src/api/controllers/role.ts
@@ -18,7 +18,6 @@ import {
   UserCtx,
   UserMetadata,
   DocumentType,
-  PermissionLevel,
   BuiltinPermissionID,
 } from "@budibase/types"
 import { RoleColor, sdk as sharedSdk, helpers } from "@budibase/shared-core"

--- a/packages/server/src/api/routes/tests/application.spec.ts
+++ b/packages/server/src/api/routes/tests/application.spec.ts
@@ -16,7 +16,7 @@ import * as setup from "./utilities"
 import { AppStatus } from "../../../db/utils"
 import { events, utils, context, features } from "@budibase/backend-core"
 import env from "../../../environment"
-import { type App } from "@budibase/types"
+import { type App, BuiltinPermissionID } from "@budibase/types"
 import tk from "timekeeper"
 import * as uuid from "uuid"
 import { structures } from "@budibase/backend-core/tests"
@@ -80,7 +80,7 @@ describe("/applications", () => {
       const role = await config.api.roles.save({
         name: "Test",
         inherits: "PUBLIC",
-        permissionId: "read_only",
+        permissionId: BuiltinPermissionID.READ_ONLY,
         version: "name",
       })
 
@@ -112,7 +112,7 @@ describe("/applications", () => {
       const role = await config.api.roles.save({
         name: roleName,
         inherits: "PUBLIC",
-        permissionId: "read_only",
+        permissionId: BuiltinPermissionID.READ_ONLY,
         version: "name",
       })
 

--- a/packages/server/src/api/routes/tests/permissions.spec.ts
+++ b/packages/server/src/api/routes/tests/permissions.spec.ts
@@ -1,5 +1,12 @@
 import { roles } from "@budibase/backend-core"
-import { Document, PermissionLevel, Role, Row, Table } from "@budibase/types"
+import {
+  BuiltinPermissionID,
+  Document,
+  PermissionLevel,
+  Role,
+  Row,
+  Table,
+} from "@budibase/types"
 import * as setup from "./utilities"
 import { generator, mocks } from "@budibase/backend-core/tests"
 
@@ -304,7 +311,7 @@ describe("/permission", () => {
       role1 = await config.api.roles.save(
         {
           name: "test_1",
-          permissionId: PermissionLevel.WRITE,
+          permissionId: BuiltinPermissionID.WRITE,
           inherits: BUILTIN_ROLE_IDS.BASIC,
         },
         { status: 200 }
@@ -312,7 +319,7 @@ describe("/permission", () => {
       role2 = await config.api.roles.save(
         {
           name: "test_2",
-          permissionId: PermissionLevel.WRITE,
+          permissionId: BuiltinPermissionID.WRITE,
           inherits: BUILTIN_ROLE_IDS.BASIC,
         },
         { status: 200 }
@@ -345,7 +352,7 @@ describe("/permission", () => {
     it("should be able to fetch two tables, with different roles, using multi-inheritance", async () => {
       const role3 = await config.api.roles.save({
         name: "role3",
-        permissionId: PermissionLevel.WRITE,
+        permissionId: BuiltinPermissionID.WRITE,
         inherits: [role1._id!, role2._id!],
       })
 

--- a/packages/server/src/api/routes/tests/role.spec.ts
+++ b/packages/server/src/api/routes/tests/role.spec.ts
@@ -232,9 +232,7 @@ describe("/roles", () => {
       const customRoleFetched = res.find(r => r._id === customRole.name)
       expect(customRoleFetched).toBeDefined()
       expect(customRoleFetched!.inherits).toEqual(BUILTIN_ROLE_IDS.BASIC)
-      expect(customRoleFetched!.permissionId).toEqual(
-        BuiltinPermissionID.READ_ONLY
-      )
+      expect(customRoleFetched!.permissionId).toEqual(BuiltinPermissionID.WRITE)
     })
 
     it("should be able to get the role with a permission added", async () => {

--- a/packages/server/src/api/routes/tests/role.spec.ts
+++ b/packages/server/src/api/routes/tests/role.spec.ts
@@ -58,6 +58,19 @@ describe("/roles", () => {
       })
       expect(res.inherits).toEqual([BUILTIN_ROLE_IDS.BASIC])
     })
+
+    it("save role without permissionId", async () => {
+      const res = await config.api.roles.save(
+        {
+          ...basicRole(),
+          permissionId: undefined,
+        },
+        {
+          status: 200,
+        }
+      )
+      expect(res.permissionId).toEqual(PermissionLevel.WRITE)
+    })
   })
 
   describe("update", () => {

--- a/packages/server/src/api/routes/tests/role.spec.ts
+++ b/packages/server/src/api/routes/tests/role.spec.ts
@@ -200,7 +200,7 @@ describe("/roles", () => {
         ...res,
         permissionId: undefined,
       })
-      expect(updatedRes.permissionId).toEqual(PermissionLevel.READ)
+      expect(updatedRes.permissionId).toEqual(BuiltinPermissionID.READ_ONLY)
     })
   })
 

--- a/packages/server/src/api/routes/tests/screen.spec.ts
+++ b/packages/server/src/api/routes/tests/screen.spec.ts
@@ -1,7 +1,7 @@
 import { checkBuilderEndpoint } from "./utilities/TestFunctions"
 import * as setup from "./utilities"
 import { events, roles } from "@budibase/backend-core"
-import { Screen, PermissionLevel, Role } from "@budibase/types"
+import { Screen, Role, BuiltinPermissionID } from "@budibase/types"
 
 const { basicScreen } = setup.structures
 
@@ -40,17 +40,17 @@ describe("/screens", () => {
       role1 = await config.api.roles.save({
         name: "role1",
         inherits: roles.BUILTIN_ROLE_IDS.BASIC,
-        permissionId: PermissionLevel.WRITE,
+        permissionId: BuiltinPermissionID.WRITE,
       })
       role2 = await config.api.roles.save({
         name: "role2",
         inherits: roles.BUILTIN_ROLE_IDS.BASIC,
-        permissionId: PermissionLevel.WRITE,
+        permissionId: BuiltinPermissionID.WRITE,
       })
       multiRole = await config.api.roles.save({
         name: "multiRole",
         inherits: [role1._id!, role2._id!],
-        permissionId: PermissionLevel.WRITE,
+        permissionId: BuiltinPermissionID.WRITE,
       })
       screen1 = await config.api.screen.save(
         {

--- a/packages/server/src/api/routes/utils/validators.ts
+++ b/packages/server/src/api/routes/utils/validators.ts
@@ -8,6 +8,7 @@ import {
   SearchFilters,
   Table,
   WebhookActionType,
+  BuiltinPermissionID,
 } from "@budibase/types"
 import Joi, { CustomValidator } from "joi"
 import { ValidSnippetNameRegex, helpers } from "@budibase/shared-core"
@@ -214,7 +215,7 @@ export function roleValidator() {
       }).optional(),
       // this is the base permission ID (for now a built in)
       permissionId: Joi.string()
-        .valid(...Object.values(permissions.BuiltinPermissionID))
+        .valid(...Object.values(BuiltinPermissionID))
         .optional(),
       permissions: Joi.object()
         .pattern(

--- a/packages/server/src/api/routes/utils/validators.ts
+++ b/packages/server/src/api/routes/utils/validators.ts
@@ -215,7 +215,7 @@ export function roleValidator() {
       // this is the base permission ID (for now a built in)
       permissionId: Joi.string()
         .valid(...Object.values(permissions.BuiltinPermissionID))
-        .required(),
+        .optional(),
       permissions: Joi.object()
         .pattern(
           /.*/,

--- a/packages/server/src/tests/utilities/structures.ts
+++ b/packages/server/src/tests/utilities/structures.ts
@@ -1,4 +1,4 @@
-import { permissions, roles, utils } from "@budibase/backend-core"
+import { roles, utils } from "@budibase/backend-core"
 import { createHomeScreen } from "../../constants/screens"
 import { EMPTY_LAYOUT } from "../../constants/layouts"
 import { cloneDeep } from "lodash/fp"
@@ -33,6 +33,7 @@ import {
   TableSourceType,
   Webhook,
   WebhookActionType,
+  BuiltinPermissionID,
 } from "@budibase/types"
 import { LoopInput } from "../../definitions/automations"
 import { merge } from "lodash"
@@ -515,7 +516,7 @@ export function basicRole(): Role {
   return {
     name: `NewRole_${utils.newid()}`,
     inherits: roles.BUILTIN_ROLE_IDS.BASIC,
-    permissionId: permissions.BuiltinPermissionID.READ_ONLY,
+    permissionId: BuiltinPermissionID.WRITE,
     permissions: {},
     version: "name",
   }

--- a/packages/shared-core/src/helpers/tests/roles.spec.ts
+++ b/packages/shared-core/src/helpers/tests/roles.spec.ts
@@ -1,5 +1,5 @@
 import { checkForRoleInheritanceLoops } from "../roles"
-import { Role } from "@budibase/types"
+import { BuiltinPermissionID, Role } from "@budibase/types"
 
 /**
  * This unit test exists as this utility will be used in the frontend and backend, confirmation
@@ -19,7 +19,7 @@ function role(id: string, inherits: string | string[]): TestRole {
     _id: id,
     inherits: inherits,
     name: "ROLE",
-    permissionId: "PERMISSION",
+    permissionId: BuiltinPermissionID.WRITE,
     permissions: {}, // not needed for this test
   }
   allRoles.push(role)

--- a/packages/types/src/api/web/role.ts
+++ b/packages/types/src/api/web/role.ts
@@ -6,7 +6,7 @@ export interface SaveRoleRequest {
   _rev?: string
   name: string
   inherits?: string | string[]
-  permissionId: string
+  permissionId?: string
   permissions?: Record<string, PermissionLevel[]>
   version?: string
   uiMetadata?: RoleUIMetadata

--- a/packages/types/src/api/web/role.ts
+++ b/packages/types/src/api/web/role.ts
@@ -1,12 +1,12 @@
 import { Role, RoleUIMetadata } from "../../documents"
-import { PermissionLevel } from "../../sdk"
+import { PermissionLevel, BuiltinPermissionID } from "../../sdk"
 
 export interface SaveRoleRequest {
   _id?: string
   _rev?: string
   name: string
   inherits?: string | string[]
-  permissionId?: string
+  permissionId?: BuiltinPermissionID
   permissions?: Record<string, PermissionLevel[]>
   version?: string
   uiMetadata?: RoleUIMetadata

--- a/packages/types/src/documents/app/role.ts
+++ b/packages/types/src/documents/app/role.ts
@@ -1,5 +1,5 @@
 import { Document } from "../document"
-import { PermissionLevel } from "../../sdk"
+import { PermissionLevel, BuiltinPermissionID } from "../../sdk"
 
 export interface RoleUIMetadata {
   displayName?: string
@@ -8,7 +8,7 @@ export interface RoleUIMetadata {
 }
 
 export interface Role extends Document {
-  permissionId: string
+  permissionId: BuiltinPermissionID
   inherits?: string | string[]
   permissions: Record<string, PermissionLevel[]>
   version?: string

--- a/packages/types/src/sdk/permissions.ts
+++ b/packages/types/src/sdk/permissions.ts
@@ -5,6 +5,15 @@ export enum PermissionLevel {
   ADMIN = "admin",
 }
 
+// used within the role, specifies base permissions
+export enum BuiltinPermissionID {
+  PUBLIC = "public",
+  READ_ONLY = "read_only",
+  WRITE = "write",
+  ADMIN = "admin",
+  POWER = "power",
+}
+
 // these are the global types, that govern the underlying default behaviour
 export enum PermissionType {
   APP = "app",

--- a/packages/types/src/sdk/permissions.ts
+++ b/packages/types/src/sdk/permissions.ts
@@ -1,3 +1,5 @@
+// used in resource permissions - permissions can be at one of these levels
+// endpoints will set what type of permission they require (e.g. searching requires READ)
 export enum PermissionLevel {
   READ = "read",
   WRITE = "write",

--- a/packages/worker/src/api/routes/global/tests/roles.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/roles.spec.ts
@@ -1,6 +1,6 @@
 import { structures, TestConfiguration } from "../../../../tests"
-import { context, db, permissions, roles } from "@budibase/backend-core"
-import { App, Database } from "@budibase/types"
+import { context, db, roles } from "@budibase/backend-core"
+import { App, Database, BuiltinPermissionID } from "@budibase/types"
 
 jest.mock("@budibase/backend-core", () => {
   const core = jest.requireActual("@budibase/backend-core")
@@ -44,7 +44,7 @@ describe("/api/global/roles", () => {
   const role = new roles.Role(
     db.generateRoleID(ROLE_NAME),
     ROLE_NAME,
-    permissions.BuiltinPermissionID.READ_ONLY,
+    BuiltinPermissionID.READ_ONLY,
     { displayName: roles.BUILTIN_ROLE_IDS.BASIC }
   )
 


### PR DESCRIPTION
## Description
Frontend now expects to be able to supply role without a `permissionId`, this update makes it so that the validators allow this.

Added test cases for the behaviour - also realised the types in this area were pretty incorrect based on the validators, `permissionId` was just a `string` when it was actually typed, fixed this.
