### PR TITLE
Add tooltip for views and tables

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/data/table/[tableId]/_components/ViewNavBar.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/table/[tableId]/_components/ViewNavBar.svelte
@@ -70,6 +70,8 @@
 
   $: overflowedViews = views.filter(view => !viewVisibiltyMap[view.id])
   $: viewHidden = viewVisibiltyMap[activeId] === false
+  $: tableName =
+    table?._id === TableNames.USERS ? "App users" : table?.name || ""
 
   const viewUrl = derived([url, params], ([$url, $params]) => viewId => {
     return $url(`../${$params.tableId}/${encodeURIComponent(viewId)}`)
@@ -238,11 +240,9 @@
     class:active={tableId === activeId}
     on:contextmenu={openTableContextMenu}
   >
-    <AbsTooltip
-      text={table?._id === TableNames.USERS ? "App users" : table?.name || ""}
-    >
+    <AbsTooltip text={tableName}>
       <div class="nav-item__title">
-        {table?._id === TableNames.USERS ? "App users" : table?.name || ""}
+        {tableName}
       </div>
     </AbsTooltip>
     {#if tableSelectedBy}

--- a/packages/builder/src/pages/builder/workspace/[application]/data/table/[tableId]/_components/ViewNavBar.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/table/[tableId]/_components/ViewNavBar.svelte
@@ -15,6 +15,7 @@
     ActionMenu,
     MenuItem,
     notifications,
+    AbsTooltip,
   } from "@budibase/bbui"
   import { params, url } from "@roxi/routify"
   import EditViewModal from "./EditViewModal.svelte"
@@ -237,9 +238,13 @@
     class:active={tableId === activeId}
     on:contextmenu={openTableContextMenu}
   >
-    <div class="nav-item__title">
-      {table?._id === TableNames.USERS ? "App users" : table?.name || ""}
-    </div>
+    <AbsTooltip
+      text={table?._id === TableNames.USERS ? "App users" : table?.name || ""}
+    >
+      <div class="nav-item__title">
+        {table?._id === TableNames.USERS ? "App users" : table?.name || ""}
+      </div>
+    </AbsTooltip>
     {#if tableSelectedBy}
       <UserAvatars size="XS" users={tableSelectedBy} />
     {/if}
@@ -295,9 +300,11 @@
           on:contextmenu={e => openViewContextMenu(e, view)}
           data-id={view.id}
         >
-          <div class="nav-item__title">
-            {view.name}
-          </div>
+          <AbsTooltip text={view.name}>
+            <div class="nav-item__title">
+              {view.name}
+            </div>
+          </AbsTooltip>
           {#if selectedBy}
             <UserAvatars size="XS" users={selectedBy} />
           {/if}


### PR DESCRIPTION
## Description
Long table and view names are truncated due to max-width constraints, making them hard to read.

This PR adds a hoverable tooltip (using the Abstooltip component) to display the whole table or view name.

## Addresses
- https://github.com/Budibase/budibase/issues/16885

## Screenshots
**Before**
<img width="611" height="191" alt="Screenshot 2025-09-04 at 09 00 23" src="https://github.com/user-attachments/assets/8e1fd0c2-6dea-453b-94f8-4e3b50c2451a" />

**After**
<img width="505" height="181" alt="Screenshot 2025-09-04 at 08 58 10" src="https://github.com/user-attachments/assets/2ba8faca-b0c4-49b2-83ae-db4102da8376" />

## Launchcontrol
Some table and view names are too long to show on screen, so they get cut off entirely.

This update makes it so that when you hover over a name, a small pop-up shows the full text.
