### PR TITLE
Fixing memory issue and "redis" issue

### DIFF
--- a/packages/backend-core/src/events/index.ts
+++ b/packages/backend-core/src/events/index.ts
@@ -9,7 +9,7 @@ import { processors } from "./processors"
 
 export function initAsyncEvents() {}
 
-export const shutdown = () => {
-  processors.shutdown()
+export const shutdown = async () => {
+  await processors.shutdown()
   console.log("Events shutdown")
 }

--- a/packages/backend-core/src/events/processors/AnalyticsProcessor.ts
+++ b/packages/backend-core/src/events/processors/AnalyticsProcessor.ts
@@ -56,9 +56,9 @@ export default class AnalyticsProcessor implements EventProcessor {
     }
   }
 
-  shutdown() {
+  async shutdown() {
     if (this.posthog) {
-      this.posthog.shutdown()
+      await this.posthog.shutdown()
     }
   }
 }

--- a/packages/backend-core/src/events/processors/AuditLogsProcessor.ts
+++ b/packages/backend-core/src/events/processors/AuditLogsProcessor.ts
@@ -92,7 +92,7 @@ export default class AuditLogsProcessor implements EventProcessor {
     // no-op
   }
 
-  shutdown(): void {
-    AuditLogsProcessor.auditLogQueue?.close()
+  async shutdown(): Promise<void> {
+    await AuditLogsProcessor.auditLogQueue?.close()
   }
 }

--- a/packages/backend-core/src/events/processors/LoggingProcessor.ts
+++ b/packages/backend-core/src/events/processors/LoggingProcessor.ts
@@ -30,7 +30,7 @@ export default class LoggingProcessor implements EventProcessor {
     console.log(`[audit] group identified`, group)
   }
 
-  shutdown(): void {
+  async shutdown(): Promise<void> {
     // no-op
   }
 }

--- a/packages/backend-core/src/events/processors/Processors.ts
+++ b/packages/backend-core/src/events/processors/Processors.ts
@@ -42,10 +42,10 @@ export default class Processor implements EventProcessor {
     }
   }
 
