### PR TITLE
Emit ACTION_AI_AGENT_EXECUTED event on every agent execution

### DIFF
--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -298,7 +298,7 @@ export async function webhookChat({
     throw responseResult.reason
   }
 
-  await events.action.aiAgentExecuted({ agentId })
+  events.action.aiAgentExecuted({ agentId })
 
   const assistantText = textResult.value
   const assistantMessage: ChatConversation["messages"][number] = {
@@ -500,7 +500,7 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
       onError: error => getErrorMessage(error),
       onFinish: async ({ messages }) => {
         await sessionLogIndexer.index()
-        await events.action.aiAgentExecuted({ agentId })
+        events.action.aiAgentExecuted({ agentId })
 
         if (chat.transient || !chatAppId) {
           return

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -1,5 +1,6 @@
 import {
   context,
+  events,
   features,
   docIds,
   getErrorMessage,
@@ -297,6 +298,8 @@ export async function webhookChat({
     throw responseResult.reason
   }
 
+  await events.action.aiAgentExecuted({ agentId })
+
   const assistantText = textResult.value
   const assistantMessage: ChatConversation["messages"][number] = {
     id: v4(),
@@ -497,6 +500,7 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
       onError: error => getErrorMessage(error),
       onFinish: async ({ messages }) => {
         await sessionLogIndexer.index()
+        await events.action.aiAgentExecuted({ agentId })
 
         if (chat.transient || !chatAppId) {
           return

--- a/packages/server/src/automations/steps/ai/agent.ts
+++ b/packages/server/src/automations/steps/ai/agent.ts
@@ -224,7 +224,7 @@ export async function run({
           metadata: { stepCount: assistantMessage?.parts?.length ?? 0 },
         })
 
-        await events.action.aiAgentExecuted({ agentId })
+        events.action.aiAgentExecuted({ agentId })
 
         return {
           success: true,

--- a/packages/server/src/automations/steps/ai/agent.ts
+++ b/packages/server/src/automations/steps/ai/agent.ts
@@ -1,5 +1,5 @@
 import * as automationUtils from "../../automationUtils"
-import { getErrorMessage } from "@budibase/backend-core"
+import { events, getErrorMessage } from "@budibase/backend-core"
 import { quotas } from "@budibase/pro"
 import {
   AgentStepInputs,
@@ -223,6 +223,8 @@ export async function run({
           outputData: responseText,
           metadata: { stepCount: assistantMessage?.parts?.length ?? 0 },
         })
+
+        await events.action.aiAgentExecuted({ agentId })
 
         return {
           success: true,

--- a/packages/server/src/automations/tests/steps/executeScript.spec.ts
+++ b/packages/server/src/automations/tests/steps/executeScript.spec.ts
@@ -9,9 +9,11 @@ describe("Execute Script Automations", () => {
 
   beforeAll(async () => {
     await config.init()
-    table = await config.api.table.save(basicTable())
-    await config.api.row.save(table._id!, {})
-    await config.api.automation.deleteAll()
+    await config.doInContext(config.getDevWorkspaceId(), async () => {
+      table = await config.api.table.save(basicTable())
+      await config.api.row.save(table._id!, {})
+      await config.api.automation.deleteAll()
+    })
   })
 
   afterAll(() => {
@@ -19,87 +21,97 @@ describe("Execute Script Automations", () => {
   })
 
   it("should execute a basic script and return the result", async () => {
-    const results = await createAutomationBuilder(config)
-      .onAppAction()
-      .executeScript({ code: "return 2 + 2" })
-      .test({ fields: {} })
+    await config.doInContext(config.getDevWorkspaceId(), async () => {
+      const results = await createAutomationBuilder(config)
+        .onAppAction()
+        .executeScript({ code: "return 2 + 2" })
+        .test({ fields: {} })
 
-    expect(results.steps[0].outputs.value).toEqual(4)
+      expect(results.steps[0].outputs.value).toEqual(4)
+    })
   })
 
   it("should access bindings from previous steps", async () => {
-    const results = await createAutomationBuilder(config)
-      .onAppAction()
-      .executeScript(
-        {
-          code: "return trigger.fields.data.map(x => x * 2)",
-        },
-        { stepId: "binding-script-step" }
-      )
-      .test({ fields: { data: [1, 2, 3] } })
+    await config.doInContext(config.getDevWorkspaceId(), async () => {
+      const results = await createAutomationBuilder(config)
+        .onAppAction()
+        .executeScript(
+          {
+            code: "return trigger.fields.data.map(x => x * 2)",
+          },
+          { stepId: "binding-script-step" }
+        )
+        .test({ fields: { data: [1, 2, 3] } })
 
-    expect(results.steps[0].outputs.value).toEqual([2, 4, 6])
+      expect(results.steps[0].outputs.value).toEqual([2, 4, 6])
+    })
   })
 
   it("should handle script execution errors gracefully", async () => {
-    const results = await createAutomationBuilder(config)
-      .onAppAction()
-      .executeScript({ code: "return nonexistentVariable.map(x => x)" })
-      .test({ fields: {} })
+    await config.doInContext(config.getDevWorkspaceId(), async () => {
+      const results = await createAutomationBuilder(config)
+        .onAppAction()
+        .executeScript({ code: "return nonexistentVariable.map(x => x)" })
+        .test({ fields: {} })
 
-    expect(results.steps[0].outputs.response).toContain(
-      "ReferenceError: nonexistentVariable is not defined"
-    )
-    expect(results.steps[0].outputs.success).toEqual(false)
+      expect(results.steps[0].outputs.response).toContain(
+        "ReferenceError: nonexistentVariable is not defined"
+      )
+      expect(results.steps[0].outputs.success).toEqual(false)
+    })
   })
 
   it("should handle conditional logic in scripts", async () => {
-    const results = await createAutomationBuilder(config)
-      .onAppAction()
-      .executeScript({
-        code: `
+    await config.doInContext(config.getDevWorkspaceId(), async () => {
+      const results = await createAutomationBuilder(config)
+        .onAppAction()
+        .executeScript({
+          code: `
             if (trigger.fields.value > 5) {
               return "Value is greater than 5";
             } else {
               return "Value is 5 or less";
             }
           `,
-      })
-      .test({ fields: { value: 10 } })
+        })
+        .test({ fields: { value: 10 } })
 
-    expect(results.steps[0].outputs.value).toEqual("Value is greater than 5")
+      expect(results.steps[0].outputs.value).toEqual("Value is greater than 5")
+    })
   })
 
   it("should use multiple steps and validate script execution", async () => {
-    const results = await createAutomationBuilder(config)
-      .onAppAction()
-      .serverLog(
-        { text: "Starting multi-step automation" },
-        { stepId: "start-log-step" }
-      )
-      .createRow(
-        { row: { name: "Test Row", value: 42, tableId: table._id } },
-        { stepId: "abc123" }
-      )
-      .executeScript(
-        {
-          code: `
+    await config.doInContext(config.getDevWorkspaceId(), async () => {
+      const results = await createAutomationBuilder(config)
+        .onAppAction()
+        .serverLog(
+          { text: "Starting multi-step automation" },
+          { stepId: "start-log-step" }
+        )
+        .createRow(
+          { row: { name: "Test Row", value: 42, tableId: table._id } },
+          { stepId: "abc123" }
+        )
+        .executeScript(
+          {
+            code: `
             const createdRow = steps['abc123'];
             return createdRow.row.value * 2;
           `,
-        },
-        { stepId: "ScriptingStep1" }
-      )
-      .serverLog({
-        text: `Final result is {{ steps.ScriptingStep1.value }}`,
-      })
-      .test({ fields: {} })
+          },
+          { stepId: "ScriptingStep1" }
+        )
+        .serverLog({
+          text: `Final result is {{ steps.ScriptingStep1.value }}`,
+        })
+        .test({ fields: {} })
 
-    expect(results.steps[0].outputs.message).toContain(
-      "Starting multi-step automation"
-    )
-    expect(results.steps[1].outputs.row.value).toEqual(42)
-    expect(results.steps[2].outputs.value).toEqual(84)
-    expect(results.steps[3].outputs.message).toContain("Final result is 84")
+      expect(results.steps[0].outputs.message).toContain(
+        "Starting multi-step automation"
+      )
+      expect(results.steps[1].outputs.row.value).toEqual(42)
+      expect(results.steps[2].outputs.value).toEqual(84)
+      expect(results.steps[3].outputs.message).toContain("Final result is 84")
+    })
   })
 })

--- a/packages/server/src/automations/tests/steps/executeScript.spec.ts
+++ b/packages/server/src/automations/tests/steps/executeScript.spec.ts
@@ -1,5 +1,4 @@
 import { createAutomationBuilder } from "../utilities/AutomationTestBuilder"
-import * as automation from "../../index"
 import { Table } from "@budibase/types"
 import TestConfiguration from "../../../tests/utilities/TestConfiguration"
 import { basicTable } from "../../../tests/utilities/structures"
@@ -10,7 +9,6 @@ describe("Execute Script Automations", () => {
 
   beforeAll(async () => {
     await config.init()
-    await automation.init()
     table = await config.api.table.save(basicTable())
     await config.api.row.save(table._id!, {})
     await config.api.automation.deleteAll()

--- a/packages/server/src/automations/tests/steps/executeScript.spec.ts
+++ b/packages/server/src/automations/tests/steps/executeScript.spec.ts
@@ -9,8 +9,8 @@ describe("Execute Script Automations", () => {
   let table: Table
 
   beforeAll(async () => {
-    await config.init()
     await automation.init()
+    await config.init()
     table = await config.api.table.save(basicTable())
     await config.api.row.save(table._id!, {})
     await config.api.automation.deleteAll()

--- a/packages/server/src/automations/tests/steps/executeScript.spec.ts
+++ b/packages/server/src/automations/tests/steps/executeScript.spec.ts
@@ -9,8 +9,8 @@ describe("Execute Script Automations", () => {
   let table: Table
 
   beforeAll(async () => {
-    await automation.init()
     await config.init()
+    await automation.init()
     table = await config.api.table.save(basicTable())
     await config.api.row.save(table._id!, {})
     await config.api.automation.deleteAll()


### PR DESCRIPTION
## Description

Fire `events.action.aiAgentExecuted()` from all three agent execution entry points so that the `ACTION_AI_AGENT_EXECUTED` event is consistently emitted whenever an agent runs.

Entry points covered:
- Automation step (`packages/server/src/automations/steps/ai/agent.ts`)
- Webhook chat (Discord / Slack / MS Teams) — `webhookChat()` in `chatConversations.ts`
- Chat stream API — `agentChatStream()` in `chatConversations.ts`

The event is only fired on successful completion; errors still throw before reaching the call.

## Launchcontrol

Tracks agent executions via the existing `ACTION_AI_AGENT_EXECUTED` analytics event, covering all three execution paths (automation steps, webhook chat, and chat stream).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit `ACTION_AI_AGENT_EXECUTED` after every successful agent run (non-blocking) across automation step, webhook chat, and chat stream for consistent analytics. Stabilized `executeScript` automation tests by running them in the dev workspace context; supports Linear 1755: Activate Actions AI.

<sup>Written for commit 727f92ff23a738951c77de526a45dce519d4f061. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

