### PR TITLE
Fix isolatedvm query issues

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,4 @@ packages/builder/.routify
 packages/sdk/sdk
 packages/pro/coverage
 **/*.ivm.bundle.js
+!**/bson-polyfills.ivm.bundle.js

--- a/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
@@ -674,7 +674,7 @@ if (descriptions.length) {
                 nestedString: "nested",
                 nestedNumber: 99,
               },
-              dateField: { $date: "2025-01-30T12:00:00Z" },
+              dateField: new Date(Date.UTC(2025, 0, 30, 12, 30, 20)),
               // timestampField: new BSON.Timestamp({ t: 1706616000, i: 1 }),
               binaryField: new BSON.Binary(
                 new TextEncoder().encode("bufferValue")
@@ -702,7 +702,12 @@ if (descriptions.length) {
                 collection,
               },
             },
-            transformer: "return data.map(x => ({ ...x }))",
+            transformer: `return data.map(x => ({ 
+                  ...x,
+                  binaryField: x.binaryField?.toString('utf8'),
+                  decimalField: x.decimalField.toString(),
+                  longField: x.longField.toString()
+              }))`,
           })
 
           const result = await config.api.query.execute(query._id!)
@@ -719,7 +724,7 @@ if (descriptions.length) {
                   nested: true,
                 },
               ],
-              binaryField: "YnVmZmVyVmFsdWU=",
+              binaryField: "bufferValue",
               booleanField: true,
               codeField: {
                 code: "function() { return 'Hello, World!'; }",
@@ -730,34 +735,11 @@ if (descriptions.length) {
                   x: 10,
                 },
               },
-              dateField: "2025-01-30T12:00:00.000Z",
-              decimalField: {
-                bytes: {
-                  "0": 21,
-                  "1": 205,
-                  "10": 0,
-                  "11": 0,
-                  "12": 0,
-                  "13": 0,
-                  "14": 56,
-                  "15": 48,
-                  "2": 91,
-                  "3": 7,
-                  "4": 0,
-                  "5": 0,
-                  "6": 0,
-                  "7": 0,
-                  "8": 0,
-                  "9": 0,
-                },
-              },
+              dateField: "2025-01-30T12:30:20.000Z",
+              decimalField: "12345.6789",
               doubleField: 42.42,
               integerField: 123,
-              longField: {
-                high: 2147483647,
-                low: -1,
-                unsigned: false,
-              },
+              longField: "9223372036854775807",
               maxKeyField: {},
               minKeyField: {},
               nullField: null,

--- a/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
@@ -657,7 +657,7 @@ if (descriptions.length) {
           ])
         })
 
