### PR TITLE
Fix model autocomplete

### DIFF
--- a/packages/server/src/api/routes/tests/ai/aiConfig.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/aiConfig.spec.ts
@@ -42,6 +42,14 @@ const mockLiteLLMProviders = () =>
           { key: "api_base", label: "Base URL", field_type: "text" },
         ],
       },
+      {
+        provider: "groq",
+        provider_display_name: "Groq",
+        litellm_provider: "groq",
+        credential_fields: [
+          { key: "api_key", label: "API Key", field_type: "password" },
+        ],
+      },
     ])
 
 const mockLiteLLMModelCostMap = () =>
@@ -56,6 +64,7 @@ const mockLiteLLMModelCostMap = () =>
       },
       "claude-3-5-haiku": { litellm_provider: "anthropic", mode: "chat" },
       "gpt-4o": { litellm_provider: ["openai", "azure"], mode: "responses" },
+      "groq/qwen/qwen3-32b": { litellm_provider: "groq", mode: "chat" },
     })
 
 const mockLiteLLMTeam = () =>
@@ -126,6 +135,14 @@ describe("BudibaseAI", () => {
         models: {
           completions: ["gpt-4o", "gpt-4o-mini"],
           embeddings: ["text-embedding-3-small"],
+        },
+      })
+
+      const groqProvider = providers.find(provider => provider.id === "groq")
+      expect(groqProvider).toMatchObject({
+        models: {
+          completions: ["qwen/qwen3-32b"],
+          embeddings: [],
         },
       })
     })

--- a/packages/server/src/sdk/workspace/ai/configs/index.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/index.ts
@@ -20,6 +20,16 @@ import * as liteLLM from "./litellm"
 
 const SECRET_ENCODING_PREFIX = "bbai_enc::"
 
+const normalizeProviderModelId = (
+  modelId: string,
+  providerId: string
+): string => {
+  const providerPrefix = `${providerId}/`
+  return modelId.startsWith(providerPrefix)
+    ? modelId.slice(providerPrefix.length)
+    : modelId
+}
+
 const encodeSecret = (value: string): string => {
   if (!value || value.startsWith(SECRET_ENCODING_PREFIX)) {
     return value
@@ -389,6 +399,11 @@ export async function fetchLiteLLMProviders(): Promise<LLMProvider[]> {
             return acc
           }
 
+          const normalizedModelId = normalizeProviderModelId(
+            modelId,
+            provider.litellm_provider
+          )
+
           const modelModes = Array.isArray(metadata?.mode)
             ? metadata.mode
             : typeof metadata?.mode === "string"
@@ -399,7 +414,7 @@ export async function fetchLiteLLMProviders(): Promise<LLMProvider[]> {
           )
 
           if (normalizedModes.includes("embedding")) {
-            acc.embeddings.push(modelId)
+            acc.embeddings.push(normalizedModelId)
           }
 
           if (
@@ -408,7 +423,7 @@ export async function fetchLiteLLMProviders(): Promise<LLMProvider[]> {
               ["chat", "completion", "responses"].includes(mode)
             )
           ) {
-            acc.completions.push(modelId)
+            acc.completions.push(normalizedModelId)
           }
 
           return acc


### PR DESCRIPTION
## Description
Fixing model/provider conflicts on autocomplete

### Before

https://github.com/user-attachments/assets/e754d4a6-fcf4-47c1-81e3-b7d9afda758f


### After
https://github.com/user-attachments/assets/1344bbc1-f1d9-4455-bc4d-35fd438bd89a


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes model autocomplete by normalizing LiteLLM model IDs and adding Groq coverage. Autocomplete now shows correct completion and embedding models without provider prefixes.

- **Bug Fixes**
  - Strip provider prefixes from model IDs when building provider configs (e.g., "groq/qwen/qwen3-32b" → "qwen/qwen3-32b").
  - Normalize model modes and include "responses" so models are correctly classified for completions vs embeddings.
  - Add tests for Groq provider to ensure correct autocomplete behavior.

<sup>Written for commit b1e81c7e066ebfe1860b4b01fe82acf7a9b7b96a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

