### PR TITLE
Fix for rest query url parsing in RestQueryViewer

### DIFF
--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -387,8 +387,10 @@
 
   const urlChanged = evt => {
     breakQs = {}
-    const fullUrl = evt.target.value
-    const [basePath, qs] = fullUrl.split("?")
+    const fullUrl = evt.detail
+    if (!fullUrl) return
+
+    const [basePath, qs] = fullUrl?.split("?")
 
     // Update the query fields path with just the base path
     if (query?.fields) {
@@ -563,7 +565,7 @@
           <div class="url">
             <Input
               on:blur={urlChanged}
-              bind:value={url}
+              value={url}
               placeholder="http://www.api.com/endpoint"
             />
           </div>
@@ -595,12 +597,22 @@
             />
           </Tab>
           <Tab title="Params">
-            <KeyValueBuilder
-              bind:object={breakQs}
-              name="param"
-              headings
-              bindings={mergedBindings}
-            />
+            {#key breakQs}
+              <KeyValueBuilder
+                name="param"
+                defaults={breakQs}
+                headings
+                bindings={mergedBindings}
+                on:change={e => {
+                  let newQs = {}
+                  e.detail.forEach(({ name, value }) => {
+                    newQs[name] = value
+                  })
+
+                  breakQs = newQs
+                }}
+              />
+            {/key}
           </Tab>
           <Tab title="Headers">
             <KeyValueBuilder

--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -170,7 +170,7 @@
         ? readableToRuntimeMap(mergedBindings, newQuery.fields.requestBody)
         : readableToRuntimeBinding(mergedBindings, newQuery.fields.requestBody)
 
-    newQuery.fields.path = url?.split("?")[0]
+    newQuery.fields.path = fromQuery.fields.path
     newQuery.fields.queryString = queryString
     newQuery.fields.disabledHeaders = restUtils.flipHeaderState(enabledHeaders)
     newQuery.schema = schema || {}
@@ -387,12 +387,22 @@
 
   const urlChanged = evt => {
     breakQs = {}
-    const qs = evt.target.value.split("?")[1]
+    const fullUrl = evt.target.value
+    const [basePath, qs] = fullUrl.split("?")
+
+    // Update the query fields path with just the base path
+    if (query?.fields) {
+      query.fields.path = basePath
+    }
+
+    // Parse query parameters
     if (qs && qs.length > 0) {
       const parts = qs.split("&")
       for (let part of parts) {
         const [key, value] = part.split("=")
-        breakQs[key] = value
+        if (key) {
+          breakQs[key] = value || ""
+        }
       }
     }
   }
@@ -553,7 +563,7 @@
           <div class="url">
             <Input
               on:blur={urlChanged}
-              bind:value={query.fields.path}
+              bind:value={url}
               placeholder="http://www.api.com/endpoint"
             />
           </div>

--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -390,7 +390,7 @@
     const fullUrl = evt.detail
     if (!fullUrl) return
 
-    const [basePath, qs] = fullUrl?.split("?")
+    const [basePath, qs] = fullUrl?.split("?") || []
 
     // Update the query fields path with just the base path
     if (query?.fields) {


### PR DESCRIPTION
## Description

- The URL now remains intact in the address input on blur. It was being erroneously stripped. This didn't affect the stored params, but it did break parsing functionality and looked odd.
- On blur any query params are properly processed and will update the `Params` section immediately.
- The inverse behaviour has also been restored. If you add or remove params from the `Params` Key/Value editor, they will be properly reflected in the URL address bar.

## Addresses
- https://github.com/Budibase/budibase/issues/16945

## Launchcontrol
URL query param parsing fix for rest query viewer