### PR TITLE
Revert "Emit ACTION_AI_AGENT_EXECUTED event on every agent execution"

### DIFF
--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -1,6 +1,5 @@
 import {
   context,
-  events,
   features,
   docIds,
   getErrorMessage,
@@ -298,8 +297,6 @@ export async function webhookChat({
     throw responseResult.reason
   }
 
-  events.action.aiAgentExecuted({ agentId })
-
   const assistantText = textResult.value
   const assistantMessage: ChatConversation["messages"][number] = {
     id: v4(),
@@ -500,7 +497,6 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
       onError: error => getErrorMessage(error),
       onFinish: async ({ messages }) => {
         await sessionLogIndexer.index()
-        events.action.aiAgentExecuted({ agentId })
 
         if (chat.transient || !chatAppId) {
           return

--- a/packages/server/src/automations/steps/ai/agent.ts
+++ b/packages/server/src/automations/steps/ai/agent.ts
@@ -1,5 +1,5 @@
 import * as automationUtils from "../../automationUtils"
-import { events, getErrorMessage } from "@budibase/backend-core"
+import { getErrorMessage } from "@budibase/backend-core"
 import { quotas } from "@budibase/pro"
 import {
   AgentStepInputs,
@@ -223,8 +223,6 @@ export async function run({
           outputData: responseText,
           metadata: { stepCount: assistantMessage?.parts?.length ?? 0 },
         })
-
-        events.action.aiAgentExecuted({ agentId })
 
         return {
           success: true,

--- a/packages/server/src/automations/tests/steps/executeScript.spec.ts
+++ b/packages/server/src/automations/tests/steps/executeScript.spec.ts
@@ -1,4 +1,5 @@
 import { createAutomationBuilder } from "../utilities/AutomationTestBuilder"
+import * as automation from "../../index"
 import { Table } from "@budibase/types"
 import TestConfiguration from "../../../tests/utilities/TestConfiguration"
 import { basicTable } from "../../../tests/utilities/structures"
@@ -8,12 +9,11 @@ describe("Execute Script Automations", () => {
   let table: Table
 
   beforeAll(async () => {
+    await automation.init()
     await config.init()
-    await config.doInContext(config.getDevWorkspaceId(), async () => {
-      table = await config.api.table.save(basicTable())
-      await config.api.row.save(table._id!, {})
-      await config.api.automation.deleteAll()
-    })
+    table = await config.api.table.save(basicTable())
+    await config.api.row.save(table._id!, {})
+    await config.api.automation.deleteAll()
   })
 
   afterAll(() => {
@@ -21,97 +21,87 @@ describe("Execute Script Automations", () => {
   })
 
   it("should execute a basic script and return the result", async () => {
-    await config.doInContext(config.getDevWorkspaceId(), async () => {
-      const results = await createAutomationBuilder(config)
-        .onAppAction()
-        .executeScript({ code: "return 2 + 2" })
-        .test({ fields: {} })
+    const results = await createAutomationBuilder(config)
+      .onAppAction()
+      .executeScript({ code: "return 2 + 2" })
+      .test({ fields: {} })
 
-      expect(results.steps[0].outputs.value).toEqual(4)
-    })
+    expect(results.steps[0].outputs.value).toEqual(4)
   })
 
   it("should access bindings from previous steps", async () => {
-    await config.doInContext(config.getDevWorkspaceId(), async () => {
-      const results = await createAutomationBuilder(config)
-        .onAppAction()
-        .executeScript(
-          {
-            code: "return trigger.fields.data.map(x => x * 2)",
-          },
-          { stepId: "binding-script-step" }
-        )
-        .test({ fields: { data: [1, 2, 3] } })
+    const results = await createAutomationBuilder(config)
+      .onAppAction()
+      .executeScript(
+        {
+          code: "return trigger.fields.data.map(x => x * 2)",
+        },
+        { stepId: "binding-script-step" }
+      )
+      .test({ fields: { data: [1, 2, 3] } })
 
-      expect(results.steps[0].outputs.value).toEqual([2, 4, 6])
-    })
+    expect(results.steps[0].outputs.value).toEqual([2, 4, 6])
   })
 
   it("should handle script execution errors gracefully", async () => {
-    await config.doInContext(config.getDevWorkspaceId(), async () => {
-      const results = await createAutomationBuilder(config)
-        .onAppAction()
-        .executeScript({ code: "return nonexistentVariable.map(x => x)" })
-        .test({ fields: {} })
+    const results = await createAutomationBuilder(config)
+      .onAppAction()
+      .executeScript({ code: "return nonexistentVariable.map(x => x)" })
+      .test({ fields: {} })
 
-      expect(results.steps[0].outputs.response).toContain(
-        "ReferenceError: nonexistentVariable is not defined"
-      )
-      expect(results.steps[0].outputs.success).toEqual(false)
-    })
+    expect(results.steps[0].outputs.response).toContain(
+      "ReferenceError: nonexistentVariable is not defined"
+    )
+    expect(results.steps[0].outputs.success).toEqual(false)
   })
 
   it("should handle conditional logic in scripts", async () => {
-    await config.doInContext(config.getDevWorkspaceId(), async () => {
-      const results = await createAutomationBuilder(config)
-        .onAppAction()
-        .executeScript({
-          code: `
+    const results = await createAutomationBuilder(config)
+      .onAppAction()
+      .executeScript({
+        code: `
             if (trigger.fields.value > 5) {
               return "Value is greater than 5";
             } else {
               return "Value is 5 or less";
             }
           `,
-        })
-        .test({ fields: { value: 10 } })
+      })
+      .test({ fields: { value: 10 } })
 
-      expect(results.steps[0].outputs.value).toEqual("Value is greater than 5")
-    })
+    expect(results.steps[0].outputs.value).toEqual("Value is greater than 5")
   })
 
   it("should use multiple steps and validate script execution", async () => {
-    await config.doInContext(config.getDevWorkspaceId(), async () => {
-      const results = await createAutomationBuilder(config)
-        .onAppAction()
-        .serverLog(
-          { text: "Starting multi-step automation" },
-          { stepId: "start-log-step" }
-        )
-        .createRow(
-          { row: { name: "Test Row", value: 42, tableId: table._id } },
-          { stepId: "abc123" }
-        )
-        .executeScript(
-          {
-            code: `
+    const results = await createAutomationBuilder(config)
+      .onAppAction()
+      .serverLog(
+        { text: "Starting multi-step automation" },
+        { stepId: "start-log-step" }
+      )
+      .createRow(
+        { row: { name: "Test Row", value: 42, tableId: table._id } },
+        { stepId: "abc123" }
+      )
+      .executeScript(
+        {
+          code: `
             const createdRow = steps['abc123'];
             return createdRow.row.value * 2;
           `,
-          },
-          { stepId: "ScriptingStep1" }
-        )
-        .serverLog({
-          text: `Final result is {{ steps.ScriptingStep1.value }}`,
-        })
-        .test({ fields: {} })
-
-      expect(results.steps[0].outputs.message).toContain(
-        "Starting multi-step automation"
+        },
+        { stepId: "ScriptingStep1" }
       )
-      expect(results.steps[1].outputs.row.value).toEqual(42)
-      expect(results.steps[2].outputs.value).toEqual(84)
-      expect(results.steps[3].outputs.message).toContain("Final result is 84")
-    })
+      .serverLog({
+        text: `Final result is {{ steps.ScriptingStep1.value }}`,
+      })
+      .test({ fields: {} })
+
+    expect(results.steps[0].outputs.message).toContain(
+      "Starting multi-step automation"
+    )
+    expect(results.steps[1].outputs.row.value).toEqual(42)
+    expect(results.steps[2].outputs.value).toEqual(84)
+    expect(results.steps[3].outputs.message).toContain("Final result is 84")
   })
 })


### PR DESCRIPTION
Reverts Budibase/budibase#18492

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the change that emitted the ACTION_AI_AGENT_EXECUTED event on each agent run, restoring previous behavior. Removes the event dispatch from chat and automation agent code and updates tests to the current setup.

- **Refactors**
  - Removed aiAgentExecuted event calls from chat conversation webhook and automation agent step.
  - Updated tests to init `automation` in beforeAll and avoid `doInContext` for setup.

<sup>Written for commit d4e6140de6df24fbfafc804f4346ef6efa554444. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

