### PR TITLE
Fix invite conflicts

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/_components/BuilderSidePanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/BuilderSidePanel.svelte
@@ -1,46 +1,46 @@
 <script>
-  import {
-    Icon,
-    Divider,
-    Heading,
-    Layout,
-    Input,
-    clickOutside,
-    notifications,
-    CopyInput,
-    Modal,
-    FancyForm,
-    FancyInput,
-    Button,
-    FancySelect,
-  } from "@budibase/bbui"
-  import {
-    builderStore,
-    appStore,
-    roles,
-    deploymentStore,
-  } from "@/stores/builder"
-  import {
-    groups,
-    licensing,
-    appsStore,
-    users,
-    auth,
-    admin,
-  } from "@/stores/portal"
-  import {
-    fetchData,
-    Constants,
-    Utils,
-    RoleUtils,
-    emailValidator,
-  } from "@budibase/frontend-core"
-  import { sdk } from "@budibase/shared-core"
   import { API } from "@/api"
-  import GroupIcon from "../../../portal/users/groups/_components/GroupIcon.svelte"
   import RoleSelect from "@/components/common/RoleSelect.svelte"
   import UpgradeModal from "@/components/common/users/UpgradeModal.svelte"
+  import {
+    appStore,
+    builderStore,
+    deploymentStore,
+    roles,
+  } from "@/stores/builder"
+  import {
+    admin,
+    appsStore,
+    auth,
+    groups,
+    licensing,
+    users,
+  } from "@/stores/portal"
+  import {
+    Button,
+    CopyInput,
+    Divider,
+    FancyForm,
+    FancyInput,
+    FancySelect,
+    Heading,
+    Icon,
+    Input,
+    Layout,
+    Modal,
+    clickOutside,
+    notifications,
+  } from "@budibase/bbui"
+  import {
+    Constants,
+    RoleUtils,
+    Utils,
+    emailValidator,
+    fetchData,
+  } from "@budibase/frontend-core"
+  import { sdk } from "@budibase/shared-core"
   import { fly } from "svelte/transition"
+  import GroupIcon from "../../../portal/users/groups/_components/GroupIcon.svelte"
   import InfoDisplay from "../design/[workspaceAppId]/[screenId]/[componentId]/_components/Component/InfoDisplay.svelte"
   import BuilderGroupPopover from "./BuilderGroupPopover.svelte"
 
