### PR TITLE
Svelte 5 errors and warnings

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,7 +5,5 @@
   "trailingComma": "es5",
   "arrowParens": "avoid",
   "bracketSameLine": false,
-  "plugins": ["prettier-plugin-svelte"],
-  "svelteSortOrder": "options-scripts-markup-styles",
-  "svelteAllowShorthand": false
+  "plugins": ["prettier-plugin-svelte"]
 }

--- a/packages/bbui/src/ActionMenu/ActionMenu.svelte
+++ b/packages/bbui/src/ActionMenu/ActionMenu.svelte
@@ -81,8 +81,16 @@
   borderRadius={roundedPopover ? "12px" : undefined}
   on:open
   on:close
-  on:mouseenter={openOnHover ? cancelHide : null}
-  on:mouseleave={openOnHover ? queueHide : null}
+  on:mouseenter={() => {
+    if (openOnHover) {
+      cancelHide()
+    }
+  }}
+  on:mouseleave={() => {
+    if (openOnHover) {
+      queueHide()
+    }
+  }}
   bind:open
 >
   <Menu>

--- a/packages/bbui/src/Form/Core/TextField.svelte
+++ b/packages/bbui/src/Form/Core/TextField.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import "@spectrum-css/textfield/dist/index-vars.css"
   import { createEventDispatcher, onMount, tick } from "svelte"
+  import type { FullAutoFill } from "svelte/elements"
   import type { UIEvent } from "@budibase/types"
 
   export let value: string | null = null
@@ -13,7 +14,7 @@
   export let quiet = false
   export let align: "left" | "right" | "center" | undefined = undefined
   export let autofocus: boolean | null = false
-  export let autocomplete: boolean | string | undefined
+  export let autocomplete: FullAutoFill | boolean | null | undefined = undefined
 
   const dispatch = createEventDispatcher()
 
@@ -69,12 +70,14 @@
     return type === "number" ? "decimal" : "text"
   }
 
+  let autocompleteValue: FullAutoFill | null | undefined
+
   $: autocompleteValue =
     typeof autocomplete === "boolean"
