### PR TITLE
Budibase AI fix

### DIFF
--- a/packages/backend-core/src/features/features.ts
+++ b/packages/backend-core/src/features/features.ts
@@ -7,7 +7,6 @@ import { Duration } from "../utils"
 import { cloneDeep } from "lodash"
 import { FeatureFlagDefaults } from "@budibase/types"
 import * as configs from "../configs"
-import { isSelfHostUsingCloud } from "../context"
 
 let posthog: PostHog | undefined
 export function init(opts?: PostHogOptions) {

--- a/packages/backend-core/src/features/features.ts
+++ b/packages/backend-core/src/features/features.ts
@@ -7,6 +7,7 @@ import { Duration } from "../utils"
 import { cloneDeep } from "lodash"
 import { FeatureFlagDefaults } from "@budibase/types"
 import * as configs from "../configs"
+import { isSelfHostUsingCloud } from "../context"
 
 let posthog: PostHog | undefined
 export function init(opts?: PostHogOptions) {
@@ -93,6 +94,11 @@ export class FlagSet<T extends { [name: string]: boolean }> {
       const flagValues = this.defaults()
       const currentTenantId = context.getTenantId()
       const specificallySetFalse = new Set<string>()
+
+      // flags can't be worked out is self hoster accessing the cloud - no global DB
+      if (context.isSelfHostUsingCloud()) {
+        return flagValues
+      }
 
       for (const { tenantId, key, value } of getEnvFlags()) {
         if (!tenantId || (tenantId !== "*" && tenantId !== currentTenantId)) {

--- a/packages/server/src/api/routes/ai.ts
+++ b/packages/server/src/api/routes/ai.ts
@@ -8,10 +8,7 @@ import { middleware } from "@budibase/pro"
 import recaptcha from "../../middleware/recaptcha"
 import { builderAdminRoutes, endpointGroupList } from "./endpointGroups"
 
-export const licensedRoutes = endpointGroupList.group(
-  middleware.licenseAuth,
-  recaptcha
-)
+export const licensedRoutes = endpointGroupList.group(middleware.licenseAuth)
 
 builderAdminRoutes
   .post("/api/ai/tables", ai.generateTables)
@@ -40,6 +37,7 @@ builderAdminRoutes
   .post("/api/ai/cron", ai.generateCronExpression)
   .post("/api/ai/js", ai.generateJs)
 
+// these are Budibase AI routes
 licensedRoutes
   .post("/api/ai/chat", ai.chatCompletion)
   .post("/api/ai/upload-file", ai.uploadFile)

--- a/packages/server/src/api/routes/ai.ts
+++ b/packages/server/src/api/routes/ai.ts
@@ -5,7 +5,6 @@ import {
   updateToolSourceValidator,
 } from "./utils/validators/agent"
 import { middleware } from "@budibase/pro"
-import recaptcha from "../../middleware/recaptcha"
 import { builderAdminRoutes, endpointGroupList } from "./endpointGroups"
 
 export const licensedRoutes = endpointGroupList.group(middleware.licenseAuth)


### PR DESCRIPTION
## Description
If self hoster accessing cloud - feature flags cannot be used due to the settings document, making default flags return in this scenario.

Looked on DD and realised there were calls to features.fetch as part of a new workspaces flag - rather than remove this flag from a middleware just return default flags so that the feature checks can still be used.