### PR TITLE
Sharepoint - display files as tree

### DIFF
--- a/packages/bbui/src/TreeView/Item.svelte
+++ b/packages/bbui/src/TreeView/Item.svelte
@@ -1,28 +1,96 @@
 <script lang="ts">
+  import { createEventDispatcher, getContext } from "svelte"
+  import { writable } from "svelte/store"
   import Icon from "../Icon/Icon.svelte"
+  import type { TreeViewContext } from "./context"
 
   export let selected: boolean = false
+  export let disabled: boolean = false
   export let open: boolean = false
   export let href: string | null = null
   export let title: string
-  export let icon: string | undefined
+  export let icon: string | undefined = undefined
+  export let hasChildren: boolean = false
+
+  const treeViewContext = getContext<TreeViewContext | undefined>(
+    "bbui-treeview"
+  ) || {
+    selectable: writable(false),
+    quiet: writable(false),
+  }
+
+  const quietStore = treeViewContext.quiet
+
+  const dispatch = createEventDispatcher<{ toggle: boolean; select: boolean }>()
+
+  let isOpen = open
+  $: isQuiet = !!$quietStore
+  $: if (!hasChildren) {
+    isOpen = false
+  }
+
+  const toggleOpen = (event: MouseEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (!hasChildren) {
+      return
+    }
+    isOpen = !isOpen
+    dispatch("toggle", isOpen)
+  }
+
+  const handleIndicatorKeydown = (event: KeyboardEvent) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault()
+      if (!hasChildren) {
+        return
+      }
+      isOpen = !isOpen
+      dispatch("toggle", isOpen)
+    }
+  }
 </script>
 
 <li
-  class:is-selected={selected}
-  class:is-open={open}
+  class:is-selected={selected && !isQuiet}
+  class:is-open={hasChildren && isOpen}
   class="spectrum-TreeView-item"
+  class:is-disabled={disabled}
 >
-  <a on:click class="spectrum-TreeView-itemLink" {href}>
-    {#if $$slots.default}
-      <Icon name="caret-right" size="M" />
+  <a
+    on:click
+    class:spectrum-TreeView-itemLink--selectable={!disabled}
+    class="spectrum-TreeView-itemLink"
+    {href}
+  >
+    {#if hasChildren}
+      <span
+        class="spectrum-TreeView-itemIndicator"
+        role="button"
+        tabindex="0"
+        on:click={toggleOpen}
+        on:keydown={handleIndicatorKeydown}
+      >
+        <Icon name="caret-right" size="M" />
+      </span>
     {/if}
+
     {#if icon}
-      <Icon name={icon} size="M" />
+      <span class="spectrum-TreeView-itemIcon">
+        <Icon name={icon} size="M" />
+      </span>
     {/if}
+
     <span class="spectrum-TreeView-itemLabel">{title}</span>
+
+    {#if $$slots.post}
+      <span class="item-post">
+        <slot name="post" />
+      </span>
+    {/if}
   </a>
-  {#if $$slots.default}
+
+  {#if hasChildren && $$slots.default}
     <ul class="spectrum-TreeView">
       <slot />
     </ul>
@@ -30,4 +98,28 @@
 </li>
 
 <style>
+  .item-post {
+    margin-inline-start: auto;
+    padding-inline-end: 8px;
+    white-space: nowrap;
+  }
+
+  .item-post :global(.spectrum-StatusLight) {
+    margin: 0;
+  }
+
+  .spectrum-TreeView-itemIndicator :global(i) {
+    font-size: 12px;
+  }
+
+  .spectrum-TreeView-itemLink--selectable .spectrum-TreeView-itemIndicator {
+    inset-inline-start: 0;
+    inset-block-start: 0;
+    margin-inline-start: 0;
+    margin-inline-end: var(--spacing-xs);
+    margin-block-end: 0;
+    padding-inline: 0;
+    padding-block: 0;
+    flex-shrink: 0;
+  }
 </style>

--- a/packages/bbui/src/TreeView/Item.svelte
+++ b/packages/bbui/src/TreeView/Item.svelte
@@ -20,16 +20,11 @@
   }
 
   const quietStore = treeViewContext.quiet
-
   const dispatch = createEventDispatcher<{ toggle: boolean; select: boolean }>()
 
-  let isOpen = open
   $: isQuiet = !!$quietStore
-  $: if (hasChildren) {
-    isOpen = open
-  }
   $: if (!hasChildren) {
-    isOpen = false
+    open = false
   }
 
   const toggleOpen = (event: MouseEvent) => {
@@ -38,8 +33,8 @@
     if (!hasChildren) {
       return
     }
-    isOpen = !isOpen
-    dispatch("toggle", isOpen)
+    open = !open
+    dispatch("toggle", open)
   }
 
   const handleIndicatorKeydown = (event: KeyboardEvent) => {
@@ -48,15 +43,15 @@
       if (!hasChildren) {
         return
       }
-      isOpen = !isOpen
-      dispatch("toggle", isOpen)
+      open = !open
+      dispatch("toggle", open)
     }
   }
 </script>
 
 <li
   class:is-selected={selected && !isQuiet}
-  class:is-open={hasChildren && isOpen}
+  class:is-open={hasChildren && open}
   class="spectrum-TreeView-item"
   class:is-disabled={disabled}
 >

--- a/packages/bbui/src/TreeView/Item.svelte
+++ b/packages/bbui/src/TreeView/Item.svelte
@@ -25,6 +25,9 @@
 
   let isOpen = open
   $: isQuiet = !!$quietStore
+  $: if (hasChildren) {
+    isOpen = open
+  }
   $: if (!hasChildren) {
     isOpen = false
   }

--- a/packages/bbui/src/TreeView/Tree.svelte
+++ b/packages/bbui/src/TreeView/Tree.svelte
@@ -1,9 +1,19 @@
 <script lang="ts">
+  import { setContext } from "svelte"
+  import { writable } from "svelte/store"
   import "@spectrum-css/treeview/dist/index-vars.css"
+  import type { TreeViewContext } from "./context"
 
   export let quiet: boolean = false
   export let standalone: boolean = true
   export let width: string = "250px"
+
+  const treeViewContext: TreeViewContext = {
+    quiet: writable(quiet),
+  }
+  setContext("bbui-treeview", treeViewContext)
+
+  $: treeViewContext.quiet.set(quiet)
 </script>
 
 <ul

--- a/packages/bbui/src/TreeView/context.ts
+++ b/packages/bbui/src/TreeView/context.ts
@@ -1,0 +1,5 @@
+import type { Writable } from "svelte/store"
+
+export interface TreeViewContext {
+  quiet: Writable<boolean>
+}

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/KnowledgeAddControls.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/KnowledgeAddControls.svelte
@@ -3,7 +3,7 @@
   import { KNOWLEDGE_FILE_ACCEPT_ATTRIBUTE } from "@budibase/types"
   import { notifications } from "@budibase/bbui"
   import { agentsStore } from "@/stores/portal"
-  import AddKnowledgeModal from "./AddKnowledgeModal.svelte"
+  import AddKnowledgeModal from "./new/AddKnowledgeModal.svelte"
   import type { PendingUpload } from "./knowledgeTableRows"
 
   const BYTES_IN_MB = 1024 * 1024

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/index.svelte
@@ -6,7 +6,6 @@
     AgentKnowledgeSourceType,
     KnowledgeBaseFileStatus,
     type Agent,
-    type KnowledgeSourceOption,
     type KnowledgeBaseFile,
     type SharePointKnowledgeSourceSnapshot,
   } from "@budibase/types"
@@ -14,21 +13,19 @@
   import { agentsStore, selectedAgent } from "@/stores/portal"
   import KnowledgeTable from "./KnowledgeTable.svelte"
   import KnowledgeAddControls from "./KnowledgeAddControls.svelte"
-  import SelectSharePointSiteModal from "./SelectSharePointSiteModal.svelte"
-  import SharePointFilesStatusModal from "./SharePointFilesStatusModal.svelte"
+  import SelectSharePointSiteModal from "./new/SelectSharePointSiteModal.svelte"
   import { onDestroy, onMount } from "svelte"
   import type { KnowledgeTableRow } from "./renderers/types"
   import type { PendingUpload } from "./knowledgeTableRows"
   import {
-    getSharePointFilesForSite,
     toFileTableRows,
     toSharePointConnectionRows,
   } from "./knowledgeTableRows"
+  import DisplaySharePointSiteModal from "./sharepoint/DisplaySharePointSiteModal.svelte"
   import {
     coalesceAgentPollRequests,
     createKnowledgePollingController,
   } from "./polling"
-  import { API } from "@/api"
 
   let currentAgent: Agent | undefined = $derived($selectedAgent)
   let activeAgentId = $derived(currentAgent?._id)
@@ -37,7 +34,6 @@
       source => source.type === AgentKnowledgeSourceType.SHAREPOINT
     )
   )
-  let hasSharePointConnection = $derived(sharePointSources.length > 0)
   let loading = $state(true)
   let pendingUploadsByAgent = $state<Record<string, PendingUpload[]>>({})
   let uploadingByAgent = $state<Record<string, boolean>>({})
@@ -54,31 +50,32 @@
   })
 
   let initialKnowledgeLoadedForAgent = $state<string | undefined>()
