### PR TITLE
Expose LLM provider config via /api/global/self.

### DIFF
--- a/packages/types/src/api/web/global/self.ts
+++ b/packages/types/src/api/web/global/self.ts
@@ -1,4 +1,4 @@
-import { License } from "../../../sdk"
+import { License, LLMProviderConfig } from "../../../sdk"
 import { Account, DevInfo, User } from "../../../documents"
 import { FeatureFlags } from "@budibase/types"
 
@@ -11,6 +11,7 @@ export interface FetchAPIKeyResponse extends DevInfo {}
 
 export interface GetGlobalSelfResponse extends User {
   flags?: FeatureFlags
+  llm?: Omit<LLMProviderConfig, "apiKey">
   account?: Account
   license: License
   budibaseAccess: boolean

--- a/packages/types/src/sdk/ai.ts
+++ b/packages/types/src/sdk/ai.ts
@@ -1,3 +1,5 @@
+import { AIProvider } from "../documents"
+
 export enum AIOperationEnum {
   SUMMARISE_TEXT = "SUMMARISE_TEXT",
   CLEAN_DATA = "CLEAN_DATA",
@@ -89,3 +91,13 @@ export type AIColumnSchema =
   | SentimentAnalysisSchema
   | PromptSchema
   | SearchWebSchema
+
+export interface LLMConfigOptions {
+  model: string
+  apiKey: string
+  measureUsage: boolean
+}
+
+export interface LLMProviderConfig extends LLMConfigOptions {
+  provider: AIProvider
+}

--- a/packages/worker/src/api/controllers/global/self.ts
+++ b/packages/worker/src/api/controllers/global/self.ts
@@ -8,7 +8,7 @@ import {
   auth as authCore,
 } from "@budibase/backend-core"
 import env from "../../../environment"
-import { groups } from "@budibase/pro"
+import { ai, groups } from "@budibase/pro"
 import {
   DevInfo,
   FetchAPIKeyResponse,
@@ -115,11 +115,20 @@ export async function getSelf(ctx: UserCtx<void, GetGlobalSelfResponse>) {
 
   // add the feature flags for this tenant
   const flags = await features.flags.fetch()
+  const llmConfig = await ai.getLLMConfig()
+  const sanitisedLLMConfig = llmConfig
+    ? {
+        provider: llmConfig.provider,
+        model: llmConfig.model,
+        measureUsage: llmConfig.measureUsage,
+      }
+    : undefined
 
   ctx.body = {
     ...enrichedUser,
     ...sessionAttributes,
     flags,
+    llm: sanitisedLLMConfig,
   }
 }
 


### PR DESCRIPTION
## Description

This is so that the frontend can know if the user has an AI provider configured and, if not, show the right calls to action in the UI.

## Addresses
- https://linear.app/budibase/issue/BUDI-9244/expose-current-llm-provider-in-apiself
