### PR TITLE
Track agent and table unpublished changes in publish UI

### DIFF
--- a/packages/builder/src/components/common/PublishMenu.svelte
+++ b/packages/builder/src/components/common/PublishMenu.svelte
@@ -15,11 +15,7 @@
     appStore,
   } from "@/stores/builder"
   import { agentsStore, featureFlags } from "@/stores/portal"
-  import {
-    FeatureFlag,
-    PluginType,
-    type Plugin,
-  } from "@budibase/types"
+  import { FeatureFlag, PluginType, type Plugin } from "@budibase/types"
   import type { PopoverAPI } from "@budibase/bbui"
 
   let actionMenu: any
@@ -118,8 +114,9 @@
   ).length
   $: tableCount = Object.keys($workspaceDeploymentStore.tables).length
   $: agentChanges = $featureFlags[FeatureFlag.AI_AGENTS]
-    ? $agentsStore.agents.filter(agent => agent.publishStatus.unpublishedChanges)
-        .length
+    ? $agentsStore.agents.filter(
+        agent => agent.publishStatus.unpublishedChanges
+      ).length
     : 0
   $: changeCount =
     automationChanges + workspaceAppChanges + tableChanges + agentChanges

--- a/packages/builder/src/components/common/PublishMenu.svelte
+++ b/packages/builder/src/components/common/PublishMenu.svelte
@@ -11,10 +11,15 @@
     deploymentStore,
     automationStore,
     workspaceAppStore,
+    workspaceDeploymentStore,
     appStore,
   } from "@/stores/builder"
   import { agentsStore, featureFlags } from "@/stores/portal"
-  import { FeatureFlag, PluginType, type Plugin } from "@budibase/types"
+  import {
+    FeatureFlag,
+    PluginType,
+    type Plugin,
+  } from "@budibase/types"
   import type { PopoverAPI } from "@budibase/bbui"
 
   let actionMenu: any
@@ -108,7 +113,16 @@
   $: workspaceAppChanges = $workspaceAppStore.workspaceApps.filter(
     workspaceApp => workspaceApp.publishStatus?.unpublishedChanges
   ).length
-  $: changeCount = automationChanges + workspaceAppChanges
+  $: tableChanges = Object.values($workspaceDeploymentStore.tables).filter(
+    table => table.unpublishedChanges
+  ).length
+  $: tableCount = Object.keys($workspaceDeploymentStore.tables).length
+  $: agentChanges = $featureFlags[FeatureFlag.AI_AGENTS]
+    ? $agentsStore.agents.filter(agent => agent.publishStatus.unpublishedChanges)
+        .length
+    : 0
+  $: changeCount =
+    automationChanges + workspaceAppChanges + tableChanges + agentChanges
   $: publishButtonText =
     changeCount > 0 ? `Publish changes (${changeCount})` : "Publish"
 </script>
