### PR TITLE
fix: improve SDK build process and file organization

### DIFF
--- a/packages/sdk/.gitignore
+++ b/packages/sdk/.gitignore
@@ -2,3 +2,4 @@ sdk
 docs
 node_modules
 dist
+src/generated

--- a/packages/sdk/scripts/generate-sdk.sh
+++ b/packages/sdk/scripts/generate-sdk.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-# Cleanup
+# Cleanup previous generated files
 if [[ -f "openapi.yaml" ]]; then
     rm openapi.yaml
 fi
 if [[ -d "generated" ]]; then
     rm -r generated
 fi
-if [[ -d "../sdk" ]]; then
-    rm -r ../sdk
+if [[ -d "../src/generated" ]]; then
+    rm -r ../src/generated
 fi
 
 # Generate new SDK
@@ -25,8 +25,9 @@ docker run --rm \
   -o /generated \
   -c /config.json
 
-# Use a subset of the generated files
-mv generated/src ../sdk
+# Move generated files to the correct location
+mkdir -p ../src/generated
+mv generated/src/* ../src/generated/
 
 # Cleanup
 if [[ -f "openapi.yaml" ]]; then

--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -1,4 +1,4 @@
-import * as BudibaseApi from "../sdk"
+import * as BudibaseApi from "./generated"
 
 export default class SDK {
   applications = new BudibaseApi.ApplicationsApi()


### PR DESCRIPTION
## Description
This PR improves the SDK build process and file organization by implementing a more structured approach to generated files. The changes focus on better organization and maintainability of the SDK codebase.

Key improvements include:
- Moving generated files to a dedicated `src/generated` directory for better organization
- Updating import paths in `index.js` to reflect the new structure
- Adding `src/generated` to `.gitignore` to prevent generated files from being committed
- Improving the generate-sdk script to handle directory management more reliably

## Addresses
- Closes #16025 

## App Export
N/A - This is an SDK infrastructure improvement that doesn't require app testing.

## Screenshots
N/A - This is a non-UI change focused on build process improvements.

## Launchcontrol
Improves the organization and reliability of the Budibase SDK build process by implementing a more structured approach to file generation and management. This change makes the SDK more maintainable and reduces potential issues with generated files in version control.