### PR TITLE
fix: display name syncing

### DIFF
--- a/packages/server/src/sdk/workspace/tables/external/index.ts
+++ b/packages/server/src/sdk/workspace/tables/external/index.ts
@@ -156,7 +156,9 @@ export async function save(
     tableToSave.views[view] = viewSdk.syncSchema(
       oldTable!.views![view] as ViewV2,
       tableToSave.schema,
-      opts?.renaming
+      opts?.renaming,
+      tableToSave.primaryDisplay,
+      oldTable?.primaryDisplay
     )
   }
 

--- a/packages/server/src/sdk/workspace/tables/external/index.ts
+++ b/packages/server/src/sdk/workspace/tables/external/index.ts
@@ -156,9 +156,11 @@ export async function save(
     tableToSave.views[view] = viewSdk.syncSchema(
       oldTable!.views![view] as ViewV2,
       tableToSave.schema,
-      opts?.renaming,
-      tableToSave.primaryDisplay,
-      oldTable?.primaryDisplay
+      {
+        renameColumn: opts?.renaming,
+        primaryDisplay: tableToSave.primaryDisplay,
+        previousPrimaryDisplay: oldTable?.primaryDisplay,
+      }
     )
   }
 

--- a/packages/server/src/sdk/workspace/tables/internal/index.ts
+++ b/packages/server/src/sdk/workspace/tables/internal/index.ts
@@ -146,7 +146,9 @@ export async function save(
         table.views[view] = viewsSdk.syncSchema(
           oldTable.views[view] as ViewV2,
           table.schema,
-          renaming
+          renaming,
+          table.primaryDisplay,
+          oldTable?.primaryDisplay
         )
       }
       continue

--- a/packages/server/src/sdk/workspace/tables/internal/index.ts
+++ b/packages/server/src/sdk/workspace/tables/internal/index.ts
@@ -146,9 +146,11 @@ export async function save(
         table.views[view] = viewsSdk.syncSchema(
           oldTable.views[view] as ViewV2,
           table.schema,
-          renaming,
-          table.primaryDisplay,
-          oldTable?.primaryDisplay
+          {
+            renameColumn: renaming,
+            primaryDisplay: table.primaryDisplay,
+            previousPrimaryDisplay: oldTable?.primaryDisplay,
+          }
         )
       }
       continue

--- a/packages/server/src/sdk/workspace/views/index.ts
+++ b/packages/server/src/sdk/workspace/views/index.ts
@@ -478,13 +478,19 @@ export async function enrichSchema(
   return { ...view, schema }
 }
 
