### PR TITLE
Configure frontend-core

### DIFF
--- a/packages/frontend-core/package.json
+++ b/packages/frontend-core/package.json
@@ -5,6 +5,9 @@
   "author": "Budibase",
   "license": "MPL-2.0",
   "svelte": "./src/index.ts",
+  "scripts": {
+    "check:types": "yarn svelte-check"
+  },
   "dependencies": {
     "@budibase/bbui": "*",
     "@budibase/shared-core": "*",
@@ -13,5 +16,8 @@
     "lodash": "4.17.21",
     "shortid": "2.2.15",
     "socket.io-client": "^4.7.5"
+  },
+  "devDependencies": {
+    "svelte-check": "^4.1.0"
   }
 }

--- a/packages/frontend-core/tsconfig.json
+++ b/packages/frontend-core/tsconfig.json
@@ -6,12 +6,7 @@
     "moduleResolution": "bundler",
     "outDir": "./dist",
     "skipLibCheck": true,
-    "allowJs": true,
-    "paths": {
-      "@budibase/types": ["../types/src"],
-      "@budibase/shared-core": ["../shared-core/src"],
-      "@budibase/bbui": ["../bbui/src"]
-    }
+    "allowJs": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/frontend-core/tsconfig.json
+++ b/packages/frontend-core/tsconfig.json
@@ -4,7 +4,9 @@
     "target": "ESNext",
     "module": "preserve",
     "moduleResolution": "bundler",
+    "outDir": "./dist",
     "skipLibCheck": true,
+    "allowJs": true,
     "paths": {
       "@budibase/types": ["../types/src"],
       "@budibase/shared-core": ["../shared-core/src"],

--- a/packages/frontend-core/tsconfig.json
+++ b/packages/frontend-core/tsconfig.json
@@ -1,6 +1,8 @@
 {
+  "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "target": "ESNext",
+    "module": "preserve",
     "moduleResolution": "bundler",
     "skipLibCheck": true,
     "paths": {


### PR DESCRIPTION
## Description
Configuring frontend-core to validate ts properly on the IDEs. Without this, some checks such as `svelte-checks` would complain but not the IDE, giving us a bad dev experience