### PR TITLE
Agent configuration screen

### DIFF
--- a/packages/backend-core/src/docIds/ids.ts
+++ b/packages/backend-core/src/docIds/ids.ts
@@ -125,8 +125,8 @@ export const generateAgentID = () => {
   return `${DocumentType.AGENT}${SEPARATOR}${newid()}`
 }
 
-export const generateAgentChatID = () => {
-  return `${DocumentType.AGENT_CHAT}${SEPARATOR}${newid()}`
+export const generateAgentChatID = (agentId: string) => {
+  return `${DocumentType.AGENT_CHAT}${SEPARATOR}${DocumentType.AGENT}${SEPARATOR}${agentId}${SEPARATOR}${newid()}`
 }
 
 export const generateAgentToolSourceID = () => {

--- a/packages/bbui/src/Button/Button.svelte
+++ b/packages/bbui/src/Button/Button.svelte
@@ -14,6 +14,7 @@
   export let overBackground = false
   export let quiet = false
   export let icon = undefined
+  export let iconColor = undefined
   export let active = false
   export let tooltip = undefined
   export let newStyles = true
@@ -50,7 +51,7 @@
     {/if}
     {#if icon}
       <span class="icon">
-        <Icon name={icon} size={size.toUpperCase()} />
+        <Icon name={icon} size={size.toUpperCase()} color={iconColor} />
       </span>
     {/if}
     {#if $$slots && !reverse}

--- a/packages/builder/src/pages/builder/workspace/[application]/_components/NoResults.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/NoResults.svelte
@@ -12,6 +12,7 @@
   export let onCtaClick: () => void
   export let ctaText: string
   export let resourceType: `${ResourceType}`
+  export let hideCta: boolean = false
 
   const iconByType = {
     [ResourceType.App]: "browser",
@@ -35,7 +36,9 @@
   </div>
   <slot />
 
-  <Button cta on:click={onCtaClick}>{ctaText}</Button>
+  {#if !hideCta}
+    <Button cta on:click={onCtaClick}>{ctaText}</Button>
+  {/if}
 </Layout>
 
 <style>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/AgentCard.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/AgentCard.svelte
@@ -2,15 +2,23 @@
   import FavouriteResourceButton from "@/pages/builder/_components/FavouriteResourceButton.svelte"
   import PublishStatusBadge from "@/components/common/PublishStatusBadge.svelte"
   import { Body, Icon, TooltipPosition } from "@budibase/bbui"
-  import type { Agent, WorkspaceFavourite } from "@budibase/types"
+  import type { Agent, WorkspaceFavourite, User } from "@budibase/types"
   import { PublishResourceState } from "@budibase/types"
   import { url } from "@roxi/routify"
+  import { users } from "@/stores/portal/users"
+  import { helpers } from "@budibase/shared-core"
 
   export let agent: Agent
   export let index: number
   export let isHighlighted: boolean = false
   export let favourite: WorkspaceFavourite
   export let onContextMenu: (_e: MouseEvent, _agent: Agent) => void
+
+  let userName = "Created by Budibase"
+
+  $: iconName = getAgentIcon(agent)
+  $: iconColor = getAgentIconColor(agent, index)
+  $: loadUserName(agent?.createdBy)
 
   const getAgentIcon = (agent: Agent) => {
     return agent.icon || "SideKick"
@@ -30,8 +38,19 @@
     return colors[index % colors.length]
   }
 
-  $: iconName = getAgentIcon(agent)
-  $: iconColor = getAgentIconColor(agent, index)
+  async function loadUserName(createdBy: string | undefined) {
+    if (!createdBy) {
+      userName = "Created by Budibase"
+      return
+    }
+
+    try {
+      const user = await users.get(createdBy)
+      userName = helpers.getUserLabel(user as User)
+    } catch {
+      userName = "Created by Budibase"
+    }
+  }
 </script>
 
 <a
@@ -65,7 +84,7 @@
         <Body weight="500" size="S">{agent.name}</Body>
       </div>
       <div class="card-creator">
-        <Body size="XS">Created by Budibase</Body>
+        <Body size="XS">{userName}</Body>
       </div>
     </div>
     <div class="card-status">

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/AgentCard.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/AgentCard.svelte
@@ -101,12 +101,10 @@
   .agent-card:hover {
     transform: translateY(-2px);
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
-    border-color: var(--agent-accent);
     background-color: rgba(255, 255, 255, 0.01);
   }
 
   .agent-card.active {
-    border-color: var(--agent-accent);
     box-shadow: 0 0 0 1px
       color-mix(in srgb, var(--agent-accent) 40%, transparent);
   }

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/AgentCard.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/AgentCard.svelte
@@ -80,7 +80,6 @@
 
 <style>
   .agent-card {
-    --agent-accent: var(--spectrum-global-color-gray-400);
     background: var(--spectrum-alias-background-color-primary);
     border: 1px solid var(--spectrum-global-color-gray-300);
     border-radius: var(--border-radius-l);
@@ -105,8 +104,7 @@
   }
 
   .agent-card.active {
-    box-shadow: 0 0 0 1px
-      color-mix(in srgb, var(--agent-accent) 40%, transparent);
+    box-shadow: 0 0 0 1px;
   }
 
   .card-actions {

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/AgentCard.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/AgentCard.svelte
@@ -12,11 +12,14 @@
   export let favourite: WorkspaceFavourite
   export let onContextMenu: (_e: MouseEvent, _agent: Agent) => void
 
-  const getAgentIcon = (_agent: Agent) => {
-    return "SideKick"
+  const getAgentIcon = (agent: Agent) => {
+    return agent.icon || "SideKick"
   }
 
   const getAgentIconColor = (agent: Agent, index: number) => {
+    if (agent.iconColor) {
+      return agent.iconColor
+    }
     const colors = [
       "#6366F1", // purple
       "#F59E0B", // orange
@@ -34,7 +37,7 @@
 <a
   class="agent-card"
   style={`--agent-accent:${iconColor};`}
-  href={$url(`./${agent._id}${agent.live ? "" : "/config"}`)}
+  href={$url(`./${agent._id}/config`)}
   on:contextmenu={e => onContextMenu(e, agent)}
   class:active={isHighlighted}
 >

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/AgentCard.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/AgentCard.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+  import FavouriteResourceButton from "@/pages/builder/_components/FavouriteResourceButton.svelte"
+  import PublishStatusBadge from "@/components/common/PublishStatusBadge.svelte"
+  import { Body, Icon, TooltipPosition } from "@budibase/bbui"
+  import type { Agent, WorkspaceFavourite } from "@budibase/types"
+  import { PublishResourceState } from "@budibase/types"
+  import { url } from "@roxi/routify"
+
+  export let agent: Agent
+  export let index: number
+  export let isHighlighted: boolean = false
+  export let favourite: WorkspaceFavourite
+  export let onContextMenu: (_e: MouseEvent, _agent: Agent) => void
+
+  const getAgentIcon = (_agent: Agent) => {
+    return "SideKick"
+  }
+
+  const getAgentIconColor = (agent: Agent, index: number) => {
+    const colors = [
+      "#6366F1", // purple
+      "#F59E0B", // orange
+      "#10B981", // green
+      "#8B5CF6", // purple
+      "#EF4444", // red
+    ]
+    return colors[index % colors.length]
+  }
+
+  $: iconName = getAgentIcon(agent)
+  $: iconColor = getAgentIconColor(agent, index)
+</script>
+
+<a
+  class="agent-card"
+  style={`--agent-accent:${iconColor};`}
+  href={$url(`./${agent._id}${agent.live ? "" : "/config"}`)}
+  on:contextmenu={e => onContextMenu(e, agent)}
+  class:active={isHighlighted}
+>
+  <div class="card-actions">
+    <div class="ctx-btn">
+      <Icon
+        name="dots-three"
+        size="M"
+        hoverable
+        on:click={e => onContextMenu(e, agent)}
+      />
+    </div>
+    <FavouriteResourceButton
+      {favourite}
+      position={TooltipPosition.Left}
+      noWrap
+    />
+  </div>
+  <div class="card-body">
+    <div class="card-icon">
+      <Icon name={iconName} size="XL" color={iconColor} />
+    </div>
+    <div class="card-content">
+      <div class="card-name">
+        <Body weight="500" size="S">{agent.name}</Body>
+      </div>
+      <div class="card-creator">
+        <Body size="XS">Created by Budibase</Body>
+      </div>
+    </div>
+    <div class="card-status">
+      <PublishStatusBadge
+        status={agent.live
+          ? PublishResourceState.PUBLISHED
+          : PublishResourceState.DISABLED}
+      />
+    </div>
+  </div>
+</a>
+
+<style>
+  .agent-card {
+    --agent-accent: var(--spectrum-global-color-gray-400);
+    background: var(--spectrum-alias-background-color-primary);
+    border: 1px solid var(--spectrum-global-color-gray-300);
+    border-radius: var(--border-radius-l);
+    padding: var(--spacing-m);
+    display: flex;
+    flex-direction: column;
+    text-decoration: none;
+    color: var(--text-color);
+    transition:
+      transform 130ms ease-out,
+      box-shadow 130ms ease-out,
+      border-color 130ms ease-out,
+      background-color 130ms ease-out;
+    position: relative;
+    min-height: 140px;
+  }
+
+  .agent-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+    border-color: var(--agent-accent);
+    background-color: rgba(255, 255, 255, 0.01);
+  }
+
+  .agent-card.active {
+    border-color: var(--agent-accent);
+    box-shadow: 0 0 0 1px
+      color-mix(in srgb, var(--agent-accent) 40%, transparent);
+  }
+
+  .card-actions {
+    position: absolute;
+    top: var(--spacing-m);
+    right: var(--spacing-m);
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    opacity: 0;
+    transition: opacity 130ms ease-out;
+  }
+
+  .agent-card:hover .card-actions {
+    opacity: 1;
+  }
+
+  .ctx-btn {
+    display: flex;
+    align-items: center;
+  }
+
+  .card-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-s);
+    flex: 1;
+  }
+
+  .card-icon {
+    width: 34px;
+    height: 34px;
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: color-mix(in srgb, var(--agent-accent) 18%, transparent);
+  }
+
+  .card-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+    flex: 1;
+  }
+
+  .card-name {
+    font-weight: 600;
+    color: var(--spectrum-global-color-gray-900);
+  }
+
+  .card-creator {
+    color: var(--spectrum-global-color-gray-600);
+  }
+
+  .card-status {
+    display: flex;
+    align-items: center;
+    margin-top: auto;
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/AgentModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/AgentModal.svelte
@@ -26,8 +26,10 @@
     const newAgent = await agentsStore.createAgent({
       name: draft.name,
       aiconfig: aiConfig,
+      live: false,
     })
-    $goto(`./${newAgent._id}`)
+    modal.hide()
+    $goto(`./${newAgent._id}/config`)
   }
 
   onMount(() => {

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/AgentToolConfigModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/AgentToolConfigModal.svelte
@@ -1,0 +1,390 @@
+<script lang="ts">
+  import {
+    Body,
+    Heading,
+    Icon,
+    Input,
+    Modal,
+    ModalContent,
+    TextArea,
+    Toggle,
+    notifications,
+  } from "@budibase/bbui"
+  import type {
+    AgentToolSource,
+    CreateToolSourceRequest,
+    AgentToolSourceWithTools,
+  } from "@budibase/types"
+  import { agentsStore } from "@/stores/portal"
+  import { createEventDispatcher, type ComponentType } from "svelte"
+  import BambooHRLogo from "../logos/BambooHR.svelte"
+  import BudibaseLogo from "../logos/Budibase.svelte"
+  import ConfluenceLogo from "../logos/Confluence.svelte"
+  import GithubLogo from "../logos/Github.svelte"
+
+  const Logos: Record<string, ComponentType> = {
+    BUDIBASE: BudibaseLogo,
+    CONFLUENCE: ConfluenceLogo,
+    GITHUB: GithubLogo,
+    BAMBOOHR: BambooHRLogo,
+  }
+
+  const ToolSources = [
+    {
+      name: "Budibase",
+      type: "BUDIBASE",
+      description: "Connect agent to your Budibase tools",
+    },
+    {
+      name: "Github",
+      type: "GITHUB",
+      description: "Automate development workflows.",
+    },
+    {
+      name: "Confluence",
+      type: "CONFLUENCE",
+      description: "Connect agent to your teams documentation",
+    },
+    {
+      name: "Sharepoint",
+      type: "SHAREPOINT",
+      description: "Sharepoint stuff",
+    },
+    {
+      name: "JIRA Service Manaagement",
+      type: "JIRA_SM",
+      description: "Automate ITSM Workflows",
+    },
+    {
+      name: "BambooHR",
+      type: "BAMBOOHR",
+      description: "Automate HR workflows and employee management",
+    },
+  ]
+
+  export let agentId: string
+
+  const dispatch = createEventDispatcher()
+
+  let modal: Modal
+  let mode: "select" | "configure" = "select"
+  let selectedSourceType: any = null
+  let editingSource: AgentToolSourceWithTools | null = null
+
+  // Configuration state
+  let config: Record<string, string> = {}
+  let disabledTools: string[] = []
+  let toolsList: any[] = []
+
+  export function show(sourceToEdit?: AgentToolSourceWithTools) {
+    if (sourceToEdit) {
+      mode = "configure"
+      editingSource = sourceToEdit
+      selectedSourceType = ToolSources.find(s => s.type === sourceToEdit.type)
+      config = { ...sourceToEdit.auth }
+      disabledTools = [...(sourceToEdit.disabledTools || [])]
+      toolsList = sourceToEdit.tools || []
+    } else {
+      mode = "select"
+      editingSource = null
+      selectedSourceType = null
+      config = {}
+      disabledTools = []
+      toolsList = []
+    }
+    modal.show()
+  }
+
+  export function hide() {
+    modal.hide()
+  }
+
+  function selectSource(source: any) {
+    selectedSourceType = source
+    mode = "configure"
+    config = {}
+    disabledTools = []
+    toolsList = [] // New sources don't have tools loaded until created/fetched usually, but for now we just configure auth.
+  }
+
+  function toggleTool(toolName: string) {
+    if (disabledTools.includes(toolName)) {
+      disabledTools = disabledTools.filter(t => t !== toolName)
+    } else {
+      disabledTools = [...disabledTools, toolName]
+    }
+  }
+
+  async function save() {
+    try {
+      if (editingSource) {
+        // Update existing
+        const updatedSource = {
+          ...editingSource,
+          auth: config,
+          disabledTools,
+          agentId,
+        }
+        await agentsStore.updateToolSource(
+          updatedSource as unknown as AgentToolSource // could be any of the tool source auth types so we have to cast here unfortunately.
+        )
+        notifications.success("Tool source updated successfully")
+      } else {
+        // Create new
+        const newSource: CreateToolSourceRequest = {
+          type: selectedSourceType.type,
+          agentId,
+          auth: config,
+          disabledTools: [], // Initially no tools are disabled or loaded really until backend processes it?
+          // The backend likely fetches tools after creation.
+        }
+        await agentsStore.createToolSource(newSource)
+        notifications.success("Tool source added successfully")
+      }
+      dispatch("saved")
+      modal.hide()
+    } catch (error: any) {
+      console.error(error)
+      notifications.error(`Error saving tool source: ${error.message}`)
+    }
+  }
+
+  function goBack() {
+    if (editingSource) {
+      modal.hide()
+    } else {
+      mode = "select"
+      selectedSourceType = null
+    }
+  }
+</script>
+
+<Modal bind:this={modal}>
+  <ModalContent
+    title={mode === "select"
+      ? "Add Tool"
+      : `${editingSource ? "Edit" : "Configure"} ${selectedSourceType?.name || "Tool"}`}
+    size="L"
+    showCloseIcon
+    showCancelButton={mode === "configure"}
+    cancelText="Back"
+    showConfirmButton={mode === "configure"}
+    confirmText="Save"
+    onCancel={goBack}
+    onConfirm={save}
+  >
+    {#if mode === "select"}
+      <div class="sources-grid">
+        {#each ToolSources as source}
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <div class="source-card" on:click={() => selectSource(source)}>
+            <div class="source-header">
+              {#if Logos[source.type]}
+                <div class="source-icon">
+                  <svelte:component
+                    this={Logos[source.type]}
+                    height="24"
+                    width="24"
+                  />
+                </div>
+              {/if}
+              <Heading size="XS">{source.name}</Heading>
+            </div>
+            <Body size="S" color="var(--spectrum-global-color-gray-700)">
+              {source.description}
+            </Body>
+            {#if $agentsStore.toolSources.some(ts => ts.type === source.type)}
+              <div class="connected-badge">
+                <Icon name="CheckmarkCircle" size="S" />
+                Connected
+              </div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {:else if mode === "configure" && selectedSourceType}
+      <div class="config-form">
+        <div class="auth-section">
+          <Heading size="XS">Authentication</Heading>
+          {#if selectedSourceType.type === "GITHUB"}
+            <Input
+              label="API Key"
+              bind:value={config.apiKey}
+              type="password"
+              placeholder="Enter your GitHub API token"
+            />
+            <Input
+              label="Base URL (Optional)"
+              bind:value={config.baseUrl}
+              type="text"
+              placeholder="https://api.github.com (leave empty for default)"
+            />
+          {:else if selectedSourceType.type === "CONFLUENCE"}
+            <Input
+              label="API Key"
+              bind:value={config.apiKey}
+              type="password"
+              placeholder="Enter your Confluence API token"
+            />
+            <Input
+              label="Email Address"
+              bind:value={config.email}
+              type="email"
+              placeholder="your.email@domain.com"
+              helpText="Your Atlassian account email address"
+            />
+            <Input
+              label="Base URL (Optional)"
+              bind:value={config.baseUrl}
+              type="text"
+              placeholder="https://your-domain.atlassian.net"
+            />
+          {:else if selectedSourceType.type === "BAMBOOHR"}
+            <Input
+              label="API Key"
+              bind:value={config.apiKey}
+              type="password"
+              placeholder="Enter your BambooHR API key"
+            />
+            <Input
+              label="Subdomain"
+              bind:value={config.subdomain}
+              type="text"
+              placeholder="your-company"
+              helpText="Your BambooHR subdomain (e.g., 'mycompany' for mycompany.bamboohr.com)"
+            />
+          {/if}
+          <TextArea
+            label="Tool Source Guidelines"
+            bind:value={config.guidelines}
+            placeholder="Add additional information to help guide the Budibase agent in the usage of this tool"
+          />
+        </div>
+
+        {#if editingSource && toolsList.length > 0}
+          <div class="tools-section">
+            <Heading size="XS">Enabled Tools</Heading>
+            <div class="tools-list">
+              {#each toolsList as tool}
+                <div class="tool-item">
+                  <div class="tool-info">
+                    <div class="tool-name">{tool.name}</div>
+                    <div class="tool-desc">{tool.description}</div>
+                  </div>
+                  <Toggle
+                    value={!disabledTools.includes(tool.name)}
+                    on:change={() => toggleTool(tool.name)}
+                  />
+                </div>
+              {/each}
+            </div>
+          </div>
+        {/if}
+      </div>
+    {/if}
+  </ModalContent>
+</Modal>
+
+<style>
+  .sources-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--spacing-m);
+  }
+
+  .source-card {
+    border: 1px solid var(--spectrum-global-color-gray-300);
+    border-radius: 8px;
+    padding: var(--spacing-l);
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-s);
+    transition: border-color 0.2s;
+    position: relative;
+  }
+
+  .source-card:hover {
+    border-color: var(--spectrum-global-color-gray-500);
+    background-color: var(--spectrum-alias-background-color-hover-overlay);
+  }
+
+  .source-header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-m);
+  }
+
+  .source-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .connected-badge {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    color: var(--spectrum-global-color-green-500);
+    font-size: var(--font-size-s);
+    margin-top: auto;
+  }
+
+  .config-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xl);
+  }
+
+  .auth-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-m);
+  }
+
+  .tools-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-m);
+  }
+
+  .tools-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-s);
+    border: 1px solid var(--spectrum-global-color-gray-200);
+    border-radius: 4px;
+    padding: var(--spacing-s);
+    max-height: 300px;
+    overflow-y: auto;
+  }
+
+  .tool-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--spacing-s);
+    border-bottom: 1px solid var(--spectrum-global-color-gray-100);
+  }
+
+  .tool-item:last-child {
+    border-bottom: none;
+  }
+
+  .tool-info {
+    flex: 1;
+    margin-right: var(--spacing-m);
+  }
+
+  .tool-name {
+    font-weight: 600;
+    font-size: var(--font-size-s);
+    font-family: var(--font-mono);
+  }
+
+  .tool-desc {
+    font-size: var(--font-size-xs);
+    color: var(--spectrum-global-color-gray-700);
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/AgentToolConfigModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/AgentToolConfigModal.svelte
@@ -71,7 +71,6 @@
   let selectedSourceType: any = null
   let editingSource: AgentToolSourceWithTools | null = null
 
-  // Configuration state
   let config: Record<string, string> = {}
   let disabledTools: string[] = []
   let toolsList: any[] = []
@@ -104,7 +103,7 @@
     mode = "configure"
     config = {}
     disabledTools = []
-    toolsList = [] // New sources don't have tools loaded until created/fetched usually, but for now we just configure auth.
+    toolsList = []
   }
 
   function toggleTool(toolName: string) {
@@ -118,7 +117,6 @@
   async function save() {
     try {
       if (editingSource) {
-        // Update existing
         const updatedSource = {
           ...editingSource,
           auth: config,
@@ -130,13 +128,11 @@
         )
         notifications.success("Tool source updated successfully")
       } else {
-        // Create new
         const newSource: CreateToolSourceRequest = {
           type: selectedSourceType.type,
           agentId,
           auth: config,
-          disabledTools: [], // Initially no tools are disabled or loaded really until backend processes it?
-          // The backend likely fetches tools after creation.
+          disabledTools: [],
         }
         await agentsStore.createToolSource(newSource)
         notifications.success("Tool source added successfully")

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
@@ -5,7 +5,6 @@
     Body,
     Button,
     Heading,
-    Icon,
     Input,
     Layout,
     notifications,
@@ -36,24 +35,24 @@
     value: config._id || "",
   }))
 
-  async function saveAgent() {
-    if (!currentAgent) return
+  // async function saveAgent() {
+  //   if (!currentAgent) return
 
-    try {
-      await agentsStore.updateAgent({
-        ...currentAgent,
-        name: draft.name,
-        description: draft.description,
-        aiconfig: draft.aiconfig,
-        promptInstructions: draft.promptInstructions,
-        icon: draft.icon,
-      })
-      notifications.success("Agent saved successfully")
-    } catch (error) {
-      console.error(error)
-      notifications.error("Error saving agent")
-    }
-  }
+  //   try {
+  //     await agentsStore.updateAgent({
+  //       ...currentAgent,
+  //       name: draft.name,
+  //       description: draft.description,
+  //       aiconfig: draft.aiconfig,
+  //       promptInstructions: draft.promptInstructions,
+  //       icon: draft.icon,
+  //     })
+  //     notifications.success("Agent saved successfully")
+  //   } catch (error) {
+  //     console.error(error)
+  //     notifications.error("Error saving agent")
+  //   }
+  // }
 
   async function setAgentLive() {
     if (!currentAgent) return
@@ -234,18 +233,6 @@
     gap: var(--spacing-xl);
     border-radius: var(--spacing-xl);
     border: 1px solid var(--spectrum-global-color-gray-300);
-  }
-
-  .config-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-
-  .header-left {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-s);
   }
 
   .config-form {

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
@@ -57,14 +57,9 @@
     try {
       await agentsStore.updateAgent({
         ...currentAgent,
-        name: draft.name,
-        description: draft.description,
-        aiconfig: draft.aiconfig,
-        promptInstructions: draft.promptInstructions,
-        goal: draft.goal,
-        icon: draft.icon,
-        iconColor: draft.iconColor,
+        ...draft,
       })
+
       notifications.success("Agent saved successfully")
       await agentsStore.fetchAgents()
     } catch (error) {
@@ -78,16 +73,16 @@
 
     try {
       if (currentAgent.live) {
-        // Pause agent - set to draft
         await agentsStore.updateAgent({
           ...currentAgent,
+          ...draft,
           live: false,
         })
         notifications.success("Agent has been paused")
       } else {
-        // Set agent live
         await agentsStore.updateAgent({
           ...currentAgent,
+          ...draft,
           live: true,
         })
         notifications.success("Agent is now live")

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
@@ -73,19 +73,31 @@
     }
   }
 
-  async function setAgentLive() {
+  async function toggleAgentLive() {
     if (!currentAgent) return
 
     try {
-      await agentsStore.updateAgent({
-        ...currentAgent,
-        live: true,
-      })
-      notifications.success("Agent is now live")
+      if (currentAgent.live) {
+        // Pause agent - set to draft
+        await agentsStore.updateAgent({
+          ...currentAgent,
+          live: false,
+        })
+        notifications.success("Agent has been paused")
+      } else {
+        // Set agent live
+        await agentsStore.updateAgent({
+          ...currentAgent,
+          live: true,
+        })
+        notifications.success("Agent is now live")
+      }
       await agentsStore.fetchAgents()
     } catch (error) {
       console.error(error)
-      notifications.error("Error setting agent live")
+      notifications.error(
+        currentAgent.live ? "Error pausing agent" : "Error setting agent live"
+      )
     }
   }
 
@@ -214,13 +226,18 @@
       <div class="config-footer">
         <div class="footer-buttons">
           <Button icon="save" on:click={saveAgent}>Save Changes</Button>
-          <Button cta icon="play" on:click={setAgentLive}>
-            Set your agent live
+          <Button
+            cta
+            icon={currentAgent?.live ? "pause" : "play"}
+            on:click={toggleAgentLive}
+          >
+            {currentAgent?.live ? "Pause Agent" : "Set your agent live"}
           </Button>
         </div>
         <Body size="S" color="var(--spectrum-global-color-gray-700)">
-          Once your agent is live, it will be available to use within
-          automations. You can pause your agent at any time.
+          {currentAgent?.live
+            ? "Your agent is currently live. Pause it to make changes and take it offline."
+            : "Once your agent is live, it will be available to use within automations. You can pause your agent at any time."}
         </Body>
       </div>
     </div>
@@ -349,9 +366,5 @@
     gap: var(--spacing-m);
     justify-content: center;
     align-items: center;
-  }
-
-  .live-banner {
-    padding: 0;
   }
 </style>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
@@ -214,6 +214,8 @@
     display: flex;
     flex-direction: column;
     flex: 1 1 auto;
+    height: 100%;
+    min-height: 0;
     background: var(--background);
     overflow-y: auto;
   }

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
@@ -1,0 +1,317 @@
+<script lang="ts">
+  import TopBar from "@/components/common/TopBar.svelte"
+  import { agentsStore, aiConfigsStore } from "@/stores/portal"
+  import {
+    Body,
+    Button,
+    Heading,
+    Icon,
+    Input,
+    Layout,
+    notifications,
+    Select,
+    TextArea,
+    ActionButton,
+    IconPicker,
+  } from "@budibase/bbui"
+  import type { Agent } from "@budibase/types"
+  import { onMount } from "svelte"
+  import { bb } from "@/stores/bb"
+
+  $: currentAgent = $agentsStore.agents.find(
+    a => a._id === $agentsStore.currentAgentId
+  )
+
+  $: draft = {
+    name: currentAgent?.name || "",
+    description: currentAgent?.description || "",
+    aiconfig: currentAgent?.aiconfig || "",
+    goal: "",
+    promptInstructions: currentAgent?.promptInstructions || "",
+    icon: currentAgent?.icon || "",
+  }
+
+  $: aiConfigs = $aiConfigsStore.customConfigs
+  $: modelOptions = aiConfigs.map(config => ({
+    label: config.name || config._id || "Unnamed",
+    value: config._id || "",
+  }))
+
+  async function saveAgent() {
+    if (!currentAgent) return
+
+    try {
+      await agentsStore.updateAgent({
+        ...currentAgent,
+        name: draft.name,
+        description: draft.description,
+        aiconfig: draft.aiconfig,
+        promptInstructions: draft.promptInstructions,
+        icon: draft.icon,
+      })
+      notifications.success("Agent saved successfully")
+    } catch (error) {
+      console.error(error)
+      notifications.error("Error saving agent")
+    }
+  }
+
+  async function setAgentLive() {
+    if (!currentAgent) return
+
+    try {
+      await agentsStore.updateAgent({
+        ...currentAgent,
+        live: true,
+      })
+      notifications.success("Agent is now live")
+      await agentsStore.fetchAgents()
+    } catch (error) {
+      console.error(error)
+      notifications.error("Error setting agent live")
+    }
+  }
+
+  onMount(async () => {
+    await agentsStore.init()
+    await aiConfigsStore.fetch()
+  })
+</script>
+
+<div class="config-wrapper">
+  <TopBar
+    breadcrumbs={[
+      { text: "Agents", url: "../" },
+      { text: currentAgent?.name || "Agent" },
+    ]}
+    icon="Effect"
+  />
+  <div class="config-content">
+    <div class="config-header">
+      <div class="header-left">
+        <Icon name={currentAgent?.icon || "Effect"} size="L" color="#8B5CF6" />
+        <Heading size="L">Agents / {currentAgent?.name || "New agent"}</Heading>
+      </div>
+      <Button cta on:click={saveAgent}>Publish</Button>
+    </div>
+
+    <div class="config-form">
+      <Layout paddingY="L" gap="L">
+        <div class="name-row">
+          <div class="name-input">
+            <Input
+              label="Name"
+              labelPosition="left"
+              bind:value={draft.name}
+              placeholder="Give your agent a name"
+            />
+          </div>
+          <IconPicker
+            value={draft.icon}
+            on:change={e => (draft.icon = e.detail)}
+          />
+        </div>
+
+        <Input
+          label="Description"
+          labelPosition="left"
+          bind:value={draft.description}
+          placeholder="Give your agent a description"
+        />
+
+        <div class="model-row">
+          <div class="model-select">
+            <Select
+              label="Model"
+              labelPosition="left"
+              bind:value={draft.aiconfig}
+              options={modelOptions}
+              placeholder="Select a model"
+            />
+          </div>
+          <ActionButton
+            size="M"
+            icon="sliders-horizontal"
+            tooltip="Manage AI configurations"
+            on:click={() => bb.settings("/ai")}
+          />
+        </div>
+
+        <div class="section">
+          <div class="section-header">
+            <Heading size="M">Variables / Bindings</Heading>
+            <Body size="S" color="var(--spectrum-global-color-gray-700)">
+              Add variables to your agent. For example, employee_name, product,
+              ticket_status.
+            </Body>
+          </div>
+          <div class="add-button">
+            <ActionButton icon="plus">Add</ActionButton>
+          </div>
+        </div>
+
+        <div class="section">
+          <div class="section-header">
+            <Heading size="M">Tools</Heading>
+            <Body size="S" color="var(--spectrum-global-color-gray-700)">
+              Give your agent access to internal and external tools so it can
+              complete tasks.
+            </Body>
+          </div>
+          <div class="add-button">
+            <ActionButton icon="plus">Add</ActionButton>
+          </div>
+        </div>
+
+        <div class="section">
+          <div class="section-header">
+            <Heading size="M">Guardrails</Heading>
+            <Body size="S" color="var(--spectrum-global-color-gray-700)">
+              Train your agent to deliver accurate, consistent answers across
+              every workflow.
+            </Body>
+          </div>
+          <div class="add-button">
+            <ActionButton icon="plus">Add</ActionButton>
+          </div>
+        </div>
+
+        <div class="section">
+          <Heading size="M">Goal</Heading>
+          <Input
+            bind:value={draft.goal}
+            placeholder="Raise a security alert."
+          />
+        </div>
+
+        <div class="section">
+          <Heading size="M">Agent instructions</Heading>
+          <TextArea
+            bind:value={draft.promptInstructions}
+            placeholder="You are the Security Agent. When a user reports a possible incident, guide them to provide type, severity, and description. After collecting inputs, call the automation raise_security_alert. Respond concisely and confirm submission."
+            minHeight={160}
+          />
+        </div>
+      </Layout>
+    </div>
+
+    <div class="config-footer">
+      <div class="live-banner">
+        <Button cta icon="play" on:click={setAgentLive}>
+          Set your agent live
+        </Button>
+      </div>
+      <Body size="S" color="var(--spectrum-global-color-gray-700)">
+        Once your agent is live, it will be available to use within automations.
+        You can pause your agent at any time.
+      </Body>
+    </div>
+  </div>
+</div>
+
+<style>
+  .config-wrapper {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    background: var(--background);
+    overflow-y: auto;
+  }
+
+  .config-content {
+    flex: 1 1 auto;
+    max-width: 900px;
+    width: 100%;
+    margin: var(--spacing-l) auto;
+    padding: var(--spacing-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xl);
+    border-radius: var(--spacing-xl);
+    border: 1px solid var(--spectrum-global-color-gray-300);
+  }
+
+  .config-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .header-left {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s);
+  }
+
+  .config-form {
+    flex: 1 1 auto;
+  }
+
+  .model-row {
+    display: flex;
+    align-items: flex-end;
+    gap: var(--spacing-m);
+  }
+
+  .model-select {
+    flex: 1;
+  }
+
+  .name-row {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xl);
+  }
+
+  .name-input {
+    flex: 1;
+  }
+
+  /* Override input backgrounds to match design */
+  :global(.config-form .spectrum-Textfield-input),
+  :global(.config-form .spectrum-Picker) {
+    background-color: var(--background) !important;
+  }
+
+  /* Align left-position labels into a clean column */
+  :global(.config-form .spectrum-Form-item:not(.above)) {
+    display: grid;
+    grid-template-columns: 140px 1fr;
+    align-items: center;
+    column-gap: var(--spacing-m);
+  }
+
+  :global(.config-form .spectrum-Form-itemLabel) {
+    justify-self: flex-start;
+  }
+
+  .section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-s);
+  }
+
+  .section-header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+  }
+
+  .add-button {
+    display: flex;
+    justify-content: flex-start;
+  }
+
+  .config-footer {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-s);
+    padding-top: var(--spacing-l);
+    border-top: 1px solid var(--spectrum-global-color-gray-300);
+    align-items: center;
+  }
+
+  .live-banner {
+    padding: var(--spacing-m) 0 0;
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
@@ -13,6 +13,8 @@
     ModalContent,
     Tags,
     Tag,
+    Icon,
+    Helpers,
   } from "@budibase/bbui"
   import type { Agent } from "@budibase/types"
   import TopBar from "@/components/common/TopBar.svelte"
