### PR TITLE
Fail pipeline if version commit fails

### DIFF
--- a/scripts/versionCommit.sh
+++ b/scripts/versionCommit.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 if [ -z "$1" ]
 then

--- a/scripts/versionCommit.sh
+++ b/scripts/versionCommit.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-if [ -z "$1" ]
+if [ -z "${1:-}" ]
 then
   echo "Error: bump type is required. Usage: $0 [major|minor|patch|prerelease]"
   exit 1


### PR DESCRIPTION
## Description
Fail pipeline if version commit fails


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the release pipeline fail fast if the version commit, tag, or push fails. Adds set -euo pipefail and switches to ${1:-} for the bump type check to prevent unbound variable errors when no argument is passed.

<sup>Written for commit e0052e513d373f3d41296c2c980943f9e49ae10d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



