### PR TITLE
fix: disable region autodiscovery for MSAL

### DIFF
--- a/packages/server/src/integrations/microsoftSqlServer.ts
+++ b/packages/server/src/integrations/microsoftSqlServer.ts
@@ -296,6 +296,7 @@ class SqlServerIntegration extends Sql implements DatasourcePlus {
 
           const response = await clientApp.acquireTokenByClientCredential({
             scopes: ["https://database.windows.net/.default"],
+            azureRegion: "DisableMsalForceRegion",
           })
 
           clientCfg.authentication = {


### PR DESCRIPTION
## Description
Security scanners are flagging IMDSv1 calls during Azure region auto-discovery against the hardcoded URL 169.254.169.254.  Budibase doesn't need Azure region discovery, so we're explicitly opting out.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable MSAL Azure region auto-discovery in the SQL Server integration to prevent IMDSv1 calls to 169.254.169.254 flagged by security scanners. We now pass `azureRegion: "DisableMsalForceRegion"` when requesting the `https://database.windows.net/.default` token, since Budibase doesn’t need region discovery.

<sup>Written for commit 81decb5f6da719e69b4a23cc6d233df94ea2ad29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

