### PR TITLE
adding buffer settings for single image

### DIFF
--- a/hosting/single/nginx/nginx-default-site.conf
+++ b/hosting/single/nginx/nginx-default-site.conf
@@ -46,6 +46,11 @@ server {
     }
 
     location ~ ^/api/(system|admin|global)/ {
+        # Enable buffering for potentially large OIDC configs
+        proxy_buffering on;
+        proxy_buffer_size 16k;
+        proxy_buffers 4 32k;
+
         proxy_pass      http://127.0.0.1:4002;
     }
 


### PR DESCRIPTION
## Description
Forgot to add the proxy buffer configuration to the single image NGINX after microsoft updated their OIDC payload.

## Addresses
- https://linear.app/budibase/issue/BUDI-8893/single-image-nginxconf-enable-proxy-buffering-for-calls-to-oidc

## Launchcontrol

Adding proxy buffer configuration for single image
