### PR TITLE
Emit lifecycle telemetry events for AI configurations

### DIFF
--- a/packages/backend-core/src/events/publishers/ai.ts
+++ b/packages/backend-core/src/events/publishers/ai.ts
@@ -1,22 +1,56 @@
 import { publishEvent } from "../events"
 import {
   Agent,
+  CustomAIProviderConfig,
   Event,
   AIConfigCreatedEvent,
   AIConfigUpdatedEvent,
+  AIConfigDeletedEvent,
   AIAgentCreatedEvent,
   AIAgentUpdatedEvent,
   AIAgentDeletedEvent,
 } from "@budibase/types"
 
-async function configCreated(timestamp?: string | number) {
-  const properties: AIConfigCreatedEvent = {}
-  await publishEvent(Event.AI_CONFIG_CREATED, properties, timestamp)
+function configCreated(
+  config: CustomAIProviderConfig,
+  timestamp?: string | number
+) {
+  const properties: AIConfigCreatedEvent = {
+    configId: config._id as string,
+    audited: { name: config.name },
+  }
+  publishEvent(Event.AI_CONFIG_CREATED, properties, timestamp).catch(err => {
+    console.error("configCreated telemetry failed", {
+      configId: config._id,
+      err,
+    })
+  })
 }
 
-async function configUpdated() {
-  const properties: AIConfigUpdatedEvent = {}
-  await publishEvent(Event.AI_CONFIG_UPDATED, properties)
+function configUpdated(config: CustomAIProviderConfig) {
+  const properties: AIConfigUpdatedEvent = {
+    configId: config._id as string,
+    audited: { name: config.name },
+  }
+  publishEvent(Event.AI_CONFIG_UPDATED, properties).catch(err => {
+    console.error("configUpdated telemetry failed", {
+      configId: config._id,
+      err,
+    })
+  })
+}
+
+function configDeleted(config: CustomAIProviderConfig) {
+  const properties: AIConfigDeletedEvent = {
+    configId: config._id as string,
+    audited: { name: config.name },
+  }
+  publishEvent(Event.AI_CONFIG_DELETED, properties).catch(err => {
+    console.error("configDeleted telemetry failed", {
+      configId: config._id,
+      err,
+    })
+  })
 }
 
 function agentCreated(agent: Agent) {
@@ -52,6 +86,7 @@ function agentDeleted(agent: Agent) {
 export default {
   configCreated,
   configUpdated,
+  configDeleted,
   agentCreated,
   agentUpdated,
   agentDeleted,

--- a/packages/server/src/sdk/workspace/ai/configs/index.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/index.spec.ts
@@ -1,0 +1,137 @@
+const mockDbPut = jest.fn().mockResolvedValue({ rev: "1-abc" })
+const mockDbGet = jest.fn()
+const mockDbTryGet = jest.fn()
+const mockDbRemove = jest.fn()
+const mockGetWorkspaceDB = jest.fn(() => ({
+  put: (...args: any[]) => mockDbPut(...args),
+  get: (...args: any[]) => mockDbGet(...args),
+  tryGet: (...args: any[]) => mockDbTryGet(...args),
+  remove: (...args: any[]) => mockDbRemove(...args),
+}))
+
+const mockConfigCreated = jest.fn()
+const mockConfigUpdated = jest.fn()
+const mockConfigDeleted = jest.fn()
+
+jest.mock("@budibase/backend-core", () => {
+  const actual = jest.requireActual("@budibase/backend-core")
+  return {
+    ...actual,
+    context: {
+      ...actual.context,
+      getWorkspaceDB: (...args: Parameters<typeof mockGetWorkspaceDB>) =>
+        mockGetWorkspaceDB(...args),
+    },
+    env: {
+      ...actual.env,
+      SELF_HOSTED: false,
+      BUDICLOUD_URL: "http://budicloud.example.com",
+    },
+    events: {
+      ...actual.events,
+      ai: {
+        configCreated: (...args: any[]) => mockConfigCreated(...args),
+        configUpdated: (...args: any[]) => mockConfigUpdated(...args),
+        configDeleted: (...args: any[]) => mockConfigDeleted(...args),
+      },
+    },
+  }
+})
+
+jest.mock("@budibase/pro", () => ({
+  licensing: {
+    keys: { getLicenseKey: jest.fn() },
+  },
+}))
+
+jest.mock("./litellm", () => ({
+  validateConfig: jest.fn(),
+  addModel: jest.fn().mockResolvedValue("model_123"),
+  updateModel: jest.fn(),
+  syncKeyModels: jest.fn(),
+  fetchPublicProviders: jest.fn().mockResolvedValue([]),
+  fetchPublicModelCostMap: jest.fn().mockResolvedValue({}),
+}))
+
+jest.mock("../../../utils", () => ({
+  processEnvironmentVariable: jest.fn((v: string) => v),
+}))
+
+import type { CustomAIProviderConfig } from "@budibase/types"
+import { AIConfigType } from "@budibase/types"
+import * as aiConfigs from "./index"
+
+const baseConfig = {
+  name: "My Config",
+  provider: "openai",
+  model: "gpt-4",
+  credentialsFields: { api_key: "sk-test" },
+  configType: AIConfigType.COMPLETIONS,
+  isDefault: false,
+} as const
+
+describe("ai configs sdk", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDbPut.mockResolvedValue({ rev: "1-abc" })
+  })
+
+  describe("create", () => {
+    it("emits ai:config:created event", async () => {
+      await aiConfigs.create(baseConfig)
+
+      expect(mockConfigCreated).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "My Config" })
+      )
+    })
+  })
+
+  describe("update", () => {
+    it("emits ai:config:updated event", async () => {
+      const existing: CustomAIProviderConfig = {
+        _id: "cfg_1",
+        _rev: "1-abc",
+        name: "My Config",
+        provider: "openai",
+        model: "gpt-4",
+        credentialsFields: { api_key: "sk-test" },
+        configType: AIConfigType.COMPLETIONS,
+        isDefault: false,
+        liteLLMModelId: "model_123",
+      }
+
+      mockDbTryGet.mockResolvedValue(existing)
+      mockDbPut.mockResolvedValue({ rev: "2-abc" })
+
+      await aiConfigs.update({ ...existing })
+
+      expect(mockConfigUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({ _id: "cfg_1", name: "My Config" })
+      )
+    })
+  })
+
+  describe("remove", () => {
+    it("emits ai:config:deleted event after deletion", async () => {
+      const existing: CustomAIProviderConfig = {
+        _id: "cfg_del",
+        _rev: "1-abc",
+        name: "Config to delete",
+        provider: "openai",
+        model: "gpt-4",
+        credentialsFields: {},
+        configType: AIConfigType.COMPLETIONS,
+        isDefault: false,
+        liteLLMModelId: "model_123",
+      }
+
+      mockDbGet.mockResolvedValue(existing)
+
+      await aiConfigs.remove("cfg_del")
+
+      expect(mockConfigDeleted).toHaveBeenCalledWith(
+        expect.objectContaining({ _id: "cfg_del", name: "Config to delete" })
+      )
+    })
+  })
+})

