### PR TITLE
Fix automation error link

### DIFF
--- a/packages/builder/src/pages/builder/portal/apps/index.svelte
+++ b/packages/builder/src/pages/builder/portal/apps/index.svelte
@@ -73,10 +73,10 @@
   }
 
   const goToAutomationError = appId => {
-    const params = new URLSearchParams({
-      open: "error",
-    })
-    $goto(`/builder/app/${appId}/settings/automations?${params.toString()}`)
+    const automationId = Object.keys(automationErrors[appId] || {})[0]
+    if (automationId) {
+      $goto(`/builder/app/${appId}/automation/${automationId}`)
+    }
   }
 
   const errorCount = errors => {


### PR DESCRIPTION
## Description
With the moving of the automation logs to within the automations section, we needed to update the error notification link. We now just link to the first automation in the errors object