### PR TITLE
Cleanup after automation tests.

### DIFF
--- a/packages/server/src/automations/tests/steps/bash.spec.ts
+++ b/packages/server/src/automations/tests/steps/bash.spec.ts
@@ -16,6 +16,7 @@ describe("Execute Bash Automations", () => {
       name: "test row",
       description: "test description",
     })
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {

--- a/packages/server/src/automations/tests/steps/createRow.spec.ts
+++ b/packages/server/src/automations/tests/steps/createRow.spec.ts
@@ -33,6 +33,7 @@ describe("test the create row action", () => {
       name: "test",
       description: "test",
     }
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {

--- a/packages/server/src/automations/tests/steps/delay.spec.ts
+++ b/packages/server/src/automations/tests/steps/delay.spec.ts
@@ -6,6 +6,7 @@ describe("test the delay logic", () => {
 
   beforeAll(async () => {
     await config.init()
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {

--- a/packages/server/src/automations/tests/steps/deleteRow.spec.ts
+++ b/packages/server/src/automations/tests/steps/deleteRow.spec.ts
@@ -13,6 +13,7 @@ describe("test the delete row action", () => {
     await config.init()
     table = await config.api.table.save(basicTable())
     row = await config.api.row.save(table._id!, {})
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {

--- a/packages/server/src/automations/tests/steps/discord.spec.ts
+++ b/packages/server/src/automations/tests/steps/discord.spec.ts
@@ -7,6 +7,7 @@ describe("test the outgoing webhook action", () => {
 
   beforeAll(async () => {
     await config.init()
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {

--- a/packages/server/src/automations/tests/steps/executeQuery.spec.ts
+++ b/packages/server/src/automations/tests/steps/executeQuery.spec.ts
@@ -26,6 +26,7 @@ if (descriptions.length) {
         const ds = await dsProvider()
         datasource = ds.datasource!
         client = ds.client!
+        await config.api.automation.deleteAll()
       })
 
       beforeEach(async () => {

--- a/packages/server/src/automations/tests/steps/executeScript.spec.ts
+++ b/packages/server/src/automations/tests/steps/executeScript.spec.ts
@@ -13,6 +13,7 @@ describe("Execute Script Automations", () => {
     await config.init()
     table = await config.api.table.save(basicTable())
     await config.api.row.save(table._id!, {})
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {

--- a/packages/server/src/automations/tests/steps/filter.spec.ts
+++ b/packages/server/src/automations/tests/steps/filter.spec.ts
@@ -26,6 +26,7 @@ describe("test the filter logic", () => {
 
   beforeAll(async () => {
     await config.init()
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {

--- a/packages/server/src/automations/tests/steps/loop.spec.ts
+++ b/packages/server/src/automations/tests/steps/loop.spec.ts
@@ -22,10 +22,7 @@ describe("Attempt to run a basic loop automation", () => {
   })
 
   beforeEach(async () => {
-    const { automations } = await config.api.automation.fetch()
-    for (const automation of automations) {
-      await config.api.automation.delete(automation)
-    }
+    await config.api.automation.deleteAll()
 
     table = await config.api.table.save(basicTable())
     await config.api.row.save(table._id!, {})

--- a/packages/server/src/automations/tests/steps/make.spec.ts
+++ b/packages/server/src/automations/tests/steps/make.spec.ts
@@ -7,6 +7,7 @@ describe("test the outgoing webhook action", () => {
 
   beforeAll(async () => {
     await config.init()
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {

--- a/packages/server/src/automations/tests/steps/n8n.spec.ts
+++ b/packages/server/src/automations/tests/steps/n8n.spec.ts
@@ -8,6 +8,7 @@ describe("test the outgoing webhook action", () => {
 
   beforeAll(async () => {
     await config.init()
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {

--- a/packages/server/src/automations/tests/steps/openai.spec.ts
+++ b/packages/server/src/automations/tests/steps/openai.spec.ts
@@ -16,6 +16,7 @@ describe("test the openai action", () => {
 
   beforeAll(async () => {
     await config.init()
+    await config.api.automation.deleteAll()
   })
 
   beforeEach(() => {

--- a/packages/server/src/automations/tests/steps/outgoingWebhook.spec.ts
+++ b/packages/server/src/automations/tests/steps/outgoingWebhook.spec.ts
@@ -8,6 +8,7 @@ describe("test the outgoing webhook action", () => {
 
   beforeAll(async () => {
     await config.init()
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {

--- a/packages/server/src/automations/tests/steps/queryRows.spec.ts
+++ b/packages/server/src/automations/tests/steps/queryRows.spec.ts
@@ -21,6 +21,7 @@ describe("Test a query step automation", () => {
     }
     await config.api.row.save(table._id!, row)
     await config.api.row.save(table._id!, row)
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {

--- a/packages/server/src/automations/tests/steps/sendSmtpEmail.spec.ts
+++ b/packages/server/src/automations/tests/steps/sendSmtpEmail.spec.ts
@@ -28,6 +28,7 @@ describe("test the outgoing webhook action", () => {
 
   beforeAll(async () => {
     await config.init()
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {

--- a/packages/server/src/automations/tests/steps/serverLog.spec.ts
+++ b/packages/server/src/automations/tests/steps/serverLog.spec.ts
@@ -6,6 +6,7 @@ describe("test the server log action", () => {
 
   beforeAll(async () => {
     await config.init()
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {

--- a/packages/server/src/automations/tests/steps/triggerAutomationRun.spec.ts
+++ b/packages/server/src/automations/tests/steps/triggerAutomationRun.spec.ts
@@ -9,6 +9,7 @@ describe("Test triggering an automation from another automation", () => {
   beforeAll(async () => {
     await automation.init()
     await config.init()
+    await config.api.automation.deleteAll()
   })
 
   afterAll(async () => {

--- a/packages/server/src/automations/tests/steps/updateRow.spec.ts
+++ b/packages/server/src/automations/tests/steps/updateRow.spec.ts
@@ -23,6 +23,7 @@ describe("test the update row action", () => {
     await config.init()
     table = await config.createTable()
     row = await config.createRow()
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {

--- a/packages/server/src/automations/tests/steps/zapier.spec.ts
+++ b/packages/server/src/automations/tests/steps/zapier.spec.ts
@@ -7,6 +7,7 @@ describe("test the outgoing webhook action", () => {
 
   beforeAll(async () => {
     await config.init()
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {

--- a/packages/server/src/automations/tests/triggers/appAction.spec.ts
+++ b/packages/server/src/automations/tests/triggers/appAction.spec.ts
@@ -9,6 +9,8 @@ describe("app action trigger", () => {
 
   beforeAll(async () => {
     await config.init()
+    await config.api.automation.deleteAll()
+
     automation = await createAutomationBuilder(config)
       .onAppAction()
       .serverLog({

--- a/packages/server/src/automations/tests/triggers/cron.spec.ts
+++ b/packages/server/src/automations/tests/triggers/cron.spec.ts
@@ -16,6 +16,7 @@ describe("cron trigger", () => {
 
   beforeAll(async () => {
     await config.init()
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {

--- a/packages/server/src/automations/tests/triggers/rowDeleted.spec.ts
+++ b/packages/server/src/automations/tests/triggers/rowDeleted.spec.ts
@@ -11,6 +11,7 @@ describe("row deleted trigger", () => {
 
   beforeAll(async () => {
     await config.init()
+    await config.api.automation.deleteAll()
     table = await config.api.table.save(basicTable())
     automation = await createAutomationBuilder(config)
       .onRowDeleted({ tableId: table._id! })

--- a/packages/server/src/automations/tests/triggers/rowSaved.spec.ts
+++ b/packages/server/src/automations/tests/triggers/rowSaved.spec.ts
@@ -11,6 +11,7 @@ describe("row saved trigger", () => {
 
   beforeAll(async () => {
     await config.init()
+    await config.api.automation.deleteAll()
     table = await config.api.table.save(basicTable())
     automation = await createAutomationBuilder(config)
       .onRowSaved({ tableId: table._id! })

--- a/packages/server/src/automations/tests/triggers/rowUpdated.spec.ts
+++ b/packages/server/src/automations/tests/triggers/rowUpdated.spec.ts
@@ -11,6 +11,7 @@ describe("row updated trigger", () => {
 
   beforeAll(async () => {
     await config.init()
+    await config.api.automation.deleteAll()
     table = await config.api.table.save(basicTable())
     automation = await createAutomationBuilder(config)
       .onRowUpdated({ tableId: table._id! })

--- a/packages/server/src/automations/tests/triggers/webhook.spec.ts
+++ b/packages/server/src/automations/tests/triggers/webhook.spec.ts
@@ -37,6 +37,7 @@ describe("Webhook trigger test", () => {
 
   beforeEach(async () => {
     await config.init()
+    await config.api.automation.deleteAll()
     table = await config.createTable()
   })
 

--- a/packages/server/src/tests/utilities/api/automation.ts
+++ b/packages/server/src/tests/utilities/api/automation.ts
@@ -133,4 +133,11 @@ export class AutomationAPI extends TestAPI {
       }
     )
   }
+
+  deleteAll = async (expectations?: Expectations): Promise<void> => {
+    const { automations } = await this.fetch()
+    await Promise.all(
+      automations.map(automation => this.delete(automation, expectations))
+    )
+  }
 }


### PR DESCRIPTION
## Description

This PR makes sure that automation tests clean up automations after themselves. This was triggered by https://github.com/Budibase/budibase/actions/runs/13636230016/job/38115608248, which I'm theorising it caused by `loop.spec.ts` being the only test to need automations deleting before it runs. Because of this, it ends up having to delete lots of automations it isn't responsible for, which takes time.

Additionally, I've also changed the automation deletion code to delete automations concurrently. This makes `loop.spec.ts` go from taking 25s locally to 10s.
