### PR TITLE
Refactor chatbox to use useChat from ai sdk

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/AgentChatPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/AgentChatPanel.svelte
@@ -61,11 +61,7 @@
   </div>
   <div class="chat-preview-body">
     {#key refreshKey}
-      <Chatbox
-        bind:chat
-        persistConversation={false}
-        {workspaceId}
-      />
+      <Chatbox bind:chat persistConversation={false} {workspaceId} />
     {/key}
   </div>
 </div>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/AgentChatPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/AgentChatPanel.svelte
@@ -63,7 +63,6 @@
     {#key refreshKey}
       <Chatbox
         bind:chat
-        loading={false}
         persistConversation={false}
         {workspaceId}
       />

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatConversationPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatConversationPanel.svelte
@@ -70,7 +70,7 @@
     <Chatbox
       bind:chat
       {workspaceId}
-      onchatSaved={event => dispatch("chatSaved", event.detail)}
+      onChatSaved={event => dispatch("chatSaved", event.detail)}
     />
   {:else}
     <div class="chat-empty">

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatConversationPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatConversationPanel.svelte
@@ -69,9 +69,8 @@
 
     <Chatbox
       bind:chat
-      {loading}
       {workspaceId}
-      on:chatSaved={event => dispatch("chatSaved", event.detail)}
+      onchatSaved={event => dispatch("chatSaved", event.detail)}
     />
   {:else}
     <div class="chat-empty">

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatConversationPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatConversationPanel.svelte
@@ -70,7 +70,7 @@
     <Chatbox
       bind:chat
       {workspaceId}
-      onChatSaved={event => dispatch("chatSaved", event.detail)}
+      onchatsaved={event => dispatch("chatSaved", event.detail)}
     />
   {:else}
     <div class="chat-empty">

--- a/packages/frontend-core/package.json
+++ b/packages/frontend-core/package.json
@@ -9,6 +9,7 @@
     "check:types": "yarn svelte-check"
   },
   "dependencies": {
+    "@ai-sdk/svelte": "^4.0.48",
     "@budibase/bbui": "*",
     "@budibase/shared-core": "*",
     "@budibase/types": "*",

--- a/packages/frontend-core/src/components/Chatbox/index.svelte
+++ b/packages/frontend-core/src/components/Chatbox/index.svelte
@@ -12,6 +12,7 @@
   import { Chat } from "@ai-sdk/svelte"
   import {
     DefaultChatTransport,
+    isTextUIPart,
     isToolUIPart,
     isReasoningUIPart,
     getToolName,
@@ -261,23 +262,21 @@
       {#if message.role === "user"}
         <div class="message user">
           <MarkdownViewer
-            value={message.parts && message.parts.length > 0
-              ? message.parts
-                  .filter(part => part.type === "text")
-                  .map(part => (part.type === "text" ? part.text : ""))
-                  .join("")
-              : "[Empty message]"}
+            value={message.parts
+              ?.filter(isTextUIPart)
+              .map(p => p.text)
+              .join("") || "[Empty message]"}
           />
         </div>
       {:else if message.role === "assistant"}
         <div class="message assistant">
           {#each message.parts || [] as part, partIndex (partIndex)}
-            {#if part.type === "text"}
-              <MarkdownViewer value={part.text || ""} />
+            {#if isTextUIPart(part)}
+              <MarkdownViewer value={part.text} />
             {:else if isReasoningUIPart(part)}
               <div class="reasoning-part">
                 <div class="reasoning-label">Reasoning</div>
-                <div class="reasoning-content">{part.text || ""}</div>
+                <div class="reasoning-content">{part.text}</div>
               </div>
             {:else if isToolUIPart(part)}
               {@const toolId = `${message.id}-${getToolName(part)}-${partIndex}`}

--- a/packages/frontend-core/src/components/Chatbox/index.svelte
+++ b/packages/frontend-core/src/components/Chatbox/index.svelte
@@ -46,34 +46,20 @@
   let resolvedChatAppId: string | undefined
   let resolvedConversationId: string | undefined
 
-  const getApiUrl = () => {
-    const chatAppId = resolvedChatAppId || chat?.chatAppId
-    const conversationId = resolvedConversationId || chat?._id || "new"
-    return `/api/chatapps/${chatAppId}/conversations/${conversationId}/stream`
-  }
-
-  const getBody = () => ({
-    _id: resolvedConversationId || chat?._id,
-    chatAppId: resolvedChatAppId || chat?.chatAppId,
-    agentId: chat?.agentId,
-    transient: !persistConversation,
-    title: chat?.title,
-  })
-
-  // Create the Chat instance with transport
   const chatInstance = new Chat<UIMessage<AgentMessageMetadata>>({
     transport: new DefaultChatTransport({
-      api: "/api/chat", // Default, will be overridden by prepareSendMessagesRequest
-      headers: () => ({
-        [Header.APP_ID]: workspaceId,
-      }),
-      body: () => getBody(),
-      prepareSendMessagesRequest: ({ messages, body: existingBody }) => {
+      headers: () => ({ [Header.APP_ID]: workspaceId }),
+      prepareSendMessagesRequest: ({ messages }) => {
+        const chatAppId = resolvedChatAppId || chat?.chatAppId
+        const conversationId = resolvedConversationId || chat?._id || "new"
         return {
-          api: getApiUrl(),
+          api: `/api/chatapps/${chatAppId}/conversations/${conversationId}/stream`,
           body: {
-            ...existingBody,
-            ...getBody(),
+            _id: resolvedConversationId || chat?._id,
+            chatAppId,
+            agentId: chat?.agentId,
+            transient: !persistConversation,
+            title: chat?.title,
             messages,
           },
         }

--- a/packages/frontend-core/src/components/Chatbox/index.svelte
+++ b/packages/frontend-core/src/components/Chatbox/index.svelte
@@ -140,6 +140,14 @@
     return undefined
   }
 
+  // Sync chatInstance messages when chat prop changes
+  let lastChatId: string | undefined = chat?._id
+  $: if (chat?._id !== lastChatId) {
+    lastChatId = chat?._id
+    chatInstance.messages = chat?.messages || []
+    expandedTools = {}
+  }
+
   $: messages = chatInstance.messages
   $: isStreaming = chatInstance.status === "streaming"
   $: showLoading = loading || isStreaming
@@ -285,7 +293,10 @@
                   class="tool-header"
                   type="button"
                   on:click={() => {
-                    expandedTools[toolId] = !expandedTools[toolId]
+                    expandedTools = {
+                      ...expandedTools,
+                      [toolId]: !expandedTools[toolId],
+                    }
                   }}
                 >
                   <span

--- a/packages/frontend-core/src/components/Chatbox/index.svelte
+++ b/packages/frontend-core/src/components/Chatbox/index.svelte
@@ -30,7 +30,7 @@
     workspaceId: string
     chat: ChatConversationLike
     persistConversation?: boolean
-    onchatSaved?: (_event: {
+    onchatsaved?: (_event: {
       detail: { chatId?: string; chat: ChatConversationLike }
     }) => void
   }
@@ -39,7 +39,7 @@
     workspaceId,
     chat = $bindable(),
     persistConversation = true,
-    onchatSaved,
+    onchatsaved,
   }: Props = $props()
 
   let API = $state(
@@ -101,7 +101,7 @@
       }
 
       chat = { ...chat, messages: chatInstance.messages }
-      onchatSaved?.({ detail: { chatId: chat._id, chat } })
+      onchatsaved?.({ detail: { chatId: chat._id, chat } })
 
       await tick()
       textareaElement?.focus()

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,15 @@
   resolved "https://registry.yarnpkg.com/@adobe/spectrum-css-workflow-icons/-/spectrum-css-workflow-icons-1.2.1.tgz#7e2cb3fcfb5c8b12d7275afafbb6ec44913551b4"
   integrity sha512-uVgekyBXnOVkxp+CUssjN/gefARtudZC8duEn1vm0lBQFwGRZFlDEzU1QC+aIRWCrD1Z8OgRpmBYlSZ7QS003w==
 
+"@ai-sdk/gateway@3.0.22":
+  version "3.0.22"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/gateway/-/gateway-3.0.22.tgz#96836072096ead43f046192c29be188109a5bec6"
+  integrity sha512-NgnlY73JNuooACHqUIz5uMOEWvqR1MMVbb2soGLMozLY1fgwEIF5iJFDAGa5/YArlzw2ATVU7zQu7HkR/FUjgA==
+  dependencies:
+    "@ai-sdk/provider" "3.0.5"
+    "@ai-sdk/provider-utils" "4.0.9"
+    "@vercel/oidc" "3.1.0"
+
 "@ai-sdk/gateway@3.0.4":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@ai-sdk/gateway/-/gateway-3.0.4.tgz#623d3581c659457ba32f85d96ae5039a5c0ca856"
@@ -38,12 +47,36 @@
     "@standard-schema/spec" "^1.1.0"
     eventsource-parser "^3.0.6"
 
+"@ai-sdk/provider-utils@4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-4.0.9.tgz#f15d6ed31fca8aeca402fa56278659a20581057e"
+  integrity sha512-bB4r6nfhBOpmoS9mePxjRoCy+LnzP3AfhyMGCkGL4Mn9clVNlqEeKj26zEKEtB6yoSVcT1IQ0Zh9fytwMCDnow==
+  dependencies:
+    "@ai-sdk/provider" "3.0.5"
+    "@standard-schema/spec" "^1.1.0"
+    eventsource-parser "^3.0.6"
+
 "@ai-sdk/provider@3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-3.0.1.tgz#5bd8809910fc401f024c7784a77eb116171d0296"
   integrity sha512-2lR4w7mr9XrydzxBSjir4N6YMGdXD+Np1Sh0RXABh7tWdNFFwIeRI1Q+SaYZMbfL8Pg8RRLcrxQm51yxTLhokg==
   dependencies:
     json-schema "^0.4.0"
+
+"@ai-sdk/provider@3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-3.0.5.tgz#730c5acdc4f074c877a547c1492fafc81bdc4f53"
+  integrity sha512-2Xmoq6DBJqmSl80U6V9z5jJSJP7ehaJJQMy2iFUqTay06wdCqTnPVBBQbtEL8RCChenL+q5DC5H5WzU3vV3v8w==
+  dependencies:
+    json-schema "^0.4.0"
+
+"@ai-sdk/svelte@^4.0.48":
+  version "4.0.48"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/svelte/-/svelte-4.0.48.tgz#efcd7f0787b7881453988bc1d0a7181d90b7b83e"
+  integrity sha512-669EcXhiRkw+dtLe1hRgv5MjjezR87u7wmRyU+azcnUnAl0w6NXRX47jxQVZlV6NJFMPukuKP29munU0sxF8zw==
+  dependencies:
+    "@ai-sdk/provider-utils" "4.0.9"
+    ai "6.0.48"
 
 "@ampproject/remapping@^2.2.0", "@ampproject/remapping@^2.2.1":
   version "2.3.0"
@@ -8665,6 +8698,11 @@
   resolved "https://registry.yarnpkg.com/@vercel/oidc/-/oidc-3.0.5.tgz#bd8db7ee777255c686443413492db4d98ef49657"
   integrity sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==
 
+"@vercel/oidc@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@vercel/oidc/-/oidc-3.1.0.tgz#066caee449b84079f33c7445fc862464fe10ec32"
+  integrity sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==
+
 "@vitest/eslint-plugin@^1.1.14":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@vitest/eslint-plugin/-/eslint-plugin-1.3.5.tgz#51a46d1b9a5654399a7f3e6b0b67713dea6f07f6"
@@ -9025,6 +9063,16 @@ aggregate-error@^3.0.0:
   dependencies:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
+
+ai@6.0.48:
+  version "6.0.48"
+  resolved "https://registry.yarnpkg.com/ai/-/ai-6.0.48.tgz#999ef339f9045cca031824c1a8d52651434dc701"
+  integrity sha512-nON0rHNTEQgzT1HahGl7AeszJh7es5ibZ6LWqm3IiN+bUAQtXkdArXD9vDlVAPBiCd7ERclZ6lUpOE6ltgJb3w==
+  dependencies:
+    "@ai-sdk/gateway" "3.0.22"
+    "@ai-sdk/provider" "3.0.5"
+    "@ai-sdk/provider-utils" "4.0.9"
+    "@opentelemetry/api" "1.9.0"
 
 ai@^6.0.3:
   version "6.0.5"
@@ -22111,7 +22159,16 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -22198,7 +22255,14 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -24106,7 +24170,7 @@ worker-farm@1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -24119,6 +24183,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Description
This refactors chatbox to use the useChat helper from ai sdk (yay svelte 5) meaning we get type safety on all of our parts, and we can clean up a lot of the complicated message code. 

Also minimises tool calls to preserve space, you can expand them if you need to. And changes the CSS so that the entire tool output is scrollable. Also adds loading state for tools. 

<img width="1468" height="1155" alt="image" src="https://github.com/user-attachments/assets/8a8a8917-03be-4727-9711-1b16babab1fb" />






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the Chatbox to use the ai SDK’s Svelte Chat helper for streaming, improving type safety and simplifying message handling. Tool outputs are collapsed by default with a toggle, now show running/success/error states, and their input/output sections are scrollable.

- **Refactors**
  - Replaced custom streaming with Chat + DefaultChatTransport; messages and status now come from the SDK.
  - Resolved chat app and conversation IDs with history lookup to persist threads when needed.
  - Unified autoscroll and input focus; disabled input while streaming; centralized error handling; Svelte 5 API update (remove loading prop; use onchatsaved prop instead of on:chatSaved).

- **Dependencies**
  - Added @ai-sdk/svelte ^4.0.48 (with related ai packages updated in yarn.lock).

<sup>Written for commit 924207fa38b0b3e7caab2241cc3a0a8596732e49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





