### PR TITLE
Fix issue with collect blocks in button actions

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/BranchNode.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/BranchNode.svelte
@@ -255,9 +255,7 @@
     </div>
   </div>
 
-  {#if !isLast}
-    <div class="separator" />
-  {/if}
+  <div class="separator" />
 
   {#if $view.dragging}
     <DragZone path={branchBlockRef.pathTo} />

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/TriggerAutomation.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/TriggerAutomation.svelte
@@ -2,8 +2,8 @@
   import { Select, Label, Input, Checkbox, Icon, Body } from "@budibase/bbui"
   import { automationStore } from "@/stores/builder"
   import DrawerBindableInput from "@/components/common/bindings/DrawerBindableInput.svelte"
-  import { TriggerStepID, ActionStepID } from "@/constants/backend/automations"
-  import { AutomationActionStepId } from "@budibase/types"
+  import { TriggerStepID } from "@/constants/backend/automations"
+  import { sdk as coreSdk } from "@budibase/shared-core"
 
   export let parameters = {}
   export let bindings = []
@@ -33,36 +33,7 @@
         automation.definition.trigger.inputs.fields || {}
       ).map(([name, type]) => ({ name, type }))
 
-      // Recursive function to check for collect blocks in steps and branch children
-      const hasCollectBlockRecursive = steps => {
-        if (!steps || !Array.isArray(steps)) {
-          return false
-        }
-
-        for (const step of steps) {
-          if (step.stepId === ActionStepID.COLLECT) {
-            return true
-          }
-
-          if (
-            step.stepId === AutomationActionStepId.BRANCH &&
-            step.inputs?.children
-          ) {
-            for (const branchId in step.inputs.children) {
-              const branchSteps = step.inputs.children[branchId]
-              if (hasCollectBlockRecursive(branchSteps)) {
-                return true
-              }
-            }
-          }
-        }
-
-        return false
-      }
-
-      let hasCollectBlock = hasCollectBlockRecursive(
-        automation.definition.steps
-      )
+      let hasCollectBlock = coreSdk.automations.checkForCollectStep(automation)
 
       return {
         name: automation.name,

--- a/packages/server/src/sdk/app/automations/utils.ts
+++ b/packages/server/src/sdk/app/automations/utils.ts
@@ -1,7 +1,1 @@
-import { Automation, AutomationActionStepId } from "@budibase/types"
-
-export function checkForCollectStep(automation: Automation) {
-  return automation.definition.steps.some(
-    (step: any) => step.stepId === AutomationActionStepId.COLLECT
-  )
-}
+export { checkForCollectStep } from "@budibase/shared-core/src/sdk/documents/automations"

--- a/packages/shared-core/src/sdk/documents/automations.ts
+++ b/packages/shared-core/src/sdk/documents/automations.ts
@@ -28,12 +28,10 @@ function hasCollectBlockRecursive(steps: AutomationStep[]): boolean {
   }
 
   for (const step of steps) {
-    // Check if current step is a collect block
     if (step.stepId === AutomationActionStepId.COLLECT) {
       return true
     }
 
-    // Check if current step is a branch with children
     if (isBranchStep(step) && step.inputs.children) {
       for (const child of Object.values(step.inputs.children)) {
         if (hasCollectBlockRecursive(child)) {

--- a/packages/shared-core/src/sdk/documents/automations.ts
+++ b/packages/shared-core/src/sdk/documents/automations.ts
@@ -2,6 +2,8 @@ import {
   Automation,
   AutomationTriggerStepId,
   AutomationActionStepId,
+  AutomationStep,
+  isBranchStep,
 } from "@budibase/types"
 
 export function isRowAction(automation: Automation) {
@@ -20,7 +22,7 @@ export function isAppAction(automation: Automation) {
   return automation.definition.trigger?.stepId === AutomationTriggerStepId.APP
 }
 
-function hasCollectBlockRecursive(steps: any[]): boolean {
+function hasCollectBlockRecursive(steps: AutomationStep[]): boolean {
   if (!steps || !Array.isArray(steps)) {
     return false
   }
@@ -32,12 +34,9 @@ function hasCollectBlockRecursive(steps: any[]): boolean {
     }
 
     // Check if current step is a branch with children
-    if (
-      step.stepId === AutomationActionStepId.BRANCH &&
-      step.inputs?.children
-    ) {
-      for (const { children } of Object.values(step.inputs.children)) {
-        if (hasCollectBlockRecursive(children)) {
+    if (isBranchStep(step) && step.inputs.children) {
+      for (const child of Object.values(step.inputs.children)) {
+        if (hasCollectBlockRecursive(child)) {
           return true
         }
       }

--- a/packages/shared-core/src/sdk/documents/automations.ts
+++ b/packages/shared-core/src/sdk/documents/automations.ts
@@ -36,10 +36,8 @@ function hasCollectBlockRecursive(steps: any[]): boolean {
       step.stepId === AutomationActionStepId.BRANCH &&
       step.inputs?.children
     ) {
-      // Branch children is an object where keys are branch IDs and values are arrays of steps
-      for (const branchId in step.inputs.children) {
-        const branchSteps = step.inputs.children[branchId]
-        if (hasCollectBlockRecursive(branchSteps)) {
+      for (const { children } of Object.values(step.inputs.children)) {
+        if (hasCollectBlockRecursive(children)) {
           return true
         }
       }


### PR DESCRIPTION
## Description
Previously we weren't correctly discovering Collect blocks that existed in branch children. That meant that the Button Action bindings weren't being updated properly. 

(also a tiny fix to remove a gate on the branch separator that shouldn't be there, was causing a slight visual discrepancy). 

## Addresses
https://linear.app/budibase/issue/BUDI-9116/the-collect-data-step-doesnt-work-if-its-at-the-end-of-a-branch-step.

## Launchcontrol
- Fix an issue with automation collect block bindings in automations