### PR TITLE
Tidy up some lint warnings

### DIFF
--- a/packages/bbui/src/Form/Core/Picker.svelte
+++ b/packages/bbui/src/Form/Core/Picker.svelte
@@ -337,7 +337,7 @@
             class="virtual-spacer"
             aria-hidden="true"
             style={`height:${virtualPaddingTop}px`}
-          />
+          ></li>
         {/if}
         {#each virtualizedOptions as { option, idx } (getOptionValue(option, idx) ?? idx)}
           <li
@@ -396,7 +396,7 @@
             class="virtual-spacer"
             aria-hidden="true"
             style={`height:${virtualPaddingBottom}px`}
-          />
+          ></li>
         {/if}
       {/if}
     </ul>

--- a/packages/builder/src/components/automation/SetupPanel/ChainOfThought.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/ChainOfThought.svelte
@@ -37,7 +37,7 @@
           <StatusLight size="S" color={getStatusLightColor(step.status)} />
         </div>
         {#if !isLast}
-          <div class="connector" />
+          <div class="connector"></div>
         {/if}
       </div>
 

--- a/packages/builder/src/components/automation/SetupPanel/ChainOfThoughtModal.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/ChainOfThoughtModal.svelte
@@ -77,7 +77,7 @@
                     />
                   </div>
                   {#if !isLast}
-                    <div class="step-line" />
+                    <div class="step-line"></div>
                   {/if}
                 </div>
                 <span class="step-name">{step.displayName}</span>

--- a/packages/builder/src/components/backend/DataTable/blankstates/ProductionBlankState.svelte
+++ b/packages/builder/src/components/backend/DataTable/blankstates/ProductionBlankState.svelte
@@ -61,7 +61,7 @@
         <Button disabled={loading} on:click={publishEmpty}>
           <div class="button-content" aria-live="polite">
             {#if publishLoading}
-              <span class="spinner" aria-hidden="true" />
+              <span class="spinner" aria-hidden="true"></span>
             {/if}
             <span>{publishLoading ? "Publishing..." : "Publish"}</span>
           </div>
@@ -85,7 +85,7 @@
         >
           <div class="button-content" aria-live="polite">
             {#if seedLoading}
-              <span class="spinner" aria-hidden="true" />
+              <span class="spinner" aria-hidden="true"></span>
             {/if}
             <span
               >{seedLoading

--- a/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
+++ b/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
@@ -196,7 +196,7 @@
 >
   <div class="content">
     {#if sourceType}
-      <p class="warning">
+      <div class="warning">
         {buildMessage(sourceType)}
         {#if affectedScreens.length > 0}
           <span class="screens">
@@ -211,7 +211,7 @@
             </ul>
           </span>
         {/if}
-      </p>
+      </div>
     {/if}
     <p class="warning">This action cannot be undone.</p>
   </div>

--- a/packages/builder/src/components/common/NavItem.svelte
+++ b/packages/builder/src/components/common/NavItem.svelte
@@ -193,9 +193,7 @@
     border: 0.5px solid var(--spectrum-global-color-gray-300);
     border-radius: 8px;
   }
-  :is(.nav-item.selected):has(+ :is(ul)) {
-    border-radius: 8px 8px 0 0 !important;
-  }
+
   .nav-item.selected:hover {
     border-radius: 8px !important;
   }

--- a/packages/builder/src/components/common/PublishStatusBadge.svelte
+++ b/packages/builder/src/components/common/PublishStatusBadge.svelte
@@ -35,11 +35,6 @@
       border: 1px solid #005d39;
     }
 
-    &.unpublished {
-      --color: var(--spectrum-global-color-orange-100);
-      border: 1px solid var(--spectrum-global-color-gray-400);
-    }
-
     &.disabled {
       --color: var(--spectrum-global-color-gray-300);
       border: 1px solid var(--spectrum-global-color-gray-400);

--- a/packages/builder/src/components/common/WorkspaceSelect.svelte
+++ b/packages/builder/src/components/common/WorkspaceSelect.svelte
@@ -190,7 +190,7 @@
           }}
         />
       {:else}
-        <span class="header-actions-spacer" aria-hidden="true" />
+        <span class="header-actions-spacer" aria-hidden="true"></span>
       {/if}
       <WorkspaceSortMenu
         {currentSort}

--- a/packages/builder/src/components/integration/APIEndpointViewer.svelte
+++ b/packages/builder/src/components/integration/APIEndpointViewer.svelte
@@ -973,7 +973,7 @@
       class="underlay"
       transition:fade={{ duration: 260 }}
       on:click={() => sidebarExpanded.set(false)}
-    />
+    ></div>
   {/if}
   {#if $sidebarExpanded}
     <div

--- a/packages/builder/src/components/settings/ModalSideBar.svelte
+++ b/packages/builder/src/components/settings/ModalSideBar.svelte
@@ -215,17 +215,4 @@
   .nav:not(.pinned):not(.focused) .collapse_icon {
     display: none;
   }
-
-  @container (max-width: 239px) {
-    .favourite-wrapper {
-      display: none;
-      transition: all 130ms ease-in-out;
-    }
-    .favourite-title {
-      display: all 130ms ease-in-out;
-    }
-    .favourite-empty-state {
-      display: all 130ms ease-in-out;
-    }
-  }
 </style>

--- a/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
@@ -366,7 +366,7 @@
 </Modal>
 
 <div class="nav_wrapper" style={`--nav-logo-width: ${navLogoSize}px;`}>
-  <div class="nav_spacer" class:pinned={$pinned} />
+  <div class="nav_spacer" class:pinned={$pinned}></div>
   <div
     class="nav"
     class:pinned={$pinned}

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/_layout.svelte
@@ -99,7 +99,7 @@
             class="dividerClickExtender"
             role="separator"
             use:resizableHandle
-          />
+          ></div>
         </div>
       </div>
     {/if}

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/index.svelte
@@ -365,11 +365,6 @@
     border: 1px solid transparent;
     padding: 3px 10px;
     height: auto;
-
-    &.is-selected {
-      background: var(--spectrum-global-color-gray-200);
-      border-color: var(--spectrum-global-color-gray-300);
-    }
   }
   .action-buttons {
     display: flex;

--- a/packages/builder/src/pages/builder/workspace/[application]/design/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/index.svelte
@@ -418,11 +418,6 @@
     border: 1px solid transparent;
     padding: 3px 10px;
     height: auto;
-
-    &.is-selected {
-      background: var(--spectrum-global-color-gray-200);
-      border-color: var(--spectrum-global-color-gray-300);
-    }
   }
   .action-buttons {
     display: flex;

--- a/packages/frontend-core/src/components/Chatbox/index.svelte
+++ b/packages/frontend-core/src/components/Chatbox/index.svelte
@@ -303,7 +303,7 @@
       on:keydown={handleKeyDown}
       placeholder="Ask anything"
       disabled={loading}
-    />
+    ></textarea>
   </div>
 </div>
 


### PR DESCRIPTION
## Description
With the upgrade to Svelte 5 and it's dependencies, there were some warnings floating about in the builder.

Things like not closing html tags which are now warnings and there was some unused css. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Svelte 5 lint warnings by closing non-void HTML tags and cleaning up unused/invalid CSS across builder and UI components. No visual or functional changes; this removes warnings.

- **Refactors**
  - Replaced self-closing tags with proper closing tags (div, span, li, textarea).
  - Removed unused/invalid CSS (unpublished badge, is-selected styles, container query, nav :has selector).
  - Adjusted markup for warning and overlay elements to align with valid HTML.

<sup>Written for commit 08f4a375e88810338c7e4fe971104fb60dd2b5a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

