### PR TITLE
Corrrectly evaluate AI suggestions

### DIFF
--- a/packages/builder/src/components/common/CodeEditor/AIGen.svelte
+++ b/packages/builder/src/components/common/CodeEditor/AIGen.svelte
@@ -22,6 +22,7 @@
   let previousContents: string | null = null
   let expanded = false
   let promptText = ""
+  let inputValue = ""
 
   const thresholdExpansionWidth = 350
 
@@ -89,6 +90,7 @@
     previousContents = null
     promptText = ""
     expanded = false
+    inputValue = ""
   }
 
   function calculateExpandedWidth() {
@@ -114,6 +116,7 @@
     placeholder="Generate with AI"
     onSubmit={generateJs}
     bind:expanded
+    bind:value={inputValue}
     readonly={!!suggestedCode}
     {expandedOnly}
   />

--- a/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
+++ b/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
@@ -415,7 +415,6 @@
     })
   }
 
-  // Handle AI generation code updates
   const handleAICodeUpdate = (event: CustomEvent<{ code: string }>) => {
     const { code } = event.detail
     value = code
@@ -423,6 +422,7 @@
       changes: { from: 0, to: editor.state.doc.length, insert: code },
     })
     isAIGeneratedContent = true
+    dispatch("change", code)
   }
 
   onMount(() => {
@@ -483,6 +483,7 @@
         changes: { from: 0, to: editor.state.doc.length, insert: code || "" },
       })
       isAIGeneratedContent = false
+      dispatch("change", code || "")
     }}
   />
 {/if}


### PR DESCRIPTION
## Description
Before when a user had suggestion from the AI JS generatiom, we weren't properly passing the value through to the evaluation drawer. Now a user can see the output of the suggested JS. 

Also fixes an issue where the prompt wasn't being cleared when accepting or rejecting a suggestion. 
