### PR TITLE
fix: AI Classify did not return "category"

### DIFF
--- a/packages/server/src/automations/steps/ai/classify.ts
+++ b/packages/server/src/automations/steps/ai/classify.ts
@@ -35,6 +35,7 @@ export async function run({
     if (determinedCategory && categories.includes(determinedCategory)) {
       return {
         response: determinedCategory,
+        category: determinedCategory,
         success: true,
       }
     }


### PR DESCRIPTION
## Description

The "Classify Text" step defines `category` as an output field, but was not returning it at runtime. The correct classification was returned in the `response` field - but this is not available as a binding in subsequent steps.

<img width="1238" height="619" alt="image" src="https://github.com/user-attachments/assets/d15b881c-7b38-40fe-87f6-19c81970ecc0" />

## Launchcontrol

Automation step - Classify Text now returns "category", as expected.
