### PR TITLE
Unify AI flags for the release

### DIFF
--- a/packages/backend-core/src/features/features.ts
+++ b/packages/backend-core/src/features/features.ts
@@ -235,9 +235,7 @@ export class FlagSet<T extends { [name: string]: boolean }> {
 const featureFlagDefaults: Record<FeatureFlag, boolean> = {
   [FeatureFlag.USE_ZOD_VALIDATOR]: false,
   [FeatureFlag.AI_AGENTS]: false,
-  [FeatureFlag.AI_CHAT]: false,
   [FeatureFlag.AI_RAG]: false,
-  [FeatureFlag.WORKSPACE_HOME]: false,
   [FeatureFlag.DEBUG_UI]: env.isDev(),
   [FeatureFlag.DEV_USE_CLIENT_FROM_STORAGE]: false,
 }

--- a/packages/builder/src/pages/builder/apps/index.svelte
+++ b/packages/builder/src/pages/builder/apps/index.svelte
@@ -49,7 +49,7 @@
   $: userApps = $clientAppsStore.apps
   $: liveChatApps = $clientChatAppsStore.chatApps
   $: chatAppsLoaded = $clientChatAppsStore.loaded
-  $: chatFeatureEnabled = $featureFlags.AI_CHAT
+  $: chatFeatureEnabled = $featureFlags.AI_AGENTS
   $: isOwner = $auth.accountPortalAccess && $admin.cloud
 
   function getUrl(app: EnrichedApp | PublishedWorkspaceData) {

--- a/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
@@ -438,7 +438,7 @@
   <CreateWorkspaceModal />
 </Modal>
 
-{#if workspaceId && $featureFlags[FeatureFlag.WORKSPACE_HOME]}
+{#if workspaceId && $featureFlags[FeatureFlag.AI_AGENTS]}
   <Modal bind:this={createAutomationModal}>
     <CreateAutomationModal {webhookModal} />
   </Modal>
@@ -512,10 +512,10 @@
         {#if workspaceId}
           <div
             class="core-sections"
-            class:workspace_home={$featureFlags[FeatureFlag.WORKSPACE_HOME]}
+            class:workspace_home={$featureFlags[FeatureFlag.AI_AGENTS]}
           >
             <div>
-              {#if $featureFlags[FeatureFlag.WORKSPACE_HOME]}
+              {#if $featureFlags[FeatureFlag.AI_AGENTS]}
                 <SideNavLink
                   icon="house"
                   text="Home"

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/deployment.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/deployment.svelte
@@ -65,7 +65,7 @@
   )
 
   const hasAiConfig = $derived.by(() => !!currentAgent?.aiconfig?.trim())
-  const agentChatEnabled = $derived(!!$featureFlags[FeatureFlag.AI_CHAT])
+  const agentChatEnabled = $derived(!!$featureFlags[FeatureFlag.AI_AGENTS])
 
   const channels = $derived.by<DeploymentRow[]>(() => [
     {

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/index.svelte
@@ -111,7 +111,7 @@
     })
 
   onMount(async () => {
-    if ($featureFlags[FeatureFlag.WORKSPACE_HOME]) {
+    if ($featureFlags[FeatureFlag.AI_AGENTS]) {
       goto($featureFlags.AI_AGENTS ? "../home?type=agent" : "../home")
       return
     }

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/index.svelte
@@ -45,7 +45,7 @@
   $: goto = $gotoStore
 
   onMount(() => {
-    if ($featureFlags[FeatureFlag.WORKSPACE_HOME]) {
+    if ($featureFlags[FeatureFlag.AI_AGENTS]) {
       goto("../home?type=automation")
     }
   })

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/index.svelte
@@ -29,23 +29,14 @@
   let chatAgents: ChatAgentConfig[] = []
   let settingChatLive = false
 
-  $: chatEnabled =
-    $featureFlags[FeatureFlag.AI_AGENTS] && $featureFlags[FeatureFlag.AI_AGENTS]
+  $: chatEnabled = $featureFlags[FeatureFlag.AI_AGENTS]
 
   onMount(() => {
     if (chatEnabled) {
       return
     }
 
-    const workspaceHomeEnabled = $featureFlags[FeatureFlag.AI_AGENTS]
-    const agentsEnabled = $featureFlags[FeatureFlag.AI_AGENTS]
-
-    if (workspaceHomeEnabled) {
-      goto(agentsEnabled ? "../home?type=agent" : "../home")
-      return
-    }
-
-    goto(agentsEnabled ? "../agent" : "../")
+    goto("../")
   })
 
   $: namedAgents = agents.filter(agent => Boolean(agent?.name))

--- a/packages/builder/src/pages/builder/workspace/[application]/chat/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/chat/index.svelte
@@ -30,14 +30,14 @@
   let settingChatLive = false
 
   $: chatEnabled =
-    $featureFlags[FeatureFlag.AI_AGENTS] && $featureFlags[FeatureFlag.AI_CHAT]
+    $featureFlags[FeatureFlag.AI_AGENTS] && $featureFlags[FeatureFlag.AI_AGENTS]
 
   onMount(() => {
     if (chatEnabled) {
       return
     }
 
-    const workspaceHomeEnabled = $featureFlags[FeatureFlag.WORKSPACE_HOME]
+    const workspaceHomeEnabled = $featureFlags[FeatureFlag.AI_AGENTS]
     const agentsEnabled = $featureFlags[FeatureFlag.AI_AGENTS]
 
     if (workspaceHomeEnabled) {

--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/new/_components/NewComponentPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/new/_components/NewComponentPanel.svelte
@@ -38,7 +38,7 @@
     $selectedComponent
   )
   $: structure = getComponentStructure({
-    chatbox: $featureFlags.AI_AGENTS && $featureFlags.AI_CHAT,
+    chatbox: $featureFlags.AI_AGENTS && $featureFlags.AI_AGENTS,
   })
   $: enrichedStructure = enrichStructure(
     structure,

--- a/packages/builder/src/pages/builder/workspace/[application]/design/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/index.svelte
@@ -43,7 +43,7 @@
   $: goto = $gotoStore
 
   onMount(() => {
-    if ($featureFlags[FeatureFlag.WORKSPACE_HOME]) {
+    if ($featureFlags[FeatureFlag.AI_AGENTS]) {
       goto("../home?type=app")
     }
   })

--- a/packages/builder/src/pages/builder/workspace/[application]/home/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/index.svelte
@@ -641,7 +641,7 @@
       return
     }
 
-    if (!$featureFlags[FeatureFlag.WORKSPACE_HOME]) {
+    if (!$featureFlags[FeatureFlag.AI_AGENTS]) {
       goto(url("../design"))
       return
     }

--- a/packages/builder/src/pages/builder/workspace/[application]/home/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/index.svelte
@@ -626,7 +626,7 @@
 
   $: filteredRows = filterHomeRows({ rows: allRows, typeFilter, searchTerm })
 
-  $: showAgentChat = $featureFlags.AI_AGENTS && $featureFlags.AI_CHAT
+  $: showAgentChat = $featureFlags.AI_AGENTS && $featureFlags.AI_AGENTS
   $: showHeaderActions = $licensing.showTrialBanner || showAgentChat
   $: budibaseAICreditLimit =
     $licensing.license?.quotas?.usage.monthly.budibaseAICredits?.value

--- a/packages/builder/src/pages/builder/workspace/[application]/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/index.svelte
@@ -12,7 +12,7 @@
     const { appId } = $appStore
     if (!appId) return
 
-    if ($featureFlags[FeatureFlag.WORKSPACE_HOME]) {
+    if ($featureFlags[FeatureFlag.AI_AGENTS]) {
       $redirect(`./home${window.location.search}`)
       return
     }

--- a/packages/types/src/sdk/featureFlag.ts
+++ b/packages/types/src/sdk/featureFlag.ts
@@ -1,9 +1,7 @@
 export enum FeatureFlag {
   USE_ZOD_VALIDATOR = "USE_ZOD_VALIDATOR",
   AI_AGENTS = "AI_AGENTS",
-  AI_CHAT = "AI_CHAT",
   AI_RAG = "AI_RAG",
-  WORKSPACE_HOME = "WORKSPACE_HOME",
 
   // Dev
   DEBUG_UI = "DEBUG_UI",


### PR DESCRIPTION
## Description
Unify ai agents, ai chat and workspace homes flags, to be all or nothing



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates feature gating under `AI_AGENTS`, removing `AI_CHAT` and `WORKSPACE_HOME`. Home, Chat, and workspace UI now only render when `AI_AGENTS` is enabled.

- **Refactors**
  - Removed `AI_CHAT` and `WORKSPACE_HOME` from `FeatureFlag` and backend defaults; fixed types in `packages/types`.
  - Replaced checks/redirects with `AI_AGENTS` across Apps list, SideNav Home, agent deploy, and agent/automation/design/chat/home pages; Chat now redirects to the workspace root when disabled.

- **Migration**
  - Remove any toggles/configs for `AI_CHAT` and `WORKSPACE_HOME`; use `AI_AGENTS` instead.
  - Verify redirects/deep links to `/home` and Chat are conditioned on `AI_AGENTS` being enabled.

<sup>Written for commit 5986dae1305e0a0c2ad7f8d155fad9e5ecaf682e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



