### PR TITLE
Make azure OpenAI config more clear

### DIFF
--- a/packages/builder/src/pages/builder/portal/settings/ai/ConfigModal.svelte
+++ b/packages/builder/src/pages/builder/portal/settings/ai/ConfigModal.svelte
@@ -19,6 +19,11 @@
   $: canEditBaseUrl =
     config.provider &&
     ConfigMap[config.provider as keyof typeof ConfigMap].baseUrl === ""
+
+  $: placeholder =
+    config.provider === "AzureOpenAI"
+      ? "https://<name>.openai.azure.com/openai/deployments/<deployment>"
+      : "https://budibase.ai"
 </script>
 
 <ModalContent
@@ -42,19 +47,21 @@
     <Label size="M">Base URL</Label>
     <Input
       disabled={!canEditBaseUrl}
-      placeholder={"https://budibase.ai"}
+      {placeholder}
       bind:value={config.baseUrl}
     />
   </div>
 
-  <div class="form-row">
-    <Label size="M">Default Model</Label>
-    <Select
-      placeholder={config.provider ? "Choose an option" : "Select a provider"}
-      bind:value={config.defaultModel}
-      options={Models}
-    />
-  </div>
+  {#if config.provider !== "AzureOpenAI"}
+    <div class="form-row">
+      <Label size="M">Default Model</Label>
+      <Select
+        placeholder={config.provider ? "Choose an option" : "Select a provider"}
+        bind:value={config.defaultModel}
+        options={Models}
+      />
+    </div>
+  {/if}
 </ModalContent>
 
 <style>


### PR DESCRIPTION
## Description

This has technically been working for a while but it's very unobvious how to get it to work. I've updated the config screen for Azure OpenAI to try and make it more clear:

![CleanShot 2025-07-02 at 11 48 16@2x](https://github.com/user-attachments/assets/77211721-088b-447b-a471-40bed9a50e10)

## Addresses
- https://linear.app/budibase/issue/BUDI-9405/azure-openai-hits-a-404-when-trying-to-use-ai-features-in-self-host

