### PR TITLE
Fix the way that the AI settings page finds AI configs for a given provider

### DIFF
--- a/packages/builder/src/pages/builder/portal/settings/ai/index.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/ai/index.svelte
@@ -55,18 +55,25 @@
   $: enabled = !isCloud ? providers.filter(p => p.key === activeKey) : providers
   $: disabled = !isCloud ? providers.filter(p => p.key !== activeKey) : []
 
+  function getConfigForProvider(key: AIProviderPartial) {
+    for (const config of Object.values(aiConfig.config)) {
+      if (config.provider === key) {
+        return config
+      }
+    }
+    return undefined
+  }
+
   function getProviderConfig(key: AIProviderPartial): ProviderConfig {
     const details = ProviderDetails[key]
-    const loadedConfig = aiConfig?.config[key] || {}
-    let baseConfig = { ...details.defaultConfig }
+    const config = getConfigForProvider(key) || { ...details.defaultConfig }
 
     return {
-      ...baseConfig,
-      ...loadedConfig,
+      ...config,
       provider: details.provider as AIProvider,
       name: details.name,
-      active: loadedConfig.active ?? baseConfig.active ?? false,
-      isDefault: loadedConfig.isDefault ?? baseConfig.isDefault ?? false,
+      active: config.active ?? false,
+      isDefault: config.isDefault ?? false,
     }
   }
 
@@ -108,12 +115,7 @@
       }
     }
 
-    // handle the old budibase_ai key
     const baseConfig = { ...aiConfig.config }
-    if (baseConfig["budibase_ai"]) {
-      delete baseConfig["budibase_ai"]
-    }
-
     const payload = {
       type: ConfigType.AI,
       config: { ...baseConfig, [key]: updated },


### PR DESCRIPTION
## Description

The code prior to this PR was looking for the provider name to be the key into the `aiConfig.config` object, which isn't necessarily the case. Those keys could really be anything, so I've changed it to look at each value of the object and check the `provider`. This functionally limits us to a single config per provider, but that's probably fine for the time being.

## Addresses
- https://linear.app/budibase/issue/BUDI-9283/settings-page-incorrectly-states-budibase-ai-is-disabled