### PR TITLE
Fix: app "loading" forever

### DIFF
--- a/packages/builder/src/pages/builder/portal/apps/[appId]/index.svelte
+++ b/packages/builder/src/pages/builder/portal/apps/[appId]/index.svelte
@@ -33,13 +33,13 @@
   let appContextMenuModals: AppContextMenuModals
 
   const getIframeURL = (app: EnrichedApp) => {
-    loading = true
-
     const workspaceUrl =
       app.status === "published" ? `/app${app.url}` : `/${app.devId}`
 
     return `${workspaceUrl}${app.defaultWorkspaceAppUrl}`
   }
+
+  $: iframeUrl && (loading = true) // If the iframe changes, set loading to true
 
   let noScreens = false
 


### PR DESCRIPTION
## Description
Fixing a small bug found on the index page of the builder. If an app is loaded, and the store gets refreshed (for example, another app was removed), we have the following issue:
1. index page reactivity gets triggered, as the apps were refreshed
2. the iframe url gets recalculated. Doing this the state is changed to "loading"
3. as the iframe url did not change, there is nothing really loaded. As we don't get the "loaded" event, the page "is loading" forever

Fixing this just changing the "loading" state when the url changes


### Existing issue

https://github.com/user-attachments/assets/b18dc1c6-e0b6-4a8c-940b-995704c55f5e

