### PR TITLE
Flesh out Google Sheets errors in testing to try and find a flake.

### DIFF
--- a/packages/server/src/integrations/tests/utils/googlesheets.ts
+++ b/packages/server/src/integrations/tests/utils/googlesheets.ts
@@ -609,7 +609,15 @@ export class GoogleSheetsMock {
       for (let col = startColumnIndex; col <= endColumnIndex; col++) {
         const cell = this.getCellNumericIndexes(sheetId, row, col)
         if (!cell) {
-          throw new Error("Cell not found")
+          const sheet = this.getSheetById(sheetId)
+          if (!sheet) {
+            throw new Error(`Sheet ${sheetId} not found`)
+          }
+          const sheetRows = sheet.data[0].rowData.length
+          const sheetCols = sheet.data[0].rowData[0].values.length
+          throw new Error(
+            `Failed to find cell at ${row}, ${col}. Range: ${valueRange.range}. Sheet dimensions: ${sheetRows}x${sheetCols}.`
+          )
         }
         const value =
           valueRange.values[row - startRowIndex][col - startColumnIndex]
@@ -638,7 +646,15 @@ export class GoogleSheetsMock {
       for (let col = startColumnIndex; col <= endColumnIndex; col++) {
         const cell = this.getCellNumericIndexes(sheetId, row, col)
         if (!cell) {
-          throw new Error("Cell not found")
+          const sheet = this.getSheetById(sheetId)
+          if (!sheet) {
+            throw new Error(`Sheet ${sheetId} not found`)
+          }
+          const sheetRows = sheet.data[0].rowData.length
+          const sheetCols = sheet.data[0].rowData[0].values.length
+          throw new Error(
+            `Failed to find cell at ${row}, ${col}. Range: ${valueRange.range}. Sheet dimensions: ${sheetRows}x${sheetCols}.`
+          )
         }
         values.push(this.cellValue(cell))
       }


### PR DESCRIPTION
We have a flake in our Google Sheets tests: https://github.com/Budibase/budibase/actions/runs/13157193175/job/36716957868?pr=15489.

I'm not sure how it happens, so this PR just makes error messages a little bit better for next time.
