### PR TITLE
Fix wrongly cached 301

### DIFF
--- a/packages/builder/src/pages/builder/workspaces.svelte
+++ b/packages/builder/src/pages/builder/workspaces.svelte
@@ -1,0 +1,7 @@
+<script>
+  // This file should not be needed, but because an error we marked /builder/apps as redirect to /builder/workspaces.
+  // This should not be the case, and it has been fixed. This will fix any user that has it cached on the browser.
+  import { redirect } from "@roxi/routify"
+
+  $: $redirect(`./apps`)
+</script>


### PR DESCRIPTION
## Description
Fix wrongly cached 301. If a browser visits it before it was fixed in https://github.com/Budibase/budibase/pull/16911, the browser will have it cached, and it will not work without a cache wipeout. This PR adds a redirect in the code to prevent any issues