### PR TITLE
[BUDI-9863] Ensure binding drawer wraps bindings

### DIFF
--- a/packages/builder/src/components/common/CodeEditor/index.ts
+++ b/packages/builder/src/components/common/CodeEditor/index.ts
@@ -258,44 +258,63 @@ const buildBindingInfoNode = (binding: EnrichedBinding) => {
   return ele
 }
 
-// Readdress these methods. They shouldn't be used
+interface WrapperState {
+  hasOpen: boolean
+  hasClose: boolean
+  inside: boolean
+}
+
+const getWrapperState = (
+  value: string | undefined,
+  from: number,
+  to: number,
+  openToken: string,
+  closeToken: string
+): WrapperState => {
+  const doc = value ?? ""
+  const left = doc.slice(0, from)
+  const right = doc.slice(to)
+
+  const lastOpen = left.lastIndexOf(openToken)
+  const lastClose = left.lastIndexOf(closeToken)
+  const hasOpen = lastOpen !== -1 && (lastClose === -1 || lastOpen > lastClose)
+
+  const nextClose = right.indexOf(closeToken)
+  const nextOpen = right.indexOf(openToken)
+  const hasClose = nextClose !== -1 && (nextOpen === -1 || nextClose < nextOpen)
+
+  return {
+    hasOpen,
+    hasClose,
+    inside: hasOpen && hasClose,
+  }
+}
+
 export const hbInsert = (
-  value: string,
+  value: string | undefined,
   from: number,
   to: number,
   text: string
 ) => {
-  let parsedInsert = ""
-
-  const left = from ? value.substring(0, from) : ""
-  const right = to ? value.substring(to) : ""
-
-  if (!left.includes("{{") || !right.includes("}}")) {
-    parsedInsert = `{{ ${text} }}`
-  } else {
-    parsedInsert = ` ${text} `
-  }
-
-  return parsedInsert
+  const { inside } = getWrapperState(value, from, to, "{{", "}}")
+  return inside ? ` ${text} ` : `{{ ${text} }}`
 }
 
 export const htmlInsert = (
-  value: string,
+  value: string | undefined,
   from: number,
   to: number,
   text: string
 ) => {
-  const left = from ? value.substring(0, from) : ""
-  const right = to ? value.substring(to) : ""
-
-  const leftPrefix = left.includes("{{") ? "" : "{{"
-  const rightPrefix = right.includes("}}") ? "" : "}}"
+  const state = getWrapperState(value, from, to, "{{", "}}")
+  const leftPrefix = state.hasOpen ? "" : "{{"
+  const rightPrefix = state.hasOpen && state.hasClose ? "" : "}}"
 
   return `${leftPrefix} ${text} ${rightPrefix}`
 }
 
 export function jsInsert(
-  value: string,
+  value: string | undefined,
   from: number,
   to: number,
   text: string,
@@ -306,13 +325,11 @@ export function jsInsert(
 ) {
   let parsedInsert = ""
 
-  const left = from ? value.substring(0, from) : ""
-  const right = to ? value.substring(to) : ""
   if (disableWrapping) {
     parsedInsert = text
   } else if (helper) {
     parsedInsert = `helpers.${text}()`
-  } else if (!left.includes('$("') || !right.includes('")')) {
+  } else if (!getWrapperState(value, from, to, '$("', '")').inside) {
     parsedInsert = `$("${text}")`
   } else {
     parsedInsert = text

--- a/packages/builder/src/components/common/CodeEditor/tests/index.test.ts
+++ b/packages/builder/src/components/common/CodeEditor/tests/index.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest"
+
+import { hbInsert, htmlInsert, jsInsert } from ".."
+
+describe("hbInsert", () => {
+  it("wraps bindings when not inside existing handlebars", () => {
+    const doc = "{{ first }} plain {{ second }}"
+    const insertionPoint = doc.indexOf("plain ") + "plain ".length
+
+    const result = hbInsert(doc, insertionPoint, insertionPoint, "user.roleId")
+
+    expect(result).toBe("{{ user.roleId }}")
+  })
+
+  it("does not duplicate braces when already inside handlebars", () => {
+    const doc = "{{ user.email }}"
+    const insertionPoint = doc.indexOf("user.email")
+
+    const result = hbInsert(doc, insertionPoint, insertionPoint, "user.roleId")
+
+    expect(result).toBe(" user.roleId ")
+  })
+})
+
+describe("htmlInsert", () => {
+  it("adds missing handlebars even when other bindings are present", () => {
+    const doc = "{{ first }} plain {{ second }}"
+    const insertionPoint = doc.indexOf("plain ") + "plain ".length
+
+    const result = htmlInsert(doc, insertionPoint, insertionPoint, "user.email")
+
+    expect(result).toBe("{{ user.email }}")
+  })
+
+  it("respects existing wrappers inside handlebars", () => {
+    const doc = "<div>{{ user.email }}</div>"
+    const insertionPoint = doc.indexOf("user.email")
+
+    const result = htmlInsert(
+      doc,
+      insertionPoint,
+      insertionPoint,
+      "user.roleId"
+    )
+
+    expect(result).toBe(" user.roleId ")
+  })
+})
+
+describe("jsInsert", () => {
+  it("wraps bindings with the javascript helper when outside", () => {
+    const doc = '$("first") plain $("second")'
+    const insertionPoint = doc.indexOf("plain ") + "plain ".length
+
+    const result = jsInsert(
+      doc,
+      insertionPoint,
+      insertionPoint,
+      "binding.value"
+    )
+
+    expect(result).toBe('$("binding.value")')
+  })
+
+  it("leaves text untouched when already inside a javascript binding", () => {
+    const doc = 'const val = $("user.email")'
+    const insertionPoint = doc.indexOf("user.email")
+
+    const result = jsInsert(doc, insertionPoint, insertionPoint, "user.roleId")
+
+    expect(result).toBe("user.roleId")
+  })
+})


### PR DESCRIPTION
## Description
- ensure the insert helpers only skip wrappers when the cursor already sits inside an existing binding
- add regression vitest coverage for handlebars/html/js inserts

## Addresses
- https://github.com/Budibase/budibase/issues/17372

## Screenshots

**BEFORE** showing bug issue. Could not reproduce after fix:

https://github.com/user-attachments/assets/45c35997-bf1a-4ded-9d23-e123e9a38124

https://github.com/user-attachments/assets/49531a3f-a16e-40cd-933c-4ad0b14d7894

**AFTER:**

https://github.com/user-attachments/assets/c0ca58bb-5097-4d3c-bb0b-e36a093dfbd0


## Launchcontrol
Ensure bindings chosen from the drawer always include the required handlebars or javascript wrappers, preventing partial inserts in the editor.