### PR TITLE
fix: context to formatter

### DIFF
--- a/packages/client/src/components/app/GridBlock.svelte
+++ b/packages/client/src/components/app/GridBlock.svelte
@@ -180,7 +180,7 @@
         order: idx,
         visible: !!column.active,
         conditions: enrichGridConditions(column.conditions, context),
-        format: createFormatter(column),
+        format: createFormatter(column, context),
 
         // Small hack to ensure we react to all changes, as our
         // memoization cannot compare differences in functions
@@ -193,11 +193,12 @@
     return overrides
   }
 
-  const createFormatter = column => {
+  const createFormatter = (column, context) => {
     if (typeof column.format !== "string" || !column.format.trim().length) {
       return null
     }
-    return row => processStringSync(column.format, { [id]: row })
+    const snippets = context?.snippets
+    return row => processStringSync(column.format, { [id]: row, snippets })
   }
 
   const enrichButtons = buttons => {


### PR DESCRIPTION
## Description

* grid rows didn't have the app context so they couldnt pass snippets to the string formater

## Addresses
Fixes  #17267 
