### PR TITLE
Fix selectedScreen store infinite loop

### DIFF
--- a/packages/builder/src/stores/builder/screens.ts
+++ b/packages/builder/src/stores/builder/screens.ts
@@ -94,10 +94,16 @@ export class ScreenStore extends BudiStore<ScreenState> {
    */
   syncAppScreens(pkg: FetchAppPackageResponse) {
     const screens = [...pkg.screens]
-    this.update(state => ({
-      ...state,
-      screens,
-    }))
+    this.update(state => {
+      const { selectedScreenId } = state
+      if (selectedScreenId && !screens.some(s => s._id === selectedScreenId)) {
+        delete state.selectedScreenId
+      }
+      return {
+        ...state,
+        screens,
+      }
+    })
   }
 
   /**


### PR DESCRIPTION
## Description
Fixing a bug found during reverting app QA. The flow goes as follows:
1. Create a new screen from design
2. Leave this screen as selected
3. Go to settings
4. Revert the app dev changes
5. Go back to design
6. As we have a `selected screen id`, we try to load it. As this id does not have a matching `screen` object, the load fails, falling back and getting into an infinite loop

The fix in here is resetting the `selectedScreenId` if this is not part of the new passed screens