### PR TITLE
Add CSP whitelist feature to custom app scripts

### DIFF
--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -52,6 +52,7 @@
     "joi": "17.6.0",
     "jsonwebtoken": "9.0.2",
     "knex": "2.4.2",
+    "koa": "2.15.4",
     "koa-passport": "^6.0.0",
     "koa-pino-logger": "4.0.0",
     "lodash": "4.17.21",

--- a/packages/backend-core/src/middleware/contentSecurityPolicy.ts
+++ b/packages/backend-core/src/middleware/contentSecurityPolicy.ts
@@ -1,6 +1,7 @@
 import crypto from "crypto"
 import { app } from "../cache"
-import { Feature } from "@budibase/types"
+import { Feature, Ctx } from "@budibase/types"
+import { Next } from "koa"
 
 const CSP_DIRECTIVES = {
   "default-src": ["'self'"],
@@ -88,7 +89,7 @@ const CSP_DIRECTIVES = {
   "worker-src": ["blob:"],
 }
 
-export async function contentSecurityPolicy(ctx: any, next: any) {
+export async function contentSecurityPolicy(ctx: Ctx, next: Next) {
   const nonce = crypto.randomBytes(16).toString("base64")
   ctx.state.nonce = nonce
   let directives = { ...CSP_DIRECTIVES }

--- a/packages/backend-core/src/middleware/contentSecurityPolicy.ts
+++ b/packages/backend-core/src/middleware/contentSecurityPolicy.ts
@@ -1,7 +1,7 @@
 import crypto from "crypto"
 import { app } from "../cache"
 import { Feature } from "@budibase/types"
-import { env as coreEnv } from "@budibase/backend-core"
+import coreEnv from "../environment"
 
 const CSP_DIRECTIVES = {
   "default-src": ["'self'"],

--- a/packages/backend-core/src/middleware/contentSecurityPolicy.ts
+++ b/packages/backend-core/src/middleware/contentSecurityPolicy.ts
@@ -1,6 +1,7 @@
 import crypto from "crypto"
 import { app } from "../cache"
 import { Feature, Ctx } from "@budibase/types"
+import { Middleware, Next } from "koa"
 
 const CSP_DIRECTIVES = {
   "default-src": ["'self'"],
@@ -88,7 +89,7 @@ const CSP_DIRECTIVES = {
   "worker-src": ["blob:"],
 }
 
-export async function contentSecurityPolicy(ctx: Ctx, next: any) {
+const contentSecurityPolicy = (async (ctx: Ctx, next: Next) => {
   const nonce = crypto.randomBytes(16).toString("base64")
   ctx.state.nonce = nonce
   let directives = { ...CSP_DIRECTIVES }
@@ -128,6 +129,6 @@ export async function contentSecurityPolicy(ctx: Ctx, next: any) {
     .join("; ")
   ctx.set("Content-Security-Policy", cspHeader)
   await next()
-}
+}) as Middleware
 
 export default contentSecurityPolicy

--- a/packages/backend-core/src/middleware/contentSecurityPolicy.ts
+++ b/packages/backend-core/src/middleware/contentSecurityPolicy.ts
@@ -90,50 +90,45 @@ const CSP_DIRECTIVES = {
 }
 
 export async function contentSecurityPolicy(ctx: any, next: any) {
-  try {
-    const nonce = crypto.randomBytes(16).toString("base64")
-    ctx.state.nonce = nonce
-    let directives = { ...CSP_DIRECTIVES }
-    directives["script-src"] = [
-      ...CSP_DIRECTIVES["script-src"],
-      `'nonce-${nonce}'`,
-    ]
+  const nonce = crypto.randomBytes(16).toString("base64")
+  ctx.state.nonce = nonce
+  let directives = { ...CSP_DIRECTIVES }
+  directives["script-src"] = [
+    ...CSP_DIRECTIVES["script-src"],
+    `'nonce-${nonce}'`,
+  ]
 
-    // Add custom app CSP whitelist
-    const licensed = ctx.user?.license?.features.includes(
-      Feature.CUSTOM_APP_SCRIPTS
-    )
-    if (licensed && ctx.appId && !coreEnv.isTest()) {
-      try {
-        const appMetadata = await app.getAppMetadata(ctx.appId)
-        if ("name" in appMetadata) {
-          for (let script of appMetadata.scripts || []) {
-            const inclusions = (script.cspWhitelist || "")
-              .split(",")
-              .filter(url => !!url?.trim().length)
-            directives["default-src"] = [
-              ...directives["default-src"],
-              ...inclusions,
-            ]
-          }
+  // Add custom app CSP whitelist
+  const licensed = ctx.user?.license?.features.includes(
+    Feature.CUSTOM_APP_SCRIPTS
+  )
+  if (licensed && ctx.appId) {
+    try {
+      const appMetadata = await app.getAppMetadata(ctx.appId)
+      if ("name" in appMetadata) {
+        for (let script of appMetadata.scripts || []) {
+          const inclusions = (script.cspWhitelist || "")
+            .split(",")
+            .filter(url => !!url?.trim().length)
+          directives["default-src"] = [
+            ...directives["default-src"],
+            ...inclusions,
+          ]
         }
-      } catch (err) {
-        console.error(
-          `Error occurred in Content-Security-Policy middleware: ${err}`
-        )
       }
+    } catch (err) {
+      // Log an error but always proceed using the default CSP
+      console.error(
+        `Error occurred in Content-Security-Policy middleware: ${err}`
+      )
     }
-
-    const cspHeader = Object.entries(directives)
-      .map(([key, sources]) => `${key} ${sources.join(" ")}`)
-      .join("; ")
-    ctx.set("Content-Security-Policy", cspHeader)
-    await next()
-  } catch (err: any) {
-    console.error(
-      `Error occurred in Content-Security-Policy middleware: ${err}`
-    )
   }
+
+  const cspHeader = Object.entries(directives)
+    .map(([key, sources]) => `${key} ${sources.join(" ")}`)
+    .join("; ")
+  ctx.set("Content-Security-Policy", cspHeader)
+  await next()
 }
 
 export default contentSecurityPolicy

--- a/packages/backend-core/src/middleware/contentSecurityPolicy.ts
+++ b/packages/backend-core/src/middleware/contentSecurityPolicy.ts
@@ -1,6 +1,7 @@
 import crypto from "crypto"
 import { app } from "../cache"
 import { Feature } from "@budibase/types"
+import { env as coreEnv } from "@budibase/backend-core"
 
 const CSP_DIRECTIVES = {
   "default-src": ["'self'"],
@@ -102,7 +103,7 @@ export async function contentSecurityPolicy(ctx: any, next: any) {
     const licensed = ctx.user?.license?.features.includes(
       Feature.CUSTOM_APP_SCRIPTS
     )
-    if (licensed && ctx.appId) {
+    if (licensed && ctx.appId && !coreEnv.isTest()) {
       try {
         const appMetadata = await app.getAppMetadata(ctx.appId)
         if ("name" in appMetadata) {

--- a/packages/backend-core/src/middleware/contentSecurityPolicy.ts
+++ b/packages/backend-core/src/middleware/contentSecurityPolicy.ts
@@ -1,7 +1,6 @@
 import crypto from "crypto"
 import { app } from "../cache"
 import { Feature, Ctx } from "@budibase/types"
-import { Next } from "koa"
 
 const CSP_DIRECTIVES = {
   "default-src": ["'self'"],
@@ -89,7 +88,7 @@ const CSP_DIRECTIVES = {
   "worker-src": ["blob:"],
 }
 
-export async function contentSecurityPolicy(ctx: Ctx, next: Next) {
+export async function contentSecurityPolicy(ctx: Ctx, next: any) {
   const nonce = crypto.randomBytes(16).toString("base64")
   ctx.state.nonce = nonce
   let directives = { ...CSP_DIRECTIVES }

--- a/packages/backend-core/src/middleware/contentSecurityPolicy.ts
+++ b/packages/backend-core/src/middleware/contentSecurityPolicy.ts
@@ -1,7 +1,6 @@
 import crypto from "crypto"
 import { app } from "../cache"
 import { Feature } from "@budibase/types"
-import coreEnv from "../environment"
 
 const CSP_DIRECTIVES = {
   "default-src": ["'self'"],

--- a/packages/backend-core/src/middleware/tests/contentSecurityPolicy.spec.ts
+++ b/packages/backend-core/src/middleware/tests/contentSecurityPolicy.spec.ts
@@ -3,7 +3,6 @@ import contentSecurityPolicy from "../contentSecurityPolicy"
 import { app } from "../../cache"
 import { Feature, App } from "@budibase/types"
 import { users, licenses } from "../../../tests/core/utilities/structures"
-import { doInAppContext } from "../../context"
 
 jest.mock("crypto", () => ({
   randomBytes: jest.fn(),

--- a/packages/backend-core/src/middleware/tests/contentSecurityPolicy.spec.ts
+++ b/packages/backend-core/src/middleware/tests/contentSecurityPolicy.spec.ts
@@ -1,9 +1,18 @@
 import crypto from "crypto"
 import contentSecurityPolicy from "../contentSecurityPolicy"
+import { app } from "../../cache"
+import { Feature, App } from "@budibase/types"
+import { users, licenses } from "../../../tests/core/utilities/structures"
+import { doInAppContext } from "../../context"
 
 jest.mock("crypto", () => ({
   randomBytes: jest.fn(),
   randomUUID: jest.fn(),
+}))
+jest.mock("../../cache", () => ({
+  app: {
+    getAppMetadata: jest.fn(),
+  },
 }))
 
 describe("contentSecurityPolicy middleware", () => {
@@ -57,19 +66,71 @@ describe("contentSecurityPolicy middleware", () => {
   })
 
   it("should handle errors and log an error message", async () => {
+    // Ctx setup to let us try and use CSP whitelist
+    const fakeAppId = "app_sdfdsfsdfsdf"
+    ctx.appId = fakeAppId
+    ctx.user = {
+      license: {
+        features: [Feature.CUSTOM_APP_SCRIPTS],
+      },
+    }
+
     const consoleSpy = jest.spyOn(console, "error").mockImplementation()
     const error = new Error("Test error")
     // @ts-ignore
-    crypto.randomBytes.mockImplementation(() => {
+    app.getAppMetadata.mockImplementation(() => {
       throw error
+    })
+    await contentSecurityPolicy(ctx, next)
+
+    expect(app.getAppMetadata).toHaveBeenCalledWith(fakeAppId)
+    expect(consoleSpy).toHaveBeenCalledWith(
+      `Error occurred in Content-Security-Policy middleware: ${error}`
+    )
+    expect(next).toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+
+  it("should add custom CSP whitelist", async () => {
+    const appId = "app_foo"
+    const domain = "https://*.foo.bar"
+
+    // Ctx setup to let us try and use CSP whitelist
+    ctx.appId = appId
+    ctx.user = users.user()
+    ctx.user.license = licenses.license({
+      features: [Feature.CUSTOM_APP_SCRIPTS],
+    })
+
+    // @ts-ignore
+    app.getAppMetadata.mockImplementation(function (): App {
+      return {
+        appId,
+        type: "foo",
+        version: "1",
+        componentLibraries: [],
+        name: "foo",
+        url: "/foo",
+        template: undefined,
+        instance: { _id: appId },
+        tenantId: ctx.user.tenantId,
+        status: "foo",
+        scripts: [
+          {
+            id: "foo",
+            name: "Test",
+            location: "Head",
+            cspWhitelist: domain,
+          },
+        ],
+      }
     })
 
     await contentSecurityPolicy(ctx, next)
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      `Error occurred in Content-Security-Policy middleware: ${error}`
-    )
-    expect(next).not.toHaveBeenCalled()
-    consoleSpy.mockRestore()
+    const cspHeader = ctx.set.mock.calls[0][1]
+    expect(cspHeader).toContain(`default-src 'self' ${domain};`)
+    expect(app.getAppMetadata).toHaveBeenCalledWith(appId)
+    expect(next).toHaveBeenCalled()
   })
 })

--- a/packages/builder/src/pages/builder/app/[application]/settings/scripts.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/settings/scripts.svelte
@@ -146,7 +146,10 @@
       />
       <Label size="L">
         CSP whitelist<br />
-        <Link href="https://docs.budibase.com/docs/app-scripts" target="_blank">
+        <Link
+          href="https://docs.budibase.com/docs/app-scripts#domain-whitelisting-for-content-security-policy-csp"
+          target="_blank"
+        >
           Learn more
         </Link>
       </Label>

--- a/packages/builder/src/pages/builder/app/[application]/settings/scripts.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/settings/scripts.svelte
@@ -16,7 +16,6 @@
     Tag,
     Tags,
     ButtonGroup,
-    Icon,
   } from "@budibase/bbui"
   import { appStore } from "@/stores/builder"
   import { type AppScript } from "@budibase/types"

--- a/packages/builder/src/pages/builder/app/[application]/settings/scripts.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/settings/scripts.svelte
@@ -16,6 +16,7 @@
     Tag,
     Tags,
     ButtonGroup,
+    Icon,
   } from "@budibase/bbui"
   import { appStore } from "@/stores/builder"
   import { type AppScript } from "@budibase/types"
@@ -143,6 +144,17 @@
         bind:value={selectedScript.html}
         minHeight={200}
         placeholder="&lt;script&gt;...&lt;/script&gt;"
+      />
+      <Label size="L">
+        CSP whitelist<br />
+        <Link href="https://docs.budibase.com/docs/app-scripts" target="_blank">
+          Learn more
+        </Link>
+      </Label>
+      <TextArea
+        bind:value={selectedScript.cspWhitelist}
+        minHeight={100}
+        placeholder="https://external.api.com&#013;https://*.domain.com"
       />
       <div />
       <div class="buttons">

--- a/packages/server/src/api/index.ts
+++ b/packages/server/src/api/index.ts
@@ -1,5 +1,10 @@
 import Router from "@koa/router"
-import { auth, middleware, env as envCore } from "@budibase/backend-core"
+import {
+  auth,
+  middleware,
+  env as envCore,
+  env as coreEnv,
+} from "@budibase/backend-core"
 import currentApp from "../middleware/currentapp"
 import cleanup from "../middleware/cleanup"
 import zlib from "zlib"
@@ -66,9 +71,13 @@ if (apiEnabled()) {
     )
     .use(pro.licensing())
     .use(currentApp)
-    .use(auth.auditLog)
-    .use(migrations)
-    .use(cleanup)
+
+  // Add CSP as soon as possible - depends on licensing and currentApp
+  if (!coreEnv.DISABLE_CONTENT_SECURITY_POLICY) {
+    router.use(middleware.csp)
+  }
+
+  router.use(auth.auditLog).use(migrations).use(cleanup)
 
   // authenticated routes
   for (let route of mainRoutes) {

--- a/packages/server/src/koa.ts
+++ b/packages/server/src/koa.ts
@@ -6,13 +6,7 @@ import * as api from "./api"
 import * as automations from "./automations"
 import { Thread } from "./threads"
 import * as redis from "./utilities/redis"
-import {
-  events,
-  logging,
-  middleware,
-  timers,
-  env as coreEnv,
-} from "@budibase/backend-core"
+import { events, logging, middleware, timers } from "@budibase/backend-core"
 import destroyable from "server-destroy"
 import { userAgent } from "koa-useragent"
 
@@ -43,9 +37,6 @@ export default function createKoaApp() {
   app.use(middleware.correlation)
   app.use(middleware.pino)
   app.use(middleware.ip)
-  if (!coreEnv.DISABLE_CONTENT_SECURITY_POLICY) {
-    app.use(middleware.csp)
-  }
   app.use(userAgent)
 
   const server = http.createServer(app.callback())

--- a/packages/types/src/documents/app/app.ts
+++ b/packages/types/src/documents/app/app.ts
@@ -89,4 +89,5 @@ export interface AppScript {
   name: string
   location: "Head" | "Body"
   html?: string
+  cspWhitelist?: string
 }


### PR DESCRIPTION
## Description
Opening for testing in feature branches.

This PR adds the ability to specify domains to be added to the content security policy, allowing resources and AJAX requests to domains which would otherwise be blocked. These domains are added to the `default-src` CSP directive, whitelisting them for most common use cases.

Notes on usage:
- If you add a third party script from an external domain in a custom app script, you *do not* need to also add that domain to the CSP whitelist, because the custom app script feature uses a nonce to automatically authenticate that resource
- The CSP is active in cloud and active by default in self host, but it can be disabled in self host. If disabled, you don't need this feature because all domains will be allowed.
- You only need this feature if the scripts you add either fetch additional resources at runtime from other domains or make requests to other domains

TODO: get docs written about this feature and add link to frontend.

![image](https://github.com/user-attachments/assets/08694736-329a-4d63-9dc5-b0665ef57375)
![image](https://github.com/user-attachments/assets/0dda301e-c7d3-4ac7-bdb6-2e82643e13d3)