### PR TITLE
Create new LiteLLM virtual keys on a workspace level

### DIFF
--- a/packages/backend-core/src/docIds/ids.ts
+++ b/packages/backend-core/src/docIds/ids.ts
@@ -145,6 +145,10 @@ export const generateAIConfigID = () => {
   return `${DocumentType.AI_CONFIG}${SEPARATOR}${newid()}`
 }
 
+export const getLiteLLMKeyID = () => {
+  return `${DocumentType.LITELLM_KEY}${SEPARATOR}config`
+}
+
 export const generateRagConfigID = () => {
   return `${DocumentType.RAG_CONFIG}${SEPARATOR}${newid()}`
 }

--- a/packages/builder/src/settings/pages/ai/ConfigModal.svelte
+++ b/packages/builder/src/settings/pages/ai/ConfigModal.svelte
@@ -63,6 +63,7 @@
         placeholder={config.provider ? "Choose an option" : "Select a provider"}
         bind:value={config.defaultModel}
         options={Models}
+        autoWidth
       />
     </div>
   {/if}

--- a/packages/server/src/api/routes/tests/ai/aiConfig.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/aiConfig.spec.ts
@@ -251,15 +251,14 @@ describe("BudibaseAI", () => {
       expect(configsResponse).toHaveLength(0)
     })
 
-    it("validates configuration", async () => {
+    it("validates wrong configuration", async () => {
       const failingScope = nock(environment.LITELLM_URL)
-        .post("/key/generate")
-        .reply(200, { token_id: "key-4", key: "secret-4" })
         .post("/health/test_connection")
         .reply(200, {
           status: "error",
           result: {
-            error: "Connection refused\nTraceback...",
+            error:
+              'OpenrouterException - {"error":{"message":"qwen/qwen3-3 is not a valid model ID","code":400},"user_id":"org_37yduZHaFSi1UlK66P4A04N0jd2"}',
           },
         })
 
@@ -274,7 +273,9 @@ describe("BudibaseAI", () => {
       )
 
       expect(failingScope.isDone()).toBe(true)
-      expect(errorResponse.message).toContain("Error validating configuration")
+      expect(errorResponse.message).toEqual(
+        'Error validating configuration: OpenrouterException - {"error":{"message":"qwen/qwen3-3 is not a valid model ID","code":400},"user_id":"org_37yduZHaFSi1UlK66P4A04N0jd2"}'
+      )
 
       const configsResponse = await config.api.ai.fetchConfigs()
       expect(configsResponse).toHaveLength(0)

--- a/packages/server/src/sdk/workspace/ai/configs/index.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/index.ts
@@ -47,7 +47,7 @@ async function ensureLiteLLMConfigured(): Promise<LiteLLMKeyConfig> {
 
   let keyConfig = await db.tryGet<LiteLLMKeyConfig>(keyDocId)
   if (!keyConfig?.keyId) {
-    const workspaceId = context.getWorkspaceId()
+    const workspaceId = context.getProdWorkspaceId()
     if (!workspaceId) {
       throw new HTTPError("Workspace ID is required to configure LiteLLM", 400)
     }

--- a/packages/server/src/sdk/workspace/ai/configs/index.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/index.ts
@@ -168,7 +168,7 @@ export async function getLiteLLMModelConfigOrThrow(configId: string): Promise<{
     throw new HTTPError("Config not found", 400)
   }
 
-  const secretKey = await liteLLM.getSecretKey()
+  const { secretKey } = await liteLLM.getKeySettings()
   if (!secretKey) {
     throw new HTTPError(
       "LiteLLM should be configured. Contact support if the issue persists.",

--- a/packages/server/src/sdk/workspace/ai/configs/litellm.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/litellm.ts
@@ -255,9 +255,7 @@ export async function validateConfig(model: {
 }
 
 export async function syncKeyModels() {
-  // Always use the dev workspace DB for the LiteLLM key so that
-  // the same key is used for both dev and published apps
-  const db = context.getDevWorkspaceDB()
+  const db = context.getWorkspaceDB()
   const keyDocId = docIds.getLiteLLMKeyID()
   const keyConfig = await db.tryGet<LiteLLMKeyConfig>(keyDocId)
 

--- a/packages/types/src/documents/document.ts
+++ b/packages/types/src/documents/document.ts
@@ -45,6 +45,7 @@ export enum DocumentType {
   AGENT_TOOL_SOURCE = "agenttoolsource",
   AGENT_FILE = "agentfile",
   AI_CONFIG = "aiconfig",
+  LITELLM_KEY = "litellmkey",
   RAG_CONFIG = "ragconfig",
   VECTOR_STORE = "vectordb",
   WORKSPACE_APP = "workspace_app",

--- a/packages/types/src/documents/global/ai.ts
+++ b/packages/types/src/documents/global/ai.ts
@@ -15,3 +15,8 @@ export interface CustomAIProviderConfig extends Document {
   webSearchConfig?: WebSearchConfig
   configType: AIConfigType
 }
+
+export interface LiteLLMKeyConfig extends Document {
+  keyId: string
+  secretKey: string
+}

--- a/packages/types/src/sdk/locks.ts
+++ b/packages/types/src/sdk/locks.ts
@@ -23,6 +23,7 @@ export enum LockName {
   WORKSPACE_MIGRATION = "app_migrations",
   PROCESS_USER_INVITE = "process_user_invite",
   SQS_SYNC_DEFINITIONS = "sys_sync_definitions",
+  LITELLM_KEY = "litellm_key",
 }
 
 export type LockOptions = {


### PR DESCRIPTION
## Description
Store LiteLLM virtual keys per workspace, using the dev workspace DB so dev and published apps share the same key. Removes reliance on global settings and updates key generation, storage, and model sync to use the workspace key.

- **New Features**
  - Added LITELLM_KEY document type and a stable key ID (litellmkey::config).
  - Persisted LiteLLMKeyConfig (keyId, secretKey) in the dev workspace DB; auto-creates if missing.
  - Generate keys using the prod workspace ID and sync models with the workspace key.
  - Ensures one key is used across dev and published apps.

<sup>Written for commit 4590e05b02ac9def65f57062038f1ced12f8b94f. Summary will update on new commits.</sup>

