### PR TITLE
fix: default value select

### DIFF
--- a/packages/client/src/components/app/SingleRowProvider.svelte
+++ b/packages/client/src/components/app/SingleRowProvider.svelte
@@ -8,7 +8,8 @@
   const component = getContext("component")
   const { styleable, API, Provider, ActionTypes } = getContext("sdk")
 
-  let row: Row | undefined
+  let row: Row | null | undefined
+  let loading = true
 
   $: datasourceId =
     datasource.type === "table" ? datasource.tableId : datasource.id
@@ -22,19 +23,30 @@
   ]
 
   const fetchRow = async (datasourceId: string, rowId: string) => {
+    if (!datasourceId || !rowId) {
+      row = undefined
+      loading = false
+      return
+    }
+
+    loading = true
     try {
       row = await API.fetchRow(datasourceId, rowId)
     } catch (e) {
       row = undefined
+    } finally {
+      loading = false
     }
   }
 </script>
 
-<div use:styleable={$component.styles}>
-  <Provider {actions} data={row ?? null}>
-    <slot />
-  </Provider>
-</div>
+{#if !loading}
+  <div use:styleable={$component.styles}>
+    <Provider {actions} data={row ?? null}>
+      <slot />
+    </Provider>
+  </div>
+{/if}
 
 <style>
   div {

--- a/packages/client/src/components/app/forms/InnerForm.svelte
+++ b/packages/client/src/components/app/forms/InnerForm.svelte
@@ -232,8 +232,17 @@
 
         // Determine the initial value for this field, reusing the current
         // value if one exists
-        if (fieldState.value != null && fieldState.value !== "") {
+        const valueIsEmptyArray =
+          Array.isArray(fieldState.value) && fieldState.value.length === 0
+        const shouldUseNewDefault =
+          fieldState.value === undefined ||
+          fieldState.value === "" ||
+          valueIsEmptyArray ||
+          fieldState.value === fieldState.defaultValue
+        if (!shouldUseNewDefault && fieldState.value != null) {
           initialValue = fieldState.value
+        } else {
+          initialValue = defaultValue
         }
 
         // If this field has already been registered and we previously had an


### PR DESCRIPTION
## Description
Default value was not persisting for multiselects when you navigate within an app preview. Changes to the `SingleRowProvider` prevents the select from glitching while you load the tab.

## Addresses
#17602 

## Screenshots
Simpler version of the repo in the ticket:
https://jam.dev/c/b8e21aec-226b-4c85-89e4-0e94067f8302
(also features Tom the Cat)

