### PR TITLE
Removing old "toggle UI" functionality

### DIFF
--- a/packages/builder/src/stores/builder/flags.ts
+++ b/packages/builder/src/stores/builder/flags.ts
@@ -16,7 +16,6 @@ export class FlagsStore extends BudiStore<FlagsState> {
 
     this.fetch = this.fetch.bind(this)
     this.updateFlag = this.updateFlag.bind(this)
-    this.toggleUiFeature = this.toggleUiFeature.bind(this)
   }
 
   async fetch() {
@@ -30,10 +29,6 @@ export class FlagsStore extends BudiStore<FlagsState> {
   async updateFlag(flag: string, value: any) {
     await API.updateFlag(flag, value)
     await this.fetch()
-  }
-
-  async toggleUiFeature(feature: string) {
-    await API.toggleUiFeature(feature)
   }
 }
 

--- a/packages/frontend-core/src/api/flags.ts
+++ b/packages/frontend-core/src/api/flags.ts
@@ -2,14 +2,12 @@ import {
   GetUserFlagsResponse,
   SetUserFlagRequest,
   SetUserFlagResponse,
-  ToggleBetaFeatureResponse,
 } from "@budibase/types"
 import { BaseAPIClient } from "./types"
 
 export interface FlagEndpoints {
   getFlags: () => Promise<GetUserFlagsResponse>
   updateFlag: (flag: string, value: any) => Promise<SetUserFlagResponse>
-  toggleUiFeature: (value: string) => Promise<ToggleBetaFeatureResponse>
 }
 
 export const buildFlagEndpoints = (API: BaseAPIClient): FlagEndpoints => ({
@@ -34,15 +32,6 @@ export const buildFlagEndpoints = (API: BaseAPIClient): FlagEndpoints => ({
         flag,
         value,
       },
-    })
-  },
-  /**
-   * Allows us to experimentally toggle a beta UI feature through a cookie.
-   * @param value the feature to toggle
-   */
-  toggleUiFeature: async value => {
-    return await API.post({
-      url: `/api/beta/${value}`,
     })
   },
 })

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -8,7 +8,6 @@ import {
   loadHandlebarsFile,
   NODE_MODULES_PATH,
   shouldServeLocally,
-  TOP_LEVEL_PATH,
 } from "../../../utilities/fileSystem"
 import env from "../../../environment"
 import {
@@ -47,36 +46,6 @@ import { getThemeVariables } from "../../../constants/themes"
 import path from "path"
 import extract from "extract-zip"
 import { tmpdir } from "os"
-
-export const toggleBetaUiFeature = async function (
-  ctx: Ctx<void, ToggleBetaFeatureResponse>
-) {
-  const cookieName = `beta:${ctx.params.feature}`
-
-  if (ctx.cookies.get(cookieName)) {
-    utils.clearCookie(ctx, cookieName)
-    ctx.body = {
-      message: `${ctx.params.feature} disabled`,
-    }
-    return
-  }
-
-  let builderPath = join(TOP_LEVEL_PATH, "new_design_ui")
-
-  // // download it from S3
-  if (!fs.existsSync(builderPath)) {
-    fs.mkdirSync(builderPath)
-  }
-  await objectStore.downloadTarballDirect(
-    "https://cdn.budi.live/beta:design_ui/new_ui.tar.gz",
-    builderPath
-  )
-  utils.setCookie(ctx, {}, cookieName)
-
-  ctx.body = {
-    message: `${ctx.params.feature} enabled`,
-  }
-}
 
 export const uploadFile = async function (
   ctx: Ctx<void, ProcessAttachmentResponse>

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -36,7 +36,6 @@ import {
   ServeAppResponse,
   ServeBuilderPreviewResponse,
   ServeClientLibraryResponse,
-  ToggleBetaFeatureResponse,
   UserCtx,
 } from "@budibase/types"
 import { isAppFullyMigrated } from "../../../appMigrations"

--- a/packages/server/src/api/routes/static.ts
+++ b/packages/server/src/api/routes/static.ts
@@ -17,7 +17,6 @@ router
   .get("/api/apps/:appId/manifest.json", controller.servePwaManifest)
   .post("/api/attachments/process", authorized(BUILDER), controller.uploadFile)
   .post("/api/pwa/process-zip", authorized(BUILDER), controller.processPWAZip)
-  .post("/api/beta/:feature", controller.toggleBetaUiFeature)
   .post(
     "/api/attachments/:tableId/upload",
     recaptcha,

--- a/packages/types/src/api/web/app/static.ts
+++ b/packages/types/src/api/web/app/static.ts
@@ -1,10 +1,6 @@
 import { App } from "../../../documents"
 import stream from "node:stream"
 
-export interface ToggleBetaFeatureResponse {
-  message: string
-}
-
 export type ServeAppResponse = string
 
 interface BuilderPreview extends App {


### PR DESCRIPTION
## Description
Removing API/frontend-core implementation for toggling UI - last reference to cdn.budi.live which isn't being used anymore, wanted to clean up functionality that could be confusing in the future.