### PR TITLE
Fix: migration related issues

### DIFF
--- a/packages/backend-core/src/constants/db.ts
+++ b/packages/backend-core/src/constants/db.ts
@@ -21,7 +21,7 @@ export enum ViewName {
   USER_BY_EMAIL = "by_email2",
   BY_API_KEY = "by_api_key",
   LINK = "by_link",
-  ROUTING = "screen_routes",
+  ROUTING = "screen_routes_2",
   AUTOMATION_LOGS = "automation_logs",
   ACCOUNT_BY_EMAIL = "account_by_email",
   PLATFORM_USERS_LOWERCASE = "platform_users_lowercase_2",

--- a/packages/server/src/appMigrations/migrations/20250618162639_workspace_apps.ts
+++ b/packages/server/src/appMigrations/migrations/20250618162639_workspace_apps.ts
@@ -7,9 +7,7 @@ const migration = async () => {
 
   const application = await sdk.applications.metadata.get()
   const allWorkspaceApps = await sdk.workspaceApps.fetch(context.getAppDB())
-  let defaultWorkspaceApp = allWorkspaceApps.find(
-    p => p.isDefault || p.name === application.name
-  )
+  let [defaultWorkspaceApp] = allWorkspaceApps
   if (!defaultWorkspaceApp) {
     const workspaceApp = await sdk.workspaceApps.create({
       name: application.name,

--- a/packages/server/src/appMigrations/migrations/20250618162639_workspace_apps.ts
+++ b/packages/server/src/appMigrations/migrations/20250618162639_workspace_apps.ts
@@ -7,8 +7,8 @@ const migration = async () => {
 
   const application = await sdk.applications.metadata.get()
   const allWorkspaceApps = await sdk.workspaceApps.fetch(context.getAppDB())
-  let [defaultWorkspaceApp] = allWorkspaceApps
-  if (!defaultWorkspaceApp) {
+  let [existingWorkspaceApp] = allWorkspaceApps
+  if (!existingWorkspaceApp) {
     const workspaceApp = await sdk.workspaceApps.create({
       name: application.name,
       url: "/",
@@ -16,7 +16,7 @@ const migration = async () => {
       navigation: application.navigation!,
       isDefault: true,
     })
-    defaultWorkspaceApp = workspaceApp
+    existingWorkspaceApp = workspaceApp
   }
 
   const db = context.getAppDB()
@@ -24,7 +24,7 @@ const migration = async () => {
     .filter(s => !s.workspaceAppId)
     .map<Screen>(s => ({
       ...s,
-      workspaceAppId: defaultWorkspaceApp._id!,
+      workspaceAppId: existingWorkspaceApp._id!,
     }))
 
   // Fixing half migrated workspaces apps, due unexpected migrations ran on some apps


### PR DESCRIPTION
## Description
Fixing a couple of issues seen releated to the latest migration:
1. @PClmnt got a migrated app, but the routing view did not refresh as it should. Forcing the recreation of this view by changing the key of it
2. Some migrations are stuck while getting the error below. This should never happen, as the code is already checking if an app with this name already exists.... For this, as the flag has never been on for anybody, we can assume that if there is any workspace app, there is no need to create another one (as nobody could create any workspace app manually)
<img width="515" alt="image" src="https://github.com/user-attachments/assets/8e406d56-21a0-4484-bda1-12c59bde58f0" />
