### PR TITLE
Fix on processing rag files

### DIFF
--- a/packages/server/src/automations/bullboard.ts
+++ b/packages/server/src/automations/bullboard.ts
@@ -7,6 +7,7 @@ import { KoaAdapter } from "@bull-board/koa"
 import { UserSyncProcessor } from "../events/docUpdates/syncUsers"
 import * as automation from "../threads/automation"
 import { getAppMigrationQueue } from "../workspaceMigrations/queue"
+import { rag } from "../sdk/workspace/ai"
 
 export const automationQueue = new queue.BudibaseQueue<AutomationData>(
   queue.JobQueue.AUTOMATION,
@@ -41,6 +42,7 @@ export async function init() {
   }
 
   queues.push(new BullAdapter(UserSyncProcessor.queue.getBullQueue()))
+  queues.push(new BullAdapter(rag.queue.getQueue().getBullQueue()))
 
   const serverAdapter = new KoaAdapter()
   createBullBoard({ queues, serverAdapter })

--- a/packages/server/src/sdk/workspace/ai/rag/files.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/files.spec.ts
@@ -1,0 +1,64 @@
+const mockCreateVectorDb = jest.fn()
+const mockEmbedMany = jest.fn()
+const mockCreateLLM = jest.fn()
+
+jest.mock("../vectorDb/utils", () => ({
+  createVectorDb: (...args: any[]) => mockCreateVectorDb(...args),
+}))
+
+jest.mock("ai", () => ({
+  tool: jest.fn(),
+  embedMany: (...args: any[]) => mockEmbedMany(...args),
+}))
+
+jest.mock("../llm", () => ({
+  createLLM: (...args: any[]) => mockCreateLLM(...args),
+}))
+
+import { AgentFileStatus, type Agent, type AgentFile } from "@budibase/types"
+import { ingestAgentFile } from "./files"
+
+describe("rag files", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("ingestAgentFile", () => {
+    it("uses the embedding model config for embeddings", async () => {
+      const vectorDb = {
+        deleteBySourceIds: jest.fn(),
+        upsertSourceChunks: jest.fn().mockResolvedValue({
+          inserted: 1,
+          total: 1,
+        }),
+      }
+
+      mockCreateVectorDb.mockResolvedValue(vectorDb)
+      mockCreateLLM.mockResolvedValue({ embedding: "mock-embedding-model" })
+      mockEmbedMany.mockResolvedValue({ embeddings: [[0.1, 0.2, 0.3]] })
+
+      const agent: Agent = {
+        _id: "agent_123",
+        name: "Agent",
+        aiconfig: "ai_config",
+        embeddingModel: "embedding_config",
+      }
+
+      const agentFile: AgentFile = {
+        _id: "file_123",
+        agentId: "agent_123",
+        filename: "test.txt",
+        objectStoreKey: "key",
+        ragSourceId: "rag_source_123",
+        status: AgentFileStatus.READY,
+        chunkCount: 0,
+        uploadedBy: "user_123",
+      }
+
+      await ingestAgentFile(agent, agentFile, Buffer.from("hello world"))
+
+      expect(mockCreateLLM).toHaveBeenCalledTimes(1)
+      expect(mockCreateLLM).toHaveBeenCalledWith("embedding_config")
+    })
+  })
+})

--- a/packages/server/src/sdk/workspace/ai/rag/files.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/files.ts
@@ -322,6 +322,10 @@ export const retrieveContextForAgent = async (
     throw new Error("RAG settings not properly configured")
   }
 
+  if (!agent.embeddingModel) {
+    throw new Error("Embedding model is not set")
+  }
+
   const agentFiles = await agents.listAgentFiles(agent._id!)
   const readyFileSources = agentFiles
     .filter(file => file.status === AgentFileStatus.READY && file.ragSourceId)
@@ -331,7 +335,11 @@ export const retrieveContextForAgent = async (
     return { text: "", chunks: [], sources: [] }
   }
 
-  const [queryEmbedding] = await embedChunks(agent.aiconfig, [question], 1)
+  const [queryEmbedding] = await embedChunks(
+    agent.embeddingModel,
+    [question],
+    1
+  )
   if (!queryEmbedding?.length) {
     throw new Error("Embedding response missing dimensions")
   }

--- a/packages/server/src/sdk/workspace/ai/rag/files.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/files.ts
@@ -246,6 +246,10 @@ export const ingestAgentFile = async (
     throw new Error("Agent id not set")
   }
 
+  if (!agent.embeddingModel) {
+    throw new Error("Embedding model is not set")
+  }
+
   const content = await getTextFromBuffer(fileBuffer, agentFile)
   const chunks = createChunksFromContent(content, agentFile.filename)
 
@@ -260,7 +264,7 @@ export const ingestAgentFile = async (
     return { inserted: 0, total: 0 }
   }
 
-  const embeddings = await embedChunks(agent.aiconfig, chunks)
+  const embeddings = await embedChunks(agent.embeddingModel, chunks)
   if (embeddings.length !== chunks.length) {
     throw new Error("Embedding response size mismatch")
   }

--- a/packages/server/src/sdk/workspace/ai/rag/queue.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/queue.ts
@@ -6,7 +6,7 @@ import { ingestAgentFile } from "./files"
 import { agents } from ".."
 
 const DEFAULT_CONCURRENCY = 2
