### PR TITLE
feat: chat app styling update

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatApp.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatApp.svelte
@@ -222,22 +222,35 @@
   })
 </script>
 
-<ChatNavigationPanel
-  {enabledAgentList}
-  {conversationHistory}
-  selectedConversationId={$chatAppsStore.currentConversationId}
-  on:agentSelected={handleAgentSelected}
-  on:conversationSelected={handleConversationSelected}
-/>
+<div class="chat-app">
+  <ChatNavigationPanel
+    {enabledAgentList}
+    {conversationHistory}
+    selectedConversationId={$chatAppsStore.currentConversationId}
+    on:agentSelected={handleAgentSelected}
+    on:conversationSelected={handleConversationSelected}
+  />
 
-<ChatConversationPanel
-  bind:chat
-  {deletingChat}
-  {enabledAgentList}
-  {selectedAgentId}
-  {selectedAgentName}
-  {workspaceId}
-  on:deleteChat={deleteCurrentChat}
-  on:chatSaved={handleChatSaved}
-  on:agentSelected={handleAgentSelected}
-/>
+  <ChatConversationPanel
+    bind:chat
+    {deletingChat}
+    {enabledAgentList}
+    {selectedAgentId}
+    {selectedAgentName}
+    {workspaceId}
+    on:deleteChat={deleteCurrentChat}
+    on:chatSaved={handleChatSaved}
+    on:agentSelected={handleAgentSelected}
+  />
+</div>
+
+<style>
+  .chat-app {
+    display: flex;
+    flex: 1 1 auto;
+    align-items: stretch;
+    height: 100%;
+    width: 100%;
+    min-width: 0;
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatApp.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatApp.svelte
@@ -36,6 +36,11 @@
   let selectedAgentId: string | null = null
   let syncingAgentSelection = false
   let lastObservedAgentId: string | null = null
+  let enabledAgentList: {
+    agentId: string
+    name?: string
+    default?: boolean
+  }[] = []
 
   $: agents = $agentsStore.agents || []
   $: chatApp = $currentChatApp
@@ -49,13 +54,24 @@
     ? getAgentName(selectedAgentId) || "Unknown agent"
     : ""
 
-  $: enabledAgentList = enabledAgents
-    .map(agent => ({
-      agentId: agent.agentId,
-      name: getAgentName(agent.agentId),
-      default: agent.default,
-    }))
-    .filter(agent => Boolean(agent.name))
+  $: {
+    const baseAgentList = enabledAgents
+      .map(agent => ({
+        agentId: agent.agentId,
+        name: getAgentName(agent.agentId),
+        default: agent.default,
+      }))
+      .filter(agent => Boolean(agent.name))
+
+    const defaultAgent = baseAgentList.find(agent => agent.default)
+    const sortedAgents = baseAgentList
+      .filter(agent => !agent.default)
+      .sort((a, b) => (a.name || "").localeCompare(b.name || ""))
+
+    enabledAgentList = defaultAgent
+      ? [defaultAgent, ...sortedAgents]
+      : sortedAgents
+  }
 
   $: storeAgentId = $agentsStore.currentAgentId || null
   $: if (storeAgentId !== lastObservedAgentId) {

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatConversationPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatConversationPanel.svelte
@@ -42,7 +42,7 @@
   {#if selectedAgentId}
     <div class="chat-header">
       <div class="chat-header-agent">
-        <Body size="S" color="var(--spectrum-global-color-gray-700)">
+        <Body size="S">
           {selectedAgentName || "Unknown agent"}
         </Body>
       </div>
@@ -109,16 +109,25 @@
 
   .chat-header {
     width: 100%;
-    padding: var(--spacing-l) 0 var(--spacing-s);
+    padding: var(--spacing-l) 0 var(--spacing-l);
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: var(--spacing-m);
+    border-bottom: var(--border-light);
   }
 
   .chat-header-agent {
     display: flex;
     align-items: center;
+  }
+
+  .chat-header-agent :global(p) {
+    font-size: 14px;
+    line-height: 17px;
+    letter-spacing: 0;
+    font-weight: 400;
+    color: white;
   }
 
   .delete-button-content {

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatConversationPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatConversationPanel.svelte
@@ -103,12 +103,12 @@
     flex: 1 1 auto;
     display: flex;
     flex-direction: column;
+    padding: 0 32px;
+    box-sizing: border-box;
   }
 
   .chat-header {
-    width: 600px;
-    max-width: 100%;
-    margin: 0 auto;
+    width: 100%;
     padding: var(--spacing-l) 0 var(--spacing-s);
     display: flex;
     align-items: center;

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatNavigationPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatNavigationPanel.svelte
@@ -35,62 +35,72 @@
   }
 </script>
 
-<Panel customWidth={260} borderRight noHeaderBorder>
-  {#if defaultAgent?.agentId}
-    <div class="list-section">
-      <button
-        class="new-chat"
-        on:click={() => selectAgent(defaultAgent.agentId)}
-      >
-        <span class="new-chat-icon">
-          <Icon name="plus" size="S" />
-        </span>
-        <span class="new-chat-label">New chat</span>
-      </button>
-    </div>
-  {/if}
-
-  <div class="list-section">
-    <div class="list-title">Agents</div>
-    {#if enabledAgentList.length}
-      {#each enabledAgentList as agent (agent.agentId)}
+<div class="chat-nav-panel">
+  <Panel customWidth={260} borderRight noHeaderBorder>
+    {#if defaultAgent?.agentId}
+      <div class="list-section">
         <button
-          class="list-item list-item-button"
-          on:click={() => selectAgent(agent.agentId)}
+          class="new-chat"
+          on:click={() => selectAgent(defaultAgent.agentId)}
         >
-          {agent.name}
+          <span class="new-chat-icon">
+            <Icon name="plus" size="S" />
+          </span>
+          <span class="new-chat-label">New chat</span>
         </button>
-      {/each}
-    {:else}
-      <Body size="XS" color="var(--spectrum-global-color-gray-500)">
-        No agents
-      </Body>
+      </div>
     {/if}
-  </div>
 
-  <div class="list-section">
-    <div class="list-title">Recent Chats</div>
-    {#if conversationHistory.length}
-      {#each conversationHistory as conversation}
-        {#if conversation._id}
+    <div class="list-section">
+      <div class="list-title">Agents</div>
+      {#if enabledAgentList.length}
+        {#each enabledAgentList as agent (agent.agentId)}
           <button
             class="list-item list-item-button"
-            class:selected={selectedConversationId === conversation._id}
-            on:click={() => selectConversation(conversation._id!)}
+            on:click={() => selectAgent(agent.agentId)}
           >
-            {conversation.title || "Untitled Chat"}
+            {agent.name}
           </button>
-        {/if}
-      {/each}
-    {:else}
-      <Body size="XS" color="var(--spectrum-global-color-gray-500)">
-        No recent chats
-      </Body>
-    {/if}
-  </div>
-</Panel>
+        {/each}
+      {:else}
+        <Body size="XS" color="var(--spectrum-global-color-gray-500)">
+          No agents
+        </Body>
+      {/if}
+    </div>
+
+    <div class="list-section">
+      <div class="list-title">Recent Chats</div>
+      {#if conversationHistory.length}
+        {#each conversationHistory as conversation}
+          {#if conversation._id}
+            <button
+              class="list-item list-item-button"
+              class:selected={selectedConversationId === conversation._id}
+              on:click={() => selectConversation(conversation._id!)}
+            >
+              {conversation.title || "Untitled Chat"}
+            </button>
+          {/if}
+        {/each}
+      {:else}
+        <Body size="XS" color="var(--spectrum-global-color-gray-500)">
+          No recent chats
+        </Body>
+      {/if}
+    </div>
+  </Panel>
+</div>
 
 <style>
+  .chat-nav-panel {
+    display: flex;
+  }
+
+  :global(.chat-nav-panel .panel) {
+    background: transparent;
+  }
+
   .list-section {
     padding: var(--spacing-m);
     display: flex;

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatNavigationPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatNavigationPanel.svelte
@@ -37,57 +37,59 @@
 
 <div class="chat-nav-panel">
   <Panel customWidth={260} borderRight noHeaderBorder>
-    {#if defaultAgent?.agentId}
-      <div class="list-section">
-        <button
-          class="new-chat"
-          on:click={() => selectAgent(defaultAgent.agentId)}
-        >
-          <span class="new-chat-icon">
-            <Icon name="plus" size="S" />
-          </span>
-          <span class="new-chat-label">New chat</span>
-        </button>
-      </div>
-    {/if}
-
-    <div class="list-section">
-      <div class="list-title">Agents</div>
-      {#if enabledAgentList.length}
-        {#each enabledAgentList as agent (agent.agentId)}
+    <div class="chat-nav-content">
+      {#if defaultAgent?.agentId}
+        <div class="list-section">
           <button
-            class="list-item list-item-button"
-            on:click={() => selectAgent(agent.agentId)}
+            class="new-chat"
+            on:click={() => selectAgent(defaultAgent.agentId)}
           >
-            {agent.name}
+            <span class="new-chat-icon">
+              <Icon name="plus" size="S" />
+            </span>
+            <span class="new-chat-label">New chat</span>
           </button>
-        {/each}
-      {:else}
-        <Body size="XS" color="var(--spectrum-global-color-gray-500)">
-          No agents
-        </Body>
+        </div>
       {/if}
-    </div>
 
-    <div class="list-section">
-      <div class="list-title">Recent Chats</div>
-      {#if conversationHistory.length}
-        {#each conversationHistory as conversation}
-          {#if conversation._id}
+      <div class="list-section">
+        <div class="list-title">Agents</div>
+        {#if enabledAgentList.length}
+          {#each enabledAgentList as agent (agent.agentId)}
             <button
               class="list-item list-item-button"
-              class:selected={selectedConversationId === conversation._id}
-              on:click={() => selectConversation(conversation._id!)}
+              on:click={() => selectAgent(agent.agentId)}
             >
-              {conversation.title || "Untitled Chat"}
+              {agent.name}
             </button>
-          {/if}
-        {/each}
-      {:else}
-        <Body size="XS" color="var(--spectrum-global-color-gray-500)">
-          No recent chats
-        </Body>
-      {/if}
+          {/each}
+        {:else}
+          <Body size="XS" color="var(--spectrum-global-color-gray-500)">
+            No agents
+          </Body>
+        {/if}
+      </div>
+
+      <div class="list-section">
+        <div class="list-title">Recent Chats</div>
+        {#if conversationHistory.length}
+          {#each conversationHistory as conversation}
+            {#if conversation._id}
+              <button
+                class="list-item list-item-button"
+                class:selected={selectedConversationId === conversation._id}
+                on:click={() => selectConversation(conversation._id!)}
+              >
+                {conversation.title || "Untitled Chat"}
+              </button>
+            {/if}
+          {/each}
+        {:else}
+          <Body size="XS" color="var(--spectrum-global-color-gray-500)">
+            No recent chats
+          </Body>
+        {/if}
+      </div>
     </div>
   </Panel>
 </div>
@@ -95,6 +97,12 @@
 <style>
   .chat-nav-panel {
     display: flex;
+  }
+
+  .chat-nav-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xl);
   }
 
   :global(.chat-nav-panel .panel) {
@@ -176,11 +184,11 @@
   }
 
   .list-title {
-    font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--spectrum-global-color-gray-500);
-    font-weight: 600;
+    font-size: 14px;
+    line-height: 17px;
+    letter-spacing: 0;
+    color: var(--spectrum-global-color-gray-600);
+    font-weight: 400;
     margin-bottom: var(--spacing-xs);
   }
 </style>

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/index.svelte
@@ -136,7 +136,7 @@
     margin: var(--spacing-xl);
     border-radius: 24px;
     border: var(--border-light);
-    background: var(--background);
+    background: transparent;
     overflow: hidden;
     min-width: 0;
   }

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/index.svelte
@@ -103,7 +103,9 @@
     />
 
     {#if $params.application}
-      <ChatApp workspaceId={$params.application} />
+      <div class="chat-app-container">
+        <ChatApp workspaceId={$params.application} />
+      </div>
     {/if}
   </div>
 </div>
@@ -126,5 +128,16 @@
     height: 0;
     width: 100%;
     align-items: stretch;
+  }
+
+  .chat-app-container {
+    flex: 1 1 auto;
+    display: flex;
+    margin: var(--spacing-xl);
+    border-radius: 24px;
+    border: var(--border-light);
+    background: var(--background);
+    overflow: hidden;
+    min-width: 0;
   }
 </style>

--- a/packages/frontend-core/src/components/Chatbox/index.svelte
+++ b/packages/frontend-core/src/components/Chatbox/index.svelte
@@ -383,8 +383,7 @@
     display: flex;
     flex-direction: column;
     gap: 24px;
-    width: 600px;
-    margin: 0 auto;
+    width: 100%;
     flex: 1 1 auto;
     padding: 48px 0 24px 0;
   }
@@ -419,8 +418,7 @@
   .input-wrapper {
     position: sticky;
     bottom: 0;
-    width: 600px;
-    margin: 0 auto;
+    width: 100%;
     background: var(--background-alt);
     padding-bottom: 32px;
     display: flex;


### PR DESCRIPTION
## Description
* styling tweaks to the Chat App to bring it much closer to design

## Screenshot

<img width="2400" height="1614" alt="image" src="https://github.com/user-attachments/assets/aaebc7a3-65a6-4ec2-8afa-dc9452702803" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the Chat App UI to match the latest design. Fixed agent ordering so the default agent is first and others are sorted A–Z.

- **Bug Fixes**
  - Wrapped ChatApp in a flexible, bordered, rounded container; panels now stretch full height.
  - Navigation panel: transparent background, updated spacing, and refined list title typography.
  - Conversation panel header: full width with padding, border-bottom, and corrected text color.
  - Removed fixed 600px widths in Chatbox content and input; use 100% width for responsiveness.

<sup>Written for commit 9fb250b3cea6ea1d9212b5177f73dfd23c729b24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

