### PR TITLE
Vastly simplify how we extract chunk data from our ai chat endpoint

### DIFF
--- a/packages/builder/src/helpers/tests/sseTransform.spec.ts
+++ b/packages/builder/src/helpers/tests/sseTransform.spec.ts
@@ -131,4 +131,3 @@ describe("createSseToJsonTransformStream", () => {
     expect(results).toEqual([{ nested: { value: 42 } }])
   })
 })
-

--- a/packages/builder/src/helpers/tests/sseTransform.spec.ts
+++ b/packages/builder/src/helpers/tests/sseTransform.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest"
+import { Utils } from "@budibase/frontend-core"
+
+const { createSseToJsonTransformStream } = Utils
+
+async function transformStream<T>(
+  transform: TransformStream<string, T>,
+  chunks: string[]
+): Promise<T[]> {
+  const results: T[] = []
+  const writer = transform.writable.getWriter()
+  const reader = transform.readable.getReader()
+
+  const readPromise = (async () => {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      results.push(value)
+    }
+  })()
+
+  for (const chunk of chunks) {
+    await writer.write(chunk)
+  }
+  await writer.close()
+  await readPromise
+
+  return results
+}
+
+describe("createSseToJsonTransformStream", () => {
+  it("parses complete SSE lines", async () => {
+    const transform = createSseToJsonTransformStream<{ type: string }>()
+    const results = await transformStream(transform, [
+      'data: {"type":"hello"}\n',
+      'data: {"type":"world"}\n',
+    ])
+
+    expect(results).toEqual([{ type: "hello" }, { type: "world" }])
+  })
+
+  it("handles chunks split across message boundaries", async () => {
+    const transform = createSseToJsonTransformStream<{ type: string }>()
+    const results = await transformStream(transform, [
+      'data: {"type":"hel',
+      'lo"}\ndata: {"type":"world"}\n',
+    ])
+
+    expect(results).toEqual([{ type: "hello" }, { type: "world" }])
+  })
+
+  it("handles multiple messages in a single chunk", async () => {
+    const transform = createSseToJsonTransformStream<{ n: number }>()
+    const results = await transformStream(transform, [
+      'data: {"n":1}\ndata: {"n":2}\ndata: {"n":3}\n',
+    ])
+
+    expect(results).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }])
+  })
+
+  it("ignores [DONE] sentinel", async () => {
+    const transform = createSseToJsonTransformStream<{ type: string }>()
+    const results = await transformStream(transform, [
+      'data: {"type":"hello"}\n',
+      "data: [DONE]\n",
+    ])
+
+    expect(results).toEqual([{ type: "hello" }])
+  })
+
+  it("ignores empty lines", async () => {
+    const transform = createSseToJsonTransformStream<{ type: string }>()
+    const results = await transformStream(transform, [
+      'data: {"type":"hello"}\n',
+      "\n",
+      "\n",
+      'data: {"type":"world"}\n',
+    ])
+
+    expect(results).toEqual([{ type: "hello" }, { type: "world" }])
+  })
+
+  it("ignores non-data lines (comments, event types)", async () => {
+    const transform = createSseToJsonTransformStream<{ type: string }>()
+    const results = await transformStream(transform, [
+      ": this is a comment\n",
+      "event: message\n",
+      'data: {"type":"hello"}\n',
+      "id: 123\n",
+    ])
+
+    expect(results).toEqual([{ type: "hello" }])
+  })
+
+  it("handles realistic SSE stream with reasoning and text deltas", async () => {
+    const transform = createSseToJsonTransformStream<{
+      type: string
+      delta?: string
+    }>()
+    const results = await transformStream(transform, [
+      'data: {"type":"reasoning-start","id":"r-0"}\n',
+      'data: {"type":"reasoning-delta","id":"r-0","delta":"Think',
+      'ing..."}\n',
+      'data: {"type":"reasoning-end","id":"r-0"}\n',
+      'data: {"type":"text-start","id":"t-0"}\n',
+      'data: {"type":"text-delta","id":"t-0","delta":"Hello"}\n',
+      'data: {"type":"text-end","id":"t-0"}\n',
+      "data: [DONE]\n",
+    ])
+
+    expect(results).toEqual([
+      { type: "reasoning-start", id: "r-0" },
+      { type: "reasoning-delta", id: "r-0", delta: "Thinking..." },
+      { type: "reasoning-end", id: "r-0" },
+      { type: "text-start", id: "t-0" },
+      { type: "text-delta", id: "t-0", delta: "Hello" },
+      { type: "text-end", id: "t-0" },
+    ])
+  })
+
+  it("handles data split mid-JSON", async () => {
+    const transform = createSseToJsonTransformStream<{
+      nested: { value: number }
+    }>()
+    const results = await transformStream(transform, [
+      'data: {"nested":',
+      '{"value":',
+      "42}}\n",
+    ])
+
+    expect(results).toEqual([{ nested: { value: 42 } }])
+  })
+})
+

