### PR TITLE
[BUDI-9806] Fix double icon in picker drop down

### DIFF
--- a/packages/bbui/src/Form/Core/Picker.svelte
+++ b/packages/bbui/src/Form/Core/Picker.svelte
@@ -277,23 +277,6 @@
             on:mouseleave={e => onOptionMouseleave(e, option)}
             class:is-disabled={!isOptionEnabled(option)}
           >
-            {#if getOptionIcon(option, idx)}
-              <span class="option-extra icon">
-                {#if useOptionIconImage}
-                  <img
-                    class="icon-dims"
-                    src={getOptionIcon(option, idx)}
-                    alt="icon"
-                  />
-                {:else}
-                  <Icon
-                    size="M"
-                    color="var(--spectrum-global-color-gray-600)"
-                    name={getOptionIcon(option, idx)}
-                  />
-                {/if}
-              </span>
-            {/if}
             {#if (optionIconDescriptor = resolveIcon(getOptionIcon(option, idx)))}
               <span class="option-extra icon">
                 <PickerIcon icon={optionIconDescriptor} {useOptionIconImage} />
@@ -352,10 +335,6 @@
 </Popover>
 
 <style>
-  .icon-dims {
-    height: 15px;
-    width: auto;
-  }
   .spectrum-Picker {
     width: 100%;
     box-shadow: none;


### PR DESCRIPTION
## Description
- ensure picker options render a single icon by routing all icon types through PickerIcon
- removes legacy inline icon span that duplicated the glyph for plain string icons

## Addresses
- https://github.com/Budibase/budibase/issues/17249

## Screenshots
<img width="382" height="511" alt="icon dropdown" src="https://github.com/user-attachments/assets/a2e3bd1b-945b-42e5-b170-f55b96e1d24a" />

## Launchcontrol
Restores single-icon rendering for dropdown list items by removing the redundant icon span.
