### PR TITLE
Fix size of boilerplate screen components on mobile

### DIFF
--- a/packages/server/src/constants/screens.ts
+++ b/packages/server/src/constants/screens.ts
@@ -365,7 +365,11 @@ export function createSampleDataTableScreen(): Screen {
           _component: "@budibase/standard-components/textv2",
           _styles: {
             normal: {
+              "--grid-desktop-col-start": 1,
               "--grid-desktop-col-end": 3,
+              "--grid-desktop-row-start": 1,
+              "--grid-desktop-row-end": 3,
+              "--grid-mobile-col-end": 7,
             },
             hover: {},
             active: {},
@@ -384,6 +388,7 @@ export function createSampleDataTableScreen(): Screen {
               "--grid-desktop-row-start": 1,
               "--grid-desktop-row-end": 3,
               "--grid-desktop-h-align": "end",
+              "--grid-mobile-col-start": 7,
             },
             hover: {},
             active: {},


### PR DESCRIPTION
## Description
Fixes a small issue where the title and button of the boilerplate screen did not have mobile sizing set, meaning they were a bit cramped by default.

Before:
![image](https://github.com/user-attachments/assets/bda2961f-4e7a-49a9-a1e9-95243938209d)

After:
![image](https://github.com/user-attachments/assets/b192b5f0-4af6-4c80-855f-6e3fda56259a)
