### PR TITLE
Don't redirect creator to onboarding

### DIFF
--- a/packages/builder/src/pages/builder/portal/workspaces/_layout.svelte
+++ b/packages/builder/src/pages/builder/portal/workspaces/_layout.svelte
@@ -35,7 +35,7 @@
       // Go to new app page if no apps exists
       if (
         !$appsStore.apps.length &&
-        sdk.users.hasBuilderPermissions($auth.user)
+        sdk.users.hasAdminPermissions($auth.user)
       ) {
         $redirect("./onboarding")
       }


### PR DESCRIPTION
## Description
Creators should not be redirected to onboarding

## Addresses
- https://linear.app/budibase/issue/BUDI-9710/when-onboarding-a-creator-it-incorrectly-redirects-to-onboarding

## Screenshots
<img width="2554" height="1217" alt="creator" src="https://github.com/user-attachments/assets/2c87aa57-086a-4f7a-b3ce-20ff7cbb10d2" />

*Instead of redirecting creators to onboarding, just show this screen*

