### PR TITLE
Remove border from component toolbar dropdowns

### DIFF
--- a/packages/client/src/components/preview/SettingsPicker.svelte
+++ b/packages/client/src/components/preview/SettingsPicker.svelte
@@ -14,6 +14,7 @@
 <div>
   <Select
     quiet
+    bordered={false}
     autoWidth
     placeholder={label}
     {options}


### PR DESCRIPTION
## Description
Removes the visible border from component toolbar dropdown pickers in the builder settings bar by disabling `bordered` on `SettingsPicker`.

## Screenshots
<img width="591" height="177" alt="before" src="https://github.com/user-attachments/assets/61964eb5-4c71-4a9c-b0b6-f8406a5b3f20" />

BEFORE

<img width="591" height="177" alt="after" src="https://github.com/user-attachments/assets/e1b30026-e465-4702-9da3-4a2c111e8027" />

AFTER (Fix to set as before)

## Launchcontrol
Removes the border around the component toolbar dropdown so it matches the expected toolbar style.


