### PR TITLE
Explicit appid on preview urls

### DIFF
--- a/packages/backend-core/src/utils/tests/utils.spec.ts
+++ b/packages/backend-core/src/utils/tests/utils.spec.ts
@@ -96,28 +96,6 @@ describe("utils", () => {
       })
     })
 
-    it("gets appId from referer", async () => {
-      const ctx = structures.koa.newContext()
-      const expected = db.generateAppID()
-      ctx.request.headers = {
-        referer: `http://example.com/builder/workspace/${expected}/design/screen_123/screens`,
-      }
-
-      const actual = await utils.getAppIdFromCtx(ctx)
-      expect(actual).toBe(expected)
-    })
-
-    it("doesn't get appId from referer when not builder", async () => {
-      const ctx = structures.koa.newContext()
-      const appId = db.generateAppID()
-      ctx.request.headers = {
-        referer: `http://example.com/foo/app/${appId}/bar`,
-      }
-
-      const actual = await utils.getAppIdFromCtx(ctx)
-      expect(actual).toBe(undefined)
-    })
-
     it("throws 403 when header and body have different valid app IDs", async () => {
       const ctx = structures.koa.newContext()
 

--- a/packages/backend-core/src/utils/tests/utils.spec.ts
+++ b/packages/backend-core/src/utils/tests/utils.spec.ts
@@ -1,11 +1,11 @@
+import { Ctx } from "@budibase/types"
 import { structures } from "../../../tests"
 import { DBTestConfiguration } from "../../../tests/extra"
-import * as utils from "../../utils"
-import * as db from "../../db"
 import { Header } from "../../constants"
-import { newid } from "../../utils"
+import * as db from "../../db"
 import env from "../../environment"
-import { Ctx } from "@budibase/types"
+import * as utils from "../../utils"
+import { newid } from "../../utils"
 
 describe("utils", () => {
   const config = new DBTestConfiguration()
@@ -76,22 +76,24 @@ describe("utils", () => {
       expect(actual).toBe(expected)
     })
 
-    it("doesn't get appId from url when previewing", async () => {
-      const ctx = structures.koa.newContext()
-      const appId = db.generateAppID()
-      const app = structures.apps.app(appId)
+    it("should return proper appid if the app url is /preview", async () => {
+      await config.doInTenant(async () => {
+        const ctx = structures.koa.newContext()
+        const appId = db.generateAppID(config.tenantId)
+        const app = structures.apps.app(appId)
 
-      // set custom url
-      const appUrl = "preview"
-      app.url = `/${appUrl}`
-      ctx.path = `/app/${appUrl}`
+        // set custom url
+        const appUrl = "preview"
+        app.url = `/${appUrl}`
+        ctx.path = `/app/${appUrl}`
 
-      // save the app
-      const database = db.getDB(appId)
-      await database.put(app)
+        // save the app
+        const database = db.getDB(appId)
+        await database.put(app)
 
-      const actual = await utils.getAppIdFromCtx(ctx)
-      expect(actual).toBe(undefined)
+        const actual = await utils.getAppIdFromCtx(ctx)
+        expect(actual).toBe(appId)
+      })
     })
 
     it("gets appId from referer", async () => {
@@ -233,7 +235,7 @@ describe("utils", () => {
     })
 
     it("returns true if current path is in builder preview", async () => {
-      ctx.path = "/app/preview/xx"
+      ctx.path = "/app/app_dev_123456/preview"
       expectResult(true)
     })
 

--- a/packages/backend-core/src/utils/utils.ts
+++ b/packages/backend-core/src/utils/utils.ts
@@ -9,7 +9,7 @@ import type { SetOption } from "cookies"
 import jwt, { Secret } from "jsonwebtoken"
 import { DocumentType, Header, MAX_VALID_DATE, SEPARATOR } from "../constants"
 import * as context from "../context"
-import { getAllApps, getDevAppID } from "../db"
+import { getAllApps } from "../db"
 import env from "../environment"
 import * as tenancy from "../tenancy"
 
@@ -88,8 +88,7 @@ export async function getAppIdFromCtx(ctx: Ctx) {
       return appId
     }
 
-    if (appId && getDevAppID(appId) !== getDevAppID(possibleAppId)) {
-      // TODO: check dev/prod conflicts
+    if (appId && appId !== possibleAppId) {
       ctx.throw("App id conflict", 403)
     }
     return appId ?? possibleAppId

--- a/packages/backend-core/src/utils/utils.ts
+++ b/packages/backend-core/src/utils/utils.ts
@@ -130,15 +130,6 @@ export async function getAppIdFromCtx(ctx: Ctx) {
     appId = confirmAppId(await resolveAppUrl(ctx))
   }
 
-  // look in the referer - builder only
-  // make sure this is performed after prod app url resolution, in case the
-  // referer header is present from a builder redirect
-  const referer = ctx.request.headers.referer
-  if (referer?.includes(BUILDER_APP_PREFIX)) {
-    const refererId = parseAppIdFromUrlPath(ctx.request.headers.referer)
-    appId = confirmAppId(refererId)
-  }
-
   return appId
 }
 

--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/_components/AppPreview.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/_components/AppPreview.svelte
@@ -272,7 +272,7 @@
   <iframe
     title="componentPreview"
     bind:this={iframe}
-    src={`/app/${get(appStore).appId}/preview`}
+    src={`/app/${$appStore.appId}/preview`}
     class:hidden={loading || error}
   />
   <div class="underlay" />

--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/_components/AppPreview.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/_components/AppPreview.svelte
@@ -1,26 +1,26 @@
 <script>
-  import { get } from "svelte/store"
-  import { onMount, onDestroy } from "svelte"
-  import {
-    previewStore,
-    builderStore,
-    themeStore,
-    componentStore,
-    appStore,
-    navigationStore,
-    selectedScreen,
-    hoverStore,
-    componentTreeNodesStore,
-    screenComponentErrors,
-    snippets,
-  } from "@/stores/builder"
   import ConfirmDialog from "@/components/common/ConfirmDialog.svelte"
-  import { Layout, Heading, Body, Icon, notifications } from "@budibase/bbui"
-  import ErrorSVG from "@budibase/frontend-core/assets/error.svg?raw"
   import { findComponent, findComponentPath } from "@/helpers/components"
-  import { isActive, goto } from "@roxi/routify"
+  import {
+    appStore,
+    builderStore,
+    componentStore,
+    componentTreeNodesStore,
+    hoverStore,
+    navigationStore,
+    previewStore,
+    screenComponentErrors,
+    selectedScreen,
+    snippets,
+    themeStore,
+  } from "@/stores/builder"
+  import { Body, Heading, Icon, Layout, notifications } from "@budibase/bbui"
   import { ClientAppSkeleton } from "@budibase/frontend-core"
+  import ErrorSVG from "@budibase/frontend-core/assets/error.svg?raw"
   import { getThemeClassNames, ThemeClassPrefix } from "@budibase/shared-core"
+  import { goto, isActive } from "@roxi/routify"
+  import { onDestroy, onMount } from "svelte"
+  import { get } from "svelte/store"
 
   let iframe
   let layout
@@ -272,7 +272,7 @@
   <iframe
     title="componentPreview"
     bind:this={iframe}
-    src="/app/preview"
+    src={`/app/${get(appStore).appId}/preview`}
     class:hidden={loading || error}
   />
   <div class="underlay" />

--- a/packages/server/src/api/routes/static.ts
+++ b/packages/server/src/api/routes/static.ts
@@ -1,11 +1,11 @@
-import Router from "@koa/router"
-import * as controller from "../controllers/static"
-import recaptcha from "../../middleware/recaptcha"
-import { authorizedMiddleware as authorized } from "../../middleware/authorized"
 import { permissions } from "@budibase/backend-core"
-import { addFileManagement } from "../utils"
-import { paramResource } from "../../middleware/resourceId"
+import Router from "@koa/router"
 import { devAppIdPath } from "../../constants/paths"
+import { authorizedMiddleware as authorized } from "../../middleware/authorized"
+import recaptcha from "../../middleware/recaptcha"
+import { paramResource } from "../../middleware/resourceId"
+import * as controller from "../controllers/static"
+import { addFileManagement } from "../utils"
 
 const { BUILDER, PermissionType, PermissionLevel } = permissions
 
@@ -28,7 +28,11 @@ router
     authorized(PermissionType.TABLE, PermissionLevel.WRITE),
     controller.uploadFile
   )
-  .get("/app/preview", authorized(BUILDER), controller.serveBuilderPreview)
+  .get(
+    `/app/:appId/preview`,
+    authorized(BUILDER),
+    controller.serveBuilderPreview
+  )
   .get("/app/service-worker.js", controller.serveServiceWorker)
   .get("/app/:appUrl/:path*", controller.serveApp)
   .get(`/${devAppIdPath}/:path*`, controller.serveApp)

--- a/packages/server/src/api/routes/tests/application.spec.ts
+++ b/packages/server/src/api/routes/tests/application.spec.ts
@@ -34,7 +34,7 @@ import {
 import * as setup from "./utilities"
 import { checkBuilderEndpoint } from "./utilities/TestFunctions"
 
-describe("/applications (workspace apps flag)", () => {
+describe("/applications", () => {
   let config = setup.getConfig()
   let app: Workspace
 
@@ -609,7 +609,7 @@ describe("/applications (workspace apps flag)", () => {
       const res = await config.withHeaders(
         { referer: `http://localhost:10000/app${app.url}` },
         () =>
-          config.api.application.getAppPackage(app.appId, {
+          config.api.application.getAppPackage(config.getProdAppId(), {
             publicUser: true,
           })
       )
@@ -798,7 +798,7 @@ describe("/applications (workspace apps flag)", () => {
               },
               async () => {
                 const res = await config.api.application.getAppPackage(
-                  app.appId,
+                  config.getAppId(),
                   {
                     headers: {
                       [Header.TYPE]: "client",
@@ -1033,9 +1033,10 @@ describe("/applications (workspace apps flag)", () => {
     })
 
     it("app should not sync if production", async () => {
-      const { message } = await config.api.application.sync(
-        app.appId.replace("_dev", ""),
-        { status: 400 }
+      const { message } = await config.withProdApp(() =>
+        config.api.application.sync(app.appId.replace("_dev", ""), {
+          status: 400,
+        })
       )
 
       expect(message).toEqual(
@@ -1060,7 +1061,9 @@ describe("/applications (workspace apps flag)", () => {
     })
 
     it("should unpublish app with prod app ID", async () => {
-      await config.api.application.unpublish(app.appId.replace("_dev", ""))
+      await config.withProdApp(() =>
+        config.api.application.unpublish(app.appId.replace("_dev", ""))
+      )
       expect(events.app.unpublished).toHaveBeenCalledTimes(1)
     })
   })
@@ -1083,7 +1086,7 @@ describe("/applications (workspace apps flag)", () => {
         .delete(`/api/global/roles/${prodAppId}`)
         .reply(200, {})
 
-      await config.api.application.delete(prodAppId)
+      await config.withProdApp(() => config.api.application.delete(prodAppId))
       expect(events.app.deleted).toHaveBeenCalledTimes(1)
       expect(events.app.unpublished).toHaveBeenCalledTimes(1)
     })

--- a/packages/server/src/api/routes/tests/deploy.spec.ts
+++ b/packages/server/src/api/routes/tests/deploy.spec.ts
@@ -1,9 +1,9 @@
-import * as setup from "./utilities"
+import { db as dbCore } from "@budibase/backend-core"
 import { structures } from "@budibase/backend-core/tests"
+import { Automation, PublishResourceState, WorkspaceApp } from "@budibase/types"
 import { createAutomationBuilder } from "../../../automations/tests/utilities/AutomationTestBuilder"
 import { basicTable } from "../../../tests/utilities/structures"
-import { Automation, PublishResourceState, WorkspaceApp } from "@budibase/types"
-import { db as dbCore } from "@budibase/backend-core"
+import * as setup from "./utilities"
 
 describe("/api/deploy", () => {
   let config = setup.getConfig()
@@ -283,7 +283,7 @@ describe("/api/deploy", () => {
       await config.api.application.sync(config.getAppId())
     }
 
-    it("should define the disable value for all workspace apps when publishing for the first time (only when flag is true, workspace apps flag %s)", async () => {
+    it("should define the disable value for all workspace apps when publishing for the first time", async () => {
       const { workspaceApp: publishedApp } =
         await config.api.workspaceApp.create({
           name: "Test App 1",
@@ -322,7 +322,7 @@ describe("/api/deploy", () => {
       await expectApp(disabledApp).disabled(true, PublishResourceState.DISABLED)
     })
 
-    it("should define the disable value for all automations when publishing for the first time (only when flag is true, workspace apps flag %s)", async () => {
+    it("should define the disable value for all automations when publishing for the first time", async () => {
       const table = await config.api.table.save(basicTable())
 
       const { automation: disabledAutomation } = await createAutomationBuilder(

--- a/packages/server/src/api/routes/tests/static.spec.ts
+++ b/packages/server/src/api/routes/tests/static.spec.ts
@@ -1,7 +1,7 @@
+import { constants } from "@budibase/backend-core"
 import { Datasource, SourceName } from "@budibase/types"
 import { setEnv } from "../../../environment"
-import { getRequest, getConfig, afterAll as _afterAll } from "./utilities"
-import { constants } from "@budibase/backend-core"
+import { afterAll as _afterAll, getConfig, getRequest } from "./utilities"
 
 describe("/static", () => {
   let request = getRequest()
@@ -130,14 +130,17 @@ describe("/static", () => {
     })
   })
 
-  describe("/app/preview", () => {
+  describe("/app/:appId/preview", () => {
     beforeEach(() => {
       jest.clearAllMocks()
     })
 
     it("should serve the builder preview", async () => {
       const headers = config.defaultHeaders()
-      const res = await request.get(`/app/preview`).set(headers).expect(200)
+      const res = await request
+        .get(`/app/${config.getAppId()}/preview`)
+        .set(headers)
+        .expect(200)
 
       expect(res.body.appId).toBe(config.appId)
       expect(res.body.builderPreview).toBe(true)

--- a/packages/server/src/automations/tests/triggers/webhook.spec.ts
+++ b/packages/server/src/automations/tests/triggers/webhook.spec.ts
@@ -1,7 +1,7 @@
-import { Table, Webhook, WebhookActionType } from "@budibase/types"
-import { createAutomationBuilder } from "../utilities/AutomationTestBuilder"
 import { mocks } from "@budibase/backend-core/tests"
+import { Table, Webhook, WebhookActionType } from "@budibase/types"
 import TestConfiguration from "../../../tests/utilities/TestConfiguration"
+import { createAutomationBuilder } from "../utilities/AutomationTestBuilder"
 
 mocks.licenses.useSyncAutomations()
 
@@ -47,12 +47,10 @@ describe("Webhook trigger test", () => {
 
   it("should run the webhook automation - checking for parameters", async () => {
     const { webhook } = await createWebhookAutomation()
-    const res = await config.api.webhook.trigger(
-      config.getProdAppId(),
-      webhook._id!,
-      {
+    const res = await config.withProdApp(() =>
+      config.api.webhook.trigger(config.getProdAppId(), webhook._id!, {
         parameter: "testing",
-      }
+      })
     )
     expect(typeof res).toBe("object")
     const collectedInfo = res as Record<string, any>


### PR DESCRIPTION
## Description
Updating the way that appid checks work on builder preview. Until now we are inferring it from the referer, given that it is loaded from an iframe in the builder. This PR removes the referer checks, and adds explicit app ids, simplifying the checks and reducing complexity.

## Launchcontrol
Use explicit appid params in builder preview