### PR TITLE
Fix test flakiness

### DIFF
--- a/packages/server/src/workspaceMigrations/migrations/tests/20250729134531_workspace_cleanups.spec.ts
+++ b/packages/server/src/workspaceMigrations/migrations/tests/20250729134531_workspace_cleanups.spec.ts
@@ -120,7 +120,10 @@ describe.each([
     let keptWorkspaceAppId: string = undefined!
 
     await config.doInContext(getWorkspaceId(), async () => {
+      tk.travel(Date.now() + 1000)
       const workspaceApp1 = await createWorkspaceApp(true)
+      tk.travel(Date.now() + 1000)
+
       const workspaceApp2 = await createWorkspaceApp(true)
 
       tk.travel(Date.now() + 1000)


### PR DESCRIPTION
## Description
Fix test flakiness due repeated timestamps


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes workspace cleanup tests by using `tk.travel` between workspace app creations to ensure unique timestamps. This removes nondeterministic ordering from identical timestamps and prevents flaky failures.

<sup>Written for commit af937ebbf59b7d7e8c6cf08c69a79464ef6a0499. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

