### PR TITLE
Some small fixes for agents

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
@@ -551,8 +551,7 @@ Any constraints the agent must follow.
       }
       await agentsStore.fetchAgents()
     } catch (error) {
-      console.error(error)
-      notifications.error("Error saving agent")
+      notifications.error(`Error saving agent: ${JSON.stringify(error)}`)
     } finally {
       saving = false
     }

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -23,6 +23,7 @@ import {
 import {
   convertToModelMessages,
   extractReasoningMiddleware,
+  isTextUIPart,
   ModelMessage,
   stepCountIs,
   streamText,
@@ -114,9 +115,9 @@ export const extractUserText = (
     return ""
   }
   return message.parts
-    .filter(part => part && typeof part === "object" && part["type"] === "text")
-    .map(part => (typeof part["text"] === "string" ? part["text"] : ""))
-    .join(" ")
+    .filter(isTextUIPart)
+    .map(part => part.text)
+    .join("")
     .trim()
 }
 

--- a/packages/server/src/sdk/workspace/ai/agents/utils.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/utils.ts
@@ -79,8 +79,10 @@ export async function buildPromptAndTools(
   tools: ToolSet
 }> {
   const { baseSystemPrompt, includeGoal = true } = options
+
   const allTools = await getAvailableTools(agent.aiconfig)
   const enabledToolNames = new Set(agent.enabledTools || [])
+  const enabledTools = allTools.filter(tool => enabledToolNames.has(tool.name))
 
   const systemPrompt = ai.composeAutomationAgentSystemPrompt({
     baseSystemPrompt,
@@ -89,15 +91,9 @@ export async function buildPromptAndTools(
     includeGoal,
   })
 
-  // This is key. We only include tools that are actually enabled on the agent.
-  const tools =
-    enabledToolNames.size > 0
-      ? allTools.filter(tool => enabledToolNames.has(tool.name))
-      : allTools
-
   return {
     systemPrompt,
-    tools: toToolSet(tools),
+    tools: toToolSet(enabledTools),
   }
 }
 


### PR DESCRIPTION
## Description
- Properly display errors when trying to save an agent
- Fix issue where the "Thinking 4.5s" wouldn't change to "Thought for 4.5s" when a tool call failed
- Fix issue where all tools were being included when an agent had 0 tools. 
- Clean up some code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agent save error messaging, reasoning timer labels in chat, and tool selection so only enabled tools are used. Also improves user-text extraction and cleans up the chat UI.

- **Bug Fixes**
  - Show a clear error when saving an agent (includes server response details).
  - Reasoning timer now switches from “Thinking” to “Thought for Xs” when a tool call fails.
  - Only include enabled tools; if none are enabled, send no tools.
  - Extract user text using a strict text-part check for better reliability.
  - Small Chatbox cleanup and refactors for readability.

<sup>Written for commit 0986188f6f4fbbd425807ee7169f5f64c119f968. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

