### PR TITLE
Feat/stablize rollouts

### DIFF
--- a/charts/budibase/templates/alb-ingress.yaml
+++ b/charts/budibase/templates/alb-ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/success-codes: '200'
     alb.ingress.kubernetes.io/healthcheck-path: '/health'
+    alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds={{ .Values.awsAlbIngress.deregistrationDelay }}
     {{- if .Values.awsAlbIngress.certificateArn }}
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'

--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -13,11 +13,15 @@ metadata:
   name: app-service
 spec:
   replicas: {{ .Values.services.apps.replicaCount }}
+  minReadySeconds: {{ .Values.services.apps.minReadySeconds }}
   selector:
     matchLabels:
       io.kompose.service: app-service
   strategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       annotations:
@@ -275,6 +279,10 @@ spec:
         args:
         {{- toYaml .Values.services.apps.args | nindent 10 }}
         {{ end }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep", "{{ .Values.services.apps.preStopDelaySeconds }}"]
         {{ if .Values.services.apps.extraVolumeMounts }}
         volumeMounts:
         {{- toYaml .Values.services.apps.extraVolumeMounts | nindent 10 }}

--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -31,6 +31,7 @@ spec:
 {{- toYaml .Values.services.proxy.templateLabels | indent 8 -}}
 {{ end }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.services.proxy.terminationGracePeriodSeconds }}
       containers:
       - image: {{ .Values.globals.dockerRegistry }}budibase/proxy:{{ .Values.globals.appVersion | default .Chart.AppVersion }}
         imagePullPolicy: Always
@@ -82,6 +83,10 @@ spec:
         resources:
         {{- toYaml . | nindent 10 }}
         {{ end }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep", "{{ .Values.services.proxy.preStopDelaySeconds }}"]
         {{ if .Values.services.proxy.extraVolumeMounts }}
         volumeMounts:
         {{- toYaml .Values.services.proxy.extraVolumeMounts | nindent 8 }}

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -13,11 +13,15 @@ metadata:
   name: worker-service
 spec:
   replicas: {{ .Values.services.worker.replicaCount }}
+  minReadySeconds: {{ .Values.services.worker.minReadySeconds }}
   selector:
     matchLabels:
       io.kompose.service: worker-service
   strategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       annotations:
@@ -253,6 +257,10 @@ spec:
         args:
         {{- toYaml .Values.services.worker.args | nindent 10 }}
         {{ end }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep", "{{ .Values.services.worker.preStopDelaySeconds }}"]
         {{ if .Values.services.worker.extraVolumeMounts }}
         volumeMounts:
         {{- toYaml .Values.services.worker.extraVolumeMounts | nindent 10 }}

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -41,6 +41,9 @@ awsAlbIngress:
   enabled: false
   # -- If you're wanting to use HTTPS, you'll need to create an ACM certificate and specify the ARN here.
   certificateArn: ""
+  # -- Time in seconds ALB waits for in-flight requests during target deregistration.
+  # This allows graceful connection draining during pod rollouts.
+  deregistrationDelay: 30
 
 # -- Sets the tolerations for all pods created by this chart. Should not ordinarily need to be changed.
 # See <https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/> for more information
@@ -164,6 +167,11 @@ services:
       worker: "http://worker-service.{{ .Release.Namespace }}.svc.{{ .Values.services.dns }}:{{ .Values.services.worker.port }}"
       minio: "http://minio-service.{{ .Release.Namespace }}.svc.{{ .Values.services.dns }}:{{ .Values.services.objectStore.port }}"
       couchdb: "http://{{ .Release.Name }}-svc-couchdb:{{ .Values.services.couchdb.port }}"
+    # -- The time in seconds to wait before sending SIGKILL after SIGTERM.
+    # Must be greater than preStopDelaySeconds to allow graceful shutdown.
+    terminationGracePeriodSeconds: 30
+    # -- Seconds to sleep before SIGTERM to allow load balancer deregistration.
+    preStopDelaySeconds: 5
     # -- The resources to use for proxy pods. See
     # <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/>
     # for more information on how to set these.
@@ -251,6 +259,11 @@ services:
     # container. This is used to give the apps service time to finish processing
     # any requests before shutting down. You shouldn't need to change this.
     terminationGracePeriodSeconds: 60
+    # -- Seconds to wait after pod is Ready before adding to endpoints.
+    # Ensures pods are stable before receiving traffic.
+    minReadySeconds: 10
+    # -- Seconds to sleep before SIGTERM to allow load balancer deregistration.
+    preStopDelaySeconds: 5
     # -- Extra environment variables to set for apps pods. Takes a list of
     # name=value pairs.
     extraEnv: []
@@ -443,6 +456,11 @@ services:
     # processing any requests before shutting down. You shouldn't need to change
     # this.
     terminationGracePeriodSeconds: 60
+    # -- Seconds to wait after pod is Ready before adding to endpoints.
+    # Ensures pods are stable before receiving traffic.
+    minReadySeconds: 10
+    # -- Seconds to sleep before SIGTERM to allow load balancer deregistration.
+    preStopDelaySeconds: 5
     # -- Extra environment variables to set for worker pods. Takes a list of
     # name=value pairs.
     extraEnv: []


### PR DESCRIPTION
## Description
To avoid dead ALB backend connections, we should adopt a stricter rollout strategy that respects the application's network connection handling. This fixes the 503 Bad Gateway errors during Helm rollouts.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Helm rollouts by adding ALB connection draining and graceful pod lifecycle settings. Prevents 503 Bad Gateway during upgrades.

- **Bug Fixes**
  - Set ALB target-group deregistration delay (default 30s) to drain in-flight requests.
  - Add preStop sleep (5s) to app, worker, and proxy pods to allow ALB deregistration before SIGTERM.
  - Tune rolling updates: maxSurge 1, maxUnavailable 0.
  - Add minReadySeconds (10s) to app and worker so pods warm up before receiving traffic.
  - Expose proxy terminationGracePeriodSeconds (30s) to ensure shutdown completes after preStop.

<sup>Written for commit 140492d853bac93c4baa662694cec1acf21d76f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

