### PR TITLE
Allow the user to see the install info

### DIFF
--- a/packages/bbui/src/Layout/Layout.svelte
+++ b/packages/bbui/src/Layout/Layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   export let horizontal: boolean = false
-  export let paddingX: "S" | "M" | "L" | "XL" | "XXL" = "M"
+  export let paddingX: "none" | "S" | "M" | "L" | "XL" | "XXL" = "M"
   export let paddingY: "none" | "S" | "M" | "L" | "XL" | "XXL" = "M"
   export let noPadding: boolean = false
   export let gap: "XXS" | "XS" | "S" | "M" | "L" | "XL" = "M"

--- a/packages/builder/src/pages/builder/portal/account/upgrade.svelte
+++ b/packages/builder/src/pages/builder/portal/account/upgrade.svelte
@@ -293,26 +293,28 @@
       <Button secondary on:click={refresh}>Refresh</Button>
     </div>
 
-    <Divider />
-    <Layout gap="XS" noPadding>
-      <Heading size="XS">
-        <div class="split-heading">
-          <span> Installation </span>
-          <span>{installInfo?.version ? `v${installInfo.version}` : ""}</span>
-        </div>
-      </Heading>
-    </Layout>
-    <Layout noPadding gap="S">
-      <Body size="S">Useful information to share with the support team.</Body>
-      <Layout paddingX="none">
-        <div class="fields">
-          <div class="field">
-            <Label size="L">Install ID</Label>
-            <CopyInput value={installInfo?.installId} />
+    {#if !$admin.offlineMode}
+      <Divider />
+      <Layout gap="XS" noPadding>
+        <Heading size="XS">
+          <div class="split-heading">
+            <span> Installation </span>
+            <span>{installInfo?.version ? `v${installInfo.version}` : ""}</span>
           </div>
-        </div>
+        </Heading>
       </Layout>
-    </Layout>
+      <Layout noPadding gap="S">
+        <Body size="S">Useful information to share with the support team.</Body>
+        <Layout paddingX="none">
+          <div class="fields">
+            <div class="field">
+              <Label size="L">Install ID</Label>
+              <CopyInput value={installInfo?.installId} />
+            </div>
+          </div>
+        </Layout>
+      </Layout>
+    {/if}
   </Layout>
 {/if}
 

--- a/packages/builder/src/pages/builder/portal/account/upgrade.svelte
+++ b/packages/builder/src/pages/builder/portal/account/upgrade.svelte
@@ -1,16 +1,16 @@
 <script>
   import {
+    Body,
+    CopyInput,
+    Divider,
     Layout,
     Heading,
-    Body,
-    Divider,
     Link,
     Button,
     Input,
     Label,
     ButtonGroup,
     notifications,
-    CopyInput,
     File,
   } from "@budibase/bbui"
   import { auth, admin } from "@/stores/portal"
@@ -38,6 +38,8 @@
   let offlineLicenseIdentifier = ""
   let offlineLicense = undefined
   const offlineLicenseExtensions = [".txt"]
+
+  let installInfo
 
   // Make sure page can't be visited directly in cloud
   $: {
@@ -178,6 +180,7 @@
       await Promise.all([getOfflineLicense(), getOfflineLicenseIdentifier()])
     } else {
       await getLicenseKey()
+      installInfo = await API.getInstallInfo()
     }
   })
 </script>
@@ -289,6 +292,27 @@
     <div>
       <Button secondary on:click={refresh}>Refresh</Button>
     </div>
+
+    <Divider />
+    <Layout gap="XS" noPadding>
+      <Heading size="XS">
+        <div class="split-heading">
+          <span> Installation </span>
+          <span>{installInfo?.version ? `v${installInfo.version}` : ""}</span>
+        </div>
+      </Heading>
+    </Layout>
+    <Layout noPadding gap="S">
+      <Body size="S">Useful information to share with the support team.</Body>
+      <Layout paddingX="none">
+        <div class="fields">
+          <div class="field">
+            <Label size="L">Install ID</Label>
+            <CopyInput value={installInfo?.installId} />
+          </div>
+        </div>
+      </Layout>
+    </Layout>
   </Layout>
 {/if}
 
