### PR TITLE
Use bounded concurrency for retrieveDirectory

### DIFF
--- a/packages/backend-core/src/objectStore/objectStore.ts
+++ b/packages/backend-core/src/objectStore/objectStore.ts
@@ -442,19 +442,23 @@ export async function retrieveDirectory(bucketName: string, path: string) {
     let numObjects = 0
     for await (const object of listAllObjects(bucketName, path)) {
       numObjects++
-
-      const filename = object.Key!
-      const stream = await getReadStream(bucketName, filename)
-      const possiblePath = filename.split("/")
-      const dirs = possiblePath.slice(0, possiblePath.length - 1)
-      const possibleDir = join(writePath, ...dirs)
-      if (possiblePath.length > 1 && !fs.existsSync(possibleDir)) {
-        await fsp.mkdir(possibleDir, { recursive: true })
-      }
-      await pipeline(
-        stream,
-        fs.createWriteStream(join(writePath, ...possiblePath), { mode: 0o644 })
-      )
+      await tracer.trace("retrieveDirectory.object", async span => {
+        const filename = object.Key!
+        span.addTags({ filename })
+        const stream = await getReadStream(bucketName, filename)
+        const possiblePath = filename.split("/")
+        const dirs = possiblePath.slice(0, possiblePath.length - 1)
+        const possibleDir = join(writePath, ...dirs)
+        if (possiblePath.length > 1 && !fs.existsSync(possibleDir)) {
+          await fsp.mkdir(possibleDir, { recursive: true })
+        }
+        await pipeline(
+          stream,
+          fs.createWriteStream(join(writePath, ...possiblePath), {
+            mode: 0o644,
+          })
+        )
+      })
     }
 
     span.addTags({ numObjects })
@@ -592,18 +596,25 @@ export async function getReadStream(
   bucketName: string,
   path: string
 ): Promise<Readable> {
-  bucketName = sanitizeBucket(bucketName)
-  path = sanitizeKey(path)
-  const client = ObjectStore()
-  const params = {
-    Bucket: bucketName,
-    Key: path,
-  }
-  const response = await client.getObject(params)
-  if (!response.Body || !(response.Body instanceof stream.Readable)) {
-    throw new Error("Unable to retrieve stream - invalid response")
-  }
-  return response.Body
+  return await tracer.trace("getReadStream", async span => {
+    bucketName = sanitizeBucket(bucketName)
+    path = sanitizeKey(path)
+    span.addTags({ bucketName, path })
+    const client = ObjectStore()
+    const params = {
+      Bucket: bucketName,
+      Key: path,
+    }
+    const response = await client.getObject(params)
+    if (!response.Body || !(response.Body instanceof stream.Readable)) {
+      throw new Error("Unable to retrieve stream - invalid response")
+    }
+    span.addTags({
+      contentLength: response.ContentLength,
+      contentType: response.ContentType,
+    })
+    return response.Body
+  })
 }
 
 export async function getObjectMetadata(

--- a/packages/shared-core/src/utils.ts
+++ b/packages/shared-core/src/utils.ts
@@ -39,24 +39,32 @@ export function unreachable(
 }
 
 export async function parallelForeach<T>(
-  items: T[],
+  items: Iterable<T> | AsyncIterable<T>,
   task: (item: T) => Promise<void>,
   maxConcurrency: number
 ): Promise<void> {
   const results: Promise<void>[] = []
-  let index = 0
+
+  // Check if it's an async iterable
+  const isAsyncIterable = Symbol.asyncIterator in items
+  const iterator = isAsyncIterable
+    ? (items as AsyncIterable<T>)[Symbol.asyncIterator]()
+    : (items as Iterable<T>)[Symbol.iterator]()
 
   const executeNext = async (): Promise<void> => {
-    while (index < items.length) {
-      const currentIndex = index++
-      const item = items[currentIndex]
+    let result = await (isAsyncIterable
+      ? (iterator as AsyncIterator<T>).next()
+      : Promise.resolve((iterator as Iterator<T>).next()))
 
-      await task(item)
+    while (!result.done) {
+      await task(result.value)
+      result = await (isAsyncIterable
+        ? (iterator as AsyncIterator<T>).next()
+        : Promise.resolve((iterator as Iterator<T>).next()))
     }
   }
 
-  // Start up to maxConcurrency workers
-  for (let i = 0; i < Math.min(maxConcurrency, items.length); i++) {
+  for (let i = 0; i < maxConcurrency; i++) {
     results.push(executeNext())
   }
 


### PR DESCRIPTION
## Description

After getting https://github.com/Budibase/budibase/pull/16624 into QA I took it for a spin and noticed it was a lil' slow, so I've made `parallelForEach` work with async generators and given it a concurrency of 3 for downloading from S3.