### PR TITLE
Fix for cron / email automatios not persisting on redis restart

### DIFF
--- a/packages/server/src/automations/index.ts
+++ b/packages/server/src/automations/index.ts
@@ -1,6 +1,7 @@
 import { processEvent } from "./utils"
 import { automationQueue } from "./bullboard"
 import { rebootTrigger } from "./triggers"
+import { rehydrateScheduledTriggers } from "./rehydrate"
 import { automationsEnabled } from "../features"
 
 export { automationQueue } from "./bullboard"
@@ -19,6 +20,9 @@ export async function init() {
   const promise = automationQueue.process(async job => {
     await processEvent(job)
   })
+  // on init we need to rehydrate any scheduled triggers that may have been lost
+  // due to reddis being ephemeral in some self hosted deployments.
+  await rehydrateScheduledTriggers()
   // on init we need to trigger any reboot automations
   await rebootTrigger()
   return promise

--- a/packages/server/src/automations/rehydrate.ts
+++ b/packages/server/src/automations/rehydrate.ts
@@ -1,0 +1,118 @@
+import { context, db as dbCore } from "@budibase/backend-core"
+import {
+  Automation,
+  CronTriggerInputs,
+  isCronTrigger,
+  isEmailTrigger,
+} from "@budibase/types"
+import { getAutomationParams } from "../db/utils"
+import env from "../environment"
+import { automationQueue } from "./bullboard"
+import { enableCronOrEmailTrigger, isRebootTrigger } from "./utils"
+
+function scheduledKey(
+  jobId: string,
+  repeat: { cron?: string; every?: number }
+) {
+  if (repeat.cron) {
+    return `${jobId}:cron:${repeat.cron}`
+  }
+  return `${jobId}:every:${repeat.every}`
+}
+
+async function getAllAutomations() {
+  const db = context.getWorkspaceDB()
+  const docs = await db.allDocs<Automation>(
+    getAutomationParams(null, { include_docs: true })
+  )
+  return docs.rows.map(row => row.doc!)
+}
+
+/**
+ * In many self-hosted setups, Redis is ephemeral. After a restart Bull no longer has any
+ * repeatable jobs, so CRON/Email automations won't fire again until the workspace is
+ * republished (which re-enables triggers).
+ *
+ * On startup we rehydrate repeatable jobs for all production workspaces.
+ */
+export async function rehydrateScheduledTriggers() {
+  // only run in the main thread at startup and only in self host / single tenant
+  if (env.isInThread() || !env.SELF_HOSTED || env.MULTI_TENANCY) {
+    return
+  }
+
+  const queue = automationQueue.getBullQueue()
+  const repeatableJobs = await queue.getRepeatableJobs()
+
+  const scheduled = new Set<string>()
+  for (const job of repeatableJobs) {
+    if (!job.id) {
+      continue
+    }
+    scheduled.add(
+      scheduledKey(job.id, {
+        cron: job.cron,
+        every: job.every,
+      })
+    )
+  }
+
+  const workspaceIds = await dbCore.getAllWorkspaces({
+    dev: false,
+    idsOnly: true,
+  })
+
+  for (const prodId of workspaceIds) {
+    await context.doInWorkspaceContext(prodId, async () => {
+      const automations = await getAllAutomations()
+      const promises = []
+
+      for (const automation of automations) {
+        const trigger = automation.definition.trigger
+        if (!trigger || automation.disabled || isRebootTrigger(automation)) {
+          continue
+        }
+
+        if (isCronTrigger(trigger)) {
+          const inputs = trigger.inputs as CronTriggerInputs
+          const cron = inputs.cron || ""
+          const jobId = trigger.cronJobId?.toString()
+          const key = jobId ? scheduledKey(jobId, { cron }) : null
+          if (!key || !scheduled.has(key)) {
+            promises.push(
+              enableCronOrEmailTrigger(prodId, automation).then(result => {
+                const scheduledJobId =
+                  result.automation.definition.trigger.cronJobId?.toString()
+                if (scheduledJobId) {
+                  scheduled.add(scheduledKey(scheduledJobId, { cron }))
+                }
+              })
+            )
+          }
+        } else if (isEmailTrigger(trigger)) {
+          const every = 30_000
+          const jobId = trigger.cronJobId?.toString()
+          const key = jobId ? scheduledKey(jobId, { every }) : null
+          if (!key || !scheduled.has(key)) {
+            promises.push(
+              enableCronOrEmailTrigger(prodId, automation).then(result => {
+                const scheduledJobId =
+                  result.automation.definition.trigger.cronJobId?.toString()
+                if (scheduledJobId) {
+                  scheduled.add(scheduledKey(scheduledJobId, { every }))
+                }
+              })
+            )
+          }
+        }
+      }
+
+      if (promises.length) {
+        console.log(
+          `Rehydrating ${promises.length} scheduled automation triggers for workspace ${prodId}`
+        )
+      }
+      await Promise.all(promises)
+    })
+  }
+}

--- a/packages/server/src/automations/tests/rehydrate.spec.ts
+++ b/packages/server/src/automations/tests/rehydrate.spec.ts
@@ -1,0 +1,115 @@
+import "@budibase/backend-core/tests"
+import { GenericContainer, StartedTestContainer } from "testcontainers"
+
+jest.setTimeout(60_000)
+
+describe("rehydrateScheduledTriggers (integration)", () => {
+  let redis: StartedTestContainer | undefined
+
+  let TestConfiguration: typeof import("../../tests/utilities/TestConfiguration").default
+  let createAutomationBuilder: typeof import("./utilities/AutomationTestBuilder").createAutomationBuilder
+  let rehydrateScheduledTriggers: typeof import("../rehydrate").rehydrateScheduledTriggers
+  let automationQueue: typeof import("../bullboard").automationQueue
+  let disableAllCrons: typeof import("../utils").disableAllCrons
+  let env: typeof import("../../environment").default
+  let coreQueue: typeof import("@budibase/backend-core").queue
+
+  const originalEnv = {
+    BULL_TEST_REDIS_PORT: process.env.BULL_TEST_REDIS_PORT,
+    MULTI_TENANCY: process.env.MULTI_TENANCY,
+    SELF_HOSTED: process.env.SELF_HOSTED,
+    FORKED_PROCESS: process.env.FORKED_PROCESS,
+  }
+
+  beforeAll(async () => {
+    redis = await new GenericContainer("redis").withExposedPorts(6379).start()
+
+    process.env.BULL_TEST_REDIS_PORT = `${redis.getMappedPort(6379)}`
+    delete process.env.FORKED_PROCESS
+    ;({ default: TestConfiguration } = await import(
+      "../../tests/utilities/TestConfiguration"
+    ))
+    ;({ createAutomationBuilder } = await import(
+      "./utilities/AutomationTestBuilder"
+    ))
+    ;({ rehydrateScheduledTriggers } = await import("../rehydrate"))
+    ;({ automationQueue } = await import("../bullboard"))
+    ;({ disableAllCrons } = await import("../utils"))
+    ;({ default: env } = await import("../../environment"))
+    ;({ queue: coreQueue } = await import("@budibase/backend-core"))
+  })
+
+  afterAll(async () => {
+    // Close Bull queues while Redis is still running to avoid connection errors.
+    if (coreQueue) {
+      await coreQueue.shutdown()
+    }
+    if (redis) {
+      await redis.stop()
+    }
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value == null) {
+        delete (process.env as any)[key]
+      } else {
+        ;(process.env as any)[key] = value
+      }
+    }
+    if (env) {
+      env._set("SELF_HOSTED", originalEnv.SELF_HOSTED || "1")
+      env._set("MULTI_TENANCY", originalEnv.MULTI_TENANCY || "1")
+    }
+  })
+
+  it("rehydrates cron triggers when repeatable jobs are missing", async () => {
+    const config = new TestConfiguration()
+    try {
+      await config.init()
+
+      env._set("SELF_HOSTED", "1")
+      env._set("MULTI_TENANCY", 0)
+      delete process.env.FORKED_PROCESS
+
+      const prodId = config.getProdWorkspaceId()
+
+      await createAutomationBuilder(config)
+        .onCron({ cron: "* * * * *" })
+        .serverLog({ text: "Hello, world!" })
+        .save()
+
+      await config.api.workspace.publish()
+
+      const queue = automationQueue.getBullQueue()
+      const initialRepeatables = await queue.getRepeatableJobs()
+      expect(
+        initialRepeatables.some(
+          job =>
+            job.id?.toString().startsWith(`${prodId}_cron_`) &&
+            job.cron === "* * * * *"
+        )
+      ).toEqual(true)
+
+      await disableAllCrons(prodId)
+      const clearedRepeatables = await queue.getRepeatableJobs()
+      expect(
+        clearedRepeatables.some(job =>
+          job.id?.toString().startsWith(`${prodId}_cron_`)
+        )
+      ).toEqual(false)
+
+      await config.doInTenant(async () => {
+        await rehydrateScheduledTriggers()
+      })
+
+      const rehydratedRepeatables = await queue.getRepeatableJobs()
+      expect(
+        rehydratedRepeatables.some(
+          job =>
+            job.id?.toString().startsWith(`${prodId}_cron_`) &&
+            job.cron === "* * * * *"
+        )
+      ).toEqual(true)
+    } finally {
+      config.end()
+    }
+  })
+})


### PR DESCRIPTION
## Description
Fixes an issue where cron and email automations can stop running after a restart in self-hosted deployments by scannig all the workspaces and re-creating any missing bull jobs.

Also added a integration test using testcontainers to cover the issue. 

## Addresses
#17619 
