### PR TITLE
Create evals for old usages

### DIFF
--- a/hosting/nginx.dev.conf
+++ b/hosting/nginx.dev.conf
@@ -57,6 +57,18 @@ http {
       rewrite ^/db/(.*)$ /$1 break;
     }
 
+    location = /health {
+      proxy_read_timeout 120s;
+      proxy_connect_timeout 120s;
+      proxy_send_timeout 120s;
+      proxy_http_version 1.1;
+
+      proxy_set_header Host $host;
+      proxy_set_header Connection "";
+
+      proxy_pass      http://app-service/health;
+    }
+
     location ~ ^/api/(system|admin|global)/ {
       proxy_read_timeout 120s;
       proxy_connect_timeout 120s;

--- a/packages/builder/src/stores/builder/automations.ts
+++ b/packages/builder/src/stores/builder/automations.ts
@@ -2478,15 +2478,18 @@ const automationActions = (store: AutomationStore) => ({
       // used in the server to detect relationships. It would be far better to
       // instead fetch the schema in the backend at runtime.
       // If _tableId is explicitly included in the update request, the schema will be requested
-      let schema: Record<any, any> = {}
+      let requestedTableSchema: Record<string, any> | undefined
       if (request?._tableId) {
-        schema = getSchemaForDatasourcePlus(request._tableId, {
+        requestedTableSchema = getSchemaForDatasourcePlus(request._tableId, {
           searchableSchema: true,
         }).schema
         delete request._tableId
       }
       try {
-        const data = { schema, ...request }
+        const data = { ...request }
+        if (requestedTableSchema) {
+          data.schema = requestedTableSchema
+        }
         const stepBlock = block as AutomationStep
         await automationStore.actions.updateBlockInputs(stepBlock, data)
       } catch (error) {

--- a/packages/pro/src/ai/generators/tableGeneration.ts
+++ b/packages/pro/src/ai/generators/tableGeneration.ts
@@ -38,7 +38,7 @@ export class TableGeneration {
   }
 
   static async init(delegates: Delegates) {
-    const llm = await getLLM({ model: "gpt-5-mini", maxTokens: 5000 })
+    const llm = await getLLM({ maxTokens: 5000 })
     if (!llm) {
       throw new HTTPError("LLM not available", 422)
     }

--- a/packages/pro/src/ai/llm.ts
+++ b/packages/pro/src/ai/llm.ts
@@ -124,7 +124,7 @@ export async function getLLMConfig(): Promise<LLMProviderConfig | undefined> {
 // the user has no LLM configuration it will return undefined. It's the caller's
 // responsibility to handle this case.
 export async function getLLM(
-  options?: LLMConfigOptions
+  options?: Omit<LLMConfigOptions, "model"> & { model?: string }
 ): Promise<LLM | undefined> {
   return await tracer.trace("getLLM", async span => {
     const { model, maxTokens } = options || {}

--- a/packages/pro/src/ai/models/anthropic.ts
+++ b/packages/pro/src/ai/models/anthropic.ts
@@ -23,6 +23,8 @@ function calculateBudibaseAICredits(usage?: AnthropicClient.Usage): number {
 }
 
 export class Anthropic extends LLM {
+  override supportsFiles = false
+
   private client: AnthropicClient
 
   constructor(opts: LLMConfigOptions) {

--- a/packages/pro/src/ai/models/azureOpenai.ts
+++ b/packages/pro/src/ai/models/azureOpenai.ts
@@ -3,6 +3,8 @@ import { OpenAI, GPT_5_MODELS } from "./openai"
 import { AzureOpenAI as AzureOpenAIClient } from "openai"
 
 export class AzureOpenAI extends OpenAI {
+  override supportsFiles = false
+
   protected override getClient(opts: LLMConfigOptions) {
     if (!opts.apiKey) {
       throw new Error("No Azure OpenAI API key found")

--- a/packages/pro/src/ai/models/base.ts
+++ b/packages/pro/src/ai/models/base.ts
@@ -48,6 +48,8 @@ export abstract class LLM {
     return this._maxTokens
   }
 
+  abstract supportsFiles: boolean
+
   protected abstract chatCompletion(
     request: LLMRequest
   ): Promise<LLMFullResponse>

--- a/packages/pro/src/ai/models/budibaseai.ts
+++ b/packages/pro/src/ai/models/budibaseai.ts
@@ -129,7 +129,7 @@ export class BudibaseAI extends LLM {
     }
 
     const result = await resp.json()
-    return result.fileId
+    return result.file
   }
 
   protected async chatCompletion(prompt: LLMRequest): Promise<LLMFullResponse> {

--- a/packages/pro/src/ai/models/budibaseai.ts
+++ b/packages/pro/src/ai/models/budibaseai.ts
@@ -15,6 +15,8 @@ import { LLM } from "./base"
 import { OpenAI } from "./openai"
 
 export class BudibaseAI extends LLM {
+  override supportsFiles = true
+
   async prompt(prompt: string | LLMRequest): Promise<LLMPromptResponse> {
     const response = await super.prompt(prompt)
     if (response.tokensUsed) {

--- a/packages/pro/src/ai/models/openai.ts
+++ b/packages/pro/src/ai/models/openai.ts
@@ -75,6 +75,8 @@ export class OpenAI extends LLM {
     this.client = this.getClient(opts)
   }
 
+  override supportsFiles = true
+
   // Default verbosity preference for supported models. Subclasses
   // (e.g. AzureOpenAI) can override to align with provider limits.
   protected getVerbosityForModel(): "low" | "medium" | undefined {

--- a/packages/pro/src/ai/prompts/index.ts
+++ b/packages/pro/src/ai/prompts/index.ts
@@ -48,7 +48,7 @@ export function extractFileData(
     `Extract data from the attached document/image that matches the provided schema.`,
     "The schema defines the structure where values like 'string', 'number', 'boolean' indicate the expected data types.",
     "Extract all items that match the schema from the document.",
-    "Return the data in json format",
+    "Return the data in json format. This array should never have more than 1 element.",
     "If no matching data is found, return an empty data array.",
   ].join("\n\n")
 

--- a/packages/pro/src/ai/prompts/index.ts
+++ b/packages/pro/src/ai/prompts/index.ts
@@ -39,6 +39,10 @@ export function extractFileData(
   schema: Record<string, any>,
   fileIdOrDataUrl: string
 ) {
+  if (typeof fileIdOrDataUrl !== "string" || !fileIdOrDataUrl.trim()) {
+    throw new Error("Invalid file reference returned from uploadFile")
+  }
+
   const prompt = [
     "You are a data extraction assistant.",
     `Extract data from the attached document/image that matches the provided schema.`,
@@ -61,7 +65,16 @@ export function extractFileData(
         },
         { type: "text", text: prompt },
       ]
-    : [{ type: "text", text: `${prompt}\n\nFile ID: ${fileIdOrDataUrl}` }]
+    : [
+        {
+          type: "file",
+          file: {
+            file_id: fileIdOrDataUrl,
+          },
+        },
+        // Keep a text fallback for providers that ignore file parts.
+        { type: "text", text: `${prompt}\n\nFile ID: ${fileIdOrDataUrl}` },
+      ]
 
   // We create a structured zod schema from the user object
   const zodSchema = createZodSchemaFromRecord(schema)

--- a/packages/pro/src/ai/prompts/index.ts
+++ b/packages/pro/src/ai/prompts/index.ts
@@ -37,7 +37,8 @@ export function summarizeText(text: string, length?: SummariseLength) {
 
 export function extractFileData(
   schema: Record<string, any>,
-  fileIdOrDataUrl: string
+  fileIdOrDataUrl: string,
+  supportsFile: boolean
 ) {
   if (typeof fileIdOrDataUrl !== "string" || !fileIdOrDataUrl.trim()) {
     throw new Error("Invalid file reference returned from uploadFile")
@@ -65,7 +66,16 @@ export function extractFileData(
         },
         { type: "text", text: prompt },
       ]
-    : [{ type: "text", text: `${prompt}\n\nFile ID: ${fileIdOrDataUrl}` }]
+    : supportsFile
+      ? [
+          {
+            type: "file",
+            file: {
+              file_id: fileIdOrDataUrl,
+            },
+          },
+        ]
+      : [{ type: "text", text: `${prompt}\n\nFile ID: ${fileIdOrDataUrl}` }]
 
   // We create a structured zod schema from the user object
   const zodSchema = createZodSchemaFromRecord(schema)

--- a/packages/pro/src/ai/prompts/index.ts
+++ b/packages/pro/src/ai/prompts/index.ts
@@ -65,16 +65,7 @@ export function extractFileData(
         },
         { type: "text", text: prompt },
       ]
-    : [
-        {
-          type: "file",
-          file: {
-            file_id: fileIdOrDataUrl,
-          },
-        },
-        // Keep a text fallback for providers that ignore file parts.
-        { type: "text", text: `${prompt}\n\nFile ID: ${fileIdOrDataUrl}` },
-      ]
+    : [{ type: "text", text: `${prompt}\n\nFile ID: ${fileIdOrDataUrl}` }]
 
   // We create a structured zod schema from the user object
   const zodSchema = createZodSchemaFromRecord(schema)

--- a/packages/pro/src/ai/prompts/index.ts
+++ b/packages/pro/src/ai/prompts/index.ts
@@ -74,6 +74,7 @@ export function extractFileData(
               file_id: fileIdOrDataUrl,
             },
           },
+          { type: "text", text: prompt },
         ]
       : [{ type: "text", text: `${prompt}\n\nFile ID: ${fileIdOrDataUrl}` }]
 

--- a/packages/pro/src/ai/prompts/index.ts
+++ b/packages/pro/src/ai/prompts/index.ts
@@ -81,7 +81,7 @@ export function extractFileData(
   // We create a structured zod schema from the user object
   const zodSchema = createZodSchemaFromRecord(schema)
   const responseSchema = z.object({
-    data: z.array(zodSchema),
+    data: z.array(zodSchema).max(1),
   })
 
   return new LLMRequest()

--- a/packages/pro/src/ai/structuredOutputs/tables.ts
+++ b/packages/pro/src/ai/structuredOutputs/tables.ts
@@ -47,7 +47,6 @@ const schema = z.array(
         .object({
           presence: z.boolean(),
         })
-        .optional()
         .nullable(),
     }),
     baseRelationshipSchema

--- a/packages/server/.env.ai-evals.example
+++ b/packages/server/.env.ai-evals.example
@@ -8,6 +8,7 @@ BUDIBASE_PASSWORD=cheekychuckles
 
 # Optional: provider filter
 # AI_EVAL_PROVIDERS=bbai,openai,azure-openai
+# Note: OpenAI and Azure OpenAI evals run only in self mode.
 
 # Optional: Budibase mode filter
 # AI_EVAL_BUDIBASE_MODES=self,cloud

--- a/packages/server/.env.ai-evals.example
+++ b/packages/server/.env.ai-evals.example
@@ -1,0 +1,27 @@
+# Base Budibase instance
+BUDIBASE_BASE_URL=http://localhost:10000
+BUDIBASE_USERNAME=local@budibase.com
+BUDIBASE_PASSWORD=cheekychuckles
+
+# Optional: pin a specific app. If omitted, the first dev app is used.
+# BUDIBASE_APP_ID=app_dev_xxx
+
+# Optional: provider filter
+# AI_EVAL_PROVIDERS=bbai,openai,azure-openai
+
+# Optional: global feature filter for all enabled providers.
+# Allowed tokens:
+# tables,js,cron,translate,classify,prompt,summarise,generate,extract,all
+# AI_EVAL_FEATURES=all
+
+# OpenAI
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-5-mini
+
+# Azure OpenAI
+AZURE_OPENAI_API_KEY=
+AZURE_OPENAI_BASE_URL=https://<resource>.openai.azure.com/openai
+AZURE_OPENAI_MODEL=gpt-4.1
+
+# Budibase AI model override (optional)
+BBAI_MODEL=gpt-5-mini

--- a/packages/server/.env.ai-evals.example
+++ b/packages/server/.env.ai-evals.example
@@ -9,6 +9,9 @@ BUDIBASE_PASSWORD=cheekychuckles
 # Optional: provider filter
 # AI_EVAL_PROVIDERS=bbai,openai,azure-openai
 
+# Optional: Budibase mode filter
+# AI_EVAL_BUDIBASE_MODES=self,cloud
+
 # Optional: global feature filter for all enabled providers.
 # Allowed tokens:
 # tables,js,cron,translate,classify,prompt,summarise,generate,extract,all

--- a/packages/server/.gitignore
+++ b/packages/server/.gitignore
@@ -9,3 +9,4 @@ dist
 coverage/
 watchtower-hook.json
 .claude
+.env.ai-evals

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,6 +32,7 @@
     "dev:stack:nuke": "node scripts/dev/manage.js nuke",
     "dev": "yarn run dev:stack:up && nodemon",
     "dev:built": "yarn run dev:stack:up && yarn run run:docker",
+    "ai:evals": "NODE_OPTIONS=\"--no-node-snapshot $NODE_OPTIONS\" ts-node --transpileOnly -r tsconfig-paths/register ./scripts/ai-refactor-evals.ts",
     "specs": "ts-node specs/generate.ts && openapi-typescript specs/openapi.yaml --output src/definitions/openapi.ts"
   },
   "keywords": [

--- a/packages/server/scripts/ai-refactor-evals.ts
+++ b/packages/server/scripts/ai-refactor-evals.ts
@@ -1,0 +1,781 @@
+import { ConfigType, ContentType, DocumentSourceType } from "@budibase/types"
+import { existsSync } from "fs"
+import { isAbsolute, resolve } from "path"
+import * as dotenv from "dotenv"
+
+type ProviderName = "BudibaseAI" | "OpenAI" | "AzureOpenAI"
+
+interface AIProviderConfig {
+  provider: ProviderName
+  name: string
+  isDefault: boolean
+  active: boolean
+  apiKey?: string
+  baseUrl?: string
+  defaultModel?: string
+}
+
+interface Scenario {
+  id: string
+  name: string
+  enabled: boolean
+  config: AIProviderConfig
+}
+
+interface EvalResult {
+  name: string
+  ok: boolean
+  detail?: string
+}
+
+type EvalFeature =
+  | "table-generation"
+  | "js-generation"
+  | "cron-generation"
+  | "automation-translate"
+  | "automation-classify"
+  | "automation-prompt-llm"
+  | "automation-summarise"
+  | "automation-generate-text"
+  | "extract-document"
+
+interface LoginResponse {
+  token: string
+}
+
+interface AutomationResponse {
+  automation: {
+    _id: string
+    _rev: string
+  }
+}
+
+interface AutomationTestResponse {
+  steps?: Array<{
+    stepId?: string
+    outputs?: Record<string, any>
+  }>
+}
+
+class ApiClient {
+  private baseUrl: string
+  private token = ""
+  private appId = ""
+  private csrfToken = ""
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl.replace(/\/$/, "")
+  }
+
+  async init() {
+    const login = await this.login()
+    this.token = login.token
+
+    const configuredAppId = process.env.BUDIBASE_APP_ID
+    this.appId = await this.resolveDevAppId(configuredAppId)
+    this.csrfToken = await this.getCsrfToken()
+  }
+
+  get currentAppId() {
+    return this.appId
+  }
+
+  private async login(): Promise<LoginResponse> {
+    const username = process.env.BUDIBASE_USERNAME || "local@budibase.com"
+    const password = process.env.BUDIBASE_PASSWORD || "cheekychuckles"
+
+    const response = await fetch(`${this.baseUrl}/api/global/auth/default/login`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ username, password }),
+    })
+
+    if (!response.ok) {
+      const body = await response.text()
+      throw new Error(`Login failed (${response.status}): ${body}`)
+    }
+
+    const token =
+      response.headers.get("x-budibase-token") || response.headers.get("token")
+
+    if (!token) {
+      throw new Error("No auth token returned by login route")
+    }
+
+    return { token }
+  }
+
+  private isDevAppId(appId: string) {
+    return appId.startsWith("app_dev_")
+  }
+
+  private toDevAppId(appId: string) {
+    if (this.isDevAppId(appId)) {
+      return appId
+    }
+    if (appId.startsWith("app_")) {
+      return appId.replace(/^app_/, "app_dev_")
+    }
+    return appId
+  }
+
+  private async getAllAppIds(): Promise<string[]> {
+    const apps = await this.request<Array<{ appId?: string; _id?: string }>>(
+      "GET",
+      "/api/applications?status=all",
+      undefined,
+      false
+    )
+
+    return apps.map(app => app.appId || app._id).filter(Boolean) as string[]
+  }
+
+  private async resolveDevAppId(configuredAppId?: string): Promise<string> {
+    const appIds = await this.getAllAppIds()
+    if (appIds.length === 0) {
+      throw new Error(
+        "No app found. Set BUDIBASE_APP_ID or create an app before running evals."
+      )
+    }
+
+    if (configuredAppId) {
+      const normalized = this.toDevAppId(configuredAppId)
+      if (!appIds.includes(normalized)) {
+        throw new Error(
+          `BUDIBASE_APP_ID resolved to ${normalized}, but that app was not found.`
+        )
+      }
+      if (normalized !== configuredAppId) {
+        console.log(
+          yellow(
+            `BUDIBASE_APP_ID ${configuredAppId} is production; using dev app ${normalized} for /test endpoints.`
+          )
+        )
+      }
+      return normalized
+    }
+
+    const devApp = appIds.find(appId => this.isDevAppId(appId))
+    if (!devApp) {
+      throw new Error(
+        `No development app found (expected app id starting with app_dev_). Found: ${appIds.join(", ")}`
+      )
+    }
+    return devApp
+  }
+
+  private async getCsrfToken(): Promise<string> {
+    const self = await this.request<{ csrfToken?: string }>(
+      "GET",
+      "/api/self",
+      undefined,
+      true
+    )
+
+    if (!self.csrfToken) {
+      throw new Error("Unable to fetch csrfToken from /api/self")
+    }
+
+    return self.csrfToken
+  }
+
+  async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    includeAppHeaders = true
+  ): Promise<T> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "x-budibase-token": this.token,
+    }
+
+    if (includeAppHeaders) {
+      headers["x-budibase-app-id"] = this.appId
+    }
+
+    if (method !== "GET") {
+      headers["x-csrf-token"] = this.csrfToken
+    }
+
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    })
+
+    const text = await response.text()
+    let payload: any = undefined
+    if (text) {
+      try {
+        payload = JSON.parse(text)
+      } catch {
+        payload = text
+      }
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `${method} ${path} failed (${response.status}): ${text || "<empty>"}`
+      )
+    }
+
+    return payload as T
+  }
+}
+
+function green(text: string) {
+  return `\x1b[32m${text}\x1b[0m`
+}
+
+function red(text: string) {
+  return `\x1b[31m${text}\x1b[0m`
+}
+
+function yellow(text: string) {
+  return `\x1b[33m${text}\x1b[0m`
+}
+
+function section(text: string) {
+  return `\n=== ${text} ===`
+}
+
+function loadEvalEnvFile() {
+  const configuredPath = process.env.AI_EVAL_ENV_FILE
+  const envFilePath = configuredPath
+    ? isAbsolute(configuredPath)
+      ? configuredPath
+      : resolve(process.cwd(), configuredPath)
+    : resolve(__dirname, "../.env.ai-evals")
+
+  if (!existsSync(envFilePath)) {
+    if (configuredPath) {
+      throw new Error(`AI_EVAL_ENV_FILE not found: ${envFilePath}`)
+    }
+    return
+  }
+
+  dotenv.config({
+    path: envFilePath,
+  })
+
+  console.log(yellow(`Loaded env: ${envFilePath}`))
+}
+
+function hasCronShape(value: string) {
+  return /^\S+\s+\S+\s+\S+\s+\S+\s+\S+(\s+\S+)?$/.test(value.trim())
+}
+
+function parseProviderFilter() {
+  const raw = process.env.AI_EVAL_PROVIDERS
+  if (!raw) {
+    return undefined
+  }
+  return raw
+    .split(",")
+    .map(v => v.trim().toLowerCase())
+    .filter(Boolean)
+}
+
+const ALL_FEATURES: EvalFeature[] = [
+  "table-generation",
+  "js-generation",
+  "cron-generation",
+  "automation-translate",
+  "automation-classify",
+  "automation-prompt-llm",
+  "automation-summarise",
+  "automation-generate-text",
+  "extract-document",
+]
+
+function normalizeFeatureToken(value: string): EvalFeature | undefined {
+  const token = value.trim().toLowerCase()
+  const aliases: Record<string, EvalFeature> = {
+    tables: "table-generation",
+    table: "table-generation",
+    "table-generation": "table-generation",
+    js: "js-generation",
+    "js-generation": "js-generation",
+    cron: "cron-generation",
+    "cron-generation": "cron-generation",
+    translate: "automation-translate",
+    "automation-translate": "automation-translate",
+    classify: "automation-classify",
+    "automation-classify": "automation-classify",
+    prompt: "automation-prompt-llm",
+    "prompt-llm": "automation-prompt-llm",
+    "automation-prompt-llm": "automation-prompt-llm",
+    summarise: "automation-summarise",
+    summarize: "automation-summarise",
+    "automation-summarise": "automation-summarise",
+    generate: "automation-generate-text",
+    "generate-text": "automation-generate-text",
+    "automation-generate-text": "automation-generate-text",
+    extract: "extract-document",
+    "extract-document": "extract-document",
+  }
+  return aliases[token]
+}
+
+function parseFeatureList(raw?: string): Set<EvalFeature> | undefined {
+  if (!raw) {
+    return undefined
+  }
+  const tokens = raw
+    .split(",")
+    .map(v => v.trim())
+    .filter(Boolean)
+  if (tokens.length === 0) {
+    return undefined
+  }
+
+  if (tokens.some(v => v.toLowerCase() === "all")) {
+    return new Set(ALL_FEATURES)
+  }
+
+  const features = new Set<EvalFeature>()
+  for (const token of tokens) {
+    const normalized = normalizeFeatureToken(token)
+    if (normalized) {
+      features.add(normalized)
+    }
+  }
+  return features.size > 0 ? features : undefined
+}
+
+function resolveFeatures(globalFeatures: Set<EvalFeature> | undefined): Set<EvalFeature> {
+  return globalFeatures || new Set(ALL_FEATURES)
+}
+
+function shouldRunScenario(id: string, selected?: string[]) {
+  if (!selected || selected.length === 0) {
+    return true
+  }
+  return selected.includes(id.toLowerCase())
+}
+
+function shouldRunBBAI(selected?: string[]) {
+  if (!selected || selected.length === 0) {
+    return true
+  }
+  return (
+    selected.includes("bbai") ||
+    selected.includes("bbai-cloud") ||
+    selected.includes("bbai-selfhost")
+  )
+}
+
+function buildScenarios(selected?: string[]): Scenario[] {
+  const openaiKey = process.env.OPENAI_API_KEY
+  const azureKey = process.env.AZURE_OPENAI_API_KEY
+  const azureBaseUrl = process.env.AZURE_OPENAI_BASE_URL
+  const azureModel = process.env.AZURE_OPENAI_MODEL || "gpt-4.1"
+
+  return [
+    {
+      id: "bbai",
+      name: "BBAI (instance-managed mode)",
+      enabled: shouldRunBBAI(selected),
+      config: {
+        provider: "BudibaseAI",
+        name: "Eval BBAI",
+        isDefault: true,
+        active: true,
+        defaultModel:
+          process.env.BBAI_MODEL ||
+          process.env.BBAI_CLOUD_MODEL ||
+          process.env.BBAI_SELFHOST_MODEL ||
+          "gpt-5-mini",
+      },
+    },
+    {
+      id: "openai",
+      name: "OpenAI",
+      enabled: shouldRunScenario("openai", selected) && Boolean(openaiKey),
+      config: {
+        provider: "OpenAI",
+        name: "Eval OpenAI",
+        isDefault: true,
+        active: true,
+        apiKey: openaiKey,
+        defaultModel: process.env.OPENAI_MODEL || "gpt-5-mini",
+      },
+    },
+    {
+      id: "azure-openai",
+      name: "Azure OpenAI",
+      enabled:
+        shouldRunScenario("azure-openai", selected) &&
+        Boolean(azureKey) &&
+        Boolean(azureBaseUrl),
+      config: {
+        provider: "AzureOpenAI",
+        name: "Eval Azure OpenAI",
+        isDefault: true,
+        active: true,
+        apiKey: azureKey,
+        baseUrl: azureBaseUrl,
+        defaultModel: azureModel,
+      },
+    },
+  ]
+}
+
+async function configureAIProvider(client: ApiClient, config: AIProviderConfig) {
+  const body = {
+    type: ConfigType.AI,
+    config: {
+      evalProvider: config,
+    },
+  }
+
+  await client.request("POST", "/api/global/configs", body, false)
+}
+
+async function getAutomationDefinitions(client: ApiClient) {
+  const triggers = await client.request<Record<string, any>>(
+    "GET",
+    "/api/automations/trigger/list"
+  )
+  const actions = await client.request<Record<string, any>>(
+    "GET",
+    "/api/automations/action/list"
+  )
+  return { triggers, actions }
+}
+
+async function runAutomationStepEval(
+  client: ApiClient,
+  definitions: { triggers: Record<string, any>; actions: Record<string, any> },
+  stepId: string,
+  inputs: Record<string, any>
+): Promise<AutomationTestResponse> {
+  const triggerDefinition = definitions.triggers.APP
+  const actionDefinition = definitions.actions[stepId]
+
+  if (!triggerDefinition) {
+    throw new Error("APP trigger definition not found")
+  }
+  if (!actionDefinition) {
+    throw new Error(`Action definition not found for ${stepId}`)
+  }
+
+  const triggerId = crypto.randomUUID()
+  const stepIdInternal = crypto.randomUUID()
+
+  const automation = {
+    name: `AI Eval ${stepId} ${Date.now()}`,
+    appId: client.currentAppId,
+    type: "automation",
+    definition: {
+      trigger: {
+        ...triggerDefinition,
+        id: triggerId,
+        stepId: "APP",
+        inputs: {},
+      },
+      steps: [
+        {
+          ...actionDefinition,
+          id: stepIdInternal,
+          stepId,
+          name: actionDefinition.name,
+          inputs,
+        },
+      ],
+      stepNames: {
+        [stepIdInternal]: actionDefinition.name,
+      },
+    },
+  }
+
+  const created = await client.request<AutomationResponse>(
+    "POST",
+    "/api/automations",
+    automation
+  )
+
+  try {
+    return await client.request<AutomationTestResponse>(
+      "POST",
+      `/api/automations/${created.automation._id}/test`,
+      { fields: {} }
+    )
+  } finally {
+    await client.request(
+      "DELETE",
+      `/api/automations/${created.automation._id}/${created.automation._rev}`
+    )
+  }
+}
+
+function getActionOutput(
+  response: AutomationTestResponse,
+  actionStepId: string
+): Record<string, any> | undefined {
+  const matched = response.steps?.find(step => step.stepId === actionStepId)
+  if (matched?.outputs) {
+    return matched.outputs
+  }
+
+  // Fallback for unexpected/legacy response shapes
+  const fallback = response as unknown as Record<string, any>
+  if (fallback.outputs && typeof fallback.outputs === "object") {
+    return fallback.outputs as Record<string, any>
+  }
+
+  return undefined
+}
+
+async function runFeatureEvals(
+  client: ApiClient,
+  enabledFeatures: Set<EvalFeature>
+): Promise<EvalResult[]> {
+  const results: EvalResult[] = []
+  const definitions = await getAutomationDefinitions(client)
+
+  async function run(name: string, fn: () => Promise<void>) {
+    try {
+      await fn()
+      results.push({ name, ok: true })
+    } catch (err: any) {
+      results.push({ name, ok: false, detail: err?.message || String(err) })
+    }
+  }
+
+  const runIf = async (
+    feature: EvalFeature,
+    name: string,
+    fn: () => Promise<void>
+  ) => {
+    if (!enabledFeatures.has(feature)) {
+      return
+    }
+    await run(name, fn)
+  }
+
+  await runIf("table-generation", "Table generation", async () => {
+    const response = await client.request<{ createdTables: Array<{ id: string }> }>(
+      "POST",
+      "/api/ai/tables",
+      {
+        prompt:
+          "Create one table called Eval Tasks with columns title (string) and status (string), with one sample row.",
+      }
+    )
+
+    if (!response.createdTables || response.createdTables.length < 1) {
+      throw new Error("No tables were created")
+    }
+  })
+
+  await runIf("js-generation", "JS generation", async () => {
+    const response = await client.request<{ code: string }>("POST", "/api/ai/js", {
+      prompt: "Return the number 42 and nothing else",
+    })
+
+    if (!response.code || !response.code.includes("42")) {
+      throw new Error(`Unexpected JS output: ${response.code}`)
+    }
+  })
+
+  await runIf("cron-generation", "Cron generation", async () => {
+    const response = await client.request<{ message: string }>(
+      "POST",
+      "/api/ai/cron",
+      {
+        prompt: "Run every Monday at 9:30 AM",
+      }
+    )
+
+    if (!response.message || !hasCronShape(response.message)) {
+      throw new Error(`Unexpected cron output: ${response.message}`)
+    }
+  })
+
+  await runIf("automation-translate", "Automation translate step", async () => {
+    const result = await runAutomationStepEval(client, definitions, "TRANSLATE", {
+      text: "Hello world",
+      language: "Spanish",
+    })
+
+    const output = getActionOutput(result, "TRANSLATE")
+    if (!output?.success || !output?.response) {
+      throw new Error(`Unexpected output: ${JSON.stringify(output)}`)
+    }
+  })
+
+  await runIf("automation-classify", "Automation classify step", async () => {
+    const result = await runAutomationStepEval(
+      client,
+      definitions,
+      "CLASSIFY_CONTENT",
+      {
+        textInput: "The customer said the support experience was excellent",
+        categoryItems: [{ category: "positive" }, { category: "negative" }],
+      }
+    )
+
+    const output = getActionOutput(result, "CLASSIFY_CONTENT")
+    const category = output?.category?.toLowerCase?.()
+    if (!output?.success || !["positive", "negative"].includes(category)) {
+      throw new Error(`Unexpected output: ${JSON.stringify(output)}`)
+    }
+  })
+
+  await runIf(
+    "automation-prompt-llm",
+    "Automation LLM prompt step",
+    async () => {
+    const result = await runAutomationStepEval(client, definitions, "PROMPT_LLM", {
+      prompt: "Reply with exactly EVAL_OK",
+    })
+
+    const output = getActionOutput(result, "PROMPT_LLM")
+    if (!output?.success || !output?.response) {
+      throw new Error(`Unexpected output: ${JSON.stringify(output)}`)
+    }
+    }
+  )
+
+  await runIf("automation-summarise", "Automation summarise step", async () => {
+    const result = await runAutomationStepEval(client, definitions, "SUMMARISE", {
+      text: "Budibase helps teams build internal tools faster with less code and strong integrations.",
+      length: "Short",
+    })
+
+    const output = getActionOutput(result, "SUMMARISE")
+    if (!output?.success || !output?.response) {
+      throw new Error(`Unexpected output: ${JSON.stringify(output)}`)
+    }
+  })
+
+  await runIf(
+    "automation-generate-text",
+    "Automation generate text step",
+    async () => {
+    const result = await runAutomationStepEval(client, definitions, "GENERATE_TEXT", {
+      contentType: ContentType.EMAIL,
+      instructions:
+        "Write a one sentence welcome email to Alex for joining the team.",
+    })
+
+    const output = getActionOutput(result, "GENERATE_TEXT")
+    if (!output?.success || !output?.response) {
+      throw new Error(`Unexpected output: ${JSON.stringify(output)}`)
+    }
+    }
+  )
+
+  await runIf("extract-document", "Extract document step", async () => {
+    const result = await runAutomationStepEval(client, definitions, "EXTRACT_FILE_DATA", {
+      source: DocumentSourceType.URL,
+      file: "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
+      fileType: "pdf",
+      schema: {
+        title: "string",
+      },
+    })
+
+    const output = getActionOutput(result, "EXTRACT_FILE_DATA")
+    if (!output?.success || !output?.data) {
+      throw new Error(`Unexpected output: ${JSON.stringify(output)}`)
+    }
+  })
+
+  return results
+}
+
+async function runScenario(
+  client: ApiClient,
+  scenario: Scenario,
+  enabledFeatures: Set<EvalFeature>
+) {
+  if (!scenario.enabled) {
+    return {
+      ok: true,
+      skipped: "Missing required environment variables",
+      results: [] as EvalResult[],
+    }
+  }
+
+  await configureAIProvider(client, scenario.config)
+  const results = await runFeatureEvals(client, enabledFeatures)
+  return {
+    ok: results.every(r => r.ok),
+    results,
+  }
+}
+
+async function main() {
+  loadEvalEnvFile()
+
+  const baseUrl = process.env.BUDIBASE_BASE_URL || "http://localhost:10000"
+  const selected = parseProviderFilter()
+  const scenarios = buildScenarios(selected)
+  const globalFeatures = parseFeatureList(process.env.AI_EVAL_FEATURES)
+
+  const client = new ApiClient(baseUrl)
+  await client.init()
+
+  const summary: Array<{
+    name: string
+    ok: boolean
+    skipped?: string
+    results: EvalResult[]
+  }> = []
+
+  for (const scenario of scenarios) {
+    console.log(section(`Provider: ${scenario.name}`))
+    const enabledFeatures = resolveFeatures(globalFeatures)
+    const result = await runScenario(client, scenario, enabledFeatures)
+    summary.push({ name: scenario.name, ...result })
+
+    if (result.skipped) {
+      console.log(yellow(`SKIPPED: ${result.skipped}`))
+      continue
+    }
+
+    for (const item of result.results) {
+      if (item.ok) {
+        console.log(green(`PASS: ${item.name}`))
+      } else {
+        console.log(red(`FAIL: ${item.name}`))
+        if (item.detail) {
+          console.log(red(`  ${item.detail}`))
+        }
+      }
+    }
+  }
+
+  const executed = summary.filter(s => !s.skipped)
+  const failed = executed.filter(s => !s.ok)
+
+  console.log(section("Summary"))
+  for (const row of summary) {
+    if (row.skipped) {
+      console.log(yellow(`SKIPPED: ${row.name} (${row.skipped})`))
+    } else if (row.ok) {
+      console.log(green(`PASS: ${row.name}`))
+    } else {
+      console.log(red(`FAIL: ${row.name}`))
+    }
+  }
+
+  if (executed.length === 0) {
+    console.log(red("No scenarios executed. Set provider env vars and re-run."))
+    process.exit(1)
+  }
+
+  if (failed.length > 0) {
+    process.exit(1)
+  }
+}
+
+main().catch((err: any) => {
+  console.error(red(err?.stack || err?.message || String(err)))
+  process.exit(1)
+})

--- a/packages/server/scripts/ai-refactor-evals.ts
+++ b/packages/server/scripts/ai-refactor-evals.ts
@@ -460,10 +460,7 @@ function shouldRunProviderMode(
     return true
   }
 
-  const modeAliases = mode === "self" ? ["self", "selfhost"] : ["cloud"]
-  const aliases = modeAliases.map(alias => `${providerId}-${alias}`)
-
-  return aliases.some(alias => selected.includes(alias))
+  return selected.includes(`${providerId}-${mode}`)
 }
 
 function buildScenarios(

--- a/packages/server/scripts/ai-refactor-evals.ts
+++ b/packages/server/scripts/ai-refactor-evals.ts
@@ -525,17 +525,7 @@ function getActionOutput(
   actionStepId: string
 ): Record<string, any> | undefined {
   const matched = response.steps?.find(step => step.stepId === actionStepId)
-  if (matched?.outputs) {
-    return matched.outputs
-  }
-
-  // Fallback for unexpected/legacy response shapes
-  const fallback = response as unknown as Record<string, any>
-  if (fallback.outputs && typeof fallback.outputs === "object") {
-    return fallback.outputs as Record<string, any>
-  }
-
-  return undefined
+  return matched?.outputs
 }
 
 function normalizeText(value: string) {

--- a/packages/server/scripts/ai-refactor-evals.ts
+++ b/packages/server/scripts/ai-refactor-evals.ts
@@ -84,13 +84,16 @@ class ApiClient {
     const username = process.env.BUDIBASE_USERNAME || "local@budibase.com"
     const password = process.env.BUDIBASE_PASSWORD || "cheekychuckles"
 
-    const response = await fetch(`${this.baseUrl}/api/global/auth/default/login`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ username, password }),
-    })
+    const response = await fetch(
+      `${this.baseUrl}/api/global/auth/default/login`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      }
+    )
 
     if (!response.ok) {
       const body = await response.text()
@@ -346,7 +349,9 @@ function parseFeatureList(raw?: string): Set<EvalFeature> | undefined {
   return features.size > 0 ? features : undefined
 }
 
-function resolveFeatures(globalFeatures: Set<EvalFeature> | undefined): Set<EvalFeature> {
+function resolveFeatures(
+  globalFeatures: Set<EvalFeature> | undefined
+): Set<EvalFeature> {
   return globalFeatures || new Set(ALL_FEATURES)
 }
 
@@ -377,7 +382,7 @@ function buildScenarios(selected?: string[]): Scenario[] {
   return [
     {
       id: "bbai",
-      name: "BBAI (instance-managed mode)",
+      name: "BBAI",
       enabled: shouldRunBBAI(selected),
       config: {
         provider: "BudibaseAI",
@@ -424,7 +429,10 @@ function buildScenarios(selected?: string[]): Scenario[] {
   ]
 }
 
-async function configureAIProvider(client: ApiClient, config: AIProviderConfig) {
+async function configureAIProvider(
+  client: ApiClient,
+  config: AIProviderConfig
+) {
   const body = {
     type: ConfigType.AI,
     config: {
@@ -558,14 +566,12 @@ async function runFeatureEvals(
   }
 
   await runIf("table-generation", "Table generation", async () => {
-    const response = await client.request<{ createdTables: Array<{ id: string }> }>(
-      "POST",
-      "/api/ai/tables",
-      {
-        prompt:
-          "Create one table called Eval Tasks with columns title (string) and status (string), with one sample row.",
-      }
-    )
+    const response = await client.request<{
+      createdTables: Array<{ id: string }>
+    }>("POST", "/api/ai/tables", {
+      prompt:
+        "Create one table called Eval Tasks with columns title (string) and status (string), with one sample row.",
+    })
 
     if (!response.createdTables || response.createdTables.length < 1) {
       throw new Error("No tables were created")
@@ -573,9 +579,13 @@ async function runFeatureEvals(
   })
 
   await runIf("js-generation", "JS generation", async () => {
-    const response = await client.request<{ code: string }>("POST", "/api/ai/js", {
-      prompt: "Return the number 42 and nothing else",
-    })
+    const response = await client.request<{ code: string }>(
+      "POST",
+      "/api/ai/js",
+      {
+        prompt: "Return the number 42 and nothing else",
+      }
+    )
 
     if (!response.code || !response.code.includes("42")) {
       throw new Error(`Unexpected JS output: ${response.code}`)
@@ -597,10 +607,15 @@ async function runFeatureEvals(
   })
 
   await runIf("automation-translate", "Automation translate step", async () => {
-    const result = await runAutomationStepEval(client, definitions, "TRANSLATE", {
-      text: "Hello world",
-      language: "Spanish",
-    })
+    const result = await runAutomationStepEval(
+      client,
+      definitions,
+      "TRANSLATE",
+      {
+        text: "Hello world",
+        language: "Spanish",
+      }
+    )
 
     const output = getActionOutput(result, "TRANSLATE")
     if (!output?.success || !output?.response) {
@@ -630,22 +645,32 @@ async function runFeatureEvals(
     "automation-prompt-llm",
     "Automation LLM prompt step",
     async () => {
-    const result = await runAutomationStepEval(client, definitions, "PROMPT_LLM", {
-      prompt: "Reply with exactly EVAL_OK",
-    })
+      const result = await runAutomationStepEval(
+        client,
+        definitions,
+        "PROMPT_LLM",
+        {
+          prompt: "Reply with exactly EVAL_OK",
+        }
+      )
 
-    const output = getActionOutput(result, "PROMPT_LLM")
-    if (!output?.success || !output?.response) {
-      throw new Error(`Unexpected output: ${JSON.stringify(output)}`)
-    }
+      const output = getActionOutput(result, "PROMPT_LLM")
+      if (!output?.success || !output?.response) {
+        throw new Error(`Unexpected output: ${JSON.stringify(output)}`)
+      }
     }
   )
 
   await runIf("automation-summarise", "Automation summarise step", async () => {
-    const result = await runAutomationStepEval(client, definitions, "SUMMARISE", {
-      text: "Budibase helps teams build internal tools faster with less code and strong integrations.",
-      length: "Short",
-    })
+    const result = await runAutomationStepEval(
+      client,
+      definitions,
+      "SUMMARISE",
+      {
+        text: "Budibase helps teams build internal tools faster with less code and strong integrations.",
+        length: "Short",
+      }
+    )
 
     const output = getActionOutput(result, "SUMMARISE")
     if (!output?.success || !output?.response) {
@@ -657,28 +682,38 @@ async function runFeatureEvals(
     "automation-generate-text",
     "Automation generate text step",
     async () => {
-    const result = await runAutomationStepEval(client, definitions, "GENERATE_TEXT", {
-      contentType: ContentType.EMAIL,
-      instructions:
-        "Write a one sentence welcome email to Alex for joining the team.",
-    })
+      const result = await runAutomationStepEval(
+        client,
+        definitions,
+        "GENERATE_TEXT",
+        {
+          contentType: ContentType.EMAIL,
+          instructions:
+            "Write a one sentence welcome email to Alex for joining the team.",
+        }
+      )
 
-    const output = getActionOutput(result, "GENERATE_TEXT")
-    if (!output?.success || !output?.response) {
-      throw new Error(`Unexpected output: ${JSON.stringify(output)}`)
-    }
+      const output = getActionOutput(result, "GENERATE_TEXT")
+      if (!output?.success || !output?.response) {
+        throw new Error(`Unexpected output: ${JSON.stringify(output)}`)
+      }
     }
   )
 
   await runIf("extract-document", "Extract document step", async () => {
-    const result = await runAutomationStepEval(client, definitions, "EXTRACT_FILE_DATA", {
-      source: DocumentSourceType.URL,
-      file: "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
-      fileType: "pdf",
-      schema: {
-        title: "string",
-      },
-    })
+    const result = await runAutomationStepEval(
+      client,
+      definitions,
+      "EXTRACT_FILE_DATA",
+      {
+        source: DocumentSourceType.URL,
+        file: "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
+        fileType: "pdf",
+        schema: {
+          title: "string",
+        },
+      }
+    )
 
     const output = getActionOutput(result, "EXTRACT_FILE_DATA")
     if (!output?.success || !output?.data) {

--- a/packages/server/scripts/ai-refactor-evals.ts
+++ b/packages/server/scripts/ai-refactor-evals.ts
@@ -545,6 +545,27 @@ function hasKeyCaseInsensitive(obj: Record<string, any>, key: string) {
   return Object.keys(obj).some(k => k.toLowerCase() === target)
 }
 
+function looksBlueColor(value: string) {
+  const raw = value.trim().toLowerCase()
+  if (!raw) {
+    return false
+  }
+  if (raw.includes("blue")) {
+    return true
+  }
+
+  const hex = raw.replace(/^#/, "")
+  if (!/^[0-9a-f]{6}$/.test(hex)) {
+    return false
+  }
+
+  const r = parseInt(hex.slice(0, 2), 16)
+  const g = parseInt(hex.slice(2, 4), 16)
+  const b = parseInt(hex.slice(4, 6), 16)
+
+  return b > 0 && b >= r && b >= g
+}
+
 async function runFeatureEvals(
   client: ApiClient,
   enabledFeatures: Set<EvalFeature>
@@ -855,10 +876,8 @@ async function runFeatureEvals(
       )
     }
 
-    const color = normalizeText(String(data.backgroundColor || ""))
-    const hasBlueSignal =
-      color.includes("blue") || color.includes("0000ff") || color.includes("#")
-    if (!hasBlueSignal) {
+    const color = String(data.backgroundColor || "")
+    if (!looksBlueColor(color)) {
       throw new Error(
         `Image extract backgroundColor is not recognizably blue: ${JSON.stringify(output.data)}`
       )

--- a/packages/server/scripts/ai-refactor-evals.ts
+++ b/packages/server/scripts/ai-refactor-evals.ts
@@ -624,14 +624,8 @@ async function runFeatureEvals(
       }
     )
 
-    if (!response.code || !response.code.includes("42")) {
+    if (!response.code || !new RegExp(/^return 42;?$/).test(response.code)) {
       throw new Error(`Unexpected JS output: ${response.code}`)
-    }
-    if (response.code.includes("```")) {
-      throw new Error("JS output should not include markdown fences")
-    }
-    if (!response.code.includes("return")) {
-      throw new Error(`JS output missing return statement: ${response.code}`)
     }
   })
 

--- a/packages/server/scripts/ai-refactor-evals.ts
+++ b/packages/server/scripts/ai-refactor-evals.ts
@@ -794,12 +794,10 @@ async function runFeatureEvals(
       "EXTRACT_FILE_DATA",
       {
         source: DocumentSourceType.URL,
-        file: "https://pdfobject.com/pdf/sample.pdf",
+        file: "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
         fileType: "pdf",
         schema: {
-          language: "string",
-          words: "number",
-          lines: "number",
+          summary: "string",
         },
       }
     )
@@ -815,19 +813,15 @@ async function runFeatureEvals(
     }
 
     const first = output.data[0]
-    if (typeof first?.language !== "string" || !first.language.trim()) {
+    if (typeof first?.summary !== "string" || !first.summary.trim()) {
       throw new Error(
-        `Extract output wrong language: ${JSON.stringify(output.data)}`
+        `Extract output missing summary: ${JSON.stringify(output.data)}`
       )
     }
-    if (typeof first.lines !== "number") {
+    const summary = normalizeText(first.summary)
+    if (!summary.includes("pdf") && !summary.includes("dummy")) {
       throw new Error(
-        `Extract output wrong lines: ${JSON.stringify(output.data)}`
-      )
-    }
-    if (typeof first.words !== "number") {
-      throw new Error(
-        `Extract output wrong words: ${JSON.stringify(output.data)}`
+        `Extract output summary does not appear to describe document content: ${JSON.stringify(output.data)}`
       )
     }
   })

--- a/packages/server/scripts/ai-refactor-evals.ts
+++ b/packages/server/scripts/ai-refactor-evals.ts
@@ -794,10 +794,12 @@ async function runFeatureEvals(
       "EXTRACT_FILE_DATA",
       {
         source: DocumentSourceType.URL,
-        file: "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
+        file: "https://pdfobject.com/pdf/sample.pdf",
         fileType: "pdf",
         schema: {
-          summary: "string",
+          language: "text",
+          words: "number",
+          lines: "number",
         },
       }
     )
@@ -813,15 +815,25 @@ async function runFeatureEvals(
     }
 
     const first = output.data[0]
-    if (typeof first?.summary !== "string" || !first.summary.trim()) {
+    if (typeof first?.language !== "string" || !first.language.trim()) {
       throw new Error(
-        `Extract output missing summary: ${JSON.stringify(output.data)}`
+        `Extract output wrong language: ${JSON.stringify(output.data)}`
       )
     }
-    const summary = normalizeText(first.summary)
-    if (!summary.includes("pdf") && !summary.includes("dummy")) {
+    const language = normalizeText(first.language)
+    if (language !== "english") {
       throw new Error(
-        `Extract output summary does not appear to describe document content: ${JSON.stringify(output.data)}`
+        `Extract output language should be English: ${JSON.stringify(output.data)}`
+      )
+    }
+    if (typeof first.words !== "number" || first.words <= 0) {
+      throw new Error(
+        `Extract output words should be > 0: ${JSON.stringify(output.data)}`
+      )
+    }
+    if (typeof first.lines !== "number" || first.lines <= 0) {
+      throw new Error(
+        `Extract output lines should be > 0: ${JSON.stringify(output.data)}`
       )
     }
   })

--- a/packages/server/scripts/ai-refactor-evals.ts
+++ b/packages/server/scripts/ai-refactor-evals.ts
@@ -467,40 +467,42 @@ function buildScenarios(
       config: bbaiBaseConfig,
     })
 
-    scenarios.push({
-      id: mode === "self" ? "openai-self" : "openai-cloud",
-      name: `OpenAI (${modeName})`,
-      mode,
-      enabled:
-        shouldRunProviderMode("openai", mode, selected) && Boolean(openaiKey),
-      config: {
-        provider: "OpenAI",
-        name: "Eval OpenAI",
-        isDefault: true,
-        active: true,
-        apiKey: openaiKey,
-        defaultModel: process.env.OPENAI_MODEL || "gpt-5-mini",
-      },
-    })
+    if (mode === "self") {
+      scenarios.push({
+        id: "openai-self",
+        name: `OpenAI (${modeName})`,
+        mode,
+        enabled:
+          shouldRunProviderMode("openai", mode, selected) && Boolean(openaiKey),
+        config: {
+          provider: "OpenAI",
+          name: "Eval OpenAI",
+          isDefault: true,
+          active: true,
+          apiKey: openaiKey,
+          defaultModel: process.env.OPENAI_MODEL || "gpt-5-mini",
+        },
+      })
 
-    scenarios.push({
-      id: mode === "self" ? "azure-openai-self" : "azure-openai-cloud",
-      name: `Azure OpenAI (${modeName})`,
-      mode,
-      enabled:
-        shouldRunProviderMode("azure-openai", mode, selected) &&
-        Boolean(azureKey) &&
-        Boolean(azureBaseUrl),
-      config: {
-        provider: "AzureOpenAI",
-        name: "Eval Azure OpenAI",
-        isDefault: true,
-        active: true,
-        apiKey: azureKey,
-        baseUrl: azureBaseUrl,
-        defaultModel: azureModel,
-      },
-    })
+      scenarios.push({
+        id: "azure-openai-self",
+        name: `Azure OpenAI (${modeName})`,
+        mode,
+        enabled:
+          shouldRunProviderMode("azure-openai", mode, selected) &&
+          Boolean(azureKey) &&
+          Boolean(azureBaseUrl),
+        config: {
+          provider: "AzureOpenAI",
+          name: "Eval Azure OpenAI",
+          isDefault: true,
+          active: true,
+          apiKey: azureKey,
+          baseUrl: azureBaseUrl,
+          defaultModel: azureModel,
+        },
+      })
+    }
   }
 
   return scenarios

--- a/packages/server/src/api/controllers/ai/budibaseai.ts
+++ b/packages/server/src/api/controllers/ai/budibaseai.ts
@@ -15,7 +15,7 @@ import { generateText, streamText } from "ai"
 export async function uploadFile(
   ctx: Ctx<UploadFileRequest, UploadFileResponse>
 ) {
-  if (env.SELF_HOSTED) {
+  if (env.SELF_HOSTED && !env.isDev()) {
     ctx.throw(500, "Budibase AI endpoints are not available in self-host")
   }
   const llm = await ai.getLLMOrThrow()
@@ -41,7 +41,7 @@ export async function getAIQuotaUsage(ctx: Ctx<void, AIQuotaUsageResponse>) {
 export async function chatCompletion(
   ctx: Ctx<ChatCompletionRequest, ChatCompletionResponse>
 ) {
-  if (env.SELF_HOSTED) {
+  if (env.SELF_HOSTED && !env.isDev()) {
     ctx.throw(500, "Budibase AI endpoints are not available in self-host")
   }
 

--- a/packages/server/src/automations/steps/ai/extract.ts
+++ b/packages/server/src/automations/steps/ai/extract.ts
@@ -9,6 +9,13 @@ import fetch from "node-fetch"
 import { Readable } from "stream"
 import * as automationUtils from "../../automationUtils"
 
+const EXTRACT_RETRY_ATTEMPTS = 5
+const EXTRACT_RETRY_DELAY_MS = 100
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
 async function processUrlFile(
   fileUrl: string,
   fileType: string | undefined,
@@ -84,9 +91,44 @@ export async function run({
       fileIdOrDataUrl,
       llm.supportsFiles
     )
-    const llmResponse = await llm.prompt(request)
+    let data: Record<string, any> | any[] = []
+    let lastError: unknown
 
-    const data = await parseAIResponse(llmResponse)
+    for (let attempt = 1; attempt <= EXTRACT_RETRY_ATTEMPTS; attempt++) {
+      try {
+        const llmResponse = await llm.prompt(request)
+        data = await parseAIResponse(llmResponse)
+
+        const isEmptyArray = Array.isArray(data) && data.length === 0
+        if (!isEmptyArray || attempt === EXTRACT_RETRY_ATTEMPTS) {
+          break
+        }
+
+        console.warn(
+          `[Extract AI] Empty extraction result on attempt ${attempt}/${EXTRACT_RETRY_ATTEMPTS}, retrying...`
+        )
+      } catch (err) {
+        lastError = err
+        if (attempt === EXTRACT_RETRY_ATTEMPTS) {
+          console.error(
+            `[Extract AI] Final extraction attempt ${attempt}/${EXTRACT_RETRY_ATTEMPTS} failed:`,
+            err
+          )
+          throw err
+        }
+
+        console.warn(
+          `[Extract AI] Extraction attempt ${attempt}/${EXTRACT_RETRY_ATTEMPTS} failed, retrying...`,
+          err
+        )
+      }
+
+      await sleep(EXTRACT_RETRY_DELAY_MS)
+    }
+
+    if (lastError && Array.isArray(data) && data.length === 0) {
+      throw lastError
+    }
 
     return {
       data,

--- a/packages/server/src/automations/steps/ai/extract.ts
+++ b/packages/server/src/automations/steps/ai/extract.ts
@@ -79,7 +79,11 @@ export async function run({
       throw new Error("Invalid file input – source and file type do not match")
     }
 
-    const request = ai.extractFileData(inputs.schema, fileIdOrDataUrl)
+    const request = ai.extractFileData(
+      inputs.schema,
+      fileIdOrDataUrl,
+      llm.supportsFiles
+    )
     const llmResponse = await llm.prompt(request)
 
     const data = await parseAIResponse(llmResponse)

--- a/packages/server/src/automations/tests/steps/extractFileData.spec.ts
+++ b/packages/server/src/automations/tests/steps/extractFileData.spec.ts
@@ -241,7 +241,9 @@ describe("test the extract file data action", () => {
   })
 
   it("should handle invalid JSON response from AI", async () => {
-    mockChatGPTResponse("This is not valid JSON - should cause parsing error")
+    mockChatGPTResponse("This is not valid JSON - should cause parsing error", {
+      times: 5,
+    })
     mockOpenAIFileUpload("file-id-789")
 
     let filename = await uploadTestFile("test-document.pdf")

--- a/packages/server/src/tests/utilities/mocks/ai/index.ts
+++ b/packages/server/src/tests/utilities/mocks/ai/index.ts
@@ -4,6 +4,7 @@ export interface MockLLMResponseOpts {
   baseUrl?: string
   format?: ResponseFormat
   rejectFormat?: boolean
+  times?: number
 }
 
 export type MockLLMResponseFn = (

--- a/packages/server/src/tests/utilities/mocks/ai/openai.ts
+++ b/packages/server/src/tests/utilities/mocks/ai/openai.ts
@@ -82,7 +82,7 @@ export const mockChatGPTResponse: MockLLMResponseFn = (answer, opts) => {
     method: "POST",
   })
   interceptor.defaultReplyHeaders({ "content-type": "application/json" })
-  interceptor.reply(200, (reqOpts: any) => {
+  const scope = interceptor.reply(200, (reqOpts: any) => {
     const reqBody = parseJsonBody(reqOpts.body)
     if (expectedFormat && !expectedFormat(reqBody)) {
       return {
@@ -155,6 +155,10 @@ export const mockChatGPTResponse: MockLLMResponseFn = (answer, opts) => {
 
     return response
   }) // Each mock call handles one request
+
+  if (opts?.times != null) {
+    scope.times(opts.times)
+  }
 }
 
 export const mockChatGPTStreamResponse = (content = "hi") => {

--- a/packages/types/src/sdk/ai.ts
+++ b/packages/types/src/sdk/ai.ts
@@ -93,7 +93,7 @@ export type AIColumnSchema =
   | SearchWebSchema
 
 export interface LLMConfigOptions {
-  model?: string
+  model: string
   apiKey?: string
   maxTokens?: number
   max_completion_tokens?: number

--- a/packages/types/src/sdk/ai.ts
+++ b/packages/types/src/sdk/ai.ts
@@ -93,7 +93,7 @@ export type AIColumnSchema =
   | SearchWebSchema
 
 export interface LLMConfigOptions {
-  model: string
+  model?: string
   apiKey?: string
   maxTokens?: number
   max_completion_tokens?: number


### PR DESCRIPTION
## Description
Create evals for old BBAI usages. Also, fixing some bugs found along the way.

<img width="307" height="162" alt="image" src="https://github.com/user-attachments/assets/f0af9f78-4042-4e25-bd66-533ca5eca205" />


<img width="307" height="162" alt="image" src="https://github.com/user-attachments/assets/176f86bb-2e39-4d0b-a0ef-58ace2c2f5a4" />


<img width="342" height="162" alt="image" src="https://github.com/user-attachments/assets/6a8274e1-5673-4ff5-891b-1786da4ad77f" />

<img width="342" height="206" alt="image" src="https://github.com/user-attachments/assets/91567736-b0dc-4840-add3-3d0afd9058c3" />






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider-agnostic eval runner to verify legacy Budibase AI flows, improves file extraction reliability and schema handling, and adds a dev health check. The runner switches between cloud and self modes, runs BBAI in both, and restores the original mode after evals.

- **New Features**
  - Eval runner (scripts/ai-refactor-evals.ts) with yarn ai:evals and .env.ai-evals.example. Supports provider/feature filters, targets a dev app, and waits for server readiness via /health.
  - Budibase mode filter (AI_EVAL_BUDIBASE_MODES). Runs BBAI in cloud and self; OpenAI/Azure OpenAI run in self only. Restores the initial Budibase mode after completion.
  - File extraction uses inline files when supported, validates the returned file reference, enforces a single-item array, and retries on empty or failed attempts.
  - Adds supportsFiles to LLMs and wires it into the extract step (OpenAI/BudibaseAI: true; Azure OpenAI/Anthropic: false).

- **Bug Fixes**
  - Preserve table schema when updating automation step inputs in the builder.
  - Table generation no longer hardcodes the model; improves Azure OpenAI compatibility.
  - BudibaseAI uploadFile returns the file object. Allow BBAI endpoints in self-hosted dev.
  - Tighten structured outputs for tables (presence no longer optional).

<sup>Written for commit 10c3b1fd93887773de6a4bdc3b064ff5cfba0302. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









