### PR TITLE
fix: The filtering does not recognize large umlauts

### DIFF
--- a/packages/backend-core/src/sql/tests/filters.spec.ts
+++ b/packages/backend-core/src/sql/tests/filters.spec.ts
@@ -161,6 +161,27 @@ describe("SQL filter parameterization", () => {
     expect(result.bindings?.[0]).toContain("beta")
   })
 
+  it("uses SQLite LIKE without LOWER for umlaut starts-with filters", () => {
+    const table = buildTable({
+      item: {
+        name: "item",
+        type: FieldType.STRING,
+        externalType: "text",
+        constraints: baseConstraints,
+      },
+    })
+    const query = buildQuery(table, {
+      string: { item: "Ü" },
+    })
+    query.meta = { sqliteUseLikeWithoutLower: true }
+
+    const result = new Sql(SqlClient.SQL_LITE)._query(query) as SqlQuery
+
+    expect(result.sql).toContain("LIKE")
+    expect(result.sql).not.toContain("LOWER")
+    expect(result.bindings).toEqual(expect.arrayContaining(["Ü%"]))
+  })
+
   it("parameterizes MySQL JSON contains filters", () => {
     const table = buildTable({
       payload: {

--- a/packages/server/src/sdk/workspace/rows/search/internal/sqs.ts
+++ b/packages/server/src/sdk/workspace/rows/search/internal/sqs.ts
@@ -406,6 +406,7 @@ export async function search(
     filters: searchFilters,
     meta: {
       columnPrefix: USER_COLUMN_PREFIX,
+      sqliteUseLikeWithoutLower: true,
     },
     resource: {
       fields: await buildInternalFieldList(source, allTables, {

--- a/packages/types/src/sdk/search.ts
+++ b/packages/types/src/sdk/search.ts
@@ -181,6 +181,8 @@ export interface QueryJson {
     oldTable?: Table
     // can specify something that columns could be prefixed with
     columnPrefix?: string
+    // internal tables can opt into SQLite LIKE without LOWER for unicode
+    sqliteUseLikeWithoutLower?: boolean
   }
   extra?: {
     idFilter?: SearchFilters


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Unicode filtering in SQLite to match uppercase umlauts (e.g., Ü) in contains and prefix filters. Internal search now opts into LIKE without LOWER for better Unicode support.


- **Bug Fixes**
  - Added meta.sqliteUseLikeWithoutLower to query options.
  - Switched SQLite filters to use raw LIKE without LOWER when the flag is set.
  - Enabled the flag for workspace row search.
  - Added a test for starts-with filter with Ü.

<sup>Written for commit d452f9d533d23c2de3a199275a8ca2bf509747f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

addresses: https://github.com/Budibase/budibase/issues/17558

