### PR TITLE
Allow numeric static formulas to be used in view calculations

### DIFF
--- a/packages/builder/src/components/backend/DataTable/buttons/grid/GridViewCalculationButton.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/GridViewCalculationButton.svelte
@@ -6,7 +6,13 @@
     Multiselect,
     Button,
   } from "@budibase/bbui"
-  import { CalculationType, canGroupBy, isNumeric } from "@budibase/types"
+  import {
+    CalculationType,
+    canGroupBy,
+    FieldType,
+    isNumeric,
+    isNumericStaticFormula,
+  } from "@budibase/types"
   import InfoDisplay from "@/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Component/InfoDisplay.svelte"
   import { getContext } from "svelte"
   import DetailPopover from "@/components/common/DetailPopover.svelte"
@@ -94,10 +100,15 @@
         if (fieldSchema.calculationType) {
           return false
         }
+        // static numeric formulas will work
+        if (isNumericStaticFormula(fieldSchema)) {
+          return true
+        }
         // Only allow numeric columns for most calculation types
         if (
           self.type !== CalculationType.COUNT &&
-          !isNumeric(fieldSchema.type)
+          !isNumeric(fieldSchema.type) &&
+          fieldSchema.responseType !== FieldType.NUMBER
         ) {
           return false
         }

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -38,10 +38,7 @@ import {
   FormulaType,
 } from "@budibase/types"
 import { generator, mocks } from "@budibase/backend-core/tests"
-import {
-  datasourceDescribe,
-  DatabaseName,
-} from "../../../integrations/tests/utils"
+import { datasourceDescribe } from "../../../integrations/tests/utils"
 import merge from "lodash/merge"
 import { quotas } from "@budibase/pro"
 import { context, db, events, roles, setEnv } from "@budibase/backend-core"

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -35,9 +35,13 @@ import {
   ViewV2,
   ViewV2Schema,
   ViewV2Type,
+  FormulaType,
 } from "@budibase/types"
 import { generator, mocks } from "@budibase/backend-core/tests"
-import { datasourceDescribe } from "../../../integrations/tests/utils"
+import {
+  datasourceDescribe,
+  DatabaseName,
+} from "../../../integrations/tests/utils"
 import merge from "lodash/merge"
 import { quotas } from "@budibase/pro"
 import { context, db, events, roles, setEnv } from "@budibase/backend-core"
@@ -3864,6 +3868,45 @@ if (descriptions.length) {
               expect(rows).toHaveLength(1)
               expect(rows[0].count).toEqual(2)
             })
+
+            isInternal &&
+              it("should be able to max a static formula field", async () => {
+                const table = await config.api.table.save(
+                  saveTableRequest({
+                    schema: {
+                      string: {
+                        type: FieldType.STRING,
+                        name: "string",
+                      },
+                      formula: {
+                        type: FieldType.FORMULA,
+                        name: "formula",
+                        formulaType: FormulaType.STATIC,
+                        responseType: FieldType.NUMBER,
+                        formula: "{{ string }}",
+                      },
+                    },
+                  })
+                )
+                await config.api.row.save(table._id!, {
+                  string: "1",
+                })
+                const view = await config.api.viewV2.create({
+                  tableId: table._id!,
+                  name: generator.guid(),
+                  type: ViewV2Type.CALCULATION,
+                  schema: {
+                    maxFormula: {
+                      visible: true,
+                      calculationType: CalculationType.MAX,
+                      field: "formula",
+                    },
+                  },
+                })
+                const { rows } = await config.api.row.search(view.id)
+                expect(rows.length).toEqual(1)
+                expect(rows[0].maxFormula).toEqual(1)
+              })
 
             it("should not be able to COUNT(DISTINCT ...) against a non-existent field", async () => {
               await config.api.viewV2.create(

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -3888,6 +3888,9 @@ if (descriptions.length) {
                 await config.api.row.save(table._id!, {
                   string: "1",
                 })
+                await config.api.row.save(table._id!, {
+                  string: "2",
+                })
                 const view = await config.api.viewV2.create({
                   tableId: table._id!,
                   name: generator.guid(),
@@ -3902,7 +3905,7 @@ if (descriptions.length) {
                 })
                 const { rows } = await config.api.row.search(view.id)
                 expect(rows.length).toEqual(1)
-                expect(rows[0].maxFormula).toEqual(1)
+                expect(rows[0].maxFormula).toEqual(2)
               })
 
             it("should not be able to COUNT(DISTINCT ...) against a non-existent field", async () => {

--- a/packages/server/src/sdk/app/views/index.ts
+++ b/packages/server/src/sdk/app/views/index.ts
@@ -4,6 +4,7 @@ import {
   canGroupBy,
   FieldType,
   isNumeric,
+  isNumericStaticFormula,
   PermissionLevel,
   RelationSchemaField,
   RenameColumn,
@@ -176,7 +177,11 @@ async function guardCalculationViewSchema(
     }
 
     const isCount = schema.calculationType === CalculationType.COUNT
-    if (!isCount && !isNumeric(targetSchema.type)) {
+    if (
+      !isCount &&
+      !isNumeric(targetSchema.type) &&
+      !isNumericStaticFormula(targetSchema)
+    ) {
       throw new HTTPError(
         `Calculation field "${name}" references field "${schema.field}" which is not a numeric field`,
         400

--- a/packages/types/src/documents/app/row.ts
+++ b/packages/types/src/documents/app/row.ts
@@ -1,4 +1,5 @@
 import { Document } from "../document"
+import { FieldSchema, FormulaType } from "./table"
 
 export enum FieldType {
   /**
@@ -145,6 +146,15 @@ export const NumericTypes = [FieldType.NUMBER, FieldType.BIGINT]
 
 export function isNumeric(type: FieldType) {
   return NumericTypes.includes(type)
+}
+
+export function isNumericStaticFormula(schema: FieldSchema) {
+  return (
+    schema.type === FieldType.FORMULA &&
+    schema.formulaType === FormulaType.STATIC &&
+    schema.responseType &&
+    isNumeric(schema.responseType)
+  )
 }
 
 export const GroupByTypes = [


### PR DESCRIPTION
## Description
Adding support for static formulas with a numeric response type when creating view calculations, this only applies to the internal DB but offers a way to transform say string columns to numbers and then calculate on these.

A static formula on a string column with a numeric response type (this string column only contains numbers)
![image](https://github.com/user-attachments/assets/10d85a23-d0e7-491c-a3f2-2e81b59b832d)

Configuring view:
![image](https://github.com/user-attachments/assets/90fd2f91-1f70-46f7-933c-b4ea0d527b33)

Displaying the max: 
![image](https://github.com/user-attachments/assets/9bd56e05-873c-4d9d-bb76-0f5820210649)

