### PR TITLE
Validate screen relationship datasource settings

### DIFF
--- a/packages/builder/src/components/design/settings/controls/DataSourceSelect/DataSourceSelect.svelte
+++ b/packages/builder/src/components/design/settings/controls/DataSourceSelect/DataSourceSelect.svelte
@@ -31,7 +31,11 @@
   import IntegrationQueryEditor from "@/components/integration/index.svelte"
   import { makePropSafe as safe } from "@budibase/string-templates"
   import { findAllComponents } from "@/helpers/components"
-  import { extractFields, extractRelationships } from "@/helpers/bindings"
+  import {
+    extractFields,
+    extractJSONArrayFields,
+    extractRelationships,
+  } from "@/helpers/bindings"
   import ClientBindingPanel from "@/components/common/bindings/ClientBindingPanel.svelte"
   import DataSourceCategory from "@/components/design/settings/controls/DataSourceSelect/DataSourceCategory.svelte"
   import { API } from "@/api"
@@ -84,27 +88,7 @@
     }))
   $: links = extractRelationships(bindings)
   $: fields = extractFields(bindings)
-  $: jsonArrays = bindings
-    .filter(
-      x =>
-        x.fieldSchema?.type === "jsonarray" ||
-        (x.fieldSchema?.type === "json" && x.fieldSchema?.subtype === "array")
-    )
-    .map(binding => {
-      const { providerId, readableBinding, runtimeBinding, tableId } = binding
-      const { name, type, prefixKeys, subtype } = binding.fieldSchema
-      return {
-        providerId,
-        label: readableBinding,
-        fieldName: name,
-        fieldType: type,
-        tableId,
-        prefixKeys,
-        type: type === "jsonarray" ? "jsonarray" : "queryarray",
-        subtype,
-        value: `{{ literal ${runtimeBinding} }}`,
-      }
-    })
+  $: jsonArrays = extractJSONArrayFields(bindings)
   $: custom = {
     type: "custom",
     label: "JSON / CSV",

--- a/packages/builder/src/helpers/bindings.ts
+++ b/packages/builder/src/helpers/bindings.ts
@@ -1,0 +1,50 @@
+import { makePropSafe } from "@budibase/string-templates"
+import { UIBinding } from "@budibase/types"
+
+export function extractRelationships(bindings: UIBinding[]) {
+  return (
+    bindings
+      // Get only link bindings
+      .filter(x => x.fieldSchema?.type === "link")
+      // Filter out bindings provided by forms
+      .filter(x => !x.component?.endsWith("/form"))
+      .map(binding => {
+        const { providerId, readableBinding, fieldSchema } = binding || {}
+        const { name, tableId } = fieldSchema || {}
+        const safeProviderId = makePropSafe(providerId)
+        return {
+          providerId,
+          label: readableBinding,
+          fieldName: name,
+          tableId,
+          type: "link",
+          // These properties will be enriched by the client library and provide
+          // details of the parent row of the relationship field, from context
+          rowId: `{{ ${safeProviderId}.${makePropSafe("_id")} }}`,
+          rowTableId: `{{ ${safeProviderId}.${makePropSafe("tableId")} }}`,
+        }
+      })
+  )
+}
+
+export function extractFields(bindings: UIBinding[]) {
+  return bindings
+    .filter(
+      x =>
+        x.fieldSchema?.type === "attachment" ||
+        (x.fieldSchema?.type === "array" && x.tableId)
+    )
+    .map(binding => {
+      const { providerId, readableBinding, runtimeBinding } = binding
+      const { name, type, tableId } = binding.fieldSchema!
+      return {
+        providerId,
+        label: readableBinding,
+        fieldName: name,
+        fieldType: type,
+        tableId,
+        type: "field",
+        value: `{{ literal ${runtimeBinding} }}`,
+      }
+    })
+}

--- a/packages/builder/src/helpers/bindings.ts
+++ b/packages/builder/src/helpers/bindings.ts
@@ -48,3 +48,27 @@ export function extractFields(bindings: UIBinding[]) {
       }
     })
 }
