### PR TITLE
Add Jira Cloud REST Template

### DIFF
--- a/packages/builder/src/stores/builder/restTemplates.ts
+++ b/packages/builder/src/stores/builder/restTemplates.ts
@@ -1,6 +1,7 @@
 import { RestTemplate, RestTemplateName } from "@budibase/types"
 import { BudiStore } from "../BudiStore"
 import BambooHRLogo from "assets/rest-template-icons/bamboohr.svg"
+import JiraLogo from "assets/rest-template-icons/jira.svg"
 import GitHubLogo from "assets/rest-template-icons/github.svg"
 import PagerDutyLogo from "assets/rest-template-icons/pagerduty.svg"
 import SlackLogo from "assets/rest-template-icons/slack.svg"
@@ -35,6 +36,18 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
         },
       ],
       icon: GitHubLogo,
+    },
+    {
+      name: "Jira Cloud",
+      description:
+        "Build apps, script interactions with Jira, or develop any other type of integration",
+      specs: [
+        {
+          version: "3.0",
+          url: "https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json",
+        },
+      ],
+      icon: JiraLogo,
     },
     {
       name: "PagerDuty",

--- a/packages/types/src/ui/rest.ts
+++ b/packages/types/src/ui/rest.ts
@@ -8,6 +8,7 @@ export type RestTemplateSpecVersion = RestTemplateSpec["version"]
 export type RestTemplateName =
   | "BambooHR"
   | "GitHub"
+  | "Jira Cloud"
   | "PagerDuty"
   | "Slack Web API"
   | "Stripe"


### PR DESCRIPTION
## Description
REST Template for Jira cloud. Unfortunately there was no variable for `your-domain`. It is baked into the URL within the official spec, so there's nothing reasonable we can do about that. 
Unfortunate design of the spec imo. 

## Screenshots
<img width="1273" height="1053" alt="add jira" src="https://github.com/user-attachments/assets/d2034bea-ea09-49a7-81ea-75db37120e2a" />

<img width="1065" height="899" alt="jira modal" src="https://github.com/user-attachments/assets/55938b8c-7c91-4bf0-bf10-7fa67ebd0474" />

<img width="1580" height="1322" alt="post" src="https://github.com/user-attachments/assets/a99f1220-c522-4594-8492-035ea348039c" />

<img width="1580" height="1322" alt="payload" src="https://github.com/user-attachments/assets/a07591bf-629b-4f4b-9e91-14f72de0844e" />


## Launchcontrol
Jira Cloud REST Template
