### PR TITLE
Remove modal as freetext

### DIFF
--- a/packages/bbui/src/Form/Core/Combobox.svelte
+++ b/packages/bbui/src/Form/Core/Combobox.svelte
@@ -33,15 +33,21 @@
   let focus = false
   let anchor
   let query = ""
+  const normalizeForSearch = (value: unknown): string => {
+    if (value === null || value === undefined) {
+      return ""
+    }
+    return String(value).toLowerCase()
+  }
 
   $: query = value || ""
   $: filteredOptions =
     !query.trim() || !options?.length
       ? options
       : options.filter(option => {
-          const optionLabel = getOptionLabel(option)?.toLowerCase() || ""
-          const optionValue = getOptionValue(option)?.toLowerCase() || ""
-          const search = query.toLowerCase()
+          const optionLabel = normalizeForSearch(getOptionLabel(option))
+          const optionValue = normalizeForSearch(getOptionValue(option))
+          const search = normalizeForSearch(query)
           return (
             optionLabel.includes(search) || optionValue.includes(search)
           )

--- a/packages/bbui/src/Form/Core/Combobox.svelte
+++ b/packages/bbui/src/Form/Core/Combobox.svelte
@@ -48,9 +48,7 @@
           const optionLabel = normalizeForSearch(getOptionLabel(option))
           const optionValue = normalizeForSearch(getOptionValue(option))
           const search = normalizeForSearch(query)
-          return (
-            optionLabel.includes(search) || optionValue.includes(search)
-          )
+          return optionLabel.includes(search) || optionValue.includes(search)
         })
 
   const selectOption = (value: string, shouldClose = true) => {

--- a/packages/bbui/src/Form/Core/Combobox.svelte
+++ b/packages/bbui/src/Form/Core/Combobox.svelte
@@ -7,7 +7,7 @@
   import "@spectrum-css/menu/dist/index-vars.css"
   import "@spectrum-css/popover/dist/index-vars.css"
   import { createEventDispatcher } from "svelte"
-  import type { ChangeEventHandler } from "svelte/elements"
+  import type { FormEventHandler } from "svelte/elements"
   import clickOutside from "../../Actions/clickOutside"
   import { PopoverAlignment } from "../../constants"
   import Icon from "../../Icon/Icon.svelte"
@@ -32,16 +32,30 @@
   let open = false
   let focus = false
   let anchor
+  let query = ""
 
-  const selectOption = (value: string) => {
+  $: query = value || ""
+  $: filteredOptions =
+    !query.trim() || !options?.length
+      ? options
+      : options.filter(option => {
+          const optionLabel = getOptionLabel(option)?.toLowerCase() || ""
+          const optionValue = getOptionValue(option)?.toLowerCase() || ""
+          const search = query.toLowerCase()
+          return (
+            optionLabel.includes(search) || optionValue.includes(search)
+          )
+        })
+
+  const selectOption = (value: string, shouldClose = true) => {
     dispatch("change", value)
-    open = false
+    open = !shouldClose
   }
 
-  const onType: ChangeEventHandler<HTMLInputElement> = e => {
+  const onType: FormEventHandler<HTMLInputElement> = e => {
     const value = e.currentTarget.value
     dispatch("type", value)
-    selectOption(value)
+    selectOption(value, false)
   }
 
   const onPick = (value: string) => {
@@ -69,7 +83,7 @@
         focus = false
         dispatch("blur")
       }}
-      on:change={onType}
+      on:input={onType}
       value={value || ""}
       placeholder={placeholder || ""}
       {disabled}
@@ -103,8 +117,8 @@
     }}
   >
     <ul class="spectrum-Menu" role="listbox">
