### PR TITLE
Fix disappearing dev app

### DIFF
--- a/packages/backend-core/src/db/instrumentation.ts
+++ b/packages/backend-core/src/db/instrumentation.ts
@@ -183,7 +183,10 @@ export class DDInstrumentedDatabase implements Database {
     })
   }
 
-  dump(stream: Writable, opts?: DatabaseDumpOpts | undefined): Promise<any> {
+  dump(
+    stream: Writable,
+    opts?: DatabaseDumpOpts | undefined
+  ): Promise<ReturnType<Database["dump"]>> {
     return tracer.trace("db.dump", span => {
       span.addTags({
         db_name: this.name,

--- a/packages/backend-core/src/db/instrumentation.ts
+++ b/packages/backend-core/src/db/instrumentation.ts
@@ -186,7 +186,7 @@ export class DDInstrumentedDatabase implements Database {
   dump(
     stream: Writable,
     opts?: DatabaseDumpOpts | undefined
-  ): Promise<ReturnType<Database["dump"]>> {
+  ): ReturnType<Database["dump"]> {
     return tracer.trace("db.dump", span => {
       span.addTags({
         db_name: this.name,
@@ -201,9 +201,7 @@ export class DDInstrumentedDatabase implements Database {
     })
   }
 
-  load(
-    ...args: Parameters<Database["load"]>
-  ): Promise<ReturnType<Database["load"]>> {
+  load(...args: Parameters<Database["load"]>): ReturnType<Database["load"]> {
     return tracer.trace("db.load", span => {
       span.addTags({ db_name: this.name, num_args: args.length })
       return this.db.load(...args)
@@ -212,7 +210,7 @@ export class DDInstrumentedDatabase implements Database {
 
   createIndex(
     ...args: Parameters<Database["createIndex"]>
-  ): Promise<ReturnType<Database["createIndex"]>> {
+  ): ReturnType<Database["createIndex"]> {
     return tracer.trace("db.createIndex", span => {
       span.addTags({ db_name: this.name, num_args: args.length })
       return this.db.createIndex(...args)
@@ -221,7 +219,7 @@ export class DDInstrumentedDatabase implements Database {
 
   deleteIndex(
     ...args: Parameters<Database["deleteIndex"]>
-  ): Promise<ReturnType<Database["deleteIndex"]>> {
+  ): ReturnType<Database["deleteIndex"]> {
     return tracer.trace("db.deleteIndex", span => {
       span.addTags({ db_name: this.name, num_args: args.length })
       return this.db.deleteIndex(...args)
@@ -230,7 +228,7 @@ export class DDInstrumentedDatabase implements Database {
 
   getIndexes(
     ...args: Parameters<Database["getIndexes"]>
-  ): Promise<ReturnType<Database["getIndexes"]>> {
+  ): ReturnType<Database["getIndexes"]> {
     return tracer.trace("db.getIndexes", span => {
       span.addTags({ db_name: this.name, num_args: args.length })
       return this.db.getIndexes(...args)

--- a/packages/backend-core/src/db/instrumentation.ts
+++ b/packages/backend-core/src/db/instrumentation.ts
@@ -198,28 +198,36 @@ export class DDInstrumentedDatabase implements Database {
     })
   }
 
-  load(...args: any[]): Promise<any> {
+  load(
+    ...args: Parameters<Database["load"]>
+  ): Promise<ReturnType<Database["load"]>> {
     return tracer.trace("db.load", span => {
       span.addTags({ db_name: this.name, num_args: args.length })
       return this.db.load(...args)
     })
   }
 
-  createIndex(...args: any[]): Promise<any> {
+  createIndex(
+    ...args: Parameters<Database["createIndex"]>
+  ): Promise<ReturnType<Database["createIndex"]>> {
     return tracer.trace("db.createIndex", span => {
       span.addTags({ db_name: this.name, num_args: args.length })
       return this.db.createIndex(...args)
     })
   }
 
-  deleteIndex(...args: any[]): Promise<any> {
+  deleteIndex(
+    ...args: Parameters<Database["deleteIndex"]>
+  ): Promise<ReturnType<Database["deleteIndex"]>> {
     return tracer.trace("db.deleteIndex", span => {
       span.addTags({ db_name: this.name, num_args: args.length })
       return this.db.deleteIndex(...args)
     })
   }
 
-  getIndexes(...args: any[]): Promise<any> {
+  getIndexes(
+    ...args: Parameters<Database["getIndexes"]>
+  ): Promise<ReturnType<Database["getIndexes"]>> {
     return tracer.trace("db.getIndexes", span => {
       span.addTags({ db_name: this.name, num_args: args.length })
       return this.db.getIndexes(...args)

--- a/packages/server/src/api/routes/tests/table.spec.ts
+++ b/packages/server/src/api/routes/tests/table.spec.ts
@@ -844,22 +844,90 @@ if (descriptions.length) {
         it("should be able to create a table with indexes", async () => {
           await context.doInAppContext(config.getAppId(), async () => {
             const db = context.getAppDB()
-            const indexCount = (await db.getIndexes()).total_rows
+            const initialIndexes = await db.getIndexes()
+            const initialIndexCount = initialIndexes.total_rows
+
             const table = basicTable()
             table.indexes = ["name"]
-            const res = await config.api.table.save(table)
-            expect(res._id).toBeDefined()
-            expect(res._rev).toBeDefined()
-            expect((await db.getIndexes()).total_rows).toEqual(indexCount + 1)
-            // update index to see what happens
-            table.indexes = ["name", "description"]
-            await config.api.table.save({
-              ...table,
-              _id: res._id,
-              _rev: res._rev,
-            })
-            // shouldn't have created a new index
-            expect((await db.getIndexes()).total_rows).toEqual(indexCount + 1)
+            const savedTable = await config.api.table.save(table)
+
+            expect(savedTable._id).toBeDefined()
+            expect(savedTable._rev).toBeDefined()
+            expect(savedTable.indexes).toEqual(["name"])
+
+            const indexesAfterCreate = await db.getIndexes()
+            expect(indexesAfterCreate.total_rows).toEqual(initialIndexCount + 1)
+
+            expect(indexesAfterCreate.indexes).toEqual([
+              {
+                ddoc: null,
+                def: {
+                  fields: [
+                    {
+                      _id: "asc",
+                    },
+                  ],
+                },
+                name: "_all_docs",
+                type: "special",
+              },
+              {
+                ddoc: "_design/search_ddoc",
+                def: {
+                  fields: [
+                    {
+                      name: "asc",
+                    },
+                  ],
+                },
+                name: `search:${savedTable._id}`,
+                partitioned: false,
+                type: "json",
+              },
+            ])
+
+            // Update table with multiple indexes
+            const updatedTable = {
+              ...savedTable,
+              indexes: ["name", "description"],
+            }
+            const resUpdated = await config.api.table.save(updatedTable)
+
+            expect(resUpdated.indexes).toEqual(["name", "description"])
+
+            // Should still have same number of indexes (recreated, not added)
+            const indexesAfterUpdate = await db.getIndexes()
+
+            expect(indexesAfterUpdate.indexes).toEqual([
+              {
+                ddoc: null,
+                def: {
+                  fields: [
+                    {
+                      _id: "asc",
+                    },
+                  ],
+                },
+                name: "_all_docs",
+                type: "special",
+              },
+              {
+                ddoc: "_design/search_ddoc",
+                def: {
+                  fields: [
+                    {
+                      name: "asc",
+                    },
+                    {
+                      description: "asc",
+                    },
+                  ],
+                },
+                name: `search:${savedTable._id}`,
+                partitioned: false,
+                type: "json",
+              },
+            ])
           })
         })
       })

--- a/packages/server/src/sdk/app/backups/imports.ts
+++ b/packages/server/src/sdk/app/backups/imports.ts
@@ -127,6 +127,8 @@ async function getTemplateStream(template: TemplateType) {
     const [type, name] = template.key.split("/")
     const tmpPath = await downloadTemplate(type, name)
     return fs.createReadStream(join(tmpPath, name, "db", "dump.txt"))
+  } else {
+    throw new Error("Either file or key is required.")
   }
 }
 
@@ -177,7 +179,7 @@ export async function importApp(
   } = { importObjStoreContents: true, updateAttachmentColumns: true }
 ) {
   let prodAppId = dbCore.getProdAppID(appId)
-  let dbStream: any
+  let dbStream: fs.ReadStream
   const isTar = template.file && template?.file?.type?.endsWith("gzip")
   const isDirectory =
     template.file && (await fsp.lstat(template.file.path)).isDirectory()

--- a/packages/types/src/documents/app/table/table.ts
+++ b/packages/types/src/documents/app/table/table.ts
@@ -23,7 +23,7 @@ export interface Table extends Document {
   relatedFormula?: string[]
   constrained?: string[]
   sql?: boolean
-  indexes?: { [key: string]: any }
+  indexes?: string[]
   created?: boolean
   rowHeight?: number
   aiGenerated?: boolean

--- a/packages/types/src/sdk/db.ts
+++ b/packages/types/src/sdk/db.ts
@@ -8,6 +8,7 @@ import {
   ViewTemplateOpts,
 } from "../"
 import { Writable } from "stream"
+import { ReadStream } from "fs"
 
 export enum SearchIndex {
   ROWS = "rows",
@@ -160,10 +161,10 @@ export interface Database {
   // these are all PouchDB related functions that are rarely used - in future
   // should be replaced by better typed/non-pouch implemented methods
   dump(stream: Writable, opts?: DatabaseDumpOpts): Promise<any>
-  load(...args: any[]): Promise<any>
-  createIndex(...args: any[]): Promise<any>
-  deleteIndex(...args: any[]): Promise<any>
-  getIndexes(...args: any[]): Promise<any>
+  load(stream: ReadStream): Promise<any>
+  createIndex(opts: DatabaseCreateIndexOpts): Promise<any>
+  deleteIndex(opts: DatabaseDeleteIndexOpts): Promise<any>
+  getIndexes(): Promise<any>
 }
 
 export interface DBError extends Error {


### PR DESCRIPTION
## Description
Fixing the way we handle backup imports to make it more resilient. CouchDB does not provide us with a way to override a full database atomically, so we've implemented a more robust backup import strategy to prevent data loss and corruption during restore operations. This might be the issue with the existing dev app disappearing (as most users were paid ones, with access to backups).

Updated steps:
1. Run the import into a temporary database, rather than directly importing into the live dev application database
2. Only after a successful import into the temporary database, remove the existing app database
3. Replicate from the temporary database to the target database

This is still prone to errors, as there is no atomicity we can use for it.
Possible pitfalls:
1. If something fails on step 1 (it might be the heavier one), the app db does not get overridden.
2. Step 2 should not fail, and if it fails it might mean that the db was never deleted.
3. We are relying on native replication, but this is now the critical point.

Pro PR:
- https://github.com/Budibase/budibase-pro/pull/440/files

## Launchcontrol
Make restoring backups more resilient