### PR TITLE
Never run disabled migrations

### DIFF
--- a/packages/server/src/appMigrations/migrationsProcessor.ts
+++ b/packages/server/src/appMigrations/migrationsProcessor.ts
@@ -39,7 +39,11 @@ export async function processMigrations(
           )
 
           let index = 0
-          for (const { id, func } of pendingMigrations) {
+          for (const { id, func, disabled } of pendingMigrations) {
+            if (disabled) {
+              // If we find a disabled migration, we prevent running any other
+              return
+            }
             const expectedMigration =
               migrationIds[migrationIds.indexOf(currentVersion) + 1]
 


### PR DESCRIPTION
## Description
We got an issue where migrations ran in certain scenarios (like apps from templates) even if they were disabled. Fixing this, ensuring that nothing runs after a disabled migration