### PR TITLE
Fix for recaptcha config screens

### DIFF
--- a/packages/builder/src/settings/pages/general.svelte
+++ b/packages/builder/src/settings/pages/general.svelte
@@ -195,7 +195,7 @@
   <div class="row">
     <Button secondary on:click={importModal?.show}>Import workspace</Button>
   </div>
-  <Divider />
+  <Divider noMargin />
   <Layout noPadding gap="XS">
     <div class="row">
       <Heading size="S">Recaptcha</Heading>

--- a/packages/builder/src/settings/pages/index.ts
+++ b/packages/builder/src/settings/pages/index.ts
@@ -31,6 +31,7 @@ import PWAPage from "@/settings/pages/pwa.svelte"
 import EmbedPage from "@/settings/pages/embed.svelte"
 import ScriptsPage from "@/settings/pages/scripts.svelte"
 import OAuth2Page from "@/settings/pages/oauth2/index.svelte"
+import Recaptcha from "@/settings/pages/recaptcha.svelte"
 
 const componentMap: Record<string, ComponentType> = {
   profile: ProfilePage,
@@ -61,6 +62,7 @@ const componentMap: Record<string, ComponentType> = {
   embed: EmbedPage,
   scripts: ScriptsPage,
   oauth2: OAuth2Page,
+  recaptcha: Recaptcha,
 }
 
 export const Pages = {

--- a/packages/builder/src/settings/pages/recaptcha.svelte
+++ b/packages/builder/src/settings/pages/recaptcha.svelte
@@ -9,13 +9,15 @@
     Layout,
     notifications,
   } from "@budibase/bbui"
-  import { auth } from "@/stores/portal"
+  import { auth, licensing } from "@/stores/portal"
   import { redirect } from "@roxi/routify"
   import { sdk } from "@budibase/shared-core"
   import { ConfigType, type RecaptchaConfig } from "@budibase/types"
   import { API } from "@/api"
   import { writable, get } from "svelte/store"
   import { onMount } from "svelte"
+  import LockedFeature from "@/pages/builder/portal/_components/LockedFeature.svelte"
+  import { routeActions } from "."
 
   let loading = false
 
@@ -32,6 +34,7 @@
   })
 
   $: configComplete = $values.siteKey && $values.secretKey
+  $: recaptchaEnabled = $licensing.recaptchaEnabled
 
   async function saveConfig() {
     const config = get(values)
@@ -74,35 +77,55 @@
   })
 </script>
 
-<Layout noPadding>
-  <Layout gap="XS" noPadding>
-    <Heading size="M">Recaptcha</Heading>
-    <Body>Configuration for app level Recaptcha protection</Body>
+<LockedFeature
+  planType={"Enterprise"}
+  enabled={recaptchaEnabled}
+  title={"Recaptcha"}
+  description={"Configuration for app level Recaptcha protection"}
+  upgradeButtonClick={async () => {
+    licensing.goToUpgradePage()
+  }}
+  showContentWhenDisabled
+>
+  <Layout noPadding>
+    {#if recaptchaEnabled}
+      <Layout gap="XS" noPadding>
+        <Body size="S">Configuration for app level Recaptcha protection</Body>
+      </Layout>
+      <Divider noMargin />
+    {/if}
+    <div class="fields">
+      <div class="field">
+        <Label size="L">Site key</Label>
+        <Input bind:value={$values.siteKey} disabled={!recaptchaEnabled} />
+      </div>
+      <div class="field">
+        <Label size="L">Secret key</Label>
+        <Input
+          type="password"
+          bind:value={$values.secretKey}
+          disabled={!recaptchaEnabled}
+        />
+      </div>
+    </div>
+    {#if recaptchaEnabled}
+      <div use:routeActions>
+        <Button
+          disabled={loading || !configComplete}
+          on:click={() => saveConfig()}
+          cta
+        >
+          Save
+        </Button>
+      </div>
+    {/if}
   </Layout>
-  <Divider />
-  <div class="fields">
-    <div class="field">
-      <Label size="L">Site key</Label>
-      <Input bind:value={$values.siteKey} />
-    </div>
-    <div class="field">
-      <Label size="L">Secret key</Label>
-      <Input type="password" bind:value={$values.secretKey} />
-    </div>
-  </div>
-  <div>
-    <Button
-      disabled={loading || !configComplete}
-      on:click={() => saveConfig()}
-      cta>Save</Button
-    >
-  </div>
-</Layout>
+</LockedFeature>
 
 <style>
   .fields {
     display: grid;
-    grid-gap: var(--spacing-m);
+    grid-gap: var(--spacing-s);
   }
   .field {
     display: grid;

--- a/packages/builder/src/settings/pages/recaptcha.svelte
+++ b/packages/builder/src/settings/pages/recaptcha.svelte
@@ -3,7 +3,6 @@
     Body,
     Button,
     Divider,
-    Heading,
     Input,
     Label,
     Layout,

--- a/packages/builder/src/settings/routes.ts
+++ b/packages/builder/src/settings/routes.ts
@@ -136,6 +136,12 @@ export const orgRoutes = (
       comp: Pages.get("auth"),
     },
     {
+      section: "Recaptcha",
+      path: "recaptcha",
+      icon: "shield-check",
+      comp: Pages.get("recaptcha"),
+    },
+    {
       section: "Audit logs",
       access: () => isAdmin,
       path: "audit",


### PR DESCRIPTION
## Description

@ConorWebb96 pointed out that the recaptcha config option was missing from the settings modal. This reinstates recaptcha inside the `ORGANISATION` section.

## Screenshots
<img width="452" height="621" alt="Screenshot 2025-09-23 at 15 54 16" src="https://github.com/user-attachments/assets/11bdfc97-015c-4212-a0b9-07865727dbd5" />

## Launchcontrol
Resurfaced the recaptcha menu in the settings modal.