### PR TITLE
Test cron removal.

### DIFF
--- a/packages/backend-core/src/queue/inMemoryQueue.ts
+++ b/packages/backend-core/src/queue/inMemoryQueue.ts
@@ -136,7 +136,6 @@ export class InMemoryQueue<T = any> implements Partial<Queue<T>> {
    * a JSON message as this is required by Bull.
    * @param repeat serves no purpose for the import queue.
    */
-  // add(name: string, data: T, opts?: JobOptions): Promise<Job<T>>;
   async add(data: T | string, optsOrT?: JobOptions | T) {
     if (typeof data === "string") {
       throw new Error("doesn't support named jobs")

--- a/packages/backend-core/src/queue/index.ts
+++ b/packages/backend-core/src/queue/index.ts
@@ -1,2 +1,3 @@
 export * from "./queue"
 export * from "./constants"
+export * from "./inMemoryQueue"

--- a/packages/server/src/automations/tests/steps/loop.spec.ts
+++ b/packages/server/src/automations/tests/steps/loop.spec.ts
@@ -21,6 +21,11 @@ describe("Attempt to run a basic loop automation", () => {
   })
 
   beforeEach(async () => {
+    const { automations } = await config.api.automation.fetch()
+    for (const automation of automations) {
+      await config.api.automation.delete(automation)
+    }
+
     table = await config.api.table.save(basicTable())
     await config.api.row.save(table._id!, {})
   })

--- a/packages/server/src/automations/tests/triggers/cron.spec.ts
+++ b/packages/server/src/automations/tests/triggers/cron.spec.ts
@@ -66,7 +66,7 @@ describe("cron trigger", () => {
     })
   })
 
-  it.only("should stop if the job fails more than 3 times", async () => {
+  it("should stop if the job fails more than 3 times", async () => {
     const { automation } = await createAutomationBuilder(config)
       .onCron({ cron: "* * * * *" })
       .queryRows({

--- a/packages/server/src/automations/tests/triggers/cron.spec.ts
+++ b/packages/server/src/automations/tests/triggers/cron.spec.ts
@@ -9,7 +9,7 @@ import {
 import { automations } from "@budibase/pro"
 import { AutomationData, AutomationStatus } from "@budibase/types"
 import { MAX_AUTOMATION_RECURRING_ERRORS } from "../../../constants"
-import { Job } from "bull"
+import { queue } from "@budibase/backend-core"
 
 describe("cron trigger", () => {
   const config = new TestConfiguration()
@@ -80,7 +80,7 @@ describe("cron trigger", () => {
     )
 
     await config.withProdApp(async () => {
-      let results: Job<AutomationData>[] = []
+      let results: queue.TestQueueMessage<AutomationData>[] = []
       const removed = await captureAutomationRemovals(automation, async () => {
         results = await captureAutomationResults(automation, async () => {
           for (let i = 0; i < MAX_AUTOMATION_RECURRING_ERRORS; i++) {

--- a/packages/server/src/automations/tests/triggers/cron.spec.ts
+++ b/packages/server/src/automations/tests/triggers/cron.spec.ts
@@ -1,11 +1,15 @@
 import { createAutomationBuilder } from "../utilities/AutomationTestBuilder"
 import TestConfiguration from "../../../tests/utilities/TestConfiguration"
 import {
-  captureAutomationQueueMessages,
+  captureAutomationMessages,
+  captureAutomationRemovals,
   captureAutomationResults,
+  triggerCron,
 } from "../utilities"
 import { automations } from "@budibase/pro"
-import { AutomationStatus } from "@budibase/types"
+import { AutomationData, AutomationStatus } from "@budibase/types"
+import { MAX_AUTOMATION_RECURRING_ERRORS } from "../../../constants"
+import { Job } from "bull"
 
 describe("cron trigger", () => {
   const config = new TestConfiguration()
@@ -33,7 +37,7 @@ describe("cron trigger", () => {
       })
       .save()
 
-    const messages = await captureAutomationQueueMessages(automation, () =>
+    const messages = await captureAutomationMessages(automation, () =>
       config.api.application.publish()
     )
     expect(messages).toHaveLength(1)
@@ -62,8 +66,8 @@ describe("cron trigger", () => {
     })
   })
 
-  it("should stop if the job fails more than 3 times", async () => {
-    const runner = await createAutomationBuilder(config)
+  it.only("should stop if the job fails more than 3 times", async () => {
+    const { automation } = await createAutomationBuilder(config)
       .onCron({ cron: "* * * * *" })
       .queryRows({
         // @ts-expect-error intentionally sending invalid data
@@ -71,28 +75,31 @@ describe("cron trigger", () => {
       })
       .save()
 
-    await config.api.application.publish()
-
-    const results = await captureAutomationResults(
-      runner.automation,
-      async () => {
-        await runner.trigger({ timeout: 1000, fields: {} })
-        await runner.trigger({ timeout: 1000, fields: {} })
-        await runner.trigger({ timeout: 1000, fields: {} })
-        await runner.trigger({ timeout: 1000, fields: {} })
-        await runner.trigger({ timeout: 1000, fields: {} })
-      }
+    const [message] = await captureAutomationMessages(automation, () =>
+      config.api.application.publish()
     )
 
-    expect(results).toHaveLength(5)
-
     await config.withProdApp(async () => {
-      const {
-        data: [latest, ..._],
-      } = await automations.logs.logSearch({
-        automationId: runner.automation._id,
+      let results: Job<AutomationData>[] = []
+      const removed = await captureAutomationRemovals(automation, async () => {
+        results = await captureAutomationResults(automation, async () => {
+          for (let i = 0; i < MAX_AUTOMATION_RECURRING_ERRORS; i++) {
+            triggerCron(message)
+          }
+        })
       })
-      expect(latest.status).toEqual(AutomationStatus.STOPPED_ERROR)
+
+      expect(removed).toHaveLength(1)
+      expect(removed[0].id).toEqual(message.id)
+
+      expect(results).toHaveLength(5)
+
+      const search = await automations.logs.logSearch({
+        automationId: automation._id,
+        status: AutomationStatus.STOPPED_ERROR,
+      })
+      expect(search.data).toHaveLength(1)
+      expect(search.data[0].status).toEqual(AutomationStatus.STOPPED_ERROR)
     })
   })
 

--- a/packages/server/src/automations/tests/utilities/index.ts
+++ b/packages/server/src/automations/tests/utilities/index.ts
@@ -120,19 +120,22 @@ export async function captureAutomationMessages(
  */
 export async function captureAllAutomationResults(
   f: () => Promise<unknown>
-): Promise<Job<AutomationData>[]> {
-  const runs: Job<AutomationData>[] = []
+): Promise<queue.TestQueueMessage<AutomationData>[]> {
+  const runs: queue.TestQueueMessage<AutomationData>[] = []
   const queue = getQueue()
   let messagesOutstanding = 0
 
-  const completedListener = async (job: Job<AutomationData>) => {
+  const completedListener = async (
+    job: queue.TestQueueMessage<AutomationData>
+  ) => {
     runs.push(job)
     messagesOutstanding--
   }
-  const messageListener = async (message: Job<AutomationData>) => {
+  const messageListener = async (
+    message: queue.TestQueueMessage<AutomationData>
+  ) => {
     // Don't count cron messages, as they don't get triggered automatically.
-    const isManualTrigger = (message as any).manualTrigger === true
-    if (!isManualTrigger && message.opts?.repeat != null) {
+    if (!message.manualTrigger && message.opts?.repeat != null) {
       return
     }
     messagesOutstanding++

--- a/packages/server/src/automations/tests/utilities/index.ts
+++ b/packages/server/src/automations/tests/utilities/index.ts
@@ -6,6 +6,7 @@ import { Knex } from "knex"
 import { getQueue } from "../.."
 import { Job } from "bull"
 import { helpers } from "@budibase/shared-core"
+import { queue } from "@budibase/backend-core"
 
 let config: TestConfiguration
 
@@ -18,6 +19,17 @@ export function getConfig(): TestConfiguration {
 
 export function afterAll() {
   config.end()
+}
+
+export function getTestQueue(): queue.InMemoryQueue<AutomationData> {
+  return getQueue() as unknown as queue.InMemoryQueue<AutomationData>
+}
+
+export function triggerCron(message: Job<AutomationData>) {
+  if (!message.opts?.repeat || !("cron" in message.opts.repeat)) {
+    throw new Error("Expected cron message")
+  }
+  getTestQueue().manualTrigger(message.id)
 }
 
 export async function runInProd(fn: any) {
@@ -34,9 +46,41 @@ export async function runInProd(fn: any) {
   }
 }
 
-export async function captureAllAutomationQueueMessages(
+export async function captureAllAutomationRemovals(f: () => Promise<unknown>) {
+  const messages: Job<AutomationData>[] = []
+  const queue = getQueue()
+
+  const messageListener = async (message: Job<AutomationData>) => {
+    messages.push(message)
+  }
+
+  queue.on("removed", messageListener)
+  try {
+    await f()
+    // Queue messages tend to be send asynchronously in API handlers, so there's
+    // no guarantee that awaiting this function will have queued anything yet.
+    // We wait here to make sure we're queued _after_ any existing async work.
+    await helpers.wait(100)
+  } finally {
+    queue.off("removed", messageListener)
+  }
+
+  return messages
+}
+
+export async function captureAutomationRemovals(
+  automation: Automation | string,
   f: () => Promise<unknown>
 ) {
+  const messages = await captureAllAutomationRemovals(f)
+  return messages.filter(
+    m =>
+      m.data.automation._id ===
+      (typeof automation === "string" ? automation : automation._id)
+  )
+}
+
+export async function captureAllAutomationMessages(f: () => Promise<unknown>) {
   const messages: Job<AutomationData>[] = []
   const queue = getQueue()
 
@@ -58,11 +102,11 @@ export async function captureAllAutomationQueueMessages(
   return messages
 }
 
-export async function captureAutomationQueueMessages(
+export async function captureAutomationMessages(
   automation: Automation | string,
   f: () => Promise<unknown>
 ) {
-  const messages = await captureAllAutomationQueueMessages(f)
+  const messages = await captureAllAutomationMessages(f)
   return messages.filter(
     m =>
       m.data.automation._id ===
@@ -87,7 +131,8 @@ export async function captureAllAutomationResults(
   }
   const messageListener = async (message: Job<AutomationData>) => {
     // Don't count cron messages, as they don't get triggered automatically.
-    if (message.opts?.repeat != null) {
+    const isManualTrigger = (message as any).manualTrigger === true
+    if (!isManualTrigger && message.opts?.repeat != null) {
       return
     }
     messagesOutstanding++

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -201,7 +201,7 @@ class Orchestrator {
         return metadata.errorCount
       } catch (error: any) {
         err = error
-        await helpers.wait(Math.random() * 10)
+        await helpers.wait(1000 + Math.random() * 1000)
       }
     }
 

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -181,17 +181,6 @@ class Orchestrator {
     await storeLog(automation, this.executionOutput)
   }
 
-  async checkIfShouldStop(): Promise<boolean> {
-    const metadata = await this.getMetadata()
-    if (!metadata.errorCount || !this.isCron()) {
-      return false
-    }
-    if (metadata.errorCount >= MAX_AUTOMATION_RECURRING_ERRORS) {
-      return true
-    }
-    return false
-  }
-
   async getMetadata(): Promise<AutomationMetadata> {
     const metadataId = generateAutomationMetadataID(this.automation._id!)
     const db = context.getAppDB()
@@ -200,24 +189,29 @@ class Orchestrator {
   }
 
   async incrementErrorCount() {
-    for (let attempt = 0; attempt < 3; attempt++) {
+    const db = context.getAppDB()
+    let err: Error | undefined = undefined
+    for (let attempt = 0; attempt < 10; attempt++) {
       const metadata = await this.getMetadata()
       metadata.errorCount ||= 0
       metadata.errorCount++
 
-      const db = context.getAppDB()
       try {
         await db.put(metadata)
-        return
-      } catch (err) {
-        logging.logAlertWithInfo(
-          "Failed to update error count in automation metadata",
-          db.name,
-          this.automation._id!,
-          err
-        )
+        return metadata.errorCount
+      } catch (error: any) {
+        err = error
+        await helpers.wait(Math.random() * 10)
       }
     }
+
+    logging.logAlertWithInfo(
+      "Failed to update error count in automation metadata",
+      db.name,
+      this.automation._id!,
+      err
+    )
+    return undefined
   }
 
   updateExecutionOutput(id: string, stepId: string, inputs: any, outputs: any) {
@@ -295,28 +289,22 @@ class Orchestrator {
           }
         )
 
-        try {
-          await storeLog(this.automation, this.executionOutput)
-        } catch (e: any) {
-          if (e.status === 413 && e.request?.data) {
-            // if content is too large we shouldn't log it
-            delete e.request.data
-            e.request.data = { message: "removed due to large size" }
-          }
-          logging.logAlert("Error writing automation log", e)
-        }
+        let errorCount = 0
         if (
           isProdAppID(this.appId) &&
           this.isCron() &&
           isErrorInOutput(this.executionOutput)
         ) {
-          await this.incrementErrorCount()
-          if (await this.checkIfShouldStop()) {
-            await this.stopCron("errors")
-            span?.addTags({ shouldStop: true })
-            return
-          }
+          errorCount = (await this.incrementErrorCount()) || 0
         }
+
+        if (errorCount >= MAX_AUTOMATION_RECURRING_ERRORS) {
+          await this.stopCron("errors")
+          span?.addTags({ shouldStop: true })
+        } else {
+          await storeLog(this.automation, this.executionOutput)
+        }
+
         return this.executionOutput
       }
     )
@@ -743,7 +731,7 @@ export async function executeInThread(
   })) as AutomationResponse
 }
 
-export const removeStalled = async (job: Job) => {
+export const removeStalled = async (job: Job<AutomationData>) => {
   const appId = job.data.event.appId
   if (!appId) {
     throw new Error("Unable to execute, event doesn't contain app ID.")


### PR DESCRIPTION
## Description

In https://github.com/Budibase/budibase/pull/15566 I was annoyed that I wasn't able to find a nice way to test that cron automations get removed correctly from Bull. In this PR, I think I've figured out a nice enough way to do it.

It boils down to capturing the cron message that goes into the queue and exposing a method to re-trigger that message in tests. With this, we ensure that when the job triggers, it's using the correct cron message, and this then correctly triggers the removal from the queue when it fails 5 times.