### PR TITLE
handle cases where datasourceName is undefined when sorting datasources

### DIFF
--- a/packages/builder/src/components/design/settings/controls/DataSourceSelect/DataSourceSelect.svelte
+++ b/packages/builder/src/components/design/settings/controls/DataSourceSelect/DataSourceSelect.svelte
@@ -56,7 +56,10 @@
     .map(table => format.table(table, $datasources.list))
     .sort((a, b) => {
       // sort tables alphabetically, grouped by datasource
-      const dsComparison = a.datasourceName.localeCompare(b.datasourceName)
+      const dsA = a.datasourceName ?? ""
+      const dsB = b.datasourceName ?? ""
+
+      const dsComparison = dsA.localeCompare(dsB)
       if (dsComparison !== 0) {
         return dsComparison
       }


### PR DESCRIPTION
## Description
Users table doesn't have a datasource name so currently crashes the builder when you create a table.

## Screenshots
<img width="537" alt="image" src="https://github.com/user-attachments/assets/5dc1843d-d934-4dab-a54b-094b62966fd9">

## Launchcontrol
Fix bug with sorting datasource names
