### PR TITLE
[BUDI-9338] fix multifield property selection

### DIFF
--- a/packages/builder/src/components/design/settings/controls/MultiFieldSelect.svelte
+++ b/packages/builder/src/components/design/settings/controls/MultiFieldSelect.svelte
@@ -9,6 +9,7 @@
   import { Explanation } from "./Explanation"
   import { params } from "@roxi/routify"
   import { debounce } from "lodash"
+  import { MultiFieldSelectionState } from "./multiFieldSelectState"
 
   export let componentInstance = {}
   export let value = ""
@@ -20,21 +21,17 @@
   let contextTooltipVisible = false
 
   const dispatch = createEventDispatcher()
+  const selectionState = new MultiFieldSelectionState()
+  let boundValue = []
   $: datasource = getDatasourceForProvider($selectedScreen, componentInstance)
   $: schema = getSchemaForDatasource($selectedScreen, datasource).schema
   $: options = Object.keys(schema || {})
-  $: boundValue = getValidOptions(value, options)
+  $: selectionState.syncFromProps(value, options)
+  $: boundValue = selectionState.getSelection()
 
-  const getValidOptions = (selectedOptions, allOptions) => {
-    // Fix the hardcoded default string value
-    if (!Array.isArray(selectedOptions)) {
-      selectedOptions = []
-    }
-    return selectedOptions.filter(val => allOptions.indexOf(val) !== -1)
-  }
-
-  const setValue = value => {
-    boundValue = getValidOptions(value.detail, options)
+  const setValue = event => {
+    selectionState.applyUserSelection(event.detail, options)
+    boundValue = selectionState.getSelection()
     dispatch("change", boundValue)
   }
 

--- a/packages/builder/src/components/design/settings/controls/multiFieldSelectState.test.ts
+++ b/packages/builder/src/components/design/settings/controls/multiFieldSelectState.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { MultiFieldSelectionState } from "./multiFieldSelectState"
+
+describe("MultiFieldSelectionState", () => {
+  it("keeps selection when options disappear temporarily", () => {
+    const state = new MultiFieldSelectionState(["alpha"], ["alpha", "beta"])
+    expect(state.getSelection()).toEqual(["alpha"])
+
+    state.syncFromProps(["alpha"], [])
+    expect(state.getSelection()).toEqual(["alpha"])
+
+    state.syncFromProps(["alpha"], ["alpha", "beta"])
+    expect(state.getSelection()).toEqual(["alpha"])
+  })
+
+  it("filters invalid entries once options change without updating value", () => {
+    const state = new MultiFieldSelectionState(["alpha"], ["alpha", "beta"])
+    expect(state.getSelection()).toEqual(["alpha"])
+
+    state.syncFromProps(["alpha"], ["beta"])
+    expect(state.getSelection()).toEqual([])
+  })
+
+  it("resets selection when the prop value is cleared", () => {
+    const state = new MultiFieldSelectionState(["alpha"], ["alpha"])
+    state.syncFromProps([], ["alpha"])
+    expect(state.getSelection()).toEqual([])
+  })
+
+  it("applies user selection and stays consistent on repeated syncs", () => {
+    const state = new MultiFieldSelectionState([], ["alpha", "beta"])
+    state.applyUserSelection(["beta"], ["alpha", "beta"])
+    expect(state.getSelection()).toEqual(["beta"])
+
+    state.syncFromProps(["beta"], ["alpha", "beta"])
+    expect(state.getSelection()).toEqual(["beta"])
+
+    state.applyUserSelection(["alpha", "missing"], ["alpha"])
+    expect(state.getSelection()).toEqual(["alpha"])
+  })
+})

--- a/packages/builder/src/components/design/settings/controls/multiFieldSelectState.ts
+++ b/packages/builder/src/components/design/settings/controls/multiFieldSelectState.ts
@@ -1,0 +1,68 @@
+const toArray = (value?: unknown): string[] => {
+  return Array.isArray(value) ? [...value] : []
+}
+
+const hasOptions = (options?: string[]): boolean => {
+  return Array.isArray(options) && options.length > 0
+}
+
+const filterValidOptions = (values: string[], options?: string[]): string[] => {
+  if (!Array.isArray(values)) {
+    return []
+  }
+  if (!hasOptions(options)) {
+    return [...values]
+  }
+  return values.filter(value => options.includes(value))
+}
+
+const arraysEqual = (a: string[], b: string[]): boolean => {
+  if (a.length !== b.length) {
+    return false
+  }
+  return a.every((value, index) => value === b[index])
+}
+
+export class MultiFieldSelectionState {
+  private selection: string[] = []
+  private lastPropValue: string[] = []
+
+  constructor(initialValue?: unknown, options?: string[]) {
+    const normalized = toArray(initialValue)
+    this.lastPropValue = normalized
+    this.selection = hasOptions(options)
+      ? filterValidOptions(normalized, options)
+      : normalized
+  }
+
+  syncFromProps(value?: unknown, options?: string[]) {
+    const normalized = toArray(value)
+    if (!arraysEqual(normalized, this.lastPropValue)) {
+      this.lastPropValue = normalized
+      this.selection = hasOptions(options)
+        ? filterValidOptions(normalized, options)
+        : normalized
+    }
+    this.applyOptionFilter(options)
+  }
+
+  applyUserSelection(value: unknown, options?: string[]) {
+    const normalized = filterValidOptions(toArray(value), options)
+    this.selection = normalized
+    this.lastPropValue = normalized
+  }
+
+  getSelection() {
+    return this.selection
+  }
+
+  private applyOptionFilter(options?: string[]) {
+    if (!hasOptions(options)) {
+      return
+    }
+    const filtered = filterValidOptions(this.selection, options)
+    if (!arraysEqual(filtered, this.selection)) {
+      this.selection = filtered
+    }
+  }
+}

--- a/packages/builder/src/components/design/settings/controls/multiFieldSelectState.ts
+++ b/packages/builder/src/components/design/settings/controls/multiFieldSelectState.ts
@@ -2,7 +2,7 @@ const toArray = (value?: unknown): string[] => {
   return Array.isArray(value) ? [...value] : []
 }
 
-const hasOptions = (options?: string[]): boolean => {
+const hasOptions = (options?: string[]): options is string[] => {
   return Array.isArray(options) && options.length > 0
 }
 


### PR DESCRIPTION
## Summary
- keep multifield picker selection state around instead of reinitialising it when dependent columns change
- add a helper and regression tests for the multifield selection lifecycle

## Addresses
https://github.com/Budibase/budibase/issues/16169

## Screenshots

https://github.com/user-attachments/assets/272eacab-5542-437c-9d53-db125474ff75

**BEFORE**

-----

https://github.com/user-attachments/assets/a393f7bd-5abc-4ed9-985c-c928a5837b8d

**AFTER**