### PR TITLE
17699 table row buttons not responsive to size setting

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonConfiguration/ButtonConfiguration.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonConfiguration/ButtonConfiguration.svelte
@@ -38,6 +38,7 @@
     bindings: allBindings,
     removeButton,
     nested,
+    parentComponent: componentInstance,
   }
   $: canAddButtons = max == null || buttonList.length < max
 

--- a/packages/builder/src/components/design/settings/controls/ButtonConfiguration/ButtonSetting.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonConfiguration/ButtonSetting.svelte
@@ -10,6 +10,7 @@
   export let anchor
   export let removeButton
   export let nested
+  export let parentComponent
 
   $: readableText = isJSBinding(item.text)
     ? "(JavaScript function)"
@@ -33,6 +34,9 @@
     let name = newSettings.find(x => x.key === "text")
     if (name) {
       name.disableBindings = true
+    }
+    if (parentComponent?._component?.endsWith("/gridblock")) {
+      newSettings = newSettings.filter(setting => setting.key !== "size")
     }
     return newSettings
   }


### PR DESCRIPTION
## Description
Removed the size setting from the button configuration UI and enforced a fixed button size. The builder now filters out the size setting for nested buttons under grid, and the grid’s button column (ButtonColumn.svelte) and grid button enrichment. This avoids a non-functional setting and keeps table row height behaviour consistent.

**Before**
<img width="360" height="356" alt="Screenshot 2026-02-25 at 14 27 37" src="https://github.com/user-attachments/assets/2325167d-af93-4558-bc13-307ebdc4932d" />

**After**
<img width="361" height="317" alt="Screenshot 2026-02-25 at 14 22 50" src="https://github.com/user-attachments/assets/4dcb8c1a-cddd-4d02-8b4a-a44cb22ddfbf" />

## Addresses
- https://github.com/Budibase/budibase/issues/17699

## Launchcontrol
Removed the “button size” option for table buttons because it didn't work. Table buttons are now always the same size, so they look consistent, and the rows don’t get squished or uneven.