### PR TITLE
Fixes to "columns" property editor ( legacy )

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ColumnEditor/CellDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/ColumnEditor/CellDrawer.svelte
@@ -19,51 +19,86 @@
 <DrawerContent>
   <div class="container">
     <Layout noPadding gap="S">
-      <Input
-        bind:value={column.width}
-        label="Width (must include a unit like px or %)"
-        placeholder="Auto"
-      />
-      <Select
-        label="Alignment"
-        bind:value={column.align}
-        options={["Left", "Center", "Right"]}
-        placeholder="Default"
-      />
-      <DrawerBindableInput
-        title="Value"
-        label="Value"
-        value={column.template}
-        on:change={e => (column.template = e.detail)}
-        placeholder={`{{ Value }}`}
-        bindings={[
-          {
-            readableBinding: "Value",
-            runtimeBinding: "[value]",
-            category: `Column: ${column.name}`,
-            icon: "table",
-          },
-        ]}
-        context={{
-          value: columnValue,
-        }}
-      />
-      <Layout noPadding gap="XS">
-        <Label>Background color</Label>
-        <ColorPicker
-          value={column.background}
-          on:change={e => (column.background = e.detail)}
-          spectrumTheme={$themeStore.theme}
-        />
-      </Layout>
-      <Layout noPadding gap="XS">
-        <Label>Text color</Label>
-        <ColorPicker
-          value={column.color}
-          on:change={e => (column.color = e.detail)}
-          spectrumTheme={$themeStore.theme}
-        />
-      </Layout>
+      <div class="row">
+        <div class="field-section">
+          <Input
+            bind:value={column.width}
+            label="Width (include unit % or px)"
+            placeholder="Auto"
+          />
+        </div>
+        <div class="field-section">
+          <Select
+            label="Alignment"
+            bind:value={column.align}
+            options={["Left", "Center", "Right"]}
+            placeholder="Default"
+          />
+        </div>
+      </div>
+      <div class="row">
+        <div class="field-section">
+          <DrawerBindableInput
+            title="Format Value"
+            label="Format Value"
+            value={column.template}
+            on:change={e => (column.template = e.detail)}
+            placeholder={`{{ Value }}`}
+            bindings={[
+              {
+                readableBinding: "Value",
+                runtimeBinding: "[value]",
+                category: `Column: ${column.name}`,
+                icon: "table",
+              },
+            ]}
+            context={{
+              value: columnValue,
+            }}
+          />
+        </div>
+        <div class="field-section">
+          <DrawerBindableInput
+            title="Default Value"
+            label="Default Value"
+            value={column.defaultValue}
+            on:change={e => (column.defaultValue = e.detail)}
+            bindings={[
+              {
+                readableBinding: "Default Value",
+                runtimeBinding: "[defaultValue]",
+                category: `Column: ${column.name}`,
+                icon: "table",
+              },
+            ]}
+            context={{
+              value: columnValue,
+            }}
+          />
+        </div>
+      </div>
+      <div class="row">
+        <div class="field-section">
+          <Layout noPadding gap="XS" class="color-section">
+            <Label>Background color</Label>
+            <ColorPicker
+              value={column.background}
+              on:change={e => (column.background = e.detail)}
+              spectrumTheme={$themeStore.theme}
+            />
+          </Layout>
+        </div>
+        <div class="field-section">
+          <Layout noPadding gap="XS" class="color-section">
+            <Label>Text color</Label>
+            <ColorPicker
+              value={column.color}
+              on:change={e => (column.color = e.detail)}
+              spectrumTheme={$themeStore.theme}
+            />
+          </Layout>
+        </div>
+      </div>
     </Layout>
   </div>
 </DrawerContent>
@@ -71,7 +106,22 @@
 <style>
   .container {
     width: 100%;
-    max-width: 240px;
+    max-width: 450px;
     margin: 0 auto;
+  }
+
+  .row {
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+  }
+
+  .field-section {
+    flex: 1;
+  }
+
+  .info {
+    font-size: var(--font-size-s);
+    color: var(--color-text-secondary);
   }
 </style>

--- a/packages/builder/src/components/design/settings/controls/ColumnEditor/ColumnEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/ColumnEditor/ColumnEditor.svelte
@@ -47,7 +47,7 @@
 
   const getText = value => {
     if (!value?.length) {
-      return placeholder
+      return placeholder || "All columns"
     }
     let text = `${value.length} column`
     if (value.length !== 1) {

--- a/packages/builder/src/stores/builder/components.ts
+++ b/packages/builder/src/stores/builder/components.ts
@@ -1100,6 +1100,11 @@ export class ComponentStore extends BudiStore<ComponentState> {
       return true
     }
 
+    // Check if the datasource resource actually changed
+    if (current?.type === "table" && update.type === "table") {
+      return current.tableId !== update.tableId || current._id !== update._id
+    }
+
     // Legacy support.
     if (current?.type === "view" && update.type === "view") {
       // Could have the same tableId but the view name is different

--- a/packages/builder/src/stores/builder/components.ts
+++ b/packages/builder/src/stores/builder/components.ts
@@ -1100,11 +1100,6 @@ export class ComponentStore extends BudiStore<ComponentState> {
       return true
     }
 
-    // Check if the datasource resource actually changed
-    if (current?.type === "table" && update.type === "table") {
-      return current.tableId !== update.tableId || current._id !== update._id
-    }
-
     // Legacy support.
     if (current?.type === "view" && update.type === "view") {
       // Could have the same tableId but the view name is different


### PR DESCRIPTION
This PR addresses #16480 

It also adds another optional prop to be collected, defaultValue
This allows the users to set default values for columns to be used by the consuming component when adding rows


This pull request refactors the `CellDrawer` in the column editor to improve usability and layout, adds support for editing default values, and enhances the display logic for column selection. The changes focus on making the column editing experience clearer and more flexible for users.

**Column Editor UI/UX improvements:**

* Refactored the `CellDrawer.svelte` layout to organize controls into rows and sections, making the UI more readable and scalable. Each property (width, alignment, format, default value, background color, text color) now has its own field section. [[1]](diffhunk://#diff-11116c6708d911d0b6dd1049135ee7a6f15116d9ab4a80c4a240e23ce2cd8fdaR22-R43) [[2]](diffhunk://#diff-11116c6708d911d0b6dd1049135ee7a6f15116d9ab4a80c4a240e23ce2cd8fdaL51-R126)
* Added a new input for editing the column's default value, including support for bindings and context.
* Improved the width input label to clarify that a unit (e.g., `%` or `px`) is required.
* Increased the maximum width of the column editor container and added styling for rows and field sections to improve layout and spacing.

**Column selection display logic:**

* Updated the placeholder logic in `ColumnEditor.svelte` so that if no columns are selected, it displays "All columns" by default.

**Component store logic:**

* Added a check in `ComponentStore` to detect changes in table data sources more accurately by comparing `tableId` and `_id`. This ensures updates only trigger when the actual resource changes.



https://github.com/user-attachments/assets/39a45326-11be-432b-b4e1-fe96dc4f8b36


