### PR TITLE
Fix issue counting number of filters when legacy structure is used

### DIFF
--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterEditor.svelte
@@ -5,7 +5,6 @@
     Button,
     Drawer,
     DrawerContent,
-    Helpers,
   } from "@budibase/bbui"
   import { createEventDispatcher } from "svelte"
   import { getDatasourceForProvider, getSchemaForDatasource } from "dataBinding"


### PR DESCRIPTION
## Description
This PR fixes a visual issue where we displayed "No filters set" even when filters were set, if the legacy filter structure of a flat array was used (which would be the case for all existing apps prior to V3).

I've also removed a few extra `cloneDeep` usages which weren't needed as we clone inside the `CoreFilterBuilder` anyway, so these were just dupes hurting performance.

Before:
![image](https://github.com/user-attachments/assets/d64f2515-4fcd-4c51-98ec-d108c9b70a86)

After:
![image](https://github.com/user-attachments/assets/f0c2acba-6d50-4cfc-96fc-b3bdeb957105)

## Addresses
- Fixes https://github.com/Budibase/budibase/issues/14947