### PR TITLE
SCIM - Handle already removed users from groups

### DIFF
--- a/packages/worker/src/api/routes/global/tests/scim.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/scim.spec.ts
@@ -1211,7 +1211,7 @@ describe("scim", () => {
           expect(persistedGroup).toEqual(expectedScimGroup)
         })
 
-        it("removing a member that no longer exists succeeds", async () => {
+        it("succeeds when removing a member that no longer exists", async () => {
           const userToRemove = users[6]
 
           // ensure the user is a member first

--- a/packages/worker/src/api/routes/global/tests/scim.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/scim.spec.ts
@@ -1210,6 +1210,61 @@ describe("scim", () => {
           const persistedGroup = await config.api.scimGroupsAPI.find(group.id)
           expect(persistedGroup).toEqual(expectedScimGroup)
         })
+
+        it("removing a member that no longer exists succeeds", async () => {
+          const userToRemove = users[6]
+
+          // ensure the user is a member first
+          await patchScimGroup({
+            id: group.id,
+            body: {
+              schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+              Operations: [
+                {
+                  op: "Add",
+                  path: "members",
+                  value: [
+                    {
+                      $ref: null,
+                      value: userToRemove.id,
+                    },
+                  ],
+                },
+              ],
+            },
+          })
+
+          // deleting the user simulates Azure holding on to a stale reference
+          await config.api.users.deleteUser(userToRemove.id)
+
+          const groupBeforeRemoval = await config.api.scimGroupsAPI.find(
+            group.id
+          )
+
+          const response = await patchScimGroup({
+            id: group.id,
+            body: {
+              schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+              Operations: [
+                {
+                  op: "Remove",
+                  path: "members",
+                  value: [
+                    {
+                      $ref: null,
+                      value: userToRemove.id,
+                    },
+                  ],
+                },
+              ],
+            },
+          })
+
+          expect(response).toEqual(groupBeforeRemoval)
+
+          const persistedGroup = await config.api.scimGroupsAPI.find(group.id)
+          expect(persistedGroup).toEqual(groupBeforeRemoval)
+        })
       })
     })
   })


### PR DESCRIPTION
## Description
Fixing a bug that adds noise to the SCIM providers' logs. If a user is removed from a group (and that was the only reference to that user), Azure calls our instances with the following flow:
1. Remove the user (by external ID)
2. Remove the user from the group (by external IDs)

The issue was on step 2. As AD sends the external IDs, when we are trying to map the external ID to the Budibase one. As they are already removed, we were getting 404s, causing the operation to fail (and to retry forever).
If we hit this case, as the user is already not part of the system, we can safely ignore it, as the user-group info is stored on the user object.

Pro PR:
- https://github.com/Budibase/budibase-pro/pull/469



## Launchcontrol
Fix SCIM related to removing users from groups