### PR TITLE
Disabling grid cell formatting

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -3089,12 +3089,6 @@
         "type": "tableConditions",
         "label": "Conditions",
         "key": "conditions"
-      },
-      {
-        "type": "text",
-        "label": "Format",
-        "key": "format",
-        "info": "Changing format will display values as text"
       }
     ]
   },
@@ -7691,8 +7685,7 @@
           {
             "type": "columns/grid",
             "key": "columns",
-            "resetOn": "table",
-            "nested": true
+            "resetOn": "table"
           }
         ]
       },

--- a/packages/client/src/components/app/GridBlock.svelte
+++ b/packages/client/src/components/app/GridBlock.svelte
@@ -114,12 +114,12 @@
     return overrides
   }
 
-  const createFormatter = column => {
-    if (typeof column.format !== "string" || !column.format.trim().length) {
-      return null
-    }
-    return row => processStringSync(column.format, { [id]: row })
-  }
+  // const createFormatter = column => {
+  //   if (typeof column.format !== "string" || !column.format.trim().length) {
+  //     return null
+  //   }
+  //   return row => processStringSync(column.format, { [id]: row })
+  // }
 
   const enrichButtons = buttons => {
     if (!buttons?.length) {

--- a/packages/client/src/components/app/GridBlock.svelte
+++ b/packages/client/src/components/app/GridBlock.svelte
@@ -5,7 +5,7 @@
   import { get, derived, readable } from "svelte/store"
   import { featuresStore } from "stores"
   import { Grid } from "@budibase/frontend-core"
-  import { processStringSync } from "@budibase/string-templates"
+  // import { processStringSync } from "@budibase/string-templates"
 
   // table is actually any datasource, but called table for legacy compatibility
   export let table

--- a/packages/client/src/components/app/GridBlock.svelte
+++ b/packages/client/src/components/app/GridBlock.svelte
@@ -105,7 +105,7 @@
         order: idx,
         conditions: column.conditions,
         visible: !!column.active,
-        format: createFormatter(column),
+        // format: createFormatter(column),
       }
       if (column.width) {
         overrides[column.field].width = column.width

--- a/packages/frontend-core/src/components/grid/stores/conditions.ts
+++ b/packages/frontend-core/src/components/grid/stores/conditions.ts
@@ -173,5 +173,6 @@ const evaluateConditions = (row: UIRow, conditions: UICondition[]) => {
       // Swallow
     }
   }
+  console.log(metadata)
   return metadata
 }

--- a/packages/frontend-core/src/components/grid/stores/conditions.ts
+++ b/packages/frontend-core/src/components/grid/stores/conditions.ts
@@ -173,6 +173,5 @@ const evaluateConditions = (row: UIRow, conditions: UICondition[]) => {
       // Swallow
     }
   }
-  console.log(metadata)
   return metadata
 }


### PR DESCRIPTION
## Description
Disabling cell formatting, it is currently incompatible with cell/row conditions in grids and to avoid breaking those for now we are removing the capability until both can be a aligned to use the same mechanism of binding evaluation.

## Addresses
- discussion: https://github.com/Budibase/budibase/discussions/15502
