### PR TITLE
Add Splunk REST template

### DIFF
--- a/packages/builder/assets/rest-template-icons/splunk.svg
+++ b/packages/builder/assets/rest-template-icons/splunk.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+  <title>splunk</title>
+  <g id="Layer_2" data-name="Layer 2">
+    <g id="invisible_box" data-name="invisible box">
+      <rect width="48" height="48" fill="none"/>
+    </g>
+    <g id="Q3_icons" data-name="Q3 icons">
+      <path fill="#74A43D" d="M37.5,4h-27A6.5,6.5,0,0,0,4,10.5v27A6.5,6.5,0,0,0,10.5,44h27A6.5,6.5,0,0,0,44,37.5v-27A6.5,6.5,0,0,0,37.5,4Z"/>
+      <path fill="#fff" d="M33.6,26.1c0,.1,0,.2-.2.3L14.7,35.8c-.1.1-.3-.1-.3-.2V30.8c0-.1,0-.2.1-.2l13.6-6.8L14.5,16.9c-.1,0-.1-.1-.1-.2V11.9c0-.1.2-.3.3-.2l18.7,9.4a.5.5,0,0,1,.2.4Z"/>
+    </g>
+  </g>
+</svg>

--- a/packages/builder/src/stores/builder/restTemplates.ts
+++ b/packages/builder/src/stores/builder/restTemplates.ts
@@ -6,6 +6,7 @@ import GitHubLogo from "assets/rest-template-icons/github.svg"
 import OktaLogo from "assets/rest-template-icons/okta.svg"
 import PagerDutyLogo from "assets/rest-template-icons/pagerduty.svg"
 import SlackLogo from "assets/rest-template-icons/slack.svg"
+import SplunkLogo from "assets/rest-template-icons/splunk.svg"
 import StripeLogo from "assets/rest-template-icons/stripe.svg"
 
 interface RestTemplatesState {
@@ -85,6 +86,18 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
         },
       ],
       icon: SlackLogo,
+    },
+    {
+      name: "Splunk Collect",
+      description:
+        "Manage Splunk Cloud Services Collect jobs to ingest event and metric data from cloud and SaaS sources",
+      specs: [
+        {
+          version: "v1beta1.8",
+          url: "https://raw.githubusercontent.com/splunk/splunk-cloud-sdk-js/master/src/services/collect/v1beta1/openapi.yaml",
+        },
+      ],
+      icon: SplunkLogo,
     },
     {
       name: "Stripe",

--- a/packages/server/src/api/controllers/query/import/tests/index.spec.ts
+++ b/packages/server/src/api/controllers/query/import/tests/index.spec.ts
@@ -577,4 +577,65 @@ describe("Rest Importer", () => {
 
     expect(staticVariables).toEqual({ companyDomain: "acme" })
   })
+
+  it("returns OpenAPI 3 component parameters as static variables", async () => {
+    const openapiWithComponentParams = {
+      openapi: "3.0.0",
+      info: {
+        title: "Component Parameters",
+        version: "1.0.0",
+      },
+      components: {
+        parameters: {
+          tenantParam: {
+            name: "tenant",
+            in: "path",
+            required: true,
+            schema: {
+              type: "string",
+              default: "example",
+            },
+          },
+          authHeader: {
+            name: "authorization",
+            in: "header",
+            required: true,
+            schema: {
+              type: "string",
+            },
+          },
+        },
+      },
+      paths: {
+        "/{tenant}/jobs": {
+          get: {
+            operationId: "getJobs",
+            parameters: [
+              {
+                $ref: "#/components/parameters/tenantParam",
+              },
+              {
+                $ref: "#/components/parameters/authHeader",
+              },
+            ],
+            responses: {
+              "200": {
+                description: "ok",
+              },
+            },
+          },
+        },
+      },
+    }
+
+    await init(JSON.stringify(openapiWithComponentParams))
+    const staticVariables = restImporter.getStaticServerVariables()
+
+    expect(staticVariables).toEqual(
+      expect.objectContaining({
+        tenant: "example",
+        authorization: "",
+      })
+    )
+  })
 })

--- a/packages/types/src/ui/rest.ts
+++ b/packages/types/src/ui/rest.ts
@@ -1,5 +1,5 @@
 export interface RestTemplateSpec {
-  version: `${number}-${number}-${number}` | `${number}.${number}`
+  version: string
   url: string
 }
 
@@ -12,6 +12,7 @@ export type RestTemplateName =
   | "Okta Management"
   | "PagerDuty"
   | "Slack Web API"
+  | "Splunk Collect"
   | "Stripe"
 
 export interface RestTemplate {


### PR DESCRIPTION
Adds a Splunk Collect REST template with its OpenAPI spec and icon, and extends the importer so OpenAPI component parameters become datasource static variables like server variables.

**Note** The authentication header could potentially have been added automatically as a Bearer token in our existing REST config, however I noticed that this particular OpenAPI spec has incorrectly defined their Bearer token auth, so I chose to treat it as a static variable, as it is just a standard header param in the spec. 
The correct spec approach is: https://swagger.io/docs/specification/v3_0/authentication/bearer-authentication/
In future this could potentially be parsed out.

<img width="1273" height="1141" alt="splunk tile" src="https://github.com/user-attachments/assets/97daf019-fe30-45ba-ba09-e7db69571849" />

<img width="664" height="628" alt="splunk options" src="https://github.com/user-attachments/assets/5f1d58d7-ebe6-4b18-b51e-29610c78feca" />

<img width="1273" height="1169" alt="static vars" src="https://github.com/user-attachments/assets/d90245dd-a17a-492e-8500-9472f6bf730f" />

<img width="1607" height="611" alt="patch" src="https://github.com/user-attachments/assets/9a7ec4d1-1b70-4793-abec-1f267c344f13" />
