### PR TITLE
fix an issue where you couldn't drag and drop components with a certa…

### DIFF
--- a/packages/client/src/utils/grid.ts
+++ b/packages/client/src/utils/grid.ts
@@ -77,11 +77,9 @@ export const isGridEvent = (e: Event): e is GridEvent => {
   if (!(e.target instanceof HTMLElement)) {
     return false
   }
-  // Check if the event target is an indicator (label or resize anchor)
   if (e.target.dataset?.indicator === "true") {
     return true
   }
-  // Find the component wrapper and check if its parent is a grid
   const componentParent = e.target.closest?.(".component")?.parentNode
   if (!(componentParent instanceof HTMLElement)) {
     return false

--- a/packages/client/src/utils/grid.ts
+++ b/packages/client/src/utils/grid.ts
@@ -77,15 +77,16 @@ export const isGridEvent = (e: Event): e is GridEvent => {
   if (!(e.target instanceof HTMLElement)) {
     return false
   }
-  const componentParent = e.target.closest?.(".component")?.parentNode as
-    | HTMLElement
-    | undefined
-  const gridDOMCandidate = componentParent?.closest(".component")
-    ?.childNodes[0] as HTMLElement | undefined
-  return (
-    e.target.dataset?.indicator === "true" ||
-    !!gridDOMCandidate?.classList?.contains("grid")
-  )
+  // Check if the event target is an indicator (label or resize anchor)
+  if (e.target.dataset?.indicator === "true") {
+    return true
+  }
+  // Find the component wrapper and check if its parent is a grid
+  const componentParent = e.target.closest?.(".component")?.parentNode
+  if (!(componentParent instanceof HTMLElement)) {
+    return false
+  }
+  return componentParent.classList.contains("grid")
 }
 
 // Svelte action to apply required class names and styles to our component


### PR DESCRIPTION
## Description
In Svelte 5, childNodes[0] can return a text node (whitespace) instead of an element node due to how Svelte 5 renders the DOM differently from Svelte 4. So our check gridDOMCandidate?.classList?.contains("grid") would return undefined, and therefore we wouldn't fire the grid events.
 
So in the below image this would mean that you could only drag the component by clicking on the blue label, not the component itself. 
<img width="633" height="250" alt="image" src="https://github.com/user-attachments/assets/97570102-6d9e-4a65-a6b0-25a08919590a" />
