### PR TITLE
Remove old stream code

### DIFF
--- a/packages/pro/src/ai/models/anthropic.ts
+++ b/packages/pro/src/ai/models/anthropic.ts
@@ -1,5 +1,5 @@
 import AnthropicClient from "@anthropic-ai/sdk"
-import { LLMConfigOptions, LLMStreamChunk } from "@budibase/types"
+import { LLMConfigOptions } from "@budibase/types"
 import { LLMFullResponse } from "../../types/ai"
 import { LLMRequest } from "../llm"
 import { LLM } from "./base"
@@ -100,38 +100,6 @@ export class Anthropic extends LLM {
         )
       }
       throw err
-    }
-  }
-
-  protected async *chatCompletionStream(
-    request: LLMRequest
-  ): AsyncGenerator<LLMStreamChunk, void, unknown> {
-    // TODO: Implement streaming for Anthropic
-    // For now, fall back to non-streaming and yield all at once
-    try {
-      const response = await this.chatCompletion(request)
-
-      // Yield the final message content if available
-      if (response.messages.length > 0) {
-        const lastMessage = response.messages[response.messages.length - 1]
-        if (lastMessage.content) {
-          yield {
-            type: "content",
-            content: lastMessage.content as string,
-          }
-        }
-      }
-
-      yield {
-        type: "done",
-        messages: response.messages,
-        tokensUsed: response.tokensUsed,
-      }
-    } catch (error: any) {
-      yield {
-        type: "error",
-        content: error.message,
-      }
     }
   }
 }

--- a/packages/pro/src/ai/models/base.ts
+++ b/packages/pro/src/ai/models/base.ts
@@ -4,7 +4,6 @@ import {
   AIOperationEnum,
   EnrichedBinding,
   LLMConfigOptions,
-  LLMStreamChunk,
   Row,
   Snippet,
 } from "@budibase/types"
@@ -53,10 +52,6 @@ export abstract class LLM {
     request: LLMRequest
   ): Promise<LLMFullResponse>
 
-  protected abstract chatCompletionStream(
-    request: LLMRequest
-  ): AsyncGenerator<LLMStreamChunk, void, unknown>
-
   async prompt(
     requestOrString: string | LLMRequest
   ): Promise<LLMPromptResponse> {
@@ -88,12 +83,6 @@ export abstract class LLM {
       const response = await this.chatCompletion(request)
       return response
     })
-  }
-
-  async *chatStream(
-    request: LLMRequest
-  ): AsyncGenerator<LLMStreamChunk, void, unknown> {
-    yield* this.chatCompletionStream(request)
   }
 
   async summarizeText(prompt: string): Promise<LLMPromptResponse> {

--- a/packages/pro/src/ai/models/budibaseai.ts
+++ b/packages/pro/src/ai/models/budibaseai.ts
@@ -3,7 +3,6 @@ import {
   ChatCompletionRequest,
   ChatCompletionResponse,
   ImageContentTypes,
-  LLMStreamChunk,
 } from "@budibase/types"
 import { tracer } from "dd-trace"
 import { Readable } from "node:stream"
@@ -227,81 +226,5 @@ export class BudibaseAI extends LLM {
 
       return result
     })
-  }
-
-  protected async *chatCompletionStream(
-    request: LLMRequest
-  ): AsyncGenerator<LLMStreamChunk, void, unknown> {
-    if (env.SELF_HOSTED) {
-      yield* this.chatCompletionStreamSelfHost(request)
-    } else {
-      yield* this.chatCompletionStreamCloud(request)
-    }
-  }
-
-  protected async *chatCompletionStreamCloud(
-    request: LLMRequest
-  ): AsyncGenerator<LLMStreamChunk, void, unknown> {
-    const llm = new OpenAI({
-      apiKey: env.OPENAI_API_KEY,
-      model: this.model,
-      max_completion_tokens: this.maxTokens,
-    })
-    // @ts-expect-error - we're being cheeky and calling a protected method
-    yield* llm.chatCompletionStream(request)
-  }
-
-  protected async *chatCompletionStreamSelfHost(
-    request: LLMRequest
-  ): AsyncGenerator<LLMStreamChunk, void, unknown> {
-    // TODO: Implement streaming for self-hosted BudibaseAI
-    // For now, fall back to non-streaming and yield all at once
-    console.debug(
-      "[BudibaseAI] chatCompletionStreamSelfHost - Starting streaming (fallback to non-streaming)",
-      {
-        messagesCount: request.messages.length,
-      }
-    )
-
-    try {
-      const response = await this.chatCompletionSelfHost(request)
-
-      console.debug(
-        "[BudibaseAI] chatCompletionStreamSelfHost - Yielding response chunks",
-        {
-          responseMessagesCount: response.messages.length,
-          tokensUsed: response.tokensUsed,
-        }
-      )
-
-      // Yield the final message content if available
-      if (response.messages.length > 0) {
-        const lastMessage = response.messages[response.messages.length - 1]
-        if (lastMessage.content) {
-          yield {
-            type: "content",
-            content: lastMessage.content as string,
-          }
-        }
-      }
-
-      yield {
-        type: "done",
-        messages: response.messages,
-        tokensUsed: response.tokensUsed,
-      }
-    } catch (error: any) {
-      console.debug(
-        "[BudibaseAI] chatCompletionStreamSelfHost - Error occurred",
-        {
-          error: error.message,
-        }
-      )
-
-      yield {
-        type: "error",
-        content: error.message,
-      }
-    }
   }
 }

