### PR TITLE
Use deploy key for tag release

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -32,7 +32,7 @@ jobs:
           exit 1
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{secrets.RELEASE_KEY}}
 
       - run: cd scripts && yarn
       - name: Tag release


### PR DESCRIPTION
## Description
_Describe the problem or feature in addition to a link to the relevant github issues._

## Addresses
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._

## Launchcontrol

_Add a small description in layman's terms of what this PR achieves. This will be used in the release notes._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the tag-release workflow to use an SSH deploy key (RELEASE_KEY) instead of GITHUB_TOKEN for checkout and tag pushes. This makes tag publishing more reliable and independent of token scope changes.

- **Migration**
  - Add the public key as a repo Deploy key with write access.
  - Add the private key as the RELEASE_KEY secret.
  - Verify the workflow can push a test tag.

<sup>Written for commit 35c886459058ddf3fbfb47ba02aecd63870ebaf7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

