### PR TITLE
Remove REST template verified flag and check-mark UI

### DIFF
--- a/packages/builder/src/components/integration/APIEndpointViewer.svelte
+++ b/packages/builder/src/components/integration/APIEndpointViewer.svelte
@@ -96,6 +96,7 @@
   let selectedEndpointOption: EndpointWithIcon | undefined
   let endpoints: ImportEndpoint[] | undefined
   let endpointsLoading = false
+  let endpointLoadError: string | undefined
   let queryParams: Record<string, string> | undefined = undefined
   let localDynamicVariables: Record<string, string> | undefined = undefined
   let savingQuery = false,
@@ -205,6 +206,7 @@
   $: if (datasourceId) {
     selectedEndpointOption = undefined
     endpoints = undefined
+    endpointLoadError = undefined
     queryParams = undefined
     originalBuiltQuery = undefined
   }
@@ -394,6 +396,7 @@
     spec &&
     !endpoints &&
     !endpointsLoading &&
+    !endpointLoadError &&
     !(query?._id && query?.restTemplateMetadata)
   ) {
     loadEndpoints(spec)
@@ -441,6 +444,7 @@
       endpointsLoading = true
       const resp = await queries.fetchImportInfo(request)
       const { endpoints: respEndpoints, url } = resp || {}
+      endpointLoadError = undefined
       if (respEndpoints) {
         endpoints = respEndpoints
       }
@@ -448,9 +452,11 @@
         baseUrl = url
       }
     } catch (err) {
-      console.error("could not fetch endpoints", err)
+      endpointLoadError = getErrorMessage(err)
+      notifications.error(`Error importing template - ${endpointLoadError}`)
+    } finally {
+      endpointsLoading = false
     }
-    endpointsLoading = false
   }
 
   const getEndpointOptions = (

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/_components/APIModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/_components/APIModal.svelte
@@ -73,12 +73,7 @@
     if (!request) {
       return undefined
     }
-    try {
-      return await queries.fetchImportInfo(request)
-    } catch (err) {
-      console.warn("Failed to load template metadata", err)
-      return undefined
-    }
+    return await queries.fetchImportInfo(request)
   }
 
   const applySecurityHeaders = (
@@ -174,15 +169,16 @@
       goto(`./datasource/${ds._id}`)
 
       notifications.success(`${selectedTemplate.name} API created`)
+      modal.hide()
     } catch (error: any) {
       notifications.error(
         `Error importing template - ${error?.message || "Unknown error"}`
       )
+    } finally {
+      loading = false
+      selectedTemplate = null
+      targetSpec = null
     }
