### PR TITLE
remove Datasource.static prefix when saving rest template static vars

### DIFF
--- a/packages/server/src/api/controllers/query/import/sources/openapi3.ts
+++ b/packages/server/src/api/controllers/query/import/sources/openapi3.ts
@@ -307,7 +307,7 @@ export class OpenAPI3 extends OpenAPISource {
             variableName
           )
           const defaultValue = hasStaticVariable
-            ? `{{ Datasource.Static.${variableName} }}`
+            ? `{{ ${variableName} }}`
             : (variable?.default ?? "")
           ensureParameter(variableName, defaultValue)
         }

--- a/packages/server/src/api/controllers/query/import/sources/tests/openapi3/openapi3.spec.js
+++ b/packages/server/src/api/controllers/query/import/sources/tests/openapi3/openapi3.spec.js
@@ -163,11 +163,11 @@ describe("OpenAPI3 Import", () => {
       expect.arrayContaining([
         {
           name: "subdomain",
-          default: "{{ Datasource.Static.subdomain }}",
+          default: "{{ subdomain }}",
         },
         {
           name: "domain",
-          default: "{{ Datasource.Static.domain }}",
+          default: "{{ domain }}",
         },
       ])
     )

--- a/packages/server/src/api/routes/tests/queries/rest.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/rest.spec.ts
@@ -674,7 +674,7 @@ describe("rest", () => {
       parameters: [
         {
           name: "localDomain",
-          default: "{{ Datasource.Static.companyDomain }}",
+          default: "{{ companyDomain }}",
         },
       ],
       queryVerb: "read",
@@ -714,7 +714,7 @@ describe("rest", () => {
       parameters: [
         {
           name: "companyDomain",
-          default: "{{ Datasource.Static.companyDomain }}",
+          default: "{{ companyDomain }}",
         },
       ],
       queryVerb: "read",

--- a/packages/server/src/threads/query.ts
+++ b/packages/server/src/threads/query.ts
@@ -396,9 +396,8 @@ class QueryRunner {
     const cleanedBinding = block
       .slice(braceLength, -braceLength)
       .replace(/\s+/g, "")
-    const binding = cleanedBinding.replace(/^Datasource\.Static\./i, "")
     const target = staticBindingName.replace(/\s+/g, "")
-    return binding === target
+    return cleanedBinding === target
   }
 }
 


### PR DESCRIPTION
## Description
Fix to save static variables for REST Templates in the same manner that they are saved for Custom REST queries. 

Relates to this comment: https://github.com/Budibase/budibase/pull/17444#discussion_r2546575614