### PR TITLE
Always return navigation from workspace app

### DIFF
--- a/packages/builder/src/stores/builder/navigation.ts
+++ b/packages/builder/src/stores/builder/navigation.ts
@@ -3,7 +3,6 @@ import { API } from "@/api"
 import { appStore, workspaceAppStore } from "@/stores/builder"
 import { DerivedBudiStore } from "../BudiStore"
 import { AppNavigation, AppNavigationLink, UIObject } from "@budibase/types"
-import { featureFlags } from "../portal"
 import { notifications } from "@budibase/bbui"
 
 export interface AppNavigationStore extends AppNavigation {}
@@ -23,11 +22,8 @@ export class NavigationStore extends DerivedBudiStore<
   constructor() {
     const makeDerivedStore = (store: Writable<AppNavigationStore>) => {
       return derived(
-        [store, workspaceAppStore, featureFlags],
-        ([$store, $workspaceAppStore, $featureFlags]) => {
-          if (!$featureFlags.WORKSPACES) {
-            return $store
-          }
+        [store, workspaceAppStore],
+        ([$store, $workspaceAppStore]) => {
           const navigation = $workspaceAppStore.selectedWorkspaceApp?.navigation
 
           return {

--- a/packages/builder/src/stores/builder/navigation.ts
+++ b/packages/builder/src/stores/builder/navigation.ts
@@ -5,22 +5,20 @@ import { DerivedBudiStore } from "../BudiStore"
 import { AppNavigation, AppNavigationLink, UIObject } from "@budibase/types"
 import { notifications } from "@budibase/bbui"
 
-export interface AppNavigationStore extends AppNavigation {}
+export interface DerivedAppNavigationStore extends AppNavigation {}
 
-export const INITIAL_NAVIGATION_STATE: AppNavigationStore = {
+export const INITIAL_NAVIGATION_STATE: DerivedAppNavigationStore = {
   navigation: "Top",
   links: [],
   textAlign: "Left",
 }
 
-export interface DerivedAppNavigationStore extends AppNavigationStore {}
-
 export class NavigationStore extends DerivedBudiStore<
-  AppNavigationStore,
+  {},
   DerivedAppNavigationStore
 > {
   constructor() {
-    const makeDerivedStore = (store: Writable<AppNavigationStore>) => {
+    const makeDerivedStore = (store: Writable<{}>) => {
       return derived(
         [store, workspaceAppStore],
         ([$store, $workspaceAppStore]) => {
@@ -38,9 +36,17 @@ export class NavigationStore extends DerivedBudiStore<
   }
 
   syncAppNavigation(nav?: AppNavigation) {
+    workspaceAppStore.update(state => {
+      const selectedWorkspaceApp = state.workspaceApps.find(
+        a => a._id === state.selectedWorkspaceAppId
+      )
+      if (selectedWorkspaceApp && nav) {
+        selectedWorkspaceApp.navigation = nav
+      }
+      return state
+    })
     this.update(state => ({
       ...state,
-      ...nav,
     }))
   }
 
@@ -70,7 +76,7 @@ export class NavigationStore extends DerivedBudiStore<
     title: string
     roleId: string
   }) {
-    const navigation = get(this.store)
+    const navigation = get(this.derivedStore)
     let links: AppNavigationLink[] = [...(navigation?.links ?? [])]
 
     // Skip if we have an identical link
@@ -92,7 +98,7 @@ export class NavigationStore extends DerivedBudiStore<
   }
 
   async deleteLink(urls: string[] | string) {
-    const navigation = get(this.store)
+    const navigation = get(this.derivedStore)
     let links = navigation?.links
     if (!links?.length) {
       return

--- a/packages/builder/src/stores/builder/tests/navigation.test.js
+++ b/packages/builder/src/stores/builder/tests/navigation.test.js
@@ -5,7 +5,7 @@ import {
   INITIAL_NAVIGATION_STATE,
   NavigationStore,
 } from "@/stores/builder/navigation"
-import { appStore } from "@/stores/builder"
+import { appStore, workspaceAppStore } from "@/stores/builder"
 
 vi.mock("@/api", () => {
   return {
@@ -25,12 +25,15 @@ vi.mock("@/stores/builder", async () => {
     set: mockAppStore.set,
   }
 
+  const mockWorkspaceApp = {
+    _id: "mockWorkspaceAppId",
+    isDefault: true,
+    navigation: {},
+  }
   const mockWorkspaceAppStore = writable({
-    selectedWorkspaceApp: {
-      _id: "mockWorkspaceAppId",
-      isDefault: true,
-      navigation: null,
-    },
+    selectedWorkspaceAppId: mockWorkspaceApp._id,
+    selectedWorkspaceApp: mockWorkspaceApp,
+    workspaceApps: [mockWorkspaceApp],
   })
   const workspaceAppStore = {
     subscribe: mockWorkspaceAppStore.subscribe,
@@ -56,6 +59,11 @@ describe("Navigation store", () => {
       },
       navigationStore,
     }
+
+    workspaceAppStore.update(state => {
+      state.selectedWorkspaceApp.navigation.links = []
+      return state
+    })
   })
 
   it("Create base navigation store with defaults", ctx => {
@@ -82,10 +90,10 @@ describe("Navigation store", () => {
       },
     ]
 
-    ctx.test.navigationStore.update(state => ({
-      ...state,
-      links,
-    }))
+    workspaceAppStore.update(state => {
+      state.selectedWorkspaceApp.navigation.links = links
+      return state
+    })
 
     await ctx.test.navigationStore.addLink({
       url: "/test-url",
@@ -108,16 +116,16 @@ describe("Navigation store", () => {
   })
 
   it("Skip save if the link already exists", async ctx => {
-    ctx.test.navigationStore.update(state => ({
-      ...state,
-      links: [
+    workspaceAppStore.update(state => {
+      state.selectedWorkspaceApp.navigation.links = [
         {
           url: "/home",
           text: "Home",
           type: "link",
         },
-      ],
-    }))
+      ]
+      return state
+    })
     const saveSpy = vi
       .spyOn(ctx.test.navigationStore, "save")
       .mockImplementation(() => {})
@@ -132,9 +140,8 @@ describe("Navigation store", () => {
   })
 
   it("Should delete all links matching the provided URLs string array", async ctx => {
-    ctx.test.navigationStore.update(state => ({
-      ...state,
-      links: [
+    workspaceAppStore.update(state => {
+      state.selectedWorkspaceApp.navigation.links = [
         {
           url: "/home",
           text: "Home",
@@ -156,8 +163,9 @@ describe("Navigation store", () => {
             },
           ],
         },
-      ],
-    }))
+      ]
+      return state
+    })
 
     const saveSpy = vi
       .spyOn(ctx.test.navigationStore, "save")
@@ -197,10 +205,10 @@ describe("Navigation store", () => {
       },
     ]
 
-    ctx.test.navigationStore.update(state => ({
-      ...state,
-      links,
-    }))
+    workspaceAppStore.update(state => {
+      state.selectedWorkspaceApp.navigation.links = links
+      return state
+    })
 
     const saveSpy = vi
       .spyOn(ctx.test.navigationStore, "save")
@@ -240,9 +248,8 @@ describe("Navigation store", () => {
       appId: "testing_123",
     }))
 
-    ctx.test.navigationStore.update(state => ({
-      ...state,
-      links: [
+    workspaceAppStore.update(state => {
+      state.selectedWorkspaceApp.navigation.links = [
         {
           url: "/home",
           text: "Home",
@@ -259,8 +266,9 @@ describe("Navigation store", () => {
             },
           ],
         },
-      ],
-    }))
+      ]
+      return state
+    })
 
     // Build the update to add 1 new link
     const update = {


### PR DESCRIPTION
## Description
We stopped saving the navigation on the application level itself, using the application one instead. We had a small bug that this was not properly reflected with the workspaces flag off in the builder.
This PR ensures that the right nav is displayed

## Launchcontrol
Fixing display app navigation in the builder