### PR TITLE
Fix: Signature modal actions visible on mobile (closes #14450)

### DIFF
--- a/packages/bbui/src/Form/Core/Signature.svelte
+++ b/packages/bbui/src/Form/Core/Signature.svelte
@@ -100,11 +100,17 @@
     }
 
     const getPos = e => {
-      let rect = canvasRef.getBoundingClientRect()
-      const canvasX = e.offsetX || e.targetTouches?.[0].pageX - rect.left
-      const canvasY = e.offsetY || e.targetTouches?.[0].pageY - rect.top
+      const rect = canvasRef.getBoundingClientRect()
+      const clientX = e.clientX ?? e.targetTouches?.[0]?.clientX
+      const clientY = e.clientY ?? e.targetTouches?.[0]?.clientY
 
-      return { x: canvasX, y: canvasY }
+      // Fallback to pageX/pageY if client coords aren’t available
+      const fallbackX = e.pageX ?? e.targetTouches?.[0]?.pageX
+      const fallbackY = e.pageY ?? e.targetTouches?.[0]?.pageY
+
+      const x = (clientX ?? fallbackX) - rect.left
+      const y = (clientY ?? fallbackY) - rect.top
+      return { x, y }
     }
 
     const checkUp = e => {
@@ -133,8 +139,13 @@
     signature.weight = 4
     signature.smoothing = 2
 
-    canvasWrap.style.width = responsive ? "100%" : `${targetWidth}px`
+    canvasWrap.style.width = `${targetWidth}px`
     canvasWrap.style.height = `${targetHeight}px`
+    // Ensure the canvas drawing buffer and CSS size match exactly to avoid pointer offset
+    canvasRef.width = targetWidth
+    canvasRef.height = targetHeight
+    canvasRef.style.width = `${targetWidth}px`
+    canvasRef.style.height = `${targetHeight}px`
 
     const { width: wrapWidth, height: wrapHeight } =
       canvasWrap.getBoundingClientRect()
@@ -254,7 +265,7 @@
   }
   #signature-canvas {
     display: block;
-    width: 100%;
+    width: auto;
     height: auto;
     max-width: 100%;
   }

--- a/packages/bbui/src/Form/Core/Signature.svelte
+++ b/packages/bbui/src/Form/Core/Signature.svelte
@@ -14,6 +14,8 @@
   export let height = 220
   export let saveIcon = false
   export let darkMode
+  export let responsive = false
+  export let maxWidth = 400
 
   export function toDataUrl() {
     // PNG to preserve transparency
@@ -79,6 +81,19 @@
     dispatch("update")
   }
 
