### PR TITLE
back out route disabling

### DIFF
--- a/packages/server/src/api/routes/view.ts
+++ b/packages/server/src/api/routes/view.ts
@@ -8,7 +8,6 @@ import {
 import { paramResource } from "../../middleware/resourceId"
 import { permissions } from "@budibase/backend-core"
 import { builderRoutes, publicRoutes } from "./endpointGroups"
-import env from "../../environment"
 
 publicRoutes.get(
   "/api/v2/views/:viewId",
@@ -20,32 +19,27 @@ publicRoutes.get(
   ),
   viewController.v2.get
 )
+publicRoutes.get(
+  "/api/views/:viewName",
+  recaptcha,
+  paramResource("viewName"),
+  authorized(
+    permissions.PermissionType.TABLE,
+    permissions.PermissionLevel.READ
+  ),
+  rowController.fetchLegacyView
+)
 
 builderRoutes
   .get("/api/v2/views", viewController.v2.fetch)
   .post("/api/v2/views", viewController.v2.create)
   .put(`/api/v2/views/:viewId`, viewController.v2.update)
   .delete(`/api/v2/views/:viewId`, viewController.v2.remove)
-
-if (env.SELF_HOSTED) {
-  publicRoutes.get(
+  .get("/api/views/export", viewController.v1.exportView)
+  .get("/api/views", viewController.v1.fetch)
+  .delete(
     "/api/views/:viewName",
-    recaptcha,
     paramResource("viewName"),
-    authorized(
-      permissions.PermissionType.TABLE,
-      permissions.PermissionLevel.READ
-    ),
-    rowController.fetchLegacyView
+    viewController.v1.destroy
   )
-
-  builderRoutes
-    .get("/api/views/export", viewController.v1.exportView)
-    .get("/api/views", viewController.v1.fetch)
-    .delete(
-      "/api/views/:viewName",
-      paramResource("viewName"),
-      viewController.v1.destroy
-    )
-    .post("/api/views", viewController.v1.save)
-}
+  .post("/api/views", viewController.v1.save)


### PR DESCRIPTION
## Description
turns out, views v1 might actually still be in use. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored Views v1 routes in all environments to prevent breakage for users still relying on them. The public legacy endpoint keeps reCAPTCHA and READ TABLE auth for security.

- **Bug Fixes**
  - Re-enabled public GET /api/views/:viewName with reCAPTCHA and READ TABLE authorization.
  - Exposed v1 builder routes globally by removing the SELF_HOSTED guard: GET /api/views, GET /api/views/export, DELETE /api/views/:viewName, POST /api/views.

<sup>Written for commit 29656f7adfb5ae70346e4025d9d78372d261f19f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

