### PR TITLE
fix dnd handlers

### DIFF
--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -231,9 +231,6 @@ const environment = {
   MIN_VERSION_WITHOUT_POWER_ROLE:
     process.env.MIN_VERSION_WITHOUT_POWER_ROLE || "3.0.0",
   DISABLE_CONTENT_SECURITY_POLICY: process.env.DISABLE_CONTENT_SECURITY_POLICY,
-  // stopgap migration strategy until we can ensure backwards compat without unsafe-inline in CSP
-  DISABLE_CSP_UNSAFE_INLINE_SCRIPTS:
-    process.env.DISABLE_CSP_UNSAFE_INLINE_SCRIPTS,
 }
 
 export function setEnv(newEnvVars: Partial<typeof environment>): () => void {

--- a/packages/backend-core/src/middleware/contentSecurityPolicy.ts
+++ b/packages/backend-core/src/middleware/contentSecurityPolicy.ts
@@ -1,5 +1,4 @@
 import crypto from "crypto"
-import env from "../environment"
 
 const CSP_DIRECTIVES = {
   "default-src": ["'self'"],
@@ -96,10 +95,6 @@ export async function contentSecurityPolicy(ctx: any, next: any) {
       ...CSP_DIRECTIVES["script-src"],
       `'nonce-${nonce}'`,
     ]
-
-    if (!env.DISABLE_CSP_UNSAFE_INLINE_SCRIPTS) {
-      directives["script-src"].push("'unsafe-inline'")
-    }
 
     ctx.state.nonce = nonce
 

--- a/packages/builder/src/components/common/NavItem.svelte
+++ b/packages/builder/src/components/common/NavItem.svelte
@@ -84,8 +84,8 @@
   on:mouseleave
   on:click={onClick}
   on:contextmenu
-  ondragover="return false"
-  ondragenter="return false"
+  on:dragover={e => e.preventDefault()}
+  on:dragenter={e => e.preventDefault()}
   {id}
   {style}
   {draggable}

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ComponentList/ComponentScrollWrapper.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ComponentList/ComponentScrollWrapper.svelte
@@ -68,8 +68,8 @@
   on:scroll
   bind:this={scrollRef}
   on:drop={onDrop}
-  ondragover="return false"
-  ondragenter="return false"
+  on:dragover={e => e.preventDefault()}
+  on:dragenter={e => e.preventDefault()}
 >
   <slot />
 </div>


### PR DESCRIPTION
## Description
Fixing a problem with inline handlers and drag and drop in the builder. We were using a direct inline handler to prevent the default drag behaviour. I've updated this to use sveltes system so we don't trigger the CSP

We also no longer need the `unsafe-inline` script fallback, because it doesn't work with the nonce based system we have implemented.