### PR TITLE
Fixing padding around icons

### DIFF
--- a/packages/bbui/src/ActionButton/ActionButton.svelte
+++ b/packages/bbui/src/ActionButton/ActionButton.svelte
@@ -50,7 +50,7 @@
   {#if icon}
     <Icon
       name={icon}
-      size="M"
+      {size}
       color={`var(--spectrum-global-color-gray-${$$slots.default ? 600 : 700})`}
     />
   {/if}

--- a/packages/bbui/src/Icon/InnerIcon.svelte
+++ b/packages/bbui/src/Icon/InnerIcon.svelte
@@ -12,13 +12,13 @@
   export let weight: "regular" | "bold" | "fill" = "regular"
 
   const sizeMap = {
-    XS: "round(0.75rem, 1px)",
-    S: "round(1rem, 1px)",
-    M: "round(1.25rem, 1px)",
-    L: "round(1.5rem, 1px)",
-    XL: "round(2rem, 1px)",
-    XXL: "round(2.5rem, 1px)",
-    XXXL: "round(5rem, 1px)",
+    XS: "14px",
+    S: "16px",
+    M: "18px",
+    L: "22px",
+    XL: "28px",
+    XXL: "36px",
+    XXXL: "72px",
   }
 
   $: phosphorIconName = getPhosphorIcon(name)

--- a/packages/bbui/src/Icon/InnerIcon.svelte
+++ b/packages/bbui/src/Icon/InnerIcon.svelte
@@ -12,13 +12,13 @@
   export let weight: "regular" | "bold" | "fill" = "regular"
 
   const sizeMap = {
-    XS: "0.75rem",
-    S: "1rem",
-    M: "1.25rem",
-    L: "1.5rem",
-    XL: "2rem",
-    XXL: "2.5rem",
-    XXXL: "5rem",
+    XS: "round(0.75rem, 1px)",
+    S: "round(1rem, 1px)",
+    M: "round(1.25rem, 1px)",
+    L: "round(1.5rem, 1px)",
+    XL: "round(2rem, 1px)",
+    XXL: "round(2.5rem, 1px)",
+    XXXL: "round(5rem, 1px)",
   }
 
   $: phosphorIconName = getPhosphorIcon(name)
@@ -58,7 +58,6 @@
 
 <style>
   i {
-    padding-top: 2px;
     display: grid;
     place-items: center;
     color: var(--color);

--- a/packages/bbui/src/Icon/InnerIcon.svelte
+++ b/packages/bbui/src/Icon/InnerIcon.svelte
@@ -58,6 +58,7 @@
 
 <style>
   i {
+    padding-top: 2px;
     display: grid;
     place-items: center;
     color: var(--color);

--- a/packages/builder/src/components/common/NavItem.svelte
+++ b/packages/builder/src/components/common/NavItem.svelte
@@ -308,6 +308,7 @@
     align-items: center;
     overflow: hidden;
     pointer-events: none;
+    gap: var(--spacing-s);
   }
   .nav-item-body span {
     white-space: nowrap;

--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -11,6 +11,7 @@
     Body,
     Divider,
     Button,
+    ActionButton,
   } from "@budibase/bbui"
   import { capitalise } from "@/helpers"
   import AccessLevelSelect from "./AccessLevelSelect.svelte"
@@ -172,10 +173,14 @@
       </div>
       <div class="controls">
         <ConnectedQueryScreens sourceId={query._id} />
-        <Button disabled={loading} on:click={runQuery} overBackground>
-          <Icon size="S" name="play" />
-          Run query</Button
+        <ActionButton
+          icon="play"
+          disabled={loading}
+          on:click={runQuery}
+          overBackground
         >
+          Run query
+        </ActionButton>
         <div class="tooltip" title="Run your query to enable saving">
           <Button
             on:click={async () => {


### PR DESCRIPTION
## Description
EDIT: Solution found - REM sizing was leading to fractional font-sizes which left a little bit of odd padding, rounding to the closest pixel.

Icons have slightly odd padding - I'm trying to work out why.

Before: 
<img width="1358" height="953" alt="image" src="https://github.com/user-attachments/assets/eaaa03f4-4538-48d1-897f-403f66271bfd" />

After: 
<img width="1358" height="953" alt="image" src="https://github.com/user-attachments/assets/62d181c3-eb75-488f-bc2a-099566bc6588" />

Check out the preview button and the icons along the left nav to see this in action.
