### PR TITLE
Fix edge case where old plugins might not have a type in the schema

### DIFF
--- a/packages/builder/src/components/common/PublishMenu.svelte
+++ b/packages/builder/src/components/common/PublishMenu.svelte
@@ -35,7 +35,7 @@
 
   $: incompatiblePlugins = ($appStore.usedPlugins || []).filter(plugin => {
     const major = getPluginSvelteMajor(plugin)
-    const isComponentPlugin = plugin.schema.type === PluginType.COMPONENT
+    const isComponentPlugin = plugin?.schema?.type === PluginType.COMPONENT
     return major !== CURRENT_SVELTE_MAJOR && isComponentPlugin
   })
 


### PR DESCRIPTION
## Description
Forgot a specific edge case where old plugins are missing a type property. 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix a crash in PublishMenu when old plugins don't have schema.type. We now safely check the type so incompatible component plugins are filtered without errors.

<sup>Written for commit bc99b7393ce7fb606122aced981058690ffe26fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

