### PR TITLE
[Fixed] Even when disabled on an app-level, re-captcha is still enabled

### DIFF
--- a/packages/builder/src/stores/builder/recaptcha.ts
+++ b/packages/builder/src/stores/builder/recaptcha.ts
@@ -20,13 +20,15 @@ export class RecaptchaStore extends BudiStore<RecaptchaState> {
   syncRecaptcha = (workspace: Workspace, key?: string) => {
     this.set({
       available: !!key,
-      enabled: !!workspace.recaptchaEnabled && !!key,
+      enabled: !!workspace.features?.recaptchaEnabled && !!key,
     })
   }
 
   async setState(enabled: boolean) {
     const appId = get(appStore).appId
-    await API.saveAppMetadata(appId, { recaptchaEnabled: enabled })
+    await API.saveAppMetadata(appId, {
+      features: { recaptchaEnabled: enabled },
+    })
     this.update(state => {
       state.enabled = state.available && enabled
       return state

--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -189,7 +189,7 @@
   >
     {#if $environmentStore.maintenance.length > 0}
       <MaintenanceScreen maintenanceList={$environmentStore.maintenance} />
-    {:else if $featuresStore.recaptchaEnabled && $appStore.recaptchaKey && !$recaptchaStore.verified && !$builderStore.inBuilder}
+    {:else if $featuresStore.recaptchaEnabled && $appStore.application?.features?.recaptchaEnabled && $appStore.recaptchaKey && !$recaptchaStore.verified && !$builderStore.inBuilder}
       <RecaptchaV2 />
     {:else}
       <EmbedProvider>

--- a/packages/server/src/api/controllers/workspace.ts
+++ b/packages/server/src/api/controllers/workspace.ts
@@ -1052,6 +1052,10 @@ export async function updateWorkspacePackage(
     const newWorkspacePackage: Workspace = {
       ...application,
       ...workspacePackage,
+      features: {
+        ...application.features,
+        ...workspacePackage.features,
+      },
     }
     if (workspacePackage._rev !== application._rev) {
       newWorkspacePackage._rev = application._rev

--- a/packages/server/src/api/routes/tests/recaptcha.spec.ts
+++ b/packages/server/src/api/routes/tests/recaptcha.spec.ts
@@ -136,7 +136,7 @@ describe("/recaptcha", () => {
     })
 
     async function setRecaptchaEnabled(value: boolean) {
-      workspace.features = {...workspace.features, recaptchaEnabled: value}
+      workspace.features = { ...workspace.features, recaptchaEnabled: value }
       await config.api.workspace.update(workspace.appId, workspace)
       await config.api.workspace.publish(workspace.appId)
     }

--- a/packages/server/src/api/routes/tests/recaptcha.spec.ts
+++ b/packages/server/src/api/routes/tests/recaptcha.spec.ts
@@ -136,7 +136,7 @@ describe("/recaptcha", () => {
     })
 
     async function setRecaptchaEnabled(value: boolean) {
-      workspace.recaptchaEnabled = value
+      workspace.features = {...workspace.features, recaptchaEnabled: value}
       await config.api.workspace.update(workspace.appId, workspace)
       await config.api.workspace.publish(workspace.appId)
     }

--- a/packages/server/src/middleware/recaptcha.ts
+++ b/packages/server/src/middleware/recaptcha.ts
@@ -27,7 +27,7 @@ const middleware = (async (ctx: UserCtx, next: Next) => {
   if ("state" in app && app.state === cache.workspace.WorkspaceState.INVALID) {
     throw new Error("App not found")
   }
-  if ((app as Workspace).recaptchaEnabled) {
+  if ((app as Workspace).features?.recaptchaEnabled) {
     const cookie = utils.getCookie<RecaptchaSessionCookie>(
       ctx,
       Cookie.RecaptchaSession

--- a/packages/types/src/documents/workspace/workspace.ts
+++ b/packages/types/src/documents/workspace/workspace.ts
@@ -37,7 +37,6 @@ export interface Workspace extends Document {
   // stores a list of IDs (automations, workspace apps, anything that can be published)
   // and when they were last published (timestamp)
   resourcesPublishedAt?: Record<string, string>
-  recaptchaEnabled?: boolean
   translationOverrides?: TranslationOverrides
 }
 
@@ -88,6 +87,7 @@ export interface WorkspaceFeatures {
   componentValidation?: boolean
   disableUserMetadata?: boolean
   skeletonLoader?: boolean
+  recaptchaEnabled?: boolean
 }
 
 export interface AutomationSettings {


### PR DESCRIPTION
## Description

Read the comment in #17477 to get more context about the fix.

Basically here:

- `recaptchaEnabled` value was in the wrong place inside the `app_metadata` document. Now it has been moved to the features object.
- Only `$featuresStore.recaptchaEnabled` was being consulted to decide if re-captcha is applied or not, but that is the value in the license but not the value set in `app_metadata`. it has been changed to check both: if it is allowed by license and if it is active for the workspace.

## Addresses
- https://github.com/Budibase/budibase/issues/17477

## Demo

https://github.com/user-attachments/assets/417de3d3-fb8a-49e6-81d1-39681a395629

## Launchcontrol

Fixes an issue with enabling and disabling reCAPTCHA. Changing the enabling setting had no effect.
