### PR TITLE
Support apps without screens

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ScreenList/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/ScreenList/index.svelte
@@ -22,6 +22,8 @@
     : $sortedScreens
   $: filteredScreens = getFilteredScreens(allScreens, searchValue)
 
+  $: workspaceAppId = $workspaceAppStore.selectedWorkspaceApp?._id || ""
+
   const handleOpenSearch = async () => {
     screensContainer.scroll({ top: 0, behavior: "smooth" })
   }
@@ -75,7 +77,7 @@
   />
 </div>
 
-<NewScreenModal bind:this={newScreenModal} />
+<NewScreenModal bind:this={newScreenModal} {workspaceAppId} />
 
 <style>
   .screens {

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_layout.svelte
@@ -19,9 +19,15 @@
     validate: (id: string) =>
       $screenStore.screens.some(screen => screen._id === id),
     fallbackUrl: () => {
+      const workspaceAppScreens = $screenStore.screens.filter(
+        s => s.workspaceAppId === $workspaceAppStore.selectedWorkspaceApp?._id
+      )
       // Fall back to the first screen if one exists
-      if ($screenStore.screens.length) {
-        return `../${$screenStore.screens[0]._id}`
+      if (workspaceAppScreens.length) {
+        return `../${workspaceAppScreens[0]._id}`
+      }
+      if ($featureFlags.WORKSPACE_APPS) {
+        return `../../design/new/${$workspaceAppStore.selectedWorkspaceApp?._id}`
       }
       return "../../design"
     },

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_layout.svelte
@@ -26,9 +26,6 @@
       if (workspaceAppScreens.length) {
         return `../${workspaceAppScreens[0]._id}`
       }
-      if ($featureFlags.WORKSPACE_APPS) {
-        return `../../design/new/${$workspaceAppStore.selectedWorkspaceApp?._id}`
-      }
       return "../../design"
     },
     routify,

--- a/packages/builder/src/pages/builder/app/[application]/design/_components/NewScreen/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/_components/NewScreen/index.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import CreationPage from "@/components/common/CreationPage.svelte"
   import { AutoScreenTypes } from "@/constants"
-  import { screenStore, workspaceAppStore } from "@/stores/builder"
+  import { screenStore } from "@/stores/builder"
   import { licensing } from "@/stores/portal"
   import {
     Body,
@@ -22,6 +22,7 @@
   export let onClose: (() => void) | null = null
   export let inline: boolean = false
   export let submitOnClick: boolean = false
+  export let workspaceAppId: string
 
   let title: string
   let rootModal: Modal
@@ -30,9 +31,6 @@
   let currentStepIndex: number
 
   $: hasScreens = $screenStore.screens?.length
-  $: workspaceAppId =
-    $workspaceAppStore.selectedWorkspaceApp?._id ||
-    $workspaceAppStore.workspaceApps[0]._id!
   $: title = hasScreens ? "Create new screen" : "Create your first screen"
 
   export const open = () => {

--- a/packages/builder/src/pages/builder/app/[application]/design/_flagged/index.new.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/_flagged/index.new.svelte
@@ -214,7 +214,9 @@
     <a
       class="app"
       class:favourite={app.favourite?._id}
-      href={`./design/${app.screens[0]?._id}`}
+      href={app.screens.length
+        ? `./design/${app.screens[0]._id}`
+        : `./design/new/${app._id}`}
       on:contextmenu={e => openContextMenu(e, app)}
       class:active={showHighlight && selectedWorkspaceApp === app}
     >

--- a/packages/builder/src/pages/builder/app/[application]/design/new.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/new.svelte
@@ -1,28 +1,9 @@
 <script lang="ts">
-  import { onMount } from "svelte"
-  import NewScreen from "./_components/NewScreen/index.svelte"
+  import { featureFlags } from "@/stores/portal"
+  import OldIndex from "./new/index.old.svelte"
+  import NewIndex from "./new/[workspaceAppId]/index.svelte"
 
-  let newScreenModal: NewScreen
-
-  onMount(() => {
-    newScreenModal.open()
-  })
+  $: index = $featureFlags.WORKSPACE_APPS ? NewIndex : OldIndex
 </script>
 
-<div class="new-screen-picker">
-  <NewScreen bind:this={newScreenModal} inline submitOnClick />
-</div>
-
-<style>
-  .new-screen-picker {
-    display: flex;
-    justify-content: center;
-    flex: 1 1 auto;
-    padding-top: 40px;
-  }
-
-  .new-screen-picker :global(.spectrum-Modal) {
-    border: none;
-    background: none;
-  }
-</style>
+<svelte:component this={index} />

--- a/packages/builder/src/pages/builder/app/[application]/design/new/[workspaceAppId]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/new/[workspaceAppId]/index.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte"
   import NewScreen from "../../_components/NewScreen/index.svelte"
   import { params } from "@roxi/routify"
+  import { workspaceAppStore } from "@/stores/builder"
 
   let newScreenModal: NewScreen
 
@@ -15,7 +16,8 @@
     bind:this={newScreenModal}
     inline
     submitOnClick
-    workspaceAppId={$params.workspaceAppId}
+    workspaceAppId={$params.workspaceAppId ||
+      $workspaceAppStore.workspaceApps[0]._id}
   />
 </div>
 

--- a/packages/builder/src/pages/builder/app/[application]/design/new/[workspaceAppId]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/new/[workspaceAppId]/index.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { onMount } from "svelte"
+  import NewScreen from "../../_components/NewScreen/index.svelte"
+  import { params } from "@roxi/routify"
+
+  let newScreenModal: NewScreen
+
+  onMount(() => {
+    newScreenModal.open()
+  })
+</script>
+
+<div class="new-screen-picker">
+  <NewScreen
+    bind:this={newScreenModal}
+    inline
+    submitOnClick
+    workspaceAppId={$params.workspaceAppId}
+  />
+</div>
+
+<style>
+  .new-screen-picker {
+    display: flex;
+    justify-content: center;
+    flex: 1 1 auto;
+    padding-top: 40px;
+  }
+
+  .new-screen-picker :global(.spectrum-Modal) {
+    border: none;
+    background: none;
+  }
+</style>

--- a/packages/builder/src/pages/builder/app/[application]/design/new/index.old.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/new/index.old.svelte
@@ -4,7 +4,7 @@
   import { workspaceAppStore } from "@/stores/builder"
 
   let newScreenModal: NewScreen
-  let workspaceAppId =
+  $: workspaceAppId =
     $workspaceAppStore.selectedWorkspaceApp?._id ||
     $workspaceAppStore.workspaceApps[0]._id!
 

--- a/packages/builder/src/pages/builder/app/[application]/design/new/index.old.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/new/index.old.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { onMount } from "svelte"
+  import NewScreen from "../_components/NewScreen/index.svelte"
+  import { workspaceAppStore } from "@/stores/builder"
+
+  let newScreenModal: NewScreen
+  let workspaceAppId =
+    $workspaceAppStore.selectedWorkspaceApp?._id ||
+    $workspaceAppStore.workspaceApps[0]._id!
+
+  onMount(() => {
+    newScreenModal.open()
+  })
+</script>
+
+<div class="new-screen-picker">
+  <NewScreen bind:this={newScreenModal} inline submitOnClick {workspaceAppId} />
+</div>
+
+<style>
+  .new-screen-picker {
+    display: flex;
+    justify-content: center;
+    flex: 1 1 auto;
+    padding-top: 40px;
+  }
+
+  .new-screen-picker :global(.spectrum-Modal) {
+    border: none;
+    background: none;
+  }
+</style>

--- a/packages/server/src/api/controllers/screen.ts
+++ b/packages/server/src/api/controllers/screen.ts
@@ -3,14 +3,12 @@ import {
   context,
   db as dbCore,
   events,
-  features,
   roles,
   tenancy,
 } from "@budibase/backend-core"
 import { updateAppPackage } from "./application"
 import {
   DeleteScreenResponse,
-  FeatureFlag,
   FetchScreenResponse,
   Plugin,
   SaveScreenRequest,
@@ -130,16 +128,6 @@ export async function destroy(ctx: UserCtx<void, DeleteScreenResponse>) {
   const db = context.getAppDB()
   const id = ctx.params.screenId
   const screen = await db.get<Screen>(id)
-
-  if (await features.isEnabled(FeatureFlag.WORKSPACE_APPS)) {
-    const allScreens = await sdk.screens.fetch()
-    const appScreens = allScreens.filter(
-      s => s.workspaceAppId === screen.workspaceAppId
-    )
-    if (appScreens.filter(s => s._id !== id).length === 0) {
-      ctx.throw("Cannot delete the last screen in a workspace app", 409)
-    }
-  }
 
   await db.remove(id, ctx.params.screenRev)
 

--- a/packages/server/src/api/routes/tests/screen.spec.ts
+++ b/packages/server/src/api/routes/tests/screen.spec.ts
@@ -234,21 +234,6 @@ describe("/screens", () => {
         featureCleanup()
       })
 
-      it("should not allow deleting the last screen", async () => {
-        const { workspaceApp } = await config.api.workspaceApp.create(
-          structures.workspaceApps.createRequest()
-        )
-        const screen = await config.api.screen.save({
-          ...basicScreen(),
-          workspaceAppId: workspaceApp._id,
-        })
-
-        await config.api.screen.destroy(screen._id!, screen._rev!, {
-          status: 409,
-          body: { message: "Cannot delete the last screen in a workspace app" },
-        })
-      })
-
       it("should allow deleting other screens", async () => {
         const { workspaceApp } = await config.api.workspaceApp.create(
           structures.workspaceApps.createRequest()

--- a/packages/server/src/api/routes/tests/screen.spec.ts
+++ b/packages/server/src/api/routes/tests/screen.spec.ts
@@ -30,6 +30,10 @@ describe("/screens", () => {
 
   beforeAll(async () => {
     await config.init()
+  })
+
+  beforeEach(async () => {
+    await config.newTenant()
     // Replace the regular app with an onboarding app to get sample data
     await config.createAppWithOnboarding("test-app-with-sample")
     screen = await config.createScreen()
@@ -67,7 +71,7 @@ describe("/screens", () => {
     let screen1: Screen, screen2: Screen
     let role1: Role, role2: Role, multiRole: Role
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       role1 = await config.api.roles.save({
         name: "role1",
         inherits: roles.BUILTIN_ROLE_IDS.BASIC,
@@ -197,6 +201,10 @@ describe("/screens", () => {
   })
 
   describe("destroy", () => {
+    beforeEach(async () => {
+      await config.newTenant()
+    })
+
     it("should be able to delete the screen", async () => {
       const [{ _id: workspaceAppId }] = (await config.api.workspaceApp.fetch())
         .workspaceApps
@@ -234,7 +242,7 @@ describe("/screens", () => {
         featureCleanup()
       })
 
-      it("should allow deleting other screens", async () => {
+      it("should allow deleting screens", async () => {
         const { workspaceApp } = await config.api.workspaceApp.create(
           structures.workspaceApps.createRequest()
         )
@@ -252,20 +260,24 @@ describe("/screens", () => {
           screenToDelete._id!,
           screenToDelete._rev!
         )
+        expect(await config.api.screen.list()).toHaveLength(2)
+
         screenToDelete = popRandomScreen(screens)
         await config.api.screen.destroy(
           screenToDelete._id!,
           screenToDelete._rev!
         )
+        expect(await config.api.screen.list()).toHaveLength(1)
+
         screenToDelete = popRandomScreen(screens)
         await config.api.screen.destroy(
           screenToDelete._id!,
-          screenToDelete._rev!,
-          { status: 409 }
+          screenToDelete._rev!
         )
+        expect(await config.api.screen.list()).toHaveLength(0)
       })
 
-      it("should allow deleting screens for other apps", async () => {
+      it("should allow deleting screens across all apps", async () => {
         const { workspaceApp: workspaceApp1 } =
           await config.api.workspaceApp.create(
             structures.workspaceApps.createRequest()
@@ -305,9 +317,9 @@ describe("/screens", () => {
         screenToDelete = popRandomScreen(app1Screens)
         await config.api.screen.destroy(
           screenToDelete._id!,
-          screenToDelete._rev!,
-          { status: 409 }
+          screenToDelete._rev!
         )
+        expect(await config.api.screen.list()).toHaveLength(2)
       })
     })
   })


### PR DESCRIPTION
## Description
Initially, we designed the workspace apps in a way that we can't have one without screens. This changed, and this PR supports having them. We can probably work around the UX, especially around removing the last screen, but they should be edge cases we can work out later on.