### PR TITLE
harden endpoint matching in auth middleware

### DIFF
--- a/packages/backend-core/src/middleware/matchers.ts
+++ b/packages/backend-core/src/middleware/matchers.ts
@@ -23,13 +23,14 @@ export const buildMatcherRegex = (
       }
     }
 
-    return { regex: new RegExp(route), method, route }
+    return { regex: new RegExp(`^${route}`), method, route }
   })
 }
 
 export const matches = (ctx: Ctx, options: RegexMatcher[]) => {
   return options.find(({ regex, method }) => {
-    const urlMatch = regex.test(ctx.request.url)
+    const path = ctx.path || ctx.request.path || ctx.request.url.split("?")[0]
+    const urlMatch = regex.test(path)
     const methodMatch =
       method === "ALL"
         ? true

--- a/packages/backend-core/src/middleware/matchers.ts
+++ b/packages/backend-core/src/middleware/matchers.ts
@@ -29,8 +29,7 @@ export const buildMatcherRegex = (
 
 export const matches = (ctx: Ctx, options: RegexMatcher[]) => {
   return options.find(({ regex, method }) => {
-    const path = ctx.path || ctx.request.path || ctx.request.url.split("?")[0]
-    const urlMatch = regex.test(path)
+    const urlMatch = regex.test(ctx.path)
     const methodMatch =
       method === "ALL"
         ? true

--- a/packages/backend-core/src/middleware/tests/activation.spec.ts
+++ b/packages/backend-core/src/middleware/tests/activation.spec.ts
@@ -101,6 +101,7 @@ describe("activeTenant middleware", () => {
         config: { active: false },
       })
 
+      ctx.path = "/api/system/tenants/tenant1"
       ctx.request = { url: "/api/system/tenants/tenant1", method: "DELETE" }
 
       const middleware = activeTenant([
@@ -119,6 +120,7 @@ describe("activeTenant middleware", () => {
         config: { active: false },
       })
 
+      ctx.path = "/api/system/environment"
       ctx.request = { url: "/api/system/environment", method: "GET" }
 
       const middleware = activeTenant([

--- a/packages/backend-core/src/middleware/tests/matchers.spec.ts
+++ b/packages/backend-core/src/middleware/tests/matchers.spec.ts
@@ -10,6 +10,7 @@ describe("matchers", () => {
       },
     ]
     const ctx = structures.koa.newContext()
+    ctx.path = "/api/tests"
     ctx.request.url = "/api/tests"
     ctx.request.method = "POST"
 
@@ -26,12 +27,47 @@ describe("matchers", () => {
       },
     ]
     const ctx = structures.koa.newContext()
+    ctx.path = "/api/tests/id/something/else"
     ctx.request.url = "/api/tests/id/something/else"
     ctx.request.method = "POST"
 
     const built = matchers.buildMatcherRegex(pattern)
 
     expect(!!matchers.matches(ctx, built)).toBe(true)
+  })
+
+  it("doesn't match later in the path", () => {
+    const pattern = [
+      {
+        route: "/api/tests",
+        method: "POST",
+      },
+    ]
+    const ctx = structures.koa.newContext()
+    ctx.path = "/foo/api/tests"
+    ctx.request.url = "/foo/api/tests"
+    ctx.request.method = "POST"
+
+    const built = matchers.buildMatcherRegex(pattern)
+
+    expect(!!matchers.matches(ctx, built)).toBe(false)
+  })
+
+  it("ignores query strings when matching", () => {
+    const pattern = [
+      {
+        route: "/api/system/status",
+        method: "GET",
+      },
+    ]
+    const ctx = structures.koa.newContext()
+    ctx.path = "/api/global/users/search"
+    ctx.request.url = "/api/global/users/search?x=/api/system/status"
+    ctx.request.method = "GET"
+
+    const built = matchers.buildMatcherRegex(pattern)
+
+    expect(!!matchers.matches(ctx, built)).toBe(false)
   })
 
   it("matches with param", () => {
@@ -42,6 +78,7 @@ describe("matchers", () => {
       },
     ]
     const ctx = structures.koa.newContext()
+    ctx.path = "/api/tests/id"
     ctx.request.url = "/api/tests/id"
     ctx.request.method = "GET"
 
@@ -58,6 +95,7 @@ describe("matchers", () => {
       },
     ]
     const ctx = structures.koa.newContext()
+    ctx.path = "/api/unknown"
     ctx.request.url = "/api/unknown"
     ctx.request.method = "POST"
 
@@ -74,6 +112,7 @@ describe("matchers", () => {
       },
     ]
     const ctx = structures.koa.newContext()
+    ctx.path = "/api/tests"
     ctx.request.url = "/api/tests"
     ctx.request.method = "GET"
 
@@ -90,6 +129,7 @@ describe("matchers", () => {
       },
     ]
     const ctx = structures.koa.newContext()
+    ctx.path = "/api/tests"
     ctx.request.url = "/api/tests"
     ctx.request.method = "GET"
 

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -1138,6 +1138,14 @@ describe("/api/global/users", () => {
       await config.api.users.searchUsers({}, { status: 403, noHeaders: true })
     })
 
+    it("should throw an error if a public route is injected in the query string", async () => {
+      await config.request
+        .post("/api/global/users/search?x=/api/system/status")
+        .send({})
+        .expect("Content-Type", /json/)
+        .expect(403)
+    })
+
     it("should be able to search using logical conditions", async () => {
       const user = await config.createUser()
       const response = await config.api.users.searchUsers({


### PR DESCRIPTION
## Description
This hardens shared endpoint matching used by authentication-related middleware.
The change updates route matching to use the request path rather than the full URL and tightens matching behaviour to avoid incorrect public-route detection. Regression tests have been added to cover the affected matcher and worker auth path.

## Addresses
https://github.com/Budibase/vulns/issues/50
https://github.com/Budibase/budibase/security/advisories/GHSA-8783-3wgf-jggf

## Launchcontrol
improves API route matching used by authentication checks