### PR TITLE
Show long group names on hover in the users sidebar

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/_components/BuilderSidePanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/BuilderSidePanel.svelte
@@ -652,7 +652,7 @@
                 >
                   <div class="details">
                     <GroupIcon {group} size="S" />
-                    <div class="group-name">
+                    <div class="group-name" title={group.name}>
                       {group.name}
                     </div>
                     <div class="auth-entity-meta">

--- a/packages/builder/src/settings/pages/people/groups/_components/GroupNameTableRenderer.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/GroupNameTableRenderer.svelte
@@ -9,7 +9,7 @@
 <div class="align">
   {#if value}
     <GroupIcon group={row} />
-    <div class="text">
+    <div class="text" title={value}>
       {value}
     </div>
   {:else}


### PR DESCRIPTION
## Description
Better support for long group names in the builder when managing and assigning groups.

## Addresses
customer request

## Screenshots
<img width="476" height="356" alt="image" src="https://github.com/user-attachments/assets/4e0e9acf-b9ce-41ca-9acf-26470e850cbe" />


## Launchcontrol
better support for long group names