### PR TITLE
Provide user with context if license key has already been activated

### DIFF
--- a/packages/builder/src/pages/builder/portal/account/upgrade.svelte
+++ b/packages/builder/src/pages/builder/portal/account/upgrade.svelte
@@ -71,7 +71,11 @@
       notifications.success("Successfully activated")
     } catch (e) {
       console.error(e)
-      notifications.error("Error activating license key")
+      if (e?.status === 409) {
+        notifications.error(e.message)
+      } else {
+        notifications.error("Error activating license key")
+      }
     }
   }
 


### PR DESCRIPTION
## Description
If a license key has already been activated, inform the user. 

## Addresses
- https://linear.app/budibase/issue/GRO-879/strange-ux-for-used-license-keys

## Screenshot
<img width="1510" alt="Screenshot 2025-04-10 at 09 49 13" src="https://github.com/user-attachments/assets/b8b73305-04d3-48f8-9d43-80e27588a696" />
