### PR TITLE
refactor: postgres installation surfaces errors properly

### DIFF
--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -55,12 +55,22 @@ RUN mkdir -p /litellm
 COPY hosting/litellm_config.yaml /litellm/config.yaml
 
 # Install postgres client for pg_dump utils
-RUN apt install -y software-properties-common apt-transport-https ca-certificates gnupg \
-    && curl -fsSl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /usr/share/keyrings/postgresql.gpg > /dev/null \
-    && echo deb [arch=amd64,arm64,ppc64el signed-by=/usr/share/keyrings/postgresql.gpg] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main | tee /etc/apt/sources.list.d/postgresql.list \
-    && apt update -y \
-    && apt install postgresql-client-15 -y \
-    && apt remove software-properties-common apt-transport-https gpg -y
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+        lsb-release; \
+    curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+      | gpg --dearmor -o /usr/share/keyrings/postgresql.gpg; \
+    echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+      > /etc/apt/sources.list.d/postgresql.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends postgresql-client-15; \
+    rm -rf /var/lib/apt/lists/*; \
+    apt-get purge -y --auto-remove curl gnupg lsb-release; \
+    rm -f /etc/apt/sources.list.d/postgresql.list
 
 # We use pm2 in order to run multiple node processes in a single container
 RUN npm install --global pm2


### PR DESCRIPTION
## Description

When the pipe that installs Postgres 15 in the single image fails, no explicit error is surfaced. We should be exiting properly and with a higher level of verbosity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor Postgres client installation in the single-image Dockerfile to fail fast and surface errors. Ensures reliable pg_dump tools and reduces image size through cleanup.

- **Refactors**
  - Use set -eux and apt-get to exit on errors and show command output.
  - Add PostgreSQL GPG key and signed APT source via lsb-release.
  - Install postgresql-client-15 with --no-install-recommends; purge curl/gnupg/lsb-release after.
  - Clean apt lists and remove the source file to shrink the image.

<sup>Written for commit 223c6cd5c378756a0440a09c90e4f6c2f17efe7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