--- a/packages/server/src/sdk/workspace/ai/configs/index.ts
+++ b/packages/server/src/sdk/workspace/ai/configs/index.ts
@@ -3,6 +3,7 @@ import {
   docIds,
   encryption,
   env,
+  events,
   HTTPError,
 } from "@budibase/backend-core"
 import { licensing } from "@budibase/pro"
@@ -253,6 +254,7 @@ export async function create(
   }
 
   await liteLLM.syncKeyModels()
+  events.ai.configCreated(newConfig)
 
   return newConfig
 }
@@ -378,6 +380,8 @@ export async function update(
     }
   }
 
+  events.ai.configUpdated(updatedConfig)
+
   return updatedConfig
 }
 
@@ -386,6 +390,7 @@ export async function remove(id: string) {
 
   const existing = await db.get<CustomAIProviderConfig>(id)
   await db.remove(existing)
+  events.ai.configDeleted(existing)
 
   await liteLLM.syncKeyModels()
 }

--- a/packages/types/src/sdk/events/ai.ts
+++ b/packages/types/src/sdk/events/ai.ts
@@ -1,8 +1,25 @@
 import { BaseEvent } from "./event"
 
-export interface AIConfigCreatedEvent extends BaseEvent {}
+export interface AIConfigCreatedEvent extends BaseEvent {
+  configId: string
+  audited: {
+    name: string
+  }
+}
 
