### PR TITLE
Prefer get account by tenantId

### DIFF
--- a/packages/backend-core/src/accounts/accounts.ts
+++ b/packages/backend-core/src/accounts/accounts.ts
@@ -4,7 +4,7 @@ import { Header } from "../constants"
 import {
   CloudAccount,
   HealthStatusResponse,
-  IAccountDetail,
+  AccountDetail,
 } from "@budibase/types"
 
 const api = new API(env.ACCOUNT_PORTAL_URL)
@@ -19,7 +19,7 @@ const EXIT_EARLY = env.SELF_HOSTED || env.DISABLE_ACCOUNT_PORTAL
 
 export const getAccount = async (
   email: string
-): Promise<IAccountDetail | undefined> => {
+): Promise<AccountDetail | undefined> => {
   if (EXIT_EARLY) {
     return
   }
@@ -33,7 +33,7 @@ export const getAccount = async (
     throw new Error(`Error getting account by email ${email}`)
   }
 
-  const json: IAccountDetail[] = await response.json()
+  const json: AccountDetail[] = await response.json()
   return json[0]
 }
 

--- a/packages/backend-core/src/accounts/accounts.ts
+++ b/packages/backend-core/src/accounts/accounts.ts
@@ -1,7 +1,11 @@
 import API from "./api"
 import env from "../environment"
 import { Header } from "../constants"
-import { CloudAccount, HealthStatusResponse, Hosting } from "@budibase/types"
+import {
+  CloudAccount,
+  HealthStatusResponse,
+  IAccountDetail,
+} from "@budibase/types"
 
 const api = new API(env.ACCOUNT_PORTAL_URL)
 
@@ -12,29 +16,6 @@ const api = new API(env.ACCOUNT_PORTAL_URL)
  * handled by the caller.
  */
 const EXIT_EARLY = env.SELF_HOSTED || env.DISABLE_ACCOUNT_PORTAL
