### PR TITLE
Fix pro package resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "@budibase/shared-core": "*",
     "@budibase/string-templates": "*",
     "@budibase/types": "*",
-    "@budibase/pro": "npm:@budibase/pro@latest",
     "tough-cookie": "4.1.3",
     "node-fetch": "2.6.7",
     "semver": "7.5.3",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -182,6 +182,9 @@
     "yargs": "^13.2.4",
     "zod": "^3.23.8"
   },
+  "resolutions": {
+    "@budibase/pro": "npm:@budibase/pro@latest"
+  },
   "nx": {
     "targets": {
       "dev": {

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -102,6 +102,9 @@
     "typescript": "5.7.2",
     "update-dotenv": "1.1.1"
   },
+  "resolutions": {
+    "@budibase/pro": "npm:@budibase/pro@latest"
+  },
   "nx": {
     "targets": {
       "dev": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2795,28 +2795,6 @@
     pouchdb-promise "^6.0.4"
     through2 "^2.0.0"
 
-"@budibase/pro@npm:@budibase/pro@latest":
-  version "3.4.22"
-  resolved "https://registry.yarnpkg.com/@budibase/pro/-/pro-3.4.22.tgz#943f23cb7056041bc1f433ee60b3d093145e7a4a"
-  integrity sha512-Du3iZsmRLopfoi2SvxQyY1P2Su3Nw0WbITOrKmZFsVLjZ9MzzTZs0Ph/SJHzrfJpM7rn9+8788BLSf3Z3l9KcQ==
-  dependencies:
-    "@anthropic-ai/sdk" "^0.27.3"
-    "@budibase/backend-core" "*"
-    "@budibase/shared-core" "*"
-    "@budibase/string-templates" "*"
-    "@budibase/types" "*"
-    "@koa/router" "13.1.0"
-    bull "4.10.1"
-    dd-trace "5.26.0"
-    joi "17.6.0"
-    jsonwebtoken "9.0.2"
-    lru-cache "^7.14.1"
-    memorystream "^0.3.1"
-    node-fetch "2.6.7"
-    openai "4.59.0"
-    scim-patch "^0.8.1"
-    scim2-parse-filter "^0.2.8"
-
 "@budibase/vm-browserify@^1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@budibase/vm-browserify/-/vm-browserify-1.1.4.tgz#eecb001bd9521cb7647e26fb4d2d29d0a4dce262"


### PR DESCRIPTION
## Description
Budibase has a submodule `pro` that is required to run Budibase, but it's not publicly available. To solve this, we used a "hack" to resolve that package from npm. Yarn workspace would load this npm package if the submodule is not loaded, and use the local one otherwise. This allows us as BB devs to work with everything locally, while OSS contributors can also run it locally without having access to the protected submodule.

For some reason, it looks like this stopped working, as the yarn workspace is now symlinking to the root of the project, but the pro version coming from npm is hoisted on the packages that use them.

This PR is moving the resolutions to the actual packages, keeping everything working as it used to. Not sure what changed the previous behaviour, but this now works as expected. I also tried using `[nohoist](https://classic.yarnpkg.com/blog/2018/02/15/nohoist/)`, but for some reason I could not get it working.