### PR TITLE
feat: remove chat apps menu item

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
@@ -615,21 +615,6 @@
                       </div>
                     </svelte:fragment>
                   </SideNavLink>
-                  {#if $featureFlags.AI_CHAT}
-                    <SideNavLink
-                      icon="chat-circle"
-                      text="Chat"
-                      url={$url("./chat")}
-                      {collapsed}
-                      on:click={keepCollapsed}
-                    >
-                      <svelte:fragment slot="right">
-                        <div class="beta-tag-wrapper">
-                          <Tag emphasized>Alpha</Tag>
-                        </div>
-                      </svelte:fragment>
-                    </SideNavLink>
-                  {/if}
                 {/if}
               {/if}
             </div>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/DeploymentChannels/AgentChatChannel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/DeploymentChannels/AgentChatChannel.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { Body } from "@budibase/bbui"
+  import BBAILogo from "assets/bb-ai.svg"
+</script>
+
+<div class="integration-row">
+  <div class="channel-main">
+    <img alt="Agent Chat" width="22px" height="22px" src={BBAILogo} />
+    <div class="channel-details">
+      <Body color={"var(--spectrum-global-color-gray-900)"} size="XS"
+        >Agent Chat</Body
+      >
+      <Body color={"var(--spectrum-global-color-gray-700)"} size="XS"
+        >An out-of-the-box chat application for AI agents</Body
+      >
+    </div>
+  </div>
+  <div class="row-action"></div>
+</div>
+
+<style>
+  .integration-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: var(--spacing-m);
+    padding: var(--spacing-s) var(--spacing-s);
+    border-bottom: 1px solid var(--spectrum-global-color-gray-200);
+    height: 40px;
+  }
+
+  .channel-main {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    min-width: 0;
+  }
+
+  .channel-details {
+    display: flex;
+    flex-direction: column;
+    margin-left: var(--spacing-m);
+  }
+
+  .row-action {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    min-width: 110px;
+    gap: 10px;
+    margin-left: 0px;
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/deployment.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/deployment.svelte
@@ -241,6 +241,18 @@
     color: var(--spectrum-global-color-gray-700);
   }
 
+  .status-chip {
+    font-weight: 500;
+  }
+
+  .status-chip.enabled {
+    color: var(--spectrum-semantic-positive-status-color);
+  }
+
+  .status-chip.disabled {
+    color: var(--spectrum-global-color-gray-600);
+  }
+
   .channel-details {
     display: flex;
     flex-direction: column;

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/deployment.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/deployment.svelte
@@ -9,8 +9,8 @@
   } from "@budibase/bbui"
   import { FeatureFlag, type Agent, type DeploymentRow } from "@budibase/types"
   import { selectedAgent, agentsStore, featureFlags } from "@/stores/portal"
+  import AgentChatChannel from "./DeploymentChannels/AgentChatChannel.svelte"
   import DiscordConfig from "./DeploymentChannels/DiscordConfig.svelte"
-  import BBAILogo from "assets/bb-ai.svg"
   import DiscordLogo from "assets/discord.svg"
 
   const AI_CONFIG_REQUIRED_MESSAGE =
@@ -37,30 +37,16 @@
   const hasAiConfig = $derived.by(() => !!currentAgent?.aiconfig?.trim())
   const agentChatEnabled = $derived(!!$featureFlags[FeatureFlag.AI_CHAT])
 
-  const channels = $derived.by<DeploymentRow[]>(() => {
-    const rows: DeploymentRow[] = [
-      {
-        id: "discord",
-        name: "Discord",
-        logo: DiscordLogo,
-        status: discordEnabled ? "Enabled" : "Disabled",
-        details: "Allow this agent to respond in Discord channels and threads",
-        configurable: true,
-      },
-    ]
-
-    if (agentChatEnabled) {
-      rows.unshift({
-        id: "agent-chat",
-        name: "Agent Chat",
-        logo: BBAILogo,
-        status: "Enabled",
-        details: "An out-of-the-box chat application for AI agents",
-      })
-    }
-
-    return rows
-  })
+  const channels = $derived.by<DeploymentRow[]>(() => [
+    {
+      id: "discord",
+      name: "Discord",
+      logo: DiscordLogo,
+      status: discordEnabled ? "Enabled" : "Disabled",
+      details: "Allow this agent to respond in Discord channels and threads",
+      configurable: true,
+    },
+  ])
 
   const onConfigureChannel = (channel: DeploymentRow) => {
     if (channel.id === "discord") {
@@ -133,6 +119,9 @@
       >
     </div>
     <div class="integration-list">
+      {#if agentChatEnabled}
+        <AgentChatChannel />
+      {/if}
       {#each channels as channel (channel.id)}
         <div class="integration-row">
           <div class="channel-main">

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/deployment.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/deployment.svelte
@@ -141,20 +141,17 @@
             </div>
           </div>
           <div class="row-action">
-            {#if channel.configurable}
-              <ActionButton
-                size="S"
-                icon="gear"
-                accentColor="Blue"
-                on:click={() => onConfigureChannel(channel)}
-                >Manage</ActionButton
-              >
-              <Toggle
-                value={channel.status === "Enabled"}
-                disabled={toggling}
-                on:change={() => onToggleChannel(channel)}
-              />
-            {/if}
+            <ActionButton
+              size="S"
+              icon="gear"
+              accentColor="Blue"
+              on:click={() => onConfigureChannel(channel)}>Manage</ActionButton
+            >
+            <Toggle
+              value={channel.status === "Enabled"}
+              disabled={toggling}
+              on:change={() => onToggleChannel(channel)}
+            />
           </div>
         </div>
       {/each}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved Agent Chat from the side menu to the agent Deployment Channels list behind the AI_CHAT feature flag for clearer, contextual access.

- **New Features**
  - Added AgentChatChannel component with logo and description in the deployment page (shown when AI_CHAT is enabled).

- **Refactors**
  - Removed Chat link from the workspace SideNav.
  - Reverted unrelated changes to keep CSS intact.

<sup>Written for commit 4b155498275034cc87168232d631afd30f71f24b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

