### PR TITLE
Improve CSV import chunking

### DIFF
--- a/packages/builder/src/components/backend/DataTable/buttons/ImportButton.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/ImportButton.svelte
@@ -2,6 +2,10 @@
   import { ActionButton, Button, Body, notifications } from "@budibase/bbui"
   import DetailPopover from "@/components/common/DetailPopover.svelte"
   import ExistingTableDataImport from "@/components/backend/TableNavigator/ExistingTableDataImport.svelte"
+  import {
+    chunkRows,
+    IMPORT_ROWS_PER_CHUNK,
+  } from "@/components/backend/TableNavigator/utils"
   import { dataAPI } from "@/stores/builder"
   import { createEventDispatcher } from "svelte"
 
@@ -30,7 +34,10 @@
   const importData = async () => {
     try {
       loading = true
-      await $dataAPI.importTableData(tableId, rows, identifierFields)
+      const chunks = chunkRows(rows, IMPORT_ROWS_PER_CHUNK)
+      for (const chunk of chunks) {
+        await $dataAPI.importTableData(tableId, chunk, identifierFields)
+      }
       notifications.success("Rows successfully imported")
       popover.hide()
     } catch (error) {

--- a/packages/builder/src/components/backend/TableNavigator/ExistingTableDataImport.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/ExistingTableDataImport.svelte
@@ -7,7 +7,7 @@
   import { Select, Toggle, Multiselect, Label, Layout } from "@budibase/bbui"
   import { DB_TYPE_INTERNAL } from "@/constants/backend"
   import { API } from "@/api"
-  import { parseFile } from "./utils"
+  import { getValidationRows, parseFile } from "./utils"
   import { tables, datasources } from "@/stores/builder"
 
   let error = null
@@ -108,11 +108,12 @@
       rows = response.rows
       fileName = response.fileName
 
-      const newValidateHash = JSON.stringify(rows)
+      const validationRows = getValidationRows(rows)
+      const newValidateHash = JSON.stringify(validationRows)
       if (newValidateHash === validateHash) {
         validation = previousValidation
       } else {
-        await validate(rows)
+        await validate(validationRows)
         validateHash = newValidateHash
       }
     } catch (e) {
@@ -122,13 +123,16 @@
     }
   }
 
