### PR TITLE
[APIs] 6/8 Scaffold APIs workspace routes

### DIFF
--- a/packages/builder/src/helpers/restTemplates.ts
+++ b/packages/builder/src/helpers/restTemplates.ts
@@ -1,0 +1,29 @@
+import type { QueryImportEndpoint } from "@budibase/types"
+
+const normalizeEndpointLabel = (value?: string) =>
+  (value || "").toLowerCase().replace(/[^a-z0-9]/g, "")
+
+export const formatEndpointLabel = (endpoint: QueryImportEndpoint) => {
+  const path = endpoint.path || ""
+  const name = endpoint.name || ""
+
+  if (!path && !name) {
+    return ""
+  }
+  if (!path) {
+    return name
+  }
+  if (!name) {
+    return path
+  }
+
+  const normalizedPath = normalizeEndpointLabel(path)
+  const normalizedName = normalizeEndpointLabel(name)
+  if (normalizedPath && normalizedPath === normalizedName) {
+    return path
+  }
+  if (name !== path) {
+    return `${path} – ${name}`
+  }
+  return path
+}

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/_layout.svelte
@@ -1,0 +1,192 @@
+<script>
+  import { Layout } from "@budibase/bbui"
+  import DatasourceNavigator from "@/components/backend/DatasourceNavigator/DatasourceNavigator.svelte"
+  import Panel from "@/components/design/Panel.svelte"
+  import { isActive, redirect, goto } from "@roxi/routify"
+  import { datasources, builderStore } from "@/stores/builder"
+  import NavHeader from "@/components/common/NavHeader.svelte"
+  import TopBar from "@/components/common/TopBar.svelte"
+  import { getHorizontalResizeActions } from "@/components/common/resizable"
+  import { IntegrationTypes } from "@/constants/backend"
+  import { onMount, onDestroy } from "svelte"
+
+  let searchValue
+  let maxWidth = window.innerWidth / 3
+  let panelWidth = 260
+
+  const loadPanelWidth = () => {
+    const saved = localStorage.getItem("api-panel-width")
+    if (saved) {
+      const width = parseInt(saved, 10)
+      if (width && width > 100 && width < window.innerWidth) {
+        panelWidth = width
+      }
+    }
+  }
+
+  const updateMaxWidth = () => {
+    maxWidth = window.innerWidth / 3
+  }
+
+  let gridDispatch = null
+
+  const sortByDatasourceName = (a, b) =>
+    (a.name || "").localeCompare(b.name || "", undefined, {
+      sensitivity: "base",
+    })
+
+  const [resizable, resizableHandle] = getHorizontalResizeActions(
+    panelWidth,
+    width => {
+      if (width > maxWidth) {
+        const element = document.querySelector(".panel-container")
+        if (element) {
+          element.style.width = `${maxWidth}px`
+          width = maxWidth
+        }
+      }
+
+      if (width) {
+        localStorage.setItem("api-panel-width", width.toString())
+        panelWidth = width
+      }
+    },
+    () => {
+      if (gridDispatch) {
+        gridDispatch("close-edit-column", {})
+      }
+    }
+  )
+
+  onMount(() => {
+    loadPanelWidth()
+    window.addEventListener("resize", updateMaxWidth)
+  })
+
+  onDestroy(() => {
+    window.removeEventListener("resize", updateMaxWidth)
+  })
+
+  $: restDatasources = ($datasources.list || []).filter(
+    datasource => datasource.source === IntegrationTypes.REST
+  )
+  $: hasRestDatasources = restDatasources.length > 0
+
+  $: {
+    if (!hasRestDatasources && !$isActive("./new")) {
+      $redirect("./new")
+    }
+  }
+</script>
+
+<!-- routify:options index=1 -->
+<div class="wrapper" class:resizing-panel={$builderStore.isResizingPanel}>
+  <TopBar icon="webhooks-logo" breadcrumbs={[{ text: "APIs" }]}></TopBar>
+  <div class="data">
+    {#if !$isActive("./new")}
+      <div class="panel-container" style="width: {panelWidth}px;" use:resizable>
+        <Panel borderRight={false} borderBottomHeader={false} resizable={true}>
+          <span class="panel-title-content" slot="panel-title-content">
+            <NavHeader
+              title="APIs"
+              placeholder="Search APIs"
+              bind:value={searchValue}
+              onAdd={() => $goto("./new")}
+            />
+          </span>
+          <Layout paddingX="L" paddingY="none" gap="S">
+            <DatasourceNavigator
+              searchTerm={searchValue}
+              datasourceFilter={datasource =>
+                datasource.source === IntegrationTypes.REST}
+              datasourceSort={sortByDatasourceName}
+              showAppUsers={false}
+              showManageRoles={false}
+            />
+          </Layout>
+        </Panel>
+        <div class="divider">
+          <div
+            class="dividerClickExtender"
+            role="separator"
+            use:resizableHandle
+          />
+        </div>
+      </div>
+    {/if}
+
+    <div class="content">
+      <slot />
+    </div>
+  </div>
+</div>
+
+<style>
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    flex: 1 1 auto;
+  }
+  .data {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: stretch;
+    height: 0;
+  }
+  .panel-container {
+    display: flex;
+    min-width: 262px;
+    width: 260px;
+    max-width: 33.33vw;
+    height: 100%;
+    overflow: visible;
+  }
+  .content {
+    padding: 28px 40px 40px 40px;
+    overflow-y: auto;
+    gap: var(--spacing-l);
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: stretch;
+    flex: 1 1 auto;
+    z-index: 2;
+    position: relative;
+  }
+
+  .panel-title-content {
+    display: contents;
+  }
+
+  .divider {
+    position: relative;
+    height: 100%;
+    width: 2px;
+    background: var(--spectrum-global-color-gray-200);
+    transition: background 130ms ease-out;
+    min-width: 2px;
+    z-index: 1;
+    flex-shrink: 0;
+  }
+  .divider:hover {
+    background: var(--spectrum-global-color-gray-300);
+    cursor: col-resize;
+  }
+  .dividerClickExtender {
+    position: absolute;
+    cursor: col-resize;
+    height: 100%;
+    width: 12px;
+    left: -5px;
+    top: 0;
+  }
+  .wrapper.resizing-panel {
+    user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/datasource/[datasourceId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/datasource/[datasourceId]/_layout.svelte
@@ -1,0 +1,28 @@
+<script>
+  import { syncURLToState } from "@/helpers/urlStateSync"
+  import { builderStore, datasources } from "@/stores/builder"
+  import * as routify from "@roxi/routify"
+  import { params } from "@roxi/routify"
+  import { onDestroy } from "svelte"
+
+  $: datasourceId = $datasources.selectedDatasourceId
+  $: builderStore.selectResource(datasourceId)
+
+  const stopSyncing = syncURLToState({
+    urlParam: "datasourceId",
+    stateKey: "selectedDatasourceId",
+    validate: id => $datasources.list?.some(ds => ds._id === id),
+    update: datasources.select,
+    fallbackUrl: "../",
+    store: datasources,
+    routify,
+  })
+
+  onDestroy(stopSyncing)
+</script>
+
+{#key $params.datasourceId}
+  {#if $datasources.selected}
+    <slot />
+  {/if}
+{/key}

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/datasource/[datasourceId]/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/datasource/[datasourceId]/index.svelte
@@ -1,0 +1,5 @@
+<script>
+  import DatasourcePage from "../../../data/datasource/[datasourceId]/index.svelte"
+</script>
+
+<DatasourcePage />

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/datasource/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/datasource/index.svelte
@@ -1,0 +1,20 @@
+<script>
+  import { datasources } from "@/stores/builder"
+  import { redirect } from "@roxi/routify"
+  import { onMount } from "svelte"
+  import { IntegrationTypes } from "@/constants/backend"
+
+  onMount(async () => {
+    const restDatasources = ($datasources.list || []).filter(
+      datasource => datasource.source === IntegrationTypes.REST
+    )
+
+    if ($datasources.selected?.source === IntegrationTypes.REST) {
+      $redirect(`./${$datasources.selected?._id}`)
+    } else if (restDatasources.length) {
+      $redirect(`./${restDatasources[0]._id}`)
+    } else {
+      $redirect("../new")
+    }
+  })
+</script>

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/index.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { onMount } from "svelte"
+  import { redirect } from "@roxi/routify"
+  import { datasources } from "@/stores/builder"
+  import { IntegrationTypes } from "@/constants/backend"
+
+  onMount(() => {
+    const restDatasources = ($datasources.list || []).filter(
+      datasource => datasource.source === IntegrationTypes.REST
+    )
+
+    if (restDatasources.length) {
+      $redirect(`./datasource/${restDatasources[0]._id}`)
+    } else {
+      $redirect("./new")
+    }
+  })
+</script>

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/new.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/new.svelte
@@ -1,0 +1,472 @@
+<script lang="ts">
+  import CreateExternalDatasourceModal from "../data/_components/CreateExternalDatasourceModal/index.svelte"
+  import DatasourceOption from "../data/_components/DatasourceOption.svelte"
+  import RestTemplateOption from "../data/_components/RestTemplateOption.svelte"
+  import CreationPage from "@/components/common/CreationPage.svelte"
+  import IntegrationIcon from "@/components/backend/DatasourceNavigator/IntegrationIcon.svelte"
+  import QueryVerbBadge from "@/components/common/QueryVerbBadge.svelte"
+  import DescriptionViewer from "@/components/common/DescriptionViewer.svelte"
+  import {
+    Body,
+    Heading,
+    Layout,
+    Modal,
+    ModalContent,
+    notifications,
+    Select,
+    ProgressCircle,
+    keepOpen,
+    ModalCancelFrom,
+  } from "@budibase/bbui"
+  import {
+    sortedIntegrations as integrations,
+    datasources,
+    queries,
+  } from "@/stores/builder"
+  import { restTemplates } from "@/stores/builder/restTemplates"
+  import { configFromIntegration } from "@/stores/selectors"
+  import { customQueryIconColor } from "@/helpers/data/utils"
+  import { formatEndpointLabel } from "@/helpers/restTemplates"
+  import { IntegrationTypes } from "@/constants/backend"
+  import { goto } from "@roxi/routify"
+  import type { RestTemplate, QueryImportEndpoint } from "@budibase/types"
+
+  let externalDatasourceModal: CreateExternalDatasourceModal
+  let externalDatasourceLoading = false
+  let templateVersionModal: Modal
+  let templateEndpointModal: Modal
+  let selectedTemplate: RestTemplate | null = null
+  let templateLoading = false
+  let templateLoadingPhase: "info" | "import" | null = null
+  let pendingTemplate: RestTemplate | null = null
+  let pendingSpec: RestTemplate["specs"][number] | null = null
+  let templateEndpoints: QueryImportEndpoint[] = []
+  let selectedEndpointId: string | undefined = undefined
+  let templateDocsBaseUrl: string | undefined = undefined
+  $: selectedEndpoint = templateEndpoints.find(
+    endpoint => endpoint.id === selectedEndpointId
+  )
+
+  $: restIntegration = ($integrations || []).find(
+    integration => integration.name === IntegrationTypes.REST
+  )
+
+  $: restDatasources = ($datasources.list || []).filter(
+    datasource => datasource.source === IntegrationTypes.REST
+  )
+  $: hasRestDatasources = restDatasources.length > 0
+
+  $: disabled = externalDatasourceLoading
+  $: templateDisabled = disabled || templateLoading
+
+  $: selectedEndpointDescription = selectedEndpoint?.description || ""
+
+  const openRestModal = () => {
+    if (!restIntegration) {
+      return
+    }
+    externalDatasourceModal.show(restIntegration)
+  }
+
+  const buildDatasourceName = (
+    template: RestTemplate,
+    spec: RestTemplate["specs"][number]
+  ) => {
+    if (template.specs.length > 1 && spec.version) {
+      return `${template.name} (${spec.version})`
+    }
+    return template.name
+  }
+
+  const handleTemplateSelection = async (
+    template: RestTemplate,
+    spec: RestTemplate["specs"][number]
+  ) => {
+    if (!restIntegration) {
+      notifications.error("REST API integration is unavailable.")
+      return
+    }
+
+    templateLoading = true
+    templateLoadingPhase = "info"
+    try {
+      const info = await queries.fetchImportInfo({ url: spec.url })
+
+      if (!info.endpoints?.length) {
+        throw new Error("No endpoints found in this template")
+      }
+
+      pendingTemplate = template
+      pendingSpec = spec
+      templateDocsBaseUrl = info.docsUrl
+      templateEndpoints = info.endpoints
+        ?.slice()
+        .sort((a, b) => compareEndpointOrder(a, b))
+      selectedEndpointId = templateEndpoints[0]?.id
+      await templateEndpointModal?.show()
+    } catch (error: any) {
+      notifications.error(
+        `Error importing template - ${error?.message || "Unknown error"}`
+      )
+    } finally {
+      templateLoading = false
+      templateLoadingPhase = null
+    }
+  }
+
+  const getEndpointIcon = (endpoint: QueryImportEndpoint) => {
+    const method = (endpoint.method || "").toUpperCase()
+    if (!method) {
+      return undefined
+    }
+    const verbKey = endpoint.queryVerb || method.toLowerCase()
+    const color = customQueryIconColor(verbKey)
+    return {
+      component: QueryVerbBadge,
+      props: {
+        verb: method,
+        color,
+      },
+    }
+  }
+
+  const verbOrder: Record<string, number> = {
+    GET: 0,
+    POST: 1,
+    PUT: 2,
+    PATCH: 3,
+    DELETE: 4,
+  }
+
+  const compareEndpointOrder = (
+    a: QueryImportEndpoint,
+    b: QueryImportEndpoint
+  ) => {
+    const methodA = (a.method || "").toUpperCase()
+    const methodB = (b.method || "").toUpperCase()
+    const orderA = verbOrder[methodA] ?? 999
+    const orderB = verbOrder[methodB] ?? 999
+    if (orderA !== orderB) {
+      return orderA - orderB
+    }
+    const labelA = formatEndpointLabel(a)
+    const labelB = formatEndpointLabel(b)
+    return labelA.localeCompare(labelB)
+  }
+
+  const importTemplate = async () => {
+    if (
+      !pendingTemplate ||
+      !pendingSpec ||
+      !selectedEndpointId ||
+      !restIntegration
+    ) {
+      notifications.error("Select an endpoint to import")
+      return keepOpen
+    }
+
+    templateLoading = true
+    templateLoadingPhase = "import"
+    try {
+      const config = {
+        ...configFromIntegration(restIntegration),
+        url: pendingSpec.url,
+      }
+
+      const datasource = await datasources.create({
+        integration: restIntegration,
+        config,
+        name: buildDatasourceName(pendingTemplate, pendingSpec),
+        uiMetadata: { iconUrl: pendingTemplate.icon },
+        isRestTemplate: true,
+      })
+
+      if (!datasource?._id) {
+        throw new Error("Datasource identifier missing")
+      }
+
+      await queries.importQueries({
+        url: pendingSpec.url,
+        datasource,
+        datasourceId: datasource._id,
+        selectedEndpointId,
+      })
+
+      await Promise.all([datasources.fetch(), queries.fetch()])
+
+      notifications.success(`${pendingTemplate.name} imported successfully`)
+      await templateEndpointModal?.hide()
+      $goto(`./datasource/${datasource._id}`)
+    } catch (error: any) {
+      notifications.error(
+        `Error importing template - ${error?.message || "Unknown error"}`
+      )
+      return keepOpen
+    } finally {
+      templateLoading = false
+      templateLoadingPhase = null
+    }
+  }
+
+  const onSelectEndpoint = (event: CustomEvent<string>) => {
+    selectedEndpointId = event.detail
+  }
+
+  const resetEndpointSelection = () => {
+    pendingTemplate = null
+    pendingSpec = null
+    templateEndpoints = []
+    selectedEndpointId = undefined
+    templateDocsBaseUrl = undefined
+  }
+
+  const cancelEndpointSelection = () => {
+    resetEndpointSelection()
+  }
+
+  const handleTemplateCancel = (event: CustomEvent<ModalCancelFrom>) => {
+    if (event.detail === ModalCancelFrom.OUTSIDE_CLICK) {
+      // Prevent outside clicks from closing the modal
+      queryMicrotask(() => templateEndpointModal?.show())
+      return
+    }
+    cancelEndpointSelection()
+  }
+
+  const queryMicrotask = (fn: () => void) => {
+    Promise.resolve().then(fn)
+  }
+
+  const selectTemplate = (template: RestTemplate) => {
+    if (!template.specs.length) {
+      notifications.error("Template has no specifications")
+      return
+    }
+
+    if (template.specs.length === 1) {
+      handleTemplateSelection(template, template.specs[0])
+      return
+    }
+
+    selectedTemplate = template
+    templateVersionModal?.show()
+  }
+
+  const importTemplateVersion = async (
+    template: RestTemplate,
+    spec: RestTemplate["specs"][number]
+  ) => {
+    templateVersionModal?.hide()
+    await handleTemplateSelection(template, spec)
+  }
+
+  const close = () => {
+    if (restDatasources.length) {
+      $goto(`./datasource/${restDatasources[0]._id}`)
+    } else {
+      $goto("../")
+    }
+  }
+</script>
+
+<CreateExternalDatasourceModal
+  bind:loading={externalDatasourceLoading}
+  bind:this={externalDatasourceModal}
+/>
+
+<CreationPage
+  showClose={hasRestDatasources}
+  onClose={close}
+  heading="Add new API"
+>
+  {#if restIntegration}
+    <div class="subHeading">
+      <Body>Connect to an external API</Body>
+    </div>
+    <div class="options bb-options">
+      <DatasourceOption
+        on:click={openRestModal}
+        title="Custom REST API"
+        disabled={templateDisabled}
+      >
+        <IntegrationIcon
+          integrationType={restIntegration.name}
+          schema={restIntegration}
+          size="32"
+        />
+      </DatasourceOption>
+    </div>
+    <div class="subHeading">
+      <Body>Or choose a template</Body>
+    </div>
+    <div class="options templateOptions">
+      {#each $restTemplates.templates as template (template.name)}
+        <RestTemplateOption
+          on:click={() => selectTemplate(template)}
+          {template}
+          disabled={templateDisabled}
+        />
+      {/each}
+    </div>
+  {:else}
+    <p class="empty-state">REST API integration is unavailable.</p>
+  {/if}
+</CreationPage>
+
+<Modal
+  bind:this={templateVersionModal}
+  on:hide={() => (selectedTemplate = null)}
+>
+  {#if selectedTemplate}
+    <Layout noPadding gap="M">
+      <div class="templateModalHeader">
+        <Heading size="S">{selectedTemplate.name}</Heading>
+        <Body size="XS">Select a version to import</Body>
+      </div>
+      <div class="versionOptions">
+        {#each selectedTemplate.specs as spec (spec.version)}
+          <button
+            class="versionOption"
+            on:click={() =>
+              selectedTemplate && importTemplateVersion(selectedTemplate, spec)}
+            disabled={templateLoading}
+          >
+            <Body size="S">{spec.version}</Body>
+          </button>
+        {/each}
+      </div>
+    </Layout>
+  {/if}
+</Modal>
+
+<Modal
+  bind:this={templateEndpointModal}
+  on:hide={resetEndpointSelection}
+  on:cancel={handleTemplateCancel}
+>
+  <ModalContent
+    size="L"
+    confirmText="Import"
+    cancelText="Cancel"
+    onConfirm={importTemplate}
+    onCancel={cancelEndpointSelection}
+    disabled={!selectedEndpointId || templateLoading}
+  >
+    <Layout noPadding gap="M">
+      <div class="endpoint-heading">
+        <IntegrationIcon
+          iconUrl={pendingTemplate?.icon}
+          integrationType={restIntegration?.name || IntegrationTypes.REST}
+          schema={restIntegration}
+          size="32"
+        />
+      </div>
+      <Heading size="S">Select action</Heading>
+      <Body size="XS">
+        Choose the action you want to import from {pendingTemplate?.name}.
+      </Body>
+      {#if templateLoading && templateLoadingPhase === "info"}
+        <div class="endpoint-loading">
+          <ProgressCircle size="S" />
+          <Body size="XS">Loading actions…</Body>
+        </div>
+      {:else if templateLoading && templateLoadingPhase === "import"}
+        <div class="endpoint-loading">
+          <ProgressCircle size="S" />
+          <Body size="XS">Importing selected action…</Body>
+        </div>
+      {:else if templateEndpoints.length > 0}
+        <Select
+          label="Action"
+          value={selectedEndpointId}
+          options={templateEndpoints}
+          getOptionValue={endpoint => endpoint.id}
+          getOptionLabel={formatEndpointLabel}
+          getOptionIcon={getEndpointIcon}
+          autocomplete={true}
+          placeholder="Select an action"
+          on:change={onSelectEndpoint}
+        />
+        <DescriptionViewer
+          description={selectedEndpointDescription}
+          baseUrl={templateDocsBaseUrl}
+        />
+      {:else}
+        <Body size="XS">No actions available for this template.</Body>
+      {/if}
+    </Layout>
+  </ModalContent>
+</Modal>
+
+<style>
+  .subHeading {
+    display: flex;
+    align-items: center;
+    margin-top: 12px;
+    margin-bottom: 24px;
+    justify-content: center;
+    gap: 8px;
+  }
+  .subHeading :global(p) {
+    color: var(--spectrum-global-color-gray-600) !important;
+  }
+  .options {
+    width: 100%;
+    display: grid;
+    column-gap: 24px;
+    row-gap: 24px;
+    grid-template-columns: repeat(auto-fit, 235px);
+    justify-content: center;
+    margin-bottom: 48px;
+    max-width: 1050px;
+  }
+  .bb-options {
+    max-width: calc(3 * 235px + 2 * 24px);
+  }
+  .templateOptions {
+    margin-bottom: 24px;
+  }
+  .templateModalHeader {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .versionOptions {
+    display: grid;
+    gap: 12px;
+  }
+  .versionOption {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border: 1px solid var(--grey-4);
+    border-radius: 4px;
+    background: var(--background);
+    cursor: pointer;
+    transition: background 130ms ease-out;
+  }
+  .versionOption:hover {
+    background: var(--background-alt);
+  }
+  .versionOption:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .empty-state {
+    text-align: center;
+    color: var(--spectrum-global-color-gray-600);
+  }
+
+  .endpoint-loading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .endpoint-heading {
+    display: flex;
+    justify-content: flex-start;
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/query/[queryId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/query/[queryId]/_layout.svelte
@@ -1,0 +1,25 @@
+<script>
+  import { queries, builderStore } from "@/stores/builder"
+  import { syncURLToState } from "@/helpers/urlStateSync"
+  import * as routify from "@roxi/routify"
+  import { onDestroy } from "svelte"
+
+  $: queryId = $queries.selectedQueryId
+  $: builderStore.selectResource(queryId)
+
+  const stopSyncing = syncURLToState({
+    urlParam: "queryId",
+    stateKey: "selectedQueryId",
+    validate: id => id === "new" || $queries.list?.some(q => q._id === id),
+    update: queries.select,
+    fallbackUrl: "../",
+    store: queries,
+    routify,
+  })
+
+  onDestroy(stopSyncing)
+</script>
+
+{#key $queries.selectedQueryId}
+  <slot />
+{/key}

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/query/[queryId]/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/query/[queryId]/index.svelte
@@ -1,0 +1,20 @@
+<script>
+  import { queries, datasources } from "@/stores/builder"
+  import RestQueryViewer from "@/components/integration/RestQueryViewer.svelte"
+  import { IntegrationTypes } from "@/constants/backend"
+  import { goto } from "@roxi/routify"
+
+  $: query = $queries.selected
+  $: datasource = $datasources.list.find(ds => ds._id === query?.datasourceId)
+  $: isRestQuery = datasource?.source === IntegrationTypes.REST
+
+  $: {
+    if (query && !isRestQuery) {
+      $goto(`../../data/query/${query._id}`)
+    }
+  }
+</script>
+
+{#if query && isRestQuery}
+  <RestQueryViewer queryId={$queries.selectedQueryId} />
+{/if}

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/query/new/[datasourceId]/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/query/new/[datasourceId]/index.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { params, redirect } from "@roxi/routify"
+  import RestQueryViewer from "@/components/integration/RestQueryViewer.svelte"
+  import { IntegrationTypes } from "@/constants/backend"
+  import { datasources } from "@/stores/builder"
+
+  $: datasource = $datasources.list.find(ds => ds._id === $params.datasourceId)
+  $: {
+    if (!datasource) {
+      $redirect("../../../")
+    } else if (datasource.source !== IntegrationTypes.REST) {
+      $redirect(`../../../data/query/new/${$params.datasourceId}`)
+    }
+  }
+</script>
+
+{#if datasource?.source === IntegrationTypes.REST}
+  <RestQueryViewer />
+{/if}

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Queries/RestTemplateImportModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Queries/RestTemplateImportModal.svelte
@@ -1,0 +1,334 @@
+<script lang="ts">
+  import { goto } from "@roxi/routify"
+  import {
+    keepOpen,
+    ModalContent,
+    notifications,
+    Body,
+    Layout,
+    Heading,
+    Select,
+    InlineAlert,
+    ProgressCircle,
+  } from "@budibase/bbui"
+  import {
+    datasources,
+    queries,
+    sortedIntegrations as integrations,
+  } from "@/stores/builder"
+  import { restTemplates } from "@/stores/builder/restTemplates"
+  import IntegrationIcon from "@/components/backend/DatasourceNavigator/IntegrationIcon.svelte"
+  import QueryVerbBadge from "@/components/common/QueryVerbBadge.svelte"
+  import DescriptionViewer from "@/components/common/DescriptionViewer.svelte"
+  import { customQueryIconColor } from "@/helpers/data/utils"
+  import { formatEndpointLabel } from "@/helpers/restTemplates"
+  import { IntegrationTypes } from "@/constants/backend"
+  import type {
+    Datasource,
+    ImportRestQueryRequest,
+    QueryImportEndpoint,
+    RestConfig,
+    RestTemplate,
+  } from "@budibase/types"
+
+  export let navigateDatasource = false
+  export let datasourceId: string | undefined = undefined
+  export let createDatasource = false
+  export let onCancel: (() => void) | undefined = undefined
+
+  let datasource: Datasource
+  $: datasource = $datasources.selected as Datasource
+  $: restTemplateList = $restTemplates.templates
+  let selectedEndpoint: QueryImportEndpoint | undefined
+  $: restIntegration = ($integrations || []).find(
+    integration => integration.name === datasource?.source
+  )
+  $: datasourceTemplateUrl = getTemplateSpecUrl(datasource)
+  $: template = getMatchingTemplate(
+    datasource,
+    restTemplateList,
+    datasourceTemplateUrl
+  )
+  $: resolvedTemplateSpecUrl = template
+    ? template.specs?.find(spec => spec.url === datasourceTemplateUrl)?.url ||
+      template.specs?.[0]?.url
+    : undefined
+  $: templateName = template?.name
+  $: templateIcon = template?.icon
+  $: isTemplateDatasource = Boolean(datasource?.isRestTemplate && template)
+  $: templateEndpointDescription = selectedEndpoint?.description || ""
+  let endpointOptions: QueryImportEndpoint[] = []
+  let selectedEndpointId: string | undefined = undefined
+  let endpointsLoading = false
+  let endpointsError: string | null = null
+  let endpointsSourceUrl: string | undefined
+  let loadRequestId = 0
+  $: confirmDisabled = !selectedEndpointId || endpointsLoading
+  let currentTemplateUrl: string | undefined
+  let templateDocsBaseUrl: string | undefined
+
+  const getTemplateSpecUrl = (source: Datasource | undefined) => {
+    if (!source?.isRestTemplate) {
+      return undefined
+    }
+    const config = (source.config || {}) as Partial<RestConfig>
+    return typeof config.url === "string" ? config.url : undefined
+  }
+
+  const getMatchingTemplate = (
+    source: Datasource | undefined,
+    templates: RestTemplate[],
+    specUrl: string | undefined
+  ) => {
+    if (!source?.isRestTemplate) {
+      return undefined
+    }
+
+    let match = specUrl
+      ? templates.find(template =>
+          template.specs?.some(spec => spec.url === specUrl)
+        )
+      : undefined
+
+    if (!match && source.uiMetadata?.iconUrl) {
+      match = templates.find(
+        template => template.icon === source.uiMetadata?.iconUrl
+      )
+    }
+
+    if (!match && source.name) {
+      match = templates.find(template => template.name === source.name)
+    }
+
+    return match
+  }
+
+  const resetEndpoints = () => {
+    loadRequestId += 1
+    endpointOptions = []
+    selectedEndpointId = undefined
+    endpointsError = null
+    endpointsLoading = false
+    endpointsSourceUrl = undefined
+    templateDocsBaseUrl = undefined
+  }
+
+  const loadTemplateEndpoints = async (specUrl: string) => {
+    resetEndpoints()
+    const requestId = ++loadRequestId
+    endpointsLoading = true
+    endpointsError = null
+
+    try {
+      const info = await queries.fetchImportInfo({ url: specUrl })
+      if (requestId !== loadRequestId) {
+        return
+      }
+      endpointsSourceUrl = specUrl
+      templateDocsBaseUrl = info.docsUrl
+      endpointOptions = (info.endpoints || [])
+        .slice()
+        .sort((a, b) => compareEndpointOrder(a, b))
+      selectedEndpointId = endpointOptions[0]?.id
+    } catch (error: any) {
+      if (requestId !== loadRequestId) {
+        return
+      }
+      endpointsError = error?.message || "Failed to load endpoints"
+      endpointOptions = []
+      selectedEndpointId = undefined
+      endpointsSourceUrl = undefined
+    } finally {
+      if (requestId === loadRequestId) {
+        endpointsLoading = false
+      }
+    }
+  }
+
+  $: if (isTemplateDatasource) {
+    const specUrl = resolvedTemplateSpecUrl
+    if (specUrl && specUrl !== currentTemplateUrl) {
+      currentTemplateUrl = specUrl
+      loadTemplateEndpoints(specUrl)
+    }
+  } else if (currentTemplateUrl) {
+    currentTemplateUrl = undefined
+  }
+
+  const getEndpointId = (endpoint: QueryImportEndpoint) => endpoint.id
+
+  const getEndpointIcon = (endpoint: QueryImportEndpoint) => {
+    const method = (endpoint.method || "").toUpperCase()
+    if (!method) {
+      return undefined
+    }
+    const verbKey = endpoint.queryVerb || method.toLowerCase()
+    return {
+      component: QueryVerbBadge,
+      props: {
+        verb: method,
+        color: customQueryIconColor(verbKey),
+      },
+    }
+  }
+
+  const verbOrder: Record<string, number> = {
+    GET: 0,
+    POST: 1,
+    PUT: 2,
+    PATCH: 3,
+    DELETE: 4,
+  }
+
+  const compareEndpointOrder = (
+    a: QueryImportEndpoint,
+    b: QueryImportEndpoint
+  ) => {
+    const methodA = (a.method || "").toUpperCase()
+    const methodB = (b.method || "").toUpperCase()
+    const orderA = verbOrder[methodA] ?? 999
+    const orderB = verbOrder[methodB] ?? 999
+    if (orderA !== orderB) {
+      return orderA - orderB
+    }
+    const labelA = formatEndpointLabel(a)
+    const labelB = formatEndpointLabel(b)
+    return labelA.localeCompare(labelB)
+  }
+
+  const onSelectEndpoint = (event: CustomEvent<string | undefined>) => {
+    selectedEndpointId = event.detail
+  }
+
+  $: selectedEndpoint = endpointOptions.find(
+    endpoint => endpoint.id === selectedEndpointId
+  )
+
+  async function importQueries() {
+    try {
+      if (!selectedEndpointId) {
+        notifications.error("Select an endpoint to import")
+        return keepOpen
+      }
+
+      if (!endpointsSourceUrl) {
+        notifications.error("Import data is missing")
+        return keepOpen
+      }
+
+      if (!datasourceId && !createDatasource) {
+        throw new Error("No datasource id")
+      }
+
+      const body: ImportRestQueryRequest = {
+        url: endpointsSourceUrl,
+        datasourceId,
+        datasource,
+        selectedEndpointId,
+      }
+      const importResult = await queries.importQueries(body)
+      if (!datasourceId) {
+        datasourceId = importResult.datasourceId
+      }
+
+      // reload
+      await datasources.fetch()
+      await queries.fetch()
+
+      if (navigateDatasource) {
+        $goto(`./datasource/${datasourceId}`)
+      }
+
+      notifications.success("Imported successfully")
+    } catch (error: any) {
+      notifications.error(`Error importing queries - ${error.message}`)
+
+      return keepOpen
+    }
+  }
+</script>
+
+<ModalContent
+  onConfirm={() => importQueries()}
+  {onCancel}
+  confirmText={"Import"}
+  cancelText={"Cancel"}
+  size="L"
+  disabled={confirmDisabled}
+>
+  <Layout noPadding>
+    {#if isTemplateDatasource}
+      <div class="template-modal">
+        <div class="endpoint-heading">
+          <IntegrationIcon
+            iconUrl={templateIcon || datasource?.uiMetadata?.iconUrl}
+            integrationType={datasource?.source || IntegrationTypes.REST}
+            schema={restIntegration}
+            size="32"
+          />
+        </div>
+        <Heading size="S">Select action</Heading>
+        <Body size="XS">
+          Choose the action you want to import from
+          {templateName || datasource?.name || "this template"}.
+        </Body>
+        {#if endpointsLoading}
+          <div class="endpoint-loading">
+            <ProgressCircle size="S" />
+            <Body size="XS">Loading actions…</Body>
+          </div>
+        {:else if endpointsError}
+          <InlineAlert
+            type="error"
+            header="Unable to load actions"
+            message={endpointsError}
+          />
+        {:else if endpointOptions.length > 0}
+          <Select
+            label="Action"
+            value={selectedEndpointId}
+            options={endpointOptions}
+            getOptionValue={getEndpointId}
+            getOptionLabel={formatEndpointLabel}
+            getOptionIcon={getEndpointIcon}
+            placeholder="Select an action"
+            autocomplete={true}
+            on:change={onSelectEndpoint}
+          />
+          <DescriptionViewer
+            description={templateEndpointDescription}
+            baseUrl={templateDocsBaseUrl}
+          />
+        {:else}
+          <Body size="XS">No actions were found for this template.</Body>
+        {/if}
+      </div>
+    {:else}
+      <div class="template-modal">
+        <Heading size="S">Template unavailable</Heading>
+        <Body size="XS">
+          We couldn't find a template configuration for this datasource. Close
+          the modal and try importing a custom collection instead.
+        </Body>
+      </div>
+    {/if}
+  </Layout>
+</ModalContent>
+
+<style>
+  .template-modal {
+    display: grid;
+    gap: 24px;
+  }
+
+  .endpoint-loading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .endpoint-heading {
+    display: flex;
+    justify-content: flex-start;
+  }
+</style>

--- a/packages/builder/src/stores/builder/datasources.ts
+++ b/packages/builder/src/stores/builder/datasources.ts
@@ -196,9 +196,15 @@ export class DatasourceStore extends DerivedBudiStore<
   async create({
     integration,
     config,
+    name,
+    uiMetadata,
+    isRestTemplate,
   }: {
     integration: UIIntegration
     config: Record<string, any>
+    name?: string
+    uiMetadata?: Datasource["uiMetadata"]
+    isRestTemplate?: boolean
   }) {
     const count = this.sourceCount(integration.name)
     const nameModifier = count === 0 ? "" : ` ${count + 1}`
@@ -207,9 +213,11 @@ export class DatasourceStore extends DerivedBudiStore<
       type: "datasource",
       source: integration.name as SourceName,
       config,
-      name: `${integration.friendlyName}${nameModifier}`,
+      name: name || `${integration.friendlyName}${nameModifier}`,
       plus: integration.plus && integration.name !== SourceName.REST,
       isSQL: integration.isSQL,
+      ...(uiMetadata && { uiMetadata }),
+      ...(isRestTemplate && { isRestTemplate: true }),
     }
 
     const { valid, error } = await this.checkDatasourceValidity(

--- a/packages/builder/src/stores/builder/queries.ts
+++ b/packages/builder/src/stores/builder/queries.ts
@@ -10,6 +10,8 @@ import {
   PreviewQueryResponse,
   SaveQueryRequest,
   ImportRestQueryRequest,
+  ImportRestQueryInfoRequest,
+  ImportRestQueryInfoResponse,
   QuerySchema,
 } from "@budibase/types"
 
@@ -101,6 +103,12 @@ export class QueryStore extends DerivedBudiStore<
 
   async importQueries(data: ImportRestQueryRequest) {
     return await API.importQueries(data)
+  }
+
+  async fetchImportInfo(
+    data: ImportRestQueryInfoRequest
+  ): Promise<ImportRestQueryInfoResponse> {
+    return await API.getImportInfo(data)
   }
 
   select(id: string | null) {

--- a/packages/frontend-core/src/api/queries.ts
+++ b/packages/frontend-core/src/api/queries.ts
@@ -6,6 +6,8 @@ import {
   FindQueryResponse,
   ImportRestQueryRequest,
   ImportRestQueryResponse,
+  ImportRestQueryInfoRequest,
+  ImportRestQueryInfoResponse,
   PreviewQueryRequest,
   PreviewQueryResponse,
   SaveQueryRequest,
@@ -26,6 +28,9 @@ export interface QueryEndpoints {
   importQueries: (
     data: ImportRestQueryRequest
   ) => Promise<ImportRestQueryResponse>
+  getImportInfo: (
+    data: ImportRestQueryInfoRequest
+  ) => Promise<ImportRestQueryInfoResponse>
 }
 
 export const buildQueryEndpoints = (API: BaseAPIClient): QueryEndpoints => ({
@@ -93,6 +98,13 @@ export const buildQueryEndpoints = (API: BaseAPIClient): QueryEndpoints => ({
   importQueries: async data => {
     return await API.post({
       url: "/api/queries/import",
+      body: data,
+    })
+  },
+
+  getImportInfo: async data => {
+    return await API.post({
+      url: "/api/queries/import/info",
       body: data,
     })
   },

--- a/packages/server/src/api/controllers/public/queries.ts
+++ b/packages/server/src/api/controllers/public/queries.ts
@@ -4,7 +4,7 @@ import { UserCtx } from "@budibase/types"
 import { Next } from "koa"
 
 export async function search(ctx: UserCtx, next: Next) {
-  await queryController.fetch(ctx)
+  await queryController.fetchQueries(ctx)
   const { name } = ctx.request.body
   ctx.body = stringSearch(ctx.body, name)
   await next()

--- a/packages/server/src/api/controllers/query/import/index.ts
+++ b/packages/server/src/api/controllers/query/import/index.ts
@@ -36,9 +36,21 @@ export class RestImporter {
     return this.source.getInfo()
   }
 
-  importQueries = async (datasourceId: string): Promise<ImportResult> => {
+  importQueries = async (
+    datasourceId: string,
+    selectedEndpointId?: string
+  ): Promise<ImportResult> => {
+    const filterIds = selectedEndpointId
+      ? new Set<string>([selectedEndpointId])
+      : undefined
     // construct the queries
-    let queries = await this.source.getQueries(datasourceId)
+    let queries = await this.source.getQueries(datasourceId, {
+      filterIds,
+    })
+
+    if (filterIds && queries.length === 0) {
+      throw new Error("Selected endpoint could not be imported")
+    }
 
     // validate queries
     const errorQueries: Query[] = []

--- a/packages/server/src/api/controllers/query/import/sources/utils/requestBody.ts
+++ b/packages/server/src/api/controllers/query/import/sources/utils/requestBody.ts
@@ -1,0 +1,733 @@
+import type { OpenAPIV2, OpenAPIV3 } from "openapi-types"
+
+type ReferenceObject = OpenAPIV3.ReferenceObject | OpenAPIV2.ReferenceObject
+
+type SchemaObject =
+  | (OpenAPIV3.SchemaObject & SchemaAugmentations)
+  | (OpenAPIV2.SchemaObject & SchemaAugmentations)
+
+interface SchemaAugmentations {
+  properties?: Record<string, SchemaObject | ReferenceObject>
+  items?: SchemaItems
+  allOf?: Array<SchemaObject | ReferenceObject>
+  oneOf?: Array<SchemaObject | ReferenceObject>
+  anyOf?: Array<SchemaObject | ReferenceObject>
+}
+
+type SchemaItems =
+  | SchemaObject
+  | ReferenceObject
+  | Array<SchemaObject | ReferenceObject>
+
+type BindingPrimitiveType = "string" | "integer" | "number" | "boolean"
+
+interface BindingPlaceholder {
+  toJSON: () => string
+}
+
+export interface GeneratedRequestBody {
+  body: unknown
+  bindings: Record<string, string>
+}
+
+export type FormDataParameter = OpenAPIV2.ParameterObject & {
+  in: "formData"
+  name: string
+}
+
+const MAX_DEPTH = 5
+export const BINDING_TOKEN_PREFIX = "__BUDIBASE_BINDING__"
+const BINDING_TOKEN_REGEX = new RegExp(
+  `"${BINDING_TOKEN_PREFIX}(string|integer|number|boolean)__([A-Za-z0-9_]+)__"`,
+  "g"
+)
+
+const BINDING_VALUE_REGEX = new RegExp(
+  `${BINDING_TOKEN_PREFIX}(string|integer|number|boolean)__([A-Za-z0-9_]+)__`
+)
+
+const sanitizeSegment = (segment: string): string => {
+  return segment.replace(/[^A-Za-z0-9_]/g, "_")
+}
+
+const isReferenceObject = (value: unknown): value is ReferenceObject => {
+  if (!value || typeof value !== "object") {
+    return false
+  }
+  return "$ref" in (value as Record<string, unknown>)
+}
+
+const toSchemaObject = (
+  value: SchemaObject | ReferenceObject | undefined
+): SchemaObject | undefined => {
+  if (!value || isReferenceObject(value)) {
+    return undefined
+  }
+  return value
+}
+
+const buildBindingName = (path: string[]): string => {
+  const sanitized = path
+    .slice(1)
+    .map(segment => sanitizeSegment(segment))
+    .filter(segment => segment && segment !== "item")
+
+  if (sanitized.length === 0) {
+    const last = path[path.length - 1] ?? "value"
+    sanitized.push(sanitizeSegment(last) || "value")
+  }
+
+  const joined = sanitized.join("_") || "value"
+  if (/^[0-9]/.test(joined)) {
+    return `_${joined}`
+  }
+  return joined
+}
+
+const createBindingPlaceholder = (
+  key: string,
+  type: BindingPrimitiveType
+): BindingPlaceholder => {
+  return {
+    toJSON() {
+      return `${BINDING_TOKEN_PREFIX}${type}__${key}__`
+    },
+  }
+}
+
+const defaultValueForType = (type: BindingPrimitiveType): string => {
+  switch (type) {
+    case "boolean":
+      return "false"
+    case "integer":
+    case "number":
+      return "0"
+    default:
+      return ""
+  }
+}
+
+const pickSchema = (
+  schema: SchemaObject | ReferenceObject | undefined
+): SchemaObject | undefined => {
+  const resolvedSchema = toSchemaObject(schema)
+  if (!resolvedSchema) {
+    return undefined
+  }
+
+  if (Array.isArray(resolvedSchema.allOf) && resolvedSchema.allOf.length > 0) {
+    const merged = resolvedSchema.allOf.reduce<SchemaObject | undefined>(
+      (accumulator, current) => {
+        const candidate = pickSchema(current)
+        if (!candidate) {
+          return accumulator
+        }
+        if (!accumulator) {
+          return { ...candidate }
+        }
+
+        const next: SchemaObject = { ...accumulator }
+
+        const mergedProperties = {
+          ...getProperties(accumulator),
+          ...getProperties(candidate),
+        }
+        if (Object.keys(mergedProperties).length > 0) {
+          next.properties = mergedProperties as SchemaObject["properties"]
+        }
+
+        const accumulatorRequired = accumulator.required ?? []
+        const candidateRequired = candidate.required ?? []
+        const mergedRequired = new Set([
+          ...accumulatorRequired,
+          ...candidateRequired,
+        ])
+        if (mergedRequired.size > 0) {
+          next.required = Array.from(mergedRequired)
+        }
+
+        if (!next.type && candidate.type) {
+          next.type = candidate.type
+        }
+        if (next.items === undefined && candidate.items !== undefined) {
+          next.items = candidate.items
+        }
+        return next
+      },
+      undefined
+    )
+    if (merged) {
+      return merged
+    }
+  }
+
+  if (Array.isArray(resolvedSchema.oneOf)) {
+    const [first] = resolvedSchema.oneOf
+    if (first) {
+      return pickSchema(first)
+    }
+  }
+
+  if (Array.isArray(resolvedSchema.anyOf)) {
+    const [first] = resolvedSchema.anyOf
+    if (first) {
+      return pickSchema(first)
+    }
+  }
+
+  return resolvedSchema
+}
+
+const getSchemaType = (
+  schema: SchemaObject | undefined
+): string | undefined => {
+  if (!schema) {
+    return undefined
+  }
+  const { type } = schema
+  if (Array.isArray(type)) {
+    return type[0]
+  }
+  if (!type) {
+    if (Object.keys(getProperties(schema)).length > 0) {
+      return "object"
+    }
+    if (getItemsSchema(schema)) {
+      return "array"
+    }
+  }
+  return typeof type === "string" ? type : undefined
+}
+
+const getRequiredProperties = (schema: SchemaObject | undefined): string[] => {
+  if (!schema?.required) {
+    return []
+  }
+  return Array.isArray(schema.required) ? [...schema.required] : []
+}
+
+const getProperties = (
+  schema: SchemaObject | undefined
+): Record<string, SchemaObject> => {
+  if (!schema?.properties) {
+    return {}
+  }
+  const entries = Object.entries(schema.properties)
+  const result: Record<string, SchemaObject> = {}
+  for (const [key, value] of entries) {
+    const propertySchema = toSchemaObject(value)
+    if (propertySchema) {
+      result[key] = propertySchema
+    }
+  }
+  return result
+}
+
+const getItemsSchema = (
+  schema: SchemaObject | undefined
+): SchemaObject | undefined => {
+  if (!schema) {
+    return undefined
+  }
+  const items = schema.items
+  if (!items) {
+    return undefined
+  }
+  if (Array.isArray(items)) {
+    const candidates = items as Array<SchemaObject | ReferenceObject>
+    for (const item of candidates) {
+      const schemaItem = pickSchema(item)
+      if (schemaItem) {
+        return schemaItem
+      }
+    }
+    return undefined
+  }
+  return pickSchema(items as SchemaObject | ReferenceObject)
+}
+
+const normalisePrimitiveType = (
+  type: string | undefined
+): BindingPrimitiveType => {
+  if (type === "integer" || type === "number" || type === "boolean") {
+    return type
+  }
+  return "string"
+}
+
+const getPrimitiveDefaultFromSchema = (
+  schema: SchemaObject | undefined,
+  type: BindingPrimitiveType
+): string => {
+  if (schema) {
+    if (schema.example !== undefined && schema.example !== null) {
+      return String(schema.example)
+    }
+    if (schema.default !== undefined && schema.default !== null) {
+      return String(schema.default)
+    }
+    const enumValues = schema.enum
+    if (Array.isArray(enumValues) && enumValues.length > 0) {
+      const [first] = enumValues
+      if (first !== undefined && first !== null) {
+        return String(first)
+      }
+    }
+  }
+  return defaultValueForType(type)
+}
+
+interface BuildOptions {
+  totalLimit?: number
+}
+
+interface BuildResult {
+  value: unknown
+  bindings: Record<string, string>
+}
+
+const mergeBindings = (
+  target: Record<string, string>,
+  source: Record<string, string>
+) => {
+  for (const [key, value] of Object.entries(source)) {
+    if (!(key in target)) {
+      target[key] = value
+    }
+  }
+}
+
+const createPrimitiveBindingResult = (
+  path: string[],
+  type: BindingPrimitiveType,
+  defaultValue: string
+): BuildResult => {
+  const key = buildBindingName(path)
+  return {
+    value: createBindingPlaceholder(key, type),
+    bindings: { [key]: defaultValue },
+  }
+}
+
+const buildFromSchema = (
+  schema: SchemaObject | undefined,
+  path: string[],
+  depth: number,
+  seen: Set<SchemaObject>,
+  options: BuildOptions
+): BuildResult => {
+  const { totalLimit = 12 } = options
+  const resolved = pickSchema(schema)
+  if (!resolved) {
+    const type = normalisePrimitiveType(undefined)
+    return createPrimitiveBindingResult(path, type, defaultValueForType(type))
+  }
+
+  if (seen.has(resolved)) {
+    const type = normalisePrimitiveType(getSchemaType(resolved))
+    return createPrimitiveBindingResult(
+      path,
+      type,
+      getPrimitiveDefaultFromSchema(resolved, type)
+    )
+  }
+
+  if (depth > MAX_DEPTH) {
+    const type = normalisePrimitiveType(getSchemaType(resolved))
+    return createPrimitiveBindingResult(
+      path,
+      type,
+      getPrimitiveDefaultFromSchema(resolved, type)
+    )
+  }
+
+  seen.add(resolved)
+
+  const type = getSchemaType(resolved)
+
+  if (type === "object") {
+    const properties = getProperties(resolved)
+    const propertyNames = Object.keys(properties)
+    if (propertyNames.length === 0) {
+      seen.delete(resolved)
+      return { value: {}, bindings: {} }
+    }
+
+    const requiredProperties = getRequiredProperties(resolved).filter(
+      property => propertyNames.includes(property)
+    )
+
+    const optionalProperties = propertyNames.filter(
+      property => !requiredProperties.includes(property)
+    )
+
+    let optionalSelection: string[] = []
+    if (optionalProperties.length > 0) {
+      const remainingCapacity = Math.max(
+        totalLimit - requiredProperties.length,
+        0
+      )
+      if (remainingCapacity > 0) {
+        optionalSelection = optionalProperties.slice(0, remainingCapacity)
+      }
+    }
+
+    let selectedProperties = [...requiredProperties, ...optionalSelection]
+
+    const uniqueSelected = new Set(selectedProperties)
+    selectedProperties = Array.from(uniqueSelected)
+
+    if (selectedProperties.length === 0) {
+      selectedProperties = propertyNames.slice(0, 1)
+    }
+
+    const objectValue: Record<string, unknown> = {}
+    const bindings: Record<string, string> = {}
+
+    for (const property of selectedProperties) {
+      const propertySchema = pickSchema(properties[property])
+      const child = buildFromSchema(
+        propertySchema,
+        [...path, property],
+        depth + 1,
+        seen,
+        options
+      )
+      if (child.value === undefined) {
+        const fallback = createPrimitiveBindingResult(
+          [...path, property],
+          "string",
+          defaultValueForType("string")
+        )
+        objectValue[property] = fallback.value
+        mergeBindings(bindings, fallback.bindings)
+      } else {
+        objectValue[property] = child.value
+        mergeBindings(bindings, child.bindings)
+      }
+    }
+
+    seen.delete(resolved)
+    return { value: objectValue, bindings }
+  }
+
+  if (type === "array") {
+    const itemSchema = getItemsSchema(resolved)
+    const child = buildFromSchema(
+      itemSchema,
+      [...path, "item"],
+      depth + 1,
+      seen,
+      options
+    )
+    const arrayValue: unknown[] = child.value === undefined ? [] : [child.value]
+    seen.delete(resolved)
+    return { value: arrayValue, bindings: child.bindings }
+  }
+
+  const primitiveType = normalisePrimitiveType(type)
+  const result = createPrimitiveBindingResult(
+    path,
+    primitiveType,
+    getPrimitiveDefaultFromSchema(resolved, primitiveType)
+  )
+  seen.delete(resolved)
+  return result
+}
+
+const buildFromExample = (
+  example: unknown,
+  path: string[],
+  depth: number,
+  seen: WeakSet<object>
+): BuildResult => {
+  if (depth > MAX_DEPTH) {
+    return createPrimitiveBindingResult(
+      path,
+      "string",
+      defaultValueForType("string")
+    )
+  }
+
+  if (
+    example === null ||
+    example === undefined ||
+    typeof example === "bigint" ||
+    typeof example === "symbol" ||
+    typeof example === "function"
+  ) {
+    return { value: example, bindings: {} }
+  }
+
+  if (typeof example === "string") {
+    return createPrimitiveBindingResult(path, "string", example)
+  }
+
+  if (typeof example === "number") {
+    return createPrimitiveBindingResult(path, "number", String(example))
+  }
+
+  if (typeof example === "boolean") {
+    return createPrimitiveBindingResult(
+      path,
+      "boolean",
+      example ? "true" : "false"
+    )
+  }
+
+  if (typeof example !== "object") {
+    return { value: example, bindings: {} }
+  }
+
+  const exampleObject = example as object
+  if (seen.has(exampleObject)) {
+    return createPrimitiveBindingResult(
+      path,
+      "string",
+      defaultValueForType("string")
+    )
+  }
+
+  seen.add(exampleObject)
+
+  if (Array.isArray(example)) {
+    if (example.length === 0) {
+      seen.delete(exampleObject)
+      return { value: [], bindings: {} }
+    }
+    const child = buildFromExample(
+      example[0],
+      [...path, "item"],
+      depth + 1,
+      seen
+    )
+    seen.delete(exampleObject)
+    return {
+      value: child.value === undefined ? [] : [child.value],
+      bindings: child.bindings,
+    }
+  }
+
+  const objectValue: Record<string, unknown> = {}
+  const bindings: Record<string, string> = {}
+
+  const exampleRecord = example as Record<string, unknown>
+  for (const [key, value] of Object.entries(exampleRecord)) {
+    const child = buildFromExample(value, [...path, key], depth + 1, seen)
+    if (child.value !== undefined) {
+      objectValue[key] = child.value
+    } else {
+      objectValue[key] = value
+    }
+    mergeBindings(bindings, child.bindings)
+  }
+
+  seen.delete(exampleObject)
+  return { value: objectValue, bindings }
+}
+
+export const generateRequestBodyFromSchema = (
+  schema:
+    | OpenAPIV2.SchemaObject
+    | OpenAPIV3.SchemaObject
+    | SchemaObject
+    | undefined,
+  rootName = "body",
+  options: BuildOptions = {}
+): GeneratedRequestBody | undefined => {
+  const resolvedSchema = pickSchema(
+    schema as SchemaObject | ReferenceObject | undefined
+  )
+  if (!resolvedSchema) {
+    return undefined
+  }
+  const seen = new Set<SchemaObject>()
+  const buildOptions: BuildOptions = {
+    totalLimit: options.totalLimit ?? 12,
+  }
+  const result = buildFromSchema(
+    resolvedSchema,
+    [rootName],
+    0,
+    seen,
+    buildOptions
+  )
+  if (result.value === undefined) {
+    return undefined
+  }
+  return { body: result.value, bindings: result.bindings }
+}
+
+export const generateRequestBodyFromExample = (
+  example: unknown,
+  rootName = "body"
+): GeneratedRequestBody | undefined => {
+  if (example === undefined) {
+    return undefined
+  }
+  const seen = new WeakSet<object>()
+  const result = buildFromExample(example, [rootName], 0, seen)
+  if (result.value === undefined) {
+    return undefined
+  }
+  return { body: result.value, bindings: result.bindings }
+}
+
+export const serialiseRequestBody = (body: unknown): string | undefined => {
+  if (body === undefined) {
+    return undefined
+  }
+  if (typeof body === "string") {
+    return body
+  }
+  const json = JSON.stringify(body, null, 2)
+  if (typeof json !== "string") {
+    return undefined
+  }
+  return json.replace(BINDING_TOKEN_REGEX, (_match, type, key) => {
+    const binding = `{{ ${key} }}`
+    if (type === "string") {
+      return `"${binding}"`
+    }
+    return binding
+  })
+}
+
+const extractBindingFromPlaceholder = (value: unknown): string | undefined => {
+  if (!value || typeof value !== "object") {
+    return undefined
+  }
+  const candidate = value as { toJSON?: () => unknown }
+  if (typeof candidate.toJSON !== "function") {
+    return undefined
+  }
+  const token = candidate.toJSON()
+  if (typeof token !== "string") {
+    return undefined
+  }
+  const match = token.match(BINDING_VALUE_REGEX)
+  if (!match) {
+    return undefined
+  }
+  return match[2]
+}
+
+const buildFormKey = (path: string[]): string => {
+  if (path.length === 0) {
+    return ""
+  }
+  const [first, ...rest] = path
+  let key = first
+  for (const segment of rest) {
+    if (segment === "item") {
+      key += "[]"
+      continue
+    }
+    key += `[${segment}]`
+  }
+  return key
+}
+
+const collectKeyValuePairs = (
+  value: unknown,
+  path: string[],
+  accumulator: Record<string, string>
+) => {
+  if (value === undefined || value === null) {
+    return
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach(item =>
+      collectKeyValuePairs(item, [...path, "item"], accumulator)
+    )
+    return
+  }
+
+  const binding = extractBindingFromPlaceholder(value)
+  if (binding) {
+    const key = buildFormKey(path)
+    if (key) {
+      accumulator[key] = `{{ ${binding} }}`
+    }
+    return
+  }
+
+  if (typeof value === "object") {
+    for (const [childKey, childValue] of Object.entries(
+      value as Record<string, unknown>
+    )) {
+      collectKeyValuePairs(childValue, [...path, childKey], accumulator)
+    }
+    return
+  }
+
+  const key = buildFormKey(path)
+  if (key) {
+    accumulator[key] = String(value)
+  }
+}
+
+export const buildKeyValueRequestBody = (
+  body: unknown
+): Record<string, string> | undefined => {
+  if (!body || typeof body !== "object") {
+    return undefined
+  }
+
+  const accumulator: Record<string, string> = {}
+  for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+    collectKeyValuePairs(value, [key], accumulator)
+  }
+
+  if (Object.keys(accumulator).length === 0) {
+    return undefined
+  }
+
+  return accumulator
+}
+
+const toFormDataParameter = (param: FormDataParameter): FormDataParameter => {
+  if (param.type) {
+    return param
+  }
+  return {
+    ...param,
+    type: "string",
+  }
+}
+
+export const buildRequestBodyFromFormDataParameters = (
+  params: FormDataParameter[]
+): GeneratedRequestBody | undefined => {
+  if (!Array.isArray(params) || params.length === 0) {
+    return undefined
+  }
+
+  const body: Record<string, unknown> = {}
+  const bindings: Record<string, string> = {}
+
+  for (const param of params) {
+    const normalized = toFormDataParameter(param)
+    if (!normalized?.name) {
+      continue
+    }
+    const type = normalisePrimitiveType(normalized.type)
+    const defaultValue = normalized.default
+      ? String(normalized.default)
+      : defaultValueForType(type)
+    const { value, bindings: paramBindings } = createPrimitiveBindingResult(
+      ["form", normalized.name],
+      type,
+      defaultValue
+    )
+    body[normalized.name] = value
+    mergeBindings(bindings, paramBindings)
+  }
+
+  if (Object.keys(body).length === 0) {
+    return undefined
+  }
+
+  return { body, bindings }
+}

--- a/packages/server/src/api/controllers/query/index.ts
+++ b/packages/server/src/api/controllers/query/index.ts
@@ -15,6 +15,8 @@ import {
   FindQueryResponse,
   ImportRestQueryRequest,
   ImportRestQueryResponse,
+  ImportRestQueryInfoRequest,
+  ImportRestQueryInfoResponse,
   JsonFieldSubType,
   PreviewQueryRequest,
   PreviewQueryResponse,
@@ -38,6 +40,7 @@ import { QueryEvent, QueryEventParameters } from "../../../threads/definitions"
 import { invalidateCachedVariable } from "../../../threads/utils"
 import { save as saveDatasource } from "../datasource"
 import { RestImporter } from "./import"
+import fetch from "node-fetch"
 
 const Runner = new Thread(ThreadType.QUERY, {
   timeoutMs: env.QUERY_THREAD_TIMEOUT,
@@ -65,15 +68,44 @@ function validateQueryInputs(parameters: QueryEventParameters) {
   }
 }
 
-export async function fetch(ctx: UserCtx<void, FetchQueriesResponse>) {
+export async function fetchQueries(ctx: UserCtx<void, FetchQueriesResponse>) {
   ctx.body = await sdk.queries.fetch()
+}
+
+const resolveImportData = async (
+  ctx: UserCtx,
+  payload: { data?: string; url?: string }
+) => {
+  const data = payload.data?.trim()
+  if (data) {
+    return payload.data as string
+  }
+
+  const url = payload.url?.trim()
+  if (url) {
+    try {
+      const response = await fetch(url)
+      if (!response.ok) {
+        ctx.throw(
+          response.status,
+          `Failed to fetch import data (status ${response.status})`
+        )
+      }
+      return await response.text()
+    } catch (error: any) {
+      const message = error?.message || "Unknown error"
+      ctx.throw(502, `Failed to fetch import data - ${message}`)
+    }
+  }
+
+  ctx.throw(400, "Import data is required")
 }
 
 const _import = async (
   ctx: UserCtx<ImportRestQueryRequest, ImportRestQueryResponse>
 ) => {
   const body = ctx.request.body
-  const data = body.data
+  const data = await resolveImportData(ctx, body)
 
   const importer = new RestImporter(data)
   await importer.init()
@@ -108,7 +140,18 @@ const _import = async (
     datasourceId = body.datasourceId
   }
 
-  const importResult = await importer.importQueries(datasourceId)
+  let importResult
+  try {
+    importResult = await importer.importQueries(
+      datasourceId,
+      body.selectedEndpointId
+    )
+  } catch (error: any) {
+    if (body.selectedEndpointId && error?.message) {
+      ctx.throw(400, error.message)
+    }
+    throw error
+  }
 
   ctx.body = {
     ...importResult,
@@ -116,6 +159,21 @@ const _import = async (
   }
 }
 export { _import as import }
+
+export async function importInfo(
+  ctx: UserCtx<ImportRestQueryInfoRequest, ImportRestQueryInfoResponse>
+) {
+  const data = await resolveImportData(ctx, ctx.request.body)
+  const importer = new RestImporter(data)
+  await importer.init()
+  const info = await importer.getInfo()
+  ctx.body = {
+    name: info.name,
+    url: info.url,
+    docsUrl: info.docsUrl,
+    endpoints: info.endpoints || [],
+  }
+}
 
 export async function save(ctx: UserCtx<SaveQueryRequest, SaveQueryResponse>) {
   const db = context.getWorkspaceDB()

--- a/packages/server/src/api/routes/query.ts
+++ b/packages/server/src/api/routes/query.ts
@@ -31,13 +31,14 @@ const writeRoutes = endpointGroupList.group(
 )
 
 builderRoutes
-  .get("/api/queries", queryController.fetch)
+  .get("/api/queries", queryController.fetchQueries)
   .post(
     "/api/queries",
     bodySubResource("datasourceId", "_id"),
     generateQueryValidation(),
     queryController.save
   )
+  .post("/api/queries/import/info", queryController.importInfo)
   .post("/api/queries/import", queryController.import)
   .post(
     "/api/queries/preview",

--- a/packages/types/src/api/web/workspace/query.ts
+++ b/packages/types/src/api/web/workspace/query.ts
@@ -3,6 +3,7 @@ import {
   Query,
   QueryPreview,
   QuerySchema,
+  QueryVerb,
 } from "../../../documents"
 
 export type FetchQueriesResponse = Query[]
@@ -12,8 +13,31 @@ export interface SaveQueryResponse extends Query {}
 
 export interface ImportRestQueryRequest {
   datasourceId?: string
-  data: string
+  data?: string
+  url?: string
   datasource: Datasource
+  selectedEndpointId?: string
+}
+
+export interface QueryImportEndpoint {
+  id: string
+  name: string
+  method?: string
+  path?: string
+  description?: string
+  queryVerb?: QueryVerb
+}
+
+export interface ImportRestQueryInfoRequest {
+  data?: string
+  url?: string
+}
+
+export interface ImportRestQueryInfoResponse {
+  name: string
+  url?: string
+  docsUrl?: string
+  endpoints: QueryImportEndpoint[]
 }
 export interface ImportRestQueryResponse {
   errorQueries: Query[]


### PR DESCRIPTION
## Summary
- add the new /apis Routify tree (layout, datasource views, query views) without linking it into navigation yet
- this keeps the new UI hidden but lets us land the bulk of the Svelte code incrementally

## Testing
- not run