### PR TITLE
Prevent syncing row changes between users for views filtered by current user

### DIFF
--- a/packages/bbui/src/Layout/Page.svelte
+++ b/packages/bbui/src/Layout/Page.svelte
@@ -43,12 +43,11 @@
     flex-direction: row;
     justify-content: flex-start;
     align-items: stretch;
-    overflow-y: scroll !important;
     flex: 1 1 auto;
     overflow-x: hidden;
   }
   .main {
-    overflow: auto;
+    overflow-y: scroll;
   }
   .content {
     display: flex;

--- a/packages/builder/src/global.css
+++ b/packages/builder/src/global.css
@@ -61,7 +61,7 @@ a {
   height: 8px;
 }
 ::-webkit-scrollbar-track {
-  background: var(--spectrum-alias-background-color-default);
+  background: transparent;
 }
 ::-webkit-scrollbar-thumb {
   background-color: var(--spectrum-global-color-gray-400);
@@ -71,6 +71,5 @@ a {
   background: var(--spectrum-alias-background-color-default);
 }
 html * {
-  scrollbar-color: var(--spectrum-global-color-gray-400)
-    var(--spectrum-alias-background-color-default);
+  scrollbar-color: var(--spectrum-global-color-gray-400) transparent;
 }


### PR DESCRIPTION
## Description
This PR prevents syncing row changes between users when using views that are filtered by any current user property. This is required as it can otherwise expose data which should not be seen by other users. I'm just stringifying and searching the `query` property for the presence of a current user binding as my litmus test. 

Currently the view doc is fetched and checked whenever a user connects to a certain datasource, which is infrequent - typically just once per page load, so I don't think there's much to be gained my computing this on update and storing a flag into the doc, but opinions are welcome.

Also contains a tiny fix for scrollbar styles as they have looked wrong for a few months and it's about time they were fixed!

## Addresses
- https://linear.app/budibase/issue/BUDI-8917/unexpected-rows-appear-in-user-specific-views-when-multiple-users
- https://github.com/Budibase/budibase/issues/15158
