### PR TITLE
chore: bump node version in Github Actions Readme workflow

### DIFF
--- a/.github/workflows/readme-openapi.yml
+++ b/.github/workflows/readme-openapi.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: yarn
       - run: yarn --frozen-lockfile
 


### PR DESCRIPTION
## Description
Bumps Node to 22.x for the Github Actions Readme workflow.

## Addresses
- Workflow complaining that installed Node version doesn't match spec version. 
- See: https://github.com/Budibase/budibase/actions/runs/16962277090/job/48077722102

