### PR TITLE
Allow S3 file uploads from public screens

### DIFF
--- a/packages/server/src/api/routes/static.ts
+++ b/packages/server/src/api/routes/static.ts
@@ -27,10 +27,6 @@ router
   .get("/app/service-worker.js", controller.serveServiceWorker)
   .get("/app/:appUrl/:path*", controller.serveApp)
   .get("/:appId/:path*", controller.serveApp)
-  .post(
-    "/api/attachments/:datasourceId/url",
-    authorized(PermissionType.TABLE, PermissionLevel.READ),
-    controller.getSignedUploadURL
-  )
+  .post("/api/attachments/:datasourceId/url", controller.getSignedUploadURL)
 
 export default router


### PR DESCRIPTION
## Description
The S3 file upload endpoint was unavailable to unauthenticated users. This change allows users of public apps to upload files to the builder's S3 bucket.

## Addresses
#15593

## Launchcontrol
Allow S3 file uploads from public screens
