### PR TITLE
Added direct call to routify goto to ensure svelte5 init

### DIFF
--- a/packages/builder/src/components/common/WorkspaceSelect.svelte
+++ b/packages/builder/src/components/common/WorkspaceSelect.svelte
@@ -10,6 +10,8 @@
   import WorkspaceSortMenu from "./WorkspaceSortMenu.svelte"
   import type { EnrichedApp } from "@/types"
 
+  $goto
+  
   const SORT_OPTIONS = [
     { key: "name", label: "Alphabetical" },
     { key: "updated", label: "Last edited" },

--- a/packages/builder/src/components/common/WorkspaceSelect.svelte
+++ b/packages/builder/src/components/common/WorkspaceSelect.svelte
@@ -11,7 +11,7 @@
   import type { EnrichedApp } from "@/types"
 
   $goto
-  
+
   const SORT_OPTIONS = [
     { key: "name", label: "Alphabetical" },
     { key: "updated", label: "Last edited" },

--- a/packages/builder/src/components/common/WorkspaceSelect.svelte
+++ b/packages/builder/src/components/common/WorkspaceSelect.svelte
@@ -10,6 +10,7 @@
   import WorkspaceSortMenu from "./WorkspaceSortMenu.svelte"
   import type { EnrichedApp } from "@/types"
 
+  // Manually subscribe - https://github.com/roxiness/routify/issues/563
   $goto
 
   const SORT_OPTIONS = [


### PR DESCRIPTION
## Description

Added explicit call to `$goto` in the workspace selector. This is a workaround to allow the current version of routify to run with svelte 5.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure workspace picker routing initializes under Svelte 5 by explicitly referencing Routify’s $goto in WorkspaceSelect. Prevents navigation from failing on first use.

- **Bug Fixes**
  - Added $goto reference to trigger Routify initialization. No UI changes.

<sup>Written for commit c5b712593e3d581dcfe7eea112042be313832cdf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