-  async function validate(rows) {
+  async function validate(rowsToValidate) {
     error = null
     validation = {}
     allValid = false
 
-    if (rows.length > 0) {
-      const response = await API.validateExistingTableImport(rows, tableId)
+    if (rowsToValidate.length > 0) {
+      const response = await API.validateExistingTableImport(
+        rowsToValidate,
+        tableId
+      )
       validation = response.schemaValidation
       invalidColumns = response.invalidColumns
       allValid = response.allValid

--- a/packages/builder/src/components/backend/TableNavigator/TableDataImport.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/TableDataImport.svelte
@@ -4,7 +4,7 @@
   import { utils } from "@budibase/shared-core"
   import { canBeDisplayColumn } from "@budibase/frontend-core"
   import { API } from "@/api"
-  import { parseFile } from "./utils"
+  import { getValidationRows, parseFile } from "./utils"
 
   export let rows = []
   export let schema = {}
@@ -112,9 +112,11 @@
     rows = rawRows.map(row => utils.trimOtherProps(row, Object.keys(schema)))
 
     // binding in consumer is causing double renders here
-    const newValidateHash = JSON.stringify(rows) + JSON.stringify(schema)
+    const validationRows = getValidationRows(rows)
+    const newValidateHash =
+      JSON.stringify(validationRows) + JSON.stringify(schema)
     if (newValidateHash !== validateHash) {
-      validate(rows, schema)
+      validate(validationRows, schema)
     }
     validateHash = newValidateHash
   }
@@ -143,11 +145,14 @@
     }
   }
 
-  async function validate(rows, schema) {
+  async function validate(rowsToValidate, schema) {
     loading = true
     try {
-      if (rows.length > 0) {
-        const response = await API.validateNewTableImport(rows, schema)
+      if (rowsToValidate.length > 0) {
+        const response = await API.validateNewTableImport(
+          rowsToValidate,
+          schema
+        )
         validation = response.schemaValidation
         allValid = response.allValid
         errors = response.errors

--- a/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
@@ -87,6 +87,14 @@
       set.add(value)
     }
 
+    const parseJsonValue = raw => {
+      try {
+        return { ok: true, value: JSON.parse(raw) }
+      } catch (_error) {
+        return { ok: false }
+      }
+    }
+
     const parseArrayValue = value => {
       if (Array.isArray(value)) {
         return value
@@ -100,12 +108,17 @@
           return []
         }
         if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
-          try {
-            const parsed = JSON.parse(trimmed.replace(/'/g, '"'))
-            return Array.isArray(parsed) ? parsed : [parsed]
-          } catch (_error) {
-            return [value]
+          const parsed = parseJsonValue(trimmed)
+          if (parsed.ok) {
+            return Array.isArray(parsed.value) ? parsed.value : [parsed.value]
           }
+          const fallback = parseJsonValue(trimmed.replace(/'/g, '"'))
+          if (fallback.ok) {
+            return Array.isArray(fallback.value)
+              ? fallback.value
+              : [fallback.value]
+          }
+          return [value]
         }
         return [value]
       }

--- a/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
@@ -1,9 +1,11 @@
 <script>
   import { goto as gotoStore, url } from "@roxi/routify"
-  import { DataEnvironmentMode } from "@budibase/types"
+  import { DataEnvironmentMode, FieldType } from "@budibase/types"
   import { notifications, Input, ModalContent } from "@budibase/bbui"
+  import { API } from "@/api"
   import { tables, datasources, dataEnvironmentStore } from "@/stores/builder"
   import TableDataImport from "../TableDataImport.svelte"
+  import { chunkRows, IMPORT_ROWS_PER_CHUNK } from "../utils"
   import {
     BUDIBASE_INTERNAL_DB_ID,
     BUDIBASE_DATASOURCE_TYPE,
@@ -44,6 +46,95 @@
   let allValid = true
   let displayColumn = null
 
+  const buildOptionConstraints = (schema, rows) => {
+    const updatedSchema = {}
+    const optionColumns = []
+
+    for (const [name, field] of Object.entries(schema || {})) {
+      const constraints = field?.constraints ? { ...field.constraints } : {}
+      updatedSchema[name] = { ...field, constraints }
+
+      if (
+        field?.type === FieldType.OPTIONS ||
+        field?.type === FieldType.ARRAY
+      ) {
+        updatedSchema[name].constraints = {
+          ...constraints,
+          inclusion: Array.isArray(constraints.inclusion)
+            ? [...constraints.inclusion]
+            : [],
+        }
+        optionColumns.push({
+          name,
+          isArray: field.type === FieldType.ARRAY,
+        })
+      }
+    }
+
+    if (!rows?.length || optionColumns.length === 0) {
+      return updatedSchema
+    }
+
+    const inclusionMap = optionColumns.reduce((acc, { name }) => {
+      acc[name] = new Set()
+      return acc
+    }, {})
+
+    const addValue = (set, value) => {
+      if (value === null || value === undefined || value === "") {
+        return
+      }
+      set.add(value)
+    }
+
+    const parseArrayValue = value => {
+      if (Array.isArray(value)) {
+        return value
+      }
+      if (value === null || value === undefined || value === "") {
+        return []
+      }
+      if (typeof value === "string") {
+        const trimmed = value.trim()
+        if (!trimmed) {
+          return []
+        }
+        if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+          try {
+            const parsed = JSON.parse(trimmed.replace(/'/g, '"'))
+            return Array.isArray(parsed) ? parsed : [parsed]
+          } catch (_error) {
+            return [value]
+          }
+        }
+        return [value]
+      }
+      return [value]
+    }
+
+    for (const row of rows) {
+      for (const { name, isArray } of optionColumns) {
+        const value = row?.[name]
+        if (isArray) {
+          const values = parseArrayValue(value)
+          values.forEach(val => addValue(inclusionMap[name], val))
+        } else if (Array.isArray(value)) {
+          value.forEach(val => addValue(inclusionMap[name], val))
+        } else {
+          addValue(inclusionMap[name], value)
+        }
+      }
+    }
+
+    for (const { name } of optionColumns) {
+      updatedSchema[name].constraints.inclusion = Array.from(
+        inclusionMap[name]
+      ).sort()
+    }
+
+    return updatedSchema
+  }
+
   function checkValid(evt) {
     const tableName = evt.target.value
     if (tableNames.includes(tableName)) {
@@ -54,10 +145,10 @@
   }
 
   async function saveTable() {
+    const schemaForSave = buildOptionConstraints(schema, rows)
     let newTable = {
       name,
-      schema: { ...schema },
-      rows,
+      schema: { ...schemaForSave },
       type: "table",
       sourceId: targetDatasourceId,
       sourceType: DB_TYPE_INTERNAL,
@@ -68,11 +159,21 @@
       newTable.primaryDisplay = displayColumn
     }
 
-    // Create table
     let table
     try {
       await beforeSave()
-      table = await tables.save(newTable)
+      if (rows.length > IMPORT_ROWS_PER_CHUNK) {
+        table = await tables.save(newTable)
+        const chunks = chunkRows(rows, IMPORT_ROWS_PER_CHUNK)
+        for (const chunk of chunks) {
+          await API.importTableData(table._id, chunk)
+        }
+      } else {
+        table = await tables.save({
+          ...newTable,
+          rows,
+        })
+      }
       dataEnvironmentStore.setMode(DataEnvironmentMode.DEVELOPMENT)
       await datasources.fetch()
       await afterSave(table)

--- a/packages/builder/src/components/backend/TableNavigator/utils.js
+++ b/packages/builder/src/components/backend/TableNavigator/utils.js
@@ -2,7 +2,8 @@ import { API } from "@/api"
 import { FIELDS } from "@/constants/backend"
 
 const BYTES_IN_MB = 1000000
-const FILE_SIZE_LIMIT = BYTES_IN_MB * 5
+const FILE_SIZE_LIMIT = BYTES_IN_MB * 10
+export const IMPORT_ROWS_PER_CHUNK = 5000
 
 const getDefaultSchema = rows => {
   const newSchema = {}
@@ -65,6 +66,31 @@ export const parseFile = e => {
 
     reader.readAsText(file)
   })
+}
+
+export const getValidationRows = rows => {
+  if (!Array.isArray(rows)) {
+    return []
+  }
+
+  if (rows.length <= IMPORT_ROWS_PER_CHUNK) {
+    return rows
+  }
+
+  return rows.slice(0, IMPORT_ROWS_PER_CHUNK)
+}
+
+export const chunkRows = (rows, size = IMPORT_ROWS_PER_CHUNK) => {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return []
+  }
+
+  const chunkSize = size > 0 ? size : IMPORT_ROWS_PER_CHUNK
+  const chunks = []
+  for (let i = 0; i < rows.length; i += chunkSize) {
+    chunks.push(rows.slice(i, i + chunkSize))
+  }
+  return chunks
 }
 
 export const alphabetical = (a, b) => {


### PR DESCRIPTION
## Description
Improve large CSV imports by chunking row uploads and limiting validation payloads to avoid timeouts. Also precomputes inclusion constraints for options/array fields when creating a table from a large CSV.

BEFORE:
<img width="491" height="93" alt="Screenshot 2026-02-04 at 13 45 32" src="https://github.com/user-attachments/assets/c5382292-3134-4766-b713-2e7d2ce329d3" />

Simply increasing the allowed file size was insufficient as the payload is too great. The import needs to be chunked for large files, i.e. 5000 rows at a time. 

After adding chunking, the 9MB 51k customers test data could be imported in under 40s, with no timeout. 

## Additional information
51k test customers csv (9MB): 
[customers-51000.csv](https://github.com/user-attachments/files/25073484/customers-51000.csv)


## Launchcontrol
Improve reliability of large CSV imports by splitting them into smaller chunks and reducing pre-validation payloads.
