### PR TITLE
"On input" actions

### DIFF
--- a/packages/builder/src/components/common/bindings/DrawerBindableInput.svelte
+++ b/packages/builder/src/components/common/bindings/DrawerBindableInput.svelte
@@ -13,7 +13,7 @@
   export let value: any = ""
   export let bindings: any[] = []
   export let title: string | undefined = undefined
-  export let placeholder: string | undefined = undefined
+  export let placeholder: string | false | undefined = undefined
   export let label: string | undefined = undefined
   export let disabled: boolean = false
   export let allowHBS: boolean = true
@@ -75,7 +75,7 @@
     on:change={event => onChange(event.detail)}
     on:blur={onBlur}
     on:scrollable={e => (scrollable = e.detail)}
-    {placeholder}
+    placeholder={placeholder || undefined}
     {updateOnChange}
     {autocomplete}
   >
@@ -96,7 +96,7 @@
   on:drawerHide={onDrawerHide}
   on:drawerShow
   bind:this={bindingDrawer}
-  title={title ?? placeholder ?? "Bindings"}
+  title={title || placeholder || "Bindings"}
   {forceModal}
 >
   <Button cta slot="buttons" on:click={saveBinding}>Save</Button>

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -3264,6 +3264,14 @@
       },
       {
         "type": "boolean",
+        "label": "Run on input",
+        "key": "runOnInput",
+        "dependsOn": "onChange",
+        "info": "Trigger actions by 'input' events as well as 'change' events",
+        "defaultValue": false
+      },
+      {
+        "type": "boolean",
         "label": "Disabled",
         "key": "disabled",
         "defaultValue": false
@@ -3408,6 +3416,14 @@
       },
       {
         "type": "boolean",
+        "label": "Run on input",
+        "key": "runOnInput",
+        "dependsOn": "onChange",
+        "info": "Trigger actions by 'input' events as well as 'change' events",
+        "defaultValue": false
+      },
+      {
+        "type": "boolean",
         "label": "Disabled",
         "key": "disabled",
         "defaultValue": false
@@ -3518,6 +3534,14 @@
       },
       {
         "type": "boolean",
+        "label": "Run on input",
+        "key": "runOnInput",
+        "dependsOn": "onChange",
+        "info": "Trigger actions by 'input' events as well as 'change' events",
+        "defaultValue": false
+      },
+      {
+        "type": "boolean",
         "label": "Disabled",
         "key": "disabled",
         "defaultValue": false
@@ -3604,6 +3628,14 @@
             "key": "value"
           }
         ]
+      },
+      {
+        "type": "boolean",
+        "label": "Run on input",
+        "key": "runOnInput",
+        "dependsOn": "onChange",
+        "info": "Trigger actions by 'input' events as well as 'change' events",
+        "defaultValue": false
       },
       {
         "type": "boolean",

--- a/packages/client/src/components/app/forms/BigIntField.svelte
+++ b/packages/client/src/components/app/forms/BigIntField.svelte
@@ -1,7 +1,5 @@
 <script>
   import StringField from "./StringField.svelte"
-
-  export let defaultValue
 </script>
 
-<StringField {...$$props} type="bigint" {defaultValue} />
+<StringField {...$$props} type="bigint" />

--- a/packages/client/src/components/app/forms/StringField.svelte
+++ b/packages/client/src/components/app/forms/StringField.svelte
@@ -12,6 +12,7 @@
   export let defaultValue = ""
   export let align
   export let onChange
+  export let runOnInput = false
   export let span
   export let helpText = null
 
@@ -20,9 +21,13 @@
 
   const handleChange = e => {
     const changed = fieldApi.setValue(e.detail)
-    if (onChange && changed) {
-      onChange({ value: e.detail })
+    if (changed) {
+      onChange?.({ value: e.detail })
     }
+  }
+
+  const handleInput = e => {
+    onChange?.({ value: e.target.value })
   }
 </script>
 
@@ -44,6 +49,7 @@
       updateOnChange={false}
       value={fieldState.value}
       on:change={handleChange}
+      on:input={runOnInput ? handleInput : undefined}
       disabled={fieldState.disabled}
       readonly={fieldState.readonly}
       id={fieldState.fieldId}


### PR DESCRIPTION
## Description
This PR adds a setting to allow users to trigger "on change" actions by "input" events as well. This only makes sense for things like text inputs that fire input events separately to change events, so it's only added to these fields for now:
- Text field
- Number field
- Big int field
- Password field

![image](https://github.com/user-attachments/assets/619efb8b-e89a-47b5-97d1-c5473ea81a07)

Enabling this setting run the actions on "input" events **as well as** change events, not instead of.

Also fixed an unrelated issue which caused placeholders of `false` everywhere.

## Addresses
- https://linear.app/budibase/issue/BUDI-9455/on-input-actions
