### PR TITLE
[BUDI-9885] Fix inline content disposition handling

### DIFF
--- a/packages/server/src/integrations/tests/restUtils.spec.ts
+++ b/packages/server/src/integrations/tests/restUtils.spec.ts
@@ -36,6 +36,11 @@ describe("getAttachmentHeaders", () => {
     expect(contentDisposition).toBe(`inline; filename="report.pdf"`)
   })
 
+  it("should leave inline content disposition without parameters alone", () => {
+    const { contentDisposition } = getAttachmentHeaders(headers("inline"))
+    expect(contentDisposition).toBe("inline")
+  })
+
   it("should handle an image", () => {
     const { contentDisposition } = getAttachmentHeaders(
       headers("", "image/png"),

--- a/packages/server/src/integrations/utils/restUtils.ts
+++ b/packages/server/src/integrations/utils/restUtils.ts
@@ -12,15 +12,22 @@ export function getAttachmentHeaders(
   // all content-disposition headers should be format disposition-type; parameters
   // but some APIs do not provide a type, causing the parse below to fail - add one to fix this
   if (contentDisposition) {
-    const quotesRegex = /"(?:[^"\\]|\\.)*"|;/g
-    let match: RegExpMatchArray | null = null,
-      found = false
-    while ((match = quotesRegex.exec(contentDisposition)) !== null) {
+    const tokenRegex = /"(?:[^"\\]|\\.)*"|[;=]/g
+    let match: RegExpMatchArray | null = null
+    let hasSeparator = false
+    let hasParameters = false
+
+    while ((match = tokenRegex.exec(contentDisposition)) !== null) {
       if (match[0] === ";") {
-        found = true
+        hasSeparator = true
+        break
+      }
+      if (match[0] === "=") {
+        hasParameters = true
       }
     }
-    if (!found) {
+
+    if (!hasSeparator && hasParameters) {
       return {
         contentDisposition: `attachment; ${contentDisposition}`,
         contentType,

--- a/packages/server/src/integrations/utils/restUtils.ts
+++ b/packages/server/src/integrations/utils/restUtils.ts
@@ -13,6 +13,7 @@ export function getAttachmentHeaders(
   // but some APIs do not provide a type, causing the parse below to fail - add one to fix this
   if (contentDisposition) {
     const tokenRegex = /"(?:[^"\\]|\\.)*"|[;=]/g
+    // Example match: parses "filename=\"report.pdf\"; size=123" into the quoted filename token and the ; or = separators
     let match: RegExpMatchArray | null = null
     let hasSeparator = false
     let hasParameters = false


### PR DESCRIPTION
## Description
- guard getAttachmentHeaders so we only prefix with attachment when a content-disposition string exposes parameters without a disposition type (e.g. filename only)
- add regression coverage ensuring bare inline disposition values remain unchanged
- yarn test src/integrations/tests/restUtils.spec.ts

## Addresses
- https://github.com/Budibase/budibase/issues/17416

## Screenshots
<img width="911" height="1014" alt="fix" src="https://github.com/user-attachments/assets/0bf9f60b-5dad-41d5-9cfd-695aca15837b" />

## Launchcontrol
Fixes REST API integrations against sources that send "inline" content-disposition headers by preventing them from being rewritten into invalid values.
