### PR TITLE
Default external table switcher to production

### DIFF
--- a/packages/builder/src/components/backend/DataTable/buttons/grid/GridDevProdSwitcher.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/GridDevProdSwitcher.svelte
@@ -28,7 +28,11 @@
     leftText: "Dev",
     rightIcon: "pulse",
     rightText: "Prod",
-    selected: (isDevMode ? "left" : "right") as "left" | "right",
+    selected: (disabled && !isInternal
+      ? "right"
+      : isDevMode
+        ? "left"
+        : "right") as "left" | "right",
     disabled,
   }
 

--- a/packages/builder/src/pages/builder/app/[application]/data/table/[tableId]/[viewId]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/table/[tableId]/[viewId]/index.svelte
@@ -4,6 +4,8 @@
     rowActions,
     dataEnvironmentStore,
     dataAPI,
+    tables,
+    datasources,
   } from "@/stores/builder"
   import { gridClipboard } from "@budibase/frontend-core"
   import { admin, themeStore, licensing } from "@/stores/portal"
@@ -22,6 +24,7 @@
   import GridDevProdSwitcher from "@/components/backend/DataTable/buttons/grid/GridDevProdSwitcher.svelte"
   import { ViewV2Type, DataEnvironmentMode, type Row } from "@budibase/types"
   import GridDevWarning from "@/components/backend/DataTable/alert/grid/GridDevWarning.svelte"
+  import { DB_TYPE_EXTERNAL } from "@/constants/backend"
 
   let generateButton: GridGenerateButton
 
@@ -33,10 +36,16 @@
     id,
     tableId: view?.tableId,
   }
+  $: isInternal = $tables.selected?.sourceType !== DB_TYPE_EXTERNAL
+  $: tableDatasource = $datasources.list.find(datasource => {
+    return datasource._id === $tables.selected?.sourceId
+  })
   $: buttons = makeRowActionButtons($rowActions[id])
   $: rowActions.refreshRowActions(id)
   $: currentTheme = $themeStore?.theme
   $: darkMode = !currentTheme.includes("light")
+  $: canSwitchToProduction =
+    isInternal || tableDatasource?.usesEnvironmentVariables
   $: isProductionMode =
     $dataEnvironmentStore.mode === DataEnvironmentMode.PRODUCTION
   $: externalClipboardData = {
@@ -107,7 +116,7 @@
       <GridDevProdSwitcher />
     </svelte:fragment>
     <GridCreateEditRowModal />
-    {#if !isProductionMode}
+    {#if !isProductionMode && canSwitchToProduction}
       <GridDevWarning />
     {/if}
   </Grid>

--- a/packages/builder/src/pages/builder/app/[application]/data/table/[tableId]/index.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/data/table/[tableId]/index.svelte
@@ -77,6 +77,8 @@
   $: darkMode = !currentTheme.includes("light")
   $: buttons = makeRowActionButtons($rowActions[id])
   $: rowActions.refreshRowActions(id)
+  $: canSwitchToProduction =
+    isInternal || tableDatasource?.usesEnvironmentVariables
   $: isProductionMode =
     $dataEnvironmentStore.mode === DataEnvironmentMode.PRODUCTION
   $: externalClipboardData = {
@@ -219,7 +221,7 @@
       {:else}
         <GridCreateEditRowModal />
       {/if}
-      {#if !isProductionMode}
+      {#if !isProductionMode && canSwitchToProduction}
         <GridDevWarning />
       {/if}
     </Grid>

--- a/packages/builder/src/stores/builder/dataEnvironment.ts
+++ b/packages/builder/src/stores/builder/dataEnvironment.ts
@@ -1,5 +1,5 @@
 import { DataEnvironmentMode } from "@budibase/types"
-import { BudiStore } from "../BudiStore"
+import { BudiStore, PersistenceType } from "../BudiStore"
 import { derived } from "svelte/store"
 import { API, productionAPI } from "@/api"
 
@@ -15,7 +15,12 @@ export const initialState: DataEnvironmentState = {
 
 export class DataEnvironmentStore extends BudiStore<DataEnvironmentState> {
   constructor() {
-    super(initialState)
+    super(initialState, {
+      persistence: {
+        type: PersistenceType.LOCAL,
+        key: "bb-data-environment",
+      },
+    })
 
     this.setMode = this.setMode.bind(this)
     this.toggleMode = this.toggleMode.bind(this)
@@ -43,10 +48,6 @@ export class DataEnvironmentStore extends BudiStore<DataEnvironmentState> {
       ...state,
       bannerHidden: true,
     }))
-  }
-
-  reset() {
-    this.set({ ...initialState })
   }
 }
 

--- a/packages/builder/src/stores/builder/index.ts
+++ b/packages/builder/src/stores/builder/index.ts
@@ -101,7 +101,6 @@ export const reset = () => {
   navigationStore.reset()
   rowActions.reset()
   workspaceDeploymentStore.reset()
-  dataEnvironmentStore.reset()
 }
 
 const refreshBuilderData = async () => {

--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -4,7 +4,6 @@ import {
   db as dbCore,
   events,
   cache,
-  features,
   errors,
 } from "@budibase/backend-core"
 import { DocumentType, getAutomationParams } from "../../../db/utils"
@@ -25,7 +24,6 @@ import {
   Automation,
   PublishAppRequest,
   PublishStatusResponse,
-  FeatureFlag,
 } from "@budibase/types"
 import sdk from "../../../sdk"
 import { builderSocket } from "../../../websockets"

--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -158,10 +158,6 @@ export async function deploymentProgress(
 }
 
 export async function publishStatus(ctx: UserCtx<void, PublishStatusResponse>) {
-  if (!(await features.isEnabled(FeatureFlag.WORKSPACE_APPS))) {
-    return (ctx.body = { automations: {}, workspaceApps: {}, tables: {} })
-  }
-
   const { automations, workspaceApps, tables } = await sdk.deployment.status()
 
   ctx.body = {


### PR DESCRIPTION
## Description
If an external datasource doesn't contain any environment variables then the switcher will be shown but default to production. It still has the tooltip to tell the users how to switch to development.

I've also added persistence on a per browser basis for the banner/switcher state, so that users can get rid of the banner permanently. 