### PR TITLE
Fix issue with forms after cleanup

### DIFF
--- a/packages/client/src/utils/schema.js
+++ b/packages/client/src/utils/schema.js
@@ -31,7 +31,7 @@ const getDatasourceFetchInstance = datasource => {
   if (!handler) {
     return null
   }
-  return new handler({ API })
+  return new handler({ API, datasource })
 }
 
 /**

--- a/packages/client/src/utils/schema.js
+++ b/packages/client/src/utils/schema.js
@@ -52,7 +52,7 @@ export const fetchDatasourceSchema = async (
   // Get the normal schema as long as we aren't wanting a form schema
   let schema
   if (datasource?.type !== "query" || !options?.formSchema) {
-    schema = instance.getSchema(datasource, definition)
+    schema = instance.getSchema(definition)
   } else if (definition.parameters?.length) {
     schema = {}
     definition.parameters.forEach(param => {


### PR DESCRIPTION
## Description
Fixing an issue introduced in https://github.com/Budibase/budibase/pull/15295
We did change the way that some datafetches are consumed, assuming we always have a valid datasource within it. I skipped a usage of it, where this was not the case.

Error we got:
<img width="1150" alt="image" src="https://github.com/user-attachments/assets/f46138c1-b7b6-4190-ae9f-beea8cc81e58" />



After the fix:
<img width="1150" alt="image" src="https://github.com/user-attachments/assets/8db91f53-df9b-438c-b071-d531a6d74ab0" />