@@ -136,6 +138,22 @@
     }
   }
 
+  const agentUrl = "budibase.app/chat/3432343dff34334334dfd"
+
+  async function copyAgentUrl() {
+    try {
+      await Helpers.copyToClipboard(agentUrl)
+      notifications.success("URL copied to clipboard")
+    } catch (error) {
+      console.error(error)
+      notifications.error("Failed to copy URL")
+    }
+  }
+
+  function openAgentUrl() {
+    window.open(`https://${agentUrl}`, "_blank")
+  }
+
   onMount(async () => {
     await Promise.all([
       agentsStore.init(),
@@ -157,7 +175,9 @@
       { text: currentAgent?.name || "Agent" },
     ]}
     icon="Effect"
-  />
+  >
+    <Button cta icon="save" on:click={saveAgent}>Save Changes</Button>
+  </TopBar>
   <div class="config-page">
     <div class="config-content">
       <div class="config-form">
@@ -296,23 +316,53 @@
         </Layout>
       </div>
 
-      <div class="config-footer">
-        <div class="footer-buttons">
-          <Button icon="save" on:click={saveAgent}>Save Changes</Button>
-          <Button
-            cta
-            icon={currentAgent?.live ? "pause" : "play"}
-            on:click={toggleAgentLive}
-          >
-            {currentAgent?.live ? "Pause Agent" : "Set your agent live"}
-          </Button>
+      {#if currentAgent?.live}
+        <div class="agent-live-card">
+          <div class="live-header">
+            <div class="live-icon">
+              <Icon name="activity" size="M" />
+            </div>
+            <Heading size="S">Your agent is live.</Heading>
+          </div>
+          <div class="url-section">
+            <div class="url">
+              <Input readonly disabled value={agentUrl} />
+            </div>
+            <div class="url-actions">
+              <div class="url-action-button">
+                <Icon name="copy" size="S" on:click={copyAgentUrl} />
+              </div>
+              <div class="url-action-button">
+                <Icon
+                  name="arrow-square-out"
+                  size="S"
+                  on:click={openAgentUrl}
+                />
+              </div>
+            </div>
+          </div>
+          <div class="live-actions">
+            <Button secondary icon="pause" on:click={toggleAgentLive}
+              >Pause agent</Button
+            >
+          </div>
         </div>
-        <Body size="S" color="var(--spectrum-global-color-gray-700)">
-          {currentAgent?.live
-            ? "Your agent is currently live. Pause it to make changes and take it offline."
-            : "Once your agent is live, it will be available to use within automations. You can pause your agent at any time."}
-        </Body>
-      </div>
+      {:else}
+        <div class="agent-live-card">
+          <Button
+            quiet
+            icon="play"
+            iconColor="var(--bb-blue)"
+            on:click={toggleAgentLive}>Set your agent live</Button
+          >
+          <div class="live-description">
+            <Body size="S">
+              Once your agent is live, it will be available to use.
+            </Body>
+            <Body size="S">You can pause your agent at any time.</Body>
+          </div>
+        </div>
+      {/if}
     </div>
   </div>
 </div>
@@ -449,24 +499,80 @@
     margin-top: var(--spacing-s);
   }
 
-  .config-footer {
+  .agent-live-card {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-s);
+    gap: var(--spacing-m);
     margin-top: var(--spacing-xl);
-    padding: var(--spacing-l);
+    padding: var(--spacing-xl);
     border-radius: 12px;
-    background-color: var(--background-alt);
-    border: 1px solid var(--spectrum-global-color-gray-300);
+    background-color: #212121;
     align-items: center;
+  }
+
+  .live-header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s);
+    width: 100%;
+    padding: var(--spacing-xl);
+    margin: calc(-1 * var(--spacing-xl)) calc(-1 * var(--spacing-xl)) 0;
+    background-color: #1a1a1a;
+    border-radius: 12px 12px 0 0;
+  }
+
+  .live-actions {
+    display: flex;
+    justify-content: flex-start;
+    gap: var(--spacing-m);
+    width: 100%;
+  }
+
+  .live-header :global(.spectrum-Heading) {
+    color: #ffffff;
+    margin: 0;
+  }
+
+  .live-icon {
+    color: #4caf50;
+    display: flex;
+    align-items: center;
+  }
+
+  .url-section {
+    width: 100%;
+    display: flex;
+  }
+
+  .url {
+    width: 100%;
+  }
+
+  .url-actions {
+    margin-left: var(--spacing-m);
+    display: flex;
+    gap: var(--spacing-m);
+    align-items: center;
+  }
+
+  .url-action-button {
+    cursor: pointer;
+  }
+
+  .url-action-button:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+
+  .live-description {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
     text-align: center;
   }
 
