### PR TITLE
Update CLI to migrate old plugin github workflows

### DIFF
--- a/packages/cli/src/plugins/migrate.ts
+++ b/packages/cli/src/plugins/migrate.ts
@@ -599,12 +599,12 @@ export async function analysePluginForSvelte5(): Promise<AnalysisResult> {
     }
     if (hasNode16) {
       nodeVersionStatus = "needs-migration"
-      report.push(
-        "Will update GitHub workflow files: node-version 16 -> 18."
-      )
+      report.push("Will update GitHub workflow files: node-version 16 -> 18.")
     } else if (hasNode18OrHigher) {
       nodeVersionStatus = "looks-new"
-      report.push("GitHub workflow files already use node-version 18 or higher.")
+      report.push(
+        "GitHub workflow files already use node-version 18 or higher."
+      )
     } else {
       nodeVersionStatus = "looks-new"
       report.push(

--- a/packages/cli/src/plugins/migrate.ts
+++ b/packages/cli/src/plugins/migrate.ts
@@ -21,6 +21,7 @@ type AnalysisResult = {
   packageJson: "needs-migration" | "looks-new"
   wrapper: "needs-migration" | "looks-new" | "not-found"
   schema: "needs-migration" | "looks-new" | "not-found" | "unknown"
+  nodeVersion: "needs-migration" | "looks-new" | "not-found"
   canBuildAfter: boolean
   report: string[]
   rollupFile?: string
@@ -365,6 +366,69 @@ export function migratePackageJson(): MigrationResult {
   }
 }
 
+export function findWorkflowFiles(): string[] {
+  const workflowDir = path.join(process.cwd(), ".github", "workflows")
+  if (!fs.existsSync(workflowDir)) {
+    return []
+  }
+  const files = fs.readdirSync(workflowDir)
+  return files
+    .filter(f => f.endsWith(".yml") || f.endsWith(".yaml"))
+    .map(f => path.join(".github", "workflows", f))
+}
+
+export function migrateNodeVersion(): MigrationResult {
+  const workflowFiles = findWorkflowFiles()
+  if (workflowFiles.length === 0) {
+    return {
+      changed: false,
+      message:
+        "No GitHub workflow files found in .github/workflows/ - skipping node version migration.",
+    }
+  }
+
+  const messages: string[] = []
+  let anyChanged = false
+
+  for (const relPath of workflowFiles) {
+    const absPath = path.join(process.cwd(), relPath)
+    const content = fs.readFileSync(absPath, "utf8")
+
+    // Check for node-version: 16 (with or without quotes)
+    const nodeVersion16Pattern = /node-version:\s*['"]?16['"]?/g
+    if (!nodeVersion16Pattern.test(content)) {
+      continue
+    }
+
+    // Replace node-version: 16 with node-version: 18
+    const updated = content.replace(
+      /node-version:\s*['"]?16['"]?/g,
+      "node-version: 18"
+    )
+
+    if (updated !== content) {
+      const backupPath = `${absPath}.pre-svelte5`
+      fs.writeFileSync(backupPath, content)
+      fs.writeFileSync(absPath, updated)
+      anyChanged = true
+      messages.push(`Updated ${relPath}: node-version 16 -> 18`)
+    }
+  }
+
+  if (!anyChanged) {
+    return {
+      changed: false,
+      message:
+        "No workflow files with node-version: 16 found - skipping node version migration.",
+    }
+  }
+
+  return {
+    changed: true,
+    message: messages.join("; "),
+  }
+}
+
 export function migrateSchemaJson(): MigrationResult {
   const schemaPath = path.join(process.cwd(), "schema.json")
   if (!fs.existsSync(schemaPath)) {
@@ -517,12 +581,49 @@ export async function analysePluginForSvelte5(): Promise<AnalysisResult> {
     ? "looks-new"
     : "needs-migration"
 
+  // node version in workflows
+  let nodeVersionStatus: AnalysisResult["nodeVersion"] = "not-found"
+  const workflowFiles = findWorkflowFiles()
+  if (workflowFiles.length > 0) {
+    let hasNode16 = false
+    let hasNode18OrHigher = false
+    for (const relPath of workflowFiles) {
+      const absPath = path.join(process.cwd(), relPath)
+      const content = fs.readFileSync(absPath, "utf8")
+      if (/node-version:\s*['"]?16['"]?/.test(content)) {
+        hasNode16 = true
+      }
+      if (/node-version:\s*['"]?(18|20|22)['"]?/.test(content)) {
+        hasNode18OrHigher = true
+      }
+    }
+    if (hasNode16) {
+      nodeVersionStatus = "needs-migration"
+      report.push(
+        "Will update GitHub workflow files: node-version 16 -> 18."
+      )
+    } else if (hasNode18OrHigher) {
+      nodeVersionStatus = "looks-new"
+      report.push("GitHub workflow files already use node-version 18 or higher.")
+    } else {
+      nodeVersionStatus = "looks-new"
+      report.push(
+        "GitHub workflow files found but no node-version: 16 detected."
+      )
+    }
+  } else {
+    report.push(
+      "No GitHub workflow files found in .github/workflows/ - skipping node version check."
+    )
+  }
+
   return {
     report,
     rollup: rollupStatus,
     packageJson: packageJsonStatus,
     wrapper: wrapperStatus,
     schema: schemaStatus,
+    nodeVersion: nodeVersionStatus,
     canBuildAfter: true,
     rollupFile,
     wrapperFile,
@@ -553,10 +654,16 @@ export async function runSvelte5Migration() {
         changed: false,
         message: "Skipped wrapper migration due to Rollup template failure.",
       },
+      nodeVersionRes: {
+        changed: false,
+        message:
+          "Skipped node version migration due to Rollup template failure.",
+      },
     }
   }
   const wrapperRes = migrateWrapper()
   const schemaRes = migrateSchemaJson()
   const pkgRes = migratePackageJson()
-  return { pkgRes, schemaRes, rollupRes, wrapperRes }
+  const nodeVersionRes = migrateNodeVersion()
+  return { pkgRes, schemaRes, rollupRes, wrapperRes, nodeVersionRes }
 }


### PR DESCRIPTION
## Description
Some old plugins could have `node-version: 16` in their github workflows. Introduces another step to the Svelte 5 migration to account for that. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new CLI migration step to update GitHub Actions workflows from node-version: 16 to 18 as part of the Svelte 5 migration. Includes detection, reporting, backups, and integration into the analysis/run flow.

- **Migration**
  - Scans .github/workflows/*.yml|yaml and finds quoted/unquoted node-version values.
  - Replaces node-version: 16 with 18 and writes .pre-svelte5 backups.
  - Analysis now reports nodeVersion status; 18/20/22 are treated as up to date.
  - runSvelte5Migration returns nodeVersionRes and skips this step if the Rollup template fails.
  - Clear messages when no workflows exist or no node-version: 16 is found.

<sup>Written for commit 3edce159117ccb24d962363fc788a8306e1eeac9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

