### PR TITLE
feat: pause chat UI

### DIFF
--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -60,6 +60,7 @@
   import DNDSelectionIndicators from "./preview/DNDSelectionIndicators.svelte"
   import RecaptchaV2 from "./RecaptchaV2.svelte"
   import { ActionTypes } from "@/constants"
+  import { API } from "@/api"
   import AppChatbox from "./app/Chatbox.svelte"
 
   // Provide contexts
@@ -76,6 +77,7 @@
   let dataLoaded = false
   let permissionError = false
   let embedNoScreens = false
+  let chatRoutePaused = false
 
   $: displayPreviewDevice =
     $builderStore.previewModalDevice || $builderStore.previewDevice
@@ -123,6 +125,28 @@
         window.location = "/builder/auth/login"
       }
     }
+  }
+
+  const refreshChatRoutePausedState = async () => {
+    if (!isChatOnlyRoute || $builderStore.inBuilder) {
+      chatRoutePaused = false
+      return
+    }
+
+    try {
+      const chatApp = await API.get({
+        url: "/api/chatapps",
+        suppressErrors: true,
+      })
+      chatRoutePaused = chatApp?.live === false
+    } catch (error) {
+      console.error(error)
+      chatRoutePaused = false
+    }
+  }
+
+  $: if (dataLoaded && isChatOnlyRoute) {
+    refreshChatRoutePausedState()
   }
 
   let fontsLoaded = false
@@ -260,7 +284,58 @@
                               <CustomThemeWrapper>
                                 <div class="chat-route-shell">
                                   <div class="chat-app-container">
