### PR TITLE
Upgrade typescript and node types

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@babel/eslint-parser": "7.25.9",
     "@babel/preset-env": "^7.22.5",
     "@esbuild-plugins/tsconfig-paths": "^0.1.2",
-    "@types/node": "^22.15.3",
+    "@types/node": "22.18.0",
     "@types/proper-lockfile": "^4.1.4",
     "@typescript-eslint/parser": "8.17.0",
     "@vitest/eslint-plugin": "^1.1.14",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "svelte-check": "^4.1.5",
     "svelte-eslint-parser": "0.43.0",
     "svelte-preprocess": "^6.0.3",
-    "typescript": "5.7.2",
+    "typescript": "5.9.2",
     "typescript-eslint": "8.17.0",
     "update-dotenv": "1.1.1",
     "yargs": "^17.7.2"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@esbuild-plugins/tsconfig-paths": "^0.1.2",
     "@types/node": "22.18.0",
     "@types/proper-lockfile": "^4.1.4",
-    "@typescript-eslint/parser": "8.17.0",
+    "@typescript-eslint/parser": "8.41.0",
     "@vitest/eslint-plugin": "^1.1.14",
     "cross-spawn": "7.0.6",
     "depcheck": "^1.4.7",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -100,8 +100,7 @@
     "pino-pretty": "10.0.0",
     "pouchdb-adapter-memory": "7.2.2",
     "testcontainers": "10.16.0",
