### PR TITLE
Add comprehensive unit tests for changeTenantOwnerEmail function

### DIFF
--- a/packages/types/src/documents/global/user.ts
+++ b/packages/types/src/documents/global/user.ts
@@ -33,6 +33,22 @@ export interface UserSSO {
 
 export type SSOUser = User & UserSSO
 
+export type OIDCUser = User & {
+  provider: string | undefined
+  providerType: SSOProviderType | undefined
+  oauth2?: OAuth2 | undefined
+  profile?:
+    | {
+        displayName?: string
+        name?: {
+          givenName?: string
+          familyName?: string
+        }
+      }
+    | undefined
+  thirdPartyProfile?: object | undefined
+}
+
 export function isSSOUser(user: User | ContextUser): user is SSOUser {
   return !!(user as SSOUser).providerType
 }

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -34,7 +34,6 @@ import {
   SaveUserResponse,
   SearchUsersRequest,
   SearchUsersResponse,
-  SSOUser,
   StrippedUser,
   UnsavedUser,
   UpdateInviteRequest,

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -30,9 +30,11 @@ import {
   LockType,
   LookupAccountHolderResponse,
   LookupTenantUserResponse,
+  OIDCUser,
   SaveUserResponse,
   SearchUsersRequest,
   SearchUsersResponse,
+  SSOUser,
   StrippedUser,
   UnsavedUser,
   UpdateInviteRequest,
@@ -114,11 +116,20 @@ export const changeTenantOwnerEmail = async (
   try {
     for (const tenantId of tenantIds) {
       await tenancy.doInTenant(tenantId, async () => {
-        const tenantUser = await userSdk.db.getUserByEmail(originalEmail)
+        const tenantUser = (await userSdk.db.getUserByEmail(
+          originalEmail
+        )) as OIDCUser
         if (!tenantUser) {
           return
         }
         tenantUser.email = newAccountEmail
+
+        tenantUser.provider = undefined
+        tenantUser.providerType = undefined
+        tenantUser.thirdPartyProfile = undefined
+        tenantUser.profile = undefined
+        tenantUser.oauth2 = undefined
+
         await userSdk.db.save(tenantUser, {
           currentUserId: tenantUser._id,
           isAccountHolder: true,

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -833,7 +833,7 @@ describe("/api/global/users", () => {
       const originalEmail = `original-${structures.uuid()}@example.com`
       const newEmail = `new-${structures.uuid()}@example.com`
       const tenant1 = config.getTenantId()
-      const tenant2 = config.createTenantId()
+      const tenant2 = structures.tenant.id()
 
       const user1 = await config.doInTenant(async () => {
         return await userSdk.db.save(

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -864,9 +864,12 @@ describe("/api/global/users", () => {
         return await userSdk.db.getUser(user1._id!)
       })
 
-      const updatedUser2 = await config.doInSpecificTenant(tenant2, async () => {
-        return await userSdk.db.getUser(user2._id!)
-      })
+      const updatedUser2 = await config.doInSpecificTenant(
+        tenant2,
+        async () => {
+          return await userSdk.db.getUser(user2._id!)
+        }
+      )
 
       expect(updatedUser1).toBeDefined()
       expect(updatedUser1!.email).toBe(newEmail)
@@ -926,9 +929,9 @@ describe("/api/global/users", () => {
         tenantId,
       ])
 
-      const updatedUser = await config.doInTenant(async () => {
+      const updatedUser = (await config.doInTenant(async () => {
         return await userSdk.db.getUserByEmail(newEmail)
-      }) as OIDCUser
+      })) as OIDCUser
 
       expect(updatedUser).toBeDefined()
       expect(updatedUser!.email).toBe(newEmail)

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -1,4 +1,4 @@
-import { InviteUsersResponse, User } from "@budibase/types"
+import { InviteUsersResponse, User, OIDCUser } from "@budibase/types"
 
 import { TestConfiguration, mocks, structures } from "../../../../tests"
 import { events, tenancy, accounts as _accounts } from "@budibase/backend-core"
@@ -798,6 +798,161 @@ describe("/api/global/users", () => {
       ])
       expect(response.successful.length).toBe(0)
       expect(response.unsuccessful.length).toBe(1)
+    })
+  })
+
+  describe("PUT /api/global/users/tenant/owner", () => {
+    it("should successfully change tenant owner email for existing user", async () => {
+      const originalEmail = `original-${structures.uuid()}@example.com`
+      const newEmail = `new-${structures.uuid()}@example.com`
+      const tenantId = config.getTenantId()
+
+      const user = await config.doInTenant(async () => {
+        return await userSdk.db.save(
+          {
+            email: originalEmail,
+            tenantId,
+          } as any,
+          { requirePassword: false, isAccountHolder: true }
+        )
+      })
+
+      await config.api.users.changeTenantOwnerEmail(newEmail, originalEmail, [
+        tenantId,
+      ])
+
+      const updatedUser = await config.doInTenant(async () => {
+        return await userSdk.db.getUser(user._id!)
+      })
+
+      expect(updatedUser).toBeDefined()
+      expect(updatedUser!.email).toBe(newEmail)
+    })
+
+    it("should handle multiple tenants", async () => {
+      const originalEmail = `original-${structures.uuid()}@example.com`
+      const newEmail = `new-${structures.uuid()}@example.com`
+      const tenant1 = config.getTenantId()
+      const tenant2 = config.createTenantId()
+
+      const user1 = await config.doInTenant(async () => {
+        return await userSdk.db.save(
+          {
+            email: originalEmail,
+            tenantId: tenant1,
+          } as any,
+          { requirePassword: false, isAccountHolder: true }
+        )
+      })
+
+      const user2 = await config.doInSpecificTenant(tenant2, async () => {
+        return await userSdk.db.save(
+          {
+            email: originalEmail,
+            tenantId: tenant2,
+          } as any,
+          { requirePassword: false, isAccountHolder: true }
+        )
+      })
+
+      await config.api.users.changeTenantOwnerEmail(newEmail, originalEmail, [
+        tenant1,
+        tenant2,
+      ])
+
+      const updatedUser1 = await config.doInTenant(async () => {
+        return await userSdk.db.getUser(user1._id!)
+      })
+
+      const updatedUser2 = await config.doInSpecificTenant(tenant2, async () => {
+        return await userSdk.db.getUser(user2._id!)
+      })
+
+      expect(updatedUser1).toBeDefined()
+      expect(updatedUser1!.email).toBe(newEmail)
+      expect(updatedUser2).toBeDefined()
+      expect(updatedUser2!.email).toBe(newEmail)
+    })
+
+    it("should not fail if user doesn't exist in tenant", async () => {
+      const originalEmail = `nonexistent-${structures.uuid()}@example.com`
+      const newEmail = `new-${structures.uuid()}@example.com`
+      const tenantId = config.getTenantId()
+
+      await config.api.users.changeTenantOwnerEmail(newEmail, originalEmail, [
+        tenantId,
+      ])
+
+      const user = await config.doInTenant(async () => {
+        return await userSdk.db.getUserByEmail(newEmail)
+      })
+
+      expect(user).toBeUndefined()
+    })
+
+    it("should handle empty tenant list", async () => {
+      const originalEmail = `original-${structures.uuid()}@example.com`
+      const newEmail = `new-${structures.uuid()}@example.com`
+
+      await config.api.users.changeTenantOwnerEmail(newEmail, originalEmail, [])
+    })
+
+    it("should clear all OIDC-related fields", async () => {
+      const originalEmail = `original-${structures.uuid()}@example.com`
+      const newEmail = `new-${structures.uuid()}@example.com`
+      const tenantId = config.getTenantId()
+      const profile = {}
+      const provider = "oidc"
+      const providerType = "oidc"
+      const thirdPartyProfile = {}
+      const oauth2 = {}
+
+      await config.doInTenant(async () => {
+        await userSdk.db.save(
+          {
+            email: originalEmail,
+            tenantId,
+            profile,
+            provider,
+            providerType,
+            thirdPartyProfile,
+            oauth2,
+          } as any,
+          { requirePassword: false, isAccountHolder: true }
+        )
+      })
+
+      await config.api.users.changeTenantOwnerEmail(newEmail, originalEmail, [
+        tenantId,
+      ])
+
+      const updatedUser = await config.doInTenant(async () => {
+        return await userSdk.db.getUserByEmail(newEmail)
+      }) as OIDCUser
+
+      expect(updatedUser).toBeDefined()
+      expect(updatedUser!.email).toBe(newEmail)
+      expect(updatedUser.profile).toBe(undefined)
+      expect(updatedUser.provider).toBe(undefined)
+      expect(updatedUser.providerType).toBe(undefined)
+      expect(updatedUser.thirdPartyProfile).toBe(undefined)
+      expect(updatedUser.oauth2).toBe(undefined)
+    })
+
+    it("should require internal API headers", async () => {
+      const originalEmail = `original-${structures.uuid()}@example.com`
+      const newEmail = `new-${structures.uuid()}@example.com`
+      const tenantId = config.getTenantId()
+
+      await config.request
+        .put(`/api/global/users/tenant/owner`)
+        .send({
+          newAccountEmail: newEmail,
+          originalEmail,
+          tenantIds: [tenantId],
+        })
+        .set(config.defaultHeaders())
+        .expect(403)
     })
   })
 })

--- a/packages/worker/src/tests/TestConfiguration.ts
+++ b/packages/worker/src/tests/TestConfiguration.ts
@@ -175,7 +175,10 @@ class TestConfiguration {
     return structures.tenant.id()
   }
 
-  async doInSpecificTenant<T>(tenantId: string, task: () => Promise<T>): Promise<T> {
+  async doInSpecificTenant<T>(
+    tenantId: string,
+    task: () => Promise<T>
+  ): Promise<T> {
     return await context.doInTenant(tenantId, async () => {
       return await task()
     })

--- a/packages/worker/src/tests/TestConfiguration.ts
+++ b/packages/worker/src/tests/TestConfiguration.ts
@@ -171,10 +171,6 @@ class TestConfiguration {
     }
   }
 
-  createTenantId() {
-    return structures.tenant.id()
-  }
-
   async doInSpecificTenant<T>(
     tenantId: string,
     task: () => Promise<T>

--- a/packages/worker/src/tests/TestConfiguration.ts
+++ b/packages/worker/src/tests/TestConfiguration.ts
@@ -138,9 +138,9 @@ class TestConfiguration {
 
   // TENANCY
 
-  doInTenant(task: any) {
-    return context.doInTenant(this.tenantId, () => {
-      return task()
+  async doInTenant<T>(task: () => Promise<T>): Promise<T> {
+    return await context.doInTenant(this.tenantId, async () => {
+      return await task()
     })
   }
 
@@ -169,6 +169,16 @@ class TestConfiguration {
     } catch (e) {
       return this.tenantId!
     }
+  }
+
+  createTenantId() {
+    return structures.tenant.id()
+  }
+
+  async doInSpecificTenant<T>(tenantId: string, task: () => Promise<T>): Promise<T> {
+    return await context.doInTenant(tenantId, async () => {
+      return await task()
+    })
   }
 
   // AUTH

--- a/packages/worker/src/tests/api/users.ts
+++ b/packages/worker/src/tests/api/users.ts
@@ -214,4 +214,17 @@ export class UserAPI extends TestAPI {
 
     return resp.body as InviteUsersResponse
   }
+
+  changeTenantOwnerEmail = (
+    newAccountEmail: string,
+    originalEmail: string,
+    tenantIds: string[],
+    status = 200
+  ) => {
+    return this.request
+      .put(`/api/global/users/tenant/owner`)
+      .send({ newAccountEmail, originalEmail, tenantIds })
+      .set(this.config.internalAPIHeaders())
+      .expect(status)
+  }
 }


### PR DESCRIPTION
- Add unit tests covering various scenarios for changeTenantOwnerEmail endpoint
- Test successful email change for single and multiple tenants
- Test handling of non-existent users and empty tenant lists
- Test OIDC field clearing functionality
- Test authentication requirements (internal API headers)
- Refactor TestConfiguration to support multi-tenant testing
- Add OIDCUser type definition for proper type checking
- Add changeTenantOwnerEmail method to UserAPI test helper

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description
Noticed that despite being a password account, OIDC users will still have some info that needs removed upon changing the email address.

## Addresses
- https://linear.app/budibase/issue/GRO-1395/remove-oidc-info-when-changing-tenant-user-email

