### PR TITLE
Add source-backed Aspire TypeScript AppHost

### DIFF
--- a/aspire-apphost/.gitignore
+++ b/aspire-apphost/.gitignore
@@ -1,0 +1,4 @@
+.modules/
+data/
+dist/
+node_modules/

--- a/aspire-apphost/STATUS.md
+++ b/aspire-apphost/STATUS.md
@@ -1,0 +1,74 @@
+# Budibase Aspire AppHost status
+
+## Deliverable
+
+This folder contains a source-backed TypeScript Aspire AppHost for Budibase.
+
+- `apphost.ts` runs Budibase from the local repository source instead of Budibase app containers.
+- Infrastructure sidecars remain containerized under Aspire.
+- The folder also includes the local TypeScript AppHost config needed to run it (`aspire.config.json`, `apphost.run.json`, `package.json`, `tsconfig*.json`, `nginx.dev.conf`).
+
+## Resources created
+
+### Executables from local source
+
+- `string-templates-dev`
+- `client-dev`
+- `builder-dev`
+- `worker-service`
+- `app-service`
+
+### Container resources
+
+- `litellm-db`
+- `litellm-service`
+- `minio-service`
+- `couchdb-service`
+- `redis-service`
+- `proxy-service`
+
+### Aspire parameters
+
+- `api-encryption-key`
+- `encryption-key`
+- `jwt-secret`
+- `minio-access-key`
+- `minio-secret-key`
+- `couch-db-user`
+- `couch-db-password`
+- `redis-password`
+- `internal-api-key`
+- `litellm-master-key`
+- `litellm-salt-key`
+- `litellm-db-user`
+- `litellm-db-name`
+- `litellm-db-password`
+- `bb-admin-user-email`
+- `bb-admin-user-password`
+
+## What was achieved
+
+- Budibase runs from the local clone source with Aspire orchestration.
+- Secrets are modeled as Aspire parameters, and sensitive values now use generated persisted secret parameters instead of hard-coded literals in the AppHost.
+- Most service URLs are injected from Aspire resource references or derived endpoint values instead of hard-coded `localhost` URLs.
+- The remaining LiteLLM startup issue was fixed by using the Budibase compose-equivalent container-local database target `litellm-db:5432`.
+- In the validated working environment, the stack returned HTTP 200 from:
+  - `http://localhost:4001/health`
+  - `http://localhost:4002/health`
+  - `http://localhost:10000/builder`
+  - `http://localhost:4000`
+
+## Local run notes
+
+- Budibase itself requires Node 22.x for the source-backed workflow.
+- The validated environment used Aspire CLI `13.3.0-preview.1.26221.2` from the Aspire daily/dev channel.
+- The validated environment also needed Budibase native module rebuilds under Node 22:
+  - `npm rebuild leveldown --build-from-source`
+  - `npm rebuild isolated-vm --build-from-source`
+- On the validating machine, port 3000 was already occupied, so the AppHost runs the Budibase builder on port 3100 and points the included `nginx.dev.conf` at that port.
+- After switching LiteLLM DB credentials to generated secrets, the validating run needed a one-time reset of `aspire-apphost/data/litellm-db` so Postgres could reinitialize with the new password.
+
+## Remaining limitations
+
+- Budibase does not currently expose an obvious OTEL/OTLP bootstrap path in `packages/server` or `packages/worker`, so OTEL export could not be enabled from the AppHost alone. This appears to be Budibase-specific rather than an Aspire dashboard limitation.
+- The generated Aspire TypeScript surface does not currently expose the .NET `HostAndPort` endpoint-expression path. Because of that, the LiteLLM container database URL cannot yet be authored as a pure resolved endpoint expression for container-network usage. The working workaround is the container alias `litellm-db:5432`.

--- a/aspire-apphost/apphost.run.json
+++ b/aspire-apphost/apphost.run.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15100",
+      "environmentVariables": {
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19100",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20100",
+        "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+      }
+    }
+  }
+}

