### PR TITLE
fix: Proxy isn't stripping headers for apps service

### DIFF
--- a/hosting/proxy/nginx.prod.conf
+++ b/hosting/proxy/nginx.prod.conf
@@ -75,20 +75,45 @@ http {
     }
 
     location /app {
+      proxy_http_version  1.1;
+
+      proxy_set_header    Connection          $connection_upgrade;
+      proxy_set_header    Upgrade             $http_upgrade;
+      proxy_set_header    X-Real-IP           $remote_addr;
+      proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+      proxy_set_header    Host                $host;
+
       proxy_pass      $apps;
     }
 
     location /embed {
       rewrite /embed/(.*) /app/$1  break;
-      proxy_pass         $apps;
+
+      proxy_http_version  1.1;
       proxy_redirect     off;
-      proxy_set_header   Host $host;
-      proxy_set_header   x-budibase-embed "true";
+
+      proxy_set_header    Connection          $connection_upgrade;
+      proxy_set_header    Upgrade             $http_upgrade;
+      proxy_set_header    X-Real-IP           $remote_addr;
+      proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+      proxy_set_header    Host                $host;
+      proxy_set_header    x-budibase-embed    "true";
+
       add_header x-budibase-embed "true";
       add_header Content-Security-Policy "frame-ancestors *";
+
+      proxy_pass         $apps;
     }
 
     location = / {
+      proxy_http_version  1.1;
+
+      proxy_set_header    Connection          $connection_upgrade;
+      proxy_set_header    Upgrade             $http_upgrade;
+      proxy_set_header    X-Real-IP           $remote_addr;
+      proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+      proxy_set_header    Host                $host;
+
       proxy_pass      $apps;
     }
 
@@ -194,9 +219,6 @@ http {
 
     location /socket/ {
       proxy_http_version  1.1;
-      proxy_set_header    Upgrade     $http_upgrade;
-      proxy_set_header    Connection  'upgrade';
-      proxy_set_header    Host        $host;
       proxy_cache_bypass  $http_upgrade;
       proxy_pass      $apps;
     }


### PR DESCRIPTION
## Description
Ensures that the proxy isn't stripping client headers.

## Addresses
- proxy is disrupting some app features because it's not respecting client headers for all upstream services.
