### PR TITLE
Enable removing OIDC PKCE method setting

### DIFF
--- a/packages/worker/src/api/controllers/global/configs.ts
+++ b/packages/worker/src/api/controllers/global/configs.ts
@@ -1,18 +1,15 @@
-import * as email from "../../../utilities/email"
-import env from "../../../environment"
-import * as auth from "./auth"
 import {
   BadRequestError,
-  ForbiddenError,
   cache,
   configs,
-  db as dbCore,
   env as coreEnv,
+  db as dbCore,
   events,
+  ForbiddenError,
   objectStore,
   tenancy,
 } from "@budibase/backend-core"
-import { checkAnyUserExists } from "../../../utilities/users"
+import * as pro from "@budibase/pro"
 import {
   AIInnerConfig,
   Config,
@@ -44,7 +41,10 @@ import {
   UploadConfigFileResponse,
   UserCtx,
 } from "@budibase/types"
-import * as pro from "@budibase/pro"
+import env from "../../../environment"
+import * as email from "../../../utilities/email"
+import { checkAnyUserExists } from "../../../utilities/users"
+import * as auth from "./auth"
 
 const getEventFns = async (config: Config, existing?: Config) => {
   const fns = []
@@ -240,6 +240,8 @@ async function processOIDCConfig(config: OIDCConfigs, existing?: OIDCConfigs) {
   if (anyPkceSettings && !(await pro.features.isPkceOidcEnabled())) {
     throw new Error("License does not allow OIDC PKCE method support")
   }
+
+  config.configs.filter(c => c.pkce === null).forEach(c => delete c.pkce)
 
   if (existing) {
     for (const c of config.configs) {

--- a/packages/worker/src/api/routes/global/configs.ts
+++ b/packages/worker/src/api/routes/global/configs.ts
@@ -51,7 +51,7 @@ function oidcValidation() {
         uuid: Joi.string().required(),
         activated: Joi.boolean().required(),
         scopes: Joi.array().optional(),
-        pkce: Joi.string().valid(...Object.values(PKCEMethod)).optional()
+        pkce: Joi.string().valid(...Object.values(PKCEMethod)).optional().allow(null)
       })
     ).required()
   }).unknown(true)

--- a/packages/worker/src/api/routes/global/configs.ts
+++ b/packages/worker/src/api/routes/global/configs.ts
@@ -1,7 +1,7 @@
-import * as controller from "../../controllers/global/configs"
 import { auth } from "@budibase/backend-core"
-import Joi from "joi"
 import { ConfigType, PKCEMethod } from "@budibase/types"
+import Joi from "joi"
+import * as controller from "../../controllers/global/configs"
 import { adminRoutes, loggedInRoutes } from "../endpointGroups"
 
 function smtpValidation() {

--- a/packages/worker/src/api/routes/global/tests/configs.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/configs.spec.ts
@@ -1,9 +1,14 @@
 jest.mock("nodemailer")
-import { TestConfiguration, structures, mocks } from "../../../../tests"
+import { configs, events } from "@budibase/backend-core"
+import {
+  Config,
+  ConfigType,
+  GetPublicSettingsResponse,
+  PKCEMethod,
+} from "@budibase/types"
+import { TestConfiguration, mocks, structures } from "../../../../tests"
 
 mocks.email.mock()
-import { configs, events } from "@budibase/backend-core"
-import { GetPublicSettingsResponse, Config, ConfigType, PKCEMethod } from "@budibase/types"
 
 const { google, smtp, settings, oidc } = structures.configs
 
@@ -13,7 +18,6 @@ describe("configs", () => {
   beforeEach(async () => {
     await config.beforeAll()
     jest.clearAllMocks()
-    // Mock PKCE license for OIDC tests
     mocks.licenses.usePkceOidc()
   })
 
@@ -194,7 +198,7 @@ describe("configs", () => {
 
         it("should strip pkce field when null", async () => {
           await saveConfig(oidc({ pkce: null as any }))
-          
+
           await config.doInTenant(async () => {
             const rawConf = await configs.getOIDCConfig()
             expect(rawConf!).not.toHaveProperty("pkce")
@@ -203,7 +207,7 @@ describe("configs", () => {
 
         it("should preserve pkce field when set to valid value", async () => {
           await saveConfig(oidc({ pkce: PKCEMethod.S256 }))
-          
+
           await config.doInTenant(async () => {
             const rawConf = await configs.getOIDCConfig()
             expect(rawConf!.pkce).toBe(PKCEMethod.S256)


### PR DESCRIPTION
## Description
Fixing a bug that does not allow the user to remove a set PKCE method

## Launchcontrol
[Fix] Enable removing OIDC PKCE method setting