### PR TITLE
Decouple channel deployments from agent chat

### DIFF
--- a/packages/server/src/api/controllers/ai/agents.ts
+++ b/packages/server/src/api/controllers/ai/agents.ts
@@ -470,15 +470,6 @@ export async function toggleAgentDiscordDeployment(
       agentId,
     })
   } else {
-    const chatAppId = agent.discordIntegration?.chatAppId?.trim()
-
-    if (chatAppId) {
-      await sdk.ai.deployments.shared.disableAgentOnChatApp({
-        chatAppId,
-        agentId,
-      })
-    }
-
     await persistDiscordDeployment({
       agent,
       interactionsEndpointUrl: undefined,
@@ -521,15 +512,6 @@ export async function toggleAgentMSTeamsDeployment(
         }),
     })
   } else {
-    const chatAppId = agent.MSTeamsIntegration?.chatAppId?.trim()
-
-    if (chatAppId) {
-      await sdk.ai.deployments.shared.disableAgentOnChatApp({
-        chatAppId,
-        agentId,
-      })
-    }
-
     await sdk.ai.agents.update({
       ...agent,
       MSTeamsIntegration: {
@@ -573,15 +555,6 @@ export async function toggleAgentSlackDeployment(
         }),
     })
   } else {
-    const chatAppId = agent.slackIntegration?.chatAppId?.trim()
-
-    if (chatAppId) {
-      await sdk.ai.deployments.shared.disableAgentOnChatApp({
-        chatAppId,
-        agentId,
-      })
-    }
-
     await sdk.ai.agents.update({
       ...agent,
       slackIntegration: {

--- a/packages/server/src/api/controllers/webhook/chatHandler.ts
+++ b/packages/server/src/api/controllers/webhook/chatHandler.ts
@@ -353,6 +353,7 @@ export interface HandleChatMessageParams {
   chatAppId: string
   agentId: string
   provider: AgentChannelProvider
+  channelEnabled: boolean
   command: SupportedChatCommand
   content: string
   user: {
@@ -386,6 +387,7 @@ export const handleChatMessage = async ({
   chatAppId,
   agentId,
   provider,
+  channelEnabled,
   command,
   content,
   user,
@@ -402,11 +404,15 @@ export const handleChatMessage = async ({
       return
     }
 
-    if (
-      !chatApp.agents?.some(
-        agent => agent.agentId === agentId && agent.isEnabled
-      )
-    ) {
+    if (!channelEnabled) {
+      await reply("Agent is not enabled for this chat app.")
+      return
+    }
+
+    const chatAgentConfig = chatApp.agents?.find(
+      agent => agent.agentId === agentId
+    )
+    if (!chatAgentConfig) {
       await reply("Agent is not enabled for this chat app.")
       return
     }
@@ -489,14 +495,6 @@ export const handleChatMessage = async ({
           provider
         )} to reconnect it.`
       )
-      return
-    }
-
-    const chatAgentConfig = chatApp.agents?.find(
-      agent => agent.agentId === agentId
-    )
-    if (!chatAgentConfig) {
-      await reply("Agent is not enabled for this chat app.")
       return
     }
 

--- a/packages/server/src/api/controllers/webhook/discord.ts
+++ b/packages/server/src/api/controllers/webhook/discord.ts
@@ -74,7 +74,13 @@ export async function discordWebhook(
     ctx,
     providerName: "Discord",
     createWebhookHandler: async ({ workspaceId, chatAppId, agentId }) => {
-      const { publicKey, botToken, applicationId, idleTimeoutMinutes } =
+      const {
+        publicKey,
+        botToken,
+        applicationId,
+        idleTimeoutMinutes,
+        channelEnabled,
+      } =
         await context.doInWorkspaceContext(workspaceId, async () => {
           const agent = await sdk.ai.agents.getOrThrow(agentId)
           const integration =
@@ -90,6 +96,8 @@ export async function discordWebhook(
             ...integration,
             publicKey: pk,
             idleTimeoutMinutes: agent.discordIntegration?.idleTimeoutMinutes,
+            channelEnabled:
+              !!agent.discordIntegration?.interactionsEndpointUrl?.trim(),
           }
         })
 
@@ -174,6 +182,7 @@ export async function discordWebhook(
               chatAppId,
               agentId,
               provider: AgentChannelProvider.DISCORD,
+              channelEnabled,
               command,
               content: event.text || "",
               user: { externalUserId: userId || "", displayName },

--- a/packages/server/src/api/controllers/webhook/discord.ts
+++ b/packages/server/src/api/controllers/webhook/discord.ts
@@ -80,26 +80,25 @@ export async function discordWebhook(
         applicationId,
         idleTimeoutMinutes,
         channelEnabled,
-      } =
-        await context.doInWorkspaceContext(workspaceId, async () => {
-          const agent = await sdk.ai.agents.getOrThrow(agentId)
-          const integration =
-            sdk.ai.deployments.discord.validateDiscordIntegration(agent)
-          const pk = agent.discordIntegration?.publicKey?.trim()
-          if (!pk) {
-            throw new HTTPError(
-              "Discord public key is not configured for this agent",
-              400
-            )
-          }
-          return {
-            ...integration,
-            publicKey: pk,
-            idleTimeoutMinutes: agent.discordIntegration?.idleTimeoutMinutes,
-            channelEnabled:
-              !!agent.discordIntegration?.interactionsEndpointUrl?.trim(),
-          }
-        })
+      } = await context.doInWorkspaceContext(workspaceId, async () => {
+        const agent = await sdk.ai.agents.getOrThrow(agentId)
+        const integration =
+          sdk.ai.deployments.discord.validateDiscordIntegration(agent)
+        const pk = agent.discordIntegration?.publicKey?.trim()
+        if (!pk) {
+          throw new HTTPError(
+            "Discord public key is not configured for this agent",
+            400
+          )
+        }
+        return {
+          ...integration,
+          publicKey: pk,
+          idleTimeoutMinutes: agent.discordIntegration?.idleTimeoutMinutes,
+          channelEnabled:
+            !!agent.discordIntegration?.interactionsEndpointUrl?.trim(),
+        }
+      })
 
       const chat = new Chat({
         userName: "Budibase",

--- a/packages/server/src/api/controllers/webhook/ms-teams.ts
+++ b/packages/server/src/api/controllers/webhook/ms-teams.ts
@@ -132,11 +132,13 @@ const createTeamsMessageHandler = ({
   workspaceId,
   chatAppId,
   agentId,
+  channelEnabled,
   idleTimeoutMinutes,
 }: {
   workspaceId: string
   chatAppId: string
   agentId: string
+  channelEnabled: boolean
   idleTimeoutMinutes?: number
 }) => {
   return async (thread: Thread, message: Message) => {
@@ -229,6 +231,7 @@ const createTeamsMessageHandler = ({
         chatAppId,
         agentId,
         provider: AgentChannelProvider.MSTEAMS,
+        channelEnabled,
         command,
         content,
         user: { externalUserId, displayName },
@@ -258,13 +261,15 @@ export async function MSTeamsWebhook(
     ctx,
     providerName: "Teams",
     createWebhookHandler: async ({ workspaceId, chatAppId, agentId }) => {
-      const { integration, idleTimeoutMinutes } =
+      const { integration, idleTimeoutMinutes, channelEnabled } =
         await context.doInWorkspaceContext(workspaceId, async () => {
           const agent = await sdk.ai.agents.getOrThrow(agentId)
           return {
             integration:
               sdk.ai.deployments.MSTeams.validateMSTeamsIntegration(agent),
             idleTimeoutMinutes: agent.MSTeamsIntegration?.idleTimeoutMinutes,
+            channelEnabled: !!agent.MSTeamsIntegration?.messagingEndpointUrl
+              ?.trim(),
           }
         })
 
@@ -286,6 +291,7 @@ export async function MSTeamsWebhook(
         workspaceId,
         chatAppId,
         agentId,
+        channelEnabled,
         idleTimeoutMinutes,
       })
       chat.onDirectMessage(async (thread, message) => {

--- a/packages/server/src/api/controllers/webhook/ms-teams.ts
+++ b/packages/server/src/api/controllers/webhook/ms-teams.ts
@@ -268,8 +268,8 @@ export async function MSTeamsWebhook(
             integration:
               sdk.ai.deployments.MSTeams.validateMSTeamsIntegration(agent),
             idleTimeoutMinutes: agent.MSTeamsIntegration?.idleTimeoutMinutes,
-            channelEnabled: !!agent.MSTeamsIntegration?.messagingEndpointUrl
-              ?.trim(),
+            channelEnabled:
+              !!agent.MSTeamsIntegration?.messagingEndpointUrl?.trim(),
           }
         })
 

--- a/packages/server/src/api/controllers/webhook/slack.ts
+++ b/packages/server/src/api/controllers/webhook/slack.ts
@@ -86,11 +86,13 @@ const createSlackInputHandler = ({
   workspaceId,
   chatAppId,
   agentId,
+  channelEnabled,
   idleTimeoutMinutes,
 }: {
   workspaceId: string
   chatAppId: string
   agentId: string
+  channelEnabled: boolean
   idleTimeoutMinutes?: number
 }) => {
   return async ({
@@ -149,6 +151,7 @@ const createSlackInputHandler = ({
         chatAppId,
         agentId,
         provider: AgentChannelProvider.SLACK,
+        channelEnabled,
         command,
         content,
         user: { externalUserId, displayName },
@@ -207,13 +210,15 @@ export async function slackWebhook(
     ctx,
     providerName: "Slack",
     createWebhookHandler: async ({ workspaceId, chatAppId, agentId }) => {
-      const { integration, idleTimeoutMinutes } =
+      const { integration, idleTimeoutMinutes, channelEnabled } =
         await context.doInWorkspaceContext(workspaceId, async () => {
           const agent = await sdk.ai.agents.getOrThrow(agentId)
           return {
             integration:
               sdk.ai.deployments.slack.validateSlackIntegration(agent),
             idleTimeoutMinutes: agent.slackIntegration?.idleTimeoutMinutes,
+            channelEnabled: !!agent.slackIntegration?.messagingEndpointUrl
+              ?.trim(),
           }
         })
 
@@ -238,6 +243,7 @@ export async function slackWebhook(
         workspaceId,
         chatAppId,
         agentId,
+        channelEnabled,
         idleTimeoutMinutes,
       })
       const handler = createSlackMessageHandler(handleSlackInput)

--- a/packages/server/src/api/controllers/webhook/slack.ts
+++ b/packages/server/src/api/controllers/webhook/slack.ts
@@ -217,8 +217,8 @@ export async function slackWebhook(
             integration:
               sdk.ai.deployments.slack.validateSlackIntegration(agent),
             idleTimeoutMinutes: agent.slackIntegration?.idleTimeoutMinutes,
-            channelEnabled: !!agent.slackIntegration?.messagingEndpointUrl
-              ?.trim(),
+            channelEnabled:
+              !!agent.slackIntegration?.messagingEndpointUrl?.trim(),
           }
         })
 

--- a/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
@@ -67,6 +67,11 @@ const extractLinkUrl = (messages: string[]) => {
 describe("agent teams integration provisioning", () => {
   const config = new TestConfiguration()
 
+  const getPersistedChatApp = async (workspaceId = config.getDevWorkspaceId()) =>
+    await config.doInContext(workspaceId, async () => {
+      return await sdk.ai.chatApps.getSingle()
+    })
+
   beforeEach(async () => {
     await config.newTenant()
     mockedWebhookChat.mockClear()
@@ -101,6 +106,13 @@ describe("agent teams integration provisioning", () => {
     expect(updated?.MSTeamsIntegration?.messagingEndpointUrl).toEqual(
       result.messagingEndpointUrl
     )
+
+    const chatApp = await getPersistedChatApp()
+    expect(chatApp?.agents).toContainEqual({
+      agentId: agent._id,
+      isEnabled: false,
+      isDefault: false,
+    })
   })
 
   it("obfuscates teams secrets in responses and preserves them on update", async () => {

--- a/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
@@ -67,7 +67,9 @@ const extractLinkUrl = (messages: string[]) => {
 describe("agent teams integration provisioning", () => {
   const config = new TestConfiguration()
 
-  const getPersistedChatApp = async (workspaceId = config.getDevWorkspaceId()) =>
+  const getPersistedChatApp = async (
+    workspaceId = config.getDevWorkspaceId()
+  ) =>
     await config.doInContext(workspaceId, async () => {
       return await sdk.ai.chatApps.getSingle()
     })

--- a/packages/server/src/sdk/workspace/ai/deployments/shared.ts
+++ b/packages/server/src/sdk/workspace/ai/deployments/shared.ts
@@ -15,18 +15,17 @@ export const WEBHOOK_PATH_BY_PROVIDER: Record<AgentChannelProvider, string> = {
   [AgentChannelProvider.SLACK]: "slack",
 }
 
-const enableAgentOnChatApp = async (chatApp: ChatApp, agentId: string) => {
+const ensureAgentOnChatApp = async (chatApp: ChatApp, agentId: string) => {
   const existingAgents = chatApp.agents || []
   const existing = existingAgents.find(agent => agent.agentId === agentId)
-  if (existing?.isEnabled) {
+  if (existing) {
     return chatApp
   }
 
-  const updatedAgents = existing
-    ? existingAgents.map(agent =>
-        agent.agentId === agentId ? { ...agent, isEnabled: true } : agent
-      )
-    : [...existingAgents, { agentId, isEnabled: true, isDefault: false }]
+  const updatedAgents = [
+    ...existingAgents,
+    { agentId, isEnabled: false, isDefault: false },
+  ]
 
   return await chatApps.update({ ...chatApp, agents: updatedAgents })
 }
@@ -61,16 +60,16 @@ export const resolveChatAppForAgent = async ({
 }) => {
   if (chatAppId) {
     const app = await chatApps.getOrThrow(chatAppId)
-    return await enableAgentOnChatApp(app, agentId)
+    return await ensureAgentOnChatApp(app, agentId)
   }
 
   const existing = await chatApps.getSingle()
   if (existing) {
-    return await enableAgentOnChatApp(existing, agentId)
+    return await ensureAgentOnChatApp(existing, agentId)
   }
 
   return await chatApps.create({
-    agents: [{ agentId, isEnabled: true, isDefault: false }],
+    agents: [{ agentId, isEnabled: false, isDefault: false }],
   })
 }
 


### PR DESCRIPTION
## Description
This fixes an enablement coupling between the deprecated Budibase Agent Chat toggle and external channel deployments.

Before this change, Teams, Slack, and Discord webhooks were blocked by `chatApp.agents[].isEnabled`, which is the same flag used by Budibase Agent Chat. Disabling Agent Chat could therefore break external channels even when their own deployment toggles were still enabled.

This change makes external channels rely on their own deployment state instead:
- Teams uses `MSTeamsIntegration.messagingEndpointUrl`
- Slack uses `slackIntegration.messagingEndpointUrl`
- Discord uses `discordIntegration.interactionsEndpointUrl`

The shared chat app entry is still used for shared config such as access roles and conversation starters, but external deployment toggles no longer mutate Agent Chat enablement.

## Addresses
- N/A

## App Export
- N/A

## Screenshots
- N/A

## Launchcontrol
Disabling the Budibase Agent Chat toggle no longer turns off agent access through Microsoft Teams, Slack, or Discord.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decoupled Teams, Slack, and Discord deployments from the Agent Chat toggle so turning off Agent Chat no longer disables external channels. Webhooks now gate on their own deployment endpoints and pass a `channelEnabled` flag to the chat handler.

- **Bug Fixes**
  - Teams/Slack/Discord webhooks gate on their own endpoint URLs (`MSTeamsIntegration.messagingEndpointUrl`, `slackIntegration.messagingEndpointUrl`, `discordIntegration.interactionsEndpointUrl`) and pass `channelEnabled` to the chat handler.
  - Chat handler checks `channelEnabled` (no more `chatApp.agents[].isEnabled`) and replies if the channel is disabled.
  - Disabling a channel no longer mutates Agent Chat or chat app agent flags; linking an agent to a chat app adds it without enabling. Updated Teams tests to assert this.

<sup>Written for commit 88442c1ccaac5276d03aefa3d05d6ca1ef49f4b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

