### PR TITLE
Enrich the datasource when not passing the datasource ID.

### DIFF
--- a/packages/server/src/sdk/app/rows/utils.ts
+++ b/packages/server/src/sdk/app/rows/utils.ts
@@ -96,7 +96,7 @@ export async function enrichQueryJson(
       })
     }
   } else {
-    datasource = json.endpoint.datasourceId
+    datasource = await sdk.datasources.enrich(json.endpoint.datasourceId)
   }
 
   let tables: Record<string, Table>


### PR DESCRIPTION
## Description
As title - issue with environment variables due to lack of enrichment - make sure the datasource is always enriched.