### PR TITLE
Fix query error messages for invalid JSON

### DIFF
--- a/packages/builder/src/components/integration/APIEndpointViewer.svelte
+++ b/packages/builder/src/components/integration/APIEndpointViewer.svelte
@@ -576,7 +576,14 @@
         notifications.success("Request sent successfully")
       }
     } catch (error) {
-      notifications.error(`Query Error: ${error}`)
+      const message =
+        error?.message === "[object Object]"
+          ? error?.message?.message ??
+            error?.message?.code ??
+            error?.message?.error ??
+            JSON.stringify(error)
+          : error?.message ?? error
+      notifications.error(`Query Error: ${message}`)
     }
     runningQuery = false
   }

--- a/packages/builder/src/components/integration/APIEndpointViewer.svelte
+++ b/packages/builder/src/components/integration/APIEndpointViewer.svelte
@@ -578,11 +578,11 @@
     } catch (error) {
       const message =
         error?.message === "[object Object]"
-          ? error?.message?.message ??
+          ? (error?.message?.message ??
             error?.message?.code ??
             error?.message?.error ??
-            JSON.stringify(error)
-          : error?.message ?? error
+            JSON.stringify(error))
+          : (error?.message ?? error)
       notifications.error(`Query Error: ${message}`)
     }
     runningQuery = false

--- a/packages/builder/src/components/integration/APIEndpointViewer.svelte
+++ b/packages/builder/src/components/integration/APIEndpointViewer.svelte
@@ -62,6 +62,7 @@
   import ResponsePanel from "./ResponsePanel.svelte"
   import AuthPicker from "./rest/AuthPicker.svelte"
   import AccessLevelSelect from "@/components/integration/AccessLevelSelect.svelte"
+  import { getErrorMessage } from "@/helpers/errors"
 
   export let queryId
   export let datasourceId
@@ -101,6 +102,7 @@
   let template: RestTemplate | undefined
   let datasource: Datasource | UIInternalDatasource | undefined
   let authConfigs: AuthConfigOption[] = []
+
   const ensureQueryDefaults = (target: Query) => {
     if (!target.fields?.disabledHeaders) {
       target.fields.disabledHeaders = {}
@@ -576,14 +578,7 @@
         notifications.success("Request sent successfully")
       }
     } catch (error) {
-      const message =
-        error?.message === "[object Object]"
-          ? (error?.message?.message ??
-            error?.message?.code ??
-            error?.message?.error ??
-            JSON.stringify(error))
-          : (error?.message ?? error)
-      notifications.error(`Query Error: ${message}`)
+      notifications.error(`Query Error: ${getErrorMessage(error)}`)
     }
     runningQuery = false
   }

--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -99,11 +99,11 @@
     } catch (error) {
       const message =
         error?.message === "[object Object]"
-          ? error?.message?.message ??
+          ? (error?.message?.message ??
             error?.message?.code ??
             error?.message?.error ??
-            JSON.stringify(error)
-          : error?.message ?? error
+            JSON.stringify(error))
+          : (error?.message ?? error)
       notifications.error(`Query Error: ${message}`)
 
       if (!suppressErrors) {

--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -97,13 +97,14 @@
 
       notifications.success("Query executed successfully")
     } catch (error) {
-      if (typeof error.message === "string") {
-        notifications.error(`Query Error: ${error.message}`)
-      } else if (typeof error.message?.code === "string") {
-        notifications.error(`Query Error: ${error.message.code}`)
-      } else {
-        notifications.error(`Query Error: ${JSON.stringify(error.message)}`)
-      }
+      const message =
+        error?.message === "[object Object]"
+          ? error?.message?.message ??
+            error?.message?.code ??
+            error?.message?.error ??
+            JSON.stringify(error)
+          : error?.message ?? error
+      notifications.error(`Query Error: ${message}`)
 
       if (!suppressErrors) {
         throw error

--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -25,6 +25,7 @@
   import QueryViewerSavePromptModal from "./QueryViewerSavePromptModal.svelte"
   import { Utils } from "@budibase/frontend-core"
   import ConnectedQueryScreens from "./ConnectedQueryScreens.svelte"
+  import { getErrorMessage } from "@/helpers/errors"
 
   $: goto = $gotoStore
 
@@ -97,14 +98,7 @@
 
       notifications.success("Query executed successfully")
     } catch (error) {
-      const message =
-        error?.message === "[object Object]"
-          ? (error?.message?.message ??
-            error?.message?.code ??
-            error?.message?.error ??
-            JSON.stringify(error))
-          : (error?.message ?? error)
-      notifications.error(`Query Error: ${message}`)
+      notifications.error(`Query Error: ${getErrorMessage(error)}`)
 
       if (!suppressErrors) {
         throw error

--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -309,7 +309,14 @@
         notifications.success("Request sent successfully")
       }
     } catch (error) {
-      notifications.error(`Query Error: ${error.message}`)
+      const message =
+        error?.message === "[object Object]"
+          ? error?.message?.message ??
+            error?.message?.code ??
+            error?.message?.error ??
+            JSON.stringify(error)
+          : error?.message ?? error
+      notifications.error(`Query Error: ${message}`)
     }
   }
 

--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -38,6 +38,7 @@
   } from "@/constants/backend"
   import JSONPreview from "@/components/integration/JSONPreview.svelte"
   import AccessLevelSelect from "@/components/integration/AccessLevelSelect.svelte"
