### PR TITLE
Fix automation name grouping

### DIFF
--- a/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
@@ -49,7 +49,14 @@
       }
       // Otherwise group by trigger
       if (!category) {
-        category = auto.definition?.trigger?.name || "No Trigger"
+        let triggerName = auto.definition?.trigger?.name || "No Trigger"
+        // The definition was changed from "App Action" to "User action" in the definition
+        // so now we have a mixed state where some people will have User action and some will have App Action
+        // so we need to normalize it to User action for consistent grouping
+        if (triggerName === "App Action") {
+          triggerName = "User action"
+        }
+        category = triggerName
       } else {
         dataTrigger = true
       }

--- a/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
@@ -51,7 +51,6 @@
       if (!category) {
         let triggerName = auto.definition?.trigger?.name || "No Trigger"
         // The definition was changed from "App Action" to "User action" in the definition
-        // so now we have a mixed state where some people will have User action and some will have App Action
         // so we need to normalize it to User action for consistent grouping
         if (triggerName === "App Action") {
           triggerName = "User action"


### PR DESCRIPTION
## Description
Fixes an issue where with the renaming of the "App Action" trigger to "User Action" you could have multiple groups of the same trigger type. This just ensures that they all appear as one group in the automations side panel. 

