### PR TITLE
Fix Azure OpenAI unable to be enabled due to missing  default model validation

### DIFF
--- a/packages/builder/src/settings/pages/ai/ConfigModal.svelte
+++ b/packages/builder/src/settings/pages/ai/ConfigModal.svelte
@@ -14,7 +14,12 @@
 
   $: {
     const { provider, defaultModel, name, apiKey } = config
-    complete = Boolean(provider && name && defaultModel && apiKey)
+    complete = Boolean(
+      provider &&
+      name &&
+      apiKey &&
+      (provider === "AzureOpenAI" || defaultModel)
+    )
   }
   $: canEditBaseUrl =
     config.provider &&

--- a/packages/builder/src/settings/pages/ai/ConfigModal.svelte
+++ b/packages/builder/src/settings/pages/ai/ConfigModal.svelte
@@ -15,10 +15,7 @@
   $: {
     const { provider, defaultModel, name, apiKey } = config
     complete = Boolean(
-      provider &&
-      name &&
-      apiKey &&
-      (provider === "AzureOpenAI" || defaultModel)
+      provider && name && apiKey && (provider === "AzureOpenAI" || defaultModel)
     )
   }
   $: canEditBaseUrl =


### PR DESCRIPTION
## Description
Fixes an issue where you could not enable AzureOpenAI in our AI Config. This was because we were expecting a "DefaultModel" variable to be completed in order to _enable the enable_ button. This was never satisifed as you specify the model as part of the connection url for Azure. 


## Launchcontrol
Fix an issue where Azure OpenAI could not be enabled. 