### PR TITLE
Ai fixes

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/CronBuilder.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/CronBuilder.svelte
@@ -9,7 +9,7 @@
   } from "@budibase/bbui"
   import { onMount, createEventDispatcher } from "svelte"
   import { flags } from "stores/builder"
-  import { licensing } from "stores/portal"
+  import { featureFlags } from "stores/portal"
   import { API } from "api"
   import MagicWand from "../../../../assets/MagicWand.svelte"
 
@@ -26,8 +26,7 @@
   let aiCronPrompt = ""
   let loadingAICronExpression = false
 
-  $: aiEnabled =
-    $licensing.customAIConfigsEnabled || $licensing.budibaseAIEnabled
+  $: aiEnabled = $featureFlags.AI_CUSTOM_CONFIGS || $featureFlags.BUDIBASE_AI
   $: {
     if (cronExpression) {
       try {

--- a/packages/builder/src/components/backend/DataTable/formula.js
+++ b/packages/builder/src/components/backend/DataTable/formula.js
@@ -8,6 +8,7 @@ const MAX_DEPTH = 1
 
 const TYPES_TO_SKIP = [
   FieldType.FORMULA,
+  FieldType.AI,
   FieldType.LONGFORM,
   FieldType.SIGNATURE_SINGLE,
   FieldType.ATTACHMENTS,

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -26,7 +26,7 @@
   import { createEventDispatcher, getContext, onMount } from "svelte"
   import { cloneDeep } from "lodash/fp"
   import { tables, datasources } from "stores/builder"
-  import { licensing } from "stores/portal"
+  import { featureFlags } from "stores/portal"
   import { TableNames, UNEDITABLE_USER_FIELDS } from "constants"
   import {
     FIELDS,
@@ -101,8 +101,7 @@
   let optionsValid = true
 
   $: rowGoldenSample = RowUtils.generateGoldenSample($rows)
-  $: aiEnabled =
-    $licensing.customAIConfigsEnabled || $licensing.budibaseAIEnabled
+  $: aiEnabled = $featureFlags.BUDIBASE_AI || $featureFlags.AI_CUSTOM_CONFIGS
   $: if (primaryDisplay) {
     editableColumn.constraints.presence = { allowEmpty: false }
   }

--- a/packages/builder/src/components/design/settings/controls/Explanation/lines/Column.svelte
+++ b/packages/builder/src/components/design/settings/controls/Explanation/lines/Column.svelte
@@ -80,6 +80,9 @@
     if (columnType === FieldType.FORMULA) {
       return "https://docs.budibase.com/docs/formula"
     }
+    if (columnType === FieldType.AI) {
+      return "https://docs.budibase.com/docs/ai"
+    }
     if (columnType === FieldType.OPTIONS) {
       return "https://docs.budibase.com/docs/options"
     }

--- a/packages/builder/src/pages/builder/app/[application]/data/table/[tableId]/[viewId]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/table/[tableId]/[viewId]/index.svelte
@@ -1,6 +1,6 @@
 <script>
   import { viewsV2, rowActions } from "stores/builder"
-  import { admin, themeStore, licensing } from "stores/portal"
+  import { admin, themeStore, featureFlags } from "stores/portal"
   import { Grid } from "@budibase/frontend-core"
   import { API } from "api"
   import { notifications } from "@budibase/bbui"
@@ -53,7 +53,7 @@
   {buttons}
   allowAddRows
   allowDeleteRows
-  aiEnabled={$licensing.budibaseAIEnabled || $licensing.customAIConfigsEnabled}
+  aiEnabled={$featureFlags.BUDIBASE_AI || $featureFlags.AI_CUSTOM_CONFIGS}
   showAvatars={false}
   on:updatedatasource={handleGridViewUpdate}
   isCloud={$admin.cloud}

--- a/packages/builder/src/pages/builder/app/[application]/data/table/[tableId]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/table/[tableId]/index.svelte
@@ -8,7 +8,7 @@
     rowActions,
     roles,
   } from "stores/builder"
-  import { themeStore, admin, licensing, featureFlags } from "stores/portal"
+  import { themeStore, admin, featureFlags } from "stores/portal"
   import { TableNames } from "constants"
   import { Grid } from "@budibase/frontend-core"
   import { API } from "api"

--- a/packages/builder/src/pages/builder/app/[application]/data/table/[tableId]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/table/[tableId]/index.svelte
@@ -8,7 +8,7 @@
     rowActions,
     roles,
   } from "stores/builder"
-  import { themeStore, admin, licensing } from "stores/portal"
+  import { themeStore, admin, licensing, featureFlags } from "stores/portal"
   import { TableNames } from "constants"
   import { Grid } from "@budibase/frontend-core"
   import { API } from "api"
@@ -130,8 +130,7 @@
     schemaOverrides={isUsersTable ? userSchemaOverrides : null}
     showAvatars={false}
     isCloud={$admin.cloud}
-    aiEnabled={$licensing.budibaseAIEnabled ||
-      $licensing.customAIConfigsEnabled}
+    aiEnabled={$featureFlags.BUDIBASE_AI || $featureFlags.AI_CUSTOM_CONFIGS}
     {buttons}
     buttonsCollapsed
     on:updatedatasource={handleGridTableUpdate}

--- a/packages/builder/src/stores/portal/featureFlags.js
+++ b/packages/builder/src/stores/portal/featureFlags.js
@@ -4,6 +4,8 @@ import { auth } from "stores/portal"
 export const INITIAL_FEATUREFLAG_STATE = {
   SQS: false,
   DEFAULT_VALUES: false,
+  BUDIBASE_AI: false,
+  AI_CUSTOM_CONFIGS: false,
 }
 
 export const featureFlags = derived([auth], ([$auth]) => {

--- a/packages/server/src/api/controllers/table/tests/utils.spec.ts
+++ b/packages/server/src/api/controllers/table/tests/utils.spec.ts
@@ -1,4 +1,4 @@
-import { AutoFieldSubType, FieldType } from "@budibase/types"
+import { AIOperationEnum, AutoFieldSubType, FieldType } from "@budibase/types"
 import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
 import { importToRows } from "../utils"
 
@@ -90,6 +90,66 @@ describe("utils", () => {
 
         const result = await importToRows(data, table)
         expect(result).toHaveLength(3)
+      })
+    })
+
+    it("Imports write as expected with AI columns", async () => {
+      await config.doInContext(config.appId, async () => {
+        const table = await config.createTable({
+          name: "table",
+          type: "table",
+          schema: {
+            autoId: {
+              name: "autoId",
+              type: FieldType.NUMBER,
+              subtype: AutoFieldSubType.AUTO_ID,
+              autocolumn: true,
+              constraints: {
+                type: FieldType.NUMBER,
+                presence: true,
+              },
+            },
+            name: {
+              name: "name",
+              type: FieldType.STRING,
+              constraints: {
+                type: FieldType.STRING,
+                presence: true,
+              },
+            },
+            aicol: {
+              name: "aicol",
+              type: FieldType.AI,
+              operation: AIOperationEnum.PROMPT,
+              prompt: "Test prompt"
+            },
+          },
+        })
+
+        const data = [
+          { name: "Alice", aicol: "test" },
+          { name: "Bob", aicol: "test" },
+          { name: "Claire", aicol: "test" }
+        ]
+
+        const result = await importToRows(data, table, config.user?._id)
+        expect(result).toEqual([
+          expect.objectContaining({
+            autoId: 1,
+            name: "Alice",
+            aicol: "test",
+          }),
+          expect.objectContaining({
+            autoId: 2,
+            name: "Bob",
+            aicol: "test",
+          }),
+          expect.objectContaining({
+            autoId: 3,
+            name: "Claire",
+            aicol: "test",
+          }),
+        ])
       })
     })
   })

--- a/packages/server/src/api/controllers/table/tests/utils.spec.ts
+++ b/packages/server/src/api/controllers/table/tests/utils.spec.ts
@@ -121,7 +121,7 @@ describe("utils", () => {
               name: "aicol",
               type: FieldType.AI,
               operation: AIOperationEnum.PROMPT,
-              prompt: "Test prompt"
+              prompt: "Test prompt",
             },
           },
         })
