### PR TITLE
Power user role assignment

### DIFF
--- a/packages/backend-core/src/security/roles.ts
+++ b/packages/backend-core/src/security/roles.ts
@@ -2,10 +2,12 @@ import { RoleColor, helpers } from "@budibase/shared-core"
 import {
   BuiltinPermissionID,
   Database,
+  InternalTable,
   PermissionLevel,
   Role as RoleDoc,
   RoleUIMetadata,
   Screen,
+  Table,
   Workspace,
 } from "@budibase/types"
 import { uniqBy } from "lodash"
@@ -552,6 +554,10 @@ export async function getAllRoles(appId?: string): Promise<RoleDoc[]> {
 }
 
 async function shouldIncludePowerRole(db: Database) {
+  if (await hasLegacyPowerRole(db)) {
+    return true
+  }
+
   const app = await db.tryGet<Workspace>(DocumentType.WORKSPACE_METADATA)
   const creationVersion = app?.creationVersion
   if (!creationVersion || !semver.valid(creationVersion)) {
@@ -564,6 +570,15 @@ async function shouldIncludePowerRole(db: Database) {
     env.MIN_VERSION_WITHOUT_POWER_ROLE
   )
   return !isGreaterThan3x
+}
+
+async function hasLegacyPowerRole(db: Database) {
+  const usersTable = await db.tryGet<Table>(InternalTable.USER_METADATA)
+  const inclusion = usersTable?.schema?.roleId?.constraints?.inclusion
+  return (
+    Array.isArray(inclusion) &&
+    inclusion.some(roleId => roleIDsAreEqual(roleId, BUILTIN_IDS.POWER))
+  )
 }
 
 export class AccessController {

--- a/packages/backend-core/src/security/roles.ts
+++ b/packages/backend-core/src/security/roles.ts
@@ -575,10 +575,19 @@ async function shouldIncludePowerRole(db: Database) {
 async function hasLegacyPowerRole(db: Database) {
   const usersTable = await db.tryGet<Table>(InternalTable.USER_METADATA)
   const inclusion = usersTable?.schema?.roleId?.constraints?.inclusion
-  return (
-    Array.isArray(inclusion) &&
-    inclusion.some(roleId => roleIDsAreEqual(roleId, BUILTIN_IDS.POWER))
+  if (!Array.isArray(inclusion)) {
+    return false
+  }
+
+  const containsPower = inclusion.some(roleId =>
+    roleIDsAreEqual(roleId, BUILTIN_IDS.POWER)
   )
+  if (!containsPower) {
+    return false
+  }
+
+  // Imported workspaces can still carry POWER as part of the legacy custom-role set.
+  return inclusion.some(roleId => !isBuiltin(roleId))
 }
 
 export class AccessController {

--- a/packages/builder/src/settings/pages/people/groups/_components/EditWorkspaceRoleModal.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/EditWorkspaceRoleModal.svelte
@@ -25,7 +25,6 @@
   const excludedRoleIds = [
     ...builtInEndUserRoles,
     Constants.Roles.PUBLIC,
-    Constants.Roles.POWER,
     Constants.Roles.CREATOR,
     Constants.Roles.GROUP,
   ]

--- a/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
+++ b/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
@@ -38,7 +38,6 @@
   const excludedRoleIds = [
     ...builtInEndUserRoles,
     Constants.Roles.PUBLIC,
-    Constants.Roles.POWER,
     Constants.Roles.CREATOR,
     Constants.Roles.GROUP,
   ]

--- a/packages/builder/src/settings/pages/people/users/_components/EditWorkspaceUserModal.svelte
+++ b/packages/builder/src/settings/pages/people/users/_components/EditWorkspaceUserModal.svelte
@@ -48,7 +48,6 @@
   const excludedRoleIds = [
     ...builtInEndUserRoles,
     Constants.Roles.PUBLIC,
-    Constants.Roles.POWER,
     Constants.Roles.CREATOR,
     Constants.Roles.GROUP,
   ]

--- a/packages/worker/src/api/routes/global/tests/roles.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/roles.spec.ts
@@ -45,6 +45,31 @@ async function updateAppMetadata(
   })
 }
 
+async function addLegacyPowerToUsersTable() {
+  await workspaceDb.put({
+    _id: "ta_users",
+    type: "table",
+    name: "Users",
+    sourceType: "internal",
+    sourceId: "bb_internal",
+    schema: {
+      roleId: {
+        name: "roleId",
+        type: "options",
+        constraints: {
+          type: "string",
+          inclusion: [
+            roles.BUILTIN_ROLE_IDS.ADMIN,
+            roles.BUILTIN_ROLE_IDS.POWER,
+            roles.BUILTIN_ROLE_IDS.BASIC,
+            roles.BUILTIN_ROLE_IDS.PUBLIC,
+          ],
+        },
+      },
+    },
+  })
+}
+
 describe("/api/global/roles", () => {
   const config = new TestConfiguration()
 
@@ -101,6 +126,20 @@ describe("/api/global/roles", () => {
         ])
       }
     )
+
+    it("includes POWER role for v3+ apps when users table still references it", async () => {
+      await updateAppMetadata({ creationVersion: "3.0.0" })
+      await addLegacyPowerToUsersTable()
+      const res = await config.api.roles.get()
+
+      expect(res.body[workspaceId].roles.map((r: any) => r._id)).toEqual([
+        ROLE_NAME,
+        roles.BUILTIN_ROLE_IDS.ADMIN,
+        roles.BUILTIN_ROLE_IDS.POWER,
+        roles.BUILTIN_ROLE_IDS.BASIC,
+        roles.BUILTIN_ROLE_IDS.PUBLIC,
+      ])
+    })
 
     it.each(["2.9.0", "1.0.0", "0.0.0", "2.32.17+2146.b125a7c"])(
       "include POWER roles before v3 (%s)",

--- a/packages/worker/src/api/routes/global/tests/roles.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/roles.spec.ts
@@ -45,7 +45,7 @@ async function updateAppMetadata(
   })
 }
 
-async function addLegacyPowerToUsersTable() {
+async function addUsersTable(roleInclusion: string[]) {
   await workspaceDb.put({
     _id: "ta_users",
     type: "table",
@@ -58,12 +58,7 @@ async function addLegacyPowerToUsersTable() {
         type: "options",
         constraints: {
           type: "string",
-          inclusion: [
-            roles.BUILTIN_ROLE_IDS.ADMIN,
-            roles.BUILTIN_ROLE_IDS.POWER,
-            roles.BUILTIN_ROLE_IDS.BASIC,
-            roles.BUILTIN_ROLE_IDS.PUBLIC,
-          ],
+          inclusion: roleInclusion,
         },
       },
     },
@@ -127,15 +122,39 @@ describe("/api/global/roles", () => {
       }
     )
 
-    it("includes POWER role for v3+ apps when users table still references it", async () => {
+    it("includes POWER role for v3+ apps when users table references POWER with custom roles", async () => {
       await updateAppMetadata({ creationVersion: "3.0.0" })
-      await addLegacyPowerToUsersTable()
+      await addUsersTable([
+        roles.BUILTIN_ROLE_IDS.ADMIN,
+        roles.BUILTIN_ROLE_IDS.POWER,
+        roles.BUILTIN_ROLE_IDS.BASIC,
+        roles.BUILTIN_ROLE_IDS.PUBLIC,
+        ROLE_NAME,
+      ])
       const res = await config.api.roles.get()
 
       expect(res.body[workspaceId].roles.map((r: any) => r._id)).toEqual([
         ROLE_NAME,
         roles.BUILTIN_ROLE_IDS.ADMIN,
         roles.BUILTIN_ROLE_IDS.POWER,
+        roles.BUILTIN_ROLE_IDS.BASIC,
+        roles.BUILTIN_ROLE_IDS.PUBLIC,
+      ])
+    })
+
+    it("does not include POWER for v3+ apps when users table only has builtin roles", async () => {
+      await updateAppMetadata({ creationVersion: "3.0.0" })
+      await addUsersTable([
+        roles.BUILTIN_ROLE_IDS.ADMIN,
+        roles.BUILTIN_ROLE_IDS.POWER,
+        roles.BUILTIN_ROLE_IDS.BASIC,
+        roles.BUILTIN_ROLE_IDS.PUBLIC,
+      ])
+      const res = await config.api.roles.get()
+
+      expect(res.body[workspaceId].roles.map((r: any) => r._id)).toEqual([
+        ROLE_NAME,
+        roles.BUILTIN_ROLE_IDS.ADMIN,
         roles.BUILTIN_ROLE_IDS.BASIC,
         roles.BUILTIN_ROLE_IDS.PUBLIC,
       ])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Previously, the "App power user" role (corresponding to the `POWER` role) was not available for selection when inviting new users to a workspace or editing existing workspace users/group roles. This was due to explicit UI-side filtering of the `POWER` role in these modals, even when the backend correctly exposed it for legacy workspaces.

This PR removes the UI-side filtering of the `POWER` role in the workspace invite, workspace-user edit, and group workspace-role selection modals, allowing "App power user" to be assigned in legacy workspaces where the backend provides this role.

## Addresses
- Bug: Can't assign the power user role to a user when inviting them to a workspace as an end user. #18228 

## Screenshots

https://github.com/user-attachments/assets/ef1456c2-c199-4682-a803-93ef73af699b



## Launchcontrol
Allows "App power user" to be selected and assigned when inviting or editing users in older workspaces.

<div><a href="https://cursor.com/agents/bc-1fa7cd91-7244-45c7-826a-6aea21c14139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fa7cd91-7244-45c7-826a-6aea21c14139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores "App power user" (`POWER`) in user and group role modals for legacy/imported workspaces. Hides `POWER` in new v3+ workspaces; backend now exposes it only for pre‑v3 apps and v3+ imports where the Users table lists `POWER` with a custom role.

- **Bug Fixes**
  - Backend: include `POWER` when app version < 3, or when `Users.roleId` inclusion contains `POWER` and any non‑builtin role; otherwise exclude it.
  - UI: stop filtering `POWER` in `AddUserModal`, `EditWorkspaceUserModal`, and `EditWorkspaceRoleModal`; add API tests that cover v3+ include/exclude cases.

<sup>Written for commit d496a3b4448c2227e35f3ad71b79bb9bb6138f0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



