### PR TITLE
Fix: removing misleading error notification

### DIFF
--- a/packages/builder/src/pages/builder/apps/index.svelte
+++ b/packages/builder/src/pages/builder/apps/index.svelte
@@ -1,14 +1,11 @@
 <script lang="ts">
   import { gradient } from "@/actions"
   import { API } from "@/api"
-  import { AppStatus } from "@/constants"
   import {
     admin,
     appsStore,
     auth,
     clientAppsStore,
-    enrichedApps,
-    featureFlags,
     groups,
     licensing,
     organisation,
@@ -33,7 +30,7 @@
   } from "@budibase/frontend-core"
   import { helpers, sdk } from "@budibase/shared-core"
   import { processStringSync } from "@budibase/string-templates"
-  import type { PublishedAppData, User, UserGroup } from "@budibase/types"
+  import type { PublishedAppData } from "@budibase/types"
   import { goto } from "@roxi/routify"
   import Logo from "assets/bb-emblem.svg"
   import Spaceman from "assets/bb-space-man.svg"
@@ -43,43 +40,8 @@
   let userInfoModal: Modal
   let changePasswordModal: Modal
 
-  $: userGroups = $groups.filter(group =>
-    group.users?.find(user => user._id === $auth.user?._id)
-  )
-  $: publishedApps = $enrichedApps.filter(
-    app => app.status === AppStatus.DEPLOYED
-  )
-  $: userApps = $featureFlags.WORKSPACE_APPS
-    ? $clientAppsStore.apps
-    : getUserApps(publishedApps, userGroups, $auth.user)
+  $: userApps = $clientAppsStore.apps
   $: isOwner = $auth.accountPortalAccess && $admin.cloud
