### PR TITLE
[18594] Fix workspace assignment for synced Azure AD groups

### DIFF
--- a/packages/builder/src/settings/pages/people/groups/group.spec.ts
+++ b/packages/builder/src/settings/pages/people/groups/group.spec.ts
@@ -1,0 +1,255 @@
+import { render, screen } from "@testing-library/svelte"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { UserGroup } from "@budibase/types"
+
+const {
+  appsStore,
+  appsStoreMock,
+  authStore,
+  bbMock,
+  groupsMock,
+  groupsStore,
+  rolesMock,
+} = vi.hoisted(() => {
+  const createStore = <T>(initialValue: T) => {
+    let value = initialValue
+    const subscribers = new Set<(value: T) => void>()
+
+    return {
+      subscribe(callback: (value: T) => void) {
+        callback(value)
+        subscribers.add(callback)
+        return () => subscribers.delete(callback)
+      },
+      set(nextValue: T) {
+        value = nextValue
+        subscribers.forEach(callback => callback(value))
+      },
+    }
+  }
+
+  const groupsStore = createStore([] as UserGroup[])
+  const appsStore = createStore({ apps: [] as { devId: string }[] })
+  const authStore = createStore({
+    user: {
+      admin: { global: true },
+    },
+  })
+
+  const rolesMock = {
+    fetch: vi.fn().mockResolvedValue(undefined),
+  }
+  const bbMock = {
+    settings: vi.fn(),
+  }
+  const groupsMock = {
+    subscribe: groupsStore.subscribe,
+    init: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    removeApp: vi.fn().mockResolvedValue(undefined),
+    getGroupAppIds: (group?: UserGroup) => {
+      let ids = Object.keys(group?.roles || {})
+      if (group?.builder?.apps) {
+        ids = ids.concat(group.builder.apps)
+      }
+      return ids
+    },
+  }
+  const appsStoreMock = {
+    subscribe: appsStore.subscribe,
+    getProdAppID: vi.fn((devId: string) => devId),
+  }
+
+  return {
+    appsStore,
+    appsStoreMock,
+    authStore,
+    bbMock,
+    groupsMock,
+    groupsStore,
+    rolesMock,
+  }
+})
+
+vi.mock("@budibase/bbui", async () => {
+  const [
+    { default: MockInput },
+    { default: MockLayout },
+    { default: MockModal },
+    { default: MockToggle },
+  ] = await Promise.all([
+    import("@/test/mocks/MockInput.svelte"),
+    import("@/test/mocks/MockLayout.svelte"),
+    import("@/test/mocks/MockModal.svelte"),
+    import("@/test/mocks/MockToggle.svelte"),
+  ])
+
+  return {
+    ActionMenu: MockLayout,
+    Heading: MockLayout,
+    Icon: MockLayout,
+    Layout: MockLayout,
+    MenuItem: MockLayout,
+    Modal: MockModal,
+    Pagination: MockLayout,
+    Search: MockInput,
+    Table: MockLayout,
+    Toggle: MockToggle,
+    notifications: {
+      error: vi.fn(),
+      success: vi.fn(),
+    },
+  }
+})
+
+vi.mock("@/components/common/ConfirmDialog.svelte", async () => {
+  const { default: MockLayout } = await import("@/test/mocks/MockLayout.svelte")
+  return { default: MockLayout }
+})
+
+vi.mock("../users/_components/AppNameTableRenderer.svelte", async () => {
+  const { default: MockLayout } = await import("@/test/mocks/MockLayout.svelte")
+  return { default: MockLayout }
+})
+
+vi.mock("../users/_components/AppRoleTableRenderer.svelte", async () => {
+  const { default: MockLayout } = await import("@/test/mocks/MockLayout.svelte")
+  return { default: MockLayout }
+})
+
+vi.mock("./_components/CreateEditGroupModal.svelte", async () => {
+  const { default: MockLayout } = await import("@/test/mocks/MockLayout.svelte")
+  return { default: MockLayout }
+})
+
+vi.mock("./_components/GroupIcon.svelte", async () => {
+  const { default: MockLayout } = await import("@/test/mocks/MockLayout.svelte")
+  return { default: MockLayout }
+})
+
+vi.mock("./_components/GroupUsers.svelte", async () => {
+  const { default: MockLayout } = await import("@/test/mocks/MockLayout.svelte")
+  return { default: MockLayout }
+})
+
+vi.mock("./_components/EditWorkspaceRoleModal.svelte", async () => {
+  const { default: MockLayout } = await import("@/test/mocks/MockLayout.svelte")
+  return { default: MockLayout }
+})
+
+vi.mock("./_components/RemoveWorkspaceTableRenderer.svelte", async () => {
+  const { default: MockLayout } = await import("@/test/mocks/MockLayout.svelte")
+  return { default: MockLayout }
+})
+
+vi.mock("./_components/AssignWorkspacePicker.svelte", async () => {
+  const { default: MockAssignWorkspacePicker } = await import(
+    "@/test/mocks/MockAssignWorkspacePicker.svelte"
+  )
+  return { default: MockAssignWorkspacePicker }
+})
+
+vi.mock("@/stores/builder", () => ({
+  roles: rolesMock,
+}))
+
+vi.mock("@/stores/portal/apps", () => ({
+  appsStore: appsStoreMock,
+}))
+
+vi.mock("@/stores/portal/auth", () => ({
+  auth: authStore,
+}))
+
+vi.mock("@/stores/portal/groups", () => ({
+  groups: groupsMock,
+}))
+
+vi.mock("@/stores/bb", () => ({
+  bb: bbMock,
+}))
+
+vi.mock("@budibase/shared-core", () => ({
+  sdk: {
+    users: {
+      isAdmin: (user: any) => !!user?.admin?.global,
+    },
+  },
+}))
+
+vi.mock("@budibase/frontend-core", () => ({
+  Constants: {
+    Roles: {
+      CREATOR: "CREATOR",
+    },
+  },
+}))
+
+import GroupPage from "./group.svelte"
+
+const buildGroup = (overrides: Partial<UserGroup> = {}): UserGroup =>
+  ({
+    _id: "group_1",
+    _rev: "rev_1",
+    name: "Sync Group",
+    users: [],
+    roles: {},
+    builder: { apps: [] },
+    ...overrides,
+  }) as UserGroup
+
+describe("group page workspace assignment permissions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    appsStore.set({ apps: [] })
+    groupsStore.set([
+      buildGroup({
+        scimInfo: { isSync: true, externalId: "123" },
+      }),
+    ])
+    authStore.set({
+      user: {
+        admin: { global: true },
+      },
+    })
+  })
+
+  const renderGroupPage = () => {
+    const routingStore = {
+      subscribe(callback: (value: { params: Record<string, string> }) => void) {
+        callback({ params: {} })
+        return () => {}
+      },
+    }
+
+    render(GroupPage, {
+      props: {
+        groupId: "group_1",
+      },
+      context: new Map([["routing", routingStore]]),
+    })
+  }
+
+  it("shows workspace assignment controls for synced groups when the user is admin", async () => {
+    renderGroupPage()
+
+    await screen.findByText("Workspaces")
+    expect(screen.getByTestId("assign-workspace-picker")).toBeInTheDocument()
+  })
+
+  it("hides workspace assignment controls for non-admin users", async () => {
+    authStore.set({
+      user: {
+        admin: { global: false },
+      },
+    })
+
+    renderGroupPage()
+
+    await screen.findByText("Workspaces")
+    expect(
+      screen.queryByTestId("assign-workspace-picker")
+    ).not.toBeInTheDocument()
+  })
+})

