### PR TITLE
[BUDI-9794] Keep filter binding drawer values

### DIFF
--- a/packages/frontend-core/src/components/FilterField.svelte
+++ b/packages/frontend-core/src/components/FilterField.svelte
@@ -117,15 +117,16 @@
 
   /**
    * Converts arrays into strings. The CodeEditor expects a string or encoded JS
-   * FilterValueType.VALUE values are emptied when first loaded in the binding drawer.
+   * value, so normalise everything to a readable string but preserve whatever the
+   * user last entered when reopening the drawer.
    *
    * @param{string} fieldValue
    */
   const toDrawerValue = fieldValue => {
-    if (filter.valueType == FilterValueType.VALUE) {
-      return ""
-    }
-    return Array.isArray(fieldValue) ? fieldValue.join(",") : readableValue
+    const normalised = Array.isArray(fieldValue)
+      ? fieldValue.join(",")
+      : readableValue
+    return normalised ?? ""
   }
 </script>
 


### PR DESCRIPTION
## Description
- keep literal filter values when opening the bindings drawer so saved inputs remain visible

## Addresses
- https://github.com/Budibase/budibase/issues/17226

## Screenshots
- N/A (behavioural fix)

## Launchcontrol
Filter bindings drawer now starts with the saved value instead of an empty editor when using literal inputs.