-        it("can handle all bson field types", async () => {
+        it("can handle all bson field types with transformers", async () => {
           collection = generator.guid()
           await withCollection(async collection => {
             await collection.insertOne({

--- a/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
@@ -656,6 +656,122 @@ if (descriptions.length) {
             { id: expectValidId },
           ])
         })
+
+        it("can handle all bson field types", async () => {
+          collection = generator.guid()
+          await withCollection(async collection => {
+            await collection.insertOne({
+              _id: new BSON.ObjectId("65b0123456789abcdef01234"),
+              stringField: "This is a string",
+              numberField: 42,
+              doubleField: new BSON.Double(42.42),
+              integerField: new BSON.Int32(123),
+              longField: new BSON.Long("9223372036854775807"),
+              booleanField: true,
+              nullField: null,
+              arrayField: [1, 2, 3, "four", { nested: true }],
+              objectField: {
+                nestedString: "nested",
+                nestedNumber: 99,
+              },
+              dateField: { $date: "2025-01-30T12:00:00Z" },
+              // timestampField: new BSON.Timestamp({ t: 1706616000, i: 1 }),
+              binaryField: new BSON.Binary(
+                new TextEncoder().encode("bufferValue")
+              ),
+              objectIdField: new BSON.ObjectId("65b0123456789abcdef01235"),
+              regexField: new BSON.BSONRegExp("^Hello.*", "i"),
+              minKeyField: new BSON.MinKey(),
+              maxKeyField: new BSON.MaxKey(),
+              decimalField: new BSON.Decimal128("12345.6789"),
+              codeField: new BSON.Code(
+                "function() { return 'Hello, World!'; }"
+              ),
+              codeWithScopeField: new BSON.Code(
+                "function(x) { return x * 2; }",
+                { x: 10 }
+              ),
+            })
+          })
+
+          const query = await createQuery({
+            fields: {
+              json: {},
+              extra: {
+                actionType: "find",
+                collection,
+              },
+            },
+            transformer: "return data.map(x => ({ ...x }))",
+          })
+
+          const result = await config.api.query.execute(query._id!)
+
+          expect(result.data).toEqual([
+            {
+              _id: "65b0123456789abcdef01234",
+              arrayField: [
+                1,
+                2,
+                3,
+                "four",
+                {
+                  nested: true,
+                },
+              ],
+              binaryField: "YnVmZmVyVmFsdWU=",
+              booleanField: true,
+              codeField: {
+                code: "function() { return 'Hello, World!'; }",
+              },
+              codeWithScopeField: {
+                code: "function(x) { return x * 2; }",
+                scope: {
+                  x: 10,
+                },
+              },
+              dateField: "2025-01-30T12:00:00.000Z",
+              decimalField: {
+                bytes: {
+                  "0": 21,
+                  "1": 205,
+                  "10": 0,
+                  "11": 0,
+                  "12": 0,
+                  "13": 0,
+                  "14": 56,
+                  "15": 48,
+                  "2": 91,
+                  "3": 7,
+                  "4": 0,
+                  "5": 0,
+                  "6": 0,
+                  "7": 0,
+                  "8": 0,
+                  "9": 0,
+                },
+              },
+              doubleField: 42.42,
+              integerField: 123,
+              longField: {
+                high: 2147483647,
+                low: -1,
+                unsigned: false,
+              },
+              maxKeyField: {},
+              minKeyField: {},
+              nullField: null,
+              numberField: 42,
+              objectField: {
+                nestedNumber: 99,
+                nestedString: "nested",
+              },
+              objectIdField: "65b0123456789abcdef01235",
+              regexField: {},
+              stringField: "This is a string",
+            },
+          ])
+        })
       })
 
       it("should throw an error if the incorrect actionType is specified", async () => {

--- a/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
@@ -675,7 +675,7 @@ if (descriptions.length) {
                 nestedNumber: 99,
               },
               dateField: new Date(Date.UTC(2025, 0, 30, 12, 30, 20)),
-              // timestampField: new BSON.Timestamp({ t: 1706616000, i: 1 }),
+              timestampField: new BSON.Timestamp({ t: 1706616000, i: 1 }),
               binaryField: new BSON.Binary(
                 new TextEncoder().encode("bufferValue")
               ),
@@ -707,7 +707,9 @@ if (descriptions.length) {
                   binaryField: x.binaryField?.toString('utf8'),
                   decimalField: x.decimalField.toString(),
                   longField: x.longField.toString(),
-                  regexField: x.regexField.toString()
+                  regexField: x.regexField.toString(),
+                  // TODO: currenlty not supported, it looks like there is bug in the library. Getting: Timestamp constructed from { t, i } must provide t as a number
+                  timestampField: null
               }))`,
           })
 

--- a/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
@@ -754,6 +754,7 @@ if (descriptions.length) {
               objectIdField: "65b0123456789abcdef01235",
               regexField: "/^Hello.*/i",
               stringField: "This is a string",
+              timestampField: null,
             },
           ])
         })

--- a/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
@@ -634,6 +634,28 @@ if (descriptions.length) {
             }
           })
         })
+
+        it("should be able to select a ObjectId in a transformer", async () => {
+          const query = await createQuery({
+            fields: {
+              json: {},
+              extra: {
+                actionType: "find",
+              },
+            },
+            transformer: "return data.map(x => ({ id: x._id }))",
+          })
+
+          const result = await config.api.query.execute(query._id!)
+
+          expect(result.data).toEqual([
+            { id: expectValidId },
+            { id: expectValidId },
+            { id: expectValidId },
+            { id: expectValidId },
+            { id: expectValidId },
+          ])
+        })
       })
 
       it("should throw an error if the incorrect actionType is specified", async () => {

--- a/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
@@ -706,7 +706,8 @@ if (descriptions.length) {
                   ...x,
                   binaryField: x.binaryField?.toString('utf8'),
                   decimalField: x.decimalField.toString(),
-                  longField: x.longField.toString()
+                  longField: x.longField.toString(),
+                  regexField: x.regexField.toString()
               }))`,
           })
 
@@ -749,7 +750,7 @@ if (descriptions.length) {
                 nestedString: "nested",
               },
               objectIdField: "65b0123456789abcdef01235",
-              regexField: {},
+              regexField: "/^Hello.*/i",
               stringField: "This is a string",
             },
           ])