-                                    <AppChatbox />
+                                    {#if chatRoutePaused && !$builderStore.inBuilder}
+                                      <div class="chat-paused-shell">
+                                        <div
+                                          class="chat-paused-nav"
+                                          aria-hidden="true"
+                                        >
+                                          <div class="chat-paused-nav-header">
+                                            <div
+                                              class="chat-paused-line chat-paused-line-title"
+                                            ></div>
+                                            <div
+                                              class="chat-paused-line chat-paused-line-subtitle"
+                                            ></div>
+                                          </div>
+                                          <div class="chat-paused-nav-items">
+                                            <div class="chat-paused-item"></div>
+                                            <div class="chat-paused-item"></div>
+                                            <div class="chat-paused-item"></div>
+                                            <div class="chat-paused-item"></div>
+                                          </div>
+                                        </div>
+
+                                        <div class="chat-paused-main">
+                                          <div class="chat-paused-main-header">
+                                            <div
+                                              class="chat-paused-line chat-paused-line-agent"
+                                            ></div>
+                                            <div class="chat-paused-badge">
+                                              Paused
+                                            </div>
+                                          </div>
+
+                                          <div class="chat-paused-content">
+                                            <Heading size="M"
+                                              >Chat is paused</Heading
+                                            >
+                                            <Body size="S">
+                                              This chat app is currently
+                                              unavailable. Ask your
+                                              administrator to set chat live.
+                                            </Body>
+                                          </div>
+
+                                          <div class="chat-paused-input">
+                                            <Body size="S">Chat is paused.</Body
+                                            >
+                                          </div>
+                                        </div>
+                                      </div>
+                                    {:else}
+                                      <AppChatbox />
+                                    {/if}
                                   </div>
                                 </div>
 
@@ -397,6 +472,135 @@
     align-items: stretch;
     overflow: hidden;
     position: relative;
+  }
+
+  .chat-paused-shell {
+    display: flex;
+    flex: 1 1 auto;
+    width: 100%;
+    min-width: 0;
+    min-height: 0;
+    background: var(--spectrum-alias-background-color-primary);
+  }
+
+  .chat-paused-nav {
+    width: 340px;
+    min-width: 340px;
+    border-right: 1px solid var(--spectrum-global-color-gray-200);
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    box-sizing: border-box;
+  }
+
+  .chat-paused-nav-header {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .chat-paused-nav-items {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .chat-paused-item {
+    height: 44px;
+    border-radius: 10px;
+    background: var(--spectrum-global-color-gray-100);
+    border: 1px solid var(--spectrum-global-color-gray-200);
+  }
+
+  .chat-paused-main {
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    padding: 0 32px 32px;
+    box-sizing: border-box;
+  }
+
+  .chat-paused-main-header {
+    width: 100%;
+    padding: var(--spacing-l) 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-m);
+    border-bottom: var(--border-dark);
+  }
+
+  .chat-paused-line {
+    border-radius: 999px;
+    background: var(--spectrum-global-color-gray-200);
+  }
+
+  .chat-paused-line-title {
+    width: 140px;
+    height: 14px;
+  }
+
+  .chat-paused-line-subtitle {
+    width: 92px;
+    height: 10px;
+  }
+
+  .chat-paused-line-agent {
+    width: 120px;
+    height: 14px;
+  }
+
+  .chat-paused-badge {
+    border-radius: 999px;
+    border: 1px solid var(--spectrum-global-color-red-300);
+    color: var(--spectrum-global-color-red-700);
+    background: var(--spectrum-global-color-red-100);
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+    padding: 6px 10px;
+  }
+
+  .chat-paused-content {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-s);
+    text-align: center;
+    padding: var(--spacing-xxl) var(--spacing-xl);
+  }
+
+  .chat-paused-input {
+    border: var(--border-light);
+    border-radius: 12px;
+    min-height: 52px;
+    display: flex;
+    align-items: center;
+    padding: 0 var(--spacing-l);
+    background: var(--spectrum-alias-background-color-secondary);
+  }
+
+  @media (max-width: 1000px) {
+    .chat-paused-shell {
+      flex-direction: column;
+    }
+
+    .chat-paused-nav {
+      width: 100%;
+      min-width: 100%;
+      border-right: 0;
+      border-bottom: 1px solid var(--spectrum-global-color-gray-200);
+    }
+
+    .chat-paused-main {
+      padding: 0 var(--spacing-l) var(--spacing-l);
+    }
   }
 
   .error {

--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -59,6 +59,7 @@
   import { ActionTypes } from "@/constants"
   import { API } from "@/api"
   import AppChatbox from "./app/Chatbox.svelte"
+  import PausedChat from "./app/PausedChat.svelte"
 
   // Provide contexts
   const context = createContextStore()
@@ -280,54 +281,7 @@
                                 <div class="chat-route-shell">
                                   <div class="chat-app-container">
                                     {#if chatRoutePaused && !$builderStore.inBuilder}
-                                      <div class="chat-paused-shell">
-                                        <div
-                                          class="chat-paused-nav"
-                                          aria-hidden="true"
-                                        >
-                                          <div class="chat-paused-nav-header">
-                                            <div
-                                              class="chat-paused-line chat-paused-line-title"
-                                            ></div>
-                                            <div
-                                              class="chat-paused-line chat-paused-line-subtitle"
-                                            ></div>
-                                          </div>
-                                          <div class="chat-paused-nav-items">
-                                            <div class="chat-paused-item"></div>
-                                            <div class="chat-paused-item"></div>
-                                            <div class="chat-paused-item"></div>
-                                            <div class="chat-paused-item"></div>
-                                          </div>
-                                        </div>
-
-                                        <div class="chat-paused-main">
-                                          <div class="chat-paused-main-header">
-                                            <div
-                                              class="chat-paused-line chat-paused-line-agent"
-                                            ></div>
-                                            <div class="chat-paused-badge">
-                                              Paused
-                                            </div>
-                                          </div>
-
-                                          <div class="chat-paused-content">
-                                            <Heading size="M"
-                                              >Chat is paused</Heading
-                                            >
-                                            <Body size="S">
-                                              This chat app is currently
-                                              unavailable. Ask your
-                                              administrator to set chat live.
-                                            </Body>
-                                          </div>
-
-                                          <div class="chat-paused-input">
-                                            <Body size="S">Chat is paused.</Body
-                                            >
-                                          </div>
-                                        </div>
-                                      </div>
+                                      <PausedChat />
                                     {:else}
                                       <AppChatbox />
                                     {/if}
@@ -467,135 +421,6 @@
     align-items: stretch;
     overflow: hidden;
     position: relative;
-  }
-
-  .chat-paused-shell {
-    display: flex;
-    flex: 1 1 auto;
-    width: 100%;
-    min-width: 0;
-    min-height: 0;
-    background: transparent;
-  }
-
-  .chat-paused-nav {
-    width: 340px;
-    min-width: 340px;
-    border-right: var(--border-light);
-    padding: 20px;
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
-    box-sizing: border-box;
-  }
-
-  .chat-paused-nav-header {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-  }
-
-  .chat-paused-nav-items {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-  }
-
-  .chat-paused-item {
-    height: 44px;
-    border-radius: 10px;
-    background: var(--spectrum-global-color-gray-100);
-    border: 1px solid var(--spectrum-global-color-gray-200);
-  }
-
-  .chat-paused-main {
-    flex: 1 1 auto;
-    min-width: 0;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-    padding: 0 32px 32px;
-    box-sizing: border-box;
-  }
-
-  .chat-paused-main-header {
-    width: 100%;
-    padding: var(--spacing-l) 0;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--spacing-m);
-    border-bottom: var(--border-light);
-  }
-
-  .chat-paused-line {
-    border-radius: 999px;
-    background: var(--spectrum-global-color-gray-200);
-  }
-
-  .chat-paused-line-title {
-    width: 140px;
-    height: 14px;
-  }
-
-  .chat-paused-line-subtitle {
-    width: 92px;
-    height: 10px;
-  }
-
-  .chat-paused-line-agent {
-    width: 120px;
-    height: 14px;
-  }
-
-  .chat-paused-badge {
-    border-radius: 999px;
-    border: 1px solid var(--spectrum-global-color-red-300);
-    color: var(--spectrum-global-color-red-700);
-    background: var(--spectrum-global-color-red-100);
-    font-size: 12px;
-    font-weight: 600;
-    line-height: 1;
-    padding: 6px 10px;
-  }
-
-  .chat-paused-content {
-    flex: 1 1 auto;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: var(--spacing-s);
-    text-align: center;
-    padding: var(--spacing-xxl) var(--spacing-xl);
-  }
-
-  .chat-paused-input {
-    border: var(--border-light);
-    border-radius: 12px;
-    min-height: 52px;
-    display: flex;
-    align-items: center;
-    padding: 0 var(--spacing-l);
-    background: var(--spectrum-alias-background-color-secondary);
-  }
-
-  @media (max-width: 1000px) {
-    .chat-paused-shell {
-      flex-direction: column;
-    }
-
-    .chat-paused-nav {
-      width: 100%;
-      min-width: 100%;
-      border-right: 0;
-      border-bottom: var(--border-light);
-    }
-
-    .chat-paused-main {
-      padding: 0 var(--spacing-l) var(--spacing-l);
-    }
   }
 
   .error {

--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -9,10 +9,7 @@
     invalidationMessage,
     popNumSessionsInvalidated,
   } from "@budibase/frontend-core"
