### PR TITLE
Nodemon config update

### DIFF
--- a/packages/server/nodemon.json
+++ b/packages/server/nodemon.json
@@ -8,6 +8,6 @@
     "../string-templates"
   ],
   "ext": "js,ts,json,svelte",
-  "ignore": ["**/*.spec.ts", "**/*.spec.js", "../*/dist/**/*"],
+  "ignore": ["**/*.spec.ts", "**/*.spec.js", "../*/dist/**/*", "client/**/*", "builder/**/*"],
   "exec": "yarn build && node --no-node-snapshot ./dist/index.js"
 }


### PR DESCRIPTION
## Description
Adding a change to nodemon configuration, this stops the services restarting twice when a build is triggered.