### PR TITLE
Handle screen conflicts between workspace apps

### DIFF
--- a/packages/builder/src/components/design/ScreenDetailsModal.svelte
+++ b/packages/builder/src/components/design/ScreenDetailsModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ModalContent, Input } from "@budibase/bbui"
+  import { ModalContent, Input, keepOpen } from "@budibase/bbui"
   import sanitizeUrl from "@/helpers/sanitizeUrl"
   import { get } from "svelte/store"
   import { screenStore } from "@/stores/builder"
@@ -42,8 +42,13 @@
         screen.routing.roleId === role
     )
   }
+  $: disabled = !route || !!error || !touched
 
   const confirmScreenDetails = async () => {
+    if (disabled) {
+      return keepOpen
+    }
+
     await onConfirm({
       route,
     })
@@ -58,7 +63,7 @@
   onConfirm={confirmScreenDetails}
   {onCancel}
   cancelText={"Back"}
-  disabled={!route || !!error || !touched}
+  {disabled}
 >
   <form on:submit|preventDefault={() => modal.confirm()}>
     <Input

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Screen/GeneralPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Screen/GeneralPanel.svelte
@@ -96,7 +96,8 @@
         },
         validate: route => {
           const existingRoute = screen.routing.route
-          if (route !== existingRoute && routeTaken(route)) {
+          const workspaceAppId = screen.workspaceAppId
+          if (route !== existingRoute && routeTaken(route, workspaceAppId)) {
             return "That URL is already in use for this role"
           }
           return null
@@ -108,7 +109,8 @@
         control: RoleSelect,
         validate: role => {
           const existingRole = screen.routing.roleId
-          if (role !== existingRole && roleTaken(role)) {
+          const workspaceAppId = screen.workspaceAppId
+          if (role !== existingRole && roleTaken(role, workspaceAppId)) {
             return "That role is already in use for this URL"
           }
           return null
@@ -130,19 +132,21 @@
     ]
   }
 
-  const routeTaken = url => {
+  const routeTaken = (url, workspaceAppId) => {
     const roleId = get(selectedScreen).routing.roleId || "BASIC"
     return get(screenStore).screens.some(
       screen =>
+        workspaceAppId === screen.workspaceAppId &&
         screen.routing.route.toLowerCase() === url.toLowerCase() &&
         screen.routing.roleId === roleId
     )
   }
 
-  const roleTaken = roleId => {
+  const roleTaken = (roleId, workspaceAppId) => {
     const url = get(selectedScreen).routing.route
     return get(screenStore).screens.some(
       screen =>
+        workspaceAppId === screen.workspaceAppId &&
         screen.routing.route.toLowerCase() === url.toLowerCase() &&
         screen.routing.roleId === roleId
     )

--- a/packages/builder/src/stores/builder/app.ts
+++ b/packages/builder/src/stores/builder/app.ts
@@ -12,6 +12,7 @@ import {
 } from "@budibase/types"
 import { get } from "svelte/store"
 import { navigationStore } from "./navigation"
+import { initialise } from "."
 
 interface ClientFeatures {
   spectrumThemes: boolean
@@ -204,7 +205,7 @@ export class AppMetaStore extends BudiStore<AppMetaState> {
   async refresh() {
     const { appId } = get(this.store)
     const appPackage = await API.fetchAppPackage(appId)
-    this.syncAppPackage(appPackage)
+    await initialise(appPackage)
   }
 }
 

--- a/packages/builder/src/stores/builder/screens.ts
+++ b/packages/builder/src/stores/builder/screens.ts
@@ -479,6 +479,24 @@ export class ScreenStore extends BudiStore<ScreenState> {
     }
     await this.patch(patchFn, screen._id)
 
+    // Ensure we don't have more than one home screen for this new role.
+    // This could happen after updating multiple different settings.
+    this.store.update(state => {
+      const otherHomeScreens = state.screens.filter(s => {
+        return (
+          s.workspaceAppId === screen.workspaceAppId &&
+          s.routing.roleId === screen.routing.roleId &&
+          s.routing.homeScreen &&
+          s._id !== screen._id
+        )
+      })
+
+      for (const screen of otherHomeScreens) {
+        screen.routing.homeScreen = false
+      }
+
+      return state
+    })
     await appStore.refresh()
   }
 

--- a/packages/builder/src/stores/builder/screens.ts
+++ b/packages/builder/src/stores/builder/screens.ts
@@ -479,28 +479,7 @@ export class ScreenStore extends BudiStore<ScreenState> {
     }
     await this.patch(patchFn, screen._id)
 
-    // Ensure we don't have more than one home screen for this new role.
-    // This could happen after updating multiple different settings.
-    const state = get(this.store)
-    const updatedScreen = state.screens.find(s => s._id === screen._id)
-    if (!updatedScreen) {
-      return
-    }
-    const otherHomeScreens = state.screens.filter(s => {
-      return (
-        s.routing.roleId === updatedScreen.routing.roleId &&
-        s.routing.homeScreen &&
-        s._id !== screen._id
-      )
-    })
-    if (otherHomeScreens.length && updatedScreen.routing.homeScreen) {
-      const patchFn = (screen: Screen) => {
-        screen.routing.homeScreen = false
-      }
-      for (let otherHomeScreen of otherHomeScreens) {
-        await this.patch(patchFn, otherHomeScreen._id)
-      }
-    }
+    await appStore.refresh()
   }
 
   // Move to layouts store

--- a/packages/builder/src/stores/builder/tests/screens.test.js
+++ b/packages/builder/src/stores/builder/tests/screens.test.js
@@ -639,23 +639,20 @@ describe("Screens store", () => {
       screens: storeScreens,
     }))
 
-    const patchSpy = vi
-      .spyOn(bb.screenStore, "patch")
-      .mockImplementation(async (patchFn, screenId) => {
+    vi.spyOn(bb.screenStore, "patch").mockImplementation(
+      async (patchFn, screenId) => {
         const target = bb.store.screens.find(screen => screen._id === screenId)
         patchFn(target)
 
         await bb.screenStore.replace(screenId, target)
-      })
+      }
+    )
 
     await bb.screenStore.updateSetting(
       storeScreens[0],
       "routing.homeScreen",
       true
     )
-
-    // One call for the update, one call for to update the existing home screen
-    expect(patchSpy).toBeCalledTimes(2)
 
     // The new homescreen for BASIC
     expect(bb.store.screens[0].routing.homeScreen).toBe(true)
@@ -703,14 +700,14 @@ describe("Screens store", () => {
       screens: sorted,
     }))
 
-    const patchSpy = vi
-      .spyOn(bb.screenStore, "patch")
-      .mockImplementation(async (patchFn, screenId) => {
+    vi.spyOn(bb.screenStore, "patch").mockImplementation(
+      async (patchFn, screenId) => {
         const target = bb.store.screens.find(screen => screen._id === screenId)
         patchFn(target)
 
         await bb.screenStore.replace(screenId, target)
-      })
+      }
+    )
 
     // ADMIN homeScreen updated from 0 to 2
     await bb.screenStore.updateSetting(sorted[2], "routing.homeScreen", true)
@@ -736,9 +733,6 @@ describe("Screens store", () => {
 
     // Homescreen was never set for POWER
     expect(results[Constants.Roles.POWER]).not.toBeDefined()
-
-    // Once to update the target screen, once to unset the existing homescreen.
-    expect(patchSpy).toBeCalledTimes(2)
   })
 
   it("Sequential patch check. Exit if the screenId is not valid.", async ({

--- a/packages/builder/src/stores/builder/workspaceApps.ts
+++ b/packages/builder/src/stores/builder/workspaceApps.ts
@@ -8,7 +8,7 @@ import {
   InsertWorkspaceAppRequest,
 } from "@budibase/types"
 import { derived, Readable } from "svelte/store"
-import { screenStore, selectedScreen } from "./screens"
+import { selectedScreen, sortedScreens } from "./screens"
 import { featureFlag } from "@/helpers"
 import { API } from "@/api"
 
@@ -29,13 +29,13 @@ export class WorkspaceAppStore extends DerivedBudiStore<
   constructor() {
     const makeDerivedStore = (store: Readable<WorkspaceAppStoreState>) => {
       return derived(
-        [store, screenStore, selectedScreen],
-        ([$store, $screenStore, $selectedScreen]) => {
+        [store, sortedScreens, selectedScreen],
+        ([$store, $sortedScreens, $selectedScreen]) => {
           const workspaceApps = $store.workspaceApps
             .map<UIWorkspaceApp>(workspaceApp => {
               return {
                 ...workspaceApp,
-                screens: $screenStore.screens.filter(
+                screens: $sortedScreens.filter(
                   s => s.workspaceAppId === workspaceApp._id
                 ),
               }

--- a/packages/builder/src/templates/screenTemplating/blank.ts
+++ b/packages/builder/src/templates/screenTemplating/blank.ts
@@ -13,7 +13,7 @@ const blank = ({
   screens: ScreenDoc[]
   workspaceAppId: string | undefined
 }) => {
-  const validRoute = getValidRoute(screens, route, Roles.BASIC)
+  const validRoute = getValidRoute(screens, route, Roles.BASIC, workspaceAppId)
 
   const template = new Screen(workspaceAppId)
     .instanceName("Blank screen")

--- a/packages/builder/src/templates/screenTemplating/form.ts
+++ b/packages/builder/src/templates/screenTemplating/form.ts
@@ -100,7 +100,7 @@ const form = async ({
   }
 
   const template = new Screen(workspaceAppId)
-    .route(getValidRoute(screens, typeSpecificRoute, role))
+    .route(getValidRoute(screens, typeSpecificRoute, role, workspaceAppId))
     .instanceName(`${tableOrView.name} - Form`)
     .role(role)
     .autoTableId(tableOrView.id)

--- a/packages/builder/src/templates/screenTemplating/getValidRoute.ts
+++ b/packages/builder/src/templates/screenTemplating/getValidRoute.ts
@@ -3,16 +3,25 @@ import { Screen } from "@budibase/types"
 
 const arbitraryMax = 10000
 
-const isScreenUrlValid = (screens: Screen[], url: string, role: string) => {
+const isScreenUrlValid = (
+  screens: Screen[],
+  url: string,
+  role: string,
+  workspaceAppId: string | undefined
+) => {
   return !screens.some(
-    screen => screen.routing?.route === url && screen.routing?.roleId === role
+    screen =>
+      screen.routing?.route === url &&
+      screen.routing?.roleId === role &&
+      screen.workspaceAppId === workspaceAppId
   )
 }
 
 const getValidScreenUrl = (
   screens: Screen[],
   url: string,
-  role: string
+  role: string,
+  workspaceAppId: string | undefined
 ): string => {
   const [firstPathSegment = "", ...restPathSegments] = url
     .split("/")
@@ -22,7 +31,7 @@ const getValidScreenUrl = (
     restPathSegments.length > 0 ? `/${restPathSegments.join("/")}` : ""
 
   const naiveUrl = sanitizeUrl(`/${firstPathSegment}${restOfPath}`)
-  if (isScreenUrlValid(screens, naiveUrl, role)) {
+  if (isScreenUrlValid(screens, naiveUrl, role, workspaceAppId)) {
     return naiveUrl
   }
 
@@ -31,7 +40,7 @@ const getValidScreenUrl = (
       `/${firstPathSegment}-${suffix}${restOfPath}`
     )
 
-    if (isScreenUrlValid(screens, suffixedUrl, role)) {
+    if (isScreenUrlValid(screens, suffixedUrl, role, workspaceAppId)) {
       return suffixedUrl
     }
   }

--- a/packages/builder/src/templates/screenTemplating/pdf.ts
+++ b/packages/builder/src/templates/screenTemplating/pdf.ts
@@ -13,7 +13,7 @@ const pdf = ({
   screens: Screen[]
   workspaceAppId: string | undefined
 }) => {
-  const validRoute = getValidRoute(screens, route, Roles.BASIC)
+  const validRoute = getValidRoute(screens, route, Roles.BASIC, workspaceAppId)
 
   const template = new PDFScreen(workspaceAppId)
     .role(Roles.BASIC)

--- a/packages/builder/src/templates/screenTemplating/table/inline.ts
+++ b/packages/builder/src/templates/screenTemplating/table/inline.ts
@@ -45,7 +45,14 @@ const inline = async ({
   }
 
   const screenTemplate = new Screen(workspaceAppId)
-    .route(getValidRoute(screens, tableOrView.name, permissions.write))
+    .route(
+      getValidRoute(
+        screens,
+        tableOrView.name,
+        permissions.write,
+        workspaceAppId
+      )
+    )
     .instanceName(`${tableOrView.name} - List`)
     .customProps({ layout: "grid" })
     .role(permissions.write)

--- a/packages/builder/src/templates/screenTemplating/table/modal.ts
+++ b/packages/builder/src/templates/screenTemplating/table/modal.ts
@@ -158,7 +158,14 @@ const modal = async ({
     .gridDesktopRowSpan(3, 21)
 
   const template = new Screen(workspaceAppId)
-    .route(getValidRoute(screens, tableOrView.name, permissions.write))
+    .route(
+      getValidRoute(
+        screens,
+        tableOrView.name,
+        permissions.write,
+        workspaceAppId
+      )
+    )
     .instanceName(`${tableOrView.name} - List and details`)
     .customProps({ layout: "grid" })
     .role(permissions.write)

--- a/packages/builder/src/templates/screenTemplating/table/newScreen.ts
+++ b/packages/builder/src/templates/screenTemplating/table/newScreen.ts
@@ -301,19 +301,22 @@ const newScreen = async ({
   const tableScreenRoute = getValidRoute(
     screens,
     tableOrView.name,
-    permissions.write
+    permissions.write,
+    workspaceAppId
   )
 
   const updateScreenRoute = getValidRoute(
     screens,
     `/${tableOrView.name}/edit/:id`,
-    permissions.write
+    permissions.write,
+    workspaceAppId
   )
 
   const createScreenRoute = getValidRoute(
     screens,
     `/${tableOrView.name}/new`,
-    permissions.write
+    permissions.write,
+    workspaceAppId
   )
 
   const tableScreenTemplate = getTableScreenTemplate({

--- a/packages/builder/src/templates/screenTemplating/table/sidePanel.ts
+++ b/packages/builder/src/templates/screenTemplating/table/sidePanel.ts
@@ -153,7 +153,14 @@ const sidePanel = async ({
     .gridDesktopRowSpan(3, 21)
 
   const template = new Screen(workspaceAppId)
-    .route(getValidRoute(screens, tableOrView.name, permissions.write))
+    .route(
+      getValidRoute(
+        screens,
+        tableOrView.name,
+        permissions.write,
+        workspaceAppId
+      )
+    )
     .instanceName(`${tableOrView.name} - List and details`)
     .customProps({ layout: "grid" })
     .role(permissions.write)

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -298,7 +298,9 @@ export async function fetchAppPackage(
     (await features.flags.isEnabled(FeatureFlag.WORKSPACE_APPS)) &&
     !isBuilder
   ) {
-    const urlPath = new URL(ctx.headers.referer || "").pathname
+    const urlPath = ctx.headers.referer
+      ? new URL(ctx.headers.referer).pathname
+      : ""
 
     const matchedWorkspaceApp =
       await sdk.workspaceApps.getMatchedWorkspaceApp(urlPath)

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -298,14 +298,10 @@ export async function fetchAppPackage(
     (await features.flags.isEnabled(FeatureFlag.WORKSPACE_APPS)) &&
     !isBuilder
   ) {
-    const urlPath = ctx.headers.referer
-      ? new URL(ctx.headers.referer).pathname
-      : "/"
+    const urlPath = new URL(ctx.headers.referer || "").pathname
 
-    const matchedWorkspaceApp = await sdk.workspaceApps.getMatchedWorkspace(
-      urlPath,
-      application
-    )
+    const matchedWorkspaceApp =
+      await sdk.workspaceApps.getMatchedWorkspaceApp(urlPath)
     if (!matchedWorkspaceApp) {
       ctx.throw("No matching workspace app found for URL path: " + urlPath, 404)
     }

--- a/packages/server/src/api/controllers/routing.ts
+++ b/packages/server/src/api/controllers/routing.ts
@@ -49,8 +49,10 @@ class Routing {
  * @returns The routing structure, this is the full structure designed for use in the builder,
  * if the client routing is required then the updateRoutingStructureForUserRole should be used.
  */
-async function getRoutingStructure(): Promise<{ routes: ScreenRoutingJson }> {
-  const screenRoutes = await getRoutingInfo()
+async function getRoutingStructure(
+  urlPath: string
+): Promise<{ routes: ScreenRoutingJson }> {
+  const screenRoutes = await getRoutingInfo(urlPath)
   const routing = new Routing()
 
   for (let screenRoute of screenRoutes) {
@@ -63,13 +65,15 @@ async function getRoutingStructure(): Promise<{ routes: ScreenRoutingJson }> {
 }
 
 export async function fetch(ctx: UserCtx<void, FetchScreenRoutingResponse>) {
-  ctx.body = await getRoutingStructure()
+  const urlPath = new URL(ctx.headers.referer || "").pathname
+  ctx.body = await getRoutingStructure(urlPath)
 }
 
 export async function clientFetch(
   ctx: UserCtx<void, FetchClientScreenRoutingResponse>
 ) {
-  const routing = await getRoutingStructure()
+  const urlPath = new URL(ctx.headers.referer || "").pathname
+  const routing = await getRoutingStructure(urlPath)
   let roleId = ctx.user?.role?._id
   const roleIds = roleId ? await roles.getUserRoleIdHierarchy(roleId) : []
   for (let topLevel of Object.values(routing.routes) as any) {

--- a/packages/server/src/api/controllers/routing.ts
+++ b/packages/server/src/api/controllers/routing.ts
@@ -64,15 +64,19 @@ async function getRoutingStructure(
   return { routes: routing.json }
 }
 
+function getReferer(ctx: UserCtx) {
+  return ctx.headers.referer ? new URL(ctx.headers.referer).pathname : ""
+}
+
 export async function fetch(ctx: UserCtx<void, FetchScreenRoutingResponse>) {
-  const urlPath = new URL(ctx.headers.referer || "").pathname
+  const urlPath = getReferer(ctx)
   ctx.body = await getRoutingStructure(urlPath)
 }
 
 export async function clientFetch(
   ctx: UserCtx<void, FetchClientScreenRoutingResponse>
 ) {
-  const urlPath = new URL(ctx.headers.referer || "").pathname
+  const urlPath = getReferer(ctx)
   const routing = await getRoutingStructure(urlPath)
   let roleId = ctx.user?.role?._id
   const roleIds = roleId ? await roles.getUserRoleIdHierarchy(roleId) : []

--- a/packages/server/src/api/controllers/screen.ts
+++ b/packages/server/src/api/controllers/screen.ts
@@ -100,6 +100,10 @@ export async function save(
     }
   }
 
+  if (screen.routing.homeScreen) {
+    await sdk.screens.ensureHomepageUniqueness(screen)
+  }
+
   if (isCreation) {
     await events.screen.created(screen)
   }

--- a/packages/server/src/appMigrations/migrations/20250514133719_workspace_apps.ts
+++ b/packages/server/src/appMigrations/migrations/20250514133719_workspace_apps.ts
@@ -29,9 +29,14 @@ const migration = async () => {
     }))
 
   const designDoc = await db.get<DesignDocument>("_design/database")
-  // Remove the routing view to be recreated (and updated to support workspace apps)
-  delete designDoc.views?.[ViewName.ROUTING]
-  docsToUpdate.push(designDoc)
+  if (
+    designDoc.views?.[ViewName.ROUTING] &&
+    designDoc.views[ViewName.ROUTING].version !== 2
+  ) {
+    // Remove the routing view to be recreated (and updated to support workspace apps)
+    delete designDoc.views?.[ViewName.ROUTING]
+    docsToUpdate.push(designDoc)
+  }
 
   await db.bulkDocs(docsToUpdate)
 }

--- a/packages/server/src/appMigrations/migrations/20250514133719_workspace_apps.ts
+++ b/packages/server/src/appMigrations/migrations/20250514133719_workspace_apps.ts
@@ -31,7 +31,8 @@ const migration = async () => {
   const designDoc = await db.get<DesignDocument>("_design/database")
   if (
     designDoc.views?.[ViewName.ROUTING] &&
-    designDoc.views[ViewName.ROUTING].version !== 2
+    // If there is no version, it is an old view
+    designDoc.views[ViewName.ROUTING].version === undefined
   ) {
     // Remove the routing view to be recreated (and updated to support workspace apps)
     delete designDoc.views?.[ViewName.ROUTING]

--- a/packages/server/src/db/views/staticViews.ts
+++ b/packages/server/src/db/views/staticViews.ts
@@ -64,7 +64,7 @@ export async function createRoutingView() {
     // if using variables in a map function need to inject them before use
     map: `function(doc) {
       if (doc._id.startsWith("${SCREEN_PREFIX}")) {
-        emit(doc._id, {
+        emit([doc.workspaceAppId, doc._id], {
           id: doc._id,
           routing: doc.routing,
         })

--- a/packages/server/src/db/views/staticViews.ts
+++ b/packages/server/src/db/views/staticViews.ts
@@ -1,6 +1,7 @@
 import { context, features } from "@budibase/backend-core"
 import { SEPARATOR, ViewName } from "../utils"
 import {
+  DBView,
   DocumentType,
   FeatureFlag,
   LinkDocument,
@@ -66,7 +67,7 @@ export async function createLinkView() {
 export async function createRoutingView() {
   const db = context.getAppDB()
   const designDoc = await db.get<any>("_design/database")
-  let view = {
+  let view: DBView = {
     // if using variables in a map function need to inject them before use
     map: `function(doc) {
       if (doc._id.startsWith("${SCREEN_PREFIX}")) {
@@ -88,6 +89,7 @@ export async function createRoutingView() {
         })
       }
     }`,
+      version: 2,
     }
   }
   designDoc.views = {

--- a/packages/server/src/sdk/app/screens/index.ts
+++ b/packages/server/src/sdk/app/screens/index.ts
@@ -1,1 +1,2 @@
 export * from "./screens"
+export * from "./utils"

--- a/packages/server/src/sdk/app/screens/utils.ts
+++ b/packages/server/src/sdk/app/screens/utils.ts
@@ -1,0 +1,19 @@
+import { Screen } from "@budibase/types"
+import sdk from "../.."
+
+export async function ensureHomepageUniqueness(screen: Screen) {
+  const allScreens = await sdk.screens.fetch()
+  const otherScreens = allScreens.filter(
+    s => s._id !== screen._id && s.workspaceAppId === screen.workspaceAppId
+  )
+
+  const toModify = otherScreens.filter(s => s.routing.homeScreen)
+  if (!toModify.length) {
+    return
+  }
+
+  for (const screen of otherScreens) {
+    screen.routing.homeScreen = false
+    await sdk.screens.update(screen)
+  }
+}

--- a/packages/server/src/sdk/app/screens/utils.ts
+++ b/packages/server/src/sdk/app/screens/utils.ts
@@ -7,7 +7,9 @@ export async function ensureHomepageUniqueness(screen: Screen) {
     s => s._id !== screen._id && s.workspaceAppId === screen.workspaceAppId
   )
 
-  const toModify = otherScreens.filter(s => s.routing.homeScreen)
+  const toModify = otherScreens.filter(
+    s => s.routing.homeScreen && s.routing.roleId === screen.routing.roleId
+  )
   if (!toModify.length) {
     return
   }

--- a/packages/server/src/sdk/app/workspaceApps/utils.ts
+++ b/packages/server/src/sdk/app/workspaceApps/utils.ts
@@ -1,11 +1,12 @@
-import { App, WorkspaceApp } from "@budibase/types"
+import { WorkspaceApp } from "@budibase/types"
 import sdk from "../.."
 import { db } from "@budibase/backend-core"
 
-export async function getMatchedWorkspace(fromUrl: string, application: App) {
-  const baseAppUrl = db.isProdAppID(application.appId)
-    ? `/app/${application.url}`.replace("//", "/")
-    : `/${application.appId}`
+export async function getMatchedWorkspaceApp(fromUrl: string | undefined) {
+  const app = await sdk.applications.metadata.get()
+  const baseAppUrl = db.isProdAppID(app.appId)
+    ? `/app/${app.url}`.replace("//", "/")
+    : `/${app.appId}`
 
   let allWorkspaceApps = await sdk.workspaceApps.fetch()
   // Sort decending to ensure we match the most strict, removing match conflicts
@@ -14,7 +15,9 @@ export async function getMatchedWorkspace(fromUrl: string, application: App) {
   )
 
   function isWorkspaceAppMatch({ urlPrefix }: WorkspaceApp) {
-    return fromUrl.startsWith(`${baseAppUrl}${urlPrefix}`.replace(/\/$/, ""))
+    return (fromUrl || "/").startsWith(
+      `${baseAppUrl}${urlPrefix}`.replace(/\/$/, "")
+    )
   }
 
   const matchedWorkspaceApp = allWorkspaceApps.find(isWorkspaceAppMatch)

--- a/packages/server/src/utilities/routing/index.ts
+++ b/packages/server/src/utilities/routing/index.ts
@@ -2,24 +2,32 @@ import { createRoutingView } from "../../db/views/staticViews"
 import { ViewName, getQueryIndex, UNICODE_MAX } from "../../db/utils"
 import { context } from "@budibase/backend-core"
 import { ScreenRoutesViewOutput } from "@budibase/types"
+import sdk from "../../sdk"
 
-export async function getRoutingInfo(): Promise<ScreenRoutesViewOutput[]> {
+export async function getRoutingInfo(
+  urlPath: string
+): Promise<ScreenRoutesViewOutput[]> {
+  const workspaceApp = await sdk.workspaceApps.getMatchedWorkspaceApp(urlPath)
   const db = context.getAppDB()
   try {
     const allRouting = await db.query<ScreenRoutesViewOutput>(
       getQueryIndex(ViewName.ROUTING),
       {
-        startkey: "",
-        endkey: UNICODE_MAX,
+        startkey: [workspaceApp?._id, ""],
+        endkey: [workspaceApp?._id, UNICODE_MAX],
       }
     )
     return allRouting.rows.map(row => row.value)
   } catch (err: any) {
     // check if the view doesn't exist, it should for all new instances
     /* istanbul ignore next */
-    if (err != null && err.name === "not_found") {
+    if (
+      err != null &&
+      err.error === "not_found" &&
+      err.reason === "missing_named_view"
+    ) {
       await createRoutingView()
-      return getRoutingInfo()
+      return getRoutingInfo(urlPath)
     } else {
       throw err
     }

--- a/packages/server/src/utilities/routing/index.ts
+++ b/packages/server/src/utilities/routing/index.ts
@@ -1,7 +1,7 @@
 import { createRoutingView } from "../../db/views/staticViews"
 import { ViewName, getQueryIndex, UNICODE_MAX } from "../../db/utils"
-import { context } from "@budibase/backend-core"
-import { ScreenRoutesViewOutput } from "@budibase/types"
+import { context, features } from "@budibase/backend-core"
+import { FeatureFlag, ScreenRoutesViewOutput } from "@budibase/types"
 import sdk from "../../sdk"
 
 export async function getRoutingInfo(
@@ -10,11 +10,16 @@ export async function getRoutingInfo(
   const workspaceApp = await sdk.workspaceApps.getMatchedWorkspaceApp(urlPath)
   const db = context.getAppDB()
   try {
+    const workspaceAppsEnabled = await features.isEnabled(
+      FeatureFlag.WORKSPACE_APPS
+    )
     const allRouting = await db.query<ScreenRoutesViewOutput>(
       getQueryIndex(ViewName.ROUTING),
       {
-        startkey: [workspaceApp?._id, ""],
-        endkey: [workspaceApp?._id, UNICODE_MAX],
+        startkey: workspaceAppsEnabled ? [workspaceApp?._id, ""] : "",
+        endkey: workspaceAppsEnabled
+          ? [workspaceApp?._id, UNICODE_MAX]
+          : UNICODE_MAX,
       }
     )
     return allRouting.rows.map(row => row.value)

--- a/packages/types/src/sdk/db.ts
+++ b/packages/types/src/sdk/db.ts
@@ -39,6 +39,7 @@ export type DBView = {
   reduce?: string
   meta?: ViewTemplateOpts
   groupBy?: string
+  version?: number
 }
 
 export interface DesignDocument extends Document {


### PR DESCRIPTION
## Description
Allowing "duplicated" settings between workspace apps. Given this new setup, we can allow things such as:
- duplicated screen names between apps
- multiple home pages (while being in different apps)

Some of this logic has been moved from the frontend, now living on the backend