### PR TITLE
Fix PM2 start race condition in single image

### DIFF
--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -177,7 +177,7 @@ chown -R postgres:postgres ${DATA_DIR}/litellm
 chmod 700 ${DATA_DIR}/litellm/postgres
 
 echo "Starting Redis runner..."
-./redis-runner.sh &
+./redis-runner.sh
 
 echo "Starting callback CouchDB runner..."
 ./bbcouch-runner.sh &


### PR DESCRIPTION
## Description
There is no reason to launch the redis-runner in backgrounded mode since it now daemonizes redis through pm2. Running it in background mode causes a race condition in pm2 startup causing pm2 to try to start twice and overwriting itself.

Fix PM2 start race condition in single image

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run redis-runner.sh in the foreground in hosting/single/runner.sh to remove a PM2 startup race in the single image. PM2 already daemonizes Redis, so this prevents duplicate starts and process overwrites.

<sup>Written for commit efdb1f78a07735efc852a0997c330ea9b6128d6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

