### PR TITLE
include app scripts in workspace imports

### DIFF
--- a/packages/server/src/api/controllers/workspace.ts
+++ b/packages/server/src/api/controllers/workspace.ts
@@ -447,6 +447,7 @@ async function performWorkspaceCreate(
         "customTheme",
         "icon",
         "snippets",
+        "scripts",
         "creationVersion",
       ]
       keys.forEach(key => {

--- a/packages/server/src/sdk/workspace/workspaces/import.ts
+++ b/packages/server/src/sdk/workspace/workspaces/import.ts
@@ -45,6 +45,7 @@ async function getNewWorkspaceMetadata(
       features: tempMetadata.features,
       icon: tempMetadata.icon,
       navigation: tempMetadata.navigation,
+      scripts: tempMetadata.scripts,
       type: tempMetadata.type,
       version: tempMetadata.version,
     }


### PR DESCRIPTION
## Description
App scripts weren't being included in workspace imports. Now they are.

https://github.com/user-attachments/assets/92032e8a-11bc-4a24-81d0-3a5def96ed6a



## Addresses
#17262

## App Export
[app scripts 6-export-1761873344216.tar.gz](https://github.com/user-attachments/files/23247775/app.scripts.6-export-1761873344216.tar.gz)

## Launchcontrol
include app scripts in workspace imports
