### PR TITLE
Pin CouchDB image npm to 11.11.1

### DIFF
--- a/hosting/couchdb/Dockerfile
+++ b/hosting/couchdb/Dockerfile
@@ -79,8 +79,8 @@ RUN set -eux; \
 # apt clean-up
     rm -rf /var/lib/apt/lists/*;
 
-# Upgrade npm to pick up patched transitive dependencies (tar, minimatch, glob).
-RUN npm install -g npm@latest && npm cache clean --force
+# Pin npm to avoid regressions in npm@latest during image builds.
+RUN npm install -g npm@10.9.7 && npm cache clean --force
 
 # Add configuration
 COPY --chown=couchdb:couchdb couch/10-docker-default.ini /opt/couchdb/etc/default.d/

--- a/hosting/couchdb/Dockerfile
+++ b/hosting/couchdb/Dockerfile
@@ -79,7 +79,7 @@ RUN set -eux; \
 # apt clean-up
     rm -rf /var/lib/apt/lists/*;
 
-# Pin npm to avoid regressions in npm@latest during image builds.
+# Upgrade npm to pick up patched transitive dependencies (tar, minimatch, glob).
 RUN npm install -g npm@11.11.1 && npm cache clean --force
 
 # Add configuration

--- a/hosting/couchdb/Dockerfile
+++ b/hosting/couchdb/Dockerfile
@@ -80,7 +80,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*;
 
 # Pin npm to avoid regressions in npm@latest during image builds.
-RUN npm install -g npm@10.9.7 && npm cache clean --force
+RUN npm install -g npm@11.11.1 && npm cache clean --force
 
 # Add configuration
 COPY --chown=couchdb:couchdb couch/10-docker-default.ini /opt/couchdb/etc/default.d/


### PR DESCRIPTION
## Description
Pin npm in the CouchDB Docker base image to `10.9.7` to avoid CI failures caused by `npm@latest` resolving to a version that fails to self-install (`Cannot find module 'promise-retry'`).

## Addresses
- https://github.com/Budibase/budibase/actions/runs/23548470559/job/68557499062?pr=18394

## App Export
- Not applicable.

## Screenshots
- Not applicable (CI/build infrastructure change).

## Launchcontrol
Stabilizes Docker image builds by pinning npm to a known working version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `npm` to `11.11.1` in the CouchDB Docker image to stabilize builds and prevent CI failures. This avoids `npm@latest` regressions that break self-install (`Cannot find module 'promise-retry'`).

<sup>Written for commit 6a26c6eaa719f833483c3928dc8ba7686d61dbf5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

