### PR TITLE
Further automation builder refactoring.

### DIFF
--- a/packages/server/src/api/routes/tests/automation.spec.ts
+++ b/packages/server/src/api/routes/tests/automation.spec.ts
@@ -251,7 +251,7 @@ describe("/automations", () => {
         .serverLog({
           text: "{{ settings.company }}",
         })
-        .run({ fields: {} })
+        .test({ fields: {} })
 
       expect(result.steps[0].outputs.message).toEndWith("https://example.com")
       expect(result.steps[1].outputs.message).toEndWith(

--- a/packages/server/src/api/routes/tests/automation.spec.ts
+++ b/packages/server/src/api/routes/tests/automation.spec.ts
@@ -108,7 +108,7 @@ describe("/automations", () => {
 
     it("Should ensure you can't have a branch as not a last step", async () => {
       const automation = createAutomationBuilder(config)
-        .appAction()
+        .onAppAction()
         .branch({
           activeBranch: {
             steps: stepBuilder =>
@@ -132,7 +132,7 @@ describe("/automations", () => {
 
     it("Should check validation on an automation that has a branch step with no children", async () => {
       const automation = createAutomationBuilder(config)
-        .appAction()
+        .onAppAction()
         .branch({})
         .serverLog({ text: "Inactive user" })
         .build()
@@ -148,7 +148,7 @@ describe("/automations", () => {
 
     it("Should check validation on a branch step with empty conditions", async () => {
       const automation = createAutomationBuilder(config)
-        .appAction()
+        .onAppAction()
         .branch({
           activeBranch: {
             steps: stepBuilder =>
@@ -169,7 +169,7 @@ describe("/automations", () => {
 
     it("Should check validation on an branch that has a condition that is not valid", async () => {
       const automation = createAutomationBuilder(config)
-        .appAction()
+        .onAppAction()
         .branch({
           activeBranch: {
             steps: stepBuilder =>
@@ -241,7 +241,7 @@ describe("/automations", () => {
 
     it("should be able to access platformUrl, logoUrl and company in the automation", async () => {
       const result = await createAutomationBuilder(config)
-        .appAction()
+        .onAppAction()
         .serverLog({
           text: "{{ settings.url }}",
         })

--- a/packages/server/src/api/routes/tests/automation.spec.ts
+++ b/packages/server/src/api/routes/tests/automation.spec.ts
@@ -108,7 +108,7 @@ describe("/automations", () => {
 
     it("Should ensure you can't have a branch as not a last step", async () => {
       const automation = createAutomationBuilder(config)
-        .appAction({ fields: { status: "active" } })
+        .appAction()
         .branch({
           activeBranch: {
             steps: stepBuilder =>
@@ -132,7 +132,7 @@ describe("/automations", () => {
 
     it("Should check validation on an automation that has a branch step with no children", async () => {
       const automation = createAutomationBuilder(config)
-        .appAction({ fields: { status: "active" } })
+        .appAction()
         .branch({})
         .serverLog({ text: "Inactive user" })
         .build()
@@ -148,7 +148,7 @@ describe("/automations", () => {
 
     it("Should check validation on a branch step with empty conditions", async () => {
       const automation = createAutomationBuilder(config)
-        .appAction({ fields: { status: "active" } })
+        .appAction()
         .branch({
           activeBranch: {
             steps: stepBuilder =>
@@ -169,7 +169,7 @@ describe("/automations", () => {
 
     it("Should check validation on an branch that has a condition that is not valid", async () => {
       const automation = createAutomationBuilder(config)
-        .appAction({ fields: { status: "active" } })
+        .appAction()
         .branch({
           activeBranch: {
             steps: stepBuilder =>
@@ -241,6 +241,7 @@ describe("/automations", () => {
 
     it("should be able to access platformUrl, logoUrl and company in the automation", async () => {
       const result = await createAutomationBuilder(config)
+        .appAction()
         .serverLog({
           text: "{{ settings.url }}",
         })
@@ -250,7 +251,7 @@ describe("/automations", () => {
         .serverLog({
           text: "{{ settings.company }}",
         })
-        .run()
+        .run({ fields: {} })
 
       expect(result.steps[0].outputs.message).toEndWith("https://example.com")
       expect(result.steps[1].outputs.message).toEndWith(

--- a/packages/server/src/automations/tests/branching.spec.ts
+++ b/packages/server/src/automations/tests/branching.spec.ts
@@ -25,7 +25,7 @@ describe("Branching automations", () => {
     const branch2Id = "44444444-4444-4444-4444-444444444444"
 
     const results = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .serverLog(
         { text: "Starting automation" },
         { stepName: "FirstLog", stepId: firstLogId }
@@ -84,7 +84,7 @@ describe("Branching automations", () => {
 
   it("should execute correct branch based on string equality", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .branch({
         activeBranch: {
           steps: stepBuilder => stepBuilder.serverLog({ text: "Active user" }),
@@ -109,7 +109,7 @@ describe("Branching automations", () => {
 
   it("should handle multiple conditions with AND operator", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .branch({
         activeAdminBranch: {
           steps: stepBuilder =>
@@ -137,7 +137,7 @@ describe("Branching automations", () => {
 
   it("should handle multiple conditions with OR operator", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .branch({
         specialBranch: {
           steps: stepBuilder => stepBuilder.serverLog({ text: "Special user" }),
@@ -169,7 +169,7 @@ describe("Branching automations", () => {
 
   it("should stop the branch automation when no conditions are met", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .createRow({ row: { name: "Test", tableId: table._id } })
       .branch({
         specialBranch: {
@@ -205,7 +205,7 @@ describe("Branching automations", () => {
 
   it("evaluate multiple conditions", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .serverLog({ text: "Starting automation" }, { stepId: "aN6znRYHG" })
       .branch({
         specialBranch: {
@@ -246,7 +246,7 @@ describe("Branching automations", () => {
 
   it("evaluate multiple conditions with interpolated text", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .serverLog({ text: "Starting automation" }, { stepId: "aN6znRYHG" })
       .branch({
         specialBranch: {

--- a/packages/server/src/automations/tests/branching.spec.ts
+++ b/packages/server/src/automations/tests/branching.spec.ts
@@ -25,6 +25,7 @@ describe("Branching automations", () => {
     const branch2Id = "44444444-4444-4444-4444-444444444444"
 
     const results = await createAutomationBuilder(config)
+      .appAction()
       .serverLog(
         { text: "Starting automation" },
         { stepName: "FirstLog", stepId: firstLogId }
@@ -75,7 +76,7 @@ describe("Branching automations", () => {
           },
         },
       })
-      .run()
+      .run({ fields: {} })
 
     expect(results.steps[3].outputs.status).toContain("branch1 branch taken")
     expect(results.steps[4].outputs.message).toContain("Branch 1.1")
@@ -83,7 +84,7 @@ describe("Branching automations", () => {
 
   it("should execute correct branch based on string equality", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction({ fields: { status: "active" } })
+      .appAction()
       .branch({
         activeBranch: {
           steps: stepBuilder => stepBuilder.serverLog({ text: "Active user" }),
@@ -99,7 +100,7 @@ describe("Branching automations", () => {
           },
         },
       })
-      .run()
+      .run({ fields: { status: "active" } })
     expect(results.steps[0].outputs.status).toContain(
       "activeBranch branch taken"
     )
@@ -108,7 +109,7 @@ describe("Branching automations", () => {
 
   it("should handle multiple conditions with AND operator", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction({ fields: { status: "active", role: "admin" } })
+      .appAction()
       .branch({
         activeAdminBranch: {
           steps: stepBuilder =>
@@ -129,14 +130,14 @@ describe("Branching automations", () => {
           },
         },
       })
-      .run()
+      .run({ fields: { status: "active", role: "admin" } })
 
     expect(results.steps[1].outputs.message).toContain("Active admin user")
   })
 
   it("should handle multiple conditions with OR operator", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction({ fields: { status: "test", role: "user" } })
+      .appAction()
       .branch({
         specialBranch: {
           steps: stepBuilder => stepBuilder.serverLog({ text: "Special user" }),
@@ -161,14 +162,14 @@ describe("Branching automations", () => {
           },
         },
       })
-      .run()
+      .run({ fields: { status: "test", role: "user" } })
 
     expect(results.steps[1].outputs.message).toContain("Special user")
   })
 
   it("should stop the branch automation when no conditions are met", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction({ fields: { status: "test", role: "user" } })
+      .appAction()
       .createRow({ row: { name: "Test", tableId: table._id } })
       .branch({
         specialBranch: {
@@ -194,7 +195,7 @@ describe("Branching automations", () => {
           },
         },
       })
-      .run()
+      .run({ fields: { status: "test", role: "user" } })
 
     expect(results.steps[1].outputs.status).toEqual(
       AutomationStatus.NO_CONDITION_MET
@@ -204,7 +205,7 @@ describe("Branching automations", () => {
 
   it("evaluate multiple conditions", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction({ fields: { test_trigger: true } })
+      .appAction()
       .serverLog({ text: "Starting automation" }, { stepId: "aN6znRYHG" })
       .branch({
         specialBranch: {
@@ -238,14 +239,14 @@ describe("Branching automations", () => {
           },
         },
       })
-      .run()
+      .run({ fields: { test_trigger: true } })
 
     expect(results.steps[2].outputs.message).toContain("Special user")
   })
 
   it("evaluate multiple conditions with interpolated text", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction({ fields: { test_trigger: true } })
+      .appAction()
       .serverLog({ text: "Starting automation" }, { stepId: "aN6znRYHG" })
       .branch({
         specialBranch: {
@@ -275,7 +276,7 @@ describe("Branching automations", () => {
           },
         },
       })
-      .run()
+      .run({ fields: { test_trigger: true } })
 
     expect(results.steps[2].outputs.message).toContain("Special user")
   })

--- a/packages/server/src/automations/tests/branching.spec.ts
+++ b/packages/server/src/automations/tests/branching.spec.ts
@@ -76,7 +76,7 @@ describe("Branching automations", () => {
           },
         },
       })
-      .run({ fields: {} })
+      .test({ fields: {} })
 
     expect(results.steps[3].outputs.status).toContain("branch1 branch taken")
     expect(results.steps[4].outputs.message).toContain("Branch 1.1")
@@ -100,7 +100,7 @@ describe("Branching automations", () => {
           },
         },
       })
-      .run({ fields: { status: "active" } })
+      .test({ fields: { status: "active" } })
     expect(results.steps[0].outputs.status).toContain(
       "activeBranch branch taken"
     )
@@ -130,7 +130,7 @@ describe("Branching automations", () => {
           },
         },
       })
-      .run({ fields: { status: "active", role: "admin" } })
+      .test({ fields: { status: "active", role: "admin" } })
 
     expect(results.steps[1].outputs.message).toContain("Active admin user")
   })
@@ -162,7 +162,7 @@ describe("Branching automations", () => {
           },
         },
       })
-      .run({ fields: { status: "test", role: "user" } })
+      .test({ fields: { status: "test", role: "user" } })
 
     expect(results.steps[1].outputs.message).toContain("Special user")
   })
@@ -195,7 +195,7 @@ describe("Branching automations", () => {
           },
         },
       })
-      .run({ fields: { status: "test", role: "user" } })
+      .test({ fields: { status: "test", role: "user" } })
 
     expect(results.steps[1].outputs.status).toEqual(
       AutomationStatus.NO_CONDITION_MET
@@ -239,7 +239,7 @@ describe("Branching automations", () => {
           },
         },
       })
-      .run({ fields: { test_trigger: true } })
+      .test({ fields: { test_trigger: true } })
 
     expect(results.steps[2].outputs.message).toContain("Special user")
   })
@@ -276,7 +276,7 @@ describe("Branching automations", () => {
           },
         },
       })
-      .run({ fields: { test_trigger: true } })
+      .test({ fields: { test_trigger: true } })
 
     expect(results.steps[2].outputs.message).toContain("Special user")
   })

--- a/packages/server/src/automations/tests/scenarios.spec.ts
+++ b/packages/server/src/automations/tests/scenarios.spec.ts
@@ -30,7 +30,7 @@ describe("Automation Scenarios", () => {
       const table = await config.api.table.save(basicTable())
 
       const results = await createAutomationBuilder(config)
-        .rowUpdated({ tableId: table._id! })
+        .onRowUpdated({ tableId: table._id! })
         .createRow({
           row: {
             name: "{{trigger.row.name}}",
@@ -63,7 +63,7 @@ describe("Automation Scenarios", () => {
       await config.api.row.save(table._id!, row)
       await config.api.row.save(table._id!, row)
       const results = await createAutomationBuilder(config)
-        .appAction()
+        .onAppAction()
         .queryRows({
           tableId: table._id!,
         })
@@ -82,7 +82,7 @@ describe("Automation Scenarios", () => {
       await config.api.row.save(table._id!, row)
       await config.api.row.save(table._id!, row)
       const results = await createAutomationBuilder(config)
-        .appAction()
+        .onAppAction()
         .queryRows({
           tableId: table._id!,
         })
@@ -124,7 +124,7 @@ describe("Automation Scenarios", () => {
       })
 
       const results = await createAutomationBuilder(config)
-        .appAction()
+        .onAppAction()
         .createRow(
           {
             row: {
@@ -193,7 +193,7 @@ describe("Automation Scenarios", () => {
       await config.api.row.save(table._id!, row)
       await config.api.row.save(table._id!, row)
       const results = await createAutomationBuilder(config)
-        .appAction()
+        .onAppAction()
         .queryRows(
           {
             tableId: table._id!,
@@ -243,7 +243,7 @@ describe("Automation Scenarios", () => {
 
     it("should stop an automation if the condition is not met", async () => {
       const results = await createAutomationBuilder(config)
-        .appAction()
+        .onAppAction()
         .createRow({
           row: {
             name: "Equal Test",
@@ -269,7 +269,7 @@ describe("Automation Scenarios", () => {
 
     it("should continue the automation if the condition is met", async () => {
       const results = await createAutomationBuilder(config)
-        .appAction()
+        .onAppAction()
         .createRow({
           row: {
             name: "Not Equal Test",
@@ -336,7 +336,7 @@ describe("Automation Scenarios", () => {
       "should pass the filter when condition is $condition",
       async ({ condition, value, rowValue, expectPass }) => {
         const results = await createAutomationBuilder(config)
-          .appAction()
+          .onAppAction()
           .createRow({
             row: {
               name: `${condition} Test`,
@@ -371,7 +371,7 @@ describe("Automation Scenarios", () => {
     const table = await config.api.table.save(basicTable())
 
     const results = await createAutomationBuilder(config)
-      .rowUpdated({ tableId: table._id! })
+      .onRowUpdated({ tableId: table._id! })
       .serverLog({ text: "{{ [user].[email] }}" })
       .run({
         row: { name: "Test", description: "TEST" },
@@ -383,7 +383,7 @@ describe("Automation Scenarios", () => {
 
   it("Check user is passed through from app trigger", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .serverLog({ text: "{{ [user].[email] }}" })
       .run({ fields: {} })
 
@@ -455,7 +455,7 @@ if (descriptions.length) {
       })
 
       const results = await createAutomationBuilder(config)
-        .appAction()
+        .onAppAction()
         .executeQuery({
           query: {
             queryId: query._id!,

--- a/packages/server/src/automations/tests/scenarios.spec.ts
+++ b/packages/server/src/automations/tests/scenarios.spec.ts
@@ -30,13 +30,7 @@ describe("Automation Scenarios", () => {
       const table = await config.api.table.save(basicTable())
 
       const results = await createAutomationBuilder(config)
-        .rowUpdated(
-          { tableId: table._id! },
-          {
-            row: { name: "Test", description: "TEST" },
-            id: "1234",
-          }
-        )
+        .rowUpdated({ tableId: table._id! })
         .createRow({
           row: {
             name: "{{trigger.row.name}}",
@@ -44,7 +38,10 @@ describe("Automation Scenarios", () => {
             tableId: table._id,
           },
         })
-        .run()
+        .run({
+          row: { name: "Test", description: "TEST" },
+          id: "1234",
+        })
 
       expect(results.steps).toHaveLength(1)
 
@@ -66,10 +63,11 @@ describe("Automation Scenarios", () => {
       await config.api.row.save(table._id!, row)
       await config.api.row.save(table._id!, row)
       const results = await createAutomationBuilder(config)
+        .appAction()
         .queryRows({
           tableId: table._id!,
         })
-        .run()
+        .run({ fields: {} })
 
       expect(results.steps).toHaveLength(1)
       expect(results.steps[0].outputs.rows).toHaveLength(2)
@@ -84,6 +82,7 @@ describe("Automation Scenarios", () => {
       await config.api.row.save(table._id!, row)
       await config.api.row.save(table._id!, row)
       const results = await createAutomationBuilder(config)
+        .appAction()
         .queryRows({
           tableId: table._id!,
         })
@@ -94,7 +93,7 @@ describe("Automation Scenarios", () => {
         .queryRows({
           tableId: table._id!,
         })
-        .run()
+        .run({ fields: {} })
 
       expect(results.steps).toHaveLength(3)
       expect(results.steps[1].outputs.success).toBeTruthy()
@@ -125,6 +124,7 @@ describe("Automation Scenarios", () => {
       })
 
       const results = await createAutomationBuilder(config)
+        .appAction()
         .createRow(
           {
             row: {
@@ -153,7 +153,7 @@ describe("Automation Scenarios", () => {
           },
           { stepName: "QueryRowsStep" }
         )
-        .run()
+        .run({ fields: {} })
 
       expect(results.steps).toHaveLength(3)
 
@@ -193,6 +193,7 @@ describe("Automation Scenarios", () => {
       await config.api.row.save(table._id!, row)
       await config.api.row.save(table._id!, row)
       const results = await createAutomationBuilder(config)
+        .appAction()
         .queryRows(
           {
             tableId: table._id!,
@@ -206,7 +207,7 @@ describe("Automation Scenarios", () => {
         .queryRows({
           tableId: table._id!,
         })
-        .run()
+        .run({ fields: {} })
 
       expect(results.steps).toHaveLength(3)
       expect(results.steps[1].outputs.success).toBeTruthy()
@@ -242,6 +243,7 @@ describe("Automation Scenarios", () => {
 
     it("should stop an automation if the condition is not met", async () => {
       const results = await createAutomationBuilder(config)
+        .appAction()
         .createRow({
           row: {
             name: "Equal Test",
@@ -258,7 +260,7 @@ describe("Automation Scenarios", () => {
           value: 20,
         })
         .serverLog({ text: "Equal condition met" })
-        .run()
+        .run({ fields: {} })
 
       expect(results.steps[2].outputs.success).toBeTrue()
       expect(results.steps[2].outputs.result).toBeFalse()
@@ -267,6 +269,7 @@ describe("Automation Scenarios", () => {
 
     it("should continue the automation if the condition is met", async () => {
       const results = await createAutomationBuilder(config)
+        .appAction()
         .createRow({
           row: {
             name: "Not Equal Test",
@@ -283,7 +286,7 @@ describe("Automation Scenarios", () => {
           value: 20,
         })
         .serverLog({ text: "Not Equal condition met" })
-        .run()
+        .run({ fields: {} })
 
       expect(results.steps[2].outputs.success).toBeTrue()
       expect(results.steps[2].outputs.result).toBeTrue()
@@ -333,6 +336,7 @@ describe("Automation Scenarios", () => {
       "should pass the filter when condition is $condition",
       async ({ condition, value, rowValue, expectPass }) => {
         const results = await createAutomationBuilder(config)
+          .appAction()
           .createRow({
             row: {
               name: `${condition} Test`,
@@ -351,7 +355,7 @@ describe("Automation Scenarios", () => {
           .serverLog({
             text: `${condition} condition ${expectPass ? "passed" : "failed"}`,
           })
-          .run()
+          .run({ fields: {} })
 
         expect(results.steps[2].outputs.result).toBe(expectPass)
         if (expectPass) {
@@ -367,23 +371,21 @@ describe("Automation Scenarios", () => {
     const table = await config.api.table.save(basicTable())
 
     const results = await createAutomationBuilder(config)
-      .rowUpdated(
-        { tableId: table._id! },
-        {
-          row: { name: "Test", description: "TEST" },
-          id: "1234",
-        }
-      )
+      .rowUpdated({ tableId: table._id! })
       .serverLog({ text: "{{ [user].[email] }}" })
-      .run()
+      .run({
+        row: { name: "Test", description: "TEST" },
+        id: "1234",
+      })
 
     expect(results.steps[0].outputs.message).toContain("example.com")
   })
 
   it("Check user is passed through from app trigger", async () => {
     const results = await createAutomationBuilder(config)
+      .appAction()
       .serverLog({ text: "{{ [user].[email] }}" })
-      .run()
+      .run({ fields: {} })
 
     expect(results.steps[0].outputs.message).toContain("example.com")
   })
@@ -453,9 +455,7 @@ if (descriptions.length) {
       })
 
       const results = await createAutomationBuilder(config)
-        .appAction({
-          fields: {},
-        })
+        .appAction()
         .executeQuery({
           query: {
             queryId: query._id!,
@@ -475,7 +475,7 @@ if (descriptions.length) {
         .queryRows({
           tableId: newTable._id!,
         })
-        .run()
+        .run({ fields: {} })
 
       expect(results.steps).toHaveLength(3)
 

--- a/packages/server/src/automations/tests/scenarios.spec.ts
+++ b/packages/server/src/automations/tests/scenarios.spec.ts
@@ -38,7 +38,7 @@ describe("Automation Scenarios", () => {
             tableId: table._id,
           },
         })
-        .run({
+        .test({
           row: { name: "Test", description: "TEST" },
           id: "1234",
         })
@@ -67,7 +67,7 @@ describe("Automation Scenarios", () => {
         .queryRows({
           tableId: table._id!,
         })
-        .run({ fields: {} })
+        .test({ fields: {} })
 
       expect(results.steps).toHaveLength(1)
       expect(results.steps[0].outputs.rows).toHaveLength(2)
@@ -93,7 +93,7 @@ describe("Automation Scenarios", () => {
         .queryRows({
           tableId: table._id!,
         })
-        .run({ fields: {} })
+        .test({ fields: {} })
 
       expect(results.steps).toHaveLength(3)
       expect(results.steps[1].outputs.success).toBeTruthy()
@@ -153,7 +153,7 @@ describe("Automation Scenarios", () => {
           },
           { stepName: "QueryRowsStep" }
         )
-        .run({ fields: {} })
+        .test({ fields: {} })
 
       expect(results.steps).toHaveLength(3)
 
@@ -207,7 +207,7 @@ describe("Automation Scenarios", () => {
         .queryRows({
           tableId: table._id!,
         })
-        .run({ fields: {} })
+        .test({ fields: {} })
 
       expect(results.steps).toHaveLength(3)
       expect(results.steps[1].outputs.success).toBeTruthy()
@@ -260,7 +260,7 @@ describe("Automation Scenarios", () => {
           value: 20,
         })
         .serverLog({ text: "Equal condition met" })
-        .run({ fields: {} })
+        .test({ fields: {} })
 
       expect(results.steps[2].outputs.success).toBeTrue()
       expect(results.steps[2].outputs.result).toBeFalse()
@@ -286,7 +286,7 @@ describe("Automation Scenarios", () => {
           value: 20,
         })
         .serverLog({ text: "Not Equal condition met" })
-        .run({ fields: {} })
+        .test({ fields: {} })
 
       expect(results.steps[2].outputs.success).toBeTrue()
       expect(results.steps[2].outputs.result).toBeTrue()
@@ -355,7 +355,7 @@ describe("Automation Scenarios", () => {
           .serverLog({
             text: `${condition} condition ${expectPass ? "passed" : "failed"}`,
           })
-          .run({ fields: {} })
+          .test({ fields: {} })
 
         expect(results.steps[2].outputs.result).toBe(expectPass)
         if (expectPass) {
@@ -373,7 +373,7 @@ describe("Automation Scenarios", () => {
     const results = await createAutomationBuilder(config)
       .onRowUpdated({ tableId: table._id! })
       .serverLog({ text: "{{ [user].[email] }}" })
-      .run({
+      .test({
         row: { name: "Test", description: "TEST" },
         id: "1234",
       })
@@ -385,7 +385,7 @@ describe("Automation Scenarios", () => {
     const results = await createAutomationBuilder(config)
       .onAppAction()
       .serverLog({ text: "{{ [user].[email] }}" })
-      .run({ fields: {} })
+      .test({ fields: {} })
 
     expect(results.steps[0].outputs.message).toContain("example.com")
   })
@@ -475,7 +475,7 @@ if (descriptions.length) {
         .queryRows({
           tableId: newTable._id!,
         })
-        .run({ fields: {} })
+        .test({ fields: {} })
 
       expect(results.steps).toHaveLength(3)
 

--- a/packages/server/src/automations/tests/steps/bash.spec.ts
+++ b/packages/server/src/automations/tests/steps/bash.spec.ts
@@ -25,7 +25,7 @@ describe("Execute Bash Automations", () => {
 
   it("should use trigger data in bash command and pass output to subsequent steps", async () => {
     const result = await createAutomationBuilder(config)
-      .appAction({ fields: { command: "hello world" } })
+      .onAppAction({ fields: { command: "hello world" } })
       .bash(
         { code: "echo '{{ trigger.fields.command }}'" },
         { stepName: "Echo Command" }
@@ -44,7 +44,7 @@ describe("Execute Bash Automations", () => {
 
   it("should chain multiple bash commands using previous outputs", async () => {
     const result = await createAutomationBuilder(config)
-      .appAction({ fields: { filename: "testfile.txt" } })
+      .onAppAction({ fields: { filename: "testfile.txt" } })
       .bash(
         { code: "echo 'initial content' > {{ trigger.fields.filename }}" },
         { stepName: "Create File" }
@@ -94,7 +94,7 @@ describe("Execute Bash Automations", () => {
 
   it("should handle bash output in conditional logic", async () => {
     const result = await createAutomationBuilder(config)
-      .appAction({ fields: { threshold: "5" } })
+      .onAppAction({ fields: { threshold: "5" } })
       .bash(
         { code: "echo $(( {{ trigger.fields.threshold }} + 5 ))" },
         { stepName: "Calculate Value" }

--- a/packages/server/src/automations/tests/steps/bash.spec.ts
+++ b/packages/server/src/automations/tests/steps/bash.spec.ts
@@ -25,7 +25,7 @@ describe("Execute Bash Automations", () => {
 
   it("should use trigger data in bash command and pass output to subsequent steps", async () => {
     const result = await createAutomationBuilder(config)
-      .onAppAction({ fields: { command: "hello world" } })
+      .onAppAction()
       .bash(
         { code: "echo '{{ trigger.fields.command }}'" },
         { stepName: "Echo Command" }
@@ -34,7 +34,7 @@ describe("Execute Bash Automations", () => {
         { text: "Bash output was: {{ steps.[Echo Command].stdout }}" },
         { stepName: "Log Output" }
       )
-      .test()
+      .test({ fields: { command: "hello world" } })
 
     expect(result.steps[0].outputs.stdout).toEqual("hello world\n")
     expect(result.steps[1].outputs.message).toContain(
@@ -44,7 +44,7 @@ describe("Execute Bash Automations", () => {
 
   it("should chain multiple bash commands using previous outputs", async () => {
     const result = await createAutomationBuilder(config)
-      .onAppAction({ fields: { filename: "testfile.txt" } })
+      .onAppAction()
       .bash(
         { code: "echo 'initial content' > {{ trigger.fields.filename }}" },
         { stepName: "Create File" }
@@ -57,7 +57,7 @@ describe("Execute Bash Automations", () => {
         { code: "rm {{ trigger.fields.filename }}" },
         { stepName: "Cleanup" }
       )
-      .test()
+      .test({ fields: { filename: "testfile.txt" } })
 
     expect(result.steps[1].outputs.stdout).toEqual("INITIAL CONTENT\n")
     expect(result.steps[1].outputs.success).toEqual(true)
@@ -65,6 +65,7 @@ describe("Execute Bash Automations", () => {
 
   it("should integrate bash output with row operations", async () => {
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .queryRows(
         {
           tableId: table._id!,
@@ -82,7 +83,7 @@ describe("Execute Bash Automations", () => {
         { text: "{{ steps.[Process Row Data].stdout }}" },
         { stepName: "Log Result" }
       )
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[1].outputs.stdout).toContain(
       "Row data: test row - test description"
@@ -94,7 +95,7 @@ describe("Execute Bash Automations", () => {
 
   it("should handle bash output in conditional logic", async () => {
     const result = await createAutomationBuilder(config)
-      .onAppAction({ fields: { threshold: "5" } })
+      .onAppAction()
       .bash(
         { code: "echo $(( {{ trigger.fields.threshold }} + 5 ))" },
         { stepName: "Calculate Value" }
@@ -112,7 +113,7 @@ describe("Execute Bash Automations", () => {
         { text: "Value was {{ steps.[Check Value].value }}" },
         { stepName: "Log Result" }
       )
-      .test()
+      .test({ fields: { threshold: "5" } })
 
     expect(result.steps[0].outputs.stdout).toEqual("10\n")
     expect(result.steps[1].outputs.value).toEqual("high")
@@ -121,12 +122,13 @@ describe("Execute Bash Automations", () => {
 
   it("should handle null values gracefully", async () => {
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .bash(
         // @ts-expect-error - testing null input
         { code: null },
         { stepName: "Null Command" }
       )
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.stdout).toBe(
       "Budibase bash automation failed: Invalid inputs"

--- a/packages/server/src/automations/tests/steps/bash.spec.ts
+++ b/packages/server/src/automations/tests/steps/bash.spec.ts
@@ -34,7 +34,7 @@ describe("Execute Bash Automations", () => {
         { text: "Bash output was: {{ steps.[Echo Command].stdout }}" },
         { stepName: "Log Output" }
       )
-      .run()
+      .test()
 
     expect(result.steps[0].outputs.stdout).toEqual("hello world\n")
     expect(result.steps[1].outputs.message).toContain(
@@ -57,7 +57,7 @@ describe("Execute Bash Automations", () => {
         { code: "rm {{ trigger.fields.filename }}" },
         { stepName: "Cleanup" }
       )
-      .run()
+      .test()
 
     expect(result.steps[1].outputs.stdout).toEqual("INITIAL CONTENT\n")
     expect(result.steps[1].outputs.success).toEqual(true)
@@ -112,7 +112,7 @@ describe("Execute Bash Automations", () => {
         { text: "Value was {{ steps.[Check Value].value }}" },
         { stepName: "Log Result" }
       )
-      .run()
+      .test()
 
     expect(result.steps[0].outputs.stdout).toEqual("10\n")
     expect(result.steps[1].outputs.value).toEqual("high")

--- a/packages/server/src/automations/tests/steps/createRow.spec.ts
+++ b/packages/server/src/automations/tests/steps/createRow.spec.ts
@@ -41,14 +41,14 @@ describe("test the create row action", () => {
 
   it("should be able to run the action", async () => {
     const result = await createAutomationBuilder(config)
-      .onAppAction({ fields: { status: "new" } })
+      .onAppAction()
       .serverLog({ text: "Starting create row flow" }, { stepName: "StartLog" })
       .createRow({ row }, { stepName: "CreateRow" })
       .serverLog(
         { text: "Row created with ID: {{ stepsByName.CreateRow.row._id }}" },
         { stepName: "CreationLog" }
       )
-      .test()
+      .test({ fields: { status: "new" } })
 
     expect(result.steps[1].outputs.success).toBeDefined()
     expect(result.steps[1].outputs.id).toBeDefined()
@@ -67,7 +67,7 @@ describe("test the create row action", () => {
 
   it("should return an error (not throw) when bad info provided", async () => {
     const result = await createAutomationBuilder(config)
-      .onAppAction({ fields: { status: "error" } })
+      .onAppAction()
       .serverLog({ text: "Starting error test flow" }, { stepName: "StartLog" })
       .createRow(
         {
@@ -78,14 +78,14 @@ describe("test the create row action", () => {
         },
         { stepName: "CreateRow" }
       )
-      .test()
+      .test({ fields: { status: "error" } })
 
     expect(result.steps[1].outputs.success).toEqual(false)
   })
 
   it("should check invalid inputs return an error", async () => {
     const result = await createAutomationBuilder(config)
-      .onAppAction({ fields: { status: "invalid" } })
+      .onAppAction()
       .serverLog({ text: "Testing invalid input" }, { stepName: "StartLog" })
       .createRow({ row: {} }, { stepName: "CreateRow" })
       .filter({
@@ -97,7 +97,7 @@ describe("test the create row action", () => {
         { text: "This log should not appear" },
         { stepName: "SkippedLog" }
       )
-      .test()
+      .test({ fields: { status: "invalid" } })
 
     expect(result.steps[1].outputs.success).toEqual(false)
     expect(result.steps.length).toBeLessThan(4)
@@ -123,7 +123,7 @@ describe("test the create row action", () => {
 
     attachmentRow.file_attachment = attachmentObject
     const result = await createAutomationBuilder(config)
-      .onAppAction({ fields: { type: "attachment" } })
+      .onAppAction()
       .serverLog(
         { text: "Processing attachment upload" },
         { stepName: "StartLog" }
@@ -140,7 +140,7 @@ describe("test the create row action", () => {
         },
         { stepName: "UploadLog" }
       )
-      .test()
+      .test({ fields: { type: "attachment" } })
 
     expect(result.steps[1].outputs.success).toEqual(true)
     expect(result.steps[1].outputs.row.file_attachment[0]).toHaveProperty("key")
@@ -174,7 +174,7 @@ describe("test the create row action", () => {
 
     attachmentRow.single_file_attachment = attachmentObject
     const result = await createAutomationBuilder(config)
-      .onAppAction({ fields: { type: "single-attachment" } })
+      .onAppAction()
       .serverLog(
         { text: "Processing single attachment" },
         { stepName: "StartLog" }
@@ -209,7 +209,7 @@ describe("test the create row action", () => {
           },
         },
       })
-      .test()
+      .test({ fields: { type: "single-attachment" } })
 
     expect(result.steps[1].outputs.success).toEqual(true)
     expect(result.steps[1].outputs.row.single_file_attachment).toHaveProperty(
@@ -245,7 +245,7 @@ describe("test the create row action", () => {
 
     attachmentRow.single_file_attachment = attachmentObject
     const result = await createAutomationBuilder(config)
-      .onAppAction({ fields: { type: "invalid-attachment" } })
+      .onAppAction()
       .serverLog(
         { text: "Testing invalid attachment keys" },
         { stepName: "StartLog" }
@@ -278,7 +278,7 @@ describe("test the create row action", () => {
           },
         },
       })
-      .test()
+      .test({ fields: { type: "invalid-attachment" } })
 
     expect(result.steps[1].outputs.success).toEqual(false)
     expect(result.steps[1].outputs.response).toEqual(

--- a/packages/server/src/automations/tests/steps/createRow.spec.ts
+++ b/packages/server/src/automations/tests/steps/createRow.spec.ts
@@ -41,7 +41,7 @@ describe("test the create row action", () => {
 
   it("should be able to run the action", async () => {
     const result = await createAutomationBuilder(config)
-      .appAction({ fields: { status: "new" } })
+      .onAppAction({ fields: { status: "new" } })
       .serverLog({ text: "Starting create row flow" }, { stepName: "StartLog" })
       .createRow({ row }, { stepName: "CreateRow" })
       .serverLog(
@@ -67,7 +67,7 @@ describe("test the create row action", () => {
 
   it("should return an error (not throw) when bad info provided", async () => {
     const result = await createAutomationBuilder(config)
-      .appAction({ fields: { status: "error" } })
+      .onAppAction({ fields: { status: "error" } })
       .serverLog({ text: "Starting error test flow" }, { stepName: "StartLog" })
       .createRow(
         {
@@ -85,7 +85,7 @@ describe("test the create row action", () => {
 
   it("should check invalid inputs return an error", async () => {
     const result = await createAutomationBuilder(config)
-      .appAction({ fields: { status: "invalid" } })
+      .onAppAction({ fields: { status: "invalid" } })
       .serverLog({ text: "Testing invalid input" }, { stepName: "StartLog" })
       .createRow({ row: {} }, { stepName: "CreateRow" })
       .filter({
@@ -123,7 +123,7 @@ describe("test the create row action", () => {
 
     attachmentRow.file_attachment = attachmentObject
     const result = await createAutomationBuilder(config)
-      .appAction({ fields: { type: "attachment" } })
+      .onAppAction({ fields: { type: "attachment" } })
       .serverLog(
         { text: "Processing attachment upload" },
         { stepName: "StartLog" }
@@ -174,7 +174,7 @@ describe("test the create row action", () => {
 
     attachmentRow.single_file_attachment = attachmentObject
     const result = await createAutomationBuilder(config)
-      .appAction({ fields: { type: "single-attachment" } })
+      .onAppAction({ fields: { type: "single-attachment" } })
       .serverLog(
         { text: "Processing single attachment" },
         { stepName: "StartLog" }
@@ -245,7 +245,7 @@ describe("test the create row action", () => {
 
     attachmentRow.single_file_attachment = attachmentObject
     const result = await createAutomationBuilder(config)
-      .appAction({ fields: { type: "invalid-attachment" } })
+      .onAppAction({ fields: { type: "invalid-attachment" } })
       .serverLog(
         { text: "Testing invalid attachment keys" },
         { stepName: "StartLog" }

--- a/packages/server/src/automations/tests/steps/createRow.spec.ts
+++ b/packages/server/src/automations/tests/steps/createRow.spec.ts
@@ -48,7 +48,7 @@ describe("test the create row action", () => {
         { text: "Row created with ID: {{ stepsByName.CreateRow.row._id }}" },
         { stepName: "CreationLog" }
       )
-      .run()
+      .test()
 
     expect(result.steps[1].outputs.success).toBeDefined()
     expect(result.steps[1].outputs.id).toBeDefined()
@@ -78,7 +78,7 @@ describe("test the create row action", () => {
         },
         { stepName: "CreateRow" }
       )
-      .run()
+      .test()
 
     expect(result.steps[1].outputs.success).toEqual(false)
   })
@@ -97,7 +97,7 @@ describe("test the create row action", () => {
         { text: "This log should not appear" },
         { stepName: "SkippedLog" }
       )
-      .run()
+      .test()
 
     expect(result.steps[1].outputs.success).toEqual(false)
     expect(result.steps.length).toBeLessThan(4)
@@ -140,7 +140,7 @@ describe("test the create row action", () => {
         },
         { stepName: "UploadLog" }
       )
-      .run()
+      .test()
 
     expect(result.steps[1].outputs.success).toEqual(true)
     expect(result.steps[1].outputs.row.file_attachment[0]).toHaveProperty("key")
@@ -209,7 +209,7 @@ describe("test the create row action", () => {
           },
         },
       })
-      .run()
+      .test()
 
     expect(result.steps[1].outputs.success).toEqual(true)
     expect(result.steps[1].outputs.row.single_file_attachment).toHaveProperty(
@@ -278,7 +278,7 @@ describe("test the create row action", () => {
           },
         },
       })
-      .run()
+      .test()
 
     expect(result.steps[1].outputs.success).toEqual(false)
     expect(result.steps[1].outputs.response).toEqual(

--- a/packages/server/src/automations/tests/steps/cron-automations.spec.ts
+++ b/packages/server/src/automations/tests/steps/cron-automations.spec.ts
@@ -27,7 +27,7 @@ describe("cron automations", () => {
   })
 
   it("should initialise the automation timestamp", async () => {
-    await createAutomationBuilder(config).cron({ cron: "* * * * *" }).save()
+    await createAutomationBuilder(config).onCron({ cron: "* * * * *" }).save()
 
     tk.travel(Date.now() + oneMinuteInMs)
     await config.publish()

--- a/packages/server/src/automations/tests/steps/delay.spec.ts
+++ b/packages/server/src/automations/tests/steps/delay.spec.ts
@@ -16,7 +16,10 @@ describe("test the delay logic", () => {
     const time = 100
     const before = performance.now()
 
-    await createAutomationBuilder(config).delay({ time }).run()
+    await createAutomationBuilder(config)
+      .onAppAction()
+      .delay({ time })
+      .test({ fields: {} })
 
     const now = performance.now()
 

--- a/packages/server/src/automations/tests/steps/deleteRow.spec.ts
+++ b/packages/server/src/automations/tests/steps/deleteRow.spec.ts
@@ -21,12 +21,13 @@ describe("test the delete row action", () => {
 
   it("should be able to run the delete row action", async () => {
     await createAutomationBuilder(config)
+      .onAppAction()
       .deleteRow({
         tableId: table._id!,
         id: row._id!,
         revision: row._rev,
       })
-      .run()
+      .test({ fields: {} })
 
     await config.api.row.get(table._id!, row._id!, {
       status: 404,
@@ -35,20 +36,22 @@ describe("test the delete row action", () => {
 
   it("should check invalid inputs return an error", async () => {
     const results = await createAutomationBuilder(config)
+      .onAppAction()
       .deleteRow({ tableId: "", id: "", revision: "" })
-      .run()
+      .test({ fields: {} })
 
     expect(results.steps[0].outputs.success).toEqual(false)
   })
 
   it("should return an error when table doesn't exist", async () => {
     const results = await createAutomationBuilder(config)
+      .onAppAction()
       .deleteRow({
         tableId: "invalid",
         id: "invalid",
         revision: "invalid",
       })
-      .run()
+      .test({ fields: {} })
 
     expect(results.steps[0].outputs.success).toEqual(false)
   })

--- a/packages/server/src/automations/tests/steps/discord.spec.ts
+++ b/packages/server/src/automations/tests/steps/discord.spec.ts
@@ -20,12 +20,13 @@ describe("test the outgoing webhook action", () => {
   it("should be able to run the action", async () => {
     nock("http://www.example.com/").post("/").reply(200, { foo: "bar" })
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .discord({
         url: "http://www.example.com",
         username: "joe_bloggs",
         content: "Hello, world",
       })
-      .run()
+      .test({ fields: {} })
     expect(result.steps[0].outputs.response.foo).toEqual("bar")
     expect(result.steps[0].outputs.success).toEqual(true)
   })

--- a/packages/server/src/automations/tests/steps/executeScript.spec.ts
+++ b/packages/server/src/automations/tests/steps/executeScript.spec.ts
@@ -21,7 +21,7 @@ describe("Execute Script Automations", () => {
 
   it("should execute a basic script and return the result", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .executeScript({ code: "return 2 + 2" })
       .run({ fields: {} })
 
@@ -30,7 +30,7 @@ describe("Execute Script Automations", () => {
 
   it("should access bindings from previous steps", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .executeScript(
         {
           code: "return trigger.fields.data.map(x => x * 2)",
@@ -44,7 +44,7 @@ describe("Execute Script Automations", () => {
 
   it("should handle script execution errors gracefully", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .executeScript({ code: "return nonexistentVariable.map(x => x)" })
       .run({ fields: {} })
 
@@ -56,7 +56,7 @@ describe("Execute Script Automations", () => {
 
   it("should handle conditional logic in scripts", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .executeScript({
         code: `
             if (trigger.fields.value > 5) {
@@ -73,7 +73,7 @@ describe("Execute Script Automations", () => {
 
   it("should use multiple steps and validate script execution", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .serverLog(
         { text: "Starting multi-step automation" },
         { stepId: "start-log-step" }

--- a/packages/server/src/automations/tests/steps/executeScript.spec.ts
+++ b/packages/server/src/automations/tests/steps/executeScript.spec.ts
@@ -23,7 +23,7 @@ describe("Execute Script Automations", () => {
     const results = await createAutomationBuilder(config)
       .onAppAction()
       .executeScript({ code: "return 2 + 2" })
-      .run({ fields: {} })
+      .test({ fields: {} })
 
     expect(results.steps[0].outputs.value).toEqual(4)
   })
@@ -37,7 +37,7 @@ describe("Execute Script Automations", () => {
         },
         { stepId: "binding-script-step" }
       )
-      .run({ fields: { data: [1, 2, 3] } })
+      .test({ fields: { data: [1, 2, 3] } })
 
     expect(results.steps[0].outputs.value).toEqual([2, 4, 6])
   })
@@ -46,7 +46,7 @@ describe("Execute Script Automations", () => {
     const results = await createAutomationBuilder(config)
       .onAppAction()
       .executeScript({ code: "return nonexistentVariable.map(x => x)" })
-      .run({ fields: {} })
+      .test({ fields: {} })
 
     expect(results.steps[0].outputs.response).toContain(
       "ReferenceError: nonexistentVariable is not defined"
@@ -66,7 +66,7 @@ describe("Execute Script Automations", () => {
             }
           `,
       })
-      .run({ fields: { value: 10 } })
+      .test({ fields: { value: 10 } })
 
     expect(results.steps[0].outputs.value).toEqual("Value is greater than 5")
   })
@@ -94,7 +94,7 @@ describe("Execute Script Automations", () => {
       .serverLog({
         text: `Final result is {{ steps.ScriptingStep1.value }}`,
       })
-      .run({ fields: {} })
+      .test({ fields: {} })
 
     expect(results.steps[0].outputs.message).toContain(
       "Starting multi-step automation"

--- a/packages/server/src/automations/tests/steps/executeScript.spec.ts
+++ b/packages/server/src/automations/tests/steps/executeScript.spec.ts
@@ -21,30 +21,32 @@ describe("Execute Script Automations", () => {
 
   it("should execute a basic script and return the result", async () => {
     const results = await createAutomationBuilder(config)
+      .appAction()
       .executeScript({ code: "return 2 + 2" })
-      .run()
+      .run({ fields: {} })
 
     expect(results.steps[0].outputs.value).toEqual(4)
   })
 
   it("should access bindings from previous steps", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction({ fields: { data: [1, 2, 3] } })
+      .appAction()
       .executeScript(
         {
           code: "return trigger.fields.data.map(x => x * 2)",
         },
         { stepId: "binding-script-step" }
       )
-      .run()
+      .run({ fields: { data: [1, 2, 3] } })
 
     expect(results.steps[0].outputs.value).toEqual([2, 4, 6])
   })
 
   it("should handle script execution errors gracefully", async () => {
     const results = await createAutomationBuilder(config)
+      .appAction()
       .executeScript({ code: "return nonexistentVariable.map(x => x)" })
-      .run()
+      .run({ fields: {} })
 
     expect(results.steps[0].outputs.response).toContain(
       "ReferenceError: nonexistentVariable is not defined"
@@ -54,7 +56,7 @@ describe("Execute Script Automations", () => {
 
   it("should handle conditional logic in scripts", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction({ fields: { value: 10 } })
+      .appAction()
       .executeScript({
         code: `
             if (trigger.fields.value > 5) {
@@ -64,14 +66,14 @@ describe("Execute Script Automations", () => {
             }
           `,
       })
-      .run()
+      .run({ fields: { value: 10 } })
 
     expect(results.steps[0].outputs.value).toEqual("Value is greater than 5")
   })
 
   it("should use multiple steps and validate script execution", async () => {
     const results = await createAutomationBuilder(config)
-      .appAction({ fields: {} })
+      .appAction()
       .serverLog(
         { text: "Starting multi-step automation" },
         { stepId: "start-log-step" }
@@ -92,7 +94,7 @@ describe("Execute Script Automations", () => {
       .serverLog({
         text: `Final result is {{ steps.ScriptingStep1.value }}`,
       })
-      .run()
+      .run({ fields: {} })
 
     expect(results.steps[0].outputs.message).toContain(
       "Starting multi-step automation"

--- a/packages/server/src/automations/tests/steps/filter.spec.ts
+++ b/packages/server/src/automations/tests/steps/filter.spec.ts
@@ -43,8 +43,9 @@ describe("test the filter logic", () => {
   ]
   it.each(pass)("should pass %p %p %p", async (field, condition, value) => {
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .filter({ field, condition: stringToFilterCondition(condition), value })
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.result).toEqual(true)
     expect(result.steps[0].outputs.success).toEqual(true)
@@ -60,8 +61,9 @@ describe("test the filter logic", () => {
   ]
   it.each(fail)("should fail %p %p %p", async (field, condition, value) => {
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .filter({ field, condition: stringToFilterCondition(condition), value })
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.result).toEqual(false)
     expect(result.steps[0].outputs.success).toEqual(true)

--- a/packages/server/src/automations/tests/steps/loop.spec.ts
+++ b/packages/server/src/automations/tests/steps/loop.spec.ts
@@ -73,7 +73,7 @@ describe("Attempt to run a basic loop automation", () => {
 
   it("should run an automation with a trigger, loop, and create row step", async () => {
     const results = await createAutomationBuilder(config)
-      .rowSaved(
+      .onRowSaved(
         { tableId: table._id! },
         {
           row: {
@@ -116,7 +116,7 @@ describe("Attempt to run a basic loop automation", () => {
 
   it("should run an automation where a loop step is between two normal steps to ensure context correctness", async () => {
     const results = await createAutomationBuilder(config)
-      .rowSaved(
+      .onRowSaved(
         { tableId: table._id! },
         {
           row: {
@@ -213,7 +213,7 @@ describe("Attempt to run a basic loop automation", () => {
 
   it("should run an automation where a loop is successfully run twice", async () => {
     const results = await createAutomationBuilder(config)
-      .rowSaved(
+      .onRowSaved(
         { tableId: table._id! },
         {
           row: {

--- a/packages/server/src/automations/tests/steps/loop.spec.ts
+++ b/packages/server/src/automations/tests/steps/loop.spec.ts
@@ -95,7 +95,7 @@ describe("Attempt to run a basic loop automation", () => {
           tableId: table._id,
         },
       })
-      .run()
+      .test()
 
     expect(results.trigger).toBeDefined()
     expect(results.steps).toHaveLength(1)
@@ -136,7 +136,7 @@ describe("Attempt to run a basic loop automation", () => {
       })
       .serverLog({ text: "Message {{loop.currentItem}}" })
       .serverLog({ text: "{{steps.1.rows.0._id}}" })
-      .run()
+      .test()
 
     results.steps[1].outputs.items.forEach(
       (output: ServerLogStepOutputs, index: number) => {
@@ -240,7 +240,7 @@ describe("Attempt to run a basic loop automation", () => {
         binding: "Message 1,Message 2,Message 3",
       })
       .serverLog({ text: "{{loop.currentItem}}" })
-      .run()
+      .test()
 
     expect(results.trigger).toBeDefined()
     expect(results.steps).toHaveLength(2)

--- a/packages/server/src/automations/tests/steps/make.spec.ts
+++ b/packages/server/src/automations/tests/steps/make.spec.ts
@@ -20,11 +20,12 @@ describe("test the outgoing webhook action", () => {
   it("should be able to run the action", async () => {
     nock("http://www.example.com/").post("/").reply(200, { foo: "bar" })
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .make({
         url: "http://www.example.com",
         body: null,
       })
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.response.foo).toEqual("bar")
     expect(result.steps[0].outputs.success).toEqual(true)
@@ -46,11 +47,12 @@ describe("test the outgoing webhook action", () => {
       .reply(200, { foo: "bar" })
 
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .make({
         body: { value: JSON.stringify(payload) },
         url: "http://www.example.com",
       })
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.response.foo).toEqual("bar")
     expect(result.steps[0].outputs.success).toEqual(true)
@@ -58,11 +60,12 @@ describe("test the outgoing webhook action", () => {
 
   it("should return a 400 if the JSON payload string is malformed", async () => {
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .make({
         body: { value: "{ invalid json }" },
         url: "http://www.example.com",
       })
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.httpStatus).toEqual(400)
     expect(result.steps[0].outputs.response).toEqual("Invalid payload JSON")

--- a/packages/server/src/automations/tests/steps/n8n.spec.ts
+++ b/packages/server/src/automations/tests/steps/n8n.spec.ts
@@ -21,12 +21,13 @@ describe("test the outgoing webhook action", () => {
   it("should be able to run the action and default to 'get'", async () => {
     nock("http://www.example.com/").get("/").reply(200, { foo: "bar" })
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .n8n({
         url: "http://www.example.com",
         body: { test: "IGNORE_ME" },
         authorization: "",
       })
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.response).toEqual({ foo: "bar" })
     expect(result.steps[0].outputs.httpStatus).toEqual(200)
@@ -39,26 +40,28 @@ describe("test the outgoing webhook action", () => {
       .reply(200)
 
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .n8n({
         url: "http://www.example.com",
         body: { value: JSON.stringify({ name: "Adam", age: 9 }) },
         method: HttpMethod.POST,
         authorization: "",
       })
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.success).toEqual(true)
   })
 
   it("should return a 400 if the JSON payload string is malformed", async () => {
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .n8n({
         url: "http://www.example.com",
         body: { value: "{ value1 1 }" },
         method: HttpMethod.POST,
         authorization: "",
       })
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.httpStatus).toEqual(400)
     expect(result.steps[0].outputs.response).toEqual("Invalid payload JSON")
@@ -71,13 +74,14 @@ describe("test the outgoing webhook action", () => {
       .reply(200)
 
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .n8n({
         url: "http://www.example.com",
         method: HttpMethod.HEAD,
         body: { test: "IGNORE_ME" },
         authorization: "",
       })
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.success).toEqual(true)
   })

--- a/packages/server/src/automations/tests/steps/openai.spec.ts
+++ b/packages/server/src/automations/tests/steps/openai.spec.ts
@@ -58,7 +58,7 @@ describe("test the openai action", () => {
     // own API key. We don't count this against your quota.
     const result = await expectAIUsage(0, () =>
       createAutomationBuilder(config)
-        .appAction()
+        .onAppAction()
         .openai({ prompt: "Hello, world", model: Model.GPT_4O_MINI })
         .run({ fields: {} })
     )
@@ -70,7 +70,7 @@ describe("test the openai action", () => {
   it("should present the correct error message when a prompt is not provided", async () => {
     const result = await expectAIUsage(0, () =>
       createAutomationBuilder(config)
-        .appAction()
+        .onAppAction()
         .openai({ prompt: "", model: Model.GPT_4O_MINI })
         .run({ fields: {} })
     )
@@ -86,7 +86,7 @@ describe("test the openai action", () => {
 
     const result = await expectAIUsage(0, () =>
       createAutomationBuilder(config)
-        .appAction()
+        .onAppAction()
         .openai({ prompt: "Hello, world", model: Model.GPT_4O_MINI })
         .run({ fields: {} })
     )
@@ -109,7 +109,7 @@ describe("test the openai action", () => {
     // key, so we charge users for it.
     const result = await expectAIUsage(14, () =>
       createAutomationBuilder(config)
-        .appAction()
+        .onAppAction()
         .openai({ model: Model.GPT_4O_MINI, prompt: "Hello, world" })
         .run({ fields: {} })
     )

--- a/packages/server/src/automations/tests/steps/openai.spec.ts
+++ b/packages/server/src/automations/tests/steps/openai.spec.ts
@@ -58,8 +58,9 @@ describe("test the openai action", () => {
     // own API key. We don't count this against your quota.
     const result = await expectAIUsage(0, () =>
       createAutomationBuilder(config)
+        .appAction()
         .openai({ prompt: "Hello, world", model: Model.GPT_4O_MINI })
-        .run()
+        .run({ fields: {} })
     )
 
     expect(result.steps[0].outputs.response).toEqual("This is a test")
@@ -69,8 +70,9 @@ describe("test the openai action", () => {
   it("should present the correct error message when a prompt is not provided", async () => {
     const result = await expectAIUsage(0, () =>
       createAutomationBuilder(config)
+        .appAction()
         .openai({ prompt: "", model: Model.GPT_4O_MINI })
-        .run()
+        .run({ fields: {} })
     )
 
     expect(result.steps[0].outputs.response).toEqual(
@@ -84,8 +86,9 @@ describe("test the openai action", () => {
 
     const result = await expectAIUsage(0, () =>
       createAutomationBuilder(config)
+        .appAction()
         .openai({ prompt: "Hello, world", model: Model.GPT_4O_MINI })
-        .run()
+        .run({ fields: {} })
     )
 
     expect(result.steps[0].outputs.response).toEqual(
@@ -106,8 +109,9 @@ describe("test the openai action", () => {
     // key, so we charge users for it.
     const result = await expectAIUsage(14, () =>
       createAutomationBuilder(config)
+        .appAction()
         .openai({ model: Model.GPT_4O_MINI, prompt: "Hello, world" })
-        .run()
+        .run({ fields: {} })
     )
 
     expect(result.steps[0].outputs.response).toEqual("This is a test")

--- a/packages/server/src/automations/tests/steps/openai.spec.ts
+++ b/packages/server/src/automations/tests/steps/openai.spec.ts
@@ -60,7 +60,7 @@ describe("test the openai action", () => {
       createAutomationBuilder(config)
         .onAppAction()
         .openai({ prompt: "Hello, world", model: Model.GPT_4O_MINI })
-        .run({ fields: {} })
+        .test({ fields: {} })
     )
 
     expect(result.steps[0].outputs.response).toEqual("This is a test")
@@ -72,7 +72,7 @@ describe("test the openai action", () => {
       createAutomationBuilder(config)
         .onAppAction()
         .openai({ prompt: "", model: Model.GPT_4O_MINI })
-        .run({ fields: {} })
+        .test({ fields: {} })
     )
 
     expect(result.steps[0].outputs.response).toEqual(
@@ -88,7 +88,7 @@ describe("test the openai action", () => {
       createAutomationBuilder(config)
         .onAppAction()
         .openai({ prompt: "Hello, world", model: Model.GPT_4O_MINI })
-        .run({ fields: {} })
+        .test({ fields: {} })
     )
 
     expect(result.steps[0].outputs.response).toEqual(
@@ -111,7 +111,7 @@ describe("test the openai action", () => {
       createAutomationBuilder(config)
         .onAppAction()
         .openai({ model: Model.GPT_4O_MINI, prompt: "Hello, world" })
-        .run({ fields: {} })
+        .test({ fields: {} })
     )
 
     expect(result.steps[0].outputs.response).toEqual("This is a test")

--- a/packages/server/src/automations/tests/steps/outgoingWebhook.spec.ts
+++ b/packages/server/src/automations/tests/steps/outgoingWebhook.spec.ts
@@ -24,13 +24,14 @@ describe("test the outgoing webhook action", () => {
       .reply(200, { foo: "bar" })
 
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .outgoingWebhook({
         requestMethod: RequestType.POST,
         url: "http://www.example.com",
         requestBody: JSON.stringify({ a: 1 }),
         headers: {},
       })
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.success).toEqual(true)
     expect(result.steps[0].outputs.httpStatus).toEqual(200)
@@ -39,13 +40,14 @@ describe("test the outgoing webhook action", () => {
 
   it("should return an error if something goes wrong in fetch", async () => {
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .outgoingWebhook({
         requestMethod: RequestType.GET,
         url: "www.invalid.com",
         requestBody: "",
         headers: {},
       })
-      .run()
+      .test({ fields: {} })
     expect(result.steps[0].outputs.success).toEqual(false)
   })
 })

--- a/packages/server/src/automations/tests/steps/queryRows.spec.ts
+++ b/packages/server/src/automations/tests/steps/queryRows.spec.ts
@@ -29,7 +29,7 @@ describe("Test a query step automation", () => {
 
   it("should be able to run the query step", async () => {
     const result = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .queryRows(
         {
           tableId: table._id!,
@@ -54,7 +54,7 @@ describe("Test a query step automation", () => {
 
   it("Returns all rows when onEmptyFilter has no value and no filters are passed", async () => {
     const result = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .queryRows(
         {
           tableId: table._id!,
@@ -75,7 +75,7 @@ describe("Test a query step automation", () => {
 
   it("Returns no rows when onEmptyFilter is RETURN_NONE and theres no filters", async () => {
     const result = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .queryRows(
         {
           tableId: table._id!,
@@ -97,7 +97,7 @@ describe("Test a query step automation", () => {
 
   it("Returns no rows when onEmptyFilters RETURN_NONE and a filter is passed with a null value", async () => {
     const result = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .queryRows(
         {
           tableId: table._id!,
@@ -123,7 +123,7 @@ describe("Test a query step automation", () => {
 
   it("Returns rows when onEmptyFilter is RETURN_ALL and no filter is passed", async () => {
     const result = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .queryRows(
         {
           tableId: table._id!,
@@ -151,7 +151,7 @@ describe("Test a query step automation", () => {
       name: NAME,
     })
     const result = await createAutomationBuilder(config)
-      .appAction()
+      .onAppAction()
       .queryRows(
         {
           tableId: tableWithSpaces._id!,

--- a/packages/server/src/automations/tests/steps/queryRows.spec.ts
+++ b/packages/server/src/automations/tests/steps/queryRows.spec.ts
@@ -44,7 +44,7 @@ describe("Test a query step automation", () => {
         },
         { stepName: "Query All Rows" }
       )
-      .run({ fields: {} })
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.success).toBe(true)
     expect(result.steps[0].outputs.rows).toBeDefined()
@@ -65,7 +65,7 @@ describe("Test a query step automation", () => {
         },
         { stepName: "Query With Empty Filter" }
       )
-      .run({ fields: {} })
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.success).toBe(true)
     expect(result.steps[0].outputs.rows).toBeDefined()
@@ -88,7 +88,7 @@ describe("Test a query step automation", () => {
         },
         { stepName: "Query With Return None" }
       )
-      .run({ fields: {} })
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.success).toBe(true)
     expect(result.steps[0].outputs.rows).toBeDefined()
@@ -114,7 +114,7 @@ describe("Test a query step automation", () => {
         },
         { stepName: "Query With Null Filter" }
       )
-      .run({ fields: {} })
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.success).toBe(true)
     expect(result.steps[0].outputs.rows).toBeDefined()
@@ -135,7 +135,7 @@ describe("Test a query step automation", () => {
         },
         { stepName: "Query With Return All" }
       )
-      .run({ fields: {} })
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.success).toBe(true)
     expect(result.steps[0].outputs.rows).toBeDefined()
@@ -160,7 +160,7 @@ describe("Test a query step automation", () => {
         },
         { stepName: "Query table with spaces" }
       )
-      .run({ fields: {} })
+      .test({ fields: {} })
     expect(result.steps[0].outputs.success).toBe(true)
     expect(result.steps[0].outputs.rows).toBeDefined()
     expect(result.steps[0].outputs.rows.length).toBe(1)

--- a/packages/server/src/automations/tests/steps/queryRows.spec.ts
+++ b/packages/server/src/automations/tests/steps/queryRows.spec.ts
@@ -29,6 +29,7 @@ describe("Test a query step automation", () => {
 
   it("should be able to run the query step", async () => {
     const result = await createAutomationBuilder(config)
+      .appAction()
       .queryRows(
         {
           tableId: table._id!,
@@ -43,7 +44,7 @@ describe("Test a query step automation", () => {
         },
         { stepName: "Query All Rows" }
       )
-      .run()
+      .run({ fields: {} })
 
     expect(result.steps[0].outputs.success).toBe(true)
     expect(result.steps[0].outputs.rows).toBeDefined()
@@ -53,6 +54,7 @@ describe("Test a query step automation", () => {
 
   it("Returns all rows when onEmptyFilter has no value and no filters are passed", async () => {
     const result = await createAutomationBuilder(config)
+      .appAction()
       .queryRows(
         {
           tableId: table._id!,
@@ -63,7 +65,7 @@ describe("Test a query step automation", () => {
         },
         { stepName: "Query With Empty Filter" }
       )
-      .run()
+      .run({ fields: {} })
 
     expect(result.steps[0].outputs.success).toBe(true)
     expect(result.steps[0].outputs.rows).toBeDefined()
@@ -73,6 +75,7 @@ describe("Test a query step automation", () => {
 
   it("Returns no rows when onEmptyFilter is RETURN_NONE and theres no filters", async () => {
     const result = await createAutomationBuilder(config)
+      .appAction()
       .queryRows(
         {
           tableId: table._id!,
@@ -85,7 +88,7 @@ describe("Test a query step automation", () => {
         },
         { stepName: "Query With Return None" }
       )
-      .run()
+      .run({ fields: {} })
 
     expect(result.steps[0].outputs.success).toBe(true)
     expect(result.steps[0].outputs.rows).toBeDefined()
@@ -94,6 +97,7 @@ describe("Test a query step automation", () => {
 
   it("Returns no rows when onEmptyFilters RETURN_NONE and a filter is passed with a null value", async () => {
     const result = await createAutomationBuilder(config)
+      .appAction()
       .queryRows(
         {
           tableId: table._id!,
@@ -110,7 +114,7 @@ describe("Test a query step automation", () => {
         },
         { stepName: "Query With Null Filter" }
       )
-      .run()
+      .run({ fields: {} })
 
     expect(result.steps[0].outputs.success).toBe(true)
     expect(result.steps[0].outputs.rows).toBeDefined()
@@ -119,6 +123,7 @@ describe("Test a query step automation", () => {
 
   it("Returns rows when onEmptyFilter is RETURN_ALL and no filter is passed", async () => {
     const result = await createAutomationBuilder(config)
+      .appAction()
       .queryRows(
         {
           tableId: table._id!,
@@ -130,7 +135,7 @@ describe("Test a query step automation", () => {
         },
         { stepName: "Query With Return All" }
       )
-      .run()
+      .run({ fields: {} })
 
     expect(result.steps[0].outputs.success).toBe(true)
     expect(result.steps[0].outputs.rows).toBeDefined()
@@ -146,6 +151,7 @@ describe("Test a query step automation", () => {
       name: NAME,
     })
     const result = await createAutomationBuilder(config)
+      .appAction()
       .queryRows(
         {
           tableId: tableWithSpaces._id!,
@@ -154,7 +160,7 @@ describe("Test a query step automation", () => {
         },
         { stepName: "Query table with spaces" }
       )
-      .run()
+      .run({ fields: {} })
     expect(result.steps[0].outputs.success).toBe(true)
     expect(result.steps[0].outputs.rows).toBeDefined()
     expect(result.steps[0].outputs.rows.length).toBe(1)

--- a/packages/server/src/automations/tests/steps/serverLog.spec.ts
+++ b/packages/server/src/automations/tests/steps/serverLog.spec.ts
@@ -14,8 +14,9 @@ describe("test the server log action", () => {
 
   it("should be able to log the text", async () => {
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .serverLog({ text: "Hello World" })
-      .run()
+      .test({ fields: {} })
     expect(result.steps[0].outputs.message).toEqual(
       `App ${config.getAppId()} - Hello World`
     )

--- a/packages/server/src/automations/tests/steps/triggerAutomationRun.spec.ts
+++ b/packages/server/src/automations/tests/steps/triggerAutomationRun.spec.ts
@@ -17,24 +17,27 @@ describe("Test triggering an automation from another automation", () => {
   })
 
   it("should trigger an other server log automation", async () => {
-    const automation = await createAutomationBuilder(config)
+    const { automation } = await createAutomationBuilder(config)
+      .onAppAction()
       .serverLog({ text: "Hello World" })
       .save()
 
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .triggerAutomationRun({
         automation: {
           automationId: automation._id!,
         },
         timeout: env.getDefaults().AUTOMATION_THREAD_TIMEOUT,
       })
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.success).toBe(true)
   })
 
   it("should fail gracefully if the automation id is incorrect", async () => {
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .triggerAutomationRun({
         automation: {
           // @ts-expect-error - incorrect on purpose
@@ -42,7 +45,7 @@ describe("Test triggering an automation from another automation", () => {
         },
         timeout: env.getDefaults().AUTOMATION_THREAD_TIMEOUT,
       })
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.success).toBe(false)
   })

--- a/packages/server/src/automations/tests/steps/updateRow.spec.ts
+++ b/packages/server/src/automations/tests/steps/updateRow.spec.ts
@@ -31,6 +31,7 @@ describe("test the update row action", () => {
 
   it("should be able to run the update row action", async () => {
     const results = await createAutomationBuilder(config)
+      .onAppAction()
       .updateRow({
         rowId: row._id!,
         row: {
@@ -40,7 +41,7 @@ describe("test the update row action", () => {
         },
         meta: {},
       })
-      .run()
+      .test({ fields: {} })
 
     expect(results.steps[0].outputs.success).toEqual(true)
     const updatedRow = await config.api.row.get(
@@ -53,20 +54,22 @@ describe("test the update row action", () => {
 
   it("should check invalid inputs return an error", async () => {
     const results = await createAutomationBuilder(config)
+      .onAppAction()
       .updateRow({ meta: {}, row: {}, rowId: "" })
-      .run()
+      .test({ fields: {} })
 
     expect(results.steps[0].outputs.success).toEqual(false)
   })
 
   it("should return an error when table doesn't exist", async () => {
     const results = await createAutomationBuilder(config)
+      .onAppAction()
       .updateRow({
         row: { _id: "invalid" },
         rowId: "invalid",
         meta: {},
       })
-      .run()
+      .test({ fields: {} })
 
     expect(results.steps[0].outputs.success).toEqual(false)
   })
@@ -104,6 +107,7 @@ describe("test the update row action", () => {
     })
 
     const results = await createAutomationBuilder(config)
+      .onAppAction()
       .updateRow({
         rowId: row._id!,
         row: {
@@ -115,7 +119,7 @@ describe("test the update row action", () => {
         },
         meta: {},
       })
-      .run()
+      .test({ fields: {} })
 
     expect(results.steps[0].outputs.success).toEqual(true)
 
@@ -157,6 +161,7 @@ describe("test the update row action", () => {
     })
 
     const results = await createAutomationBuilder(config)
+      .onAppAction()
       .updateRow({
         rowId: row._id!,
         row: {
@@ -174,7 +179,7 @@ describe("test the update row action", () => {
           },
         },
       })
-      .run()
+      .test({ fields: {} })
 
     expect(results.steps[0].outputs.success).toEqual(true)
 

--- a/packages/server/src/automations/tests/steps/zapier.spec.ts
+++ b/packages/server/src/automations/tests/steps/zapier.spec.ts
@@ -21,8 +21,9 @@ describe("test the outgoing webhook action", () => {
     nock("http://www.example.com/").post("/").reply(200, { foo: "bar" })
 
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .zapier({ url: "http://www.example.com", body: null })
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.response.foo).toEqual("bar")
     expect(result.steps[0].outputs.success).toEqual(true)
@@ -44,11 +45,12 @@ describe("test the outgoing webhook action", () => {
       .reply(200, { foo: "bar" })
 
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .zapier({
         url: "http://www.example.com",
         body: { value: JSON.stringify(payload) },
       })
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.response.foo).toEqual("bar")
     expect(result.steps[0].outputs.success).toEqual(true)
@@ -56,11 +58,12 @@ describe("test the outgoing webhook action", () => {
 
   it("should return a 400 if the JSON payload string is malformed", async () => {
     const result = await createAutomationBuilder(config)
+      .onAppAction()
       .zapier({
         url: "http://www.example.com",
         body: { value: "{ invalid json }" },
       })
-      .run()
+      .test({ fields: {} })
 
     expect(result.steps[0].outputs.success).toEqual(false)
     expect(result.steps[0].outputs.response).toEqual("Invalid payload JSON")

--- a/packages/server/src/automations/tests/triggers/cron.spec.ts
+++ b/packages/server/src/automations/tests/triggers/cron.spec.ts
@@ -25,7 +25,7 @@ describe("cron trigger", () => {
     })
 
     await createAutomationBuilder(config)
-      .cron({ cron: "* * * * *" })
+      .onCron({ cron: "* * * * *" })
       .serverLog({
         text: "Hello, world!",
       })
@@ -45,7 +45,7 @@ describe("cron trigger", () => {
 
   it("should fail if the cron expression is invalid", async () => {
     await createAutomationBuilder(config)
-      .cron({ cron: "* * * * * *" })
+      .onCron({ cron: "* * * * * *" })
       .serverLog({
         text: "Hello, world!",
       })

--- a/packages/server/src/automations/tests/triggers/webhook.spec.ts
+++ b/packages/server/src/automations/tests/triggers/webhook.spec.ts
@@ -12,7 +12,7 @@ describe("Branching automations", () => {
 
   async function createWebhookAutomation() {
     const { automation } = await createAutomationBuilder(config)
-      .webhook({ fields: { parameter: "string" } })
+      .onWebhook({ fields: { parameter: "string" } })
       .createRow({
         row: { tableId: table._id!, name: "{{ trigger.parameter }}" },
       })

--- a/packages/server/src/automations/tests/triggers/webhook.spec.ts
+++ b/packages/server/src/automations/tests/triggers/webhook.spec.ts
@@ -11,7 +11,7 @@ describe("Branching automations", () => {
   let webhook: Webhook
 
   async function createWebhookAutomation() {
-    const automation = await createAutomationBuilder(config)
+    const { automation } = await createAutomationBuilder(config)
       .webhook({ fields: { parameter: "string" } })
       .createRow({
         row: { tableId: table._id!, name: "{{ trigger.parameter }}" },

--- a/packages/server/src/automations/tests/utilities/AutomationTestBuilder.ts
+++ b/packages/server/src/automations/tests/utilities/AutomationTestBuilder.ts
@@ -31,7 +31,7 @@ type BranchConfig = {
 }
 
 class TriggerBuilder {
-  private config: TestConfiguration
+  private readonly config: TestConfiguration
 
   constructor(config: TestConfiguration) {
     this.config = config
@@ -64,10 +64,10 @@ class TriggerBuilder {
 }
 
 class BranchStepBuilder<TStep extends AutomationTriggerStepId> {
-  protected steps: AutomationStep[] = []
-  protected stepNames: { [key: string]: string } = {}
+  protected readonly steps: AutomationStep[] = []
+  protected readonly stepNames: { [key: string]: string } = {}
 
-  protected createStepFn<TStep extends AutomationActionStepId>(stepId: TStep) {
+  protected step<TStep extends AutomationActionStepId>(stepId: TStep) {
     return (
       inputs: AutomationStepInputs<TStep>,
       opts?: { stepName?: string; stepId?: string }
@@ -88,28 +88,28 @@ class BranchStepBuilder<TStep extends AutomationTriggerStepId> {
     }
   }
 
-  createRow = this.createStepFn(AutomationActionStepId.CREATE_ROW)
-  updateRow = this.createStepFn(AutomationActionStepId.UPDATE_ROW)
-  deleteRow = this.createStepFn(AutomationActionStepId.DELETE_ROW)
-  sendSmtpEmail = this.createStepFn(AutomationActionStepId.SEND_EMAIL_SMTP)
-  executeQuery = this.createStepFn(AutomationActionStepId.EXECUTE_QUERY)
-  queryRows = this.createStepFn(AutomationActionStepId.QUERY_ROWS)
-  loop = this.createStepFn(AutomationActionStepId.LOOP)
-  serverLog = this.createStepFn(AutomationActionStepId.SERVER_LOG)
-  executeScript = this.createStepFn(AutomationActionStepId.EXECUTE_SCRIPT)
-  filter = this.createStepFn(AutomationActionStepId.FILTER)
-  bash = this.createStepFn(AutomationActionStepId.EXECUTE_BASH)
-  openai = this.createStepFn(AutomationActionStepId.OPENAI)
-  collect = this.createStepFn(AutomationActionStepId.COLLECT)
-  zapier = this.createStepFn(AutomationActionStepId.zapier)
-  triggerAutomationRun = this.createStepFn(
+  createRow = this.step(AutomationActionStepId.CREATE_ROW)
+  updateRow = this.step(AutomationActionStepId.UPDATE_ROW)
+  deleteRow = this.step(AutomationActionStepId.DELETE_ROW)
+  sendSmtpEmail = this.step(AutomationActionStepId.SEND_EMAIL_SMTP)
+  executeQuery = this.step(AutomationActionStepId.EXECUTE_QUERY)
+  queryRows = this.step(AutomationActionStepId.QUERY_ROWS)
+  loop = this.step(AutomationActionStepId.LOOP)
+  serverLog = this.step(AutomationActionStepId.SERVER_LOG)
+  executeScript = this.step(AutomationActionStepId.EXECUTE_SCRIPT)
+  filter = this.step(AutomationActionStepId.FILTER)
+  bash = this.step(AutomationActionStepId.EXECUTE_BASH)
+  openai = this.step(AutomationActionStepId.OPENAI)
+  collect = this.step(AutomationActionStepId.COLLECT)
+  zapier = this.step(AutomationActionStepId.zapier)
+  triggerAutomationRun = this.step(
     AutomationActionStepId.TRIGGER_AUTOMATION_RUN
   )
-  outgoingWebhook = this.createStepFn(AutomationActionStepId.OUTGOING_WEBHOOK)
-  n8n = this.createStepFn(AutomationActionStepId.n8n)
-  make = this.createStepFn(AutomationActionStepId.integromat)
-  discord = this.createStepFn(AutomationActionStepId.discord)
-  delay = this.createStepFn(AutomationActionStepId.DELAY)
+  outgoingWebhook = this.step(AutomationActionStepId.OUTGOING_WEBHOOK)
+  n8n = this.step(AutomationActionStepId.n8n)
+  make = this.step(AutomationActionStepId.integromat)
+  discord = this.step(AutomationActionStepId.discord)
+  delay = this.step(AutomationActionStepId.DELAY)
 
   protected addBranchStep(branchConfig: BranchConfig): void {
     const inputs: BranchStepInputs = {
@@ -142,8 +142,8 @@ class BranchStepBuilder<TStep extends AutomationTriggerStepId> {
 class StepBuilder<
   TStep extends AutomationTriggerStepId
 > extends BranchStepBuilder<TStep> {
-  private config: TestConfiguration
-  private trigger: AutomationTrigger
+  private readonly config: TestConfiguration
+  private readonly trigger: AutomationTrigger
   private _name: string | undefined = undefined
 
   constructor(config: TestConfiguration, trigger: AutomationTrigger) {
@@ -176,26 +176,26 @@ class StepBuilder<
     return new AutomationRunner<TStep>(this.config, automation)
   }
 
-  async run(outputs: AutomationTriggerOutputs<TStep>) {
+  async test(triggerOutput: AutomationTriggerOutputs<TStep>) {
     const runner = await this.save()
-    return await runner.run(outputs)
+    return await runner.test(triggerOutput)
   }
 }
 
 class AutomationRunner<TStep extends AutomationTriggerStepId> {
-  private config: TestConfiguration
-  automation: Automation
+  private readonly config: TestConfiguration
+  readonly automation: Automation
 
   constructor(config: TestConfiguration, automation: Automation) {
     this.config = config
     this.automation = automation
   }
 
-  async run(outputs: AutomationTriggerOutputs<TStep>) {
+  async test(triggerOutput: AutomationTriggerOutputs<TStep>) {
     const response = await this.config.api.automation.test(
       this.automation._id!,
       // TODO: figure out why this cast is needed.
-      outputs as TestAutomationRequest
+      triggerOutput as TestAutomationRequest
     )
 
     if (isDidNotTriggerResponse(response)) {

--- a/packages/server/src/automations/tests/utilities/AutomationTestBuilder.ts
+++ b/packages/server/src/automations/tests/utilities/AutomationTestBuilder.ts
@@ -54,13 +54,13 @@ class TriggerBuilder {
     }
   }
 
-  appAction = this.trigger(AutomationTriggerStepId.APP)
+  onAppAction = this.trigger(AutomationTriggerStepId.APP)
 
-  rowSaved = this.trigger(AutomationTriggerStepId.ROW_SAVED)
-  rowUpdated = this.trigger(AutomationTriggerStepId.ROW_UPDATED)
-  rowDeleted = this.trigger(AutomationTriggerStepId.ROW_DELETED)
-  webhook = this.trigger(AutomationTriggerStepId.WEBHOOK)
-  cron = this.trigger(AutomationTriggerStepId.CRON)
+  onRowSaved = this.trigger(AutomationTriggerStepId.ROW_SAVED)
+  onRowUpdated = this.trigger(AutomationTriggerStepId.ROW_UPDATED)
+  onRowDeleted = this.trigger(AutomationTriggerStepId.ROW_DELETED)
+  onWebhook = this.trigger(AutomationTriggerStepId.WEBHOOK)
+  onCron = this.trigger(AutomationTriggerStepId.CRON)
 }
 
 class BranchStepBuilder<TStep extends AutomationTriggerStepId> {

--- a/packages/server/src/tests/utilities/structures.ts
+++ b/packages/server/src/tests/utilities/structures.ts
@@ -217,10 +217,8 @@ export function basicAutomation(opts?: DeepPartial<Automation>): Automation {
         icon: "test",
         description: "test",
         type: AutomationStepType.TRIGGER,
+        inputs: {},
         id: "test",
-        inputs: {
-          fields: {},
-        },
         schema: {
           inputs: {
             properties: {},

--- a/packages/types/src/documents/app/automation/StepInputsOutputs.ts
+++ b/packages/types/src/documents/app/automation/StepInputsOutputs.ts
@@ -253,10 +253,6 @@ export type OutgoingWebhookStepInputs = {
   headers: string | Record<string, string>
 }
 
-export type AppActionTriggerInputs = {
-  fields: object
-}
-
 export type AppActionTriggerOutputs = {
   fields: object
 }

--- a/packages/types/src/documents/app/automation/schema.ts
+++ b/packages/types/src/documents/app/automation/schema.ts
@@ -331,7 +331,7 @@ export type AutomationTriggerDefinition = Omit<
 
 export type AutomationTriggerInputs<T extends AutomationTriggerStepId> =
   T extends AutomationTriggerStepId.APP
-    ? void
+    ? void | Record<string, any>
     : T extends AutomationTriggerStepId.CRON
     ? CronTriggerInputs
     : T extends AutomationTriggerStepId.ROW_ACTION

--- a/packages/types/src/documents/app/automation/schema.ts
+++ b/packages/types/src/documents/app/automation/schema.ts
@@ -45,7 +45,6 @@ import {
   OpenAIStepInputs,
   OpenAIStepOutputs,
   LoopStepInputs,
-  AppActionTriggerInputs,
   CronTriggerInputs,
   RowUpdatedTriggerInputs,
   RowCreatedTriggerInputs,
@@ -332,7 +331,7 @@ export type AutomationTriggerDefinition = Omit<
 
 export type AutomationTriggerInputs<T extends AutomationTriggerStepId> =
   T extends AutomationTriggerStepId.APP
-    ? AppActionTriggerInputs
+    ? void
     : T extends AutomationTriggerStepId.CRON
     ? CronTriggerInputs
     : T extends AutomationTriggerStepId.ROW_ACTION


### PR DESCRIPTION
## Description

While working on a previous automation builder refactor I noticed that all of the trigger methods (e.g. `appAction`, `rowCreated`, etc.) took both an `inputs` and an `outputs`. The `outputs` were optional and only get used later if/when you call `run`. This confused me and made it difficult to follow the flow of information.

I've refactored this flow so that this:
```typescript
await createAutomationBuilder(config)
  .cron({ cron: "* * * * *" }, { timestamp: 123456789 })
  .serverLog({ text: "Hello!" })
  .run()
```

Becomes this:
```typescript
await createAutomationBuilder(config)
  .onCron({ cron: "* * * * *" })
  .serverLog({ text: "Hello!" })
  .test({ timestamp: 123456789 })
```

A few things are happening here:
1. Triggers have been renamed to start with `on` to make them read nicer in-situ (`onCron` is admittedly not the nicest example of this, things like `onRowSaved` is much nicer though).
2. `createAutomationBuilder` now returns a `TriggerBuilder` that you can only use to choose a trigger. Once you do, a `StepBuilder<T>` is returned that lets you create steps. This forces you to choose exactly 1 trigger, and types the automation based on the trigger chosen. This `T` is then used later in the renamed `test` (used to be `run` but `test` makes it more clear what API is being used) to know what output type to accept.
3. Not shown but the `save` method (which `test` calls internally) now returns an `AutomationRunner<T>` which allows you to call `test` as many times as you want without creating a new automation. This opens up some new use-cases of testing an automation multiple times without having to do gymnastic with the builder API.

So in short this new structure makes it more difficult to make mistakes, and more obvious what data is going where and when.