### PR TITLE
[BUDI-9731] Ensure static formulas sync to production

### DIFF
--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -12,7 +12,9 @@ import {
   DeploymentDoc,
   DeploymentProgressResponse,
   DeploymentStatus,
+  FieldType,
   FetchDeploymentResponse,
+  FormulaType,
   PublishStatusResponse,
   PublishWorkspaceRequest,
   PublishWorkspaceResponse,
@@ -29,6 +31,7 @@ import sdk from "../../../sdk"
 import { builderSocket } from "../../../websockets"
 import { doInMigrationLock } from "../../../workspaceMigrations"
 import Deployment from "./Deployment"
+import { updateAllFormulasInTable } from "../row/staticFormula"
 
 // the max time we can wait for an invalidation to complete before considering it failed
 const MAX_PENDING_TIME_MS = 30 * 60000
@@ -116,6 +119,22 @@ async function initDeployedApp(prodAppId: any) {
   // information attached
   await sdk.workspaces.syncWorkspace(dbCore.getDevWorkspaceID(prodAppId), {
     automationOnly: true,
+  })
+}
+
+async function syncStaticFormulasToProduction(prodWorkspaceId: string) {
+  await context.doInWorkspaceContext(prodWorkspaceId, async () => {
+    const tables = await sdk.tables.getAllInternalTables()
+    for (const table of tables) {
+      const hasStaticFormula = Object.values(table.schema).some(
+        column =>
+          column?.type === FieldType.FORMULA &&
+          column.formulaType === FormulaType.STATIC
+      )
+      if (hasStaticFormula) {
+        await updateAllFormulasInTable(table)
+      }
+    }
   })
 }
 
@@ -296,6 +315,7 @@ export const publishWorkspace = async function (
       await db.put(appDoc)
       await cache.workspace.invalidateWorkspaceMetadata(prodId)
       await initDeployedApp(prodId)
+      await syncStaticFormulasToProduction(prodId)
       deployment.setStatus(DeploymentStatus.SUCCESS)
       await storeDeploymentHistory(deployment)
       app = appDoc


### PR DESCRIPTION
## Description
- ensure static formulas are recomputed in production during publish so schema changes reach existing rows
- add regression coverage for static formula sync when publishing from dev

## Addresses
- https://github.com/Budibase/budibase/issues/17102
- https://linear.app/budibase/issue/BUDI-9731/formula-columns-not-syncing-correctly-between-dev-and-prod-on-publish

## Screenshots
https://github.com/user-attachments/assets/237d9a37-be10-45fd-9da9-4f927a100f96


## Launchcontrol
Recomputes static formulas during publish so production rows get updated when new formulas are added.
