### PR TITLE
Use account email instead of budibaseUserId

### DIFF
--- a/packages/backend-core/src/events/identification.ts
+++ b/packages/backend-core/src/events/identification.ts
@@ -171,9 +171,9 @@ const identifyUser = async (
   if (isSSOUser(user)) {
     providerType = user.providerType
   }
-  const accountHolder = account?.budibaseUserId === user._id || false
-  const verified =
-    account && account?.budibaseUserId === user._id ? account.verified : false
+  const accountHolder = await users.getExistingAccounts([user.email])
+  const isAccountHolder = accountHolder.length > 0
+  const verified = account && isAccountHolder ? account.verified : false
   const installationId = await getInstallationId()
   const hosting = account ? account.hosting : getHostingFromEnv()
   const environment = getDeploymentEnvironment()
@@ -185,7 +185,7 @@ const identifyUser = async (
     installationId,
     tenantId,
     verified,
-    accountHolder,
+    accountHolder: isAccountHolder,
     providerType,
     builder,
     admin,
@@ -207,9 +207,10 @@ const identifyAccount = async (account: Account) => {
   const environment = getDeploymentEnvironment()
 
   if (isCloudAccount(account)) {
-    if (account.budibaseUserId) {
+    const user = await users.getGlobalUserByEmail(account.email)
+    if (user?._id) {
       // use the budibase user as the id if set
-      id = account.budibaseUserId
+      id = user._id
     }
   }
 


### PR DESCRIPTION
## Description
Refactoring `identifyUser` code to use the email address of the account instead of the budibaseUserId

## Addresses
- https://linear.app/budibase/issue/GRO-738/refactor-code-that-returns-the-account-holder-from-user-id
