### PR TITLE
Make processDates more resilient to invalid dates, and improve error reporting.

### DIFF
--- a/packages/server/src/utilities/rowProcessor/utils.ts
+++ b/packages/server/src/utilities/rowProcessor/utils.ts
@@ -186,7 +186,7 @@ export function processDates<T extends Row | Row[]>(
 ): T {
   let rows = Array.isArray(inputRows) ? inputRows : [inputRows]
   let datesWithTZ: string[] = []
-  for (let [column, schema] of Object.entries(table.schema)) {
+  for (const [column, schema] of Object.entries(table.schema)) {
     if (schema.type !== FieldType.DATETIME) {
       continue
     }
@@ -198,10 +198,17 @@ export function processDates<T extends Row | Row[]>(
     }
   }
 
-  for (let row of rows) {
-    for (let col of datesWithTZ) {
+  for (const row of rows) {
+    for (const col of datesWithTZ) {
       if (row[col] && typeof row[col] === "string" && !row[col].endsWith("Z")) {
-        row[col] = new Date(row[col] + "Z").toISOString()
+        let date = new Date(row[col] + "Z")
+        if (isNaN(date.getTime())) {
+          date = new Date(row[col])
+        }
+        if (isNaN(date.getTime())) {
+          throw new Error(`Invalid date format for column ${col}: ${row[col]}`)
+        }
+        row[col] = date.toISOString()
       }
     }
   }


### PR DESCRIPTION
## Description

A customer has reported a problem with the error "Invalid time value" and I can see it in [DataDog](https://app.datadoghq.eu/error-tracking/issue/d2e966aa-5b2b-11f0-845b-da7ad0900005?query=&index=&tb=%40usr.tenantId%2Cresource_name%2Cservice&from_ts=1751818221454&to_ts=1751904621454&live=true). I tracked it down to a change I made recently to handle all dates internally as UTC, and didn't realise `new Date("...").toISOString()` can throw.

This PR makes the code a bit more resilient and also makes the error handling more descriptive when it goes wrong. I'm not quite sure what values could be stored into the DB to cause this so it's not clear to me how exactly to test it, so this PR does not have tests.

## Launchcontrol

Fix a bug around date handling in external datasources (the "Invalid time value" bug).
