### PR TITLE
Fix query parameter binding when passing a 0, it shouldn't fall back to the default value.

### DIFF
--- a/packages/server/src/api/controllers/query/index.ts
+++ b/packages/server/src/api/controllers/query/index.ts
@@ -169,8 +169,10 @@ function enrichParameters(
   validateQueryInputs(requestParameters)
   // make sure parameters are fully enriched with defaults
   for (const parameter of query.parameters) {
-    let value: string | null =
-      requestParameters[parameter.name] || parameter.default
+    let value = requestParameters[parameter.name]
+    if (value == null) {
+      value = parameter.default
+    }
     if (query.nullDefaultSupport && paramNotSet(value)) {
       value = null
     }

--- a/packages/server/src/api/routes/tests/queries/generic-sql.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/generic-sql.spec.ts
@@ -642,6 +642,35 @@ if (descriptions.length) {
               expect(rows).toHaveLength(1)
             }
           )
+
+          it("should be able to create a new row with a JS value of 0 without falling back to the default", async () => {
+            const query = await createQuery({
+              name: "New Query",
+              queryVerb: "create",
+              fields: {
+                sql: client(tableName)
+                  .insert({ number: client.raw("{{ number }}") })
+                  .toString(),
+              },
+              parameters: [
+                {
+                  name: "number",
+                  default: "999",
+                },
+              ],
+            })
+
+            await config.api.query.execute(query._id!, {
+              parameters: { number: 0 },
+            })
+
+            const rows = await client(tableName).select("*")
+            expect(rows).toHaveLength(6)
+            expect(rows[5].number).toEqual(0)
+
+            const rowsWith999 = rows.filter(row => row.number === 999)
+            expect(rowsWith999).toHaveLength(0)
+          })
         })
 
         describe("read", () => {

--- a/packages/server/src/threads/definitions.ts
+++ b/packages/server/src/threads/definitions.ts
@@ -16,7 +16,7 @@ export interface QueryEvent
   ctx?: any
 }
 
-export type QueryEventParameters = Record<string, string | null>
+export type QueryEventParameters = Record<string, string | number | null>
 
 export interface QueryResponse {
   rows: Row[]

--- a/packages/types/src/api/web/app/query.ts
+++ b/packages/types/src/api/web/app/query.ts
@@ -34,7 +34,7 @@ export interface PreviewQueryResponse {
 }
 
 export interface ExecuteQueryRequest {
-  parameters?: Record<string, string>
+  parameters?: Record<string, string | number | null>
   pagination?: any
 }
 export type ExecuteV1QueryResponse = Record<string, any>[]


### PR DESCRIPTION
## Description

Query params were being considered falsey if they were the number 0, and the default value being substituted in their place. This PR corrects the offending if statement and adds a test for this case.

## Addresses
- https://linear.app/budibase/issue/BUDI-9189/passing-0-into-query-using-js-returns-default-value

## Launchcontrol

Fixes a case where query bindings were falling back to their default value if the value given was a 0.