### PR TITLE
Capture codegen accept/reject events in PostHog.

### DIFF
--- a/packages/builder/src/analytics/constants.ts
+++ b/packages/builder/src/analytics/constants.ts
@@ -3,6 +3,8 @@ export const Events = {
   COMPONENT_UPDATED: "component:updated",
   APP_VIEW_PUBLISHED: "app:view_published",
   BLOCK_EJECTED: "block:ejected",
+  AI_JS_ACCEPTED: "ai_js:accepted",
+  AI_JS_REJECTED: "ai_js:rejected",
 }
 
 export const EventSource = {

--- a/packages/builder/src/components/common/CodeEditor/AIGen.svelte
+++ b/packages/builder/src/components/common/CodeEditor/AIGen.svelte
@@ -4,6 +4,7 @@
   import { API } from "@/api"
   import type { EnrichedBinding } from "@budibase/types"
   import BBAI from "assets/bb-ai.svg"
+  import analytics, { Events } from "@/analytics"
 
   export let bindings: EnrichedBinding[] = []
   export let value: string | null = ""
@@ -64,11 +65,19 @@
   }
 
   function acceptSuggestion() {
+    analytics.captureEvent(Events.AI_JS_ACCEPTED, {
+      code: suggestedCode,
+      prompt: promptText,
+    })
     dispatch("accept")
     resetExpand()
   }
 
   function rejectSuggestion() {
+    analytics.captureEvent(Events.AI_JS_REJECTED, {
+      code: suggestedCode,
+      prompt: promptText,
+    })
     dispatch("reject", { code: previousContents })
     resetExpand()
   }


### PR DESCRIPTION
## Description

Creates analytics events for whether users accept or reject code generated with LLMs, so we can track whether changes are improving quality or not.

## Addresses
- https://linear.app/budibase/issue/BUDI-9145/send-events-to-posthog-on-acceptreject-of-ai-suggestions
