### PR TITLE
Fix update queries against Google Sheets datasources.

### DIFF
--- a/packages/server/src/api/controllers/datasource.ts
+++ b/packages/server/src/api/controllers/datasource.ts
@@ -1,5 +1,4 @@
 import { getQueryParams, getTableParams } from "../../db/utils"
-import { getIntegration } from "../../integrations"
 import { invalidateCachedVariable } from "../../threads/utils"
 import { context, db as dbCore, events } from "@budibase/backend-core"
 import {
@@ -173,14 +172,6 @@ export async function update(
   )
   await events.datasource.updated(datasource)
   datasource._rev = response.rev
-
-  // Drain connection pools when configuration is changed
-  if (datasource.source && !isBudibaseSource) {
-    const source = await getIntegration(datasource.source)
-    if (source && source.pool) {
-      await source.pool.end()
-    }
-  }
 
   ctx.message = "Datasource saved successfully."
   ctx.body = {

--- a/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
@@ -761,7 +761,7 @@ if (descriptions.length) {
       })
 
       it("should throw an error if the incorrect actionType is specified", async () => {
-        const verbs = ["read", "create", "update", "delete"]
+        const verbs = ["read", "create", "update", "delete"] as const
         for (const verb of verbs) {
           const query = await createQuery({
             fields: { json: {}, extra: { actionType: "invalid" } },

--- a/packages/server/src/integrations/base/query.ts
+++ b/packages/server/src/integrations/base/query.ts
@@ -3,7 +3,7 @@ import {
   EnrichedQueryJson,
   QueryJson,
 } from "@budibase/types"
-import { getIntegration } from "../index"
+import { getIntegration, isDatasourcePlusConstructor } from "../index"
 import sdk from "../../sdk"
 import { enrichQueryJson } from "../../sdk/app/rows/utils"
 
@@ -29,8 +29,7 @@ export async function makeExternalQuery(
 
   const Integration = await getIntegration(json.datasource.source)
 
-  // query is the opinionated function
-  if (!Integration.prototype.query) {
+  if (!isDatasourcePlusConstructor(Integration)) {
     throw "Datasource does not support query."
   }
 

--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -18,7 +18,6 @@ import {
   DatasourcePlusQueryResponse,
   BBReferenceFieldSubType,
   EnrichedQueryJson,
-  TableSchema,
 } from "@budibase/types"
 import { OAuth2Client } from "google-auth-library"
 import {

--- a/packages/server/src/integrations/googlesheets.ts
+++ b/packages/server/src/integrations/googlesheets.ts
@@ -18,6 +18,7 @@ import {
   DatasourcePlusQueryResponse,
   BBReferenceFieldSubType,
   EnrichedQueryJson,
+  TableSchema,
 } from "@budibase/types"
 import { OAuth2Client } from "google-auth-library"
 import {
@@ -626,7 +627,7 @@ export class GoogleSheetsIntegration implements DatasourcePlus {
     sheet: string
     rowIndex: number
     row: any
-    table: Table
+    table?: Table
   }) {
     try {
       await this.connect()
@@ -644,13 +645,15 @@ export class GoogleSheetsIntegration implements DatasourcePlus {
             row.set(key, "")
           }
 
-          const { type, subtype, constraints } = query.table.schema[key]
-          const isDeprecatedSingleUser =
-            type === FieldType.BB_REFERENCE &&
-            subtype === BBReferenceFieldSubType.USER &&
-            constraints?.type !== "array"
-          if (isDeprecatedSingleUser && Array.isArray(row.get(key))) {
-            row.set(key, row.get(key)[0])
+          if (query.table) {
+            const { type, subtype, constraints } = query.table.schema[key]
+            const isDeprecatedSingleUser =
+              type === FieldType.BB_REFERENCE &&
+              subtype === BBReferenceFieldSubType.USER &&
+              constraints?.type !== "array"
+            if (isDeprecatedSingleUser && Array.isArray(row.get(key))) {
+              row.set(key, row.get(key)[0])
+            }
           }
         }
         await row.save()

--- a/packages/server/src/integrations/index.ts
+++ b/packages/server/src/integrations/index.ts
@@ -19,6 +19,7 @@ import {
   Integration,
   PluginType,
   IntegrationBase,
+  DatasourcePlus,
 } from "@budibase/types"
 import { getDatasourcePlugin } from "../utilities/fileSystem"
 import env from "../environment"
@@ -48,6 +49,13 @@ const DEFINITIONS: Record<SourceName, Integration | undefined> = {
 }
 
 type IntegrationBaseConstructor = new (...args: any[]) => IntegrationBase
+type DatasourcePlusConstructor = new (...args: any[]) => DatasourcePlus
+
+export function isDatasourcePlusConstructor(
+  integration: IntegrationBaseConstructor
+): integration is DatasourcePlusConstructor {
+  return !!integration.prototype.query
+}
 
 const INTEGRATIONS: Record<SourceName, IntegrationBaseConstructor | undefined> =
   {

--- a/packages/server/src/integrations/index.ts
+++ b/packages/server/src/integrations/index.ts
@@ -106,7 +106,9 @@ export async function getDefinitions() {
   }
 }
 
-export async function getIntegration(integration: SourceName) {
+export async function getIntegration(
+  integration: SourceName
+): Promise<IntegrationBaseConstructor> {
   if (INTEGRATIONS[integration]) {
     return INTEGRATIONS[integration]
   }

--- a/packages/server/src/integrations/tests/utils/googlesheets.ts
+++ b/packages/server/src/integrations/tests/utils/googlesheets.ts
@@ -540,9 +540,28 @@ export class GoogleSheetsMock {
       throw new Error("Only row-based deletes are supported")
     }
 
-    this.iterateRange(range, cell => {
-      cell.userEnteredValue = this.createValue(null)
-    })
+    const sheet = this.getSheetById(range.sheetId)
+    if (!sheet) {
+      throw new Error(`Sheet ${range.sheetId} not found`)
+    }
+
+    if (!range.startRowIndex || !range.endRowIndex) {
+      throw new Error("Range must have start and end row indexes")
+    }
+
+    const totalRows = sheet.data[0].rowData.length
+    if (totalRows < range.endRowIndex) {
+      throw new Error(
+        `Cannot delete range ${JSON.stringify(range)} from sheet ${
+          sheet.properties.title
+        }. Only ${totalRows} rows exist.`
+      )
+    }
+
+    const rowsToDelete = range.endRowIndex - range.startRowIndex
+    sheet.data[0].rowData.splice(range.startRowIndex, rowsToDelete)
+    sheet.data[0].rowMetadata.splice(range.startRowIndex, rowsToDelete)
+    sheet.properties.gridProperties.rowCount -= rowsToDelete
   }
 
   private handleDeleteSheet(request: DeleteSheetRequest) {

--- a/packages/server/src/integrations/tests/utils/googlesheets.ts
+++ b/packages/server/src/integrations/tests/utils/googlesheets.ts
@@ -545,7 +545,7 @@ export class GoogleSheetsMock {
       throw new Error(`Sheet ${range.sheetId} not found`)
     }
 
-    if (!range.startRowIndex || !range.endRowIndex) {
+    if (range.startRowIndex === undefined || range.endRowIndex === undefined) {
       throw new Error("Range must have start and end row indexes")
     }
 

--- a/packages/server/src/sdk/app/datasources/datasources.ts
+++ b/packages/server/src/sdk/app/datasources/datasources.ts
@@ -14,11 +14,7 @@ import {
 } from "@budibase/types"
 import { cloneDeep } from "lodash/fp"
 import { getEnvironmentVariables } from "../../utils"
-import {
-  getDefinitions,
-  getDefinition,
-  getIntegration,
-} from "../../../integrations"
+import { getDefinitions, getDefinition } from "../../../integrations"
 import merge from "lodash/merge"
 import {
   BudibaseInternalDB,
@@ -328,14 +324,6 @@ export async function save(
   )
   await events.datasource.created(datasource)
   datasource._rev = dbResp.rev
-
-  // Drain connection pools when configuration is changed
-  if (datasource.source) {
-    const source = await getIntegration(datasource.source)
-    if (source && source.pool) {
-      await source.pool.end()
-    }
-  }
 
   return { datasource, errors }
 }

--- a/packages/server/src/sdk/app/datasources/datasources.ts
+++ b/packages/server/src/sdk/app/datasources/datasources.ts
@@ -14,7 +14,11 @@ import {
 } from "@budibase/types"
 import { cloneDeep } from "lodash/fp"
 import { getEnvironmentVariables } from "../../utils"
-import { getDefinitions, getDefinition } from "../../../integrations"
+import {
+  getDefinitions,
+  getDefinition,
+  getIntegration,
+} from "../../../integrations"
 import merge from "lodash/merge"
 import {
   BudibaseInternalDB,
@@ -292,6 +296,9 @@ export async function save(
   datasource: Datasource,
   opts?: { fetchSchema?: boolean; tablesFilter?: string[] }
 ): Promise<{ datasource: Datasource; errors: Record<string, string> }> {
+  // getIntegration throws an error if the integration is not found
+  await getIntegration(datasource.source)
+
   const db = context.getAppDB()
   const plus = datasource.plus
 

--- a/packages/types/src/documents/app/query.ts
+++ b/packages/types/src/documents/app/query.ts
@@ -8,6 +8,8 @@ export interface QuerySchema {
   subtype?: string
 }
 
+export type QueryVerb = "read" | "create" | "update" | "delete"
+
 export interface Query extends Document {
   datasourceId: string
   name: string
@@ -17,7 +19,7 @@ export interface Query extends Document {
   schema: Record<string, QuerySchema | string>
   nestedSchemaFields?: Record<string, Record<string, QuerySchema | string>>
   readable: boolean
-  queryVerb: string
+  queryVerb: QueryVerb
   // flag to state whether the default bindings are empty strings (old behaviour) or null
   nullDefaultSupport?: boolean
 }

--- a/packages/types/src/documents/app/query.ts
+++ b/packages/types/src/documents/app/query.ts
@@ -14,7 +14,10 @@ export interface Query extends Document {
   datasourceId: string
   name: string
   parameters: QueryParameter[]
-  fields: RestQueryFields & SQLQueryFields & MongoQueryFields
+  fields: RestQueryFields &
+    SQLQueryFields &
+    MongoQueryFields &
+    GoogleSheetsQueryFields
   transformer: string | null
   schema: Record<string, QuerySchema | string>
   nestedSchemaFields?: Record<string, Record<string, QuerySchema | string>>
@@ -83,6 +86,12 @@ export interface MongoQueryFields {
       | "deleteMany"
   }
   json?: object | string
+}
+
+export interface GoogleSheetsQueryFields {
+  sheet?: string
+  rowIndex?: string
+  row?: Row
 }
 
 export interface PaginationConfig {


### PR DESCRIPTION
## Description

As part of this PR I've added tests for all 4 query verbs against Google Sheets datasources to make sure this doesn't regress in future. Had to update the way our Google Sheets mock works when deleting data to make this work correctly, the way that the Google Sheets API does this is to bring all rows below the deleted row up 1. We weren't doing this, which caused a mismatch between tests and reality.

## Addresses
- https://linear.app/budibase/issue/BUDI-9153/gsheets-cannot-read-properties-of-undefined-reading-schema

## Launchcontrol

- Fixes an undefined property error when attempting to run an update query against a Google Sheets datasource.
