### PR TITLE
Fix scroll on automation side-bar-nav class.

### DIFF
--- a/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/AutomationPanel.svelte
@@ -169,6 +169,7 @@
     flex: 1 1 auto;
     overflow: auto;
     overflow-x: hidden;
+    max-height: calc(100vh - 118px);
   }
 
   .no-results {


### PR DESCRIPTION
## Description
After x amount of automations were added, the automation list couldn't be scrolled through. This adds a max height so the overflow: auto can scroll through the list. `- 118px` accounts for the nav, side-bar-controls height, and padding applied to the top of the automation list.

## Addresses
- Customer report

## Screenshots
**Before**
![20250725_090924](https://github.com/user-attachments/assets/83f26b09-0039-44d2-bc8c-09c4e0fd2d9c)

**After**
![20250725_090836](https://github.com/user-attachments/assets/e6b6422e-c011-4e8f-a3b3-10abbb9bb089)

## Launchcontrol
Fixed an issue where you couldn't scroll through an extensive list of automations.