### PR TITLE
Add feature flag for datasource setting checks

### DIFF
--- a/packages/builder/src/helpers/index.ts
+++ b/packages/builder/src/helpers/index.ts
@@ -9,3 +9,4 @@ export {
   lowercase,
   isBuilderInputFocused,
 } from "./helpers"
+export * as featureFlag from "./featureFlags"

--- a/packages/builder/src/stores/builder/screenComponent.ts
+++ b/packages/builder/src/stores/builder/screenComponent.ts
@@ -5,9 +5,15 @@ import { viewsV2 } from "./viewsV2"
 import { findComponentsBySettingsType } from "@/helpers/screen"
 import { Screen, Table, ViewV2 } from "@budibase/types"
 
+import { featureFlag } from "@/helpers"
+
 export const screenComponentErrors = derived(
   [selectedScreen, tables, viewsV2],
   ([$selectedScreen, $tables, $viewsV2]): Record<string, string[]> => {
+    if (!featureFlag.isEnabled("CHECK_SCREEN_COMPONENT_SETTINGS_ERRORS")) {
+      return {}
+    }
+
     function flattenTablesAndViews(tables: Table[], views: ViewV2[]) {
       return {
         ...tables.reduce(

--- a/packages/types/src/sdk/featureFlag.ts
+++ b/packages/types/src/sdk/featureFlag.ts
@@ -1,5 +1,6 @@
 export enum FeatureFlag {
   USE_ZOD_VALIDATOR = "USE_ZOD_VALIDATOR",
+  CHECK_SCREEN_COMPONENT_SETTINGS_ERRORS = "CHECK_SCREEN_COMPONENT_SETTINGS_ERRORS",
 
   // Account-portal
   DIRECT_LOGIN_TO_ACCOUNT_PORTAL = "DIRECT_LOGIN_TO_ACCOUNT_PORTAL",
@@ -7,6 +8,7 @@ export enum FeatureFlag {
 
 export const FeatureFlagDefaults = {
   [FeatureFlag.USE_ZOD_VALIDATOR]: false,
+  [FeatureFlag.CHECK_SCREEN_COMPONENT_SETTINGS_ERRORS]: false,
 
   // Account-portal
   [FeatureFlag.DIRECT_LOGIN_TO_ACCOUNT_PORTAL]: false,


### PR DESCRIPTION
## Description
Add feature flag for datasource setting checks. This should be a safe feature, but if something goes wrong the builder might not load the components as it should. This is adding a quick way to disable it.