### PR TITLE
Conditions reactivity fix + row actions improvement

### DIFF
--- a/packages/client/src/components/Component.svelte
+++ b/packages/client/src/components/Component.svelte
@@ -554,7 +554,12 @@
       cachedSettings = { ...allSettings }
       initialSettings = cachedSettings
     } else {
-      Object.keys(allSettings).forEach(key => {
+      // We need to compare all keys from both the current and previous settings, as
+      // keys may have disappeared in the current set which would otherwise be ignored
+      // if we only checked the current set keys
+      const keys = new Set(Object.keys(allSettings))
+      Object.keys(cachedSettings).forEach(key => keys.add(key))
+      keys.forEach(key => {
         const same = propsAreSame(allSettings[key], cachedSettings[key])
         if (!same) {
           // Updated cachedSettings (which is assigned by reference to

--- a/packages/client/src/utils/buttonActions.js
+++ b/packages/client/src/utils/buttonActions.js
@@ -500,6 +500,10 @@ const rowActionHandler = async action => {
     sourceId: resourceId,
     rowId,
   })
+  // Refresh related datasources
+  await dataSourceStore.actions.invalidateDataSource(resourceId, {
+    invalidateRelationships: true,
+  })
 }
 
 const handlerMap = {


### PR DESCRIPTION
## Description
- Fixes an issue where component settings added then removed by conditions would fail to be reflected in components https://linear.app/budibase/issue/BUDI-8771/conditions-on-child-components-arent-updating-when-a-data-provider-is
- Automatically refreshes datasources after triggering row actions via button actions