### PR TITLE
Automations External Data Connector picker

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AutomationSchemaLayout.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationSchemaLayout.svelte
@@ -184,6 +184,8 @@
     },
     [SchemaFieldTypes.QUERY_PARAMS]: {
       comp: QueryParamSelector,
+      fullWidth: true,
+      title: "Query*",
     },
     [SchemaFieldTypes.CODE]: {
       comp: ExecuteScript,
@@ -281,7 +283,9 @@
     }
     const type = getFieldType(field, block)
     const config = type ? SchemaTypes[type] : null
-    const title = getFieldLabel(key, field, requiredProperties?.includes(key))
+    const title =
+      config?.title ||
+      getFieldLabel(key, field, requiredProperties?.includes(key))
     const value = getInputValue(inputData, key)
     const meta = getInputValue(inputData, "meta")
 

--- a/packages/builder/src/components/automation/SetupPanel/QueryParamSelector.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/QueryParamSelector.svelte
@@ -1,9 +1,10 @@
 <script>
   import { createEventDispatcher } from "svelte"
   import { queries } from "@/stores/builder"
-  import { Select, Label } from "@budibase/bbui"
+  import { Select } from "@budibase/bbui"
   import DrawerBindableInput from "../../common/bindings/DrawerBindableInput.svelte"
   import AutomationBindingPanel from "../../common/bindings/ServerBindingPanel.svelte"
+  import PropField from "./PropField.svelte"
 
   const dispatch = createEventDispatcher()
 
@@ -28,7 +29,6 @@
 </script>
 
 <div class="schema-field">
-  <Label>Query</Label>
   <div class="field-width">
     <Select
       on:change={onChangeQuery}
@@ -42,26 +42,23 @@
 
 {#if parameters.length}
   {#each parameters as field}
-    <div class="schema-field">
-      <Label>{field.name}</Label>
-      <div class="field-width">
-        <DrawerBindableInput
-          panel={AutomationBindingPanel}
-          extraThin
-          value={value[field.name]}
-          on:change={e => onChange(e, field)}
-          type="string"
-          {bindings}
-          updateOnChange={false}
-        />
-      </div>
-    </div>
+    <PropField label={field.name} fullWidth>
+      <DrawerBindableInput
+        panel={AutomationBindingPanel}
+        extraThin
+        value={value[field.name]}
+        on:change={e => onChange(e, field)}
+        type="string"
+        {bindings}
+        updateOnChange={false}
+      />
+    </PropField>
   {/each}
 {/if}
 
 <style>
   .field-width {
-    width: 320px;
+    width: 100%;
   }
 
   .schema-field {

--- a/packages/builder/src/types/automations.ts
+++ b/packages/builder/src/types/automations.ts
@@ -149,6 +149,7 @@ export const customTypeToSchema: Record<string, SchemaFieldTypes> = {
     SchemaFieldTypes.AUTOMATION_FIELDS,
   [AutomationCustomIOType.WEBHOOK_URL]: SchemaFieldTypes.WEBHOOK_URL,
   [AutomationCustomIOType.QUERY_LIMIT]: SchemaFieldTypes.QUERY_LIMIT,
+  [AutomationCustomIOType.QUERY_PARAMS]: SchemaFieldTypes.QUERY_PARAMS,
   ["fields"]: SchemaFieldTypes.FIELDS,
 }
 


### PR DESCRIPTION
## Description
The external data connector had it's connector mistakenly removed after the automations UI rework. This fix adds the control back and readjusts the layout to match the others.

## Addresses
- https://github.com/Budibase/budibase/issues/15886

## Launchcontrol
Fix to add the query selector back into the External Data Connector