### PR TITLE
Revert "Update the add SSO endpoint to use the internal api guard."

### DIFF
--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -153,9 +153,6 @@ export const changeTenantOwnerEmail = async (
 export const addSsoSupport = async (
   ctx: Ctx<AddSSoUserRequest, AddSSoUserResponse>
 ) => {
-  if (!ctx.internal) {
-    ctx.throw(403, "Unauthorized")
-  }
   const { email, ssoId } = ctx.request.body
   try {
     const [userByEmail] = await users.getExistingPlatformUsers([email])

--- a/packages/worker/src/api/index.ts
+++ b/packages/worker/src/api/index.ts
@@ -42,6 +42,10 @@ const PUBLIC_ENDPOINTS = [
     method: "POST",
   },
   {
+    route: "/api/global/users/sso",
+    method: "POST",
+  },
+  {
     route: "/api/global/users/invite/accept",
     method: "POST",
   },

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -1,11 +1,6 @@
 import { InviteUsersResponse, OIDCUser, User } from "@budibase/types"
 
-import {
-  accounts as _accounts,
-  events,
-  tenancy,
-  withEnv,
-} from "@budibase/backend-core"
+import { accounts as _accounts, events, tenancy } from "@budibase/backend-core"
 import { mocks as featureMocks } from "@budibase/backend-core/tests"
 import { sdk as proSdk } from "@budibase/pro"
 import * as userSdk from "../../../../sdk/users"
@@ -823,16 +818,6 @@ describe("/api/global/users", () => {
           .addSsoSupportDefaultAuth(ssoId, user.email)
           .expect("Content-Type", /json/)
           .expect(403)
-      })
-
-      it("sso support cannot be used without internal key on self-hosted", async () => {
-        const user = await createPasswordUser()
-        const ssoId = "fake-ssoId"
-        await withEnv({ SELF_HOSTED: true }, () =>
-          config.api.users
-            .addSsoSupportDefaultAuth(ssoId, user.email)
-            .expect(403)
-        )
       })
 
       it("if user email doesn't exist, SSO support couldn't be added. Not found error returned", async () => {


### PR DESCRIPTION
Reverts Budibase/budibase#18160

Checking if this is causing issues on cloud login

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the internal API guard on the add SSO endpoint to unblock cloud login. The /api/global/users/sso route is public again and no longer requires the internal key.

- **Bug Fixes**
  - Removed ctx.internal check from addSsoSupport.
  - Added /api/global/users/sso to PUBLIC_ENDPOINTS.
  - Removed self-hosted test that expected a 403 without the internal key.

<sup>Written for commit f086c67f802e969f4715ab5fb7161af368a45d2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