@@ -454,36 +454,21 @@
   }
 
   const onUpdateUserInvite = async (invite, role) => {
-    let updateBody = {
-      apps: {
-        ...invite.apps,
-        [prodAppId]: role,
-      },
+    try {
+      await users.addWorkspaceIdToInvite(invite.code, prodAppId, role)
+      await filterInvites(query)
+    } catch (err) {
+      notifications.error("Error editing invite")
     }
-    if (role === Constants.Roles.CREATOR) {
-      updateBody.builder = updateBody.builder || {}
-      updateBody.builder.apps = [...(updateBody.builder.apps ?? []), prodAppId]
-      delete updateBody?.apps?.[prodAppId]
-    } else if (role !== Constants.Roles.CREATOR && invite?.builder?.apps) {
-      invite.builder.apps = []
-    }
-    await users.updateInvite(invite.code, updateBody)
-    await filterInvites(query)
   }
 
   const onUninviteAppUser = async invite => {
-    await uninviteAppUser(invite)
-    await filterInvites(query)
-  }
-
-  // Purge only the app from the invite or recind the invite if only 1 app remains?
-  const uninviteAppUser = async invite => {
-    let updated = { ...invite }
-    delete updated.info.apps[prodAppId]
-
-    return await users.updateInvite(updated.code, {
-      apps: updated.apps,
-    })
+    try {
+      await users.removeWorkspaceIdFromInvite(invite.code, prodAppId)
+      await filterInvites(query)
+    } catch (err) {
+      notifications.error("Error editing invite")
+    }
   }
 
   const addAppBuilder = async userId => {

--- a/packages/builder/src/stores/portal/users.ts
+++ b/packages/builder/src/stores/portal/users.ts
@@ -1,20 +1,19 @@
 import { API } from "@/api"
-import { licensing } from "."
-import { sdk } from "@budibase/shared-core"
+import { UserInfo } from "@/types"
+import { notifications } from "@budibase/bbui"
 import { Constants } from "@budibase/frontend-core"
+import { sdk } from "@budibase/shared-core"
 import {
   DeleteInviteUsersRequest,
   InviteUsersRequest,
   SearchUsersRequest,
   SearchUsersResponse,
-  UpdateInviteRequest,
+  UnsavedUser,
   User,
   UserIdentifier,
-  UnsavedUser,
 } from "@budibase/types"
+import { licensing } from "."
 import { BudiStore } from "../BudiStore"
-import { notifications } from "@budibase/bbui"
-import { UserInfo } from "@/types"
 
 type UserState = SearchUsersResponse & SearchUsersRequest
 
@@ -107,8 +106,12 @@ class UserStore extends BudiStore<UserState> {
     return API.getUserInvites()
   }
 
-  async updateInvite(code: string, invite: UpdateInviteRequest) {
-    return API.updateUserInvite(code, invite)
+  async addWorkspaceIdToInvite(code: string, appId: string, role: string) {
+    return API.addWorkspaceIdToInvite(code, appId, role)
+  }
+
+  async removeWorkspaceIdFromInvite(code: string, appId: string) {
+    return API.removeWorkspaceIdFromInvite(code, appId)
   }
 
   async getUserCountByApp(appId: string) {

--- a/packages/frontend-core/src/api/user.ts
+++ b/packages/frontend-core/src/api/user.ts
@@ -22,7 +22,6 @@ import {
   SearchUsersRequest,
   SearchUsersResponse,
   UnsavedUser,
-  UpdateInviteRequest,
   UpdateInviteResponse,
   UpdateSelfMetadataRequest,
   UpdateSelfMetadataResponse,
@@ -59,9 +58,14 @@ export interface UserEndpoints {
     users: UnsavedUser[],
     groups: any[]
   ) => Promise<BulkUserCreated | undefined>
-  updateUserInvite: (
+  addWorkspaceIdToInvite: (
     code: string,
-    data: UpdateInviteRequest
+    appId: string,
+    role: string
+  ) => Promise<UpdateInviteResponse>
+  removeWorkspaceIdFromInvite: (
+    code: string,
+    appId: string
   ) => Promise<UpdateInviteResponse>
 
   // Missing request or response types
@@ -188,14 +192,14 @@ export const buildUserEndpoints = (API: BaseAPIClient): UserEndpoints => ({
     })
   },
 
-  /**
-   * Accepts a user invite as a body and will update the associated app roles.
-   * for an existing invite
-   */
-  updateUserInvite: async (code, data) => {
-    return await API.post<UpdateInviteRequest, UpdateInviteResponse>({
-      url: `/api/global/users/invite/update/${code}`,
-      body: data,
+  addWorkspaceIdToInvite: async (code, appId, role) => {
+    return await API.post<void, UpdateInviteResponse>({
+      url: `/api/global/users/invite/update/${code}/${appId}/${role}`,
+    })
+  },
+  removeWorkspaceIdFromInvite: async (code, appId) => {
+    return await API.delete<void, UpdateInviteResponse>({
+      url: `/api/global/users/invite/update/${code}/${appId}`,
     })
   },
 

--- a/packages/types/src/api/web/user.ts
+++ b/packages/types/src/api/web/user.ts
@@ -157,13 +157,6 @@ export interface CheckInviteResponse {
 
 export type GetUserInvitesResponse = InviteWithCode[]
 
-export interface UpdateInviteRequest extends Omit<Invite, "email"> {
-  email?: string
-  builder?: {
-    apps: string[]
-  }
-  apps: string[]
-}
 export interface UpdateInviteResponse extends Invite {}
 
 export type LookupAccountHolderResponse = AccountMetadata | null

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -513,12 +513,16 @@ export const addWorkspaceIdToInvite = async (
 ) => {
   const { code, appId, role } = ctx.params
 
-  const invite = await cache.invite.getCode(code)
-  invite.info.apps ??= {}
-  invite.info.apps[appId] = role
+  try {
+    const invite = await cache.invite.getCode(code)
+    invite.info.apps ??= {}
+    invite.info.apps[appId] = role
 
-  await cache.invite.updateCode(code, invite)
-  ctx.body = { ...invite }
+    await cache.invite.updateCode(code, invite)
+    ctx.body = { ...invite }
+  } catch (e) {
+    ctx.throw(400, "Invitation is not valid or has expired.")
+  }
 }
 
 export const removeWorkspaceIdFromInvite = async (
@@ -526,12 +530,16 @@ export const removeWorkspaceIdFromInvite = async (
 ) => {
   const { code, appId } = ctx.params
 
-  const invite = await cache.invite.getCode(code)
-  invite.info.apps ??= {}
-  delete invite.info.apps[appId]
+  try {
+    const invite = await cache.invite.getCode(code)
+    invite.info.apps ??= {}
+    delete invite.info.apps[appId]
 
-  await cache.invite.updateCode(code, invite)
-  ctx.body = { ...invite }
+    await cache.invite.updateCode(code, invite)
+    ctx.body = { ...invite }
+  } catch (e) {
+    ctx.throw(400, "Invitation is not valid or has expired.")
+  }
 }
 
 export const inviteAccept = async (

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -114,6 +114,90 @@ describe("/api/global/users", () => {
     })
   })
 
+  describe("POST /api/global/users/invite/update/:code/:appId/:role", () => {
+    it("should be able to add workspace id to invite", async () => {
+      const email = structures.users.newEmail()
+      const { code } = await config.api.users.sendUserInvite(
+        sendMailMock,
+        email
+      )
+      const appId = "app_123456789"
+      const role = "BASIC"
+
+      const res = await config.api.users.addWorkspaceIdToInvite(
+        code,
+        appId,
+        role
+      )
+
+      expect(res.body.info.apps).toBeDefined()
+      expect(res.body.info.apps[appId]).toBe(role)
+    })
+
+    it("should handle invalid invite code", async () => {
+      const appId = "app_123456789"
+      const role = "BASIC"
+
+      await config.api.users.addWorkspaceIdToInvite(
+        "invalid_code",
+        appId,
+        role,
+        400
+      )
+    })
+  })
+
+  describe("DELETE /api/global/users/invite/update/:code/:appId", () => {
+    it("should be able to remove workspace id from invite", async () => {
+      const email = structures.users.newEmail()
+      const { code } = await config.api.users.sendUserInvite(
+        sendMailMock,
+        email
+      )
+      const appId = "app_123456789"
+      const role = "BASIC"
+
+      // First add the workspace
+      await config.api.users.addWorkspaceIdToInvite(code, appId, role)
+
+      // Then remove it
+      const res = await config.api.users.removeWorkspaceIdFromInvite(
+        code,
+        appId
+      )
+
+      expect(res.body.info.apps).toBeDefined()
+      expect(res.body.info.apps[appId]).toBeUndefined()
+    })
+
+    it("should handle removing non-existent workspace id", async () => {
+      const email = structures.users.newEmail()
+      const { code } = await config.api.users.sendUserInvite(
+        sendMailMock,
+        email
+      )
+      const appId = "app_nonexistent"
+
+      const res = await config.api.users.removeWorkspaceIdFromInvite(
+        code,
+        appId
+      )
+
+      expect(res.body.info.apps).toBeDefined()
+      expect(res.body.info.apps[appId]).toBeUndefined()
+    })
+
+    it("should handle invalid invite code", async () => {
+      const appId = "app_123456789"
+
+      await config.api.users.removeWorkspaceIdFromInvite(
+        "invalid_code",
+        appId,
+        400
+      )
+    })
+  })
+
   describe("POST /api/global/users/multi/invite", () => {
     it("should be able to generate an invitation", async () => {
       const newUserInvite = () => ({

--- a/packages/worker/src/api/routes/global/users.ts
+++ b/packages/worker/src/api/routes/global/users.ts
@@ -102,6 +102,14 @@ builderOrAdminRoutes
   .get("/api/global/users/count/:appId", controller.countByApp)
   .get("/api/global/users/invites", controller.getUserInvites)
   .get("/api/global/users/:id", controller.find)
+  .post(
+    "/api/global/users/invite/update/:code/:appId/:role",
+    controller.addWorkspaceIdToInvite
+  )
+  .delete(
+    "/api/global/users/invite/update/:code/:appId",
+    controller.removeWorkspaceIdFromInvite
+  )
 
 adminRoutes
   .post("/api/global/users/invite", buildInviteValidation(), controller.invite)
@@ -118,14 +126,6 @@ adminRoutes
   .post(
     "/api/global/users/multi/invite/delete",
     controller.removeMultipleInvites
-  )
-  .post(
-    "/api/global/users/invite/update/:code/:appId/:role",
-    controller.addWorkspaceIdToInvite
-  )
-  .delete(
-    "/api/global/users/invite/update/:code/:appId",
-    controller.removeWorkspaceIdFromInvite
   )
 
 loggedInRoutes

--- a/packages/worker/src/api/routes/global/users.ts
+++ b/packages/worker/src/api/routes/global/users.ts
@@ -119,7 +119,14 @@ adminRoutes
     "/api/global/users/multi/invite/delete",
     controller.removeMultipleInvites
   )
-  .post("/api/global/users/invite/update/:code", controller.updateInvite)
+  .post(
+    "/api/global/users/invite/update/:code/:appId/:role",
+    controller.addWorkspaceIdToInvite
+  )
+  .delete(
+    "/api/global/users/invite/update/:code/:appId",
+    controller.removeWorkspaceIdFromInvite
+  )
 
 loggedInRoutes
   // search can be used by any user now, to retrieve users for user column

--- a/packages/worker/src/tests/api/users.ts
+++ b/packages/worker/src/tests/api/users.ts
@@ -1,14 +1,14 @@
+import { generator } from "@budibase/backend-core/tests"
 import {
-  BulkUserResponse,
   BulkUserRequest,
-  InviteUsersRequest,
-  User,
+  BulkUserResponse,
   CreateAdminUserRequest,
-  SearchFilters,
+  InviteUsersRequest,
   InviteUsersResponse,
+  SearchFilters,
+  User,
 } from "@budibase/types"
 import structures from "../structures"
-import { generator } from "@budibase/backend-core/tests"
 import { TestAPI, TestAPIOpts } from "./base"
 
 export class UserAPI extends TestAPI {
@@ -225,6 +225,27 @@ export class UserAPI extends TestAPI {
       .put(`/api/global/users/tenant/owner`)
       .send({ newAccountEmail, originalEmail, tenantIds })
       .set(this.config.internalAPIHeaders())
+      .expect(status)
+  }
+
+  addWorkspaceIdToInvite = (
+    code: string,
+    appId: string,
+    role: string,
+    status = 200
+  ) => {
+    return this.request
+      .post(`/api/global/users/invite/update/${code}/${appId}/${role}`)
+      .set(this.config.defaultHeaders())
+      .expect("Content-Type", /json/)
+      .expect(status)
+  }
+
+  removeWorkspaceIdFromInvite = (code: string, appId: string, status = 200) => {
+    return this.request
+      .delete(`/api/global/users/invite/update/${code}/${appId}`)
+      .set(this.config.defaultHeaders())
+      .expect("Content-Type", /json/)
       .expect(status)
   }
 }


### PR DESCRIPTION
## Description
Adding invited users to apps was using an update endpoint that was doing too many things. Currently, given an invite we can only do the following actions:
Admin:
1. Create invites
2. Revoke invites

Admin or builders:
1. Create an invite for a workspace
2. Add a workspace to an invite
3. Remove a workspace from an invite

Admin endpoints are left as they were. Admin or builder endpoints were simplified to their own endpoints with their own security