### PR TITLE
Add command for outputting release PRs

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "build:sdk": "lerna run --stream build:sdk",
     "deps:circular": "madge packages/server/dist/index.js packages/worker/src/index.ts packages/backend-core/dist/src/index.js packages/cli/src/index.js --circular",
     "release": "lerna publish from-package --yes --force-publish --no-git-tag-version --no-push --no-git-reset",
+    "pending-releases": "TAG=${TAG:-$(gh release view --json tagName -q '.tagName')} && gh pr list --state merged --base master --search \"merged:>$(git log -1 --format=%aI \"$TAG\")\" --limit 100",
     "restore": "yarn run clean && yarn && yarn run build",
     "nuke": "yarn run nuke:packages && yarn run nuke:docker",
     "nuke:packages": "yarn run restore",


### PR DESCRIPTION
## Description
Add a command to output the PRs pending to release.

`yarn pending-releases`
Output:
```
Showing 2 of 2 pull requests in Budibase/budibase that match your search

ID      TITLE                                                      BRANCH                                                            CREATED AT        
#17052  Fix issues around assigning roles for users with SSO only  budi-9705-assigning-roles-fails-with-password-change-is-disabled  about 18 hours ago
#17050  fix: openapi readme version pin                            fix-openapi-readme-job                                            about 1 day ago
```


It can also use specific tags
`TAG=3.20.0 yarn pending-releases`
Output:
```
Showing 19 of 19 pull requests in Budibase/budibase that match your search

ID      TITLE                                                                   BRANCH                                                            CREATED AT        
#17052  Fix issues around assigning roles for users with SSO only               budi-9705-assigning-roles-fails-with-password-change-is-disabled  about 18 hours ago
#17050  fix: openapi readme version pin                                         fix-openapi-readme-job                                            about 1 day ago
#17046  Feature/new onboarding                                                  feature/new-onboarding                                            about 1 day ago
#17044  Revert "Merge pull request #16981 from Budibase/feature/new-onboardin…  revert/onboarding                                                 about 1 day ago
#17039  Ensure JSON fields are re-rendered when the block id changes.           fix/json-picker-rerender-on-change-block                          about 1 day ago
#17030  BUDI-9693 - Quick fix for select fields issue in Create Row automation  budi-9693-select-fields-dropdown-moves-off-screen-in-create-row   about 5 days ago
#17028  Fix for sidebar ellipsis behaviour. Values were not truncating          fix/workspace-favourite-scroll                                    about 5 days ago
#17027  fix: Always pass conf when running redis-server in singleimage          simplify-redis-runner-script                                      about 5 days ago
#17020  fix link                                                                fix/broken-link                                                   about 6 days ago
[...]
```