### PR TITLE
Allow static formulas to be sorted

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -61,6 +61,7 @@
     AutoFieldSubType,
     FormulaResponseType,
     FieldSchemaConfig,
+    UIFieldSchema,
   } from "@budibase/types"
 
   export let field: FieldSchema
@@ -210,7 +211,8 @@
     : availableAutoColumns
   // used to select what different options can be displayed for column type
   $: canBeDisplay =
-    canBeDisplayColumn(editableColumn) && !editableColumn.autocolumn
+    canBeDisplayColumn(editableColumn as UIFieldSchema) &&
+    !editableColumn.autocolumn
   $: canHaveDefault = !required && canHaveDefaultColumn(editableColumn.type)
   $: canBeRequired =
     editableColumn?.type !== FieldType.LINK &&

--- a/packages/frontend-core/src/components/grid/cells/HeaderCell.svelte
+++ b/packages/frontend-core/src/components/grid/cells/HeaderCell.svelte
@@ -6,7 +6,12 @@
   import { getColumnIcon } from "../../../utils/schema"
   import MigrationModal from "../controls/MigrationModal.svelte"
   import { debounce } from "../../../utils/utils"
-  import { FieldType, FormulaType, SortOrder } from "@budibase/types"
+  import {
+    FieldType,
+    FormulaType,
+    SortOrder,
+    isStaticFormula,
+  } from "@budibase/types"
   import { TableNames } from "../../../constants"
   import GridPopover from "../overlays/GridPopover.svelte"
 
@@ -73,7 +78,11 @@
         descending: "high-low",
       }
     }
