### PR TITLE
fix(builder): allow SCIM workspace role edits

### DIFF
--- a/packages/builder/src/settings/pages/people/groups/_components/CreateEditGroupModal.spec.ts
+++ b/packages/builder/src/settings/pages/people/groups/_components/CreateEditGroupModal.spec.ts
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/svelte"
+import { describe, expect, it, vi } from "vitest"
+import MockBody from "@/test/mocks/MockBody.svelte"
+import MockColorPicker from "@/test/mocks/MockColorPicker.svelte"
+import MockIconPicker from "@/test/mocks/MockIconPicker.svelte"
+import MockInput from "@/test/mocks/MockInput.svelte"
+import MockModalContent from "@/test/mocks/MockModalContent.svelte"
+
+vi.mock("@budibase/bbui", () => ({
+  keepOpen: Symbol("keepOpen"),
+  ColorPicker: MockColorPicker,
+  Body: MockBody,
+  ModalContent: MockModalContent,
+  Input: MockInput,
+  IconPicker: MockIconPicker,
+}))
+
+import CreateEditGroupModal from "./CreateEditGroupModal.svelte"
+
+const buildGroup = (overrides = {}) => ({
+  _id: "group-1",
+  _rev: "rev-1",
+  name: "Operations",
+  icon: "UserGroup",
+  color: "#336699",
+  users: [],
+  ...overrides,
+})
+
+describe("CreateEditGroupModal", () => {
+  it("keeps synced group names read-only while leaving other fields editable", () => {
+    render(CreateEditGroupModal, {
+      props: {
+        group: buildGroup({
+          scimInfo: { isSync: true },
+        }),
+        saveGroup: vi.fn(),
+      },
+    })
+
+    expect(screen.getByLabelText("Name")).toBeDisabled()
+    expect(screen.getByLabelText("Icon")).not.toBeDisabled()
+    expect(screen.getByLabelText("Color")).not.toBeDisabled()
+  })
+
+  it("allows non-scim groups to edit all exposed fields", () => {
+    render(CreateEditGroupModal, {
+      props: {
+        group: buildGroup(),
+        saveGroup: vi.fn(),
+      },
+    })
+
+    expect(screen.getByLabelText("Name")).not.toBeDisabled()
+    expect(screen.getByLabelText("Icon")).not.toBeDisabled()
+    expect(screen.getByLabelText("Color")).not.toBeDisabled()
+  })
+})

--- a/packages/builder/src/settings/pages/people/groups/_components/GroupNameTableRenderer.spec.ts
+++ b/packages/builder/src/settings/pages/people/groups/_components/GroupNameTableRenderer.spec.ts
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/svelte"
+import { describe, expect, it, vi } from "vitest"
+import MockActiveDirectoryInfo from "@/test/mocks/MockActiveDirectoryInfo.svelte"
+import MockGroupIcon from "@/test/mocks/MockGroupIcon.svelte"
+
+vi.mock("./GroupIcon.svelte", () => ({
+  default: MockGroupIcon,
+}))
+
+vi.mock("../../_components/ActiveDirectoryInfo.svelte", () => ({
+  default: MockActiveDirectoryInfo,
+}))
+
+import GroupNameTableRenderer from "./GroupNameTableRenderer.svelte"
+
+describe("GroupNameTableRenderer", () => {
+  it("shows a sync badge for scim groups", () => {
+    render(GroupNameTableRenderer, {
+      props: {
+        value: "Synced group",
+        row: {
+          name: "Synced group",
+          scimInfo: { isSync: true },
+        },
+      },
+    })
+
+    expect(screen.getByTitle("Synced group")).toBeInTheDocument()
+    expect(screen.getByTestId("sync-badge")).toBeInTheDocument()
+  })
+
+  it("does not show a sync badge for non-scim groups", () => {
+    render(GroupNameTableRenderer, {
+      props: {
+        value: "Manual group",
+        row: {
+          name: "Manual group",
+        },
+      },
+    })
+
+    expect(screen.queryByTestId("sync-badge")).not.toBeInTheDocument()
+  })
+})

