### PR TITLE
Litellm improvements

### DIFF
--- a/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
@@ -57,6 +57,8 @@ describe("agent files", () => {
       .reply(200, { data: [] })
 
     const liteLLMScope = nock(environment.LITELLM_URL)
+      .post("/team/new")
+      .reply(200, { team_id: "team-2" })
       .post("/key/generate")
       .reply(200, { token_id: "embed-key-2", key: "embed-secret-2" })
       .post("/model/new")

--- a/packages/server/src/api/routes/tests/ai/aiConfig.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/aiConfig.spec.ts
@@ -830,7 +830,6 @@ describe("BudibaseAI", () => {
 
       const keyDoc = await getLiteLLMKeyDoc()
       expect(keyDoc?.teamId).toBe("tenant-team-1")
-      expect(keyDoc?.teamAlias).toBe(expectedTeamAlias)
     })
 
     it("backfills team on existing keys without rotating the key", async () => {
@@ -848,7 +847,6 @@ describe("BudibaseAI", () => {
           keyId: existingKeyId,
           secretKey: existingSecret,
           teamId: undefined as any, // Force missing values
-          teamAlias: undefined as any,
         })
       })
 
@@ -892,7 +890,6 @@ describe("BudibaseAI", () => {
       expect(keyDoc?.keyId).toBe(existingKeyId)
       expect(keyDoc?.secretKey).toBe(existingSecret)
       expect(keyDoc?.teamId).toBe("tenant-team-backfill")
-      expect(keyDoc?.teamAlias).toBe(expectedTeamAlias)
     })
 
     it("syncs the key with model IDs from the workspace", async () => {

--- a/packages/server/src/api/routes/tests/ai/aiConfig.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/aiConfig.spec.ts
@@ -771,8 +771,8 @@ describe("BudibaseAI", () => {
       expect(keyDoc?.keyId).toBe("reused-key")
     })
 
-    it("uses the prod workspace ID as the key alias", async () => {
-      const expectedAlias = config.getProdWorkspaceId()
+    it("prefixes the key alias with tenant and workspace IDs", async () => {
+      const expectedAlias = `${config.getTenantId()}:${config.getProdWorkspaceId()}`
 
       const keyGenerateScope = nock(environment.LITELLM_URL)
         .post("/key/generate", body => {
@@ -797,8 +797,8 @@ describe("BudibaseAI", () => {
     it("creates a team per tenant and assigns keys to it", async () => {
       nock.cleanAll()
       mockLiteLLMProviders()
-      const expectedTeamAlias = `budibase-tenant-${config.getTenantId()}`
-      const expectedKeyAlias = config.getProdWorkspaceId()
+      const expectedTeamAlias = config.getTenantId()
+      const expectedKeyAlias = `${config.getTenantId()}:${config.getProdWorkspaceId()}`
 
       const teamScope = nock(environment.LITELLM_URL)
         .post("/team/new", body => {
@@ -838,7 +838,7 @@ describe("BudibaseAI", () => {
 
       const existingKeyId = "legacy-key-id"
       const existingSecret = "legacy-secret-key"
-      const expectedTeamAlias = `budibase-tenant-${config.getTenantId()}`
+      const expectedTeamAlias = config.getTenantId()
 
       await config.doInContext(config.getDevWorkspaceId(), async () => {
         const keyDocId = docIds.getLiteLLMKeyID()

--- a/packages/server/src/sdk/workspace/ai/configs/index.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/index.ts
@@ -176,6 +176,11 @@ export async function create(
     config.credentialsFields.api_key = licenseKey
   }
 
+  const configId =
+    config.provider === BUDIBASE_AI_PROVIDER_ID
+      ? docIds.generateAIConfigID("bbai")
+      : docIds.generateAIConfigID()
+
   let modelId
   if (!isBBAI || isSelfhost) {
     await liteLLM.validateConfig({
@@ -186,6 +191,7 @@ export async function create(
     })
 
     modelId = await liteLLM.addModel({
+      configId,
       provider: config.provider,
       model: config.model,
       credentialFields: config.credentialsFields,
@@ -197,10 +203,7 @@ export async function create(
   }
 
   const newConfig: CustomAIProviderConfig = {
-    _id:
-      config.provider === BUDIBASE_AI_PROVIDER_ID
-        ? docIds.generateAIConfigID("bbai")
-        : docIds.generateAIConfigID(),
+    _id: configId,
     name: config.name,
     provider: config.provider,
     credentialsFields: config.credentialsFields,
@@ -325,6 +328,7 @@ export async function update(
   if (shouldUpdateLiteLLM) {
     try {
       await liteLLM.updateModel({
+        configId: id,
         llmModelId: updatedConfig.liteLLMModelId,
         provider: updatedConfig.provider,
         name: updatedConfig.model,

--- a/packages/server/src/sdk/workspace/ai/configs/litellm.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/litellm.ts
@@ -38,7 +38,7 @@ const tenantTeamDocId = "litellmteam_config"
 
 const getTenantTeamAlias = () => {
   const tenantId = context.getTenantId()
-  return `budibase-tenant-${tenantId}`
+  return tenantId
 }
 
 async function createTeam(alias: string): Promise<LiteLLMTeam> {

--- a/packages/server/src/sdk/workspace/ai/configs/litellm.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/litellm.ts
@@ -41,6 +41,10 @@ const getTenantTeamAlias = () => {
   return tenantId
 }
 
+const getKeyAlias = (workspaceId: string) => {
+  return `${context.getTenantId()}:${workspaceId}`
+}
+
 async function createTeam(alias: string): Promise<LiteLLMTeam> {
   const response = await fetch(`${liteLLMUrl}/team/new`, {
     method: "POST",
@@ -395,7 +399,7 @@ export async function getKeySettings(): Promise<{
           return { ...updatedConfig, _rev: rev }
         }
 
-        const key = await generateKey(workspaceId, team.id)
+        const key = await generateKey(getKeyAlias(workspaceId), team.id)
         const config: LiteLLMKeyConfig = {
           _id: keyDocId,
           keyId: key.id,

--- a/packages/server/src/sdk/workspace/ai/configs/litellm.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/litellm.ts
@@ -32,7 +32,6 @@ interface LiteLLMTenantTeamConfig {
   _id: string
   _rev?: string
   teamId: string
-  teamAlias: string
 }
 
 const tenantTeamDocId = "litellmteam_config"
@@ -83,7 +82,7 @@ async function getOrCreateTenantTeam(): Promise<LiteLLMTeam> {
   if (existing) {
     return {
       id: existing.teamId,
-      alias: existing.teamAlias,
+      alias: getTenantTeamAlias(),
     }
   }
 
@@ -99,7 +98,7 @@ async function getOrCreateTenantTeam(): Promise<LiteLLMTeam> {
       if (maybeExisting) {
         return {
           id: maybeExisting.teamId,
-          alias: maybeExisting.teamAlias,
+          alias: getTenantTeamAlias(),
         }
       }
 
@@ -107,7 +106,6 @@ async function getOrCreateTenantTeam(): Promise<LiteLLMTeam> {
       await tenantDb.put({
         _id: tenantTeamDocId,
         teamId: team.id,
-        teamAlias: team.alias,
       })
       return team
     }
@@ -392,7 +390,6 @@ export async function getKeySettings(): Promise<{
           const updatedConfig: LiteLLMKeyConfig = {
             ...existingKeyConfig,
             teamId: team.id,
-            teamAlias: team.alias,
           }
           const { rev } = await db.put(updatedConfig)
           return { ...updatedConfig, _rev: rev }
@@ -404,12 +401,8 @@ export async function getKeySettings(): Promise<{
           keyId: key.id,
           secretKey: key.secret,
           teamId: team.id,
-          teamAlias: team.alias,
         }
-        const { rev } = await db.put({
-          ...config,
-          _rev: existingKeyConfig?._rev,
-        })
+        const { rev } = await db.put(config)
         return { ...config, _rev: rev }
       }
     )

--- a/packages/server/src/sdk/workspace/ai/llm/litellm.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/llm/litellm.spec.ts
@@ -50,6 +50,7 @@ describe("createLiteLLMOpenAI", () => {
     getKeySettingsMock.mockResolvedValue({
       keyId: "key-id",
       secretKey: "secret-key",
+      teamId: "team-id",
     })
 
     mockChatGPTResponse("hello", {

--- a/packages/types/src/documents/global/ai.ts
+++ b/packages/types/src/documents/global/ai.ts
@@ -25,5 +25,4 @@ export interface LiteLLMKeyConfig extends Document {
   keyId: string
   secretKey: string
   teamId: string
-  teamAlias: string
 }

--- a/packages/types/src/documents/global/ai.ts
+++ b/packages/types/src/documents/global/ai.ts
@@ -24,4 +24,6 @@ export interface CustomAIProviderConfig extends Document {
 export interface LiteLLMKeyConfig extends Document {
   keyId: string
   secretKey: string
+  teamId: string
+  teamAlias: string
 }


### PR DESCRIPTION
## Description
LiteLLM improvements.
1. Use teams, great for monitoring
2. Prefix keys by tenant, to avoid conflicts
3. Use tenant:workspaceId:configId as display model name, for better monitoring/filtering

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-tenant LiteLLM teams with persisted team IDs and tenant-scoped key/model aliases to improve monitoring and avoid cross-tenant conflicts. Existing keys are backfilled into tenant teams without rotating secrets.

- New Features
  - Persist a LiteLLM team per tenant; store teamId on keys and assign new keys to that team.
  - Ensure unique aliases: key_alias is tenant:workspace; model_name is tenant:prodWorkspace:configId (create and update).
  - Backfill teams onto legacy keys and sync models via key update, no secret rotation.
  - Updated types (teamId in LiteLLMKeyConfig), improved error handling for team/key ops, and tests.

- Migration
  - No action required; keys are backfilled automatically.

<sup>Written for commit d09fa5f553828318ab9b709b955dd83f78518405. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

