### PR TITLE
Fix: handle issues with duplicated workspaceapps

### DIFF
--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -325,7 +325,7 @@ export async function fetchAppPackage(
       ? new URL(ctx.headers.referer).pathname
       : ""
 
-    const matchedWorkspaceApp =
+    const [matchedWorkspaceApp] =
       await sdk.workspaceApps.getMatchedWorkspaceApp(urlPath)
     if (!matchedWorkspaceApp) {
       ctx.throw("No matching workspace app found for URL path: " + urlPath, 404)

--- a/packages/server/src/sdk/app/workspaceApps/tests/utils.spec.ts
+++ b/packages/server/src/sdk/app/workspaceApps/tests/utils.spec.ts
@@ -40,7 +40,7 @@ describe("workspaceApps utils", () => {
     closingChar => {
       it("should be able to get the base workspaceApp", async () => {
         await config.doInContext(config.getAppId(), async () => {
-          const result = await getMatchedWorkspaceApp(
+          const [result] = await getMatchedWorkspaceApp(
             `/${config.getAppId()}${closingChar}`
           )
           expect(result).toBeDefined()
@@ -50,7 +50,7 @@ describe("workspaceApps utils", () => {
 
       it("should be able to get the a workspaceApp by its path", async () => {
         await config.doInContext(config.getAppId(), async () => {
-          const result = await getMatchedWorkspaceApp(
+          const [result] = await getMatchedWorkspaceApp(
             `/${config.getAppId()}/app${closingChar}`
           )
           expect(result).toBeDefined()
@@ -60,7 +60,7 @@ describe("workspaceApps utils", () => {
 
       it("should be able to get the a workspaceApp by its path for overlapping urls", async () => {
         await config.doInContext(config.getAppId(), async () => {
-          const result = await getMatchedWorkspaceApp(
+          const [result] = await getMatchedWorkspaceApp(
             `/${config.getAppId()}/app2${closingChar}`
           )
           expect(result).toBeDefined()
@@ -70,7 +70,7 @@ describe("workspaceApps utils", () => {
 
       it("should return undefined for partial matching paths", async () => {
         await config.doInContext(config.getAppId(), async () => {
-          const result = await getMatchedWorkspaceApp(
+          const [result] = await getMatchedWorkspaceApp(
             `/${config.getAppId()}/app22${closingChar}`
           )
           expect(result).toBeUndefined()

--- a/packages/server/src/sdk/app/workspaceApps/utils.ts
+++ b/packages/server/src/sdk/app/workspaceApps/utils.ts
@@ -17,6 +17,6 @@ export async function getMatchedWorkspaceApp(fromUrl: string) {
     )
   }
 
-  const matchedWorkspaceApp = allWorkspaceApps.find(isWorkspaceAppMatch)
+  const matchedWorkspaceApp = allWorkspaceApps.filter(isWorkspaceAppMatch)
   return matchedWorkspaceApp
 }

--- a/packages/server/src/utilities/routing/index.ts
+++ b/packages/server/src/utilities/routing/index.ts
@@ -7,20 +7,24 @@ import sdk from "../../sdk"
 export async function getRoutingInfo(
   urlPath: string
 ): Promise<ScreenRoutesViewOutput[]> {
-  const workspaceApp = await sdk.workspaceApps.getMatchedWorkspaceApp(urlPath)
-  if (!workspaceApp) {
+  const workspaceApps = await sdk.workspaceApps.getMatchedWorkspaceApp(urlPath)
+  if (!workspaceApps.length) {
     return []
   }
   const db = context.getAppDB()
   try {
-    const allRouting = await db.query<ScreenRoutesViewOutput>(
-      getQueryIndex(ViewName.ROUTING),
-      {
-        startkey: [workspaceApp._id, ""],
-        endkey: [workspaceApp._id, UNICODE_MAX],
-      }
-    )
-    return allRouting.rows.map(row => row.value)
+    const result: ScreenRoutesViewOutput[] = []
+    for (const workspaceApp of workspaceApps) {
+      const allRouting = await db.query<ScreenRoutesViewOutput>(
+        getQueryIndex(ViewName.ROUTING),
+        {
+          startkey: [workspaceApp._id, ""],
+          endkey: [workspaceApp._id, UNICODE_MAX],
+        }
+      )
+      result.push(...allRouting.rows.map(row => row.value))
+    }
+    return result
   } catch (err: any) {
     // check if the view doesn't exist, it should for all new instances
     /* istanbul ignore next */


### PR DESCRIPTION
## Description
We got an issue where multiple workspace apps were created. We are not yet sure if this happened during migrations or when, but this resulted on 2 different workspace apps, with some of views assigned to one and some to the others.
This caused issues around linking on the client, as they were considered to be part of different apps.

This PR temporally updates the getMatchedWorkspaceApp to allow returning multiple workspace apps. This should never happen and it will be investigated and cleaned, but meanwhile this fixes the issue as both workspace apps will return as result, returning the right routes


Theory on why duplication happened:
1. Migrations were enabled,
2. Somebody accessed the app in production. Migration ran and it created a workspace app,
3. Somebody accessed the app in dev. Migration ran as well. This happened as "different times",
4. All was published, synching both apps, merging and duplicating them

I will investigate and put a solution for that