### PR TITLE
prevents user from dragging images and selecting text

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/design/_components/NewScreen/TypeModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/_components/NewScreen/TypeModal.svelte
@@ -42,7 +42,7 @@
         on:click={() => (selectedType = type.id)}
       >
         <div class="image">
-          <img alt={type.img.alt} src={type.img.src} />
+          <img alt={type.img.alt} src={type.img.src} draggable="false" />
         </div>
         <div class="typeContent">
           <Body>{type.title}</Body>
@@ -63,6 +63,7 @@
     border-radius: 4px;
     display: flex;
     overflow: hidden;
+    user-select: none;
   }
 
   .type:hover {
@@ -92,5 +93,6 @@
 
   .image img {
     height: 100%;
+    -webkit-user-drag: none;
   }
 </style>

--- a/packages/builder/src/pages/builder/workspace/[application]/design/_components/NewScreen/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/_components/NewScreen/index.svelte
@@ -250,7 +250,6 @@
     flex-direction: column;
     gap: 2px;
     min-height: 46px;
-
     user-select: none;
   }
   .text :global(p:first-child) {

--- a/packages/builder/src/pages/builder/workspace/[application]/design/_components/NewScreen/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/_components/NewScreen/index.svelte
@@ -113,7 +113,7 @@
           class:selected={selectedType === AutoScreenTypes.BLANK}
         >
           <div class="image">
-            <img alt="A blank screen" src={blank} />
+            <img alt="A blank screen" src={blank} draggable="false" />
           </div>
           <div class="text">
             <Body
@@ -131,7 +131,7 @@
           class:selected={selectedType === AutoScreenTypes.TABLE}
         >
           <div class="image">
-            <img alt="A table of data" src={table} />
+            <img alt="A table of data" src={table} draggable="false" />
           </div>
           <div class="text">
             <Body
@@ -149,7 +149,7 @@
           class:selected={selectedType === AutoScreenTypes.FORM}
         >
           <div class="image">
-            <img alt="A form containing data" src={form} />
+            <img alt="A form containing data" src={form} draggable="false" />
           </div>
           <div class="text">
             <Body
@@ -170,7 +170,7 @@
           class:selected={selectedType === AutoScreenTypes.PDF}
         >
           <div class="image">
-            <img alt="A PDF document" src={pdf} width="185" />
+            <img alt="A PDF document" src={pdf} width="185" draggable="false" />
           </div>
           <div class="text">
             <Body
@@ -250,6 +250,8 @@
     flex-direction: column;
     gap: 2px;
     min-height: 46px;
+
+    user-select: none;
   }
   .text :global(p:first-child) {
     display: flex;


### PR DESCRIPTION
## Description
This PR is purely selfish - when I'm rushing to create a new screen with an idea burning in my mind, I often mis-click and instead of selecting a new screen type, I accidentally drag the image or select/highlight the text instead.

These changes prevent the images from being dragged, and prevent the text from being selected.

## Screenshots
Before: https://jam.dev/c/87aec849-eb7d-45dc-8a71-bd8bed6d7594 

After: https://jam.dev/c/ee55b11c-d34c-4dea-bb77-e3745542ad28

## Launchcontrol

_Prevents images and text in new-screen modals from being selected or dragged._
