### PR TITLE
[GHSA-4f9j-vr4p-642r] Set budibase:auth cookie with secure flag

### DIFF
--- a/packages/backend-core/src/utils/utils.ts
+++ b/packages/backend-core/src/utils/utils.ts
@@ -216,6 +216,7 @@ export function setCookie(
     expires: MAX_VALID_DATE,
     path: "/",
     httpOnly: opts.httpOnly ?? false,
+    secure: ctx.secure,
     overwrite: true,
   }
 


### PR DESCRIPTION
## Description

Part of the fix for GHSA-4f9j-vr4p-642r. The `budibase:auth` session cookie was missing the `secure` flag, meaning it could be transmitted over plain HTTP connections and potentially intercepted on unencrypted networks.

This PR adds `secure: ctx.secure` to the cookie configuration in `setCookie()` (`packages/backend-core/src/utils/utils.ts`).

`ctx.secure` is used rather than hardcoding `true` because both server and worker already have `app.proxy = true`, which makes Koa read the `X-Forwarded-Proto` header. This means the flag dynamically reflects the actual security of the connection:

- **Cloud (HTTPS):** `secure: true`
- **Self-hosted with a TLS-terminating reverse proxy:** `secure: true` — the proxy sets `X-Forwarded-Proto: https` and Koa reads it
- **Self-hosted over plain HTTP:** `secure: false` — cookie still works, login does not break
- **Local dev:** `secure: false`, no behaviour change

Hardcoding `true` would have broken self-hosted deployments running over HTTP, whether intentionally (internal networks) or because TLS is terminated upstream and the internal hop is plain HTTP.

## Addresses

- https://github.com/Budibase/budibase/security/advisories/GHSA-4f9j-vr4p-642r

## Launchcontrol

Hardens the `budibase:auth` session cookie by adding the `secure` flag, preventing it from being sent over unencrypted HTTP connections. Self-hosted deployments on plain HTTP are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `secure` flag to the `budibase:auth` session cookie to prevent it from being sent over plain HTTP (GHSA-4f9j-vr4p-642r). The flag uses `ctx.secure` so HTTPS behind TLS-terminating proxies is respected, while self-hosted HTTP and local dev keep working.

<sup>Written for commit 5cab121854c31c7ea9a502fb2b925b8399eacdd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

