### PR TITLE
Display grant type field

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/settings/oauth2/OAuth2ConfigModalContent.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/settings/oauth2/OAuth2ConfigModalContent.svelte
@@ -15,6 +15,7 @@
   import type { InsertOAuth2ConfigRequest } from "@budibase/types"
   import {
     OAuth2CredentialsMethod,
+    OAuth2GrantType,
     PASSWORD_REPLACEMENT,
   } from "@budibase/types"
   import type { ZodType } from "zod"
@@ -63,6 +64,9 @@
       clientSecret: requiredString("Client secret is required."),
       method: z.nativeEnum(OAuth2CredentialsMethod, {
         message: "Authentication method is required.",
+      }),
+      grantType: z.nativeEnum(OAuth2GrantType, {
+        message: "Grant type is required.",
       }),
     }) satisfies ZodType<InsertOAuth2ConfigRequest>
 
@@ -156,6 +160,24 @@
       Basic will use the Authorisation Bearer header for each connection, while
       POST will include the credentials in the body of the request under the
       access_token property.
+    </Body>
+  </div>
+
+  <Select
+    label="Grant type*"
+    options={[
+      {
+        label: "Client credentials",
+        value: OAuth2GrantType.CLIENT_CREDENTIALS,
+      },
+    ]}
+    bind:value={data.grantType}
+    error={errors.grantType}
+    disabled
+  />
+  <div class="field-info">
+    <Body size="XS" color="var(--spectrum-global-color-gray-700)">
+      Only client credentials mode is supported currently.
     </Body>
   </div>
   <Input

--- a/packages/builder/src/pages/builder/app/[application]/settings/oauth2/OAuth2ConfigModalContent.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/settings/oauth2/OAuth2ConfigModalContent.svelte
@@ -28,6 +28,8 @@
 
   $: data = (config as Partial<OAuth2Config>) ?? {}
 
+  $: data.grantType ??= OAuth2GrantType.CLIENT_CREDENTIALS
+
   $: isCreation = !config
   $: title = isCreation
     ? "Create new OAuth2 connection"

--- a/packages/builder/src/pages/builder/app/[application]/settings/oauth2/OAuth2ConfigModalContent.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/settings/oauth2/OAuth2ConfigModalContent.svelte
@@ -103,6 +103,7 @@
         clientId: configData.clientId,
         clientSecret: configData.clientSecret,
         method: configData.method,
+        grantType: configData.grantType,
       })
       if (!connectionValidation.valid) {
         let message = "Connection settings could not be validated"

--- a/packages/builder/src/stores/builder/oauth2.ts
+++ b/packages/builder/src/stores/builder/oauth2.ts
@@ -38,6 +38,7 @@ export class OAuth2Store extends BudiStore<OAuth2StoreState> {
           clientId: c.clientId,
           clientSecret: c.clientSecret,
           method: c.method,
+          grantType: c.grantType,
         })),
         loading: false,
       }))

--- a/packages/server/src/api/controllers/oauth2.ts
+++ b/packages/server/src/api/controllers/oauth2.ts
@@ -99,6 +99,7 @@ export async function validate(
     clientId: body.clientId,
     clientSecret: body.clientSecret,
     method: body.method,
+    grantType: body.grantType,
   }
 
   if (config.clientSecret === PASSWORD_REPLACEMENT && body._id) {

--- a/packages/server/src/api/controllers/oauth2.ts
+++ b/packages/server/src/api/controllers/oauth2.ts
@@ -24,6 +24,7 @@ function toFetchOAuth2ConfigsResponse(
     clientId: config.clientId,
     clientSecret: PASSWORD_REPLACEMENT,
     method: config.method,
+    grantType: config.grantType,
   }
 }
 

--- a/packages/server/src/api/controllers/oauth2.ts
+++ b/packages/server/src/api/controllers/oauth2.ts
@@ -46,6 +46,7 @@ export async function create(
     clientId: body.clientId,
     clientSecret: body.clientSecret,
     method: body.method,
+    grantType: body.grantType,
   }
 
   const config = await sdk.oauth2.create(newConfig)
@@ -72,6 +73,7 @@ export async function edit(
     clientId: body.clientId,
     clientSecret: body.clientSecret,
     method: body.method,
+    grantType: body.grantType,
   }
 
   const config = await sdk.oauth2.update(toUpdate)

--- a/packages/server/src/api/routes/oauth2.ts
+++ b/packages/server/src/api/routes/oauth2.ts
@@ -1,5 +1,9 @@
 import Router from "@koa/router"
-import { OAuth2CredentialsMethod, PermissionType } from "@budibase/types"
+import {
+  OAuth2CredentialsMethod,
+  OAuth2GrantType,
+  PermissionType,
+} from "@budibase/types"
 import { middleware } from "@budibase/backend-core"
 import authorized from "../../middleware/authorized"
 
