### PR TITLE
Prepends Datasource to tables and views in App Actions

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DeleteRow.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DeleteRow.svelte
@@ -1,19 +1,29 @@
 <script>
   import { Select, Label, Checkbox, Body } from "@budibase/bbui"
-  import { tables, viewsV2 } from "@/stores/builder"
+  import { tables, datasources, viewsV2 } from "@/stores/builder"
   import DrawerBindableInput from "@/components/common/bindings/DrawerBindableInput.svelte"
 
   export let parameters
   export let bindings = []
 
-  $: tableOptions = $tables.list.map(table => ({
-    label: table.name,
-    resourceId: table._id,
-  }))
-  $: viewOptions = $viewsV2.list.map(view => ({
-    label: view.name,
-    resourceId: view.id,
-  }))
+  $: datasourceMap = Object.fromEntries(
+    ($datasources.list || []).map(ds => [ds._id, ds.name])
+  )
+  $: tableOptions = $tables.list.map(table => {
+    const datasourceName = datasourceMap[table.sourceId] || "Unknown"
+    return {
+      label: `${datasourceName} - ${table.name}`,
+      resourceId: table._id,
+    }
+  })
+  $: viewOptions = $viewsV2.list.map(view => {
+    const table = $tables.list.find(t => t._id === view.tableId)
+    const datasourceName = datasourceMap[table.sourceId] || "Unknown"
+    return {
+      label: `${datasourceName} - ${view.name}`,
+      resourceId: view.id,
+    }
+  })
   $: options = [...(tableOptions || []), ...(viewOptions || [])]
 </script>
 

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DuplicateRow.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DuplicateRow.svelte
@@ -4,6 +4,7 @@
     selectedScreen,
     componentStore,
     tables,
+    datasources,
     viewsV2,
   } from "@/stores/builder"
   import DrawerBindableInput from "@/components/common/bindings/DrawerBindableInput.svelte"
@@ -21,14 +22,24 @@
     nested,
   })
   $: schemaFields = getSchemaFields(parameters?.tableId)
-  $: tableOptions = $tables.list.map(table => ({
-    label: table.name,
-    resourceId: table._id,
-  }))
-  $: viewOptions = $viewsV2.list.map(view => ({
-    label: view.name,
-    resourceId: view.id,
-  }))
+  $: datasourceMap = Object.fromEntries(
+    ($datasources.list || []).map(ds => [ds._id, ds.name])
+  )
+  $: tableOptions = $tables.list.map(table => {
+    const datasourceName = datasourceMap[table.sourceId] || "Unknown"
+    return {
+      label: `${datasourceName} - ${table.name}`,
+      resourceId: table._id,
+    }
+  })
+  $: viewOptions = $viewsV2.list.map(view => {
+    const table = $tables.list.find(t => t._id === view.tableId)
+    const datasourceName = datasourceMap[table.sourceId] || "Unknown"
+    return {
+      label: `${datasourceName} - ${view.name}`,
+      resourceId: view.id,
+    }
+  })
   $: options = [...(tableOptions || []), ...(viewOptions || [])]
 
   const getSchemaFields = resourceId => {

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/FetchRow.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/FetchRow.svelte
@@ -1,19 +1,29 @@
 <script>
   import { Select, Label } from "@budibase/bbui"
-  import { tables, viewsV2 } from "@/stores/builder"
+  import { tables, datasources, viewsV2 } from "@/stores/builder"
   import DrawerBindableInput from "@/components/common/bindings/DrawerBindableInput.svelte"
 
   export let parameters
   export let bindings = []
 
-  $: tableOptions = $tables.list.map(table => ({
-    label: table.name,
-    resourceId: table._id,
-  }))
-  $: viewOptions = $viewsV2.list.map(view => ({
-    label: view.name,
-    resourceId: view.id,
-  }))
+  $: datasourceMap = Object.fromEntries(
+    ($datasources.list || []).map(ds => [ds._id, ds.name])
+  )
+  $: tableOptions = $tables.list.map(table => {
+    const datasourceName = datasourceMap[table.sourceId] || "Unknown"
+    return {
+      label: `${datasourceName} - ${table.name}`,
+      resourceId: table._id,
+    }
+  })
+  $: viewOptions = $viewsV2.list.map(view => {
+    const table = $tables.list.find(t => t._id === view.tableId)
+    const datasourceName = datasourceMap[table.sourceId] || "Unknown"
+    return {
+      label: `${datasourceName} - ${view.name}`,
+      resourceId: view.id,
+    }
+  })
   $: options = [...(tableOptions || []), ...(viewOptions || [])]
 </script>
 

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/SaveRow.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/SaveRow.svelte
@@ -4,6 +4,7 @@
     selectedScreen,
     componentStore,
     tables,
+    datasources,
     viewsV2,
   } from "@/stores/builder"
   import DrawerBindableInput from "@/components/common/bindings/DrawerBindableInput.svelte"
@@ -21,14 +22,24 @@
     nested,
   })
   $: schemaFields = getSchemaFields(parameters?.tableId)
-  $: tableOptions = $tables.list.map(table => ({
-    label: table.name,
-    resourceId: table._id,
-  }))
-  $: viewOptions = $viewsV2.list.map(view => ({
-    label: view.name,
-    resourceId: view.id,
-  }))
+  $: datasourceMap = Object.fromEntries(
+    ($datasources.list || []).map(ds => [ds._id, ds.name])
+  )
+  $: tableOptions = $tables.list.map(table => {
+    const datasourceName = datasourceMap[table.sourceId] || "Unknown"
+    return {
+      label: `${datasourceName} - ${table.name}`,
+      resourceId: table._id,
+    }
+  })
+  $: viewOptions = $viewsV2.list.map(view => {
+    const table = $tables.list.find(t => t._id === view.tableId)
+    const datasourceName = datasourceMap[table.sourceId] || "Unknown"
+    return {
+      label: `${datasourceName} - ${view.name}`,
+      resourceId: view.id,
+    }
+  })
   $: options = [...(tableOptions || []), ...(viewOptions || [])]
 
   const getSchemaFields = resourceId => {


### PR DESCRIPTION
## Description
This PR adds the Datasource to any table or view names in App Actions. The issue raised in #16174 notes that creators with similarly named tables accross multiple datasources found it difficult to know which table was which. This PR helps address that.

## Addresses
[- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required](https://github.com/Budibase/budibase/issues/16174)

## App Export
[PostgreSQL-export-1747667709141.tar.gz](https://github.com/user-attachments/files/20299779/PostgreSQL-export-1747667709141.tar.gz)


## Screenshots
<img width="999" alt="image" src="https://github.com/user-attachments/assets/16fa795e-a2bd-4c10-b6d9-ad18fe36de78" />


## Launchcontrol

_Adds Datasource to tables in App Actions_