-export interface AIConfigUpdatedEvent extends BaseEvent {}
+export interface AIConfigUpdatedEvent extends BaseEvent {
+  configId: string
+  audited: {
+    name: string
+  }
+}
+
+export interface AIConfigDeletedEvent extends BaseEvent {
+  configId: string
+  audited: {
+    name: string
+  }
+}
 
 export interface AIAgentCreatedEvent extends BaseEvent {
   agentId: string

--- a/packages/types/src/sdk/events/event.ts
+++ b/packages/types/src/sdk/events/event.ts
@@ -37,6 +37,8 @@ export enum Event {
   AI_CONFIG_CREATED = "ai:config:created",
   AI_CONFIG_UPDATED = "ai:config:updated",
 
+  AI_CONFIG_DELETED = "ai:config:deleted",
+
   // AI AGENT
   AI_AGENT_CREATED = "ai:agent:created",
   AI_AGENT_UPDATED = "ai:agent:updated",
@@ -283,8 +285,9 @@ export const AuditedEventFriendlyName: Record<Event, string | undefined> = {
   [Event.EMAIL_SMTP_UPDATED]: `Email configuration updated`,
 
   // AI
-  [Event.AI_CONFIG_CREATED]: `AI configuration created`,
-  [Event.AI_CONFIG_UPDATED]: `AI configuration updated`,
+  [Event.AI_CONFIG_CREATED]: `AI configuration "{{ name }}" created`,
+  [Event.AI_CONFIG_UPDATED]: `AI configuration "{{ name }}" updated`,
+  [Event.AI_CONFIG_DELETED]: `AI configuration "{{ name }}" deleted`,
   [Event.AI_AGENT_CREATED]: `AI agent "{{ name }}" created`,
   [Event.AI_AGENT_UPDATED]: `AI agent "{{ name }}" updated`,
   [Event.AI_AGENT_DELETED]: `AI agent "{{ name }}" deleted`,

--- a/packages/types/src/sdk/events/event.ts
+++ b/packages/types/src/sdk/events/event.ts
@@ -36,7 +36,6 @@ export enum Event {
   // AI
   AI_CONFIG_CREATED = "ai:config:created",
   AI_CONFIG_UPDATED = "ai:config:updated",
-
   AI_CONFIG_DELETED = "ai:config:deleted",
 
   // AI AGENT


### PR DESCRIPTION
## Description

Adds missing lifecycle telemetry events for AI configurations. The publisher functions `configCreated` and `configUpdated` were already defined but never called. This wires them up and also adds the missing `configDeleted` event.

Events emitted:
- `ai:config:created` when a new AI configuration is created
- `ai:config:updated` when an existing AI configuration is updated
- `ai:config:deleted` when an AI configuration is deleted

All events include `configId` and `audited.name` for audit log visibility, and follow the fire-and-forget pattern with `.catch` error handling to avoid unhandled promise rejections.

## Addresses

N/A (follow-up from #18576)

## Screen recording

https://github.com/user-attachments/assets/6eee5252-9d32-4ec6-927c-4643d9be3a7e

## Launchcontrol

Wires up telemetry events for AI configuration lifecycle (create, update, delete) so these actions are tracked in product analytics and the audit log.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds lifecycle telemetry for AI config lifecycle so create, update, and delete are tracked in analytics and the audit log.

- **New Features**
  - Emit `ai:config:created`, `ai:config:updated`, `ai:config:deleted` with `{ configId, audited.name }`.
  - Wire events into server config create/update/delete flows.
  - Add `Event` enum entries and payload types; audited friendly names use `"{{ name }}"` for created/updated/deleted.
  - Publish events fire-and-forget with `.catch` and error logging; add tests for create, update, and remove event emission.

<sup>Written for commit d3056ea99e19e72418185a1f75039bf7bb1bdb05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



