### PR TITLE
[BUDI-9918] Fix JS editor conditional return validation

### DIFF
--- a/packages/builder/src/components/common/CodeEditor/validator/js.ts
+++ b/packages/builder/src/components/common/CodeEditor/validator/js.ts
@@ -42,7 +42,10 @@ const getHelperFunctionName = (callee: acorn.Expression | acorn.Super) => {
     return callee.property.name
   }
 
-  if (callee.property.type === "Literal" && typeof callee.property.value === "string") {
+  if (
+    callee.property.type === "Literal" &&
+    typeof callee.property.value === "string"
+  ) {
     return callee.property.value
   }
 
@@ -137,7 +140,8 @@ export function validateJsTemplate(
           return
         }
 
-        const from = lineOffsets[node.loc.start.line - 1] + node.loc.start.column
+        const from =
+          lineOffsets[node.loc.start.line - 1] + node.loc.start.column
         const to = lineOffsets[node.loc.end.line - 1] + node.loc.end.column
 
         if (!(functionName in validations)) {
@@ -151,7 +155,10 @@ export function validateJsTemplate(
         }
 
         const { arguments: expectedArguments } = validations[functionName]
-        if (expectedArguments && node.arguments.length !== expectedArguments.length) {
+        if (
+          expectedArguments &&
+          node.arguments.length !== expectedArguments.length
+        ) {
           diagnostics.push({
             from,
             to,

--- a/packages/builder/src/components/common/CodeEditor/validator/tests/js.spec.ts
+++ b/packages/builder/src/components/common/CodeEditor/validator/tests/js.spec.ts
@@ -80,9 +80,9 @@ describe("js validator", () => {
   })
 
   it("fails if the conditional return is not within a plain else block", () => {
-    const text = `if (true) {
+    const text = `if (false) {
       return "A"
-    } else if (false) {
+    } else if (true) {
       return "B"
     }`
     const validators = {}

--- a/packages/builder/src/components/common/CodeEditor/validator/tests/js.spec.ts
+++ b/packages/builder/src/components/common/CodeEditor/validator/tests/js.spec.ts
@@ -67,6 +67,37 @@ describe("js validator", () => {
     ])
   })
 
+  it("allows top level conditional returns", () => {
+    const text = `if (true) {
+      return "A"
+    } else {
+      return "B"
+    }`
+    const validators = {}
+
+    const result = validateJsTemplate(text, validators)
+    expect(result).toEqual([])
+  })
+
+  it("fails if the conditional return is not within a plain else block", () => {
+    const text = `if (true) {
+      return "A"
+    } else if (false) {
+      return "B"
+    }`
+    const validators = {}
+
+    const result = validateJsTemplate(text, validators)
+    expect(result).toEqual([
+      {
+        from: 0,
+        message: "Your code must return a value.",
+        severity: "error",
+        to: text.length,
+      },
+    ])
+  })
+
   describe("helpers", () => {
     const validators: CodeValidator = {
       helperFunction: {


### PR DESCRIPTION
## Description
- ensure top-level conditional returns inside a final plain else satisfy the JS editor validator while other blocks still warn
- add regression tests covering both the valid `if/else` and invalid `else if` cases

## Addresses
- https://github.com/Budibase/budibase/issues/17468

## Screenshots

<img width="271" height="135" alt="Screenshot 2025-12-02 at 21 17 22" src="https://github.com/user-attachments/assets/2e45d094-e47f-44a4-a2e4-24a0692a8ba2" />

<img width="271" height="164" alt="Screenshot 2025-12-02 at 21 17 41" src="https://github.com/user-attachments/assets/98da47c5-44d9-4867-947c-2ca3f4bcccfd" />

<img width="271" height="164" alt="Screenshot 2025-12-02 at 21 18 02" src="https://github.com/user-attachments/assets/4fc8ff56-c71d-45e0-8b65-b418f41cd2bb" />

<img width="271" height="164" alt="Screenshot 2025-12-02 at 21 18 21" src="https://github.com/user-attachments/assets/78e5257d-a540-4c72-9557-14771266efef" />

<img width="271" height="164" alt="Screenshot 2025-12-02 at 21 19 08" src="https://github.com/user-attachments/assets/1e8d1e9a-8cda-4c0f-99f2-7acf6230f9c4" />

<img width="271" height="229" alt="Screenshot 2025-12-02 at 21 19 33" src="https://github.com/user-attachments/assets/61587ae4-228d-4cef-bde7-b4f0892d4bc8" />

<img width="271" height="337" alt="Screenshot 2025-12-02 at 21 21 07" src="https://github.com/user-attachments/assets/c7db32ab-e957-4520-b1df-15ebd0c40a2c" />


## Launchcontrol
- Builder JS validator now understands top-level `if/else` flows so valid code no longer triggers false "must return" errors
