### PR TITLE
login platform user after forced password reset

### DIFF
--- a/packages/builder/src/pages/builder/auth/reset.svelte
+++ b/packages/builder/src/pages/builder/auth/reset.svelte
@@ -30,10 +30,16 @@
     try {
       loading = true
       if (forceResetPassword) {
+        const email = $auth.user.email
+        const tenantId = $auth.user.tenantId
         await auth.updateSelf({
           password,
           forceResetPassword: false,
         })
+        if (!$auth.user) {
+          // Update self will clear the platform user, so need to login
+          await auth.login(email, password, tenantId)
+        }
         $goto("../portal/")
       } else {
         await auth.resetPassword(password, resetCode)

--- a/packages/builder/src/stores/portal/auth.ts
+++ b/packages/builder/src/stores/portal/auth.ts
@@ -121,8 +121,8 @@ class AuthStore extends BudiStore<PortalAuthStore> {
     }
   }
 
-  async login(username: string, password: string) {
-    const tenantId = get(this.store).tenantId
+  async login(username: string, password: string, targetTenantId?: string) {
+    const tenantId = targetTenantId || get(this.store).tenantId
     await API.logIn(tenantId, username, password)
     await this.getSelf()
   }


### PR DESCRIPTION
## Description
Small bug fix relating to platform users with generated passwords. Originally the user would be logged out after changing their password, not they are automatically logged in. 

## Addresses
- https://linear.app/budibase/issue/GRO-822/when-a-user-is-invited-and-they-reset-password-auto-login

## Screenshots
https://github.com/user-attachments/assets/52577806-90c4-4fd4-accf-1ecf4c882840

