### PR TITLE
Style tweaks

### DIFF
--- a/packages/client/src/components/app/Text.svelte
+++ b/packages/client/src/components/app/Text.svelte
@@ -44,4 +44,12 @@
   div :global(.editor-preview-full) {
     height: auto;
   }
+  div :global(h1),
+  div :global(h2),
+  div :global(h3),
+  div :global(h4),
+  div :global(h5),
+  div :global(h6) {
+    font-weight: 600;
+  }
 </style>

--- a/packages/client/src/components/app/Text.svelte
+++ b/packages/client/src/components/app/Text.svelte
@@ -41,4 +41,7 @@
   div :global(img) {
     max-width: 100%;
   }
+  div :global(.editor-preview-full) {
+    height: auto;
+  }
 </style>

--- a/packages/frontend-core/src/components/grid/cells/HeaderCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/HeaderCell.svelte
@@ -465,7 +465,7 @@
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
-    font-weight: bold;
+    font-weight: 600;
   }
   .header-cell.searching .name {
     opacity: 0;

--- a/packages/frontend-core/src/components/grid/layout/Grid.svelte
+++ b/packages/frontend-core/src/components/grid/layout/Grid.svelte
@@ -219,7 +219,7 @@
     --grid-background-alt: var(--spectrum-global-color-gray-100);
     --header-cell-background: var(
       --custom-header-cell-background,
-      var(--grid-background-alt)
+      var(--spectrum-global-color-gray-100)
     );
     --cell-background: var(--grid-background);
     --cell-background-hover: var(--grid-background-alt);

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -358,8 +358,8 @@ async function performAppCreate(
       },
       theme: DefaultAppTheme,
       customTheme: {
-        primaryColor: "var(--spectrum-global-color-static-blue-1200)",
-        primaryColorHover: "var(--spectrum-global-color-static-blue-800)",
+        primaryColor: "var(--spectrum-global-color-blue-700)",
+        primaryColorHover: "var(--spectrum-global-color-blue-600)",
         buttonBorderRadius: "16px",
       },
       features: {


### PR DESCRIPTION
## Description
- Fix height of text component when used inside flex container
- Use 600 weight for table headers and markdown generated headline elements
- Fix table header cell background color in data section and non-quiet tables in apps
- Use a theme-aware reactive color for app accent color again