--- a/aspire-apphost/apphost.ts
+++ b/aspire-apphost/apphost.ts
@@ -1,0 +1,215 @@
+import { createBuilder, refExpr } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+const generatedSecret = {
+    minLength: 24,
+    lower: true,
+    upper: true,
+    numeric: true,
+    special: false,
+    minUpper: 2,
+    minNumeric: 2,
+};
+const generatedIdentifier = {
+    minLength: 12,
+    lower: true,
+    upper: true,
+    numeric: true,
+    special: false,
+    minUpper: 1,
+    minNumeric: 1,
+};
+
+async function getHostAndPort(endpointPromise: Promise<{ host: { get(): Promise<string> }, port: { get(): Promise<number> } }>)
+{
+    const endpoint = await endpointPromise;
+    const host = await endpoint.host.get();
+    const port = await endpoint.port.get();
+    return `${host}:${port}`;
+}
+
+const apiEncryptionKey = await builder.addParameterWithGeneratedValue('api-encryption-key', generatedSecret, { secret: true, persist: true });
+const encryptionKey = await builder.addParameterWithGeneratedValue('encryption-key', generatedSecret, { secret: true, persist: true });
+const jwtSecret = await builder.addParameterWithGeneratedValue('jwt-secret', generatedSecret, { secret: true, persist: true });
+const minioAccessKey = await builder.addParameterWithGeneratedValue('minio-access-key', generatedIdentifier, { secret: true, persist: true });
+const minioSecretKey = await builder.addParameterWithGeneratedValue('minio-secret-key', generatedSecret, { secret: true, persist: true });
+const couchDbUser = await builder.addParameterWithValue('couch-db-user', 'budibase');
+const couchDbPassword = await builder.addParameterWithGeneratedValue('couch-db-password', generatedSecret, { secret: true, persist: true });
+const redisPassword = await builder.addParameterWithGeneratedValue('redis-password', generatedSecret, { secret: true, persist: true });
+const internalApiKey = await builder.addParameterWithGeneratedValue('internal-api-key', generatedSecret, { secret: true, persist: true });
+const litellmMasterKey = await builder.addParameterWithGeneratedValue('litellm-master-key', generatedSecret, { secret: true, persist: true });
+const litellmSaltKey = await builder.addParameterWithGeneratedValue('litellm-salt-key', generatedSecret, { secret: true, persist: true });
+const litellmDbUser = await builder.addParameterWithValue('litellm-db-user', 'llmproxy');
+const litellmDbName = await builder.addParameterWithValue('litellm-db-name', 'litellm');
+const litellmDbPassword = await builder.addParameterWithGeneratedValue('litellm-db-password', generatedSecret, { secret: true, persist: true });
+const adminEmail = await builder.addParameterWithValue('bb-admin-user-email', 'local@budibase.com');
+const adminPassword = await builder.addParameterWithGeneratedValue('bb-admin-user-password', generatedSecret, { secret: true, persist: true });
+
+const litellmDb = await builder.addContainer('litellm-db', 'postgres:16');
+await litellmDb.withContainerNetworkAlias('litellm-db');
+await litellmDb.withEnvironment('POSTGRES_DB', litellmDbName);
+await litellmDb.withEnvironment('POSTGRES_USER', litellmDbUser);
+await litellmDb.withEnvironment('POSTGRES_PASSWORD', litellmDbPassword);
+await litellmDb.withBindMount('./data/litellm-db', '/var/lib/postgresql/data');
+await litellmDb.withEndpoint({ port: 5432, targetPort: 5432, name: 'postgres' });
+
+const litellm = await builder.addContainer('litellm-service', 'ghcr.io/berriai/litellm:main-v1.81.14-stable');
+await litellm.withContainerNetworkAlias('litellm-service');
+await litellm.withBindMount('../hosting/litellm_config.yaml', '/app/config.yaml');
+await litellm.withEnvironment('STORE_MODEL_IN_DB', 'True');
+await litellm.withEnvironment('LITELLM_REASONING_AUTO_SUMMARY', 'true');
+await litellm.withEnvironment('LITELLM_MASTER_KEY', litellmMasterKey);
+await litellm.withEnvironment('LITELLM_SALT_KEY', litellmSaltKey);
+await litellm.withEnvironment('DATABASE_URL', refExpr`postgresql://${litellmDbUser}:${litellmDbPassword}@litellm-db:5432/${litellmDbName}`);
+await litellm.withArgs(['--config', '/app/config.yaml']);
+await litellm.withHttpEndpoint({ port: 4000, targetPort: 4000 });
+await litellm.waitFor(litellmDb);
+
+const minio = await builder.addContainer('minio-service', 'minio/minio:latest');
+await minio.withContainerNetworkAlias('minio-service');
+await minio.withEnvironment('MINIO_ACCESS_KEY', minioAccessKey);
+await minio.withEnvironment('MINIO_SECRET_KEY', minioSecretKey);
+await minio.withEnvironment('MINIO_BROWSER', 'off');
+await minio.withArgs(['server', '/data', '--console-address', ':9001']);
+await minio.withBindMount('./data/minio', '/data');
+await minio.withHttpEndpoint({ port: 4004, targetPort: 9000 });
+
+const minioUrl = await minio.getEndpoint('http');
+
+const couchDb = await builder.addContainer('couchdb-service', 'budibase/database:2.1.0');
+await couchDb.withContainerNetworkAlias('couchdb-service');
+await couchDb.withEnvironment('COUCHDB_PASSWORD', couchDbPassword);
+await couchDb.withEnvironment('COUCHDB_USER', couchDbUser);
+await couchDb.withEnvironment('TARGETBUILD', 'docker-compose');
+await couchDb.withEnvironment('DATA_DIR', '/data');
+await couchDb.withBindMount('./data/couchdb', '/data');
+await couchDb.withEndpoint({ port: 4005, targetPort: 5984, name: 'couchdb' });
+await couchDb.withEndpoint({ port: 4006, targetPort: 4984, name: 'sqs' });
+
+const redis = await builder.addContainer('redis-service', 'redis:latest');
+await redis.withContainerNetworkAlias('redis-service');
+await redis.withEnvironment('REDIS_PASSWORD', redisPassword);
+await redis.withArgs(['sh', '-c', 'exec redis-server --requirepass "$REDIS_PASSWORD"']);
+await redis.withBindMount('./data/redis', '/data');
+await redis.withEndpoint({ port: 6379, targetPort: 6379, name: 'redis' });
+const litellmUrl = await litellm.getEndpoint('http');
+
+const stringTemplates = await builder.addExecutable(
+    'string-templates-dev',
+    'corepack',
+    '../packages/string-templates',
+    ['yarn', 'dev'],
+);
+
+const client = await builder.addExecutable(
+    'client-dev',
+    'corepack',
+    '../packages/client',
+    ['yarn', 'dev'],
+);
+await client.waitFor(stringTemplates);
+
+const builderDev = await builder.addExecutable(
+    'builder-dev',
+    'corepack',
+    '../packages/builder',
+    ['yarn', 'dev:vite', '--', '--port', '3100'],
+);
+await builderDev.waitFor(stringTemplates);
+await builderDev.withHttpEndpoint({ port: 3100, name: 'builder', isProxied: false });
+
+const worker = await builder.addExecutable(
+    'worker-service',
+    'corepack',
+    '../packages/worker',
+    ['yarn', 'dev'],
+);
+await worker.withEnvironment('SELF_HOSTED', '1');
+await worker.withEnvironment('WORKER_PORT', '4002');
+await worker.withEnvironment('PORT', '4002');
+await worker.withEnvironment('CLUSTER_PORT', '10000');
+await worker.withEnvironment('JWT_SECRET', jwtSecret);
+await worker.withEnvironment('ENCRYPTION_KEY', encryptionKey);
+await worker.withEnvironment('API_ENCRYPTION_KEY', apiEncryptionKey);
+await worker.withEnvironment('INTERNAL_API_KEY', internalApiKey);
+await worker.withEnvironment('MINIO_ACCESS_KEY', minioAccessKey);
+await worker.withEnvironment('MINIO_SECRET_KEY', minioSecretKey);
+await worker.withEnvironment('MINIO_URL', minioUrl);
+await worker.withEnvironment('REDIS_PASSWORD', redisPassword);
+await worker.withEnvironment('COUCH_DB_USERNAME', couchDbUser);
+await worker.withEnvironment('COUCH_DB_USER', couchDbUser);
+await worker.withEnvironment('COUCH_DB_PASSWORD', couchDbPassword);
+await worker.withEnvironment('DISABLE_ACCOUNT_PORTAL', '1');
+await worker.withEnvironment('LITELLM_URL', litellmUrl);
+await worker.withEnvironment('LITELLM_MASTER_KEY', litellmMasterKey);
+await worker.withEnvironmentCallback(async (ctx) => {
+    const redisHostAndPort = await getHostAndPort(redis.getEndpoint('redis'));
+    const couchDbHostAndPort = await getHostAndPort(couchDb.getEndpoint('couchdb'));
+    await ctx.environmentVariables.set('REDIS_URL', redisHostAndPort);
+    await ctx.environmentVariables.set('COUCH_DB_URL', refExpr`http://${couchDbUser}:${couchDbPassword}@${couchDbHostAndPort}`);
+});
+await worker.withHttpEndpoint({ port: 4002, isProxied: false });
+await worker.waitFor(redis);
+await worker.waitFor(minio);
+await worker.waitFor(couchDb);
+await worker.waitFor(litellm);
+
+const app = await builder.addExecutable(
+    'app-service',
+    'corepack',
+    '../packages/server',
+    ['yarn', 'exec', 'nodemon'],
+);
+await app.withEnvironment('SELF_HOSTED', '1');
+await app.withEnvironment('APPS_PORT', '4001');
+await app.withEnvironment('PORT', '4001');
+await app.withEnvironment('JWT_SECRET', jwtSecret);
+await app.withEnvironment('ENCRYPTION_KEY', encryptionKey);
+await app.withEnvironment('API_ENCRYPTION_KEY', apiEncryptionKey);
+await app.withEnvironment('INTERNAL_API_KEY', internalApiKey);
+await app.withEnvironment('MINIO_ACCESS_KEY', minioAccessKey);
+await app.withEnvironment('MINIO_SECRET_KEY', minioSecretKey);
+await app.withEnvironment('MINIO_URL', minioUrl);
+await app.withEnvironment('REDIS_PASSWORD', redisPassword);
+await app.withEnvironment('COUCH_DB_USERNAME', couchDbUser);
+await app.withEnvironment('COUCH_DB_USER', couchDbUser);
+await app.withEnvironment('COUCH_DB_PASSWORD', couchDbPassword);
+await app.withEnvironment('WORKER_URL', await worker.getEndpoint('http'));
+await app.withEnvironment('BUDIBASE_ENVIRONMENT', 'PRODUCTION');
+await app.withEnvironment('BB_ADMIN_USER_EMAIL', adminEmail);
+await app.withEnvironment('BB_ADMIN_USER_PASSWORD', adminPassword);
+await app.withEnvironment('LITELLM_URL', litellmUrl);
+await app.withEnvironment('LITELLM_MASTER_KEY', litellmMasterKey);
+await app.withEnvironmentCallback(async (ctx) => {
+    const redisHostAndPort = await getHostAndPort(redis.getEndpoint('redis'));
+    const couchDbHostAndPort = await getHostAndPort(couchDb.getEndpoint('couchdb'));
+    await ctx.environmentVariables.set('REDIS_URL', redisHostAndPort);
+    await ctx.environmentVariables.set('COUCH_DB_URL', refExpr`http://${couchDbUser}:${couchDbPassword}@${couchDbHostAndPort}`);
+});
+await app.withHttpEndpoint({ port: 4001, isProxied: false });
+await app.waitFor(client);
+await app.waitFor(worker);
+await app.waitFor(redis);
+await app.waitFor(minio);
+await app.waitFor(couchDb);
+await app.waitFor(litellm);
+
+const proxy = await builder.addContainer('proxy-service', 'nginx:latest');
+await proxy.withContainerNetworkAlias('proxy-service');
+await proxy.withEnvironment('NGINX_ENVSUBST_OUTPUT_DIR', '/etc/nginx');
+await proxy.withEnvironment('PROXY_ADDRESS', 'host.docker.internal');
+await proxy.withBindMount('./nginx.dev.conf', '/etc/nginx/templates/nginx.conf.template');
+await proxy.withBindMount('../hosting/proxy/error.html', '/usr/share/nginx/html/error.html');
+await proxy.withHttpEndpoint({ port: 10000, targetPort: 10000 });
+await proxy.withExternalHttpEndpoints();
+await proxy.waitFor(builderDev);
+await proxy.waitFor(app);
+await proxy.waitFor(worker);
+await proxy.waitFor(minio);
+await proxy.waitFor(couchDb);
+
+await worker.withEnvironment('APPS_URL', await app.getEndpoint('http'));
+await worker.withEnvironment('PLATFORM_URL', await proxy.getEndpoint('http'));
+await app.withEnvironment('PLATFORM_URL', await proxy.getEndpoint('http'));
+
+await builder.build().run();

