### PR TITLE
feat: add native SeaTable integration

### DIFF
--- a/packages/server/src/integrations/index.ts
+++ b/packages/server/src/integrations/index.ts
@@ -12,6 +12,7 @@ import rest from "./rest"
 import googlesheets from "./googlesheets"
 import firebase from "./firebase"
 import redis from "./redis"
+import seatable from "./seatable"
 import snowflake from "./snowflake"
 import oracle from "./oracle"
 import {
@@ -39,6 +40,7 @@ const DEFINITIONS: Record<SourceName, Integration | undefined> = {
   [SourceName.FIRESTORE]: firebase.schema,
   [SourceName.GOOGLE_SHEETS]: googlesheets.schema,
   [SourceName.REDIS]: redis.schema,
+  [SourceName.SEATABLE]: seatable.schema,
   [SourceName.SNOWFLAKE]: snowflake.schema,
   [SourceName.ORACLE]: oracle.schema,
   /* deprecated - not available through UI */
@@ -71,6 +73,7 @@ const INTEGRATIONS: Record<SourceName, IntegrationBaseConstructor | undefined> =
     [SourceName.FIRESTORE]: firebase.integration,
     [SourceName.GOOGLE_SHEETS]: googlesheets.integration,
     [SourceName.REDIS]: redis.integration,
+    [SourceName.SEATABLE]: seatable.integration,
     [SourceName.SNOWFLAKE]: snowflake.integration,
     [SourceName.ORACLE]: oracle.integration,
     /* deprecated - not available through UI */

--- a/packages/server/src/integrations/seatable.ts
+++ b/packages/server/src/integrations/seatable.ts
@@ -161,7 +161,8 @@ class SeaTableIntegration implements IntegrationBase {
       })
       return res.data.first_row ?? res.data
     } catch (err) {
-      console.error("Error creating row in SeaTable", err)
+      const message = err instanceof Error ? err.message : "Unknown error"
+      console.error("Error creating row in SeaTable:", message)
       throw err
     }
   }
@@ -181,7 +182,8 @@ class SeaTableIntegration implements IntegrationBase {
       const res = await this.http!.get("/rows/", { params })
       return res.data.rows ?? []
     } catch (err) {
-      console.error("Error reading from SeaTable", err)
+      const message = err instanceof Error ? err.message : "Unknown error"
+      console.error("Error reading from SeaTable:", message)
       return []
     }
   }
@@ -200,7 +202,8 @@ class SeaTableIntegration implements IntegrationBase {
       })
       return res.data
     } catch (err) {
-      console.error("Error updating row in SeaTable", err)
+      const message = err instanceof Error ? err.message : "Unknown error"
+      console.error("Error updating row in SeaTable:", message)
       throw err
     }
   }
@@ -214,7 +217,8 @@ class SeaTableIntegration implements IntegrationBase {
       })
       return res.data
     } catch (err) {
-      console.error("Error deleting row from SeaTable", err)
+      const message = err instanceof Error ? err.message : "Unknown error"
+      console.error("Error deleting row from SeaTable:", message)
       throw err
     }
   }

