### PR TITLE
fix: handle https calls over http proxy

### DIFF
--- a/packages/backend-core/src/utils/fetch.ts
+++ b/packages/backend-core/src/utils/fetch.ts
@@ -22,17 +22,28 @@ function createProxyDispatcher(options?: {
     return undefined
   }
 
+  const rejectUnauthorized = options?.rejectUnauthorized
+
   console.log("[fetch] Creating ProxyAgent", {
     proxyUrl,
-    rejectUnauthorized: options?.rejectUnauthorized,
+    rejectUnauthorized,
   })
 
-  return new ProxyAgent({
+  const proxyConfig: any = {
     uri: proxyUrl,
     requestTls: {
-      rejectUnauthorized: options?.rejectUnauthorized ?? true,
+      rejectUnauthorized,
     },
-  })
+  }
+
+  // Only configure proxyTls if the proxy itself uses HTTPS
+  if (proxyUrl.startsWith("https://")) {
+    proxyConfig.proxyTls = {
+      rejectUnauthorized,
+    }
+  }
+
+  return new ProxyAgent(proxyConfig)
 }
 
 let cachedDispatcher: ProxyAgent | undefined | null = null

--- a/packages/backend-core/src/utils/tests/fetch.spec.ts
+++ b/packages/backend-core/src/utils/tests/fetch.spec.ts
@@ -1,0 +1,196 @@
+import { getProxyDispatcher, resetProxyDispatcherCache } from "../fetch"
+
+describe("fetch utilities", () => {
+  let originalEnv: NodeJS.ProcessEnv
+
+  beforeEach(() => {
+    originalEnv = { ...process.env }
+
+    delete process.env.GLOBAL_AGENT_HTTP_PROXY
+    delete process.env.GLOBAL_AGENT_HTTPS_PROXY
+    delete process.env.HTTP_PROXY
+    delete process.env.HTTPS_PROXY
+    resetProxyDispatcherCache()
+
+    jest.spyOn(console, "log").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    jest.restoreAllMocks()
+  })
+  describe("getProxyDispatcher", () => {
+    describe("when no proxy is configured", () => {
+      it("should return false when no proxy environment variables are set", () => {
+        const result = getProxyDispatcher()
+        expect(result).toBe(false)
+      })
+    })
+
+    describe("when HTTP_PROXY is configured", () => {
+      beforeEach(() => {
+        process.env.HTTP_PROXY = "http://proxy.example.com:8080"
+      })
+
+      it("should return a ProxyAgent instance", () => {
+        const result = getProxyDispatcher()
+        expect(result).toBeDefined()
+        expect(result?.constructor.name).toBe("ProxyAgent")
+      })
+
+      it("should pass rejectUnauthorized option", () => {
+        const result1 = getProxyDispatcher({ rejectUnauthorized: false })
+        const result2 = getProxyDispatcher({ rejectUnauthorized: true })
+
+        expect(result1).toBeDefined()
+        expect(result2).toBeDefined()
+        expect(result1).not.toBe(result2)
+      })
+    })
+
+    describe("when HTTPS_PROXY is configured", () => {
+      beforeEach(() => {
+        process.env.HTTPS_PROXY = "https://secure-proxy.example.com:8443"
+      })
+
+      it("should return a ProxyAgent instance", () => {
+        const result = getProxyDispatcher()
+        expect(result).toBeDefined()
+        expect(result?.constructor.name).toBe("ProxyAgent")
+      })
+    })
+
+    describe("when both HTTP_PROXY and HTTPS_PROXY are configured", () => {
+      beforeEach(() => {
+        process.env.HTTP_PROXY = "http://proxy.example.com:8080"
+        process.env.HTTPS_PROXY = "https://secure-proxy.example.com:8443"
+      })
+
+      it("should return a ProxyAgent instance (preferring HTTPS)", () => {
+        const result = getProxyDispatcher()
+        expect(result).toBeDefined()
+        expect(result?.constructor.name).toBe("ProxyAgent")
+      })
+    })
+
+    describe("when GLOBAL_AGENT_* environment variables are configured", () => {
+      beforeEach(() => {
+        process.env.GLOBAL_AGENT_HTTP_PROXY =
+          "http://global-proxy.example.com:3128"
+        process.env.GLOBAL_AGENT_HTTPS_PROXY =
+          "https://global-secure-proxy.example.com:3129"
+      })
+
+      it("should return a ProxyAgent instance", () => {
+        const result = getProxyDispatcher()
+        expect(result).toBeDefined()
+        expect(result?.constructor.name).toBe("ProxyAgent")
+      })
+
+      it("should fall back to GLOBAL_AGENT_HTTP_PROXY if HTTPS is not set", () => {
+        delete process.env.GLOBAL_AGENT_HTTPS_PROXY
+
+        const result = getProxyDispatcher()
+        expect(result).toBeDefined()
+        expect(result?.constructor.name).toBe("ProxyAgent")
+      })
+    })
+
+    describe("environment variable precedence", () => {
+      beforeEach(() => {
+        process.env.GLOBAL_AGENT_HTTP_PROXY =
+          "http://global-proxy.example.com:3128"
+        process.env.GLOBAL_AGENT_HTTPS_PROXY =
+          "https://global-secure-proxy.example.com:3129"
+        process.env.HTTP_PROXY = "http://proxy.example.com:8080"
+        process.env.HTTPS_PROXY = "https://secure-proxy.example.com:8443"
+      })
+
+      it("should return a ProxyAgent instance with correct precedence", () => {
+        const result = getProxyDispatcher()
+        expect(result).toBeDefined()
+        expect(result?.constructor.name).toBe("ProxyAgent")
+      })
+
+      it("should prefer GLOBAL_AGENT_HTTP_PROXY over standard HTTP_PROXY", () => {
+        delete process.env.GLOBAL_AGENT_HTTPS_PROXY
+        delete process.env.HTTPS_PROXY
+
+        const result = getProxyDispatcher()
+        expect(result).toBeDefined()
+        expect(result?.constructor.name).toBe("ProxyAgent")
+      })
+    })
+
+    describe("caching behavior", () => {
+      beforeEach(() => {
+        process.env.HTTP_PROXY = "http://proxy.example.com:8080"
+      })
+
+      it("should cache dispatcher when no options are provided", () => {
+        const result1 = getProxyDispatcher()
+        const result2 = getProxyDispatcher()
+
+        expect(result1).toBe(result2)
+      })
+
+      it("should not cache dispatcher when options are provided", () => {
+        const result1 = getProxyDispatcher({ rejectUnauthorized: false })
+        const result2 = getProxyDispatcher({ rejectUnauthorized: false })
+
+        expect(result1).not.toBe(result2)
+      })
+
+      it("should create new dispatcher for different options", () => {
+        const result1 = getProxyDispatcher({ rejectUnauthorized: true })
+        const result2 = getProxyDispatcher({ rejectUnauthorized: false })
+
+        expect(result1).not.toBe(result2)
+      })
+    })
+
+    describe("logging", () => {
+      beforeEach(() => {
+        process.env.HTTP_PROXY = "http://proxy.example.com:8080"
+      })
+
+      it("should log proxy configuration", () => {
+        const consoleSpy = jest.spyOn(console, "log")
+
+        getProxyDispatcher({ rejectUnauthorized: false })
+
+        expect(consoleSpy).toHaveBeenCalledWith("[fetch] Creating ProxyAgent", {
+          proxyUrl: "http://proxy.example.com:8080",
+          rejectUnauthorized: false,
+        })
+      })
+    })
+
+    describe("edge cases", () => {
+      it("should handle empty string proxy URLs", () => {
+        process.env.HTTP_PROXY = ""
+
+        const result = getProxyDispatcher()
+
+        expect(result).toBe(false)
+      })
+
+      it("should handle whitespace-only proxy URLs", () => {
+        process.env.HTTP_PROXY = "   "
+
+        const result = getProxyDispatcher()
+
+        expect(result).toBe(false)
+      })
+
+      it("should handle proxy URLs with different protocols", () => {
+        process.env.HTTP_PROXY = "socks5://proxy.example.com:1080"
+
+        const result = getProxyDispatcher()
+
+        expect(result).toBeDefined()
+        expect(result?.constructor.name).toBe("ProxyAgent")
+      })
+    })
+  })
+})

