### PR TITLE
[BUDI-16769] Fix "Visit the Docs" link to open in new tab

### DIFF
--- a/packages/builder/src/components/backend/DataTable/alert/grid/GridDevWarning.svelte
+++ b/packages/builder/src/components/backend/DataTable/alert/grid/GridDevWarning.svelte
@@ -13,7 +13,12 @@
       <span>
         You're currently in Dev, so you can test things out without affecting
         real users. Switch to Prod to view/edit live data.
-        <a href="https://docs.budibase.com/docs/dev-prod-switcher" class="link">
+        <a
+          href="https://docs.budibase.com/docs/dev-prod-switcher"
+          class="link"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           Visit the Docs ↗
         </a>
       </span>


### PR DESCRIPTION

## Description
Updated the documentation link in GridDevWarning component to include target="_blank" and rel="noopener noreferrer" attributes so it opens in a new tab as expected by users.

## Addresses
- https://linear.app/budibase/issue/BUDI-9574/link-should-open-in-new-tab
- https://github.com/Budibase/budibase/issues/16769

## Launchcontrol
Open visit docs link in new tab
