### PR TITLE
Budi 9707 self host onboarding errors

### DIFF
--- a/packages/builder/src/components/start/CreateAppModal.svelte
+++ b/packages/builder/src/components/start/CreateAppModal.svelte
@@ -7,7 +7,6 @@
     ModalContent,
     Dropzone,
   } from "@budibase/bbui"
-  import { initialise } from "@/stores/builder"
   import { API } from "@/api"
   import { appsStore, admin, auth, appCreationStore } from "@/stores/portal"
   import { onMount } from "svelte"
@@ -148,13 +147,8 @@
       // Create App
       const createdApp = await API.createApp(data)
 
-      // Select Correct Application/DB in prep for creating user
-      const pkg = await API.fetchAppPackage(createdApp.instance._id)
-
-      await initialise(pkg)
-
       // Update checklist - in case first app
-      await admin.init()
+      admin.markChecklistItemChecked("apps")
 
       // Create user
       await auth.setInitInfo({})

--- a/packages/builder/src/components/start/CreateAppModal.svelte
+++ b/packages/builder/src/components/start/CreateAppModal.svelte
@@ -9,6 +9,7 @@
   } from "@budibase/bbui"
   import { API } from "@/api"
   import { appsStore, admin, auth, appCreationStore } from "@/stores/portal"
+  import { initialise } from "@/stores/builder"
   import { onMount } from "svelte"
   import { goto } from "@roxi/routify"
   import { createValidationStore } from "@budibase/frontend-core/src/utils/validation/yup"
@@ -146,6 +147,10 @@
 
       // Create App
       const createdApp = await API.createApp(data)
+
+      // Select Correct Application/DB in prep for creating user
+      const pkg = await API.fetchAppPackage(createdApp.instance._id)
+      await initialise(pkg)
 
       // Update checklist - in case first app
       admin.markChecklistItemChecked("apps")

--- a/packages/builder/src/pages/builder/admin/index.svelte
+++ b/packages/builder/src/pages/builder/admin/index.svelte
@@ -34,7 +34,7 @@
       // Save the admin user
       await API.createAdminUser(adminUser)
       notifications.success("Admin user created")
