### PR TITLE
Treat citext as string

### DIFF
--- a/packages/server/src/integration-test/postgres.spec.ts
+++ b/packages/server/src/integration-test/postgres.spec.ts
@@ -210,6 +210,31 @@ if (mainDescriptions.length) {
           expect(row.price).toBe("400.00")
         })
       })
+
+      describe("citext field", () => {
+        const tableName = "citexttable"
+        let table: Table
+
+        beforeAll(async () => {
+          await client.raw(`
+        CREATE EXTENSION IF NOT EXISTS citext;
+        CREATE TABLE ${tableName} (
+          id serial PRIMARY KEY,
+          email citext
+        )   
+      `)
+          const response = await config.api.datasource.fetchSchema({
+            datasourceId: datasource._id!,
+          })
+          table = response.datasource.entities![tableName]
+        })
+
+        it("should map citext column to internal type string", async () => {
+          expect(table).toBeDefined()
+          expect(table?.schema.email.type).toBe(FieldType.STRING)
+          expect(table?.schema.email.externalType).toBe("USER-DEFINED")
+        })
+      })
     }
   )
 

--- a/packages/server/src/integrations/postgres.ts
+++ b/packages/server/src/integrations/postgres.ts
@@ -378,6 +378,7 @@ class PostgresIntegration extends Sql implements DatasourcePlus {
           presence: required && !hasDefault && !isGenerated,
           externalType: column.data_type,
           options: enumValues?.[column.udt_name],
+          userDefinedType: column.udt_name,
         })
       }
 

--- a/packages/server/src/integrations/utils/utils.ts
+++ b/packages/server/src/integrations/utils/utils.ts
@@ -110,6 +110,10 @@ const SQL_TYPE_MAP: Record<string, PrimitiveTypes> = {
   ...SQL_OPTIONS_TYPE_MAP,
 }
 
+const SQL_USER_DEFINED_TYPE_MAP: Record<string, PrimitiveTypes> = {
+  citext: FieldType.STRING,
+}
+
 export const isExternalTableID = sql.utils.isExternalTableID
 export const isExternalTable = sql.utils.isExternalTable
 export const buildExternalTableId = sql.utils.buildExternalTableId
@@ -134,8 +138,10 @@ export function generateColumnDefinition(config: {
   name: string
   presence: boolean
   options?: string[]
+  userDefinedType?: string
 }) {
-  let { externalType, autocolumn, name, presence, options } = config
+  let { externalType, autocolumn, name, presence, options, userDefinedType } =
+    config
   let foundType = FieldType.STRING
   const lowerCaseType = externalType.toLowerCase()
   let matchingTypes: { external: string; internal: PrimitiveTypes }[] = []
@@ -146,6 +152,8 @@ export function generateColumnDefinition(config: {
   // check for an enum column and handle that separately.
   if (lowerCaseType.startsWith("enum")) {
     matchingTypes.push({ external: "enum", internal: FieldType.OPTIONS })
+  } else if (userDefinedType && userDefinedType in SQL_USER_DEFINED_TYPE_MAP) {
+    foundType = SQL_USER_DEFINED_TYPE_MAP[userDefinedType]
   } else {
     for (let [external, internal] of Object.entries(SQL_TYPE_MAP)) {
       if (lowerCaseType.includes(external)) {


### PR DESCRIPTION
## Description
Importing **citext** was being treated as *Options* internal type, which was causing problems. Updated to treat **citext** as *Text* instead.

## Addresses
- https://linear.app/budibase/issue/GRO-1312/email-field-is-imported-as-dropdown-and-throws-error-when-trying-to

## Screensh
![Screenshot 2025-06-24 at 11 16 02](https://github.com/user-attachments/assets/e0885397-855d-447e-ab5d-9be5db447b4b)

*Correctly importing as Text instead of Options*


## Launchcontrol
Support **citext** data type in Postgres