@@ -129,7 +129,7 @@ describe("utils", () => {
         const data = [
           { name: "Alice", aicol: "test" },
           { name: "Bob", aicol: "test" },
-          { name: "Claire", aicol: "test" }
+          { name: "Claire", aicol: "test" },
         ]
 
         const result = await importToRows(data, table, config.user?._id)

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -2462,6 +2462,7 @@ describe.each([
           [FieldType.ATTACHMENT_SINGLE]: setup.structures.basicAttachment(),
           [FieldType.FORMULA]: undefined, // generated field
           [FieldType.AUTO]: undefined, // generated field
+          [FieldType.AI]: "LLM Output",
           [FieldType.JSON]: { name: generator.guid() },
           [FieldType.INTERNAL]: generator.guid(),
           [FieldType.BARCODEQR]: generator.guid(),
@@ -2493,6 +2494,7 @@ describe.each([
           }),
           [FieldType.FORMULA]: fullSchema[FieldType.FORMULA].formula,
           [FieldType.AUTO]: expect.any(Number),
+          [FieldType.AI]: expect.any(String),
           [FieldType.JSON]: rowValues[FieldType.JSON],
           [FieldType.INTERNAL]: rowValues[FieldType.INTERNAL],
           [FieldType.BARCODEQR]: rowValues[FieldType.BARCODEQR],
@@ -2565,7 +2567,7 @@ describe.each([
               expectedRowData["bb_reference_single"].sample,
               false
             ),
-            ai: null,
+            ai: "LLM Output",
           },
         ])
       })
@@ -2624,7 +2626,6 @@ describe.each([
           tableId: tableId,
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
-          ai: null,
         }
         expect(allRows).toEqual([expectedRow, expectedRow, expectedRow])
       })

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -2462,7 +2462,6 @@ describe.each([
           [FieldType.ATTACHMENT_SINGLE]: setup.structures.basicAttachment(),
           [FieldType.FORMULA]: undefined, // generated field
           [FieldType.AUTO]: undefined, // generated field
-          [FieldType.AI]: undefined, // generated field
           [FieldType.JSON]: { name: generator.guid() },
           [FieldType.INTERNAL]: generator.guid(),
           [FieldType.BARCODEQR]: generator.guid(),
@@ -2625,6 +2624,7 @@ describe.each([
           tableId: tableId,
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
+          ai: null,
         }
         expect(allRows).toEqual([expectedRow, expectedRow, expectedRow])
       })

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -216,10 +216,6 @@ export async function inputProcessing(
     if (field.type === FieldType.FORMULA) {
       delete clonedRow[key]
     }
-    // remove any AI values, they are to be generated
-    if (field.type === FieldType.AI) {
-      delete clonedRow[key]
-    }
     // otherwise coerce what is there to correct types
     else {
       clonedRow[key] = coerce(value, field.type)


### PR DESCRIPTION
## Description
Some fixes for the AI functionality for v3. Importing an AI field from a table import caused empty values to be written, and the AI column functionality was not correctly wired up to our posthog feature flagging system.

## Addresses
- https://linear.app/budibase/issue/BUDI-8786/bulk-importing-an-ai-field-does-not-work-also-overwrites-existing-data
- https://linear.app/budibase/issue/BUDI-8787/ai-columns-not-feature-flagged
