### PR TITLE
Add license feature for PDF and update UI to account for it

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/_components/NewScreen/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/_components/NewScreen/index.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Body } from "@budibase/bbui"
+  import { Body, Tag, Tags } from "@budibase/bbui"
   import CreationPage from "@/components/common/CreationPage.svelte"
   import blank from "./images/blank.svg"
   import table from "./images/tableInline.svg"
@@ -7,6 +7,7 @@
   import pdf from "./images/pdf.svg"
   import CreateScreenModal from "./CreateScreenModal.svelte"
   import { screenStore } from "@/stores/builder"
+  import { licensing } from "@/stores/portal"
   import { AutoScreenTypes } from "@/constants"
 
   export let onClose = null
@@ -57,19 +58,6 @@
 
       <div
         class="card"
-        on:click={() => createScreenModal.show(AutoScreenTypes.PDF)}
-      >
-        <div class="image">
-          <img alt="A form containing data" src={pdf} width="185" />
-        </div>
-        <div class="text">
-          <Body size="M">PDF</Body>
-          <Body size="XS">Create, edit and export your PDF</Body>
-        </div>
-      </div>
-
-      <div
-        class="card"
         on:click={() => createScreenModal.show(AutoScreenTypes.FORM)}
       >
         <div class="image">
@@ -78,6 +66,29 @@
         <div class="text">
           <Body size="M">Form</Body>
           <Body size="XS">Capture data from your users</Body>
+        </div>
+      </div>
+
+      <div
+        class="card"
+        class:disabled={!$licensing.pdfEnabled}
+        on:click={$licensing.pdfEnabled
+          ? () => createScreenModal.show(AutoScreenTypes.PDF)
+          : null}
+      >
+        <div class="image">
+          <img alt="A PDF document" src={pdf} width="185" />
+        </div>
+        <div class="text">
+          <Body size="M">
+            PDF
+            {#if !$licensing.pdfEnabled}
+              <Tags>
+                <Tag icon="LockClosed">Premium</Tag>
+              </Tags>
+            {/if}
+          </Body>
+          <Body size="XS">Create, edit and export your PDF</Body>
         </div>
       </div>
     </div>
@@ -110,7 +121,7 @@
     transition: filter 150ms;
   }
 
-  .card:hover {
+  .card:not(.disabled):hover {
     filter: brightness(1.1);
     cursor: pointer;
   }
@@ -120,16 +131,22 @@
     width: 100%;
     max-height: 127px;
     overflow: hidden;
-  }
-
-  .image img {
-    width: 100%;
-  }
-
-  .card .image {
     min-width: 235px;
     height: 127px;
     background-color: var(--grey-2);
+    position: relative;
+  }
+  .card.disabled .image:after {
+    content: "";
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+    position: absolute;
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .image img {
+    width: 100%;
   }
 
   .text {
@@ -140,7 +157,11 @@
     flex-direction: column;
     gap: 2px;
   }
-
+  .text :global(p:first-child) {
+    display: flex;
+    gap: var(--spacing-m);
+    align-items: center;
+  }
   .text :global(p:nth-child(2)) {
     color: var(--spectrum-global-color-gray-600);
   }

--- a/packages/builder/src/stores/portal/licensing.ts
+++ b/packages/builder/src/stores/portal/licensing.ts
@@ -39,6 +39,7 @@ interface LicensingState {
   customAppScriptsEnabled: boolean
   syncAutomationsEnabled: boolean
   triggerAutomationRunEnabled: boolean
+  pdfEnabled: boolean
   // the currently used quotas from the db
   quotaUsage?: QuotaUsage
   // derived quota metrics for percentages used
@@ -81,6 +82,7 @@ class LicensingStore extends BudiStore<LicensingState> {
       customAppScriptsEnabled: false,
       syncAutomationsEnabled: false,
       triggerAutomationRunEnabled: false,
+      pdfEnabled: false,
       // the currently used quotas from the db
       quotaUsage: undefined,
       // derived quota metrics for percentages used
@@ -187,6 +189,7 @@ class LicensingStore extends BudiStore<LicensingState> {
     const customAppScriptsEnabled = features.includes(
       Constants.Features.CUSTOM_APP_SCRIPTS
     )
+    const pdfEnabled = features.includes(Constants.Features.PDF)
     this.update(state => {
       return {
         ...state,
@@ -208,6 +211,7 @@ class LicensingStore extends BudiStore<LicensingState> {
         triggerAutomationRunEnabled,
         perAppBuildersEnabled,
         customAppScriptsEnabled,
+        pdfEnabled,
       }
     })
   }

--- a/packages/types/src/sdk/licensing/feature.ts
+++ b/packages/types/src/sdk/licensing/feature.ts
@@ -14,6 +14,7 @@ export enum Feature {
   OFFLINE = "offline",
   EXPANDED_PUBLIC_API = "expandedPublicApi",
   CUSTOM_APP_SCRIPTS = "customAppScripts",
+  PDF = "pdf",
   // deprecated - no longer licensed
   VIEW_PERMISSIONS = "viewPermissions",
   VIEW_READONLY_COLUMNS = "viewReadonlyColumns",


### PR DESCRIPTION
## Description
Makes PDF a premium feature. Need to merge this before I can update pro and account portal to include the new feature in licenses.

Also just swaps the order of the form and PDF templates so that PDF is last.

![image](https://github.com/user-attachments/assets/94e9aeeb-6090-4b57-a42d-32efad92a3d6)

Pro PR: https://github.com/Budibase/budibase-pro/pull/375
