### PR TITLE
Chore/change datasource metadata

### DIFF
--- a/packages/builder/src/components/backend/DatasourceNavigator/DatasourceNavItem/DatasourceNavItem.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/DatasourceNavItem/DatasourceNavItem.svelte
@@ -12,8 +12,6 @@
 
   export let datasource
 
-  let templateIcon
-
   $: templateIcon = datasource?.restTemplate
     ? $restTemplates.templates.find(
         template => template.name === datasource.restTemplate

--- a/packages/builder/src/components/backend/DatasourceNavigator/DatasourceNavItem/DatasourceNavItem.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/DatasourceNavItem/DatasourceNavItem.svelte
@@ -2,6 +2,7 @@
   import { isActive } from "@roxi/routify"
   import { BUDIBASE_INTERNAL_DB_ID } from "@/constants/backend"
   import { contextMenuStore, userSelectedResourceMap } from "@/stores/builder"
+  import { restTemplates } from "@/stores/builder/restTemplates"
   import NavItem from "@/components/common/NavItem.svelte"
 
   import IntegrationIcon from "@/components/backend/DatasourceNavigator/IntegrationIcon.svelte"
@@ -10,6 +11,14 @@
   import DeleteDataConfirmModal from "@/components/backend/modals/DeleteDataConfirmationModal.svelte"
 
   export let datasource
+
+  let templateIcon
+
+  $: templateIcon = datasource?.restTemplate
+    ? $restTemplates.templates.find(
+        template => template.name === datasource.restTemplate
+      )?.icon
+    : undefined
 
   let editModal
   let deleteConfirmationModal
@@ -63,7 +72,7 @@
     <IntegrationIcon
       integrationType={datasource.source}
       schema={datasource.schema}
-      iconUrl={datasource.uiMetadata?.iconUrl}
+      iconUrl={templateIcon}
       size="18"
     />
   </div>

--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -107,7 +107,7 @@
     ...globalDynamicRequestBindings,
   ]
 
