### PR TITLE
fix for conditional automation step options always showing

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -865,7 +865,7 @@
   <!-- Custom Layouts -->
   {#if stepLayouts[block.stepId]}
     {#each Object.keys(stepLayouts[block.stepId] || {}) as key}
-      {#if canShowField(key, stepLayouts[block.stepId].schema)}
+      {#if canShowField(stepLayouts[block.stepId].schema)}
         {#each stepLayouts[block.stepId][key].content as config}
           {#if config.title}
             <PropField label={config.title} labelTooltip={config.tooltip}>
@@ -890,7 +890,7 @@
   {:else}
     <!-- Default Schema Property Layout -->
     {#each schemaProperties as [key, value]}
-      {#if canShowField(key, value)}
+      {#if canShowField(value)}
         {@const label = getFieldLabel(key, value)}
         <div class:block-field={shouldRenderField(value)}>
           {#if key !== "fields" && value.type !== "boolean" && shouldRenderField(value)}
@@ -913,7 +913,7 @@
             </div>
           {/if}
           <div class:field-width={shouldRenderField(value)}>
-            {#if value.type === "string" && value.enum && canShowField(key, value)}
+            {#if value.type === "string" && value.enum && canShowField(value)}
               <Select
                 on:change={e => onChange({ [key]: e.detail })}
                 value={inputData[key]}


### PR DESCRIPTION
## Description
Automation step options that should conditionally render based on other settings are currently always showing. I think the only place this is used is the send email automation step where calendar invite options should be shown only when **Add calendar invite** is checked.

## Addresses
[BUDI-8820](https://linear.app/budibase/issue/BUDI-8820/conditional-automation-step-options-always-rendering-send-email)

## Screenshots
**before**
<img width="582" alt="SCR-20241105-kzny" src="https://github.com/user-attachments/assets/08fdeaf8-899c-4a45-9eb3-93d755e2357a">


**after**
<img width="566" alt="SCR-20241105-lbqe" src="https://github.com/user-attachments/assets/ed1fece6-9d3b-4709-9426-ec73e95574c2">


## Launchcontrol
fix for send email automation step settings
