### PR TITLE
Missing old row on automations

### DIFF
--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -7,6 +7,7 @@ import * as internal from "./internal"
 import * as external from "./external"
 import { isExternalTableID } from "../../../integrations/utils"
 import {
+  AutomationEventType,
   Ctx,
   DeleteRow,
   DeleteRowRequest,
@@ -64,15 +65,15 @@ export async function patch(
       ctx.throw(404, "Row not found")
     }
     ctx.status = 200
-    ctx.eventEmitter &&
-      ctx.eventEmitter.emitRow({
-        eventName: `row:update`,
-        appId,
-        row,
-        table,
-        oldRow,
-        user: sdk.users.getUserContextBindings(ctx.user),
-      })
+
+    ctx.eventEmitter?.emitRow({
+      eventName: AutomationEventType.ROW_UPDATE,
+      appId,
+      row,
+      table,
+      oldRow,
+      user: sdk.users.getUserContextBindings(ctx.user),
+    })
     ctx.message = `${table.name} updated successfully.`
     ctx.body = row
     gridSocket?.emitRowUpdate(ctx, row)

--- a/packages/server/src/api/controllers/table/index.ts
+++ b/packages/server/src/api/controllers/table/index.ts
@@ -16,6 +16,7 @@ import {
   BulkImportResponse,
   CsvToJsonRequest,
   CsvToJsonResponse,
+  EventType,
   FetchTablesResponse,
   FieldType,
   MigrateRequest,
@@ -129,8 +130,7 @@ export async function save(ctx: UserCtx<SaveTableRequest, SaveTableResponse>) {
   }
   ctx.status = 200
   ctx.message = `Table ${table.name} saved successfully.`
-  ctx.eventEmitter &&
-    ctx.eventEmitter.emitTable(`table:save`, appId, { ...savedTable })
+  ctx.eventEmitter?.emitTable(EventType.TABLE_SAVE, appId, { ...savedTable })
   ctx.body = savedTable
 
   savedTable = await processTable(savedTable)
@@ -143,8 +143,8 @@ export async function destroy(ctx: UserCtx) {
   await sdk.rowActions.deleteAll(tableId)
   const deletedTable = await pickApi({ tableId }).destroy(ctx)
   await events.table.deleted(deletedTable)
-  ctx.eventEmitter &&
-    ctx.eventEmitter.emitTable(`table:delete`, appId, deletedTable)
+
+  ctx.eventEmitter?.emitTable(EventType.TABLE_DELETE, appId, deletedTable)
   ctx.status = 200
   ctx.table = deletedTable
   ctx.body = { message: `Table ${tableId} deleted.` }

--- a/packages/server/src/db/linkedRows/index.ts
+++ b/packages/server/src/db/linkedRows/index.ts
@@ -17,6 +17,7 @@ import {
 import { context, features } from "@budibase/backend-core"
 import {
   ContextUser,
+  EventType,
   FeatureFlag,
   FieldType,
   LinkDocumentValue,
@@ -44,15 +45,7 @@ const INVALID_DISPLAY_COLUMN_TYPE = [
  * This functionality makes sure that when rows with links are created, updated or deleted they are processed
  * correctly - making sure that no stale links are left around and that all links have been made successfully.
  */
-
-export const EventType = {
-  ROW_SAVE: "row:save",
-  ROW_UPDATE: "row:update",
-  ROW_DELETE: "row:delete",
-  TABLE_SAVE: "table:save",
-  TABLE_UPDATED: "table:updated",
-  TABLE_DELETE: "table:delete",
-}
+export { EventType } from "@budibase/types"
 
 function clearRelationshipFields(schema: TableSchema, rows: Row[]) {
   for (let [key, field] of Object.entries(schema)) {

--- a/packages/server/src/events/AutomationEmitter.ts
+++ b/packages/server/src/events/AutomationEmitter.ts
@@ -1,7 +1,15 @@
 import { rowEmission, tableEmission } from "./utils"
 import mainEmitter from "./index"
 import env from "../environment"
-import { Table, Row, DocumentType, App, ContextEmitter } from "@budibase/types"
+import {
+  Table,
+  Row,
+  DocumentType,
+  App,
+  ContextEmitter,
+  EventType,
+  UserBindings,
+} from "@budibase/types"
 import { context } from "@budibase/backend-core"
 
 const MAX_AUTOMATIONS_ALLOWED = 5
@@ -36,11 +44,15 @@ class AutomationEmitter implements ContextEmitter {
     appId,
     row,
     table,
+    oldRow,
+    user,
   }: {
-    eventName: string
+    eventName: EventType.ROW_SAVE | EventType.ROW_DELETE | EventType.ROW_UPDATE
     appId: string
     row: Row
     table?: Table
+    oldRow?: Row
+    user: UserBindings
   }) {
     let MAX_AUTOMATION_CHAIN = await this.getMaxAutomationChain()
 
@@ -54,7 +66,9 @@ class AutomationEmitter implements ContextEmitter {
       appId,
       row,
       table,
+      oldRow,
       metadata: this.metadata,
+      user,
     })
   }
 

--- a/packages/server/src/events/AutomationEmitter.ts
+++ b/packages/server/src/events/AutomationEmitter.ts
@@ -1,12 +1,12 @@
 import { rowEmission, tableEmission } from "./utils"
 import mainEmitter from "./index"
 import env from "../environment"
-import { Table, Row, DocumentType, App } from "@budibase/types"
+import { Table, Row, DocumentType, App, ContextEmitter } from "@budibase/types"
 import { context } from "@budibase/backend-core"
 
 const MAX_AUTOMATIONS_ALLOWED = 5
 
-class AutomationEmitter {
+class AutomationEmitter implements ContextEmitter {
   chainCount: number
   metadata: { automationChainCount: number }
 

--- a/packages/server/src/events/BudibaseEmitter.ts
+++ b/packages/server/src/events/BudibaseEmitter.ts
@@ -1,6 +1,12 @@
 import { EventEmitter } from "events"
 import { rowEmission, tableEmission } from "./utils"
-import { Table, Row, User } from "@budibase/types"
+import {
+  Table,
+  Row,
+  UserBindings,
+  EventType,
+  ContextEmitter,
+} from "@budibase/types"
 
 /**
  * keeping event emitter in one central location as it might be used for things other than
@@ -12,7 +18,7 @@ import { Table, Row, User } from "@budibase/types"
  * Extending the standard emitter to some syntactic sugar and standardisation to the emitted event.
  * This is specifically quite important for template strings used in automations.
  */
-class BudibaseEmitter extends EventEmitter {
+class BudibaseEmitter extends EventEmitter implements ContextEmitter {
   emitRow({
     eventName,
     appId,
@@ -21,17 +27,17 @@ class BudibaseEmitter extends EventEmitter {
     oldRow,
     user,
   }: {
-    eventName: string
+    eventName: EventType.ROW_SAVE | EventType.ROW_DELETE | EventType.ROW_UPDATE
     appId: string
     row: Row
     table?: Table
     oldRow?: Row
-    user: User
+    user: UserBindings
   }) {
     rowEmission({ emitter: this, eventName, appId, row, table, oldRow, user })
   }
 
-  emitTable(eventName: string, appId: string, table?: Table) {
+  emitTable(eventName: EventType, appId: string, table?: Table) {
     tableEmission({ emitter: this, eventName, appId, table })
   }
 

--- a/packages/server/src/events/utils.ts
+++ b/packages/server/src/events/utils.ts
@@ -1,4 +1,4 @@
-import { Table, Row, User } from "@budibase/types"
+import { Table, Row, UserBindings } from "@budibase/types"
 import BudibaseEmitter from "./BudibaseEmitter"
 
 type BBEventOpts = {
@@ -9,7 +9,7 @@ type BBEventOpts = {
   row?: Row
   oldRow?: Row
   metadata?: any
-  user?: User
+  user?: UserBindings
 }
 
 interface BBEventTable extends Table {
@@ -25,7 +25,7 @@ type BBEvent = {
   id?: string
   revision?: string
   metadata?: any
-  user?: User
+  user?: UserBindings
 }
 
 export function rowEmission({

--- a/packages/types/src/core/events.ts
+++ b/packages/types/src/core/events.ts
@@ -1,0 +1,8 @@
+export const enum EventType {
+  ROW_SAVE = "row:save",
+  ROW_UPDATE = "row:update",
+  ROW_DELETE = "row:delete",
+  TABLE_SAVE = "table:save",
+  TABLE_UPDATED = "table:updated",
+  TABLE_DELETE = "table:delete",
+}

--- a/packages/types/src/core/index.ts
+++ b/packages/types/src/core/index.ts
@@ -1,1 +1,2 @@
 export * from "./installation"
+export * from "./events"

--- a/packages/types/src/sdk/koa.ts
+++ b/packages/types/src/sdk/koa.ts
@@ -1,5 +1,14 @@
 import { Context, Request } from "koa"
-import { User, Role, UserRoles, Account, ConfigType } from "../documents"
+import {
+  User,
+  Role,
+  UserRoles,
+  Account,
+  ConfigType,
+  Row,
+  Table,
+  AutomationEventType,
+} from "../documents"
 import { FeatureFlag, License } from "../sdk"
 import { Files } from "formidable"
 
@@ -40,6 +49,7 @@ export interface UserCtx<RequestBody = any, ResponseBody = any>
   extends Ctx<RequestBody, ResponseBody> {
   user: ContextUser
   roleId?: string
+  eventEmitter?: ContextEmitter
 }
 
 /**
@@ -48,4 +58,13 @@ export interface UserCtx<RequestBody = any, ResponseBody = any>
  */
 export interface BBContext extends Ctx {
   user?: ContextUser
+}
+
+export interface ContextEmitter {
+  emitRow: (params: {
+    eventName: AutomationEventType
+    appId: string
+    row: Row
+    table?: Table
+  }) => Promise<void>
 }

--- a/packages/types/src/sdk/koa.ts
+++ b/packages/types/src/sdk/koa.ts
@@ -7,10 +7,11 @@ import {
   ConfigType,
   Row,
   Table,
-  AutomationEventType,
+  UserBindings,
 } from "../documents"
 import { FeatureFlag, License } from "../sdk"
 import { Files } from "formidable"
+import { EventType } from "../core"
 
 export interface ContextUser extends Omit<User, "roles"> {
   globalId?: string
@@ -61,10 +62,25 @@ export interface BBContext extends Ctx {
 }
 
 export interface ContextEmitter {
-  emitRow: (params: {
-    eventName: AutomationEventType
+  emitRow(values: {
+    eventName: EventType.ROW_SAVE
     appId: string
     row: Row
-    table?: Table
-  }) => Promise<void>
+    table: Table
+    user: UserBindings
+  }): void
+  emitRow(values: {
+    eventName: EventType.ROW_UPDATE
+    appId: string
+    row: Row
+    table: Table
+    oldRow: Row
+    user: UserBindings
+  }): void
+  emitRow(values: {
+    eventName: EventType.ROW_DELETE
+    appId: string
+    row: Row
+    user: UserBindings
+  }): void
 }

--- a/packages/types/src/sdk/koa.ts
+++ b/packages/types/src/sdk/koa.ts
@@ -83,4 +83,9 @@ export interface ContextEmitter {
     row: Row
     user: UserBindings
   }): void
+  emitTable(
+    eventName: EventType.TABLE_SAVE | EventType.TABLE_DELETE,
+    appId: string,
+    table?: Table
+  ): void
 }


### PR DESCRIPTION
## Description
We had an issue where some chained automations were not passing the proper data, missing some data such as "oldRow". The problem was that it was not properly sent, and while debugging the issue I realised that there is not much typing around automation emitters.
This PR is mainly typing everything around emitters to stop using magic strings, parameters and `any`s. It also fixes the actual issue, passing the `oldRow` accordingly.


<img width="1059" alt="image" src="https://github.com/user-attachments/assets/dd489710-1b27-4bed-8ed4-77057b317ed7">
