### PR TITLE
feat: default agent api

### DIFF
--- a/packages/server/src/sdk/workspace/ai/chatApps.ts
+++ b/packages/server/src/sdk/workspace/ai/chatApps.ts
@@ -74,7 +74,7 @@ export async function create(chatApp: Omit<ChatApp, "_id" | "_rev">) {
     throw new HTTPError("Chat App already exists for this workspace", 400)
   }
   const normalizedEnabledAgents = normalizeEnabledAgents(
-    chatApp.enabledAgents ?? []
+    chatApp.enabledAgents === undefined ? undefined : chatApp.enabledAgents
   )
 
   const now = new Date().toISOString()
@@ -100,7 +100,9 @@ export async function update(chatApp: ChatApp) {
     throw new HTTPError("Chat App not found", 404)
   }
   const normalizedEnabledAgents = normalizeEnabledAgents(
-    chatApp.enabledAgents ?? existing.enabledAgents ?? []
+    chatApp.enabledAgents === undefined
+      ? (existing.enabledAgents ?? [])
+      : chatApp.enabledAgents
   )
 
   const now = new Date().toISOString()

--- a/packages/server/src/sdk/workspace/ai/chatApps.ts
+++ b/packages/server/src/sdk/workspace/ai/chatApps.ts
@@ -6,21 +6,41 @@ const withDefaults = (chatApp: ChatApp): ChatApp => ({
   live: chatApp.live ?? false,
 })
 
