### PR TITLE
fix: use "Default workspace" as the first workspace name

### DIFF
--- a/packages/server/src/api/controllers/workspace.ts
+++ b/packages/server/src/api/controllers/workspace.ts
@@ -81,6 +81,8 @@ import { builderSocket } from "../../websockets"
 import * as workspaceMigrations from "../../workspaceMigrations"
 import { processMigrations } from "../../workspaceMigrations/migrationsProcessor"
 
+const DEFAULT_WORKSPACE_NAME = "Default workspace"
+
 // utility function, need to do away with this
 async function getLayouts() {
   const db = context.getWorkspaceDB()
@@ -183,13 +185,12 @@ async function addSampleDataDocs() {
   }
 }
 
-async function createDefaultWorkspaceApp(): Promise<string> {
-  const appMetadata = await sdk.applications.metadata.get()
+async function createDefaultWorkspaceApp(name: string): Promise<string> {
   const workspaceApp = await sdk.workspaceApps.create({
-    name: appMetadata.name,
+    name: name,
     url: "/",
     navigation: {
-      ...defaultAppNavigator(appMetadata.name),
+      ...defaultAppNavigator(name),
       links: [],
     },
     disabled: true,
@@ -416,7 +417,7 @@ async function performAppCreate(
       type: "app",
       version: envCore.VERSION,
       componentLibraries: ["@budibase/standard-components"],
-      name: name,
+      name: isOnboarding ? DEFAULT_WORKSPACE_NAME : name,
       url: appUrl,
       template: templateKey,
       instance,
@@ -486,7 +487,7 @@ async function performAppCreate(
     // Add sample datasource and example screen for non-templates/non-imports
     if (addSampleData) {
       try {
-        await createDefaultWorkspaceApp()
+        await createDefaultWorkspaceApp(name)
         await addSampleDataDocs()
         await addSampleDataScreen()
 

--- a/packages/server/src/api/routes/tests/workspace.spec.ts
+++ b/packages/server/src/api/routes/tests/workspace.spec.ts
@@ -159,8 +159,12 @@ describe("/applications", () => {
     }
 
     it("creates empty app without sample data", async () => {
-      const app = await config.api.workspace.create({ name: utils.newid() })
-      expect(app._id).toBeDefined()
+      const newId = utils.newid()
+      const newWorkspace = await config.api.workspace.create({
+        name: newId,
+      })
+      expect(newWorkspace.name).toBe(newId)
+      expect(newWorkspace._id).toBeDefined()
       expect(events.app.created).toHaveBeenCalledTimes(1)
 
       // Ensure we created a blank app without sample data
@@ -169,16 +173,22 @@ describe("/applications", () => {
     })
 
     it("creates app with sample data when onboarding", async () => {
-      const newApp = await config.api.workspace.create({
-        name: utils.newid(),
+      const newId = utils.newid()
+      const newWorkspace = await config.api.workspace.create({
+        name: newId,
         isOnboarding: "true",
       })
-      expect(newApp._id).toBeDefined()
+      expect(newWorkspace._id).toBeDefined()
+      expect(newWorkspace.name).toBe("Default workspace")
       expect(events.app.created).toHaveBeenCalledTimes(1)
 
       // Check sample resources in the newly created app context
-      await config.withApp(newApp, async () => {
-        const res = await config.api.workspace.getDefinition(newApp.appId)
+      await config.withApp(newWorkspace, async () => {
+        const workspaceAppsFetchResult = await config.api.workspaceApp.fetch()
+        const [app] = workspaceAppsFetchResult.workspaceApps
+        expect(app.name).toBe(newId)
+
+        const res = await config.api.workspace.getDefinition(newWorkspace.appId)
         expect(res.screens.length).toEqual(1)
 
         const tables = await config.api.table.fetch()

--- a/packages/server/src/api/routes/tests/workspace.spec.ts
+++ b/packages/server/src/api/routes/tests/workspace.spec.ts
@@ -185,7 +185,9 @@ describe("/applications", () => {
       // Check sample resources in the newly created app context
       await config.withApp(newWorkspace, async () => {
         const workspaceAppsFetchResult = await config.api.workspaceApp.fetch()
-        const [app] = workspaceAppsFetchResult.workspaceApps
+        const {
+          workspaceApps: [app],
+        } = workspaceAppsFetchResult
         expect(app.name).toBe(newId)
 
         const res = await config.api.workspace.getDefinition(newWorkspace.appId)

--- a/packages/server/src/api/routes/tests/workspace.spec.ts
+++ b/packages/server/src/api/routes/tests/workspace.spec.ts
@@ -1,14 +1,7 @@
 import { DEFAULT_TABLES } from "../../../db/defaultData/datasource_bb_default"
 import { setEnv, withEnv } from "../../../environment"
 
-import {
-  Header,
-  context,
-  db,
-  events,
-  roles,
-  utils,
-} from "@budibase/backend-core"
+import { Header, context, db, events, roles } from "@budibase/backend-core"
 import { structures } from "@budibase/backend-core/tests"
 import {
   type Workspace,
@@ -33,6 +26,10 @@ import {
 } from "../../../tests/utilities/structures"
 import * as setup from "./utilities"
 import { checkBuilderEndpoint } from "./utilities/TestFunctions"
+
+const generateAppName = () => {
+  return structures.generator.word({ length: 10 })
+}
 
 describe("/applications", () => {
   let config = setup.getConfig()
@@ -159,11 +156,11 @@ describe("/applications", () => {
     }
 
     it("creates empty app without sample data", async () => {
-      const newId = utils.newid()
+      const name = generateAppName()
       const newWorkspace = await config.api.workspace.create({
-        name: newId,
+        name,
       })
-      expect(newWorkspace.name).toBe(newId)
+      expect(newWorkspace.name).toBe(name)
       expect(newWorkspace._id).toBeDefined()
       expect(events.app.created).toHaveBeenCalledTimes(1)
 
@@ -173,9 +170,9 @@ describe("/applications", () => {
     })
 
     it("creates app with sample data when onboarding", async () => {
-      const newId = utils.newid()
+      const name = generateAppName()
       const newWorkspace = await config.api.workspace.create({
-        name: newId,
+        name,
         isOnboarding: "true",
       })
       expect(newWorkspace._id).toBeDefined()
@@ -188,7 +185,7 @@ describe("/applications", () => {
         const {
           workspaceApps: [app],
         } = workspaceAppsFetchResult
-        expect(app.name).toBe(newId)
+        expect(app.name).toBe(name)
 
         const res = await config.api.workspace.getDefinition(newWorkspace.appId)
         expect(res.screens.length).toEqual(1)
@@ -207,7 +204,7 @@ describe("/applications", () => {
         )
 
       const newApp = await config.api.workspace.create({
-        name: utils.newid(),
+        name: generateAppName(),
         useTemplate: "true",
         templateKey: "app/expense-approval",
       })
@@ -227,7 +224,7 @@ describe("/applications", () => {
 
     it("creates app from file", async () => {
       const newApp = await config.api.workspace.create({
-        name: utils.newid(),
+        name: generateAppName(),
         useTemplate: "true",
         fileToImport: "src/api/routes/tests/data/old-app.txt", // export.tx was empty
       })
@@ -256,7 +253,7 @@ describe("/applications", () => {
 
     it("migrates navigation settings from old apps", async () => {
       const app = await config.api.workspace.create({
-        name: utils.newid(),
+        name: generateAppName(),
         useTemplate: "true",
         fileToImport: "src/api/routes/tests/data/old-app.txt",
       })
@@ -1012,7 +1009,8 @@ describe("/applications", () => {
     it("middleware should set updatedAt", async () => {
       const app = await tk.withFreeze(
         "2021-01-01",
-        async () => await config.api.workspace.create({ name: utils.newid() })
+        async () =>
+          await config.api.workspace.create({ name: generateAppName() })
       )
       expect(app.updatedAt).toEqual("2021-01-01T00:00:00.000Z")
 


### PR DESCRIPTION
## Description
When onboarding, create a workspace called `Default workspace`

Adds some extra tests to validate that workspaces have the correct names

superceeds #16915 
