### PR TITLE
Allow rowId to be provided for Get Row automation step

### DIFF
--- a/packages/server/src/automations/steps/getRow.ts
+++ b/packages/server/src/automations/steps/getRow.ts
@@ -103,7 +103,6 @@ export async function run({
       rows = ctx.body ? ctx.body.rows : []
     }
 
-    console.log("ROWS ??? ", rows)
     return {
       row: rows && rows.length > 0 ? rows[0] : null,
       success: true,

--- a/packages/server/src/automations/steps/getRow.ts
+++ b/packages/server/src/automations/steps/getRow.ts
@@ -27,7 +27,7 @@ export async function run({
   inputs: GetRowStepInputs
   appId: string
 }): Promise<GetRowStepOutputs> {
-  const { tableId, filters, sortColumn, sortOrder } = inputs
+  const { tableId, rowId, filters, sortColumn, sortOrder } = inputs
   if (!tableId) {
     return {
       success: false,
@@ -35,6 +35,35 @@ export async function run({
       response: {
         message: "You must select a table to query.",
       },
+    }
+  }
+
+  if (rowId) {
+    const ctx = buildCtx(appId, null, {
+      params: {
+        tableId: decodeURIComponent(tableId),
+        rowId,
+      },
+    })
+
+    try {
+      await rowController.find(ctx)
+      return {
+        row: ctx.body || null,
+        success: true,
+      }
+    } catch (err) {
+      // continue
+    }
+  }
+
+  const hasFilters =
+    (filters && Object.keys(filters).length > 0) ||
+    (inputs["filters-def"] && inputs["filters-def"].length > 0)
+  if (!hasFilters) {
+    return {
+      success: false,
+      row: null,
     }
   }
 
@@ -74,6 +103,7 @@ export async function run({
       rows = ctx.body ? ctx.body.rows : []
     }
 
+    console.log("ROWS ??? ", rows)
     return {
       row: rows && rows.length > 0 ? rows[0] : null,
       success: true,

--- a/packages/server/src/automations/steps/getRow.ts
+++ b/packages/server/src/automations/steps/getRow.ts
@@ -64,6 +64,10 @@ export async function run({
     return {
       success: false,
       row: null,
+      response: {
+        message:
+          "You must provide a matching row ID or at least one filter to get row.",
+      },
     }
   }
 

--- a/packages/server/src/automations/tests/steps/getRow.spec.ts
+++ b/packages/server/src/automations/tests/steps/getRow.spec.ts
@@ -74,6 +74,9 @@ describe("Get row automation step", () => {
 
     expect(result.steps[0].outputs.success).toBe(false)
     expect(result.steps[0].outputs.row).toBeNull()
+    expect(result.steps[0].outputs.response.message).toBe(
+      "You must provide a matching row ID or at least one filter to get row."
+    )
   })
 
   it("returns the row when rowId is provided even if filters don't match", async () => {

--- a/packages/server/src/automations/tests/steps/getRow.spec.ts
+++ b/packages/server/src/automations/tests/steps/getRow.spec.ts
@@ -9,6 +9,7 @@ const NAME = "Test"
 describe("Get row automation step", () => {
   const config = new TestConfiguration()
   let table: Table
+  let rowId: string
 
   beforeAll(async () => {
     await automation.init()
@@ -20,7 +21,8 @@ describe("Get row automation step", () => {
       description: "original description",
     }
 
-    await config.api.row.save(table._id!, row)
+    const savedRow = await config.api.row.save(table._id!, row)
+    rowId = savedRow._id!
     await config.api.row.save(table._id!, {
       name: `${NAME} 2`,
       description: "second description",
@@ -56,7 +58,7 @@ describe("Get row automation step", () => {
     expect(result.steps[0].outputs.row?.name).toBe(NAME)
   })
 
-  it("returns null when onEmptyFilter is RETURN_NONE and filters are empty", async () => {
+  it("returns null when rowId and filters are empty", async () => {
     const result = await createAutomationBuilder(config)
       .onAppAction()
       .getRow(
@@ -70,23 +72,48 @@ describe("Get row automation step", () => {
       )
       .test({ fields: {} })
 
-    expect(result.steps[0].outputs.success).toBe(true)
+    expect(result.steps[0].outputs.success).toBe(false)
     expect(result.steps[0].outputs.row).toBeNull()
   })
 
-  it("returns the first row when onEmptyFilter is RETURN_ALL and filters are empty", async () => {
+  it("returns the row when rowId is provided even if filters don't match", async () => {
     const result = await createAutomationBuilder(config)
       .onAppAction()
       .getRow(
         {
           tableId: table._id!,
-          onEmptyFilter: EmptyFilterOption.RETURN_ALL,
-          filters: {},
-          "filters-def": [],
+          rowId,
+          filters: {
+            equal: {
+              name: "does not exist",
+            },
+          },
+        },
+        { stepName: "Get row by id" }
+      )
+      .test({ fields: {} })
+
+    expect(result.steps[0].outputs.success).toBe(true)
+    expect(result.steps[0].outputs.row).toBeDefined()
+    expect(result.steps[0].outputs.row?._id).toBe(rowId)
+  })
+
+  it("falls back to filters when rowId is not found and filters are set", async () => {
+    const result = await createAutomationBuilder(config)
+      .onAppAction()
+      .getRow(
+        {
+          tableId: table._id!,
+          rowId: "ro_missing_row_id",
+          filters: {
+            equal: {
+              name: NAME,
+            },
+          },
           sortColumn: "name",
           sortOrder: SortOrder.ASCENDING,
         },
-        { stepName: "Get row with empty filters, returning all" }
+        { stepName: "Get row fallback" }
       )
       .test({ fields: {} })
 

--- a/packages/shared-core/src/automations/steps/getRow.ts
+++ b/packages/shared-core/src/automations/steps/getRow.ts
@@ -33,6 +33,10 @@ export const definition: AutomationStepDefinition = {
           customType: AutomationCustomIOType.TABLE,
           title: "Table",
         },
+        rowId: {
+          type: AutomationIOType.STRING,
+          title: "Row ID",
+        },
         filters: {
           type: AutomationIOType.OBJECT,
           customType: AutomationCustomIOType.FILTERS,

--- a/packages/types/src/documents/workspace/automation/StepInputsOutputs.ts
+++ b/packages/types/src/documents/workspace/automation/StepInputsOutputs.ts
@@ -340,6 +340,7 @@ export type QueryRowsStepOutputs = BaseAutomationOutputs & {
 
 export type GetRowStepInputs = {
   tableId: string
+  rowId?: string
   filters?: SearchFilters
   "filters-def"?: any
   sortColumn?: string


### PR DESCRIPTION
## Description
Use **rowId** first. If not provided, or does not match, then fallback to filters. 

If the rowId is not provided or does not match, and no filters are provided, then set status to *failed*, and return null.

## Addresses
- https://github.com/Budibase/budibase/issues/17642

## Screenshots
<img width="996" height="792" alt="Screenshot 2026-01-06 at 14 07 10" src="https://github.com/user-attachments/assets/11a65611-9f17-4149-9127-c5557776911b" />

## Launchcontrol
Allow rowId to be provided for Get Row automation step
