### PR TITLE
Fix client error SVG

### DIFF
--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -2,7 +2,7 @@
   import { writable, get } from "svelte/store"
   import { setContext, onMount } from "svelte"
   import { Layout, Heading, Body } from "@budibase/bbui"
-  import ErrorSVG from "@budibase/frontend-core/assets/error.svg"
+  import ErrorSVG from "@budibase/frontend-core/assets/error.svg?raw"
   import { Constants, CookieUtils } from "@budibase/frontend-core"
   import { getThemeClassNames } from "@budibase/shared-core"
   import Component from "./Component.svelte"

--- a/packages/string-templates/rollup.config.js
+++ b/packages/string-templates/rollup.config.js
@@ -32,7 +32,7 @@ const config = (input, outputFile, format) => ({
     }),
     commonjs(),
     json(),
-    inject({ Buffer: ["buffer", "Buffer"], process: "process/browser" }),
+    inject({ Buffer: ["buffer", "Buffer"] }),
     production && terser(),
   ],
 })

--- a/packages/string-templates/rollup.config.js
+++ b/packages/string-templates/rollup.config.js
@@ -32,7 +32,7 @@ const config = (input, outputFile, format) => ({
     }),
     commonjs(),
     json(),
-    inject({ Buffer: ["buffer", "Buffer"] }),
+    inject({ Buffer: ["buffer", "Buffer"], process: "process/browser" }),
     production && terser(),
   ],
 })


### PR DESCRIPTION
## Description
After moving from rollup to vite we need to import SVG files slightly differently. Currently the error image when you don't have access to an app is broken.

Before:
![image](https://github.com/user-attachments/assets/91571ca1-5ddc-402a-bc94-ffea368327ae)

After:
![image](https://github.com/user-attachments/assets/0f346ae9-ac81-4342-b9c2-bbfc59cddf44)
