### PR TITLE
Update BBAI models

### DIFF
--- a/packages/types/src/shared/budibaseModels.ts
+++ b/packages/types/src/shared/budibaseModels.ts
@@ -9,22 +9,10 @@ export interface BudibaseAIModel {
 
 export const BUDIBASE_AI_MODELS: BudibaseAIModel[] = [
   {
-    id: "budibase/gpt-4o-mini",
-    provider: "openai",
-    model: "gpt-4o-mini",
-    label: "GPT 4o Mini",
-  },
-  {
-    id: "budibase/gpt-4o",
-    provider: "openai",
-    model: "gpt-4o",
-    label: "GPT 4o",
-  },
-  {
     id: "budibase/gpt-5",
     provider: "openai",
-    model: "gpt-5",
-    label: "GPT 5",
+    model: "gpt-5.2",
+    label: "GPT 5.2",
   },
   {
     id: "budibase/gpt-5-mini",
@@ -37,6 +25,24 @@ export const BUDIBASE_AI_MODELS: BudibaseAIModel[] = [
     provider: "openai",
     model: "gpt-5-nano",
     label: "GPT 5 Nano",
+  },
+  {
+    id: "mistral/mistral-small-latest",
+    provider: "mistral",
+    model: "mistral/mistral-small-latest",
+    label: "Mistral small",
+  },
+  {
+    id: "mistral/mistral-medium-latest",
+    provider: "mistral",
+    model: "mistral/mistral-medium-latest",
+    label: "Mistral medium",
+  },
+  {
+    id: "mistral/mistral-large-latest",
+    provider: "mistral",
+    model: "mistral/mistral-large-latest",
+    label: "Mistral large",
   },
 ]
 

--- a/packages/types/src/shared/budibaseModels.ts
+++ b/packages/types/src/shared/budibaseModels.ts
@@ -27,21 +27,21 @@ export const BUDIBASE_AI_MODELS: BudibaseAIModel[] = [
     label: "GPT 5 Nano",
   },
   {
-    id: "mistral/mistral-small-latest",
+    id: "budibase/mistral-small-latest",
     provider: "mistral",
-    model: "mistral/mistral-small-latest",
+    model: "mistral-small-latest",
     label: "Mistral small",
   },
   {
-    id: "mistral/mistral-medium-latest",
+    id: "budibase/mistral-medium-latest",
     provider: "mistral",
-    model: "mistral/mistral-medium-latest",
+    model: "mistral-medium-latest",
     label: "Mistral medium",
   },
   {
-    id: "mistral/mistral-large-latest",
+    id: "budibase/mistral-large-latest",
     provider: "mistral",
-    model: "mistral/mistral-large-latest",
+    model: "mistral-large-latest",
     label: "Mistral large",
   },
 ]


### PR DESCRIPTION
## Description
Update BBAI models

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Budibase AI model list to match current OpenAI and Mistral models.
Upgraded gpt-5 to gpt-5.2, removed gpt-4o and gpt-4o-mini, added Mistral small/medium/large latest models, and corrected model IDs.

<sup>Written for commit d5d7ec250ed1f1604f9cf520dc7367ae42747a0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

