### PR TITLE
Disable major update from actions

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -13,7 +13,6 @@ on:
         options:
           - patch
           - minor
-          - major
         required: true
 
 jobs:


### PR DESCRIPTION
## Description
Remove the "major" option when releasing new versions. If we run a major version by mistake, we will not be able to roll back easily, so we are removing this option from the picker. If we need a v4 upgrade, we will add this option, but removing it is the safest.