### PR TITLE
Explicitly fetch the data from fetch

### DIFF
--- a/packages/client/src/utils/schema.js
+++ b/packages/client/src/utils/schema.js
@@ -31,7 +31,7 @@ const getDatasourceFetchInstance = datasource => {
   if (!handler) {
     return null
   }
-  return new handler({ API })
+  return new handler({ API, datasource })
 }
 
 /**

--- a/packages/client/src/utils/schema.js
+++ b/packages/client/src/utils/schema.js
@@ -52,7 +52,7 @@ export const fetchDatasourceSchema = async (
   // Get the normal schema as long as we aren't wanting a form schema
   let schema
   if (datasource?.type !== "query" || !options?.formSchema) {
-    schema = instance.getSchema(datasource, definition)
+    schema = instance.getSchema(definition)
   } else if (definition.parameters?.length) {
     schema = {}
     definition.parameters.forEach(param => {

--- a/packages/frontend-core/src/fetch/DataFetch.ts
+++ b/packages/frontend-core/src/fetch/DataFetch.ts
@@ -179,9 +179,6 @@ export default abstract class DataFetch<
       this.store.update($store => ({ ...$store, loaded: true }))
       return
     }
-
-    // Initially fetch data but don't bother waiting for the result
-    this.getInitialData()
   }
 
   /**

--- a/packages/frontend-core/src/fetch/index.ts
+++ b/packages/frontend-core/src/fetch/index.ts
@@ -33,7 +33,12 @@ const DataFetchMap = {
 export const fetchData = ({ API, datasource, options }: any) => {
   const Fetch =
     DataFetchMap[datasource?.type as keyof typeof DataFetchMap] || TableFetch
-  return new Fetch({ API, datasource, ...options })
+  const fetch = new Fetch({ API, datasource, ...options })
+
+  // Initially fetch data but don't bother waiting for the result
+  fetch.getInitialData()
+
+  return fetch
 }
 
 // Creates an empty fetch instance with no datasource configured, so no data


### PR DESCRIPTION
## Description
Updating data fetchers to do not fetch data by default on the constructor. We have some use cases where we don't want to do this, and the way we use to handle this was passing an empty datasource on the constructor. This was changed in here: https://github.com/Budibase/budibase/pull/15332
This PR change the behaviour to work as expected.

Also, reading the reverted changes from here: https://github.com/Budibase/budibase/pull/15332, fixing an issue while loading the forms.

### QA process
1. Grid calls a single search, new forms are not performing any search and edit forms run a single search with limit 1

https://github.com/user-attachments/assets/a71599c7-3be3-4694-a36c-179aad109bbd


2. Forms with relationships run one extra search for relationship field

https://github.com/user-attachments/assets/02620ab1-5338-4c9e-bcdb-b471c07943d8


3. Grid on data section loads as expected

https://github.com/user-attachments/assets/b56c2392-9d9d-4e27-ade7-4fb9a52830af


4. Multiple datasources are properly displayed on the clients: as tables, forms, repeaters...

https://github.com/user-attachments/assets/98340e10-5889-4260-a076-43a290021bb1

