### PR TITLE
Add automated VM startup guide

### DIFF
--- a/.agents/skills/budibase-setup-run/SKILL.md
+++ b/.agents/skills/budibase-setup-run/SKILL.md
@@ -196,12 +196,13 @@ If dependencies or build outputs look corrupt, rebuild without deleting Docker-b
 yarn restore
 ```
 
-If the user is in a cloud VM with nested Docker, Docker may need to be started manually and the socket made accessible before `yarn dev`:
+If the user is in a cloud VM with nested Docker, Docker may need to be started manually before `yarn dev`:
 
 ```bash
 sudo dockerd
-sudo chmod 666 /var/run/docker.sock
 ```
+
+Do not change `/var/run/docker.sock` to be world-writable. If Docker permission errors persist, use the environment's approved Docker group, rootless Docker, or VM provisioning setup.
 
 If local mode changes do not appear in the browser, clear Budibase cookies for `localhost`.
 

--- a/.agents/skills/budibase-setup-run/SKILL.md
+++ b/.agents/skills/budibase-setup-run/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: budibase-setup-run
+description: Set up, bootstrap, run, and troubleshoot the Budibase monorepo for local development and automated VM environments. Use when an AI coding agent or developer needs to install prerequisites, clone Budibase, run yarn setup/build/dev/dev:agent, start or verify the local dev stack, log in locally, run package tests, reset Docker-backed data, or explain Budibase development ports and services.
+---
+
+# Budibase Setup Run
+
+## Core Path
+
+Use this workflow for a fresh local Budibase checkout.
+
+1. Clone and enter the repo:
+
+```bash
+git clone https://github.com/Budibase/budibase.git
+cd budibase
+```
+
+2. Use the Node version pinned by the repo:
+
+```bash
+nvm install
+nvm use
+node -v
+```
+
+Budibase requires Node `>=22.0.0 <23.0.0`; this repo pins `v22.18.0` in `.nvmrc`.
+
+3. Install Yarn if needed:
+
+```bash
+npm install -g yarn
+yarn -v
+```
+
+4. Confirm Docker and Compose are available and running:
+
+```bash
+docker --version
+docker compose version
+docker info
+```
+
+5. Bootstrap and run the project for normal local development:
+
+```bash
+yarn setup
+```
+
+`yarn setup` configures submodules, checks Docker prerequisites, installs dependencies, builds packages, and starts the dev environment.
+
+For automated VM environments where dependencies and build outputs can be cached, prefer the agent path:
+
+```bash
+yarn
+yarn build
+yarn dev:agent
+```
+
+`yarn dev:agent` preserves existing build artifacts by skipping the root clean/prebuild step. Use it after a successful build or when restoring a VM image that already contains valid `dist` outputs.
+
+## Manual Setup
+
+Use the manual path when `yarn setup` fails partway through or the user wants separate steps:
+
+```bash
+yarn
+yarn build
+yarn dev
+```
+
+On first setup, `yarn build` is required before the dev loop. Later edits to shared packages such as `@budibase/shared-core`, `@budibase/backend-core`, or types may require another build.
+
+## Running Locally
+
+Start the local development environment from the repo root:
+
+```bash
+yarn dev
+```
+
+This command:
+
+- Creates or updates `.env` through `scripts/dev/manage.js`.
+- Frees app ports through `yarn kill-all`.
+- Runs package prebuilds.
+- Starts the server, worker, builder, and Docker-backed development stack.
+
+For automated VM runs after a successful build, use:
+
+```bash
+yarn dev:agent
+```
+
+This keeps the normal developer workflow unchanged while reducing startup work in cached environments.
+
+Access Budibase at:
+
+- Main proxy: `http://localhost:10000`
+- Builder: `http://localhost:10000/builder`
+
+Default local login:
+
+- Email: `local@budibase.com`
+- Password: `cheekychuckles`
+
+## Services And Ports
+
+Expect these local services:
+
+| Service | Port | Notes |
+| --- | ---: | --- |
+| Nginx proxy | `10000` | Main entry point |
+| Builder | `3000` | Vite/Svelte dev server |
+| Server | `4001` | Koa API for apps |
+| Worker | `4002` | Background jobs and platform APIs |
+| MinIO | `4004` | S3-compatible storage |
+| CouchDB | `4005` | Primary database |
+| CouchDB SQS | `4006` | Queue-related CouchDB service |
+| Redis | `6379` | Cache, sessions, queues |
+| LiteLLM | `4000` | Optional AI proxy, token `budibase` |
+
+Health checks:
+
+```bash
+curl http://localhost:4001/health
+curl http://localhost:4002/health
+```
+
+## Common Commands
+
+Build everything:
+
+```bash
+yarn build
+```
+
+Run type checks:
+
+```bash
+yarn check:types
+```
+
+Run lint:
+
+```bash
+yarn lint
+```
+
+Run a package test from inside that package:
+
+```bash
+cd packages/server
+yarn test path/to/test-file.test.ts
+```
+
+Run only server and worker:
+
+```bash
+yarn dev:server
+```
+
+Run the optimized automated-environment startup path:
+
+```bash
+yarn dev:agent
+```
+
+Run frontend/dev stack without local server processes:
+
+```bash
+yarn dev:noserver
+```
+
+Switch development modes:
+
+```bash
+yarn mode:self
+yarn mode:cloud
+yarn mode:account
+```
+
+Clear all local Budibase Docker data and restart:
+
+```bash
+yarn nuke:docker
+yarn dev
+```
+
+## Troubleshooting
+
+If Docker commands fail, ensure Docker Desktop or the Docker daemon is running before rerunning setup.
+
+If ports are stale, run:
+
+```bash
+yarn kill-all
+```
+
+If dependencies or builds look corrupt, use the lighter reset first:
+
+```bash
+yarn restore
+```
+
+Use the full reset only when needed because it removes package installs and Docker-backed development data:
+
+```bash
+yarn nuke
+```
+
+If the user is in a cloud VM with nested Docker, Docker may need to be started manually and the socket made accessible before `yarn dev`:
+
+```bash
+sudo dockerd
+sudo chmod 666 /var/run/docker.sock
+```
+
+If local mode changes do not appear in the browser, clear Budibase cookies for `localhost`.
+
+## Contributor Notes
+
+Use `@budibase/` scoped imports between packages. The main package split is:
+
+- Backend: `packages/server`, `packages/worker`, `packages/backend-core`
+- Frontend: `packages/builder`, `packages/frontend-core`, `packages/bbui`
+- Shared: `packages/shared-core`
+
+For server API tests, prefer `TestConfiguration` from `packages/server/src/tests/TestConfiguration.ts`. For automation tests, use `createAutomationBuilder` from `packages/server/src/automations/tests/utilities/AutomationTestBuilder.ts`.

