### PR TITLE
Fix tsconfig

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 # Helm chart validation (only runs when charts/ files are staged)
-sh "$(dirname "$0")/../scripts/helm-pre-commit.sh"
+"$(dirname "$0")/../scripts/helm-pre-commit.sh"

--- a/packages/bbui/src/css.d.ts
+++ b/packages/bbui/src/css.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css"

--- a/packages/bbui/tsconfig.json
+++ b/packages/bbui/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
+    "noEmit": true,
     "allowJs": true,
     "outDir": "./dist",
     "lib": ["ESNext"],
-    "baseUrl": ".",
     "paths": {
       "@budibase/*": [
         "../*/src/index.ts",

--- a/packages/builder/tsconfig.json
+++ b/packages/builder/tsconfig.json
@@ -2,17 +2,13 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
     "outDir": "./dist",
     "lib": ["ESNext"],
     "paths": {
-      "@budibase/*": [
-        "../*/src/index.ts",
-        "../*/src/index.js",
-        "../*",
-        "../../node_modules/@budibase/*"
-      ],
-      "assets/*": ["assets/*"],
-      "@/*": ["src/*"]
+      "@budibase/*": ["../*/src/index.ts"],
+      "assets/*": ["./assets/*"],
+      "@/*": ["./src/*"]
     }
   },
   "exclude": []

--- a/packages/builder/tsconfig.json
+++ b/packages/builder/tsconfig.json
@@ -4,7 +4,6 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "./dist",
     "lib": ["ESNext"],
-    "baseUrl": ".",
     "paths": {
       "@budibase/*": [
         "../*/src/index.ts",

--- a/packages/pro/package.json
+++ b/packages/pro/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "setup": "yarn && yarn build",
     "prebuild": "rimraf dist",
-    "build": "node ../../scripts/build.js && yarn build:types",
+    "build": "node ./scripts/build.js && yarn build:types",
     "build:types": "tsc -p tsconfig.build.json --emitDeclarationOnly --paths null",
     "check:types": "tsc -p tsconfig.build.json --noEmit --incremental --paths null",
     "test": "jest --runInBand",

--- a/packages/pro/scripts/build.js
+++ b/packages/pro/scripts/build.js
@@ -1,0 +1,13 @@
+#!/usr/bin/node
+const coreBuild = require("../../../scripts/build")
+
+const externals = [
+  "deasync",
+  "better-sqlite3",
+  "mysql",
+  "pg-query-stream",
+  "sqlite3",
+  "pg-native",
+]
+
+coreBuild("./src/index.ts", "./dist/index.js", { external: externals })

--- a/packages/pro/tsconfig.json
+++ b/packages/pro/tsconfig.json
@@ -3,11 +3,11 @@
   "compilerOptions": {
     "sourceMap": true,
     "paths": {
-      "@budibase/types": ["./packages/types/src"],
-      "@budibase/backend-core": ["./packages/backend-core/src"],
-      "@budibase/backend-core/*": ["./packages/backend-core/*"],
-      "@budibase/shared-core": ["./packages/shared-core/src"],
-      "@budibase/string-templates": ["./packages/string-templates/src"]
+      "@budibase/types": ["../types/src"],
+      "@budibase/backend-core": ["../backend-core/src"],
+      "@budibase/backend-core/*": ["../backend-core/*"],
+      "@budibase/shared-core": ["../shared-core/src"],
+      "@budibase/string-templates": ["../string-templates/src"]
     }
   },
   "include": ["src/**/*", "tests/**/*"],

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  },
   "ts-node": {
     "require": ["tsconfig-paths/register"],
     "swc": true

--- a/packages/string-templates/tsconfig.json
+++ b/packages/string-templates/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "lib": ["dom"],
-    "baseUrl": ".",
     "outDir": "dist"
   },
   "include": ["src/**/*"]

--- a/packages/upgrade-tests/tsconfig.build.json
+++ b/packages/upgrade-tests/tsconfig.build.json
@@ -6,7 +6,6 @@
     "allowArbitraryExtensions": true,
     "isolatedModules": false,
     "outDir": "./dist",
-    "baseUrl": ".",
     "rootDir": "."
   },
   "include": ["src/**/*"],

--- a/packages/upgrade-tests/tsconfig.build.json
+++ b/packages/upgrade-tests/tsconfig.build.json
@@ -5,8 +5,7 @@
     "lib": ["es2020"],
     "allowArbitraryExtensions": true,
     "isolatedModules": false,
-    "outDir": "./dist",
-    "rootDir": "."
+    "outDir": "./dist"
   },
   "include": ["src/**/*"],
   "exclude": [

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -16,6 +16,9 @@ const {
 } = require("@esbuild-plugins/tsconfig-paths")
 const { nodeExternalsPlugin } = require("esbuild-node-externals")
 
+const workspacePackageAllowList =
+  /^@budibase\/(backend-core|shared-core|types|pro|string-templates|frontend-core|bbui)(\/.*)?$/
+
 const svelteCompilePlugin = {
   name: "svelteCompile",
   setup(build) {
@@ -86,7 +89,7 @@ async function runBuild(entry, outfile, opts = {}) {
       TsconfigPathsPlugin({ tsconfig: tsconfigPathPluginContent }),
       nodeExternalsPlugin({
         allowList: [
-          "@budibase/frontend-core",
+          workspacePackageAllowList,
           "svelte",
           "chat",
           "@chat-adapter/discord",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,7 +10,6 @@
     "skipLibCheck": true,
     "declaration": true,
     "isolatedModules": true,
-    "baseUrl": ".",
     "sourceMap": true,
     "paths": {
       "@budibase/types": ["./packages/types/src"],

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -12,15 +12,15 @@
     "isolatedModules": true,
     "sourceMap": true,
     "paths": {
-      "@budibase/types": ["./packages/types/src"],
-      "@budibase/backend-core": ["./packages/backend-core/src"],
-      "@budibase/backend-core/*": ["./packages/backend-core/*"],
-      "@budibase/shared-core": ["./packages/shared-core/src"],
-      "@budibase/pro": ["./packages/pro/src"],
-      "@budibase/string-templates": ["./packages/string-templates/src"],
-      "@budibase/string-templates/*": ["./packages/string-templates/*"],
-      "@budibase/frontend-core": ["./packages/frontend-core/src"],
-      "@budibase/bbui": ["./packages/bbui/src"]
+      "@budibase/types": ["../types/src"],
+      "@budibase/backend-core": ["../backend-core/src"],
+      "@budibase/backend-core/*": ["../backend-core/*"],
+      "@budibase/shared-core": ["../shared-core/src"],
+      "@budibase/pro": ["../pro/src"],
+      "@budibase/string-templates": ["../string-templates/src"],
+      "@budibase/string-templates/*": ["../string-templates/*"],
+      "@budibase/frontend-core": ["../frontend-core/src"],
+      "@budibase/bbui": ["../bbui/src"]
     }
   },
   "exclude": []


### PR DESCRIPTION
## Description
_Describe the problem or feature in addition to a link to the relevant github issues._

## Addresses
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._

## Launchcontrol

_Add a small description in layman's terms of what this PR achieves. This will be used in the release notes._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TypeScript path resolution and build issues across the monorepo. Removes deprecated config, adds missing typings, and ensures builds correctly handle internal packages and the `pro` package.

- **Bug Fixes**
  - Standardized tsconfig: removed `baseUrl` and corrected `paths` in `packages/builder`, `packages/bbui`, `packages/pro`, `packages/string-templates`, and root `tsconfig.build.json`; set `"noEmit": true` in `packages/builder` and `packages/bbui`; fixed local aliases in `packages/builder` (`assets/*`, `@/*`).
  - Added typings: `packages/bbui/src/css.d.ts` for CSS modules; `"types": ["node", "jest"]` in `packages/server`.
  - `packages/upgrade-tests`: removed conflicting `rootDir`/`baseUrl` to avoid build errors.
  - `.husky/pre-commit`: run Helm validation via its shebang.

- **Refactors**
  - Updated `scripts/build.js`: switched the `esbuild-node-externals` allowlist to a regex covering workspace `@budibase/*` packages and kept `@esbuild-plugins/tsconfig-paths` resolution.
  - `packages/pro`: added `scripts/build.js` and updated `package.json` to use it; externalizes native deps (`deasync`, `better-sqlite3`, `mysql`, `pg-query-stream`, `sqlite3`, `pg-native`).

<sup>Written for commit 9adf4fc89d32cab09b4edbe2f8a23464d682f2f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

