### PR TITLE
bump scan count to 1000

### DIFF
--- a/packages/backend-core/src/redis/redis.ts
+++ b/packages/backend-core/src/redis/redis.ts
@@ -141,11 +141,11 @@ class RedisWrapper {
       let stream: ScanStream
       if (isCluster(this.client)) {
         let node = this.client.nodes("master")
-        stream = node[0].scanStream({ match: key + "*", count: 100 })
+        stream = node[0].scanStream({ match: key + "*", count: 1000 })
       } else {
         stream = (this.client as Redis).scanStream({
           match: key + "*",
-          count: 100,
+          count: 1000,
         })
       }
 


### PR DESCRIPTION
## Description
Noticed the performance of the user invites table in production is slow. Increasing the count of the redis scan to see if it helps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase Redis scanStream count from 100 to 1000 to speed up user invites table load times in production. Applies to both cluster and single-node clients.

<sup>Written for commit 7e5ea2a6fcc6a58e0d352f33683b0bd21574f6e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