--- a/.agents/skills/budibase-setup-run/SKILL.md
+++ b/.agents/skills/budibase-setup-run/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: budibase-setup-run
-description: Set up, bootstrap, run, and troubleshoot the Budibase monorepo for local development and automated VM environments. Use when an AI coding agent or developer needs to install prerequisites, clone Budibase, run yarn setup/build/dev/dev:agent, start or verify the local dev stack, log in locally, run package tests, reset Docker-backed data, or explain Budibase development ports and services.
+description: Set up, bootstrap, run, and troubleshoot the Budibase monorepo for local development and automated VM environments. Use when an AI coding agent or developer needs to install prerequisites, clone Budibase, run yarn setup/build/dev/dev:agent, start or verify the local dev stack, log in locally, run package tests, or explain Budibase development ports and services.
 ---
 
 # Budibase Setup Run
@@ -180,13 +180,6 @@ yarn mode:cloud
 yarn mode:account
 ```
 
-Clear all local Budibase Docker data and restart:
-
-```bash
-yarn nuke:docker
-yarn dev
-```
-
 ## Troubleshooting
 
 If Docker commands fail, ensure Docker Desktop or the Docker daemon is running before rerunning setup.
@@ -197,16 +190,10 @@ If ports are stale, run:
 yarn kill-all
 ```
 
-If dependencies or builds look corrupt, use the lighter reset first:
+If dependencies or build outputs look corrupt, rebuild without deleting Docker-backed data:
 
 ```bash
 yarn restore
-```
-
-Use the full reset only when needed because it removes package installs and Docker-backed development data:
-
-```bash
-yarn nuke
 ```
 
 If the user is in a cloud VM with nested Docker, Docker may need to be started manually and the socket made accessible before `yarn dev`:

--- a/.agents/skills/budibase-setup-run/agents/openai.yaml
+++ b/.agents/skills/budibase-setup-run/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Budibase Setup Run"
+  short_description: "Set up and run the Budibase monorepo locally."
+  default_prompt: "Help me set up and run Budibase locally from a fresh checkout."

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "kill-all": "yarn run kill-builder && yarn run kill-server && yarn kill-accountportal",
     "dev:init": "node scripts/dev/manage.js",
     "dev": "yarn dev:init && yarn run kill-all && lerna run --parallel prebuild && lerna run --stream dev",
+    "dev:agent": "yarn dev:init && lerna run --stream dev",
     "dev:noserver": "yarn dev:init && yarn run kill-builder && lerna run --stream dev:stack:up && lerna run --stream dev --ignore @budibase/backend-core --ignore @budibase/server --ignore @budibase/worker",
     "dev:server": "yarn dev:init && yarn run kill-server && lerna run --stream dev --scope @budibase/worker --scope @budibase/server",
     "dev:built": "yarn dev:init && yarn run kill-all && cd packages/server && yarn dev:stack:up && cd ../../ && lerna run --stream dev:built",


### PR DESCRIPTION
## Description
Adds a repo-local `.agents` skill that documents how an AI coding agent or other automated VM environment should set up and run Budibase. It also adds a new `yarn dev:agent` script that starts the existing dev process without the root `kill-all` and clean/prebuild step, so cached dependencies and build outputs can be reused.

The normal developer workflow remains unchanged: `yarn dev` still runs the same startup command as before.

## Addresses
- N/A

## App Export
- N/A

## Screenshots
- N/A - no UI-facing changes.

## Launchcontrol
Adds an automated-environment startup guide and script for faster repeated local startup while preserving the normal `yarn dev` workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an automated VM startup guide and a `yarn dev:agent` script to speed up local startup in cached environments. The regular `yarn dev` flow is unchanged.

- **New Features**
  - Adds `.agents/skills/budibase-setup-run` with setup/run/troubleshooting, ports, and common commands for local and automated VMs; removes unsafe reset steps and world-writable Docker socket advice.
  - Adds `yarn dev:agent` (`yarn dev:init && lerna run --stream dev`) to skip root `kill-all` and prebuild so cached deps/builds are reused.
  - Adds `.agents/skills/budibase-setup-run/agents/openai.yaml` metadata.

<sup>Written for commit b7a0c2ab13909c844c91c3a3376ef827a6fdb8fd. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18620?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

