### PR TITLE
Remove on:focus event attribute from Icon

### DIFF
--- a/packages/bbui/src/Icon/Icon.svelte
+++ b/packages/bbui/src/Icon/Icon.svelte
@@ -25,12 +25,12 @@
   noWrap={tooltipWrap}
 >
   <div class="icon" class:newStyles>
+    <!-- svelte-ignore a11y-mouse-events-have-key-events -->
     <svg
       on:contextmenu
       on:click
       on:mouseover
       on:mouseleave
-      on:focus
       class:hoverable
       class:disabled
       class="spectrum-Icon spectrum-Icon--size{size}"


### PR DESCRIPTION
## Description
The `on:focus` event attribute was triggering the default focus outline on click. This meant that any clickable icon would be wrapped in a blue border when clicked. This was particularly noticeable in areas like the bindings menu in the builder. 

## Screenshots
![Screenshot 2025-03-12 at 12 53 56](https://github.com/user-attachments/assets/f3710fc8-cb50-40c0-8e8d-f1deb7b1f27b)

## Launchcontrol
Remove default focus outline from Icons on click.