### PR TITLE
MS-SQL JSON column fix

### DIFF
--- a/packages/backend-core/src/sql/sql.ts
+++ b/packages/backend-core/src/sql/sql.ts
@@ -391,8 +391,12 @@ class InternalBuilder {
       return null
     }
 
-    // MS-SQL doesn't allow an object to be passed in
-    if (this.requiresJsonAsStringClient() && isJsonColumn(schema)) {
+    // some database don't allow an object to be passed in
+    if (
+      this.requiresJsonAsStringClient() &&
+      isJsonColumn(schema) &&
+      typeof input === "object"
+    ) {
       return JSON.stringify(input)
     }
 

--- a/packages/backend-core/src/sql/sql.ts
+++ b/packages/backend-core/src/sql/sql.ts
@@ -188,6 +188,16 @@ class InternalBuilder {
     return this.table.schema[column]
   }
 
+  private requiresJsonAsStringClient(): boolean {
+    const requiresJsonAsString = [
+      SqlClient.MS_SQL,
+      SqlClient.MY_SQL,
+      SqlClient.MARIADB,
+      SqlClient.ORACLE,
+    ]
+    return requiresJsonAsString.includes(this.client)
+  }
+
   private quoteChars(): [string, string] {
     const wrapped = this.knexClient.wrapIdentifier("foo", {})
     return [wrapped[0], wrapped[wrapped.length - 1]]
@@ -382,7 +392,7 @@ class InternalBuilder {
     }
 
     // MS-SQL doesn't allow an object to be passed in
-    if (this.client === SqlClient.MS_SQL && isJsonColumn(schema)) {
+    if (this.requiresJsonAsStringClient() && isJsonColumn(schema)) {
       return JSON.stringify(input)
     }
 


### PR DESCRIPTION
## Description
Fixing an issue discovered by @mikesealey around attachment columns in SQL Server, it seems that when `knex.insert` is used to create a row, JSON is stringified in the bindings but when `knex.update` is used, the bindings are not converted to strings.

When an object is passed to MS-SQL this breaks.

EDIT: this also appeared to be the case for MySQL, MariaDB and Oracle, which have all been updated to handle this as well.