### PR TITLE
Setup dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,24 +5,19 @@ updates:
     schedule:
       interval: "daily"
     groups:
-      non-major-version:
-        applies-to: version-updates
+      all-non-major:
         patterns:
           - "*"
         update-types:
           - "minor"
           - "patch"
-      non-major-security:
+      all-non-major-security:
         applies-to: security-updates
         patterns:
           - "*"
         update-types:
           - "minor"
           - "patch"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -43,7 +38,3 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      non-major-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      non-major-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      non-major-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      non-major-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"

--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -16,6 +16,9 @@ on:
         description: Force running checks as if it was an OSS contributor
         default: false
 
+permissions:
+  contents: read
+
 env:
   BRANCH: ${{ github.event.pull_request.head.ref }}
   BASE_BRANCH: ${{ github.event.pull_request.base.ref}}
@@ -34,7 +37,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js 22.x
         uses: actions/setup-node@v6
@@ -73,7 +76,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js 22.x
         uses: actions/setup-node@v6
@@ -98,7 +101,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js 22.x
         uses: actions/setup-node@v6
@@ -121,7 +124,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 2
 
       - name: Fetch base branch for affected tasks
@@ -163,7 +166,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js 22.x
         uses: actions/setup-node@v6
@@ -208,7 +211,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 2
 
       - name: Fetch base branch for affected tasks
@@ -262,7 +265,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 2
 
       - name: Fetch base branch for affected tasks
@@ -341,7 +344,7 @@ jobs:
         if: needs.compute-affected-jobs.outputs.run_worker_tests == 'true'
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js 22.x
         if: needs.compute-affected-jobs.outputs.run_worker_tests == 'true'
@@ -437,7 +440,7 @@ jobs:
         if: needs.compute-affected-jobs.outputs.run_server_tests == 'true'
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js 22.x
         if: needs.compute-affected-jobs.outputs.run_server_tests == 'true'
@@ -531,7 +534,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js 22.x
         uses: actions/setup-node@v6
@@ -565,7 +568,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js 22.x
         uses: actions/setup-node@v6
@@ -626,7 +629,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js 22.x
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Description
Setup dependabot config

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable automated dependency updates and make CI run on Dependabot PRs. Adds daily `npm` and `github-actions` checks (minor/patch only) and switches CI checkout to `secrets.GITHUB_TOKEN` with read permissions.

- **New Features**
  - Added `.github/dependabot.yml` with daily checks for `npm` and `github-actions`; unified non‑major groups for both version and security updates.
  - Updated `.github/workflows/budibase_ci.yml`: set `permissions: contents: read` and use `secrets.GITHUB_TOKEN` for `actions/checkout@v6`.

<sup>Written for commit 423961b5c0b826dc0c25a2fe6c47bb352284bdc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

