### PR TITLE
fix column names with spaces for relationship columns

### DIFF
--- a/packages/backend-core/src/sql/sql.ts
+++ b/packages/backend-core/src/sql/sql.ts
@@ -1191,7 +1191,7 @@ class InternalBuilder {
             query = query.orderByRaw(`?? ?? nulls ??`, [
               this.rawQuotedIdentifier(composite),
               this.knex.raw(direction),
-              this.knex.raw(nulls as string)
+              this.knex.raw(nulls as string),
             ])
           }
         }

--- a/packages/backend-core/src/sql/sql.ts
+++ b/packages/backend-core/src/sql/sql.ts
@@ -1167,15 +1167,14 @@ class InternalBuilder {
         let nulls: "first" | "last" | undefined = undefined
         if (
           this.client === SqlClient.POSTGRES ||
-          this.client === SqlClient.ORACLE
+          this.client === SqlClient.ORACLE ||
+          this.client === SqlClient.SQL_LITE
         ) {
           nulls = value.direction === SortOrder.ASCENDING ? "first" : "last"
         }
 
         if (this.isAggregateField(key)) {
-          // query = query.orderBy(this.quotedIdentifier(key), direction, nulls)
-          // query = query.orderBy(this.rawQuotedIdentifier(key), direction, nulls)
-          query = query.orderByRaw(`?? ??`, [
+          query = query.orderByRaw(`?? ?? nulls ??`, [
             this.rawQuotedIdentifier(key),
             this.knex.raw(direction),
             this.knex.raw(nulls as string),
@@ -1189,11 +1188,11 @@ class InternalBuilder {
               this.knex.raw(nulls as string),
             ])
           } else {
-            query = query.orderByRaw(`?? ??`, [
+            query = query.orderByRaw(`?? ?? nulls ??`, [
               this.rawQuotedIdentifier(composite),
               this.knex.raw(direction),
+              this.knex.raw(nulls as string)
             ])
-            // query = query.orderBy(this.quotedIdentifier(key), direction, nulls)
           }
         }
       }

--- a/packages/backend-core/src/sql/sql.ts
+++ b/packages/backend-core/src/sql/sql.ts
@@ -1162,20 +1162,14 @@ class InternalBuilder {
         const direction =
           value.direction === SortOrder.ASCENDING ? "asc" : "desc"
 
-        // TODO: figure out a way to remove this conditional, not relying on
-        // the defaults of each datastore.
-        let nulls: "first" | "last" | undefined = undefined
-        if (
-          this.client === SqlClient.POSTGRES ||
-          this.client === SqlClient.ORACLE
-        ) {
-          nulls = value.direction === SortOrder.ASCENDING ? "first" : "last"
-        }
+        let nulls: "first" | "last" =
+          value.direction === SortOrder.ASCENDING ? "first" : "last"
 
         if (this.isAggregateField(key)) {
-          query = query.orderByRaw(`?? ??`, [
+          query = query.orderByRaw(`?? ?? nulls ??`, [
             this.rawQuotedIdentifier(key),
             this.knex.raw(direction),
+            this.knex.raw(nulls as string),
           ])
         } else {
           let composite = `${aliased}.${key}`
@@ -1186,9 +1180,10 @@ class InternalBuilder {
               this.knex.raw(nulls as string),
             ])
           } else {
-            query = query.orderByRaw(`?? ??`, [
+            query = query.orderByRaw(`?? ?? nulls ??`, [
               this.rawQuotedIdentifier(composite),
               this.knex.raw(direction),
+              this.knex.raw(nulls as string),
             ])
           }
         }

--- a/packages/backend-core/src/sql/sql.ts
+++ b/packages/backend-core/src/sql/sql.ts
@@ -1167,17 +1167,15 @@ class InternalBuilder {
         let nulls: "first" | "last" | undefined = undefined
         if (
           this.client === SqlClient.POSTGRES ||
-          this.client === SqlClient.ORACLE ||
-          this.client === SqlClient.SQL_LITE
+          this.client === SqlClient.ORACLE
         ) {
           nulls = value.direction === SortOrder.ASCENDING ? "first" : "last"
         }
 
         if (this.isAggregateField(key)) {
-          query = query.orderByRaw(`?? ?? nulls ??`, [
+          query = query.orderByRaw(`?? ??`, [
             this.rawQuotedIdentifier(key),
             this.knex.raw(direction),
-            this.knex.raw(nulls as string),
           ])
         } else {
           let composite = `${aliased}.${key}`
@@ -1188,10 +1186,9 @@ class InternalBuilder {
               this.knex.raw(nulls as string),
             ])
           } else {
-            query = query.orderByRaw(`?? ?? nulls ??`, [
+            query = query.orderByRaw(`?? ??`, [
               this.rawQuotedIdentifier(composite),
               this.knex.raw(direction),
-              this.knex.raw(nulls as string),
             ])
           }
         }

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -3650,48 +3650,50 @@ if (descriptions.length) {
         })
       })
 
-      describe("Fields with spaces", () => {
-        let table: Table
-        let otherTable: Table
-        let relatedRow: Row, mainRow: Row
+      if (isInternal || isMSSQL) {
+        describe("Fields with spaces", () => {
+          let table: Table
+          let otherTable: Table
+          let relatedRow: Row
 
-        beforeAll(async () => {
-          otherTable = await config.api.table.save(defaultTable())
-          table = await config.api.table.save(
-            saveTableRequest({
-              schema: {
-                links: {
-                  name: "links",
-                  fieldName: "links",
-                  type: FieldType.LINK,
-                  tableId: otherTable._id!,
-                  relationshipType: RelationshipType.ONE_TO_MANY,
+          beforeAll(async () => {
+            otherTable = await config.api.table.save(defaultTable())
+            table = await config.api.table.save(
+              saveTableRequest({
+                schema: {
+                  links: {
+                    name: "links",
+                    fieldName: "links",
+                    type: FieldType.LINK,
+                    tableId: otherTable._id!,
+                    relationshipType: RelationshipType.ONE_TO_MANY,
+                  },
+                  "nameWithSpace ": {
+                    name: "nameWithSpace ",
+                    type: FieldType.STRING,
+                  },
                 },
-                "nameWithSpace ": {
-                  name: "nameWithSpace ",
-                  type: FieldType.STRING,
-                },
-              },
+              })
+            )
+            relatedRow = await config.api.row.save(otherTable._id!, {
+              name: generator.word(),
+              description: generator.paragraph(),
             })
-          )
-          relatedRow = await config.api.row.save(otherTable._id!, {
-            name: generator.word(),
-            description: generator.paragraph(),
+            await config.api.row.save(table._id!, {
+              "nameWithSpace ": generator.word(),
+              tableId: table._id!,
+              links: [relatedRow._id],
+            })
           })
-          mainRow = await config.api.row.save(table._id!, {
-            "nameWithSpace ": generator.word(),
-            tableId: table._id!,
-            links: [relatedRow._id],
-          })
-        })
 
-        it("Successfully returns rows that have spaces in their field names", async () => {
-          const { rows } = await config.api.row.search(table._id!)
-          expect(rows.length).toBe(1)
-          const row = rows[0]
-          expect(row["nameWithSpace "]).toBeDefined()
+          it("Successfully returns rows that have spaces in their field names", async () => {
+            const { rows } = await config.api.row.search(table._id!)
+            expect(rows.length).toBe(1)
+            const row = rows[0]
+            expect(row["nameWithSpace "]).toBeDefined()
+          })
         })
-      })
+      }
 
       if (!isInternal && !isOracle) {
         describe("bigint ids", () => {

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -3650,6 +3650,49 @@ if (descriptions.length) {
         })
       })
 
+      describe("Fields with spaces", () => {
+        let table: Table
+        let otherTable: Table
+        let relatedRow: Row, mainRow: Row
+
+        beforeAll(async () => {
+          otherTable = await config.api.table.save(defaultTable())
+          table = await config.api.table.save(
+            saveTableRequest({
+              schema: {
+                links: {
+                  name: "links",
+                  fieldName: "links",
+                  type: FieldType.LINK,
+                  tableId: otherTable._id!,
+                  relationshipType: RelationshipType.ONE_TO_MANY,
+                },
+                "nameWithSpace ": {
+                  name: "nameWithSpace ",
+                  type: FieldType.STRING,
+                },
+              },
+            })
+          )
+          relatedRow = await config.api.row.save(otherTable._id!, {
+            name: generator.word(),
+            description: generator.paragraph(),
+          })
+          mainRow = await config.api.row.save(table._id!, {
+            "nameWithSpace ": generator.word(),
+            tableId: table._id!,
+            links: [relatedRow._id],
+          })
+        })
+
+        it("Successfully returns rows that have spaces in their field names", async () => {
+          const { rows } = await config.api.row.search(table._id!)
+          expect(rows.length).toBe(1)
+          const row = rows[0]
+          expect(row["nameWithSpace "]).toBeDefined()
+        })
+      })
+
       if (!isInternal && !isOracle) {
         describe("bigint ids", () => {
           let table1: Table, table2: Table

--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -276,6 +276,7 @@ class SqlServerIntegration extends Sql implements DatasourcePlus {
           encrypt,
           enableArithAbort: true,
           requestTimeout: env.QUERY_THREAD_TIMEOUT,
+          connectTimeout: env.QUERY_THREAD_TIMEOUT,
         },
       }
       if (encrypt) {


### PR DESCRIPTION
## Description
Column names with spaces at the end were being trimmed in some places by knex, causing the query to fail and no rows to be returned. We need to wrap them in a `knex.raw` so the spaces are preserved

## Addresses
- https://linear.app/budibase/issue/BUDI-8973/rows-being-deleted-after-changing-tables-or-going-on-something-else