@@ -13,6 +17,9 @@ const baseSchema = {
   method: Joi.string()
     .required()
     .valid(...Object.values(OAuth2CredentialsMethod)),
+  grantType: Joi.string()
+    .required()
+    .valid(...Object.values(OAuth2GrantType)),
 }
 
 const insertSchema = Joi.object({

--- a/packages/server/src/api/routes/tests/oauth2.spec.ts
+++ b/packages/server/src/api/routes/tests/oauth2.spec.ts
@@ -3,6 +3,7 @@ import {
   InsertOAuth2ConfigRequest,
   OAuth2ConfigResponse,
   OAuth2CredentialsMethod,
+  OAuth2GrantType,
   PASSWORD_REPLACEMENT,
 } from "@budibase/types"
 import * as setup from "./utilities"
@@ -19,6 +20,7 @@ describe("/oauth2", () => {
       clientId: generator.guid(),
       clientSecret: generator.hash(),
       method: generator.pickone(Object.values(OAuth2CredentialsMethod)),
+      grantType: generator.pickone(Object.values(OAuth2GrantType)),
     }
   }
 
@@ -58,6 +60,7 @@ describe("/oauth2", () => {
             clientId: c.clientId,
             clientSecret: PASSWORD_REPLACEMENT,
             method: c.method,
+            grantType: c.grantType,
           }))
         ),
       })
@@ -80,6 +83,7 @@ describe("/oauth2", () => {
             clientId: oauth2Config.clientId,
             clientSecret: PASSWORD_REPLACEMENT,
             method: oauth2Config.method,
+            grantType: oauth2Config.grantType,
           },
         ],
       })
@@ -102,6 +106,7 @@ describe("/oauth2", () => {
             clientId: oauth2Config.clientId,
             clientSecret: PASSWORD_REPLACEMENT,
             method: oauth2Config.method,
+            grantType: oauth2Config.grantType,
           },
           {
             _id: expectOAuth2ConfigId,
@@ -111,6 +116,7 @@ describe("/oauth2", () => {
             clientId: oauth2Config2.clientId,
             clientSecret: PASSWORD_REPLACEMENT,
             method: oauth2Config2.method,
+            grantType: oauth2Config2.grantType,
           },
         ])
       )
@@ -139,6 +145,7 @@ describe("/oauth2", () => {
           clientId: oauth2Config.clientId,
           clientSecret: PASSWORD_REPLACEMENT,
           method: oauth2Config.method,
+          grantType: oauth2Config.grantType,
         },
       ])
     })
@@ -177,6 +184,7 @@ describe("/oauth2", () => {
             clientId: configData.clientId,
             clientSecret: PASSWORD_REPLACEMENT,
             method: configData.method,
+            grantType: configData.grantType,
           },
         ])
       )

--- a/packages/server/src/integrations/tests/rest.spec.ts
+++ b/packages/server/src/integrations/tests/rest.spec.ts
@@ -6,6 +6,7 @@ import {
   BearerRestAuthConfig,
   BodyType,
   OAuth2CredentialsMethod,
+  OAuth2GrantType,
   RestAuthType,
 } from "@budibase/types"
 import { Response } from "node-fetch"
@@ -286,6 +287,7 @@ describe("REST Integration", () => {
         clientId: generator.guid(),
         clientSecret: secret,
         method: OAuth2CredentialsMethod.HEADER,
+        grantType: OAuth2GrantType.CLIENT_CREDENTIALS,
       })
 
       const token = generator.guid()
@@ -323,6 +325,7 @@ describe("REST Integration", () => {
         clientId: generator.guid(),
         clientSecret: secret,
         method: OAuth2CredentialsMethod.BODY,
+        grantType: OAuth2GrantType.CLIENT_CREDENTIALS,
       })
 
       const token = generator.guid()

--- a/packages/server/src/sdk/app/oauth2/tests/utils.spec.ts
+++ b/packages/server/src/sdk/app/oauth2/tests/utils.spec.ts
@@ -6,7 +6,8 @@ import { generateToken } from "../utils"
 import path from "path"
 import { KEYCLOAK_IMAGE } from "../../../../integrations/tests/utils/images"
 import { startContainer } from "../../../../integrations/tests/utils"
-import { OAuth2CredentialsMethod } from "@budibase/types"
+import { OAuth2CredentialsMethod, OAuth2GrantType } from "@budibase/types"
+import { method } from "lodash"
 
 const config = new TestConfiguration()
 
@@ -42,77 +43,84 @@ describe("oauth2 utils", () => {
     keycloakUrl = `http://127.0.0.1:${port}`
   })
 
