### PR TITLE
Ensure LiteLLM drops invalid params

### DIFF
--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -619,6 +619,8 @@ services:
       general_settings:
         store_model_in_db: true
         store_prompts_in_spend_logs: true
+      litellm_settings:
+        drop_params: true
     tailscale:
       # -- Whether to expose the litellm service to a Tailscale tailnet via annotation.
       expose: false


### PR DESCRIPTION
## Description
Some parameters that we are passing aren't compatible with certain models. LiteLLM allows us to pass a flag so these can be dropped and not effect the processing of the request (i.e `reasoning_effort`)

https://docs.litellm.ai/docs/completion/drop_params


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled LiteLLM to drop unsupported request parameters so requests don’t fail across models. This sets litellm_settings.drop_params: true, removing invalid params like reasoning_effort at runtime.

<sup>Written for commit db2ca96928f7a287863e19e553cfddd3701cdaa5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

