### PR TITLE
Move some tests into release CI

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -156,16 +156,6 @@ jobs:
       matrix:
         datasource:
           [
-            mssql,
-            mysql,
-            postgres,
-            postgres_legacy,
-            mongodb,
-            mariadb,
-            oracle,
-            sqs,
-            elasticsearch,
-            dynamodb,
             none,
           ]
     steps:
@@ -190,25 +180,6 @@ jobs:
 
       - name: Pull testcontainers images
         run: |
-          if [ "${{ matrix.datasource }}" == "mssql" ]; then
-            docker pull mcr.microsoft.com/mssql/server@${{ steps.dotenv.outputs.MSSQL_SHA }}
-          elif [ "${{ matrix.datasource }}" == "mysql" ]; then
-            docker pull mysql@${{ steps.dotenv.outputs.MYSQL_SHA }}
-          elif [ "${{ matrix.datasource }}" == "postgres" ]; then
-            docker pull postgres@${{ steps.dotenv.outputs.POSTGRES_SHA }}
-          elif [ "${{ matrix.datasource }}" == "mongodb" ]; then
-            docker pull mongo@${{ steps.dotenv.outputs.MONGODB_SHA }}
-          elif [ "${{ matrix.datasource }}" == "mariadb" ]; then
-            docker pull mariadb@${{ steps.dotenv.outputs.MARIADB_SHA }}
-          elif [ "${{ matrix.datasource }}" == "oracle" ]; then
-            docker pull budibase/oracle-database:23.2-slim-faststart
-          elif [ "${{ matrix.datasource }}" == "postgres_legacy" ]; then
-            docker pull postgres:9.5.25
-          elif [ "${{ matrix.datasource }}" == "elasticsearch" ]; then
-            docker pull elasticsearch@${{ steps.dotenv.outputs.ELASTICSEARCH_SHA }}
-          elif [ "${{ matrix.datasource }}" == "dynamodb" ]; then
-            docker pull amazon/dynamodb-local@${{ steps.dotenv.outputs.DYNAMODB_SHA }}
-          fi
           docker pull minio/minio &
           docker pull redis &
           docker pull testcontainers/ryuk:0.5.1 &
@@ -221,20 +192,6 @@ jobs:
 
       - name: Build client library - necessary for component tests
         run: yarn build:client
-
-      - name: Set up PostgreSQL 16
-        if: matrix.datasource == 'postgres'
-        run: |
-          sudo systemctl stop postgresql
-          sudo apt-get remove --purge -y postgresql* libpq-dev
-          sudo rm -rf /etc/postgresql /var/lib/postgresql
-          sudo apt-get autoremove -y
-          sudo apt-get autoclean
-
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo apt-get update
-          sudo apt-get install -y postgresql-16
 
       - name: Test server
         env:
@@ -371,43 +328,3 @@ jobs:
             echo "OpenAPI specs are up to date."
           fi
 
-  check-client-build-size:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          submodules: ${{ env.IS_OSS_CONTRIBUTOR == 'false' }}
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
-
-      - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-          cache: yarn
-      - run: yarn --frozen-lockfile
-
-      - name: Build client library
-        run: yarn build:client
-
-      - name: Check client build size
-        run: |
-          CLIENT_FILE="packages/client/dist/budibase-client.js"
-          if [ ! -f "$CLIENT_FILE" ]; then
-            echo "Error: Client build file not found at $CLIENT_FILE"
-            exit 1
-          fi
-          
-          SIZE_BYTES=$(stat -c%s "$CLIENT_FILE")
-          SIZE_MB=$(awk "BEGIN {printf \"%.2f\", $SIZE_BYTES / 1024 / 1024}")
-          MAX_SIZE_BYTES=$((8 * 1024 * 1024))
-          
-          echo "Client build size: ${SIZE_MB}MB"
-          echo "Maximum allowed size: 8MB"
-          
-          if [ $SIZE_BYTES -gt $MAX_SIZE_BYTES ]; then
-            echo "Client build size (${SIZE_MB}MB) exceeds maximum allowed size (8MB)"
-            exit 1
-          else
-            echo "Client build size (${SIZE_MB}MB) is within acceptable limits"
-          fi

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -16,6 +16,141 @@ on:
         required: true
 
 jobs:
