### PR TITLE
[BUDI-18450] API form-data parameters are not saved

### DIFF
--- a/packages/builder/src/components/integration/APIEndpointViewer.spec.ts
+++ b/packages/builder/src/components/integration/APIEndpointViewer.spec.ts
@@ -852,8 +852,9 @@ describe("API Endpoint Viewer", () => {
       const getBodyTextInputs = () =>
         Array.from(
           container.querySelectorAll(".spectrum-Tabs-content input")
-        ).filter(input => (input as HTMLInputElement).type !== "radio") as
-          | HTMLInputElement[]
+        ).filter(
+          input => (input as HTMLInputElement).type !== "radio"
+        ) as HTMLInputElement[]
 
       await waitFor(() => expect(getTab(container, "Body")).not.toBeUndefined())
       await fireEvent.click(getTab(container, "Body")!)

--- a/packages/builder/src/components/integration/APIEndpointViewer.spec.ts
+++ b/packages/builder/src/components/integration/APIEndpointViewer.spec.ts
@@ -833,6 +833,60 @@ describe("API Endpoint Viewer", () => {
       })
     })
 
+    it("persists form-data body parameters when switching tabs", async () => {
+      queries.store.update(s => ({
+        ...s,
+        list: [
+          {
+            ...SAVED_QUERY,
+            queryVerb: "create",
+            fields: {
+              ...SAVED_QUERY.fields,
+              bodyType: "form" as any,
+              requestBody: {},
+            },
+          },
+        ],
+      }))
+      const { container } = setupDOM({ queryId: QUERY_ID })
+      const getBodyTextInputs = () =>
+        Array.from(
+          container.querySelectorAll(".spectrum-Tabs-content input")
+        ).filter(input => (input as HTMLInputElement).type !== "radio") as
+          | HTMLInputElement[]
+
+      await waitFor(() => expect(getTab(container, "Body")).not.toBeUndefined())
+      await fireEvent.click(getTab(container, "Body")!)
+
+      const addParamButton = await waitFor(() => {
+        const button = Array.from(container.querySelectorAll("button")).find(
+          btn => btn.textContent?.trim().includes("Add param")
+        )
+        expect(button).not.toBeUndefined()
+        return button as HTMLButtonElement
+      })
+      await fireEvent.click(addParamButton)
+
+      await waitFor(() => {
+        expect(getBodyTextInputs().length).toBeGreaterThanOrEqual(2)
+      })
+      const [keyInput, valueInput] = getBodyTextInputs()
+
+      await fireEvent.input(keyInput, { target: { value: "username" } })
+      await fireEvent.blur(keyInput)
+      await fireEvent.input(valueInput, { target: { value: "alice" } })
+      await fireEvent.blur(valueInput)
+
+      await fireEvent.click(getTab(container, "Bindings")!)
+      await fireEvent.click(getTab(container, "Body")!)
+
+      await waitFor(() => {
+        const values = getBodyTextInputs().map(input => input.value)
+        expect(values).toContain("username")
+        expect(values).toContain("alice")
+      })
+    })
+
     it("clicking the Transformer tab shows a code editor", async () => {
       const { container } = setupDOM({ datasourceId: REST_DS_ID })
       await waitFor(() =>

--- a/packages/builder/src/components/integration/RestBodyInput.svelte
+++ b/packages/builder/src/components/integration/RestBodyInput.svelte
@@ -76,7 +76,9 @@
         name="param"
         headings
         on:change={e => {
-          dispatch("change", { requestBody: keyValueArrayToRecord(e.detail) })
+          dispatch("change", {
+            requestBody: keyValueArrayToRecord(e.detail.fields),
+          })
         }}
       />
     {/key}


### PR DESCRIPTION
## Description
Fixes API Explorer dropping request body fields for `form-data` and `x-www-form-encoded` body types when switching tabs.

Root cause: the body editor was passing the wrong payload shape into `keyValueArrayToRecord`, so key/value body fields were not persisted correctly.

Changes made:
- Use `e.detail.fields` when converting form body entries in `RestBodyInput`.
- Add a regression test covering: Body tab -> add form-data fields -> switch tabs -> return to Body, with fields still present.

## Addresses
- https://github.com/Budibase/budibase/issues/18450

## Launchcontrol
API Explorer now keeps `form-data` and `x-www-form-urlencoded` body parameters saved when moving between tabs.
