### PR TITLE
Add accountId to tenant_info

### DIFF
--- a/packages/types/src/documents/global/tenantInfo.ts
+++ b/packages/types/src/documents/global/tenantInfo.ts
@@ -11,5 +11,6 @@ export interface TenantInfo extends Document {
     budibaseUserId?: string
   }
   tenantId: string
+  accountId: string
   hosting: Hosting
 }

--- a/packages/worker/src/api/routes/global/tests/tenant.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/tenant.spec.ts
@@ -35,6 +35,7 @@ describe("/api/global/tenant", () => {
           familyName: "Doe",
           budibaseUserId: "USER_ID",
         },
+        accountId: "account_id",
         tenantId: "tenant123",
         hosting: Hosting.CLOUD,
       }


### PR DESCRIPTION
## Description
Adding accountId to the tenant_info doc, as this could be useful for calling back to account-portal.
While tenantId should suffice, it does no harm to have both. 

`tenant_info` is cloud only. 

Merge in after: https://github.com/Budibase/account-portal/pull/797

## Addresses
- https://linear.app/budibase/issue/GRO-739/make-sure-tenant-info-doc-exists-in-cloud-databases
