### PR TITLE
Font tweaks

### DIFF
--- a/packages/bbui/src/Button/Button.svelte
+++ b/packages/bbui/src/Button/Button.svelte
@@ -44,6 +44,7 @@
       }
     }}
   >
+    sdfdsf
     {#if $$slots && reverse}
       <span class="spectrum-Button-label"><slot /></span>
     {/if}
@@ -69,6 +70,9 @@
   }
   button.is-disabled {
     cursor: default;
+  }
+  .spectrum-Button {
+    padding-bottom: calc(var(--spectrum-button-padding-y) - 1px);
   }
   .spectrum-Button-label {
     white-space: nowrap;

--- a/packages/bbui/src/Button/Button.svelte
+++ b/packages/bbui/src/Button/Button.svelte
@@ -44,7 +44,6 @@
       }
     }}
   >
-    sdfdsf
     {#if $$slots && reverse}
       <span class="spectrum-Button-label"><slot /></span>
     {/if}

--- a/packages/bbui/src/Form/Core/TextField.svelte
+++ b/packages/bbui/src/Form/Core/TextField.svelte
@@ -121,6 +121,7 @@
 <style>
   .spectrum-Textfield {
     width: 100%;
+    --spectrum-textfield-padding-bottom: var(--spectrum-textfield-padding-top);
   }
 
   input::placeholder {

--- a/packages/bbui/src/bbui.css
+++ b/packages/bbui/src/bbui.css
@@ -122,6 +122,7 @@
 .spectrum {
   --spectrum-alias-body-text-font-family: var(--font-sans) !important;
   --spectrum-global-font-family-base: var(--font-sans) !important;
+  --spectrum-global-font-line-height-small: 1.4 !important;
   --spectrum-alias-text-color-disabled: var(--spectrum-global-color-gray-600) !important;
 }
 

--- a/packages/bbui/src/bbui.css
+++ b/packages/bbui/src/bbui.css
@@ -1,3 +1,4 @@
+/* Custom variables */
 :root {
   --background: #ffffff;
   --ink: #000000;
@@ -71,8 +72,6 @@
   --font-serif: "Georgia", Cambria, Times New Roman, Times, serif;
   --font-mono: Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
     monospace;
-  --spectrum-alias-body-text-font-family: var(--font-sans);
-  --spectrum-global-font-family-base: var(--font-sans);
 
   font-size: 16px;
   --font-size-xs: 0.75rem;
@@ -117,9 +116,16 @@
   --border-blue: 2px var(--blue) solid;
   --border-transparent: 2px transparent solid;
 
-  --spectrum-alias-text-color-disabled: var(--spectrum-global-color-gray-600);
 }
 
+/* Spectrum overrides */
+.spectrum {
+  --spectrum-alias-body-text-font-family: var(--font-sans) !important;
+  --spectrum-global-font-family-base: var(--font-sans) !important;
+  --spectrum-alias-text-color-disabled: var(--spectrum-global-color-gray-600) !important;
+}
+
+/* Generic styles */
 a {
   text-decoration: none;
 }

--- a/packages/bbui/src/bbui.css
+++ b/packages/bbui/src/bbui.css
@@ -72,6 +72,7 @@
   --font-mono: Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
     monospace;
   --spectrum-alias-body-text-font-family: var(--font-sans);
+  --spectrum-global-font-family-base: var(--font-sans);
 
   font-size: 16px;
   --font-size-xs: 0.75rem;

--- a/packages/server/src/api/controllers/static/templates/BudibaseApp.svelte
+++ b/packages/server/src/api/controllers/static/templates/BudibaseApp.svelte
@@ -91,12 +91,10 @@
 
     /* Inject latest font CSS from bbui.css, as the real file is versioned with the client lib */
     .spectrum {
-      --font-sans:
-        "Source Sans 3", -apple-system, BlinkMacSystemFont, Segoe UI, "Inter",
-        "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
-      --font-accent:
-        "Source Sans 3", -apple-system, BlinkMacSystemFont, Segoe UI, "Inter",
-        "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
+      --font-sans: "Source Sans 3", -apple-system, BlinkMacSystemFont, Segoe UI,
+        "Inter", "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
+      --font-accent: "Source Sans 3", -apple-system, BlinkMacSystemFont,
+        Segoe UI, "Inter", "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
       --spectrum-alias-body-text-font-family: var(--font-sans) !important;
       --spectrum-global-font-family-base: var(--font-sans) !important;
       --spectrum-global-font-line-height-small: 1.4 !important;

--- a/packages/server/src/api/controllers/static/templates/BudibaseApp.svelte
+++ b/packages/server/src/api/controllers/static/templates/BudibaseApp.svelte
@@ -39,9 +39,6 @@
     <link rel="icon" type="image/png" href="/builder/bblogo.png" />
   {/if}
 
-  <link href="/builder/fonts/source-sans-pro/400.css" rel="stylesheet" />
-  <link href="/builder/fonts/source-sans-pro/600.css" rel="stylesheet" />
-  <link href="/builder/fonts/source-sans-pro/700.css" rel="stylesheet" />
   <link
     href="/builder/fonts/source-sans-3/source-sans-3.css"
     rel="stylesheet"

--- a/packages/server/src/api/controllers/static/templates/BudibaseApp.svelte
+++ b/packages/server/src/api/controllers/static/templates/BudibaseApp.svelte
@@ -89,6 +89,7 @@
       font-weight: 400;
     }
 
+    /* Inject latest font CSS from bbui.css, as the real file is versioned with the client lib */
     .spectrum {
       --font-sans: "Source Sans 3", -apple-system, BlinkMacSystemFont, Segoe UI,
         "Inter", "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;

--- a/packages/server/src/api/controllers/static/templates/BudibaseApp.svelte
+++ b/packages/server/src/api/controllers/static/templates/BudibaseApp.svelte
@@ -91,12 +91,15 @@
 
     /* Inject latest font CSS from bbui.css, as the real file is versioned with the client lib */
     .spectrum {
-      --font-sans: "Source Sans 3", -apple-system, BlinkMacSystemFont, Segoe UI,
-        "Inter", "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
-      --font-accent: "Source Sans 3", -apple-system, BlinkMacSystemFont,
-        Segoe UI, "Inter", "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
+      --font-sans:
+        "Source Sans 3", -apple-system, BlinkMacSystemFont, Segoe UI, "Inter",
+        "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
+      --font-accent:
+        "Source Sans 3", -apple-system, BlinkMacSystemFont, Segoe UI, "Inter",
+        "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
       --spectrum-alias-body-text-font-family: var(--font-sans) !important;
       --spectrum-global-font-family-base: var(--font-sans) !important;
+      --spectrum-global-font-line-height-small: 1.4 !important;
     }
   </style>
 

--- a/packages/server/src/api/controllers/static/templates/BudibaseApp.svelte
+++ b/packages/server/src/api/controllers/static/templates/BudibaseApp.svelte
@@ -39,6 +39,9 @@
     <link rel="icon" type="image/png" href="/builder/bblogo.png" />
   {/if}
 
+  <link href="/builder/fonts/source-sans-pro/400.css" rel="stylesheet" />
+  <link href="/builder/fonts/source-sans-pro/600.css" rel="stylesheet" />
+  <link href="/builder/fonts/source-sans-pro/700.css" rel="stylesheet" />
   <link
     href="/builder/fonts/source-sans-3/source-sans-3.css"
     rel="stylesheet"
@@ -87,6 +90,15 @@
     #error h2 {
       color: #888;
       font-weight: 400;
+    }
+
+    .spectrum {
+      --font-sans: "Source Sans 3", -apple-system, BlinkMacSystemFont, Segoe UI,
+        "Inter", "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
+      --font-accent: "Source Sans 3", -apple-system, BlinkMacSystemFont,
+        Segoe UI, "Inter", "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
+      --spectrum-alias-body-text-font-family: var(--font-sans) !important;
+      --spectrum-global-font-family-base: var(--font-sans) !important;
     }
   </style>
 

--- a/packages/server/src/api/controllers/static/templates/preview.hbs
+++ b/packages/server/src/api/controllers/static/templates/preview.hbs
@@ -27,6 +27,16 @@
     *:after {
       box-sizing: border-box;
     }
+
+    /* Inject latest font CSS from bbui.css, as the real file is versioned with the client lib */
+    .spectrum {
+      --font-sans: "Source Sans 3", -apple-system, BlinkMacSystemFont, Segoe UI,
+      "Inter", "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
+      --font-accent: "Source Sans 3", -apple-system, BlinkMacSystemFont, Segoe UI,
+      "Inter", "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
+      --spectrum-alias-body-text-font-family: var(--font-sans) !important;
+      --spectrum-global-font-family-base: var(--font-sans) !important;
+    }
   </style>
   <script src='{{ clientLibPath }}'></script>
   <script nonce="{{ nonce }}">

--- a/packages/server/src/api/controllers/static/templates/preview.hbs
+++ b/packages/server/src/api/controllers/static/templates/preview.hbs
@@ -27,16 +27,6 @@
     *:after {
       box-sizing: border-box;
     }
-
-    /* Inject latest font CSS from bbui.css, as the real file is versioned with the client lib */
-    .spectrum {
-      --font-sans: "Source Sans 3", -apple-system, BlinkMacSystemFont, Segoe UI,
-      "Inter", "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
-      --font-accent: "Source Sans 3", -apple-system, BlinkMacSystemFont, Segoe UI,
-      "Inter", "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
-      --spectrum-alias-body-text-font-family: var(--font-sans) !important;
-      --spectrum-global-font-family-base: var(--font-sans) !important;
-    }
   </style>
   <script src='{{ clientLibPath }}'></script>
   <script nonce="{{ nonce }}">

--- a/packages/server/src/api/controllers/static/templates/preview.hbs
+++ b/packages/server/src/api/controllers/static/templates/preview.hbs
@@ -36,6 +36,7 @@
       "Inter", "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
       --spectrum-alias-body-text-font-family: var(--font-sans) !important;
       --spectrum-global-font-family-base: var(--font-sans) !important;
+      --spectrum-global-font-line-height-small: 1.4 !important;
     }
   </style>
   <script src='{{ clientLibPath }}'></script>


### PR DESCRIPTION
## Description
This PR adds a few CSS tweaks to improve compatibility with Source Sans 3.

Changes:
- Adjusted button padding
- Adjusted text input padding
- Inject latest font CSS into server-rendered HTML to bypass client versioning and ensure Source Sans 3 works in old apps

The main font fix here **does not** require an app update, which is the whole point of it. It immediately fixes the font in old client apps as soon as the platform is updated, but does not need an app update.

Before (notice the font is wrong, as it is incorrectly attempting to use Source Sans Pro as it is using versioned CSS):
![image](https://github.com/user-attachments/assets/702b8c4d-9aac-42d0-b83e-2c267ad86ff8)

After:
![image](https://github.com/user-attachments/assets/0bcf334a-0641-4f5a-8c66-fb5eda25a662)

