### PR TITLE
Remove BUDIBASE_AI_DEFAULT_MODEL, use the provider by default

### DIFF
--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -273,7 +273,6 @@ const environment = {
   CUSTOM_CSP_FRAME_SRC: process.env.CUSTOM_CSP_FRAME_SRC,
   OPENROUTER_BASE_URL:
     process.env.OPENROUTER_BASE_URL || "https://openrouter.ai/api/v1",
-  BUDIBASE_AI_DEFAULT_MODEL: process.env.BUDIBASE_AI_DEFAULT_MODEL,
 }
 
 export function setEnv(newEnvVars: Partial<typeof environment>): () => void {

--- a/packages/pro/src/ai/llm.ts
+++ b/packages/pro/src/ai/llm.ts
@@ -108,16 +108,11 @@ function getBudibaseAIKeyConfig(): LLMProviderConfig | undefined {
       return
     }
 
-    if (!env.BUDIBASE_AI_DEFAULT_MODEL) {
-      span.addTags({ enabled: false, reason: "no BUDIBASE_AI_DEFAULT_MODEL" })
-      return
-    }
-
     span.addTags({ enabled: true })
 
     return {
       provider: "BudibaseAI",
-      model: env.BUDIBASE_AI_DEFAULT_MODEL,
+      model: DefaultModelByProvider.BudibaseAI,
     }
   })
 }

--- a/packages/server/src/api/routes/tests/ai.spec.ts
+++ b/packages/server/src/api/routes/tests/ai.spec.ts
@@ -292,9 +292,7 @@ describe("BudibaseAI", () => {
   beforeAll(async () => {
     await config.init()
     cleanup.push(await budibaseAI()(config))
-    cleanup.push(
-      setEnv({ SELF_HOSTED: false, BUDIBASE_AI_DEFAULT_MODEL: "gpt-4o" })
-    )
+    cleanup.push(setEnv({ SELF_HOSTED: false }))
   })
 
   beforeEach(async () => {


### PR DESCRIPTION
## Description
Fix an issue using bbai selfhost, reverted in here: https://github.com/Budibase/budibase/pull/18148


### Before
<img width="901" height="122" alt="image" src="https://github.com/user-attachments/assets/c9d915a8-860c-41ed-ba62-bd8243364124" />


### After
<img width="612" height="226" alt="image" src="https://github.com/user-attachments/assets/c451a139-0a3f-4817-ade4-16f319fa6541" />


## Launchcontrol
Fix an issue using bbai selfhost


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the BudibaseAI provider’s default model instead of the BUDIBASE_AI_DEFAULT_MODEL env var. This simplifies configuration and ensures BudibaseAI is enabled when a key is present; tests updated accordingly.

<sup>Written for commit 0722da6b2ca4db469b91a160bfcbf023ebc42eb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

