### PR TITLE
Fix: Loop step failing to iterate arrays from JavaScript steps

### DIFF
--- a/packages/server/src/automations/tests/steps/loop.spec.ts
+++ b/packages/server/src/automations/tests/steps/loop.spec.ts
@@ -560,7 +560,7 @@ describe("Attempt to run a basic loop automation", () => {
     expect(results.steps[2].outputs.rows).toHaveLength(0)
   })
 
-  it.only("should successfully loop over an array returned by a JavaScript step with Array input type", async () => {
+  it("should successfully loop over an array returned by a JavaScript step with Array input type", async () => {
     const results = await createAutomationBuilder(config)
       .onAppAction()
       .executeScript({

--- a/packages/server/src/automations/tests/steps/loop.spec.ts
+++ b/packages/server/src/automations/tests/steps/loop.spec.ts
@@ -560,6 +560,105 @@ describe("Attempt to run a basic loop automation", () => {
     expect(results.steps[2].outputs.rows).toHaveLength(0)
   })
 
+  it.only("should successfully loop over an array returned by a JavaScript step with Array input type", async () => {
+    const results = await createAutomationBuilder(config)
+      .onAppAction()
+      .executeScript({
+        code: "return [1, 2, 3, 4, 5]",
+      })
+      .loop({
+        option: LoopStepType.ARRAY,
+        binding: "{{ steps.1.value }}",
+      })
+      .serverLog({ text: "Processing item: {{loop.currentItem}}" })
+      .test({ fields: {} })
+
+    expect(results.steps[1].outputs.success).toBe(true)
+    expect(results.steps[1].outputs.iterations).toBe(5)
+    expect(results.steps[1].outputs.items).toHaveLength(5)
+
+    results.steps[1].outputs.items.forEach((output: any, index: number) => {
+      expect(output).toMatchObject({
+        success: true,
+      })
+      expect(output.message).toContain(`Processing item: ${index + 1}`)
+    })
+  })
+
+  it("should test array binding directly", async () => {
+    const results = await createAutomationBuilder(config)
+      .onAppAction()
+      .loop({
+        option: LoopStepType.ARRAY,
+        binding: [1, 2, 3],
+      })
+      .serverLog({ text: "Processing item: {{loop.currentItem}}" })
+      .test({ fields: {} })
+
+    expect(results.steps[0].outputs.success).toBe(true)
+    expect(results.steps[0].outputs.iterations).toBe(3)
+    expect(results.steps[0].outputs.items).toHaveLength(3)
+  })
+
+  it("should successfully loop over an array of objects returned by a JavaScript step", async () => {
+    const results = await createAutomationBuilder(config)
+      .onAppAction()
+      .executeScript({
+        code: `
+          return [
+            { id: 1, name: 'Alice' },
+            { id: 2, name: 'Bob' },
+            { id: 3, name: 'Charlie' }
+          ]
+        `,
+      })
+      .loop({
+        option: LoopStepType.ARRAY,
+        binding: "{{ steps.1.value }}",
+      })
+      .serverLog({
+        text: "User: {{loop.currentItem.name}} (ID: {{loop.currentItem.id}})",
+      })
+      .test({ fields: {} })
+
+    expect(results.steps[1].outputs.success).toBe(true)
+    expect(results.steps[1].outputs.iterations).toBe(3)
+    expect(results.steps[1].outputs.items).toHaveLength(3)
+
+    const expectedNames = ["Alice", "Bob", "Charlie"]
+    const expectedIds = [1, 2, 3]
+
+    results.steps[1].outputs.items.forEach((output: any, index: number) => {
+      expect(output).toMatchObject({
+        success: true,
+      })
+      expect(output.message).toContain(
+        `User: ${expectedNames[index]} (ID: ${expectedIds[index]})`
+      )
+    })
+  })
+
+  it("should successfully loop over an empty array returned by a JavaScript step", async () => {
+    const results = await createAutomationBuilder(config)
+      .onAppAction()
+      .executeScript({
+        code: "return []",
+      })
+      .loop({
+        option: LoopStepType.ARRAY,
+        binding: "{{ steps.1.value }}",
+      })
+      .serverLog({ text: "This should not execute" })
+      .test({ fields: {} })
+
+    expect(results.steps[1].outputs.success).toBe(true)
+    expect(results.steps[1].outputs.status).toBe(
+      AutomationStepStatus.NO_ITERATIONS
+    )
+    expect(results.steps[1].outputs.iterations).toBe(0)
+    expect(results.steps[1].outputs.items).toHaveLength(0)
+  })
+
   describe("loop output", () => {
     it("should not output anything if a filter stops the automation", async () => {
       const results = await createAutomationBuilder(config)

--- a/packages/server/src/automations/tests/steps/loop.spec.ts
+++ b/packages/server/src/automations/tests/steps/loop.spec.ts
@@ -148,22 +148,6 @@ describe("Attempt to run a basic loop automation", () => {
     expect(results.steps[2].outputs.message).toContain("ro_ta")
   })
 
-  it("if an incorrect type is passed to the loop it should return an error", async () => {
-    const results = await createAutomationBuilder(config)
-      .onAppAction()
-      .loop({
-        option: LoopStepType.ARRAY,
-        binding: "1, 2, 3",
-      })
-      .serverLog({ text: "Message {{loop.currentItem}}" })
-      .test({ fields: {} })
-
-    expect(results.steps[0].outputs).toEqual({
-      success: false,
-      status: "INCORRECT_TYPE",
-    })
-  })
-
   it("ensure the loop stops if the failure condition is reached", async () => {
     const results = await createAutomationBuilder(config)
       .onAppAction()

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -67,11 +67,18 @@ function getLoopIterable(step: LoopStep): any[] {
   const option = step.inputs.option
   let input = step.inputs.binding
 
-  if (option === LoopStepType.ARRAY && typeof input === "string") {
-    if (input === "") {
-      input = []
-    } else {
-      input = JSON.parse(input)
+  if (option === LoopStepType.ARRAY) {
+    // If input is already an array (e.g., from JavaScript step), use it directly
+    if (Array.isArray(input)) {
+      return input
+    }
+    // If input is a string, parse it as JSON
+    if (typeof input === "string") {
+      if (input === "") {
+        input = []
+      } else {
+        input = JSON.parse(input)
+      }
     }
   }
 

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -64,30 +64,20 @@ function matchesLoopFailureCondition(step: LoopStep, currentItem: any) {
 // function handles the various ways that a LoopStep can be configured, parsing
 // the input and returning an array of items to loop over.
 function getLoopIterable(step: LoopStep): any[] {
-  const option = step.inputs.option
   let input = step.inputs.binding
 
-  if (option === LoopStepType.ARRAY) {
-    // If input is already an array (e.g., from JavaScript step), use it directly
-    if (Array.isArray(input)) {
-      return input
-    }
-    // If input is a string, parse it as JSON
-    if (typeof input === "string") {
-      if (input === "") {
-        input = []
-      } else {
+  if (Array.isArray(input)) {
+    return input
+  } else if (typeof input === "string") {
+    if (input === "") {
+      input = []
+    } else {
+      try {
         input = JSON.parse(input)
+      } catch (e) {
+        input = automationUtils.stringSplit(input)
       }
     }
-  }
-
-  if (option === LoopStepType.STRING && Array.isArray(input)) {
-    input = input.join(",")
-  }
-
-  if (option === LoopStepType.STRING && typeof input === "string") {
-    input = automationUtils.stringSplit(input)
   }
 
   return Array.isArray(input) ? input : [input]

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -22,7 +22,6 @@ import {
   BranchStep,
   LoopStep,
   ContextEmitter,
-  LoopStepType,
   AutomationTriggerResult,
   AutomationResults,
   AutomationStepResult,


### PR DESCRIPTION
## Summary

Fixes BUDI-9258 where JavaScript automation steps returning arrays could not be properly iterated in subsequent loop steps when input type was set to "Array".

## Problem

When a JavaScript step returned an array (e.g., `[1, 2, 3]`), the loop step would fail. This occurred because the `getLoopIterable` function was not correctly handling string formats when `LoopStepType` was `ARRAY`.

## Solution

- Removed the checking of the `LoopStepType` in `getLoopIterable`. It doesn't appear to be necessary, we can just check for any possible variant we're expecting. In a future PR I'll clean up any references left to `LoopStepType`.