### PR TITLE
chore: change authentication error logging from error to warn.

### DIFF
--- a/packages/backend-core/src/middleware/authenticated.ts
+++ b/packages/backend-core/src/middleware/authenticated.ts
@@ -238,7 +238,7 @@ export function authenticated(
         return next()
       }
     } catch (err: any) {
-      console.error(`Auth Error: ${err.message}`)
+      console.warn(`Auth Error: ${err.message}`)
       // invalid token, clear the cookie
       if (err?.name === "JsonWebTokenError") {
         clearCookie(ctx, Cookie.Auth)

--- a/packages/backend-core/src/middleware/authenticated.ts
+++ b/packages/backend-core/src/middleware/authenticated.ts
@@ -174,7 +174,7 @@ export function authenticated(
           authenticated = true
         } catch (err: any) {
           authenticated = false
-          console.error(`Auth Error: ${err.message}`)
+          console.warn(`Auth Error: ${err.message}`)
           // remove the cookie as the user does not exist anymore
           clearCookie(ctx, Cookie.Auth)
         }


### PR DESCRIPTION
## Description

Throwing an error for an invalid API key pollutes the error logs for a non-actionable error state. We should be emitting a warning for this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the auth middleware to log invalid token/API key errors as warnings instead of errors. This reduces noise in error logs for non-actionable authentication failures.

<sup>Written for commit 520bde9df6ac14f091b6ab96022707b86109a546. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

