### PR TITLE
Fix issue with branch step bindings

### DIFF
--- a/packages/server/src/automations/steps/branch.ts
+++ b/packages/server/src/automations/steps/branch.ts
@@ -39,9 +39,17 @@ export const definition: AutomationStepDefinition = {
         branchName: {
           type: AutomationIOType.STRING,
         },
-        result: {
+        status: {
+          type: AutomationIOType.STRING,
+          description: "Branch result",
+        },
+        branchId: {
+          type: AutomationIOType.STRING,
+          description: "Branch ID",
+        },
+        success: {
           type: AutomationIOType.BOOLEAN,
-          description: "Whether the condition was met",
+          description: "Branch success",
         },
       },
       required: ["output"],

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -516,6 +516,7 @@ class Orchestrator {
       const condition = await this.evaluateBranchCondition(branch.condition)
       if (condition) {
         const branchStatus = {
+          branchName: branch.name,
           status: `${branch.name} branch taken`,
           branchId: `${branch.id}`,
           success: true,
@@ -528,6 +529,7 @@ class Orchestrator {
           branchStatus
         )
         this.context.steps[this.context.steps.length] = branchStatus
+        this.context.stepsById[branchStep.id] = branchStatus
 
         const branchSteps = children?.[branch.id] || []
         // A final +1 to accomodate the branch step itself


### PR DESCRIPTION
## Description
The branch object wasn't being added to context correctly so adding a branch binding such as `branch.status` was not working. 
