### PR TITLE
prevent empty snippets being saved, don't crash for old empty snippets

### DIFF
--- a/packages/builder/src/components/common/bindings/SnippetDrawer.svelte
+++ b/packages/builder/src/components/common/bindings/SnippetDrawer.svelte
@@ -63,7 +63,7 @@
     if (!name?.length) {
       return "Name is required"
     }
-    if (snippets.some(snippet => snippet.name === name)) {
+    if (!snippet?.name && snippets.some(snippet => snippet.name === name)) {
       return "That name is already in use"
     }
     if (firstCharNumberRegex.test(name)) {
@@ -106,11 +106,7 @@
         Delete
       </Button>
     {/if}
-    <Button
-      cta
-      on:click={saveSnippet}
-      disabled={!snippet && (loading || nameError)}
-    >
+    <Button cta on:click={saveSnippet} disabled={!code || loading || nameError}>
       Save
     </Button>
   </svelte:fragment>

--- a/packages/builder/src/components/common/bindings/SnippetSidePanel.svelte
+++ b/packages/builder/src/components/common/bindings/SnippetSidePanel.svelte
@@ -186,7 +186,7 @@
   <div class="snippet-popover">
     {#key hoveredSnippet}
       <CodeEditor
-        value={hoveredSnippet.code.trim()}
+        value={hoveredSnippet.code?.trim()}
         mode={EditorModes.JS}
         readonly
       />


### PR DESCRIPTION
## Description
Fixes some issues with snippets:
- Prevents saving of empty snippets
- Prevents the builder crashing from empty snippets saved before this
- Fixes name validation - it was causing an error when you tried to edit an existing snippet because the name existed

## Addresses
- https://github.com/Budibase/budibase/issues/15113

## Launchcontrol

Fix issues with snippets crashing builder UI
