### PR TITLE
chore: remove ts annotations in rest intg

### DIFF
--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -503,7 +503,6 @@ export class RestIntegration implements IntegrationBase {
         hasDispatcher: true,
         rejectUnauthorized: this.config.rejectUnauthorized,
       })
-      // @ts-expect-error - ProxyAgent is compatible with Dispatcher but types don't align perfectly
       input.dispatcher = proxyDispatcher
     } else if (this.config.rejectUnauthorized === false) {
       // No proxy, but need to disable TLS verification
@@ -512,7 +511,6 @@ export class RestIntegration implements IntegrationBase {
           rejectUnauthorized: false,
         },
       })
-      // @ts-ignore - Agent is compatible with Dispatcher but types don't align perfectly
       input.dispatcher = agent
     }
 


### PR DESCRIPTION
## Description
Undici supports dispatcher native types - no longer need annotations for linter. 

