### PR TITLE
Fix for Make connector where body wasn't being parsed correctly

### DIFF
--- a/packages/server/src/automations/steps/make.ts
+++ b/packages/server/src/automations/steps/make.ts
@@ -1,6 +1,10 @@
 import fetch from "node-fetch"
 import { getFetchResponse } from "./utils"
-import { ExternalAppStepOutputs, MakeIntegrationInputs } from "@budibase/types"
+import {
+  ExternalAppStepOutputs,
+  JSONValue,
+  MakeIntegrationInputs,
+} from "@budibase/types"
 
 export async function run({
   inputs,
@@ -9,7 +13,7 @@ export async function run({
 }): Promise<ExternalAppStepOutputs> {
   const { url, body } = inputs
 
-  let payload: any = {}
+  let payload: Record<string, JSONValue> = {}
   try {
     if (body?.value) {
       if (typeof body.value === "string") {

--- a/packages/server/src/automations/steps/make.ts
+++ b/packages/server/src/automations/steps/make.ts
@@ -11,7 +11,10 @@ export async function run({
 
   let payload = {}
   try {
-    payload = body?.value ? JSON.parse(body?.value) : {}
+    if (body?.value) {
+      payload =
+        typeof body.value === "string" ? JSON.parse(body.value) : body.value
+    }
   } catch (err) {
     return {
       httpStatus: 400,

--- a/packages/server/src/automations/steps/make.ts
+++ b/packages/server/src/automations/steps/make.ts
@@ -9,11 +9,26 @@ export async function run({
 }): Promise<ExternalAppStepOutputs> {
   const { url, body } = inputs
 
-  let payload = {}
+  let payload: any = {}
   try {
     if (body?.value) {
-      payload =
-        typeof body.value === "string" ? JSON.parse(body.value) : body.value
+      if (typeof body.value === "string") {
+        payload = JSON.parse(body.value)
+      } else {
+        payload = body.value
+      }
+
+      // Handle double-encoded strings in nested properties
+      Object.keys(payload).forEach(key => {
+        if (typeof payload[key] === "string") {
+          try {
+            const parsed = JSON.parse(payload[key])
+            payload[key] = parsed
+          } catch {
+            // If parsing fails, keep the original string value
+          }
+        }
+      })
     }
   } catch (err) {
     return {


### PR DESCRIPTION
## Description
Fixes an issue where when having a single quote in your Make payload would result in a malformed payload being sent.
## Addresses
https://linear.app/budibase/issue/BUDI-9407/json-containing-apostrophes-gets-many-added-in

## Screenshots

Make working correctly previously broken payload:
<img width="466" alt="image" src="https://github.com/user-attachments/assets/f7218403-738e-4c71-b373-f1ae1a70ff45" />
## Launchcontrol
Fix an issue where the Make connector was sending malformed data. 