### PR TITLE
Potential fix for user screen not loading in certain situations

### DIFF
--- a/packages/builder/src/pages/builder/portal/users/users/[userId].svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/[userId].svelte
@@ -143,7 +143,7 @@
       return Constants.Roles.CREATOR
     }
 
-    if (user?.roles[prodAppId]) {
+    if (user?.roles?.[prodAppId]) {
       return user.roles[prodAppId]
     }
 


### PR DESCRIPTION
## Description
A user reported an issue where their user screen wouldn't load at all, preceeded by an error `Na.roles is undefined`.

I have a strong suspicion that user.roles has been minified to Na.roles and hence I'm adding this guard in to test this theory. 