### PR TITLE
feat: generate convo summary with llm

### DIFF
--- a/packages/server/src/tests/api/chatConversations.spec.ts
+++ b/packages/server/src/tests/api/chatConversations.spec.ts
@@ -8,7 +8,10 @@ import type {
 import TestConfiguration from "../utilities/TestConfiguration"
 import {
   findLatestUserQuestion,
+  getUserMessageTexts,
   prepareChatConversationForSave,
+  shouldRegenerateTitle,
+  stripThoughtTags,
   truncateTitle,
 } from "../../api/controllers/ai/chatConversations"
 
@@ -235,6 +238,46 @@ describe("chat conversation title helpers", () => {
     }
 
     expect(findLatestUserQuestion(chat)).toBe("latest question")
+  })
+
+  it("collects user message text", () => {
+    const chat: ChatConversationRequest = {
+      ...baseChat,
+      messages: [
+        {
+          id: "message-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "assistant reply" }],
+        },
+        {
+          id: "message-2",
+          role: "user",
+          parts: [{ type: "text", text: "first question" }],
+        },
+        {
+          id: "message-3",
+          role: "user",
+          parts: [{ type: "text", text: "second question" }],
+        },
+      ],
+    }
+
+    expect(getUserMessageTexts(chat.messages)).toEqual([
+      "first question",
+      "second question",
+    ])
+  })
+
+  it("regenerates titles at the interval", () => {
+    expect(shouldRegenerateTitle(2)).toBe(false)
+    expect(shouldRegenerateTitle(3)).toBe(true)
+    expect(shouldRegenerateTitle(6)).toBe(false)
+  })
+
+  it("strips thought tags", () => {
+    expect(stripThoughtTags("<think>draft</think>Hello Chat")).toBe(
+      "Hello Chat"
+    )
   })
 
   it("truncates titles with an ellipsis", () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Generate conversation titles with an LLM based on recent user messages, with safe thought-tag stripping and truncation. Titles update on the 3rd user message and fall back to the first user message for early chats.

- **New Features**
  - Regenerate title on every 3rd user message using the last 3 user messages and the previous title.
  - Sanitize model output by stripping <think> tags and truncate to 120 chars.
  - Fallback to the first user message (truncated) when fewer than 3 user messages or when generation returns empty.

- **Refactors**
  - Added helpers: getUserMessageTexts, shouldRegenerateTitle, stripThoughtTags.
  - Reused a wrapped model with reasoning extraction for both streaming and title generation.
  - Added unit tests for new helpers and title logic.

<sup>Written for commit 532f3b9d8ce5e6cd3a7ecd12f212b5faf89fff9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