--- a/aspire-apphost/aspire.config.json
+++ b/aspire-apphost/aspire.config.json
@@ -1,0 +1,13 @@
+{
+  "appHost": {
+    "path": "apphost.ts",
+    "language": "typescript/nodejs"
+  },
+  "sdk": {
+    "version": "13.3.0-preview.1.26221.2"
+  },
+  "channel": "daily",
+  "packages": {
+    "Aspire.Hosting.JavaScript": "13.3.0-preview.1.26221.2"
+  }
+}

--- a/aspire-apphost/nginx.dev.conf
+++ b/aspire-apphost/nginx.dev.conf
@@ -1,0 +1,251 @@
+user                    nginx;
+error_log               /var/log/nginx/error.log debug;
+pid                     /var/run/nginx.pid;
+worker_processes        auto;
+worker_rlimit_nofile    33282;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+  proxy_set_header Host $host;
+
+  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for" '
+                    'response_time=$upstream_response_time proxy_host=$proxy_host upstream_addr=$upstream_addr';
+
+  access_log /var/log/nginx/access.log main;
+  
+  map $http_upgrade $connection_upgrade {
+    default     "upgrade";
+  }
+
+  upstream app-service {
+    server ${PROXY_ADDRESS}:4001;
+    keepalive 32;
+  }
+
+  upstream worker-service {
+    server ${PROXY_ADDRESS}:4002;
+    keepalive 32;
+  }
+
+  upstream builder {
+    server ${PROXY_ADDRESS}:3100;
+    keepalive 32;
+  }
+
+  server { 
+    listen       10000 default_server;
+    server_name  _;
+    client_max_body_size 50000m;
+    ignore_invalid_headers off;
+    proxy_buffering off;
+
+    error_page 502 503 504 /error.html;
+    location = /error.html {
+      root /usr/share/nginx/html; 
+      internal;
+    }
+
+    location /db/ {
+      proxy_pass      http://couchdb-service:5984;
+      rewrite ^/db/(.*)$ /$1 break;
+    }
+
+    location = /health {
+      proxy_read_timeout 120s;
+      proxy_connect_timeout 120s;
+      proxy_send_timeout 120s;
+      proxy_http_version 1.1;
+
+      proxy_set_header Host $host;
+      proxy_set_header Connection "";
+
+      proxy_pass      http://app-service/health;
+    }
+
+    location ~ ^/api/(system|admin|global)/ {
+      proxy_read_timeout 120s;
+      proxy_connect_timeout 120s;
+      proxy_send_timeout 120s;
+      proxy_http_version 1.1;
+
+      # Enable buffering for potentially large OIDC configs
+      proxy_buffering on;
+      proxy_buffer_size 16k;
+      proxy_buffers 4 32k;
+
+      proxy_set_header Host $host;
+      proxy_set_header Connection "";
+
+      proxy_pass      http://worker-service;
+    }
+
+    location /api/backups/ {
+      proxy_read_timeout 1800s;
+      proxy_connect_timeout 1800s;
+      proxy_send_timeout 1800s;
+      proxy_pass      http://app-service;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+    }
+
+    location /api/ {
+      proxy_read_timeout 120s;
+      proxy_connect_timeout 120s;
+      proxy_send_timeout 120s;
+      proxy_http_version 1.1;
+
+      proxy_set_header Host $host;
+      proxy_set_header Connection "";
+
+      proxy_pass      http://app-service;
+    }
+
+    location = / {
+      proxy_read_timeout 120s;
+      proxy_connect_timeout 120s;
+      proxy_send_timeout 120s;
+      proxy_http_version 1.1;
+
+      proxy_set_header Host $host;
+      proxy_set_header Connection "";
+
+      proxy_pass      http://app-service;
+    }
+
+    location /app_ {
+      proxy_read_timeout 120s;
+      proxy_connect_timeout 120s;
+      proxy_send_timeout 120s;
+      proxy_http_version 1.1;
+
+      proxy_set_header Host $host;
+      proxy_set_header Connection "";
+
+      proxy_pass      http://app-service;
+    }
+
+    location /app {
+      proxy_read_timeout 120s;
+      proxy_connect_timeout 120s;
+      proxy_send_timeout 120s;
+      proxy_http_version 1.1;
+
+      proxy_set_header Host $host;
+      proxy_set_header Connection "";
+
+      proxy_pass      http://app-service;
+    }
+
+    location /embed {
+      rewrite /embed/(.*) /app/$1  break;
+      proxy_pass         http://app-service;
+      proxy_redirect     off;
+      proxy_set_header   Host $host;
+      proxy_set_header   x-budibase-embed "true";
+      add_header x-budibase-embed "true";
+      add_header Content-Security-Policy "frame-ancestors *";
+    }
+
+    # Redirects for renamed routes
+    location ~ ^/builder/portal/apps(/.*)?$ {
+      return 301 /builder/portal/workspaces$1;
+    }
+
+    location ~ ^/builder/app(/.*)?$ {
+      return 301 /builder/workspace$1;
+    }
+
+    location /builder {
+      proxy_read_timeout 120s;
+      proxy_connect_timeout 120s;
+      proxy_send_timeout 120s;
+      proxy_http_version 1.1;
+
+      proxy_set_header Host $host;
+      proxy_set_header Connection "";
+
+      proxy_pass      http://builder;
+      rewrite ^/builder(.*)$ /builder/$1 break;
+    }
+
+    location /builder/ {
+      proxy_http_version  1.1;
+
+      proxy_set_header    Host                $host;
+      proxy_set_header    Connection          $connection_upgrade;
+      proxy_set_header    Upgrade             $http_upgrade;
+      proxy_set_header    X-Real-IP           $remote_addr;
+      proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+
+      proxy_read_timeout 120s;
+      proxy_connect_timeout 120s;
+      proxy_send_timeout 120s;
+
+      proxy_pass      http://builder;
+    }
+
+    location /vite/ {
+      proxy_pass  http://builder;
+      proxy_read_timeout 120s;
+      proxy_connect_timeout 120s;
+      proxy_send_timeout 120s;
+      rewrite     ^/vite(.*)$ /$1 break;
+    }
+
+    location /socket/ {
+      proxy_http_version  1.1;
+      proxy_set_header    Upgrade     $http_upgrade;
+      proxy_set_header    Connection  'upgrade';
+      proxy_set_header    Host        $host;
+      proxy_cache_bypass  $http_upgrade;
+      proxy_pass          http://app-service;
+    }
+
+    location / {
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header Host $http_host;
+
+      proxy_connect_timeout 300;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+      chunked_transfer_encoding off;
+
+      proxy_pass      http://minio-service:9000;
+    }
+
+    location /files/signed/ {
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+
+      # IMPORTANT: Signed urls will inspect the host header of the request.
+      # Normally a signed url will need to be generated with a specified client host in mind.
+      # To support dynamic hosts, e.g. some unknown self-hosted installation url,
+      # use a predefined host header. The host 'minio-service' is also used at the time of url signing.
+      proxy_set_header Host minio-service;
+
+      proxy_connect_timeout 300;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+      chunked_transfer_encoding off;
+
+      proxy_pass      http://minio-service:9000;
+      rewrite ^/files/signed/(.*)$ /$1 break;
+    }
+
+    client_header_timeout 60;
+    client_body_timeout   60;
+    keepalive_timeout     60;
+    gzip                  off;
+    gzip_comp_level       4;
+  }
+}

