### PR TITLE
Update custom REST icon

### DIFF
--- a/packages/builder/src/components/backend/DatasourceNavigator/icons/Rest.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/icons/Rest.svelte
@@ -1,39 +1,44 @@
 <script>
   export let width = "100"
   export let height = "100"
+
+  const resolveNumber = value => {
+    if (typeof value === "number") {
+      return value
+    }
+    const parsed = parseFloat(value)
+    return Number.isFinite(parsed) ? parsed : 18
+  }
+
+  $: dimension = Math.min(resolveNumber(width), resolveNumber(height))
+  $: iconStyle = `font-size:${dimension}px;`
 </script>
 
-<svg
-  {width}
-  {height}
-  viewBox="0 0 120 120"
-  fill="none"
-  xmlns="http://www.w3.org/2000/svg"
->
-  <path
-    d="M103.125 20.625H68.25L60.375
-    36.375H16.5V99.375H111V20.625H103.125ZM103.125 36.375H72.375L76.5
-    28.5H103.125V36.375Z"
-    fill="#FFBA58"
-  />
-  <path
-    d="M75 46.875V52.5H60C58.0127 52.5059 56.1085 53.298 54.7033 54.7033C53.298
-    56.1085 52.5059 58.0127 52.5 60V75H46.875C44.3886 75 42.004 75.9877 40.2459
-    77.7459C38.4877 79.504 37.5 81.8886 37.5 84.375C37.5 86.8614 38.4877 89.246
-    40.2459 91.0041C42.004 92.7623 44.3886 93.75 46.875
-    93.75H52.5V108.75C52.5059 110.737 53.298 112.642 54.7033 114.047C56.1085
-    115.452 58.0127 116.244 60 116.25H74.25V110.625C74.25 107.94 75.3167 105.364
-    77.2155 103.466C79.1143 101.567 81.6897 100.5 84.375 100.5C87.0603 100.5
-    89.6357 101.567 91.5345 103.466C93.4333 105.364 94.5 107.94 94.5
-    110.625V116.25H108.75C110.737 116.244 112.642 115.452 114.047
-    114.047C115.452 112.642 116.244 110.737 116.25 108.75V94.5H110.625C107.94
-    94.5 105.364 93.4333 103.466 91.5345C101.567 89.6357 100.5 87.0603 100.5
-    84.375C100.5 81.6897 101.567 79.1143 103.466 77.2155C105.364 75.3167 107.94
-    74.25 110.625 74.25H116.25V60C116.244 58.0127 115.452 56.1085 114.047
-    54.7033C112.642 53.298 110.737 52.5059 108.75 52.5H93.75V46.875C93.75
-    44.3886 92.7623 42.004 91.0041 40.2459C89.246 38.4877 86.8614 37.5 84.375
-    37.5C81.8886 37.5 79.504 38.4877 77.7459 40.2459C75.9877 42.004 75 44.3886
-    75 46.875Z"
-    fill="#E76A00"
-  />
-</svg>
+<span class="rest-icon" style={iconStyle}>
+  <i
+    class="ph ph-regular ph-webhooks-logo rest-icon__layer rest-icon__stroke"
+    aria-hidden="true"
+  ></i>
+</span>
+
+<style>
+  .rest-icon {
+    position: relative;
+    display: inline-flex;
+    width: 1em;
+    height: 1em;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .rest-icon__layer {
+    line-height: 1;
+    color: inherit;
+  }
+
+  .rest-icon__stroke {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+</style>


### PR DESCRIPTION
## Description
Replace the jigsaw/folder icon with the phosphor webhooks-logo icon instead.

## Screenshots
<img width="284" height="140" alt="Screenshot 2025-11-05 at 10 12 20" src="https://github.com/user-attachments/assets/0a86f26f-d372-434c-a78f-45258ff8a544" />

<img width="1026" height="632" alt="Screenshot 2025-11-05 at 10 13 04" src="https://github.com/user-attachments/assets/de9a10fc-6e6a-43ae-9f69-14fdde7a44a4" />


## Launchcontrol
Update custom REST icon
