### PR TITLE
Fix issue with external datasources dev / prod switching

### DIFF
--- a/packages/builder/src/components/backend/DataTable/buttons/grid/GridDevProdSwitcher.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/GridDevProdSwitcher.svelte
@@ -28,7 +28,11 @@
     leftText: "Dev",
     rightIcon: "pulse",
     rightText: "Prod",
-    selected: selected(),
+    selected: (disabled && !isInternal
+      ? "right"
+      : isDevMode
+        ? "left"
+        : "right") as "left" | "right",
     disabled,
   }
 

--- a/packages/builder/src/components/backend/DataTable/buttons/grid/GridDevProdSwitcher.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/GridDevProdSwitcher.svelte
@@ -17,11 +17,8 @@
   $: tableDatasource = $datasources.list.find(datasource => {
     return datasource._id === $tables.selected?.sourceId
   })
-  $: disabled = !isDeployed && !tableDatasource?.usesEnvironmentVariables
-  $: tooltip =
-    isInternal && !isDeployed
-      ? "Please publish to view production"
-      : "No production environment variables"
+  $: disabled = !isInternal && !tableDatasource?.usesEnvironmentVariables
+  $: tooltip = "No production environment variables"
 
   $: switcherProps = {
     leftIcon: "wrench",
@@ -34,12 +31,6 @@
         ? "left"
         : "right") as "left" | "right",
     disabled,
-  }
-
-  const selected = () => {
-    if (disabled && !isInternal) return "right" as "left" | "right"
-    if (isDevMode) return "left"
-    return "right"
   }
 
   const handleLeft = () =>

--- a/packages/builder/src/components/backend/DataTable/buttons/grid/GridDevProdSwitcher.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/GridDevProdSwitcher.svelte
@@ -1,72 +1,60 @@
 <script lang="ts">
   import { Switcher, AbsTooltip, TooltipPosition } from "@budibase/bbui"
-  import { DataEnvironmentMode } from "@budibase/types"
   import {
     dataEnvironmentStore,
     workspaceDeploymentStore,
     tables,
+    datasources,
   } from "@/stores/builder"
-  import { TableNames } from "@/constants"
+  import { DataEnvironmentMode } from "@budibase/types"
   import { DB_TYPE_EXTERNAL } from "@/constants/backend"
 
   $: isDevMode = $dataEnvironmentStore.mode === DataEnvironmentMode.DEVELOPMENT
   $: tableId = $tables.selected?._id!
-  $: isBudiUsersTable = tableId === TableNames.USERS
   $: isInternal = $tables.selected?.sourceType !== DB_TYPE_EXTERNAL
   $: isDeployed =
     isInternal && $workspaceDeploymentStore.tables[tableId]?.published
-  $: hasProductionData = isInternal ? isDeployed : true
-  $: switcherDisabled = !isInternal
-  $: tooltip = isInternal
-    ? "Publish to view production data"
-    : "Dev data is only available for internal tables"
-  $: showTooltip = switcherDisabled || !hasProductionData
-  $: hideSwitcher = isBudiUsersTable
+  $: tableDatasource = $datasources.list.find(datasource => {
+    return datasource._id === $tables.selected?.sourceId
+  })
+  $: disabled = !isDeployed && !tableDatasource?.usesEnvironmentVariables
+  $: tooltip =
+    isInternal && !isDeployed
+      ? "Please publish to view production"
+      : "No production environment variables"
 
   $: switcherProps = {
     leftIcon: "wrench",
     leftText: "Dev",
     rightIcon: "pulse",
     rightText: "Prod",
-    selected: (isDevMode ? "left" : "right") as "left" | "right",
-    disabled: switcherDisabled,
-  }
-
-  $: if (isBudiUsersTable) {
-    dataEnvironmentStore.setMode(DataEnvironmentMode.DEVELOPMENT)
-  }
-
-  $: if (switcherDisabled && isDevMode && !isBudiUsersTable) {
-    dataEnvironmentStore.setMode(DataEnvironmentMode.PRODUCTION)
+    selected: (disabled && !isInternal
+      ? "right"
+      : isDevMode
+        ? "left"
+        : "right") as "left" | "right",
+    disabled,
   }
 
   const handleLeft = () =>
     dataEnvironmentStore.setMode(DataEnvironmentMode.DEVELOPMENT)
-  const handleRight = () => {
-    if (switcherDisabled) return
+  const handleRight = () =>
     dataEnvironmentStore.setMode(DataEnvironmentMode.PRODUCTION)
-  }
 </script>
 
