### PR TITLE
Rename operations to actions in UI

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/LogComponents/LogsSessionList.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/LogComponents/LogsSessionList.svelte
@@ -60,7 +60,8 @@
     trigger: { width: "0.8fr", displayName: "Trigger" },
     environmentLabel: { width: "0.55fr", displayName: "Environment" },
     startTime: { width: "1fr", displayName: "Start time" },
-    operations: { width: "0.4fr", displayName: "Operations" },
+    // TODO: Rename this key when the underlying API contract changes from operations to actions. This UI change keeps the existing data shape.
+    operations: { width: "0.4fr", displayName: "Actions" },
   }
 </script>
 

--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeMetrics.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeMetrics.svelte
@@ -72,7 +72,7 @@
       {metrics ? formatMetric(metrics.operationsThisMonth) : "-"}
     </Body>
     <Body size="S" color="var(--spectrum-global-color-gray-600)">
-      Operations this month
+      Actions this month
     </Body>
   </div>
 

--- a/packages/builder/src/settings/pages/people/groups/_components/CreateEditGroupModal.spec.ts
+++ b/packages/builder/src/settings/pages/people/groups/_components/CreateEditGroupModal.spec.ts
@@ -20,7 +20,7 @@ import CreateEditGroupModal from "./CreateEditGroupModal.svelte"
 const buildGroup = (overrides = {}) => ({
   _id: "group-1",
   _rev: "rev-1",
-  name: "Operations",
+  name: "Actions",
   icon: "UserGroup",
   color: "#336699",
   users: [],

--- a/packages/builder/src/settings/pages/usage.svelte
+++ b/packages/builder/src/settings/pages/usage.svelte
@@ -75,7 +75,7 @@
         if (value.value !== 0) {
           const isAICredits = value.name === "Budibase AI Credits"
           monthlyUsage.push({
-            name: value.name === "Actions" ? "Operations" : value.name,
+            name: value.name,
             used: isAICredits ? Math.floor((used ?? 0) / 1000) : (used ?? 0),
             total: isAICredits ? Math.floor(value.value / 1000) : value.value,
           })


### PR DESCRIPTION
## Description

This PR renames the "Operations" terminology to "Actions" across the builder UI to align with the updated naming convention introduced in the backend quota system (`ACTIONS` monthly quota).

Changes:
- **Agent log column**: "Operations" → "Actions" display name (key unchanged, pending API update)
- **Home metrics**: "Operations this month" → "Actions this month"
- **Usage page**: Removed the workaround that mapped the "Actions" quota name back to "Operations"; now displays "Actions" directly
- **Test fixture**: Updated group name in `CreateEditGroupModal.spec.ts` to match

## Screenshots

<img width="1249" height="592" alt="Screenshot 2026-03-12 at 13 02 25" src="https://github.com/user-attachments/assets/754a8066-9b82-4e25-b363-e38ed5696be7" />

<img width="1168" height="738" alt="Screenshot 2026-03-12 at 13 03 12" src="https://github.com/user-attachments/assets/74567679-8554-4559-acb0-338f7ec51714" />

## Launchcontrol

Renames "Operations" to "Actions" in the builder UI (agent log columns, home metrics, and usage page) to match the backend quota naming convention.