### PR TITLE
Remove ACCOUNT_PORTAL_API_KEY.

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -148,8 +148,6 @@ spec:
           value: {{ .Values.globals.platformUrl | quote }}
         - name: ACCOUNT_PORTAL_URL
           value: {{ .Values.globals.accountPortalUrl | quote }}
-        - name: ACCOUNT_PORTAL_API_KEY
-          value: {{ .Values.globals.accountPortalApiKey | quote }}
         - name: COOKIE_DOMAIN
           value: {{ .Values.globals.cookieDomain | quote }}
         - name: HTTP_MIGRATIONS

--- a/charts/budibase/templates/automation-worker-service-deployment.yaml
+++ b/charts/budibase/templates/automation-worker-service-deployment.yaml
@@ -149,8 +149,6 @@ spec:
           value: {{ .Values.globals.platformUrl | quote }}
         - name: ACCOUNT_PORTAL_URL
           value: {{ .Values.globals.accountPortalUrl | quote }}
-        - name: ACCOUNT_PORTAL_API_KEY
-          value: {{ .Values.globals.accountPortalApiKey | quote }}
         - name: COOKIE_DOMAIN
           value: {{ .Values.globals.cookieDomain | quote }}
         - name: HTTP_MIGRATIONS

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -142,8 +142,6 @@ spec:
           value: {{ .Values.globals.posthogToken }}
         - name: ACCOUNT_PORTAL_URL
           value: {{ .Values.globals.accountPortalUrl | quote }}
-        - name: ACCOUNT_PORTAL_API_KEY
-          value: {{ .Values.globals.accountPortalApiKey | quote }}
         - name: PLATFORM_URL
           value: {{ .Values.globals.platformUrl | quote }}
         - name: COOKIE_DOMAIN

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -78,8 +78,6 @@ globals:
   offlineMode: "0"
   # @ignore (only needs to be set in our cloud environment)
   accountPortalUrl: ""
-  # @ignore (only needs to be set in our cloud environment)
-  accountPortalApiKey: ""
   # -- Sets the domain attribute of the cookie that Budibase uses to store session information.
   # See <https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent>
   # for details on why you might want to set this.

--- a/packages/backend-core/src/accounts/accounts.ts
+++ b/packages/backend-core/src/accounts/accounts.ts
@@ -25,7 +25,7 @@ export const getAccount = async (
   const response = await api.post(`/api/accounts/search`, {
     body: payload,
     headers: {
-      [Header.API_KEY]: env.ACCOUNT_PORTAL_API_KEY,
+      [Header.API_KEY]: env.INTERNAL_API_KEY,
     },
   })
 
@@ -49,7 +49,7 @@ export const getAccountByTenantId = async (
   const response = await api.post(`/api/accounts/search`, {
     body: payload,
     headers: {
-      [Header.API_KEY]: env.ACCOUNT_PORTAL_API_KEY,
+      [Header.API_KEY]: env.INTERNAL_API_KEY,
     },
   })
 
@@ -69,7 +69,7 @@ export const getStatus = async (): Promise<
   }
   const response = await api.get(`/api/status`, {
     headers: {
-      [Header.API_KEY]: env.ACCOUNT_PORTAL_API_KEY,
+      [Header.API_KEY]: env.INTERNAL_API_KEY,
     },
   })
   const json = await response.json()

--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -162,7 +162,6 @@ const environment = {
   MULTI_TENANCY: process.env.MULTI_TENANCY,
   ACCOUNT_PORTAL_URL:
     process.env.ACCOUNT_PORTAL_URL || "https://account.budibase.app",
-  ACCOUNT_PORTAL_API_KEY: process.env.ACCOUNT_PORTAL_API_KEY || "",
   BUDICLOUD_URL: process.env.BUDICLOUD_URL || "https://budibase.app",
   DISABLE_ACCOUNT_PORTAL: process.env.DISABLE_ACCOUNT_PORTAL,
   SELF_HOSTED: selfHosted,

--- a/packages/server/scripts/dev/manage.js
+++ b/packages/server/scripts/dev/manage.js
@@ -26,7 +26,6 @@ async function init() {
     WORKER_URL: "http://localhost:4002",
     INTERNAL_API_KEY: "budibase",
     ACCOUNT_PORTAL_URL: "http://localhost:10001",
-    ACCOUNT_PORTAL_API_KEY: "budibase",
     PLATFORM_URL: "http://localhost:10000",
     JWT_SECRET: "testsecret",
     ENCRYPTION_KEY: "testsecret",

--- a/packages/worker/scripts/dev/manage.js
+++ b/packages/worker/scripts/dev/manage.js
@@ -21,7 +21,6 @@ async function init() {
     MULTI_TENANCY: "",
     DISABLE_ACCOUNT_PORTAL: "1",
     ACCOUNT_PORTAL_URL: "http://localhost:10001",
-    ACCOUNT_PORTAL_API_KEY: "budibase",
     PLATFORM_URL: "http://localhost:10000",
     APPS_URL: "http://localhost:4001",
     SERVICE: "worker-service",


### PR DESCRIPTION
## Description

We're standardising on having `INTERNAL_API_KEY` set to the same value across services, to make things simpler.

Pro PR: https://github.com/Budibase/budibase-pro/pull/417