### PR TITLE
Fix/no auto commit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,10 @@
   this can be used to access the test API under `new TestConfiguration().api`, a list of functions and
   request/response types can be found in `packages/server/src/tests/utilities/api`.
 
+## Git commit
+
+Only commit changes when explicitly asked to do so.
+
 ## Pull requests
 
 - Always respect the format of pull_request_template.md. Some sections may not

--- a/packages/backend-core/src/users/db.ts
+++ b/packages/backend-core/src/users/db.ts
@@ -48,11 +48,13 @@ type GroupUpdateFn = (groupId: string, userIds: string[]) => Promise<any>
 type FeatureFn = () => Promise<Boolean>
 type GroupGetFn = (ids: string[]) => Promise<UserGroup[]>
 type GroupBuildersFn = (user: User) => Promise<string[]>
+type GetDefaultGroupFn = () => Promise<UserGroup | undefined>
 type QuotaFns = { addUsers: QuotaUpdateFn; removeUsers: QuotaUpdateFn }
 type GroupFns = {
   addUsers: GroupUpdateFn
   getBulk: GroupGetFn
   getGroupBuilderAppIds: GroupBuildersFn
+  getDefaultGroup?: GetDefaultGroupFn
 }
 type CreateAdminUserOpts = {
   password?: string
@@ -307,14 +309,21 @@ export class UserDB {
 
       // make sure we set the _id field for a new user
       // Also if this is a new user, associate groups with them
+      let groupIdsToAssign = [...userGroups]
+      if (isNewUser && groupIdsToAssign.length === 0) {
+        const defaultGroup = await UserDB.groups.getDefaultGroup?.()
+        if (defaultGroup?._id) {
+          groupIdsToAssign = [defaultGroup._id]
+        }
+      }
+
       const groupPromises = []
-      if (!_id) {
-        if (userGroups.length > 0) {
-          for (let groupId of userGroups) {
-            groupPromises.push(
-              UserDB.groups.addUsers(groupId, [builtUser._id!])
-            )
-          }
+      if (isNewUser) {
+        if (groupIdsToAssign.length > 0) {
+          builtUser.userGroups = groupIdsToAssign
+        }
+        for (let groupId of groupIdsToAssign) {
+          groupPromises.push(UserDB.groups.addUsers(groupId, [builtUser._id!]))
         }
       }
 
@@ -364,6 +373,13 @@ export class UserDB {
     const emails = newUsersRequested.map((user: User) => user.email)
     const existingEmails = await searchExistingEmails(emails)
     const unsuccessful: { email: string; reason: string }[] = []
+    let groupIdsToAssign = groups && groups.length ? [...groups] : []
+    if (!groupIdsToAssign.length) {
+      const defaultGroup = await UserDB.groups.getDefaultGroup?.()
+      if (defaultGroup?._id) {
+        groupIdsToAssign = [defaultGroup._id]
+      }
+    }
 
     for (const newUser of newUsersRequested) {
       const duplicateUser = newUsers.find(
@@ -374,7 +390,7 @@ export class UserDB {
         unsuccessful.push({ email: newUser.email, reason: `Unavailable` })
         continue
       }
-      newUser.userGroups = groups || []
+      newUser.userGroups = [...groupIdsToAssign]
       newUsers.push(newUser)
       if (await isCreatorAsync(newUser)) {
         newCreators.push(newUser)
@@ -423,10 +439,10 @@ export class UserDB {
         })
 
         // now update the groups
-        if (Array.isArray(saved) && groups) {
+        if (Array.isArray(saved) && groupIdsToAssign.length) {
           const groupPromises = []
           const createdUserIds = saved.map(user => user._id!)
-          for (let groupId of groups) {
+          for (let groupId of groupIdsToAssign) {
             groupPromises.push(UserDB.groups.addUsers(groupId, createdUserIds))
           }
           await Promise.all(groupPromises)

--- a/packages/backend-core/src/users/test/db.spec.ts
+++ b/packages/backend-core/src/users/test/db.spec.ts
@@ -1,6 +1,7 @@
-import { BulkUserCreated, User, UserStatus } from "@budibase/types"
+import { BulkUserCreated, User, UserGroup, UserStatus } from "@budibase/types"
 import { DBTestConfiguration, generator, structures } from "../../../tests"
 import * as accounts from "../../accounts"
+import { getGlobalDB } from "../../context"
 import { withEnv } from "../../environment"
 import { UserDB } from "../db"
 import { searchExistingEmails } from "../lookup"
@@ -27,6 +28,7 @@ const groups = {
   addUsers: jest.fn(),
   getBulk: jest.fn(),
   getGroupBuilderAppIds: jest.fn(),
+  getDefaultGroup: jest.fn(),
 }
 const features = { isSSOEnforced: jest.fn() }
 
@@ -37,6 +39,7 @@ describe("UserDB", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    groups.getDefaultGroup.mockResolvedValue(undefined)
   })
 
   describe("save", () => {
@@ -95,6 +98,51 @@ describe("UserDB", () => {
             `Email already in use: '${email}'`
           )
         )
+      })
+
+      it("auto-assigns the default group when none is provided", async () => {
+        const defaultGroupId = `group_${generator.guid()}`
+        groups.getDefaultGroup.mockResolvedValue({ _id: defaultGroupId })
+
+        const user: User = structures.users.user({
+          email: generator.email({}),
+          tenantId: config.getTenantId(),
+        })
+        delete user.userGroups
+
+        await config.doInTenant(async () => {
+          const saved = await db.save(user)
+
+          expect(groups.addUsers).toHaveBeenCalledWith(defaultGroupId, [
+            saved._id!,
+          ])
+          const persistedUser = await db.getUser(saved._id!)
+          expect(persistedUser?.userGroups).toEqual([defaultGroupId])
+        })
+      })
+
+      it("uses explicit groups over default assignment", async () => {
+        const defaultGroupId = `group_${generator.guid()}`
+        const explicitGroupId = `group_${generator.guid()}`
+        groups.getDefaultGroup.mockResolvedValue({ _id: defaultGroupId })
+
+        const user: User = structures.users.user({
+          email: generator.email({}),
+          tenantId: config.getTenantId(),
+          userGroups: [explicitGroupId],
+        })
+
+        await config.doInTenant(async () => {
+          const saved = await db.save(user)
+
+          expect(groups.getDefaultGroup).not.toHaveBeenCalled()
+          expect(groups.addUsers).toHaveBeenCalledWith(explicitGroupId, [
+            saved._id!,
+          ])
+          expect(groups.addUsers).not.toHaveBeenCalledWith(defaultGroupId, [
+            saved._id!,
+          ])
+        })
       })
     })
 
@@ -216,6 +264,45 @@ describe("UserDB", () => {
   })
 
   describe("bulkCreate", () => {
+    it("auto-assigns the default group during bulk create when no groups are provided", async () => {
+      features.isSSOEnforced.mockResolvedValue(false)
+      const defaultGroupId = `group_${generator.guid()}`
+      const defaultGroup: UserGroup = {
+        ...structures.userGroups.userGroup(),
+        _id: defaultGroupId,
+      }
+      groups.getDefaultGroup.mockResolvedValue(defaultGroup)
+
+      await config.doInTenant(async () => {
+        await getGlobalDB().put(defaultGroup)
+
+        const users: User[] = [
+          structures.users.user({
+            email: generator.email({}),
+            password: "validPassword123!",
+            tenantId: config.getTenantId(),
+          }),
+          structures.users.user({
+            email: generator.email({}),
+            password: "validPassword456!",
+            tenantId: config.getTenantId(),
+          }),
+        ]
+
+        const result = await db.bulkCreate(users)
+        const createdUserIds = result.successful.map(user => user._id!)
+        const createdUsers = await db.bulkGet(createdUserIds)
+
+        expect(groups.addUsers).toHaveBeenCalledWith(
+          defaultGroupId,
+          expect.arrayContaining(createdUserIds)
+        )
+        expect(
+          createdUsers.every(user => user.userGroups?.includes(defaultGroupId))
+        ).toBe(true)
+      })
+    })
+
     describe("when SSO is NOT enforced", () => {
       beforeEach(() => {
         features.isSSOEnforced.mockResolvedValue(false)

--- a/packages/builder/src/settings/pages/people/groups/_components/CreateEditGroupModal.spec.ts
+++ b/packages/builder/src/settings/pages/people/groups/_components/CreateEditGroupModal.spec.ts
@@ -5,6 +5,7 @@ import MockColorPicker from "@/test/mocks/MockColorPicker.svelte"
 import MockIconPicker from "@/test/mocks/MockIconPicker.svelte"
 import MockInput from "@/test/mocks/MockInput.svelte"
 import MockModalContent from "@/test/mocks/MockModalContent.svelte"
+import MockToggle from "@/test/mocks/MockToggle.svelte"
 
 vi.mock("@budibase/bbui", () => ({
   keepOpen: Symbol("keepOpen"),
@@ -13,6 +14,7 @@ vi.mock("@budibase/bbui", () => ({
   ModalContent: MockModalContent,
   Input: MockInput,
   IconPicker: MockIconPicker,
+  Toggle: MockToggle,
 }))
 
 import CreateEditGroupModal from "./CreateEditGroupModal.svelte"
@@ -41,6 +43,9 @@ describe("CreateEditGroupModal", () => {
     expect(screen.getByLabelText("Name")).toBeDisabled()
     expect(screen.getByLabelText("Icon")).not.toBeDisabled()
     expect(screen.getByLabelText("Color")).not.toBeDisabled()
+    expect(
+      screen.getByLabelText("Make this the default group")
+    ).not.toBeDisabled()
   })
 
   it("allows non-scim groups to edit all exposed fields", () => {
@@ -54,5 +59,8 @@ describe("CreateEditGroupModal", () => {
     expect(screen.getByLabelText("Name")).not.toBeDisabled()
     expect(screen.getByLabelText("Icon")).not.toBeDisabled()
     expect(screen.getByLabelText("Color")).not.toBeDisabled()
+    expect(
+      screen.getByLabelText("Make this the default group")
+    ).not.toBeDisabled()
   })
 })

--- a/packages/builder/src/settings/pages/people/groups/_components/CreateEditGroupModal.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/CreateEditGroupModal.svelte
@@ -6,6 +6,7 @@
     ModalContent,
     Input,
     IconPicker,
+    Toggle,
   } from "@budibase/bbui"
 
   export let group
@@ -34,6 +35,9 @@
     error={nameError}
     disabled={readonlyTitle}
   />
+  <div class="toggle-row">
+    <Toggle bind:value={group.isDefault} text="Make this the default group" />
+  </div>
   <div class="modal-format">
     <div class="modal-inner">
       <Body size="XS">Icon</Body>
@@ -61,6 +65,9 @@
     display: flex;
     justify-content: space-between;
     width: 40%;
+  }
+  .toggle-row {
+    margin-top: var(--spacing-s);
   }
 
   .modal-inner {

--- a/packages/builder/src/settings/pages/people/groups/_components/GroupNameTableRenderer.spec.ts
+++ b/packages/builder/src/settings/pages/people/groups/_components/GroupNameTableRenderer.spec.ts
@@ -41,4 +41,18 @@ describe("GroupNameTableRenderer", () => {
 
     expect(screen.queryByTestId("sync-badge")).not.toBeInTheDocument()
   })
+
+  it("shows a default badge for default groups", () => {
+    render(GroupNameTableRenderer, {
+      props: {
+        value: "Default group",
+        row: {
+          name: "Default group",
+          isDefault: true,
+        },
+      },
+    })
+
+    expect(screen.getByText("Default")).toBeInTheDocument()
+  })
 })

--- a/packages/builder/src/settings/pages/people/groups/_components/GroupNameTableRenderer.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/GroupNameTableRenderer.svelte
@@ -15,6 +15,9 @@
   {:else}
     <div class="text">-</div>
   {/if}
+  {#if row.isDefault}
+    <div class="default-badge">Default</div>
+  {/if}
   {#if row.scimInfo?.isSync}
     <ActiveDirectoryInfo iconSize="XS" />
   {/if}
@@ -34,5 +37,16 @@
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+  }
+  .default-badge {
+    color: var(--spectrum-global-color-static-white);
+    background: var(--primary-500);
+    border-radius: 6px;
+    padding: 2px 8px;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    width: fit-content;
+    flex-shrink: 0;
   }
 </style>

--- a/packages/builder/src/settings/pages/people/groups/group.svelte
+++ b/packages/builder/src/settings/pages/people/groups/group.svelte
@@ -9,6 +9,7 @@
     Pagination,
     Search,
     Table,
+    Toggle,
     notifications,
   } from "@budibase/bbui"
   import ConfirmDialog from "@/components/common/ConfirmDialog.svelte"
@@ -47,6 +48,7 @@
   let workspaceSearch
   let workspacePageNumber = 0
   let previousWorkspaceSearch
+  let defaultUpdating = false
   const WORKSPACE_PAGE_SIZE = 3
 
   $: group = $groups.find(x => x._id === groupId)
@@ -163,6 +165,23 @@
     }
   }
 
+  async function updateDefaultStatus(isDefault) {
+    if (!group?._id || group?.isDefault === isDefault || defaultUpdating) {
+      return
+    }
+    try {
+      defaultUpdating = true
+      await groups.save({ ...group, isDefault })
+      notifications.success(
+        isDefault ? "Default group updated" : "Default group removed"
+      )
+    } catch (error) {
+      notifications.error(error?.message || "Failed to update default group")
+    } finally {
+      defaultUpdating = false
+    }
+  }
+
   const removeApp = async app => {
     try {
       await groups.removeApp(groupId, app)
@@ -200,27 +219,40 @@
     <div class="header">
       <GroupIcon {group} size="M" />
       <Heading size="S">{group?.name}</Heading>
-      <ActionMenu align="right">
-        <span slot="control">
-          <Icon hoverable name="dots-three" />
-        </span>
-        <MenuItem
-          icon="pencil"
-          on:click={() => editModal.show()}
-          disabled={!isAdmin}
+      <div class="header-actions">
+        <div
+          class="default-toggle"
+          title={isScimGroup && "Group synced from your AD"}
         >
-          Edit
-        </MenuItem>
-        <div title={isScimGroup && "Group synced from your AD"}>
-          <MenuItem
-            icon="trash"
-            on:click={() => deleteModal.show()}
-            disabled={readonly}
-          >
-            Delete
-          </MenuItem>
+          <Toggle
+            value={!!group?.isDefault}
+            disabled={readonly || defaultUpdating}
+            on:change={e => updateDefaultStatus(e.detail)}
+          />
+          <span class="default-toggle-label">Default</span>
         </div>
-      </ActionMenu>
+        <ActionMenu align="right">
+          <span slot="control">
+            <Icon hoverable name="dots-three" />
+          </span>
+          <MenuItem
+            icon="pencil"
+            on:click={() => editModal.show()}
+            disabled={!isAdmin}
+          >
+            Edit
+          </MenuItem>
+          <div title={isScimGroup && "Group synced from your AD"}>
+            <MenuItem
+              icon="trash"
+              on:click={() => deleteModal.show()}
+              disabled={readonly}
+            >
+              Delete
+            </MenuItem>
+          </div>
+        </ActionMenu>
+      </div>
     </div>
 
     <Layout noPadding gap="S">
@@ -295,7 +327,15 @@
   okText="Delete user group"
   onOk={deleteGroup}
 >
-  Are you sure you wish to delete <b>{group?.name}?</b>
+  {#if group?.isDefault}
+    <p>
+      <b>{group?.name}</b> is the default group. Deleting it will leave new users
+      without automatic group assignment until another default group is set.
+    </p>
+    <p>Are you sure you want to continue?</p>
+  {:else}
+    Are you sure you wish to delete <b>{group?.name}?</b>
+  {/if}
 </ConfirmDialog>
 
 <style>
@@ -308,6 +348,25 @@
   }
   .header :global(.spectrum-Heading) {
     flex: 1 1 auto;
+  }
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-l);
+  }
+  .default-toggle :global(.spectrum-Switch) {
+    display: flex;
+    align-items: center;
+  }
+  .default-toggle {
+    display: flex;
+    align-items: center;
+  }
+  .default-toggle-label {
+    display: flex;
+    align-items: center;
+    line-height: 1;
+    margin-top: 1px;
   }
   .placeholder {
     width: 100%;

--- a/packages/builder/src/settings/pages/people/groups/index.svelte
+++ b/packages/builder/src/settings/pages/people/groups/index.svelte
@@ -25,6 +25,7 @@
     name: "",
     icon: "users",
     color: "var(--spectrum-global-color-blue-600)",
+    isDefault: false,
     users: [],
     roles: {},
   }

--- a/packages/builder/src/settings/pages/people/users/index.svelte
+++ b/packages/builder/src/settings/pages/people/users/index.svelte
@@ -311,7 +311,8 @@
     if (isWorkspaceOnly) {
       const result = await assignExistingUsersToWorkspace(
         userData,
-        currentWorkspaceId
+        currentWorkspaceId,
+        $groups
       )
       usersForInvite = result.usersToInvite
       const shouldShowInviteModal = usersForInvite.length > 0
@@ -411,7 +412,8 @@
       if (isWorkspaceOnly) {
         const result = await assignExistingUsersToWorkspace(
           usersForCreation,
-          currentWorkspaceId
+          currentWorkspaceId,
+          $groups
         )
         usersForCreation = { ...usersForCreation, users: result.usersToInvite }
         addedToWorkspaceEmails = result.addedToWorkspaceEmails

--- a/packages/builder/src/settings/pages/people/users/index.svelte
+++ b/packages/builder/src/settings/pages/people/users/index.svelte
@@ -334,7 +334,8 @@
       usersForInvite,
       userData.groups,
       currentWorkspaceId,
-      assignToWorkspace
+      assignToWorkspace,
+      $groups
     )
     try {
       inviteUsersResponse = await users.invite(payload)
@@ -440,7 +441,9 @@
         const assignmentResult = await assignCreatedUsersToWorkspace(
           bulkSaveResponse.successful,
           usersForCreation.users,
-          currentWorkspaceId
+          currentWorkspaceId,
+          usersForCreation.groups,
+          $groups
         )
         if (assignmentResult.failedCount) {
           notifications.error("Error adding some users to workspace")

--- a/packages/builder/src/settings/pages/people/users/workspaceInviteUtils.spec.ts
+++ b/packages/builder/src/settings/pages/people/users/workspaceInviteUtils.spec.ts
@@ -56,6 +56,29 @@ describe("workspaceInviteUtils", () => {
     ).toBe(false)
   })
 
+  it("does not infer default-group workspace role when default fallback is disabled", () => {
+    expect(
+      shouldUseGroupWorkspaceRole({
+        workspaceId,
+        role: Constants.BudibaseRoles.AppUser,
+        appRole: Constants.Roles.BASIC,
+        allGroups: [
+          {
+            _id: "group_default",
+            isDefault: true,
+            name: "Default",
+            icon: "ri-user-line",
+            color: "#000000",
+            roles: {
+              [workspaceId]: Constants.Roles.ADMIN,
+            },
+          },
+        ],
+        useDefaultGroupFallback: false,
+      })
+    ).toBe(false)
+  })
+
   it("does not set workspace apps payload when group-managed workspace role applies", () => {
     const payload = buildWorkspaceInvitePayload(
       [

--- a/packages/builder/src/settings/pages/people/users/workspaceInviteUtils.spec.ts
+++ b/packages/builder/src/settings/pages/people/users/workspaceInviteUtils.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest"
+import { Constants } from "@budibase/frontend-core"
+import type { UserGroup } from "@budibase/types"
+import {
+  buildWorkspaceInvitePayload,
+  shouldUseGroupWorkspaceRole,
+} from "./workspaceInviteUtils"
+
+describe("workspaceInviteUtils", () => {
+  const workspaceId = "workspace_123"
+
+  it("uses group workspace role for app users with basic role when default group controls the workspace", () => {
+    const allGroups: UserGroup[] = [
+      {
+        _id: "group_default",
+        isDefault: true,
+        name: "Default",
+        icon: "ri-user-line",
+        color: "#000000",
+        roles: {
+          [workspaceId]: Constants.Roles.ADMIN,
+        },
+      },
+    ]
+
+    expect(
+      shouldUseGroupWorkspaceRole({
+        workspaceId,
+        role: Constants.BudibaseRoles.AppUser,
+        appRole: Constants.Roles.BASIC,
+        allGroups,
+      })
+    ).toBe(true)
+  })
+
+  it("does not use group workspace role when non-basic app role is selected", () => {
+    expect(
+      shouldUseGroupWorkspaceRole({
+        workspaceId,
+        role: Constants.BudibaseRoles.AppUser,
+        appRole: Constants.Roles.ADMIN,
+        selectedGroupIds: ["group_default"],
+        allGroups: [
+          {
+            _id: "group_default",
+            isDefault: true,
+            name: "Default",
+            icon: "ri-user-line",
+            color: "#000000",
+            roles: {
+              [workspaceId]: Constants.Roles.ADMIN,
+            },
+          },
+        ],
+      })
+    ).toBe(false)
+  })
+
+  it("does not set workspace apps payload when group-managed workspace role applies", () => {
+    const payload = buildWorkspaceInvitePayload(
+      [
+        {
+          email: "group-user@test.com",
+          role: Constants.BudibaseRoles.AppUser,
+          appRole: Constants.Roles.BASIC,
+          password: "password",
+        },
+      ],
+      [],
+      workspaceId,
+      true,
+      [
+        {
+          _id: "group_default",
+          isDefault: true,
+          name: "Default",
+          icon: "ri-user-line",
+          color: "#000000",
+          roles: {
+            [workspaceId]: Constants.Roles.ADMIN,
+          },
+        },
+      ]
+    )
+
+    expect(payload[0].apps).toBeUndefined()
+  })
+
+  it("sets workspace apps payload when no group controls the workspace", () => {
+    const payload = buildWorkspaceInvitePayload(
+      [
+        {
+          email: "basic-user@test.com",
+          role: Constants.BudibaseRoles.AppUser,
+          appRole: Constants.Roles.BASIC,
+          password: "password",
+        },
+      ],
+      [],
+      workspaceId,
+      true,
+      []
+    )
+
+    expect(payload[0].apps).toEqual({ [workspaceId]: Constants.Roles.BASIC })
+  })
+})

--- a/packages/builder/src/settings/pages/people/users/workspaceInviteUtils.ts
+++ b/packages/builder/src/settings/pages/people/users/workspaceInviteUtils.ts
@@ -1,7 +1,7 @@
 import { users } from "@/stores/portal/users"
 import type { UserInfo } from "@/types"
 import { Constants } from "@budibase/frontend-core"
-import type { User } from "@budibase/types"
+import type { User, UserGroup } from "@budibase/types"
 import { getRoleFlags, shouldSyncGlobalRole } from "./roleUtils"
 
 export interface UserData {
@@ -52,10 +52,19 @@ export const buildWorkspaceInvitePayload = (
   usersForInvite: UserInfo[],
   groups: string[],
   workspaceId: string,
-  assignToWorkspace = true
+  assignToWorkspace = true,
+  allGroups: UserGroup[] = []
 ): InvitePayloadUser[] => {
   return usersForInvite.map(user => {
-    const workspaceRole = getWorkspaceRole(workspaceId, user.role, user.appRole)
+    const workspaceRole = shouldUseGroupWorkspaceRole({
+      workspaceId,
+      role: user.role,
+      appRole: user.appRole,
+      selectedGroupIds: groups,
+      allGroups,
+    })
+      ? undefined
+      : getWorkspaceRole(workspaceId, user.role, user.appRole)
     return {
       email: user.email,
       builder: user.role === Constants.BudibaseRoles.Developer,
@@ -88,6 +97,56 @@ export const getWorkspaceRole = (
     return appRole || Constants.Roles.BASIC
   }
   return Constants.Roles.BASIC
+}
+
+interface ShouldUseGroupWorkspaceRoleParams {
+  workspaceId: string
+  role?: string
+  appRole?: string
+  selectedGroupIds?: string[]
+  allGroups?: UserGroup[]
+}
+
+const getEffectiveGroupIds = (
+  selectedGroupIds: string[] = [],
+  allGroups: UserGroup[] = []
+) => {
+  if (selectedGroupIds.length) {
+    return selectedGroupIds
+  }
+  const defaultGroupId = allGroups.find(group => group.isDefault)?._id
+  return defaultGroupId ? [defaultGroupId] : []
+}
+
+export const shouldUseGroupWorkspaceRole = ({
+  workspaceId,
+  role,
+  appRole,
+  selectedGroupIds = [],
+  allGroups = [],
+}: ShouldUseGroupWorkspaceRoleParams) => {
+  if (role !== Constants.BudibaseRoles.AppUser) {
+    return false
+  }
+
+  if (!workspaceId) {
+    return false
+  }
+
+  if (appRole && appRole !== Constants.Roles.BASIC) {
+    return false
+  }
+
+  const effectiveGroupIds = getEffectiveGroupIds(selectedGroupIds, allGroups)
+  if (!effectiveGroupIds.length) {
+    return false
+  }
+
+  return effectiveGroupIds.some(groupId => {
+    return !!allGroups.find(group => {
+      return group._id === groupId && group.roles?.[workspaceId]
+    })
+  })
 }
 
 export const assignExistingUsersToWorkspace = async (
@@ -181,7 +240,9 @@ export const assignExistingUsersToWorkspace = async (
 export const assignCreatedUsersToWorkspace = async (
   createdUsers: WorkspaceCreatedUser[],
   sourceUsers: UserInfo[],
-  workspaceId: string
+  workspaceId: string,
+  selectedGroupIds: string[] = [],
+  allGroups: UserGroup[] = []
 ): Promise<WorkspaceCreatedUserResult> => {
   if (!workspaceId || !createdUsers.length) {
     return {
@@ -207,6 +268,16 @@ export const assignCreatedUsersToWorkspace = async (
         matchingUser?.role,
         matchingUser?.appRole
       )
+      const useGroupWorkspaceRole = shouldUseGroupWorkspaceRole({
+        workspaceId,
+        role: matchingUser?.role,
+        appRole: matchingUser?.appRole,
+        selectedGroupIds,
+        allGroups,
+      })
+      if (useGroupWorkspaceRole) {
+        return null
+      }
       if (!role) {
         return null
       }

--- a/packages/builder/src/settings/pages/people/users/workspaceInviteUtils.ts
+++ b/packages/builder/src/settings/pages/people/users/workspaceInviteUtils.ts
@@ -105,14 +105,19 @@ interface ShouldUseGroupWorkspaceRoleParams {
   appRole?: string
   selectedGroupIds?: string[]
   allGroups?: UserGroup[]
+  useDefaultGroupFallback?: boolean
 }
 
 const getEffectiveGroupIds = (
   selectedGroupIds: string[] = [],
-  allGroups: UserGroup[] = []
+  allGroups: UserGroup[] = [],
+  useDefaultGroupFallback = true
 ) => {
   if (selectedGroupIds.length) {
     return selectedGroupIds
+  }
+  if (!useDefaultGroupFallback) {
+    return []
   }
   const defaultGroupId = allGroups.find(group => group.isDefault)?._id
   return defaultGroupId ? [defaultGroupId] : []
@@ -124,6 +129,7 @@ export const shouldUseGroupWorkspaceRole = ({
   appRole,
   selectedGroupIds = [],
   allGroups = [],
+  useDefaultGroupFallback = true,
 }: ShouldUseGroupWorkspaceRoleParams) => {
   if (role !== Constants.BudibaseRoles.AppUser) {
     return false
@@ -137,7 +143,11 @@ export const shouldUseGroupWorkspaceRole = ({
     return false
   }
 
-  const effectiveGroupIds = getEffectiveGroupIds(selectedGroupIds, allGroups)
+  const effectiveGroupIds = getEffectiveGroupIds(
+    selectedGroupIds,
+    allGroups,
+    useDefaultGroupFallback
+  )
   if (!effectiveGroupIds.length) {
     return false
   }
@@ -151,7 +161,8 @@ export const shouldUseGroupWorkspaceRole = ({
 
 export const assignExistingUsersToWorkspace = async (
   userData: UserData,
-  workspaceId: string
+  workspaceId: string,
+  allGroups: UserGroup[] = []
 ): Promise<WorkspaceExistingUserResult> => {
   const dedupedUserData = dedupeUsersByEmail(userData)
   if (!workspaceId) {
@@ -168,6 +179,7 @@ export const assignExistingUsersToWorkspace = async (
     existingUsers.map(user => [user.email.toLowerCase(), user])
   )
   const usersToInvite: UserInfo[] = []
+  const groupManagedUsers: string[] = []
   const usersToAssign: {
     user: User
     role: string
@@ -179,6 +191,18 @@ export const assignExistingUsersToWorkspace = async (
     const existingUser = existingByEmail.get(user.email.toLowerCase())
     if (!existingUser) {
       usersToInvite.push(user)
+      continue
+    }
+    const useGroupWorkspaceRole = shouldUseGroupWorkspaceRole({
+      workspaceId,
+      role: user.role,
+      appRole: user.appRole,
+      selectedGroupIds: existingUser.userGroups,
+      allGroups,
+      useDefaultGroupFallback: false,
+    })
+    if (useGroupWorkspaceRole) {
+      groupManagedUsers.push(user.email)
       continue
     }
     const role = getWorkspaceRole(workspaceId, user.role, user.appRole)
@@ -220,12 +244,13 @@ export const assignExistingUsersToWorkspace = async (
     })
   )
 
-  const addedToWorkspaceEmails = assignmentResults
+  const assignedUsers = assignmentResults
     .filter(
       (result): result is PromiseFulfilledResult<string> =>
         result.status === "fulfilled"
     )
     .map(result => result.value)
+  const addedToWorkspaceEmails = [...groupManagedUsers, ...assignedUsers]
 
   return {
     usersToInvite,

--- a/packages/builder/src/stores/portal/groups.ts
+++ b/packages/builder/src/stores/portal/groups.ts
@@ -41,6 +41,14 @@ class GroupStore extends BudiStore<UserGroup[]> {
     const response = await API.saveGroup(dataToSave)
     group._id = response._id
     group._rev = response._rev
+
+    // Setting a default group has side effects on other groups, so refresh all.
+    if (group.isDefault) {
+      const latestGroups = await API.getGroups()
+      this.set(latestGroups)
+      return latestGroups.find(g => g._id === group._id) || group
+    }
+
     this.updateStore(group)
     return group
   }

--- a/packages/builder/src/test/mocks/MockToggle.svelte
+++ b/packages/builder/src/test/mocks/MockToggle.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  export let text = ""
+  export let value = false
+  export let disabled = false
+</script>
+
+<label>
+  <span>{text}</span>
+  <input
+    type="checkbox"
+    aria-label={text}
+    bind:checked={value}
+    {disabled}
+  />
+</label>

--- a/packages/pro/src/db/groups.ts
+++ b/packages/pro/src/db/groups.ts
@@ -155,6 +155,10 @@ async function getAllGroupDocuments() {
   ).rows.map(row => row.doc!)
 }
 
+export async function getAll(): Promise<UserGroup[]> {
+  return getAllGroupDocuments()
+}
+
 export async function fetch(): Promise<EnrichedUserGroup[]> {
   const [groups, appIds] = await Promise.all([
     getAllGroupDocuments(),

--- a/packages/pro/src/sdk/groups/groups.ts
+++ b/packages/pro/src/sdk/groups/groups.ts
@@ -180,6 +180,11 @@ export async function get(id: string) {
   return (await db.groups.get(id)) as UserGroup
 }
 
+export async function getDefaultGroup() {
+  const groups = await db.groups.getAll()
+  return groups.find(group => group.isDefault)
+}
+
 export async function getBulk(
   ids: string[],
   opts: { enriched: true }
@@ -224,6 +229,45 @@ function isCreatorGroup(group: Pick<UserGroup, "roles">) {
   return Object.values(group.roles || {}).includes("CREATOR")
 }
 
+function stripEnrichedFields(group: UserGroup | EnrichedUserGroup): UserGroup {
+  const { users: _users, ...groupDoc } = group
+  return groupDoc
+}
+
+async function saveGroupWithDefaultUpdates(group: UserGroup) {
+  if (!group.isDefault) {
+    return db.groups.save(group)
+  }
+
+  const existingGroups = await db.groups.getAll()
+  const previousDefaultGroups = existingGroups
+    .filter(existing => existing._id !== group._id)
+    .filter(existing => existing.isDefault)
+
+  if (!previousDefaultGroups.length) {
+    return db.groups.save(group)
+  }
+
+  const response = await db.groups.bulkSave([
+    ...previousDefaultGroups.map(existing => ({
+      ...existing,
+      isDefault: false,
+    })),
+    group,
+  ])
+
+  const savedDefaultGroup = response.find(result => result.id === group._id)
+  if (savedDefaultGroup?.rev) {
+    return {
+      id: group._id!,
+      rev: savedDefaultGroup.rev,
+    }
+  }
+
+  const persisted = await db.groups.get(group._id!)
+  return { id: persisted._id!, rev: persisted._rev! }
+}
+
 export async function save(group: UserGroup | EnrichedUserGroup) {
   let eventPromises = []
   // Config does not exist yet
@@ -261,9 +305,9 @@ export async function save(group: UserGroup | EnrichedUserGroup) {
   }
 
   await Promise.all(eventPromises)
-  const { users: _users, ...groupToSave } = group
+  const groupToSave = stripEnrichedFields(group)
   const saveGroup = () => {
-    return db.groups.save(groupToSave)
+    return saveGroupWithDefaultUpdates(groupToSave)
   }
   if (isCreate) {
     return await quotas.addGroup(saveGroup)

--- a/packages/pro/src/sdk/groups/tests/groupsQuotas.spec.ts
+++ b/packages/pro/src/sdk/groups/tests/groupsQuotas.spec.ts
@@ -29,6 +29,8 @@ const { groups } = jest.mocked(_db)
 groups.save.mockResolvedValue({ id: GROUP_ID, rev: generator.guid() })
 groups.get.mockResolvedValue(group)
 groups.getGroupUsers.mockResolvedValue(group.users!)
+groups.getAll.mockResolvedValue([])
+groups.bulkSave.mockResolvedValue([])
 
 import {
   save,
@@ -75,6 +77,49 @@ describe("Creators quotas by group assignment", () => {
     groups.save.mockResolvedValue({ id: GROUP_ID, rev: generator.guid() })
     groups.get.mockResolvedValue(group)
     groups.getGroupUsers.mockResolvedValue(group.users!)
+    groups.getAll.mockResolvedValue([])
+    groups.bulkSave.mockResolvedValue([])
+  })
+
+  it("unsets an existing default group when saving a new default group", async () => {
+    const tenantId = `test_tenant_${generator.guid()}`
+
+    const { context } = require("@budibase/backend-core")
+
+    await context.doInTenant(tenantId, async () => {
+      const oldDefaultGroup = {
+        ...group,
+        _id: `old-default-${generator.guid()}`,
+        isDefault: true,
+      }
+      const newDefaultGroup = {
+        ...group,
+        _id: GROUP_ID,
+        isDefault: true,
+      }
+
+      groups.get.mockResolvedValue({ ...group, isDefault: false })
+      groups.getAll.mockResolvedValue([oldDefaultGroup, newDefaultGroup])
+      groups.bulkSave.mockResolvedValue([
+        { id: oldDefaultGroup._id, rev: generator.guid() },
+        { id: newDefaultGroup._id, rev: generator.guid() },
+      ])
+
+      await save(newDefaultGroup)
+
+      expect(groups.bulkSave).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            _id: oldDefaultGroup._id,
+            isDefault: false,
+          }),
+          expect.objectContaining({
+            _id: newDefaultGroup._id,
+            isDefault: true,
+          }),
+        ])
+      )
+    })
   })
 
   it("shouldn't increment creators quotas if group doesn't have creator role", async () => {

--- a/packages/types/src/documents/global/userGroup.ts
+++ b/packages/types/src/documents/global/userGroup.ts
@@ -5,6 +5,7 @@ export interface UserGroup extends Document {
   name: string
   icon: string
   color: string
+  isDefault?: boolean
   users?: GroupUser[]
   roles?: UserGroupRoles
   // same structure as users

--- a/packages/worker/src/api/routes/global/groups.ts
+++ b/packages/worker/src/api/routes/global/groups.ts
@@ -19,6 +19,7 @@ function buildGroupSaveValidation() {
       users: Joi.array().optional(),
       apps: Joi.array().optional(),
       roles: Joi.object().optional(),
+      isDefault: Joi.boolean().optional(),
       builder: Joi.object({
         apps: Joi.array().items(Joi.string()).optional(),
       }).optional(),

--- a/packages/worker/src/api/routes/global/tests/groups.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/groups.spec.ts
@@ -62,6 +62,13 @@ describe("/api/global/groups", () => {
       )
     })
 
+    it("should allow setting isDefault when creating a group", async () => {
+      const group = { ...structures.groups.UserGroup(), isDefault: true }
+      const response = await config.api.groups.saveGroup(group, { expect: 200 })
+      const savedGroup = await config.api.groups.find(response.body._id)
+      expect(savedGroup.body.isDefault).toBe(true)
+    })
+
     describe("name max length", () => {
       const maxLength = 50
 


### PR DESCRIPTION
## Description
Don't auto commit changes. Always ask


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “default user group” support across backend, API, and UI so new users without explicit groups are auto-assigned. Also updates the contributor guide to require explicit git commits.

- **New Features**
  - Auto-assign users to the default group on create/bulk-create when no groups are provided; adds `getDefaultGroup` and `isDefault` support (types + API validation).
  - UI: toggle to set/unset a default group, “Default” badge in lists, and clearer delete messaging; store refresh ensures a single default is reflected.
  - Backend/SDK: enforce a single default by unsetting previous defaults on save; adds `groups.getAll`/`getDefaultGroup`.

- **Bug Fixes**
  - Workspace invites and assignments no longer override group-managed workspace roles for App Users with BASIC role (payload omits workspace apps when a selected/default group controls the workspace).

<sup>Written for commit dd5caa4ff296ed4a143fdf7cdbb5784d204e2376. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

