### PR TITLE
Revert "Navigation from workspace app"

### DIFF
--- a/packages/builder/src/stores/builder/app.ts
+++ b/packages/builder/src/stores/builder/app.ts
@@ -11,7 +11,7 @@ import {
   UpdateAppRequest,
 } from "@budibase/types"
 import { get } from "svelte/store"
-import { initialise, navigationStore, workspaceAppStore } from "."
+import { initialise, navigationStore } from "."
 
 interface ClientFeatures {
   spectrumThemes: boolean
@@ -206,15 +206,9 @@ export class AppMetaStore extends BudiStore<AppMetaState> {
   }
 
   async refreshAppNav() {
-    const { selectedWorkspaceApp } = get(workspaceAppStore)
-    if (!selectedWorkspaceApp) {
-      return
-    }
-
-    const { navigation } = await API.workspaceApp.find(
-      selectedWorkspaceApp._id!
-    )
-    navigationStore.syncAppNavigation(navigation)
+    const { appId } = get(this.store)
+    const { application } = await API.fetchAppPackage(appId)
+    navigationStore.syncAppNavigation(application?.navigation)
   }
 }
 

--- a/packages/builder/src/stores/builder/screens.ts
+++ b/packages/builder/src/stores/builder/screens.ts
@@ -7,6 +7,7 @@ import {
   appStore,
   componentStore,
   layoutStore,
+  navigationStore,
   previewStore,
   selectedComponent,
   workspaceAppStore,
@@ -18,6 +19,7 @@ import {
   Component,
   ComponentDefinition,
   DeleteScreenResponse,
+  FeatureFlag,
   FetchAppPackageResponse,
   SaveScreenRequest,
   SaveScreenResponse,
@@ -25,6 +27,7 @@ import {
   ScreenVariant,
   WithRequired,
 } from "@budibase/types"
+import { featureFlag } from "@/helpers"
 
 interface ScreenState {
   screens: Screen[]
@@ -264,6 +267,17 @@ export class ScreenStore extends BudiStore<ScreenState> {
 
       return state
     })
+
+    if (
+      !featureFlag.isEnabled(FeatureFlag.WORKSPACE_APPS) &&
+      navigationLinkLabel
+    ) {
+      await navigationStore.addLink({
+        url: screen.routing.route,
+        title: navigationLinkLabel,
+        roleId: screen.routing.roleId,
+      })
+    }
 
     await appStore.refreshAppNav()
 

--- a/packages/frontend-core/src/api/workspaceApps.ts
+++ b/packages/frontend-core/src/api/workspaceApps.ts
@@ -1,6 +1,5 @@
 import {
   FetchWorkspaceAppResponse,
-  FindWorkspaceAppResponse,
   InsertWorkspaceAppRequest,
   InsertWorkspaceAppResponse,
   UpdateWorkspaceAppRequest,
@@ -9,7 +8,6 @@ import {
 import { BaseAPIClient } from "./types"
 
 export interface WorkspaceAppEndpoints {
-  find: (id: string) => Promise<FindWorkspaceAppResponse>
   fetch: () => Promise<FetchWorkspaceAppResponse>
   create: (
     workspaceApp: InsertWorkspaceAppRequest
@@ -23,11 +21,6 @@ export interface WorkspaceAppEndpoints {
 export const buildWorkspaceAppEndpoints = (
   API: BaseAPIClient
 ): WorkspaceAppEndpoints => ({
-  find: async id => {
-    return await API.get({
-      url: `/api/workspaceApp/${id}`,
-    })
-  },
   fetch: async () => {
     return await API.get({
       url: "/api/workspaceApp",

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -26,6 +26,7 @@ import {
   docIds,
   env as envCore,
   events,
+  features,
   objectStore,
   roles,
   tenancy,
@@ -68,6 +69,7 @@ import {
   AddAppSampleDataResponse,
   UnpublishAppResponse,
   ErrorCode,
+  FeatureFlag,
   FetchPublishedAppsResponse,
 } from "@budibase/types"
 import { BASE_LAYOUT_PROP_IDS } from "../../constants/layouts"
@@ -202,6 +204,29 @@ async function addSampleDataScreen() {
 
   const screen = createSampleDataTableScreen(workspaceApp._id!)
   await sdk.screens.create(screen)
+
+  {
+    // TODO: remove when cleaning the flag FeatureFlag.WORKSPACE_APPS
+    const db = context.getAppDB()
+    let app = await sdk.applications.metadata.get()
+    if (!app.navigation) {
+      return
+    }
+    if (!app.navigation.links) {
+      app.navigation.links = []
+    }
+    app.navigation.links.push({
+      text: "Inventory",
+      url: "/inventory",
+      type: "link",
+      roleId: roles.BUILTIN_ROLE_IDS.BASIC,
+    })
+
+    await db.put(app)
+
+    // remove any cached metadata, so that it will be updated
+    await cache.app.invalidateAppMetadata(app.appId)
+  }
 }
 
 export const addSampleData = async (
@@ -295,7 +320,10 @@ export async function fetchAppPackage(
     screens = await accessController.checkScreensAccess(screens, userRoleId)
   }
 
-  if (!isBuilder) {
+  if (
+    (await features.flags.isEnabled(FeatureFlag.WORKSPACE_APPS)) &&
+    !isBuilder
+  ) {
     const urlPath = ctx.headers.referer
       ? new URL(ctx.headers.referer).pathname
       : ""

--- a/packages/server/src/api/routes/navigation.ts
+++ b/packages/server/src/api/routes/navigation.ts
@@ -1,4 +1,5 @@
 import * as controller from "../controllers/navigation"
 import { builderRoutes } from "./endpointGroups"
 
+// TODO: remove when cleaning the flag FeatureFlag.WORKSPACE_APPS
 builderRoutes.put("/api/navigation/:workspaceAppId", controller.update)

--- a/packages/server/src/api/routes/tests/navigation.spec.ts
+++ b/packages/server/src/api/routes/tests/navigation.spec.ts
@@ -1,3 +1,4 @@
+import { structures } from "@budibase/backend-core/tests"
 import * as setup from "./utilities"
 import { AppNavigation, WithRequired, WorkspaceApp } from "@budibase/types"
 
@@ -44,12 +45,41 @@ describe("/navigation", () => {
       expect(updatedApp!.navigation).toEqual(sampleNavigation)
     })
 
+    it("should update both workspace app and default app navigation for default workspaceApps", async () => {
+      await config.api.navigation.update(workspaceApp._id, {
+        navigation: sampleNavigation,
+      })
+
+      const appMetadata = await config.api.application.get(config.getAppId())
+      expect(appMetadata.navigation).toEqual(sampleNavigation)
+    })
+
     it("should return 400 for invalid workspace app id", async () => {
       await config.api.navigation.update(
         "invalid_id",
         { navigation: sampleNavigation },
         { status: 400 }
       )
+    })
+
+    it("should not update app navigation app navigation when updating not default workspaces", async () => {
+      const { workspaceApp: otherWorkspaceApp } =
+        await config.api.workspaceApp.create({
+          ...structures.workspaceApps.createRequest(),
+        })
+      expect(otherWorkspaceApp.isDefault).toBe(false)
+
+      await config.api.navigation.update(otherWorkspaceApp._id, {
+        navigation: sampleNavigation,
+      })
+
+      const updatedWorkspaceApp = await config.api.workspaceApp.find(
+        otherWorkspaceApp._id
+      )
+      expect(updatedWorkspaceApp.navigation).toEqual(sampleNavigation)
+
+      const appMetadata = await config.api.application.get(config.getAppId())
+      expect(appMetadata.navigation).not.toEqual(sampleNavigation)
     })
 
     it("should handle empty navigation links", async () => {
@@ -62,6 +92,9 @@ describe("/navigation", () => {
       const updatedApp = await config.api.workspaceApp.find(workspaceApp._id)
       expect(updatedApp).toBeDefined()
       expect(updatedApp!.navigation).toEqual(emptyNavigation)
+
+      const appMetadata = await config.api.application.get(config.getAppId())
+      expect(appMetadata.navigation).toEqual(emptyNavigation)
     })
   })
 })

--- a/packages/server/src/sdk/app/navigation/index.ts
+++ b/packages/server/src/sdk/app/navigation/index.ts
@@ -1,6 +1,6 @@
-import { HTTPError } from "@budibase/backend-core"
+import { context, HTTPError } from "@budibase/backend-core"
 import sdk from "../.."
-import { AppNavigation } from "@budibase/types"
+import { App, AppNavigation } from "@budibase/types"
 
 export async function addLink({
   label,
@@ -26,6 +26,24 @@ export async function addLink({
   })
 
   await sdk.workspaceApps.update(workspaceApp)
+
+  if (workspaceApp.isDefault) {
+    // TODO: remove when cleaning the flag FeatureFlag.WORKSPACE_APPS
+    const appMetadata = await sdk.applications.metadata.get()
+    appMetadata.navigation ??= {
+      navigation: "Top",
+    }
+    appMetadata.navigation.links ??= []
+    appMetadata.navigation.links.push({
+      text: label,
+      url,
+      roleId,
+      type: "link",
+    })
+
+    const db = context.getAppDB()
+    await db.put(appMetadata)
+  }
 }
 
 export async function deleteLink(route: string, workspaceAppId: string) {
@@ -48,6 +66,35 @@ export async function deleteLink(route: string, workspaceAppId: string) {
     ...workspaceApp,
     navigation: { ...workspaceApp.navigation, links: updatedLinks },
   })
+
+  if (workspaceApp.isDefault) {
+    // TODO: remove when cleaning the flag FeatureFlag.WORKSPACE_APPS
+    const appMetadata = await sdk.applications.metadata.get()
+    const navigation = appMetadata.navigation
+    if (!navigation || !navigation.links?.length) {
+      return
+    }
+
+    // Filter out top level links pointing to these URLs
+    const updatedLinks = navigation.links.filter(link => link.url !== route)
+
+    // Filter out nested links pointing to these URLs
+    updatedLinks.forEach(link => {
+      if (link.type === "sublinks" && link.subLinks?.length) {
+        link.subLinks = link.subLinks.filter(subLink => subLink.url !== route)
+      }
+    })
+
+    const db = context.getAppDB()
+    const updatedMetadata: App = {
+      ...appMetadata,
+      navigation: {
+        ...navigation,
+        links: updatedLinks,
+      },
+    }
+    await db.put(updatedMetadata)
+  }
 }
 
 export async function update(
@@ -59,4 +106,12 @@ export async function update(
     throw new HTTPError("Workspace app not found", 400)
   }
   await sdk.workspaceApps.update({ ...workspaceApp, navigation })
+
+  if (workspaceApp.isDefault) {
+    const appMetadata = await sdk.applications.metadata.get()
+    appMetadata.navigation = navigation
+
+    const db = context.getAppDB()
+    await db.put(appMetadata)
+  }
 }

--- a/packages/types/src/documents/app/app.ts
+++ b/packages/types/src/documents/app/app.ts
@@ -19,7 +19,7 @@ export interface App extends Document {
   revertableVersion?: string
   lockedBy?: User
   sessions?: SocketSession[]
-  /** @deprecated use workspace app navigation instead */
+  // @deprecated  use workspace app navigation instead
   navigation?: AppNavigation
   automationErrors?: AppMetadataErrors
   backupErrors?: AppMetadataErrors


### PR DESCRIPTION
Reverts Budibase/budibase#16611

Reverting it as this should not be done until we have a migration that cleans up duplicated workspace apps