### PR TITLE
Ignore default values for view sort

### DIFF
--- a/packages/frontend-core/src/components/grid/stores/datasources/viewV2.ts
+++ b/packages/frontend-core/src/components/grid/stores/datasources/viewV2.ts
@@ -151,6 +151,35 @@ export const initialise = (context: StoreContext) => {
       })
     )
 
+    function sortHasChanged(
+      newSort: {
+        column: string | null | undefined
+        order: SortOrder
+      },
+      existingSort?: {
+        field: string
+        order?: SortOrder
+      }
+    ) {
+      const newColumn = newSort.column ?? null
+      const existingColumn = existingSort?.field ?? null
+      if (newColumn !== existingColumn) {
+        return true
+      }
+
+      if (!newColumn) {
+        return false
+      }
+
+      const newOrder = newSort.order ?? null
+      const existingOrder = existingSort?.order ?? null
+      if (newOrder !== existingOrder) {
+        return true
+      }
+
+      return false
+    }
+
     // When sorting changes, ensure view definition is kept up to date
     unsubscribers.push(
       sort.subscribe(async $sort => {
@@ -161,10 +190,7 @@ export const initialise = (context: StoreContext) => {
         }
 
         // Skip if nothing actually changed
-        if (
-          $sort?.column === $view.sort?.field &&
-          $sort?.order === $view.sort?.order
-        ) {
+        if (!sortHasChanged($sort, $view.sort)) {
           return
         }
 


### PR DESCRIPTION
## Description
While QAing an issue related to views was found. Due the frontend setting default values for grid sort, unnecessary updates are submitted when creating new views. This is happening in both views and calculation views, and due some recent changes on the backend calculation views are displaying some errors. Even so, the views are created correctly.

https://github.com/user-attachments/assets/8ad9fc11-b121-421a-a9f5-3f8fd9c1579b

Instead of fixing the error on the backend to not throw, the frontend has been fixed in order to not create these calls.

The problematic flow does as it follows:
1. Create a new view (by default, the sort configuration is not set)
2. Update the datasource in the frontend accordingly
3. The frontend sees that the sort config is not defined, so it sets the default order as ascending
4. As there is a change in the config, it tries to update the definition via API (this happens as it cannot differentiate if it was a user change or an "automatic" one)

This is currently happening in production

## Launchcontrol
Remove wrong and confusing message when creating new views