### PR TITLE
Fix bbai extract docs

### DIFF
--- a/hosting/docker-compose.dev.yaml
+++ b/hosting/docker-compose.dev.yaml
@@ -63,7 +63,7 @@ services:
 
   litellm-service:
     container_name: budi-litellm-dev
-    image: docker.litellm.ai/berriai/litellm:v1.81.12-stable.1
+    image: docker.litellm.ai/berriai/litellm:v1.81.14-stable
     ports:
       - "${LITELLM_PORT:-4000}:4000"
     volumes:

--- a/packages/server/src/automations/steps/ai/extract.spec.ts
+++ b/packages/server/src/automations/steps/ai/extract.spec.ts
@@ -64,6 +64,9 @@ describe("extract file data step unit tests", () => {
       chat: {} as any,
       embedding: {} as any,
       providerOptions: undefined,
+      uploadFile: jest
+        .fn()
+        .mockRejectedValue(new Error("This model doesn't support create_file")),
     })
 
     generateTextMock.mockResolvedValue({
@@ -151,6 +154,7 @@ describe("extract file data step unit tests", () => {
       chat: {} as any,
       embedding: {} as any,
       providerOptions: undefined,
+      uploadFile: jest.fn(),
     })
 
     PDFParseMock.mockImplementation(

--- a/packages/server/src/automations/steps/ai/extract.spec.ts
+++ b/packages/server/src/automations/steps/ai/extract.spec.ts
@@ -3,6 +3,7 @@ import { generateText } from "ai"
 import sdk from "../../../sdk"
 import fetch from "node-fetch"
 import { PDFParse } from "pdf-parse"
+import { Readable } from "stream"
 import { run } from "./extract"
 
 jest.mock("node-fetch", () => jest.fn())
@@ -43,6 +44,60 @@ describe("extract file data step unit tests", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+  })
+
+  it("streams pdf uploads and avoids buffering when upload succeeds", async () => {
+    const fileStream = Readable.from(Buffer.from("fake pdf bytes"))
+    const bufferMock = jest.fn()
+    const uploadFile = jest.fn().mockResolvedValue("file-123")
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      body: fileStream,
+      buffer: bufferMock,
+    } as any)
+
+    getDefaultLLMMock.mockResolvedValue({
+      chat: {} as any,
+      embedding: {} as any,
+      providerOptions: undefined,
+      uploadFile,
+    })
+
+    generateTextMock.mockResolvedValue({
+      output: { data: [{ invoiceNumber: "INV-1" }] },
+    } as any)
+
+    const result = await run({
+      inputs: {
+        source: DocumentSourceType.URL,
+        file: "https://example.com/invoice.pdf",
+        fileType: SupportedFileType.PDF,
+        schema: { invoiceNumber: "string" },
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(uploadFile).toHaveBeenCalledWith(
+      fileStream,
+      "document.pdf",
+      SupportedFileType.PDF
+    )
+    expect(bufferMock).not.toHaveBeenCalled()
+    expect(generateTextMock.mock.calls[0][0].messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "user",
+          content: expect.arrayContaining([
+            expect.objectContaining({
+              type: "file",
+              data: "file-123",
+              mediaType: "application/pdf",
+            }),
+          ]),
+        }),
+      ])
+    )
   })
 
   it("falls back to inline pdf text when llm.uploadFile is unavailable", async () => {

--- a/packages/server/src/automations/steps/ai/extract.ts
+++ b/packages/server/src/automations/steps/ai/extract.ts
@@ -124,11 +124,10 @@ async function processUrlFile(
     return { kind: "image", value: toImageDataUrl(data, fileType) }
   }
 
-  const data = await response.buffer()
   const filename = `document.${fileType || "pdf"}`
   try {
     const uploaded = await llm.uploadFile(
-      Readable.from(data),
+      response.body as Readable,
       filename,
       fileType
     )
@@ -138,6 +137,13 @@ async function processUrlFile(
     }
   } catch (error) {
     if (shouldInlineFileAfterUploadFailure(error)) {
+      const fallbackResponse = await fetch(fileUrl)
+      if (!fallbackResponse.ok) {
+        throw new Error(
+          `Failed to fetch file from URL: ${fallbackResponse.statusText}`
+        )
+      }
+      const data = await fallbackResponse.buffer()
       const text = await extractPdfText(data)
       return { kind: "text", value: text }
     }
@@ -158,20 +164,17 @@ async function processAttachmentFile(
     return { kind: "image", value: toImageDataUrl(data, contentType) }
   }
 
-  const data = await buffer(stream)
   const filename = attachment.name || "document"
   try {
-    const uploaded = await llm.uploadFile(
-      Readable.from(data),
-      filename,
-      contentType
-    )
+    const uploaded = await llm.uploadFile(stream, filename, contentType)
     return {
       kind: "file",
       value: uploaded,
     }
   } catch (error) {
     if (shouldInlineFileAfterUploadFailure(error)) {
+      const fallback = await objectStore.getReadStream(bucket, attachment.key!)
+      const data = await buffer(fallback.stream)
       const text = await extractPdfText(data)
       return { kind: "text", value: text }
     }

--- a/packages/server/src/automations/steps/ai/extract.ts
+++ b/packages/server/src/automations/steps/ai/extract.ts
@@ -124,16 +124,24 @@ async function processUrlFile(
     return { kind: "image", value: toImageDataUrl(data, fileType) }
   }
 
-  if (!llm.uploadFile) {
-    const data = await response.buffer()
-    const text = await extractPdfText(data)
-    return { kind: "text", value: text }
-  }
-  const stream = response.body as Readable
+  const data = await response.buffer()
   const filename = `document.${fileType || "pdf"}`
-  return {
-    kind: "file",
-    value: await llm.uploadFile(stream, filename, fileType),
+  try {
+    const uploaded = await llm.uploadFile(
+      Readable.from(data),
+      filename,
+      fileType
+    )
+    return {
+      kind: "file",
+      value: uploaded,
+    }
+  } catch (error) {
+    if (shouldInlineFileAfterUploadFailure(error)) {
+      const text = await extractPdfText(data)
+      return { kind: "text", value: text }
+    }
+    throw error
   }
 }
 
@@ -150,16 +158,35 @@ async function processAttachmentFile(
     return { kind: "image", value: toImageDataUrl(data, contentType) }
   }
 
-  if (!llm.uploadFile) {
-    const data = await buffer(stream)
-    const text = await extractPdfText(data)
-    return { kind: "text", value: text }
-  }
+  const data = await buffer(stream)
   const filename = attachment.name || "document"
-  return {
-    kind: "file",
-    value: await llm.uploadFile(stream, filename, contentType),
+  try {
+    const uploaded = await llm.uploadFile(
+      Readable.from(data),
+      filename,
+      contentType
+    )
+    return {
+      kind: "file",
+      value: uploaded,
+    }
+  } catch (error) {
+    if (shouldInlineFileAfterUploadFailure(error)) {
+      const text = await extractPdfText(data)
+      return { kind: "text", value: text }
+    }
+    throw error
   }
+}
+
+function shouldInlineFileAfterUploadFailure(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false
+  }
+  return (
+    /doesn't support .*create_file/i.test(error.message) ||
+    error.message === "File id not found"
+  )
 }
 
 export async function run({

--- a/packages/server/src/tests/api/chatConversations.spec.ts
+++ b/packages/server/src/tests/api/chatConversations.spec.ts
@@ -425,6 +425,7 @@ describe("chat conversation transient behavior", () => {
       chat: mockModel as LanguageModelV3,
       embedding: {} as EmbeddingModelV3,
       providerOptions: jest.fn(),
+      uploadFile: jest.fn(),
     })
     ;(
       convertToModelMessages as jest.MockedFunction<
@@ -739,6 +740,7 @@ describe("Agent chat tool call tracking", () => {
       chat: {} as any,
       embedding: {} as any,
       providerOptions: jest.fn().mockReturnValue({}),
+      uploadFile: jest.fn(),
     })
     ;(
       convertToModelMessages as jest.MockedFunction<

--- a/packages/types/src/sdk/ai.ts
+++ b/packages/types/src/sdk/ai.ts
@@ -107,7 +107,7 @@ export interface LLMResponse {
   chat: LanguageModelV3
   embedding: EmbeddingModelV3
   providerOptions?: (hasTools: boolean) => LLMProviderOptions | undefined
-  uploadFile?: (
+  uploadFile: (
     stream: Readable,
     filename: string,
     contentType?: string


### PR DESCRIPTION
## Description
### Before
<img width="1082" height="723" alt="image" src="https://github.com/user-attachments/assets/f3298e14-01c2-429a-89aa-4a9ba489c319" />


### After
<img width="1026" height="696" alt="image" src="https://github.com/user-attachments/assets/c14c8731-69d5-44d7-b9d0-c9d24642760b" />


## Launchcontrol
Fixing file generation for BBAI and providers that don't support files



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix document extraction by streaming file uploads to the LLM and falling back to inline PDF text when uploads fail or the provider doesn’t support file endpoints. This reduces memory usage and improves reliability across providers.

- **Bug Fixes**
  - Stream uploads for URL and attachment inputs; buffer only on fallback.
  - Inline PDF text if upload fails with “doesn’t support create_file” or “File id not found”.
  - Make uploadFile required in LLMResponse and update tests for streaming, fallback, and chat mocks.

- **Dependencies**
  - Update litellm Docker image to v1.81.14-stable.

<sup>Written for commit f25bc3d9c7463fbea090995ba008b26660b1505b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



