### PR TITLE
Fix: Match ALL filter ignores 'Is In' with empty array

### DIFF
--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -142,7 +142,6 @@ export const NoEmptyFilterStrings = [
   OperatorOptions.Contains.value,
   OperatorOptions.NotContains.value,
   OperatorOptions.ContainsAny.value,
-  OperatorOptions.In.value,
 ] as (keyof SearchQueryFields)[]
 
 export function recurseLogicalOperators(


### PR DESCRIPTION
## Description

Fixes #17951

When using the "Is In" (`oneOf`) filter with an empty array value under "Match ALL" logic, the filter was silently stripped by `cleanupQuery`, causing the query to behave as if that filter didn't exist. This meant rows that should have been excluded were returned.

### Root Cause

`NoEmptyFilterStrings` in `packages/shared-core/src/filters.ts` included `OperatorOptions.In.value` (`"oneOf"`). The `cleanupQuery` function iterates over this list and deletes any filter entries whose value is `null`, `""`, or an empty array. Since an empty array `[]` was treated the same as "no value", the `oneOf` filter was removed before it could be evaluated.

With "Match ALL", dropping a filter that should match nothing effectively turns the query into "Match ALL (minus that filter)", returning results that should have been excluded.

### Fix

Removed `OperatorOptions.In.value` from `NoEmptyFilterStrings`. This preserves the `oneOf` filter even when it has an empty array value.

This is safe because both downstream handlers already handle empty arrays correctly:
- **In-memory** (`runQuery`): `testValue.some(item => ...)` on `[]` returns `false` — no doc matches
- **SQL** (`sql.ts`): `whereIn(key, [])` correctly returns no results

### How to Test

1. Create two tables with a many-to-many relationship
2. Add a repeater block with filters using "Match ALL"
3. Add an "Is In" filter on the relationship field, passing an empty array
4. Add a secondary filter (e.g., equals a static number)
5. Before fix: both filters are evaluated but the empty "Is In" is dropped, so only the secondary filter applies → results are returned
6. After fix: the "Is In []" filter is preserved and correctly matches nothing → no results returned

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where "Match ALL" ignored "Is In" (`oneOf`) filters with an empty array, returning rows that should have been excluded. The filter is now preserved and correctly matches no results.

- **Bug Fixes**
  - Removed `OperatorOptions.In.value` from `NoEmptyFilterStrings` in `packages/shared-core/src/filters.ts`.
  - Stops `cleanupQuery` from stripping `oneOf: []`; both in-memory and SQL paths already handle empty arrays by returning no matches.

<sup>Written for commit 5c08c7fad772a581e37c29a9fc4e33019c897b24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

