### PR TITLE
Fixing pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 # Helm chart validation (only runs when charts/ files are staged)
-sh "$(dirname "$0")/../scripts/helm-pre-commit.sh"
+"$(dirname "$0")/../scripts/helm-pre-commit.sh"


### PR DESCRIPTION
## Description
Fixing an issue with publishing the NPM packages due a failure in the pre-commit script 

<img width="773" height="162" alt="image" src="https://github.com/user-attachments/assets/36746f48-d037-4ca2-b5fc-72ae91177895" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the `husky` pre-commit hook to run `scripts/helm-pre-commit.sh` directly (no `sh`), honoring the shebang and failing commits on Helm validation errors. Restores Helm chart validation when files under `charts/` are staged.

<sup>Written for commit 204bda3bdc801481dadc04cc7f5e9af2cab7f00d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



