### PR TITLE
Ensure REST datasource statics override bindings

### DIFF
--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -61,7 +61,10 @@
     requestBindings = {}
   let saveId
   let response, schema, enabledHeaders
-  let dynamicVariables = {}, addVariableModal, varBinding, globalDynamicBindings = {}
+  let dynamicVariables = {},
+    addVariableModal,
+    varBinding,
+    globalDynamicBindings = {}
   let restBindings = getRestBindings()
   let nestedSchemaFields = {}
   let saving
@@ -90,7 +93,10 @@
   )
 
   const getBindingContext = objects => {
-    return objects.reduce((acc, current) => ({ ...acc, ...(current || {}) }), {})
+    return objects.reduce(
+      (acc, current) => ({ ...acc, ...(current || {}) }),
+      {}
+    )
   }
 
   $: mergedBindings = [

--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -59,7 +59,7 @@
     requestBindings = {}
   let saveId
   let response, schema, enabledHeaders
-  let dynamicVariables, addVariableModal, varBinding, globalDynamicBindings
+  let dynamicVariables = {}, addVariableModal, varBinding, globalDynamicBindings = {}
   let restBindings = getRestBindings()
   let nestedSchemaFields = {}
   let saving
@@ -84,12 +84,23 @@
     "Datasource Static"
   )
 
+  const getBindingContext = objects => {
+    return objects.reduce((acc, current) => ({ ...acc, ...(current || {}) }), {})
+  }
+
   $: mergedBindings = [
+    ...dataSourceStaticBindings,
     ...restBindings,
     ...customRequestBindings,
     ...globalDynamicRequestBindings,
-    ...dataSourceStaticBindings,
   ]
+
+  $: bindingPreviewContext = getBindingContext([
+    requestBindings,
+    globalDynamicBindings,
+    dynamicVariables,
+    staticVariables,
+  ])
 
   $: datasourceType = datasource?.source
   $: integrationInfo = $integrations[datasourceType]
@@ -378,10 +389,10 @@
     )
 
     const prettyBindings = [
+      ...dataSourceStaticBindings,
       ...restBindings,
       ...customRequestBindings,
       ...dynamicRequestBindings,
-      ...dataSourceStaticBindings,
     ]
 
     //Parse the body here as now all bindings have been updated.
@@ -473,7 +484,7 @@
     }
     // if query doesn't have ID then its new - don't try to copy existing dynamic variables
     if (!queryId) {
-      dynamicVariables = []
+      dynamicVariables = {}
       globalDynamicBindings = getDynamicVariables(datasource)
     } else {
       dynamicVariables = getDynamicVariables(
@@ -599,10 +610,11 @@
               keyPlaceholder="Binding name"
               valuePlaceholder="Default"
               bindings={[
+                ...dataSourceStaticBindings,
                 ...restBindings,
                 ...globalDynamicRequestBindings,
-                ...dataSourceStaticBindings,
               ]}
+              context={bindingPreviewContext}
             />
           </Tab>
           <Tab title="Params">
@@ -612,6 +624,7 @@
                 defaults={breakQs}
                 headings
                 bindings={mergedBindings}
+                context={bindingPreviewContext}
                 on:change={e => {
                   let newQs = {}
                   e.detail.forEach(({ name, value }) => {
@@ -631,6 +644,7 @@
               name="header"
               headings
               bindings={mergedBindings}
+              context={bindingPreviewContext}
             />
           </Tab>
           <Tab title="Body">

--- a/packages/server/src/threads/query.ts
+++ b/packages/server/src/threads/query.ts
@@ -316,14 +316,16 @@ class QueryRunner {
     }
     const staticVars = datasource.config.staticVariables || {}
     const dynamicVars = datasource.config.dynamicVariables || []
-    for (let [key, value] of Object.entries(staticVars)) {
-      const paramValue = parameters[key]
+    for (let [staticBindingKey, staticBindingValue] of Object.entries(
+      staticVars
+    )) {
+      const paramValue = parameters[staticBindingKey]
       const shouldOverride =
         paramValue == null ||
         paramValue === "" ||
-        this.isSelfReferencingBinding(paramValue, key)
+        this.doesStaticBindingMatchLocal(paramValue, staticBindingKey)
       if (shouldOverride) {
-        parameters[key] = value
+        parameters[staticBindingKey] = staticBindingValue
       }
     }
     if (!this.noRecursiveQuery) {
@@ -361,7 +363,7 @@ class QueryRunner {
     return parameters
   }
 
-  isSelfReferencingBinding(value: unknown, name: string) {
+  doesStaticBindingMatchLocal(value: unknown, staticBindingName: string) {
     if (typeof value !== "string") {
       return false
     }
@@ -370,7 +372,7 @@ class QueryRunner {
       return false
     }
     const binding = match[1].replace(/\s+/g, "")
-    const target = name.replace(/\s+/g, "")
+    const target = staticBindingName.replace(/\s+/g, "")
     return binding === target
   }
 }


### PR DESCRIPTION
## Description
- Update the query runner so datasource static values always populate request parameters when bindings are unset or just reference themselves, which fixes REST queries that rely on statics such as hostnames.

## Addresses
- https://github.com/Budibase/budibase/issues/15981

## Screenshots
<img width="1050" height="1054" alt="static binding" src="https://github.com/user-attachments/assets/21a77b6c-fd70-4e47-88af-abc4682cddb8" />

<img width="1050" height="1054" alt="working" src="https://github.com/user-attachments/assets/62c524fd-ecec-4112-936a-ad653389b4b4" />


## Launchcontrol
Ensures REST datasource static variables always override bindings so REST URLs resolve correctly.
