### PR TITLE
Don't default the OPENAI_API_KEY to an invalid value locally.

### DIFF
--- a/packages/server/scripts/dev/manage.js
+++ b/packages/server/scripts/dev/manage.js
@@ -46,7 +46,6 @@ async function init() {
     HTTP_LOGGING: "0",
     VERSION: "0.0.0+local",
     PASSWORD_MIN_LENGTH: "1",
-    OPENAI_API_KEY: "sk-abcdefghijklmnopqrstuvwxyz1234567890abcd",
     BUDICLOUD_URL: "https://budibaseqa.app",
   }
 


### PR DESCRIPTION
## Description

This just gets in the way of local development because the OpenAI client always rejects it.
