### PR TITLE
Re-enables radio buttons in settings

### DIFF
--- a/packages/bbui/src/Form/Core/RadioGroup.svelte
+++ b/packages/bbui/src/Form/Core/RadioGroup.svelte
@@ -39,6 +39,8 @@
   {#if parsedOptions && Array.isArray(parsedOptions)}
     {#each parsedOptions as option}
       {@const isOptionDisabled = disabled || getOptionDisabled(option)}
+      {@const optionLabel = getOptionLabel(option)}
+      {@const optionSubtitle = getOptionSubtitle(option)}
       <div
         title={getOptionTitle(option)}
         class="spectrum-Radio spectrum-FieldGroup-item spectrum-Radio--emphasized"
@@ -54,10 +56,10 @@
         />
         <span class="spectrum-Radio-button"></span>
         <label for="" class="spectrum-Radio-label radio-label">
-          <span class="radio-label-text">{getOptionLabel(option)}</span>
-          {#if getOptionSubtitle(option)}
+          <span class="radio-label-text">{optionLabel}</span>
+          {#if optionSubtitle && optionSubtitle !== optionLabel}
             <span class="radio-label-subtitle">
-              {getOptionSubtitle(option)}
+              {optionSubtitle}
             </span>
           {/if}
         </label>

--- a/packages/bbui/src/Form/RadioGroup.svelte
+++ b/packages/bbui/src/Form/RadioGroup.svelte
@@ -13,8 +13,8 @@
   export let getOptionLabel = option => extractProperty(option, "label")
   export let getOptionValue = option => extractProperty(option, "value")
   export let getOptionTitle = option => extractProperty(option, "label")
-  export let getOptionSubtitle = option => extractProperty(option, "subtitle")
-  export let getOptionDisabled = option => extractProperty(option, "disabled")
+  export let getOptionSubtitle = option => extractProperty(option, "subtitle", undefined)
+  export let getOptionDisabled = option => extractProperty(option, "disabled", false)
   export let helpText = undefined
 
   const dispatch = createEventDispatcher()
@@ -22,11 +22,11 @@
     value = e.detail
     dispatch("change", e.detail)
   }
-  const extractProperty = (value, property) => {
+  const extractProperty = (value, property, primitiveFallback = value) => {
     if (value && typeof value === "object") {
       return value[property]
     }
-    return value
+    return primitiveFallback
   }
 </script>
 

--- a/packages/bbui/src/Form/RadioGroup.svelte
+++ b/packages/bbui/src/Form/RadioGroup.svelte
@@ -13,8 +13,10 @@
   export let getOptionLabel = option => extractProperty(option, "label")
   export let getOptionValue = option => extractProperty(option, "value")
   export let getOptionTitle = option => extractProperty(option, "label")
-  export let getOptionSubtitle = option => extractProperty(option, "subtitle", undefined)
-  export let getOptionDisabled = option => extractProperty(option, "disabled", false)
+  export let getOptionSubtitle = option =>
+    extractProperty(option, "subtitle", undefined)
+  export let getOptionDisabled = option =>
+    extractProperty(option, "disabled", false)
   export let helpText = undefined
 
   const dispatch = createEventDispatcher()


### PR DESCRIPTION
## Description
The original reason for looking into this issue was that the Form Block settings for "Type" were disabled, with labels duplicated. 

<img width="280" height="286" alt="image" src="https://github.com/user-attachments/assets/8fb0fd1a-3949-4faa-8522-fca392c07e56" />

But looking closer, other components that use `"type": "radio",` in  `manifest.json` were also affected. This was mostly limited to the Barcode/QR Code generator, as other uses of that setting seemed to be on deprecated components. It seems to have been caused by some changes that sought more complex values, but would default to taking strings, meaning any string would equate to truthy and trigger the `disabled` property.
<img width="868" height="168" alt="image" src="https://github.com/user-attachments/assets/34b30bd7-351c-4e2c-8537-f25dd2bb7c78" />

This approach seems to still respect the work done in https://github.com/Budibase/budibase/pull/17806 regarding subtitles and disabled-settings

<img width="557" height="613" alt="image" src="https://github.com/user-attachments/assets/1509f478-a8c4-4d12-b95a-2914f1e3cfca" />


## Addresses
- https://github.com/Budibase/budibase/issues/17929

## Screenshots
<img width="312" height="225" alt="image" src="https://github.com/user-attachments/assets/c3745274-10ca-4937-9d38-848dc5b99b98" />

<img width="299" height="402" alt="image" src="https://github.com/user-attachments/assets/d6fcffd1-d9fd-4e2c-9f3d-81f0b19404ec" />

## Launchcontrol

Fixes "Type" setting for Form Block and Barcode/QRCode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enables radio buttons across settings by correctly handling primitive option values and subtitles. Fixes 17929 by restoring the Form Block “Type” selector and Barcode/QR options; includes minor lint cleanup.

- **Bug Fixes**
  - Default disabled=false and subtitle=undefined for primitive options so radios aren’t incorrectly disabled.
  - Only show a subtitle when it exists and differs from the label to prevent duplicate text.

<sup>Written for commit b0b986f429b167b26d559ebccb14a23e72d8f061. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

