### PR TITLE
chore: retype a few any

### DIFF
--- a/packages/server/__mocks__/@google-cloud/firestore.ts
+++ b/packages/server/__mocks__/@google-cloud/firestore.ts
@@ -1,6 +1,7 @@
+// @ts-nocheck
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 module FirebaseMock {
-  const firebase: any = {}
+  const firebase = {}
 
   firebase.Firestore = function () {
     this.get = jest.fn(() => [

--- a/packages/server/__mocks__/arangojs.ts
+++ b/packages/server/__mocks__/arangojs.ts
@@ -1,6 +1,7 @@
+// @ts-nocheck
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 module ArangoMock {
-  const arangodb: any = {}
+  const arangodb = {}
 
   arangodb.Database = function () {
     this.query = jest.fn(() => ({
@@ -10,7 +11,6 @@ module ArangoMock {
     this.close = jest.fn()
   }
 
-  // @ts-ignore
   arangodb.aql = (strings, ...args) => {
     let str = strings.join("{}")
 

--- a/packages/server/specs/resources/utils/Resource.ts
+++ b/packages/server/specs/resources/utils/Resource.ts
@@ -1,9 +1,11 @@
+// any is required as the real examples are very deeply nested
 type Example = {
   [key: string]: {
     [key: string]: any
   }
 }
 
+// any is required as the real schema are very deeply nested
 type Schema = {
   [key: string]: {
     [key: string]: any

--- a/packages/server/src/ai/tools/bamboohr/index.ts
+++ b/packages/server/src/ai/tools/bamboohr/index.ts
@@ -28,7 +28,10 @@ export class BambooHRClient {
   /**
    * Make API request to BambooHR API
    */
-  private async makeRequest(endpoint: string, options: any = {}): Promise<any> {
+  private async makeRequest(
+    endpoint: string,
+    options = { headers: {} }
+  ): Promise<any> {
     const url = `${this.baseUrl}${endpoint}`
 
     const response = await fetch(url, {

--- a/packages/server/src/ai/tools/budibase/rows.ts
+++ b/packages/server/src/ai/tools/budibase/rows.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
 import { newTool } from ".."
 import sdk from "../../../sdk"
+import { RowSearchParams, SortOrder } from "@budibase/types"
 
 export default [
   newTool({
@@ -93,8 +94,8 @@ export default [
         .describe("Sort configuration"),
       limit: z.number().optional().describe("Maximum number of results"),
     }),
-    handler: async ({ tableId, query, sort, limit }) => {
-      const searchParams: any = {
+    handler: async ({ tableId, query = {}, sort, limit }) => {
+      const searchParams: RowSearchParams = {
         tableId,
         query,
         limit,
@@ -102,7 +103,9 @@ export default [
       if (sort) {
         searchParams.sort = sort.column
         searchParams.sortOrder =
-          sort.order === "ascending" ? "ascending" : "descending"
+          sort.order === SortOrder.ASCENDING
+            ? SortOrder.ASCENDING
+            : SortOrder.DESCENDING
       }
 
       const rows = await sdk.rows.search(searchParams)

--- a/packages/server/src/ai/tools/confluence/index.ts
+++ b/packages/server/src/ai/tools/confluence/index.ts
@@ -206,7 +206,7 @@ export class ConfluenceClient {
             .replace(/\\n/g, "\n")
             .replace(/\\r\\n/g, "\n")
 
-          const body: any = {
+          const body: Record<string, unknown> = {
             spaceId: space_id,
             status,
             title,

--- a/packages/server/src/ai/tools/github/index.ts
+++ b/packages/server/src/ai/tools/github/index.ts
@@ -189,7 +189,7 @@ export class GitHubClient {
           state,
           labels,
         }) => {
-          const updateData: any = {}
+          const updateData: Record<string, unknown> = {}
           if (title) updateData.title = title
           if (body) {
             // Ensure proper formatting by converting escaped newlines to actual newlines

--- a/packages/server/src/api/controllers/automation.ts
+++ b/packages/server/src/api/controllers/automation.ts
@@ -267,7 +267,7 @@ export async function test(
 
   ctx.body = await withTestFlag(automation._id!, async () => {
     const occurredAt = new Date().getTime()
-    await updateTestHistory(appId, automation, { ...body, occurredAt })
+    await updateTestHistory(automation, { ...body, occurredAt })
     const input = prepareTestInput(body)
     const user = sdk.users.getUserContextBindings(ctx.user)
     return await triggers.externalTrigger(

--- a/packages/server/src/api/controllers/component.ts
+++ b/packages/server/src/api/controllers/component.ts
@@ -16,7 +16,7 @@ export async function fetchAppComponentDefinitions(
     const app = await db.get<Workspace>(DocumentType.WORKSPACE_METADATA)
 
     let componentManifests = await Promise.all(
-      app.componentLibraries.map(async (library: any) => {
+      app.componentLibraries.map(async library => {
         let manifest = await getComponentLibraryManifest(library)
         return {
           manifest,

--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -56,7 +56,7 @@ async function checkAllDeployments(
   return { updated, deployments }
 }
 
-async function storeDeploymentHistory(deployment: any) {
+async function storeDeploymentHistory(deployment: Deployment) {
   const deploymentJSON = deployment.getJSON()
   const db = context.getWorkspaceDB()
 
@@ -85,7 +85,7 @@ async function storeDeploymentHistory(deployment: any) {
   return deployment
 }
 
-async function initDeployedApp(prodAppId: any) {
+async function initDeployedApp(prodAppId: string) {
   const db = context.getProdWorkspaceDB()
   console.log("Reading automation docs")
   const automations = (

--- a/packages/server/src/api/controllers/plugin/github.ts
+++ b/packages/server/src/api/controllers/plugin/github.ts
@@ -4,7 +4,7 @@ import { downloadUnzipTarball } from "./utils"
 
 export async function request(
   url: string,
-  headers: { [key: string]: string },
+  headers: Record<string, string> = {},
   err: string
 ) {
   const response = await fetch(url, { headers })
@@ -30,7 +30,9 @@ export async function githubUpload(url: string, name = "", token = "") {
     "https://github.com/",
     "https://api.github.com/repos/"
   )
-  const headers: any = token ? { Authorization: `Bearer ${token}` } : {}
+  const headers: Record<string, string> = token
+    ? { Authorization: `Bearer ${token}` }
+    : {}
   const pluginDetails = await request(
     githubApiUrl,
     headers,

--- a/packages/server/src/api/controllers/role.ts
+++ b/packages/server/src/api/controllers/role.ts
@@ -191,7 +191,7 @@ export async function save(ctx: UserCtx<SaveRoleRequest, SaveRoleResponse>) {
       target: prodDb.name,
     })
     await replication.replicate({
-      filter: (doc: any) => {
+      filter: doc => {
         return doc._id && doc._id.startsWith("role_")
       },
     })

--- a/packages/server/src/api/controllers/row/internal.ts
+++ b/packages/server/src/api/controllers/row/internal.ts
@@ -55,7 +55,7 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   }
 
   // need to build up full patch fields before coerce
-  let combinedRow: any = cloneDeep(oldRow)
+  let combinedRow = cloneDeep(oldRow)
   for (let key of Object.keys(inputs)) {
     if (!table.schema[key]) continue
     combinedRow[key] = inputs[key]

--- a/packages/server/src/api/controllers/row/utils/utils.ts
+++ b/packages/server/src/api/controllers/row/utils/utils.ts
@@ -173,16 +173,16 @@ export function isUserMetadataTable(tableId: string) {
 }
 
 export async function enrichArrayContext(
-  fields: any[],
+  fields: Record<string, unknown>[],
   inputs = {},
   helpers = true
-): Promise<any[]> {
+): Promise<Record<string, any>[]> {
   const map: Record<string, any> = {}
   for (let index in fields) {
     map[index] = fields[index]
   }
   const output = await enrichSearchContext(map, inputs, helpers)
-  const outputArray: any[] = []
+  const outputArray = []
   for (let [key, value] of Object.entries(output)) {
     outputArray[parseInt(key)] = value
   }
@@ -194,7 +194,7 @@ export async function enrichSearchContext(
   inputs = {},
   helpers = true
 ): Promise<Record<string, any>> {
-  const enrichedQuery: Record<string, any> = {}
+  const enrichedQuery: Record<string, unknown> = {}
   if (!fields || !inputs) {
     return enrichedQuery
   }

--- a/packages/server/src/api/controllers/webhook.ts
+++ b/packages/server/src/api/controllers/webhook.ts
@@ -128,7 +128,7 @@ export async function trigger(
 
         if (triggers.isAutomationResults(response)) {
           let collectedValue = response.steps.find(
-            (step: any) => step.stepId === AutomationActionStepId.COLLECT
+            step => step.stepId === AutomationActionStepId.COLLECT
           )
 
           ctx.body = collectedValue?.outputs

--- a/packages/server/src/api/controllers/workspace.ts
+++ b/packages/server/src/api/controllers/workspace.ts
@@ -108,9 +108,9 @@ function checkWorkspaceUrl(
   currentAppId?: string
 ) {
   if (currentAppId) {
-    apps = apps.filter((app: any) => app.appId !== currentAppId)
+    apps = apps.filter(app => app.appId !== currentAppId)
   }
-  if (apps.some((app: any) => app.url === url)) {
+  if (apps.some(app => app.url === url)) {
     ctx.throw(400, "App URL is already in use.")
   }
 }

--- a/packages/server/src/api/routes/public/middleware/mapper.ts
+++ b/packages/server/src/api/routes/public/middleware/mapper.ts
@@ -73,7 +73,7 @@ function processQueries(ctx: Ctx) {
   }
 }
 
-export default async (ctx: Ctx, next: any) => {
+export default async (ctx: Ctx, next: () => Promise<void>) => {
   if (!ctx.body || noResponse(ctx) || isAttachment(ctx)) {
     return await next()
   }

--- a/packages/server/src/api/routes/public/middleware/testErrorHandling.ts
+++ b/packages/server/src/api/routes/public/middleware/testErrorHandling.ts
@@ -6,7 +6,7 @@ export default () => {
     throw new Error("This middleware is only for testing")
   }
 
-  return async (ctx: Ctx, next: any) => {
+  return async (ctx: Ctx, next: () => Promise<void>) => {
     try {
       await next()
     } catch (err: any) {

--- a/packages/server/src/api/utils.ts
+++ b/packages/server/src/api/utils.ts
@@ -5,7 +5,7 @@ import Router from "@koa/router"
 
 export function addFileManagement(router: Router) {
   /* istanbul ignore next */
-  router.param("file", async (file: any, ctx: any, next: any) => {
+  router.param("file", async (file: any, ctx: any, next: () => void) => {
     ctx.file = file && file.includes(".") ? file : "index.html"
     if (!ctx.file.startsWith("budibase-client")) {
       return next()

--- a/packages/server/src/automations/steps/utils.ts
+++ b/packages/server/src/automations/steps/utils.ts
@@ -1,6 +1,7 @@
 import { ContextEmitter } from "@budibase/types"
+import { Response } from "node-fetch"
 
-export async function getFetchResponse(fetched: any) {
+export async function getFetchResponse(fetched: Response) {
   let status = fetched.status,
     message
   const contentType = fetched.headers.get("content-type")
@@ -29,7 +30,7 @@ export function buildCtx(
     appId,
     user: opts.user || { appId },
     eventEmitter: emitter,
-    throw: (code: string, error: any) => {
+    throw: (_code: string, error: any) => {
       throw error
     },
   }

--- a/packages/server/src/automations/tests/utilities/AutomationTestBuilder.ts
+++ b/packages/server/src/automations/tests/utilities/AutomationTestBuilder.ts
@@ -37,10 +37,10 @@ type BranchConfig = {
 
 type LoopConfig = {
   option: LoopStepType
-  binding: any
+  binding: unknown
   steps: StepBuilderFunction
   iterations?: number
-  failure?: any
+  failure?: string
   resultOptions?: {
     storeFullResults?: boolean
     summarizeOnly?: boolean

--- a/packages/server/src/automations/tests/utilities/index.ts
+++ b/packages/server/src/automations/tests/utilities/index.ts
@@ -42,7 +42,7 @@ export function triggerCron(message: Job<AutomationData>) {
   getTestQueue().manualTrigger(message.id)
 }
 
-export async function runInProd(fn: any) {
+export async function runInProd(fn: () => unknown) {
   env._set("NODE_ENV", "production")
   let error
   try {

--- a/packages/server/src/automations/utils.ts
+++ b/packages/server/src/automations/utils.ts
@@ -7,6 +7,7 @@ import {
   CronTriggerInputs,
   isCronTrigger,
   MetadataType,
+  TestAutomationRequest,
 } from "@budibase/types"
 import { JobId } from "bull"
 import tracer from "dd-trace"
@@ -96,13 +97,12 @@ export async function processEvent(job: AutomationJob) {
 }
 
 export async function updateTestHistory(
-  appId: any,
-  automation: any,
-  history: any
+  automation: Automation,
+  history: TestAutomationRequest & { occurredAt: number }
 ) {
   return updateEntityMetadata(
     MetadataType.AUTOMATION_TEST_HISTORY,
-    automation._id,
+    automation._id as string,
     (metadata: any) => {
       if (metadata && Array.isArray(metadata.history)) {
         metadata.history.push(history)
@@ -117,7 +117,7 @@ export async function updateTestHistory(
 }
 
 // end the repetition and the job itself
-export async function disableAllCrons(appId: any) {
+export async function disableAllCrons(appId: string) {
   const promises = []
   const jobs = await automationQueue.getBullQueue().getRepeatableJobs()
   for (let job of jobs) {

--- a/packages/server/src/db/defaultData/datasource_bb_default.ts
+++ b/packages/server/src/db/defaultData/datasource_bb_default.ts
@@ -652,18 +652,16 @@ export async function buildDefaultDocs() {
   )
 
   // Build one link doc for each employee/job
-  const jobEmployeeLinks = employeeData.rows.map(
-    (employee: any, index: any) => {
-      return new LinkDocument(
-        employeeData.table._id!,
-        "Jobs",
-        employeeData.rows[index]._id!,
-        jobData.table._id!,
-        "Assigned",
-        jobData.rows[index]._id!
-      )
-    }
-  )
+  const jobEmployeeLinks = employeeData.rows.map((_employee, index) => {
+    return new LinkDocument(
+      employeeData.table._id!,
+      "Jobs",
+      employeeData.rows[index]._id!,
+      jobData.table._id!,
+      "Assigned",
+      jobData.rows[index]._id!
+    )
+  })
 
   const dataSource = {
     ...defaultDatasource,

--- a/packages/server/src/db/linkedRows/index.ts
+++ b/packages/server/src/db/linkedRows/index.ts
@@ -282,7 +282,7 @@ export async function squashLinks<T = Row[] | Row>(
         row[column] = await coreOutputProcessing(relatedTable, row[column])
       }
       row[column] = row[column].map((link: Row) => {
-        const obj: any = { _id: link._id }
+        const obj: Record<string, unknown> = { _id: link._id }
         obj.primaryDisplay = getPrimaryDisplayValue(link, relatedTable)
 
         if (viewSchema[column]?.columns) {

--- a/packages/server/src/db/utils.ts
+++ b/packages/server/src/db/utils.ts
@@ -77,10 +77,7 @@ export function generateTableID() {
 /**
  * Gets parameters for retrieving automations, this is a utility function for the getDocParams function.
  */
-export function getAutomationParams(
-  automationId?: Optional,
-  otherProps: any = {}
-) {
+export function getAutomationParams(automationId?: Optional, otherProps = {}) {
   return getDocParams(DocumentType.AUTOMATION, automationId, otherProps)
 }
 
@@ -149,7 +146,7 @@ export function generateLayoutID(id?: string) {
 /**
  * Gets parameters for retrieving layout, this is a utility function for the getDocParams function.
  */
-export function getLayoutParams(layoutId?: Optional, otherProps: any = {}) {
+export function getLayoutParams(layoutId?: Optional, otherProps = {}) {
   return getDocParams(DocumentType.LAYOUT, layoutId, otherProps)
 }
 
@@ -164,7 +161,7 @@ export function generateScreenID() {
 /**
  * Gets parameters for retrieving screens, this is a utility function for the getDocParams function.
  */
-export function getScreenParams(screenId?: Optional, otherProps: any = {}) {
+export function getScreenParams(screenId?: Optional, otherProps = {}) {
   return getDocParams(DocumentType.SCREEN, screenId, otherProps)
 }
 
@@ -179,7 +176,7 @@ export function generateWebhookID() {
 /**
  * Gets parameters for retrieving a webhook, this is a utility function for the getDocParams function.
  */
-export function getWebhookParams(webhookId?: Optional, otherProps: any = {}) {
+export function getWebhookParams(webhookId?: Optional, otherProps = {}) {
   return getDocParams(DocumentType.WEBHOOK, webhookId, otherProps)
 }
 
@@ -196,10 +193,7 @@ export function generateDatasourceID({ plus = false } = {}) {
 /**
  * Gets parameters for retrieving a datasource, this is a utility function for the getDocParams function.
  */
-export function getDatasourceParams(
-  datasourceId?: Optional,
-  otherProps: any = {}
-) {
+export function getDatasourceParams(datasourceId?: Optional, otherProps = {}) {
   return getDocParams(DocumentType.DATASOURCE, datasourceId, otherProps)
 }
 
@@ -231,7 +225,7 @@ export function generateAutomationMetadataID(automationId: string) {
 /**
  * Retrieve all automation metadata in a workspace database.
  */
-export function getAutomationMetadataParams(otherProps: any = {}) {
+export function getAutomationMetadataParams(otherProps = {}) {
   return getDocParams(DocumentType.AUTOMATION_METADATA, null, otherProps)
 }
 

--- a/packages/server/src/integrations/airtable.ts
+++ b/packages/server/src/integrations/airtable.ts
@@ -7,7 +7,7 @@ import {
   QueryType,
 } from "@budibase/types"
 
-import Airtable from "airtable"
+import Airtable, { FieldSet } from "airtable"
 
 interface AirtableConfig {
   apiKey: string
@@ -117,7 +117,7 @@ class AirtableIntegration implements IntegrationBase {
     }
   }
 
-  async create(query: { table: any; json: any }) {
+  async create(query: { table: string; json: FieldSet }) {
     const { table, json } = query
 
     try {
@@ -132,7 +132,7 @@ class AirtableIntegration implements IntegrationBase {
     }
   }
 
-  async read(query: { table: any; numRecords: any; view: any }) {
+  async read(query: { table: string; numRecords: number; view: string }) {
     try {
       const records = await this.client(query.table)
         .select({ maxRecords: query.numRecords || 10, view: query.view })
@@ -145,7 +145,7 @@ class AirtableIntegration implements IntegrationBase {
     }
   }
 
-  async update(query: { table: any; id: any; json: any }) {
+  async update(query: { table: string; id: string; json: FieldSet }) {
     const { table, id, json } = query
 
     try {
@@ -161,7 +161,7 @@ class AirtableIntegration implements IntegrationBase {
     }
   }
 
-  async delete(query: { table: any; ids: any }) {
+  async delete(query: { table: string; ids: string | string }) {
     try {
       return await this.client(query.table).destroy(query.ids)
     } catch (err) {

--- a/packages/server/src/integrations/arangodb.ts
+++ b/packages/server/src/integrations/arangodb.ts
@@ -97,7 +97,7 @@ class ArangoDBIntegration implements IntegrationBase {
     return response
   }
 
-  async read(query: { sql: any }) {
+  async read(query: { sql: string }) {
     try {
       const result = await this.client.query(query.sql)
       return result.all()
@@ -110,7 +110,7 @@ class ArangoDBIntegration implements IntegrationBase {
     }
   }
 
-  async create(query: { json: any }) {
+  async create(query: { json: string }) {
     const clc = this.client.collection(this.config.collection)
     try {
       const result = await this.client.query(

--- a/packages/server/src/integrations/mysql.ts
+++ b/packages/server/src/integrations/mysql.ts
@@ -100,7 +100,7 @@ const SCHEMA: Integration = {
   },
 }
 
-const defaultTypeCasting = function (field: any, next: any) {
+const defaultTypeCasting = function (field: any, next: () => void) {
   if (
     field.type == "DATETIME" ||
     field.type === "DATE" ||
@@ -210,7 +210,7 @@ class MySQLIntegration extends Sql implements DatasourcePlus {
     if (!schema) {
       return
     }
-    this.config.typeCast = function (field: any, next: any) {
+    this.config.typeCast = function (field: any, next: () => void) {
       if (schema[field.name]?.name === field.name) {
         if (["LONGLONG", "NEWDECIMAL", "DECIMAL"].includes(field.type)) {
           if (schema[field.name]?.type === "number") {

--- a/packages/server/src/middleware/appInfo.ts
+++ b/packages/server/src/middleware/appInfo.ts
@@ -7,7 +7,7 @@ export enum AppType {
 }
 
 export function middleware({ appType }: { appType?: AppType } = {}) {
-  return (ctx: Ctx, next: any) => {
+  return (ctx: Ctx, next: () => Promise<void>) => {
     const workspaceId = ctx.appId
     if (
       appType === AppType.DEV &&

--- a/packages/server/src/middleware/ensureTenantAppOwnership.ts
+++ b/packages/server/src/middleware/ensureTenantAppOwnership.ts
@@ -3,7 +3,7 @@ import { UserCtx } from "@budibase/types"
 
 export async function ensureTenantAppOwnershipMiddleware(
   ctx: UserCtx,
-  next: any
+  next: () => Promise<void> | void
 ) {
   const appId = await utils.getAppIdFromCtx(ctx)
   if (!appId) {

--- a/packages/server/src/middleware/joi-validator.ts
+++ b/packages/server/src/middleware/joi-validator.ts
@@ -3,7 +3,7 @@ import { Ctx } from "@budibase/types"
 
 function validate(schema: Joi.Schema, property: string) {
   // Return a Koa middleware function
-  return (ctx: Ctx, next: any) => {
+  return (ctx: Ctx, next: () => Promise<void>) => {
     if (!schema) {
       return next()
     }
@@ -25,7 +25,6 @@ function validate(schema: Joi.Schema, property: string) {
     const { error } = schema.validate(params)
     if (error) {
       ctx.throw(400, `Invalid ${property} - ${error.message}`)
-      return
     }
     return next()
   }

--- a/packages/server/src/middleware/publicApi.ts
+++ b/packages/server/src/middleware/publicApi.ts
@@ -4,7 +4,7 @@ import { Ctx } from "@budibase/types"
 export function publicApiMiddleware({
   requiresAppId,
 }: { requiresAppId?: boolean } = {}) {
-  return async (ctx: Ctx, next: any) => {
+  return async (ctx: Ctx, next: () => void) => {
     const appId = await utils.getAppIdFromCtx(ctx)
     if (requiresAppId && !appId) {
       ctx.throw(

--- a/packages/server/src/middleware/resourceId.ts
+++ b/packages/server/src/middleware/resourceId.ts
@@ -26,7 +26,7 @@ export class ResourceIdGetter {
     const parameter = this.parameter,
       main = this.main,
       sub = this.sub
-    return (ctx: Ctx, next: any) => {
+    return (ctx: Ctx, next: () => void) => {
       // @ts-ignore
       const request = ctx.request[parameter] || ctx[parameter]
       if (request == null) {

--- a/packages/server/src/middleware/zod-validator.ts
+++ b/packages/server/src/middleware/zod-validator.ts
@@ -7,7 +7,7 @@ import { fromZodError } from "zod-validation-error"
 
 function validate(schema: AnyZodObject, property: "body" | "params") {
   // Return a Koa middleware function
-  return async (ctx: Ctx, next: any) => {
+  return async (ctx: Ctx, next: () => void) => {
     if (!(await features.isEnabled(FeatureFlag.USE_ZOD_VALIDATOR))) {
       return next()
     }

--- a/packages/server/src/sdk/workspace/rows/search/external.ts
+++ b/packages/server/src/sdk/workspace/rows/search/external.ts
@@ -133,7 +133,7 @@ export async function search(
         key => source.schema?.[key].visible !== false
       )
     const allowedFields = [...visibleFields, ...PROTECTED_EXTERNAL_COLUMNS]
-    processed = processed.map((r: any) => pick(r, allowedFields))
+    processed = processed.map(r => pick(r, allowedFields))
 
     // need wrapper object for bookmarks etc when paginating
     const response: SearchResponse<Row> = { rows: processed, hasNextPage }

--- a/packages/server/src/sdk/workspace/rows/utils.ts
+++ b/packages/server/src/sdk/workspace/rows/utils.ts
@@ -142,7 +142,7 @@ export function cleanExportRows(
   let cleanRows = [...rows]
 
   const relationships = Object.entries(schema)
-    .filter((entry: any[]) => entry[1].type === FieldType.LINK)
+    .filter(entry => entry[1].type === FieldType.LINK)
     .map(entry => entry[0])
 
   relationships.forEach(column => {

--- a/packages/server/src/tests/utilities/api/base.ts
+++ b/packages/server/src/tests/utilities/api/base.ts
@@ -30,7 +30,7 @@ export interface Expectations {
   status?: number
   headers?: Record<string, string | RegExp>
   headersNotPresent?: string[]
-  body?: Record<string, any>
+  body?: Record<string, unknown>
 }
 
 export interface RequestOpts {

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -54,7 +54,7 @@ function stepSuccess(
   if (step.isLegacyLoop) {
     outputs.items = automationUtils.convertLegacyLoopOutputs(outputs.items)
 
-    const legacyChild: any = (step as LoopV2Step)?.inputs?.children?.[0]
+    const legacyChild = (step as LoopV2Step)?.inputs?.children?.[0]
     const legacyId = legacyChild?.id || step.id
     const legacyStepId = legacyChild?.stepId || step.stepId
     const legacyInputs = inputs || legacyChild?.inputs || step.inputs

--- a/packages/server/src/threads/query.ts
+++ b/packages/server/src/threads/query.ts
@@ -262,7 +262,7 @@ class QueryRunner {
       throw new Error("No refresh token found for authenticated user")
     }
 
-    const resp: any = await auth.refreshOAuthToken(
+    const resp = await auth.refreshOAuthToken(
       oauth2.refreshToken,
       providerType,
       configId

--- a/packages/server/src/utilities/fileSystem/filesystem.ts
+++ b/packages/server/src/utilities/fileSystem/filesystem.ts
@@ -65,7 +65,7 @@ export const loadHandlebarsFile = (path: PathLike) => {
  * @param contents the contents of the file which is to be returned from the API.
  * @return the read stream which can be put into the koa context body.
  */
-export const apiFileReturn = (contents: any) => {
+export const apiFileReturn = (contents: string | NodeJS.ArrayBufferView) => {
   const path = join(budibaseTempDir(), uuid())
   fs.writeFileSync(path, contents)
   return fs.createReadStream(path)
@@ -92,7 +92,9 @@ export const storeTempFile = (
  * Utility function for getting a file read stream - a simple in memory buffered read
  * stream doesn't work for pouchdb.
  */
-export const stringToFileStream = (contents: any) => {
+export const stringToFileStream = (
+  contents: string | NodeJS.ArrayBufferView
+) => {
   const path = storeTempFile(contents)
   return fs.createReadStream(path)
 }
@@ -101,7 +103,7 @@ export const stringToFileStream = (contents: any) => {
  * Creates a temp file and returns it from the API.
  * @param fileContents the contents to be returned in file.
  */
-export const sendTempFile = (fileContents: any) => {
+export const sendTempFile = (fileContents: string | NodeJS.ArrayBufferView) => {
   const path = storeTempFile(fileContents)
   return fs.createReadStream(path)
 }
@@ -115,7 +117,7 @@ export const readFileSync = (filepath: PathLike, options = "utf8") => {
   return fs.readFileSync(filepath, options)
 }
 
-export const createTempFolder = (item: any) => {
+export const createTempFolder = (item: string) => {
   const path = join(budibaseTempDir(), item)
   try {
     // remove old tmp directories automatically - don't combine
@@ -140,7 +142,10 @@ export const extractTarball = async (fromFilePath: string, toPath: string) => {
 /**
  * Find for a file recursively from start path applying filter, return first match
  */
-export const findFileRec = (startPath: PathLike, filter: string): any => {
+export const findFileRec = (
+  startPath: PathLike,
+  filter: string
+): string | undefined => {
   if (!fs.existsSync(startPath)) {
     return
   }

--- a/packages/server/src/utilities/fileSystem/plugin.ts
+++ b/packages/server/src/utilities/fileSystem/plugin.ts
@@ -1,4 +1,4 @@
-import { Plugin, PluginUpload } from "@budibase/types"
+import { Package, Plugin, PluginSchema, PluginUpload } from "@budibase/types"
 import { budibaseTempDir } from "../budibaseDir"
 import fs from "fs"
 import { join } from "path"
@@ -11,8 +11,8 @@ const AUTOMATION_PATH = join(budibaseTempDir(), "automation")
 export const getPluginMetadata = async (
   path: string
 ): Promise<PluginUpload> => {
-  let pkg: any
-  let schema: any
+  let pkg: Package
+  let schema: PluginSchema
   try {
     pkg = JSON.parse(fs.readFileSync(join(path, "package.json"), "utf8"))
     schema = JSON.parse(fs.readFileSync(join(path, "schema.json"), "utf8"))

--- a/packages/server/src/utilities/fileSystem/template.ts
+++ b/packages/server/src/utilities/fileSystem/template.ts
@@ -8,7 +8,10 @@ import { objectStore } from "@budibase/backend-core"
  * @param template The template object retrieved from the Koa context object.
  * @returns Returns an fs read stream which can be loaded into the database.
  */
-export const getTemplateStream = async (template: any) => {
+export const getTemplateStream = async (template: {
+  file: { path: string }
+  key: string
+}) => {
   if (template.file) {
     return fs.createReadStream(template.file.path)
   } else {

--- a/packages/server/src/utilities/index.ts
+++ b/packages/server/src/utilities/index.ts
@@ -39,7 +39,7 @@ export function isDate(str: string) {
   return false
 }
 
-export function removeFromArray(array: any[], element: any) {
+export function removeFromArray(array: unknown[], element: unknown) {
   const index = array.indexOf(element)
   if (index !== -1) {
     array.splice(index, 1)

--- a/packages/server/src/utilities/redis.ts
+++ b/packages/server/src/utilities/redis.ts
@@ -2,6 +2,7 @@ import { redis, RedisClient, utils } from "@budibase/backend-core"
 import { getGlobalIDFromUserMetadataID } from "../db/utils"
 import { ContextUser } from "@budibase/types"
 import env from "../environment"
+import Redis, { Cluster } from "ioredis"
 
 const APP_DEV_LOCK_SECONDS = 600
 const AUTOMATION_TEST_FLAG_SECONDS = 60
@@ -16,7 +17,7 @@ let devAppClient: RedisClient,
 
 // We need to maintain a duplicate client for socket.io pub/sub
 let socketClient: RedisClient
-let socketSubClient: any
+let socketSubClient: Redis | Cluster
 
 // We init this as we want to keep the connection open all the time
 // reduces the performance hit

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -167,7 +167,7 @@ async function processDefaultValues(table: Table, row: Row) {
  * @param type The type fo coerce to
  * @returns The coerced value
  */
-export function coerce(value: unknown, type: FieldType) {
+export function coerce(value: string | Date | string[], type: FieldType) {
   // no coercion specified for type, skip it
   if (!TYPE_TRANSFORM_MAP[type]) {
     return value
@@ -177,7 +177,6 @@ export function coerce(value: unknown, type: FieldType) {
     // @ts-ignore
     return TYPE_TRANSFORM_MAP[type][value]
   } else if (TYPE_TRANSFORM_MAP[type].parse) {
-    // @ts-ignore
     return TYPE_TRANSFORM_MAP[type].parse(value)
   }
 

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -167,13 +167,13 @@ async function processDefaultValues(table: Table, row: Row) {
  * @param type The type fo coerce to
  * @returns The coerced value
  */
-export function coerce(value: unknown, type: string) {
+export function coerce(value: unknown, type: FieldType) {
   // no coercion specified for type, skip it
   if (!TYPE_TRANSFORM_MAP[type]) {
     return value
   }
   // eslint-disable-next-line no-prototype-builtins
-  if (TYPE_TRANSFORM_MAP[type].hasOwnProperty(value)) {
+  if (TYPE_TRANSFORM_MAP[type].hasOwnProperty(value as PropertyKey)) {
     // @ts-ignore
     return TYPE_TRANSFORM_MAP[type][value]
   } else if (TYPE_TRANSFORM_MAP[type].parse) {

--- a/packages/server/src/utilities/rowProcessor/map.ts
+++ b/packages/server/src/utilities/rowProcessor/map.ts
@@ -23,7 +23,7 @@ const parseArrayString = (value: string | unknown) => {
 export const TYPE_TRANSFORM_MAP: Record<
   FieldType,
   {
-    ""?: null
+    ""?: null | []
     true?: true
     false?: false
     parse?: (input: string | Date) => string | undefined | {}
@@ -35,7 +35,7 @@ export const TYPE_TRANSFORM_MAP: Record<
     [null]: [],
     //@ts-ignore
     [undefined]: undefined,
-    parse: (link: string | { _id?: string }[]) => {
+    parse: link => {
       if (Array.isArray(link) && typeof link[0] === "object") {
         return link.map(el => (el && el._id ? el._id : el))
       }
@@ -176,6 +176,27 @@ export const TYPE_TRANSFORM_MAP: Record<
       } catch (err) {
         return input
       }
+    },
+  },
+  [FieldType.AI]: {
+    parse: () => {
+      throw new Error(`FieldType.AI parse is not implemented`)
+    },
+  },
+
+  [FieldType.BB_REFERENCE_SINGLE]: {
+    parse: () => {
+      throw new Error(`FieldType.BB_REFERENCE_SINGLE parse is not implemented`)
+    },
+  },
+  [FieldType.SIGNATURE_SINGLE]: {
+    parse: () => {
+      throw new Error(`FieldType.SIGNATURE_SINGLE #parse is not implemented`)
+    },
+  },
+  [FieldType.INTERNAL]: {
+    parse: () => {
+      throw new Error(`FieldType.INTERNAL is deprecated`)
     },
   },
 }

--- a/packages/server/src/utilities/rowProcessor/map.ts
+++ b/packages/server/src/utilities/rowProcessor/map.ts
@@ -26,7 +26,9 @@ export const TYPE_TRANSFORM_MAP: Record<
     ""?: null | []
     true?: true
     false?: false
-    parse?: (input: string | Date) => string | undefined | {}
+    parse?: (
+      input: string | string[] | { _id: unknown }[] | Date
+    ) => string | undefined | {}
   }
 > = {
   [FieldType.LINK]: {
@@ -37,7 +39,10 @@ export const TYPE_TRANSFORM_MAP: Record<
     [undefined]: undefined,
     parse: link => {
       if (Array.isArray(link) && typeof link[0] === "object") {
-        return link.map(el => (el && el._id ? el._id : el))
+        return link.map(el => {
+          const objEl = el as { _id: unknown }
+          return objEl && objEl._id ? objEl._id : el
+        })
       }
       if (typeof link === "string") {
         return [link]
@@ -132,7 +137,7 @@ export const TYPE_TRANSFORM_MAP: Record<
         // system expects UTC dates.
         let parsed = new Date(`${input}Z`)
         if (isNaN(parsed.getTime())) {
-          parsed = new Date(input)
+          parsed = new Date(input as string)
           if (isNaN(parsed.getTime())) {
             throw new Error(`Invalid date value: "${input}"`)
           }

--- a/packages/server/src/utilities/rowProcessor/map.ts
+++ b/packages/server/src/utilities/rowProcessor/map.ts
@@ -183,25 +183,8 @@ export const TYPE_TRANSFORM_MAP: Record<
       }
     },
   },
-  [FieldType.AI]: {
-    parse: () => {
-      throw new Error(`FieldType.AI parse is not implemented`)
-    },
-  },
-
-  [FieldType.BB_REFERENCE_SINGLE]: {
-    parse: () => {
-      throw new Error(`FieldType.BB_REFERENCE_SINGLE parse is not implemented`)
-    },
-  },
-  [FieldType.SIGNATURE_SINGLE]: {
-    parse: () => {
-      throw new Error(`FieldType.SIGNATURE_SINGLE #parse is not implemented`)
-    },
-  },
-  [FieldType.INTERNAL]: {
-    parse: () => {
-      throw new Error(`FieldType.INTERNAL is deprecated`)
-    },
-  },
+  [FieldType.AI]: {},
+  [FieldType.BB_REFERENCE_SINGLE]: {},
+  [FieldType.SIGNATURE_SINGLE]: {},
+  [FieldType.INTERNAL]: {},
 }

--- a/packages/server/src/utilities/rowProcessor/map.ts
+++ b/packages/server/src/utilities/rowProcessor/map.ts
@@ -103,7 +103,7 @@ export const TYPE_TRANSFORM_MAP: Record<
     "": null,
     //@ts-ignore
     [null]: null,
-    //@ts-ignore
+    //@ts-expect-error
     [undefined]: undefined,
     parse: (n: unknown) => {
       const parsed = parseFloat(n as string)

--- a/packages/server/src/utilities/rowProcessor/map.ts
+++ b/packages/server/src/utilities/rowProcessor/map.ts
@@ -1,7 +1,7 @@
 import { sql } from "@budibase/backend-core"
 import { FieldType } from "@budibase/types"
 
-const parseArrayString = (value: any) => {
+const parseArrayString = (value: string | unknown) => {
   if (typeof value === "string") {
     if (value === "") {
       return []
@@ -27,7 +27,7 @@ export const TYPE_TRANSFORM_MAP: any = {
     [null]: [],
     //@ts-ignore
     [undefined]: undefined,
-    parse: (link: any) => {
+    parse: (link: string | { _id?: string }[]) => {
       if (Array.isArray(link) && typeof link[0] === "object") {
         return link.map(el => (el && el._id ? el._id : el))
       }

--- a/packages/server/src/utilities/schema.ts
+++ b/packages/server/src/utilities/schema.ts
@@ -241,7 +241,7 @@ export function parse(rows: Rows, table: Table): Rows {
 }
 
 function isValidBBReference(
-  data: any,
+  data: string,
   type: FieldType.BB_REFERENCE | FieldType.BB_REFERENCE_SINGLE,
   subtype: BBReferenceFieldSubType,
   isRequired: boolean
@@ -276,15 +276,15 @@ function isValidBBReference(
   }
 }
 
-function parseJsonExport<T>(value: any) {
+function parseJsonExport<TReturn = unknown>(value: string): TReturn {
   if (typeof value !== "string") {
-    return value
+    return value as TReturn
   }
 
   try {
     const parsed = JSON.parse(value)
 
-    return parsed as T
+    return parsed as TReturn
   } catch (e: any) {
     if (
       e.message.startsWith("Expected property name or '}' in JSON at position ")
@@ -296,7 +296,7 @@ function parseJsonExport<T>(value: any) {
       // exported data and stored it, hoping to be able to restore it later, so
       // we leave this in place to support that.
       const parsed = JSON.parse(value.replace(/'/g, '"'))
-      return parsed as T
+      return parsed as TReturn
     }
 
     // It is not valid JSON

--- a/packages/server/src/utilities/schema.ts
+++ b/packages/server/src/utilities/schema.ts
@@ -36,7 +36,7 @@ export function isSchema(schema: any): schema is TableSchema {
   )
 }
 
-export function isRows(rows: any): rows is Rows {
+export function isRows(rows: Rows): rows is Rows {
   return Array.isArray(rows) && rows.every(row => typeof row === "object")
 }
 

--- a/packages/server/src/utilities/workerRequests.ts
+++ b/packages/server/src/utilities/workerRequests.ts
@@ -17,14 +17,14 @@ import { Response, default as fetch, type RequestInit } from "node-fetch"
 import env from "../environment"
 import { checkSlashesInUrl } from "./index"
 
-interface Request {
+interface Request<TBody = Record<string, unknown>> {
   ctx?: Ctx
   method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH"
-  headers?: { [key: string]: string }
-  body?: { [key: string]: any }
+  headers?: Record<string, string>
+  body?: TBody
 }
 
-export function createRequest(request: Request): RequestInit {
+export function createRequest<TBody>(request: Request<TBody>): RequestInit {
   const headers: Record<string, string> = {}
   const requestInit: RequestInit = {
     method: request.method,
@@ -131,7 +131,7 @@ export async function sendSmtpEmail({
   }
   const response = await fetch(
     checkSlashesInUrl(env.WORKER_URL + `/api/global/email/send`),
-    createRequest({ method: "POST", body: request })
+    createRequest<SendEmailRequest>({ method: "POST", body: request })
   )
   return (await checkResponse(response, "send email")) as SendEmailResponse
 }

--- a/packages/server/src/websockets/builder.ts
+++ b/packages/server/src/websockets/builder.ts
@@ -3,6 +3,7 @@ import { BuilderSocketEvent } from "@budibase/shared-core"
 import {
   Automation,
   ContextUser,
+  Ctx,
   Datasource,
   Role,
   Screen,
@@ -31,7 +32,7 @@ export default class BuilderSocket extends BaseSocket {
       const sessions = await this.getRoomSessions(appId)
 
       // Track collaboration usage by unique users
-      let userIdMap: any = {}
+      let userIdMap: Record<string, boolean> = {}
       sessions?.forEach(session => {
         if (session._id) {
           userIdMap[session._id] = true
@@ -102,14 +103,14 @@ export default class BuilderSocket extends BaseSocket {
     })
   }
 
-  emitRoleUpdate(ctx: any, role: Role) {
+  emitRoleUpdate(ctx: Ctx, role: Role) {
     this.emitToRoom(ctx, ctx.appId, BuilderSocketEvent.RoleChange, {
       id: role._id,
       role,
     })
   }
 
-  emitRoleDeletion(ctx: any, role: Role) {
+  emitRoleDeletion(ctx: Ctx, role: Role) {
     this.emitToRoom(ctx, ctx.appId, BuilderSocketEvent.RoleChange, {
       id: role._id,
       role: null,
@@ -117,7 +118,7 @@ export default class BuilderSocket extends BaseSocket {
   }
 
   emitWorkspaceAppUpdate(
-    ctx: any,
+    ctx: Ctx,
     workspaceApp: WorkspaceApp,
     options?: EmitOptions
   ) {
@@ -134,7 +135,7 @@ export default class BuilderSocket extends BaseSocket {
     gridSocket?.emitWorkspaceAppUpdate(ctx, workspaceApp)
   }
 
-  emitTableUpdate(ctx: any, table: Table, options?: EmitOptions) {
+  emitTableUpdate(ctx: Ctx, table: Table, options?: EmitOptions) {
     if (table.sourceId == null || table.sourceId === "") {
       throw new Error("Table sourceId is not set")
     }
@@ -152,7 +153,7 @@ export default class BuilderSocket extends BaseSocket {
     gridSocket?.emitTableUpdate(ctx, table)
   }
 
-  emitTableDeletion(ctx: any, table: Table) {
+  emitTableDeletion(ctx: Ctx, table: Table) {
     this.emitToRoom(ctx, ctx.appId, BuilderSocketEvent.TableChange, {
       id: table._id,
       table: null,
@@ -160,62 +161,62 @@ export default class BuilderSocket extends BaseSocket {
     gridSocket?.emitTableDeletion(ctx, table)
   }
 
-  emitDatasourceUpdate(ctx: any, datasource: Datasource) {
+  emitDatasourceUpdate(ctx: Ctx, datasource: Datasource) {
     this.emitToRoom(ctx, ctx.appId, BuilderSocketEvent.DatasourceChange, {
       id: datasource._id,
       datasource,
     })
   }
 
-  emitDatasourceDeletion(ctx: any, id: string) {
+  emitDatasourceDeletion(ctx: Ctx, id: string) {
     this.emitToRoom(ctx, ctx.appId, BuilderSocketEvent.DatasourceChange, {
       id,
       datasource: null,
     })
   }
 
-  emitScreenUpdate(ctx: any, screen: Screen) {
+  emitScreenUpdate(ctx: Ctx, screen: Screen) {
     this.emitToRoom(ctx, ctx.appId, BuilderSocketEvent.ScreenChange, {
       id: screen._id,
       screen,
     })
   }
 
-  emitScreenDeletion(ctx: any, id: string) {
+  emitScreenDeletion(ctx: Ctx, id: string) {
     this.emitToRoom(ctx, ctx.appId, BuilderSocketEvent.ScreenChange, {
       id,
       screen: null,
     })
   }
 
-  emitAppMetadataUpdate(ctx: any, metadata: Partial<Workspace>) {
+  emitAppMetadataUpdate(ctx: Ctx, metadata: Partial<Workspace>) {
     this.emitToRoom(ctx, ctx.appId, BuilderSocketEvent.AppMetadataChange, {
       metadata,
     })
   }
 
-  emitAppPublish(ctx: any) {
+  emitAppPublish(ctx: Ctx) {
     this.emitToRoom(ctx, ctx.appId, BuilderSocketEvent.AppPublishChange, {
       published: true,
       user: ctx.user,
     })
   }
 
-  emitAppUnpublish(ctx: any) {
+  emitAppUnpublish(ctx: Ctx) {
     this.emitToRoom(ctx, ctx.appId, BuilderSocketEvent.AppPublishChange, {
       published: false,
       user: ctx.user,
     })
   }
 
-  emitAutomationUpdate(ctx: any, automation: Automation) {
+  emitAutomationUpdate(ctx: Ctx, automation: Automation) {
     this.emitToRoom(ctx, ctx.appId, BuilderSocketEvent.AutomationChange, {
       id: automation._id,
       automation,
     })
   }
 
-  emitAutomationDeletion(ctx: any, id: string) {
+  emitAutomationDeletion(ctx: Ctx, id: string) {
     this.emitToRoom(ctx, ctx.appId, BuilderSocketEvent.AutomationChange, {
       id,
       automation: null,

--- a/packages/server/src/websockets/grid.ts
+++ b/packages/server/src/websockets/grid.ts
@@ -5,7 +5,7 @@ import {
   findHBSBlocks,
   isJSBinding,
 } from "@budibase/string-templates"
-import { Row, Table, View, ViewV2, WorkspaceApp } from "@budibase/types"
+import { Ctx, Row, Table, View, ViewV2, WorkspaceApp } from "@budibase/types"
 import http from "http"
 import Koa from "koa"
 import { userAgent } from "koa-useragent"
@@ -116,7 +116,7 @@ export default class GridSocket extends BaseSocket {
     })
   }
 
-  emitRowUpdate(ctx: any, row: Row) {
+  emitRowUpdate(ctx: Ctx<any, any, any>, row: Row) {
     const source = getSourceId(ctx)
     const resourceId = source.viewId ?? source.tableId
     const room = `${ctx.appId}-${resourceId}`
@@ -126,7 +126,7 @@ export default class GridSocket extends BaseSocket {
     })
   }
 
-  emitRowDeletion(ctx: any, row: Row) {
+  emitRowDeletion(ctx: Ctx<any, any, any>, row: Row) {
     const source = getSourceId(ctx)
     const resourceId = source.viewId ?? source.tableId
     const room = `${ctx.appId}-${resourceId}`
@@ -136,7 +136,7 @@ export default class GridSocket extends BaseSocket {
     })
   }
 
-  emitWorkspaceAppUpdate(ctx: any, workspaceApp: WorkspaceApp) {
+  emitWorkspaceAppUpdate(ctx: Ctx<any, any, any>, workspaceApp: WorkspaceApp) {
     const room = `${ctx.appId}-${workspaceApp._id}`
     this.emitToRoom(ctx, room, GridSocketEvent.WorkspaceAppChange, {
       id: workspaceApp._id,
@@ -144,7 +144,7 @@ export default class GridSocket extends BaseSocket {
     })
   }
 
-  emitTableUpdate(ctx: any, table: Table) {
+  emitTableUpdate(ctx: Ctx<any, any, any>, table: Table) {
     const room = `${ctx.appId}-${table._id}`
     this.emitToRoom(ctx, room, GridSocketEvent.DatasourceChange, {
       id: table._id,
@@ -152,7 +152,7 @@ export default class GridSocket extends BaseSocket {
     })
   }
 
-  emitTableDeletion(ctx: any, table: Table) {
+  emitTableDeletion(ctx: Ctx<any, any, any>, table: Table) {
     const room = `${ctx.appId}-${table._id}`
     this.emitToRoom(ctx, room, GridSocketEvent.DatasourceChange, {
       id: table._id,
@@ -168,7 +168,7 @@ export default class GridSocket extends BaseSocket {
       })
   }
 
-  emitViewUpdate(ctx: any, view: ViewV2) {
+  emitViewUpdate(ctx: Ctx<any, any, any>, view: ViewV2) {
     const room = `${ctx.appId}-${view.id}`
     this.emitToRoom(ctx, room, GridSocketEvent.DatasourceChange, {
       id: view.id,
@@ -176,7 +176,7 @@ export default class GridSocket extends BaseSocket {
     })
   }
 
-  emitViewDeletion(ctx: any, view: ViewV2) {
+  emitViewDeletion(ctx: Ctx<any, any, any>, view: ViewV2) {
     const room = `${ctx.appId}-${view.id}`
     this.emitToRoom(ctx, room, GridSocketEvent.DatasourceChange, {
       id: view.id,

--- a/packages/server/src/websockets/grid.ts
+++ b/packages/server/src/websockets/grid.ts
@@ -116,7 +116,7 @@ export default class GridSocket extends BaseSocket {
     })
   }
 
-  emitRowUpdate(ctx: Ctx<any, any, any>, row: Row) {
+  emitRowUpdate(ctx: Ctx, row: Row) {
     const source = getSourceId(ctx)
     const resourceId = source.viewId ?? source.tableId
     const room = `${ctx.appId}-${resourceId}`
@@ -126,7 +126,7 @@ export default class GridSocket extends BaseSocket {
     })
   }
 
-  emitRowDeletion(ctx: Ctx<any, any, any>, row: Row) {
+  emitRowDeletion(ctx: Ctx, row: Row) {
     const source = getSourceId(ctx)
     const resourceId = source.viewId ?? source.tableId
     const room = `${ctx.appId}-${resourceId}`
@@ -136,7 +136,7 @@ export default class GridSocket extends BaseSocket {
     })
   }
 
-  emitWorkspaceAppUpdate(ctx: Ctx<any, any, any>, workspaceApp: WorkspaceApp) {
+  emitWorkspaceAppUpdate(ctx: Ctx, workspaceApp: WorkspaceApp) {
     const room = `${ctx.appId}-${workspaceApp._id}`
     this.emitToRoom(ctx, room, GridSocketEvent.WorkspaceAppChange, {
       id: workspaceApp._id,
@@ -144,7 +144,7 @@ export default class GridSocket extends BaseSocket {
     })
   }
 
-  emitTableUpdate(ctx: Ctx<any, any, any>, table: Table) {
+  emitTableUpdate(ctx: Ctx, table: Table) {
     const room = `${ctx.appId}-${table._id}`
     this.emitToRoom(ctx, room, GridSocketEvent.DatasourceChange, {
       id: table._id,
@@ -152,7 +152,7 @@ export default class GridSocket extends BaseSocket {
     })
   }
 
-  emitTableDeletion(ctx: Ctx<any, any, any>, table: Table) {
+  emitTableDeletion(ctx: Ctx, table: Table) {
     const room = `${ctx.appId}-${table._id}`
     this.emitToRoom(ctx, room, GridSocketEvent.DatasourceChange, {
       id: table._id,
@@ -168,7 +168,7 @@ export default class GridSocket extends BaseSocket {
       })
   }
 
-  emitViewUpdate(ctx: Ctx<any, any, any>, view: ViewV2) {
+  emitViewUpdate(ctx: Ctx, view: ViewV2) {
     const room = `${ctx.appId}-${view.id}`
     this.emitToRoom(ctx, room, GridSocketEvent.DatasourceChange, {
       id: view.id,
@@ -176,7 +176,7 @@ export default class GridSocket extends BaseSocket {
     })
   }
 
-  emitViewDeletion(ctx: Ctx<any, any, any>, view: ViewV2) {
+  emitViewDeletion(ctx: Ctx, view: ViewV2) {
     const room = `${ctx.appId}-${view.id}`
     this.emitToRoom(ctx, room, GridSocketEvent.DatasourceChange, {
       id: view.id,

--- a/packages/server/src/websockets/middleware.ts
+++ b/packages/server/src/websockets/middleware.ts
@@ -32,7 +32,7 @@ export const createContext = (
     },
     cookies: new Cookies(socket.request, res),
     get: (field: string) => socket.request.headers?.[field] as string,
-    throw: (...params: any[]) => {
+    throw: (...params: string[]) => {
       // Throw has a bunch of different signatures, so we'll just stringify
       // whatever params we get given
       throw new Error(

--- a/packages/server/src/websockets/websocket.ts
+++ b/packages/server/src/websockets/websocket.ts
@@ -6,7 +6,7 @@ import { auth, Header, redis } from "@budibase/backend-core"
 import { createAdapter } from "@socket.io/redis-adapter"
 import { getSocketPubSubClients } from "../utilities/redis"
 import { SocketEvent, SocketSessionTTL } from "@budibase/shared-core"
-import { SocketSession } from "@budibase/types"
+import { Ctx, SocketSession } from "@budibase/types"
 import { v4 as uuid } from "uuid"
 import { createContext, runMiddlewares } from "./middleware"
 
@@ -271,14 +271,14 @@ export class BaseSocket {
   }
 
   // Emit an event to all sockets
-  emit(event: string, payload: any) {
+  emit(event: string, payload: unknown) {
     this.io.sockets.emit(event, payload)
   }
 
   // Emit an event to everyone in a room, including metadata of whom
   // the originator of the request was
   emitToRoom(
-    ctx: any,
+    ctx: Ctx,
     room: string | string[],
     event: string,
     payload: any,

--- a/packages/types/src/documents/global/plugin.ts
+++ b/packages/types/src/documents/global/plugin.ts
@@ -39,7 +39,7 @@ export interface PluginSchema {
   [key: string]: any
 }
 
-interface Package {
+export interface Package {
   name: string
   version: string
   description: string


### PR DESCRIPTION
## Description

add types for some `any` usages in the api. 

For the api, we have ~500 `any` remaning, of which ~70 are in error handlers. There's a good chunk that we will struggle to remove entirely as they are related to type coercion of unstructured data. For those I'd propose that instead of `any` we use `ts-ignore` with a comment, to make it clear that its a concious choice.

I'll keep nibbling away at them for a couple hours a week. Should take ~3 weeks to have the api fully typed
