### PR TITLE
Fix issue with inserting js bindings

### DIFF
--- a/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
+++ b/packages/builder/src/components/common/CodeEditor/CodeEditor.svelte
@@ -53,7 +53,12 @@
   import { html } from "@codemirror/lang-html"
   import { EditorModes } from "./"
   import { themeStore } from "@/stores/portal"
-  import { type EnrichedBinding, type EditorMode } from "@budibase/types"
+  import {
+    type EnrichedBinding,
+    type EditorMode,
+    type CaretPositionFn,
+    type InsertAtPositionFn,
+  } from "@budibase/types"
   import { tooltips } from "@codemirror/view"
   import type { BindingCompletion, CodeValidator } from "@/types"
   import { validateHbsTemplate } from "./validator/hbs"
@@ -78,6 +83,11 @@
   export let aiEnabled = true
   export let lineWrapping = true
   export let renderBindingsAsTags = false
+  export let getCaretPosition: CaretPositionFn = () => ({
+    start: 0,
+    end: 0,
+  })
+  export let insertAtPos: InsertAtPositionFn = () => {}
 
   const dispatch = createEventDispatcher()
 
@@ -152,35 +162,31 @@
     }
   }
 
-  // Export a function to expose caret position
-  export const getCaretPosition = () => {
-    const selection_range = editor.state.selection.ranges[0]
-    return {
-      start: selection_range?.from,
-      end: selection_range?.to,
+  const exposeEditorApi = () => {
+    getCaretPosition = () => {
+      const selection_range = editor.state.selection.ranges[0]
+      return {
+        start: selection_range?.from,
+        end: selection_range?.to,
+      }
     }
-  }
 
-  export const insertAtPos = (opts: {
-    start: number
-    end?: number
-    value: string
-    cursor: { anchor: number }
-  }) => {
-    // Updating the value inside.
-    // Retain focus
-    editor.dispatch({
-      changes: {
-        from: opts.start || editor.state.doc.length,
-        to: opts.end || editor.state.doc.length,
-        insert: opts.value,
-      },
-      selection: opts.cursor
-        ? {
-            anchor: opts.start + opts.value.length,
-          }
-        : undefined,
-    })
+    insertAtPos = opts => {
+      // Updating the value inside.
+      // Retain focus
+      editor.dispatch({
+        changes: {
+          from: opts.start || editor.state.doc.length,
+          to: opts.end || editor.state.doc.length,
+          insert: opts.value,
+        },
+        selection: opts.cursor
+          ? {
+              anchor: opts.start + opts.value.length,
+            }
+          : undefined,
+      })
+    }
   }
 
   // Match decoration for HBS bindings
@@ -419,6 +425,7 @@
       ]),
       parent: textarea,
     })
+    exposeEditorApi()
   }
 
   const handleAICodeUpdate = (event: CustomEvent<{ code: string }>) => {

--- a/packages/builder/src/components/common/bindings/BindingPanel.svelte
+++ b/packages/builder/src/components/common/bindings/BindingPanel.svelte
@@ -65,8 +65,11 @@
   let initialValueJS = value?.startsWith?.("{{ js ")
   let jsValue: string | null = initialValueJS ? value : null
   let hbsValue: string | null = initialValueJS ? null : value
-  let getCaretPosition: CaretPositionFn | undefined
-  let insertAtPos: InsertAtPositionFn | undefined
+  let getCaretPosition: CaretPositionFn = () => ({
+    start: 0,
+    end: 0,
+  })
+  let insertAtPos: InsertAtPositionFn = () => {}
   let targetMode: BindingMode | null = null
   let expressionResult: string | undefined
   let expressionLogs: Log[] | undefined


### PR DESCRIPTION
## Description

Svelte 5 upgrade tightened what `bind: `can attach to. In Svelte 4 we were incorrectlyrelying on instance exports 
```(export const getCaretPosition/insertAtPos)``` being available for bind:…. In Svelte 5, those are module exports, not instance props, so the binding writes undefined into the parent and BindingHelpers ends up calling
  undefined.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken JS binding insertion by exposing the CodeEditor caret and insert APIs as bindable instance props in Svelte 5, and adding safe defaults to prevent undefined calls.

- **Bug Fixes**
  - CodeEditor: switched from module exports to bindable props (getCaretPosition, insertAtPos) and initialized them after editor setup.
  - BindingPanel: added no-op defaults for getCaretPosition and insertAtPos to avoid runtime errors when bindings initialize.

<sup>Written for commit 1a1024cfc119640d8c92752f48e965059a375944. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

