### PR TITLE
Button Group improvements and fixes

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonConditionEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonConditionEditor.svelte
@@ -77,6 +77,16 @@
     },
   ]
 
+  const valueTypeToFieldTypeMap: Record<
+    ComponentCondition["valueType"],
+    FieldType
+  > = {
+    string: FieldType.STRING,
+    number: FieldType.NUMBER,
+    datetime: FieldType.DATETIME,
+    boolean: FieldType.BOOLEAN,
+  }
+
   let dragDisabled = true
 
   let settings: ExtendedComponentSetting[] = []
@@ -182,14 +192,8 @@
   ) => {
     condition.referenceValue = null
     condition.valueType = newValueType
-    condition.type =
-      newValueType === "string"
-        ? FieldType.STRING
-        : newValueType === "number"
-          ? FieldType.NUMBER
-          : newValueType === "datetime"
-            ? FieldType.DATETIME
-            : FieldType.BOOLEAN
+
+    condition.type = valueTypeToFieldTypeMap[newValueType]
 
     // Ensure a valid operator is set
     const validOperators = QueryUtils.getValidOperatorsForType({

--- a/packages/builder/src/components/design/settings/controls/ButtonConditionEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonConditionEditor.svelte
@@ -224,7 +224,22 @@
   }
 
   const openDrawer = () => {
-    conditions = cloneDeep(value || [])
+    conditions = cloneDeep(value || []).map((condition: ComponentCondition) => {
+      // Migrate old conditions that only have 'type' to also have 'valueType'
+      if (condition.valueType === undefined && condition.type) {
+        const typeToValueTypeMap: Record<
+          string,
+          ComponentCondition["valueType"]
+        > = {
+          string: "string",
+          number: "number",
+          boolean: "boolean",
+          datetime: "datetime",
+        }
+        condition.valueType = typeToValueTypeMap[condition.type] || "string"
+      }
+      return condition
+    })
     drawer.show()
   }
   const save = async () => {

--- a/packages/builder/src/components/design/settings/controls/ButtonConditionEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonConditionEditor.svelte
@@ -94,15 +94,13 @@
   $: count = value?.length
   $: conditionText = `${count || "No"} condition${count !== 1 ? "s" : ""} set`
 
-  $: settings = (
-    (componentStore.getComponentSettings(componentInstance?._component) as
-      | ExtendedComponentSetting[]
-      | undefined) ?? []
-  ).concat({
-    label: "Custom CSS",
-    key: "_css",
-    type: "text",
-  })
+  $: settings = componentStore
+    .getComponentSettings(componentInstance?._component)
+    .concat({
+      label: "Custom CSS",
+      key: "_css",
+      type: "text",
+    })
   $: settingOptions = settings
     .filter(
       setting =>
@@ -125,9 +123,7 @@
   const getSettingDefinition = (
     key: string | undefined
   ): ExtendedComponentSetting | undefined => {
-    return settings?.find(setting => setting.key === key) as
-      | ExtendedComponentSetting
-      | undefined
+    return settings.find(setting => setting.key === key)
   }
 
   const addCondition = () => {

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -762,7 +762,7 @@
         "key": "conditions",
         "nestedOnly": true,
         "contextAccess": {
-          "global": false,
+          "global": true,
           "self": true
         }
       }

--- a/packages/client/src/components/app/ButtonGroup.svelte
+++ b/packages/client/src/components/app/ButtonGroup.svelte
@@ -50,18 +50,19 @@
         buttons={collapsedButtons}
       />
     {:else}
-      {#each buttons as { text, type, quiet, disabled, onClick, size, icon, gap }}
+      {#each buttons as button}
         <BlockComponent
           type="button"
           props={{
-            text: text || "Button",
-            onClick,
-            type,
-            quiet,
-            disabled,
-            icon,
-            gap,
-            size: size || "M",
+            text: button?.text || "Button",
+            onClick: button?.onClick,
+            type: button?.type,
+            quiet: button?.quiet,
+            disabled: button?.disabled,
+            icon: button?.icon,
+            gap: button?.gap,
+            size: button?.size || "M",
+            _conditions: button?._conditions || button?.conditions,
           }}
         />
       {/each}

--- a/packages/client/src/components/app/blocks/form/InnerFormBlock.svelte
+++ b/packages/client/src/components/app/blocks/form/InnerFormBlock.svelte
@@ -95,30 +95,37 @@
       {#if description}
         <BlockComponent type="textv2" props={{ text: description }} order={1} />
       {/if}
-      <BlockComponent type="container">
+      <BlockComponent
+        type="container"
+        props={{
+          direction: "column",
+          hAlign: "stretch",
+          vAlign: "top",
+        }}
+      >
         <div class="form-block fields" class:mobile={$context.device.mobile}>
           {#each fields as field, idx}
             <FormBlockComponent {field} {schema} order={idx} />
           {/each}
         </div>
+        {#if buttonPosition === "bottom"}
+          <BlockComponent
+            type="buttongroup"
+            props={{
+              buttons,
+              collapsed: buttonsCollapsed,
+              collapsedText: buttonsCollapsedText,
+            }}
+            styles={{
+              normal: {
+                "margin-top": "20px",
+              },
+            }}
+            order={fields.length + 1}
+          />
+        {/if}
       </BlockComponent>
     </BlockComponent>
-    {#if buttonPosition === "bottom"}
-      <BlockComponent
-        type="buttongroup"
-        props={{
-          buttons,
-          collapsed: buttonsCollapsed,
-          collapsedText: buttonsCollapsedText,
-        }}
-        styles={{
-          normal: {
-            "margin-top": "24",
-          },
-        }}
-        order={1}
-      />
-    {/if}
   </BlockComponent>
 {:else}
   <Placeholder


### PR DESCRIPTION
## Description
A number of similar fixes and improvements to the Button Group component (and the Form Block/auto generated form screen which uses it very often)

## Addresses
set of issues grouped in #17326

- **#17731**
This was due to the Button Group in a standard form block being left outside of the main fields container when the form block was ejected.
before:
<img width="1512" height="949" alt="SCR-20260112-jqdz" src="https://github.com/user-attachments/assets/61b1531d-cd3f-44b8-802e-ed4a930798dc" />

after:
<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/fd3044f2-fff7-4a03-8b4b-0539edaffeb2" />

---

- #17294
now it's possible to conditionally change the settings of any individual button in the button group in the button group's own conditions. this is a bit ugly like how it is for form group conditions, but is acceptable as usually there aren't too many buttons in a group. it's particularly useful if you want to change all button settings via one condition.
<img width="1057" height="321" alt="image" src="https://github.com/user-attachments/assets/11f86ecf-1118-407f-a3f8-7981f1e7b8eb" />

---

- #17295 and #17296
these are grouped together. the bindings in conditions for individual buttons in a group were broken.
<img width="613" height="314" alt="image" src="https://github.com/user-attachments/assets/c8ce5231-afbd-4d60-b424-8e9a314421f2" />

before:
<img width="898" height="386" alt="image" src="https://github.com/user-attachments/assets/74bb3b52-50d5-49a2-b8ad-166523783731" />


after:
<img width="1065" height="473" alt="image" src="https://github.com/user-attachments/assets/670d80f3-8aa4-44ea-b997-e8d71b8ee111" />


## Launchcontrol
fixes and improvements for the button group component

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the Button Group with per-button conditional setting updates and fixes its placement inside Form Block so ejected forms keep the correct layout. Restores bindings and global context access for button conditions and addresses items in #17326.

- **New Features**
  - Update any individual button’s settings via Button Group conditions (#17294).

- **Bug Fixes**
  - Button Group now renders inside the form fields container; ejected forms keep correct layout (#17731).
  - Fixed per-button condition bindings and enabled global context access; conditions pass through to button components (#17295, #17296).
  - Migrated legacy button conditions to include valueType to avoid breakage.

<sup>Written for commit 819a15f92cce89f7fee31f3909ca179545b0ace3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

