### PR TITLE
Modal to prevent losing REST datasource changes

### DIFF
--- a/packages/builder/src/components/common/ConfirmDialog.svelte
+++ b/packages/builder/src/components/common/ConfirmDialog.svelte
@@ -1,16 +1,16 @@
-<script>
+<script lang="ts">
   import { Modal, ModalContent, Body } from "@budibase/bbui"
 
-  export let title = ""
-  export let body = ""
-  export let okText = "Confirm"
-  export let cancelText = "Cancel"
-  export let onOk = undefined
-  export let onCancel = undefined
-  export let warning = true
-  export let disabled = false
+  export let title: string = ""
+  export let body: string = ""
+  export let okText: string = "Confirm"
+  export let cancelText: string = "Cancel"
+  export let onOk: (() => void) | undefined = undefined
+  export let onCancel: (() => void) | undefined = undefined
+  export let warning: boolean = true
+  export let disabled: boolean = false
 
-  let modal
+  let modal: Modal
 
   export const show = () => {
     modal.show()

--- a/packages/builder/src/components/common/ConfirmDialog.svelte
+++ b/packages/builder/src/components/common/ConfirmDialog.svelte
@@ -5,6 +5,7 @@
   export let body: string = ""
   export let okText: string = "Confirm"
   export let cancelText: string = "Cancel"
+  export let size: "S" | "M" | "L" | "XL" | undefined = undefined
   export let onOk: (() => void) | undefined = undefined
   export let onCancel: (() => void) | undefined = undefined
   export let warning: boolean = true
@@ -28,6 +29,7 @@
     {cancelText}
     {warning}
     {disabled}
+    {size}
   >
     <Body size="S">
       {body}

--- a/packages/builder/src/components/common/ConfirmDialog.svelte
+++ b/packages/builder/src/components/common/ConfirmDialog.svelte
@@ -8,6 +8,7 @@
   export let size: "S" | "M" | "L" | "XL" | undefined = undefined
   export let onOk: (() => void) | undefined = undefined
   export let onCancel: (() => void) | undefined = undefined
+  export let onClose: (() => void) | undefined = undefined
   export let warning: boolean = true
   export let disabled: boolean = false
 
@@ -21,9 +22,10 @@
   }
 </script>
 
-<Modal bind:this={modal} on:hide={onCancel}>
+<Modal bind:this={modal} on:hide={onClose ?? onCancel}>
   <ModalContent
     onConfirm={onOk}
+    {onCancel}
     {title}
     confirmText={okText}
     {cancelText}

--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -63,6 +63,7 @@
   let nestedSchemaFields = {}
   let saving
   let queryNameLabel
+  let mounted = false
 
   $: staticVariables = datasource?.config?.staticVariables || {}
 
@@ -104,8 +105,10 @@
 
   $: runtimeUrlQueries = readableToRuntimeMap(mergedBindings, breakQs)
 
-  $: originalQuery = originalQuery ?? cloneDeep(query)
   $: builtQuery = buildQuery(query, runtimeUrlQueries, requestBindings)
+  $: originalQuery = mounted
+    ? originalQuery ?? cloneDeep(builtQuery)
+    : undefined
   $: isModified = JSON.stringify(originalQuery) !== JSON.stringify(builtQuery)
 
   function getSelectedQuery() {
@@ -477,6 +480,8 @@
       staticVariables,
       restBindings
     )
+
+    mounted = true
   })
 
   $beforeUrlChange(async () => {

--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -25,7 +25,7 @@
     EditorModes,
   } from "@/components/common/CodeMirrorEditor.svelte"
   import RestBodyInput from "./RestBodyInput.svelte"
-  import { capitalise } from "@/helpers"
+  import { capitalise, confirm } from "@/helpers"
   import { onMount } from "svelte"
   import restUtils from "@/helpers/data/utils"
   import {
@@ -37,7 +37,6 @@
   } from "@/constants/backend"
   import JSONPreview from "@/components/integration/JSONPreview.svelte"
   import AccessLevelSelect from "@/components/integration/AccessLevelSelect.svelte"
-  import ConfirmDialog from "@/components/common/ConfirmDialog.svelte"
   import DynamicVariableModal from "./DynamicVariableModal.svelte"
   import Placeholder from "assets/bb-spaceship.svg"
   import { cloneDeep } from "lodash/fp"
@@ -485,26 +484,12 @@
       return true
     }
 
