### PR TITLE
Enable JS and table AI generation to self-hosters by default

### DIFF
--- a/packages/types/src/sdk/featureFlag.ts
+++ b/packages/types/src/sdk/featureFlag.ts
@@ -12,8 +12,8 @@ export enum FeatureFlag {
 
 export const FeatureFlagDefaults: Record<FeatureFlag, boolean> = {
   [FeatureFlag.USE_ZOD_VALIDATOR]: false,
-  [FeatureFlag.AI_JS_GENERATION]: false,
-  [FeatureFlag.AI_TABLE_GENERATION]: false,
+  [FeatureFlag.AI_JS_GENERATION]: true,
+  [FeatureFlag.AI_TABLE_GENERATION]: true,
   [FeatureFlag.AI_AGENTS]: false,
   [FeatureFlag.WORKSPACE_APPS]: false,
 


### PR DESCRIPTION
## Description
Update the flag default to be on, in order to be accessible by default to all environments (selfhosters included)

## Launchcontrol
Enabling JS and table AI generation to self-hosters by default