### PR TITLE
Don't swallow errors when serving apps

### DIFF
--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -376,30 +376,14 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
       // just return the app info for jest to assert on
       ctx.body = appInfo
     }
-  } catch (error) {
-    if (!env.isJest()) {
-      const props: BudibaseAppProps = {
-        usedPlugins: [],
-        title: branding?.metaTitle || "",
-        metaTitle: branding?.metaTitle || "",
-        metaImage:
-          branding?.metaImageUrl ||
-          "https://res.cloudinary.com/daog6scxm/image/upload/v1698759482/meta-images/plain-branded-meta-image-coral_ocxmgu.png",
-        metaDescription: branding?.metaDescription || "",
-        favicon:
-          branding.faviconUrl !== ""
-            ? await objectStore.getGlobalFileUrl("settings", "faviconUrl")
-            : "",
-      }
-      const { head, html, css } = AppComponent.render({ props })
-
-      const appHbs = loadHandlebarsFile(appHbsPath)
-      ctx.body = await processString(appHbs, {
-        head,
-        body: html,
-        style: css.code,
-      })
+  } catch (error: any) {
+    let msg = "An unknown error occurred"
+    if (typeof error === "string") {
+      msg = error
+    } else if (error?.message) {
+      msg = error.message
     }
+    ctx.throw(500, msg)
   }
 }
 


### PR DESCRIPTION
## Description
Currently we swallow errors when serving apps, and try to render the app again for some reason - without required props - which of course still results in a broken app. This PR stops that behaviour, and lets the server throw a real 500 with a message if we encounter an unhandled error.
