### PR TITLE
BUDI-9693 - Quick fix for select fields issue in Create Row automation

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/RowSelector.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/RowSelector.svelte
@@ -256,6 +256,37 @@
   const customDrawer = ["string", "number", "barcodeqr", "bigint"]
 </script>
 
+{#if table && schemaFields}
+  <div class="add-fields-btn" class:empty={Object.is(editableFields, {})}>
+    <PropField {componentWidth} {fullWidth}>
+      <div class="prop-control-wrap" bind:this={popoverAnchor}>
+        <ActionGroup>
+          <ActionButton
+            on:click={() => {
+              customPopover.show()
+            }}
+            disabled={!schemaFields}
+          >
+            Edit fields
+          </ActionButton>
+          {#if schemaFields.length}
+            <ActionButton
+              on:click={() => {
+                dispatch("change", {
+                  meta: { fields: {} },
+                  row: {},
+                })
+              }}
+            >
+              Clear
+            </ActionButton>
+          {/if}
+        </ActionGroup>
+      </div>
+    </PropField>
+  </div>
+{/if}
+
 {#each schemaFields || [] as [field, schema]}
   {#if !isAutoincrement(schema) && Object.hasOwn(editableFields, field)}
     <PropField
@@ -315,37 +346,6 @@
     </PropField>
   {/if}
 {/each}
-
-{#if table && schemaFields}
-  <div class="add-fields-btn" class:empty={Object.is(editableFields, {})}>
-    <PropField {componentWidth} {fullWidth}>
-      <div class="prop-control-wrap" bind:this={popoverAnchor}>
-        <ActionGroup>
-          <ActionButton
-            on:click={() => {
-              customPopover.show()
-            }}
-            disabled={!schemaFields}
-          >
-            Edit fields
-          </ActionButton>
-          {#if schemaFields.length}
-            <ActionButton
-              on:click={() => {
-                dispatch("change", {
-                  meta: { fields: {} },
-                  row: {},
-                })
-              }}
-            >
-              Clear
-            </ActionButton>
-          {/if}
-        </ActionGroup>
-      </div>
-    </PropField>
-  </div>
-{/if}
 
 <Popover
   align="left"


### PR DESCRIPTION
## Description
When selecting the columns, the dropdown seems to move around, depending on how many columns are being selected, eventually becoming entirely obscured. This seems to be because the "Edit Fields" button appears _underneath_ the newly selected fields. This just puts the button above where the fields display, meaning it stays put when adding many fields to the automation step.

NB: No new code was written, just shuffled around a bit.

## Addresses
https://github.com/Budibase/budibase/issues/17029 

## Screenshots
https://jam.dev/c/302378fa-8de8-4a2c-9d14-a016e022499c 