--- a/packages/frontend-core/src/components/Chatbox/index.svelte
+++ b/packages/frontend-core/src/components/Chatbox/index.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Helpers, MarkdownViewer, notifications } from "@budibase/bbui"
+  import { MarkdownViewer, notifications } from "@budibase/bbui"
   import type { AgentChat } from "@budibase/types"
   import BBAI from "../../icons/BBAI.svelte"
   import { tick } from "svelte"
@@ -7,7 +7,7 @@
   import { onMount } from "svelte"
   import { createEventDispatcher } from "svelte"
   import { createAPIClient } from "@budibase/frontend-core"
-  import type { UIMessage, UIMessageChunk } from "ai"
+  import type { UIMessage } from "ai"
   import { v4 as uuidv4 } from "uuid"
 
   export let API = createAPIClient()
@@ -52,97 +52,36 @@
       parts: [{ type: "text", text: inputValue }],
     }
 
-    const updatedChat = {
+    const updatedChat: AgentChat = {
       ...chat,
       messages: [...chat.messages, userMessage],
     }
 
-    // Update local display immediately with user message
     chat = updatedChat
-
-    // Ensure we scroll to the new message
     await scrollToBottom()
 
     inputValue = ""
     loading = true
 
-    let streamingText = ""
-    let assistantIndex = -1
-    let streamCompleted = false
-
     try {
-      await API.agentChatStream(
-        updatedChat,
-        workspaceId,
-        (chunk: UIMessageChunk) => {
-          if (chunk.type === "text-start") {
-            const assistantMessage: UIMessage = {
-              id: Helpers.uuid(),
-              role: "assistant",
-              parts: [{ type: "text", text: "", state: "streaming" }],
-            }
-            chat = {
-              ...chat,
-              messages: [...updatedChat.messages, assistantMessage],
-            }
-            assistantIndex = chat.messages.length - 1
-            scrollToBottom()
-          } else if (chunk.type === "text-delta") {
-            streamingText += chunk.delta || ""
-            if (assistantIndex >= 0) {
-              const messages = [...chat.messages]
-              const assistant = { ...messages[assistantIndex] }
-              const parts = [...assistant.parts]
-              const textPart = parts.find(p => p.type === "text")
-              if (textPart) {
-                textPart.text = streamingText
-              }
-              assistant.parts = parts
-              messages[assistantIndex] = assistant
-              chat = { ...chat, messages }
-            }
-            scrollToBottom()
-          } else if (chunk.type === "text-end") {
-            loading = false
-            streamCompleted = true
-            if (assistantIndex >= 0) {
-              const messages = [...chat.messages]
-              const assistant = { ...messages[assistantIndex] }
-              const parts = [...assistant.parts]
-              const textPart = parts.find(p => p.type === "text")
-              if (textPart) {
-                textPart.state = "done"
-              }
-              assistant.parts = parts
-              messages[assistantIndex] = assistant
-              chat = { ...chat, messages }
-            }
-            scrollToBottom()
-          } else if (chunk.type === "error") {
-            notifications.error(chunk.errorText || "An error occurred")
-            loading = false
-          }
-        },
-        error => {
-          console.error("Streaming error:", error)
-          notifications.error(error.message)
-          loading = false
-        }
-      )
+      const messageStream = await API.agentChatStream(updatedChat, workspaceId)
 
-      if (streamCompleted && chat) {
-        setTimeout(() => {
-          const chatId = chat._id || ""
-          dispatch("chatSaved", { chatId })
-        }, 500)
+      for await (const message of messageStream) {
+        chat = {
+          ...updatedChat,
+          messages: [...updatedChat.messages, message],
+        }
+        scrollToBottom()
       }
+
+      loading = false
+      dispatch("chatSaved", { chatId: chat._id || "" })
     } catch (err: any) {
       console.error(err)
       notifications.error(err.message)
       loading = false
     }
 
-    // Return focus to textarea after the response
     await tick()
     if (textareaElement) {
       textareaElement.focus()


### PR DESCRIPTION
## Description
Previously we were doing lots of manual parsing to extract out specific chunk types from the ai sdk stream on our backend. This pipes this stream through the ai sdk's own `readUIMessageStream` meaning that we got type awareness / safety without having to do any manual parsing of our own. 

Also fixes an issue with chat streaming in that certain inference providers send through` <think/> `tags  with the actual response, so extracting those out in a middleware. 