### PR TITLE
[BUDI-17041] Add workspace creator to dev users table

### DIFF
--- a/packages/server/src/api/controllers/workspace.ts
+++ b/packages/server/src/api/controllers/workspace.ts
@@ -55,6 +55,9 @@ import { createOnboardingWelcomeScreen } from "../../constants/screens"
 import { buildDefaultDocs } from "../../db/defaultData/datasource_bb_default"
 import {
   DocumentType,
+  InternalTables,
+  USER_METDATA_PREFIX,
+  generateUserMetadataID,
   generateWorkspaceID,
   getDevWorkspaceID,
   getLayoutParams,
@@ -81,6 +84,7 @@ import { removeWorkspaceFromUserRoles } from "../../utilities/workerRequests"
 import { builderSocket } from "../../websockets"
 import * as workspaceMigrations from "../../workspaceMigrations"
 import { processMigrations } from "../../workspaceMigrations/migrationsProcessor"
+import { getGlobalUser } from "../../utilities/global"
 
 const DEFAULT_WORKSPACE_NAME = "Default workspace"
 
@@ -173,6 +177,53 @@ async function createInstance(appId: string, template: AppTemplate) {
   }
 
   return { _id: appId }
+}
+
+function getCreatorMetadataId(ctx: UserCtx) {
+  const userId = ctx.user?._id
+  if (!userId) {
+    return
+  }
+  if (userId.startsWith(USER_METDATA_PREFIX)) {
+    return userId
+  }
+  return generateUserMetadataID(userId)
+}
+
+async function addCreatorToUsersTable(ctx: UserCtx) {
+  const metadataId = getCreatorMetadataId(ctx)
+  if (!metadataId) {
+    return
+  }
+  const db = context.getWorkspaceDB()
+  try {
+    await db.get(metadataId)
+    return
+  } catch (err: any) {
+    if (err.status && err.status !== 404) {
+      throw err
+    }
+  }
+
+  let creator
+  try {
+    creator = await getGlobalUser(metadataId)
+  } catch (err) {
+    return
+  }
+
+  if (!creator.roleId || creator.roleId === roles.BUILTIN_ROLE_IDS.PUBLIC) {
+    creator.roleId = roles.BUILTIN_ROLE_IDS.ADMIN
+  }
+
+  const metadata = sdk.users.combineMetadataAndUser(creator, [])
+  if (!metadata) {
+    return
+  }
+
+  metadata.tableId = InternalTables.USER_METADATA
+  metadata._id = metadataId
+  await db.put(metadata)
 }
 
 async function addSampleDataDocs() {
@@ -398,6 +449,8 @@ async function performWorkspaceCreate(
     const instance = await createInstance(workspaceId, instanceConfig)
     const db = context.getWorkspaceDB()
     const isImport = !!instanceConfig.file
+
+    await addCreatorToUsersTable(ctx)
 
     if (instanceConfig.useTemplate && !instanceConfig.file) {
       await updateUserColumns(workspaceId, db, ctx.user._id!)


### PR DESCRIPTION
## Description
- add a helper that writes the workspace creator to the dev users table as soon as the workspace database is created so they appear in the default app without requiring a publish
- add a regression test that confirms the creator now exists inside the dev users table

## Addresses
- https://github.com/Budibase/budibase/issues/17041

## Screenshots
<img width="1628" height="441" alt="new workspace" src="https://github.com/user-attachments/assets/02eb2eb4-ed86-4e14-adbe-1e5c7ae8f21d" />

*Creator added to the users dev table upon creation of the workspace.*

## Launchcontrol
Adds the workspace creator to the dev users table when a workspace is created so builders immediately see themselves in the default app.