### PR TITLE
CI check for client library size

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -340,3 +340,44 @@ jobs:
           else
             echo "yarn.lock file is unchanged."
           fi
+
+  check-client-build-size:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: ${{ env.IS_OSS_CONTRIBUTOR == 'false' }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: yarn
+      - run: yarn --frozen-lockfile
+
+      - name: Build client library
+        run: yarn build:client
+
+      - name: Check client build size
+        run: |
+          CLIENT_FILE="packages/client/dist/budibase-client.js"
+          if [ ! -f "$CLIENT_FILE" ]; then
+            echo "Error: Client build file not found at $CLIENT_FILE"
+            exit 1
+          fi
+          
+          SIZE_BYTES=$(stat -c%s "$CLIENT_FILE")
+          SIZE_MB=$(awk "BEGIN {printf \"%.2f\", $SIZE_BYTES / 1024 / 1024}")
+          MAX_SIZE_BYTES=$((8 * 1024 * 1024))
+          
+          echo "Client build size: ${SIZE_MB}MB"
+          echo "Maximum allowed size: 8MB"
+          
+          if [ $SIZE_BYTES -gt $MAX_SIZE_BYTES ]; then
+            echo "Client build size (${SIZE_MB}MB) exceeds maximum allowed size (8MB)"
+            exit 1
+          else
+            echo "Client build size (${SIZE_MB}MB) is within acceptable limits"
+          fi


### PR DESCRIPTION
## Description
Adding a check to make sure the client library build is less than 8MB.