-    "timekeeper": "2.2.0",
-    "typescript": "5.7.2"
+    "timekeeper": "2.2.0"
   },
   "nx": {
     "targets": {

--- a/packages/backend-core/src/logging/system.ts
+++ b/packages/backend-core/src/logging/system.ts
@@ -76,6 +76,6 @@ export function getLogReadStream() {
 
   streams.push(fs.readFileSync(getFullPath(logsFileName)))
 
-  const combinedContent = Buffer.concat(streams)
+  const combinedContent = Buffer.concat(streams.map(stream => new Uint8Array(stream)))
   return combinedContent
 }

--- a/packages/backend-core/src/logging/system.ts
+++ b/packages/backend-core/src/logging/system.ts
@@ -76,6 +76,8 @@ export function getLogReadStream() {
 
   streams.push(fs.readFileSync(getFullPath(logsFileName)))
 
-  const combinedContent = Buffer.concat(streams.map(stream => new Uint8Array(stream)))
+  const combinedContent = Buffer.concat(
+    streams.map(stream => new Uint8Array(stream))
+  )
   return combinedContent
 }

--- a/packages/backend-core/src/security/encryption.ts
+++ b/packages/backend-core/src/security/encryption.ts
@@ -37,7 +37,7 @@ export function getSecret(secretOption: SecretOption): string {
 }
 
 function stretchString(secret: string, salt: Buffer) {
-  return crypto.pbkdf2Sync(secret, salt, ITERATIONS, STRETCH_LENGTH, "sha512")
+  return crypto.pbkdf2Sync(secret, new Uint8Array(salt), ITERATIONS, STRETCH_LENGTH, "sha512")
 }
 
 export function encrypt(
@@ -46,10 +46,10 @@ export function encrypt(
 ) {
   const salt = crypto.randomBytes(SALT_LENGTH)
   const stretched = stretchString(getSecret(secretOption), salt)
-  const cipher = crypto.createCipheriv(ALGO, stretched, salt)
-  const base = cipher.update(input)
+  const cipher = crypto.createCipheriv(ALGO, new Uint8Array(stretched), new Uint8Array(salt))
+  const base = cipher.update(input, 'utf8')
   const final = cipher.final()
-  const encrypted = Buffer.concat([base, final]).toString("hex")
+  const encrypted = Buffer.concat([new Uint8Array(base), new Uint8Array(final)]).toString("hex")
   return `${salt.toString("hex")}${SEPARATOR}${encrypted}`
 }
 
@@ -60,10 +60,10 @@ export function decrypt(
   const [salt, encrypted] = input.split(SEPARATOR)
   const saltBuffer = Buffer.from(salt, "hex")
   const stretched = stretchString(getSecret(secretOption), saltBuffer)
-  const decipher = crypto.createDecipheriv(ALGO, stretched, saltBuffer)
-  const base = decipher.update(Buffer.from(encrypted, "hex"))
+  const decipher = crypto.createDecipheriv(ALGO, new Uint8Array(stretched), new Uint8Array(saltBuffer))
+  const base = decipher.update(encrypted, 'hex')
   const final = decipher.final()
-  return Buffer.concat([base, final]).toString()
+  return Buffer.concat([new Uint8Array(base), new Uint8Array(final)]).toString()
 }
 
 export async function encryptFile(
@@ -82,7 +82,7 @@ export async function encryptFile(
   const salt = crypto.randomBytes(SALT_LENGTH)
   const iv = crypto.randomBytes(IV_LENGTH)
   const stretched = stretchString(secret, salt)
-  const cipher = crypto.createCipheriv(ALGO, stretched, iv)
+  const cipher = crypto.createCipheriv(ALGO, new Uint8Array(stretched), new Uint8Array(iv))
 
   outputFile.write(salt)
   outputFile.write(iv)
@@ -124,7 +124,7 @@ export async function decryptFile(
   const outputFile = fs.createWriteStream(outputPath)
 
   const stretched = stretchString(secret, salt)
-  const decipher = crypto.createDecipheriv(ALGO, stretched, iv)
+  const decipher = crypto.createDecipheriv(ALGO, new Uint8Array(stretched), new Uint8Array(iv))
 
   const unzip = zlib.createGunzip()
 
@@ -171,7 +171,7 @@ function readBytes(stream: fs.ReadStream, length: number) {
         bytesRead += chunk.length
       }
 
-      resolve(Buffer.concat(data))
+      resolve(Buffer.concat(data.map(buf => new Uint8Array(buf))))
     })
 
     stream.on("end", () => {

--- a/packages/backend-core/src/security/encryption.ts
+++ b/packages/backend-core/src/security/encryption.ts
@@ -37,7 +37,13 @@ export function getSecret(secretOption: SecretOption): string {
 }
 
 function stretchString(secret: string, salt: Buffer) {
-  return crypto.pbkdf2Sync(secret, new Uint8Array(salt), ITERATIONS, STRETCH_LENGTH, "sha512")
+  return crypto.pbkdf2Sync(
+    secret,
+    new Uint8Array(salt),
+    ITERATIONS,
+    STRETCH_LENGTH,
+    "sha512"
+  )
 }
 
 export function encrypt(
@@ -46,10 +52,17 @@ export function encrypt(
 ) {
   const salt = crypto.randomBytes(SALT_LENGTH)
   const stretched = stretchString(getSecret(secretOption), salt)
-  const cipher = crypto.createCipheriv(ALGO, new Uint8Array(stretched), new Uint8Array(salt))
-  const base = cipher.update(input, 'utf8')
+  const cipher = crypto.createCipheriv(
+    ALGO,
+    new Uint8Array(stretched),
+    new Uint8Array(salt)
+  )
+  const base = cipher.update(input, "utf8")
   const final = cipher.final()
-  const encrypted = Buffer.concat([new Uint8Array(base), new Uint8Array(final)]).toString("hex")
+  const encrypted = Buffer.concat([
+    new Uint8Array(base),
+    new Uint8Array(final),
+  ]).toString("hex")
   return `${salt.toString("hex")}${SEPARATOR}${encrypted}`
 }
 
@@ -60,8 +73,12 @@ export function decrypt(
   const [salt, encrypted] = input.split(SEPARATOR)
   const saltBuffer = Buffer.from(salt, "hex")
   const stretched = stretchString(getSecret(secretOption), saltBuffer)
-  const decipher = crypto.createDecipheriv(ALGO, new Uint8Array(stretched), new Uint8Array(saltBuffer))
-  const base = decipher.update(encrypted, 'hex')
+  const decipher = crypto.createDecipheriv(
+    ALGO,
+    new Uint8Array(stretched),
+    new Uint8Array(saltBuffer)
+  )
+  const base = decipher.update(encrypted, "hex")
   const final = decipher.final()
   return Buffer.concat([new Uint8Array(base), new Uint8Array(final)]).toString()
 }
@@ -82,7 +99,11 @@ export async function encryptFile(
   const salt = crypto.randomBytes(SALT_LENGTH)
   const iv = crypto.randomBytes(IV_LENGTH)
   const stretched = stretchString(secret, salt)
-  const cipher = crypto.createCipheriv(ALGO, new Uint8Array(stretched), new Uint8Array(iv))
+  const cipher = crypto.createCipheriv(
+    ALGO,
+    new Uint8Array(stretched),
+    new Uint8Array(iv)
+  )
 
   outputFile.write(salt)
   outputFile.write(iv)
@@ -124,7 +145,11 @@ export async function decryptFile(
   const outputFile = fs.createWriteStream(outputPath)
 
   const stretched = stretchString(secret, salt)
-  const decipher = crypto.createDecipheriv(ALGO, new Uint8Array(stretched), new Uint8Array(iv))
+  const decipher = crypto.createDecipheriv(
+    ALGO,
+    new Uint8Array(stretched),
+    new Uint8Array(iv)
+  )
 
   const unzip = zlib.createGunzip()
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,6 @@
     "@types/jest": "29.5.5",
     "@types/node-fetch": "2.6.4",
     "@types/pouchdb": "^6.4.0",
-    "ts-node": "10.8.1",
-    "typescript": "5.7.2"
+    "ts-node": "10.8.1"
   }
 }

--- a/packages/client/src/utils/grid.ts
+++ b/packages/client/src/utils/grid.ts
@@ -186,7 +186,6 @@ export const gridLayout = (node: HTMLDivElement, metadata: GridMetadata) => {
     }
 
     // Apply all CSS variables to the wrapper
-    // @ts-expect-error TODO
     node.style = buildStyleString(vars)
 
     // Add a listener to select this node on click

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -174,7 +174,6 @@
     "timekeeper": "2.2.0",
     "ts-node": "10.8.1",
     "tsconfig-paths": "4.0.0",
-    "typescript": "5.7.2",
     "undici": "^5.28.4",
     "yargs": "^13.2.4",
     "zod": "^3.23.8"

--- a/packages/server/src/utilities/rowProcessor/utils.ts
+++ b/packages/server/src/utilities/rowProcessor/utils.ts
@@ -213,5 +213,5 @@ export function processDates<T extends Row | Row[]>(
     }
   }
 
-  return Array.isArray(inputRows) ? rows : rows[0]
+  return (Array.isArray(inputRows) ? rows : rows[0]) as T
 }

--- a/packages/shared-core/package.json
+++ b/packages/shared-core/package.json
@@ -19,8 +19,7 @@
     "cron-validate": "1.4.5"
   },
   "devDependencies": {
-    "rimraf": "3.0.2",
-    "typescript": "5.7.2"
+    "rimraf": "3.0.2"
   },
   "nx": {
     "targets": {

--- a/packages/string-templates/package.json
+++ b/packages/string-templates/package.json
@@ -40,7 +40,6 @@
     "rollup": "^4.9.6",
     "rollup-plugin-polyfill-node": "^0.13.0",
     "rollup-plugin-terser": "^7.0.2",
-    "ts-jest": "29.1.1",
-    "typescript": "5.7.2"
+    "ts-jest": "29.1.1"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -21,7 +21,6 @@
     "@types/redlock": "4.0.7",
     "koa-useragent": "^4.1.0",
     "rimraf": "3.0.2",
-    "typescript": "5.7.2",
     "zod": "^3.23.8"
   },
   "dependencies": {

--- a/packages/upgrade-tests/package.json
+++ b/packages/upgrade-tests/package.json
@@ -37,8 +37,7 @@
     "@types/semver": "^7.5.8",
     "@types/uuid": "^9.0.7",
     "jest": "29.7.0",
-    "ts-jest": "29.1.1",
-    "typescript": "5.7.2"
+    "ts-jest": "29.1.1"
   },
   "nx": {
     "targets": {

--- a/packages/upgrade-tests/src/api/application.ts
+++ b/packages/upgrade-tests/src/api/application.ts
@@ -29,7 +29,7 @@ export class ApplicationAPI {
     const form = new FormData()
 
     // Create a Blob from the buffer with the correct type
-    const blob = new Blob([fileBuffer], { type: "application/gzip" })
+    const blob = new Blob([new Uint8Array(fileBuffer)], { type: "application/gzip" })
 
     // Append the file
     form.append("fileToImport", blob, filename)

--- a/packages/upgrade-tests/src/api/application.ts
+++ b/packages/upgrade-tests/src/api/application.ts
@@ -29,7 +29,9 @@ export class ApplicationAPI {
     const form = new FormData()
 
     // Create a Blob from the buffer with the correct type
-    const blob = new Blob([new Uint8Array(fileBuffer)], { type: "application/gzip" })
+    const blob = new Blob([new Uint8Array(fileBuffer)], {
+      type: "application/gzip",
+    })
 
     // Append the file
     form.append("fileToImport", blob, filename)

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -94,8 +94,7 @@
     "superagent": "^10.1.1",
     "supertest": "6.3.3",
     "testcontainers": "10.16.0",
-    "timekeeper": "2.2.0",
-    "typescript": "5.7.2"
+    "timekeeper": "2.2.0"
   },
   "resolutions": {
     "@budibase/pro": "npm:@budibase/pro@latest"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19925,7 +19925,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -20017,7 +20026,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -20030,6 +20039,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -21088,7 +21104,12 @@ typescript-eslint@8.17.0:
     "@typescript-eslint/parser" "8.17.0"
     "@typescript-eslint/utils" "8.17.0"
 
-typescript@5.7.2, "typescript@>=3 < 6":
+typescript@5.9.2:
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
+  integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
+
+"typescript@>=3 < 6":
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
   integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
@@ -21883,7 +21904,7 @@ worker-farm@1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -21900,6 +21921,15 @@ wrap-ansi@^5.1.0:
     ansi-styles "^3.2.0"
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6462,6 +6462,26 @@
     "@typescript-eslint/visitor-keys" "8.17.0"
     debug "^4.3.4"
 
+"@typescript-eslint/parser@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.41.0.tgz#677f5b2b3fa947ee1eac4129220c051b1990d898"
+  integrity sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==
+  dependencies:
+    "@typescript-eslint/scope-manager" "8.41.0"
+    "@typescript-eslint/types" "8.41.0"
+    "@typescript-eslint/typescript-estree" "8.41.0"
+    "@typescript-eslint/visitor-keys" "8.41.0"
+    debug "^4.3.4"
+
+"@typescript-eslint/project-service@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.41.0.tgz#08ebf882d413a038926e73fda36e00c3dba84882"
+  integrity sha512-b8V9SdGBQzQdjJ/IO3eDifGpDBJfvrNTp2QD9P2BeqWTGrRibgfgIlBSw6z3b6R7dPzg752tOs4u/7yCLxksSQ==
+  dependencies:
+    "@typescript-eslint/tsconfig-utils" "^8.41.0"
+    "@typescript-eslint/types" "^8.41.0"
+    debug "^4.3.4"
+
 "@typescript-eslint/scope-manager@8.17.0":
   version "8.17.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.17.0.tgz#a3f49bf3d4d27ff8d6b2ea099ba465ef4dbcaa3a"
@@ -6469,6 +6489,19 @@
   dependencies:
     "@typescript-eslint/types" "8.17.0"
     "@typescript-eslint/visitor-keys" "8.17.0"
+
+"@typescript-eslint/scope-manager@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.41.0.tgz#c8aba12129cb9cead1f1727f58e6a0fcebeecdb5"
+  integrity sha512-n6m05bXn/Cd6DZDGyrpXrELCPVaTnLdPToyhBoFkLIMznRUQUEQdSp96s/pcWSQdqOhrgR1mzJ+yItK7T+WPMQ==
+  dependencies:
+    "@typescript-eslint/types" "8.41.0"
+    "@typescript-eslint/visitor-keys" "8.41.0"
+
+"@typescript-eslint/tsconfig-utils@8.41.0", "@typescript-eslint/tsconfig-utils@^8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.41.0.tgz#134dee36eb16cdd78095a20bca0516d10b5dda75"
+  integrity sha512-TDhxYFPUYRFxFhuU5hTIJk+auzM/wKvWgoNYOPcOf6i4ReYlOoYN8q1dV5kOTjNQNJgzWN3TUUQMtlLOcUgdUw==
 
 "@typescript-eslint/type-utils@8.17.0":
   version "8.17.0"
@@ -6495,6 +6528,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.17.0.tgz#ef84c709ef8324e766878834970bea9a7e3b72cf"
   integrity sha512-gY2TVzeve3z6crqh2Ic7Cr+CAv6pfb0Egee7J5UAVWCpVvDI/F71wNfolIim4FE6hT15EbpZFVUj9j5i38jYXA==
 
+"@typescript-eslint/types@8.41.0", "@typescript-eslint/types@^8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.41.0.tgz#9935afeaae65e535abcbcee95383fa649c64d16d"
+  integrity sha512-9EwxsWdVqh42afLbHP90n2VdHaWU/oWgbH2P0CfcNfdKL7CuKpwMQGjwev56vWu9cSKU7FWSu6r9zck6CVfnag==
+
 "@typescript-eslint/typescript-estree@8.17.0":
   version "8.17.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.17.0.tgz#40b5903bc929b1e8dd9c77db3cb52cfb199a2a34"
@@ -6508,6 +6546,22 @@
     minimatch "^9.0.4"
     semver "^7.6.0"
     ts-api-utils "^1.3.0"
+
+"@typescript-eslint/typescript-estree@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.41.0.tgz#7c9cff8b4334ce96f14e9689692e8cf426ce4d59"
+  integrity sha512-D43UwUYJmGhuwHfY7MtNKRZMmfd8+p/eNSfFe6tH5mbVDto+VQCayeAt35rOx3Cs6wxD16DQtIKw/YXxt5E0UQ==
+  dependencies:
+    "@typescript-eslint/project-service" "8.41.0"
+    "@typescript-eslint/tsconfig-utils" "8.41.0"
+    "@typescript-eslint/types" "8.41.0"
+    "@typescript-eslint/visitor-keys" "8.41.0"
+    debug "^4.3.4"
+    fast-glob "^3.3.2"
+    is-glob "^4.0.3"
+    minimatch "^9.0.4"
+    semver "^7.6.0"
+    ts-api-utils "^2.1.0"
 
 "@typescript-eslint/typescript-estree@^4.33.0":
   version "4.33.0"
@@ -6568,6 +6622,14 @@
   dependencies:
     "@typescript-eslint/types" "8.17.0"
     eslint-visitor-keys "^4.2.0"
+
+"@typescript-eslint/visitor-keys@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.41.0.tgz#16eb99b55d207f6688002a2cf425e039579aa9a9"
+  integrity sha512-+GeGMebMCy0elMNg67LRNoVnUFPIm37iu5CmHESVx56/9Jsfdpsvbv605DQ81Pi/x11IdKUsS5nzgTYbCQU9fg==
+  dependencies:
+    "@typescript-eslint/types" "8.41.0"
+    eslint-visitor-keys "^4.2.1"
 
 "@ungap/structured-clone@^1.2.0":
   version "1.2.0"
@@ -10651,6 +10713,11 @@ eslint-visitor-keys@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz#687bacb2af884fcdda8a6e7d65c606f46a14cd45"
   integrity sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==
+
+eslint-visitor-keys@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz#4cfea60fe7dd0ad8e816e1ed026c1d5251b512c1"
+  integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
 eslint@9.16.0:
   version "9.16.0"
@@ -20836,6 +20903,11 @@ ts-api-utils@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.3.0.tgz#4b490e27129f1e8e686b45cc4ab63714dc60eea1"
   integrity sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==
+
+ts-api-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.1.0.tgz#595f7094e46eed364c13fd23e75f9513d29baf91"
+  integrity sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==
 
 ts-graphviz@^1.5.0:
   version "1.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5929,7 +5929,7 @@
     "@types/node" "*"
     form-data "^4.0.0"
 
-"@types/node@*", "@types/node@>=10.0.0", "@types/node@>=13.13.4", "@types/node@>=13.7.0", "@types/node@>=18", "@types/node@^22.15.3":
+"@types/node@*", "@types/node@>=10.0.0", "@types/node@>=13.13.4", "@types/node@>=13.7.0", "@types/node@>=18":
   version "22.15.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.3.tgz#b7fb9396a8ec5b5dfb1345d8ac2502060e9af68b"
   integrity sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==
@@ -5940,6 +5940,13 @@
   version "16.9.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.1.tgz#0611b37db4246c937feef529ddcc018cf8e35708"
   integrity sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==
+
+"@types/node@22.18.0":
+  version "22.18.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.18.0.tgz#9e4709be4f104e3568f7dd1c71e2949bf147a47b"
+  integrity sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==
+  dependencies:
+    undici-types "~6.21.0"
 
 "@types/node@22.9.0":
   version "22.9.0"


### PR DESCRIPTION
## Description
While updating jest and node, I found some inconsistencies around some node api we use. This PR updates the typescript to the latest version, and aligns the node types to the ones used.
Pro PR:
- https://github.com/Budibase/budibase-pro/pull/454