### PR TITLE
Update search row examples

### DIFF
--- a/packages/builder/src/components/automation/SetupPanel/AgentOutputViewer.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/AgentOutputViewer.svelte
@@ -50,6 +50,11 @@
       let status: ChainStep["status"]
       if (part.state === "output-error") {
         status = "error"
+      } else if (
+        part.state === "output-available" &&
+        hasOutputError(part.output)
+      ) {
+        status = "error"
       } else if (part.state === "output-available") {
         status = "completed"
       } else if (
@@ -94,6 +99,18 @@
       return undefined
     }
     return reasoningParts.map(p => p.text).join("\n\n") || undefined
+  }
+
+  function hasOutputError(output: unknown): boolean {
+    if (typeof output !== "object" || output === null) {
+      return false
+    }
+    if (!("error" in output)) {
+      return false
+    }
+
+    const error = (output as Record<string, unknown>).error
+    return error !== null && error !== undefined && error !== false
   }
 
   function copyToClipboard(text: string) {

--- a/packages/server/src/ai/tools/budibase/rows.ts
+++ b/packages/server/src/ai/tools/budibase/rows.ts
@@ -29,10 +29,13 @@ const SEARCH_QUERY_DESCRIPTION =
   `Query filters object. Structure: { operator: { fieldName: value } }. ` +
   `CRITICAL: fieldName must match an existing column in the table schema exactly (case-sensitive). ` +
   `Valid operators: "equal", "notEqual", "empty", "notEmpty", "fuzzy", "string", "contains", "notContains", "containsAny", "oneOf", "range". ` +
+  `IMPORTANT: Do NOT use "and", "or", or array syntax. All operators must be top-level keys in a single flat object. ` +
+  `To combine multiple filters, include multiple operator keys: {"fuzzy": {"name": "John", "city": "London"}, "equal": {"status": "active"}}. ` +
   `Examples: ` +
   `Find where status equals "active": {"equal": {"status": "active"}}. ` +
   `Find where name is not empty: {"notEmpty": {"name": true}}. ` +
-  `Find where price is within the range of 10 to 100: {"range": {"price": {"low": 10, "high": 100}}}.`
+  `Find where price is within the range of 10 to 100: {"range": {"price": {"low": 10, "high": 100}}}. ` +
+  `Combine fuzzy name with exact status: {"fuzzy": {"name": "John"}, "equal": {"status": "active"}}.`
 
 const MAX_SCHEMA_FIELDS = 30
 

--- a/packages/server/src/ai/tools/budibase/rows.ts
+++ b/packages/server/src/ai/tools/budibase/rows.ts
@@ -29,10 +29,13 @@ const SEARCH_QUERY_DESCRIPTION =
   `Query filters object. Structure: { operator: { fieldName: value } }. ` +
   `CRITICAL: fieldName must match an existing column in the table schema exactly (case-sensitive). ` +
   `Valid operators: "equal", "notEqual", "empty", "notEmpty", "fuzzy", "string", "contains", "notContains", "containsAny", "oneOf", "range". ` +
-  `IMPORTANT: Do NOT use "and", "or", or array syntax. All operators must be top-level keys in a single flat object. ` +
+  `IMPORTANT: Do NOT use "and", "or", or nested $and/$or conditions. All operators must be top-level keys in a single flat object. ` +
+  `Operators oneOf and containsAny require array values (e.g. {"oneOf": {"status": ["active", "pending"]}}). ` +
   `To combine multiple filters, include multiple operator keys: {"fuzzy": {"name": "John", "city": "London"}, "equal": {"status": "active"}}. ` +
   `Examples: ` +
   `Find where status equals "active": {"equal": {"status": "active"}}. ` +
+  `Find where status is "active" OR "pending": {"oneOf": {"status": ["active", "pending"]}}. ` +
+  `Find where tags contains any of "urgent", "review": {"containsAny": {"tags": ["urgent", "review"]}}. ` +
   `Find where name is not empty: {"notEmpty": {"name": true}}. ` +
   `Find where price is within the range of 10 to 100: {"range": {"price": {"low": 10, "high": 100}}}. ` +
   `Combine fuzzy name with exact status: {"fuzzy": {"name": "John"}, "equal": {"status": "active"}}.`

--- a/packages/server/src/ai/tools/index.ts
+++ b/packages/server/src/ai/tools/index.ts
@@ -11,8 +11,48 @@ export interface AiToolDefinition {
   sourceIconType?: string
 }
 
+const getToolFailure = (result: unknown): string | undefined => {
+  if (!result || typeof result !== "object" || !("error" in result)) {
+    return
+  }
+
+  const { error } = result
+  if (error == null || error === false) {
+    return
+  }
+
+  if (error instanceof Error) {
+    return error.message || "Tool execution failed"
+  }
+
+  return String(error)
+}
+
+const wrapTool = (toolDef: AiToolDefinition): Tool => {
+  const execute = toolDef.tool.execute
+  if (!execute) {
+    return toolDef.tool
+  }
+
+  const wrappedExecute: NonNullable<Tool["execute"]> = async (...args) => {
+    const result = await execute(...args)
+    const failureMessage = getToolFailure(result)
+    if (failureMessage) {
+      throw new Error(failureMessage)
+    }
+    return result
+  }
+
+  return {
+    ...toolDef.tool,
+    execute: wrappedExecute,
+  }
+}
+
 export const toToolSet = (tools: AiToolDefinition[]): ToolSet => {
-  return Object.fromEntries(tools.map(toolDef => [toolDef.name, toolDef.tool]))
+  return Object.fromEntries(
+    tools.map(toolDef => [toolDef.name, wrapTool(toolDef)])
+  )
 }
 
 export { default as budibase } from "./budibase"

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -268,8 +268,13 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
       system,
       tools: hasTools ? tools : undefined,
       stopWhen: stepCountIs(30),
-      onStepFinish({ toolCalls, toolResults }) {
+      onStepFinish({ content, toolCalls, toolResults }) {
         updatePendingToolCalls(pendingToolCalls, toolCalls, toolResults)
+        for (const part of content) {
+          if (part.type === "tool-error") {
+            pendingToolCalls.delete(part.toolCallId)
+          }
+        }
       },
       providerOptions: ai.getLiteLLMProviderOptions(hasTools),
       onError({ error }) {

--- a/packages/server/src/automations/steps/ai/agent.ts
+++ b/packages/server/src/automations/steps/ai/agent.ts
@@ -132,8 +132,13 @@ export async function run({
           stopWhen: stepCountIs(30),
           providerOptions: ai.getLiteLLMProviderOptions(hasTools),
           output: outputOption,
-          onStepFinish({ toolCalls, toolResults }) {
+          onStepFinish({ content, toolCalls, toolResults }) {
             updatePendingToolCalls(pendingToolCalls, toolCalls, toolResults)
+            for (const part of content) {
+              if (part.type === "tool-error") {
+                pendingToolCalls.delete(part.toolCallId)
+              }
+            }
           },
         })
 
@@ -167,6 +172,7 @@ export async function run({
           return {
             success: false,
             response: errorMessage,
+            message: assistantMessage,
           }
         }
 
@@ -187,6 +193,7 @@ export async function run({
           return {
             success: false,
             response: error,
+            message: assistantMessage,
           }
         }
         const usage = await streamResult.usage


### PR DESCRIPTION
## Description
- The agent wasn't properly being instructed on how to use the search_rows tool. Updated the details on that
- Made sure that all our tools were properly throwing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified search_rows query docs: use a flat object with top‑level operators, no and/or or nested $and/$or, arrays only for oneOf/containsAny, plus examples. Also improved tool error handling: throw on error results, clear failed tool calls, and show errors in output.

<sup>Written for commit 9f95516a53d41f87f7044a4be19bb406a1f16710. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

