### PR TITLE
Fix issue with pdf parse on non AVX NAS CPUs

### DIFF
--- a/packages/server/src/sdk/workspace/ai/rag/files.lazyImport.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/files.lazyImport.spec.ts
@@ -1,0 +1,36 @@
+describe("rag files lazy imports", () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it("does not load pdf-parse when the module is imported", () => {
+    jest.doMock("pdf-parse", () => {
+      throw new Error("pdf-parse should not be loaded eagerly")
+    })
+
+    jest.doMock("../vectorDb/utils", () => ({
+      createVectorDb: jest.fn(),
+    }))
+
+    jest.doMock("ai", () => ({
+      tool: jest.fn(),
+      embedMany: jest.fn(),
+    }))
+
+    jest.doMock("../llm", () => ({
+      createLLM: jest.fn(),
+    }))
+
+    jest.doMock("..", () => ({
+      knowledgeBase: {
+        find: jest.fn(),
+      },
+    }))
+
+    expect(() => {
+      jest.isolateModules(() => {
+        require("./files")
+      })
+    }).not.toThrow()
+  })
+})

--- a/packages/server/src/sdk/workspace/ai/rag/files.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/files.ts
@@ -1,6 +1,5 @@
 import { embedMany } from "ai"
 import * as crypto from "crypto"
-import { PDFParse } from "pdf-parse"
 import { parse as parseYaml } from "yaml"
 import {
   AgentMessageRagSource,
@@ -37,6 +36,16 @@ const textFileExtensions = new Set([
 ])
 
 const yamlExtensions = new Set([".yaml", ".yml"])
+
+let pdfParsePromise: Promise<typeof import("pdf-parse")> | undefined
+
+const getPdfParse = async () => {
+  if (!pdfParsePromise) {
+    pdfParsePromise = import("pdf-parse")
+  }
+
+  return await pdfParsePromise
+}
 
 const hashChunk = (chunk: string) => {
   return crypto.createHash("sha256").update(chunk).digest("hex")
@@ -253,6 +262,7 @@ const getTextFromBuffer = async (
   file: Pick<RagFileInput, "filename" | "mimetype">
 ) => {
   if (isPdfFile(file)) {
+    const { PDFParse } = await getPdfParse()
     const parser = new PDFParse({ data: buffer as any })
     const parsed = await parser.getText()
     return (parsed.text || "").trim()


### PR DESCRIPTION
## Description
https://github.com/Budibase/budibase/discussions/17921

Reasonably speculative fix for the above issue. Looks like pdf parse pulls in something called `@napi-rs/canvas` which breaks old Intel NAS CPU builds. 

lazy load pdf-parse here so users don't run into this issue. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-loads `pdf-parse` in RAG file processing so it only loads when parsing PDFs, preventing crashes on non‑AVX NAS CPUs. PDF parsing behavior is unchanged.

- **Bug Fixes**
  - Replaced eager import with a memoized dynamic import (`getPdfParse()`) to avoid pulling in `@napi-rs/canvas` on module load.
  - Added `files.lazyImport.spec.ts` to ensure importing `./files` does not load `pdf-parse` eagerly.

<sup>Written for commit dec6b1797f111c5c8755d479975bcc7254a6c485. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

