### PR TITLE
[18266] Fix backup restore for production attachments

### DIFF
--- a/packages/pro/src/sdk/backups/processing.ts
+++ b/packages/pro/src/sdk/backups/processing.ts
@@ -9,6 +9,8 @@ import {
   BackupStatus,
   BackupTrigger,
   BackupType,
+  DocumentType,
+  Workspace,
   WorkspaceBackupContents,
   WorkspaceBackupQueueData,
 } from "@budibase/types"
@@ -48,6 +50,27 @@ type RunBackupOpts = {
 async function removeExistingApp(devId: string) {
   const devDb = dbCore.getDB(devId, { skip_setup: true })
   await devDb.destroy()
+}
+
+async function updateWorkspaceMetadataAppId(
+  workspaceId: string,
+  appId: string
+) {
+  const workspaceDb = dbCore.getDB(workspaceId)
+  if (!(await workspaceDb.exists())) {
+    return
+  }
+  const metadata = await workspaceDb.tryGet<Workspace>(
+    DocumentType.WORKSPACE_METADATA
+  )
+  if (!metadata) {
+    return
+  }
+  metadata.appId = appId
+  if (metadata.instance) {
+    metadata.instance._id = appId
+  }
+  await workspaceDb.put(metadata)
 }
 
 const DELETE_BATCH_SIZE = 1000
@@ -212,6 +235,9 @@ async function runBackup(
 ) {
   const devWorkspaceId = dbCore.getDevWorkspaceID(appId),
     prodAppId = dbCore.getProdWorkspaceID(appId)
+  const backupSourceWorkspaceId = (await dbCore.dbExists(prodAppId))
+    ? prodAppId
+    : devWorkspaceId
   const timestamp = new Date().toISOString()
   const updateMetadata = async (
     status: BackupStatus,
@@ -241,7 +267,7 @@ async function runBackup(
     }
   }
   try {
-    const tarPath = await opts.processing.exportAppFn(devWorkspaceId, {
+    const tarPath = await opts.processing.exportAppFn(backupSourceWorkspaceId, {
       tar: true,
     })
     const contents = await opts.processing.statsFn(devWorkspaceId)
@@ -290,6 +316,8 @@ async function importProcessor(job: Job, opts: BackupProcessingOpts) {
   const tenantId = tenancy.getTenantIDFromWorkspaceID(appId) as string
   return tenancy.doInTenant(tenantId, async () => {
     const devWorkspaceId = dbCore.getDevWorkspaceID(appId)
+    const prodWorkspaceId = dbCore.getProdWorkspaceID(appId)
+    const isPublished = await dbCore.dbExists(prodWorkspaceId)
     const tempAppId = `${devWorkspaceId}_temp_${Date.now()}`
 
     const { rev } = await backups.updateRestoreStatus(
@@ -330,6 +358,17 @@ async function importProcessor(job: Job, opts: BackupProcessingOpts) {
         tempAppId,
         devWorkspaceId
       )
+
+      if (isPublished) {
+        await updateWorkspaceMetadataAppId(tempAppId, prodWorkspaceId)
+        await removeExistingApp(prodWorkspaceId)
+        await new db.Replication({
+          source: tempAppId,
+          target: prodWorkspaceId,
+        }).replicate()
+      }
+
+      await updateWorkspaceMetadataAppId(tempAppId, devWorkspaceId)
 
       // if import succeeds, replace the original app with the temporary one
       await removeExistingApp(devWorkspaceId)

--- a/packages/pro/src/sdk/backups/tests/index.spec.ts
+++ b/packages/pro/src/sdk/backups/tests/index.spec.ts
@@ -227,6 +227,22 @@ describe("backups", () => {
     })
   })
 
+  it("should export production data for published workspaces", async () => {
+    await config.doInTenant(async () => {
+      const devWorkspaceId = db.getDevWorkspaceID(config.workspaceId)
+      await db.getDB(config.workspaceId).put({
+        _id: "published-workspace-marker",
+        type: "app",
+      })
+
+      await createBackup({ workspaceId: devWorkspaceId })
+
+      expect(exportAppFn).toHaveBeenCalledWith(config.workspaceId, {
+        tar: true,
+      })
+    })
+  })
+
   it("should call importAppFn with dev workspace id, not temp app id", async () => {
     await config.doInTenant(async () => {
       const restore = await createRestore()

--- a/packages/server/src/api/routes/tests/backup.spec.ts
+++ b/packages/server/src/api/routes/tests/backup.spec.ts
@@ -1,6 +1,6 @@
 import { context, events } from "@budibase/backend-core"
 import { generator, mocks } from "@budibase/backend-core/tests"
-import { DocumentType, Workspace } from "@budibase/types"
+import { BackupStatus, DocumentType, Workspace } from "@budibase/types"
 import path from "path"
 import { Readable, Writable } from "stream"
 import { pipeline } from "stream/promises"
@@ -15,6 +15,27 @@ mocks.licenses.useBackups()
 
 describe("/backups", () => {
   let config = setup.getConfig()
+
+  async function waitForRestoreToComplete(
+    appId: string,
+    restoreId: string
+  ): Promise<BackupStatus> {
+    for (let i = 0; i < 30; i++) {
+      const response = await config.getRequest()!
+        .post(`/api/apps/${appId}/backups/search`)
+        .set(await config.defaultHeaders())
+        .send({})
+      const restore = response.body?.data?.find((b: any) => b._id === restoreId)
+      if (
+        restore?.status === BackupStatus.COMPLETE ||
+        restore?.status === BackupStatus.FAILED
+      ) {
+        return restore.status
+      }
+      await new Promise(resolve => setTimeout(resolve, 1000))
+    }
+    throw new Error("Restore did not complete")
+  }
 
   afterAll(() => {
     setup.afterAll()
@@ -191,6 +212,63 @@ describe("/backups", () => {
         exportRes.backupId
       )
       await config.api.backup.importBackup(workspaceId, exportRes.backupId)
+    })
+
+    it("should restore production attachment values from a backup", async () => {
+      const workspaceId = config.getDevWorkspaceId()
+      const table = await config.api.table.save(
+        setup.structures.basicTableWithAttachmentField()
+      )
+      await config.api.table.publish(table._id!)
+
+      const prodHeaders = await config.defaultHeaders({}, true)
+      const [attachment] = await config.withHeaders(prodHeaders, async () =>
+        config.api.attachment.upload(
+          table._id!,
+          "prod-file.txt",
+          Buffer.from("prod-content")
+        )
+      )
+
+      const prodRow = await config.withHeaders(prodHeaders, async () =>
+        config.api.row.save(table._id!, {
+          single_file_attachment: attachment,
+        })
+      )
+      expect(prodRow.single_file_attachment?.key).toBeDefined()
+
+      const exportRes = await config.api.backup.createBackup(workspaceId)
+      await config.api.backup.waitForBackupToComplete(workspaceId, exportRes.backupId)
+
+      await config.withHeaders(prodHeaders, async () =>
+        config.api.row.patch(table._id!, {
+          _id: prodRow._id,
+          single_file_attachment: null,
+        })
+      )
+      let prodRows = await config.api.row.fetchProd(table._id!)
+      expect(prodRows[0].single_file_attachment).toBeFalsy()
+
+      const restoreRes = await config.api.backup.importBackup(
+        workspaceId,
+        exportRes.backupId
+      )
+      const restoreStatus = await waitForRestoreToComplete(
+        workspaceId,
+        restoreRes.restoreId
+      )
+      expect(restoreStatus).toEqual(BackupStatus.COMPLETE)
+
+      const devRows = await config.api.row.fetch(table._id!)
+      expect(devRows[0].single_file_attachment?.key).toBeDefined()
+      await context.doInWorkspaceContext(workspaceId, async () => {
+        const db = context.getWorkspaceDB()
+        const metadata = await db.get<Workspace>(DocumentType.WORKSPACE_METADATA)
+        expect(metadata.appId).toEqual(workspaceId)
+      })
+
+      prodRows = await config.api.row.fetchProd(table._id!)
+      expect(prodRows[0].single_file_attachment?.key).toBeDefined()
     })
   })
 


### PR DESCRIPTION
## Description
Fix backup restore for production attachments not appearing after restore.

Attachments are stored in shared object storage paths (prod workspace prefix), while restore previously only cut over the development DB. This caused production attachment references to be stale/missing after restore.

This PR updates backup/restore behavior so that:
- published workspaces are backed up from production data,
- restore updates production and development DBs where applicable,
- workspace metadata app IDs are normalized per restore target before replication.

## Addresses
- https://github.com/Budibase/budibase/issues/18266

## App Export
- N/A

## Screenshots
- N/A (backend behavior change)

## Launchcontrol
Restoring an app backup now correctly brings back attachment data for both development and published versions, so production files appear after restore.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes backup restore so production attachments return after an app restore. Exports from the right source and updates both prod and dev with normalized metadata so attachment keys point to the correct files. Fixes #18266.

- **Bug Fixes**
  - Export from production when the workspace is published; otherwise export from development.
  - On restore, replicate to production (if published) and development, replacing existing DBs.
  - Normalize workspace metadata `appId` per target before replication so attachment paths resolve; tests cover prod export and end-to-end restore.

<sup>Written for commit b4e066ba99706f99d237f334656de41b20eeda73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

