### PR TITLE
Fix AI config error

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
@@ -561,6 +561,9 @@
 
   onMount(async () => {
     await Promise.all([agentsStore.init(), aiConfigsStore.fetch()])
+    if (draft.aiconfig) {
+      agentsStore.fetchTools(draft.aiconfig)
+    }
   })
 
   onDestroy(() => {

--- a/packages/builder/src/stores/portal/agents.ts
+++ b/packages/builder/src/stores/portal/agents.ts
@@ -25,7 +25,7 @@ export class AgentsStore extends BudiStore<AgentStoreState> {
   }
 
   init = async () => {
-    await Promise.all([this.fetchAgents(), this.fetchTools()])
+    await this.fetchAgents()
   }
 
   fetchAgents = async () => {


### PR DESCRIPTION
## Description
We were calling fetchTools() inside the init for the agents store. This was incorrect as it now takes a param, it was also totally unnecessary anyway. 


Prompt and conversation for this fix - https://opncd.ai/share/1wCXk9Cd

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed agents store initialization by removing the unconditional fetchTools() call and fetching tools only when an AI config exists. Prevents runtime errors from missing params and avoids unnecessary requests.

- **Bug Fixes**
  - Removed fetchTools() from AgentsStore.init; it now only fetches agents.
  - In agent config page, fetch tools with agentsStore.fetchTools(draft.aiconfig) after init and AI configs load, only when aiconfig is present.

<sup>Written for commit 656be9d0edc44102442cfc4ba8a861131714c1c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

