### PR TITLE
feat: add native SeaTable integration

### DIFF
--- a/packages/builder/src/components/backend/DatasourceNavigator/icons/SeaTable.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/icons/SeaTable.svelte
@@ -1,0 +1,37 @@
+<script>
+  export let width = "100"
+  export let height = "100"
+</script>
+
+<svg
+  {width}
+  {height}
+  viewBox="0 0 145 145"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <defs>
+    <linearGradient
+      id="seatable_gradient"
+      x1="0"
+      y1="0"
+      x2="1"
+      y2="0"
+      gradientUnits="userSpaceOnUse"
+      gradientTransform="matrix(-9.4681,-27.4234,27.4234,-9.4681,57.904,91.0448)"
+    >
+      <stop offset="0" stop-color="rgb(255,128,0)" />
+      <stop offset="1" stop-color="rgb(236,40,55)" />
+    </linearGradient>
+  </defs>
+  <g transform="translate(22)">
+    <path
+      d="M 13.26,109.938 47.172,143.85 95.915,95.108 c 8.844,-8.845 8.844,-23.185 0,-32.028 L 78.019,45.182 77.7,44.863 24.155,98.292 24.53,98.667 Z"
+      fill="url(#seatable_gradient)"
+    />
+    <path
+      d="M 24.53,98.667 89.289,33.913 55.377,0 6.633,48.743 c -8.844,8.844 -8.844,23.184 0,32.028 z"
+      fill="#ff8000"
+    />
+  </g>
+</svg>

--- a/packages/builder/src/components/backend/DatasourceNavigator/icons/index.js
+++ b/packages/builder/src/components/backend/DatasourceNavigator/icons/index.js
@@ -14,6 +14,7 @@ import Oracle from "./Oracle.svelte"
 import GoogleSheets from "./GoogleSheets.svelte"
 import Firebase from "./Firebase.svelte"
 import Redis from "./Redis.svelte"
+import SeaTable from "./SeaTable.svelte"
 import Snowflake from "./Snowflake.svelte"
 import Custom from "./Custom.svelte"
 
@@ -34,6 +35,7 @@ const ICONS = {
   GOOGLE_SHEETS: GoogleSheets,
   FIRESTORE: Firebase,
   REDIS: Redis,
+  SEATABLE: SeaTable,
   SNOWFLAKE: Snowflake,
   CUSTOM: Custom,
 }

--- a/packages/server/src/integrations/index.ts
+++ b/packages/server/src/integrations/index.ts
@@ -12,6 +12,7 @@ import rest from "./rest"
 import googlesheets from "./googlesheets"
 import firebase from "./firebase"
 import redis from "./redis"
