### PR TITLE
SMTP - Cloud send email issue

### DIFF
--- a/packages/backend-core/src/configs/configs.ts
+++ b/packages/backend-core/src/configs/configs.ts
@@ -245,6 +245,7 @@ export async function getSMTPConfig(
         user: env.SMTP_USER!,
         pass: env.SMTP_PASSWORD!,
       },
+      fallback: true,
     }
   }
 }

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/ActionModal.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/ActionModal.svelte
@@ -35,12 +35,13 @@
 
   $: blockRef = $selectedAutomation.blockRefs?.[block.id]
   $: lastStep = blockRef?.terminating
-  $: pathSteps = block.id && $selectedAutomation?.data
-    ? automationStore.actions.getPathSteps(
-        blockRef.pathTo,
-        $selectedAutomation.data
-      )
-    : []
+  $: pathSteps =
+    block.id && $selectedAutomation?.data
+      ? automationStore.actions.getPathSteps(
+          blockRef.pathTo,
+          $selectedAutomation.data
+        )
+      : []
 
   $: collectBlockExists = pathSteps?.some(
     step => step.stepId === ActionStepID.COLLECT
@@ -49,7 +50,8 @@
   const disabled = () => {
     return {
       SEND_EMAIL_SMTP: {
-        disabled: !$admin.checklist?.smtp?.checked || $admin.checklist?.smtp.fallback,
+        disabled:
+          !$admin.checklist?.smtp?.checked || $admin.checklist?.smtp.fallback,
         message: "Please configure SMTP",
       },
       COLLECT: {
@@ -77,36 +79,45 @@
     }
   }
 
-  const external = actions.reduce((acc: Record<string, AutomationStepDefinition>, elm) => {
-    const [k, v] = elm
-    if (!v.internal && !v.custom) {
-      acc[k] = v
-    }
-    return acc
-  }, {})
+  const external = actions.reduce(
+    (acc: Record<string, AutomationStepDefinition>, elm) => {
+      const [k, v] = elm
+      if (!v.internal && !v.custom) {
+        acc[k] = v
+      }
+      return acc
+    },
+    {}
+  )
 
-  const internal = actions.reduce((acc: Record<string, AutomationStepDefinition>, elm) => {
-    const [k, v] = elm
-    if (v.internal) {
-      acc[k] = v
-    }
-    delete acc.LOOP
+  const internal = actions.reduce(
+    (acc: Record<string, AutomationStepDefinition>, elm) => {
+      const [k, v] = elm
+      if (v.internal) {
+        acc[k] = v
+      }
+      delete acc.LOOP
 
-    const stepId = $selectedAutomation.data?.definition.trigger.stepId
-    // Filter out Collect block if not App Action or Webhook
-    if (stepId && !collectBlockAllowedSteps.includes(stepId)) {
-      delete acc.COLLECT
-    }
-    return acc
-  }, {})
+      const stepId = $selectedAutomation.data?.definition.trigger.stepId
+      // Filter out Collect block if not App Action or Webhook
+      if (stepId && !collectBlockAllowedSteps.includes(stepId)) {
+        delete acc.COLLECT
+      }
+      return acc
+    },
+    {}
+  )
 
-  const plugins = actions.reduce((acc: Record<string, AutomationStepDefinition>, elm) => {
-    const [k, v] = elm
-    if (v.custom) {
-      acc[k] = v
-    }
-    return acc
-  }, {})
+  const plugins = actions.reduce(
+    (acc: Record<string, AutomationStepDefinition>, elm) => {
+      const [k, v] = elm
+      if (v.custom) {
+        acc[k] = v
+      }
+      return acc
+    },
+    {}
+  )
 
   const selectAction = async (action: AutomationStepDefinition) => {
     selectedAction = action.name

--- a/packages/builder/src/stores/portal/licensing.ts
+++ b/packages/builder/src/stores/portal/licensing.ts
@@ -36,6 +36,8 @@ interface LicensingState {
   budibaseAIEnabled: boolean
   customAIConfigsEnabled: boolean
   auditLogsEnabled: boolean
+  syncAutomationsEnabled: boolean
+  triggerAutomationRunEnabled: boolean
   // the currently used quotas from the db
   quotaUsage?: QuotaUsage
   // derived quota metrics for percentages used
@@ -75,6 +77,8 @@ class LicensingStore extends BudiStore<LicensingState> {
       budibaseAIEnabled: false,
       customAIConfigsEnabled: false,
       auditLogsEnabled: false,
+      syncAutomationsEnabled: false,
+      triggerAutomationRunEnabled: false,
       // the currently used quotas from the db
       quotaUsage: undefined,
       // derived quota metrics for percentages used

--- a/packages/types/src/api/web/global/configs.ts
+++ b/packages/types/src/api/web/global/configs.ts
@@ -45,9 +45,12 @@ interface ChecklistItem {
   label: string
   link: string
 }
+interface SmtpChecklistItem extends ChecklistItem {
+  fallback?: boolean
+}
 export interface ConfigChecklistResponse {
   apps: ChecklistItem
-  smtp: ChecklistItem
+  smtp: SmtpChecklistItem
   adminUser: ChecklistItem
   sso: ChecklistItem
   branding: SettingsBrandingConfig

--- a/packages/types/src/documents/global/config.ts
+++ b/packages/types/src/documents/global/config.ts
@@ -16,6 +16,7 @@ export interface SMTPInnerConfig {
     pass: string
   }
   connectionTimeout?: any
+  fallback?: boolean
 }
 
 export interface SMTPConfig extends Config<SMTPInnerConfig> {}

--- a/packages/worker/src/api/controllers/global/configs.ts
+++ b/packages/worker/src/api/controllers/global/configs.ts
@@ -586,6 +586,7 @@ export async function configChecklist(ctx: Ctx<void, ConfigChecklistResponse>) {
             checked: !!smtpConfig,
             label: "Set up email",
             link: "/builder/portal/settings/email",
+            fallback: smtpConfig?.fallback || false,
           },
           adminUser: {
             checked: userExists,

--- a/packages/worker/src/api/routes/global/tests/configs.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/configs.spec.ts
@@ -279,6 +279,7 @@ describe("configs", () => {
 
       expect(checklist.apps.checked).toBeFalsy()
       expect(checklist.smtp.checked).toBeTruthy()
+      expect(checklist.smtp.fallback).toBeFalsy()
       expect(checklist.adminUser.checked).toBeTruthy()
     })
   })


### PR DESCRIPTION
Fixing an issue with SMTP config, in the Cloud it is possible to configure send email without having added SMTP configuration, this will always fail.

This is supposed to appear as: 
![image](https://github.com/user-attachments/assets/23eb26c8-088c-4765-b75b-8265811326e1)

But in the cloud it's always enabled.

## Addresses
- https://linear.app/budibase/issue/BUDI-9094/cloud-allows-adding-send-email-step-to-automation-without-smtp
