### PR TITLE
Further fixes and tests for covering issues around column renames

### DIFF
--- a/packages/server/src/api/routes/tests/deploy.spec.ts
+++ b/packages/server/src/api/routes/tests/deploy.spec.ts
@@ -510,7 +510,7 @@ describe("/api/deploy", () => {
     }
 
     // casting to any here because TS can't infer the description property properly.
-    delete renamedSchema.description
+    delete (renamedSchema as any).description
 
     const renamedTable = await config.api.table.save({
       ...table,

--- a/packages/server/src/api/routes/tests/deploy.spec.ts
+++ b/packages/server/src/api/routes/tests/deploy.spec.ts
@@ -1,14 +1,17 @@
-import { constants, db as dbCore } from "@budibase/backend-core"
+import { constants, context, db as dbCore } from "@budibase/backend-core"
 import { structures } from "@budibase/backend-core/tests"
 import {
   Automation,
   FieldType,
   FormulaType,
   PublishResourceState,
+  Row,
+  Table,
   WorkspaceApp,
 } from "@budibase/types"
 import { cloneDeep } from "lodash/fp"
 import { createAutomationBuilder } from "../../../automations/tests/utilities/AutomationTestBuilder"
+import { getRowParams } from "../../../db/utils"
 import { basicTable } from "../../../tests/utilities/structures"
 import * as setup from "./utilities"
 
@@ -507,7 +510,7 @@ describe("/api/deploy", () => {
     }
 
     // casting to any here because TS can't infer the description property properly.
-    delete (renamedSchema as any).description
+    delete renamedSchema.description
 
     const renamedTable = await config.api.table.save({
       ...table,
@@ -529,6 +532,78 @@ describe("/api/deploy", () => {
 
       expect(prodRows.rows[0].details).toBe("original value")
       expect(prodRows.rows[0].description).toBeUndefined()
+    })
+  })
+
+  it("applies pending renames even when the replicated schema is stale", async () => {
+    const table = await config.api.table.save(basicTable())
+    await config.api.row.save(table._id!, {
+      name: "Test Row",
+      description: "original value",
+    })
+
+    await config.api.workspace.publish(config.devWorkspace!.appId)
+
+    const rename = { old: "description", updated: "details" }
+    const renamedSchema = {
+      ...table.schema,
+      details: {
+        ...table.schema.description,
+        name: "details",
+      },
+    }
+    delete (renamedSchema as any).description
+
+    const renamedTable = await config.api.table.save({
+      ...table,
+      schema: renamedSchema,
+      _rename: rename,
+    })
+
+    // Simulating that we got a stale schema that still uses the old column.
+    await config.doInContext(config.getDevWorkspaceId(), async () => {
+      const db = context.getWorkspaceDB()
+      const tableDoc = await db.tryGet<Table>(renamedTable._id!)
+      if (tableDoc) {
+        tableDoc.schema = {
+          ...tableDoc.schema,
+          description: { ...table.schema.description, name: "description" },
+        }
+        delete tableDoc.schema.details
+        await db.put(tableDoc)
+      }
+
+      const rows = (
+        await db.allDocs<Row>(
+          getRowParams(renamedTable._id!, null, { include_docs: true })
+        )
+      ).rows.map(row => row.doc!)
+
+      await db.bulkDocs(
+        rows.map(row => {
+          const updated: Row = {
+            ...row,
+            description: row.details || row.description,
+          }
+          delete updated.details
+          return updated
+        })
+      )
+    })
+
+    await config.api.workspace.publish(config.devWorkspace!.appId)
+
+    await config.withProdApp(async () => {
+      const prodRows = await config.api.row.search(renamedTable._id!, {
+        query: {},
+      })
+
+      expect(prodRows.rows[0].details).toBe("original value")
+      expect(prodRows.rows[0].description).toBeUndefined()
+
+      const prodTable = await config.api.table.get(renamedTable._id!)
+      expect(prodTable.pendingColumnRenames || []).toHaveLength(0)
+      expect(prodTable.schema.details).toBeDefined()
     })
   })
 })

--- a/packages/server/src/sdk/workspace/rows/search/internal/sqs.ts
+++ b/packages/server/src/sdk/workspace/rows/search/internal/sqs.ts
@@ -116,6 +116,9 @@ export async function buildInternalFieldList(
   }
   for (let key of schemaFields) {
     const col = table.schema[key]
+    if (!col) {
+      continue
+    }
 
     const isRelationship = col.type === FieldType.LINK
     if (!relationships && isRelationship) {

--- a/packages/server/src/sdk/workspace/rows/search/internal/test/sqs.spec.ts
+++ b/packages/server/src/sdk/workspace/rows/search/internal/test/sqs.spec.ts
@@ -614,5 +614,20 @@ describe("buildInternalFieldList", () => {
       const result = await buildInternalFieldList(view, [])
       expect(result).toEqual([`${view.tableId}.data_amount`])
     })
+
+    it("skips view fields that no longer exist on the table", async () => {
+      const baseTable = new TableConfig().create()
+      const view = new ViewConfig(baseTable).withVisible("missing").create()
+
+      const result = await buildInternalFieldList(view, [])
+      expect(result).toEqual([
+        `${view.tableId}._id`,
+        `${view.tableId}._rev`,
+        `${view.tableId}.type`,
+        `${view.tableId}.createdAt`,
+        `${view.tableId}.updatedAt`,
+        `${view.tableId}.tableId`,
+      ])
+    })
   })
 })