+import seatable from "./seatable"
 import snowflake from "./snowflake"
 import oracle from "./oracle"
 import {
@@ -39,6 +40,7 @@ const DEFINITIONS: Record<SourceName, Integration | undefined> = {
   [SourceName.FIRESTORE]: firebase.schema,
   [SourceName.GOOGLE_SHEETS]: googlesheets.schema,
   [SourceName.REDIS]: redis.schema,
+  [SourceName.SEATABLE]: seatable.schema,
   [SourceName.SNOWFLAKE]: snowflake.schema,
   [SourceName.ORACLE]: oracle.schema,
   /* deprecated - not available through UI */
@@ -71,6 +73,7 @@ const INTEGRATIONS: Record<SourceName, IntegrationBaseConstructor | undefined> =
     [SourceName.FIRESTORE]: firebase.integration,
     [SourceName.GOOGLE_SHEETS]: googlesheets.integration,
     [SourceName.REDIS]: redis.integration,
+    [SourceName.SEATABLE]: seatable.integration,
     [SourceName.SNOWFLAKE]: snowflake.integration,
     [SourceName.ORACLE]: oracle.integration,
     /* deprecated - not available through UI */

--- a/packages/server/src/integrations/seatable.ts
+++ b/packages/server/src/integrations/seatable.ts
@@ -131,17 +131,19 @@ class SeaTableIntegration implements IntegrationBase {
 
     const baseToken = res.data.access_token
     this.baseUuid = res.data.dtable_uuid
+    const dtableServer: string = res.data.dtable_server ?? ""
 
-    if (!baseToken || !this.baseUuid) {
+    if (!baseToken || !this.baseUuid || !dtableServer) {
       throw new Error(
-        "SeaTable token exchange failed – missing access_token or dtable_uuid"
+        "SeaTable token exchange failed – missing access_token, dtable_uuid, or dtable_server"
       )
     }
 
     this.tokenExpiresAt = Date.now() + 59 * 60 * 1000
 
+    const baseURL = `${dtableServer.replace(/\/$/, "")}/api/v2/dtables/${this.baseUuid}`
     this.http = axios.create({
-      baseURL: `${this.serverUrl}/api-gateway/api/v2/dtables/${this.baseUuid}`,
+      baseURL,
       timeout: 30_000,
       headers: { Authorization: `Bearer ${baseToken}` },
     })
@@ -167,7 +169,6 @@ class SeaTableIntegration implements IntegrationBase {
       const res = await this.http!.post("/rows/", {
         table_name: table,
         rows: [json],
-        convert_keys: true,
       })
       return res.data.first_row ?? res.data
     } catch (err) {
@@ -194,7 +195,7 @@ class SeaTableIntegration implements IntegrationBase {
     } catch (err) {
       const message = sanitizeError(err)
       console.error("Error reading from SeaTable:", message)
-      return []
+      throw new Error(message)
     }
   }
 

--- a/packages/server/src/integrations/seatable.ts
+++ b/packages/server/src/integrations/seatable.ts
@@ -1,0 +1,240 @@
+import {
+  ConnectionInfo,
+  DatasourceFeature,
+  DatasourceFieldType,
+  Integration,
+  IntegrationBase,
+  QueryType,
+} from "@budibase/types"
+
+import axios, { AxiosInstance } from "axios"
+
+interface SeaTableConfig {
+  serverUrl: string
+  apiToken: string
+}
+
+const SCHEMA: Integration = {
+  docs: "https://developer.seatable.com",
+  description:
+    "SeaTable is an open-source collaborative database platform. Works with SeaTable Cloud (cloud.seatable.io) or any self-hosted instance.",
+  friendlyName: "SeaTable",
+  type: "Spreadsheet",
+  features: {
+    [DatasourceFeature.CONNECTION_CHECKING]: true,
+  },
+  datasource: {
+    serverUrl: {
+      display: "Server URL",
+      type: DatasourceFieldType.STRING,
+      default: "https://cloud.seatable.io",
+      required: true,
+    },
+    apiToken: {
+      display: "API Token",
+      type: DatasourceFieldType.PASSWORD,
+      default: "",
+      required: true,
+    },
+  },
+  query: {
+    create: {
+      type: QueryType.FIELDS,
+      customisable: true,
+      fields: {
+        table: {
+          type: DatasourceFieldType.STRING,
+          required: true,
+        },
+      },
+    },
+    read: {
+      type: QueryType.FIELDS,
+      fields: {
+        table: {
+          type: DatasourceFieldType.STRING,
+          required: true,
+        },
+        view: {
+          type: DatasourceFieldType.STRING,
+        },
+        numRecords: {
+          type: DatasourceFieldType.NUMBER,
+          default: 100,
+        },
+      },
+    },
+    update: {
+      type: QueryType.FIELDS,
+      customisable: true,
+      fields: {
+        table: {
+          type: DatasourceFieldType.STRING,
+          required: true,
+        },
+        id: {
+          display: "Row ID",
+          type: DatasourceFieldType.STRING,
+          required: true,
+        },
+      },
+    },
+    delete: {
+      type: QueryType.FIELDS,
+      fields: {
+        table: {
+          type: DatasourceFieldType.STRING,
+          required: true,
+        },
+        id: {
+          display: "Row ID",
+          type: DatasourceFieldType.STRING,
+          required: true,
+        },
+      },
+    },
+  },
+}
+
+function sanitizeError(err: unknown): string {
+  if (axios.isAxiosError(err)) {
+    const status = err.response?.status ?? "unknown"
+    const statusText = err.response?.statusText ?? ""
+    const detail = err.response?.data?.error_msg ?? err.message
+    return `HTTP ${status} ${statusText}: ${detail}`
+  }
+  return err instanceof Error ? err.message : "Unknown error"
+}
+
+class SeaTableIntegration implements IntegrationBase {
+  private readonly serverUrl: string
+  private readonly apiToken: string
+  private http?: AxiosInstance
+  private baseUuid?: string
+  private tokenExpiresAt = 0
+
+  constructor(config: SeaTableConfig) {
+    this.serverUrl = config.serverUrl.replace(/\/$/, "")
+    this.apiToken = config.apiToken
+  }
+
+  private async ensureAuthenticated(): Promise<void> {
+    if (this.http && Date.now() < this.tokenExpiresAt) {
+      return
+    }
+
+    const url = `${this.serverUrl}/api/v2.1/dtable/app-access-token/`
+    const res = await axios.get(url, {
+      headers: { Authorization: `Bearer ${this.apiToken}` },
+      timeout: 15_000,
+    })
+
+    const baseToken = res.data.access_token
+    this.baseUuid = res.data.dtable_uuid
+
+    if (!baseToken || !this.baseUuid) {
+      throw new Error(
+        "SeaTable token exchange failed – missing access_token or dtable_uuid"
+      )
+    }
+
+    this.tokenExpiresAt = Date.now() + 59 * 60 * 1000
+
+    this.http = axios.create({
+      baseURL: `${this.serverUrl}/api-gateway/api/v2/dtables/${this.baseUuid}`,
+      timeout: 30_000,
+      headers: { Authorization: `Bearer ${baseToken}` },
+    })
+  }
+
+  async testConnection(): Promise<ConnectionInfo> {
+    try {
+      await this.ensureAuthenticated()
+      await this.http!.get("/metadata/")
+      return { connected: true }
+    } catch (e: any) {
+      return {
+        connected: false,
+        error: sanitizeError(e),
+      }
+    }
+  }
+
+  async create(query: { table: string; json: Record<string, unknown> }) {
+    const { table, json } = query
+    try {
+      await this.ensureAuthenticated()
+      const res = await this.http!.post("/rows/", {
+        table_name: table,
+        rows: [json],
+        convert_keys: true,
+      })
+      return res.data.first_row ?? res.data
+    } catch (err) {
+      const message = sanitizeError(err)
+      console.error("Error creating row in SeaTable:", message)
+      throw new Error(message)
+    }
+  }
+
+  async read(query: { table: string; numRecords: number; view?: string }) {
+    try {
+      await this.ensureAuthenticated()
+      const params: Record<string, unknown> = {
+        table_name: query.table,
+        start: 0,
+        limit: query.numRecords || 100,
+        convert_keys: true,
+      }
+      if (query.view) {
+        params.view_name = query.view
+      }
+      const res = await this.http!.get("/rows/", { params })
+      return res.data.rows ?? []
+    } catch (err) {
+      const message = sanitizeError(err)
+      console.error("Error reading from SeaTable:", message)
+      return []
+    }
+  }
+
+  async update(query: {
+    table: string
+    id: string
+    json: Record<string, unknown>
+  }) {
+    const { table, id, json } = query
+    try {
+      await this.ensureAuthenticated()
+      const res = await this.http!.put("/rows/", {
+        table_name: table,
+        updates: [{ row_id: id, row: json }],
+      })
+      return res.data
+    } catch (err) {
+      const message = sanitizeError(err)
+      console.error("Error updating row in SeaTable:", message)
+      throw new Error(message)
+    }
+  }
+
+  async delete(query: { table: string; id: string }) {
+    const { table, id } = query
+    try {
+      await this.ensureAuthenticated()
+      const res = await this.http!.delete("/rows/", {
+        data: { table_name: table, row_ids: [id] },
+      })
+      return res.data
+    } catch (err) {
+      const message = sanitizeError(err)
+      console.error("Error deleting row from SeaTable:", message)
+      throw new Error(message)
+    }
+  }
+}
+
+export default {
+  schema: SCHEMA,
+  integration: SeaTableIntegration,
+}

--- a/packages/server/src/integrations/tests/seatable.integration.spec.ts
+++ b/packages/server/src/integrations/tests/seatable.integration.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Integration tests for SeaTable – runs against a real SeaTable instance.
+ *
+ * These tests are skipped unless the following environment variables are set:
+ *   SEATABLE_SERVER_URL  – e.g. https://seatable-demo.de
+ *   SEATABLE_API_TOKEN   – a base-level API token
+ *
+ * The target base must contain a table called "Table1" with at least
+ * a "Name" column of type text.
+ *
+ * Run with:
+ *   SEATABLE_SERVER_URL=https://seatable-demo.de SEATABLE_API_TOKEN=<token> \
+ *     yarn jest src/integrations/tests/seatable.integration
+ */
+
+import { default as SeaTableModule } from "../seatable"
+
+const SERVER_URL = process.env.SEATABLE_SERVER_URL
+const API_TOKEN = process.env.SEATABLE_API_TOKEN
+const TABLE_NAME = "Table1"
+
+const runIntegration = SERVER_URL && API_TOKEN
+
+const describeIf = runIntegration ? describe : describe.skip
+
+describeIf("SeaTable Integration (live)", () => {
+  let integration: any
+
+  beforeAll(() => {
+    integration = new SeaTableModule.integration({
+      serverUrl: SERVER_URL!,
+      apiToken: API_TOKEN!,
+    })
+  })
+
+  it("connects successfully", async () => {
+    const result = await integration.testConnection()
+    expect(result.connected).toBe(true)
+  })
+
+  it("performs full CRUD lifecycle", async () => {
+    // Create
+    const created = await integration.create({
+      table: TABLE_NAME,
+      json: { Name: "Budibase Integration Test" },
+    })
+    expect(created).toBeDefined()
+
+    // The create method returns first_row (with column keys) or full response.
+    // first_row always contains _id.
+    const rowId = created._id
+    expect(rowId).toBeDefined()
+    expect(typeof rowId).toBe("string")
+
+    // Read – verify the row exists
+    const rows = await integration.read({
+      table: TABLE_NAME,
+      numRecords: 100,
+    })
+    expect(Array.isArray(rows)).toBe(true)
+    expect(rows.some((r: any) => r._id === rowId)).toBe(true)
+
+    // Update
+    const updateResult = await integration.update({
+      table: TABLE_NAME,
+      id: rowId,
+      json: { Name: "Budibase Updated Test" },
+    })
+    expect(updateResult).toBeDefined()
+
+    // Delete
+    const deleteResult = await integration.delete({
+      table: TABLE_NAME,
+      id: rowId,
+    })
+    expect(deleteResult).toBeDefined()
+
+    // Verify deletion
+    const rowsAfterDelete = await integration.read({
+      table: TABLE_NAME,
+      numRecords: 100,
+    })
+    expect(rowsAfterDelete.some((r: any) => r._id === rowId)).toBe(false)
+  }, 30_000)
+
+  it("reads rows from a table", async () => {
+    const rows = await integration.read({
+      table: TABLE_NAME,
+      numRecords: 10,
+    })
+    expect(Array.isArray(rows)).toBe(true)
+  })
+
+  it("returns connected false for invalid token", async () => {
+    const badIntegration = new SeaTableModule.integration({
+      serverUrl: SERVER_URL!,
+      apiToken: "invalid-token-that-does-not-exist",
+    })
+    const result = await badIntegration.testConnection()
+    expect(result.connected).toBe(false)
+  })
+})

--- a/packages/server/src/integrations/tests/seatable.spec.ts
+++ b/packages/server/src/integrations/tests/seatable.spec.ts
@@ -1,0 +1,218 @@
+jest.mock("axios", () => {
+  const mockHttpClient = {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  }
+
+  const mockAxios: any = {
+    get: jest.fn(),
+    create: jest.fn(() => mockHttpClient),
+    isAxiosError: jest.fn(() => false),
+    __mockHttpClient: mockHttpClient,
+  }
+  return { default: mockAxios, __esModule: true }
+})
+
+import axios from "axios"
+import { default as SeaTableIntegration } from "../seatable"
+
+const mockAxios = axios as jest.Mocked<typeof axios> & {
+  __mockHttpClient: {
+    get: jest.Mock
+    post: jest.Mock
+    put: jest.Mock
+    delete: jest.Mock
+  }
+}
+
+const ACCESS_TOKEN_RESPONSE = {
+  data: {
+    access_token: "test-base-token",
+    dtable_uuid: "test-uuid-456",
+    dtable_server: "https://cloud.seatable.io/dtable-server/",
+  },
+}
+
+function createIntegration() {
+  return new SeaTableIntegration.integration({
+    serverUrl: "https://cloud.seatable.io",
+    apiToken: "test-api-token",
+  })
+}
+
+describe("SeaTable Integration", () => {
+  let integration: any
+  const http = mockAxios.__mockHttpClient
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockAxios.get.mockResolvedValue(ACCESS_TOKEN_RESPONSE)
+    integration = createIntegration()
+  })
+
+  describe("authentication", () => {
+    it("exchanges API token for base token", async () => {
+      http.get.mockResolvedValue({ data: { metadata: { tables: [] } } })
+
+      await integration.testConnection()
+
+      expect(mockAxios.get).toHaveBeenCalledWith(
+        "https://cloud.seatable.io/api/v2.1/dtable/app-access-token/",
+        expect.objectContaining({
+          headers: { Authorization: "Bearer test-api-token" },
+        })
+      )
+    })
+
+    it("uses dtable_server from token response as baseURL", async () => {
+      http.get.mockResolvedValue({ data: { metadata: { tables: [] } } })
+
+      await integration.testConnection()
+
+      expect(mockAxios.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL:
+            "https://cloud.seatable.io/dtable-server/api/v2/dtables/test-uuid-456",
+        })
+      )
+    })
+
+    it("fails when token response is incomplete", async () => {
+      mockAxios.get.mockResolvedValue({
+        data: { access_token: "tok" },
+      })
+
+      const result = await integration.testConnection()
+      expect(result.connected).toBe(false)
+    })
+  })
+
+  describe("testConnection", () => {
+    it("returns connected true on success", async () => {
+      http.get.mockResolvedValue({ data: { metadata: { tables: [] } } })
+
+      const result = await integration.testConnection()
+      expect(result.connected).toBe(true)
+    })
+
+    it("returns connected false on failure", async () => {
+      http.get.mockRejectedValue(new Error("connection refused"))
+
+      const result = await integration.testConnection()
+      expect(result.connected).toBe(false)
+      expect(result.error).toContain("connection refused")
+    })
+  })
+
+  describe("create", () => {
+    it("posts a new row", async () => {
+      http.post.mockResolvedValue({
+        data: { first_row: { _id: "new-row", Name: "Alice" } },
+      })
+
+      const result = await integration.create({
+        table: "Contacts",
+        json: { Name: "Alice" },
+      })
+
+      expect(http.post).toHaveBeenCalledWith("/rows/", {
+        table_name: "Contacts",
+        rows: [{ Name: "Alice" }],
+      })
+      expect(result).toEqual({ _id: "new-row", Name: "Alice" })
+    })
+
+    it("throws on error", async () => {
+      http.post.mockRejectedValue(new Error("bad request"))
+
+      await expect(
+        integration.create({ table: "T", json: {} })
+      ).rejects.toThrow("bad request")
+    })
+  })
+
+  describe("read", () => {
+    it("fetches rows with params", async () => {
+      http.get.mockResolvedValue({
+        data: { rows: [{ _id: "r1", Name: "Alice" }] },
+      })
+
+      const result = await integration.read({
+        table: "Contacts",
+        numRecords: 50,
+        view: "Default",
+      })
+
+      expect(http.get).toHaveBeenCalledWith("/rows/", {
+        params: {
+          table_name: "Contacts",
+          start: 0,
+          limit: 50,
+          convert_keys: true,
+          view_name: "Default",
+        },
+      })
+      expect(result).toEqual([{ _id: "r1", Name: "Alice" }])
+    })
+
+    it("throws on error instead of returning empty array", async () => {
+      http.get.mockRejectedValue(new Error("server error"))
+
+      await expect(
+        integration.read({ table: "T", numRecords: 10 })
+      ).rejects.toThrow("server error")
+    })
+  })
+
+  describe("update", () => {
+    it("sends updates array", async () => {
+      http.put.mockResolvedValue({ data: { success: true } })
+
+      const result = await integration.update({
+        table: "Contacts",
+        id: "row1",
+        json: { Name: "Bob" },
+      })
+
+      expect(http.put).toHaveBeenCalledWith("/rows/", {
+        table_name: "Contacts",
+        updates: [{ row_id: "row1", row: { Name: "Bob" } }],
+      })
+      expect(result).toEqual({ success: true })
+    })
+
+    it("throws on error", async () => {
+      http.put.mockRejectedValue(new Error("not found"))
+
+      await expect(
+        integration.update({ table: "T", id: "r1", json: {} })
+      ).rejects.toThrow("not found")
+    })
+  })
+
+  describe("delete", () => {
+    it("sends row_ids in request body", async () => {
+      http.delete.mockResolvedValue({ data: { deleted_rows: 1 } })
+
+      const result = await integration.delete({
+        table: "Contacts",
+        id: "row1",
+      })
+
+      expect(http.delete).toHaveBeenCalledWith("/rows/", {
+        data: { table_name: "Contacts", row_ids: ["row1"] },
+      })
+      expect(result).toEqual({ deleted_rows: 1 })
+    })
+
+    it("throws on error", async () => {
+      http.delete.mockRejectedValue(new Error("forbidden"))
+
+      await expect(
+        integration.delete({ table: "T", id: "r1" })
+      ).rejects.toThrow("forbidden")
+    })
+  })
+})

