### PR TITLE
Behaviour when deleting all workspace apps

### DIFF
--- a/packages/builder/src/components/ContextMenu.svelte
+++ b/packages/builder/src/components/ContextMenu.svelte
@@ -1,6 +1,12 @@
-<script>
+<script lang="ts">
   import { contextMenuStore } from "@/stores/builder"
-  import { Menu, MenuItem, Popover } from "@budibase/bbui"
+  import {
+    AbsTooltip,
+    Menu,
+    MenuItem,
+    Popover,
+    TooltipPosition,
+  } from "@budibase/bbui"
   import NewPill from "./common/NewPill.svelte"
 
   let dropdown
@@ -12,7 +18,7 @@
     }
   }
 
-  const handleItemClick = async itemCallback => {
+  const handleItemClick = async (itemCallback: () => void | Promise<void>) => {
     await itemCallback()
     contextMenuStore.close()
   }
@@ -40,19 +46,21 @@
   <Menu>
     {#each $contextMenuStore.items as item}
       {#if item.visible}
-        <MenuItem
-          icon={item.icon}
-          keyBind={item.keyBind}
-          on:click={() => handleItemClick(item.callback)}
-          disabled={item.disabled}
-        >
-          {item.name}
-          <div slot="right">
-            {#if item.isNew}
-              <NewPill />
-            {/if}
-          </div>
-        </MenuItem>
+        <AbsTooltip text={item.tooltip} position={TooltipPosition.Right}>
+          <MenuItem
+            icon={item.icon}
+            keyBind={item.keyBind ?? undefined}
+            on:click={() => handleItemClick(item.callback)}
+            disabled={item.disabled}
+          >
+            {item.name}
+            <div slot="right">
+              {#if item.isNew}
+                <NewPill />
+              {/if}
+            </div>
+          </MenuItem>
+        </AbsTooltip>
       {/if}
     {/each}
   </Menu>

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ScreenList/ScreenNavItem.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ScreenList/ScreenNavItem.svelte
@@ -91,6 +91,7 @@
         visible: true,
         disabled: !deletionAllowed,
         callback: confirmDeleteDialog.show,
+        tooltip: deletionAllowed ? "" : "At least one screen is required",
       },
     ]
 

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ScreenList/ScreenNavItem.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ScreenList/ScreenNavItem.svelte
@@ -16,6 +16,7 @@
   import type { Screen } from "@budibase/types"
 
   export let screen
+  export let deletionAllowed: boolean
 
   let confirmDeleteDialog: ConfirmDialog
   let screenDetailsModal: Modal
@@ -88,7 +89,7 @@
         name: "Delete",
         keyBind: null,
         visible: true,
-        disabled: false,
+        disabled: !deletionAllowed,
         callback: confirmDeleteDialog.show,
       },
     ]

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ScreenList/WorkspaceAppNavItem.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ScreenList/WorkspaceAppNavItem.svelte
@@ -16,7 +16,7 @@
 
 {#each workspaceApp.screens as screen (screen._id)}
   <div class="screen">
-    <ScreenNavItem {screen} />
+    <ScreenNavItem {screen} deletionAllowed={workspaceApp.screens.length > 1} />
   </div>
 {:else}
   <Layout paddingY="none" paddingX="L">

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ScreenList/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ScreenList/index.svelte
@@ -116,7 +116,7 @@
       <WorkspaceAppList workspaceApps={filteredWorkspaceApps} {searchValue} />
     {:else if filteredScreens?.length}
       {#each filteredScreens as screen (screen._id)}
-        <ScreenNavItem {screen} />
+        <ScreenNavItem {screen} deletionAllowed />
       {/each}
     {:else}
       <Layout paddingY="none" paddingX="L">

--- a/packages/builder/src/pages/builder/app/[application]/design/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/index.svelte
@@ -7,7 +7,7 @@
   $: {
     if (
       featureFlag.isEnabled(FeatureFlag.WORKSPACE_APPS) &&
-      $workspaceAppStore.workspaceApps.length > 0
+      workspaceAppStore.workspaceApps?.[0]?.screens?.[0]
     ) {
       $redirect(`./${$workspaceAppStore.workspaceApps[0].screens[0]._id}`)
     } else if ($screenStore.screens.length > 0) {

--- a/packages/builder/src/pages/builder/app/[application]/design/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/index.svelte
@@ -1,9 +1,16 @@
 <script>
+  import { featureFlag } from "@/helpers"
+  import { screenStore, workspaceAppStore } from "@/stores/builder"
+  import { FeatureFlag } from "@budibase/types"
   import { redirect } from "@roxi/routify"
-  import { screenStore } from "@/stores/builder"
 
   $: {
-    if ($screenStore.screens.length > 0) {
+    if (
+      featureFlag.isEnabled(FeatureFlag.WORKSPACE_APPS) &&
+      $workspaceAppStore.workspaceApps.length > 0
+    ) {
+      $redirect(`./${$workspaceAppStore.workspaceApps[0].screens[0]._id}`)
+    } else if ($screenStore.screens.length > 0) {
       $redirect(`./${$screenStore.screens[0]._id}`)
     } else {
       $redirect("./new")

--- a/packages/builder/src/pages/builder/app/[application]/design/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/index.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { featureFlag } from "@/helpers"
   import { screenStore, workspaceAppStore } from "@/stores/builder"
   import { FeatureFlag } from "@budibase/types"
@@ -7,7 +7,7 @@
   $: {
     if (
       featureFlag.isEnabled(FeatureFlag.WORKSPACE_APPS) &&
-      workspaceAppStore.workspaceApps?.[0]?.screens?.[0]
+      $workspaceAppStore.workspaceApps?.[0]?.screens?.[0]
     ) {
       $redirect(`./${$workspaceAppStore.workspaceApps[0].screens[0]._id}`)
     } else if ($screenStore.screens.length > 0) {

--- a/packages/builder/src/stores/builder/app.ts
+++ b/packages/builder/src/stores/builder/app.ts
@@ -12,6 +12,7 @@ import {
 } from "@budibase/types"
 import { get } from "svelte/store"
 import { navigationStore } from "./navigation"
+import { workspaceAppStore } from "./workspaceApps"
 
 interface ClientFeatures {
   spectrumThemes: boolean
@@ -205,6 +206,8 @@ export class AppMetaStore extends BudiStore<AppMetaState> {
     const { appId } = get(this.store)
     const appPackage = await API.fetchAppPackage(appId)
     this.syncAppPackage(appPackage)
+
+    workspaceAppStore.fetch()
   }
 }
 

--- a/packages/builder/src/stores/builder/app.ts
+++ b/packages/builder/src/stores/builder/app.ts
@@ -13,6 +13,7 @@ import {
 import { get } from "svelte/store"
 import { navigationStore } from "./navigation"
 import { workspaceAppStore } from "./workspaceApps"
+import { screenStore } from "./screens"
 
 interface ClientFeatures {
   spectrumThemes: boolean
@@ -206,6 +207,7 @@ export class AppMetaStore extends BudiStore<AppMetaState> {
     const { appId } = get(this.store)
     const appPackage = await API.fetchAppPackage(appId)
     this.syncAppPackage(appPackage)
+    screenStore.syncAppScreens(appPackage)
 
     workspaceAppStore.fetch()
   }

--- a/packages/builder/src/stores/builder/contextMenu.ts
+++ b/packages/builder/src/stores/builder/contextMenu.ts
@@ -13,6 +13,7 @@ interface MenuItem {
   disabled?: boolean
   callback: () => void
   isNew?: boolean
+  tooltip?: string
 }
 
 interface ContextMenuState {

--- a/packages/builder/src/stores/builder/screens.ts
+++ b/packages/builder/src/stores/builder/screens.ts
@@ -270,6 +270,8 @@ export class ScreenStore extends BudiStore<ScreenState> {
       })
     }
 
+    appStore.refresh()
+
     return savedScreen
   }
 

--- a/packages/builder/src/stores/builder/workspaceApps.ts
+++ b/packages/builder/src/stores/builder/workspaceApps.ts
@@ -9,6 +9,7 @@ import { derived, Readable } from "svelte/store"
 import { screenStore } from "./screens"
 import { featureFlag } from "@/helpers"
 import { API } from "@/api"
+import { appStore } from "./app"
 
 interface WorkspaceAppStoreState {
   workspaceApps: WorkspaceApp[]
@@ -97,6 +98,8 @@ export class WorkspaceAppStore extends DerivedBudiStore<
         workspaceApps: state.workspaceApps.filter(app => app._id !== id),
       }
     })
+
+    appStore.refresh()
   }
 }
 

--- a/packages/builder/src/stores/builder/workspaceApps.ts
+++ b/packages/builder/src/stores/builder/workspaceApps.ts
@@ -89,9 +89,12 @@ export class WorkspaceAppStore extends DerivedBudiStore<
 
   async delete(id: string, rev: string) {
     await API.workspaceApp.delete(id, rev)
+
     this.store.update(state => {
-      state.workspaceApps = state.workspaceApps.filter(app => app._id !== id)
-      return state
+      return {
+        ...state,
+        workspaceApps: state.workspaceApps.filter(app => app._id !== id),
+      }
     })
   }
 }

--- a/packages/builder/src/stores/builder/workspaceApps.ts
+++ b/packages/builder/src/stores/builder/workspaceApps.ts
@@ -10,6 +10,7 @@ import { screenStore } from "./screens"
 import { featureFlag } from "@/helpers"
 import { API } from "@/api"
 import { appStore } from "./app"
+import * as screenTemplating from "@/templates/screenTemplating"
 
 interface WorkspaceAppStoreState {
   workspaceApps: WorkspaceApp[]
@@ -65,11 +66,21 @@ export class WorkspaceAppStore extends DerivedBudiStore<
   }
 
   async add(workspaceApp: WorkspaceApp) {
-    const createdWorkspaceApp = await API.workspaceApp.create(workspaceApp)
+    const { workspaceApp: createdWorkspaceApp } =
+      await API.workspaceApp.create(workspaceApp)
     this.store.update(state => ({
       ...state,
-      workspaceApps: [...state.workspaceApps, createdWorkspaceApp.workspaceApp],
+      workspaceApps: [...state.workspaceApps, createdWorkspaceApp],
     }))
+
+    await screenStore.save({
+      ...screenTemplating.blank({
+        route: "/",
+        screens: [],
+        workspaceAppId: createdWorkspaceApp._id,
+      })[0].data,
+      workspaceAppId: createdWorkspaceApp._id,
+    })
   }
 
   async edit(workspaceApp: UpdateWorkspaceAppRequest) {

--- a/packages/builder/src/stores/builder/workspaceApps.ts
+++ b/packages/builder/src/stores/builder/workspaceApps.ts
@@ -54,6 +54,7 @@ export class WorkspaceAppStore extends DerivedBudiStore<
     if (!featureFlag.isEnabled(FeatureFlag.WORKSPACE_APPS)) {
       return
     }
+
     const { workspaceApps } = await API.workspaceApp.fetch()
     this.update(state => ({
       ...state,
@@ -64,10 +65,10 @@ export class WorkspaceAppStore extends DerivedBudiStore<
 
   async add(workspaceApp: WorkspaceApp) {
     const createdWorkspaceApp = await API.workspaceApp.create(workspaceApp)
-    this.store.update(state => {
-      state.workspaceApps.push(createdWorkspaceApp.workspaceApp)
-      return state
-    })
+    this.store.update(state => ({
+      ...state,
+      workspaceApps: [...state.workspaceApps, createdWorkspaceApp.workspaceApp],
+    }))
   }
 
   async edit(workspaceApp: UpdateWorkspaceAppRequest) {

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -182,13 +182,7 @@ async function addSampleDataDocs() {
 async function addSampleDataScreen() {
   let workspaceAppId: string | undefined
   if (await features.isEnabled(FeatureFlag.WORKSPACE_APPS)) {
-    const appMetadata = await sdk.applications.metadata.get()
-
-    const workspaceApp = await sdk.workspaceApps.create({
-      name: appMetadata.name,
-      urlPrefix: "/",
-      icon: "Monitoring",
-    })
+    const workspaceApp = await sdk.workspaceApps.createDefaultWorkspaceApp()
     workspaceAppId = workspaceApp._id!
   }
 

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -278,7 +278,10 @@ export async function fetchAppPackage(
     screens = await accessController.checkScreensAccess(screens, userRoleId)
   }
 
-  if (await features.flags.isEnabled(FeatureFlag.WORKSPACE_APPS)) {
+  if (
+    (await features.flags.isEnabled(FeatureFlag.WORKSPACE_APPS)) &&
+    !isBuilder
+  ) {
     const urlPath = ctx.headers.referer
       ? new URL(ctx.headers.referer).pathname
       : "/"

--- a/packages/server/src/api/controllers/screen.ts
+++ b/packages/server/src/api/controllers/screen.ts
@@ -24,7 +24,6 @@ import {
 import { builderSocket } from "../../websockets"
 import sdk from "../../sdk"
 import { sdk as sharedSdk } from "@budibase/shared-core"
-import { defaultAppNavigator } from "../../constants/definitions"
 
 export async function fetch(ctx: UserCtx<void, FetchScreenResponse>) {
   const screens = await sdk.screens.fetch()
@@ -54,14 +53,16 @@ export async function save(
     ) {
       ctx.throw("workspaceAppId is not valid")
     } else {
-      const appMetadata = await sdk.applications.metadata.get()
-      const newWorkspaceApp = await sdk.workspaceApps.create({
-        name: appMetadata.name,
-        urlPrefix: "/",
-        icon: "Monitoring",
-        navigation: defaultAppNavigator(appMetadata.name),
-      })
-      screen.workspaceAppId = newWorkspaceApp._id
+      let [workspaceApp] = await sdk.workspaceApps.fetch()
+      if (!workspaceApp) {
+        const appMetadata = await sdk.applications.metadata.get()
+        workspaceApp = await sdk.workspaceApps.create({
+          name: appMetadata.name,
+          urlPrefix: "/",
+          icon: "Monitoring",
+        })
+      }
+      screen.workspaceAppId = workspaceApp._id
     }
   }
 

--- a/packages/server/src/api/controllers/screen.ts
+++ b/packages/server/src/api/controllers/screen.ts
@@ -52,15 +52,10 @@ export async function save(
       !(await sdk.workspaceApps.get(screen.workspaceAppId))
     ) {
       ctx.throw("workspaceAppId is not valid")
-    } else {
+    } else if (!screen.workspaceAppId) {
       let [workspaceApp] = await sdk.workspaceApps.fetch()
       if (!workspaceApp) {
-        const appMetadata = await sdk.applications.metadata.get()
-        workspaceApp = await sdk.workspaceApps.create({
-          name: appMetadata.name,
-          urlPrefix: "/",
-          icon: "Monitoring",
-        })
+        workspaceApp = await sdk.workspaceApps.createDefaultWorkspaceApp()
       }
       screen.workspaceAppId = workspaceApp._id
     }

--- a/packages/server/src/api/routes/tests/screen.spec.ts
+++ b/packages/server/src/api/routes/tests/screen.spec.ts
@@ -1,6 +1,6 @@
 import { checkBuilderEndpoint } from "./utilities/TestFunctions"
 import * as setup from "./utilities"
-import { events, roles } from "@budibase/backend-core"
+import { events, features, roles } from "@budibase/backend-core"
 import {
   Screen,
   Role,
@@ -10,6 +10,7 @@ import {
 } from "@budibase/types"
 import { basicDatasourcePlus } from "../../../tests/utilities/structures"
 import { SAMPLE_DATA_SCREEN_NAME } from "../../../constants/screens"
+import { structures } from "@budibase/backend-core/tests"
 
 const {
   basicScreen,
@@ -203,6 +204,120 @@ describe("/screens", () => {
         config,
         method: "DELETE",
         url: `/api/screens/${screen._id}/${screen._rev}`,
+      })
+    })
+
+    describe("workspace apps", () => {
+      let featureCleanup: () => void
+      beforeAll(() => {
+        featureCleanup = features.testutils.setFeatureFlags("*", {
+          WORKSPACE_APPS: true,
+        })
+      })
+
+      afterAll(() => {
+        featureCleanup()
+      })
+
+      it("should not allow deleting the last screen", async () => {
+        const { workspaceApp } = await config.api.workspaceApp.create(
+          structures.workspaceApps.workspaceApp()
+        )
+        const screen = await config.api.screen.save({
+          ...basicScreen(),
+          workspaceAppId: workspaceApp._id,
+        })
+
+        await config.api.screen.destroy(screen._id!, screen._rev!, {
+          status: 409,
+          body: { message: "Cannot delete the last screen in a workspace app" },
+        })
+      })
+
+      it("should allow deleting other screens", async () => {
+        const { workspaceApp } = await config.api.workspaceApp.create(
+          structures.workspaceApps.workspaceApp()
+        )
+        const screens = await Promise.all(
+          Array.from({ length: 3 }).map(() =>
+            config.api.screen.save({
+              ...basicScreen(),
+              workspaceAppId: workspaceApp._id,
+            })
+          )
+        )
+
+        function popRandomScreen() {
+          const index = Math.floor(Math.random() * screens.length)
+          return screens.splice(index, 1)[0]
+        }
+
+        let screenToDelete = popRandomScreen()
+        await config.api.screen.destroy(
+          screenToDelete._id!,
+          screenToDelete._rev!
+        )
+        screenToDelete = popRandomScreen()
+        await config.api.screen.destroy(
+          screenToDelete._id!,
+          screenToDelete._rev!
+        )
+        screenToDelete = popRandomScreen()
+        await config.api.screen.destroy(
+          screenToDelete._id!,
+          screenToDelete._rev!,
+          { status: 409 }
+        )
+      })
+
+      it("should allow deleting screens for other apps", async () => {
+        const { workspaceApp: workspaceApp1 } =
+          await config.api.workspaceApp.create(
+            structures.workspaceApps.workspaceApp()
+          )
+        const { workspaceApp: workspaceApp2 } =
+          await config.api.workspaceApp.create(
+            structures.workspaceApps.workspaceApp()
+          )
+        const app1Screens = await Promise.all(
+          Array.from({ length: 3 }).map(() =>
+            config.api.screen.save({
+              ...basicScreen(),
+              workspaceAppId: workspaceApp1._id,
+            })
+          )
+        )
+        // Other screens
+        await Promise.all(
+          Array.from({ length: 2 }).map(() =>
+            config.api.screen.save({
+              ...basicScreen(),
+              workspaceAppId: workspaceApp2._id,
+            })
+          )
+        )
+
+        function popRandomScreen(screens: Screen[]) {
+          const index = Math.floor(Math.random() * screens.length)
+          return screens.splice(index, 1)[0]
+        }
+
+        let screenToDelete = popRandomScreen(app1Screens)
+        await config.api.screen.destroy(
+          screenToDelete._id!,
+          screenToDelete._rev!
+        )
+        screenToDelete = popRandomScreen(app1Screens)
+        await config.api.screen.destroy(
+          screenToDelete._id!,
+          screenToDelete._rev!
+        )
+        screenToDelete = popRandomScreen(app1Screens)
+        await config.api.screen.destroy(
+          screenToDelete._id!,
+          screenToDelete._rev!,
+          { status: 409 }
+        )
       })
     })
   })

--- a/packages/server/src/api/routes/tests/screen.spec.ts
+++ b/packages/server/src/api/routes/tests/screen.spec.ts
@@ -33,6 +33,11 @@ describe("/screens", () => {
     screen = await config.createScreen()
   })
 
+  function popRandomScreen(screens: Screen[]) {
+    const index = Math.floor(Math.random() * screens.length)
+    return screens.splice(index, 1)[0]
+  }
+
   describe("fetch", () => {
     it("should create the sample data screen", async () => {
       const screens = await config.api.screen.list()
@@ -247,22 +252,17 @@ describe("/screens", () => {
           )
         )
 
-        function popRandomScreen() {
-          const index = Math.floor(Math.random() * screens.length)
-          return screens.splice(index, 1)[0]
-        }
-
-        let screenToDelete = popRandomScreen()
+        let screenToDelete = popRandomScreen(screens)
         await config.api.screen.destroy(
           screenToDelete._id!,
           screenToDelete._rev!
         )
-        screenToDelete = popRandomScreen()
+        screenToDelete = popRandomScreen(screens)
         await config.api.screen.destroy(
           screenToDelete._id!,
           screenToDelete._rev!
         )
-        screenToDelete = popRandomScreen()
+        screenToDelete = popRandomScreen(screens)
         await config.api.screen.destroy(
           screenToDelete._id!,
           screenToDelete._rev!,
@@ -296,11 +296,6 @@ describe("/screens", () => {
             })
           )
         )
-
-        function popRandomScreen(screens: Screen[]) {
-          const index = Math.floor(Math.random() * screens.length)
-          return screens.splice(index, 1)[0]
-        }
 
         let screenToDelete = popRandomScreen(app1Screens)
         await config.api.screen.destroy(

--- a/packages/server/src/sdk/app/workspaceApps/index.ts
+++ b/packages/server/src/sdk/app/workspaceApps/index.ts
@@ -82,3 +82,12 @@ export async function remove(
   )
   await db.bulkRemove(screensToDelete)
 }
+
+export async function createDefaultWorkspaceApp() {
+  const appMetadata = await sdk.applications.metadata.get()
+  return create({
+    name: appMetadata.name,
+    urlPrefix: "/",
+    icon: "Monitoring",
+  })
+}


### PR DESCRIPTION
## Description
Handling builder flows when deleting all workspace apps and screens. The main changes are:
1. When creating a new workspace app, a default blank screen will be added in it
2. Backend checks, not allowing to delete the last screen in an app
3. Frontend changes, not allowing to delete the last screen in an app

https://github.com/user-attachments/assets/ca40a073-4f93-4a42-b101-5cad866b9819

