### PR TITLE
Revert setting a default icon

### DIFF
--- a/packages/builder/src/stores/builder/components.ts
+++ b/packages/builder/src/stores/builder/components.ts
@@ -311,8 +311,6 @@ export class ComponentStore extends BudiStore<ComponentState> {
             component[setting.key] = fieldOptions[0]
             component.label = fieldOptions[0]
           }
-        } else if (setting.type === "icon") {
-          component[setting.key] = "ri-star-fill"
         } else if (useDefaultValues && setting.defaultValue !== undefined) {
           // Use default value where required
           component[setting.key] = setting.defaultValue

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -1455,7 +1455,8 @@
         "type": "icon",
         "label": "Icon",
         "key": "icon",
-        "required": true
+        "required": true,
+        "defaultValue": "ri-star-fill"
       },
       {
         "type": "select",


### PR DESCRIPTION
## Description
This can cause undesired effects for plugin authors, so I'm reverting this. We'll continue to show an error when adding icon components.