-  shutdown() {
+  async shutdown() {
     for (const eventProcessor of this.processors) {
       if (eventProcessor.shutdown) {
-        eventProcessor.shutdown()
+        await eventProcessor.shutdown()
       }
     }
   }

--- a/packages/backend-core/src/events/processors/posthog/PosthogProcessor.ts
+++ b/packages/backend-core/src/events/processors/posthog/PosthogProcessor.ts
@@ -110,7 +110,7 @@ export default class PosthogProcessor implements EventProcessor {
     this.posthog.groupIdentify(payload)
   }
 
-  shutdown() {
-    this.posthog.shutdown()
+  async shutdown() {
+    await this.posthog.shutdown()
   }
 }

--- a/packages/server/src/koa.ts
+++ b/packages/server/src/koa.ts
@@ -55,7 +55,7 @@ export default function createKoaApp() {
     signals: "SIGINT SIGTERM",
     timeout: 30000, // in ms
     onShutdown: shutdown,
-    forceExit: !env.isTest,
+    forceExit: !env.isTest(),
     finally: () => {
       console.log("Server shutdown complete")
     },
@@ -69,7 +69,7 @@ export default function createKoaApp() {
       return
     }
     await shutdown()
-    if (!env.isTest) {
+    if (!env.isTest()) {
       process.exit(1)
     }
   })
@@ -77,7 +77,7 @@ export default function createKoaApp() {
   process.on("unhandledRejection", async reason => {
     logging.logAlert("Unhandled Promise Rejection", reason as Error)
     await shutdown()
-    if (!env.isTest) {
+    if (!env.isTest()) {
       process.exit(1)
     }
   })

--- a/packages/types/src/sdk/events/event.ts
+++ b/packages/types/src/sdk/events/event.ts
@@ -438,5 +438,5 @@ export interface EventProcessor {
   ): Promise<void>
   identify?(identity: Identity, timestamp?: string | number): Promise<void>
   identifyGroup?(group: Group, timestamp?: string | number): Promise<void>
-  shutdown?(): void
+  shutdown?(): Promise<void>
 }

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -85,15 +85,7 @@ app.use(api.routes())
 
 const server = http.createServer(app.callback())
 
-let isShuttingDown = false
-
 const shutdown = async (signal?: string) => {
-  if (isShuttingDown) {
-    console.log("Shutdown already in progress, skipping...")
-    return
-  }
-  isShuttingDown = true
-
   console.log(
     `Worker service shutting down gracefully... ${signal ? `Signal: ${signal}` : ""}`
   )

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -88,7 +88,7 @@ const server = http.createServer(app.callback())
 const shutdown = async () => {
   console.log("Worker service shutting down gracefully...")
   timers.cleanup()
-  events.shutdown()
+  await events.shutdown()
   await redis.clients.shutdown()
   await queue.shutdown()
 }

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -85,8 +85,18 @@ app.use(api.routes())
 
 const server = http.createServer(app.callback())
 
-const shutdown = async () => {
-  console.log("Worker service shutting down gracefully...")
+let isShuttingDown = false
+
+const shutdown = async (signal?: string) => {
+  if (isShuttingDown) {
+    console.log("Shutdown already in progress, skipping...")
+    return
+  }
+  isShuttingDown = true
+
+  console.log(
+    `Worker service shutting down gracefully... ${signal ? `Signal: ${signal}` : ""}`
+  )
   timers.cleanup()
   await events.shutdown()
   await redis.clients.shutdown()

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -107,7 +107,7 @@ gracefulShutdown(server, {
   signals: "SIGINT SIGTERM",
   timeout: 30000,
   onShutdown: shutdown,
-  forceExit: !env.isTest,
+  forceExit: !env.isTest(),
   finally: () => {
     console.log("Worker service shutdown complete")
   },
@@ -116,7 +116,7 @@ gracefulShutdown(server, {
 process.on("uncaughtException", async err => {
   logging.logAlert("Uncaught exception.", err)
   await shutdown()
-  if (!env.isTest) {
+  if (!env.isTest()) {
     process.exit(1)
   }
 })
@@ -124,7 +124,7 @@ process.on("uncaughtException", async err => {
 process.on("unhandledRejection", async reason => {
   logging.logAlert("Unhandled Promise Rejection", reason as Error)
   await shutdown()
-  if (!env.isTest) {
+  if (!env.isTest()) {
     process.exit(1)
   }
 })

--- a/packages/worker/src/tests/TestConfiguration.ts
+++ b/packages/worker/src/tests/TestConfiguration.ts
@@ -37,10 +37,13 @@ import {
 } from "@budibase/types"
 import API from "./api"
 import jwt, { Secret } from "jsonwebtoken"
+import http from "http"
 
 class TestConfiguration {
-  server: any
-  request: any
+  server?: http.Server<typeof http.IncomingMessage, typeof http.ServerResponse>
+
+  request?: supertest.SuperTest<supertest.Test>
+
   api: API
   tenantId: string
   user?: User

--- a/packages/worker/src/tests/TestConfiguration.ts
+++ b/packages/worker/src/tests/TestConfiguration.ts
@@ -40,9 +40,10 @@ import jwt, { Secret } from "jsonwebtoken"
 import http from "http"
 
 class TestConfiguration {
-  server?: http.Server<typeof http.IncomingMessage, typeof http.ServerResponse>
+  server: http.Server<typeof http.IncomingMessage, typeof http.ServerResponse> =
+    undefined!
 
-  request?: supertest.SuperTest<supertest.Test>
+  request: supertest.SuperTest<supertest.Test> = undefined!
 
   api: API
   tenantId: string

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -3,7 +3,7 @@
 const start = Date.now()
 
 const fs = require("fs")
-const { cp, readdir, copyFile, mkdir } = require("node:fs/promises")
+const { readdir, copyFile, mkdir } = require("node:fs/promises")
 const path = require("path")
 
 const { build } = require("esbuild")


### PR DESCRIPTION
## Description
Fixing an issue introduced in this [PR](https://github.com/Budibase/budibase/pull/16083) that causes the processes to not stop properly.
The issue is that the process was not proper existing, so both signals (SIGINT & SIGTERM) were being listen. The second to run would have issues closing the redis connections (as they would be already closed), causing an infinite loop because the `uncaughtException`/`unhandledRejection` handlers.
This scenario caused Redis to seem the culprit, while it was not their fault at all. Sorry, Redis.

Along the way I also updated the shutdowns to be proper async, hopefully helping us to catch unhandled errors in the future
