### PR TITLE
Filter and Gridblock fixes

### DIFF
--- a/packages/client/src/components/app/filter/Filter.svelte
+++ b/packages/client/src/components/app/filter/Filter.svelte
@@ -112,8 +112,10 @@
     : ActionTypes.RemoveDataProviderQueryExtension
 
   // Register extension actions
-  $: addExtension = componentId ? getAction(componentId, addAction) : null
-  $: removeExtension = componentId ? getAction(componentId, removeAction) : null
+  $: addExtension =
+    componentId && loaded ? getAction(componentId, addAction) : null
+  $: removeExtension =
+    componentId && loaded ? getAction(componentId, removeAction) : null
 
   // If the filters are updated, notify the target of the change
   $: hydrated && dataComponent && loaded && fire(filterExtension)
@@ -206,7 +208,6 @@
     if (persistFilters) {
       toLocalStorage()
     }
-
     addExtension?.($component.id, isGridblock ? extension : query)
   }
 
@@ -397,7 +398,7 @@
 
   onDestroy(() => {
     // Ensure the extension is cleared on destroy
-    removeExtension($component.id)
+    removeExtension?.($component.id)
   })
 </script>
 

--- a/packages/client/src/components/app/filter/FilterButton.svelte
+++ b/packages/client/src/components/app/filter/FilterButton.svelte
@@ -36,7 +36,7 @@
   let filterMeta: string | undefined
   let filterTitle: string | undefined
 
-  $: iconName = !filter ? "selection-plus" : "x-circle"
+  $: iconName = !filter ? "plus-circle" : "x-circle"
   $: fieldSchema = config ? schema?.[config?.field] : undefined
   $: filterOp = filter
     ? operators?.find(op => op.value === filter.operator)

--- a/packages/frontend-core/src/components/grid/stores/conditions.ts
+++ b/packages/frontend-core/src/components/grid/stores/conditions.ts
@@ -73,15 +73,16 @@ export const initialise = (context: StoreContext) => {
     const $metadata = get(metadata)
     let metadataUpdates: Record<string, any> = {}
     for (let row of $rows) {
+      const meta = $metadata[row._id]
       const changed =
         // No _rev indicates a new row
         !row._rev ||
         // _rev changed since last evaluation
-        $metadata[row._id].version !== row._rev ||
+        (meta && meta.version !== row._rev) ||
         // this is an external row, we have no way to know if it has changed, so
         // we always re-evaluate
         row._rev === EXTERNAL_ROW_REV
-      if (!changed) {
+      if (!changed && meta) {
         continue
       }
 


### PR DESCRIPTION
## Description
Some fixes around the `Filter` and `GridBlock` components. The `Filter` component was holding on to action context from the `GridBlock` provider. As this context isn't cleared when leaving the page, upon return there was a window in which the old context could be grabbed and effectively disconnect the Filter and Grid.

## Addresses
- Fix to ensure the `Filter` will update its copy of the `GridBlock` action callbacks when navigating to another page and back
- Adds a fix to ensure that when processing row conditions for a `GridBlock`, in then event there is no cached record of metadata for a row, a request to parse the metadata is made. When refreshing a page with a `GridBlock` and a `Filter` configured to persist it would retrigger the conditions checks but if there were new rows that hadn't been processed it would crash the builder.
- Switches the filter icon to the phosphor `plus-circle` icon


## Launchcontrol
Fixed to ensure filters use the correct action context on page load and stop Grid for throwing an error when processing metadata for conditions.