--- a/aspire-apphost/package.json
+++ b/aspire-apphost/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "budibase-aspire-apphost",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "aspire:start": "aspire run",
+    "aspire:build": "tsc -p tsconfig.apphost.json"
+  },
+  "dependencies": {
+    "vscode-jsonrpc": "^8.2.0"
+  },
+  "engines": {
+    "node": "^20.19.0 || ^22.13.0 || >=24"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/aspire-apphost/tsconfig.apphost.json
+++ b/aspire-apphost/tsconfig.apphost.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist/apphost",
+    "rootDir": "."
+  },
+  "include": ["apphost.ts", ".modules/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/aspire-apphost/tsconfig.json
+++ b/aspire-apphost/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true
+  }
+}


### PR DESCRIPTION
## Summary
- add a checked-in TypeScript Aspire AppHost under `aspire-apphost/`
- run Budibase from local source while keeping infra sidecars under Aspire
- include a status note with achieved results, resources created, and remaining limitations

## What was validated
- source-backed Budibase apphost reached HTTP 200 on `/health` for app and worker plus the Budibase builder/proxy URL in the validated environment
- secrets moved to Aspire parameters with generated persisted secret values for sensitive settings
- LiteLLM startup was fixed by using the container-local `litellm-db:5432` topology

## Remaining limitations
- Budibase does not currently expose an obvious OTEL/OTLP bootstrap path in `packages/server` or `packages/worker`
- Aspire TypeScript does not yet expose a `HostAndPort` endpoint-expression API for the LiteLLM container database URL, so the working configuration uses the container alias `litellm-db:5432`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a source-backed TypeScript Aspire AppHost to run Budibase from local source with Aspire-managed infra sidecars. Includes a dev proxy and fixes LiteLLM startup so the full stack boots and passes health checks.

- **New Features**
  - Added `aspire-apphost/` with `apphost.ts`, configs, and `nginx.dev.conf`.
  - Runs source services: `string-templates-dev`, `client-dev`, `builder-dev` (port 3100), `worker-service`, `app-service`.
  - Manages infra containers: `litellm-db`, `litellm-service`, `minio-service`, `couchdb-service`, `redis-service`, `proxy-service`.
  - Moved secrets to Aspire parameters with generated, persisted values.
  - Validated: `http://localhost:4001/health`, `http://localhost:4002/health`, `http://localhost:10000/builder`, `http://localhost:4000`.
  - LiteLLM DB uses the container alias `litellm-db:5432` for reliable startup.

- **Migration**
  - Requires Node 22.x for source-backed dev.
  - Rebuild native modules if needed: `npm rebuild leveldown --build-from-source` and `npm rebuild isolated-vm --build-from-source`.
  - Builder runs on 3100; access via `http://localhost:10000/builder`.
  - If LiteLLM DB creds change, remove `aspire-apphost/data/litellm-db` once to reinit.

<sup>Written for commit 131f8f8894977948d6f258e267d08914882fd667. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