-  describe.each(Object.values(OAuth2CredentialsMethod))(
-    "generateToken (in %s)",
-    method => {
-      it("successfully generates tokens", async () => {
-        const response = await config.doInContext(config.appId, async () => {
+  describe.each(
+    Object.values(OAuth2CredentialsMethod).flatMap(method =>
+      Object.values(OAuth2GrantType).map<
+        [OAuth2CredentialsMethod, OAuth2GrantType]
+      >(grantType => [method, grantType])
+    )
+  )("generateToken (in %s, grant type %s)", (method, grantType) => {
+    it("successfully generates tokens", async () => {
+      const response = await config.doInContext(config.appId, async () => {
+        const oauthConfig = await sdk.oauth2.create({
+          name: generator.guid(),
+          url: `${keycloakUrl}/realms/myrealm/protocol/openid-connect/token`,
+          clientId: "my-client",
+          clientSecret: "my-secret",
+          method,
+          grantType,
+        })
+
+        const response = await generateToken(oauthConfig._id)
+        return response
+      })
+
+      expect(response).toEqual(expect.stringMatching(/^Bearer .+/))
+    })
+
+    it("handles wrong urls", async () => {
+      await expect(
+        config.doInContext(config.appId, async () => {
+          const oauthConfig = await sdk.oauth2.create({
+            name: generator.guid(),
+            url: `${keycloakUrl}/realms/wrong/protocol/openid-connect/token`,
+            clientId: "my-client",
+            clientSecret: "my-secret",
+            method,
+            grantType,
+          })
+
+          await generateToken(oauthConfig._id)
+        })
+      ).rejects.toThrow("Error fetching oauth2 token: Not Found")
+    })
+
+    it("handles wrong client ids", async () => {
+      await expect(
+        config.doInContext(config.appId, async () => {
+          const oauthConfig = await sdk.oauth2.create({
+            name: generator.guid(),
+            url: `${keycloakUrl}/realms/myrealm/protocol/openid-connect/token`,
+            clientId: "wrong-client-id",
+            clientSecret: "my-secret",
+            method,
+            grantType,
+          })
+
+          await generateToken(oauthConfig._id)
+        })
+      ).rejects.toThrow(
+        "Error fetching oauth2 token: Invalid client or Invalid client credentials"
+      )
+    })
+
+    it("handles wrong secrets", async () => {
+      await expect(
+        config.doInContext(config.appId, async () => {
           const oauthConfig = await sdk.oauth2.create({
             name: generator.guid(),
             url: `${keycloakUrl}/realms/myrealm/protocol/openid-connect/token`,
             clientId: "my-client",
-            clientSecret: "my-secret",
+            clientSecret: "wrong-secret",
             method,
+            grantType,
           })
 
-          const response = await generateToken(oauthConfig._id)
-          return response
+          await generateToken(oauthConfig._id)
         })
-
-        expect(response).toEqual(expect.stringMatching(/^Bearer .+/))
-      })
-
-      it("handles wrong urls", async () => {
-        await expect(
-          config.doInContext(config.appId, async () => {
-            const oauthConfig = await sdk.oauth2.create({
-              name: generator.guid(),
-              url: `${keycloakUrl}/realms/wrong/protocol/openid-connect/token`,
-              clientId: "my-client",
-              clientSecret: "my-secret",
-              method,
-            })
-
-            await generateToken(oauthConfig._id)
-          })
-        ).rejects.toThrow("Error fetching oauth2 token: Not Found")
-      })
-
-      it("handles wrong client ids", async () => {
-        await expect(
-          config.doInContext(config.appId, async () => {
-            const oauthConfig = await sdk.oauth2.create({
-              name: generator.guid(),
-              url: `${keycloakUrl}/realms/myrealm/protocol/openid-connect/token`,
-              clientId: "wrong-client-id",
-              clientSecret: "my-secret",
-              method,
-            })
-
-            await generateToken(oauthConfig._id)
-          })
-        ).rejects.toThrow(
-          "Error fetching oauth2 token: Invalid client or Invalid client credentials"
-        )
-      })
-
-      it("handles wrong secrets", async () => {
-        await expect(
-          config.doInContext(config.appId, async () => {
-            const oauthConfig = await sdk.oauth2.create({
-              name: generator.guid(),
-              url: `${keycloakUrl}/realms/myrealm/protocol/openid-connect/token`,
-              clientId: "my-client",
-              clientSecret: "wrong-secret",
-              method,
-            })
-
-            await generateToken(oauthConfig._id)
-          })
-        ).rejects.toThrow(
-          "Error fetching oauth2 token: Invalid client or Invalid client credentials"
-        )
-      })
-    }
-  )
+      ).rejects.toThrow(
+        "Error fetching oauth2 token: Invalid client or Invalid client credentials"
+      )
+    })
+  })
 })

