### PR TITLE
[1755] Activate action events

### DIFF
--- a/packages/backend-core/src/events/processors/posthog/PosthogProcessor.ts
+++ b/packages/backend-core/src/events/processors/posthog/PosthogProcessor.ts
@@ -17,6 +17,9 @@ const EXCLUDED_EVENTS: Event[] = [
   Event.VIEW_CALCULATION_UPDATED,
   Event.AUTOMATION_TRIGGER_UPDATED,
   Event.USER_GROUP_UPDATED,
+  Event.ACTION_AUTOMATION_STEP_EXECUTED,
+  Event.ACTION_CRUD_EXECUTED,
+  Event.ACTION_AI_AGENT_EXECUTED,
 ]
 
 export default class PosthogProcessor implements EventProcessor {

--- a/packages/backend-core/src/events/publishers/action.ts
+++ b/packages/backend-core/src/events/publishers/action.ts
@@ -1,3 +1,4 @@
+import { publishEvent } from "../events"
 import {
   Event,
   ActionAutomationStepExecuted,
@@ -9,36 +10,21 @@ async function automationStepExecuted(
   action: ActionAutomationStepExecuted,
   timestamp?: string | number
 ) {
-  console.info(
-    Event.ACTION_AUTOMATION_STEP_EXECUTED,
-    `disabled. Action step ${action.stepId} not published at ${timestamp}`
-  )
-  // TODO enable event publish -> https://github.com/Budibase/account-portal/issues/1639
-  //await publishEvent(Event.ACTION_AUTOMATION_STEP_EXECUTED, action, timestamp)
+  await publishEvent(Event.ACTION_AUTOMATION_STEP_EXECUTED, action, timestamp)
 }
 
 async function crudExecuted(
   action: ActionCrudExecuted,
   timestamp?: string | number
 ) {
-  console.info(
-    Event.ACTION_AUTOMATION_STEP_EXECUTED,
-    `disabled. Action type ${action.type} not published at ${timestamp}`
-  )
-  // TODO enable event publish -> https://github.com/Budibase/account-portal/issues/1639
-  //await publishEvent(Event.ACTION_CRUD_EXECUTED, action, timestamp)
+  await publishEvent(Event.ACTION_CRUD_EXECUTED, action, timestamp)
 }
 
 async function aiAgentExecuted(
   action: ActionAiAgentExecuted,
   timestamp?: string | number
 ) {
-  console.info(
-    Event.ACTION_AUTOMATION_STEP_EXECUTED,
-    `disabled. Execution for ai agent ${action.agentId} not published at ${timestamp}`
-  )
-  // TODO enable event publish -> https://github.com/Budibase/account-portal/issues/1639
-  //await publishEvent(Event.ACTION_AI_AGENT_EXECUTED, action, timestamp)
+  await publishEvent(Event.ACTION_AI_AGENT_EXECUTED, action, timestamp)
 }
 
 export default {


### PR DESCRIPTION
## Description
Action events (`action:automation_step:executed`, `action:crud:executed`, `action:ai_agent:executed`) were disabled pending [account-portal/issues/1639](https://github.com/Budibase/account-portal/issues/1639). This PR activates them so they flow to Snowflake via `EventBrokerProcessor`, while explicitly excluding them from Posthog.

## Addresses
- https://github.com/Budibase/account-portal/issues/1755

## Launchcontrol
Activates previously disabled action events. They are now sent to Snowflake and excluded from Posthog analytics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activates action events (automation step, CRUD, AI agent) so they publish and flow to Snowflake via `EventBrokerProcessor`, while staying excluded from Posthog. Aligns with 1755’s requirement to send these events to Snowflake only.

- New Features
  - Enabled publishing for `Event.ACTION_AUTOMATION_STEP_EXECUTED`, `Event.ACTION_CRUD_EXECUTED`, and `Event.ACTION_AI_AGENT_EXECUTED` via `publishEvent`.
  - Added these events to `PosthogProcessor`’s exclude list to prevent Posthog ingestion.

<sup>Written for commit 18fa2a448968e5ca591c8b0059f8422085ada6d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