+  check-client-build-size:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: ${{ env.IS_OSS_CONTRIBUTOR == 'false' }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: yarn
+      - run: yarn --frozen-lockfile
+
+      - name: Build client library
+        run: yarn build:client
+
+      - name: Check client build size
+        run: |
+          CLIENT_FILE="packages/client/dist/budibase-client.js"
+          if [ ! -f "$CLIENT_FILE" ]; then
+            echo "Error: Client build file not found at $CLIENT_FILE"
+            exit 1
+          fi
+          
+          SIZE_BYTES=$(stat -c%s "$CLIENT_FILE")
+          SIZE_MB=$(awk "BEGIN {printf \"%.2f\", $SIZE_BYTES / 1024 / 1024}")
+          MAX_SIZE_BYTES=$((8 * 1024 * 1024))
+          
+          echo "Client build size: ${SIZE_MB}MB"
+          echo "Maximum allowed size: 8MB"
+          
+          if [ $SIZE_BYTES -gt $MAX_SIZE_BYTES ]; then
+            echo "Client build size (${SIZE_MB}MB) exceeds maximum allowed size (8MB)"
+            exit 1
+          else
+            echo "Client build size (${SIZE_MB}MB) is within acceptable limits"
+          fi
+
+  test-server:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        datasource:
+          [
+            mssql,
+            mysql,
+            postgres,
+            postgres_legacy,
+            mongodb,
+            mariadb,
+            oracle,
+            sqs,
+            elasticsearch,
+            dynamodb,
+          ]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: ${{ env.IS_OSS_CONTRIBUTOR == 'false' }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          fetch-depth: 0
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: yarn
+
+      - name: Load dotenv
+        id: dotenv
+        uses: falti/dotenv-action@v1.1.3
+        with:
+          path: ./packages/server/images-sha.env
+
+      - name: Pull testcontainers images
+        run: |
+          if [ "${{ matrix.datasource }}" == "mssql" ]; then
+            docker pull mcr.microsoft.com/mssql/server@${{ steps.dotenv.outputs.MSSQL_SHA }}
+          elif [ "${{ matrix.datasource }}" == "mysql" ]; then
+            docker pull mysql@${{ steps.dotenv.outputs.MYSQL_SHA }}
+          elif [ "${{ matrix.datasource }}" == "postgres" ]; then
+            docker pull postgres@${{ steps.dotenv.outputs.POSTGRES_SHA }}
+          elif [ "${{ matrix.datasource }}" == "mongodb" ]; then
+            docker pull mongo@${{ steps.dotenv.outputs.MONGODB_SHA }}
+          elif [ "${{ matrix.datasource }}" == "mariadb" ]; then
+            docker pull mariadb@${{ steps.dotenv.outputs.MARIADB_SHA }}
+          elif [ "${{ matrix.datasource }}" == "oracle" ]; then
+            docker pull budibase/oracle-database:23.2-slim-faststart
+          elif [ "${{ matrix.datasource }}" == "postgres_legacy" ]; then
+            docker pull postgres:9.5.25
+          elif [ "${{ matrix.datasource }}" == "elasticsearch" ]; then
+            docker pull elasticsearch@${{ steps.dotenv.outputs.ELASTICSEARCH_SHA }}
+          elif [ "${{ matrix.datasource }}" == "dynamodb" ]; then
+            docker pull amazon/dynamodb-local@${{ steps.dotenv.outputs.DYNAMODB_SHA }}
+          fi
+          docker pull minio/minio &
+          docker pull redis &
+          docker pull testcontainers/ryuk:0.5.1 &
+          docker pull budibase/couchdb:v3.3.3-sqs-v2.1.1 &
+          docker pull ${{ steps.dotenv.outputs.KEYCLOAK_IMAGE }} &
+
+          wait $(jobs -p)
+
+      - run: yarn --frozen-lockfile
+
+      - name: Build client library - necessary for component tests
+        run: yarn build:client
+
+      - name: Set up PostgreSQL 16
+        if: matrix.datasource == 'postgres'
+        run: |
+          sudo systemctl stop postgresql
+          sudo apt-get remove --purge -y postgresql* libpq-dev
+          sudo rm -rf /etc/postgresql /var/lib/postgresql
+          sudo apt-get autoremove -y
+          sudo apt-get autoclean
+
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get install -y postgresql-16
+
+      - name: Test server
+        env:
+          DATASOURCE: ${{ matrix.datasource }}
+          # DEBUG: testcontainers*
+        run: |
+          FILTER="./src/tests/filters/datasource-tests.js"
+          cd packages/server
+          yarn test --filter $FILTER --verbose --reporters=default --reporters=github-actions
+
   tag-release:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
## Description
Improve PR CI times by moving some of the test runs into the release CI instead.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up PR CI by moving the heavy datasource matrix tests and client bundle size check to the release workflow. PRs get faster feedback; full coverage runs on release.

- **Refactors**
  - PR CI (.github/workflows/budibase_ci.yml)
    - Shrinks test-server matrix to "none".
    - Removes DB image pulls and PostgreSQL 16 setup.
    - Removes client build size check.
  - Release CI (.github/workflows/tag-release.yml)
    - Adds test-server matrix for mssql, mysql, postgres (incl. legacy), mongodb, mariadb, oracle, sqs, elasticsearch, dynamodb.
    - Pulls required testcontainer images, builds client, and runs filtered datasource tests.
    - Adds client build size check (8MB limit).

<sup>Written for commit 18ef6421a9fa2548c7a7f1855f246e59acca16bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

