### PR TITLE
fix(single): keep curl for couchdb runner

### DIFF
--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -69,7 +69,7 @@ RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends postgresql-client-15; \
     rm -rf /var/lib/apt/lists/*; \
-    apt-get purge -y --auto-remove curl gnupg lsb-release; \
+    apt-get purge -y --auto-remove gnupg lsb-release; \
     rm -f /etc/apt/sources.list.d/postgresql.list
 
 # We use pm2 in order to run multiple node processes in a single container


### PR DESCRIPTION
## Description
Fix single image startup by keeping curl so the couchdb runner readiness checks work.

This commit (https://github.com/Budibase/budibase/commit/f774fca9d4cf9040c80111143c02c231680464ad) was breaking Docker single image as it removed **curl** which was still needed by the couchdb runner. 

## Launchcontrol
Keep curl in the single Docker image so the couchdb runner can perform health checks during startup.
