### PR TITLE
Consider apps with future migrations as fully migrated, and fix migrations UI

### DIFF
--- a/packages/client/src/components/UpdatingApp.svelte
+++ b/packages/client/src/components/UpdatingApp.svelte
@@ -1,6 +1,9 @@
 <script>
   import { Updating } from "@budibase/frontend-core"
   import { API } from "../api"
+  import { onMount } from "svelte"
+  import { getThemeClassNames } from "@budibase/shared-core"
+  import { themeStore } from "@/stores"
 
   async function isMigrationDone() {
     const response = await API.getMigrationStatus()
@@ -10,14 +13,17 @@
   async function onMigrationDone() {
     window.location.reload()
   }
+
+  onMount(() => {
+    document.getElementById("clientAppSkeletonLoader")?.remove()
+  })
 </script>
 
-<div class="updating">
+<div
+  id="spectrum-root"
+  lang="en"
+  dir="ltr"
+  class="spectrum spectrum--medium {getThemeClassNames($themeStore.theme)}"
+>
   <Updating {isMigrationDone} {onMigrationDone} />
 </div>
-
-<style>
-  .updating {
-    font-family: var(--font-sans);
-  }
-</style>

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -110,7 +110,7 @@ export interface SDK {
   BlockComponent: typeof BlockComponent
 }
 
-let app: ClientApp
+let app: ClientApp | UpdatingApp
 
 const loadBudibase = async () => {
   // Update builder store with any builder flags
@@ -140,9 +140,11 @@ const loadBudibase = async () => {
   )
 
   if (window.MIGRATING_APP) {
-    new UpdatingApp({
-      target: window.document.body,
-    })
+    if (!app) {
+      app = new UpdatingApp({
+        target: window.document.body,
+      })
+    }
     return
   }
 

--- a/packages/frontend-core/src/components/Updating.svelte
+++ b/packages/frontend-core/src/components/Updating.svelte
@@ -38,9 +38,9 @@
   </span>
   <span class="subtext">
     {#if !timedOut}
-      Please wait and we will be back in a second!
+      Please wait and we'll be back in a second!
       <br />
-      Checkout the
+      Check out the
       <a href="https://docs.budibase.com/docs/app-migrations" target="_blank"
         >documentation</a
       > on app migrations.

--- a/packages/server/src/api/controllers/migrations.ts
+++ b/packages/server/src/api/controllers/migrations.ts
@@ -1,22 +1,12 @@
 import { context } from "@budibase/backend-core"
 import { Ctx, GetMigrationStatus } from "@budibase/types"
-import {
-  getAppMigrationVersion,
-  getLatestEnabledMigrationId,
-} from "../../appMigrations"
+import { isAppFullyMigrated } from "../../appMigrations"
 
 export async function getMigrationStatus(ctx: Ctx<void, GetMigrationStatus>) {
   const appId = context.getAppId()
-
   if (!appId) {
     ctx.throw("AppId could not be found")
   }
-
-  const latestAppliedMigration = await getAppMigrationVersion(appId)
-
-  const latestMigrationId = getLatestEnabledMigrationId()
-  const migrated =
-    !latestMigrationId || latestAppliedMigration >= latestMigrationId
-
+  const migrated = await isAppFullyMigrated(appId)
   ctx.body = { migrated }
 }

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -232,7 +232,7 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
     ctx.redirect("/builder/bblogo.png")
     return
   }
-  // No app ID found, cannot serve - return message insteadc
+  // No app ID found, cannot serve - return message instead
   const appId = context.getAppId()
   if (!appId) {
     ctx.body = "No content found - requires app ID"

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -40,10 +40,7 @@ import {
   ToggleBetaFeatureResponse,
   UserCtx,
 } from "@budibase/types"
-import {
-  getAppMigrationVersion,
-  getLatestEnabledMigrationId,
-} from "../../../appMigrations"
+import { isAppFullyMigrated } from "../../../appMigrations"
 
 import send from "koa-send"
 import { getThemeVariables } from "../../../constants/themes"
@@ -215,22 +212,6 @@ export async function processPWAZip(ctx: UserCtx) {
   }
 }
 
-const requiresMigration = async (ctx: Ctx) => {
-  const appId = context.getAppId()
-  if (!appId) {
-    ctx.throw("AppId could not be found")
-  }
-
-  const latestMigration = getLatestEnabledMigrationId()
-  if (!latestMigration) {
-    return false
-  }
-
-  const latestMigrationApplied = await getAppMigrationVersion(appId)
-
-  return latestMigrationApplied !== latestMigration
-}
-
 const getAppScriptHTML = (
   app: App,
   location: "Head" | "Body",
@@ -251,14 +232,14 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
     ctx.redirect("/builder/bblogo.png")
     return
   }
-  // no app ID found, cannot serve - return message instead
-  if (!context.getAppId()) {
+  // No app ID found, cannot serve - return message insteadc
+  const appId = context.getAppId()
+  if (!appId) {
     ctx.body = "No content found - requires app ID"
     return
   }
 
-  const needMigrations = await requiresMigration(ctx)
-
+  const fullyMigrated = await isAppFullyMigrated(appId)
   const bbHeaderEmbed =
     ctx.request.get("x-budibase-embed")?.toLowerCase() === "true"
 
@@ -275,8 +256,6 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
   try {
     db = context.getAppDB({ skip_setup: true })
     const appInfo = await db.get<any>(DocumentType.APP_METADATA)
-
-    let appId = context.getAppId()
     const hideDevTools = !!ctx.params.appUrl
     const sideNav = appInfo.navigation.navigation === "Left"
     const hideFooter =
@@ -315,7 +294,7 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
           branding.faviconUrl !== ""
             ? await objectStore.getGlobalFileUrl("settings", "faviconUrl")
             : "",
-        appMigrating: needMigrations,
+        appMigrating: !fullyMigrated,
         nonce,
       }
 

--- a/packages/server/src/appMigrations/index.ts
+++ b/packages/server/src/appMigrations/index.ts
@@ -66,3 +66,12 @@ export async function checkMissingMigrations(
 
   return next()
 }
+
+export const isAppFullyMigrated = async (appId: string) => {
+  const latestMigration = getLatestEnabledMigrationId()
+  if (!latestMigration) {
+    return true
+  }
+  const latestMigrationApplied = await getAppMigrationVersion(appId)
+  return latestMigrationApplied >= latestMigration
+}


### PR DESCRIPTION
## Description
Updates the logic that checks whether apps need migrations to assume apps with future migrations are fully migrated.
Also fixes the UI shown when migrations are running, which is horribly bugged and shown offscreen.

Changes:
- Consider apps with future migrations as fully migrated
- Unify migration checking logic (previously there were 2 different implementations, meaning the endpoint to check the status of migration disagreed with the data provided when serving an app)
- Hide skeleton content when showing migration UI
- Don't spawn multiple instances of migration UI
- Use actual app theme to match skeleton and real app
- Improve wording
- Hide loading spinner

Before (giant screen, need to scroll down):
![image](https://github.com/user-attachments/assets/1c061d71-9771-490e-8097-3b8a78a8de3c)
![image](https://github.com/user-attachments/assets/71b53e0d-3848-4026-a936-baeec105e23e)

After:
![image](https://github.com/user-attachments/assets/9b973a0d-75fd-4c54-9e34-3662dd8ddb93)
