### PR TITLE
Improve migration checks

### DIFF
--- a/packages/builder/src/pages/builder/workspace/updating/[application].svelte
+++ b/packages/builder/src/pages/builder/workspace/updating/[application].svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { Updating } from "@budibase/frontend-core"
   import { redirect, params } from "@roxi/routify"
   import { get } from "svelte/store"
@@ -6,7 +6,7 @@
   import { API } from "@/api"
   import { appStore } from "@/stores/builder"
 
-  export let application
+  export let application: string
 
   // Set appId immediately so API calls have the correct context
   // Only update if it's different to avoid unnecessary re-renders

--- a/packages/client/src/components/UpdatingApp.svelte
+++ b/packages/client/src/components/UpdatingApp.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { Updating } from "@budibase/frontend-core"
   import { API } from "../api"
   import { onMount } from "svelte"

--- a/packages/frontend-core/src/api/index.ts
+++ b/packages/frontend-core/src/api/index.ts
@@ -209,8 +209,9 @@ export const createAPIClient = (config: APIClientConfig = {}): APIClient => {
       return
     }
     const migration = response.headers.get(Header.MIGRATING_APP)
+    const shouldSkipWait = response.headers.get(Header.SKIP_MIGRATING_WAIT)
 
-    if (migration) {
+    if (migration && !shouldSkipWait) {
       config.onMigrationDetected(migration)
     }
   }

--- a/packages/frontend-core/src/components/Updating.svelte
+++ b/packages/frontend-core/src/components/Updating.svelte
@@ -8,7 +8,7 @@
   async function checkMigrationsFinished() {
     let totalWaitMs = 0
     while (true) {
-      const waitForMs = 500
+      const waitForMs = 500 + Math.random() * 200
       await new Promise(resolve => setTimeout(resolve, waitForMs))
       totalWaitMs += waitForMs
 

--- a/packages/frontend-core/src/components/Updating.svelte
+++ b/packages/frontend-core/src/components/Updating.svelte
@@ -8,7 +8,7 @@
   async function checkMigrationsFinished() {
     let totalWaitMs = 0
     while (true) {
-      const waitForMs = 5000 + Math.random() * 5000
+      const waitForMs = 500
       await new Promise(resolve => setTimeout(resolve, waitForMs))
       totalWaitMs += waitForMs
 

--- a/packages/frontend-core/src/components/Updating.svelte
+++ b/packages/frontend-core/src/components/Updating.svelte
@@ -1,6 +1,6 @@
-<script>
-  export let isMigrationDone
-  export let onMigrationDone
+<script lang="ts">
+  export let isMigrationDone: () => Promise<boolean>
+  export let onMigrationDone: () => void
   export let timeoutSeconds = 60 // 1 minute
 
   let timedOut = false

--- a/packages/server/src/environment.ts
+++ b/packages/server/src/environment.ts
@@ -149,7 +149,7 @@ const environment = {
   ENABLE_PLUGIN_GH_ORIGIN_BACKFILL:
     process.env.ENABLE_PLUGIN_GH_ORIGIN_BACKFILL ?? "true",
   SYNC_MIGRATION_CHECKS_MS:
-    parseIntSafe(process.env.SYNC_MIGRATION_CHECKS_MS) || 5000,
+    parseIntSafe(process.env.SYNC_MIGRATION_CHECKS_MS) || 2000,
   SKIP_MIGRATION_LOCKS_IN_TESTS:
     process.env.SKIP_MIGRATION_LOCKS_IN_TESTS ?? true,
   REST_REJECT_UNAUTHORIZED: process.env.REST_REJECT_UNAUTHORIZED !== "false",

--- a/packages/server/src/workspaceMigrations/index.ts
+++ b/packages/server/src/workspaceMigrations/index.ts
@@ -1,4 +1,5 @@
 import { context, db, Header } from "@budibase/backend-core"
+import { ClientHeader } from "@budibase/shared-core"
 import { UserCtx } from "@budibase/types"
 import { Next } from "koa"
 import environment from "../environment"
@@ -17,10 +18,14 @@ export type WorkspaceMigration = {
   disabled?: boolean
 }
 
-const SKIP_MIGRATION_WAIT_ENDPOINTS = new RegExp(["appPackage"].join("|"))
+const BUILDER_APP_PACKAGE_ENDPOINT =
+  /^\/api\/applications\/[^/]+\/appPackage\/?$/
 
 function shouldSkipMigrationWait(ctx: UserCtx): boolean {
-  return SKIP_MIGRATION_WAIT_ENDPOINTS.test(ctx.path || "")
+  return (
+    BUILDER_APP_PACKAGE_ENDPOINT.test(ctx.path || "") &&
+    ctx.headers[Header.CLIENT] === ClientHeader.BUILDER
+  )
 }
 
 export function getLatestEnabledMigrationId(migrations?: WorkspaceMigration[]) {

--- a/packages/server/src/workspaceMigrations/index.ts
+++ b/packages/server/src/workspaceMigrations/index.ts
@@ -90,6 +90,7 @@ export async function checkMissingMigrations(
       }
     } else {
       ctx.response.set(Header.MIGRATING_APP, workspaceId)
+      ctx.response.set(Header.SKIP_MIGRATING_WAIT, "true")
     }
   }
 

--- a/packages/shared-core/src/constants/api.ts
+++ b/packages/shared-core/src/constants/api.ts
@@ -21,5 +21,6 @@ export enum Header {
   CORRELATION_ID = "x-budibase-correlation-id",
   AUTHORIZATION = "authorization",
   MIGRATING_APP = "x-budibase-migrating-app",
+  SKIP_MIGRATING_WAIT = "x-budibase-migrating-app-skip-wait",
   COOKIE = "cookie",
 }


### PR DESCRIPTION
## Description
UX bug introduced in here: https://github.com/Budibase/budibase/pull/17432

### Running a quick migration
Old: https://jam.dev/c/585bd7c7-a384-4ec3-bdc1-c0975b5e6652
New, from builder: https://jam.dev/c/489099ce-db3d-4006-a2dd-c7f56060fb72
New, from client: https://jam.dev/c/1764280e-6d91-44ea-9840-130341ea0bfe


### Running a slow migration
Old: https://jam.dev/c/52095ab8-1af8-4306-b08b-a460cc013272
New, from builder: https://jam.dev/c/3b1f6734-3e77-443d-8013-8efb99c6e0fa
New, from client: https://jam.dev/c/166393b3-57d1-4030-b5df-aa4c58c51b65

## Launchcontrol
Improve migration flow


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve migration handling to avoid redirecting the Builder during app packaging and make the Updating screen finish faster. Adds TypeScript types and randomized polling to speed up migration detection.

- **Bug Fixes**
  - Server sets x-budibase-migrating-app-skip-wait only for Builder appPackage requests (via client header); client ignores migration redirects when this header is present.
  - Update polling checks every ~0.5s with small randomness (was 5–10s) to detect migration completion sooner.
  - Reduce server sync migration checks to 2s (was 5s) to shorten waits.

- **Refactors**
  - Convert Updating-related Svelte scripts to TypeScript and add prop types.

<sup>Written for commit 4eda5ef0797da3dde747027f9560a1fd21cb147a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



