### PR TITLE
Guard display column in the api

### DIFF
--- a/packages/server/src/api/controllers/table/index.ts
+++ b/packages/server/src/api/controllers/table/index.ts
@@ -37,6 +37,7 @@ import { jsonFromCsvString } from "../../../utilities/csv"
 import { builderSocket } from "../../../websockets"
 import { cloneDeep } from "lodash"
 import {
+  canBeDisplayColumn,
   helpers,
   PROTECTED_EXTERNAL_COLUMNS,
   PROTECTED_INTERNAL_COLUMNS,
@@ -64,6 +65,20 @@ function checkDefaultFields(table: Table) {
         400
       )
     }
+  }
+}
+
+function guardTable(table: Table) {
+  checkDefaultFields(table)
+
+  if (
+    table.primaryDisplay &&
+    !canBeDisplayColumn(table.schema[table.primaryDisplay]?.type)
+  ) {
+    throw new HTTPError(
+      `Column "${table.primaryDisplay}" cannot be used as a display type.`,
+      400
+    )
   }
 }
 
@@ -111,7 +126,7 @@ export async function save(ctx: UserCtx<SaveTableRequest, SaveTableResponse>) {
 
   const isCreate = !table._id
 
-  checkDefaultFields(table)
+  guardTable(table)
 
   let savedTable: Table
   if (isCreate) {

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -3399,7 +3399,7 @@ if (descriptions.length) {
                       type: FieldType.LINK,
                       relationshipType: RelationshipType.MANY_TO_ONE,
                       tableId: toRelateTableId,
-                      fieldName: "link",
+                      fieldName: "main",
                     },
                   })
 
@@ -3408,7 +3408,7 @@ if (descriptions.length) {
                   )
                   await config.api.table.save({
                     ...toRelateTable,
-                    primaryDisplay: "link",
+                    primaryDisplay: "name",
                   })
                   const relatedRows = await Promise.all([
                     config.api.row.save(toRelateTable._id!, {

--- a/packages/shared-core/src/table.ts
+++ b/packages/shared-core/src/table.ts
@@ -12,8 +12,8 @@ const allowDisplayColumnByType: Record<FieldType, boolean> = {
   [FieldType.AUTO]: true,
   [FieldType.INTERNAL]: true,
   [FieldType.BARCODEQR]: true,
-
   [FieldType.BIGINT]: true,
+
   [FieldType.BOOLEAN]: false,
   [FieldType.ARRAY]: false,
   [FieldType.ATTACHMENTS]: false,


### PR DESCRIPTION
## Description
Some table configurations, such as what column types might be used as a display, are handled in the frontend. This is not done on the API level, so some tests and possible API usages leavesdata into an inconsistent state.

This PR adds a guard to ensure that we cannot create or update display columns to non-valid data.

## Launchcontrol
Verifying display columns to be valid