-
-  function getUserApps(
-    publishedApps: EnrichedApp[],
-    userGroups: UserGroup[],
-    user: User | undefined
-  ) {
-    if (sdk.users.isAdmin(user)) {
-      return publishedApps
-    }
-    return publishedApps.filter(app => {
-      if (sdk.users.isBuilder(user, app.prodId)) {
-        return true
-      }
-      if (!Object.keys(user?.roles || {}).length && user?.userGroups) {
-        return userGroups.find(group => {
-          return groups
-            .getGroupAppIds(group)
-            .map(role => appsStore.extractAppId(role))
-            .includes(app.appId)
-        })
-      } else {
-        return Object.keys($auth.user?.roles || {})
-          .map(x => appsStore.extractAppId(x))
-          .includes(app.appId)
-      }
-    })
-  }
 
   function getUrl(app: EnrichedApp | PublishedAppData) {
     if (app.url) {

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -248,11 +248,6 @@ export async function fetch(ctx: UserCtx<void, FetchAppsResponse>) {
 export async function fetchClientApps(
   ctx: UserCtx<void, FetchPublishedAppsResponse>
 ) {
-  if (!(await features.isEnabled(FeatureFlag.WORKSPACE_APPS))) {
-    // Don't use this if workspaceapps are not enabled
-    ctx.throw(404)
-  }
-
   const apps = await sdk.applications.fetch(AppStatus.DEPLOYED, ctx.user)
 
   const result: FetchPublishedAppsResponse["apps"] = []

--- a/packages/server/src/api/routes/tests/application.spec.ts
+++ b/packages/server/src/api/routes/tests/application.spec.ts
@@ -263,242 +263,220 @@ describe("/applications", () => {
   })
 
   describe("fetchClientApps", () => {
-    describe("with WORKSPACE_APPS feature flag disabled", () => {
-      it("should return 404 when workspace apps feature is disabled", async () => {
-        await config.api.application.fetchClientApps({
-          status: 404,
+    it("should return apps with default workspace app when published", async () => {
+      const response = await config.api.application.fetchClientApps()
+      expect(response.apps).toHaveLength(1)
+      expect(response.apps[0]).toEqual(
+        expect.objectContaining({
+          prodId: config.getProdAppId(),
+          url: app.url,
         })
-      })
+      )
     })
 
-    describe("with WORKSPACE_APPS feature flag enabled", () => {
-      let featureCleanup: () => void
-
-      beforeAll(() => {
-        featureCleanup = features.testutils.setFeatureFlags("*", {
-          WORKSPACE_APPS: true,
+    it("should return multiple apps when published app with workspace apps exists", async () => {
+      await config.api.workspaceApp.create(
+        structures.workspaceApps.createRequest({
+          name: "Test Workspace App",
+          url: "/testapp",
         })
-      })
+      )
+      await config.publish()
 
-      afterAll(() => {
-        featureCleanup()
-      })
+      const response = await config.api.application.fetchClientApps()
 
-      it("should return apps with default workspace app when published", async () => {
-        const response = await config.api.application.fetchClientApps()
-        expect(response.apps).toHaveLength(1)
-        expect(response.apps[0]).toEqual(
-          expect.objectContaining({
-            prodId: config.getProdAppId(),
+      expect(response.apps.length).toBe(2)
+
+      const testApp = response.apps.find(a => a.name === "Test Workspace App")
+      expect(testApp).toEqual(
+        expect.objectContaining({
+          prodId: config.getProdAppId(),
+          name: "Test Workspace App",
+          url: `${app.url}/testapp`,
+        })
+      )
+    })
+
+    it("should handle creating multiple workspace apps", async () => {
+      const { workspaceApp: workspaceApp1 } =
+        await config.api.workspaceApp.create(
+          structures.workspaceApps.createRequest({
+            name: "App One",
+            url: "/appone",
+          })
+        )
+
+      const { workspaceApp: workspaceApp2 } =
+        await config.api.workspaceApp.create(
+          structures.workspaceApps.createRequest({
+            name: "App Two",
+            url: "/apptwo",
+          })
+        )
+      const app = await config.publish()
+
+      const response = await config.api.application.fetchClientApps()
+
+      expect(response.apps.length).toBe(3)
+      expect(response.apps).toEqual(
+        expect.arrayContaining([
+          {
+            appId: expect.stringMatching(
+              new RegExp(`^${app.appId}_workspace_app_.+`)
+            ),
+            name: app.name,
+            prodId: app.appId,
+            updatedAt: app.updatedAt,
             url: app.url,
-          })
-        )
-      })
-
-      it("should return multiple apps when published app with workspace apps exists", async () => {
-        await config.api.workspaceApp.create(
-          structures.workspaceApps.createRequest({
-            name: "Test Workspace App",
-            url: "/testapp",
-          })
-        )
-        await config.publish()
-
-        const response = await config.api.application.fetchClientApps()
-
-        expect(response.apps.length).toBe(2)
-
-        const testApp = response.apps.find(a => a.name === "Test Workspace App")
-        expect(testApp).toEqual(
-          expect.objectContaining({
+          },
+          {
+            appId: `${app.appId}_${workspaceApp1._id}`,
+            name: "App One",
             prodId: config.getProdAppId(),
-            name: "Test Workspace App",
-            url: `${app.url}/testapp`,
-          })
-        )
-      })
+            updatedAt: app.updatedAt,
+            url: `${app.url}/appone`,
+          },
+          {
+            appId: `${app.appId}_${workspaceApp2._id}`,
+            name: "App Two",
+            prodId: config.getProdAppId(),
+            updatedAt: app.updatedAt,
+            url: `${app.url}/apptwo`,
+          },
+        ])
+      )
+    })
 
-      it("should handle creating multiple workspace apps", async () => {
-        const { workspaceApp: workspaceApp1 } =
-          await config.api.workspaceApp.create(
-            structures.workspaceApps.createRequest({
-              name: "App One",
-              url: "/appone",
-            })
-          )
-
-        const { workspaceApp: workspaceApp2 } =
-          await config.api.workspaceApp.create(
-            structures.workspaceApps.createRequest({
-              name: "App Two",
-              url: "/apptwo",
-            })
-          )
-        const app = await config.publish()
-
-        const response = await config.api.application.fetchClientApps()
-
-        expect(response.apps.length).toBe(3)
-        expect(response.apps).toEqual(
-          expect.arrayContaining([
-            {
-              appId: expect.stringMatching(
-                new RegExp(`^${app.appId}_workspace_app_.+`)
-              ),
-              name: app.name,
-              prodId: app.appId,
-              updatedAt: app.updatedAt,
-              url: app.url,
-            },
-            {
-              appId: `${app.appId}_${workspaceApp1._id}`,
-              name: "App One",
-              prodId: config.getProdAppId(),
-              updatedAt: app.updatedAt,
-              url: `${app.url}/appone`,
-            },
-            {
-              appId: `${app.appId}_${workspaceApp2._id}`,
-              name: "App Two",
-              prodId: config.getProdAppId(),
-              updatedAt: app.updatedAt,
-              url: `${app.url}/apptwo`,
-            },
-          ])
-        )
-      })
-
-      it("should return apps from multiple published workspaces", async () => {
-        const { workspaceApp: app1Workspace1 } =
-          await config.api.workspaceApp.create(
-            structures.workspaceApps.createRequest({
-              name: "App One",
-              url: "/appone",
-            })
-          )
-        app = await config.publish()
-
-        const secondApp = await tk.withFreeze(new Date(), async () => {
-          // Create second app
-          let secondApp = await config.api.application.create({
-            name: "Second App",
-          })
-
-          await config.api.workspaceApp.create(
-            structures.workspaceApps.createRequest({
-              name: "App Two",
-              url: "/apptwo",
-            })
-          )
-          await config.api.application.publish(secondApp.appId)
-          return secondApp
-        })
-
-        const response = await config.api.application.fetchClientApps()
-
-        expect(response.apps).toHaveLength(3)
-
-        expect(response.apps).toEqual(
-          expect.arrayContaining([
-            {
-              appId: expect.stringMatching(
-                new RegExp(`^${app.appId}_workspace_app_.+`)
-              ),
-              name: app.name,
-              prodId: app.appId,
-              updatedAt: app.updatedAt,
-              url: app.url,
-            },
-            {
-              appId: `${app.appId}_${app1Workspace1._id}`,
-              name: "App One",
-              prodId: config.getProdAppId(),
-              updatedAt: app.updatedAt,
-              url: `${app.url}/appone`,
-            },
-            {
-              appId: expect.stringMatching(
-                new RegExp(
-                  `^${db.getProdAppID(secondApp.appId)}_workspace_app_.+`
-                )
-              ),
-              name: secondApp.name,
-              prodId: db.getProdAppID(secondApp.appId),
-              updatedAt: secondApp.updatedAt,
-              url: secondApp.url,
-            },
-          ])
-        )
-      })
-
-      it("should not return unpublished apps", async () => {
-        const { workspaceApp: app1Workspace1 } =
-          await config.api.workspaceApp.create(
-            structures.workspaceApps.createRequest({
-              name: "App One",
-              url: "/appone",
-            })
-          )
-        app = await config.publish()
-
-        // Non published workspace
+    it("should return apps from multiple published workspaces", async () => {
+      const { workspaceApp: app1Workspace1 } =
         await config.api.workspaceApp.create(
           structures.workspaceApps.createRequest({
-            name: "Another app",
-            url: "/other",
+            name: "App One",
+            url: "/appone",
           })
         )
+      app = await config.publish()
 
+      const secondApp = await tk.withFreeze(new Date(), async () => {
         // Create second app
-        const secondApp = await tk.withFreeze(new Date(), async () => {
-          const secondApp = await config.api.application.create({
-            name: "Second App",
+        let secondApp = await config.api.application.create({
+          name: "Second App",
+        })
+
+        await config.api.workspaceApp.create(
+          structures.workspaceApps.createRequest({
+            name: "App Two",
+            url: "/apptwo",
           })
-          await config.api.application.publish(secondApp.appId)
-          return secondApp
-        })
-
-        // Unpublished app
-        await config.api.application.create({
-          name: "Third App",
-        })
-
-        const response = await config.api.application.fetchClientApps()
-
-        expect(response.apps).toHaveLength(3)
-
-        expect(response.apps).toEqual(
-          expect.arrayContaining([
-            {
-              appId: expect.stringMatching(
-                new RegExp(`^${app.appId}_workspace_app_.+`)
-              ),
-              name: app.name,
-              prodId: app.appId,
-              updatedAt: app.updatedAt,
-              url: app.url,
-            },
-            {
-              appId: `${app.appId}_${app1Workspace1._id}`,
-              name: "App One",
-              prodId: config.getProdAppId(),
-              updatedAt: app.updatedAt,
-              url: `${app.url}/appone`,
-            },
-            {
-              appId: expect.stringMatching(
-                new RegExp(
-                  `^${db.getProdAppID(secondApp.appId)}_workspace_app_.+`
-                )
-              ),
-              name: secondApp.name,
-              prodId: db.getProdAppID(secondApp.appId),
-              updatedAt: secondApp.updatedAt,
-              url: secondApp.url,
-            },
-          ])
         )
+        await config.api.application.publish(secondApp.appId)
+        return secondApp
       })
+
+      const response = await config.api.application.fetchClientApps()
+
+      expect(response.apps).toHaveLength(3)
+
+      expect(response.apps).toEqual(
+        expect.arrayContaining([
+          {
+            appId: expect.stringMatching(
+              new RegExp(`^${app.appId}_workspace_app_.+`)
+            ),
+            name: app.name,
+            prodId: app.appId,
+            updatedAt: app.updatedAt,
+            url: app.url,
+          },
+          {
+            appId: `${app.appId}_${app1Workspace1._id}`,
+            name: "App One",
+            prodId: config.getProdAppId(),
+            updatedAt: app.updatedAt,
+            url: `${app.url}/appone`,
+          },
+          {
+            appId: expect.stringMatching(
+              new RegExp(
+                `^${db.getProdAppID(secondApp.appId)}_workspace_app_.+`
+              )
+            ),
+            name: secondApp.name,
+            prodId: db.getProdAppID(secondApp.appId),
+            updatedAt: secondApp.updatedAt,
+            url: secondApp.url,
+          },
+        ])
+      )
+    })
+
+    it("should not return unpublished apps", async () => {
+      const { workspaceApp: app1Workspace1 } =
+        await config.api.workspaceApp.create(
+          structures.workspaceApps.createRequest({
+            name: "App One",
+            url: "/appone",
+          })
+        )
+      app = await config.publish()
+
+      // Non published workspace
+      await config.api.workspaceApp.create(
+        structures.workspaceApps.createRequest({
+          name: "Another app",
+          url: "/other",
+        })
+      )
+
+      // Create second app
+      const secondApp = await tk.withFreeze(new Date(), async () => {
+        const secondApp = await config.api.application.create({
+          name: "Second App",
+        })
+        await config.api.application.publish(secondApp.appId)
+        return secondApp
+      })
+
+      // Unpublished app
+      await config.api.application.create({
+        name: "Third App",
+      })
+
+      const response = await config.api.application.fetchClientApps()
+
+      expect(response.apps).toHaveLength(3)
+
+      expect(response.apps).toEqual(
+        expect.arrayContaining([
+          {
+            appId: expect.stringMatching(
+              new RegExp(`^${app.appId}_workspace_app_.+`)
+            ),
+            name: app.name,
+            prodId: app.appId,
+            updatedAt: app.updatedAt,
+            url: app.url,
+          },
+          {
+            appId: `${app.appId}_${app1Workspace1._id}`,
+            name: "App One",
+            prodId: config.getProdAppId(),
+            updatedAt: app.updatedAt,
+            url: `${app.url}/appone`,
+          },
+          {
+            appId: expect.stringMatching(
+              new RegExp(
+                `^${db.getProdAppID(secondApp.appId)}_workspace_app_.+`
+              )
+            ),
+            name: secondApp.name,
+            prodId: db.getProdAppID(secondApp.appId),
+            updatedAt: secondApp.updatedAt,
+            url: secondApp.url,
+          },
+        ])
+      )
     })
   })
 


### PR DESCRIPTION
## Description
Due some flag issues, we are getting an error while loading the apps "homepage". This is not a real error, as the "failing" store is not really used.
![image](https://github.com/user-attachments/assets/dbf9854a-a1de-48dc-b121-d8cb54c59ec5)

This PR removes the flag for it, as the merged [PR](https://github.com/Budibase/budibase/pull/16383) allows removing this flag using the new endpoint correctly