### PR TITLE
feat: configure CouchDB persistent volume mount path.

### DIFF
--- a/charts/budibase/charts/couchdb/templates/statefulset.yaml
+++ b/charts/budibase/charts/couchdb/templates/statefulset.yaml
@@ -129,6 +129,9 @@ spec:
                   key: erlangCookie
             - name: ERL_FLAGS
               value: "{{ range $k, $v := .Values.erlangFlags }} -{{ $k }} {{ $v }} {{ end }}"
+{{- if .Values.extraEnvs }}
+{{ toYaml .Values.extraEnvs | indent 12 }}
+{{- end }}
 {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
 {{- if .Values.couchdbConfig.chttpd.require_valid_user }}
@@ -177,7 +180,7 @@ spec:
             mountPath: /opt/couchdb/etc/local.d
 {{- end }}
           - name: database-storage
-            mountPath: /data
+            mountPath: {{ .Values.persistentVolume.mountPath }}
           {{- if .Values.containerSecurityContext }}
           securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 12 }}
           {{- end }}

--- a/charts/budibase/charts/couchdb/values.yaml
+++ b/charts/budibase/charts/couchdb/values.yaml
@@ -74,6 +74,7 @@ persistentVolume:
   accessModes:
     - ReadWriteOnce
   size: 10Gi
+  mountPath: /data
   # storageClass: "-"
 
 # Experimental - FEATURE STATE: Kubernetes v1.27 [beta]
@@ -112,7 +113,8 @@ podManagementPolicy: Parallel
 
 ## To better tolerate Node failures, we can prevent Kubernetes scheduler from
 ## assigning more than one Pod of CouchDB StatefulSet per Node using podAntiAffinity.
-affinity: {}
+affinity:
+  {}
   # podAntiAffinity:
   #   requiredDuringSchedulingIgnoredDuringExecution:
   #     - labelSelector:
@@ -125,7 +127,8 @@ affinity: {}
 
 ## To control how Pods are spread across your cluster among failure-domains such as regions,
 ## zones, nodes, and other user-defined topology domains use topologySpreadConstraints.
-topologySpreadConstraints: {}
+topologySpreadConstraints:
+  {}
   # topologySpreadConstraints:
   #   - maxSkew: 1
   #     topologyKey: "topology.kubernetes.io/zone"
@@ -163,7 +166,8 @@ service:
 ## If you need to expose any additional ports on the CouchDB container, for example
 ## if you're running CouchDB container with additional processes that need to
 ## be accessible outside of the pod, you can define them here.
-extraPorts: []
+extraPorts:
+  []
   # - name: sqs
   #   containerPort: 4984
 
@@ -177,7 +181,8 @@ ingress:
   hosts:
     - chart-example.local
   path: /
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls:
@@ -188,7 +193,8 @@ ingress:
 
 ## Optional resource requests and limits for the CouchDB container
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-resources: {}
+resources:
+  {}
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
@@ -198,7 +204,8 @@ resources: {}
 
 ## Optional resource requests and limits for the CouchDB init container
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-initResources: {}
+initResources:
+  {}
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
@@ -273,7 +280,8 @@ prometheusPort:
 
 # Configure arbitrary sidecar containers for CouchDB pods created by the
 # StatefulSet
-sidecars: {}
+sidecars:
+  {}
   # - name: foo
   #   image: "busybox"
   #   imagePullPolicy: IfNotPresent

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -747,6 +747,9 @@ couchdb:
     accessModes:
       - ReadWriteOnce
     size: 10Gi
+    # -- The path where the persistent volume will be mounted.
+    # If you change this, make sure to also update the DATA_DIR environment variable above.
+    mountPath: /data
 
   extraPorts:
     # -- Extra ports to expose on the CouchDB service. We expose the SQS port


### PR DESCRIPTION
## Description
Matches upstream CouchDB persistent volume mount config with internal `DATA_DIR` config. 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the CouchDB persistent volume mount path configurable and aligns it with DATA_DIR to prevent data path mismatches. Also allows passing extra environment variables to the CouchDB container.

- **New Features**
  - Use persistentVolume.mountPath for the database-storage volume (default: /data).
  - Add mountPath to couchdb values in both charts.
  - Support extraEnvs for injecting additional container environment variables.

- **Migration**
  - If you changed DATA_DIR, set persistentVolume.mountPath to the same path.
  - No action needed if you use the default /data.

<sup>Written for commit 2de577f077c51db2b96e1e0df8e20c3802200550. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

