### PR TITLE
Update lodash to 4.17.23

### DIFF
--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -58,7 +58,7 @@
     "koa-passport": "^6.0.0",
     "koa-pino-logger": "4.0.0",
     "@koa/router": "13.1.0",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "node-fetch": "2.6.7",
     "object-sizeof": "2.6.1",
     "passport-google-oauth": "2.0.0",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -72,7 +72,7 @@
     "dayjs": "^1.10.8",
     "downloadjs": "1.4.7",
     "fast-json-patch": "^3.1.1",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "marked": "^15.0.8",
     "posthog-js": "^1.118.0",
     "remixicon": "2.5.0",

--- a/packages/frontend-core/package.json
+++ b/packages/frontend-core/package.json
@@ -14,7 +14,7 @@
     "@budibase/types": "*",
     "ai": "^6.0.3",
     "dayjs": "^1.10.8",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "shortid": "2.2.15",
     "socket.io-client": "^4.7.5"
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -103,7 +103,7 @@
     "koa-send": "5.0.1",
     "koa-useragent": "^4.1.0",
     "koa2-ratelimit": "1.1.1",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "mailparser": "^3.7.2",
     "memorystream": "0.3.1",
     "mongodb": "6.7.0",

--- a/packages/upgrade-tests/package.json
+++ b/packages/upgrade-tests/package.json
@@ -25,7 +25,7 @@
     "@budibase/types": "*",
     "chalk": "^4.1.2",
     "commander": "^11.0.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.23",
     "ora": "^5.4.1",
     "semver": "^7.5.4",
     "uuid": "^9.0.1"

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -58,7 +58,7 @@
     "koa-session": "5.13.1",
     "koa-static": "5.0.0",
     "koa-useragent": "^4.1.0",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "marked": "^15.0.11",
     "node-fetch": "2.6.7",
     "nodemailer": "7.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17248,7 +17248,12 @@ lodash.xor@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.xor/-/lodash.xor-4.5.0.tgz#4d48ed7e98095b0632582ba714d3ff8ae8fb1db6"
   integrity sha512-sVN2zimthq7aZ5sPGXnSz32rZPuqcparVW50chJQe+mzTYV+IsxSsl/2gnkWWE2Of7K3myBQBqtLKOUEHJKRsQ==
 
-lodash@4.17.21, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.3, lodash@^4.7.0:
+lodash@4.17.23, lodash@^4.17.23:
+  version "4.17.23"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
+  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+
+lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.3, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
## Description
Dependabot related


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped lodash to 4.17.23 across the monorepo to pick up recent fixes and security updates. No runtime or API changes expected.

- **Dependencies**
  - Updated lodash to 4.17.23 in backend-core, builder, frontend-core, server, upgrade-tests, and worker; refreshed yarn.lock.

<sup>Written for commit c07ecb78e993579da24aa96592cc335a5f7d9768. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

