### PR TITLE
New automation JS editor fixes.

### DIFF
--- a/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
+++ b/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
@@ -280,16 +280,13 @@
         EditorView.inputHandler.of((view, from, to, insert) => {
           if (jsBindingWrapping && insert === "$") {
             let { text } = view.state.doc.lineAt(from)
-
             const left = from ? text.substring(0, from) : ""
             const right = to ? text.substring(to) : ""
-            const wrap = !left.includes('$("') || !right.includes('")')
+            const wrap = (!left.includes('$("') || !right.includes('")')) && !(left.includes("`") && right.includes("`"))
+            const anchor = from + (wrap ? 3 : 1)
             const tr = view.state.update(
               {
                 changes: [{ from, insert: wrap ? '$("")' : "$" }],
-                selection: {
-                  anchor: from + (wrap ? 3 : 1),
-                },
               },
               {
                 scrollIntoView: true,
@@ -297,6 +294,17 @@
               }
             )
             view.dispatch(tr)
+            // the selection needs to fired after the dispatch - this seems
+            // to fix an issue with the cursor not moving when the editor is
+            // first loaded, the first usage of the editor is not ready
+            // for the anchor to move as well as perform a change
+            setTimeout(() => {
+              view.dispatch(view.state.update({
+                selection: {
+                  anchor,
+                },
+              }))
+            }, 1)
             return true
           }
           return false
@@ -421,6 +429,7 @@
   .code-editor {
     font-size: 12px;
     height: 100%;
+    cursor: text;
   }
   .code-editor :global(.cm-editor) {
     height: 100%;

--- a/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
+++ b/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
@@ -282,7 +282,9 @@
             let { text } = view.state.doc.lineAt(from)
             const left = from ? text.substring(0, from) : ""
             const right = to ? text.substring(to) : ""
-            const wrap = (!left.includes('$("') || !right.includes('")')) && !(left.includes("`") && right.includes("`"))
+            const wrap =
+              (!left.includes('$("') || !right.includes('")')) &&
+              !(left.includes("`") && right.includes("`"))
             const anchor = from + (wrap ? 3 : 1)
             const tr = view.state.update(
               {
@@ -299,11 +301,13 @@
             // first loaded, the first usage of the editor is not ready
             // for the anchor to move as well as perform a change
             setTimeout(() => {
-              view.dispatch(view.state.update({
-                selection: {
-                  anchor,
-                },
-              }))
+              view.dispatch(
+                view.state.update({
+                  selection: {
+                    anchor,
+                  },
+                })
+              )
             }, 1)
             return true
           }


### PR DESCRIPTION
## Description
A couple of small fixes for automation JS editor experience, making sure that the first use of `$` correctly jumps to within the binding and handling template string usage.

While it is a bit hacky, it seems that the first use of a completion just simply will not re-anchor the cursor, so breaking the cursor setting out of it to be after the text has been altered seems to rectify this issue.

EDIT: appears these problems are global - affecting all JS bindings.