### PR TITLE
Delete row actions when removing a datasource

### DIFF
--- a/packages/server/src/api/controllers/datasource.ts
+++ b/packages/server/src/api/controllers/datasource.ts
@@ -267,6 +267,8 @@ export async function destroy(ctx: UserCtx) {
   const datasource = await sdk.datasources.get(datasourceId)
   // Delete all queries for the datasource
 
+  await sdk.rowActions.deleteAllForDatasource(datasourceId)
+
   if (datasource.type === dbCore.BUDIBASE_DATASOURCE_TYPE) {
     await destroyInternalTablesBySourceId(datasourceId)
   } else {

--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -958,7 +958,7 @@ describe("/rowsActions", () => {
       // document was not being cleaned up. This meant there existed code paths
       // that would find it and try to reference the tables within it, resulting
       // in errors.
-      await config.api.automation.fetchEnriched({
+      await config.api.automation.fetch({
         status: 200,
       })
     })

--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -1,7 +1,11 @@
 import _ from "lodash"
 import tk from "timekeeper"
 
-import { context, roles } from "@budibase/backend-core"
+import {
+  context,
+  DEFAULT_BB_DATASOURCE_ID,
+  roles,
+} from "@budibase/backend-core"
 import { automations } from "@budibase/pro"
 import {
   CreateRowActionRequest,
@@ -967,6 +971,17 @@ describe("/rowsActions", () => {
     })
 
     it.each([
+      [
+        "internal",
+        async () => {
+          await config.api.application.addSampleData(config.getAppId())
+          const tables = await config.api.table.fetch()
+          const table = tables.find(
+            t => t.sourceId === DEFAULT_BB_DATASOURCE_ID
+          )!
+          return table
+        },
+      ],
       [
         "external",
         async () => {

--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -974,6 +974,7 @@ describe("/rowsActions", () => {
       [
         "internal",
         async () => {
+          await config.newTenant()
           await config.api.application.addSampleData(config.getAppId())
           const tables = await config.api.table.fetch()
           const table = tables.find(
@@ -985,6 +986,7 @@ describe("/rowsActions", () => {
       [
         "external",
         async () => {
+          await config.newTenant()
           const ds = await config.createDatasource({
             datasource: await getDatasource(DatabaseName.POSTGRES),
           })

--- a/packages/server/src/api/routes/tests/rowAction.spec.ts
+++ b/packages/server/src/api/routes/tests/rowAction.spec.ts
@@ -1,17 +1,20 @@
 import _ from "lodash"
 import tk from "timekeeper"
 
+import { context, roles } from "@budibase/backend-core"
+import { automations } from "@budibase/pro"
 import {
   CreateRowActionRequest,
   DocumentType,
   PermissionLevel,
   RowActionResponse,
+  TableRowActions,
 } from "@budibase/types"
 import * as setup from "./utilities"
 import { generator, mocks } from "@budibase/backend-core/tests"
 import { Expectations } from "../../../tests/utilities/api/base"
-import { roles } from "@budibase/backend-core"
-import { automations } from "@budibase/pro"
+import { DatabaseName, getDatasource } from "../../../integrations/tests/utils"
+import { generateRowActionsID } from "../../../db/utils"
 
 const expectAutomationId = () =>
   expect.stringMatching(`^${DocumentType.AUTOMATION}_.+`)
@@ -962,5 +965,57 @@ describe("/rowsActions", () => {
         status: 200,
       })
     })
+
+    it.each([
+      [
+        "external",
+        async () => {
+          const ds = await config.createDatasource({
+            datasource: await getDatasource(DatabaseName.POSTGRES),
+          })
+          const table = await config.api.table.save(
+            setup.structures.tableForDatasource(ds)
+          )
+          return table
+        },
+      ],
+    ])(
+      "should delete all the row actions (and automations) for its tables when a datasource is deleted",
+      async (_, getTable) => {
+        async function getRowActionsFromDb(tableId: string) {
+          return await context.doInAppContext(config.getAppId(), async () => {
+            const db = context.getAppDB()
+            const tableDoc = await db.tryGet<TableRowActions>(
+              generateRowActionsID(tableId)
+            )
+            return tableDoc
+          })
+        }
+
+        const table = await getTable()
+        const tableId = table._id!
+
+        await config.api.rowAction.save(tableId, {
+          name: generator.guid(),
+        })
+        await config.api.rowAction.save(tableId, {
+          name: generator.guid(),
+        })
+
+        const { actions } = (await getRowActionsFromDb(tableId))!
+        expect(Object.entries(actions)).toHaveLength(2)
+
+        const { automations } = await config.api.automation.fetch()
+        expect(automations).toHaveLength(2)
+
+        const datasource = await config.api.datasource.get(table.sourceId)
+        await config.api.datasource.delete(datasource)
+
+        const automationsResp = await config.api.automation.fetch()
+        expect(automationsResp.automations).toHaveLength(0)
+
+        expect(await getRowActionsFromDb(tableId)).toBeUndefined()
+      }
+    )
   })
 })

--- a/packages/server/src/sdk/app/rowActions/crud.ts
+++ b/packages/server/src/sdk/app/rowActions/crud.ts
@@ -7,11 +7,11 @@ import {
   User,
   VirtualDocumentType,
 } from "@budibase/types"
-import { generateRowActionsID } from "../../db/utils"
-import automations from "./automations"
-import { definitions as TRIGGER_DEFINITIONS } from "../../automations/triggerInfo"
-import * as triggers from "../../automations/triggers"
-import sdk from ".."
+import { generateRowActionsID } from "../../../db/utils"
+import automations from "../automations"
+import { definitions as TRIGGER_DEFINITIONS } from "../../../automations/triggerInfo"
+import * as triggers from "../../../automations/triggers"
+import sdk from "../.."
 
 async function ensureUniqueAndThrow(
   doc: TableRowActions,

--- a/packages/server/src/sdk/app/rowActions/index.ts
+++ b/packages/server/src/sdk/app/rowActions/index.ts
@@ -1,0 +1,1 @@
+export * from "./crud"

--- a/packages/server/src/sdk/app/rowActions/index.ts
+++ b/packages/server/src/sdk/app/rowActions/index.ts
@@ -1,1 +1,2 @@
 export * from "./crud"
+export * from "./utils"

--- a/packages/server/src/sdk/app/rowActions/utils.ts
+++ b/packages/server/src/sdk/app/rowActions/utils.ts
@@ -1,0 +1,9 @@
+import sdk from "../../../sdk"
+
+export async function deleteAllForDatasource(datasourceId: string) {
+  const allTables = await sdk.tables.getAllTables()
+  const tables = allTables.filter(t => t.sourceId === datasourceId)
+  for (const table of Object.values(tables)) {
+    await sdk.rowActions.deleteAll(table._id!)
+  }
+}

--- a/packages/server/src/tests/utilities/api/automation.ts
+++ b/packages/server/src/tests/utilities/api/automation.ts
@@ -23,17 +23,6 @@ export class AutomationAPI extends TestAPI {
     })
   }
 
-  fetchEnriched = async (
-    expectations?: Expectations
-  ): Promise<FetchAutomationResponse> => {
-    return await this._get<FetchAutomationResponse>(
-      `/api/automations?enrich=true`,
-      {
-        expectations,
-      }
-    )
-  }
-
   post = async (
     body: Automation,
     expectations?: Expectations


### PR DESCRIPTION
## Description
When deleting a table, we are currently deleting their related row actions and their automations. This PR ensures that the same happens when deleting a datasource, not leaving orphan row actions