### PR TITLE
Remove workspaceApps from appPackage response

### DIFF
--- a/packages/builder/src/stores/builder/screens.ts
+++ b/packages/builder/src/stores/builder/screens.ts
@@ -18,13 +18,11 @@ import {
   Component,
   ComponentDefinition,
   DeleteScreenResponse,
-  FeatureFlag,
   FetchAppPackageResponse,
   SaveScreenResponse,
   Screen,
   ScreenVariant,
 } from "@budibase/types"
-import { featureFlag } from "@/helpers"
 
 interface ScreenState {
   screens: Screen[]
@@ -89,10 +87,7 @@ export class ScreenStore extends BudiStore<ScreenState> {
    * @param {FetchAppPackageResponse} pkg
    */
   syncAppScreens(pkg: FetchAppPackageResponse) {
-    let screens = [...pkg.screens]
-    if (featureFlag.isEnabled(FeatureFlag.WORKSPACE_APPS)) {
-      screens = [...pkg.workspaceApps.flatMap(p => p.screens)]
-    }
+    const screens = [...pkg.screens]
     this.update(state => ({
       ...state,
       screens,

--- a/packages/server/src/api/controllers/workspaceApp.ts
+++ b/packages/server/src/api/controllers/workspaceApp.ts
@@ -6,6 +6,7 @@ import {
   WorkspaceAppResponse,
   UpdateWorkspaceAppRequest,
   UpdateWorkspaceAppResponse,
+  FetchWorkspaceAppResponse,
 } from "@budibase/types"
 import sdk from "../../sdk"
 
@@ -19,6 +20,13 @@ function toWorkspaceAppResponse(
     urlPrefix: workspaceApp.urlPrefix,
     icon: workspaceApp.icon,
     iconColor: workspaceApp.iconColor,
+  }
+}
+
+export async function fetch(ctx: Ctx<void, FetchWorkspaceAppResponse>) {
+  const workspaceApps = await sdk.workspaceApps.fetch()
+  ctx.body = {
+    workspaceApps: workspaceApps.map(toWorkspaceAppResponse),
   }
 }
 

--- a/packages/server/src/api/routes/workspaceApp.ts
+++ b/packages/server/src/api/routes/workspaceApp.ts
@@ -31,6 +31,11 @@ function workspaceAppValidator(
 
 const router: Router = new Router()
 
+router.get(
+  "/api/workspaceApp",
+  authorized(PermissionType.BUILDER),
+  controller.fetch
+)
 router.post(
   "/api/workspaceApp",
   authorized(PermissionType.BUILDER),

--- a/packages/types/src/api/web/app/application.ts
+++ b/packages/types/src/api/web/app/application.ts
@@ -1,5 +1,5 @@
 import type { PlanType } from "../../../sdk"
-import type { Layout, App, Screen, WorkspaceApp } from "../../../documents"
+import type { Layout, App, Screen } from "../../../documents"
 import { ReadStream } from "fs"
 
 export interface SyncAppResponse {
@@ -35,15 +35,10 @@ export interface FetchAppDefinitionResponse {
   libraries: string[]
 }
 
-interface WorkspaceAppResponse extends WorkspaceApp {
-  screens: Screen[]
-}
-
 export interface FetchAppPackageResponse {
   application: App
   licenseType: PlanType
   screens: Screen[]
-  workspaceApps: WorkspaceAppResponse[]
   layouts: Layout[]
   clientLibPath: string
   hasLock: boolean

--- a/packages/types/src/api/web/app/workspaceApp.ts
+++ b/packages/types/src/api/web/app/workspaceApp.ts
@@ -30,3 +30,7 @@ export interface UpdateWorkspaceAppRequest {
 export interface UpdateWorkspaceAppResponse {
   workspaceApp: WorkspaceAppResponse
 }
+
+export interface FetchWorkspaceAppResponse {
+  workspaceApps: WorkspaceAppResponse[]
+}


### PR DESCRIPTION
## Description
This was never used and it's not actually needed after some refactors, so it can be safetly removed