### PR TITLE
Improve knowledge base back and forth

### DIFF
--- a/packages/builder/src/settings/pages/ai/knowledge-bases/EmbeddingModelForm.svelte
+++ b/packages/builder/src/settings/pages/ai/knowledge-bases/EmbeddingModelForm.svelte
@@ -18,10 +18,9 @@
   export interface Props {
     configId?: string
     provider?: string | undefined
-    knowledgeBaseId?: string
   }
 
-  let { configId, provider, knowledgeBaseId }: Props = $props()
+  let { configId, provider }: Props = $props()
 
   let config = $derived(
     $aiConfigsStore.customConfigs.find(c => c._id === configId)
@@ -133,12 +132,6 @@
         draft._rev = updated._rev
         captureSavedSnapshot()
         notifications.success(`Configuration updated`)
-
-        if (knowledgeBaseId && knowledgeBaseId !== "new") {
-          bb.settings(`/ai-config/knowledge-bases/${knowledgeBaseId}`)
-        } else {
-          bb.settings(`/ai-config/knowledge-bases`)
-        }
       } else {
         const { _id, ...rest } = Helpers.cloneDeep(draft)
         const created = await aiConfigsStore.createConfig(rest)
@@ -154,13 +147,8 @@
             embeddingModel: created._id,
           })
         }
-
-        if (knowledgeBaseId && knowledgeBaseId !== "new") {
-          bb.settings(`/ai-config/knowledge-bases/${knowledgeBaseId}`)
-        } else {
-          bb.settings(`/ai-config/knowledge-bases`)
-        }
       }
+      bb.goToParent()
     } catch (err: any) {
       notifications.error(err.message || `Failed to save configuration`)
     } finally {
@@ -189,7 +177,7 @@
         try {
           await aiConfigsStore.deleteConfig(configId)
           notifications.success(`Configuration deleted`)
-          bb.settings(`/ai-config/knowledge-bases`)
+          bb.goToParent()
         } catch (err: any) {
           notifications.error(err.message || `Failed to delete configuration`)
         }

--- a/packages/builder/src/settings/pages/ai/knowledge-bases/KnowledgeBaseForm.svelte
+++ b/packages/builder/src/settings/pages/ai/knowledge-bases/KnowledgeBaseForm.svelte
@@ -6,7 +6,14 @@
     knowledgeBaseStore,
     vectorDbStore,
   } from "@/stores/portal"
-  import { Button, Helpers, Input, notifications, Select } from "@budibase/bbui"
+  import {
+    ActionButton,
+    Button,
+    Helpers,
+    Input,
+    notifications,
+    Select,
+  } from "@budibase/bbui"
   import { onMount } from "svelte"
   import KnowledgeBaseFilesPanel from "./files-panel/index.svelte"
   import { routeActions } from "../.."
@@ -180,6 +187,34 @@
     }
   }
 
+  function openEmbeddingModel() {
+    knowledgeBaseStore.setFormDraft(Helpers.cloneDeep(draft))
+    const currentKnowledgeBaseId = knowledgeBaseId || "new"
+    if (draft.embeddingModel) {
+      bb.settings(
+        `/ai-config/knowledge-bases/${currentKnowledgeBaseId}/embedding/${draft.embeddingModel}`
+      )
+      return
+    }
+    bb.settings(
+      `/ai-config/knowledge-bases/${currentKnowledgeBaseId}/embedding/new`
+    )
+  }
+
+  function openVectorDb() {
+    knowledgeBaseStore.setFormDraft(Helpers.cloneDeep(draft))
+    const currentKnowledgeBaseId = knowledgeBaseId || "new"
+    if (draft.vectorDb) {
+      bb.settings(
+        `/ai-config/knowledge-bases/${currentKnowledgeBaseId}/vectordb/${draft.vectorDb}`
+      )
+      return
+    }
+    bb.settings(
+      `/ai-config/knowledge-bases/${currentKnowledgeBaseId}/vectordb/new`
+    )
+  }
+
   async function deleteKnowledgeBase() {
     if (!draft._id) {
       return
@@ -244,6 +279,11 @@
         ? "Remove all files to change the embedding model."
         : ""}
     />
+    <ActionButton
+      icon={draft.embeddingModel ? "pencil" : "Add"}
+      size="M"
+      on:click={openEmbeddingModel}
+    />
   </div>
 
   <div class="select">
@@ -259,6 +299,11 @@
       tooltip={!canEditReferences
         ? "Remove all files to change the vector database."
         : ""}
+    />
+    <ActionButton
+      icon={draft.vectorDb ? "pencil" : "Add"}
+      size="M"
+      on:click={openVectorDb}
     />
   </div>
 

--- a/packages/builder/src/settings/pages/ai/knowledge-bases/KnowledgeBaseForm.svelte
+++ b/packages/builder/src/settings/pages/ai/knowledge-bases/KnowledgeBaseForm.svelte
@@ -261,7 +261,12 @@
         ? "Remove all files to change the embedding model."
         : ""}
     />
