### PR TITLE
Allow testing disabled apps

### DIFF
--- a/packages/server/src/api/controllers/automation.ts
+++ b/packages/server/src/api/controllers/automation.ts
@@ -251,7 +251,7 @@ export async function test(
     const input = prepareTestInput(body)
     const user = sdk.users.getUserContextBindings(ctx.user)
     return await triggers.externalTrigger(
-      automation,
+      { ...automation, disabled: false },
       { ...{ ...input, ...(table ? { table } : {}) }, appId, user },
       { getResponses: true }
     )

--- a/packages/server/src/api/routes/tests/automation.spec.ts
+++ b/packages/server/src/api/routes/tests/automation.spec.ts
@@ -300,6 +300,20 @@ describe("/automations", () => {
       }
       throw "Failed to find the rows"
     })
+
+    it("should be able to test a disabled automation", async () => {
+      const { automation } = await config.api.automation.post(
+        collectAutomation({ disabled: true })
+      )
+
+      await config.api.automation.test(automation._id!, {
+        fields: {},
+      })
+
+      expect(sdk.automations.utils.checkForCollectStep(automation)).toEqual(
+        true
+      )
+    })
   })
 
   describe("trigger", () => {


### PR DESCRIPTION
## Description
We should allow testing disabled automations. This is only done for dev automations, so we should not need to enable it to test it. This becomes more of a visible issue with the new UI, as enabling it will publish it automatically

## Launchcontrol
Enable testing disabled automations on dev