### PR TITLE
Fix for rest query name

### DIFF
--- a/packages/builder/src/helpers/data/utils.ts
+++ b/packages/builder/src/helpers/data/utils.ts
@@ -142,6 +142,11 @@ export function customQueryText(
     name = name.slice(0, -1)
   }
 
+  // Use the full path if there is no hostname
+  if (!name.includes(".")) {
+    return name
+  }
+
   // Only use path
   const split = name.split("/")
   if (split[1]) {

--- a/packages/builder/src/helpers/tests/dataUtils.test.js
+++ b/packages/builder/src/helpers/tests/dataUtils.test.js
@@ -1,5 +1,10 @@
 import { expect, describe, it } from "vitest"
-import { breakQueryString, buildQueryString } from "../data/utils"
+import {
+  breakQueryString,
+  buildQueryString,
+  customQueryText,
+} from "../data/utils"
+import { IntegrationTypes } from "@/constants/backend"
 
 describe("check query string utils", () => {
   const obj1 = {
@@ -45,5 +50,43 @@ describe("check query string utils", () => {
       values: "a%2Cb%2Cc",
     })
     expect(queryString).toBe("values=a%2Cb%2Cc")
+  })
+
+  describe("customQueryText", () => {
+    it("should remove the protocol", () => {
+      const datasource = { source: IntegrationTypes.REST }
+      const query = { name: "https://www.example.com" }
+
+      const queryName = customQueryText(datasource, query)
+
+      expect(queryName).toEqual("www.example.com")
+    })
+
+    it("should remove a trailing slash", () => {
+      const datasource = { source: IntegrationTypes.REST }
+      const query = { name: "test/" }
+
+      const queryName = customQueryText(datasource, query)
+
+      expect(queryName).toEqual("test")
+    })
+
+    it("should only use the path given a base url", () => {
+      const datasource = { source: IntegrationTypes.REST }
+      const query = { name: "www.example.com/api/health" }
+
+      const queryName = customQueryText(datasource, query)
+
+      expect(queryName).toEqual("/api/health")
+    })
+
+    it("should use the full path if the base is not a hostname", () => {
+      const datasource = { source: IntegrationTypes.REST }
+      const query = { name: "example/api/health" }
+
+      const queryName = customQueryText(datasource, query)
+
+      expect(queryName).toEqual("example/api/health")
+    })
   })
 })


### PR DESCRIPTION
## Description
Minor UI bug fix. The base of the path was being excluded incorrectly as it was always assuming a hostname. Now checking for the hostname, and if it's not a hostname then include the full name in the list item.

Unit tests added. 

## Addresses
- https://github.com/Budibase/budibase/issues/17317

## Screenshots
<img width="529" height="192" alt="exclude hostname" src="https://github.com/user-attachments/assets/83fdfcb7-d071-46a2-be4d-5baf70e0cf27" />

*Exclude the hostname as before*

<img width="529" height="192" alt="include basename" src="https://github.com/user-attachments/assets/d48b59bf-ff14-4a64-ac19-e270accb3c5a" />

*But now if the base is not a hostname, then include it in the list item name*


## Launchcontrol
Minor UI fix for REST query names
