### PR TITLE
Open API - security update

### DIFF
--- a/packages/backend-core/src/context/identity.ts
+++ b/packages/backend-core/src/context/identity.ts
@@ -27,7 +27,7 @@ export function doInUserContext(user: User, ctx: Ctx, task: any) {
     hostInfo: {
       ipAddress: ctx.request.ip,
       // filled in by koa-useragent package
-      userAgent: ctx.userAgent._agent.source,
+      userAgent: ctx.userAgent.source,
     },
   }
   return doInIdentityContext(userContext, task)

--- a/packages/server/specs/generate.ts
+++ b/packages/server/specs/generate.ts
@@ -20,19 +20,15 @@ const options = {
       {
         url: "https://budibase.app/api/public/v1",
         description: "Budibase Cloud API",
-      },
-      {
-        url: "{protocol}://{hostname}/api/public/v1",
-        description: "Budibase self hosted API",
         variables: {
-          protocol: {
-            default: "http",
-            description:
-              "Whether HTTP or HTTPS should be used to communicate with your Budibase instance.",
+          apiKey: {
+            default: "<user API key>",
+            description: "The API key of the user to assume for API call.",
           },
-          hostname: {
-            default: "localhost:10000",
-            description: "The URL of your Budibase instance.",
+          appId: {
+            default: "<App ID>",
+            description:
+              "The ID of the app the calls will be executed within the context of, this should start with app_ (production) or app_dev (development).",
           },
         },
       },

--- a/packages/server/specs/openapi.json
+++ b/packages/server/specs/openapi.json
@@ -47,6 +47,7 @@
         "required": true,
         "description": "The ID of the app which this request is targeting.",
         "schema": {
+          "default": "{{ appId }}",
           "type": "string"
         }
       },
@@ -56,6 +57,7 @@
         "required": true,
         "description": "The ID of the app which this request is targeting.",
         "schema": {
+          "default": "{{ appId }}",
           "type": "string"
         }
       },

--- a/packages/server/specs/openapi.json
+++ b/packages/server/specs/openapi.json
@@ -8,19 +8,15 @@
   "servers": [
     {
       "url": "https://budibase.app/api/public/v1",
-      "description": "Budibase Cloud API"
-    },
-    {
-      "url": "{protocol}://{hostname}/api/public/v1",
-      "description": "Budibase self hosted API",
+      "description": "Budibase Cloud API",
       "variables": {
-        "protocol": {
-          "default": "http",
-          "description": "Whether HTTP or HTTPS should be used to communicate with your Budibase instance."
+        "apiKey": {
+          "default": "<user API key>",
+          "description": "The API key of the user to assume for API call."
         },
-        "hostname": {
-          "default": "localhost:10000",
-          "description": "The URL of your Budibase instance."
+        "appId": {
+          "default": "<App ID>",
+          "description": "The ID of the app the calls will be executed within the context of, this should start with app_ (production) or app_dev (development)."
         }
       }
     }
@@ -833,7 +829,8 @@
                       "type": "string",
                       "enum": [
                         "static",
-                        "dynamic"
+                        "dynamic",
+                        "ai"
                       ],
                       "description": "Defines whether this is a static or dynamic formula."
                     }
@@ -857,6 +854,7 @@
                         "link",
                         "formula",
                         "auto",
+                        "ai",
                         "json",
                         "internal",
                         "barcodeqr",
@@ -1042,7 +1040,8 @@
                           "type": "string",
                           "enum": [
                             "static",
-                            "dynamic"
+                            "dynamic",
+                            "ai"
                           ],
                           "description": "Defines whether this is a static or dynamic formula."
                         }
@@ -1066,6 +1065,7 @@
                             "link",
                             "formula",
                             "auto",
+                            "ai",
                             "json",
                             "internal",
                             "barcodeqr",
@@ -1262,7 +1262,8 @@
                             "type": "string",
                             "enum": [
                               "static",
-                              "dynamic"
+                              "dynamic",
+                              "ai"
                             ],
                             "description": "Defines whether this is a static or dynamic formula."
                           }
@@ -1286,6 +1287,7 @@
                               "link",
                               "formula",
                               "auto",
+                              "ai",
                               "json",
                               "internal",
                               "barcodeqr",

--- a/packages/server/specs/openapi.yaml
+++ b/packages/server/specs/openapi.yaml
@@ -36,6 +36,7 @@ components:
       required: true
       description: The ID of the app which this request is targeting.
       schema:
+        default: "{{ appId }}"
         type: string
     appIdUrl:
       in: path
@@ -43,6 +44,7 @@ components:
       required: true
       description: The ID of the app which this request is targeting.
       schema:
+        default: "{{ appId }}"
         type: string
     queryId:
       in: path

--- a/packages/server/specs/openapi.yaml
+++ b/packages/server/specs/openapi.yaml
@@ -6,16 +6,14 @@ info:
 servers:
   - url: https://budibase.app/api/public/v1
     description: Budibase Cloud API
-  - url: "{protocol}://{hostname}/api/public/v1"
-    description: Budibase self hosted API
     variables:
-      protocol:
-        default: http
-        description: Whether HTTP or HTTPS should be used to communicate with your
-          Budibase instance.
-      hostname:
-        default: localhost:10000
-        description: The URL of your Budibase instance.
+      apiKey:
+        default: <user API key>
+        description: The API key of the user to assume for API call.
+      appId:
+        default: <App ID>
+        description: The ID of the app the calls will be executed within the context of,
+          this should start with app_ (production) or app_dev (development).
 components:
   parameters:
     tableId:
@@ -761,6 +759,7 @@ components:
                     enum:
                       - static
                       - dynamic
+                      - ai
                     description: Defines whether this is a static or dynamic formula.
               - type: object
                 properties:
@@ -779,6 +778,7 @@ components:
                       - link
                       - formula
                       - auto
+                      - ai
                       - json
                       - internal
                       - barcodeqr
@@ -929,6 +929,7 @@ components:
                         enum:
                           - static
                           - dynamic
+                          - ai
                         description: Defines whether this is a static or dynamic formula.
                   - type: object
                     properties:
@@ -947,6 +948,7 @@ components:
                           - link
                           - formula
                           - auto
+                          - ai
                           - json
                           - internal
                           - barcodeqr
@@ -1104,6 +1106,7 @@ components:
                           enum:
                             - static
                             - dynamic
+                            - ai
                           description: Defines whether this is a static or dynamic formula.
                     - type: object
                       properties:
@@ -1122,6 +1125,7 @@ components:
                             - link
                             - formula
                             - auto
+                            - ai
                             - json
                             - internal
                             - barcodeqr

--- a/packages/server/specs/parameters.ts
+++ b/packages/server/specs/parameters.ts
@@ -24,6 +24,7 @@ export const appId = {
   required: true,
   description: "The ID of the app which this request is targeting.",
   schema: {
+    default: "{{ appId }}",
     type: "string",
   },
 }
@@ -34,6 +35,7 @@ export const appIdUrl = {
   required: true,
   description: "The ID of the app which this request is targeting.",
   schema: {
+    default: "{{ appId }}",
     type: "string",
   },
 }

--- a/packages/server/src/api/routes/public/tests/Request.ts
+++ b/packages/server/src/api/routes/public/tests/Request.ts
@@ -1,0 +1,110 @@
+import { User, Table, SearchFilters, Row } from "@budibase/types"
+import { HttpMethod, MakeRequestResponse, generateMakeRequest } from "./utils"
+import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
+import { Expectations } from "../../../../tests/utilities/api/base"
+
+type RequestOpts = { internal?: boolean; appId?: string }
+
+type PublicAPIExpectations = Omit<Expectations, "headers" | "headersNotPresent">
+
+export class PublicAPIRequest {
+  private makeRequest: MakeRequestResponse | undefined
+  private appId: string | undefined
+  private _tables: PublicTableAPI | undefined
+  private _rows: PublicRowAPI | undefined
+  private _apiKey: string | undefined
+
+  async init(config: TestConfiguration, user: User, opts?: RequestOpts) {
+    this._apiKey = await config.generateApiKey(user._id)
+    this.makeRequest = generateMakeRequest(this.apiKey, opts)
+    this.appId = opts?.appId
+    this._tables = new PublicTableAPI(this)
+    this._rows = new PublicRowAPI(this)
+    return this
+  }
+
+  opts(opts: RequestOpts) {
+    if (opts.appId) {
+      this.appId = opts.appId
+    }
+    this.makeRequest = generateMakeRequest(this.apiKey, opts)
+  }
+
+  async send(
+    method: HttpMethod,
+    endpoint: string,
+    body?: any,
+    expectations?: PublicAPIExpectations
+  ) {
+    if (!this.makeRequest) {
+      throw new Error("Init has not been called")
+    }
+    const res = await this.makeRequest(method, endpoint, body, this.appId)
+    if (expectations?.status) {
+      expect(res.status).toEqual(expectations.status)
+    }
+    if (expectations?.body) {
+      expect(res.body).toEqual(expectations?.body)
+    }
+    return res.body
+  }
+
+  get apiKey(): string {
+    if (!this._apiKey) {
+      throw new Error("Init has not been called")
+    }
+    return this._apiKey
+  }
+
+  get tables(): PublicTableAPI {
+    if (!this._tables) {
+      throw new Error("Init has not been called")
+    }
+    return this._tables
+  }
+
+  get rows(): PublicRowAPI {
+    if (!this._rows) {
+      throw new Error("Init has not been called")
+    }
+    return this._rows
+  }
+}
+
+export class PublicTableAPI {
+  request: PublicAPIRequest
+
+  constructor(request: PublicAPIRequest) {
+    this.request = request
+  }
+
+  async create(
+    table: Table,
+    expectations?: PublicAPIExpectations
+  ): Promise<{ data: Table }> {
+    return this.request.send("post", "/tables", table, expectations)
+  }
+}
+
+export class PublicRowAPI {
+  request: PublicAPIRequest
+
+  constructor(request: PublicAPIRequest) {
+    this.request = request
+  }
+
+  async search(
+    tableId: string,
+    query: SearchFilters,
+    expectations?: PublicAPIExpectations
+  ): Promise<{ data: Row[] }> {
+    return this.request.send(
+      "post",
+      `/tables/${tableId}/rows/search`,
+      {
+        query,
+      },
+      expectations
+    )
+  }
+}

--- a/packages/server/src/api/routes/public/tests/metrics.spec.ts
+++ b/packages/server/src/api/routes/public/tests/metrics.spec.ts
@@ -1,4 +1,4 @@
-const setup = require("../../tests/utilities")
+import * as setup from "../../tests/utilities"
 
 describe("/metrics", () => {
   let request = setup.getRequest()

--- a/packages/server/src/api/routes/public/tests/security.spec.ts
+++ b/packages/server/src/api/routes/public/tests/security.spec.ts
@@ -1,0 +1,74 @@
+import * as setup from "../../tests/utilities"
+import { roles } from "@budibase/backend-core"
+import { basicTable } from "../../../../tests/utilities/structures"
+import { Table, User } from "@budibase/types"
+import { PublicAPIRequest } from "./Request"
+
+const BROWSER_USER_AGENT =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36"
+
+describe("check public API security", () => {
+  const config = setup.getConfig()
+  let builderRequest: PublicAPIRequest,
+    appUserRequest: PublicAPIRequest,
+    table: Table,
+    appUser: User
+
+  beforeAll(async () => {
+    await config.init()
+    const builderUser = await config.globalUser()
+    appUser = await config.globalUser({
+      builder: { global: false },
+      roles: {
+        [config.getProdAppId()]: roles.BUILTIN_ROLE_IDS.BASIC,
+      },
+    })
+    builderRequest = await new PublicAPIRequest().init(config, builderUser)
+    appUserRequest = await new PublicAPIRequest().init(config, appUser)
+    table = (await builderRequest.tables.create(basicTable())).data
+  })
+
+  it("should allow with builder API key", async () => {
+    const res = await builderRequest.rows.search(
+      table._id!,
+      {},
+      {
+        status: 200,
+      }
+    )
+    expect(res.data.length).toEqual(0)
+  })
+
+  it("should 403 when from browser, but API key", async () => {
+    await appUserRequest.rows.search(
+      table._id!,
+      {},
+      {
+        status: 403,
+      }
+    )
+  })
+
+  it("should re-direct when using cookie", async () => {
+    const headers = await config.login({
+      userId: appUser._id!,
+      builder: false,
+      prodApp: false,
+    })
+    await config.withHeaders(
+      {
+        ...headers,
+        "User-Agent": BROWSER_USER_AGENT,
+      },
+      async () => {
+        await config.api.row.search(
+          table._id!,
+          { query: {} },
+          {
+            status: 302,
+          }
+        )
+      }
+    )
+  })
+})

--- a/packages/server/src/api/routes/public/tests/security.spec.ts
+++ b/packages/server/src/api/routes/public/tests/security.spec.ts
@@ -4,9 +4,6 @@ import { basicTable } from "../../../../tests/utilities/structures"
 import { Table, User } from "@budibase/types"
 import { PublicAPIRequest } from "./Request"
 
-const BROWSER_USER_AGENT =
-  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36"
-
 describe("check public API security", () => {
   const config = setup.getConfig()
   let builderRequest: PublicAPIRequest,
@@ -58,7 +55,7 @@ describe("check public API security", () => {
     await config.withHeaders(
       {
         ...headers,
-        "User-Agent": BROWSER_USER_AGENT,
+        "User-Agent": config.browserUserAgent(),
       },
       async () => {
         await config.api.row.search(

--- a/packages/server/src/definitions/openapi.ts
+++ b/packages/server/src/definitions/openapi.ts
@@ -257,7 +257,7 @@ export interface components {
                * @description Defines whether this is a static or dynamic formula.
                * @enum {string}
                */
-              formulaType?: "static" | "dynamic";
+              formulaType?: "static" | "dynamic" | "ai";
             }
           | {
               /**
@@ -277,11 +277,14 @@ export interface components {
                 | "link"
                 | "formula"
                 | "auto"
+                | "ai"
                 | "json"
                 | "internal"
                 | "barcodeqr"
+                | "signature_single"
                 | "bigint"
-                | "bb_reference";
+                | "bb_reference"
+                | "bb_reference_single";
               /** @description A constraint can be applied to the column which will be validated against when a row is saved. */
               constraints?: {
                 /** @enum {string} */
@@ -366,7 +369,7 @@ export interface components {
                  * @description Defines whether this is a static or dynamic formula.
                  * @enum {string}
                  */
-                formulaType?: "static" | "dynamic";
+                formulaType?: "static" | "dynamic" | "ai";
               }
             | {
                 /**
@@ -386,11 +389,14 @@ export interface components {
                   | "link"
                   | "formula"
                   | "auto"
+                  | "ai"
                   | "json"
                   | "internal"
                   | "barcodeqr"
+                  | "signature_single"
                   | "bigint"
-                  | "bb_reference";
+                  | "bb_reference"
+                  | "bb_reference_single";
                 /** @description A constraint can be applied to the column which will be validated against when a row is saved. */
                 constraints?: {
                   /** @enum {string} */
@@ -477,7 +483,7 @@ export interface components {
                  * @description Defines whether this is a static or dynamic formula.
                  * @enum {string}
                  */
-                formulaType?: "static" | "dynamic";
+                formulaType?: "static" | "dynamic" | "ai";
               }
             | {
                 /**
@@ -497,11 +503,14 @@ export interface components {
                   | "link"
                   | "formula"
                   | "auto"
+                  | "ai"
                   | "json"
                   | "internal"
                   | "barcodeqr"
+                  | "signature_single"
                   | "bigint"
-                  | "bb_reference";
+                  | "bb_reference"
+                  | "bb_reference_single";
                 /** @description A constraint can be applied to the column which will be validated against when a row is saved. */
                 constraints?: {
                   /** @enum {string} */

--- a/packages/server/src/middleware/currentapp.ts
+++ b/packages/server/src/middleware/currentapp.ts
@@ -10,7 +10,7 @@ import {
 import { generateUserMetadataID, isDevAppID } from "../db/utils"
 import { getCachedSelf } from "../utilities/global"
 import env from "../environment"
-import { isWebhookEndpoint } from "./utils"
+import { isWebhookEndpoint, isBrowser, isApiKey } from "./utils"
 import { UserCtx, ContextUser } from "@budibase/types"
 import tracer from "dd-trace"
 
@@ -27,7 +27,7 @@ export default async (ctx: UserCtx, next: any) => {
   }
 
   // deny access to application preview
-  if (!env.isTest()) {
+  if (isBrowser(ctx) && !isApiKey(ctx)) {
     if (
       isDevAppID(requestAppId) &&
       !isWebhookEndpoint(ctx) &&

--- a/packages/server/src/middleware/tests/currentapp.spec.ts
+++ b/packages/server/src/middleware/tests/currentapp.spec.ts
@@ -1,4 +1,6 @@
-require("../../db").init()
+import * as db from "../../db"
+
+db.init()
 mockAuthWithNoCookie()
 mockWorker()
 mockUserGroups()
@@ -45,7 +47,7 @@ function mockAuthWithNoCookie() {
       },
       cache: {
         user: {
-          getUser: async id => {
+          getUser: async () => {
             return {
               _id: "us_uuid1",
             }
@@ -82,7 +84,7 @@ function mockAuthWithCookie() {
       },
       cache: {
         user: {
-          getUser: async id => {
+          getUser: async () => {
             return {
               _id: "us_uuid1",
             }
@@ -94,6 +96,10 @@ function mockAuthWithCookie() {
 }
 
 class TestConfiguration {
+  next: jest.MockedFunction<any>
+  throw: jest.MockedFunction<any>
+  ctx: any
+
   constructor() {
     this.next = jest.fn()
     this.throw = jest.fn()
@@ -130,7 +136,7 @@ class TestConfiguration {
 }
 
 describe("Current app middleware", () => {
-  let config
+  let config: TestConfiguration
 
   beforeEach(() => {
     config = new TestConfiguration()
@@ -192,7 +198,7 @@ describe("Current app middleware", () => {
           },
           cache: {
             user: {
-              getUser: async id => {
+              getUser: async () => {
                 return {
                   _id: "us_uuid1",
                 }

--- a/packages/server/src/middleware/utils.ts
+++ b/packages/server/src/middleware/utils.ts
@@ -9,8 +9,8 @@ export function isWebhookEndpoint(ctx: UserCtx) {
 }
 
 export function isBrowser(ctx: UserCtx) {
-  const browser = ctx.userAgent.browser
-  return browser !== "unknown"
+  const browser = ctx.userAgent?.browser
+  return browser && browser !== "unknown"
 }
 
 export function isApiKey(ctx: UserCtx) {

--- a/packages/server/src/middleware/utils.ts
+++ b/packages/server/src/middleware/utils.ts
@@ -1,9 +1,18 @@
-import { BBContext } from "@budibase/types"
+import { LoginMethod, UserCtx } from "@budibase/types"
 
 const WEBHOOK_ENDPOINTS = new RegExp(
   ["webhooks/trigger", "webhooks/schema"].join("|")
 )
 
-export function isWebhookEndpoint(ctx: BBContext) {
+export function isWebhookEndpoint(ctx: UserCtx) {
   return WEBHOOK_ENDPOINTS.test(ctx.request.url)
+}
+
+export function isBrowser(ctx: UserCtx) {
+  const browser = ctx.userAgent.browser
+  return browser !== "unknown"
+}
+
+export function isApiKey(ctx: UserCtx) {
+  return ctx.loginMethod === LoginMethod.API_KEY
 }

--- a/packages/server/src/tests/utilities/TestConfiguration.ts
+++ b/packages/server/src/tests/utilities/TestConfiguration.ts
@@ -423,6 +423,7 @@ export default class TestConfiguration {
         Accept: "application/json",
         Cookie: [`${constants.Cookie.Auth}=${authToken}`],
         [constants.Header.APP_ID]: appId,
+        ...this.temporaryHeaders,
       }
     })
   }
@@ -525,6 +526,10 @@ export default class TestConfiguration {
     prodApp = true,
   } = {}) {
     return this.login({ userId: email, roleId, builder, prodApp })
+  }
+
+  browserUserAgent() {
+    return "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36"
   }
 
   // TENANCY

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -19,7 +19,8 @@
     "@types/koa": "2.13.4",
     "@types/redlock": "4.0.7",
     "rimraf": "3.0.2",
-    "typescript": "5.5.2"
+    "typescript": "5.5.2",
+    "koa-useragent": "^4.1.0"
   },
   "dependencies": {
     "scim-patch": "^0.8.1"

--- a/packages/types/src/sdk/koa.ts
+++ b/packages/types/src/sdk/koa.ts
@@ -2,6 +2,12 @@ import { Context, Request } from "koa"
 import { User, Role, UserRoles, Account, ConfigType } from "../documents"
 import { FeatureFlag, License } from "../sdk"
 import { Files } from "formidable"
+import { UserAgentContext } from "koa-useragent"
+
+export enum LoginMethod {
+  API_KEY = "api_key",
+  COOKIE = "cookie",
+}
 
 export interface ContextUser extends Omit<User, "roles"> {
   globalId?: string
@@ -31,6 +37,7 @@ export interface BBRequest<RequestBody> extends Request {
 export interface Ctx<RequestBody = any, ResponseBody = any> extends Context {
   request: BBRequest<RequestBody>
   body: ResponseBody
+  userAgent: UserAgentContext["userAgent"]
 }
 
 /**
@@ -40,6 +47,7 @@ export interface UserCtx<RequestBody = any, ResponseBody = any>
   extends Ctx<RequestBody, ResponseBody> {
   user: ContextUser
   roleId?: string
+  loginMethod?: LoginMethod
 }
 
 /**


### PR DESCRIPTION
## Description
@shogunpurple noticed there was an issue with using the public API to access development apps from non-builder roles, when this occurred the response was a re-direct as we expect in the browser, however this makes little sense in an API call.

I've updated the test cases a bit around the public API to make this a testable scenario, as well as updating `currentapp.ts` to 403 in these cases rather than a re-direct, by detecting it is using an API key.

I've also removed the `isTest` which was hiding this from our test cases and instead check if the call is coming from a browser.

Final small update is the OpenAPI spec was a little hard to use as you had to work out all the variables you needed, I've defaulted these so that when imported to tools that support OpenAPI specifications it shows all the variables listed with descriptions, making it a lot quicker to get up and running.
