### PR TITLE
fix: respect USE_DEFAULT_REDIS_CONFIG

### DIFF
--- a/hosting/single/redis-runner.sh
+++ b/hosting/single/redis-runner.sh
@@ -1,22 +1,34 @@
 #!/bin/bash
 
-REDIS_CONFIG="/etc/redis/redis.conf"
-
-sed -i "s#DATA_DIR#${DATA_DIR}#g" "${REDIS_CONFIG}"
-
-REDIS_LAUNCH_SCRIPT="/tmp/redis-server-launch.sh"
-cat <<'EOF' > "$REDIS_LAUNCH_SCRIPT"
-#!/bin/bash
-
-CMD=("redis-server" "/etc/redis/redis.conf")
-
-if [[ -n "${REDIS_USERNAME}" && -n "${REDIS_PASSWORD}" ]]; then
-    CMD+=("--user" "${REDIS_USERNAME}" "--requirepass" "${REDIS_PASSWORD}")
-elif [[ -n "${REDIS_PASSWORD}" ]]; then
-    CMD+=("--requirepass" "${REDIS_PASSWORD}")
+if [[ -z "${REDIS_CONFIG}" ]]; then
+    REDIS_CONFIG="/etc/redis/redis.conf"
 fi
 
-exec "${CMD[@]}"
+if [[ -n "${REDIS_CONFIG}" && -f "${REDIS_CONFIG}" ]]; then
+    sed -i "s#DATA_DIR#${DATA_DIR}#g" "${REDIS_CONFIG}"
+fi
+
+if [[ -n "${USE_DEFAULT_REDIS_CONFIG}" ]]; then
+    unset REDIS_CONFIG
+fi
+
+REDIS_LAUNCH_SCRIPT="/tmp/redis-server-launch.sh"
+cat <<EOF > "$REDIS_LAUNCH_SCRIPT"
+#!/bin/bash
+
+if [[ -n "\${REDIS_CONFIG}" ]]; then
+    CMD=("redis-server" "\${REDIS_CONFIG}")
+else
+    CMD=("redis-server")
+fi
+
+if [[ -n "\${REDIS_USERNAME}" && -n "\${REDIS_PASSWORD}" ]]; then
+    CMD+=("--user" "\${REDIS_USERNAME}" "--requirepass" "\${REDIS_PASSWORD}")
+elif [[ -n "\${REDIS_PASSWORD}" ]]; then
+    CMD+=("--requirepass" "\${REDIS_PASSWORD}")
+fi
+
+exec "\${CMD[@]}"
 EOF
 
 chmod +x "$REDIS_LAUNCH_SCRIPT"


### PR DESCRIPTION
Related https://github.com/Budibase/budibase/pull/17123

## Description
Reinstates the `USE_DEFAULT_REDIS_CONFIG` setting option that's used by some self-host installations.

Expected behavior matrix:


REDIS_CONFIG | USE_DEFAULT_REDIS_CONFIG | Result
-- | -- | --
Not set | Not set | Uses /etc/redis/redis.conf (default)
Not set | Set | Uses Redis defaults (no config)
Custom path | Not set | Uses custom config file
Custom path | Set | Uses Redis defaults (no config)