-  .footer-buttons {
-    display: flex;
-    gap: var(--spacing-m);
-    justify-content: center;
-    align-items: center;
+  .live-description :global(.spectrum-Body) {
+    color: #bdbdbd;
+    margin: 0;
   }
 
   .tools-tags {

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
@@ -14,7 +14,6 @@
     ActionButton,
     IconPicker,
   } from "@budibase/bbui"
-  import type { Agent } from "@budibase/types"
   import { onMount } from "svelte"
   import { bb } from "@/stores/bb"
 
@@ -86,125 +85,119 @@
     ]}
     icon="Effect"
   />
-  <div class="config-content">
-    <div class="config-header">
-      <div class="header-left">
-        <Icon name={currentAgent?.icon || "Effect"} size="L" color="#8B5CF6" />
-        <Heading size="L">Agents / {currentAgent?.name || "New agent"}</Heading>
-      </div>
-      <Button cta on:click={saveAgent}>Publish</Button>
-    </div>
-
-    <div class="config-form">
-      <Layout paddingY="L" gap="L">
-        <div class="name-row">
-          <div class="name-input">
-            <Input
-              label="Name"
-              labelPosition="left"
-              bind:value={draft.name}
-              placeholder="Give your agent a name"
+  <div class="config-page">
+    <div class="config-content">
+      <div class="config-form">
+        <Layout paddingY="L" gap="S">
+          <div class="name-row">
+            <div class="name-input">
+              <Input
+                label="Name"
+                labelPosition="left"
+                bind:value={draft.name}
+                placeholder="Give your agent a name"
+              />
+            </div>
+            <IconPicker
+              value={draft.icon}
+              on:change={e => (draft.icon = e.detail)}
             />
           </div>
