### PR TITLE
fix: resolve custom role regressions

### DIFF
--- a/packages/server/src/api/controllers/role.ts
+++ b/packages/server/src/api/controllers/role.ts
@@ -148,7 +148,7 @@ export async function save(ctx: UserCtx<SaveRoleRequest, SaveRoleResponse>) {
     description: uiMetadata?.description || "Custom role",
     color: uiMetadata?.color || RoleColor.DEFAULT_CUSTOM,
   }).addInheritance(inherits)
-  if (dbRole?.permissions && !role.permissions) {
+  if (dbRole?.permissions) {
     role.permissions = dbRole.permissions
   }
 
@@ -163,7 +163,7 @@ export async function save(ctx: UserCtx<SaveRoleRequest, SaveRoleResponse>) {
     ctx.throw(400, "Role inheritance contains a loop, this is not supported")
   }
 
-  const foundRev = _rev || dbRole?._rev
+  const foundRev = dbRole?._rev || _rev
   if (foundRev) {
     role._rev = foundRev
   }

--- a/packages/server/src/api/controllers/workspace.ts
+++ b/packages/server/src/api/controllers/workspace.ts
@@ -217,6 +217,8 @@ async function createInstance(appId: string, template: AppTemplate) {
     }
     await sdk.backups.importApp(appId, db, template, opts)
   } else {
+    // Re-construct USERS_TABLE_SCHEMA because we need to exclude the POWER role
+    // if we are not importing a workspace.
     const usersTable = {
       ...USERS_TABLE_SCHEMA,
       schema: {

--- a/packages/server/src/api/controllers/workspace.ts
+++ b/packages/server/src/api/controllers/workspace.ts
@@ -217,8 +217,25 @@ async function createInstance(appId: string, template: AppTemplate) {
     }
     await sdk.backups.importApp(appId, db, template, opts)
   } else {
+    const usersTable = {
+      ...USERS_TABLE_SCHEMA,
+      schema: {
+        ...USERS_TABLE_SCHEMA.schema,
+        roleId: {
+          ...USERS_TABLE_SCHEMA.schema.roleId,
+          constraints: {
+            ...USERS_TABLE_SCHEMA.schema.roleId.constraints,
+            inclusion: [
+              roles.BUILTIN_ROLE_IDS.ADMIN,
+              roles.BUILTIN_ROLE_IDS.BASIC,
+              roles.BUILTIN_ROLE_IDS.PUBLIC,
+            ],
+          },
+        },
+      },
+    }
     // create the users table
-    await db.put(USERS_TABLE_SCHEMA)
+    await db.put(usersTable)
   }
 
   return { _id: appId }

--- a/packages/server/src/api/routes/tests/role.spec.ts
+++ b/packages/server/src/api/routes/tests/role.spec.ts
@@ -1,5 +1,9 @@
 import { db as dbCore, events, roles } from "@budibase/backend-core"
-import { BuiltinPermissionID, PermissionLevel } from "@budibase/types"
+import {
+  BuiltinPermissionID,
+  PermissionLevel,
+  type Workspace,
+} from "@budibase/types"
 import * as setup from "./utilities"
 
 const { basicRole } = setup.structures
@@ -9,6 +13,21 @@ const LOOP_ERROR = "Role inheritance contains a loop, this is not supported"
 
 describe("/roles", () => {
   let config = setup.getConfig()
+
+  const setWorkspaceCreationVersion = async (version: string) => {
+    const workspaceIds = [
+      config.getDevWorkspaceId(),
+      config.getProdWorkspaceId(),
+    ]
+    for (const workspaceId of workspaceIds) {
+      const db = dbCore.getDB(workspaceId)
+      const metadata = await db.get<Workspace>(
+        dbCore.DocumentType.WORKSPACE_METADATA
+      )
+      metadata.creationVersion = version
+      await db.put(metadata)
+    }
+  }
 
   afterAll(setup.afterAll)
 
@@ -197,22 +216,58 @@ describe("/roles", () => {
       })
       expect(updatedRes.permissionId).toEqual(BuiltinPermissionID.READ_ONLY)
     })
+
+    it("handles stale revisions when updating inheritance and preserves permissions", async () => {
+      const inheritedRole = await config.api.roles.save({
+        ...basicRole(),
+        name: "inherited_role",
+      })
+      const parentRole = await config.api.roles.save({
+        ...basicRole(),
+        name: "parent_role",
+        inherits: [BUILTIN_ROLE_IDS.BASIC, inheritedRole._id!],
+      })
+      const staleParentRole = {
+        ...parentRole,
+        inherits: [BUILTIN_ROLE_IDS.BASIC],
+      }
+
+      const table = await config.createTable()
+      await config.api.permission.add({
+        roleId: parentRole._id!,
+        resourceId: table._id!,
+        level: PermissionLevel.READ,
+      })
+
+      const updatedRole = await config.api.roles.save(staleParentRole, {
+        status: 200,
+      })
+      expect(updatedRole.inherits).toEqual([BUILTIN_ROLE_IDS.BASIC])
+
+      const fetchedRole = await config.api.roles.find(parentRole._id!, {
+        status: 200,
+      })
+      expect(fetchedRole.permissions[table._id!]).toEqual([
+        PermissionLevel.READ,
+      ])
+    })
   })
 
   describe("fetch", () => {
     beforeAll(async () => {
       // Recreate the app
       await config.newTenant()
+      await setWorkspaceCreationVersion("3.0.0")
     })
 
-    it("should list custom roles, plus 2 default roles", async () => {
+    it("should list custom roles and not include POWER in new workspaces", async () => {
       const customRole = await config.createRole()
 
       const res = await config.api.roles.fetch({
         status: 200,
       })
 
-      expect(res.length).toBe(5)
+      expect(res.length).toBe(4)
 
       const adminRole = res.find(r => r._id === BUILTIN_ROLE_IDS.ADMIN)
       expect(adminRole).toBeDefined()
@@ -220,9 +275,7 @@ describe("/roles", () => {
       expect(adminRole!.permissionId).toEqual(BuiltinPermissionID.ADMIN)
 
       const powerUserRole = res.find(r => r._id === BUILTIN_ROLE_IDS.POWER)
-      expect(powerUserRole).toBeDefined()
-      expect(powerUserRole!.inherits).toEqual(BUILTIN_ROLE_IDS.BASIC)
-      expect(powerUserRole!.permissionId).toEqual(BuiltinPermissionID.POWER)
+      expect(powerUserRole).toBeUndefined()
 
       const customRoleFetched = res.find(r => r._id === customRole.name)
       expect(customRoleFetched).toBeDefined()
@@ -290,6 +343,7 @@ describe("/roles", () => {
     beforeAll(async () => {
       // new app, reset roles
       await config.newTenant()
+      await setWorkspaceCreationVersion("3.0.0")
       // create one custom role
       await config.createRole()
     })
@@ -299,7 +353,7 @@ describe("/roles", () => {
         const res = await config.api.roles.accessible({
           status: 200,
         })
-        expect(res.length).toBe(5)
+        expect(res.length).toBe(4)
         expect(typeof res[0]).toBe("string")
       })
     })
@@ -393,7 +447,7 @@ describe("/roles", () => {
         const res = await config.api.roles.accessible({
           status: 200,
         })
-        expect(res).toEqual([role3, role1, "BASIC", "PUBLIC", role2, "POWER"])
+        expect(res).toEqual([role3, role1, "BASIC", "PUBLIC", role2])
       })
     })
   })


### PR DESCRIPTION
## Description
Fixes custom role regressions introduced while addressing the role editor issues.

This PR:
- Prevents new non-import workspaces from including `POWER` in users-table role inclusion by default (so `POWER` does not unexpectedly reappear when creating custom roles).
- Preserves legacy imported-workspace `POWER` behavior (avoids regression of issue #18228).
- Fixes stale `_rev` role update conflicts and preserves existing role permissions when updating inheritance.
- Adds/updates role API test coverage for modern workspace behavior and stale revision updates.

## Addresses
- https://github.com/Budibase/budibase/issues/18361

## Launchcontrol
Improves custom role reliability by preventing unexpected `POWER` role behavior in new workspaces, preserving legacy imports, and preventing inheritance updates from failing with document conflicts.
