### PR TITLE
Improve automation step search

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/SelectStepSidePanel.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/SelectStepSidePanel.svelte
@@ -259,26 +259,33 @@
     {}
   )
 
+  const matchesSearch = (action: AutomationStepDefinition, term: string) => {
+    const lowerTerm = term.trim().toLowerCase()
+    if (!lowerTerm) return true
+    const name = action.name?.toLowerCase() || ""
+    const stepTitle = action.stepTitle?.toLowerCase() || ""
+    const tagline = action.tagline?.toLowerCase() || ""
+    const description = action.description?.toLowerCase() || ""
+    return (
+      name.includes(lowerTerm) ||
+      stepTitle.includes(lowerTerm) ||
+      tagline.includes(lowerTerm) ||
+      description.includes(lowerTerm)
+    )
+  }
+
   $: filteredCategories = categories
     .map(category => ({
       ...category,
-      items: category.items.filter(([_, action]) => {
-        const term = searchString.trim().toLowerCase()
-        if (!term) return true
-        const name = action.name?.toLowerCase() || ""
-        const stepTitle = action.stepTitle?.toLowerCase() || ""
-        return name.includes(term) || stepTitle.includes(term)
-      }),
+      items: category.items.filter(([_, action]) =>
+        matchesSearch(action, searchString)
+      ),
     }))
     .filter(category => category.items.length > 0)
 
-  $: filteredPlugins = Object.entries(plugins).filter(([_, action]) => {
-    const term = searchString.trim().toLowerCase()
-    if (!term) return true
-    const name = action.name?.toLowerCase() || ""
-    const stepTitle = action.stepTitle?.toLowerCase() || ""
-    return name.includes(term) || stepTitle.includes(term)
-  })
+  $: filteredPlugins = Object.entries(plugins).filter(([_, action]) =>
+    matchesSearch(action, searchString)
+  )
 
   const selectAction = async (action: AutomationStepDefinition) => {
     selectedAction = action.name


### PR DESCRIPTION
## Description
- extend automation step search to include taglines and descriptions so REST queries find the API Request block

## Addresses
- https://github.com/Budibase/budibase/issues/16816

## Screenshots
<img width="423" height="418" alt="improved automation step search" src="https://github.com/user-attachments/assets/5d94ee77-c081-477c-b2e2-c6fa062ef5ca" />


## Launchcontrol
Improve automation builder search results by matching descriptive copy (e.g. REST) for each action.