-          <IconPicker
-            value={draft.icon}
-            on:change={e => (draft.icon = e.detail)}
-          />
-        </div>
 
-        <Input
-          label="Description"
-          labelPosition="left"
-          bind:value={draft.description}
-          placeholder="Give your agent a description"
-        />
-
-        <div class="model-row">
-          <div class="model-select">
-            <Select
-              label="Model"
-              labelPosition="left"
-              bind:value={draft.aiconfig}
-              options={modelOptions}
-              placeholder="Select a model"
-            />
-          </div>
-          <ActionButton
-            size="M"
-            icon="sliders-horizontal"
-            tooltip="Manage AI configurations"
-            on:click={() => bb.settings("/ai")}
-          />
-        </div>
-
-        <div class="section">
-          <div class="section-header">
-            <Heading size="M">Variables / Bindings</Heading>
-            <Body size="S" color="var(--spectrum-global-color-gray-700)">
-              Add variables to your agent. For example, employee_name, product,
-              ticket_status.
-            </Body>
-          </div>
-          <div class="add-button">
-            <ActionButton icon="plus">Add</ActionButton>
-          </div>
-        </div>
-
-        <div class="section">
-          <div class="section-header">
-            <Heading size="M">Tools</Heading>
-            <Body size="S" color="var(--spectrum-global-color-gray-700)">
-              Give your agent access to internal and external tools so it can
-              complete tasks.
-            </Body>
-          </div>
-          <div class="add-button">
-            <ActionButton icon="plus">Add</ActionButton>
-          </div>
-        </div>
-
-        <div class="section">
-          <div class="section-header">
-            <Heading size="M">Guardrails</Heading>
-            <Body size="S" color="var(--spectrum-global-color-gray-700)">
-              Train your agent to deliver accurate, consistent answers across
-              every workflow.
-            </Body>
-          </div>
-          <div class="add-button">
-            <ActionButton icon="plus">Add</ActionButton>
-          </div>
-        </div>
-
-        <div class="section">
-          <Heading size="M">Goal</Heading>
           <Input
-            bind:value={draft.goal}
-            placeholder="Raise a security alert."
+            label="Description"
+            labelPosition="left"
+            bind:value={draft.description}
+            placeholder="Give your agent a description"
           />
-        </div>
 
-        <div class="section">
-          <Heading size="M">Agent instructions</Heading>
-          <TextArea
-            bind:value={draft.promptInstructions}
-            placeholder="You are the Security Agent. When a user reports a possible incident, guide them to provide type, severity, and description. After collecting inputs, call the automation raise_security_alert. Respond concisely and confirm submission."
-            minHeight={160}
-          />
-        </div>
-      </Layout>
-    </div>
+          <div class="model-row">
+            <div class="model-select">
+              <Select
+                label="Model"
+                labelPosition="left"
+                bind:value={draft.aiconfig}
+                options={modelOptions}
+                placeholder="Select a model"
+              />
+            </div>
+            <ActionButton
+              size="M"
+              icon="sliders-horizontal"
+              tooltip="Manage AI configurations"
+              on:click={() => bb.settings("/ai")}
+            />
+          </div>
 
