### PR TITLE
Rename automation trigger "User action" to "On demand"

### DIFF
--- a/packages/shared-core/src/automations/triggers/app.ts
+++ b/packages/shared-core/src/automations/triggers/app.ts
@@ -8,11 +8,11 @@ import {
 } from "@budibase/types"
 
 export const definition: AutomationTriggerDefinition = {
-  name: "User action",
+  name: "On demand",
   event: AutomationEventType.APP_TRIGGER,
   icon: "cursor-click",
-  tagline: "Automation fired from the frontend",
-  description: "Trigger an automation from an action inside your app",
+  tagline: "Automation runs when invoked",
+  description: "Runs when invoked by a user or agent.",
   stepId: AutomationTriggerStepId.APP,
   inputs: {},
   schema: {


### PR DESCRIPTION
## Description
Rename the APP automation trigger label in the UI-facing definition from `User action` to `On demand`, and update supporting copy to match the new invocation model across user and agent flows.

## Addresses
- https://github.com/Budibase/budibase/issues/18422

## App Export
- Not required for this change (copy-only update).

## Screenshots
- Not included (string-only UI copy change).

## Launchcontrol
Renames the automation trigger previously shown as "User action" to "On demand" and updates helper text so it is clearer this trigger is invoked explicitly by a user or an agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the app automation trigger from "User action" to "On demand" to align with the new invocation model. Updated the tagline and description so it’s clear the trigger runs only when invoked by a user or an agent.

Changes in `packages/shared-core/src/automations/triggers/app.ts`: updated `name`, `tagline`, and `description`.

<sup>Written for commit e693143d25deda35cc749a1f928dbaa8144e5e69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

