### PR TITLE
Chore/zendesk template

### DIFF
--- a/packages/builder/assets/rest-template-icons/zendesk.svg
+++ b/packages/builder/assets/rest-template-icons/zendesk.svg
@@ -1,0 +1,7 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <title>Zendesk</title>
+  <rect x="1" y="1" width="22" height="22" rx="5" fill="#E5E7EB" />
+  <g fill="#03363D" transform="translate(3.6 3.6) scale(0.7)">
+    <path d="M12.914 2.904V16.29L24 2.905H12.914zM0 2.906C0 5.966 2.483 8.45 5.543 8.45s5.542-2.484 5.543-5.544H0zm11.086 4.807L0 21.096h11.086V7.713zm7.37 7.84c-3.063 0-5.542 2.48-5.542 5.543H24c0-3.06-2.48-5.543-5.543-5.543z" />
+  </g>
+</svg>

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/_components/SelectCategoryAPIModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/_components/SelectCategoryAPIModal.svelte
@@ -233,7 +233,7 @@
           </div>
           <div class="group-step-body">
             <Select
-              label={`Select category`}
+              label="Select category"
               options={activeGroupOptions}
               bind:value={activeGroupTemplateName}
               disabled={loading}

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/new.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/new.svelte
@@ -632,7 +632,7 @@
           />
         </div>
         <Heading size="S">{pendingTemplate?.name}</Heading>