--- a/packages/pro/src/ai/models/openai.ts
+++ b/packages/pro/src/ai/models/openai.ts
@@ -1,7 +1,6 @@
 import {
   ImageContentTypes,
   LLMConfigOptions,
-  LLMStreamChunk,
   ResponseFormat,
 } from "@budibase/types"
 import { Readable } from "node:stream"
@@ -152,66 +151,6 @@ export class OpenAI extends LLM {
       }
     } else {
       throw new Error("No response found")
-    }
-  }
-
-  protected async *chatCompletionStream(
-    request: LLMRequest
-  ): AsyncGenerator<LLMStreamChunk, void, unknown> {
-    const parameters: OpenAITypes.ChatCompletionCreateParamsStreaming = {
-      model: this.model,
-      messages: request.messages,
-      max_tokens: this.maxTokens,
-      response_format: parseResponseFormat(request.format),
-      stream: true,
-    }
-
-    try {
-      const stream = await this.client.chat.completions.create(parameters)
-
-      let contentBuffer = ""
-      let finalUsage: OpenAIClient.CompletionUsage | null = null
-
-      for await (const chunk of stream) {
-        const delta = chunk?.choices?.[0]?.delta
-        if (!delta) continue
-
-        // Handle content streaming
-        if (delta.content) {
-          contentBuffer += delta.content
-          yield {
-            type: "content",
-            content: delta.content,
-          }
-        }
-
-        if (chunk.usage) {
-          finalUsage = chunk.usage
-        }
-      }
-
-      const totalTokens = finalUsage
-        ? calculateBudibaseAICredits(finalUsage)
-        : 0
-
-      // Final response
-      if (contentBuffer) {
-        request.addMessage({
-          role: "assistant",
-          content: contentBuffer,
-        })
-      }
-
-      yield {
-        type: "done",
-        messages: request.messages,
-        tokensUsed: totalTokens,
-      }
-    } catch (error: any) {
-      yield {
-        type: "error",
-        content: error.message,
-      }
     }
   }
 }

--- a/packages/types/src/sdk/ai.ts
+++ b/packages/types/src/sdk/ai.ts
@@ -1,5 +1,4 @@
-import { Message } from "../api"
-import { ChatConversation, AIProvider } from "../documents"
+import { AIProvider } from "../documents"
 
 export enum AIOperationEnum {
   SUMMARISE_TEXT = "SUMMARISE_TEXT",
@@ -104,28 +103,4 @@ export interface LLMConfigOptions {
 
 export interface LLMProviderConfig extends LLMConfigOptions {
   provider: AIProvider
-}
-
-export interface LLMStreamChunk {
-  type:
-    | "content"
-    | "tool_call_start"
-    | "tool_call_result"
-    | "done"
-    | "error"
-    | "chat_saved"
-  content?: string
-  toolCall?: {
-    id: string
-    name: string
-    arguments: string
-  }
-  toolResult?: {
-    id: string
-    result: string
-    error?: string
-  }
-  messages?: Message[]
-  chat?: ChatConversation
-  tokensUsed?: number
 }


### PR DESCRIPTION
## Description
Remove old (and never used) stream code



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed legacy streaming code for chat completions across providers and types. Standardizes on non‑streaming chatCompletion and simplifies the LLM base.

- **Refactors**
  - Removed chatStream/chatCompletionStream from LLM base and providers (OpenAI, BudibaseAI, Anthropic).
  - Deleted LLMStreamChunk and unused types/imports in @budibase/types.
  - Cleaned imports and simplified model code paths.

- **Migration**
  - Replace chatStream/chatCompletionStream with chatCompletion.
  - Remove references to LLMStreamChunk.
  - Non‑stream APIs are unchanged; handle full responses from chatCompletion.

<sup>Written for commit 5760359856c21e7fb07e076df393eb8a42e82057. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



