### PR TITLE
Fix for Signature upload on public apps

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -4893,6 +4893,7 @@
       "width": 400,
       "height": 60
     },
+    "requiredAncestors": ["form"],
     "settings": [
       {
         "type": "field/signature_single",

--- a/packages/frontend-core/src/components/grid/cells/SignatureCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/SignatureCell.svelte
@@ -11,7 +11,7 @@
   export let readonly = false
   export let api
 
-  const { API, notifications, props } = getContext("grid")
+  const { API, notifications, props, datasource } = getContext("grid")
 
   let isOpen = false
   let modal
@@ -47,9 +47,12 @@
     attachRequest.append("file", signatureFile)
 
     try {
-      const uploadReq = await API.uploadBuilderAttachment(attachRequest)
-      const [signatureAttachment] = uploadReq
-      onChange(signatureAttachment)
+      const tableId = $datasource?.tableId || $datasource?.id
+      const result = await (tableId
+        ? API.uploadAttachment(tableId, attachRequest)
+        : API.uploadBuilderAttachment(attachRequest))
+
+      onChange(result[0])
     } catch (error) {
       $notifications.error(error.message || "Failed to save signature")
       return []


### PR DESCRIPTION
## Description
Signature cells in tables were not functioning properly in public apps. The upload method was incorrect and needed a datasource specific flow to properly take into account datasource permissions.

Also, I noticed while fixing this that signature field components display when not in a form. This lead to confusion and they will now only display properly when they are the child of a form component. This is exactly the same for attachment fields

## Addresses
- https://github.com/Budibase/budibase/issues/16697

## Screenshots
Ensure its clear to users that when the signature field is not within a form, it is actually not functional.
<img width="429" height="153" alt="Screenshot 2025-10-01 at 15 59 22" src="https://github.com/user-attachments/assets/f72d9dd7-0361-4ec0-a024-4bdcb5e0027a" />

## Launchcontrol
Public signature field fixes