### PR TITLE
Remove bcryptjs fallback

### DIFF
--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -43,7 +43,6 @@
     "aws-cloudfront-sign": "3.0.2",
     "aws-sdk": "2.1692.0",
     "bcrypt": "6.0.0",
-    "bcryptjs": "3.0.3",
     "bull": "4.10.1",
     "correlation-id": "4.0.0",
     "csvtojson": "2.0.10",

--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -153,7 +153,6 @@ const environment = {
     return !isDev()
   },
   BUDIBASE_ENVIRONMENT: process.env.BUDIBASE_ENVIRONMENT,
-  JS_BCRYPT: process.env.JS_BCRYPT,
   JWT_SECRET: process.env.JWT_SECRET
     ? createSecretKey(process.env.JWT_SECRET, "utf8")
     : undefined,

--- a/packages/backend-core/src/utils/hashing.ts
+++ b/packages/backend-core/src/utils/hashing.ts
@@ -1,7 +1,7 @@
 import env from "../environment"
 
 export * from "../docIds/newid"
-const bcrypt = env.JS_BCRYPT ? require("bcryptjs") : require("bcrypt")
+const bcrypt = require("bcrypt")
 
 const SALT_ROUNDS = env.SALT_ROUNDS || 10
 

--- a/packages/cli/src/environment.ts
+++ b/packages/cli/src/environment.ts
@@ -1,4 +1,3 @@
 process.env.DISABLE_PINO_LOGGER = "1"
 process.env.NO_JS = "1"
-process.env.JS_BCRYPT = "1"
 process.env.DISABLE_JWT_WARNING = "1"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -70,7 +70,6 @@
     "arangojs": "7.2.0",
     "archiver": "7.0.1",
     "bcrypt": "6.0.0",
-    "bcryptjs": "3.0.3",
     "bson": "^6.9.0",
     "buffer": "6.0.3",
     "bull": "4.10.1",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -39,7 +39,6 @@
     "@types/global-agent": "2.1.1",
     "aws-sdk": "2.1692.0",
     "bcrypt": "6.0.0",
-    "bcryptjs": "3.0.3",
     "bull": "4.10.1",
     "dd-trace": "5.63.0",
     "dotenv": "8.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9756,11 +9756,6 @@ bcrypt@6.0.0:
     node-addon-api "^8.3.0"
     node-gyp-build "^4.8.4"
 
-bcryptjs@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/bcryptjs/-/bcryptjs-3.0.3.tgz#4b93d6a398c48bfc9f32ee65d301174a8a8ea56f"
-  integrity sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==
-
 before-after-hook@^2.2.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.3.tgz#c51e809c81a4e354084422b9b26bad88249c517c"


### PR DESCRIPTION
## Description
Remove the bcryptjs fallback and JS_BCRYPT toggle so hashing consistently uses native bcrypt; drop bcryptjs dependencies.

CLI does not use hasing utils, so remove the unnecessary bcryptjs dependency.

## Launchcontrol
Use native bcrypt everywhere and remove bcryptjs fallback dependencies.