### PR TITLE
Fix popover root selector

### DIFF
--- a/packages/client/src/components/CustomThemeWrapper.svelte
+++ b/packages/client/src/components/CustomThemeWrapper.svelte
@@ -8,7 +8,7 @@
   const id = Helpers.uuid()
 
   if (popoverRoot) {
-    setContext(Context.PopoverRoot, `#id`)
+    setContext(Context.PopoverRoot, `#${id}`)
   }
 </script>
 


### PR DESCRIPTION
## Description
Popover root selected was misconfigured, resulting in an invalid selector.