### PR TITLE
update cla to account for cursor

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,7 +24,7 @@ jobs:
           path-to-document: 'https://github.com/budibase/budibase/blob/next/.github/cla/individual-cla.md' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'next'
-          allowlist: user1,bot*
+          allowlist: user1,bot*,cursoragent
 
          #below are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)


### PR DESCRIPTION
## Description
Just allowlist the cursoragent bot so we dont keep it asking to sign the cla, which it can't do. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add cursoragent to the CLA allowlist to stop CLA checks failing on its commits and avoid blocking PRs from bot activity.

<sup>Written for commit 75fc9dd858228e563054827eb3f9b2db9e4b99f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

