### PR TITLE
Allow views and tables with whitespaces

### DIFF
--- a/packages/backend-core/src/sql/utils.ts
+++ b/packages/backend-core/src/sql/utils.ts
@@ -70,6 +70,10 @@ export function encodeTableId(tableId: string) {
   }
 }
 
+export function encodeViewId(viewId: string) {
+  return encodeURIComponent(viewId)
+}
+
 export function breakExternalTableId(tableId: string) {
   const parts = tableId.split(DOUBLE_SEPARATOR)
   let datasourceId = parts.shift()

--- a/packages/server/src/api/controllers/row/utils/utils.ts
+++ b/packages/server/src/api/controllers/row/utils/utils.ts
@@ -66,7 +66,7 @@ export function getSourceId(ctx: Ctx): { tableId: string; viewId?: string } {
     if (docIds.isViewId(sourceId)) {
       return {
         tableId: utils.extractViewInfoFromID(sourceId).tableId,
-        viewId: sourceId,
+        viewId: sql.utils.encodeViewId(sourceId),
       }
     }
     return { tableId: sql.utils.encodeTableId(ctx.params.sourceId) }

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1902,7 +1902,7 @@ if (descriptions.length) {
           it("tables and views can contain whitespaces", async () => {
             const table = await config.api.table.save(
               saveTableRequest({
-                name: "table with spaces",
+                name: `table with spaces ${generator.hash()}`,
                 schema: {
                   name: {
                     type: FieldType.STRING,

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -55,7 +55,7 @@ if (descriptions.length) {
       let datasource: Datasource | undefined
 
       function saveTableRequest(
-        ...overrides: Partial<Omit<SaveTableRequest, "name">>[]
+        ...overrides: Partial<SaveTableRequest>[]
       ): SaveTableRequest {
         const req: SaveTableRequest = {
           name: generator.guid().replaceAll("-", "").substring(0, 16),
@@ -1897,6 +1897,36 @@ if (descriptions.length) {
               ],
             }
             expect(view.queryUI).toEqual(expected)
+          })
+
+          it("tables and views can contain whitespaces", async () => {
+            const table = await config.api.table.save(
+              saveTableRequest({
+                name: "table with spaces",
+                schema: {
+                  name: {
+                    type: FieldType.STRING,
+                    name: "name",
+                  },
+                },
+              })
+            )
+
+            const view = await config.api.viewV2.create({
+              tableId: table._id!,
+              name: `view name with spaces`,
+              schema: {
+                name: { visible: true },
+              },
+            })
+
+            expect(await getDelegate(view)).toEqual({
+              ...view,
+              schema: {
+                id: { ...table.schema["id"], visible: false },
+                name: { ...table.schema["name"], visible: true },
+              },
+            })
           })
         })
 

--- a/packages/server/src/db/utils.ts
+++ b/packages/server/src/db/utils.ts
@@ -1,10 +1,4 @@
-import {
-  context,
-  db as dbCore,
-  docIds,
-  utils,
-  sql,
-} from "@budibase/backend-core"
+import { context, db as dbCore, docIds, utils } from "@budibase/backend-core"
 import {
   DatabaseQueryOpts,
   Datasource,
@@ -334,7 +328,7 @@ export function extractViewInfoFromID(viewId: string) {
   const regex = new RegExp(`^(?<tableId>.+)${SEPARATOR}([^${SEPARATOR}]+)$`)
   const res = regex.exec(viewId)
   return {
-    tableId: sql.utils.encodeTableId(res!.groups!["tableId"]),
+    tableId: res!.groups!["tableId"],
   }
 }
 

--- a/packages/server/src/tests/utilities/api/viewV2.ts
+++ b/packages/server/src/tests/utilities/api/viewV2.ts
@@ -46,8 +46,11 @@ export class ViewV2API extends TestAPI {
   }
 
   get = async (viewId: string) => {
-    return (await this._get<ViewResponseEnriched>(`/api/v2/views/${viewId}`))
-      .data
+    return (
+      await this._get<ViewResponseEnriched>(
+        `/api/v2/views/${encodeURIComponent(viewId)}`
+      )
+    ).data
   }
 
   fetch = async (expectations?: Expectations) => {


### PR DESCRIPTION
## Description
Fixing an existing error due to having whitespace in the table ids and views. We have some mismatches between encodings, and some "gets" were failing.
<img width="1113" alt="image" src="https://github.com/user-attachments/assets/3a6fefcc-7ad8-4a58-8f05-22cf3e68cfbc" />


This PR adds some tests capturing the issue and fixes it.


## Launchcontrol
Fixing conflicts with external datasources for views in tables with whitespaces in the name 