### PR TITLE
17871 google sheets sign in is endlessly looping

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,7 +25,10 @@
       "request": "launch",
       "name": "Launch Chrome against localhost",
       "url": "http://localhost:10000",
-      "webRoot": "${workspaceFolder}"
+      "webRoot": "${workspaceFolder}",
+      "sourceMapPathOverrides": {
+        "http://localhost:10000/builder/src/*": "${workspaceFolder}/packages/builder/src/*"
+      }
     }
   ],
   "compounds": [

--- a/packages/bbui/src/Modal/Modal.svelte
+++ b/packages/bbui/src/Modal/Modal.svelte
@@ -36,14 +36,8 @@
   }>()
   let visible: boolean = fixed || inline
   let modal: HTMLElement | undefined
-  let previousVisible: boolean = visible
 
-  $: {
-    if (previousVisible !== visible) {
-      dispatch(visible ? "show" : "hide")
-      previousVisible = visible
-    }
-  }
+  $: dispatch(visible ? "show" : "hide")
 
   export function show(): void {
     if (visible) {

--- a/packages/bbui/src/Modal/Modal.svelte
+++ b/packages/bbui/src/Modal/Modal.svelte
@@ -36,8 +36,14 @@
   }>()
   let visible: boolean = fixed || inline
   let modal: HTMLElement | undefined
+  let previousVisible: boolean = visible
 
-  $: dispatch(visible ? "show" : "hide")
+  $: {
+    if (previousVisible !== visible) {
+      dispatch(visible ? "show" : "hide")
+      previousVisible = visible
+    }
+  }
 
   export function show(): void {
     if (visible) {

--- a/packages/builder/src/pages/builder/workspace/[application]/data/_components/CreateExternalDatasourceModal/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/_components/CreateExternalDatasourceModal/index.svelte
@@ -19,6 +19,8 @@
   const onGoogleAuth = createOnGoogleAuthStore()
   let modal
 
+  let modalVisible = false
+
   const handleStoreChanges = (store, modal, goto) => {
     store.stage === null ? modal?.hide() : modal?.show()
 
@@ -80,7 +82,18 @@
   }
 </script>
 
-<Modal on:hide={store.cancel} bind:this={modal}>
+<Modal
+  on:show={() => {
+    modalVisible = true
+  }}
+  on:hide={() => {
+    if (modalVisible) {
+      modalVisible = false
+      store.cancel()
+    }
+  }}
+  bind:this={modal}
+>
   {#if $store.stage === "googleAuth"}
     <GoogleAuthPrompt
       on:close={() => {


### PR DESCRIPTION
## Description
BBUI modal is dispatching `on:hide` and `on:show` on load, because that reactivity statement: `$: dispatch(visible ? "show" : "hide")`. This is causing issues with the google datasource setup. This is a multistep setup, with a redirect back from google. When we get the redirect, the `on:hide` triggers by default, cancelling the process.

The right solution is to only dispatch `on:hide` if it actually hides the modal, not on load. But because we don't know the impact of it and it needs to be tested, now I just handle it in the google datasource itself in order to release the quickfix.
<img width="623" height="235" alt="image" src="https://github.com/user-attachments/assets/3b30e631-a470-4a22-a867-e721464ddfa3" />


## Launchcontrol
Fix google docs datasource creation



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Google Sheets sign-in loop (Linear 17871) by handling modal show/hide only after the modal has actually been shown, preventing the initial mount from triggering cancel. Adds a VS Code source map path override to improve local debugging.

<sup>Written for commit 966486b9b29f24ddc05d62e1b60d9145fcbe2ec4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



