### PR TITLE
Separating modal actions ignore clicks outside and hide close button

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -7926,7 +7926,18 @@
       {
         "type": "boolean",
         "key": "ignoreClicksOutside",
-        "label": "Prevent manual closing",
+        "label": "Ignore clicks outside",
+        "defaultValue": false,
+        "dependsOn": {
+          "setting": "hideCloseIcon",
+          "value": true,
+          "invert": true
+        }
+      },
+      {
+        "type": "boolean",
+        "key": "hideCloseIcon",
+        "label": "Hide close button",
         "defaultValue": false
       },
       {

--- a/packages/client/src/components/app/Modal.svelte
+++ b/packages/client/src/components/app/Modal.svelte
@@ -8,6 +8,7 @@
 
   export let onClose
   export let ignoreClicksOutside
+  export let hideCloseIcon
   export let size
   let modal
 
@@ -30,6 +31,9 @@
   }
 
   $: open = $modalStore.contentId === $component.id
+
+  $: resolvedHideCloseIcon =
+    hideCloseIcon === undefined ? !!ignoreClicksOutside : hideCloseIcon
 
   const handleModalClose = async () => {
     if (onClose) {
@@ -56,12 +60,14 @@
   <Modal
     on:cancel={handleModalClose}
     bind:this={modal}
-    disableCancel={$builderStore.inBuilder || ignoreClicksOutside}
+    disableCancel={$builderStore.inBuilder ||
+      ignoreClicksOutside ||
+      resolvedHideCloseIcon}
     zIndex={2}
   >
     <div use:styleable={$component.styles} class={`modal-content ${size}`}>
       <div class="modal-header">
-        {#if !ignoreClicksOutside}
+        {#if !resolvedHideCloseIcon}
           <Icon
             color="var(--spectrum-global-color-gray-800)"
             name="x"


### PR DESCRIPTION
## Description
Customer feedback - adds an extra setting to prevent breaking current workflows.

## Addresses
- https://github.com/Budibase/budibase/issues/17265
- https://github.com/Budibase/budibase/pull/17266

## Launchcontrol
Customer feedback - adds an extra setting to prevent breaking current workflows.