### PR TITLE
Fix close modal on grid+modal generation

### DIFF
--- a/packages/frontend-core/src/utils/utils.js
+++ b/packages/frontend-core/src/utils/utils.js
@@ -209,6 +209,9 @@ export const buildFormBlockButtonConfig = props => {
     {
       "##eventHandlerType": "Close Side Panel",
     },
+    {
+      "##eventHandlerType": "Close Modal",
+    },
 
     ...(actionUrl
       ? [


### PR DESCRIPTION
## Description
Updating the template to add the action of closing a modal when deleting an element from it.

### Before

https://github.com/user-attachments/assets/93a53f53-f6bd-47e8-a514-8fcc90886fda


### After

https://github.com/user-attachments/assets/a5094511-7671-427c-ab00-69f814237be5




## Launchcontrol
Fixing closing models on deletion for autogenerated grid+modal screens