### PR TITLE
Fix startup

### DIFF
--- a/packages/server/src/automations/bullboard.ts
+++ b/packages/server/src/automations/bullboard.ts
@@ -1,6 +1,6 @@
-import { features, queue } from "@budibase/backend-core"
+import { queue } from "@budibase/backend-core"
 import { backups } from "@budibase/pro"
-import { AutomationData, FeatureFlag } from "@budibase/types"
+import { AutomationData } from "@budibase/types"
 import { createBullBoard } from "@bull-board/api"
 import { BullAdapter } from "@bull-board/api/bullAdapter"
 import { KoaAdapter } from "@bull-board/koa"
@@ -42,9 +42,7 @@ export async function init() {
   }
 
   queues.push(new BullAdapter(UserSyncProcessor.queue.getBullQueue()))
-  if (await features.isEnabled(FeatureFlag.AI_RAG)) {
-    queues.push(new BullAdapter(rag.queue.getQueue().getBullQueue()))
-  }
+  queues.push(new BullAdapter(rag.queue.getQueue().getBullQueue()))
 
   const serverAdapter = new KoaAdapter()
   createBullBoard({ queues, serverAdapter })


### PR DESCRIPTION
## Description
Fix startup after https://github.com/Budibase/budibase/pull/18044

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed server startup by always registering the RAG queue with BullBoard and removing the AI_RAG feature flag check. Cleaned up unused imports.

<sup>Written for commit b7d56ed75f1a87dcb6f73c877826871c40185042. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

