### PR TITLE
Fix SQL query bindings disappearing while editing query text

### DIFF
--- a/packages/builder/src/components/integration/QueryViewerBindingBuilder.svelte
+++ b/packages/builder/src/components/integration/QueryViewerBindingBuilder.svelte
@@ -1,15 +1,25 @@
 <script>
   import KeyValueBuilder from "@/components/integration/KeyValueBuilder.svelte"
   import { getUserBindings } from "@/dataBinding"
+  import { createEventDispatcher } from "svelte"
 
   export let queryBindings = []
 
+  const dispatch = createEventDispatcher()
   const userBindings = getUserBindings()
 
   let internalBindings = queryBindings.reduce((acc, binding) => {
     acc[binding.name] = binding.default
     return acc
   }, {})
+
+  function onBindingsChange(event) {
+    const fields = Array.isArray(event?.detail)
+      ? event.detail
+      : event?.detail?.fields || []
+
+    dispatch("change", fields)
+  }
 </script>
 
 <KeyValueBuilder
@@ -22,5 +32,5 @@
   valuePlaceholder="Default"
   bindings={[...userBindings]}
   allowHelpers={false}
-  on:change
+  on:change={onBindingsChange}
 />


### PR DESCRIPTION
## Description
Fixes a regression where SQL query bindings disappeared while editing query text in the query editor.

Root cause: `KeyValueBuilder` now emits `{ fields, activity }` on `change`, but the SQL bindings flow still expected an array and attempted to map directly over `e.detail`.

This PR normalizes the event payload in `QueryViewerBindingBuilder` so it always re-emits an array of binding fields to `QueryViewer`.

## Addresses
- https://github.com/Budibase/budibase/issues/18338

## App Export
- Not included (targeted UI bugfix in query editor component).

## Screenshots
- Not included.

## Launchcontrol
Fixes a bug where SQL query parameter bindings could disappear while editing the query text in the builder.


