### PR TITLE
Fix unable to select a different workspace from within an app

### DIFF
--- a/packages/builder/src/components/common/WorkspaceSelect.svelte
+++ b/packages/builder/src/components/common/WorkspaceSelect.svelte
@@ -24,7 +24,7 @@
     workspaceMenu?.hide()
   }
 
-  const dispatch = createEventDispatcher()
+  const dispatch = createEventDispatcher<{ create: void }>()
 
   export let open = false
   let sortOpen = false

--- a/packages/builder/src/components/common/WorkspaceSelect.svelte
+++ b/packages/builder/src/components/common/WorkspaceSelect.svelte
@@ -42,7 +42,7 @@
   $: favourites = filtered.filter(app => app.favourite)
   $: nonFavourites = filtered.filter(app => !app.favourite)
   $: displayApps = [...favourites, ...nonFavourites]
-  $: activeIndex = displayApps.length ? 0 : -1
+  $: activeIndex = displayApps.findIndex(a => a.devId === appId)
 
   $: if (open && activeIndex >= 0) {
     itemEls[activeIndex]?.scrollIntoView({ block: "nearest" })

--- a/packages/builder/src/globals.d.ts
+++ b/packages/builder/src/globals.d.ts
@@ -1,0 +1,8 @@
+export {}
+declare global {
+  interface Window {
+    isBuilder: boolean
+    closePreview: () => void
+    previewFullscreenUrl: string
+  }
+}

--- a/packages/builder/src/helpers/urlStateSync.ts
+++ b/packages/builder/src/helpers/urlStateSync.ts
@@ -73,10 +73,12 @@ export const syncURLToState = <State extends Record<string, any>>(
   let cachedGoto = get(routify.goto)
   let cachedRedirect = get(routify.redirect)
   let cachedPage = get(routify.page)
+  const initialPage = cachedPage
   let previousParamsHash: string | null = null
   let debug = false
   const log = (...params: unknown[]) =>
     debug && console.debug(`[${urlParam}]`, ...params)
+  const isExitingPage = () => get(routify.page)?.path !== initialPage?.path
 
   // Navigate to a certain URL
   const gotoUrl = (url: string, params: Record<string, unknown>) => {
@@ -118,7 +120,7 @@ export const syncURLToState = <State extends Record<string, any>>(
     }
 
     // Check if new value is valid
-    if (validate && fallbackUrl) {
+    if (validate && fallbackUrl && !isExitingPage()) {
       if (!validate(urlValue)) {
         log("Invalid URL param!", urlValue)
         redirectUrl(fallbackUrl)
@@ -148,7 +150,7 @@ export const syncURLToState = <State extends Record<string, any>>(
     const stateValue = state?.[stateKey]
 
     // As the store updated, validate that the current state value is valid
-    if (validate && fallbackUrl) {
+    if (validate && fallbackUrl && !isExitingPage()) {
       if (!validate(stateValue)) {
         log("Invalid state param!", stateValue)
         redirectUrl(fallbackUrl)

--- a/packages/builder/src/pages/builder/workspace/[application]/_components/PreviewOverlay.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/PreviewOverlay.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { onMount } from "svelte"
   import { fade, fly } from "svelte/transition"
   import { previewStore, selectedAppUrls, themeStore } from "@/stores/builder"

--- a/packages/builder/src/pages/builder/workspace/[application]/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_layout.svelte
@@ -1,18 +1,12 @@
-<script>
+<script lang="ts">
   import WorkspaceLayout from "./_layout.workspace.svelte"
 
-  export let application
-
-  let currentAppId = application
-
-  $: if (application !== currentAppId) {
-    currentAppId = application
-  }
+  export let application: string
 </script>
 
 <!-- Needs to agressively re-render if the appId has changed -->
-{#key currentAppId}
-  <WorkspaceLayout application={currentAppId}>
+{#key application}
+  <WorkspaceLayout {application}>
     <slot />
   </WorkspaceLayout>
 {/key}

--- a/packages/builder/src/pages/builder/workspace/[application]/_layout.workspace.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_layout.workspace.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import {
     initialise,
     reset,
@@ -14,12 +14,12 @@
   import PreviewOverlay from "./_components/PreviewOverlay.svelte"
   import SideNav from "./_components/SideNav/SideNav.svelte"
 
-  export let application
+  export let application: string
 
   let promise = getPackage(application)
-  let sideNav = null
+  let sideNav: SideNav
 
-  async function getPackage(appId) {
+  async function getPackage(appId: string) {
     try {
       if ($admin.maintenance.length) {
         return
@@ -35,7 +35,7 @@
         await initialise(pkg)
       }
       await deploymentStore.load()
-    } catch (error) {
+    } catch (error: any) {
       console.error(`Error initialising app: ${error?.message}`)
       sideNav.show()
 

--- a/packages/builder/src/stores/builder/index.ts
+++ b/packages/builder/src/stores/builder/index.ts
@@ -105,6 +105,7 @@ export const reset = () => {
   navigationStore.reset()
   rowActions.reset()
   workspaceDeploymentStore.reset()
+  workspaceAppStore.reset()
 }
 
 const refreshBuilderData = async () => {

--- a/packages/builder/src/stores/builder/workspaceApps.ts
+++ b/packages/builder/src/stores/builder/workspaceApps.ts
@@ -24,11 +24,11 @@ interface DerivedWorkspaceAppStoreState extends WorkspaceAppStoreState {
   selectedWorkspaceApp: UIWorkspaceApp | undefined
 }
 
-const initialState: WorkspaceAppStoreState = {
+const createInitialState = (): WorkspaceAppStoreState => ({
   workspaceApps: [],
   loading: true,
   selectedWorkspaceAppId: undefined,
-}
+})
 
 export class WorkspaceAppStore extends DerivedBudiStore<
   WorkspaceAppStoreState,
@@ -65,11 +65,11 @@ export class WorkspaceAppStore extends DerivedBudiStore<
       )
     }
 
-    super({ ...initialState }, makeDerivedStore)
+    super(createInitialState(), makeDerivedStore)
   }
 
   reset() {
-    this.set({ ...initialState })
+    this.set(createInitialState())
   }
 
   async fetch() {

--- a/packages/builder/src/stores/builder/workspaceApps.ts
+++ b/packages/builder/src/stores/builder/workspaceApps.ts
@@ -24,19 +24,17 @@ interface DerivedWorkspaceAppStoreState extends WorkspaceAppStoreState {
   selectedWorkspaceApp: UIWorkspaceApp | undefined
 }
 
+const initialState: WorkspaceAppStoreState = {
+  workspaceApps: [],
+  loading: true,
+  selectedWorkspaceAppId: undefined,
+}
+
 export class WorkspaceAppStore extends DerivedBudiStore<
   WorkspaceAppStoreState,
   DerivedWorkspaceAppStoreState
 > {
-  private readonly initialState: WorkspaceAppStoreState
-
   constructor() {
-    const initialState: WorkspaceAppStoreState = {
-      workspaceApps: [],
-      loading: true,
-      selectedWorkspaceAppId: undefined,
-    }
-
     const makeDerivedStore = (store: Readable<WorkspaceAppStoreState>) => {
       return derived(
         [store, sortedScreens, workspaceDeploymentStore],
@@ -67,13 +65,11 @@ export class WorkspaceAppStore extends DerivedBudiStore<
       )
     }
 
-    super(initialState, makeDerivedStore)
-
-    this.initialState = initialState
+    super({ ...initialState }, makeDerivedStore)
   }
 
   reset() {
-    this.set({ ...this.initialState })
+    this.set({ ...initialState })
   }
 
   async fetch() {

--- a/packages/builder/src/stores/builder/workspaceApps.ts
+++ b/packages/builder/src/stores/builder/workspaceApps.ts
@@ -28,7 +28,15 @@ export class WorkspaceAppStore extends DerivedBudiStore<
   WorkspaceAppStoreState,
   DerivedWorkspaceAppStoreState
 > {
+  private readonly initialState: WorkspaceAppStoreState
+
   constructor() {
+    const initialState: WorkspaceAppStoreState = {
+      workspaceApps: [],
+      loading: true,
+      selectedWorkspaceAppId: undefined,
+    }
+
     const makeDerivedStore = (store: Readable<WorkspaceAppStoreState>) => {
       return derived(
         [store, sortedScreens, workspaceDeploymentStore],
@@ -59,14 +67,13 @@ export class WorkspaceAppStore extends DerivedBudiStore<
       )
     }
 
-    super(
-      {
-        workspaceApps: [],
-        loading: true,
-        selectedWorkspaceAppId: undefined,
-      },
-      makeDerivedStore
-    )
+    super(initialState, makeDerivedStore)
+
+    this.initialState = initialState
+  }
+
+  reset() {
+    this.set({ ...this.initialState })
   }
 
   async fetch() {


### PR DESCRIPTION
## Description
Fixing an issue that, in the builder, occurs when changing from a workspace resource to a new workspace that does not have this kind of resource (via the workspace dropdown). The state validators were failing, causing the state to refresh the page and not to navigate properly to that page.

## Launchcontrol
Fixing a bug that prevented switching between workspaces in some situations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workspace switching in Builder so you can move to a different workspace even if it doesn’t have the current resource. Addresses Linear 17755 by preventing invalid state validation from redirecting during navigation.

- **Bug Fixes**
  - Stop URL validation/redirects while the page is exiting to avoid forced refreshes.
  - Reset workspaceAppStore when builder stores reset to clear stale selection.
  - Highlight the active app in WorkspaceSelect and scroll it into view.
  - Key the workspace layout directly by application id; add TS typings and window globals for preview.

<sup>Written for commit 1ad9aea6158fdd35a355e127362703d6d84ebb2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

