### PR TITLE
Return doc on db.put

### DIFF
--- a/packages/backend-core/src/db/couch/DatabaseImpl.ts
+++ b/packages/backend-core/src/db/couch/DatabaseImpl.ts
@@ -335,7 +335,13 @@ export class DatabaseImpl implements Database {
           }
         }
       }
-      return () => db.insert(document)
+      return async () => {
+        const response = await db.insert(document)
+        if (!opts?.returnDoc) {
+          return response
+        }
+        return { ...response, doc: { ...document, _rev: response.rev } }
+      }
     })
   }
 

--- a/packages/backend-core/src/db/couch/tests/DatabaseImpl.spec.ts
+++ b/packages/backend-core/src/db/couch/tests/DatabaseImpl.spec.ts
@@ -43,6 +43,72 @@ describe("DatabaseImpl", () => {
         updatedAt: new Date().toISOString(),
       })
     })
+
+    describe("returnDoc option", () => {
+      it("returns standard response when returnDoc is not provided", async () => {
+        const id = generator.guid()
+        const response = await db.put({ _id: id })
+
+        expect(response).toEqual({
+          id,
+          rev: expect.any(String),
+          ok: true,
+        })
+        expect(response).not.toHaveProperty("doc")
+      })
+
+      it("returns standard response when returnDoc is false", async () => {
+        const id = generator.guid()
+        const response = await db.put({ _id: id }, { returnDoc: false })
+
+        expect(response).toEqual({
+          id,
+          rev: expect.any(String),
+          ok: true,
+        })
+        expect(response).not.toHaveProperty("doc")
+      })
+
+      it("returns document with updated _rev when returnDoc is true", async () => {
+        const id = generator.guid()
+        const originalDoc = { _id: id, value: "test" }
+        const response = await db.put(originalDoc, { returnDoc: true })
+
+        expect(response).toEqual({
+          id,
+          rev: expect.any(String),
+          ok: true,
+          doc: {
+            _id: id,
+            _rev: response.rev,
+            value: "test",
+            createdAt: initialTime.toISOString(),
+            updatedAt: initialTime.toISOString(),
+          },
+        })
+      })
+
+      it("includes all document fields in returned doc", async () => {
+        const id = generator.guid()
+        const originalDoc = {
+          _id: id,
+          name: "test",
+          count: 42,
+          nested: { value: "nested" },
+        }
+        const response = await db.put(originalDoc, { returnDoc: true })
+
+        expect(response.doc).toEqual({
+          _id: id,
+          _rev: response.rev,
+          name: "test",
+          count: 42,
+          nested: { value: "nested" },
+          createdAt: initialTime.toISOString(),
+          updatedAt: initialTime.toISOString(),
+        })
+      })
+    })
   })
 
   describe("bulkDocs", () => {

--- a/packages/server/src/sdk/app/workspaceApps/crud.ts
+++ b/packages/server/src/sdk/app/workspaceApps/crud.ts
@@ -35,15 +35,14 @@ export async function create(
 
   await guardName(workspaceApp.name)
 
-  const response = await db.put({
-    _id: docIds.generateWorkspaceAppID(),
-    ...workspaceApp,
-  })
-  return {
-    ...workspaceApp,
-    _id: response.id!,
-    _rev: response.rev!,
-  }
+  const response = await db.put(
+    {
+      _id: docIds.generateWorkspaceAppID(),
+      ...workspaceApp,
+    },
+    { returnDoc: true }
+  )
+  return response.doc
 }
 
 export async function update(
@@ -69,11 +68,7 @@ export async function update(
     _deleted: undefined,
   }
   const response = await db.put(docToUpdate)
-  return {
-    ...docToUpdate,
-    _id: response.id!,
-    _rev: response.rev!,
-  }
+  return response.doc
 }
 
 export async function remove(

--- a/packages/types/src/sdk/db.ts
+++ b/packages/types/src/sdk/db.ts
@@ -65,6 +65,7 @@ export type DatabaseOpts = {
 
 export type DatabasePutOpts = {
   force?: boolean
+  returnDoc?: boolean
 }
 
 export type DatabaseCreateIndexOpts = {
@@ -135,9 +136,13 @@ export interface Database {
     documents: Document[],
     opts?: { silenceErrors?: boolean }
   ): Promise<void>
-  put(
-    document: AnyDocument,
-    opts?: DatabasePutOpts
+  put<T extends AnyDocument>(
+    document: T,
+    opts?: DatabasePutOpts & { returnDoc: true }
+  ): Promise<Nano.DocumentInsertResponse & { doc: T }>
+  put<T extends AnyDocument>(
+    document: T,
+    opts?: DatabasePutOpts & { returnDoc?: false }
   ): Promise<Nano.DocumentInsertResponse>
   bulkDocs(documents: AnyDocument[]): Promise<Nano.DocumentBulkResponse[]>
   sql<T extends Document>(


### PR DESCRIPTION
## Description
There are plenty of places where when we do a db.put, we need to get the response and to properly map _rev. And on other cases, we need to re-retrieve the document to be able to get the latest updated/createdAt fields. Because of this, this PR is adding a flag to retrieve the document just stored, mapping to the right _rev. This will ensure we get the right data, and it will remove the need to do it on each usage