### PR TITLE
Respect what's in values.yaml when updating secrets through the Helm chart.

### DIFF
--- a/charts/budibase/templates/secrets.yaml
+++ b/charts/budibase/templates/secrets.yaml
@@ -12,12 +12,12 @@ metadata:
 type: Opaque
 data:
   {{- if $existingSecret }}
-  internalApiKey: {{ index $existingSecret.data "internalApiKey" | quote }}
-  jwtSecret: {{ index $existingSecret.data "jwtSecret" | quote }}
-  objectStoreAccess: {{ index $existingSecret.data "objectStoreAccess" | quote }}
-  objectStoreSecret: {{ index $existingSecret.data "objectStoreSecret" | quote }}
-  bbEncryptionKey: {{ index $existingSecret.data "bbEncryptionKey" | quote }}
-  apiEncryptionKey: {{ index $existingSecret.data "apiEncryptionKey" | quote }}
+  internalApiKey: {{ if .Values.globals.internalApiKey }}{{ .Values.globals.internalApiKey}}{{ else }}{{ index $existingSecret.data "internalApiKey" | quote }}{{ end }}
+  jwtSecret: {{ if .Values.globals.jwtSecret }}{{ .Values.globals.jwtSecret}}{{ else }}{{ index $existingSecret.data "jwtSecret" | quote }}{{ end }}
+  objectStoreAccess: {{ if .Values.services.objectStore.accessKey }}{{ .Values.services.objectStore.accessKey}}{{ else }}{{ index $existingSecret.data "objectStoreAccess" | quote }}{{ end }}
+  objectStoreSecret: {{ if .Values.services.objectStore.secretKey }}{{ .Values.services.objectStore.secretKey}}{{ else }}{{ index $existingSecret.data "objectStoreSecret" | quote }}{{ end }}
+  bbEncryptionKey: {{ if .Values.globals.bbEncryptionKey }}{{ .Values.globals.bbEncryptionKey}}{{ else }}{{ index $existingSecret.data "bbEncryptionKey" | quote }}{{ end }}
+  apiEncryptionKey: {{ if .Values.globals.apiEncryptionKey }}{{ .Values.globals.apiEncryptionKey}}{{ else }}{{ index $existingSecret.data "apiEncryptionKey" | quote }}{{ end }}
   {{- else }}
   internalApiKey: {{ template "budibase.defaultsecret" .Values.globals.internalApiKey }}
   jwtSecret: {{ template "budibase.defaultsecret" .Values.globals.jwtSecret }}


### PR DESCRIPTION
## Description

Up until this PR, if you tried to change the value of e.g. `internalApiKey` it wouldn't work. The Helm chart is written in such a way that secret values prefer the current value to anything found in values.yaml, so weren't updateable after creation.

This PR changes that such that what's in values.yaml is the preference, allowing you to change the value of secrets through values.yaml.

## Launchcontrol

Makes it possible to update secret values through the Helm chart.
