### PR TITLE
Small fixes for agent config / output viewing

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/ChainOfThoughtModal.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/ChainOfThoughtModal.svelte
@@ -392,10 +392,17 @@
     flex-direction: column;
   }
 
+  .tabs-container :global(.spectrum-Tabs-content) {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+  }
+
   .tab-content {
     padding: var(--spacing-m) 0;
     overflow: auto;
     flex: 1;
+    min-height: 0;
   }
 
   .empty-state {

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
@@ -730,11 +730,6 @@
 />
 
 <style>
-  .section:first-of-type {
-    flex: 1;
-    min-height: 0;
-  }
-
   .tools-section {
     flex-shrink: 0;
     margin-bottom: calc(-1 * var(--spacing-l));
@@ -754,10 +749,9 @@
   }
 
   .prompt-editor-wrapper {
-    flex: 1;
     display: flex;
     flex-direction: column;
-    min-height: 0;
+    max-height: 500px;
     border: 1px solid var(--spectrum-global-color-gray-200);
     border-radius: 8px;
     overflow: hidden;
@@ -766,7 +760,7 @@
   .prompt-editor {
     flex: 1;
     min-height: 0;
-    overflow: hidden;
+    overflow-y: auto;
   }
 
   .prompt-editor :global(.cm-editor) {

--- a/packages/builder/src/settings/pages/ai/CustomConfigModal.svelte
+++ b/packages/builder/src/settings/pages/ai/CustomConfigModal.svelte
@@ -68,9 +68,6 @@
   }, {})
   $: selectedProvider = providersMap?.[draft.provider]
 
-  $: modelPlaceholder =
-    selectedProvider?.defaultModelPlaceholder || "gpt-4o-mini"
-
   onMount(async () => {
     try {
       await aiConfigsStore.fetchProviders()
@@ -80,6 +77,9 @@
   })
 
   async function confirm() {
+    draft.name = draft.name.trim()
+    draft.model = draft.model.trim()
+
     try {
       if (draft._id) {
         await aiConfigsStore.updateConfig(draft)
@@ -173,7 +173,7 @@
 
   <div class="row">
     <Label size="M">Model</Label>
-    <Input placeholder={modelPlaceholder} bind:value={draft.model} />
+    <Input bind:value={draft.model} />
   </div>
 
   {#each selectedProvider?.credentialFields as field (field.key)}

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -18,6 +18,7 @@ import {
   convertToModelMessages,
   extractReasoningMiddleware,
   ModelMessage,
+  stepCountIs,
   streamText,
   wrapLanguageModel,
 } from "ai"
@@ -278,6 +279,7 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
       messages: messagesWithContext,
       system,
       tools,
+      stopWhen: stepCountIs(30),
     })
 
     const title = latestQuestion ? truncateTitle(latestQuestion) : chat.title

--- a/packages/server/src/sdk/workspace/ai/configs/index.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/index.ts
@@ -194,8 +194,6 @@ export async function fetchLiteLLMProviders(): Promise<LLMProvider[]> {
         id: provider.provider,
         displayName: provider.provider_display_name,
         externalProvider: provider.litellm_provider,
-        defaultModelPlaceholder:
-          provider.default_model_placeholder ?? undefined,
         credentialFields: provider.credential_fields.map(f => {
           const field: RequiredKeys<LLMProviderField> = {
             key: f.key,

--- a/packages/types/src/api/web/global/aiConfigs.ts
+++ b/packages/types/src/api/web/global/aiConfigs.ts
@@ -22,7 +22,6 @@ export interface LLMProvider {
   id: string
   displayName: string
   externalProvider: string
-  defaultModelPlaceholder?: string
   credentialFields: LLMProviderField[]
 }
 


### PR DESCRIPTION
## Description
- Fixes an issue where the agent output would overflow the container in the agent output viewer
- Trim whitespace on agent config
- Get rid of model placeholder.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix output overflow in agent views and the instructions editor, and streamline the AI config modal. Add multi-step agent chat (up to 30 steps) and remove the provider model placeholder.

- **Bug Fixes**
  - Tabs/content in the agent output viewer and instructions editor now flex and scroll correctly to prevent overflow.
  - Trim whitespace for config name and model before saving.

<sup>Written for commit 6b6e68235ee39c932a7f48298453c7f42efffa70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

