### PR TITLE
switches column icons out for number-icons

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -3328,7 +3328,7 @@
       },
       {
         "type": "select",
-        "label": "Layout",
+        "label": "Columns",
         "key": "span",
         "defaultValue": 6,
         "hidden": true,
@@ -3338,19 +3338,19 @@
           {
             "label": "1 column",
             "value": 6,
-            "barIcon": "Stop",
+            "barIcon": "number-square-one",
             "barTitle": "1 column"
           },
           {
             "label": "2 columns",
             "value": 3,
-            "barIcon": "ColumnTwoA",
+            "barIcon": "number-square-two",
             "barTitle": "2 columns"
           },
           {
             "label": "3 columns",
             "value": 2,
-            "barIcon": "ViewColumn",
+            "barIcon": "number-square-three",
             "barTitle": "3 columns"
           }
         ]
@@ -3446,7 +3446,7 @@
       },
       {
         "type": "select",
-        "label": "Layout",
+        "label": "Columns",
         "key": "span",
         "defaultValue": 6,
         "hidden": true,
@@ -3456,19 +3456,19 @@
           {
             "label": "1 column",
             "value": 6,
-            "barIcon": "Stop",
+            "barIcon": "number-square-one",
             "barTitle": "1 column"
           },
           {
             "label": "2 columns",
             "value": 3,
-            "barIcon": "ColumnTwoA",
+            "barIcon": "number-square-two",
             "barTitle": "2 columns"
           },
           {
             "label": "3 columns",
             "value": 2,
-            "barIcon": "ViewColumn",
+            "barIcon": "number-square-three",
             "barTitle": "3 columns"
           }
         ]
@@ -3548,7 +3548,7 @@
       },
       {
         "type": "select",
-        "label": "Layout",
+        "label": "Columns",
         "key": "span",
         "defaultValue": 6,
         "hidden": true,
@@ -3558,19 +3558,19 @@
           {
             "label": "1 column",
             "value": 6,
-            "barIcon": "Stop",
+            "barIcon": "number-square-one",
             "barTitle": "1 column"
           },
           {
             "label": "2 columns",
             "value": 3,
-            "barIcon": "ColumnTwoA",
+            "barIcon": "number-square-two",
             "barTitle": "2 columns"
           },
           {
             "label": "3 columns",
             "value": 2,
-            "barIcon": "ViewColumn",
+            "barIcon": "number-square-three",
             "barTitle": "3 columns"
           }
         ]
@@ -3650,7 +3650,7 @@
       },
       {
         "type": "select",
-        "label": "Layout",
+        "label": "Columns",
         "key": "span",
         "defaultValue": 6,
         "hidden": true,
@@ -3660,19 +3660,19 @@
           {
             "label": "1 column",
             "value": 6,
-            "barIcon": "Stop",
+            "barIcon": "number-square-one",
             "barTitle": "1 column"
           },
           {
             "label": "2 columns",
             "value": 3,
-            "barIcon": "ColumnTwoA",
+            "barIcon": "number-square-two",
             "barTitle": "2 columns"
           },
           {
             "label": "3 columns",
             "value": 2,
-            "barIcon": "ViewColumn",
+            "barIcon": "number-square-three",
             "barTitle": "3 columns"
           }
         ]
@@ -3872,7 +3872,7 @@
       },
       {
         "type": "select",
-        "label": "Layout",
+        "label": "Columns",
         "key": "span",
         "defaultValue": 6,
         "hidden": true,
@@ -3882,19 +3882,19 @@
           {
             "label": "1 column",
             "value": 6,
-            "barIcon": "Stop",
+            "barIcon": "number-square-one",
             "barTitle": "1 column"
           },
           {
             "label": "2 columns",
             "value": 3,
-            "barIcon": "ColumnTwoA",
+            "barIcon": "number-square-two",
             "barTitle": "2 columns"
           },
           {
             "label": "3 columns",
             "value": 2,
-            "barIcon": "ViewColumn",
+            "barIcon": "number-square-three",
             "barTitle": "3 columns"
           }
         ]
@@ -4088,7 +4088,7 @@
       },
       {
         "type": "select",
-        "label": "Layout",
+        "label": "Columns",
         "key": "span",
         "defaultValue": 6,
         "hidden": true,
@@ -4098,19 +4098,19 @@
           {
             "label": "1 column",
             "value": 6,
-            "barIcon": "Stop",
+            "barIcon": "number-square-one",
             "barTitle": "1 column"
           },
           {
             "label": "2 columns",
             "value": 3,
-            "barIcon": "ColumnTwoA",
+            "barIcon": "number-square-two",
             "barTitle": "2 columns"
           },
           {
             "label": "3 columns",
             "value": 2,
-            "barIcon": "ViewColumn",
+            "barIcon": "number-square-three",
             "barTitle": "3 columns"
           }
         ]
