### PR TITLE
Fixed an issue were the bottom logo was stretched due to flex on some browsers

### DIFF
--- a/packages/client/src/components/app/Layout.svelte
+++ b/packages/client/src/components/app/Layout.svelte
@@ -324,16 +324,18 @@
               <div class="user left">
                 <UserMenu />
                 {#if logoPosition === "bottom"}
-                  <Logo
-                    {logoUrl}
-                    {logoLinkUrl}
-                    {openLogoLinkInNewTab}
-                    {hideLogo}
-                    {title}
-                    {linkable}
-                    {isInternal}
-                    {getSanitizedUrl}
-                  />
+                  <div>
+                    <Logo
+                      {logoUrl}
+                      {logoLinkUrl}
+                      {openLogoLinkInNewTab}
+                      {hideLogo}
+                      {title}
+                      {linkable}
+                      {isInternal}
+                      {getSanitizedUrl}
+                    />
+                  </div>
                 {/if}
               </div>
             {/if}


### PR DESCRIPTION
## Description
Added a containing div to avoid some browsers stretching bottom positioned logos.

## Launchcontrol
Fixed an issue where bottom-positioned logos were stretched on specific browsers
