### PR TITLE
Fix issue with oauth2 tokens failing to refresh

### DIFF
--- a/packages/backend-core/src/auth/auth.ts
+++ b/packages/backend-core/src/auth/auth.ts
@@ -26,6 +26,7 @@ import {
 import { ssoSaveUserNoOp } from "../middleware/passport/sso/sso"
 import { getSessionsForUser, invalidateSessions } from "../security/sessions"
 import { clearCookie, getCookie } from "../utils"
+import OpenIDConnectStrategy from "@govtechsg/passport-openidconnect"
 
 const refresh = require("passport-oauth2-refresh")
 
@@ -56,7 +57,7 @@ async function refreshOIDCAccessToken(
 ): Promise<RefreshResponse> {
   const callbackUrl = await oidc.getCallbackUrl()
   let enrichedConfig: any
-  let strategy: any
+  let strategy: OpenIDConnectStrategy
 
   try {
     enrichedConfig = await oidc.fetchStrategyConfig(chosenConfig, callbackUrl)
@@ -68,11 +69,7 @@ async function refreshOIDCAccessToken(
     throw new Error("Could not refresh OAuth Token")
   }
 
-  refresh.use(strategy, {
-    setRefreshOAuth2() {
-      return strategy._getOAuth2Client(enrichedConfig)
-    },
-  })
+  refresh.use(strategy)
 
   return new Promise(resolve => {
     refresh.requestNewAccessToken(

--- a/packages/backend-core/src/auth/auth.ts
+++ b/packages/backend-core/src/auth/auth.ts
@@ -5,6 +5,7 @@ import {
   ConfigType,
   GoogleInnerConfig,
   OIDCInnerConfig,
+  OIDCStrategyConfiguration,
   PlatformLogoutOpts,
   SessionCookie,
   SSOProviderType,
@@ -56,7 +57,7 @@ async function refreshOIDCAccessToken(
   refreshToken: string
 ): Promise<RefreshResponse> {
   const callbackUrl = await oidc.getCallbackUrl()
-  let enrichedConfig: any
+  let enrichedConfig: OIDCStrategyConfiguration
   let strategy: OpenIDConnectStrategy
 
   try {

--- a/packages/backend-core/src/auth/tests/auth.spec.ts
+++ b/packages/backend-core/src/auth/tests/auth.spec.ts
@@ -21,6 +21,7 @@ jest.mock("../../middleware", () => {
 import { structures } from "../../../tests"
 import { testEnv } from "../../../tests/extra"
 import { ConfigType, SSOProviderType } from "@budibase/types"
+import type OpenIDConnectStrategy from "@govtechsg/passport-openidconnect"
 import * as auth from "../auth"
 import * as configs from "../../configs"
 import * as events from "../../events"
@@ -87,7 +88,7 @@ describe("refreshOAuthToken", () => {
         },
       },
       name: ConfigType.OIDC,
-    }
+    } as unknown as OpenIDConnectStrategy
 
     getOIDCConfigById.mockResolvedValue(oidcConfig)
     getCallbackUrl.mockResolvedValue(callbackUrl)

--- a/packages/backend-core/src/auth/tests/auth.spec.ts
+++ b/packages/backend-core/src/auth/tests/auth.spec.ts
@@ -1,7 +1,39 @@
+jest.mock("../../configs", () => {
+  const actual = jest.requireActual("../../configs")
+  return {
+    ...actual,
+    getOIDCConfigById: jest.fn(),
+  }
+})
+jest.mock("../../middleware", () => {
+  const actual = jest.requireActual("../../middleware")
+  return {
+    ...actual,
+    oidc: {
+      ...actual.oidc,
+      getCallbackUrl: jest.fn(),
+      fetchStrategyConfig: jest.fn(),
+      strategyFactory: jest.fn(),
+    },
+  }
+})
+
 import { structures } from "../../../tests"
 import { testEnv } from "../../../tests/extra"
+import { ConfigType, SSOProviderType } from "@budibase/types"
 import * as auth from "../auth"
+import * as configs from "../../configs"
 import * as events from "../../events"
+import * as middleware from "../../middleware"
+
+const refresh = require("passport-oauth2-refresh") as {
+  _strategies: Record<string, unknown>
+  has: (name: string) => boolean
+}
+const getOIDCConfigById = jest.mocked(configs.getOIDCConfigById)
+const getCallbackUrl = jest.mocked(middleware.oidc.getCallbackUrl)
+const fetchStrategyConfig = jest.mocked(middleware.oidc.fetchStrategyConfig)
+const strategyFactory = jest.mocked(middleware.oidc.strategyFactory)
 
 describe("platformLogout", () => {
   it("should call platform logout", async () => {
@@ -10,5 +42,70 @@ describe("platformLogout", () => {
       await auth.platformLogout({ ctx, userId: "test" })
       expect(events.auth.logout).toHaveBeenCalledTimes(1)
     })
+  })
+})
+
+describe("refreshOAuthToken", () => {
+  afterEach(() => {
+    refresh._strategies = {}
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
+  it("should register oidc refresh using the strategy oauth2 adapter", async () => {
+    const oidcConfig = structures.sso.oidcConfig()
+    const configId = "config-id"
+    const callbackUrl = "http://localhost/auth/oidc/callback"
+    const strategyConfig = {
+      issuer: "https://issuer.example.com",
+      authorizationURL: "https://issuer.example.com/authorize",
+      tokenURL: "https://issuer.example.com/token",
+      userInfoURL: "https://issuer.example.com/userinfo",
+      clientID: oidcConfig.clientID,
+      clientSecret: oidcConfig.clientSecret,
+      callbackURL: callbackUrl,
+    }
+    const strategy = {
+      _oauth2: {
+        _clientId: oidcConfig.clientID,
+        _clientSecret: oidcConfig.clientSecret,
+        _baseSite: "",
+        _authorizeUrl: strategyConfig.authorizationURL,
+        _accessTokenUrl: strategyConfig.tokenURL,
+        _customHeaders: {},
+        getOAuthAccessToken: (
+          _refreshToken: string,
+          _params: Record<string, string>,
+          done: (
+            err: null,
+            accessToken: string,
+            refreshToken: string,
+            params: Record<string, string>
+          ) => void
+        ) => {
+          done(null, "access-token", "refresh-token", { scope: "openid" })
+        },
+      },
+      name: ConfigType.OIDC,
+    }
+
+    getOIDCConfigById.mockResolvedValue(oidcConfig)
+    getCallbackUrl.mockResolvedValue(callbackUrl)
+    fetchStrategyConfig.mockResolvedValue(strategyConfig)
+    strategyFactory.mockResolvedValue(strategy)
+
+    const result = await auth.refreshOAuthToken(
+      "existing-refresh-token",
+      SSOProviderType.OIDC,
+      configId
+    )
+
+    expect(result).toEqual({
+      err: null,
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      params: { scope: "openid" },
+    })
+    expect(refresh.has(ConfigType.OIDC)).toBe(true)
   })
 })


### PR DESCRIPTION
## Description
We moved the library we used for our OIDC token refresh, and `_getOAuth2Client` didn't exist on it. So using the correct flow for the new library which is to call `.use()`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth2/OIDC token refresh by registering the OIDC strategy directly with passport-oauth2-refresh, aligned with @govtechsg/passport-openidconnect. This restores reliable token renewal.

- **Bug Fixes**
  - Use refresh.use(strategy) and remove the deprecated _getOAuth2Client path.
  - Strengthen types with OIDCStrategyConfiguration and OpenIDConnectStrategy; import the strategy explicitly.
  - Add tests for refreshOAuthToken that mock OIDC config and middleware, verify new access token flow, and confirm strategy registration with passport-oauth2-refresh.

<sup>Written for commit 0628ce775b8c707f6f65e0d2103b3158e4a890dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

