### PR TITLE
[BUDI-9930] Prevent copying views when duplicating tables

### DIFF
--- a/packages/server/src/api/routes/tests/table.spec.ts
+++ b/packages/server/src/api/routes/tests/table.spec.ts
@@ -33,7 +33,7 @@ import timekeeper from "timekeeper"
 import { datasourceDescribe } from "../../../integrations/tests/utils"
 import { tableForDatasource } from "../../../tests/utilities/structures"
 
-const { basicTable } = setup.structures
+const { basicTable, viewV2: viewV2Structures } = setup.structures
 const ISO_REGEX_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
 
 const descriptions = datasourceDescribe({ plus: true })
@@ -1164,6 +1164,21 @@ if (descriptions.length) {
             // Verify original table still has its data
             const originalRows = await config.api.row.fetch(testTable._id!)
             expect(originalRows.length).toBe(2)
+          })
+
+          it("should not duplicate table views", async () => {
+            const createdView = await config.api.viewV2.create(
+              viewV2Structures.createRequest(testTable._id!)
+            )
+
+            const duplicatedTable = await config.api.table.duplicate(
+              testTable._id!
+            )
+
+            expect(Object.keys(duplicatedTable.views || {})).toHaveLength(0)
+
+            const originalTable = await config.api.table.get(testTable._id!)
+            expect(originalTable.views?.[createdView.name]).toBeDefined()
           })
 
           it("should apply authorization to endpoint", async () => {

--- a/packages/server/src/sdk/workspace/tables/duplicate.ts
+++ b/packages/server/src/sdk/workspace/tables/duplicate.ts
@@ -23,7 +23,7 @@ export async function duplicate(table: Table, userId?: string): Promise<Table> {
     sourceType: table.sourceType,
     sourceId: table.sourceId,
     schema: { ...table.schema },
-    views: table.views ? { ...table.views } : {},
+    views: {},
     indexes: table.indexes ? { ...table.indexes } : undefined,
     // Don't include any data/rows - this is intentionally empty
   }


### PR DESCRIPTION
## Description
- Internal table duplication now always creates table copies with an empty `views` map so duplicates no longer surface the original views.
- Added an API test that builds a v2 view, duplicates the table, and asserts that only the source retains the view.

## Addresses
- https://github.com/Budibase/budibase/issues/17495

## Screenshots
<img width="728" height="284" alt="with view" src="https://github.com/user-attachments/assets/9d1214b4-26f2-4335-a148-6e4b79fd4e8c" />

ORIGINAL TABLE WITH VIEW

<img width="728" height="284" alt="duplicated table" src="https://github.com/user-attachments/assets/c4de9f95-c366-422e-9a20-3d5b52a0ab5e" />

DUPLICATED TABLE (no view copied)

## Launchcontrol
Table duplication now leaves the views list empty so the original table remains the only owner of its existing views.
