### PR TITLE
Allow primary display column to be hidden in Grid table

### DIFF
--- a/packages/builder/src/components/design/settings/controls/GridColumnConfiguration/PrimaryColumnFieldSetting.svelte
+++ b/packages/builder/src/components/design/settings/controls/GridColumnConfiguration/PrimaryColumnFieldSetting.svelte
@@ -1,14 +1,17 @@
 <script>
   import EditComponentPopover from "../EditComponentPopover.svelte"
-  import { Icon } from "@budibase/bbui"
-  import { setContext } from "svelte"
+  import { Icon, Toggle } from "@budibase/bbui"
+  import { setContext, createEventDispatcher } from "svelte"
   import { writable } from "svelte/store"
   import { FieldTypeToComponentMap } from "../FieldConfiguration/utils"
   import { componentStore } from "@/stores/builder"
+  import { cloneDeep } from "lodash/fp"
 
   export let item
   export let anchor
   export let bindings
+
+  const dispatch = createEventDispatcher()
 
   let draggableStore = writable({
     selected: null,
@@ -39,6 +42,13 @@
     return componentStore.getDefinition(component)?.icon
   }
 
+  const onToggle = item => {
+    return e => {
+      item.active = e.detail
+      dispatch("change", { ...cloneDeep(item), active: e.detail })
+    }
+  }
+
   $: icon = getIcon(item)
 </script>
 
@@ -58,8 +68,16 @@
     </EditComponentPopover>
     <div class="field-label">{item.label || item.field}</div>
   </div>
-  <div title="The display column is always shown first" class="list-item-right">
-    <Icon name={"Info"} />
+  <div class="list-item-right">
+    <Toggle
+      on:click={e => {
+        e.stopPropagation()
+      }}
+      on:change={onToggle(item)}
+      text=""
+      value={item.active}
+      thin
+    />
   </div>
 </div>
 
@@ -76,9 +94,8 @@
     gap: var(--spacing-m);
     min-width: 0;
   }
-  .list-item-right :global(svg) {
-    color: var(--grey-5);
-    padding: 7px 5px 7px 0;
+  .list-item-right :global(div.spectrum-Switch) {
+    margin: 0px;
   }
   .list-item-body {
     justify-content: space-between;

--- a/packages/builder/src/components/design/settings/controls/GridColumnConfiguration/getColumns.js
+++ b/packages/builder/src/components/design/settings/controls/GridColumnConfiguration/getColumns.js
@@ -36,14 +36,6 @@ export const removeInvalidAddMissing = (
 
   const combinedColumns = [...validColumns, ...missingColumns]
 
-  // Ensure the primary display column is always visible
-  const primaryDisplayIndex = combinedColumns.findIndex(
-    column => column.field === primaryDisplayColumnName
-  )
-  if (primaryDisplayIndex > -1) {
-    combinedColumns[primaryDisplayIndex].active = true
-  }
-
   return combinedColumns
 }
 

--- a/packages/builder/src/components/design/settings/controls/GridColumnConfiguration/getColumns.js
+++ b/packages/builder/src/components/design/settings/controls/GridColumnConfiguration/getColumns.js
@@ -14,11 +14,7 @@ export const modernize = columns => {
   return columns
 }
 
-export const removeInvalidAddMissing = (
-  columns = [],
-  defaultColumns = [],
-  primaryDisplayColumnName
-) => {
+export const removeInvalidAddMissing = (columns = [], defaultColumns = []) => {
   const defaultColumnNames = defaultColumns.map(column => column.field)
   const columnNames = columns.map(column => column.field)
 

--- a/packages/builder/src/components/design/settings/controls/GridColumnConfiguration/getColumns.test.js
+++ b/packages/builder/src/components/design/settings/controls/GridColumnConfiguration/getColumns.test.js
@@ -102,7 +102,7 @@ describe("getColumns", () => {
       expect(ctx.columns.primary).toEqual({
         _id: "four",
         _instanceName: "four",
-        active: true,
+        active: false,
         columnType: "foo",
         componentName: "@budibase/standard-components/labelfield",
         field: "four",
@@ -164,7 +164,7 @@ describe("getColumns", () => {
       expect(ctx.columns.primary).toEqual({
         _id: "four",
         _instanceName: "four",
-        active: true,
+        active: false,
         columnType: "foo",
         componentName: "@budibase/standard-components/labelfield",
         field: "four",
@@ -234,7 +234,7 @@ describe("getColumns", () => {
       expect(ctx.columns.primary).toEqual({
         _id: "four",
         _instanceName: "four",
-        active: true,
+        active: false,
         columnType: "foo",
         componentName: "@budibase/standard-components/labelfield",
         field: "four",
@@ -301,7 +301,7 @@ describe("getColumns", () => {
       expect(ctx.columns.primary).toEqual({
         _id: "four",
         _instanceName: "four",
-        active: true,
+        active: false,
         columnType: "foo",
         componentName: "@budibase/standard-components/labelfield",
         field: "four",
@@ -356,7 +356,7 @@ describe("getColumns", () => {
           {
             field: "four",
             label: "four",
-            active: true,
+            active: false,
           },
         ])
       })
@@ -386,7 +386,7 @@ describe("getColumns", () => {
           {
             _id: "two",
             _instanceName: "two",
-            active: false,
+            active: true,
             columnType: "foo",
             componentName: "@budibase/standard-components/labelfield",
             field: "two",
@@ -411,12 +411,12 @@ describe("getColumns", () => {
           {
             field: "two",
             label: "two",
-            active: false,
+            active: true,
           },
           {
             field: "four",
             label: "four",
-            active: true,
+            active: false,
           },
         ])
       })


### PR DESCRIPTION
## Description
Within the Design view, sometimes you want to hide the primary display field.

## Addresses
- https://github.com/Budibase/budibase/issues/12714
- https://linear.app/budibase/issue/BUDI-7872/allow-the-primary-display-column-to-be-hidden-for-the-grid-component

## Screenshots
https://github.com/user-attachments/assets/06c3132a-544d-469f-b955-9768a3f4f070

## Launchcontrol
Allow primary display field to be hidden in the Grid table component
