### PR TITLE
Cleanup matched workspace app code

### DIFF
--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -323,7 +323,7 @@ export async function fetchAppPackage(
       ? new URL(ctx.headers.referer).pathname
       : ""
 
-    const [matchedWorkspaceApp] =
+    const matchedWorkspaceApp =
       await sdk.workspaceApps.getMatchedWorkspaceApp(urlPath)
 
     // disabled workspace apps should appear to not exist

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -220,9 +220,7 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
   try {
     context.getAppDB({ skip_setup: true })
 
-    const [workspaceApp] = await sdk.workspaceApps.getMatchedWorkspaceApp(
-      ctx.url
-    )
+    const workspaceApp = await sdk.workspaceApps.getMatchedWorkspaceApp(ctx.url)
 
     const appInfo = await sdk.applications.metadata.get()
     const hideDevTools = !!ctx.params.appUrl

--- a/packages/server/src/sdk/app/workspaceApps/tests/utils.spec.ts
+++ b/packages/server/src/sdk/app/workspaceApps/tests/utils.spec.ts
@@ -40,7 +40,7 @@ describe("workspaceApps utils", () => {
     closingChar => {
       it("should be able to get the base workspaceApp", async () => {
         await config.doInContext(config.getAppId(), async () => {
-          const [result] = await getMatchedWorkspaceApp(
+          const result = await getMatchedWorkspaceApp(
             `/${config.getAppId()}${closingChar}`
           )
           expect(result).toBeDefined()

--- a/packages/server/src/sdk/app/workspaceApps/tests/utils.spec.ts
+++ b/packages/server/src/sdk/app/workspaceApps/tests/utils.spec.ts
@@ -50,7 +50,7 @@ describe("workspaceApps utils", () => {
 
       it("should be able to get the a workspaceApp by its path", async () => {
         await config.doInContext(config.getAppId(), async () => {
-          const [result] = await getMatchedWorkspaceApp(
+          const result = await getMatchedWorkspaceApp(
             `/${config.getAppId()}/app${closingChar}`
           )
           expect(result).toBeDefined()
@@ -60,7 +60,7 @@ describe("workspaceApps utils", () => {
 
       it("should be able to get the a workspaceApp by its path for overlapping urls", async () => {
         await config.doInContext(config.getAppId(), async () => {
-          const [result] = await getMatchedWorkspaceApp(
+          const result = await getMatchedWorkspaceApp(
             `/${config.getAppId()}/app2${closingChar}`
           )
           expect(result).toBeDefined()
@@ -70,7 +70,7 @@ describe("workspaceApps utils", () => {
 
       it("should return undefined for partial matching paths", async () => {
         await config.doInContext(config.getAppId(), async () => {
-          const [result] = await getMatchedWorkspaceApp(
+          const result = await getMatchedWorkspaceApp(
             `/${config.getAppId()}/app22${closingChar}`
           )
           expect(result).toBeUndefined()

--- a/packages/server/src/sdk/app/workspaceApps/utils.ts
+++ b/packages/server/src/sdk/app/workspaceApps/utils.ts
@@ -2,7 +2,9 @@ import { WorkspaceApp } from "@budibase/types"
 import sdk from "../.."
 import { db } from "@budibase/backend-core"
 
-export async function getMatchedWorkspaceApp(fromUrl: string) {
+export async function getMatchedWorkspaceApp(
+  fromUrl: string
+): Promise<WorkspaceApp | undefined> {
   const app = await sdk.applications.metadata.get()
   const baseAppUrl = db.isProdAppID(app.appId)
     ? `/app/${app.url}`.replace("//", "/")
@@ -24,6 +26,6 @@ export async function getMatchedWorkspaceApp(fromUrl: string) {
     )
   }
 
-  const matchedWorkspaceApp = allWorkspaceApps.filter(isWorkspaceAppMatch)
+  const matchedWorkspaceApp = allWorkspaceApps.find(isWorkspaceAppMatch)
   return matchedWorkspaceApp
 }


### PR DESCRIPTION
## Description
We introduced the capacity of checking multiple workspace apps due a bug in the migration. Now that this has been fixed and we have a single default app, this can be removed