### PR TITLE
Fix for automation snippets

### DIFF
--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -633,6 +633,7 @@ export function execute(job: Job<AutomationData>, callback: WorkerCallback) {
     appId,
     automationId,
     task: async () => {
+      await context.ensureSnippetContext()
       const envVars = await sdkUtils.getEnvironmentVariables()
       await context.doInEnvironmentContext(envVars, async () => {
         const orchestrator = new Orchestrator(job)


### PR DESCRIPTION
## Description
The snippet context was not being added to automation tasks from the bull queue. In that scenario the snippet would fail to resolve and return and error message.  

## Addresses
- https://github.com/Budibase/budibase/issues/16184

## Launchcontrol
Fix for queued automation task snippet context