### PR TITLE
feat: add PDF export margin controls

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -8907,6 +8907,37 @@
         "label": "Button text",
         "key": "buttonText",
         "defaultValue": "Download PDF"
+      },
+      {
+        "section": true,
+        "name": "Margins (pt)",
+        "collapsed": true,
+        "settings": [
+          {
+            "type": "number",
+            "label": "Top",
+            "key": "marginTop",
+            "placeholder": "Default"
+          },
+          {
+            "type": "number",
+            "label": "Bottom",
+            "key": "marginBottom",
+            "placeholder": "Default"
+          },
+          {
+            "type": "number",
+            "label": "Left",
+            "key": "marginLeft",
+            "placeholder": "Default"
+          },
+          {
+            "type": "number",
+            "label": "Right",
+            "key": "marginRight",
+            "placeholder": "Default"
+          }
+        ]
       }
     ]
   },

--- a/packages/client/src/components/app/pdf/PDF.svelte
+++ b/packages/client/src/components/app/pdf/PDF.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getContext, onMount, tick } from "svelte"
   import { Heading, Button } from "@budibase/bbui"
-  import { htmlToPdf, pxToPt, A4HeightPx, type PDFOptions } from "./pdf"
+  import { htmlToPdf, pxToPt, ptToPx, A4HeightPx, type PDFOptions } from "./pdf"
   import { GridRowHeight } from "@/constants"
   import CustomThemeWrapper from "@/components/CustomThemeWrapper.svelte"
 
@@ -10,12 +10,26 @@
 
   export let fileName: string | undefined
   export let buttonText: string | undefined
+  export let marginTop: number | undefined
+  export let marginBottom: number | undefined
+  export let marginLeft: number | undefined
+  export let marginRight: number | undefined
 
   // Derive dimension calculations
   const DesiredRows = 40
-  const innerPageHeightPx = GridRowHeight * DesiredRows
-  const doubleMarginPx = A4HeightPx - innerPageHeightPx
-  const marginPt = pxToPt(doubleMarginPx / 2)
+  const defaultInnerPageHeightPx = GridRowHeight * DesiredRows
+  const defaultDoubleMarginPx = A4HeightPx - defaultInnerPageHeightPx
+  const defaultMarginPt = pxToPt(defaultDoubleMarginPx / 2)
+
+  // Use custom margins if provided, otherwise fall back to defaults
+  $: topPt = marginTop != null ? marginTop : defaultMarginPt
+  $: bottomPt = marginBottom != null ? marginBottom : defaultMarginPt
+  $: leftPt = marginLeft != null ? marginLeft : defaultMarginPt
+  $: rightPt = marginRight != null ? marginRight : defaultMarginPt
+  $: marginPt = [topPt, leftPt, bottomPt, rightPt]
+  $: verticalMarginPx = ptToPx(topPt + bottomPt)
+  $: innerPageHeightPx = A4HeightPx - verticalMarginPx
+  $: doubleMarginPx = verticalMarginPx
 
   let rendering = false
   let pageCount = 1
@@ -25,8 +39,8 @@
   $: safeName = fileName || "Report"
   $: safeButtonText = buttonText || "Download PDF"
   $: heightPx = pageCount * innerPageHeightPx + doubleMarginPx
-  $: pageStyle = `--height:${heightPx}px; --margin:${marginPt}pt;`
-  $: gridMinHeight = pageCount * DesiredRows * GridRowHeight
+  $: pageStyle = `--height:${heightPx}px; --margin-top:${topPt}pt; --margin-right:${rightPt}pt; --margin-bottom:${bottomPt}pt; --margin-left:${leftPt}pt;`
+  $: gridMinHeight = pageCount * Math.floor(innerPageHeightPx / GridRowHeight) * GridRowHeight
 
   const generatePDF = async () => {
     rendering = true
@@ -59,7 +73,8 @@
   }
 
   const getDividerStyle = (idx: number) => {
-    const top = (idx + 1) * innerPageHeightPx + doubleMarginPx / 2
+    const topMarginPx = ptToPx(topPt)
+    const top = (idx + 1) * innerPageHeightPx + topMarginPx
     return `--idx:"${idx + 1}"; --top:${top}px;`
   }
 
@@ -110,7 +125,7 @@
 </script>
 
 <Block>
