### PR TITLE
[Fixed] Wrong user/creator calculation on app init

### DIFF
--- a/packages/backend-core/src/users/db.ts
+++ b/packages/backend-core/src/users/db.ts
@@ -261,9 +261,13 @@ export class UserDB {
       }
     }
 
-    const change = dbUser ? 0 : 1 // no change if there is existing user
-
+    let change = 1
     let creatorsChange = 0
+    if (opts.isAccountHolder || dbUser) {
+      change = 0
+      creatorsChange = 1
+    }
+
     if (dbUser) {
       const [isDbUserCreator, isUserCreator] = await creatorsInList([
         dbUser,


### PR DESCRIPTION
## Description

Creators was being set to 0 on application init. Account holder was being considered as user.

Now if `isAccountHolder` flag is given, it is considered as a creator addition. This change is needed because it was causing problems when the first user (the holder) was being created.

## Addresses

https://linear.app/budibase/issue/GRO-1050/wrong-usercreator-calculation-on-app-init
