### PR TITLE
17232 fix autoid handling in table documents

### DIFF
--- a/packages/backend-core/src/db/Replication.spec.ts
+++ b/packages/backend-core/src/db/Replication.spec.ts
@@ -124,6 +124,54 @@ describe("Replication", () => {
       expect((opts.filter as Function)(appMetadataDoc, {})).toBe(false)
     })
 
+    it("should skip auto column state docs when replicating to production after creation", () => {
+      const replication = new Replication({
+        source: `${DocumentType.WORKSPACE_DEV}_source`,
+        target: `${DocumentType.WORKSPACE}_target`,
+      })
+
+      const opts = replication.appReplicateOpts({ isCreation: false })
+
+      const autoColumnStateDoc = {
+        _id: `${DocumentType.AUTO_COLUMN_STATE}_tableId`,
+        type: "auto_column_state",
+      }
+
+      expect((opts.filter as Function)(autoColumnStateDoc, {})).toBe(false)
+    })
+
+    it("should include auto column state docs when creating production workspace", () => {
+      const replication = new Replication({
+        source: `${DocumentType.WORKSPACE_DEV}_source`,
+        target: `${DocumentType.WORKSPACE}_target`,
+      })
+
+      const opts = replication.appReplicateOpts({ isCreation: true })
+
+      const autoColumnStateDoc = {
+        _id: `${DocumentType.AUTO_COLUMN_STATE}_tableId`,
+        type: "auto_column_state",
+      }
+
+      expect((opts.filter as Function)(autoColumnStateDoc, {})).toBe(true)
+    })
+
+    it("should include auto column state docs when replicating to dev", () => {
+      const replication = new Replication({
+        source: `${DocumentType.WORKSPACE}_source`,
+        target: `${DocumentType.WORKSPACE_DEV}_target`,
+      })
+
+      const opts = replication.appReplicateOpts({ isCreation: false })
+
+      const autoColumnStateDoc = {
+        _id: `${DocumentType.AUTO_COLUMN_STATE}_tableId`,
+        type: "auto_column_state",
+      }
+
+      expect((opts.filter as Function)(autoColumnStateDoc, {})).toBe(true)
+    })
+
     it("should filter out design documents when replicating to dev", () => {
       const replication = new Replication({
         source: `${DocumentType.WORKSPACE}_source`,

--- a/packages/backend-core/src/db/Replication.ts
+++ b/packages/backend-core/src/db/Replication.ts
@@ -150,6 +150,13 @@ class Replication {
         if (startsWithID(doc._id, USER_METADATA_PREFIX)) {
           return true
         }
+        if (
+          direction === ReplicationDirection.TO_PRODUCTION &&
+          !isCreation &&
+          startsWithID(doc._id, DocumentType.AUTO_COLUMN_STATE)
+        ) {
+          return false
+        }
         if (isData(doc._id)) {
           return (
             !!tableSyncList?.find(id => doc._id.includes(id)) || syncAllTables

--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -26,10 +26,7 @@ import {
   disableAllCrons,
   enableCronOrEmailTrigger,
 } from "../../../automations/utils"
-import {
-  DocumentType,
-  getAutomationParams,
-} from "../../../db/utils"
+import { DocumentType, getAutomationParams } from "../../../db/utils"
 import env from "../../../environment"
 import sdk from "../../../sdk"
 import { builderSocket } from "../../../websockets"
@@ -142,7 +139,6 @@ async function syncStaticFormulasToProduction(prodWorkspaceId: string) {
     }
   })
 }
-
 
 export async function fetchDeployments(
   ctx: UserCtx<void, FetchDeploymentResponse>

--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -15,18 +15,21 @@ import {
   FieldType,
   FetchDeploymentResponse,
   FormulaType,
-  Workspace,
   PublishStatusResponse,
   PublishWorkspaceRequest,
   PublishWorkspaceResponse,
   UserCtx,
+  Workspace,
 } from "@budibase/types"
 import {
   clearMetadata,
   disableAllCrons,
   enableCronOrEmailTrigger,
 } from "../../../automations/utils"
-import { DocumentType, getAutomationParams } from "../../../db/utils"
+import {
+  DocumentType,
+  getAutomationParams,
+} from "../../../db/utils"
 import env from "../../../environment"
 import sdk from "../../../sdk"
 import { builderSocket } from "../../../websockets"
@@ -139,6 +142,7 @@ async function syncStaticFormulasToProduction(prodWorkspaceId: string) {
     }
   })
 }
+
 
 export async function fetchDeployments(
   ctx: UserCtx<void, FetchDeploymentResponse>

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -389,7 +389,15 @@ if (descriptions.length) {
 
             const persistedTable = await config.api.table.get(table._id!)
             const initialRev = persistedTable._rev
-            const initialSchema = persistedTable.schema["Row ID"] as {
+            const initialSchema = JSON.parse(
+              JSON.stringify(persistedTable.schema["Row ID"])
+            ) as {
+              name?: string
+              type?: FieldType
+              subtype?: AutoFieldSubType
+              icon?: string
+              autocolumn?: boolean
+              constraints?: FieldSchema["constraints"]
               lastID?: number
             }
             const initialLastId = initialSchema.lastID ?? 0
@@ -400,10 +408,8 @@ if (descriptions.length) {
             const updatedTable = await config.api.table.get(table._id!)
             expect(updatedTable._rev).toEqual(initialRev)
 
-            const updatedSchema = updatedTable.schema["Row ID"] as {
-              lastID?: number
-            }
-            expect(updatedSchema.lastID ?? 0).toEqual(initialLastId)
+            const updatedSchema = updatedTable.schema["Row ID"]
+            expect(updatedSchema).toEqual(initialSchema)
           })
 
         isInternal &&

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -364,6 +364,49 @@ if (descriptions.length) {
           })
 
         isInternal &&
+          it("does not update the table document when creating rows", async () => {
+            const table = await config.api.table.save(
+              saveTableRequest({
+                schema: {
+                  "Row ID": {
+                    name: "Row ID",
+                    type: FieldType.NUMBER,
+                    subtype: AutoFieldSubType.AUTO_ID,
+                    icon: "ri-magic-line",
+                    autocolumn: true,
+                    constraints: {
+                      type: "number",
+                      presence: true,
+                      numericality: {
+                        greaterThanOrEqualTo: "",
+                        lessThanOrEqualTo: "",
+                      },
+                    },
+                  },
+                },
+              })
+            )
+
+            const persistedTable = await config.api.table.get(table._id!)
+            const initialRev = persistedTable._rev
+            const initialSchema = persistedTable.schema["Row ID"] as {
+              lastID?: number
+            }
+            const initialLastId = initialSchema.lastID ?? 0
+
+            const row = await config.api.row.save(table._id!, {})
+            expect(row["Row ID"]).toEqual(initialLastId + 1)
+
+            const updatedTable = await config.api.table.get(table._id!)
+            expect(updatedTable._rev).toEqual(initialRev)
+
+            const updatedSchema = updatedTable.schema["Row ID"] as {
+              lastID?: number
+            }
+            expect(updatedSchema.lastID ?? 0).toEqual(initialLastId)
+          })
+
+        isInternal &&
           it("doesn't allow creating in user table", async () => {
             const response = await config.api.row.save(
               InternalTable.USER_METADATA,

--- a/packages/server/src/sdk/workspace/deployment/status.ts
+++ b/packages/server/src/sdk/workspace/deployment/status.ts
@@ -88,8 +88,10 @@ export async function status() {
   ) => {
     const id = resource._id!
     const resourcePublishedAt = metadata?.resourcesPublishedAt?.[id]
+    const isPublished = prodIds.has(id) || !!resourcePublishedAt
+
     map[id] = {
-      published: prodIds.has(id),
+      published: isPublished,
       name: resource.name,
       publishedAt: resourcePublishedAt,
       unpublishedChanges:

--- a/packages/server/src/utilities/rowProcessor/autoColumnState.ts
+++ b/packages/server/src/utilities/rowProcessor/autoColumnState.ts
@@ -1,8 +1,8 @@
 import { context } from "@budibase/backend-core"
-import { Document, Row, Table } from "@budibase/types"
+import { Document, DocumentType, Row, Table, SEPARATOR } from "@budibase/types"
 import { getRowParams } from "../../db/utils"
 
-const AUTO_COLUMN_STATE_DOC_PREFIX = "autocolumn:"
+const AUTO_COLUMN_STATE_DOC_PREFIX = `${DocumentType.AUTO_COLUMN_STATE}${SEPARATOR}`
 const MAX_ALLOCATE_ATTEMPTS = 5
 
 interface AutoColumnStateDoc extends Document {

--- a/packages/server/src/utilities/rowProcessor/autoColumnState.ts
+++ b/packages/server/src/utilities/rowProcessor/autoColumnState.ts
@@ -20,11 +20,11 @@ function buildDocId(tableId: string) {
 function getSchemaSeed(table: Table, columnName: string): number {
   const schema = table.schema[columnName] as
     | {
-        lastID?: number
+        lastId?: number
       }
     | undefined
-  if (schema?.lastID != null && !Number.isNaN(schema.lastID)) {
-    return schema.lastID
+  if (schema?.lastId != null && !Number.isNaN(schema.lastId)) {
+    return schema.lastId
   }
   return 0
 }

--- a/packages/server/src/utilities/rowProcessor/autoColumnState.ts
+++ b/packages/server/src/utilities/rowProcessor/autoColumnState.ts
@@ -18,9 +18,11 @@ function buildDocId(tableId: string) {
 }
 
 function getSchemaSeed(table: Table, columnName: string): number {
-  const schema = table.schema[columnName] as {
-    lastID?: number
-  } | undefined
+  const schema = table.schema[columnName] as
+    | {
+        lastID?: number
+      }
+    | undefined
   if (schema?.lastID != null && !Number.isNaN(schema.lastID)) {
     return schema.lastID
   }

--- a/packages/server/src/utilities/rowProcessor/autoColumnState.ts
+++ b/packages/server/src/utilities/rowProcessor/autoColumnState.ts
@@ -53,23 +53,15 @@ async function computeRowMaxes(
       continue
     }
     for (const columnName of columnNames) {
-      const value = doc[columnName]
-      let numericValue: number | undefined
-      if (typeof value === "number") {
-        numericValue = value
-      } else if (typeof value === "string" && value.length > 0) {
-        const parsed = Number(value)
-        if (!Number.isNaN(parsed)) {
-          numericValue = parsed
-        }
+      const currentValue = doc[columnName]
+      if (typeof currentValue !== "number") {
+        continue
       }
 
-      if (
-        numericValue != null &&
-        !Number.isNaN(numericValue) &&
-        numericValue > (maxes[columnName] ?? 0)
-      ) {
-        maxes[columnName] = numericValue
+      const currentMax = maxes[columnName] ?? 0
+      const isNewMaximum = currentValue > currentMax
+      if (isNewMaximum) {
+        maxes[columnName] = currentValue
       }
     }
   }

--- a/packages/server/src/utilities/rowProcessor/autoColumnState.ts
+++ b/packages/server/src/utilities/rowProcessor/autoColumnState.ts
@@ -2,7 +2,7 @@ import { context } from "@budibase/backend-core"
 import { Document, Row, Table } from "@budibase/types"
 import { getRowParams } from "../../db/utils"
 
-const AUTO_COLUMN_STATE_DOC_PREFIX = "_local/autocolumn:"
+const AUTO_COLUMN_STATE_DOC_PREFIX = "autocolumn:"
 const MAX_ALLOCATE_ATTEMPTS = 5
 
 interface AutoColumnStateDoc extends Document {

--- a/packages/server/src/utilities/rowProcessor/autoColumnState.ts
+++ b/packages/server/src/utilities/rowProcessor/autoColumnState.ts
@@ -1,0 +1,159 @@
+import { context } from "@budibase/backend-core"
+import { Document, Row, Table } from "@budibase/types"
+import { getRowParams } from "../../db/utils"
+
+const AUTO_COLUMN_STATE_DOC_PREFIX = "_local/autocolumn:"
+const MAX_ALLOCATE_ATTEMPTS = 5
+
+interface AutoColumnStateDoc extends Document {
+  tableId: string
+  columns: Record<string, number>
+}
+
+const isConflictError = (err: any) =>
+  err?.status === 409 || err?.statusCode === 409
+
+function buildDocId(tableId: string) {
+  return `${AUTO_COLUMN_STATE_DOC_PREFIX}${tableId}`
+}
+
+function getSchemaSeed(table: Table, columnName: string): number {
+  const schema = table.schema[columnName] as {
+    lastID?: number
+  } | undefined
+  if (schema?.lastID != null && !Number.isNaN(schema.lastID)) {
+    return schema.lastID
+  }
+  return 0
+}
+
+async function computeRowMaxes(
+  table: Table,
+  columnNames: string[]
+): Promise<Record<string, number>> {
+  const maxes: Record<string, number> = {}
+  if (!columnNames.length) {
+    return maxes
+  }
+
+  const db = context.getWorkspaceDB()
+  const response = await db.allDocs<Row>(
+    getRowParams(table._id!, null, {
+      include_docs: true,
+    })
+  )
+
+  for (const columnName of columnNames) {
+    maxes[columnName] = 0
+  }
+
+  for (const row of response.rows) {
+    const doc = row.doc
+    if (!doc) {
+      continue
+    }
+    for (const columnName of columnNames) {
+      const value = doc[columnName]
+      let numericValue: number | undefined
+      if (typeof value === "number") {
+        numericValue = value
+      } else if (typeof value === "string" && value.length > 0) {
+        const parsed = Number(value)
+        if (!Number.isNaN(parsed)) {
+          numericValue = parsed
+        }
+      }
+
+      if (
+        numericValue != null &&
+        !Number.isNaN(numericValue) &&
+        numericValue > (maxes[columnName] ?? 0)
+      ) {
+        maxes[columnName] = numericValue
+      }
+    }
+  }
+
+  return maxes
+}
+
+async function initialiseMissingColumns(
+  state: AutoColumnStateDoc,
+  table: Table,
+  columnNames: string[]
+) {
+  const missing = columnNames.filter(
+    columnName => state.columns[columnName] == null
+  )
+  if (!missing.length) {
+    return
+  }
+
+  const rowMaxes = await computeRowMaxes(table, missing)
+
+  for (const columnName of missing) {
+    const schemaSeed = getSchemaSeed(table, columnName)
+    const rowMax = rowMaxes[columnName] ?? 0
+    state.columns[columnName] = Math.max(schemaSeed, rowMax)
+  }
+}
+
+export async function allocateAutoColumnValues(
+  table: Table,
+  columnNames: string[]
+): Promise<Record<string, number>> {
+  if (!columnNames.length) {
+    return {}
+  }
+  if (!table._id) {
+    throw new Error(
+      "Unable to allocate auto column values for table without an _id."
+    )
+  }
+
+  const db = context.getWorkspaceDB()
+  const docId = buildDocId(table._id)
+  const uniqueColumns = [...new Set(columnNames)]
+
+  let attempt = 0
+  while (attempt < MAX_ALLOCATE_ATTEMPTS) {
+    let state =
+      (await db.tryGet<AutoColumnStateDoc>(docId)) ||
+      ({
+        _id: docId,
+        tableId: table._id,
+        columns: {},
+      } as AutoColumnStateDoc)
+
+    await initialiseMissingColumns(state, table, uniqueColumns)
+
+    const updatedState: AutoColumnStateDoc = {
+      ...state,
+      columns: { ...state.columns },
+    }
+    const allocations: Record<string, number> = {}
+
+    for (const columnName of uniqueColumns) {
+      const current = updatedState.columns[columnName] ?? 0
+      const next = current + 1
+      updatedState.columns[columnName] = next
+      allocations[columnName] = next
+    }
+
+    try {
+      const response = await db.put(updatedState)
+      updatedState._rev = response.rev
+      return allocations
+    } catch (err: any) {
+      if (isConflictError(err)) {
+        attempt++
+        continue
+      }
+      throw err
+    }
+  }
+
+  throw new Error(
+    `Unable to allocate auto column values for table ${table._id} after ${MAX_ALLOCATE_ATTEMPTS} attempts`
+  )
+}

--- a/packages/types/src/documents/document.ts
+++ b/packages/types/src/documents/document.ts
@@ -45,6 +45,7 @@ export enum DocumentType {
   AI_CONFIG = "aiconfig",
   WORKSPACE_APP = "workspace_app",
   WORKSPACE_FAVOURITE = "workspace_favourite",
+  AUTO_COLUMN_STATE = "autocolumn_state",
 }
 
 // these are the core documents that make up the data, design


### PR DESCRIPTION
## Description

Fix for #17232 

If the user has an internal table with an autoId column, then adding a row will increment the maximum int id. Similarly removing a row might reduce the max id. Because the autoId state is stored in the same document as the table definition, row operations that increment or / decrement the autoId state will cause a change in the rev of the document. The results in the dev and prod environments not syncing properly (see #17232 for repro steps).

This change moves the state for the autoId state into its own document so that row operations do not result in changes to the schema doc.

