### PR TITLE
Add end-user app role selection and optional select borders

### DIFF
--- a/packages/bbui/src/Form/Core/Picker.svelte
+++ b/packages/bbui/src/Form/Core/Picker.svelte
@@ -24,6 +24,7 @@
   export let id: string | undefined = undefined
   export let size: "S" | "M" | "L" = "M"
   export let disabled: boolean = false
+  export let bordered: boolean = true
   export let fieldText: string = ""
   export let fieldIcon: PickerIconInput = undefined
   export let fieldColour: string = ""
@@ -226,6 +227,7 @@
 <button
   {id}
   class="spectrum-Picker spectrum-Picker--size{size}"
+  class:has-border={bordered}
   class:spectrum-Picker--quiet={quiet}
   {disabled}
   class:is-open={open}
@@ -425,6 +427,8 @@
   .spectrum-Picker {
     width: 100%;
     box-shadow: none;
+  }
+  .spectrum-Picker.has-border {
     border: 1px solid var(--spectrum-global-color-gray-200);
     border-radius: 6px;
   }

--- a/packages/bbui/src/Form/Core/Select.svelte
+++ b/packages/bbui/src/Form/Core/Select.svelte
@@ -33,6 +33,7 @@
   export let readonly: boolean = false
   export let size: "S" | "M" | "L" = "M"
   export let quiet: boolean = false
+  export let bordered: boolean = true
   export let autoWidth: boolean = false
   export let autocomplete: boolean = false
   export let sort: boolean = false
@@ -104,6 +105,7 @@
   bind:searchTerm
   on:loadMore
   {size}
+  {bordered}
   {quiet}
   {id}
   {disabled}

--- a/packages/bbui/src/Form/Select.svelte
+++ b/packages/bbui/src/Form/Select.svelte
@@ -30,6 +30,7 @@
     | undefined = undefined
   export let quiet: boolean = false
   export let size: "S" | "M" | "L" = "M"
+  export let bordered: boolean = true
   export let autoWidth: boolean = false
   export let sort: boolean = false
   export let tooltip: string | undefined = undefined
@@ -65,6 +66,7 @@
 <Field {helpText} {label} {labelPosition} {error} {tooltip}>
   <Select
     {size}
+    {bordered}
     {quiet}
     {loading}
     {disabled}

--- a/packages/builder/src/components/common/RoleSelect.svelte
+++ b/packages/builder/src/components/common/RoleSelect.svelte
@@ -21,6 +21,7 @@
   export let placeholder: string | boolean = false
   export let autoWidth: boolean = false
   export let quiet: boolean = false
+  export let bordered: boolean = true
   export let allowPublic: boolean = true
   export let allowRemove: boolean = false
   export let disabled: boolean = false
@@ -162,6 +163,7 @@
   <Select
     {autoWidth}
     {quiet}
+    {bordered}
     {disabled}
     {align}
     {footer}

--- a/packages/builder/src/pages/builder/workspace/[application]/_components/BuilderSidePanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/BuilderSidePanel.svelte
@@ -613,6 +613,7 @@
                       allowPublic={false}
                       allowCreator={true}
                       quiet={true}
+                      bordered={false}
                       on:change={e => {
                         onUpdateUserInvite(invite, e.detail)
                       }}
@@ -666,6 +667,7 @@
                       allowRemove={!!group.role}
                       allowPublic={false}
                       quiet={true}
