### PR TITLE
SCIM RFC-7643 compliant

### DIFF
--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -256,7 +256,7 @@ const environment = {
     environment[key] = value
   },
   ROLLING_LOG_MAX_SIZE: process.env.ROLLING_LOG_MAX_SIZE || "10M",
-  DISABLE_SCIM_CALLS: process.env.DISABLE_SCIM_CALLS,
+  ENABLE_SCIM_LOGGER: process.env.ENABLE_SCIM_LOGGER,
   BB_ADMIN_USER_EMAIL: process.env.BB_ADMIN_USER_EMAIL,
   BB_ADMIN_USER_PASSWORD: process.env.BB_ADMIN_USER_PASSWORD,
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,

--- a/packages/types/src/api/web/global/scim/users.ts
+++ b/packages/types/src/api/web/global/scim/users.ts
@@ -1,4 +1,4 @@
-import { ScimResource, ScimMeta } from "scim-patch"
+import { ScimMeta, ScimResource } from "scim-patch"
 import { ScimListResponse } from "./shared"
 
 type BooleanString = boolean | "True" | "true" | "False" | "false"
@@ -25,6 +25,9 @@ export interface ScimUserResponse extends ScimResource {
   }
   active: BooleanString
   emails?: Emails
+  "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"?: {
+    manager?: { value: string }
+  }
 }
 
 export interface ScimCreateUserRequest {


### PR DESCRIPTION
## Description
Fixing an issue around SCIM. The property manager is sent as a string (https://learn.microsoft.com/en-us/entra/identity/app-provisioning/use-scim-to-provision-users-and-groups#design-your-user-and-group-schema), but on the response it expects to be SCIM compliant, returning an object. 
This PR adds the map to handle these cases.

Also, re-adding the capacity to log SCIM calls (and disable it by default)

Pro PR:
- https://github.com/Budibase/budibase-pro/pull/465



## Launchcontrol
Fix usage of "manager" values in SCIM