### PR TITLE
Related to account-portal change

### DIFF
--- a/packages/worker/src/api/routes/global/tests/auth.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/auth.spec.ts
@@ -15,6 +15,7 @@ import { Response } from "superagent"
 import * as userSdk from "../../../../sdk/users"
 import nock from "nock"
 import * as jwt from "jsonwebtoken"
+import { utils } from "@budibase/backend-core"
 
 function getAuthCookie(response: Response) {
   return response.headers["set-cookie"]
@@ -203,7 +204,7 @@ describe("/api/global/auth", () => {
         )
         delete user.password
 
-        const newPassword = "newpassword1"
+        const newPassword = await utils.hash("newpassword1")
         const res = await config.api.auth.updatePassword(code!, newPassword)
 
         user = (await config.getUser(user.email))!
@@ -214,7 +215,7 @@ describe("/api/global/auth", () => {
         expect(events.user.passwordReset).toHaveBeenCalledWith(user)
 
         // login using new password
-        await config.api.auth.login(user.tenantId, user.email, newPassword)
+        await config.api.auth.login(user.tenantId, user.email, "newpassword1")
       })
 
       describe("sso user", () => {

--- a/packages/worker/src/sdk/auth/auth.ts
+++ b/packages/worker/src/sdk/auth/auth.ts
@@ -81,7 +81,9 @@ export const resetUpdate = async (resetCode: string, password: string) => {
 
   let user = await userSdk.db.getUser(userId)
   user.password = password
-  user = await userSdk.db.save(user)
+  user = await userSdk.db.save(user, {
+    hashPassword: false,
+  })
 
   await cache.passwordReset.invalidateCode(resetCode)
   await sessions.invalidateSessions(userId)

--- a/packages/worker/src/sdk/auth/tests/auth.spec.ts
+++ b/packages/worker/src/sdk/auth/tests/auth.spec.ts
@@ -21,9 +21,7 @@ describe("auth", () => {
 
         const persistedUser = await config.getUser(user.email)
         expect(persistedUser.password).not.toBe(previousPassword)
-        expect(
-          await utils.compare(newPassword, persistedUser.password!)
-        ).toBeTruthy()
+        expect(newPassword).toEqual(persistedUser.password)
       })
     })
 

--- a/packages/worker/src/sdk/auth/tests/auth.spec.ts
+++ b/packages/worker/src/sdk/auth/tests/auth.spec.ts
@@ -1,4 +1,4 @@
-import { cache, context, sessions, utils } from "@budibase/backend-core"
+import { cache, context, sessions } from "@budibase/backend-core"
 import { loginUser, resetUpdate } from "../auth"
 import { generator, structures } from "@budibase/backend-core/tests"
 import { TestConfiguration } from "../../../tests"


### PR DESCRIPTION
## Description
Account portal already hashes the password.

**Do not merge** - Deployment strategy needed

## Addresses
- https://linear.app/budibase/issue/GRO-886/issue-with-forgot-password-reset-email-not-being-received-for-tenant