-    const shouldSave = await new Promise(resolve => {
-      const dialog = new ConfirmDialog({
-        target: document.body,
-        props: {
-          title: "Some updates are not saved",
-          body: "Some of your changes are not yet saved. Do you want to save them before leaving?",
-          okText: "Save and continue",
-          cancelText: "Discard and continue",
-          size: "M",
-          onOk: () => {
-            dialog.$destroy()
-            resolve(true)
-          },
-          onCancel: () => {
-            dialog.$destroy()
-            resolve(false)
-          },
-        },
-      })
-      dialog.show()
+    const shouldSave = await confirm({
+      title: "Some updates are not saved",
+      body: "Some of your changes are not yet saved. Do you want to save them before leaving?",
+      okText: "Save and continue",
+      cancelText: "Discard and continue",
+      size: "M",
     })
 
     if (!shouldSave) {

--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -209,11 +209,14 @@
       originalQuery = null
 
       queryNameLabel.disableEditingState()
+      return { ok: true }
     } catch (err) {
       notifications.error(`Error saving query`)
     } finally {
       saving = false
     }
+
+    return { ok: false }
   }
 
   const validateQuery = async () => {
@@ -482,7 +485,7 @@
       return true
     }
 
-    return new Promise(resolve => {
+    const shouldSave = await new Promise(resolve => {
       const dialog = new ConfirmDialog({
         target: document.body,
         props: {
@@ -503,6 +506,19 @@
       })
       dialog.show()
     })
+
+    if (!shouldSave) {
+      // Leave without saving anything
+      return true
+    }
+
+    const saveResult = await saveQuery()
+    if (!saveResult.ok) {
+      // We can't leave as the query was not properly saved
+      return false
+    }
+
+    return true
   })
 </script>
 

--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -484,26 +484,29 @@
       return true
     }
 
-    const shouldSave = await confirm({
+    return await confirm({
       title: "Some updates are not saved",
       body: "Some of your changes are not yet saved. Do you want to save them before leaving?",
       okText: "Save and continue",
       cancelText: "Discard and continue",
       size: "M",
+      onConfirm: async () => {
+        const saveResult = await saveQuery()
+        if (!saveResult.ok) {
+          // We can't leave as the query was not properly saved
+          return false
+        }
+
+        return true
+      },
+      onCancel: () => {
+        // Leave without saving anything
+        return true
+      },
+      onClose: () => {
+        return false
+      },
     })
-
-    if (!shouldSave) {
-      // Leave without saving anything
-      return true
-    }
-
-    const saveResult = await saveQuery()
-    if (!saveResult.ok) {
-      // We can't leave as the query was not properly saved
-      return false
-    }
-
-    return true
   })
 </script>
 

--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { goto, params } from "@roxi/routify"
+  import { beforeUrlChange, goto, params } from "@roxi/routify"
   import { datasources, flags, integrations, queries } from "@/stores/builder"
   import { environment } from "@/stores/portal"
   import {
@@ -37,6 +37,7 @@
   } from "@/constants/backend"
   import JSONPreview from "@/components/integration/JSONPreview.svelte"
   import AccessLevelSelect from "@/components/integration/AccessLevelSelect.svelte"
+  import ConfirmDialog from "@/components/common/ConfirmDialog.svelte"
   import DynamicVariableModal from "./DynamicVariableModal.svelte"
   import Placeholder from "assets/bb-spaceship.svg"
   import { cloneDeep } from "lodash/fp"
@@ -474,6 +475,34 @@
       staticVariables,
       restBindings
     )
+  })
+
+  $beforeUrlChange(async () => {
+    if (!isModified) {
+      return true
+    }
+
+    return new Promise(resolve => {
+      const dialog = new ConfirmDialog({
+        target: document.body,
+        props: {
+          title: "Some updates are not saved",
+          body: "Some of your changes are not yet saved. Do you want to save them before leaving?",
+          okText: "Save and continue",
+          cancelText: "Discard and continue",
+          size: "M",
+          onOk: () => {
+            dialog.$destroy()
+            resolve(true)
+          },
+          onCancel: () => {
+            dialog.$destroy()
+            resolve(false)
+          },
+        },
+      })
+      dialog.show()
+    })
   })
 </script>
 

