### PR TITLE
Fix for sidebar ellipsis behaviour. Values were not truncating

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNavLink.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNavLink.svelte
@@ -98,12 +98,15 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    min-width: 0;
+    flex: 1;
   }
 
   .link .link_content {
     flex: 1;
     display: flex;
     justify-content: space-between;
+    min-width: 0;
   }
   .link.collapsed .link_content {
     display: none;


### PR DESCRIPTION
## Description
Fix for `SideNavLink` ellipsis behaviour. If the text body was too long the option wouldn't truncate properly and cause scrolling.

## Launchcontrol
Fix for sidebar ellipsis behaviour. Long menu items should not cause a scroll bar