### PR TITLE
allow users to select firestore databases other than the default

### DIFF
--- a/packages/builder/src/components/backend/Datasources/ConfigEditor/ConfigInput.svelte
+++ b/packages/builder/src/components/backend/Datasources/ConfigEditor/ConfigInput.svelte
@@ -12,6 +12,7 @@
   export let name
   export let config
   export let showModal = () => {}
+  export let placeholder
 
   const selectComponent = type => {
     if (type === "object") {
@@ -40,6 +41,7 @@
   {name}
   {config}
   {showModal}
+  {placeholder}
   on:blur
   on:change
 />

--- a/packages/builder/src/components/backend/Datasources/ConfigEditor/fields/LongForm.svelte
+++ b/packages/builder/src/components/backend/Datasources/ConfigEditor/fields/LongForm.svelte
@@ -5,11 +5,12 @@
   export let name
   export let value
   export let error
+  export let placeholder
 </script>
 
 <div class="form-row">
   <Label>{name}</Label>
-  <TextArea on:blur on:change {type} {value} {error} />
+  <TextArea on:blur on:change {type} {value} {error} {placeholder} />
 </div>
 
 <style>

--- a/packages/builder/src/components/backend/Datasources/ConfigEditor/fields/Select.svelte
+++ b/packages/builder/src/components/backend/Datasources/ConfigEditor/fields/Select.svelte
@@ -6,6 +6,7 @@
   export let value
   export let error
   export let config
+  export let placeholder
 </script>
 
 <div class="form-row">
@@ -17,6 +18,7 @@
     {type}
     value={value || undefined}
     {error}
+    {placeholder}
   />
 </div>
 

--- a/packages/builder/src/components/backend/Datasources/ConfigEditor/fields/String.svelte
+++ b/packages/builder/src/components/backend/Datasources/ConfigEditor/fields/String.svelte
@@ -6,6 +6,7 @@
   export let name
   export let value
   export let error
+  export let placeholder
   export let showModal = () => {}
 
   async function handleUpgradePanel() {
@@ -22,6 +23,7 @@
     type={type === "port" ? "string" : type}
     {value}
     {error}
+    {placeholder}
     variables={$environment.variables}
     environmentVariablesEnabled={$licensing.environmentVariablesEnabled}
     {showModal}

--- a/packages/builder/src/components/backend/Datasources/ConfigEditor/index.svelte
+++ b/packages/builder/src/components/backend/Datasources/ConfigEditor/index.svelte
@@ -85,7 +85,7 @@
     />
   {/if}
 
-  {#each $configStore.validatedConfig as { type, key, value, error, name, hidden, config }}
+  {#each $configStore.validatedConfig as { type, key, value, error, name, hidden, config, placeholder }}
     {#if hidden === undefined || !eval(processStringSync(hidden, $configStore.config))}
       <ConfigInput
         {type}
@@ -93,6 +93,7 @@
         {error}
         {name}
         {config}
+        {placeholder}
         showModal={() =>
           showModal(newValue => configStore.updateFieldValue(key, newValue))}
         on:blur={() => configStore.markFieldActive(key)}

--- a/packages/builder/src/components/backend/Datasources/ConfigEditor/stores/validatedConfig.js
+++ b/packages/builder/src/components/backend/Datasources/ConfigEditor/stores/validatedConfig.js
@@ -114,6 +114,7 @@ export const createValidatedConfigStore = (integration, config) => {
           value: getValue(),
           error: $errorsStore[key],
           name: capitalise(properties.display || key),
+          placeholder: properties.placeholder,
           type: properties.type,
           hidden: properties.hidden,
           config: properties.config,

--- a/packages/server/src/integrations/firebase.ts
+++ b/packages/server/src/integrations/firebase.ts
@@ -12,6 +12,7 @@ interface FirebaseConfig {
   email: string
   privateKey: string
   projectId: string
+  databaseId?: string
 }
 
 const SCHEMA: Integration = {
@@ -30,11 +31,20 @@ const SCHEMA: Integration = {
     },
     privateKey: {
       type: DatasourceFieldType.STRING,
+      display: "Private Key",
       required: true,
     },
     projectId: {
       type: DatasourceFieldType.STRING,
+      display: "Project ID",
       required: true,
+    },
+    databaseId: {
+      type: DatasourceFieldType.STRING,
+      display: "Database ID",
+      required: false,
+      default: "(default)",
+      placeholder: "(default)",
     },
   },
   query: {
@@ -97,6 +107,7 @@ class FirebaseIntegration implements IntegrationBase {
     this.config = config
     this.client = new Firestore({
       projectId: config.projectId,
+      databaseId: config.databaseId || "(default)",
       credentials: {
         client_email: config.email,
         private_key: config.privateKey?.replace(/\\n/g, "\n"),

--- a/packages/types/src/sdk/datasources.ts
+++ b/packages/types/src/sdk/datasources.ts
@@ -119,6 +119,7 @@ interface DatasourceBasicFieldConfig {
   default?: any
   deprecated?: boolean
   hidden?: string
+  placeholder?: string
 }
 
 interface DatasourceSelectFieldConfig extends DatasourceBasicFieldConfig {


### PR DESCRIPTION
## Description
Currently the firestore connector can only use the `(default)` firestore DB. In cases where a user has more than one db, this allows them to specifically connect to one of them by id. The (default) is added by default. For visibility in cases where a connection setup already exists, the field now shows with `(default)` as a placeholder in the datasource config fields. To allow this, I have had to add support for configurable placeholders on each relevant config field type.


## Screenshots
_before_
![image](https://github.com/user-attachments/assets/775205e3-ff49-48ca-9cb5-2412cbd5340e)

_after_
![image](https://github.com/user-attachments/assets/ae7a5c69-25d2-49ad-ae56-6432fac270cc)

## Launchcontrol
add support for database selection in firestore connector
