### PR TITLE
Add USE_DEFAULT_REDIS_CONFIG environment variable to single image to disable our config customisations.

### DIFF
--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -81,11 +81,17 @@ mkdir -p ${DATA_DIR}/minio
 mkdir -p ${DATA_DIR}/redis
 chown -R couchdb:couchdb ${DATA_DIR}/couch
 
-sed -i "s#DATA_DIR#${DATA_DIR}#g" /etc/redis/redis.conf
+REDIS_CONFIG="/etc/redis/redis.conf"
+sed -i "s#DATA_DIR#${DATA_DIR}#g" "${REDIS_CONFIG}"
+
+if [[ -n "${USE_DEFAULT_REDIS_CONFIG}" ]]; then
+  REDIS_CONFIG=""
+fi
+
 if [[ -n "${REDIS_PASSWORD}" ]]; then
-  redis-server /etc/redis/redis.conf --requirepass $REDIS_PASSWORD > /dev/stdout 2>&1 &
+  redis-server "${REDIS_CONFIG}" --requirepass $REDIS_PASSWORD > /dev/stdout 2>&1 &
 else
-  redis-server /etc/redis/redis.conf > /dev/stdout 2>&1 &
+  redis-server "${REDIS_CONFIG}" > /dev/stdout 2>&1 &
 fi
 /bbcouch-runner.sh &
 


### PR DESCRIPTION
## Description

This is in response to https://github.com/Budibase/budibase/pull/14880. We don't want to totally disable Redis persistence because it performs an important function: stopping you getting logged out when you update or otherwise restart the Budibase single image.

But for people running in serverless environments, where you don't control how many runners run your container, this causes problems. Redis doesn't appear to like multiple processes writing to its append-only log, and gets into a corrupt state.