### PR TITLE
Flexible app layout to accommodate banners in the builder

### DIFF
--- a/packages/builder/src/global.css
+++ b/packages/builder/src/global.css
@@ -32,6 +32,8 @@ body {
   height: 100%;
   box-sizing: border-box;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .hoverable:hover {

--- a/packages/builder/src/pages/builder/workspace/[application]/_layout.workspace.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_layout.workspace.svelte
@@ -94,8 +94,7 @@
     background: var(--background);
   }
   .root {
-    min-height: 100%;
-    height: 100%;
+    flex: 1;
     width: 100%;
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
## Description
Fix to stop old portal banners from displacing the builder; pushing builder content out of sight.