-  $: isTemplateDatasource = Boolean(datasource?.isRestTemplate)
+  $: isTemplateDatasource = Boolean(datasource?.restTemplate)
   $: bindingPreviewContext = getBindingContext([
     requestBindings,
     globalDynamicBindings,

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/new.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/new.svelte
@@ -168,16 +168,14 @@
     templateLoading = true
     templateLoadingPhase = "import"
     try {
-      const config = {
-        ...configFromIntegration(restIntegration),
-        url: pendingSpec.url,
-      }
+      const config = configFromIntegration(restIntegration)
 
       const datasource = await datasources.create({
         integration: restIntegration,
         config,
         name: buildDatasourceName(pendingTemplate, pendingSpec),
         restTemplate: pendingTemplate.name,
+        restTemplateVersion: pendingSpec.version,
       })
 
       if (!datasource?._id) {

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/new.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/new.svelte
@@ -177,8 +177,7 @@
         integration: restIntegration,
         config,
         name: buildDatasourceName(pendingTemplate, pendingSpec),
-        uiMetadata: { iconUrl: pendingTemplate.icon },
-        isRestTemplate: true,
+        restTemplate: pendingTemplate.name,
       })
 
       if (!datasource?._id) {

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Queries/RestTemplateImportModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Queries/RestTemplateImportModal.svelte
@@ -27,7 +27,6 @@
     Datasource,
     ImportRestQueryRequest,
     QueryImportEndpoint,
-    RestConfig,
     RestTemplate,
   } from "@budibase/types"
 
@@ -42,16 +41,17 @@
   $: restIntegration = ($integrations || []).find(
     integration => integration.name === datasource?.source
   )
-  $: datasourceTemplateUrl = getTemplateSpecUrl(datasource)
-  $: template = getMatchingTemplate(
-    datasource,
-    restTemplateList,
-    datasourceTemplateUrl
-  )
-  $: resolvedTemplateSpecUrl = template
-    ? template.specs?.find(spec => spec.url === datasourceTemplateUrl)?.url ||
-      template.specs?.[0]?.url
+  $: template = datasource?.restTemplate
+    ? restTemplateList.find(
+        template => template.name === datasource.restTemplate
+      )
     : undefined
+  $: selectedTemplateSpec = template
+    ? template.specs?.find(
+        spec => spec.version === datasource?.restTemplateVersion
+      ) || template.specs?.[0]
+    : undefined
+  $: resolvedTemplateSpecUrl = selectedTemplateSpec?.url
   $: templateName = template?.name
   $: templateIcon = template?.icon
   $: isTemplateDatasource = Boolean(datasource?.restTemplate && template)
@@ -65,30 +65,6 @@
   $: confirmDisabled = !selectedEndpointId || endpointsLoading
   let currentTemplateUrl: string | undefined
   let templateDocsBaseUrl: string | undefined
-
-  const getTemplateSpecUrl = (source: Datasource | undefined) => {
-    const config = (source?.config || {}) as Partial<RestConfig>
-    return typeof config?.url === "string" ? config.url : undefined
-  }
-
-  const getMatchingTemplate = (
-    source: Datasource | undefined,
-    templates: RestTemplate[],
-    specUrl: string | undefined
-  ) => {
-    if (!source?.restTemplate) {
-      return undefined
-    }
-
-    return (
-      templates.find(template => template.name === source.restTemplate) ||
-      (specUrl
-        ? templates.find(template =>
-            template.specs?.some(spec => spec.url === specUrl)
-          )
-        : undefined)
-    )
-  }
 
   const resetEndpoints = () => {
     loadRequestId += 1

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Queries/RestTemplateImportModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Queries/RestTemplateImportModal.svelte
@@ -54,7 +54,7 @@
     : undefined
   $: templateName = template?.name
   $: templateIcon = template?.icon
-  $: isTemplateDatasource = Boolean(datasource?.isRestTemplate && template)
+  $: isTemplateDatasource = Boolean(datasource?.restTemplate && template)
   $: templateEndpointDescription = selectedEndpoint?.description || ""
   let endpointOptions: QueryImportEndpoint[] = []
   let selectedEndpointId: string | undefined = undefined
@@ -67,11 +67,8 @@
   let templateDocsBaseUrl: string | undefined
 
   const getTemplateSpecUrl = (source: Datasource | undefined) => {
-    if (!source?.isRestTemplate) {
-      return undefined
-    }
-    const config = (source.config || {}) as Partial<RestConfig>
-    return typeof config.url === "string" ? config.url : undefined
+    const config = (source?.config || {}) as Partial<RestConfig>
+    return typeof config?.url === "string" ? config.url : undefined
   }
 
   const getMatchingTemplate = (
@@ -79,27 +76,18 @@
     templates: RestTemplate[],
     specUrl: string | undefined
   ) => {
-    if (!source?.isRestTemplate) {
+    if (!source?.restTemplate) {
       return undefined
     }
 
-    let match = specUrl
-      ? templates.find(template =>
-          template.specs?.some(spec => spec.url === specUrl)
-        )
-      : undefined
-
-    if (!match && source.uiMetadata?.iconUrl) {
-      match = templates.find(
-        template => template.icon === source.uiMetadata?.iconUrl
-      )
-    }
-
-    if (!match && source.name) {
-      match = templates.find(template => template.name === source.name)
-    }
-
-    return match
+    return (
+      templates.find(template => template.name === source.restTemplate) ||
+      (specUrl
+        ? templates.find(template =>
+            template.specs?.some(spec => spec.url === specUrl)
+          )
+        : undefined)
+    )
   }
 
   const resetEndpoints = () => {
@@ -260,7 +248,7 @@
       <div class="template-modal">
         <div class="endpoint-heading">
           <IntegrationIcon
-            iconUrl={templateIcon || datasource?.uiMetadata?.iconUrl}
+            iconUrl={templateIcon}
             integrationType={datasource?.source || IntegrationTypes.REST}
             schema={restIntegration}
             size="32"

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Queries/RestTemplateImportModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Queries/RestTemplateImportModal.svelte
@@ -27,7 +27,6 @@
     Datasource,
     ImportRestQueryRequest,
     QueryImportEndpoint,
-    RestTemplate,
   } from "@budibase/types"
 
   export let navigateDatasource = false

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Queries/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Queries/index.svelte
@@ -28,7 +28,8 @@
       ? QueryVerbRenderer
       : CapitaliseRenderer
   $: isRestDatasource = datasource?.source === "REST"
-  $: showImportButton = isRestDatasource && !datasource?.isRestTemplate
+  $: isTemplateDatasource = Boolean(datasource?.restTemplate)
+  $: showImportButton = isRestDatasource && !isTemplateDatasource
   $: createQueryLabel = isRestDatasource ? "Add action" : "Create new query"
 </script>
 
@@ -46,7 +47,7 @@
 
 {#if isRestDatasource}
   <Modal bind:this={restImportModal}>
-    {#if datasource?.isRestTemplate}
+    {#if isTemplateDatasource}
       <RestTemplateImportModal
         datasourceId={datasource._id}
         createDatasource={false}
@@ -65,7 +66,7 @@
     <Button
       cta
       on:click={() =>
-        datasource?.isRestTemplate
+        isTemplateDatasource
           ? restImportModal?.show()
           : $goto(`../../query/new/${datasource._id}`)}
     >

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/index.svelte
@@ -19,7 +19,6 @@
 
   let selectedPanel = $params.tab ?? null
   let panelOptions = []
-  let templateIcon
 
   $: datasource = $datasources.selected
   $: templateIcon = datasource?.restTemplate

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/index.svelte
@@ -2,6 +2,7 @@
   import { params } from "@roxi/routify"
   import { Tabs, Tab, Heading, Body, Layout } from "@budibase/bbui"
   import { datasources, integrations } from "@/stores/builder"
+  import { restTemplates } from "@/stores/builder/restTemplates"
   import IntegrationIcon from "@/components/backend/DatasourceNavigator/IntegrationIcon.svelte"
   import EditDatasourceConfig from "./_components/EditDatasourceConfig.svelte"
   import TablesPanel from "./_components/panels/Tables/index.svelte"
@@ -18,8 +19,14 @@
 
   let selectedPanel = $params.tab ?? null
   let panelOptions = []
+  let templateIcon
 
   $: datasource = $datasources.selected
+  $: templateIcon = datasource?.restTemplate
+    ? $restTemplates.templates.find(
+        template => template.name === datasource.restTemplate
+      )?.icon
+    : undefined
 
   $: isCloud = $admin.cloud
   $: isPostgres = datasource?.source === IntegrationTypes.POSTGRES
@@ -66,7 +73,7 @@
         <IntegrationIcon
           integrationType={datasource?.source}
           schema={$integrations?.[datasource?.source]}
-          iconUrl={datasource?.uiMetadata?.iconUrl}
+          iconUrl={templateIcon}
           size="26"
         />
         <Heading size="M">{$datasources.selected?.name}</Heading>

--- a/packages/builder/src/stores/builder/datasources.ts
+++ b/packages/builder/src/stores/builder/datasources.ts
@@ -10,6 +10,7 @@ import {
   DatasourceFeature,
   Integration,
   RestTemplateName,
+  RestTemplateSpecVersion,
   SourceName,
   Table,
   UIIntegration,
@@ -199,11 +200,13 @@ export class DatasourceStore extends DerivedBudiStore<
     config,
     name,
     restTemplate,
+    restTemplateVersion,
   }: {
     integration: UIIntegration
     config: Record<string, any>
     name?: string
     restTemplate?: RestTemplateName
+    restTemplateVersion?: RestTemplateSpecVersion
   }) {
     const count = this.sourceCount(integration.name)
     const nameModifier = count === 0 ? "" : ` ${count + 1}`
@@ -216,6 +219,7 @@ export class DatasourceStore extends DerivedBudiStore<
       plus: integration.plus && integration.name !== SourceName.REST,
       isSQL: integration.isSQL,
       ...(restTemplate && { restTemplate }),
+      ...(restTemplateVersion && { restTemplateVersion }),
     }
 
     const { valid, error } = await this.checkDatasourceValidity(

--- a/packages/builder/src/stores/builder/datasources.ts
+++ b/packages/builder/src/stores/builder/datasources.ts
@@ -9,6 +9,7 @@ import {
   Datasource,
   DatasourceFeature,
   Integration,
+  RestTemplateName,
   SourceName,
   Table,
   UIIntegration,
@@ -197,14 +198,12 @@ export class DatasourceStore extends DerivedBudiStore<
     integration,
     config,
     name,
-    uiMetadata,
-    isRestTemplate,
+    restTemplate,
   }: {
     integration: UIIntegration
     config: Record<string, any>
     name?: string
-    uiMetadata?: Datasource["uiMetadata"]
-    isRestTemplate?: boolean
+    restTemplate?: RestTemplateName
   }) {
     const count = this.sourceCount(integration.name)
     const nameModifier = count === 0 ? "" : ` ${count + 1}`
@@ -216,8 +215,7 @@ export class DatasourceStore extends DerivedBudiStore<
       name: name || `${integration.friendlyName}${nameModifier}`,
       plus: integration.plus && integration.name !== SourceName.REST,
       isSQL: integration.isSQL,
-      ...(uiMetadata && { uiMetadata }),
-      ...(isRestTemplate && { isRestTemplate: true }),
+      ...(restTemplate && { restTemplate }),
     }
 
     const { valid, error } = await this.checkDatasourceValidity(

--- a/packages/builder/src/stores/builder/restTemplates.ts
+++ b/packages/builder/src/stores/builder/restTemplates.ts
@@ -1,4 +1,4 @@
-import { RestTemplate } from "@budibase/types"
+import { RestTemplate, RestTemplateName } from "@budibase/types"
 import { BudiStore } from "../BudiStore"
 
 interface RestTemplatesState {
@@ -69,6 +69,13 @@ export class RestTemplatesStore extends BudiStore<RestTemplatesState> {
       templates = state.templates
     })()
     return templates
+  }
+
+  getByName(name?: RestTemplateName) {
+    if (!name) {
+      return undefined
+    }
+    return this.templates.find(template => template.name === name)
   }
 }
 

--- a/packages/builder/src/stores/builder/restTemplates.ts
+++ b/packages/builder/src/stores/builder/restTemplates.ts
@@ -13,8 +13,8 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
         "GitHub REST API for repositories, issues, pull requests, and actions",
       specs: [
         {
-          version: "latest",
-          url: "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.yaml",
+          version: "1.1.4",
+          url: "https://raw.githubusercontent.com/github/rest-api-description/refs/heads/main/descriptions/api.github.com/api.github.com.2022-11-28.yaml",
         },
       ],
       icon: "/builder/assets/rest-template-icons/github.svg",
@@ -25,8 +25,8 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
         "PagerDuty REST resources for services, incidents, and incident automation",
       specs: [
         {
-          version: "latest",
-          url: "https://raw.githubusercontent.com/stackql/stackql-provider-registry/main/providers/src/pagerduty/v00.00.00000/services/services.yaml",
+          version: "2.0.0",
+          url: "https://raw.githubusercontent.com/PagerDuty/api-schema/main/reference/REST/openapiv3.json",
         },
       ],
       icon: "/builder/assets/rest-template-icons/pagerduty.svg",
@@ -37,7 +37,7 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
         "The Slack Web API is an interface for querying information from and enacting change in a Slack workspace.",
       specs: [
         {
-          version: "v2",
+          version: "1.7.0",
           url: "https://api.slack.com/specs/openapi/v2/slack_web.json",
         },
       ],

--- a/packages/types/src/documents/workspace/datasource.ts
+++ b/packages/types/src/documents/workspace/datasource.ts
@@ -1,7 +1,7 @@
 import { Document } from "../document"
 import { SourceName } from "../../sdk"
 import { Table } from "./table"
-import { RestTemplateName } from "../../ui/rest"
+import { RestTemplateName, RestTemplateSpecVersion } from "../../ui/rest"
 
 export interface Datasource extends Document {
   type: string
@@ -15,6 +15,7 @@ export interface Datasource extends Document {
   plus?: boolean
   isSQL?: boolean
   restTemplate?: RestTemplateName
+  restTemplateVersion?: RestTemplateSpecVersion
   usesEnvironmentVariables?: boolean
   entities?: Record<string, Table>
 }

--- a/packages/types/src/documents/workspace/datasource.ts
+++ b/packages/types/src/documents/workspace/datasource.ts
@@ -1,10 +1,7 @@
 import { Document } from "../document"
 import { SourceName } from "../../sdk"
 import { Table } from "./table"
-
-export interface DatasourceUIMetadata {
-  iconUrl?: string
-}
+import { RestTemplateName } from "../../ui/rest"
 
 export interface Datasource extends Document {
   type: string
@@ -17,10 +14,9 @@ export interface Datasource extends Document {
   config?: Record<string, any>
   plus?: boolean
   isSQL?: boolean
-  isRestTemplate?: boolean
+  restTemplate?: RestTemplateName
   usesEnvironmentVariables?: boolean
   entities?: Record<string, Table>
-  uiMetadata?: DatasourceUIMetadata
 }
 
 export enum RestAuthType {

--- a/packages/types/src/ui/rest.ts
+++ b/packages/types/src/ui/rest.ts
@@ -1,11 +1,9 @@
-interface OpenAPI {
-  version:
-    | `v${number}`
-    | "latest"
-    | `${number}-${number}-${number}`
-    | `${number}.${number}`
+export interface RestTemplateSpec {
+  version: `${number}-${number}-${number}` | `${number}.${number}`
   url: string
 }
+
+export type RestTemplateSpecVersion = RestTemplateSpec["version"]
 
 export type RestTemplateName =
   | "GitHub"
@@ -16,6 +14,6 @@ export type RestTemplateName =
 export interface RestTemplate {
   name: RestTemplateName
   description: string
-  specs: OpenAPI[]
+  specs: RestTemplateSpec[]
   icon: string
 }

--- a/packages/types/src/ui/rest.ts
+++ b/packages/types/src/ui/rest.ts
@@ -7,8 +7,14 @@ interface OpenAPI {
   url: string
 }
 
+export type RestTemplateName =
+  | "GitHub"
+  | "PagerDuty"
+  | "Slack Web API"
+  | "Stripe"
+
 export interface RestTemplate {
-  name: string
+  name: RestTemplateName
   description: string
   specs: OpenAPI[]
   icon: string


### PR DESCRIPTION
## Description
We need to track rest template version in the datasource in case we need to upgrade. 

Removed uiMetadata and instead we get the icon and openapi spec url from the templates list via the `restTemplate` key. 

## Screenshots
<img width="568" height="443" alt="Screenshot 2025-11-13 at 17 42 10" src="https://github.com/user-attachments/assets/36c4978a-a0ba-46ad-bc7a-9f7a8968bd4b" />

