### PR TITLE
Fix issue where filter component hard crashes builder. 

### DIFF
--- a/packages/builder/src/components/design/settings/controls/DraggableList.svelte
+++ b/packages/builder/src/components/design/settings/controls/DraggableList.svelte
@@ -43,15 +43,23 @@
   let inactive = true
 
   const buildDraggable = items => {
+    const seenIds = new Set()
     return items
       .map(item => {
+        let id = listItemKey ? item[listItemKey] : generate()
         return {
-          id: listItemKey ? item[listItemKey] : generate(),
+          id,
           item,
           type: zoneType,
         }
       })
-      .filter(item => item.id)
+      .filter(item => {
+        if (item.id && !seenIds.has(item.id)) {
+          seenIds.add(item.id)
+          return true
+        }
+        return false
+      })
   }
 
   $: if (items) {
@@ -78,6 +86,7 @@
   const onItemChanged = e => {
     dispatch("itemChange", e.detail)
   }
+  $: console.log(draggableItems)
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->

--- a/packages/builder/src/components/design/settings/controls/DraggableList.svelte
+++ b/packages/builder/src/components/design/settings/controls/DraggableList.svelte
@@ -53,13 +53,7 @@
           type: zoneType,
         }
       })
-      .filter(item => {
-        if (item.id && !seenIds.has(item.id)) {
-          seenIds.add(item.id)
-          return true
-        }
-        return false
-      })
+      .filter(({ id }) => id && seenIds.has(id) && seenIds.add(id))
   }
 
   $: if (items) {

--- a/packages/builder/src/components/design/settings/controls/DraggableList.svelte
+++ b/packages/builder/src/components/design/settings/controls/DraggableList.svelte
@@ -86,7 +86,6 @@
   const onItemChanged = e => {
     dispatch("itemChange", e.detail)
   }
-  $: console.log(draggableItems)
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->


### PR DESCRIPTION
## Description
- Fix an issue where having duplicate ids in a list of draggable items would result in a crash in the DraggableList component. 

## Addresses
- https://github.com/Budibase/budibase/issues/16691


## Launchcontrol
Fix an issue which was causing the filter component to crash.