### PR TITLE
Fix 409s

### DIFF
--- a/packages/builder/src/stores/builder/websocket.ts
+++ b/packages/builder/src/stores/builder/websocket.ts
@@ -10,6 +10,7 @@ import {
   datasources,
   tables,
   roles,
+  workspaceAppStore,
 } from "@/stores/builder"
 import { get } from "svelte/store"
 import { auth, appsStore } from "@/stores/portal"
@@ -23,6 +24,7 @@ import {
   Table,
   UIUser,
   Screen,
+  WorkspaceApp,
 } from "@budibase/types"
 
 export const createBuilderWebsocket = (appId: string) => {
@@ -98,6 +100,13 @@ export const createBuilderWebsocket = (appId: string) => {
   )
 
   // App events
+  socket.on(
+    BuilderSocketEvent.WorkspaceAppChange,
+    ({ id, workspaceApp }: { id: string; workspaceApp: WorkspaceApp }) => {
+      workspaceAppStore.replaceDatasource(id, workspaceApp)
+    }
+  )
+
   socket.onOther(
     BuilderSocketEvent.AppMetadataChange,
     ({ metadata }: { metadata: any }) => {

--- a/packages/builder/src/stores/builder/workspaceApps.ts
+++ b/packages/builder/src/stores/builder/workspaceApps.ts
@@ -161,6 +161,17 @@ export class WorkspaceAppStore extends DerivedBudiStore<
     await deploymentStore.publishApp()
     await workspaceDeploymentStore.fetch()
   }
+
+  replaceDatasource(_id: string, workspaceApp: WorkspaceApp) {
+    const index = get(this.store).workspaceApps.findIndex(
+      x => x._id === workspaceApp._id
+    )
+
+    this.store.update(state => {
+      state.workspaceApps[index] = workspaceApp
+      return state
+    })
+  }
 }
 
 export const workspaceAppStore = new WorkspaceAppStore()

--- a/packages/server/src/api/controllers/navigation.ts
+++ b/packages/server/src/api/controllers/navigation.ts
@@ -1,5 +1,6 @@
 import { Ctx, UpdateNavigationRequest } from "@budibase/types"
 import sdk from "../../sdk"
+import { builderSocket } from "../../websockets"
 
 export async function update(
   ctx: Ctx<UpdateNavigationRequest, void, { workspaceAppId: string }>
@@ -7,5 +8,11 @@ export async function update(
   const { workspaceAppId } = ctx.params
   const { navigation } = ctx.request.body
   await sdk.navigation.update(workspaceAppId, navigation)
+
+  const workspaceApp = await sdk.workspaceApps.get(workspaceAppId)
+  if (workspaceApp) {
+    builderSocket?.emitWorkspaceAppUpdate(ctx, workspaceApp)
+  }
+
   ctx.status = 204
 }

--- a/packages/server/src/api/controllers/screen.ts
+++ b/packages/server/src/api/controllers/screen.ts
@@ -111,6 +111,11 @@ export async function save(
       roleId: screen.routing.roleId,
       workspaceAppId: screen.workspaceAppId,
     })
+
+    const workspaceApp = await sdk.workspaceApps.get(screen.workspaceAppId)
+    if (workspaceApp) {
+      builderSocket?.emitWorkspaceAppUpdate(ctx, workspaceApp)
+    }
   }
 
   ctx.message = `Screen ${screen.name} saved.`
@@ -145,6 +150,11 @@ export async function destroy(ctx: UserCtx<void, DeleteScreenResponse>) {
     message: "Screen deleted successfully",
   }
   builderSocket?.emitScreenDeletion(ctx, id)
+
+  const workspaceApp = await sdk.workspaceApps.get(screen.workspaceAppId)
+  if (workspaceApp) {
+    builderSocket?.emitWorkspaceAppUpdate(ctx, workspaceApp)
+  }
 }
 
 function findPlugins(component: ScreenProps, foundPlugins: string[]) {

--- a/packages/server/src/websockets/builder.ts
+++ b/packages/server/src/websockets/builder.ts
@@ -12,6 +12,7 @@ import {
   App,
   Automation,
   Role,
+  WorkspaceApp,
 } from "@budibase/types"
 import { gridSocket } from "./index"
 import { clearLock, updateLock } from "../utilities/redis"
@@ -113,6 +114,24 @@ export default class BuilderSocket extends BaseSocket {
       id: role._id,
       role: null,
     })
+  }
+
+  emitWorkspaceAppUpdate(
+    ctx: any,
+    workspaceApp: WorkspaceApp,
+    options?: EmitOptions
+  ) {
+    this.emitToRoom(
+      ctx,
+      ctx.appId,
+      BuilderSocketEvent.WorkspaceAppChange,
+      {
+        id: workspaceApp._id,
+        workspaceApp,
+      },
+      options
+    )
+    gridSocket?.emitWorkspaceAppUpdate(ctx, workspaceApp)
   }
 
   emitTableUpdate(ctx: any, table: Table, options?: EmitOptions) {

--- a/packages/server/src/websockets/grid.ts
+++ b/packages/server/src/websockets/grid.ts
@@ -5,7 +5,7 @@ import { auth, permissions, context } from "@budibase/backend-core"
 import http from "http"
 import Koa from "koa"
 import { getSourceId } from "../api/controllers/row/utils"
-import { Row, Table, View, ViewV2 } from "@budibase/types"
+import { Row, Table, View, ViewV2, WorkspaceApp } from "@budibase/types"
 import { Socket } from "socket.io"
 import { GridSocketEvent } from "@budibase/shared-core"
 import { userAgent } from "koa-useragent"
@@ -133,6 +133,14 @@ export default class GridSocket extends BaseSocket {
     this.emitToRoom(ctx, room, GridSocketEvent.RowChange, {
       id: row._id,
       row: null,
+    })
+  }
+
+  emitWorkspaceAppUpdate(ctx: any, workspaceApp: WorkspaceApp) {
+    const room = `${ctx.appId}-${workspaceApp._id}`
+    this.emitToRoom(ctx, room, GridSocketEvent.WorkspaceAppChange, {
+      id: workspaceApp._id,
+      workspaceApp,
     })
   }
 

--- a/packages/shared-core/src/constants/index.ts
+++ b/packages/shared-core/src/constants/index.ts
@@ -86,6 +86,7 @@ export enum GridSocketEvent {
   DatasourceChange = "DatasourceChange",
   SelectDatasource = "SelectDatasource",
   SelectCell = "SelectCell",
+  WorkspaceAppChange = "WorkspaceAppChange",
 }
 
 export enum BuilderSocketEvent {
@@ -99,6 +100,7 @@ export enum BuilderSocketEvent {
   AppPublishChange = "AppPublishChange",
   AutomationChange = "AutomationChange",
   RoleChange = "RoleChange",
+  WorkspaceAppChange = "WorkspaceAppChange",
 }
 
 export const SocketSessionTTL = 60


### PR DESCRIPTION
## Description
We are getting 409 on navigation updates, because some endpoints are modifying the workspaceApp document.
Instead of refetching it on the frontend, this PR created a new websocket channel to update them on the client. This also improves the multiuser experience, and it should probably be the way to go.