### PR TITLE
Bulk upload client library

### DIFF
--- a/packages/backend-core/src/objectStore/objectStore.ts
+++ b/packages/backend-core/src/objectStore/objectStore.ts
@@ -361,7 +361,7 @@ export async function streamUpload({
     })
 
     span.addTags({ contentType, contentLength: headDetails.ContentLength })
-    return details
+    return { ...details, ContentLength: headDetails.ContentLength }
   })
 }
 

--- a/packages/backend-core/src/objectStore/objectStore.ts
+++ b/packages/backend-core/src/objectStore/objectStore.ts
@@ -34,12 +34,6 @@ const STATE = {
 }
 export const SIGNED_FILE_PREFIX = "/files/signed"
 
-type BucketContext = {
-  client: ReturnType<typeof ObjectStore>
-  bucket: string
-  bucketCreated: Awaited<ReturnType<typeof createBucketIfNotExists>>
-}
-
 type ListParams = {
   ContinuationToken?: string
 }
@@ -210,7 +204,7 @@ const initialiseBucket = async (
   bucketName: string,
   ttl?: number,
   span?: any
-): Promise<BucketContext> => {
+) => {
   const bucket = sanitizeBucket(bucketName)
   const client = ObjectStore()
   const bucketCreated = await createBucketIfNotExists(client, bucket)

--- a/packages/backend-core/src/objectStore/objectStore.ts
+++ b/packages/backend-core/src/objectStore/objectStore.ts
@@ -346,11 +346,6 @@ export async function streamUpload({
 
     const { bucket, client } = await initialiseBucket(bucketName, ttl, span)
 
-    const headDetails = await client.headObject({
-      Bucket: bucket,
-      Key: sanitizeKey(filename),
-    })
-
     const { details, contentType } = await streamUploadInternal({
       client,
       bucket,
@@ -358,6 +353,11 @@ export async function streamUpload({
       stream,
       type,
       extra,
+    })
+
+    const headDetails = await client.headObject({
+      Bucket: bucket,
+      Key: sanitizeKey(filename),
     })
 
     span.addTags({ contentType, contentLength: headDetails.ContentLength })

--- a/packages/backend-core/src/objectStore/objectStore.ts
+++ b/packages/backend-core/src/objectStore/objectStore.ts
@@ -202,14 +202,14 @@ const resolveContentType = (filename: string, type?: string | null) => {
 
 const initialiseBucket = async (
   bucketName: string,
-  ttl?: number,
-  span?: any
+  ttl: number | undefined,
+  span: tracer.Span
 ) => {
   const bucket = sanitizeBucket(bucketName)
   const client = ObjectStore()
   const bucketCreated = await createBucketIfNotExists(client, bucket)
 
-  span?.addTags({
+  span.addTags({
     bucketCreated: bucketCreated.created,
     bucketExists: bucketCreated.exists,
   })

--- a/packages/backend-core/src/objectStore/tests/objectStore.spec.ts
+++ b/packages/backend-core/src/objectStore/tests/objectStore.spec.ts
@@ -320,24 +320,30 @@ describe("objectStore", () => {
       })
 
       expect(mockUpload).toHaveBeenCalledTimes(2)
-      expect(mockUpload).toHaveBeenNthCalledWith(1, {
-        client: expect.any(Object),
-        params: {
-          Bucket: "test-bucket",
-          Key: "app_123/budibase-client.js",
-          Body: jsStream,
-          ContentType: "application/javascript",
-        },
-      })
-      expect(mockUpload).toHaveBeenNthCalledWith(2, {
-        client: expect.any(Object),
-        params: {
-          Bucket: "test-bucket",
-          Key: "app_123/manifest.json",
-          Body: jsonStream,
-          ContentType: "application/json",
-        },
-      })
+      expect(mockUpload.mock.calls).toEqual([
+        [
+          expect.objectContaining({
+            client: expect.any(Object),
+            params: {
+              Bucket: "test-bucket",
+              Key: "app_123/budibase-client.js",
+              Body: jsStream,
+              ContentType: "application/javascript",
+            },
+          }),
+        ],
+        [
+          expect.objectContaining({
+            client: expect.any(Object),
+            params: {
+              Bucket: "test-bucket",
+              Key: "app_123/manifest.json",
+              Body: jsonStream,
+              ContentType: "application/json",
+            },
+          }),
+        ],
+      ])
     })
 
     it("should preserve extra parameters when provided", async () => {

--- a/packages/backend-core/src/objectStore/tests/objectStore.spec.ts
+++ b/packages/backend-core/src/objectStore/tests/objectStore.spec.ts
@@ -1,7 +1,7 @@
 import { Upload } from "@aws-sdk/lib-storage"
 import { PassThrough } from "stream"
 import { structures } from "../../../tests"
-import { streamUpload, upload } from "../objectStore"
+import { streamUpload, streamUploadMany, upload } from "../objectStore"
 
 // Get mock instances
 const mockUpload = Upload as jest.MockedClass<typeof Upload>
@@ -301,6 +301,69 @@ describe("objectStore", () => {
           Key: "config.backup.json",
           Body: mockStream,
           ContentType: "application/json",
+        },
+      })
+    })
+  })
+
+  describe("streamUploadMany", () => {
+    it("should upload each file with inferred content type", async () => {
+      const jsStream = new PassThrough()
+      const jsonStream = new PassThrough()
+
+      await streamUploadMany({
+        bucket: "test-bucket",
+        files: [
+          { filename: "app_123/budibase-client.js", stream: jsStream },
+          { filename: "app_123/manifest.json", stream: jsonStream },
+        ],
+      })
+
+      expect(mockUpload).toHaveBeenCalledTimes(2)
+      expect(mockUpload).toHaveBeenNthCalledWith(1, {
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "app_123/budibase-client.js",
+          Body: jsStream,
+          ContentType: "application/javascript",
+        },
+      })
+      expect(mockUpload).toHaveBeenNthCalledWith(2, {
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "app_123/manifest.json",
+          Body: jsonStream,
+          ContentType: "application/json",
+        },
+      })
+    })
+
+    it("should preserve extra parameters when provided", async () => {
+      const stream = new PassThrough()
+
+      await streamUploadMany({
+        bucket: "test-bucket",
+        files: [
+          {
+            filename: "app_123/chunks/chunk.js",
+            stream,
+            extra: {
+              CacheControl: "max-age=3600",
+            },
+          },
+        ],
+      })
+
+      expect(mockUpload).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        params: {
+          Bucket: "test-bucket",
+          Key: "app_123/chunks/chunk.js",
+          Body: stream,
+          ContentType: "application/javascript",
+          CacheControl: "max-age=3600",
         },
       })
     })

--- a/packages/builder/src/components/deploy/VersionModal.svelte
+++ b/packages/builder/src/components/deploy/VersionModal.svelte
@@ -7,6 +7,7 @@
     Modal,
     ModalContent,
     notifications,
+    ProgressCircle,
     StatusLight,
   } from "@budibase/bbui"
 
@@ -60,7 +61,9 @@
     updateModal.hide()
   }
 
