### PR TITLE
sort table names alphabetically when selecting data source

### DIFF
--- a/packages/builder/src/components/design/settings/controls/DataSourceSelect/DataSourceSelect.svelte
+++ b/packages/builder/src/components/design/settings/controls/DataSourceSelect/DataSourceSelect.svelte
@@ -52,9 +52,16 @@
   let modal
 
   $: text = value?.label ?? "Choose an option"
-  $: tables = $tablesStore.list.map(table =>
-    format.table(table, $datasources.list)
-  )
+  $: tables = $tablesStore.list
+    .map(table => format.table(table, $datasources.list))
+    .sort((a, b) => {
+      // sort tables alphabetically, grouped by datasource
+      const dsComparison = a.datasourceName.localeCompare(b.datasourceName)
+      if (dsComparison !== 0) {
+        return dsComparison
+      }
+      return a.label.localeCompare(b.label)
+    })
   $: viewsV1 = $viewsStore.list.map(view => ({
     ...view,
     label: view.name,


### PR DESCRIPTION
## Description
Currently, tables are not sorted alphabetically when selecting a data source for a data provider. I think for Budibase DB, they're just sorted alphabetically by table id.

thanks to @poirazis for suggesting this fix

![image](https://github.com/user-attachments/assets/1c08fcc2-dbbd-4c6c-86e3-f90290c83c00)


## Addresses
https://discord.com/channels/733030666647765003/1014909112565379163/1313456575608000563

## Before
<img width="810" alt="SCR-20241203-luxz" src="https://github.com/user-attachments/assets/8025483a-910e-42b6-831a-dc0acd9271a5">


## After
<img width="810" alt="SCR-20241203-lxfv" src="https://github.com/user-attachments/assets/fab83da8-7f74-4644-b17f-a0d4f8cc078b">


## Launchcontrol
sort table names alphabetically when selecting data source
