### PR TITLE
Small fix: for REST textarea for raw and jsonpreview

### DIFF
--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -706,7 +706,7 @@
             {#if response}
               <Tab title="JSON">
                 <div>
-                  <JSONPreview height="300" data={response.rows[0]} />
+                  <JSONPreview height={300} data={response.rows[0]} />
                 </div>
               </Tab>
             {/if}
@@ -726,7 +726,7 @@
             {/if}
             {#if response}
               <Tab title="Raw">
-                <TextArea disabled value={response.extra?.raw} height="300" />
+                <TextArea disabled value={response.extra?.raw} height={300} />
               </Tab>
               <Tab title="Headers">
                 <KeyValueBuilder


### PR DESCRIPTION
## Description
A change made 5 months ago introduced logic that only adds a "px" suffix to the height value if it's a number. If the height is passed as a string (e.g., "300"), it skips the suffix and uses the value as-is.

In this case, the REST text area fields had height values set as strings ("300"). So the raw value was used.

This PR ensures the height is passed as a number instead of a string. That way, it includes the "px" suffix, resulting in a valid CSS style attribute, fixing the issue.

## Addresses
- https://github.com/Budibase/budibase/issues/16048

## Screenshots
**Before**
<img width="1239" alt="Screenshot 2025-07-10 at 11 15 36" src="https://github.com/user-attachments/assets/f3ca9207-39cf-4247-adf3-fbd5b7747b0b" />

**After**
<img width="1247" alt="Screenshot 2025-07-10 at 11 13 00" src="https://github.com/user-attachments/assets/f01ef3a9-c67b-4c21-a2b8-22c9b101a8fb" />

## Launchcontrol
A change a while back made the text area’s height work properly only if the number had no quotes around it (like 300 instead of "300"). But in some places, the height was written as a string with quotes, so the system didn’t add "px" to the end, and the result wasn’t valid CSS, which messed up how the text area displayed.

This fixes a number rather than a string, so px is added to the end of the number value.