### PR TITLE
[Fixed] Use getExistingPlatformUsers to get email

### DIFF
--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -113,7 +113,7 @@ export const addSsoSupport = async (
   try {
     const [userByEmail] = await users.getExistingPlatformUsers([email])
     if (!userByEmail) {
-      ctx.throw(400, "User not found")
+      ctx.throw(404, "Not Found")
     }
 
     await platform.users.addSsoUser(

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -29,7 +29,6 @@ import {
   LockType,
   LookupAccountHolderResponse,
   LookupTenantUserResponse,
-  PlatformUserByEmail,
   SaveUserResponse,
   SearchUsersRequest,
   SearchUsersResponse,
@@ -113,7 +112,7 @@ export const addSsoSupport = async (
   const { email, ssoId } = ctx.request.body
   try {
     const [userByEmail] = await users.getExistingPlatformUsers([email])
-    if(!userByEmail) {
+    if (!userByEmail) {
       ctx.throw(400, "User not found")
     }
 

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -112,10 +112,11 @@ export const addSsoSupport = async (
 ) => {
   const { email, ssoId } = ctx.request.body
   try {
-    // Status is changed to 404 from getUserDoc if user is not found
-    const userByEmail = (await platform.users.getUserDoc(
-      email
-    )) as PlatformUserByEmail
+    const [userByEmail] = await users.getExistingPlatformUsers([email])
+    if(!userByEmail) {
+      ctx.throw(400, "User not found")
+    }
+
     await platform.users.addSsoUser(
       ssoId,
       email,


### PR DESCRIPTION
## Description

Replaced `getUserDoc` with `getExistingPlatformUsers` in order to find by lower case email

`getUserDoc` is causing a problem with SSO when it tries to retrieve the emails with capital letters.