### PR TITLE
fix(client): Rating Field icons reflect selected value

### DIFF
--- a/packages/client/src/components/app/forms/InnerForm.svelte
+++ b/packages/client/src/components/app/forms/InnerForm.svelte
@@ -355,10 +355,14 @@
       // Update field state
       const error = validator?.(value)
       fieldInfo.update(state => {
-        state.fieldState.value = value
-        state.fieldState.error = error
-        state.fieldState.lastUpdate = Date.now()
-        return state
+        state.fieldState = {
+          ...state.fieldState,
+          value,
+          error,
+          lastUpdate: Date.now(),
+        }
+        // Replace top-level state object to ensure reactivity cascades
+        return { ...state }
       })
 
       return true
@@ -372,10 +376,13 @@
 
       // Update field state
       fieldInfo.update(state => {
-        state.fieldState.value = newValue
-        state.fieldState.error = null
-        state.fieldState.lastUpdate = Date.now()
-        return state
+        state.fieldState = {
+          ...state.fieldState,
+          value: newValue,
+          error: null,
+          lastUpdate: Date.now(),
+        }
+        return { ...state }
       })
     }
 
@@ -384,9 +391,12 @@
     const deregister = () => {
       const fieldInfo = getField(field)
       fieldInfo.update(state => {
-        state.fieldState.validator = null
-        state.fieldState.error = null
-        return state
+        state.fieldState = {
+          ...state.fieldState,
+          validator: null,
+          error: null,
+        }
+        return { ...state }
       })
     }
 
@@ -399,8 +409,11 @@
 
       // Update disabled state
       fieldInfo.update(state => {
-        state.fieldState.disabled = disabled || fieldDisabled || isAutoColumn
-        return state
+        state.fieldState = {
+          ...state.fieldState,
+          disabled: disabled || fieldDisabled || isAutoColumn,
+        }
+        return { ...state }
       })
     }
 

--- a/packages/client/src/components/app/forms/RatingField.svelte
+++ b/packages/client/src/components/app/forms/RatingField.svelte
@@ -67,8 +67,17 @@
     }
   }
 
-  const isRated = (value: number | null, index: number): boolean => {
-    return typeof value === "number" && value >= index + 1
+  const toNumber = (value: unknown): number | null => {
+    if (value == null || value === "") {
+      return null
+    }
+    const num = Number(value)
+    return isNaN(num) ? null : num
+  }
+
+  const isRated = (value: unknown, index: number): boolean => {
+    const numeric = toNumber(value)
+    return numeric != null && numeric >= index + 1
   }
 </script>
 


### PR DESCRIPTION
Fixes #16408.\n\n- Ensure reactive state updates in form field store so icon re-renders occur when value changes.\n- Normalize rating value to a number for icon fill comparison in packages/client/src/components/app/forms/RatingField.svelte.\n\nTesting:\n- Add a Rating Field and a Text component bound to its value.\n- Click on various rating icons; the Text value and icon fill state now stay in sync.\n\nNotes:\n- Change is localized to client form handling and the rating component.\n- No breaking changes expected.