@@ -305,5 +329,9 @@
   }
   .identifier-input {
     width: 300px;
+  }
+  .split-heading {
+    display: flex;
+    justify-content: space-between;
   }
 </style>

--- a/packages/frontend-core/src/api/licensing.ts
+++ b/packages/frontend-core/src/api/licensing.ts
@@ -3,6 +3,7 @@ import {
   ActivateLicenseKeyResponse,
   ActivateOfflineLicenseTokenRequest,
   ActivateOfflineLicenseTokenResponse,
+  GetInstallInfo,
   GetLicenseKeyResponse,
   GetOfflineIdentifierResponse,
   GetOfflineLicenseTokenResponse,
@@ -25,6 +26,7 @@ export interface LicensingEndpoints {
   getOfflineLicenseIdentifier: () => Promise<GetOfflineIdentifierResponse>
   refreshLicense: () => Promise<RefreshOfflineLicenseResponse>
   getQuotaUsage: () => Promise<QuotaUsage>
+  getInstallInfo: () => Promise<GetInstallInfo | void>
 }
 
 export const buildLicensingEndpoints = (
@@ -46,6 +48,19 @@ export const buildLicensingEndpoints = (
     try {
       return await API.get({
         url: "/api/global/license/key",
+      })
+    } catch (e: any) {
+      if (e.status !== 404) {
+        throw e
+      }
+    }
+  },
+
+  // INSTALL ID
+  getInstallInfo: async () => {
+    try {
+      return await API.get({
+        url: "/api/global/install",
       })
     } catch (e: any) {
       if (e.status !== 404) {

--- a/packages/types/src/api/web/global/license.ts
+++ b/packages/types/src/api/web/global/license.ts
@@ -39,3 +39,8 @@ export interface GetOfflineIdentifierResponse {
 }
 
 export interface GetQuotaUsageResponse extends QuotaUsage {}
+
+export interface GetInstallInfo {
+  installId: string
+  version: string
+}

--- a/packages/worker/src/api/controllers/global/license.ts
+++ b/packages/worker/src/api/controllers/global/license.ts
@@ -4,6 +4,7 @@ import {
   ActivateLicenseKeyResponse,
   ActivateOfflineLicenseTokenRequest,
   ActivateOfflineLicenseTokenResponse,
+  GetInstallInfo,
   GetLicenseKeyResponse,
   GetOfflineIdentifierResponse,
   GetOfflineLicenseTokenResponse,
@@ -11,6 +12,7 @@ import {
   RefreshOfflineLicenseResponse,
   UserCtx,
 } from "@budibase/types"
+import { installation } from "@budibase/backend-core"
 
 // LICENSE KEY
 
@@ -93,4 +95,12 @@ export const getQuotaUsage = async (
   ctx: UserCtx<void, GetQuotaUsageResponse>
 ) => {
   ctx.body = await quotas.getQuotaUsage()
+}
+
+export const getInstallInfo = async (ctx: UserCtx<void, GetInstallInfo>) => {
+  const install = await installation.getInstall()
+  ctx.body = {
+    installId: install.installId,
+    version: install.version,
+  }
 }

--- a/packages/worker/src/api/routes/global/license.ts
+++ b/packages/worker/src/api/routes/global/license.ts
@@ -18,6 +18,7 @@ const activateOfflineLicenseValidator = middleware.joiValidator.body(
 loggedInRoutes
   .post("/api/global/license/refresh", controller.refresh)
   .get("/api/global/license/usage", controller.getQuotaUsage)
+  .get("/api/global/install", controller.getInstallInfo)
   // LICENSE KEY
   .post(
     "/api/global/license/key",


### PR DESCRIPTION
## Description
It's useful for support to have the install ID.

## Addresses
- https://linear.app/budibase/issue/GRO-1384/display-installation-id-in-budibase-platform

## Screenshots
<img width="1269" height="1229" alt="install info" src="https://github.com/user-attachments/assets/b6a311ac-20f2-4740-8c2c-cfa7e8b1e736" />

## Launchcontrol
Allow self-hosted users to see the installation info
