### PR TITLE
fix: chat app title and favicon

### DIFF
--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -319,7 +319,9 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
        * BudibaseApp.svelte file as we can never detect if the types are correct. To get around this
        * I've created a type which expects what the app will expect to receive.
        */
-      const appName = isChatRoute ? "Chat" : workspaceApp?.name || `${appInfo.name}`
+      const appName = isChatRoute
+        ? "Chat"
+        : workspaceApp?.name || `${appInfo.name}`
       const appTitle = isChatRoute ? "Chat" : branding?.platformTitle || appName
       const nonce = ctx.state.nonce || ""
       let props: BudibaseAppProps = {

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -281,7 +281,8 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
   const bbHeaderEmbed =
     ctx.request.get("x-budibase-embed")?.toLowerCase() === "true"
   const normalizedPath = ctx.path.replace(/\/$/, "")
-  const isChatRoute = normalizedPath.startsWith("/app-chat/")
+  const isChatRoute =
+    normalizedPath === "/app-chat" || normalizedPath.startsWith("/app-chat/")
   const [fullyMigrated, settingsConfig, recaptchaConfig] = await Promise.all([
     isWorkspaceFullyMigrated(workspaceId),
     configs.getSettingsConfigDoc(),

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -338,7 +338,7 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
         clientCacheKey: await objectStore.getClientCacheKey(appInfo.version),
         usedPlugins: plugins,
         favicon:
-          branding.faviconUrl !== ""
+          branding.faviconUrl && branding.faviconUrl !== ""
             ? await objectStore.getGlobalFileUrl("settings", "faviconUrl")
             : "",
         appMigrating: !fullyMigrated,

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -340,10 +340,9 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
           : branding?.metaTitle || `${appName} - built with Budibase`,
         clientCacheKey: await objectStore.getClientCacheKey(appInfo.version),
         usedPlugins: plugins,
-        favicon:
-          branding.faviconUrl
-            ? await objectStore.getGlobalFileUrl("settings", "faviconUrl")
-            : "",
+        favicon: branding.faviconUrl
+          ? await objectStore.getGlobalFileUrl("settings", "faviconUrl")
+          : "",
         appMigrating: !fullyMigrated,
         recaptchaKey: recaptchaConfig?.config.siteKey,
         nonce,

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -280,6 +280,8 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
 
   const bbHeaderEmbed =
     ctx.request.get("x-budibase-embed")?.toLowerCase() === "true"
+  const normalizedPath = ctx.path.replace(/\/$/, "")
+  const isChatRoute = normalizedPath.startsWith("/app-chat/")
   const [fullyMigrated, settingsConfig, recaptchaConfig] = await Promise.all([
     isWorkspaceFullyMigrated(workspaceId),
     configs.getSettingsConfigDoc(),
@@ -317,10 +319,11 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
        * BudibaseApp.svelte file as we can never detect if the types are correct. To get around this
        * I've created a type which expects what the app will expect to receive.
        */
-      const appName = workspaceApp?.name || `${appInfo.name}`
+      const appName = isChatRoute ? "Chat" : workspaceApp?.name || `${appInfo.name}`
+      const appTitle = isChatRoute ? "Chat" : branding?.platformTitle || appName
       const nonce = ctx.state.nonce || ""
       let props: BudibaseAppProps = {
-        title: branding?.platformTitle || appName,
+        title: appTitle,
         showSkeletonLoader: appInfo.features?.skeletonLoader ?? false,
         hideDevTools,
         sideNav,
@@ -329,7 +332,9 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
           branding?.metaImageUrl ||
           "https://res.cloudinary.com/daog6scxm/image/upload/v1698759482/meta-images/plain-branded-meta-image-coral_ocxmgu.png",
         metaDescription: branding?.metaDescription || "",
-        metaTitle: branding?.metaTitle || `${appName} - built with Budibase`,
+        metaTitle: isChatRoute
+          ? "Chat"
+          : branding?.metaTitle || `${appName} - built with Budibase`,
         clientCacheKey: await objectStore.getClientCacheKey(appInfo.version),
         usedPlugins: plugins,
         favicon:

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -341,7 +341,7 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
         clientCacheKey: await objectStore.getClientCacheKey(appInfo.version),
         usedPlugins: plugins,
         favicon:
-          branding.faviconUrl && branding.faviconUrl !== ""
+          branding.faviconUrl
             ? await objectStore.getGlobalFileUrl("settings", "faviconUrl")
             : "",
         appMigrating: !fullyMigrated,

--- a/packages/server/src/api/controllers/workspace.ts
+++ b/packages/server/src/api/controllers/workspace.ts
@@ -483,14 +483,18 @@ export async function fetchAppPackage(
     // disabled workspace apps should appear to not exist
     // if the dev workspace is being served, allow the request regardless
     if (
-      !matchedWorkspaceApp ||
-      (matchedWorkspaceApp.disabled && !isDev && !isChatRoute)
+      (!matchedWorkspaceApp && !isChatRoute) ||
+      (matchedWorkspaceApp?.disabled && !isDev && !isChatRoute)
     ) {
       ctx.throw("No matching workspace app found for URL path: " + urlPath, 404)
     }
-    screens = screens.filter(s => s.workspaceAppId === matchedWorkspaceApp._id)
 
-    application.navigation = matchedWorkspaceApp.navigation
+    if (matchedWorkspaceApp) {
+      screens = screens.filter(s => s.workspaceAppId === matchedWorkspaceApp._id)
+      application.navigation = matchedWorkspaceApp.navigation
+    } else {
+      screens = []
+    }
   }
 
   const clientLibPath = await objectStore.clientLibraryUrl(

--- a/packages/server/src/api/controllers/workspace.ts
+++ b/packages/server/src/api/controllers/workspace.ts
@@ -483,8 +483,8 @@ export async function fetchAppPackage(
     // disabled workspace apps should appear to not exist
     // if the dev workspace is being served, allow the request regardless
     if (
-      (!matchedWorkspaceApp && !isChatRoute) ||
-      (matchedWorkspaceApp?.disabled && !isDev && !isChatRoute)
+      !isChatRoute &&
+      (!matchedWorkspaceApp || (matchedWorkspaceApp.disabled && !isDev))
     ) {
       ctx.throw("No matching workspace app found for URL path: " + urlPath, 404)
     }

--- a/packages/server/src/api/controllers/workspace.ts
+++ b/packages/server/src/api/controllers/workspace.ts
@@ -490,7 +490,9 @@ export async function fetchAppPackage(
     }
 
     if (matchedWorkspaceApp) {
-      screens = screens.filter(s => s.workspaceAppId === matchedWorkspaceApp._id)
+      screens = screens.filter(
+        s => s.workspaceAppId === matchedWorkspaceApp._id
+      )
       application.navigation = matchedWorkspaceApp.navigation
     } else {
       screens = []

--- a/packages/server/src/api/routes/tests/workspace.spec.ts
+++ b/packages/server/src/api/routes/tests/workspace.spec.ts
@@ -1138,6 +1138,38 @@ describe("/applications", () => {
             )
           )
         })
+
+        it("should allow chat route app package when no workspace apps exist", async () => {
+          await config.publish()
+
+          await context.doInWorkspaceContext(config.getProdWorkspaceId(), async () => {
+            const workspaceApps = await sdk.workspaceApps.fetch()
+            for (const workspaceApp of workspaceApps) {
+              await sdk.workspaceApps.remove(workspaceApp._id!, workspaceApp._rev!)
+            }
+          })
+
+          await config.withProdApp(() =>
+            config.withHeaders(
+              {
+                referer: `http://localhost:10000/app-chat${config.prodWorkspace?.url}`,
+              },
+              async () => {
+                const res = await config.api.workspace.getAppPackage(
+                  config.getDevWorkspaceId(),
+                  {
+                    headers: {
+                      [Header.TYPE]: "client",
+                    },
+                  }
+                )
+
+                expect(res.application).toBeDefined()
+                expect(res.screens).toEqual([])
+              }
+            )
+          )
+        })
       })
     })
   })

--- a/packages/server/src/api/routes/tests/workspace.spec.ts
+++ b/packages/server/src/api/routes/tests/workspace.spec.ts
@@ -1142,12 +1142,18 @@ describe("/applications", () => {
         it("should allow chat route app package when no workspace apps exist", async () => {
           await config.publish()
 
-          await context.doInWorkspaceContext(config.getProdWorkspaceId(), async () => {
-            const workspaceApps = await sdk.workspaceApps.fetch()
-            for (const workspaceApp of workspaceApps) {
-              await sdk.workspaceApps.remove(workspaceApp._id!, workspaceApp._rev!)
+          await context.doInWorkspaceContext(
+            config.getProdWorkspaceId(),
+            async () => {
+              const workspaceApps = await sdk.workspaceApps.fetch()
+              for (const workspaceApp of workspaceApps) {
+                await sdk.workspaceApps.remove(
+                  workspaceApp._id!,
+                  workspaceApp._rev!
+                )
+              }
             }
-          })
+          )
 
           await config.withProdApp(() =>
             config.withHeaders(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes chat app routing and branding so chat pages always show “Chat” for title/metaTitle and use the right favicon, independent of workspace apps. Prevents branding conflation and lets the chat app load even when no workspace apps exist.

- **Bug Fixes**
  - Detect /app-chat and /app-chat/* (normalize trailing slashes) and force appName/title/metaTitle to “Chat”.
  - Allow chat app to boot with no workspace apps; return empty screens and skip workspace navigation; added test.
  - Only include favicon when branding.faviconUrl is set to avoid blank or incorrect icons.

<sup>Written for commit 4c8b8d4b3ea583ba431dfdcfb84774d35401bed5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

