### PR TITLE
Avoid conflicts with existing bbai configs

### DIFF
--- a/packages/server/src/workspaceMigrations/migrations/20260227144312_unify_ai_configs.ts
+++ b/packages/server/src/workspaceMigrations/migrations/20260227144312_unify_ai_configs.ts
@@ -165,7 +165,15 @@ const migration = async () => {
       const normalizedModel = normalizeModel(provider, model)
 
       const name = legacyProvider.name || legacyProvider.provider
-      if (existingConfigs.some(c => c.name === name)) {
+      const hasExistingConfig =
+        existingConfigs.some(c => c.name === name) ||
+        (provider === BUDIBASE_AI_PROVIDER_ID &&
+          existingConfigs.some(
+            c =>
+              c.provider === BUDIBASE_AI_PROVIDER_ID &&
+              c.configType === AIConfigType.COMPLETIONS
+          ))
+      if (hasExistingConfig) {
         skippedExisting++
         continue
       }

--- a/packages/server/src/workspaceMigrations/migrations/tests/20260227144312_unify_ai_configs.spec.ts
+++ b/packages/server/src/workspaceMigrations/migrations/tests/20260227144312_unify_ai_configs.spec.ts
@@ -163,6 +163,45 @@ describe("20260227144312_unify_ai_configs", () => {
     )
   })
 
+  it("does not create Budibase AI config when one already exists with a different name", async () => {
+    const legacyConfig: AIConfig = {
+      type: ConfigType.AI,
+      config: {
+        bbai: {
+          provider: "BudibaseAI",
+          name: "Budibase AI",
+          active: true,
+          isDefault: true,
+        },
+      },
+    }
+    await config.doInTenant(async () => {
+      await configs.save(legacyConfig)
+    })
+
+    const createMock = aiConfigs.create as jest.MockedFunction<
+      typeof aiConfigs.create
+    >
+    createMock.mockResolvedValue({} as any)
+
+    await config.doInContext(config.getDevWorkspaceId(), async () => {
+      await db.getDB(config.getDevWorkspaceId()).put({
+        _id: docIds.generateAIConfigID("bbai"),
+        name: "Existing Budibase AI",
+        provider: BUDIBASE_AI_PROVIDER_ID,
+        model: "budibase/legacy/gpt-5-mini",
+        credentialsFields: {},
+        liteLLMModelId: "existing-model-id",
+        configType: AIConfigType.COMPLETIONS,
+        isDefault: true,
+      })
+    })
+
+    await config.doInContext(config.getDevWorkspaceId(), migration)
+
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
   it("maps legacy AzureOpenAI provider to Azure", async () => {
     const legacyConfig: AIConfig = {
       type: ConfigType.AI,


### PR DESCRIPTION
## Description
1. Fix issue conflicting migration of bbai when this already exists in the workspace (only affecting bb employees and potentially people with beta access)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update migration to skip creating a new Budibase AI completions config when one already exists, even if the name is different. Prevents duplicate `bbai` configs during workspace migration.

- **Bug Fixes**
  - Check for existing Budibase AI completions configs by provider/type, not just name.
  - Added test to confirm no new config is created when an existing `bbai` config is present with a different name.

<sup>Written for commit 95a94c74a91db5bd2b84300257ce63fb35f4ff79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