--- a/packages/builder/src/settings/pages/people/groups/group.svelte
+++ b/packages/builder/src/settings/pages/people/groups/group.svelte
@@ -54,7 +54,8 @@
   $: group = $groups.find(x => x._id === groupId)
   $: isScimGroup = group?.scimInfo?.isSync
   $: isAdmin = sdk.users.isAdmin($auth.user)
-  $: readonly = !isAdmin || isScimGroup
+  $: groupReadonly = !isAdmin || isScimGroup
+  $: workspaceReadonly = !isAdmin
   $: appSchema = {
     name: {
       width: "1fr",
@@ -62,7 +63,7 @@
     role: {
       width: "1fr",
     },
-    ...(readonly
+    ...(workspaceReadonly
       ? {}
       : {
           prodAppId: {
@@ -97,7 +98,7 @@
         ...app,
         _id: prodAppId,
         prodAppId,
-        readonly,
+        readonly: workspaceReadonly,
         role: group?.builder?.apps.includes(prodAppId)
           ? Constants.Roles.CREATOR
           : group?.roles?.[prodAppId],
@@ -191,7 +192,7 @@
   }
 
   const openWorkspaceRoleModal = workspace => {
-    if (readonly || workspace?.__skeleton) {
+    if (workspaceReadonly || workspace?.__skeleton) {
       return
     }
     selectedWorkspace = workspace
@@ -201,7 +202,7 @@
 
   setContext("groupApps", {
     removeApp,
-    getReadonly: () => readonly,
+    getReadonly: () => workspaceReadonly,
   })
 
   onMount(async () => {
@@ -226,7 +227,7 @@
         >
           <Toggle
             value={!!group?.isDefault}
-            disabled={readonly || defaultUpdating}
+            disabled={groupReadonly || defaultUpdating}
             on:change={e => updateDefaultStatus(e.detail)}
           />
           <span class="default-toggle-label">Default</span>
@@ -246,7 +247,7 @@
             <MenuItem
               icon="trash"
               on:click={() => deleteModal.show()}
-              disabled={readonly}
+              disabled={groupReadonly}
             >
               Delete
             </MenuItem>
@@ -256,13 +257,13 @@
     </div>
 
     <Layout noPadding gap="S">
-      <GroupUsers {groupId} {readonly} {isScimGroup} />
+      <GroupUsers {groupId} readonly={groupReadonly} {isScimGroup} />
     </Layout>
 
     <Layout noPadding gap="S">
       <Heading size="S">Workspaces</Heading>
       <div class="workspace-controls">
-        {#if !readonly}
+        {#if !workspaceReadonly}
           <AssignWorkspacePicker {groupId} />
         {/if}
         <div class="workspace-controls-right">

--- a/packages/builder/src/test/mocks/MockAssignWorkspacePicker.svelte
+++ b/packages/builder/src/test/mocks/MockAssignWorkspacePicker.svelte
@@ -1,0 +1,1 @@
+<div data-testid="assign-workspace-picker" />


### PR DESCRIPTION
## Description
Fixes a regression where synced Azure AD (SCIM) groups could not be assigned to workspaces from the group details page because workspace controls were incorrectly gated behind a SCIM read-only check.

This change separates group-management read-only state from workspace-assignment permissions so admins can assign/edit/remove workspace access for synced groups while keeping SCIM identity/membership protections in place.

## Addresses
- https://github.com/Budibase/budibase/issues/18594

## Launchcontrol
Allow admins to assign synced Azure AD groups to workspaces again in the People > Groups settings page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression that blocked workspace assignment for SCIM-synced Azure AD groups. Admins can now assign, edit, and remove workspace access from the group page while SCIM identity and membership stay read-only. Addresses budibase/budibase#18594.

- **Bug Fixes**
  - Split read-only logic: `groupReadonly` (SCIM identity/membership) vs `workspaceReadonly` (admin-gated).
  - Show `AssignWorkspacePicker` to admins for synced groups; hide for non-admins.
  - Keep delete/default actions admin-only; prevent workspace role edits when not admin.
  - Added tests for workspace controls visibility and a mock `MockAssignWorkspacePicker`.

<sup>Written for commit db06ef688be7730eb05f3ed21898f776254bd11a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

