### PR TITLE
Don't show row test data selector outside of test modal.

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -387,6 +387,55 @@
         ]
       }
 
+      const getTestDataSelector = () => {
+        if (!isTestModal) {
+          return []
+        }
+        return [{
+          type: CoreSelect,
+          title: "Row",
+          props: {
+            disabled: !table,
+            placeholder: "Select a row",
+            options: fetchedRows,
+            loading: fetchLoading,
+            value: selectedRow,
+            autocomplete: true,
+            filter: false,
+            getOptionLabel: row => row?.[primaryDisplay] || "",
+            compare: (a, b) => a?.[primaryDisplay] === b?.[primaryDisplay],
+            onChange: e => {
+              if (isTestModal) {
+                onChange({
+                  id: e.detail?._id,
+                  revision: e.detail?._rev,
+                  row: e.detail,
+                  oldRow: e.detail,
+                  meta: {
+                    fields: inputData["meta"]?.fields || {},
+                    oldFields: e.detail?.meta?.fields || {},
+                  },
+                })
+              }
+            },
+          },
+        },
+        {
+          type: InfoDisplay,
+          props: {
+            warning: true,
+            icon: "AlertCircleFilled",
+            body: `Be careful when testing this automation because your data may be modified or deleted.`,
+          },
+        },
+        {
+          type: Divider,
+          props: {
+            noMargin: true,
+          },
+        }]
+      }
+
       stepLayouts[block.stepId] = {
         row: {
           schema: schema["row"],
@@ -413,49 +462,7 @@
                 disabled: isTestModal,
               },
             },
-            {
-              type: CoreSelect,
-              title: "Row",
-              props: {
-                disabled: !table,
-                placeholder: "Select a row",
-                options: fetchedRows,
-                loading: fetchLoading,
-                value: selectedRow,
-                autocomplete: true,
-                filter: false,
-                getOptionLabel: row => row?.[primaryDisplay] || "",
-                compare: (a, b) => a?.[primaryDisplay] === b?.[primaryDisplay],
-                onChange: e => {
-                  if (isTestModal) {
-                    onChange({
-                      id: e.detail?._id,
-                      revision: e.detail?._rev,
-                      row: e.detail,
-                      oldRow: e.detail,
-                      meta: {
-                        fields: inputData["meta"]?.fields || {},
-                        oldFields: e.detail?.meta?.fields || {},
-                      },
-                    })
-                  }
-                },
-              },
-            },
-            {
-              type: InfoDisplay,
-              props: {
-                warning: true,
-                icon: "AlertCircleFilled",
-                body: `Be careful when testing this automation because your data may be modified or deleted.`,
-              },
-            },
-            {
-              type: Divider,
-              props: {
-                noMargin: true,
-              },
-            },
+            ...getTestDataSelector(),
             ...getIdConfig(),
             ...getRevConfig(),
             ...getRowTypeConfig(),

--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -220,7 +220,18 @@
   const stepStore = writable({})
   $: stepState = $stepStore?.[block.id]
 
-  $: customStepLayouts($memoBlock, schemaProperties, stepState, fetchedRows)
+  const updateSelectedRow = testData => {
+    selectedRow = testData?.row
+  }
+  $: updateSelectedRow(testData)
+
+  $: customStepLayouts(
+    $memoBlock,
+    schemaProperties,
+    stepState,
+    fetchedRows,
+    selectedRow
+  )
 
   const customStepLayouts = block => {
     if (

--- a/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationBlockSetup.svelte
@@ -391,49 +391,51 @@
         if (!isTestModal) {
           return []
         }
-        return [{
-          type: CoreSelect,
-          title: "Row",
-          props: {
-            disabled: !table,
-            placeholder: "Select a row",
-            options: fetchedRows,
-            loading: fetchLoading,
-            value: selectedRow,
-            autocomplete: true,
-            filter: false,
-            getOptionLabel: row => row?.[primaryDisplay] || "",
-            compare: (a, b) => a?.[primaryDisplay] === b?.[primaryDisplay],
-            onChange: e => {
-              if (isTestModal) {
-                onChange({
-                  id: e.detail?._id,
-                  revision: e.detail?._rev,
-                  row: e.detail,
-                  oldRow: e.detail,
-                  meta: {
-                    fields: inputData["meta"]?.fields || {},
-                    oldFields: e.detail?.meta?.fields || {},
-                  },
-                })
-              }
+        return [
+          {
+            type: CoreSelect,
+            title: "Row",
+            props: {
+              disabled: !table,
+              placeholder: "Select a row",
+              options: fetchedRows,
+              loading: fetchLoading,
+              value: selectedRow,
+              autocomplete: true,
+              filter: false,
+              getOptionLabel: row => row?.[primaryDisplay] || "",
+              compare: (a, b) => a?.[primaryDisplay] === b?.[primaryDisplay],
+              onChange: e => {
+                if (isTestModal) {
+                  onChange({
+                    id: e.detail?._id,
+                    revision: e.detail?._rev,
+                    row: e.detail,
+                    oldRow: e.detail,
+                    meta: {
+                      fields: inputData["meta"]?.fields || {},
+                      oldFields: e.detail?.meta?.fields || {},
+                    },
+                  })
+                }
+              },
             },
           },
-        },
-        {
-          type: InfoDisplay,
-          props: {
-            warning: true,
-            icon: "AlertCircleFilled",
-            body: `Be careful when testing this automation because your data may be modified or deleted.`,
+          {
+            type: InfoDisplay,
+            props: {
+              warning: true,
+              icon: "AlertCircleFilled",
+              body: `Be careful when testing this automation because your data may be modified or deleted.`,
+            },
           },
-        },
-        {
-          type: Divider,
-          props: {
-            noMargin: true,
+          {
+            type: Divider,
+            props: {
+              noMargin: true,
+            },
           },
-        }]
+        ]
       }
 
       stepLayouts[block.stepId] = {


### PR DESCRIPTION
## Description

Oversight on my part, I didn't realise the code for the test modal was reused for steps within the automation. Thanks @deanhannigan for noticing this!

## Launchcontrol

- Fixes automation row update step showing UI elements it shouldn't have.