-    <div class="config-footer">
-      <div class="live-banner">
-        <Button cta icon="play" on:click={setAgentLive}>
-          Set your agent live
-        </Button>
+          <div class="section">
+            <div class="section-header">
+              <Heading size="XS">Variables / Bindings</Heading>
+              <Body size="S" color="var(--spectrum-global-color-gray-700)">
+                Add variables to your agent. For example, employee_name,
+                product, ticket_status.
+              </Body>
+            </div>
+            <div class="add-button">
+              <ActionButton size="S" icon="plus">Add</ActionButton>
+            </div>
+          </div>
+
+          <div class="section">
+            <div class="section-header">
+              <Heading size="XS">Tools</Heading>
+              <Body size="S" color="var(--spectrum-global-color-gray-700)">
+                Give your agent access to internal and external tools so it can
+                complete tasks.
+              </Body>
+            </div>
+            <div class="add-button">
+              <ActionButton size="S" icon="plus">Add</ActionButton>
+            </div>
+          </div>
+
+          <div class="section">
+            <div class="section-header">
+              <Heading size="XS">Guardrails</Heading>
+              <Body size="S" color="var(--spectrum-global-color-gray-700)">
+                Train your agent to deliver accurate, consistent answers across
+                every workflow.
+              </Body>
+            </div>
+            <div class="add-button">
+              <ActionButton size="S" icon="plus">Add</ActionButton>
+            </div>
+          </div>
+
+          <div class="section">
+            <Heading size="XS">Goal</Heading>
+            <Input
+              bind:value={draft.goal}
+              placeholder="Raise a security alert."
+            />
+          </div>
+
+          <div class="section">
+            <Heading size="XS">Agent instructions</Heading>
+            <TextArea
+              bind:value={draft.promptInstructions}
+              placeholder="You are the Security Agent. When a user reports a possible incident, guide them to provide type, severity, and description. After collecting inputs, call the automation raise_security_alert. Respond concisely and confirm submission."
+              minHeight={100}
+            />
+          </div>
+        </Layout>
       </div>
-      <Body size="S" color="var(--spectrum-global-color-gray-700)">
-        Once your agent is live, it will be available to use within automations.
-        You can pause your agent at any time.
-      </Body>
+
+      <div class="config-footer">
+        <div class="live-banner">
+          <Button cta icon="play" on:click={setAgentLive}>
+            Set your agent live
+          </Button>
+        </div>
+        <Body size="S" color="var(--spectrum-global-color-gray-700)">
+          Once your agent is live, it will be available to use within
+          automations. You can pause your agent at any time.
+        </Body>
+      </div>
     </div>
   </div>
 </div>
@@ -213,19 +206,29 @@
   .config-wrapper {
     display: flex;
     flex-direction: column;
+    align-items: stretch;
     flex: 1 1 auto;
-    height: 100%;
-    min-height: 0;
     background: var(--background);
+  }
+
+  .config-page {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    height: 0;
     overflow-y: auto;
+    overflow-x: hidden;
+    padding: 0 var(--spacing-l);
+    box-sizing: border-box;
   }
 
   .config-content {
-    flex: 1 1 auto;
+    flex: 0 0 auto;
     max-width: 900px;
     width: 100%;
     margin: var(--spacing-l) auto;
-    padding: var(--spacing-xl);
+    padding: var(--spacing-m) var(--spacing-m) 0 var(--spacing-m);
     display: flex;
     flex-direction: column;
     gap: var(--spacing-xl);
@@ -251,7 +254,7 @@
 
   .model-row {
     display: flex;
-    align-items: flex-end;
+    align-items: center;
     gap: var(--spacing-m);
   }
 
@@ -278,7 +281,7 @@
   /* Align left-position labels into a clean column */
   :global(.config-form .spectrum-Form-item:not(.above)) {
     display: grid;
-    grid-template-columns: 140px 1fr;
+    grid-template-columns: 70px 1fr;
     align-items: center;
     column-gap: var(--spacing-m);
   }

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
@@ -207,7 +207,7 @@
             />
           </div>
 
-          <div class="section section-banner">
+          <!-- <div class="section section-banner">
             <div class="section-header">
               <Heading size="XS">Variables / Bindings</Heading>
               <Body size="S" color="var(--spectrum-global-color-gray-700)">
@@ -218,7 +218,7 @@
                 <ActionButton size="S" icon="plus">Add</ActionButton>
               </div>
             </div>
-          </div>
+          </div> -->
 
           <div class="section section-banner">
             <div class="section-header">
@@ -262,7 +262,7 @@
             </div>
           </div>
 
-          <div class="section section-banner">
+          <!-- <div class="section section-banner">
             <div class="section-header">
               <Heading size="XS">Guardrails</Heading>
               <Body size="S" color="var(--spectrum-global-color-gray-700)">
@@ -274,7 +274,7 @@
               </div>
             </div>
           </div>
-
+ -->
           <div class="section">
             <Input
               label="Goal"

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
@@ -87,7 +87,7 @@
   <div class="config-page">
     <div class="config-content">
       <div class="config-form">
-        <Layout paddingY="L" gap="S">
+        <Layout paddingY="XL" gap="L">
           <div class="name-row">
             <div class="name-input">
               <Input
@@ -128,7 +128,7 @@
             />
           </div>
 
-          <div class="section">
+          <div class="section section-banner">
             <div class="section-header">
               <Heading size="XS">Variables / Bindings</Heading>
               <Body size="S" color="var(--spectrum-global-color-gray-700)">
@@ -141,7 +141,7 @@
             </div>
           </div>
 
-          <div class="section">
+          <div class="section section-banner">
             <div class="section-header">
               <Heading size="XS">Tools</Heading>
               <Body size="S" color="var(--spectrum-global-color-gray-700)">
@@ -154,7 +154,7 @@
             </div>
           </div>
 
-          <div class="section">
+          <div class="section section-banner">
             <div class="section-header">
               <Heading size="XS">Guardrails</Heading>
               <Body size="S" color="var(--spectrum-global-color-gray-700)">
@@ -168,19 +168,21 @@
           </div>
 
           <div class="section">
-            <Heading size="XS">Goal</Heading>
             <Input
+              label="Goal"
+              labelPosition="left"
               bind:value={draft.goal}
               placeholder="Raise a security alert."
             />
           </div>
 
           <div class="section">
-            <Heading size="XS">Agent instructions</Heading>
             <TextArea
+              label="Agent instructions"
+              labelPosition="left"
               bind:value={draft.promptInstructions}
               placeholder="You are the Security Agent. When a user reports a possible incident, guide them to provide type, severity, and description. After collecting inputs, call the automation raise_security_alert. Respond concisely and confirm submission."
-              minHeight={100}
+              minHeight={140}
             />
           </div>
         </Layout>
@@ -214,25 +216,24 @@
     flex: 1 1 auto;
     display: flex;
     flex-direction: column;
-    align-items: center;
     height: 0;
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 0 var(--spacing-l);
+    padding: var(--spacing-xl) var(--spacing-l) var(--spacing-xl);
     box-sizing: border-box;
   }
 
   .config-content {
-    flex: 0 0 auto;
-    max-width: 900px;
+    max-width: 840px;
     width: 100%;
-    margin: var(--spacing-l) auto;
-    padding: var(--spacing-m) var(--spacing-m) 0 var(--spacing-m);
+    margin: 0 auto;
+    padding: var(--spacing-xl);
     display: flex;
     flex-direction: column;
     gap: var(--spacing-xl);
-    border-radius: var(--spacing-xl);
+    border-radius: 16px;
     border: 1px solid var(--spectrum-global-color-gray-300);
+    background: var(--spectrum-alias-background-color-primary);
   }
 
   .config-form {
@@ -268,7 +269,7 @@
   /* Align left-position labels into a clean column */
   :global(.config-form .spectrum-Form-item:not(.above)) {
     display: grid;
-    grid-template-columns: 70px 1fr;
+    grid-template-columns: 120px 1fr;
     align-items: center;
     column-gap: var(--spacing-m);
   }
@@ -280,30 +281,46 @@
   .section {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-s);
+    gap: var(--spacing-m);
+  }
+
+  .section.section-banner {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: var(--spacing-m);
+    border-radius: 12px;
+    background-color: var(--background-alt);
+    border: 1px dashed var(--spectrum-global-color-gray-300);
   }
 
   .section-header {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-xs);
+    max-width: 70%;
   }
 
   .add-button {
     display: flex;
-    justify-content: flex-start;
+    align-items: center;
+    justify-content: flex-end;
   }
 
   .config-footer {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-s);
-    padding-top: var(--spacing-l);
-    border-top: 1px solid var(--spectrum-global-color-gray-300);
+    margin-top: var(--spacing-xl);
+    padding: var(--spacing-l);
+    border-radius: 12px;
+    background-color: var(--background-alt);
+    border: 1px solid var(--spectrum-global-color-gray-300);
     align-items: center;
+    text-align: center;
   }
 
   .live-banner {
-    padding: var(--spacing-m) 0 0;
+    padding: 0;
   }
 </style>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/index.svelte
@@ -1,26 +1,23 @@
 <script lang="ts">
   import ConfirmDialog from "@/components/common/ConfirmDialog.svelte"
-  import HeroBanner from "@/components/common/HeroBanner.svelte"
-  import TopBar from "@/components/common/TopBar.svelte"
-  import { BannerType } from "@/constants/banners"
-  import { capitalise, durationFromNow } from "@/helpers"
   import FavouriteResourceButton from "@/pages/builder/_components/FavouriteResourceButton.svelte"
   import { contextMenuStore, workspaceFavouriteStore } from "@/stores/builder"
   import { agentsStore } from "@/stores/portal"
   import {
-    AbsTooltip,
+    ActionButton,
     Body,
     Button,
-    Helpers,
+    Heading,
     Icon,
     type ModalAPI,
     notifications,
+    Tabs,
+    Tab,
     TooltipPosition,
   } from "@budibase/bbui"
   import type { Agent } from "@budibase/types"
   import { WorkspaceResource } from "@budibase/types"
   import { url } from "@roxi/routify"
-  import AppsHero from "assets/automation-hero-x1.png"
   import NoResults from "../_components/NoResults.svelte"
   import AgentModal from "./AgentModal.svelte"
   import UpdateAgentModal from "../_components/UpdateAgentModal.svelte"
@@ -31,6 +28,8 @@
   let updateModal: Pick<ModalAPI, "show" | "hide">
   let confirmDeleteDialog: Pick<ModalAPI, "show" | "hide">
   let selectedAgent: Agent | undefined = undefined
+  let activeTab = "Your agents"
+  let activeSubTab = "All"
 
   $: favourites = workspaceFavouriteStore.lookup
 
@@ -83,6 +82,22 @@
     )
   }
 
