### PR TITLE
updates column name in import modal

### DIFF
--- a/packages/builder/src/components/backend/TableNavigator/TableDataImport.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/TableDataImport.svelte
@@ -38,7 +38,7 @@
       },
     },
     [FIELDS.OPTIONS.type]: {
-      label: "Single-select",
+      label: "Single select",
       value: FIELDS.OPTIONS.type,
       config: {
         type: FIELDS.OPTIONS.type,
@@ -46,7 +46,7 @@
       },
     },
     [FIELDS.ARRAY.type]: {
-      label: "Multi-select",
+      label: "Multi select",
       value: FIELDS.ARRAY.type,
       config: {
         type: FIELDS.ARRAY.type,

--- a/packages/builder/src/components/backend/TableNavigator/TableDataImport.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/TableDataImport.svelte
@@ -38,7 +38,7 @@
       },
     },
     [FIELDS.OPTIONS.type]: {
-      label: "Options",
+      label: "Single-select",
       value: FIELDS.OPTIONS.type,
       config: {
         type: FIELDS.OPTIONS.type,


### PR DESCRIPTION
## Description
Updates the name of the single-option olumn type in the Import CSV modal from Options to Single-select in order to conform with column types in the internal database.

## Addresses
https://github.com/Budibase/budibase/issues/15904
## Screenshots
Before
![image](https://github.com/user-attachments/assets/85cc5701-10e4-4efe-9cac-0aee670e432b)

After
![image](https://github.com/user-attachments/assets/9b78aa47-f3f7-4714-a048-107ef29d9a94)


## Launchcontrol
_Improves column-type conformity in TableDataImport modal._
