### PR TITLE
Disable resources on unpublish

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/settings/general.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/settings/general.svelte
@@ -99,13 +99,24 @@
       </Body>
     </div>
     <div class="row">
-      <Button
-        cta
-        disabled={$deploymentStore.isPublishing}
-        on:click={deploymentStore.publishApp}
-      >
-        Publish
-      </Button>
+      {#if !$featureFlags.WORKSPACE_APPS}
+        <Button
+          cta
+          disabled={$deploymentStore.isPublishing}
+          on:click={deploymentStore.publishApp}
+        >
+          Publish
+        </Button>
+      {:else}
+        <Button
+          icon="arrow-circle-up"
+          primary
+          disabled={$deploymentStore.isPublishing}
+          on:click={deploymentStore.publishApp}
+        >
+          Publish
+        </Button>
+      {/if}
     </div>
   {/if}
   <Divider id="version" />

--- a/packages/builder/src/pages/builder/app/[application]/settings/general.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/settings/general.svelte
@@ -17,7 +17,7 @@
     recaptchaStore,
   } from "@/stores/builder"
   import VersionModal from "@/components/deploy/VersionModal.svelte"
-  import { appsStore, admin, licensing } from "@/stores/portal"
+  import { appsStore, admin, licensing, featureFlags } from "@/stores/portal"
   import ExportAppModal from "@/components/start/ExportAppModal.svelte"
   import ImportAppModal from "@/components/start/ImportAppModal.svelte"
   import ConfirmDialog from "@/components/common/ConfirmDialog.svelte"
@@ -37,6 +37,8 @@
   $: updateAvailable = $appStore.upgradableVersion !== $appStore.version
   $: revertAvailable = $appStore.revertableVersion != null
   $: appRecaptchaEnabled = $recaptchaStore.enabled
+
+  $: appOrWorkspace = $featureFlags.WORKSPACE_APPS ? "workspace" : "app"
 
   const exportApp = opts => {
     exportPublishedVersion = !!opts?.published
@@ -240,10 +242,16 @@
 <ConfirmDialog
   bind:this={unpublishModal}
   title="Confirm unpublish"
-  okText="Unpublish app"
+  okText="Unpublish"
   onOk={deploymentStore.unpublishApp}
 >
-  Are you sure you want to unpublish the app <b>{selectedApp?.name}</b>?
+  Are you sure you want to unpublish the {appOrWorkspace}
+  <b>{selectedApp?.name}</b>?
+  {#if $featureFlags.WORKSPACE_APPS}
+    <br />
+    <br />
+    This will disable all apps and automations
+  {/if}
 </ConfirmDialog>
 
 <RevertModal bind:this={revertModal} />

--- a/packages/builder/src/stores/builder/deployment.ts
+++ b/packages/builder/src/stores/builder/deployment.ts
@@ -115,8 +115,11 @@ class DeploymentStore extends DerivedBudiStore<
     }
     try {
       await API.unpublishApp(get(appStore).appId)
-      await workspaceDeploymentStore.fetch()
-      await appsStore.load()
+      await Promise.all([
+        workspaceDeploymentStore.fetch(),
+        appsStore.load(),
+        automationStore.actions.fetch(),
+      ])
       notifications.send("App unpublished", {
         type: "success",
         icon: "globe",


### PR DESCRIPTION
## Description
If we unpublish, we need to mark all resources as disabled. Otherwise, we might have unexpected behaviours, as publishing something resources will publish all the rest. This PR marks everything as disabled, so we honor what is being displayed on the UI 