+  const getAgentIcon = (_agent: Agent) => {
+    // default for now, will update when storing agent icon properly
+    return "SideKick"
+  }
+
+  const getAgentIconColor = (agent: Agent, index: number) => {
+    const colors = [
+      "#6366F1", // purple
+      "#F59E0B", // orange
+      "#10B981", // green
+      "#8B5CF6", // purple
+      "#EF4444", // red
+    ]
+    return colors[index % colors.length]
+  }
+
   $: agents = $agentsStore.agents
     .map(agent => {
       return {
@@ -110,94 +125,120 @@
 </script>
 
 <div class="agents-index">
-  <HeroBanner
-    key={BannerType.AGENTS}
-    title="Transform workflows at scale with Budibase Agents and AI"
-    linkTitle="Agents explained"
-    linkHref="https://docs.budibase.com/docs/TODO"
-    image={AppsHero}
-    color="#1C3F62"
-  >
-    Automate more processes for your employees and customers with our visual
-    agent builder. Use agents to transform workflows with AI, automate manual
-    tasks, and add logic to apps.
-  </HeroBanner>
-
-  <TopBar icon="cpu" breadcrumbs={[{ text: "Agents" }]} showPublish={false}
-  ></TopBar>
-  <div class="secondary-bar">
-    <div class="filter">
-      <!-- TODO -->
-    </div>
-    <div class="action-buttons">
-      <Button
-        icon="lightbulb"
-        secondary
-        on:click={() => {
-          window.open("https://docs.budibase.com/docs/TODO", "_blank")
-        }}
-      >
-        Learn
-      </Button>
-      <Button cta icon="plus" on:click={upsertModal.show}>New agent</Button>
-    </div>
-  </div>
-
-  <div class="table-wrapper">
-    <div class="table-header">
-      <span>Name</span>
-      <span>Last updated</span>
-      <span></span>
-    </div>
-    <div class="agents">
-      {#each agents as agent}
+  <div class="content-wrapper">
+    <div class="header">
+      <div class="title-section">
+        <Icon name="Effect" size="L" color="#8B5CF6" />
+        <Heading size="L">Agents</Heading>
+      </div>
+      <div class="header-actions">
         <a
-          class="agent"
-          class:favourite={agent.favourite?._id}
-          href={$url(`./${agent._id}`)}
-          on:contextmenu={e => openContextMenu(e, agent)}
-          class:active={showHighlight && selectedAgent === agent}
+          href="https://docs.budibase.com/docs/TODO"
+          target="_blank"
+          class="learn-link"
         >
-          <Body size="S" color="var(--spectrum-global-color-gray-900)">
-            <div class="auto-name">
-              {agent.name}
-            </div>
-          </Body>
-          <AbsTooltip text={Helpers.getDateDisplayValue(agent.updatedAt)}>
-            <span>
-              {capitalise(durationFromNow(agent.updatedAt || ""))}
-            </span>
-          </AbsTooltip>
-          <div class="actions">
-            <div class="ctx-btn">
-              <Icon
-                name="More"
-                size="M"
-                hoverable
-                on:click={e => openContextMenu(e, agent)}
-              />
-            </div>
-
-            <span class="favourite-btn">
-              <FavouriteResourceButton
-                favourite={agent.favourite}
-                position={TooltipPosition.Left}
-                noWrap
-              />
-            </span>
-          </div>
+          <Icon name="Education" size="M" />
+          <Body size="S">Agent building 101</Body>
         </a>
-      {/each}
-      {#if !agents.length}
-        <NoResults
-          ctaText="Create your first agent"
-          onCtaClick={() => upsertModal.show()}
-          resourceType="agent"
-        >
-          No agents yet! Build your first agent to get started.
-        </NoResults>
-      {/if}
+        <Button cta icon="plus" on:click={upsertModal.show}>New agent</Button>
+      </div>
     </div>
+
+    <div class="tabs-section">
+      <Tabs selected={activeTab} on:select={e => (activeTab = e.detail)}>
+        <Tab title="Inspiration" />
+        <Tab title="Your agents" />
+      </Tabs>
+    </div>
+
+    {#if activeTab === "Your agents"}
+      <div class="sub-tabs">
+        <ActionButton
+          quiet
+          selected={activeSubTab === "All"}
+          on:click={() => (activeSubTab = "All")}
+        >
+          All
+        </ActionButton>
+        <ActionButton
+          quiet
+          selected={activeSubTab === "Live"}
+          on:click={() => (activeSubTab = "Live")}
+        >
+          Live
+        </ActionButton>
+        <ActionButton
+          quiet
+          selected={activeSubTab === "Draft"}
+          on:click={() => (activeSubTab = "Draft")}
+        >
+          Draft
+        </ActionButton>
+      </div>
+
+      {#if activeSubTab === "All"}
+        <div class="agents-grid">
+          {#each agents as agent, index}
+            {@const iconName = getAgentIcon(agent)}
+            {@const iconColor = getAgentIconColor(agent, index)}
+            <a
+              class="agent-card"
+              href={$url(`./${agent._id}`)}
+              on:contextmenu={e => openContextMenu(e, agent)}
+              class:active={showHighlight && selectedAgent === agent}
+            >
+              <div class="card-icon" style="background-color: {iconColor}20;">
+                <Icon name={iconName} size="XL" color={iconColor} />
+              </div>
+              <div class="card-content">
+                <div class="card-name">
+                  <Body size="M">{agent.name}</Body>
+                </div>
+                <div class="card-creator">
+                  <Body size="S">Created by Budibase</Body>
+                </div>
+              </div>
+              <div class="card-actions">
+                <div class="ctx-btn">
+                  <Icon
+                    name="dots-three"
+                    size="M"
+                    hoverable
+                    on:click={e => openContextMenu(e, agent)}
+                  />
+                </div>
+                <FavouriteResourceButton
+                  favourite={agent.favourite}
+                  position={TooltipPosition.Left}
+                  noWrap
+                />
+              </div>
+            </a>
+          {/each}
+          {#if !agents.length}
+            <NoResults
+              ctaText="Create your first agent"
+              onCtaClick={() => upsertModal.show()}
+              resourceType="agent"
+            >
+              No agents yet! Build your first agent to get started.
+            </NoResults>
+          {/if}
+        </div>
+      {:else if activeSubTab === "Live"}
+        <div class="empty-state">
+          <Body size="M">Live agents will appear here</Body>
+        </div>
+      {:else if activeSubTab === "Draft"}
+        <div class="empty-state">
+          <Body size="M">Draft agents will appear here</Body>
+        </div>
+      {/if}
+    {:else if activeTab === "Inspiration"}
+      <div class="empty-state">
+        <Body size="M">Inspiration content coming soon</Body>
+      </div>
+    {/if}
   </div>
 </div>
 
@@ -217,103 +258,153 @@
 {/if}
 
 <style>
-  .auto-name {
-    display: flex;
-    gap: var(--spacing-xs);
-  }
   .agents-index {
     background: var(--background);
     flex: 1 1 auto;
-    --border: 1px solid var(--spectrum-global-color-gray-200);
     display: flex;
     flex-direction: column;
+    align-items: center;
+    overflow-y: auto;
+    padding: 0 var(--spacing-l);
+    box-sizing: border-box;
   }
-  .secondary-bar {
-    padding: 10px 12px;
-    border-bottom: var(--border);
+
+  .content-wrapper {
+    max-width: 1400px;
+    width: 100%;
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    padding: var(--spacing-l) 0;
+    gap: var(--spacing-m);
+  }
+
+  .header {
     display: flex;
     justify-content: space-between;
-    align-content: center;
-  }
-  .filter {
-    display: flex;
-    gap: 10px;
-  }
-  .filter :global(.spectrum-ActionButton) {
-    border-radius: 8px;
-    transition:
-      border-color 130ms ease-out,
-      background 130ms ease-out;
-    border: 1px solid transparent;
-    padding: 3px 10px;
-    height: auto;
-
-    &.is-selected {
-      background: var(--spectrum-global-color-gray-200);
-      border-color: var(--spectrum-global-color-gray-300);
-    }
-  }
-  .action-buttons {
-    display: flex;
-    gap: 8px;
-  }
-  .agent,
-  .table-header {
-    display: grid;
-    grid-template-columns: 1fr 200px 50px;
-    border-bottom: var(--border);
     align-items: center;
+    margin-bottom: var(--spacing-m);
   }
-  .table-header {
-    padding: 5px 12px;
-    color: var(--spectrum-global-color-gray-700);
-  }
-  .agent {
-    padding: 9px 12px;
-    color: var(--text-color);
-    transition: background 130ms ease-out;
 
-    &:hover,
-    &.active {
-      background: var(--spectrum-global-color-gray-200);
-
-      & .actions > * {
-        opacity: 1;
-        pointer-events: all;
-      }
-    }
-    &.favourite {
-      & .actions .favourite-btn {
-        opacity: 1;
-      }
-    }
-  }
-  .actions {
-    justify-content: flex-end;
+  .title-section {
     display: flex;
     align-items: center;
-    pointer-events: none;
+    gap: var(--spacing-s);
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-m);
+  }
+
+  .learn-link {
+    display: flex;
+    align-items: center;
     gap: var(--spacing-xs);
+    color: var(--spectrum-global-color-gray-700);
+    text-decoration: none;
+    transition: color 130ms ease-out;
   }
 
-  .actions > * {
+  .learn-link:hover {
+    color: var(--spectrum-global-color-gray-900);
+  }
+
+  .tabs-section {
+    margin-bottom: var(--spacing-m);
+  }
+
+  .sub-tabs {
+    display: flex;
+    gap: var(--spacing-xs);
+    margin-bottom: var(--spacing-l);
+  }
+
+  .sub-tabs :global(.spectrum-ActionButton) {
+    border-radius: 20px;
+    padding: 4px 12px;
+    height: auto;
+    font-size: 14px;
+  }
+
+  .agents-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: calc(var(--spacing-xl) * 3);
+  }
+
+  .agent-card {
+    background: var(--spectrum-alias-background-color-primary);
+    border: 1px solid var(--spectrum-global-color-gray-300);
+    border-radius: var(--border-radius-s);
+    padding: var(--spacing-l);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-m);
+    text-decoration: none;
+    color: var(--text-color);
+    transition:
+      transform 130ms ease-out,
+      box-shadow 130ms ease-out,
+      border-color 130ms ease-out;
+    position: relative;
+  }
+
+  .agent-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    border-color: var(--spectrum-global-color-gray-400);
+  }
+
+  .card-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: var(--border-radius-s);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .card-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+    flex: 1;
+  }
+
+  .card-name {
+    font-weight: 600;
+    color: var(--spectrum-global-color-gray-900);
+  }
+
+  .card-creator {
+    color: var(--spectrum-global-color-gray-600);
+  }
+
+  .card-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--spacing-xs);
     opacity: 0;
     transition: opacity 130ms ease-out;
   }
 
-  .actions .favourite-btn {
-    pointer-events: all;
+  .agent-card:hover .card-actions {
+    opacity: 1;
   }
 
-  .table-wrapper {
-    flex: 1 1 auto;
+  .ctx-btn {
     display: flex;
-    flex-direction: column;
-    height: 0;
+    align-items: center;
   }
 
-  .agents {
-    overflow-y: auto;
-    flex: 1 1 auto;
+  .empty-state {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: var(--spacing-xxl);
+    color: var(--spectrum-global-color-gray-600);
   }
 </style>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/index.svelte
@@ -9,6 +9,7 @@
     Button,
     Heading,
     Icon,
+    StatusLight,
     type ModalAPI,
     notifications,
     Tabs,
@@ -184,7 +185,7 @@
       </div>
 
       {#if activeSubTab === "All"}
-        <div class="agents-grid">
+        <div class="agents-grid" class:empty={!agents.length}>
           {#each agents as agent, index}
             {@const iconName = getAgentIcon(agent)}
             {@const iconColor = getAgentIconColor(agent, index)}
@@ -198,8 +199,20 @@
                 <Icon name={iconName} size="XL" color={iconColor} />
               </div>
               <div class="card-content">
-                <div class="card-name">
-                  <Body size="M">{agent.name}</Body>
+                <div class="card-header-row">
+                  <div class="card-name">
+                    <Body size="M">{agent.name}</Body>
+                  </div>
+                  <StatusLight
+                    size="S"
+                    color={agent.live
+                      ? "var(--spectrum-global-color-static-green-600)"
+                      : "var(--spectrum-global-color-static-gray-500)"}
+                  >
+                    <Body size="XS">
+                      {agent.live ? "Live" : "Draft"}
+                    </Body>
+                  </StatusLight>
                 </div>
                 <div class="card-creator">
                   <Body size="S">Created by Budibase</Body>
@@ -233,7 +246,7 @@
           {/if}
         </div>
       {:else if activeSubTab === "Live" || activeSubTab === "Draft"}
-        <div class="agents-grid">
+        <div class="agents-grid" class:empty={!agents.length}>
           {#each agents as agent, index}
             {@const iconName = getAgentIcon(agent)}
             {@const iconColor = getAgentIconColor(agent, index)}
@@ -247,8 +260,20 @@
                 <Icon name={iconName} size="XL" color={iconColor} />
               </div>
               <div class="card-content">
-                <div class="card-name">
-                  <Body size="M">{agent.name}</Body>
+                <div class="card-header-row">
+                  <div class="card-name">
+                    <Body size="M">{agent.name}</Body>
+                  </div>
+                  <StatusLight
+                    size="S"
+                    color={agent.live
+                      ? "var(--spectrum-global-color-static-green-600)"
+                      : "var(--spectrum-global-color-static-gray-500)"}
+                  >
+                    <Body size="XS">
+                      {agent.live ? "Live" : "Draft"}
+                    </Body>
+                  </StatusLight>
                 </div>
                 <div class="card-creator">
                   <Body size="S">Created by Budibase</Body>
@@ -384,6 +409,13 @@
     gap: calc(var(--spacing-xl) * 3);
   }
 
+  .agents-grid.empty {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 320px;
+  }
+
   .agent-card {
     background: var(--spectrum-alias-background-color-primary);
     border: 1px solid var(--spectrum-global-color-gray-300);
@@ -421,6 +453,13 @@
     flex-direction: column;
     gap: var(--spacing-xs);
     flex: 1;
+  }
+
+  .card-header-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-s);
   }
 
   .card-name {

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/index.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import ConfirmDialog from "@/components/common/ConfirmDialog.svelte"
-  import FavouriteResourceButton from "@/pages/builder/_components/FavouriteResourceButton.svelte"
   import { contextMenuStore, workspaceFavouriteStore } from "@/stores/builder"
   import { agentsStore } from "@/stores/portal"
   import {
@@ -9,19 +8,17 @@
     Button,
     Heading,
     Icon,
-    StatusLight,
     type ModalAPI,
     notifications,
     Tabs,
     Tab,
-    TooltipPosition,
   } from "@budibase/bbui"
   import type { Agent } from "@budibase/types"
   import { WorkspaceResource } from "@budibase/types"
-  import { url } from "@roxi/routify"
   import NoResults from "../_components/NoResults.svelte"
   import AgentModal from "./AgentModal.svelte"
   import UpdateAgentModal from "../_components/UpdateAgentModal.svelte"
+  import AgentCard from "./AgentCard.svelte"
   import { onMount } from "svelte"
 
   let showHighlight = false
@@ -81,22 +78,6 @@
         showHighlight = false
       }
     )
-  }
-
-  const getAgentIcon = (_agent: Agent) => {
-    // default for now, will update when storing agent icon properly
-    return "SideKick"
-  }
-
-  const getAgentIconColor = (agent: Agent, index: number) => {
-    const colors = [
-      "#6366F1", // purple
-      "#F59E0B", // orange
-      "#10B981", // green
-      "#8B5CF6", // purple
-      "#EF4444", // red
-    ]
-    return colors[index % colors.length]
   }
 
   $: filteredAgents = $agentsStore.agents.filter(agent => {
@@ -187,53 +168,13 @@
       {#if activeSubTab === "All"}
         <div class="agents-grid" class:empty={!agents.length}>
           {#each agents as agent, index}
-            {@const iconName = getAgentIcon(agent)}
-            {@const iconColor = getAgentIconColor(agent, index)}
-            <a
-              class="agent-card"
-              href={$url(`./${agent._id}${agent.live ? "" : "/config"}`)}
-              on:contextmenu={e => openContextMenu(e, agent)}
-              class:active={showHighlight && selectedAgent === agent}
-            >
-              <div class="card-icon" style="background-color: {iconColor}20;">
-                <Icon name={iconName} size="XL" color={iconColor} />
-              </div>
-              <div class="card-content">
-                <div class="card-header-row">
-                  <div class="card-name">
-                    <Body size="M">{agent.name}</Body>
-                  </div>
-                  <StatusLight
-                    size="S"
-                    color={agent.live
-                      ? "var(--spectrum-global-color-static-green-600)"
-                      : "var(--spectrum-global-color-static-gray-500)"}
-                  >
-                    <Body size="XS">
-                      {agent.live ? "Live" : "Draft"}
-                    </Body>
-                  </StatusLight>
-                </div>
-                <div class="card-creator">
-                  <Body size="S">Created by Budibase</Body>
-                </div>
-              </div>
-              <div class="card-actions">
-                <div class="ctx-btn">
-                  <Icon
-                    name="dots-three"
-                    size="M"
-                    hoverable
-                    on:click={e => openContextMenu(e, agent)}
-                  />
-                </div>
-                <FavouriteResourceButton
-                  favourite={agent.favourite}
-                  position={TooltipPosition.Left}
-                  noWrap
-                />
-              </div>
-            </a>
+            <AgentCard
+              {agent}
+              {index}
+              isHighlighted={showHighlight && selectedAgent === agent}
+              favourite={agent.favourite}
+              onContextMenu={openContextMenu}
+            />
           {/each}
           {#if !agents.length}
             <NoResults
@@ -248,53 +189,13 @@
       {:else if activeSubTab === "Live" || activeSubTab === "Draft"}
         <div class="agents-grid" class:empty={!agents.length}>
           {#each agents as agent, index}
-            {@const iconName = getAgentIcon(agent)}
-            {@const iconColor = getAgentIconColor(agent, index)}
-            <a
-              class="agent-card"
-              href={$url(`./${agent._id}${agent.live ? "" : "/config"}`)}
-              on:contextmenu={e => openContextMenu(e, agent)}
-              class:active={showHighlight && selectedAgent === agent}
-            >
-              <div class="card-icon" style="background-color: {iconColor}20;">
-                <Icon name={iconName} size="XL" color={iconColor} />
-              </div>
-              <div class="card-content">
-                <div class="card-header-row">
-                  <div class="card-name">
-                    <Body size="M">{agent.name}</Body>
-                  </div>
-                  <StatusLight
-                    size="S"
-                    color={agent.live
-                      ? "var(--spectrum-global-color-static-green-600)"
-                      : "var(--spectrum-global-color-static-gray-500)"}
-                  >
-                    <Body size="XS">
-                      {agent.live ? "Live" : "Draft"}
-                    </Body>
-                  </StatusLight>
-                </div>
-                <div class="card-creator">
-                  <Body size="S">Created by Budibase</Body>
-                </div>
-              </div>
-              <div class="card-actions">
-                <div class="ctx-btn">
-                  <Icon
-                    name="dots-three"
-                    size="M"
-                    hoverable
-                    on:click={e => openContextMenu(e, agent)}
-                  />
-                </div>
-                <FavouriteResourceButton
-                  favourite={agent.favourite}
-                  position={TooltipPosition.Left}
-                  noWrap
-                />
-              </div>
-            </a>
+            <AgentCard
+              {agent}
+              {index}
+              isHighlighted={showHighlight && selectedAgent === agent}
+              favourite={agent.favourite}
+              onContextMenu={openContextMenu}
+            />
           {/each}
           {#if !agents.length}
             <NoResults
@@ -405,8 +306,8 @@
 
   .agents-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-    gap: calc(var(--spacing-xl) * 3);
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: var(--spacing-xl);
   }
 
   .agents-grid.empty {
@@ -414,79 +315,6 @@
     justify-content: center;
     align-items: center;
     min-height: 320px;
-  }
-
-  .agent-card {
-    background: var(--spectrum-alias-background-color-primary);
-    border: 1px solid var(--spectrum-global-color-gray-300);
-    border-radius: var(--border-radius-s);
-    padding: var(--spacing-l);
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-m);
-    text-decoration: none;
-    color: var(--text-color);
-    transition:
-      transform 130ms ease-out,
-      box-shadow 130ms ease-out,
-      border-color 130ms ease-out;
-    position: relative;
-  }
-
-  .agent-card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-    border-color: var(--spectrum-global-color-gray-400);
-  }
-
-  .card-icon {
-    width: 48px;
-    height: 48px;
-    border-radius: var(--border-radius-s);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .card-content {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs);
-    flex: 1;
-  }
-
-  .card-header-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--spacing-s);
-  }
-
-  .card-name {
-    font-weight: 600;
-    color: var(--spectrum-global-color-gray-900);
-  }
-
-  .card-creator {
-    color: var(--spectrum-global-color-gray-600);
-  }
-
-  .card-actions {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: var(--spacing-xs);
-    opacity: 0;
-    transition: opacity 130ms ease-out;
-  }
-
-  .agent-card:hover .card-actions {
-    opacity: 1;
-  }
-
-  .ctx-btn {
-    display: flex;
-    align-items: center;
   }
 
   .empty-state {

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/index.svelte
@@ -98,7 +98,14 @@
     return colors[index % colors.length]
   }
 
-  $: agents = $agentsStore.agents
+  $: filteredAgents = $agentsStore.agents.filter(agent => {
+    if (activeSubTab === "All") return true
+    if (activeSubTab === "Live") return agent.live === true
+    if (activeSubTab === "Draft") return agent.live !== true
+    return true
+  })
+
+  $: agents = filteredAgents
     .map(agent => {
       return {
         ...agent,
@@ -183,7 +190,7 @@
             {@const iconColor = getAgentIconColor(agent, index)}
             <a
               class="agent-card"
-              href={$url(`./${agent._id}`)}
+              href={$url(`./${agent._id}${agent.live ? "" : "/config"}`)}
               on:contextmenu={e => openContextMenu(e, agent)}
               class:active={showHighlight && selectedAgent === agent}
             >
@@ -225,13 +232,56 @@
             </NoResults>
           {/if}
         </div>
-      {:else if activeSubTab === "Live"}
-        <div class="empty-state">
-          <Body size="M">Live agents will appear here</Body>
-        </div>
-      {:else if activeSubTab === "Draft"}
-        <div class="empty-state">
-          <Body size="M">Draft agents will appear here</Body>
+      {:else if activeSubTab === "Live" || activeSubTab === "Draft"}
+        <div class="agents-grid">
+          {#each agents as agent, index}
+            {@const iconName = getAgentIcon(agent)}
+            {@const iconColor = getAgentIconColor(agent, index)}
+            <a
+              class="agent-card"
+              href={$url(`./${agent._id}${agent.live ? "" : "/config"}`)}
+              on:contextmenu={e => openContextMenu(e, agent)}
+              class:active={showHighlight && selectedAgent === agent}
+            >
+              <div class="card-icon" style="background-color: {iconColor}20;">
+                <Icon name={iconName} size="XL" color={iconColor} />
+              </div>
+              <div class="card-content">
+                <div class="card-name">
+                  <Body size="M">{agent.name}</Body>
+                </div>
+                <div class="card-creator">
+                  <Body size="S">Created by Budibase</Body>
+                </div>
+              </div>
+              <div class="card-actions">
+                <div class="ctx-btn">
+                  <Icon
+                    name="dots-three"
+                    size="M"
+                    hoverable
+                    on:click={e => openContextMenu(e, agent)}
+                  />
+                </div>
+                <FavouriteResourceButton
+                  favourite={agent.favourite}
+                  position={TooltipPosition.Left}
+                  noWrap
+                />
+              </div>
+            </a>
+          {/each}
+          {#if !agents.length}
+            <NoResults
+              ctaText="Create your first agent"
+              onCtaClick={() => upsertModal.show()}
+              resourceType="agent"
+            >
+              {activeSubTab === "Live"
+                ? "No live agents yet!"
+                : "No draft agents yet!"}
+            </NoResults>
+          {/if}
         </div>
       {/if}
     {:else if activeTab === "Inspiration"}

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/index.svelte
@@ -202,10 +202,10 @@
               ctaText="Create your first agent"
               onCtaClick={() => upsertModal.show()}
               resourceType="agent"
+              hideCta={activeSubTab === "Live" ||
+                (activeSubTab === "Draft" && !agents.length)}
             >
-              {activeSubTab === "Live"
-                ? "No live agents yet!"
-                : "No draft agents yet!"}
+              {activeSubTab === "Live" ? "No live agents!" : "No draft agents!"}
             </NoResults>
           {/if}
         </div>

--- a/packages/server/src/api/controllers/ai/agents.ts
+++ b/packages/server/src/api/controllers/ai/agents.ts
@@ -338,7 +338,7 @@ export async function updateAgent(
 ) {
   const body = ctx.request.body
 
-  const updateRequest: UpdateAgentRequest = {
+  const updateRequest: RequiredKeys<UpdateAgentRequest> = {
     _id: body._id,
     _rev: body._rev,
     name: body.name,
@@ -347,6 +347,7 @@ export async function updateAgent(
     promptInstructions: body.promptInstructions,
     goal: body.goal,
     allowedTools: body.allowedTools,
+    _deleted: false,
     icon: body.icon,
     iconColor: body.iconColor,
     live: body.live,

--- a/packages/server/src/api/controllers/ai/agents.ts
+++ b/packages/server/src/api/controllers/ai/agents.ts
@@ -109,7 +109,7 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
     result.pipeUIMessageStreamToResponse(ctx.res, {
       originalMessages: chat.messages,
       onFinish: async ({ messages }) => {
-        const chatId = chat._id ?? docIds.generateAgentChatID()
+        const chatId = chat._id ?? docIds.generateAgentChatID(agent._id!)
         const existingChat = chat._id
           ? await db.tryGet<AgentChat>(chat._id)
           : null
@@ -319,7 +319,11 @@ export async function createAgent(
     description: body.description,
     aiconfig: body.aiconfig,
     promptInstructions: body.promptInstructions,
+    goal: body.goal,
     allowedTools: body.allowedTools || [],
+    icon: body.icon,
+    iconColor: body.iconColor,
+    live: body.live,
     _deleted: false,
   }
 
@@ -334,15 +338,18 @@ export async function updateAgent(
 ) {
   const body = ctx.request.body
 
-  const updateRequest: RequiredKeys<UpdateAgentRequest> = {
+  const updateRequest: UpdateAgentRequest = {
     _id: body._id,
     _rev: body._rev,
     name: body.name,
     description: body.description,
     aiconfig: body.aiconfig,
     promptInstructions: body.promptInstructions,
+    goal: body.goal,
     allowedTools: body.allowedTools,
-    _deleted: false,
+    icon: body.icon,
+    iconColor: body.iconColor,
+    live: body.live,
   }
 
   const agent = await sdk.ai.agents.update(updateRequest)

--- a/packages/server/src/api/controllers/ai/agents.ts
+++ b/packages/server/src/api/controllers/ai/agents.ts
@@ -1,4 +1,4 @@
-import { context, docIds, HTTPError } from "@budibase/backend-core"
+import { context, db, docIds, HTTPError } from "@budibase/backend-core"
 import { ai } from "@budibase/pro"
 import {
   Agent,
@@ -313,6 +313,8 @@ export async function createAgent(
   ctx: UserCtx<CreateAgentRequest, CreateAgentResponse>
 ) {
   const body = ctx.request.body
+  const createdBy = ctx.user?._id!
+  const globalId = db.getGlobalIDFromUserMetadataID(createdBy)
 
   const createRequest: RequiredKeys<CreateAgentRequest> = {
     name: body.name,
@@ -325,6 +327,7 @@ export async function createAgent(
     iconColor: body.iconColor,
     live: body.live,
     _deleted: false,
+    createdBy: globalId,
   }
 
   const agent = await sdk.ai.agents.create(createRequest)
@@ -351,6 +354,7 @@ export async function updateAgent(
     icon: body.icon,
     iconColor: body.iconColor,
     live: body.live,
+    createdBy: body.createdBy,
   }
 
   const agent = await sdk.ai.agents.update(updateRequest)

--- a/packages/server/src/api/routes/utils/validators/agent.ts
+++ b/packages/server/src/api/routes/utils/validators/agent.ts
@@ -89,6 +89,7 @@ export function createAgentValidator() {
       aiconfig: Joi.string().required(),
       promptInstructions: OPTIONAL_STRING,
       allowedTools: OPTIONAL_ARRAY.items(Joi.object().unknown(true)),
+      live: Joi.boolean().optional(),
     })
   )
 }

--- a/packages/server/src/api/routes/utils/validators/agent.ts
+++ b/packages/server/src/api/routes/utils/validators/agent.ts
@@ -90,6 +90,9 @@ export function createAgentValidator() {
       promptInstructions: OPTIONAL_STRING,
       allowedTools: OPTIONAL_ARRAY.items(Joi.object().unknown(true)),
       live: Joi.boolean().optional(),
+      goal: OPTIONAL_STRING,
+      icon: OPTIONAL_STRING,
+      iconColor: OPTIONAL_STRING,
     })
   )
 }
@@ -104,6 +107,10 @@ export function updateAgentValidator() {
       aiconfig: Joi.string().required(),
       promptInstructions: OPTIONAL_STRING,
       allowedTools: OPTIONAL_ARRAY.items(Joi.object().unknown(true)),
+      live: Joi.boolean().optional(),
+      goal: OPTIONAL_STRING,
+      icon: OPTIONAL_STRING,
+      iconColor: OPTIONAL_STRING,
     }).unknown(true)
   )
 }

--- a/packages/server/src/sdk/workspace/ai/agents/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/crud.ts
@@ -57,6 +57,7 @@ export async function create(request: CreateAgentRequest): Promise<Agent> {
     iconColor: request.iconColor,
     goal: request.goal,
     createdAt: now,
+    createdBy: request.createdBy,
   }
 
   const { rev } = await db.put(agent)

--- a/packages/server/src/sdk/workspace/ai/agents/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/crud.ts
@@ -9,6 +9,7 @@ import {
 const withAgentDefaults = (agent: Agent): Agent => ({
   ...agent,
   allowedTools: agent.allowedTools || [],
+  live: agent.live ?? false,
 })
 
 export async function fetch(): Promise<Agent[]> {
@@ -51,6 +52,8 @@ export async function create(request: CreateAgentRequest): Promise<Agent> {
     aiconfig: request.aiconfig,
     allowedTools: request.allowedTools,
     promptInstructions: request.promptInstructions,
+    live: request.live ?? false,
+    icon: request.icon,
     createdAt: now,
   }
 

--- a/packages/server/src/sdk/workspace/ai/agents/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/crud.ts
@@ -54,6 +54,8 @@ export async function create(request: CreateAgentRequest): Promise<Agent> {
     promptInstructions: request.promptInstructions,
     live: request.live ?? false,
     icon: request.icon,
+    iconColor: request.iconColor,
+    goal: request.goal,
     createdAt: now,
   }
 

--- a/packages/types/src/documents/global/agents.ts
+++ b/packages/types/src/documents/global/agents.ts
@@ -7,6 +7,8 @@ export interface Agent extends Document {
   aiconfig: string
   allowedTools?: AgentToolSource[]
   promptInstructions?: string
+  live?: boolean
+  icon?: string
 }
 
 export interface AgentChat extends Document {

--- a/packages/types/src/documents/global/agents.ts
+++ b/packages/types/src/documents/global/agents.ts
@@ -11,6 +11,7 @@ export interface Agent extends Document {
   live?: boolean
   icon?: string
   iconColor?: string
+  createdBy?: string
 }
 
 export interface AgentChat extends Document {

--- a/packages/types/src/documents/global/agents.ts
+++ b/packages/types/src/documents/global/agents.ts
@@ -7,8 +7,10 @@ export interface Agent extends Document {
   aiconfig: string
   allowedTools?: AgentToolSource[]
   promptInstructions?: string
+  goal?: string
   live?: boolean
   icon?: string
+  iconColor?: string
 }
 
 export interface AgentChat extends Document {


### PR DESCRIPTION
## Description
This PR updates the agents section in the codebase to allow users to create different agents with configurations on a per agent basis, and then to set those agents live. Setting guardrails / bindings etc is not enabled right now. 

This is only the first PR of multiple to come, so I wouldn't worry too much about testing the UI etc just yet. Things will change in the coming weeks almost certainly. 
## Addresses
- #17387 

## Screenshots

https://github.com/user-attachments/assets/ba442b35-0c38-4ba7-8588-be9a8b0390a2


