### PR TITLE
Updates Publish popover with details of agents

### DIFF
--- a/packages/builder/src/components/common/PublishMenu.svelte
+++ b/packages/builder/src/components/common/PublishMenu.svelte
@@ -13,6 +13,7 @@
     workspaceAppStore,
     appStore,
   } from "@/stores/builder"
+  import { agentsStore } from "@/stores/portal"
   import { PluginType, type Plugin } from "@budibase/types"
   import type { PopoverAPI } from "@budibase/bbui"
 
@@ -134,6 +135,10 @@
       {/if}
       {#if $workspaceAppStore.workspaceApps.length}
         Apps published: {$workspaceAppStore.workspaceApps.length}
+        <br />
+      {/if}
+      {#if $agentsStore.agents.length}
+        Agents published: {$agentsStore.agents.length}
       {/if}
     </Body>
   </div>

--- a/packages/builder/src/components/common/PublishMenu.svelte
+++ b/packages/builder/src/components/common/PublishMenu.svelte
@@ -13,8 +13,8 @@
     workspaceAppStore,
     appStore,
   } from "@/stores/builder"
-  import { agentsStore } from "@/stores/portal"
-  import { PluginType, type Plugin } from "@budibase/types"
+  import { agentsStore, featureFlags } from "@/stores/portal"
+  import { FeatureFlag, PluginType, type Plugin } from "@budibase/types"
   import type { PopoverAPI } from "@budibase/bbui"
 
   let actionMenu: any
@@ -137,7 +137,7 @@
         Apps published: {$workspaceAppStore.workspaceApps.length}
         <br />
       {/if}
-      {#if $agentsStore.agents.length}
+      {#if $featureFlags[FeatureFlag.AI_AGENTS] && $agentsStore.agents.length}
         Agents published: {$agentsStore.agents.length}
       {/if}
     </Body>

--- a/packages/builder/src/stores/builder/deployment.ts
+++ b/packages/builder/src/stores/builder/deployment.ts
@@ -11,6 +11,7 @@ import { selectedAppUrls } from "./appUrls"
 import { workspaceDeploymentStore } from "@/stores/builder/workspaceDeployment"
 import { automationStore } from "./automations"
 import { workspaceAppStore } from "./workspaceApps"
+import { agentsStore } from "@/stores/portal/agents"
 
 interface DeploymentState {
   deployments: DeploymentProgressResponse[]
@@ -115,6 +116,7 @@ class DeploymentStore extends DerivedBudiStore<
         workspaceAppStore.refresh(),
         appsStore.load(),
         automationStore.actions.fetch(),
+        agentsStore.fetchAgents(),
       ])
       await this.load()
     } catch (err) {


### PR DESCRIPTION
## Description
We weren't showing if any agents had been published in the publish popover. 


## Screenshots
<img width="242" height="150" alt="image" src="https://github.com/user-attachments/assets/befce901-029b-417a-bfe9-78750ecc939b" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds agent publish details to the Publish popover, gated by the AI Agents feature flag. Agents are fetched during deployment so the popover shows accurate counts.

<sup>Written for commit 446ecccdf9b4dfb3dddb6640190fe428eeea9748. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

