### PR TITLE
Add lint rule for child :global selectors

### DIFF
--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -24,7 +24,7 @@ const extractStyleBlocks = text => {
 const buildLineOffsets = text => {
   const offsets = [0]
   for (let i = 0; i < text.length; i += 1) {
-    if (text[i] === "\\n") {
+    if (text[i] === "\n") {
       offsets.push(i + 1)
     }
   }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -70,6 +70,7 @@ export default [
       "no-useless-rename": "error",
       "no-var": "error",
       "no-void": "error",
+      "local-rules/no-display-contents-custom-props": "error",
 
       "no-unused-vars": [
         "error",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,6 +71,7 @@ export default [
       "no-var": "error",
       "no-void": "error",
       "local-rules/no-display-contents-custom-props": "error",
+      "local-rules/no-multiple-child-global-selectors": "error",
 
       "no-unused-vars": [
         "error",

--- a/packages/bbui/src/Table/Table.svelte
+++ b/packages/bbui/src/Table/Table.svelte
@@ -533,6 +533,8 @@
     --table-border: 1px solid var(--spectrum-alias-border-color-mid);
     --cell-padding: var(--spectrum-global-dimension-size-250);
     overflow: auto;
+  }
+  .wrapper {
     display: contents;
   }
   .wrapper--quiet {

--- a/packages/builder/src/components/settings/ModalSideBar.svelte
+++ b/packages/builder/src/components/settings/ModalSideBar.svelte
@@ -98,7 +98,6 @@
 
 <style>
   .modal_sidebar_wrapper {
-    display: contents;
     --nav-logo-width: 20px;
     --nav-padding: 12px;
     --nav-collapsed-width: calc(
@@ -106,6 +105,9 @@
     );
     --nav-width: 240px;
     --nav-border: 1px solid var(--spectrum-global-color-gray-200);
+  }
+  .modal_sidebar_wrapper {
+    display: contents;
   }
   /* Spacer to allow nav to always be absolutely positioned */
   .nav_spacer {

--- a/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
@@ -644,15 +644,15 @@
 
   /* Split into two rules to prevent CSS tree-shaking in production builds */
   .nav_wrapper {
-    display: contents;
-  }
-  .nav_wrapper {
     --nav-padding: 12px;
     --nav-collapsed-width: calc(
       var(--nav-logo-width) + var(--nav-padding) * 2 + 2px
     );
     --nav-width: 240px;
     --nav-border: 1px solid var(--spectrum-global-color-gray-200);
+  }
+  .nav_wrapper {
+    display: contents;
   }
   /* Spacer to allow nav to always be absolutely positioned */
   .nav_spacer {

--- a/packages/client/src/components/app/pdf/PDFTable.svelte
+++ b/packages/client/src/components/app/pdf/PDFTable.svelte
@@ -113,8 +113,10 @@
 
 <style>
   .vars {
-    display: contents;
     --border-color: var(--spectrum-global-color-gray-300);
+  }
+  .vars {
+    display: contents;
   }
   .table {
     display: grid;


### PR DESCRIPTION
## Description
Adds a local ESLint rule that flags comma-separated selectors containing multiple child combinator :global(...) entries, preventing the CSS minification issue fixed in bb648c77159c395b7126cee9a4f197e5643f4ee5.


## Screenshots
<img width="1586" height="125" alt="lint error example" src="https://github.com/user-attachments/assets/0bff8ec3-bae0-4e64-9ee1-85ed59cfef0d" />

<img width="1001" height="288" alt="Screenshot 2026-01-29 at 19 23 00" src="https://github.com/user-attachments/assets/0861a3f6-33ef-41fb-bd91-a88a3472c915" />

Example errors

## Launchcontrol
Prevents unsafe child :global selector lists by linting for multiple child combinator :global entries in a single rule.


