### PR TITLE
Chore/figma rest template

### DIFF
--- a/packages/builder/assets/rest-template-icons/figma.svg
+++ b/packages/builder/assets/rest-template-icons/figma.svg
@@ -1,0 +1,9 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(16 8) scale(0.17)">
+    <path d="M50 300c27.6 0 50-22.4 50-50v-50H50c-27.6 0-50 22.4-50 50s22.4 50 50 50z" fill="#0ACF83"/>
+    <path d="M0 150c0-27.6 22.4-50 50-50h50v100H50c-27.6 0-50-22.4-50-50z" fill="#A259FF"/>
+    <path d="M0 50C0 22.4 22.4 0 50 0h50v100H50C22.4 100 0 77.6 0 50z" fill="#F24E1E"/>
+    <path d="M100 0h50c27.6 0 50 22.4 50 50s-22.4 50-50 50h-50V0z" fill="#FF7262"/>
+    <path d="M200 150c0 27.6-22.4 50-50 50s-50-22.4-50-50 22.4-50 50-50 50 22.4 50 50z" fill="#1ABCFE"/>
+  </g>
+</svg>

--- a/packages/builder/src/components/integration/APIEndpointViewer.svelte
+++ b/packages/builder/src/components/integration/APIEndpointViewer.svelte
@@ -1006,7 +1006,7 @@
 
 <style>
   .details :global(.markdown-viewer code) {
-    color: white;
+    color: var(--spectrum-alias-text-color);
   }
   .bottom {
     flex: 1;
@@ -1107,7 +1107,7 @@
     display: flex;
   }
   .send :global(.spectrum-Button-label) {
-    color: white;
+    color: var(--spectrum-alias-text-color);
   }
   .send :global(.icon) {
     color: var(--spectrum-global-color-gray-700);

--- a/packages/builder/src/stores/builder/restTemplates.ts
+++ b/packages/builder/src/stores/builder/restTemplates.ts
@@ -10,6 +10,7 @@ import AttioLogo from "assets/rest-template-icons/attio.svg"
 import BambooHRLogo from "assets/rest-template-icons/bamboohr.svg"
 import ConfluenceLogo from "assets/rest-template-icons/confluence.svg"
 import DiscordLogo from "assets/rest-template-icons/discord.svg"
+import FigmaLogo from "assets/rest-template-icons/figma.svg"
 import JiraLogo from "assets/rest-template-icons/jira.svg"
 import GitHubLogo from "assets/rest-template-icons/github.svg"
 import OktaLogo from "assets/rest-template-icons/okta.svg"
@@ -533,6 +534,18 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
         },
       ],
       icon: DiscordLogo,
+    },
+    {
+      name: "Figma",
+      description: "Design platform API for files, projects, teams, and comments",
+      specs: [
+        {
+          version: "1.0.0",
+          url: "https://raw.githubusercontent.com/figma/rest-api-spec/main/openapi/openapi.yaml",
+        },
+      ],
+      icon: FigmaLogo,
+      verified: true,
     },
     {
       name: "GitHub",

--- a/packages/builder/src/stores/builder/restTemplates.ts
+++ b/packages/builder/src/stores/builder/restTemplates.ts
@@ -529,7 +529,7 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       description: "Discord API for guilds, channels, messages, and webhooks",
       specs: [
         {
-          version: "1.0.0",
+          version: "10",
           url: "https://raw.githubusercontent.com/discord/discord-api-spec/main/specs/openapi.json",
         },
       ],
@@ -537,10 +537,11 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
     },
     {
       name: "Figma",
-      description: "Design platform API for files, projects, teams, and comments",
+      description:
+        "Design platform API for files, projects, teams, and comments",
       specs: [
         {
-          version: "1.0.0",
+          version: "0.35.0",
           url: "https://raw.githubusercontent.com/figma/rest-api-spec/main/openapi/openapi.yaml",
         },
       ],

--- a/packages/builder/src/stores/builder/restTemplates.ts
+++ b/packages/builder/src/stores/builder/restTemplates.ts
@@ -534,6 +534,7 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
         },
       ],
       icon: DiscordLogo,
+      verified: true,
     },
     {
       name: "Figma",

--- a/packages/types/src/ui/rest.ts
+++ b/packages/types/src/ui/rest.ts
@@ -16,6 +16,7 @@ export type RestTemplateName =
   | "BambooHR"
   | "Confluence"
   | "Discord"
+  | "Figma"
   | "GitHub"
   | "Jira Cloud"
   | "Okta Management"


### PR DESCRIPTION
## Description
Add Figma


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the Figma REST API template with icon and spec. Also switched APIEndpointViewer text/button colors to theme variables and updated the Discord template (correct version, marked verified).

- **New Features**
  - Figma REST template added with spec v0.35.0 and figma.svg icon.
  - Types updated to include "Figma".

- **Bug Fixes**
  - Use theme text color in APIEndpointViewer code blocks and Send button label.
  - Discord template: set version to 10 and mark as verified.

<sup>Written for commit 864aed78a2825d38d572f1890dd473d2935102cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

