### PR TITLE
Fix s3 integration error handling

### DIFF
--- a/packages/server/src/integrations/s3.ts
+++ b/packages/server/src/integrations/s3.ts
@@ -218,14 +218,14 @@ class S3Integration implements IntegrationBase {
       const response = await this.client.createBucket(params).promise()
       return response
     } catch (e: unknown) {
-      let message = "AWS S3: Unable to process the request"
+      let message = "Unable to process the request"
       if (e instanceof Error) {
-        message = "AWS S3: " + e.message
+        message = e.message
       }
 
       // Do not rethrow AWS errors as the statusCode prop will be
       // interpreted by koa
-      throw new Error(message)
+      throw new Error("AWS S3: " + message)
     }
   }
 
@@ -249,12 +249,12 @@ class S3Integration implements IntegrationBase {
         .promise()
       return response.Contents
     } catch (e: unknown) {
-      let message = "AWS S3: Unable to process the request"
+      let message = "Unable to process the request"
       if (e instanceof Error) {
-        message = "AWS S3: " + e.message
+        message = e.message
       }
 
-      throw new Error(message)
+      throw new Error("AWS S3: " + message)
     }
   }
 
@@ -279,12 +279,14 @@ class S3Integration implements IntegrationBase {
       stream.on("finish", () => {
         resolve(response)
       })
-    }).catch(err => {
+    }).catch((e: unknown) => {
+      let message = "Unable to process the request"
       if (csvError) {
-        throw new Error("Could not read CSV")
-      } else {
-        throw err
+        message = "Could not read CSV"
+      } else if (e instanceof Error) {
+        message = e.message
       }
+      throw new Error("AWS S3: " + message)
     })
   }
 
@@ -298,12 +300,12 @@ class S3Integration implements IntegrationBase {
         .promise()
       return response
     } catch (e: unknown) {
-      let message = "AWS S3: Unable to process the request"
+      let message = "Unable to process the request"
       if (e instanceof Error) {
-        message = "AWS S3: " + e.message
+        message = e.message
       }
 
-      throw new Error(message)
+      throw new Error("AWS S3: " + message)
     }
   }
 }


### PR DESCRIPTION
## Description

The default behaviour for handling integration errors is to throw the error and have koa relay it as a `400`.
If an error object thrown by an integration contains a `statusCode`, koa will ignore the `400` and use that instead.

In development, if you encountered a permission restriction with your S3 integration, the AWS client would return a `403` and log you out. In prod, the page you were on would reload and you would lose the error message.

All errors in the S3 integration throw a new instance of `Error` with any relevant messaging. This will then be relayed with the default `400` status.

## Addresses
- https://github.com/Budibase/budibase/issues/14935

## Launchcontrol

S3 integration error handling updated
