### PR TITLE
Show AI JS prompt in expanded state when in drawer

### DIFF
--- a/packages/builder/src/components/common/CodeEditor/AIGen.svelte
+++ b/packages/builder/src/components/common/CodeEditor/AIGen.svelte
@@ -40,12 +40,14 @@
   let switchOnAIModal: Modal
   let addCreditsModal: Modal
 
+  const thresholdExpansionWidth = 350
   $: accountPortalAccess = $auth?.user?.accountPortalAccess
   $: accountPortal = $admin.accountPortalUrl
   $: aiEnabled = $auth?.user?.llm
 
   $: expanded =
-    expandedOnly || (parentWidth !== null && parentWidth > 450)
+    expandedOnly ||
+    (parentWidth !== null && parentWidth > thresholdExpansionWidth)
       ? true
       : expanded
 
@@ -54,7 +56,7 @@
 
   $: if (
     expandedOnly ||
-    (expanded && parentWidth !== null && parentWidth > 350)
+    (expanded && parentWidth !== null && parentWidth > thresholdExpansionWidth)
   ) {
     containerWidth = calculateExpandedWidth()
   } else if (!expanded) {

--- a/packages/builder/src/components/common/CodeEditor/AIGen.svelte
+++ b/packages/builder/src/components/common/CodeEditor/AIGen.svelte
@@ -43,11 +43,22 @@
   $: accountPortalAccess = $auth?.user?.accountPortalAccess
   $: accountPortal = $admin.accountPortalUrl
   $: aiEnabled = $auth?.user?.llm
-  $: expanded = expandedOnly ? true : expanded
+
+  $: expanded =
+    expandedOnly || (parentWidth !== null && parentWidth > 450)
+      ? true
+      : expanded
+
   $: creditsExceeded = $licensing.aiCreditsExceeded
   $: disabled = suggestedCode !== null || !aiEnabled || creditsExceeded
-  $: if (expandedOnly) {
+
+  $: if (
+    expandedOnly ||
+    (expanded && parentWidth !== null && parentWidth > 350)
+  ) {
     containerWidth = calculateExpandedWidth()
+  } else if (!expanded) {
+    containerWidth = "auto"
   }
 
   async function generateJs(prompt: string) {

--- a/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
+++ b/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
@@ -443,7 +443,6 @@
     const resizeObserver = new ResizeObserver(() => {
       updateEditorWidth()
     })
-
     resizeObserver.observe(editorEle)
     return () => {
       resizeObserver.disconnect()
@@ -469,7 +468,6 @@
 
 {#if aiGenEnabled}
   <AIGen
-    expandedOnly={true}
     {bindings}
     {value}
     parentWidth={editorWidth}


### PR DESCRIPTION
## Description
Updates the JS generator component to open fully when in binding editor mode.

