### PR TITLE
Fix experimental pipeline tag sanitisation

### DIFF
--- a/.github/workflows/build-experimental.yml
+++ b/.github/workflows/build-experimental.yml
@@ -28,12 +28,13 @@ jobs:
         id: tag
         run: |
           if [ -n "${{ github.event.inputs.tag_suffix }}" ]; then
-            TAG="experimental-${{ github.event.inputs.tag_suffix }}"
+            RAW="${{ github.event.inputs.tag_suffix }}"
           else
-            # Sanitise branch name for use as a Docker tag
-            RAW_REF="${GITHUB_REF_NAME}"
-            TAG="experimental-$(echo "$RAW_REF" | sed 's/[^a-zA-Z0-9._-]/-/g' | cut -c1-128)"
+            RAW="${GITHUB_REF_NAME}"
           fi
+          # Sanitise for Docker tag: replace any character not in [a-zA-Z0-9._-]
+          SAFE="$(echo "$RAW" | tr '/' '-' | sed 's/[^a-zA-Z0-9._-]/-/g' | cut -c1-128)"
+          TAG="experimental-${SAFE}"
           SHORT_SHA=$(git rev-parse --short HEAD)
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "sha_tag=$TAG-$SHORT_SHA" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description

Fixes the experimental Docker image build pipeline to properly sanitise branch names and `tag_suffix` input containing slashes (e.g. `fix/ceph-s3-api` → `fix-ceph-s3-api`). Without this, Docker rejects the tag as invalid.

## Launchcontrol

Fix tag sanitisation in the experimental image build workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Docker tag sanitization in the experimental image build workflow. Branch names and the `tag_suffix` input are now sanitized to prevent invalid tags and failed builds.

- **Bug Fixes**
  - Build tag from `tag_suffix` (if set) or `GITHUB_REF_NAME`, replace `/` with `-`, strip non `[a-zA-Z0-9._-]`, truncate to 128 chars, and prefix with `experimental-`.
  - Keep outputs unchanged: `tag` and `sha_tag`.

<sup>Written for commit 4ba34cd6f0bbd7c30fae48ee08a8b5fd909d4a4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

