### PR TITLE
views security issue

### DIFF
--- a/packages/server/src/api/controllers/view/tests/viewBuilder.spec.ts
+++ b/packages/server/src/api/controllers/view/tests/viewBuilder.spec.ts
@@ -49,6 +49,43 @@ describe("viewBuilder", () => {
         },
       })
     })
+
+    it("escapes filter keys and values in generated expressions", () => {
+      const payload = `x" ); globalThis.pwned = true; ("`
+      const key = `Name"] ; globalThis.pwned = true; //`
+
+      const view = viewTemplate({
+        field: "myField",
+        tableId: "tableId",
+        filters: [
+          {
+            value: payload,
+            condition: "EQUALS",
+            key,
+          },
+        ],
+      })
+
+      expect(view.map).toContain(
+        `doc["Name\\"] ; globalThis.pwned = true; //"] === "x\\" ); globalThis.pwned = true; (\\""`
+      )
+    })
+
+    it("throws for unknown filter conditions", () => {
+      expect(() =>
+        viewTemplate({
+          field: "myField",
+          tableId: "tableId",
+          filters: [
+            {
+              value: "test",
+              condition: "BAD_TOKEN" as any,
+              key: "Name",
+            },
+          ],
+        })
+      ).toThrow("Invalid filter condition")
+    })
   })
 
   describe("Calculate", () => {

--- a/packages/server/src/api/controllers/view/utils.ts
+++ b/packages/server/src/api/controllers/view/utils.ts
@@ -15,6 +15,10 @@ import {
 import env from "../../../environment"
 import viewBuilder from "./viewBuilder"
 
+function getGroupByMulti(meta: any): boolean {
+  return meta?.groupByMulti ?? (meta?.schema?.group?.type === "array")
+}
+
 export async function getView(viewName: string) {
   const db = context.getWorkspaceDB()
   if (env.SELF_HOSTED) {
@@ -143,7 +147,7 @@ export async function migrateToInMemoryView(db: Database, viewName: string) {
     throw new Error("Unable to migrate view - no metadata")
   }
   // run the view back through the view builder to update it
-  const view = viewBuilder(meta)
+  const view = viewBuilder(meta, getGroupByMulti(meta))
   delete designDoc.views?.[viewName]
   await db.put(designDoc)
   await saveView(null, viewName, view)
@@ -159,7 +163,7 @@ export async function migrateToDesignView(db: Database, viewName: string) {
   if (!designDoc.views) {
     designDoc.views = {}
   }
-  designDoc.views[viewName] = viewBuilder(meta)
+  designDoc.views[viewName] = viewBuilder(meta, getGroupByMulti(meta))
   await db.put(designDoc)
   await db.remove(view._id!, view._rev)
 }

--- a/packages/server/src/api/controllers/view/utils.ts
+++ b/packages/server/src/api/controllers/view/utils.ts
@@ -16,7 +16,7 @@ import env from "../../../environment"
 import viewBuilder from "./viewBuilder"
 
 function getGroupByMulti(meta: any): boolean {
-  return meta?.groupByMulti ?? (meta?.schema?.group?.type === "array")
+  return meta?.groupByMulti ?? meta?.schema?.group?.type === "array"
 }
 
 export async function getView(viewName: string) {

--- a/packages/server/src/api/controllers/view/viewBuilder.ts
+++ b/packages/server/src/api/controllers/view/viewBuilder.ts
@@ -208,6 +208,7 @@ export default function (
       filters,
       schema,
       calculation,
+      ...(groupByMulti ? { groupByMulti } : {}),
     },
     map: `function (doc) {
       if (${coreExpression} ${filterExpression}) {

--- a/packages/server/src/api/controllers/view/viewBuilder.ts
+++ b/packages/server/src/api/controllers/view/viewBuilder.ts
@@ -118,9 +118,7 @@ function parseFilterExpression(filters: ViewFilter[]) {
       const condition = tokenOrThrow("condition", filter.condition)
       const value = JSON.stringify(filter.value)
 
-      expression.push(
-        `${docKeyExpression(filter.key)} ${condition} ${value}`
-      )
+      expression.push(`${docKeyExpression(filter.key)} ${condition} ${value}`)
     }
     first = false
   }

--- a/packages/server/src/api/routes/view.ts
+++ b/packages/server/src/api/routes/view.ts
@@ -10,17 +10,16 @@ import { permissions } from "@budibase/backend-core"
 import { builderRoutes, publicRoutes } from "./endpointGroups"
 import env from "../../environment"
 
-publicRoutes
-  .get(
-    "/api/v2/views/:viewId",
-    recaptcha,
-    authorizedResource(
-      permissions.PermissionType.VIEW,
-      permissions.PermissionLevel.READ,
-      "viewId"
-    ),
-    viewController.v2.get
-  )
+publicRoutes.get(
+  "/api/v2/views/:viewId",
+  recaptcha,
+  authorizedResource(
+    permissions.PermissionType.VIEW,
+    permissions.PermissionLevel.READ,
+    "viewId"
+  ),
+  viewController.v2.get
+)
 
 builderRoutes
   .get("/api/v2/views", viewController.v2.fetch)

--- a/packages/server/src/api/routes/view.ts
+++ b/packages/server/src/api/routes/view.ts
@@ -8,6 +8,7 @@ import {
 import { paramResource } from "../../middleware/resourceId"
 import { permissions } from "@budibase/backend-core"
 import { builderRoutes, publicRoutes } from "./endpointGroups"
+import env from "../../environment"
 
 publicRoutes
   .get(
@@ -20,7 +21,15 @@ publicRoutes
     ),
     viewController.v2.get
   )
-  .get(
+
+builderRoutes
+  .get("/api/v2/views", viewController.v2.fetch)
+  .post("/api/v2/views", viewController.v2.create)
+  .put(`/api/v2/views/:viewId`, viewController.v2.update)
+  .delete(`/api/v2/views/:viewId`, viewController.v2.remove)
+
+if (env.SELF_HOSTED) {
+  publicRoutes.get(
     "/api/views/:viewName",
     recaptcha,
     paramResource("viewName"),
@@ -31,16 +40,13 @@ publicRoutes
     rowController.fetchLegacyView
   )
 
-builderRoutes
-  .get("/api/v2/views", viewController.v2.fetch)
-  .post("/api/v2/views", viewController.v2.create)
-  .put(`/api/v2/views/:viewId`, viewController.v2.update)
-  .delete(`/api/v2/views/:viewId`, viewController.v2.remove)
-  .get("/api/views/export", viewController.v1.exportView)
-  .get("/api/views", viewController.v1.fetch)
-  .delete(
-    "/api/views/:viewName",
-    paramResource("viewName"),
-    viewController.v1.destroy
-  )
-  .post("/api/views", viewController.v1.save)
+  builderRoutes
+    .get("/api/views/export", viewController.v1.exportView)
+    .get("/api/views", viewController.v1.fetch)
+    .delete(
+      "/api/views/:viewName",
+      paramResource("viewName"),
+      viewController.v1.destroy
+    )
+    .post("/api/views", viewController.v1.save)
+}

--- a/packages/server/src/db/inMemoryView.ts
+++ b/packages/server/src/db/inMemoryView.ts
@@ -31,7 +31,7 @@ export async function runView(
 
     // Rebuild map/reduce from metadata to avoid executing untrusted map strings.
     const groupByMulti =
-      view.meta.groupByMulti ?? (view.meta.schema?.group?.type === "array")
+      view.meta.groupByMulti ?? view.meta.schema?.group?.type === "array"
     const rebuiltView = viewBuilder(view.meta as any, groupByMulti)
     let fn = (doc: Document, emit: any) => emit(doc._id)
     // BUDI-7060 -> indirect eval call appears to cause issues in cloud

--- a/packages/server/src/db/inMemoryView.ts
+++ b/packages/server/src/db/inMemoryView.ts
@@ -30,7 +30,9 @@ export async function runView(
     }
 
     // Rebuild map/reduce from metadata to avoid executing untrusted map strings.
-    const rebuiltView = viewBuilder(view.meta as any)
+    const groupByMulti =
+      view.meta.groupByMulti ?? (view.meta.schema?.group?.type === "array")
+    const rebuiltView = viewBuilder(view.meta as any, groupByMulti)
     let fn = (doc: Document, emit: any) => emit(doc._id)
     // BUDI-7060 -> indirect eval call appears to cause issues in cloud
     eval(


### PR DESCRIPTION
## Description
Fix an issue with views v1 security 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a views v1 security vulnerability by sanitizing filter expressions and rebuilding map/reduce from metadata to avoid executing untrusted code. Disables legacy v1 view endpoints on cloud.

- **Bug Fixes**
  - Escape filter keys/values with JSON.stringify and use a safe docKeyExpression for key access, emit, and tableId.
  - Validate filter conditions/conjunctions with token checks; throw on invalid tokens.
  - Rebuild map/reduce from view metadata in inMemoryView; stop using stored map strings directly. Throw when legacy metadata is missing.
  - Gate legacy v1 endpoints behind env.SELF_HOSTED; disable public and builder v1 routes on cloud.
  - Preserve multi-grouping by detecting array group fields and carrying groupByMulti through viewBuilder and migrations.

<sup>Written for commit 2a7871d71d1d1b7946512f097df5f7cc891c1528. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

