### PR TITLE
fix for edit row modal not respecting prod/dev switcher setting

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditRow.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditRow.svelte
@@ -1,9 +1,8 @@
 <script>
   import { createEventDispatcher } from "svelte"
-  import { tables } from "@/stores/builder"
+  import { tables, dataAPI } from "@/stores/builder"
   import { ModalContent, keepOpen, notifications } from "@budibase/bbui"
   import RowFieldControl from "../RowFieldControl.svelte"
-  import { API } from "@/api"
   import { FIELDS } from "@/constants/backend"
 
   const FORMULA_TYPE = FIELDS.FORMULA.type
@@ -23,7 +22,7 @@
   async function saveRow() {
     errors = []
     try {
-      const res = await API.saveRow({ ...row, tableId: table._id })
+      const res = await $dataAPI.saveRow({ ...row, tableId: table._id })
       notifications.success("Row saved successfully")
       dispatch("updaterows", res._id)
     } catch (error) {


### PR DESCRIPTION
## Description
When editing a row from the modal, it was always saving back to dev even if you opened up the modal on a prod row. This meant that if there was no corresponding data in dev, you would get a _Row does not exist_ error. If there was corresponding data in dev, it would edit that and the production data would be unmodified.

<img width="1209" height="741" alt="SCR-20250827-hqtz" src="https://github.com/user-attachments/assets/b8356a13-90c0-4d6f-8011-f01b475e1e59" />


## Addresses
[BUDI-9599](https://linear.app/budibase/issue/BUDI-9599)

## Launchcontrol
fixes a prod/dev switcher bug when editing a row in the modal
