### PR TITLE
Reload the auth store after making AI settings changes.

### DIFF
--- a/packages/builder/src/pages/builder/portal/settings/ai/index.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/ai/index.svelte
@@ -12,6 +12,7 @@
   } from "@budibase/bbui"
   import BBAI from "assets/bb-ai.svg"
   import { admin } from "@/stores/portal"
+  import { auth } from "@/stores/portal"
   import { BudiStore, PersistenceType } from "@/stores/BudiStore"
 
   import { API } from "@/api"
@@ -136,6 +137,7 @@
     try {
       await API.saveConfig(payload)
       aiConfig = (await API.getConfig(ConfigType.AI)) as AIConfig
+      await auth.getSelf()
       notifications.success(`AI provider updated`)
     } catch (err: any) {
       notifications.error(err.message || "Failed to update AI provider")


### PR DESCRIPTION
## Description

This fixes the situation where you make an AI config change, e.g. to enable an LLM, but the UI doesn't know that's happened until you refresh.