### PR TITLE
Fix searching for a date on a string field.

### DIFF
--- a/packages/backend-core/src/sql/sql.ts
+++ b/packages/backend-core/src/sql/sql.ts
@@ -388,7 +388,7 @@ class InternalBuilder {
       }
     }
 
-    if (typeof input === "string") {
+    if (typeof input === "string" && schema.type === FieldType.DATETIME) {
       if (isInvalidISODateString(input)) {
         return null
       }

--- a/packages/server/src/api/routes/tests/search.spec.ts
+++ b/packages/server/src/api/routes/tests/search.spec.ts
@@ -1040,6 +1040,12 @@ if (descriptions.length) {
                     string: { name: "FO" },
                   }).toContainExactly([{ name: "foo" }])
                 })
+
+                it("should not coerce string to date for string columns", async () => {
+                  await expectQuery({
+                    string: { name: "2020-01-01" },
+                  }).toFindNothing()
+                })
               })
 
               describe("range", () => {


### PR DESCRIPTION
## Description

We were erroneously converting date formatted strings into date objects for searches against fields that were not `FieldType.DATETIME`, which caused these searches to return an error.

## Addresses
- https://linear.app/budibase/issue/BUDI-9018/searching-budidb-column-headings-in-the-data-tab-breaks-grid

## Launchcontrol

- Fix searching for date-formatted strings on non-date fields.
