### PR TITLE
Fixes for Automation UI

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/DragZone.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/DragZone.svelte
@@ -45,7 +45,7 @@
     min-height: calc(var(--spectrum-global-dimension-size-225) + 12px);
     min-width: 100%;
     background-color: rgba(28, 168, 114, 0.2);
-    border-radius: 4px;
+    border-radius: 12px;
     border: 1px dashed #1ca872;
     position: relative;
     text-align: center;

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
@@ -319,7 +319,7 @@
     width: var(--pswidth);
     background-color: rgba(92, 92, 92, 0.1);
     border: 1px dashed #5c5c5c;
-    border-radius: 4px;
+    border-radius: 12px;
     display: block;
   }
   .block-core {

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItemStatus.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItemStatus.svelte
@@ -116,7 +116,7 @@
       <span />
     {/if}
     {#if blockResult && flowStatus && !hideStatus}
-      <span class={`flow-${flowStatus.type}`}>
+      <span class={`flow-${flowStatus.type} flow-status-btn`}>
         <ActionButton
           size="S"
           icon={flowStatus.icon}
@@ -169,5 +169,9 @@
   }
   .flow-warn :global(.spectrum-ActionButton i) {
     color: var(--spectrum-global-color-yellow-600);
+  }
+
+  .flow-status-btn :global(.spectrum-ActionButton i) {
+    color: unset;
   }
 </style>


### PR DESCRIPTION
## Description
Some UI fixes to accommodate recent Automation updates
- Fix greyed out flow status icons displayed above the blocks after a test run.
- Add border radius to drag zones to match the content being dragged.

## Screenshots
Status icons were greyed out
![Screenshot 2025-06-30 at 09 47 23](https://github.com/user-attachments/assets/cd33eb5b-9181-465d-917c-d28ee14a91d7)

Drag placeholders did not share the same shape as the automation block.
![Screenshot 2025-06-30 at 09 25 46](https://github.com/user-attachments/assets/d99ee30f-0711-4102-8e93-0aa56017522a)

## Launchcontrol
Some UI fixes to accommodate recent UI updates