### PR TITLE
Fix an issue where automation mode wasn't being reset to Editor

### DIFF
--- a/packages/builder/src/stores/builder/automations.ts
+++ b/packages/builder/src/stores/builder/automations.ts
@@ -1610,6 +1610,10 @@ const automationActions = (store: AutomationStore) => ({
       delete state.testResults
       state.showTestModal = false
       delete state.selectedNodeId
+      state.showLogsPanel = false
+      state.showLogDetailsPanel = false
+      delete state.selectedLog
+      delete state.selectedLogStepData
       return state
     })
   },

--- a/packages/builder/src/types/automations.ts
+++ b/packages/builder/src/types/automations.ts
@@ -140,6 +140,7 @@ export interface AutomationState {
   selectedLog?: any
   selectedLogStepData?: any
   showLogsPanel?: boolean
+  showLogDetailsPanel?: boolean
 }
 
 export interface DerivedAutomationState extends AutomationState {


### PR DESCRIPTION
## Description
If you had the logs view selected and you selected a new automation, the editor / logs toggles would both be active. 