### PR TITLE
adds better icon for closing sidepanel

### DIFF
--- a/packages/client/src/components/app/Layout.svelte
+++ b/packages/client/src/components/app/Layout.svelte
@@ -367,7 +367,7 @@
     <div class="side-panel-header">
       <Icon
         color="var(--spectrum-global-color-gray-600)"
-        name="sidebar"
+        name="caret-line-right"
         hoverable
         on:click={sidePanelStore.actions.close}
       />


### PR DESCRIPTION
## Description
It's not clear what the current close-side-panel icon does.

<img width="455" height="209" alt="image" src="https://github.com/user-attachments/assets/121f90ce-0965-41dc-8cea-2bd334e2cd1d" />

This PR replaces it with a Phosphor icon 'caret-line-right'
<img width="459" height="196" alt="image" src="https://github.com/user-attachments/assets/948692fa-7fdb-4596-8845-45cb593eb2b3" />

