### PR TITLE
17911 translations should affect the required validation rule

### DIFF
--- a/packages/client/src/components/app/forms/InnerForm.svelte
+++ b/packages/client/src/components/app/forms/InnerForm.svelte
@@ -4,6 +4,7 @@
   import { derived, get, writable } from "svelte/store"
   import { createValidatorFromConstraints } from "./validation"
   import { Helpers } from "@budibase/bbui"
+  import { loadTranslationsByGroup } from "@budibase/frontend-core"
   import {
     type DataFetchDatasource,
     type FieldSchema,
@@ -56,6 +57,7 @@
 
   const component = getContext("component")
   const { styleable, Provider, ActionTypes } = getContext("sdk")
+  const validationLabels = loadTranslationsByGroup("validation")
 
   let fields: Writable<FieldInfo>[] = []
   const formState = writable({
@@ -216,7 +218,8 @@
         schemaConstraints,
         validationRules,
         field,
-        definition
+        definition,
+        validationLabels.required
       )
 
       // Sanitise the default value to ensure it doesn't contain invalid data

--- a/packages/client/src/components/app/forms/validation.ts
+++ b/packages/client/src/components/app/forms/validation.ts
@@ -15,7 +15,8 @@ export const createValidatorFromConstraints = (
   schemaConstraints: FieldConstraints | null | undefined,
   customRules: UIFieldValidationRule[],
   field: string,
-  definition: Table | undefined
+  definition: Table | undefined,
+  requiredError?: string
 ) => {
   let rules: UIFieldValidationRule[] = []
 
@@ -33,7 +34,7 @@ export const createValidatorFromConstraints = (
             ? FieldType.ARRAY
             : FieldType.STRING,
         constraint: "required",
-        error: "Required",
+        error: requiredError || "Required",
       })
     }
 

--- a/packages/shared-core/src/translations/index.ts
+++ b/packages/shared-core/src/translations/index.ts
@@ -6,6 +6,7 @@ import { recaptchaTranslations } from "./recaptcha"
 import { portalTranslations } from "./portal"
 import { loginTranslations } from "./login"
 import { forgotPasswordTranslations } from "./forgotPassword"
+import { validationTranslations } from "./validation"
 import type {
   TranslationCategory,
   TranslationDefinition,
@@ -22,6 +23,7 @@ export {
   portalTranslations,
   loginTranslations,
   forgotPasswordTranslations,
+  validationTranslations,
 }
 
 const translationModules = [
@@ -33,6 +35,7 @@ const translationModules = [
   portalTranslations,
   loginTranslations,
   forgotPasswordTranslations,
+  validationTranslations,
 ]
 
 export const TRANSLATION_CATEGORY_LABELS: Record<TranslationCategory, string> =
@@ -45,6 +48,7 @@ export const TRANSLATION_CATEGORY_LABELS: Record<TranslationCategory, string> =
     portal: "Portal",
     login: "Login",
     forgotPassword: "Forgot password",
+    validation: "Validation",
   }
 
 // Central export of all translation definitions across modules.

--- a/packages/shared-core/src/translations/types.ts
+++ b/packages/shared-core/src/translations/types.ts
@@ -7,6 +7,7 @@ export type TranslationCategory =
   | "portal"
   | "login"
   | "forgotPassword"
+  | "validation"
 
 export interface TranslationDefinitionInput {
   key: string

--- a/packages/shared-core/src/translations/validation.ts
+++ b/packages/shared-core/src/translations/validation.ts
@@ -1,0 +1,11 @@
+import { createTranslationDefinitions } from "./types"
+
+const category = "validation"
+
+export const validationTranslations = createTranslationDefinitions(category, [
+  {
+    key: "required",
+    name: "Required field error",
+    defaultValue: "Required",
+  },
+])


### PR DESCRIPTION
## Description
Added a new "Validation" translation category with a required‑field message, and wired form validation to use it so the required text can be customised via the translations feature. The required rule now pulls validation.required from translations, falling back to the previous "Required" message when no override is set.

## Addresses
- https://github.com/Budibase/budibase/issues/17911

## Screenshots
<img width="911" height="428" alt="Screenshot 2026-02-02 at 12 50 48" src="https://github.com/user-attachments/assets/71ccf8c1-7c11-44c0-a6cc-bfb8d118a493" />

## Launchcontrol
Adds a new Validation section for translations that includes a message for required fields. The form now uses this message when showing "required" errors, so the wording can be changed through translations. If no custom message is provided, it will still show the original “Required” text as a fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Validation translation group and uses it for required-field errors in forms so teams can localize or customize the message. If no translation is set, it falls back to "Required".

- **New Features**
  - New "Validation" translation group with key validation.required.
  - Required rule reads the translated message; falls back to "Required".

- **Migration**
  - Optional: add a "Validation > Required field error" translation to customize the text.

<sup>Written for commit b6b7323ad032d909906f7a4854f8ff86fd4611b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

