### PR TITLE
Fix adding component after undo

### DIFF
--- a/packages/builder/src/stores/builder/automations.ts
+++ b/packages/builder/src/stores/builder/automations.ts
@@ -1437,8 +1437,6 @@ class AutomationStore extends BudiStore<AutomationState> {
     this.history = createHistoryStore({
       getDoc: this.actions.getDefinition.bind(this),
       selectDoc: this.actions.select.bind(this),
-      beforeAction: () => {},
-      afterAction: () => {},
     })
 
     // Then wrap save and delete with history

--- a/packages/builder/src/stores/builder/components.ts
+++ b/packages/builder/src/stores/builder/components.ts
@@ -376,7 +376,7 @@ export class ComponentStore extends BudiStore<ComponentState> {
             getSchemaForDatasource(screen, dataSource, {})
 
           // Finds fields by types from the schema of the configured datasource
-          const findFieldTypes = (fieldTypes: any) => {
+          const findFieldTypes = (fieldTypes: FieldType | FieldType[]) => {
             if (!Array.isArray(fieldTypes)) {
               fieldTypes = [fieldTypes]
             }
@@ -531,7 +531,7 @@ export class ComponentStore extends BudiStore<ComponentState> {
   async create(
     componentName: string,
     presetProps: any,
-    parent: any,
+    parent: Component,
     index: number
   ) {
     const state = get(this.store)

--- a/packages/builder/src/stores/builder/components.ts
+++ b/packages/builder/src/stores/builder/components.ts
@@ -254,7 +254,10 @@ export class ComponentStore extends BudiStore<ComponentState> {
    * @param {object} opts
    * @returns
    */
-  enrichEmptySettings(component: Component, opts: any) {
+  enrichEmptySettings(
+    component: Component,
+    opts: { screen?: Screen; parent?: Component; useDefaultValues?: boolean }
+  ) {
     if (!component?._component) {
       return
     }
@@ -1339,7 +1342,7 @@ export const componentStore = new ComponentStore()
 
 export const selectedComponent = derived(
   [componentStore, selectedScreen],
-  ([$store, $selectedScreen]) => {
+  ([$store, $selectedScreen]): Component | null => {
     if (
       $selectedScreen &&
       $store.selectedComponentId?.startsWith(`${$selectedScreen._id}-`)

--- a/packages/builder/src/stores/builder/history.js
+++ b/packages/builder/src/stores/builder/history.js
@@ -16,8 +16,8 @@ export const initialState = {
 export const createHistoryStore = ({
   getDoc,
   selectDoc,
-  beforeAction,
-  afterAction,
+  beforeAction = () => {},
+  afterAction = () => {},
 }) => {
   // Use a derived store to check if we are able to undo or redo any operations
   const store = writable(initialState)

--- a/packages/builder/src/stores/builder/screens.ts
+++ b/packages/builder/src/stores/builder/screens.ts
@@ -58,13 +58,12 @@ export class ScreenStore extends BudiStore<ScreenState> {
       getDoc: (id: string) =>
         get(this.store).screens?.find(screen => screen._id === id),
       selectDoc: this.select,
-      beforeAction: () => {},
       afterAction: () => {
         // Ensure a valid component is selected
         if (!get(selectedComponent)) {
-          this.update(state => ({
+          componentStore.update(state => ({
             ...state,
-            selectedComponentId: get(selectedScreen)?.props._id,
+            selectedComponentId: get(selectedScreen)?._id,
           }))
         }
       },


### PR DESCRIPTION
## Description
Fixing a small bug that broke adding a component after an undo action. In that state, the current selected element is empty, and this breaks adding a new component until a new component is selected. Based on the code, in this case we were meant to select the top level screen. This PR fixes it.

### Before

https://github.com/user-attachments/assets/871363c5-6bdf-403e-b4e3-4b90861215ca

### After

https://github.com/user-attachments/assets/c3950be9-f7c1-4011-8631-cb5108b7f511



## Launchcontrol
Fix adding a component immediately an undo action