### PR TITLE
Remove hardcoded default blacklisted ips

### DIFF
--- a/packages/backend-core/src/blacklist/blacklist.ts
+++ b/packages/backend-core/src/blacklist/blacklist.ts
@@ -3,24 +3,8 @@ import net from "net"
 import env from "../environment"
 import { promisify } from "util"
 
-const DEFAULT_BLACKLIST = [
-  "127.0.0.0/8",
-  "10.0.0.0/8",
-  "172.16.0.0/12",
-  "192.168.0.0/16",
-  "169.254.0.0/16",
-  "0.0.0.0/8",
-  "::1/128",
-  "fc00::/7",
-  "fe80::/10",
-] as const
-
 let blackList: net.BlockList | undefined
 const performLookup = promisify(dns.lookup)
-
-function shouldApplyDefaultBlacklist() {
-  return !(env.SELF_HOSTED && env.BLACKLIST_IPS !== undefined)
-}
 
 function getIpVersion(address: string): "ipv4" | "ipv6" {
   return net.isIP(address) === 6 ? "ipv6" : "ipv4"
@@ -101,12 +85,6 @@ function addEntryToBlacklist(blockList: net.BlockList, entry: string) {
 
 export async function refreshBlacklist() {
   const next = new net.BlockList()
-  if (shouldApplyDefaultBlacklist()) {
-    for (const entry of DEFAULT_BLACKLIST) {
-      addEntryToBlacklist(next, entry)
-    }
-  }
-
   const configuredBlacklist = env.BLACKLIST_IPS?.split(",") || []
   for (const entry of configuredBlacklist) {
     const trimmed = entry.trim()
@@ -139,7 +117,7 @@ export async function isBlacklisted(address: string): Promise<boolean> {
     try {
       ips = await lookup(address)
     } catch {
-      return shouldApplyDefaultBlacklist()
+      return true
     }
   } else {
     ips = [address]

--- a/packages/backend-core/src/blacklist/tests/blacklist.spec.ts
+++ b/packages/backend-core/src/blacklist/tests/blacklist.spec.ts
@@ -15,20 +15,6 @@ describe("blacklist", () => {
       await refreshBlacklist()
     })
 
-    it("should blacklist localhost", async () => {
-      expect(await isBlacklisted("127.0.0.1")).toBe(true)
-    })
-
-    it("should blacklist RFC1918 addresses", async () => {
-      expect(await isBlacklisted("192.168.1.1")).toBe(true)
-      expect(await isBlacklisted("10.0.0.1")).toBe(true)
-      expect(await isBlacklisted("172.16.0.1")).toBe(true)
-    })
-
-    it("should blacklist link-local addresses", async () => {
-      expect(await isBlacklisted("169.254.169.254")).toBe(true)
-    })
-
     it("should allow public IPs by default", async () => {
       expect(await isBlacklisted("8.8.8.8")).toBe(false)
     })
@@ -109,14 +95,14 @@ describe("blacklist", () => {
       expect(await isBlacklisted("172.16.0.1")).toBe(false)
     })
 
-    it("should fail open on DNS lookup errors when self-hosted override is empty", async () => {
+    it("should fail closed on DNS lookup errors when self-hosted override is empty", async () => {
       restoreEnv = setEnv({
         SELF_HOSTED: true,
         BLACKLIST_IPS: "",
       })
       await refreshBlacklist()
 
-      expect(await isBlacklisted("https://budibase-ssrf.invalid")).toBe(false)
+      expect(await isBlacklisted("https://budibase-ssrf.invalid")).toBe(true)
     })
 
     it("should use only configured entries when self-hosted override is set", async () => {

--- a/packages/server/src/api/routes/tests/queries/rest.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/rest.spec.ts
@@ -239,48 +239,11 @@ describe("rest", () => {
         {
           status: 400,
           body: {
-            message: "Cannot connect to URL.",
+            message: "URL resolved to a blacklisted IP address.",
           },
         }
       )
     } finally {
-      resetBlacklistEnv()
-      await blacklist.refreshBlacklist()
-    }
-  })
-
-  it("should allow localhost requests in local development", async () => {
-    const resetBlacklistEnv = setCoreEnv({ BLACKLIST_IPS: undefined })
-    const resetDevEnv = setServerEnv({
-      NODE_ENV: "development",
-      JEST_WORKER_ID: "null",
-    })
-    await blacklist.refreshBlacklist()
-
-    mockAgent!
-      .get("http://127.0.0.1:5984")
-      .intercept({ path: "/", method: "GET" })
-      .reply(200, [{ status: "ok" }], { headers: jsonHeaders })
-
-    try {
-      const response = await config.api.query.preview({
-        datasourceId: datasource._id!,
-        name: "test query",
-        parameters: [],
-        queryVerb: "read",
-        transformer: "",
-        schema: {},
-        readable: true,
-        fields: {
-          path: "http://127.0.0.1:5984",
-        },
-      })
-
-      expect(response.schema).toEqual({
-        status: { type: "string", name: "status" },
-      })
-    } finally {
-      resetDevEnv()
       resetBlacklistEnv()
       await blacklist.refreshBlacklist()
     }

--- a/packages/server/src/api/routes/tests/queries/rest.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/rest.spec.ts
@@ -218,37 +218,6 @@ describe("rest", () => {
     expect(cached.rows[0].name).toEqual("one")
   })
 
-  it("should block localhost requests when BLACKLIST_IPS is unset", async () => {
-    const resetBlacklistEnv = setCoreEnv({ BLACKLIST_IPS: undefined })
-    await blacklist.refreshBlacklist()
-
-    try {
-      await config.api.query.preview(
-        {
-          datasourceId: datasource._id!,
-          name: "test query",
-          parameters: [],
-          queryVerb: "read",
-          transformer: "",
-          schema: {},
-          readable: true,
-          fields: {
-            path: "http://127.0.0.1:5984",
-          },
-        },
-        {
-          status: 400,
-          body: {
-            message: "URL is blocked or could not be resolved safely.",
-          },
-        }
-      )
-    } finally {
-      resetBlacklistEnv()
-      await blacklist.refreshBlacklist()
-    }
-  })
-
   it("should allow localhost requests in self-hosted when blacklist override is empty", async () => {
     const resetBlacklistEnv = setCoreEnv({
       BLACKLIST_IPS: "",

--- a/packages/server/src/api/routes/tests/queries/rest.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/rest.spec.ts
@@ -239,7 +239,7 @@ describe("rest", () => {
         {
           status: 400,
           body: {
-            message: "URL resolved to a blacklisted IP address.",
+            message: "URL is blocked or could not be resolved safely.",
           },
         }
       )

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -752,7 +752,7 @@ export class RestIntegration implements IntegrationBase {
       paginationValues
     )
     if (await blacklist.isBlacklisted(url)) {
-      throw new Error("URL resolved to a blacklisted IP address.")
+      throw new Error("URL is blocked or could not be resolved safely.")
     }
 
     // Configure dispatcher for proxy and/or TLS settings

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -751,13 +751,8 @@ export class RestIntegration implements IntegrationBase {
       pagination,
       paginationValues
     )
-    const disableBlacklistForLocalDevelopment =
-      environment.isDev() && !environment.isTest()
-    if (
-      !disableBlacklistForLocalDevelopment &&
-      (await blacklist.isBlacklisted(url))
-    ) {
-      throw new Error("Cannot connect to URL.")
+    if (await blacklist.isBlacklisted(url)) {
+      throw new Error("URL resolved to a blacklisted IP address.")
     }
 
     // Configure dispatcher for proxy and/or TLS settings


### PR DESCRIPTION
## Description
Remove hardcoded default blacklisted IPs.
Use env variables in the cloud instead:

The bug came from this https://github.com/Budibase/budibase/pull/18236, increasing some security.


## Launchcontrol
Remove hardcoded default blacklisted IPs.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the hardcoded default IP blacklist so only `BLACKLIST_IPS` controls blocking. DNS lookup errors now fail closed, and the dev-only bypass is removed.

- **Migration**
  - If you relied on default blocking of private/link‑local ranges, set `BLACKLIST_IPS` (comma‑separated CIDRs), e.g. `127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,0.0.0.0/8,::1/128,fc00::/7,fe80::/10`.
  - Requests with unresolvable hosts are now blocked and return "URL is blocked or could not be resolved safely."
  - No development bypass; behavior is consistent across environments.

<sup>Written for commit 052380ef0268938d25648efd9b576a1420694db0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