-  let sharePointSites = $state<KnowledgeSourceOption[]>()
   let sharePointSourceSnapshots = $derived.by(() => {
     const agentId = currentAgent?._id
     if (!agentId) {
       return [] as SharePointKnowledgeSourceSnapshot[]
     }
-    return $agentsStore.knowledgeByAgent[agentId].sharePointSources || []
+    return $agentsStore.knowledgeByAgent[agentId]?.sharePointSources || []
+  })
+  let hasSharePointConnection = $derived.by(() => {
+    const agentId = currentAgent?._id
+    if (!agentId) {
+      return false
+    }
+    return (
+      $agentsStore.knowledgeByAgent[agentId]?.hasSharePointConnection || false
+    )
   })
   let selectedSiteIds = $derived.by(() =>
     sharePointSources
       .map(source => source.config.site?.id)
       .filter((siteId): siteId is string => !!siteId)
   )
-  let pendingSiteIds = $state<string[]>([])
-  let effectiveSelectedSiteIds = $derived.by(() =>
-    Array.from(new Set([...selectedSiteIds, ...pendingSiteIds]))
-  )
-  let loadingSharePointSites = $state(false)
-  let sharePointSiteModal = $state<SelectSharePointSiteModal>()
-  let sharePointFilesStatusModal = $state<SharePointFilesStatusModal>()
+  let selectSharePointSiteModal = $state<SelectSharePointSiteModal>()
+  let displaySharePointSiteModal = $state<DisplaySharePointSiteModal>()
   let selectedSharePointSiteId = $state("")
-  let selectedStatusSiteId = $state<string | undefined>()
-  let selectedStatusSiteName = $state<string | undefined>()
   let shouldOpenSharePointPickerAfterOauth = $state(false)
-  const SHAREPOINT_BOOTSTRAP_POLLS = 60
+  let loadingSharePointSites = $state(false)
   const KNOWLEDGE_POLL_INTERVAL_MS = 1000
   const knowledgePollingController = createKnowledgePollingController({
     intervalMs: KNOWLEDGE_POLL_INTERVAL_MS,
@@ -133,13 +130,6 @@
     knowledgePollingController.stop()
   }
 
-  const startSharePointBootstrapPolling = (
-    agentId: string,
-    pollCount = SHAREPOINT_BOOTSTRAP_POLLS
-  ) => {
-    knowledgePollingController.boost(agentId, pollCount)
-  }
-
   const showSharePointSyncResult = (
     result: SyncAgentKnowledgeSourcesResponse
   ) => {
@@ -152,8 +142,13 @@
         return
       }
       if (alreadySynced > 0) {
+        const details = [
+          alreadySynced > 0 ? `${alreadySynced} already synced` : "",
+        ]
+          .filter(Boolean)
+          .join(", ")
         notifications.info(
-          `SharePoint sync complete (0 new files, ${alreadySynced} already synced)`
+          `SharePoint sync complete (0 new files${details ? `, ${details}` : ""})`
         )
         return
       }
@@ -170,31 +165,19 @@
     }
   }
 
-  const openSharePointFilesStatusModal = (siteId: string, siteName: string) => {
-    selectedStatusSiteId = siteId
-    selectedStatusSiteName = siteName
-    sharePointFilesStatusModal?.show()
-  }
-
   const handleKnowledgeRowClick = (row: KnowledgeTableRow) => {
     if (row.kind !== "sharepoint_connection") {
       return
     }
-    openSharePointFilesStatusModal(row.siteId, row.filename)
+    openSharePointSiteConfigModal(row.siteId).catch(error => {
+      console.error(error)
+      notifications.error("Failed to load SharePoint folders/files")
+    })
   }
-
-  let selectedStatusSiteFiles = $derived.by(() => {
-    if (!selectedStatusSiteId) {
-      return [] as KnowledgeBaseFile[]
-    }
-    return getSharePointFilesForSite(files, selectedStatusSiteId).sort((a, b) =>
-      a.filename.localeCompare(b.filename)
-    )
-  })
 
   let fileTableRows = $derived.by(() =>
     toFileTableRows(
-      files.filter(file => file.source?.type !== "sharepoint"),
+      files.filter(file => !file.source),
       removeFile,
       activePendingUploads
     )
@@ -224,15 +207,6 @@
     }
   }
 
