### PR TITLE
Remove row actions when unfetching tables

### DIFF
--- a/packages/server/src/sdk/app/datasources/plus.ts
+++ b/packages/server/src/sdk/app/datasources/plus.ts
@@ -9,6 +9,7 @@ import * as datasources from "./datasources"
 import tableSdk from "../tables"
 import { getIntegration } from "../../../integrations"
 import { context } from "@budibase/backend-core"
+import sdk from "../.."
 
 function checkForSchemaErrors(schema: Record<string, Table>) {
   const errors: Record<string, string> = {}
@@ -96,6 +97,15 @@ export async function buildSchemaFromSource(
   const datasource = await datasources.get(datasourceId)
 
   const { tables, errors } = await buildFilteredSchema(datasource, tablesFilter)
+
+  const oldTables = datasource.entities || {}
+  const tablesToRemove = Object.keys(oldTables).filter(
+    t => !Object.keys(tables).includes(t)
+  )
+  for (const table of tablesToRemove) {
+    await sdk.rowActions.deleteAll(oldTables[table]._id!)
+  }
+
   datasource.entities = tables
 
   datasources.setDefaultDisplayColumns(datasource)


### PR DESCRIPTION
## Description
Similar to https://github.com/Budibase/budibase/pull/14859, we might have orphan row actions when some tables are "unfetched". This PR ensures that row actions are removed when a table has been indirectly removed.

<img width="662" alt="image" src="https://github.com/user-attachments/assets/39fb0da8-b812-4398-8d4d-a02d680aebd0">