--- a/packages/server/src/integrations/seatable.ts
+++ b/packages/server/src/integrations/seatable.ts
@@ -1,0 +1,226 @@
+import {
+  ConnectionInfo,
+  DatasourceFeature,
+  DatasourceFieldType,
+  Integration,
+  IntegrationBase,
+  QueryType,
+} from "@budibase/types"
+
+import axios, { AxiosInstance } from "axios"
+
+interface SeaTableConfig {
+  serverUrl: string
+  apiToken: string
+}
+
+const SCHEMA: Integration = {
+  docs: "https://developer.seatable.com",
+  description:
+    "SeaTable is an open-source collaborative database platform. Works with SeaTable Cloud (cloud.seatable.io) or any self-hosted instance.",
+  friendlyName: "SeaTable",
+  type: "Spreadsheet",
+  features: {
+    [DatasourceFeature.CONNECTION_CHECKING]: true,
+  },
+  datasource: {
+    serverUrl: {
+      display: "Server URL",
+      type: DatasourceFieldType.STRING,
+      default: "https://cloud.seatable.io",
+      required: true,
+    },
+    apiToken: {
+      display: "API Token",
+      type: DatasourceFieldType.PASSWORD,
+      default: "",
+      required: true,
+    },
+  },
+  query: {
+    create: {
+      type: QueryType.FIELDS,
+      customisable: true,
+      fields: {
+        table: {
+          type: DatasourceFieldType.STRING,
+          required: true,
+        },
+      },
+    },
+    read: {
+      type: QueryType.FIELDS,
+      fields: {
+        table: {
+          type: DatasourceFieldType.STRING,
+          required: true,
+        },
+        view: {
+          type: DatasourceFieldType.STRING,
+        },
+        numRecords: {
+          type: DatasourceFieldType.NUMBER,
+          default: 100,
+        },
+      },
+    },
+    update: {
+      type: QueryType.FIELDS,
+      customisable: true,
+      fields: {
+        table: {
+          type: DatasourceFieldType.STRING,
+          required: true,
+        },
+        id: {
+          display: "Row ID",
+          type: DatasourceFieldType.STRING,
+          required: true,
+        },
+      },
+    },
+    delete: {
+      type: QueryType.FIELDS,
+      fields: {
+        table: {
+          type: DatasourceFieldType.STRING,
+          required: true,
+        },
+        id: {
+          display: "Row ID",
+          type: DatasourceFieldType.STRING,
+          required: true,
+        },
+      },
+    },
+  },
+}
+
+class SeaTableIntegration implements IntegrationBase {
+  private readonly serverUrl: string
+  private readonly apiToken: string
+  private http?: AxiosInstance
+  private baseUuid?: string
+  private tokenExpiresAt = 0
+
+  constructor(config: SeaTableConfig) {
+    this.serverUrl = config.serverUrl.replace(/\/$/, "")
+    this.apiToken = config.apiToken
+  }
+
+  private async ensureAuthenticated(): Promise<void> {
+    if (this.http && Date.now() < this.tokenExpiresAt) {
+      return
+    }
+
+    const url = `${this.serverUrl}/api/v2.1/dtable/app-access-token/`
+    const res = await axios.get(url, {
+      headers: { Authorization: `Bearer ${this.apiToken}` },
+      timeout: 15_000,
+    })
+
+    const baseToken = res.data.access_token
+    this.baseUuid = res.data.dtable_uuid
+
+    if (!baseToken || !this.baseUuid) {
+      throw new Error(
+        "SeaTable token exchange failed – missing access_token or dtable_uuid"
+      )
+    }
+
+    this.tokenExpiresAt = Date.now() + 59 * 60 * 1000
+
+    this.http = axios.create({
+      baseURL: `${this.serverUrl}/api-gateway/api/v2/dtables/${this.baseUuid}`,
+      timeout: 30_000,
+      headers: { Authorization: `Bearer ${baseToken}` },
+    })
+  }
+
+  async testConnection(): Promise<ConnectionInfo> {
+    try {
+      await this.ensureAuthenticated()
+      await this.http!.get("/metadata/")
+      return { connected: true }
+    } catch (e: any) {
+      return {
+        connected: false,
+        error: e.message as string,
+      }
+    }
+  }
+
+  async create(query: { table: string; json: Record<string, unknown> }) {
+    const { table, json } = query
+    try {
+      await this.ensureAuthenticated()
+      const res = await this.http!.post("/rows/", {
+        table_name: table,
+        rows: [json],
+        convert_keys: true,
+      })
+      return res.data.first_row ?? res.data
+    } catch (err) {
+      console.error("Error creating row in SeaTable", err)
+      throw err
+    }
+  }
+
+  async read(query: { table: string; numRecords: number; view?: string }) {
+    try {
+      await this.ensureAuthenticated()
+      const params: Record<string, unknown> = {
+        table_name: query.table,
+        start: 0,
+        limit: query.numRecords || 100,
+        convert_keys: true,
+      }
+      if (query.view) {
+        params.view_name = query.view
+      }
+      const res = await this.http!.get("/rows/", { params })
+      return res.data.rows ?? []
+    } catch (err) {
+      console.error("Error reading from SeaTable", err)
+      return []
+    }
+  }
+
+  async update(query: {
+    table: string
+    id: string
+    json: Record<string, unknown>
+  }) {
+    const { table, id, json } = query
+    try {
+      await this.ensureAuthenticated()
+      const res = await this.http!.put("/rows/", {
+        table_name: table,
+        updates: [{ row_id: id, row: json }],
+      })
+      return res.data
+    } catch (err) {
+      console.error("Error updating row in SeaTable", err)
+      throw err
+    }
+  }
+
+  async delete(query: { table: string; id: string }) {
+    const { table, id } = query
+    try {
+      await this.ensureAuthenticated()
+      const res = await this.http!.delete("/rows/", {
+        data: { table_name: table, row_ids: [id] },
+      })
+      return res.data
+    } catch (err) {
+      console.error("Error deleting row from SeaTable", err)
+      throw err
+    }
+  }
+}
+
+export default {
+  schema: SCHEMA,
+  integration: SeaTableIntegration,
+}