--- a/packages/types/src/sdk/datasources.ts
+++ b/packages/types/src/sdk/datasources.ts
@@ -63,6 +63,7 @@ export enum SourceName {
   REDIS = "REDIS",
   REST = "REST",
   S3 = "S3",
+  SEATABLE = "SEATABLE",
   SNOWFLAKE = "SNOWFLAKE",
   SQL_SERVER = "SQL_SERVER",
 }


### PR DESCRIPTION
> [!NOTE]
> This replaces #18314, which was closed when the source fork was moved to a different organization.

## Summary

Adds [SeaTable](https://seatable.com) as a native datasource integration.

SeaTable is a collaborative database platform (self-hostable alternative to Airtable). This connector works with any SeaTable server — cloud (cloud.seatable.io) or self-hosted.

Closes #18313

## Changes

- **`packages/server/src/integrations/seatable.ts`** – New integration file (follows the same pattern as `airtable.ts`)
- **`packages/types/src/sdk/datasources.ts`** – Add `SEATABLE` to `SourceName` enum
- **`packages/server/src/integrations/index.ts`** – Register SeaTable in DEFINITIONS and INTEGRATIONS
- **`packages/server/src/integrations/tests/seatable.spec.ts`** – Unit tests with mocked axios
- **`packages/server/src/integrations/tests/seatable.integration.spec.ts`** – Integration tests against live SeaTable instance (env-var gated)
- **`packages/builder/.../icons/SeaTable.svelte`** – Vector icon for datasource navigator
- **`packages/builder/.../icons/index.js`** – Register SeaTable icon

## Operations

| Operation | Description |
|---|---|
| **Create** | Insert a new row (customisable fields) |
| **Read** | List rows with optional view filter and record limit |
| **Update** | Update a row by ID (customisable fields) |
| **Delete** | Delete a row by ID |
| **testConnection** | Validates credentials via token exchange + metadata fetch |

## Authentication

SeaTable uses a two-step token exchange:
1. Exchange long-lived API-Token for a short-lived Base-Token via `GET /api/v2.1/dtable/app-access-token/`
2. Use the `dtable_server` URL from the token response for all CRUD operations

Credentials:
- **Server URL** – Any SeaTable server (default: `https://cloud.seatable.io`)
- **API Token** – Base-scoped token, created in SeaTable UI

## Changes vs #18314

- **Security fix**: Error handling now sanitizes Axios errors via a dedicated `sanitizeError()` helper to prevent token/credential leakage in server logs
- **Use `dtable_server` from token response** instead of hardcoding the API gateway URL — ensures compatibility with all SeaTable deployments
- **Consistent error handling**: `read()` now throws on error instead of silently returning an empty array
- **Unit tests** with mocked axios covering authentication, all CRUD operations, and error paths
- **Integration tests** that run against a live SeaTable instance (gated by environment variables)
- **SeaTable icon** added to the datasource navigator (vector SVG)

## Verified against live SeaTable instance

All CRUD operations have been tested and verified against a live SeaTable server:

| Operation | Status | Details |
|---|---|---|
| **Auth / Token Exchange** | ✅ | API token exchanged for base token, `dtable_server` URL used correctly |
| **Create** | ✅ | Row inserted, row ID returned |
| **Read** | ✅ | Rows listed with `convert_keys=true`, column names returned correctly |
| **Update** | ✅ | Row updated by ID, `{"success": true}` confirmed |
| **Delete** | ✅ | Row deleted by ID, deletion verified via subsequent read |
| **testConnection** | ✅ | Valid token → connected, invalid token → clear error |

The integration tests can be reproduced by running:
```bash
SEATABLE_SERVER_URL=https://your-server.example.com SEATABLE_API_TOKEN=your-token \
  yarn jest src/integrations/tests/seatable.integration
```

## Test plan

- [x] Unit tests with mocked axios (13 tests covering auth, CRUD, error handling)
- [x] Integration tests against live SeaTable instance (4 tests, env-var gated)
- [x] All CRUD operations verified against live SeaTable server
- [x] testConnection validates credentials and returns clear error messages
- [x] Error sanitization prevents token leakage in logs
- [ ] Manual test in Budibase UI (datasource creation + query builder)

## References

- SeaTable website: https://seatable.com
- SeaTable API docs: https://api.seatable.com
- SeaTable on GitHub: https://github.com/seatable