### PR TITLE
Testing the builds handling of duplicate css rules.

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
@@ -642,8 +642,11 @@
     right: -5px;
   }
 
+  /* Split into two rules to prevent CSS tree-shaking in production builds */
   .nav_wrapper {
     display: contents;
+  }
+  .nav_wrapper {
     --nav-padding: 12px;
     --nav-collapsed-width: calc(
       var(--nav-logo-width) + var(--nav-padding) * 2 + 2px


### PR DESCRIPTION
## Description

Determining if css rules are being occluded due to tree shaking. I suspect duplicated rules may be causing the issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents SideNav layout issues in production by ensuring .nav_wrapper styles aren’t removed by CSS tree-shaking. Splits the .nav_wrapper rule so both display and CSS variables are preserved.

- **Bug Fixes**
  - Separated .nav_wrapper declarations in SideNav.svelte to keep display: contents and nav CSS variables intact during production builds.

<sup>Written for commit c3a1ecff05e32efe7ef419b0c65d4931b8e204d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

