### PR TITLE
Fix replication issue after applying column renames in production during publish

### DIFF
--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -125,10 +125,13 @@ async function initDeployedApp(prodAppId: string) {
   })
 }
 
-async function applyPendingColumnRenames(workspaceId: string) {
-  await context.doInWorkspaceContext(workspaceId, async () => {
+async function applyPendingColumnRenames(
+  workspaceId: string
+): Promise<Table[]> {
+  return await context.doInWorkspaceContext(workspaceId, async () => {
     const db = context.getWorkspaceDB()
     const tables = await sdk.tables.getAllInternalTables()
+    const updatedTables: Table[] = []
 
     for (let table of tables) {
       if (table._deleted) {
@@ -164,7 +167,10 @@ async function applyPendingColumnRenames(workspaceId: string) {
 
       const updatedTable: Table = { ...table, pendingColumnRenames: [] }
       await db.put(updatedTable)
+      updatedTables.push(updatedTable)
     }
+
+    return updatedTables
   })
 }
 
@@ -335,7 +341,37 @@ export const publishWorkspace = async function (
           })
         )
 
-        await applyPendingColumnRenames(prodId)
+        const updatedProdTables = await applyPendingColumnRenames(prodId)
+
+        // Keep development revs aligned with production after renaming, so the
+        // next publish doesn't see production ahead and delete / tombstone the doc.
+        if (updatedProdTables.length > 0) {
+          await context.doInWorkspaceContext(devId, async () => {
+            const devDb = context.getWorkspaceDB()
+            for (const prodTable of updatedProdTables) {
+              try {
+                const devTable = await devDb.tryGet<Table>(prodTable._id!)
+                if (!devTable) {
+                  console.warn(
+                    `Failed to get development table for table ${prodTable._id} 
+                    when applying column renames`
+                  )
+                  continue
+                }
+                await devDb.put({
+                  ...prodTable,
+                  _rev: devTable._rev,
+                })
+              } catch (err) {
+                console.warn(
+                  `Failed to update development table with production table 
+                  revision when applying column renames for table ${prodTable._id}: ${err}`
+                )
+              }
+            }
+          })
+        }
+
         await clearPendingColumnRenames(devId)
 
         const db = context.getProdWorkspaceDB()

--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -166,8 +166,9 @@ async function applyPendingColumnRenames(
       }
 
       const updatedTable: Table = { ...table, pendingColumnRenames: [] }
-      await db.put(updatedTable)
-      updatedTables.push(updatedTable)
+      const putResult = await db.put(updatedTable)
+      const persistedTable: Table = { ...updatedTable, _rev: putResult.rev }
+      updatedTables.push(persistedTable)
     }
 
     return updatedTables


### PR DESCRIPTION
## Description
Fixes an issue that some users have been having an in production, where after we applied column renames that existed in development, to production tables (as part of applyPendingColumnRenames) -  the production revision would be ahead of the development revision (triggering the tombstoning of the production document)

This fixes that by applying the production table document  back to the development table document. Thus bumping the development revision and keeping development revision  > production revision.

## Launchcontrol
- Fixes an issue with replication in publish step causing table schemas to be missing in production environments. 