### PR TITLE
Make date-only fields a bit more clever in accepting input dates.

### DIFF
--- a/packages/backend-core/src/sql/sql.ts
+++ b/packages/backend-core/src/sql/sql.ts
@@ -1,6 +1,7 @@
 import { Knex, knex } from "knex"
 import * as dbCore from "../db"
 import {
+  extractDate,
   getNativeSql,
   isExternalTable,
   isInvalidISODateString,
@@ -422,6 +423,12 @@ class InternalBuilder {
         if (!isValidTime(input)) {
           return null
         }
+      } else if (schema.dateOnly) {
+        const date = extractDate(input)
+        if (!date) {
+          return null
+        }
+        return new Date(date)
       } else {
         if (isInvalidISODateString(input)) {
           return null

--- a/packages/backend-core/src/sql/utils.ts
+++ b/packages/backend-core/src/sql/utils.ts
@@ -15,6 +15,7 @@ const DOUBLE_SEPARATOR = `${SEPARATOR}${SEPARATOR}`
 const ROW_ID_REGEX = /^\[.*]$/g
 const ENCODED_SPACE = encodeURIComponent(" ")
 const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:.\d{3})?Z)?$/
+const DATE_REGEX = /(\d{4}-\d{2}-\d{2})/
 const TIME_REGEX = /^(?:\d{2}:)?(?:\d{2}:)(?:\d{2})$/
 
 export function isExternalTableID(tableId: string) {
@@ -150,6 +151,14 @@ export function isValidISODateString(str: string) {
 
 export function isInvalidISODateString(str: string) {
   return !isValidISODateString(str)
+}
+
+export function extractDate(str: string) {
+  const match = str.match(DATE_REGEX)
+  if (!match) {
+    return undefined
+  }
+  return match[0]
 }
 
 export function isValidFilter(value: any) {


### PR DESCRIPTION
## Description

A while ago I put code in place that made input handling for date-time fields more strict. This was as a result of some bugs where improperly-formatted date-times were being stored as-is in the database and causing problems.

This had the unintended consequence of rejecting somewhat* valid dates when using date-only columns. I say somewhat because it's a bit nuanced. The workflow we're seeing users expect to work is directly querying the date field in their DB and expecting to be able to use whatever that field comes back as as input to Budibase. Unfortunately date-only fields are backed in different ways per-database. Some databases don't have the notion of a date-only field, so we use a date-time field and strip the time out in the API. So dates could come back as, e.g. `2023-01-02 10:00:00`, which we consider invalid because we're looking for ISO8601 date-time strings.

So this change adds a branch for date-only handling that looks for a YYYY-MM-DD in whatever string it's given and extracts it out if it finds it. It's not super ideal but it fixes this workflow people expect to be able to do.

## Addresses
- https://linear.app/budibase/issue/BUDI-9224/date-disappears-after-update-row#comment-5bc34e75
- https://linear.app/budibase/issue/BUDI-9291/postgres-or-any-other-rdbms-ignore-time-zones-for-datetime-column-not

## Launchcontrol

Makes date-only fields more lenient in the input strings they will accept. You should now be able to date the raw SQL output of a Budibase-created date-only field and feed it successfully back in to Budibase without losing it.