### PR TITLE
Use Clever API v3.0.0 OpenAPI spec

### DIFF
--- a/packages/builder/src/stores/builder/restTemplates.ts
+++ b/packages/builder/src/stores/builder/restTemplates.ts
@@ -1885,11 +1885,12 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
         "Offers one secure place for teachers and students to access the applications they love and depend on.",
       specs: [
         {
-          version: "3.1.0",
-          url: "https://raw.githubusercontent.com/Budibase/openapi-rest-templates/main/clever/openapi.yaml",
+          version: "3.0.0",
+          url: "https://dev.clever.com/openapi/6054fe66dc8ea400120e9f7a",
         },
       ],
       icon: CleverLogo,
+      verified: true,
     },
     {
       name: "Clickup",


### PR DESCRIPTION
## Description
- Update the Clever REST template to point at the official Clever OpenAPI v3.0.0 spec.

## Launchcontrol
Uses Clever's official v3.0.0 OpenAPI spec for the REST template.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the Clever REST template to the official OpenAPI v3.0.0 spec for more accurate endpoints. Improved the API connectors catalog and endpoint naming, and added a verified HubSpot template group.

- **New Features**
  - Added a verified HubSpot template group with icons and many APIs.
  - Marked Clever as verified and pointed it to the official v3.0.0 spec.
  - API catalog: larger dialog, 4-column grid, verified badge on cards.

- **Refactors**
  - Clearer endpoint names when importing OpenAPI 2/3: use operationId/summary/description, humanize paths, and handle batch actions.
  - Simplified endpoint labels to use the name only.
  - Fixed infinite scroll re-init and cleared search when leaving group selection.

<sup>Written for commit 6a8fdabcfd28394c15de826fe7a9a2c0aedaf042. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

