### PR TITLE
fix: reset ui when delete last chat

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatApp.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/_components/ChatApp.svelte
@@ -186,9 +186,15 @@
         const [nextChat] = remainingConversations
         await selectChat(nextChat)
       } else {
-        // Return to blank state (agent still selected)
-        chat = { ...INITIAL_CHAT, chatAppId: $chatAppsStore.chatAppId || "" }
-        chatAppsStore.clearCurrentConversationId()
+        syncingAgentSelection = true
+        try {
+          await agentsStore.selectAgent(undefined)
+          selectedAgentId = null
+          chat = { ...INITIAL_CHAT, chatAppId: $chatAppsStore.chatAppId || "" }
+          chatAppsStore.clearCurrentConversationId()
+        } finally {
+          syncingAgentSelection = false
+        }
       }
     } catch (err) {
       const message =


### PR DESCRIPTION
## Description

if you deleted the last saved chat, you'd end up with the chatbox visible, but if you tried to start a new convo it would tell you to select an agent first


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset the chat UI when the last conversation is deleted so the app returns to a clean state and no agent remains selected.

- **Bug Fixes**
  - Clear the selected agent and set selectedAgentId to null, wrapped with syncingAgentSelection to avoid UI glitches.
  - Reset chat to INITIAL_CHAT and clear the current conversation ID.

<sup>Written for commit 49d742e6436fbb868fd1a4e1ab3ab223fccc37ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