+  function computeDimensions() {
+    const targetWidth = responsive
+      ? Math.min(
+          maxWidth,
+          canvasWrap?.parentElement?.getBoundingClientRect()?.width || width
+        )
+      : width
+    const aspect = height / width
+    const targetHeight = Math.round(targetWidth * aspect)
+
+    return { targetWidth, targetHeight }
+  }
+
   onMount(() => {
     if (!editable) {
       return
@@ -107,17 +122,19 @@
 
     document.addEventListener("pointerup", checkUp)
 
+    const { targetWidth, targetHeight } = computeDimensions()
+
     signature = new Atrament(canvasRef, {
-      width,
-      height,
+      width: targetWidth,
+      height: targetHeight,
       color: "white",
     })
 
     signature.weight = 4
     signature.smoothing = 2
 
-    canvasWrap.style.width = `${width}px`
-    canvasWrap.style.height = `${height}px`
+    canvasWrap.style.width = responsive ? "100%" : `${targetWidth}px`
+    canvasWrap.style.height = `${targetHeight}px`
 
     const { width: wrapWidth, height: wrapHeight } =
       canvasWrap.getBoundingClientRect()

--- a/packages/bbui/src/Form/Core/Signature.svelte
+++ b/packages/bbui/src/Form/Core/Signature.svelte
@@ -14,8 +14,6 @@
   export let height = 220
   export let saveIcon = false
   export let darkMode
-  export let responsive = false
-  export let maxWidth = 400
 
   export function toDataUrl() {
     // PNG to preserve transparency
@@ -81,36 +79,17 @@
     dispatch("update")
   }
 
-  function computeDimensions() {
-    const targetWidth = responsive
-      ? Math.min(
-          maxWidth,
-          canvasWrap?.parentElement?.getBoundingClientRect()?.width || width
-        )
-      : width
-    const aspect = height / width
-    const targetHeight = Math.round(targetWidth * aspect)
-
-    return { targetWidth, targetHeight }
-  }
-
   onMount(() => {
     if (!editable) {
       return
     }
 
     const getPos = e => {
-      const rect = canvasRef.getBoundingClientRect()
-      const clientX = e.clientX ?? e.targetTouches?.[0]?.clientX
-      const clientY = e.clientY ?? e.targetTouches?.[0]?.clientY
+      let rect = canvasRef.getBoundingClientRect()
+      const canvasX = e.offsetX || e.targetTouches?.[0].pageX - rect.left
+      const canvasY = e.offsetY || e.targetTouches?.[0].pageY - rect.top
 
-      // Fallback to pageX/pageY if client coords aren’t available
-      const fallbackX = e.pageX ?? e.targetTouches?.[0]?.pageX
-      const fallbackY = e.pageY ?? e.targetTouches?.[0]?.pageY
-
-      const x = (clientX ?? fallbackX) - rect.left
-      const y = (clientY ?? fallbackY) - rect.top
-      return { x, y }
+      return { x: canvasX, y: canvasY }
     }
 
     const checkUp = e => {
@@ -128,24 +107,17 @@
 
     document.addEventListener("pointerup", checkUp)
 
-    const { targetWidth, targetHeight } = computeDimensions()
-
     signature = new Atrament(canvasRef, {
-      width: targetWidth,
-      height: targetHeight,
+      width,
+      height,
       color: "white",
     })
 
     signature.weight = 4
     signature.smoothing = 2
 
-    canvasWrap.style.width = `${targetWidth}px`
-    canvasWrap.style.height = `${targetHeight}px`
-    // Ensure the canvas drawing buffer and CSS size match exactly to avoid pointer offset
-    canvasRef.width = targetWidth
-    canvasRef.height = targetHeight
-    canvasRef.style.width = `${targetWidth}px`
-    canvasRef.style.height = `${targetHeight}px`
+    canvasWrap.style.width = `${width}px`
+    canvasWrap.style.height = `${height}px`
 
     const { width: wrapWidth, height: wrapHeight } =
       canvasWrap.getBoundingClientRect()

--- a/packages/bbui/src/Form/Core/Signature.svelte
+++ b/packages/bbui/src/Form/Core/Signature.svelte
@@ -244,14 +244,19 @@
   }
   .canvas-wrap {
     position: relative;
-    margin: auto;
+    margin: 0 auto;
+    width: 100%;
+    max-width: 100%;
+    overflow: hidden;
   }
   .signature img {
     max-width: 100%;
   }
   #signature-canvas {
-    max-width: var(--max-sig-width);
-    max-height: var(--max-sig-height);
+    display: block;
+    width: 100%;
+    height: auto;
+    max-width: 100%;
   }
   .signature.light img,
   .signature.light #signature-canvas {

--- a/packages/bbui/src/Modal/Modal.svelte
+++ b/packages/bbui/src/Modal/Modal.svelte
@@ -166,8 +166,9 @@
     position: fixed;
     top: 0;
     left: 0;
+    right: 0;
     height: 100vh;
-    width: 100vw;
+    width: auto; /* avoid 100vw causing horizontal overflow when a vertical scrollbar is present */
     opacity: 0.65;
     pointer-events: none;
   }
@@ -180,6 +181,8 @@
     justify-content: center;
     align-items: flex-start;
     max-height: 100%;
+    width: 100%;
+    overflow-x: hidden;
   }
   .modal-inner-wrapper {
     padding: 40px;
@@ -191,6 +194,8 @@
     align-items: flex-start;
     width: 0;
     position: relative;
+    max-width: 100%;
+    box-sizing: border-box;
   }
 
   .spectrum-Modal {
@@ -203,6 +208,7 @@
       --spectrum-global-dimension-size-100
     );
     max-width: 100%;
+    box-sizing: border-box;
   }
   :global(.spectrum--lightest .spectrum-Modal.inline) {
     border: var(--border-light);

--- a/packages/bbui/src/Modal/Modal.svelte
+++ b/packages/bbui/src/Modal/Modal.svelte
@@ -217,10 +217,14 @@
   @media (max-width: 640px) {
     .modal-inner-wrapper {
       padding: 16px;
+      width: auto;
     }
     .spectrum-Modal {
       width: 100%;
       max-height: calc(100vh - 32px);
+    }
+    .spectrum-Underlay {
+      overflow-x: hidden;
     }
   }
 </style>

--- a/packages/bbui/src/Modal/Modal.svelte
+++ b/packages/bbui/src/Modal/Modal.svelte
@@ -166,9 +166,8 @@
     position: fixed;
     top: 0;
     left: 0;
-    right: 0;
     height: 100vh;
-    width: auto; /* avoid 100vw causing horizontal overflow when a vertical scrollbar is present */
+    width: 100vw;
     opacity: 0.65;
     pointer-events: none;
   }
@@ -228,9 +227,6 @@
     .spectrum-Modal {
       width: 100%;
       max-height: calc(100vh - 32px);
-    }
-    .spectrum-Underlay {
-      overflow-x: hidden;
     }
   }
 </style>

