### PR TITLE
Use default values when empty string is passed

### DIFF
--- a/packages/server/src/api/controllers/query/index.ts
+++ b/packages/server/src/api/controllers/query/index.ts
@@ -170,7 +170,7 @@ function enrichParameters(
   // make sure parameters are fully enriched with defaults
   for (const parameter of query.parameters) {
     let value = requestParameters[parameter.name]
-    if (value == null) {
+    if (value == null || value === "") {
       value = parameter.default
     }
     if (query.nullDefaultSupport && paramNotSet(value)) {

--- a/packages/server/src/api/routes/tests/queries/generic-sql.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/generic-sql.spec.ts
@@ -671,6 +671,35 @@ if (descriptions.length) {
             const rowsWith999 = rows.filter(row => row.number === 999)
             expect(rowsWith999).toHaveLength(0)
           })
+
+          it("should be able to create a new row with a JS value of empty string, falling back to the default", async () => {
+            const query = await createQuery({
+              name: "New Query",
+              queryVerb: "create",
+              fields: {
+                sql: client(tableName)
+                  .insert({ name: client.raw("{{ name }}") })
+                  .toString(),
+              },
+              parameters: [
+                {
+                  name: "name",
+                  default: "abc",
+                },
+              ],
+            })
+
+            await config.api.query.execute(query._id!, {
+              parameters: { name: "" },
+            })
+
+            const rows = await client(tableName).select("*").orderBy("id")
+            expect(rows).toHaveLength(6)
+            expect(rows[5].name).toEqual("abc")
+
+            const rowsWithEmptyName = rows.filter(row => row.name === "")
+            expect(rowsWithEmptyName).toHaveLength(0)
+          })
         })
 
         describe("read", () => {


### PR DESCRIPTION
## Description
Fix default value fallback when passing empty strings

## Addresses
- https://linear.app/budibase/issue/BUDI-9342/default-binding-in-query-failed-to-trigger-when-no-value-passed

## Launchcontrol
Fixes defaulting to default value when empty string is passed