### PR TITLE
[BUDI-17435] Fix workspace import file field mismatch

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -139,6 +139,7 @@
     "@babel/core": "^7.22.5",
     "@babel/preset-env": "7.16.11",
     "@types/archiver": "6.0.2",
+    "@types/formidable": "^1.0.31",
     "@types/global-agent": "2.1.1",
     "@types/html-to-text": "^9.0.4",
     "@types/js-yaml": "^4.0.9",

--- a/packages/server/src/api/controllers/workspace.ts
+++ b/packages/server/src/api/controllers/workspace.ts
@@ -15,6 +15,7 @@ import {
 } from "@budibase/backend-core"
 import { groups, licensing, quotas } from "@budibase/pro"
 import { DefaultAppTheme, sdk as sharedCoreSDK } from "@budibase/shared-core"
+import type { File, Files } from "formidable"
 import {
   AddWorkspaceSampleDataResponse,
   BBReferenceFieldSubType,
@@ -890,11 +891,17 @@ export async function sync(ctx: UserCtx<void, SyncWorkspaceResponse>) {
   }
 }
 
+type WorkspaceImportFiles = Files & {
+  appExport?: File | File[]
+  file?: File | File[]
+}
+
 export async function importToWorkspace(
   ctx: UserCtx<ImportToUpdateWorkspaceRequest, ImportToUpdateWorkspaceResponse>
 ) {
   const { appId: workspaceId } = ctx.params
-  const workspaceExport = ctx.request.files?.appExport
+  const files = ctx.request.files as WorkspaceImportFiles | undefined
+  const workspaceExport = files?.appExport ?? files?.file
   const password = ctx.request.body.encryptionPassword
   if (!workspaceExport) {
     ctx.throw(400, "Must supply export file to import")

--- a/packages/server/src/api/routes/public/tests/workspace.spec.ts
+++ b/packages/server/src/api/routes/public/tests/workspace.spec.ts
@@ -40,7 +40,7 @@ describe("check export/import", () => {
     )
   }
 
-  async function runImport() {
+  async function runImport(field: "appExport" | "file" = "appExport") {
     const pathToExport = join(
       __dirname,
       "..",
@@ -54,7 +54,7 @@ describe("check export/import", () => {
       `/workspaces/${config.devWorkspaceId}/import`,
       {
         encryptionPassword: PASSWORD,
-        appExport: { path: pathToExport },
+        [field]: { path: pathToExport },
       }
     )
   }

--- a/packages/server/src/api/routes/tests/workspaceImport.spec.ts
+++ b/packages/server/src/api/routes/tests/workspaceImport.spec.ts
@@ -203,4 +203,20 @@ describe("/applications/:appId/import", () => {
       "manifest.json": "93bcfcf77d7c3fa555642816f42214fa",
     })
   })
+
+  it("should import when the file is provided under the 'file' field", async () => {
+    const appId = config.getDevWorkspaceId()
+    await request
+      .post(`/api/applications/${appId}/import`)
+      .field("encryptionPassword", PASSWORD)
+      .attach("file", path.join(__dirname, "data", "old-export.enc.tar.gz"))
+      .set(config.defaultHeaders())
+      .expect("Content-Type", /json/)
+      .expect(200)
+
+    const screens = await config.api.screen.list()
+    expect(screens.length).toBe(2)
+    expect(screens[0].routing.route).toBe("/derp")
+    expect(screens[1].routing.route).toBe("/blank")
+  })
 })


### PR DESCRIPTION
## Summary
- allow workspace import to consume either `file` or `appExport` multipart fields so the public API matches the OpenAPI schema
- update the internal controller and helper to share the same file normalization logic
- strengthen regression coverage by adding a routes test that imports using `files.file`

## Testing
- `yarn test src/api/routes/tests/workspaceImport.spec.ts`

## Addresses
- https://github.com/Budibase/budibase/issues/17435

## Screenshots
https://github.com/user-attachments/assets/ce490a5b-baaa-4a71-a0e5-eb1151aca4a8