-  import {
-    DefaultBuilderTheme,
-    getThemeClassNames,
-  } from "@budibase/shared-core"
+  import { getThemeClassNames } from "@budibase/shared-core"
   import Component from "./Component.svelte"
   import SDK from "@/sdk"
   import {
@@ -88,9 +85,7 @@
     typeof window !== "undefined" &&
     (window.location.pathname.replace(/\/$/, "").endsWith("/_chat") ||
       window.location.pathname.startsWith("/app-chat/"))
-  $: resolvedThemeClassNames = getThemeClassNames(
-    isChatOnlyRoute ? DefaultBuilderTheme : $themeStore.theme
-  )
+  $: resolvedThemeClassNames = getThemeClassNames($themeStore.theme)
 
   // Handle no matching route
   $: {
@@ -480,13 +475,13 @@
     width: 100%;
     min-width: 0;
     min-height: 0;
-    background: var(--spectrum-alias-background-color-primary);
+    background: transparent;
   }
 
   .chat-paused-nav {
     width: 340px;
     min-width: 340px;
-    border-right: 1px solid var(--spectrum-global-color-gray-200);
+    border-right: var(--border-light);
     padding: 20px;
     display: flex;
     flex-direction: column;
@@ -530,7 +525,7 @@
     align-items: center;
     justify-content: space-between;
     gap: var(--spacing-m);
-    border-bottom: var(--border-dark);
+    border-bottom: var(--border-light);
   }
 
   .chat-paused-line {
@@ -595,7 +590,7 @@
       width: 100%;
       min-width: 100%;
       border-right: 0;
-      border-bottom: 1px solid var(--spectrum-global-color-gray-200);
+      border-bottom: var(--border-light);
     }
 
     .chat-paused-main {
@@ -645,7 +640,7 @@
     flex: 1 1 auto;
     display: flex;
     border-radius: 24px;
-    border: var(--border-dark);
+    border: var(--border-light);
     background: transparent;
     overflow: hidden;
     min-width: 0;

--- a/packages/client/src/components/app/Chatbox.svelte
+++ b/packages/client/src/components/app/Chatbox.svelte
@@ -55,7 +55,6 @@
   let chat: ChatConversationLike = { ...INITIAL_CHAT }
   let deletingChat = false
   let loading = true
-  let isChatPaused = false
   let initialPrompt = ""
   let selectedAgentId: string | null = null
   let enabledAgentList: EnabledAgentListItem[] = []
@@ -96,7 +95,6 @@
   })
   $: hasAnyAgents = agents.length > 0
   $: hasEnabledAgents = enabledAgentList.length > 0
