### PR TITLE
fix: Legacy OpenAI config usages were broken

### DIFF
--- a/packages/builder/src/settings/pages/ai/constants.ts
+++ b/packages/builder/src/settings/pages/ai/constants.ts
@@ -29,7 +29,7 @@ export const ProviderDetails: Partial<Record<AIProvider, AIProviderDetails>> = {
       provider: "OpenAI",
       active: false,
       isDefault: false,
-      baseUrl: "https://api.openai.com",
+      baseUrl: "https://api.openai.com/v1",
     },
     models: Models,
   },
@@ -47,7 +47,7 @@ export const ProviderDetails: Partial<Record<AIProvider, AIProviderDetails>> = {
 export const ConfigMap = {
   OpenAI: {
     name: "OpenAI",
-    baseUrl: "https://api.openai.com",
+    baseUrl: "https://api.openai.com/v1",
   },
   Anthropic: {
     name: "Anthropic",

--- a/packages/server/src/sdk/workspace/ai/llm/legacy.ts
+++ b/packages/server/src/sdk/workspace/ai/llm/legacy.ts
@@ -7,6 +7,13 @@ import { LLMResponse } from "."
 import { ai, licensing } from "@budibase/pro"
 import { createBBAIClient } from "./bbai"
 
+const normalizeLegacyOpenAIBaseUrl = (baseUrl?: string) => {
+  if (!baseUrl) return baseUrl
+  const normalised =
+    baseUrl === "https://api.openai.com" ? "https://api.openai.com/v1" : baseUrl
+  return normalised
+}
+
 const getLegacyProviderClient = async (
   provider: AIProvider,
   config: LLMProviderConfig
@@ -17,6 +24,10 @@ const getLegacyProviderClient = async (
 
   switch (provider) {
     case "OpenAI":
+      return createOpenAI({
+        baseURL: normalizeLegacyOpenAIBaseUrl(config.baseUrl),
+        apiKey: config.apiKey,
+      })
     case "TogetherAI":
     case "Custom":
       return createOpenAI({


### PR DESCRIPTION
## Description
Fix an issue where legacy ai was broken for users with OpenAI configs. 
## Addresses
#18096

## Launchcontrol
- Fix an issue with legacy OpenAI configs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken legacy provider configs by normalizing base URLs (adds /v1, trims trailing slashes) and updating defaults, restoring chat and embedding functionality. Addresses #18096.

- **Bug Fixes**
  - Normalize base URLs for OpenAI, Anthropic, TogetherAI, and Custom; add /v1 when missing, trim trailing slashes, and leave unchanged when /v1 already exists.
  - Update builder defaults to https://api.openai.com/v1 to prevent misconfiguration.

<sup>Written for commit 1dfffd22d9e95e6f4563cbeabf1574c4b2895cd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



