### PR TITLE
Hide Day Passes

### DIFF
--- a/packages/builder/src/pages/builder/portal/account/usage.svelte
+++ b/packages/builder/src/pages/builder/portal/account/usage.svelte
@@ -32,6 +32,7 @@
   const oneDayInSeconds = 86400
 
   const EXCLUDE_QUOTAS = {
+    ["Day Passes"]: () => true,
     Queries: () => true,
     Users: license => {
       return license.plan.model !== PlanModel.PER_USER


### PR DESCRIPTION
## Description
Day Passes are no longer used, so should be hidden from the UI

## Addresses
- https://linear.app/budibase/issue/GRO-1140/remove-day-passes-from-ui

## Screenshots
![Screenshot 2025-04-15 at 11 32 18](https://github.com/user-attachments/assets/c13ff1d4-e043-44bd-8f15-cf24249664f6)

## Launchcontrol
Hide Day Passes from usage UI
