### PR TITLE
Test decodeId with null input. Closes #16929.

### DIFF
--- a/packages/string-templates/test/helpers.spec.ts
+++ b/packages/string-templates/test/helpers.spec.ts
@@ -553,7 +553,7 @@ describe("Test the decodeId helper", () => {
 
   it("Handles null gracefully", async () => {
     const output = await processString("{{ decodeId value }}", {
-      value: undefined,
+      value: null,
     })
     expect(output).toBe("")
   })


### PR DESCRIPTION
## Description
Same test was implemented twice rather than actually testing for null.

## Addresses
- #16929 

## Launchcontrol
Addresses a minor oversight in the `decodeId` string helper, improving maintainability and reliability.