### PR TITLE
[Added] Flexible tenant locking mechanism to support non-usage-based lock scenarios

### DIFF
--- a/packages/builder/src/components/portal/licensing/AccountLockedModal.svelte
+++ b/packages/builder/src/components/portal/licensing/AccountLockedModal.svelte
@@ -1,8 +1,10 @@
 <script>
   import { Modal, ModalContent, Body } from "@budibase/bbui"
+  import { LockReason } from "@budibase/types"
 
   let modal
 
+  export let lockedBy
   export let onConfirm
 
   export function show() {
@@ -23,9 +25,15 @@
     confirmText={"View plans"}
     {onConfirm}
   >
-    <Body size="S"
-      >Due to the free plan user limit being exceeded, your account has been
-      de-activated. Upgrade your plan to re-activate your account.</Body
-    >
+    <Body size="S">
+      {#if lockedBy === LockReason.FREE_TIER}
+        You’re currently on Budibase’s Free plan, which is no longer available
+        for cloud users. Your tenant has been temporarily locked. Please upgrade
+        to a paid plan to keep your data — otherwise it will be removed soon.
+      {:else}
+        Due to the free plan user limit being exceeded, your account has been
+        de-activated. Upgrade your plan to re-activate your account.
+      {/if}
+    </Body>
   </ModalContent>
 </Modal>

--- a/packages/builder/src/components/portal/licensing/AccountLockedModal.svelte
+++ b/packages/builder/src/components/portal/licensing/AccountLockedModal.svelte
@@ -27,7 +27,7 @@
   >
     <Body size="S">
       {#if lockedBy === LockReason.FREE_TIER}
-        You’re currently on Budibase’s Free plan, which is no longer available
+        You’re currently on the Budibase Free plan, which is no longer available
         for cloud users. Your tenant has been temporarily locked. Please upgrade
         to a paid plan to keep your data — otherwise it will be removed soon.
       {:else}

--- a/packages/builder/src/components/portal/licensing/AccountLockedModal.svelte
+++ b/packages/builder/src/components/portal/licensing/AccountLockedModal.svelte
@@ -31,7 +31,7 @@
         for cloud users. Your tenant has been temporarily locked. Please upgrade
         to a paid plan to keep your data — otherwise it will be removed soon.
       {:else}
-        Due to the free plan user limit being exceeded, your account has been
+        Due to the Free plan user limit being exceeded, your account has been
         de-activated. Upgrade your plan to re-activate your account.
       {/if}
     </Body>

--- a/packages/builder/src/components/portal/licensing/licensingBanners.js
+++ b/packages/builder/src/components/portal/licensing/licensingBanners.js
@@ -111,7 +111,7 @@ const buildLockedBanner = EXPIRY_KEY => {
       defaultCacheFn(EXPIRY_KEY)
     },
     criteria: () => {
-      return userLicensing.errUserLimit || get(auth).user.lockedBy
+      return userLicensing.errUserLimit || get(auth).user?.lockedBy
     },
     message: "Your Budibase account is de-activated. Upgrade your plan",
     ...{

--- a/packages/builder/src/components/portal/licensing/licensingBanners.js
+++ b/packages/builder/src/components/portal/licensing/licensingBanners.js
@@ -102,7 +102,7 @@ const buildPaymentFailedBanner = () => {
   }
 }
 
-const buildUsersAboveLimitBanner = EXPIRY_KEY => {
+const buildLockedBanner = EXPIRY_KEY => {
   const userLicensing = get(licensing)
   return {
     key: EXPIRY_KEY,
@@ -111,7 +111,7 @@ const buildUsersAboveLimitBanner = EXPIRY_KEY => {
       defaultCacheFn(EXPIRY_KEY)
     },
     criteria: () => {
-      return userLicensing.errUserLimit
+      return userLicensing.errUserLimit || get(auth).user.lockedBy
     },
     message: "Your Budibase account is de-activated. Upgrade your plan",
     ...{
@@ -146,7 +146,7 @@ export const getBanners = () => {
       ExpiringKeys.LICENSING_QUERIES_WARNING_BANNER,
       90
     ),
-    buildUsersAboveLimitBanner(ExpiringKeys.LICENSING_USERS_ABOVE_LIMIT_BANNER),
+    buildLockedBanner(ExpiringKeys.LICENSING_USERS_ABOVE_LIMIT_BANNER),
   ].filter(licensingBanner => {
     return (
       !temporalStore.getExpiring(licensingBanner.key) &&

--- a/packages/builder/src/pages/builder/_layout.svelte
+++ b/packages/builder/src/pages/builder/_layout.svelte
@@ -61,9 +61,10 @@
     hasAuthenticated = isAuthenticated
   }
 
-  $: usersLimitLockAction = $licensing?.errUserLimit
-    ? () => accountLockedModal.show()
-    : null
+  $: lockAction =
+    $licensing?.errUserLimit || $auth?.user?.lockedBy
+      ? () => accountLockedModal.show()
+      : null
 
   $: updateBannerVisibility($auth.user, $licensing.license?.plan?.type, isOwner)
 
@@ -244,8 +245,8 @@
 
         await auth.getInitInfo()
 
-        if (usersLimitLockAction) {
-          usersLimitLockAction()
+        if (lockAction) {
+          lockAction()
         }
       }
 
@@ -294,6 +295,7 @@
 
 <AccountLockedModal
   bind:this={accountLockedModal}
+  lockedBy={$auth.user?.lockedBy}
   onConfirm={() =>
     isOwner ? licensing.goToUpgradePage() : licensing.goToPricingPage()}
 />

--- a/packages/builder/src/pages/builder/_layout.svelte
+++ b/packages/builder/src/pages/builder/_layout.svelte
@@ -63,7 +63,7 @@
 
   $: lockAction =
     $licensing?.errUserLimit || $auth?.user?.lockedBy
-      ? () => accountLockedModal.show()
+      ? accountLockedModal.show
       : null
 
   $: updateBannerVisibility($auth.user, $licensing.license?.plan?.type, isOwner)

--- a/packages/types/src/api/web/global/self.ts
+++ b/packages/types/src/api/web/global/self.ts
@@ -1,6 +1,6 @@
 import { License, LLMProviderConfig } from "../../../sdk"
 import { Account, DevInfo, User } from "../../../documents"
-import { FeatureFlags } from "@budibase/types"
+import { FeatureFlags, LockReason } from "@budibase/types"
 
 export interface GenerateAPIKeyRequest {
   userId?: string
@@ -13,6 +13,7 @@ export interface GetGlobalSelfResponse extends User {
   flags?: FeatureFlags
   llm?: Omit<LLMProviderConfig, "apiKey">
   account?: Account
+  lockedBy?: LockReason
   license: License
   budibaseAccess: boolean
   accountPortalAccess: boolean

--- a/packages/types/src/documents/global/config.ts
+++ b/packages/types/src/documents/global/config.ts
@@ -36,6 +36,10 @@ export interface SettingsBrandingConfig {
   metaTitle?: string
 }
 
+export enum LockReason {
+  FREE_TIER = "free_tier", // Locked because grace period in free tier has ended
+}
+
 export interface SettingsInnerConfig {
   platformUrl?: string
   company?: string
@@ -46,6 +50,7 @@ export interface SettingsInnerConfig {
   analyticsEnabled?: boolean
   isSSOEnforced?: boolean
   createdVersion?: string
+  lockedBy?: LockReason
   liteLLM?: { keyId: string; secretKey: string }
 }
 

--- a/packages/worker/src/api/controllers/global/self.ts
+++ b/packages/worker/src/api/controllers/global/self.ts
@@ -1,6 +1,7 @@
 import {
   auth as authCore,
   db as dbCore,
+  configs,
   encryption,
   features,
   tenancy,
@@ -95,6 +96,7 @@ const getUserSessionAttributes = (ctx: UserCtx) => ({
 })
 
 export async function getSelf(ctx: UserCtx<void, GetGlobalSelfResponse>) {
+  ///
   if (!ctx.user) {
     ctx.throw(403, "User not logged in")
   }
@@ -123,11 +125,15 @@ export async function getSelf(ctx: UserCtx<void, GetGlobalSelfResponse>) {
       }
     : undefined
 
+  // add locked reason if proceed
+  const settingsConfig = await configs.getSettingsConfig()
+
   ctx.body = {
     ...enrichedUser,
     ...sessionAttributes,
     flags,
     llm: sanitisedLLMConfig,
+    lockedBy: settingsConfig?.lockedBy,
   }
 }
 

--- a/packages/worker/src/api/controllers/global/self.ts
+++ b/packages/worker/src/api/controllers/global/self.ts
@@ -96,7 +96,6 @@ const getUserSessionAttributes = (ctx: UserCtx) => ({
 })
 
 export async function getSelf(ctx: UserCtx<void, GetGlobalSelfResponse>) {
-  ///
   if (!ctx.user) {
     ctx.throw(403, "User not logged in")
   }
@@ -125,7 +124,6 @@ export async function getSelf(ctx: UserCtx<void, GetGlobalSelfResponse>) {
       }
     : undefined
 
-  // add locked reason if proceed
   const settingsConfig = await configs.getSettingsConfig()
 
   ctx.body = {


### PR DESCRIPTION
## Description

Introduces a new tenant locking system decoupled from usage limits.
Previously, tenants could only be locked when exceeding user limits (e.g. Free plan over 5 users).
This update adds a `LockReason` enum and `lockedBy` field, allowing tenants to be locked for other reasons — such as Free tier restrictions or future policy conditions — and enabling the UI to display contextual messages accordingly.

In a short term, this lock mechanism will be used by a flow in charge of free plan deactivation. It will be responsible to activate or deactivate `lockedBy` field.

### How it works

- A new field `lockedBy` has been added to the tenant configuration.  
- If `lockedBy` is set, the tenant is considered **locked**, regardless of other limits.  
- The lock reason determines how the **UI** should respond — e.g., showing different messages or actions depending on the reason.  
- The configuration is stored under the **`ConfigSettings` document in CouchDB**, which is associated with the tenant.

## Addresses
- https://github.com/Budibase/account-portal/issues/1628
- https://github.com/Budibase/budibase/issues/17358

## Screen recording

https://github.com/user-attachments/assets/3dfdbe03-dbda-4c12-b2a8-9c7a5a022307

## Launchcontrol

Add flexible tenant locking mechanism to support non-usage-based lock scenarios.
