### PR TITLE
Fix permissions issue on single image with new postgres db

### DIFF
--- a/hosting/single/litellm-db-runner.sh
+++ b/hosting/single/litellm-db-runner.sh
@@ -20,6 +20,7 @@ fi
 
 mkdir -p "${POSTGRES_DATA_DIR}"
 chown -R postgres:postgres "${POSTGRES_DATA_DIR}"
+chmod 700 "${POSTGRES_DATA_DIR}"
 
 if [[ ! -f "${POSTGRES_DATA_DIR}/PG_VERSION" ]]; then
     echo "Initializing LiteLLM postgres data directory at ${POSTGRES_DATA_DIR}..."

--- a/packages/cli/src/hosting/index.ts
+++ b/packages/cli/src/hosting/index.ts
@@ -12,7 +12,7 @@ export default new Command(`${CommandWord.HOSTING}`)
   .addHelp("Controls self hosting on the Budibase platform.")
   .addSubOption(
     "--init [type]",
-    "Configure a self hosted platform in current directory, type can be unspecified, 'quick' or 'single'.",
+    "Configure a self hosted platform in current directory, type can be unspecified, 'quick' or 'do'. Use --single for a single-image deployment.",
     init
   )
   .addSubOption(
@@ -47,5 +47,5 @@ export default new Command(`${CommandWord.HOSTING}`)
   )
   .addSubOption(
     "--single",
-    "Specify this with init or update to target a single-image deployment."
+    "Specify this with init or update to target a single-image deployment (also supports --init single)."
   )

--- a/packages/cli/src/hosting/init.ts
+++ b/packages/cli/src/hosting/init.ts
@@ -37,9 +37,10 @@ export async function init(opts: any) {
   let type, isSingle, watchDir, genUser, port, silent
   if (typeof opts === "string") {
     type = opts
+    isSingle = type === "single"
   } else {
     type = opts["init"]
-    isSingle = opts["single"]
+    isSingle = opts["single"] || type === "single"
     watchDir = opts["watchPluginDir"]
     genUser = opts["genUser"]
     port = opts["port"]
@@ -48,8 +49,11 @@ export async function init(opts: any) {
   const isQuick = type === InitType.QUICK || type === InitType.DIGITAL_OCEAN
   await checkDockerConfigured()
   if (!isQuick) {
+    const message = isSingle
+      ? "This will create a single-image docker-compose.yaml in current directory, should continue?"
+      : "This will create multiple files in current directory, should continue?"
     const shouldContinue = await confirmation(
-      "This will create multiple files in current directory, should continue?"
+      message
     )
     if (!shouldContinue) {
       console.log("Stopping.")


### PR DESCRIPTION
## Description
Fix single image postgres problems, mounts had incorrect permissions

Also improves messaging in budi cli. 

## Launchcontrol

- Fix permissions issue with postgres in the single image

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Postgres startup in single-image deployments by enforcing secure data dir permissions and robust .env parsing. Also clarifies CLI help and lets you select single-image via --init single or --single.

- **Bug Fixes**
  - Enforce secure ownership and 700 permissions for Postgres data dirs (${POSTGRES_DATA_DIR}, ${DATA_DIR}/litellm/postgres).
  - Normalize and safely source ${DATA_DIR}/.env (CRLF→LF, ensure trailing newline, use set -a).

- **New Features**
  - Support selecting single-image via --init single or --single, with clearer help and confirmation text.

<sup>Written for commit a28bffaeb7878e3abdc5592ba15ce241a67d455a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



