### PR TITLE
Async file deletion

### DIFF
--- a/packages/server/src/api/controllers/ai/files.ts
+++ b/packages/server/src/api/controllers/ai/files.ts
@@ -103,11 +103,14 @@ export async function uploadAgentFile(
 }
 
 export async function deleteAgentFile(
-  ctx: UserCtx<void, { deleted: true }, { agentId: string; fileId: string }>
+  ctx: UserCtx<void, void, { agentId: string; fileId: string }>
 ) {
   const { agentId, fileId } = ctx.params
-  await sdk.ai.rag.deleteFileForAgent(agentId, fileId)
-  ctx.body = { deleted: true }
+  await sdk.ai.rag.knowledgeSourceSyncQueue.enqueueDeleteFileJob(
+    agentId,
+    fileId
+  )
+
   ctx.status = 200
 }
 

--- a/packages/server/src/api/controllers/ai/sharepoint.ts
+++ b/packages/server/src/api/controllers/ai/sharepoint.ts
@@ -66,7 +66,9 @@ export async function cleanupSharePointFilesForAgent({
     filesToDelete
       .map(file => file._id)
       .filter((fileId): fileId is string => !!fileId)
-      .map(fileId => sdk.ai.rag.deleteFileForAgent(agentId, fileId))
+      .map(fileId =>
+        sdk.ai.rag.knowledgeSourceSyncQueue.enqueueDeleteFileJob(agentId, fileId)
+      )
   )
   const failedDeletes = results.filter(
     result => result.status === "rejected"

--- a/packages/server/src/api/controllers/ai/sharepoint.ts
+++ b/packages/server/src/api/controllers/ai/sharepoint.ts
@@ -61,7 +61,10 @@ export async function cleanupSharePointFilesForAgent({
       .map(file => file._id)
       .filter((fileId): fileId is string => !!fileId)
       .map(fileId =>
-        sdk.ai.rag.knowledgeSourceSyncQueue.enqueueDeleteFileJob(agentId, fileId)
+        sdk.ai.rag.knowledgeSourceSyncQueue.enqueueDeleteFileJob(
+          agentId,
+          fileId
+        )
       )
   )
   const failedDeletes = results.filter(

--- a/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
@@ -261,7 +261,10 @@ describe("agent files", () => {
       expect(upload.file.status).toBe(KnowledgeBaseFileStatus.PROCESSING)
       expect(upload.file._id).toBeDefined()
 
-      const deleteScope = mockGeminiFileDelete("vector-store-1", upload.file._id!)
+      const deleteScope = mockGeminiFileDelete(
+        "vector-store-1",
+        upload.file._id!
+      )
 
       await config.api.agent.removeFile(created._id!, upload.file._id!)
       await utils.queue.processMessages(
@@ -431,6 +434,9 @@ describe("agent files", () => {
           sourceIds: ["site-2"],
         }
       )
+      await utils.queue.processMessages(
+        getKnowledgeSourceSyncQueue().getBullQueue()
+      )
 
       expect(deleteScope.isDone()).toBe(true)
       expect(response.options.map(site => site.id)).toEqual([
@@ -548,6 +554,9 @@ describe("agent files", () => {
 
       const response = await config.api.agent.disconnectKnowledgeSources(
         created._id!
+      )
+      await utils.queue.processMessages(
+        getKnowledgeSourceSyncQueue().getBullQueue()
       )
       expect(response).toEqual({
         agentId: created._id!,

--- a/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "@budibase/types"
 import environment, { setEnv } from "../../../../environment"
 import { getQueue } from "../../../../sdk/workspace/ai/rag/queue"
+import { getQueue as getKnowledgeSourceSyncQueue } from "../../../../sdk/workspace/ai/rag/knowledgeSourceSyncQueue"
 import { upsertKnowledgeSourceConnection } from "../../../../sdk/workspace/ai/knowledgeSources"
 import { sharePointConnectionCacheKey } from "../../../../sdk/workspace/ai/sharepoint"
 import { installHttpMocking, resetHttpMocking } from "../../../../tests/jestEnv"
@@ -232,11 +233,11 @@ describe("agent files", () => {
       await utils.queue.processMessages(getQueue().getBullQueue())
       expect(ingestScope.isDone()).toBe(true)
 
-      const response = await config.api.agent.removeFile(
-        created._id!,
-        upload.file._id!
+      await config.api.agent.removeFile(created._id!, upload.file._id!)
+      await utils.queue.processMessages(
+        getKnowledgeSourceSyncQueue().getBullQueue()
       )
-      expect(response.deleted).toBe(true)
+
       expect(deleteScope.isDone()).toBe(true)
 
       const { files } = await config.api.agent.fetchFiles(created._id!)

--- a/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
@@ -211,7 +211,7 @@ describe("agent files", () => {
     })
   })
 
-  it("deletes an uploaded agent file", async () => {
+  it("deletes an uploaded agent file after it has been processed", async () => {
     await withRagEnabled(async () => {
       const created = await config.api.agent.create({
         name: "Support Agent",
@@ -238,6 +238,37 @@ describe("agent files", () => {
         getKnowledgeSourceSyncQueue().getBullQueue()
       )
 
+      expect(deleteScope.isDone()).toBe(true)
+
+      const { files } = await config.api.agent.fetchFiles(created._id!)
+      expect(files).toHaveLength(0)
+    })
+  })
+
+  it("deletes an uploaded agent file before processing starts", async () => {
+    await withRagEnabled(async () => {
+      const created = await config.api.agent.create({
+        name: "Support Agent",
+        aiconfig: "default",
+      })
+
+      mockAutoKnowledgeBaseCreate()
+
+      const upload = await config.api.agent.uploadFile(created._id!, {
+        file: fileBuffer,
+        name: "queued.txt",
+      })
+      expect(upload.file.status).toBe(KnowledgeBaseFileStatus.PROCESSING)
+      expect(upload.file._id).toBeDefined()
+
+      const deleteScope = mockGeminiFileDelete("vector-store-1", upload.file._id!)
+
+      await config.api.agent.removeFile(created._id!, upload.file._id!)
+      await utils.queue.processMessages(
+        getKnowledgeSourceSyncQueue().getBullQueue()
+      )
+
+      await utils.queue.processMessages(getQueue().getBullQueue())
       expect(deleteScope.isDone()).toBe(true)
 
       const { files } = await config.api.agent.fetchFiles(created._id!)
@@ -450,7 +481,7 @@ describe("agent files", () => {
     })
   })
 
-  it("disconnect endpoint removes all SharePoint files", async () => {
+  it("disconnecting SharePoint sources removes all synced files", async () => {
     await withRagEnabled(async () => {
       const created = await config.api.agent.create({
         name: "SharePoint Disconnect Endpoint Agent",

--- a/packages/server/src/sdk/workspace/ai/rag/knowledgeSourceSyncQueue.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/knowledgeSourceSyncQueue.spec.ts
@@ -5,6 +5,9 @@ const mockRemoveRepeatableByKey = jest.fn()
 const mockRemoveJobs = jest.fn()
 const mockDoInWorkspaceContext = jest.fn()
 const mockSyncSharePointSourcesForAgent = jest.fn()
+const mockDeleteFileForAgent = jest.fn()
+const mockDeleteSharePointFilesForAgentSites = jest.fn()
+const mockDeleteKnowledgeSourceSyncStateForAgent = jest.fn()
 const mockGetAllWorkspaces = jest.fn()
 const mockWorkspaceAllDocs = jest.fn()
 
@@ -54,6 +57,14 @@ jest.mock("@budibase/backend-core", () => {
 jest.mock("./sharepoint", () => ({
   syncSharePointSourcesForAgent: (...args: any[]) =>
     mockSyncSharePointSourcesForAgent(...args),
+  deleteSharePointFilesForAgentSites: (...args: any[]) =>
+    mockDeleteSharePointFilesForAgentSites(...args),
+  deleteKnowledgeSourceSyncStateForAgent: (...args: any[]) =>
+    mockDeleteKnowledgeSourceSyncStateForAgent(...args),
+}))
+
+jest.mock("./files", () => ({
+  deleteFileForAgent: (...args: any[]) => mockDeleteFileForAgent(...args),
 }))
 
 import { AgentKnowledgeSourceType, type Agent } from "@budibase/types"
@@ -83,6 +94,7 @@ describe("knowledgeSourceSyncQueue", () => {
     await scheduleJob({
       workspaceId: "app_dev_test",
       agentId: "agent_1",
+      jobType: "sync",
       sourceType: AgentKnowledgeSourceType.SHAREPOINT,
       sourceId: "sharepoint_site_site_1",
     })
@@ -91,6 +103,7 @@ describe("knowledgeSourceSyncQueue", () => {
       {
         workspaceId: "app_dev_test",
         agentId: "agent_1",
+        jobType: "sync",
         sourceType: AgentKnowledgeSourceType.SHAREPOINT,
         sourceId: "sharepoint_site_site_1",
       },
@@ -146,6 +159,7 @@ describe("knowledgeSourceSyncQueue", () => {
       {
         workspaceId: "app_dev_test",
         agentId: "agent_1",
+        jobType: "sync",
         sourceType: AgentKnowledgeSourceType.SHAREPOINT,
         sourceId: "sharepoint_site_site_2",
       },
@@ -196,6 +210,7 @@ describe("knowledgeSourceSyncQueue", () => {
       data: {
         workspaceId: "app_dev_test",
         agentId: "agent_1",
+        jobType: "sync",
         sourceType: AgentKnowledgeSourceType.SHAREPOINT,
         sourceId: "sharepoint_site_site_1",
       },

--- a/packages/server/src/sdk/workspace/ai/rag/knowledgeSourceSyncQueue.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/knowledgeSourceSyncQueue.spec.ts
@@ -255,6 +255,29 @@ describe("knowledgeSourceSyncQueue", () => {
     )
   })
 
+  it("fails disconnect job when SharePoint cleanup fails", async () => {
+    jest.resetModules()
+    mockDeleteSharePointFilesForAgentSite.mockRejectedValueOnce(
+      new Error("cleanup failed")
+    )
+    const queueModule = await import("./knowledgeSourceSyncQueue")
+    queueModule.init()
+
+    const processHandler = mockQueueProcess.mock.calls[0][1]
+
+    await expect(
+      processHandler({
+        data: {
+          workspaceId: "app_dev_test",
+          agentId: "agent_1",
+          jobType: "disconnect_sharepoint_site",
+          siteId: "site_1",
+        },
+      })
+    ).rejects.toThrow("cleanup failed")
+    expect(mockDeleteKnowledgeSourceSyncStateForAgent).not.toHaveBeenCalled()
+  })
+
   it("removes orphan jobs during rehydration", async () => {
     mockGetRepeatableJobs.mockResolvedValue([
       {

--- a/packages/server/src/sdk/workspace/ai/rag/knowledgeSourceSyncQueue.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/knowledgeSourceSyncQueue.ts
@@ -6,7 +6,12 @@ import {
   type Agent,
 } from "@budibase/types"
 import env from "../../../../environment"
-import { syncSharePointSourcesForAgent } from "./sharepoint"
+import { deleteFileForAgent } from "./files"
+import {
+  deleteKnowledgeSourceSyncStateForAgent,
+  deleteSharePointFilesForAgentSites,
+  syncSharePointSourcesForAgent,
+} from "./sharepoint"
 
 const DEFAULT_CONCURRENCY = 2
 const DEFAULT_BACKOFF_MS = utils.Duration.fromSeconds(10).toMs()
@@ -15,12 +20,31 @@ const DEFAULT_TIMEOUT_MS = utils.Duration.fromMinutes(15).toMs()
 const getScheduleWorkspaceNamespace = (workspaceId: string) =>
   db.getProdWorkspaceID(workspaceId)
 
-export interface KnowledgeSourceSyncJob {
+interface BaseKnowledgeSourceJob {
   workspaceId: string
   agentId: string
+}
+
+export interface KnowledgeSourceSyncJob extends BaseKnowledgeSourceJob {
+  jobType: "sync"
   sourceType: AgentKnowledgeSourceType
   sourceId: string
 }
+
+interface KnowledgeBaseFileDeleteJob extends BaseKnowledgeSourceJob {
+  jobType: "delete_file"
+  fileId: string
+}
+
+interface SharePointSiteDisconnectJob extends BaseKnowledgeSourceJob {
+  jobType: "disconnect_sharepoint_site"
+  siteId: string
+}
+
+export type KnowledgeSourceJob =
+  | KnowledgeSourceSyncJob
+  | KnowledgeBaseFileDeleteJob
+  | SharePointSiteDisconnectJob
 
 interface ReconcileAgentJobsSummary {
   clearedSchedules: number
@@ -28,7 +52,7 @@ interface ReconcileAgentJobsSummary {
 }
 
 let knowledgeSourceSyncQueue:
-  | queue.BudibaseQueue<KnowledgeSourceSyncJob>
+  | queue.BudibaseQueue<KnowledgeSourceJob>
   | undefined
 let knowledgeSourceSyncQueueInitialised = false
 
@@ -49,7 +73,10 @@ const hasSchedulableSharePointSource = (agent: Agent) => {
   )
 }
 
-const getDesiredJobsForAgent = (workspaceId: string, agent: Agent) => {
+const getDesiredJobsForAgent = (
+  workspaceId: string,
+  agent: Agent
+): KnowledgeSourceSyncJob[] => {
   if (!agent._id || !hasSchedulableSharePointSource(agent)) {
     return []
   }
@@ -63,6 +90,7 @@ const getDesiredJobsForAgent = (workspaceId: string, agent: Agent) => {
   return sourceIds.map(sourceId => ({
     workspaceId,
     agentId: agent._id!,
+    jobType: "sync" as const,
     sourceType: AgentKnowledgeSourceType.SHAREPOINT,
     sourceId,
   }))
@@ -70,7 +98,7 @@ const getDesiredJobsForAgent = (workspaceId: string, agent: Agent) => {
 
 export function getQueue() {
   if (!knowledgeSourceSyncQueue) {
-    knowledgeSourceSyncQueue = new queue.BudibaseQueue<KnowledgeSourceSyncJob>(
+    knowledgeSourceSyncQueue = new queue.BudibaseQueue<KnowledgeSourceJob>(
       queue.JobQueue.KNOWLEDGE_SOURCE_SYNC,
       {
         maxStalledCount: 3,
@@ -87,8 +115,13 @@ export function getQueue() {
         jobTags: data => ({
           workspaceId: data.workspaceId,
           agentId: data.agentId,
-          sourceType: data.sourceType,
-          sourceId: data.sourceId,
+          sourceType: data.jobType === "sync" ? data.sourceType : data.jobType,
+          sourceId:
+            data.jobType === "sync"
+              ? data.sourceId
+              : data.jobType === "delete_file"
+                ? data.fileId
+                : data.siteId,
         }),
       }
     )
@@ -105,31 +138,53 @@ export function init(concurrency = DEFAULT_CONCURRENCY) {
     knowledgeSourceSyncQueueInitialised = true
     return getQueue().process(
       concurrency,
-      async (job: Job<KnowledgeSourceSyncJob>) => {
-        const { workspaceId, agentId, sourceType, sourceId } = job.data
+      async (job: Job<KnowledgeSourceJob>) => {
+        const { workspaceId, agentId } = job.data
         console.log("Processing knowledge source sync queue job", {
           workspaceId,
           agentId,
-          sourceType,
-          sourceId,
+          jobType: job.data.jobType,
+          sourceType:
+            "sourceType" in job.data ? job.data.sourceType : undefined,
+          sourceId: "sourceId" in job.data ? job.data.sourceId : undefined,
+          fileId: "fileId" in job.data ? job.data.fileId : undefined,
+          siteId: "siteId" in job.data ? job.data.siteId : undefined,
           jobId: job.id,
         })
         await context.doInWorkspaceContext(workspaceId, async () => {
-          switch (sourceType) {
-            case AgentKnowledgeSourceType.SHAREPOINT:
-              await syncSharePointSourcesForAgent(agentId, [sourceId])
+          switch (job.data.jobType) {
+            case "sync":
+              switch (job.data.sourceType) {
+                case AgentKnowledgeSourceType.SHAREPOINT:
+                  await syncSharePointSourcesForAgent(agentId, [
+                    job.data.sourceId,
+                  ])
+                  break
+                default:
+                  throw new Error(
+                    `Unsupported knowledge source type for sync queue: ${job.data.sourceType}`
+                  )
+              }
+              break
+            case "delete_file":
+              await deleteFileForAgent(agentId, job.data.fileId)
+              break
+            case "disconnect_sharepoint_site":
+              await deleteSharePointFilesForAgentSites(agentId, [
+                job.data.siteId,
+              ])
+              await deleteKnowledgeSourceSyncStateForAgent(agentId, [
+                job.data.siteId,
+              ])
               break
             default:
-              throw new Error(
-                `Unsupported knowledge source type for sync queue: ${sourceType}`
-              )
+              throw new Error("Unsupported knowledge source queue job type")
           }
         })
         console.log("Completed knowledge source sync queue job", {
           workspaceId,
           agentId,
-          sourceType,
-          sourceId,
+          jobType: job.data.jobType,
           jobId: job.id,
         })
       }
@@ -150,6 +205,65 @@ export async function scheduleJob(job: KnowledgeSourceSyncJob) {
     },
     jobId,
   })
+}
+
+export async function enqueueJob(job: KnowledgeSourceJob) {
+  init()
+  return await getQueue().add(job)
+}
+
+export async function enqueueDeleteFileJob(agentId: string, fileId: string) {
+  const workspaceId = context.getWorkspaceId()
+  if (!workspaceId || !agentId || !fileId) {
+    return
+  }
+  await enqueueJob({
+    workspaceId,
+    agentId,
+    jobType: "delete_file",
+    fileId,
+  })
+}
+
+export async function enqueueDisconnectSharePointSiteJob(
+  agentId: string,
+  siteId: string
+) {
+  const workspaceId = context.getWorkspaceId()
+  if (!workspaceId || !agentId || !siteId) {
+    return
+  }
+  await enqueueJob({
+    workspaceId,
+    agentId,
+    jobType: "disconnect_sharepoint_site",
+    siteId,
+  })
+}
+
+export async function enqueueAgentJobs(
+  agentId: string,
+  sourceType: AgentKnowledgeSourceType,
+  sourceIds: string[]
+) {
+  const workspaceId = context.getWorkspaceId()
+  if (!workspaceId || !agentId || sourceIds.length === 0) {
+    return
+  }
+  await Promise.all(
+    sourceIds.map(sourceId => {
+      const job: KnowledgeSourceSyncJob = {
+        workspaceId,
+        agentId,
+        jobType: "sync",
+        sourceType,
+        sourceId,
+      }
+      return getQueue().add(job, {
+        jobId: getJobId(job),
+      })
+    })
+  )
 }
 
 export async function removeJob(job: KnowledgeSourceSyncJob) {

--- a/packages/server/src/sdk/workspace/ai/rag/sharepoint.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/sharepoint.spec.ts
@@ -7,6 +7,8 @@ const mockKnowledgeBaseListFiles = jest.fn()
 const mockKnowledgeBaseUploadFile = jest.fn()
 const mockGetSharePointBearerToken = jest.fn()
 const mockEnsureKnowledgeBaseForAgent = jest.fn()
+const mockDeleteFileForAgent = jest.fn()
+const mockListFilesForAgent = jest.fn()
 
 jest.mock("@budibase/backend-core", () => {
   const actual = jest.requireActual("@budibase/backend-core")
@@ -50,6 +52,8 @@ jest.mock("./files", () => {
   return {
     ensureKnowledgeBaseForAgent: (...args: any[]) =>
       mockEnsureKnowledgeBaseForAgent(...args),
+    deleteFileForAgent: (...args: any[]) => mockDeleteFileForAgent(...args),
+    listFilesForAgent: (...args: any[]) => mockListFilesForAgent(...args),
   }
 })
 
@@ -60,7 +64,10 @@ import {
   type Agent,
   type KnowledgeBaseFile,
 } from "@budibase/types"
-import { syncSharePointSourcesForAgent } from "./sharepoint"
+import {
+  deleteSharePointFilesForAgentSite,
+  syncSharePointSourcesForAgent,
+} from "./sharepoint"
 
 const toArrayBuffer = (value: string) => {
   const buffer = Buffer.from(value)
@@ -200,5 +207,43 @@ describe("rag/sharepoint sync deduplication", () => {
       unsupported: 0,
       totalDiscovered: 1,
     })
+  })
+})
+
+describe("rag/sharepoint cleanup", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("throws when at least one SharePoint file deletion fails", async () => {
+    mockListFilesForAgent.mockResolvedValue([
+      {
+        _id: "file_1",
+        source: {
+          type: "sharepoint",
+          knowledgeSourceId: "source-1",
+          siteId: "site-1",
+          driveId: "drive-1",
+          itemId: "item-1",
+        },
+      },
+      {
+        _id: "file_2",
+        source: {
+          type: "sharepoint",
+          knowledgeSourceId: "source-1",
+          siteId: "site-1",
+          driveId: "drive-1",
+          itemId: "item-2",
+        },
+      },
+    ])
+    mockDeleteFileForAgent
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("delete failed"))
+
+    await expect(
+      deleteSharePointFilesForAgentSite("agent_1", "site-1")
+    ).rejects.toThrow("Failed to delete 1/2 SharePoint files for site site-1")
   })
 })

--- a/packages/server/src/sdk/workspace/ai/rag/sharepoint.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/sharepoint.ts
@@ -19,7 +19,11 @@ import {
   isAllowedSharePointNextLink,
   sharePointConnectionCacheKey,
 } from "../sharepoint"
-import { ensureKnowledgeBaseForAgent } from "./files"
+import {
+  deleteFileForAgent,
+  ensureKnowledgeBaseForAgent,
+  listFilesForAgent,
+} from "./files"
 
 interface SharePointDrive {
   id?: string
@@ -604,4 +608,45 @@ export const syncSharePointSourcesForAgent = async (
 
     totalDiscovered,
   }
+}
+
+export const deleteSharePointFilesForAgentSites = async (
+  agentId: string,
+  siteIds: string[]
+) => {
+  const trimmedAgentId = trimString(agentId)
+  if (!trimmedAgentId) {
+    return
+  }
+  const normalizedSiteIds = Array.from(
+    new Set(siteIds.map(siteId => trimString(siteId)).filter(Boolean))
+  )
+  if (normalizedSiteIds.length === 0) {
+    return
+  }
+
+  const files = await listFilesForAgent(trimmedAgentId)
+  const fileIdsToDelete = files
+    .filter(file => {
+      const externalSourceId = trimString(file.externalSourceId)
+      const uploadedBy = trimString(file.uploadedBy)
+      return normalizedSiteIds.some(
+        siteId =>
+          externalSourceId.startsWith(`sharepoint:${siteId}:`) ||
+          uploadedBy === `sharepoint:${siteId}`
+      )
+    })
+    .map(file => file._id)
+    .filter((fileId): fileId is string => !!fileId)
+
+  const results = await Promise.allSettled(
+    fileIdsToDelete.map(fileId => deleteFileForAgent(trimmedAgentId, fileId))
+  )
+  const failed = results.filter(result => result.status === "rejected").length
+  console.log("SharePoint file cleanup completed for sites", {
+    agentId: trimmedAgentId,
+    siteIds: normalizedSiteIds,
+    deleted: fileIdsToDelete.length - failed,
+    failed,
+  })
 }

--- a/packages/server/src/sdk/workspace/ai/rag/sharepoint.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/sharepoint.ts
@@ -596,11 +596,21 @@ export const deleteSharePointFilesForAgentSite = async (
   const results = await Promise.allSettled(
     fileIdsToDelete.map(fileId => deleteFileForAgent(agentId, fileId))
   )
-  const failed = results.filter(result => result.status === "rejected").length
+  const failedFileIds = results
+    .map((result, index) => ({ result, fileId: fileIdsToDelete[index] }))
+    .filter(item => item.result.status === "rejected")
+    .map(item => item.fileId)
+  const failed = failedFileIds.length
   console.log("SharePoint file cleanup completed for site", {
     agentId,
     siteId,
     deleted: fileIdsToDelete.length - failed,
     failed,
   })
+
+  if (failed > 0) {
+    throw new Error(
+      `Failed to delete ${failed}/${fileIdsToDelete.length} SharePoint files for site ${siteId}: ${failedFileIds.join(", ")}`
+    )
+  }
 }


### PR DESCRIPTION
## Description
Process file deletions as a queue instead of being sync, to prevent having stale data in the rag system

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make agent file deletions async to cut request time and prevent stale RAG data. SharePoint cleanup now fails fast with clear errors.

- **New Features**
  - `deleteAgentFile` now enqueues `delete_file` jobs via `knowledgeSourceSyncQueue` and returns 200 with no body.
  - `knowledgeSourceSyncQueue` supports `sync`, `delete_file`, and `disconnect_sharepoint_site` jobs.
  - SharePoint cleanup and disconnect now enqueue deletions instead of deleting immediately.
  - SharePoint cleanup throws when any deletion fails (includes failed file IDs), and `disconnect_sharepoint_site` jobs surface these failures.

- **Migration**
  - Clients should not expect a `{ deleted: true }` response. Treat a 200 response as an acknowledgment; the queue processes deletion asynchronously.

<sup>Written for commit 2cd3c3be14a194170c41f1586af65803bbdb98c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

