### PR TITLE
fix(singleimage): use pm2 to manage redis-server

### DIFF
--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -83,6 +83,8 @@ COPY hosting/single/redis.conf /etc/redis/redis.conf
 WORKDIR /
 COPY hosting/single/runner.sh .
 RUN chmod +x ./runner.sh
+COPY hosting/single/redis-runner.sh .
+RUN chmod +x ./redis-runner.sh
 COPY hosting/single/healthcheck.sh .
 RUN chmod +x ./healthcheck.sh
 

--- a/hosting/single/redis-runner.sh
+++ b/hosting/single/redis-runner.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+REDIS_CONFIG="/etc/redis/redis.conf"
+sed -i "s#DATA_DIR#${DATA_DIR}#g" "${REDIS_CONFIG}"
+
+if [[ -n "${USE_DEFAULT_REDIS_CONFIG}" ]]; then
+    unset REDIS_CONFIG
+fi
+
+REDIS_LAUNCH_SCRIPT="/tmp/redis-server-launch.sh"
+cat <<EOF > "$REDIS_LAUNCH_SCRIPT"
+#!/bin/bash
+if [[ -n "\${REDIS_PASSWORD}" ]]; then
+    if [[ -n "\${REDIS_CONFIG}" ]]; then
+        exec redis-server "\${REDIS_CONFIG}" --requirepass "\$REDIS_PASSWORD"
+    else
+        exec redis-server --requirepass "\$REDIS_PASSWORD"
+    fi
+else
+    if [[ -n "\${REDIS_CONFIG}" ]]; then
+        exec redis-server "\${REDIS_CONFIG}"
+    else
+        exec redis-server
+    fi
+fi
+EOF
+
+chmod +x "$REDIS_LAUNCH_SCRIPT"
+
+echo "Starting redis-server with pm2..."
+pm2 start "$REDIS_LAUNCH_SCRIPT" --name redis-server --interpreter bash

--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -88,18 +88,8 @@ mkdir -p ${DATA_DIR}/redis
 mkdir -p ${DATA_DIR}/couch
 chown -R couchdb:couchdb ${DATA_DIR}/couch
 
-REDIS_CONFIG="/etc/redis/redis.conf"
-sed -i "s#DATA_DIR#${DATA_DIR}#g" "${REDIS_CONFIG}"
-
-if [[ -n "${USE_DEFAULT_REDIS_CONFIG}" ]]; then
-    REDIS_CONFIG=""
-fi
-
-if [[ -n "${REDIS_PASSWORD}" ]]; then
-    redis-server "${REDIS_CONFIG}" --requirepass $REDIS_PASSWORD >/dev/stdout 2>&1 &
-else
-    redis-server "${REDIS_CONFIG}" >/dev/stdout 2>&1 &
-fi
+echo "Starting Redis runner..."
+./redis-runner.sh &
 
 echo "Starting callback CouchDB runner..."
 ./bbcouch-runner.sh &


### PR DESCRIPTION
Helps with the `redis-server` process being killed if the container is idling on serverless environments
