### PR TITLE
Automation test details fix

### DIFF
--- a/packages/builder/src/stores/builder/automations.ts
+++ b/packages/builder/src/stores/builder/automations.ts
@@ -291,8 +291,8 @@ const automationActions = (store: AutomationStore) => ({
     let result: (AutomationStep | AutomationTrigger)[] = []
     pathWay.forEach(path => {
       const { stepIdx, branchIdx } = path
-      let last = result ? result[result.length - 1] : []
-      if (!result) {
+      let last = result.length ? result[result.length - 1] : []
+      if (!result.length) {
         // Preceeding steps.
         result = steps.slice(0, stepIdx + 1)
         return


### PR DESCRIPTION
## Description
The recent migration of automations to Typescript introduced a minor bug in the `getPathSteps` behaviour. The executed path would always return as empty and which would manifest as a blank test results screen. 

## Addresses
- https://github.com/Budibase/budibase/issues/15246

## Launchcontrol
Fix for path processing in automations.