### PR TITLE
Refresh tenantId when logging out of multi-tenancy

### DIFF
--- a/packages/builder/src/pages/builder/auth/index.svelte
+++ b/packages/builder/src/pages/builder/auth/index.svelte
@@ -20,6 +20,7 @@
 
   onMount(async () => {
     try {
+      await auth.validateTenantId()
       await admin.init()
       await auth.checkQueryString()
     } catch (error) {

--- a/packages/builder/src/stores/portal/auth.ts
+++ b/packages/builder/src/stores/portal/auth.ts
@@ -65,7 +65,7 @@ class AuthStore extends BudiStore<PortalAuthStore> {
     this.setUser(undefined, true)
   }
 
-  async setOrganisation(tenantId: string = "default") {
+  async setOrganisation(tenantId = "default") {
     const prevId = get(this.store).tenantId
     auth.update(store => {
       store.tenantId = tenantId

--- a/packages/builder/src/stores/portal/auth.ts
+++ b/packages/builder/src/stores/portal/auth.ts
@@ -207,7 +207,7 @@ class AuthStore extends BudiStore<PortalAuthStore> {
     const store = get(this.store)
     const adminStore = get(admin)
     const host = window.location.host
-    if (!adminStore.baseUrl) {
+    if (host.includes("localhost:") || !adminStore.baseUrl) {
       // ignore local dev
       return
     }

--- a/packages/builder/src/stores/portal/auth.ts
+++ b/packages/builder/src/stores/portal/auth.ts
@@ -65,7 +65,7 @@ class AuthStore extends BudiStore<PortalAuthStore> {
     this.setUser(undefined, true)
   }
 
-  async setOrganisation(tenantId: string) {
+  async setOrganisation(tenantId: string = "default") {
     const prevId = get(this.store).tenantId
     auth.update(store => {
       store.tenantId = tenantId
@@ -196,6 +196,56 @@ class AuthStore extends BudiStore<PortalAuthStore> {
   async fetchAPIKey() {
     const info = await API.fetchDeveloperInfo()
     return info?.apiKey
+  }
+
+  /**
+   * Determine the tenantId and set it
+   * This is required for checklist requests on load or logout.
+   * If it can't be determined, "default" is used.
+   */
+  async validateTenantId() {
+    const store = get(this.store)
+    const adminStore = get(admin)
+    const host = window.location.host
+    if (!adminStore.baseUrl) {
+      // ignore local dev
+      return
+    }
+    const mainHost = new URL(adminStore.baseUrl).host
+    let urlTenantId
+    // remove the main host part
+    const hostParts = host.split(mainHost).filter(part => part !== "")
+    // if there is a part left, it has to be the tenant ID subdomain
+    if (hostParts.length === 1) {
+      urlTenantId = hostParts[0].replace(/\./g, "")
+    }
+
+    if (store.user && store.user?.tenantId) {
+      if (!urlTenantId) {
+        // redirect to correct tenantId subdomain
+        if (!window.location.host.includes("localhost")) {
+          let redirectUrl = window.location.href
+          redirectUrl = redirectUrl.replace("://", `://${store.user.tenantId}.`)
+          window.location.href = redirectUrl
+        }
+        return
+      }
+
+      if (urlTenantId && store.user.tenantId !== urlTenantId) {
+        // user should not be here - play it safe and log them out
+        try {
+          await this.logout()
+          await this.setOrganisation()
+        } catch (error) {
+          console.error(
+            `Tenant mis-match - "${urlTenantId}" and "${store.user.tenantId}" - logout`
+          )
+        }
+      }
+    } else {
+      // no user - set the org according to the url
+      await this.setOrganisation(urlTenantId)
+    }
   }
 }
 


### PR DESCRIPTION
## Description

When logging out of a cloud tenant, the login page was not reflecting the tenants custom config changes. The checklist requests were using `default` as the tenant id, because the tenant info had been cleared. Tenant id now resolves again when landing on the tenant login screen.

Related to (https://github.com/Budibase/budibase/pull/17068).
