### PR TITLE
[BUDI-9229] Allow view display column to be read-only

### DIFF
--- a/packages/builder/src/components/backend/DataTable/buttons/grid/ColumnsSettingContent.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/ColumnsSettingContent.svelte
@@ -44,25 +44,8 @@
 
     const defaultPermission = permissions[0]
     const requiredTooltips = {
-      [FieldPermissions.WRITABLE]: (() => {
-        if (defaultPermission === FieldPermissions.WRITABLE) {
-          if (isDisplayLocked) {
-            return "Display column must be writable"
-          }
-          if (isRequired) {
-            return "Required columns must be writable"
-          }
-        }
-      })(),
+      [FieldPermissions.WRITABLE]: (() => {})(),
       [FieldPermissions.READONLY]: (() => {
-        if (defaultPermission === FieldPermissions.WRITABLE) {
-          if (isDisplayLocked) {
-            return "Display column cannot be read-only"
-          }
-          if (isRequired) {
-            return "Required columns cannot be read-only"
-          }
-        }
         if (defaultPermission === FieldPermissions.READONLY) {
           if (isDisplayColumn) {
             return "Display column must be read-only"

--- a/packages/builder/src/components/backend/DataTable/buttons/grid/ColumnsSettingContent.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/ColumnsSettingContent.svelte
@@ -18,7 +18,7 @@
   export let columns
   export let fromRelationshipField
 
-  const { datasource, dispatch } = getContext("grid")
+  const { datasource, dispatch, config } = getContext("grid")
 
   let relationshipPanelAnchor
   let relationshipFieldName
@@ -36,15 +36,20 @@
     {}
   )
 
+  $: viewHasCrudActions =
+    $config.canAddRows || $config.canEditRows || $config.canDeleteRows
+
   $: displayColumns = columns.map(c => {
+    const isDisplayColumn = c.primaryDisplay
+    const isDisplayLocked = isDisplayColumn && viewHasCrudActions
     const isRequired =
-      c.primaryDisplay || helpers.schema.isRequired(c.schema.constraints)
+      isDisplayLocked || helpers.schema.isRequired(c.schema.constraints)
 
     const defaultPermission = permissions[0]
     const requiredTooltips = {
       [FieldPermissions.WRITABLE]: (() => {
         if (defaultPermission === FieldPermissions.WRITABLE) {
-          if (c.primaryDisplay) {
+          if (isDisplayLocked) {
             return "Display column must be writable"
           }
           if (isRequired) {
@@ -54,7 +59,7 @@
       })(),
       [FieldPermissions.READONLY]: (() => {
         if (defaultPermission === FieldPermissions.WRITABLE) {
-          if (c.primaryDisplay) {
+          if (isDisplayLocked) {
             return "Display column cannot be read-only"
           }
           if (isRequired) {
@@ -62,7 +67,7 @@
           }
         }
         if (defaultPermission === FieldPermissions.READONLY) {
-          if (c.primaryDisplay) {
+          if (isDisplayColumn) {
             return "Display column must be read-only"
           }
           if (isRequired) {
@@ -71,7 +76,7 @@
         }
       })(),
       [FieldPermissions.HIDDEN]: (() => {
-        if (c.primaryDisplay) {
+        if (isDisplayColumn) {
           return "Display column cannot be hidden"
         }
         if (isRequired) {

--- a/packages/builder/src/components/backend/DataTable/buttons/grid/ColumnsSettingContent.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/ColumnsSettingContent.svelte
@@ -41,7 +41,10 @@
 
   $: displayColumns = columns.map(c => {
     const isDisplayColumn = c.primaryDisplay
-    const isDisplayLocked = isDisplayColumn && viewHasCrudActions
+    const isDisplayLocked =
+      isDisplayColumn &&
+      viewHasCrudActions &&
+      $datasource?.type !== "viewV2"
     const isRequired =
       isDisplayLocked || helpers.schema.isRequired(c.schema.constraints)
 

--- a/packages/builder/src/components/backend/DataTable/buttons/grid/ColumnsSettingContent.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/ColumnsSettingContent.svelte
@@ -18,7 +18,7 @@
   export let columns
   export let fromRelationshipField
 
-  const { datasource, dispatch, config } = getContext("grid")
+  const { datasource, dispatch } = getContext("grid")
 
   let relationshipPanelAnchor
   let relationshipFieldName
@@ -36,15 +36,9 @@
     {}
   )
 
-  $: viewHasCrudActions =
-    $config.canAddRows || $config.canEditRows || $config.canDeleteRows
-
   $: displayColumns = columns.map(c => {
     const isDisplayColumn = c.primaryDisplay
-    const isDisplayLocked =
-      isDisplayColumn &&
-      viewHasCrudActions &&
-      $datasource?.type !== "viewV2"
+    const isDisplayLocked = isDisplayColumn && $datasource?.type !== "viewV2"
     const isRequired =
       isDisplayLocked || helpers.schema.isRequired(c.schema.constraints)
 

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -430,7 +430,7 @@ if (descriptions.length) {
               })
             })
 
-            it("required fields cannot be marked as readonly", async () => {
+            it("required fields can be marked as readonly", async () => {
               const table = await config.api.table.save(
                 saveTableRequest({
                   schema: {
@@ -459,12 +459,12 @@ if (descriptions.length) {
                 },
               }
 
-              await config.api.viewV2.create(newView, {
-                status: 400,
-                body: {
-                  message:
-                    'You can\'t make "name" readonly because it is a required field.',
-                  status: 400,
+              const res = await config.api.viewV2.create(newView)
+              expect(res.schema).toEqual({
+                id: { visible: true },
+                name: {
+                  visible: true,
+                  readonly: true,
                 },
               })
             })

--- a/packages/server/src/sdk/workspace/views/index.ts
+++ b/packages/server/src/sdk/workspace/views/index.ts
@@ -302,15 +302,6 @@ function checkRequiredFields(
       )
     }
 
-    if (
-      helpers.views.isBasicViewField(viewSchemaField) &&
-      viewSchemaField.readonly
-    ) {
-      throw new HTTPError(
-        `You can't make "${field.name}" readonly because it is a required field.`,
-        400
-      )
-    }
   }
 }
 


### PR DESCRIPTION
## Description
Allow view display column to be read-only when the datasource is a view while still enforcing the writable requirement for editable tables.

## Addresses
- https://github.com/Budibase/budibase/issues/15923

## Screenshots
<img width="1638" height="809" alt="all columns readonly" src="https://github.com/user-attachments/assets/1f24d72d-ff6d-480f-b8de-70b136cecf3d" />

**Setting all columns to read-only**

<img width="1397" height="604" alt="display col is readonly" src="https://github.com/user-attachments/assets/40b74d4a-792c-465d-937e-0642f4dfe07f" />

**Display column is read-only** *(leave it up to the app builder to untick the 'Add rows' option rather than trying to be too fancy here - the validation will prevent empty rows being inserted)*

## Launchcontrol
- Allow view display columns to be set read-only by skipping the display-locked restriction for view datasources, keeping the UI consistent with view-only behavior.