--- a/packages/bbui/src/Modal/Modal.svelte
+++ b/packages/bbui/src/Modal/Modal.svelte
@@ -166,8 +166,9 @@
     position: fixed;
     top: 0;
     left: 0;
+    right: 0;
     height: 100vh;
-    width: 100vw;
+    width: auto; /* avoid 100vw causing horizontal overflow when a vertical scrollbar is present */
     opacity: 0.65;
     pointer-events: none;
   }
@@ -199,14 +200,15 @@
 
   .spectrum-Modal {
     border: 2px solid var(--spectrum-global-color-gray-200);
-    /* Ensure the modal never exceeds the viewport height on mobile */
-    overflow: auto;
+    /* Prevent horizontal overflow; allow vertical scroll for tall content */
+    overflow-y: auto;
+    overflow-x: hidden;
     max-height: calc(100vh - 64px);
     transform: none;
     --spectrum-dialog-confirm-border-radius: var(
       --spectrum-global-dimension-size-100
     );
-    max-width: 100%;
+    max-width: calc(100vw - 32px);
     box-sizing: border-box;
   }
   :global(.spectrum--lightest .spectrum-Modal.inline) {
@@ -226,6 +228,7 @@
     }
     .spectrum-Modal {
       width: 100%;
+      max-width: calc(100vw - 24px);
       max-height: calc(100vh - 32px);
     }
   }

