### PR TITLE
Bulk delete plugins and show app usage

### DIFF
--- a/packages/builder/src/settings/pages/plugins/_components/DeletePluginModal.svelte
+++ b/packages/builder/src/settings/pages/plugins/_components/DeletePluginModal.svelte
@@ -6,8 +6,13 @@
   export let plugin
 
   let dispatch = createEventDispatcher()
+  $: usedInApps = plugin?.usedInApps || []
+  $: isUsedInApps = usedInApps.length > 0
 
   async function deletePlugin() {
+    if (isUsedInApps) {
+      return
+    }
     try {
       const name = plugin.name
       await plugins.deletePlugin(plugin._id)
@@ -27,8 +32,26 @@
   confirmText="Delete plugin"
   cancelText="Cancel"
   showCloseIcon={false}
+  disabled={isUsedInApps}
 >
   <Body>
-    Are you sure you want to delete <strong>{plugin?.name}</strong>?
+    {#if isUsedInApps}
+      <div>
+        <div>
+          <strong>{plugin?.name}</strong> is currently used in the following app{usedInApps.length ===
+          1
+            ? ""
+            : "s"}:
+        </div>
+        <ul>
+          {#each usedInApps as appName}
+            <li>{appName}</li>
+          {/each}
+        </ul>
+        Remove this plugin from those apps before deleting it.
+      </div>
+    {:else}
+      Are you sure you want to delete <strong>{plugin?.name}</strong>?
+    {/if}
   </Body>
 </ModalContent>

--- a/packages/builder/src/settings/pages/plugins/_components/DeletePluginModal.svelte
+++ b/packages/builder/src/settings/pages/plugins/_components/DeletePluginModal.svelte
@@ -35,7 +35,10 @@
     Are you sure you want to delete <strong>{plugin?.name}</strong>?
     {#if isUsedInApps}
       <div>
-        This plugin is currently used in {usedInApps.length} app{usedInApps.length === 1 ? "" : "s"}:
+        This plugin is currently used in {usedInApps.length} app{usedInApps.length ===
+        1
+          ? ""
+          : "s"}:
         <ul>
           {#each usedInApps as appName}
             <li>{appName}</li>

--- a/packages/builder/src/settings/pages/plugins/_components/DeletePluginModal.svelte
+++ b/packages/builder/src/settings/pages/plugins/_components/DeletePluginModal.svelte
@@ -10,9 +10,6 @@
   $: isUsedInApps = usedInApps.length > 0
 
   async function deletePlugin() {
-    if (isUsedInApps) {
-      return
-    }
     try {
       const name = plugin.name
       await plugins.deletePlugin(plugin._id)
@@ -32,26 +29,19 @@
   confirmText="Delete plugin"
   cancelText="Cancel"
   showCloseIcon={false}
-  disabled={isUsedInApps}
+  disabled={false}
 >
   <Body>
+    Are you sure you want to delete <strong>{plugin?.name}</strong>?
     {#if isUsedInApps}
       <div>
-        <div>
-          <strong>{plugin?.name}</strong> is currently used in the following app{usedInApps.length ===
-          1
-            ? ""
-            : "s"}:
-        </div>
+        This plugin is currently used in {usedInApps.length} app{usedInApps.length === 1 ? "" : "s"}:
         <ul>
           {#each usedInApps as appName}
             <li>{appName}</li>
           {/each}
         </ul>
-        Remove this plugin from those apps before deleting it.
       </div>
-    {:else}
-      Are you sure you want to delete <strong>{plugin?.name}</strong>?
     {/if}
   </Body>
 </ModalContent>

--- a/packages/builder/src/settings/pages/plugins/_components/UsedInAppsRenderer.svelte
+++ b/packages/builder/src/settings/pages/plugins/_components/UsedInAppsRenderer.svelte
@@ -1,0 +1,32 @@
+<script>
+  export let row
+
+  $: usedInApps = row?.usedInApps || []
+  $: tooltipText = usedInApps.length
+    ? usedInApps.join(", ")
+    : "Not used in any app"
+</script>
+
+<div class="usage" title={tooltipText}>
+  {#if usedInApps.length}
+    {#if usedInApps.length === 1}
+      {usedInApps[0]}
+    {:else}
+      {usedInApps[0]} +{usedInApps.length - 1}
+    {/if}
+  {:else}
+    <span class="unused">Not used</span>
+  {/if}
+</div>
+
+<style>
+  .usage {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .unused {
+    color: var(--spectrum-global-color-gray-700);
+  }
+</style>

--- a/packages/builder/src/settings/pages/plugins/index.svelte
+++ b/packages/builder/src/settings/pages/plugins/index.svelte
@@ -12,40 +12,67 @@
     notifications,
   } from "@budibase/bbui"
   import { onMount } from "svelte"
+  import type { Plugin } from "@budibase/types"
   import { admin } from "@/stores/portal/admin"
+  import { appsStore } from "@/stores/portal/apps"
   import { plugins } from "@/stores/portal/plugins"
   import AddPluginModal from "./_components/AddPluginModal.svelte"
   import PluginNameRenderer from "./_components/PluginNameRenderer.svelte"
   import EditPluginRenderer from "./_components/EditPluginRenderer.svelte"
+  import UsedInAppsRenderer from "./_components/UsedInAppsRenderer.svelte"
+  import ConfirmDialog from "@/components/common/ConfirmDialog.svelte"
   import { routeActions } from "@/settings/pages"
+  import type { StoreApp } from "@/types"
+
+  interface PluginTableRow extends Plugin {
+    usedInApps: string[]
+    usedInAppsLabel: string
+    __selectable: boolean
+  }
 
   const schema = {
     name: {
       width: "2fr",
       minWidth: "200px",
+      preventSelectRow: true,
     },
     version: {
       width: "1fr",
+      preventSelectRow: true,
     },
     "schema.type": {
       width: "1fr",
       displayName: "Type",
       capitalise: true,
       minWidth: "120px",
+      preventSelectRow: true,
+    },
+    usedInAppsLabel: {
+      width: "1.5fr",
+      displayName: "Used in apps",
+      minWidth: "180px",
+      sortable: false,
+      preventSelectRow: true,
     },
     edit: {
       width: "auto",
       displayName: "",
+      sortable: false,
+      preventSelectRow: true,
     },
   }
   const customRenderers = [
     { column: "name", component: PluginNameRenderer },
+    { column: "usedInAppsLabel", component: UsedInAppsRenderer },
     { column: "edit", component: EditPluginRenderer },
   ]
 
   let modal: any
+  let bulkDeleteDialog: any
   let searchTerm: any = ""
   let filter: any = "all"
+  let selectedRows: PluginTableRow[] = []
+  let deletingPlugins = false
   let filterOptions = [
     { label: "All plugins", value: "all" },
     { label: "Components", value: "component" },
@@ -59,7 +86,65 @@
     filterOptions.push({ label: "Automation", value: "automation" })
   }
 
-  $: filteredPlugins = $plugins
+  const buildPluginUsageMap = (apps: StoreApp[]): Map<string, string[]> => {
+    const usage = new Map<string, Set<string>>()
+    for (const app of apps || []) {
+      if (!app?.name || !Array.isArray(app.usedPlugins)) {
+        continue
+      }
+      for (const plugin of app.usedPlugins) {
+        if (!plugin?._id) {
+          continue
+        }
+        if (!usage.has(plugin._id)) {
+          usage.set(plugin._id, new Set())
+        }
+        usage.get(plugin._id)?.add(app.name)
+      }
+    }
+
+    const usageMap = new Map<string, string[]>()
+    for (const [pluginId, appNames] of usage.entries()) {
+      usageMap.set(
+        pluginId,
+        [...appNames].sort((a, b) => a.localeCompare(b))
+      )
+    }
+    return usageMap
+  }
+
+  $: pluginUsageById = buildPluginUsageMap($appsStore.apps)
+
+  $: enrichedPlugins = ($plugins || []).map(plugin => {
+    const usedInApps = plugin._id ? pluginUsageById.get(plugin._id) || [] : []
+    return {
+      ...plugin,
+      usedInApps,
+      usedInAppsLabel: usedInApps.length
+        ? `${usedInApps.length} app${usedInApps.length === 1 ? "" : "s"}`
+        : "Not used",
+      __selectable: usedInApps.length === 0,
+    }
+  }) as PluginTableRow[]
+
+  $: {
+    const selectablePluginIds = new Set(
+      enrichedPlugins
+        .filter(plugin => plugin._id && plugin.__selectable !== false)
+        .map(plugin => plugin._id as string)
+    )
+    const nextSelection = selectedRows.filter(
+      row => row._id && selectablePluginIds.has(row._id)
+    )
+    const hasSameSelection =
+      nextSelection.length === selectedRows.length &&
+      nextSelection.every((row, index) => row?._id === selectedRows[index]?._id)
+    if (!hasSameSelection) {
+      selectedRows = nextSelection
+    }
+  }
+
+  $: filteredPlugins = enrichedPlugins
     .filter((plugin: any) => {
       return filter === "all" || plugin.schema.type === filter
     })
@@ -71,7 +156,7 @@
     })
 
   onMount(async () => {
-    await plugins.load()
+    await Promise.all([plugins.load(), appsStore.load()])
     try {
       await plugins.checkUpdates()
     } catch (err: any) {
@@ -82,6 +167,65 @@
       )
     }
   })
+
+  async function bulkDeletePlugins() {
+    if (deletingPlugins || selectedRows.length === 0) {
+      return
+    }
+    deletingPlugins = true
+    const pluginsToDelete = [...selectedRows]
+    try {
+      const deletionResults = await Promise.allSettled(
+        pluginsToDelete.map(async plugin => {
+          if (!plugin._id) {
+            throw new Error("Plugin ID missing")
+          }
+          await plugins.deletePlugin(plugin._id)
+          return plugin._id
+        })
+      )
+
+      const deletedPluginIds = new Set<string>()
+      const failedPluginIds = new Set<string>()
+      const failedMessages: string[] = []
+      for (let index = 0; index < deletionResults.length; index++) {
+        const result = deletionResults[index]
+        const plugin = pluginsToDelete[index]
+        if (!plugin?._id) {
+          continue
+        }
+        if (result.status === "fulfilled") {
+          deletedPluginIds.add(result.value)
+          continue
+        }
+        failedPluginIds.add(plugin._id)
+        const reason =
+          result.reason?.message ||
+          result.reason?.error ||
+          JSON.stringify(result.reason)
+        failedMessages.push(`${plugin.name}: ${reason}`)
+      }
+
+      if (deletedPluginIds.size > 0) {
+        notifications.success(
+          deletedPluginIds.size === 1
+            ? "Deleted 1 plugin"
+            : `Deleted ${deletedPluginIds.size} plugins`
+        )
+      }
+      if (failedMessages.length > 0) {
+        notifications.error(
+          `Failed to delete plugins:\n${failedMessages.join("\n")}`
+        )
+      }
+
+      selectedRows = selectedRows.filter(
+        row => row._id && failedPluginIds.has(row._id)
+      )
+    } finally {
+      deletingPlugins = false
+    }
+  }
 
   async function applyAllUpdates() {
     if (applyingUpdates) {
@@ -173,7 +317,19 @@
           </div>
         </div>
       {/if}
-      <Button size="M" on:click={modal.show} cta>Add plugin</Button>
+      <div class="actions">
+        {#if selectedRows.length}
+          <Button
+            size="M"
+            warning
+            on:click={bulkDeleteDialog.show}
+            disabled={deletingPlugins}
+          >
+            Delete selected ({selectedRows.length})
+          </Button>
+        {/if}
+        <Button size="M" on:click={modal.show} cta>Add plugin</Button>
+      </div>
     </div>
 
     {#if $plugins?.length}
@@ -182,9 +338,10 @@
         data={filteredPlugins}
         allowEditColumns={false}
         allowEditRows={false}
-        allowSelectRows={false}
+        allowSelectRows={true}
         allowClickRows={false}
         {customRenderers}
+        bind:selectedRows
       />
     {/if}
   </Layout>
@@ -193,6 +350,19 @@
 <Modal bind:this={modal}>
   <AddPluginModal />
 </Modal>
+
+<ConfirmDialog
+  bind:this={bulkDeleteDialog}
+  title="Delete selected plugins"
+  okText={deletingPlugins ? "Deleting..." : "Delete plugins"}
+  onOk={bulkDeletePlugins}
+  disabled={deletingPlugins}
+>
+  Are you sure you want to delete {selectedRows.length} selected plugin{selectedRows.length ===
+  1
+    ? ""
+    : "s"}?
+</ConfirmDialog>
 
 <style>
   .filters {
@@ -209,6 +379,11 @@
   .controls :global(.spectrum-Search) {
     width: 200px;
   }
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s);
+  }
 
   @media (max-width: 640px) {
     .filters {
@@ -217,6 +392,10 @@
     }
     .controls :global(.spectrum-Search) {
       width: auto;
+    }
+    .actions {
+      width: 100%;
+      justify-content: flex-end;
     }
   }
   .updates-banner {

--- a/packages/builder/src/settings/pages/plugins/index.svelte
+++ b/packages/builder/src/settings/pages/plugins/index.svelte
@@ -27,7 +27,6 @@
   interface PluginTableRow extends Plugin {
     usedInApps: string[]
     usedInAppsLabel: string
-    __selectable: boolean
   }
 
   const schema = {
@@ -68,9 +67,9 @@
   ]
 
   let modal: any
-  let bulkDeleteDialog: any
-  let searchTerm: any = ""
-  let filter: any = "all"
+  let bulkDeleteDialog: ConfirmDialog
+  let searchTerm = ""
+  let filter = "all"
   let selectedRows: PluginTableRow[] = []
   let deletingPlugins = false
   let filterOptions = [
@@ -123,26 +122,8 @@
       usedInAppsLabel: usedInApps.length
         ? `${usedInApps.length} app${usedInApps.length === 1 ? "" : "s"}`
         : "Not used",
-      __selectable: usedInApps.length === 0,
     }
   }) as PluginTableRow[]
-
-  $: {
-    const selectablePluginIds = new Set(
-      enrichedPlugins
-        .filter(plugin => plugin._id && plugin.__selectable !== false)
-        .map(plugin => plugin._id as string)
-    )
-    const nextSelection = selectedRows.filter(
-      row => row._id && selectablePluginIds.has(row._id)
-    )
-    const hasSameSelection =
-      nextSelection.length === selectedRows.length &&
-      nextSelection.every((row, index) => row?._id === selectedRows[index]?._id)
-    if (!hasSameSelection) {
-      selectedRows = nextSelection
-    }
-  }
 
   $: filteredPlugins = enrichedPlugins
     .filter((plugin: any) => {
@@ -362,6 +343,18 @@
   1
     ? ""
     : "s"}?
+  {#if selectedRows.some(row => row.usedInApps?.length)}
+    <div class="usage-warning">
+      The following plugins are currently used in apps:
+      <ul>
+        {#each selectedRows.filter(row => row.usedInApps?.length) as row}
+          <li>
+            <strong>{row.name}</strong> — {row.usedInApps.join(", ")}
+          </li>
+        {/each}
+      </ul>
+    </div>
+  {/if}
 </ConfirmDialog>
 
 <style>
@@ -397,6 +390,13 @@
       width: 100%;
       justify-content: flex-end;
     }
+  }
+  .usage-warning {
+    margin-top: var(--spacing-m);
+  }
+  .usage-warning ul {
+    margin: var(--spacing-xs) 0 0 0;
+    padding-left: var(--spacing-l);
   }
   .updates-banner {
     display: flex;


### PR DESCRIPTION
## Description
- Allow users to bulk delete plugins
- Show users if a plugin is in use with an app

## Screenshots
<img width="921" height="460" alt="image" src="https://github.com/user-attachments/assets/0b3db676-044c-4da8-8754-a42301d99360" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bulk delete to the Plugins page and shows where each plugin is used. Adds usage-aware confirmations and clear feedback on partial failures.

- **New Features**
  - “Used in apps” column with counts; hover shows app names; shows “Not used” when unused.
  - Select rows and bulk delete with a confirmation dialog that lists selected plugins and warns if they’re used.
  - Single-delete modal shows the app names using the plugin.
  - Aggregated success/error messages per plugin; failed deletions remain selected.
  - Loads apps and plugins on page load to compute usage.

<sup>Written for commit 58b0044a3fde699707364e793f312323eeb1c238. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