--- a/packages/types/src/sdk/datasources.ts
+++ b/packages/types/src/sdk/datasources.ts
@@ -63,6 +63,7 @@ export enum SourceName {
   REDIS = "REDIS",
   REST = "REST",
   S3 = "S3",
+  SEATABLE = "SEATABLE",
   SNOWFLAKE = "SNOWFLAKE",
   SQL_SERVER = "SQL_SERVER",
 }


### PR DESCRIPTION
## Summary

Adds [SeaTable](https://seatable.com) as a native datasource integration.

SeaTable is a collaborative database platform (self-hostable alternative to Airtable). This connector works with any SeaTable server — cloud (cloud.seatable.io) or self-hosted.

Closes #18313

## Changes

- **`packages/server/src/integrations/seatable.ts`** – New integration file (follows the same pattern as `airtable.ts`)
- **`packages/types/src/sdk/datasources.ts`** – Add `SEATABLE` to `SourceName` enum
- **`packages/server/src/integrations/index.ts`** – Register SeaTable in DEFINITIONS and INTEGRATIONS

## Operations

| Operation | Description |
|---|---|
| **Create** | Insert a new row (customisable fields) |
| **Read** | List rows with optional view filter and record limit |
| **Update** | Update a row by ID (customisable fields) |
| **Delete** | Delete a row by ID |
| **testConnection** | Validates credentials via token exchange + metadata fetch |

## Authentication

SeaTable uses a two-step token exchange:
1. Exchange long-lived API-Token for a short-lived Base-Token via `GET /api/v2.1/dtable/app-access-token/`
2. Use Base-Token for all CRUD operations against `/api-gateway/api/v2/dtables/{base_uuid}/...`

Credentials:
- **Server URL** – Any SeaTable server (default: `https://cloud.seatable.io`)
- **API Token** – Base-scoped token, created in SeaTable UI

## Test plan

- [x] All CRUD operations verified against a real SeaTable instance
- [x] testConnection validates credentials and returns clear error messages
- [ ] Manual test in Budibase UI (datasource creation + query builder)

## References

- SeaTable website: https://seatable.com
- SeaTable API docs: https://developer.seatable.com
- SeaTable on GitHub: https://github.com/seatable

🤖 Generated with [Claude Code](https://claude.ai/code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a native SeaTable datasource integration for cloud or self-hosted servers with full CRUD and connection testing. Includes two-step token auth and safer error logging.

- **New Features**
  - SeaTable connector with Create, Read (view + limit), Update (by row ID), Delete (by row ID), and `testConnection`.
  - Two-step auth flow (API Token → Base Token) with token caching and Axios client.
  - Config fields: `serverUrl` (default `https://cloud.seatable.io`) and `apiToken`.
  - Wiring: new `packages/server/src/integrations/seatable.ts`, registered in `packages/server/src/integrations/index.ts`, and `SEATABLE` added to `SourceName` in `packages/types/src/sdk/datasources.ts`.

- **Bug Fixes**
  - Sanitize error logging to prevent token leakage by logging only error messages (no Axios error objects or headers).

<sup>Written for commit 5094e55e24cdcac067d3daad0f2a150583de5f28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



