### PR TITLE
disabled prop should override warning

### DIFF
--- a/packages/bbui/src/Button/Button.svelte
+++ b/packages/bbui/src/Button/Button.svelte
@@ -32,7 +32,7 @@
     class:spectrum-Button--cta={cta}
     class:spectrum-Button--primary={primary}
     class:spectrum-Button--secondary={secondary}
-    class:spectrum-Button--warning={warning}
+    class:spectrum-Button--warning={warning && !disabled}
     class:spectrum-Button--overBackground={overBackground}
     class:spectrum-Button--quiet={quiet}
     class:new-styles={newStyles}

--- a/packages/bbui/src/Button/Button.svelte
+++ b/packages/bbui/src/Button/Button.svelte
@@ -32,7 +32,7 @@
     class:spectrum-Button--cta={cta}
     class:spectrum-Button--primary={primary}
     class:spectrum-Button--secondary={secondary}
-    class:spectrum-Button--warning={warning && !disabled}
+    class:spectrum-Button--warning={warning}
     class:spectrum-Button--overBackground={overBackground}
     class:spectrum-Button--quiet={quiet}
     class:new-styles={newStyles}
@@ -110,7 +110,15 @@
     border-color: transparent;
     color: var(--spectrum-global-color-gray-900);
   }
-  .spectrum-Button--warning.new-styles:hover {
+  .spectrum-Button--warning.new-styles:not(.is-disabled):hover {
     background: var(--spectrum-global-color-red-500);
+  }
+  .spectrum-Button--primary.new-styles.is-disabled {
+    background: var(--spectrum-global-color-gray-200);
+    color: var(--spectrum-global-color-gray-500);
+  }
+  .spectrum-Button--warning.new-styles.is-disabled {
+    background: var(--spectrum-global-color-gray-200);
+    color: var(--spectrum-global-color-gray-500);
   }
 </style>


### PR DESCRIPTION
## Description
Minor UI fix. If a warning button is disabled, it doesn't appear disabled, just unclickable. Changed to make sure that disabled overrides warning.

## Addresses
- https://linear.app/budibase/issue/GRO-1383/update-password-button-should-be-disabled-until-a-valid-password-has

## Screenshots
<img width="576" height="303" alt="Screenshot 2025-07-31 at 13 55 39" src="https://github.com/user-attachments/assets/4ca7cf83-7229-42ce-a17d-9a981b2653ed" />

*BEFORE. This button is disabled*

After it will appear disabled. 

## Launchcontrol
Minor UI fix for disabled warning buttons.