+export interface SyncSchemaOpts {
+  renameColumn?: RenameColumn
+  primaryDisplay?: string
+  previousPrimaryDisplay?: string
+}
+
 export function syncSchema(
   view: ViewV2,
   schema: TableSchema,
-  renameColumn: RenameColumn | undefined,
-  primaryDisplay?: string,
-  previousPrimaryDisplay?: string
+  opts: SyncSchemaOpts = {}
 ): ViewV2 {
+  const { renameColumn, primaryDisplay, previousPrimaryDisplay } = opts
+
   if (renameColumn && view.schema && view.schema[renameColumn.old] != null) {
     if (!view.schema[renameColumn.updated]) {
       view.schema[renameColumn.updated] = view.schema[renameColumn.old]

--- a/packages/server/src/sdk/workspace/views/index.ts
+++ b/packages/server/src/sdk/workspace/views/index.ts
@@ -481,13 +481,19 @@ export async function enrichSchema(
 export function syncSchema(
   view: ViewV2,
   schema: TableSchema,
-  renameColumn: RenameColumn | undefined
+  renameColumn: RenameColumn | undefined,
+  primaryDisplay?: string,
+  previousPrimaryDisplay?: string
 ): ViewV2 {
   if (renameColumn && view.schema && view.schema[renameColumn.old] != null) {
     if (!view.schema[renameColumn.updated]) {
       view.schema[renameColumn.updated] = view.schema[renameColumn.old]
     }
     delete view.schema[renameColumn.old]
+  }
+
+  if (renameColumn && view.primaryDisplay === renameColumn.old) {
+    view.primaryDisplay = renameColumn.updated
   }
 
   if (view.schema) {
@@ -505,6 +511,21 @@ export function syncSchema(
       if (!view.schema[fieldName]) {
         view.schema[fieldName] = { visible: false }
       }
+    }
+  }
+
+  if (
+    primaryDisplay &&
+    (view.primaryDisplay == null ||
+      view.primaryDisplay === previousPrimaryDisplay)
+  ) {
+    view.primaryDisplay = primaryDisplay
+    view.schema ??= {}
+    const displaySchema = view.schema[primaryDisplay] || {}
+    view.schema[primaryDisplay] = {
+      ...displaySchema,
+      visible: true,
+      readonly: false,
     }
   }
 

--- a/packages/server/src/sdk/workspace/views/tests/views.spec.ts
+++ b/packages/server/src/sdk/workspace/views/tests/views.spec.ts
@@ -669,6 +669,50 @@ describe("table sdk", () => {
         )
         expect(result).toEqual(view)
       })
+
+      it("updates primaryDisplay to match the table when inheriting", () => {
+        const view: ViewV2 = {
+          ...basicView,
+          primaryDisplay: "name",
+          schema: {
+            name: { visible: true, width: 100 },
+            description: { visible: false, readonly: true },
+          },
+        }
+
+        const result = syncSchema(
+          _.cloneDeep(view),
+          basicTable.schema,
+          undefined,
+          "description",
+          "name"
+        )
+
+        expect(result.primaryDisplay).toEqual("description")
+        expect(result.schema?.description?.visible).toBe(true)
+        expect(result.schema?.description?.readonly).toBe(false)
+      })
+
+      it("keeps custom view primaryDisplay when it differs from the table", () => {
+        const view: ViewV2 = {
+          ...basicView,
+          primaryDisplay: "id",
+          schema: {
+            id: { visible: true, width: 20 },
+            name: { visible: true, width: 100 },
+          },
+        }
+
+        const result = syncSchema(
+          _.cloneDeep(view),
+          basicTable.schema,
+          undefined,
+          "description",
+          "name"
+        )
+
+        expect(result.primaryDisplay).toEqual("id")
+      })
     })
   })
 })

--- a/packages/server/src/sdk/workspace/views/tests/views.spec.ts
+++ b/packages/server/src/sdk/workspace/views/tests/views.spec.ts
@@ -445,8 +445,10 @@ describe("table sdk", () => {
         } as TableSchema
 
         const result = syncSchema(_.cloneDeep(view), newTableSchema, {
-          old: "description",
-          updated: "updatedDescription",
+          renameColumn: {
+            old: "description",
+            updated: "updatedDescription",
+          },
         })
         expect(result).toEqual({
           ...view,
@@ -583,8 +585,10 @@ describe("table sdk", () => {
         } as TableSchema
 
         const result = syncSchema(_.cloneDeep(view), newTableSchema, {
-          old: "description",
-          updated: "updatedDescription",
+          renameColumn: {
+            old: "description",
+            updated: "updatedDescription",
+          },
         })
         expect(result).toEqual({
           ...view,
@@ -612,8 +616,10 @@ describe("table sdk", () => {
         } as TableSchema
 
         const result = syncSchema(_.cloneDeep(view), newTableSchema, {
-          old: "description",
-          updated: "updatedDescription",
+          renameColumn: {
+            old: "description",
+            updated: "updatedDescription",
+          },
         })
 
         expect(result.schema?.updatedDescription).toEqual(
@@ -680,13 +686,10 @@ describe("table sdk", () => {
           },
         }
 
-        const result = syncSchema(
-          _.cloneDeep(view),
-          basicTable.schema,
-          undefined,
-          "description",
-          "name"
-        )
+        const result = syncSchema(_.cloneDeep(view), basicTable.schema, {
+          primaryDisplay: "description",
+          previousPrimaryDisplay: "name",
+        })
 
         expect(result.primaryDisplay).toEqual("description")
         expect(result.schema?.description?.visible).toBe(true)
@@ -703,13 +706,10 @@ describe("table sdk", () => {
           },
         }
 
-        const result = syncSchema(
-          _.cloneDeep(view),
-          basicTable.schema,
-          undefined,
-          "description",
-          "name"
-        )
+        const result = syncSchema(_.cloneDeep(view), basicTable.schema, {
+          primaryDisplay: "description",
+          previousPrimaryDisplay: "name",
+        })
 
         expect(result.primaryDisplay).toEqual("id")
       })


### PR DESCRIPTION
## Description

* ensure changes to `primaryName` are propagated
* refactor `syncSchema` to accept a opts object as 5 params seemed excessive

Fixes [#16943](https://github.com/Budibase/budibase/issues/16943)