### PR TITLE
Don't enrich user groups with all users as part of the processUser function

### DIFF
--- a/packages/server/src/utilities/global.ts
+++ b/packages/server/src/utilities/global.ts
@@ -39,7 +39,7 @@ export async function processUser(
   if (workspaceId && user?.userGroups?.length) {
     groupList = opts.groups
       ? opts.groups
-      : await groups.getBulk(user.userGroups)
+      : await groups.getBulk(user.userGroups, { enriched: false })
   }
   // check if a group provides builder access
   const builderAppIds = await groups.getGroupBuilderAppIds(user, {

--- a/packages/types/src/documents/global/userGroup.ts
+++ b/packages/types/src/documents/global/userGroup.ts
@@ -18,6 +18,10 @@ export interface UserGroup extends Document {
   }
 }
 
+export interface EnrichedUserGroup extends UserGroup {
+  users: GroupUser[]
+}
+
 export interface GroupUser {
   _id: string
   email: string


### PR DESCRIPTION
## Description
We were enriching every group with all it's users when calling processUser as part of requests. This was unnecessary and causing severe performance slowdowns.

Pro PR - https://github.com/Budibase/budibase-pro/pull/502
## Launchcontrol
- Fix performance issue with user groups