### PR TITLE
[Added] Multi-tenant functionality will need the tenantId in GetLicenseRequest

### DIFF
--- a/packages/types/src/api/account/license.ts
+++ b/packages/types/src/api/account/license.ts
@@ -6,6 +6,7 @@ export interface GetLicenseRequest {
   // All fields should be optional to cater for
   // historical versions of budibase
   quotaUsage?: QuotaUsage
+  tenantId?: string
   install: {
     id: string
     tenantId: string


### PR DESCRIPTION
## Description

Because of new multi-tenant functionality, `tenantId` must be sent in order to get the license. `tenantId` has been included inside `GetLicenseRequest` as an optional value (by now).

## Addresses

https://linear.app/budibase/issue/GRO-1050/wrong-usercreator-calculation-on-app-init

