### PR TITLE
Add automation survey popup

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/automation/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/automation/_layout.svelte
@@ -89,6 +89,7 @@
           href="https://t.maze.co/310149185"
           target="_blank"
           rel="noopener noreferrer"
+          on:click={() => surveyDismissed.set(true)}
         >
           Complete our survey on Automations</a
         >

--- a/packages/builder/src/pages/builder/app/[application]/automation/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/automation/_layout.svelte
@@ -13,6 +13,7 @@
     selectedAutomation,
   } from "stores/builder"
   import { createLocalStorageStore } from "@budibase/frontend-core"
+  import { fly } from "svelte/transition"
 
   $: automationId = $selectedAutomation?.data?._id
   $: builderStore.selectResource(automationId)
@@ -30,9 +31,11 @@
 
   let modal
   let webhookModal
+  let mounted = false
 
   onMount(() => {
     $automationStore.showTestPanel = false
+    mounted = true
   })
 
   onDestroy(stopSyncing)
@@ -80,8 +83,12 @@
   </Modal>
 </div>
 
-{#if !$surveyDismissed}
-  <div class="survey">
+{#if !$surveyDismissed && mounted}
+  <div
+    class="survey"
+    in:fly={{ x: 600, duration: 260, delay: 1000 }}
+    out:fly={{ x: 600, duration: 260 }}
+  >
     <div class="survey__body">
       <div class="survey__title">We value your feedback!</div>
       <div class="survey__text">

--- a/packages/builder/src/pages/builder/app/[application]/automation/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/automation/_layout.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Heading, Body, Layout, Button, Modal } from "@budibase/bbui"
+  import { Heading, Body, Layout, Button, Modal, Icon } from "@budibase/bbui"
   import AutomationPanel from "components/automation/AutomationPanel/AutomationPanel.svelte"
   import CreateAutomationModal from "components/automation/AutomationPanel/CreateAutomationModal.svelte"
   import CreateWebhookModal from "components/automation/Shared/CreateWebhookModal.svelte"
@@ -12,11 +12,12 @@
     automationStore,
     selectedAutomation,
   } from "stores/builder"
+  import { createLocalStorageStore } from "@budibase/frontend-core"
 
   $: automationId = $selectedAutomation?.data?._id
   $: builderStore.selectResource(automationId)
 
-  // Keep URL and state in sync for selected screen ID
+  const surveyDismissed = createLocalStorageStore("automation-survey", false)
   const stopSyncing = syncURLToState({
     urlParam: "automationId",
     stateKey: "selectedAutomationId",
@@ -79,6 +80,38 @@
   </Modal>
 </div>
 
+{#if !$surveyDismissed}
+  <div class="survey">
+    <div class="survey__body">
+      <div class="survey__title">We value your feedback!</div>
+      <div class="survey__text">
+        <a
+          href="https://t.maze.co/310149185"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Complete our survey on Automations</a
+        >
+        and receive a $20 thank-you gift.
+        <a
+          href="https://drive.google.com/file/d/12-qk_2F9g5PdbM6wuKoz2KkIyLI-feMX/view?usp=sharing"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Terms apply.
+        </a>
+      </div>
+    </div>
+    <Icon
+      name="Close"
+      hoverable
+      color="var(--spectrum-global-color-static-gray-300)"
+      hoverColor="var(--spectrum-global-color-static-gray-100)"
+      on:click={() => surveyDismissed.set(true)}
+    />
+  </div>
+{/if}
+
 <style>
   .root {
     flex: 1 1 auto;
@@ -108,11 +141,9 @@
     justify-content: center;
     align-items: center;
   }
-
   .main {
     width: 300px;
   }
-
   .setup {
     padding-top: 9px;
     border-left: var(--border-light);
@@ -124,5 +155,40 @@
     background-color: var(--background);
     grid-column: 3;
     overflow: auto;
+  }
+
+  /* Survey */
+  .survey {
+    position: absolute;
+    bottom: 32px;
+    right: 32px;
+    background: var(--spectrum-semantic-positive-color-background);
+    display: flex;
+    flex-direction: row;
+    padding: var(--spacing-l) var(--spacing-xl);
+    border-radius: 4px;
+    gap: var(--spacing-xl);
+  }
+  .survey * {
+    color: var(--spectrum-global-color-static-gray-300);
+    white-space: nowrap;
+  }
+  .survey a {
+    text-decoration: underline;
+    transition: color 130ms ease-out;
+  }
+  .survey a:hover {
+    color: var(--spectrum-global-color-static-gray-100);
+    cursor: pointer;
+  }
+  .survey__body {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .survey__title {
+    font-weight: 600;
+    font-size: 15px;
   }
 </style>


### PR DESCRIPTION
## Description
This PR adds a popup in the automations section prompting users to complete a survey.

The [primary link](https://t.maze.co/310149185) points to the maze survey.
The [terms link](https://drive.google.com/file/d/12-qk_2F9g5PdbM6wuKoz2KkIyLI-feMX/view?usp=sharing) points to the PDF which I've hosted in Google Drive and made publicly readable.

Visibility is controlled by a simple local storage flag, so it won't reappear after being dismissed unless local storage is cleared, which typically happens infrequently. For a short term popup like this I don't think it's correct to start saving permanent metadata against the user doc.

The popup will be hidden by either clicking the close icon or by clicking the link.

The popup has a slight delay before sliding in from the right, to catch the eye of the user.

https://github.com/user-attachments/assets/364fbb12-39ad-4a1f-bb50-e7ef7f2fc104

## Addresses
- https://linear.app/budibase/issue/PRO-267/feedback-button-for-automations

## Screenshots
![image](https://github.com/user-attachments/assets/6b64ef7a-1298-4c3f-a7ab-61e0b901f2f0)
![image](https://github.com/user-attachments/assets/38bfa550-63ed-43d7-a213-b26d4d034de8)

## Launchcontrol
Add automation survey popup.