### PR TITLE
Add inheritance and variant options for button groups and individual buttons

### DIFF
--- a/packages/bbui/src/ButtonGroup/CollapsedButtonGroup.svelte
+++ b/packages/bbui/src/ButtonGroup/CollapsedButtonGroup.svelte
@@ -6,6 +6,7 @@
 
   export let buttons
   export let text = "Action"
+  export let type = "primary"
   export let size = "M"
   export let align = "left"
   export let offset
@@ -19,6 +20,12 @@
     popover.hide()
     await button.onClick?.()
   }
+
+  $: cta = type === "cta"
+  $: primary = type === "primary"
+  $: secondary = type === "secondary"
+  $: warning = type === "warning"
+  $: overBackground = type === "overBackground"
 </script>
 
 <Button
@@ -26,9 +33,12 @@
   {size}
   icon="caret-down"
   {quiet}
-  primary={quiet}
-  cta={!quiet}
-  newStyles={!quiet}
+  {cta}
+  {primary}
+  {secondary}
+  {warning}
+  {overBackground}
+  newStyles={true}
   on:click={() => popover?.show()}
   on:click
   reverse

--- a/packages/builder/src/components/design/settings/componentSettings.js
+++ b/packages/builder/src/components/design/settings/componentSettings.js
@@ -38,6 +38,7 @@ import TableConditionEditor from "./controls/TableConditionEditor.svelte"
 import ButtonConditionEditor from "./controls/ButtonConditionEditor.svelte"
 import MultilineDrawerBindableInput from "@/components/common/MultilineDrawerBindableInput.svelte"
 import FilterableSelect from "./controls/FilterableSelect.svelte"
+import InfoDisplay from "@/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Component/InfoDisplay.svelte"
 import { setComponentSettingsResolver } from "./componentSettingsRegistry"
 
 const componentMap = {
@@ -110,6 +111,7 @@ const componentMap = {
   "validation/signature_single": ValidationEditor,
   "validation/link": ValidationEditor,
   "validation/bb_reference": ValidationEditor,
+  infoDisplay: InfoDisplay,
 }
 
 export const getComponentForSetting = setting => {

--- a/packages/builder/src/components/design/settings/controls/ButtonConfiguration/ButtonConfiguration.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonConfiguration/ButtonConfiguration.svelte
@@ -75,7 +75,8 @@
       {
         _instanceName: Helpers.uuid(),
         text: cfg.text,
-        type: cfg.type || "primary",
+        type: cfg.type || "inherit",
+        size: cfg.size || "inherit",
       }
     )
   }

--- a/packages/builder/src/components/design/settings/controls/ButtonConfiguration/ButtonSetting.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonConfiguration/ButtonSetting.svelte
@@ -3,6 +3,7 @@
   import { Icon } from "@budibase/bbui"
   import { runtimeToReadableBinding } from "@/dataBinding"
   import { isJSBinding } from "@budibase/string-templates"
+  import { title } from "process"
 
   export let item
   export let componentBindings
