### PR TITLE
Fix issue where button action values were being duplicated between steps

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionDrawer.svelte
@@ -1,5 +1,6 @@
 <script>
   import { flip } from "svelte/animate"
+  import { tick } from "svelte"
   import { dndzone } from "svelte-dnd-action"
   import {
     Icon,
@@ -147,7 +148,11 @@
     selectedAction = newAction
   }
 
-  const selectAction = action => () => {
+  const selectAction = action => async () => {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur()
+    }
+    await tick()
     selectedAction = action
     originalActionIndex = actions.findIndex(item => item.id === action.id)
   }


### PR DESCRIPTION
## Description
Fixes an issue where if you had multiple button actions of the same kind, adding a value to one and then immediately moving to the other button action of the same type, would result in that same value being populated.



## Addresses
#17574 

## Launchcontrol
- Fix an issue with button actions values being duplicated across actions