### PR TITLE
Fix an issue where channel deployment wasn't enabled correctly

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/DeploymentChannels/DiscordConfig.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/DeploymentChannels/DiscordConfig.svelte
@@ -3,6 +3,7 @@
   import { ChatCommands } from "@budibase/shared-core"
   import type { Agent, SyncAgentDiscordCommandsResponse } from "@budibase/types"
   import { agentsStore } from "@/stores/portal"
+  import { deploymentStore } from "@/stores/builder"
   import ChannelConfigLayout from "./ChannelConfigLayout.svelte"
   import {
     DEFAULT_IDLE_TIMEOUT_MINUTES,
@@ -134,6 +135,9 @@
     try {
       await saveDiscordIntegration()
       syncResult = await agentsStore.syncDiscordCommands(agent._id)
+      if (agent.live) {
+        await deploymentStore.publishApp()
+      }
       notifications.success("Discord channel enabled")
     } catch (error) {
       console.error(error)

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/DeploymentChannels/MicrosoftTeamsConfig.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/DeploymentChannels/MicrosoftTeamsConfig.svelte
@@ -6,6 +6,7 @@
     ProvisionAgentMSTeamsChannelResponse,
   } from "@budibase/types"
   import { agentsStore } from "@/stores/portal"
+  import { deploymentStore } from "@/stores/builder"
   import ChannelConfigLayout from "./ChannelConfigLayout.svelte"
   import {
     DEFAULT_IDLE_TIMEOUT_MINUTES,
@@ -86,6 +87,9 @@
         },
       })
       provisionResult = await agentsStore.provisionMSTeamsChannel(agent._id)
+      if (agent.live) {
+        await deploymentStore.publishApp()
+      }
       notifications.success("Microsoft Teams channel settings saved")
     } catch (error) {
       console.error(error)

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/DeploymentChannels/SlackConfig.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/DeploymentChannels/SlackConfig.svelte
@@ -6,6 +6,7 @@
     ProvisionAgentSlackChannelResponse,
   } from "@budibase/types"
   import { agentsStore } from "@/stores/portal"
+  import { deploymentStore } from "@/stores/builder"
   import ChannelConfigLayout from "./ChannelConfigLayout.svelte"
   import {
     DEFAULT_IDLE_TIMEOUT_MINUTES,
@@ -75,6 +76,9 @@
         },
       })
       provisionResult = await agentsStore.provisionSlackChannel(agent._id)
+      if (agent.live) {
+        await deploymentStore.publishApp()
+      }
       notifications.success("Slack channel settings saved")
     } catch (error) {
       console.error(error)

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/deployment.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/deployment.svelte
@@ -16,6 +16,7 @@
     type DeploymentRow,
   } from "@budibase/types"
   import { selectedAgent, agentsStore, featureFlags } from "@/stores/portal"
+  import { deploymentStore } from "@/stores/builder"
   import AgentChatChannel from "./DeploymentChannels/AgentChatChannel.svelte"
   import DiscordConfig from "./DeploymentChannels/DiscordConfig.svelte"
   import MicrosoftTeamsConfig from "./DeploymentChannels/MicrosoftTeamsConfig.svelte"
