### PR TITLE
user settings workspace home/sidebar improvements

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
@@ -71,6 +71,7 @@
   export const show = () => {
     pinned.set(true)
   }
+  export let canInviteUsers = false
   export let onInviteUser: () => void = () => {}
 
   $: automationErrors = getAutomationErrors($enrichedApps || [], workspaceId)
@@ -649,12 +650,14 @@
                 {collapsed}
                 on:click={keepCollapsed}
               />
-              <SideNavLink
-                icon="user-plus"
-                text="Invite users"
-                on:click={openInviteUser}
-                {collapsed}
-              />
+              {#if canInviteUsers}
+                <SideNavLink
+                  icon="user-plus"
+                  text="Invite users"
+                  on:click={openInviteUser}
+                  {collapsed}
+                />
+              {/if}
               <span class="root-nav" class:error={backupErrorCount}>
                 {#if collapsed && backupErrorCount}
                   <span class="status-indicator">

--- a/packages/builder/src/pages/builder/workspace/[application]/_layout.workspace.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_layout.workspace.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { sdk } from "@budibase/shared-core"
   import {
     initialise,
     reset,
@@ -7,7 +8,7 @@
     deploymentStore,
     appStore,
   } from "@/stores/builder"
-  import { appsStore, admin, aiConfigsStore } from "@/stores/portal"
+  import { appsStore, admin, aiConfigsStore, auth } from "@/stores/portal"
   import { bb } from "@/stores/bb"
   import { Heading, Layout, Body } from "@budibase/bbui"
   import { API } from "@/api"
@@ -21,7 +22,11 @@
   let promise = getPackage(application)
   let sideNav: SideNav
   let showInviteUsersModal = false
+  $: canInviteUsers = sdk.users.isAdmin($auth.user)
   $: if ($bb.settings.open && showInviteUsersModal) {
+    showInviteUsersModal = false
+  }
+  $: if (!canInviteUsers && showInviteUsersModal) {
     showInviteUsersModal = false
   }
 
@@ -54,14 +59,19 @@
   })
 </script>
 
-{#if showInviteUsersModal}
+{#if canInviteUsers && showInviteUsersModal}
   <InviteUsersModal onHide={() => (showInviteUsersModal = false)} />
 {/if}
 
 <div class="root" class:blur={$previewStore.showPreview}>
   <SideNav
     bind:this={sideNav}
-    onInviteUser={() => (showInviteUsersModal = true)}
+    {canInviteUsers}
+    onInviteUser={() => {
+      if (canInviteUsers) {
+        showInviteUsersModal = true
+      }
+    }}
   />
   {#await promise}
     <div class="loading"></div>

--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeMetrics.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeMetrics.svelte
@@ -2,8 +2,11 @@
   import { Body, Icon } from "@budibase/bbui"
   import type { GetWorkspaceHomeMetricsResponse } from "@budibase/types"
   import { onMount } from "svelte"
+  import type { Route } from "@/types/routing"
 
   import { API } from "@/api"
+  import { bb } from "@/stores/bb"
+  import { flattenedRoutes } from "@/stores/routing"
 
   const GITHUB_REPO_URL = "https://github.com/Budibase/budibase"
 
@@ -11,6 +14,9 @@
   export let showBudibaseAIMetric = true
 
   let githubStars: number | null = null
+  $: canViewOrganisationUsers = $flattenedRoutes.some(
+    (route: Route) => route.path === "/people/users"
+  )
 
   const formatMetric = (value: number) => {
     return new Intl.NumberFormat("en").format(value)
@@ -38,9 +44,27 @@
     <Body size="XL" weight="600">
       {metrics ? formatMetric(metrics.totalUsers) : "-"}
     </Body>
-    <Body size="S" color="var(--spectrum-global-color-gray-600)">
-      Total users
-    </Body>
+    {#if canViewOrganisationUsers}
+      <button
+        type="button"
+        class="metric-label-link metric-label-button"
+        on:click={() => bb.settings("/people/users")}
+      >
+        <Body size="S" color="var(--spectrum-global-color-gray-600)">
+          Total users
+        </Body>
+        <Icon
+          name="arrow-up-right"
+          size="XS"
+          color="var(--spectrum-global-color-gray-600)"
+          weight="regular"
+        />
+      </button>
+    {:else}
+      <Body size="S" color="var(--spectrum-global-color-gray-600)">
+        Total users
+      </Body>
+    {/if}
   </div>
 
   <div class="metric-card">
@@ -114,6 +138,14 @@
     text-decoration: none;
     color: inherit;
     width: fit-content;
+  }
+
+  .metric-label-button {
+    padding: 0;
+    border: 0;
+    background: none;
+    cursor: pointer;
+    font: inherit;
   }
 
   .metric-label-link:hover {


### PR DESCRIPTION
## Description
- hide the workspace Invite users entry points for users without admin access
- add a shortcut from the workspace home Total users metric to organisation user management when that route is permitted

## Addresses
bug where creator users could open the Add workspace user dialog, and would get stuck because they don't have permissions to use the bulk user create endpoint

https://github.com/user-attachments/assets/319a74d5-4131-436c-82ef-beb92ae4acb6



## Screenshots
_admin - user metric has link to settings, Invite users shows in the sidebar_
<img width="674" height="467" alt="SCR-20260312-jhep-2" src="https://github.com/user-attachments/assets/6dff1e56-3573-4718-86f0-7b0e3760cb6d" />


_creator - user metric has no link, Invite users not present in the sidebar_
<img width="674" height="467" alt="SCR-20260312-jgsm-2" src="https://github.com/user-attachments/assets/c1705c64-066e-464a-8471-07c58221744c" />


## Launchcontrol
minor user setting fixes
