### PR TITLE
Remove erroneous cast.

### DIFF
--- a/packages/worker/src/api/controllers/global/configs.ts
+++ b/packages/worker/src/api/controllers/global/configs.ts
@@ -361,7 +361,7 @@ export async function find(ctx: UserCtx<void, FindConfigResponse>) {
     if (scopedConfig) {
       await handleConfigType(type, scopedConfig)
     } else if (type === ConfigType.AI) {
-      scopedConfig = { config: {} } as AIConfig
+      scopedConfig = { type: ConfigType.AI, config: {} }
       await handleAIConfig(scopedConfig)
     } else {
       // If no config found and not AI type, just return an empty body


### PR DESCRIPTION
## Description

This cast was causing a disparity between frontend and backend type checking. The frontend believed it had hold of a correct `AIConfig` object but it was missing the `type` field, which caused problems when the frontend tried to send this object to the backend to be saved.