### PR TITLE
Unify config tabs onto one page for REST queries

### DIFF
--- a/packages/builder/src/components/integration/KeyValueBuilder.svelte
+++ b/packages/builder/src/components/integration/KeyValueBuilder.svelte
@@ -39,12 +39,15 @@
   export let actionButtonDisabled: boolean = false
   export let compare = (option: O, value: O) => option === value
   export let context: any = null
+  export let lockedKeys: string[] = []
 
   let fields = Object.entries(object || {}).map(([name, value]) => ({
     name,
     value,
   }))
   let fieldActivity = buildFieldActivity(activity)
+  $: lockedKeySet = new Set((lockedKeys || []).filter(Boolean))
+  const isLocked = (name?: string) => (name ? lockedKeySet.has(name) : false)
 
   $: fullObject = fields.reduce<Record<string, string>>((acc, next) => {
     acc[next.name] = next.value
@@ -140,14 +143,18 @@
             field.name = e.detail
             changed()
           }}
-          disabled={readOnly}
+          disabled={readOnly || isLocked(field.name)}
           value={field.name}
           {allowJS}
           {allowHelpers}
           {context}
         />
       {:else}
-        <Input readonly={readOnly} bind:value={field.name} on:blur={changed} />
+        <Input
+          readonly={readOnly || isLocked(field.name)}
+          bind:value={field.name}
+          on:blur={changed}
+        />
       {/if}
       {#if isJsonArray(field.value)}
         <Select readonly={true} value="Array" options={["Array"]} />
@@ -183,9 +190,11 @@
       {#if toggle}
         <Toggle bind:value={fieldActivity[idx]} on:change={changed} />
       {/if}
-      {#if !readOnly}
-        <Icon hoverable name="x" on:click={() => deleteEntry(idx)} />
-      {/if}
+      <div class="delete-cell">
+        {#if !readOnly && !isLocked(field.name)}
+          <Icon hoverable name="x" on:click={() => deleteEntry(idx)} />
+        {/if}
+      </div>
       {#if menuItems?.length && showMenu}
         <ActionMenu>
           <div slot="control" class="control icon">
@@ -239,5 +248,10 @@
   }
   .control {
     margin-top: 4px;
+  }
+  .delete-cell {
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 </style>

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Authentication/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Authentication/index.svelte
@@ -7,7 +7,6 @@
 
   export let datasource
   export let updatedDatasource
-  let localUpdatedDatasource
   $: localUpdatedDatasource = cloneDeep(datasource ?? updatedDatasource)
 
   const updateAuthConfigs = async newAuthConfigs => {

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Authentication/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Authentication/index.svelte
@@ -2,20 +2,22 @@
   import RestAuthenticationBuilder from "./RestAuthenticationBuilder.svelte"
   import { cloneDeep } from "lodash/fp"
   import Panel from "../Panel.svelte"
-  import Tooltip from "../Tooltip.svelte"
   import { integrations } from "@/stores/builder"
   import { notifications } from "@budibase/bbui"
 
   export let datasource
-  $: updatedDatasource = cloneDeep(datasource)
+  export let updatedDatasource
+  let localUpdatedDatasource
+  $: localUpdatedDatasource = cloneDeep(datasource ?? updatedDatasource)
 
   const updateAuthConfigs = async newAuthConfigs => {
-    updatedDatasource.config.authConfigs = newAuthConfigs
+    localUpdatedDatasource.config.authConfigs = newAuthConfigs
 
+    // Auto-save authentication changes
     try {
-      await integrations.saveDatasource(updatedDatasource)
+      await integrations.saveDatasource(localUpdatedDatasource)
       notifications.success(
-        `Datasource ${updatedDatasource.name} updated successfully`
+        `Datasource ${localUpdatedDatasource.name} updated successfully`
       )
     } catch (error) {
       notifications.error(`Error saving datasource: ${error.message}`)
@@ -24,13 +26,8 @@
 </script>
 
 <Panel>
-  <Tooltip
-    slot="tooltip"
-    title="REST Authentication"
-    href="https://docs.budibase.com/docs/rest-authentication"
-  />
   <RestAuthenticationBuilder
     on:change={({ detail }) => updateAuthConfigs(detail)}
-    authConfigs={updatedDatasource.config.authConfigs}
+    authConfigs={localUpdatedDatasource.config.authConfigs}
   />
 </Panel>

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Headers.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Headers.svelte
@@ -6,38 +6,46 @@
     readableToRuntimeBinding,
     runtimeToReadableMap,
   } from "@/dataBinding"
-  import { cloneDeep } from "lodash/fp"
-  import SaveDatasourceButton from "./SaveDatasourceButton.svelte"
+  import { cloneDeep, isEqual } from "lodash/fp"
   import Panel from "./Panel.svelte"
-  import Tooltip from "./Tooltip.svelte"
 
   export let datasource
+  export let updatedDatasource
+  export let markDirty
   let restBindings = getRestBindings()
   let addHeader
 
-  $: updatedDatasource = cloneDeep(datasource)
+  // Use parent-provided updatedDatasource when available
+  let localUpdatedDatasource
+  $: localUpdatedDatasource = updatedDatasource ?? cloneDeep(datasource)
   $: parsedHeaders = runtimeToReadableMap(
     restBindings,
-    updatedDatasource?.config?.defaultHeaders
+    localUpdatedDatasource?.config?.defaultHeaders
   )
 
   const onDefaultHeaderUpdate = headers => {
     const flatHeaders = cloneDeep(headers).reduce((acc, entry) => {
-      acc[entry.name] = readableToRuntimeBinding(restBindings, entry.value)
+      const name = (entry?.name ?? "").toString().trim()
+      const valueRaw = entry?.value
+      const valueStr =
+        valueRaw == null ? "" : valueRaw.toString ? valueRaw.toString() : ""
+      const value = valueStr.trim()
+
+      if (name !== "" || value !== "") {
+        acc[name] = readableToRuntimeBinding(restBindings, entry.value)
+      }
       return acc
     }, {})
 
-    updatedDatasource.config.defaultHeaders = flatHeaders
+    const prev = localUpdatedDatasource.config.defaultHeaders || {}
+    if (!isEqual(prev, flatHeaders)) {
+      localUpdatedDatasource.config.defaultHeaders = flatHeaders
+      markDirty && markDirty()
+    }
   }
 </script>
 
 <Panel>
-  <SaveDatasourceButton slot="controls" {datasource} {updatedDatasource} />
-  <Tooltip
-    slot="tooltip"
-    title="REST Headers"
-    href="https://docs.budibase.com/docs/rest-queries#headers"
-  />
   <KeyValueBuilder
     bind:this={addHeader}
     object={parsedHeaders}

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Headers.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Headers.svelte
@@ -16,7 +16,6 @@
   let addHeader
 
   // Use parent-provided updatedDatasource when available
-  let localUpdatedDatasource
   $: localUpdatedDatasource = updatedDatasource ?? cloneDeep(datasource)
   $: parsedHeaders = runtimeToReadableMap(
     restBindings,

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Headers.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Headers.svelte
@@ -26,8 +26,7 @@
     const flatHeaders = cloneDeep(headers).reduce((acc, entry) => {
       const name = (entry?.name ?? "").toString().trim()
       const valueRaw = entry?.value
-      const valueStr =
-        valueRaw == null ? "" : valueRaw.toString ? valueRaw.toString() : ""
+      const valueStr = valueRaw?.toString?.() || ""
       const value = valueStr.trim()
 
       if (name !== "" || value !== "") {

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Queries/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Queries/index.svelte
@@ -2,7 +2,6 @@
   import { goto } from "@roxi/routify"
   import { Button, Table, Modal } from "@budibase/bbui"
   import { queries } from "@/stores/builder"
-  import QueryVerbRenderer from "@/components/common/renderers/QueryVerbRenderer.svelte"
   import CapitaliseRenderer from "@/components/common/renderers/CapitaliseRenderer.svelte"
   import RestImportButton from "./RestImportButton.svelte"
   import RestImportQueriesModal from "./RestImportQueriesModal.svelte"
@@ -10,7 +9,6 @@
   import Panel from "../Panel.svelte"
   import Tooltip from "../Tooltip.svelte"
   import ViewImportSelection from "@/components/backend/Datasources/TableImportSelection/ViewImportSelection.svelte"
-  import { IntegrationTypes } from "@/constants/backend"
 
   export let datasource
 
@@ -23,10 +21,6 @@
 
   $: supportsViews =
     datasource.source === "POSTGRES" || datasource.source === "MYSQL"
-  $: methodRenderer =
-    datasource?.source === IntegrationTypes.REST
-      ? QueryVerbRenderer
-      : CapitaliseRenderer
   $: isRestDatasource = datasource?.source === "REST"
   $: isTemplateDatasource = Boolean(datasource?.restTemplate)
   $: showImportButton = isRestDatasource && !isTemplateDatasource
@@ -72,6 +66,7 @@
     >
       {createQueryLabel}
     </Button>
+    <slot name="global-save" />
     {#if supportsViews}
       <Button secondary on:click={viewSelectionModal.show}>Fetch views</Button>
     {/if}
@@ -79,28 +74,34 @@
       <RestImportButton datasourceId={datasource._id} />
     {/if}
   </div>
-  <Tooltip
-    slot="tooltip"
-    title="Custom queries"
-    href="https://docs.budibase.com/docs/data-sources#custom-queries "
-  />
-  <Table
-    on:click={({ detail }) => $goto(`../../query/${detail._id}`)}
-    schema={{
-      name: {},
-      queryVerb: { displayName: "Method" },
-    }}
-    data={queryList}
-    allowEditColumns={false}
-    allowEditRows={false}
-    allowSelectRows={false}
-    customRenderers={[{ column: "queryVerb", component: methodRenderer }]}
-  />
+  <svelte:fragment slot="tooltip">
+    {#if !isRestDatasource}
+      <Tooltip
+        title="Custom queries"
+        href="https://docs.budibase.com/docs/data-sources#custom-queries "
+      />
+    {/if}
+  </svelte:fragment>
+  {#if !isRestDatasource}
+    <Table
+      on:click={({ detail }) => $goto(`../../query/${detail._id}`)}
+      schema={{
+        name: {},
+        queryVerb: { displayName: "Method" },
+      }}
+      data={queryList}
+      allowEditColumns={false}
+      allowEditRows={false}
+      allowSelectRows={false}
+      customRenderers={[{ column: "queryVerb", component: CapitaliseRenderer }]}
+    />
+  {/if}
 </Panel>
 
 <style>
   .controls {
     display: flex;
     gap: var(--spacing-m);
+    align-items: center;
   }
 </style>

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/SaveDatasourceButton.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/SaveDatasourceButton.svelte
@@ -5,8 +5,13 @@
 
   export let datasource
   export let updatedDatasource
+  export let onSaved
+  export let isDirty
 
-  $: hasChanged = !isEqual(datasource, updatedDatasource)
+  $: hasChanged =
+    typeof isDirty === "boolean"
+      ? isDirty
+      : !isEqual(datasource, updatedDatasource)
 
   const save = async () => {
     try {
@@ -14,6 +19,7 @@
       notifications.success(
         `Datasource ${updatedDatasource.name} updated successfully`
       )
+      onSaved?.()
     } catch (error) {
       notifications.error(`Error saving datasource: ${error.message}`)
     }

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Tooltip.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Tooltip.svelte
@@ -3,12 +3,18 @@
 
   export let title = ""
   export let href = null
+  export let showLabel = true
+
+  const ariaLabel = title || "More info"
 </script>
 
 <ActionButton
   quiet
   icon="question"
+  aria-label={ariaLabel}
   on:click={() => window.open(href, "_blank")}
 >
-  {title}
+  {#if showLabel}
+    {title}
+  {/if}
 </ActionButton>

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Variables/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Variables/index.svelte
@@ -15,7 +15,6 @@
 
   // Use parent-provided updatedDatasource when available
   let localUpdatedDatasource
-  let templateStaticVariableKeys = []
   $: localUpdatedDatasource = updatedDatasource ?? cloneDeep(datasource)
 
   $: queriesForDatasource = $queries.list.filter(

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Variables/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Variables/index.svelte
@@ -5,28 +5,49 @@
   import { getEnvironmentBindings } from "@/dataBinding"
   import { environment, licensing } from "@/stores/portal"
   import { queries } from "@/stores/builder"
-  import { cloneDeep } from "lodash/fp"
-  import SaveDatasourceButton from "../SaveDatasourceButton.svelte"
+  import { cloneDeep, isEqual } from "lodash/fp"
   import Panel from "../Panel.svelte"
-  import Tooltip from "../Tooltip.svelte"
   import { onMount } from "svelte"
 
   export let datasource
+  export let updatedDatasource
+  export let markDirty
 
-  $: updatedDatasource = cloneDeep(datasource)
+  // Use parent-provided updatedDatasource when available
+  let localUpdatedDatasource
+  let templateStaticVariableKeys = []
+  $: localUpdatedDatasource = updatedDatasource ?? cloneDeep(datasource)
 
   $: queriesForDatasource = $queries.list.filter(
     query => query.datasourceId === datasource?._id
   )
 
-  const handleChange = newUnparsedStaticVariables => {
-    const newStaticVariables = {}
-
-    newUnparsedStaticVariables.forEach(({ name, value }) => {
-      newStaticVariables[name] = value
+  const buildStaticVariablesObject = values => {
+    const next = {}
+    values.forEach(({ name, value }) => {
+      const key = (name ?? "").toString().trim()
+      const valStr = value == null ? "" : value.toString ? value.toString() : ""
+      const val = valStr.trim()
+      if (key !== "" || val !== "") {
+        next[key] = value
+      }
     })
+    return next
+  }
 
-    updatedDatasource.config.staticVariables = newStaticVariables
+  const handleStaticChange = newUnparsedStaticVariables => {
+    if (!localUpdatedDatasource) {
+      return
+    }
+    localUpdatedDatasource.config = localUpdatedDatasource.config || {}
+    const prev = localUpdatedDatasource.config.staticVariables || {}
+    const newStaticVariables = buildStaticVariablesObject(
+      newUnparsedStaticVariables
+    )
+    if (!isEqual(prev, newStaticVariables)) {
+      localUpdatedDatasource.config.staticVariables = newStaticVariables
+      markDirty && markDirty()
+    }
   }
 
   onMount(async () => {
@@ -39,13 +60,6 @@
 </script>
 
 <Panel>
-  <SaveDatasourceButton slot="controls" {datasource} {updatedDatasource} />
-  <Tooltip
-    slot="tooltip"
-    title="REST variables"
-    href="https://docs.budibase.com/docs/rest-variables"
-  />
-
   <Layout>
     <Layout noPadding gap="XS">
       <Heading size="S">Static</Heading>
@@ -53,8 +67,8 @@
         name="Variable"
         keyPlaceholder="Name"
         headings
-        object={updatedDatasource.config.staticVariables}
-        on:change={({ detail }) => handleChange(detail)}
+        object={localUpdatedDatasource?.config?.staticVariables || {}}
+        on:change={({ detail }) => handleStaticChange(detail)}
         bindings={$licensing.environmentVariablesEnabled
           ? getEnvironmentBindings()
           : []}

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Variables/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Variables/index.svelte
@@ -24,7 +24,7 @@
     const next = {}
     values.forEach(({ name, value }) => {
       const key = (name ?? "").toString().trim()
-      const valStr = value == null ? "" : value.toString ? value.toString() : ""
+      const valStr = value?.toString?.() || ""
       const val = valStr.trim()
       if (key !== "" || val !== "") {
         next[key] = value

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Variables/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/panels/Variables/index.svelte
@@ -14,7 +14,6 @@
   export let markDirty
 
   // Use parent-provided updatedDatasource when available
-  let localUpdatedDatasource
   $: localUpdatedDatasource = updatedDatasource ?? cloneDeep(datasource)
 
   $: queriesForDatasource = $queries.list.filter(

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/index.svelte
@@ -16,6 +16,29 @@
   import { helpers } from "@budibase/shared-core"
   import { admin } from "@/stores/portal"
   import { IntegrationTypes } from "@/constants/backend"
+  import Tooltip from "./_components/panels/Tooltip.svelte"
+  import SaveDatasourceButton from "./_components/panels/SaveDatasourceButton.svelte"
+  import { cloneDeep } from "lodash/fp"
+
+  const REST_PANEL_SECTIONS = [
+    { title: "", component: QueriesPanel },
+    {
+      title: "Authentication",
+      component: RestAuthenticationPanel,
+    },
+    {
+      title: "Headers",
+      component: RestHeadersPanel,
+    },
+    {
+      title: "Variables",
+      component: RestVariablesPanel,
+      tooltip: {
+        title: "REST variables",
+        href: "https://docs.budibase.com/docs/rest-variables",
+      },
+    },
+  ]
 
   let selectedPanel = $params.tab ?? null
   let panelOptions = []
@@ -29,9 +52,44 @@
 
   $: isCloud = $admin.cloud
   $: isPostgres = datasource?.source === IntegrationTypes.POSTGRES
+  $: isRestDatasource = datasource?.source === IntegrationTypes.REST
   $: getOptions(datasource)
 
+  // Central updated datasource state for REST config edits
+  let updatedDatasource
+  let restConfigDirty = false
+  $: if (
+    datasource &&
+    (!updatedDatasource || updatedDatasource._id !== datasource._id)
+  ) {
+    updatedDatasource = cloneDeep(datasource)
+    restConfigDirty = false
+  }
+
+  const markDirty = () => {
+    if (!updatedDatasource) {
+      return
+    }
+    restConfigDirty = true
+    // trigger reactivity for children like Save button
+    updatedDatasource = { ...updatedDatasource }
+  }
+
+  const handleRestConfigSaved = () => {
+    if (!updatedDatasource) {
+      return
+    }
+    restConfigDirty = false
+    updatedDatasource = cloneDeep(datasource ?? updatedDatasource)
+  }
+
   const getOptions = datasource => {
+    if (!datasource) {
+      panelOptions = []
+      selectedPanel = null
+      return
+    }
+
     if (datasource.plus) {
       // Google Sheets' integration definition specifies `relationships: false` as it doesn't support relationships like other plus datasources
       panelOptions =
@@ -41,17 +99,13 @@
       selectedPanel = panelOptions.includes(selectedPanel)
         ? selectedPanel
         : "Tables"
-    } else if (datasource.source === "REST") {
-      panelOptions = ["Queries", "Headers", "Authentication", "Variables"]
-      selectedPanel = panelOptions.includes(selectedPanel)
-        ? selectedPanel
-        : "Queries"
     } else {
-      panelOptions = ["Queries"]
-      selectedPanel = "Queries"
+      const isRest = datasource.source === "REST"
+      panelOptions = isRest ? [] : ["Queries"]
+      selectedPanel = isRest ? null : "Queries"
     }
     // always the last option for SQL
-    if (helpers.isSQL(datasource)) {
+    if (!isRestDatasource && helpers.isSQL(datasource)) {
       if (isCloud && isPostgres) {
         // We don't show the settings panel for Postgres on Budicloud because
         // it requires pg_dump to work and we don't want to enable shell injection
@@ -79,35 +133,70 @@
       </header>
     </Layout>
     <EditDatasourceConfig {datasource} />
-    <div class="tabs">
-      <Tabs size="L" noPadding noHorizPadding selected={selectedPanel}>
-        {#each panelOptions as panelOption}
-          <Tab
-            title={panelOption}
-            on:click={() => (selectedPanel = panelOption)}
-          />
+    {#if isRestDatasource}
+      <div class="rest-sections">
+        {#each REST_PANEL_SECTIONS as restPanel (restPanel.title)}
+          <div class="rest-section">
+            {#if restPanel.title}
+              <div class="rest-section__title">
+                <Heading size="S" class="rest-section__heading">
+                  {restPanel.title}
+                </Heading>
+                {#if restPanel.tooltip}
+                  <Tooltip
+                    title={restPanel.tooltip.title}
+                    href={restPanel.tooltip.href}
+                    showLabel={false}
+                  />
+                {/if}
+              </div>
+            {/if}
+            {#if restPanel.component === QueriesPanel}
+              <svelte:component this={restPanel.component} {datasource}>
+                <SaveDatasourceButton
+                  slot="global-save"
+                  {datasource}
+                  {updatedDatasource}
+                  isDirty={restConfigDirty}
+                  onSaved={handleRestConfigSaved}
+                />
+              </svelte:component>
+            {:else}
+              <svelte:component
+                this={restPanel.component}
+                {datasource}
+                {updatedDatasource}
+                {markDirty}
+              />
+            {/if}
+          </div>
         {/each}
-      </Tabs>
-    </div>
-
-    {#if selectedPanel === null}
-      <Body>loading...</Body>
-    {:else if selectedPanel === "Tables"}
-      <TablesPanel {datasource} />
-    {:else if selectedPanel === "Relationships"}
-      <RelationshipsPanel {datasource} />
-    {:else if selectedPanel === "Queries"}
-      <QueriesPanel {datasource} />
-    {:else if selectedPanel === "Headers"}
-      <RestHeadersPanel {datasource} />
-    {:else if selectedPanel === "Authentication"}
-      <RestAuthenticationPanel {datasource} />
-    {:else if selectedPanel === "Variables"}
-      <RestVariablesPanel {datasource} />
-    {:else if selectedPanel === "Settings"}
-      <SettingsPanel {datasource} />
+      </div>
     {:else}
-      <Body>Something went wrong</Body>
+      <div class="tabs">
+        <Tabs size="L" noPadding noHorizPadding selected={selectedPanel}>
+          {#each panelOptions as panelOption}
+            <Tab
+              title={panelOption}
+              on:click={() => (selectedPanel = panelOption)}
+            />
+          {/each}
+        </Tabs>
+      </div>
+
+      {#if selectedPanel === null}
+        <Body>loading...</Body>
+      {:else if selectedPanel === "Tables"}
+        <TablesPanel {datasource} />
+      {:else if selectedPanel === "Relationships"}
+        <RelationshipsPanel {datasource} />
+      {:else if selectedPanel === "Queries"}
+        <QueriesPanel {datasource} />
+      {:else if selectedPanel === "Settings"}
+        <SettingsPanel {datasource} />
+      {:else}
+        <Body>Something went wrong</Body>
+      {/if}
     {/if}
   </Layout>
 </section>
@@ -124,5 +213,23 @@
     gap: var(--spacing-l);
     align-items: center;
     margin-bottom: 12px;
+  }
+
+  .rest-sections {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xxl);
+    margin-top: var(--spacing-xl);
+  }
+
+  .rest-section {
+    margin-bottom: 35px;
+  }
+
+  .rest-section__title {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s);
+    margin-bottom: var(--spacing-m);
   }
 </style>


### PR DESCRIPTION
## Description
The UI piece of https://github.com/Budibase/budibase/pull/17398

This unifies the REST datasource config onto one page, and places *Authentication* into a prime location.

<img src="https://private-user-images.githubusercontent.com/101575380/514496263-68de8d56-1160-4637-a2f9-70de6396a4d3.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjM1NDU5NDIsIm5iZiI6MTc2MzU0NTY0MiwicGF0aCI6Ii8xMDE1NzUzODAvNTE0NDk2MjYzLTY4ZGU4ZDU2LTExNjAtNDYzNy1hMmY5LTcwZGU2Mzk2YTRkMy5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUxMTE5JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MTExOVQwOTQ3MjJaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0xZGJjYWZiNTUxNzdiMDcwNDYxNjQ1NTY0MDkwNmQ2Y2NiYjE3NTZhNThhNTJlM2U1ZTZiYzAzNWYzNzJlNDJhJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.Bjc1u0mXkkLh8OIAX3HiqKy8V3osbLRc4bxfj9KoeKg" />
