### PR TITLE
[Fix] Ensure prod tables dont get dropped

### DIFF
--- a/packages/backend-core/src/db/Replication.spec.ts
+++ b/packages/backend-core/src/db/Replication.spec.ts
@@ -333,7 +333,7 @@ describe("Replication", () => {
 
       await replication.resolveInconsistencies(["doc1"])
 
-      expect(mockSourceDb.put).toHaveBeenCalledTimes(4) // 3 versions to jump, so loop executes 4 times
+      expect(mockSourceDb.put).toHaveBeenCalledTimes(4) // the target is ahead of source 3 versions. Loop executes 4 times to ensure source rev exceeds target
       expect(mockTargetDb.remove).not.toHaveBeenCalled()
       expect(replication.replicate).not.toHaveBeenCalled()
     })

--- a/packages/backend-core/src/db/Replication.spec.ts
+++ b/packages/backend-core/src/db/Replication.spec.ts
@@ -8,6 +8,7 @@ const mockSourceDb = {
   },
   name: "source_db",
   get: jest.fn(),
+  put: jest.fn(),
 }
 
 const mockTargetDb = {
@@ -267,7 +268,7 @@ describe("Replication", () => {
     })
   })
 
-  describe("haveReplicationInconsistencies", () => {
+  describe("replicationDelta", () => {
     let replication: Replication
 
     beforeEach(() => {
@@ -281,19 +282,19 @@ describe("Replication", () => {
       {
         sourceRev: "5-abc123",
         targetRev: "8-def456",
-        expected: true,
+        expected: 3,
         description: "target has higher revision",
       },
       {
         sourceRev: "10-abc123",
         targetRev: "8-def456",
-        expected: false,
+        expected: -2,
         description: "source has higher revision",
       },
       {
         sourceRev: "5-abc123",
         targetRev: "5-def456",
-        expected: false,
+        expected: 0,
         description: "revisions are equal",
       },
     ])(
@@ -302,9 +303,10 @@ describe("Replication", () => {
         const sourceDoc = { _rev: sourceRev }
         const targetDoc = { _rev: targetRev }
 
-        const hasInconsistency = (
-          replication as any
-        ).haveReplicationInconsistencies(sourceDoc, targetDoc)
+        const hasInconsistency = (replication as any).replicationDelta(
+          sourceDoc,
+          targetDoc
+        )
         expect(hasInconsistency).toBe(expected)
       }
     )
@@ -322,24 +324,21 @@ describe("Replication", () => {
       jest.spyOn(replication, "replicate").mockResolvedValue({} as any)
     })
 
-    it("should remove conflicted documents and replicate them", async () => {
+    it("should bump source revisions when target is ahead", async () => {
       const sourceDoc = { _id: "doc1", _rev: "5-abc123" }
       const targetDoc = { _id: "doc1", _rev: "8-def456" }
 
       mockSourceDb.get.mockResolvedValue(sourceDoc)
       mockTargetDb.get.mockResolvedValue(targetDoc)
-      mockTargetDb.remove.mockResolvedValue({})
 
       await replication.resolveInconsistencies(["doc1"])
 
-      expect(mockTargetDb.remove).toHaveBeenCalledWith({
-        _id: "doc1",
-        _rev: "8-def456",
-      })
-      expect(replication.replicate).toHaveBeenCalledWith({ doc_ids: ["doc1"] })
+      expect(mockSourceDb.put).toHaveBeenCalledTimes(4) // 3 versions to jump, so loop executes 4 times
+      expect(mockTargetDb.remove).not.toHaveBeenCalled()
+      expect(replication.replicate).not.toHaveBeenCalled()
     })
 
-    it("should not remove documents without inconsistencies", async () => {
+    it("should skip documents without inconsistencies", async () => {
       const sourceDoc = { _id: "doc1", _rev: "8-abc123" }
       const targetDoc = { _id: "doc1", _rev: "5-def456" }
 
@@ -348,6 +347,7 @@ describe("Replication", () => {
 
       await replication.resolveInconsistencies(["doc1"])
 
+      expect(mockSourceDb.put).not.toHaveBeenCalled()
       expect(mockTargetDb.remove).not.toHaveBeenCalled()
       expect(replication.replicate).not.toHaveBeenCalled()
     })

--- a/packages/backend-core/src/db/Replication.ts
+++ b/packages/backend-core/src/db/Replication.ts
@@ -54,9 +54,8 @@ class Replication {
     })
   }
 
-  // Resolves replication conflicts by treating source as the source of truth.
-  // For documents where target revision is higher than source, removes the target
-  // document and re-replicates from source to ensure source version prevails.
+  // If the target rev went ahead the source rev, replication will cause conflicts and the document will not update in the target.
+  // This function checks the delta, and updates the source document rev to be ahead of the target, allowing the document to be copied
   async resolveInconsistencies(documentIds: string[]) {
     for (const documentId of documentIds) {
       try {

--- a/packages/backend-core/src/db/Replication.ts
+++ b/packages/backend-core/src/db/Replication.ts
@@ -63,7 +63,7 @@ class Replication {
           this.source.get(documentId),
           this.target.get(documentId),
         ])
-        const versionsToJump = this.haveReplicationInconsistencies(
+        const versionsToJump = this.replicationDelta(
           sourceDocument,
           targetDocument
         )
@@ -81,10 +81,7 @@ class Replication {
     }
   }
 
-  private haveReplicationInconsistencies(
-    sourceDocument: Document,
-    targetDocument: Document
-  ) {
+  private replicationDelta(sourceDocument: Document, targetDocument: Document) {
     const sourceRevisionNumber = this.getRevisionNumber(sourceDocument)
     const targetRevisionNumber = this.getRevisionNumber(targetDocument)
     return targetRevisionNumber - sourceRevisionNumber

--- a/packages/backend-core/src/db/Replication.ts
+++ b/packages/backend-core/src/db/Replication.ts
@@ -84,7 +84,7 @@ class Replication {
 
         await tracer.trace("Replication.resolveInconsistencies", async span => {
           span.addTags({
-            delta: versionsToJump,
+            versionsToJump,
             toFix: true,
             id: documentId,
             sourceRev: sourceDocument._rev,

--- a/packages/server/src/api/routes/tests/table.spec.ts
+++ b/packages/server/src/api/routes/tests/table.spec.ts
@@ -1804,7 +1804,7 @@ if (descriptions.length) {
 
             devTable = await getDevTable()
             prodTable = await getProdTable()
-            expectsRevVersion(devTable, 2)
+            expectsRevVersion(devTable, 3)
             expect(prodTable).toEqual(devTable)
             expect(devTable._rev).toEqual(prodTable._rev)
           })


### PR DESCRIPTION
## Description
Prevents production tables from being dropped during publish when production revisions are ahead. Replication now aligns revisions without deleting production documents.

- **Bug Fixes**
  - Replace target document deletion with revision alignment in resolveInconsistencies: compute target–source rev delta and bump source revs to catch up.
  - Avoids removing production docs, eliminating accidental table drops.
  - Added tests to cover:
    - Publishing a dev table when production rev is ahead (revs are aligned and prod matches dev).
    - No rev changes when production is not ahead.

<sup>Written for commit d2df5b26b73c672ef44ef9d1f1e11b5c4855cc5a. Summary will update automatically on new commits.</sup>


### Before

https://github.com/user-attachments/assets/e612d0d5-ab9d-459f-a4de-e3c2efa9eff4



### After

https://github.com/user-attachments/assets/463f5e15-56ae-4702-ad3d-1bbb2ec11ddf



## Launchcontrol
Fixes the issue that causes some drops for schema tables