@@ -22,21 +23,54 @@
   // We will need to update this in future if the normal button component
   // gets broken into multiple settings sections, as we assume a flat array.
   const updatedNestedFlags = settings => {
-    if (!nested || !settings?.length) {
+    if (!settings?.length) {
       return settings
     }
-    let newSettings = settings.map(setting => ({
-      ...setting,
-      nested: true,
-    }))
-    // We need to prevent bindings for the button names because of how grid
-    // blocks work. This is an edge case but unavoidable.
-    let name = newSettings.find(x => x.key === "text")
-    if (name) {
-      name.disableBindings = true
+    let newSettings = nested
+      ? settings.map(setting => ({ ...setting, nested: true }))
+      : [...settings]
+    if (nested) {
+      // We need to prevent bindings for the button names because of how grid
+      // blocks work. This is an edge case but unavoidable.
+      let name = newSettings.find(x => x.key === "text")
+      if (name) {
+        name.disableBindings = true
+      }
+      if (parentComponent?._component?.endsWith("/gridblock")) {
+        newSettings = newSettings.filter(setting => setting.key !== "size")
+      }
     }
-    if (parentComponent?._component?.endsWith("/gridblock")) {
-      newSettings = newSettings.filter(setting => setting.key !== "size")
+    // For buttons inside a button group, inject an "Inherit" option for variant
+    // and size so individual buttons can fall back to the group-level settings.
+    if (parentComponent?._component?.endsWith("/buttongroup")) {
+      const typeSetting = newSettings.find(x => x.key === "type")
+      if (typeSetting?.options) {
+        typeSetting.options = [
+          { label: "Inherit", value: "inherit" },
+          ...typeSetting.options,
+        ]
+      }
+      const sizeSetting = newSettings.find(x => x.key === "size")
+      if (sizeSetting?.options) {
+        sizeSetting.options = [
+          { label: "Inherit", value: "inherit" },
+          ...sizeSetting.options,
+        ]
+      }
+      // Insert info display after the size setting
+      const sizeIndex = newSettings.findIndex(x => x.key === "size")
+      if (sizeIndex !== -1) {
+        newSettings.splice(sizeIndex + 1, 0, {
+          type: "infoDisplay",
+          key: "inheritInfo",
+          label: "",
+          labelHidden: true,
+          wide: true,
+          title: "Button type and size inheritance",
+          icon: "info",
+          body: "These override the Variant and Size of the individual button when specified. Set to &quot;Inherit&quot; to use the size specified in the button group's settings.",
+        })
+      }
     }
     return newSettings
   }

--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Component/ComponentSettingsSection.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Component/ComponentSettingsSection.svelte
@@ -171,6 +171,11 @@
                 // Component configuration
                 componentType: setting.componentType,
                 wide: setting.wide,
+
+                // InfoDisplay settings
+                icon: setting.icon,
+                title: setting.title,
+                body: setting.body,
               }}
               {bindings}
               {componentBindings}

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -429,14 +429,60 @@
             "nested": true,
             "defaultValue": [
               {
-                "type": "cta",
-                "text": "Button 1"
+                "text": "Button 1",
+                "type": "inherit",
+                "size": "inherit"
               },
               {
-                "type": "primary",
-                "text": "Button 2"
+                "text": "Button 2",
+                "type": "inherit",
+                "size": "inherit"
               }
             ]
+          }
+        ]
+      },
+      {
+        "section": true,
+        "name": "Button style",
+        "settings": [
+          {
+            "type": "select",
+            "label": "Variant",
+            "key": "buttonType",
+            "options": [
+              {
+                "label": "Action",
+                "value": "cta"
+              },
+              {
+                "label": "Primary",
+                "value": "primary"
+              },
+              {
+                "label": "Secondary",
+                "value": "secondary"
+              },
+              {
+                "label": "Warning",
+                "value": "warning"
+              },
+              {
+                "label": "Over background",
+                "value": "overBackground"
+              }
+            ],
+            "defaultValue": "primary"
+          },
+          {
+            "type": "boolean",
+            "label": "Quiet",
+            "key": "buttonQuiet"
+          },
+          {
+            "type": "boolean",
+            "label": "Disabled",
+            "key": "buttonDisabled"
           }
         ]
       },
@@ -461,6 +507,34 @@
             "label": "Collapsed button size",
             "key": "collapsedSize",
             "dependsOn": "collapsed",
+            "options": [
+              {
+                "label": "Small",
+                "value": "S"
+              },
+              {
+                "label": "Medium",
+                "value": "M"
+              },
+              {
+                "label": "Large",
+                "value": "L"
+              },
+              {
+                "label": "Extra Large",
+                "value": "XL"
+              }
+            ],
+            "defaultValue": "M"
+          },
+          {
+            "type": "select",
+            "label": "Button size",
+            "key": "buttonSize",
+            "dependsOn": {
+              "setting": "collapsed",
+              "invert": true
+            },
             "options": [
               {
                 "label": "Small",

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -475,14 +475,42 @@
             "defaultValue": "primary"
           },
           {
-            "type": "boolean",
-            "label": "Quiet",
-            "key": "buttonQuiet"
+            "type": "select",
+            "label": "Size",
+            "key": "buttonSize",
+            "dependsOn": {
+              "setting": "collapsed",
+              "invert": true
+            },
+            "options": [
+              {
+                "label": "Small",
+                "value": "S"
+              },
+              {
+                "label": "Medium",
+                "value": "M"
+              },
+              {
+                "label": "Large",
+                "value": "L"
+              },
+              {
+                "label": "Extra Large",
+                "value": "XL"
+              }
+            ],
+            "defaultValue": "M"
           },
           {
             "type": "boolean",
             "label": "Disabled",
             "key": "buttonDisabled"
+          },
+          {
+            "type": "boolean",
+            "label": "Quiet",
+            "key": "buttonQuiet"
           }
         ]
       },
@@ -507,34 +535,6 @@
             "label": "Collapsed button size",
             "key": "collapsedSize",
             "dependsOn": "collapsed",
