### PR TITLE
fix(groups): resolve assign-user popover not reopening

### DIFF
--- a/packages/builder/src/settings/pages/people/groups/_components/EditUserPicker.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/EditUserPicker.svelte
@@ -42,7 +42,7 @@
 </script>
 
 <div bind:this={popoverAnchor}>
-  <Button on:click={popover.show()} cta>Add user</Button>
+  <Button on:click={() => popover?.show()} cta>Add user</Button>
 </div>
 <Popover align="left" bind:this={popover} anchor={popoverAnchor}>
   <UserGroupPicker


### PR DESCRIPTION
## Description
Fixes #18104.

Fixes a UI bug on the group settings page where the `Add user`/`Assign user` popover stops opening after the first interaction.

Root cause: the button used `on:click={popover.show()}`, which invokes `show()` immediately during render rather than on click.

Fix: update the click binding to `on:click={() => popover?.show()}` so the popover opens reliably on each click.

## Addresses
- https://github.com/Budibase/budibase/issues/18104

## Launchcontrol
Fixes the group user assignment button so admins can repeatedly open the assign-user dropdown without it becoming unresponsive.


