### PR TITLE
Fix selecting 'old row' in row updated trigger.

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -293,7 +293,7 @@
               type: RowSelector,
               props: {
                 row: inputData["oldRow"] || {
-                  tableId: inputData["row"].tableId,
+                  tableId: inputData["row"]?.tableId,
                 },
                 meta: {
                   fields: inputData["meta"]?.oldFields || {},


### PR DESCRIPTION
## Description

If you have an automation with the trigger "row updated" and you open the test data modal and select "old row", it currently does not work.

![CleanShot 2025-01-23 at 17 34 19@2x](https://github.com/user-attachments/assets/25260997-7406-4551-8bf0-254d577e7a95)

Was a simple missing null check, this PR fixes it.

## Launchcontrol

- Fixes a missing null check when selecting "old row" to populate test data for an automation run.