-  $: showPausedState = !loading && isChatPaused
   $: showEmptyState = !loading && !hasEnabledAgents
   $: emptyStateMessage = hasAnyAgents
     ? "No agents enabled for this chat app. Ask your administrator to enable one to start chatting."
@@ -143,19 +141,6 @@
     loading = true
     try {
       const chatApp = await API.fetchChatApp(workspaceId)
-      isChatPaused = chatApp?.live === false
-
-      if (isChatPaused) {
-        chatAppId = chatApp?._id || ""
-        chatAgents = chatApp?.agents || []
-        agents = []
-        enabledAgentList = []
-        conversationHistory = []
-        selectedAgentId = null
-        selectedConversationId = undefined
-        chat = { ...INITIAL_CHAT, chatAppId }
-        return
-      }
 
       chatAppId = chatApp?._id || ""
       chatAgents = chatApp?.agents || []
@@ -195,7 +180,6 @@
     } catch (err) {
       console.error(err)
       notifications.error("Failed to load chat")
-      isChatPaused = false
       enabledAgentList = []
       conversationHistory = []
     } finally {
@@ -310,11 +294,7 @@
 </script>
 
 <div class="chat-app-shell">
-  {#if showPausedState}
-    <div class="chat-empty-state">
-      <Body size="M">Chat is paused</Body>
-    </div>
-  {:else if showEmptyState}
+  {#if showEmptyState}
     <div class="chat-empty-state">
       <Body size="M">{emptyStateMessage}</Body>
     </div>

--- a/packages/client/src/components/app/PausedChat.svelte
+++ b/packages/client/src/components/app/PausedChat.svelte
@@ -1,0 +1,168 @@
+<script>
+  import { Heading, Body } from "@budibase/bbui"
+</script>
+
+<div class="chat-paused-shell">
+  <div class="chat-paused-nav" aria-hidden="true">
+    <div class="chat-paused-nav-header">
+      <div class="chat-paused-line chat-paused-line-title"></div>
+      <div class="chat-paused-line chat-paused-line-subtitle"></div>
+    </div>
+    <div class="chat-paused-nav-items">
+      <div class="chat-paused-item"></div>
+      <div class="chat-paused-item"></div>
+      <div class="chat-paused-item"></div>
+      <div class="chat-paused-item"></div>
+    </div>
+  </div>
+
+  <div class="chat-paused-main">
+    <div class="chat-paused-main-header">
+      <div class="chat-paused-line chat-paused-line-agent"></div>
+      <div class="chat-paused-badge">Paused</div>
+    </div>
+
+    <div class="chat-paused-content">
+      <Heading size="M">Chat is paused</Heading>
+      <Body size="S">
+        This chat app is currently unavailable. Ask your administrator to set
+        chat live.
+      </Body>
+    </div>
+
+    <div class="chat-paused-input">
+      <Body size="S">Chat is paused.</Body>
+    </div>
+  </div>
+</div>
+
+<style>
+  .chat-paused-shell {
+    display: flex;
+    flex: 1 1 auto;
+    width: 100%;
+    min-width: 0;
+    min-height: 0;
+    background: transparent;
+  }
+
+  .chat-paused-nav {
+    width: 340px;
+    min-width: 340px;
+    border-right: var(--border-light);
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    box-sizing: border-box;
+  }
+
+  .chat-paused-nav-header {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .chat-paused-nav-items {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .chat-paused-item {
+    height: 44px;
+    border-radius: 10px;
+    background: var(--spectrum-global-color-gray-100);
+    border: 1px solid var(--spectrum-global-color-gray-200);
+  }
+
+  .chat-paused-main {
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    padding: 0 32px 32px;
+    box-sizing: border-box;
+  }
+
+  .chat-paused-main-header {
+    width: 100%;
+    padding: var(--spacing-l) 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-m);
+    border-bottom: var(--border-light);
+  }
+
+  .chat-paused-line {
+    border-radius: 999px;
+    background: var(--spectrum-global-color-gray-200);
+  }
+
+  .chat-paused-line-title {
+    width: 140px;
+    height: 14px;
+  }
+
+  .chat-paused-line-subtitle {
+    width: 92px;
+    height: 10px;
+  }
+
+  .chat-paused-line-agent {
+    width: 120px;
+    height: 14px;
+  }
+
+  .chat-paused-badge {
+    border-radius: 999px;
+    border: 1px solid var(--spectrum-global-color-red-300);
+    color: var(--spectrum-global-color-red-700);
+    background: var(--spectrum-global-color-red-100);
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+    padding: 6px 10px;
+  }
+
+  .chat-paused-content {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-s);
+    text-align: center;
+    padding: var(--spacing-xxl) var(--spacing-xl);
+  }
+
+  .chat-paused-input {
+    border: var(--border-light);
+    border-radius: 12px;
+    min-height: 52px;
+    display: flex;
+    align-items: center;
+    padding: 0 var(--spacing-l);
+    background: var(--spectrum-alias-background-color-secondary);
+  }
+
+  @media (max-width: 1000px) {
+    .chat-paused-shell {
+      flex-direction: column;
+    }
+
+    .chat-paused-nav {
+      width: 100%;
+      min-width: 100%;
+      border-right: 0;
+      border-bottom: var(--border-light);
+    }
+
+    .chat-paused-main {
+      padding: 0 var(--spacing-l) var(--spacing-l);
+    }
+  }
+</style>

--- a/packages/frontend-core/src/components/Chatbox/ChatConversationPanel.svelte
+++ b/packages/frontend-core/src/components/Chatbox/ChatConversationPanel.svelte
@@ -255,7 +255,7 @@
     align-items: center;
     justify-content: space-between;
     gap: var(--spacing-m);
-    border-bottom: var(--border-dark);
+    border-bottom: var(--border-light);
   }
 
   .chat-header-agent {


### PR DESCRIPTION
## Description

When you pause a chat app, users should not be able to continue interacting with it. Note, API changes to come in another PR.

## Screenshot

<img width="3022" height="1720" alt="image" src="https://github.com/user-attachments/assets/5f2b64ba-01a1-4267-8434-ceef84597cf7" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a “Chat is paused” screen on chat-only routes when the chat app isn’t live, instead of rendering the chatbox. Also standardizes chat borders to use light borders.

- **New Features**
  - Detects paused state via GET /api/chatapps (live === false) and shows a dedicated paused shell with clear messaging.
  - Applies only on chat-only routes (/_chat, /app-chat) and when not in the builder.
  - Keeps layout responsive and leaves normal chat flow unchanged when live.

- **Refactors**
  - Uses $themeStore.theme for chat routes (removes DefaultBuilderTheme override).
  - Extracts paused UI into a new PausedChat component and renders it from ClientApp.
  - Switches chat container and header borders to --border-light for consistency.

<sup>Written for commit d82025fd9cf52144daa86c71482a70e2e7e2bb9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



