### PR TITLE
Fixing wrongly display bindings on JS

### DIFF
--- a/packages/builder/src/components/common/bindings/BindingSidePanel.svelte
+++ b/packages/builder/src/components/common/bindings/BindingSidePanel.svelte
@@ -145,9 +145,11 @@
       return
     }
     popoverAnchor = target
+
+    const doc = new DOMParser().parseFromString(helper.description, "text/html")
     hoverTarget = {
       type: "helper",
-      description: helper.description,
+      description: doc.body.textContent || "",
       code: getHelperExample(helper, mode === BindingMode.JavaScript),
     }
     popover.show()
@@ -241,8 +243,7 @@
     >
       {#if hoverTarget.description}
         <div>
-          <!-- eslint-disable-next-line svelte/no-at-html-tags-->
-          {@html hoverTarget.description}
+          {hoverTarget.description}
         </div>
       {/if}
       {#if hoverTarget.code}

--- a/packages/builder/src/components/common/bindings/BindingSidePanel.svelte
+++ b/packages/builder/src/components/common/bindings/BindingSidePanel.svelte
@@ -246,15 +246,15 @@
         </div>
       {/if}
       {#if hoverTarget.code}
-        {#if mode === BindingMode.JavaScript}
+        {#if mode === BindingMode.Text || (mode === BindingMode.JavaScript && hoverTarget.type === "binding")}
+          <!-- eslint-disable-next-line svelte/no-at-html-tags-->
+          <pre>{@html hoverTarget.code}</pre>
+        {:else}
           <CodeEditor
             value={hoverTarget.code?.trim()}
             mode={EditorModes.JS}
             readonly
           />
-        {:else if mode === BindingMode.Text}
-          <!-- eslint-disable-next-line svelte/no-at-html-tags-->
-          <pre>{@html hoverTarget.code}</pre>
         {/if}
       {/if}
     </div>


### PR DESCRIPTION
## Description
A recent update introduced the usage of codemirror to render some binding values in js. This way, we format properly snippets and helpers. Previously, we had some formatters for bindings, and they conflict.
For this, in this PR we use the previous usage for bindings in JS (leaving the rest to use codemirror). Also, fixing a small issue that caused binding descriptions to render html tags incorreclty formatted.

## Screenshots
| Before | After |
|--------|--------|
|<img width="863" alt="image" src="https://github.com/user-attachments/assets/611bca0e-fb2f-4f2b-9950-252287b1f6da" /> |<img width="863" alt="image" src="https://github.com/user-attachments/assets/c6bcc9a8-8c4d-4c0a-aa9c-da913edc6e2b" /> |
|<img width="863" alt="image" src="https://github.com/user-attachments/assets/1319af47-0851-474a-8e23-524bd5ebe644" />|<img width="863" alt="image" src="https://github.com/user-attachments/assets/db06e625-5dab-42b6-abb6-95d9f26a0ab5" /> |
|<img width="863" alt="image" src="https://github.com/user-attachments/assets/f9aeda05-80e2-439b-9f1b-7cf7eb50560b" /> | <img width="863" alt="image" src="https://github.com/user-attachments/assets/f33319d1-3002-4cfb-8bdf-b2d18669a086" /> | 

## Launchcontrol
Fixing wrongly display binding descriptions on JS