### PR TITLE
Add LiteLLM configuration to automation worker deployment

### DIFF
--- a/charts/budibase/templates/automation-worker-service-deployment.yaml
+++ b/charts/budibase/templates/automation-worker-service-deployment.yaml
@@ -147,6 +147,12 @@ spec:
           value: {{ .Values.globals.posthogToken | quote }}
         - name: WORKER_URL
           value: http://worker-service:{{ .Values.services.worker.port }}
+        - name: LITELLM_URL
+          value: {{ .Values.globals.litellmUrl | quote }}
+        {{- if .Values.services.litellm.masterKey }}
+        - name: LITELLM_MASTER_KEY
+          value: {{ .Values.services.litellm.masterKey | quote }}
+        {{- end }}
         - name: PLATFORM_URL
           value: {{ .Values.globals.platformUrl | quote }}
         - name: ACCOUNT_PORTAL_URL


### PR DESCRIPTION
## Description
Adds `LITELLM_* config variables to the deployment of the automation worker.

## Launchcontrol

Automation worker supports `LITELLM_` config


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds LITELLM_URL and optional LITELLM_MASTER_KEY to the automation worker deployment to enable LiteLLM integration. Behavior is unchanged unless these values are set.

- **New Features**
  - LITELLM_URL from .Values.globals.litellmUrl
  - LITELLM_MASTER_KEY when .Values.services.litellm.masterKey is provided

- **Migration**
  - Set globals.litellmUrl (and optionally services.litellm.masterKey) in values.yaml
  - Deploy to roll out the env vars

<sup>Written for commit 68d7ec8f7f4d4f6d66dff73220492cf37bb4b07e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

