### PR TITLE
Changed screen navigation logo position based on feedback.

### DIFF
--- a/packages/client/src/components/app/Layout.svelte
+++ b/packages/client/src/components/app/Layout.svelte
@@ -607,7 +607,6 @@
   .user.left {
     display: flex;
     flex-direction: column;
-    align-items: inherit;
     gap: var(--spacing-m);
   }
   .mobile .user.left {

--- a/packages/client/src/components/app/Layout.svelte
+++ b/packages/client/src/components/app/Layout.svelte
@@ -322,6 +322,7 @@
             {/if}
             {#if !embedded}
               <div class="user left">
+                <UserMenu />
                 {#if logoPosition === "bottom"}
                   <Logo
                     {logoUrl}
@@ -334,7 +335,6 @@
                     {getSanitizedUrl}
                   />
                 {/if}
-                <UserMenu />
               </div>
             {/if}
           </div>
@@ -606,7 +606,8 @@
   }
   .user.left {
     display: flex;
-    align-items: center;
+    flex-direction: column;
+    align-items: inherit;
     gap: var(--spacing-m);
   }
   .mobile .user.left {


### PR DESCRIPTION
Description
A minor adjustment has been made to the logo positioning when it is set to appear at the bottom. The logo now displays beneath the user details section.

Layman’s Version:
Made a minor tweak; if the logo is set to show at the bottom, it now appears below the user’s details section.