### PR TITLE
Fix for automation traversal

### DIFF
--- a/packages/builder/src/stores/builder/automations.ts
+++ b/packages/builder/src/stores/builder/automations.ts
@@ -484,7 +484,7 @@ const automationActions = (store: AutomationStore) => ({
         branches.forEach((branch, bIdx) => {
           children[branch.id].forEach(
             (bBlock: AutomationStep, sIdx: number, array: AutomationStep[]) => {
-              const ended = array.length - 1 === sIdx && !branches.length
+              const ended = array.length - 1 === sIdx
               treeTraverse(bBlock, pathToCurrentNode, sIdx, bIdx, ended)
             }
           )
@@ -505,7 +505,6 @@ const automationActions = (store: AutomationStore) => ({
     blocks.forEach((block, idx, array) => {
       treeTraverse(block, null, idx, null, array.length - 1 === idx)
     })
-
     return blockRefs
   },
 


### PR DESCRIPTION
## Description
The `terminated` flag was not being set on the step references when traversing. This would manifest in the UI as automation flows that would seemingly come to an unexpected end and `Collect Data` would no longer be a selectable step type.

## Addresses
- https://linear.app/budibase/issue/BUDI-9079/cannot-add-collect-data-step-as-ui-no-longer-recognises-the-end-of-an

## Launchcontrol
Minor fix to ensure terminated flag is set when traversing automations.