### PR TITLE
Agent UI tweaks

### DIFF
--- a/packages/builder/src/components/common/NavHeader.svelte
+++ b/packages/builder/src/components/common/NavHeader.svelte
@@ -9,6 +9,7 @@
   export let onAdd: (_e: Event) => void
   export let search: boolean = false
   export let searchable = true
+  export let showAddIcon = true
 
   let searchInput: HTMLInputElement
 
@@ -52,7 +53,11 @@
   />
 
   <div class="title" class:hide={search}>
-    <Body size="S">{title}</Body>
+    {#if $$slots.default}
+      <slot></slot>
+    {:else}
+      <Body size="S">{title}</Body>
+    {/if}
   </div>
 
   {#if searchable}
@@ -66,14 +71,18 @@
     </div>
   {/if}
 
-  <div
-    on:click={handleAddButton}
-    on:keydown={e => keyUtils.handleEnter(() => handleAddButton(e))}
-    class="addButton"
-    class:rotate={search}
-  >
-    <Icon name="Add" hoverable hoverColor="var(--ink)" />
-  </div>
+  {#if showAddIcon}
+    <div
+      on:click={handleAddButton}
+      on:keydown={e => keyUtils.handleEnter(() => handleAddButton(e))}
+      class="addButton"
+      class:rotate={search}
+    >
+      <Icon name="Add" hoverable hoverColor="var(--ink)" />
+    </div>
+  {/if}
+
+  <slot name="right" />
 </div>
 
 <style>

--- a/packages/builder/src/components/common/NavHeader.svelte
+++ b/packages/builder/src/components/common/NavHeader.svelte
@@ -5,9 +5,10 @@
 
   export let title: string
   export let placeholder: string
-  export let value: string
+  export let value: string | undefined = undefined
   export let onAdd: (_e: Event) => void
   export let search: boolean = false
+  export let searchable = true
 
   let searchInput: HTMLInputElement
 
@@ -53,14 +54,17 @@
   <div class="title" class:hide={search}>
     <Body size="S">{title}</Body>
   </div>
-  <div
-    on:click={openSearch}
-    on:keydown={keyUtils.handleEnter(openSearch)}
-    class="searchButton"
-    class:hide={search}
-  >
-    <Icon size="S" name="Search" hoverable hoverColor="var(--ink)" />
-  </div>
+
+  {#if searchable}
+    <div
+      on:click={openSearch}
+      on:keydown={keyUtils.handleEnter(openSearch)}
+      class="searchButton"
+      class:hide={search}
+    >
+      <Icon size="S" name="Search" hoverable hoverColor="var(--ink)" />
+    </div>
+  {/if}
 
   <div
     on:click={handleAddButton}

--- a/packages/builder/src/components/common/NavHeader.svelte
+++ b/packages/builder/src/components/common/NavHeader.svelte
@@ -4,7 +4,7 @@
   import { keyUtils } from "@/helpers/keyUtils"
 
   export let title: string
-  export let placeholder: string
+  export let placeholder: string = ""
   export let value: string | undefined = undefined
   export let onAdd: (_e: Event) => void
   export let search: boolean = false

--- a/packages/builder/src/components/common/NavItem.svelte
+++ b/packages/builder/src/components/common/NavItem.svelte
@@ -305,6 +305,7 @@
   }
   .subtext {
     color: var(--spectrum-global-color-gray-700);
+    font-weight: normal;
   }
 
   .actions {

--- a/packages/builder/src/components/common/NavItem.svelte
+++ b/packages/builder/src/components/common/NavItem.svelte
@@ -11,6 +11,7 @@
   export let showActions: boolean = false
   export let indentLevel: number = 0
   export let text: string
+  export let subtext: string | undefined = undefined
   export let border: boolean = true
   export let selected: boolean = false
   export let opened: boolean = false
@@ -75,6 +76,7 @@
   class:selectedBy
   class:disabled
   class:nonSelectable
+  class:multiline={subtext}
   on:dragend
   on:dragstart
   on:dragover
@@ -124,8 +126,15 @@
         />
       </div>
     {/if}
-    <div class="text" title={showTooltip ? text : null}>
-      <span title={text}>{text}</span>
+    <div class="nav-item-body" title={showTooltip ? text : null}>
+      <div class="text">
+        <span title={text}>{text}</span>
+        {#if subtext}
+          <span class="subtext">
+            {subtext}
+          </span>
+        {/if}
+      </div>
       {#if selectedBy}
         <UserAvatars size="XS" users={selectedBy} />
       {/if}
@@ -157,6 +166,9 @@
     flex-direction: row;
     justify-content: flex-start;
     align-items: stretch;
+  }
+  .nav-item.multiline {
+    height: 52px;
   }
   .nav-item.nonSelectable {
     cursor: inherit;
@@ -216,6 +228,7 @@
     align-items: center;
     color: var(--spectrum-global-color-gray-600);
     order: 1;
+    margin-right: 2px;
   }
   .icon.right {
     order: 4;
@@ -262,7 +275,7 @@
     flex: 0 0 34px;
   }
 
-  .text {
+  .nav-item-body {
     font-weight: 600;
     font-size: 12px;
     flex: 1 1 auto;
@@ -274,14 +287,24 @@
     gap: 8px;
     overflow: hidden;
   }
-  .text span {
+  .nav-item-body span {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
-  .scrollable .text {
+  .scrollable .nav-item-body {
     flex: 0 1 auto;
     width: auto;
+  }
+  .text {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 2px;
+    overflow: hidden;
+  }
+  .subtext {
+    color: var(--spectrum-global-color-gray-700);
   }
 
   .actions {

--- a/packages/builder/src/components/design/Panel.svelte
+++ b/packages/builder/src/components/design/Panel.svelte
@@ -39,39 +39,41 @@
   class:borderRight
   style={panelStyle}
 >
-  <div
-    class="header"
-    class:custom={customHeaderContent}
-    class:borderBottom={borderBottomHeader}
-    class:noHeaderBorder
-  >
-    {#if showBackButton}
-      <Icon name="ArrowLeft" hoverable on:click={onClickBackButton} />
-    {/if}
-    {#if icon}
-      <Icon
-        name={icon}
-        tooltipType={TooltipType.Info}
-        tooltip={iconTooltip}
-        tooltipPosition={TooltipPosition.Top}
-      />
-    {/if}
-    <div class:title={titleCSS}>
-      {#if customTitleContent}
-        <slot name="panel-title-content" />
-      {:else}
-        <Body size="S">{title || ""}</Body>
+  {#if title || customTitleContent}
+    <div
+      class="header"
+      class:custom={customHeaderContent}
+      class:borderBottom={borderBottomHeader}
+      class:noHeaderBorder
+    >
+      {#if showBackButton}
+        <Icon name="ArrowLeft" hoverable on:click={onClickBackButton} />
+      {/if}
+      {#if icon}
+        <Icon
+          name={icon}
+          tooltipType={TooltipType.Info}
+          tooltip={iconTooltip}
+          tooltipPosition={TooltipPosition.Top}
+        />
+      {/if}
+      <div class:title={titleCSS}>
+        {#if customTitleContent}
+          <slot name="panel-title-content" />
+        {:else}
+          <Body size="S">{title || ""}</Body>
+        {/if}
+      </div>
+      {#if showAddButton}
+        <div class="add-button" on:click={onClickAddButton}>
+          <Icon name="Add" />
+        </div>
+      {/if}
+      {#if showCloseButton}
+        <Icon name={closeButtonIcon} hoverable on:click={onClickCloseButton} />
       {/if}
     </div>
-    {#if showAddButton}
-      <div class="add-button" on:click={onClickAddButton}>
-        <Icon name="Add" />
-      </div>
-    {/if}
-    {#if showCloseButton}
-      <Icon name={closeButtonIcon} hoverable on:click={onClickCloseButton} />
-    {/if}
-  </div>
+  {/if}
 
   {#if customHeaderContent}
     <span class="custom-content-wrap">

--- a/packages/builder/src/pages/builder/app/[application]/agent/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/agent/index.svelte
@@ -881,11 +881,12 @@
     padding: var(--spacing-m);
     border: 1px solid var(--spectrum-global-color-gray-300);
     border-radius: 8px;
-    background-color: var(--spectrum-alias-background-color-secondary);
+    background-color: var(--background-alt);
   }
 
   .tool-source-preview .tool-name {
     font-weight: 600;
     color: var(--spectrum-global-color-gray-900);
+    margin: 0;
   }
 </style>

--- a/packages/builder/src/pages/builder/app/[application]/agent/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/agent/index.svelte
@@ -410,7 +410,7 @@
     </div>
   </div>
 
-  <Panel customWidth={320} borderLeft noHeaderBorder>
+  <Panel customWidth={320} borderLeft noHeaderBorder={panelView === "tools"}>
     <NavHeader
       slot="panel-title-content"
       title="Tools"
@@ -439,7 +439,7 @@
           </Body>
         </div>
       {/if}
-      <div slot="right">
+      <div slot="right" style="display:contents;">
         {#if panelView === "toolConfig"}
           <Button
             cta
@@ -450,80 +450,74 @@
         {/if}
       </div>
     </NavHeader>
-    <div class="tab-content">
+    {#if panelView === "tools"}
       <Layout paddingX="L" paddingY="none" gap="S">
-        {#if panelView === "tools"}
-          <InfoDisplay
-            body="Add tools to give your agent knowledge and allow it to take
+        <InfoDisplay
+          body="Add tools to give your agent knowledge and allow it to take
                 action"
-          />
-          <Layout noPadding noGap>
-            {#if toolSources.length > 0}
-              <div class="saved-tools-list">
-                {#each toolSources as toolSource}
-                  {@const menuCallback = createToolMenuCallback(toolSource)}
-                  <NavItem
-                    text={ToolSources.find(ts => ts.type === toolSource.type)
-                      ?.name || ""}
-                    on:click={() => openToolsConfig(toolSource)}
-                    on:contextmenu={menuCallback}
-                  >
-                    <div class="tool-icon" slot="icon">
-                      <svelte:component
-                        this={Logos[toolSource.type]}
-                        height="16"
-                        width="16"
-                      />
-                    </div>
-                    <Icon
-                      on:click={menuCallback}
-                      hoverable
-                      name="MoreSmallList"
-                    />
-                    <Icon size="S" name="ChevronRight" slot="right" />
-                  </NavItem>
-                {/each}
-              </div>
-            {:else}
-              <div class="empty-state">
-                <Body size="S">
-                  No tools connected yet.
-                  <br />
-                  Click "Add Tools" to get started!
-                </Body>
-              </div>
-            {/if}
-          </Layout>
-        {:else if panelView === "toolConfig"}
-          {#if selectedConfigToolSource?.tools}
-            <div class="tools-list">
-              {#each selectedConfigToolSource.tools as tool}
-                <div class="tool-toggle-item">
-                  <div class="tool-toggle-info">
-                    <div class="tool-toggle-name">{tool.name}</div>
-                    <div class="tool-toggle-description">
-                      {tool.description}
-                    </div>
-                  </div>
-                  <div class="tool-toggle-switch">
-                    <Toggle
-                      value={!selectedConfigToolSource.disabledTools?.includes(
-                        tool.name
-                      )}
-                      on:change={() => toggleTool(tool.name)}
-                    />
-                  </div>
+        />
+        {#if toolSources.length > 0}
+          <div class="saved-tools-list">
+            {#each toolSources as toolSource}
+              {@const menuCallback = createToolMenuCallback(toolSource)}
+              <NavItem
+                text={ToolSources.find(ts => ts.type === toolSource.type)
+                  ?.name || ""}
+                on:click={() => openToolsConfig(toolSource)}
+                on:contextmenu={menuCallback}
+              >
+                <div class="tool-icon" slot="icon">
+                  <svelte:component
+                    this={Logos[toolSource.type]}
+                    height="16"
+                    width="16"
+                  />
                 </div>
-              {/each}
-            </div>
-          {:else}
-            <div class="empty-state">
-              <Body size="S">No tools available for this source.</Body>
-            </div>
-          {/if}
+                <Icon on:click={menuCallback} hoverable name="MoreSmallList" />
+                <Icon size="S" name="ChevronRight" slot="right" />
+              </NavItem>
+            {/each}
+          </div>
+        {:else}
+          <div class="empty-state">
+            <Body size="S">
+              No tools connected yet.
+              <br />
+              Click "Add Tools" to get started!
+            </Body>
+          </div>
         {/if}
       </Layout>
-    </div>
+    {:else if panelView === "toolConfig"}
+      <Layout paddingX="L" paddingY="L" gap="S">
+        {#if selectedConfigToolSource?.tools}
+          <div class="tools-list">
+            {#each selectedConfigToolSource.tools as tool}
+              <div class="tool-toggle-item">
+                <div class="tool-toggle-info">
+                  <div class="tool-toggle-name">{tool.name}</div>
+                  <div class="tool-toggle-description">
+                    {tool.description}
+                  </div>
+                </div>
+                <div class="tool-toggle-switch">
+                  <Toggle
+                    value={!selectedConfigToolSource.disabledTools?.includes(
+                      tool.name
+                    )}
+                    on:change={() => toggleTool(tool.name)}
+                  />
+                </div>
+              </div>
+            {/each}
+          </div>
+        {:else}
+          <div class="empty-state">
+            <Body size="S">No tools available for this source.</Body>
+          </div>
+        {/if}
+      </Layout>
+    {/if}
   </Panel>
 </div>
 

--- a/packages/builder/src/pages/builder/app/[application]/agent/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/agent/index.svelte
@@ -360,17 +360,19 @@
     {/if}
   </Panel>
 
-  <div class="chat-area" bind:this={chatAreaElement}>
-    <Chatbox bind:chat {loading} />
-    <div class="input-wrapper">
-      <textarea
-        bind:value={inputValue}
-        bind:this={textareaElement}
-        class="input spectrum-Textfield-input"
-        on:keydown={handleKeyDown}
-        placeholder="Ask anything"
-        disabled={loading}
-      />
+  <div class="chat-wrapper">
+    <div class="chat-area" bind:this={chatAreaElement}>
+      <Chatbox bind:chat {loading} />
+      <div class="input-wrapper">
+        <textarea
+          bind:value={inputValue}
+          bind:this={textareaElement}
+          class="input spectrum-Textfield-input"
+          on:keydown={handleKeyDown}
+          placeholder="Ask anything"
+          disabled={loading}
+        />
+      </div>
     </div>
   </div>
 
@@ -681,11 +683,17 @@
     align-items: stretch;
   }
 
+  .chat-wrapper {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+  }
   .chat-area {
     flex: 1 1 auto;
     display: flex;
     flex-direction: column;
     overflow-y: auto;
+    height: 0;
   }
 
   .agent-actions-heading {
@@ -734,7 +742,7 @@
     width: 600px;
     margin: 0 auto;
     background: var(--background-alt);
-    padding-bottom: 48px;
+    padding-bottom: 32px;
     display: flex;
     flex-direction: column;
   }

--- a/packages/builder/src/pages/builder/app/[application]/agent/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/agent/index.svelte
@@ -9,8 +9,6 @@
     Modal,
     ModalContent,
     notifications,
-    Tab,
-    Tabs,
     TextArea,
     Toggle,
   } from "@budibase/bbui"

--- a/packages/builder/src/pages/builder/app/[application]/agent/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/agent/index.svelte
@@ -530,37 +530,38 @@
     showCloseIcon
     onCancel={() => toolSourceModal.hide()}
   >
-    <div class="vote-banner">
-      <Icon name="Hand" />
-      <span> Vote for which tools we add next </span>
-      <Button>Vote</Button>
-    </div>
     <section class="tool-source-tiles">
       {#each ToolSources as toolSource}
         <div class="tool-source-tile">
           <div class="tool-source-header">
-            <div class="tool-source-icon">
-              {#if Logos[toolSource.type]}
+            {#if Logos[toolSource.type]}
+              <div class="tool-source-icon">
                 <svelte:component
                   this={Logos[toolSource.type]}
-                  height="24"
-                  width="24"
+                  height="20"
+                  width="20"
                 />
-              {/if}
-            </div>
+              </div>
+            {/if}
             <Heading size="XS">{toolSource.name}</Heading>
           </div>
-          <Body size="S">
-            {toolSource.description}
-          </Body>
-          <Button
-            cta
-            size="S"
-            disabled={toolSources.some(ts => ts.type === toolSource.type)}
-            on:click={() => openToolConfig(toolSource)}
-          >
-            Connect
-          </Button>
+          <div class="tool-source-description">
+            <Body size="S" color="var(--spectrum-global-color-gray-700)">
+              {toolSource.description}
+            </Body>
+          </div>
+          {#if toolSources.some(ts => ts.type === toolSource.type)}
+            <div class="tile-connected">
+              <Icon size="S" name="CheckmarkCircle" />
+              Connected
+            </div>
+          {:else}
+            <div>
+              <Button cta size="S" on:click={() => openToolConfig(toolSource)}>
+                Connect
+              </Button>
+            </div>
+          {/if}
         </div>
       {/each}
     </section>
@@ -721,7 +722,7 @@
   .tool-source-tiles {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 10px;
+    gap: 12px;
   }
 
   .tool-source-tile {
@@ -729,18 +730,33 @@
     border: 1px solid var(--spectrum-global-color-gray-300);
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
-    height: 100px;
-    border-radius: 5px;
+    justify-content: flex-start;
+    gap: var(--spacing-m);
+    height: 110px;
+    border-radius: 4px;
   }
 
   .tool-source-header {
     display: flex;
     align-items: center;
-    gap: var(--spacing-s);
-    margin-bottom: var(--spacing-s);
+    gap: var(--spacing-m);
   }
-
+  .tool-source-description {
+    flex: 1 1 auto;
+  }
+  .tool-source-description :global(p) {
+    overflow: hidden;
+    line-clamp: 2;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    display: -webkit-box;
+  }
+  .tile-connected {
+    color: var(--spectrum-global-color-green-400);
+    display: flex;
+    gap: 6px;
+    font-size: 12px;
+  }
   .tool-source-icon {
     display: flex;
     align-items: center;
@@ -853,19 +869,6 @@
   }
   .tool-toggle-switch {
     margin-right: -14px;
-  }
-
-  .vote-banner {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-l);
-    background-color: #2e3851;
-    border-radius: var(--border-radius-m);
-    padding: var(--spacing-s);
-  }
-
-  .vote-banner:last-child {
-    margin-left: auto;
   }
 
   .delete-confirm-content {

--- a/packages/builder/src/stores/portal/agents.ts
+++ b/packages/builder/src/stores/portal/agents.ts
@@ -6,6 +6,7 @@ import {
   AgentToolSourceWithTools,
   CreateToolSourceRequest,
 } from "@budibase/types"
+import { get } from "svelte/store"
 
 interface AgentStore {
   chats: AgentChat[]
@@ -84,6 +85,10 @@ export class AgentsStore extends BudiStore<AgentStore> {
       )
       return state
     })
+  }
+
+  getToolSource = (type: string) => {
+    return get(this.store).toolSources.find(ts => ts.type === type)
   }
 
   setCurrentChatId = (chatId: string) => {


### PR DESCRIPTION
## Description
This PR is a collection of UI improvements for the new agent page.

### Full page
Before:
![image](https://github.com/user-attachments/assets/657e3252-b909-47ac-b0a9-4bd0b1da8372)

After:
![image](https://github.com/user-attachments/assets/45e407d3-d4b5-40d5-b036-7e559e211cb2)

### Chat list
Before:
![image](https://github.com/user-attachments/assets/5d0af21f-86a2-4c0c-921b-04265ee4e7ba)

After:
![image](https://github.com/user-attachments/assets/de379d05-3215-4a95-a0c3-81039bb01ee8)

### Integration list
Edit and delete have been moved into a "more" menu, also triggerable via right click:
![image](https://github.com/user-attachments/assets/19236082-b896-44b6-96f4-f1698f4995b9)
![image](https://github.com/user-attachments/assets/6984a26a-6de9-4231-8e79-73ff70486dc4)

Before:
![image](https://github.com/user-attachments/assets/94c7ad4f-1dea-4b39-afa0-7445a804d985)

After:
![image](https://github.com/user-attachments/assets/8259888c-0586-407b-a1b7-9043a5fc586c)

### Integration tool config
Save button is now only highlighted when changes have been made and need saved. Changes are properly discarded upon going back without saving.

Before:
![image](https://github.com/user-attachments/assets/8118945b-a5a5-4067-aa49-70e27158d604)

After:
![image](https://github.com/user-attachments/assets/41732363-126d-46f6-8bf5-1894f0016da1)

### Add tool modal
Before:
![image](https://github.com/user-attachments/assets/1930e684-df01-4108-8d0b-1d76c05e1501)

After:
![image](https://github.com/user-attachments/assets/2978dc28-cd41-4d21-9176-348163e3b577)
