### PR TITLE
Allow multiple tenant users to be created for account holders

### DIFF
--- a/packages/backend-core/src/users/db.ts
+++ b/packages/backend-core/src/users/db.ts
@@ -264,7 +264,9 @@ export class UserDB {
     const creatorsChange =
       (await isCreator(dbUser)) !== (await isCreator(user)) ? 1 : 0
     return UserDB.quotas.addUsers(change, creatorsChange, async () => {
-      await validateUniqueUser(email, tenantId)
+      if (!opts.isAccountHolder) {
+        await validateUniqueUser(email, tenantId)
+      }
 
       let builtUser = await UserDB.buildUser(user, opts, tenantId, dbUser)
       // don't allow a user to update its own roles/perms
@@ -569,6 +571,7 @@ export class UserDB {
       hashPassword: opts?.hashPassword,
       requirePassword: opts?.requirePassword,
       skipPasswordValidation: opts?.skipPasswordValidation,
+      isAccountHolder: true,
     })
   }
 

--- a/packages/types/src/sdk/user.ts
+++ b/packages/types/src/sdk/user.ts
@@ -4,4 +4,5 @@ export interface SaveUserOpts {
   currentUserId?: string
   skipPasswordValidation?: boolean
   allowChangingEmail?: boolean
+  isAccountHolder?: boolean
 }


### PR DESCRIPTION
## Description
Allow account holders to be added as a tenant user for multiple tenants. 

## Addresses
- https://linear.app/budibase/issue/GRO-733/an-account-holder-should-be-able-to-be-a-user-of-multiple-workspaces

