### PR TITLE
Centre align login header whenever the text wraps

### DIFF
--- a/packages/builder/src/pages/builder/auth/login.svelte
+++ b/packages/builder/src/pages/builder/auth/login.svelte
@@ -75,7 +75,7 @@
         {#if loaded}
           <img alt="logo" src={$organisation.logoUrl || Logo} />
         {/if}
-        <Heading size="M">
+        <Heading size="M" textAlign="center">
           {$organisation.loginHeading || "Log in to Budibase"}
         </Heading>
       </Layout>


### PR DESCRIPTION
## Description
When a custom branding login header was long enough to wrap over one line, the block of text was aligned left. This tiny update ensures the heading is always centred regardless of length,

## Screenshots
_before_
<img width="510" height="598" alt="SCR-20250710-pgvt" src="https://github.com/user-attachments/assets/8cc3a2ad-fd88-4d70-8885-33ae61140acf" />


_after_
<img width="510" height="598" alt="SCR-20250710-pgsz" src="https://github.com/user-attachments/assets/03802ac1-4581-45e4-93e7-22957b756a24" />


## Launchcontrol
centre align login screen header text
