### PR TITLE
Validate screen field datasource settings

### DIFF
--- a/packages/builder/src/stores/builder/screenComponent.ts
+++ b/packages/builder/src/stores/builder/screenComponent.ts
@@ -33,6 +33,7 @@ const validationKeyByType: Record<UIDatasourceType, string | null> = {
   query: "_id",
   custom: null,
   link: "rowId",
+  field: "label",
 }
 
 export const screenComponentErrors = derived(
@@ -72,6 +73,7 @@ export const screenComponentErrors = derived(
             "rowId",
             bindings.extractRelationships(componentBindings)
           ),
+          ...reduceBy("label", bindings.extractFields(componentBindings)),
         }
 
         const resourceId = componentSettings[validationKey]

--- a/packages/builder/src/stores/builder/screenComponent.ts
+++ b/packages/builder/src/stores/builder/screenComponent.ts
@@ -33,7 +33,7 @@ const validationKeyByType: Record<UIDatasourceType, string | null> = {
   query: "_id",
   custom: null,
   link: "rowId",
-  field: "label",
+  field: "value",
 }
 
 export const screenComponentErrors = derived(
@@ -73,7 +73,7 @@ export const screenComponentErrors = derived(
             "rowId",
             bindings.extractRelationships(componentBindings)
           ),
-          ...reduceBy("label", bindings.extractFields(componentBindings)),
+          ...reduceBy("value", bindings.extractFields(componentBindings)),
         }
 
         const resourceId = componentSettings[validationKey]

--- a/packages/types/src/ui/datasource.ts
+++ b/packages/types/src/ui/datasource.ts
@@ -5,3 +5,4 @@ export type UIDatasourceType =
   | "query"
   | "custom"
   | "link"
+  | "field"


### PR DESCRIPTION
## Description
Following https://github.com/Budibase/budibase/pull/15439 and https://github.com/Budibase/budibase/pull/15433, validate data providers settings of type fields


## Screenshots

https://github.com/user-attachments/assets/d2b86c86-05fb-4c38-9561-3dcb3b33e3de



## Launchcontrol
Validation fields in datasource settings in components.