### PR TITLE
Fix applying styles to Popover.

### DIFF
--- a/packages/bbui/src/Actions/position_dropdown.ts
+++ b/packages/bbui/src/Actions/position_dropdown.ts
@@ -240,7 +240,12 @@ export default function positionDropdown(element: HTMLElement, opts: Opts) {
     }
 
     for (const [key, value] of Object.entries(styles)) {
-      element.style.setProperty(key, value ? `${value}px` : null)
+      const name = key as keyof Styles
+      if (value != null) {
+        element.style[name] = `${value}px`
+      } else {
+        element.style[name] = ""
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Recent typing changes caused some styles to not be applied to the `<Popover>` element, e.g. maxHeight was doing nothing causing popovers to overflow the page.
