### PR TITLE
PDBs for services and disruption budger for proxy

### DIFF
--- a/charts/budibase/templates/pdb.yaml
+++ b/charts/budibase/templates/pdb.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "budibase.fullname" . }}-proxy-pdb
+  labels:
+    {{- include "budibase.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: budibase-proxy
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "budibase.fullname" . }}-apps-pdb
+  labels:
+    {{- include "budibase.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      io.kompose.service: app-service
+---
+{{- if .Values.services.worker.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "budibase.fullname" . }}-worker-pdb
+  labels:
+    {{- include "budibase.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      io.kompose.service: worker-service
+{{- end }}
+{{- end }}

--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -19,6 +19,9 @@ spec:
   minReadySeconds: 10
   strategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       annotations:

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -1,5 +1,12 @@
 # -- Passed to all pods created by this chart. Should not ordinarily need to be changed.
 imagePullSecrets: []
+
+podDisruptionBudget:
+  # -- Whether to create a PodDisruptionBudget for the services.
+  enabled: false
+  # -- The minimum number of available pods for the services.
+  minAvailable: 1
+
 # -- Override the name of the deployment. Defaults to {{ .Chart.Name }}.
 nameOverride: ""
 
@@ -169,9 +176,9 @@ services:
       couchdb: "http://{{ .Release.Name }}-svc-couchdb:{{ .Values.services.couchdb.port }}"
     # -- The time in seconds to wait before sending SIGKILL after SIGTERM.
     # Must be greater than preStopDelaySeconds to allow graceful shutdown.
-    terminationGracePeriodSeconds: 30
+    terminationGracePeriodSeconds: 60
     # -- Seconds to sleep before SIGTERM to allow load balancer deregistration.
-    preStopDelaySeconds: 5
+    preStopDelaySeconds: 10
     # -- The resources to use for proxy pods. See
     # <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/>
     # for more information on how to set these.
@@ -187,7 +194,7 @@ services:
         port: 10000
         scheme: HTTP
       # @ignore
-      failureThreshold: 30
+      failureThreshold: 40
       # @ignore
       periodSeconds: 3
     # -- Readiness probe configuration for proxy pods. You shouldn't need to
@@ -201,9 +208,9 @@ services:
         port: 10000
         scheme: HTTP
       # @ignore
-      periodSeconds: 3
+      periodSeconds: 5
       # @ignore
-      failureThreshold: 1
+      failureThreshold: 3
     # -- Liveness probe configuration for proxy pods. You shouldn't need to
     # change this, but if you want to you can find more information here:
     # <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/>
@@ -460,7 +467,7 @@ services:
     # Ensures pods are stable before receiving traffic.
     minReadySeconds: 10
     # -- Seconds to sleep before SIGTERM to allow load balancer deregistration.
-    preStopDelaySeconds: 5
+    preStopDelaySeconds: 10
     # -- Extra environment variables to set for worker pods. Takes a list of
     # name=value pairs.
     extraEnv: []
@@ -482,7 +489,7 @@ services:
         port: 4003
         scheme: HTTP
       # @ignore
-      failureThreshold: 30
+      failureThreshold: 40
       # @ignore
       periodSeconds: 3
     # -- Readiness probe configuration for worker pods. You shouldn't need to
@@ -496,9 +503,9 @@ services:
         port: 4003
         scheme: HTTP
       # @ignore
-      periodSeconds: 3
+      periodSeconds: 5
       # @ignore
-      failureThreshold: 1
+      failureThreshold: 3
     # -- Liveness probe configuration for worker pods. You shouldn't need to
     # change this, but if you want to you can find more information here:
     # <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/>


### PR DESCRIPTION
## Description
Adds PDBs in the Helm chart and configures a disruption budget for the proxy service.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PodDisruptionBudgets for proxy, apps, and worker, and tunes proxy rolling updates to avoid downtime. Improves graceful shutdown and health probe resilience during upgrades.

- **New Features**
  - PodDisruptionBudgets for proxy, apps, and worker (conditional), configurable via values.podDisruptionBudget.enabled and minAvailable.
  - Proxy rollout set to maxUnavailable: 0 and maxSurge: 1; longer termination and preStop delays; relaxed readiness/liveness probe timings for proxy and worker.

- **Migration**
  - To enable PDBs, set podDisruptionBudget.enabled: true and choose minAvailable in values.yaml.

<sup>Written for commit 1102253f4abd60f848818b0d75624d137e93a058. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

