### PR TITLE
Move dependency

### DIFF
--- a/packages/bbui/package.json
+++ b/packages/bbui/package.json
@@ -81,6 +81,7 @@
     "@spectrum-css/typography": "3.0.1",
     "@spectrum-css/underlay": "2.0.9",
     "@spectrum-css/vars": "3.0.1",
+    "atrament": "^4.3.0",
     "dayjs": "^1.10.8",
     "easymde": "^2.16.1",
     "svelte-dnd-action": "^0.9.8",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -33,8 +33,7 @@
     "sanitize-html": "^2.13.0",
     "screenfull": "^6.0.1",
     "shortid": "^2.2.15",
-    "svelte-spa-router": "^4.0.1",
-    "atrament": "^4.3.0"
+    "svelte-spa-router": "^4.0.1"
   },
   "devDependencies": {
     "@rollup/plugin-alias": "^5.1.0",


### PR DESCRIPTION
## Description
While working on detaching the account-portal from the monorepo, we got an issue with some missing dependencies. The `atrament` is referenced in bbui but not added in the package.json, so usages of bbui break if that package is not installed.
Moving the dependency to bbui fixes the issue