### PR TITLE
Fix issue with oauth2 config modal

### DIFF
--- a/packages/builder/src/settings/pages/oauth2/OAuth2ConfigModalContent.svelte
+++ b/packages/builder/src/settings/pages/oauth2/OAuth2ConfigModalContent.svelte
@@ -80,11 +80,12 @@
     const validationResult = validator.safeParse(config)
     errors = {}
     if (!validationResult.success) {
-      errors = Object.entries(
-        validationResult.error.formErrors.fieldErrors
-      ).reduce<Record<string, string>>((acc, [field, errors]) => {
-        if (errors[0]) {
-          acc[field] = errors[0]
+      const flattened = validationResult.error.flatten()
+      errors = Object.entries(flattened.fieldErrors).reduce<
+        Record<string, string>
+      >((acc, [field, fieldErrors]) => {
+        if (fieldErrors?.[0]) {
+          acc[field] = fieldErrors[0]
         }
         return acc
       }, {})


### PR DESCRIPTION
## Description
Needed to call `flatten()` first as formErrors didn't actually exist on the object. 

## Launchcontrol
- Fix issue with form validation in oauth2 config modal. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix form validation in the OAuth2 config modal so field errors render correctly and no runtime error occurs. Use Zod’s error.flatten().fieldErrors to map the first error per field.

<sup>Written for commit 344c4efae06dc5a1cc4d019dc169f0d925296de6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

