### PR TITLE
fix: pass reasoning effort to groq

### DIFF
--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -256,7 +256,7 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
     })
 
   try {
-    const { modelId, apiKey, baseUrl } =
+    const { modelId, apiKey, baseUrl, provider } =
       await sdk.ai.configs.getLiteLLMModelConfigOrThrow(agent.aiconfig)
 
     const sessionId = chat._id || v4()
@@ -290,7 +290,7 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
       system,
       tools,
       stopWhen: stepCountIs(30),
-      providerOptions: ai.getLiteLLMProviderOptions(),
+      providerOptions: ai.getLiteLLMProviderOptions(modelId, provider),
       onError({ error }) {
         console.error("Agent streaming error", {
           agentId,

--- a/packages/server/src/automations/steps/ai/agent.ts
+++ b/packages/server/src/automations/steps/ai/agent.ts
@@ -77,7 +77,7 @@ export async function run({
         const { systemPrompt, tools } =
           await sdk.ai.agents.buildPromptAndTools(agentConfig)
 
-        const { modelId, apiKey, baseUrl, modelName } =
+        const { modelId, apiKey, baseUrl, modelName, provider } =
           await sdk.ai.configs.getLiteLLMModelConfigOrThrow(
             agentConfig.aiconfig
           )
@@ -116,7 +116,7 @@ export async function run({
           instructions: systemPrompt || undefined,
           tools,
           stopWhen: stepCountIs(30),
-          providerOptions: ai.getLiteLLMProviderOptions(),
+          providerOptions: ai.getLiteLLMProviderOptions(modelId, provider),
           output: outputOption,
         })
 

--- a/packages/server/src/sdk/workspace/ai/configs/index.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/index.ts
@@ -161,6 +161,7 @@ export async function getLiteLLMModelConfigOrThrow(configId: string): Promise<{
   modelId: string
   apiKey: string
   baseUrl: string
+  provider: string
 }> {
   const aiConfig = await find(configId)
 
@@ -181,6 +182,7 @@ export async function getLiteLLMModelConfigOrThrow(configId: string): Promise<{
     modelId: aiConfig.liteLLMModelId,
     apiKey: secretKey,
     baseUrl: environment.LITELLM_URL,
+    provider: aiConfig.provider,
   }
 }
 

--- a/packages/server/src/tests/api/chatConversations.spec.ts
+++ b/packages/server/src/tests/api/chatConversations.spec.ts
@@ -355,6 +355,7 @@ describe("chat conversation transient behavior", () => {
       modelId: "model-1",
       apiKey: "api-key",
       baseUrl: "http://localhost",
+      provider: "groq",
     })
 
     const openAiMock = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure Groq models receive the reasoning_effort parameter by passing provider-specific options to LiteLLM in chat and automation flows. Improves response quality and consistency for Groq.

- **Bug Fixes**
  - Return provider from getLiteLLMModelConfigOrThrow.
  - Pass modelId and provider to getLiteLLMProviderOptions in chatConversations and automation agent.
  - Update chat conversation test to set provider: "groq".

<sup>Written for commit 9323699321a53e102d1a7d223f235ea75865e914. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

