### PR TITLE
prevent attachment column updates when importing budibase templates

### DIFF
--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -153,7 +153,11 @@ async function createInstance(appId: string, template: AppTemplate) {
   await createAllSearchIndex()
 
   if (template && template.useTemplate) {
-    await sdk.backups.importApp(appId, db, template)
+    const opts = {
+      importObjStoreContents: true,
+      updateAttachmentColumns: !template.key, // preserve attachments when using Budibase templates
+    }
+    await sdk.backups.importApp(appId, db, template, opts)
   } else {
     // create the users table
     await db.put(USERS_TABLE_SCHEMA)

--- a/packages/server/src/sdk/app/applications/import.ts
+++ b/packages/server/src/sdk/app/applications/import.ts
@@ -123,6 +123,7 @@ export async function updateWithExport(
     // don't need obj store, the existing app already has everything we need
     await backups.importApp(devId, tempDb, template, {
       importObjStoreContents: false,
+      updateAttachmentColumns: true,
     })
     const newMetadata = await getNewAppMetadata(tempDb, appDb)
     // get the documents to copy

--- a/packages/server/src/sdk/app/backups/imports.ts
+++ b/packages/server/src/sdk/app/backups/imports.ts
@@ -170,7 +170,10 @@ export async function importApp(
   appId: string,
   db: Database,
   template: TemplateType,
-  opts: { importObjStoreContents: boolean } = { importObjStoreContents: true }
+  opts: {
+    importObjStoreContents: boolean
+    updateAttachmentColumns?: boolean
+  } = { importObjStoreContents: true, updateAttachmentColumns: true }
 ) {
   let prodAppId = dbCore.getProdAppID(appId)
   let dbStream: any
@@ -219,7 +222,9 @@ export async function importApp(
   if (!ok) {
     throw "Error loading database dump from template."
   }
-  await updateAttachmentColumns(prodAppId, db)
+  if (opts.updateAttachmentColumns) {
+    await updateAttachmentColumns(prodAppId, db)
+  }
   await updateAutomations(prodAppId, db)
   // clear up afterward
   if (tmpPath) {

--- a/packages/server/src/sdk/app/backups/imports.ts
+++ b/packages/server/src/sdk/app/backups/imports.ts
@@ -172,7 +172,7 @@ export async function importApp(
   template: TemplateType,
   opts: {
     importObjStoreContents: boolean
-    updateAttachmentColumns?: boolean
+    updateAttachmentColumns: boolean
   } = { importObjStoreContents: true, updateAttachmentColumns: true }
 ) {
   let prodAppId = dbCore.getProdAppID(appId)


### PR DESCRIPTION
## Description
We want to be able to import apps from templates while preserving the attachment data from those template dbs. `updateAttachmentColumns` is great when importing an app with attachments from a file, but wrecks the attachment data in our templates which is always pointing to a public s3 bucket rather than the instance's own object storage

for example, an attachment in my template app db:
```json
"Image":{"size":604516,"name":"amsterdam.jpg","extension":"jpg","key":"amsterdam.jpg","url":"https://prod-budi-templates.s3.eu-west-1.amazonaws.com/attachments/expense-approval/amsterdam.jpg"}
```

gets completely stripped out by the above function. I've added in a flag to prevent it from running when we're importing from a template rather than a file (i.e. when `template.key` has a value)

## Launchcontrol
fix for attachments in budibase templates
