### PR TITLE
Pin singleimage litellm

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -87,6 +87,22 @@ jobs:
           fail-on-cache-miss: true
       - run: yarn lint
 
+  litellm-version-sync:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+
+      - name: Verify LiteLLM versions are synchronized
+        run: yarn check:litellm-version
+
   build:
     runs-on: ubuntu-24.04
     needs:

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -616,7 +616,7 @@ services:
     # -- Whether or not to deploy the litellm gateway.
     enabled: false
     # -- litellm image to use.
-    image: ghcr.io/berriai/litellm:main-latest
+    image: ghcr.io/berriai/litellm:main-v1.82.3-stable
     # -- Port exposed by the litellm container.
     port: 4000
     # -- Number of litellm replicas.

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -616,7 +616,7 @@ services:
     # -- Whether or not to deploy the litellm gateway.
     enabled: false
     # -- litellm image to use.
-    image: ghcr.io/berriai/litellm:main-v1.82.3-stable
+    image: ghcr.io/berriai/litellm:main-v1.81.14-stable
     # -- Port exposed by the litellm container.
     port: 4000
     # -- Number of litellm replicas.

--- a/hosting/docker-compose.build.yaml
+++ b/hosting/docker-compose.build.yaml
@@ -88,7 +88,7 @@ services:
       - couchdb-service
 
   litellm-service:
-    image: docker.litellm.ai/berriai/litellm:1.80.15-stable.1
+    image: ghcr.io/berriai/litellm:main-v1.82.3-stable
     ports:
       - "${LITELLM_PORT:-4000}:4000"
     volumes:

--- a/hosting/docker-compose.build.yaml
+++ b/hosting/docker-compose.build.yaml
@@ -88,7 +88,7 @@ services:
       - couchdb-service
 
   litellm-service:
-    image: ghcr.io/berriai/litellm:main-v1.82.3-stable
+    image: ghcr.io/berriai/litellm:main-v1.81.14-stable
     ports:
       - "${LITELLM_PORT:-4000}:4000"
     volumes:

--- a/hosting/docker-compose.dev.yaml
+++ b/hosting/docker-compose.dev.yaml
@@ -63,7 +63,7 @@ services:
 
   litellm-service:
     container_name: budi-litellm-dev
-    image: ghcr.io/berriai/litellm:main-v1.82.3-stable
+    image: ghcr.io/berriai/litellm:main-v1.81.14-stable
     ports:
       - "${LITELLM_PORT:-4000}:4000"
     volumes:

--- a/hosting/docker-compose.dev.yaml
+++ b/hosting/docker-compose.dev.yaml
@@ -63,7 +63,7 @@ services:
 
   litellm-service:
     container_name: budi-litellm-dev
-    image: docker.litellm.ai/berriai/litellm:v1.81.14-stable
+    image: ghcr.io/berriai/litellm:main-v1.82.3-stable
     ports:
       - "${LITELLM_PORT:-4000}:4000"
     volumes:

--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -122,7 +122,7 @@ services:
 
   litellm-service:
     restart: unless-stopped
-    image: ghcr.io/berriai/litellm:main-v1.82.3-stable
+    image: ghcr.io/berriai/litellm:main-v1.81.14-stable
     ports:
       - "${LITELLM_PORT:-4000}:4000"
     volumes:

--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -122,7 +122,7 @@ services:
 
   litellm-service:
     restart: unless-stopped
-    image: docker.litellm.ai/berriai/litellm:1.80.15-stable.1
+    image: ghcr.io/berriai/litellm:main-v1.82.3-stable
     ports:
       - "${LITELLM_PORT:-4000}:4000"
     volumes:

--- a/hosting/litellm-version.json
+++ b/hosting/litellm-version.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.82.3",
+  "channel": "stable"
+}

--- a/hosting/litellm-version.json
+++ b/hosting/litellm-version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.82.3",
+  "version": "1.81.14",
   "channel": "stable"
 }

--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -62,8 +62,8 @@ RUN apt-get update && \
 
 # Install litellm
 RUN python3 -m venv /opt/venv/litellm
-# Keep this pinned and in sync with charts/budibase/values.yaml (services.litellm.image)
-ARG LITELLM_PYPI_VERSION=1.82.3
+
+ARG LITELLM_PYPI_VERSION=1.81.14
 RUN /opt/venv/litellm/bin/pip install "litellm[proxy]==${LITELLM_PYPI_VERSION}"
 ENV PATH="/opt/venv/litellm/bin:${PATH}"
 RUN mkdir -p /litellm

--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -62,7 +62,9 @@ RUN apt-get update && \
 
 # Install litellm
 RUN python3 -m venv /opt/venv/litellm
