### PR TITLE
Fix minio-service command on docker-compose.yaml

### DIFF
--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -67,7 +67,8 @@ services:
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
       MINIO_BROWSER: "off"
-    command: server /data --console-address ":9001"
+      MINIO_CONSOLE_PORT: 9001
+    command: server /data
     healthcheck:
       test: "timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1"
       interval: 30s


### PR DESCRIPTION
## Description
The minio-service fails when run docker-compose up.

## Addresses
- https://github.com/Budibase/budibase/issues/16001

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
<!--_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._-->

## Launchcontrol

<!--_Add a small description in layman's terms of what this PR achieves. This will be used in the release notes._-->
minor fix on docker-compose.yaml