### PR TITLE
Further UX updates for the AI JS generation

### DIFF
--- a/packages/builder/src/components/common/CodeEditor/AIGen.svelte
+++ b/packages/builder/src/components/common/CodeEditor/AIGen.svelte
@@ -14,28 +14,15 @@
     reject: { code: string | null }
   }>()
 
-  let buttonContainer: HTMLElement
-  let promptInput: HTMLTextAreaElement
+  let promptInput: HTMLInputElement
   let buttonElement: HTMLButtonElement
   let promptLoading = false
   let suggestedCode: string | null = null
   let previousContents: string | null = null
   let expanded = false
   let containerWidth = "auto"
-  let containerHeight = "40px"
   let promptText = ""
   let animateBorder = false
-
-  function adjustContainerHeight() {
-    if (promptInput && buttonElement) {
-      promptInput.style.height = "0px"
-      const newHeight = Math.min(promptInput.scrollHeight, 100)
-      promptInput.style.height = `${newHeight}px`
-      containerHeight = `${Math.max(40, newHeight + 20)}px`
-    }
-  }
-
-  $: if (promptInput && promptText) adjustContainerHeight()
 
   async function generateJs(prompt: string) {
     if (!prompt.trim()) return
@@ -76,7 +63,6 @@
   function resetExpand() {
     expanded = false
     containerWidth = "auto"
-    containerHeight = "40px"
     promptText = ""
     suggestedCode = null
     previousContents = null
@@ -91,7 +77,6 @@
       containerWidth = parentWidth
         ? `${Math.min(Math.max(parentWidth * 0.8, 300), 600)}px`
         : "300px"
-      containerHeight = "40px"
       setTimeout(() => {
         promptInput?.focus()
       }, 250)
@@ -116,11 +101,7 @@
   }
 </script>
 
-<div
-  class="ai-gen-container"
-  style="--container-width: {containerWidth}; --container-height: {containerHeight}"
-  bind:this={buttonContainer}
->
+<div class="ai-gen-container" style="--container-width: {containerWidth}">
   {#if suggestedCode !== null}
     <div class="floating-actions">
       <ActionButton size="S" icon="CheckmarkCircle" on:click={acceptSuggestion}>
@@ -142,16 +123,15 @@
     <div class="button-content-wrapper">
       <img src={BBAI} alt="AI" class="ai-icon" />
       {#if expanded}
-        <textarea
+        <input
+          type="text"
           bind:this={promptInput}
           bind:value={promptText}
           class="prompt-input"
           placeholder="Generate Javascript..."
           on:keydown={handleKeyPress}
-          on:input={adjustContainerHeight}
           disabled={suggestedCode !== null}
           readonly={suggestedCode !== null}
-          rows="1"
         />
       {:else}
         <span class="spectrum-ActionButton-label ai-gen-text">
@@ -189,13 +169,12 @@
 
 <style>
   .ai-gen-container {
+    height: 40px;
     --container-width: auto;
-    --container-height: 40px;
     position: absolute;
     right: 10px;
     bottom: 10px;
     width: var(--container-width);
-    height: var(--container-height);
     display: flex;
     overflow: visible;
   }
@@ -229,7 +208,7 @@
     background: linear-gradient(
       125deg,
       transparent -10%,
-      #6e56ff 5%,
+      #6e56ff 2%,
       #9f8fff 15%,
       #9f8fff 25%,
       transparent 35%,
@@ -326,18 +305,16 @@
     border: none;
     background: transparent;
     outline: none;
-    font-size: var(--font-size-s);
     font-family: var(--font-sans);
     color: var(--spectrum-alias-text-color);
     min-width: 0;
     resize: none;
     overflow: hidden;
-    line-height: 1.2;
-    min-height: 10px !important;
   }
 
   .prompt-input::placeholder {
     color: var(--spectrum-global-color-gray-600);
+    font-family: var(--font-sans);
   }
 
   .action-buttons {

--- a/packages/builder/src/components/common/CodeEditor/AIGen.svelte
+++ b/packages/builder/src/components/common/CodeEditor/AIGen.svelte
@@ -424,8 +424,4 @@
     filter: grayscale(1) brightness(1.5);
     opacity: 0.5;
   }
-
-  :global(.ai-gen-container[expandedonly]) .ai-icon {
-    cursor: default;
-  }
 </style>

--- a/packages/builder/src/components/common/CodeEditor/AIGen.svelte
+++ b/packages/builder/src/components/common/CodeEditor/AIGen.svelte
@@ -37,10 +37,12 @@
   let creditsExceeded = false // TODO: Make this computed when quota is implemented
   let switchOnAIModal: Modal
   let addCreditsModal: Modal
+  export let expandedOnly: boolean = false
 
   $: accountPortalAccess = $auth?.user?.accountPortalAccess
   $: accountPortal = $admin.accountPortalUrl
   $: aiEnabled = !!$auth?.user?.llm
+  $: expanded = expandedOnly ? true : expanded
 
   async function generateJs(prompt: string) {
     if (!prompt.trim()) return
@@ -146,10 +148,12 @@
         class="ai-icon"
         class:disabled={expanded &&
           (suggestedCode !== null || !aiEnabled || creditsExceeded)}
-        on:click={e => {
-          e.stopPropagation()
-          toggleExpand()
-        }}
+        on:click={!expandedOnly
+          ? e => {
+              e.stopPropagation()
+              toggleExpand()
+            }
+          : undefined}
       />
       {#if expanded}
         <input
@@ -347,7 +351,7 @@
     height: 18px;
     margin-right: 8px;
     flex-shrink: 0;
-    cursor: pointer;
+    cursor: var(--ai-icon-cursor, pointer);
   }
 
   .ai-gen-text {
@@ -403,5 +407,9 @@
   .ai-icon.disabled {
     filter: grayscale(1) brightness(1.5);
     opacity: 0.5;
+  }
+
+  :global(.ai-gen-container[expandedonly]) .ai-icon {
+    cursor: default;
   }
 </style>

--- a/packages/builder/src/components/common/CodeEditor/AIGen.svelte
+++ b/packages/builder/src/components/common/CodeEditor/AIGen.svelte
@@ -42,8 +42,11 @@
 
   $: accountPortalAccess = $auth?.user?.accountPortalAccess
   $: accountPortal = $admin.accountPortalUrl
-  $: aiEnabled = !!$auth?.user?.llm
+  $: aiEnabled = false
   $: expanded = expandedOnly ? true : expanded
+  $: if (expandedOnly) {
+    containerWidth = calculateExpandedWidth()
+  }
 
   async function generateJs(prompt: string) {
     if (!prompt.trim()) return
@@ -90,14 +93,17 @@
     animateBorder = false
   }
 
+  function calculateExpandedWidth() {
+    return parentWidth
+      ? `${Math.min(Math.max(parentWidth * 0.8, 300), 600)}px`
+      : "300px"
+  }
+
   function toggleExpand() {
     if (!expanded) {
       expanded = true
       animateBorder = true
-      // Calculate width based on size of parent
-      containerWidth = parentWidth
-        ? `${Math.min(Math.max(parentWidth * 0.8, 300), 600)}px`
-        : "300px"
+      containerWidth = calculateExpandedWidth()
       setTimeout(() => {
         promptInput?.focus()
       }, 250)

--- a/packages/builder/src/components/common/CodeEditor/AIGen.svelte
+++ b/packages/builder/src/components/common/CodeEditor/AIGen.svelte
@@ -9,7 +9,7 @@
     Body,
     Link,
   } from "@budibase/bbui"
-  import { auth, admin } from "@/stores/portal"
+  import { auth, admin, licensing } from "@/stores/portal"
 
   import { createEventDispatcher } from "svelte"
   import { API } from "@/api"
@@ -36,14 +36,15 @@
   let containerWidth = "auto"
   let promptText = ""
   let animateBorder = false
-  let creditsExceeded = false // TODO: Make this computed when quota is implemented
   let switchOnAIModal: Modal
   let addCreditsModal: Modal
 
   $: accountPortalAccess = $auth?.user?.accountPortalAccess
   $: accountPortal = $admin.accountPortalUrl
-  $: aiEnabled = false
+  $: aiEnabled = $auth?.user?.llm
   $: expanded = expandedOnly ? true : expanded
+  $: creditsExceeded = $licensing.aiCreditsExceeded
+  $: disabled = suggestedCode !== null || !aiEnabled || creditsExceeded
   $: if (expandedOnly) {
     containerWidth = calculateExpandedWidth()
   }
@@ -153,8 +154,7 @@
         src={BBAI}
         alt="AI"
         class="ai-icon"
-        class:disabled={expanded &&
-          (suggestedCode !== null || !aiEnabled || creditsExceeded)}
+        class:disabled={expanded && disabled}
         on:click={!expandedOnly
           ? e => {
               e.stopPropagation()
@@ -170,7 +170,7 @@
           class="prompt-input"
           placeholder="Generate Javascript..."
           on:keydown={handleKeyPress}
-          disabled={suggestedCode !== null || !aiEnabled || creditsExceeded}
+          {disabled}
           readonly={suggestedCode !== null}
         />
       {:else}

--- a/packages/builder/src/components/common/CodeEditor/AIGen.svelte
+++ b/packages/builder/src/components/common/CodeEditor/AIGen.svelte
@@ -22,20 +22,27 @@
   let previousContents: string | null = null
   let expanded = false
   let containerWidth = "auto"
-  let containerHeight = "40px"
+  let containerHeight = "44px"
   let promptText = ""
   let animateBorder = false
-
   function adjustContainerHeight() {
     if (promptInput && buttonElement) {
+      if (!promptText.trim()) {
+        promptInput.style.height = "24px"
+        containerHeight = "44px"
+        return
+      }
+
       promptInput.style.height = "0px"
       const newHeight = Math.min(promptInput.scrollHeight, 100)
       promptInput.style.height = `${newHeight}px`
-      containerHeight = `${Math.max(40, newHeight + 20)}px`
+      containerHeight = `${Math.max(44, newHeight + 18)}px`
+    } else if (!promptInput) {
+      containerHeight = "44px"
     }
   }
 
-  $: if (promptInput && promptText) adjustContainerHeight()
+  $: if (promptInput) adjustContainerHeight()
 
   async function generateJs(prompt: string) {
     if (!prompt.trim()) return
@@ -76,7 +83,7 @@
   function resetExpand() {
     expanded = false
     containerWidth = "auto"
-    containerHeight = "40px"
+    containerHeight = "44px"
     promptText = ""
     suggestedCode = null
     previousContents = null
@@ -91,7 +98,7 @@
       containerWidth = parentWidth
         ? `${Math.min(Math.max(parentWidth * 0.8, 300), 600)}px`
         : "300px"
-      containerHeight = "40px"
+      containerHeight = "44px"
       setTimeout(() => {
         promptInput?.focus()
       }, 250)
@@ -190,7 +197,7 @@
 <style>
   .ai-gen-container {
     --container-width: auto;
-    --container-height: 40px;
+    --container-height: 44px;
     position: absolute;
     right: 10px;
     bottom: 10px;
@@ -229,7 +236,7 @@
     background: linear-gradient(
       125deg,
       transparent -10%,
-      #6e56ff 5%,
+      #6e56ff 2%,
       #9f8fff 15%,
       #9f8fff 25%,
       transparent 35%,
@@ -332,7 +339,9 @@
     min-width: 0;
     resize: none;
     overflow: hidden;
-    line-height: 1.2;
+    line-height: 1.3;
+    padding: 6px 0 0 0;
+    height: 24px;
     min-height: 10px !important;
   }
 

--- a/packages/builder/src/components/common/CodeEditor/AIGen.svelte
+++ b/packages/builder/src/components/common/CodeEditor/AIGen.svelte
@@ -24,7 +24,7 @@
     accept: void
     reject: { code: string | null }
   }>()
-
+  $: console.log($auth.user?.llm)
   let promptInput: HTMLInputElement
   let buttonElement: HTMLButtonElement
   let promptLoading = false
@@ -34,13 +34,13 @@
   let containerWidth = "auto"
   let promptText = ""
   let animateBorder = false
-  let aiEnabled = false
   let creditsExceeded = false // TODO: Make this computed when quota is implemented
   let switchOnAIModal: Modal
   let addCreditsModal: Modal
 
   $: accountPortalAccess = $auth?.user?.accountPortalAccess
   $: accountPortal = $admin.accountPortalUrl
+  $: aiEnabled = !!$auth?.user?.llm
 
   async function generateJs(prompt: string) {
     if (!prompt.trim()) return
@@ -144,6 +144,8 @@
         src={BBAI}
         alt="AI"
         class="ai-icon"
+        class:disabled={expanded &&
+          (suggestedCode !== null || !aiEnabled || creditsExceeded)}
         on:click={e => {
           e.stopPropagation()
           toggleExpand()
@@ -378,6 +380,7 @@
     gap: var(--spacing-s);
     z-index: 4;
     flex-shrink: 0;
+    margin-right: var(--spacing-s);
   }
 
   .button-content-wrapper {
@@ -395,5 +398,10 @@
   .prompt-input[readonly] {
     color: var(--spectrum-global-color-gray-500);
     cursor: not-allowed;
+  }
+
+  .ai-icon.disabled {
+    filter: grayscale(1) brightness(1.5);
+    opacity: 0.5;
   }
 </style>

--- a/packages/builder/src/components/common/CodeEditor/AIGen.svelte
+++ b/packages/builder/src/components/common/CodeEditor/AIGen.svelte
@@ -18,13 +18,15 @@
 
   export let bindings: EnrichedBinding[] = []
   export let value: string | null = ""
+  export let expandedOnly: boolean = false
+
   export let parentWidth: number | null = null
   export const dispatch = createEventDispatcher<{
     update: { code: string }
     accept: void
     reject: { code: string | null }
   }>()
-  $: console.log($auth.user?.llm)
+
   let promptInput: HTMLInputElement
   let buttonElement: HTMLButtonElement
   let promptLoading = false
@@ -37,7 +39,6 @@
   let creditsExceeded = false // TODO: Make this computed when quota is implemented
   let switchOnAIModal: Modal
   let addCreditsModal: Modal
-  export let expandedOnly: boolean = false
 
   $: accountPortalAccess = $auth?.user?.accountPortalAccess
   $: accountPortal = $admin.accountPortalUrl

--- a/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
+++ b/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
@@ -469,6 +469,7 @@
 
 {#if aiGenEnabled}
   <AIGen
+    expandedOnly={true}
     {bindings}
     {value}
     parentWidth={editorWidth}

--- a/packages/builder/src/stores/portal/licensing.ts
+++ b/packages/builder/src/stores/portal/licensing.ts
@@ -56,7 +56,9 @@ interface LicensingState {
   // user limits
   userCount?: number
   userLimit?: number
+  aiCreditsLimit?: number
   userLimitReached: boolean
+  aiCreditsExceeded: boolean
   errUserLimit: boolean
 }
 
@@ -102,6 +104,8 @@ class LicensingStore extends BudiStore<LicensingState> {
       userLimit: undefined,
       userLimitReached: false,
       errUserLimit: false,
+      // AI Limits
+      aiCreditsExceeded: false,
     })
   }
 
@@ -117,6 +121,16 @@ class LicensingStore extends BudiStore<LicensingState> {
       return false
     }
     return userCount > userLimit
+  }
+
+  aiCreditsExceeded(
+    aiCredits: number,
+    aiCreditsLimit = get(this.store).aiCreditsLimit
+  ) {
+    if (aiCreditsLimit === UNLIMITED || aiCreditsLimit === undefined) {
+      return false
+    }
+    return aiCredits > aiCreditsLimit
   }
 
   async isCloud() {
@@ -291,9 +305,15 @@ class LicensingStore extends BudiStore<LicensingState> {
 
     const userQuota = license.quotas.usage.static.users
     const userLimit = userQuota.value
+    const aiCreditsQuota = license.quotas.usage.monthly.budibaseAICredits
+    const aiCreditsLimit = aiCreditsQuota.value
     const userCount = usage.usageQuota.users
     const userLimitReached = this.usersLimitReached(userCount, userLimit)
     const userLimitExceeded = this.usersLimitExceeded(userCount, userLimit)
+    const aiCreditsExceeded = this.aiCreditsExceeded(
+      usage.monthly.current.budibaseAICredits,
+      aiCreditsLimit
+    )
     const isCloudAccount = await this.isCloud()
     const errUserLimit =
       isCloudAccount &&
@@ -315,6 +335,8 @@ class LicensingStore extends BudiStore<LicensingState> {
         userLimit,
         userLimitReached,
         errUserLimit,
+        aiCreditsLimit,
+        aiCreditsExceeded,
       }
     })
   }


### PR DESCRIPTION
## Description
Updates some of the UI around the BB AI generation work:

- Now using an input instead of a textarea, and therefore was able to remove a lot of complexity around adjusting the container size
- Setting the prompt to be always open
- Removed the `X` icon to close in favour of clicking the BBAI icon 
 

As well as adding states for:

- If AI is not enabled then we show a CTA that opens a modal telling the user to enable it
- If the user has ran out of credits then we show a CTA informing then that they need to add more credits, we need the actual quota logic to be implemented for this, I think? This is currently disabled from showing. 

- ## Screenshots
![image](https://github.com/user-attachments/assets/9f0afed6-129b-4516-b02b-4ecf87918264)
![image](https://github.com/user-attachments/assets/f2ca3866-6269-4916-ae4b-e94d5824bb76)
![image](https://github.com/user-attachments/assets/0b2bf198-c98d-4e35-84f8-ba24301c6329)

