### PR TITLE
Fixing issue with postgres tests.

### DIFF
--- a/packages/server/src/api/routes/tests/datasource.spec.ts
+++ b/packages/server/src/api/routes/tests/datasource.spec.ts
@@ -647,6 +647,9 @@ if (datasources.length) {
             // pg_dump 17 puts this config parameter into the dump but no DB < 17
             // can load it. We're using postgres 16 in tests at the time of writing.
             schema = schema.replace("SET transaction_timeout = 0;", "")
+            // Remove \restrict and \unrestrict commands that are not valid in older PostgreSQL versions
+            schema = schema.replace(/\\restrict\s+[^\n]+\n?/g, "")
+            schema = schema.replace(/\\unrestrict\s+[^\n]+\n?/g, "")
           }
           if (isPostgres && isLegacy) {
             // in older versions of Postgres, this is not a valid option - Postgres 9.5 does not support this.


### PR DESCRIPTION
## Description
There was some flake due to an oddity in the Postgres schema dump, removing it to fix flake.
