### PR TITLE
Fix redirect from apps to workspaces

### DIFF
--- a/hosting/proxy/nginx.prod.conf
+++ b/hosting/proxy/nginx.prod.conf
@@ -118,11 +118,11 @@ http {
     }
 
     # Redirects for renamed routes
-    location ~ ^/builder/portal/apps(/?.*)?$ {
+    location ~ ^/builder/portal/apps(/.*)?$ {
       return 301 $scheme://$host/builder/portal/workspaces$1;
     }
 
-    location ~ ^/builder/app(/?.*)?$ {
+    location ~ ^/builder/app(/.*)?$ {
       return 301 $scheme://$host/builder/workspace$1;
     }
 


### PR DESCRIPTION
## Description
Fixing an issue with the regex that handles the redirect from `/app/*` to `/workspace/*`. The regex was matching `/builder/apps`, redirecting to `/builder/workspace`, causing issues as this is not expected.

Tested it forcing a QA release and it works fine: https://github.com/Budibase/budibase-deploys/actions/runs/17552351840

Uploading Screen Recording 2025-09-08 at 15.39.23.mov…


## Launchcontrol
Fix wrong redirect accessing `/builder/apps` in the cloud

