### PR TITLE
Fix AI settings page

### DIFF
--- a/packages/builder/src/components/common/CodeEditor/AIGen.svelte
+++ b/packages/builder/src/components/common/CodeEditor/AIGen.svelte
@@ -48,19 +48,17 @@
       }
       suggestedCode = code
       dispatch("update", { code })
-    } catch (e) {
+    } catch (e: any) {
       console.error(e)
-      if (!(e instanceof Error)) {
-        notifications.error("Unable to generate code. Please try again later.")
-        return
-      }
 
       if ("code" in e && e.code === ErrorCode.USAGE_LIMIT_EXCEEDED) {
         notifications.error(
           "Monthly usage limit reached. We're exploring options to expand this soon. Questions? Contact support@budibase.com"
         )
-      } else {
+      } else if ("message" in e) {
         notifications.error(`Unable to generate code: ${e.message}`)
+      } else {
+        notifications.error(`Unable to generate code.`)
       }
     }
   }

--- a/packages/builder/src/pages/builder/portal/settings/ai/AIConfigTile.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/ai/AIConfigTile.svelte
@@ -3,27 +3,24 @@
   import OpenAILogo from "./logos/OpenAI.svelte"
   import AzureOpenAILogo from "./logos/AzureOpenAI.svelte"
   import BudibaseAILogo from "./logos/BBAI.svelte"
-  import type { ProviderConfig } from "@budibase/types"
-  import { Providers } from "./constants"
+  import type { AIProvider, ProviderConfig } from "@budibase/types"
+  import { type ComponentType } from "svelte"
 