+
+export function extractJSONArrayFields(bindings: UIBinding[]) {
+  return bindings
+    .filter(
+      x =>
+        x.fieldSchema?.type === "jsonarray" ||
+        (x.fieldSchema?.type === "json" && x.fieldSchema?.subtype === "array")
+    )
+    .map(binding => {
+      const { providerId, readableBinding, runtimeBinding, tableId } = binding
+      const { name, type, prefixKeys, subtype } = binding.fieldSchema!
+      return {
+        providerId,
+        label: readableBinding,
+        fieldName: name,
+        fieldType: type,
+        tableId,
+        prefixKeys,
+        type: type === "jsonarray" ? "jsonarray" : "queryarray",
+        subtype,
+        value: `{{ literal ${runtimeBinding} }}`,
+      }
+    })
+}

--- a/packages/builder/src/helpers/index.ts
+++ b/packages/builder/src/helpers/index.ts
@@ -10,3 +10,4 @@ export {
   isBuilderInputFocused,
 } from "./helpers"
 export * as featureFlag from "./featureFlags"
+export * as bindings from "./bindings"

--- a/packages/builder/src/stores/builder/screenComponent.ts
+++ b/packages/builder/src/stores/builder/screenComponent.ts
@@ -69,9 +69,6 @@ export const screenComponentErrors = derived(
         const type = componentSettings.type as UIDatasourceType
 
         const validationKey = validationKeyByType[type]
-        if (type === "link") {
-          debugger
-        }
         if (!validationKey) {
           continue
         }

--- a/packages/types/src/ui/bindings/binding.ts
+++ b/packages/types/src/ui/bindings/binding.ts
@@ -31,6 +31,8 @@ export interface UIBinding {
     name: string
     tableId: string
     type: string
+    subtype?: string
+    prefixKeys?: string
   }
   component?: string
   providerId: string

--- a/packages/types/src/ui/bindings/binding.ts
+++ b/packages/types/src/ui/bindings/binding.ts
@@ -24,3 +24,16 @@ export type InsertAtPositionFn = (_: {
   value: string
   cursor?: { anchor: number }
 }) => void
+
+export interface UIBinding {
+  tableId?: string
+  fieldSchema?: {
+    name: string
+    tableId: string
+    type: string
+  }
+  component?: string
+  providerId: string
+  readableBinding?: string
+  runtimeBinding?: string
+}

--- a/packages/types/src/ui/datasource.ts
+++ b/packages/types/src/ui/datasource.ts
@@ -1,1 +1,7 @@
-export type UIDatasourceType = "table" | "view" | "viewV2" | "query" | "custom"
+export type UIDatasourceType =
+  | "table"
+  | "view"
+  | "viewV2"
+  | "query"
+  | "custom"
+  | "link"


### PR DESCRIPTION
## Description
Adding validation for relationship fields in datasource selectors. Follow up of https://github.com/Budibase/budibase/pull/15433

### Before
If a component was referencing an element it did not exist on the component chain, it would not complain. It would just return no rows.

https://github.com/user-attachments/assets/a3697f35-e2d8-43e7-8d45-4a2cbbf2f995

The same would happen if the relationship were dropped
<img width="1502" alt="image" src="https://github.com/user-attachments/assets/4656186e-d4d7-4845-b70e-1dd75a37765b" />


### After
The component using the invalid datasource will complain (either because of a wrong component tree or a dropped relationship)

https://github.com/user-attachments/assets/931e3d78-65d9-4680-b92f-563bb1842a2c



<img width="1502" alt="image" src="https://github.com/user-attachments/assets/40b979a3-5df6-4145-ae15-8416024344e2" />


## Launchcontrol
Validation relationship fields in datasource settings in components.
