### PR TITLE
Fixing release pipeline

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -3,6 +3,9 @@ concurrency:
   group: tag-release
   cancel-in-progress: false
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -29,7 +32,7 @@ jobs:
           exit 1
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: cd scripts && yarn
       - name: Tag release


### PR DESCRIPTION
## Description
Fixing release pipeline after adding stricter branch protection to master. This change allows the push to come from the github action, allowing to bypass the stricter permissions for users.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore release tagging after stricter master protections. The workflow now uses GITHUB_TOKEN and grants write access so it can push tags.

- **Bug Fixes**
  - Add permissions: contents: write to tag-release workflow.
  - Switch actions/checkout token from PERSONAL_ACCESS_TOKEN to GITHUB_TOKEN.

<sup>Written for commit 99c6645151e14b4633442520753b3d29eb6b68b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

