### PR TITLE
Custom role in groups issue

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "vite build",
-    "dev": "vite build --watch"
+    "dev": "vite build --watch --mode=dev"
   },
   "dependencies": {
     "@budibase/bbui": "*",

--- a/packages/client/vite.config.mjs
+++ b/packages/client/vite.config.mjs
@@ -25,8 +25,8 @@ export default defineConfig(({ mode }) => {
         outDir: "dist",
         name: "budibase_client",
         fileName: () => "budibase-client.js",
-        minify: isProduction,
       },
+      minify: isProduction,
     },
     plugins: [
       svelte({


### PR DESCRIPTION
## Description
Fixing an issue with custom roles. If we have a single custom role, it has role order 0, but the check it not contemplating this properly. This PR just adds a test catching the error and fixes the issue.
Also, fixing the client dev build to not be minimised, as I had some struggles while trying to find the origin of the issue

Related:
- https://github.com/Budibase/budibase-pro/pull/346

## Launchcontrol
Fixing an issue with custom roles in groups