### PR TITLE
Fix: dont swallow agent errors

### DIFF
--- a/packages/builder/src/helpers/tests/agentChatStream.spec.ts
+++ b/packages/builder/src/helpers/tests/agentChatStream.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { createAPIClient } from "@budibase/frontend-core"
+import type { AgentChat } from "@budibase/types"
+
+const chat: AgentChat = {
+  title: "Test chat",
+  messages: [],
+}
+
+const createStreamResponse = (sse: string) =>
+  new Response(sse, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  })
+
+const drainStream = async (stream: AsyncIterable<unknown>) => {
+  for await (const _ of stream) {
+    // drain
+  }
+}
+
+describe("agentChatStream error handling", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it("throws when the stream emits an error chunk with text", async () => {
+    const fetchMock = vi.fn(async () =>
+      createStreamResponse(
+        'data: {"type":"error","errorText":"Custom agent failure"}\n'
+      )
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const api = createAPIClient()
+
+    await expect(async () => {
+      const stream = await api.agentChatStream(chat, "workspace-123")
+      await drainStream(stream)
+    }).rejects.toThrow("Custom agent failure")
+  })
+
+  it("falls back to a default message when no errorText is provided", async () => {
+    const fetchMock = vi.fn(async () =>
+      createStreamResponse('data: {"type":"error"}\n')
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const api = createAPIClient()
+
+    await expect(async () => {
+      const stream = await api.agentChatStream(chat, "workspace-123")
+      await drainStream(stream)
+    }).rejects.toThrow("Agent action failed")
+  })
+})

--- a/packages/frontend-core/src/api/agents.ts
+++ b/packages/frontend-core/src/api/agents.ts
@@ -69,8 +69,21 @@ export const buildAgentEndpoints = (API: BaseAPIClient): AgentEndpoints => ({
     const chunkStream = response.body
       .pipeThrough(new TextDecoderStream())
       .pipeThrough(createSseToJsonTransformStream<UIMessageChunk>())
+      .pipeThrough(
+        new TransformStream<UIMessageChunk, UIMessageChunk>({
+          transform(chunk, controller) {
+            if (chunk.type === "error") {
+              throw new Error(chunk.errorText || "Agent action failed")
+            }
+            controller.enqueue(chunk)
+          },
+        })
+      )
 
-    return readUIMessageStream({ stream: chunkStream })
+    return readUIMessageStream({
+      stream: chunkStream,
+      terminateOnError: true,
+    })
   },
 
   removeChat: async (chatId: string) => {


### PR DESCRIPTION
if there was some upstream error (such as a rate limit) then the chat would just hang, this change terminates if liteLLM sends an error chunk.

UI is very much 'for now' while we are in dev!

<img width="1512" height="855" alt="Screenshot 2025-12-05 at 13 42 45" src="https://github.com/user-attachments/assets/7787472b-25fc-4f5d-b672-cde6dc985026" />
