### PR TITLE
Validate screen json array datasource settings

### DIFF
--- a/packages/builder/src/stores/builder/screenComponent.ts
+++ b/packages/builder/src/stores/builder/screenComponent.ts
@@ -34,6 +34,7 @@ const validationKeyByType: Record<UIDatasourceType, string | null> = {
   custom: null,
   link: "rowId",
   field: "value",
+  jsonarray: "value",
 }
 
 export const screenComponentErrors = derived(
@@ -74,6 +75,10 @@ export const screenComponentErrors = derived(
             bindings.extractRelationships(componentBindings)
           ),
           ...reduceBy("value", bindings.extractFields(componentBindings)),
+          ...reduceBy(
+            "value",
+            bindings.extractJSONArrayFields(componentBindings)
+          ),
         }
 
         const resourceId = componentSettings[validationKey]

--- a/packages/types/src/ui/datasource.ts
+++ b/packages/types/src/ui/datasource.ts
@@ -6,3 +6,4 @@ export type UIDatasourceType =
   | "custom"
   | "link"
   | "field"
+  | "jsonarray"


### PR DESCRIPTION
## Description
Following https://github.com/Budibase/budibase/pull/15439 and https://github.com/Budibase/budibase/pull/15433, validate data providers settings of type json arrays


## Screenshots

https://github.com/user-attachments/assets/7033d90c-a071-4c2c-8aba-63805c938efe






## Launchcontrol
Validation json arrays in datasource settings in components.