### PR TITLE
removes longform text from types-to-skip

### DIFF
--- a/packages/builder/src/components/backend/DataTable/formula.js
+++ b/packages/builder/src/components/backend/DataTable/formula.js
@@ -9,7 +9,6 @@ const MAX_DEPTH = 1
 
 const TYPES_TO_SKIP = [
   FieldType.AI,
-  FieldType.LONGFORM,
   FieldType.SIGNATURE_SINGLE,
   FieldType.ATTACHMENTS,
   //https://github.com/Budibase/budibase/issues/3030


### PR DESCRIPTION
## Description
An enterprise customer was asking for the ability to use Long-form text fields in Formula columns. This PR enables that by removing itf from the array of `TYPES_TO_SKIP` in `formula.js`

## Addresses
- https://github.com/Budibase/budibase/issues/18257

## App Export
[18257-export-1773300223144.tar.gz](https://github.com/user-attachments/files/25927933/18257-export-1773300223144.tar.gz)


## Screenshots
<img width="1625" height="231" alt="image" src="https://github.com/user-attachments/assets/2bea79b6-1342-40aa-b668-38dc45c90533" />

<img width="1374" height="301" alt="image" src="https://github.com/user-attachments/assets/b28f429c-f39d-432d-bbc9-edff3751f6fb" />


## Launchcontrol

_Adds Long-form text field to bindings drawers in Formula columns._
