### PR TITLE
Add dummy action buttons for new panels

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPanel.svelte
@@ -3,6 +3,9 @@
   import AppPreview from "./AppPreview.svelte"
   import { screenStore, appStore } from "@/stores/builder"
   import UndoRedoControl from "@/components/common/UndoRedoControl.svelte"
+  import { ActionButton } from "@budibase/bbui"
+  import BindingsPanel from "./BindingsPanel.svelte"
+  import StatePanel from "./StatePanel.svelte"
 </script>
 
 <div class="app-panel">
@@ -10,11 +13,13 @@
   <div class="header">
     <div class="header-left">
       <UndoRedoControl store={screenStore.history} />
-    </div>
-    <div class="header-right">
       {#if $appStore.clientFeatures.devicePreview}
         <DevicePreviewSelect />
       {/if}
+    </div>
+    <div class="header-right">
+      <BindingsPanel />
+      <StatePanel />
     </div>
   </div>
   <div class="content">
@@ -50,6 +55,9 @@
     margin-bottom: 9px;
   }
 
+  .header-left {
+    display: flex;
+  }
   .header-left :global(div) {
     border-right: none;
   }

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/BindingsPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/BindingsPanel.svelte
@@ -1,0 +1,14 @@
+<script>
+  import { ActionButton, Modal, ModalContent } from "@budibase/bbui"
+
+  let visible = false
+  let modal
+</script>
+
+<ActionButton on:click={modal.show}>Bindings</ActionButton>
+
+<Modal bind:this={modal}>
+  <ModalContent title="Bindings" showConfirmButton={false} cancelText="Close">
+    Some awesome bindings content.
+  </ModalContent>
+</Modal>

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/StatePanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/StatePanel.svelte
@@ -1,0 +1,14 @@
+<script>
+  import { ActionButton, Modal, ModalContent } from "@budibase/bbui"
+
+  let visible = false
+  let modal
+</script>
+
+<ActionButton on:click={modal.show}>State</ActionButton>
+
+<Modal bind:this={modal}>
+  <ModalContent title="State" showConfirmButton={false} cancelText="Close">
+    Some awesome state content.
+  </ModalContent>
+</Modal>


### PR DESCRIPTION
## Description
Adds dummy action buttons for the new panels.

![image](https://github.com/user-attachments/assets/adc6e2c5-3511-401c-950d-7337291d1580)
![image](https://github.com/user-attachments/assets/6067abe0-911d-4d55-a282-981e9fc4314b)
![image](https://github.com/user-attachments/assets/21cd45c9-a4d2-42d4-9f7d-71768f2af756)

## Addresses
https://linear.app/budibase/issue/PRO-269/create-dummy-action-bar-for-bindings-and-state