### PR TITLE
Change email endpoint for account holder tenant users

### DIFF
--- a/packages/server/.gitignore
+++ b/packages/server/.gitignore
@@ -8,3 +8,4 @@ db/dev.db/
 dist
 coverage/
 watchtower-hook.json
+.claude

--- a/packages/types/src/api/web/user.ts
+++ b/packages/types/src/api/web/user.ts
@@ -112,6 +112,11 @@ export interface CreateAdminUserRequest {
   familyName?: string
   givenName?: string
 }
+export interface CreateAdminUserResponse {
+  _id: string
+  _rev: string
+  email: string
+}
 
 export interface AddSSoUserRequest {
   ssoId: string
@@ -121,19 +126,12 @@ export interface AddSSoUserResponse {
   message: string
 }
 
-export interface CreateAdminUserResponse {
-  _id: string
-  _rev: string
-  email: string
-}
-
 export interface AcceptUserInviteRequest {
   inviteCode: string
   password: string
   firstName: string
   lastName?: string
 }
-
 export interface AcceptUserInviteResponse {
   _id: string
   _rev: string
@@ -169,3 +167,8 @@ export interface UpdateInviteRequest extends Omit<Invite, "email"> {
 export interface UpdateInviteResponse extends Invite {}
 
 export type LookupAccountHolderResponse = AccountMetadata | null
+
+export interface ChangeTenantOwnerEmailRequest {
+  newAccountEmail: string
+  originalEmail: string
+}

--- a/packages/types/src/api/web/user.ts
+++ b/packages/types/src/api/web/user.ts
@@ -171,4 +171,5 @@ export type LookupAccountHolderResponse = AccountMetadata | null
 export interface ChangeTenantOwnerEmailRequest {
   newAccountEmail: string
   originalEmail: string
+  tenantIds: string[]
 }

--- a/packages/types/src/documents/platform/users.ts
+++ b/packages/types/src/documents/platform/users.ts
@@ -4,6 +4,9 @@ import { Document } from "../document"
  * doc id is user email
  */
 export interface PlatformUserByEmail extends Document {
+  /**
+   * @Deprecated - multi-tenancy means that there is a one email to many tenant ids relationship
+   */
   tenantId: string
   userId: string
 }

--- a/packages/types/src/documents/platform/users.ts
+++ b/packages/types/src/documents/platform/users.ts
@@ -5,7 +5,7 @@ import { Document } from "../document"
  */
 export interface PlatformUserByEmail extends Document {
   /**
-   * @Deprecated - multi-tenancy means that there is a one email to many tenant ids relationship
+   * @deprecated - multi-tenancy means that there is a one email to many tenant ids relationship
    */
   tenantId: string
   userId: string

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -110,11 +110,10 @@ export const save = async (ctx: UserCtx<UnsavedUser, SaveUserResponse>) => {
 export const changeTenantOwnerEmail = async (
   ctx: Ctx<ChangeTenantOwnerEmailRequest, void>
 ) => {
-  const { newAccountEmail, originalEmail } = ctx.request.body
+  const { newAccountEmail, originalEmail, tenantIds } = ctx.request.body
   try {
-    const usersByEmail = await users.getExistingPlatformUsers([originalEmail])
-    for (const platformUser of usersByEmail) {
-      await tenancy.doInTenant(platformUser.tenantId, async () => {
+    for (const tenantId of tenantIds) {
+      await tenancy.doInTenant(tenantId, async () => {
         const tenantUser = await userSdk.db.getUserByEmail(originalEmail)
         if (!tenantUser) {
           return

--- a/packages/worker/src/api/index.ts
+++ b/packages/worker/src/api/index.ts
@@ -120,6 +120,10 @@ const NO_TENANCY_ENDPOINTS = [
     route: "/api/global/users/accountholder",
     method: "GET",
   },
+  {
+    route: "/api/global/users/tenant/owner",
+    method: "PUT",
+  },
 ]
 
 // most public endpoints are gets, but some are posts

--- a/packages/worker/src/api/routes/global/users.ts
+++ b/packages/worker/src/api/routes/global/users.ts
@@ -59,6 +59,15 @@ function buildInviteAcceptValidation() {
   }).required().unknown(true))
 }
 
+function buildChangeTenantOwnerEmailValidation() {
+  return auth.joiValidator.body(
+    Joi.object({
+      newAccountEmail: Joi.string().required(),
+      originalEmail: Joi.string().required(),
+    }).required()
+  )
+}
+
 router
   .post(
     "/api/global/users",
@@ -140,5 +149,11 @@ router
   .get("/api/global/users/tenant/:id", controller.tenantUserLookup)
   // global endpoint but needs to come at end (blocks other endpoints otherwise)
   .get("/api/global/users/:id", auth.builderOrAdmin, controller.find)
+  .put(
+    "/api/global/users/tenant/owner",
+    cloudRestricted,
+    buildChangeTenantOwnerEmailValidation(),
+    controller.changeTenantOwnerEmail
+  )
 
 export default router

--- a/packages/worker/src/api/routes/global/users.ts
+++ b/packages/worker/src/api/routes/global/users.ts
@@ -64,6 +64,7 @@ function buildChangeTenantOwnerEmailValidation() {
     Joi.object({
       newAccountEmail: Joi.string().required(),
       originalEmail: Joi.string().required(),
+      tenantIds: Joi.array().items(Joi.string()).required(),
     }).required()
   )
 }


### PR DESCRIPTION
## Description
Part of the change email process for account holders. 
Once the account email has been changed, the user doc needs to also be updated to reflect this, in CouchDB, for each cloud tenant the account holder has. 

## Addresses
- https://linear.app/budibase/issue/GRO-1332/add-a-restricted-endpoint-in-budibase-for-changing-user-email

## Screenshots
![put](https://github.com/user-attachments/assets/396c12b6-8d3c-47fb-98bd-3c3ad0585e3e)

*After:*

![platform user](https://github.com/user-attachments/assets/6a394a27-6ac7-4c5e-9f8d-7e6afcdd835f)

![first](https://github.com/user-attachments/assets/226b3afc-12b7-4630-9cbb-b54a95e6e783)

![second](https://github.com/user-attachments/assets/c2a7dccf-399a-4bcd-af7d-ce0daf133115)