-  const loadSharePointSites = async (agentId: string) => {
-    loadingSharePointSites = true
-    try {
-      const response = await API.fetchAgentKnowledgeSourceOptions(agentId)
-      sharePointSites = response.options
-    } finally {
-      loadingSharePointSites = false
-    }
-  }
   $effect(() => {
     const agentId = currentAgent?._id
     if (!agentId) {
@@ -314,60 +288,31 @@
     window.location.href = oauthUrl
   }
 
-  async function handleAddSharePointKnowledge() {
-    if (
-      hasSharePointConnection ||
-      !sharePointSites ||
-      sharePointSites.length > 0
-    ) {
-      await openSharePointSiteModal()
+  async function openSharePointFlow() {
+    if (!hasSharePointConnection) {
+      connectSharePoint()
       return
     }
-    connectSharePoint()
+    await openSharePointSiteModal()
   }
 
   async function openSharePointSiteModal() {
-    const agentId = currentAgent?._id
-    if (!agentId) {
-      return
-    }
-    await loadSharePointSites(agentId)
-    const selectedSiteIdSet = new Set(effectiveSelectedSiteIds)
-    const availableSites = sharePointSites?.filter(
-      site => !selectedSiteIdSet.has(site.id)
-    )
-    selectedSharePointSiteId = availableSites?.[0]?.id || ""
-    sharePointSiteModal?.show()
+    await selectSharePointSiteModal?.show()
   }
 
-  async function saveSharePointSites() {
+  async function onSharePointSiteCreated(siteId: string) {
     const agentId = currentAgent?._id
-    if (!agentId) {
-      return
-    }
-    if (!selectedSharePointSiteId) {
-      notifications.error("Please select a SharePoint site")
-      return
-    }
-    try {
-      await agentsStore.connectAgentSharePointSite(agentId, {
-        siteId: selectedSharePointSiteId,
-      })
-      startSharePointBootstrapPolling(agentId)
-      const nextSiteIds = Array.from(
-        new Set([...effectiveSelectedSiteIds, selectedSharePointSiteId])
-      )
-      pendingSiteIds = nextSiteIds.filter(id => !selectedSiteIds.includes(id))
-      sharePointSiteModal?.hide()
-      await loadSharePointSites(agentId)
+    if (agentId) {
+      knowledgePollingController.boost(agentId, 60)
       await fetchFiles(agentId)
-      pendingSiteIds = []
-      notifications.success("SharePoint site added")
-    } catch (error) {
-      pendingSiteIds = []
-      console.error(error)
-      notifications.error("Failed to sync SharePoint")
     }
+    selectedSharePointSiteId = siteId
+    selectSharePointSiteModal?.hide()
+  }
+
+  async function openSharePointSiteConfigModal(siteId: string) {
+    selectedSharePointSiteId = siteId
+    displaySharePointSiteModal?.show()
   }
 
   async function syncSharePointNow(sourceId: string) {
@@ -380,7 +325,6 @@
       const result = await agentsStore.syncAgentKnowledgeSources(agentId, {
         sourceId,
       })
-      await loadSharePointSites(agentId)
       await fetchFiles(agentId)
       showSharePointSyncResult(result)
     } catch (error) {
@@ -391,7 +335,7 @@
 
   async function removeSharePointSite(siteId: string) {
     const agent = currentAgent
-    if (!agent?._id || !hasSharePointConnection) {
+    if (!agent?._id || sharePointSources.length === 0) {
       return
     }
     const agentId = agent._id
@@ -405,21 +349,9 @@
       body: `Are you sure you want to remove ${siteName}? This action can't be undone.`,
       okText: "Delete",
       onConfirm: async () => {
-        pendingSiteIds = pendingSiteIds.filter(id => id !== siteId)
-        const nextSites = sharePointSources
-          .map(source => source.config.site)
-          .filter(
-            (site): site is { id: string; name?: string; webUrl?: string } =>
-              !!site?.id && site.id !== siteId
-          )
-        const nextSiteIds = nextSites.map(site => site.id)
         try {
           await agentsStore.disconnectAgentSharePointSite(agentId, siteId)
-          pendingSiteIds = []
           await fetchFiles(agentId)
-          if (nextSiteIds.length === 0) {
-            await loadSharePointSites(agentId)
-          }
           notifications.success("SharePoint site removed")
         } catch (error) {
           console.error(error)
@@ -483,7 +415,7 @@
         await fetchFiles(agentId)
       }}
       onSharePoint={() =>
-        handleAddSharePointKnowledge().catch(error => {
+        openSharePointFlow().catch(error => {
           console.error(error)
           notifications.error("Failed to fetch SharePoint sites")
         })}
@@ -498,18 +430,17 @@
 </Layout>
 
 <SelectSharePointSiteModal
-  bind:this={sharePointSiteModal}
-  {loadingSharePointSites}
-  {sharePointSites}
-  bind:selectedSiteId={selectedSharePointSiteId}
-  onSave={saveSharePointSites}
+  bind:this={selectSharePointSiteModal}
+  agentId={activeAgentId || ""}
+  existingSiteIds={selectedSiteIds}
+  onCreated={onSharePointSiteCreated}
 />
 
-<SharePointFilesStatusModal
-  bind:this={sharePointFilesStatusModal}
-  siteName={selectedStatusSiteName}
-  files={selectedStatusSiteFiles}
-/>
+<DisplaySharePointSiteModal
+  bind:this={displaySharePointSiteModal}
+  agentId={currentAgent?._id}
+  siteId={selectedSharePointSiteId}
+></DisplaySharePointSiteModal>
 
 <style>
   .section-header {

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/index.svelte
@@ -232,7 +232,13 @@
     const hasProcessingFiles = files.some(
       file => file.status === KnowledgeBaseFileStatus.PROCESSING
     )
-    knowledgePollingController.setContinuous(agentId, hasProcessingFiles)
+    const hasUnsyncedSharePointSites = sharePointSourceSnapshots.some(
+      source => !source.lastRunAt
+    )
+    knowledgePollingController.setContinuous(
+      agentId,
+      hasProcessingFiles || hasUnsyncedSharePointSites
+    )
   })
 
   $effect(() => {
@@ -303,7 +309,6 @@
   async function onSharePointSiteCreated(siteId: string) {
     const agentId = currentAgent?._id
     if (agentId) {
-      knowledgePollingController.boost(agentId, 60)
       await fetchFiles(agentId)
     }
     selectedSharePointSiteId = siteId

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/knowledgeTableRows.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/knowledgeTableRows.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 import {
   AgentKnowledgeSourceSyncRunStatus,
+  KnowledgeBaseFileSourceType,
   KnowledgeBaseFileStatus,
   type KnowledgeBaseFile,
 } from "@budibase/types"
@@ -52,7 +53,7 @@ describe("knowledgeTableRows", () => {
         _id: "f1",
         status: KnowledgeBaseFileStatus.READY,
         source: {
-          type: "sharepoint",
+          type: KnowledgeBaseFileSourceType.SHAREPOINT,
           knowledgeSourceId: "source-1",
           siteId: "site-1",
           driveId: "drive-1",
@@ -64,7 +65,7 @@ describe("knowledgeTableRows", () => {
         _id: "f2",
         status: KnowledgeBaseFileStatus.PROCESSING,
         source: {
-          type: "sharepoint",
+          type: KnowledgeBaseFileSourceType.SHAREPOINT,
           knowledgeSourceId: "source-1",
           siteId: "site-1",
           driveId: "drive-1",
@@ -76,7 +77,7 @@ describe("knowledgeTableRows", () => {
         _id: "f3",
         status: KnowledgeBaseFileStatus.FAILED,
         source: {
-          type: "sharepoint",
+          type: KnowledgeBaseFileSourceType.SHAREPOINT,
           knowledgeSourceId: "source-2",
           siteId: "site-2",
           driveId: "drive-1",

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/knowledgeTableRows.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/knowledgeTableRows.spec.ts
@@ -57,6 +57,7 @@ describe("knowledgeTableRows", () => {
           siteId: "site-1",
           driveId: "drive-1",
           itemId: "item-1",
+          path: "folder-1/file-1.txt",
         },
       }),
       makeFile({
@@ -68,6 +69,7 @@ describe("knowledgeTableRows", () => {
           siteId: "site-1",
           driveId: "drive-1",
           itemId: "item-2",
+          path: "folder-1/file-2.txt",
         },
       }),
       makeFile({
@@ -79,6 +81,7 @@ describe("knowledgeTableRows", () => {
           siteId: "site-2",
           driveId: "drive-1",
           itemId: "item-3",
+          path: "folder-2/file-3.txt",
         },
       }),
     ]

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/knowledgeTableRows.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/knowledgeTableRows.ts
@@ -1,5 +1,6 @@
 import { helpers } from "@budibase/shared-core"
 import {
+  KnowledgeBaseFileSourceType,
   KnowledgeBaseFileStatus,
   type KnowledgeBaseFile,
   type SharePointKnowledgeSourceSnapshot,
@@ -87,7 +88,9 @@ export const getSharePointFilesForSite = (
   siteId: string
 ) =>
   files.filter(
-    file => file.source?.type === "sharepoint" && file.source.siteId === siteId
+    file =>
+      file.source?.type === KnowledgeBaseFileSourceType.SHAREPOINT &&
+      file.source.siteId === siteId
   )
 
 export const getSharePointFileProcessingCounts = (

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/new/AddKnowledgeModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/new/AddKnowledgeModal.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import "@spectrum-css/dialog/dist/index-vars.css"
+  import { ActionButton, Body, Modal, ModalContent } from "@budibase/bbui"
+  import MicrosoftSharepointLogo from "assets/rest-template-icons/microsoft-sharepoint.svg"
+  import { featureFlags } from "@/stores/portal"
+  import { FeatureFlag } from "@budibase/types"
+
+  export interface Props {
+    MAX_FILE_SIZE_LABEL: string
+    isUploading?: boolean
+    onUpload?: () => void
+    onSharePoint?: () => Promise<void>
+  }
+
+  let {
+    onUpload,
+    onSharePoint,
+    MAX_FILE_SIZE_LABEL,
+    isUploading = false,
+  }: Props = $props()
+
+  let modal = $state<Modal>()
+  let loading = $state(false)
+
+  export function show() {
+    modal?.show()
+  }
+
+  function hide() {
+    modal?.hide()
+  }
+
+  const handleUpload = () => {
+    if (isUploading) {
+      return
+    }
+    onUpload?.()
+    hide()
+  }
+
+  const handleSharePoint = async () => {
+    if (loading) {
+      return
+    }
+    loading = true
+    try {
+      await onSharePoint?.()
+      hide()
+    } finally {
+      loading = false
+    }
+  }
+</script>
+
+<Modal bind:this={modal}>
+  <ModalContent
+    showConfirmButton={false}
+    showCancelButton={false}
+    showCloseIcon={false}
+    showDivider={false}
+    custom
+  >
+    <div class="content">
+      <div class="title">
+        <Body size="S">Add knowledge to agent</Body>
+      </div>
+
+      <ActionButton
+        quiet
+        icon="paperclip"
+        fullWidth
+        disabled={loading || isUploading}
+        on:click={handleUpload}
+      >
+        {isUploading ? "Uploading..." : "Add files"}
+        <span class="file-limit-note">(max {MAX_FILE_SIZE_LABEL} per file)</span
+        >
+      </ActionButton>
+      {#if $featureFlags[FeatureFlag.AI_RAG_SHAREPOINT]}
+        <ActionButton
+          quiet
+          icon={MicrosoftSharepointLogo}
+          fullWidth
+          disabled={loading}
+          on:click={handleSharePoint}
+        >
+          {loading ? "Loading SharePoint..." : "Add from SharePoint"}
+        </ActionButton>
+      {/if}
+    </div>
+  </ModalContent>
+</Modal>
+
+<style>
+  .content {
+    width: 300px;
+    padding: var(--spacing-s);
+  }
+  .title {
+    padding: var(--spacing-s);
+  }
+
+  .file-limit-note {
+    color: var(--spectrum-global-color-gray-600);
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/new/SelectSharePointSiteModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/new/SelectSharePointSiteModal.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  import { agentsStore } from "@/stores/portal"
+  import { notifications } from "@budibase/bbui"
+  import {
+    Body,
+    Button,
+    ButtonGroup,
+    Modal,
+    ModalContent,
+    Select,
+  } from "@budibase/bbui"
+
+  import { type KnowledgeSourceOption } from "@budibase/types"
+
+  export interface Props {
+    agentId: string
+    existingSiteIds?: string[]
+    onCreated?: (_siteId: string) => Promise<void> | void
+  }
+
+  let { agentId, existingSiteIds = [], onCreated }: Props = $props()
+
+  let sharePointSites = $state<KnowledgeSourceOption[]>([])
+  let availableSites = $derived.by(() => {
+    const excluded = new Set(existingSiteIds)
+    return sharePointSites.filter(site => !excluded.has(site.id))
+  })
+
+  let selectedSiteId = $state("")
+  let modal = $state<Modal>()
+  let loadingSites = $state(false)
+
+  const displaySharePointSites = $derived(
+    [...availableSites]
+      .map(site => ({
+        ...site,
+        name: site.name || site.webUrl || site.id,
+      }))
+      .sort((a, b) => {
+        const aKey = a.name.trim().toLocaleLowerCase()
+        const bKey = b.name.trim().toLocaleLowerCase()
+        return aKey.localeCompare(bKey)
+      })
+  )
+
+  let saving = $state<boolean>()
+
+  const loadSharePointSites = async () => {
+    if (!agentId) {
+      sharePointSites = []
+      selectedSiteId = ""
+      return
+    }
+    loadingSites = true
+    sharePointSites = []
+    selectedSiteId = ""
+    try {
+      const response =
+        await agentsStore.fetchAgentKnowledgeSourceOptions(agentId)
+      sharePointSites = response.options
+      selectedSiteId = displaySharePointSites[0]?.id || ""
+    } catch (error) {
+      console.error(error)
+      notifications.error("Failed to fetch SharePoint sites")
+      sharePointSites = []
+      selectedSiteId = ""
+    } finally {
+      loadingSites = false
+    }
+  }
+
+  export async function show() {
+    await loadSharePointSites()
+    modal?.show()
+  }
+
+  export function hide() {
+    modal?.hide()
+  }
+
+  const handleSelect = async () => {
+    if (!agentId || !selectedSiteId) {
+      return
+    }
+
+    saving = true
+    try {
+      await agentsStore.connectAgentSharePointSite(agentId, {
+        siteId: selectedSiteId,
+      })
+      notifications.success("SharePoint site added")
+      hide()
+
+      await onCreated?.(selectedSiteId)
+    } catch (error) {
+      console.error(error)
+      notifications.error("Failed to add SharePoint site")
+    } finally {
+      saving = false
+    }
+  }
+</script>
+
+<Modal bind:this={modal}>
+  <ModalContent
+    custom
+    showDivider={false}
+    showConfirmButton={false}
+    showCancelButton={false}
+    disabled={!selectedSiteId}
+  >
+    <div class="content">
+      <div class="title">
+        <Body size="S">Add from SharePoint</Body>
+      </div>
+
+      {#if loadingSites}
+        <Body size="S">Loading SharePoint sites...</Body>
+      {:else if availableSites.length === 0}
+        <Body size="S">No SharePoint sites found for this connection.</Body>
+      {:else}
+        <Select
+          bind:value={selectedSiteId}
+          label="Select site"
+          options={displaySharePointSites}
+          getOptionLabel={o => o.name || o.webUrl || o.id}
+          getOptionSubtitle={o => o.webUrl}
+          getOptionValue={o => o.id}
+        />
+      {/if}
+    </div>
+
+    <ButtonGroup slot="footer">
+      <Button
+        cta
+        on:click={() => handleSelect()}
+        disabled={!selectedSiteId || saving}
+      >
+        Sync
+      </Button>
+    </ButtonGroup>
+  </ModalContent>
+</Modal>
+
+<style>
+  .content {
+    padding: var(--spacing-l);
+    width: min(460px, 95vw);
+  }
+
+  .title {
+    padding-bottom: var(--spacing-s);
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/polling.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/polling.ts
@@ -12,12 +12,10 @@ interface CreateAgentPollingControllerConfig {
 
 interface UnifiedPollingState extends PollingState {
   continuous: boolean
-  burstRemaining: number
 }
 
 interface KnowledgePollingController {
   setContinuous: (agentId: string, enabled: boolean) => void
-  boost: (agentId: string, pollCount: number) => void
   stop: () => void
   isRunning: () => boolean
 }
@@ -60,7 +58,7 @@ export const createKnowledgePollingController = ({
   }
 
   const shouldStop = () => {
-    return !state?.continuous && (state?.burstRemaining || 0) <= 0
+    return !state?.continuous
   }
 
   const tick = async (agentId: string) => {
@@ -77,9 +75,6 @@ export const createKnowledgePollingController = ({
       await onPoll(agentId)
     } finally {
       if (state?.agentId === agentId) {
-        if (state.burstRemaining > 0) {
-          state.burstRemaining -= 1
-        }
         state.inFlight = false
         if (shouldStop()) {
           stop()
@@ -103,7 +98,6 @@ export const createKnowledgePollingController = ({
       interval,
       inFlight: false,
       continuous: false,
-      burstRemaining: 0,
     }
   }
 
@@ -121,24 +115,12 @@ export const createKnowledgePollingController = ({
     }
   }
 
-  const boost = (agentId: string, pollCount: number) => {
-    if (!agentId || pollCount <= 0) {
-      return
-    }
-    ensureState(agentId)
-    if (!state || state.agentId !== agentId) {
-      return
-    }
-    state.burstRemaining = Math.max(state.burstRemaining, pollCount)
-  }
-
   const isRunning = () => {
     return !!state
   }
 
   return {
     setContinuous,
-    boost,
     stop,
     isRunning,
   }

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/DisplaySharePointSiteModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/DisplaySharePointSiteModal.svelte
@@ -50,6 +50,8 @@
     buildEntryTree(
       sharePointFiles.map(file => ({
         filename: file.filename,
+        sourcePath:
+          file.source?.type === "sharepoint" ? file.source.path : undefined,
         status: file.status,
         errorMessage: file.errorMessage,
       }))

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/DisplaySharePointSiteModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/DisplaySharePointSiteModal.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  import { Body, Modal, ModalContent, TreeView } from "@budibase/bbui"
+  import {
+    AgentKnowledgeSourceType,
+    type KnowledgeBaseFile,
+  } from "@budibase/types"
+  import { agentsStore, selectedAgent } from "@/stores/portal"
+  import SharePointEntryTreeItem from "./tree/SharePointEntryTreeItem.svelte"
+  import { buildEntryTree } from "./sharePointModalUtils"
+
+  export interface Props {
+    agentId?: string
+    siteId?: string
+  }
+
+  let { agentId, siteId }: Props = $props()
+  let modal = $state<Modal>()
+
+  const sharePointSource = $derived.by(() => {
+    if (!siteId) {
+      return undefined
+    }
+    return $selectedAgent?.knowledgeSources?.find(
+      source =>
+        source.type === AgentKnowledgeSourceType.SHAREPOINT &&
+        source.config.site?.id === siteId
+    )
+  })
+
+  const selectedSiteLabel = $derived(
+    sharePointSource?.config.site?.name ||
+      sharePointSource?.config.site?.webUrl ||
+      siteId ||
+      ""
+  )
+
+  const sharePointFiles = $derived.by(() => {
+    if (!agentId || !sharePointSource?.id) {
+      return [] as KnowledgeBaseFile[]
+    }
+    const files = $agentsStore.knowledgeByAgent?.[agentId]?.files || []
+    return files.filter(
+      file =>
+        file.source?.type === "sharepoint" &&
+        file.source.knowledgeSourceId === sharePointSource.id
+    )
+  })
+
+  const entryTree = $derived(
+    buildEntryTree(
+      sharePointFiles.map(file => ({
+        filename: file.filename,
+        status: file.status,
+        errorMessage: file.errorMessage,
+      }))
+    )
+  )
+
+  export function show() {
+    modal?.show()
+  }
+
+  export function hide() {
+    modal?.hide()
+  }
+</script>
+
+<Modal bind:this={modal}>
+  <ModalContent
+    title={`SharePoint - ${selectedSiteLabel}`}
+    showDivider={false}
+    size="XL"
+    showCloseIcon={false}
+    showConfirmButton={false}
+    showCancelButton={false}
+  >
+    {#if entryTree.length === 0}
+      <Body size="S">This SharePoint site does not contain any file.</Body>
+    {:else}
+      <Body size="S">The following files are synced for this site:</Body>
+      <div class="entries-list">
+        <TreeView standalone={false} quiet width="auto">
+          {#each entryTree as node (node.path)}
+            <SharePointEntryTreeItem {node} />
+          {/each}
+        </TreeView>
+      </div>
+    {/if}
+  </ModalContent>
+</Modal>
+
+<style>
+  .entries-list {
+    margin-top: var(--spacing-xxs);
+    max-height: 420px;
+    overflow: auto;
+    border: 1px solid var(--spectrum-global-color-gray-300);
+    border-radius: 8px;
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/DisplaySharePointSiteModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/DisplaySharePointSiteModal.svelte
@@ -51,10 +51,7 @@
     buildEntryTree(
       sharePointFiles.map(file => ({
         filename: file.filename,
-        sourcePath:
-          file.source?.type === KnowledgeBaseFileSourceType.SHAREPOINT
-            ? file.source.path
-            : undefined,
+        sourcePath: file.source?.path,
         status: file.status,
         errorMessage: file.errorMessage,
       }))

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/DisplaySharePointSiteModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/DisplaySharePointSiteModal.svelte
@@ -2,6 +2,7 @@
   import { Body, Modal, ModalContent, TreeView } from "@budibase/bbui"
   import {
     AgentKnowledgeSourceType,
+    KnowledgeBaseFileSourceType,
     type KnowledgeBaseFile,
   } from "@budibase/types"
   import { agentsStore, selectedAgent } from "@/stores/portal"
@@ -41,7 +42,7 @@
     const files = $agentsStore.knowledgeByAgent?.[agentId]?.files || []
     return files.filter(
       file =>
-        file.source?.type === "sharepoint" &&
+        file.source?.type === KnowledgeBaseFileSourceType.SHAREPOINT &&
         file.source.knowledgeSourceId === sharePointSource.id
     )
   })
@@ -51,7 +52,9 @@
       sharePointFiles.map(file => ({
         filename: file.filename,
         sourcePath:
-          file.source?.type === "sharepoint" ? file.source.path : undefined,
+          file.source?.type === KnowledgeBaseFileSourceType.SHAREPOINT
+            ? file.source.path
+            : undefined,
         status: file.status,
         errorMessage: file.errorMessage,
       }))

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/sharePointModalUtils.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/sharePointModalUtils.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest"
+import { KnowledgeBaseFileStatus } from "@budibase/types"
+import { buildEntryTree } from "./sharePointModalUtils"
+
+describe("sharePointModalUtils.buildEntryTree", () => {
+  it("builds a nested tree from source paths", () => {
+    const tree = buildEntryTree([
+      {
+        filename: "ignored.txt",
+        sourcePath: "docs/guides/intro.md",
+        status: KnowledgeBaseFileStatus.READY,
+      },
+      {
+        filename: "ignored-2.txt",
+        sourcePath: "docs/api/reference.md",
+        status: KnowledgeBaseFileStatus.PROCESSING,
+      },
+    ])
+
+    expect(tree).toHaveLength(1)
+    expect(tree[0].type).toBe("folder")
+    expect(tree[0].path).toBe("docs")
+
+    const docsChildren = tree[0].children
+    expect(docsChildren.map(node => node.path)).toEqual([
+      "docs/api",
+      "docs/guides",
+    ])
+    expect(docsChildren[0].children[0]).toMatchObject({
+      path: "docs/api/reference.md",
+      type: "file",
+      status: KnowledgeBaseFileStatus.PROCESSING,
+    })
+    expect(docsChildren[1].children[0]).toMatchObject({
+      path: "docs/guides/intro.md",
+      type: "file",
+      status: KnowledgeBaseFileStatus.READY,
+    })
+  })
+
+  it("updates leaf metadata when the same path appears again", () => {
+    const tree = buildEntryTree([
+      {
+        filename: "same-file.md",
+        sourcePath: "root/same-file.md",
+        status: KnowledgeBaseFileStatus.PROCESSING,
+      },
+      {
+        filename: "same-file.md",
+        sourcePath: "root/same-file.md",
+        status: KnowledgeBaseFileStatus.FAILED,
+        errorMessage: "parse failed",
+      },
+    ])
+
+    const fileNode = tree[0].children[0]
+    expect(fileNode).toMatchObject({
+      path: "root/same-file.md",
+      type: "file",
+      status: KnowledgeBaseFileStatus.FAILED,
+      errorMessage: "parse failed",
+    })
+  })
+
+  it("uses filename when sourcePath is not provided and ignores empty paths", () => {
+    const tree = buildEntryTree([
+      {
+        filename: "loose.txt",
+        status: KnowledgeBaseFileStatus.READY,
+      },
+      {
+        filename: "",
+        sourcePath: "",
+      },
+    ])
+
+    expect(tree).toHaveLength(1)
+    expect(tree[0]).toMatchObject({
+      path: "loose.txt",
+      type: "file",
+      status: KnowledgeBaseFileStatus.READY,
+    })
+  })
+
+  it("sorts folders before files and names alphabetically", () => {
+    const tree = buildEntryTree([
+      { filename: "z.txt" },
+      { filename: "alpha/b.txt" },
+      { filename: "alpha/a.txt" },
+      { filename: "a.txt" },
+    ])
+
+    expect(tree.map(node => node.path)).toEqual(["alpha", "a.txt", "z.txt"])
+    expect(tree[0].children.map(node => node.path)).toEqual([
+      "alpha/a.txt",
+      "alpha/b.txt",
+    ])
+  })
+})

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/sharePointModalUtils.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/sharePointModalUtils.ts
@@ -8,16 +8,6 @@ export interface TreeEntryInput {
   errorMessage?: string
 }
 
-const normalizePath = (value: string) =>
-  value
-    .replace(/^\/+/, "")
-    .replace(/\\/g, "/")
-    .replace(/\/{2,}/g, "/")
-    .trim()
-
-const getPath = (file: TreeEntryInput) =>
-  normalizePath(file.sourcePath || file.filename)
-
 export const buildEntryTree = (
   files: TreeEntryInput[]
 ): SharePointEntryTreeNode[] => {
@@ -25,7 +15,7 @@ export const buildEntryTree = (
   const byPath = new Map<string, SharePointEntryTreeNode>()
 
   for (const file of files) {
-    const path = getPath(file)
+    const path = file.sourcePath || file.filename
     if (!path) {
       continue
     }

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/sharePointModalUtils.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/sharePointModalUtils.ts
@@ -1,0 +1,79 @@
+import { type KnowledgeBaseFileStatus } from "@budibase/types"
+import type { SharePointEntryTreeNode } from "./tree/sharePointEntryTree"
+
+export interface TreeEntryInput {
+  filename: string
+  sourcePath?: string
+  status?: KnowledgeBaseFileStatus
+  errorMessage?: string
+}
+
+const normalizePath = (value: string) =>
+  value
+    .replace(/^\/+/, "")
+    .replace(/\\/g, "/")
+    .replace(/\/{2,}/g, "/")
+    .trim()
+
+const getPath = (file: TreeEntryInput) =>
+  normalizePath(file.sourcePath || file.filename)
+
+export const buildEntryTree = (
+  files: TreeEntryInput[]
+): SharePointEntryTreeNode[] => {
+  const roots: SharePointEntryTreeNode[] = []
+  const byPath = new Map<string, SharePointEntryTreeNode>()
+
+  for (const file of files) {
+    const path = getPath(file)
+    if (!path) {
+      continue
+    }
+
+    const parts = path.split("/").filter(Boolean)
+    let parent = roots
+    let currentPath = ""
+
+    for (let i = 0; i < parts.length; i++) {
+      const segment = parts[i]
+      currentPath = currentPath ? `${currentPath}/${segment}` : segment
+      const isLeaf = i === parts.length - 1
+
+      let node = byPath.get(currentPath)
+      if (!node) {
+        node = {
+          id: currentPath,
+          name: segment,
+          path: currentPath,
+          type: isLeaf ? "file" : "folder",
+          status: isLeaf ? file.status : undefined,
+          errorMessage: isLeaf ? file.errorMessage : undefined,
+          children: [],
+        }
+        byPath.set(currentPath, node)
+        parent.push(node)
+      } else if (isLeaf) {
+        node.type = "file"
+        node.status = file.status
+        node.errorMessage = file.errorMessage
+      }
+
+      parent = node.children
+    }
+  }
+
+  const sortNodes = (nodes: SharePointEntryTreeNode[]) => {
+    nodes.sort((a, b) => {
+      if (a.type !== b.type) {
+        return a.type === "folder" ? -1 : 1
+      }
+      return a.name.localeCompare(b.name)
+    })
+    for (const node of nodes) {
+      sortNodes(node.children)
+    }
+  }
+
+  sortNodes(roots)
+  return roots
+}

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/tree/SharePointEntryTreeItem.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/tree/SharePointEntryTreeItem.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  import { KnowledgeBaseFileStatus } from "@budibase/types"
+  import { StatusLight, TreeItem } from "@budibase/bbui"
+  import SharePointEntryTreeItem from "./SharePointEntryTreeItem.svelte"
+  import type { SharePointEntryTreeNode } from "./sharePointEntryTree"
+
+  export interface Props {
+    node: SharePointEntryTreeNode
+    selectedPaths?: string[]
+    onTogglePaths?: (_paths: string[], _nextSelected: boolean) => void
+    showStatus?: boolean
+  }
+
+  let {
+    node,
+    selectedPaths,
+    onTogglePaths,
+    showStatus = true,
+  }: Props = $props()
+
+  const getSharePointStatusText = (
+    status?: SharePointEntryTreeNode["status"]
+  ) => {
+    switch (status) {
+      case KnowledgeBaseFileStatus.PROCESSING:
+        return "Processing"
+      case KnowledgeBaseFileStatus.READY:
+        return "Ready"
+      case KnowledgeBaseFileStatus.FAILED:
+        return "Failed"
+      default:
+        return undefined
+    }
+  }
+
+  const getSharePointStatusLightProps = (
+    status?: SharePointEntryTreeNode["status"]
+  ) => {
+    switch (status) {
+      case KnowledgeBaseFileStatus.READY:
+        return { positive: true }
+      case KnowledgeBaseFileStatus.FAILED:
+        return { negative: true }
+      default:
+        return { notice: true }
+    }
+  }
+
+  let hasChildren = $derived(node.children.length > 0)
+</script>
+
+<div class="sharepoint-entry-tree-item">
+  <TreeItem title={node.name} open={hasChildren} {hasChildren}>
+    <svelte:fragment slot="post">
+      {#if showStatus && node.type === "file" && getSharePointStatusText(node.status)}
+        <div class="status-container">
+          <StatusLight size="S" {...getSharePointStatusLightProps(node.status)}>
+            {getSharePointStatusText(node.status)}
+          </StatusLight>
+          {#if node.status === "failed" && node.errorMessage}
+            <span class="error-message" title={node.errorMessage}>
+              {node.errorMessage}
+            </span>
+          {/if}
+        </div>
+      {/if}
+    </svelte:fragment>
+
+    {#if hasChildren}
+      {#each node.children as child (child.path)}
+        <SharePointEntryTreeItem
+          node={child}
+          {selectedPaths}
+          {onTogglePaths}
+          {showStatus}
+        />
+      {/each}
+    {/if}
+  </TreeItem>
+</div>
+
+<style>
+  .status-container {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .error-message {
+    font-size: 11px;
+    line-height: 1.2;
+    color: var(--spectrum-semantic-negative-color-default);
+    max-width: 280px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .sharepoint-entry-tree-item :global(.spectrum-TreeView-itemLink) {
+    padding-inline-end: 8px;
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/tree/sharePointEntryTree.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/sharepoint/tree/sharePointEntryTree.ts
@@ -1,0 +1,11 @@
+import { KnowledgeBaseFileStatus } from "@budibase/types"
+
+export interface SharePointEntryTreeNode {
+  id: string
+  name: string
+  path: string
+  type: "folder" | "file"
+  children: SharePointEntryTreeNode[]
+  status?: KnowledgeBaseFileStatus
+  errorMessage?: string
+}

--- a/packages/builder/src/stores/portal/agents.spec.ts
+++ b/packages/builder/src/stores/portal/agents.spec.ts
@@ -78,6 +78,7 @@ describe("agentsStore sharepoint and file syncing", () => {
           siteId: "site-1",
           driveId: "drive-1",
           itemId: "item-1",
+          path: "folder-1/notes.md",
         },
         ragSourceId: "rag_source_1",
         filename: "notes.md",

--- a/packages/builder/src/stores/portal/agents.spec.ts
+++ b/packages/builder/src/stores/portal/agents.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { get } from "svelte/store"
 import {
+  KnowledgeBaseFileSourceType,
   KnowledgeBaseFileStatus,
   type Agent,
   type AgentFileUploadResponse,
@@ -73,7 +74,7 @@ describe("agentsStore sharepoint and file syncing", () => {
         _id: "kb_file_1",
         knowledgeBaseId: "kb_1",
         source: {
-          type: "sharepoint",
+          type: KnowledgeBaseFileSourceType.SHAREPOINT,
           knowledgeSourceId: "source-1",
           siteId: "site-1",
           driveId: "drive-1",

--- a/packages/builder/src/stores/portal/agents.ts
+++ b/packages/builder/src/stores/portal/agents.ts
@@ -8,6 +8,7 @@ import {
   CreateAgentRequest,
   DisconnectAgentSharePointSiteResponse,
   FetchAgentKnowledgeResponse,
+  FetchAgentKnowledgeSourceOptionsResponse,
   SharePointKnowledgeSourceSnapshot,
   ProvisionAgentSlackChannelRequest,
   ProvisionAgentSlackChannelResponse,
@@ -188,6 +189,12 @@ export class AgentsStore extends BudiStore<AgentStoreState> {
 
   deleteAgentFile = async (agentId: string, fileId: string) =>
     await API.deleteAgentFile(agentId, fileId)
+
+  fetchAgentKnowledgeSourceOptions = async (
+    agentId: string
+  ): Promise<FetchAgentKnowledgeSourceOptionsResponse> => {
+    return await API.fetchAgentKnowledgeSourceOptions(agentId)
+  }
 
   connectAgentSharePointSite = async (
     agentId: string,

--- a/packages/server/src/api/controllers/ai/sharepoint.ts
+++ b/packages/server/src/api/controllers/ai/sharepoint.ts
@@ -3,6 +3,7 @@ import {
   AgentKnowledgeSource,
   AgentKnowledgeSourceType,
   KnowledgeBaseFile,
+  KnowledgeBaseFileSourceType,
 } from "@budibase/types"
 import sdk from "../../../sdk"
 
@@ -20,14 +21,16 @@ export const getSharePointSiteIds = (agent?: Agent): Set<string> => {
 
 const isSharePointFile = (
   file: Pick<KnowledgeBaseFile, "source" | "uploadedBy">
-) => file.source?.type === "sharepoint"
+) => file.source?.type === KnowledgeBaseFileSourceType.SHAREPOINT
 
 const isSharePointFileForRemovedSite = (
   file: Pick<KnowledgeBaseFile, "source" | "uploadedBy">,
   removedSharePointSiteIds: string[]
 ) => {
   const sourceSiteId =
-    file.source?.type === "sharepoint" ? file.source.siteId : undefined
+    file.source?.type === KnowledgeBaseFileSourceType.SHAREPOINT
+      ? file.source.siteId
+      : undefined
   return removedSharePointSiteIds.some(siteId => {
     return sourceSiteId === siteId
   })

--- a/packages/server/src/sdk/workspace/ai/rag/sharepoint.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/sharepoint.spec.ts
@@ -124,6 +124,7 @@ describe("rag/sharepoint sync deduplication", () => {
           siteId,
           driveId: "drive-a",
           itemId: "item-1",
+          path: "existing.txt",
         },
         filename: "existing.txt",
         objectStoreKey: "key-existing",
@@ -188,6 +189,7 @@ describe("rag/sharepoint sync deduplication", () => {
           siteId,
           driveId: "drive-b",
           itemId: "item-1",
+          path: "new.txt",
         },
         filename: "new.txt",
       })

--- a/packages/server/src/sdk/workspace/ai/rag/sharepoint.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/sharepoint.spec.ts
@@ -55,6 +55,7 @@ jest.mock("./files", () => {
 
 import {
   AgentKnowledgeSourceType,
+  KnowledgeBaseFileSourceType,
   KnowledgeBaseFileStatus,
   KnowledgeBaseType,
   type Agent,
@@ -119,7 +120,7 @@ describe("rag/sharepoint sync deduplication", () => {
         _id: "existing_1",
         knowledgeBaseId: "kb_1",
         source: {
-          type: "sharepoint",
+          type: KnowledgeBaseFileSourceType.SHAREPOINT,
           knowledgeSourceId: sourceId,
           siteId,
           driveId: "drive-a",
@@ -184,7 +185,7 @@ describe("rag/sharepoint sync deduplication", () => {
       expect.objectContaining({
         knowledgeBaseId: "kb_1",
         source: {
-          type: "sharepoint",
+          type: KnowledgeBaseFileSourceType.SHAREPOINT,
           knowledgeSourceId: sourceId,
           siteId,
           driveId: "drive-b",

--- a/packages/server/src/sdk/workspace/ai/rag/sharepoint.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/sharepoint.ts
@@ -11,6 +11,7 @@ import {
   isKnowledgeFileSupported,
   type KnowledgeSourceEntry,
   type SyncAgentKnowledgeSourcesResponse,
+  KnowledgeBaseFileSourceType,
 } from "@budibase/types"
 import { agents as agentsSdk, knowledgeBase as knowledgeBaseSdk } from ".."
 import {
@@ -452,7 +453,10 @@ export const syncSharePointSourcesForAgent = async (
   >()
   for (const file of existingFiles) {
     const fileId = file._id
-    if (!fileId || file.source?.type !== "sharepoint") {
+    if (
+      !fileId ||
+      file.source?.type !== KnowledgeBaseFileSourceType.SHAREPOINT
+    ) {
       continue
     }
     const externalId = getSharePointFileDedupKey({
@@ -515,7 +519,7 @@ export const syncSharePointSourcesForAgent = async (
           await knowledgeBaseSdk.uploadKnowledgeBaseFile({
             knowledgeBaseId,
             source: {
-              type: "sharepoint",
+              type: KnowledgeBaseFileSourceType.SHAREPOINT,
               knowledgeSourceId: sourceId,
               siteId,
               driveId,
@@ -589,7 +593,8 @@ export const deleteSharePointFilesForAgentSite = async (
   const fileIdsToDelete = files
     .filter(
       file =>
-        file.source?.type === "sharepoint" && file.source.siteId === siteId
+        file.source?.type === KnowledgeBaseFileSourceType.SHAREPOINT &&
+        file.source.siteId === siteId
     )
     .map(file => file._id)
     .filter((fileId): fileId is string => !!fileId)

--- a/packages/server/src/sdk/workspace/ai/rag/sharepoint.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/sharepoint.ts
@@ -520,6 +520,7 @@ export const syncSharePointSourcesForAgent = async (
               siteId,
               driveId,
               itemId: file.itemId,
+              path: file.path,
             },
             filename: file.filename,
             mimetype: file.mimetype,

--- a/packages/types/src/documents/global/knowledgeBase.ts
+++ b/packages/types/src/documents/global/knowledgeBase.ts
@@ -26,6 +26,7 @@ export interface SharePointKnowledgeBaseFileSource {
   siteId: string
   driveId: string
   itemId: string
+  path: string
 }
 
 export type KnowledgeBaseFileSource = SharePointKnowledgeBaseFileSource

--- a/packages/types/src/documents/global/knowledgeBase.ts
+++ b/packages/types/src/documents/global/knowledgeBase.ts
@@ -20,8 +20,12 @@ export enum KnowledgeBaseFileStatus {
   FAILED = "failed",
 }
 
+export enum KnowledgeBaseFileSourceType {
+  SHAREPOINT = "sharepoint",
+}
+
 export interface SharePointKnowledgeBaseFileSource {
-  type: "sharepoint"
+  type: KnowledgeBaseFileSourceType.SHAREPOINT
   knowledgeSourceId: string
   siteId: string
   driveId: string


### PR DESCRIPTION
## Description
Display SharePoint files as tree
<img width="1088" height="595" alt="image" src="https://github.com/user-attachments/assets/244b71ec-9834-425c-a373-59b081a9178f" />

<img width="1044" height="503" alt="image" src="https://github.com/user-attachments/assets/b15bd2f6-42ef-4b9d-9d15-63832d803164" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show SharePoint files in a collapsible tree inside a new modal and streamline adding sites with a dedicated picker. Upgrades the `bbui` `TreeView`, persists SharePoint file paths, switches to enums for file source types, and simplifies polling.

- New Features
  - Modal to view a SharePoint site’s synced files as a folder tree with per-file status and errors.
  - Site picker modal to add SharePoint sites (filters existing, triggers sync); integrated into the Add Knowledge flow.
  - `TreeView` updates: toggle indicator with keyboard support, "post" slot for status, quiet mode via context, disabled state, and unified open state handling.

- Refactors
  - Simplified knowledge polling: removed burst/boost; now polls continuously only when files are processing or a SharePoint site hasn’t run yet.
  - Clicking a SharePoint connection opens the new modal; removed the old status modal and pending logic. SharePoint files are no longer shown in the main file table.
  - Persisted `path` on SharePoint file sources; replaced string literals with `KnowledgeBaseFileSourceType.SHAREPOINT`; exposed `agentsStore.fetchAgentKnowledgeSourceOptions`.
  - Added unit tests for SharePoint tree building and cleaned up SharePoint enums/filters in specs.

<sup>Written for commit ddb4ba159b2a01138a96b3a7cce1603f40f328e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

