### PR TITLE
Migrate old OpenAI code

### DIFF
--- a/packages/server/scripts/.env.ai-evals.example
+++ b/packages/server/scripts/.env.ai-evals.example
@@ -15,7 +15,7 @@ BUDIBASE_PASSWORD=cheekychuckles
 
 # Optional: global feature filter for all enabled providers.
 # Allowed tokens:
-# tables,js,cron,translate,classify,prompt,summarise,generate,extract,all
+# tables,js,cron,translate,classify,prompt,summarise,generate,extract,openai,all
 # AI_EVAL_FEATURES=all
 
 # OpenAI

--- a/packages/server/scripts/ai-refactor-evals.ts
+++ b/packages/server/scripts/ai-refactor-evals.ts
@@ -806,7 +806,8 @@ function extractCreatedTablesFromResponse(
 async function runFeatureEvals(
   client: ApiClient,
   enabledFeatures: Set<EvalFeature>,
-  mode: BudibaseMode
+  mode: BudibaseMode,
+  scenarioConfig: AIProviderConfig
 ): Promise<EvalResult[]> {
   const results: EvalResult[] = []
   const definitions = await getAutomationDefinitions(client)
@@ -952,13 +953,14 @@ async function runFeatureEvals(
     "automation-openai",
     "Automation OpenAI step",
     async () => {
+      const automationModel = scenarioConfig.defaultModel || "gpt-4o-mini"
       const result = await runAutomationStepEval(
         client,
         definitions,
         "OPENAI",
         {
           prompt: "Reply with exactly EVAL_OPENAI_OK",
-          model: "gpt-4o-mini",
+          model: automationModel,
         }
       )
 
@@ -1368,7 +1370,12 @@ async function runScenario(
 
   await configureAIProvider(client, scenario.config)
   const startedAt = Date.now()
-  const results = await runFeatureEvals(client, enabledFeatures, scenario.mode)
+  const results = await runFeatureEvals(
+    client,
+    enabledFeatures,
+    scenario.mode,
+    scenario.config
+  )
   return {
     ok: results.every(r => r.ok),
     elapsedMs: Date.now() - startedAt,

--- a/packages/server/scripts/ai-refactor-evals.ts
+++ b/packages/server/scripts/ai-refactor-evals.ts
@@ -28,6 +28,7 @@ interface Scenario {
 interface EvalResult {
   name: string
   ok: boolean
+  skipped?: boolean
   detail?: string
   elapsedMs?: number
 }
@@ -38,6 +39,7 @@ type EvalFeature =
   | "table-generation"
   | "js-generation"
   | "cron-generation"
+  | "automation-openai"
   | "automation-translate"
   | "automation-classify"
   | "automation-prompt-llm"
@@ -449,6 +451,7 @@ const ALL_FEATURES: EvalFeature[] = [
   "table-generation",
   "js-generation",
   "cron-generation",
+  "automation-openai",
   "automation-translate",
   "automation-classify",
   "automation-prompt-llm",
@@ -467,6 +470,8 @@ function normalizeFeatureToken(value: string): EvalFeature | undefined {
     "js-generation": "js-generation",
     cron: "cron-generation",
     "cron-generation": "cron-generation",
+    openai: "automation-openai",
+    "automation-openai": "automation-openai",
     translate: "automation-translate",
     "automation-translate": "automation-translate",
     classify: "automation-classify",
@@ -800,7 +805,8 @@ function extractCreatedTablesFromResponse(
 
 async function runFeatureEvals(
   client: ApiClient,
-  enabledFeatures: Set<EvalFeature>
+  enabledFeatures: Set<EvalFeature>,
+  mode: BudibaseMode
 ): Promise<EvalResult[]> {
   const results: EvalResult[] = []
   const definitions = await getAutomationDefinitions(client)
@@ -855,9 +861,22 @@ async function runFeatureEvals(
   const runIf = async (
     feature: EvalFeature,
     name: string,
-    fn: () => Promise<void>
+    fn: () => Promise<void>,
+    opts?: { when?: boolean; skipReason?: string }
   ) => {
     if (!enabledFeatures.has(feature)) {
+      return
+    }
+    if (opts?.when === false) {
+      results.push({
+        name,
+        ok: true,
+        skipped: true,
+        detail: opts.skipReason || "Condition not met",
+      })
+      console.log(
+        yellow(`SKIPPED: ${name} - ${opts.skipReason || "Condition not met"}`)
+      )
       return
     }
     await run(name, fn)
@@ -928,6 +947,39 @@ async function runFeatureEvals(
       )
     }
   })
+
+  await runIf(
+    "automation-openai",
+    "Automation OpenAI step",
+    async () => {
+      const result = await runAutomationStepEval(
+        client,
+        definitions,
+        "OPENAI",
+        {
+          prompt: "Reply with exactly EVAL_OPENAI_OK",
+          model: "gpt-4o-mini",
+        }
+      )
+
+      const output = getActionOutput(result, "OPENAI")
+      if (!output?.success || !output?.response) {
+        throw new Error(`Unexpected output: ${JSON.stringify(output)}`)
+      }
+      if (!String(output.response).toUpperCase().includes("EVAL_OPENAI_OK")) {
+        throw new Error(
+          `OpenAI step output missing EVAL_OPENAI_OK: ${output.response}`
+        )
+      }
+    },
+    {
+      when: mode === "self" && Boolean(definitions.actions.OPENAI),
+      skipReason:
+        mode !== "self"
+          ? "OPENAI action is only available in self mode"
+          : "Action definition not found for OPENAI in current mode",
+    }
+  )
 
   await runIf("automation-translate", "Automation translate step", async () => {
     const result = await runAutomationStepEval(
@@ -1316,7 +1368,7 @@ async function runScenario(
 
   await configureAIProvider(client, scenario.config)
   const startedAt = Date.now()
-  const results = await runFeatureEvals(client, enabledFeatures)
+  const results = await runFeatureEvals(client, enabledFeatures, scenario.mode)
   return {
     ok: results.every(r => r.ok),
     elapsedMs: Date.now() - startedAt,

--- a/packages/server/src/automations/steps/openai.ts
+++ b/packages/server/src/automations/steps/openai.ts
@@ -23,9 +23,14 @@ export async function run({
       success: true,
     }
   } catch (err) {
+    const error = automationUtils.getError(err)
+    const response = error.includes("Invalid JSON response")
+      ? "Error: No response found"
+      : error
+
     return {
       success: false,
-      response: automationUtils.getError(err),
+      response,
     }
   }
 }

--- a/packages/server/src/automations/steps/openai.ts
+++ b/packages/server/src/automations/steps/openai.ts
@@ -1,38 +1,14 @@
-import { OpenAI } from "openai"
-
 import { OpenAIStepInputs, OpenAIStepOutputs } from "@budibase/types"
-import { env } from "@budibase/backend-core"
 import * as automationUtils from "../automationUtils"
 import { ai } from "@budibase/pro"
-
-/**
- * Maintains backward compatibility with automation steps created before the introduction
- * of custom configurations and Budibase AI
- * @param inputs - automation inputs from the OpenAI automation step.
- */
-async function legacyOpenAIPrompt(inputs: OpenAIStepInputs) {
-  const openai = new OpenAI({
-    apiKey: env.OPENAI_API_KEY,
-  })
-
-  const completion = await openai.chat.completions.create({
-    model: inputs.model,
-    messages: [
-      {
-        role: "user",
-        content: inputs.prompt,
-      },
-    ],
-  })
-  return completion?.choices[0]?.message?.content
-}
+import { promptWithDefaultLLM } from "./ai/llm"
 
 export async function run({
   inputs,
 }: {
   inputs: OpenAIStepInputs
 }): Promise<OpenAIStepOutputs> {
-  if (inputs.prompt == null) {
+  if (inputs.prompt == null || inputs.prompt.trim()) {
     return {
       success: false,
       response: "Budibase OpenAI Automation Failed: No prompt supplied",
@@ -40,12 +16,8 @@ export async function run({
   }
 
   try {
-    let response
-    const llm = await ai.getLLM({ model: inputs.model })
-    response = llm
-      ? (await llm.prompt(inputs.prompt)).message
-      : await legacyOpenAIPrompt(inputs)
-
+    const request = new ai.LLMRequest().addUserMessage(inputs.prompt)
+    const response = await promptWithDefaultLLM(request.messages)
     return {
       response,
       success: true,

--- a/packages/server/src/automations/steps/openai.ts
+++ b/packages/server/src/automations/steps/openai.ts
@@ -8,7 +8,7 @@ export async function run({
 }: {
   inputs: OpenAIStepInputs
 }): Promise<OpenAIStepOutputs> {
-  if (inputs.prompt == null || inputs.prompt.trim()) {
+  if (!inputs.prompt?.trim()) {
     return {
       success: false,
       response: "Budibase OpenAI Automation Failed: No prompt supplied",


### PR DESCRIPTION
## Description
```
=== Provider: BBAI (selfhost mode) ===
PASS: JS generation (2344ms)
PASS: Automation OpenAI step (3620ms)

=== Provider: OpenAI (selfhost mode) ===
PASS: JS generation (2833ms)
PASS: Automation OpenAI step (1999ms)

=== Provider: Azure OpenAI (selfhost mode) ===
PASS: JS generation (1251ms)
PASS: Automation OpenAI step (1663ms)

=== Provider: BBAI (cloud mode) ===
PASS: JS generation (2416ms)
SKIPPED: Automation OpenAI step - OPENAI action is only available in self mode
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the OpenAI automation step to the shared LLM prompt flow, added an eval, and improved error handling. The eval runs only in self mode when the OPENAI action is available, with clear skips; tests updated to reflect the new behavior.

- **Refactors**
  - Replaced legacy OpenAI client usage with promptWithDefaultLLM and ai.LLMRequest.
  - Removed direct OpenAI SDK dependency and old compatibility code.

- **New Features**
  - Added “automation-openai” eval that checks the step returns EVAL_OPENAI_OK.
  - Added “openai” token to AI_EVAL_FEATURES and feature normalization.
  - Eval now runs only in self mode and skips with a reason if the OPENAI action isn’t present.

<sup>Written for commit 22fbbe0e1b02663329deab1c0cd60b1f481932fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



