### PR TITLE
Restrict Svelte 5 plugin uploads for now

### DIFF
--- a/packages/server/src/api/controllers/plugin/index.ts
+++ b/packages/server/src/api/controllers/plugin/index.ts
@@ -96,6 +96,13 @@ export async function create(
       )
     }
 
+    // Block Svelte 5 plugins until we release Svelte 5
+    if (metadata.schema?.metadata?.svelteMajor === 5) {
+      throw new Error(
+        "Svelte 5 plugins are not yet supported in Budibase"
+      )
+    }
+
     let origin
     if (source === PluginSource.GITHUB) {
       const { repo, url: canonical } = sdk.plugins.parseGithubRepo(url)

--- a/packages/server/src/api/controllers/plugin/index.ts
+++ b/packages/server/src/api/controllers/plugin/index.ts
@@ -98,9 +98,7 @@ export async function create(
 
     // Block Svelte 5 plugins until we release Svelte 5
     if (metadata.schema?.metadata?.svelteMajor === 5) {
-      throw new Error(
-        "Svelte 5 plugins are not yet supported in Budibase"
-      )
+      throw new Error("Svelte 5 plugins are not yet supported in Budibase")
     }
 
     let origin

--- a/packages/server/src/sdk/plugins/index.ts
+++ b/packages/server/src/sdk/plugins/index.ts
@@ -132,6 +132,11 @@ export async function processUploaded(plugin: KoaFile, source: PluginSource) {
     throw new Error("Only component plugins are supported outside of self-host")
   }
 
+  // Block Svelte 5 plugins until we release Svelte 5
+  if (metadata.schema?.metadata?.svelteMajor === 5) {
+    throw new Error("Svelte 5 plugins are not yet supported in Budibase")
+  }
+
   const doc = await pro.plugins.storePlugin(metadata, directory, source)
   clientAppSocket?.emit("plugin-update", { name: doc.name, hash: doc.hash })
   return doc


### PR DESCRIPTION
## Description
We don't want to allow Svelte 5 plugins to be uploaded right now, just in case some people use the CLI utility to upgrade. They won't be able to be uploaded until we merge the main Svelte 5 branch. 

`metadata?.svelteMajor ` is a property in the Svelte 5 plugin's `schema.json`. We add it when using the migration utility. It will also be added in the new skeleton: https://github.com/Budibase/budibase-skeleton/pull/4

So we can rely on it existing for all Svelte 5 plugins.  