### PR TITLE
Added configurable headers and rounded corners to table

### DIFF
--- a/packages/bbui/src/Table/Table.svelte
+++ b/packages/bbui/src/Table/Table.svelte
@@ -43,10 +43,12 @@
   export let compact: boolean = false
   export let customPlaceholder: boolean = false
   export let showHeaderBorder: boolean = true
+  export let showHeader: boolean = true
   export let placeholderText: string = "No rows found"
   export let snippets: any[] = []
   export let defaultSortColumn: string | undefined = undefined
   export let defaultSortOrder: "Ascending" | "Descending" = "Ascending"
+  export let rounded: boolean = false
   export let stickyHeader: boolean = true
 
   const dispatch = createEventDispatcher()
@@ -382,9 +384,11 @@
       <div
         class="spectrum-Table"
         class:no-scroll={!rowCount}
+        class:rounded
         style={`${heightStyle}${gridStyle}`}
+        class:show-header={showHeader}
       >
-        {#if fields.length}
+        {#if fields.length && showHeader}
           <div class="spectrum-Table-head">
             {#if showEditColumn}
               <div
@@ -710,11 +714,17 @@
     justify-content: center;
     align-items: center;
     border: var(--table-border);
-    border-top: none;
     grid-column: 1 / -1;
     background-color: var(--table-bg);
     padding: 40px;
   }
+  .spectrum-Table.show-header .placeholder {
+    border-top: none;
+  }
+  .spectrum-Table:not(.show-header) {
+    border-top: var(--table-border);
+  }
+
   .placeholder--no-fields {
     border-top: var(--table-border);
   }
@@ -742,5 +752,24 @@
       var(--spectrum-alias-font-size-default)
     );
     text-align: center;
+  }
+
+  /* Rounded corners */
+  .spectrum-Table.rounded {
+    border-radius: 6px;
+  }
+  .rounded.show-header .spectrum-Table-head > :first-child,
+  .rounded:not(.show-header) .spectrum-Table-row:first-child > :first-child {
+    border-top-left-radius: 6px;
+  }
+  .rounded.show-header .spectrum-Table-head > :last-child,
+  .rounded:not(.show-header) .spectrum-Table-row:first-child > :last-child {
+    border-top-right-radius: 6px;
+  }
+  .rounded .spectrum-Table-row:last-child > :first-child {
+    border-bottom-left-radius: 6px;
+  }
+  .rounded .spectrum-Table-row:last-child > :last-child {
+    border-bottom-right-radius: 6px;
   }
 </style>

--- a/packages/bbui/src/Table/Table.svelte
+++ b/packages/bbui/src/Table/Table.svelte
@@ -43,7 +43,7 @@
   export let compact: boolean = false
   export let customPlaceholder: boolean = false
   export let showHeaderBorder: boolean = true
-  export let showHeader: boolean = true
+  export let hideHeader: boolean = false
   export let placeholderText: string = "No rows found"
   export let snippets: any[] = []
   export let defaultSortColumn: string | undefined = undefined
@@ -80,12 +80,14 @@
     rowCount,
     rowHeight
   )
+  $: effectiveHeaderHeight = hideHeader ? 0 : headerHeight
   $: heightStyle = getHeightStyle(
     visibleRowCount,
     rowCount,
     totalRowCount,
     rowHeight,
-    loading
+    loading,
+    effectiveHeaderHeight
   )
   $: sortedRows = sortRows(rows, sortColumn, sortOrder)
   $: gridStyle = getGridStyle(fields, schema, showEditColumn)
@@ -148,15 +150,16 @@
     rowCount: number,
     totalRowCount: number,
     rowHeight: number,
-    loading: boolean
+    loading: boolean,
+    effectiveHeaderHeight: number
   ): string => {
     if (loading) {
-      return `height: ${headerHeight + visibleRowCount * rowHeight}px;`
+      return `height: ${effectiveHeaderHeight + visibleRowCount * rowHeight}px;`
     }
     if (!rowCount || !visibleRowCount || totalRowCount <= rowCount) {
       return ""
     }
-    return `height: ${headerHeight + visibleRowCount * rowHeight}px;`
+    return `height: ${effectiveHeaderHeight + visibleRowCount * rowHeight}px;`
   }
 
   const getGridStyle = (
@@ -372,7 +375,7 @@
     class:wrapper--quiet={quiet}
     class:wrapper--compact={compact}
     class:wrapper--sticky-header={stickyHeader}
-    style={`--row-height: ${rowHeight}px; --header-height: ${headerHeight}px;`}
+    style={`--row-height: ${rowHeight}px; --header-height: ${hideHeader ? 0 : headerHeight}px;`}
   >
     {#if loading}
       <div class="loading" style={heightStyle}>
@@ -386,9 +389,9 @@
         class:no-scroll={!rowCount}
         class:rounded
         style={`${heightStyle}${gridStyle}`}
-        class:show-header={showHeader}
+        class:show-header={!hideHeader}
       >
-        {#if fields.length && showHeader}
+        {#if fields.length && !hideHeader}
           <div class="spectrum-Table-head">
             {#if showEditColumn}
               <div


### PR DESCRIPTION
## Description

Added 2 new props to the core bb Table component to allow optional headers on the table and rounded corners.
- `hideHeader` `(true|false)` to enable or disable the headers. `false` by default
- `rounded` `(true|false)` to enable or disable the rounded corners. `false` by default

## Screenshots
Original
<img width="882" height="115" alt="Screenshot 2026-02-12 at 10 53 50" src="https://github.com/user-attachments/assets/162446df-5f59-4da8-bf5a-a0c3d20f8a74" />

Rounded Headers
<img width="883" height="111" alt="Screenshot 2026-02-12 at 10 54 27" src="https://github.com/user-attachments/assets/300a58ab-afeb-4834-937b-4c2b7115b44e" />

No headers
<img width="869" height="122" alt="Screenshot 2026-02-12 at 10 54 54" src="https://github.com/user-attachments/assets/895244a2-c435-464f-a0e3-9b4534899222" />

## Launchcontrol
Added support for configurable rounded corners and optional header in the bb table component. 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the bb Table header optional and added an option for rounded corners. Defaults keep the current look while improving height and border behavior when the header is hidden.

- **New Features**
  - hideHeader (boolean, default false) to remove the table header; header height becomes 0 and grid height/borders adjust; .show-header is applied only when visible.
  - rounded (boolean, default false) to add a 6px radius; corners apply to header cells when visible or to the first/last row cells when hidden (.rounded).

<sup>Written for commit 2eb634aaa6b4865ad84379348ce9c542c48bec0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