-const DEFAULT_BACKOFF_MS = utils.Duration.fromSeconds(30).toMs()
+const DEFAULT_BACKOFF_MS = utils.Duration.fromSeconds(10).toMs()
 const DEFAULT_TIMEOUT_MS = utils.Duration.fromMinutes(10).toMs()
 
 export interface RagIngestionJob {

--- a/packages/server/src/sdk/workspace/ai/vectorDb/pgVectorDb.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/vectorDb/pgVectorDb.spec.ts
@@ -1,0 +1,62 @@
+const mockClient = {
+  connect: jest.fn(),
+  end: jest.fn(),
+  query: jest.fn(),
+}
+
+jest.mock("pg", () => ({
+  Client: jest.fn(() => mockClient),
+}))
+
+jest.mock("@budibase/backend-core", () => {
+  const actual = jest.requireActual("@budibase/backend-core")
+  return {
+    ...actual,
+    context: {
+      ...actual.context,
+      getOrThrowWorkspaceId: jest.fn(() => "ws_dev_123"),
+    },
+    db: {
+      ...actual.db,
+      getProdWorkspaceID: jest.fn((id: string) => id.replace("_dev", "")),
+    },
+    tenancy: {
+      ...actual.tenancy,
+      getTenantId: jest.fn(() => "tenant_123"),
+    },
+  }
+})
+
+import { VectorDbProvider } from "@budibase/types"
+import { buildPgVectorDbConfig } from "./pgVectorDb"
+
+describe("pgVectorDb", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("deleteBySourceIds", () => {
+    it("does not throw when the table does not exist", async () => {
+      mockClient.query.mockRejectedValue({ code: "42P01" })
+
+      const vectorDb = buildPgVectorDbConfig(
+        {
+          name: "test",
+          provider: VectorDbProvider.PGVECTOR,
+          host: "localhost",
+          port: 5432,
+          database: "test",
+          user: "user",
+          password: "pass",
+        },
+        { agentId: "agent_123" }
+      )
+
+      await vectorDb.deleteBySourceIds(["source_1"])
+
+      expect(mockClient.connect).toHaveBeenCalledTimes(1)
+      expect(mockClient.query).toHaveBeenCalledTimes(1)
+      expect(mockClient.end).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/server/src/sdk/workspace/ai/vectorDb/pgVectorDb.ts
+++ b/packages/server/src/sdk/workspace/ai/vectorDb/pgVectorDb.ts
@@ -169,11 +169,20 @@ class PgVectorDb implements VectorDb {
     if (!sourceIds || sourceIds.length === 0) {
       return
     }
+
     await this.withClient(async client => {
-      await client.query(
-        `DELETE FROM ${this.tableName} WHERE source = ANY($1::text[])`,
-        [sourceIds]
-      )
+      try {
+        await client.query(
+          `DELETE FROM ${this.tableName} WHERE source = ANY($1::text[])`,
+          [sourceIds]
+        )
+      } catch (error: any) {
+        if (error?.code === "42P01") {
+          // Table does not exist
+          return
+        }
+        throw error
+      }
     })
   }
 

--- a/packages/server/src/sdk/workspace/ai/vectorDb/pgVectorDb.ts
+++ b/packages/server/src/sdk/workspace/ai/vectorDb/pgVectorDb.ts
@@ -1,7 +1,7 @@
 import { VectorDbProvider, type VectorDb as VectorDbDoc } from "@budibase/types"
 import * as crypto from "crypto"
 import { Client } from "pg"
-import { context, db as dbCore } from "@budibase/backend-core"
+import { context, db as dbCore, tenancy } from "@budibase/backend-core"
 import type {
   ChunkInput,
   PgVectorDbConfig,
@@ -21,10 +21,10 @@ const buildAgentTableName = (agentId: string) => {
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_+|_+$/g, "")
   const currentWorkspaceId = context.getOrThrowWorkspaceId()
-  const hashWorkspaceId = dbCore.getProdWorkspaceID(currentWorkspaceId)
+  const prodWorkspaceId = dbCore.getProdWorkspaceID(currentWorkspaceId)
   const hash = crypto
     .createHash("sha256")
-    .update(`${hashWorkspaceId}:${agentId}`)
+    .update(`${tenancy.getTenantId()}:${prodWorkspaceId}:${agentId}`)
     .digest("hex")
     .slice(0, TABLE_HASH_LENGTH)
   const maxBaseLength = 63 - TABLE_PREFIX.length - 1 - TABLE_HASH_LENGTH


### PR DESCRIPTION
## Description
Fixing some issues added with a recent refactor. Also, changing the pg vector table to prevent clashes between tenants. This might add breaking changes, but not important as this is not yet live

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RAG file processing by using the correct embedding model and adds safer handling around vector tables. Also exposes the RAG queue in BullBoard and reduces retry backoff for faster ingestion.

- **Bug Fixes**
  - Use agent.embeddingModel for embeddings during ingestion and queries; fail fast if missing.
  - Prevent errors when deleting sources if the pgvector table is absent (ignore 42P01).
  - Include tenant ID in pgvector table names to avoid cross-tenant collisions.
  - Add unit tests for ingestAgentFile embedding usage and pgvector 42P01 handling.

<sup>Written for commit 647a2a0f072ef789578af2358d7212077d2c1b10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

