### PR TITLE
Fix unable to dismiss automation errors on workspace home

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/home/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/index.svelte
@@ -577,6 +577,19 @@
     goto(url(`../automation/${automationId}`))
   }
 
+  const dismissAutomationError = async (automationId: string) => {
+    try {
+      await automationStore.actions.clearLogErrors({
+        automationId,
+        appId: $appStore.appId,
+      })
+      await appsStore.load()
+    } catch (err) {
+      console.error(err)
+      notifications.error("Error dismissing automation error")
+    }
+  }
+
   const automationErrorMessage = (
     automationName: string | undefined,
     errorCount: number
@@ -648,6 +661,7 @@
               entry.automation?.name,
               entry.errorCount
             )}
+            on:dismiss={() => dismissAutomationError(entry.automationId)}
           />
         {/each}
       </div>


### PR DESCRIPTION
## Description
Fixes an issue where automation error notifications on the workspace home page could not be dismissed. The notification close (`X`) now clears the automation error state and refreshes app metadata so the banner is removed immediately and stays cleared.

## Addresses
- https://github.com/Budibase/budibase/issues/18387

## Launchcontrol
Allows builders to dismiss automation error notifications from the workspace home page as expected.

