### PR TITLE
fixes mismatched border radiuses

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/_components/NewScreen/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/_components/NewScreen/index.svelte
@@ -311,7 +311,7 @@
   }
 
   .selected {
-    border-radius: 4px;
+    border-radius: 8px;
     outline: 1px solid var(--blue);
   }
 </style>


### PR DESCRIPTION
## Description
When selecting the type of screen to add in the modal, the highlighting border radius does not match that of the card itself.
<img width="589" height="570" alt="image" src="https://github.com/user-attachments/assets/f0559eaf-4a92-482e-84f6-6dba3f4f77c9" />


<img width="642" height="411" alt="image" src="https://github.com/user-attachments/assets/daaa9f8a-6f49-4755-9840-d0be4cdee81f" />

The border radius on "Selected" was half that of the image itself. This PR simply aligns these two values.
<img width="741" height="315" alt="image" src="https://github.com/user-attachments/assets/81c6a54e-ff5c-49b6-816e-f71fdfcc384b" />

