### PR TITLE
Ensure that creators only include users with the creator role

### DIFF
--- a/packages/backend-core/src/security/roles.ts
+++ b/packages/backend-core/src/security/roles.ts
@@ -26,7 +26,6 @@ export const BUILTIN_ROLE_IDS = {
   POWER: "POWER",
   BASIC: "BASIC",
   PUBLIC: "PUBLIC",
-  CREATOR: "CREATOR",
 }
 
 const BUILTIN_IDS = {

--- a/packages/backend-core/src/security/roles.ts
+++ b/packages/backend-core/src/security/roles.ts
@@ -26,6 +26,7 @@ export const BUILTIN_ROLE_IDS = {
   POWER: "POWER",
   BASIC: "BASIC",
   PUBLIC: "PUBLIC",
+  CREATOR: "CREATOR",
 }
 
 const BUILTIN_IDS = {

--- a/packages/backend-core/src/users/test/utils.spec.ts
+++ b/packages/backend-core/src/users/test/utils.spec.ts
@@ -37,7 +37,7 @@ describe("Users", () => {
     expect(isCreatorSync(user, [])).toBe(false)
   })
 
-  it("User is a creator if it remains to a group with ADMIN permissions", async () => {
+  it("User is a not a creator if it remains to a group with ADMIN permissions", async () => {
     const usersInGroup = 10
     const groupId = "gr_17abffe89e0b40268e755b952f101a59"
     const group: UserGroup = {
@@ -60,7 +60,7 @@ describe("Users", () => {
       for (let user of users) {
         await db.put(user)
         const creator = (await creatorsInList([user]))[0]
-        expect(creator).toBe(true)
+        expect(creator).toBe(false)
       }
     })
   })

--- a/packages/backend-core/src/users/test/utils.spec.ts
+++ b/packages/backend-core/src/users/test/utils.spec.ts
@@ -32,9 +32,9 @@ describe("Users", () => {
     expect(isCreatorSync(user, [])).toBe(true)
   })
 
-  it("User is a creator if it has ADMIN permission in some application", () => {
+  it("User is a not a creator if it has ADMIN permission in some application", () => {
     const user: User = structures.users.user({ roles: { app1: "ADMIN" } })
-    expect(isCreatorSync(user, [])).toBe(true)
+    expect(isCreatorSync(user, [])).toBe(false)
   })
 
   it("User is a creator if it remains to a group with ADMIN permissions", async () => {

--- a/packages/backend-core/src/users/utils.ts
+++ b/packages/backend-core/src/users/utils.ts
@@ -4,7 +4,6 @@ import env from "../environment"
 import { getExistingAccounts, getFirstPlatformUser } from "./lookup"
 import { EmailUnavailableError } from "../errors"
 import { sdk } from "@budibase/shared-core"
-import { BUILTIN_ROLE_IDS } from "../security/roles"
 import * as context from "../context"
 
 // extract from shared-core to make easily accessible from backend-core

--- a/packages/backend-core/src/users/utils.ts
+++ b/packages/backend-core/src/users/utils.ts
@@ -57,7 +57,7 @@ function isCreatorByGroupMembership(
   )
   if (userGroups && userGroups.length > 0) {
     return userGroups.some(group =>
-      Object.values(group.roles || {}).includes(BUILTIN_ROLE_IDS.CREATOR)
+      Object.values(group.roles || {}).includes("CREATOR")
     )
   }
   return false

--- a/packages/backend-core/src/users/utils.ts
+++ b/packages/backend-core/src/users/utils.ts
@@ -57,7 +57,7 @@ function isCreatorByGroupMembership(
   )
   if (userGroups && userGroups.length > 0) {
     return userGroups.some(group =>
-      Object.values(group.roles || {}).includes(BUILTIN_ROLE_IDS.ADMIN)
+      Object.values(group.roles || {}).includes(BUILTIN_ROLE_IDS.CREATOR)
     )
   }
   return false

--- a/packages/builder/src/pages/builder/app/[application]/_components/BuilderSidePanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/_components/BuilderSidePanel.svelte
@@ -524,7 +524,7 @@
       return `This user has been given ${role?.name} access from the ${user.group} group`
     }
     if (user.isAdminOrGlobalBuilder) {
-      return "Account admins can edit all apps"
+      return "Workspace admins can edit all apps"
     }
     return null
   }

--- a/packages/frontend-core/src/constants.ts
+++ b/packages/frontend-core/src/constants.ts
@@ -52,9 +52,9 @@ export const BudibaseRoleOptionsOld = [
 ]
 export const BudibaseRoleOptions = [
   {
-    label: "Account admin",
+    label: "Workspace admin",
     value: BudibaseRoles.Admin,
-    subtitle: "Has full access to all apps and settings in your account",
+    subtitle: "Has full access to all apps and settings in your workspace",
     sortOrder: 1,
   },
   {

--- a/packages/shared-core/src/sdk/documents/users.ts
+++ b/packages/shared-core/src/sdk/documents/users.ts
@@ -68,7 +68,7 @@ export function hasAppCreatorPermissions(user?: User | ContextUser): boolean {
   return _.flow(
     _.get("roles"),
     _.values,
-    _.find(x => ["CREATOR", "ADMIN"].includes(x)),
+    _.find(x => ["CREATOR"].includes(x)),
     x => !!x
   )(user)
 }


### PR DESCRIPTION
## Description
Fixes a bug where app users with the app-level admin role were incorrectly counted as creators.

Also updates the labels from "Account admin" to "Workspace admin" to better reflect intent.

## Addresses
- https://linear.app/budibase/issue/GRO-1111/ensure-that-creators-only-include-users-with-the-creator-roles-or-the
- https://linear.app/budibase/issue/GRO-1110/change-account-admin-label-to-workspace-admin

## Screenshots
https://github.com/user-attachments/assets/7244d573-c97a-42a7-a6b5-c0cb8db3da92


## Launchcontrol
Bug fix relating to creator count
