### PR TITLE
adds Workspace Automation Error notification into workspace selector

### DIFF
--- a/packages/builder/src/components/common/WorkspaceSelect.svelte
+++ b/packages/builder/src/components/common/WorkspaceSelect.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher, onMount } from "svelte"
   import { goto } from "@roxi/routify"
-  import { ActionMenu, MenuItem, Icon } from "@budibase/bbui"
+  import { ActionMenu, MenuItem, Icon, StatusLight } from "@budibase/bbui"
   import { sdk } from "@budibase/shared-core"
   import { processStringSync } from "@budibase/string-templates"
   import { appStore } from "@/stores/builder"
@@ -220,6 +220,14 @@
         >
           {ws.name}
           <div slot="right" class="fav-slot">
+            <div class="menu-item-error-status">
+              {#if Object.keys(ws.automationErrors || {}).length}
+                <StatusLight
+                  color="var(--spectrum-global-color-static-red-600)"
+                  size="M"
+                />
+              {/if}
+            </div>
             <button
               type="button"
               class="fav-icon-button fav-icon"
@@ -289,7 +297,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 24px;
+    width: 32px;
   }
   .fav-icon-button {
     background: transparent;
@@ -385,5 +393,10 @@
     display: inline-flex;
     justify-content: center;
     align-items: center;
+  }
+
+  .menu-item-error-status {
+    width: 16px !important;
+    height: 18px;
   }
 </style>


### PR DESCRIPTION
## Description
From within a workspace, I can see if an automation is erroring with this red dot
<img width="409" height="412" alt="image" src="https://github.com/user-attachments/assets/b162feea-9b75-4718-9302-e99626802c57" />

But at the Workspace Selector level, I could not, and would need to visit every workspace in order to check. This PR adds the Workspace Automation Errors indicator to the Workspace Selector.

## Addresses
https://github.com/Budibase/budibase/issues/17564 

## Screenshots
<img width="336" height="567" alt="image" src="https://github.com/user-attachments/assets/1e79f666-0555-4556-9f72-4701eac03fd4" />

## Launchcontrol

Surfaces automation-errors to the Workspace Selector.