--- a/packages/backend-core/src/utils/tests/fetch.spec.ts
+++ b/packages/backend-core/src/utils/tests/fetch.spec.ts
@@ -183,8 +183,8 @@ describe("fetch utilities", () => {
         expect(result).toBe(false)
       })
 
-      it("should handle proxy URLs with different protocols", () => {
-        process.env.HTTP_PROXY = "socks5://proxy.example.com:1080"
+      it("should handle HTTPS proxy URLs", () => {
+        process.env.HTTPS_PROXY = "https://secure-proxy.example.com:8443"
 
         const result = getProxyDispatcher()
 

--- a/packages/server/src/environment.ts
+++ b/packages/server/src/environment.ts
@@ -142,7 +142,7 @@ const environment = {
     parseIntSafe(process.env.SYNC_MIGRATION_CHECKS_MS) || 5000,
   SKIP_MIGRATION_LOCKS_IN_TESTS:
     process.env.SKIP_MIGRATION_LOCKS_IN_TESTS ?? true,
-  REST_REJECT_UNAUTHORIZED: process.env.REST_REJECT_UNAUTHORIZED,
+  REST_REJECT_UNAUTHORIZED: (process.env.REST_REJECT_UNAUTHORIZED || true) as boolean,
   // old
   CLIENT_ID: process.env.CLIENT_ID,
   _set(key: string, value: any) {

--- a/packages/server/src/environment.ts
+++ b/packages/server/src/environment.ts
@@ -142,6 +142,7 @@ const environment = {
     parseIntSafe(process.env.SYNC_MIGRATION_CHECKS_MS) || 5000,
   SKIP_MIGRATION_LOCKS_IN_TESTS:
     process.env.SKIP_MIGRATION_LOCKS_IN_TESTS ?? true,
+  REST_REJECT_UNAUTHORIZED: process.env.REST_REJECT_UNAUTHORIZED,
   // old
   CLIENT_ID: process.env.CLIENT_ID,
   _set(key: string, value: any) {

--- a/packages/server/src/environment.ts
+++ b/packages/server/src/environment.ts
@@ -142,7 +142,7 @@ const environment = {
     parseIntSafe(process.env.SYNC_MIGRATION_CHECKS_MS) || 5000,
   SKIP_MIGRATION_LOCKS_IN_TESTS:
     process.env.SKIP_MIGRATION_LOCKS_IN_TESTS ?? true,
-  REST_REJECT_UNAUTHORIZED: (process.env.REST_REJECT_UNAUTHORIZED || true) as boolean,
+  REST_REJECT_UNAUTHORIZED: process.env.REST_REJECT_UNAUTHORIZED ?? true,
   // old
   CLIENT_ID: process.env.CLIENT_ID,
   _set(key: string, value: any) {

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -495,7 +495,7 @@ export class RestIntegration implements IntegrationBase {
     }
 
     // Configure dispatcher for proxy and/or TLS settings
-    const rejectUnauthorized = environment.REST_REJECT_UNAUTHORIZED === "false"
+    const rejectUnauthorized = environment.REST_REJECT_UNAUTHORIZED
 
     const proxyDispatcher = getProxyDispatcher({
       rejectUnauthorized,
@@ -513,8 +513,9 @@ export class RestIntegration implements IntegrationBase {
           process.env.HTTPS_PROXY ||
           process.env.HTTP_PROXY,
       })
+      // @ts-expect-error - ProxyAgent is compatible with Dispatcher but types don't align perfectly
       input.dispatcher = proxyDispatcher
-    } else if (rejectUnauthorized === false) {
+    } else if (rejectUnauthorized) {
       // No proxy, but need to disable TLS verification
       const agent = new Agent({
         connect: {

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -495,8 +495,7 @@ export class RestIntegration implements IntegrationBase {
     }
 
     // Configure dispatcher for proxy and/or TLS settings
-    const rejectUnauthorized = environment.REST_REJECT_UNAUTHORIZED
-
+    const rejectUnauthorized = environment.REST_REJECT_UNAUTHORIZED === "0"
     const proxyDispatcher = getProxyDispatcher({
       rejectUnauthorized,
     })
@@ -522,7 +521,6 @@ export class RestIntegration implements IntegrationBase {
           rejectUnauthorized: false,
         },
       })
-      // @ts-ignore - Agent is compatible with Dispatcher but types don't align perfectly
       input.dispatcher = agent
     }
 

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -495,7 +495,7 @@ export class RestIntegration implements IntegrationBase {
     }
 
     // Configure dispatcher for proxy and/or TLS settings
-    const rejectUnauthorized = environment.REST_REJECT_UNAUTHORIZED === "0"
+    const rejectUnauthorized = !!environment.REST_REJECT_UNAUTHORIZED
     const proxyDispatcher = getProxyDispatcher({
       rejectUnauthorized,
     })


### PR DESCRIPTION
## Description
Allows explicitly configuring whether https calls are rejected over plain http proxies

## Addresses
- users in need of `https` rest integrations over `http` proxies.
