### PR TITLE
Add clear row selection for gridblock

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/ClearRowSelection.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/ClearRowSelection.svelte
@@ -2,7 +2,6 @@
   import { Label, Select, Body } from "@budibase/bbui"
   import { findAllMatchingComponents } from "@/helpers/components"
   import { selectedScreen } from "@/stores/builder"
-  import { InlineAlert } from "@budibase/bbui"
 
   export let parameters
 
@@ -19,7 +18,13 @@
     label: block._instanceName,
     value: `${block._id}-table`,
   }))
-  $: componentOptions = tables.concat(tableBlocks)
+  $: gridBlocks = findAllMatchingComponents($selectedScreen?.props, component =>
+    component._component.endsWith("gridblock")
+  ).map(block => ({
+    label: block._instanceName,
+    value: block._id,
+  }))
+  $: componentOptions = tables.concat(tableBlocks).concat(gridBlocks)
 </script>
 
 <div class="root">
@@ -28,12 +33,6 @@
     <Label small>Table</Label>
     <Select bind:value={parameters.componentId} options={componentOptions} />
   </div>
-  <InlineAlert
-    header="Legacy action"
-    message="This action is only compatible with the (deprecated) Table Block. Please see the documentation for further info."
-    link="https://docs.budibase.com/docs/data-actions#clear-row-selection"
-    linkText="Budibase Documentation"
-  />
 </div>
 
 <style>

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -8215,7 +8215,11 @@
         ]
       }
     ],
-    "actions": ["RefreshDatasource", "AddDataProviderFilterExtension"]
+    "actions": [
+      "AddDataProviderFilterExtension",
+      "ClearRowSelection",
+      "RefreshDatasource"
+    ]
   },
   "bbreferencefield": {
     "devComment": "As bb reference is only used for user subtype for now, we are using user for icon and labels",

--- a/packages/client/src/components/app/GridBlock.svelte
+++ b/packages/client/src/components/app/GridBlock.svelte
@@ -76,6 +76,10 @@
       callback: addFilterExtension,
     },
     {
+      type: ActionTypes.ClearRowSelection,
+      callback: () => gridContext?.selectedRows?.set?.({}),
+    },
+    {
       type: ActionTypes.RemoveDataProviderFilterExtension,
       callback: removeFilterExtension,
     },


### PR DESCRIPTION
## Description
Allow rows in the grid block to be unselected via action. 

Warning should be removed from the docs: https://docs.budibase.com/docs/data-actions#clear-row-selection

## Addresses
- https://linear.app/budibase/issue/BUDI-9111/allow-clear-row-selection-to-work-with-the-newer-table-component
- https://github.com/Budibase/budibase/issues/15690

## Screenshots
https://github.com/user-attachments/assets/2b45cdc9-a896-47f6-8821-a0a6445d19ca


## Launchcontrol
Support Clear Row Selection action in the new table component (Grid Block)