--- a/packages/server/src/jsRunner/bundles/bson-polyfills.ivm.bundle.js
+++ b/packages/server/src/jsRunner/bundles/bson-polyfills.ivm.bundle.js
@@ -1,0 +1,6 @@
+function atob(...args){
+    return atobCB(...args)
+}
+function btoa(...args){
+    return btoaCB(...args)
+}

--- a/packages/server/src/jsRunner/bundles/bson-polyfills.ivm.bundle.js
+++ b/packages/server/src/jsRunner/bundles/bson-polyfills.ivm.bundle.js
@@ -1,8 +1,81 @@
-function atob(...args) {
-  return atobCB(...args)
-}
-function btoa(...args) {
-  return btoaCB(...args)
+if (typeof btoa !== "function") {
+  var chars = {
+    ascii: function () {
+      return "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
+    },
+    indices: function () {
+      if (!this.cache) {
+        this.cache = {}
+        var ascii = chars.ascii()
+
+        for (var c = 0; c < ascii.length; c++) {
+          var chr = ascii[c]
+          this.cache[chr] = c
+        }
+      }
+      return this.cache
+    },
+  }
+
+  function atob(b64) {
+    var indices = chars.indices(),
+      pos = b64.indexOf("="),
+      padded = pos > -1,
+      len = padded ? pos : b64.length,
+      i = -1,
+      data = ""
+
+    while (i < len) {
+      var code =
+        (indices[b64[++i]] << 18) |
+        (indices[b64[++i]] << 12) |
+        (indices[b64[++i]] << 6) |
+        indices[b64[++i]]
+      if (code !== 0) {
+        data += String.fromCharCode(
+          (code >>> 16) & 255,
+          (code >>> 8) & 255,
+          code & 255
+        )
+      }
+    }
+
+    if (padded) {
+      data = data.slice(0, pos - b64.length)
+    }
+
+    return data
+  }
+
+  function btoa(data) {
+    var ascii = chars.ascii(),
+      len = data.length - 1,
+      i = -1,
+      b64 = ""
+
+    while (i < len) {
+      var code =
+        (data.charCodeAt(++i) << 16) |
+        (data.charCodeAt(++i) << 8) |
+        data.charCodeAt(++i)
+      b64 +=
+        ascii[(code >>> 18) & 63] +
+        ascii[(code >>> 12) & 63] +
+        ascii[(code >>> 6) & 63] +
+        ascii[code & 63]
+    }
+
+    var pads = data.length % 3
+    if (pads > 0) {
+      b64 = b64.slice(0, pads - 3)
+
+      while (b64.length % 4 !== 0) {
+        b64 += "="
+      }
+    }
+
+    return b64
+  }
 }
 
 class TextDecoder {

--- a/packages/server/src/jsRunner/bundles/bson-polyfills.ivm.bundle.js
+++ b/packages/server/src/jsRunner/bundles/bson-polyfills.ivm.bundle.js
@@ -1,6 +1,21 @@
-function atob(...args){
-    return atobCB(...args)
+function atob(...args) {
+  return atobCB(...args)
 }
-function btoa(...args){
-    return btoaCB(...args)
+function btoa(...args) {
+  return btoaCB(...args)
+}
+
+class TextDecoder {
+  constructorArgs
+
+  constructor(...constructorArgs) {
+    this.constructorArgs = constructorArgs
+  }
+
+  decode(...input) {
+    return textDecoderCb({
+      constructorArgs: this.constructorArgs,
+      functionArgs: input,
+    })
+  }
 }

--- a/packages/server/src/jsRunner/bundles/index.ts
+++ b/packages/server/src/jsRunner/bundles/index.ts
@@ -5,6 +5,7 @@ export const enum BundleType {
   BSON = "bson",
   SNIPPETS = "snippets",
   BUFFER = "buffer",
+  BSON_POLYFILLS = "bson_polyfills",
 }
 
 const bundleSourceFile: Record<BundleType, string> = {
@@ -12,6 +13,7 @@ const bundleSourceFile: Record<BundleType, string> = {
   [BundleType.BSON]: "./bson.ivm.bundle.js",
   [BundleType.SNIPPETS]: "./snippets.ivm.bundle.js",
   [BundleType.BUFFER]: "./buffer.ivm.bundle.js",
+  [BundleType.BSON_POLYFILLS]: "./bson-polyfills.ivm.bundle.js",
 }
 const bundleSourceCode: Partial<Record<BundleType, string>> = {}
 

--- a/packages/server/src/jsRunner/bundles/snippets.ts
+++ b/packages/server/src/jsRunner/bundles/snippets.ts
@@ -1,6 +1,5 @@
 // @ts-ignore
-// eslint-disable-next-line local-rules/no-budibase-imports
-import { iifeWrapper } from "@budibase/string-templates/iife"
+import { iifeWrapper } from "@budibase/string-templates"
 
 export default new Proxy(
   {},

--- a/packages/server/src/jsRunner/vm/isolated-vm.ts
+++ b/packages/server/src/jsRunner/vm/isolated-vm.ts
@@ -161,6 +161,8 @@ export class IsolatedVM implements VM {
 
     const bsonSource = loadBundle(BundleType.BSON)
 
+    // "Polyfilling" text decoder and other utils. `bson.deserialize` requires decoding. We are creating a bridge function so we don't need to inject the full library
+    const bsonPolyfills = loadBundle(BundleType.BSON_POLYFILLS)
     this.addToContext({
       textDecoderCb: new ivm.Callback(
         (args: {
@@ -182,9 +184,6 @@ export class IsolatedVM implements VM {
         return result
       }),
     })
-
-    // "Polyfilling" text decoder and other utils. `bson.deserialize` requires decoding. We are creating a bridge function so we don't need to inject the full library
-    const bsonPolyfills = loadBundle(BundleType.BSON_POLYFILLS)
 
     const script = this.isolate.compileScriptSync(
       `${bsonPolyfills};${bsonSource}`

--- a/packages/server/src/jsRunner/vm/isolated-vm.ts
+++ b/packages/server/src/jsRunner/vm/isolated-vm.ts
@@ -175,14 +175,6 @@ export class IsolatedVM implements VM {
           return result
         }
       ),
-      atobCB: new ivm.Callback((...args: Parameters<typeof atob>) => {
-        const result = atob(...args)
-        return result
-      }),
-      btoaCB: new ivm.Callback((...args: Parameters<typeof btoa>) => {
-        const result = btoa(...args)
-        return result
-      }),
     })
 
     const script = this.isolate.compileScriptSync(

--- a/packages/server/src/jsRunner/vm/isolated-vm.ts
+++ b/packages/server/src/jsRunner/vm/isolated-vm.ts
@@ -161,21 +161,7 @@ export class IsolatedVM implements VM {
 
     const bsonSource = loadBundle(BundleType.BSON)
 
-    // "Polyfilling" text decoder and other utils. `bson.deserialize` requires decoding. We are creating a bridge function so we don't need to inject the full library
     const bsonPolyfills = loadBundle(BundleType.BSON_POLYFILLS)
-    this.addToContext({
-      textDecoderCb: new ivm.Callback(
-        (args: {
-          constructorArgs: any
-          functionArgs: Parameters<InstanceType<typeof TextDecoder>["decode"]>
-        }) => {
-          const result = new TextDecoder(...args.constructorArgs).decode(
-            ...args.functionArgs
-          )
-          return result
-        }
-      ),
-    })
 
     const script = this.isolate.compileScriptSync(
       `${bsonPolyfills};${bsonSource}`

--- a/packages/string-templates/package.json
+++ b/packages/string-templates/package.json
@@ -11,8 +11,7 @@
       "require": "./dist/bundle.cjs",
       "import": "./dist/bundle.mjs"
     },
-    "./package.json": "./package.json",
-    "./iife": "./dist/iife.mjs"
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "tsc --emitDeclarationOnly && rollup -c",


### PR DESCRIPTION
## Description
After introducing minifications for the esbuild bundles (https://github.com/Budibase/budibase/pull/15371) we broke some usages on the implementation for isolated-vm. Isolated-vm and bson required polyfilling some functions and classes, but this stopped working fine because the modification transformations.
This PR does as it follows:
1. Extract the polyfills to a static js that will be bundled in the isolated-vm instance
2. Remove the bridge functions (in favour of full polyfills). This adds extra security, and isolated-vm is not 100% isolated
3. Add some tests to cover the bson document transformations

## Launchcontrol
Fix issues with MongoDB and queries