### PR TITLE
Remove codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,0 @@
-/packages/server         @Budibase/backend
-/packages/worker         @Budibase/backend
-/packages/backend-core   @Budibase/backend


### PR DESCRIPTION
## Description
Remove codeowners file, as this does not make much sense given the current file structure

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the CODEOWNERS file to stop auto-assigning `@Budibase/backend` for changes in `/packages/server`, `/packages/worker`, and `/packages/backend-core`. Reviewers will now follow repo defaults or be assigned manually.

<sup>Written for commit 276ab1d6ab9c6d0537cea94f6bde4514378e9330. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

