### PR TITLE
Fix cron unexpected runs

### DIFF
--- a/packages/server/src/automations/tests/utils.spec.ts
+++ b/packages/server/src/automations/tests/utils.spec.ts
@@ -140,7 +140,7 @@ describe("enableCronOrEmailTrigger", () => {
         { key: "repeat:legacy2:123:::0 0 * * *" },
       ])
     mockGetBullQueue.mockReturnValue({
-      ...automationQueue.getBullQueue(),
+      ...(automationQueue.getBullQueue() ?? {}),
       removeRepeatableByKey: mockRemoveRepeatableByKey,
       getRepeatableJobs: mockGetRepeatableJobs,
     } as ReturnType<typeof automationQueue.getBullQueue>)

--- a/packages/server/src/automations/tests/utils.spec.ts
+++ b/packages/server/src/automations/tests/utils.spec.ts
@@ -45,6 +45,9 @@ jest.mock("@budibase/backend-core", () => {
 const mockAdd = automationQueue.add as MockedFunction<
   typeof automationQueue.add
 >
+const mockGetBullQueue = automationQueue.getBullQueue as MockedFunction<
+  typeof automationQueue.getBullQueue
+>
 const mockDoWithDB = dbCore.doWithDB as MockedFunction<typeof dbCore.doWithDB>
 const mockNewId = coreUtils.newid as MockedFunction<typeof coreUtils.newid>
 
@@ -124,6 +127,43 @@ describe("enableCronOrEmailTrigger", () => {
       expect.objectContaining({ jobId: "app_dev_123_cron_existing" })
     )
     expect(mockDoWithDB).not.toHaveBeenCalled()
+  })
+
+  it("migrates legacy cron repeatable job ids", async () => {
+    const automation = buildCronAutomation("repeat:legacy:123")
+    const mockRemoveRepeatableByKey = jest.fn()
+    const mockGetRepeatableJobs = jest
+      .fn()
+      .mockResolvedValue([
+        { key: "repeat:legacy:123:::* * * * 0" },
+        { key: "repeat:legacy:123:::* * * * 1" },
+        { key: "repeat:legacy2:123:::0 0 * * *" },
+      ])
+    mockGetBullQueue.mockReturnValue({
+      ...automationQueue.getBullQueue(),
+      removeRepeatableByKey: mockRemoveRepeatableByKey,
+      getRepeatableJobs: mockGetRepeatableJobs,
+    } as ReturnType<typeof automationQueue.getBullQueue>)
+
+    await enableCronOrEmailTrigger("app_dev_123", automation)
+
+    expect(mockGetRepeatableJobs).toHaveBeenCalledTimes(1)
+
+    expect(mockRemoveRepeatableByKey).toHaveBeenCalledWith(
+      "repeat:legacy:123:::* * * * 0"
+    )
+    expect(mockRemoveRepeatableByKey).toHaveBeenCalledWith(
+      "repeat:legacy:123:::* * * * 1"
+    )
+    expect(mockRemoveRepeatableByKey).toHaveBeenCalledTimes(2)
+
+    expect(mockAdd).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ jobId: "app_dev_123_cron_mockid" })
+    )
+    expect(mockAdd).toHaveBeenCalledTimes(1)
+
+    expect(mockDoWithDB).toHaveBeenCalledTimes(1)
   })
 
   it("persists when a cron job id needs generated", async () => {

--- a/packages/server/src/automations/utils.ts
+++ b/packages/server/src/automations/utils.ts
@@ -26,6 +26,35 @@ if (automationsEnabled()) {
   Runner = new Thread(ThreadType.AUTOMATION)
 }
 
+function isLegacyRepeatableJobId(jobId?: string) {
+  return !!jobId?.startsWith("repeat:")
+}
+
+async function removeLegacyRepeatableJob(
+  legacyJobId: string,
+  appId: string,
+  automationId?: string
+) {
+  let count = 0
+  try {
+    const jobs = await automationQueue.getBullQueue().getRepeatableJobs()
+    for (let job of jobs) {
+      if (job.key.includes(legacyJobId)) {
+        await automationQueue.getBullQueue().removeRepeatableByKey(job.key)
+        count++
+      }
+    }
+  } catch (err) {
+    console.log("Failed to remove legacy repeatable job", {
+      appId,
+      automationId,
+      jobId: legacyJobId,
+      err,
+    })
+  }
+  return count
+}
+
 function loggingArgs(job: AutomationJob) {
   return [
     {
@@ -210,12 +239,18 @@ export function isRebootTrigger(auto: Automation) {
 export async function enableCronOrEmailTrigger(
   appId: string,
   automation: Automation
-) {
+): Promise<{
+  enabled: boolean
+  automation: Automation
+  clearedRepeatableJobs: number
+}> {
   const trigger = automation ? automation.definition.trigger : null
   let enabled = false
 
+  let clearedRepeatableJobs = 0
+
   if (!trigger || automation.disabled || isRebootTrigger(automation)) {
-    return { enabled, automation }
+    return { enabled, automation, clearedRepeatableJobs }
   }
 
   if (isCronTrigger(trigger)) {
@@ -229,7 +264,18 @@ export async function enableCronOrEmailTrigger(
     }
 
     const existingJobId = trigger.cronJobId
-    const jobId = existingJobId || `${appId}_cron_${utils.newid()}`
+    if (existingJobId && isLegacyRepeatableJobId(existingJobId)) {
+      const removedJobs = await removeLegacyRepeatableJob(
+        existingJobId,
+        appId,
+        automation._id
+      )
+      clearedRepeatableJobs += removedJobs
+    }
+    const jobId =
+      !existingJobId || isLegacyRepeatableJobId(existingJobId)
+        ? `${appId}_cron_${utils.newid()}`
+        : existingJobId
     await automationQueue.add(
       {
         automation,
@@ -249,7 +295,7 @@ export async function enableCronOrEmailTrigger(
     }
 
     enabled = true
-    return { enabled, automation }
+    return { enabled, automation, clearedRepeatableJobs }
   }
 
   if (isEmailTrigger(trigger)) {
@@ -259,10 +305,21 @@ export async function enableCronOrEmailTrigger(
         automationId: automation._id,
         appId,
       })
-      return { enabled: false, automation }
+      return { enabled: false, automation, clearedRepeatableJobs }
     }
     const existingJobId = trigger.cronJobId
-    const jobId = existingJobId || `${appId}_email_${utils.newid()}`
+    if (existingJobId && isLegacyRepeatableJobId(existingJobId)) {
+      const removedJobs = await removeLegacyRepeatableJob(
+        existingJobId,
+        appId,
+        automation._id
+      )
+      clearedRepeatableJobs += removedJobs
+    }
+    const jobId =
+      !existingJobId || isLegacyRepeatableJobId(existingJobId)
+        ? `${appId}_email_${utils.newid()}`
+        : existingJobId
     await automationQueue.add(
       {
         automation,
@@ -282,10 +339,10 @@ export async function enableCronOrEmailTrigger(
     }
 
     enabled = true
-    return { enabled, automation }
+    return { enabled, automation, clearedRepeatableJobs }
   }
 
-  return { enabled, automation }
+  return { enabled, automation, clearedRepeatableJobs }
 }
 
 function isValidEmailTriggerInputs(inputs: EmailTriggerInputs): boolean {


### PR DESCRIPTION
## Description
Some customers complained that some cron automations are running at unexpected times. After some research, we found an issue that caused old automations to not clean properly (the new ones have a different id shape that prevents this from happening).
This PR migrates (on publish) these ids to the new shape, removing any dangling jobs.
Also stops ghost runs when a workspace database no longer exists.
ase no longer exists.

- **Bug Fixes**
  - Detect legacy repeatable job IDs (repeat:...) and remove matching jobs from the Bull queue; create new per-app IDs (appId_cron_* / appId_email_*) and persist them.
  - During deploy, track and include the number of cleared repeatable jobs.
  - Disable cron by job ID if a repeat job runs and the workspace DB is missing.
  - Added tests to validate legacy ID migration and cleanup.

## Launchcontrol
Fixes an issue that caused cron automations to not be cleared properly on cron update.