+  import { getErrorMessage } from "@/helpers/errors"
   import DynamicVariableModal from "./DynamicVariableModal.svelte"
   import Placeholder from "assets/bb-spaceship.svg"
   import { cloneDeep } from "lodash/fp"
@@ -309,14 +310,7 @@
         notifications.success("Request sent successfully")
       }
     } catch (error) {
-      const message =
-        error?.message === "[object Object]"
-          ? (error?.message?.message ??
-            error?.message?.code ??
-            error?.message?.error ??
-            JSON.stringify(error))
-          : (error?.message ?? error)
-      notifications.error(`Query Error: ${message}`)
+      notifications.error(`Query Error: ${getErrorMessage(error)}`)
     }
   }
 

--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -311,11 +311,11 @@
     } catch (error) {
       const message =
         error?.message === "[object Object]"
-          ? error?.message?.message ??
+          ? (error?.message?.message ??
             error?.message?.code ??
             error?.message?.error ??
-            JSON.stringify(error)
-          : error?.message ?? error
+            JSON.stringify(error))
+          : (error?.message ?? error)
       notifications.error(`Query Error: ${message}`)
     }
   }

--- a/packages/builder/src/helpers/errors.ts
+++ b/packages/builder/src/helpers/errors.ts
@@ -1,0 +1,50 @@
+export const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error && error.message !== "[object Object]") {
+    return error.message
+  }
+
+  if (error && typeof error === "object") {
+    const errObject = error as {
+      message?: unknown
+      code?: unknown
+      error?: unknown
+    }
+    const messageValue = errObject.message
+
+    if (typeof messageValue === "string" && messageValue !== "[object Object]") {
+      return messageValue
+    }
+
+    if (messageValue && typeof messageValue === "object") {
+      const nestedMessage = messageValue as {
+        message?: unknown
+        code?: unknown
+        error?: unknown
+      }
+      const nestedText =
+        (typeof nestedMessage.message === "string" && nestedMessage.message) ||
+        (typeof nestedMessage.code === "string" && nestedMessage.code) ||
+        (typeof nestedMessage.error === "string" && nestedMessage.error)
+
+      return nestedText || JSON.stringify(messageValue)
+    }
+
+    const fallbackText =
+      (typeof errObject.code === "string" && errObject.code) ||
+      (typeof errObject.error === "string" && errObject.error)
+
+    if (fallbackText) {
+      return fallbackText
+    }
+  }
+
+  if (typeof error === "string") {
+    return error
+  }
+
+  try {
+    return JSON.stringify(error)
+  } catch (stringifyError) {
+    return String(error)
+  }
+}

--- a/packages/builder/src/helpers/errors.ts
+++ b/packages/builder/src/helpers/errors.ts
@@ -11,7 +11,10 @@ export const getErrorMessage = (error: unknown) => {
     }
     const messageValue = errObject.message
 
-    if (typeof messageValue === "string" && messageValue !== "[object Object]") {
+    if (
+      typeof messageValue === "string" &&
+      messageValue !== "[object Object]"
+    ) {
       return messageValue
     }
 

--- a/packages/builder/src/helpers/tests/errors.spec.ts
+++ b/packages/builder/src/helpers/tests/errors.spec.ts
@@ -1,0 +1,48 @@
+import { getErrorMessage } from "../errors"
+
+describe("getErrorMessage", () => {
+  it("returns a string error as-is", () => {
+    expect(getErrorMessage("boom")).toBe("boom")
+  })
+
+  it("returns message for Error instances", () => {
+    const error = new Error("failed")
+    expect(getErrorMessage(error)).toBe("failed")
+  })
+
+  it("returns nested message when error.message is an object", () => {
+    const error = {
+      message: {
+        message: "nested",
+      },
+    }
+    expect(getErrorMessage(error)).toBe("nested")
+  })
+
+  it("returns nested code when error.message is an object without message", () => {
+    const error = {
+      message: {
+        code: "E_NESTED",
+      },
+    }
+    expect(getErrorMessage(error)).toBe("E_NESTED")
+  })
+
+  it("returns top-level code when present", () => {
+    const error = {
+      code: "E_TOP",
+    }
+    expect(getErrorMessage(error)).toBe("E_TOP")
+  })
+
+  it("stringifies objects when no message fields are present", () => {
+    const error = { detail: "extra" }
+    expect(getErrorMessage(error)).toBe(JSON.stringify(error))
+  })
+
+  it("falls back to String(error) when JSON.stringify fails", () => {
+    const error: Record<string, unknown> = {}
+    error.self = error
+    expect(getErrorMessage(error)).toBe("[object Object]")
+  })
+})


### PR DESCRIPTION
## Description
Fixes query preview error handling so invalid JSON payloads show a useful message instead of `[object Object]`.

## Addresses
- https://github.com/Budibase/budibase/issues/17849

## Screenshots
<img width="620" height="865" alt="before" src="https://github.com/user-attachments/assets/afae8693-9dae-452c-aec4-3c18c36b78bd" />

BEFORE

<img width="620" height="865" alt="after" src="https://github.com/user-attachments/assets/00347a76-fdb5-4bd3-a38b-cbdfd9d41903" />

AFTER

## Launchcontrol
Improve REST query preview error messaging for invalid JSON payloads.
