### PR TITLE
Renamed the sidebar class to determine if this is causing a build issue

### DIFF
--- a/packages/builder/src/components/settings/ModalSideBar.svelte
+++ b/packages/builder/src/components/settings/ModalSideBar.svelte
@@ -61,7 +61,7 @@
   })
 </script>
 
-<div class="nav_wrapper">
+<div class="modal_sidebar_wrapper">
   <div class="nav_spacer" class:pinned={$pinned}></div>
   <div
     class="nav"
@@ -97,7 +97,7 @@
 </div>
 
 <style>
-  .nav_wrapper {
+  .modal_sidebar_wrapper {
     display: contents;
     --nav-logo-width: 20px;
     --nav-padding: 12px;

--- a/packages/builder/src/components/settings/SettingsModal.svelte
+++ b/packages/builder/src/components/settings/SettingsModal.svelte
@@ -424,7 +424,7 @@
     margin-right: 2px;
   }
 
-  .spectrum-Dialog-content :global(.nav_wrapper .nav) {
+  .spectrum-Dialog-content :global(.modal_sidebar_wrapper .nav) {
     border-top-left-radius: var(--spectrum-global-dimension-size-100);
     border-bottom-left-radius: var(--spectrum-global-dimension-size-100);
   }


### PR DESCRIPTION
## Description

Renaming the `.nav_wrapper` class used in the modal side bar to determine if prod css bundling is omitting css styles based on duplicate names.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the modal sidebar CSS class from .nav_wrapper to .modal_sidebar_wrapper to avoid production CSS bundling collisions that were dropping styles. Updated the SettingsModal selector to target the new class.

<sup>Written for commit 77b3abf03ba7a3ff642a1e83a1c701e93caa8b26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

