### PR TITLE
Ensure connections are available to creators

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/SideNav/SideNav.svelte
@@ -71,6 +71,7 @@
     pinned.set(true)
   }
   export let canInviteUsers = false
+  export let canManageConnections = false
   export let onInviteUser: () => void = () => {}
 
   $: automationErrors = getAutomationErrors($enrichedApps || [], workspaceId)
@@ -623,15 +624,17 @@
             </div>
 
             <div class="core-secondary">
-              <SideNavLink
-                icon="cube"
-                text="Connections"
-                {collapsed}
-                on:click={() => {
-                  bb.settings(`/connections/apis`)
-                  keepCollapsed()
-                }}
-              />
+              {#if canManageConnections}
+                <SideNavLink
+                  icon="cube"
+                  text="Connections"
+                  {collapsed}
+                  on:click={() => {
+                    bb.settings(`/connections/apis`)
+                    keepCollapsed()
+                  }}
+                />
+              {/if}
               <SideNavLink
                 icon="globe-simple"
                 text="API explorer"

--- a/packages/builder/src/pages/builder/workspace/[application]/_layout.workspace.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/_layout.workspace.svelte
@@ -23,6 +23,8 @@
   let sideNav: SideNav
   let showInviteUsersModal = false
   $: canInviteUsers = sdk.users.isAdmin($auth.user)
+  $: canManageConnections =
+    $auth.user != null && sdk.users.canCreateApps($auth.user)
   $: if ($bb.settings.open && showInviteUsersModal) {
     showInviteUsersModal = false
   }
@@ -67,6 +69,7 @@
   <SideNav
     bind:this={sideNav}
     {canInviteUsers}
+    {canManageConnections}
     onInviteUser={() => {
       if (canInviteUsers) {
         showInviteUsersModal = true

--- a/packages/builder/src/settings/routes.ts
+++ b/packages/builder/src/settings/routes.ts
@@ -248,7 +248,7 @@ export const workspaceRoutes = (
   if (!appStore?.appId) {
     return []
   }
-  const isAdmin = user != null && sdk.users.isAdmin(user)
+  const isCreator = user != null && sdk.users.canCreateApps(user)
   const getBackupErrors = (apps: StoreApp[], appId: string) => {
     const target = apps.find(app => app.devId === appId)
     return target?.backupErrors || {}
@@ -280,7 +280,7 @@ export const workspaceRoutes = (
     {
       section: "Connections",
       title: "Connections",
-      access: () => isAdmin,
+      access: () => isCreator,
       path: "connections",
       icon: "cube",
       new: true,


### PR DESCRIPTION
## Description

The connection settings was locked to `admin` level users. This ensures that `creators` can also access the new menus for `APIs`, `AI Models` and `Knowledge bases`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow creators to access the Connections settings (APIs, AI Models, Knowledge Bases) in the workspace. Non-creators no longer see the menu; behavior remains unchanged for admins.

- **Bug Fixes**
  - SideNav shows “Connections” only when canManageConnections is true.
  - Workspace layout sets canManageConnections via sdk.users.canCreateApps(user) and passes it to SideNav.
  - Settings routes switch access for “Connections” from admin-only to creator (canCreateApps).

<sup>Written for commit d78cb1a2470978e25e20e75b4ed85cfd851c5895. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

