### PR TITLE
Enable AI models in settings

### DIFF
--- a/packages/builder/src/settings/routes.ts
+++ b/packages/builder/src/settings/routes.ts
@@ -318,7 +318,7 @@ export const workspaceRoutes = (
         },
         {
           path: AIConfigType.COMPLETIONS,
-          title: featureFlag.isEnabled(FeatureFlag.AI_RAG) ? "AI models" : "",
+          title: "AI models",
           component: Pages.get("ai_configs"),
           routes: [
             {


### PR DESCRIPTION
## Description
Display AI models in settings

## Launchcontrol
Display AI models in settings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show the AI models page in Settings by removing the `FeatureFlag.AI_RAG` gate in the settings routes of `packages/builder`. The AI models settings are now visible for all workspaces.

<sup>Written for commit ff61148a9a9b01c2a88a373ef5dc2427eee84fd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

