### PR TITLE
Add resolver for settings routing as it was causing issues in HMR

### DIFF
--- a/packages/builder/src/stores/bb.ts
+++ b/packages/builder/src/stores/bb.ts
@@ -1,7 +1,13 @@
-import { match, MatchedRoute } from "@/types/routing"
+import type { MatchedRoute } from "@/types/routing"
 import { BudiStore } from "./BudiStore"
-import { get } from "svelte/store"
-import { flattenedRoutes } from "@/stores/routing"
+
+type SettingsRouteResolver = (path: string) => MatchedRoute | null
+
+let settingsRouteResolver: SettingsRouteResolver | null = null
+
+export const setSettingsRouteResolver = (resolver: SettingsRouteResolver) => {
+  settingsRouteResolver = resolver
+}
 
 export interface Settings {
   open: boolean
@@ -21,7 +27,6 @@ export const INITIAL_GLOBAL_STATE: BBState = {
 export class BBStore extends BudiStore<BBState> {
   constructor() {
     super(INITIAL_GLOBAL_STATE)
-
     this.hideSettings = this.hideSettings.bind(this)
   }
 
@@ -30,7 +35,6 @@ export class BBStore extends BudiStore<BBState> {
   }
 
   settings(path?: string) {
-    // Just open the settings and allow it to defer to its default path
     if (!path) {
       this.update(state => ({
         ...state,
@@ -42,8 +46,7 @@ export class BBStore extends BudiStore<BBState> {
       return
     }
 
-    const matchedRoute = match(path, get(flattenedRoutes))
-
+    const matchedRoute = settingsRouteResolver?.(path)
     if (matchedRoute) {
       this.update(state => ({
         ...state,

--- a/packages/builder/src/stores/routing.ts
+++ b/packages/builder/src/stores/routing.ts
@@ -1,10 +1,11 @@
-import { flatten } from "@/types/routing"
-import { derived } from "svelte/store"
+import { flatten, match } from "@/types/routing"
+import { derived, get } from "svelte/store"
 
 // Use direct imports to avoid circular dependency in licensing
 import { auth } from "@/stores/portal/auth"
 import { admin } from "@/stores/portal/admin"
 import { appStore } from "@/stores/builder/app"
+import { setSettingsRouteResolver } from "@/stores/bb"
 import { appsStore } from "@/stores/portal/apps"
 import {
   appRoutes,
@@ -32,4 +33,8 @@ export const permittedRoutes = derived(
 
 export const flattenedRoutes = derived([permittedRoutes], ([$permitted]) => {
   return flatten($permitted)
+})
+
+setSettingsRouteResolver(path => {
+  return match(path, get(flattenedRoutes)) || null
 })


### PR DESCRIPTION
## Description

Moved the settings routing to a resolver pattern. Our eager loading and initialisation of modules was causing issues during hot module reloading.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched settings routing to a resolver to fix HMR issues caused by eager imports. BBStore now defers route matching, and routing.ts registers the resolver using match(get(flattenedRoutes)) so settings paths resolve correctly after reloads and permission updates.

<sup>Written for commit 368e74799094a4c978d515a453b5bdbb4553fd23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

