### PR TITLE
BBAI improvements

### DIFF
--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -271,8 +271,6 @@ const environment = {
   CUSTOM_CSP_IMG_SRC: process.env.CUSTOM_CSP_IMG_SRC,
   CUSTOM_CSP_FONT_SRC: process.env.CUSTOM_CSP_FONT_SRC,
   CUSTOM_CSP_FRAME_SRC: process.env.CUSTOM_CSP_FRAME_SRC,
-  BBAI_OPENAI_API_KEY: process.env.BBAI_OPENAI_API_KEY,
-  BBAI_OPENROUTER_API_KEY: process.env.BBAI_OPENROUTER_API_KEY,
   OPENROUTER_BASE_URL:
     process.env.OPENROUTER_BASE_URL || "https://openrouter.ai/api/v1",
 }
@@ -319,8 +317,6 @@ export const SECRETS: EnvironmentKey[] = [
   "OPENAI_API_KEY",
   "REDIS_PASSWORD",
   "REDIS_USERNAME",
-  "BBAI_OPENAI_API_KEY",
-  "BBAI_OPENROUTER_API_KEY",
 ]
 
 // clean up any environment variable edge cases

--- a/packages/builder/src/settings/pages/ai/licenseStatus.ts
+++ b/packages/builder/src/settings/pages/ai/licenseStatus.ts
@@ -1,5 +1,5 @@
 import { writable, get } from "svelte/store"
-import { licensing } from "@/stores/portal"
+import { admin, licensing } from "@/stores/portal"
 import { API } from "@/api"
 
 export type LicenseStatus = "checking" | "has_key" | "missing_key"
