### PR TITLE
replaces incorrect icons in Button Group

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -466,13 +466,13 @@
               {
                 "label": "Column",
                 "value": "column",
-                "barIcon": "TableSelectColumn",
+                "barIcon": "rows-plus-bottom",
                 "barTitle": "Column layout"
               },
               {
                 "label": "Row",
                 "value": "row",
-                "barIcon": "TableSelectRow",
+                "barIcon": "columns-plus-right",
                 "barTitle": "Row layout"
               }
             ],


### PR DESCRIPTION
## Description
Replaced incorrect icons

Before:
<img width="214" height="127" alt="image" src="https://github.com/user-attachments/assets/fb895527-2bae-4569-bd11-5901602555ba" />

![Screen Recording 2025-08-21 at 10 05 17](https://github.com/user-attachments/assets/43218b9b-3ac7-4f0c-bb4e-d39ebf148352)


## Addresses
https://github.com/Budibase/budibase/issues/16774 

## Launchcontrol

_Fixed button group alignment icons._
