### PR TITLE
Hide AI custom config quota.

### DIFF
--- a/packages/builder/src/pages/builder/portal/account/usage.svelte
+++ b/packages/builder/src/pages/builder/portal/account/usage.svelte
@@ -9,6 +9,7 @@
     Link,
     TooltipWrapper,
   } from "@budibase/bbui"
+  import { Feature } from "@budibase/types"
   import { onMount } from "svelte"
   import { admin, auth, licensing } from "@/stores/portal"
   import { Constants } from "@budibase/frontend-core"
@@ -33,6 +34,7 @@
 
   const EXCLUDE_QUOTAS = {
     ["Day Passes"]: () => true,
+    [Feature.AI_CUSTOM_CONFIGS]: () => true,
     Queries: () => true,
     Users: license => {
       return license.plan.model !== PlanModel.PER_USER


### PR DESCRIPTION
## Description

`Feature.AI_CUSTOM_CONFIG` is being opened up to all and as a result we have no need to show your quota for this feature anymore.