### PR TITLE
Refactor the agent controller surface

### DIFF
--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -134,11 +134,26 @@ const applyChatStreamPathParams = (
   chat: ChatAgentRequest,
   params: UserCtx<ChatAgentRequest, void>["params"]
 ) => {
-  if (params?.chatAppId) {
-    chat.chatAppId = params.chatAppId
+  const chatAppId = params?.chatAppId
+  if (chatAppId && chat.chatAppId && chat.chatAppId !== chatAppId) {
+    throw new HTTPError("chatAppId in body does not match path", 400)
   }
-  if (params?.chatConversationId && params.chatConversationId !== "new") {
-    chat._id = params.chatConversationId
+
+  const chatConversationId = params?.chatConversationId
+  if (
+    chatConversationId &&
+    chatConversationId !== "new" &&
+    chat._id &&
+    chat._id !== chatConversationId
+  ) {
+    throw new HTTPError("chatConversationId in body does not match path", 400)
+  }
+
+  if (chatAppId) {
+    chat.chatAppId = chatAppId
+  }
+  if (chatConversationId && chatConversationId !== "new") {
+    chat._id = chatConversationId
   }
 }
 

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -180,7 +180,13 @@ const resolveChatStreamRequest = async (
   const db = context.getWorkspaceDB()
   const chatAppId = chat.chatAppId
   const isBuilderOrAdmin = usersSdk.users.isAdminOrBuilder(ctx.user)
-  const canUsePreview = chat.isPreview === true && isBuilderOrAdmin
+  const requestedPreview = chat.isPreview === true
+
+  if (requestedPreview && !isBuilderOrAdmin) {
+    throw new HTTPError("Forbidden", 403)
+  }
+
+  const canUsePreview = requestedPreview
 
   if (!canUsePreview && !chatAppId) {
     throw new HTTPError("chatAppId is required", 400)

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -1,15 +1,12 @@
 import {
   context,
   events,
-  features,
   docIds,
   getErrorMessage,
   HTTPError,
 } from "@budibase/backend-core"
 import { v4 } from "uuid"
-import { ai, quotas } from "@budibase/pro"
 import {
-  AgentMessageMetadata,
   ChatAgentRequest,
   ChatApp,
   ChatConversation,
@@ -18,33 +15,22 @@ import {
   DocumentType,
   FetchAgentHistoryResponse,
   ContextUser,
-  FeatureFlag,
   UserCtx,
   WebhookChatCompleteResult,
 } from "@budibase/types"
-import {
-  extractReasoningMiddleware,
-  stepCountIs,
-  streamText,
-  wrapLanguageModel,
-} from "ai"
+import { consumeStream } from "ai"
 import sdk from "../../../sdk"
 import {
   formatIncompleteToolCallError,
-  updatePendingToolCalls,
+  prepareAgentChatRun,
 } from "../../../sdk/workspace/ai/agents"
-import { createSessionLogIndexer } from "../../../sdk/workspace/ai/agentLogs"
 import { sdk as usersSdk } from "@budibase/shared-core"
-import { retrieveContextForAgent } from "../../../sdk/workspace/ai/rag"
 import {
   assertChatAppIsLiveForUser,
   canAccessChatAppAgentForUser,
 } from "./chatApps"
 import {
-  addRetrievedContextToMessages,
-  findLatestUserQuestion,
   prepareChatConversationForSave,
-  prepareModelMessages,
   truncateTitle,
 } from "../../../sdk/workspace/ai/chatConversations"
 
@@ -91,86 +77,6 @@ const assertCanAccessChatAgent = async (
   }
 }
 
-const getRetrievedAgentContext = async (
-  agent: Awaited<ReturnType<typeof sdk.ai.agents.getOrThrow>>,
-  latestQuestion: string
-) => {
-  if (
-    !latestQuestion ||
-    !agent.knowledgeBases?.length ||
-    !(await features.isEnabled(FeatureFlag.AI_RAG))
-  ) {
-    return {
-      text: "",
-      sources: undefined as AgentMessageMetadata["ragSources"] | undefined,
-    }
-  }
-
-  try {
-    return await retrieveContextForAgent(agent, latestQuestion)
-  } catch (error) {
-    console.error("Failed to retrieve agent context", error)
-    return {
-      text: "",
-      sources: undefined as AgentMessageMetadata["ragSources"] | undefined,
-    }
-  }
-}
-
-const prepareAgentChatRun = async ({
-  agent,
-  agentId,
-  chat,
-  errorLabel,
-  sessionId,
-  user,
-}: {
-  agent: Awaited<ReturnType<typeof sdk.ai.agents.getOrThrow>>
-  agentId: string
-  chat: ChatConversationRequest
-  errorLabel: string
-  sessionId: string
-  user: ContextUser
-}) => {
-  const latestQuestion = findLatestUserQuestion(chat)
-  const sessionLogIndexer = createSessionLogIndexer({
-    agentId,
-    sessionId,
-    firstInput: latestQuestion,
-    errorLabel,
-  })
-
-  const [retrievedContext, promptAndTools, llm, modelMessages] =
-    await Promise.all([
-      getRetrievedAgentContext(agent, latestQuestion),
-      sdk.ai.agents.buildPromptAndTools(agent, {
-        baseSystemPrompt: ai.agentSystemPrompt(user),
-        includeGoal: false,
-      }),
-      sdk.ai.llm.createLLM(agent.aiconfig, sessionId, undefined, agentId),
-      prepareModelMessages(chat.messages),
-    ])
-
-  const trimmedRetrievedContext = retrievedContext.text.trim()
-  const ragSourcesMetadata =
-    trimmedRetrievedContext.length > 0 ? retrievedContext.sources : undefined
-
-  return {
-    chatLLM: llm.chat,
-    latestQuestion,
-    messagesWithContext: addRetrievedContextToMessages(
-      modelMessages,
-      trimmedRetrievedContext
-    ),
-    providerOptions: llm.providerOptions,
-    ragSourcesMetadata,
-    sessionLogIndexer,
-    system: promptAndTools.systemPrompt,
-    toolDisplayNames: promptAndTools.toolDisplayNames,
-    tools: promptAndTools.tools,
-  }
-}
-
 const getChatConversation = async (
   db: ReturnType<typeof context.getWorkspaceDB>,
   ctx: UserCtx,
@@ -207,6 +113,116 @@ const getChatConversation = async (
   return chat
 }
 
+interface ResolvedChatStreamRequest {
+  agentId: string
+  canUsePreview: boolean
+  chat: ChatAgentRequest
+  chatAppId?: string
+  existingChat?: ChatConversation
+  userId: string
+}
+
+const applyChatStreamPathParams = (
+  chat: ChatAgentRequest,
+  params: UserCtx<ChatAgentRequest, void>["params"]
+) => {
+  if (params?.chatAppId) {
+    chat.chatAppId = params.chatAppId
+  }
+  if (params?.chatConversationId && params.chatConversationId !== "new") {
+    chat._id = params.chatConversationId
+  }
+}
+
+const getExistingChatForStream = async ({
+  canUsePreview,
+  chat,
+  chatAppId,
+  db,
+  userId,
+}: {
+  canUsePreview: boolean
+  chat: ChatAgentRequest
+  chatAppId?: string
+  db: ReturnType<typeof context.getWorkspaceDB>
+  userId: string
+}) => {
+  if (!chat._id) {
+    return undefined
+  }
+
+  const existingChat = await db.tryGet<ChatConversation>(chat._id)
+  if (!existingChat) {
+    throw new HTTPError("chat not found", 404)
+  }
+  if (!canUsePreview && existingChat.chatAppId !== chatAppId) {
+    throw new HTTPError("chat does not belong to this chat app", 400)
+  }
+  if (existingChat.userId && existingChat.userId !== userId) {
+    throw new HTTPError("Forbidden", 403)
+  }
+  if (chat.agentId && chat.agentId !== existingChat.agentId) {
+    throw new HTTPError("agentId cannot be changed", 400)
+  }
+
+  return existingChat
+}
+
+const resolveChatStreamRequest = async (
+  ctx: UserCtx<ChatAgentRequest, void>
+): Promise<ResolvedChatStreamRequest> => {
+  const chat = ctx.request.body
+  const userId = getGlobalUserId(ctx)
+  applyChatStreamPathParams(chat, ctx.params)
+
+  const db = context.getWorkspaceDB()
+  const chatAppId = chat.chatAppId
+  const isBuilderOrAdmin = usersSdk.users.isAdminOrBuilder(ctx.user)
+  const canUsePreview = chat.isPreview === true && isBuilderOrAdmin
+
+  if (!canUsePreview && !chatAppId) {
+    throw new HTTPError("chatAppId is required", 400)
+  }
+
+  let chatApp: ChatApp | undefined
+  if (!canUsePreview) {
+    chatApp = await db.tryGet<ChatApp>(chatAppId)
+    if (!chatApp) {
+      throw new HTTPError("Chat app not found", 404)
+    }
+    assertChatAppIsLiveForUser(ctx, chatApp)
+  }
+
+  const existingChat = await getExistingChatForStream({
+    canUsePreview,
+    chat,
+    chatAppId,
+    db,
+    userId,
+  })
+
+  const agentId = existingChat?.agentId || chat.agentId
+  if (!agentId) {
+    throw new HTTPError("agentId is required", 400)
+  }
+
+  if (!canUsePreview && chatApp) {
+    const chatAgentConfig = getEnabledChatAgentConfig(chatApp, agentId)
+    await assertCanAccessChatAgent(ctx, chatAgentConfig)
+  }
+
+  chat.agentId = agentId
+
+  return {
+    agentId,
+    canUsePreview,
+    chat,
+    chatAppId,
+    existingChat,
+    userId,
+  }
+}
+
 export async function webhookChat({
   chat,
   user,
@@ -236,15 +252,7 @@ export async function webhookChat({
   const providerPrefix = chat.channel?.provider || "chat"
   const chatId = chat._id ?? docIds.generateChatConversationID()
   const sessionId = `${providerPrefix}:${chatId}`
-  const {
-    chatLLM,
-    latestQuestion,
-    messagesWithContext,
-    providerOptions,
-    sessionLogIndexer,
-    system,
-    tools,
-  } = await prepareAgentChatRun({
+  const run = await prepareAgentChatRun({
     agent,
     agentId,
     chat,
@@ -252,37 +260,11 @@ export async function webhookChat({
     sessionId,
     user,
   })
-  const title = latestQuestion ? truncateTitle(latestQuestion) : chat.title
+  const title = run.latestQuestion
+    ? truncateTitle(run.latestQuestion)
+    : chat.title
 
-  const hasTools = Object.keys(tools).length > 0
-  const result = streamText({
-    model: wrapLanguageModel({
-      model: chatLLM,
-      middleware: extractReasoningMiddleware({
-        tagName: "think",
-      }),
-    }),
-    messages: messagesWithContext,
-    system,
-    tools: hasTools ? tools : undefined,
-    toolChoice: hasTools ? "auto" : "none",
-    stopWhen: stepCountIs(30),
-    providerOptions: providerOptions?.(hasTools),
-    async onStepFinish({ toolResults, response }) {
-      sessionLogIndexer.addRequestId(response?.id)
-      for (const _toolResult of toolResults) {
-        await quotas.addAction(async () => {})
-      }
-    },
-    onError({ error }) {
-      console.error("Agent streaming error", {
-        agentId,
-        chatAppId,
-        sessionId,
-        error,
-      })
-    },
-  })
+  const result = await run.stream()
 
   const [textResult, responseResult] = await Promise.allSettled([
     result.text,
@@ -292,13 +274,25 @@ export async function webhookChat({
     responseResult.status === "fulfilled"
       ? (responseResult.value.id ?? undefined)
       : undefined
-  sessionLogIndexer.addRequestId(requestId)
-  await sessionLogIndexer.index()
+  run.sessionLogIndexer.addRequestId(requestId)
+  await run.sessionLogIndexer.index()
 
   if (textResult.status === "rejected") {
+    console.error("Agent streaming error", {
+      agentId,
+      chatAppId,
+      sessionId,
+      error: textResult.reason,
+    })
     throw textResult.reason
   }
   if (responseResult.status === "rejected") {
+    console.error("Agent response metadata error", {
+      agentId,
+      chatAppId,
+      sessionId,
+      error: responseResult.reason,
+    })
     throw responseResult.reason
   }
 
@@ -319,80 +313,9 @@ export async function webhookChat({
 }
 
 export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
-  const chat = ctx.request.body
-  const chatAppIdFromPath = ctx.params?.chatAppId
-  const chatConversationIdFromPath = ctx.params?.chatConversationId
-  const userId = getGlobalUserId(ctx)
-  if (
-    chatAppIdFromPath &&
-    chat.chatAppId &&
-    chat.chatAppId !== chatAppIdFromPath
-  ) {
-    throw new HTTPError("chatAppId in body does not match path", 400)
-  }
-  if (
-    chatConversationIdFromPath &&
-    chatConversationIdFromPath !== "new" &&
-    chat._id &&
-    chat._id !== chatConversationIdFromPath
-  ) {
-    throw new HTTPError("chatConversationId in body does not match path", 400)
-  }
-  if (chatAppIdFromPath) {
-    chat.chatAppId = chatAppIdFromPath
-  }
-  if (chatConversationIdFromPath && chatConversationIdFromPath !== "new") {
-    chat._id = chatConversationIdFromPath
-  }
   const db = context.getWorkspaceDB()
-  const chatAppId = chat.chatAppId
-  const isBuilderOrAdmin = usersSdk.users.isAdminOrBuilder(ctx.user)
-  const canUsePreview = chat.isPreview === true && isBuilderOrAdmin
-
-  if (!canUsePreview && !chatAppId) {
-    throw new HTTPError("chatAppId is required", 400)
-  }
-
-  let chatApp: ChatApp | undefined
-  if (!canUsePreview) {
-    chatApp = await db.tryGet<ChatApp>(chatAppId)
-    if (!chatApp) {
-      throw new HTTPError("Chat app not found", 404)
-    }
-    assertChatAppIsLiveForUser(ctx, chatApp)
-  }
-
-  let existingChat: ChatConversation | undefined
-  if (chat._id) {
-    existingChat = await db.tryGet<ChatConversation>(chat._id)
-    if (!existingChat) {
-      throw new HTTPError("chat not found", 404)
-    }
-    if (!canUsePreview && existingChat.chatAppId !== chatAppId) {
-      throw new HTTPError("chat does not belong to this chat app", 400)
-    }
-    if (existingChat.userId && existingChat.userId !== userId) {
-      throw new HTTPError("Forbidden", 403)
-    }
-    if (chat.agentId && chat.agentId !== existingChat.agentId) {
-      throw new HTTPError("agentId cannot be changed", 400)
-    }
-  }
-
-  const agentId = existingChat?.agentId || chat.agentId
-
-  if (!agentId) {
-    throw new HTTPError("agentId is required", 400)
-  }
-
-  if (!canUsePreview && chatApp) {
-    const chatAgentConfig = getEnabledChatAgentConfig(chatApp, agentId)
-    await assertCanAccessChatAgent(ctx, chatAgentConfig)
-  }
-
-  if (!chat.agentId) {
-    chat.agentId = agentId
-  }
+  const { agentId, chat, chatAppId, userId } =
+    await resolveChatStreamRequest(ctx)
 
   ctx.status = 200
   ctx.set("Content-Type", "text/event-stream")
@@ -407,17 +330,7 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
   try {
     const chatId = chat._id ?? docIds.generateChatConversationID()
     const sessionId = chat.transient ? chat.sessionId || chatId : chatId
-    const {
-      chatLLM,
-      latestQuestion,
-      messagesWithContext,
-      providerOptions,
-      ragSourcesMetadata,
-      sessionLogIndexer,
-      system,
-      toolDisplayNames,
-      tools,
-    } = await prepareAgentChatRun({
+    const run = await prepareAgentChatRun({
       agent,
       agentId,
       chat,
@@ -429,58 +342,23 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
     const pendingToolCalls = new Set<string>()
     let listedKnowledgeFiles = false
 
-    const hasTools = Object.keys(tools).length > 0
-    const result = streamText({
-      model: wrapLanguageModel({
-        model: chatLLM,
-        middleware: extractReasoningMiddleware({
-          tagName: "think",
-        }),
-      }),
-      messages: messagesWithContext,
-      system,
-      tools: hasTools ? tools : undefined,
-      toolChoice: hasTools ? "auto" : "none",
-      stopWhen: stepCountIs(30),
-      async onStepFinish({ content, toolCalls, toolResults, response }) {
-        sessionLogIndexer.addRequestId(response?.id)
-        updatePendingToolCalls(pendingToolCalls, toolCalls, toolResults)
-        for (const toolResult of toolResults) {
-          if (
-            toolResult.toolName === "list_knowledge_files" &&
-            !toolResult.preliminary
-          ) {
-            listedKnowledgeFiles = true
-          }
-          await quotas.addAction(async () => {})
-        }
-        for (const part of content) {
-          if (part.type === "tool-error") {
-            pendingToolCalls.delete(part.toolCallId)
-          }
-        }
-      },
-      onFinish({ response }) {
-        sessionLogIndexer.addRequestId(response?.id)
-      },
-      providerOptions: providerOptions?.(hasTools),
-      async onError({ error }) {
-        await sessionLogIndexer.index()
-        console.error("Agent streaming error", {
-          agentId,
-          chatAppId,
-          sessionId,
-          error,
-        })
+    const result = await run.stream({
+      pendingToolCalls,
+      onKnowledgeFilesListed() {
+        listedKnowledgeFiles = true
       },
     })
 
-    const title = latestQuestion ? truncateTitle(latestQuestion) : chat.title
+    const title = run.latestQuestion
+      ? truncateTitle(run.latestQuestion)
+      : chat.title
 
     ctx.respond = false
     const streamStartTime = Date.now()
     const sharedMetadata = {
-      ...(Object.keys(toolDisplayNames).length > 0 ? { toolDisplayNames } : {}),
+      ...(Object.keys(run.toolDisplayNames).length > 0
+        ? { toolDisplayNames: run.toolDisplayNames }
+        : {}),
     }
     result.pipeUIMessageStreamToResponse(ctx.res, {
       originalMessages: chat.messages,
@@ -499,8 +377,8 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
 
           return {
             ...sharedMetadata,
-            ...(ragSourcesMetadata?.length && !listedKnowledgeFiles
-              ? { ragSources: ragSourcesMetadata }
+            ...(run.ragSourcesMetadata?.length && !listedKnowledgeFiles
+              ? { ragSources: run.ragSourcesMetadata }
               : {}),
             createdAt: streamStartTime,
             completedAt: Date.now(),
@@ -510,9 +388,25 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
           }
         }
       },
-      onError: error => getErrorMessage(error),
+      onError: error => {
+        run.sessionLogIndexer.index().catch(indexError => {
+          console.error("Failed to index agent session after stream error", {
+            agentId,
+            chatAppId,
+            sessionId,
+            error: indexError,
+          })
+        })
+        console.error("Agent streaming error", {
+          agentId,
+          chatAppId,
+          sessionId,
+          error,
+        })
+        return getErrorMessage(error)
+      },
       onFinish: async ({ messages }) => {
-        await sessionLogIndexer.index()
+        await run.sessionLogIndexer.index()
         events.action.aiAgentExecuted({ agentId })
 
         if (chat.transient || !chatAppId) {
@@ -535,6 +429,7 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
 
         await db.put(chatToSave)
       },
+      consumeSseStream: consumeStream,
       sendReasoning: true,
     })
     return

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -122,6 +122,14 @@ interface ResolvedChatStreamRequest {
   userId: string
 }
 
+interface getExistingChatForStreamParams {
+  canUsePreview: boolean
+  chat: ChatAgentRequest
+  chatAppId?: string
+  db: ReturnType<typeof context.getWorkspaceDB>
+  userId: string
+}
+
 const applyChatStreamPathParams = (
   chat: ChatAgentRequest,
   params: UserCtx<ChatAgentRequest, void>["params"]
@@ -140,13 +148,7 @@ const getExistingChatForStream = async ({
   chatAppId,
   db,
   userId,
-}: {
-  canUsePreview: boolean
-  chat: ChatAgentRequest
-  chatAppId?: string
-  db: ReturnType<typeof context.getWorkspaceDB>
-  userId: string
-}) => {
+}: getExistingChatForStreamParams) => {
   if (!chat._id) {
     return undefined
   }

--- a/packages/server/src/sdk/workspace/ai/agents/agentRuntime.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/agentRuntime.ts
@@ -1,0 +1,172 @@
+import { features } from "@budibase/backend-core"
+import { ai, quotas } from "@budibase/pro"
+import {
+  Agent,
+  AgentMessageMetadata,
+  ChatConversationRequest,
+  ContextUser,
+  FeatureFlag,
+} from "@budibase/types"
+import {
+  extractReasoningMiddleware,
+  stepCountIs,
+  ToolLoopAgent,
+  type StreamTextResult,
+  type ToolSet,
+  wrapLanguageModel,
+} from "ai"
+import sdk from "../../.."
+import { createSessionLogIndexer } from "../agentLogs"
+import {
+  addRetrievedContextToMessages,
+  findLatestUserQuestion,
+  prepareModelMessages,
+} from "../chatConversations"
+import { retrieveContextForAgent } from "../rag"
+import { updatePendingToolCalls } from "./utils"
+
+interface PrepareAgentChatRunParams {
+  agent: Agent
+  agentId: string
+  chat: ChatConversationRequest
+  errorLabel: string
+  sessionId: string
+  user: ContextUser
+}
+
+export interface AgentChatRun {
+  latestQuestion: string
+  ragSourcesMetadata?: AgentMessageMetadata["ragSources"]
+  sessionLogIndexer: ReturnType<typeof createSessionLogIndexer>
+  stream: (
+    options?: AgentChatStreamOptions
+  ) => Promise<StreamTextResult<ToolSet, never>>
+  toolDisplayNames: Record<string, string>
+}
+
+export interface AgentChatStreamOptions {
+  onFinish?: (responseId?: string) => void | Promise<void>
+  onKnowledgeFilesListed?: () => void
+  pendingToolCalls?: Set<string>
+}
+
+const getRetrievedAgentContext = async (
+  agent: Agent,
+  latestQuestion: string
+) => {
+  if (
+    !latestQuestion ||
+    !agent.knowledgeBases?.length ||
+    !(await features.isEnabled(FeatureFlag.AI_RAG))
+  ) {
+    return {
+      text: "",
+      sources: undefined as AgentMessageMetadata["ragSources"] | undefined,
+    }
+  }
+
+  try {
+    return await retrieveContextForAgent(agent, latestQuestion)
+  } catch (error) {
+    console.error("Failed to retrieve agent context", error)
+    return {
+      text: "",
+      sources: undefined as AgentMessageMetadata["ragSources"] | undefined,
+    }
+  }
+}
+
+export const prepareAgentChatRun = async ({
+  agent,
+  agentId,
+  chat,
+  errorLabel,
+  sessionId,
+  user,
+}: PrepareAgentChatRunParams): Promise<AgentChatRun> => {
+  const latestQuestion = findLatestUserQuestion(chat)
+  const sessionLogIndexer = createSessionLogIndexer({
+    agentId,
+    sessionId,
+    firstInput: latestQuestion,
+    errorLabel,
+  })
+
+  const [retrievedContext, promptAndTools, llm, modelMessages] =
+    await Promise.all([
+      getRetrievedAgentContext(agent, latestQuestion),
+      sdk.ai.agents.buildPromptAndTools(agent, {
+        baseSystemPrompt: ai.agentSystemPrompt(user),
+        includeGoal: false,
+      }),
+      sdk.ai.llm.createLLM(agent.aiconfig, sessionId, undefined, agentId),
+      prepareModelMessages(chat.messages),
+    ])
+
+  const trimmedRetrievedContext = retrievedContext.text.trim()
+  const ragSourcesMetadata =
+    trimmedRetrievedContext.length > 0 ? retrievedContext.sources : undefined
+  const tools = promptAndTools.tools
+  const hasTools = Object.keys(tools).length > 0
+  const agentRunner = new ToolLoopAgent({
+    model: wrapLanguageModel({
+      model: llm.chat,
+      middleware: extractReasoningMiddleware({
+        tagName: "think",
+      }),
+    }),
+    instructions: promptAndTools.systemPrompt || undefined,
+    tools: hasTools ? tools : undefined,
+    toolChoice: hasTools ? "auto" : "none",
+    stopWhen: stepCountIs(30),
+    providerOptions: llm.providerOptions?.(hasTools),
+  })
+
+  return {
+    latestQuestion,
+    ragSourcesMetadata,
+    sessionLogIndexer,
+    toolDisplayNames: promptAndTools.toolDisplayNames,
+    stream: async ({
+      onFinish,
+      onKnowledgeFilesListed,
+      pendingToolCalls,
+    } = {}) =>
+      await agentRunner.stream({
+        messages: addRetrievedContextToMessages(
+          modelMessages,
+          trimmedRetrievedContext
+        ),
+        async onStepFinish({ content, toolCalls, toolResults, response }) {
+          sessionLogIndexer.addRequestId(response?.id)
+          if (pendingToolCalls) {
+            updatePendingToolCalls(pendingToolCalls, toolCalls, toolResults)
+          }
+
+          for (const toolResult of toolResults) {
+            if (
+              toolResult.toolName === "list_knowledge_files" &&
+              !toolResult.preliminary
+            ) {
+              onKnowledgeFilesListed?.()
+            }
+            await quotas.addAction(async () => {})
+          }
+
+          if (!pendingToolCalls) {
+            return
+          }
+
+          for (const part of content) {
+            if (part.type === "tool-error") {
+              pendingToolCalls.delete(part.toolCallId)
+            }
+          }
+        },
+        async onFinish({ response }) {
+          sessionLogIndexer.addRequestId(response?.id)
+          await onFinish?.(response?.id)
+        },
+      }),
+  }
+}

--- a/packages/server/src/sdk/workspace/ai/agents/index.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/index.ts
@@ -1,2 +1,3 @@
 export * from "./crud"
 export * from "./utils"
+export * from "./agentRuntime"

--- a/packages/server/src/tests/api/chatConversations.spec.ts
+++ b/packages/server/src/tests/api/chatConversations.spec.ts
@@ -37,11 +37,31 @@ jest.mock("@budibase/pro", () => {
 
 jest.mock("ai", () => {
   const actual = jest.requireActual("ai")
+  const mockStreamText = jest.fn()
+
+  class MockToolLoopAgent {
+    private settings: Record<string, any>
+
+    constructor(settings: Record<string, any>) {
+      this.settings = settings
+    }
+
+    async stream(options: Record<string, any>) {
+      const { instructions, ...settings } = this.settings
+      return mockStreamText({
+        ...settings,
+        ...options,
+        system: instructions,
+      })
+    }
+  }
+
   return {
     ...actual,
     convertToModelMessages: jest.fn(),
     pruneMessages: jest.fn(),
-    streamText: jest.fn(),
+    streamText: mockStreamText,
+    ToolLoopAgent: MockToolLoopAgent,
   }
 })
 
@@ -909,7 +929,7 @@ describe("chat conversation title helpers", () => {
   })
 })
 
-describe("chat conversation path validation", () => {
+describe("chat conversation path resolution", () => {
   const config = new TestConfiguration()
 
   beforeAll(async () => {
@@ -920,7 +940,7 @@ describe("chat conversation path validation", () => {
     config.end()
   })
 
-  it("rejects mismatched chatAppId between path and body", async () => {
+  it("uses chatAppId from the path over the body", async () => {
     const headers = await config.defaultHeaders({}, true)
 
     const res = await config
@@ -934,10 +954,10 @@ describe("chat conversation path validation", () => {
         title: "hello",
       })
 
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(404)
   })
 
-  it("rejects mismatched chatConversationId between path and body", async () => {
+  it("uses chatConversationId from the path over the body", async () => {
     const headers = await config.defaultHeaders({}, true)
 
     const res = await config
@@ -952,7 +972,7 @@ describe("chat conversation path validation", () => {
         title: "hello",
       })
 
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(404)
   })
 })
 

--- a/packages/server/src/tests/api/chatConversations.spec.ts
+++ b/packages/server/src/tests/api/chatConversations.spec.ts
@@ -931,9 +931,44 @@ describe("chat conversation title helpers", () => {
 
 describe("chat conversation path resolution", () => {
   const config = new TestConfiguration()
+  let bodyChatApp: ChatApp
+  let pathChatApp: ChatApp
+  let bodyConversation: ChatConversation
 
   beforeAll(async () => {
     await config.init("chat-conversation-validation")
+    await context.doInWorkspaceContext(
+      config.getProdWorkspaceId(),
+      async () => {
+        const db = context.getWorkspaceDB()
+        const now = new Date().toISOString()
+        bodyChatApp = {
+          _id: docIds.generateChatAppID(),
+          agents: [{ agentId: "agent-1", isEnabled: true, isDefault: true }],
+          live: true,
+          createdAt: now,
+        }
+        pathChatApp = {
+          _id: docIds.generateChatAppID(),
+          agents: [{ agentId: "agent-1", isEnabled: true, isDefault: true }],
+          live: true,
+          createdAt: now,
+        }
+        bodyConversation = {
+          _id: docIds.generateChatConversationID(),
+          chatAppId: pathChatApp._id!,
+          agentId: "agent-1",
+          userId: config.getUser()._id!,
+          messages: [],
+          title: "body conversation",
+          createdAt: now,
+        }
+
+        await db.put(bodyChatApp)
+        await db.put(pathChatApp)
+        await db.put(bodyConversation)
+      }
+    )
   })
 
   afterAll(() => {
@@ -948,7 +983,7 @@ describe("chat conversation path resolution", () => {
       .post("/api/chatapps/chatapp-path/conversations/new/stream")
       .set(headers)
       .send({
-        chatAppId: "chatapp-body",
+        chatAppId: bodyChatApp._id,
         agentId: "agent-1",
         messages: [],
         title: "hello",
@@ -962,12 +997,12 @@ describe("chat conversation path resolution", () => {
 
     const res = await config
       .getRequest()!
-      .post("/api/chatapps/chatapp-path/conversations/convo-path/stream")
+      .post(`/api/chatapps/${pathChatApp._id}/conversations/convo-path/stream`)
       .set(headers)
       .send({
-        chatAppId: "chatapp-path",
+        chatAppId: pathChatApp._id,
         agentId: "agent-1",
-        _id: "convo-body",
+        _id: bodyConversation._id,
         messages: [],
         title: "hello",
       })

--- a/packages/server/src/tests/api/chatConversations.spec.ts
+++ b/packages/server/src/tests/api/chatConversations.spec.ts
@@ -931,12 +931,20 @@ describe("chat conversation title helpers", () => {
 
 describe("chat conversation path resolution", () => {
   const config = new TestConfiguration()
+  let basicUser: User
   let bodyChatApp: ChatApp
   let pathChatApp: ChatApp
   let bodyConversation: ChatConversation
 
   beforeAll(async () => {
     await config.init("chat-conversation-validation")
+    basicUser = await config.createUser({
+      roles: {
+        [config.getProdWorkspaceId()]: roles.BUILTIN_ROLE_IDS.BASIC,
+      },
+      builder: { global: false },
+      admin: { global: false },
+    })
     await context.doInWorkspaceContext(
       config.getProdWorkspaceId(),
       async () => {
@@ -1008,6 +1016,25 @@ describe("chat conversation path resolution", () => {
       })
 
     expect(res.status).toBe(404)
+  })
+
+  it("rejects preview mode for non-builder users before input validation", async () => {
+    const headers = await config.withUser(basicUser, async () =>
+      config.defaultHeaders({}, true)
+    )
+
+    const res = await config
+      .getRequest()!
+      .post("/api/chatapps/chatapp-path/conversations/new/stream")
+      .set(headers)
+      .send({
+        agentId: "agent-1",
+        isPreview: true,
+        messages: [],
+        title: "hello",
+      })
+
+    expect(res.status).toBe(403)
   })
 })
 

--- a/packages/server/src/tests/api/chatConversations.spec.ts
+++ b/packages/server/src/tests/api/chatConversations.spec.ts
@@ -929,12 +929,12 @@ describe("chat conversation title helpers", () => {
   })
 })
 
-describe("chat conversation path resolution", () => {
+describe("chat conversation path validation", () => {
   const config = new TestConfiguration()
   let basicUser: User
   let bodyChatApp: ChatApp
   let pathChatApp: ChatApp
-  let bodyConversation: ChatConversation
+  let pathConversation: ChatConversation
 
   beforeAll(async () => {
     await config.init("chat-conversation-validation")
@@ -962,7 +962,7 @@ describe("chat conversation path resolution", () => {
           live: true,
           createdAt: now,
         }
-        bodyConversation = {
+        pathConversation = {
           _id: docIds.generateChatConversationID(),
           chatAppId: pathChatApp._id!,
           agentId: "agent-1",
@@ -974,7 +974,7 @@ describe("chat conversation path resolution", () => {
 
         await db.put(bodyChatApp)
         await db.put(pathChatApp)
-        await db.put(bodyConversation)
+        await db.put(pathConversation)
       }
     )
   })
@@ -983,12 +983,12 @@ describe("chat conversation path resolution", () => {
     config.end()
   })
 
-  it("uses chatAppId from the path over the body", async () => {
+  it("rejects mismatched chatAppId between path and body", async () => {
     const headers = await config.defaultHeaders({}, true)
 
     const res = await config
       .getRequest()!
-      .post("/api/chatapps/chatapp-path/conversations/new/stream")
+      .post(`/api/chatapps/${pathChatApp._id}/conversations/new/stream`)
       .set(headers)
       .send({
         chatAppId: bodyChatApp._id,
@@ -997,25 +997,27 @@ describe("chat conversation path resolution", () => {
         title: "hello",
       })
 
-    expect(res.status).toBe(404)
+    expect(res.status).toBe(400)
   })
 
-  it("uses chatConversationId from the path over the body", async () => {
+  it("rejects mismatched chatConversationId between path and body", async () => {
     const headers = await config.defaultHeaders({}, true)
 
     const res = await config
       .getRequest()!
-      .post(`/api/chatapps/${pathChatApp._id}/conversations/convo-path/stream`)
+      .post(
+        `/api/chatapps/${pathChatApp._id}/conversations/${pathConversation._id}/stream`
+      )
       .set(headers)
       .send({
         chatAppId: pathChatApp._id,
         agentId: "agent-1",
-        _id: bodyConversation._id,
+        _id: docIds.generateChatConversationID(),
         messages: [],
         title: "hello",
       })
 
-    expect(res.status).toBe(404)
+    expect(res.status).toBe(400)
   })
 
   it("rejects preview mode for non-builder users before input validation", async () => {


### PR DESCRIPTION
## Description
Refactors some of the controller code for agents into an sdk file

- We were reusing a lot of the same code in chatConversations.ts, there was also a lot of logic just sitting in the controller that should probably have been in an sdk file, it was becoming quite hard to parse and follow through.
- We inconsistently used `streamText` when we should be using `ToolLoopAgent` everywhere.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted agent runtime into the SDK and standardized streaming via `ToolLoopAgent`, reducing duplication and tightening request validation. Stream requests now validate path vs body IDs before applying them, with early preview gating and clearer error logging.

- **Refactors**
  - Added `packages/server/src/sdk/workspace/ai/agents/agentRuntime.ts` with `prepareAgentChatRun()` and a `run.stream()` API using `ToolLoopAgent`.
  - Introduced `resolveChatStreamRequest()` to validate path params before applying, enforce preview checks, and resolve existing chats; controller now uses it.
  - Stream piping now uses `consumeStream` from `ai`; improved session log indexing on finish and errors.

- **Migration**
  - `chatAppId` and `chatConversationId` mismatches between path and body now return 400; path params are applied only when consistent.
  - Unknown IDs return 404.
  - Preview mode is limited to builders/admins; non-privileged preview requests return 403 before other validation.

<sup>Written for commit 2783a3142d1aefaf83d64c1a16922e3a35002b92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

