### PR TITLE
Revert "build(deps-dev): bump undici from 5.29.0 to 6.23.0"

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -179,7 +179,7 @@
     "timekeeper": "2.2.0",
     "ts-node": "10.8.1",
     "tsconfig-paths": "4.0.0",
-    "undici": "^6.23.0",
+    "undici": "^5.28.4",
     "yargs": "^17.7.2",
     "zod": "^4.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3583,6 +3583,11 @@
     "@eslint/core" "^0.13.0"
     levn "^0.4.1"
 
+"@fastify/busboy@^2.0.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
+  integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
+
 "@google-cloud/firestore@7.8.0":
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/@google-cloud/firestore/-/firestore-7.8.0.tgz#029bed6c47de84c667a27256acbaca6f6ee50e15"
@@ -23437,10 +23442,12 @@ undici-types@~7.10.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.10.0.tgz#4ac2e058ce56b462b056e629cc6a02393d3ff350"
   integrity sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==
 
-undici@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.23.0.tgz#7953087744d9095a96f115de3140ca3828aff3a4"
-  integrity sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==
+undici@^5.28.4:
+  version "5.29.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.29.0.tgz#419595449ae3f2cdcba3580a2e8903399bd1f5a3"
+  integrity sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==
+  dependencies:
+    "@fastify/busboy" "^2.0.0"
 
 undici@^7.12.0, undici@^7.16.0:
   version "7.18.2"


### PR DESCRIPTION
Reverts Budibase/budibase#17800

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverted undici in the server package from v6.23.0 back to v5.x to restore compatibility and avoid build/runtime issues.

- **Dependencies**
  - Set undici to ^5.28.4 (resolves to 5.29.0).
  - Updated yarn.lock; adds @fastify/busboy as a transitive dependency.

<sup>Written for commit cf6f9ced9244e98bb810d1e75b7101374cc969ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

