### PR TITLE
Don't clear user prompt if the user rejects a suggestion

### DIFF
--- a/packages/builder/src/components/common/CodeEditor/AIGen.svelte
+++ b/packages/builder/src/components/common/CodeEditor/AIGen.svelte
@@ -78,15 +78,17 @@
       prompt: promptText,
     })
     dispatch("reject", { code: previousContents })
-    reset()
+    reset(false)
   }
 
-  function reset() {
+  function reset(clearPrompt: boolean = true) {
+    if (clearPrompt) {
+      promptText = ""
+      inputValue = ""
+    }
     suggestedCode = null
     previousContents = null
-    promptText = ""
     expanded = false
-    inputValue = ""
   }
 </script>
 


### PR DESCRIPTION
## Description
Fixes an issue where if the user rejected an AI JS suggestion the prompt would be cleared regardless. 
