### PR TITLE
Add user count to usages

### DIFF
--- a/packages/builder/src/pages/builder/portal/account/usage.svelte
+++ b/packages/builder/src/pages/builder/portal/account/usage.svelte
@@ -36,8 +36,8 @@
     ["Day Passes"]: () => true,
     [Feature.AI_CUSTOM_CONFIGS]: () => true,
     Queries: () => true,
-    Users: license => {
-      return license.plan.model !== PlanModel.PER_USER
+    Creators: license => {
+      return license.plan.model === PlanModel.PER_USER
     },
   }
 

--- a/packages/builder/src/pages/builder/portal/users/users/_components/OnboardingTypeModal.svelte
+++ b/packages/builder/src/pages/builder/portal/users/users/_components/OnboardingTypeModal.svelte
@@ -27,7 +27,7 @@
       }}
     >
       <div class="content onboarding-type-wrap">
-        <Icon name="browser" />
+        <Icon name="envelope-simple" />
         <div class="onboarding-type-text">
           <Body size="S">Send email invites</Body>
         </div>


### PR DESCRIPTION
## Description
Include users in the usage page. Also updated the invite user modal to use an envelope icon instead of the browser.

## Addresses
- https://linear.app/budibase/issue/GRO-1113/add-user-count

## Screenshots
![show users count](https://github.com/user-attachments/assets/c8dba4d2-79c2-4785-b515-a499842a04fc)

![send_email_invites](https://github.com/user-attachments/assets/c0a5d494-bd71-405c-9026-e157240eb9e4)


## Launchcontrol
Add missing users count to the usage page
