### PR TITLE
fix: mask imap password when typing

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/layouts/EmailTrigger.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/layouts/EmailTrigger.svelte
@@ -80,6 +80,7 @@
             {key}
             updateOnChange={false}
             placeholder={schema[key].description}
+            inputType={key === "password" ? "password" : undefined}
             on:change={event => handleChange(key, event.detail)}
           />
         </PropField>

--- a/packages/builder/src/components/common/bindings/DrawerBindableInput.svelte
+++ b/packages/builder/src/components/common/bindings/DrawerBindableInput.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Icon, Input, Drawer, Button, TextArea } from "@budibase/bbui"
+  import type { HTMLInputTypeAttribute } from "svelte/elements"
   import {
     readableToRuntimeBinding,
     runtimeToReadableBinding,
@@ -27,7 +28,7 @@
   export let autocomplete: boolean | undefined = undefined
   export let multiline: boolean = false
   export let allowHTML: boolean = false
-  export let inputType: string | undefined = undefined
+  export let inputType: HTMLInputTypeAttribute | undefined = undefined
 
   const dispatch = createEventDispatcher()
 

--- a/packages/builder/src/components/common/bindings/DrawerBindableInput.svelte
+++ b/packages/builder/src/components/common/bindings/DrawerBindableInput.svelte
@@ -27,6 +27,7 @@
   export let autocomplete: boolean | undefined = undefined
   export let multiline: boolean = false
   export let allowHTML: boolean = false
+  export let inputType: string | undefined = undefined
 
   const dispatch = createEventDispatcher()
 
@@ -79,6 +80,7 @@
     placeholder={placeholder || undefined}
     {updateOnChange}
     {autocomplete}
+    type={multiline ? undefined : inputType}
   >
     {#if !disabled && !disableBindings}
       <div


### PR DESCRIPTION
## Description
IMAP password was only masked after save, now its masked while typing too (same as SMTP password)