-    <ActionButton icon={"Add"} size="M" on:click={createNewEmbeddingModel} />
+    <ActionButton
+      icon={"Add"}
+      size="M"
+      disabled={!canEditReferences}
+      on:click={createNewEmbeddingModel}
+    />
   </div>
 
   <div class="select">
@@ -278,7 +283,12 @@
         ? "Remove all files to change the vector database."
         : ""}
     />
-    <ActionButton icon={"Add"} size="M" on:click={createNewVectorDb} />
+    <ActionButton
+      icon={"Add"}
+      size="M"
+      disabled={!canEditReferences}
+      on:click={createNewVectorDb}
+    />
   </div>
 
   <KnowledgeBaseFilesPanel knowledgeBaseId={draft._id} {hasReferenceChanges} />

--- a/packages/builder/src/settings/pages/ai/knowledge-bases/KnowledgeBaseForm.svelte
+++ b/packages/builder/src/settings/pages/ai/knowledge-bases/KnowledgeBaseForm.svelte
@@ -187,32 +187,14 @@
     }
   }
 
-  function openEmbeddingModel() {
+  function createNewEmbeddingModel() {
     knowledgeBaseStore.setFormDraft(Helpers.cloneDeep(draft))
-    const currentKnowledgeBaseId = knowledgeBaseId || "new"
-    if (draft.embeddingModel) {
-      bb.settings(
-        `/ai-config/knowledge-bases/${currentKnowledgeBaseId}/embedding/${draft.embeddingModel}`
-      )
-      return
-    }
-    bb.settings(
-      `/ai-config/knowledge-bases/${currentKnowledgeBaseId}/embedding/new`
-    )
+    bb.settings(`/ai-config/knowledge-bases/${knowledgeBaseId}/embedding/new`)
   }
 
-  function openVectorDb() {
+  function createNewVectorDb() {
     knowledgeBaseStore.setFormDraft(Helpers.cloneDeep(draft))
-    const currentKnowledgeBaseId = knowledgeBaseId || "new"
-    if (draft.vectorDb) {
-      bb.settings(
-        `/ai-config/knowledge-bases/${currentKnowledgeBaseId}/vectordb/${draft.vectorDb}`
-      )
-      return
-    }
-    bb.settings(
-      `/ai-config/knowledge-bases/${currentKnowledgeBaseId}/vectordb/new`
-    )
+    bb.settings(`/ai-config/knowledge-bases/${knowledgeBaseId}/vectordb/new`)
   }
 
   async function deleteKnowledgeBase() {
@@ -279,11 +261,7 @@
         ? "Remove all files to change the embedding model."
         : ""}
     />
-    <ActionButton
-      icon={draft.embeddingModel ? "pencil" : "Add"}
-      size="M"
-      on:click={openEmbeddingModel}
-    />
+    <ActionButton icon={"Add"} size="M" on:click={createNewEmbeddingModel} />
   </div>
 
   <div class="select">
@@ -300,11 +278,7 @@
         ? "Remove all files to change the vector database."
         : ""}
     />
-    <ActionButton
-      icon={draft.vectorDb ? "pencil" : "Add"}
-      size="M"
-      on:click={openVectorDb}
-    />
+    <ActionButton icon={"Add"} size="M" on:click={createNewVectorDb} />
   </div>
 
   <KnowledgeBaseFilesPanel knowledgeBaseId={draft._id} {hasReferenceChanges} />

--- a/packages/builder/src/settings/pages/ai/knowledge-bases/VectorDatabaseForm.svelte
+++ b/packages/builder/src/settings/pages/ai/knowledge-bases/VectorDatabaseForm.svelte
@@ -9,10 +9,9 @@
 
   export interface Props {
     id?: string
-    knowledgeBaseId?: string
   }
 
-  let { id, knowledgeBaseId }: Props = $props()
+  let { id }: Props = $props()
 
   let config = $derived($vectorDbStore.configs.find(db => db._id === id))
 
@@ -101,12 +100,6 @@
         draft.port = payload.port
         captureSavedSnapshot()
         notifications.success("Vector database updated")
-
-        if (knowledgeBaseId && knowledgeBaseId !== "new") {
-          bb.settings(`/ai-config/knowledge-bases/${knowledgeBaseId}`)
-        } else {
-          bb.settings(`/ai-config/knowledge-bases`)
-        }
       } else {
         const created = await vectorDbStore.create(payload)
         draft._id = created._id
@@ -122,13 +115,8 @@
             vectorDb: created._id,
           })
         }
