### PR TITLE
Fix grid conditions

### DIFF
--- a/packages/client/src/components/app/GridBlock.svelte
+++ b/packages/client/src/components/app/GridBlock.svelte
@@ -215,7 +215,7 @@
         type: settings.type,
         icon: settings.icon,
         getRowConditions: row =>
-          enrichConditions(settings.conditions, { [id]: row }),
+          enrichConditions(settings.conditions, { ...$context, [id]: row }),
         conditions: settings.conditions,
         onClick: async row => {
           // Create a fake, ephemeral context to run the buttons actions/conditions with

--- a/packages/client/src/components/app/GridBlock.svelte
+++ b/packages/client/src/components/app/GridBlock.svelte
@@ -6,6 +6,7 @@
   import { featuresStore } from "@/stores"
   import { Grid } from "@budibase/frontend-core"
   import { processStringSync } from "@budibase/string-templates"
+  import { enrichGridConditions } from "@/utils/conditions"
   import { UILogicalOperator, EmptyFilterOption } from "@budibase/types"
 
   // table is actually any datasource, but called table for legacy compatibility
@@ -169,7 +170,7 @@
         displayName: column.label,
         order: idx,
         visible: !!column.active,
-        conditions: enrichConditions(column.conditions, context),
+        conditions: enrichGridConditions(column.conditions, context),
         format: createFormatter(column),
 
         // Small hack to ensure we react to all changes, as our
@@ -181,19 +182,6 @@
       }
     })
     return overrides
-  }
-
-  const enrichConditions = (conditions, context) => {
-    return conditions?.map(condition => {
-      return {
-        ...condition,
-        referenceValue: processStringSync(
-          condition.referenceValue || "",
-          context
-        ),
-        newValue: processStringSync(condition.newValue || "", context),
-      }
-    })
   }
 
   const createFormatter = column => {
@@ -215,7 +203,7 @@
         type: settings.type,
         icon: settings.icon,
         getRowConditions: row =>
-          enrichConditions(settings.conditions, { ...$context, [id]: row }),
+          enrichGridConditions(settings.conditions, { ...$context, [id]: row }),
         conditions: settings.conditions,
         onClick: async row => {
           // Create a fake, ephemeral context to run the buttons actions/conditions with

--- a/packages/client/src/utils/conditions.js
+++ b/packages/client/src/utils/conditions.js
@@ -1,5 +1,6 @@
 import { QueryUtils } from "@budibase/frontend-core"
 import { EmptyFilterOption } from "@budibase/types"
+import { processStringSync } from "@budibase/string-templates"
 
 export const getActiveConditions = conditions => {
   if (!conditions?.length) {
@@ -56,4 +57,17 @@ export const reduceConditionActions = conditions => {
   })
 
   return { settingUpdates, visible }
+}
+
+export const enrichGridConditions = (conditions, context) => {
+  return conditions?.map(condition => {
+    return {
+      ...condition,
+      referenceValue: processStringSync(
+        condition.referenceValue || "",
+        context
+      ),
+      newValue: processStringSync(condition.newValue || "", context),
+    }
+  })
 }

--- a/packages/client/src/utils/conditions.test.js
+++ b/packages/client/src/utils/conditions.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { enrichGridConditions } from "./conditions"
+
+describe("enrichGridConditions", () => {
+  it("enriches row and current user bindings in conditions", () => {
+    const context = {
+      user: { roleId: "ADMIN" },
+      table1: { name: "Row 1" },
+    }
+
+    const [condition] = enrichGridConditions(
+      [
+        {
+          referenceValue: "{{ [user].[roleId] }}",
+          newValue: "{{ [table1].[name] }}",
+        },
+      ],
+      context
+    )
+
+    expect(condition.referenceValue).toEqual("ADMIN")
+    expect(condition.newValue).toEqual("Row 1")
+  })
+})

--- a/packages/client/src/utils/conditions.test.js
+++ b/packages/client/src/utils/conditions.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, expect, it } from "vitest"
 import { enrichGridConditions } from "./conditions"
 


### PR DESCRIPTION
## Description
Fixes table button visibility conditions that rely on Current User bindings by ensuring row button condition enrichment merges the existing app context with the row context, and adds a small regression test for condition enrichment.

## Addresses
- Customer reported issue

## Screenshots
**Binding value**
<img width="1232" height="424" alt="Screenshot 2026-02-02 at 10 53 50" src="https://github.com/user-attachments/assets/43e1bfc3-b018-499c-b508-e464fe05f0b3" />

**Before fix**
<img width="1567" height="918" alt="Screenshot 2026-02-02 at 10 54 11" src="https://github.com/user-attachments/assets/d922b8c4-e310-4692-a297-54ac6b4f17bd" />

**After Fix**
<img width="1565" height="920" alt="Screenshot 2026-02-02 at 10 55 38" src="https://github.com/user-attachments/assets/ea6b75ac-d07c-4574-a2c3-5e6033b33881" />

## Launchcontrol
Table buttons now have access to the extra context they need to work with the current user bindings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes grid row button visibility by resolving conditions with both Current User and row context. Buttons now show/hide correctly in tables.

- **Bug Fixes**
  - Merge app context with row context when evaluating row button conditions, so Current User bindings work.

- **Refactors**
  - Move condition enrichment to utils as enrichGridConditions and use it for columns and row buttons.
  - Add a regression test covering user and row binding resolution.

<sup>Written for commit c05b446d0353984e9ce47381152320dbf0b8350d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

