### PR TITLE
Remove noise around app migrations for unexisting apps

### DIFF
--- a/packages/server/src/appMigrations/index.ts
+++ b/packages/server/src/appMigrations/index.ts
@@ -47,6 +47,10 @@ export async function checkMissingMigrations(
     return next()
   }
 
+  if (!(await db.getDB(appId).exists())) {
+    return next()
+  }
+
   if (!(await isAppFullyMigrated(appId))) {
     const queue = getAppMigrationQueue()
     await queue.add(

--- a/packages/server/src/appMigrations/index.ts
+++ b/packages/server/src/appMigrations/index.ts
@@ -3,8 +3,9 @@ import { Next } from "koa"
 import { getAppMigrationVersion } from "./appMigrationMetadata"
 import { MIGRATIONS } from "./migrations"
 import { UserCtx } from "@budibase/types"
-import { db, Header } from "@budibase/backend-core"
+import { context, db, Header } from "@budibase/backend-core"
 import environment from "../environment"
+import sdk from "../sdk"
 
 export * from "./appMigrationMetadata"
 export * from "./migrationLock"
@@ -47,7 +48,11 @@ export async function checkMissingMigrations(
     return next()
   }
 
-  if (!(await db.getDB(appId).exists())) {
+  const appExists = await context.doInAppContext(
+    appId,
+    async () => !!(await sdk.applications.metadata.tryGet())
+  )
+  if (!appExists) {
     return next()
   }
 

--- a/packages/server/src/appMigrations/tests/migrations.spec.ts
+++ b/packages/server/src/appMigrations/tests/migrations.spec.ts
@@ -195,4 +195,30 @@ describe("migrations", () => {
     expect(ctx.response.set).not.toHaveBeenCalled()
     expect(mockNext).toHaveBeenCalled()
   })
+
+  describe("app existence check", () => {
+    beforeEach(() => {
+      migrations.MIGRATIONS.length = 0
+      migrations.MIGRATIONS.push({
+        id: "20231211101320_test",
+        func: migrationLogic(),
+      })
+    })
+
+    it("should skip migrations when app does not exist", async () => {
+      const config = setup.getConfig()
+      await config.init()
+
+      // Use a non-existent app ID
+      const nonExistentAppId = "app_nonexistent123456"
+
+      const mockNext = jest.fn()
+      const ctx = { response: { set: jest.fn() } } as any
+
+      await checkMissingMigrations(ctx, mockNext, nonExistentAppId)
+
+      expect(ctx.response.set).not.toHaveBeenCalled()
+      expect(mockNext).toHaveBeenCalled()
+    })
+  })
 })


### PR DESCRIPTION
## Description
The current behaviour of migrations checks if a specific app is the latest migration, if it's not queues a message to process it. These checks don't check if the app actually exists, so we are queueing messages for non-existent apps. This is logged in our Datadog, with some nonexistent apps trying to get migrated over and over:
<img width="1340" height="724" alt="image" src="https://github.com/user-attachments/assets/53e69aef-7a58-4ad7-b1fd-b62812b32e3d" />

This is possibly triggered by external calls like webhooks, as some of them are called every X minutes.


This change just checks if the app exists before attempting to migrate it. If it does not exist, don't do anything around migrations.
