### PR TITLE
Don't include query params if the binding value is empty

### DIFF
--- a/packages/server/src/api/routes/tests/queries/rest.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/rest.spec.ts
@@ -474,7 +474,8 @@ describe("rest", () => {
       readable: true,
       fields: {
         path: "www.example.com",
-        queryString: "emptyParam={{emptyParam}}&validParam={{validParam}}&anotherEmptyParam={{anotherEmptyParam}}",
+        queryString:
+          "emptyParam={{emptyParam}}&validParam={{validParam}}&anotherEmptyParam={{anotherEmptyParam}}",
       },
     })
 

--- a/packages/server/src/api/routes/tests/queries/rest.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/rest.spec.ts
@@ -454,4 +454,55 @@ describe("rest", () => {
 
     expect(mock.isDone()).toEqual(true)
   })
+
+  it("should remove empty query parameters from bindings", async () => {
+    const mock = nock("http://www.example.com")
+      .get("/?validParam=test")
+      .reply(200, { success: true })
+
+    await config.api.query.preview({
+      datasourceId: datasource._id!,
+      name: generator.guid(),
+      parameters: [
+        { name: "emptyParam", default: "" },
+        { name: "validParam", default: "test" },
+        { name: "anotherEmptyParam", default: "" },
+      ],
+      queryVerb: "read",
+      transformer: "",
+      schema: {},
+      readable: true,
+      fields: {
+        path: "www.example.com",
+        queryString: "emptyParam={{emptyParam}}&validParam={{validParam}}&anotherEmptyParam={{anotherEmptyParam}}",
+      },
+    })
+
+    expect(mock.isDone()).toEqual(true)
+  })
+
+  it("should handle query string with all empty bindings", async () => {
+    const mock = nock("http://www.example.com")
+      .get("/")
+      .reply(200, { success: true })
+
+    await config.api.query.preview({
+      datasourceId: datasource._id!,
+      name: generator.guid(),
+      parameters: [
+        { name: "emptyParam1", default: "" },
+        { name: "emptyParam2", default: "" },
+      ],
+      queryVerb: "read",
+      transformer: "",
+      schema: {},
+      readable: true,
+      fields: {
+        path: "www.example.com",
+        queryString: "emptyParam1={{emptyParam1}}&emptyParam2={{emptyParam2}}",
+      },
+    })
+
+    expect(mock.isDone()).toEqual(true)
+  })
 })

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -272,8 +272,23 @@ export class RestIntegration implements IntegrationBase {
     }
 
     if (queryString) {
-      // make sure the query string is fully encoded
-      queryString = "?" + qs.encode(qs.decode(queryString))
+      // decode the query string to get individual parameters
+      const decoded = qs.decode(queryString)
+
+      // filter out parameters with empty string values
+      const filtered: Record<string, string | string[]> = {}
+      for (const [key, value] of Object.entries(decoded)) {
+        if (value !== "" && value != null) {
+          filtered[key] = value
+        }
+      }
+
+      // only add query string if there are remaining parameters
+      if (Object.keys(filtered).length > 0) {
+        queryString = "?" + qs.encode(filtered)
+      } else {
+        queryString = ""
+      }
     }
     const main = `${path}${queryString}`
 

--- a/packages/server/src/integrations/tests/rest.spec.ts
+++ b/packages/server/src/integrations/tests/rest.spec.ts
@@ -648,7 +648,7 @@ describe("REST Integration", () => {
       nock("https://example.com")
         .get("/api?param2=value&param3=another")
         .reply(200, { success: true })
-      
+
       const { data } = await integration.read({
         path: "api",
         queryString: "param1=&param2=value&param3=another",
@@ -657,10 +657,8 @@ describe("REST Integration", () => {
     })
 
     it("should handle query string with only empty parameters", async () => {
-      nock("https://example.com")
-        .get("/api")
-        .reply(200, { success: true })
-      
+      nock("https://example.com").get("/api").reply(200, { success: true })
+
       const { data } = await integration.read({
         path: "api",
         queryString: "param1=&param2=",
@@ -672,7 +670,7 @@ describe("REST Integration", () => {
       nock("https://example.com")
         .get("/api?valid=test&another=123")
         .reply(200, { success: true })
-      
+
       const { data } = await integration.read({
         path: "api",
         queryString: "empty1=&valid=test&empty2=&another=123&empty3=",

--- a/packages/server/src/integrations/tests/rest.spec.ts
+++ b/packages/server/src/integrations/tests/rest.spec.ts
@@ -643,6 +643,42 @@ describe("REST Integration", () => {
       })
       expect(data).toEqual({ foo: "bar" })
     })
+
+    it("should remove empty query parameters", async () => {
+      nock("https://example.com")
+        .get("/api?param2=value&param3=another")
+        .reply(200, { success: true })
+      
+      const { data } = await integration.read({
+        path: "api",
+        queryString: "param1=&param2=value&param3=another",
+      })
+      expect(data).toEqual({ success: true })
+    })
+
+    it("should handle query string with only empty parameters", async () => {
+      nock("https://example.com")
+        .get("/api")
+        .reply(200, { success: true })
+      
+      const { data } = await integration.read({
+        path: "api",
+        queryString: "param1=&param2=",
+      })
+      expect(data).toEqual({ success: true })
+    })
+
+    it("should handle mixed empty and valid parameters", async () => {
+      nock("https://example.com")
+        .get("/api?valid=test&another=123")
+        .reply(200, { success: true })
+      
+      const { data } = await integration.read({
+        path: "api",
+        queryString: "empty1=&valid=test&empty2=&another=123&empty3=",
+      })
+      expect(data).toEqual({ success: true })
+    })
   })
 
   describe("Configuration options", () => {


### PR DESCRIPTION
## Description
I was running into external validation issues because empty strings were being passed through bindings into the query params.

The code has now been updated to remove query params that have empty string or null values.

## Addresses
- https://github.com/Budibase/budibase/issues/16859

## Launchcontrol
Empty bindings will now remove query params.
