### PR TITLE
Autoupdate for automerges

### DIFF
--- a/.github/workflows/autoupdate-automerge.yml
+++ b/.github/workflows/autoupdate-automerge.yml
@@ -1,0 +1,24 @@
+name: Autoupdate Automerge PRs
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Update eligible PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = require("./scripts/autoupdate-automerge")
+            await run({ github, context, core })

--- a/scripts/autoupdate-automerge.js
+++ b/scripts/autoupdate-automerge.js
@@ -1,0 +1,93 @@
+module.exports = async ({ github, context, core }) => {
+  const owner = context.repo.owner
+  const repo = context.repo.repo
+
+  const getReviewDecision = async prNumber => {
+    const { data: reviews } = await github.rest.pulls.listReviews({
+      owner,
+      repo,
+      pull_number: prNumber,
+      per_page: 100,
+    })
+
+    const latestByUser = new Map()
+    for (const review of reviews) {
+      if (!review.user?.login || !review.submitted_at) {
+        continue
+      }
+      const existing = latestByUser.get(review.user.login)
+      if (!existing || new Date(review.submitted_at) > new Date(existing.submitted_at)) {
+        latestByUser.set(review.user.login, review)
+      }
+    }
+
+    let hasApproval = false
+    let hasChangesRequested = false
+    for (const review of latestByUser.values()) {
+      if (review.state === "APPROVED") {
+        hasApproval = true
+      }
+      if (review.state === "CHANGES_REQUESTED") {
+        hasChangesRequested = true
+      }
+    }
+
+    return hasApproval && !hasChangesRequested
+  }
+
+  const updateIfEligible = async pr => {
+    if (pr.auto_merge == null) {
+      return false
+    }
+
+    const fromFork = pr.head.repo.full_name !== `${owner}/${repo}`
+    if (fromFork) {
+      return false
+    }
+
+    if (pr.mergeable_state !== "behind") {
+      return false
+    }
+
+    const approved = await getReviewDecision(pr.number)
+    if (!approved) {
+      return false
+    }
+
+    await github.graphql(
+      `mutation($pullRequestId: ID!, $expectedHeadOid: GitObjectID) {
+        updatePullRequestBranch(input: { pullRequestId: $pullRequestId, expectedHeadOid: $expectedHeadOid }) {
+          pullRequest { number }
+        }
+      }`,
+      { pullRequestId: pr.node_id, expectedHeadOid: pr.head.sha }
+    )
+
+    core.info(`Branch update requested for PR #${pr.number}`)
+    return true
+  }
+
+  const prs = await github.paginate(github.rest.pulls.list, {
+    owner,
+    repo,
+    state: "open",
+    per_page: 100,
+  })
+
+  let updated = 0
+  for (const prSummary of prs) {
+    if (!prSummary.auto_merge) {
+      continue
+    }
+    const { data: pr } = await github.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: prSummary.number,
+    })
+    if (await updateIfEligible(pr)) {
+      updated++
+    }
+  }
+
+  core.info(`Updated ${updated} PR(s)`)
+}

--- a/scripts/autoupdate-automerge.js
+++ b/scripts/autoupdate-automerge.js
@@ -2,7 +2,7 @@ module.exports = async ({ github, context, core }) => {
   const owner = context.repo.owner
   const repo = context.repo.repo
 
-  const getReviewDecision = async prNumber => {
+  const isApproved = async prNumber => {
     const { data: reviews } = await github.rest.pulls.listReviews({
       owner,
       repo,
@@ -16,7 +16,10 @@ module.exports = async ({ github, context, core }) => {
         continue
       }
       const existing = latestByUser.get(review.user.login)
-      if (!existing || new Date(review.submitted_at) > new Date(existing.submitted_at)) {
+      if (
+        !existing ||
+        new Date(review.submitted_at) > new Date(existing.submitted_at)
+      ) {
         latestByUser.set(review.user.login, review)
       }
     }
@@ -49,7 +52,7 @@ module.exports = async ({ github, context, core }) => {
       return false
     }
 
-    const approved = await getReviewDecision(pr.number)
+    const approved = await isApproved(pr.number)
     if (!approved) {
       return false
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automatically updates approved auto-merge PRs that are behind master. Runs on every push to master so eligible PRs stay up to date and merge faster.

- **New Features**
  - Adds a GitHub Action triggered on push to master.
  - Script updates PRs that: have auto-merge on, are from this repo, are behind, have approval, and no changes requested.
  - Uses the latest review per user to decide approval.
  - Calls updatePullRequestBranch with expected head SHA to safely update branches.

<sup>Written for commit d8b3db160dde2cd5f0d95922d8ff5bf89874dc0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