@@ -4221,7 +4221,7 @@
       },
       {
         "type": "select",
-        "label": "Layout",
+        "label": "Columns",
         "key": "span",
         "defaultValue": 6,
         "hidden": true,
@@ -4231,19 +4231,19 @@
           {
             "label": "1 column",
             "value": 6,
-            "barIcon": "Stop",
+            "barIcon": "number-square-one",
             "barTitle": "1 column"
           },
           {
             "label": "2 columns",
             "value": 3,
-            "barIcon": "ColumnTwoA",
+            "barIcon": "number-square-two",
             "barTitle": "2 columns"
           },
           {
             "label": "3 columns",
             "value": 2,
-            "barIcon": "ViewColumn",
+            "barIcon": "number-square-three",
             "barTitle": "3 columns"
           }
         ]
@@ -4353,7 +4353,7 @@
       },
       {
         "type": "select",
-        "label": "Layout",
+        "label": "Columns",
         "key": "span",
         "defaultValue": 6,
         "hidden": true,
@@ -4363,19 +4363,19 @@
           {
             "label": "1 column",
             "value": 6,
-            "barIcon": "Stop",
+            "barIcon": "number-square-one",
             "barTitle": "1 column"
           },
           {
             "label": "2 columns",
             "value": 3,
-            "barIcon": "ColumnTwoA",
+            "barIcon": "number-square-two",
             "barTitle": "2 columns"
           },
           {
             "label": "3 columns",
             "value": 2,
-            "barIcon": "ViewColumn",
+            "barIcon": "number-square-three",
             "barTitle": "3 columns"
           }
         ]
@@ -4481,7 +4481,7 @@
       },
       {
         "type": "select",
-        "label": "Layout",
+        "label": "Columns",
         "key": "span",
         "defaultValue": 6,
         "hidden": true,
@@ -4491,19 +4491,19 @@
           {
             "label": "1 column",
             "value": 6,
-            "barIcon": "Stop",
+            "barIcon": "number-square-one",
             "barTitle": "1 column"
           },
           {
             "label": "2 columns",
             "value": 3,
-            "barIcon": "ColumnTwoA",
+            "barIcon": "number-square-two",
             "barTitle": "2 columns"
           },
           {
             "label": "3 columns",
             "value": 2,
-            "barIcon": "ViewColumn",
+            "barIcon": "number-square-three",
             "barTitle": "3 columns"
           }
         ]
@@ -4656,7 +4656,7 @@
       },
       {
         "type": "select",
-        "label": "Layout",
+        "label": "Columns",
         "key": "span",
         "defaultValue": 6,
         "hidden": true,
@@ -4666,19 +4666,19 @@
           {
             "label": "1 column",
             "value": 6,
-            "barIcon": "Stop",
+            "barIcon": "number-square-one",
             "barTitle": "1 column"
           },
           {
             "label": "2 columns",
             "value": 3,
-            "barIcon": "ColumnTwoA",
+            "barIcon": "number-square-two",
             "barTitle": "2 columns"
           },
           {
             "label": "3 columns",
             "value": 2,
-            "barIcon": "ViewColumn",
+            "barIcon": "number-square-three",
             "barTitle": "3 columns"
           }
         ]
@@ -5037,7 +5037,7 @@
       },
       {
         "type": "select",
-        "label": "Layout",
+        "label": "Columns",
         "key": "span",
         "defaultValue": 6,
         "hidden": true,
@@ -5047,19 +5047,19 @@
           {
             "label": "1 column",
             "value": 6,
-            "barIcon": "Stop",
+            "barIcon": "number-square-one",
             "barTitle": "1 column"
           },
           {
             "label": "2 columns",
             "value": 3,
-            "barIcon": "ColumnTwoA",
+            "barIcon": "number-square-two",
             "barTitle": "2 columns"
           },
           {
             "label": "3 columns",
             "value": 2,
-            "barIcon": "ViewColumn",
+            "barIcon": "number-square-three",
             "barTitle": "3 columns"
           }
         ]
@@ -5163,7 +5163,7 @@
       },
       {
         "type": "select",
-        "label": "Layout",
+        "label": "Columns",
         "key": "span",
         "defaultValue": 6,
         "hidden": true,
@@ -5173,19 +5173,19 @@
           {
             "label": "1 column",
             "value": 6,
-            "barIcon": "Stop",
+            "barIcon": "number-square-one",
             "barTitle": "1 column"
           },
           {
             "label": "2 columns",
             "value": 3,
-            "barIcon": "ColumnTwoA",
+            "barIcon": "number-square-two",
             "barTitle": "2 columns"
           },
           {
             "label": "3 columns",
             "value": 2,
-            "barIcon": "ViewColumn",
+            "barIcon": "number-square-three",
             "barTitle": "3 columns"
           }
         ]
