### PR TITLE
Bump npm package version in docker image

### DIFF
--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -156,6 +156,8 @@ VOLUME /data
 ARG BUDIBASE_VERSION
 # Ensuring the version argument is sent
 RUN test -n "$BUDIBASE_VERSION"
+RUN jq --arg v "$BUDIBASE_VERSION" '.version = $v' /app/package.json > /tmp/pkg.json && mv /tmp/pkg.json /app/package.json
+RUN jq --arg v "$BUDIBASE_VERSION" '.version = $v' /worker/package.json > /tmp/pkg.json && mv /tmp/pkg.json /worker/package.json
 ENV BUDIBASE_VERSION=$BUDIBASE_VERSION
 
 HEALTHCHECK --interval=15s --timeout=15s --start-period=45s CMD "/healthcheck.sh"

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -68,6 +68,7 @@ ARG BUDIBASE_VERSION
 ARG GIT_COMMIT_SHA
 # Ensuring the version argument is sent
 RUN test -n "$BUDIBASE_VERSION"
+RUN jq --arg v "$BUDIBASE_VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
 ENV BUDIBASE_VERSION=$BUDIBASE_VERSION
 ENV DD_GIT_REPOSITORY_URL=https://github.com/budibase/budibase
 ENV DD_GIT_COMMIT_SHA=$GIT_COMMIT_SHA

--- a/packages/worker/Dockerfile
+++ b/packages/worker/Dockerfile
@@ -64,6 +64,7 @@ ARG BUDIBASE_VERSION
 ARG GIT_COMMIT_SHA
 # Ensuring the version argument is sent
 RUN test -n "$BUDIBASE_VERSION"
+RUN jq --arg v "$BUDIBASE_VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
 ENV BUDIBASE_VERSION=$BUDIBASE_VERSION
 ENV DD_GIT_REPOSITORY_URL=https://github.com/budibase/budibase
 ENV DD_GIT_COMMIT_SHA=$GIT_COMMIT_SHA


### PR DESCRIPTION
## Description
Updates the version attribute in the NPM package definition on container image manifests.

## Addresses
- Some container tooling (vuln scanners, etc)  gets confused when it keeps seeing nil versions being presented on NPM packages. 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets the NPM package version in the Docker images to match BUDIBASE_VERSION so scanners and tooling don’t see null versions. Updates package.json during build in the hosting/single, server, and worker images using jq.

<sup>Written for commit 747ba5d2ee698d0f14920605b751659fcb4308e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

