### PR TITLE
[Dependabot] Only update on security vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
     groups:
-      all-non-major:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
       all-non-major-security:
         applies-to: security-updates
         patterns:
@@ -23,14 +18,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
     groups:
-      non-major-version:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
       non-major-security:
         applies-to: security-updates
         patterns:


### PR DESCRIPTION
## Description
[Dependabot] Only update on security vulnerabilities

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configured Dependabot to only create PRs for security vulnerabilities. Removed non-major version update groups and set open-pull-requests-limit: 0, disabling routine version updates while keeping security update groups active.

<sup>Written for commit 4f38ddf7732b99676fe3a23adc0f1083e5f51fa6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

