### PR TITLE
enable proxy buffering for calls to OIDC endpoints

### DIFF
--- a/hosting/proxy/nginx.prod.conf
+++ b/hosting/proxy/nginx.prod.conf
@@ -106,6 +106,12 @@ http {
 
     location ~ ^/api/(system|admin|global)/ {
       proxy_set_header    Host                $host;
+
+      # Enable buffering for potentially large OIDC configs
+      proxy_buffering on;
+      proxy_buffer_size 16k;
+      proxy_buffers 4 32k;
+
       proxy_pass      $worker;
     }
 


### PR DESCRIPTION
## Description
Sometimes OIDC responses are very heavy - lots of headers and big response bodies. This was causing an issue in our NGINX layer for MSFT AD.