@@ -7,6 +7,10 @@ export type LicenseStatus = "checking" | "has_key" | "missing_key"
 export const aiLicenseStatus = writable<LicenseStatus>("checking")
 
 const resolveStatus = async (): Promise<LicenseStatus> => {
+  if (get(admin).cloud) {
+    return "has_key"
+  }
+
   const license = get(licensing).license
   const isOfflineLicense = !!(license && "identifier" in license)
   if (isOfflineLicense) {

--- a/packages/server/src/api/controllers/ai/budibaseai-v2.ts
+++ b/packages/server/src/api/controllers/ai/budibaseai-v2.ts
@@ -1,0 +1,143 @@
+import { env } from "@budibase/backend-core"
+import { ChatCompletionRequestV2, type Ctx } from "@budibase/types"
+import { bbai } from "../../../sdk/workspace/ai/llm"
+import environment from "../../../environment"
+
+interface StreamUsageState {
+  sseBuffer: string
+  usageCaptured: boolean
+}
+
+async function parseStreamUsageFromChunk(
+  decodedChunk: string,
+  state: StreamUsageState
+) {
+  if (state.usageCaptured) {
+    return
+  }
+
+  state.sseBuffer += decodedChunk
+  let newLineIndex = state.sseBuffer.indexOf("\n")
+
+  while (newLineIndex !== -1) {
+    const line = state.sseBuffer.slice(0, newLineIndex).trim()
+    state.sseBuffer = state.sseBuffer.slice(newLineIndex + 1)
+
+    if (line.startsWith("data: ")) {
+      const data = line.slice(6)
+      if (data && data !== "[DONE]") {
+        try {
+          const parsed = JSON.parse(data)
+          if (parsed?.usage) {
+            state.usageCaptured = true
+            await bbai
+              .incrementBudibaseAICreditsFromOpenAIUsage(parsed.usage)
+              .catch(() => {})
+          }
+        } catch {
+          // ignore partial or non-JSON event lines
+        }
+      }
+    }
+
+    newLineIndex = state.sseBuffer.indexOf("\n")
+  }
+}
+
+export async function chatCompletionV2(ctx: Ctx<ChatCompletionRequestV2>) {
+  const { messages, model, stream } = ctx.request.body
+
+  if (!messages?.length) {
+    ctx.throw(400, "Missing required field: messages")
+  }
+
+  if (env.SELF_HOSTED && !env.isDev()) {
+    ctx.throw(500, "Budibase AI endpoints are not available in self-host")
+  }
+
+  if (!model) {
+    ctx.throw(400, "Missing required field: model")
+  }
+
+  bbai.assertSupportedBBAIModel(model)
+
+  if (!environment.BBAI_LITELLM_KEY) {
+    ctx.throw(500, "BBAI_LITELLM_KEY not configured")
+  }
+
+  const upstreamResponse = await fetch(
+    `${environment.LITELLM_URL.replace(/\/$/, "")}/chat/completions`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${environment.BBAI_LITELLM_KEY}`,
+      },
+      body: JSON.stringify(ctx.request.body),
+    }
+  )
+
+  if (stream) {
+    if (!upstreamResponse.body) {
+      ctx.throw(500, "Streaming error")
+    }
+
+    const decoder = new TextDecoder()
+    const reader = upstreamResponse.body.getReader()
+    const streamUsageState: StreamUsageState = {
+      sseBuffer: "",
+      usageCaptured: false,
+    }
+
+    ctx.respond = false
+    ctx.res.statusCode = upstreamResponse.status
+    upstreamResponse.headers.forEach((value, key) => {
+      ctx.res.setHeader(key, value)
+    })
+
+    try {
+      for (;;) {
+        const { done, value } = await reader.read()
+        if (done) {
+          break
+        }
+
+        await parseStreamUsageFromChunk(
+          decoder.decode(value, { stream: true }),
+          streamUsageState
+        )
+
+        ctx.res.write(value)
+      }
+
+      ctx.res.end()
+      return
+    } catch (error: any) {
+      if (!ctx.res.headersSent) {
+        ctx.throw(error?.status || 500, error?.message || "Streaming error")
+      }
+      ctx.res.end()
+      return
+    }
+  }
+
+  const responseBodyText = await upstreamResponse.text()
+  const contentType = upstreamResponse.headers.get("content-type")
+
+  ctx.status = upstreamResponse.status
+  if (contentType) {
+    ctx.set("Content-Type", contentType)
+  }
+
+  try {
+    const parsedBody = JSON.parse(responseBodyText)
+    if (parsedBody?.usage) {
+      await bbai
+        .incrementBudibaseAICreditsFromOpenAIUsage(parsedBody.usage)
+        .catch(() => {})
+    }
+    ctx.body = parsedBody
+  } catch {
+    ctx.body = responseBodyText
+  }
+}

--- a/packages/server/src/api/controllers/ai/budibaseai.ts
+++ b/packages/server/src/api/controllers/ai/budibaseai.ts
@@ -2,15 +2,12 @@ import { env } from "@budibase/backend-core"
 import { ai, quotas } from "@budibase/pro"
 import {
   AIQuotaUsageResponse,
-  ChatCompletionRequestV2,
   type ChatCompletionRequest,
   type ChatCompletionResponse,
   type Ctx,
   type UploadFileRequest,
   type UploadFileResponse,
 } from "@budibase/types"
-import { bbai } from "../../../sdk/workspace/ai/llm"
-import { generateText, streamText } from "ai"
 
 export async function uploadFile(
   ctx: Ctx<UploadFileRequest, UploadFileResponse>
@@ -47,73 +44,4 @@ export async function chatCompletion(
 
   const llm = await ai.getLLMOrThrow()
   ctx.body = await llm.chat(ai.LLMRequest.fromRequest(ctx.request.body))
-}
-
-export async function chatCompletionV2(ctx: Ctx<ChatCompletionRequestV2>) {
-  const { messages, model, stream } = ctx.request.body
-
-  if (!messages?.length) {
-    ctx.throw(400, "Missing required field: messages")
-  }
-
-  if (env.SELF_HOSTED && !env.isDev()) {
-    ctx.throw(500, "Budibase AI endpoints are not available in self-host")
-  }
-
-  if (!model) {
-    ctx.throw(400, "Missing required field: model")
-  }
-
-  const { chat } = await bbai.createBBAIClient(model)
-
-  if (stream) {
-    try {
-      const result = streamText({
-        model: chat,
-        messages,
-        includeRawChunks: true,
-      })
-
-      ctx.status = 200
-      ctx.set("Content-Type", "text/event-stream")
-      ctx.set("Cache-Control", "no-cache")
-      ctx.set("Connection", "keep-alive")
-
-      ctx.res.setHeader("X-Accel-Buffering", "no")
-      ctx.res.setHeader("Transfer-Encoding", "chunked")
-
-      ctx.respond = false
-
-      for await (const chunk of result.fullStream) {
-        if (chunk.type !== "raw") continue
-        ctx.res.write(`data: ${JSON.stringify(chunk.rawValue)}\n\n`)
-      }
-      ctx.res.write("data: [DONE]\n\n")
-      ctx.res.end()
-      return
-    } catch (error: any) {
-      if (ctx.res.headersSent) {
-        ctx.res.write(
-          `data: ${JSON.stringify({
-            error: {
-              message: env.isProd()
-                ? "Streaming error"
-                : error?.message || "Streaming error",
-              type: "server_error",
-            },
-          })}\n\n`
-        )
-        ctx.res.end()
-        return
-      }
-
-      ctx.throw(error?.status || 500, error?.message || "Streaming error")
-    }
-  }
-
-  const result = await generateText({
-    model: chat,
-    messages,
-  })
-  ctx.body = result.response.body
 }

--- a/packages/server/src/api/controllers/ai/index.ts
+++ b/packages/server/src/api/controllers/ai/index.ts
@@ -1,5 +1,6 @@
 export * from "./agents"
 export * from "./budibaseai"
+export * from "./budibaseai-v2"
 export * from "./cron"
 export * from "./js"
 export * from "./tables"

--- a/packages/server/src/api/routes/tests/ai.spec.ts
+++ b/packages/server/src/api/routes/tests/ai.spec.ts
@@ -156,14 +156,7 @@ const allProviders: TestSetup[] = [
   {
     name: "BudibaseAI",
     setup: budibaseAI(),
-    mockLLMResponse: (
-      answer: string | ((prompt: string) => string),
-      opts?: MockLLMResponseOpts
-    ) =>
-      mockAISDKChatGPTResponse(answer, {
-        baseUrl: "http://test.litellm.com",
-        ...opts,
-      }),
+    mockLLMResponse: mockAISDKChatGPTResponse,
   },
 ]
 
@@ -1203,9 +1196,7 @@ describe("BudibaseAI", () => {
     })
 
     it("proxies the OpenAI response without reshaping", async () => {
-      mockAISDKChatGPTResponse("hello from openai", {
-        baseUrl: "http://test.litellm.com",
-      })
+      mockAISDKChatGPTResponse("hello from openai")
 
       const response = await config.api.ai.openaiChatCompletions({
         model: "budibase/v1",
@@ -1221,7 +1212,6 @@ describe("BudibaseAI", () => {
     it("forwards extra fields (e.g. response_format)", async () => {
       const format = toResponseFormat(z.object({ value: z.string() }))
       mockAISDKChatGPTResponse(`{"value":"ok"}`, {
-        baseUrl: "http://test.litellm.com",
         format,
       })
 
@@ -1240,7 +1230,6 @@ describe("BudibaseAI", () => {
 
     it("returns HTTP errors from upstream", async () => {
       mockChatGPTStreamFailure({
-        baseUrl: "http://test.litellm.com",
         status: 401,
         errorMessage: "Unauthorized",
       })
@@ -1265,9 +1254,7 @@ describe("BudibaseAI", () => {
       let usage = await getQuotaUsage()
       expect(usage.monthly.current.budibaseAICredits).toBe(0)
 
-      mockAISDKChatGPTResponse("charged now here", {
-        baseUrl: "http://test.litellm.com",
-      })
+      mockAISDKChatGPTResponse("charged now here")
 
       await config.api.ai.openaiChatCompletions({
         model: "budibase/v1",

--- a/packages/server/src/api/routes/tests/ai.spec.ts
+++ b/packages/server/src/api/routes/tests/ai.spec.ts
@@ -156,7 +156,14 @@ const allProviders: TestSetup[] = [
   {
     name: "BudibaseAI",
     setup: budibaseAI(),
-    mockLLMResponse: mockAISDKChatGPTResponse,
+    mockLLMResponse: (
+      answer: string | ((prompt: string) => string),
+      opts?: MockLLMResponseOpts
+    ) =>
+      mockAISDKChatGPTResponse(answer, {
+        baseUrl: "http://test.litellm.com",
+        ...opts,
+      }),
   },
 ]
 

--- a/packages/server/src/environment.ts
+++ b/packages/server/src/environment.ts
@@ -159,6 +159,7 @@ const environment = {
     process.env.LITELLM_URL ||
     `http://localhost:${process.env.LITELLM_PORT || "4000"}`,
   LITELLM_MASTER_KEY: process.env.LITELLM_MASTER_KEY,
+  BBAI_LITELLM_KEY: process.env.BBAI_LITELLM_KEY,
   // old
   CLIENT_ID: process.env.CLIENT_ID,
   _set(key: string, value: any) {

--- a/packages/server/src/tests/jestEnv.ts
+++ b/packages/server/src/tests/jestEnv.ts
@@ -29,7 +29,7 @@ process.env.SYNC_MIGRATION_CHECKS_MS = "10"
 process.env.SKIP_WORKSPACE_MIGRATIONS = "1"
 
 process.env.BBAI_LITELLM_KEY = "sk-test-key"
-process.env.LITELLM_URL = "http://test.litellm.com/v1"
+process.env.LITELLM_URL = "https://api.openai.com/v1"
 
 let agent: MockAgent | null = null
 

--- a/packages/server/src/tests/jestEnv.ts
+++ b/packages/server/src/tests/jestEnv.ts
@@ -28,6 +28,9 @@ process.env.MINIO_SECRET_KEY = "budibase"
 process.env.SYNC_MIGRATION_CHECKS_MS = "10"
 process.env.SKIP_WORKSPACE_MIGRATIONS = "1"
 
+process.env.BBAI_LITELLM_KEY = "sk-test-key"
+process.env.LITELLM_URL = "http://test.litellm.com/v1"
+
 let agent: MockAgent | null = null
 
 // Don't eagerly install MockAgent - let tests control when they need it


### PR DESCRIPTION
## Description
1. Proxy bbai usage via litellm
2. Fix selfhost BBAI usage, allowing tools and other usages. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proxies Budibase AI chat completions through LiteLLM and returns upstream responses and streams unchanged. Parses OpenAI-style usage to increment Budibase AI credits, and skips AI license checks on cloud.

- **New Features**
  - Forward requests to LiteLLM /chat/completions and stream SSE chunks unchanged.
  - Parse usage from responses/streams to update BBAI credits.
  - Validate BBAI models and forward extra fields (e.g., response_format, temperature).
  - Return upstream status, headers, and errors as-is.

- **Migration**
  - Set BBAI_LITELLM_KEY and LITELLM_URL in the server environment.
  - Remove deprecated env vars: BBAI_OPENAI_API_KEY and BBAI_OPENROUTER_API_KEY.

<sup>Written for commit add41cefd5febaa69371c07adb798bec2e1483a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

