### PR TITLE
Don't store API keys as plain text

### DIFF
--- a/packages/backend-core/src/security/encryption.ts
+++ b/packages/backend-core/src/security/encryption.ts
@@ -89,8 +89,15 @@ export function compare(
   secretOption: SecretOption = SecretOption.API
 ) {
   try {
-    const decrypted = decrypt(encrypted, secretOption)
-    return decrypted === plain
+    const encoder = new TextEncoder()
+    const decryptedBuffer = encoder.encode(decrypt(encrypted, secretOption))
+    const plainBuffer = encoder.encode(plain)
+
+    if (decryptedBuffer.length !== plainBuffer.length) {
+      return false
+    }
+
+    return crypto.timingSafeEqual(decryptedBuffer, plainBuffer)
   } catch {
     return false
   }

--- a/packages/backend-core/src/security/encryption.ts
+++ b/packages/backend-core/src/security/encryption.ts
@@ -83,6 +83,19 @@ export function decrypt(
   return Buffer.concat([new Uint8Array(base), new Uint8Array(final)]).toString()
 }
 
+export function compare(
+  plain: string,
+  encrypted: string,
+  secretOption: SecretOption = SecretOption.API
+) {
+  try {
+    const decrypted = decrypt(encrypted, secretOption)
+    return decrypted === plain
+  } catch {
+    return false
+  }
+}
+
 export async function encryptFile(
   { dir, filename }: { dir: string; filename: string },
   secret: string

--- a/packages/backend-core/src/security/tests/encryption.spec.ts
+++ b/packages/backend-core/src/security/tests/encryption.spec.ts
@@ -1,4 +1,10 @@
-import { encrypt, decrypt, SecretOption, getSecret } from "../encryption"
+import {
+  compare,
+  decrypt,
+  encrypt,
+  getSecret,
+  SecretOption,
+} from "../encryption"
 import env from "../../environment"
 
 describe("encryption", () => {
@@ -27,5 +33,13 @@ describe("encryption", () => {
     const encryptionEncrypted = encrypt(plaintext, SecretOption.ENCRYPTION)
     const decrypted = decrypt(encryptionEncrypted, SecretOption.ENCRYPTION)
     expect(decrypted).toEqual(plaintext)
+  })
+
+  it("should compare plaintext against encrypted values", () => {
+    env._set("API_ENCRYPTION_KEY", "api_secret")
+    const plaintext = "budibase"
+    const encrypted = encrypt(plaintext, SecretOption.API)
+    expect(compare(plaintext, encrypted, SecretOption.API)).toBe(true)
+    expect(compare("not-budibase", encrypted, SecretOption.API)).toBe(false)
   })
 })

--- a/packages/backend-core/src/security/tests/encryption.spec.ts
+++ b/packages/backend-core/src/security/tests/encryption.spec.ts
@@ -5,7 +5,7 @@ import {
   getSecret,
   SecretOption,
 } from "../encryption"
-import env from "../../environment"
+import env, { withEnv } from "../../environment"
 
 describe("encryption", () => {
   it("should throw an error if API encryption key is not set", () => {
@@ -20,26 +20,29 @@ describe("encryption", () => {
   })
 
   it("should encrypt and decrypt a string using API encryption key", () => {
-    env._set("API_ENCRYPTION_KEY", "api_secret")
-    const plaintext = "budibase"
-    const apiEncrypted = encrypt(plaintext, SecretOption.API)
-    const decrypted = decrypt(apiEncrypted, SecretOption.API)
-    expect(decrypted).toEqual(plaintext)
+    withEnv({ API_ENCRYPTION_KEY: "api_secret" }, () => {
+      const plaintext = "budibase"
+      const apiEncrypted = encrypt(plaintext, SecretOption.API)
+      const decrypted = decrypt(apiEncrypted, SecretOption.API)
+      expect(decrypted).toEqual(plaintext)
+    })
   })
 
   it("should encrypt and decrypt a string using encryption key", () => {
-    env._set("ENCRYPTION_KEY", "normal_secret")
-    const plaintext = "budibase"
-    const encryptionEncrypted = encrypt(plaintext, SecretOption.ENCRYPTION)
-    const decrypted = decrypt(encryptionEncrypted, SecretOption.ENCRYPTION)
-    expect(decrypted).toEqual(plaintext)
+    withEnv({ ENCRYPTION_KEY: "normal_secret" }, () => {
+      const plaintext = "budibase"
+      const encryptionEncrypted = encrypt(plaintext, SecretOption.ENCRYPTION)
+      const decrypted = decrypt(encryptionEncrypted, SecretOption.ENCRYPTION)
+      expect(decrypted).toEqual(plaintext)
+    })
   })
 
   it("should compare plaintext against encrypted values", () => {
-    env._set("API_ENCRYPTION_KEY", "api_secret")
-    const plaintext = "budibase"
-    const encrypted = encrypt(plaintext, SecretOption.API)
-    expect(compare(plaintext, encrypted, SecretOption.API)).toBe(true)
-    expect(compare("not-budibase", encrypted, SecretOption.API)).toBe(false)
+    withEnv({ API_ENCRYPTION_KEY: "api_secret" }, () => {
+      const plaintext = "budibase"
+      const encrypted = encrypt(plaintext, SecretOption.API)
+      expect(compare(plaintext, encrypted, SecretOption.API)).toBe(true)
+      expect(compare("not-budibase", encrypted, SecretOption.API)).toBe(false)
+    })
   })
 })

--- a/packages/server/src/api/controllers/ai/configs.ts
+++ b/packages/server/src/api/controllers/ai/configs.ts
@@ -17,18 +17,7 @@ import sdk from "../../../sdk"
 const sanitizeConfig = async (
   config: CustomAIProviderConfig
 ): Promise<AIConfigResponse> => {
-  let providers = await sdk.ai.configs.fetchLiteLLMProviders()
-  providers = [
-    ...providers,
-    {
-      id: BUDIBASE_AI_PROVIDER_ID,
-      displayName: "Budibase AI",
-      externalProvider: "custom_openai",
-      credentialFields: [
-        { key: "api_key", label: "api_key", field_type: "password" },
-      ],
-    },
-  ]
+  const providers = await sdk.ai.configs.fetchLiteLLMProviders()
   const provider = providers.find(p => p.id === config.provider)
 
   if (!provider) {
@@ -72,7 +61,9 @@ export const fetchAIConfigs = async (
 export const fetchAIProviders = async (
   ctx: UserCtx<void, LLMProvidersResponse>
 ) => {
-  ctx.body = await sdk.ai.configs.fetchLiteLLMProviders()
+  const allProviders = await sdk.ai.configs.fetchLiteLLMProviders()
+  const providers = allProviders.filter(p => p.id !== BUDIBASE_AI_PROVIDER_ID)
+  ctx.body = providers
 }
 
 export const createAIConfig = async (

--- a/packages/server/src/sdk/workspace/ai/configs/index.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/index.ts
@@ -224,6 +224,15 @@ export async function fetchLiteLLMProviders(): Promise<LLMProvider[]> {
       }
       return mapProvider
     })
+
+    liteLLMProviders.push({
+      id: BUDIBASE_AI_PROVIDER_ID,
+      displayName: "Budibase AI",
+      externalProvider: "custom_openai",
+      credentialFields: [
+        { key: "api_key", label: "api_key", field_type: "password" },
+      ],
+    })
   }
   return liteLLMProviders
 }


### PR DESCRIPTION
## Description
Don't store API keys as plain text


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encrypt provider secrets (API and web search keys) at rest and keep them masked in API responses. Moved Budibase AI provider registration into the SDK and filtered it from the public providers API.

- **New Features**
  - Encode secrets at rest with bbai_enc:: prefix and AES; decode on read for internal use.
  - Encrypt password-type credential fields and webSearchConfig.apiKey; mask in responses with PASSWORD_REPLACEMENT.
  - Add timing-safe encryption.compare and tests.
  - Register Budibase AI provider in the SDK; controllers return external providers only.

<sup>Written for commit 2b793adf8657a3f16a9af33386bf38824593a473. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



