### PR TITLE
Remove fallback url

### DIFF
--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -644,6 +644,10 @@ export async function create(
   ctx.body = newApplication
 }
 
+export async function find(ctx: UserCtx) {
+  ctx.body = await sdk.applications.metadata.get()
+}
+
 // This endpoint currently operates as a PATCH rather than a PUT
 // Thus name and url fields are handled only if present
 export async function update(

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -196,10 +196,6 @@ const getAppScriptHTML = (
 }
 
 export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
-  if (ctx.url.includes("apple-touch-icon.png")) {
-    ctx.redirect("/builder/bblogo.png")
-    return
-  }
   // No app ID found, cannot serve - return message instead
   const appId = context.getAppId()
   if (!appId) {

--- a/packages/server/src/api/routes/application.ts
+++ b/packages/server/src/api/routes/application.ts
@@ -6,6 +6,7 @@ import { builderRoutes, creatorRoutes, publicRoutes } from "./endpointGroups"
 
 builderRoutes
   .post("/api/applications/:appId/sync", controller.sync)
+  .get("/api/applications/:appId", controller.find)
   .put(
     "/api/applications/:appId",
     applicationValidator({ isCreate: false }),

--- a/packages/server/src/api/routes/static.ts
+++ b/packages/server/src/api/routes/static.ts
@@ -5,6 +5,7 @@ import { authorizedMiddleware as authorized } from "../../middleware/authorized"
 import { permissions } from "@budibase/backend-core"
 import { addFileManagement } from "../utils"
 import { paramResource } from "../../middleware/resourceId"
+import { devAppIdPath } from "../../constants/paths"
 
 const { BUILDER, PermissionType, PermissionLevel } = permissions
 
@@ -27,7 +28,7 @@ router
   .get("/app/preview", authorized(BUILDER), controller.serveBuilderPreview)
   .get("/app/service-worker.js", controller.serveServiceWorker)
   .get("/app/:appUrl/:path*", controller.serveApp)
-  .get("/:appId/:path*", controller.serveApp)
+  .get(`/${devAppIdPath}/:path*`, controller.serveApp)
   .post(
     "/api/attachments/:datasourceId/url",
     recaptcha,

--- a/packages/server/src/api/routes/static.ts
+++ b/packages/server/src/api/routes/static.ts
@@ -14,6 +14,9 @@ const router: Router = new Router()
 addFileManagement(router)
 
 router
+  .get("/apple-touch-icon.png", async ctx => {
+    ctx.redirect("/builder/bblogo.png")
+  })
   .get("/api/assets/client", controller.serveClientLibrary)
   .get("/api/apps/:appId/manifest.json", controller.servePwaManifest)
   .post("/api/attachments/process", authorized(BUILDER), controller.uploadFile)

--- a/packages/server/src/api/routes/tests/static.spec.ts
+++ b/packages/server/src/api/routes/tests/static.spec.ts
@@ -23,18 +23,6 @@ describe("/static", () => {
       jest.clearAllMocks()
     })
 
-    it("should serve the app by id", async () => {
-      const headers = config.defaultHeaders()
-      delete headers[constants.Header.APP_ID]
-
-      const res = await request
-        .get(`/${config.prodAppId}`)
-        .set(headers)
-        .expect(200)
-
-      expect(res.body.appId).toBe(config.prodAppId)
-    })
-
     it("should serve the app by url", async () => {
       const headers = config.defaultHeaders()
       delete headers[constants.Header.APP_ID]

--- a/packages/server/src/constants/paths.ts
+++ b/packages/server/src/constants/paths.ts
@@ -1,3 +1,3 @@
 import { DocumentType } from "@budibase/types"
 
-export const devAppIdPath = `:appId(^${DocumentType.APP_DEV}_.+)`
+export const devAppIdPath = `:appId(${DocumentType.APP_DEV}_.+)`

--- a/packages/server/src/constants/paths.ts
+++ b/packages/server/src/constants/paths.ts
@@ -1,0 +1,3 @@
+import { DocumentType } from "@budibase/types"
+
+export const devAppIdPath = `:appId(^${DocumentType.APP_DEV}_.+)`

--- a/packages/server/src/tests/utilities/api/automation.ts
+++ b/packages/server/src/tests/utilities/api/automation.ts
@@ -33,7 +33,7 @@ export class AutomationAPI extends TestAPI {
     expectations?: Expectations
   ): Promise<GetAutomationActionDefinitionsResponse> => {
     return await this._get<GetAutomationActionDefinitionsResponse>(
-      `/api/automations/actions/list`,
+      `/api/automations/action/list`,
       {
         expectations,
       }
@@ -44,7 +44,7 @@ export class AutomationAPI extends TestAPI {
     expectations?: Expectations
   ): Promise<GetAutomationTriggerDefinitionsResponse> => {
     return await this._get<GetAutomationTriggerDefinitionsResponse>(
-      `/api/automations/triggers/list`,
+      `/api/automations/trigger/list`,
       {
         expectations,
       }


### PR DESCRIPTION
## Description
Recently, we added changes to the app serve endpoint, and some automation tests started [failing](https://github.com/Budibase/budibase/actions/runs/16931651129/job/47978384634?pr=16724). Then we discovered that the serve app endpoint was being used as a fallback, resulting in a significant number of false positives.
This PR ensures that the fallback is only used for dev app URLs (it's meant to be used on the preview app), and fixes any issues with it