--- a/packages/builder/src/settings/pages/people/users/_components/EditWorkspaceUserModal.spec.ts
+++ b/packages/builder/src/settings/pages/people/users/_components/EditWorkspaceUserModal.spec.ts
@@ -1,0 +1,160 @@
+import { render, screen } from "@testing-library/svelte"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { Constants } from "@budibase/frontend-core"
+import type { User } from "@budibase/types"
+const { authStore, rolesStore, usersMock } = vi.hoisted(() => {
+  const createStore = <T,>(initialValue: T) => {
+    let value = initialValue
+    const subscribers = new Set<(value: T) => void>()
+
+    return {
+      subscribe(callback: (value: T) => void) {
+        callback(value)
+        subscribers.add(callback)
+        return () => subscribers.delete(callback)
+      },
+      set(nextValue: T) {
+        value = nextValue
+        subscribers.forEach(callback => callback(value))
+      },
+    }
+  }
+
+  return {
+    authStore: createStore({
+      user: {
+        _id: "user-current",
+      },
+    }),
+    rolesStore: createStore([] as any[]),
+    usersMock: {
+      get: vi.fn(),
+      save: vi.fn(),
+      addUserToWorkspace: vi.fn(),
+      removeUserFromWorkspace: vi.fn(),
+      getUserRole: vi.fn(),
+    },
+  }
+})
+
+vi.mock("@budibase/bbui", async () => {
+  const [
+    { default: MockInput },
+    { default: MockLayout },
+    { default: MockModalContent },
+    { default: MockSelect },
+  ] = await Promise.all([
+    import("@/test/mocks/MockInput.svelte"),
+    import("@/test/mocks/MockLayout.svelte"),
+    import("@/test/mocks/MockModalContent.svelte"),
+    import("@/test/mocks/MockSelect.svelte"),
+  ])
+
+  return {
+    Input: MockInput,
+    Layout: MockLayout,
+    ModalContent: MockModalContent,
+    Select: MockSelect,
+    Helpers: {
+      uuid: vi.fn(() => "session-id"),
+    },
+    keepOpen: Symbol("keepOpen"),
+    notifications: {
+      success: vi.fn(),
+      error: vi.fn(),
+    },
+  }
+})
+
+vi.mock("@/components/common/GlobalRoleSelect.svelte", async () => {
+  const { default: MockGlobalRoleSelect } = await import(
+    "@/test/mocks/MockGlobalRoleSelect.svelte"
+  )
+
+  return {
+    default: MockGlobalRoleSelect,
+  }
+})
+
+vi.mock("@/stores/builder", () => ({
+  roles: rolesStore,
+}))
+
+vi.mock("@/stores/portal", () => ({
+  auth: authStore,
+  users: usersMock,
+}))
+
+vi.mock("../roleUtils", () => ({
+  getRoleFlags: vi.fn(() => ({
+    admin: { global: false },
+    builder: { global: false, creator: false, apps: [] },
+  })),
+}))
+
+import EditWorkspaceUserModal from "./EditWorkspaceUserModal.svelte"
+
+const buildUser = (overrides: Partial<User> = {}): User =>
+  ({
+    _id: "user-1",
+    _rev: "rev-1",
+    tenantId: "tenant-1",
+    email: "user@example.com",
+    firstName: "Casey",
+    lastName: "Rowan",
+    roles: { app_1: Constants.Roles.BASIC },
+    admin: { global: false },
+    builder: { global: false, creator: false, apps: [] },
+    ...overrides,
+  }) as User
+
+describe("EditWorkspaceUserModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authStore.set({ user: { _id: "user-current" } })
+    rolesStore.set([
+      {
+        _id: Constants.Roles.BASIC,
+        name: "Basic",
+        uiMetadata: { displayName: "Basic user", color: "#111111" },
+      },
+      {
+        _id: Constants.Roles.ADMIN,
+        name: "Admin",
+        uiMetadata: { displayName: "Admin user", color: "#222222" },
+      },
+    ])
+    usersMock.getUserRole.mockReturnValue(Constants.BudibaseRoles.AppUser)
+  })
+
+  it("keeps synced user identity fields read-only while leaving role fields editable", () => {
+    render(EditWorkspaceUserModal, {
+      props: {
+        user: buildUser({
+          scimInfo: { isSync: true },
+        }),
+        workspaceId: "app_1",
+      },
+    })
+
+    expect(screen.getByLabelText("Email")).toHaveAttribute("readonly")
+    expect(screen.getByLabelText("First name")).toBeDisabled()
+    expect(screen.getByLabelText("Last name")).toBeDisabled()
+    expect(screen.getByLabelText("Select role")).not.toBeDisabled()
+    expect(screen.getByLabelText("Select end user role")).not.toBeDisabled()
+  })
+
+  it("allows non-scim users to edit identity and role fields", () => {
+    render(EditWorkspaceUserModal, {
+      props: {
+        user: buildUser(),
+        workspaceId: "app_1",
+      },
+    })
+
+    expect(screen.getByLabelText("First name")).not.toBeDisabled()
+    expect(screen.getByLabelText("Last name")).not.toBeDisabled()
+    expect(screen.getByLabelText("Select role")).not.toBeDisabled()
+    expect(screen.getByLabelText("Select end user role")).not.toBeDisabled()
+  })
+})

