### PR TITLE
Add LiteLLM assets to airgapped packaging

### DIFF
--- a/hosting/scripts/airgapped/airgappedDockerBuild.js
+++ b/hosting/scripts/airgapped/airgappedDockerBuild.js
@@ -12,6 +12,8 @@ let IMAGES = {
 	couch: "ibmcom/couchdb3",
 	curl: "curlimages/curl",
 	redis: "redis",
+	litellm: "docker.litellm.ai/berriai/litellm:1.80.15-stable.1",
+	litellmPostgres: "postgres:16",
 }
 
 if (IS_SINGLE_IMAGE) {
@@ -22,7 +24,8 @@ if (IS_SINGLE_IMAGE) {
 
 const FILES = {
 	COMPOSE: "docker-compose.yaml",
-	ENV: ".env"
+	ENV: ".env",
+	LITELLM_CONFIG: "litellm_config.yaml",
 }
 
 const OUTPUT_DIR = path.join(__dirname, "../", "bb-airgapped")
@@ -48,6 +51,7 @@ for (let image in IMAGES) {
 // copy config files
 if (!IS_SINGLE_IMAGE) {
 	copyFile(FILES.COMPOSE)
+	copyFile(FILES.LITELLM_CONFIG)
 }
 copyFile(FILES.ENV)
 


### PR DESCRIPTION
## Description
Add the airgapped packaging updates required by the LiteLLM docker-compose changes:
- include `docker.litellm.ai/berriai/litellm:1.80.15-stable.1` and `postgres:16` in exported image tar files
- include `hosting/litellm_config.yaml` in the generated `bb-airgapped` bundle

## Launchcontrol
When generating an airgapped Budibase bundle, we now include the additional LiteLLM dependencies so offline installs have the required images and config files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds LiteLLM assets to the airgapped bundle so offline docker-compose installs work out of the box. Exports docker.litellm.ai/berriai/litellm:1.80.15-stable.1 and postgres:16, and includes hosting/litellm_config.yaml in bb-airgapped (copied with docker-compose.yaml for multi-container bundles).

<sup>Written for commit d2e2fd5b238c7b14cc43ee88ea26474150b94cd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

