### PR TITLE
Fix screen conflicts while changing home screen settings

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Screen/GeneralPanel.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/[screenId]/[componentId]/_components/Screen/GeneralPanel.svelte
@@ -10,7 +10,7 @@
   } from "@budibase/bbui"
   import PropertyControl from "@/components/design/settings/controls/PropertyControl.svelte"
   import RoleSelect from "@/components/design/settings/controls/RoleSelect.svelte"
-  import { selectedScreen, screenStore } from "@/stores/builder"
+  import { selectedScreen, screenStore, appStore } from "@/stores/builder"
   import sanitizeUrl from "@/helpers/sanitizeUrl"
   import ButtonActionEditor from "@/components/design/settings/controls/ButtonActionEditor/ButtonActionEditor.svelte"
   import { getBindableProperties } from "@/dataBinding"
@@ -83,6 +83,7 @@
         props: {
           text: "Set as home screen",
         },
+        onChange: () => appStore.refresh(),
       },
       {
         key: "routing.route",
@@ -184,6 +185,8 @@
       console.error(error)
       notifications.error("Error saving screen settings")
     }
+
+    await setting.onChange?.()
   }
 
   const removeCustomLayout = async () => {


### PR DESCRIPTION
## Description
As title says. When setting a home screen, we update the existing home pages to be marked as no-homepage. This might cause 409, as the state is not properly updated.
This PR refreshed all screens when this setting is modified

## Launchcontrol
Fix screen conflicts while changing home screen settings