### PR TITLE
refactor: switch to direct redirect action

### DIFF
--- a/charts/budibase/templates/alb-ingress.yaml
+++ b/charts/budibase/templates/alb-ingress.yaml
@@ -11,12 +11,12 @@ metadata:
     alb.ingress.kubernetes.io/healthcheck-path: '/health'
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds={{ .Values.awsAlbIngress.deregistrationDelay }}
     {{- if .Values.awsAlbIngress.certificateArn }}
-    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/ssl-redirect: '443'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.awsAlbIngress.certificateArn }} 
     {{- end }}
     {{- if .Values.awsAlbIngress.sslPolicy }}
-    alb.ingress.kubernetes.io/actions.ssl-policy: {{ .Values.awsAlbIngress.sslPolicy }}
+    alb.ingress.kubernetes.io/ssl-policy: {{ .Values.awsAlbIngress.sslPolicy }}
     {{- end }}
     {{- if .Values.awsAlbIngress.securityGroups }}
     alb.ingress.kubernetes.io/security-groups: {{ .Values.awsAlbIngress.securityGroups }}
@@ -25,15 +25,6 @@ spec:
   rules:
     - http:
         paths:
-        {{- if .Values.awsAlbIngress.certificateArn }}
-        - path: /
-          pathType: Prefix
-          backend:
-            service:
-              name: ssl-redirect
-              port:
-                name: use-annotation
-        {{- end }}
         - path: /
           pathType: Prefix
           backend:


### PR DESCRIPTION
## Description
Switches to the modern annotation for the ALB: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.10/guide/ingress/annotations/#ssl-redirect




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches ALB Ingress to the native SSL redirect annotations, removing the legacy action-based redirect. Keeps HTTP→HTTPS behavior and aligns with aws-load-balancer-controller v2.10.

- **Refactors**
  - Replaced actions.ssl-redirect with ssl-redirect: '443'.
  - Replaced actions.ssl-policy with ssl-policy.
  - Removed the extra path/backend for ssl-redirect; redirect is now handled by the annotation.

<sup>Written for commit 4fc2e4f2cfc1fd346b9baac974d0a447383b8eb7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