+                      bordered={false}
                       allowCreator={group.role === Constants.Roles.CREATOR}
                       on:change={e => {
                         onUpdateGroup(group, e.detail)
@@ -722,6 +724,7 @@
                       allowPublic={false}
                       allowCreator={true}
                       quiet={true}
+                      bordered={false}
                       on:addcreator={() => {}}
                       on:change={e => {
                         onUpdateUser(user, e.detail)

--- a/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
+++ b/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
@@ -32,6 +32,11 @@
   let emailError = null
   const maxItems = 15
   let selectedRole = Constants.BudibaseRoles.AppUser
+  const endUserRoleOptions = [
+    { label: "End user: Basic", value: Constants.Roles.BASIC },
+    { label: "End user: Admin", value: Constants.Roles.ADMIN },
+  ]
+  let endUserRole = Constants.Roles.BASIC
   let onboardingType = OnboardingType.EMAIL
 
   $: userData = [
@@ -133,6 +138,10 @@
     return emailsInput.map(email => ({
       email,
       role: selectedRole,
+      appRole:
+        workspaceOnly && selectedRole === Constants.BudibaseRoles.AppUser
+          ? endUserRole
+          : undefined,
       password: generatePassword(12),
       forceResetPassword: true,
     }))
@@ -220,6 +229,19 @@
           showSelectedSubtitle={true}
         />
       </div>
+
+      {#if workspaceOnly && selectedRole === Constants.BudibaseRoles.AppUser}
+        <div class="role-select-compact">
+          <Select
+            label="Select end user role"
+            bind:value={endUserRole}
+            options={endUserRoleOptions}
+            getOptionLabel={option => option.label}
+            getOptionValue={option => option.value}
+            placeholder={false}
+          />
+        </div>
+      {/if}
 
       <div class="onboarding">
         <Label>Select onboarding</Label>

--- a/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
+++ b/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
@@ -202,7 +202,11 @@
   <svelte:fragment slot="header">
     {#if useWorkspaceInviteModal}
       <span class="modal-title">
-        <Icon name="user-plus" size="XL" />
+        <Icon
+          name="user-plus"
+          size="XL"
+          color="var(--spectrum-global-color-gray-600)"
+        />
         <span>{inviteTitle}</span>
       </span>
     {/if}

--- a/packages/builder/src/settings/pages/people/users/index.svelte
+++ b/packages/builder/src/settings/pages/people/users/index.svelte
@@ -259,7 +259,7 @@
   async function createUserFlow() {
     const assignToWorkspace = userData.assignToWorkspace ?? isWorkspaceOnly
     const payload = (userData?.users ?? []).map(user => {
-      const workspaceRole = getWorkspaceRole(user.role)
+      const workspaceRole = getWorkspaceRole(user.role, user.appRole)
       return {
         email: user.email,
         builder: user.role === Constants.BudibaseRoles.Developer,
@@ -346,7 +346,7 @@
             const matchingUser = userData.users.find(
               created => created.email === user.email
             )
-            const role = getWorkspaceRole(matchingUser?.role)
+            const role = getWorkspaceRole(matchingUser?.role, matchingUser?.appRole)
             if (!role) {
               return
             }
@@ -413,7 +413,7 @@
       .slice(0, length)
   }
 
-  const getWorkspaceRole = (role?: string) => {
+  const getWorkspaceRole = (role?: string, appRole?: string) => {
     if (!isWorkspaceOnly || !currentWorkspaceId || !role) {
       return undefined
     }
@@ -422,6 +422,9 @@
     }
     if (role === Constants.BudibaseRoles.Admin) {
       return Constants.Roles.CREATOR
+    }
+    if (role === Constants.BudibaseRoles.AppUser) {
+      return appRole || Constants.Roles.BASIC
     }
     return Constants.Roles.BASIC
   }

--- a/packages/builder/src/settings/pages/people/users/index.svelte
+++ b/packages/builder/src/settings/pages/people/users/index.svelte
@@ -346,7 +346,10 @@
             const matchingUser = userData.users.find(
               created => created.email === user.email
             )
-            const role = getWorkspaceRole(matchingUser?.role, matchingUser?.appRole)
+            const role = getWorkspaceRole(
+              matchingUser?.role,
+              matchingUser?.appRole
+            )
             if (!role) {
               return
             }

--- a/packages/builder/src/types/user.ts
+++ b/packages/builder/src/types/user.ts
@@ -6,6 +6,7 @@ export interface UserInfo {
   password: string
   forceResetPassword?: boolean
   role: keyof typeof Constants.BudibaseRoles
+  appRole?: (typeof Constants.Roles)[keyof typeof Constants.Roles]
 }
 
 export interface User extends UserDoc {

--- a/packages/frontend-core/src/constants.ts
+++ b/packages/frontend-core/src/constants.ts
@@ -60,13 +60,14 @@ export const BudibaseRoleOptions = [
   {
     label: "Creator",
     value: BudibaseRoles.Creator,
-    subtitle: "Can create and edit apps they have access to",
+    subtitle:
+      "Builder access. Can create/edit everything within assigned workspace.",
     sortOrder: 2,
   },
   {
-    label: "App user",
+    label: "End user",
     value: BudibaseRoles.AppUser,
-    subtitle: "Can only use published apps they have access to",
+    subtitle: "No builder access. Can only access published apps and agents.",
     sortOrder: 3,
   },
 ]


### PR DESCRIPTION
## Description
Add end-user app role selection in the workspace invite modal and add an optional border toggle for Selects so the access role dropdown can render borderless in the invite users side panel.

## Addresses
- https://github.com/Budibase/budibase/issues/17694

## Screenshots
<img width="567" height="637" alt="invite admin ws" src="https://github.com/user-attachments/assets/0f9fc5f0-dce5-482f-9bdf-483820a892ca" />

<img width="1601" height="400" alt="users added as admin" src="https://github.com/user-attachments/assets/512dc8e0-024e-4248-9abb-2749ddd8b5d0" />

*Users added to the workspace as admin*

<img width="460" height="358" alt="remove border" src="https://github.com/user-attachments/assets/eccb1429-4793-4ed6-a732-85b0ccf964f6" />

*I noticed I had previously introduced a dropdown border to this select where there had not been one. Added a property to the select component to allow the border to be optional.*

## Launchcontrol
Allow choosing end-user app access during workspace invites and make the access dropdown match the borderless style in the invite side panel.
