### PR TITLE
Don't return any workspace app is flag is not enabled

### DIFF
--- a/packages/server/src/sdk/app/workspaceApps/crud.ts
+++ b/packages/server/src/sdk/app/workspaceApps/crud.ts
@@ -1,5 +1,5 @@
-import { context, docIds, HTTPError } from "@budibase/backend-core"
-import { WithoutDocMetadata, WorkspaceApp } from "@budibase/types"
+import { context, docIds, features, HTTPError } from "@budibase/backend-core"
+import { FeatureFlag, WithoutDocMetadata, WorkspaceApp } from "@budibase/types"
 import sdk from "../.."
 
 async function guardName(name: string, id?: string) {
@@ -11,6 +11,10 @@ async function guardName(name: string, id?: string) {
 }
 
 export async function fetch(): Promise<WorkspaceApp[]> {
+  if (!features.isEnabled(FeatureFlag.WORKSPACE_APPS)) {
+    return []
+  }
+
   const db = context.getAppDB()
   const docs = await db.allDocs<WorkspaceApp>(
     docIds.getWorkspaceAppParams(null, { include_docs: true })


### PR DESCRIPTION
## Description
Don't return any workspace app is flag is not enabled. This will make sure there is no usages for unexpected migrated clients