+  let reverting = false
   const revert = async () => {
+    reverting = true
     try {
       await API.revertAppClientVersion(appId)
 
@@ -71,6 +74,8 @@
       )
     } catch (err) {
       notifications.error(err?.message || err || "Error reverting app")
+    } finally {
+      reverting = false
     }
     updateModal.hide()
   }
@@ -89,7 +94,13 @@
   >
     <div slot="footer">
       {#if revertAvailable}
-        <Button quiet secondary on:click={revert}>Revert</Button>
+        <Button quiet secondary on:click={revert} disabled={reverting}>
+          {#if reverting}
+            <ProgressCircle overBackground={true} size="S" />
+          {:else}
+            Revert
+          {/if}
+        </Button>
       {/if}
     </div>
     {#if updateAvailable}

--- a/packages/server/src/utilities/fileSystem/clientLibrary.ts
+++ b/packages/server/src/utilities/fileSystem/clientLibrary.ts
@@ -22,13 +22,13 @@ export function devClientLibPath() {
  * The paths for the in-use version are:
  * {appId}/manifest.json
  * {appId}/budibase-client.js
- * {appId}/_dependencies/...
+ * {appId}/_chunks/...
  * {appId}/... (and any other app files)
  *
  * The paths for the backups are:
  * {appId}/.bak/manifest.json
  * {appId}/.bak/budibase-client.js
- * {appId}/.bak/_dependencies/...
+ * {appId}/.bak/_chunks/...
  * {appId}/.bak/... (complete folder backup)
  *
  * We don't rely on NPM at all any more, as when updating to the latest version

--- a/packages/server/src/utilities/fileSystem/tests/clientLibrary.spec.ts
+++ b/packages/server/src/utilities/fileSystem/tests/clientLibrary.spec.ts
@@ -7,6 +7,7 @@ jest.mock("@budibase/backend-core", () => {
       listAllObjects: jest.fn(),
       retrieveToTmp: jest.fn().mockResolvedValue("/tmp/file"),
       streamUpload: jest.fn(),
+      streamUploadMany: jest.fn().mockResolvedValue([]),
       upload: jest.fn(),
       deleteFile: jest.fn(),
       getReadStream: jest.fn(),
@@ -174,31 +175,31 @@ describe("clientLibrary", () => {
 
       expect(mockedFs.readdirSync).toHaveBeenCalledTimes(1)
 
-      expect(mockedObjectStore.streamUpload).toHaveBeenCalledTimes(5)
-      expect(mockedObjectStore.streamUpload).toHaveBeenCalledWith({
+      expect(mockedObjectStore.streamUploadMany).toHaveBeenCalledTimes(1)
+      expect(mockedObjectStore.streamUploadMany).toHaveBeenCalledWith({
         bucket: ObjectStoreBuckets.APPS,
-        filename: "app_123/manifest.json",
-        stream: "stream1",
-      })
-      expect(mockedObjectStore.streamUpload).toHaveBeenCalledWith({
-        bucket: ObjectStoreBuckets.APPS,
-        filename: "app_123/budibase-client.js",
-        stream: "stream2",
-      })
-      expect(mockedObjectStore.streamUpload).toHaveBeenCalledWith({
-        bucket: ObjectStoreBuckets.APPS,
-        filename: "app_123/budibase-client.esm.js",
-        stream: "stream3",
-      })
-      expect(mockedObjectStore.streamUpload).toHaveBeenCalledWith({
-        bucket: ObjectStoreBuckets.APPS,
-        filename: "app_123/chunks/chunk1.js",
-        stream: "stream4",
-      })
-      expect(mockedObjectStore.streamUpload).toHaveBeenCalledWith({
-        bucket: ObjectStoreBuckets.APPS,
-        filename: "app_123/chunks/chunk2.js",
-        stream: "stream5",
+        files: [
+          {
+            filename: "app_123/manifest.json",
+            stream: "stream1",
+          },
+          {
+            filename: "app_123/budibase-client.js",
+            stream: "stream2",
+          },
+          {
+            filename: "app_123/budibase-client.esm.js",
+            stream: "stream3",
+          },
+          {
+            filename: "app_123/chunks/chunk1.js",
+            stream: "stream4",
+          },
+          {
+            filename: "app_123/chunks/chunk2.js",
+            stream: "stream5",
+          },
+        ],
       })
       expect(result).toEqual({ version: "1.0.0" })
     })


### PR DESCRIPTION
## Description
Now that we are uploading many chunks, updating the client library files is getting pretty slow. This is because we are calling multiple individual updates. This PR is changing it to use a single bulkUpdate, which will avoid multi-bucket checks and configs.

Also, adding a loading state on the revert button, as it's a slow process, and not getting feedback induces you to click multiple times