-      ? autocomplete
-        ? "on"
-        : "off"
-      : undefined
+      ? (autocomplete ? "on" : "off")
+      : autocomplete === null
+        ? null
+        : autocomplete
 
   onMount(async () => {
     if (disabled) return

--- a/packages/bbui/src/Form/Input.svelte
+++ b/packages/bbui/src/Form/Input.svelte
@@ -2,6 +2,7 @@
   import Field from "./Field.svelte"
   import TextField from "./Core/TextField.svelte"
   import { createEventDispatcher } from "svelte"
+  import type { FullAutoFill } from "svelte/elements"
 
   export let value: any = undefined
   export let label: string | undefined = undefined
@@ -14,7 +15,7 @@
   export let updateOnChange = true
   export let quiet = false
   export let autofocus: boolean | undefined = undefined
-  export let autocomplete: boolean | string | undefined = undefined
+  export let autocomplete: FullAutoFill | boolean | null | undefined = undefined
   export let helpText: string | undefined = undefined
 
   const dispatch = createEventDispatcher<{

--- a/packages/builder/src/components/automation/SetupPanel/AutomationCustomLayout.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AutomationCustomLayout.svelte
@@ -22,7 +22,9 @@
         {bindings}
         {block}
         {context}
-        on:change={config.onChange}
+        on:change={(e: CustomEvent) => {
+          if (config?.onChange) config.onChange(e)
+        }}
       />
     {:else}
       <PropField
@@ -36,7 +38,9 @@
           {bindings}
           {block}
           {context}
-          on:change={config.onChange}
+          on:change={(e: CustomEvent) => {
+            if (config?.onChange) config.onChange(e)
+          }}
         />
       </PropField>
     {/if}

--- a/packages/builder/src/components/common/ConfirmDialog.svelte
+++ b/packages/builder/src/components/common/ConfirmDialog.svelte
@@ -20,9 +20,17 @@
   export const hide = () => {
     modal.hide()
   }
+
+  const handleHide = () => {
+    if (onClose) {
+      onClose()
+      return
+    }
+    onCancel?.()
+  }
 </script>
 
-<Modal bind:this={modal} on:hide={onClose ?? onCancel}>
+<Modal bind:this={modal} on:hide={handleHide}>
   <ModalContent
     onConfirm={onOk}
     {onCancel}

--- a/packages/builder/src/components/common/CreationPage.svelte
+++ b/packages/builder/src/components/common/CreationPage.svelte
@@ -9,7 +9,7 @@
 <section class="page">
   {#if showClose}
     <div class="closeButton">
-      <Icon hoverable name="x" on:click={onClose} />
+      <Icon hoverable name="x" on:click={() => onClose?.()} />
     </div>
   {/if}
   <div class="heading">

--- a/packages/builder/src/components/common/bindings/SnippetDrawer.svelte
+++ b/packages/builder/src/components/common/bindings/SnippetDrawer.svelte
@@ -137,9 +137,7 @@
         placeholder="return function(input) &#10100; ... &#10101;"
         value={code}
         on:change={e => (code = e.detail)}
-      >
-        <Input placeholder="Name" />
-      </BindingPanel>
+      />
     {/key}
   </svelte:fragment>
 </Drawer>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/index.svelte
@@ -22,14 +22,16 @@
     CreateToolSourceRequest,
     UserMessage,
   } from "@budibase/types"
-  import { onDestroy, onMount, type ComponentType } from "svelte"
+  import { onDestroy, onMount } from "svelte"
   import Chatbox from "./Chatbox.svelte"
   import BambooHRLogo from "./logos/BambooHR.svelte"
   import BudibaseLogo from "./logos/Budibase.svelte"
   import ConfluenceLogo from "./logos/Confluence.svelte"
   import GithubLogo from "./logos/Github.svelte"
 
-  const Logos: Record<string, ComponentType> = {
+  type LogoComponent = typeof BudibaseLogo
+
+  const Logos: Record<string, LogoComponent> = {
     BUDIBASE: BudibaseLogo,
     CONFLUENCE: ConfluenceLogo,
     GITHUB: GithubLogo,
@@ -142,7 +144,7 @@
       await API.agentChatStream(
         updatedChat,
         $params.application,
-        chunk => {
+        (chunk: any) => {
           if (chunk.type === "content") {
             // Accumulate streaming content
             streamingContent += chunk.content || ""
@@ -479,7 +481,7 @@
 
     <div class="chat-wrapper">
       <div class="chat-area" bind:this={chatAreaElement}>
-        <Chatbox bind:chat {loading} />
+        <Chatbox bind:chat={chat} loading={loading} />
         <div class="input-wrapper">
           <textarea
             bind:value={inputValue}
@@ -488,7 +490,7 @@
             on:keydown={handleKeyDown}
             placeholder="Ask anything"
             disabled={loading}
-         ></textarea>
+          ></textarea>
         </div>
       </div>
     </div>
@@ -511,11 +513,13 @@
               hoverable
               on:click={backToToolsList}
             />
-            <svelte:component
-              this={Logos[selectedConfigToolSource.type]}
-              height="16"
-              width="16"
-            />
+            {#if Logos[selectedConfigToolSource.type]}
+              <svelte:component
+                this={Logos[selectedConfigToolSource.type]}
+                height="16"
+                width="16"
+              />
+            {/if}
             <Body size="S">
               {ToolSources.find(ts => selectedConfigToolSource.type === ts.type)
                 ?.name}
@@ -549,13 +553,17 @@
                   on:click={() => openToolsConfig(toolSource)}
                   on:contextmenu={menuCallback}
                 >
-                  <div class="tool-icon" slot="icon">
-                    <svelte:component
-                      this={Logos[toolSource.type]}
-                      height="16"
-                      width="16"
-                    />
-                  </div>
+                  <svelte:fragment slot="icon">
+                    {#if Logos[toolSource.type]}
+                      <div class="tool-icon">
+                        <svelte:component
+                          this={Logos[toolSource.type]}
+                          height="16"
+                          width="16"
+                        />
+                      </div>
+                    {/if}
+                  </svelte:fragment>
                   <Icon
                     on:click={menuCallback}
                     hoverable
@@ -765,13 +773,15 @@
       </Body>
       {#if toolSourceToDelete}
         <div class="tool-source-preview">
-          <div class="tool-icon">
-            <svelte:component
-              this={Logos[toolSourceToDelete.type]}
-              height="20"
-              width="20"
-            />
-          </div>
+          {#if Logos[toolSourceToDelete.type]}
+            <div class="tool-icon">
+              <svelte:component
+                this={Logos[toolSourceToDelete.type]}
+                height="20"
+                width="20"
+              />
+            </div>
+          {/if}
           <span class="tool-name">
             {ToolSources.find(ts => ts.type === toolSourceToDelete.type)?.name}
           </span>

--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Component/componentStyles.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Component/componentStyles.ts
@@ -1,7 +1,27 @@
+import type { Component } from "svelte"
 import { Input, Select } from "@budibase/bbui"
 import ColorPicker from "@/components/design/settings/controls/ColorPicker.svelte"
 
-export const margin = {
+interface StyleOption {
+  label: string
+  value: string
+}
+
+interface StyleSetting {
+  label: string
+  key: string
+  control: Component<any>
+  placeholder?: string
+  options?: StyleOption[]
+  column?: string
+}
+
+interface StyleGroup {
+  label: string
+  settings: StyleSetting[]
+}
+
+export const margin: StyleGroup = {
   label: "Margin",
   settings: [
     {
@@ -87,7 +107,7 @@ export const margin = {
   ],
 }
 
-export const padding = {
+export const padding: StyleGroup = {
   label: "Padding",
   settings: [
     {
@@ -173,7 +193,7 @@ export const padding = {
   ],
 }
 
-export const size = {
+export const size: StyleGroup = {
   label: "Size",
   settings: [
     {
@@ -191,7 +211,7 @@ export const size = {
   ],
 }
 
-export const font = {
+export const font: StyleGroup = {
   label: "Font",
   settings: [
     {
@@ -202,7 +222,7 @@ export const font = {
   ],
 }
 
-export const background = {
+export const background: StyleGroup = {
   label: "Background",
   settings: [
     {
@@ -290,7 +310,7 @@ export const background = {
   ],
 }
 
-export const border = {
+export const border: StyleGroup = {
   label: "Border",
   settings: [
     {
@@ -360,4 +380,4 @@ export const border = {
   ],
 }
 
-export const all = [margin]
+export const all: StyleGroup[] = [margin]

--- a/packages/builder/src/settings/Router.svelte
+++ b/packages/builder/src/settings/Router.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Routing, MatchedRoute } from "@/types/routing"
-  import { type SvelteComponent } from "svelte"
+  import type { Component } from "svelte"
   import { setContext } from "svelte"
   import { writable } from "svelte/store"
   import { memo } from "@budibase/frontend-core"
@@ -14,7 +14,7 @@
   setContext("routing", routing)
 
   // Load the comp
-  let page: typeof SvelteComponent<any> | undefined
+  let page: Component<Record<string, unknown>> | undefined
 
   $: memoRoute.set(route)
 

--- a/packages/builder/src/settings/pages/ai/AIConfigTile.svelte
+++ b/packages/builder/src/settings/pages/ai/AIConfigTile.svelte
@@ -4,9 +4,10 @@
   import AzureOpenAILogo from "./logos/AzureOpenAI.svelte"
   import BudibaseAILogo from "./logos/BBAI.svelte"
   import type { AIProvider, ProviderConfig } from "@budibase/types"
-  import { type ComponentType } from "svelte"
 
-  const logos: Partial<Record<AIProvider, ComponentType>> = {
+  type LogoComponent = typeof BudibaseAILogo
+
+  const logos: Partial<Record<AIProvider, LogoComponent>> = {
     BudibaseAI: BudibaseAILogo,
     OpenAI: OpenAILogo,
     AzureOpenAI: AzureOpenAILogo,
@@ -20,7 +21,13 @@
 <div class="option">
   <div class="details">
     <div class="icon">
-      <svelte:component this={logos[config.provider]} height="26" width="26" />
+      {#if logos[config.provider]}
+        <svelte:component
+          this={logos[config.provider]}
+          height="26"
+          width="26"
+        />
+      {/if}
     </div>
     <div class="header">
       <Body size="S" weight={"600"}>{config.name}</Body>

--- a/packages/builder/src/settings/pages/index.ts
+++ b/packages/builder/src/settings/pages/index.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from "svelte"
+import type { Component } from "svelte"
 
 // General
 import ProfilePage from "@/settings/pages/profile.svelte"
@@ -33,7 +33,7 @@ import ScriptsPage from "@/settings/pages/scripts.svelte"
 import OAuth2Page from "@/settings/pages/oauth2/index.svelte"
 import Recaptcha from "@/settings/pages/recaptcha.svelte"
 
-const componentMap: Record<string, ComponentType> = {
+const componentMap = {
   profile: ProfilePage,
   users: UsersPage,
   user: UserPage,
@@ -63,10 +63,10 @@ const componentMap: Record<string, ComponentType> = {
   scripts: ScriptsPage,
   oauth2: OAuth2Page,
   recaptcha: Recaptcha,
-}
+} satisfies Record<string, Component<any>>
 
 export const Pages = {
-  get: (key: keyof typeof componentMap) => {
+  get: (key: keyof typeof componentMap): Component<any> | undefined => {
     const component = componentMap[key]
     if (!component) {
       console.error(`Component not found for key: ${key}`)

--- a/packages/builder/src/types/routing.ts
+++ b/packages/builder/src/types/routing.ts
@@ -1,5 +1,4 @@
-import { ComponentType } from "svelte"
-import { SvelteComponent } from "svelte"
+import type { Component } from "svelte"
 
 export interface Routing {
   params?: Record<string, any>
@@ -27,12 +26,12 @@ export const isSettingIcon = (
 
 export interface RouteIcon {
   props: Record<string, any>
-  comp: typeof SvelteComponent<any>
+  comp: Component<any>
 }
 
 export interface Route {
   path?: string
-  comp?: ComponentType | undefined
+  comp?: Component<any>
   routes?: Route[]
   section?: string
   title?: string

--- a/packages/client/src/components/app/filter/FilterPopover.svelte
+++ b/packages/client/src/components/app/filter/FilterPopover.svelte
@@ -33,6 +33,11 @@
   import dayjs from "dayjs"
   import utc from "dayjs/plugin/utc"
 
+  interface $$Slots {
+    default: Record<string, never>
+    anchor: Record<string, never>
+  }
+
   dayjs.extend(utc)
 
   export const show = () => popover?.show()

--- a/packages/client/src/context.d.ts
+++ b/packages/client/src/context.d.ts
@@ -1,10 +1,15 @@
-import { Writable } from "svelte"
-import { Component, Context, FieldGroupContext, FormContext } from "@/types"
-import { SDK } from "@/index.ts"
+import type { Writable } from "svelte/store"
+import type {
+  Component as ComponentStore,
+  Context,
+  FieldGroupContext,
+  FormContext,
+} from "@/types"
+import type { SDK } from "@/index"
 
 declare module "svelte" {
   export function getContext(key: "sdk"): SDK
-  export function getContext(key: "component"): Component
+  export function getContext(key: "component"): ComponentStore
   export function getContext(key: "current-step"): Writable<number>
   export function getContext(key: "context"): Context
   export function getContext(key: "form"): FormContext | undefined


### PR DESCRIPTION
## Description
This PR addresses some of the errors and warnings that appeared thanks to the migration from Svelte 5 and some of the compiler tightening that took place due to it. 

The most confusing here is the routing changes to Component<any>, essentially in Svelte 4 a default component export was a `SvelteComponent` but in Svelte 5 it changed to be a `Component<props>` meaning that our routing typing was broken because we weren't passing the props. i.e user.svelte does `export let userId`, its type is `Component<{ userId: string }>`

To properly type this would be a bigger refactor so i thought it best to just do this for now. 