### PR TITLE
Update BB AI model to Gemini 3 Flash

### DIFF
--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -272,8 +272,9 @@ const environment = {
   CUSTOM_CSP_FONT_SRC: process.env.CUSTOM_CSP_FONT_SRC,
   CUSTOM_CSP_FRAME_SRC: process.env.CUSTOM_CSP_FRAME_SRC,
   BBAI_OPENAI_API_KEY: process.env.BBAI_OPENAI_API_KEY,
-  BBAI_MISTRAL_API_KEY: process.env.BBAI_MISTRAL_API_KEY,
-  MISTRAL_BASE_URL: process.env.MISTRAL_BASE_URL || "https://api.mistral.ai/v1",
+  BBAI_OPENROUTER_API_KEY: process.env.BBAI_OPENROUTER_API_KEY,
+  OPENROUTER_BASE_URL:
+    process.env.OPENROUTER_BASE_URL || "https://openrouter.ai/api/v1",
 }
 
 export function setEnv(newEnvVars: Partial<typeof environment>): () => void {
@@ -319,7 +320,7 @@ export const SECRETS: EnvironmentKey[] = [
   "REDIS_PASSWORD",
   "REDIS_USERNAME",
   "BBAI_OPENAI_API_KEY",
-  "BBAI_MISTRAL_API_KEY",
+  "BBAI_OPENROUTER_API_KEY",
 ]
 
 // clean up any environment variable edge cases

--- a/packages/server/src/api/routes/tests/ai.spec.ts
+++ b/packages/server/src/api/routes/tests/ai.spec.ts
@@ -39,20 +39,6 @@ jest.mock("ai", () => {
   }
 })
 
-jest.mock("@budibase/types", () => {
-  const actual = jest.requireActual("@budibase/types")
-  return {
-    ...actual,
-    BUDIBASE_AI_MODEL_MAP: {
-      ...actual.BUDIBASE_AI_MODEL_MAP,
-      "budibase/mistral-small-latest": {
-        provider: "mistral",
-        model: "mistral-small-latest",
-      },
-    },
-  }
-})
-
 function toResponseFormat(schema: any, name = "response") {
   return {
     type: "json_schema" as const,
@@ -1180,8 +1166,8 @@ describe("BudibaseAI", () => {
       envCleanup = setEnv({
         SELF_HOSTED: false,
         ACCOUNT_PORTAL_API_KEY: internalApiKey,
-        BBAI_MISTRAL_API_KEY: "mistral-key",
-        MISTRAL_BASE_URL: "https://api.mistral.ai",
+        BBAI_OPENROUTER_API_KEY: "openrouter-key",
+        OPENROUTER_BASE_URL: "https://openrouter.ai/api/v1",
       })
     })
 
@@ -1318,40 +1304,8 @@ describe("BudibaseAI", () => {
       )
     })
 
-    it("accepts Mistral models when configured", async () => {
-      await withEnv(
-        {
-          BBAI_MISTRAL_API_KEY: "mistral-key",
-          MISTRAL_BASE_URL: "https://api.mistral.ai",
-        },
-        async () => {
-          generateTextMock.mockResolvedValue({
-            response: {
-              body: {
-                object: "chat.completion",
-                choices: [
-                  {
-                    message: { content: "hello from mistral" },
-                  },
-                ],
-              },
-            },
-          } as unknown as ReturnType<typeof generateText>)
-
-          const response = await config.api.ai.openaiChatCompletions({
-            model: "budibase/mistral-small-latest",
-            messages: [{ role: "user", content: "hello" }],
-            stream: false,
-            licenseKey,
-          })
-
-          expect(response.choices[0].message.content).toBe("hello from mistral")
-        }
-      )
-    })
-
-    it("errors when mistral API key is missing", async () => {
-      await withEnv({ BBAI_MISTRAL_API_KEY: "" }, async () => {
+    it("errors when OpenRouter API key is missing", async () => {
+      await withEnv({ BBAI_OPENROUTER_API_KEY: "" }, async () => {
         await config.api.ai.openaiChatCompletions(
           {
             model: "budibase/v1",

--- a/packages/server/src/sdk/workspace/ai/llm/bbai.ts
+++ b/packages/server/src/sdk/workspace/ai/llm/bbai.ts
@@ -42,12 +42,14 @@ export async function createBBAIClient(model: string): Promise<LLMResponse> {
   let baseURL: string | undefined
   if (provider === "openai") {
     apiKey = env.BBAI_OPENAI_API_KEY
-  } else {
-    apiKey = env.BBAI_MISTRAL_API_KEY
-    baseURL = env.MISTRAL_BASE_URL
+  } else if (provider === "openrouter") {
+    apiKey = env.BBAI_OPENROUTER_API_KEY
+    baseURL = env.OPENROUTER_BASE_URL
     if (!baseURL) {
-      throw new HTTPError("MISTRAL_BASE_URL not configured", 500)
+      throw new HTTPError("OPENROUTER_BASE_URL not configured", 500)
     }
+  } else {
+    throw new HTTPError(`Unsupported BBAI provider: ${provider}`, 400)
   }
 
   if (!apiKey) {

--- a/packages/types/src/shared/budibaseModels.ts
+++ b/packages/types/src/shared/budibaseModels.ts
@@ -1,4 +1,4 @@
-export type BudibaseAIProvider = "openai" | "mistral"
+export type BudibaseAIProvider = "openai" | "openrouter"
 
 export interface BudibaseAIModel {
   id: string
@@ -10,9 +10,9 @@ export interface BudibaseAIModel {
 export const BUDIBASE_AI_MODELS: BudibaseAIModel[] = [
   {
     id: "budibase/v1",
-    provider: "mistral",
-    model: "mistral-large-latest",
-    label: "Mistral large",
+    provider: "openrouter",
+    model: "google/gemini-3-flash-preview",
+    label: "Gemini 3 Flash",
   },
 ]
 


### PR DESCRIPTION
## Description
As title, update BBAI to Gemini 3 Flash and update tests 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Budibase AI to Gemini 3 Flash via OpenRouter. Removes Mistral, updates environment keys, and adjusts client/tests to the new provider.

- **Migration**
  - Set BBAI_OPENROUTER_API_KEY in your environment.
  - (Optional) Set OPENROUTER_BASE_URL; defaults to https://openrouter.ai/api/v1.
  - Remove BBAI_MISTRAL_API_KEY and MISTRAL_BASE_URL from config/secrets.
  - Note: Requests fail with 500 if OpenRouter API key or base URL is missing.

<sup>Written for commit c5d2c2baf4ffd3d3041a819e61da4bd7c4d4d169. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

