### PR TITLE
Fix: Updated IP Blacklist can break self-hosted deployments

### DIFF
--- a/packages/backend-core/src/blacklist/blacklist.ts
+++ b/packages/backend-core/src/blacklist/blacklist.ts
@@ -19,7 +19,10 @@ let blackList: net.BlockList | undefined
 const performLookup = promisify(dns.lookup)
 
 function shouldApplyDefaultBlacklist() {
-  return !(env.SELF_HOSTED && env.BLACKLIST_IPS !== undefined)
+  if (env.SELF_HOSTED) {
+    return false
+  }
+  return env.BLACKLIST_IPS === undefined
 }
 
 function getIpVersion(address: string): "ipv4" | "ipv6" {

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -757,7 +757,7 @@ export class RestIntegration implements IntegrationBase {
       !disableBlacklistForLocalDevelopment &&
       (await blacklist.isBlacklisted(url))
     ) {
-      throw new Error("Cannot connect to URL.")
+      throw new Error("URL resolved to a blacklisted IP address.")
     }
 
     // Configure dispatcher for proxy and/or TLS settings


### PR DESCRIPTION
## Description

This PR fixes an issue where self-hosted deployments could start using the default IP blacklist when `BLACKLIST_IPS` environment variable was not explicitly set.

Previously, introducing the new environment variable meant existing self-hosted instances could unexpectedly block requests to local or private network services, such as APIs hosted on reserved IP ranges.

This change restores backwards-compatible behaviour by ensuring the default blacklist is not automatically applied for self-hosted deployments unless explicitly configured.

## Addresses

- https://github.com/Budibase/budibase/issues/18299

## Launchcontrol

Prevents self-hosted instances from unexpectedly blocking requests to internal or private network services after upgrading. Adds clearer warning when block does occur.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Never apply the default IP blacklist on self-hosted deployments to avoid blocking internal/private services after upgrades. Use a custom list only when `BLACKLIST_IPS` is set, and show a clearer REST error: "URL resolved to a blacklisted IP address."

<sup>Written for commit ea61e723b1d55cc2eb758ce3b903254d3196689e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