--- a/packages/builder/src/helpers/confirm.ts
+++ b/packages/builder/src/helpers/confirm.ts
@@ -1,0 +1,31 @@
+import ConfirmDialog from "@/components/common/ConfirmDialog.svelte"
+
+export async function confirm(props: {
+  title: string
+  body?: string
+  okText?: string
+  cancelText?: string
+  size?: "S" | "M" | "L" | "XL"
+}) {
+  return await new Promise(resolve => {
+    const dialog = new ConfirmDialog({
+      target: document.body,
+      props: {
+        title: props.title,
+        body: props.body,
+        okText: props.okText,
+        cancelText: props.cancelText,
+        size: props.size,
+        onOk: () => {
+          dialog.$destroy()
+          resolve(true)
+        },
+        onCancel: () => {
+          dialog.$destroy()
+          resolve(false)
+        },
+      },
+    })
+    dialog.show()
+  })
+}

--- a/packages/builder/src/helpers/confirm.ts
+++ b/packages/builder/src/helpers/confirm.ts
@@ -21,6 +21,7 @@ export async function confirm(props: {
         okText: props.okText,
         cancelText: props.cancelText,
         size: props.size,
+        warning: false,
         onOk: () => {
           dialog.$destroy()
           resolve(props.onConfirm?.() || true)

--- a/packages/builder/src/helpers/confirm.ts
+++ b/packages/builder/src/helpers/confirm.ts
@@ -1,11 +1,16 @@
 import ConfirmDialog from "@/components/common/ConfirmDialog.svelte"
 
+export enum ConfirmOutput {}
+
 export async function confirm(props: {
   title: string
   body?: string
   okText?: string
   cancelText?: string
   size?: "S" | "M" | "L" | "XL"
+  onConfirm?: () => void
+  onCancel?: () => void
+  onClose?: () => void
 }) {
   return await new Promise(resolve => {
     const dialog = new ConfirmDialog({
@@ -18,11 +23,15 @@ export async function confirm(props: {
         size: props.size,
         onOk: () => {
           dialog.$destroy()
-          resolve(true)
+          resolve(props.onConfirm?.() || true)
         },
         onCancel: () => {
           dialog.$destroy()
-          resolve(false)
+          resolve(props.onCancel?.() || false)
+        },
+        onClose: () => {
+          dialog.$destroy()
+          resolve(props.onClose?.() || false)
         },
       },
     })

--- a/packages/builder/src/helpers/index.ts
+++ b/packages/builder/src/helpers/index.ts
@@ -11,3 +11,4 @@ export {
 } from "./helpers"
 export * as featureFlag from "./featureFlags"
 export * as bindings from "./bindings"
+export * from "./confirm"


### PR DESCRIPTION
## Description
REST datasources currently behave quite differently from the other datasources and the rest of the platform, as it is one of the few points where we don't autosave on actions: the user is required to save via the save click. This might be confusing as the UI and some of its elements might give the impression that the data is persisted on change. This will be even more problematic as we are changing some of its configuration elements from dropdowns to context buttons and menus.
This PR introduces a mechanism to detect if you are leaving a REST config with unsaved changes. If this is the case, the user will have 2 options:
1. Leave discarding the changes
2. Leave saving the changes
3. Close the modal and stay on the current page (this required some extra props on the confirm modal)


## Screenshots
### No modal when no changes
![no modal](https://github.com/user-attachments/assets/2452b27d-7107-4889-b1a5-90a37192045a)


### Modal appears when there are changes
![modal on changes](https://github.com/user-attachments/assets/54ddc74e-636b-4ca6-9855-d0fcf88c21e7)

### Saving on exiting the screen
![save on quit](https://github.com/user-attachments/assets/7f1792e3-cbf7-4276-9636-0d644ff1896b)

### Discard changes on exit
![discarding](https://github.com/user-attachments/assets/8306889f-c7eb-447a-8f05-ebc80886f8f0)

### Closing the modal will prevent from exiting
![cancelling](https://github.com/user-attachments/assets/b3f07c98-ca40-495d-91c1-2d9c55297a1e)

### On new endpoint, we will validate if it's saved
![new](https://github.com/user-attachments/assets/0d620eda-a8bf-4c43-ad04-93f6f98dfa5a)

### We will not validate new endpoint "save" status if there is no changes at all
![empty new](https://github.com/user-attachments/assets/850eb275-b97b-4bc1-92a7-af258e577a9f)




## Launchcontrol
Confirm modal when leaving a rest configuration page with unsaved changes