### PR TITLE
Allow Navigate action peek toggle to be bindable

### DIFF
--- a/packages/builder/src/components/common/bindings/DrawerBindableCheckbox.svelte
+++ b/packages/builder/src/components/common/bindings/DrawerBindableCheckbox.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Checkbox, Icon, Drawer, Button } from "@budibase/bbui"
+  import type { LabelPosition } from "@budibase/bbui"
   import { createEventDispatcher, setContext } from "svelte"
   import {
     readableToRuntimeBinding,
@@ -14,14 +15,13 @@
   export let bindings: any[] = []
   export let text: string | undefined = undefined
   export let label: string | undefined = undefined
-  export let labelPosition: "above" | "side" = "above"
+  export let labelPosition: LabelPosition = "above"
   export let helpText: string | undefined = undefined
   export let disabled: boolean = false
   export let allowHBS: boolean = true
   export let allowJS: boolean = true
   export let allowHelpers: boolean = true
   export let allowHTML: boolean = false
-  export let allowSnippets: boolean = true
   export let key: string | null = null
   export let title: string | undefined = undefined
   export let disableBindings: boolean = false
@@ -29,8 +29,13 @@
   export let context: any | undefined = undefined
   export let size: "S" | "M" | "L" | "XL" = "M"
 
+  type DrawerHandle = {
+    hide: () => void
+    show: () => void
+  }
+
   const dispatch = createEventDispatcher()
-  let bindingDrawer
+  let bindingDrawer: DrawerHandle | null = null
   let currentVal = value
 
   $: readableValue = runtimeToReadableBinding(bindings, value)
@@ -112,7 +117,7 @@
     currentVal = readableToRuntimeBinding(bindings, parsed)
     dispatch("change", currentVal)
     builderStore.propertyFocus(null)
-    bindingDrawer.hide()
+    bindingDrawer?.hide()
   }
 
   setContext("binding-drawer-actions", {
@@ -150,7 +155,7 @@
         class="icon"
         on:click={() => {
           builderStore.propertyFocus(key)
-          bindingDrawer.show()
+          bindingDrawer?.show()
         }}
       >
         <Icon size="S" weight="fill" name="lightning" />
@@ -180,7 +185,6 @@
     {allowJS}
     {allowHelpers}
     {allowHTML}
-    {allowSnippets}
     {context}
   />
 </Drawer>

--- a/packages/builder/src/components/common/bindings/DrawerBindableCheckbox.svelte
+++ b/packages/builder/src/components/common/bindings/DrawerBindableCheckbox.svelte
@@ -1,0 +1,223 @@
+<script lang="ts">
+  import { Checkbox, Icon, Drawer, Button } from "@budibase/bbui"
+  import { createEventDispatcher, setContext } from "svelte"
+  import {
+    readableToRuntimeBinding,
+    runtimeToReadableBinding,
+  } from "@/dataBinding"
+  import ClientBindingPanel from "@/components/common/bindings/ClientBindingPanel.svelte"
+  import { builderStore } from "@/stores/builder"
+  import { isJSBinding } from "@budibase/string-templates"
+
+  export let panel = ClientBindingPanel
+  export let value: any = false
+  export let bindings: any[] = []
+  export let text: string | undefined = undefined
+  export let label: string | undefined = undefined
+  export let labelPosition: "above" | "side" = "above"
+  export let helpText: string | undefined = undefined
+  export let disabled: boolean = false
+  export let allowHBS: boolean = true
+  export let allowJS: boolean = true
+  export let allowHelpers: boolean = true
+  export let allowHTML: boolean = false
+  export let allowSnippets: boolean = true
+  export let key: string | null = null
+  export let title: string | undefined = undefined
+  export let disableBindings: boolean = false
+  export let forceModal: boolean = false
+  export let context: any | undefined = undefined
+  export let size: "S" | "M" | "L" | "XL" = "M"
+
+  const dispatch = createEventDispatcher()
+  let bindingDrawer
+  let currentVal = value
+
+  $: readableValue = runtimeToReadableBinding(bindings, value)
+  $: displayValue = toDisplayValue(readableValue)
+  $: tempValue = displayValue
+  $: checkboxValue = toBooleanValue(readableValue)
+  $: isJS = isJSBinding(value)
+  $: hasBinding = isReadableBinding(displayValue)
+  $: checkboxDisabled = disabled || isJS
+  $: indeterminate = Boolean(isJS || hasBinding)
+  $: bindingPreview = getBindingPreview(displayValue, hasBinding, isJS)
+
+  const toDisplayValue = (val: any) => {
+    if (typeof val === "string") {
+      return val
+    }
+    if (typeof val === "boolean") {
+      return val ? "true" : "false"
+    }
+    if (val == null) {
+      return ""
+    }
+    return String(val)
+  }
+
+  const toBooleanValue = (val: any) => {
+    if (typeof val === "boolean") {
+      return val
+    }
+    if (typeof val === "string") {
+      const trimmed = val.trim().toLowerCase()
+      if (trimmed === "true") {
+        return true
+      }
+      if (trimmed === "false") {
+        return false
+      }
+    }
+    return false
+  }
+
+  const isReadableBinding = (val: any) => {
+    if (typeof val !== "string") {
+      return false
+    }
+    const trimmed = val.trim()
+    return trimmed.startsWith("{{") && trimmed.endsWith("}}")
+  }
+
+  const getBindingPreview = (
+    val: string,
+    bindingApplied: boolean,
+    jsBinding: boolean
+  ) => {
+    if (jsBinding) {
+      return "(JavaScript function)"
+    }
+    if (bindingApplied) {
+      return val
+    }
+    return ""
+  }
+
+  const parseTypedValue = (val: any) => {
+    if (typeof val === "string") {
+      const trimmed = val.trim().toLowerCase()
+      if (trimmed === "true") {
+        return true
+      }
+      if (trimmed === "false") {
+        return false
+      }
+    }
+    return val
+  }
+
+  const saveBinding = () => {
+    const parsed = parseTypedValue(tempValue)
+    currentVal = readableToRuntimeBinding(bindings, parsed)
+    dispatch("change", currentVal)
+    builderStore.propertyFocus(null)
+    bindingDrawer.hide()
+  }
+
+  setContext("binding-drawer-actions", {
+    save: saveBinding,
+  })
+
+  const onDrawerHide = (event: CustomEvent) => {
+    builderStore.propertyFocus(null)
+    dispatch("drawerHide", event.detail)
+  }
+
+  const onCheckboxChange = (event: CustomEvent<boolean>) => {
+    currentVal = readableToRuntimeBinding(bindings, event.detail)
+    dispatch("change", currentVal)
+  }
+</script>
+
+<div class="control">
+  <div class="checkbox-wrapper">
+    <Checkbox
+      {text}
+      {label}
+      {labelPosition}
+      {helpText}
+      {size}
+      disabled={checkboxDisabled}
+      value={checkboxValue}
+      {indeterminate}
+      on:change={onCheckboxChange}
+    />
+    {#if !disableBindings}
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <div
+        class="icon"
+        on:click={() => {
+          builderStore.propertyFocus(key)
+          bindingDrawer.show()
+        }}
+      >
+        <Icon size="S" weight="fill" name="lightning" />
+      </div>
+    {/if}
+  </div>
+  {#if bindingPreview}
+    <div class="binding-preview">{bindingPreview}</div>
+  {/if}
+</div>
+
+<Drawer
+  bind:this={bindingDrawer}
+  on:drawerHide={onDrawerHide}
+  on:drawerShow
+  title={title || text || "Bindings"}
+  {forceModal}
+>
+  <Button cta slot="buttons" on:click={saveBinding}>Save</Button>
+  <svelte:component
+    this={panel}
+    slot="body"
+    value={tempValue}
+    on:change={event => (tempValue = event.detail)}
+    {bindings}
+    {allowHBS}
+    {allowJS}
+    {allowHelpers}
+    {allowHTML}
+    {allowSnippets}
+    {context}
+  />
+</Drawer>
+
+<style>
+  .control {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xxs);
+  }
+  .checkbox-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+  }
+  .checkbox-wrapper :global(.spectrum-Form-item) {
+    margin: 0;
+    flex: 1;
+  }
+  .icon {
+    border-radius: 4px;
+    display: grid;
+    place-items: center;
+    width: 28px;
+    height: 28px;
+    color: var(--spectrum-alias-text-color);
+    border: 1px solid var(--spectrum-alias-border-color);
+    cursor: pointer;
+  }
+  .icon:hover {
+    color: var(--spectrum-alias-text-color-hover);
+    border-color: var(--spectrum-alias-border-color-hover);
+  }
+  .binding-preview {
+    color: var(--spectrum-global-color-gray-700);
+    font-size: var(--spectrum-global-dimension-font-size-75);
+    padding-left: 2px;
+  }
+</style>

--- a/packages/builder/src/components/common/bindings/index.js
+++ b/packages/builder/src/components/common/bindings/index.js
@@ -1,6 +1,7 @@
 export { default as BindableCombobox } from "./BindableCombobox.svelte"
 export { default as BindingPanel } from "./BindingPanel.svelte"
 export { default as BindingSidePanel } from "./BindingSidePanel.svelte"
+export { default as DrawerBindableCheckbox } from "./DrawerBindableCheckbox.svelte"
 export { default as DrawerBindableCombobox } from "./DrawerBindableCombobox.svelte"
 export { default as ClientBindingPanel } from "./ClientBindingPanel.svelte"
 export { default as DrawerBindableInput } from "./DrawerBindableInput.svelte"

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/NavigateTo.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/NavigateTo.svelte
@@ -1,9 +1,10 @@
 <script>
   import { screenStore } from "@/stores/builder"
   import { onMount } from "svelte"
-  import { Label, Checkbox, Select } from "@budibase/bbui"
+  import { Label, Select, Checkbox } from "@budibase/bbui"
   import DrawerBindableInput from "@/components/common/bindings/DrawerBindableInput.svelte"
   import DrawerBindableCombobox from "@/components/common/bindings/DrawerBindableCombobox.svelte"
+  import DrawerBindableCheckbox from "@/components/common/bindings/DrawerBindableCheckbox.svelte"
 
   export let parameters
   export let bindings = []
@@ -49,7 +50,12 @@
       appendBindingsAsOptions={false}
     />
     <div />
-    <Checkbox text="Open screen in modal" bind:value={parameters.peek} />
+    <DrawerBindableCheckbox
+      text="Open screen in modal"
+      value={parameters.peek}
+      on:change={event => (parameters.peek = event.detail)}
+      {bindings}
+    />
   {:else}
     <DrawerBindableInput
       title="Destination"


### PR DESCRIPTION
## Description
- Adds a reusable bindable checkbox control so boolean action parameters can use bindings without workarounds.
- Switches the Navigate To action's "Open screen in modal" option to the bindable control to satisfy #16463.
- Keeps existing behaviour for the external tab option.

## Addresses
- https://github.com/Budibase/budibase/issues/16463

## Screenshots
<img width="879" height="421" alt="Screenshot 2025-12-18 at 17 35 51" src="https://github.com/user-attachments/assets/2fbd3814-0d66-41e4-815a-49f7a95d1b70" />

<img width="879" height="252" alt="Screenshot 2025-12-18 at 17 36 10" src="https://github.com/user-attachments/assets/453215d2-7483-4343-b1a6-d60d73118392" />

<img width="879" height="252" alt="Screenshot 2025-12-18 at 17 36 28" src="https://github.com/user-attachments/assets/075c339d-2325-4bc5-8191-6faede8e9651" />

*Uses checkbox when the binding is removed*

## Launchcontrol
Allow Navigate actions to decide whether to open the destination screen in a modal via bindings (e.g. only on desktop).