### PR TITLE
Allow uploading of signatures through views

### DIFF
--- a/packages/client/src/components/app/forms/SignatureField.svelte
+++ b/packages/client/src/components/app/forms/SignatureField.svelte
@@ -31,10 +31,12 @@
         let attachRequest = new FormData()
         attachRequest.append("file", signatureFile)
 
-        const resp = await API.uploadAttachment(
-          formContext?.dataSource?.tableId,
-          attachRequest
-        )
+        let sourceId = formContext?.dataSource?.tableId
+        if (formContext?.dataSource?.type === "viewV2") {
+          sourceId = formContext.dataSource.id
+        }
+
+        const resp = await API.uploadAttachment(sourceId, attachRequest)
         const [signatureAttachment] = resp
         updateValue = signatureAttachment
       } else {


### PR DESCRIPTION
## Description
This PR updates the signature component to allow upload based on the view ID. (rather than the tables permissions)

## Addresses
- https://github.com/Budibase/budibase/issues/15708
- https://linear.app/budibase/issue/BUDI-9121/signature-field-permission-issue-to-save

## App Export
[signature-views-export-1741773990346.tar.gz](https://github.com/user-attachments/files/19207627/test.views-export-1741773990346.tar.gz)

## Screenshots
**Before**
![Screenshot 2025-03-12 at 10 07 53](https://github.com/user-attachments/assets/99064b81-d401-4c43-83a8-0c157abac259)

**After**
![Screenshot 2025-03-12 at 10 09 42](https://github.com/user-attachments/assets/8886040a-6758-4074-b770-237897e33ab4)