### PR TITLE
Time only picker alignment

### DIFF
--- a/packages/bbui/src/Form/Core/DatePicker/DatePicker.svelte
+++ b/packages/bbui/src/Form/Core/DatePicker/DatePicker.svelte
@@ -77,6 +77,7 @@
   portalTarget={appendTo}
   {anchor}
   {align}
+  useAnchorWidth={timeOnly}
   resizable={false}
 >
   {#if isOpen}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This pull request contains changes generated by a Cursor Cloud Agent
<!-- CURSOR_AGENT_PR_BODY_END -->

<p><a href="https://cursor.com/agents/bc-32f07d59-1e80-4817-a6bd-6fe5a2d0a9ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32f07d59-1e80-4817-a6bd-6fe5a2d0a9ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


https://github.com/user-attachments/assets/2e03a508-119b-43a0-841c-d14acd6d97ac



<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/fbc56727-5696-4145-9c8d-c9456020a58b" />
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/a2e61f67-cf41-4d17-a660-63cef88c4e93" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misalignment in the time-only DatePicker by making the popover match the input width when timeOnly is enabled. The popover now lines up with the field.

- **Bug Fixes**
  - Pass useAnchorWidth={timeOnly} to Popover so it matches the anchor width in time-only mode.

<sup>Written for commit 642f1cfd8db0dfb8e7650dc9890bb255edf13cdb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



