### PR TITLE
fix: preserve action bindings when reordering

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionDrawer.svelte
@@ -33,6 +33,7 @@
   let actionQuery
   let selectedAction = actions?.length ? actions[0] : null
   let originalActionIndex
+  let draggingActionId
 
   const setUpdateActions = actions => {
     return actions
@@ -156,15 +157,26 @@
     toggleActionList()
   }
 
-  function handleDndConsider(e) {
-    actions = e.detail.items
-
-    // set the initial index of the action being dragged
-    if (e.detail.info.trigger === "draggedEntered") {
-      originalActionIndex = actions.findIndex(
-        action => action.id === e.detail.info.id
-      )
+  const recordOriginalActionIndex = id => {
+    if (!actions || !id) {
+      return
     }
+    if (draggingActionId !== id) {
+      draggingActionId = id
+      originalActionIndex = -1
+    }
+    if (originalActionIndex >= 0) {
+      return
+    }
+    const index = actions.findIndex(action => action.id === id)
+    if (index !== -1) {
+      originalActionIndex = index
+    }
+  }
+
+  function handleDndConsider(e) {
+    recordOriginalActionIndex(e.detail.info.id)
+    actions = e.detail.items
   }
   function handleDndFinalize(e) {
     actions = e.detail.items
@@ -181,6 +193,7 @@
     })
 
     originalActionIndex = -1
+    draggingActionId = undefined
   }
 
   const getAllBindings = (actionBindings, eventContextBindings, actions) => {

--- a/packages/builder/src/dataBinding.js
+++ b/packages/builder/src/dataBinding.js
@@ -1485,6 +1485,12 @@ export const updateReferencesInObject = ({
   label,
   originalIndex,
 }) => {
+  if (
+    action === UpdateReferenceAction.MOVE &&
+    (typeof originalIndex !== "number" || originalIndex < 0)
+  ) {
+    return
+  }
   const stepIndexRegex = new RegExp(`{{\\s*${label}\\.(\\d+)\\.`, "g")
   const updateActionStep = (str, index, replaceWith) =>
     str.replace(`{{ ${label}.${index}.`, `{{ ${label}.${replaceWith}.`)
@@ -1516,7 +1522,7 @@ export const updateReferencesInObject = ({
             obj[key] = updateActionStep(obj[key], referencedStep, modifiedIndex)
           } else if (
             modifiedIndex <= referencedStep &&
-            modifiedIndex < originalIndex
+            referencedStep < originalIndex
           ) {
             obj[key] = updateActionStep(
               obj[key],
@@ -1524,8 +1530,8 @@ export const updateReferencesInObject = ({
               referencedStep + 1
             )
           } else if (
-            modifiedIndex >= referencedStep &&
-            modifiedIndex > originalIndex
+            originalIndex < referencedStep &&
+            referencedStep <= modifiedIndex
           ) {
             obj[key] = updateActionStep(
               obj[key],

--- a/packages/builder/src/dataBinding.test.js
+++ b/packages/builder/src/dataBinding.test.js
@@ -511,6 +511,60 @@ describe("Builder dataBinding", () => {
       ])
     })
 
+    it("should not decrement references that sit before the moved action", () => {
+      let obj = [
+        {
+          id: "queryAction",
+          parameters: {
+            text: "{{ actions.0.result }}",
+          },
+        },
+        {
+          id: "notification",
+          parameters: {
+            text: "{{ actions.0.result }}",
+          },
+        },
+        {
+          id: "prompt",
+          parameters: {
+            text: "Prompt",
+          },
+        },
+      ]
+
+      updateReferencesInObject({
+        obj,
+        modifiedIndex: 2,
+        action: "move",
+        label: "actions",
+        originalIndex: 1,
+      })
+
+      expect(obj[1].parameters.text).toEqual("{{ actions.0.result }}")
+    })
+
+    it("should skip move updates when the original index is invalid", () => {
+      let obj = [
+        {
+          id: "queryAction",
+          parameters: {
+            text: "{{ actions.0.result }}",
+          },
+        },
+      ]
+
+      updateReferencesInObject({
+        obj,
+        modifiedIndex: 0,
+        action: "move",
+        label: "actions",
+        originalIndex: -1,
+      })
+
+      expect(obj[0].parameters.text).toEqual("{{ actions.0.result }}")
+    })
+
     it("should handle on 'move' to a higher index", () => {
       let obj = [
         {


### PR DESCRIPTION
## Description
Fix for action binding ordering

## Addresses
- https://github.com/Budibase/budibase/issues/17092

## Screenshots
https://github.com/user-attachments/assets/c786ba5b-1c1d-477a-b4d0-c2e145749c6e

## Launchcontrol
Make sure actions binding reference is correct on re-order.
