### PR TITLE
adds onDestroy handler for auto refresh Data Prov

### DIFF
--- a/packages/client/src/components/app/DataProvider.svelte
+++ b/packages/client/src/components/app/DataProvider.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getContext } from "svelte"
+  import { getContext, onDestroy } from "svelte"
   import { Pagination, ProgressCircle } from "@budibase/bbui"
   import { fetchData, QueryUtils } from "@budibase/frontend-core"
   import type {
@@ -175,6 +175,10 @@
       interval = setInterval(fetch.refresh, Math.max(10000, autoRefresh * 1000))
     }
   }
+
+  onDestroy(() => {
+    clearInterval(interval) // Clears auto-refresh when navigating away
+  })
 </script>
 
 <div use:styleable={$component.styles} class="container">


### PR DESCRIPTION
## Description
If a DataProvider is set to Auto-refresh, the timers don't get removed/cancelled when the user navigates away to a different page. This can be demonstrated with a 10-second interval, navigating elsewhere in the app. Looking at the browser's network tab you'll see the request fires even after leaving the page.

## Addresses
- https://github.com/Budibase/budibase/issues/16082

## App Export
[BUDI 9297-export-1747321455930.tar.gz](https://github.com/user-attachments/files/20230539/BUDI.9297-export-1747321455930.tar.gz)

## Screenshots
Check the Network tab in Jam:
https://jam.dev/c/6c61d570-ceea-4e4b-ae2f-33a345f77f52

## Launchcontrol

_Removes AutoRefresh timers on Data Providers after navigating away_
