### PR TITLE
chore: add static vars to API templates

### DIFF
--- a/packages/builder/src/components/integration/APIEndpointViewer.svelte
+++ b/packages/builder/src/components/integration/APIEndpointViewer.svelte
@@ -276,9 +276,7 @@
 
       // Add static variables with binding syntax as defaults
       for (const [name, _] of Object.entries(staticVariables)) {
-        if (!allBindings[name]) {
-          allBindings[name] = `{{ ${name} }}`
-        }
+        allBindings[name] = `{{ ${name} }}`
       }
 
       const parameters = Object.entries(allBindings).map(

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/_components/APIModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/_components/APIModal.svelte
@@ -118,11 +118,11 @@
     const templateVariables = new Set(
       (config.templateStaticVariables || []).filter(Boolean)
     )
-    const target = (config.staticVariables = config.staticVariables || {})
+    config.staticVariables ||= {}
     for (const [name, value] of entries) {
       templateVariables.add(name)
-      if (target[name] == null) {
-        target[name] = value ?? ""
+      if (config.staticVariables[name] == null) {
+        config.staticVariables[name] = value ?? ""
       }
     }
     config.templateStaticVariables = Array.from(templateVariables)

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/_components/APIModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/_components/APIModal.svelte
@@ -64,36 +64,68 @@
     targetSpec = null
   }
 
-  const applySecurityHeaders = async (
-    config: Record<string, any>,
-    spec?: RestTemplateSpec | null
-  ) => {
+  const loadTemplateInfo = async (spec?: RestTemplateSpec | null) => {
     if (!spec?.url) {
+      return undefined
+    }
+    try {
+      return await queries.fetchImportInfo({ url: spec.url })
+    } catch (err) {
+      console.warn("Failed to load template metadata", err)
+      return undefined
+    }
+  }
+
+  const applySecurityHeaders = (
+    config: Record<string, any>,
+    securityHeaders?: string[] | null
+  ) => {
+    const normalizedHeaders = (securityHeaders || []).filter(
+      (header): header is string => Boolean(header)
+    )
+    if (!normalizedHeaders.length) {
       return config
     }
-
-    try {
-      const info = await queries.fetchImportInfo({ url: spec.url })
-      const securityHeaders = info.securityHeaders || []
-      if (!securityHeaders.length) {
-        return config
+    const headers = (config.defaultHeaders = config.defaultHeaders || {})
+    for (const header of normalizedHeaders) {
+      if (!header) {
+        continue
       }
-      const headers = (config.defaultHeaders = config.defaultHeaders || {})
-      for (const header of securityHeaders) {
-        if (!header) {
-          continue
-        }
-        const normalized = header.toLowerCase()
-        const existing = Object.keys(headers).find(
-          key => key?.toLowerCase() === normalized
-        )
-        if (!existing) {
-          headers[header] = headers[header] ?? ""
-        }
+      const normalized = header.toLowerCase()
+      const existing = Object.keys(headers).find(
+        key => key?.toLowerCase() === normalized
+      )
+      if (!existing) {
+        headers[header] = headers[header] ?? ""
       }
-    } catch (err) {
-      console.warn("Failed to apply security headers", err)
     }
+    return config
+  }
+
+  const applyTemplateStaticVariables = (
+    config: Record<string, any>,
+    staticVariables?: Record<string, string> | null
+  ) => {
+    if (!staticVariables) {
+      return config
+    }
+    const entries = Object.entries(staticVariables).filter(
+      ([name]) => name.trim() !== ""
+    )
+    if (!entries.length) {
+      return config
+    }
+    const templateVariables = new Set(
+      (config.templateStaticVariables || []).filter(Boolean)
+    )
+    const target = (config.staticVariables = config.staticVariables || {})
+    for (const [name, value] of entries) {
+      templateVariables.add(name)
+      if (target[name] == null) {
+        target[name] = value ?? ""
+      }
+    }
+    config.templateStaticVariables = Array.from(templateVariables)
     return config
   }
 
@@ -113,7 +145,9 @@
       targetSpec = template.specs[0] || null
 
       const config = configFromIntegration(restIntegration)
-      await applySecurityHeaders(config, targetSpec)
+      const templateInfo = await loadTemplateInfo(targetSpec)
+      applySecurityHeaders(config, templateInfo?.securityHeaders)
+      applyTemplateStaticVariables(config, templateInfo?.staticVariables)
 
       const ds = await datasources.create({
         integration: restIntegration,

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/_components/APIModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/_components/APIModal.svelte
@@ -159,8 +159,8 @@
 
       await datasources.fetch()
 
-      // Go to the new query page.
-      $goto(`./query/new/${ds._id}`)
+      // Go to the newly created datasource page.
+      $goto(`./datasource/${ds._id}`)
 
       notifications.success(`${selectedTemplate.name} API created`)
     } catch (error: any) {

--- a/packages/builder/src/stores/selectors.js
+++ b/packages/builder/src/stores/selectors.js
@@ -1,5 +1,6 @@
 import { DEFAULT_BB_DATASOURCE_ID } from "@/constants/backend"
 import { DatasourceFeature } from "@budibase/types"
+import { cloneDeep } from "lodash/fp"
 
 export const integrationForDatasource = (integrations, datasource) => ({
   name: datasource.source,
@@ -23,7 +24,7 @@ export const configFromIntegration = integration => {
         config[fieldKey] = null
       })
     } else {
-      config[key] = properties.default ?? null
+      config[key] = cloneDeep(properties.default ?? null)
     }
   })
 

--- a/packages/server/src/api/controllers/query/import/sources/openapi2.ts
+++ b/packages/server/src/api/controllers/query/import/sources/openapi2.ts
@@ -92,9 +92,6 @@ export class OpenAPI2 extends OpenAPISource {
     if (scheme.type === "apiKey" && scheme.in === "header" && scheme.name) {
       return scheme.name
     }
-    if (scheme.type === "basic" || scheme.type === "oauth2") {
-      return "Authorization"
-    }
     return undefined
   }
 

--- a/packages/server/src/api/controllers/query/import/sources/openapi3.ts
+++ b/packages/server/src/api/controllers/query/import/sources/openapi3.ts
@@ -237,9 +237,6 @@ export class OpenAPI3 extends OpenAPISource {
     if (scheme.type === "apiKey" && scheme.in === "header" && scheme.name) {
       return scheme.name
     }
-    if (scheme.type === "http" || scheme.type === "oauth2") {
-      return "Authorization"
-    }
     return undefined
   }
 

--- a/packages/server/src/api/controllers/query/index.ts
+++ b/packages/server/src/api/controllers/query/index.ts
@@ -177,12 +177,14 @@ export async function importInfo(
   const importer = new RestImporter(data)
   await importer.init()
   const info = await importer.getInfo()
+  const staticVariables = importer.getStaticServerVariables()
   ctx.body = {
     name: info.name,
     url: info.url,
     docsUrl: info.docsUrl,
     endpoints: info.endpoints || [],
     securityHeaders: info.securityHeaders || [],
+    staticVariables,
   }
 }
 

--- a/packages/types/src/api/web/workspace/query.ts
+++ b/packages/types/src/api/web/workspace/query.ts
@@ -30,6 +30,7 @@ export interface ImportRestQueryInfoResponse {
   docsUrl?: string
   endpoints: ImportEndpoint[]
   securityHeaders?: string[]
+  staticVariables?: Record<string, string>
 }
 export interface ImportRestQueryResponse {
   errorQueries: Query[]


### PR DESCRIPTION
 ## Description
  - load REST template metadata once, reuse security headers, and hydrate
  static variables before datasource creation
  - deep-clone integration defaults so template static variables don't
  leak between configs
  - expose template static variables through the REST import info
  endpoint and rely on the importer output instead of guessing
  Authorization headers
  Improves API template imports by auto-populating security headers and
  static server variables for new datasources.

## Screenshots
https://github.com/user-attachments/assets/076cd311-4884-4383-86d0-640e474b7532

## Launchcontrol
 Improves API template imports by auto-populating security headers and static server variables for new datasources.
