### PR TITLE
Fix: api webhooks from singleimage nginx

### DIFF
--- a/hosting/single/nginx/nginx-default-site.conf
+++ b/hosting/single/nginx/nginx-default-site.conf
@@ -96,7 +96,7 @@ server {
 
     location /api/webhooks/ {
         # calls to webhooks are rate limited with bursting (accommodating for tests)
-        limit_req zone=webhooks burst=20 nodelay;
+        limit_req zone=webhooks burst=100 nodelay;
 
         # 120s timeout on API requests
         proxy_read_timeout 120s;

--- a/hosting/single/nginx/nginx-default-site.conf
+++ b/hosting/single/nginx/nginx-default-site.conf
@@ -95,8 +95,8 @@ server {
     }
 
     location /api/webhooks/ {
-        # calls to webhooks are rate limited
-        limit_req zone=webhooks nodelay;
+        # calls to webhooks are rate limited with bursting (accommodating for tests)
+        limit_req zone=webhooks burst=20 nodelay;
 
         # 120s timeout on API requests
         proxy_read_timeout 120s;

--- a/hosting/single/nginx/nginx-default-site.conf
+++ b/hosting/single/nginx/nginx-default-site.conf
@@ -96,7 +96,7 @@ server {
 
     location /api/webhooks/ {
         # calls to webhooks are rate limited with bursting (accommodating for tests)
-        limit_req zone=webhooks burst=100 nodelay;
+        limit_req zone=webhooks burst=200 nodelay;
 
         # 120s timeout on API requests
         proxy_read_timeout 120s;

--- a/packages/upgrade-tests/src/api/webhook.ts
+++ b/packages/upgrade-tests/src/api/webhook.ts
@@ -5,7 +5,7 @@ export class WebhookAPI {
   constructor(private client: BudibaseClient) {}
 
   async fetch(): Promise<Webhook[]> {
-    const { data } = await this.client.get<Webhook[]>("/api/webhooks")
+    const { data } = await this.client.get<Webhook[]>("/api/webhooks/")
     return data
   }
 


### PR DESCRIPTION
## Description
Upgrade tests are failing after introducing proxying for the webhooks API in the single image. This fixes the path for the webhook tests and sets up burst capacity for the same API in the single image.

## Addresses
- https://github.com/Budibase/budibase/actions/runs/19371838277/job/55430144649
