### PR TITLE
Revert cell highlight colors

### DIFF
--- a/packages/frontend-core/src/components/grid/layout/Grid.svelte
+++ b/packages/frontend-core/src/components/grid/layout/Grid.svelte
@@ -218,7 +218,7 @@
     /* Variables */
     --accent-color: var(--primaryColor, var(--spectrum-global-color-blue-400));
     --grid-background: var(--spectrum-global-color-gray-50);
-    --grid-background-alt: var(--background);
+    --grid-background-alt: var(--spectrum-global-color-gray-100);
     --header-cell-background: var(
       --custom-header-cell-background,
       var(--spectrum-global-color-gray-100)
@@ -230,7 +230,7 @@
     --cell-spacing: 4px;
     --cell-border: 1px solid var(--spectrum-global-color-gray-200);
     --cell-font-size: 14px;
-    --cell-font-color: var(--spectrum-global-color-gray-900);
+    --cell-font-color: var(--spectrum-global-color-gray-800);
     flex: 1 1 auto;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Description
Grid highlight colors were hard altered recently and the background color for cells was set to the core background value of white. I've reverted the background and font color changes.

## Addresses
-  Colors were altered here. https://github.com/Budibase/budibase/pull/16414

## Launchcontrol
Fix for grid highlight color