### PR TITLE
Revert "Write Redis data to the persistent data dir in single image."

### DIFF
--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -69,9 +69,6 @@ WORKDIR /minio
 COPY scripts/install-minio.sh ./install.sh
 RUN chmod +x install.sh && ./install.sh
 
-# setup redis
-COPY hosting/single/redis.conf /etc/redis/redis.conf
-
 # setup runner file
 WORKDIR /
 COPY hosting/single/runner.sh .

--- a/hosting/single/redis.conf
+++ b/hosting/single/redis.conf
@@ -1,7 +1,0 @@
-dir "DATA_DIR/redis"
-
-appendonly yes
-appendfsync everysec
-
-auto-aof-rewrite-percentage 100
-auto-aof-rewrite-min-size 64mb

--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -75,17 +75,13 @@ fi
 for LINE in $(cat ${DATA_DIR}/.env); do export $LINE; done
 ln -s ${DATA_DIR}/.env /app/.env
 ln -s ${DATA_DIR}/.env /worker/.env
-
 # make these directories in runner, incase of mount
 mkdir -p ${DATA_DIR}/minio
-mkdir -p ${DATA_DIR}/redis
 chown -R couchdb:couchdb ${DATA_DIR}/couch
-
-sed -i "s#DATA_DIR#${DATA_DIR}#g" /etc/redis/redis.conf
 if [[ -n "${REDIS_PASSWORD}" ]]; then
-  redis-server /etc/redis/redis.conf --requirepass $REDIS_PASSWORD > /dev/stdout 2>&1 &
+  redis-server --requirepass $REDIS_PASSWORD > /dev/stdout 2>&1 &
 else
-  redis-server /etc/redis/redis.conf > /dev/stdout 2>&1 &
+  redis-server > /dev/stdout 2>&1 &
 fi
 /bbcouch-runner.sh &
 


### PR DESCRIPTION
Reverts Budibase/budibase#14797

This causes the redis database to become corrupted when running under hosting that shares files for multiple instances (Eg: Google Cloud Run)