### PR TITLE
Fixes UI overflow bug on new workspace modal

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/_components/CreateWorkspaceModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/CreateWorkspaceModal.svelte
@@ -231,7 +231,7 @@
   showCancelButton={false}
 >
   {#if currentStep === Step.CONFIG}
-    <div>
+    <div class="modal-content">
       <Input
         autofocus={true}
         bind:value={$values.name}
@@ -302,5 +302,9 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .modal-content {
+    overflow: hidden;
   }
 </style>


### PR DESCRIPTION
## Description
_Describe the problem or feature in addition to a link to the relevant github issues._

## Addresses
- https://github.com/Budibase/budibase/issues/17306

## Steps to test
1. From a premium or enterprise tenant, in the workspace selector, click the plus icon
2. Provide a very long workspace name.

## Screenshots
Before
<img width="928" height="361" alt="image" src="https://github.com/user-attachments/assets/496e0097-17e2-4d89-a745-65df031e4bfc" />

After
<img width="589" height="358" alt="image" src="https://github.com/user-attachments/assets/d4955ac6-206a-482c-8419-ca8c7ae25579" />


## Launchcontrol

Fixes UI overflow in New Workspace modal.
