### PR TITLE
No longer delete production database when unpublishing app

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionDrawer.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/ButtonActionDrawer.svelte
@@ -1,5 +1,6 @@
 <script>
   import { flip } from "svelte/animate"
+  import { tick } from "svelte"
   import { dndzone } from "svelte-dnd-action"
   import {
     Icon,
@@ -147,7 +148,11 @@
     selectedAction = newAction
   }
 
-  const selectAction = action => () => {
+  const selectAction = action => async () => {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur()
+    }
+    await tick()
     selectedAction = action
     originalActionIndex = actions.findIndex(item => item.id === action.id)
   }

--- a/packages/server/src/sdk/dev/devRevertProcessor.ts
+++ b/packages/server/src/sdk/dev/devRevertProcessor.ts
@@ -41,8 +41,11 @@ class DevRevertProcessor extends queue.QueuedProcessor<DevRevertQueueData> {
 
     // App must have been deployed first
     const db = context.getProdWorkspaceDB({ skip_setup: true })
-    const exists = await db.exists()
-    if (!exists) {
+
+    // The production db will still exist now (16/12/25). But the existence of the metadata docs
+    // is how we define whether the app is published or not.
+    const isPublished = await db.exists(DocumentType.WORKSPACE_METADATA)
+    if (!isPublished) {
       throw new queue.UnretriableError("App must be deployed to be reverted.")
     }
     const deploymentDoc = await db.get<DeploymentDoc>(DocumentType.DEPLOYMENTS)

--- a/packages/server/src/sdk/dev/devRevertProcessor.ts
+++ b/packages/server/src/sdk/dev/devRevertProcessor.ts
@@ -11,7 +11,7 @@ import {
   DocumentType,
   Workspace,
 } from "@budibase/types"
-
+import { isWorkspacePublished } from "../workspace/workspaces/utils"
 let _devRevertProcessor: DevRevertProcessor | undefined
 
 class DevRevertProcessor extends queue.QueuedProcessor<DevRevertQueueData> {
@@ -42,9 +42,7 @@ class DevRevertProcessor extends queue.QueuedProcessor<DevRevertQueueData> {
     // App must have been deployed first
     const db = context.getProdWorkspaceDB({ skip_setup: true })
 
-    // The production db will still exist now (16/12/25). But the existence of the metadata docs
-    // is how we define whether the app is published or not.
-    const isPublished = await db.exists(DocumentType.WORKSPACE_METADATA)
+    const isPublished = await isWorkspacePublished(productionAppId)
     if (!isPublished) {
       throw new queue.UnretriableError("App must be deployed to be reverted.")
     }

--- a/packages/server/src/sdk/workspace/deployment/status.ts
+++ b/packages/server/src/sdk/workspace/deployment/status.ts
@@ -22,8 +22,9 @@ function getPublishedState(
 }
 
 export async function status() {
-  const prodDb = context.getProdWorkspaceDB()
-  const productionExists = await prodDb.exists()
+  const prodWorkspaceId = context.getProdWorkspaceId()
+  const productionExists =
+    await sdk.workspaces.isWorkspacePublished(prodWorkspaceId)
   type State = {
     automations: Automation[]
     workspaceApps: WorkspaceApp[]

--- a/packages/server/src/tests/utilities/TestConfiguration.ts
+++ b/packages/server/src/tests/utilities/TestConfiguration.ts
@@ -738,7 +738,6 @@ export default class TestConfiguration {
     const response = await this._req(workspaceController.unpublish, undefined, {
       appId: this.devWorkspaceId,
     })
-    this.prodWorkspaceId = undefined
     this.prodWorkspace = undefined
     return response
   }


### PR DESCRIPTION
## Description
Currently when unpublishing a workspace this would delete all the production database for the workspace entirely, this is bad. Previously it was fine because prod had synced back to dev, so you'd get all the data back in prod again when dev replicated.

Fixed this so now when you unpublish:

- Disable all apps and automations in both dev and prod.
- Disable cron triggers
- Delete the production `WORKSPACE_METADATA` document. We now check for the existence of this document in multiple places to decide whether a workspace is published or not. 
- DO NOT destroy the production database.


## Addresses
(https://github.com/Budibase/vulns/issues/21)

## Launchcontrol
- Fix a issue where unpublishing your workspace could result in production data loss. 