### PR TITLE
Fixes line numbers in API Response Transformer

### DIFF
--- a/packages/builder/src/components/common/CodeMirrorEditor.svelte
+++ b/packages/builder/src/components/common/CodeMirrorEditor.svelte
@@ -28,7 +28,7 @@
   import { Label } from "@budibase/bbui"
   import CodeMirror from "@/components/integration/codemirror"
   import { themeStore } from "@/stores/portal"
-  import { createEventDispatcher, onMount } from "svelte"
+  import { createEventDispatcher, onMount, tick } from "svelte"
 
   export let mode = EditorModes.JS
   export let value = ""
@@ -91,6 +91,10 @@
 
     // Construct CM instance
     editor = CodeMirror.fromTextArea(textarea, options)
+
+    // Allow layout to settle before forcing a refresh so gutters are measured
+    await tick()
+    editor?.refresh()
 
     // Use a blur handler to update the value
     editor.on("blur", instance => {


### PR DESCRIPTION
## Description
This PR makes the builder wait until the screen is fully loaded before refreshing the line-numbers in the code editor.

## Addresses
- https://github.com/Budibase/budibase/issues/18072

## Launchcontrol

_Fixes line numbers in API Response Transformer_
