### PR TITLE
Fix for workspace app url customisation on create

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/WorkspaceApp/WorkspaceAppModal.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/WorkspaceApp/WorkspaceAppModal.svelte
@@ -3,7 +3,6 @@
   import {
     Input,
     keepOpen,
-    Body,
     Modal,
     ModalContent,
     notifications,

--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/WorkspaceApp/WorkspaceAppModal.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/_components/WorkspaceApp/WorkspaceAppModal.svelte
@@ -142,14 +142,12 @@
 
 <Modal bind:this={modal} on:show={onShow} on:hide>
   <ModalContent {title} {onConfirm} size="M">
-    <Body>
-      Use underscores "_" to seperate words within your app name. Do not use
-      hyphens "-" or spaces.</Body
-    >
-
     <Input
       label="App Name"
       on:enterkey={onEnterKey}
+      on:change={() => {
+        data.url = `/${data.name.toLowerCase().replace(/\s+/g, "-")}`
+      }}
       on:focus={() => {
         validationState.touched.name = true
         delete validationState.errors.name
@@ -167,7 +165,6 @@
       }}
       bind:value={data.url}
       error={validationState.errors.url}
-      disabled
     />
   </ModalContent>
 </Modal>

--- a/packages/server/src/api/routes/workspaceApp.ts
+++ b/packages/server/src/api/routes/workspaceApp.ts
@@ -8,7 +8,7 @@ const baseSchema = {
   name: Joi.string().required(),
   url: Joi.string()
     .required()
-    .regex(/^\/\w*$/),
+    .regex(/^\/[\w-]*$/),
   disabled: Joi.boolean().optional(),
 }
 


### PR DESCRIPTION
## Description
Allow free url customisation when creating a workspace app and a minor fix for the server-side validation regex when validating workspace app urls.

## Launchcontrol
Minor fix for workspace app create and allow free editing of the workspace app base url