### PR TITLE
Scroll chat preview

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
@@ -167,6 +167,7 @@
   .config-preview {
     flex: 1 1 auto;
     border-left: 1px solid var(--spectrum-global-color-gray-200);
+    overflow-y: scroll;
   }
 
   .config-form {


### PR DESCRIPTION
## Description
UI fix, to enable scrolling on agent chat preview

https://github.com/user-attachments/assets/01040294-59d9-4b21-a781-1404b3617522



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled vertical scrolling in the agent chat preview so long conversations are readable and no content is cut off. Applied overflow-y: scroll to the config-preview container.

<sup>Written for commit a37d4b50addb4d2cc506de2b22a2194f0e480b43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

