### PR TITLE
Fix issue with parsing automation attachments

### DIFF
--- a/packages/server/src/automations/automationUtils.ts
+++ b/packages/server/src/automations/automationUtils.ts
@@ -128,15 +128,7 @@ export function guardAttachment(
     return false
   }
   if (typeof attachmentObject !== "object") {
-    throw new Error(
-      `Attachments must be objects with both "url" and "filename" keys.`
-    )
-  }
-  if (!("url" in attachmentObject) || !("filename" in attachmentObject)) {
-    const providedKeys = Object.keys(attachmentObject).join(", ")
-    throw new Error(
-      `Attachments must have both "url" and "filename" keys. You have provided: ${providedKeys}`
-    )
+    throw new Error(`Attachments must be objects.`)
   }
   return true
 }

--- a/packages/server/src/automations/automationUtils.ts
+++ b/packages/server/src/automations/automationUtils.ts
@@ -229,7 +229,9 @@ export async function sendAutomationAttachmentsToStorage(
         guardAttachment(normalized)
       }
 
-      attachmentRows[prop] = normalized as any
+      attachmentRows[prop] = normalized as
+        | AutomationAttachment
+        | AutomationAttachment[]
     }
   }
 

--- a/packages/server/src/automations/automationUtils.ts
+++ b/packages/server/src/automations/automationUtils.ts
@@ -127,9 +127,6 @@ export function guardAttachment(
   if (!attachmentObject) {
     return false
   }
-  if (typeof attachmentObject !== "object") {
-    throw new Error(`Attachments must be objects.`)
-  }
   return true
 }
 
@@ -146,10 +143,6 @@ function deriveFilenameFromUrl(url: string) {
 function normalizeSingleAttachment(
   input: string | AutomationAttachment
 ): AutomationAttachment | null {
-  if (input == null || input === "") {
-    return null
-  }
-
   if (typeof input === "string") {
     try {
       const parsed = JSON.parse(input)

--- a/packages/server/src/automations/tests/steps/createRow.spec.ts
+++ b/packages/server/src/automations/tests/steps/createRow.spec.ts
@@ -233,6 +233,85 @@ describe("test the create row action", () => {
     expect(objectData.ContentLength).toBeGreaterThan(0)
   })
 
+  it("should accept attachment values provided as JSON strings (array)", async () => {
+    let attachmentTable = await config.api.table.save(
+      basicTableWithAttachmentField()
+    )
+
+    let attachmentRow: Row = { tableId: attachmentTable._id }
+
+    const filename = "test_json_array.txt"
+    const presignedUrl = await uploadTestFile(filename)
+    const attachmentJson = JSON.stringify([{ url: presignedUrl, filename }])
+
+    // Simulate binding producing a JSON string
+    attachmentRow.file_attachment = attachmentJson as unknown as any
+
+    const result = await createAutomationBuilder(config)
+      .onAppAction()
+      .createRow({ row: attachmentRow }, { stepName: "CreateRowJsonArray" })
+      .test({ fields: { type: "attachment-json-array" } })
+
+    expect(result.steps[0].outputs.success).toEqual(true)
+    expect(result.steps[0].outputs.row.file_attachment[0]).toHaveProperty("key")
+  })
+
+  it("should accept attachment values provided as JSON strings (single)", async () => {
+    let attachmentTable = await config.api.table.save(
+      basicTableWithAttachmentField()
+    )
+
+    let attachmentRow: Row = { tableId: attachmentTable._id }
+
+    const filename = "test_json_single.txt"
+    const presignedUrl = await uploadTestFile(filename)
+    const attachmentJson = JSON.stringify({ url: presignedUrl, filename })
+
+    // Simulate binding producing a JSON string
+    attachmentRow.single_file_attachment = attachmentJson as unknown as any
+
+    const result = await createAutomationBuilder(config)
+      .onAppAction()
+      .createRow({ row: attachmentRow }, { stepName: "CreateRowJsonSingle" })
+      .test({ fields: { type: "attachment-json-single" } })
+
+    expect(result.steps[0].outputs.success).toEqual(true)
+    expect(result.steps[0].outputs.row.single_file_attachment).toHaveProperty(
+      "key"
+    )
+  })
+
+  it("should accept attachment objects from bindings with { name, url, key } by deriving filename", async () => {
+    let attachmentTable = await config.api.table.save(
+      basicTableWithAttachmentField()
+    )
+
+    let attachmentRow: Row = { tableId: attachmentTable._id }
+
+    const filename = "test_binding_like.jpg"
+    const presignedUrl = await uploadTestFile(filename)
+    // Simulate a value similar to what bindings can produce from an existing row
+    const bindingLike = JSON.stringify({
+      name: filename,
+      url: presignedUrl,
+      key: `some_workspace/attachments/${filename}`,
+      size: 12345,
+      extension: "jpg",
+    })
+
+    attachmentRow.single_file_attachment = bindingLike as unknown as any
+
+    const result = await createAutomationBuilder(config)
+      .onAppAction()
+      .createRow({ row: attachmentRow }, { stepName: "CreateRowBindingLike" })
+      .test({ fields: { type: "attachment-binding-like" } })
+
+    expect(result.steps[0].outputs.success).toEqual(true)
+    expect(result.steps[0].outputs.row.single_file_attachment).toHaveProperty(
+      "key"
+    )
+  })
+
   it("should check that attachment without the correct keys throws an error", async () => {
     let attachmentTable = await config.api.table.save(
       basicTableWithAttachmentField()

--- a/packages/server/src/automations/tests/steps/createRow.spec.ts
+++ b/packages/server/src/automations/tests/steps/createRow.spec.ts
@@ -244,7 +244,6 @@ describe("test the create row action", () => {
     const presignedUrl = await uploadTestFile(filename)
     const attachmentJson = JSON.stringify([{ url: presignedUrl, filename }])
 
-    // Simulate binding producing a JSON string
     attachmentRow.file_attachment = attachmentJson as unknown as any
 
     const result = await createAutomationBuilder(config)
@@ -290,7 +289,6 @@ describe("test the create row action", () => {
 
     const filename = "test_binding_like.jpg"
     const presignedUrl = await uploadTestFile(filename)
-    // Simulate a value similar to what bindings can produce from an existing row
     const bindingLike = JSON.stringify({
       name: filename,
       url: presignedUrl,

--- a/packages/types/src/documents/workspace/automation/automation.ts
+++ b/packages/types/src/documents/workspace/automation/automation.ts
@@ -281,6 +281,7 @@ export interface AutomationMetadata extends Document {
 export type AutomationAttachment = {
   url: string
   filename: string
+  name?: string
 }
 
 export type AutomationAttachmentContent = {


### PR DESCRIPTION
## Description
Fix an issue where when passing an attachment object as a binding, we weren't correctly parsing it from a string. Also added some other utilities to improve type safety and general error handling in this area. 

## Addresses
#17197 



## Launchcontrol
- Fix issue with attachment bindings