### PR TITLE
Fix flaky test

### DIFF
--- a/packages/server/src/api/routes/tests/application.spec.ts
+++ b/packages/server/src/api/routes/tests/application.spec.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_TABLES } from "../../../db/defaultData/datasource_bb_default"
-import { setEnv } from "../../../environment"
+import { setEnv, withEnv } from "../../../environment"
 
 import { checkBuilderEndpoint } from "./utilities/TestFunctions"
 import * as setup from "./utilities"
@@ -972,9 +972,15 @@ describe("/applications", () => {
         .reply(200, {})
 
       expect(migrationMock).not.toHaveBeenCalled()
-      await config.api.application.delete(app.appId, {
-        headersNotPresent: [Header.MIGRATING_APP],
-      })
+      await withEnv(
+        {
+          SYNC_MIGRATION_CHECKS_MS: 1000,
+        },
+        () =>
+          config.api.application.delete(app.appId, {
+            headersNotPresent: [Header.MIGRATING_APP],
+          })
+      )
 
       expect(migrationMock).toHaveBeenCalledTimes(2)
       expect(events.app.deleted).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Description
Fixing a ghostly flaky test. This test (as all of them) is using the "wait for migration complete timeout", and for Jest it is really short to prevent timeouts. This specific test expects the migration to complete, and because it's so short, from time to time it times out and reruns. This causes the flake.
Increasing the timeout ensures the flake goes away