### PR TITLE
chore: upgrade to database:2.0.0

### DIFF
--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -98,7 +98,7 @@ services:
 
   couchdb-service:
     restart: unless-stopped
-    image: budibase/couchdb:v3.3.3-sqs-v2.1.1
+    image: budibase/couchdb:v4-sqs-v2.1.1
     environment:
       - COUCHDB_PASSWORD=${COUCH_DB_PASSWORD}
       - COUCHDB_USER=${COUCH_DB_USER}

--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -98,7 +98,7 @@ services:
 
   couchdb-service:
     restart: unless-stopped
-    image: budibase/couchdb:v4-sqs-v2.1.1
+    image: budibase/database:2.0.0
     environment:
       - COUCHDB_PASSWORD=${COUCH_DB_PASSWORD}
       - COUCHDB_USER=${COUCH_DB_USER}


### PR DESCRIPTION
## Description
Updates the recommended compose setup to CouchDB's V2 image.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the recommended docker-compose to use the new database image (budibase/database:2.0.0) for the couchdb-service. This standardizes deployments on 2.0.0 and prepares the hosting stack for future updates.

<sup>Written for commit 4d9026b37e769017d2a9fd0845f48ff5663ebf96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



