### PR TITLE
Adjust PillInput tag spacing

### DIFF
--- a/packages/bbui/src/Form/PillInput.svelte
+++ b/packages/bbui/src/Form/PillInput.svelte
@@ -147,6 +147,7 @@
     class:is-disabled={disabled}
     class:is-focused={focused}
     class:is-invalid={!!error}
+    role="presentation"
     on:click={() => {
       if (!disabled && !readonly) {
         inputEl?.focus()

--- a/packages/bbui/src/Form/PillInput.svelte
+++ b/packages/bbui/src/Form/PillInput.svelte
@@ -245,6 +245,15 @@
     line-height: 1;
     display: inline-flex;
     align-items: center;
+    padding-left: 4px;
+    padding-right: 2px;
+  }
+  .pill-input :global(.spectrum-ClearButton) {
+    width: 16px;
+    height: 16px;
+  }
+  .pill-input :global(.spectrum-ClearButton i) {
+    font-size: 12px;
   }
   .pill-list {
     display: contents;


### PR DESCRIPTION
## Description

Adjust the PillInput tag spacing and clear icon sizing for the user invite email pills.

## Screenshots
<img width="552" height="548" alt="Screenshot_2026-01-30_at_13 53 51" src="https://github.com/user-attachments/assets/63351c64-b343-47f5-9b15-692f288f053e" />


## Launchcontrol
Smaller, better-spaced email pills in the invite input.