### PR TITLE
Add extra date helpers

### DIFF
--- a/packages/string-templates/scripts/gen-collection-info.ts
+++ b/packages/string-templates/scripts/gen-collection-info.ts
@@ -53,7 +53,7 @@ const ADDED_HELPERS = {
     },
     durationFromNow: {
       args: ["time"],
-      example: '{{durationFromNow "2025-09-30"}} -> 7 months',
+      example: '{{durationFromNow "2021-09-30"}} -> 8 months',
       description:
         "Produce a humanized duration left/until given an amount of time and the type of time measurement.",
     },

--- a/packages/string-templates/scripts/gen-collection-info.ts
+++ b/packages/string-templates/scripts/gen-collection-info.ts
@@ -51,6 +51,12 @@ const ADDED_HELPERS = {
       description:
         "Gets the difference between two dates, in milliseconds. Pass a third parameter to adjust the unit measurement.",
     },
+    durationFromNow: {
+      args: ["time"],
+      example: '{{durationFromNow "2025-09-30"}} -> 7 months',
+      description:
+        "Produce a humanized duration left/until given an amount of time and the type of time measurement.",
+    },
   },
 }
 

--- a/packages/string-templates/scripts/gen-collection-info.ts
+++ b/packages/string-templates/scripts/gen-collection-info.ts
@@ -44,6 +44,13 @@ const ADDED_HELPERS = {
       description:
         "Produce a humanized duration left/until given an amount of time and the type of time measurement.",
     },
+    difference: {
+      args: ["from", "to", "[unitType=ms]"],
+      example:
+        '{{ difference "2025-09-30" "2025-06-17" "seconds" }} -> 9072000',
+      description:
+        "Gets the difference between two dates, in milliseconds. Pass a third parameter to adjust the unit measurement.",
+    },
   },
 }
 

--- a/packages/string-templates/src/helpers/date.ts
+++ b/packages/string-templates/src/helpers/date.ts
@@ -134,7 +134,7 @@ export const duration = (str: any, pattern: any, format?: any) => {
   }
 }
 
-export const difference = (from: string, to: string, units: UnitType) => {
+export const difference = (from: string, to: string, units?: UnitType) => {
   const result = dayjs(new Date(from)).diff(dayjs(new Date(to)), units)
   return result
 }

--- a/packages/string-templates/src/helpers/date.ts
+++ b/packages/string-templates/src/helpers/date.ts
@@ -1,4 +1,4 @@
-import dayjs from "dayjs"
+import dayjs, { UnitType } from "dayjs"
 
 import dayjsDurationPlugin from "dayjs/plugin/duration"
 import dayjsAdvancedFormatPlugin from "dayjs/plugin/advancedFormat"
@@ -132,4 +132,9 @@ export const duration = (str: any, pattern: any, format: any) => {
   } else {
     return duration.humanize()
   }
+}
+
+export const difference = (from: string, to: string, units: UnitType) => {
+  const result = dayjs(new Date(from)).diff(dayjs(new Date(to)), units)
+  return result
 }

--- a/packages/string-templates/src/helpers/date.ts
+++ b/packages/string-templates/src/helpers/date.ts
@@ -121,7 +121,7 @@ export const date = (str: any, pattern: any, options: any) => {
   return date.format(config.pattern)
 }
 
-export const duration = (str: any, pattern: any, format: any) => {
+export const duration = (str: any, pattern: any, format?: any) => {
   const config = initialConfig(str, pattern)
 
   setLocale(config.str, config.pattern)
@@ -137,4 +137,9 @@ export const duration = (str: any, pattern: any, format: any) => {
 export const difference = (from: string, to: string, units: UnitType) => {
   const result = dayjs(new Date(from)).diff(dayjs(new Date(to)), units)
   return result
+}
+
+export const durationFromNow = (from: string) => {
+  const diff = difference(from, new Date().toISOString(), "ms")
+  return duration(diff, "ms")
 }

--- a/packages/string-templates/src/helpers/external.ts
+++ b/packages/string-templates/src/helpers/external.ts
@@ -1,7 +1,7 @@
 // @ts-ignore we don't have types for it
 import helpers from "@budibase/handlebars-helpers"
 
-import { date, duration } from "./date"
+import { date, difference, duration } from "./date"
 import {
   HelperFunctionBuiltin,
   EXTERNAL_FUNCTION_COLLECTIONS,
@@ -9,8 +9,9 @@ import {
 import Handlebars from "handlebars"
 
 const ADDED_HELPERS = {
-  date: date,
-  duration: duration,
+  date,
+  duration,
+  difference,
 }
 
 export const externalCollections = EXTERNAL_FUNCTION_COLLECTIONS

--- a/packages/string-templates/src/helpers/external.ts
+++ b/packages/string-templates/src/helpers/external.ts
@@ -1,7 +1,7 @@
 // @ts-ignore we don't have types for it
 import helpers from "@budibase/handlebars-helpers"
 
-import { date, difference, duration } from "./date"
+import { date, difference, duration, durationFromNow } from "./date"
 import {
   HelperFunctionBuiltin,
   EXTERNAL_FUNCTION_COLLECTIONS,
@@ -12,6 +12,7 @@ const ADDED_HELPERS = {
   date,
   duration,
   difference,
+  durationFromNow,
 }
 
 export const externalCollections = EXTERNAL_FUNCTION_COLLECTIONS

--- a/packages/string-templates/src/manifest.json
+++ b/packages/string-templates/src/manifest.json
@@ -1236,7 +1236,7 @@
       "args": [
         "time"
       ],
-      "example": "{{durationFromNow \"2025-09-30\"}} -> 7 months",
+      "example": "{{durationFromNow \"2021-09-30\"}} -> 8 months",
       "description": "<p>Produce a humanized duration left/until given an amount of time and the type of time measurement.</p>\n"
     }
   }

--- a/packages/string-templates/src/manifest.json
+++ b/packages/string-templates/src/manifest.json
@@ -1222,6 +1222,15 @@
       ],
       "example": "{{duration 8 \"seconds\"}} -> a few seconds",
       "description": "<p>Produce a humanized duration left/until given an amount of time and the type of time measurement.</p>\n"
+    },
+    "difference": {
+      "args": [
+        "from",
+        "to",
+        "[unitType=ms]"
+      ],
+      "example": "{{ difference \"2025-09-30\" \"2025-06-17\" \"seconds\" }} -> 9072000",
+      "description": "<p>Gets the difference between two dates, in milliseconds. Pass a third parameter to adjust the unit measurement.</p>\n"
     }
   }
 }

