### PR TITLE
Fix for safari embeds

### DIFF
--- a/packages/client/src/api/api.ts
+++ b/packages/client/src/api/api.ts
@@ -5,6 +5,7 @@ import {
   devToolsEnabled,
   devToolsStore,
   recaptchaStore,
+  appStore,
 } from "../stores"
 import { get } from "svelte/store"
 
@@ -17,6 +18,13 @@ export const API = createAPIClient({
     // Attach app ID header
     if (window["##BUDIBASE_APP_ID##"]) {
       headers["x-budibase-app-id"] = window["##BUDIBASE_APP_ID##"]
+    }
+
+    // Attach the iframe location pathname to ensure the app url is fully preserved.
+    // Needed for workspace app resolution and client routing in an embed
+    const appData = get(appStore)
+    if (appData.embedded) {
+      headers["x-budibase-embed-location"] = window.location.pathname
     }
 
     // Attach client header if not inside the builder preview

--- a/packages/server/src/api/controllers/application.ts
+++ b/packages/server/src/api/controllers/application.ts
@@ -319,9 +319,13 @@ export async function fetchAppPackage(
     const accessController = new roles.AccessController()
     screens = await accessController.checkScreensAccess(screens, userRoleId)
 
-    const urlPath = ctx.headers.referer
-      ? new URL(ctx.headers.referer).pathname
-      : ""
+    const embedPath: string | undefined = ctx.request.get(
+      "x-budibase-embed-location"
+    )
+
+    const urlPath =
+      embedPath ||
+      (ctx.headers.referer ? new URL(ctx.headers.referer).pathname : "")
 
     const matchedWorkspaceApp =
       await sdk.workspaceApps.getMatchedWorkspaceApp(urlPath)

--- a/packages/server/src/api/controllers/routing.ts
+++ b/packages/server/src/api/controllers/routing.ts
@@ -76,7 +76,10 @@ export async function fetch(ctx: UserCtx<void, FetchScreenRoutingResponse>) {
 export async function clientFetch(
   ctx: UserCtx<void, FetchClientScreenRoutingResponse>
 ) {
-  const urlPath = getReferer(ctx)
+  const embedPath: string | undefined = ctx.request.get(
+    "x-budibase-embed-location"
+  )
+  const urlPath = embedPath || getReferer(ctx)
   const routing = await getRoutingStructure(urlPath)
   let roleId = ctx.user?.role?._id
   const roleIds = roleId ? await roles.getUserRoleIdHierarchy(roleId) : []


### PR DESCRIPTION
## Description
Cross-origin iframe requests within Safari quietly strip the `referer`.  Unfortunately, we used the `referer` header to extract the app url. This url was used to resolve the target workspace app and build the app routing. 

The behaviour has been modified now so that embedded apps will pass the frames location info to the server via a new header: `x-budibase-embed-location`. If this header is part of a client request it will now be used for app resolution. If the header isn't supplied, the server will attempt to default to the old `referer` header instead.

## Addresses
- https://github.com/Budibase/budibase/issues/16824

## Launchcontrol
Fix for CORS issue for embedded apps loaded via Safari.