### PR TITLE
Readd manifest.json

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,9 +9,9 @@
     "url": "https://github.com/Budibase/budibase.git"
   },
   "scripts": {
-    "prebuild": "rimraf dist/",
+    "prebuild": "rimraf dist/ client/",
     "build": "node ./scripts/build.js",
-    "postbuild": "copyfiles -f ../client/dist/* client && copyfiles -f ../../yarn.lock ./dist/",
+    "postbuild": "copyfiles -f ../client/dist/*.js ../client/manifest.json client && copyfiles -f ../../yarn.lock ./dist/",
     "check:types": "tsc -p tsconfig.json --noEmit --paths null",
     "check:dependencies": "node ../../scripts/depcheck.js",
     "build:isolated-vm-lib:snippets": "esbuild --minify --bundle src/jsRunner/bundles/snippets.ts --outfile=src/jsRunner/bundles/snippets.ivm.bundle.js --platform=node --format=iife --global-name=snippets",


### PR DESCRIPTION
## Description
Readd manifest.json, fixing issue introduced in https://github.com/Budibase/budibase/pull/16878/files#diff-92fadee1dfb23b20d6b0f6557a3ea0b8a231a7591db73f9f37772383bd0575d9L14

Also, removing the analysis HTML, increase the image size but it's not needed

### Before
<img width="341" height="194" alt="image" src="https://github.com/user-attachments/assets/ccaf9d07-19bd-41c7-b670-e2458fe6a70e" />

### After
<img width="294" height="149" alt="image" src="https://github.com/user-attachments/assets/4d2fbc94-c77b-4427-b61d-237d7390dfb0" />
