### PR TITLE
Implementation

### DIFF
--- a/packages/client/src/components/app/Layout.svelte
+++ b/packages/client/src/components/app/Layout.svelte
@@ -611,6 +611,7 @@
     position: relative;
     padding: 32px;
     align-self: center;
+    flex: 1;
   }
   .main:not(.size--max):has(.screenslot-dom > .component > .grid) {
     padding: calc(32px - var(--grid-spacing) * 2px);


### PR DESCRIPTION
This pull request makes a small layout improvement to the main content area in the `Layout.svelte` component. The change ensures that the main section will flexibly expand to fill available space within its container.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adjusted the main content area in Layout.svelte to fill available space, fixing main page slot alignment and reducing gaps on large screens. Added flex: 1 to .main.

<sup>Written for commit 70d69a7b5140961f999bd058f885d0c05573b31c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

