### PR TITLE
Format the plan type label

### DIFF
--- a/packages/builder/src/pages/builder/portal/account/upgrade.svelte
+++ b/packages/builder/src/pages/builder/portal/account/upgrade.svelte
@@ -20,6 +20,7 @@
   import { API } from "@/api"
   import { onMount } from "svelte"
   import { sdk } from "@budibase/shared-core"
+  import { getFormattedPlanName } from "@/helpers/planTitle"
 
   $: license = $auth.user.license
   $: upgradeUrl = `${$admin.accountPortalUrl}/portal/upgrade`
@@ -260,7 +261,11 @@
     <Layout gap="XS" noPadding>
       <Heading size="XS">Plan</Heading>
       <Layout noPadding gap="S">
-        <Body size="S">You are currently on the {license.plan.type} plan</Body>
+        <Body size="S"
+          >You are currently on the <b
+            >{getFormattedPlanName(license.plan.type)}</b
+          ></Body
+        >
         <div>
           <Body size="S"
             >If you purchase or update your plan on the account</Body


### PR DESCRIPTION
## Description
Noticed the "Premium" plan was displaying as "premium_plus". Using the label helper to present this nicely. Also added bold to make it more obvious.

## Addresses
- https://linear.app/budibase/issue/GRO-1075/replace-premium-plus-with-premium-in-the-budibase-platform-ui

## Screenshots
![plan](https://github.com/user-attachments/assets/e23edc0a-a1c6-4876-8ddc-8d2b7ebf18ce)

