### PR TITLE
Fix Jira Cloud template

### DIFF
--- a/packages/builder/src/stores/builder/restTemplates.ts
+++ b/packages/builder/src/stores/builder/restTemplates.ts
@@ -477,7 +477,7 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       specs: [
         {
           version: "3.0",
-          url: "https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json",
+          url: "https://raw.githubusercontent.com/Budibase/openapi-rest-templates/main/jira-cloud/openapi.json",
         },
       ],
       icon: JiraLogo,


### PR DESCRIPTION
## Description
The official template included `your-domain` directly in the URL, which we set to read-only in a template endpoint.

To get around this, I have imported their template into our Budibase templates repo: https://github.com/Budibase/openapi-rest-templates/blob/main/jira-cloud/openapi.json

But with one tweak: 
```json
[{'url': 'https://{companySubDomain}.atlassian.net', 'variables': {'companySubDomain': {'default': 'companySubDomain', 'description': 'Company domain'}}}]
```

Which follows the BambooHR pattern.

## Screenshots
<img width="725" height="849" alt="sub domain setting" src="https://github.com/user-attachments/assets/bf162ce5-e1ec-4db4-a320-2e017899065b" />

<img width="1292" height="638" alt="endpoint" src="https://github.com/user-attachments/assets/6e27df01-7f0f-451b-9828-bc55cb89d405" />


## Launchcontrol
Allow sub domain to be set for Jira Cloud REST Template

