### PR TITLE
Fix double "save" modal

### DIFF
--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -179,7 +179,7 @@
     return newQuery
   }
 
-  async function saveQuery() {
+  async function saveQuery(redirectIfNew = true) {
     const toSave = builtQuery
     saving = true
     try {
@@ -195,7 +195,7 @@
       }
 
       notifications.success(`Request saved successfully`)
-      if (isNew) {
+      if (isNew && redirectIfNew) {
         $goto(`../../${_id}`)
       }
 
@@ -497,7 +497,7 @@
       cancelText: "Discard and continue",
       size: "M",
       onConfirm: async () => {
-        const saveResult = await saveQuery()
+        const saveResult = await saveQuery(false)
         if (!saveResult.ok) {
           // We can't leave as the query was not properly saved
           return false


### PR DESCRIPTION
## Description
Fixing an issue with the "unsaved changes" modal. If this is happening in a creation, the modal gets triggered twice, as we are having an extra `$go(` on successful creation. This PR skips this call when saving from the modal, avoiding this issue