### PR TITLE
Fix link theme in delete data confirmation modal

### DIFF
--- a/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
+++ b/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
@@ -208,8 +208,10 @@
             <ul class="screens-list">
               {#each affectedScreens as item}
                 <li>
-                  <Link overBackground={isDarkTheme} target="_blank" href={item.url}
-                    >{item.text}</Link
+                  <Link
+                    overBackground={isDarkTheme}
+                    target="_blank"
+                    href={item.url}>{item.text}</Link
                   >
                 </li>
               {/each}

--- a/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
+++ b/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
@@ -9,10 +9,11 @@
     views,
     viewsV2,
   } from "@/stores/builder"
+  import { themeStore } from "@/stores/portal"
   import { markSkipUnsavedPrompt } from "@/stores/builder/queries"
   import ConfirmDialog from "@/components/common/ConfirmDialog.svelte"
   import { helpers, utils } from "@budibase/shared-core"
-  import { SourceType } from "@budibase/types"
+  import { SourceType, Theme } from "@budibase/types"
   import { goto as gotoStore, params as paramsStore } from "@roxi/routify"
   import { DB_TYPE_EXTERNAL } from "@/constants/backend"
   import { get } from "svelte/store"
@@ -23,6 +24,7 @@
 
   $: goto = $gotoStore
   $: params = $paramsStore
+  $: isDarkTheme = $themeStore.theme !== Theme.LIGHT
 
   export let source: Table | ViewV2 | Datasource | Query | undefined
 
@@ -206,7 +208,7 @@
             <ul class="screens-list">
               {#each affectedScreens as item}
                 <li>
-                  <Link overBackground target="_blank" href={item.url}
+                  <Link overBackground={isDarkTheme} target="_blank" href={item.url}
                     >{item.text}</Link
                   >
                 </li>

--- a/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
+++ b/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
@@ -24,7 +24,7 @@
 
   $: goto = $gotoStore
   $: params = $paramsStore
-  $: isDarkTheme = $themeStore.theme !== Theme.LIGHT
+  $: isDarkTheme = ![Theme.LIGHTEST, Theme.LIGHT].includes($themeStore.theme)
 
   export let source: Table | ViewV2 | Datasource | Query | undefined
 


### PR DESCRIPTION
## Description
Fix the delete data confirmation modal links so they use the correct theme styling instead of always over-background.

## Addresses
- https://github.com/Budibase/budibase/issues/17712

## Screenshots
<img width="445" height="523" alt="Screenshot 2026-01-09 at 09 59 47" src="https://github.com/user-attachments/assets/50697e36-80ab-4038-9090-fc06df6d8bfc" />

<img width="445" height="523" alt="Screenshot 2026-01-09 at 09 59 22" src="https://github.com/user-attachments/assets/6d4e2190-0b0c-415d-a5bb-d9f1578d42de" />


## Launchcontrol
Fixes link styling in the delete data confirmation modal so it matches the current theme.
