### PR TITLE
feat: handle email cc list

### DIFF
--- a/packages/server/src/automations/email/utils/toOutputFields.ts
+++ b/packages/server/src/automations/email/utils/toOutputFields.ts
@@ -12,8 +12,11 @@ interface BodyLimitResult {
   truncated: boolean
 }
 
-const extractAddresses = (addresses: MessageAddressObject[] = []) =>
-  addresses.map(address => address.address).filter(address => !!address)
+const extractAddresses = (addresses: MessageAddressObject[] = []): string[] =>
+  addresses.reduce<string[]>((acc, { address }) => {
+    if (address) acc.push(address)
+    return acc
+  }, [])
 
 const applyBodyLimit = (body: string | undefined): BodyLimitResult => {
   if (!body) {

--- a/packages/server/src/automations/email/utils/toOutputFields.ts
+++ b/packages/server/src/automations/email/utils/toOutputFields.ts
@@ -1,4 +1,4 @@
-import { FetchMessageObject } from "imapflow"
+import { FetchMessageObject, MessageAddressObject } from "imapflow"
 import { simpleParser } from "mailparser"
 import type { EmailTriggerOutputs } from "@budibase/types"
 import { htmlToText } from "html-to-text"
@@ -11,6 +11,11 @@ interface BodyLimitResult {
   body: string | undefined
   truncated: boolean
 }
+
+const extractAddresses = (addresses?: MessageAddressObject[]) =>
+  (addresses ?? [])
+    .map(address => address.address)
+    .filter((address): address is string => !!address)
 
 const applyBodyLimit = (body: string | undefined): BodyLimitResult => {
   if (!body) {
@@ -56,9 +61,14 @@ export const toOutputFields = async (
 ): Promise<EmailTriggerOutputs> => {
   const text = await getBodyText(message)
   const { body: bodyText, truncated: bodyTextTruncated } = applyBodyLimit(text)
+
+  const toAddresses = extractAddresses(message.envelope?.to)
+  const cc = extractAddresses(message.envelope?.cc)
+  const fromAddresses = extractAddresses(message.envelope?.from)
   return {
-    from: message.envelope?.from?.map(f => f.address).join(", ") || "unknown",
-    to: message.envelope?.to?.map(f => f.address).join(", ") || "unknown",
+    from: fromAddresses.join(", ") || "unknown",
+    to: toAddresses.join(", ") || "unknown",
+    cc,
     subject: message.envelope?.subject,
     sentAt: message.envelope?.date?.toISOString(),
     bodyText,

--- a/packages/server/src/automations/email/utils/toOutputFields.ts
+++ b/packages/server/src/automations/email/utils/toOutputFields.ts
@@ -12,10 +12,8 @@ interface BodyLimitResult {
   truncated: boolean
 }
 
-const extractAddresses = (addresses?: MessageAddressObject[]) =>
-  (addresses ?? [])
-    .map(address => address.address)
-    .filter((address): address is string => !!address)
+const extractAddresses = (addresses: MessageAddressObject[] = []) =>
+  addresses.map(address => address.address).filter(address => !!address)
 
 const applyBodyLimit = (body: string | undefined): BodyLimitResult => {
   if (!body) {

--- a/packages/server/src/automations/tests/triggers/email.spec.ts
+++ b/packages/server/src/automations/tests/triggers/email.spec.ts
@@ -133,6 +133,7 @@ describe("checkMail behaviour", () => {
     const fields = {
       from: "sender@example.com",
       to: "recipient@example.com",
+      cc: [],
       subject: "Hello",
       sentAt: "2024-01-01T00:00:00.000Z",
       bodyText: "Parsed email body",
@@ -182,11 +183,13 @@ describe("checkMail behaviour", () => {
     const firstFields = {
       from: "sender@example.com",
       bodyText: "First body",
+      cc: [],
       bodyTextTruncated: false,
     }
     const secondFields = {
       from: "other@example.com",
       bodyText: "Second body",
+      cc: [],
       bodyTextTruncated: false,
     }
 

--- a/packages/shared-core/src/automations/triggers/email.ts
+++ b/packages/shared-core/src/automations/triggers/email.ts
@@ -26,6 +26,11 @@ export const definition: AutomationTriggerDefinition = {
           type: AutomationIOType.STRING,
           description: "Who received the email",
         },
+        cc: {
+          type: AutomationIOType.ARRAY,
+          subtype: AutomationIOType.STRING,
+          description: "Who was CC'd on the email",
+        },
         subject: {
           type: AutomationIOType.STRING,
           description: "What was the subject of the email",

--- a/packages/types/src/documents/workspace/automation/StepInputsOutputs.ts
+++ b/packages/types/src/documents/workspace/automation/StepInputsOutputs.ts
@@ -433,6 +433,7 @@ export type CronTriggerOutputs = {
 export type EmailTriggerOutputs = {
   from: string
   to: string
+  cc: string[]
   subject?: string
   sentAt?: string
   bodyText?: string


### PR DESCRIPTION
## Description

* adds `cc` list to the email trigger output

<img width="1543" height="651" alt="image" src="https://github.com/user-attachments/assets/50bd24d3-ec55-40a4-9afc-4b513fd082e0" />
