### PR TITLE
Bypass via webhook query param

### DIFF
--- a/packages/server/src/middleware/tests/authorized.spec.ts
+++ b/packages/server/src/middleware/tests/authorized.spec.ts
@@ -33,6 +33,7 @@ class TestConfiguration {
     this.headers = {}
     this.ctx = {
       headers: {},
+      path: "",
       request: {
         url: "",
       },
@@ -67,6 +68,7 @@ class TestConfiguration {
 
   setRequestUrl(url: string) {
     this.ctx.request.url = url
+    this.ctx.path = url.split("?")[0]
   }
 
   setEnvironment(isProd: boolean) {
@@ -219,6 +221,32 @@ describe("Authorization middleware", () => {
         expect(mockedGetResourcePerms).toHaveBeenCalledTimes(1)
         expect(mockedGetResourcePerms).toHaveBeenCalledWith(resourceId)
       })
+    })
+  })
+
+  describe("webhook detection", () => {
+    beforeEach(() => {
+      config = new TestConfiguration()
+      config.setEnvironment(true)
+      config.setAuthenticated(true)
+    })
+
+    it("does not bypass auth when webhook path appears in query string", async () => {
+      config.setRequestUrl("/api/tables?/webhooks/trigger")
+
+      await config.executeMiddleware()
+
+      expect(config.throw).toHaveBeenCalledWith(401, "No user info found")
+      expect(config.next).not.toHaveBeenCalled()
+    })
+
+    it("bypasses auth for actual webhook endpoints", async () => {
+      config.setRequestUrl("/api/webhooks/trigger/app-id/webhook-id")
+
+      await config.executeMiddleware()
+
+      expect(config.next).toHaveBeenCalled()
+      expect(config.throw).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/server/src/middleware/tests/authorized.spec.ts
+++ b/packages/server/src/middleware/tests/authorized.spec.ts
@@ -20,10 +20,10 @@ const APP_ID = ""
 initProMocks()
 
 class TestConfiguration {
-  middleware: (ctx: any, next: any) => Promise<void>
+  middleware: ReturnType<typeof authorizedMiddleware>
   next: () => void
   throw: () => void
-  headers: Record<string, any>
+  headers: Record<string, string>
   ctx: any
 
   constructor() {
@@ -53,8 +53,9 @@ class TestConfiguration {
     this.ctx.user = user
   }
 
-  setMiddlewareRequiredPermission(...perms: any[]) {
-    // @ts-ignore
+  setMiddlewareRequiredPermission(
+    ...perms: Parameters<typeof authorizedMiddleware>
+  ) {
     this.middleware = authorizedMiddleware(...perms)
   }
 
@@ -75,7 +76,7 @@ class TestConfiguration {
     env._set("NODE_ENV", isProd ? "production" : "jest")
   }
 
-  setRequestHeaders(headers: Record<string, any>) {
+  setRequestHeaders(headers: Record<string, string>) {
     this.ctx.headers = headers
   }
 

--- a/packages/server/src/middleware/utils.ts
+++ b/packages/server/src/middleware/utils.ts
@@ -1,17 +1,12 @@
 import { LoginMethod, UserCtx } from "@budibase/types"
 
 const WEBHOOK_ENDPOINTS = new RegExp(
-  [
-    "webhooks/trigger",
-    "webhooks/schema",
-    "webhooks/discord",
-    "webhooks/ms-teams",
-    "webhooks/slack",
-  ].join("|")
+  "^/api/webhooks/(trigger|schema|discord|ms-teams|slack)(/|$)"
 )
 
 export function isWebhookEndpoint(ctx: UserCtx) {
-  return WEBHOOK_ENDPOINTS.test(ctx.request.url)
+  const path = ctx.path || ctx.request.url.split("?")[0]
+  return WEBHOOK_ENDPOINTS.test(path)
 }
 
 export function isBrowser(ctx: UserCtx) {

--- a/packages/server/src/middleware/utils.ts
+++ b/packages/server/src/middleware/utils.ts
@@ -4,16 +4,16 @@ const WEBHOOK_ENDPOINTS = new RegExp(
   "^/api/webhooks/(trigger|schema|discord|ms-teams|slack)(/|$)"
 )
 
-export function isWebhookEndpoint(ctx: UserCtx) {
+export function isWebhookEndpoint(ctx: UserCtx): boolean {
   const path = ctx.path || ctx.request.url.split("?")[0]
   return WEBHOOK_ENDPOINTS.test(path)
 }
 
-export function isBrowser(ctx: UserCtx) {
+export function isBrowser(ctx: UserCtx): boolean {
   const browser = ctx.userAgent?.browser
-  return browser && browser !== "unknown"
+  return !!browser && browser !== "unknown"
 }
 
-export function isApiKey(ctx: UserCtx) {
+export function isApiKey(ctx: UserCtx): boolean {
   return ctx.loginMethod === LoginMethod.API_KEY
 }


### PR DESCRIPTION
## Description
Fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an auth bypass where webhook endpoints were mistakenly detected from query params. Webhook detection now uses the request path with a stricter, anchored regex, so only real webhook routes are bypassed.

- **Bug Fixes**
  - Parse path without query string before webhook checks.
  - Anchor webhook regex to /api/webhooks and specific actions.
  - Add tests to block query-based bypass and allow real webhook routes.

<sup>Written for commit 9587e1607341ebed17c1a3496c18a3a9697bb35d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

