### PR TITLE
fix: paginate global permission users in workspace search

### DIFF
--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -370,6 +370,44 @@ export const search = async (
 }
 
 const DEFAULT_USER_LIMIT = 8
+const GLOBAL_PERMISSION_USER_PAGE_LIMIT = 1000
+
+const getGlobalPermissionUsers = async () => {
+  const globalDb = context.getGlobalDB()
+  const globalPermissionUsers = new Map<string, User>()
+  let bookmark: string | undefined
+  let nextBookmark: string | undefined
+
+  do {
+    const response = await globalDb.find<User>({
+      selector: {
+        _id: {
+          $regex: `^${db.DocumentType.USER}${db.SEPARATOR}`,
+        },
+        $or: [{ "admin.global": true }, { "builder.global": true }],
+      },
+      limit: GLOBAL_PERMISSION_USER_PAGE_LIMIT,
+      ...(bookmark ? { bookmark } : {}),
+    })
+
+    for (const user of response.docs) {
+      if (user?._id) {
+        globalPermissionUsers.set(user._id, user)
+      }
+    }
+
+    nextBookmark =
+      response.docs.length === GLOBAL_PERMISSION_USER_PAGE_LIMIT
+        ? response.bookmark
+        : undefined
+    if (!nextBookmark || nextBookmark === bookmark) {
+      break
+    }
+    bookmark = nextBookmark
+  } while (bookmark)
+
+  return [...globalPermissionUsers.values()]
+}
 
 const searchWorkspaceUsers = async (
   body: SearchUsersRequest
@@ -394,16 +432,7 @@ const searchWorkspaceUsers = async (
         undefined,
         { arrayResponse: true }
       ) as Promise<User[]>,
-      globalDb
-        .find<User>({
-          selector: {
-            _id: {
-              $regex: `^${db.DocumentType.USER}${db.SEPARATOR}`,
-            },
-            $or: [{ "admin.global": true }, { "builder.global": true }],
-          },
-        })
-        .then(response => response.docs),
+      getGlobalPermissionUsers(),
       globalDb
         .allDocs<UserGroup>(
           db.getDocParams(db.DocumentType.GROUP, null, {

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -978,6 +978,34 @@ describe("/api/global/users", () => {
       expect(response.body.data[0].email).toBe(email)
     })
 
+    it("should include all global admins in workspace search when there are more than 25", async () => {
+      const workspaceId = "app_workspace_filter_global_admin_many"
+      const globalAdminUsers = await Promise.all(
+        Array.from({ length: 30 }).map((_, index) =>
+          config.createUser({
+            email: `workspace-global-admin-${index}-${structures.users.newEmail()}`,
+            admin: { global: true },
+            builder: { global: true },
+          })
+        )
+      )
+      const globalAdminIds = globalAdminUsers
+        .map(user => user._id)
+        .filter(Boolean) as string[]
+
+      const response = await config.api.users.searchUsers({
+        workspaceId,
+        query: { oneOf: { _id: globalAdminIds } },
+        limit: 100,
+      })
+
+      const returnedIds = response.body.data
+        .map((user: User) => user._id)
+        .filter(Boolean)
+      expect(returnedIds).toHaveLength(globalAdminIds.length)
+      expect(returnedIds).toEqual(expect.arrayContaining(globalAdminIds))
+    })
+
     it("should return no users when workspaceId is empty", async () => {
       const email = structures.users.newEmail()
       await config.createUser({ email })


### PR DESCRIPTION
## Description
Mango queries default to a limit of 25, so at most 25 Organisation Admins could be appended to the workspace users table. Now all of them can be, even if there are thousands of admins for some reason.

## Screenshots
<img width="1171" height="182" alt="users" src="https://github.com/user-attachments/assets/efec11e2-5acf-4ad0-a4b2-ab10ee31cf49" />

 *Testing a couple of thousand admins*

<img width="1173" height="755" alt="search workspace users" src="https://github.com/user-attachments/assets/2242749f-6c1c-4ef3-8e1f-3e75d99786aa" />

*Searching Org admins*

## Launchcontrol
Ensure Organisation Admins are all included in the workspace users search

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workspace user search to include all users with global permissions (org-wide admins and builders), not just the first 25. This ensures large orgs see every relevant user in results.

- **Bug Fixes**
  - Paginate Mango queries for global-permission users using bookmarks (1000 per page) until all results are fetched.
  - Deduplicate results and integrate them via a new getGlobalPermissionUsers helper in searchWorkspaceUsers.
  - Added a test that verifies all >25 global admins are returned in workspace search.

<sup>Written for commit 288c35b36062e3c73e773c1ab443ed90940e8802. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

