### PR TITLE
[Fixed] Prevent PWA from applying to the whole domain

### DIFF
--- a/packages/builder/src/settings/pages/pwa.svelte
+++ b/packages/builder/src/settings/pages/pwa.svelte
@@ -39,6 +39,7 @@
     theme_color: "#FFFFFF",
     display: "standalone",
     start_url: "",
+    scope: "",
   }
 
   $: iconCount = pwaConfig.icons?.length || 0

--- a/packages/builder/src/stores/builder/app.ts
+++ b/packages/builder/src/stores/builder/app.ts
@@ -97,6 +97,7 @@ export const INITIAL_APP_META_STATE: AppMetaState = {
     background_color: "",
     theme_color: "",
     start_url: "",
+    scope: "",
     screenshots: [],
   },
   scripts: [],
@@ -203,6 +204,7 @@ export class AppMetaStore extends BudiStore<AppMetaState> {
         background_color: state.pwa?.background_color || "",
         theme_color: state.pwa?.theme_color || "",
         start_url: state.pwa?.start_url || "",
+        scope: state.pwa?.scope || "",
         screenshots: state.pwa?.screenshots || [],
       },
     }))

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -502,6 +502,7 @@ export async function servePwaManifest(ctx: UserCtx<void, any>) {
 
     const manifest: PWAManifest = {
       name: appInfo.pwa.name || appInfo.name,
+      scope: `/app${appInfo.url}`,
       short_name: appInfo.pwa.short_name || appInfo.name,
       description: appInfo.pwa.description || "",
       start_url: `/app${appInfo.url}`,

--- a/packages/types/src/documents/workspace/workspace.ts
+++ b/packages/types/src/documents/workspace/workspace.ts
@@ -98,6 +98,7 @@ export interface PWAManifest {
   name: string
   short_name: string
   description: string
+  scope: string
   icons: PWAManifestImage[]
   screenshots: PWAManifestImage[]
   background_color: string


### PR DESCRIPTION
# Prevent PWA from applying to the whole domain

## Description

When enabling PWA capabilities for a Budibase app, the browser was showing the "Open in App" prompt across the entire domain, even on pages that did not belong to the PWA or did not include any manifest.json.

This occurred because the PWA manifest only defined start_url, but did not provide a scope. According to PWA standards, when scope is omitted, the browser defaults it to /, meaning that the installed application is considered valid for the entire origin.

As a result, Chrome detected any URL under the same domain as part of the PWA territory, and therefore showed the "Open in App" suggestion globally.

This PR fixes this by explicitly adding a scope in the manifest. Scope restricts which paths belong to the PWA environment, and prevents the browser from offering the application outside that defined boundary.

## Addresses

- https://github.com/Budibase/budibase/issues/17534

## Demo

https://github.com/user-attachments/assets/e4a0dae9-63d3-40b6-a0ab-bd3ed2619199

## Launchcontrol

Added an explicit scope in the manifest to limit PWA coverage to the intended path and prevent “Open in App” from appearing across the entire domain.
