### PR TITLE
Fix svelte-check

### DIFF
--- a/packages/bbui/src/Form/Select.svelte
+++ b/packages/bbui/src/Form/Select.svelte
@@ -1,4 +1,7 @@
-<script lang="ts" generics="O extends any,V">
+<script
+  lang="ts"
+  generics="O extends any, V, P extends string | boolean = string | boolean"
+>
   import Field from "./Field.svelte"
   import Select from "./Core/Select.svelte"
   import { createEventDispatcher } from "svelte"
@@ -11,7 +14,7 @@
   export let readonly: boolean = false
   export let labelPosition: LabelPosition = "above"
   export let error: string | undefined = undefined
-  export let placeholder: string | boolean = "Choose an option"
+  export let placeholder: P = "Choose an option" as P
   export let options: O[] = []
   export let getOptionLabel = (option: O, _index?: number) =>
     extractProperty(option, "label")
@@ -53,8 +56,10 @@
   export let wrapText: boolean = false
   export let description: string | undefined = undefined
 
-  const dispatch = createEventDispatcher<{ change: V }>()
-  const onChange = (e: CustomEvent<V>) => {
+  type ChangeValue = P extends false | "" ? V : V | undefined
+
+  const dispatch = createEventDispatcher<{ change: ChangeValue }>()
+  const onChange = (e: CustomEvent<ChangeValue>) => {
     value = e.detail
     dispatch("change", e.detail)
   }

--- a/packages/bbui/src/Form/Select.svelte
+++ b/packages/bbui/src/Form/Select.svelte
@@ -53,8 +53,8 @@
   export let wrapText: boolean = false
   export let description: string | undefined = undefined
 
-  const dispatch = createEventDispatcher<{ change: V | undefined }>()
-  const onChange = (e: CustomEvent<any>) => {
+  const dispatch = createEventDispatcher<{ change: V }>()
+  const onChange = (e: CustomEvent<V>) => {
     value = e.detail
     dispatch("change", e.detail)
   }

--- a/packages/bbui/src/PhosphorIconPicker/PhosphorIconPicker.svelte
+++ b/packages/bbui/src/PhosphorIconPicker/PhosphorIconPicker.svelte
@@ -64,7 +64,7 @@
     <TextField
       quiet
       value={searchString}
-      on:change={e => (searchString = e.detail)}
+      on:change={e => (searchString = e.detail || "")}
       autocomplete={false}
       placeholder="Search icons"
       autofocus

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -11,7 +11,7 @@
     "rollup": "rollup -c -w",
     "test": "vitest run",
     "test:watch": "vitest",
-    "check:types": "yarn svelte-check --incremental"
+    "check:types": "yarn svelte-check"
   },
   "jest": {
     "globals": {

--- a/packages/builder/src/components/design/settings/controls/RoleSelect.svelte
+++ b/packages/builder/src/components/design/settings/controls/RoleSelect.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
   import { Select } from "@budibase/bbui"
   import { roles } from "@/stores/builder"
+  import { createEventDispatcher } from "svelte"
 
   export let value: string
   export let error: string | undefined = undefined
   export let placeholder: string | undefined = undefined
   export let autoWidth: boolean = false
+
+  const dispatch = createEventDispatcher<{ change: string | undefined }>()
 </script>
 
 <Select
   bind:value
-  on:change
+  on:change={r => dispatch("change", r.detail)}
   options={$roles}
   getOptionLabel={role => role.uiMetadata?.displayName}
   getOptionValue={role => role._id}

--- a/packages/builder/src/components/integration/AccessLevelSelect.svelte
+++ b/packages/builder/src/components/integration/AccessLevelSelect.svelte
@@ -12,11 +12,11 @@
 
   let roleId: string, loaded: boolean, fetched: Query | undefined
 
-  async function updateRole(role: string) {
+  async function updateRole(role: string | undefined) {
     try {
-      roleId = role
+      roleId = role || ""
       const queryId = query._id
-      if (roleId && queryId) {
+      if (role && queryId) {
         for (let level of [PermissionLevel.READ, PermissionLevel.WRITE]) {
           await permissions.save({
             level,

--- a/packages/builder/src/components/integration/KeyValueBuilder.svelte
+++ b/packages/builder/src/components/integration/KeyValueBuilder.svelte
@@ -189,7 +189,7 @@
         <Input
           placeholder={valuePlaceholder}
           readonly={readOnly}
-          bind:value={field.value}
+          bind:value={field.value as any}
           on:blur={changed}
         />
       {/if}

--- a/packages/builder/src/components/integration/ResponsePanel.svelte
+++ b/packages/builder/src/components/integration/ResponsePanel.svelte
@@ -65,7 +65,7 @@
     selectedTab = "JSON"
   }
 
-  const handleTabChange = (e: CustomEvent<string>) => {
+  const handleTabChange = (e: CustomEvent<string | undefined>) => {
     selectedTab = e.detail
   }
 

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/knowledgeTableRows.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/knowledgeTableRows.spec.ts
@@ -42,7 +42,7 @@ describe("knowledgeTableRows", () => {
     )
 
     expect(rows.map(row => row.filename)).toEqual(["a.md", "z.md"])
-    await rows[0].onDelete()
+    await rows[0].onDelete?.()
     expect(onDelete).toHaveBeenCalledTimes(1)
   })
 
@@ -83,6 +83,7 @@ describe("knowledgeTableRows", () => {
         synced: 1,
         failed: 0,
         skipped: 0,
+        unsupported: 0,
         totalDiscovered: 1,
         status: AgentKnowledgeSourceSyncRunStatus.SUCCESS,
       },

--- a/packages/builder/src/settings/pages/ai/AIConfigEditor.svelte
+++ b/packages/builder/src/settings/pages/ai/AIConfigEditor.svelte
@@ -235,7 +235,7 @@
       model={draft.model}
       {providers}
       disabled={disableProviderOnEdit && isEdit}
-      on:providerChange={event => (draft.provider = event.detail)}
+      on:providerChange={event => (draft.provider = event.detail || "")}
       on:modelChange={event => (draft.model = event.detail)}
     />
 

--- a/packages/builder/src/settings/pages/ai/ProviderModelFields.svelte
+++ b/packages/builder/src/settings/pages/ai/ProviderModelFields.svelte
@@ -6,7 +6,7 @@
 
   interface Props {
     configType: AIConfigType
-    provider: string
+    provider: string | undefined
     model: string
     providers?: LLMProvider[]
     disabled?: boolean
@@ -18,7 +18,7 @@
   }
 
   const dispatch = createEventDispatcher<{
-    providerChange: string
+    providerChange: string | undefined
     modelChange: string
   }>()
 
@@ -45,7 +45,9 @@
     }, {})
   )
 
-  let selectedProvider = $derived(providersMap?.[provider])
+  let selectedProvider = $derived(
+    provider ? providersMap?.[provider] : undefined
+  )
 
   let modelOptions = $derived.by(() => {
     const models = selectedProvider?.models?.[configType] || []
@@ -74,7 +76,7 @@
     return modelOptions.length ? "Select or type a model" : "Type a model"
   })
 
-  function handleProviderChange(event: CustomEvent<string>) {
+  function handleProviderChange(event: CustomEvent<string | undefined>) {
     const nextProvider = event.detail
     provider = nextProvider
     dispatch("providerChange", nextProvider)

--- a/packages/builder/src/stores/portal/agents.spec.ts
+++ b/packages/builder/src/stores/portal/agents.spec.ts
@@ -59,6 +59,7 @@ describe("agentsStore sharepoint and file syncing", () => {
       synced: 2,
       failed: 0,
       skipped: 1,
+      unsupported: 0,
       totalDiscovered: 3,
     })
 

--- a/packages/builder/src/stores/portal/aiConfigs.test.ts
+++ b/packages/builder/src/stores/portal/aiConfigs.test.ts
@@ -37,7 +37,7 @@ describe("AIConfigStore", () => {
     })
     const missingTypeConfig = makeConfig({
       _id: "cfg_3",
-      configType: undefined as AIConfigType,
+      configType: undefined as unknown as AIConfigType,
     })
 
     store.set({

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite build --watch --mode=dev",
-    "check:types": "yarn svelte-check --incremental",
+    "check:types": "yarn svelte-check",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/client/src/components/app/filter/FilterPopover.svelte
+++ b/packages/client/src/components/app/filter/FilterPopover.svelte
@@ -219,7 +219,7 @@
 
               const sanitized = sanitizeOperator({
                 ...editableFilter,
-                operator: e.detail,
+                operator: e.detail as any,
               })
 
               editableFilter = { ...(sanitized || editableFilter) }

--- a/packages/frontend-core/package.json
+++ b/packages/frontend-core/package.json
@@ -6,7 +6,7 @@
   "license": "MPL-2.0",
   "svelte": "./src/index.ts",
   "scripts": {
-    "check:types": "yarn svelte-check --incremental",
+    "check:types": "yarn svelte-check",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## Description
Fix svelte-check, as it was not processing files properly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix `svelte-check` by removing `--incremental` so all files are type-checked, updating `check:types` in `packages/builder`, `packages/client`, and `packages/frontend-core` to run `yarn svelte-check`.

Tighten types across components: `@budibase/bbui` `Select` adds a placeholder generic that controls `change` nullability; consumers use undefined-safe handlers/defaults (re-dispatch in `RoleSelect`, AI provider fields, `PhosphorIconPicker`) plus minimal casts. Tests use optional chaining and add `unsupported` counts.

<sup>Written for commit 38d2493c646a261b1e825c9a30ec262f4fc7aba9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