-      {#if options && Array.isArray(options)}
-        {#each options as option}
+      {#if filteredOptions && Array.isArray(filteredOptions) && filteredOptions.length}
+        {#each filteredOptions as option}
           <li
             class="spectrum-Menu-item"
             class:is-selected={getOptionValue(option) === value}
@@ -120,6 +134,8 @@
             </div>
           </li>
         {/each}
+      {:else}
+        <li class="spectrum-Menu-item empty">No results</li>
       {/if}
     </ul>
   </div>
@@ -138,6 +154,11 @@
   }
   .check {
     display: none;
+  }
+
+  .empty {
+    opacity: 0.7;
+    cursor: default;
   }
   li.is-selected .check {
     display: block;

--- a/packages/builder/src/settings/pages/ai/AIConfigForm.svelte
+++ b/packages/builder/src/settings/pages/ai/AIConfigForm.svelte
@@ -89,6 +89,9 @@
     }, {})
   )
   let selectedProvider = $derived(providersMap?.[draft.provider])
+  let hasProviderModelOptions = $derived(
+    !!selectedProvider?.models?.length && !!draft.provider?.trim()
+  )
   let modelOptions = $derived.by(() => {
     const models = selectedProvider?.models || []
     const options = models.map<ModelOption>(model => ({
@@ -260,17 +263,27 @@
       loading={!providers}
     />
 
-    <Select
-      label="Model"
-      description="The model you would like to connect to"
-      required
-      bind:value={draft.model}
-      options={modelOptions}
-      getOptionValue={o => o.value}
-      getOptionLabel={o => o.label}
-      placeholder={modelPlaceholder}
-      loading={!providers}
-    />
+    {#if hasProviderModelOptions}
+      <Select
+        label="Model"
+        description="The model you would like to connect to"
+        required
+        bind:value={draft.model}
+        options={modelOptions}
+        getOptionValue={o => o.value}
+        getOptionLabel={o => o.label}
+        placeholder={modelPlaceholder}
+        loading={!providers}
+      />
+    {:else}
+      <Input
+        label="Model"
+        description="The model you would like to connect to"
+        required
+        bind:value={draft.model}
+        placeholder="GPT-5.2"
+      />
+    {/if}
 
     <Input
       label="Display name"

--- a/packages/builder/src/settings/pages/ai/AIConfigForm.svelte
+++ b/packages/builder/src/settings/pages/ai/AIConfigForm.svelte
@@ -56,6 +56,7 @@
         } satisfies RequiredKeys<CreateAIConfigRequest>)
 
   let draft: AIConfigResponse = $state(createDraft())
+  let previousProvider = $state(draft.provider)
 
   let isEdit = $derived(!!draft._id)
   let typeLabel = $derived(
@@ -141,6 +142,13 @@
         f => f.required && !draft.credentialsFields[f.key]?.trim()
       )
     )
+  })
+
+  $effect(() => {
+    if (previousProvider !== draft.provider) {
+      draft.model = ""
+      previousProvider = draft.provider
+    }
   })
 
   onMount(async () => {

--- a/packages/builder/src/settings/pages/ai/AIConfigForm.svelte
+++ b/packages/builder/src/settings/pages/ai/AIConfigForm.svelte
@@ -2,7 +2,14 @@
   import { confirm } from "@/helpers"
   import { bb } from "@/stores/bb"
   import { aiConfigsStore } from "@/stores/portal"
-  import { Button, Helpers, Input, notifications, Select } from "@budibase/bbui"
+  import {
+    Button,
+    Combobox,
+    Helpers,
+    Input,
+    notifications,
+    Select,
+  } from "@budibase/bbui"
   import type {
     AIConfigResponse,
     CreateAIConfigRequest,
@@ -90,9 +97,6 @@
     }, {})
   )
   let selectedProvider = $derived(providersMap?.[draft.provider])
-  let hasProviderModelOptions = $derived(
-    !!selectedProvider?.models?.length && !!draft.provider?.trim()
-  )
   let modelOptions = $derived.by(() => {
     const models = selectedProvider?.models || []
     const options = models.map<ModelOption>(model => ({
@@ -114,7 +118,7 @@
     if (!providers) {
       return "Loading models..."
     }
-    return modelOptions.length ? "Select a model" : "No models available"
+    return modelOptions.length ? "Select or type a model" : "Type a model"
   })
 
   let isSaving = $state(false)
@@ -273,29 +277,14 @@
       searchPlaceholder="Search providers"
     />
 
-    {#if hasProviderModelOptions}
-      <Select
-        label="Model"
-        description="The model you would like to connect to"
-        required
-        bind:value={draft.model}
-        options={modelOptions}
-        getOptionValue={o => o.value}
-        getOptionLabel={o => o.label}
-        placeholder={modelPlaceholder}
-        loading={!providers}
-        autocomplete
-        searchPlaceholder="Search models"
-      />
-    {:else}
-      <Input
-        label="Model"
-        description="The model you would like to connect to"
-        required
-        bind:value={draft.model}
-        placeholder="GPT-5.2"
-      />
-    {/if}
+    <Combobox
+      label="Model"
+      bind:value={draft.model}
+      options={modelOptions}
+      getOptionValue={o => o.value}
+      getOptionLabel={o => o.label}
+      placeholder={modelPlaceholder}
+    />
 
     <Input
       label="Display name"

--- a/packages/builder/src/settings/pages/ai/AIConfigForm.svelte
+++ b/packages/builder/src/settings/pages/ai/AIConfigForm.svelte
@@ -269,6 +269,8 @@
       getOptionLabel={o => o.displayName}
       placeholder={providerPlaceholder}
       loading={!providers}
+      autocomplete
+      searchPlaceholder="Search providers"
     />
 
     {#if hasProviderModelOptions}
@@ -282,6 +284,8 @@
         getOptionLabel={o => o.label}
         placeholder={modelPlaceholder}
         loading={!providers}
+        autocomplete
+        searchPlaceholder="Search models"
       />
     {:else}
       <Input

--- a/packages/builder/src/settings/pages/ai/AIConfigForm.svelte
+++ b/packages/builder/src/settings/pages/ai/AIConfigForm.svelte
@@ -67,6 +67,10 @@
     { label: "Medium", value: "medium" },
     { label: "High", value: "high" },
   ]
+  interface ModelOption {
+    label: string
+    value: string
+  }
 
   let providers = $derived($aiConfigsStore.providers)
 
@@ -85,6 +89,29 @@
     }, {})
   )
   let selectedProvider = $derived(providersMap?.[draft.provider])
+  let modelOptions = $derived.by(() => {
+    const models = selectedProvider?.models || []
+    const options = models.map<ModelOption>(model => ({
+      label: model,
+      value: model,
+    }))
+    if (draft.model?.trim() && !models.includes(draft.model)) {
+      options.unshift({
+        label: `${draft.model} (custom)`,
+        value: draft.model,
+      })
+    }
+    return options
+  })
+  let modelPlaceholder = $derived.by(() => {
+    if (!draft.provider?.trim()) {
+      return "Choose a provider first"
+    }
+    if (!providers) {
+      return "Loading models..."
+    }
+    return modelOptions.length ? "Select a model" : "No models available"
+  })
 
   let isSaving = $state(false)
   let savedSnapshot = $state(JSON.stringify(draft))
@@ -233,12 +260,16 @@
       loading={!providers}
     />
 
-    <Input
+    <Select
       label="Model"
       description="The model you would like to connect to"
       required
       bind:value={draft.model}
-      placeholder="GPT-5.2"
+      options={modelOptions}
+      getOptionValue={o => o.value}
+      getOptionLabel={o => o.label}
+      placeholder={modelPlaceholder}
+      loading={!providers}
     />
 
     <Input

--- a/packages/builder/src/settings/pages/ai/AIConfigForm.svelte
+++ b/packages/builder/src/settings/pages/ai/AIConfigForm.svelte
@@ -98,7 +98,7 @@
   )
   let selectedProvider = $derived(providersMap?.[draft.provider])
   let modelOptions = $derived.by(() => {
-    const models = selectedProvider?.models || []
+    const models = selectedProvider?.models?.[draft.configType] || []
     const options = models.map<ModelOption>(model => ({
       label: model,
       value: model,

--- a/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
@@ -44,6 +44,17 @@ describe("agent files", () => {
         },
       ])
 
+  const mockLiteLLMModelCostMap = () =>
+    nock(environment.LITELLM_URL)
+      .persist()
+      .get("/public/litellm_model_cost_map")
+      .reply(200, {
+        "text-embedding-3-small": {
+          litellm_provider: "openai",
+          mode: "embedding",
+        },
+      })
+
   afterAll(() => {
     config.end()
   })
@@ -52,6 +63,7 @@ describe("agent files", () => {
 
   const createAgentWithRag = async () => {
     mockLiteLLMProviders()
+    mockLiteLLMModelCostMap()
     const embeddingValidationScope = nock(environment.LITELLM_URL)
       .post("/v1/embeddings")
       .reply(200, { data: [] })

--- a/packages/server/src/api/routes/tests/ai/aiConfig.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/aiConfig.spec.ts
@@ -119,7 +119,9 @@ describe("BudibaseAI", () => {
 
     it("fetches provider-specific models from LiteLLM cost map", async () => {
       const providers = await config.api.ai.fetchProviders()
-      const openAIProvider = providers.find(provider => provider.id === "OpenAI")
+      const openAIProvider = providers.find(
+        provider => provider.id === "OpenAI"
+      )
       expect(openAIProvider).toMatchObject({
         models: {
           completions: ["gpt-4o", "gpt-4o-mini"],

--- a/packages/server/src/api/routes/tests/ai/aiConfig.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/aiConfig.spec.ts
@@ -49,9 +49,13 @@ const mockLiteLLMModelCostMap = () =>
     .persist()
     .get("/public/litellm_model_cost_map")
     .reply(200, {
-      "gpt-4o-mini": { litellm_provider: "openai" },
-      "claude-3-5-haiku": { litellm_provider: "anthropic" },
-      "gpt-4o": { litellm_provider: ["openai", "azure"] },
+      "gpt-4o-mini": { litellm_provider: "openai", mode: "chat" },
+      "text-embedding-3-small": {
+        litellm_provider: "openai",
+        mode: "embedding",
+      },
+      "claude-3-5-haiku": { litellm_provider: "anthropic", mode: "chat" },
+      "gpt-4o": { litellm_provider: ["openai", "azure"], mode: "responses" },
     })
 
 const mockLiteLLMTeam = () =>
@@ -117,7 +121,10 @@ describe("BudibaseAI", () => {
       const providers = await config.api.ai.fetchProviders()
       const openAIProvider = providers.find(provider => provider.id === "OpenAI")
       expect(openAIProvider).toMatchObject({
-        models: ["gpt-4o", "gpt-4o-mini"],
+        models: {
+          completions: ["gpt-4o", "gpt-4o-mini"],
+          embeddings: ["text-embedding-3-small"],
+        },
       })
     })
 

--- a/packages/server/src/api/routes/tests/ai/aiConfig.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/aiConfig.spec.ts
@@ -44,6 +44,16 @@ const mockLiteLLMProviders = () =>
       },
     ])
 
+const mockLiteLLMModelCostMap = () =>
+  nock(environment.LITELLM_URL)
+    .persist()
+    .get("/public/litellm_model_cost_map")
+    .reply(200, {
+      "gpt-4o-mini": { litellm_provider: "openai" },
+      "claude-3-5-haiku": { litellm_provider: "anthropic" },
+      "gpt-4o": { litellm_provider: ["openai", "azure"] },
+    })
+
 const mockLiteLLMTeam = () =>
   nock(environment.LITELLM_URL)
     .persist()
@@ -99,7 +109,16 @@ describe("BudibaseAI", () => {
       nock.cleanAll()
 
       mockLiteLLMProviders()
+      mockLiteLLMModelCostMap()
       mockLiteLLMTeam()
+    })
+
+    it("fetches provider-specific models from LiteLLM cost map", async () => {
+      const providers = await config.api.ai.fetchProviders()
+      const openAIProvider = providers.find(provider => provider.id === "OpenAI")
+      expect(openAIProvider).toMatchObject({
+        models: ["gpt-4o", "gpt-4o-mini"],
+      })
     })
 
     it("creates a custom config and sanitizes the API key", async () => {

--- a/packages/server/src/sdk/workspace/ai/configs/index.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/index.ts
@@ -365,11 +365,38 @@ let liteLLMProviders: LLMProvider[]
 export async function fetchLiteLLMProviders(): Promise<LLMProvider[]> {
   if (!liteLLMProviders?.length) {
     const providers = await liteLLM.fetchPublicProviders()
+    let modelCostMap: Awaited<
+      ReturnType<typeof liteLLM.fetchPublicModelCostMap>
+    > = {}
+    try {
+      modelCostMap = await liteLLM.fetchPublicModelCostMap()
+    } catch (err) {
+      console.log("Failed to fetch LiteLLM model cost map", err)
+    }
+
     liteLLMProviders = providers.map(provider => {
+      const models = Object.entries(modelCostMap)
+        .filter(([, metadata]) => {
+          const modelProvider = metadata?.litellm_provider
+          if (Array.isArray(modelProvider)) {
+            return modelProvider.includes(provider.litellm_provider)
+          }
+          if (typeof modelProvider === "string") {
+            return modelProvider
+              .split(",")
+              .map(value => value.trim())
+              .includes(provider.litellm_provider)
+          }
+          return false
+        })
+        .map(([modelId]) => modelId)
+        .sort((a, b) => a.localeCompare(b))
+
       const mapProvider: RequiredKeys<LLMProvider> = {
         id: provider.provider,
         displayName: provider.provider_display_name,
         externalProvider: provider.litellm_provider,
+        models,
         credentialFields: provider.credential_fields.map(f => {
           const field: RequiredKeys<LLMProviderField> = {
             key: f.key,
@@ -391,6 +418,7 @@ export async function fetchLiteLLMProviders(): Promise<LLMProvider[]> {
       id: BUDIBASE_AI_PROVIDER_ID,
       displayName: "Budibase AI",
       externalProvider: "custom_openai",
+      models: ["budibase/v1"],
       credentialFields: [
         { key: "api_key", label: "api_key", field_type: "password" },
       ],

--- a/packages/server/src/sdk/workspace/ai/configs/index.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/index.ts
@@ -375,22 +375,60 @@ export async function fetchLiteLLMProviders(): Promise<LLMProvider[]> {
     }
 
     liteLLMProviders = providers.map(provider => {
-      const models = Object.entries(modelCostMap)
-        .filter(([, metadata]) => {
+      const modelsByType = Object.entries(modelCostMap).reduce<{
+        completions: string[]
+        embeddings: string[]
+      }>(
+        (acc, [modelId, metadata]) => {
           const modelProvider = metadata?.litellm_provider
-          if (Array.isArray(modelProvider)) {
-            return modelProvider.includes(provider.litellm_provider)
+          const isMatchingProvider = Array.isArray(modelProvider)
+            ? modelProvider.includes(provider.litellm_provider)
+            : typeof modelProvider === "string"
+              ? modelProvider
+                  .split(",")
+                  .map(value => value.trim())
+                  .includes(provider.litellm_provider)
+              : false
+
+          if (!isMatchingProvider) {
+            return acc
           }
-          if (typeof modelProvider === "string") {
-            return modelProvider
-              .split(",")
-              .map(value => value.trim())
-              .includes(provider.litellm_provider)
+
+          const modelModes = Array.isArray(metadata?.mode)
+            ? metadata.mode
+            : typeof metadata?.mode === "string"
+              ? metadata.mode.split(",")
+              : []
+          const normalizedModes = modelModes.map(mode =>
+            mode.trim().toLowerCase()
+          )
+
+          if (normalizedModes.includes("embedding")) {
+            acc.embeddings.push(modelId)
           }
-          return false
-        })
-        .map(([modelId]) => modelId)
-        .sort((a, b) => a.localeCompare(b))
+
+          if (
+            !normalizedModes.length ||
+            normalizedModes.some(mode =>
+              ["chat", "completion", "responses"].includes(mode)
+            )
+          ) {
+            acc.completions.push(modelId)
+          }
+
+          return acc
+        },
+        { completions: [], embeddings: [] }
+      )
+
+      const models = {
+        completions: [...new Set(modelsByType.completions)].sort((a, b) =>
+          a.localeCompare(b)
+        ),
+        embeddings: [...new Set(modelsByType.embeddings)].sort((a, b) =>
+          a.localeCompare(b)
+        ),
+      }
 
       const mapProvider: RequiredKeys<LLMProvider> = {
         id: provider.provider,
@@ -418,7 +456,10 @@ export async function fetchLiteLLMProviders(): Promise<LLMProvider[]> {
       id: BUDIBASE_AI_PROVIDER_ID,
       displayName: "Budibase AI",
       externalProvider: "custom_openai",
-      models: ["budibase/v1"],
+      models: {
+        completions: ["budibase/v1"],
+        embeddings: [],
+      },
       credentialFields: [
         { key: "api_key", label: "api_key", field_type: "password" },
       ],

--- a/packages/server/src/sdk/workspace/ai/configs/index.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/index.ts
@@ -364,15 +364,10 @@ let liteLLMProviders: LLMProvider[]
 
 export async function fetchLiteLLMProviders(): Promise<LLMProvider[]> {
   if (!liteLLMProviders?.length) {
-    const providers = await liteLLM.fetchPublicProviders()
-    let modelCostMap: Awaited<
-      ReturnType<typeof liteLLM.fetchPublicModelCostMap>
-    > = {}
-    try {
-      modelCostMap = await liteLLM.fetchPublicModelCostMap()
-    } catch (err) {
-      console.log("Failed to fetch LiteLLM model cost map", err)
-    }
+    const [providers, modelCostMap] = await Promise.all([
+      liteLLM.fetchPublicProviders(),
+      liteLLM.fetchPublicModelCostMap(),
+    ])
 
     liteLLMProviders = providers.map(provider => {
       const modelsByType = Object.entries(modelCostMap).reduce<{

--- a/packages/server/src/sdk/workspace/ai/configs/litellm.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/litellm.ts
@@ -511,6 +511,7 @@ type LiteLLMModelCostMap = Record<
   string,
   {
     litellm_provider?: string | string[] | null
+    mode?: string | string[] | null
   }
 >
 

--- a/packages/server/src/sdk/workspace/ai/configs/litellm.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/litellm.ts
@@ -507,6 +507,27 @@ export async function fetchPublicProviders(): Promise<LiteLLMPublicProvider[]> {
   return json as LiteLLMPublicProvider[]
 }
 
+type LiteLLMModelCostMap = Record<
+  string,
+  {
+    litellm_provider?: string | string[] | null
+  }
+>
+
+export async function fetchPublicModelCostMap(): Promise<LiteLLMModelCostMap> {
+  const res = await fetch(`${liteLLMUrl}/public/litellm_model_cost_map`)
+  if (!res.ok) {
+    const text = await res.text()
+    throw new HTTPError(
+      `Error fetching LiteLLM model cost map: ${text || res.statusText}`,
+      res.status
+    )
+  }
+
+  const json = await res.json()
+  return json as LiteLLMModelCostMap
+}
+
 async function mapToLiteLLMProvider(provider: string) {
   if (provider === BUDIBASE_AI_PROVIDER_ID) {
     return "custom_openai"

--- a/packages/server/src/tests/utilities/api/ai.ts
+++ b/packages/server/src/tests/utilities/api/ai.ts
@@ -1,6 +1,7 @@
 import { constants } from "@budibase/backend-core"
 import {
   AIConfigListResponse,
+  LLMProvidersResponse,
   ChatCompletionRequest,
   ChatCompletionRequestV2,
   ChatCompletionResponse,
@@ -157,6 +158,14 @@ export class AIAPI extends TestAPI {
     expectations?: Expectations
   ): Promise<AIConfigListResponse> => {
     return await this._get<AIConfigListResponse>(`/api/configs`, {
+      expectations,
+    })
+  }
+
+  fetchProviders = async (
+    expectations?: Expectations
+  ): Promise<LLMProvidersResponse> => {
+    return await this._get<LLMProvidersResponse>(`/api/configs/providers`, {
       expectations,
     })
   }

--- a/packages/types/src/api/web/global/aiConfigs.ts
+++ b/packages/types/src/api/web/global/aiConfigs.ts
@@ -36,6 +36,7 @@ export interface LLMProvider {
   displayName: string
   externalProvider: string
   credentialFields: LLMProviderField[]
+  models?: string[]
 }
 
 export type LLMProvidersResponse = LLMProvider[]

--- a/packages/types/src/api/web/global/aiConfigs.ts
+++ b/packages/types/src/api/web/global/aiConfigs.ts
@@ -31,12 +31,17 @@ export interface LLMProviderField {
   default_value?: string | null
 }
 
+export interface LLMProviderModels {
+  completions: string[]
+  embeddings: string[]
+}
+
 export interface LLMProvider {
   id: string
   displayName: string
   externalProvider: string
   credentialFields: LLMProviderField[]
-  models?: string[]
+  models?: LLMProviderModels
 }
 
 export type LLMProvidersResponse = LLMProvider[]


### PR DESCRIPTION
## Description
We are going to release the new ai config, and I was revisiting it the UX. Thought on having this?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements provider-scoped model selection with an autocomplete Combobox synced to the chosen provider. Providers and the LiteLLM model cost map load in parallel; the model resets when the provider changes.

- **New Features**
  - Model field is now a Combobox with type-ahead, input filtering, keeps menu open while typing, shows “No results”, accepts custom entries; dynamic placeholder; allows free text if the provider has no known models.
  - Provider select gets autocomplete with a search placeholder.
  - Server returns provider-scoped models (completions, embeddings) from LiteLLM’s cost map; Budibase AI exposes “budibase/v1” for completions.
  - Types updated; tests added for provider models, providers API, and agent files; test fix included.

<sup>Written for commit efd7928e27daf042361186c7e125379d0f8112d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

