### PR TITLE
Improve users sort

### DIFF
--- a/packages/builder/src/pages/builder/portal/users/users/index.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/index.svelte
@@ -400,7 +400,7 @@
     allowSelectRows={!readonly}
     {customRenderers}
     loading={!$fetch.loaded || !groupsLoaded}
-    defaultSortColumn={"__selectable"}
+    defaultSortColumn={"access"}
   />
 
   <div class="pagination">


### PR DESCRIPTION
## Description
Have account holder and account admins at the top of the page. This is on a per page basis only.

## Screenshots
![Screenshot 2024-10-29 at 09 22 56](https://github.com/user-attachments/assets/0a30fffe-9079-48bf-a06f-c9b01299271c)

![Screenshot 2024-10-29 at 09 24 05](https://github.com/user-attachments/assets/d1261549-f30c-4bd0-b969-63f9913a13eb)
