### PR TITLE
Feat/pdb improvements on helm

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -39,6 +39,10 @@ spec:
 {{ end }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.services.apps.terminationGracePeriodSeconds }}
+      {{- if .Values.services.apps.readinessGates }}
+      readinessGates:
+        {{- toYaml .Values.services.apps.readinessGates | nindent 8 }}
+      {{- end }}
       containers:
       - env:
         - name: BUDIBASE_ENVIRONMENT

--- a/charts/budibase/templates/automation-worker-service-deployment.yaml
+++ b/charts/budibase/templates/automation-worker-service-deployment.yaml
@@ -33,6 +33,10 @@ spec:
 {{ end }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.services.automationWorkers.terminationGracePeriodSeconds }}
+      {{- if .Values.services.automationWorkers.readinessGates }}
+      readinessGates:
+        {{- toYaml .Values.services.automationWorkers.readinessGates | nindent 8 }}
+      {{- end }}
       containers:
       - env:
         - name: BUDIBASE_ENVIRONMENT
@@ -276,6 +280,10 @@ spec:
         args:
         {{- toYaml .Values.services.automationWorkers.args | nindent 10 }}
         {{ end }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep", "{{ .Values.services.automationWorkers.preStopDelaySeconds }}"]
         {{ if .Values.services.automationWorkers.extraVolumeMounts }}
         volumeMounts:
         {{- toYaml .Values.services.automationWorkers.extraVolumeMounts | nindent 10 }}

--- a/charts/budibase/templates/litellm-service-deployment.yaml
+++ b/charts/budibase/templates/litellm-service-deployment.yaml
@@ -18,6 +18,11 @@ spec:
       labels:
         io.kompose.service: litellm-service
     spec:
+      terminationGracePeriodSeconds: {{ .Values.services.litellm.terminationGracePeriodSeconds }}
+      {{- if .Values.services.litellm.readinessGates }}
+      readinessGates:
+        {{- toYaml .Values.services.litellm.readinessGates | nindent 8 }}
+      {{- end }}
       containers:
         - name: litellm
           image: {{ .Values.globals.dockerRegistry }}{{ .Values.services.litellm.image }}
@@ -56,6 +61,10 @@ spec:
           {{- if .Values.services.litellm.extraVolumeMounts }}
 {{- toYaml .Values.services.litellm.extraVolumeMounts | nindent 10 }}
           {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "{{ .Values.services.litellm.preStopDelaySeconds }}"]
       volumes:
         - name: litellm-config
           configMap:

--- a/charts/budibase/templates/pdb.yaml
+++ b/charts/budibase/templates/pdb.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "budibase.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ coalesce .Values.services.proxy.pdb.minAvailable .Values.podDisruptionBudget.minAvailable }}
   selector:
     matchLabels:
       app.kubernetes.io/name: budibase-proxy
@@ -18,12 +18,11 @@ metadata:
   labels:
     {{- include "budibase.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ coalesce .Values.services.apps.pdb.minAvailable .Values.podDisruptionBudget.minAvailable }}
   selector:
     matchLabels:
       io.kompose.service: app-service
 ---
-{{- if .Values.services.worker.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -31,9 +30,36 @@ metadata:
   labels:
     {{- include "budibase.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ coalesce .Values.services.worker.pdb.minAvailable .Values.podDisruptionBudget.minAvailable }}
   selector:
     matchLabels:
       io.kompose.service: worker-service
+{{- if .Values.services.automationWorkers.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "budibase.fullname" . }}-automation-worker-pdb
+  labels:
+    {{- include "budibase.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ coalesce .Values.services.automationWorkers.pdb.minAvailable .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      io.kompose.service: automation-worker-service
+{{- end }}
+{{- if .Values.services.litellm.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "budibase.fullname" . }}-litellm-pdb
+  labels:
+    {{- include "budibase.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ coalesce .Values.services.litellm.pdb.minAvailable .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      io.kompose.service: litellm-service
 {{- end }}
 {{- end }}

--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -39,6 +39,10 @@ spec:
 {{ end }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.services.proxy.terminationGracePeriodSeconds }}
+      {{- if .Values.services.proxy.readinessGates }}
+      readinessGates:
+        {{- toYaml .Values.services.proxy.readinessGates | nindent 8 }}
+      {{- end }}
       containers:
       - image: {{ .Values.services.proxy.image | default (printf "%sbudibase/proxy:%s" (.Values.globals.dockerRegistry | default "") (.Values.globals.appVersion | default .Chart.AppVersion)) }}
         imagePullPolicy: Always

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -39,6 +39,10 @@ spec:
 {{ end }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.services.worker.terminationGracePeriodSeconds }}
+      {{- if .Values.services.worker.readinessGates }}
+      readinessGates:
+        {{- toYaml .Values.services.worker.readinessGates | nindent 8 }}
+      {{- end }}
       containers:
       - env:
         - name: BUDIBASE_ENVIRONMENT

--- a/charts/budibase/tests/app_service_deployment_test.yaml
+++ b/charts/budibase/tests/app_service_deployment_test.yaml
@@ -123,3 +123,29 @@ tests:
           content:
             name: APP_FEATURES
             value: "api"
+
+  - it: should set terminationGracePeriodSeconds to 75 by default
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 75
+
+  - it: should set preStop sleep to 40 by default
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: ["sleep", "40"]
+
+  - it: should not render readinessGates by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.readinessGates
+
+  - it: should render readinessGates when configured
+    set:
+      services.apps.readinessGates:
+        - conditionType: target-health.elbv2.k8s.aws/my-tgb
+    asserts:
+      - equal:
+          path: spec.template.spec.readinessGates[0].conditionType
+          value: target-health.elbv2.k8s.aws/my-tgb

--- a/charts/budibase/tests/automation_worker_deployment_test.yaml
+++ b/charts/budibase/tests/automation_worker_deployment_test.yaml
@@ -97,3 +97,36 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 4002
+
+  - it: should set terminationGracePeriodSeconds to 75 by default
+    set:
+      services.automationWorkers.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 75
+
+  - it: should set preStop sleep to 40 by default
+    set:
+      services.automationWorkers.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: ["sleep", "40"]
+
+  - it: should not render readinessGates by default
+    set:
+      services.automationWorkers.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.readinessGates
+
+  - it: should render readinessGates when configured
+    set:
+      services.automationWorkers.enabled: true
+      services.automationWorkers.readinessGates:
+        - conditionType: target-health.elbv2.k8s.aws/my-tgb
+    asserts:
+      - equal:
+          path: spec.template.spec.readinessGates[0].conditionType
+          value: target-health.elbv2.k8s.aws/my-tgb

--- a/charts/budibase/tests/pdb_test.yaml
+++ b/charts/budibase/tests/pdb_test.yaml
@@ -1,0 +1,145 @@
+suite: PodDisruptionBudget
+templates:
+  - templates/pdb.yaml
+release:
+  name: budibase
+chart:
+  version: 3.0.0
+  appVersion: 3.0.0
+tests:
+  - it: should not render any PDBs when disabled
+    set:
+      podDisruptionBudget.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render proxy, apps, and worker PDBs by default
+    set:
+      services.automationWorkers.enabled: false
+      services.litellm.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: should render automation-worker PDB when enabled
+    set:
+      services.automationWorkers.enabled: true
+      services.litellm.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 4
+      - equal:
+          path: metadata.name
+          value: budibase-budibase-automation-worker-pdb
+        documentIndex: 3
+
+  - it: should render litellm PDB when enabled
+    set:
+      services.automationWorkers.enabled: false
+      services.litellm.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 4
+      - equal:
+          path: metadata.name
+          value: budibase-budibase-litellm-pdb
+        documentIndex: 3
+
+  - it: should render all five PDBs when all services enabled
+    set:
+      services.automationWorkers.enabled: true
+      services.litellm.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 5
+
+  - it: should use global minAvailable by default
+    set:
+      podDisruptionBudget.minAvailable: 2
+      services.automationWorkers.enabled: false
+      services.litellm.enabled: false
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+        documentIndex: 0
+      - equal:
+          path: spec.minAvailable
+          value: 2
+        documentIndex: 1
+      - equal:
+          path: spec.minAvailable
+          value: 2
+        documentIndex: 2
+
+  - it: should use per-service minAvailable when set
+    set:
+      podDisruptionBudget.minAvailable: 1
+      services.proxy.pdb.minAvailable: 2
+      services.apps.pdb.minAvailable: 3
+      services.automationWorkers.enabled: false
+      services.litellm.enabled: false
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+        documentIndex: 0
+      - equal:
+          path: spec.minAvailable
+          value: 3
+        documentIndex: 1
+      - equal:
+          path: spec.minAvailable
+          value: 1
+        documentIndex: 2
+
+  - it: proxy PDB should target budibase-proxy pods
+    set:
+      services.automationWorkers.enabled: false
+      services.litellm.enabled: false
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: budibase-proxy
+        documentIndex: 0
+
+  - it: apps PDB should target app-service pods
+    set:
+      services.automationWorkers.enabled: false
+      services.litellm.enabled: false
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["io.kompose.service"]
+          value: app-service
+        documentIndex: 1
+
+  - it: worker PDB should target worker-service pods
+    set:
+      services.automationWorkers.enabled: false
+      services.litellm.enabled: false
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["io.kompose.service"]
+          value: worker-service
+        documentIndex: 2
+
+  - it: automation-worker PDB should target automation-worker-service pods
+    set:
+      services.automationWorkers.enabled: true
+      services.litellm.enabled: false
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["io.kompose.service"]
+          value: automation-worker-service
+        documentIndex: 3
+
+  - it: litellm PDB should target litellm-service pods
+    set:
+      services.automationWorkers.enabled: false
+      services.litellm.enabled: true
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["io.kompose.service"]
+          value: litellm-service
+        documentIndex: 3

--- a/charts/budibase/tests/proxy_service_deployment_test.yaml
+++ b/charts/budibase/tests/proxy_service_deployment_test.yaml
@@ -95,3 +95,29 @@ tests:
       - equal:
           path: spec.template.spec.imagePullSecrets[0].name
           value: my-pull-secret
+
+  - it: should set terminationGracePeriodSeconds to 75 by default
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 75
+
+  - it: should set preStop sleep to 40 by default
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: ["sleep", "40"]
+
+  - it: should not render readinessGates by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.readinessGates
+
+  - it: should render readinessGates when configured
+    set:
+      services.proxy.readinessGates:
+        - conditionType: target-health.elbv2.k8s.aws/my-tgb
+    asserts:
+      - equal:
+          path: spec.template.spec.readinessGates[0].conditionType
+          value: target-health.elbv2.k8s.aws/my-tgb

--- a/charts/budibase/tests/worker_service_deployment_test.yaml
+++ b/charts/budibase/tests/worker_service_deployment_test.yaml
@@ -135,3 +135,29 @@ tests:
           content:
             name: SMTP_HOST
             value: "smtp.example.com"
+
+  - it: should set terminationGracePeriodSeconds to 75 by default
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 75
+
+  - it: should set preStop sleep to 40 by default
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: ["sleep", "40"]
+
+  - it: should not render readinessGates by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.readinessGates
+
+  - it: should render readinessGates when configured
+    set:
+      services.worker.readinessGates:
+        - conditionType: target-health.elbv2.k8s.aws/my-tgb
+    asserts:
+      - equal:
+          path: spec.template.spec.readinessGates[0].conditionType
+          value: target-health.elbv2.k8s.aws/my-tgb

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -2,9 +2,11 @@
 imagePullSecrets: []
 
 podDisruptionBudget:
-  # -- Whether to create a PodDisruptionBudget for the services.
-  enabled: false
-  # -- The minimum number of available pods for the services.
+  # -- Whether to create PodDisruptionBudgets for the services.
+  # Enabled by default. Requires replicaCount >= 2 per service to avoid blocking voluntary disruptions.
+  enabled: true
+  # -- Default minimum number of available pods across all services.
+  # Can be overridden per-service via services.<name>.pdb.minAvailable.
   minAvailable: 1
 
 # -- Override the name of the deployment. Defaults to {{ .Chart.Name }}.
@@ -167,7 +169,7 @@ services:
     # @ignore (you shouldn't need to change this)
     port: 10000
     # -- The number of proxy replicas to run.
-    replicaCount: 1
+    replicaCount: 2
     # @ignore (you should never need to change this)
     upstreams:
       apps: "http://app-service.{{ .Release.Namespace }}.svc.{{ .Values.services.dns }}:{{ .Values.services.apps.port }}"
@@ -176,9 +178,17 @@ services:
       couchdb: "http://{{ .Release.Name }}-svc-couchdb:{{ .Values.services.couchdb.port }}"
     # -- The time in seconds to wait before sending SIGKILL after SIGTERM.
     # Must be greater than preStopDelaySeconds to allow graceful shutdown.
-    terminationGracePeriodSeconds: 60
+    terminationGracePeriodSeconds: 75
     # -- Seconds to sleep before SIGTERM to allow load balancer deregistration.
-    preStopDelaySeconds: 10
+    preStopDelaySeconds: 40
+    # -- Pod readiness gates for the proxy pods. Useful for ALB target group
+    # health tracking with the AWS Load Balancer Controller.
+    # Example: [{conditionType: "target-health.elbv2.k8s.aws/my-tgb"}]
+    readinessGates: []
+    # -- PodDisruptionBudget settings for the proxy service.
+    # Requires podDisruptionBudget.enabled to be true.
+    # Set minAvailable to override the global podDisruptionBudget.minAvailable for this service.
+    pdb: {}
     # -- The resources to use for proxy pods. See
     # <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/>
     # for more information on how to set these.
@@ -253,7 +263,7 @@ services:
     # @ignore (you shouldn't need to change this)
     port: 4002
     # -- The number of apps replicas to run.
-    replicaCount: 1
+    replicaCount: 2
     # -- The log level for the apps service.
     logLevel: info
     # -- Whether or not to log HTTP requests to the apps service.
@@ -265,12 +275,20 @@ services:
     # -- The amount of time to wait between requesting a shutdown and killing the
     # container. This is used to give the apps service time to finish processing
     # any requests before shutting down. You shouldn't need to change this.
-    terminationGracePeriodSeconds: 60
+    terminationGracePeriodSeconds: 75
     # -- Seconds to wait after pod is Ready before adding to endpoints.
     # Ensures pods are stable before receiving traffic.
     minReadySeconds: 10
     # -- Seconds to sleep before SIGTERM to allow load balancer deregistration.
-    preStopDelaySeconds: 5
+    preStopDelaySeconds: 40
+    # -- Pod readiness gates for the apps pods. Useful for ALB target group
+    # health tracking with the AWS Load Balancer Controller.
+    # Example: [{conditionType: "target-health.elbv2.k8s.aws/my-tgb"}]
+    readinessGates: []
+    # -- PodDisruptionBudget settings for the apps service.
+    # Requires podDisruptionBudget.enabled to be true.
+    # Set minAvailable to override the global podDisruptionBudget.minAvailable for this service.
+    pdb: {}
     # -- Extra environment variables to set for apps pods. Takes a list of
     # name=value pairs.
     extraEnv: []
@@ -354,7 +372,7 @@ services:
     # @ignore (you shouldn't need to change this)
     port: 4002
     # -- The number of automation worker replicas to run.
-    replicaCount: 1
+    replicaCount: 2
     # -- The log level for the automation worker service.
     logLevel: info
     # -- The resources to use for automation worker pods. See
@@ -365,7 +383,17 @@ services:
     # the container. This is used to give the automation worker service time to
     # finish processing any requests before shutting down. You shouldn't need to
     # change this.
-    terminationGracePeriodSeconds: 60
+    terminationGracePeriodSeconds: 75
+    # -- Seconds to sleep before SIGTERM to allow load balancer deregistration.
+    preStopDelaySeconds: 40
+    # -- Pod readiness gates for the automation worker pods. Useful for ALB
+    # target group health tracking with the AWS Load Balancer Controller.
+    # Example: [{conditionType: "target-health.elbv2.k8s.aws/my-tgb"}]
+    readinessGates: []
+    # -- PodDisruptionBudget settings for the automation worker service.
+    # Requires podDisruptionBudget.enabled to be true.
+    # Set minAvailable to override the global podDisruptionBudget.minAvailable for this service.
+    pdb: {}
     # -- Extra environment variables to set for automation worker pods. Takes a list of
     # name=value pairs.
     extraEnv: []
@@ -449,7 +477,7 @@ services:
     # @ignore (you shouldn't need to change this)
     port: 4003
     # -- The number of worker replicas to run.
-    replicaCount: 1
+    replicaCount: 2
     # -- The log level for the worker service.
     logLevel: info
     # -- Whether or not to log HTTP requests to the worker service.
@@ -462,12 +490,20 @@ services:
     # the container. This is used to give the worker service time to finish
     # processing any requests before shutting down. You shouldn't need to change
     # this.
-    terminationGracePeriodSeconds: 60
+    terminationGracePeriodSeconds: 75
     # -- Seconds to wait after pod is Ready before adding to endpoints.
     # Ensures pods are stable before receiving traffic.
     minReadySeconds: 10
     # -- Seconds to sleep before SIGTERM to allow load balancer deregistration.
-    preStopDelaySeconds: 10
+    preStopDelaySeconds: 40
+    # -- Pod readiness gates for the worker pods. Useful for ALB target group
+    # health tracking with the AWS Load Balancer Controller.
+    # Example: [{conditionType: "target-health.elbv2.k8s.aws/my-tgb"}]
+    readinessGates: []
+    # -- PodDisruptionBudget settings for the worker service.
+    # Requires podDisruptionBudget.enabled to be true.
+    # Set minAvailable to override the global podDisruptionBudget.minAvailable for this service.
+    pdb: {}
     # -- Extra environment variables to set for worker pods. Takes a list of
     # name=value pairs.
     extraEnv: []
@@ -620,7 +656,19 @@ services:
     # -- Port exposed by the litellm container.
     port: 4000
     # -- Number of litellm replicas.
-    replicaCount: 1
+    replicaCount: 2
+    # -- The time in seconds to wait before sending SIGKILL after SIGTERM.
+    terminationGracePeriodSeconds: 75
+    # -- Seconds to sleep before SIGTERM to allow load balancer deregistration.
+    preStopDelaySeconds: 40
+    # -- Pod readiness gates for the litellm pods. Useful for ALB target group
+    # health tracking with the AWS Load Balancer Controller.
+    # Example: [{conditionType: "target-health.elbv2.k8s.aws/my-tgb"}]
+    readinessGates: []
+    # -- PodDisruptionBudget settings for the litellm service.
+    # Requires podDisruptionBudget.enabled to be true.
+    # Set minAvailable to override the global podDisruptionBudget.minAvailable for this service.
+    pdb: {}
     # -- Resources for litellm pods.
     resources: {}
     # -- Extra environment variables for the litellm container.


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-service PodDisruptionBudgets and optional readiness gates to the Helm chart to improve safe rollouts and load balancer draining. Updated defaults for replicas and graceful shutdown reduce downtime during node drains and deployments.

- New Features
  - PDBs enabled by default with global `podDisruptionBudget.minAvailable` (override per-service via `services.<name>.pdb.minAvailable`).
  - PDBs added for proxy, apps, worker, `automationWorkers`, and `litellm`.
  - Optional `readinessGates` for proxy, apps, worker, `automationWorkers`, and `litellm` (e.g. `target-health.elbv2.k8s.aws/my-tgb`).
  - More graceful shutdown: `terminationGracePeriodSeconds: 75`, `preStop` sleep: 40s.
  - Default `replicaCount` set to 2 for proxy, apps, worker, `automationWorkers`, and `litellm`.
  - Comprehensive Helm tests for PDBs, readiness gates, and defaults.

- Migration
  - Running single-replica? Either set `podDisruptionBudget.enabled: false`, or set per-service `pdb.minAvailable: 0`, or keep PDBs and scale replicas to 2.
  - The longer preStop/grace period slows rollouts slightly; ensure your controller timeouts accommodate this.

<sup>Written for commit 4e995109cff877bdd018941d9d63af0dcc0b9244. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

