### PR TITLE
Fix for binding drawer render loop

### DIFF
--- a/packages/builder/src/components/common/bindings/BindingPanel.svelte
+++ b/packages/builder/src/components/common/bindings/BindingPanel.svelte
@@ -352,39 +352,35 @@
       {/if}
       <div class="editor">
         {#if mode === BindingMode.Text}
-          {#key completions}
-            <CodeEditor
-              value={hbsValue || ""}
-              on:change={onChangeHBSValue}
-              bind:getCaretPosition
-              bind:insertAtPos
-              {completions}
-              {bindings}
-              {validations}
-              autofocus={autofocusEditor}
-              placeholder={placeholder ||
-                "Add bindings by typing {{ or use the menu on the right"}
-              jsBindingWrapping={false}
-            />
-          {/key}
+          <CodeEditor
+            value={hbsValue || ""}
+            on:change={onChangeHBSValue}
+            bind:getCaretPosition
+            bind:insertAtPos
+            {completions}
+            {bindings}
+            {validations}
+            autofocus={autofocusEditor}
+            placeholder={placeholder ||
+              "Add bindings by typing {{ or use the menu on the right"}
+            jsBindingWrapping={false}
+          />
         {:else if mode === BindingMode.JavaScript}
-          {#key completions}
-            <CodeEditor
-              value={jsValue ? decodeJSBinding(jsValue) : ""}
-              on:change={onChangeJSValue}
-              on:ai_suggestion={() => (sidePanel = "Evaluation")}
-              {completions}
-              {bindings}
-              {validations}
-              mode={EditorModes.JS}
-              bind:getCaretPosition
-              bind:insertAtPos
-              autofocus={autofocusEditor}
-              placeholder={placeholder ||
-                "Add bindings by typing $ or use the menu on the right"}
-              jsBindingWrapping={completions.length > 0}
-            />
-          {/key}
+          <CodeEditor
+            value={jsValue ? decodeJSBinding(jsValue) : ""}
+            on:change={onChangeJSValue}
+            on:ai_suggestion={() => (sidePanel = "Evaluation")}
+            {completions}
+            {bindings}
+            {validations}
+            mode={EditorModes.JS}
+            bind:getCaretPosition
+            bind:insertAtPos
+            autofocus={autofocusEditor}
+            placeholder={placeholder ||
+              "Add bindings by typing $ or use the menu on the right"}
+            jsBindingWrapping={completions.length > 0}
+          />
         {/if}
         {#if targetMode}
           <div class="mode-overlay">


### PR DESCRIPTION
## Description
There was an issue whereby the `CodeEditor` in the `BindingPanel` was getting stuck in a render loop. When editing a bindable field in the component settings section, the builder would become unresponsive when an update was saved. The issue only seemed to affect dev environments.

## Addresses
- https://github.com/Budibase/budibase/issues/16396

## Launchcontrol
Fix for BindingPanel render loop.