### PR TITLE
Delete Datasource modal - puts screens into unordered list

### DIFF
--- a/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
+++ b/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
@@ -191,13 +191,15 @@
         {buildMessage(sourceType)}
         {#if affectedScreens.length > 0}
           <span class="screens">
-            {#each affectedScreens as item, idx}
-              <Link overBackground target="_blank" href={item.url}
-                >{item.text}{idx !== affectedScreens.length - 1
-                  ? ","
-                  : ""}</Link
-              >
-            {/each}
+            <ul class="screens-list">
+              {#each affectedScreens as item}
+                <li>
+                  <Link overBackground target="_blank" href={item.url}
+                    >{item.text}</Link
+                  >
+                </li>
+              {/each}
+            </ul>
           </span>
         {/if}
       </p>
@@ -215,6 +217,7 @@
   .warning {
     margin: 0;
     max-width: 100%;
+    overflow: hidden;
   }
 
   .screens {


### PR DESCRIPTION
## Description
When deleting a datasource (Table or Query) that is used in many screens, the modal isn't laid out neatly to accomodate many links.

<img width="793" height="403" alt="image" src="https://github.com/user-attachments/assets/45671b3b-5199-4668-aae6-7a986bb2cfe3" />

This PR places the named screens in an unordered list, rather than a continuous span of links.

## Addresses
- #17177 

## Screenshots
Deleting Tables:
<img width="426" height="648" alt="image" src="https://github.com/user-attachments/assets/be5eac61-1504-4d39-aa01-a92496c476d6" />

Deleting Queries
<img width="428" height="523" alt="image" src="https://github.com/user-attachments/assets/9c3db52f-13c3-429e-a196-717e3db94b34" />


## Launchcontrol

Fixes overflow on Delete Datasource modal.
