### PR TITLE
Add beta tag to agents nav

### DIFF
--- a/packages/builder/src/components/common/TopBar.svelte
+++ b/packages/builder/src/components/common/TopBar.svelte
@@ -2,11 +2,12 @@
   interface Breadcrumb {
     text?: string
     url?: string
+    tag?: string
   }
 </script>
 
 <script lang="ts">
-  import { Body, Icon, Popover, PopoverAlignment } from "@budibase/bbui"
+  import { Body, Icon, Popover, PopoverAlignment, Tag } from "@budibase/bbui"
   import PublishMenu from "./PublishMenu.svelte"
   import { deploymentStore } from "@/stores/builder"
   import type { PopoverAPI } from "@budibase/bbui"
@@ -42,7 +43,14 @@
   <div class="breadcrumbs">
     {#each breadcrumbs as breadcrumb, idx}
       {#if breadcrumb.text}
-        <a href={$url(breadcrumb.url || "./")}>{breadcrumb.text}</a>
+        <div class="breadcrumb-item">
+          <a href={$url(breadcrumb.url || "./")}>{breadcrumb.text}</a>
+          {#if breadcrumb.tag}
+            <div class="breadcrumb-tag-wrapper">
+              <Tag emphasized>{breadcrumb.tag}</Tag>
+            </div>
+          {/if}
+        </div>
         {#if idx < breadcrumbs.length - 1}
           <div class="divider">/</div>
         {/if}
@@ -93,6 +101,19 @@
     flex-direction: row;
     align-items: center;
     gap: 6px;
+  }
+  .breadcrumb-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .breadcrumb-tag-wrapper :global(.spectrum-Tags-item) {
+    padding: 0 3px;
+    border-radius: 5px;
+  }
+  .breadcrumb-tag-wrapper :global(.spectrum-Tags-itemLabel) {
+    font-size: 11px;
+    line-height: 1.1;
   }
   .breadcrumbs a {
     font-size: 14px;

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
@@ -88,7 +88,7 @@
 <div class="config-wrapper">
   <TopBar
     breadcrumbs={[
-      { text: "Agents", url: "../" },
+      { text: "Agents", url: "../", tag: "Beta" },
       { text: currentAgent?.name || "Agent" },
     ]}
     icon="Effect"


### PR DESCRIPTION
## Description
Adds a beta tag to the agents nav


## Screenshots
<img width="648" height="98" alt="image" src="https://github.com/user-attachments/assets/550913a2-c53f-4dd7-9161-35c1b4cdec24" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Beta” tag to the Agents breadcrumb in the top bar to clearly show the feature is in beta. Updated `TopBar` to support optional breadcrumb tags using `Tag` from `@budibase/bbui` with compact styling.

<sup>Written for commit 69d6b0edb8af1e4f4dcc094bab210aba8d81451f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

