### PR TITLE
Removing codemirror whitespace highlighting

### DIFF
--- a/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
+++ b/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
@@ -25,7 +25,6 @@
     dropCursor,
     highlightActiveLine,
     highlightActiveLineGutter,
-    highlightWhitespace,
     placeholder as placeholderFn,
     MatchDecorator,
     ViewPlugin,
@@ -325,9 +324,6 @@
     if (mode.name === "javascript") {
       complete.push(snippetMatchDecoPlugin)
       complete.push(javascript())
-      if (!readonly) {
-        complete.push(highlightWhitespace())
-      }
     }
     // HBS only plugins
     else {
@@ -510,9 +506,6 @@
     width: 100%;
     background: var(--spectrum-global-color-gray-100) !important;
     z-index: -2;
-  }
-  .code-editor :global(.cm-highlightSpace:before) {
-    color: var(--spectrum-global-color-gray-500);
   }
 
   /* Code selection */


### PR DESCRIPTION
## Description
Remove the codemirror JS whitespace plugin, tis ugly and we don't need it.

Before:
![image](https://github.com/user-attachments/assets/ed90fb04-0926-41ab-940f-cf02fd6a7264)

After:
![image](https://github.com/user-attachments/assets/af91583c-1d98-4a69-acf6-daa912db4143)