### PR TITLE
Fix navigation guard on APIs new

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/apis/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/_layout.svelte
@@ -75,9 +75,7 @@
   const APIS_BASE_ROUTE = "/builder/workspace/:application/apis"
 
   $: shouldRedirectToNew =
-    !hasRestDatasources &&
-    !$isActive("./new") &&
-    $isActive(APIS_BASE_ROUTE)
+    !hasRestDatasources && !$isActive("./new") && $isActive(APIS_BASE_ROUTE)
 
   $: if (shouldRedirectToNew) {
     $redirect("./new")

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/_layout.svelte
@@ -72,10 +72,15 @@
   )
   $: hasRestDatasources = restDatasources.length > 0
 
-  $: {
-    if (!hasRestDatasources && !$isActive("./new")) {
-      $redirect("./new")
-    }
+  const APIS_BASE_ROUTE = "/builder/workspace/:application/apis"
+
+  $: shouldRedirectToNew =
+    !hasRestDatasources &&
+    !$isActive("./new") &&
+    $isActive(APIS_BASE_ROUTE)
+
+  $: if (shouldRedirectToNew) {
+    $redirect("./new")
   }
 </script>
 

--- a/packages/builder/src/stores/builder/restTemplates.ts
+++ b/packages/builder/src/stores/builder/restTemplates.ts
@@ -1,5 +1,9 @@
 import { RestTemplate, RestTemplateName } from "@budibase/types"
 import { BudiStore } from "../BudiStore"
+import GitHubLogo from "assets/rest-template-icons/github.svg"
+import PagerDutyLogo from "assets/rest-template-icons/pagerduty.svg"
+import SlackLogo from "assets/rest-template-icons/slack.svg"
+import StripeLogo from "assets/rest-template-icons/stripe.svg"
 
 interface RestTemplatesState {
   templates: RestTemplate[]
@@ -17,7 +21,7 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
           url: "https://raw.githubusercontent.com/github/rest-api-description/refs/heads/main/descriptions/api.github.com/api.github.com.2022-11-28.yaml",
         },
       ],
-      icon: "/builder/assets/rest-template-icons/github.svg",
+      icon: GitHubLogo,
     },
     {
       name: "PagerDuty",
@@ -29,7 +33,7 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
           url: "https://raw.githubusercontent.com/PagerDuty/api-schema/main/reference/REST/openapiv3.json",
         },
       ],
-      icon: "/builder/assets/rest-template-icons/pagerduty.svg",
+      icon: PagerDutyLogo,
     },
     {
       name: "Slack Web API",
@@ -41,7 +45,7 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
           url: "https://api.slack.com/specs/openapi/v2/slack_web.json",
         },
       ],
-      icon: "/builder/assets/rest-template-icons/slack.svg",
+      icon: SlackLogo,
     },
     {
       name: "Stripe",
@@ -53,7 +57,7 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
           url: "https://raw.githubusercontent.com/APIs-guru/openapi-directory/refs/heads/main/APIs/stripe.com/2022-11-15/openapi.yaml",
         },
       ],
-      icon: "/builder/assets/rest-template-icons/stripe.svg",
+      icon: StripeLogo,
     },
   ],
 }


### PR DESCRIPTION
## Description
Fix the APIs layout redirect so /apis/new no longer traps navigation to other sections while still redirecting nested APIs routes when no REST datasources exist.

## Launchcontrol
Let builders leave the Add API page even when no REST datasources exist, while keeping the safeguard that sends API sub-routes back to creation.