--- a/packages/bbui/src/Modal/Modal.svelte
+++ b/packages/bbui/src/Modal/Modal.svelte
@@ -195,8 +195,9 @@
 
   .spectrum-Modal {
     border: 2px solid var(--spectrum-global-color-gray-200);
-    overflow: visible;
-    max-height: none;
+    /* Ensure the modal never exceeds the viewport height on mobile */
+    overflow: auto;
+    max-height: calc(100vh - 64px);
     transform: none;
     --spectrum-dialog-confirm-border-radius: var(
       --spectrum-global-dimension-size-100
@@ -210,5 +211,16 @@
   .portal,
   .portal :global(> div) {
     display: contents;
+  }
+
+  /* Mobile adjustments */
+  @media (max-width: 640px) {
+    .modal-inner-wrapper {
+      padding: 16px;
+    }
+    .spectrum-Modal {
+      width: 100%;
+      max-height: calc(100vh - 32px);
+    }
   }
 </style>

--- a/packages/bbui/src/Modal/ModalContent.svelte
+++ b/packages/bbui/src/Modal/ModalContent.svelte
@@ -154,6 +154,7 @@
   .spectrum-Dialog--medium {
     width: 540px;
   }
+  /* keep default small width from Spectrum; do not override here */
 
   .content-grid {
     display: grid;
@@ -161,9 +162,29 @@
     gap: var(--spacing-xl);
   }
 
+  /* For custom (no-grid) dialogs, stretch content and center children */
+  .no-grid .spectrum-Dialog-content.content-grid {
+    display: flex;
+    width: 100%;
+    justify-content: center;
+    align-items: stretch;
+    box-sizing: border-box;
+  }
+
+  /* Ensure inner container stretches to modal width */
+  .modal-core {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    box-sizing: border-box;
+  }
+
   .spectrum-Dialog-content {
     overflow: visible;
     max-width: 100%;
+    width: 100%;
+    box-sizing: border-box;
   }
 
   .no-grid .spectrum-Dialog-content {
@@ -175,6 +196,12 @@
     font-size: 24px;
   }
 
+  .spectrum-Dialog-heading,
+  .spectrum-Dialog-buttonGroup {
+    box-sizing: border-box;
+    width: 100%;
+  }
+
   .no-grid .spectrum-Dialog-heading {
     margin-top: 12px;
     margin-left: 12px;
@@ -182,6 +209,8 @@
 
   .spectrum-Dialog.no-grid {
     width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
   }
 
   .spectrum-Dialog.no-grid .spectrum-Dialog-buttonGroup {
@@ -222,6 +251,8 @@
   .spectrum-Dialog-buttonGroup {
     padding-left: 0;
     overflow-x: hidden;
+    box-sizing: border-box;
+    width: 100%;
   }
 
   .confirm-wrap :global(.spectrum-Button-label) {
@@ -244,4 +275,6 @@
       z-index: 1;
     }
   }
+
+  /* no extra scaling breakpoints; rely on modal container width */
 </style>

--- a/packages/bbui/src/Modal/ModalContent.svelte
+++ b/packages/bbui/src/Modal/ModalContent.svelte
@@ -163,6 +163,7 @@
 
   .spectrum-Dialog-content {
     overflow: visible;
+    max-width: 100%;
   }
 
   .no-grid .spectrum-Dialog-content {
@@ -220,6 +221,7 @@
 
   .spectrum-Dialog-buttonGroup {
     padding-left: 0;
+    overflow-x: hidden;
   }
 
   .confirm-wrap :global(.spectrum-Button-label) {

--- a/packages/bbui/src/Modal/ModalContent.svelte
+++ b/packages/bbui/src/Modal/ModalContent.svelte
@@ -230,6 +230,7 @@
   @media (max-width: 640px) {
     .spectrum-Dialog-content.content-grid {
       padding-bottom: 80px; /* ensure content isn't hidden behind sticky footer */
+      overflow-x: hidden; /* prevent accidental horizontal scroll */
     }
     .spectrum-Dialog-buttonGroup {
       position: sticky;

--- a/packages/bbui/src/Modal/ModalContent.svelte
+++ b/packages/bbui/src/Modal/ModalContent.svelte
@@ -225,4 +225,20 @@
   .confirm-wrap :global(.spectrum-Button-label) {
     display: contents;
   }
+
+  /* Keep actions visible in mobile portrait and allow content to scroll */
+  @media (max-width: 640px) {
+    .spectrum-Dialog-content.content-grid {
+      padding-bottom: 80px; /* ensure content isn't hidden behind sticky footer */
+    }
+    .spectrum-Dialog-buttonGroup {
+      position: sticky;
+      bottom: 0;
+      background: var(--spectrum-global-color-gray-50);
+      padding-top: 12px;
+      padding-bottom: 12px;
+      box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.06);
+      z-index: 1;
+    }
+  }
 </style>

--- a/packages/frontend-core/src/components/SignatureModal.svelte
+++ b/packages/frontend-core/src/components/SignatureModal.svelte
@@ -50,7 +50,7 @@
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-    align-items: stretch;
+    align-items: center;
     background-color: var(--spectrum-global-color-gray-50);
     color: var(--spectrum-alias-text-color);
     box-sizing: border-box;
@@ -59,10 +59,8 @@
 
   /* Ensure the signature canvas scales on small screens */
   .signature-wrap.modal :global(#signature-canvas) {
-    width: 100%;
-    height: auto;
-    max-width: 100%;
     display: block;
+    max-width: 100%;
   }
 
   @media (max-width: 640px) {

--- a/packages/frontend-core/src/components/SignatureModal.svelte
+++ b/packages/frontend-core/src/components/SignatureModal.svelte
@@ -36,6 +36,8 @@
         {darkMode}
         {value}
         saveIcon={false}
+        responsive
+        maxWidth={360}
         bind:this={canvas}
         on:update={() => {
           edited = true
@@ -65,8 +67,9 @@
 
   @media (max-width: 640px) {
     .signature-wrap.modal {
-      max-height: calc(100vh - 160px);
+      max-height: calc(100vh - 200px);
       overflow: auto;
+      overscroll-behavior: contain;
     }
   }
 </style>

--- a/packages/frontend-core/src/components/SignatureModal.svelte
+++ b/packages/frontend-core/src/components/SignatureModal.svelte
@@ -36,8 +36,6 @@
         {darkMode}
         {value}
         saveIcon={false}
-        responsive
-        maxWidth={360}
         bind:this={canvas}
         on:update={() => {
           edited = true

--- a/packages/frontend-core/src/components/SignatureModal.svelte
+++ b/packages/frontend-core/src/components/SignatureModal.svelte
@@ -63,6 +63,8 @@
   .signature-wrap.modal :global(#signature-canvas) {
     width: 100%;
     height: auto;
+    max-width: 100%;
+    display: block;
   }
 
   @media (max-width: 640px) {

--- a/packages/frontend-core/src/components/SignatureModal.svelte
+++ b/packages/frontend-core/src/components/SignatureModal.svelte
@@ -56,4 +56,17 @@
     box-sizing: border-box;
     position: relative;
   }
+
+  /* Ensure the signature canvas scales on small screens */
+  .signature-wrap.modal :global(#signature-canvas) {
+    width: 100%;
+    height: auto;
+  }
+
+  @media (max-width: 640px) {
+    .signature-wrap.modal {
+      max-height: calc(100vh - 160px);
+      overflow: auto;
+    }
+  }
 </style>


### PR DESCRIPTION
## Description
Fix signature modal usability on mobile/portrait. Eliminates horizontal overflow, keeps Confirm button visible, and centers the signature canvas. Minimal CSS tweaks in BBUI modal and signature modal. No behavioral/API changes.

## Addresses
- Closes #14450

## App Export
- N/A

## Screenshots / QA notes
- Validated at 375x667 (iPhone SE), 430–640px, and ~980px widths
- Confirm button remains visible with sticky footer
- No horizontal scroll; canvas centered within dialog

## Implementation
- Modal: hide horizontal overflow; cap max-width with viewport calc; avoid 100vw underlay overflow
- ModalContent: ensure no-grid content/button group use width: 100% with border-box
- SignatureModal: center wrapper; canvas max-width: 100%

## Developer notes
- Minimal CSS-only changes; commit messages include attribution

## Launchcontrol
Improves mobile signature capture: dialog fits phone screens, Confirm is always reachable, and the canvas is centered.

---
Generated by GPT-5
