### PR TITLE
Enable LiteLLM configuration on cloud

### DIFF
--- a/packages/builder/src/settings/pages/ai/index.svelte
+++ b/packages/builder/src/settings/pages/ai/index.svelte
@@ -55,7 +55,7 @@
   let customModalConfig: CustomAIProviderConfig | null = null
 
   $: isCloud = $admin.cloud
-  $: privateLLMSEnabled = !$admin.cloud && $featureFlags.PRIVATE_LLMS
+  $: privateLLMSEnabled = $featureFlags.PRIVATE_LLMS
   $: providerNames = isCloud
     ? ["BudibaseAI"]
     : ["BudibaseAI", "OpenAI", "AzureOpenAI"]


### PR DESCRIPTION
## Description
Remove the `!cloud` flag so we can configure LiteLLM on cloud. 

