### PR TITLE
Remove mysterious curly brace

### DIFF
--- a/packages/client/src/components/preview/HoverIndicator.svelte
+++ b/packages/client/src/components/preview/HoverIndicator.svelte
@@ -54,4 +54,4 @@
     zIndex={selected ? 890 : 910}
     allowResizeAnchors
   />
-{/if}}
+{/if}


### PR DESCRIPTION
## Description
There was a stray `}` in the `HoverIndicator` that manifested as a small white dot in the bottom left of the designer app preview.

## Screenshots
Exhibit A
![Screenshot 2025-04-03 at 15 39 19](https://github.com/user-attachments/assets/eee144d3-9b3a-46c8-8f8b-46d2ad5df604)

## Launchcontrol
Reduced character count by 1