### PR TITLE
Added enableEmailBranding check to default.hbs

### DIFF
--- a/packages/worker/src/constants/templates/base.hbs
+++ b/packages/worker/src/constants/templates/base.hbs
@@ -443,23 +443,27 @@
   <tr>
     <td align="center">
       <table class="email-content" width="100%" cellpadding="0" cellspacing="0" role="presentation">
-        <tr>
-          <td class="email-masthead">
-            <a href="{{ platformUrl }}" class="f-fallback email-masthead_name">
-              {{ company }}
-            </a>
-          </td>
-        </tr>
+        {{#if enableEmailBranding}}
+          <tr>
+            <td class="email-masthead">
+              <a href="{{ platformUrl }}" class="f-fallback email-masthead_name">
+                {{ company }}
+              </a>
+            </td>
+          </tr>
+        {{/if}}
         {{ body }}
-        <tr>
-          <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
-            <tr>
-              <td class="content-cell" align="center">
-                <p class="f-fallback sub align-center">&copy; {{ currentYear }} {{ company }}. All rights reserved.</p>
-              </td>
-            </tr>
-          </table>
-        </tr>
+        {{#if enableEmailBranding}}
+          <tr>
+            <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
+              <tr>
+                <td class="content-cell" align="center">
+                  <p class="f-fallback sub align-center">&copy; {{ currentYear }} {{ company }}. All rights reserved.</p>
+                </td>
+              </tr>
+            </table>
+          </tr>
+        {{/if}}
       </table>
     </td>
   </tr>

--- a/packages/worker/src/constants/templates/tests/email_templates.yaml
+++ b/packages/worker/src/constants/templates/tests/email_templates.yaml
@@ -447,23 +447,27 @@ templates:
       <tr>
         <td align="center">
           <table class="email-content" width="100%" cellpadding="0" cellspacing="0" role="presentation">
-            <tr>
-              <td class="email-masthead">
-                <a href="{{ platformUrl }}" class="f-fallback email-masthead_name">
-                  {{ company }}
-                </a>
-              </td>
-            </tr>
+            {{#if enableEmailBranding}}
+              <tr>
+                <td class="email-masthead">
+                  <a href="{{ platformUrl }}" class="f-fallback email-masthead_name">
+                    {{ company }}
+                  </a>
+                </td>
+              </tr>
+            {{/if}}
             {{ body }}
-            <tr>
-              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
-                <tr>
-                  <td class="content-cell" align="center">
-                    <p class="f-fallback sub align-center">&copy; {{ currentYear }} {{ company }}. All rights reserved.</p>
-                  </td>
-                </tr>
-              </table>
-            </tr>
+            {{#if enableEmailBranding}}
+              <tr>
+                <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
+                  <tr>
+                    <td class="content-cell" align="center">
+                      <p class="f-fallback sub align-center">&copy; {{ currentYear }} {{ company }}. All rights reserved.</p>
+                    </td>
+                  </tr>
+                </table>
+              </tr>
+            {{/if}}
           </table>
         </td>
       </tr>


### PR DESCRIPTION
## Description
Adds a check that removes specific elements of text if removing branding is enabled for automation emails.

## Addresses
- Customer request

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
**Before**
<img width="1127" height="373" alt="Screenshot 2025-10-20 at 13 50 44" src="https://github.com/user-attachments/assets/c88819bc-6d6d-4c1f-997b-77add9462dc8" />

**After**
<img width="1125" height="271" alt="Screenshot 2025-10-20 at 13 50 23" src="https://github.com/user-attachments/assets/a506b09d-a5a0-403d-828e-8fde24cf4ec3" />

## Launchcontrol
Small check that removes org name and link, as well as footer name and link, if remove branding is toggled on.
