### PR TITLE
Fix stale credentials on CouchDB pods after Helm upgrades

### DIFF
--- a/charts/budibase/charts/couchdb/templates/secrets.yaml
+++ b/charts/budibase/charts/couchdb/templates/secrets.yaml
@@ -10,8 +10,10 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  adminUsername: {{ template "couchdb.defaultsecret" .Values.adminUsername }}
-  adminPassword: {{ template "couchdb.defaultsecret" .Values.adminPassword }}
+  {{- $adminUsernameArgs := dict "key" "adminUsername" "ns" $.Release.Namespace "secretName" (include "couchdb.fullname" .) "secret" .Values.adminUsername }}
+  adminUsername: {{ template "couchdb.defaultsecret-stateful" $adminUsernameArgs }}
+  {{- $adminPasswordArgs := dict "key" "adminPassword" "ns" $.Release.Namespace "secretName" (include "couchdb.fullname" .) "secret" .Values.adminPassword }}
+  adminPassword: {{ template "couchdb.defaultsecret-stateful" $adminPasswordArgs }}
   {{- $erlangCookieArgs := dict "key" "erlangCookie" "ns" $.Release.Namespace "secretName" (include "couchdb.fullname" .) "secret" .Values.erlangFlags.setcookie }}
   erlangCookie: {{ template "couchdb.defaultsecret-stateful" $erlangCookieArgs }}
   cookieAuthSecret: {{ template "couchdb.defaultsecret" .Values.cookieAuthSecret }}

--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -26,6 +26,9 @@ spec:
     metadata:
       annotations:
         ad.datadoghq.com/bbapps.logs: '[{"source":"nodejs"}]'
+{{- if .Values.services.couchdb.enabled }}
+        checksum/couchdb-secret: {{ (lookup "v1" "Secret" .Release.Namespace (include "couchdb.fullname" .)) | toYaml | sha256sum }}
+{{- end }}
 {{ if .Values.services.apps.templateAnnotations }}
 {{- toYaml .Values.services.apps.templateAnnotations | indent 8 -}}
 {{ end }}

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -26,6 +26,9 @@ spec:
     metadata:
       annotations:
         ad.datadoghq.com/bbworker.logs: '[{"source":"nodejs"}]'
+{{- if .Values.services.couchdb.enabled }}
+        checksum/couchdb-secret: {{ (lookup "v1" "Secret" .Release.Namespace (include "couchdb.fullname" .)) | toYaml | sha256sum }}
+{{- end }}
 {{ if .Values.services.worker.templateAnnotations }}
 {{- toYaml .Values.services.worker.templateAnnotations | indent 8 -}}
 {{ end }}


### PR DESCRIPTION
## Description
Currently the secret regenerates on every helm upgrade while the CouchDB entrypoint ignores new credentials if any already exist. This creates stale disk credentials that need to be wiped manually for the live secret values to be respected.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop regenerating CouchDB admin credentials on Helm upgrades and roll dependent pods when the secret changes. This prevents stale on-disk creds and auth mismatches.

- **Bug Fixes**
  - Make `adminUsername` and `adminPassword` stateful via `couchdb.defaultsecret-stateful` so values persist across upgrades.
  - Add `checksum/couchdb-secret` annotation to app and worker deployments (when CouchDB is enabled) to roll pods on secret changes.

<sup>Written for commit f817afba38a27a67c1ddb4b72635073c1fd6b7fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

