### PR TITLE
Remove dynamic formulas for selectable list for view calculations

### DIFF
--- a/packages/builder/src/components/backend/DataTable/buttons/grid/GridViewCalculationButton.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/GridViewCalculationButton.svelte
@@ -9,7 +9,6 @@
   import {
     CalculationType,
     canGroupBy,
-    FieldType,
     isNumeric,
     isNumericStaticFormula,
   } from "@budibase/types"
@@ -107,8 +106,7 @@
         // Only allow numeric columns for most calculation types
         if (
           self.type !== CalculationType.COUNT &&
-          !isNumeric(fieldSchema.type) &&
-          fieldSchema.responseType !== FieldType.NUMBER
+          !isNumeric(fieldSchema.type)
         ) {
           return false
         }


### PR DESCRIPTION
## Description
A very small fix that removes dynamic columns from being selectable when setting up your view calculations.

## Screenshots
<img width="366" height="447" alt="Screenshot 2025-09-12 at 09 27 53" src="https://github.com/user-attachments/assets/2ad27330-922a-48c5-9cc8-d0eadf978a4a" />

<img width="487" height="310" alt="Screenshot 2025-09-12 at 09 28 42" src="https://github.com/user-attachments/assets/f821964f-6079-42cb-80ec-a11c55ed4481" />

<img width="1039" height="491" alt="Screenshot 2025-09-12 at 09 28 46" src="https://github.com/user-attachments/assets/4e7d9326-2810-414f-abbe-b5688f673121" />

**Can't select this column anymore**
<img width="498" height="353" alt="Screenshot 2025-09-12 at 09 29 39" src="https://github.com/user-attachments/assets/15bc8f4d-60a9-43b6-9869-de0fd96b8f2f" />

## Launchcontrol
Removed dynamic columns from the view calculations columns list. Prevents users from running into an error.