### PR TITLE
Sharepoint sync logging

### DIFF
--- a/packages/server/src/api/controllers/ai/files.ts
+++ b/packages/server/src/api/controllers/ai/files.ts
@@ -129,9 +129,21 @@ export async function syncAgentKnowledgeSources(
   const sourceIds = Array.isArray(ctx.request.body?.sourceIds)
     ? ctx.request.body.sourceIds
     : undefined
+  console.log("Agent knowledge source sync requested", {
+    agentId,
+    sourceIds: sourceIds?.length ? sourceIds : "all",
+  })
   const response = sourceIds
     ? await sdk.ai.rag.syncSharePointSourcesForAgent(agentId, sourceIds)
     : await sdk.ai.rag.syncSharePointSourcesForAgent(agentId)
+  console.log("Agent knowledge source sync completed", {
+    agentId,
+    sourceIds: sourceIds?.length ? sourceIds : "all",
+    synced: response.synced,
+    failed: response.failed,
+    skipped: response.skipped,
+    totalDiscovered: response.totalDiscovered,
+  })
   ctx.body = response
   ctx.status = 200
 }
@@ -160,7 +172,21 @@ export async function setAgentKnowledgeSources(
   }
   const sharePointSources = getSharePointSources(existingAgent)
 
-  const previousSiteIds = getSharePointSiteIds(existingAgent)
+  const previousSiteIdsSet = getSharePointSiteIds(existingAgent)
+  const previousSiteIds = Array.from(previousSiteIdsSet)
+  const addedSharePointSiteIds = siteIds.filter(
+    id => !previousSiteIdsSet.has(id)
+  )
+  const removedSharePointSiteIds = previousSiteIds.filter(
+    id => !siteIds.includes(id)
+  )
+  console.log("Updating agent knowledge sources", {
+    agentId,
+    previousSiteCount: previousSiteIds.length,
+    nextSiteCount: siteIds.length,
+    addedSharePointSiteIds,
+    removedSharePointSiteIds,
+  })
   const availableSites = await sdk.ai.rag.fetchSharePointSitesForAgent(agentId)
   const availableById = new Map(
     availableSites.options.map(site => [
@@ -203,9 +229,6 @@ export async function setAgentKnowledgeSources(
   })
   await sdk.ai.rag.knowledgeSourceSyncQueue.reconcileAgentJobs(updated)
 
-  const removedSharePointSiteIds = [...previousSiteIds].filter(
-    id => !siteIds.includes(id)
-  )
   await cleanupSharePointFilesForAgent({
     agentId,
     removedSharePointSiteIds,
@@ -221,6 +244,13 @@ export async function setAgentKnowledgeSources(
     await sdk.ai.rag.syncSharePointSourcesForAgent(agentId, nextSourceIds)
   }
 
+  console.log("Updated agent knowledge sources", {
+    agentId,
+    nextSourceIds,
+    addedSharePointSiteIds,
+    removedSharePointSiteIds,
+  })
+
   ctx.body = await sdk.ai.rag.fetchSharePointSitesForAgent(agentId)
   ctx.status = 200
 }
@@ -234,6 +264,14 @@ export async function disconnectAgentKnowledgeSources(
 ) {
   const { agentId } = ctx.params
   const existingAgent = await sdk.ai.agents.getOrThrow(agentId)
+  const removedSharePointSiteIds = Array.from(
+    getSharePointSiteIds(existingAgent)
+  )
+  console.log("Disconnecting agent knowledge sources", {
+    agentId,
+    removedSharePointSiteIds,
+    removedCount: removedSharePointSiteIds.length,
+  })
 
   const nextSources = (existingAgent.knowledgeSources || []).filter(
     source => source.type !== AgentKnowledgeSourceType.SHAREPOINT
@@ -249,6 +287,10 @@ export async function disconnectAgentKnowledgeSources(
     sharePointDisconnected: true,
   })
   await sdk.ai.rag.deleteKnowledgeSourceSyncStateForAgent(agentId)
+  console.log("Disconnected agent knowledge sources", {
+    agentId,
+    removedSharePointSiteIds,
+  })
 
   ctx.body = {
     agentId,

--- a/packages/server/src/api/controllers/ai/sharepointAuth.ts
+++ b/packages/server/src/api/controllers/ai/sharepointAuth.ts
@@ -43,6 +43,10 @@ export async function startSharePointAuth(ctx: UserCtx<void, void>) {
   if (!appId) {
     ctx.throw(400, "appId query param not present.")
   }
+  console.log("Starting SharePoint OAuth flow", {
+    appId,
+    hasReturnPath: !!returnPath,
+  })
 
   const { clientId, tenantId } = getMicrosoftConfig()
   const platformUrl = await configs.getPlatformUrl({ tenantAware: false })
@@ -192,6 +196,10 @@ export async function completeSharePointAuth(ctx: UserCtx<void, void>) {
       }
     )
   )
+  console.log("Completed SharePoint OAuth flow", {
+    appId,
+    connected: true,
+  })
 
   utils.clearCookie(ctx, constants.Cookie.DatasourceAuth)
 

--- a/packages/server/src/sdk/workspace/ai/rag/knowledgeSourceSyncQueue.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/knowledgeSourceSyncQueue.ts
@@ -107,6 +107,13 @@ export function init(concurrency = DEFAULT_CONCURRENCY) {
       concurrency,
       async (job: Job<KnowledgeSourceSyncJob>) => {
         const { workspaceId, agentId, sourceType, sourceId } = job.data
+        console.log("Processing knowledge source sync queue job", {
+          workspaceId,
+          agentId,
+          sourceType,
+          sourceId,
+          jobId: job.id,
+        })
         await context.doInWorkspaceContext(workspaceId, async () => {
           switch (sourceType) {
             case AgentKnowledgeSourceType.SHAREPOINT:
@@ -117,6 +124,13 @@ export function init(concurrency = DEFAULT_CONCURRENCY) {
                 `Unsupported knowledge source type for sync queue: ${sourceType}`
               )
           }
+        })
+        console.log("Completed knowledge source sync queue job", {
+          workspaceId,
+          agentId,
+          sourceType,
+          sourceId,
+          jobId: job.id,
         })
       }
     )

--- a/packages/server/src/sdk/workspace/ai/rag/sharepoint.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/sharepoint.ts
@@ -421,7 +421,18 @@ export const syncSharePointSourcesForAgent = async (
   const runSites = sites.length > 0 ? sites : normalizeSites(existingSites)
   const siteIds = runSites.map(site => site.id)
 
+  console.log("Starting SharePoint sync for agent", {
+    agentId: trimmedAgentId,
+    sourceIds: sourceIds?.length ? sourceIds : "all",
+    siteCount: siteIds.length,
+    siteIds,
+    lastRunAt,
+  })
+
   if (siteIds.length === 0) {
+    console.log("SharePoint sync skipped for agent (no sites selected)", {
+      agentId: trimmedAgentId,
+    })
     return {
       agentId: trimmedAgentId,
       synced: 0,
@@ -456,8 +467,17 @@ export const syncSharePointSourcesForAgent = async (
     let siteFailed = 0
     let siteSkipped = 0
     let siteTotalDiscovered = 0
+    console.log("Starting SharePoint site sync for agent", {
+      agentId: trimmedAgentId,
+      siteId,
+    })
     try {
       const driveIds = await listDrives(bearerToken, siteId)
+      console.log("Fetched SharePoint drives for site", {
+        agentId: trimmedAgentId,
+        siteId,
+        driveCount: driveIds.length,
+      })
       for (const driveId of driveIds) {
         const files = await collectFilesRecursive(bearerToken, driveId)
         siteTotalDiscovered += files.length
@@ -521,8 +541,25 @@ export const syncSharePointSourcesForAgent = async (
         skipped: siteSkipped,
         totalDiscovered: siteTotalDiscovered,
       })
+      console.log("Completed SharePoint site sync for agent", {
+        agentId: trimmedAgentId,
+        siteId,
+        synced: siteSynced,
+        failed: siteFailed,
+        skipped: siteSkipped,
+        totalDiscovered: siteTotalDiscovered,
+      })
     }
   }
+
+  console.log("Completed SharePoint sync for agent", {
+    agentId: trimmedAgentId,
+    siteCount: siteIds.length,
+    synced,
+    failed,
+    skipped,
+    totalDiscovered,
+  })
 
   return {
     agentId: trimmedAgentId,


### PR DESCRIPTION
## Description
Add logs around Sharepoint sync

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured logs across SharePoint auth and sync flows to improve traceability and debugging. Covers job lifecycle, selected sites, drive/file counts, and sync results per agent and site.

- **New Features**
  - API: logs start/end of `syncAgentKnowledgeSources`; diffs added/removed site IDs in `setAgentKnowledgeSources`; logs disconnects with counts.
  - Auth: logs start/end of SharePoint OAuth with `appId` and return path presence.
  - Queue: logs start/end of `knowledgeSourceSyncQueue` jobs with workspace, agent, source type/ID, and job ID.
  - RAG SharePoint: logs start/skip/complete of `syncSharePointSourcesForAgent`; per-site sync start/end with drive counts and per-site metrics (synced, failed, skipped, discovered).

<sup>Written for commit 1838361cc8dce39c49d272aa2ac1f23d8c37959f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

