### PR TITLE
Fix parent status when nested automation is stopped

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItemStatus.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItemStatus.svelte
@@ -169,6 +169,21 @@
       }
     }
 
+    const outputStatus =
+      outputs &&
+      "status" in outputs &&
+      typeof outputs.status === "string"
+        ? outputs.status.toLowerCase()
+        : undefined
+
+    if (outputStatus === "stopped" || outputStatus === "stopped_error") {
+      return {
+        message: "Stopped",
+        icon: "warning",
+        type: FlowStatusType.WARN,
+      }
+    }
+
     if (branch && isBranchStep(block)) {
       // Do not give status markers to branch nodes that were not part of the run.
       if (outputs && "branchId" in outputs && outputs.branchId !== branch.id)

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItemStatus.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItemStatus.svelte
@@ -170,9 +170,7 @@
     }
 
     const outputStatus =
-      outputs &&
-      "status" in outputs &&
-      typeof outputs.status === "string"
+      outputs && "status" in outputs && typeof outputs.status === "string"
         ? outputs.status.toLowerCase()
         : undefined
 

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItemStatus.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItemStatus.svelte
@@ -8,6 +8,7 @@
     ViewMode,
   } from "@/types/automations"
   import {
+    AutomationStatus,
     type AutomationStep,
     type AutomationStepResult,
     type AutomationTrigger,
@@ -174,7 +175,10 @@
         ? outputs.status.toLowerCase()
         : undefined
 
-    if (outputStatus === "stopped" || outputStatus === "stopped_error") {
+    if (
+      outputStatus === AutomationStatus.STOPPED ||
+      outputStatus === AutomationStatus.STOPPED_ERROR
+    ) {
       return {
         message: "Stopped",
         icon: "warning",

--- a/packages/server/src/automations/steps/triggerAutomationRun.ts
+++ b/packages/server/src/automations/steps/triggerAutomationRun.ts
@@ -45,8 +45,11 @@ export async function run({
       )
 
       if (triggers.isAutomationResults(response)) {
+        const isSuccessStatus =
+          response.status === AutomationStatus.SUCCESS ||
+          response.status === AutomationStatus.STOPPED
         return {
-          success: response.status === AutomationStatus.SUCCESS,
+          success: isSuccessStatus,
           value: response.steps,
           status: response.status,
         }

--- a/packages/server/src/automations/tests/steps/triggerAutomationRun.spec.ts
+++ b/packages/server/src/automations/tests/steps/triggerAutomationRun.spec.ts
@@ -1,7 +1,11 @@
 import * as automation from "../../index"
 import TestConfiguration from "../../../tests/utilities/TestConfiguration"
 import { createAutomationBuilder } from "../utilities/AutomationTestBuilder"
-import { AutomationStatus, FilterCondition, LoopStepType } from "@budibase/types"
+import {
+  AutomationStatus,
+  FilterCondition,
+  LoopStepType,
+} from "@budibase/types"
 
 describe("Test triggering an automation from another automation", () => {
   const config = new TestConfiguration()

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -589,6 +589,12 @@ class Orchestrator {
               addToContext(step, result, true)
             }
             this.reportStepProgress(step, progressStatus(result), result, ctx)
+            if (
+              result.outputs.success === false &&
+              result.outputs.status == null
+            ) {
+              return results
+            }
             stepIndex++
             break
           }

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -616,6 +616,14 @@ class Orchestrator {
             const latest = results.at(-1)
             if (latest) {
               this.reportStepProgress(step, progressStatus(latest), latest, ctx)
+              if (
+                step.stepId === AutomationActionStepId.TRIGGER_AUTOMATION_RUN &&
+                latest.outputs.success === false &&
+                (latest.outputs.status === AutomationStatus.ERROR ||
+                  latest.outputs.status === AutomationStatus.STOPPED_ERROR)
+              ) {
+                return results
+              }
             }
             stepIndex++
             break

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -741,6 +741,20 @@ class Orchestrator {
                 )
               )
             }
+
+            if (this.stopped) {
+              const output = automationUtils.buildLoopOutput(
+                storage,
+                undefined,
+                iterations + 1
+              )
+              output.status = AutomationStatus.STOPPED
+              span.addTags({
+                status: AutomationStatus.STOPPED,
+                iterations: iterations + 1,
+              })
+              return stepSuccess(step, output)
+            }
           } finally {
             // Restore the previous loop context (for nested loops)
             ctx.loop = savedLoopContext
@@ -862,6 +876,13 @@ class Orchestrator {
       ) {
         this.stopped = true
         ;(outputs as any).status = AutomationStatus.STOPPED
+      }
+      if (
+        step.stepId === AutomationActionStepId.TRIGGER_AUTOMATION_RUN &&
+        "status" in outputs &&
+        outputs.status === AutomationStatus.STOPPED
+      ) {
+        this.stopped = true
       }
 
       span.addTags({ outputsKeys: Object.keys(outputs) })


### PR DESCRIPTION
## Description
Fixes incorrect automation status propagation when a nested automation stops.

Previously, when `Trigger an automation` called a child automation that ended with `stopped`, the parent flow could be marked as `error` or shown as `Completed` in loop UI status. This PR ensures stopped state is propagated correctly and displayed as **Stopped**.

## Addresses
- https://github.com/Budibase/budibase/issues/17914

## App Export
[nested_automations.tar.gz](https://github.com/user-attachments/files/25129450/nested_automations.tar.gz)

## Screenshots

### Before
<img width="1020" height="1088" alt="before" src="https://github.com/user-attachments/assets/4e960177-ea7e-4805-b5f2-fb2802ab81b4" />

In this case the child automation was just stopped, but it is treated incorrectly as a failure. Furthermore, it doesn't actually stop the parent automation!

### After

<img width="1020" height="1055" alt="child_not_stopped" src="https://github.com/user-attachments/assets/b0c6d5c7-4c94-4f7a-b80a-d7b1c5f01fa2" />

**Not stopped, all iterations completed**

<img width="1020" height="1055" alt="stopped" src="https://github.com/user-attachments/assets/7653516b-6567-4b4c-a0f3-93fd1e13cee1" />

**The child automation stopped**

<img width="1020" height="1088" alt="partially stopped" src="https://github.com/user-attachments/assets/3c803eb2-43d1-43f2-ba52-297296fd3ccb" />

**If any child runs are stopped, even if some succeed, then the loop block is stopped in the parent automation**

<img width="663" height="1024" alt="actual failure" src="https://github.com/user-attachments/assets/18de49d3-5492-4553-bfd8-e253ae5f8fcc" />

**If a child run actually fails, then show the failure tag and stop the parent run**

## Launchcontrol
When one automation calls another and the child is intentionally stopped, the parent now also shows as stopped instead of completed/error.
