### PR TITLE
rely on llm status rather than initialised variable

### DIFF
--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -48,7 +48,7 @@ jest.mock("@budibase/pro", () => ({
   ai: {
     LargeLanguageModel: {
       forCurrentTenant: async () => ({
-        initialised: true,
+        llm: {},
         run: jest.fn(() => `Mock LLM Response`),
         buildPromptFromAIOperation: jest.fn(),
       }),

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -52,7 +52,7 @@ jest.mock("@budibase/pro", () => ({
   ai: {
     LargeLanguageModel: {
       forCurrentTenant: async () => ({
-        initialised: true,
+        llm: {},
         run: jest.fn(() => `Mock LLM Response`),
         buildPromptFromAIOperation: jest.fn(),
       }),

--- a/packages/server/src/automations/steps/openai.ts
+++ b/packages/server/src/automations/steps/openai.ts
@@ -108,7 +108,9 @@ export async function run({
 
     let llmWrapper
     if (budibaseAIEnabled || customConfigsEnabled) {
-      llmWrapper = await pro.ai.LargeLanguageModel.forCurrentTenant(inputs.model)
+      llmWrapper = await pro.ai.LargeLanguageModel.forCurrentTenant(
+        inputs.model
+      )
     }
 
     response = llmWrapper?.llm

--- a/packages/server/src/automations/steps/openai.ts
+++ b/packages/server/src/automations/steps/openai.ts
@@ -106,13 +106,13 @@ export async function run({
       (await features.flags.isEnabled(FeatureFlag.BUDIBASE_AI)) &&
       (await pro.features.isBudibaseAIEnabled())
 
-    let llm
+    let llmWrapper
     if (budibaseAIEnabled || customConfigsEnabled) {
-      llm = await pro.ai.LargeLanguageModel.forCurrentTenant(inputs.model)
+      llmWrapper = await pro.ai.LargeLanguageModel.forCurrentTenant(inputs.model)
     }
 
-    response = llm?.initialised
-      ? await llm.run(inputs.prompt)
+    response = llmWrapper?.llm
+      ? await llmWrapper.run(inputs.prompt)
       : await legacyOpenAIPrompt(inputs)
 
     return {

--- a/packages/server/src/automations/tests/openai.spec.ts
+++ b/packages/server/src/automations/tests/openai.spec.ts
@@ -27,7 +27,7 @@ jest.mock("@budibase/pro", () => ({
   ai: {
     LargeLanguageModel: {
       forCurrentTenant: jest.fn().mockImplementation(() => ({
-        initialised: true,
+        llm: {},
         init: jest.fn(),
         run: jest.fn(),
       })),

--- a/packages/server/src/utilities/rowProcessor/tests/utils.spec.ts
+++ b/packages/server/src/utilities/rowProcessor/tests/utils.spec.ts
@@ -18,7 +18,7 @@ jest.mock("@budibase/pro", () => ({
   ai: {
     LargeLanguageModel: {
       forCurrentTenant: async () => ({
-        initialised: true,
+        llm: {},
         run: jest.fn(() => "response from LLM"),
         buildPromptFromAIOperation: buildPromptMock,
       }),

--- a/packages/server/src/utilities/rowProcessor/utils.ts
+++ b/packages/server/src/utilities/rowProcessor/utils.ts
@@ -126,8 +126,8 @@ export async function processAIColumns<T extends Row | Row[]>(
     const numRows = Array.isArray(inputRows) ? inputRows.length : 1
     span?.addTags({ table_id: table._id, numRows })
     const rows = Array.isArray(inputRows) ? inputRows : [inputRows]
-    const llm = await pro.ai.LargeLanguageModel.forCurrentTenant("gpt-4o-mini")
-    if (rows && llm.initialised) {
+    const llmWrapper = await pro.ai.LargeLanguageModel.forCurrentTenant("gpt-4o-mini")
+    if (rows && llmWrapper.llm) {
       // Ensure we have snippet context
       await context.ensureSnippetContext()
 

--- a/packages/server/src/utilities/rowProcessor/utils.ts
+++ b/packages/server/src/utilities/rowProcessor/utils.ts
@@ -126,7 +126,9 @@ export async function processAIColumns<T extends Row | Row[]>(
     const numRows = Array.isArray(inputRows) ? inputRows.length : 1
     span?.addTags({ table_id: table._id, numRows })
     const rows = Array.isArray(inputRows) ? inputRows : [inputRows]
-    const llmWrapper = await pro.ai.LargeLanguageModel.forCurrentTenant("gpt-4o-mini")
+    const llmWrapper = await pro.ai.LargeLanguageModel.forCurrentTenant(
+      "gpt-4o-mini"
+    )
     if (rows && llmWrapper.llm) {
       // Ensure we have snippet context
       await context.ensureSnippetContext()
@@ -151,14 +153,14 @@ export async function processAIColumns<T extends Row | Row[]>(
             }
           }
 
-          const prompt = llm.buildPromptFromAIOperation({
+          const prompt = llmWrapper.buildPromptFromAIOperation({
             schema: aiSchema,
             row,
           })
 
           return tracer.trace("processAIColumn", {}, async span => {
             span?.addTags({ table_id: table._id, column })
-            const llmResponse = await llm.run(prompt!)
+            const llmResponse = await llmWrapper.run(prompt!)
             return {
               ...row,
               [column]: llmResponse,


### PR DESCRIPTION
## Description
Update LLM code to use the `llm` attribute on the `LargeLanguageModel` wrapper, rather than an `initialised` variable that wasn't needed