### PR TITLE
Revert "fix: Always pass conf when running redis-server in singleimage"

### DIFF
--- a/hosting/single/redis-runner.sh
+++ b/hosting/single/redis-runner.sh
@@ -1,22 +1,28 @@
 #!/bin/bash
 
 REDIS_CONFIG="/etc/redis/redis.conf"
-
 sed -i "s#DATA_DIR#${DATA_DIR}#g" "${REDIS_CONFIG}"
 
-REDIS_LAUNCH_SCRIPT="/tmp/redis-server-launch.sh"
-cat <<'EOF' > "$REDIS_LAUNCH_SCRIPT"
-#!/bin/bash
-
-CMD=("redis-server" "/etc/redis/redis.conf")
-
-if [[ -n "${REDIS_USERNAME}" && -n "${REDIS_PASSWORD}" ]]; then
-    CMD+=("--user" "${REDIS_USERNAME}" "--requirepass" "${REDIS_PASSWORD}")
-elif [[ -n "${REDIS_PASSWORD}" ]]; then
-    CMD+=("--requirepass" "${REDIS_PASSWORD}")
+if [[ -n "${USE_DEFAULT_REDIS_CONFIG}" ]]; then
+    unset REDIS_CONFIG
 fi
 
-exec "${CMD[@]}"
+REDIS_LAUNCH_SCRIPT="/tmp/redis-server-launch.sh"
+cat <<EOF > "$REDIS_LAUNCH_SCRIPT"
+#!/bin/bash
+if [[ -n "\${REDIS_PASSWORD}" ]]; then
+    if [[ -n "\${REDIS_CONFIG}" ]]; then
+        exec redis-server "\${REDIS_CONFIG}" --requirepass "\$REDIS_PASSWORD"
+    else
+        exec redis-server --requirepass "\$REDIS_PASSWORD"
+    fi
+else
+    if [[ -n "\${REDIS_CONFIG}" ]]; then
+        exec redis-server "\${REDIS_CONFIG}"
+    else
+        exec redis-server
+    fi
+fi
 EOF
 
 chmod +x "$REDIS_LAUNCH_SCRIPT"


### PR DESCRIPTION
Reverts Budibase/budibase#17027

This breaks the `USE_DEFAULT_REDIS_CONFIG` environment variable that is required for some environments.