### PR TITLE
Add new pill to auth picker

### DIFF
--- a/packages/builder/src/components/integration/rest/AuthPicker.svelte
+++ b/packages/builder/src/components/integration/rest/AuthPicker.svelte
@@ -65,7 +65,7 @@
 </script>
 
 <DetailPopover bind:this={popover} {title} align={PopoverAlignment.Right}>
-  <div slot="anchor">
+  <div slot="anchor" class="anchor">
     <ActionButton icon="LockClosed" quiet selected>
       {#if !authConfig}
         Authentication
@@ -122,3 +122,16 @@
     </div>
   {/if}
 </DetailPopover>
+
+<style>
+  .anchor :global(.spectrum-ActionButton)::before {
+    content: "NEW";
+    font-size: 10px;
+    background: var(--bb-indigo);
+    border-radius: 4px;
+    padding: 2px 4px;
+    margin-right: var(--spacing-s);
+    color: white;
+    font-weight: bold;
+  }
+</style>

--- a/packages/builder/src/components/integration/rest/AuthPicker.svelte
+++ b/packages/builder/src/components/integration/rest/AuthPicker.svelte
@@ -65,7 +65,7 @@
 </script>
 
 <DetailPopover bind:this={popover} {title} align={PopoverAlignment.Right}>
-  <div slot="anchor" class="anchor">
+  <div slot="anchor" class:display-new={!authConfig}>
     <ActionButton icon="LockClosed" quiet selected>
       {#if !authConfig}
         Authentication
@@ -124,7 +124,7 @@
 </DetailPopover>
 
 <style>
-  .anchor :global(.spectrum-ActionButton)::before {
+  .display-new :global(.spectrum-ActionButton)::before {
     content: "NEW";
     font-size: 10px;
     background: var(--bb-indigo);


### PR DESCRIPTION
## Description
Following designs, displaying the new pill on the auth picker. This will only be visible if there is no auth config selected.

## Screenshots
### None selected, closed picker
![image](https://github.com/user-attachments/assets/8ac07e50-685a-4f59-8862-cc2a29c7b9e1)
### None selected, open picker
![image](https://github.com/user-attachments/assets/d30b18bb-7d35-47b8-bb24-1c9a84eb7eb1)
### Selected auth
![image](https://github.com/user-attachments/assets/e65f17f6-248d-4dae-a282-4981f340ea19)