-{#if !hideSwitcher}
-  <div class="wrapper">
-    {#if showTooltip}
-      <AbsTooltip text={tooltip} position={TooltipPosition.Left}>
-        <Switcher
-          {...switcherProps}
-          on:left={handleLeft}
-          on:right={handleRight}
-        />
-      </AbsTooltip>
-    {:else}
+<div class="wrapper">
+  {#if disabled}
+    <AbsTooltip text={tooltip} position={TooltipPosition.Left}>
       <Switcher
         {...switcherProps}
         on:left={handleLeft}
         on:right={handleRight}
       />
-    {/if}
-  </div>
-{/if}
+    </AbsTooltip>
+  {:else}
+    <Switcher {...switcherProps} on:left={handleLeft} on:right={handleRight} />
+  {/if}
+</div>
 
 <style>
   .wrapper {

--- a/packages/builder/src/components/backend/DataTable/buttons/grid/GridDevProdSwitcher.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/GridDevProdSwitcher.svelte
@@ -1,19 +1,11 @@
 <script lang="ts">
   import { Switcher, AbsTooltip, TooltipPosition } from "@budibase/bbui"
   import { DataEnvironmentMode } from "@budibase/types"
-  import {
-    dataEnvironmentStore,
-    workspaceDeploymentStore,
-    tables,
-    datasources,
-  } from "@/stores/builder"
+  import { dataEnvironmentStore, tables, datasources } from "@/stores/builder"
   import { DB_TYPE_EXTERNAL } from "@/constants/backend"
 
   $: isDevMode = $dataEnvironmentStore.mode === DataEnvironmentMode.DEVELOPMENT
-  $: tableId = $tables.selected?._id!
   $: isInternal = $tables.selected?.sourceType !== DB_TYPE_EXTERNAL
-  $: isDeployed =
-    isInternal && $workspaceDeploymentStore.tables[tableId]?.published
   $: tableDatasource = $datasources.list.find(datasource => {
     return datasource._id === $tables.selected?.sourceId
   })

--- a/packages/builder/src/components/backend/DataTable/buttons/grid/GridDevProdSwitcher.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/GridDevProdSwitcher.svelte
@@ -2,15 +2,23 @@
   import { Switcher, AbsTooltip, TooltipPosition } from "@budibase/bbui"
   import { DataEnvironmentMode } from "@budibase/types"
   import { dataEnvironmentStore, tables, datasources } from "@/stores/builder"
+  import { TableNames } from "@/constants"
   import { DB_TYPE_EXTERNAL } from "@/constants/backend"
 
   $: isDevMode = $dataEnvironmentStore.mode === DataEnvironmentMode.DEVELOPMENT
+  $: tableId = $tables.selected?._id!
+  $: isBudiUsersTable = tableId === TableNames.USERS
   $: isInternal = $tables.selected?.sourceType !== DB_TYPE_EXTERNAL
   $: tableDatasource = $datasources.list.find(datasource => {
     return datasource._id === $tables.selected?.sourceId
   })
   $: disabled = !isInternal && !tableDatasource?.usesEnvironmentVariables
   $: tooltip = "No production environment variables"
+  $: hideSwitcher = isBudiUsersTable
+
+  $: if (isBudiUsersTable) {
+    dataEnvironmentStore.setMode(DataEnvironmentMode.DEVELOPMENT)
+  }
 
   $: switcherProps = {
     leftIcon: "wrench",
@@ -31,19 +39,25 @@
     dataEnvironmentStore.setMode(DataEnvironmentMode.PRODUCTION)
 </script>
 
-<div class="wrapper">
-  {#if disabled}
-    <AbsTooltip text={tooltip} position={TooltipPosition.Left}>
+{#if !hideSwitcher}
+  <div class="wrapper">
+    {#if disabled}
+      <AbsTooltip text={tooltip} position={TooltipPosition.Left}>
+        <Switcher
+          {...switcherProps}
+          on:left={handleLeft}
+          on:right={handleRight}
+        />
+      </AbsTooltip>
+    {:else}
       <Switcher
         {...switcherProps}
         on:left={handleLeft}
         on:right={handleRight}
       />
-    </AbsTooltip>
-  {:else}
-    <Switcher {...switcherProps} on:left={handleLeft} on:right={handleRight} />
-  {/if}
-</div>
+    {/if}
+  </div>
+{/if}
 
 <style>
   .wrapper {

--- a/packages/builder/src/components/backend/DataTable/buttons/grid/GridDevProdSwitcher.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/GridDevProdSwitcher.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { Switcher, AbsTooltip, TooltipPosition } from "@budibase/bbui"
+  import { DataEnvironmentMode } from "@budibase/types"
   import {
     dataEnvironmentStore,
     workspaceDeploymentStore,
     tables,
     datasources,
   } from "@/stores/builder"
-  import { DataEnvironmentMode } from "@budibase/types"
   import { DB_TYPE_EXTERNAL } from "@/constants/backend"
 
   $: isDevMode = $dataEnvironmentStore.mode === DataEnvironmentMode.DEVELOPMENT
@@ -28,12 +28,14 @@
     leftText: "Dev",
     rightIcon: "pulse",
     rightText: "Prod",
-    selected: (disabled && !isInternal
-      ? "right"
-      : isDevMode
-        ? "left"
-        : "right") as "left" | "right",
+    selected: selected(),
     disabled,
+  }
+
+  const selected = () => {
+    if (disabled && !isInternal) return "right" as "left" | "right"
+    if (isDevMode) return "left"
+    return "right"
   }
 
   const handleLeft = () =>


### PR DESCRIPTION
## Description
Fixes an issue introduced by https://github.com/Budibase/budibase/pull/17524 where users were incorrectly being shown an error when connecting external data sources. 

## Addresses
#17662 [17662](https://github.com/Budibase/budibase/issues/17662)
















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dev/prod switching for external datasources. Users no longer see errors when connecting.

- **Bug Fixes**
  - Switcher: disable only for external datasources without env vars, auto-select Prod when disabled, show tooltip only when disabled, and keep Users table hidden and forced to Dev.

<sup>Written for commit 53476e924dd6b2d5cc13dd6485be0644df7c15e0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->















