### PR TITLE
Allow fields on count calculations.

### DIFF
--- a/packages/backend-core/src/sql/sql.ts
+++ b/packages/backend-core/src/sql/sql.ts
@@ -1091,7 +1091,14 @@ class InternalBuilder {
             )
           }
         } else {
-          query = query.count(`* as ${aggregation.name}`)
+          if (this.client === SqlClient.ORACLE) {
+            const field = this.convertClobs(`${tableName}.${aggregation.field}`)
+            query = query.select(
+              this.knex.raw(`COUNT(??) as ??`, [field, aggregation.name])
+            )
+          } else {
+            query = query.count(`${aggregation.field} as ${aggregation.name}`)
+          }
         }
       } else {
         const fieldSchema = this.getFieldSchema(aggregation.field)

--- a/packages/server/src/api/controllers/view/viewsV2.ts
+++ b/packages/server/src/api/controllers/view/viewsV2.ts
@@ -12,6 +12,8 @@ import {
   RelationSchemaField,
   ViewFieldMetadata,
   CalculationType,
+  CountDistinctCalculationFieldMetadata,
+  CountCalculationFieldMetadata,
 } from "@budibase/types"
 import { builderSocket, gridSocket } from "../../../websockets"
 import { helpers } from "@budibase/shared-core"
@@ -22,27 +24,31 @@ function stripUnknownFields(
   if (helpers.views.isCalculationField(field)) {
     if (field.calculationType === CalculationType.COUNT) {
       if ("distinct" in field && field.distinct) {
-        return {
+        const strippedField: RequiredKeys<CountDistinctCalculationFieldMetadata> =
+          {
+            order: field.order,
+            width: field.width,
+            visible: field.visible,
+            readonly: field.readonly,
+            icon: field.icon,
+            distinct: field.distinct,
+            calculationType: field.calculationType,
+            field: field.field,
+            columns: field.columns,
+          }
+        return strippedField
+      } else {
+        const strippedField: RequiredKeys<CountCalculationFieldMetadata> = {
           order: field.order,
           width: field.width,
           visible: field.visible,
           readonly: field.readonly,
           icon: field.icon,
-          distinct: field.distinct,
           calculationType: field.calculationType,
           field: field.field,
           columns: field.columns,
         }
-      } else {
-        return {
-          order: field.order,
-          width: field.width,
-          visible: field.visible,
-          readonly: field.readonly,
-          icon: field.icon,
-          calculationType: field.calculationType,
-          columns: field.columns,
-        }
+        return strippedField
       }
     }
     const strippedField: RequiredKeys<ViewCalculationFieldMetadata> = {

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -693,6 +693,12 @@ describe.each([
                 calculationType: CalculationType.COUNT,
                 field: "Price",
               },
+              countDistinct: {
+                visible: true,
+                calculationType: CalculationType.COUNT,
+                distinct: true,
+                field: "Price",
+              },
               min: {
                 visible: true,
                 calculationType: CalculationType.MIN,
@@ -706,11 +712,6 @@ describe.each([
               avg: {
                 visible: true,
                 calculationType: CalculationType.AVG,
-                field: "Price",
-              },
-              sum2: {
-                visible: true,
-                calculationType: CalculationType.SUM,
                 field: "Price",
               },
             },
@@ -763,10 +764,12 @@ describe.each([
               count: {
                 visible: true,
                 calculationType: CalculationType.COUNT,
+                field: "Price",
               },
               count2: {
                 visible: true,
                 calculationType: CalculationType.COUNT,
+                field: "Price",
               },
             },
           },
@@ -774,7 +777,7 @@ describe.each([
             status: 400,
             body: {
               message:
-                'Duplicate calculation on field "*", calculation type "count"',
+                'Duplicate calculation on field "Price", calculation type "count"',
             },
           }
         )
@@ -805,7 +808,7 @@ describe.each([
             status: 400,
             body: {
               message:
-                'Duplicate calculation on field "Price", calculation type "count"',
+                'Duplicate calculation on field "Price", calculation type "count distinct"',
             },
           }
         )
@@ -820,12 +823,33 @@ describe.each([
             count: {
               visible: true,
               calculationType: CalculationType.COUNT,
+              field: "Price",
             },
             count2: {
               visible: true,
               calculationType: CalculationType.COUNT,
               distinct: true,
               field: "Price",
+            },
+          },
+        })
+      })
+
+      it("does not confuse counts on different fields in the duplicate check", async () => {
+        await config.api.viewV2.create({
+          tableId: table._id!,
+          name: generator.guid(),
+          type: ViewV2Type.CALCULATION,
+          schema: {
+            count: {
+              visible: true,
+              calculationType: CalculationType.COUNT,
+              field: "Price",
+            },
+            count2: {
+              visible: true,
+              calculationType: CalculationType.COUNT,
+              field: "Category",
             },
           },
         })
@@ -1607,6 +1631,7 @@ describe.each([
             view.schema!.count = {
               visible: true,
               calculationType: CalculationType.COUNT,
+              field: "age",
             }
             await config.api.viewV2.update(view)
 
@@ -3759,6 +3784,51 @@ describe.each([
 
               expect(rows).toHaveLength(1)
               expect(rows[0].sum).toEqual(55)
+            })
+
+            it("should be able to count non-numeric fields", async () => {
+              const table = await config.api.table.save(
+                saveTableRequest({
+                  schema: {
+                    firstName: {
+                      type: FieldType.STRING,
+                      name: "firstName",
+                    },
+                    lastName: {
+                      type: FieldType.STRING,
+                      name: "lastName",
+                    },
+                  },
+                })
+              )
+
+              const view = await config.api.viewV2.create({
+                tableId: table._id!,
+                name: generator.guid(),
+                type: ViewV2Type.CALCULATION,
+                schema: {
+                  count: {
+                    visible: true,
+                    calculationType: CalculationType.COUNT,
+                    field: "firstName",
+                  },
+                },
+              })
+
+              await config.api.row.bulkImport(table._id!, {
+                rows: [
+                  { firstName: "Jane", lastName: "Smith" },
+                  { firstName: "Jane", lastName: "Doe" },
+                  { firstName: "Alice", lastName: "Smith" },
+                ],
+              })
+
+              const { rows } = await config.api.viewV2.search(view.id, {
+                query: {},
+              })
+
+              expect(rows).toHaveLength(1)
+              expect(rows[0].count).toEqual(3)
             })
 
             it("should be able to filter rows on the view itself", async () => {

--- a/packages/server/src/sdk/app/rows/search/internal/sqs.ts
+++ b/packages/server/src/sdk/app/rows/search/internal/sqs.ts
@@ -351,6 +351,7 @@ export async function search(
           aggregations.push({
             name: key,
             calculationType: field.calculationType,
+            field: mapToUserColumn(field.field),
           })
         }
       } else {

--- a/packages/types/src/documents/app/view.ts
+++ b/packages/types/src/documents/app/view.ts
@@ -54,12 +54,12 @@ export interface NumericCalculationFieldMetadata
 
 export interface CountCalculationFieldMetadata extends BasicViewFieldMetadata {
   calculationType: CalculationType.COUNT
+  field: string
 }
 
 export interface CountDistinctCalculationFieldMetadata
   extends CountCalculationFieldMetadata {
   distinct: true
-  field: string
 }
 
 export type ViewCalculationFieldMetadata =

--- a/packages/types/src/sdk/row.ts
+++ b/packages/types/src/sdk/row.ts
@@ -18,11 +18,11 @@ export interface NumericAggregation extends BaseAggregation {
 
 export interface CountAggregation extends BaseAggregation {
   calculationType: CalculationType.COUNT
+  field: string
 }
 
 export interface CountDistinctAggregation extends CountAggregation {
   distinct: true
-  field: string
 }
 
 export type Aggregation =


### PR DESCRIPTION
## Description

Prior to this PR, calculation view "count" columns didn't take a `field`. They just assumed the field was `*`. This PR makes `field` required for counts, which allows you to count specific non-null values of a given column.
