### PR TITLE
Add fsGroup security context to redis deployment

### DIFF
--- a/charts/budibase/templates/redis-service-deployment.yaml
+++ b/charts/budibase/templates/redis-service-deployment.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         io.kompose.service: redis-service
     spec:
+      securityContext:
+        fsGroup: 999
       containers:
       - args:
         - redis-server 

--- a/charts/budibase/templates/redis-service-deployment.yaml
+++ b/charts/budibase/templates/redis-service-deployment.yaml
@@ -18,7 +18,9 @@ spec:
         io.kompose.service: redis-service
     spec:
       securityContext:
-        fsGroup: 999
+        runAsUser: 999
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
       - args:
         - redis-server 


### PR DESCRIPTION
## Description
The data directory for the default Redis service that is shipped with the Helm chart is owned by `root:root` leading to permission issues. We are adding a security context to ensure that the directory is owned by the redis process.

## Launchcontrol

Fixes permissions bug in the Redis data directory ownership of the Helm chart.