### PR TITLE
Fix serving apps without themes due to defaulting a string to an object

### DIFF
--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -281,7 +281,7 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
     const sideNav = appInfo.navigation.navigation === "Left"
     const hideFooter =
       ctx?.user?.license?.features?.includes(Feature.BRANDING) || false
-    const themeVariables = getThemeVariables(appInfo?.theme || {})
+    const themeVariables = getThemeVariables(appInfo?.theme)
     const hasPWA = Object.keys(appInfo.pwa || {}).length > 0
     const manifestUrl = hasPWA ? `/api/apps/${appId}/manifest.json` : ""
     const addAppScripts =


### PR DESCRIPTION
## Description
Fix serving apps without themes due to defaulting a string to an object.
This should be left as is without defaulting to an object as the `ensureValidTheme` call properly handles this and defaults it to a real theme if required.

