### PR TITLE
Make sure tooltip position is at the bottom for banners

### DIFF
--- a/packages/bbui/src/Banner/BannerDisplay.svelte
+++ b/packages/bbui/src/Banner/BannerDisplay.svelte
@@ -5,6 +5,7 @@
   import Banner from "./Banner.svelte"
   import { fly } from "svelte/transition"
   import TooltipWrapper from "../Tooltip/TooltipWrapper.svelte"
+  import { TooltipPosition } from "../constants"
 </script>
 
 <Portal target=".banner-container">
@@ -24,7 +25,11 @@
             ? message.showCloseButton
             : true}
         >
-          <TooltipWrapper tooltip={message.tooltip} disabled={false}>
+          <TooltipWrapper
+            tooltip={message.tooltip}
+            disabled={false}
+            position={TooltipPosition.Bottom}
+          >
             {message.message}
           </TooltipWrapper>
         </Banner>

--- a/packages/bbui/src/Tooltip/TooltipWrapper.svelte
+++ b/packages/bbui/src/Tooltip/TooltipWrapper.svelte
@@ -6,7 +6,7 @@
   export let tooltip: string = ""
   export let size: "S" | "M" | "L" = "M"
   export let disabled: boolean = true
-  export let position: TooltipPosition | undefined
+  export let position: TooltipPosition | undefined = undefined
 </script>
 
 <div class:container={!!tooltip}>

--- a/packages/bbui/src/Tooltip/TooltipWrapper.svelte
+++ b/packages/bbui/src/Tooltip/TooltipWrapper.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Icon from "../Icon/Icon.svelte"
   import AbsTooltip from "./AbsTooltip.svelte"
-  import { TooltipPosition } from "../constants"
+  import type { TooltipPosition } from "../constants"
 
   export let tooltip: string = ""
   export let size: "S" | "M" | "L" = "M"

--- a/packages/bbui/src/Tooltip/TooltipWrapper.svelte
+++ b/packages/bbui/src/Tooltip/TooltipWrapper.svelte
@@ -1,17 +1,19 @@
 <script lang="ts">
   import Icon from "../Icon/Icon.svelte"
   import AbsTooltip from "./AbsTooltip.svelte"
+  import { TooltipPosition } from "../constants"
 
   export let tooltip: string = ""
   export let size: "S" | "M" | "L" = "M"
   export let disabled: boolean = true
+  export let position: TooltipPosition | undefined
 </script>
 
 <div class:container={!!tooltip}>
   <slot />
   {#if tooltip}
     <div class="icon-container">
-      <AbsTooltip text={tooltip}>
+      <AbsTooltip text={tooltip} {position}>
         <div
           class="icon"
           class:icon-small={size === "M" || size === "S"}

--- a/packages/builder/src/components/portal/licensing/licensingBanners.js
+++ b/packages/builder/src/components/portal/licensing/licensingBanners.js
@@ -73,6 +73,7 @@ const buildUsageInfoBanner = (
     criteria: () => {
       return appLicensing?.usageMetrics[metricKey] >= percentageThreshold
     },
+    showCloseButton: false,
     tooltip: appLicensing?.quotaResetDate,
   }
 


### PR DESCRIPTION
## Description
Make sure tooltip position is at the bottom for banners

## Addresses
- https://linear.app/budibase/issue/BUDI-9532/minor-tooltip-issue

## Launchcontrol
Minor tooltip fix for banners
