### PR TITLE
OAuth2 documentation links

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/settings/oauth2/OAuth2ConfigModalContent.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/settings/oauth2/OAuth2ConfigModalContent.svelte
@@ -213,7 +213,7 @@
   />
   <Body size="S"
     >To learn how to configure OAuth2, our documentation <Link
-      href="TODO"
+      href="https://docs.budibase.com/docs/rest-oauth2"
       target="_blank"
       size="M">our documentation.</Link
     ></Body


### PR DESCRIPTION
## Description
Set the right URL on docs
![image](https://github.com/user-attachments/assets/042548d4-29fa-4eb4-8e5c-39273a1bf2d9)
