### PR TITLE
Update AI JS generation prompt to start minimised. 

### DIFF
--- a/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
+++ b/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
@@ -81,19 +81,12 @@
   let mounted = false
   let isEditorInitialised = false
   let queuedRefresh = false
-  let editorWidth: number | null = null
   let isAIGeneratedContent = false
 
   // Theming!
   let currentTheme = $themeStore?.theme
   let isDark = !currentTheme.includes("light")
   let themeConfig = new Compartment()
-
-  const updateEditorWidth = () => {
-    if (editorEle) {
-      editorWidth = editorEle.offsetWidth
-    }
-  }
 
   $: aiGenEnabled =
     $featureFlags.AI_JS_GENERATION && mode.name === "javascript" && !readonly
@@ -432,16 +425,6 @@
     editorEle.addEventListener("wheel", e => {
       e.stopPropagation()
     })
-
-    // Need to get the width of the drawer to pass to the prompt component
-    updateEditorWidth()
-    const resizeObserver = new ResizeObserver(() => {
-      updateEditorWidth()
-    })
-    resizeObserver.observe(editorEle)
-    return () => {
-      resizeObserver.disconnect()
-    }
   })
 
   onDestroy(() => {

--- a/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
+++ b/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
@@ -470,7 +470,6 @@
   <AIGen
     {bindings}
     {value}
-    parentWidth={editorWidth}
     on:update={handleAICodeUpdate}
     on:accept={() => {
       dispatch("change", editor.state.doc.toString())


### PR DESCRIPTION
## Description
Ensure the AI JS generation box starts off minimised in the bindings drawer. 

## Addresses
https://linear.app/budibase/issue/BUDI-9384/option-to-minimize-generate-ai-prompt-field-down-to-just-the
## Screenshots
<img width="823" alt="image" src="https://github.com/user-attachments/assets/bdb79d99-1f63-4137-b9e9-76b1540b8cee" />

## Launchcontrol
- Fix an issue where the AI JS generation prompt would cover the entire bottom of the bindings drawer. 