### PR TITLE
update styling around log detail

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/LogComponents/LogsSessionDetail.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/LogComponents/LogsSessionDetail.svelte
@@ -195,6 +195,7 @@
   .steps-list {
     display: flex;
     flex-direction: column;
+    gap: 4px;
   }
 
   .detail-empty {

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/LogComponents/LogsSessionStep.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/LogComponents/LogsSessionStep.svelte
@@ -219,6 +219,12 @@
     border-bottom: none;
   }
 
+  .step--expanded {
+    background: var(--spectrum-global-color-gray-100);
+    border: 1px solid var(--spectrum-global-color-gray-200);
+    border-radius: 8px;
+  }
+
   .step-header {
     display: grid;
     grid-template-columns: 34px minmax(0, 1fr) auto;
@@ -231,11 +237,16 @@
     text-align: left;
     cursor: pointer;
     transition: background 130ms ease-out;
+    border-radius: 8px;
   }
 
-  .step-header:hover,
-  .step--expanded .step-header {
+  .step-header:hover {
     background: var(--spectrum-global-color-gray-100);
+  }
+
+  .step--expanded .step-header {
+    background: transparent;
+    border-radius: 8px 8px 0 0;
   }
 
   .step-number {
@@ -367,7 +378,6 @@
     display: flex;
     align-items: center;
     padding-bottom: 10px;
-    border-bottom: 1px solid var(--spectrum-global-color-gray-200);
   }
 
   .panel-title {
@@ -471,7 +481,7 @@
     border-radius: 6px;
     overflow: auto;
     max-height: 220px;
-    background: var(--background-alt);
+    background: var(--background);
     scrollbar-width: thin;
   }
 


### PR DESCRIPTION
## Description
Updates the styling around the log detail. 

## Screenshots
<img width="1125" height="889" alt="image" src="https://github.com/user-attachments/assets/be52ab19-d171-45eb-87e8-48e75658ac80" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines log session detail styling for clearer hierarchy and less noise. Adds a 4px gap between steps, gives expanded steps a gray background with 8px radius and 1px border, removes panel header bottom border, and uses the main background for payload blocks.

<sup>Written for commit cb94cfa2dc1fe6faebb914af61cf42e8aaccdbed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

