### PR TITLE
fix builder crash for legacy ai config types

### DIFF
--- a/packages/builder/src/stores/portal/aiConfigs.test.ts
+++ b/packages/builder/src/stores/portal/aiConfigs.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest"
+import { get } from "svelte/store"
+import { AIConfigType, type AIConfigResponse } from "@budibase/types"
+import { AIConfigStore } from "./aiConfigs"
+
+vi.mock("@/api", () => ({
+  API: {
+    aiConfig: {
+      fetch: async () => [],
+    },
+  },
+}))
+
+const makeConfig = (
+  overrides: Partial<AIConfigResponse> = {}
+): AIConfigResponse => ({
+  _id: "cfg_1",
+  _rev: "1-test",
+  name: "test config",
+  provider: "OpenAI",
+  model: "gpt-5-mini",
+  isDefault: false,
+  webSearchConfig: undefined,
+  configType: AIConfigType.COMPLETIONS,
+  reasoningEffort: undefined,
+  credentialsFields: {},
+  ...overrides,
+})
+
+describe("AIConfigStore", () => {
+  it("groups known config types and ignores unsupported ones", () => {
+    const store = new AIConfigStore()
+    const completionsConfig = makeConfig()
+    const unsupportedConfig = makeConfig({
+      _id: "cfg_2",
+      configType: "embeddings" as AIConfigType,
+    })
+    const missingTypeConfig = makeConfig({
+      _id: "cfg_3",
+      configType: undefined as AIConfigType,
+    })
+
+    store.set({
+      customConfigs: [completionsConfig, unsupportedConfig, missingTypeConfig],
+      providers: undefined,
+    })
+
+    const state = get(store)
+
+    expect(state.customConfigsPerType.completions).toEqual([completionsConfig])
+  })
+})

--- a/packages/builder/src/stores/portal/aiConfigs.ts
+++ b/packages/builder/src/stores/portal/aiConfigs.ts
@@ -30,7 +30,10 @@ export class AIConfigStore extends DerivedBudiStore<
           DerivedAIConfigState["customConfigsPerType"]
         >(
           (acc, config) => {
-            acc[config.configType].push(config)
+            const configs = acc[config.configType]
+            if (configs) {
+              configs.push(config)
+            }
             return acc
           },
           {


### PR DESCRIPTION
## Description
Fixes a regression where switching an automation step binding to JavaScript could crash the builder for workspaces containing legacy AI configs with `configType: "embeddings"`.

The builder was still fetching those AI config records, but only initialising completion config buckets when grouping them for the editor. This change hardens that grouping logic so unsupported config types are ignored instead of crashing the UI.

## Addresses
- https://github.com/Budibase/budibase/issues/18498

## Context
- Not attached. The issue was reproduced from a cloud workspace that contained legacy AI configs with `configType: "embeddings"`.

## Launchcontrol
fix builder crash for legacy ai config types