-    modal.hide()
-    loading = false
-    selectedTemplate = null
-    targetSpec = null
   }
 
   const buildDatasourceName = (

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/_components/SelectCategoryAPIModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/_components/SelectCategoryAPIModal.svelte
@@ -293,12 +293,6 @@
               </div>
 
               <div class="api-name">{card.name}</div>
-              {#if card.type === "group" ? card.group.verified : card.template.verified}
-                <i
-                  class="ph ph-seal-check verified-icon"
-                  aria-label="Verified template"
-                ></i>
-              {/if}
             </div>
           {/each}
         </div>
@@ -319,7 +313,7 @@
   .api {
     display: flex;
     height: 38px;
-    padding: 6px 32px 6px 12px;
+    padding: 6px 12px;
     align-items: center;
     gap: 8px;
     flex-shrink: 0;
@@ -328,7 +322,6 @@
     border-radius: 8px;
     border: 1px solid var(--spectrum-global-color-gray-200);
     background-color: var(--spectrum-global-color-gray-100);
-    position: relative;
   }
 
   .api:hover {
@@ -374,14 +367,6 @@
   .api-icon.group-icon {
     width: 48px;
     height: 48px;
-  }
-
-  .verified-icon {
-    color: var(--spectrum-global-color-gray-600);
-    font-size: 16px;
-    flex-shrink: 0;
-    position: absolute;
-    right: 12px;
   }
 
   .api-header {

--- a/packages/builder/src/pages/builder/workspace/[application]/apis/new.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/apis/new.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onDestroy } from "svelte"
   import CreateExternalDatasourceModal from "../data/_components/CreateExternalDatasourceModal/index.svelte"
   import DatasourceOption from "../data/_components/DatasourceOption.svelte"
   import RestTemplateOption from "../data/_components/RestTemplateOption.svelte"
@@ -19,11 +18,6 @@
     ProgressCircle,
     keepOpen,
     ModalCancelFrom,
-    Popover,
-    Icon,
-    PopoverAlignment,
-    Link,
-    type PopoverAPI,
   } from "@budibase/bbui"
   import {
     sortedIntegrations as integrations,
@@ -73,10 +67,6 @@
   let templateEndpoints: ImportEndpoint[] = []
   let selectedEndpointId: string | undefined = undefined
   let templateDocsBaseUrl: string | undefined = undefined
-  let templatesInfoPopover: PopoverAPI | undefined
-  let templatesInfoAnchor: HTMLElement | undefined
-  let templatesInfoOpen = false
-  let templatesInfoTimeout: ReturnType<typeof setTimeout> | undefined
   let templateSearchValue = ""
   $: selectedEndpoint = templateEndpoints.find(
     endpoint => endpoint.id === selectedEndpointId
@@ -114,37 +104,13 @@
         template.name.toLowerCase().includes(normalizedTemplateSearch)
       )
     : restTemplatesList
-  $: verifiedRestTemplates = filteredRestTemplates.filter(
-    template => template.verified
-  )
-  $: unverifiedRestTemplates = filteredRestTemplates.filter(
-    template => !template.verified
-  )
-  $: verifiedTemplateGroups = filteredTemplateGroups.filter(
-    group => group.verified
-  )
-  $: unverifiedTemplateGroups = filteredTemplateGroups.filter(
-    group => !group.verified
-  )
-  $: verifiedTemplateOptions = [
-    ...verifiedTemplateGroups.map(group => ({
+  $: templateOptions = [
+    ...filteredTemplateGroups.map(group => ({
       type: "group" as const,
       name: group.name,
       group,
     })),
-    ...verifiedRestTemplates.map(template => ({
-      type: "template" as const,
-      name: template.name,
-      template,
-    })),
-  ].sort((a, b) => a.name.localeCompare(b.name))
-  $: unverifiedTemplateOptions = [
-    ...unverifiedTemplateGroups.map(group => ({
-      type: "group" as const,
-      name: group.name,
-      group,
-    })),
-    ...unverifiedRestTemplates.map(template => ({
+    ...filteredRestTemplates.map(template => ({
       type: "template" as const,
       name: template.name,
       template,
@@ -413,7 +379,6 @@
       specs: selectedTemplateGroupItem.specs,
       operationsCount: selectedTemplateGroupItem.operationsCount,
       icon: selectedTemplateGroup.icon,
-      verified: selectedTemplateGroup.verified,
     })
   }
 
@@ -424,12 +389,6 @@
       goto("../")
     }
   }
-
-  onDestroy(() => {
-    if (templatesInfoTimeout) {
-      clearTimeout(templatesInfoTimeout)
-    }
-  })
 </script>
 
 <CreateExternalDatasourceModal
@@ -465,64 +424,19 @@
       </div>
     </div>
 
-    {#if normalizedTemplateSearch && !verifiedTemplateOptions.length && !unverifiedTemplateOptions.length}
+    {#if normalizedTemplateSearch && !templateOptions.length}
       <p class="empty-state">No templates match your search.</p>
     {/if}
-
-    {#if verifiedTemplateOptions.length}
-      <div class="templates-header">
-        <Body
-          size="S"
-          weight="500"
-          color="var(--spectrum-global-color-gray-900)">Verified templates</Body
-        >
-      </div>
-      <div class="options templateOptions">
-        {#each verifiedTemplateOptions as option (option.name)}
-          <RestTemplateOption
-            on:click={() =>
-              option.type === "group"
-                ? selectTemplateGroup(option.group)
-                : selectTemplate(option.template)}
-            template={option.type === "group" ? option.group : option.template}
-            disabled={templateDisabled}
-          />
-        {/each}
-      </div>
-    {/if}
-    {#if unverifiedTemplateOptions.length}
+    {#if templateOptions.length}
       <div class="templates-header">
         <Body
           size="S"
           weight="500"
           color="var(--spectrum-global-color-gray-900)">Templates</Body
         >
-        <div
-          class="info-icon-wrapper"
-          bind:this={templatesInfoAnchor}
-          role="button"
-          tabindex="0"
-          on:mouseenter={() => {
-            if (templatesInfoTimeout) {
-              clearTimeout(templatesInfoTimeout)
-            }
-            templatesInfoPopover?.show()
-          }}
-          on:mouseleave={() => {
-            templatesInfoTimeout = setTimeout(() => {
-              templatesInfoPopover?.hide()
-            }, 100)
-          }}
-        >
-          <Icon
-            name="info"
-            size="S"
-            color="var(--spectrum-global-color-gray-600)"
-          />
-        </div>
       </div>
       <div class="options templateOptions">
-        {#each unverifiedTemplateOptions as option (option.name)}
+        {#each templateOptions as option (`${option.type}-${option.name}`)}
           <RestTemplateOption
             on:click={() =>
               option.type === "group"
@@ -538,40 +452,6 @@
     <p class="empty-state">REST API integration is unavailable.</p>
   {/if}
 </CreationPage>
-
-<Popover
-  bind:this={templatesInfoPopover}
-  bind:open={templatesInfoOpen}
-  anchor={templatesInfoAnchor}
-  align={PopoverAlignment.Left}
-  minWidth={400}
-  maxWidth={400}
-  dismissible={false}
-  clickOutsideOverride={true}
-  on:mouseenter={() => {
-    if (templatesInfoTimeout) {
-      clearTimeout(templatesInfoTimeout)
-    }
-  }}
-  on:mouseleave={() => {
-    templatesInfoTimeout = setTimeout(() => {
-      templatesInfoPopover?.hide()
-    }, 100)
-  }}
->
-  <div class="templates-popover-content">
-    <Body size="S" color="var(--spectrum-global-color-gray-700)">
-      These templates are not verified by Budibase and we cannot guarantee the
-      validity of them. You can review all specs using the following link:{" "}
-      <Link
-        href="https://github.com/Budibase/openapi-rest-templates"
-        target="_blank"
-      >
-        https://github.com/Budibase/openapi-rest-templates
-      </Link>
-    </Body>
-  </div>
-</Popover>
 
 <Modal
   bind:this={templateVersionModal}
@@ -752,25 +632,6 @@
     gap: 6px;
     margin: 12px 0;
     font-weight: 600;
-  }
-  .info-icon-wrapper {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-  }
-  .info-icon-wrapper :global(svg) {
-    width: 20px;
-    height: 20px;
-  }
-  .templates-popover-content {
-    padding: 16px;
-    margin: 0;
-  }
-  .templates-popover-content :global(p) {
-    margin: 0;
-  }
-  :global(.spectrum-Popover:has(.templates-popover-content)) {
-    background-color: var(--background);
   }
   .versionOptions {
     display: grid;

--- a/packages/builder/src/pages/builder/workspace/[application]/data/_components/RestTemplateOption.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/_components/RestTemplateOption.svelte
@@ -22,10 +22,6 @@
         >{template.name}</Body
       >
     </div>
-    {#if template.verified}
-      <i class="ph ph-seal-check verified-icon" aria-label="Verified template"
-      ></i>
-    {/if}
   </div>
 </div>
 
@@ -86,12 +82,6 @@
   .icon img {
     width: 100%;
     height: 100%;
-  }
-
-  .verified-icon {
-    color: var(--spectrum-global-color-gray-600);
-    font-size: 16px;
-    flex-shrink: 0;
   }
 
   .disabled {

--- a/packages/builder/src/stores/builder/restTemplates.ts
+++ b/packages/builder/src/stores/builder/restTemplates.ts
@@ -97,7 +97,6 @@ interface RestTemplatesState {
 const hubspotRestTemplateGroup: RestTemplateGroup<"HubSpot"> = {
   name: "HubSpot",
   icon: HubSpotLogo,
-  verified: true,
   description:
     "CRM, marketing, CMS, and automation APIs for HubSpot's platform.",
   operationsCount: 1274,
@@ -1270,7 +1269,6 @@ const hubspotRestTemplateGroup: RestTemplateGroup<"HubSpot"> = {
 const twilioRestTemplateGroup: RestTemplateGroup<"Twilio"> = {
   name: "Twilio",
   icon: TwilioLogo,
-  verified: true,
   description:
     "Combines powerful communications APIs with AI and first-party data.",
   operationsCount: 795,
@@ -1661,7 +1659,6 @@ const twilioRestTemplateGroup: RestTemplateGroup<"Twilio"> = {
 const zendeskRestTemplateGroup: RestTemplateGroup<"Zendesk"> = {
   name: "Zendesk",
   icon: ZendeskLogo,
-  verified: true,
   description: "Customer support and messaging APIs from Zendesk.",
   operationsCount: 68,
   templates: [
@@ -1683,7 +1680,6 @@ const microsoftSharepointRestTemplateGroup: RestTemplateGroup<"Microsoft SharePo
   {
     name: "Microsoft SharePoint",
     icon: MicrosoftSharepointLogo,
-    verified: true,
     description:
       "Microsoft Graph SharePoint APIs for sites, drives, and shared items.",
     operationsCount: 2826,
@@ -1727,7 +1723,6 @@ const microsoftSharepointRestTemplateGroup: RestTemplateGroup<"Microsoft SharePo
 const splunkRestTemplateGroup: RestTemplateGroup<"Splunk"> = {
   name: "Splunk",
   icon: SplunkLogo,
-  verified: true,
   description:
     "Official OpenAPI specifications for Splunk Cloud and Splunk Enterprise Security.",
   operationsCount: 151,
@@ -1784,7 +1779,6 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       ],
       operationsCount: 66,
       icon: AttioLogo,
-      verified: true,
     },
     {
       name: "BambooHR",
@@ -1798,7 +1792,6 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       ],
       operationsCount: 134,
       icon: BambooHRLogo,
-      verified: true,
     },
     {
       name: "Confluence",
@@ -1806,12 +1799,11 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       specs: [
         {
           version: "2.0.0",
-          url: "https://dac-static.atlassian.com/cloud/confluence/openapi-v2.v3.json?_v=1.8327.0",
+          url: "https://raw.githubusercontent.com/Budibase/openapi-rest-templates/refs/heads/main/confluence/openapi.json",
         },
       ],
       operationsCount: 212,
       icon: ConfluenceLogo,
-      verified: true,
     },
     {
       name: "Discord",
@@ -1824,7 +1816,6 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       ],
       operationsCount: 227,
       icon: DiscordLogo,
-      verified: true,
     },
     {
       name: "Figma",
@@ -1838,7 +1829,6 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       ],
       operationsCount: 46,
       icon: FigmaLogo,
-      verified: true,
     },
     {
       name: "GitHub",
@@ -1852,7 +1842,6 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       ],
       operationsCount: 1078,
       icon: GitHubLogo,
-      verified: true,
     },
     {
       name: "Jira Cloud",
@@ -1866,7 +1855,6 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       ],
       operationsCount: 616,
       icon: JiraLogo,
-      verified: true,
     },
     {
       name: "Okta Management",
@@ -1880,7 +1868,6 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       ],
       operationsCount: 694,
       icon: OktaLogo,
-      verified: true,
     },
     {
       name: "PagerDuty",
@@ -1894,7 +1881,6 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       ],
       operationsCount: 390,
       icon: PagerDutyLogo,
-      verified: true,
     },
     {
       name: "Slack Web API",
@@ -1908,7 +1894,6 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       ],
       operationsCount: 172,
       icon: SlackLogo,
-      verified: true,
     },
     {
       name: "ServiceNow",
@@ -1922,7 +1907,6 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       ],
       operationsCount: 25,
       icon: ServiceNowLogo,
-      verified: true,
     },
     {
       name: "VirusTotal",
@@ -1936,11 +1920,7 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       ],
       operationsCount: 159,
       icon: VirusTotalLogo,
-      verified: true,
     },
-    /**
-     * UNVERIFIED
-     */
     {
       name: "Gitlab",
       description: "The most comprehensive DevSecOps platform.",
@@ -1978,7 +1958,6 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       ],
       operationsCount: 587,
       icon: StripeLogo,
-      verified: true,
     },
     {
       name: "Ansible AWX",
@@ -2107,7 +2086,6 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       ],
       operationsCount: 42,
       icon: CleverLogo,
-      verified: true,
     },
     {
       name: "Clickup",
@@ -2416,7 +2394,6 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       ],
       operationsCount: 552,
       icon: MicrosoftTeamsLogo,
-      verified: true,
     },
     {
       name: "Nanonets",
@@ -2455,7 +2432,6 @@ const INITIAL_REST_TEMPLATES_STATE: RestTemplatesState = {
       ],
       operationsCount: 57,
       icon: OpenRouterLogo,
-      verified: true,
     },
     {
       name: "Oyster HR",

--- a/packages/types/src/ui/rest.ts
+++ b/packages/types/src/ui/rest.ts
@@ -266,7 +266,6 @@ export interface RestTemplate {
   specs: RestTemplateSpec[]
   icon: string
   operationsCount: number
-  verified?: true
 }
 
 export interface RestTemplateWithoutIcon<Name> {
@@ -283,7 +282,6 @@ export interface RestTemplateGroup<
   description: string
   icon: string
   operationsCount: number
-  verified?: true
   templates: RestTemplateWithoutIcon<RestTemplateGroups[TemplateGroupName]>[]
 }
 


### PR DESCRIPTION
## Description
This PR updates REST template import UX/data in the builder.

- removes the `verified` boolean from REST templates/template groups
- removes verified check-mark indicators in template selection cards
- removes verified/unverified split sections and related informational popover in the API template picker
- keeps template import behavior aligned with missing-spec handling improvements already on this branch

## Screenshots
<img width="985" height="880" alt="404 no loop" src="https://github.com/user-attachments/assets/cbb6be98-4a76-4ff0-bcf3-202c1cf81bdd" />

*If the URL content is missing, then throw an error - don't loop*

<img width="2049" height="911" alt="confluence fixed" src="https://github.com/user-attachments/assets/751ec7fe-6137-46eb-a09b-49d78f035fb0" />

*Fixed confluence URL*

<img width="2049" height="1296" alt="remove verified badge" src="https://github.com/user-attachments/assets/137b4d94-d122-4b3c-abe9-b6e25e82f171" />

*Removed the verified badge*

## Launchcontrol
This simplifies API template selection by removing the verified badge concept and showing a single consistent template list.
