### PR TITLE
UI - always ask for password with encrypted app exports

### DIFF
--- a/packages/builder/src/components/start/CreateAppModal.svelte
+++ b/packages/builder/src/components/start/CreateAppModal.svelte
@@ -26,6 +26,7 @@
   const values = writable({ name: "", url: null })
   const validation = createValidationStore()
   const encryptionValidation = createValidationStore()
+  const isEncryptedRegex = /^.*\.enc.*\.tar\.gz$/gm
 
   $: {
     const { url } = $values
@@ -37,7 +38,9 @@
     encryptionValidation.check({ ...$values })
   }
 
-  $: encryptedFile = $values.file?.name?.endsWith(".enc.tar.gz")
+  // filename should be separated to avoid updates everytime any other form element changes
+  $: filename = $values.file?.name
+  $: encryptedFile = isEncryptedRegex.test(filename)
 
   onMount(async () => {
     const lastChar = $auth.user?.firstName
@@ -171,7 +174,7 @@
           try {
             await createNewApp()
           } catch (error) {
-            notifications.error("Error creating app")
+            notifications.error(`Error creating app - ${error.message}`)
           }
         }
       },

--- a/packages/builder/src/pages/builder/portal/apps/index.svelte
+++ b/packages/builder/src/pages/builder/portal/apps/index.svelte
@@ -139,7 +139,7 @@
       await auth.setInitInfo({})
       $goto(`/builder/app/${createdApp.instance._id}`)
     } catch (error) {
-      notifications.error("Error creating app")
+      notifications.error(`Error creating app - ${error.message}`)
     }
   }
 

--- a/packages/server/src/sdk/app/backups/imports.ts
+++ b/packages/server/src/sdk/app/backups/imports.ts
@@ -187,6 +187,10 @@ export async function importApp(
       await decryptFiles(tmpPath, template.file.password)
     }
     const contents = await fsp.readdir(tmpPath)
+    const stillEncrypted = !!contents.find(name => name.endsWith(".enc"))
+    if (stillEncrypted) {
+      throw new Error("Files are encrypted but no password has been supplied.")
+    }
     // have to handle object import
     if (contents.length && opts.importObjStoreContents) {
       let promises = []


### PR DESCRIPTION
## Description
Make sure password is always requested when working with encrypted files - if the enc file has been copied the name may change format, we should handle if this happens.

Addresses: https://github.com/Budibase/budibase/issues/15187