### PR TITLE
make changelog link font size consistent with body text

### DIFF
--- a/packages/builder/src/components/deploy/VersionModal.svelte
+++ b/packages/builder/src/components/deploy/VersionModal.svelte
@@ -118,7 +118,9 @@
     {/if}
     <Body size="S">
       Find the changelog for the latest release
-      <Link href={CHANGELOG_URL} target="_blank">here</Link>
+      <span class="changelog-link-size">
+        <Link href={CHANGELOG_URL} target="_blank">here</Link>
+      </span>
     </Body>
     {#if revertAvailable}
       <Body size="S">
@@ -129,3 +131,11 @@
     {/if}
   </ModalContent>
 </Modal>
+
+<style>
+  .changelog-link-size {
+    --spectrum-link-primary-m-text-size: var(
+      --spectrum-alias-font-size-default
+    );
+  }
+</style>


### PR DESCRIPTION
## Description
body text was 14px, link text was 13px :'(

## Screenshots
### before
<img width="439" height="371" alt="SCR-20260219-krfx" src="https://github.com/user-attachments/assets/0383dae1-8839-4ac4-8976-0fe36d3e5349" />

### after
<img width="439" height="371" alt="SCR-20260219-kred" src="https://github.com/user-attachments/assets/b76bd282-362d-444a-aba9-8b38313d6bb1" />


## Launchcontrol
fix changelog link size


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the changelog link font size match the surrounding body text in VersionModal. This removes a 1px mismatch and improves visual consistency.

Implemented by overriding the link text-size CSS variable within a scoped span.

<sup>Written for commit 476e3c5f215c514c00926413c1db9b6dcb8c811e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

