### PR TITLE
[17954] Fix duplicate automation trigger list theme in light mode

### DIFF
--- a/packages/builder/src/components/automation/AutomationPanel/DuplicateAutomationModal.svelte
+++ b/packages/builder/src/components/automation/AutomationPanel/DuplicateAutomationModal.svelte
@@ -107,20 +107,23 @@
 
   .item {
     cursor: pointer;
-    border: none;
+    border: 0.5px solid var(--spectrum-global-color-gray-300);
     border-radius: 12px;
     padding: var(--spacing-s) var(--spacing-m);
     font: inherit;
     text-align: left;
     color: inherit;
-    background: #0f1116;
+    background: var(--spectrum-global-color-gray-50);
     display: flex;
     align-items: center;
     gap: var(--spacing-s);
-    border: 1px solid rgba(255, 255, 255, 0.1);
     transition:
       border 0.2s,
       background 0.2s;
+  }
+
+  .item:hover {
+    background: var(--spectrum-global-color-gray-75);
   }
 
   .item:focus-visible {
@@ -130,7 +133,7 @@
 
   .item.selected {
     border-color: var(--spectrum-global-color-blue-600);
-    background: #1a1e27;
+    background: var(--spectrum-global-color-gray-75);
   }
 
   .icon-container {


### PR DESCRIPTION
## Description
Fixes a theming inconsistency in the duplicate automation modal where trigger options were styled with hard-coded dark colors. Updated the trigger list item styles to use theme tokens so they follow the active UI theme.

## Addresses
- https://github.com/Budibase/budibase/issues/17954

## Screenshots
<img width="554" height="480" alt="Screenshot 2026-02-06 at 15 33 13" src="https://github.com/user-attachments/assets/2fe9f7d5-2bf1-4b98-b068-86c2b522b347" />

## Launchcontrol
The duplicate automation trigger picker now correctly follows light or dark mode, matching the rest of the UI.
