### PR TITLE
Use sourcemaps for local debug (to properly debug backend-core)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,11 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "debug.javascript.terminalOptions": {
+    "sourceMaps": true,
+    "resolveSourceMapLocations": [
+      "${workspaceFolder}/packages/**",
+      "!**/node_modules/**"
+    ],
     "skipFiles": [
       "${workspaceFolder}/packages/backend-core/node_modules/**",
       "<node_internals>/**"


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables source maps in VS Code debug settings to step through TypeScript in `packages/*`, especially `backend-core`, during local debugging. Adds `sourceMaps: true` and `resolveSourceMapLocations` (include `packages/**`, exclude `**/node_modules/**`) so breakpoints and stack traces map to source while skipping `node_modules` and Node internals.

<sup>Written for commit 3774cde5bae24d55a559e03ab7aeed506d993882. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

