### PR TITLE
Protect against group.roles being undefined on the user details page.

### DIFF
--- a/packages/builder/src/pages/builder/portal/users/users/[userId].svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/[userId].svelte
@@ -149,7 +149,7 @@
 
     // check if access via group for creator
     const foundGroup = $groups?.find(
-      group => group.roles[prodAppId] || group.builder?.apps[prodAppId]
+      group => group.roles?.[prodAppId] || group.builder?.apps[prodAppId]
     )
     if (foundGroup.builder?.apps[prodAppId]) {
       return Constants.Roles.CREATOR


### PR DESCRIPTION
## Description

Elusive little problem where `group.roles` can possibly be undefined but we're not accounting for that on the user details page. Small question mark-based fix to make sure we aren't trying to index into it.

## Launchcontrol

Fix a rare crash on the user details page.