### PR TITLE
[VUL-53] Fix SSRF in plugin URL upload via trivial tar.gz bypass

### DIFF
--- a/packages/backend-core/src/objectStore/objectStore.ts
+++ b/packages/backend-core/src/objectStore/objectStore.ts
@@ -697,10 +697,15 @@ export async function uploadDirectory(
 export async function downloadTarballDirect(
   url: string,
   path: string,
-  headers = {}
+  headers = {},
+  { followRedirects = true }: { followRedirects?: boolean } = {}
 ) {
   path = sanitizeKey(path)
-  const response = await fetchWithBlacklist(url, { headers })
+  const response = await fetchWithBlacklist(
+    url,
+    { headers },
+    { followRedirects }
+  )
   if (!response.ok) {
     throw new Error(`unexpected response ${response.statusText}`)
   }

--- a/packages/backend-core/src/objectStore/tests/objectStore.spec.ts
+++ b/packages/backend-core/src/objectStore/tests/objectStore.spec.ts
@@ -401,7 +401,8 @@ describe("objectStore", () => {
 
       expect(fetchWithBlacklistMock).toHaveBeenCalledWith(
         "http://169.254.169.254/metadata/v1/",
-        { headers: {} }
+        { headers: {} },
+        { followRedirects: true }
       )
     })
 

--- a/packages/backend-core/src/utils/outboundFetch.ts
+++ b/packages/backend-core/src/utils/outboundFetch.ts
@@ -92,7 +92,8 @@ function releaseResponseBody(response: Response) {
 
 export async function fetchWithBlacklist(
   url: string,
-  request: RequestInit = {}
+  request: RequestInit = {},
+  { followRedirects = true }: { followRedirects?: boolean } = {}
 ): Promise<Response> {
   let nextUrl = url
   let nextRequest: RedirectSafeRequest = {
@@ -107,17 +108,20 @@ export async function fetchWithBlacklist(
       return response
     }
 
+    releaseResponseBody(response)
+
+    if (!followRedirects) {
+      throw new Error("Redirects are not permitted.")
+    }
+
     if (redirects === MAX_REDIRECTS) {
-      releaseResponseBody(response)
       break
     }
 
     const location = response.headers.get("location")
     if (!location) {
-      return response
+      throw new Error("Maximum redirect reached.")
     }
-
-    releaseResponseBody(response)
 
     const redirectUrl = parseUrl(
       new URL(location, nextUrl).toString()

--- a/packages/backend-core/src/utils/tests/outboundFetch.spec.ts
+++ b/packages/backend-core/src/utils/tests/outboundFetch.spec.ts
@@ -1,8 +1,13 @@
-import fetch from "node-fetch"
+import fetch, { Headers } from "node-fetch"
 import { isBlacklisted } from "../../blacklist"
 import { fetchWithBlacklist } from "../outboundFetch"
 
-jest.mock("node-fetch", () => jest.fn())
+// Expose the real Headers class so the redirect header-stripping logic works
+jest.mock("node-fetch", () => {
+  const actual = jest.requireActual("node-fetch")
+  return Object.assign(jest.fn(), { Headers: actual.Headers })
+})
+
 jest.mock("../../blacklist", () => ({
   isBlacklisted: jest.fn(),
 }))
@@ -17,6 +22,8 @@ describe("outboundFetch", () => {
     jest.clearAllMocks()
   })
 
+  // ─── URL validation ───────────────────────────────────────────────────────
+
   it("blocks blacklisted urls", async () => {
     isBlacklistedMock.mockResolvedValue(true)
 
@@ -26,29 +33,30 @@ describe("outboundFetch", () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it("blocks redirects to blacklisted urls", async () => {
-    isBlacklistedMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
-    const resume = jest.fn()
-
-    fetchMock.mockResolvedValue({
-      status: 302,
-      headers: { get: jest.fn().mockReturnValue("http://169.254.169.254/") },
-      body: { resume },
-    } as any)
-
-    await expect(
-      fetchWithBlacklist("https://example.com/spec.json")
-    ).rejects.toThrow("URL is blocked or could not be resolved safely.")
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(resume).toHaveBeenCalledTimes(1)
-  })
-
   it("rejects unsupported schemes", async () => {
     isBlacklistedMock.mockResolvedValue(false)
 
     await expect(fetchWithBlacklist("file:///etc/passwd")).rejects.toThrow(
       "Only HTTP(S) URLs are allowed."
     )
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects URL with embedded username", async () => {
+    isBlacklistedMock.mockResolvedValue(false)
+
+    await expect(
+      fetchWithBlacklist("https://attacker@example.com/")
+    ).rejects.toThrow("URL must not include credentials.")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects URL with embedded username and password", async () => {
+    isBlacklistedMock.mockResolvedValue(false)
+
+    await expect(
+      fetchWithBlacklist("https://user:pass@169.254.169.254/")
+    ).rejects.toThrow("URL must not include credentials.")
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
@@ -68,5 +76,311 @@ describe("outboundFetch", () => {
       expect.objectContaining({ redirect: "manual" })
     )
     expect(result).toBe(response)
+  })
+
+  // ─── Redirect handling ────────────────────────────────────────────────────
+
+  it("blocks redirects to blacklisted urls", async () => {
+    isBlacklistedMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+    const resume = jest.fn()
+
+    fetchMock.mockResolvedValue({
+      status: 302,
+      headers: { get: jest.fn().mockReturnValue("http://169.254.169.254/") },
+      body: { resume },
+    } as any)
+
+    await expect(
+      fetchWithBlacklist("https://example.com/spec.json")
+    ).rejects.toThrow("URL is blocked or could not be resolved safely.")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(resume).toHaveBeenCalledTimes(1)
+  })
+
+  it("throws when a redirect is encountered and followRedirects is false", async () => {
+    isBlacklistedMock.mockResolvedValue(false)
+    const resume = jest.fn()
+
+    fetchMock.mockResolvedValue({
+      status: 302,
+      headers: { get: jest.fn().mockReturnValue("https://other.example.com/") },
+      body: { resume },
+    } as any)
+
+    await expect(
+      fetchWithBlacklist(
+        "https://example.com/plugin.tar.gz",
+        {},
+        { followRedirects: false }
+      )
+    ).rejects.toThrow("Redirects are not permitted.")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(resume).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([301, 302, 303, 307, 308])(
+    "treats %d as a redirect status",
+    async status => {
+      isBlacklistedMock.mockResolvedValue(false)
+      const resume = jest.fn()
+
+      fetchMock
+        .mockResolvedValueOnce({
+          status,
+          headers: {
+            get: jest.fn().mockReturnValue("https://example.com/final"),
+          },
+          body: { resume },
+        } as any)
+        .mockResolvedValueOnce({
+          status: 200,
+          ok: true,
+          headers: { get: jest.fn() },
+        } as any)
+
+      await fetchWithBlacklist("https://example.com/start")
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(resume).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it("rejects redirect to URL with embedded credentials", async () => {
+    isBlacklistedMock.mockResolvedValue(false)
+    const resume = jest.fn()
+
+    fetchMock.mockResolvedValue({
+      status: 302,
+      headers: {
+        get: jest.fn().mockReturnValue("https://user:pass@evil.com/"),
+      },
+      body: { resume },
+    } as any)
+
+    await expect(
+      fetchWithBlacklist("https://example.com/start")
+    ).rejects.toThrow("URL must not include credentials.")
+  })
+
+  it("throws after exceeding the maximum redirect count", async () => {
+    isBlacklistedMock.mockResolvedValue(false)
+    const resume = jest.fn()
+
+    fetchMock.mockResolvedValue({
+      status: 302,
+      headers: {
+        get: jest.fn().mockReturnValue("https://example.com/loop"),
+      },
+      body: { resume },
+    } as any)
+
+    await expect(
+      fetchWithBlacklist("https://example.com/start")
+    ).rejects.toThrow("Maximum redirect reached.")
+
+    // Loop runs for redirects 0..5 inclusive → 6 fetch calls
+    expect(fetchMock).toHaveBeenCalledTimes(6)
+  })
+
+  it("resolves a relative Location header against the current URL", async () => {
+    isBlacklistedMock.mockResolvedValue(false)
+    const resume = jest.fn()
+
+    fetchMock
+      .mockResolvedValueOnce({
+        status: 302,
+        headers: { get: jest.fn().mockReturnValue("/other/path") },
+        body: { resume },
+      } as any)
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        headers: { get: jest.fn() },
+      } as any)
+
+    await fetchWithBlacklist("https://example.com/original")
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://example.com/other/path",
+      expect.objectContaining({ redirect: "manual" })
+    )
+  })
+
+  // ─── Method mutation on redirect ──────────────────────────────────────────
+
+  it.each([
+    [301, "POST"],
+    [302, "POST"],
+  ])(
+    "converts method from POST to GET on %d redirect",
+    async (status, initialMethod) => {
+      isBlacklistedMock.mockResolvedValue(false)
+      const resume = jest.fn()
+
+      fetchMock
+        .mockResolvedValueOnce({
+          status,
+          headers: {
+            get: jest.fn().mockReturnValue("https://example.com/final"),
+          },
+          body: { resume },
+        } as any)
+        .mockResolvedValueOnce({
+          status: 200,
+          ok: true,
+          headers: { get: jest.fn() },
+        } as any)
+
+      await fetchWithBlacklist("https://example.com/resource", {
+        method: initialMethod,
+      })
+
+      const secondCallRequest = fetchMock.mock.calls[1][1]
+      expect(secondCallRequest?.method).toBe("GET")
+    }
+  )
+
+  it("converts method to GET on 303 redirect regardless of original method", async () => {
+    isBlacklistedMock.mockResolvedValue(false)
+    const resume = jest.fn()
+
+    fetchMock
+      .mockResolvedValueOnce({
+        status: 303,
+        headers: {
+          get: jest.fn().mockReturnValue("https://example.com/final"),
+        },
+        body: { resume },
+      } as any)
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        headers: { get: jest.fn() },
+      } as any)
+
+    await fetchWithBlacklist("https://example.com/resource", { method: "PUT" })
+
+    const secondCallRequest = fetchMock.mock.calls[1][1]
+    expect(secondCallRequest?.method).toBe("GET")
+  })
+
+  it.each([307, 308])(
+    "preserves method on %d redirect",
+    async redirectStatus => {
+      isBlacklistedMock.mockResolvedValue(false)
+      const resume = jest.fn()
+
+      fetchMock
+        .mockResolvedValueOnce({
+          status: redirectStatus,
+          headers: {
+            get: jest.fn().mockReturnValue("https://example.com/final"),
+          },
+          body: { resume },
+        } as any)
+        .mockResolvedValueOnce({
+          status: 200,
+          ok: true,
+          headers: { get: jest.fn() },
+        } as any)
+
+      await fetchWithBlacklist("https://example.com/resource", {
+        method: "POST",
+      })
+
+      const secondCallRequest = fetchMock.mock.calls[1][1]
+      expect(secondCallRequest?.method).toBe("POST")
+    }
+  )
+
+  it("does not convert method to GET on 301 GET redirect", async () => {
+    isBlacklistedMock.mockResolvedValue(false)
+    const resume = jest.fn()
+
+    fetchMock
+      .mockResolvedValueOnce({
+        status: 301,
+        headers: {
+          get: jest.fn().mockReturnValue("https://example.com/final"),
+        },
+        body: { resume },
+      } as any)
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        headers: { get: jest.fn() },
+      } as any)
+
+    // GET is the default method — it should remain GET, not be changed for any
+    // other reason
+    await fetchWithBlacklist("https://example.com/resource")
+
+    const secondCallRequest = fetchMock.mock.calls[1][1]
+    // method field is undefined (default GET); the key point is it's not "POST"
+    expect(secondCallRequest?.method).not.toBe("POST")
+  })
+
+  // ─── Header stripping on cross-origin redirect ────────────────────────────
+
+  it.each(["authorization", "cookie", "cookie2", "proxy-authorization"])(
+    "strips the %s header when redirected to a different origin",
+    async sensitiveHeader => {
+      isBlacklistedMock.mockResolvedValue(false)
+      const resume = jest.fn()
+
+      fetchMock
+        .mockResolvedValueOnce({
+          status: 302,
+          headers: {
+            get: jest.fn().mockReturnValue("https://other.example.com/final"),
+          },
+          body: { resume },
+        } as any)
+        .mockResolvedValueOnce({
+          status: 200,
+          ok: true,
+          headers: { get: jest.fn() },
+        } as any)
+
+      await fetchWithBlacklist("https://example.com/resource", {
+        headers: { [sensitiveHeader]: "secret-value" },
+      })
+
+      const secondCallHeaders = new Headers(
+        fetchMock.mock.calls[1][1]?.headers as any
+      )
+      expect(secondCallHeaders.get(sensitiveHeader)).toBeNull()
+    }
+  )
+
+  it("preserves sensitive headers when redirected to the same origin", async () => {
+    isBlacklistedMock.mockResolvedValue(false)
+    const resume = jest.fn()
+
+    fetchMock
+      .mockResolvedValueOnce({
+        status: 302,
+        headers: {
+          get: jest
+            .fn()
+            .mockReturnValue("https://example.com/same-origin-path"),
+        },
+        body: { resume },
+      } as any)
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        headers: { get: jest.fn() },
+      } as any)
+
+    await fetchWithBlacklist("https://example.com/resource", {
+      headers: { authorization: "Bearer token" },
+    })
+
+    const secondCallHeaders = new Headers(
+      fetchMock.mock.calls[1][1]?.headers as any
+    )
+    expect(secondCallHeaders.get("authorization")).toBe("Bearer token")
   })
 })

--- a/packages/server/src/api/controllers/plugin/tests/security.spec.ts
+++ b/packages/server/src/api/controllers/plugin/tests/security.spec.ts
@@ -1,6 +1,7 @@
 import { utils as coreUtils } from "@budibase/backend-core"
 import { githubUpload } from "../github"
 import { npmUpload } from "../npm"
+import { urlUpload } from "../url"
 import { downloadUnzipTarball } from "../utils"
 import { getPluginMetadata } from "../../../../utilities/fileSystem"
 
@@ -35,45 +36,140 @@ describe("plugin SSRF hardening", () => {
     jest.clearAllMocks()
   })
 
-  it("rejects github urls outside github.com", async () => {
-    await expect(
-      githubUpload("https://example.com/owner/repo", "plugin-name")
-    ).rejects.toThrow("The plugin origin must be from Github")
+  // ─── urlUpload URL validation ──────────────────────────────────────────────
+
+  describe("urlUpload URL validation", () => {
+    it.each([
+      [
+        "non-https URL",
+        "http://example.com/plugin.tar.gz",
+        "Plugin URL must use HTTPS.",
+      ],
+      ["invalid URL", "not-a-url", "Invalid plugin URL."],
+      [
+        ".tar.gz only in fragment — SSRF bypass attempt",
+        "https://169.254.169.254/latest/meta-data#.tar.gz",
+        "Plugin must be compressed into a gzipped tarball.",
+      ],
+      [
+        ".tar.gz only in query string — SSRF bypass attempt",
+        "https://169.254.169.254/latest/meta-data?.tar.gz",
+        "Plugin must be compressed into a gzipped tarball.",
+      ],
+      [
+        "path does not end with .tar.gz",
+        "https://example.com/plugin.tar.gz.evil",
+        "Plugin must be compressed into a gzipped tarball.",
+      ],
+      [
+        ".tar.gz in subdirectory but not at the end",
+        "https://example.com/plugin.tar.gz/extra",
+        "Plugin must be compressed into a gzipped tarball.",
+      ],
+    ])("rejects %s", async (_label, url, expectedError) => {
+      await expect(urlUpload(url, "plugin-name")).rejects.toThrow(expectedError)
+      expect(downloadUnzipTarballMock).not.toHaveBeenCalled()
+    })
+
+    it("accepts a valid https URL ending with .tar.gz in the path", async () => {
+      downloadUnzipTarballMock.mockResolvedValue("/tmp/plugin")
+      getPluginMetadataMock.mockResolvedValue({} as any)
+
+      await urlUpload("https://example.com/plugin.tar.gz", "plugin-name")
+
+      expect(downloadUnzipTarballMock).toHaveBeenCalledWith(
+        "https://example.com/plugin.tar.gz",
+        "plugin-name",
+        {},
+        { followRedirects: false }
+      )
+    })
+
+    it("passes followRedirects: false to prevent redirect-based SSRF", async () => {
+      downloadUnzipTarballMock.mockResolvedValue("/tmp/plugin")
+      getPluginMetadataMock.mockResolvedValue({} as any)
+
+      await urlUpload(
+        "https://releases.example.com/v1.0/myplugin.tar.gz",
+        "myplugin"
+      )
+
+      const [, , , options] = downloadUnzipTarballMock.mock.calls[0]
+      expect(options).toEqual({ followRedirects: false })
+    })
   })
 
-  it("rejects npm urls outside npm hosts", async () => {
-    await expect(
-      npmUpload("https://example.com/package/foo", "plugin-name")
-    ).rejects.toThrow("The plugin origin must be from NPM")
+  // ─── githubUpload URL validation ───────────────────────────────────────────
+
+  describe("githubUpload URL validation", () => {
+    it("rejects github urls outside github.com", async () => {
+      await expect(
+        githubUpload("https://example.com/owner/repo", "plugin-name")
+      ).rejects.toThrow("The plugin origin must be from Github")
+    })
+
+    it("rejects http (non-https) github urls", async () => {
+      await expect(
+        githubUpload("http://github.com/owner/repo", "plugin-name")
+      ).rejects.toThrow("The plugin origin must be from Github")
+    })
+
+    it("rejects a github URL that uses github.com as a path component", async () => {
+      await expect(
+        githubUpload("https://evil.com/github.com/owner/repo", "plugin-name")
+      ).rejects.toThrow("The plugin origin must be from Github")
+    })
   })
 
-  it("resolves npm package metadata through fetchWithBlacklist", async () => {
-    fetchWithBlacklistMock.mockResolvedValue({
-      status: 200,
-      json: jest.fn().mockResolvedValue({
-        name: "foo",
-        "dist-tags": { latest: "1.0.0" },
-        versions: {
-          "1.0.0": {
-            dist: {
-              tarball: "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
+  // ─── npmUpload URL validation ──────────────────────────────────────────────
+
+  describe("npmUpload URL validation", () => {
+    it("rejects npm urls outside npm hosts", async () => {
+      await expect(
+        npmUpload("https://example.com/package/foo", "plugin-name")
+      ).rejects.toThrow("The plugin origin must be from NPM")
+    })
+
+    it("rejects http (non-https) npm urls", async () => {
+      await expect(
+        npmUpload("http://www.npmjs.com/package/foo", "plugin-name")
+      ).rejects.toThrow("The plugin origin must be from NPM")
+    })
+
+    it("rejects a URL that uses npmjs.com as a subdomain of another host", async () => {
+      await expect(
+        npmUpload("https://www.npmjs.com.evil.com/package/foo", "plugin-name")
+      ).rejects.toThrow("The plugin origin must be from NPM")
+    })
+
+    it("resolves npm package metadata through fetchWithBlacklist", async () => {
+      fetchWithBlacklistMock.mockResolvedValue({
+        status: 200,
+        json: jest.fn().mockResolvedValue({
+          name: "foo",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              dist: {
+                tarball: "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
+              },
             },
           },
-        },
-      }),
-    } as any)
-    downloadUnzipTarballMock.mockResolvedValue("/tmp/plugin")
-    getPluginMetadataMock.mockResolvedValue({} as any)
+        }),
+      } as any)
+      downloadUnzipTarballMock.mockResolvedValue("/tmp/plugin")
+      getPluginMetadataMock.mockResolvedValue({} as any)
 
-    await npmUpload("https://www.npmjs.com/package/foo", "plugin-name")
+      await npmUpload("https://www.npmjs.com/package/foo", "plugin-name")
 
-    expect(fetchWithBlacklistMock).toHaveBeenCalledWith(
-      "https://registry.npmjs.org/foo"
-    )
-    expect(downloadUnzipTarballMock).toHaveBeenCalledWith(
-      "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
-      "foo",
-      {}
-    )
+      expect(fetchWithBlacklistMock).toHaveBeenCalledWith(
+        "https://registry.npmjs.org/foo"
+      )
+      expect(downloadUnzipTarballMock).toHaveBeenCalledWith(
+        "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
+        "foo",
+        {}
+      )
+    })
   })
 })

--- a/packages/server/src/api/controllers/plugin/url.ts
+++ b/packages/server/src/api/controllers/plugin/url.ts
@@ -4,12 +4,31 @@ import {
   getPluginMetadata,
 } from "../../../utilities/fileSystem"
 
-export async function urlUpload(url: string, name = "", headers = {}) {
-  if (!url.includes(".tar.gz")) {
+function parseTarGzUrl(url: string): URL {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new Error("Invalid plugin URL.")
+  }
+
+  if (parsed.protocol !== "https:") {
+    throw new Error("Plugin URL must use HTTPS.")
+  }
+
+  if (!parsed.pathname.endsWith(".tar.gz")) {
     throw new Error("Plugin must be compressed into a gzipped tarball.")
   }
 
-  const path = await downloadUnzipTarball(url, name, headers)
+  return parsed
+}
+
+export async function urlUpload(url: string, name = "", headers = {}) {
+  parseTarGzUrl(url)
+
+  const path = await downloadUnzipTarball(url, name, headers, {
+    followRedirects: false,
+  })
   try {
     return await getPluginMetadata(path)
   } catch (err) {

--- a/packages/server/src/api/controllers/plugin/utils.ts
+++ b/packages/server/src/api/controllers/plugin/utils.ts
@@ -7,12 +7,15 @@ import { objectStore } from "@budibase/backend-core"
 export async function downloadUnzipTarball(
   url: string,
   name: string,
-  headers = {}
+  headers = {},
+  { followRedirects = true }: { followRedirects?: boolean } = {}
 ) {
   const path = createTempFolder(name)
 
   try {
-    await objectStore.downloadTarballDirect(url, path, headers)
+    await objectStore.downloadTarballDirect(url, path, headers, {
+      followRedirects,
+    })
     return path
   } catch (e: any) {
     deleteFolderFileSystem(path)


### PR DESCRIPTION
## Addresses

https://github.com/Budibase/vulns/issues/53

## Description

Fixes a Server-Side Request Forgery (SSRF) vulnerability in the plugin URL upload flow (GHSA-xh5j-727m-w6gg).

The original validation used `url.includes(".tar.gz")`, which was trivially bypassable by placing `.tar.gz` in the query string or URL fragment (e.g. `https://169.254.169.254/metadata?.tar.gz`). An authenticated attacker could use this to make the server issue HTTP requests to internal network resources.

**Changes:**

- Replace `url.includes(".tar.gz")` with a proper URL parser that checks `pathname.endsWith(".tar.gz")`, preventing query-string and fragment bypasses
- Enforce HTTPS-only for plugin URL uploads
- Disable redirect following in `urlUpload` to block redirect-based SSRF (where a valid URL redirects to an internal address)
- Add `followRedirects` option to `fetchWithBlacklist` and thread it through `downloadUnzipTarball` / `downloadTarballDirect`
- Fix two bugs in `fetchWithBlacklist`: response body was not released before processing redirects; a redirect response with no `Location` header was returned instead of throwing
- Add unit tests covering all bypass vectors and redirect edge cases

## Screenshots or Screen Recordings

https://github.com/user-attachments/assets/43af4168-742d-43f4-b39b-4041b3a6f795