-    switch (column?.schema?.type) {
+    let schemaType = column.schema?.type
+    if (isStaticFormula(column.schema)) {
+      schemaType = column.schema.responseType
+    }
+    switch (schemaType) {
       case FieldType.NUMBER:
       case FieldType.BIGINT:
         return {

--- a/packages/frontend-core/src/fetch/DataFetch.ts
+++ b/packages/frontend-core/src/fetch/DataFetch.ts
@@ -241,6 +241,7 @@ export default abstract class BaseDataFetch<
       if (
         fieldSchema?.type === FieldType.NUMBER ||
         fieldSchema?.type === FieldType.BIGINT ||
+        fieldSchema?.responseType === FieldType.NUMBER ||
         ("calculationType" in fieldSchema && fieldSchema?.calculationType)
       ) {
         this.options.sortType = SortType.NUMBER

--- a/packages/frontend-core/src/utils/table.js
+++ b/packages/frontend-core/src/utils/table.js
@@ -16,6 +16,10 @@ export function canBeSortColumn(column) {
   if (column.calculationType) {
     return true
   }
+  // Allow static-only formula columns to be sorted
+  if (column.type === "formula" && column.formulaType === "static") {
+    return true
+  }
   if (!sharedCore.canBeSortColumn(column.type)) {
     return false
   }

--- a/packages/frontend-core/src/utils/table.ts
+++ b/packages/frontend-core/src/utils/table.ts
@@ -1,6 +1,7 @@
 import * as sharedCore from "@budibase/shared-core"
+import { UIFieldSchema, isStaticFormula } from "@budibase/types"
 
-export function canBeDisplayColumn(column) {
+export function canBeDisplayColumn(column: UIFieldSchema) {
   if (!sharedCore.canBeDisplayColumn(column.type)) {
     return false
   }
@@ -11,20 +12,20 @@ export function canBeDisplayColumn(column) {
   return true
 }
 
-export function canBeSortColumn(column) {
+export function canBeSortColumn(columnSchema: UIFieldSchema) {
   // Allow sorting by calculation columns
-  if (column.calculationType) {
+  if (columnSchema.calculationType) {
     return true
   }
   // Allow static-only formula columns to be sorted
-  if (column.type === "formula" && column.formulaType === "static") {
+  if (isStaticFormula(columnSchema)) {
     return true
   }
-  if (!sharedCore.canBeSortColumn(column.type)) {
+  if (!sharedCore.canBeSortColumn(columnSchema.type)) {
     return false
   }
   // If it's a related column (only available in the frontend), don't allow using it as display column
-  if (column.related) {
+  if (columnSchema.related) {
     return false
   }
   return true

--- a/packages/server/src/sdk/workspace/rows/search/internal/sqs.ts
+++ b/packages/server/src/sdk/workspace/rows/search/internal/sqs.ts
@@ -18,6 +18,7 @@ import {
   EnrichedQueryJson,
   FieldType,
   isLogicalSearchOperator,
+  isStaticFormula,
   LockName,
   LockType,
   Operation,
@@ -428,8 +429,11 @@ export async function search(
         },
       }
     } else if (sortField) {
+      const responseType = isStaticFormula(sortField)
+        ? sortField.responseType
+        : sortField.type
       const sortType =
-        sortField.type === FieldType.NUMBER ? SortType.NUMBER : SortType.STRING
+        responseType === FieldType.NUMBER ? SortType.NUMBER : SortType.STRING
       request.sort = {
         [mapToUserColumn(sortField.name)]: {
           direction: params.sortOrder || SortOrder.ASCENDING,

--- a/packages/types/src/documents/workspace/row.ts
+++ b/packages/types/src/documents/workspace/row.ts
@@ -1,5 +1,5 @@
 import { Document } from "../document"
-import { FieldSchema, FormulaType } from "./table"
+import { FieldSchema, FormulaFieldMetadata, FormulaType } from "./table"
 
 export const EXTERNAL_ROW_REV = "rev"
 
@@ -174,7 +174,9 @@ export function canGroupBy(type: FieldType) {
   return GroupByTypes.includes(type)
 }
 
-export function isStaticFormula(schema: FieldSchema) {
+export function isStaticFormula(
+  schema: FieldSchema
+): schema is FormulaFieldMetadata {
   return (
     schema.type === FieldType.FORMULA &&
     schema.formulaType === FormulaType.STATIC

--- a/packages/types/src/ui/stores/grid/table.ts
+++ b/packages/types/src/ui/stores/grid/table.ts
@@ -1,5 +1,6 @@
 import {
   BasicViewFieldMetadata,
+  CalculationType,
   FieldSchema,
   FieldType,
   RelationSchemaField,
@@ -24,10 +25,11 @@ export interface UITable extends Table {
 
 export type UIFieldSchema = FieldSchema &
   BasicViewFieldMetadata & {
-    related?: { field: string; subField: string }
-    columns?: Record<string, UIRelationSchemaField>
+    calculationType?: CalculationType
     cellRenderType?: string
+    columns?: Record<string, UIRelationSchemaField>
     disabled?: boolean
+    related?: { field: string; subField: string }
     format?: (row: UIRow) => any
   }
 


### PR DESCRIPTION
## Description
There's no reason not to allow static formulas to be sorted. Dynamic formulas (which are generated on read) continue to not support sort.

## Addresses
- https://github.com/Budibase/budibase/issues/16260

## Screenshots
<img width="206" height="304" alt="dynamic" src="https://github.com/user-attachments/assets/9e3564c2-36aa-4012-841a-007d5cfaaa4f" />

*Dynamic formula column cannot be sorted*

<img width="206" height="304" alt="static" src="https://github.com/user-attachments/assets/dc69acd3-a576-4fc8-aa25-53ade1bf6150" />

*Static formula column can be sorted*

<img width="206" height="304" alt="a-z" src="https://github.com/user-attachments/assets/67781f7f-d556-4fe9-84d0-4ab1a1d87f68" />

<img width="206" height="304" alt="z-a" src="https://github.com/user-attachments/assets/3758b3ed-30ef-4bd0-b155-7a4c0a587166" />

-----

**The sort mode is determined by the formula response type:**

<img width="361" height="300" alt="datetime" src="https://github.com/user-attachments/assets/43f4436a-4f77-449e-91e2-f0f1b8c6fbe4" />

<img width="208" height="300" alt="new-old" src="https://github.com/user-attachments/assets/ccc0838a-9acd-461f-b64c-bbfc7024afb2" />

<img width="208" height="300" alt="sort" src="https://github.com/user-attachments/assets/a3c54e43-93a1-432c-a933-618c7fc3a703" />


## Launchcontrol
Support sorting for static formula columns
