### PR TITLE
Ensure apps are not included multiple times in the group count

### DIFF
--- a/packages/builder/src/settings/pages/people/groups/_components/GroupAppsTableRenderer.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/GroupAppsTableRenderer.svelte
@@ -10,8 +10,8 @@
   const getCount = (row, value) => {
     return sdk.users.hasAppBuilderPermissions(row)
       ? row.builder.apps.length +
-          Object.keys(row.roles || {}).filter(appId =>
-            !row.builder.apps.includes(appId)
+          Object.keys(row.roles || {}).filter(
+            appId => !row.builder.apps.includes(appId)
           ).length
       : Object.keys(value || {}).length
   }

--- a/packages/builder/src/settings/pages/people/groups/_components/GroupAppsTableRenderer.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/GroupAppsTableRenderer.svelte
@@ -11,7 +11,7 @@
     return sdk.users.hasAppBuilderPermissions(row)
       ? row.builder.apps.length +
           Object.keys(row.roles || {}).filter(appId =>
-            row.builder.apps.includes(appId)
+            !row.builder.apps.includes(appId)
           ).length
       : Object.keys(value || {}).length
   }


### PR DESCRIPTION
## Description
The workspace count was including both the `.roles` and `.builder.apps` entries. The meant that if a user owned a workspace and had also been granted permissions via RBAC, the count would be 2 instead of 1. The role based access count will now be ignored if the count already included the same workspace.

## Screenshots
<img width="1247" height="371" alt="Screenshot 2025-11-03 at 17 26 59" src="https://github.com/user-attachments/assets/fa9d8cb1-fdee-4339-bf69-cfd99a123a98" />
