### PR TITLE
Fixing `Accordion` icons

### DIFF
--- a/packages/bbui/src/Accordion/Accordion.svelte
+++ b/packages/bbui/src/Accordion/Accordion.svelte
@@ -40,15 +40,15 @@
         style="--font-weight: {bold ? 'bold' : 'normal'}"
         on:click={() => (isOpen = !isOpen)}
       >
+        <Icon name={isOpen ? "caret-down" : "caret-right"} size="S" />
         {header}
       </button>
-      <Icon name="caret-right" size="S" />
     </h3>
     <div
       class="spectrum-Accordion-itemContent"
       role={itemName}
       style={noPadding
-        ? "padding-left: 20px; padding-bottom: 0;"
+        ? "padding-left: 0; padding-bottom: 0;"
         : "padding-left: 30px;"}
     >
       <slot />
@@ -57,9 +57,6 @@
 </div>
 
 <style>
-  .spectrum-Accordion {
-    margin-left: -20px;
-  }
   .spectrum-Accordion-item {
     border: none;
   }
@@ -70,6 +67,12 @@
     text-transform: none;
     font-weight: var(--font-weight);
     min-height: auto;
+    display: flex;
+    gap: var(--spacing-m);
+    padding-left: 0;
+  }
+  .spectrum-Accordion-itemHeader:hover {
+    background-color: transparent;
   }
   .spectrum-Accordion-itemHeaderS {
     font-size: 0.875rem;


### PR DESCRIPTION
## Description
Fixing Accordion component has it depended on the dimensions of the old icons.

Before: 
![image](https://github.com/user-attachments/assets/0170cbd6-2532-4871-8a74-047d43f27499)

![image](https://github.com/user-attachments/assets/89f10d02-1ef2-465a-a05a-4dcd3eec95bd)


Now:
![image](https://github.com/user-attachments/assets/3efe9738-10d6-4a62-adc0-ed738277ff4b)

![image](https://github.com/user-attachments/assets/978e7994-4b22-49cc-86f1-bf58f13edd60)
