### PR TITLE
[#18072] Fix REST transformer gutter alignment

### DIFF
--- a/packages/builder/src/components/integration/RestQueryViewer.svelte
+++ b/packages/builder/src/components/integration/RestQueryViewer.svelte
@@ -22,9 +22,8 @@
   } from "@budibase/bbui"
   import KeyValueBuilder from "@/components/integration/KeyValueBuilder.svelte"
   import EditableLabel from "@/components/common/inputs/EditableLabel.svelte"
-  import CodeMirrorEditor, {
-    EditorModes,
-  } from "@/components/common/CodeMirrorEditor.svelte"
+  import CodeEditor from "@/components/common/CodeEditor/CodeEditor.svelte"
+  import { EditorModes } from "@/components/common/CodeEditor"
   import RestBodyInput from "./RestBodyInput.svelte"
   import { capitalise, confirm } from "@/helpers"
   import { onMount } from "svelte"
@@ -744,13 +743,14 @@
                   Add a JavaScript function to transform the query result.
                 </Banner>
               {/if}
-              <CodeMirrorEditor
-                height={200}
-                mode={EditorModes.JSON}
-                value={query.transformer}
-                resize="vertical"
-                on:change={e => (query.transformer = e.detail)}
-              />
+              <div class="embed">
+                <CodeEditor
+                  value={query.transformer}
+                  mode={EditorModes.JS}
+                  aiEnabled={false}
+                  on:change={e => (query.transformer = e.detail)}
+                />
+              </div>
             </Layout>
           </Tab>
           <div class="auth-container">
@@ -969,5 +969,16 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: var(--spacing-m);
+  }
+
+  .embed :global(.cm-editor) {
+    min-height: 200px;
+    border: 1px solid var(--spectrum-global-color-gray-400);
+    border-radius: 4px;
+  }
+
+  .embed :global(.cm-gutters) {
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
   }
 </style>


### PR DESCRIPTION
## Description
Fixes a UI issue where the Transformer editor gutter/line number area in REST API requests was not rendered correctly. The REST transformer now uses the same `CodeEditor` implementation and styling already used in the API endpoint viewer.

## Addresses
- https://github.com/Budibase/budibase/issues/18072

## Screenshots
<img width="841" height="416" alt="Screenshot 2026-02-26 at 13 20 48" src="https://github.com/user-attachments/assets/2a56cb58-4340-4d4b-b84d-14f108977cdf" />

## Launchcontrol
Fixes the code editor layout in REST API transformers so line numbers and gutter spacing display correctly.
