### PR TITLE
feat: tailscale annotations in litellm service

### DIFF
--- a/charts/budibase/templates/litellm-service-service.yaml
+++ b/charts/budibase/templates/litellm-service-service.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     app.kubernetes.io/name: litellm
     io.kompose.service: litellm-service
+  {{- if .Values.services.litellm.tailscale.expose }}
+  annotations:
+    tailscale.com/expose: "true"
+  {{- end }}
 spec:
   type: ClusterIP
   selector:

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -619,6 +619,9 @@ services:
       general_settings:
         store_model_in_db: true
         store_prompts_in_spend_logs: true
+    tailscale:
+      # -- Whether to expose the litellm service to a Tailscale tailnet via annotation.
+      expose: false
 
   objectStore:
     # -- Set to false if using another object store, such as S3. You will need


### PR DESCRIPTION
## Description
Allowing exposure of the LiteLLM service object on Tailnets through a Helm chart flag



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional Tailscale exposure for the LiteLLM Kubernetes Service via a Helm value. When enabled, the Service gets the tailscale.com/expose annotation to make it reachable on your Tailnet.

- **New Features**
  - Added services.litellm.tailscale.expose flag (default false) in values.yaml.
  - When true, adds tailscale.com/expose: "true" annotation to the litellm Service.

<sup>Written for commit 93ad9d2429bcf734272d0b3f26132a2adc56b9d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

