### PR TITLE
Fix for builder modal positioning 

### DIFF
--- a/packages/builder/src/App.svelte
+++ b/packages/builder/src/App.svelte
@@ -20,6 +20,15 @@
 
 <style>
   .modal-container {
-    position: absolute;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 999;
+  }
+  .modal-container :global(*) {
+    pointer-events: auto;
   }
 </style>


### PR DESCRIPTION
## Description
A layout change (https://github.com/Budibase/budibase/pull/17208) in the builder broke modal positioning. This fix ensures that modals remain in view.

## Addresses
- https://github.com/Budibase/budibase/issues/17215

## Launchcontrol
Fixes modal display in the builder