### PR TITLE
Fixing undo/redo

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPanel.svelte
@@ -96,6 +96,7 @@
     overflow: hidden;
     top: 0;
     left: 0;
+    z-index: -99;
   }
   .header {
     display: flex;

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/AppPanel.svelte
@@ -96,7 +96,8 @@
     overflow: hidden;
     top: 0;
     left: 0;
-    z-index: -99;
+    /* this container is just used for measurement, doesn't need to be seen */
+    visibility: hidden;
   }
   .header {
     display: flex;

--- a/packages/builder/src/stores/builder/app.ts
+++ b/packages/builder/src/stores/builder/app.ts
@@ -11,7 +11,7 @@ import {
   UpdateAppRequest,
 } from "@budibase/types"
 import { get } from "svelte/store"
-import { initialise } from "."
+import { initialise, navigationStore } from "."
 
 interface ClientFeatures {
   spectrumThemes: boolean
@@ -203,6 +203,12 @@ export class AppMetaStore extends BudiStore<AppMetaState> {
     const { appId } = get(this.store)
     const appPackage = await API.fetchAppPackage(appId)
     await initialise(appPackage)
+  }
+
+  async refreshAppNav() {
+    const { appId } = get(this.store)
+    const { application } = await API.fetchAppPackage(appId)
+    navigationStore.syncAppNavigation(application?.navigation)
   }
 }
 

--- a/packages/builder/src/stores/builder/screens.ts
+++ b/packages/builder/src/stores/builder/screens.ts
@@ -28,6 +28,7 @@ import {
   WithRequired,
 } from "@budibase/types"
 import { featureFlag } from "@/helpers"
+import { appsStore } from "@/stores/portal"
 
 interface ScreenState {
   screens: Screen[]
@@ -273,7 +274,7 @@ export class ScreenStore extends BudiStore<ScreenState> {
       })
     }
 
-    appStore.refresh()
+    await appStore.refreshAppNav()
 
     return savedScreen
   }
@@ -397,8 +398,8 @@ export class ScreenStore extends BudiStore<ScreenState> {
       })
     await Promise.all(promises)
 
-    appStore.refresh()
-    workspaceAppStore.refresh()
+    await appStore.refreshAppNav()
+    await workspaceAppStore.refresh()
     const deletedIds = screensToDelete.map(screen => screen._id)
     const routesResponse = await API.fetchAppRoutes()
     this.update(state => {

--- a/packages/builder/src/stores/builder/screens.ts
+++ b/packages/builder/src/stores/builder/screens.ts
@@ -28,7 +28,6 @@ import {
   WithRequired,
 } from "@budibase/types"
 import { featureFlag } from "@/helpers"
-import { appsStore } from "@/stores/portal"
 
 interface ScreenState {
   screens: Screen[]

--- a/packages/builder/src/stores/builder/tests/screens.test.js
+++ b/packages/builder/src/stores/builder/tests/screens.test.js
@@ -32,6 +32,7 @@ vi.mock("@/stores/builder", async () => {
     update: mockAppStore.update,
     set: mockAppStore.set,
     refresh: vi.fn(),
+    refreshAppNav: vi.fn(),
   }
 
   const navigationStore = {
@@ -288,7 +289,7 @@ describe("Screens store", () => {
     // Saved the existing screen having modified it.
     await bb.screenStore.save(existingScreens[2].json())
 
-    expect(appStore.refresh).toHaveBeenCalledOnce()
+    expect(appStore.refreshAppNav).toHaveBeenCalledOnce()
     expect(saveSpy).toHaveBeenCalled()
 
     // On save, the screen is spliced back into the store with the saved content


### PR DESCRIPTION
## Description
Removing complete refresh on screen save/delete and sending the drawer-container down z-index to stop it blocking buttons.

Addresses: https://linear.app/budibase/issue/BUDI-9427/undoredo-buttons-dont-work
https://github.com/Budibase/budibase/issues/16418