### PR TITLE
If the SingleRowProvider finds no row, don't throw just explain

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -8976,6 +8976,12 @@
         "key": "rowId",
         "required": true,
         "resetOn": "datasource"
+      },
+      {
+        "type": "text",
+        "label": "No row message",
+        "key": "noRowMessage",
+        "defaultValue": "No row found"
       }
     ],
     "context": {

--- a/packages/client/src/components/app/SingleRowProvider.svelte
+++ b/packages/client/src/components/app/SingleRowProvider.svelte
@@ -10,6 +10,7 @@
 
   let row: Row | null | undefined
   let loading = true
+  let noRowFound = false
 
   $: datasourceId =
     datasource.type === "table" ? datasource.tableId : datasource.id
@@ -25,15 +26,19 @@
   const fetchRow = async (datasourceId: string, rowId: string) => {
     if (!datasourceId || !rowId) {
       row = undefined
+      noRowFound = true
       loading = false
       return
     }
 
     loading = true
+    noRowFound = false
     try {
-      row = await API.fetchRow(datasourceId, rowId)
+      row = await API.fetchRow(datasourceId, rowId, true)
+      noRowFound = row == null
     } catch (e) {
       row = undefined
+      noRowFound = true
     } finally {
       loading = false
     }
@@ -42,9 +47,13 @@
 
 {#if !loading}
   <div use:styleable={$component.styles}>
-    <Provider {actions} data={row ?? null}>
-      <slot />
-    </Provider>
+    {#if noRowFound}
+      <div class="noRows"><i class="ri-list-check-2"></i>No row found</div>
+    {:else}
+      <Provider {actions} data={row ?? null}>
+        <slot />
+      </Provider>
+    {/if}
   </div>
 {/if}
 
@@ -54,5 +63,18 @@
     flex-direction: column;
     justify-content: flex-start;
     align-items: stretch;
+  }
+
+  .noRows {
+    color: var(--spectrum-global-color-gray-600);
+    font-size: var(--font-size-s);
+    padding: var(--spacing-l);
+    display: grid;
+    place-items: center;
+  }
+  .noRows i {
+    margin-bottom: var(--spacing-m);
+    font-size: 1.5rem;
+    color: var(--spectrum-global-color-gray-600);
   }
 </style>

--- a/packages/client/src/components/app/SingleRowProvider.svelte
+++ b/packages/client/src/components/app/SingleRowProvider.svelte
@@ -4,6 +4,7 @@
 
   export let datasource: TableDatasource | ViewDatasource
   export let rowId: string
+  export let noRowMessage: string | undefined
 
   const component = getContext("component")
   const { styleable, API, Provider, ActionTypes } = getContext("sdk")
@@ -48,7 +49,9 @@
 {#if !loading}
   <div use:styleable={$component.styles}>
     {#if noRowFound}
-      <div class="noRows"><i class="ri-list-check-2"></i>No row found</div>
+      <div class="noRows">
+        <i class="ri-list-check-2"></i>{noRowMessage ?? "No row found"}
+      </div>
     {:else}
       <Provider {actions} data={row ?? null}>
         <slot />

--- a/packages/frontend-core/src/api/rows.ts
+++ b/packages/frontend-core/src/api/rows.ts
@@ -11,7 +11,11 @@ import {
 import { BaseAPIClient } from "./types"
 
 export interface RowEndpoints {
-  fetchRow: (tableId: string, rowId: string) => Promise<FindRowResponse>
+  fetchRow: (
+    tableId: string,
+    rowId: string,
+    suppressErrors?: boolean
+  ) => Promise<FindRowResponse>
   saveRow: (
     row: SaveRowRequest,
     suppressErrors?: boolean
@@ -34,10 +38,12 @@ export const buildRowEndpoints = (API: BaseAPIClient): RowEndpoints => ({
    * Fetches data about a certain row in a data source.
    * @param sourceId the ID of the table or view to fetch from
    * @param rowId the ID of the row to fetch
+   * @param suppressErrors whether or not to suppress error notifications
    */
-  fetchRow: async (sourceId, rowId) => {
+  fetchRow: async (sourceId, rowId, suppressErrors = false) => {
     return await API.get({
       url: `/api/${sourceId}/rows/${rowId}`,
+      suppressErrors,
     })
   },
 


### PR DESCRIPTION
## Description
Previously the SingleRowProvider was throwing an error if no row was found. Now simply displaying a message "No row found" and hide nested components, similar to the Repeater Block.

## Addresses
- https://github.com/Budibase/budibase/issues/17389

## Screenshots
https://github.com/user-attachments/assets/fc76c63d-6457-474f-9961-7d0170a9fd1c

## Launchcontrol
Don't throw error if SingleRowProvider does not find a row

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop throwing when SingleRowProvider can’t find a row. Show a configurable “No row found” message and hide child content, matching Repeater Block behavior.

- **Bug Fixes**
  - SingleRowProvider: detect missing row, render message, skip nested content.
  - rows API: add suppressErrors to fetchRow and use it to suppress error notifications.

- **New Features**
  - SingleRowProvider: add “No row message” setting/prop to customize the text.

<sup>Written for commit 02f3ff0800ff99d6f05db71380a4512f676ee4fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

