### PR TITLE
fix(rest): allow self-hosted blacklist override

### DIFF
--- a/packages/backend-core/src/blacklist/blacklist.ts
+++ b/packages/backend-core/src/blacklist/blacklist.ts
@@ -18,6 +18,10 @@ const DEFAULT_BLACKLIST = [
 let blackList: net.BlockList | undefined
 const performLookup = promisify(dns.lookup)
 
+function shouldApplyDefaultBlacklist() {
+  return !(env.SELF_HOSTED && env.BLACKLIST_IPS !== undefined)
+}
+
 function getIpVersion(address: string): "ipv4" | "ipv6" {
   return net.isIP(address) === 6 ? "ipv6" : "ipv4"
 }
@@ -97,8 +101,10 @@ function addEntryToBlacklist(blockList: net.BlockList, entry: string) {
 
 export async function refreshBlacklist() {
   const next = new net.BlockList()
-  for (const entry of DEFAULT_BLACKLIST) {
-    addEntryToBlacklist(next, entry)
+  if (shouldApplyDefaultBlacklist()) {
+    for (const entry of DEFAULT_BLACKLIST) {
+      addEntryToBlacklist(next, entry)
+    }
   }
 
   const configuredBlacklist = env.BLACKLIST_IPS?.split(",") || []
@@ -133,7 +139,7 @@ export async function isBlacklisted(address: string): Promise<boolean> {
     try {
       ips = await lookup(address)
     } catch {
-      return true
+      return shouldApplyDefaultBlacklist()
     }
   } else {
     ips = [address]

--- a/packages/backend-core/src/blacklist/tests/blacklist.spec.ts
+++ b/packages/backend-core/src/blacklist/tests/blacklist.spec.ts
@@ -88,6 +88,49 @@ describe("blacklist", () => {
     })
   })
 
+  describe("self-hosted blacklist override", () => {
+    let restoreEnv: (() => void) | undefined
+
+    afterEach(async () => {
+      restoreEnv?.()
+      restoreEnv = undefined
+      await refreshBlacklist()
+    })
+
+    it("should allow private IPs when self-hosted override is empty", async () => {
+      restoreEnv = setEnv({
+        SELF_HOSTED: true,
+        BLACKLIST_IPS: "",
+      })
+      await refreshBlacklist()
+
+      expect(await isBlacklisted("192.168.1.1")).toBe(false)
+      expect(await isBlacklisted("10.0.0.1")).toBe(false)
+      expect(await isBlacklisted("172.16.0.1")).toBe(false)
+    })
+
+    it("should fail open on DNS lookup errors when self-hosted override is empty", async () => {
+      restoreEnv = setEnv({
+        SELF_HOSTED: true,
+        BLACKLIST_IPS: "",
+      })
+      await refreshBlacklist()
+
+      expect(await isBlacklisted("https://budibase-ssrf.invalid")).toBe(false)
+    })
+
+    it("should use only configured entries when self-hosted override is set", async () => {
+      restoreEnv = setEnv({
+        SELF_HOSTED: true,
+        BLACKLIST_IPS: "1.1.1.1",
+      })
+      await refreshBlacklist()
+
+      expect(await isBlacklisted("1.1.1.1")).toBe(true)
+      expect(await isBlacklisted("192.168.1.1")).toBe(false)
+    })
+  })
+
   describe("malformed CIDR entries", () => {
     let restoreEnv: (() => void) | undefined
 

--- a/packages/server/src/api/routes/tests/queries/rest.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/rest.spec.ts
@@ -278,6 +278,41 @@ describe("rest", () => {
     }
   })
 
+  it("should allow localhost requests in self-hosted when blacklist override is empty", async () => {
+    const resetBlacklistEnv = setCoreEnv({
+      BLACKLIST_IPS: "",
+      SELF_HOSTED: true,
+    })
+    await blacklist.refreshBlacklist()
+
+    mockAgent!
+      .get("http://127.0.0.1:5984")
+      .intercept({ path: "/", method: "GET" })
+      .reply(200, [{ status: "ok" }], { headers: jsonHeaders })
+
+    try {
+      const response = await config.api.query.preview({
+        datasourceId: datasource._id!,
+        name: "test query",
+        parameters: [],
+        queryVerb: "read",
+        transformer: "",
+        schema: {},
+        readable: true,
+        fields: {
+          path: "http://127.0.0.1:5984",
+        },
+      })
+
+      expect(response.schema).toEqual({
+        status: { type: "string", name: "status" },
+      })
+    } finally {
+      resetBlacklistEnv()
+      await blacklist.refreshBlacklist()
+    }
+  })
+
   it("should update schema when structure changes from JSON to array", async () => {
     const datasource = await config.api.datasource.create({
       name: generator.guid(),


### PR DESCRIPTION
## Description
Allow self-hosted deployments to override the default REST SSRF blacklist through BLACKLIST_IPS.

When BLACKLIST_IPS is unset, the existing default private-range blacklist still applies. When it is set on self-hosted, the configured value becomes the effective blacklist, which lets operators explicitly disable the default ranges with an empty value or replace them with a custom list.

Included coverage:
- backend-core blacklist unit tests for empty and custom self-hosted overrides
- server REST query test to verify localhost requests succeed when the self-hosted override is empty

## Addresses
- N/A

## App Export
- N/A

## Screenshots
- N/A

## Launchcontrol
Allow self-hosted Budibase instances to control which network addresses REST queries can reach through the existing blacklist environment variable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow self-hosted deployments to override the REST SSRF blacklist via `BLACKLIST_IPS`. When `SELF_HOSTED` is true and `BLACKLIST_IPS` is set, the default private-range blacklist is skipped; an empty value disables it, and custom entries replace it.

- **Bug Fixes**
  - Apply default blacklist only when no self-hosted override is present.
  - In override mode, DNS lookup failures fail open instead of blocking.
  - Added tests in `backend-core` for empty/custom overrides and in `server` to allow localhost requests.

<sup>Written for commit 9b9a727b23a1fc13aa41cac4766511659e420753. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

