### PR TITLE
Show disabled AI providers in cloud

### DIFF
--- a/packages/builder/src/pages/builder/portal/settings/ai/index.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/ai/index.svelte
@@ -43,7 +43,7 @@
   let providerNames: AIProvider[]
   let hasLicenseKey: string | undefined
 
-  $: isCloud = true // $admin.cloud
+  $: isCloud = $admin.cloud
   $: providerNames = isCloud
     ? ["BudibaseAI"]
     : ["BudibaseAI", "OpenAI", "AzureOpenAI"]

--- a/packages/builder/src/pages/builder/portal/settings/ai/index.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/ai/index.svelte
@@ -213,18 +213,16 @@
         <Body size="S">No LLMs are enabled</Body>
       </div>
     {/if}
-    {#if !isCloud}
-      <div class="section-title disabled-title">Disabled</div>
-      <div class="ai-list">
-        {#each disabledProviders as { provider, config } (provider)}
-          <AIConfigTile
-            {config}
-            editHandler={() => handleEnable(provider)}
-            disableHandler={() => disableProvider(provider)}
-          />
-        {/each}
-      </div>
-    {/if}
+    <div class="section-title disabled-title">Disabled</div>
+    <div class="ai-list">
+      {#each disabledProviders as { provider, config } (provider)}
+        <AIConfigTile
+          {config}
+          editHandler={() => handleEnable(provider)}
+          disableHandler={() => disableProvider(provider)}
+        />
+      {/each}
+    </div>
   </div>
 </Layout>
 

--- a/packages/builder/src/pages/builder/portal/settings/ai/index.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/ai/index.svelte
@@ -43,7 +43,7 @@
   let providerNames: AIProvider[]
   let hasLicenseKey: string | undefined
 
-  $: isCloud = $admin.cloud
+  $: isCloud = true // $admin.cloud
   $: providerNames = isCloud
     ? ["BudibaseAI"]
     : ["BudibaseAI", "OpenAI", "AzureOpenAI"]
@@ -213,16 +213,18 @@
         <Body size="S">No LLMs are enabled</Body>
       </div>
     {/if}
-    <div class="section-title disabled-title">Disabled</div>
-    <div class="ai-list">
-      {#each disabledProviders as { provider, config } (provider)}
-        <AIConfigTile
-          {config}
-          editHandler={() => handleEnable(provider)}
-          disableHandler={() => disableProvider(provider)}
-        />
-      {/each}
-    </div>
+    {#if disabledProviders.length > 0}
+      <div class="section-title disabled-title">Disabled</div>
+      <div class="ai-list">
+        {#each disabledProviders as { provider, config } (provider)}
+          <AIConfigTile
+            {config}
+            editHandler={() => handleEnable(provider)}
+            disableHandler={() => disableProvider(provider)}
+          />
+        {/each}
+      </div>
+    {/if}
   </div>
 </Layout>
 


### PR DESCRIPTION
## Description

We weren't showing the list of disabled providers in cloud but this led to a situation where if you dismissed the Budibase AI banner you were no longer able to enable Budibase AI.