-const ensureEnabledAgents = (chatApp: ChatApp) => {
-  const enabledAgents = chatApp.enabledAgents
-  const hasAtLeastOne = Array.isArray(enabledAgents) && enabledAgents.length > 0
-  const allValid =
-    hasAtLeastOne &&
-    enabledAgents.every(
-      agent => typeof agent?.agentId === "string" && agent.agentId.trim().length
-    )
+const normalizeEnabledAgents = (enabledAgents?: ChatApp["enabledAgents"]) => {
+  if (enabledAgents === undefined) {
+    return undefined
+  }
+  if (!Array.isArray(enabledAgents)) {
+    throw new HTTPError("enabledAgents must contain valid agentId entries", 400)
+  }
+  if (enabledAgents.length === 0) {
+    return []
+  }
+
+  const allValid = enabledAgents.every(
+    agent => typeof agent?.agentId === "string" && agent.agentId.trim().length
+  )
 
   if (!allValid) {
-    throw new HTTPError(
-      "enabledAgents must contain at least one valid agentId",
-      400
-    )
+    throw new HTTPError("enabledAgents must contain valid agentId entries", 400)
   }
+
+  const defaultCount = enabledAgents.filter(agent => agent.default).length
+  if (defaultCount > 1) {
+    throw new HTTPError("enabledAgents must contain at most one default", 400)
+  }
+
+  if (defaultCount === 0) {
+    return enabledAgents.map((agent, index) => ({
+      ...agent,
+      default: index === 0,
+    }))
+  }
+
+  return enabledAgents.map(agent => ({
+    ...agent,
+    default: agent.default === true,
+  }))
 }
 
 export async function getSingle(): Promise<ChatApp | undefined> {
@@ -53,7 +73,9 @@ export async function create(chatApp: Omit<ChatApp, "_id" | "_rev">) {
   if (existing) {
     throw new HTTPError("Chat App already exists for this workspace", 400)
   }
-  ensureEnabledAgents(chatApp)
+  const normalizedEnabledAgents = normalizeEnabledAgents(
+    chatApp.enabledAgents ?? []
+  )
 
   const now = new Date().toISOString()
   const doc: ChatApp = {
@@ -61,6 +83,7 @@ export async function create(chatApp: Omit<ChatApp, "_id" | "_rev">) {
     createdAt: now,
     updatedAt: now,
     ...chatApp,
+    enabledAgents: normalizedEnabledAgents ?? [],
   }
 
   const { rev } = await db.put(doc)
@@ -76,12 +99,15 @@ export async function update(chatApp: ChatApp) {
   if (!existing) {
     throw new HTTPError("Chat App not found", 404)
   }
-  ensureEnabledAgents(chatApp)
+  const normalizedEnabledAgents = normalizeEnabledAgents(
+    chatApp.enabledAgents ?? existing.enabledAgents ?? []
+  )
 
   const now = new Date().toISOString()
   const updated: ChatApp = {
     ...existing,
     ...chatApp,
+    enabledAgents: normalizedEnabledAgents ?? [],
     updatedAt: now,
   }
   const { rev } = await db.put(updated)

--- a/packages/server/src/tests/api/chatApps.spec.ts
+++ b/packages/server/src/tests/api/chatApps.spec.ts
@@ -34,11 +34,17 @@ describe("chat apps validation", () => {
 
   const updateChatApp = async (body: any) => {
     const headers = await config.defaultHeaders({}, true)
-    return await config
+    const res = await config
       .getRequest()!
       .put(`/api/chatapps/${chatApp._id}`)
       .set(headers)
       .send(body)
+
+    if (res.status === 200 && res.body?._rev) {
+      chatApp = { ...chatApp, _rev: res.body._rev }
+    }
+
+    return res
   }
 
   it("rejects enabledAgents entries without agentId", async () => {
@@ -56,6 +62,16 @@ describe("chat apps validation", () => {
       _id: chatApp._id,
       _rev: chatApp._rev,
       enabledAgents: [{ agentId: "" }],
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it("rejects null enabledAgents", async () => {
+    const res = await updateChatApp({
+      _id: chatApp._id,
+      _rev: chatApp._rev,
+      enabledAgents: null,
     })
 
     expect(res.status).toBe(400)

--- a/packages/server/src/tests/api/chatApps.spec.ts
+++ b/packages/server/src/tests/api/chatApps.spec.ts
@@ -60,4 +60,42 @@ describe("chat apps validation", () => {
 
     expect(res.status).toBe(400)
   })
+
+  it("allows empty enabledAgents", async () => {
+    const res = await updateChatApp({
+      _id: chatApp._id,
+      _rev: chatApp._rev,
+      enabledAgents: [],
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.body.enabledAgents).toEqual([])
+  })
+
+  it("assigns default when missing", async () => {
+    const res = await updateChatApp({
+      _id: chatApp._id,
+      _rev: chatApp._rev,
+      enabledAgents: [{ agentId: "agent-1" }, { agentId: "agent-2" }],
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.body.enabledAgents).toEqual([
+      { agentId: "agent-1", default: true },
+      { agentId: "agent-2", default: false },
+    ])
+  })
+
+  it("rejects multiple default agents", async () => {
+    const res = await updateChatApp({
+      _id: chatApp._id,
+      _rev: chatApp._rev,
+      enabledAgents: [
+        { agentId: "agent-1", default: true },
+        { agentId: "agent-2", default: true },
+      ],
+    })
+
+    expect(res.status).toBe(400)
+  })
 })

--- a/packages/server/src/tests/api/chatApps.spec.ts
+++ b/packages/server/src/tests/api/chatApps.spec.ts
@@ -1,5 +1,6 @@
 import { context, docIds } from "@budibase/backend-core"
 import type { ChatApp } from "@budibase/types"
+import sdk from "../../sdk"
 import TestConfiguration from "../utilities/TestConfiguration"
 
 describe("chat apps validation", () => {
@@ -113,5 +114,32 @@ describe("chat apps validation", () => {
     })
 
     expect(res.status).toBe(400)
+  })
+})
+
+describe("chat apps create validation", () => {
+  const config = new TestConfiguration()
+
+  beforeAll(async () => {
+    await config.init("chat-app-create-validation")
+  })
+
+  afterAll(() => {
+    config.end()
+  })
+
+  it("rejects null enabledAgents", async () => {
+    await context.doInWorkspaceContext(
+      config.getProdWorkspaceId(),
+      async () => {
+        const payload = {
+          enabledAgents: null,
+        } as unknown as Omit<ChatApp, "_id" | "_rev">
+
+        await expect(sdk.ai.chatApps.create(payload)).rejects.toThrow(
+          "enabledAgents must contain valid agentId entries"
+        )
+      }
+    )
   })
 })

--- a/packages/types/src/documents/global/chat.ts
+++ b/packages/types/src/documents/global/chat.ts
@@ -3,6 +3,7 @@ import type { UIMessage } from "ai"
 
 export interface ChatAppEnabledAgent {
   agentId: string
+  default?: boolean
 }
 
 export interface ChatApp extends Document {


### PR DESCRIPTION
## Description

* adds the concept of a defaultAgent
* the first agent to be enabled is gets the default 
* future UI to change the defaultAgent
* can only have one defaultAgent

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce default agent support in Chat Apps. The API picks the first enabled agent as default when missing, enforces a single default, allows empty enabledAgents, and rejects null values.

- **New Features**
  - Add a default flag to enabled agents and normalize it on create/update.
  - Auto-assign default to the first agent if none provided; reject multiple defaults.
  - Allow enabledAgents to be empty; creating a Chat App no longer requires an agent.
  - Validate agentId entries and reject invalid payloads.
  - Reject explicit null enabledAgents.

<sup>Written for commit 5621c381d2a1abd45ae6a57e2dba7443e5ce6940. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

