### PR TITLE
Ensuring disabled flag is properly for resources

### DIFF
--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -157,10 +157,6 @@ export async function deploymentProgress(
 }
 
 export async function publishStatus(ctx: UserCtx<void, PublishStatusResponse>) {
-  if (!(await features.isEnabled(FeatureFlag.WORKSPACE_APPS))) {
-    return (ctx.body = { automations: {}, workspaceApps: {} })
-  }
-
   const { automations, workspaceApps } = await sdk.deployment.status()
 
   ctx.body = {

--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -191,6 +191,26 @@ export const publishApp = async function (
       const devAppId = dbCore.getDevelopmentAppID(appId)
       const productionAppId = dbCore.getProdAppID(appId)
 
+      if (await features.isEnabled(FeatureFlag.WORKSPACE_APPS)) {
+        const allWorkspaceApps = await sdk.workspaceApps.fetch()
+        for (const workspaceApp of allWorkspaceApps) {
+          if (workspaceApp.disabled !== undefined) {
+            continue
+          }
+
+          await sdk.workspaceApps.update({ ...workspaceApp, disabled: true })
+        }
+
+        const allAutomations = await sdk.automations.fetch()
+        for (const automation of allAutomations) {
+          if (automation.disabled !== undefined) {
+            continue
+          }
+
+          await sdk.automations.update({ ...automation, disabled: true })
+        }
+      }
+
       const isPublished = await sdk.applications.isAppPublished(productionAppId)
 
       // don't try this if feature isn't allowed, will error

--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -191,7 +191,10 @@ export const publishApp = async function (
       const devAppId = dbCore.getDevelopmentAppID(appId)
       const productionAppId = dbCore.getProdAppID(appId)
 
-      if (await features.isEnabled(FeatureFlag.WORKSPACE_APPS)) {
+      if (
+        (await features.isEnabled(FeatureFlag.WORKSPACE_APPS)) &&
+        !(await sdk.applications.isAppPublished(productionAppId))
+      ) {
         const allWorkspaceApps = await sdk.workspaceApps.fetch()
         for (const workspaceApp of allWorkspaceApps) {
           if (workspaceApp.disabled !== undefined) {

--- a/packages/server/src/api/routes/tests/deploy.spec.ts
+++ b/packages/server/src/api/routes/tests/deploy.spec.ts
@@ -3,6 +3,7 @@ import { structures } from "@budibase/backend-core/tests"
 import { features } from "@budibase/backend-core"
 import { createAutomationBuilder } from "../../../automations/tests/utilities/AutomationTestBuilder"
 import { basicTable } from "../../../tests/utilities/structures"
+import { Automation, PublishResourceState, WorkspaceApp } from "@budibase/types"
 
 describe("/api/deploy", () => {
   let config = setup.getConfig(),
@@ -224,6 +225,217 @@ describe("/api/deploy", () => {
       // Should not include deleted automation
       expect(res.automations[automation._id!]).toBeUndefined()
       expect(Object.keys(res.automations)).toHaveLength(0)
+    })
+  })
+
+  describe.each([false, true])("POST /api/deploy", workspaceAppsFlag => {
+    let cleanup: () => void
+    afterAll(() => {
+      cleanup()
+    })
+
+    beforeAll(async () => {
+      cleanup = features.testutils.setFeatureFlags("*", {
+        WORKSPACE_APPS: workspaceAppsFlag,
+      })
+
+      await config.init()
+    })
+
+    beforeEach(async () => {
+      await config.unpublish()
+    })
+
+    function expectApp(app: WorkspaceApp) {
+      return {
+        disabled: async (
+          disabled: boolean | undefined,
+          state: PublishResourceState
+        ) => {
+          expect((await config.api.workspaceApp.find(app._id!)).disabled).toBe(
+            disabled
+          )
+
+          const status = await config.api.deploy.publishStatus()
+          expect(status.workspaceApps[app._id!]).toEqual(
+            expect.objectContaining({
+              state,
+            })
+          )
+        },
+      }
+    }
+    function expectAutomation(automation: Automation) {
+      return {
+        disabled: async (
+          disabled: boolean | undefined,
+          state: PublishResourceState
+        ) => {
+          expect(
+            (await config.api.automation.get(automation._id!)).disabled
+          ).toBe(disabled)
+
+          const status = await config.api.deploy.publishStatus()
+          expect(status.automations[automation._id!]).toEqual(
+            expect.objectContaining({
+              state,
+            })
+          )
+        },
+      }
+    }
+
+    async function publishProdApp() {
+      await config.api.application.publish(config.getAppId())
+      await config.api.application.sync(config.getAppId())
+    }
+
+    it("should define the disable value for all workspace apps when publishing for the first time (only when flag is true, workspace apps flag %s)", async () => {
+      const { workspaceApp: publishedApp } =
+        await config.api.workspaceApp.create({
+          name: "Test App 1",
+          url: "/app1",
+          disabled: false,
+        })
+      const { workspaceApp: appWithoutInfo } =
+        await config.api.workspaceApp.create({
+          name: "Test App 2",
+          url: "/app2",
+        })
+      const { workspaceApp: disabledApp } =
+        await config.api.workspaceApp.create(
+          structures.workspaceApps.createRequest({
+            name: "Disabled App",
+            url: "/disabled",
+            disabled: true,
+          })
+        )
+
+      expect(publishedApp.disabled).toBe(false)
+      expect(appWithoutInfo.disabled).toBeUndefined()
+      expect(disabledApp.disabled).toBe(true)
+
+      // Publish the app for the first time
+      await publishProdApp()
+
+      await expectApp(publishedApp).disabled(
+        false,
+        PublishResourceState.PUBLISHED
+      )
+      await expectApp(appWithoutInfo).disabled(
+        !workspaceAppsFlag ? undefined : true,
+        !workspaceAppsFlag
+          ? PublishResourceState.PUBLISHED
+          : PublishResourceState.DISABLED
+      )
+      await expectApp(disabledApp).disabled(true, PublishResourceState.DISABLED)
+    })
+
+    it("should define the disable value for all automations when publishing for the first time (only when flag is true, workspace apps flag %s)", async () => {
+      const table = await config.api.table.save(basicTable())
+
+      const { automation: disabledAutomation } = await createAutomationBuilder(
+        config
+      )
+        .onRowSaved({ tableId: table._id! })
+        .save({ disabled: true })
+      const { automation: enabledAutomation } = await createAutomationBuilder(
+        config
+      )
+        .onRowSaved({ tableId: table._id! })
+        .save({ disabled: false })
+      const { automation: automationWithoutInfo } =
+        await createAutomationBuilder(config)
+          .onRowSaved({ tableId: table._id! })
+          .save({ disabled: undefined })
+
+      // Verify apps are not disabled before publishing
+      expect(disabledAutomation.disabled).toBe(true)
+      expect(enabledAutomation.disabled).toBe(false)
+      expect(automationWithoutInfo.disabled).toBe(undefined)
+
+      // Publish the app for the first time
+      await publishProdApp()
+
+      await expectAutomation(disabledAutomation).disabled(
+        true,
+        PublishResourceState.DISABLED
+      )
+      await expectAutomation(enabledAutomation).disabled(
+        false,
+        PublishResourceState.PUBLISHED
+      )
+      await expectAutomation(automationWithoutInfo).disabled(
+        !workspaceAppsFlag ? undefined : true,
+        !workspaceAppsFlag
+          ? PublishResourceState.PUBLISHED
+          : PublishResourceState.DISABLED
+      )
+    })
+
+    it("should not disable workspace apps on subsequent publishes", async () => {
+      const { workspaceApp: initialApp } = await config.api.workspaceApp.create(
+        {
+          name: "Test App 1",
+          url: "/app1",
+          disabled: undefined,
+        }
+      )
+
+      await features.testutils.withFeatureFlags(
+        config.getTenantId(),
+        {
+          WORKSPACE_APPS: false,
+        },
+        () => publishProdApp()
+      )
+
+      const { workspaceApp: secondApp } = await config.api.workspaceApp.create({
+        name: "Test App 2",
+        url: "/app2",
+        disabled: true,
+      })
+      await publishProdApp()
+
+      await expectApp(initialApp).disabled(
+        undefined,
+        PublishResourceState.PUBLISHED
+      )
+      await expectApp(secondApp).disabled(true, PublishResourceState.DISABLED)
+    })
+
+    it("should not disable automations on subsequent publishes", async () => {
+      const table = await config.api.table.save(basicTable())
+
+      const { automation: initialAutomation } = await createAutomationBuilder(
+        config
+      )
+        .onRowSaved({ tableId: table._id! })
+        .save({ disabled: undefined })
+
+      await features.testutils.withFeatureFlags(
+        config.getTenantId(),
+        {
+          WORKSPACE_APPS: false,
+        },
+        () => publishProdApp()
+      )
+
+      const { automation: secondAutomation } = await createAutomationBuilder(
+        config
+      )
+        .onRowSaved({ tableId: table._id! })
+        .save({ disabled: true })
+      await publishProdApp()
+
+      await expectAutomation(initialAutomation).disabled(
+        undefined,
+        PublishResourceState.PUBLISHED
+      )
+      await expectAutomation(secondAutomation).disabled(
+        true,
+        PublishResourceState.DISABLED
+      )
     })
   })
 })

--- a/packages/server/src/automations/tests/utilities/AutomationTestBuilder.ts
+++ b/packages/server/src/automations/tests/utilities/AutomationTestBuilder.ts
@@ -173,7 +173,7 @@ class StepBuilder<
         trigger: this._trigger,
         stepNames: this.stepNames,
       },
-      disabled: opts?.disabled || undefined,
+      disabled: opts?.disabled,
       type: "automation",
       appId: this.config.getAppId(),
     }

--- a/packages/server/src/sdk/app/workspaceApps/crud.ts
+++ b/packages/server/src/sdk/app/workspaceApps/crud.ts
@@ -50,7 +50,13 @@ export async function update(
 ): Promise<WorkspaceApp> {
   const db = context.getAppDB()
 
-  const persisted = (await get(workspaceApp._id!))!
+  const persisted = await get(workspaceApp._id!)
+  if (!persisted) {
+    throw new HTTPError(
+      `Project app with id '${workspaceApp._id}' not found.`,
+      404
+    )
+  }
   if (workspaceApp.name !== persisted.name) {
     await guardName(workspaceApp.name, workspaceApp._id)
   }
@@ -80,8 +86,9 @@ export async function remove(
   try {
     const existing = await db.tryGet<WorkspaceApp>(workspaceAppId)
     if (!existing)
-      throw new Error(
-        `Delete failed. Workspace app not found: ${workspaceAppId}`
+      throw new HTTPError(
+        `Project app with id '${workspaceAppId}' not found.`,
+        404
       )
 
     await db.remove(workspaceAppId, _rev)


### PR DESCRIPTION
## Description
Fixing a bug detected by @mikesealey around publishing. The issue can be reproduced below:
1. With the flag off, create a new workspace from a template
2. Without publishing, enable the flag
3. Publish

You will see that some resources are set as enabled, even if they are not meant to. This might affect any app that is not published on flag toggle on