### PR TITLE
Add RAG feature flag

### DIFF
--- a/packages/backend-core/src/features/features.ts
+++ b/packages/backend-core/src/features/features.ts
@@ -236,6 +236,7 @@ const featureFlagDefaults: Record<FeatureFlag, boolean> = {
   [FeatureFlag.USE_ZOD_VALIDATOR]: false,
   [FeatureFlag.AI_AGENTS]: false,
   [FeatureFlag.AI_CHAT]: false,
+  [FeatureFlag.AI_RAG]: false,
   [FeatureFlag.WORKSPACE_HOME]: false,
   [FeatureFlag.DEBUG_UI]: env.isDev(),
   [FeatureFlag.DEV_USE_CLIENT_FROM_STORAGE]: false,

--- a/packages/builder/src/settings/pages/ai/embeddings.svelte
+++ b/packages/builder/src/settings/pages/ai/embeddings.svelte
@@ -40,7 +40,7 @@
 </script>
 
 <Layout noPadding gap="S">
-  {#if $featureFlags.AI_AGENTS}
+  {#if $featureFlags.AI_RAG}
     <div class="section">
       <div class="section-header">
         <div class="section-title">Embeddings models</div>

--- a/packages/builder/src/settings/routes.ts
+++ b/packages/builder/src/settings/routes.ts
@@ -1,5 +1,5 @@
 import { sdk, helpers } from "@budibase/shared-core"
-import { GetGlobalSelfResponse } from "@budibase/types"
+import { FeatureFlag, GetGlobalSelfResponse } from "@budibase/types"
 import { UserAvatar } from "@budibase/frontend-core"
 
 import { Target, type Route } from "@/types/routing"
@@ -295,6 +295,7 @@ export const appRoutes = (
         {
           path: "embedding-settings",
           title: "Embeddings",
+          access: () => featureFlag.isEnabled(FeatureFlag.AI_RAG),
           comp: Pages.get("embeddings"),
         },
       ],

--- a/packages/server/src/api/controllers/ai/agents.ts
+++ b/packages/server/src/api/controllers/ai/agents.ts
@@ -1,4 +1,4 @@
-import { db } from "@budibase/backend-core"
+import { db, features } from "@budibase/backend-core"
 import {
   Agent,
   CreateAgentRequest,
@@ -9,6 +9,7 @@ import {
   ToggleAgentDiscordResponse,
   SyncAgentDiscordCommandsRequest,
   SyncAgentDiscordCommandsResponse,
+  FeatureFlag,
   ToolMetadata,
   UpdateAgentRequest,
   UpdateAgentResponse,
@@ -55,6 +56,7 @@ export async function createAgent(
   ctx: UserCtx<CreateAgentRequest, CreateAgentResponse>
 ) {
   const body = ctx.request.body
+  const ragEnabled = await features.isEnabled(FeatureFlag.AI_RAG)
   const createdBy = ctx.user?._id!
   const globalId = db.getGlobalIDFromUserMetadataID(createdBy)
 
@@ -70,10 +72,10 @@ export async function createAgent(
     _deleted: false,
     createdBy: globalId,
     enabledTools: body.enabledTools,
-    embeddingModel: body.embeddingModel,
-    vectorDb: body.vectorDb,
-    ragMinDistance: body.ragMinDistance,
-    ragTopK: body.ragTopK,
+    embeddingModel: ragEnabled ? body.embeddingModel : undefined,
+    vectorDb: ragEnabled ? body.vectorDb : undefined,
+    ragMinDistance: ragEnabled ? body.ragMinDistance : undefined,
+    ragTopK: ragEnabled ? body.ragTopK : undefined,
     discordIntegration: body.discordIntegration,
   }
 
@@ -87,6 +89,7 @@ export async function updateAgent(
   ctx: UserCtx<UpdateAgentRequest, UpdateAgentResponse>
 ) {
   const body = ctx.request.body
+  const ragEnabled = await features.isEnabled(FeatureFlag.AI_RAG)
 
   const updateRequest: RequiredKeys<UpdateAgentRequest> = {
     _id: body._id,
@@ -100,10 +103,10 @@ export async function updateAgent(
     iconColor: body.iconColor,
     live: body.live,
     enabledTools: body.enabledTools,
-    embeddingModel: body.embeddingModel,
-    vectorDb: body.vectorDb,
-    ragMinDistance: body.ragMinDistance,
-    ragTopK: body.ragTopK,
+    embeddingModel: ragEnabled ? body.embeddingModel : undefined,
+    vectorDb: ragEnabled ? body.vectorDb : undefined,
+    ragMinDistance: ragEnabled ? body.ragMinDistance : undefined,
+    ragTopK: ragEnabled ? body.ragTopK : undefined,
     discordIntegration: body.discordIntegration,
   }
 

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -1,5 +1,6 @@
 import {
   context,
+  features,
   docIds,
   getErrorMessage,
   HTTPError,
@@ -16,6 +17,7 @@ import {
   DocumentType,
   FetchAgentHistoryResponse,
   ContextUser,
+  FeatureFlag,
   UserCtx,
 } from "@budibase/types"
 import {
@@ -161,9 +163,10 @@ export async function discordChat({
   const agent = await sdk.ai.agents.getOrThrow(agentId)
   const latestQuestion = findLatestUserQuestion(chat)
   let retrievedContext = ""
+  const ragEnabled = await features.isEnabled(FeatureFlag.AI_RAG)
 
   const hasRagConfig = !!agent.embeddingModel && !!agent.vectorDb
-  if (hasRagConfig && latestQuestion) {
+  if (ragEnabled && hasRagConfig && latestQuestion) {
     try {
       const result = await retrieveContextForAgent(agent, latestQuestion)
       retrievedContext = result.text
@@ -326,9 +329,10 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
   const latestQuestion = findLatestUserQuestion(chat)
   let retrievedContext = ""
   let ragSourcesMetadata: AgentMessageMetadata["ragSources"] | undefined
+  const ragEnabled = await features.isEnabled(FeatureFlag.AI_RAG)
 
   const hasRagConfig = !!agent.embeddingModel && !!agent.vectorDb
-  if (hasRagConfig && latestQuestion) {
+  if (ragEnabled && hasRagConfig && latestQuestion) {
     try {
       const result = await retrieveContextForAgent(agent, latestQuestion)
       retrievedContext = result.text

--- a/packages/server/src/api/routes/tests/ai/vectorDb.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/vectorDb.spec.ts
@@ -1,4 +1,9 @@
-import { PASSWORD_REPLACEMENT, VectorDbProvider } from "@budibase/types"
+import { features } from "@budibase/backend-core"
+import {
+  FeatureFlag,
+  PASSWORD_REPLACEMENT,
+  VectorDbProvider,
+} from "@budibase/types"
 import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
 
 describe("vector db configs", () => {
@@ -7,6 +12,14 @@ describe("vector db configs", () => {
   afterAll(() => {
     config.end()
   })
+
+  const withRagEnabled = async <T>(f: () => Promise<T>) => {
+    return await features.testutils.withFeatureFlags(
+      config.getTenantId(),
+      { [FeatureFlag.AI_RAG]: true },
+      f
+    )
+  }
 
   const vectorDbRequest = {
     name: "Primary Vector DB",
@@ -23,41 +36,47 @@ describe("vector db configs", () => {
   })
 
   it("creates and lists vector db configs", async () => {
-    const created = await config.api.vectorDb.create(vectorDbRequest)
-    expect(created._id).toBeDefined()
-    expect(created.password).toBe(PASSWORD_REPLACEMENT)
+    await withRagEnabled(async () => {
+      const created = await config.api.vectorDb.create(vectorDbRequest)
+      expect(created._id).toBeDefined()
+      expect(created.password).toBe(PASSWORD_REPLACEMENT)
 
-    const configs = await config.api.vectorDb.fetch()
-    expect(configs).toHaveLength(1)
-    expect(configs[0].name).toBe(vectorDbRequest.name)
-    expect(configs[0].password).toBe(PASSWORD_REPLACEMENT)
+      const configs = await config.api.vectorDb.fetch()
+      expect(configs).toHaveLength(1)
+      expect(configs[0].name).toBe(vectorDbRequest.name)
+      expect(configs[0].password).toBe(PASSWORD_REPLACEMENT)
+    })
   })
 
   it("updates and deletes vector db configs", async () => {
-    const created = await config.api.vectorDb.create(vectorDbRequest)
+    await withRagEnabled(async () => {
+      const created = await config.api.vectorDb.create(vectorDbRequest)
 
-    const updated = await config.api.vectorDb.update({
-      ...created,
-      name: "Updated Vector DB",
-      password: PASSWORD_REPLACEMENT,
+      const updated = await config.api.vectorDb.update({
+        ...created,
+        name: "Updated Vector DB",
+        password: PASSWORD_REPLACEMENT,
+      })
+      expect(updated.name).toBe("Updated Vector DB")
+      expect(updated.password).toBe(PASSWORD_REPLACEMENT)
+
+      const { deleted } = await config.api.vectorDb.remove(created._id!)
+      expect(deleted).toBe(true)
+
+      const configs = await config.api.vectorDb.fetch()
+      expect(configs).toHaveLength(0)
     })
-    expect(updated.name).toBe("Updated Vector DB")
-    expect(updated.password).toBe(PASSWORD_REPLACEMENT)
-
-    const { deleted } = await config.api.vectorDb.remove(created._id!)
-    expect(deleted).toBe(true)
-
-    const configs = await config.api.vectorDb.fetch()
-    expect(configs).toHaveLength(0)
   })
 
   it("rejects unsupported providers", async () => {
-    await config.api.vectorDb.create(
-      {
-        ...vectorDbRequest,
-        provider: "pinecone" as VectorDbProvider,
-      },
-      { status: 400 }
-    )
+    await withRagEnabled(async () => {
+      await config.api.vectorDb.create(
+        {
+          ...vectorDbRequest,
+          provider: "pinecone" as VectorDbProvider,
+        },
+        { status: 400 }
+      )
+    })
   })
 })

--- a/packages/server/src/automations/bullboard.ts
+++ b/packages/server/src/automations/bullboard.ts
@@ -1,6 +1,6 @@
-import { queue } from "@budibase/backend-core"
+import { features, queue } from "@budibase/backend-core"
 import { backups } from "@budibase/pro"
-import { AutomationData } from "@budibase/types"
+import { AutomationData, FeatureFlag } from "@budibase/types"
 import { createBullBoard } from "@bull-board/api"
 import { BullAdapter } from "@bull-board/api/bullAdapter"
 import { KoaAdapter } from "@bull-board/koa"
@@ -42,7 +42,9 @@ export async function init() {
   }
 
   queues.push(new BullAdapter(UserSyncProcessor.queue.getBullQueue()))
-  queues.push(new BullAdapter(rag.queue.getQueue().getBullQueue()))
+  if (await features.isEnabled(FeatureFlag.AI_RAG)) {
+    queues.push(new BullAdapter(rag.queue.getQueue().getBullQueue()))
+  }
 
   const serverAdapter = new KoaAdapter()
   createBullBoard({ queues, serverAdapter })

--- a/packages/server/src/middleware/aiRagEnabled.ts
+++ b/packages/server/src/middleware/aiRagEnabled.ts
@@ -1,0 +1,10 @@
+import { Next } from "koa"
+import { features } from "@budibase/backend-core"
+import { Ctx, FeatureFlag } from "@budibase/types"
+
+export async function aiRagEnabled(ctx: Ctx, next: Next) {
+  if (!(await features.isEnabled(FeatureFlag.AI_RAG))) {
+    ctx.throw(404)
+  }
+  return next()
+}

--- a/packages/server/src/sdk/workspace/ai/rag/files.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/files.ts
@@ -2,9 +2,11 @@ import { embedMany } from "ai"
 import * as crypto from "crypto"
 import { PDFParse } from "pdf-parse"
 import { parse as parseYaml } from "yaml"
+import { features } from "@budibase/backend-core"
 import {
   AgentFileStatus,
   AgentMessageRagSource,
+  FeatureFlag,
   type Agent,
   type AgentFile,
 } from "@budibase/types"
@@ -15,6 +17,12 @@ import { createLLM } from "../llm"
 const DEFAULT_CHUNK_SIZE = 1500
 const DEFAULT_CHUNK_OVERLAP = 200
 const DEFAULT_EMBEDDING_BATCH_SIZE = 64
+
+const ensureRagEnabled = async () => {
+  if (!(await features.isEnabled(FeatureFlag.AI_RAG))) {
+    throw new Error("RAG feature is disabled")
+  }
+}
 
 const textFileExtensions = new Set([
   ".txt",
@@ -241,6 +249,7 @@ export const ingestAgentFile = async (
   inserted: number
   total: number
 }> => {
+  await ensureRagEnabled()
   const { _id: agentId } = agent
   if (!agentId) {
     throw new Error("Agent id not set")
@@ -282,6 +291,7 @@ export const deleteAgentFileChunks = async (
   agent: Agent,
   sourceIds: string[]
 ) => {
+  await ensureRagEnabled()
   if (!sourceIds || sourceIds.length === 0) {
     return
   }
@@ -309,6 +319,7 @@ export const retrieveContextForAgent = async (
   agent: Agent,
   question: string
 ): Promise<RetrievedContextResult> => {
+  await ensureRagEnabled()
   if (!question || question.trim().length === 0) {
     return { text: "", chunks: [], sources: [] }
   }

--- a/packages/server/src/startup/index.ts
+++ b/packages/server/src/startup/index.ts
@@ -29,6 +29,7 @@ import { watch } from "../watch"
 import { initialise as initialiseWebsockets } from "../websockets"
 import * as workspaceMigrations from "../workspaceMigrations/queue"
 import { rag } from "../sdk/workspace/ai"
+import { FeatureFlag } from "@budibase/types"
 
 export type State = "uninitialised" | "starting" | "ready"
 let STATE: State = "uninitialised"
@@ -127,7 +128,9 @@ export async function startup(
   // configure events to use the pro audit log write
   // can't integrate directly into backend-core due to cyclic issues
   queuePromises.push(events.processors.init(pro.sdk.auditLogs.write))
-  queuePromises.push(rag.queue.init())
+  if (await features.isEnabled(FeatureFlag.AI_RAG)) {
+    queuePromises.push(rag.queue.init())
+  }
   // app migrations and automations on other service
   if (automationsEnabled()) {
     queuePromises.push(automations.init())

--- a/packages/server/src/startup/index.ts
+++ b/packages/server/src/startup/index.ts
@@ -29,7 +29,6 @@ import { watch } from "../watch"
 import { initialise as initialiseWebsockets } from "../websockets"
 import * as workspaceMigrations from "../workspaceMigrations/queue"
 import { rag } from "../sdk/workspace/ai"
-import { FeatureFlag } from "@budibase/types"
 
 export type State = "uninitialised" | "starting" | "ready"
 let STATE: State = "uninitialised"
@@ -128,9 +127,7 @@ export async function startup(
   // configure events to use the pro audit log write
   // can't integrate directly into backend-core due to cyclic issues
   queuePromises.push(events.processors.init(pro.sdk.auditLogs.write))
-  if (await features.isEnabled(FeatureFlag.AI_RAG)) {
-    queuePromises.push(rag.queue.init())
-  }
+  queuePromises.push(rag.queue.init())
   // app migrations and automations on other service
   if (automationsEnabled()) {
     queuePromises.push(automations.init())

--- a/packages/types/src/sdk/featureFlag.ts
+++ b/packages/types/src/sdk/featureFlag.ts
@@ -2,6 +2,7 @@ export enum FeatureFlag {
   USE_ZOD_VALIDATOR = "USE_ZOD_VALIDATOR",
   AI_AGENTS = "AI_AGENTS",
   AI_CHAT = "AI_CHAT",
+  AI_RAG = "AI_RAG",
   WORKSPACE_HOME = "WORKSPACE_HOME",
 
   // Dev


### PR DESCRIPTION
## Description
Add RAG behind it's own feature flag



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an AI_RAG feature flag that gates all RAG functionality across API, SDK, UI, and queues. When off, RAG UI is hidden, RAG settings aren’t saved, RAG routes return 404, and the RAG queue isn’t loaded.

- **New Features**
  - Added FeatureFlag.AI_RAG (default: false) and middleware (aiRagEnabled) to protect agent files and vector DB routes.
  - Agents only store/use embedding, vector DB, and RAG params when the flag is on; chat retrieval now checks the flag.
  - RAG SDK functions (ingest, delete chunks, retrieve context) enforce the flag.
  - Bullboard only registers the RAG queue when enabled.
  - Builder UI hides the Agent Knowledge tab and redirects to Config if disabled; Embeddings settings are hidden and route access requires the flag.
  - Tests updated to toggle the flag via test utils.

- **Migration**
  - Enable AI_RAG per tenant to use RAG endpoints and agent RAG configuration.
  - No data migration needed; existing agents work as before, with RAG fields ignored until enabled.

<sup>Written for commit 652c091e47c914491e62e604a7cb18fb2c1dd524. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