-            "options": [
-              {
-                "label": "Small",
-                "value": "S"
-              },
-              {
-                "label": "Medium",
-                "value": "M"
-              },
-              {
-                "label": "Large",
-                "value": "L"
-              },
-              {
-                "label": "Extra Large",
-                "value": "XL"
-              }
-            ],
-            "defaultValue": "M"
-          },
-          {
-            "type": "select",
-            "label": "Button size",
-            "key": "buttonSize",
-            "dependsOn": {
-              "setting": "collapsed",
-              "invert": true
-            },
             "options": [
               {
                 "label": "Small",
@@ -715,6 +715,21 @@
             "dependsOn": {
               "setting": "collapsed",
               "invert": true
+            }
+          }
+        ]
+      },
+      {
+        "section": true,
+        "name": "Conditions",
+        "settings": [
+          {
+            "type": "buttonConditions",
+            "label": "Conditions",
+            "key": "conditions",
+            "contextAccess": {
+              "global": true,
+              "self": true
             }
           }
         ]

--- a/packages/client/src/components/app/ButtonGroup.svelte
+++ b/packages/client/src/components/app/ButtonGroup.svelte
@@ -46,6 +46,7 @@
       <CollapsedButtonGroup
         text={collapsedText || "Action"}
         buttons={collapsedButtons}
+        type={buttonType || "primary"}
         size={collapsedSize}
       />
     {:else}

--- a/packages/client/src/components/app/ButtonGroup.svelte
+++ b/packages/client/src/components/app/ButtonGroup.svelte
@@ -13,6 +13,10 @@
   export let collapsed = false
   export let collapsedText = "Action"
   export let collapsedSize = "M"
+  export let buttonSize = "M"
+  export let buttonType = undefined
+  export let buttonQuiet = undefined
+  export let buttonDisabled = undefined
 
   const { enrichButtonActions } = getContext("sdk")
   const context = getContext("context")
@@ -51,12 +55,18 @@
           props={{
             text: button?.text || "Button",
             onClick: button?.onClick,
-            type: button?.type,
-            quiet: button?.quiet,
-            disabled: button?.disabled,
+            type:
+              button?.type === "inherit" || button?.type == null
+                ? buttonType || "primary"
+                : button?.type,
+            quiet: button?.quiet ?? buttonQuiet,
+            disabled: button?.disabled ?? buttonDisabled,
             icon: button?.icon,
             gap: button?.gap,
-            size: button?.size || "M",
+            size:
+              button?.size === "inherit" || button?.size == null
+                ? buttonSize || "M"
+                : button?.size,
             _conditions: button?._conditions || button?.conditions,
           }}
         />


### PR DESCRIPTION
# Add button group inheritance and conditions support

## Description
This pull request introduces a full inheritance system for button style and size within Button Groups, along with group-level conditions, collapsed-button improvements, and several UI/UX enhancements. These changes make Button Groups more flexible, reduce duplication, and provide a clearer editing experience.

## Addresses
- Fixes #18016

---

## Overview
Added inheritance and conditional styling support to Button Groups, allowing individual buttons to inherit style properties from the group level and enabling dynamic updates via conditions.

---

## Key Changes

### Button Style Inheritance
Button Groups now act as a styling parent:

- Added Variant, Size, Disabled, and Quiet controls to the group-level "Button style" section.
- Individual buttons can now set their `type` and `size` to "Inherit", following the group's `buttonType` and `buttonSize`.
- Buttons with explicit values override the group settings.
- Newly created buttons default to "Inherit".
- Added contextual InfoDisplay explaining inheritance behavior.

### Group-Level Conditions
Button Groups now support their own Conditions section:

- Group-level conditions can update any button style property.
- All buttons set to "Inherit" automatically respond to these conditional changes.
- Enables responsive, state-driven styling.

### UI/UX Improvements
Enhancements to make editing clearer and more intuitive:

- Button settings UI now injects "Inherit" options for variant and size.
- Added an informational message explaining inheritance behavior.
- Improved nested settings handling and edge-case logic.

### Collapsed Button Support
The collapsed button now participates fully in the inheritance system:

- Collapsed button uses the group's Variant setting.
- Updated `CollapsedButton


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds group-level Variant, Size, Disabled, and Quiet controls to Button Groups with per-button inheritance and conditions. Collapsed and individual buttons now follow group style by default, reducing duplicate setup. Fixes #18016.

- **New Features**
  - Group-level "Button style" controls: `buttonType`, `buttonSize`, `buttonQuiet`, `buttonDisabled`.
  - Per-button "Inherit" option for Variant and Size; new buttons default to "Inherit".
  - Group-level Conditions for style; inherited buttons update automatically.
  - Collapsed button now uses the group's Variant.
  - Builder UI: injects "Inherit" options and shows an info message explaining inheritance.

- **Migration**
  - No breaking changes; existing explicit button settings still override the group.
  - New buttons default to "Inherit". Set group "Button style" to apply shared styling.
  - To drive styles dynamically, add rules in the group's "Conditions" section.

<sup>Written for commit f4cb245e84107b6c220f4f9c85950f69fd4030e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

