### PR TITLE
Workspace index page fixes

### DIFF
--- a/packages/builder/src/pages/builder/app/[application]/_components/SideNav/SideNavUserSettings.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/_components/SideNav/SideNavUserSettings.svelte
@@ -28,7 +28,7 @@
 </script>
 
 {#if user}
-  <UserDropdown align={PopoverAlignment.RightOutside} let:open>
+  <UserDropdown align={PopoverAlignment.RightOutside} let:open isPortal={false}>
     <SideNavLink text={name} {collapsed} forceActive={open}>
       <UserAvatar slot="icon" size="XS" {user} showTooltip={false} />
     </SideNavLink>

--- a/packages/builder/src/pages/builder/app/[application]/automation/_flagged/index.new.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/automation/_flagged/index.new.svelte
@@ -214,7 +214,18 @@
       {/each}
     </div>
     <div class="action-buttons">
-      <Button icon="lightbulb" secondary>Learn</Button>
+      <Button
+        icon="lightbulb"
+        secondary
+        on:click={() => {
+          window.open(
+            "https://docs.budibase.com/docs/automation-steps",
+            "_blank"
+          )
+        }}
+      >
+        Learn
+      </Button>
       <Button cta icon="plus" on:click={createModal.show}>
         New automation
       </Button>

--- a/packages/builder/src/pages/builder/app/[application]/design/_flagged/index.new.svelte
+++ b/packages/builder/src/pages/builder/app/[application]/design/_flagged/index.new.svelte
@@ -221,7 +221,26 @@
     </div>
 
     <div class="action-buttons">
-      <Button icon="lightbulb" secondary>Learn</Button>
+      <Button
+        icon="squares-four"
+        secondary
+        on:click={() => {
+          window.open("/builder/apps", "_blank")
+        }}
+        >View apps portal
+      </Button>
+      <Button
+        icon="lightbulb"
+        secondary
+        on:click={() => {
+          window.open(
+            "https://docs.budibase.com/docs/app-building-101",
+            "_blank"
+          )
+        }}
+      >
+        Learn
+      </Button>
       <Button cta icon="plus" on:click={createApp}>New app</Button>
     </div>
   </div>

--- a/packages/builder/src/pages/builder/portal/_components/UserDropdown.svelte
+++ b/packages/builder/src/pages/builder/portal/_components/UserDropdown.svelte
@@ -10,6 +10,7 @@
   import { API } from "@/api"
 
   export let align = "right"
+  export let isPortal = true
 
   let themeModal
   let profileModal
@@ -60,9 +61,11 @@
   <MenuItem icon="key" on:click={() => apiKeyModal.show()}>
     View API key
   </MenuItem>
-  <MenuItem icon="code" on:click={() => $goto("../apps")}>
-    Close developer mode
-  </MenuItem>
+  {#if isPortal}
+    <MenuItem icon="code" on:click={() => $goto("/builder/apps")}>
+      Close developer mode
+    </MenuItem>
+  {/if}
   <MenuItem icon="sign-out" on:click={logout}>Log out</MenuItem>
 </ActionMenu>
 


### PR DESCRIPTION
## Description

- Added documentation links to app and automation pages that open in a new tab.
- Added `View portal` button to the apps index page header that opens the user app portal in a new tab.
- Hide the `Close developer mode` option in the builder