### PR TITLE
Fix updatedby relationship type direction

### DIFF
--- a/packages/builder/src/helpers/utils.ts
+++ b/packages/builder/src/helpers/utils.ts
@@ -63,7 +63,7 @@ export function buildAutoColumn(
         constraints: FIELDS.LINK.constraints,
         tableId: TableNames.USERS,
         fieldName: `${tableName}-${name}`,
-        relationshipType: RelationshipType.MANY_TO_ONE,
+        relationshipType: RelationshipType.ONE_TO_MANY,
       }
 
     case AUTO_COLUMN_SUB_TYPES.AUTO_ID:


### PR DESCRIPTION
## Description
Fix the initial setup of the relationship type to be one-to-many instead of many-to-one. This caused issues with the usage of these columns, as attempting to have 2 rows with the same `created/updated by` would cause constraint issues.
This will not fix any current setup, as this would require live updating the existing schemas (potentially causing other issues). As any usage of this column is not likely to have much data in it (given this issue), it's better to delete and recreate is instead of attempting to fix it. If required, it's easily fixable fixing the schema manually.



## Launchcontrol
Fixing "1:N Relationship Error: Record already linked to another" related to `updated by` columns