### PR TITLE
Use correct URL for confluence

### DIFF
--- a/packages/builder/src/stores/builder/restTemplates.ts
+++ b/packages/builder/src/stores/builder/restTemplates.ts
@@ -1805,11 +1805,11 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       description: "Atlassian Confluence API for content, spaces, and users",
       specs: [
         {
-          version: "1.0.0",
-          url: "https://raw.githubusercontent.com/Budibase/openapi-rest-templates/main/confluence/openapi.json",
+          version: "2.0.0",
+          url: "https://dac-static.atlassian.com/cloud/confluence/openapi-v2.v3.json?_v=1.8327.0",
         },
       ],
-      operationsCount: 616,
+      operationsCount: 212,
       icon: ConfluenceLogo,
       verified: true,
     },


### PR DESCRIPTION
## Launchcontrol
Correct URL for Confluence REST Template


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Confluence REST template to use Atlassian’s official OpenAPI v2 spec. This fixes the URL, sets version to 2.0.0, and aligns the operation count to 212.

<sup>Written for commit 8e4b1c907c7972f2b1e6d37a9cece0a9b2b34c6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

