### PR TITLE
Fix patching rows from views with hidden relationships

### DIFF
--- a/packages/server/src/api/controllers/row/utils/utils.ts
+++ b/packages/server/src/api/controllers/row/utils/utils.ts
@@ -110,6 +110,21 @@ function fixBooleanFields(row: Row, table: Table) {
   return row
 }
 
+export function getSourceFields(source: Table | ViewV2): string[] {
+  const isView = sdk.views.isView(source)
+  if (isView) {
+    const fields = Object.keys(
+      helpers.views.basicFields(source, { visible: true })
+    )
+    return fields
+  }
+
+  const fields = Object.entries(source.schema)
+    .filter(([_, field]) => field.visible !== false)
+    .map(([columnName]) => columnName)
+  return fields
+}
+
 export async function sqlOutputProcessing(
   rows: DatasourcePlusQueryResponse,
   source: Table | ViewV2,


### PR DESCRIPTION
## Description
Fixing the following scenario:
1. Create an external table with related data
2. Create a view excluding the relations
3. Update a row from that view
4. Go back to the main table, see the relationship being dropped

This PR adds tests catching the issue and fixes to the proper behaviour, where the relationship is not dropped. Also, it makes sure that any field that is not part of the views can be modified.


https://github.com/user-attachments/assets/43b30030-df50-4cd1-8384-6ea409f2f447


## Launchcontrol
Fixing wrongly dropped relationships for trimmed tables