@@ -5311,7 +5311,7 @@
       },
       {
         "type": "select",
-        "label": "Layout",
+        "label": "Columns",
         "key": "span",
         "defaultValue": 6,
         "hidden": true,
@@ -5321,19 +5321,19 @@
           {
             "label": "1 column",
             "value": 6,
-            "barIcon": "Stop",
+            "barIcon": "number-square-one",
             "barTitle": "1 column"
           },
           {
             "label": "2 columns",
             "value": 3,
-            "barIcon": "ColumnTwoA",
+            "barIcon": "number-square-two",
             "barTitle": "2 columns"
           },
           {
             "label": "3 columns",
             "value": 2,
-            "barIcon": "ViewColumn",
+            "barIcon": "number-square-three",
             "barTitle": "3 columns"
           }
         ]
@@ -5406,7 +5406,7 @@
       },
       {
         "type": "select",
-        "label": "Layout",
+        "label": "Columns",
         "key": "span",
         "defaultValue": 6,
         "hidden": true,
@@ -5416,19 +5416,19 @@
           {
             "label": "1 column",
             "value": 6,
-            "barIcon": "Stop",
+            "barIcon": "number-square-one",
             "barTitle": "1 column"
           },
           {
             "label": "2 columns",
             "value": 3,
-            "barIcon": "ColumnTwoA",
+            "barIcon": "number-square-two",
             "barTitle": "2 columns"
           },
           {
             "label": "3 columns",
             "value": 2,
-            "barIcon": "ViewColumn",
+            "barIcon": "number-square-three",
             "barTitle": "3 columns"
           }
         ]
@@ -8305,7 +8305,7 @@
       },
       {
         "type": "select",
-        "label": "Layout",
+        "label": "Columns",
         "key": "span",
         "defaultValue": 6,
         "hidden": true,
@@ -8315,19 +8315,19 @@
           {
             "label": "1 column",
             "value": 6,
-            "barIcon": "Stop",
+            "barIcon": "number-square-one",
             "barTitle": "1 column"
           },
           {
             "label": "2 columns",
             "value": 3,
-            "barIcon": "ColumnTwoA",
+            "barIcon": "number-square-two",
             "barTitle": "2 columns"
           },
           {
             "label": "3 columns",
             "value": 2,
-            "barIcon": "ViewColumn",
+            "barIcon": "number-square-three",
             "barTitle": "3 columns"
           }
         ]
@@ -8421,7 +8421,7 @@
       },
       {
         "type": "select",
-        "label": "Layout",
+        "label": "Columns",
         "key": "span",
         "defaultValue": 6,
         "hidden": true,
@@ -8431,19 +8431,19 @@
           {
             "label": "1 column",
             "value": 6,
-            "barIcon": "Stop",
+            "barIcon": "number-square-one",
             "barTitle": "1 column"
           },
           {
             "label": "2 columns",
             "value": 3,
-            "barIcon": "ColumnTwoA",
+            "barIcon": "number-square-two",
             "barTitle": "2 columns"
           },
           {
             "label": "3 columns",
             "value": 2,
-            "barIcon": "ViewColumn",
+            "barIcon": "number-square-three",
             "barTitle": "3 columns"
           }
         ]


### PR DESCRIPTION
## Description
The new Phosphor Icons do not have a relevant 3-column icon. Since the switch to Phosphor, we've used 2-column to show both 2-columns and 3-columns layouts in the form block.
<img width="459" height="110" alt="image" src="https://github.com/user-attachments/assets/143d755d-afc2-4121-9fa3-cc8978f42f36" />

This PR renamed the setting for "Layout" in favour of calling it "Columns" and simply displaying icons with "1" "2" "3"
<img width="303" height="216" alt="image" src="https://github.com/user-attachments/assets/799e22cd-5d21-4758-a030-3e7436339acc" />

Notably, these column-settings are present, but don't work on `JSON Field` and `Barcode/QR Scanner`, and are not present at all on the `Signature Field` - this could be something worth considering in future.

Also worth a mention: `Password Field` and `Rating Field` do not currently have data-types in the internal DB, and therefor cannot be populated into a `Form Block` 

## Addresses
https://github.com/Budibase/budibase/issues/16795

## App Export
[Columns Layout-export-1755765050507.tar.gz](https://github.com/user-attachments/files/21913704/Columns.Layout-export-1755765050507.tar.gz)

## Screenshots
<img width="658" height="496" alt="image" src="https://github.com/user-attachments/assets/d620d378-5cea-40fe-a83e-6c726b6d1d00" />


## Launchcontrol

_Fixes column icons in Form Block layout_