### PR TITLE
Ensure lucene query is only run against parsed values for row button …

### DIFF
--- a/packages/frontend-core/src/components/grid/stores/conditions.ts
+++ b/packages/frontend-core/src/components/grid/stores/conditions.ts
@@ -48,12 +48,17 @@ export const deriveStores = (context: StoreContext): ConditionDerivedStore => {
 
       // Add button conditions
       if ($props.buttons) {
-        for (let button of $props.buttons) {
+        for (
+          let buttonIndex = 0;
+          buttonIndex < $props.buttons.length;
+          buttonIndex++
+        ) {
+          const button = $props.buttons[buttonIndex]
           for (let condition of button.conditions || []) {
             newConditions.push({
               ...condition,
               target: "button",
-              buttonIndex: $props.buttons.indexOf(button),
+              buttonIndex,
             })
           }
         }
@@ -161,14 +166,30 @@ const evaluateConditions = (
 
   // Add dynamic button conditions from getRowConditions
   if ($props.buttons) {
-    for (let button of $props.buttons) {
-      if (button.getRowConditions) {
-        const dynamicConditions = button.getRowConditions(row) || []
+    for (
+      let buttonIndex = 0;
+      buttonIndex < $props.buttons.length;
+      buttonIndex++
+    ) {
+      const button = $props.buttons[buttonIndex]
+      if (!button.getRowConditions) {
+        continue
+      }
+
+      const dynamicConditions = button.getRowConditions(row) || []
+      if (dynamicConditions.length) {
+        allConditions = allConditions.filter(condition => {
+          return !(
+            condition.target === "button" &&
+            condition.buttonIndex === buttonIndex
+          )
+        })
+
         for (let condition of dynamicConditions) {
           allConditions.push({
             ...condition,
             target: "button",
-            buttonIndex: $props.buttons.indexOf(button),
+            buttonIndex,
           })
         }
       }


### PR DESCRIPTION
## Description
Fix bug with *Not equals* filter on table row button condition.

## Addresses
- https://linear.app/budibase/issue/BUDI-9711/not-equals-condition-on-buttons-in-tables-does-not-work
- https://github.com/Budibase/budibase/issues/17059

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
<img width="861" height="820" alt="show equals" src="https://github.com/user-attachments/assets/7adfa63c-15aa-4e6c-ad0f-aa0c9d248a5b" />

**Show equals**

---

<img width="861" height="820" alt="hide equals" src="https://github.com/user-attachments/assets/2a974832-1b49-47e9-8c9d-f7045d27aad5" />

**Hide equals**

---

<img width="861" height="820" alt="show not equals" src="https://github.com/user-attachments/assets/9c02693b-21c2-45bd-90c3-f467c86ef0a2" />

**Show not equals**

---

<img width="861" height="820" alt="hide not equals" src="https://github.com/user-attachments/assets/eba72726-b533-49d5-8deb-1476cc59ba0a" />

**Hide not equals**

---

## Launchcontrol
Fix bug with *Not equals* filter on table row button condition.
