### PR TITLE
Switch changelog link to point to github releases

### DIFF
--- a/packages/builder/src/constants/index.ts
+++ b/packages/builder/src/constants/index.ts
@@ -65,7 +65,7 @@ export const PlanModel = {
   PER_USER: "perUser",
 }
 
-export const CHANGELOG_URL = "https://docs.budibase.com/changelog"
+export const CHANGELOG_URL = "https://github.com/Budibase/budibase/releases"
 export const DISCORD_URL = "https://discord.com/invite/ZepTmGbtfF"
 export const DOCUMENTATION_URL = "https://docs.budibase.com/docs"
 export const GITHUB_DISCUSSIONS_URL =


### PR DESCRIPTION
## Description
Switch the changelog link in the product to point to GitHub releases, instead of the docs releases blog.

## Screenshots
<img width="962" height="650" alt="Screenshot 2026-02-19 at 11 03 26" src="https://github.com/user-attachments/assets/9c9c79f1-629c-483c-b52b-f7bfab696e9e" />

## Launchcontrol
Update changelog link to point to GitHub releases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the in-app Changelog link to GitHub Releases so users see the latest release notes and downloads in one place.

This replaces the old docs changelog URL with https://github.com/Budibase/budibase/releases.

<sup>Written for commit 07fbd33bc87acd3ef4d9d62ebbc9cf8764227f29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

