### PR TITLE
Fix issue where looping nodes weren't horizontal in horizontal mode

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowFactories.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowFactories.ts
@@ -47,7 +47,14 @@ export const branchNode = (
   laneWidth?: number,
   position: { x: number; y: number } = { x: 0, y: 0 }
 ): FlowNode => {
-  const data = { block: step, branch, branchIdx, direction }
+  const data = {
+    block: step,
+    branch,
+    branchIdx,
+    direction,
+    ...(parentId ? { isSubflow: true } : {}),
+    ...(laneWidth ? { laneWidth } : {}),
+  }
   const node: FlowNode = {
     id,
     type: "branch-node",

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowGraphBuilder.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowGraphBuilder.ts
@@ -478,8 +478,9 @@ export const renderLoopV2Container = (
   const paddingBottom = SUBFLOW.paddingBottom
   const internalSpacing = SUBFLOW.internalSpacing
   const childHeight = SUBFLOW.childHeight
-  const lrGapForWidth = isLR ? 60 : 0
-  const lrSpacing = SUBFLOW.internalSpacing + (isLR ? 60 : 0)
+  const lrWidth = 60
+  const lrGapForWidth = isLR ? lrWidth : 0
+  const lrSpacing = SUBFLOW.internalSpacing + (isLR ? lrWidth : 0)
   const lrMinExit = lrSpacing + 20
 
   let dynamicHeight = paddingTop

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/nodes/AnchorNode.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/nodes/AnchorNode.svelte
@@ -9,7 +9,7 @@
   $: isHorizontal = direction === "LR"
 </script>
 
-<div class="anchor">
+<div class="anchor" style={isHorizontal ? "width:1px" : undefined}>
   <Handle
     class="custom-handle"
     type="target"

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/nodes/BranchNodeWrapper.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/nodes/BranchNodeWrapper.svelte
@@ -20,7 +20,7 @@
   $: automation = $selectedAutomation?.data
   $: direction = (data.direction || "TB") as LayoutDirection
   $: isHorizontal = direction === "LR"
-  $: isSubflow = Boolean(data?.isSubflow)
+  $: isSubflow = !!data?.isSubflow
   $: laneWidth = data?.laneWidth || SUBFLOW.laneWidth
   $: handleOffset =
     isHorizontal && isSubflow

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/nodes/BranchNodeWrapper.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/nodes/BranchNodeWrapper.svelte
@@ -4,6 +4,7 @@
   import { ViewMode, type BranchNodeData } from "@/types/automations"
   import { Handle, Position } from "@xyflow/svelte"
   import { enrichLog } from "../../AutomationStepHelpers"
+  import { STEP, SUBFLOW } from "../FlowGeometry"
   import {
     type AutomationStepResult,
     type AutomationTriggerResult,
@@ -19,6 +20,12 @@
   $: automation = $selectedAutomation?.data
   $: direction = (data.direction || "TB") as LayoutDirection
   $: isHorizontal = direction === "LR"
+  $: isSubflow = Boolean(data?.isSubflow)
+  $: laneWidth = data?.laneWidth || SUBFLOW.laneWidth
+  $: handleOffset =
+    isHorizontal && isSubflow
+      ? Math.max(0, Math.round((laneWidth - STEP.width) / 2))
+      : 0
 
   // Handle step selection in logs mode (open details panel)
   function handleStepSelect(
@@ -39,12 +46,15 @@
   }
 </script>
 
-<div style="position: relative;">
+<div class="branch-wrapper">
   <Handle
     isConnectable={false}
     class="custom-handle"
     type="target"
     position={isHorizontal ? Position.Left : Position.Top}
+    style={isHorizontal && isSubflow
+      ? `left: ${handleOffset - 3}px;`
+      : undefined}
   />
   <div class="branch-container">
     <BranchNode
@@ -60,5 +70,8 @@
     class="custom-handle"
     type="source"
     position={isHorizontal ? Position.Right : Position.Bottom}
+    style={isHorizontal && isSubflow
+      ? `right: ${handleOffset - 3}px;`
+      : undefined}
   />
 </div>

--- a/packages/builder/src/types/automations.ts
+++ b/packages/builder/src/types/automations.ts
@@ -294,6 +294,8 @@ export interface BranchNodeData {
   branch: Branch
   branchIdx: number
   direction?: LayoutDirection
+  isSubflow?: boolean
+  laneWidth?: number
   [key: string]: unknown
 }
 


### PR DESCRIPTION
## Description
Fixes an issue where in left to right mode for the entire automation, the loop subflow nodes were actually vertical. This updates it and ensures that they're horizontal. 

There's a lot of custom code here as well, we essentially need to do many different calculations for when the chart is horizontal / vertical. Adjusting x / y positions of nodes and edges. 


## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
<img width="1485" height="547" alt="image" src="https://github.com/user-attachments/assets/c5178958-3330-4f17-90d4-b90ba64e28e2" />

## Launchcontrol
Ensure loop subflow nodes in horizontal mode actually run horizontally.