### PR TITLE
Align quota values with account-portal Plan definitions

### DIFF
--- a/packages/pro/src/constants/licenses.ts
+++ b/packages/pro/src/constants/licenses.ts
@@ -12,9 +12,9 @@ export const CLOUD_FREE_LICENSE: License = {
     usage: {
       monthly: {
         ...quotas.queries(UNLIMITED),
-        ...quotas.automations(200),
+        ...quotas.automations(UNLIMITED),
         ...quotas.budibaseAICredits(0),
-        ...quotas.actions(UNLIMITED),
+        ...quotas.actions(5000),
       },
       static: {
         ...quotas.apps(UNLIMITED),

--- a/packages/pro/src/sdk/licensing/licenses/quotas.ts
+++ b/packages/pro/src/sdk/licensing/licenses/quotas.ts
@@ -54,9 +54,9 @@ const CLOUD_QUOTAS: PlanQuotas = {
       },
     },
     constant: {
-      ...quotas.agentLogRetentionDays(30),
-      ...quotas.automationLogRetentionDays(30),
-      ...quotas.appBackupRetentionDays(30),
+      ...quotas.agentLogRetentionDays(7),
+      ...quotas.automationLogRetentionDays(7),
+      ...quotas.appBackupRetentionDays(7),
     },
   },
   [PlanType.PREMIUM_MAX]: {
@@ -78,9 +78,9 @@ const CLOUD_QUOTAS: PlanQuotas = {
       },
     },
     constant: {
-      ...quotas.agentLogRetentionDays(30),
-      ...quotas.automationLogRetentionDays(30),
-      ...quotas.appBackupRetentionDays(30),
+      ...quotas.agentLogRetentionDays(7),
+      ...quotas.automationLogRetentionDays(7),
+      ...quotas.appBackupRetentionDays(7),
     },
   },
   [PlanType.PREMIUM_PLUS_TRIAL]: {
@@ -102,9 +102,9 @@ const CLOUD_QUOTAS: PlanQuotas = {
       },
     },
     constant: {
-      ...quotas.agentLogRetentionDays(30),
-      ...quotas.automationLogRetentionDays(30),
-      ...quotas.appBackupRetentionDays(30),
+      ...quotas.agentLogRetentionDays(7),
+      ...quotas.automationLogRetentionDays(7),
+      ...quotas.appBackupRetentionDays(7),
     },
   },
   [PlanType.PRO]: {
@@ -126,9 +126,9 @@ const CLOUD_QUOTAS: PlanQuotas = {
       },
     },
     constant: {
-      ...quotas.agentLogRetentionDays(7),
-      ...quotas.automationLogRetentionDays(7),
-      ...quotas.appBackupRetentionDays(7),
+      ...quotas.agentLogRetentionDays(1),
+      ...quotas.automationLogRetentionDays(1),
+      ...quotas.appBackupRetentionDays(0),
     },
   },
   [PlanType.PRO_MAX]: {
@@ -335,7 +335,7 @@ const SELF_QUOTAS: PlanQuotas = {
       monthly: {
         ...quotas.queries(UNLIMITED),
         ...quotas.automations(UNLIMITED),
-        ...quotas.budibaseAICredits(millions(2)),
+        ...quotas.budibaseAICredits(0),
         ...quotas.actions(UNLIMITED),
       },
       static: {
@@ -445,9 +445,9 @@ const SELF_QUOTAS: PlanQuotas = {
       },
     },
     constant: {
-      ...quotas.agentLogRetentionDays(90),
-      ...quotas.automationLogRetentionDays(90),
-      ...quotas.appBackupRetentionDays(365),
+      ...quotas.agentLogRetentionDays(UNLIMITED),
+      ...quotas.automationLogRetentionDays(UNLIMITED),
+      ...quotas.appBackupRetentionDays(UNLIMITED),
     },
   },
   [PlanType.ENTERPRISE_BASIC]: {
@@ -455,7 +455,7 @@ const SELF_QUOTAS: PlanQuotas = {
       monthly: {
         ...quotas.queries(UNLIMITED),
         ...quotas.automations(UNLIMITED),
-        ...quotas.budibaseAICredits(millions(4)),
+        ...quotas.budibaseAICredits(millions(50)),
         ...quotas.actions(UNLIMITED),
       },
       static: {
@@ -479,7 +479,7 @@ const SELF_QUOTAS: PlanQuotas = {
       monthly: {
         ...quotas.queries(UNLIMITED),
         ...quotas.automations(UNLIMITED),
-        ...quotas.budibaseAICredits(millions(4)),
+        ...quotas.budibaseAICredits(750000),
         ...quotas.actions(UNLIMITED),
       },
       static: {
@@ -503,7 +503,7 @@ const SELF_QUOTAS: PlanQuotas = {
       monthly: {
         ...quotas.queries(UNLIMITED),
         ...quotas.automations(UNLIMITED),
-        ...quotas.budibaseAICredits(millions(4)),
+        ...quotas.budibaseAICredits(millions(50)),
         ...quotas.actions(UNLIMITED),
       },
       static: {

--- a/packages/pro/src/sdk/quotas/tests/triggers.spec.ts
+++ b/packages/pro/src/sdk/quotas/tests/triggers.spec.ts
@@ -102,12 +102,8 @@ describe("triggers", () => {
         type: QuotaUsageType.MONTHLY,
       })
       let usage = await db.quotas.getQuotaUsage()
-      expect(usage.monthly[currentMonthString].triggers.actions![80]).toBe(
-        now
-      ) // 80 is also recorded
-      expect(usage.monthly[currentMonthString].triggers.actions![90]).toBe(
-        now
-      )
+      expect(usage.monthly[currentMonthString].triggers.actions![80]).toBe(now) // 80 is also recorded
+      expect(usage.monthly[currentMonthString].triggers.actions![90]).toBe(now)
       expect(usage.monthly[currentMonthString].triggers.actions![100]).toBe(
         undefined
       )
@@ -127,15 +123,9 @@ describe("triggers", () => {
         type: QuotaUsageType.MONTHLY,
       })
       usage = await db.quotas.getQuotaUsage()
-      expect(usage.monthly[currentMonthString].triggers.actions![80]).toBe(
-        now
-      )
-      expect(usage.monthly[currentMonthString].triggers.actions![90]).toBe(
-        now
-      )
-      expect(usage.monthly[currentMonthString].triggers.actions![100]).toBe(
-        now
-      )
+      expect(usage.monthly[currentMonthString].triggers.actions![80]).toBe(now)
+      expect(usage.monthly[currentMonthString].triggers.actions![90]).toBe(now)
+      expect(usage.monthly[currentMonthString].triggers.actions![100]).toBe(now)
       expect(mockTriggerQuota).toHaveBeenCalledTimes(1)
       expect(mockTriggerQuota).toHaveBeenCalledWith({
         name: "Actions",
@@ -160,15 +150,9 @@ describe("triggers", () => {
         type: QuotaUsageType.MONTHLY,
       })
       const usage = await db.quotas.getQuotaUsage()
-      expect(usage.monthly[currentMonthString].triggers.actions![80]).toBe(
-        now
-      )
-      expect(usage.monthly[currentMonthString].triggers.actions![90]).toBe(
-        now
-      )
-      expect(usage.monthly[currentMonthString].triggers.actions![100]).toBe(
-        now
-      )
+      expect(usage.monthly[currentMonthString].triggers.actions![80]).toBe(now)
+      expect(usage.monthly[currentMonthString].triggers.actions![90]).toBe(now)
+      expect(usage.monthly[currentMonthString].triggers.actions![100]).toBe(now)
       expect(mockTriggerQuota).toHaveBeenCalledTimes(1)
       expect(mockTriggerQuota).toHaveBeenCalledWith({
         name: "Actions",

--- a/packages/pro/src/sdk/quotas/tests/triggers.spec.ts
+++ b/packages/pro/src/sdk/quotas/tests/triggers.spec.ts
@@ -89,7 +89,7 @@ describe("triggers", () => {
 
   it("monthly - 90 then 100", async () => {
     const license = mocks.licenses.useCloudFree()
-    const quota = license.quotas.usage.monthly.automations
+    const quota = license.quotas.usage.monthly.actions
     const now = new Date().toISOString()
     const currentMonthString = db.quotas.utils.getCurrentMonthString()
 
@@ -98,22 +98,22 @@ describe("triggers", () => {
       let value = quota.value * 0.9
       await quotas.incrementMany({
         change: value,
-        name: MonthlyQuotaName.AUTOMATIONS,
+        name: MonthlyQuotaName.ACTIONS,
         type: QuotaUsageType.MONTHLY,
       })
       let usage = await db.quotas.getQuotaUsage()
-      expect(usage.monthly[currentMonthString].triggers.automations![80]).toBe(
+      expect(usage.monthly[currentMonthString].triggers.actions![80]).toBe(
         now
       ) // 80 is also recorded
-      expect(usage.monthly[currentMonthString].triggers.automations![90]).toBe(
+      expect(usage.monthly[currentMonthString].triggers.actions![90]).toBe(
         now
       )
-      expect(usage.monthly[currentMonthString].triggers.automations![100]).toBe(
+      expect(usage.monthly[currentMonthString].triggers.actions![100]).toBe(
         undefined
       )
       expect(mockTriggerQuota).toHaveBeenCalledTimes(1)
       expect(mockTriggerQuota).toHaveBeenCalledWith({
-        name: "Automations",
+        name: "Actions",
         percentage: 90,
         resetDate: usage.quotaReset,
       })
@@ -123,22 +123,22 @@ describe("triggers", () => {
       value = quota.value * 0.1
       await quotas.incrementMany({
         change: value,
-        name: MonthlyQuotaName.AUTOMATIONS,
+        name: MonthlyQuotaName.ACTIONS,
         type: QuotaUsageType.MONTHLY,
       })
       usage = await db.quotas.getQuotaUsage()
-      expect(usage.monthly[currentMonthString].triggers.automations![80]).toBe(
+      expect(usage.monthly[currentMonthString].triggers.actions![80]).toBe(
         now
       )
-      expect(usage.monthly[currentMonthString].triggers.automations![90]).toBe(
+      expect(usage.monthly[currentMonthString].triggers.actions![90]).toBe(
         now
       )
-      expect(usage.monthly[currentMonthString].triggers.automations![100]).toBe(
+      expect(usage.monthly[currentMonthString].triggers.actions![100]).toBe(
         now
       )
       expect(mockTriggerQuota).toHaveBeenCalledTimes(1)
       expect(mockTriggerQuota).toHaveBeenCalledWith({
-        name: "Automations",
+        name: "Actions",
         percentage: 100,
         resetDate: usage.quotaReset,
       })
@@ -148,7 +148,7 @@ describe("triggers", () => {
 
   it("monthly - direct to 100, only triggers once", async () => {
     const license = mocks.licenses.useCloudFree()
-    const quota = license.quotas.usage.monthly.automations
+    const quota = license.quotas.usage.monthly.actions
     const now = new Date().toISOString()
     const currentMonthString = db.quotas.utils.getCurrentMonthString()
 
@@ -156,22 +156,22 @@ describe("triggers", () => {
       const value = quota.value
       await quotas.incrementMany({
         change: value,
-        name: MonthlyQuotaName.AUTOMATIONS,
+        name: MonthlyQuotaName.ACTIONS,
         type: QuotaUsageType.MONTHLY,
       })
       const usage = await db.quotas.getQuotaUsage()
-      expect(usage.monthly[currentMonthString].triggers.automations![80]).toBe(
+      expect(usage.monthly[currentMonthString].triggers.actions![80]).toBe(
         now
       )
-      expect(usage.monthly[currentMonthString].triggers.automations![90]).toBe(
+      expect(usage.monthly[currentMonthString].triggers.actions![90]).toBe(
         now
       )
-      expect(usage.monthly[currentMonthString].triggers.automations![100]).toBe(
+      expect(usage.monthly[currentMonthString].triggers.actions![100]).toBe(
         now
       )
       expect(mockTriggerQuota).toHaveBeenCalledTimes(1)
       expect(mockTriggerQuota).toHaveBeenCalledWith({
-        name: "Automations",
+        name: "Actions",
         percentage: 100,
         resetDate: usage.quotaReset,
       })
@@ -221,12 +221,12 @@ describe("triggers", () => {
 
   it("monthly - re-triggers the following month", async () => {
     const license = mocks.licenses.useCloudFree()
-    const quota = license.quotas.usage.monthly.automations
+    const quota = license.quotas.usage.monthly.actions
     await config.doInWorkspace(async () => {
       let value = quota.value
       await quotas.incrementMany({
         change: value,
-        name: MonthlyQuotaName.AUTOMATIONS,
+        name: MonthlyQuotaName.ACTIONS,
         type: QuotaUsageType.MONTHLY,
       })
 
@@ -234,7 +234,7 @@ describe("triggers", () => {
       let usage = await db.quotas.getQuotaUsage()
       expect(mockTriggerQuota).toHaveBeenCalledTimes(1)
       expect(mockTriggerQuota).toHaveBeenCalledWith({
-        name: "Automations",
+        name: "Actions",
         percentage: 100,
         resetDate: usage.quotaReset,
       })
@@ -247,14 +247,14 @@ describe("triggers", () => {
 
       await quotas.incrementMany({
         change: value,
-        name: MonthlyQuotaName.AUTOMATIONS,
+        name: MonthlyQuotaName.ACTIONS,
         type: QuotaUsageType.MONTHLY,
       })
       // re-triggered
       usage = await db.quotas.getQuotaUsage()
       expect(mockTriggerQuota).toHaveBeenCalledTimes(1)
       expect(mockTriggerQuota).toHaveBeenCalledWith({
-        name: "Automations",
+        name: "Actions",
         percentage: 100,
         resetDate: usage.quotaReset,
       })


### PR DESCRIPTION
## Description

Sync per-plan quota values across Cloud and Self-hosted tiers to match the canonical definitions in the account-portal `Plan` class. Discrepancies were found in `budibaseAICredits`, `actions`, `automations`, `automationLogRetentionDays`, `appBackupRetentionDays`, and `agentLogRetentionDays`.

### Changes in `packages/pro/src/sdk/licensing/licenses/quotas.ts`

| Hosting | Plan | Field | Before | After | Active |
|---------|------|-------|--------|-------|--------|
| Cloud | PRO | `agentLogRetentionDays` | 7 | 1 | true |
| Cloud | PRO | `automationLogRetentionDays` | 7 | 1 | true |
| Cloud | PRO | `appBackupRetentionDays` | 7 | 0 | true |
| Cloud | PREMIUM_PLUS | `agentLogRetentionDays` | 30 | 7 | true |
| Cloud | PREMIUM_PLUS | `automationLogRetentionDays` | 30 | 7 | true |
| Cloud | PREMIUM_PLUS | `appBackupRetentionDays` | 30 | 7 | true |
| Cloud | PREMIUM_MAX | `agentLogRetentionDays` | 30 | 7 | true |
| Cloud | PREMIUM_MAX | `automationLogRetentionDays` | 30 | 7 | true |
| Cloud | PREMIUM_MAX | `appBackupRetentionDays` | 30 | 7 | true |
| Cloud | PREMIUM_PLUS_TRIAL | `agentLogRetentionDays` | 30 | 7 | true |
| Cloud | PREMIUM_PLUS_TRIAL | `automationLogRetentionDays` | 30 | 7 | true |
| Cloud | PREMIUM_PLUS_TRIAL | `appBackupRetentionDays` | 30 | 7 | true |
| Self | PREMIUM_PLUS_TRIAL | `budibaseAICredits` | 2,000,000 | 0 | false |
| Self | BUSINESS | `agentLogRetentionDays` | 90 | UNLIMITED | false |
| Self | BUSINESS | `automationLogRetentionDays` | 90 | UNLIMITED | false |
| Self | BUSINESS | `appBackupRetentionDays` | 365 | UNLIMITED | false |
| Self | ENTERPRISE_BASIC | `budibaseAICredits` | 4,000,000 | 50,000,000 | true |
| Self | ENTERPRISE_BASIC_TRIAL | `budibaseAICredits` | 4,000,000 | 750,000 | true |
| Self | ENTERPRISE | `budibaseAICredits` | 4,000,000 | 50,000,000 | true |

### Changes in `packages/pro/src/constants/licenses.ts`

| Hosting | Plan | Field | Before | After | Active |
|---------|------|-------|--------|-------|--------|
| Cloud | FREE | `automations` | 200 | UNLIMITED | true |
| Cloud | FREE | `actions` | UNLIMITED | 5,000 | true |

## Launchcontrol

Quota values in budibase are now aligned with the canonical per-plan definitions in the account-portal, ensuring consistent enforcement of limits across Cloud and Self-hosted deployments.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align quotas with account-portal `Plan` definitions for consistent limits across Cloud and Self-hosted. Also updates monthly trigger tests to use the actions quota since Cloud FREE automations are now unlimited.

- **Bug Fixes**
  - Cloud PRO: agentLogRetentionDays: 1; automationLogRetentionDays: 1; appBackupRetentionDays: 0.
  - Cloud PREMIUM_PLUS / PREMIUM_MAX / PREMIUM_PLUS_TRIAL: all retention set to 7 days.
  - Self-hosted BUSINESS: all retention set to UNLIMITED.
  - Self-hosted AI credits: ENTERPRISE_BASIC/ENTERPRISE → 50,000,000; ENTERPRISE_BASIC_TRIAL → 750,000; PREMIUM_PLUS_TRIAL → 0.
  - Cloud FREE: automations → UNLIMITED; actions → 5,000.

<sup>Written for commit f1a1ac8c12d4be3092a0be78a93be04b7ac09768. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



