### PR TITLE
chore: fix workflow call for new repo

### DIFF
--- a/.github/workflows/close-featurebranch.yml
+++ b/.github/workflows/close-featurebranch.yml
@@ -23,6 +23,6 @@ jobs:
           PAYLOAD_BRANCH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.BRANCH || github.head_ref }}
           PAYLOAD_PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
-          repository: budibase/budibase-deploys
+          repository: budibase/featurebranches
           event: featurebranch-qa-close
           github_pat: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-featurebranch.yml
+++ b/.github/workflows/deploy-featurebranch.yml
@@ -2,7 +2,7 @@ name: deploy-featurebranch
 
 on:
   pull_request:
-    types: 
+    types:
       - labeled
       - opened
       - synchronize
@@ -24,7 +24,7 @@ jobs:
       PAYLOAD_BRANCH: ${{ github.head_ref }}
       PAYLOAD_PR_NUMBER: ${{ github.event.pull_request.number }}
       PAYLOAD_LICENSE_TYPE: |
-        ${{ 
+        ${{
           contains(github.event.pull_request.labels.*.name, 'feature-branch') && 'free' ||
           contains(github.event.pull_request.labels.*.name, 'feature-branch-pro') && 'pro' ||
           contains(github.event.pull_request.labels.*.name, 'feature-branch-team') && 'team' ||
@@ -36,6 +36,6 @@ jobs:
 
       - uses: passeidireto/trigger-external-workflow-action@main
         with:
-          repository: budibase/budibase-deploys
+          repository: budibase/featurebranches
           event: featurebranch-qa-deploy
           github_pat: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
## Description

We've moved the manifests and pipelines for the preview environments to a separate repo. This updates the workflow calls to reflect that internal change. 