-
-export interface ITenantDetail {
-  id: string
-  name: string
-  hosting: Hosting
-  installation?: {
-    id: string
-    version: string
-  }
-  license?: {
-    key: string
-    session?: string
-  }
-}
-export interface IAccountDetail {
-  id: string
-  email: string
-  name: string
-  displayName: string
-  customerId: string | null
-  createdAt: Date
-  tenants: ITenantDetail[]
-}
 
 export const getAccount = async (
   email: string

--- a/packages/backend-core/src/accounts/accounts.ts
+++ b/packages/backend-core/src/accounts/accounts.ts
@@ -13,7 +13,7 @@ const api = new API(env.ACCOUNT_PORTAL_URL)
  */
 const EXIT_EARLY = env.SELF_HOSTED || env.DISABLE_ACCOUNT_PORTAL
 
-interface ITenantDetail {
+export interface ITenantDetail {
   id: string
   name: string
   hosting: Hosting
@@ -26,7 +26,7 @@ interface ITenantDetail {
     session?: string
   }
 }
-interface IAccountDetail {
+export interface IAccountDetail {
   id: string
   email: string
   name: string

--- a/packages/backend-core/src/accounts/accounts.ts
+++ b/packages/backend-core/src/accounts/accounts.ts
@@ -1,7 +1,7 @@
 import API from "./api"
 import env from "../environment"
 import { Header } from "../constants"
-import { CloudAccount, HealthStatusResponse } from "@budibase/types"
+import { CloudAccount, HealthStatusResponse, Hosting } from "@budibase/types"
 
 const api = new API(env.ACCOUNT_PORTAL_URL)
 
@@ -13,17 +13,36 @@ const api = new API(env.ACCOUNT_PORTAL_URL)
  */
 const EXIT_EARLY = env.SELF_HOSTED || env.DISABLE_ACCOUNT_PORTAL
 
+interface ITenantDetail {
+  id: string
+  name: string
+  hosting: Hosting
+  installation?: {
+    id: string
+    version: string
+  }
+  license?: {
+    key: string
+    session?: string
+  }
+}
+interface IAccountDetail {
+  id: string
+  email: string
+  name: string
+  displayName: string
+  customerId: string | null
+  createdAt: Date
+  tenants: ITenantDetail[]
+}
+
 export const getAccount = async (
   email: string
-): Promise<CloudAccount | undefined> => {
+): Promise<IAccountDetail | undefined> => {
   if (EXIT_EARLY) {
     return
   }
-  const payload = {
-    email,
-  }
-  const response = await api.post(`/api/accounts/search`, {
-    body: payload,
+  const response = await api.get(`/api/v2/admin/account?email=${email}`, {
     headers: {
       [Header.API_KEY]: env.ACCOUNT_PORTAL_API_KEY,
     },
@@ -33,7 +52,7 @@ export const getAccount = async (
     throw new Error(`Error getting account by email ${email}`)
   }
 
-  const json: CloudAccount[] = await response.json()
+  const json: IAccountDetail[] = await response.json()
   return json[0]
 }
 

--- a/packages/backend-core/src/cache/user.ts
+++ b/packages/backend-core/src/cache/user.ts
@@ -6,7 +6,7 @@ import env from "../environment"
 import * as accounts from "../accounts"
 import { UserDB } from "../users"
 import { sdk } from "@budibase/shared-core"
-import { User, UserMetadata } from "@budibase/types"
+import { CloudAccount, User, UserMetadata } from "@budibase/types"
 
 const EXPIRY_SECONDS = 3600
 
@@ -39,10 +39,9 @@ async function populateUsersFromDB(
   const users = getUsersResponse.filter(x => x)
 
   await Promise.all(
-    users.map(async (user: any) => {
+    users.map(async (user: User & { account?: CloudAccount }) => {
       user.budibaseAccess = true
       if (!env.SELF_HOSTED && !env.DISABLE_ACCOUNT_PORTAL) {
-        user.te
         const account = await accounts.getAccountByTenantId(user.tenantId)
         if (account) {
           user.account = account

--- a/packages/backend-core/src/cache/user.ts
+++ b/packages/backend-core/src/cache/user.ts
@@ -18,7 +18,7 @@ async function populateFromDB(userId: string, tenantId: string) {
   const user = await db.get<UserMetadata>(userId)
   user.budibaseAccess = true
   if (!env.SELF_HOSTED && !env.DISABLE_ACCOUNT_PORTAL) {
-    const account = await accounts.getAccount(user.email)
+    const account = await accounts.getAccountByTenantId(tenantId)
     if (account) {
       user.account = account
       user.accountPortalAccess = true
@@ -42,7 +42,8 @@ async function populateUsersFromDB(
     users.map(async (user: any) => {
       user.budibaseAccess = true
       if (!env.SELF_HOSTED && !env.DISABLE_ACCOUNT_PORTAL) {
-        const account = await accounts.getAccount(user.email)
+        user.te
+        const account = await accounts.getAccountByTenantId(user.tenantId)
         if (account) {
           user.account = account
           user.accountPortalAccess = true

--- a/packages/backend-core/src/users/db.ts
+++ b/packages/backend-core/src/users/db.ts
@@ -529,8 +529,8 @@ export class UserDB {
 
     if (!env.SELF_HOSTED && !env.DISABLE_ACCOUNT_PORTAL) {
       // root account holder can't be deleted from inside budibase
-      const email = dbUser.email
-      const account = await accountSdk.getAccount(email)
+      const tenantId = dbUser.tenantId
+      const account = await accountSdk.getAccountByTenantId(tenantId)
       if (account) {
         if (dbUser.userId === getIdentity()!._id) {
           throw new HTTPError('Please visit "Account" to delete this user', 400)

--- a/packages/backend-core/src/users/utils.ts
+++ b/packages/backend-core/src/users/utils.ts
@@ -74,7 +74,7 @@ export async function validateUniqueUser(email: string, tenantId: string) {
   // check root account users in account portal
   if (!env.SELF_HOSTED && !env.DISABLE_ACCOUNT_PORTAL) {
     const account = await accountSdk.getAccount(email)
-    if (account && account.verified && account.tenantId !== tenantId) {
+    if (account) {
       throw new EmailUnavailableError(email)
     }
   }

--- a/packages/backend-core/tests/core/utilities/structures/accounts.ts
+++ b/packages/backend-core/tests/core/utilities/structures/accounts.ts
@@ -6,7 +6,7 @@ import {
   AccountSSOProviderType,
   AuthType,
   CloudAccount,
-  IAccountDetail,
+  AccountDetail,
   Hosting,
   SSOAccount,
 } from "@budibase/types"
@@ -44,7 +44,7 @@ export const cloudAccount = (): CloudAccount => {
   }
 }
 
-export const accountDetail = (): IAccountDetail => {
+export const accountDetail = (): AccountDetail => {
   const account = cloudAccount()
   return {
     id: account.accountId,

--- a/packages/backend-core/tests/core/utilities/structures/accounts.ts
+++ b/packages/backend-core/tests/core/utilities/structures/accounts.ts
@@ -1,3 +1,4 @@
+import { IAccountDetail } from "@budibase/backend-core/src/accounts"
 import { generator, quotas, uuid } from "."
 import { generateGlobalUserID } from "../../../../src/docIds"
 import {
@@ -40,6 +41,19 @@ export const cloudAccount = (): CloudAccount => {
     ...account(),
     hosting: Hosting.CLOUD,
     budibaseUserId: generateGlobalUserID(),
+  }
+}
+
+export const accountDetail = (): IAccountDetail => {
+  const account = cloudAccount()
+  return {
+    id: account.accountId,
+    email: account.email,
+    name: account.accountName,
+    displayName: account.name!,
+    customerId: null,
+    createdAt: new Date(account.createdAt),
+    tenants: [],
   }
 }
 

--- a/packages/backend-core/tests/core/utilities/structures/accounts.ts
+++ b/packages/backend-core/tests/core/utilities/structures/accounts.ts
@@ -1,4 +1,3 @@
-import { IAccountDetail } from "@budibase/backend-core/src/accounts"
 import { generator, quotas, uuid } from "."
 import { generateGlobalUserID } from "../../../../src/docIds"
 import {
@@ -7,6 +6,7 @@ import {
   AccountSSOProviderType,
   AuthType,
   CloudAccount,
+  IAccountDetail,
   Hosting,
   SSOAccount,
 } from "@budibase/types"

--- a/packages/types/src/documents/account/account.ts
+++ b/packages/types/src/documents/account/account.ts
@@ -67,7 +67,7 @@ export interface CloudAccount extends Account {
   budibaseUserId: string
 }
 
-export interface ITenantDetail {
+export interface TenantDetail {
   id: string
   name: string
   hosting: Hosting
@@ -80,14 +80,14 @@ export interface ITenantDetail {
     session?: string
   }
 }
-export interface IAccountDetail {
+export interface AccountDetail {
   id: string
   email: string
   name: string
   displayName: string
   customerId: string | null
   createdAt: Date
-  tenants: ITenantDetail[]
+  tenants: TenantDetail[]
 }
 
 export const isCloudAccount = (account: Account): account is CloudAccount =>

--- a/packages/types/src/documents/account/account.ts
+++ b/packages/types/src/documents/account/account.ts
@@ -67,6 +67,29 @@ export interface CloudAccount extends Account {
   budibaseUserId: string
 }
 
+export interface ITenantDetail {
+  id: string
+  name: string
+  hosting: Hosting
+  installation?: {
+    id: string
+    version: string
+  }
+  license?: {
+    key: string
+    session?: string
+  }
+}
+export interface IAccountDetail {
+  id: string
+  email: string
+  name: string
+  displayName: string
+  customerId: string | null
+  createdAt: Date
+  tenants: ITenantDetail[]
+}
+
 export const isCloudAccount = (account: Account): account is CloudAccount =>
   account.hosting === Hosting.CLOUD
 

--- a/packages/worker/src/api/routes/global/tests/scim.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/scim.spec.ts
@@ -648,7 +648,7 @@ describe("scim", () => {
           budibaseUserId: user.id,
           email: user.emails![0].value,
         }
-        mocks.accounts.getAccount.mockResolvedValue(account)
+        mocks.accounts.getAccountByTenantId.mockResolvedValue(account)
 
         await deleteScimUser(user.id, {
           expect: {

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -284,7 +284,7 @@ describe("/api/global/users", () => {
 
     it("should not be able to create user with the same email as an account", async () => {
       const user = structures.users.user()
-      const account = structures.accounts.cloudAccount()
+      const account = structures.accounts.accountDetail()
       accounts.getAccount.mockReturnValueOnce(Promise.resolve(account))
 
       const response = await config.api.users.saveUser(user, 400)
@@ -743,7 +743,9 @@ describe("/api/global/users", () => {
     it("should not be able to destroy account owner", async () => {
       const user = await config.createUser()
       const account = structures.accounts.cloudAccount()
-      accounts.getAccount.mockReturnValueOnce(Promise.resolve(account))
+      accounts.getAccountByTenantId.mockReturnValueOnce(
+        Promise.resolve(account)
+      )
 
       const response = await config.api.users.deleteUser(user._id!, 400)
 
@@ -754,7 +756,9 @@ describe("/api/global/users", () => {
       const user = await config.user!
       const account = structures.accounts.cloudAccount()
       account.email = user.email
-      accounts.getAccount.mockReturnValueOnce(Promise.resolve(account))
+      accounts.getAccountByTenantId.mockReturnValueOnce(
+        Promise.resolve(account)
+      )
 
       const response = await config.api.users.deleteUser(user._id!, 400)
 


### PR DESCRIPTION
## Description
https://linear.app/budibase/issue/GRO-1146/remove-dynamo-from-convertaccounttolegacy

Use the V2 endpoint for getting the account by email. 

For the V1 search account search endpoint, prefer `tenantId`
