### PR TITLE
Improve test loads

### DIFF
--- a/packages/server/src/api/routes/tests/backup.spec.ts
+++ b/packages/server/src/api/routes/tests/backup.spec.ts
@@ -6,6 +6,7 @@ import { Readable } from "stream"
 import { pipeline } from "stream/promises"
 import tar from "tar"
 import tk from "timekeeper"
+import { withEnv } from "../../../environment"
 import sdk from "../../../sdk"
 import * as setup from "./utilities"
 import { checkBuilderEndpoint } from "./utilities/TestFunctions"
@@ -15,14 +16,14 @@ mocks.licenses.useBackups()
 describe("/backups", () => {
   let config = setup.getConfig()
 
-  afterAll(async () => {
+  afterAll(() => {
     setup.afterAll()
   })
 
   beforeEach(async () => {
     tk.reset()
     jest.clearAllMocks()
-    await config.init()
+    await withEnv({ UPLOAD_APPS_FILES_ON_TEST: "1" }, () => config.init())
   })
 
   describe("/api/backups/export", () => {

--- a/packages/server/src/environment.ts
+++ b/packages/server/src/environment.ts
@@ -142,6 +142,7 @@ const environment = {
     parseIntSafe(process.env.SYNC_MIGRATION_CHECKS_MS) || 5000,
   SKIP_MIGRATION_LOCKS_IN_TESTS:
     process.env.SKIP_MIGRATION_LOCKS_IN_TESTS ?? true,
+  UPLOAD_APPS_FILES_ON_TEST: process.env.UPLOAD_APPS_FILES_ON_TEST,
   // old
   CLIENT_ID: process.env.CLIENT_ID,
   _set(key: string, value: any) {

--- a/packages/server/src/utilities/fileSystem/app.ts
+++ b/packages/server/src/utilities/fileSystem/app.ts
@@ -1,4 +1,4 @@
-import { context, objectStore } from "@budibase/backend-core"
+import { context, env, objectStore } from "@budibase/backend-core"
 import fs from "fs"
 import { join } from "path"
 import { ObjectStoreBuckets } from "../../constants"
@@ -14,6 +14,10 @@ export const NODE_MODULES_PATH = join(TOP_LEVEL_PATH, "node_modules")
  * @return once promise completes app resources should be ready in object store.
  */
 export const uploadAppFiles = async (appId: string) => {
+  if (env.isTest()) {
+    // We don't need the real data on tests, and parallel workspace creation is making all tests really slow
+    return
+  }
   await updateClientLibrary(appId)
 }
 

--- a/packages/server/src/utilities/fileSystem/app.ts
+++ b/packages/server/src/utilities/fileSystem/app.ts
@@ -2,6 +2,7 @@ import { context, env, objectStore } from "@budibase/backend-core"
 import fs from "fs"
 import { join } from "path"
 import { ObjectStoreBuckets } from "../../constants"
+import environment from "../../environment"
 import { budibaseTempDir } from "../budibaseDir"
 import { shouldServeLocally, updateClientLibrary } from "./clientLibrary"
 import { TOP_LEVEL_PATH } from "./filesystem"
@@ -14,7 +15,7 @@ export const NODE_MODULES_PATH = join(TOP_LEVEL_PATH, "node_modules")
  * @return once promise completes app resources should be ready in object store.
  */
 export const uploadAppFiles = async (appId: string) => {
-  if (env.isTest()) {
+  if (env.isTest() && !environment.UPLOAD_APPS_FILES_ON_TEST) {
     // We don't need the real data on tests, and parallel workspace creation is making all tests really slow
     return
   }


### PR DESCRIPTION
## Description
Prevent uploading app files on workspace creation for tests. This is done in all the tests, creating some bottlenecks around minio and hitting minio free limits, when they are not used at all (only for few tests)