--- a/packages/server/src/sdk/app/oauth2/tests/utils.spec.ts
+++ b/packages/server/src/sdk/app/oauth2/tests/utils.spec.ts
@@ -7,7 +7,6 @@ import path from "path"
 import { KEYCLOAK_IMAGE } from "../../../../integrations/tests/utils/images"
 import { startContainer } from "../../../../integrations/tests/utils"
 import { OAuth2CredentialsMethod, OAuth2GrantType } from "@budibase/types"
-import { method } from "lodash"
 
 const config = new TestConfiguration()
 

--- a/packages/server/src/sdk/app/oauth2/utils.ts
+++ b/packages/server/src/sdk/app/oauth2/utils.ts
@@ -1,13 +1,14 @@
 import fetch, { RequestInit } from "node-fetch"
 import { HttpError } from "koa"
 import { get } from "../oauth2"
-import { OAuth2CredentialsMethod } from "@budibase/types"
+import { OAuth2CredentialsMethod, OAuth2GrantType } from "@budibase/types"
 
 async function fetchToken(config: {
   url: string
   clientId: string
   clientSecret: string
   method: OAuth2CredentialsMethod
+  grantType: OAuth2GrantType
 }) {
   const fetchConfig: RequestInit = {
     method: "POST",
@@ -30,7 +31,7 @@ async function fetchToken(config: {
     }
   } else {
     fetchConfig.body = new URLSearchParams({
-      grant_type: "client_credentials",
+      grant_type: config.grantType,
       client_id: config.clientId,
       client_secret: config.clientSecret,
     })
@@ -64,6 +65,7 @@ export async function validateConfig(config: {
   clientId: string
   clientSecret: string
   method: OAuth2CredentialsMethod
+  grantType: OAuth2GrantType
 }): Promise<{ valid: boolean; message?: string }> {
   try {
     const resp = await fetchToken(config)

--- a/packages/types/src/api/web/app/oauth2.ts
+++ b/packages/types/src/api/web/app/oauth2.ts
@@ -8,6 +8,7 @@ export interface OAuth2ConfigResponse {
   clientId: string
   clientSecret: string
   method: OAuth2CredentialsMethod
+  grantType: OAuth2GrantType
 }
 
 export interface FetchOAuth2ConfigsResponse {

--- a/packages/types/src/api/web/app/oauth2.ts
+++ b/packages/types/src/api/web/app/oauth2.ts
@@ -49,6 +49,7 @@ export interface ValidateConfigRequest {
   clientId: string
   clientSecret: string
   method: OAuth2CredentialsMethod
+  grantType: OAuth2GrantType
 }
 
 export interface ValidateConfigResponse {

--- a/packages/types/src/api/web/app/oauth2.ts
+++ b/packages/types/src/api/web/app/oauth2.ts
@@ -1,4 +1,4 @@
-import { OAuth2CredentialsMethod } from "@budibase/types"
+import { OAuth2CredentialsMethod, OAuth2GrantType } from "@budibase/types"
 
 export interface OAuth2ConfigResponse {
   _id: string
@@ -20,6 +20,7 @@ export interface InsertOAuth2ConfigRequest {
   clientId: string
   clientSecret: string
   method: OAuth2CredentialsMethod
+  grantType: OAuth2GrantType
 }
 
 export interface InsertOAuth2ConfigResponse {
@@ -34,6 +35,7 @@ export interface UpdateOAuth2ConfigRequest {
   clientId: string
   clientSecret: string
   method: OAuth2CredentialsMethod
+  grantType: OAuth2GrantType
 }
 
 export interface UpdateOAuth2ConfigResponse {

--- a/packages/types/src/documents/app/oauth2.ts
+++ b/packages/types/src/documents/app/oauth2.ts
@@ -5,10 +5,15 @@ export enum OAuth2CredentialsMethod {
   BODY = "BODY",
 }
 
+export enum OAuth2GrantType {
+  CLIENT_CREDENTIALS = "client_credentials",
+}
+
 export interface OAuth2Config extends Document {
   name: string
   url: string
   clientId: string
   clientSecret: string
   method: OAuth2CredentialsMethod
+  grantType: OAuth2GrantType
 }


### PR DESCRIPTION
## Description
After some initial testing we realised that it was not obvious that only `client credentials` are supported in BB on the new oauth2. We decided to add it as a part of the form, but not editable, so it will be explicit.
Added support to store it in the actual configuration, making it easier to extend in the future if we start supporting new grant type

## Screenshots
![image](https://github.com/user-attachments/assets/25846438-a0d1-4eee-8a3c-c05413aa868c)