### PR TITLE
Fix builder serve endpoint error rate

### DIFF
--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -6,7 +6,6 @@ import { ObjectStoreBuckets } from "../../../constants"
 import { processString } from "@budibase/string-templates"
 import {
   loadHandlebarsFile,
-  streamFile,
   NODE_MODULES_PATH,
   shouldServeLocally,
   TOP_LEVEL_PATH,
@@ -146,7 +145,7 @@ const requiresMigration = async (ctx: Ctx) => {
 }
 
 export const serveApp = async function (ctx: UserCtx) {
-  if (ctx.url.includes("apple-touch-icon")) {
+  if (ctx.url.includes("apple-touch-icon.png")) {
     ctx.redirect("/builder/bblogo.png")
     return
   }

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -6,6 +6,7 @@ import { ObjectStoreBuckets } from "../../../constants"
 import { processString } from "@budibase/string-templates"
 import {
   loadHandlebarsFile,
+  streamFile,
   NODE_MODULES_PATH,
   shouldServeLocally,
   TOP_LEVEL_PATH,
@@ -145,6 +146,16 @@ const requiresMigration = async (ctx: Ctx) => {
 }
 
 export const serveApp = async function (ctx: UserCtx) {
+  if (ctx.url.includes("apple-touch-icon")) {
+    ctx.redirect("/builder/bblogo.png")
+    return
+  }
+  // no app ID found, cannot serve - return message instead
+  if (!context.getAppId()) {
+    ctx.body = "No content found - requires app ID"
+    return
+  }
+
   const needMigrations = await requiresMigration(ctx)
 
   const bbHeaderEmbed =

--- a/packages/server/src/api/routes/tests/static.spec.ts
+++ b/packages/server/src/api/routes/tests/static.spec.ts
@@ -152,4 +152,22 @@ describe("/static", () => {
       expect(res.body.builderPreview).toBe(true)
     })
   })
+
+  describe("/", () => {
+    it("should move permanently from base call (public call)", async () => {
+      const res = await request.get(`/`)
+      expect(res.status).toEqual(301)
+      expect(res.text).toEqual(
+        `Redirecting to <a href="/builder">/builder</a>.`
+      )
+    })
+
+    it("should not error when trying to get 'apple-touch-icon.png' (public call)", async () => {
+      const res = await request.get(`/apple-touch-icon.png`)
+      expect(res.status).toEqual(302)
+      expect(res.text).toEqual(
+        `Redirecting to <a href="/builder/bblogo.png">/builder/bblogo.png</a>.`
+      )
+    })
+  })
 })

--- a/packages/server/src/sdk/app/applications/applications.ts
+++ b/packages/server/src/sdk/app/applications/applications.ts
@@ -25,10 +25,12 @@ export async function fetch(status: AppStatus, user: ContextUser) {
   const all = status === AppStatus.ALL
   let apps = (await dbCore.getAllApps({ dev, all })) as App[]
 
-  const enrichedUser = await groups.enrichUserRolesFromGroups({
+  // need to type this correctly - add roles back in to convert from ContextUser to User
+  const completeUser: User = {
     ...user,
-    roles: user.roles || {},
-  })
+    roles: user?.roles || {},
+  }
+  const enrichedUser = await groups.enrichUserRolesFromGroups(completeUser)
   apps = filterAppList(enrichedUser, apps)
 
   const appIds = apps


### PR DESCRIPTION
## Description
Fixing an issue with serving the builder, increased error rate due to requests that hit the / endpoint, these were 500ing due to a lack of app ID.