### PR TITLE
Fix issue where users couldn't upload non component plugins

### DIFF
--- a/packages/builder/src/components/common/PublishMenu.svelte
+++ b/packages/builder/src/components/common/PublishMenu.svelte
@@ -13,7 +13,7 @@
     workspaceAppStore,
     appStore,
   } from "@/stores/builder"
-  import { type Plugin } from "@budibase/types"
+  import { PluginType, type Plugin } from "@budibase/types"
   import type { PopoverAPI } from "@budibase/bbui"
 
   let actionMenu: any
@@ -35,9 +35,8 @@
 
   $: incompatiblePlugins = ($appStore.usedPlugins || []).filter(plugin => {
     const major = getPluginSvelteMajor(plugin)
-    // `schema.metadata.svelteMajor` only exists on Svelte 5 plugins - treat
-    // absence as legacy (Svelte 4).
-    return major !== CURRENT_SVELTE_MAJOR
+    const isComponentPlugin = plugin.schema.type === PluginType.COMPONENT
+    return major !== CURRENT_SVELTE_MAJOR && isComponentPlugin
   })
 
   const hasAcknowledgedSvelte4PluginWarning = (appId?: string) => {

--- a/packages/server/src/api/controllers/plugin/index.ts
+++ b/packages/server/src/api/controllers/plugin/index.ts
@@ -103,8 +103,10 @@ export async function create(
       )
     }
 
-    // Only allow Svelte 5 plugins on this branch
-    if (metadata.schema?.metadata?.svelteMajor !== 5) {
+    if (
+      metadata.schema?.metadata?.svelteMajor !== 5 &&
+      metadata.schema?.type === PluginType.COMPONENT
+    ) {
       throw new Error("Only Svelte 5 plugins are supported on this branch")
     }
 

--- a/packages/server/src/sdk/plugins/index.ts
+++ b/packages/server/src/sdk/plugins/index.ts
@@ -133,7 +133,10 @@ export async function processUploaded(plugin: KoaFile, source: PluginSource) {
   }
 
   // Only allow Svelte 5 plugins on this branch
-  if (metadata.schema?.metadata?.svelteMajor !== 5) {
+  if (
+    metadata.schema?.metadata?.svelteMajor !== 5 &&
+    metadata.schema?.type === PluginType.COMPONENT
+  ) {
     throw new Error("Only Svelte 5 plugins are supported on this branch")
   }
 


### PR DESCRIPTION
## Description
Fixes an issue where users couldn't upload datasource plugins because of specific checks for component plugins (to ensure they are svelte 5 compatible)

## Launchcontrol
- Fix an issue with uploading datasource plugins

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows uploading non-component plugins (e.g., datasource plugins) by applying the Svelte 5 requirement only to component plugins. Fixes the upload error and removes false incompatibility warnings in the builder.

- **Bug Fixes**
  - Server: restrict Svelte 5 check to component plugins in upload controller and SDK, so datasource plugins are accepted.
  - Builder: only flag incompatible component plugins in PublishMenu; non-component plugins are not blocked.

<sup>Written for commit 840a1f75ec4df16880b0ad75a863b48c3ecdc247. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

