### PR TITLE
Re-add tests files in backend-core/dist

### DIFF
--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "prebuild": "rimraf dist/",
     "prepack": "cp package.json dist",
-    "build": "node ./scripts/build.js && tsc -p tsconfig.build.json --emitDeclarationOnly --paths null",
+    "build": "node ./scripts/build.js && tsc -p tsconfig.build.json --emitDeclarationOnly --paths null && tsc -p tsconfig.test.json --paths null",
     "build:dev": "yarn prebuild && tsc --build --watch --preserveWatchOutput",
     "build:oss": "node ./scripts/build.js",
     "check:types": "tsc -p tsconfig.json --noEmit --paths null",

--- a/packages/backend-core/tsconfig.test.json
+++ b/packages/backend-core/tsconfig.test.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "sourceMap": true
   },
   "include": ["tests/**/*.js", "tests/**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/packages/backend-core/tsconfig.test.json
+++ b/packages/backend-core/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["tests/**/*.js", "tests/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Description
After a monorepo refactor (https://github.com/Budibase/budibase/pull/15128) we stopped adding the tests files in the backend-core npm package. These are used in places such as account-portal, and they might be used somewhere else.
This PR adds this files explicitly, to fix it avoiding to be oversighted again.

Updated dist folder:
![image](https://github.com/user-attachments/assets/11c0b742-4a66-4cb9-80e2-2da0d9192c50)



Matches the working version:
<img width="788" alt="image" src="https://github.com/user-attachments/assets/d6477bd2-a199-4f9d-a296-bb038b209b55" />



## Launchcontrol
Re-add test files in backend-core/dist