### PR TITLE
Fix loops being given empty strings.

### DIFF
--- a/packages/server/src/automations/tests/steps/loop.spec.ts
+++ b/packages/server/src/automations/tests/steps/loop.spec.ts
@@ -7,6 +7,8 @@ import {
   CreateRowStepOutputs,
   FieldType,
   FilterCondition,
+  AutomationStatus,
+  AutomationStepStatus,
 } from "@budibase/types"
 import { createAutomationBuilder } from "../utilities/AutomationTestBuilder"
 import TestConfiguration from "../../../tests/utilities/TestConfiguration"
@@ -559,6 +561,26 @@ describe("Attempt to run a basic loop automation", () => {
         success: true,
         status: "stopped",
       })
+    })
+
+    it("should not fail if queryRows returns nothing", async () => {
+      const table = await config.api.table.save(basicTable())
+      const results = await createAutomationBuilder(config)
+        .onAppAction()
+        .queryRows({
+          tableId: table._id!,
+        })
+        .loop({
+          option: LoopStepType.ARRAY,
+          binding: "{{ steps.1.rows }}",
+        })
+        .serverLog({ text: "Message {{loop.currentItem}}" })
+        .test({ fields: {} })
+
+      expect(results.steps[1].outputs.success).toBe(true)
+      expect(results.steps[1].outputs.status).toBe(
+        AutomationStepStatus.NO_ITERATIONS
+      )
     })
   })
 })

--- a/packages/server/src/automations/tests/steps/loop.spec.ts
+++ b/packages/server/src/automations/tests/steps/loop.spec.ts
@@ -7,7 +7,6 @@ import {
   CreateRowStepOutputs,
   FieldType,
   FilterCondition,
-  AutomationStatus,
   AutomationStepStatus,
 } from "@budibase/types"
 import { createAutomationBuilder } from "../utilities/AutomationTestBuilder"

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -68,7 +68,11 @@ function getLoopIterable(step: LoopStep): any[] {
   let input = step.inputs.binding
 
   if (option === LoopStepType.ARRAY && typeof input === "string") {
-    input = JSON.parse(input)
+    if (input === "") {
+      input = []
+    } else {
+      input = JSON.parse(input)
+    }
   }
 
   if (option === LoopStepType.STRING && Array.isArray(input)) {
@@ -492,7 +496,7 @@ class Orchestrator {
       }
 
       const status =
-        iterations === 0 ? AutomationStatus.NO_CONDITION_MET : undefined
+        iterations === 0 ? AutomationStepStatus.NO_ITERATIONS : undefined
       return stepSuccess(stepToLoop, { status, iterations, items })
     })
   }


### PR DESCRIPTION
## Description

Loops were not correctly looping 0 times when given an empty input, this PR fixes that and adds a test to prevent future regression.

## Launchcontrol

- Fix `INCORRECT_TYPE` error when trying to loop over an empty array.
