### PR TITLE
Add tags to context

### DIFF
--- a/packages/server/src/sdk/workspace/ai/llm/bbai.ts
+++ b/packages/server/src/sdk/workspace/ai/llm/bbai.ts
@@ -90,7 +90,7 @@ const createBBAIFetch = (sessionId?: string): BBAIFetch => {
         body.metadata = {
           ...body.metadata,
           tags: [
-            `bbai`,
+            `bbai-cloud`,
             `tenant:${context.getTenantId()}`,
             `workspace:${context.getWorkspaceId()}`,
           ],

--- a/packages/server/src/sdk/workspace/ai/llm/bbai.ts
+++ b/packages/server/src/sdk/workspace/ai/llm/bbai.ts
@@ -4,9 +4,11 @@ import type {
   LanguageModelV3StreamPart,
   LanguageModelV3Usage,
 } from "@ai-sdk/provider"
+import tracer from "dd-trace"
 import { quotas } from "@budibase/pro"
 import { wrapLanguageModel } from "ai"
 import { TransformStream } from "node:stream/web"
+import { context } from "@budibase/backend-core"
 import { LLMResponse } from "."
 import environment from "../../../../environment"
 
@@ -53,10 +55,85 @@ export async function incrementBudibaseAICreditsFromOpenAIUsage(
   }
 }
 
-export async function createBBAIClient(model: string): Promise<LLMResponse> {
+type BBAIFetch = (
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1]
+) => ReturnType<typeof fetch>
+
+const createBBAIFetch = (sessionId?: string): BBAIFetch => {
+  const bbaiFetch = (async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1]
+  ) => {
+    let modifiedInit = init
+
+    if (typeof init?.body === "string") {
+      try {
+        const body = JSON.parse(init.body)
+        const span = tracer.scope().active()
+        if (span) {
+          body.metadata = {
+            ...body.metadata,
+            dd_trace_id: span.context().toTraceId(),
+            dd_span_id: span.context().toSpanId(),
+          }
+        }
+
+        if (sessionId) {
+          body.litellm_session_id = sessionId
+          body.metadata = {
+            ...body.metadata,
+            session_id: sessionId,
+          }
+        }
+
+        body.metadata = {
+          ...body.metadata,
+          tags: [
+            `bbai`,
+            `tenant:${context.getTenantId()}`,
+            `workspace:${context.getWorkspaceId()}`,
+          ],
+        }
+
+        modifiedInit = { ...init, body: JSON.stringify(body) }
+      } catch {
+        // Not JSON, pass through
+      }
+    }
+
+    return fetch(input, modifiedInit)
+  }) as BBAIFetch
+
+  // Preserve the preconnect helper required by the OpenAI client typings.
+  if (typeof (fetch as any).preconnect === "function") {
+    ;(bbaiFetch as any).preconnect = (fetch as any).preconnect.bind(fetch)
+  }
+
+  return bbaiFetch
+}
+
+export async function createBBAIClient(
+  model: string,
+  sessionId?: string,
+  span?: tracer.Span
+): Promise<LLMResponse> {
+  const baseUrl = environment.LITELLM_URL
+
+  if (span) {
+    tracer.llmobs.annotate(span, {
+      metadata: {
+        modelId: model,
+        modelName: model,
+        baseUrl,
+      },
+    })
+  }
+
   const client = createOpenAI({
     apiKey: environment.BBAI_LITELLM_KEY,
-    baseURL: environment.LITELLM_URL,
+    baseURL: baseUrl,
+    fetch: createBBAIFetch(sessionId),
   })
   const chat = wrapLanguageModel({
     model: client.chat(model),

--- a/packages/server/src/sdk/workspace/ai/llm/index.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/llm/index.spec.ts
@@ -65,9 +65,13 @@ describe("createLLM", () => {
       const expected = { chat: "chat" }
       createBBAIClientMock.mockResolvedValue(expected as any)
 
-      const result = await createLLM("config-1")
+      const result = await createLLM("config-1", "session-1")
 
-      expect(createBBAIClient).toHaveBeenCalledWith("budibase/gpt-5-mini")
+      expect(createBBAIClient).toHaveBeenCalledWith(
+        "budibase/gpt-5-mini",
+        "session-1",
+        undefined
+      )
       expect(createLiteLLMOpenAI).not.toHaveBeenCalled()
       expect(result).toBe(expected)
     })

--- a/packages/server/src/sdk/workspace/ai/llm/index.ts
+++ b/packages/server/src/sdk/workspace/ai/llm/index.ts
@@ -35,7 +35,7 @@ export async function createLLM(
   }
 
   if (aiConfig.provider === BUDIBASE_AI_PROVIDER_ID && !env.SELF_HOSTED) {
-    return createBBAIClient(aiConfig.model)
+    return createBBAIClient(aiConfig.model, sessionId, span)
   }
 
   return createLiteLLMOpenAI(aiConfig, sessionId, span)

--- a/packages/types/src/api/web/ai.ts
+++ b/packages/types/src/api/web/ai.ts
@@ -38,6 +38,7 @@ export interface ChatCompletionRequestV2 {
   messages: ModelMessage[]
   model: string
   stream?: boolean
+  metadata?: Record<string, string>
 }
 
 export interface ChatCompletionRequest {


### PR DESCRIPTION
## Description
Add better tracking for BBAI

### Tracking by tag
<img width="1277" height="339" alt="image" src="https://github.com/user-attachments/assets/cb8b2d1b-0ae9-4b48-81ed-f0a71029b3ef" />

### Tags in cloud request
<img width="1181" height="98" alt="image" src="https://github.com/user-attachments/assets/7879fa2e-657f-43b6-9ec6-1d701f71e849" />

### Tags in self request
<img width="443" height="102" alt="image" src="https://github.com/user-attachments/assets/ad510278-5e65-4ef3-a546-cb60daf2e923" />





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds request tagging and Datadog tracing to the BBAI client and proxy for better observability and per-session tracking. Cloud and self-hosted paths now attach tenant/workspace tags, session IDs, and trace IDs.

- **New Features**
  - Inject dd_trace_id/dd_span_id and session IDs into request metadata; ChatCompletionRequestV2 now supports a metadata field.
  - Add tags: bbai-cloud (client), bbai-self (proxy), plus tenant:<id> and workspace:<id>.
  - Use a custom fetch (preconnect preserved) to attach tags/metadata and set litellm_session_id/session_id; annotate spans with model and baseUrl; createLLM forwards sessionId/span (tests updated).

<sup>Written for commit 1292642f3cb79f01d39301cf720b0b0deaf47ba5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





