### PR TITLE
feat: chat agent settings

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/AgentList.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/AgentList.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+  import { Body, Icon, Toggle } from "@budibase/bbui"
+  import type { Agent } from "@budibase/types"
+
+  type AgentListItem = Agent & {
+    agentId: string
+    default?: boolean
+  }
+
+  export let resolvedDefaultAgent: AgentListItem | undefined
+  export let otherAgents: AgentListItem[] = []
+  export let isAgentAvailable: (agentId: string) => boolean
+  export let onToggleEnabled: (agentId: string, enabled: boolean) => void
+  export let onOpenSettings: (agent: AgentListItem) => void
+</script>
+
+<div class="settings-group">
+  <Body size="XS" color="var(--spectrum-global-color-gray-500)">
+    Default agent
+  </Body>
+  {#if resolvedDefaultAgent?.agentId}
+    <div class="settings-agent">
+      <div class="settings-agent-info">
+        <Body size="S">
+          {resolvedDefaultAgent.name || "Unknown agent"}
+        </Body>
+      </div>
+      <div class="settings-agent-actions">
+        <Toggle
+          value={isAgentAvailable(resolvedDefaultAgent.agentId)}
+          on:change={event =>
+            onToggleEnabled(resolvedDefaultAgent.agentId, event.detail)}
+        />
+        <button
+          class="settings-gear"
+          type="button"
+          on:click={() => onOpenSettings(resolvedDefaultAgent)}
+          aria-label="Open agent settings"
+        >
+          <Icon name="gear" size="S" />
+        </button>
+      </div>
+    </div>
+  {:else}
+    <Body size="S" color="var(--spectrum-global-color-gray-500)">
+      No default agent
+    </Body>
+  {/if}
+</div>
+
+<div class="settings-group">
+  <Body size="XS" color="var(--spectrum-global-color-gray-500)">
+    Other agents
+  </Body>
+  {#if otherAgents.length}
+    {#each otherAgents as agent (agent.agentId)}
+      <div class="settings-agent">
+        <div class="settings-agent-info">
+          <Body size="S">{agent.name}</Body>
+        </div>
+        <div class="settings-agent-actions">
+          <Toggle
+            value={isAgentAvailable(agent.agentId)}
+            on:change={event => onToggleEnabled(agent.agentId, event.detail)}
+          />
+          <button
+            class="settings-gear"
+            type="button"
+            on:click={() => onOpenSettings(agent)}
+            aria-label="Open agent settings"
+          >
+            <Icon name="gear" size="S" />
+          </button>
+        </div>
+      </div>
+    {/each}
+  {:else}
+    <Body size="S" color="var(--spectrum-global-color-gray-500)">
+      No other agents
+    </Body>
+  {/if}
+</div>
+
+<style>
+  .settings-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+  }
+
+  .settings-agent {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-s);
+  }
+
+  .settings-agent-info {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xxs);
+  }
+
+  .settings-agent-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+  }
+
+  .settings-gear {
+    border: none;
+    background: transparent;
+    padding: 0;
+    color: var(--spectrum-global-color-gray-600);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .settings-gear:hover {
+    color: var(--spectrum-global-color-gray-800);
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/AgentList.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/AgentList.svelte
@@ -26,11 +26,6 @@
         </Body>
       </div>
       <div class="settings-agent-actions">
-        <Toggle
-          value={isAgentAvailable(resolvedDefaultAgent.agentId)}
-          on:change={event =>
-            onToggleEnabled(resolvedDefaultAgent.agentId, event.detail)}
-        />
         <button
           class="settings-gear"
           type="button"

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/AgentList.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/AgentList.svelte
@@ -9,9 +9,9 @@
 
   export let resolvedDefaultAgent: AgentListItem | undefined
   export let otherAgents: AgentListItem[] = []
-  export let isAgentAvailable: (agentId: string) => boolean
-  export let onToggleEnabled: (agentId: string, enabled: boolean) => void
-  export let onOpenSettings: (agent: AgentListItem) => void
+  export let isAgentAvailable: (_agentId: string) => boolean
+  export let onToggleEnabled: (_agentId: string, _enabled: boolean) => void
+  export let onOpenSettings: (_agent: AgentListItem) => void
 </script>
 
 <div class="settings-group">

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/AgentSettingsModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/AgentSettingsModal.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { Button, Modal, ModalContent } from "@budibase/bbui"
+  import type { Agent } from "@budibase/types"
+
+  type AgentListItem = Agent & {
+    agentId: string
+    default?: boolean
+  }
+
+  export let open = false
+  export let selectedAgent: AgentListItem | undefined
+  export let defaultAgentId: string | undefined
+  export let isAgentAvailable: (agentId: string) => boolean
+  export let onSetDefault: (agentId: string) => void
+  export let onClose: () => void
+
+  let modal: Modal | undefined
+
+  $: if (modal) {
+    if (open) {
+      modal.show()
+    } else {
+      modal.hide()
+    }
+  }
+
+  $: isDefault = selectedAgent?.agentId === defaultAgentId
+  $: isDisabled =
+    !selectedAgent || !isAgentAvailable(selectedAgent.agentId) || isDefault
+
+  const handleSetDefault = () => {
+    if (selectedAgent) {
+      onSetDefault(selectedAgent.agentId)
+    }
+  }
+</script>
+
+<Modal bind:this={modal} on:hide={() => (open ? onClose() : undefined)}>
+  <ModalContent
+    size="M"
+    title={`${selectedAgent?.name || "Agent"} settings`}
+    showConfirmButton={false}
+  >
+    <div class="agent-settings">
+      <Button size="S" disabled={isDisabled} on:click={handleSetDefault}>
+        Set as default
+      </Button>
+    </div>
+  </ModalContent>
+</Modal>
+
+<style>
+  .agent-settings {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-s);
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/AgentSettingsModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/AgentSettingsModal.svelte
@@ -10,8 +10,8 @@
   export let open = false
   export let selectedAgent: AgentListItem | undefined
   export let defaultAgentId: string | undefined
-  export let isAgentAvailable: (agentId: string) => boolean
-  export let onSetDefault: (agentId: string) => void
+  export let isAgentAvailable: (_agentId: string) => boolean
+  export let onSetDefault: (_agentId: string) => void
   export let onClose: () => void
 
   let modal: Modal | undefined

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/AgentSettingsModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/AgentSettingsModal.svelte
@@ -25,8 +25,13 @@
   }
 
   $: isDefault = selectedAgent?.agentId === defaultAgentId
-  $: isDisabled =
-    !selectedAgent || !isAgentAvailable(selectedAgent.agentId) || isDefault
+  $: isAvailable = selectedAgent && isAgentAvailable(selectedAgent.agentId)
+  $: disabledReason = isDefault
+    ? "This agent is already the default."
+    : !isAvailable
+      ? "Enable this agent to set it as default."
+      : ""
+  $: isDisabled = !selectedAgent || !isAvailable || isDefault
 
   const handleSetDefault = () => {
     if (selectedAgent) {
@@ -45,6 +50,9 @@
       <Button size="S" disabled={isDisabled} on:click={handleSetDefault}>
         Set as default
       </Button>
+      {#if disabledReason}
+        <p class="agent-settings-helper">{disabledReason}</p>
+      {/if}
     </div>
   </ModalContent>
 </Modal>
@@ -54,5 +62,11 @@
     display: flex;
     flex-direction: column;
     gap: var(--spacing-s);
+  }
+
+  .agent-settings-helper {
+    margin: 0;
+    font-size: 12px;
+    color: var(--spectrum-global-color-gray-600);
   }
 </style>

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatSettingsPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatSettingsPanel.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
   import Panel from "@/components/design/Panel.svelte"
-  import { Body, Icon, Modal, ModalContent, Toggle } from "@budibase/bbui"
+  import {
+    Body,
+    Checkbox,
+    Icon,
+    Modal,
+    ModalContent,
+    Toggle,
+  } from "@budibase/bbui"
   import type { Agent } from "@budibase/types"
 
   type EnabledAgent = {
@@ -20,9 +27,13 @@
     _agentId: string,
     _enabled: boolean
   ) => void
+  export let handleDefaultToggle: (_agentId: string) => void
 
   let settingsModal: Modal | undefined
+  let selectedAgentId: string | undefined
   let selectedAgent: AgentListItem | undefined
+
+  $: selectedAgent = agentList.find(agent => agent.agentId === selectedAgentId)
 
   $: agentList = namedAgents
     .filter(agent => agent._id)
@@ -43,7 +54,7 @@
   )
 
   const openAgentSettings = (agent: AgentListItem) => {
-    selectedAgent = agent
+    selectedAgentId = agent.agentId
     settingsModal?.show()
   }
 </script>
@@ -139,7 +150,20 @@
     size="M"
     title={`${selectedAgent?.name || "Agent"} settings`}
     showConfirmButton={false}
-  />
+  >
+    <div class="agent-settings">
+      <Checkbox
+        text="Default agent"
+        value={selectedAgent?.agentId === resolvedDefaultAgent?.agentId}
+        disabled={!selectedAgent || !isAgentAvailable(selectedAgent.agentId)}
+        on:change={event => {
+          if (selectedAgent && event.detail) {
+            handleDefaultToggle(selectedAgent.agentId)
+          }
+        }}
+      />
+    </div>
+  </ModalContent>
 </Modal>
 
 <style>
@@ -193,5 +217,11 @@
 
   .settings-gear:hover {
     color: var(--spectrum-global-color-gray-800);
+  }
+
+  .agent-settings {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-s);
   }
 </style>

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatSettingsPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatSettingsPanel.svelte
@@ -2,7 +2,7 @@
   import Panel from "@/components/design/Panel.svelte"
   import {
     Body,
-    Checkbox,
+    Button,
     Icon,
     Modal,
     ModalContent,
@@ -152,16 +152,19 @@
     showConfirmButton={false}
   >
     <div class="agent-settings">
-      <Checkbox
-        text="Default agent"
-        value={selectedAgent?.agentId === resolvedDefaultAgent?.agentId}
-        disabled={!selectedAgent || !isAgentAvailable(selectedAgent.agentId)}
-        on:change={event => {
-          if (selectedAgent && event.detail) {
+      <Button
+        size="S"
+        disabled={!selectedAgent ||
+          !isAgentAvailable(selectedAgent.agentId) ||
+          selectedAgent.agentId === resolvedDefaultAgent?.agentId}
+        on:click={() => {
+          if (selectedAgent) {
             handleDefaultToggle(selectedAgent.agentId)
           }
         }}
-      />
+      >
+        Set as default
+      </Button>
     </div>
   </ModalContent>
 </Modal>

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/index.svelte
@@ -7,7 +7,7 @@
   import ChatApp from "./_components/ChatApp.svelte"
   import ChatSettingsPanel from "./_components/ChatSettingsPanel.svelte"
 
-  type EnabledAgent = { agentId: string }
+  type EnabledAgent = { agentId: string; default?: boolean }
 
   $: namedAgents = agents.filter(agent => Boolean(agent?.name))
   $: chatApp = $currentChatApp
@@ -64,6 +64,31 @@
 
     await chatAppsStore.updateEnabledAgents(nextEnabledAgents)
   }
+
+  const handleDefaultToggle = async (agentId: string) => {
+    const workspaceId = $params.application
+    if (!workspaceId) {
+      return
+    }
+
+    if (!agentId || !isAgentAvailable(agentId)) {
+      return
+    }
+
+    // Ensure we have a chat app loaded before updating enabled agents
+    await chatAppsStore.ensureChatApp(undefined, workspaceId)
+
+    const current = enabledAgents
+    const hasAgent = current.some(agent => agent.agentId === agentId)
+    const baseAgents = hasAgent ? current : [...current, { agentId }]
+
+    const nextEnabledAgents = baseAgents.map(agent => ({
+      agentId: agent.agentId,
+      default: agent.agentId === agentId,
+    }))
+
+    await chatAppsStore.updateEnabledAgents(nextEnabledAgents)
+  }
 </script>
 
 <div class="wrapper">
@@ -74,6 +99,7 @@
       {enabledAgents}
       {isAgentAvailable}
       {handleAvailabilityToggle}
+      {handleDefaultToggle}
     />
 
     {#if $params.application}


### PR DESCRIPTION
## Description

* adds a settings modal, toggled by pressing the cog icon
* can set a default agent
* button is disabled if you can't press it (because the agent is already default, agent is not enabled)
* refactors the settings panel into list and modal
* note: zero effort styling


## Video
https://github.com/user-attachments/assets/61398529-c690-48c9-9004-8cb6561ad574


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a chat agent settings UI so users can enable/disable agents and set a default agent directly from the chat settings panel. Introduces a modal-driven flow that updates the app state and keeps the default selection in sync.

- **New Features**
  - Agent list with availability toggles and a per-agent settings modal.
  - “Set as default” updates enabledAgents, ensuring only one default and the agent remains enabled.
  - Disables the default action when an agent is unavailable or already default.

- **Refactors**
  - Extracted AgentList and AgentSettingsModal components; simplified ChatSettingsPanel.
  - EnabledAgent now includes a default flag; index.svelte ensures the chat app loads before updating and centralizes default switching logic.

<sup>Written for commit c680c259159f32cd1c778c60c435b0b43c151847. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