-RUN /opt/venv/litellm/bin/pip install 'litellm[proxy]'
+# Keep this pinned and in sync with charts/budibase/values.yaml (services.litellm.image)
+ARG LITELLM_PYPI_VERSION=1.82.3
+RUN /opt/venv/litellm/bin/pip install "litellm[proxy]==${LITELLM_PYPI_VERSION}"
 ENV PATH="/opt/venv/litellm/bin:${PATH}"
 RUN mkdir -p /litellm
 

--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -128,8 +128,6 @@ RUN chmod +x ./healthcheck.sh
 RUN /opt/venv/litellm/bin/pip install prisma
 RUN LITELLM_SCHEMA_PATH=$(/opt/venv/litellm/bin/python -c "from importlib.util import find_spec; from pathlib import Path; spec = find_spec('litellm'); assert spec and spec.origin; print(Path(spec.origin).resolve().parent / 'proxy' / 'schema.prisma')") && \
     PRISMA_HIDE_UPDATE_MESSAGE=true /opt/venv/litellm/bin/prisma generate --schema "${LITELLM_SCHEMA_PATH}"
-RUN LITELLM_PROXY_EXTRAS_SCHEMA_PATH=$(/opt/venv/litellm/bin/python -c "from importlib.util import find_spec; from pathlib import Path; spec = find_spec('litellm_proxy_extras'); assert spec and spec.origin; print(Path(spec.origin).resolve().parent / 'schema.prisma')") && \
-    PRISMA_HIDE_UPDATE_MESSAGE=true /opt/venv/litellm/bin/prisma generate --schema "${LITELLM_PROXY_EXTRAS_SCHEMA_PATH}"
 
 # Script below sets the path for storing data based on $DATA_DIR
 # For Azure App Service install SSH & point data locations to /home

--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -260,6 +260,8 @@ if [[ -z "${LITELLM_MASTER_KEY}" || -z "${LITELLM_SALT_KEY}" ]]; then
     exit 1
 fi
 
