### PR TITLE
Filter what files to upload

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/KnowledgeAddControls.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/KnowledgeAddControls.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Button } from "@budibase/bbui"
+  import { KNOWLEDGE_FILE_ACCEPT_ATTRIBUTE } from "@budibase/types"
   import { notifications } from "@budibase/bbui"
   import { agentsStore } from "@/stores/portal"
   import AddKnowledgeModal from "./AddKnowledgeModal.svelte"
@@ -15,9 +16,6 @@
   }
 
   let { agentId, onUploaded, onSharePoint }: Props = $props()
-
-  const ACCEPTED_KNOWLEDGE_FILE_TYPES =
-    ".txt,.md,.markdown,.json,.yaml,.yml,.csv,.tsv,.pdf,.html,.htm,.xml,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.rtf"
 
   let fileInput = $state<HTMLInputElement>()
   let addKnowledgeModal = $state<AddKnowledgeModal>()
@@ -78,7 +76,7 @@
 
 <input
   type="file"
-  accept={ACCEPTED_KNOWLEDGE_FILE_TYPES}
+  accept={KNOWLEDGE_FILE_ACCEPT_ATTRIBUTE}
   hidden
   bind:this={fileInput}
   onchange={handleFileUpload}

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/index.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Body, Layout, notifications } from "@budibase/bbui"
   import { confirm } from "@/helpers"
