### PR TITLE
Safari fixes

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/_layout.svelte
@@ -234,6 +234,9 @@
     border-bottom: var(--border-light);
     z-index: 2;
   }
+  .top-nav > * {
+    height: 100%;
+  }
 
   .topcenternav {
     display: flex;
@@ -255,6 +258,7 @@
     position: relative;
     margin-bottom: -2px;
     overflow: hidden;
+    height: calc(100% + 2px);
   }
 
   .topleftnav :global(.spectrum-Tabs-itemLabel) {

--- a/packages/builder/src/pages/builder/app/[application]/data/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/_layout.svelte
@@ -60,6 +60,7 @@
     align-items: stretch;
     flex: 1 1 auto;
     z-index: 1;
+    position: relative;
   }
 
   .panel-title-content {

--- a/packages/builder/src/pages/builder/app/[application]/data/table/[tableId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/table/[tableId]/_layout.svelte
@@ -28,8 +28,11 @@
 
 <style>
   .wrapper {
-    flex: 1 1 auto;
-    margin: -28px -40px -40px -40px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
     display: flex;
     flex-direction: column;
     background: var(--spectrum-global-color-gray-50);

--- a/packages/frontend-core/src/components/grid/cells/GridCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/GridCell.svelte
@@ -134,7 +134,6 @@
     opacity: 0.16;
     background: var(--spectrum-global-color-blue-400);
     z-index: 2;
-    pointer-events: none;
   }
 
   /* Cell border for cells with labels */
@@ -161,6 +160,7 @@
   }
   .cell:not(.focused) {
     user-select: none;
+    -webkit-user-select: none;
   }
   .cell:hover {
     cursor: default;


### PR DESCRIPTION
## Description
Couple of fixes for Safari.

- Fix the primary builder nav not taking up full height
Before:
![image](https://github.com/user-attachments/assets/d2649819-8d4a-4dab-8bf0-89ae471c7dc9)
After:
![image](https://github.com/user-attachments/assets/866631c3-6f52-440e-80ce-222e8075d006)
- Fix data section tables having a horizontal scroll bar
Before:
![image](https://github.com/user-attachments/assets/209ac8fe-e08a-4d5d-b427-4e3473ee61e7)
After:
![image](https://github.com/user-attachments/assets/1ad9c875-c204-4e7d-a144-320fdbd46b80)
- Fix text selection in grids, which was erroneously selecting text in all cells when dragging to bulk select cells