+export USE_PRISMA_MIGRATE="True"
+
 upsert_env_var() {
     local name="$1"
     local value="$2"

--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -313,15 +313,23 @@ pm2 start /opt/venv/litellm/bin/litellm \
 echo "Waiting for LiteLLM to become ready..."
 litellm_ready_timeout="${LITELLM_READY_TIMEOUT_SECONDS:-120}"
 litellm_wait_seconds=0
+litellm_ready="false"
 until [[ $(curl -s -o /dev/null -w "%{http_code}" http://localhost:4000/health/liveliness) -eq 200 ]]; do
     litellm_wait_seconds=$((litellm_wait_seconds + 1))
     if [[ "${litellm_wait_seconds}" -ge "${litellm_ready_timeout}" ]]; then
-        echo "Timed out waiting for LiteLLM readiness after ${litellm_ready_timeout}s."
-        exit 1
+        echo "Timed out waiting for LiteLLM readiness after ${litellm_ready_timeout}s. Continuing startup without waiting further."
+        break
     fi
     sleep 1
 done
-echo "LiteLLM is ready."
+if [[ $(curl -s -o /dev/null -w "%{http_code}" http://localhost:4000/health/liveliness) -eq 200 ]]; then
+    litellm_ready="true"
+fi
+if [[ "${litellm_ready}" == "true" ]]; then
+    echo "LiteLLM is ready."
+else
+    echo "LiteLLM is not ready yet. App and worker will still start."
+fi
 
 pushd app
 pm2 start --name app "yarn run:docker"

--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -308,6 +308,19 @@ pm2 start /opt/venv/litellm/bin/litellm \
   --time \
   -- -c "${LITELLM_CONFIG_PATH}"
 
+echo "Waiting for LiteLLM to become ready..."
+litellm_ready_timeout="${LITELLM_READY_TIMEOUT_SECONDS:-120}"
+litellm_wait_seconds=0
+until [[ $(curl -s -o /dev/null -w "%{http_code}" http://localhost:4000/health/liveliness) -eq 200 ]]; do
+    litellm_wait_seconds=$((litellm_wait_seconds + 1))
+    if [[ "${litellm_wait_seconds}" -ge "${litellm_ready_timeout}" ]]; then
+        echo "Timed out waiting for LiteLLM readiness after ${litellm_ready_timeout}s."
+        exit 1
+    fi
+    sleep 1
+done
+echo "LiteLLM is ready."
+
 pushd app
 pm2 start --name app "yarn run:docker"
 popd

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "build:digitalocean": "cd hosting/digitalocean && ./build.sh && cd -",
     "build:docker:single:multiarch": "docker buildx build --platform linux/arm64,linux/amd64 -f hosting/single/Dockerfile -t budibase:latest .",
     "build:docker:single": "./scripts/build-single-image.sh",
+    "sync:litellm-version": "node ./scripts/syncLiteLLMVersion.js",
     "build:docker:dependencies": "docker build -f hosting/dependencies/Dockerfile -t budibase/dependencies:latest ./hosting",
     "publish:docker:couch": "docker buildx build --platform linux/arm64,linux/amd64 -f hosting/couchdb/Dockerfile -t budibase/database:latest -t budibase/database:2.1.0 --push ./hosting/couchdb",
     "publish:docker:dependencies": "docker buildx build --platform linux/arm64,linux/amd64 -f hosting/dependencies/Dockerfile -t budibase/dependencies:latest -t budibase/dependencies:v3.2.1 --push ./hosting",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "build:digitalocean": "cd hosting/digitalocean && ./build.sh && cd -",
     "build:docker:single:multiarch": "docker buildx build --platform linux/arm64,linux/amd64 -f hosting/single/Dockerfile -t budibase:latest .",
     "build:docker:single": "./scripts/build-single-image.sh",
+    "check:litellm-version": "node ./scripts/syncLiteLLMVersion.js --check",
     "sync:litellm-version": "node ./scripts/syncLiteLLMVersion.js",
     "build:docker:dependencies": "docker build -f hosting/dependencies/Dockerfile -t budibase/dependencies:latest ./hosting",
     "publish:docker:couch": "docker buildx build --platform linux/arm64,linux/amd64 -f hosting/couchdb/Dockerfile -t budibase/database:latest -t budibase/database:2.1.0 --push ./hosting/couchdb",

--- a/packages/builder/src/settings/routes.ts
+++ b/packages/builder/src/settings/routes.ts
@@ -318,7 +318,7 @@ export const workspaceRoutes = (
         },
         {
           path: AIConfigType.COMPLETIONS,
-          title: featureFlag.isEnabled(FeatureFlag.AI_RAG) ? "AI models" : "",
+          title: "AI models",
           component: Pages.get("ai_configs"),
           routes: [
             {

--- a/scripts/syncLiteLLMVersion.js
+++ b/scripts/syncLiteLLMVersion.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+const fs = require("fs")
+const path = require("path")
+
+const repoRoot = path.resolve(__dirname, "..")
+const versionConfigPath = path.join(repoRoot, "hosting", "litellm-version.json")
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"))
+}
+
+function updateFile(filePath, updater) {
+  const original = fs.readFileSync(filePath, "utf8")
+  const updated = updater(original)
+
+  if (original !== updated) {
+    fs.writeFileSync(filePath, updated)
+    return true
+  }
+
+  return false
+}
+
+function required(value, label) {
+  if (!value || typeof value !== "string") {
+    throw new Error(`Invalid ${label}`)
+  }
+  return value
+}
+
+function replaceRequired(content, pattern, replacement, filePath) {
+  if (!pattern.test(content)) {
+    throw new Error(`Could not find target pattern in ${filePath}`)
+  }
+  return content.replace(pattern, replacement)
+}
+
+function main() {
+  const versionConfig = readJson(versionConfigPath)
+  const version = required(versionConfig.version, "version")
+  const channel = required(versionConfig.channel, "channel")
+
+  const imageTag = `main-v${version}-${channel}`
+
+  const updates = [
+    {
+      path: path.join(repoRoot, "hosting", "single", "Dockerfile"),
+      update: content =>
+        replaceRequired(
+          content,
+          /ARG LITELLM_PYPI_VERSION=.*/,
+          `ARG LITELLM_PYPI_VERSION=${version}`,
+          "hosting/single/Dockerfile"
+        ),
+    },
+    {
+      path: path.join(repoRoot, "hosting", "docker-compose.yaml"),
+      update: content =>
+        replaceRequired(
+          content,
+          /image:\s*(?:docker\.litellm\.ai|ghcr\.io)\/berriai\/litellm:[^\s\n]+/,
+          `image: ghcr.io/berriai/litellm:${imageTag}`,
+          "hosting/docker-compose.yaml"
+        ),
+    },
+    {
+      path: path.join(repoRoot, "hosting", "docker-compose.build.yaml"),
+      update: content =>
+        replaceRequired(
+          content,
+          /image:\s*(?:docker\.litellm\.ai|ghcr\.io)\/berriai\/litellm:[^\s\n]+/,
+          `image: ghcr.io/berriai/litellm:${imageTag}`,
+          "hosting/docker-compose.build.yaml"
+        ),
+    },
+    {
+      path: path.join(repoRoot, "hosting", "docker-compose.dev.yaml"),
+      update: content =>
+        replaceRequired(
+          content,
+          /image:\s*(?:docker\.litellm\.ai|ghcr\.io)\/berriai\/litellm:[^\s\n]+/,
+          `image: ghcr.io/berriai/litellm:${imageTag}`,
+          "hosting/docker-compose.dev.yaml"
+        ),
+    },
+    {
+      path: path.join(repoRoot, "charts", "budibase", "values.yaml"),
+      update: content =>
+        replaceRequired(
+          content,
+          /image:\s*ghcr\.io\/berriai\/litellm:[^\s\n]+/,
+          `image: ghcr.io/berriai/litellm:${imageTag}`,
+          "charts/budibase/values.yaml"
+        ),
+    },
+  ]
+
+  const changed = []
+  for (const item of updates) {
+    if (updateFile(item.path, item.update)) {
+      changed.push(path.relative(repoRoot, item.path))
+    }
+  }
+
+  console.log(`LiteLLM version synced: version=${version}, channel=${channel}`)
+  if (changed.length > 0) {
+    console.log(`Updated files:\n${changed.join("\n")}`)
+  } else {
+    console.log("No files changed")
+  }
+}
+
+main()

--- a/scripts/syncLiteLLMVersion.js
+++ b/scripts/syncLiteLLMVersion.js
@@ -13,12 +13,10 @@ function updateFile(filePath, updater) {
   const original = fs.readFileSync(filePath, "utf8")
   const updated = updater(original)
 
-  if (original !== updated) {
-    fs.writeFileSync(filePath, updated)
-    return true
+  return {
+    changed: original !== updated,
+    updated,
   }
-
-  return false
 }
 
 function required(value, label) {
@@ -36,6 +34,7 @@ function replaceRequired(content, pattern, replacement, filePath) {
 }
 
 function main() {
+  const checkOnly = process.argv.includes("--check")
   const versionConfig = readJson(versionConfigPath)
   const version = required(versionConfig.version, "version")
   const channel = required(versionConfig.channel, "channel")
@@ -97,16 +96,28 @@ function main() {
 
   const changed = []
   for (const item of updates) {
-    if (updateFile(item.path, item.update)) {
+    const result = updateFile(item.path, item.update)
+    if (result.changed) {
+      if (!checkOnly) {
+        fs.writeFileSync(item.path, result.updated)
+      }
       changed.push(path.relative(repoRoot, item.path))
     }
   }
 
-  console.log(`LiteLLM version synced: version=${version}, channel=${channel}`)
+  console.log(
+    `LiteLLM version ${
+      checkOnly ? "check" : "sync"
+    }: version=${version}, channel=${channel}`
+  )
   if (changed.length > 0) {
-    console.log(`Updated files:\n${changed.join("\n")}`)
+    const header = checkOnly ? "Out-of-sync files" : "Updated files"
+    console.log(`${header}:\n${changed.join("\n")}`)
+    if (checkOnly) {
+      process.exit(1)
+    }
   } else {
-    console.log("No files changed")
+    console.log(checkOnly ? "All files are in sync" : "No files changed")
   }
 }
 


### PR DESCRIPTION
## Description
Pins litellm to v1.81.14 (stable) across Docker, Helm, and the single-image build to prevent version drift.
Changing how we use prisma, added in [#18059](https://github.com/Budibase/budibase/pull/18059/changes#diff-2daca463d3c20a262bdb6e997752dc3ecbb099509d62beb6f51ef3e120744787)
Using `USE_PRISMA_MIGRATE="True"` as recommended in https://docs.litellm.ai/docs/proxy/prod#9-use-prisma-migrate-deploy


## Launchcontrol
Pins litellm to v1.81.14 (stable) across Docker, Helm, and the single-image build to prevent version drift.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `litellm` to v1.81.14 across Docker, Helm, and the single-image build. Improves single-image startup by waiting for LiteLLM readiness with a timeout, soft-failing if it’s not ready, and fixing Prisma initialization. Also makes the “AI models” settings visible to all workspaces.

- **Dependencies**
  - Use `ghcr.io/berriai/litellm:main-v1.81.14-stable` in Docker Compose and Helm.
  - Pin PyPI install in the single-image Dockerfile to `litellm[proxy]==1.81.14`.
  - Add `hosting/litellm-version.json` and `scripts/syncLiteLLMVersion.js`, plus `check:litellm-version`/`sync:litellm-version` and a CI check.

- **Bug Fixes**
  - Single-image: wait for LiteLLM `/health/liveliness` with a timeout; continue app/worker startup if not ready.
  - Enable Prisma migrations (`USE_PRISMA_MIGRATE=true`) and remove `litellm_proxy_extras` Prisma generate to avoid init errors.

<sup>Written for commit 2fc60fee2d7a2c71b0cac7dc3c7cbebd797eefc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