-  <div class="wrapper" style="--margin:{marginPt}pt;">
+  <div class="wrapper" style="--margin-top:{topPt}pt; --margin-left:{leftPt}pt;">
     <div class="container" use:styleable={$component.styles}>
       <div class="title">
         <Heading size="M">{safeName}</Heading>
@@ -180,7 +195,7 @@
   .page {
     width: 595.28pt;
     min-height: var(--height);
-    padding: var(--margin);
+    padding: var(--margin-top) var(--margin-right) var(--margin-bottom) var(--margin-left);
     background-color: white;
     flex: 0 0 auto;
     display: flex;
@@ -208,7 +223,7 @@
     transform: translateY(-50%);
   }
   .divider.last {
-    top: calc(var(--top) + var(--margin));
+    top: calc(var(--top) + var(--margin-top));
     background: transparent;
   }
 </style>

--- a/packages/client/src/components/app/pdf/pdf.ts
+++ b/packages/client/src/components/app/pdf/pdf.ts
@@ -7,7 +7,7 @@ export const A4HeightPx = ptToPx(841.92) + 1
 
 export interface PDFOptions {
   fileName?: string
-  marginPt?: number
+  marginPt?: number | number[]
   orientation?: "portrait" | "landscape"
   htmlScale?: number
   footer?: boolean
@@ -53,20 +53,24 @@ export async function htmlToPdf(el: HTMLElement, opts: PDFOptions = {}) {
     if (opts.footer) {
       worker.get("pdf").then(pdf => {
         const totalPages = pdf.internal.getNumberOfPages()
+        const marginArr = Array.isArray(options.margin)
+          ? options.margin
+          : [options.margin, options.margin, options.margin, options.margin]
+        const [, marginLeft, marginBottom, marginRight] = marginArr
         for (let i = 1; i <= totalPages; i++) {
           pdf.setPage(i)
           pdf.setFontSize(10)
           pdf.setTextColor(200)
           pdf.text(
             `Page ${i} of ${totalPages}`,
-            pdf.internal.pageSize.getWidth() - options.margin,
-            pdf.internal.pageSize.getHeight() - options.margin / 2,
+            pdf.internal.pageSize.getWidth() - marginRight,
+            pdf.internal.pageSize.getHeight() - marginBottom / 2,
             "right"
           )
           pdf.text(
             options.filename.replace(".pdf", ""),
-            options.margin,
-            pdf.internal.pageSize.getHeight() - options.margin / 2
+            marginLeft,
+            pdf.internal.pageSize.getHeight() - marginBottom / 2
           )
         }
       })


### PR DESCRIPTION
## Description

Adds configurable margin settings (top, bottom, left, right) to the PDF component, allowing users to control the margins of exported PDFs individually.

## Changes

### `packages/client/src/components/app/pdf/PDF.svelte`
- Added `marginTop`, `marginBottom`, `marginLeft`, `marginRight` props
- Updated page layout to use individual CSS margin values instead of uniform margin
- Recalculated inner page height based on custom vertical margins
- Updated divider positioning for multi-page PDFs
- Passes margin array `[top, right, bottom, left]` to `htmlToPdf`

### `packages/client/src/components/app/pdf/pdf.ts`
- Updated `PDFOptions.marginPt` type to accept `number | number[]`
- Updated footer positioning to handle array margins (using individual left/right/bottom values)

### `packages/client/manifest.json`
- Added collapsed "Margins (pt)" section to PDF component settings with Top, Bottom, Left, Right number inputs

## How it works

When no custom margins are provided, the default behavior is preserved (margins calculated to fit 40 grid rows per page, approximately 60pt). When custom margins are set, they override the defaults individually, allowing fine-grained control over the PDF layout.

The `html2pdf.js` library natively supports margin as an array `[top, left, bottom, right]`, so the margin values are passed through directly.

Fixes #17967

---

I have read the CLA Document and I hereby sign the CLA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-side PDF margin controls (Top, Bottom, Left, Right in pt) for precise export layout. Defaults apply when fields are empty.

- New Features
  - PDF.svelte: Added marginTop/Bottom/Left/Right props; per-side CSS padding; inner height/dividers derived from margins; passes [top, left, bottom, right] to htmlToPdf.
  - pdf.ts: marginPt supports number | number[]; footer text uses left/right/bottom margins.
  - manifest.json: Collapsed “Margins (pt)” section with Top/Bottom/Left/Right inputs.

<sup>Written for commit 859ad33b654f5951c4b4672d961c39553205b545. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