--- a/packages/builder/src/settings/pages/people/users/_components/EditWorkspaceUserModal.spec.ts
+++ b/packages/builder/src/settings/pages/people/users/_components/EditWorkspaceUserModal.spec.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { Constants } from "@budibase/frontend-core"
 import type { User } from "@budibase/types"
 const { authStore, rolesStore, usersMock } = vi.hoisted(() => {
-  const createStore = <T,>(initialValue: T) => {
+  const createStore = <T>(initialValue: T) => {
     let value = initialValue
     const subscribers = new Set<(value: T) => void>()
 

--- a/packages/builder/src/settings/pages/people/users/_components/EditWorkspaceUserModal.svelte
+++ b/packages/builder/src/settings/pages/people/users/_components/EditWorkspaceUserModal.svelte
@@ -167,7 +167,7 @@
     !user || canWorkspaceRoleOverrideGlobalRole(users.getUserRole(user))
   )
   const disableRole = $derived(
-    disableFields ||
+    readonly ||
       isTenantOwner ||
       user?._id === $auth.user?._id ||
       !canEditWorkspaceRole

--- a/packages/builder/src/settings/pages/people/users/_components/EmailTableRenderer.spec.ts
+++ b/packages/builder/src/settings/pages/people/users/_components/EmailTableRenderer.spec.ts
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/svelte"
+import { describe, expect, it, vi } from "vitest"
+import MockActiveDirectoryInfo from "@/test/mocks/MockActiveDirectoryInfo.svelte"
+
+vi.mock("../../_components/ActiveDirectoryInfo.svelte", () => ({
+  default: MockActiveDirectoryInfo,
+}))
+
+import EmailTableRenderer from "./EmailTableRenderer.svelte"
+
+describe("EmailTableRenderer", () => {
+  it("shows a sync badge for scim users", () => {
+    render(EmailTableRenderer, {
+      props: {
+        value: "scim@example.com",
+        row: { scimInfo: { isSync: true } },
+      },
+    })
+
+    expect(screen.getByText("scim@example.com")).toBeInTheDocument()
+    expect(screen.getByTestId("sync-badge")).toBeInTheDocument()
+  })
+
+  it("does not show a sync badge for non-scim users", () => {
+    render(EmailTableRenderer, {
+      props: {
+        value: "manual@example.com",
+        row: {},
+      },
+    })
+
+    expect(screen.queryByTestId("sync-badge")).not.toBeInTheDocument()
+  })
+})

--- a/packages/builder/src/test/mocks/MockActiveDirectoryInfo.svelte
+++ b/packages/builder/src/test/mocks/MockActiveDirectoryInfo.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  export let text = ""
+  export let iconSize = "S"
+</script>
+
+<div data-testid="sync-badge" data-icon-size={iconSize}>
+  {text || "Synced from your AD"}
+</div>

--- a/packages/builder/src/test/mocks/MockBody.svelte
+++ b/packages/builder/src/test/mocks/MockBody.svelte
@@ -1,0 +1,3 @@
+<div data-testid="body">
+  <slot />
+</div>

--- a/packages/builder/src/test/mocks/MockColorPicker.svelte
+++ b/packages/builder/src/test/mocks/MockColorPicker.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  export let value = ""
+  export let disabled = false
+</script>
+
+<label>
+  <span>Color</span>
+  <input aria-label="Color" bind:value {disabled} />
+</label>

--- a/packages/builder/src/test/mocks/MockGlobalRoleSelect.svelte
+++ b/packages/builder/src/test/mocks/MockGlobalRoleSelect.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import MockSelect from "./MockSelect.svelte"
+
+  export let value: any = ""
+  export let options: any[] = []
+  export let disabled = false
+</script>
+
+<MockSelect
+  label="Select role"
+  bind:value
+  {options}
+  {disabled}
+  getOptionLabel={option => option.label}
+  getOptionValue={option => option.value}
+/>

--- a/packages/builder/src/test/mocks/MockGroupIcon.svelte
+++ b/packages/builder/src/test/mocks/MockGroupIcon.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  export let group: { name?: string } | undefined
+</script>
+
+<div data-testid="group-icon">{group?.name || "group"}</div>

--- a/packages/builder/src/test/mocks/MockIconPicker.svelte
+++ b/packages/builder/src/test/mocks/MockIconPicker.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  export let value = ""
+  export let disabled = false
+</script>
+
+<label>
+  <span>Icon</span>
+  <input aria-label="Icon" bind:value {disabled} />
+</label>

--- a/packages/builder/src/test/mocks/MockInput.svelte
+++ b/packages/builder/src/test/mocks/MockInput.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  export let label = ""
+  export let value = ""
+  export let disabled = false
+  export let readonly = false
+  export let error: string | undefined = undefined
+</script>
+
+<label>
+  <span>{label}</span>
+  <input aria-label={label} bind:value {disabled} {readonly} />
+  {#if error}
+    <span>{error}</span>
+  {/if}
+</label>

--- a/packages/builder/src/test/mocks/MockLayout.svelte
+++ b/packages/builder/src/test/mocks/MockLayout.svelte
@@ -1,0 +1,3 @@
+<div data-testid="layout">
+  <slot />
+</div>

--- a/packages/builder/src/test/mocks/MockModalContent.svelte
+++ b/packages/builder/src/test/mocks/MockModalContent.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  export let onConfirm = () => {}
+  export let size = "M"
+  export let title = ""
+  export let confirmText = "Save"
+  export let disabled = false
+</script>
+
+<div data-testid="modal-content" data-size={size}>
+  {#if title}
+    <h1>{title}</h1>
+  {/if}
+  <slot name="header" />
+  <slot />
+  <button type="button" on:click={onConfirm} {disabled}>
+    {confirmText}
+  </button>
+</div>

--- a/packages/builder/src/test/mocks/MockSelect.svelte
+++ b/packages/builder/src/test/mocks/MockSelect.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  export let label = ""
+  export let value: any = ""
+  export let options: any[] = []
+  export let disabled = false
+  export let getOptionLabel = (option: any) => option?.label ?? option
+  export let getOptionValue = (option: any) => option?.value ?? option
+</script>
+
+<label>
+  <span>{label}</span>
+  <select aria-label={label} bind:value {disabled}>
+    {#each options as option}
+      <option value={getOptionValue(option)}>{getOptionLabel(option)}</option>
+    {/each}
+  </select>
+</label>


### PR DESCRIPTION
## Description
Allow SCIM-managed users to keep externally managed identity fields read-only while still allowing Budibase role changes in the workspace user modal. This also adds frontend test coverage for synced user/group badges and the editable vs read-only behaviour for SCIM and non-SCIM users/groups.

The fix is a one-liner: https://github.com/Budibase/budibase/pull/18256/changes#diff-75d6b29ff2c3f3d533f59a7558ce81c32b739016928d14973014349c519c5a1bR170

It was incorrectly assumed that the role would be synced from the Active Directory, but this is set within Budibase.

## Launchcontrol
SCIM-synced users and groups still show as externally managed, but admins can now update Budibase-managed access fields without editing directory-managed identity fields.