@@ -151,12 +152,15 @@
     toggling = true
     try {
       const provider = DEPLOYMENT_ID_TO_PROVIDER[channel.id]
+      let channelUpdated = false
       if (provider === AgentChannelProvider.DISCORD) {
         if (isChannelEnabled) {
           await agentsStore.toggleDiscordDeployment(currentAgent._id, false)
+          channelUpdated = true
           notifications.success("Discord channel disabled")
         } else if (discordConfigured) {
           await agentsStore.toggleDiscordDeployment(currentAgent._id, true)
+          channelUpdated = true
           notifications.success("Discord channel enabled")
         } else {
           discordModal?.show()
@@ -164,9 +168,11 @@
       } else if (provider === AgentChannelProvider.MSTEAMS) {
         if (isChannelEnabled) {
           await agentsStore.toggleMSTeamsDeployment(currentAgent._id, false)
+          channelUpdated = true
           notifications.success("Microsoft Teams channel disabled")
         } else if (MSTeamsConfigured) {
           await agentsStore.toggleMSTeamsDeployment(currentAgent._id, true)
+          channelUpdated = true
           notifications.success("Microsoft Teams channel enabled")
         } else {
           MSTeamsModal?.show()
@@ -174,13 +180,19 @@
       } else if (provider === AgentChannelProvider.SLACK) {
         if (isChannelEnabled) {
           await agentsStore.toggleSlackDeployment(currentAgent._id, false)
+          channelUpdated = true
           notifications.success("Slack channel disabled")
         } else if (slackConfigured) {
           await agentsStore.toggleSlackDeployment(currentAgent._id, true)
+          channelUpdated = true
           notifications.success("Slack channel enabled")
         } else {
           slackModal?.show()
         }
+      }
+
+      if (channelUpdated && currentAgent.live) {
+        await deploymentStore.publishApp()
       }
     } catch (e) {
       notifications.error(

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -68,6 +68,17 @@ const getEnabledChatAgentConfig = (chatApp: ChatApp, agentId: string) => {
   return chatAgentConfig
 }
 
+const getConfiguredChatAgentConfig = (chatApp: ChatApp, agentId: string) => {
+  const chatAgentConfig = chatApp.agents?.find(
+    agent => agent.agentId === agentId
+  )
+  if (!chatAgentConfig) {
+    throw new HTTPError("agentId is not configured for this chat app", 400)
+  }
+
+  return chatAgentConfig
+}
+
 const assertCanAccessChatAgent = async (
   ctx: UserCtx,
   chatAgentConfig: NonNullable<NonNullable<ChatApp["agents"]>[number]>
@@ -270,7 +281,7 @@ export async function webhookChat({
     throw new HTTPError("agentId is required", 400)
   }
 
-  getEnabledChatAgentConfig(chatApp, agentId)
+  getConfiguredChatAgentConfig(chatApp, agentId)
   const agent = await sdk.ai.agents.getOrThrow(agentId)
   const providerPrefix = chat.channel?.provider || "chat"
   const chatId = chat._id ?? docIds.generateChatConversationID()

--- a/packages/server/src/api/routes/tests/ai/agentDiscord.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentDiscord.spec.ts
@@ -3,6 +3,7 @@ import nock from "nock"
 import { db, encryption } from "@budibase/backend-core"
 import { ChatCommands } from "@budibase/shared-core"
 import type { Agent } from "@budibase/types"
+import sdk from "../../../../sdk"
 import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
 
 const DISCORD_PUBLIC_KEY_DER_PREFIX = "302a300506032b6570032100"
@@ -60,6 +61,11 @@ describe("agent discord integration sync", () => {
     }
     return result
   }
+
+  const getPersistedChatApp = async () =>
+    await config.doInContext(config.getDevWorkspaceId(), async () => {
+      return await sdk.ai.chatApps.getSingle()
+    })
 
   beforeEach(async () => {
     await config.newTenant()
@@ -149,6 +155,13 @@ describe("agent discord integration sync", () => {
     expect(result.inviteUrl).toContain("client_id=app-123")
     expect(globalScope.isDone()).toBe(true)
     expect(guildScope.isDone()).toBe(true)
+
+    const chatApp = await getPersistedChatApp()
+    expect(chatApp?.agents).toContainEqual({
+      agentId: agent._id,
+      isEnabled: false,
+      isDefault: false,
+    })
   })
 
   it("obfuscates discord secrets in responses and preserves them on update", async () => {

--- a/packages/server/src/api/routes/tests/ai/agentSlack.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentSlack.spec.ts
@@ -89,6 +89,11 @@ describe("agent slack integration provisioning", () => {
     return result
   }
 
+  const getPersistedChatApp = async () =>
+    await config.doInContext(config.getDevWorkspaceId(), async () => {
+      return await sdk.ai.chatApps.getSingle()
+    })
+
   beforeEach(async () => {
     await config.newTenant()
     mockedWebhookChat.mockClear()
@@ -125,6 +130,13 @@ describe("agent slack integration provisioning", () => {
     expect(updated?.slackIntegration?.messagingEndpointUrl).toEqual(
       result.messagingEndpointUrl
     )
+
+    const chatApp = await getPersistedChatApp()
+    expect(chatApp?.agents).toContainEqual({
+      agentId: agent._id,
+      isEnabled: false,
+      isDefault: false,
+    })
   })
 
   it("obfuscates slack secrets in responses and preserves them on update", async () => {

--- a/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
@@ -117,6 +117,36 @@ describe("agent teams integration provisioning", () => {
     })
   })
 
+  it("preserves internal agent chat state when provisioning teams", async () => {
+    const agent = await config.api.agent.create({
+      name: "Teams Agent With Internal Chat",
+      MSTeamsIntegration: {
+        appId: "teams-app-id",
+        appPassword: "teams-app-password",
+        tenantId: "azure-tenant-id",
+      },
+    })
+
+    await config.doInContext(config.getDevWorkspaceId(), async () => {
+      const db = context.getWorkspaceDB()
+      await db.put({
+        _id: docIds.generateChatAppID(),
+        agents: [{ agentId: agent._id!, isEnabled: true, isDefault: true }],
+        live: true,
+        createdAt: new Date().toISOString(),
+      })
+    })
+
+    await config.api.agent.provisionMSTeamsChannel(agent._id!)
+
+    const chatApp = await getPersistedChatApp()
+    expect(chatApp?.agents).toContainEqual({
+      agentId: agent._id,
+      isEnabled: true,
+      isDefault: true,
+    })
+  })
+
   it("obfuscates teams secrets in responses and preserves them on update", async () => {
     const created = await config.api.agent.create({
       name: "Teams Obfuscation Agent",

--- a/packages/server/src/sdk/workspace/ai/deployments/shared.ts
+++ b/packages/server/src/sdk/workspace/ai/deployments/shared.ts
@@ -15,17 +15,48 @@ export const WEBHOOK_PATH_BY_PROVIDER: Record<AgentChannelProvider, string> = {
   [AgentChannelProvider.SLACK]: "slack",
 }
 
-const ensureAgentOnChatApp = async (chatApp: ChatApp, agentId: string) => {
+const normalizeDefaultAgent = (agents: NonNullable<ChatApp["agents"]>) => {
+  const defaultAgentId =
+    agents.find(agent => agent.isEnabled && agent.isDefault)?.agentId ||
+    agents.find(agent => agent.isEnabled)?.agentId
+
+  return agents.map(agent => ({
+    ...agent,
+    isDefault: !!defaultAgentId && agent.agentId === defaultAgentId,
+  }))
+}
+
+const ensureAgentOnChatApp = async (
+  chatApp: ChatApp,
+  agentId: string,
+  isEnabled?: boolean
+) => {
   const existingAgents = chatApp.agents || []
   const existing = existingAgents.find(agent => agent.agentId === agentId)
   if (existing) {
-    return chatApp
+    if (isEnabled === undefined || existing.isEnabled === isEnabled) {
+      return chatApp
+    }
+
+    const updatedAgents = normalizeDefaultAgent(
+      existingAgents.map(agent =>
+        agent.agentId === agentId
+          ? {
+              ...agent,
+              isEnabled,
+              isDefault: isEnabled ? agent.isDefault : false,
+            }
+          : agent
+      )
+    )
+
+    return await chatApps.update({ ...chatApp, agents: updatedAgents })
   }
 
-  const updatedAgents = [
+  const updatedAgents = normalizeDefaultAgent([
     ...existingAgents,
-    { agentId, isEnabled: false, isDefault: false },
-  ]
+    { agentId, isEnabled, isDefault: false },
+  ])
 
   return await chatApps.update({ ...chatApp, agents: updatedAgents })
 }
@@ -54,22 +85,26 @@ export const disableAgentOnChatApp = async ({
 export const resolveChatAppForAgent = async ({
   agentId,
   chatAppId,
+  isEnabled,
 }: {
   agentId: string
   chatAppId?: string
+  isEnabled?: boolean
 }) => {
   if (chatAppId) {
     const app = await chatApps.getOrThrow(chatAppId)
-    return await ensureAgentOnChatApp(app, agentId)
+    return await ensureAgentOnChatApp(app, agentId, isEnabled)
   }
 
   const existing = await chatApps.getSingle()
   if (existing) {
-    return await ensureAgentOnChatApp(existing, agentId)
+    return await ensureAgentOnChatApp(existing, agentId, isEnabled)
   }
 
   return await chatApps.create({
-    agents: [{ agentId, isEnabled: false, isDefault: false }],
+    agents: normalizeDefaultAgent([
+      { agentId, isEnabled: isEnabled === true, isDefault: false },
+    ]),
   })
 }
 

--- a/packages/server/src/sdk/workspace/ai/deployments/shared.ts
+++ b/packages/server/src/sdk/workspace/ai/deployments/shared.ts
@@ -55,7 +55,7 @@ const ensureAgentOnChatApp = async (
 
   const updatedAgents = normalizeDefaultAgent([
     ...existingAgents,
-    { agentId, isEnabled, isDefault: false },
+    { agentId, isEnabled: isEnabled === true, isDefault: false },
   ])
 
   return await chatApps.update({ ...chatApp, agents: updatedAgents })

--- a/packages/server/src/tests/api/chatConversations.spec.ts
+++ b/packages/server/src/tests/api/chatConversations.spec.ts
@@ -1,8 +1,7 @@
 import { context, docIds, features, roles } from "@budibase/backend-core"
-import { DocumentType, FeatureFlag } from "@budibase/types"
+import { AgentChannelProvider, DocumentType, FeatureFlag } from "@budibase/types"
 import type {
   Agent,
-  AgentChannelProvider,
   ChatApp,
   ChatConversation,
   ChatConversationRequest,
@@ -1543,6 +1542,48 @@ describe("Agent chat tool call tracking", () => {
   })
 
   describe("webhookChat", () => {
+    it("allows configured channel deployments when internal agent chat is disabled", async () => {
+      jest
+        .mocked(streamText)
+        .mockImplementation(makeWebhookStreamTextMock([]) as any)
+
+      await context.doInWorkspaceContext(
+        config.getProdWorkspaceId(),
+        async () => {
+          const db = context.getWorkspaceDB()
+          const disabledChatApp: ChatApp = {
+            ...chatApp,
+            _id: docIds.generateChatAppID(),
+            agents: [
+              { agentId: "agent-1", isEnabled: false, isDefault: false },
+            ],
+          }
+          await db.put(disabledChatApp)
+
+          const result = await webhookChat({
+            chat: {
+              chatAppId: disabledChatApp._id!,
+              agentId: "agent-1",
+              channel: {
+                provider: AgentChannelProvider.MSTEAMS,
+                externalUserId: "teams-user-1",
+              },
+              messages: [
+                {
+                  id: "msg-1",
+                  role: "user",
+                  parts: [{ type: "text", text: "hello" }],
+                },
+              ],
+            },
+            user: { _id: "user-1" } as any,
+          })
+
+          expect(result.assistantText).toBe("response")
+        }
+      )
+    })
+
     it("counts each completed tool call as one action", async () => {
       jest
         .mocked(streamText)

--- a/packages/server/src/tests/api/chatConversations.spec.ts
+++ b/packages/server/src/tests/api/chatConversations.spec.ts
@@ -1,5 +1,9 @@
 import { context, docIds, features, roles } from "@budibase/backend-core"
-import { AgentChannelProvider, DocumentType, FeatureFlag } from "@budibase/types"
+import {
+  AgentChannelProvider,
+  DocumentType,
+  FeatureFlag,
+} from "@budibase/types"
 import type {
   Agent,
   ChatApp,


### PR DESCRIPTION
## Description
Teams / slack / discord were inherently linked to the status of Budibase chat. When it was disabled it meant those were also disabled. This delinks the agent deployment from each other. 

<img width="591" height="329" alt="image" src="https://github.com/user-attachments/assets/d9189b5a-b1ca-40f5-b49d-58b32052b546" />
## Launchcontrol

- Fix an issue where Agents where unintentionally disabled in Teams / Slack / Discord deployments


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where Teams, Slack, and Discord deployments were disabled when Budibase Chat was off. Channel setup, toggles, and provisioning now work independently and auto-publish changes to live apps.

- **Bug Fixes**
  - Webhooks validate against configured agents (not only enabled), so external channels work when internal chat is off.
  - Persist agent entries on the ChatApp during provisioning (disabled by default); preserve existing default/enabled state; clear default on disable; normalize to one default.
  - Builder publishes the live app after provisioning or toggling Discord/Slack/Teams to keep deployment state in sync.
  - Added tests for Slack/Discord/Teams provisioning persistence/defaults (including preserving internal chat state) and for webhooks when internal chat is disabled.

<sup>Written for commit a18a6dd22ba34e0f35e719fb3e2344696c98e16a. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18622?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



