### PR TITLE
Add experimental Docker image build pipeline

### DIFF
--- a/.github/workflows/build-experimental.yml
+++ b/.github/workflows/build-experimental.yml
@@ -1,0 +1,121 @@
+name: Build Experimental Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_suffix:
+        type: string
+        description: "Optional suffix for the image tag (e.g. 'ceph-fix'). If empty, the branch name is used."
+        required: false
+
+concurrency:
+  group: build-experimental-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  HUSKY: 0
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          if [ -n "${{ github.event.inputs.tag_suffix }}" ]; then
+            TAG="experimental-${{ github.event.inputs.tag_suffix }}"
+          else
+            # Sanitise branch name for use as a Docker tag
+            RAW_REF="${GITHUB_REF_NAME}"
+            TAG="experimental-$(echo "$RAW_REF" | sed 's/[^a-zA-Z0-9._-]/-/g' | cut -c1-128)"
+          fi
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=$TAG-$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "Image tags: $TAG, $TAG-$SHORT_SHA"
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+
+      - name: Restore hoisted node_modules cache
+        id: cache
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: ${{ runner.os }}-node22-hoisted-node-modules-${{ hashFiles('yarn.lock') }}
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_API_KEY }}
+
+      - name: Build and push apps image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: packages/server/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            BUDIBASE_VERSION=${{ steps.tag.outputs.tag }}
+            GIT_COMMIT_SHA=${{ github.sha }}
+          tags: |
+            budibase/apps:${{ steps.tag.outputs.tag }}
+            budibase/apps:${{ steps.tag.outputs.sha_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push worker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: packages/worker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            BUDIBASE_VERSION=${{ steps.tag.outputs.tag }}
+            GIT_COMMIT_SHA=${{ github.sha }}
+          tags: |
+            budibase/worker:${{ steps.tag.outputs.tag }}
+            budibase/worker:${{ steps.tag.outputs.sha_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Print image references
+        run: |
+          echo "### Experimental images pushed" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Image | Tags |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`budibase/apps\` | \`${{ steps.tag.outputs.tag }}\`, \`${{ steps.tag.outputs.sha_tag }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`budibase/worker\` | \`${{ steps.tag.outputs.tag }}\`, \`${{ steps.tag.outputs.sha_tag }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Pull with:" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "docker pull budibase/apps:${{ steps.tag.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "docker pull budibase/worker:${{ steps.tag.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Description

Adds a `workflow_dispatch` GitHub Actions workflow that builds and pushes `budibase/apps` and `budibase/worker` Docker images with `experimental-*` tags from any branch. This enables testing feature branch builds against real infrastructure (e.g. Ceph Object Gateway) without going through the full release cycle.

**Tag scheme:**
- `budibase/apps:experimental-<suffix>` — mutable, overwritten on re-runs
- `budibase/apps:experimental-<suffix>-<short-sha>` — immutable, pinned to a commit

**Trigger:** Manual from any branch via Actions UI, with an optional tag suffix input.

## Launchcontrol

New CI workflow for building experimental Docker images from feature branches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual GitHub Actions workflow to build and push experimental Docker images for `budibase/apps` and `budibase/worker` from any branch. This lets us test feature branches against real infra without a full release.

- New Features
  - `workflow_dispatch` to build `budibase/apps` and `budibase/worker` with an optional `tag_suffix`; falls back to sanitized branch name.
  - Tags: `experimental-<suffix>` (mutable) and `experimental-<suffix>-<short-sha>` (immutable).
  - Multi-arch images (linux/amd64, linux/arm64) pushed to Docker Hub.
  - Build cache and workflow concurrency to speed up runs and avoid overlaps.
  - Job summary prints image tags and ready-to-copy pull commands.

<sup>Written for commit 067ab2806dea1ddd7785ec2695cf8c5dead7b10c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

