### PR TITLE
Handle outside clicks when clicking the iframe

### DIFF
--- a/packages/bbui/src/Actions/click_outside.ts
+++ b/packages/bbui/src/Actions/click_outside.ts
@@ -34,14 +34,14 @@ let candidateTarget: HTMLElement | undefined
 // Processes a "click outside" event and invokes callbacks if our source element
 // is valid
 const handleClick = (e: MouseEvent) => {
-  const target = e.target as HTMLElement
+  const target = e.target as HTMLElement | null
 
   // Ignore click if this is an ignored class
-  if (target.closest('[data-ignore-click-outside="true"]')) {
+  if (target?.closest('[data-ignore-click-outside="true"]')) {
     return
   }
   for (let className of ignoredClasses) {
-    if (target.closest(className)) {
+    if (target?.closest(className)) {
       return
     }
   }
@@ -55,8 +55,8 @@ const handleClick = (e: MouseEvent) => {
 
     // Ignore clicks for certain classes unless we're nested inside them
     for (let className of conditionallyIgnoredClasses) {
-      const sourceInside = handler.anchor.closest(className) != null
-      const clickInside = target.closest(className) != null
+      const sourceInside = handler.anchor?.closest(className) != null
+      const clickInside = target?.closest(className) != null
       if (clickInside && !sourceInside) {
         return
       }

--- a/packages/bbui/src/Actions/click_outside.ts
+++ b/packages/bbui/src/Actions/click_outside.ts
@@ -37,11 +37,11 @@ const handleClick = (e: MouseEvent) => {
   const target = e.target as HTMLElement | null
 
   // Ignore click if this is an ignored class
-  if (target?.closest('[data-ignore-click-outside="true"]')) {
+  if (target?.closest?.('[data-ignore-click-outside="true"]')) {
     return
   }
   for (let className of ignoredClasses) {
-    if (target?.closest(className)) {
+    if (target?.closest?.(className)) {
       return
     }
   }
@@ -55,8 +55,8 @@ const handleClick = (e: MouseEvent) => {
 
     // Ignore clicks for certain classes unless we're nested inside them
     for (let className of conditionallyIgnoredClasses) {
-      const sourceInside = handler.anchor?.closest(className) != null
-      const clickInside = target?.closest(className) != null
+      const sourceInside = handler.anchor.closest(className) != null
+      const clickInside = target?.closest?.(className) != null
       if (clickInside && !sourceInside) {
         return
       }

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPreview.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPreview.svelte
@@ -214,6 +214,9 @@
         }
       }
       previewStore.setSelectedComponentContext(context)
+    } else if (type === "click") {
+      // TODO
+      console.error("click")
     } else {
       console.warn(`Client sent unknown event type: ${type}`)
     }

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPreview.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPreview.svelte
@@ -215,8 +215,8 @@
       }
       previewStore.setSelectedComponentContext(context)
     } else if (type === "click") {
-      // TODO
-      console.error("click")
+      // Force clickoutside to close modals or side panels from the builder
+      document.dispatchEvent(new MouseEvent("contextmenu"))
     } else {
       console.warn(`Client sent unknown event type: ${type}`)
     }

--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -44,6 +44,7 @@
   import MaintenanceScreen from "components/MaintenanceScreen.svelte"
   import SnippetsProvider from "./context/SnippetsProvider.svelte"
   import EmbedProvider from "./context/EmbedProvider.svelte"
+  import MouseManager from "components/preview/MouseManager.svelte"
 
   // Provide contexts
   setContext("sdk", SDK)
@@ -278,6 +279,7 @@
     {/if}
   </div>
   <KeyboardManager />
+  <MouseManager />
 {/if}
 
 <style>

--- a/packages/client/src/components/preview/MouseManager.svelte
+++ b/packages/client/src/components/preview/MouseManager.svelte
@@ -1,0 +1,25 @@
+<script>
+  import { onMount, onDestroy } from "svelte"
+  import { get } from "svelte/store"
+  import { builderStore } from "stores"
+
+  onMount(() => {
+    if (get(builderStore).inBuilder) {
+      document.addEventListener("click", onClick)
+    }
+  })
+
+  onDestroy(() => {
+    if (get(builderStore).inBuilder) {
+      document.removeEventListener("click", onClick)
+    }
+  })
+
+  const onClick = () => {
+    const state = get(builderStore)
+    if (!state.inBuilder || state.editMode) {
+      return
+    }
+    builderStore.actions.click()
+  }
+</script>

--- a/packages/client/src/stores/builder.js
+++ b/packages/client/src/stores/builder.js
@@ -50,6 +50,9 @@ const createBuilderStore = () => {
     keyDown: (key, ctrlKey) => {
       eventStore.actions.dispatchEvent("key-down", { key, ctrlKey })
     },
+    click: () => {
+      eventStore.actions.dispatchEvent("click")
+    },
     duplicateComponent: (id, mode = "below", selectComponent = true) => {
       eventStore.actions.dispatchEvent("duplicate-component", {
         id,

--- a/packages/client/src/utils/grid.ts
+++ b/packages/client/src/utils/grid.ts
@@ -109,8 +109,7 @@ export const gridLayout = (node: HTMLDivElement, metadata: GridMetadata) => {
     }
 
     // Callback to select the component when clicking on the wrapper
-    selectComponent = (e: Event) => {
-      e.stopPropagation()
+    selectComponent = () => {
       builderStore.actions.selectComponent(id)
     }
 

--- a/packages/client/src/utils/styleable.js
+++ b/packages/client/src/utils/styleable.js
@@ -67,10 +67,8 @@ export const styleable = (node, styles = {}) => {
 
     // Handler to select a component in the builder when clicking it in the
     // builder preview
-    selectComponent = event => {
+    selectComponent = () => {
       builderStore.actions.selectComponent(componentId)
-      event.preventDefault()
-      event.stopPropagation()
       return false
     }
 


### PR DESCRIPTION
## Description
The builder uses a `click_outside` hander in order to perform some operations such as closing modals and side panels. If we are in the design section, if we click in the iframe, this absorbs the click and the builder is not aware of it. This causes some inconsistencies in the UX.

https://github.com/user-attachments/assets/96bdec76-e0a0-4364-bb04-f8f3a9d668ca

This is even more visible in the new error popover:

https://github.com/user-attachments/assets/ff0477a0-5679-4802-8a1a-d4fddfbbc7d0

Happy to discuss the taken approach and other possible solutions.