### PR TITLE
[GHSA-4f9j-vr4p-642r] Set budibase:auth cookie with HttpOnly flag

### DIFF
--- a/packages/backend-core/src/utils/utils.ts
+++ b/packages/backend-core/src/utils/utils.ts
@@ -206,7 +206,7 @@ export function setCookie(
   ctx: Ctx,
   value: any,
   name = "builder",
-  opts = { sign: true }
+  opts: { sign: boolean; httpOnly?: boolean } = { sign: true }
 ) {
   if (value && opts && opts.sign) {
     value = jwt.sign(value, env.JWT_SECRET as Secret)
@@ -215,7 +215,7 @@ export function setCookie(
   const config: SetOption = {
     expires: MAX_VALID_DATE,
     path: "/",
-    httpOnly: false,
+    httpOnly: opts.httpOnly ?? false,
     overwrite: true,
   }
 

--- a/packages/builder/src/api.ts
+++ b/packages/builder/src/api.ts
@@ -45,21 +45,15 @@ const newClient = (opts?: { production?: boolean }) =>
       // Log all errors to console
       console.warn(`[Builder] HTTP ${status} on ${method}:${url}\n\t${message}`)
 
-      // In the event that the server has terminated the session, we need to
-      // manually clear the auth user, trigger a redirect to auth.
-      const hasAuthCookie = !!CookieUtils.getCookie(Constants.Cookies.Auth)
-
-      if (!hasAuthCookie && get(auth).user) {
+      // On 401 the server has explicitly rejected the credentials.
+      // Clear the client session and let the layout redirect to login
+      if (status === 401 && get(auth).user) {
         auth.clearSession()
-        // Let the user be redirected to auth by the core layout
         return
       }
 
       // Logout on 403's
       if (status === 403) {
-        // Remove cookies
-        CookieUtils.removeCookie(Constants.Cookies.Auth)
-
         const isAuthenticated = !!get(auth).user
         if (isAuthenticated) {
           // Clear return URL to prevent redirect loops with invalid URLs

--- a/packages/worker/src/api/controllers/global/auth.ts
+++ b/packages/worker/src/api/controllers/global/auth.ts
@@ -95,7 +95,7 @@ async function passportCallback(
   const loginResult = await authSdk.loginUser(user)
 
   // set a cookie for browser access
-  setCookie(ctx, loginResult.token, Cookie.Auth, { sign: false })
+  setCookie(ctx, loginResult.token, Cookie.Auth, { sign: false, httpOnly: true })
   // set the token in a header as well for APIs
   ctx.set(Header.TOKEN, loginResult.token)
 

--- a/packages/worker/src/api/controllers/global/auth.ts
+++ b/packages/worker/src/api/controllers/global/auth.ts
@@ -95,7 +95,10 @@ async function passportCallback(
   const loginResult = await authSdk.loginUser(user)
 
   // set a cookie for browser access
-  setCookie(ctx, loginResult.token, Cookie.Auth, { sign: false, httpOnly: true })
+  setCookie(ctx, loginResult.token, Cookie.Auth, {
+    sign: false,
+    httpOnly: true,
+  })
   // set the token in a header as well for APIs
   ctx.set(Header.TOKEN, loginResult.token)
 


### PR DESCRIPTION
## Description

The `budibase:auth` session cookie was set with `httpOnly: false` in `packages/backend-core/src/utils/utils.ts`. This allows any JavaScript running in the browser to read the JWT session token via `document.cookie`. Combined with any XSS vulnerability — including the previously reported stored XSS (GHSA-gp5x-2v54-v2q5) — this escalates the attack to a full account takeover: the attacker steals the JWT and has persistent access to the victim's account.

**CWE-1004** — Sensitive Cookie Without 'HttpOnly' Flag. CVSS 8.1 (High).

This PR addresses only the `httpOnly` flag. `secure` and `sameSite` hardening are out of scope here and will be addressed separately.

## Addresses
- https://github.com/Budibase/budibase/security/advisories/GHSA-4f9j-vr4p-642r

## Changes

### `packages/backend-core/src/utils/utils.ts`
`setCookie()` is a shared utility used by all server-set cookies (auth, init, OIDC config, recaptcha session, feature flags, etc.). Setting `httpOnly: true` unconditionally would break any cookie that needs to be readable from JavaScript. The fix adds `httpOnly` as an **optional** parameter in `opts`, defaulting to `false` to preserve existing behaviour for all other cookies.

### `packages/worker/src/api/controllers/global/auth.ts`
The only call site where `Cookie.Auth` is written — shared by password login, Google SSO and OIDC callbacks, all of which go through `passportCallback`. Passes `httpOnly: true` explicitly.

### `packages/builder/src/api.ts`
The builder's API error handler previously detected server-terminated sessions by reading `budibase:auth` from `document.cookie`. With `httpOnly: true` that is no longer possible — the browser will not expose the cookie to JavaScript. The check is replaced with an explicit `status === 401` guard. The existing `403` path (session expired → server clears cookie → returns 403 via auth guard middlewares → `location.reload()`) continues to work unchanged; the reload redirects to login because the cookie is gone. The `status === 401` guard is forward-looking for when the server is updated to return semantically correct 401 responses for authentication failures.

The client-side `CookieUtils.removeCookie(Cookie.Auth)` call on 403 is also removed — it was a no-op with `httpOnly: true` since JavaScript cannot delete an `httpOnly` cookie; server-side `clearCookie()` already handles this.

## ⚠️ Account Portal companion issue required

**This fix alone has no effect on Budibase Cloud.** In Cloud deployments, the `budibase:auth` cookie is ultimately issued by the **Account Portal**, not by this repository. The Account Portal must apply the same `httpOnly: true` flag when setting this cookie, otherwise the vulnerability remains exploitable for Cloud users. A separate issue must be created in the `account-portal` repository to track this.

## Launchcontrol

Hardens the `budibase:auth` session cookie with the `HttpOnly` flag, preventing JavaScript from reading the JWT token and eliminating the cookie-theft vector that turns any XSS into an account takeover.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the `budibase:auth` session cookie with `HttpOnly` to block JavaScript access to the JWT and close the XSS-to-account-takeover vector (GHSA-4f9j-vr4p-642r).

- **Bug Fixes**
  - `packages/backend-core/src/utils/utils.ts`: `setCookie()` now accepts `httpOnly?` (default `false`) to keep JS-readable cookies working.
  - `packages/worker/src/api/controllers/global/auth.ts`: Set `Cookie.Auth` with `{ httpOnly: true }`.
  - `packages/builder/src/api.ts`: Stop reading `budibase:auth` via `document.cookie`; use `status === 401` to clear session and remove client-side delete on 403.

- **Migration**
  - Budibase Cloud: The Account Portal must also set `budibase:auth` with `HttpOnly: true` or the issue remains exploitable.

<sup>Written for commit 20b18972a080f14e3235eef1ce557a48aaa08f4b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

