### PR TITLE
Correctly propagate errors using AI SDK's onError callback

### DIFF
--- a/packages/backend-core/src/errors/errors.ts
+++ b/packages/backend-core/src/errors/errors.ts
@@ -19,6 +19,35 @@ export abstract class BudibaseError extends Error {
  * For the given error, build the public representation that is safe
  * to be exposed over an api.
  */
+/**
+ * Extract a human-readable error message from any error type.
+ * Handles Error instances, objects with message property, strings, and unknown types.
+ */
+export function getErrorMessage(err: unknown): string {
+  if (err == null) {
+    return "No error provided."
+  }
+  if (err instanceof Error) {
+    return err.message
+  }
+  if (typeof err === "string") {
+    return err
+  }
+  if (typeof err === "object" && "message" in err) {
+    return String((err as { message: unknown }).message)
+  }
+  try {
+    const serialized = JSON.stringify(err)
+    if (serialized !== "{}") {
+      return serialized
+    }
+  } catch {
+    // Fall through
+  }
+  const str = String(err)
+  return str !== "[object Object]" ? str : "An unknown error occurred"
+}
+
 export const getPublicError = (err: any) => {
   let error
   if (err.code) {

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -284,6 +284,14 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
       tools,
       stopWhen: stepCountIs(30),
       providerOptions: ai.getLiteLLMProviderOptions(),
+      onError({ error }) {
+        console.error("Agent streaming error", {
+          agentId,
+          chatAppId,
+          sessionId,
+          error,
+        })
+      },
     })
 
     const title = latestQuestion ? truncateTitle(latestQuestion) : chat.title
@@ -299,6 +307,18 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
       ...(messageMetadata && {
         messageMetadata: () => messageMetadata,
       }),
+      onError: error => {
+        if (error == null) {
+          return "An unknown error occurred"
+        }
+        if (typeof error === "string") {
+          return error
+        }
+        if (error instanceof Error) {
+          return error.message
+        }
+        return JSON.stringify(error)
+      },
       onFinish: async ({ messages }) => {
         if (chat.transient) {
           return

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -1,4 +1,9 @@
-import { context, docIds, HTTPError } from "@budibase/backend-core"
+import {
+  context,
+  docIds,
+  getErrorMessage,
+  HTTPError,
+} from "@budibase/backend-core"
 import { v4 } from "uuid"
 import { ai } from "@budibase/pro"
 import {
@@ -307,18 +312,7 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
       ...(messageMetadata && {
         messageMetadata: () => messageMetadata,
       }),
-      onError: error => {
-        if (error == null) {
-          return "An unknown error occurred"
-        }
-        if (typeof error === "string") {
-          return error
-        }
-        if (error instanceof Error) {
-          return error.message
-        }
-        return JSON.stringify(error)
-      },
+      onError: error => getErrorMessage(error),
       onFinish: async ({ messages }) => {
         if (chat.transient) {
           return

--- a/packages/server/src/automations/automationUtils.ts
+++ b/packages/server/src/automations/automationUtils.ts
@@ -121,6 +121,31 @@ export function getError(err: any) {
   return typeof err !== "string" ? err.toString() : err
 }
 
+export function getErrorMessage(err: unknown): string {
+  if (err == null) {
+    return "No error provided."
+  }
+  if (err instanceof Error) {
+    return err.message
+  }
+  if (typeof err === "string") {
+    return err
+  }
+  if (typeof err === "object" && "message" in err) {
+    return String((err as { message: unknown }).message)
+  }
+  try {
+    const serialized = JSON.stringify(err)
+    if (serialized !== "{}") {
+      return serialized
+    }
+  } catch {
+    // Fall through
+  }
+  const str = String(err)
+  return str !== "[object Object]" ? str : "An unknown error occurred"
+}
+
 export function guardAttachment(
   attachmentObject?: object
 ): attachmentObject is AutomationAttachment {

--- a/packages/server/src/automations/automationUtils.ts
+++ b/packages/server/src/automations/automationUtils.ts
@@ -121,31 +121,6 @@ export function getError(err: any) {
   return typeof err !== "string" ? err.toString() : err
 }
 
-export function getErrorMessage(err: unknown): string {
-  if (err == null) {
-    return "No error provided."
-  }
-  if (err instanceof Error) {
-    return err.message
-  }
-  if (typeof err === "string") {
-    return err
-  }
-  if (typeof err === "object" && "message" in err) {
-    return String((err as { message: unknown }).message)
-  }
-  try {
-    const serialized = JSON.stringify(err)
-    if (serialized !== "{}") {
-      return serialized
-    }
-  } catch {
-    // Fall through
-  }
-  const str = String(err)
-  return str !== "[object Object]" ? str : "An unknown error occurred"
-}
-
 export function guardAttachment(
   attachmentObject?: object
 ): attachmentObject is AutomationAttachment {

--- a/packages/server/src/automations/steps/ai/agent.ts
+++ b/packages/server/src/automations/steps/ai/agent.ts
@@ -138,7 +138,9 @@ export async function run({
           assistantMessage = uiMessage
         }
 
-        if (streamingError) {
+        const responseText = await streamResult.text
+
+        if (streamingError && !responseText) {
           tracer.llmobs.annotate(agentSpan, {
             outputData: streamingError,
             tags: { error: "1", "error.type": "StreamingError" },
@@ -148,8 +150,6 @@ export async function run({
             response: streamingError,
           }
         }
-
-        const responseText = await streamResult.text
         const usage = await streamResult.usage
         const output = outputOption
           ? ((await streamResult.output) as Record<string, any>)

--- a/packages/server/src/automations/steps/ai/agent.ts
+++ b/packages/server/src/automations/steps/ai/agent.ts
@@ -128,17 +128,20 @@ export async function run({
           stream: streamResult.toUIMessageStream({
             sendReasoning: true,
             onError: error => {
-              const errorMessage =
-                error instanceof Error ? error.message : String(error)
-              streamingError = errorMessage
-              return errorMessage
+              streamingError = automationUtils.getErrorMessage(error)
+              return streamingError
             },
           }),
         })) {
           assistantMessage = uiMessage
         }
 
-        const responseText = await streamResult.text
+        let responseText: string | undefined
+        try {
+          responseText = await streamResult.text
+        } catch {
+          // Ignore - go to check streamingError below
+        }
 
         if (streamingError && !responseText) {
           tracer.llmobs.annotate(agentSpan, {


### PR DESCRIPTION
## Description
We were swallowing important errors coming from LiteLLM, this meant that we showed a basic error message that wasn't very helpful to the user. 

We now correctly propagate the error using the onError callback of the ai sdk. 

<img width="1508" height="845" alt="image" src="https://github.com/user-attachments/assets/5c4aa6cc-cc9e-4054-8076-8c89b053ac06" />

^ before this error would have simply been `AI_NoOutputGeneratedError: No output generated. Check the stream for errors.`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates real LiteLLM streaming errors to users instead of a generic message, improving visibility and debuggability. Uses the AI SDK onError callbacks to surface and normalize errors, log with context, and tag tracing; also handles text extraction failures.

- **Bug Fixes**
  - Wired onError in agent stream and UI message stream to return the actual error message to clients.
  - Logged errors with agentId, chatAppId, and sessionId for easier tracing.
  - Standardized error extraction (getErrorMessage); caught text parsing failures; annotated llmobs and only short-circuited when no output is produced.

<sup>Written for commit a0d7090cd031427f175fb8e68dd44312e6c83f56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



