### PR TITLE
Update Budibase DB data section layout

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/data/_components/AITableGeneration.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/_components/AITableGeneration.svelte
@@ -65,15 +65,26 @@
     gap: 10px;
   }
 
+  .ai-generation-prompt {
+    width: 100%;
+  }
+
   .ai-generation-examples {
     display: grid;
     gap: 10px;
+    width: 100%;
+    grid-template-columns: 1fr;
   }
 
   @media (min-width: 833px) {
     .ai-generation-examples {
-      grid-auto-flow: column;
+      grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
     }
+  }
+
+  .ai-generation-examples :global(.spectrum-ActionButton) {
+    width: 100%;
+    justify-content: center;
   }
   .ai-generation :global(.spectrum-Textfield-input),
   .ai-generation :global(.spectrum-ActionButton) {

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/bb_internal/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/bb_internal/index.svelte
@@ -39,7 +39,7 @@
     <Layout gap="XS" noPadding>
       <header>
         <svelte:component this={ICONS.BUDIBASE} height="26" width="26" />
-        <Heading size="M">Budibase Internal</Heading>
+        <Heading size="M">Budibase DB</Heading>
       </header>
       <Body size="M">
         Budibase internal tables are part of your app, so the data will be

--- a/packages/builder/src/pages/builder/workspace/[application]/data/new.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/new.svelte
@@ -57,17 +57,17 @@
   onClose={() => goto("./table")}
   heading="Add new data source"
 >
-  <div class="subHeading">
-    <Body>Get started with our Budibase DB</Body>
-    <AbsTooltip text="Budibase DB is built with CouchDB">
-      <Icon name="info" size="S" />
-    </AbsTooltip>
-  </div>
-
-  <div class="options bb-options">
+  <div class="bb-section">
     <div class="ai-generation">
       <AiTableGeneration />
     </div>
+    <div class="subHeading bb-subheading">
+      <Body>Get started with our Budibase DB</Body>
+      <AbsTooltip text="Budibase DB is built with CouchDB">
+        <Icon name="info" size="S" />
+      </AbsTooltip>
+    </div>
+    <div class="options bb-options">
     <DatasourceOption
       on:click={() => internalTableModal.show()}
       title="Create new table"
@@ -89,6 +89,7 @@
     >
       <svelte:component this={ICONS.BUDIBASE} height="20" width="20" />
     </DatasourceOption>
+    </div>
   </div>
 
   <div class="subHeading">
@@ -132,10 +133,15 @@
     margin-bottom: 48px;
     max-width: 1050px;
   }
+  .bb-section {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+  }
   .bb-options {
     max-width: calc(3 * 235px + 2 * 24px); /* 3 columns + 2 gaps */
   }
-  .options .ai-generation {
-    grid-column: 1 / -1;
+  .bb-subheading {
+    justify-content: flex-start;
   }
 </style>

--- a/packages/builder/src/pages/builder/workspace/[application]/data/new.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/new.svelte
@@ -68,27 +68,27 @@
       </AbsTooltip>
     </div>
     <div class="options bb-options">
-    <DatasourceOption
-      on:click={() => internalTableModal.show()}
-      title="Create new table"
-      {disabled}
-    >
-      <svelte:component this={ICONS.BUDIBASE} height="20" width="20" />
-    </DatasourceOption>
-    <DatasourceOption
-      on:click={createSampleData}
-      title="Use sample data"
-      disabled={disabled || $datasources.hasDefaultData}
-    >
-      <svelte:component this={ICONS.BUDIBASE} height="20" width="20" />
-    </DatasourceOption>
-    <DatasourceOption
-      on:click={() => internalTableModal.show({ promptUpload: true })}
-      title="Upload CSV / JSON"
-      {disabled}
-    >
-      <svelte:component this={ICONS.BUDIBASE} height="20" width="20" />
-    </DatasourceOption>
+      <DatasourceOption
+        on:click={() => internalTableModal.show()}
+        title="Create new table"
+        {disabled}
+      >
+        <svelte:component this={ICONS.BUDIBASE} height="20" width="20" />
+      </DatasourceOption>
+      <DatasourceOption
+        on:click={createSampleData}
+        title="Use sample data"
+        disabled={disabled || $datasources.hasDefaultData}
+      >
+        <svelte:component this={ICONS.BUDIBASE} height="20" width="20" />
+      </DatasourceOption>
+      <DatasourceOption
+        on:click={() => internalTableModal.show({ promptUpload: true })}
+        title="Upload CSV / JSON"
+        {disabled}
+      >
+        <svelte:component this={ICONS.BUDIBASE} height="20" width="20" />
+      </DatasourceOption>
     </div>
   </div>
 


### PR DESCRIPTION
## Description
Align Budibase DB data section copy and AI prompt layout; update internal datasource heading to "Budibase DB".

## Screenshots
<img width="2316" height="1112" alt="fix ds page" src="https://github.com/user-attachments/assets/50826ecb-4144-457c-9f41-a74748d3eeb5" />

## Launchcontrol
Improve the Budibase DB data section layout and labels in the data source setup flow.
