### PR TITLE
feat/mysql-views - Import MySQL views as custom queries

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Queries/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Queries/index.svelte
@@ -16,7 +16,8 @@
 
   let viewSelectionModal
 
-  $: supportsViews = datasource.source === "POSTGRES"
+  $: supportsViews =
+    datasource.source === "POSTGRES" || datasource.source === "MYSQL"
 </script>
 
 {#if supportsViews}

--- a/packages/builder/src/stores/builder/datasources.ts
+++ b/packages/builder/src/stores/builder/datasources.ts
@@ -311,7 +311,7 @@ export class DatasourceStore extends DerivedBudiStore<
       const sql =
         "SELECT * FROM " +
         viewName +
-        " \nOFFSET {{ offset }} \nLIMIT {{ limit }}"
+        " \nLIMIT {{ limit }} \nOFFSET {{ offset }}"
 
       const query = {
         datasourceId: datasource._id!,


### PR DESCRIPTION
This PR implements importing MYSQL views as custom queries
It also addresses #17170 

This pull request improves MySQL support in the builder workspace and backend integration code. The main changes enable view support for MySQL datasources and refactor how table and view names are queried from MySQL databases.

**Frontend: View support for MySQL datasources**

* The `supportsViews` flag in `index.svelte` now includes MySQL datasources, allowing users to interact with views in addition to tables. ([packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Queries/index.svelteL19-R20](diffhunk://#diff-615b33f5598aa6f46d84993810009460d7e9d55dca83ad10033159dea79f2b07L19-R20))

**Backend: MySQL integration improvements**

* Refactored `queryTableNames` in `mysql.ts` to use a more robust SQL query for retrieving table names, ensuring compatibility regardless of database naming conventions.
* Added new methods `queryViewNames` and `getViewNames` to `MySQLIntegration`, enabling reliable retrieval of view names from MySQL databases.
