### PR TITLE
Relationship searching on tables with spaces

### DIFF
--- a/globalSetup.ts
+++ b/globalSetup.ts
@@ -4,8 +4,8 @@ import {
   getContainerRuntimeClient,
 } from "testcontainers"
 import { ContainerInfo } from "dockerode"
-import path from "path"
-import lockfile from "proper-lockfile"
+import * as path from "path"
+import * as lockfile from "proper-lockfile"
 import { execSync } from "child_process"
 
 interface DockerContext {
@@ -29,8 +29,8 @@ function getCurrentDockerContext(): DockerContext {
 
 async function getBudibaseContainers() {
   const client = await getContainerRuntimeClient()
-  const conatiners = await client.container.list()
-  return conatiners.filter(
+  const containers = await client.container.list()
+  return containers.filter(
     container =>
       container.Labels["com.budibase"] === "true" &&
       container.Labels["org.testcontainers"] === "true"

--- a/packages/backend-core/src/sql/utils.ts
+++ b/packages/backend-core/src/sql/utils.ts
@@ -66,6 +66,14 @@ export function buildExternalTableId(datasourceId: string, tableName: string) {
   return `${datasourceId}${DOUBLE_SEPARATOR}${tableName}`
 }
 
+export function checkTableId(tableId: string) {
+  if (isExternalTableID(tableId) && tableId.includes(" ")) {
+    return encodeURIComponent(tableId)
+  } else {
+    return tableId
+  }
+}
+
 export function breakExternalTableId(tableId: string) {
   const parts = tableId.split(DOUBLE_SEPARATOR)
   let datasourceId = parts.shift()

--- a/packages/backend-core/src/sql/utils.ts
+++ b/packages/backend-core/src/sql/utils.ts
@@ -59,15 +59,11 @@ export function isExternalTable(table: Table) {
 }
 
 export function buildExternalTableId(datasourceId: string, tableName: string) {
-  // encode spaces
-  if (tableName.includes(" ")) {
-    tableName = encodeURIComponent(tableName)
-  }
-  return `${datasourceId}${DOUBLE_SEPARATOR}${tableName}`
+  return `${datasourceId}${DOUBLE_SEPARATOR}${encodeURIComponent(tableName)}`
 }
 
-export function checkTableId(tableId: string) {
-  if (isExternalTableID(tableId) && tableId.includes(" ")) {
+export function encodeTableId(tableId: string) {
+  if (isExternalTableID(tableId)) {
     return encodeURIComponent(tableId)
   } else {
     return tableId

--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -288,19 +288,21 @@ function replaceTableNamesInFilters(
     for (const key of Object.keys(filter)) {
       const matches = key.match(`^(?<relation>.+)\\.(?<field>.+)`)
 
-      const relation = matches?.groups?.["relation"]
+      // this is the possible table name which we need to check if it needs to be converted
+      const relatedTableName = matches?.groups?.["relation"]
       const field = matches?.groups?.["field"]
 
-      if (!relation || !field) {
+      if (!relatedTableName || !field) {
         continue
       }
 
-      const table = allTables.find(r => r._id === tableId)!
-      if (Object.values(table.schema).some(f => f.name === relation)) {
+      const table = allTables.find(r => r._id === tableId)
+      const isColumnName = !!table?.schema[relatedTableName]
+      if (!table || isColumnName) {
         continue
       }
 
-      const matchedTable = allTables.find(t => t.name === relation)
+      const matchedTable = allTables.find(t => t.name === relatedTableName)
       const relationship = Object.values(table.schema).find(
         f => isRelationshipField(f) && f.tableId === matchedTable?._id
       )

--- a/packages/server/src/api/controllers/row/utils/utils.ts
+++ b/packages/server/src/api/controllers/row/utils/utils.ts
@@ -1,6 +1,6 @@
 import * as utils from "../../../../db/utils"
 
-import { docIds } from "@budibase/backend-core"
+import { docIds, sql } from "@budibase/backend-core"
 import {
   Ctx,
   DatasourcePlusQueryResponse,
@@ -65,19 +65,21 @@ export function getSourceId(ctx: Ctx): { tableId: string; viewId?: string } {
     const { sourceId } = ctx.params
     if (docIds.isViewId(sourceId)) {
       return {
-        tableId: utils.extractViewInfoFromID(sourceId).tableId,
+        tableId: sql.utils.checkTableId(
+          utils.extractViewInfoFromID(sourceId).tableId
+        ),
         viewId: sourceId,
       }
     }
-    return { tableId: ctx.params.sourceId }
+    return { tableId: sql.utils.checkTableId(ctx.params.sourceId) }
   }
   // now check for old way of specifying table ID
   if (ctx.params?.tableId) {
-    return { tableId: ctx.params.tableId }
+    return { tableId: sql.utils.checkTableId(ctx.params.tableId) }
   }
   // check body for a table ID
   if (ctx.request.body?.tableId) {
-    return { tableId: ctx.request.body.tableId }
+    return { tableId: sql.utils.checkTableId(ctx.request.body.tableId) }
   }
   throw new Error("Unable to find table ID in request")
 }

--- a/packages/server/src/api/controllers/row/utils/utils.ts
+++ b/packages/server/src/api/controllers/row/utils/utils.ts
@@ -65,21 +65,19 @@ export function getSourceId(ctx: Ctx): { tableId: string; viewId?: string } {
     const { sourceId } = ctx.params
     if (docIds.isViewId(sourceId)) {
       return {
-        tableId: sql.utils.checkTableId(
-          utils.extractViewInfoFromID(sourceId).tableId
-        ),
+        tableId: utils.extractViewInfoFromID(sourceId).tableId,
         viewId: sourceId,
       }
     }
-    return { tableId: sql.utils.checkTableId(ctx.params.sourceId) }
+    return { tableId: sql.utils.encodeTableId(ctx.params.sourceId) }
   }
   // now check for old way of specifying table ID
   if (ctx.params?.tableId) {
-    return { tableId: sql.utils.checkTableId(ctx.params.tableId) }
+    return { tableId: sql.utils.encodeTableId(ctx.params.tableId) }
   }
   // check body for a table ID
   if (ctx.request.body?.tableId) {
-    return { tableId: sql.utils.checkTableId(ctx.request.body.tableId) }
+    return { tableId: sql.utils.encodeTableId(ctx.request.body.tableId) }
   }
   throw new Error("Unable to find table ID in request")
 }

--- a/packages/server/src/db/utils.ts
+++ b/packages/server/src/db/utils.ts
@@ -1,4 +1,10 @@
-import { context, db as dbCore, docIds, utils } from "@budibase/backend-core"
+import {
+  context,
+  db as dbCore,
+  docIds,
+  utils,
+  sql,
+} from "@budibase/backend-core"
 import {
   DatabaseQueryOpts,
   Datasource,
@@ -328,7 +334,7 @@ export function extractViewInfoFromID(viewId: string) {
   const regex = new RegExp(`^(?<tableId>.+)${SEPARATOR}([^${SEPARATOR}]+)$`)
   const res = regex.exec(viewId)
   return {
-    tableId: res!.groups!["tableId"],
+    tableId: sql.utils.encodeTableId(res!.groups!["tableId"]),
   }
 }
 


### PR DESCRIPTION
## Description
It is possible to search for rows using the table name - this is something that data providers will often do - but if the external table name contained a space there could be an issue with the table name not lining up after it comes in through the API (in the body of the request).

Added a test case for this as well, only applies to external tables as the internal table name is not used for searching.

Addresses: https://github.com/Budibase/budibase/issues/15139
