### PR TITLE
Nav update conflicts

### DIFF
--- a/packages/builder/src/stores/builder/navigation.ts
+++ b/packages/builder/src/stores/builder/navigation.ts
@@ -53,24 +53,14 @@ export class NavigationStore extends DerivedBudiStore<
   }
 
   async save(navigation: AppNavigation) {
-    const $workspaceAppStore = get(workspaceAppStore)
-    if (!$workspaceAppStore.selectedWorkspaceApp) {
+    const { selectedWorkspaceApp } = get(workspaceAppStore)
+    if (!selectedWorkspaceApp) {
       notifications.error("Non selected workspace app")
       return
     }
-    workspaceAppStore.edit({
-      ...$workspaceAppStore.selectedWorkspaceApp,
-      navigation,
-    })
 
-    if ($workspaceAppStore.selectedWorkspaceApp.isDefault) {
-      // TODO: remove when cleaning the flag FeatureFlag.WORKSPACE_APPS
-      const appId = get(appStore).appId
-      const app = await API.saveAppMetadata(appId, { navigation })
-      if (app.navigation) {
-        this.syncAppNavigation(app.navigation)
-      }
-    }
+    await API.navigation.updateNavigation(selectedWorkspaceApp._id!, navigation)
+    this.syncAppNavigation(navigation)
   }
 
   async addLink({

--- a/packages/builder/src/stores/builder/navigation.ts
+++ b/packages/builder/src/stores/builder/navigation.ts
@@ -59,7 +59,9 @@ export class NavigationStore extends DerivedBudiStore<
       return
     }
 
-    await API.navigation.updateNavigation(selectedWorkspaceApp._id!, navigation)
+    await API.navigation.updateNavigation(selectedWorkspaceApp._id!, {
+      navigation,
+    })
     this.syncAppNavigation(navigation)
   }
 

--- a/packages/builder/src/stores/builder/tests/navigation.test.js
+++ b/packages/builder/src/stores/builder/tests/navigation.test.js
@@ -10,7 +10,9 @@ import { appStore } from "@/stores/builder"
 vi.mock("@/api", () => {
   return {
     API: {
-      saveAppMetadata: vi.fn(),
+      navigation: {
+        updateNavigation: vi.fn(),
+      },
     },
   }
 })
@@ -25,6 +27,7 @@ vi.mock("@/stores/builder", async () => {
 
   const mockWorkspaceAppStore = writable({
     selectedWorkspaceApp: {
+      _id: "mockWorkspaceAppId",
       isDefault: true,
       navigation: null,
     },
@@ -272,17 +275,15 @@ describe("Navigation store", () => {
       ],
     }
 
-    const saveSpy = vi.spyOn(API, "saveAppMetadata").mockImplementation(() => {
-      return {
-        navigation: update,
-      }
-    })
+    const saveSpy = vi.spyOn(API.navigation, "updateNavigation")
 
     expect(ctx.test.store.links.length).toBe(2)
 
     await ctx.test.navigationStore.save(update)
 
-    expect(saveSpy).toHaveBeenCalledWith("testing_123", { navigation: update })
+    expect(saveSpy).toHaveBeenCalledWith("mockWorkspaceAppId", {
+      navigation: update,
+    })
 
     expect(ctx.test.store.links.length).toBe(3)
 

--- a/packages/frontend-core/src/api/navigation.ts
+++ b/packages/frontend-core/src/api/navigation.ts
@@ -1,17 +1,23 @@
 import { BaseAPIClient } from "./types"
-import { AppNavigation, UpdateNavigationRequest } from "@budibase/types"
+import { UpdateNavigationRequest } from "@budibase/types"
 
 export interface NavigationEndpoints {
-  updateNavigation: (appId: string, navigation: AppNavigation) => Promise<void>
+  updateNavigation: (
+    appId: string,
+    navigation: UpdateNavigationRequest
+  ) => Promise<void>
 }
 
 export const buildNavigationEndpoints = (
   API: BaseAPIClient
 ): NavigationEndpoints => ({
-  updateNavigation: async (appId: string, navigation: AppNavigation) => {
+  updateNavigation: async (
+    appId: string,
+    navigation: UpdateNavigationRequest
+  ) => {
     return await API.put<UpdateNavigationRequest>({
       url: `/api/navigation/${appId}`,
-      body: { navigation },
+      body: navigation,
     })
   },
 })

--- a/packages/server/src/api/controllers/navigation.ts
+++ b/packages/server/src/api/controllers/navigation.ts
@@ -1,8 +1,11 @@
 import { Ctx, UpdateNavigationRequest } from "@budibase/types"
 import sdk from "../../sdk"
 
-export async function update(ctx: Ctx<UpdateNavigationRequest, void>) {
+export async function update(
+  ctx: Ctx<UpdateNavigationRequest, void, { workspaceAppId: string }>
+) {
+  const { workspaceAppId } = ctx.params
   const { navigation } = ctx.request.body
-  await sdk.navigation.update(navigation)
+  await sdk.navigation.update(workspaceAppId, navigation)
   ctx.status = 204
 }

--- a/packages/server/src/api/controllers/workspaceApp.ts
+++ b/packages/server/src/api/controllers/workspaceApp.ts
@@ -1,6 +1,7 @@
 import {
   Ctx,
   FetchWorkspaceAppResponse,
+  FindWorkspaceAppResponse,
   InsertWorkspaceAppRequest,
   InsertWorkspaceAppResponse,
   UpdateWorkspaceAppRequest,
@@ -32,6 +33,18 @@ export async function fetch(ctx: Ctx<void, FetchWorkspaceAppResponse>) {
   ctx.body = {
     workspaceApps: workspaceApps.map(toWorkspaceAppResponse),
   }
+}
+
+export async function find(
+  ctx: Ctx<void, FindWorkspaceAppResponse, { id: string }>
+) {
+  const { id } = ctx.params
+  const workspaceApp = await sdk.workspaceApps.get(id)
+  if (!workspaceApp) {
+    ctx.throw(404)
+  }
+
+  ctx.body = toWorkspaceAppResponse(workspaceApp)
 }
 
 export async function create(

--- a/packages/server/src/api/routes/navigation.ts
+++ b/packages/server/src/api/routes/navigation.ts
@@ -5,9 +5,8 @@ import * as controller from "../controllers/navigation"
 
 const router: Router = new Router()
 
-// TODO: remove when cleaning the flag FeatureFlag.WORKSPACE_APPS
 router.put(
-  "/api/navigation/:appId",
+  "/api/navigation/:workspaceAppId",
   authorized(permissions.BUILDER),
   controller.update
 )

--- a/packages/server/src/api/routes/tests/navigation.spec.ts
+++ b/packages/server/src/api/routes/tests/navigation.spec.ts
@@ -62,7 +62,7 @@ describe("/navigation", () => {
       )
     })
 
-    it("should not app navigation app navigation when updating not default workspaces", async () => {
+    it("should not update app navigation app navigation when updating not default workspaces", async () => {
       const { workspaceApp: otherWorkspaceApp } =
         await config.api.workspaceApp.create({
           ...structures.workspaceApps.createRequest(),

--- a/packages/server/src/api/routes/tests/navigation.spec.ts
+++ b/packages/server/src/api/routes/tests/navigation.spec.ts
@@ -1,0 +1,109 @@
+import { structures } from "@budibase/backend-core/tests"
+import * as setup from "./utilities"
+import { AppNavigation, WithRequired, WorkspaceApp } from "@budibase/types"
+
+describe("/navigation", () => {
+  let request = setup.getRequest()
+  let config = setup.getConfig()
+  let workspaceApp: WithRequired<WorkspaceApp, "_id">
+
+  beforeAll(async () => {
+    await config.init()
+  })
+
+  beforeEach(async () => {
+    await config.newTenant()
+    const { workspaceApps } = await config.api.workspaceApp.fetch()
+    workspaceApp = workspaceApps[0]
+  })
+
+  afterAll(setup.afterAll)
+
+  const sampleNavigation: AppNavigation = {
+    navigation: "Top",
+    links: [
+      {
+        url: "/home",
+        text: "Home",
+        type: "link",
+      },
+      {
+        url: "/about",
+        text: "About",
+        type: "link",
+      },
+    ],
+  }
+
+  describe("PUT /api/navigation/:workspaceAppId", () => {
+    it("should update navigation for workspace app", async () => {
+      await request
+        .put(`/api/navigation/${workspaceApp._id}`)
+        .send({ navigation: sampleNavigation })
+        .set(config.defaultHeaders())
+        .expect(204)
+
+      const updatedApp = await config.api.workspaceApp.find(workspaceApp._id)
+      expect(updatedApp).toBeDefined()
+      expect(updatedApp!.navigation).toEqual(sampleNavigation)
+    })
+
+    it("should update both workspace app and default app navigation for default workspaceApps", async () => {
+      await request
+        .put(`/api/navigation/${workspaceApp._id}`)
+        .send({ navigation: sampleNavigation })
+        .set(config.defaultHeaders())
+        .expect(204)
+
+      const appMetadata = await config.api.application.get(config.getAppId())
+      expect(appMetadata.navigation).toEqual(sampleNavigation)
+    })
+
+    it("should return 400 for invalid workspace app id", async () => {
+      await request
+        .put("/api/navigation/invalid_id")
+        .send({ navigation: sampleNavigation })
+        .set(config.defaultHeaders())
+        .expect(400)
+    })
+
+    it("should not app navigation app navigation when updating not default workspaces", async () => {
+      const { workspaceApp: otherWorkspaceApp } =
+        await config.api.workspaceApp.create({
+          ...structures.workspaceApps.createRequest(),
+        })
+      expect(otherWorkspaceApp.isDefault).toBe(false)
+
+      await request
+        .put(`/api/navigation/${otherWorkspaceApp._id}`)
+        .send({ navigation: sampleNavigation })
+        .set(config.defaultHeaders())
+        .expect(204)
+
+      const updatedWorkspaceApp = await config.api.workspaceApp.find(
+        otherWorkspaceApp._id
+      )
+      expect(updatedWorkspaceApp.navigation).toEqual(sampleNavigation)
+
+      const appMetadata = await config.api.application.get(config.getAppId())
+      expect(appMetadata.navigation).not.toEqual(sampleNavigation)
+    })
+
+    it("should handle empty navigation links", async () => {
+      const emptyNavigation: AppNavigation = { navigation: "Left", links: [] }
+
+      await request
+        .put(`/api/navigation/${workspaceApp._id}`)
+        .send({ navigation: emptyNavigation })
+        .set(config.defaultHeaders())
+        .expect(204)
+
+      const updatedApp = await config.api.workspaceApp.find(workspaceApp._id)
+      expect(updatedApp).toBeDefined()
+      expect(updatedApp!.navigation).toEqual(emptyNavigation)
+
+      const appMetadata = await config.api.application.get(config.getAppId())
+      expect(appMetadata.navigation).toEqual(emptyNavigation)
+    })
+  })
+})

--- a/packages/server/src/api/routes/tests/navigation.spec.ts
+++ b/packages/server/src/api/routes/tests/navigation.spec.ts
@@ -3,7 +3,6 @@ import * as setup from "./utilities"
 import { AppNavigation, WithRequired, WorkspaceApp } from "@budibase/types"
 
 describe("/navigation", () => {
-  let request = setup.getRequest()
   let config = setup.getConfig()
   let workspaceApp: WithRequired<WorkspaceApp, "_id">
 
@@ -37,11 +36,9 @@ describe("/navigation", () => {
 
   describe("PUT /api/navigation/:workspaceAppId", () => {
     it("should update navigation for workspace app", async () => {
-      await request
-        .put(`/api/navigation/${workspaceApp._id}`)
-        .send({ navigation: sampleNavigation })
-        .set(config.defaultHeaders())
-        .expect(204)
+      await config.api.navigation.update(workspaceApp._id, {
+        navigation: sampleNavigation,
+      })
 
       const updatedApp = await config.api.workspaceApp.find(workspaceApp._id)
       expect(updatedApp).toBeDefined()
@@ -49,22 +46,20 @@ describe("/navigation", () => {
     })
 
     it("should update both workspace app and default app navigation for default workspaceApps", async () => {
-      await request
-        .put(`/api/navigation/${workspaceApp._id}`)
-        .send({ navigation: sampleNavigation })
-        .set(config.defaultHeaders())
-        .expect(204)
+      await config.api.navigation.update(workspaceApp._id, {
+        navigation: sampleNavigation,
+      })
 
       const appMetadata = await config.api.application.get(config.getAppId())
       expect(appMetadata.navigation).toEqual(sampleNavigation)
     })
 
     it("should return 400 for invalid workspace app id", async () => {
-      await request
-        .put("/api/navigation/invalid_id")
-        .send({ navigation: sampleNavigation })
-        .set(config.defaultHeaders())
-        .expect(400)
+      await config.api.navigation.update(
+        "invalid_id",
+        { navigation: sampleNavigation },
+        { status: 400 }
+      )
     })
 
     it("should not app navigation app navigation when updating not default workspaces", async () => {
@@ -74,11 +69,9 @@ describe("/navigation", () => {
         })
       expect(otherWorkspaceApp.isDefault).toBe(false)
 
-      await request
-        .put(`/api/navigation/${otherWorkspaceApp._id}`)
-        .send({ navigation: sampleNavigation })
-        .set(config.defaultHeaders())
-        .expect(204)
+      await config.api.navigation.update(otherWorkspaceApp._id, {
+        navigation: sampleNavigation,
+      })
 
       const updatedWorkspaceApp = await config.api.workspaceApp.find(
         otherWorkspaceApp._id
@@ -92,11 +85,9 @@ describe("/navigation", () => {
     it("should handle empty navigation links", async () => {
       const emptyNavigation: AppNavigation = { navigation: "Left", links: [] }
 
-      await request
-        .put(`/api/navigation/${workspaceApp._id}`)
-        .send({ navigation: emptyNavigation })
-        .set(config.defaultHeaders())
-        .expect(204)
+      await config.api.navigation.update(workspaceApp._id, {
+        navigation: emptyNavigation,
+      })
 
       const updatedApp = await config.api.workspaceApp.find(workspaceApp._id)
       expect(updatedApp).toBeDefined()

--- a/packages/server/src/api/routes/workspaceApp.ts
+++ b/packages/server/src/api/routes/workspaceApp.ts
@@ -39,6 +39,11 @@ router.get(
   authorized(PermissionType.BUILDER),
   controller.fetch
 )
+router.get(
+  "/api/workspaceApp/:id",
+  authorized(PermissionType.BUILDER),
+  controller.find
+)
 router.post(
   "/api/workspaceApp",
   authorized(PermissionType.BUILDER),

--- a/packages/server/src/sdk/app/navigation/index.ts
+++ b/packages/server/src/sdk/app/navigation/index.ts
@@ -97,10 +97,21 @@ export async function deleteLink(route: string, workspaceAppId: string) {
   }
 }
 
-export async function update(navigation: AppNavigation) {
-  const appMetadata = await sdk.applications.metadata.get()
-  appMetadata.navigation = navigation
+export async function update(
+  workspaceAppId: string,
+  navigation: AppNavigation
+) {
+  const workspaceApp = await sdk.workspaceApps.get(workspaceAppId)
+  if (!workspaceApp) {
+    throw new HTTPError("Workspace app not found", 400)
+  }
+  await sdk.workspaceApps.update({ ...workspaceApp, navigation })
 
-  const db = context.getAppDB()
-  await db.put(appMetadata)
+  if (workspaceApp.isDefault) {
+    const appMetadata = await sdk.applications.metadata.get()
+    appMetadata.navigation = navigation
+
+    const db = context.getAppDB()
+    await db.put(appMetadata)
+  }
 }

--- a/packages/server/src/tests/utilities/api/index.ts
+++ b/packages/server/src/tests/utilities/api/index.ts
@@ -27,6 +27,7 @@ import { AIAPI } from "./ai"
 import { WorkspaceAppAPI } from "./workspaceApp"
 import { ResourceAPI } from "./resource"
 import { DeployAPI } from "./deploy"
+import { NavigationAPI } from "./navigation"
 
 export default class API {
   ai: AIAPI
@@ -55,6 +56,7 @@ export default class API {
   assets: AssetsAPI
   workspaceApp: WorkspaceAppAPI
   resource: ResourceAPI
+  navigation: NavigationAPI
 
   public: {
     user: UserPublicAPI
@@ -88,6 +90,7 @@ export default class API {
     this.assets = new AssetsAPI(config)
     this.workspaceApp = new WorkspaceAppAPI(config)
     this.resource = new ResourceAPI(config)
+    this.navigation = new NavigationAPI(config)
     this.public = {
       user: new UserPublicAPI(config),
       row: new RowPublicAPI(config),

--- a/packages/server/src/tests/utilities/api/navigation.ts
+++ b/packages/server/src/tests/utilities/api/navigation.ts
@@ -1,0 +1,18 @@
+import { UpdateNavigationRequest } from "@budibase/types"
+import { Expectations, TestAPI } from "./base"
+
+export class NavigationAPI extends TestAPI {
+  update = async (
+    id: string,
+    request: UpdateNavigationRequest,
+    expectations?: Expectations
+  ) => {
+    return await this._put<void>(`/api/navigation/${id}`, {
+      body: request,
+      expectations: {
+        status: 204,
+        ...expectations,
+      },
+    })
+  }
+}

--- a/packages/server/src/tests/utilities/api/workspaceApp.ts
+++ b/packages/server/src/tests/utilities/api/workspaceApp.ts
@@ -1,5 +1,6 @@
 import {
   FetchWorkspaceAppResponse,
+  FindWorkspaceAppResponse,
   InsertWorkspaceAppRequest,
   InsertWorkspaceAppResponse,
 } from "@budibase/types"
@@ -26,5 +27,17 @@ export class WorkspaceAppAPI extends TestAPI {
         ...expectations,
       },
     })
+  }
+
+  find = async (id: string, expectations?: Expectations) => {
+    return await this._get<FindWorkspaceAppResponse>(
+      `/api/workspaceApp/${id}`,
+      {
+        expectations: {
+          status: 200,
+          ...expectations,
+        },
+      }
+    )
   }
 }

--- a/packages/types/src/api/web/app/workspaceApp.ts
+++ b/packages/types/src/api/web/app/workspaceApp.ts
@@ -39,3 +39,5 @@ export interface UpdateWorkspaceAppResponse {
 export interface FetchWorkspaceAppResponse {
   workspaceApps: WorkspaceAppResponse[]
 }
+
+export interface FindWorkspaceAppResponse extends WorkspaceAppResponse {}

--- a/packages/types/src/sdk/koa.ts
+++ b/packages/types/src/sdk/koa.ts
@@ -43,7 +43,12 @@ export interface BBRequest<RequestBody> extends Request {
 /**
  * Basic context with no user.
  */
-export interface Ctx<RequestBody = any, ResponseBody = any> extends Context {
+export interface Ctx<
+  RequestBody = any,
+  ResponseBody = any,
+  Params extends Record<string, any> = any,
+> extends Context {
+  params: Params
   request: BBRequest<RequestBody>
   body: ResponseBody
   userAgent: UserAgentContext["userAgent"]
@@ -53,8 +58,11 @@ export interface Ctx<RequestBody = any, ResponseBody = any> extends Context {
 /**
  * Authenticated context.
  */
-export interface UserCtx<RequestBody = any, ResponseBody = any>
-  extends Ctx<RequestBody, ResponseBody> {
+export interface UserCtx<
+  RequestBody = any,
+  ResponseBody = any,
+  Params extends Record<string, any> = any,
+> extends Ctx<RequestBody, ResponseBody, Params> {
   user: ContextUser
   state: { nonce?: string }
   roleId?: string


### PR DESCRIPTION
## Description
Cleaning the code around navigation for the frontend. This was meant to be a temporally status, so we had a patch that was updating both workspace app and app metadata navigation if required. As this might stay longer, and we found a bug around this (where the store was not properly updated and we had some silent errors), we are moving this logic into the backend.

The logic is as it was:
1. If we are updating a navigation part of the default workspace app, we update both workspace app navigation and the app metadata
2. If it's not the default workspace app, we only update the workspace app

## Launchcontrol
Ensure default workspace app and app metadata navigation are always on sync
