### PR TITLE
feat: display default agent

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatApp.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatApp.svelte
@@ -53,6 +53,7 @@
     .map(agent => ({
       agentId: agent.agentId,
       name: getAgentName(agent.agentId),
+      default: agent.default,
     }))
     .filter(agent => Boolean(agent.name))
 

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatNavigationPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatNavigationPanel.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import Panel from "@/components/design/Panel.svelte"
-  import { Body } from "@budibase/bbui"
+  import { Body, Icon } from "@budibase/bbui"
   import { createEventDispatcher } from "svelte"
 
   type EnabledAgentListItem = {
     agentId: string
     name?: string
+    default?: boolean
   }
 
   type ConversationListItem = {
@@ -16,6 +17,9 @@
   export let enabledAgentList: EnabledAgentListItem[] = []
   export let conversationHistory: ConversationListItem[] = []
   export let selectedConversationId: string | undefined
+
+  $: defaultAgent =
+    enabledAgentList.find(agent => agent.default) || enabledAgentList[0]
 
   const dispatch = createEventDispatcher<{
     agentSelected: { agentId: string }
@@ -32,6 +36,20 @@
 </script>
 
 <Panel customWidth={260} borderRight noHeaderBorder>
+  {#if defaultAgent?.agentId}
+    <div class="list-section">
+      <button
+        class="new-chat"
+        on:click={() => selectAgent(defaultAgent.agentId)}
+      >
+        <span class="new-chat-icon">
+          <Icon name="plus" size="S" />
+        </span>
+        <span class="new-chat-label">New chat</span>
+      </button>
+    </div>
+  {/if}
+
   <div class="list-section">
     <div class="list-title">Agents</div>
     {#if enabledAgentList.length}
@@ -82,6 +100,40 @@
 
   .list-section + .list-section {
     padding-top: 0;
+  }
+
+  .new-chat {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s);
+    background: transparent;
+    border: none;
+    padding: var(--spacing-xs) 0;
+    font: inherit;
+    color: var(--spectrum-global-color-gray-700);
+    text-align: left;
+    width: 100%;
+    cursor: pointer;
+  }
+
+  .new-chat-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: #6a9bcc;
+    color: var(--spectrum-global-color-gray-50);
+  }
+
+  .new-chat-label {
+    font-size: 14px;
+    color: var(--spectrum-global-color-gray-800);
+  }
+
+  .new-chat:hover .new-chat-icon {
+    background: #5c8dbf;
   }
 
   .list-item {

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/index.svelte
@@ -71,6 +71,7 @@
   <div class="page">
     <ChatSettingsPanel
       {namedAgents}
+      {enabledAgents}
       {isAgentAvailable}
       {handleAvailabilityToggle}
     />


### PR DESCRIPTION
## Description
* split out the default agent in the settings panel
* add a create chat button that starts a convo with the default

<img width="1082" height="1224" alt="image" src="https://github.com/user-attachments/assets/2a3664e7-9218-4ace-8e48-84995ec175fa" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the default agent in chat and settings. Adds a New chat button that starts a conversation with the default agent.

- New Features
  - New chat button in the navigation panel starts with the default agent.
  - Settings panel highlights the default agent (with availability toggle) and lists other agents separately.
  - Default agent is resolved from enabledAgents; falls back to the first enabled agent if none is set.

<sup>Written for commit 54165824966e995a467b6deced9d5fd0f112c4c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



