### PR TITLE
feat: standardize CouchDB data directory to `/data`

### DIFF
--- a/hosting/couchdb/Dockerfile
+++ b/hosting/couchdb/Dockerfile
@@ -63,9 +63,9 @@ RUN set -eux; \
 # Undo symlinks to /var/log and /var/lib
     rmdir /var/lib/couchdb /var/log/couchdb; \
     rm /opt/couchdb/data /opt/couchdb/var/log; \
-    mkdir -p /opt/couchdb/data /opt/couchdb/var/log; \
-    chown couchdb:couchdb /opt/couchdb/data /opt/couchdb/var/log; \
-    chmod 777 /opt/couchdb/data /opt/couchdb/var/log; \
+    mkdir -p /opt/couchdb/data /opt/couchdb/var/log /data; \
+    chown couchdb:couchdb /opt/couchdb/data /opt/couchdb/var/log /data; \
+    chmod 777 /opt/couchdb/data /opt/couchdb/var/log /data; \
 # Remove file that sets logging to a file
     rm /opt/couchdb/etc/default.d/10-filelog.ini; \
 # Check we own everything in /opt/couchdb. Matches the command in dockerfile_entrypoint.sh
@@ -87,7 +87,7 @@ COPY docker-entrypoint.sh /usr/local/bin
 RUN ln -s usr/local/bin/docker-entrypoint.sh /docker-entrypoint.sh # backwards compat
 ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
 
-VOLUME /opt/couchdb/data
+VOLUME /data
 
 # 5984: Main CouchDB endpoint
 # 4369: Erlang portmap daemon (epmd)

--- a/hosting/couchdb/docker-entrypoint.sh
+++ b/hosting/couchdb/docker-entrypoint.sh
@@ -48,8 +48,12 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 		# when it creates the files. The approach taken here ensures that the
 		# contents of the datadir have the same permissions as they had when they
 		# were initially created. This should minimize any startup delay.
-		find /opt/couchdb/data -type d ! -perm 0755 -exec chmod -f 0755 '{}' +
-		find /opt/couchdb/data -type f ! -perm 0644 -exec chmod -f 0644 '{}' +
+		CHECK_DIR="/opt/couchdb/data"
+		if [ -d "/data" ]; then
+			CHECK_DIR="/data"
+		fi
+		find "$CHECK_DIR" -type d ! -perm 0755 -exec chmod -f 0755 '{}' +
+		find "$CHECK_DIR" -type f ! -perm 0644 -exec chmod -f 0644 '{}' +
 
 		# Do the same thing for configuration files and directories. Technically
 		# CouchDB only needs read access to the configuration files as all online

--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -103,8 +103,9 @@ services:
       - COUCHDB_PASSWORD=${COUCH_DB_PASSWORD}
       - COUCHDB_USER=${COUCH_DB_USER}
       - TARGETBUILD=docker-compose
+      - DATA_DIR=/data
     volumes:
-      - couchdb3_data:/opt/couchdb/data
+      - couchdb3_data:/data
 
   redis-service:
     restart: unless-stopped


### PR DESCRIPTION
## Description
We're unifying all builds to use a consistent storage structure under `/data` (with subdirectories for databases, search indexes, and SQS). Includes migration logic for any installations that used the `/opt/couchdb/data` directory that was the previous default.

## Launchcontrol

Unify CouchDB storage structure for all the hosting options.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized CouchDB persistent storage to /data across all hosting options. Includes auto-migration from legacy /opt/couchdb/data layouts to prevent data loss.

- **New Features**
  - Set image VOLUME to /data; data lives under /data (e.g., couch/dbs, search).
  - Use DATA_DIR env across Docker, docker-compose, Kubernetes, and single builds.
  - Entry-point now fixes file permissions in /data when present.
  - docker-compose mounts couchdb3_data at /data and sets DATA_DIR=/data.

- **Migration**
  - On startup, move legacy *.couch files from DATA_DIR root to DATA_DIR/couch/dbs.

<sup>Written for commit 5a45e8ff4910dd1ef158a65883fc18e64662291b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

