### PR TITLE
Deny creators from inviting platform users

### DIFF
--- a/packages/worker/src/api/routes/global/roles.ts
+++ b/packages/worker/src/api/routes/global/roles.ts
@@ -1,7 +1,8 @@
 import * as controller from "../../controllers/global/roles"
-import { builderOrAdminRoutes } from "../endpointGroups"
+import { adminRoutes, builderOrAdminRoutes } from "../endpointGroups"
 
 builderOrAdminRoutes
   .get("/api/global/roles", controller.fetch)
   .get("/api/global/roles/:appId", controller.find)
-  .delete("/api/global/roles/:appId", controller.removeAppRole)
+
+adminRoutes.delete("/api/global/roles/:appId", controller.removeAppRole)

--- a/packages/worker/src/api/routes/global/users.ts
+++ b/packages/worker/src/api/routes/global/users.ts
@@ -1,13 +1,13 @@
-import * as controller from "../../controllers/global/users"
 import { auth } from "@budibase/backend-core"
 import Joi from "joi"
-import { users } from "../validation"
+import * as controller from "../../controllers/global/users"
 import {
-  loggedInRoutes,
-  cloudRestrictedRoutes,
-  builderOrAdminRoutes,
   adminRoutes,
+  builderOrAdminRoutes,
+  cloudRestrictedRoutes,
+  loggedInRoutes,
 } from "../endpointGroups"
+import { users } from "../validation"
 
 const OPTIONAL_STRING = Joi.string().optional().allow(null).allow("")
 
@@ -100,6 +100,10 @@ adminRoutes
 builderOrAdminRoutes
   .get("/api/global/users", controller.fetch)
   .get("/api/global/users/count/:appId", controller.countByApp)
+  .get("/api/global/users/invites", controller.getUserInvites)
+  .get("/api/global/users/:id", controller.find)
+
+adminRoutes
   .post("/api/global/users/invite", buildInviteValidation(), controller.invite)
   .post(
     "/api/global/users/onboard",
@@ -116,8 +120,6 @@ builderOrAdminRoutes
     controller.removeMultipleInvites
   )
   .post("/api/global/users/invite/update/:code", controller.updateInvite)
-  .get("/api/global/users/invites", controller.getUserInvites)
-  .get("/api/global/users/:id", controller.find)
 
 loggedInRoutes
   // search can be used by any user now, to retrieve users for user column

--- a/packages/worker/src/tests/TestConfiguration.ts
+++ b/packages/worker/src/tests/TestConfiguration.ts
@@ -7,37 +7,37 @@ mocks.licenses.init(mocks.pro)
 mocks.licenses.useUnlimited()
 
 import * as dbConfig from "../db"
-
-dbConfig.init()
 import env from "../environment"
 import * as controllers from "./controllers"
 
+dbConfig.init()
+
 import supertest from "supertest"
 
-import { Config } from "../constants"
 import {
-  users,
-  context,
-  sessions,
   constants,
+  context,
   env as coreEnv,
   db as dbCore,
   encryption,
+  sessions,
+  users,
   utils,
 } from "@budibase/backend-core"
-import structures, { CSRF_TOKEN } from "./structures"
 import {
-  SaveUserResponse,
-  User,
   AuthToken,
-  SCIMConfig,
   ConfigType,
+  SaveUserResponse,
+  SCIMConfig,
   SMTPConfig,
   SMTPInnerConfig,
+  User,
 } from "@budibase/types"
-import API from "./api"
-import jwt, { Secret } from "jsonwebtoken"
 import http from "http"
+import jwt, { Secret } from "jsonwebtoken"
+import { Config } from "../constants"
+import API from "./api"
+import structures, { CSRF_TOKEN } from "./structures"
 
 class TestConfiguration {
   server: http.Server<typeof http.IncomingMessage, typeof http.ServerResponse> =
@@ -223,11 +223,11 @@ class TestConfiguration {
     }
   }
 
-  async withUser(user: User, f: () => Promise<void>) {
+  async withUser<T>(user: User, f: () => Promise<T>): Promise<T> {
     const oldUser = this.user
     this.user = user
     try {
-      await f()
+      return await f()
     } finally {
       this.user = oldUser
     }


### PR DESCRIPTION
## Description
Prevent creators from inviting platform users via the API

## Launchcontrol
Deny creators from inviting platform users via the API