### PR TITLE
Enterprise-only note for workspace import/export public API docs

### DIFF
--- a/packages/server/specs/openapi.json
+++ b/packages/server/specs/openapi.json
@@ -4874,7 +4874,7 @@
       "post": {
         "operationId": "workspaceImport",
         "summary": "Import a workspace to an existing workspace 🔒",
-        "description": "This endpoint is only available on a business or enterprise license.",
+        "description": "This endpoint is only available on an enterprise license.",
         "tags": [
           "workspaces"
         ],
@@ -4917,7 +4917,7 @@
       "post": {
         "operationId": "workspaceExport",
         "summary": "Export a workspace 🔒",
-        "description": "This endpoint is only available on a business or enterprise license.",
+        "description": "This endpoint is only available on an enterprise license.",
         "tags": [
           "workspaces"
         ],

--- a/packages/server/specs/openapi.yaml
+++ b/packages/server/specs/openapi.yaml
@@ -3557,7 +3557,7 @@ paths:
     post:
       operationId: workspaceImport
       summary: Import a workspace to an existing workspace 🔒
-      description: This endpoint is only available on a business or enterprise license.
+      description: This endpoint is only available on an enterprise license.
       tags:
         - workspaces
       parameters:
@@ -3584,7 +3584,7 @@ paths:
     post:
       operationId: workspaceExport
       summary: Export a workspace 🔒
-      description: This endpoint is only available on a business or enterprise license.
+      description: This endpoint is only available on an enterprise license.
       tags:
         - workspaces
       parameters:

--- a/packages/server/src/api/routes/public/workspaces.ts
+++ b/packages/server/src/api/routes/public/workspaces.ts
@@ -141,7 +141,7 @@ write.push(
  *   post:
  *     operationId: workspaceImport
  *     summary: Import a workspace to an existing workspace 🔒
- *     description: This endpoint is only available on a business or enterprise license.
+ *     description: This endpoint is only available on an enterprise license.
  *     tags:
  *       - workspaces
  *     parameters:
@@ -175,7 +175,7 @@ write.push(
  *   post:
  *     operationId: workspaceExport
  *     summary: Export a workspace 🔒
- *     description: This endpoint is only available on a business or enterprise license.
+ *     description: This endpoint is only available on an enterprise license.
  *     tags:
  *       - workspaces
  *     parameters:

--- a/packages/server/src/definitions/openapi.ts
+++ b/packages/server/src/definitions/openapi.ts
@@ -610,7 +610,7 @@ export interface paths {
         put?: never;
         /**
          * Import a workspace to an existing workspace 🔒
-         * @description This endpoint is only available on a business or enterprise license.
+         * @description This endpoint is only available on an enterprise license.
          */
         post: operations["workspaceImport"];
         delete?: never;
@@ -630,7 +630,7 @@ export interface paths {
         put?: never;
         /**
          * Export a workspace 🔒
-         * @description This endpoint is only available on a business or enterprise license.
+         * @description This endpoint is only available on an enterprise license.
          */
         post: operations["workspaceExport"];
         delete?: never;


### PR DESCRIPTION
## Description
This updates the public API documentation for workspace import and export to clearly state that these endpoints are only available with an Enterprise license. The documentation is generated from the server’s OpenAPI annotations, so the change is applied at the source, and the generated OpenAPI files were rebuilt to keep everything in sync.

## Launchcontrol
Changes the descriptions of workspace import and export endpoints in the public API to state that they are only available to enterprise users.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the public API docs to state that workspace import and export endpoints are available only with an Enterprise license. Changed the server OpenAPI annotations and regenerated the OpenAPI specs to keep the docs in sync.

<sup>Written for commit caa13adda856ca8bb553ad04fcc31fc19fe33c55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

