### PR TITLE
[BUDI-9431] Fix MySQL CALL syntax highlighting

### DIFF
--- a/packages/builder/src/components/integration/index.svelte
+++ b/packages/builder/src/components/integration/index.svelte
@@ -10,11 +10,21 @@
     Button,
     ActionButton,
   } from "@budibase/bbui"
+  import { IntegrationTypes } from "@/constants/backend"
 
   const QueryTypes = {
     SQL: "sql",
     JSON: "json",
     FIELDS: "fields",
+  }
+
+  const DEFAULT_SQL_MODE = "sql"
+
+  const SQLModes = {
+    [IntegrationTypes.MYSQL]: "text/x-mysql",
+    [IntegrationTypes.POSTGRES]: "text/x-pgsql",
+    [IntegrationTypes.SQL_SERVER]: "text/x-mssql",
+    [IntegrationTypes.ORACLE]: "text/x-plsql",
   }
 
   export let query
@@ -25,6 +35,11 @@
   export let noLabel = false
 
   let stepEditors = []
+
+  $: sqlEditorMode =
+    schema?.type === QueryTypes.SQL
+      ? SQLModes[datasource?.source] || DEFAULT_SQL_MODE
+      : DEFAULT_SQL_MODE
 
   $: urlDisplay =
     schema.urlDisplay &&
@@ -76,7 +91,7 @@
       <Editor
         editorHeight={height}
         label={noLabel ? null : "Query"}
-        mode="sql"
+        mode={sqlEditorMode}
         on:change={updateQuery}
         readOnly={!editable}
         value={query.fields.sql}

--- a/packages/builder/src/components/integration/index.svelte
+++ b/packages/builder/src/components/integration/index.svelte
@@ -24,7 +24,7 @@
     [IntegrationTypes.MYSQL]: "text/x-mysql",
     [IntegrationTypes.POSTGRES]: "text/x-pgsql",
     [IntegrationTypes.SQL_SERVER]: "text/x-mssql",
-    [IntegrationTypes.ORACLE]: "text/x-plsql",
+    [IntegrationTypes.ORACLE]: "text/x-sql",
   }
 
   export let query

--- a/packages/builder/src/components/integration/index.svelte
+++ b/packages/builder/src/components/integration/index.svelte
@@ -36,10 +36,7 @@
 
   let stepEditors = []
 
-  $: sqlEditorMode =
-    schema?.type === QueryTypes.SQL
-      ? SQLModes[datasource?.source] || DEFAULT_SQL_MODE
-      : DEFAULT_SQL_MODE
+  $: sqlEditorMode = SQLModes[datasource?.source] || DEFAULT_SQL_MODE
 
   $: urlDisplay =
     schema.urlDisplay &&


### PR DESCRIPTION
## Description
Adds datasource-aware CodeMirror dialect selection so SQL queries use the correct syntax highlighter per datasource (MySQL, Postgres, SQL Server, Oracle), ensuring keywords like CALL are highlighted. Falls back to the generic sql mode when no specific dialect is available.

## Addresses
- https://github.com/Budibase/budibase/issues/16429

## Screenshots
<img width="797" height="387" alt="Screenshot 2025-11-11 at 11 46 59" src="https://github.com/user-attachments/assets/790a1285-60d2-4f9e-a4a2-c77417903487" />


## Launchcontrol
Ensures the SQL editor loads the correct syntax highlighter for each datasource so MySQL CALL statements render with the expected highlighting.