### PR TITLE
Automation ai steps on new llm

### DIFF
--- a/packages/server/src/automations/steps/ai/classify.ts
+++ b/packages/server/src/automations/steps/ai/classify.ts
@@ -4,6 +4,7 @@ import {
   ClassifyContentStepInputs,
   ClassifyContentStepOutputs,
 } from "@budibase/types"
+import { promptWithDefaultLLM } from "./llm"
 
 export async function run({
   inputs,
@@ -23,14 +24,11 @@ export async function run({
   }
 
   try {
-    const llm = await ai.getLLMOrThrow()
-
-    const categories = inputs.categoryItems!.map(item => item.category)
+    const categories = inputs.categoryItems.map(item => item.category)
 
     const request = ai.classifyText(inputs.textInput, categories)
-
-    const llmResponse = await llm.prompt(request)
-    const determinedCategory = llmResponse?.message?.trim()
+    const llmResponse = await promptWithDefaultLLM(request.messages)
+    const determinedCategory = llmResponse?.trim()
 
     if (determinedCategory && categories.includes(determinedCategory)) {
       return {

--- a/packages/server/src/automations/steps/ai/generate.ts
+++ b/packages/server/src/automations/steps/ai/generate.ts
@@ -6,6 +6,7 @@ import {
   ContentType,
 } from "@budibase/types"
 import { utils } from "@budibase/shared-core"
+import { promptWithDefaultLLM } from "./llm"
 
 export async function run({
   inputs,
@@ -21,8 +22,6 @@ export async function run({
   }
 
   try {
-    const llm = await ai.getLLMOrThrow()
-
     const contentTypePrompt = getContentTypePrompt(
       inputs.contentType as ContentType
     )
@@ -35,8 +34,8 @@ Instructions: ${inputs.instructions}
 Generate the content based on these instructions. Format appropriately for a ${inputs.contentType}.`
     )
 
-    const llmResponse = await llm.prompt(request)
-    const generatedText = llmResponse?.message?.trim()
+    const llmResponse = await promptWithDefaultLLM(request.messages)
+    const generatedText = llmResponse?.trim()
 
     if (generatedText) {
       return {

--- a/packages/server/src/automations/steps/ai/llm.ts
+++ b/packages/server/src/automations/steps/ai/llm.ts
@@ -1,21 +1,7 @@
-import { Message } from "@budibase/types"
-import { generateText, type ModelMessage } from "ai"
+import type { Message } from "@budibase/types"
+import { generateText } from "ai"
 import sdk from "../../../sdk"
-
-function toModelMessages(messages: Message[]): ModelMessage[] {
-  return messages.map<ModelMessage>(message => {
-    if (typeof message.content !== "string") {
-      throw new Error("AI message content must be a string")
-    }
-    if (message.role === "tool") {
-      throw new Error("AI tool messages are not supported")
-    }
-    return {
-      role: message.role as Exclude<ModelMessage["role"], "tool">,
-      content: message.content,
-    }
-  })
-}
+import { toModelMessages } from "../../../sdk/workspace/ai/llm/messages"
 
 export async function promptWithDefaultLLM(messages: Message[]) {
   const { chat, providerOptions } = await sdk.ai.llm.getDefaultLLMOrThrow()

--- a/packages/server/src/automations/steps/ai/llm.ts
+++ b/packages/server/src/automations/steps/ai/llm.ts
@@ -1,0 +1,28 @@
+import { Message } from "@budibase/types"
+import { generateText, type ModelMessage } from "ai"
+import sdk from "../../../sdk"
+
+function toModelMessages(messages: Message[]): ModelMessage[] {
+  return messages.map<ModelMessage>(message => {
+    if (typeof message.content !== "string") {
+      throw new Error("AI message content must be a string")
+    }
+    if (message.role === "tool") {
+      throw new Error("AI tool messages are not supported")
+    }
+    return {
+      role: message.role as Exclude<ModelMessage["role"], "tool">,
+      content: message.content,
+    }
+  })
+}
+
+export async function promptWithDefaultLLM(messages: Message[]) {
+  const { chat, providerOptions } = await sdk.ai.llm.getDefaultLLMOrThrow()
+  const response = await generateText({
+    model: chat,
+    messages: toModelMessages(messages),
+    providerOptions: providerOptions?.(false),
+  })
+  return response.text
+}

--- a/packages/server/src/automations/steps/ai/promptLLM.ts
+++ b/packages/server/src/automations/steps/ai/promptLLM.ts
@@ -1,6 +1,7 @@
 import { PromptLLMStepInputs, PromptLLMStepOutputs } from "@budibase/types"
 import * as automationUtils from "../../automationUtils"
 import { ai } from "@budibase/pro"
+import { promptWithDefaultLLM } from "./llm"
 
 export async function run({
   inputs,
@@ -15,10 +16,10 @@ export async function run({
   }
 
   try {
-    const llm = await ai.getLLM()
-    const response = await llm?.prompt(inputs.prompt)
+    const request = new ai.LLMRequest().addUserMessage(inputs.prompt)
+    const response = await promptWithDefaultLLM(request.messages)
     return {
-      response: response?.message,
+      response,
       success: true,
     }
   } catch (err) {

--- a/packages/server/src/automations/steps/ai/summarise.ts
+++ b/packages/server/src/automations/steps/ai/summarise.ts
@@ -1,6 +1,7 @@
 import { SummariseStepInputs, SummariseStepOutputs } from "@budibase/types"
 import * as automationUtils from "../../automationUtils"
 import { ai } from "@budibase/pro"
+import { promptWithDefaultLLM } from "./llm"
 
 export async function run({
   inputs,
@@ -15,12 +16,10 @@ export async function run({
   }
 
   try {
-    const llm = await ai.getLLMOrThrow()
     const request = ai.summarizeText(inputs.text, inputs.length)
-
-    const response = await llm?.prompt(request)
+    const response = await promptWithDefaultLLM(request.messages)
     return {
-      response: response?.message,
+      response,
       success: true,
     }
   } catch (err) {

--- a/packages/server/src/automations/steps/ai/translate.ts
+++ b/packages/server/src/automations/steps/ai/translate.ts
@@ -1,6 +1,7 @@
 import { TranslateStepInputs, TranslateStepOutputs } from "@budibase/types"
 import * as automationUtils from "../../automationUtils"
 import { ai } from "@budibase/pro"
+import { promptWithDefaultLLM } from "./llm"
 
 export async function run({
   inputs,
@@ -15,12 +16,10 @@ export async function run({
   }
 
   try {
-    const llm = await ai.getLLMOrThrow()
     const request = ai.translate(inputs.text, inputs.language)
-
-    const response = await llm?.prompt(request)
+    const response = await promptWithDefaultLLM(request.messages)
     return {
-      response: response?.message,
+      response,
       success: true,
     }
   } catch (err) {

--- a/packages/server/src/sdk/workspace/ai/llm/messages.ts
+++ b/packages/server/src/sdk/workspace/ai/llm/messages.ts
@@ -1,0 +1,17 @@
+import type { Message } from "@budibase/types"
+import type { ModelMessage } from "ai"
+
+export function toModelMessages(messages: Message[]): ModelMessage[] {
+  return messages.map<ModelMessage>(message => {
+    if (typeof message.content !== "string") {
+      throw new Error("AI message content must be a string")
+    }
+    if (message.role === "tool") {
+      throw new Error("AI tool messages are not supported")
+    }
+    return {
+      role: message.role as Exclude<ModelMessage["role"], "tool">,
+      content: message.content,
+    }
+  })
+}

--- a/packages/server/src/utilities/rowProcessor/utils.ts
+++ b/packages/server/src/utilities/rowProcessor/utils.ts
@@ -3,7 +3,7 @@ import { ai } from "@budibase/pro"
 import { OperationFields } from "@budibase/shared-core"
 import { processStringSync } from "@budibase/string-templates"
 import { LLMResponse, AIOperationEnum, AIFieldMetadata } from "@budibase/types"
-import { generateText, type ModelMessage } from "ai"
+import { generateText } from "ai"
 import {
   AutoColumnFieldMetadata,
   AutoFieldSubType,
@@ -18,6 +18,7 @@ import tracer from "dd-trace"
 import { AutoFieldDefaultNames } from "../../constants"
 import { isAIColumn } from "../../db/utils"
 import sdk from "../../sdk"
+import { toModelMessages } from "../../sdk/workspace/ai/llm/messages"
 import { coerce } from "./index"
 
 interface FormulaOpts {
@@ -57,23 +58,6 @@ function promptForAIOperation(schema: AIFieldMetadata, row: Row) {
     default:
       throw new Error(`Unsupported AI operation: ${operation}`)
   }
-}
-
-function toModelMessages(
-  messages: { role: string; content: any }[]
-): ModelMessage[] {
-  return messages.map<ModelMessage>(message => {
-    if (typeof message.content !== "string") {
-      throw new Error("AI message content must be a string")
-    }
-    if (message.role === "tool") {
-      throw new Error("AI tool messages are not supported in row AI operations")
-    }
-    return {
-      role: message.role as Exclude<ModelMessage["role"], "tool">,
-      content: message.content,
-    }
-  })
 }
 
 async function runAIOperation(


### PR DESCRIPTION
## Description
Automation AI steps on the new llm. There is still the extract one, which uses files, and it's more complex. To be tackled separately.
<img width="686" height="626" alt="image" src="https://github.com/user-attachments/assets/0abc6fc0-4971-453d-a74d-9a3fc77ddab5" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch automation LLM steps to the new default LLM pipeline for consistent prompts and simpler message handling. Centralizes message conversion and removes duplicate code.

- **Refactors**
  - Added promptWithDefaultLLM wrapper around generateText to use the workspace’s default LLM.
  - Updated classify, generate, summarise, translate, and prompt steps to use request.messages via promptWithDefaultLLM and return plain text.
  - Introduced shared toModelMessages utility (sdk/workspace/ai/llm/messages) and reused it in rowProcessor; removed the local duplicate.
  - Extract step remains on the old path for now.

<sup>Written for commit be0514a4a17daea3ce18e8de0a5b1335da517588. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

