### PR TITLE
Feat/suggested questions

### DIFF
--- a/packages/server/src/sdk/workspace/ai/chatApps.ts
+++ b/packages/server/src/sdk/workspace/ai/chatApps.ts
@@ -4,6 +4,7 @@ import { ChatApp, DocumentType } from "@budibase/types"
 const withDefaults = (chatApp: ChatApp): ChatApp => ({
   ...chatApp,
   live: chatApp.live ?? false,
+  suggestedQuestions: chatApp.suggestedQuestions ?? [],
 })
 
 export async function getSingle(): Promise<ChatApp | undefined> {

--- a/packages/server/src/sdk/workspace/ai/chatApps.ts
+++ b/packages/server/src/sdk/workspace/ai/chatApps.ts
@@ -4,7 +4,7 @@ import { ChatApp, DocumentType } from "@budibase/types"
 const withDefaults = (chatApp: ChatApp): ChatApp => ({
   ...chatApp,
   live: chatApp.live ?? false,
-  suggestedQuestions: chatApp.suggestedQuestions ?? [],
+  conversationStarters: chatApp.conversationStarters ?? [],
 })
 
 export async function getSingle(): Promise<ChatApp | undefined> {

--- a/packages/server/src/tests/api/chatApps.spec.ts
+++ b/packages/server/src/tests/api/chatApps.spec.ts
@@ -1,0 +1,79 @@
+import { context, docIds } from "@budibase/backend-core"
+import type { ChatApp } from "@budibase/types"
+import TestConfiguration from "../utilities/TestConfiguration"
+
+describe("chat apps suggested questions", () => {
+  const config = new TestConfiguration()
+  let chatApp: ChatApp
+
+  beforeAll(async () => {
+    await config.init("chat-apps-suggested-questions")
+    await context.doInWorkspaceContext(
+      config.getProdWorkspaceId(),
+      async () => {
+        const db = context.getWorkspaceDB()
+        const now = new Date().toISOString()
+        const baseChatApp: ChatApp = {
+          _id: docIds.generateChatAppID(),
+          agentId: "agent-1",
+          createdAt: now,
+          updatedAt: now,
+        }
+        const { rev } = await db.put(baseChatApp)
+        chatApp = { ...baseChatApp, _rev: rev }
+      }
+    )
+  })
+
+  afterAll(() => {
+    config.end()
+  })
+
+  it("returns default suggested questions when missing", async () => {
+    const headers = await config.defaultHeaders({}, true)
+
+    const res = await config.getRequest()!.get("/api/chatapps").set(headers)
+
+    expect(res.status).toBe(200)
+    expect(res.body.suggestedQuestions).toEqual([])
+  })
+
+  it("persists updated suggested questions", async () => {
+    const headers = await config.defaultHeaders({}, true)
+    const suggestedQuestions = [
+      {
+        id: "q1",
+        text: "What can you help with?",
+        enabled: true,
+        order: 1,
+      },
+      {
+        id: "q2",
+        text: "Show me recent activity",
+        enabled: false,
+        order: 2,
+      },
+    ]
+
+    const res = await config
+      .getRequest()!
+      .put(`/api/chatapps/${chatApp._id}`)
+      .set(headers)
+      .send({
+        ...chatApp,
+        suggestedQuestions,
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body.suggestedQuestions).toEqual(suggestedQuestions)
+
+    await context.doInWorkspaceContext(
+      config.getProdWorkspaceId(),
+      async () => {
+        const db = context.getWorkspaceDB()
+        const stored = await db.get<ChatApp>(chatApp._id!)
+        expect(stored.suggestedQuestions).toEqual(suggestedQuestions)
+      }
+    )
+  })
+})

--- a/packages/server/src/tests/api/chatApps.spec.ts
+++ b/packages/server/src/tests/api/chatApps.spec.ts
@@ -2,12 +2,12 @@ import { context, docIds } from "@budibase/backend-core"
 import type { ChatApp } from "@budibase/types"
 import TestConfiguration from "../utilities/TestConfiguration"
 
-describe("chat apps suggested questions", () => {
+describe("chat apps conversation starters", () => {
   const config = new TestConfiguration()
   let chatApp: ChatApp
 
   beforeAll(async () => {
-    await config.init("chat-apps-suggested-questions")
+    await config.init("chat-apps-conversation-starters")
     await context.doInWorkspaceContext(
       config.getProdWorkspaceId(),
       async () => {
@@ -29,18 +29,18 @@ describe("chat apps suggested questions", () => {
     config.end()
   })
 
-  it("returns default suggested questions when missing", async () => {
+  it("returns default conversation starters when missing", async () => {
     const headers = await config.defaultHeaders({}, true)
 
     const res = await config.getRequest()!.get("/api/chatapps").set(headers)
 
     expect(res.status).toBe(200)
-    expect(res.body.suggestedQuestions).toEqual([])
+    expect(res.body.conversationStarters).toEqual([])
   })
 
-  it("persists updated suggested questions", async () => {
+  it("persists updated conversation starters", async () => {
     const headers = await config.defaultHeaders({}, true)
-    const suggestedQuestions = [
+    const conversationStarters = [
       {
         id: "q1",
         text: "What can you help with?",
@@ -61,18 +61,18 @@ describe("chat apps suggested questions", () => {
       .set(headers)
       .send({
         ...chatApp,
-        suggestedQuestions,
+        conversationStarters,
       })
 
     expect(res.status).toBe(200)
-    expect(res.body.suggestedQuestions).toEqual(suggestedQuestions)
+    expect(res.body.conversationStarters).toEqual(conversationStarters)
 
     await context.doInWorkspaceContext(
       config.getProdWorkspaceId(),
       async () => {
         const db = context.getWorkspaceDB()
         const stored = await db.get<ChatApp>(chatApp._id!)
-        expect(stored.suggestedQuestions).toEqual(suggestedQuestions)
+        expect(stored.conversationStarters).toEqual(conversationStarters)
       }
     )
   })

--- a/packages/types/src/documents/global/chat.ts
+++ b/packages/types/src/documents/global/chat.ts
@@ -1,7 +1,7 @@
 import { Document } from "../../"
 import type { UIMessage } from "ai"
 
-export interface ChatSuggestedQuestion {
+export interface ChatConversationStarter {
   id: string
   text: string
   enabled?: boolean
@@ -16,7 +16,7 @@ export interface ChatApp extends Document {
   agentId: string
   live?: boolean
   settings?: Record<string, any>
-  suggestedQuestions?: ChatSuggestedQuestion[]
+  conversationStarters?: ChatConversationStarter[]
 }
 
 export interface ChatConversationRequest extends Document {

--- a/packages/types/src/documents/global/chat.ts
+++ b/packages/types/src/documents/global/chat.ts
@@ -1,6 +1,13 @@
 import { Document } from "../../"
 import type { UIMessage } from "ai"
 
+export interface ChatSuggestedQuestion {
+  id: string
+  text: string
+  enabled?: boolean
+  order?: number
+}
+
 export interface ChatApp extends Document {
   title?: string
   greeting?: string
@@ -9,6 +16,7 @@ export interface ChatApp extends Document {
   agentId: string
   live?: boolean
   settings?: Record<string, any>
+  suggestedQuestions?: ChatSuggestedQuestion[]
 }
 
 export interface ChatConversationRequest extends Document {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add conversation starters (suggested questions) to Chat Apps to display preset prompts. Defaults to an empty list and persists via the Chat Apps API.

- **New Features**
  - Added ChatConversationStarter type and conversationStarters field to ChatApp.
  - Applied default [] when conversation starters are missing.
  - API accepts and stores conversationStarters via PUT /api/chatapps/:id; tests cover defaults and persistence.

<sup>Written for commit beb6da06bb56758b9f94688fc41c392ec8ac1459. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

