### PR TITLE
Migration processor for corrupted prod apps

### DIFF
--- a/packages/server/src/appMigrations/migrationsProcessor.ts
+++ b/packages/server/src/appMigrations/migrationsProcessor.ts
@@ -18,7 +18,7 @@ export async function processMigrations(
     await doInMigrationLock(appId, async () => {
       const devAppId = db.getDevAppID(appId)
       const prodAppId = db.getProdAppID(appId)
-      const isPublished = await db.dbExists(prodAppId)
+      const isPublished = await sdk.applications.isAppPublished(prodAppId)
       const appIdToMigrate = isPublished ? prodAppId : devAppId
 
       console.log(`Starting app migration for "${appIdToMigrate}"`)

--- a/packages/server/src/sdk/app/applications/applications.ts
+++ b/packages/server/src/sdk/app/applications/applications.ts
@@ -35,8 +35,8 @@ export async function fetch(status: AppStatus, user: ContextUser) {
   apps = filterAppList(enrichedUser, apps)
 
   const appIds = apps
-    .filter((app: any) => app.status === "development")
-    .map((app: any) => app.appId)
+    .filter(app => app.status === "development")
+    .map(app => app.appId)
 
   // get the locks for all the dev apps
   if (dev || all) {

--- a/packages/server/src/sdk/app/applications/utils.ts
+++ b/packages/server/src/sdk/app/applications/utils.ts
@@ -1,3 +1,5 @@
+import { db } from "@budibase/backend-core"
+
 const URL_REGEX_SLASH = /\/|\\/g
 
 export function getAppUrl(opts?: { name?: string; url?: string }) {
@@ -14,4 +16,13 @@ export function getAppUrl(opts?: { name?: string; url?: string }) {
     url = `/${url.replace(URL_REGEX_SLASH, "")}`.toLowerCase()
   }
   return url as string
+}
+
+export async function isAppPublished(prodAppId: string): Promise<boolean> {
+  if (db.isDevAppID(prodAppId)) {
+    prodAppId = db.getProdAppID(prodAppId)
+  }
+
+  const existingApps = await db.getAppsByIDs([prodAppId])
+  return !!existingApps.length
 }

--- a/packages/server/src/sdk/users/sessions.ts
+++ b/packages/server/src/sdk/users/sessions.ts
@@ -4,8 +4,8 @@ import { App, SocketSession } from "@budibase/types"
 export const enrichApps = async (apps: App[]) => {
   // Sessions can only exist for dev app IDs
   const devAppIds = apps
-    .filter((app: any) => app.status === "development")
-    .map((app: any) => app.appId)
+    .filter(app => app.status === "development")
+    .map(app => app.appId)
 
   // Get all sessions for all apps and enrich app list
   const sessions = await builderSocket?.getRoomSessions(devAppIds)


### PR DESCRIPTION
## Description
There is a known issue that some apps prod db are not properly cleaned.
<img width="1907" height="479" alt="image" src="https://github.com/user-attachments/assets/8de95186-172f-4ea7-9d7d-72899bc27b11" />

Our code checks if the prod db exists to determine if a specific app is published. I used the same for migrationProcessor, but this caused some errors as the db exists, but the appMetadata (expected) does not. This PR created a util to check if an app is published (using the same mechanism to show publish/non-published in the builder.
This is only used for the migrationProcessor now (to fix the current issue), but I will check the other possible uses and replace it properly if needed.


## Launchcontrol
Fix migration processor for half-published apps