+  import type { SyncAgentKnowledgeSourcesResponse } from "@budibase/types"
   import {
     AgentKnowledgeSourceType,
     type Agent,
@@ -79,13 +80,10 @@
   let selectedStatusSiteName = $state<string | undefined>()
   let shouldOpenSharePointPickerAfterOauth = $state(false)
 
-  const showSharePointSyncResult = (result: {
-    synced: number
-    failed: number
-    skipped?: number
-    totalDiscovered?: number
-  }) => {
-    const skipped = result.skipped ?? 0
+  const showSharePointSyncResult = (
+    result: SyncAgentKnowledgeSourcesResponse
+  ) => {
+    const skipped = result.skipped - result.unsupported
     const discovered = result.totalDiscovered ?? result.synced + skipped
 
     if (result.synced === 0 && result.failed === 0) {
@@ -149,7 +147,6 @@
       hasSharePointConnection,
       selectedSiteIds: effectiveSelectedSiteIds,
       sharePointSources,
-      sharePointSites,
       sharePointSyncRunsBySiteId,
       files,
       loadingSharePointSites,

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/knowledgeTableRows.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/knowledgeTableRows.ts
@@ -136,7 +136,7 @@ export const toSharePointConnectionRows = ({
         files,
         siteId
       )
-      const total = run?.totalDiscovered || 0
+      const total = (run?.totalDiscovered || 0) - (run?.unsupported || 0)
       const completed = Math.min(ready + failed, total)
       const siteDisplayName =
         site.name ||

--- a/packages/server/src/api/controllers/ai/files.ts
+++ b/packages/server/src/api/controllers/ai/files.ts
@@ -78,7 +78,6 @@ export async function uploadAgentFile(
     await unlinkSafe(filePath)
     throw new HTTPError("Unsupported file type for knowledge ingestion", 400)
   }
-  }
 
   const buffer = await readFile(filePath)
 

--- a/packages/server/src/api/controllers/ai/files.ts
+++ b/packages/server/src/api/controllers/ai/files.ts
@@ -6,6 +6,7 @@ import {
   DisconnectAgentKnowledgeSourcesResponse,
   FetchAgentKnowledgeSourceOptionsResponse,
   FetchAgentFilesResponse,
+  isKnowledgeFileSupported,
   SetAgentKnowledgeSourcesRequest,
   SetAgentKnowledgeSourcesResponse,
   SyncAgentKnowledgeSourcesRequest,
@@ -73,6 +74,9 @@ export async function uploadAgentFile(
     typeof upload.size === "number"
       ? upload.size
       : Number(upload.size) || undefined
+  if (!isKnowledgeFileSupported({ filename, mimetype })) {
+    throw new HTTPError("Unsupported file type for knowledge ingestion", 400)
+  }
 
   const buffer = await readFile(filePath)
 

--- a/packages/server/src/api/controllers/ai/files.ts
+++ b/packages/server/src/api/controllers/ai/files.ts
@@ -75,7 +75,9 @@ export async function uploadAgentFile(
       ? upload.size
       : Number(upload.size) || undefined
   if (!isKnowledgeFileSupported({ filename, mimetype })) {
+    await unlinkSafe(filePath)
     throw new HTTPError("Unsupported file type for knowledge ingestion", 400)
+  }
   }
 
   const buffer = await readFile(filePath)

--- a/packages/server/src/sdk/workspace/ai/rag/sharepoint.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/sharepoint.ts
@@ -7,6 +7,7 @@ import {
   type AgentKnowledgeSource,
   DocumentType,
   type FetchAgentKnowledgeSourceOptionsResponse,
+  isKnowledgeFileSupported,
   type KnowledgeSourceOption,
   type SyncAgentKnowledgeSourcesResponse,
 } from "@budibase/types"
@@ -238,6 +239,13 @@ interface SharePointFileRef {
   mimetype?: string
 }
 
+const isSupportedSharePointFile = (file: SharePointFileRef) => {
+  return isKnowledgeFileSupported({
+    filename: file.filename,
+    mimetype: file.mimetype,
+  })
+}
+
 const collectFilesRecursive = async (
   bearerToken: string,
   driveId: string,
@@ -460,12 +468,14 @@ export const syncSharePointSourcesForAgent = async (
   let synced = 0
   let failed = 0
   let skipped = 0
+  let unsupported = 0
   let totalDiscovered = 0
 
   for (const siteId of siteIds) {
     let siteSynced = 0
     let siteFailed = 0
     let siteSkipped = 0
+    let siteUnsupported = 0
     let siteTotalDiscovered = 0
     console.log("Starting SharePoint site sync for agent", {
       agentId: trimmedAgentId,
@@ -483,6 +493,13 @@ export const syncSharePointSourcesForAgent = async (
         siteTotalDiscovered += files.length
         totalDiscovered += files.length
         for (const file of files) {
+          if (!isSupportedSharePointFile(file)) {
+            skipped++
+            siteSkipped++
+            unsupported++
+            siteUnsupported++
+            continue
+          }
           const externalSourceId = `sharepoint:${siteId}:${driveId}:${file.itemId}`
           if (existingExternalIds.has(externalSourceId)) {
             skipped++
@@ -547,6 +564,7 @@ export const syncSharePointSourcesForAgent = async (
         synced: siteSynced,
         failed: siteFailed,
         skipped: siteSkipped,
+        unsupported: siteUnsupported,
         totalDiscovered: siteTotalDiscovered,
       })
     }
@@ -558,6 +576,7 @@ export const syncSharePointSourcesForAgent = async (
     synced,
     failed,
     skipped,
+    unsupported,
     totalDiscovered,
   })
 

--- a/packages/server/src/sdk/workspace/ai/rag/sharepoint.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/sharepoint.ts
@@ -356,6 +356,7 @@ export const fetchKnowledgeSourceSyncStateForAgent = async (
       synced: doc.synced,
       failed: doc.failed,
       skipped: doc.skipped,
+      unsupported: doc.unsupported,
       totalDiscovered: doc.totalDiscovered,
       status: doc.status,
     }))
@@ -446,6 +447,7 @@ export const syncSharePointSourcesForAgent = async (
       synced: 0,
       failed: 0,
       skipped: 0,
+      unsupported: 0,
       totalDiscovered: 0,
     }
   }
@@ -585,6 +587,8 @@ export const syncSharePointSourcesForAgent = async (
     synced,
     failed,
     skipped,
+    unsupported,
+
     totalDiscovered,
   }
 }

--- a/packages/types/src/api/web/global/agents.ts
+++ b/packages/types/src/api/web/global/agents.ts
@@ -50,6 +50,7 @@ export interface KnowledgeSourceSyncRun {
   synced: number
   failed: number
   skipped: number
+  unsupported: number
   totalDiscovered: number
   status: AgentKnowledgeSourceSyncRunStatus
 }
@@ -63,6 +64,7 @@ export interface SyncAgentKnowledgeSourcesResponse {
   synced: number
   failed: number
   skipped: number
+  unsupported: number
   totalDiscovered: number
 }
 

--- a/packages/types/src/core/index.ts
+++ b/packages/types/src/core/index.ts
@@ -1,3 +1,4 @@
 export * from "./installation"
 export * from "./events"
 export * from "./common"
+export * from "./knowledgeFiles"

--- a/packages/types/src/core/knowledgeFiles.ts
+++ b/packages/types/src/core/knowledgeFiles.ts
@@ -1,0 +1,86 @@
+export const KNOWLEDGE_FILE_EXTENSIONS = [
+  ".txt",
+  ".md",
+  ".markdown",
+  ".json",
+  ".yaml",
+  ".yml",
+  ".csv",
+  ".tsv",
+  ".pdf",
+  ".html",
+  ".htm",
+  ".xml",
+  ".doc",
+  ".docx",
+  ".ppt",
+  ".pptx",
+  ".xls",
+  ".xlsx",
+  ".rtf",
+] as const
+
+export const KNOWLEDGE_FILE_MIME_TYPES = [
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "text/tab-separated-values",
+  "application/pdf",
+  "application/json",
+  "application/yaml",
+  "text/yaml",
+  "application/xml",
+  "text/xml",
+  "text/html",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.ms-powerpoint",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.ms-excel",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/rtf",
+  "text/rtf",
+] as const
+
+export const KNOWLEDGE_FILE_ACCEPT_ATTRIBUTE =
+  KNOWLEDGE_FILE_EXTENSIONS.join(",")
+
+const KNOWLEDGE_FILE_EXTENSION_SET = new Set<string>(KNOWLEDGE_FILE_EXTENSIONS)
+const KNOWLEDGE_FILE_MIME_TYPE_SET = new Set<string>(KNOWLEDGE_FILE_MIME_TYPES)
+
+const trimString = (value?: string) =>
+  typeof value === "string" ? value.trim() : ""
+
+export const getKnowledgeFileExtension = (filename?: string) => {
+  const normalized = trimString(filename).toLowerCase()
+  const index = normalized.lastIndexOf(".")
+  if (index < 0) {
+    return ""
+  }
+  return normalized.slice(index)
+}
+
+export const isKnowledgeFileSupported = ({
+  filename,
+  mimetype,
+}: {
+  filename?: string
+  mimetype?: string
+}) => {
+  const extension = getKnowledgeFileExtension(filename)
+  if (extension && KNOWLEDGE_FILE_EXTENSION_SET.has(extension)) {
+    return true
+  }
+
+  const normalizedMimetype = trimString(mimetype).toLowerCase()
+  if (!normalizedMimetype) {
+    return false
+  }
+  if (normalizedMimetype.startsWith("image/")) {
+    return false
+  }
+  if (normalizedMimetype.startsWith("text/")) {
+    return true
+  }
+  return KNOWLEDGE_FILE_MIME_TYPE_SET.has(normalizedMimetype)
+}

--- a/packages/types/src/documents/global/agentKnowledgeSourceSyncState.ts
+++ b/packages/types/src/documents/global/agentKnowledgeSourceSyncState.ts
@@ -14,6 +14,7 @@ export interface AgentKnowledgeSourceSyncState extends Document {
   synced: number
   failed: number
   skipped: number
+  unsupported: number
   totalDiscovered: number
   status: AgentKnowledgeSourceSyncRunStatus
 }


### PR DESCRIPTION
## Description
Filter what files to upload

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a shared allowlist for knowledge file types and enforce it across uploads and SharePoint sync. Unsupported files are validated, skipped, and tracked to improve clarity and UX.

- **New Features**
  - Centralized allowed extensions/MIME types and helpers in `@budibase/types` (`knowledgeFiles`), exported from core; added `KNOWLEDGE_FILE_ACCEPT_ATTRIBUTE`.
  - Builder file input uses `KNOWLEDGE_FILE_ACCEPT_ATTRIBUTE`; SharePoint sync UI now reads `SyncAgentKnowledgeSourcesResponse`, shows skipped excluding unsupported, and subtracts `unsupported` from discovered totals in rows.
  - Server validates uploads with `isKnowledgeFileSupported` and returns 400 for unsupported files.
  - SharePoint sync skips unsupported files and reports them as `unsupported` in `SyncAgentKnowledgeSourcesResponse` and `KnowledgeSourceSyncRun`, persisted in sync state.

- **Bug Fixes**
  - Delete temp upload before erroring on unsupported types.

<sup>Written for commit 3a2289060083767b4f1af05abbd832623f431901. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

