### PR TITLE
Enrich data on posthog flags

### DIFF
--- a/packages/backend-core/src/events/identification.ts
+++ b/packages/backend-core/src/events/identification.ts
@@ -268,6 +268,7 @@ export const getUniqueTenantId = async (tenantId: string): Promise<string> => {
       } else {
         uniqueTenantId = `${newid()}_${tenantId}`
         config.config.uniqueTenantId = uniqueTenantId
+        config.config.createdVersion = env.VERSION
         await db.put(config)
         return uniqueTenantId
       }

--- a/packages/backend-core/src/features/features.ts
+++ b/packages/backend-core/src/features/features.ts
@@ -145,19 +145,31 @@ export class FlagSet<T extends { [name: string]: boolean }> {
 
         const config = await configs.getSettingsConfigDoc()
         const personProperties: Record<string, string> = { tenantId }
+
+        const groupProperties: {
+          tenant: {
+            id: string
+            createdVersion?: string
+            createdAt?: string
+          }
+        } = {
+          tenant: {
+            id: tenantId,
+          },
+        }
+        if (config.config.createdVersion) {
+          groupProperties.tenant.createdVersion = config.config.createdVersion
+        }
+        if (config.createdAt) {
+          groupProperties.tenant.createdAt = `${config.createdAt}`
+        }
         const posthogFlags = await posthog.getAllFlags(userId, {
           personProperties,
           onlyEvaluateLocally: true,
           groups: {
             tenant: tenantId,
           },
-          groupProperties: {
-            tenant: {
-              id: tenantId,
-              createdVersion: config.config.createdVersion,
-              createdAt: `${config.createdAt ?? ""} `,
-            },
-          },
+          groupProperties,
         })
 
         for (const [name, value] of Object.entries(posthogFlags)) {

--- a/packages/backend-core/src/features/features.ts
+++ b/packages/backend-core/src/features/features.ts
@@ -6,6 +6,7 @@ import tracer from "dd-trace"
 import { Duration } from "../utils"
 import { cloneDeep } from "lodash"
 import { FeatureFlagDefaults } from "@budibase/types"
+import * as configs from "../configs"
 
 let posthog: PostHog | undefined
 export function init(opts?: PostHogOptions) {
@@ -142,10 +143,21 @@ export class FlagSet<T extends { [name: string]: boolean }> {
       if (posthog && userId) {
         tags[`readFromPostHog`] = true
 
+        const config = await configs.getSettingsConfigDoc()
         const personProperties: Record<string, string> = { tenantId }
         const posthogFlags = await posthog.getAllFlags(userId, {
           personProperties,
           onlyEvaluateLocally: true,
+          groups: {
+            tenant: tenantId,
+          },
+          groupProperties: {
+            tenant: {
+              id: tenantId,
+              createdVersion: config.config.createdVersion,
+              createdAt: `${config.createdAt ?? ""} `,
+            },
+          },
         })
 
         for (const [name, value] of Object.entries(posthogFlags)) {

--- a/packages/types/src/documents/global/config.ts
+++ b/packages/types/src/documents/global/config.ts
@@ -46,7 +46,7 @@ export interface SettingsInnerConfig {
   uniqueTenantId?: string
   analyticsEnabled?: boolean
   isSSOEnforced?: boolean
-  createdVersion: string
+  createdVersion?: string
 }
 
 export interface SettingsConfig extends Config<SettingsInnerConfig> {}

--- a/packages/types/src/documents/global/config.ts
+++ b/packages/types/src/documents/global/config.ts
@@ -46,6 +46,7 @@ export interface SettingsInnerConfig {
   uniqueTenantId?: string
   analyticsEnabled?: boolean
   isSSOEnforced?: boolean
+  createdVersion: string
 }
 
 export interface SettingsConfig extends Config<SettingsInnerConfig> {}


### PR DESCRIPTION
## Description
As we are using `onlyEvaluateLocally`, we can't access the data that posthog has about the users. For this, we are passing the createdVersion and createdAt added [here](https://github.com/Budibase/budibase/pull/16780) in order to be used