### PR TITLE
Fix user pagination total pages

### DIFF
--- a/packages/backend-core/src/users/users.ts
+++ b/packages/backend-core/src/users/users.ts
@@ -246,6 +246,7 @@ export async function paginatedUsers({
   const db = getGlobalDB()
   const pageSize = limit ?? PAGE_LIMIT
   const pageLimit = pageSize + 1
+  let totalRows: number | undefined
   // get one extra document, to have the next page
   const opts: DatabaseQueryOpts = {
     include_docs: true,
@@ -261,33 +262,57 @@ export async function paginatedUsers({
     getKey
   if (query?.equal?._id) {
     userList = [await getById(query.equal._id)]
+    totalRows = userList.length
   } else if (appId) {
     userList = await searchGlobalUsersByApp(appId, opts)
     getKey = (doc: any) => getGlobalUserByAppPage(appId, doc)
   } else if (query?.string?.email) {
     userList = await searchGlobalUsersByEmail(query?.string?.email, opts)
+    totalRows = (
+      await searchGlobalUsersByEmail(query?.string?.email, {
+        ...opts,
+        limit: undefined,
+        startkey: undefined,
+      })
+    ).length
     property = "email"
   } else if (query?.oneOf?._id) {
     userList = await bulkGetGlobalUsersById(query?.oneOf?._id, {
       cleanup: true,
     })
+    totalRows = userList.length
   } else if (query) {
     // TODO: this should use SQS search, but the logic is built in the 'server' package. Using the in-memory filtering to get this working meanwhile
     const response = await db.allDocs<User>(
-      getGlobalUserParams(null, { ...opts, limit: undefined })
+      getGlobalUserParams(null, {
+        ...opts,
+        limit: undefined,
+        startkey: undefined,
+      })
     )
     userList = response.rows.map(row => row.doc!)
-    userList = dataFilters.search(userList, { query, limit: opts.limit }).rows
+    const searchResponse = dataFilters.search(userList, {
+      query,
+      countRows: true,
+    })
+    userList = bookmark
+      ? searchResponse.rows.filter(user => (user._id || "") >= bookmark)
+      : searchResponse.rows
+    totalRows = searchResponse.totalRows
   } else {
     // no search, query allDocs
     const response = await db.allDocs<User>(getGlobalUserParams(null, opts))
     userList = response.rows.map(row => row.doc!)
+    totalRows = await getUserCount()
   }
-  return pagination(userList, pageSize, {
-    paginate: true,
-    property,
-    getKey,
-  })
+  return {
+    ...pagination(userList, pageSize, {
+      paginate: true,
+      property,
+      getKey,
+    }),
+    totalRows,
+  }
 }
 
 export async function getUserCount() {

--- a/packages/bbui/src/Pagination/Pagination.svelte
+++ b/packages/bbui/src/Pagination/Pagination.svelte
@@ -9,6 +9,7 @@
   export let goToNextPage: () => void
   export let hasPrevPage: boolean = true
   export let hasNextPage: boolean = true
+  export let totalPages: number | undefined = undefined
 </script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
@@ -23,6 +24,8 @@
   </div>
   <span class="spectrum-Body--secondary spectrum-Pagination-counter">
     Page {page}
+    {#if totalPages != null}
+      of {totalPages}{/if}
   </span>
   <div
     class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--quiet spectrum-Pagination-nextButton"

--- a/packages/builder/src/settings/pages/people/users/index.svelte
+++ b/packages/builder/src/settings/pages/people/users/index.svelte
@@ -128,6 +128,10 @@
       currentWorkspaceId
   $: tableLoading =
     !workspaceReady || !isWorkspaceQueryReady || !$fetch.loaded || !groupsLoaded
+  $: totalPages =
+    $fetch.info?.totalRows == null
+      ? undefined
+      : Math.max(1, Math.ceil($fetch.info.totalRows / PAGE_SIZE))
 
   $: customRenderers = [
     { column: "email", component: EmailTableRenderer },
@@ -691,6 +695,7 @@
       page={$fetch.pageNumber + 1}
       hasPrevPage={tableLoading ? false : $fetch.hasPrevPage}
       hasNextPage={tableLoading ? false : $fetch.hasNextPage}
+      totalPages={tableLoading ? undefined : totalPages}
       goToPrevPage={fetch.prevPage}
       goToNextPage={fetch.nextPage}
     />

--- a/packages/frontend-core/src/fetch/UserFetch.ts
+++ b/packages/frontend-core/src/fetch/UserFetch.ts
@@ -76,6 +76,7 @@ export default class UserFetch extends BaseDataFetch<
       const res = await this.API.searchUsers(opts)
       return {
         rows: res?.data || [],
+        info: { totalRows: res?.totalRows },
         hasNextPage: res?.hasNextPage || false,
         cursor: res?.nextPage || null,
       }

--- a/packages/types/src/api/web/user.ts
+++ b/packages/types/src/api/web/user.ts
@@ -115,6 +115,7 @@ export interface SearchUsersResponse {
   data: User[] | StrippedUser[]
   hasNextPage?: boolean
   nextPage?: string
+  totalRows?: number
 }
 
 export type FetchUsersResponse = User[]

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -359,6 +359,7 @@ export const search = async (
       data: paginated.data,
       hasNextPage: paginated.hasNextPage,
       nextPage: paginated.nextPage,
+      totalRows: paginated.totalRows,
     }
   }
 
@@ -414,7 +415,7 @@ const searchWorkspaceUsers = async (
 ): Promise<SearchUsersResponse> => {
   const workspaceId = body.workspaceId
   if (!workspaceId) {
-    return { data: [], hasNextPage: false }
+    return { data: [], hasNextPage: false, totalRows: 0 }
   }
 
   const prodWorkspaceId = db.getProdWorkspaceID(workspaceId)
@@ -535,6 +536,7 @@ const searchWorkspaceUsers = async (
     data,
     hasNextPage,
     nextPage: hasNextPage ? nextPage : undefined,
+    totalRows: filtered.length,
   }
 }
 

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -919,6 +919,7 @@ describe("/api/global/users", () => {
       })
       expect(response.body.data.length).toBe(1)
       expect(response.body.data[0].email).toBe(user.email)
+      expect(response.body.totalRows).toBe(1)
     })
 
     it("should support fuzzy email fragments", async () => {
@@ -930,6 +931,31 @@ describe("/api/global/users", () => {
       })
       expect(response.body.data.length).toBe(1)
       expect(response.body.data[0].email).toBe(email)
+      expect(response.body.totalRows).toBe(1)
+    })
+
+    it("should keep total rows stable when paginating searched users", async () => {
+      const users = await Promise.all(
+        Array.from({ length: 5 }).map((_, index) =>
+          config.createUser({
+            email: `stable-user-pages-${index}-${structures.users.newEmail()}`,
+          })
+        )
+      )
+      const firstPage = await config.api.users.searchUsers({
+        query: { fuzzy: { email: "stable-user-pages" } },
+        limit: 2,
+      })
+      const secondPage = await config.api.users.searchUsers({
+        bookmark: firstPage.body.nextPage,
+        query: { fuzzy: { email: "stable-user-pages" } },
+        limit: 2,
+      })
+
+      expect(firstPage.body.data.length).toBe(2)
+      expect(secondPage.body.data.length).toBe(2)
+      expect(firstPage.body.totalRows).toBe(users.length)
+      expect(secondPage.body.totalRows).toBe(users.length)
     })
 
     it("should filter by workspace access when workspaceId is provided", async () => {
@@ -1047,6 +1073,7 @@ describe("/api/global/users", () => {
 
       expect(response.body.data.length).toBe(0)
       expect(response.body.hasNextPage).toBe(false)
+      expect(response.body.totalRows).toBe(0)
     })
 
     it("should be able to search by email with numeric prefixing", async () => {


### PR DESCRIPTION
## Description
Fixes user pagination so people pages can display a stable total page count. The user search API now returns `totalRows`, and the shared pagination component can display `Page X of Y` when a total is provided.

## Addresses
- https://github.com/Budibase/budibase/issues/17217

## Screenshots
<img width="1183" height="751" alt="first page" src="https://github.com/user-attachments/assets/f6d517ac-04f8-4a90-8dfb-cb2e19be826f" />

**First page**

<img width="1183" height="751" alt="last page" src="https://github.com/user-attachments/assets/ac4597c1-09d5-4de3-a04a-2cf76afc97d0" />

**Last page**

<img width="1183" height="751" alt="filtered" src="https://github.com/user-attachments/assets/3be02e90-0a82-42c2-95b7-e940e1863ea8" />

**Filtered users table updates total pages count**

## Launchcontrol
User pagination now shows the total number of pages and keeps that total stable when moving between pages.