-  const logos: Record<string, any> = {
-    [Providers.BudibaseAI]: BudibaseAILogo,
-    [Providers.OpenAI]: OpenAILogo,
-    [Providers.AzureOpenAI]: AzureOpenAILogo,
+  const logos: Partial<Record<AIProvider, ComponentType>> = {
+    BudibaseAI: BudibaseAILogo,
+    OpenAI: OpenAILogo,
+    AzureOpenAI: AzureOpenAILogo,
   }
 
   export let config: ProviderConfig
   export let editHandler: (() => void) | null
   export let disableHandler: (() => void) | null
-
-  let selectedLogo: any =
-    logos[Providers[config.provider as keyof typeof Providers]]
 </script>
 
 <div class="option">
   <div class="details">
     <div class="icon">
-      <svelte:component this={selectedLogo} height="26" width="26" />
+      <svelte:component this={logos[config.provider]} height="26" width="26" />
     </div>
     <div class="header">
       <Body size="S" weight={"600"}>{config.name}</Body>

--- a/packages/builder/src/pages/builder/portal/settings/ai/PortalModal.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/ai/PortalModal.svelte
@@ -23,7 +23,7 @@
   <div>
     Either use an existing self-host workspace, or create a new one. Once you
     have signed up, you will be able to link your license key to this self-host
-    installation by doing to "Account" at the top of this page, and then
+    installation by going to "Account" at the top of this page, and then
     "Upgrade" tab. Paste your license key in there, return to this page, and try
     again.
   </div>

--- a/packages/builder/src/pages/builder/portal/settings/ai/PortalModal.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/ai/PortalModal.svelte
@@ -7,22 +7,24 @@
 </script>
 
 <ModalContent
-  title="Setup BB AI"
+  title="Set up Budibase AI"
   confirmText="Account portal"
   cancelText="Cancel"
   onConfirm={confirmHandler}
   onCancel={cancelHandler}
 >
-  <div>To setup BB AI you must add a Budibase license key.</div>
+  <div>To set up Budibase AI you need a Budibase license key.</div>
 
-  <div class="link-container">
-    To get your license key, account admins must sign up to the
+  <div>
+    To get your license key, an account admin must sign up to Budibase using the
     <Link href={$admin.accountPortalUrl}>Budibase Account Portal</Link>
   </div>
-</ModalContent>
 
-<style>
-  .link-container {
-    margin-top: calc(var(--spacing-xl) * -1);
-  }
-</style>
+  <div>
+    Either use an existing self-host workspace, or create a new one. Once you
+    have signed up, you will be able to link your license key to this self-host
+    installation by doing to "Account" at the top of this page, and then
+    "Upgrade" tab. Paste your license key in there, return to this page, and try
+    again.
+  </div>
+</ModalContent>

--- a/packages/builder/src/pages/builder/portal/settings/ai/constants.ts
+++ b/packages/builder/src/pages/builder/portal/settings/ai/constants.ts
@@ -1,12 +1,4 @@
-export const BBAI_KEY = "BudibaseAI"
-export const OPENAI_KEY = "OpenAI"
-export const AZURE_KEY = "AzureOpenAI"
-
-export const Providers = {
-  BudibaseAI: "BudibaseAI",
-  OpenAI: "OpenAI",
-  AzureOpenAI: "AzureOpenAI",
-}
+import { AIProvider, ProviderConfig } from "@budibase/types"
 
 export const Models = [
   { label: "GPT 4o Mini", value: "gpt-4o-mini" },
@@ -16,53 +8,39 @@ export const Models = [
   { label: "GPT 3.5 Turbo", value: "gpt-3.5-turbo" },
 ]
 
-export const ProviderDetails = {
-  [BBAI_KEY]: {
-    provider: "BudibaseAI",
-    name: "BB AI",
+interface AIProviderDetails {
+  defaultConfig: ProviderConfig
+  models: { label: string; value: string }[]
+}
+
+export const ProviderDetails: Partial<Record<AIProvider, AIProviderDetails>> = {
+  BudibaseAI: {
     defaultConfig: {
+      name: "Budibase AI",
+      provider: "BudibaseAI",
       active: false,
       isDefault: false,
     },
     models: [],
   },
-  [OPENAI_KEY]: {
-    provider: "OpenAI",
-    name: "OpenAI",
-    baseUrl: "https://api.openai.com",
+  OpenAI: {
     defaultConfig: {
+      name: "OpenAI",
+      provider: "OpenAI",
       active: false,
       isDefault: false,
-      apiKey: "",
       baseUrl: "https://api.openai.com",
-      defaultModel: "",
     },
-    models: [
-      { label: "GPT 4o Mini", value: "gpt-4o-mini" },
-      { label: "GPT 4o", value: "gpt-4o" },
-      { label: "GPT 4 Turbo", value: "gpt-4-turbo" },
-      { label: "GPT 4", value: "gpt-4" },
-      { label: "GPT 3.5 Turbo", value: "gpt-3.5-turbo" },
-    ],
+    models: Models,
   },
-  [AZURE_KEY]: {
-    provider: "AzureOpenAI",
-    name: "Azure OpenAI",
-    baseUrl: "",
+  AzureOpenAI: {
     defaultConfig: {
+      name: "Azure OpenAI",
+      provider: "AzureOpenAI",
       active: false,
       isDefault: false,
-      apiKey: "",
-      baseUrl: "",
-      defaultModel: "",
     },
-    models: [
-      { label: "GPT 4o Mini", value: "gpt-4o-mini" },
-      { label: "GPT 4o", value: "gpt-4o" },
-      { label: "GPT 4 Turbo", value: "gpt-4-turbo" },
-      { label: "GPT 4", value: "gpt-4" },
-      { label: "GPT 3.5 Turbo", value: "gpt-3.5-turbo" },
-    ],
+    models: Models,
   },
 }
 

--- a/packages/types/src/documents/global/config.ts
+++ b/packages/types/src/documents/global/config.ts
@@ -119,8 +119,6 @@ export type AIProvider =
   | "Custom"
   | "BudibaseAI"
 
-export type AIProviderPartial = "BudibaseAI" | "OpenAI" | "AzureOpenAI"
-
 export interface ProviderConfig {
   provider: AIProvider
   isDefault: boolean


### PR DESCRIPTION
## Description

This is a fairly big refactor to the AI settings page. Previously, it cared a lot about what the keys were inside the AIConfig object. It no longer cares at all what they are, it instead finds configs by looping over the configs and inspecting the `provider` property.