### PR TITLE
fix(builder): deployment channel row layout on small screens

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/deployment.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/deployment.svelte
@@ -385,7 +385,7 @@
     gap: var(--spacing-m);
     padding: var(--spacing-s) var(--spacing-s);
     border-bottom: 1px solid var(--spectrum-global-color-gray-200);
-    height: 40px;
+    min-height: 40px;
   }
 
   .integration-row:last-child {


### PR DESCRIPTION
## Description
Messaging channel rows on the agent Deployment tab used a fixed 40px height, so when description text wrapped on narrow viewports it overlapped the row borders. The row now uses `min-height: 40px` so content can grow.

## Addresses
- N/A (no linked issue)

## App Export
- N/A for this CSS fix.

## Screenshots
- Before/after: verify Agent → Deployment → Messaging channels on a narrow window; multi-line descriptions should clear the dividers.

## Launchcontrol
Fixes overlapping text and borders in the agent deployment messaging channel list on smaller screens.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overlapping text and borders in the Agent → Deployment → Messaging channels list on small screens by switching row `height: 40px` to `min-height: 40px`. Rows now expand for wrapped descriptions, keeping dividers intact.

<sup>Written for commit a9c52e82004144fffb8156ec9aa330e5e1fa7132. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