-
-        if (knowledgeBaseId && knowledgeBaseId !== "new") {
-          bb.settings(`/ai-config/knowledge-bases/${knowledgeBaseId}`)
-        } else {
-          bb.settings(`/ai-config/knowledge-bases`)
-        }
       }
+      bb.goToParent()
     } catch (err: any) {
       notifications.error(err.message || "Failed to save vector database")
     } finally {
@@ -157,7 +145,7 @@
         try {
           await vectorDbStore.delete(vectorDbId)
           notifications.success("Vector database deleted")
-          bb.settings("/ai-config/knowledge-bases")
+          bb.goToParent()
         } catch (err: any) {
           notifications.error(err.message || "Failed to delete vector database")
         }

--- a/packages/builder/src/stores/bb.ts
+++ b/packages/builder/src/stores/bb.ts
@@ -1,4 +1,5 @@
 import type { MatchedRoute } from "@/types/routing"
+import { get } from "svelte/store"
 import { BudiStore } from "./BudiStore"
 
 type SettingsRouteResolver = (path: string) => MatchedRoute | null
@@ -7,6 +8,16 @@ let settingsRouteResolver: SettingsRouteResolver | null = null
 
 export const setSettingsRouteResolver = (resolver: SettingsRouteResolver) => {
   settingsRouteResolver = resolver
+}
+
+const resolvePathParams = (
+  path: string | undefined,
+  params: Record<string, string>
+) => {
+  if (!path) {
+    return path
+  }
+  return path.replace(/:([^/]+)/g, (_match, key) => params[key] ?? `:${key}`)
 }
 
 export interface Settings {
@@ -29,6 +40,7 @@ export class BBStore extends BudiStore<BBState> {
     super(INITIAL_GLOBAL_STATE)
     this.clearSettings = this.clearSettings.bind(this)
     this.hideSettings = this.hideSettings.bind(this)
+    this.goToParent = this.goToParent.bind(this)
   }
 
   reset() {
@@ -83,6 +95,18 @@ export class BBStore extends BudiStore<BBState> {
         open: false,
       },
     }))
+  }
+
+  goToParent() {
+    const route = get(this.store).settings.route
+    const parentRoute = route?.entry.crumbs?.at(-2)
+    const parentPath = resolvePathParams(parentRoute?.path, route?.params || {})
+
+    if (!parentPath) {
+      console.error("Parent from route not valid", { route })
+      return
+    }
+    this.settings(parentPath)
   }
 }
 


### PR DESCRIPTION
## Description
Adding the option to add new models/db to on the knowledge base creation, keeping the flow simplier avoiding back and forths

<img width="885" height="432" alt="image" src="https://github.com/user-attachments/assets/84ac11dc-68d7-4ef0-8808-ee59f51ec513" />


### Adding from scratch

https://github.com/user-attachments/assets/8e433382-6b4b-420b-b69e-c0dfe30fe74c

### Adding from the knowledge base list
https://github.com/user-attachments/assets/da867152-00fe-4b36-8f5c-22c1b08c5300




## Launchcontrol
Improve Knowledge base UX


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds quick Add buttons to create an embedding model or vector DB from the Knowledge Base form, preserving unsaved changes and disabling when references can’t be edited. Navigation is now breadcrumb-aware, returning to the parent view after save/delete.

- **New Features**
  - Add-only `ActionButton` from `@budibase/bbui` next to both selects; saves draft to `knowledgeBaseStore` and routes to `/ai-config/knowledge-bases/{id}/embedding/new` or `/ai-config/knowledge-bases/{id}/vectordb/new`; disabled when `!canEditReferences`.
  - Child forms use `bb.goToParent()` to return after create/update/delete, removing path-specific logic; editing existing configs from the Knowledge Base form is disabled.

<sup>Written for commit dab65bf08303abe0158bf1e74a8ca7338edc0b89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



