### PR TITLE
Add access control to REST template queries

### DIFF
--- a/packages/builder/src/components/integration/APIEndpointViewer.svelte
+++ b/packages/builder/src/components/integration/APIEndpointViewer.svelte
@@ -61,6 +61,7 @@
   import { readableToRuntimeMap, runtimeToReadableMap } from "@/dataBinding"
   import ResponsePanel from "./ResponsePanel.svelte"
   import AuthPicker from "./rest/AuthPicker.svelte"
+  import AccessLevelSelect from "@/components/integration/AccessLevelSelect.svelte"
 
   export let queryId
   export let datasourceId
@@ -721,6 +722,11 @@
     </div>
     <div class="actions">
       <div class="grouped">
+        {#if query}
+          <div class="access">
+            <AccessLevelSelect {query} label="Access" />
+          </div>
+        {/if}
         {#if query && selectedEndpointOption}
           <AuthPicker
             bind:authConfigId={query.fields.authConfigId}
@@ -1105,6 +1111,7 @@
   }
   .actions .grouped {
     display: flex;
+    gap: var(--spacing-m);
   }
   .send :global(.spectrum-Button-label) {
     color: var(--spectrum-alias-text-color);
@@ -1186,6 +1193,11 @@
     display: flex;
     flex-direction: row;
     gap: var(--spacing-s);
+  }
+  .access {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-m);
   }
   .embed :global(.cm-editor) {
     min-height: 200px;


### PR DESCRIPTION
## Description
Adds an access level selector to REST template query endpoints so template actions can be permissioned like Custom REST API queries. Fixes #17760.

## Addresses
- https://github.com/Budibase/budibase/issues/17760

## Screenshots
<img width="2044" height="375" alt="app user" src="https://github.com/user-attachments/assets/1f4c6a02-e718-4f3d-8d62-eb458b65cc34" />

<img width="1599" height="616" alt="public" src="https://github.com/user-attachments/assets/b16566ee-8525-4588-8d55-55a6b485ab98" />

<img width="1599" height="616" alt="spp user" src="https://github.com/user-attachments/assets/6ac8d8aa-5cbd-4622-8378-4ab43eb8c348" />


## Launchcontrol
Expose access level selection for REST template query endpoints so admins can control who can run them.