### PR TITLE
Feat/move minio binary to s3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-scripts/resources/minio filter=lfs diff=lfs merge=lfs -text

--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -104,11 +104,6 @@ RUN mkdir -p /var/log/nginx && \
 # Setup minio
 WORKDIR /minio
 
-# A 2022 version of minio that supports gateway mode
-COPY scripts/resources/minio /minio
-RUN chmod +x minio
-
-# Handles the installation of minio in non-aas environments
 COPY scripts/install-minio.sh ./install.sh
 RUN chmod +x install.sh && ./install.sh
 

--- a/scripts/install-minio.sh
+++ b/scripts/install-minio.sh
@@ -2,7 +2,7 @@
 
 if [[ $TARGETBUILD == "aas" ]]; then
   echo "INSTALLING AAS MINIO (2022 gateway-compatible build)"
-  wget https://dwiquhvocfant.cloudfront.net/minio/minio
+  wget https://dwiquhvocfant.cloudfront.net/minio/minio # this is a Budibase controlled CF distribution
   chmod +x minio
   exit 0
 fi

--- a/scripts/install-minio.sh
+++ b/scripts/install-minio.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 if [[ $TARGETBUILD == "aas" ]]; then
-  echo "A aas-compatible version of Minio is already installed."
+  echo "INSTALLING AAS MINIO (2022 gateway-compatible build)"
+  wget https://dwiquhvocfant.cloudfront.net/minio/minio
+  chmod +x minio
   exit 0
 fi
 
 if [[ $TARGETARCH == arm* ]]; then
   echo "INSTALLING ARM64 MINIO"
-  rm -f minio
   wget https://dl.min.io/server/minio/release/linux-arm64/minio
 else
   echo "INSTALLING AMD64 MINIO"
-  rm -f minio
   wget https://dl.min.io/server/minio/release/linux-amd64/minio
 fi
 

--- a/scripts/resources/minio
+++ b/scripts/resources/minio
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:63db3aa3c2299ebaf13b46c64523a589bd5bf272f9e971d17f1eaa55f6f1fd79
-size 118595584


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch `minio` from a vendored Git LFS binary to build-time downloads. This reduces repo size, simplifies the Dockerfile, and ensures AAS uses a 2022 gateway-compatible build for S3 gateway support.

- **Refactors**
  - Removed `scripts/resources/minio` and its LFS rule in `.gitattributes`.
  - Dockerfile no longer copies a local `minio`; it runs `scripts/install-minio.sh`.
  - `scripts/install-minio.sh`: for `TARGETBUILD=aas`, download the 2022 `minio` from Budibase CloudFront and `chmod +x`; otherwise fetch arch-specific binaries from official release URLs.

<sup>Written for commit 795b1bd0c65f81e1aef53a3d4ac8b60e10a44e5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



