### PR TITLE
flag AI chat

### DIFF
--- a/packages/backend-core/src/features/features.ts
+++ b/packages/backend-core/src/features/features.ts
@@ -235,6 +235,7 @@ export class FlagSet<T extends { [name: string]: boolean }> {
 const featureFlagDefaults: Record<FeatureFlag, boolean> = {
   [FeatureFlag.USE_ZOD_VALIDATOR]: false,
   [FeatureFlag.AI_AGENTS]: false,
+  [FeatureFlag.AI_CHAT]: false,
   [FeatureFlag.WORKSPACE_HOME]: false,
   [FeatureFlag.DEBUG_UI]: env.isDev(),
   [FeatureFlag.DEV_USE_CLIENT_FROM_STORAGE]: false,

--- a/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
@@ -615,19 +615,21 @@
                       </div>
                     </svelte:fragment>
                   </SideNavLink>
-                  <SideNavLink
-                    icon="chat-circle"
-                    text="Chat"
-                    url={$url("./chat")}
-                    {collapsed}
-                    on:click={keepCollapsed}
-                  >
-                    <svelte:fragment slot="right">
-                      <div class="beta-tag-wrapper">
-                        <Tag emphasized>Alpha</Tag>
-                      </div>
-                    </svelte:fragment>
-                  </SideNavLink>
+                  {#if $featureFlags.AI_CHAT}
+                    <SideNavLink
+                      icon="chat-circle"
+                      text="Chat"
+                      url={$url("./chat")}
+                      {collapsed}
+                      on:click={keepCollapsed}
+                    >
+                      <svelte:fragment slot="right">
+                        <div class="beta-tag-wrapper">
+                          <Tag emphasized>Alpha</Tag>
+                        </div>
+                      </svelte:fragment>
+                    </SideNavLink>
+                  {/if}
                 {/if}
               {/if}
             </div>

--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/new/_components/NewComponentPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/new/_components/NewComponentPanel.svelte
@@ -37,7 +37,9 @@
     $selectedScreen,
     $selectedComponent
   )
-  $: structure = getComponentStructure({ chatbox: $featureFlags.AI_AGENTS })
+  $: structure = getComponentStructure({
+    chatbox: $featureFlags.AI_AGENTS && $featureFlags.AI_CHAT,
+  })
   $: enrichedStructure = enrichStructure(
     structure,
     $componentStore.components,

--- a/packages/builder/src/pages/builder/workspace/[application]/home/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/index.svelte
@@ -675,7 +675,7 @@
         >
       </div>
 
-      {#if $featureFlags.AI_AGENTS}
+      {#if $featureFlags.AI_AGENTS && $featureFlags.AI_CHAT}
         <div class="header-actions">
           <a href={url("../chat")} class="header-link header-link--with-icons">
             <Icon name="chat-circle" size="XS" color="#8CA171" weight="fill" />

--- a/packages/types/src/sdk/featureFlag.ts
+++ b/packages/types/src/sdk/featureFlag.ts
@@ -1,6 +1,7 @@
 export enum FeatureFlag {
   USE_ZOD_VALIDATOR = "USE_ZOD_VALIDATOR",
   AI_AGENTS = "AI_AGENTS",
+  AI_CHAT = "AI_CHAT",
   WORKSPACE_HOME = "WORKSPACE_HOME",
 
   // Dev


### PR DESCRIPTION
## Description
put chat alpha functionality behind AI_CHAT feature flag for initial agents beta

## Launchcontrol
chat flag

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Put the Chat experience behind the AI_CHAT feature flag for the agents beta. Chat UI and components now only appear when both AI_AGENTS and AI_CHAT are enabled.

- **New Features**
  - Added AI_CHAT flag (default off) to types and backend defaults.
  - Hid the Chat link in the workspace sidebar unless AI_CHAT is enabled.
  - Redirected the Chat page when disabled, respecting Workspace Home (to Home or Home filtered to agents) or falling back to Agents/root.
  - Showed the Home header Chat action only when both AI_AGENTS and AI_CHAT are enabled.
  - Gated the chatbox in the New Component panel behind both flags.

<sup>Written for commit 805dca8b99c40f5aa41621c5a144e98a1ea8a52a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

