### PR TITLE
clear results context on every run

### DIFF
--- a/packages/server/src/jsRunner/tests/isolatedVM.spec.ts
+++ b/packages/server/src/jsRunner/tests/isolatedVM.spec.ts
@@ -112,10 +112,10 @@ describe("Test isolated vm directly", () => {
     const context = {}
     // throw error
     // Ensure the first execution throws an error
-    expect(() => runJSWithIsolatedVM(`test.foo.bar = 123`, context)).toThrow();
+    expect(() => runJSWithIsolatedVM(`test.foo.bar = 123`, context)).toThrow()
 
     // Ensure the error is not persisted across VMs
-    const secondResult = runJSWithIsolatedVM(`return {}`, context);
+    const secondResult = runJSWithIsolatedVM(`return {}`, context)
     expect(secondResult).toEqual({})
   })
 })

--- a/packages/server/src/jsRunner/tests/isolatedVM.spec.ts
+++ b/packages/server/src/jsRunner/tests/isolatedVM.spec.ts
@@ -107,4 +107,14 @@ describe("Test isolated vm directly", () => {
     )
     expect(result).toEqual([])
   })
+
+  it("should ensure error results are cleared between runs", () => {
+    const context = {}
+    // throw error
+    const result = runJSWithIsolatedVM(`test.foo.bar = 123`, context)
+    expect(result).toEqual({})
+    // ensure error not persisted across vms
+    const secondResult = runJSWithIsolatedVM(`return {}`, context)
+    expect(secondResult).toEqual({})
+  })
 })

--- a/packages/server/src/jsRunner/tests/isolatedVM.spec.ts
+++ b/packages/server/src/jsRunner/tests/isolatedVM.spec.ts
@@ -111,10 +111,11 @@ describe("Test isolated vm directly", () => {
   it("should ensure error results are cleared between runs", () => {
     const context = {}
     // throw error
-    const result = runJSWithIsolatedVM(`test.foo.bar = 123`, context)
-    expect(result).toEqual({})
-    // ensure error not persisted across vms
-    const secondResult = runJSWithIsolatedVM(`return {}`, context)
+    // Ensure the first execution throws an error
+    expect(() => runJSWithIsolatedVM(`test.foo.bar = 123`, context)).toThrow();
+
+    // Ensure the error is not persisted across VMs
+    const secondResult = runJSWithIsolatedVM(`return {}`, context);
     expect(secondResult).toEqual({})
   })
 })

--- a/packages/server/src/jsRunner/vm/isolated-vm.ts
+++ b/packages/server/src/jsRunner/vm/isolated-vm.ts
@@ -186,6 +186,7 @@ export class IsolatedVM implements VM {
 
     code = `
       try {
+        results = {}
         results['${this.runResultKey}']=${this.codeWrapper(code)}
       } catch (e) {
         results['${this.runErrorKey}']=e


### PR DESCRIPTION
## Description
Fix for formula columns persisting errors across runs.

## Addresses
- https://linear.app/budibase/issue/BUDI-9023/when-a-formula-column-errors-it-affects-other-formula-columns-within-a