### PR TITLE
Add ignore rule for @budibase dependencies in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "@budibase/*"
     open-pull-requests-limit: 0
     groups:
       all-non-major-security:


### PR DESCRIPTION
## Description
Add ignore rule for @budibase dependencies in dependabot configuration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Dependabot to ignore `@budibase/*` packages so it no longer opens update PRs for those dependencies. This reduces noise and lets us manage these updates manually.

<sup>Written for commit 35565313f5325ecdcf6975719ead64a7a2c6d12e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

