### PR TITLE
Feat/parity in singleimage re req limits

### DIFF
--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -44,7 +44,7 @@ ENV TARGETBUILD=$TARGETBUILD
 
 # install base dependencies
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends software-properties-common nginx uuid-runtime redis-server libaio1
+  apt-get install -y --no-install-recommends software-properties-common nginx uuid-runtime redis-server libaio1 gettext-base
 
 # Install postgres client for pg_dump utils
 RUN apt install -y software-properties-common apt-transport-https ca-certificates gnupg \

--- a/hosting/single/nginx/nginx-default-site.conf
+++ b/hosting/single/nginx/nginx-default-site.conf
@@ -94,6 +94,24 @@ server {
         proxy_pass      http://127.0.0.1:4001;
     }
 
+    location /api/webhooks/ {
+        # calls to webhooks are rate limited
+        limit_req zone=webhooks nodelay;
+
+        # 120s timeout on API requests
+        proxy_read_timeout 120s;
+        proxy_connect_timeout 120s;
+        proxy_send_timeout 120s;
+
+        proxy_http_version  1.1;
+        proxy_set_header    Connection          $connection_upgrade;
+        proxy_set_header    Upgrade             $http_upgrade;
+        proxy_set_header    X-Real-IP           $remote_addr;
+        proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+
+        proxy_pass      http://127.0.0.1:4001;
+    }
+
     location /api/ {
         # calls to the API are rate limited with bursting
         limit_req zone=ratelimit burst=20 nodelay;

--- a/hosting/single/nginx/nginx.conf
+++ b/hosting/single/nginx/nginx.conf
@@ -9,7 +9,10 @@ events {
 }
 
 http {
-  limit_req_zone $binary_remote_addr zone=ratelimit:10m rate=20r/s;
+  # rate limiting
+  limit_req_status 429;
+  limit_req_zone $binary_remote_addr zone=ratelimit:10m rate=${PROXY_RATE_LIMIT_API_PER_SECOND}r/s;
+  limit_req_zone $binary_remote_addr zone=webhooks:10m rate=${PROXY_RATE_LIMIT_WEBHOOKS_PER_SECOND}r/s;
   proxy_set_header Host $host;
   charset utf-8;
   sendfile on;

--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -9,6 +9,10 @@ export BUDIBASE_ENVIRONMENT="${BUDIBASE_ENVIRONMENT:-PRODUCTION}"
 export CLUSTER_PORT="${CLUSTER_PORT:-80}"
 export DEPLOYMENT_ENVIRONMENT="${DEPLOYMENT_ENVIRONMENT:-docker}"
 
+# set defaults for proxy rate limiting (matching production defaults)
+export PROXY_RATE_LIMIT_API_PER_SECOND="${PROXY_RATE_LIMIT_API_PER_SECOND:-50}"
+export PROXY_RATE_LIMIT_WEBHOOKS_PER_SECOND="${PROXY_RATE_LIMIT_WEBHOOKS_PER_SECOND:-10}"
+
 # only set MINIO_URL if neither MINIO_URL nor USE_S3 is set
 if [[ -z "${MINIO_URL}" && -z "${USE_S3}" ]]; then
   export MINIO_URL="http://127.0.0.1:9000"
@@ -108,6 +112,9 @@ if [[ -z "${USE_S3}" ]]; then
         /minio/minio server --console-address ":9001" ${DATA_DIR}/minio >/dev/stdout 2>&1 &
     fi
 fi
+
+echo "Processing nginx configuration templates..."
+envsubst '${PROXY_RATE_LIMIT_API_PER_SECOND} ${PROXY_RATE_LIMIT_WEBHOOKS_PER_SECOND}' < /etc/nginx/nginx.conf > /tmp/nginx.conf && mv /tmp/nginx.conf /etc/nginx/nginx.conf
 
 /etc/init.d/nginx restart
 if [[ ! -z "${CUSTOM_DOMAIN}" ]]; then


### PR DESCRIPTION
## Description

Improves Nginx configuration handling in single-image deployments by introducing dynamic and parametric request rate limiting.

## Addresses
- failing to load app content due to bursts in request volume in single-image deployments

## Launchcontrol

Fixes an issue with [single-image](https://hub.docker.com/r/budibase/budibase) deployments that results to non-responsive apps due to Nginx rate limits after an increase in request bursts for chunked content. 
