### PR TITLE
Move Manage roles to top-level workspace navigation

### DIFF
--- a/packages/builder/src/components/backend/DatasourceNavigator/DatasourceNavigator.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/DatasourceNavigator.svelte
@@ -27,7 +27,6 @@
   export let searchTerm
   export let datasourceFilter = _ => true
   export let showAppUsers = true
-  export let showManageRoles = true
   export let datasourceSort
   let toggledDatasources = {}
 
@@ -95,15 +94,6 @@
         $tables.selected?._id === TableNames.USERS}
       on:click={() => selectTable(TableNames.USERS)}
       selectedBy={$userSelectedResourceMap[TableNames.USERS]}
-    />
-  {/if}
-  {#if showManageRoles}
-    <NavItem
-      icon="user-gear"
-      text="Manage roles"
-      selected={$isActive("./roles")}
-      on:click={() => $goto("./roles")}
-      selectedBy={$userSelectedResourceMap.roles}
     />
   {/if}
   {#each displayedDatasources.filter(ds => ds.show) as datasource}

--- a/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
@@ -698,6 +698,13 @@
                 on:click={keepCollapsed}
               />
               <SideNavLink
+                icon="user-gear"
+                text="Manage roles"
+                url={$url("./roles")}
+                {collapsed}
+                on:click={keepCollapsed}
+              />
+              <SideNavLink
                 icon="user-plus"
                 text="Invite user"
                 on:click={() => {

--- a/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
@@ -698,7 +698,7 @@
                 on:click={keepCollapsed}
               />
               <SideNavLink
-                icon="user-gear"
+                icon="lock-simple-open"
                 text="Manage roles"
                 url={$url("./roles")}
                 {collapsed}

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/_layout.svelte
@@ -90,7 +90,6 @@
               {datasourceFilter}
               datasourceSort={sortByDatasourceName}
               showAppUsers={false}
-              showManageRoles={false}
             />
           </Layout>
         </Panel>

--- a/packages/builder/src/pages/builder/workspace/[application]/data/roles.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/roles.svelte
@@ -1,8 +1,5 @@
 <script>
-  import RoleEditor from "@/components/backend/RoleEditor/RoleEditor.svelte"
-  import { builderStore } from "@/stores/builder"
+  import { redirect } from "@roxi/routify"
 
-  builderStore.selectResource("roles")
+  $redirect("../roles")
 </script>
-
-<RoleEditor />

--- a/packages/builder/src/pages/builder/workspace/[application]/roles.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/roles.svelte
@@ -1,0 +1,37 @@
+<script>
+  import TopBar from "@/components/common/TopBar.svelte"
+  import RoleEditor from "@/components/backend/RoleEditor/RoleEditor.svelte"
+  import { builderStore } from "@/stores/builder"
+
+  builderStore.selectResource("roles")
+</script>
+
+<div class="wrapper">
+  <TopBar icon="user-gear" breadcrumbs={[{ text: "Manage roles" }]}></TopBar>
+  <div class="content">
+    <RoleEditor />
+  </div>
+</div>
+
+<style>
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+  .content {
+    padding: 28px 40px 40px 40px;
+    overflow-y: auto;
+    gap: var(--spacing-l);
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: stretch;
+    flex: 1 1 auto;
+    z-index: 2;
+    position: relative;
+    min-height: 0;
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/roles.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/roles.svelte
@@ -7,7 +7,8 @@
 </script>
 
 <div class="wrapper">
-  <TopBar icon="lock-simple-open" breadcrumbs={[{ text: "Manage roles" }]}></TopBar>
+  <TopBar icon="lock-simple-open" breadcrumbs={[{ text: "Manage roles" }]}
+  ></TopBar>
   <div class="content">
     <RoleEditor />
   </div>

--- a/packages/builder/src/pages/builder/workspace/[application]/roles.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/roles.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <div class="wrapper">
-  <TopBar icon="user-gear" breadcrumbs={[{ text: "Manage roles" }]}></TopBar>
+  <TopBar icon="lock-simple-open" breadcrumbs={[{ text: "Manage roles" }]}></TopBar>
   <div class="content">
     <RoleEditor />
   </div>


### PR DESCRIPTION
## Description

**do not merge** - do we have a 'People' section instead? 

Move the **Manage roles** navigation item and page out of the Data section into the top-level workspace navigation, positioned between **Data** and **Invite user**.

Implementation details:
- Added a new top-level route: `/builder/workspace/:application/roles`
- Added top-level sidebar link: `Manage roles`
- Removed nested `Manage roles` item from the Data navigator
- Added redirect from legacy route `/builder/workspace/:application/data/roles` to the new `/roles` route

## Addresses
- https://github.com/Budibase/budibase/issues/17694

## Screenshots
<img width="1651" height="1322" alt="manage roles" src="https://github.com/user-attachments/assets/0d6cc664-8d35-47d8-8d04-3a4e39d22a7d" />

## Launchcontrol
Users can now access **Manage roles** directly from the main workspace sidebar, without opening **Data** first.


