### PR TITLE
Fix docs link

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
@@ -131,7 +131,10 @@
         <Icon
           tooltip="Documentation"
           on:click={() =>
-            window.open("https://docs.budibase.com/docs/agents", "_blank")}
+            window.open(
+              "https://docs.budibase.com/docs/agent-building-101",
+              "_blank"
+            )}
           name="info"
           size="M"
           color="var(--spectrum-global-color-gray-600)"


### PR DESCRIPTION
## Description
yes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "Documentation" link in the agent builder layout so it opens the correct "Agent Building 101" page.
The info icon in `packages/builder/.../[agentId]/_layout.svelte` now points to https://docs.budibase.com/docs/agent-building-101 instead of the outdated agents page.

<sup>Written for commit 8c1123247ec0fe14f87429b699f32af47a6b8355. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

