### PR TITLE
fix: gate chat app from portal with feature flag

### DIFF
--- a/packages/builder/src/pages/builder/apps/index.svelte
+++ b/packages/builder/src/pages/builder/apps/index.svelte
@@ -202,50 +202,48 @@
                 </Layout>
               </div>
             {/if}
-            {#if chatFeatureEnabled}
-              {#if userApps.length || !chatAppsLoaded || liveChatApps.length}
-                <Heading size="S">Chat</Heading>
-                <div class="group">
-                  <Layout gap="S" noPadding>
-                    {#if !chatAppsLoaded}
-                      <Body size="S">Loading chat apps...</Body>
-                    {:else if liveChatApps.length}
-                      {#each liveChatApps as chatApp (chatApp.chatAppId)}
-                        <a
-                          class="app"
-                          target="_blank"
-                          rel="noreferrer"
-                          href={`/app-chat${chatApp.url}`}
-                        >
-                          <div
-                            class="preview"
-                            use:gradient={{ seed: chatApp.name }}
-                          ></div>
-                          <div class="app-info">
-                            <Heading size="XS">{chatApp.name}</Heading>
-                            <Body size="S">
-                              {#if chatApp.updatedAt}
-                                {processStringSync(portalLabels.updatedAgo, {
-                                  time:
-                                    new Date().getTime() -
-                                    new Date(chatApp.updatedAt).getTime(),
-                                })}
-                              {:else}
-                                {portalLabels.neverUpdated}
-                              {/if}
-                            </Body>
-                          </div>
-                          <div class="icon-muted">
-                            <Icon name="caret-right" />
-                          </div>
-                        </a>
-                      {/each}
-                    {:else}
-                      <Body size="S">No live chat apps yet.</Body>
-                    {/if}
-                  </Layout>
-                </div>
-              {/if}
+            {#if chatFeatureEnabled && (userApps.length || !chatAppsLoaded || liveChatApps.length)}
+              <Heading size="S">Chat</Heading>
+              <div class="group">
+                <Layout gap="S" noPadding>
+                  {#if !chatAppsLoaded}
+                    <Body size="S">Loading chat apps...</Body>
+                  {:else if liveChatApps.length}
+                    {#each liveChatApps as chatApp (chatApp.chatAppId)}
+                      <a
+                        class="app"
+                        target="_blank"
+                        rel="noreferrer"
+                        href={`/app-chat${chatApp.url}`}
+                      >
+                        <div
+                          class="preview"
+                          use:gradient={{ seed: chatApp.name }}
+                        ></div>
+                        <div class="app-info">
+                          <Heading size="XS">{chatApp.name}</Heading>
+                          <Body size="S">
+                            {#if chatApp.updatedAt}
+                              {processStringSync(portalLabels.updatedAgo, {
+                                time:
+                                  new Date().getTime() -
+                                  new Date(chatApp.updatedAt).getTime(),
+                              })}
+                            {:else}
+                              {portalLabels.neverUpdated}
+                            {/if}
+                          </Body>
+                        </div>
+                        <div class="icon-muted">
+                          <Icon name="caret-right" />
+                        </div>
+                      </a>
+                    {/each}
+                  {:else}
+                    <Body size="S">No live chat apps yet.</Body>
+                  {/if}
+                </Layout>
+              </div>
             {/if}
             {#if !userApps.length && (!chatFeatureEnabled || (chatAppsLoaded && !liveChatApps.length))}
               <Layout gap="XS" noPadding>

--- a/packages/builder/src/pages/builder/apps/index.svelte
+++ b/packages/builder/src/pages/builder/apps/index.svelte
@@ -70,14 +70,15 @@
 
   onMount(async () => {
     try {
-      await Promise.all(
-        [clientAppsStore.load(), translations.init()].concat(
-          chatFeatureEnabled ? [clientChatAppsStore.load()] : []
-        )
-      )
+      await Promise.all([clientAppsStore.load(), translations.init()])
     } catch (error) {
       notifications.error("Error loading apps")
     }
+
+    if (chatFeatureEnabled) {
+      await clientChatAppsStore.load()
+    }
+
     loaded = true
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Gate Chat in the portal behind the AI_CHAT feature flag. When the flag is off, the Chat UI is hidden, chat apps don’t load, and the normal empty state shows.

- **New Features**
  - Load chat apps only after init and only when featureFlags.AI_CHAT is enabled.
  - Show the Chat section only when the flag is enabled; otherwise show the standard empty state.

<sup>Written for commit e951611d6dd5ada74be08bf2bd52da55007a9291. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

