### PR TITLE
Removed background color change for the app panel

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/_components/AppPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/_components/AppPanel.svelte
@@ -136,7 +136,6 @@
     padding: 9px 10px 12px 10px;
     position: relative;
     transition: width 360ms ease-out;
-    background: var(--background);
   }
   .drawer-container {
     position: absolute;


### PR DESCRIPTION
## Description
Minor visual fix to ensure consistent contrast between the app panel, preview and border. This was more apparent in the nord theme as the background was the same colour as the app panel border. Without the contrast the UI blended together.