### PR TITLE
Disable nginx IPv6 in single image

### DIFF
--- a/hosting/single/nginx/nginx-default-site.conf
+++ b/hosting/single/nginx/nginx-default-site.conf
@@ -1,6 +1,5 @@
 server {
     listen       80 default_server;
-    listen  [::]:80 default_server;
     server_name  _;
     error_log            /dev/stderr warn;
     access_log           /dev/stdout main;


### PR DESCRIPTION
IPv6 is not supported by all platforms and even on platforms where it would be supported isn't necessarily enabled. Nothing else in the container is configured to use IPv6.

## Description
nginx fails to start in some configurations


## Launchcontrol

Disable nginx IPv6 in single image


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the IPv6 listener in the single-image nginx config to prevent startup failures on hosts without IPv6 support. Removed "listen [::]:80 default_server;" from nginx-default-site.conf so the server listens on IPv4 only.

<sup>Written for commit 484d1a2ab4f2b942a30de49ccece141b69bdbd37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

