### PR TITLE
Refactor svelte globals and add missing internals

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -35,6 +35,9 @@ import { APIClient } from "@budibase/frontend-core"
 import BlockComponent from "./components/BlockComponent.svelte"
 import Block from "./components/Block.svelte"
 
+// Expose Svelte modules globally for plugin compatibility
+import "@/svelteGlobals"
+
 // Set up global PWA install prompt handler
 if (typeof window !== "undefined") {
   window.addEventListener("beforeinstallprompt", e => {
@@ -42,36 +45,6 @@ if (typeof window !== "undefined") {
     window.deferredPwaPrompt = e
   })
 }
-
-import * as svelte from "svelte"
-import * as svelteStore from "svelte/store"
-// Legacy Svelte 4 runtime for plugin compatibility
-import * as svelteLegacy from "svelte-legacy"
-// @ts-ignore
-import * as svelteLegacyStore from "svelte-legacy/store"
-// @ts-ignore
-import * as svelteInternal from "svelte/internal/client"
-// @ts-ignore
-import * as svelteLegacyInternal from "svelte-legacy/internal"
-
-window.svelte = svelte
-// Expose legacy runtime under dedicated globals so Svelte 5 consumers stay untouched
-// @ts-ignore - augmenting the window at runtime
-window.svelteLegacy = svelteLegacy
-// @ts-ignore - augmenting the window at runtime
-window.svelteLegacyStore = svelteLegacyStore
-// @ts-ignore - augmenting the window at runtime
-window.svelteLegacyInternal = svelteLegacyInternal
-// Provide the legacy global names that Svelte 4 bundles hardcode
-// @ts-ignore - augmenting the window at runtime
-window.svelte_internal = svelteLegacyInternal
-// @ts-ignore - augmenting the window at runtime
-window.svelte_store = svelteLegacyStore
-// Maintain existing camelCase aliases expected by some plugins
-// @ts-ignore - augmenting the window at runtime
-window.svelteStore = svelteStore
-// @ts-ignore - augmenting the window at runtime
-window.svelteInternal = svelteInternal
 
 // Extend global window scope
 declare global {
@@ -104,9 +77,6 @@ declare global {
     handleBuilderRuntimeEvent: (type: string, data: any) => void
     registerCustomComponent: typeof componentStore.actions.registerCustomComponent
     loadBudibase: typeof loadBudibase
-    svelte: typeof svelte
-    svelteStore: typeof svelteStore
-    svelteInternal: typeof svelteInternal
     INIT_TIME: number
   }
 }

--- a/packages/client/src/svelteGlobals.ts
+++ b/packages/client/src/svelteGlobals.ts
@@ -1,0 +1,88 @@
+/**
+ * Exposes Svelte modules globally for plugin compatibility.
+ *
+ * Plugins are built with Svelte externalized, expecting these modules
+ * to be available on the window object at runtime.
+ */
+
+// Svelte 5 modules
+import * as svelte from "svelte"
+import * as svelteStore from "svelte/store"
+// @ts-ignore - no types for internal
+import * as svelteInternal from "svelte/internal/client"
+import * as svelteTransition from "svelte/transition"
+import * as svelteAnimate from "svelte/animate"
+import * as svelteMotion from "svelte/motion"
+import * as svelteEasing from "svelte/easing"
+
+// Svelte 4 (legacy) modules for backward compatibility
+import * as svelteLegacy from "svelte-legacy"
+// @ts-ignore - no types for legacy modules
+import * as svelteLegacyStore from "svelte-legacy/store"
+// @ts-ignore
+import * as svelteLegacyInternal from "svelte-legacy/internal"
+// @ts-ignore
+import * as svelteLegacyTransition from "svelte-legacy/transition"
+// @ts-ignore
+import * as svelteLegacyAnimate from "svelte-legacy/animate"
+// @ts-ignore
+import * as svelteLegacyMotion from "svelte-legacy/motion"
+// @ts-ignore
+import * as svelteLegacyEasing from "svelte-legacy/easing"
+
+// Extend Window interface for all Svelte globals
+declare global {
+  interface Window {
+    // Svelte 5 globals (camelCase)
+    svelte: typeof svelte
+    svelteStore: typeof svelteStore
+    svelteInternal: typeof svelteInternal
+    svelteTransition: typeof svelteTransition
+    svelteAnimate: typeof svelteAnimate
+    svelteMotion: typeof svelteMotion
+    svelteEasing: typeof svelteEasing
+
+    // Svelte 4 legacy globals (camelCase)
+    svelteLegacy: typeof svelteLegacy
+    svelteLegacyStore: typeof svelteLegacyStore
+    svelteLegacyInternal: typeof svelteLegacyInternal
+    svelteLegacyTransition: typeof svelteLegacyTransition
+    svelteLegacyAnimate: typeof svelteLegacyAnimate
+    svelteLegacyMotion: typeof svelteLegacyMotion
+    svelteLegacyEasing: typeof svelteLegacyEasing
+
+    // Svelte 4 legacy globals (snake_case - hardcoded by Svelte 4 bundles)
+    svelte_internal: typeof svelteLegacyInternal
+    svelte_store: typeof svelteLegacyStore
+    svelte_transition: typeof svelteLegacyTransition
+    svelte_animate: typeof svelteLegacyAnimate
+    svelte_motion: typeof svelteLegacyMotion
+    svelte_easing: typeof svelteLegacyEasing
+  }
+}
+
+// Svelte 5 globals
+window.svelte = svelte
+window.svelteStore = svelteStore
+window.svelteInternal = svelteInternal
+window.svelteTransition = svelteTransition
+window.svelteAnimate = svelteAnimate
+window.svelteMotion = svelteMotion
+window.svelteEasing = svelteEasing
+
+// Svelte 4 legacy globals (camelCase)
+window.svelteLegacy = svelteLegacy
+window.svelteLegacyStore = svelteLegacyStore
+window.svelteLegacyInternal = svelteLegacyInternal
+window.svelteLegacyTransition = svelteLegacyTransition
+window.svelteLegacyAnimate = svelteLegacyAnimate
+window.svelteLegacyMotion = svelteLegacyMotion
+window.svelteLegacyEasing = svelteLegacyEasing
+
+// Svelte 4 legacy globals (snake_case - for bundles that hardcode these names)
+window.svelte_internal = svelteLegacyInternal
+window.svelte_store = svelteLegacyStore
+window.svelte_transition = svelteLegacyTransition
+window.svelte_animate = svelteLegacyAnimate
+window.svelte_motion = svelteLegacyMotion
+window.svelte_easing = svelteLegacyEasing


### PR DESCRIPTION
## Description
We were missing some svelte internals from the client initialisation (for use in plugins). So added these and refactored out into it's own file. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized and expanded Svelte globals to restore plugin compatibility, exposing missing internals and runtime modules for Svelte 5 and Svelte 4. Moved globals out of client init into a dedicated svelteGlobals file and auto-loaded from index.ts.

- **Bug Fixes**
  - Expose Svelte 5 internals and modules (store, transition, animate, motion, easing) globally.
  - Expose Svelte 4 legacy runtime and modules (store, transition, animate, motion, easing), plus snake_case globals expected by older bundles.
  - Ensures plugins with externalized Svelte work across versions.

- **Refactors**
  - Extracted global Svelte exposure into packages/client/src/svelteGlobals.ts and imported in index.ts.
  - Removed window typings and assignments from index.ts.

<sup>Written for commit 9fc88b4e307b3e108adc1ef08ac42db397fe252e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

