### PR TITLE
Bump PROXY_RATE_LIMIT_API_PER_SECOND to 50 temporarily

### DIFF
--- a/hosting/docker-compose.build.yaml
+++ b/hosting/docker-compose.build.yaml
@@ -69,7 +69,7 @@ services:
     image: budibase/proxy
     environment:
       - PROXY_RATE_LIMIT_WEBHOOKS_PER_SECOND=10
-      - PROXY_RATE_LIMIT_API_PER_SECOND=20
+      - PROXY_RATE_LIMIT_API_PER_SECOND=50
       - APPS_UPSTREAM_URL=http://app-service:4002
       - WORKER_UPSTREAM_URL=http://worker-service:4003
       - MINIO_UPSTREAM_URL=http://minio-service:9000

--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -82,7 +82,7 @@ services:
     image: budibase/proxy
     environment:
       - PROXY_RATE_LIMIT_WEBHOOKS_PER_SECOND=10
-      - PROXY_RATE_LIMIT_API_PER_SECOND=20
+      - PROXY_RATE_LIMIT_API_PER_SECOND=50
       - APPS_UPSTREAM_URL=http://app-service:4002
       - WORKER_UPSTREAM_URL=http://worker-service:4003
       - MINIO_UPSTREAM_URL=http://minio-service:9000

--- a/hosting/proxy/Dockerfile
+++ b/hosting/proxy/Dockerfile
@@ -16,7 +16,7 @@ COPY error.html /usr/share/nginx/html/error.html
 
 # Default environment
 ENV PROXY_RATE_LIMIT_WEBHOOKS_PER_SECOND=10
-ENV PROXY_RATE_LIMIT_API_PER_SECOND=20
+ENV PROXY_RATE_LIMIT_API_PER_SECOND=50
 ENV PROXY_TIMEOUT_SECONDS=120
 # Use docker-compose values as defaults for backwards compatibility
 ENV APPS_UPSTREAM_URL=http://app-service:4002


### PR DESCRIPTION
## Description
Resolves an issue of 429 errors during docker-compose / single image onboarding. This is a temp fix until the number of requests are reduced.

## Addresses
- https://linear.app/budibase/issue/BUDI-9707/self-host-onboarding-errors

## Launchcontrol
Bug fix for self-host onboarding
