### PR TITLE
Remove workflow-level concurrency and fail fast on main CI action

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -1,9 +1,5 @@
 name: Budibase CI
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 on:
   # Trigger the workflow on push or pull request,
   # but only for the master branch
@@ -31,6 +27,9 @@ env:
 jobs:
   install-deps:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-install-deps-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -66,6 +65,9 @@ jobs:
 
   lint:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-lint-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     needs: install-deps
     steps:
       - name: Checkout repo
@@ -89,6 +91,9 @@ jobs:
 
   litellm-version-sync:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-litellm-version-sync-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -105,6 +110,9 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-build-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     needs:
       - install-deps
       - compute-affected-jobs
@@ -147,6 +155,9 @@ jobs:
 
   missing-deps:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-missing-deps-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     needs: install-deps
     steps:
       - name: Checkout repo
@@ -173,6 +184,9 @@ jobs:
 
   helm-lint:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-helm-lint-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -183,6 +197,9 @@ jobs:
 
   test-libraries:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-test-libraries-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     needs:
       - install-deps
       - compute-affected-jobs
@@ -232,6 +249,9 @@ jobs:
   compute-affected-jobs:
     name: Compute affected jobs
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-compute-affected-jobs-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     needs: install-deps
     outputs:
       run_build: ${{ steps.affected.outputs.run_build }}
@@ -306,6 +326,9 @@ jobs:
 
   test-worker:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-test-worker-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     needs:
       - install-deps
       - compute-affected-jobs
@@ -342,10 +365,14 @@ jobs:
 
   test-server:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-test-server-${{ matrix.datasource }}-${{ matrix.shard_index }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: false
     needs:
       - install-deps
       - compute-affected-jobs
     strategy:
+      fail-fast: false
       matrix:
         include:
           # Use uneven sharding to balance runtime across datasources.
@@ -495,6 +522,9 @@ jobs:
 
   check-lockfile:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-check-lockfile-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     needs: install-deps
     if: inputs.run_as_oss != true  && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'Budibase/budibase')
     steps:
@@ -527,6 +557,9 @@ jobs:
 
   check-openapi-specs:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-check-openapi-specs-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     needs: install-deps
     steps:
       - name: Checkout repo
@@ -563,6 +596,9 @@ jobs:
 
   build-database-image:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-build-database-image-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -582,6 +618,9 @@ jobs:
 
   check-client-build-size:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-check-client-build-size-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     needs: install-deps
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## Description
a) Removed workflow-level concurrency                                                                                                                                                                    
b) Added fail-fast: false to the test-server matrix strategy                                                           
c) Added per-job concurrency groups 

## Addresses
- context cancelled jobs that run in parallel -> https://github.com/Budibase/budibase/actions/runs/24179962991/job/70570301337?pr=18492


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed workflow-level concurrency and moved to per-job concurrency groups to stop cross-job cancellations. Disabled matrix fail-fast for `test-server` so all shards run to completion and reduce “context canceled” errors.

- **Bug Fixes**
  - Removed top-level `concurrency` to prevent unrelated jobs from canceling each other.
  - Added per-job `concurrency` groups (`cancel-in-progress: true`), with a shard/datasource-scoped group for `test-server` (`cancel-in-progress: false`).
  - Set `fail-fast: false` for the `test-server` matrix to avoid early cancellation and flaky failures.

<sup>Written for commit ea2702fc6fb8f36e15ace57add54bf8309f2c2a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

