### PR TITLE
fix: tenant admin perms

### DIFF
--- a/packages/builder/src/pages/builder/apps/index.svelte
+++ b/packages/builder/src/pages/builder/apps/index.svelte
@@ -213,7 +213,7 @@
                       <a
                         class="app"
                         target="_blank"
-                        rel="noreferrer"
+                        rel="noopener"
                         href={appChatUrl(chatApp.url)}
                       >
                         <div

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/DeploymentChannels/AgentChatChannel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/DeploymentChannels/AgentChatChannel.svelte
@@ -237,7 +237,7 @@
   </div>
   <div class="row-action">
     {#if enabled && chatUrl}
-      <a class="chat-link" href={chatUrl} target="_blank" rel="noreferrer">
+      <a class="chat-link" href={chatUrl} target="_blank" rel="noopener">
         Open chat
       </a>
     {/if}


### PR DESCRIPTION
## Description
Tenant admins are not automatically app-role admins unless they’re builders for that app; role resolution can fall back to PUBLIC, leading to a brittle role resolution for chat apps

This change fixes a chat launch edge case caused by `rel="noreferrer"` on chat links.  
When noreferrer is set, browsers omit the Referer header on the new-tab navigation. In the chat bootstrap path, server-side route resolution uses `x-budibase-embed-location` or` Referer` headers to determine the current. If that context is missing, the request can be evaluated like a normal app view, and users without explicit workspace role mapping can fall back to PUBLIC, resulting in a 'you can't view this app screen'.