### PR TITLE
Fix CSS minification issue

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
@@ -981,8 +981,14 @@ Any constraints the agent must follow.
     max-width: 600px;
   }
 
-  .llm-header > :global(.spectrum-Body):first-child,
-  .section-header > :global(.spectrum-Body):first-child,
+  .llm-header > :global(.spectrum-Body):first-child {
+    font-weight: 500;
+  }
+
+  .section-header > :global(.spectrum-Body):first-child {
+    font-weight: 500;
+  }
+
   .title-tools-bar > :global(.spectrum-Body) {
     font-weight: 500;
   }


### PR DESCRIPTION
## Description
  - The combined selector rule with :global() and comma-separated selectors was confusing the css minifier
  - During production build minification, it incorrectly concatenated selectors, causing .nav_wrapper to be dropped entirely
  - This removed the CSS variables (--nav-padding, --nav-collapsed-width, etc.) that the entire SideNav depends on


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a CSS minification bug by splitting combined :global() selectors, preventing incorrect selector concatenation in production and restoring SideNav styles.

- **Bug Fixes**
  - In config.svelte, split the combined selectors for .llm-header and .section-header so each applies font-weight: 500 separately.
  - Prevents the minifier from dropping selectors (e.g., nav wrapper) and preserves required CSS variables in production builds.

<sup>Written for commit 392a7fa51b89606e261e947d1703d57761fb4848. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

