### PR TITLE
Some missing $gotos

### DIFF
--- a/packages/builder/src/components/backend/DataTable/buttons/grid/GridRowActionsButton.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/grid/GridRowActionsButton.svelte
@@ -13,10 +13,10 @@
   import DetailPopover from "@/components/common/DetailPopover.svelte"
   import { getContext } from "svelte"
   import { appStore, rowActions } from "@/stores/builder"
-  import { goto, url } from "@roxi/routify"
+  import { goto as gotoStore, url } from "@roxi/routify"
   import { derived } from "svelte/store"
 
-  $goto
+  $: goto = $gotoStore
   $url
 
   const { datasource } = getContext("grid")
@@ -64,7 +64,7 @@
         newName
       )
       notifications.success("Row action created successfully")
-      $goto($rowActionUrl(newRowAction))
+      goto($rowActionUrl(newRowAction))
     } catch (error) {
       console.error(error)
       notifications.error("Error creating row action")

--- a/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
+++ b/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
@@ -118,7 +118,6 @@
         goto("./datasource")
       }
     } catch (error) {
-      console.log(error)
       notifications.error("Error deleting datasource")
     }
   }

--- a/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
+++ b/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
@@ -13,13 +13,16 @@
   import ConfirmDialog from "@/components/common/ConfirmDialog.svelte"
   import { helpers, utils } from "@budibase/shared-core"
   import { SourceType } from "@budibase/types"
-  import { goto, params } from "@roxi/routify"
+  import { goto as gotoStore, params as paramsStore } from "@roxi/routify"
   import { DB_TYPE_EXTERNAL } from "@/constants/backend"
   import { get } from "svelte/store"
   import type { Table, ViewV2, View, Datasource, Query } from "@budibase/types"
 
-  $goto
-  $params
+  $gotoStore
+  $paramsStore
+
+  $: goto = $gotoStore
+  $: params = $paramsStore
 
   export let source: Table | ViewV2 | Datasource | Query | undefined
 
@@ -69,7 +72,7 @@
   }
 
   async function deleteTable(table: Table & { datasourceId?: string }) {
-    const isSelected = $params.tableId === table._id
+    const isSelected = params.tableId === table._id
     try {
       await tables.delete({
         _id: table._id!,
@@ -81,7 +84,7 @@
       }
       notifications.success("Table deleted")
       if (isSelected) {
-        $goto(`./datasource/${table.datasourceId}`)
+        goto(`./datasource/${table.datasourceId}`)
       }
     } catch (error: any) {
       notifications.error(`Error deleting table - ${error.message}`)
@@ -112,9 +115,10 @@
       const isSelected =
         get(datasources).selectedDatasourceId === datasource._id
       if (isSelected) {
-        $goto("./datasource")
+        goto("./datasource")
       }
     } catch (error) {
+      console.log(error)
       notifications.error("Error deleting datasource")
     }
   }
@@ -124,7 +128,7 @@
       // Go back to the datasource if we are deleting the active query
       if ($queries.selectedQueryId === query._id) {
         markSkipUnsavedPrompt(query._id)
-        $goto(`./datasource/${query.datasourceId}`)
+        goto(`./datasource/${query.datasourceId}`)
       }
       await queries.delete(query)
       await datasources.fetch()

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/AgentModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/AgentModal.svelte
@@ -4,6 +4,7 @@
   import { goto } from "@roxi/routify"
   import { onMount } from "svelte"
 
+  $goto
   export const show = () => {
     modal.show()
   }

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
@@ -54,7 +54,7 @@
   } from "../logos/tagIconUrls"
   import { goto } from "@roxi/routify"
   import BudibaseLogoSvg from "assets/bb-emblem.svg"
-
+  $goto
   // Code editor tag icons must be URL strings (see `hbsTags.ts`).
   // Use URLs derived from the same Phosphor SVG paths as the Svelte logo components.
   const WebSearchIconSvg = WEB_SEARCH_TAG_ICON_URL

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/new.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/new.svelte
@@ -40,6 +40,7 @@
   } from "@budibase/types"
   import { SourceName } from "@budibase/types"
 
+  $goto
   let externalDatasourceModal: CreateExternalDatasourceModal
   let externalDatasourceLoading = false
   let templateVersionModal: Modal

--- a/packages/builder/src/pages/builder/workspace/[application]/data/_components/AITableGeneration.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/_components/AITableGeneration.svelte
@@ -4,9 +4,9 @@
   import { datasources, tables } from "@/stores/builder"
   import { auth, licensing } from "@/stores/portal"
   import { ActionButton, notifications } from "@budibase/bbui"
-  import { goto } from "@roxi/routify"
+  import { goto as gotoStore } from "@roxi/routify"
 
-  $goto
+  $: goto = $gotoStore
 
   let promptText = ""
 
@@ -25,7 +25,7 @@
       notifications.success(`Tables created successfully.`)
       await datasources.fetch()
       await tables.fetch()
-      $goto(`./table/${tableToRedirect.id}`)
+      goto(`./table/${tableToRedirect.id}`)
     } catch (e: any) {
       notifications.error(e.message)
     }

--- a/packages/builder/src/pages/builder/workspace/[application]/data/table/[tableId]/_components/CreateViewButton.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/table/[tableId]/_components/CreateViewButton.svelte
@@ -8,11 +8,11 @@
     Icon,
     ListItem,
   } from "@budibase/bbui"
-  import { goto } from "@roxi/routify"
+  import { goto as gotoStore } from "@roxi/routify"
   import { viewsV2 } from "@/stores/builder"
   import { ViewV2Type } from "@budibase/types"
 
-  $goto
+  $: goto = $gotoStore
 
   export let table
   export let firstView = false
@@ -53,7 +53,7 @@
         type: calculation ? ViewV2Type.CALCULATION : undefined,
       })
       notifications.success(`View ${name} created`)
-      $goto(`./${newView.id}`)
+      goto(`./${newView.id}`)
     } catch (error) {
       notifications.error("Error creating view")
     }

--- a/packages/frontend-core/src/components/grid/layout/ButtonColumn.svelte
+++ b/packages/frontend-core/src/components/grid/layout/ButtonColumn.svelte
@@ -8,7 +8,7 @@
   const {
     renderedRows,
     hoveredRowId,
-    gridProps,
+    props: gridProps,
     width,
     rows,
     focusedRow,


### PR DESCRIPTION
## Description 
- Adds some missing $goto that were missed
- Fixes an issue were destructured prop was named incorrectly. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes navigation and grid prop wiring in Svelte 5. Ensures row action creation and delete flows redirect correctly, and the grid button column reads the right context prop.

- **Bug Fixes**
  - Rewired Routify stores: derive goto and params from gotoStore/paramsStore and call goto() directly.
  - Added missing $goto in pages to enable navigation: APIs “new”, Agent modal, and Agent config.
  - Corrected grid context destructuring to use props: gridProps in ButtonColumn.

<sup>Written for commit 3643b12acb793c18eb264cca94cb7ff97cc8c3e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

