### PR TITLE
Always use the current docker context.

### DIFF
--- a/packages/backend-core/tests/core/utilities/testContainerUtils.ts
+++ b/packages/backend-core/tests/core/utilities/testContainerUtils.ts
@@ -78,7 +78,34 @@ export function getExposedV4Port(container: ContainerInfo, port: number) {
   return getExposedV4Ports(container).find(x => x.container === port)?.host
 }
 
+interface DockerContext {
+  Name: string
+  Description: string
+  DockerEndpoint: string
+  ContextType: string
+  Error: string
+}
+
+function getCurrentDockerContext(): DockerContext {
+  const out = execSync("docker context ls --format json")
+  for (const line of out.toString().split("\n")) {
+    const parsed = JSON.parse(line)
+    if (parsed.Current) {
+      return parsed as DockerContext
+    }
+  }
+  throw new Error("No current Docker context")
+}
+
 export function setupEnv(...envs: any[]) {
+  // For whatever reason, testcontainers doesn't always use the correct current
+  // docker context. This bit of code forces the issue by finding the current
+  // context and setting it as the DOCKER_HOST environment
+  if (!process.env.DOCKER_HOST) {
+    const dockerContext = getCurrentDockerContext()
+    process.env.DOCKER_HOST = dockerContext.DockerEndpoint
+  }
+
   // We start couchdb in globalSetup.ts, in the root of the monorepo, so it
   // should be relatively safe to look for it by its image name.
   const couch = getContainerByImage("budibase/couchdb")

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -3329,7 +3329,7 @@ if (descriptions.length) {
               })
 
             isSql &&
-              describe("primaryDisplay", () => {
+              describe.only("primaryDisplay", () => {
                 beforeAll(async () => {
                   let toRelateTableId = await createTable({
                     name: {

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -3329,7 +3329,7 @@ if (descriptions.length) {
               })
 
             isSql &&
-              describe.only("primaryDisplay", () => {
+              describe("primaryDisplay", () => {
                 beforeAll(async () => {
                   let toRelateTableId = await createTable({
                     name: {


### PR DESCRIPTION
## Description

We discovered recently that if you have multiple Docker runtimes open at the same time, it's possible for the packages/server tests to pick one runtime during globalSetup.ts and the other one during the test runs. This results in the tests failing because CouchDB and minio have not been started in the Docker runtime the tests are using.

I was able to reproduce this locally, and setting `process.env.DOCKER_HOST` fixes it. `testcontainers` reads this environment variable when creating its Docker client.

I've duplicated the code between globalSetup.ts and testContainerUtils.ts because I don't want globalSetup.ts important from anything within Budibase in case it triggers `testcontainers` to generate its runtime config. It only does this once then caches it.