### PR TITLE
SQL Server updating signatures support

### DIFF
--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -2276,6 +2276,25 @@ if (descriptions.length) {
           expect(updated.attachment.key).toBe(newAttachment.key)
         })
 
+        it("should allow updating signature row", async () => {
+          const { table, row } = await coreAttachmentEnrichment(
+            {
+              signature: {
+                type: FieldType.SIGNATURE_SINGLE,
+                name: "signature",
+                constraints: { presence: false },
+              },
+            },
+            "signature",
+            `${uuid.v4()}.png`
+          )
+
+          const newSignature = generateAttachment(`${uuid.v4()}.png`)
+          row["signature"] = newSignature
+          const updated = await config.api.row.save(table._id!, row)
+          expect(updated.signature.key).toBe(newSignature.key)
+        })
+
         it("should allow enriching attachment list rows", async () => {
           await coreAttachmentEnrichment(
             {

--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -371,8 +371,7 @@ class SqlServerIntegration extends Sql implements DatasourcePlus {
           ? `${query.sql}; SELECT SCOPE_IDENTITY() AS id;`
           : query.sql
       this.log(sql, query.bindings)
-      const resp = await request.query(sql)
-      return resp
+      return await request.query(sql)
     } catch (err: any) {
       let readableMessage = getReadableErrorMessage(
         SourceName.SQL_SERVER,

--- a/packages/shared-core/src/constants/fields.ts
+++ b/packages/shared-core/src/constants/fields.ts
@@ -30,4 +30,12 @@ export const SWITCHABLE_TYPES: SwitchableTypes = {
     FieldType.LONGFORM,
   ],
   [FieldType.NUMBER]: [FieldType.NUMBER, FieldType.BOOLEAN],
+  [FieldType.JSON]: [
+    FieldType.JSON,
+    FieldType.ARRAY,
+    FieldType.ATTACHMENTS,
+    FieldType.ATTACHMENT_SINGLE,
+    FieldType.BB_REFERENCE,
+    FieldType.SIGNATURE_SINGLE,
+  ],
 }

--- a/packages/types/src/documents/app/row.ts
+++ b/packages/types/src/documents/app/row.ts
@@ -128,6 +128,7 @@ export enum FieldType {
 export const JsonTypes = [
   FieldType.ATTACHMENT_SINGLE,
   FieldType.ATTACHMENTS,
+  FieldType.SIGNATURE_SINGLE,
   // only BB_REFERENCE is JSON, it's an array, BB_REFERENCE_SINGLE is a string type
   FieldType.BB_REFERENCE,
   FieldType.JSON,


### PR DESCRIPTION
## Description
Fix for signatures, they were not considered JSON fields which meant  that SQL server was denying updates to them (as with the attachment fields).