--- a/packages/server/src/sdk/workspace/tables/internal/index.ts
+++ b/packages/server/src/sdk/workspace/tables/internal/index.ts
@@ -115,7 +115,7 @@ export async function save(
   }
 
   // rename row fields when table column is renamed
-  if (renaming && table.schema[renaming.updated].type === FieldType.LINK) {
+  if (renaming && table.schema[renaming.updated]?.type === FieldType.LINK) {
     throw new Error("Cannot rename a linked column.")
   }
 

--- a/packages/server/src/sdk/workspace/views/index.ts
+++ b/packages/server/src/sdk/workspace/views/index.ts
@@ -483,14 +483,20 @@ export function syncSchema(
   schema: TableSchema,
   renameColumn: RenameColumn | undefined
 ): ViewV2 {
-  if (renameColumn && view.schema) {
-    view.schema[renameColumn.updated] = view.schema[renameColumn.old]
+  if (renameColumn && view.schema && view.schema[renameColumn.old] != null) {
+    if (!view.schema[renameColumn.updated]) {
+      view.schema[renameColumn.updated] = view.schema[renameColumn.old]
+    }
     delete view.schema[renameColumn.old]
   }
 
   if (view.schema) {
     for (const fieldName of Object.keys(view.schema)) {
       const viewSchema = view.schema[fieldName]
+      if (!viewSchema) {
+        delete view.schema[fieldName]
+        continue
+      }
       if (!helpers.views.isCalculationField(viewSchema) && !schema[fieldName]) {
         delete view.schema[fieldName]
       }

--- a/packages/server/src/sdk/workspace/views/tests/views.spec.ts
+++ b/packages/server/src/sdk/workspace/views/tests/views.spec.ts
@@ -596,6 +596,32 @@ describe("table sdk", () => {
         })
       })
 
+      it("ignores pending renames when the view schema is already using the updated column name", () => {
+        const view: ViewV2 = {
+          ...basicView,
+          schema: {
+            updatedDescription: { visible: true, width: 150, icon: "ic-any" },
+          },
+        }
+        const { description, ...newTableSchema } = {
+          ...basicTable.schema,
+          updatedDescription: {
+            ...basicTable.schema.description,
+            name: "updatedDescription",
+          },
+        } as TableSchema
+
+        const result = syncSchema(_.cloneDeep(view), newTableSchema, {
+          old: "description",
+          updated: "updatedDescription",
+        })
+
+        expect(result.schema?.updatedDescription).toEqual(
+          view.schema?.updatedDescription
+        )
+        expect(result.schema?.description).toBeUndefined()
+      })
+
       it("changing no UI schema will not affect the view", () => {
         const view: ViewV2 = {
           ...basicView,


### PR DESCRIPTION
## Description
I'm not exactly sure how, but replication could somehow leave the column renaming process in a bad state, leaving production half synced. 


```
  @budibase/server: [08:52:49.136] WARN (88802): Cannot resolve inconsistencies for document ta_1522a0be80484b128a33741b6d20fb11 {"service":"@budibase/
  server","tenantId":"default","appId":"app_dev_221d3681cddb47daa0cadfeb157175e6","identityId":"us_3e7cd0879cda43949bc87c58b8c8e7da","identityType":"user","correlationId":"6702bf33-
  5ac4-42c2-b868-108393358ff8"}
```

This error would occur, and then couch would pick a previous revision to replicate across that didn't have the new column mame. So the pending rename existed on the table but the name wasn't on the schema. Meaning the data looked "deleted" in production, but it was just under the old key. 


Basically we now check if this state has happened, and if it has, we get the correct schema as part of the renaming process, and then we give it the new name, and continue as normal. Also added in a number of defensive checks to make sure if we get into this state we handle it a bit more gracefully. 