### PR TITLE
Use folders for client backups

### DIFF
--- a/packages/backend-core/__mocks__/@aws-sdk/client-s3.ts
+++ b/packages/backend-core/__mocks__/@aws-sdk/client-s3.ts
@@ -1,4 +1,7 @@
 export class S3 {
+  headObject() {
+    return jest.fn().mockReturnThis()
+  }
   headBucket() {
     return jest.fn().mockReturnThis()
   }

--- a/packages/backend-core/__mocks__/@aws-sdk/lib-storage.ts
+++ b/packages/backend-core/__mocks__/@aws-sdk/lib-storage.ts
@@ -1,0 +1,5 @@
+export const Upload = jest.fn().mockImplementation(() => {
+  return {
+    done: jest.fn().mockReturnThis(),
+  }
+})

--- a/packages/backend-core/src/objectStore/objectStore.ts
+++ b/packages/backend-core/src/objectStore/objectStore.ts
@@ -271,24 +271,6 @@ export async function streamUpload({
       await objectStore.putBucketLifecycleConfiguration(ttlConfig)
     }
 
-    // Set content type for certain known extensions
-    if (filename?.endsWith(".js")) {
-      extra = {
-        ...extra,
-        ContentType: "application/javascript",
-      }
-    } else if (filename?.endsWith(".json")) {
-      extra = {
-        ...extra,
-        ContentType: "application/json",
-      }
-    } else if (filename?.endsWith(".svg")) {
-      extra = {
-        ...extra,
-        ContentType: "image",
-      }
-    }
-
     let contentType = type
     if (!contentType) {
       contentType = extension

--- a/packages/backend-core/src/objectStore/objectStore.ts
+++ b/packages/backend-core/src/objectStore/objectStore.ts
@@ -277,6 +277,11 @@ export async function streamUpload({
         ...extra,
         ContentType: "application/javascript",
       }
+    } else if (filename?.endsWith(".json")) {
+      extra = {
+        ...extra,
+        ContentType: "application/json",
+      }
     } else if (filename?.endsWith(".svg")) {
       extra = {
         ...extra,

--- a/packages/backend-core/src/objectStore/tests/objectStore.spec.ts
+++ b/packages/backend-core/src/objectStore/tests/objectStore.spec.ts
@@ -1,5 +1,3 @@
-// Import after mocks
-
 import { Upload } from "@aws-sdk/lib-storage"
 import { PassThrough } from "stream"
 import { streamUpload } from "../objectStore"
@@ -7,15 +5,15 @@ import { streamUpload } from "../objectStore"
 // Get mock instances
 const mockUpload = Upload as jest.MockedClass<typeof Upload>
 
-describe("objectStore - streamUpload content type handling (real function)", () => {
+describe("objectStore", () => {
   const mockStream = new PassThrough()
 
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
-  describe("actual streamUpload function with content type inference", () => {
-    it("should call Upload with application/javascript for .js files", async () => {
+  describe("streamUpload", () => {
+    it("should upload with application/javascript for .js files", async () => {
       await streamUpload({
         bucket: "test-bucket",
         filename: "budibase-client.js",
@@ -33,7 +31,7 @@ describe("objectStore - streamUpload content type handling (real function)", () 
       })
     })
 
-    it("should call Upload with application/json for .json files", async () => {
+    it("should upload with application/json for .json files", async () => {
       await streamUpload({
         bucket: "test-bucket",
         filename: "manifest.json",
@@ -51,7 +49,7 @@ describe("objectStore - streamUpload content type handling (real function)", () 
       })
     })
 
-    it("should call Upload with image for .svg files", async () => {
+    it("should upload with image for .svg files", async () => {
       await streamUpload({
         bucket: "test-bucket",
         filename: "icon.svg",

--- a/packages/backend-core/src/objectStore/tests/objectStore.spec.ts
+++ b/packages/backend-core/src/objectStore/tests/objectStore.spec.ts
@@ -1,0 +1,175 @@
+// Import after mocks
+
+import { Upload } from "@aws-sdk/lib-storage"
+import { PassThrough } from "stream"
+import { streamUpload } from "../objectStore"
+
+// Get mock instances
+const mockUpload = Upload as jest.MockedClass<typeof Upload>
+
+describe("objectStore - streamUpload content type handling (real function)", () => {
+  const mockStream = new PassThrough()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("actual streamUpload function with content type inference", () => {
+    it("should call Upload with application/javascript for .js files", async () => {
+      await streamUpload({
+        bucket: "test-bucket",
+        filename: "budibase-client.js",
+        stream: mockStream,
+      })
+
+      expect(mockUpload).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "budibase-client.js",
+          Body: mockStream,
+          ContentType: "application/javascript",
+        },
+      })
+    })
+
+    it("should call Upload with application/json for .json files", async () => {
+      await streamUpload({
+        bucket: "test-bucket",
+        filename: "manifest.json",
+        stream: mockStream,
+      })
+
+      expect(mockUpload).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "manifest.json",
+          Body: mockStream,
+          ContentType: "application/json",
+        },
+      })
+    })
+
+    it("should call Upload with image for .svg files", async () => {
+      await streamUpload({
+        bucket: "test-bucket",
+        filename: "icon.svg",
+        stream: mockStream,
+      })
+
+      expect(mockUpload).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "icon.svg",
+          Body: mockStream,
+          ContentType: "image/svg+xml",
+        },
+      })
+    })
+
+    it("should not override explicit ContentType in extra params", async () => {
+      await streamUpload({
+        bucket: "test-bucket",
+        filename: "manifest.json",
+        stream: mockStream,
+        extra: {
+          ContentType: "application/custom",
+        },
+      })
+
+      expect(mockUpload).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "manifest.json",
+          Body: mockStream,
+          ContentType: "application/custom",
+        },
+      })
+    })
+
+    it("should preserve other extra params while adding ContentType", async () => {
+      await streamUpload({
+        bucket: "test-bucket",
+        filename: "data.json",
+        stream: mockStream,
+        extra: {
+          CacheControl: "max-age=3600",
+          Metadata: {
+            customKey: "customValue",
+          },
+        },
+      })
+
+      expect(mockUpload).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "data.json",
+          Body: mockStream,
+          ContentType: "application/json",
+          CacheControl: "max-age=3600",
+          Metadata: {
+            customKey: "customValue",
+          },
+        },
+      })
+    })
+
+    it("should not add ContentType for unsupported extensions", async () => {
+      await streamUpload({
+        bucket: "test-bucket",
+        filename: "file.unknown",
+        stream: mockStream,
+      })
+
+      expect(mockUpload).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "file.unknown",
+          Body: mockStream,
+          ContentType: undefined,
+        },
+      })
+    })
+
+    it("should handle nested file paths correctly", async () => {
+      await streamUpload({
+        bucket: "test-bucket",
+        filename: "app_123/_dependencies/config.json",
+        stream: mockStream,
+      })
+
+      expect(mockUpload).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "app_123/_dependencies/config.json",
+          Body: mockStream,
+          ContentType: "application/json",
+        },
+      })
+    })
+
+    it("should handle files with multiple dots", async () => {
+      await streamUpload({
+        bucket: "test-bucket",
+        filename: "config.backup.json",
+        stream: mockStream,
+      })
+
+      expect(mockUpload).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "config.backup.json",
+          Body: mockStream,
+          ContentType: "application/json",
+        },
+      })
+    })
+  })
+})

--- a/packages/backend-core/src/objectStore/tests/objectStore.spec.ts
+++ b/packages/backend-core/src/objectStore/tests/objectStore.spec.ts
@@ -1,18 +1,153 @@
 import { Upload } from "@aws-sdk/lib-storage"
 import { PassThrough } from "stream"
-import { streamUpload } from "../objectStore"
+import { structures } from "../../../tests"
+import { streamUpload, upload } from "../objectStore"
 
 // Get mock instances
 const mockUpload = Upload as jest.MockedClass<typeof Upload>
 
 describe("objectStore", () => {
-  const mockStream = new PassThrough()
-
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
+  describe("upload", () => {
+    let body: Buffer
+    beforeEach(() => {
+      body = Buffer.from(structures.generator.paragraph())
+    })
+
+    it("should upload with application/javascript for .js files", async () => {
+      await upload({
+        bucket: "test-bucket",
+        filename: "budibase-client.js",
+        body,
+      })
+
+      expect(mockUpload).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "budibase-client.js",
+          Body: body,
+          ContentType: "application/javascript",
+        },
+      })
+    })
+
+    it("should upload with application/json for .json files", async () => {
+      await upload({
+        bucket: "test-bucket",
+        filename: "manifest.json",
+        body,
+      })
+
+      expect(mockUpload).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "manifest.json",
+          Body: body,
+          ContentType: "application/json",
+        },
+      })
+    })
+
+    it("should upload with image for .svg files", async () => {
+      await upload({
+        bucket: "test-bucket",
+        filename: "icon.svg",
+        body,
+      })
+
+      expect(mockUpload).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "icon.svg",
+          Body: body,
+          ContentType: "image/svg+xml",
+        },
+      })
+    })
+
+    it("should not override explicit ContentType", async () => {
+      await upload({
+        bucket: "test-bucket",
+        filename: "manifest.json",
+        body,
+        type: "application/custom",
+      })
+
+      expect(mockUpload).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "manifest.json",
+          Body: body,
+          ContentType: "application/custom",
+        },
+      })
+    })
+
+    it("should not add ContentType for unsupported extensions", async () => {
+      await upload({
+        bucket: "test-bucket",
+        filename: "file.unknown",
+        body,
+      })
+
+      expect(mockUpload).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "file.unknown",
+          Body: body,
+          ContentType: undefined,
+        },
+      })
+    })
+
+    it("should handle nested file paths correctly", async () => {
+      await upload({
+        bucket: "test-bucket",
+        filename: "app_123/_dependencies/config.json",
+        body,
+      })
+
+      expect(mockUpload).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "app_123/_dependencies/config.json",
+          Body: body,
+          ContentType: "application/json",
+        },
+      })
+    })
+
+    it("should handle files with multiple dots", async () => {
+      await upload({
+        bucket: "test-bucket",
+        filename: "config.backup.json",
+        body,
+      })
+
+      expect(mockUpload).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "config.backup.json",
+          Body: body,
+          ContentType: "application/json",
+        },
+      })
+    })
+  })
+
   describe("streamUpload", () => {
+    const mockStream = new PassThrough()
+
     it("should upload with application/javascript for .js files", async () => {
       await streamUpload({
         bucket: "test-bucket",

--- a/packages/server/src/utilities/fileSystem/clientLibrary.ts
+++ b/packages/server/src/utilities/fileSystem/clientLibrary.ts
@@ -134,7 +134,7 @@ export async function revertClientLibrary(appId: string) {
   let manifestContent
   let hasBackup = false
 
-  // Process all files in the backup folder using parallelForeach
+  // First try to process files from the backup folder
   await utils.parallelForeach(
     objectStore.listAllObjects(ObjectStoreBuckets.APPS, `${appId}.bak`),
     async file => {
@@ -165,6 +165,51 @@ export async function revertClientLibrary(appId: string) {
     },
     5
   )
+
+  // If no backup folder found, try to find old .bak files
+  if (!hasBackup) {
+    await utils.parallelForeach(
+      objectStore.listAllObjects(ObjectStoreBuckets.APPS, appId),
+      async file => {
+        if (!file.Key?.endsWith(".bak")) {
+          return
+        }
+
+        hasBackup = true
+
+        // Restore .bak file to original location
+        const restoreKey = file.Key!.replace(".bak", "")
+
+        // For manifest file, we need to read the content to return it
+        if (restoreKey.endsWith("manifest.json")) {
+          const tmpPath = await objectStore.retrieveToTmp(
+            ObjectStoreBuckets.APPS,
+            file.Key!
+          )
+          manifestContent = await fs.promises.readFile(tmpPath, "utf8")
+
+          await objectStore.upload({
+            bucket: ObjectStoreBuckets.APPS,
+            filename: restoreKey,
+            path: tmpPath,
+          })
+        } else {
+          // For all other files, use streaming
+          const stream = await objectStore.getReadStream(
+            ObjectStoreBuckets.APPS,
+            file.Key!
+          )
+
+          await objectStore.streamUpload({
+            bucket: ObjectStoreBuckets.APPS,
+            filename: restoreKey,
+            stream,
+          })
+        }
+      },
+      5
+    )
+  }
 
   if (!hasBackup) {
     throw new Error(`No backup found for app ${appId}`)

--- a/packages/server/src/utilities/fileSystem/clientLibrary.ts
+++ b/packages/server/src/utilities/fileSystem/clientLibrary.ts
@@ -25,10 +25,10 @@ export function devClientLibPath() {
  * {appId}/... (and any other app files)
  *
  * The paths for the backups are:
- * {appId}.bak/manifest.json
- * {appId}.bak/budibase-client.js
- * {appId}.bak/_dependencies/...
- * {appId}.bak/... (complete folder backup)
+ * {appId}/.bak/manifest.json
+ * {appId}/.bak/budibase-client.js
+ * {appId}/.bak/_dependencies/...
+ * {appId}/.bak/... (complete folder backup)
  *
  * We don't rely on NPM at all any more, as when updating to the latest version
  * we pull both the manifest and client bundle from the server's dependencies
@@ -46,7 +46,7 @@ export async function backupClientLibrary(appId: string) {
   appId = sdk.applications.getProdAppID(appId)
   // First, remove any existing backup folder
   try {
-    await objectStore.deleteFolder(ObjectStoreBuckets.APPS, `${appId}.bak`)
+    await objectStore.deleteFolder(ObjectStoreBuckets.APPS, `${appId}/.bak`)
   } catch (error) {
     // Ignore errors if backup doesn't exist
   }
@@ -54,7 +54,7 @@ export async function backupClientLibrary(appId: string) {
   await utils.parallelForeach(
     objectStore.listAllObjects(ObjectStoreBuckets.APPS, appId),
     async file => {
-      if (file.Key?.endsWith(".bak")) {
+      if (file.Key?.includes("/.bak/") || file.Key?.endsWith(".bak")) {
         return
       }
 
@@ -136,7 +136,7 @@ export async function revertClientLibrary(appId: string) {
 
   // First try to process files from the backup folder
   await utils.parallelForeach(
-    objectStore.listAllObjects(ObjectStoreBuckets.APPS, `${appId}.bak`),
+    objectStore.listAllObjects(ObjectStoreBuckets.APPS, `${appId}/.bak`),
     async file => {
       hasBackup = true
 

--- a/packages/server/src/utilities/fileSystem/clientLibrary.ts
+++ b/packages/server/src/utilities/fileSystem/clientLibrary.ts
@@ -51,27 +51,23 @@ export async function backupClientLibrary(appId: string) {
     // Ignore errors if backup doesn't exist
   }
 
-  await utils.parallelForeach(
-    objectStore.listAllObjects(ObjectStoreBuckets.APPS, appId),
-    async file => {
-      if (file.Key?.includes("/.bak/") || file.Key?.endsWith(".bak")) {
-        return
-      }
+  await forEachObject(appId, async fileKey => {
+    if (fileKey.includes("/.bak/") || fileKey.endsWith(".bak")) {
+      return
+    }
 
-      const tmpPath = await objectStore.retrieveToTmp(
-        ObjectStoreBuckets.APPS,
-        file.Key!
-      )
+    const tmpPath = await objectStore.retrieveToTmp(
+      ObjectStoreBuckets.APPS,
+      fileKey
+    )
 
-      const backupKey = file.Key!.replace(appId, `${appId}/.bak`)
-      await objectStore.upload({
-        bucket: ObjectStoreBuckets.APPS,
-        filename: backupKey,
-        path: tmpPath,
-      })
-    },
-    5
-  )
+    const backupKey = fileKey.replace(appId, `${appId}/.bak`)
+    await objectStore.upload({
+      bucket: ObjectStoreBuckets.APPS,
+      filename: backupKey,
+      path: tmpPath,
+    })
+  })
 }
 
 /**
@@ -127,90 +123,78 @@ export async function revertClientLibrary(appId: string) {
   const restoredFiles = new Set<string>()
 
   // First, restore all files from the backup folder
-  await utils.parallelForeach(
-    objectStore.listAllObjects(ObjectStoreBuckets.APPS, `${appId}/.bak`),
-    async file => {
-      hasBackup = true
+  await forEachObject(`${appId}/.bak`, async filePath => {
+    hasBackup = true
 
-      // Download the backup file to temp
-      const tmpPath = await objectStore.retrieveToTmp(
-        ObjectStoreBuckets.APPS,
-        file.Key!
-      )
+    // Download the backup file to temp
+    const tmpPath = await objectStore.retrieveToTmp(
+      ObjectStoreBuckets.APPS,
+      filePath
+    )
 
-      // Restore to original location
-      const restoreKey = file.Key!.replace(`${appId}/.bak`, appId)
-      restoredFiles.add(restoreKey)
+    // Restore to original location
+    const restoreKey = filePath.replace(`${appId}/.bak`, appId)
+    restoredFiles.add(restoreKey)
 
-      // Read manifest content if this is the manifest file
-      if (restoreKey.endsWith("manifest.json")) {
-        manifestContent = await fs.promises.readFile(tmpPath, "utf8")
-      }
+    // Read manifest content if this is the manifest file
+    if (restoreKey.endsWith("manifest.json")) {
+      manifestContent = await fs.promises.readFile(tmpPath, "utf8")
+    }
 
-      await objectStore.upload({
-        bucket: ObjectStoreBuckets.APPS,
-        filename: restoreKey,
-        path: tmpPath,
-      })
-    },
-    5
-  )
+    await objectStore.upload({
+      bucket: ObjectStoreBuckets.APPS,
+      filename: restoreKey,
+      path: tmpPath,
+    })
+  })
 
   // After successful restore, clean up any extra files that weren't in backup
   if (hasBackup) {
-    await utils.parallelForeach(
-      objectStore.listAllObjects(ObjectStoreBuckets.APPS, appId),
-      async file => {
-        if (
-          !file.Key?.includes("/.bak/") &&
-          !file.Key?.endsWith(".bak") &&
-          !restoredFiles.has(file.Key!)
-        ) {
-          await objectStore.deleteFile(ObjectStoreBuckets.APPS, file.Key!)
-        }
-      },
-      5
-    )
+    await forEachObject(appId, async filePath => {
+      if (
+        !filePath.includes("/.bak/") &&
+        !filePath.endsWith(".bak") &&
+        !restoredFiles.has(filePath)
+      ) {
+        await objectStore.deleteFile(ObjectStoreBuckets.APPS, filePath)
+      }
+    })
   }
 
   // If no backup folder found, try to find old .bak files
   if (!hasBackup) {
-    await utils.parallelForeach(
-      objectStore.listAllObjects(ObjectStoreBuckets.APPS, appId),
-      async file => {
-        if (!file.Key?.endsWith(".bak")) {
-          return
-        }
+    await forEachObject(appId, async filePath => {
+      if (!filePath.endsWith(".bak")) {
+        return
+      }
 
-        hasBackup = true
+      hasBackup = true
 
-        // Restore .bak file to original location
-        const restoreKey = file.Key!.replace(".bak", "")
+      // Restore .bak file to original location
+      const restoreKey = filePath.replace(".bak", "")
 
-        // For manifest file, we need to read the content to return it
+      // For manifest file, we need to read the content to return it
 
-        if (restoreKey.endsWith("manifest.json")) {
-          const tmpPath = await objectStore.retrieveToTmp(
-            ObjectStoreBuckets.APPS,
-            file.Key!
-          )
-          manifestContent = await fs.promises.readFile(tmpPath, "utf8")
-        }
-
-        // For all other files, use streaming
-        const stream = await objectStore.getReadStream(
+      if (restoreKey.endsWith("manifest.json")) {
+        const tmpPath = await objectStore.retrieveToTmp(
           ObjectStoreBuckets.APPS,
-          file.Key!
+          filePath
         )
+        manifestContent = await fs.promises.readFile(tmpPath, "utf8")
+      }
 
-        await objectStore.streamUpload({
-          bucket: ObjectStoreBuckets.APPS,
-          filename: restoreKey,
-          stream,
-        })
-      },
-      5
-    )
+      // For all other files, use streaming
+      const stream = await objectStore.getReadStream(
+        ObjectStoreBuckets.APPS,
+        filePath
+      )
+
+      await objectStore.streamUpload({
+        bucket: ObjectStoreBuckets.APPS,
+        filename: restoreKey,
+        stream,
+      })
+    })
   }
 
   if (!hasBackup) {
@@ -223,6 +207,21 @@ export async function revertClientLibrary(appId: string) {
 
   return JSON.parse(manifestContent)
 }
+
+const forEachObject = (
+  path: string,
+  task: (fileKey: string) => Promise<void>
+) =>
+  utils.parallelForeach(
+    objectStore.listAllObjects(ObjectStoreBuckets.APPS, path),
+    async file => {
+      if (!file.Key) {
+        throw new Error("file.Key must be defined")
+      }
+      await task(file.Key)
+    },
+    5
+  )
 
 export function shouldServeLocally() {
   if (env.isDev()) {

--- a/packages/server/src/utilities/fileSystem/tests/clientLibrary.spec.ts
+++ b/packages/server/src/utilities/fileSystem/tests/clientLibrary.spec.ts
@@ -1,0 +1,328 @@
+jest.mock("@budibase/backend-core", () => {
+  const actual = jest.requireActual("@budibase/backend-core")
+  return {
+    ...actual,
+    objectStore: {
+      deleteFolder: jest.fn(),
+      listAllObjects: jest.fn(),
+      retrieveToTmp: jest.fn().mockResolvedValue("/tmp/file"),
+      streamUpload: jest.fn(),
+      upload: jest.fn(),
+      deleteFile: jest.fn(),
+      getReadStream: jest.fn(),
+      ObjectStoreBuckets: actual.objectStore.ObjectStoreBuckets,
+    },
+    sdk: {
+      applications: {
+        getProdAppID: jest.fn((id: string) => id.replace("_dev", "")),
+      },
+    },
+  }
+})
+
+jest.mock("fs", () => ({
+  createReadStream: jest.fn(),
+  promises: {
+    readFile: jest.fn(),
+  },
+}))
+
+jest.mock("../../../environment", () => ({
+  isDev: jest.fn(),
+  isTest: jest.fn(),
+  DEV_USE_CLIENT_FROM_STORAGE: false,
+}))
+
+jest.mock("../filesystem", () => ({
+  TOP_LEVEL_PATH: "/mock/top/level/path",
+}))
+
+import { objectStore } from "@budibase/backend-core"
+import fs from "fs"
+import { ObjectStoreBuckets } from "../../../constants"
+import env from "../../../environment"
+import {
+  backupClientLibrary,
+  revertClientLibrary,
+  shouldServeLocally,
+  updateClientLibrary,
+} from "../clientLibrary"
+
+const mockedObjectStore = objectStore as jest.Mocked<typeof objectStore>
+const mockedFs = fs as jest.Mocked<typeof fs>
+const mockedEnv = env as jest.Mocked<typeof env>
+
+type ObjectStoreFile = { Key?: string }
+type MockedReadFile = jest.MockedFunction<typeof fs.promises.readFile>
+
+describe("clientLibrary", () => {
+  const testAppId = "app_123"
+  const testAppIdDev = "app_dev_123"
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("backupClientLibrary", () => {
+    it("should backup entire app folder to /.bak folder", async () => {
+      const mockFiles: ObjectStoreFile[] = [
+        { Key: "app_123/manifest.json" },
+        { Key: "app_123/budibase-client.js" },
+        { Key: "app_123/_dependencies/some-lib.js" },
+        { Key: "app_123/custom-file.json" },
+      ]
+
+      mockedObjectStore.listAllObjects.mockReturnValue(mockFiles as any)
+
+      await backupClientLibrary(testAppId)
+
+      expect(mockedObjectStore.deleteFolder).toHaveBeenCalledWith(
+        ObjectStoreBuckets.APPS,
+        "app_123/.bak"
+      )
+
+      expect(mockedObjectStore.upload).toHaveBeenCalledTimes(4)
+      expect(mockedObjectStore.upload).toHaveBeenCalledWith({
+        bucket: ObjectStoreBuckets.APPS,
+        filename: "app_123/.bak/manifest.json",
+        path: "/tmp/file",
+      })
+      expect(mockedObjectStore.upload).toHaveBeenCalledWith({
+        bucket: ObjectStoreBuckets.APPS,
+        filename: "app_123/.bak/budibase-client.js",
+        path: "/tmp/file",
+      })
+      expect(mockedObjectStore.upload).toHaveBeenCalledWith({
+        bucket: ObjectStoreBuckets.APPS,
+        filename: "app_123/.bak/_dependencies/some-lib.js",
+        path: "/tmp/file",
+      })
+      expect(mockedObjectStore.upload).toHaveBeenCalledWith({
+        bucket: ObjectStoreBuckets.APPS,
+        filename: "app_123/.bak/custom-file.json",
+        path: "/tmp/file",
+      })
+    })
+
+    it("should skip .bak files during backup", async () => {
+      const mockFiles: ObjectStoreFile[] = [
+        { Key: "app_123/manifest.json" },
+        { Key: "app_123/.bak/old-file.js" },
+        { Key: "app_123/file.js.bak" },
+      ]
+
+      mockedObjectStore.listAllObjects.mockReturnValue(mockFiles as any)
+
+      await backupClientLibrary(testAppId)
+
+      expect(mockedObjectStore.upload).toHaveBeenCalledTimes(1)
+      expect(mockedObjectStore.upload).toHaveBeenCalledWith({
+        bucket: ObjectStoreBuckets.APPS,
+        filename: "app_123/.bak/manifest.json",
+        path: "/tmp/file",
+      })
+    })
+
+    it("should handle dev app IDs correctly", async () => {
+      const mockFiles: ObjectStoreFile[] = [{ Key: "app_123/manifest.json" }]
+      mockedObjectStore.listAllObjects.mockReturnValue(mockFiles as any)
+
+      await backupClientLibrary(testAppIdDev)
+
+      expect(mockedObjectStore.listAllObjects).toHaveBeenCalledWith(
+        ObjectStoreBuckets.APPS,
+        testAppId // should be converted to prod ID
+      )
+    })
+
+    it("should continue if backup folder delete fails", async () => {
+      const mockFiles: ObjectStoreFile[] = [{ Key: "app_123/manifest.json" }]
+      mockedObjectStore.listAllObjects.mockReturnValue(mockFiles as any)
+      mockedObjectStore.deleteFolder.mockRejectedValue(new Error("Not found"))
+
+      await expect(backupClientLibrary(testAppId)).resolves.not.toThrow()
+      expect(mockedObjectStore.upload).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("updateClientLibrary", () => {
+    beforeEach(() => {
+      mockedFs.createReadStream.mockReturnValue("stream" as any)
+      ;(mockedFs.promises.readFile as MockedReadFile).mockResolvedValue(
+        '{"version": "1.0.0"}' as any
+      )
+    })
+
+    it.each([
+      ["dev", true],
+      ["production", false],
+    ])("should upload manifest and client in %s mode", async (_, isDev) => {
+      mockedEnv.isDev.mockReturnValue(isDev)
+
+      const result = await updateClientLibrary(testAppId)
+
+      expect(mockedObjectStore.streamUpload).toHaveBeenCalledTimes(2)
+      expect(mockedObjectStore.streamUpload).toHaveBeenCalledWith({
+        bucket: ObjectStoreBuckets.APPS,
+        filename: "app_123/manifest.json",
+        stream: "stream",
+      })
+      expect(mockedObjectStore.streamUpload).toHaveBeenCalledWith({
+        bucket: ObjectStoreBuckets.APPS,
+        filename: "app_123/budibase-client.js",
+        stream: "stream",
+      })
+      expect(result).toEqual({ version: "1.0.0" })
+    })
+  })
+
+  describe("revertClientLibrary", () => {
+    const manifestContent = '{"version": "0.9.0"}'
+
+    beforeEach(() => {
+      ;(mockedFs.promises.readFile as MockedReadFile).mockResolvedValue(
+        manifestContent as any
+      )
+    })
+
+    it("should restore from .bak folder structure", async () => {
+      const mockBackupFiles: ObjectStoreFile[] = [
+        { Key: "app_123/.bak/manifest.json" },
+        { Key: "app_123/.bak/budibase-client.js" },
+        { Key: "app_123/.bak/_dependencies/lib.js" },
+      ]
+      const mockCurrentFiles: ObjectStoreFile[] = [
+        { Key: "app_123/manifest.json" },
+        { Key: "app_123/budibase-client.js" },
+        { Key: "app_123/_dependencies/lib.js" },
+        { Key: "app_123/extra-file.js" }, // This should be deleted
+      ]
+
+      mockedObjectStore.listAllObjects
+        .mockReturnValueOnce(mockBackupFiles as any) // First call for backup files
+        .mockReturnValueOnce(mockCurrentFiles as any) // Second call for cleanup
+
+      const result = await revertClientLibrary(testAppId)
+
+      expect(mockedObjectStore.upload).toHaveBeenCalledTimes(3)
+      ;["manifest.json", "budibase-client.js", "manifest.json"].forEach(
+        fileName => {
+          expect(mockedObjectStore.upload).toHaveBeenCalledWith({
+            bucket: ObjectStoreBuckets.APPS,
+            filename: `app_123/${fileName}`,
+            path: "/tmp/file",
+          })
+        }
+      )
+
+      expect(mockedObjectStore.deleteFile).toHaveBeenCalledTimes(1)
+      expect(mockedObjectStore.deleteFile).toHaveBeenCalledWith(
+        ObjectStoreBuckets.APPS,
+        "app_123/extra-file.js"
+      )
+
+      expect(result).toEqual({ version: "0.9.0" })
+    })
+
+    it("should fallback to old .bak files if no .bak folder exists", async () => {
+      const mockOldBackupFiles: ObjectStoreFile[] = [
+        { Key: "app_123/manifest.json" },
+        { Key: "app_123/manifest.json.bak" },
+        { Key: "app_123/budibase-client.js" },
+        { Key: "app_123/budibase-client.js.bak" },
+      ]
+
+      mockedObjectStore.getReadStream.mockReturnValueOnce("stream1" as any)
+      mockedObjectStore.getReadStream.mockReturnValueOnce("stream2" as any)
+
+      mockedObjectStore.listAllObjects
+        .mockReturnValueOnce([] as any) // No .bak folder
+        .mockReturnValueOnce(mockOldBackupFiles as any) // Old .bak files
+
+      const result = await revertClientLibrary(testAppId)
+
+      expect(mockedObjectStore.streamUpload).toHaveBeenCalledTimes(2)
+      expect(mockedObjectStore.streamUpload).toHaveBeenCalledWith({
+        bucket: ObjectStoreBuckets.APPS,
+        filename: "app_123/budibase-client.js",
+        stream: "stream1",
+      })
+      expect(mockedObjectStore.streamUpload).toHaveBeenCalledWith({
+        bucket: ObjectStoreBuckets.APPS,
+        filename: "app_123/manifest.json",
+        stream: "stream2",
+      })
+
+      expect(result).toEqual({ version: "0.9.0" })
+    })
+
+    it("should throw error if no backup found", async () => {
+      mockedObjectStore.listAllObjects
+        .mockReturnValueOnce([] as any) // No .bak folder
+        .mockReturnValueOnce([] as any) // No old .bak files
+
+      await expect(revertClientLibrary(testAppId)).rejects.toThrow(
+        "No backup found for app app_123"
+      )
+    })
+
+    it("should throw error if manifest not found in backup", async () => {
+      const mockBackupFiles: ObjectStoreFile[] = [
+        { Key: "app_123/.bak/budibase-client.js" },
+      ]
+
+      mockedObjectStore.listAllObjects.mockReturnValueOnce(
+        mockBackupFiles as any
+      )
+
+      await expect(revertClientLibrary(testAppId)).rejects.toThrow(
+        "No manifest found in backup for app app_123"
+      )
+    })
+
+    it("should handle dev app IDs correctly", async () => {
+      const mockBackupFiles: ObjectStoreFile[] = [
+        { Key: "app_123/.bak/manifest.json" },
+      ]
+
+      mockedObjectStore.listAllObjects.mockReturnValueOnce(
+        mockBackupFiles as any
+      )
+
+      await revertClientLibrary(testAppIdDev)
+
+      expect(mockedObjectStore.listAllObjects).toHaveBeenCalledWith(
+        ObjectStoreBuckets.APPS,
+        "app_123/.bak" // should use prod ID
+      )
+    })
+  })
+
+  describe("shouldServeLocally", () => {
+    beforeEach(() => {
+      mockedEnv.isDev.mockReturnValue(false)
+      mockedEnv.isTest.mockReturnValue(false)
+      ;(mockedEnv as any).DEV_USE_CLIENT_FROM_STORAGE = false
+    })
+
+    it("should serve locally in dev mode", () => {
+      mockedEnv.isDev.mockReturnValue(true)
+      expect(shouldServeLocally()).toBe(true)
+    })
+
+    it("should not serve locally in dev mode if DEV_USE_CLIENT_FROM_STORAGE is true", () => {
+      mockedEnv.isDev.mockReturnValue(true)
+      ;(mockedEnv as any).DEV_USE_CLIENT_FROM_STORAGE = true
+      expect(shouldServeLocally()).toBe(false)
+    })
+
+    it("should serve locally in test mode", () => {
+      mockedEnv.isTest.mockReturnValue(true)
+      expect(shouldServeLocally()).toBe(true)
+    })
+
+    it("should not serve locally in production", () => {
+      expect(shouldServeLocally()).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Description
We are introducing changes in the client library that adds extra files, such as AB testing versions and dependency files. This PR changes the way we handle backups and restores, in order to be able to backup everything properly instead of hardcoding a line for each file in the restore/backup

Also, adding tests around objectStore

## Launchcontrol
Client backup using a .bak folder instead of files {name}.bak