-        <Body size="M">
+        <Body size="S">
           Select the action you want to import from {pendingTemplate?.name}:
         </Body>
         {#if templateLoading && templateLoadingPhase === "info"}
@@ -751,10 +751,42 @@
     gap: 16px;
     min-width: 0;
     max-width: 100%;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .endpoint-modal > * {
+    min-width: 0;
+  }
+
+  .endpoint-modal :global(.spectrum-Field) {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .endpoint-modal :global(.spectrum-FieldGroup),
+  .endpoint-modal :global(.spectrum-InputGroup),
+  .endpoint-modal :global(.spectrum-Textfield) {
+    width: 100%;
+    max-width: 100%;
   }
 
   .endpoint-modal :global(.description-viewer) {
     max-width: 100%;
+  }
+
+  .endpoint-modal :global(.description-content),
+  .endpoint-modal :global(.description-content p),
+  .endpoint-modal :global(.description-content a),
+  .endpoint-modal :global(.description-content code),
+  .endpoint-modal :global(.description-content pre) {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .endpoint-modal :global(.description-content pre),
+  .endpoint-modal :global(.description-content code) {
+    white-space: pre-wrap;
   }
 
   .endpoint-heading {

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/new.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/new.svelte
@@ -40,6 +40,11 @@
   import { goto as gotoStore } from "@roxi/routify"
   import type {
     RestTemplate,
+    RestTemplateGroup,
+    RestTemplateGroupName,
+    GroupTemplateName,
+    RestTemplateName,
+    RestTemplateWithoutIcon,
     ImportEndpoint,
     Datasource,
     ImportRestQueryRequest,
@@ -52,7 +57,14 @@
   let externalDatasourceLoading = false
   let templateVersionModal: Modal
   let templateEndpointModal: Modal
+  let templateGroupModal: Modal
   let selectedTemplate: RestTemplate | null = null
+  let selectedTemplateGroup: RestTemplateGroup<RestTemplateGroupName> | null =
+    null
+  let selectedGroupTemplateName: GroupTemplateName | null = null
+  let selectedGroupTemplate: RestTemplateWithoutIcon<GroupTemplateName> | null =
+    null
+  let selectedGroupTemplateDescription = ""
   let templateLoading = false
   let templateLoadingPhase: "info" | "import" | null = null
   let pendingTemplate: RestTemplate | null = null
@@ -76,13 +88,63 @@
     datasource => datasource.source === IntegrationTypes.REST
   )
   $: hasRestDatasources = restDatasources.length > 0
-  $: restTemplatesList = $restTemplates.templates || []
+  $: templateGroupsList = $restTemplates.templateGroups || []
+  $: groupedTemplateNames = new Set<RestTemplateName>(
+    templateGroupsList.flatMap(group =>
+      group.templates.map(template => template.name)
+    )
+  )
+  $: restTemplatesList = ($restTemplates.templates || []).filter(
+    template => !groupedTemplateNames.has(template.name)
+  )
   $: verifiedRestTemplates = restTemplatesList.filter(
     template => template.verified
   )
   $: unverifiedRestTemplates = restTemplatesList.filter(
     template => !template.verified
   )
+  $: verifiedTemplateGroups = templateGroupsList.filter(group => group.verified)
+  $: unverifiedTemplateGroups = templateGroupsList.filter(
+    group => !group.verified
+  )
+  $: verifiedTemplateOptions = [
+    ...verifiedTemplateGroups.map(group => ({
+      type: "group" as const,
+      name: group.name,
+      group,
+    })),
+    ...verifiedRestTemplates.map(template => ({
+      type: "template" as const,
+      name: template.name,
+      template,
+    })),
+  ].sort((a, b) => a.name.localeCompare(b.name))
+  $: unverifiedTemplateOptions = [
+    ...unverifiedTemplateGroups.map(group => ({
+      type: "group" as const,
+      name: group.name,
+      group,
+    })),
+    ...unverifiedRestTemplates.map(template => ({
+      type: "template" as const,
+      name: template.name,
+      template,
+    })),
+  ].sort((a, b) => a.name.localeCompare(b.name))
+  $: selectedGroupTemplate =
+    selectedTemplateGroup && selectedGroupTemplateName
+      ? selectedTemplateGroup.templates.find(
+          template => template.name === selectedGroupTemplateName
+        ) || null
+      : null
+  $: selectedGroupTemplateDescription = selectedGroupTemplate?.description || ""
+  $: groupTemplateOptions = selectedTemplateGroup
+    ? selectedTemplateGroup.templates.map(template => ({
+        label: template.name,
+        value: template.name,
+        description: template.description,
+      }))
+    : []
 
   $: disabled = externalDatasourceLoading
   $: templateDisabled = disabled || templateLoading
@@ -305,6 +367,38 @@
     await handleTemplateSelection(template, spec)
   }
 
+  const selectTemplateGroup = (
+    group: RestTemplateGroup<RestTemplateGroupName>
+  ) => {
+    selectedTemplateGroup = group
+    selectedGroupTemplateName = group.templates[0]?.name || null
+    templateGroupModal?.show()
+  }
+
+  const cancelGroupSelection = () => {
+    selectedTemplateGroup = null
+    selectedGroupTemplateName = null
+  }
+
+  const confirmGroupSelection = () => {
+    if (!selectedTemplateGroup || !selectedGroupTemplateName) {
+      notifications.error("Select a template")
+      return
+    }
+    if (!selectedGroupTemplate) {
+      notifications.error("Selected template could not be found.")
+      return
+    }
+    templateGroupModal?.hide()
+    selectTemplate({
+      name: selectedGroupTemplate.name,
+      description: selectedGroupTemplate.description,
+      specs: selectedGroupTemplate.specs,
+      icon: selectedTemplateGroup.icon,
+      verified: selectedTemplateGroup.verified,
+    })
+  }
+
   const close = () => {
     if (restDatasources.length) {
       goto(`./datasource/${restDatasources[0]._id}`)
@@ -346,7 +440,7 @@
       </DatasourceOption>
     </div>
 
-    {#if verifiedRestTemplates.length}
+    {#if verifiedTemplateOptions.length}
       <div class="templates-header">
         <Body
           size="S"
@@ -355,16 +449,19 @@
         >
       </div>
       <div class="options templateOptions">
-        {#each verifiedRestTemplates as template (template.name)}
+        {#each verifiedTemplateOptions as option (option.name)}
           <RestTemplateOption
-            on:click={() => selectTemplate(template)}
-            {template}
+            on:click={() =>
+              option.type === "group"
+                ? selectTemplateGroup(option.group)
+                : selectTemplate(option.template)}
+            template={option.type === "group" ? option.group : option.template}
             disabled={templateDisabled}
           />
         {/each}
       </div>
     {/if}
-    {#if unverifiedRestTemplates.length}
+    {#if unverifiedTemplateOptions.length}
       <div class="templates-header">
         <Body
           size="S"
@@ -396,10 +493,13 @@
         </div>
       </div>
       <div class="options templateOptions">
-        {#each unverifiedRestTemplates as template (template.name)}
+        {#each unverifiedTemplateOptions as option (option.name)}
           <RestTemplateOption
-            on:click={() => selectTemplate(template)}
-            {template}
+            on:click={() =>
+              option.type === "group"
+                ? selectTemplateGroup(option.group)
+                : selectTemplate(option.template)}
+            template={option.type === "group" ? option.group : option.template}
             disabled={templateDisabled}
           />
         {/each}
@@ -470,6 +570,44 @@
   {/if}
 </Modal>
 
+<Modal bind:this={templateGroupModal} on:hide={cancelGroupSelection}>
+  {#if selectedTemplateGroup}
+    <ModalContent
+      size="M"
+      confirmText="Select"
+      cancelText="Cancel"
+      onConfirm={confirmGroupSelection}
+      onCancel={cancelGroupSelection}
+      disabled={!selectedGroupTemplateName || templateLoading}
+    >
+      <Layout noPadding gap="S">
+        <div class="endpoint-heading">
+          <IntegrationIcon
+            iconUrl={selectedTemplateGroup.icon}
+            integrationType={restIntegration?.name || IntegrationTypes.REST}
+            schema={restIntegration}
+            size="32"
+          />
+        </div>
+        <Heading size="S">{selectedTemplateGroup.name}</Heading>
+        <Body size="M">Select a template to import:</Body>
+        <Select
+          label="Select category"
+          options={groupTemplateOptions}
+          bind:value={selectedGroupTemplateName}
+          disabled={templateLoading}
+        />
+        {#if selectedGroupTemplateDescription}
+          <DescriptionViewer
+            description={selectedGroupTemplateDescription}
+            label={undefined}
+          />
+        {/if}
+      </Layout>
+    </ModalContent>
+  {/if}
+</Modal>
+
 <Modal
   bind:this={templateEndpointModal}
   on:hide={resetEndpointSelection}
@@ -484,47 +622,49 @@
     disabled={!selectedEndpointId || templateLoading}
   >
     <Layout noPadding gap="S">
-      <div class="endpoint-heading">
-        <IntegrationIcon
-          iconUrl={pendingTemplate?.icon}
-          integrationType={restIntegration?.name || IntegrationTypes.REST}
-          schema={restIntegration}
-          size="32"
-        />
+      <div class="endpoint-modal">
+        <div class="endpoint-heading">
+          <IntegrationIcon
+            iconUrl={pendingTemplate?.icon}
+            integrationType={restIntegration?.name || IntegrationTypes.REST}
+            schema={restIntegration}
+            size="32"
+          />
+        </div>
+        <Heading size="S">{pendingTemplate?.name}</Heading>
+        <Body size="M">
+          Select the action you want to import from {pendingTemplate?.name}:
+        </Body>
+        {#if templateLoading && templateLoadingPhase === "info"}
+          <div class="endpoint-loading">
+            <ProgressCircle size="S" />
+            <Body size="XS">Loading actions…</Body>
+          </div>
+        {:else if templateLoading && templateLoadingPhase === "import"}
+          <div class="endpoint-loading">
+            <ProgressCircle size="S" />
+            <Body size="XS">Importing selected action…</Body>
+          </div>
+        {:else if templateEndpoints.length > 0}
+          <Select
+            size="L"
+            value={selectedEndpointId}
+            options={templateEndpoints}
+            getOptionValue={endpoint => endpoint.id}
+            getOptionLabel={formatEndpointLabel}
+            getOptionIcon={getEndpointIcon}
+            autocomplete={true}
+            placeholder="Select an action"
+            on:change={onSelectEndpoint}
+          />
+          <DescriptionViewer
+            description={selectedEndpointDescription}
+            baseUrl={templateDocsBaseUrl}
+          />
+        {:else}
+          <Body size="XS">No actions available for this template.</Body>
+        {/if}
       </div>
-      <Heading size="S">{pendingTemplate?.name}</Heading>
-      <Body size="M">
-        Select the action/endpoint you want to import from {pendingTemplate?.name}:
-      </Body>
-      {#if templateLoading && templateLoadingPhase === "info"}
-        <div class="endpoint-loading">
-          <ProgressCircle size="S" />
-          <Body size="XS">Loading actions…</Body>
-        </div>
-      {:else if templateLoading && templateLoadingPhase === "import"}
-        <div class="endpoint-loading">
-          <ProgressCircle size="S" />
-          <Body size="XS">Importing selected action…</Body>
-        </div>
-      {:else if templateEndpoints.length > 0}
-        <Select
-          size="L"
-          value={selectedEndpointId}
-          options={templateEndpoints}
-          getOptionValue={endpoint => endpoint.id}
-          getOptionLabel={formatEndpointLabel}
-          getOptionIcon={getEndpointIcon}
-          autocomplete={true}
-          placeholder="Select an action"
-          on:change={onSelectEndpoint}
-        />
-        <DescriptionViewer
-          description={selectedEndpointDescription}
-          baseUrl={templateDocsBaseUrl}
-        />
-      {:else}
-        <Body size="XS">No actions available for this template.</Body>
-      {/if}
     </Layout>
   </ModalContent>
 </Modal>
@@ -604,6 +744,17 @@
     display: flex;
     align-items: center;
     gap: 8px;
+  }
+
+  .endpoint-modal {
+    display: grid;
+    gap: 16px;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .endpoint-modal :global(.description-viewer) {
+    max-width: 100%;
   }
 
   .endpoint-heading {

--- a/packages/builder/src/pages/builder/workspace/[application]/data/_components/RestTemplateOption.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/_components/RestTemplateOption.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { Body } from "@budibase/bbui"
-  import type { RestTemplate, RestTemplateGroup, RestTemplateGroupName } from "@budibase/types"
+  import type {
+    RestTemplate,
+    RestTemplateGroup,
+    RestTemplateGroupName,
+  } from "@budibase/types"
 
   export let template: RestTemplate | RestTemplateGroup<RestTemplateGroupName>
   export let disabled = false

--- a/packages/builder/src/pages/builder/workspace/[application]/data/_components/RestTemplateOption.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/_components/RestTemplateOption.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { Body } from "@budibase/bbui"
-  import { type RestTemplate } from "@budibase/types"
+  import type { RestTemplate, RestTemplateGroup, RestTemplateGroupName } from "@budibase/types"
 
-  export let template: RestTemplate
+  export let template: RestTemplate | RestTemplateGroup<RestTemplateGroupName>
   export let disabled = false
 </script>
 

--- a/packages/builder/src/stores/builder/restTemplates.ts
+++ b/packages/builder/src/stores/builder/restTemplates.ts
@@ -82,6 +82,7 @@ import VerifiableLogo from "assets/rest-template-icons/verifiable.svg"
 import VoltIOLogo from "assets/rest-template-icons/volt-io.svg"
 import WorkableLogo from "assets/rest-template-icons/workable.svg"
 import XLogo from "assets/rest-template-icons/x.svg"
+import ZendeskLogo from "assets/rest-template-icons/zendesk.svg"
 import serviceNowSpecData from "assets/rest-template-specs/servicenow.yaml?raw"
 
 interface RestTemplatesState {
@@ -92,6 +93,7 @@ interface RestTemplatesState {
 const twilioRestTemplateGroup: RestTemplateGroup<"Twilio"> = {
   name: "Twilio",
   icon: TwilioLogo,
+  verified: true,
   description:
     "Combines powerful communications APIs with AI and first-party data.",
   templates: [
@@ -485,6 +487,25 @@ const twilioRestTemplateGroup: RestTemplateGroup<"Twilio"> = {
   ],
 }
 
+const zendeskRestTemplateGroup: RestTemplateGroup<"Zendesk"> = {
+  name: "Zendesk",
+  icon: ZendeskLogo,
+  verified: true,
+  description: "Customer support and messaging APIs from Zendesk.",
+  templates: [
+    {
+      name: "Sunshine Conversations",
+      description: "Messaging and conversation APIs for Zendesk Sunshine.",
+      specs: [
+        {
+          version: "17.2.1",
+          url: "https://raw.githubusercontent.com/Budibase/openapi-rest-templates/main/zendesk/sunshine-conversations/openapi.yaml",
+        },
+      ],
+    },
+  ],
+}
+
 const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
   templates: [
     {
@@ -523,6 +544,7 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
         },
       ],
       icon: ConfluenceLogo,
+      verified: true,
     },
     {
       name: "Discord",
@@ -1393,7 +1415,7 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       icon: XLogo,
     },
   ],
-  templateGroups: [twilioRestTemplateGroup],
+  templateGroups: [twilioRestTemplateGroup, zendeskRestTemplateGroup],
 }
 
 export class RestTemplatesStore extends BudiStore<RestTemplatesState> {

--- a/packages/builder/src/stores/builder/restTemplates.ts
+++ b/packages/builder/src/stores/builder/restTemplates.ts
@@ -694,11 +694,12 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
         "Secure payment processing, subscriptions, billing, and reporting APIs",
       specs: [
         {
-          version: "2022-11-15",
-          url: "https://raw.githubusercontent.com/Budibase/openapi-rest-templates/main/stripe/openapi.yaml",
+          version: "2026-01-28.clover",
+          url: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.yaml",
         },
       ],
       icon: StripeLogo,
+      verified: true,
     },
     {
       name: "Ansible AWX",

--- a/packages/types/src/ui/rest.ts
+++ b/packages/types/src/ui/rest.ts
@@ -88,11 +88,13 @@ export type RestTemplateName =
   | "Workable"
   | "X"
   | TwilioRestTemplateName
+  | ZendeskRestTemplateName
 
-export type RestTemplateGroupName = "Twilio"
+export type RestTemplateGroupName = "Twilio" | "Zendesk"
 
 export type RestTemplateGroups = {
   Twilio: TwilioRestTemplateName
+  Zendesk: ZendeskRestTemplateName
 }
 
 export type TwilioRestTemplateName =
@@ -135,6 +137,8 @@ export type TwilioRestTemplateName =
   | "Twilio Voice"
   | "Twilio Wireless"
 
+export type ZendeskRestTemplateName = "Sunshine Conversations"
+
 export interface RestTemplate {
   name: RestTemplateName
   description: string
@@ -155,6 +159,7 @@ export interface RestTemplateGroup<
   name: TemplateGroupName
   description: string
   icon: string
+  verified?: true
   templates: RestTemplateWithoutIcon<RestTemplateGroups[TemplateGroupName]>[]
 }
 

--- a/packages/types/src/ui/rest.ts
+++ b/packages/types/src/ui/rest.ts
@@ -1,9 +1,5 @@
 export interface RestTemplateSpec {
-  version:
-    | `${number}`
-    | `${number}-${number}-${number}`
-    | `${number}.${number}.${number}`
-    | `v${number}`
+  version: string
   url?: string
   data?: string
 }


### PR DESCRIPTION
## Description
Zendesk Template

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Zendesk as a REST template group and updates the New REST API flow to support grouped templates with a selection modal. Also fixes overflow in the endpoint selection modal.

- **New Features**
  - Added Zendesk group (verified) with “Sunshine Conversations” (OpenAPI 17.2.1) and icon.
  - Show template groups alongside templates; selecting a group opens a modal to pick a template, with descriptions and inherited group icon.
  - Grouped templates are hidden from the standalone list; options are sorted by name.
  - Updated types and store for Zendesk group and group verification; RestTemplateOption now accepts groups.
  - Switched Stripe template to the official OpenAPI spec and marked it verified.

- **Bug Fixes**
  - Prevented overflow in the endpoint selection modal with a responsive layout and proper wrapping for long content.

<sup>Written for commit 77eee294a72ef304fcbc553e5c8ff9abdd741e62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