--- a/packages/string-templates/src/manifest.json
+++ b/packages/string-templates/src/manifest.json
@@ -1231,6 +1231,13 @@
       ],
       "example": "{{ difference \"2025-09-30\" \"2025-06-17\" \"seconds\" }} -> 9072000",
       "description": "<p>Gets the difference between two dates, in milliseconds. Pass a third parameter to adjust the unit measurement.</p>\n"
+    },
+    "durationFromNow": {
+      "args": [
+        "time"
+      ],
+      "example": "{{durationFromNow \"2025-09-30\"}} -> 7 months",
+      "description": "<p>Produce a humanized duration left/until given an amount of time and the type of time measurement.</p>\n"
     }
   }
 }

--- a/packages/string-templates/test/helpers/date.spec.ts
+++ b/packages/string-templates/test/helpers/date.spec.ts
@@ -1,11 +1,15 @@
+import tk from "timekeeper"
 import * as date from "../../src/helpers/date"
+
+const frozenDate = new Date("2025-03-06T11:38:41.000Z")
+tk.freeze(frozenDate)
 
 describe("date helper", () => {
   describe("difference", () => {
     it("should return the difference between two dates", () => {
       const result = date.difference(
-        "2021-01-02T12:34:56.789",
-        "2021-01-01T01:00:00"
+        "2021-01-02T12:34:56.789Z",
+        "2021-01-01T01:00:00.000Z"
       )
       const expected =
         1 * 24 * 60 * 60 * 1000 + // 1 day
@@ -23,6 +27,28 @@ describe("date helper", () => {
         "days"
       )
       expect(result).toEqual(1)
+    })
+  })
+
+  describe("durationFromNow", () => {
+    it("should return the difference between two close dates", () => {
+      const result = date.durationFromNow("2025-03-06T11:38:43.000Z")
+      expect(result).toEqual("a few seconds")
+    })
+
+    it("should return the difference between two days hours apart", () => {
+      const result = date.durationFromNow("2025-03-06T01:00:00.000Z")
+      expect(result).toEqual("11 hours")
+    })
+
+    it("accepts days in the past", () => {
+      const result = date.durationFromNow("2025-03-01")
+      expect(result).toEqual("5 days")
+    })
+
+    it("accepts days in the future", () => {
+      const result = date.durationFromNow("2025-03-08")
+      expect(result).toEqual("2 days")
     })
   })
 })

--- a/packages/string-templates/test/helpers/date.spec.ts
+++ b/packages/string-templates/test/helpers/date.spec.ts
@@ -1,0 +1,28 @@
+import * as date from "../../src/helpers/date"
+
+describe("date helper", () => {
+  describe("difference", () => {
+    it("should return the difference between two dates", () => {
+      const result = date.difference(
+        "2021-01-02T12:34:56.789",
+        "2021-01-01T01:00:00"
+      )
+      const expected =
+        1 * 24 * 60 * 60 * 1000 + // 1 day
+        11 * 60 * 60 * 1000 + // 11 hours
+        34 * 60 * 1000 + // 34 minutes
+        56 * 1000 + // seconds
+        789 // milliseconds
+      expect(result).toEqual(expected)
+    })
+
+    it("should be able to set the time unit", () => {
+      const result = date.difference(
+        "2021-01-02T12:34:56",
+        "2021-01-01T01:00:00",
+        "days"
+      )
+      expect(result).toEqual(1)
+    })
+  })
+})


### PR DESCRIPTION
## Description
Add two extra date helpers:
1. difference: Gets the difference between two dates, in milliseconds. Pass a third parameter to adjust the unit measurement.
<img width="690" alt="image" src="https://github.com/user-attachments/assets/f999e8aa-1645-4e04-b7ef-fc795d74584c" />
<img width="690" alt="image" src="https://github.com/user-attachments/assets/c783ddf7-4e58-4cb8-ad40-1f0596d26b2c" />


2. durationFromNow: Produce a humanized duration left/until given an amount of time and the type of time measurement.
<img width="690" alt="image" src="https://github.com/user-attachments/assets/bc2541b0-43ef-4fba-ade0-4ad8e40b541d" />


## Launchcontrol
Add two extra date helpers