### PR TITLE
Cache token on oauth2 usage

### DIFF
--- a/packages/backend-core/src/cache/generic.ts
+++ b/packages/backend-core/src/cache/generic.ts
@@ -2,14 +2,15 @@ import BaseCache from "./base"
 
 const GENERIC = new BaseCache()
 
-export enum CacheKey {
-  CHECKLIST = "checklist",
-  INSTALLATION = "installation",
-  ANALYTICS_ENABLED = "analyticsEnabled",
-  UNIQUE_TENANT_ID = "uniqueTenantId",
-  EVENTS = "events",
-  BACKFILL_METADATA = "backfillMetadata",
-  EVENTS_RATE_LIMIT = "eventsRateLimit",
+export const CacheKey = {
+  CHECKLIST: "checklist",
+  INSTALLATION: "installation",
+  ANALYTICS_ENABLED: "analyticsEnabled",
+  UNIQUE_TENANT_ID: "uniqueTenantId",
+  EVENTS: "events",
+  BACKFILL_METADATA: "backfillMetadata",
+  EVENTS_RATE_LIMIT: "eventsRateLimit",
+  OAUTH2_TOKEN: (configId: string) => `oauth2Token_${configId}`,
 }
 
 export enum TTL {

--- a/packages/backend-core/src/cache/generic.ts
+++ b/packages/backend-core/src/cache/generic.ts
@@ -30,5 +30,8 @@ export const destroy = (...args: Parameters<typeof GENERIC.delete>) =>
 export const withCache = <T>(
   ...args: Parameters<typeof GENERIC.withCache<T>>
 ) => GENERIC.withCache(...args)
+export const withCacheWithDynamicTTL = <T>(
+  ...args: Parameters<typeof GENERIC.withCacheWithDynamicTTL<T>>
+) => GENERIC.withCacheWithDynamicTTL(...args)
 export const bustCache = (...args: Parameters<typeof GENERIC.bustCache>) =>
   GENERIC.bustCache(...args)

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -418,7 +418,7 @@ export class RestIntegration implements IntegrationBase {
     return headers
   }
 
-  async _req(query: RestQuery, retry401 = true) {
+  async _req(query: RestQuery, retry401 = true): Promise<ParsedResponse> {
     const {
       path = "",
       queryString = "",
@@ -486,7 +486,7 @@ export class RestIntegration implements IntegrationBase {
       retry401
     ) {
       await sdk.oauth2.cleanStoredToken(authConfigId!)
-      return this._req(query, false)
+      return await this._req(query, false)
     }
     return await this.parseResponse(response, pagination)
   }

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -418,7 +418,7 @@ export class RestIntegration implements IntegrationBase {
     return headers
   }
 
-  async _req(query: RestQuery) {
+  async _req(query: RestQuery, retry401 = true) {
     const {
       path = "",
       queryString = "",
@@ -480,6 +480,14 @@ export class RestIntegration implements IntegrationBase {
       throw new Error("Cannot connect to URL.")
     }
     const response = await fetch(url, input)
+    if (
+      response.status === 401 &&
+      authConfigType === RestAuthType.OAUTH2 &&
+      retry401
+    ) {
+      await sdk.oauth2.cleanStoredToken(authConfigId!)
+      return this._req(query, false)
+    }
     return await this.parseResponse(response, pagination)
   }
 

--- a/packages/server/src/integrations/tests/rest.spec.ts
+++ b/packages/server/src/integrations/tests/rest.spec.ts
@@ -278,6 +278,29 @@ describe("REST Integration", () => {
       expect(data).toEqual({ foo: "bar" })
     })
 
+    function nockTokenCredentials(
+      oauth2Url: string,
+      clientId: string,
+      password: string,
+      resultCode: number,
+      resultBody: any
+    ) {
+      const url = new URL(oauth2Url)
+      const token = generator.guid()
+      nock(url.origin)
+        .post(url.pathname, {
+          grant_type: "client_credentials",
+        })
+        .basicAuth({ user: clientId, pass: password })
+        .reply(200, { token_type: "Bearer", access_token: token })
+
+      return nock("https://example.com", {
+        reqheaders: { Authorization: `Bearer ${token}` },
+      })
+        .get("/")
+        .reply(resultCode, resultBody)
+    }
+
     it("adds OAuth2 auth (via header)", async () => {
       const oauth2Url = generator.url()
       const secret = generator.hash()
@@ -290,22 +313,11 @@ describe("REST Integration", () => {
         grantType: OAuth2GrantType.CLIENT_CREDENTIALS,
       })
 
-      const token = generator.guid()
-
-      const url = new URL(oauth2Url)
-      nock(url.origin)
-        .post(url.pathname, {
-          grant_type: "client_credentials",
-        })
-        .basicAuth({ user: oauthConfig.clientId, pass: secret })
-        .reply(200, { token_type: "Bearer", access_token: token })
-
-      nock("https://example.com", {
-        reqheaders: { Authorization: `Bearer ${token}` },
+      nockTokenCredentials(oauth2Url, oauthConfig.clientId, secret, 200, {
+        foo: "bar",
       })
-        .get("/")
-        .reply(200, { foo: "bar" })
-      const { data } = await config.doInContext(
+
+      const { data, info } = await config.doInContext(
         config.appId,
         async () =>
           await integration.read({
@@ -314,6 +326,7 @@ describe("REST Integration", () => {
           })
       )
       expect(data).toEqual({ foo: "bar" })
+      expect(info.code).toEqual(200)
     })
 
     it("adds OAuth2 auth (via body)", async () => {
@@ -348,7 +361,8 @@ describe("REST Integration", () => {
       })
         .get("/")
         .reply(200, { foo: "bar" })
-      const { data } = await config.doInContext(
+
+      const { data, info } = await config.doInContext(
         config.appId,
         async () =>
           await integration.read({
@@ -357,6 +371,95 @@ describe("REST Integration", () => {
           })
       )
       expect(data).toEqual({ foo: "bar" })
+      expect(info.code).toEqual(200)
+    })
+
+    it("handles OAuth2 auth cached expired token", async () => {
+      const oauth2Url = generator.url()
+      const secret = generator.hash()
+      const { config: oauthConfig } = await config.api.oauth2.create({
+        name: generator.guid(),
+        url: oauth2Url,
+        clientId: generator.guid(),
+        clientSecret: secret,
+        method: OAuth2CredentialsMethod.HEADER,
+        grantType: OAuth2GrantType.CLIENT_CREDENTIALS,
+      })
+
+      nockTokenCredentials(oauth2Url, oauthConfig.clientId, secret, 401, {})
+      const token2Request = nockTokenCredentials(
+        oauth2Url,
+        oauthConfig.clientId,
+        secret,
+        200,
+        {
+          foo: "bar",
+        }
+      )
+
+      const { data, info } = await config.doInContext(
+        config.appId,
+        async () =>
+          await integration.read({
+            authConfigId: oauthConfig._id,
+            authConfigType: RestAuthType.OAUTH2,
+          })
+      )
+
+      expect(data).toEqual({ foo: "bar" })
+      expect(info.code).toEqual(200)
+      expect(token2Request.isDone()).toBe(true)
+    })
+
+    it("does not loop when handling OAuth2 auth cached expired token", async () => {
+      const oauth2Url = generator.url()
+      const secret = generator.hash()
+      const { config: oauthConfig } = await config.api.oauth2.create({
+        name: generator.guid(),
+        url: oauth2Url,
+        clientId: generator.guid(),
+        clientSecret: secret,
+        method: OAuth2CredentialsMethod.HEADER,
+        grantType: OAuth2GrantType.CLIENT_CREDENTIALS,
+      })
+
+      const firstRequest = nockTokenCredentials(
+        oauth2Url,
+        oauthConfig.clientId,
+        secret,
+        401,
+        {}
+      )
+      const secondRequest = nockTokenCredentials(
+        oauth2Url,
+        oauthConfig.clientId,
+        secret,
+        401,
+        {}
+      )
+      const thirdRequest = nockTokenCredentials(
+        oauth2Url,
+        oauthConfig.clientId,
+        secret,
+        200,
+        { foo: "bar" }
+      )
+
+      const { data, info } = await config.doInContext(
+        config.appId,
+        async () =>
+          await integration.read({
+            authConfigId: oauthConfig._id,
+            authConfigType: RestAuthType.OAUTH2,
+          })
+      )
+
+      expect(info.code).toEqual(401)
+      expect(data).toEqual({})
+
+      expect(firstRequest.isDone()).toBe(true)
+      expect(secondRequest.isDone()).toBe(true)
+      expect(thirdRequest.isDone()).toBe(false)
     })
   })
 

--- a/packages/server/src/sdk/app/oauth2/utils.ts
+++ b/packages/server/src/sdk/app/oauth2/utils.ts
@@ -6,7 +6,7 @@ import {
   OAuth2CredentialsMethod,
   OAuth2GrantType,
 } from "@budibase/types"
-import { cache, context, docIds, Duration } from "@budibase/backend-core"
+import { cache, context, docIds } from "@budibase/backend-core"
 
 interface OAuth2LogDocument extends Document {
   lastUsage: number
@@ -81,7 +81,7 @@ export async function getToken(id: string) {
       }
 
       const token = `${jsonResponse.token_type} ${jsonResponse.access_token}`
-      const ttl = jsonResponse.expires_in ?? Duration.fromHours(1).toSeconds()
+      const ttl = jsonResponse.expires_in ?? -1
       return { value: token, ttl }
     }
   )

--- a/packages/server/src/sdk/app/oauth2/utils.ts
+++ b/packages/server/src/sdk/app/oauth2/utils.ts
@@ -139,3 +139,7 @@ export async function getLastUsages(ids: string[]) {
   }, {})
   return result
 }
+
+export async function cleanStoredToken(id: string) {
+  await cache.destroy(cache.CacheKey.OAUTH2_TOKEN(id), { useTenancy: true })
+}


### PR DESCRIPTION
## Description
Cache token on oauth2 usage to speed up requests and to avoid issues with 429 (too many requests). This is recommended in the [RFC](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1).
This PR also handles retries: if using a token in a rest request we get a 401, we will clean the cached token and retry ONE extra time. This will avoid issues with revoked tokens or other conflicting issues. Otherwise, all the requests will fail until the TTL expires