### PR TITLE
Make Proxy Timeouts Configurable via PROXY_TIMEOUT_SECONDS

### DIFF
--- a/hosting/proxy/Dockerfile
+++ b/hosting/proxy/Dockerfile
@@ -17,6 +17,7 @@ COPY error.html /usr/share/nginx/html/error.html
 # Default environment
 ENV PROXY_RATE_LIMIT_WEBHOOKS_PER_SECOND=10
 ENV PROXY_RATE_LIMIT_API_PER_SECOND=20
+ENV PROXY_TIMEOUT_SECONDS=120
 # Use docker-compose values as defaults for backwards compatibility
 ENV APPS_UPSTREAM_URL=http://app-service:4002
 ENV WORKER_UPSTREAM_URL=http://worker-service:4003

--- a/hosting/proxy/nginx.prod.conf
+++ b/hosting/proxy/nginx.prod.conf
@@ -144,9 +144,9 @@ http {
       limit_req zone=ratelimit burst=20 nodelay;
 
       # 120s timeout on API requests
-      proxy_read_timeout 120s;
-      proxy_connect_timeout 120s;
-      proxy_send_timeout 120s;
+      proxy_read_timeout ${PROXY_TIMEOUT_SECONDS}s;
+      proxy_connect_timeout ${PROXY_TIMEOUT_SECONDS}s;
+      proxy_send_timeout ${PROXY_TIMEOUT_SECONDS}s;
 
       proxy_http_version  1.1;
       proxy_set_header    Connection          $connection_upgrade;
@@ -164,9 +164,9 @@ http {
 
       # Rest of configuration copied from /api/ location above
       # 120s timeout on API requests
-      proxy_read_timeout 120s;
-      proxy_connect_timeout 120s;
-      proxy_send_timeout 120s;
+      proxy_read_timeout ${PROXY_TIMEOUT_SECONDS}s;
+      proxy_connect_timeout ${PROXY_TIMEOUT_SECONDS}s;
+      proxy_send_timeout ${PROXY_TIMEOUT_SECONDS}s;
 
       proxy_http_version  1.1;
       proxy_set_header    Connection          $connection_upgrade;


### PR DESCRIPTION
## Description
This PR introduces the ability to configure the proxy timeout settings via an environment variable, `PROXY_TIMEOUT_SECONDS`. The following are now set by this environment variable.:
- proxy_read_timeout
- proxy_connect_timeout
- proxy_send_timeout

## Launchcontrol
This change allows the timeout settings for how long the proxy waits during certain operations to be controlled using an environment variable instead of manually updating configuration files each time.


