### PR TITLE
Propagate table renames in dev over to prod correctly

### DIFF
--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -163,7 +163,7 @@ async function applyPendingColumnRenames(
           const updatedRows = docs.map(original => {
             const row = cloneDeep(original) as Row
             for (const rename of pending) {
-              if (Object.prototype.hasOwnProperty.call(row, rename.old)) {
+              if (Object.hasOwn(row, rename.old)) {
                 row[rename.updated] = row[rename.old]
                 delete row[rename.old]
               }

--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -134,18 +134,18 @@ async function applyPendingColumnRenames(workspaceId: string) {
       if (table._deleted) {
         continue
       }
-      const pending = table.pendingRenames
-      if (!pending?.length) {
+      const pendingColumnRenames = table.pendingColumnRenames
+      if (!pendingColumnRenames?.length) {
         continue
       }
 
-      for (const rename of pending) {
+      for (const rename of pendingColumnRenames) {
         await sdk.tables.update(table, rename)
       }
 
       const updatedTable: Table = {
         ...table,
-        pendingRenames: [],
+        pendingColumnRenames: [],
       }
       await db.put(updatedTable)
     }
@@ -161,12 +161,12 @@ async function clearPendingColumnRenames(workspaceId: string) {
       if (table._deleted) {
         continue
       }
-      if (!table.pendingRenames?.length) {
+      if (!table.pendingColumnRenames?.length) {
         continue
       }
       const updatedTable: Table = {
         ...table,
-        pendingRenames: [],
+        pendingColumnRenames: [],
       }
       await db.put(updatedTable)
     }

--- a/packages/server/src/api/controllers/table/utils.ts
+++ b/packages/server/src/api/controllers/table/utils.ts
@@ -444,6 +444,15 @@ export async function checkForViewUpdates(
   }
 }
 
+export function mergePendingColumnRenames(
+  existing: RenameColumn[],
+  renaming: RenameColumn
+) {
+  const pending = existing ? [...existing] : []
+  pending.push(renaming)
+  return pending
+}
+
 export function generateForeignKey(
   column: RelationshipFieldMetadata,
   relatedTable: Table

--- a/packages/server/src/api/controllers/table/utils.ts
+++ b/packages/server/src/api/controllers/table/utils.ts
@@ -74,7 +74,11 @@ export async function checkForColumnUpdates(
     updatedRows = rawRows.map((row: any) => {
       row = cloneDeep(row)
       if (columnRename) {
-        row[columnRename.updated] = row[columnRename.old]
+        const hasUpdated = row[columnRename.updated] !== undefined
+        const hasOld = row[columnRename.old] !== undefined
+        if (!hasUpdated && hasOld) {
+          row[columnRename.updated] = row[columnRename.old]
+        }
         delete row[columnRename.old]
       } else if (deletedColumns.length !== 0) {
         deletedColumns.forEach((colName: any) => delete row[colName])

--- a/packages/server/src/api/routes/tests/deploy.spec.ts
+++ b/packages/server/src/api/routes/tests/deploy.spec.ts
@@ -506,6 +506,9 @@ describe("/api/deploy", () => {
       },
     }
 
+    // casting to any here because TS can't infer the description property properly.
+    delete (renamedSchema as any).description
+
     const renamedTable = await config.api.table.save({
       ...table,
       schema: renamedSchema,

--- a/packages/server/src/api/routes/tests/deploy.spec.ts
+++ b/packages/server/src/api/routes/tests/deploy.spec.ts
@@ -488,4 +488,44 @@ describe("/api/deploy", () => {
 
     expect(prodRowAfterPublish[formulaFieldName]).toBe(6)
   })
+
+  it("migrates production row data when a column is renamed in development", async () => {
+    const table = await config.api.table.save(basicTable())
+    await config.api.row.save(table._id!, {
+      name: "Test Row",
+      description: "original value",
+    })
+
+    await config.api.workspace.publish(config.devWorkspace!.appId)
+
+    const renamedSchema = {
+      ...table.schema,
+      details: {
+        ...table.schema.description,
+        name: "details",
+      },
+    }
+
+    const renamedTable = await config.api.table.save({
+      ...table,
+      schema: renamedSchema,
+      _rename: { old: "description", updated: "details" },
+    })
+
+    const devRows = await config.api.row.search(renamedTable._id!, {
+      query: {},
+    })
+    expect(devRows.rows[0].details).toBe("original value")
+
+    await config.api.workspace.publish(config.devWorkspace!.appId)
+
+    await config.withProdApp(async () => {
+      const prodRows = await config.api.row.search(renamedTable._id!, {
+        query: {},
+      })
+
+      expect(prodRows.rows[0].details).toBe("original value")
+      expect(prodRows.rows[0].description).toBeUndefined()
+    })
+  })
 })

--- a/packages/server/src/api/routes/tests/workspace.spec.ts
+++ b/packages/server/src/api/routes/tests/workspace.spec.ts
@@ -1291,6 +1291,46 @@ describe("/applications", () => {
         expect(prodRole!.name).toBe("TestRole")
       })
     })
+
+    it.only("should migrate production row data when a column is renamed in development", async () => {
+      const table = await config.api.table.save(basicTable())
+      await config.api.row.save(table._id!, {
+        name: "Test Row",
+        description: "original value",
+      })
+
+      await config.publish()
+
+      const renamedSchema = {
+        ...table.schema,
+        details: {
+          ...table.schema.description,
+          name: "details",
+        },
+      }
+
+      const renamedTable = await config.api.table.save({
+        ...table,
+        schema: renamedSchema,
+        _rename: { old: "description", updated: "details" },
+      })
+
+      const devRows = await config.api.row.search(renamedTable._id!, {
+        query: {},
+      })
+      expect(devRows.rows[0].details).toBe("original value")
+
+      await config.api.workspace.publish(config.getDevWorkspaceId())
+
+      await config.withProdApp(async () => {
+        const prodRows = await config.api.row.search(renamedTable._id!, {
+          query: {},
+        })
+
+        expect(prodRows.rows[0].details).toBe("original value")
+        expect(prodRows.rows[0].description).toBeUndefined()
+      })
+    })
   })
 
   describe("manage client library version", () => {

--- a/packages/server/src/api/routes/tests/workspace.spec.ts
+++ b/packages/server/src/api/routes/tests/workspace.spec.ts
@@ -1291,46 +1291,6 @@ describe("/applications", () => {
         expect(prodRole!.name).toBe("TestRole")
       })
     })
-
-    it.only("should migrate production row data when a column is renamed in development", async () => {
-      const table = await config.api.table.save(basicTable())
-      await config.api.row.save(table._id!, {
-        name: "Test Row",
-        description: "original value",
-      })
-
-      await config.publish()
-
-      const renamedSchema = {
-        ...table.schema,
-        details: {
-          ...table.schema.description,
-          name: "details",
-        },
-      }
-
-      const renamedTable = await config.api.table.save({
-        ...table,
-        schema: renamedSchema,
-        _rename: { old: "description", updated: "details" },
-      })
-
-      const devRows = await config.api.row.search(renamedTable._id!, {
-        query: {},
-      })
-      expect(devRows.rows[0].details).toBe("original value")
-
-      await config.api.workspace.publish(config.getDevWorkspaceId())
-
-      await config.withProdApp(async () => {
-        const prodRows = await config.api.row.search(renamedTable._id!, {
-          query: {},
-        })
-
-        expect(prodRows.rows[0].details).toBe("original value")
-        expect(prodRows.rows[0].description).toBeUndefined()
-      })
-    })
   })
 
   describe("manage client library version", () => {

--- a/packages/types/src/documents/workspace/table/table.ts
+++ b/packages/types/src/documents/workspace/table/table.ts
@@ -27,6 +27,7 @@ export interface Table extends Document {
   created?: boolean
   rowHeight?: number
   aiGenerated?: boolean
+  pendingRenames?: RenameColumn[]
 }
 
 export interface TableRequest extends Table {

--- a/packages/types/src/documents/workspace/table/table.ts
+++ b/packages/types/src/documents/workspace/table/table.ts
@@ -27,7 +27,7 @@ export interface Table extends Document {
   created?: boolean
   rowHeight?: number
   aiGenerated?: boolean
-  pendingRenames?: RenameColumn[]
+  pendingColumnRenames?: RenameColumn[]
 }
 
 export interface TableRequest extends Table {


### PR DESCRIPTION
## Description
We no longer replicate data from dev -> prod. So whenever a column name got updated in prod, the table schema got updated with the new column name, but the row documents didn't leading to disappearing 

## Addresses
#17400 

## Launchcontrol
- Fixes an issue where renaming columns in dev would lead to data dissapearing in production. 