### PR TITLE
Add missing span in llmobs annotate call

### DIFF
--- a/packages/server/src/automations/steps/ai/agent.ts
+++ b/packages/server/src/automations/steps/ai/agent.ts
@@ -40,11 +40,11 @@ export async function run({
 
   return llmobs.trace(
     { kind: "agent", name: "automation.agent", sessionId },
-    async () => {
+    async agentSpan => {
       try {
         const agentConfig = await sdk.ai.agents.getOrThrow(agentId)
 
-        llmobs.annotate({
+        llmobs.annotate(agentSpan, {
           inputData: prompt,
           metadata: {
             agentId,
@@ -56,7 +56,7 @@ export async function run({
         })
 
         if (appId && isProdWorkspaceID(appId) && agentConfig.live !== true) {
-          llmobs.annotate({
+          llmobs.annotate(agentSpan, {
             outputData: "Agent is paused",
             tags: { error: "agent_paused" },
           })
@@ -73,7 +73,7 @@ export async function run({
         const { modelId, apiKey, baseUrl, modelName } =
           await sdk.aiConfigs.getLiteLLMModelConfigOrThrow(agentConfig.aiconfig)
 
-        llmobs.annotate({
+        llmobs.annotate(agentSpan, {
           metadata: {
             modelId,
             modelName,
@@ -106,7 +106,7 @@ export async function run({
 
         const steps = sdk.ai.agents.attachReasoningToSteps(result.steps)
 
-        llmobs.annotate({
+        llmobs.annotate(agentSpan, {
           outputData: result.text,
           metadata: { stepCount: result.steps?.length ?? 0 },
         })
@@ -119,7 +119,7 @@ export async function run({
       } catch (err: any) {
         const errorMessage = automationUtils.getError(err)
 
-        llmobs.annotate({
+        llmobs.annotate(agentSpan, {
           outputData: errorMessage,
           tags: {
             error: "1",


### PR DESCRIPTION
## Description
LLM calls still weren't showing up in Datadog LLM obs. This adds the span into the annotate call which I think was the missing piece of the puzzle. 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach the active trace span to all llmobs.annotate calls in the agent flow so Datadog LLM observability captures and links events correctly. This makes agent inputs, outputs, and errors show up under the proper trace.

- **Bug Fixes**
  - Use llmobs.trace(async agentSpan => ...) and pass agentSpan to annotate for input, paused notice, model metadata, output, and error.
  - No change to agent logic; telemetry only.

<sup>Written for commit 1c75a2332c1c9cf688f6c4e7c740f763552f7e46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