-      await admin.init()
+      admin.markChecklistItemChecked("adminUser")
       await auth.login(formData?.email.trim(), formData?.password)
       $goto("../portal")
     } catch (error) {

--- a/packages/builder/src/pages/builder/portal/workspaces/index.svelte
+++ b/packages/builder/src/pages/builder/portal/workspaces/index.svelte
@@ -198,6 +198,10 @@
       // Create App
       const createdApp = await API.createApp(data)
 
+      // Select Correct Application/DB in prep for creating user
+      const pkg = await API.fetchAppPackage(createdApp.instance._id)
+      await initialise(pkg)
+
       // Update checklist - in case first app
       admin.markChecklistItemChecked("apps")
 

--- a/packages/builder/src/pages/builder/portal/workspaces/index.svelte
+++ b/packages/builder/src/pages/builder/portal/workspaces/index.svelte
@@ -1,4 +1,7 @@
 <script>
+  import { onMount } from "svelte"
+  import { get } from "svelte/store"
+  import { goto } from "@roxi/routify"
   import {
     Heading,
     Layout,
@@ -11,14 +14,13 @@
     Body,
     Search,
   } from "@budibase/bbui"
+  import { sdk } from "@budibase/shared-core"
+  import { API } from "@/api"
   import Spinner from "@/components/common/Spinner.svelte"
   import CreateAppModal from "@/components/start/CreateAppModal.svelte"
   import AppLimitModal from "@/components/portal/licensing/AppLimitModal.svelte"
   import AccountLockedModal from "@/components/portal/licensing/AccountLockedModal.svelte"
-  import { sdk } from "@budibase/shared-core"
-  import { automationStore, initialise } from "@/stores/builder"
-  import { API } from "@/api"
-  import { onMount } from "svelte"
+  import { automationStore } from "@/stores/builder"
   import {
     appsStore,
     auth,
@@ -30,7 +32,6 @@
     appCreationStore,
     backups,
   } from "@/stores/portal"
-  import { goto } from "@roxi/routify"
   import AppRow from "@/components/start/AppRow.svelte"
   import Logo from "assets/bb-space-man.svg"
   import TemplatesModal from "@/components/start/TemplatesModal.svelte"
@@ -197,12 +198,8 @@
       // Create App
       const createdApp = await API.createApp(data)
 
-      // Select Correct Application/DB in prep for creating user
-      const pkg = await API.fetchAppPackage(createdApp.instance._id)
-      await initialise(pkg)
-
       // Update checklist - in case first app
-      await admin.init()
+      admin.markChecklistItemChecked("apps")
 
       // Create user
       await API.updateOwnMetadata({
@@ -258,7 +255,9 @@
       if (usersLimitLockAction) {
         usersLimitLockAction()
       }
-      await templates.load()
+      if (get(templates).length === 0) {
+        await templates.load()
+      }
     } catch (error) {
       notifications.error("Error getting init info")
     }

--- a/packages/builder/src/pages/builder/portal/workspaces/index.svelte
+++ b/packages/builder/src/pages/builder/portal/workspaces/index.svelte
@@ -20,7 +20,7 @@
   import CreateAppModal from "@/components/start/CreateAppModal.svelte"
   import AppLimitModal from "@/components/portal/licensing/AppLimitModal.svelte"
   import AccountLockedModal from "@/components/portal/licensing/AccountLockedModal.svelte"
-  import { automationStore } from "@/stores/builder"
+  import { automationStore, initialise } from "@/stores/builder"
   import {
     appsStore,
     auth,

--- a/packages/builder/src/pages/builder/portal/workspaces/onboarding/index.svelte
+++ b/packages/builder/src/pages/builder/portal/workspaces/onboarding/index.svelte
@@ -5,7 +5,6 @@
   import Spinner from "@/components/common/Spinner.svelte"
   import { API } from "@/api"
   import { auth, admin } from "@/stores/portal"
-  import { initialise } from "@/stores/builder"
   import {
     buildBuilderWorkspaceDesignRoute,
     buildBuilderWorkspaceRoute,
@@ -32,8 +31,7 @@
 
       const pkg = await API.fetchAppPackage(createdApp.instance._id)
 
-      await initialise(pkg)
-      await admin.init()
+      admin.markChecklistItemChecked("apps")
       await auth.setInitInfo({})
 
       const homeScreen = pkg.screens.find(screen => screen.routing?.homeScreen)

--- a/packages/builder/src/pages/builder/portal/workspaces/onboarding/index.svelte
+++ b/packages/builder/src/pages/builder/portal/workspaces/onboarding/index.svelte
@@ -5,6 +5,7 @@
   import Spinner from "@/components/common/Spinner.svelte"
   import { API } from "@/api"
   import { auth, admin } from "@/stores/portal"
+  import { initialise } from "@/stores/builder"
   import {
     buildBuilderWorkspaceDesignRoute,
     buildBuilderWorkspaceRoute,
@@ -30,6 +31,7 @@
       const createdApp = await API.createApp(data)
 
       const pkg = await API.fetchAppPackage(createdApp.instance._id)
+      await initialise(pkg)
 
       admin.markChecklistItemChecked("apps")
       await auth.setInitInfo({})

--- a/packages/builder/src/stores/portal/admin.ts
+++ b/packages/builder/src/stores/portal/admin.ts
@@ -13,7 +13,7 @@ import { auth } from "./auth"
 export interface AdminState
   extends Omit<GetEnvironmentResponse, "serveDevClientFromStorage"> {
   loaded: boolean
-  checklist?: ConfigChecklistResponse
+  checklist: ConfigChecklistResponse
   status?: SystemStatusResponse
   usingLocalComponentLibs: boolean
 }
@@ -115,7 +115,7 @@ export class AdminStore extends BudiStore<AdminState> {
 
   markChecklistItemChecked(key: ChecklistKey) {
     this.update(store => {
-      const checklist = store.checklist ?? createDefaultChecklist()
+      const checklist = store.checklist
       store.checklist = {
         ...checklist,
         [key]: {

--- a/packages/builder/src/stores/portal/admin.ts
+++ b/packages/builder/src/stores/portal/admin.ts
@@ -23,28 +23,20 @@ type ChecklistKey = keyof Pick<
   "apps" | "adminUser" | "smtp" | "sso"
 >
 
+const checklistDefault = {
+  checked: false,
+  label: "",
+  link: "",
+}
+
 const createDefaultChecklist = (): ConfigChecklistResponse => ({
-  apps: {
-    checked: false,
-    label: "",
-    link: "",
-  },
-  adminUser: {
-    checked: false,
-    label: "",
-    link: "",
-  },
+  apps: { ...checklistDefault },
+  adminUser: { ...checklistDefault },
   smtp: {
-    checked: false,
-    label: "",
-    link: "",
+    ...checklistDefault,
     fallback: false,
   },
-  sso: {
-    checked: false,
-    label: "",
-    link: "",
-  },
+  sso: { ...checklistDefault },
   branding: {},
 })
 
@@ -58,6 +50,7 @@ export class AdminStore extends BudiStore<AdminState> {
       disableAccountPortal: false,
       offlineMode: false,
       maintenance: [],
+      checklist: createDefaultChecklist(),
       usingLocalComponentLibs: false,
     })
   }

--- a/packages/builder/src/stores/portal/admin.ts
+++ b/packages/builder/src/stores/portal/admin.ts
@@ -18,6 +18,36 @@ export interface AdminState
   usingLocalComponentLibs: boolean
 }
 
+type ChecklistKey = keyof Pick<
+  ConfigChecklistResponse,
+  "apps" | "adminUser" | "smtp" | "sso"
+>
+
+const createDefaultChecklist = (): ConfigChecklistResponse => ({
+  apps: {
+    checked: false,
+    label: "",
+    link: "",
+  },
+  adminUser: {
+    checked: false,
+    label: "",
+    link: "",
+  },
+  smtp: {
+    checked: false,
+    label: "",
+    link: "",
+    fallback: false,
+  },
+  sso: {
+    checked: false,
+    label: "",
+    link: "",
+  },
+  branding: {},
+})
+
 export class AdminStore extends BudiStore<AdminState> {
   constructor() {
     super({
@@ -90,14 +120,13 @@ export class AdminStore extends BudiStore<AdminState> {
     })
   }
 
-  markChecklistItemChecked(key: "apps" | "adminUser" | "smtp" | "sso") {
+  markChecklistItemChecked(key: ChecklistKey) {
     this.update(store => {
-      const checklist = store.checklist ?? {}
-      const current = checklist[key] ?? {}
+      const checklist = store.checklist ?? createDefaultChecklist()
       store.checklist = {
         ...checklist,
         [key]: {
-          ...current,
+          ...checklist[key],
           checked: true,
         },
       }

--- a/packages/builder/src/stores/portal/admin.ts
+++ b/packages/builder/src/stores/portal/admin.ts
@@ -90,6 +90,21 @@ export class AdminStore extends BudiStore<AdminState> {
     })
   }
 
+  markChecklistItemChecked(key: "apps" | "adminUser" | "smtp" | "sso") {
+    this.update(store => {
+      const checklist = store.checklist ?? {}
+      const current = checklist[key] ?? {}
+      store.checklist = {
+        ...checklist,
+        [key]: {
+          ...current,
+          checked: true,
+        },
+      }
+      return store
+    })
+  }
+
   unload() {
     this.update(store => {
       store.loaded = false


### PR DESCRIPTION
## Description
The new onboarding flow for self-host was causing a ratelimit due to large numbers of requests in a short window. 
As `admin.init` is already called onMount, I've updated the code to directly call checklist update instead of calling `admin.init` multiple times.

The number of network requests for self-host onboarding has been reduced from **67** down to **60**.

Unfortunately not being able to remove the `fetchAppPackage` calls adds 13 network requests.

## Addresses
- https://linear.app/budibase/issue/BUDI-9707/self-host-onboarding-errors

## Screenshots
https://github.com/user-attachments/assets/e78a8a2a-7771-491d-9182-9abd82a6c7ad
*self-host*

https://github.com/user-attachments/assets/3aa9a5d4-ea73-4304-bff5-bb37c4d1d701
*cloud*

## Launchcontrol
Fix for new onboarding in self-host. Solves issue relating to ratelimit.
