### PR TITLE
Proxy service metrics improvement

### DIFF
--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -26,6 +26,9 @@ spec:
     metadata:
       annotations:
         ad.datadoghq.com/proxy-service.logs: '[{"source":"nginx","service":"budibase-proxy"}]'
+        ad.datadoghq.com/proxy-service.check_names: '["nginx"]'
+        ad.datadoghq.com/proxy-service.init_configs: '[{}]'
+        ad.datadoghq.com/proxy-service.instances: '[{"nginx_status_url": "http://%%host%%:81/nginx_status"}]'
 {{ if .Values.services.proxy.templateAnnotations }}
 {{- toYaml .Values.services.proxy.templateAnnotations | indent 8 -}}
 {{ end }}

--- a/hosting/proxy/nginx.prod.conf
+++ b/hosting/proxy/nginx.prod.conf
@@ -31,10 +31,27 @@ http {
   ignore_invalid_headers off;
   proxy_buffering off;
 
-  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                    '$status $body_bytes_sent "$http_referer" '
-                    '"$http_user_agent" "$http_x_forwarded_for" '
-                    'response_time=$upstream_response_time proxy_host=$proxy_host upstream_addr=$upstream_addr';
+  log_format  main escape=json
+  '{'
+    '"time_local": "$time_iso8601",'
+    '"remote_addr": "$remote_addr",'
+    '"remote_user": "$remote_user",'
+    '"request": "$request",'
+    '"status": "$status",'
+    '"body_bytes_sent": "$body_bytes_sent",'
+    '"request_time": "$request_time",'
+    '"http_referer": "$http_referer",'
+    '"http_user_agent": "$http_user_agent",'
+    '"http_x_forwarded_for": "$http_x_forwarded_for",'
+    '"upstream_connect_time": "$upstream_connect_time",'
+    '"upstream_header_time": "$upstream_header_time",'
+    '"upstream_response_time": "$upstream_response_time",'
+    '"upstream_status": "$upstream_status",'
+    '"proxy_host": "$proxy_host",'
+    '"upstream_addr": "$upstream_addr",'
+    '"request_length": "$request_length",'
+    '"bytes_sent": "$bytes_sent"'
+  '}';
 
   access_log /var/log/nginx/access.log main;
 


### PR DESCRIPTION
## Description
Refactoring the proxy service log format to expose more `request` and `upstream` timing and payload metrics.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch NGINX access logs to structured JSON and enable the Datadog NGINX integration to collect detailed request and upstream metrics. Improves observability and makes logs easier to parse.

- **New Features**
  - JSON access logs with timing and payload fields (request_time, upstream_connect/header/response_time, upstream_status, request_length, bytes_sent, etc.).
  - Datadog autodiscovery enabled for the proxy; NGINX status scraped at http://%host%:81/nginx_status.

<sup>Written for commit 7111b122cab85b702116e8f790e1064fef85a5e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