@@ -145,6 +159,10 @@
       {/if}
       {#if $workspaceAppStore.workspaceApps.length}
         Apps published: {$workspaceAppStore.workspaceApps.length}
+        <br />
+      {/if}
+      {#if tableCount}
+        Tables published: {tableCount}
         <br />
       {/if}
       {#if $featureFlags[FeatureFlag.AI_AGENTS] && $agentsStore.agents.length}

--- a/packages/builder/src/components/common/PublishMenu.svelte
+++ b/packages/builder/src/components/common/PublishMenu.svelte
@@ -17,6 +17,7 @@
   import { agentsStore, featureFlags } from "@/stores/portal"
   import { FeatureFlag, PluginType, type Plugin } from "@budibase/types"
   import type { PopoverAPI } from "@budibase/bbui"
+  import { getPublishButtonText, getPublishChangeCount } from "./publishChanges"
 
   let actionMenu: any
   let publishPopoverAnchor: HTMLElement | undefined
@@ -103,25 +104,15 @@
     await publishWithoutChecks()
   }
 
-  $: automationChanges = $automationStore.automations.filter(
-    automation => automation.publishStatus?.unpublishedChanges
-  ).length
-  $: workspaceAppChanges = $workspaceAppStore.workspaceApps.filter(
-    workspaceApp => workspaceApp.publishStatus?.unpublishedChanges
-  ).length
-  $: tableChanges = Object.values($workspaceDeploymentStore.tables).filter(
-    table => table.unpublishedChanges
-  ).length
   $: tableCount = Object.keys($workspaceDeploymentStore.tables).length
-  $: agentChanges = $featureFlags[FeatureFlag.AI_AGENTS]
-    ? $agentsStore.agents.filter(
-        agent => agent.publishStatus.unpublishedChanges
-      ).length
-    : 0
-  $: changeCount =
-    automationChanges + workspaceAppChanges + tableChanges + agentChanges
-  $: publishButtonText =
-    changeCount > 0 ? `Publish changes (${changeCount})` : "Publish"
+  $: changeCount = getPublishChangeCount({
+    automations: $automationStore.automations,
+    workspaceApps: $workspaceAppStore.workspaceApps,
+    tables: $workspaceDeploymentStore.tables,
+    agents: $agentsStore.agents,
+    agentsEnabled: $featureFlags[FeatureFlag.AI_AGENTS],
+  })
+  $: publishButtonText = getPublishButtonText(changeCount)
 </script>
 
 <div

--- a/packages/builder/src/components/common/PublishMenu.svelte
+++ b/packages/builder/src/components/common/PublishMenu.svelte
@@ -106,10 +106,10 @@
 
   $: tableCount = Object.keys($workspaceDeploymentStore.tables).length
   $: changeCount = getPublishChangeCount({
-    automations: $automationStore.automations,
-    workspaceApps: $workspaceAppStore.workspaceApps,
+    automations: $workspaceDeploymentStore.automations,
+    workspaceApps: $workspaceDeploymentStore.workspaceApps,
     tables: $workspaceDeploymentStore.tables,
-    agents: $agentsStore.agents,
+    agents: $workspaceDeploymentStore.agents,
     agentsEnabled: $featureFlags[FeatureFlag.AI_AGENTS],
   })
   $: publishButtonText = getPublishButtonText(changeCount)

--- a/packages/builder/src/components/common/publishChanges.test.ts
+++ b/packages/builder/src/components/common/publishChanges.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest"
+
+import { getPublishButtonText, getPublishChangeCount } from "./publishChanges"
+
+describe("publishChanges", () => {
+  it("counts unpublished changes across deployment status maps", () => {
+    const changeCount = getPublishChangeCount({
+      automations: {
+        auto_1: { unpublishedChanges: true },
+        auto_2: { unpublishedChanges: false },
+      },
+      workspaceApps: {
+        app_1: { unpublishedChanges: true },
+      },
+      tables: {
+        table_1: { unpublishedChanges: true },
+        table_2: { unpublishedChanges: false },
+      },
+      agents: {
+        agent_1: { unpublishedChanges: true },
+      },
+      agentsEnabled: true,
+    })
+
+    expect(changeCount).toBe(4)
+  })
+
+  it("ignores agent changes when agents are disabled", () => {
+    const changeCount = getPublishChangeCount({
+      automations: {
+        auto_1: { unpublishedChanges: true },
+      },
+      workspaceApps: {
+        app_1: { unpublishedChanges: true },
+      },
+      tables: {
+        table_1: { unpublishedChanges: true },
+      },
+      agents: {
+        agent_1: { unpublishedChanges: true },
+      },
+      agentsEnabled: false,
+    })
+
+    expect(changeCount).toBe(3)
+  })
+
+  it("counts unpublished changes for deleted resources represented in status maps", () => {
+    const changeCount = getPublishChangeCount({
+      automations: {
+        deleted_automation: { unpublishedChanges: true },
+      },
+      workspaceApps: {},
+      tables: {},
+      agents: {},
+      agentsEnabled: true,
+    })
+
+    expect(changeCount).toBe(1)
+  })
+
+  it("builds publish button text from the change count", () => {
+    expect(getPublishButtonText(0)).toBe("Publish")
+    expect(getPublishButtonText(2)).toBe("Publish changes (2)")
+  })
+})

--- a/packages/builder/src/components/common/publishChanges.ts
+++ b/packages/builder/src/components/common/publishChanges.ts
@@ -1,29 +1,18 @@
 interface UnpublishedResource {
-  publishStatus?: {
-    unpublishedChanges?: boolean
-  }
-  disabled?: boolean
-  live?: boolean
-}
-
-interface UnpublishedTable {
   unpublishedChanges?: boolean
 }
 
 interface PublishChangeCountParams {
-  automations: UnpublishedResource[]
-  workspaceApps: UnpublishedResource[]
-  tables: Record<string, UnpublishedTable>
-  agents: UnpublishedResource[]
+  automations: Record<string, UnpublishedResource>
+  workspaceApps: Record<string, UnpublishedResource>
+  tables: Record<string, UnpublishedResource>
+  agents: Record<string, UnpublishedResource>
   agentsEnabled: boolean
 }
 
-const countUnpublishedResources = (resources: UnpublishedResource[]) =>
-  resources.filter(resource => resource.publishStatus?.unpublishedChanges)
-    .length
-
-const countUnpublishedTables = (tables: Record<string, UnpublishedTable>) =>
-  Object.values(tables).filter(table => table.unpublishedChanges).length
+const countUnpublishedResources = (
+  resources: Record<string, UnpublishedResource>
+) => Object.values(resources).filter(resource => resource.unpublishedChanges).length
 
 export const getPublishChangeCount = ({
   automations,
@@ -34,7 +23,7 @@ export const getPublishChangeCount = ({
 }: PublishChangeCountParams) => {
   const automationChanges = countUnpublishedResources(automations)
   const workspaceAppChanges = countUnpublishedResources(workspaceApps)
-  const tableChanges = countUnpublishedTables(tables)
+  const tableChanges = countUnpublishedResources(tables)
   const agentChanges = agentsEnabled ? countUnpublishedResources(agents) : 0
 
   return automationChanges + workspaceAppChanges + tableChanges + agentChanges

--- a/packages/builder/src/components/common/publishChanges.ts
+++ b/packages/builder/src/components/common/publishChanges.ts
@@ -12,7 +12,9 @@ interface PublishChangeCountParams {
 
 const countUnpublishedResources = (
   resources: Record<string, UnpublishedResource>
-) => Object.values(resources).filter(resource => resource.unpublishedChanges).length
+) =>
+  Object.values(resources).filter(resource => resource.unpublishedChanges)
+    .length
 
 export const getPublishChangeCount = ({
   automations,

--- a/packages/builder/src/components/common/publishChanges.ts
+++ b/packages/builder/src/components/common/publishChanges.ts
@@ -1,0 +1,44 @@
+interface UnpublishedResource {
+  publishStatus?: {
+    unpublishedChanges?: boolean
+  }
+  disabled?: boolean
+  live?: boolean
+}
+
+interface UnpublishedTable {
+  unpublishedChanges?: boolean
+}
+
+interface PublishChangeCountParams {
+  automations: UnpublishedResource[]
+  workspaceApps: UnpublishedResource[]
+  tables: Record<string, UnpublishedTable>
+  agents: UnpublishedResource[]
+  agentsEnabled: boolean
+}
+
+const countUnpublishedResources = (resources: UnpublishedResource[]) =>
+  resources.filter(resource => resource.publishStatus?.unpublishedChanges)
+    .length
+
+const countUnpublishedTables = (tables: Record<string, UnpublishedTable>) =>
+  Object.values(tables).filter(table => table.unpublishedChanges).length
+
+export const getPublishChangeCount = ({
+  automations,
+  workspaceApps,
+  tables,
+  agents,
+  agentsEnabled,
+}: PublishChangeCountParams) => {
+  const automationChanges = countUnpublishedResources(automations)
+  const workspaceAppChanges = countUnpublishedResources(workspaceApps)
+  const tableChanges = countUnpublishedTables(tables)
+  const agentChanges = agentsEnabled ? countUnpublishedResources(agents) : 0
+
+  return automationChanges + workspaceAppChanges + tableChanges + agentChanges
+}
+
+export const getPublishButtonText = (changeCount: number) =>
+  changeCount > 0 ? `Publish changes (${changeCount})` : "Publish"

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
@@ -61,12 +61,19 @@
     try {
       togglingLive = true
 
-      await agentsStore.updateAgent({
-        ...currentAgent,
-        ...agentUpdateOverrides,
-        live: nextLive,
-      })
-      await deploymentStore.publishApp()
+      await agentsStore.updateAgent(
+        {
+          ...currentAgent,
+          ...agentUpdateOverrides,
+          live: nextLive,
+        },
+        {
+          markUnpublishedChanges: false,
+        }
+      )
+      if (nextLive) {
+        await deploymentStore.publishApp()
+      }
       await agentsStore.fetchAgents()
 
       notifications.success(

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
@@ -602,12 +602,6 @@ Any constraints the agent must follow.
   }) {
     if (!currentAgent) return
     if (saving) return
-    if (!draft.aiconfig) {
-      if (showNotifications) {
-        notifications.error("Please select an AI model")
-      }
-      return
-    }
 
     saving = true
     try {

--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/rows.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/rows.spec.ts
@@ -1,7 +1,7 @@
 import {
   WorkspaceResource,
-  type Agent,
   type HomeRow,
+  type UIAgent,
   type WorkspaceFavourite,
 } from "@budibase/types"
 import { sortHomeRows } from "./rows"
@@ -36,7 +36,7 @@ const buildAgentRow = ({
   live: true,
   updatedAt,
   createdAt,
-  resource: {} as Agent,
+  resource: {} as UIAgent,
   favourite: buildFavourite(id, favouriteId),
   icon: "sparkle",
   iconColor: "#BDB0F5",

--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/rows.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/rows.ts
@@ -1,12 +1,12 @@
 import {
   WorkspaceResource,
-  type Agent,
   type HomeRow,
   type HomeRowType,
   type HomeSortColumn,
   type HomeSortOrder,
   type HomeType,
   type UIAutomation,
+  type UIAgent,
   type UIWorkspaceApp,
   type WorkspaceFavourite,
 } from "@budibase/types"
@@ -15,7 +15,7 @@ import { getAgentStatusLabel, getPublishResourceStatusLabel } from "./status"
 interface BuildHomeRowsParams {
   apps: UIWorkspaceApp[]
   automations: UIAutomation[]
-  agents: Agent[]
+  agents: UIAgent[]
   agentsEnabled: boolean
   getFavourite: (
     resourceType: WorkspaceResource,

--- a/packages/builder/src/stores/builder/automations.ts
+++ b/packages/builder/src/stores/builder/automations.ts
@@ -2530,6 +2530,7 @@ const automationActions = (store: AutomationStore) => ({
   },
 
   delete: async (automation: Automation) => {
+    const automationId = automation._id
     const isRowAction = sdk.automations.isRowAction(automation)
     if (isRowAction) {
       const rowAction = automation.definition.trigger as RowActionTrigger
@@ -2551,7 +2552,10 @@ const automationActions = (store: AutomationStore) => ({
       }
       return state
     })
-    await deploymentStore.publishApp()
+
+    if (automationId) {
+      workspaceDeploymentStore.setAutomationUnpublishedChanges(automationId)
+    }
   },
 
   /**

--- a/packages/builder/src/stores/builder/tables.ts
+++ b/packages/builder/src/stores/builder/tables.ts
@@ -13,6 +13,7 @@ import { get, derived, Writable } from "svelte/store"
 import { cloneDeep } from "lodash/fp"
 import { API } from "@/api"
 import { DerivedBudiStore } from "@/stores/BudiStore"
+import { workspaceDeploymentStore } from "./workspaceDeployment"
 
 function pickFallbackDisplayField(
   draft: SaveTableRequest,
@@ -132,6 +133,7 @@ export class TableStore extends DerivedBudiStore<
     }
 
     const savedTable = await API.saveTable(updatedTable)
+    workspaceDeploymentStore.setTableUnpublishedChanges(savedTable._id!)
     this.replaceTable(savedTable._id, savedTable)
     this.select(savedTable._id)
     // make sure tables up to date (related)
@@ -161,11 +163,13 @@ export class TableStore extends DerivedBudiStore<
 
   async delete(table: { _id: string; _rev: string }) {
     await API.deleteTable(table._id, table._rev)
+    workspaceDeploymentStore.setTableUnpublishedChanges(table._id)
     this.replaceTable(table._id, null)
   }
 
   async duplicate(tableId: string) {
     const duplicatedTable = await API.duplicateTable(tableId)
+    workspaceDeploymentStore.setTableUnpublishedChanges(duplicatedTable._id!)
     this.replaceTable(duplicatedTable._id, duplicatedTable)
     this.select(duplicatedTable._id)
     return duplicatedTable

--- a/packages/builder/src/stores/builder/workspaceApps.ts
+++ b/packages/builder/src/stores/builder/workspaceApps.ts
@@ -160,10 +160,7 @@ export class WorkspaceAppStore extends DerivedBudiStore<
         workspaceApps: state.workspaceApps.filter(app => app._id !== id),
       }
     })
-
-    const { deploymentStore } = await import("./deployment")
-
-    await deploymentStore.publishApp()
+    workspaceDeploymentStore.setWorkspaceAppUnpublishedChanges(id)
     appStore.refresh()
   }
 

--- a/packages/builder/src/stores/builder/workspaceDeployment.ts
+++ b/packages/builder/src/stores/builder/workspaceDeployment.ts
@@ -6,20 +6,23 @@ interface WorkspaceDeploymentStoreState extends PublishStatusResponse {}
 
 export class WorkspaceDeploymentStore extends BudiStore<WorkspaceDeploymentStoreState> {
   constructor() {
-    super({ automations: {}, workspaceApps: {}, tables: {} })
+    super({ agents: {}, automations: {}, workspaceApps: {}, tables: {} })
 
     this.fetch = this.fetch.bind(this)
     this.reset = this.reset.bind(this)
+    this.setAgentUnpublishedChanges = this.setAgentUnpublishedChanges.bind(this)
     this.setAutomationUnpublishedChanges =
       this.setAutomationUnpublishedChanges.bind(this)
+    this.setTableUnpublishedChanges = this.setTableUnpublishedChanges.bind(this)
     this.setWorkspaceAppUnpublishedChanges =
       this.setWorkspaceAppUnpublishedChanges.bind(this)
   }
 
   async fetch() {
-    const { automations, workspaceApps, tables } =
+    const { agents, automations, workspaceApps, tables } =
       await API.deployment.getPublishStatus()
     this.store.update(state => {
+      state.agents = agents
       state.automations = automations
       state.workspaceApps = workspaceApps
       state.tables = tables
@@ -28,7 +31,21 @@ export class WorkspaceDeploymentStore extends BudiStore<WorkspaceDeploymentStore
   }
 
   reset() {
-    this.store.set({ automations: {}, workspaceApps: {}, tables: {} })
+    this.store.set({ agents: {}, automations: {}, workspaceApps: {}, tables: {} })
+  }
+
+  setAgentUnpublishedChanges(agentId: string) {
+    this.store.update(state => {
+      if (!state.agents[agentId]) {
+        state.agents[agentId] = {
+          published: false,
+          name: "Agent",
+          state: PublishResourceState.DISABLED,
+        }
+      }
+      state.agents[agentId].unpublishedChanges = true
+      return state
+    })
   }
 
   setAutomationUnpublishedChanges(automationId: string) {
@@ -41,6 +58,20 @@ export class WorkspaceDeploymentStore extends BudiStore<WorkspaceDeploymentStore
         }
       }
       state.automations[automationId].unpublishedChanges = true
+      return state
+    })
+  }
+
+  setTableUnpublishedChanges(tableId: string) {
+    this.store.update(state => {
+      if (!state.tables[tableId]) {
+        state.tables[tableId] = {
+          published: false,
+          name: "Table",
+          state: PublishResourceState.DISABLED,
+        }
+      }
+      state.tables[tableId].unpublishedChanges = true
       return state
     })
   }

--- a/packages/builder/src/stores/builder/workspaceDeployment.ts
+++ b/packages/builder/src/stores/builder/workspaceDeployment.ts
@@ -31,7 +31,12 @@ export class WorkspaceDeploymentStore extends BudiStore<WorkspaceDeploymentStore
   }
 
   reset() {
-    this.store.set({ agents: {}, automations: {}, workspaceApps: {}, tables: {} })
+    this.store.set({
+      agents: {},
+      automations: {},
+      workspaceApps: {},
+      tables: {},
+    })
   }
 
   setAgentUnpublishedChanges(agentId: string) {

--- a/packages/builder/src/stores/portal/agents.ts
+++ b/packages/builder/src/stores/portal/agents.ts
@@ -137,6 +137,7 @@ export class AgentsStore extends BudiStore<AgentStoreState> {
 
   deleteAgent = async (agentId: string) => {
     await API.deleteAgent(agentId)
+    workspaceDeploymentStore.setAgentUnpublishedChanges(agentId)
     await this.fetchAgents()
   }
 

--- a/packages/builder/src/stores/portal/agents.ts
+++ b/packages/builder/src/stores/portal/agents.ts
@@ -149,8 +149,8 @@ export class AgentsStore extends BudiStore<AgentStoreState> {
     agentId: string,
     body?: SyncAgentDiscordCommandsRequest
   ): Promise<SyncAgentDiscordCommandsResponse> =>
-    await this.runAndRefreshAgents(() =>
-      API.syncAgentDiscordCommands(agentId, body),
+    await this.runAndRefreshAgents(
+      () => API.syncAgentDiscordCommands(agentId, body),
       agentId
     )
 
@@ -158,8 +158,8 @@ export class AgentsStore extends BudiStore<AgentStoreState> {
     agentId: string,
     body?: ProvisionAgentMSTeamsChannelRequest
   ): Promise<ProvisionAgentMSTeamsChannelResponse> =>
-    await this.runAndRefreshAgents(() =>
-      API.provisionAgentMSTeamsChannel(agentId, body),
+    await this.runAndRefreshAgents(
+      () => API.provisionAgentMSTeamsChannel(agentId, body),
       agentId
     )
 
@@ -167,26 +167,26 @@ export class AgentsStore extends BudiStore<AgentStoreState> {
     agentId: string,
     body?: ProvisionAgentSlackChannelRequest
   ): Promise<ProvisionAgentSlackChannelResponse> =>
-    await this.runAndRefreshAgents(() =>
-      API.provisionAgentSlackChannel(agentId, body),
+    await this.runAndRefreshAgents(
+      () => API.provisionAgentSlackChannel(agentId, body),
       agentId
     )
 
   toggleDiscordDeployment = async (agentId: string, enabled: boolean) =>
-    await this.runAndRefreshAgents(() =>
-      API.toggleAgentDiscordDeployment(agentId, enabled),
+    await this.runAndRefreshAgents(
+      () => API.toggleAgentDiscordDeployment(agentId, enabled),
       agentId
     )
 
   toggleMSTeamsDeployment = async (agentId: string, enabled: boolean) =>
-    await this.runAndRefreshAgents(() =>
-      API.toggleAgentMSTeamsDeployment(agentId, enabled),
+    await this.runAndRefreshAgents(
+      () => API.toggleAgentMSTeamsDeployment(agentId, enabled),
       agentId
     )
 
   toggleSlackDeployment = async (agentId: string, enabled: boolean) =>
-    await this.runAndRefreshAgents(() =>
-      API.toggleAgentSlackDeployment(agentId, enabled),
+    await this.runAndRefreshAgents(
+      () => API.toggleAgentSlackDeployment(agentId, enabled),
       agentId
     )
 }

--- a/packages/builder/src/stores/portal/agents.ts
+++ b/packages/builder/src/stores/portal/agents.ts
@@ -1,25 +1,42 @@
 import { API } from "@/api"
 import { BudiStore } from "../BudiStore"
+import { workspaceDeploymentStore } from "@/stores/builder/workspaceDeployment"
 import {
   Agent,
   CreateAgentRequest,
+  PublishResourceState,
+  PublishStatusResource,
   ProvisionAgentSlackChannelRequest,
   ProvisionAgentSlackChannelResponse,
   ProvisionAgentMSTeamsChannelRequest,
   ProvisionAgentMSTeamsChannelResponse,
   SyncAgentDiscordCommandsRequest,
   SyncAgentDiscordCommandsResponse,
+  UIAgent,
   UpdateAgentRequest,
   ToolMetadata,
 } from "@budibase/types"
-import { derived } from "svelte/store"
+import { derived, get } from "svelte/store"
 
 interface AgentStoreState {
-  agents: Agent[]
+  agents: UIAgent[]
   currentAgentId?: string
   tools: ToolMetadata[]
   agentsLoaded: boolean
 }
+
+const getAgentPublishStatus = (agent: Agent): PublishStatusResource =>
+  get(workspaceDeploymentStore).agents[agent._id!] || {
+    published: false,
+    name: agent.name,
+    state: PublishResourceState.DISABLED,
+    unpublishedChanges: true,
+  }
+
+const withPublishStatus = (agent: Agent): UIAgent => ({
+  ...agent,
+  publishStatus: getAgentPublishStatus(agent),
+})
 
 export class AgentsStore extends BudiStore<AgentStoreState> {
   constructor() {
@@ -27,6 +44,13 @@ export class AgentsStore extends BudiStore<AgentStoreState> {
       agents: [],
       tools: [],
       agentsLoaded: false,
+    })
+
+    workspaceDeploymentStore.subscribe(() => {
+      this.update(state => {
+        state.agents = state.agents.map(withPublishStatus)
+        return state
+      })
     })
   }
 
@@ -37,11 +61,11 @@ export class AgentsStore extends BudiStore<AgentStoreState> {
   fetchAgents = async () => {
     const { agents } = await API.fetchAgents()
     this.update(state => {
-      state.agents = agents
+      state.agents = agents.map(withPublishStatus)
       state.agentsLoaded = true
       return state
     })
-    return agents
+    return agents.map(withPublishStatus)
   }
 
   selectAgent = async (agentId: string | undefined) => {
@@ -70,32 +94,38 @@ export class AgentsStore extends BudiStore<AgentStoreState> {
 
   createAgent = async (agent: CreateAgentRequest) => {
     const created = await API.createAgent(agent)
+    workspaceDeploymentStore.setAgentUnpublishedChanges(created._id!)
+    const createdWithPublishStatus = withPublishStatus(created)
     this.update(state => {
-      state.agents = [...state.agents, created]
+      state.agents = [...state.agents, createdWithPublishStatus]
       return state
     })
-    return created
+    return createdWithPublishStatus
   }
 
   updateAgent = async (agent: UpdateAgentRequest) => {
     const updated = await API.updateAgent(agent)
+    workspaceDeploymentStore.setAgentUnpublishedChanges(updated._id!)
+    const updatedWithPublishStatus = withPublishStatus(updated)
     this.update(state => {
       const index = state.agents.findIndex(a => a._id === updated._id)
       if (index !== -1) {
-        state.agents[index] = updated
+        state.agents[index] = updatedWithPublishStatus
       }
       return state
     })
-    return updated
+    return updatedWithPublishStatus
   }
 
   duplicateAgent = async (agentId: string) => {
     const duplicated = await API.duplicateAgent(agentId)
+    workspaceDeploymentStore.setAgentUnpublishedChanges(duplicated._id!)
+    const duplicatedWithPublishStatus = withPublishStatus(duplicated)
     this.update(state => {
-      state.agents = [...state.agents, duplicated]
+      state.agents = [...state.agents, duplicatedWithPublishStatus]
       return state
     })
-    return duplicated
+    return duplicatedWithPublishStatus
   }
 
   deleteAgent = async (agentId: string) => {
@@ -104,9 +134,13 @@ export class AgentsStore extends BudiStore<AgentStoreState> {
   }
 
   private runAndRefreshAgents = async <T>(
-    action: () => Promise<T>
+    action: () => Promise<T>,
+    agentId?: string
   ): Promise<T> => {
     const result = await action()
+    if (agentId) {
+      workspaceDeploymentStore.setAgentUnpublishedChanges(agentId)
+    }
     await this.fetchAgents()
     return result
   }
@@ -116,7 +150,8 @@ export class AgentsStore extends BudiStore<AgentStoreState> {
     body?: SyncAgentDiscordCommandsRequest
   ): Promise<SyncAgentDiscordCommandsResponse> =>
     await this.runAndRefreshAgents(() =>
-      API.syncAgentDiscordCommands(agentId, body)
+      API.syncAgentDiscordCommands(agentId, body),
+      agentId
     )
 
   provisionMSTeamsChannel = async (
@@ -124,7 +159,8 @@ export class AgentsStore extends BudiStore<AgentStoreState> {
     body?: ProvisionAgentMSTeamsChannelRequest
   ): Promise<ProvisionAgentMSTeamsChannelResponse> =>
     await this.runAndRefreshAgents(() =>
-      API.provisionAgentMSTeamsChannel(agentId, body)
+      API.provisionAgentMSTeamsChannel(agentId, body),
+      agentId
     )
 
   provisionSlackChannel = async (
@@ -132,22 +168,26 @@ export class AgentsStore extends BudiStore<AgentStoreState> {
     body?: ProvisionAgentSlackChannelRequest
   ): Promise<ProvisionAgentSlackChannelResponse> =>
     await this.runAndRefreshAgents(() =>
-      API.provisionAgentSlackChannel(agentId, body)
+      API.provisionAgentSlackChannel(agentId, body),
+      agentId
     )
 
   toggleDiscordDeployment = async (agentId: string, enabled: boolean) =>
     await this.runAndRefreshAgents(() =>
-      API.toggleAgentDiscordDeployment(agentId, enabled)
+      API.toggleAgentDiscordDeployment(agentId, enabled),
+      agentId
     )
 
   toggleMSTeamsDeployment = async (agentId: string, enabled: boolean) =>
     await this.runAndRefreshAgents(() =>
-      API.toggleAgentMSTeamsDeployment(agentId, enabled)
+      API.toggleAgentMSTeamsDeployment(agentId, enabled),
+      agentId
     )
 
   toggleSlackDeployment = async (agentId: string, enabled: boolean) =>
     await this.runAndRefreshAgents(() =>
-      API.toggleAgentSlackDeployment(agentId, enabled)
+      API.toggleAgentSlackDeployment(agentId, enabled),
+      agentId
     )
 }
 export const agentsStore = new AgentsStore()

--- a/packages/builder/src/stores/portal/agents.ts
+++ b/packages/builder/src/stores/portal/agents.ts
@@ -103,9 +103,16 @@ export class AgentsStore extends BudiStore<AgentStoreState> {
     return createdWithPublishStatus
   }
 
-  updateAgent = async (agent: UpdateAgentRequest) => {
+  updateAgent = async (
+    agent: UpdateAgentRequest,
+    opts?: {
+      markUnpublishedChanges?: boolean
+    }
+  ) => {
     const updated = await API.updateAgent(agent)
-    workspaceDeploymentStore.setAgentUnpublishedChanges(updated._id!)
+    if (opts?.markUnpublishedChanges !== false) {
+      workspaceDeploymentStore.setAgentUnpublishedChanges(updated._id!)
+    }
     const updatedWithPublishStatus = withPublishStatus(updated)
     this.update(state => {
       const index = state.agents.findIndex(a => a._id === updated._id)

--- a/packages/server/src/api/controllers/deploy/index.ts
+++ b/packages/server/src/api/controllers/deploy/index.ts
@@ -264,9 +264,11 @@ export async function deploymentProgress(
 }
 
 export async function publishStatus(ctx: UserCtx<void, PublishStatusResponse>) {
-  const { automations, workspaceApps, tables } = await sdk.deployment.status()
+  const { agents, automations, workspaceApps, tables } =
+    await sdk.deployment.status()
 
   ctx.body = {
+    agents,
     automations,
     workspaceApps,
     tables,
@@ -462,10 +464,11 @@ export const publishWorkspaceInternal = async (
         deployment.appUrl = appDoc.url
         appDoc.appId = prodId
         appDoc.instance._id = prodId
-        const [automations, workspaceApps, tables] = await Promise.all([
+        const [automations, workspaceApps, tables, agents] = await Promise.all([
           sdk.automations.fetch(),
           sdk.workspaceApps.fetch(),
           sdk.tables.getAllInternalTables(),
+          sdk.ai.agents.fetch(),
         ])
         const tablesMarkedForPublish =
           restrictToTables && tablesToPublish
@@ -480,15 +483,21 @@ export const publishWorkspaceInternal = async (
           .filter(app => app.disabled !== true)
           .map(app => app._id!)
         const tableIds = tablesMarkedForPublish.map(table => table._id!)
+        const agentIds = agents.map(agent => agent._id!)
+        const deployedAgentIds = agents
+          .filter(agent => agent.live === true)
+          .map(agent => agent._id!)
         const fullMap = [
           ...(automationIds ?? []),
           ...(workspaceAppIds ?? []),
           ...(tableIds ?? []),
+          ...(agentIds ?? []),
         ]
         const deployedMap = [
           ...(deployedAutomationIds ?? []),
           ...(deployedWorkspaceAppIds ?? []),
           ...(tableIds ?? []),
+          ...(deployedAgentIds ?? []),
         ]
         const publishedAt = new Date().toISOString()
         appDoc.resourcesPublishedAt = {

--- a/packages/server/src/api/routes/tests/deploy.spec.ts
+++ b/packages/server/src/api/routes/tests/deploy.spec.ts
@@ -189,6 +189,34 @@ describe("/api/deploy", () => {
       })
     })
 
+    it("returns agent publish status and unpublished changes", async () => {
+      const agent = await config.api.agent.create({
+        name: "Support Agent",
+        aiconfig: "default",
+        live: false,
+      })
+
+      let res = await config.api.deploy.publishStatus()
+      expect(res.agents[agent._id!]).toEqual({
+        published: false,
+        name: agent.name,
+        unpublishedChanges: true,
+        state: "disabled",
+      })
+
+      await config.api.workspace.publish(config.devWorkspace!.appId)
+
+      res = await config.api.deploy.publishStatus()
+      expect(res.agents[agent._id!]).toEqual({
+        publishedAt: expect.any(String),
+        published: true,
+        name: agent.name,
+        unpublishedChanges: false,
+        state: "disabled",
+      })
+      expect(res.agents[agent._id!].lastDeployedLiveAt).toBeUndefined()
+    })
+
     it("handles app with disabled automation/workspace app", async () => {
       const table = await config.api.table.save(basicTable())
 

--- a/packages/server/src/sdk/workspace/deployment/status.ts
+++ b/packages/server/src/sdk/workspace/deployment/status.ts
@@ -1,5 +1,6 @@
 import { context } from "@budibase/backend-core"
 import {
+  Agent,
   Automation,
   PublishResourceState,
   PublishStatusResource,
@@ -26,30 +27,36 @@ export async function status() {
   const productionExists =
     await sdk.workspaces.isWorkspacePublished(prodWorkspaceId)
   type State = {
+    agents: Agent[]
     automations: Automation[]
     workspaceApps: WorkspaceApp[]
     screens: Screen[]
     tables: Table[]
   }
   const developmentState: State = {
+    agents: [],
     automations: [],
     workspaceApps: [],
     screens: [],
     tables: [],
   }
   const productionState: State = {
+    agents: [],
     automations: [],
     workspaceApps: [],
     screens: [],
     tables: [],
   }
   const updateState = async (state: State) => {
-    const [automations, workspaceApps, screens, tables] = await Promise.all([
-      sdk.automations.fetch(),
-      sdk.workspaceApps.fetch(),
-      sdk.screens.fetch(),
-      sdk.tables.getAllInternalTables(),
-    ])
+    const [agents, automations, workspaceApps, screens, tables] =
+      await Promise.all([
+        sdk.ai.agents.fetch(),
+        sdk.automations.fetch(),
+        sdk.workspaceApps.fetch(),
+        sdk.screens.fetch(),
+        sdk.tables.getAllInternalTables(),
+      ])
+    state.agents = agents
     state.automations = automations
     state.workspaceApps = workspaceApps
     state.screens = screens
@@ -76,6 +83,7 @@ export async function status() {
     productionState.workspaceApps.map(w => w._id)
   )
   const prodTableIds = new Set(productionState.tables.map(t => t._id))
+  const prodAgentIds = new Set(productionState.agents.map(agent => agent._id))
 
   const processResource = (
     map: Record<string, PublishStatusResource>,
@@ -137,5 +145,15 @@ export async function status() {
     }
   }
 
-  return { automations, workspaceApps, tables }
+  const agents: Record<string, PublishStatusResource> = {}
+  for (const agent of developmentState.agents) {
+    processResource(agents, prodAgentIds, {
+      _id: agent._id,
+      name: agent.name,
+      updatedAt: agent.updatedAt,
+      disabled: agent.live !== true,
+    })
+  }
+
+  return { agents, automations, workspaceApps, tables }
 }

--- a/packages/types/src/api/web/workspace/deployment.ts
+++ b/packages/types/src/api/web/workspace/deployment.ts
@@ -26,6 +26,7 @@ export interface PublishStatusResponse {
   workspaceApps: Record<string, PublishStatusResource>
   automations: Record<string, PublishStatusResource>
   tables: Record<string, PublishStatusResource>
+  agents: Record<string, PublishStatusResource>
 }
 
 export interface DeploymentProgressResponse {

--- a/packages/types/src/ui/agents.ts
+++ b/packages/types/src/ui/agents.ts
@@ -1,4 +1,5 @@
-import { ToolMetadata } from "../documents"
+import { PublishStatusResource } from "../api"
+import { Agent, ToolMetadata } from "../documents"
 
 export interface EnrichedTool extends ToolMetadata {
   readableBinding: string
@@ -14,4 +15,8 @@ export interface DeploymentRow {
   status: "Enabled" | "Disabled"
   details: string
   configurable?: boolean
+}
+
+export interface UIAgent extends Agent {
+  publishStatus: PublishStatusResource
 }

--- a/packages/types/src/ui/home/types.ts
+++ b/packages/types/src/ui/home/types.ts
@@ -1,5 +1,6 @@
 import type { PublishResourceState } from "../../api"
-import type { Agent, WorkspaceFavourite } from "../../documents"
+import type { WorkspaceFavourite } from "../../documents"
+import type { UIAgent } from "../agents"
 import type { UIAutomation } from "../stores/automations"
 import type { UIWorkspaceApp } from "../workspaceApps"
 
@@ -35,7 +36,7 @@ export interface AutomationRow extends HomeRowBase {
 
 export interface AgentRow extends HomeRowBase {
   type: "agent"
-  resource: Agent
+  resource: UIAgent
   live: boolean
 }
 


### PR DESCRIPTION
## Description
Add agents and tables to publish changes count.

## Screenshots
<img width="275" height="163" alt="publish" src="https://github.com/user-attachments/assets/970df0ac-21d4-4343-bfcc-aa5de58510eb" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds agents and tables to the publish changes flow. The menu and backend now count their unpublished changes and include agent publish status; stopping a live agent no longer clears "Published changes". Deleted resources are tracked so counts persist and reset correctly.

- **New Features**
  - Publish menu counts automations, apps, tables, and agents from `workspaceDeploymentStore`; button text uses a shared helper; counts include deleted resources.
  - Shows tables published total; shows agent totals when `FeatureFlag.AI_AGENTS` is enabled.
  - Backend `publishStatus` includes `agents`; publish flow records agent published/deployed state; UI uses `UIAgent` with `publishStatus` synced to `workspaceDeploymentStore`.

- **Bug Fixes**
  - Stopping a live agent no longer removes "Published changes"; enabling live triggers a publish, disabling does not mark changes.
  - Deleting resources marks unpublished changes instead of triggering publish; publish-change state resets correctly.

<sup>Written for commit 1310631537491ecac81268b9dea46f317378eeb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

