### PR TITLE
Improve dropdown sizing in condition builders

### DIFF
--- a/packages/bbui/src/ActionMenu/ActionMenu.svelte
+++ b/packages/bbui/src/ActionMenu/ActionMenu.svelte
@@ -2,7 +2,7 @@
   import { setContext, getContext } from "svelte"
   import Popover from "../Popover/Popover.svelte"
   import Menu from "../Menu/Menu.svelte"
-  import type { PopoverAlignment } from "../constants"
+  import type { PopoverAlignment, PopoverWidthMode } from "../constants"
 
   export let disabled: boolean = false
   export let align: `${PopoverAlignment}` = "left"
@@ -10,7 +10,7 @@
   export let openOnHover: boolean = false
   export let animate: boolean | undefined = true
   export let offset: number | undefined = undefined
-  export let useAnchorWidth = false
+  export let widthMode: PopoverWidthMode = "no-anchor"
   export let roundedPopover: boolean = false
 
   const actionMenuContext = getContext("actionMenu")
@@ -76,7 +76,7 @@
   {portalTarget}
   {animate}
   {offset}
-  {useAnchorWidth}
+  {widthMode}
   resizable={false}
   borderRadius={roundedPopover ? "12px" : undefined}
   on:open

--- a/packages/bbui/src/Actions/positionDropdown.ts
+++ b/packages/bbui/src/Actions/positionDropdown.ts
@@ -31,11 +31,13 @@ interface Opts {
   maxHeight?: number
   maxWidth?: number
   minWidth?: number
+  minAnchorWidth?: boolean
   useAnchorWidth: boolean
   offset: number
   customUpdate?: UpdateHandler
   resizable: boolean
   wrap: boolean
+  onScroll?: () => void
 }
 
 export default function positionDropdown(element: HTMLElement, opts: Opts) {
@@ -44,7 +46,16 @@ export default function positionDropdown(element: HTMLElement, opts: Opts) {
 
   // We need a static reference to this function so that we can properly
   // clean up the scroll listener.
-  const scrollUpdate = () => updatePosition(latestOpts)
+  const scrollUpdate = (event: Event) => {
+    if (event.target instanceof Node && element.contains(event.target)) {
+      return
+    }
+    if (latestOpts.onScroll) {
+      latestOpts.onScroll()
+      return
+    }
+    updatePosition(latestOpts)
+  }
 
   // Updates the position of the dropdown
   const updatePosition = (opts: Opts) => {
@@ -54,6 +65,7 @@ export default function positionDropdown(element: HTMLElement, opts: Opts) {
       maxHeight,
       maxWidth,
       minWidth,
+      minAnchorWidth,
       useAnchorWidth,
       offset = 5,
       customUpdate,
@@ -72,7 +84,7 @@ export default function positionDropdown(element: HTMLElement, opts: Opts) {
     const screenOffset = 8
     let styles: Styles = {
       maxHeight,
-      minWidth: useAnchorWidth ? anchorBounds.width : minWidth,
+      minWidth: useAnchorWidth || minAnchorWidth ? anchorBounds.width : minWidth,
       maxWidth: useAnchorWidth ? anchorBounds.width : maxWidth,
       left: 0,
       top: 0,

--- a/packages/bbui/src/Actions/positionDropdown.ts
+++ b/packages/bbui/src/Actions/positionDropdown.ts
@@ -84,7 +84,8 @@ export default function positionDropdown(element: HTMLElement, opts: Opts) {
     const screenOffset = 8
     let styles: Styles = {
       maxHeight,
-      minWidth: useAnchorWidth || minAnchorWidth ? anchorBounds.width : minWidth,
+      minWidth:
+        useAnchorWidth || minAnchorWidth ? anchorBounds.width : minWidth,
       maxWidth: useAnchorWidth ? anchorBounds.width : maxWidth,
       left: 0,
       top: 0,

--- a/packages/bbui/src/Actions/positionDropdown.ts
+++ b/packages/bbui/src/Actions/positionDropdown.ts
@@ -1,6 +1,6 @@
 // Strategies are defined as [Popover]To[Anchor].
 // They can apply for both horizontal and vertical alignment.
-import { PopoverAlignment } from "../constants"
+import { PopoverAlignment, type PopoverWidthMode } from "../constants"
 
 type Strategy =
   | "StartToStart"
@@ -14,6 +14,7 @@ export interface Styles {
   maxHeight?: number
   minWidth?: number
   maxWidth?: number
+  widthMode: PopoverWidthMode
   offset?: number
   left: number
   top: number
@@ -31,8 +32,7 @@ interface Opts {
   maxHeight?: number
   maxWidth?: number
   minWidth?: number
-  minAnchorWidth?: boolean
-  useAnchorWidth: boolean
+  widthMode: PopoverWidthMode
   offset: number
   customUpdate?: UpdateHandler
   resizable: boolean
@@ -65,8 +65,7 @@ export default function positionDropdown(element: HTMLElement, opts: Opts) {
       maxHeight,
       maxWidth,
       minWidth,
-      minAnchorWidth,
-      useAnchorWidth,
+      widthMode,
       offset = 5,
       customUpdate,
       resizable,
@@ -82,11 +81,13 @@ export default function positionDropdown(element: HTMLElement, opts: Opts) {
     const winWidth = window.innerWidth
     const winHeight = window.innerHeight
     const screenOffset = 8
+    const fixedToAnchor = widthMode === "fixed-to-anchor"
+    const minAnchor = widthMode === "min-to-anchor"
     let styles: Styles = {
       maxHeight,
-      minWidth:
-        useAnchorWidth || minAnchorWidth ? anchorBounds.width : minWidth,
-      maxWidth: useAnchorWidth ? anchorBounds.width : maxWidth,
+      minWidth: fixedToAnchor || minAnchor ? anchorBounds.width : minWidth,
+      maxWidth: fixedToAnchor ? anchorBounds.width : maxWidth,
+      widthMode,
       left: 0,
       top: 0,
     }
@@ -279,6 +280,9 @@ export default function positionDropdown(element: HTMLElement, opts: Opts) {
 
     for (const [key, value] of Object.entries(styles)) {
       const name = key as keyof Styles
+      if (name === "widthMode") {
+        continue
+      }
       if (value != null) {
         element.style[name] = `${value}px`
       } else {

--- a/packages/bbui/src/Form/Combobox.svelte
+++ b/packages/bbui/src/Form/Combobox.svelte
@@ -15,6 +15,8 @@
   export let options: O[] = []
   export let helpText: string | undefined = undefined
   export let required: boolean | undefined = false
+  export let popoverAutoWidth = false
+  export let wrapText = false
 
   const extractProperty = (item: O, property: string): string => {
     if (item && typeof item === "object" && property in item) {
@@ -63,6 +65,8 @@
     {readonly}
     {getOptionLabel}
     {getOptionValue}
+    {popoverAutoWidth}
+    {wrapText}
     on:change={onChange}
     on:pick
     on:type

--- a/packages/bbui/src/Form/Core/Combobox.svelte
+++ b/packages/bbui/src/Form/Core/Combobox.svelte
@@ -114,8 +114,7 @@
   {open}
   align={PopoverAlignment.Left}
   on:close={() => (open = false)}
-  useAnchorWidth={!popoverAutoWidth}
-  minAnchorWidth={popoverAutoWidth}
+  widthMode={popoverAutoWidth ? "min-to-anchor" : "fixed-to-anchor"}
   maxWidth={popoverAutoWidth ? 400 : undefined}
   closeOnScroll
 >

--- a/packages/bbui/src/Form/Core/Combobox.svelte
+++ b/packages/bbui/src/Form/Core/Combobox.svelte
@@ -68,7 +68,6 @@
     dispatch("pick", value)
     selectOption(value)
   }
-
 </script>
 
 <div

--- a/packages/bbui/src/Form/Core/Combobox.svelte
+++ b/packages/bbui/src/Form/Core/Combobox.svelte
@@ -21,6 +21,8 @@
   export let options: O[] = []
   export let getOptionLabel = (option: O) => `${option}`
   export let getOptionValue = (option: O) => `${option}`
+  export let popoverAutoWidth = false
+  export let wrapText = false
 
   const dispatch = createEventDispatcher<{
     change: string
@@ -66,6 +68,7 @@
     dispatch("pick", value)
     selectOption(value)
   }
+
 </script>
 
 <div
@@ -112,10 +115,15 @@
   {open}
   align={PopoverAlignment.Left}
   on:close={() => (open = false)}
-  useAnchorWidth
+  useAnchorWidth={!popoverAutoWidth}
+  minAnchorWidth={popoverAutoWidth}
+  maxWidth={popoverAutoWidth ? 400 : undefined}
+  closeOnScroll
 >
   <div
     class="popover-content"
+    class:auto-width={popoverAutoWidth}
+    class:wrap-text={wrapText}
     use:clickOutside={() => {
       open = false
     }}
@@ -174,6 +182,25 @@
   }
   .popover-content:not(.auto-width) .spectrum-Menu-itemLabel {
     width: 0;
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .popover-content.auto-width .spectrum-Menu-item {
+    padding-right: var(--spacing-xl);
+  }
+  .popover-content.wrap-text .spectrum-Menu-item {
+    height: auto;
+    min-height: var(--spectrum-menu-item-height);
+    align-items: flex-start;
+  }
+  .popover-content.wrap-text .spectrum-Menu-itemLabel {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: unset;
+    overflow-wrap: anywhere;
+    width: auto;
     flex: 1 1 auto;
   }
 </style>

--- a/packages/bbui/src/Form/Core/DatePicker/DatePicker.svelte
+++ b/packages/bbui/src/Form/Core/DatePicker/DatePicker.svelte
@@ -77,7 +77,7 @@
   portalTarget={appendTo}
   {anchor}
   {align}
-  useAnchorWidth={timeOnly}
+  widthMode={timeOnly ? "fixed-to-anchor" : "no-anchor"}
   resizable={false}
 >
   {#if isOpen}

--- a/packages/bbui/src/Form/Core/Multiselect.svelte
+++ b/packages/bbui/src/Form/Core/Multiselect.svelte
@@ -18,6 +18,7 @@
   export let autocomplete: boolean = false
   export let sort: boolean = false
   export let autoWidth: boolean = false
+  export let popoverAutoWidth: boolean = false
   export let searchTerm: string | null = null
   export let customPopoverHeight: string | undefined = undefined
   export let open: boolean = false
@@ -140,6 +141,7 @@
   onSelectOption={toggleOption}
   {sort}
   {autoWidth}
+  {popoverAutoWidth}
   {customPopoverHeight}
   {loading}
   {onOptionMouseenter}

--- a/packages/bbui/src/Form/Core/Picker.svelte
+++ b/packages/bbui/src/Form/Core/Picker.svelte
@@ -280,8 +280,7 @@
   align={align || PopoverAlignment.Left}
   {open}
   on:close={() => (open = false)}
-  useAnchorWidth={!effectivePopoverAutoWidth}
-  minAnchorWidth={effectivePopoverAutoWidth}
+  widthMode={effectivePopoverAutoWidth ? "min-to-anchor" : "fixed-to-anchor"}
   maxWidth={effectivePopoverAutoWidth ? 400 : undefined}
   customHeight={customPopoverHeight}
   {maxHeight}

--- a/packages/bbui/src/Form/Core/Picker.svelte
+++ b/packages/bbui/src/Form/Core/Picker.svelte
@@ -55,6 +55,7 @@
   export let readonly: boolean = false
   export let quiet: boolean = false
   export let autoWidth: boolean | undefined = false
+  export let popoverAutoWidth: boolean | undefined = false
   export let autocomplete: boolean = false
   export let sort: boolean = false
   export let searchTerm: string | null = null
@@ -93,6 +94,7 @@
   let virtualPaddingTop = 0
   let virtualPaddingBottom = 0
 
+  $: effectivePopoverAutoWidth = autoWidth || popoverAutoWidth
   const resolveIcon = (icon: PickerIconInput): ResolvedIcon | null => {
     if (!icon) {
       return null
@@ -278,14 +280,16 @@
   align={align || PopoverAlignment.Left}
   {open}
   on:close={() => (open = false)}
-  useAnchorWidth={!autoWidth}
-  maxWidth={autoWidth ? 400 : undefined}
+  useAnchorWidth={!effectivePopoverAutoWidth}
+  minAnchorWidth={effectivePopoverAutoWidth}
+  maxWidth={effectivePopoverAutoWidth ? 400 : undefined}
   customHeight={customPopoverHeight}
   {maxHeight}
+  closeOnScroll
 >
   <div
     class="popover-content"
-    class:auto-width={autoWidth}
+    class:auto-width={effectivePopoverAutoWidth}
     class:wrap-text={wrapText}
     class:size-s={size === "S"}
     class:size-m={size === "M"}

--- a/packages/bbui/src/Form/Core/Select.svelte
+++ b/packages/bbui/src/Form/Core/Select.svelte
@@ -37,6 +37,7 @@
   export let quiet: boolean = false
   export let bordered: boolean = true
   export let autoWidth: boolean = false
+  export let popoverAutoWidth: boolean = false
   export let autocomplete: boolean = false
   export let sort: boolean = false
   export let align: PopoverAlignment | undefined = PopoverAlignment.Left
@@ -122,6 +123,7 @@
   {fieldColour}
   {options}
   {autoWidth}
+  {popoverAutoWidth}
   {align}
   {footer}
   {getOptionLabel}

--- a/packages/bbui/src/Form/Multiselect.svelte
+++ b/packages/bbui/src/Form/Multiselect.svelte
@@ -20,6 +20,7 @@
   ) => option
   export let sort = false
   export let autoWidth = false
+  export let popoverAutoWidth = false
   export let autocomplete = false
   export let searchTerm: string | undefined = undefined
   export let customPopoverHeight: string | undefined = undefined
@@ -48,6 +49,7 @@
     {getOptionLabel}
     {getOptionValue}
     {autoWidth}
+    {popoverAutoWidth}
     {autocomplete}
     {customPopoverHeight}
     {onOptionMouseenter}

--- a/packages/bbui/src/Form/Select.svelte
+++ b/packages/bbui/src/Form/Select.svelte
@@ -37,6 +37,7 @@
   export let size: "S" | "M" | "L" = "M"
   export let bordered: boolean = true
   export let autoWidth: boolean = false
+  export let popoverAutoWidth: boolean = false
   export let sort: boolean = false
   export let tooltip: string | undefined = undefined
   export let tooltipMessage:
@@ -92,6 +93,7 @@
     {options}
     {placeholder}
     {autoWidth}
+    {popoverAutoWidth}
     {sort}
     {align}
     {footer}

--- a/packages/bbui/src/Popover/Popover.svelte
+++ b/packages/bbui/src/Popover/Popover.svelte
@@ -15,7 +15,7 @@
   import positionDropdown, {
     type UpdateHandler,
   } from "../Actions/positionDropdown"
-  import { PopoverAlignment } from "../constants"
+  import { PopoverAlignment, type PopoverWidthMode } from "../constants"
   import Context from "../context"
 
   export let anchor: HTMLElement | undefined
@@ -23,12 +23,11 @@
     PopoverAlignment.Right
   export let portalTarget: string | undefined = undefined
   export let minWidth: number | undefined = undefined
-  export let minAnchorWidth = false
   export let maxWidth: number | undefined = undefined
   export let maxHeight: number | undefined = undefined
   export let borderRadius: string | undefined = undefined
   export let open = false
-  export let useAnchorWidth = false
+  export let widthMode: PopoverWidthMode = "no-anchor"
   export let dismissible = true
   export let offset = 4
   export let customHeight: string | undefined = undefined
@@ -129,8 +128,7 @@
         maxHeight,
         maxWidth,
         minWidth,
-        minAnchorWidth,
-        useAnchorWidth,
+        widthMode,
         offset,
         customUpdate: handlePositionUpdate,
         resizable,

--- a/packages/bbui/src/Popover/Popover.svelte
+++ b/packages/bbui/src/Popover/Popover.svelte
@@ -23,6 +23,7 @@
     PopoverAlignment.Right
   export let portalTarget: string | undefined = undefined
   export let minWidth: number | undefined = undefined
+  export let minAnchorWidth = false
   export let maxWidth: number | undefined = undefined
   export let maxHeight: number | undefined = undefined
   export let borderRadius: string | undefined = undefined
@@ -38,6 +39,7 @@
   export let clickOutsideOverride = false
   export let resizable = true
   export let wrap = false
+  export let closeOnScroll = false
 
   const dispatch = createEventDispatcher<{ open: void; close: void }>()
   const animationDuration = 260
@@ -127,11 +129,13 @@
         maxHeight,
         maxWidth,
         minWidth,
+        minAnchorWidth,
         useAnchorWidth,
         offset,
         customUpdate: handlePositionUpdate,
         resizable,
         wrap,
+        onScroll: closeOnScroll ? hide : undefined,
       }}
       use:clickOutside={{
         callback: dismissible ? handleOutsideClick : () => {},

--- a/packages/bbui/src/constants.ts
+++ b/packages/bbui/src/constants.ts
@@ -8,6 +8,8 @@ export enum PopoverAlignment {
   LeftContextMenu = "left-context-menu",
 }
 
+export type PopoverWidthMode = "no-anchor" | "min-to-anchor" | "fixed-to-anchor"
+
 export enum TooltipPosition {
   Top = "top",
   Right = "right",

--- a/packages/builder/src/components/automation/SetupPanel/RowSelector.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/RowSelector.svelte
@@ -351,7 +351,7 @@
   align="left"
   bind:this={customPopover}
   anchor={editableFields ? popoverAnchor : null}
-  useAnchorWidth
+  widthMode="fixed-to-anchor"
   maxHeight={300}
   resizable={false}
 >

--- a/packages/builder/src/components/design/settings/controls/ButtonConditionEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonConditionEditor.svelte
@@ -300,12 +300,14 @@
                   placeholder={false}
                   options={actionOptions}
                   bind:value={condition.action}
+                  popoverAutoWidth
                 />
                 {#if condition.action === "update"}
                   <Select
                     options={settingOptions}
                     bind:value={condition.setting}
                     on:change={e => onSettingChange(e, condition)}
+                    popoverAutoWidth
                   />
                   <div>TO</div>
                   {#if definition}
@@ -341,6 +343,7 @@
                   options={getOperatorOptions(condition)}
                   bind:value={condition.operator}
                   on:change={e => onOperatorChange(condition, e.detail)}
+                  popoverAutoWidth
                 />
                 <Select
                   disabled={condition.noValue || condition.operator === "oneOf"}
@@ -348,6 +351,7 @@
                   bind:value={condition.valueType}
                   placeholder={false}
                   on:change={e => onValueTypeChange(condition, e.detail)}
+                  popoverAutoWidth
                 />
                 {#if ["string", "number"].includes(condition.valueType)}
                   <DrawerBindableInput
@@ -369,6 +373,7 @@
                     disabled={condition.noValue}
                     options={["True", "False"]}
                     bind:value={condition.referenceValue}
+                    popoverAutoWidth
                   />
                 {/if}
                 <Icon

--- a/packages/builder/src/components/design/settings/controls/ButtonConfiguration/ButtonConfiguration.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonConfiguration/ButtonConfiguration.svelte
@@ -137,7 +137,12 @@
   </div>
 </div>
 
-<Popover bind:this={popover} {anchor} useAnchorWidth resizable={false}>
+<Popover
+  bind:this={popover}
+  {anchor}
+  widthMode="fixed-to-anchor"
+  resizable={false}
+>
   <Menu>
     <MenuItem on:click={addCustomButton}>Custom button</MenuItem>
     {#each rowActionTemplates as template}

--- a/packages/builder/src/components/design/settings/controls/TableConditionEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/TableConditionEditor.svelte
@@ -183,11 +183,13 @@
                   placeholder={null}
                   options={targetOptions}
                   bind:value={condition.target}
+                  popoverAutoWidth
                 />
                 <Select
                   placeholder={null}
                   options={conditionOptions}
                   bind:value={condition.metadataKey}
+                  popoverAutoWidth
                 />
                 <span>to</span>
                 <ColorPicker
@@ -200,6 +202,7 @@
                   options={operatorOptions}
                   bind:value={condition.operator}
                   on:change={e => onOperatorChange(condition, e.detail)}
+                  popoverAutoWidth
                 />
                 {#if hasValueOption}
                   <Select
@@ -208,6 +211,7 @@
                     bind:value={condition.valueType}
                     placeholder={null}
                     on:change={() => onValueTypeChange(condition)}
+                    popoverAutoWidth
                   />
                 {/if}
                 {#if type === FieldType.DATETIME && condition.valueType === type}
@@ -222,6 +226,7 @@
                     disabled={condition.noValue}
                     options={["True", "False"]}
                     bind:value={condition.referenceValue}
+                    popoverAutoWidth
                   />
                 {:else if (type === FieldType.OPTIONS || type === FieldType.ARRAY) && condition.valueType === type}
                   {#if condition.operator === Constants.OperatorOptions.In.value}
@@ -231,6 +236,7 @@
                         componentInstance.field
                       ]?.constraints?.inclusion || []}
                       bind:value={condition.referenceValue}
+                      popoverAutoWidth
                     />
                   {:else}
                     <Combobox
@@ -239,6 +245,8 @@
                         componentInstance.field
                       ]?.constraints?.inclusion || []}
                       bind:value={condition.referenceValue}
+                      popoverAutoWidth
+                      wrapText
                     />
                   {/if}
                 {:else if (type === FieldType.BB_REFERENCE || type === FieldType.BB_REFERENCE_SINGLE) && condition.valueType === type}

--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Component/ConditionalUIDrawer.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Component/ConditionalUIDrawer.svelte
@@ -207,12 +207,14 @@
                 placeholder={false}
                 options={finalActionOptions}
                 bind:value={condition.action}
+                popoverAutoWidth
               />
               {#if condition.action === "update"}
                 <Select
                   options={settingOptions}
                   bind:value={condition.setting}
                   on:change={e => onSettingChange(e, condition)}
+                  popoverAutoWidth
                 />
                 <div>TO</div>
                 {#if definition}
@@ -248,6 +250,7 @@
                 options={getOperatorOptions(condition)}
                 bind:value={condition.operator}
                 on:change={e => onOperatorChange(condition, e.detail)}
+                popoverAutoWidth
               />
               <Select
                 disabled={condition.noValue || condition.operator === "oneOf"}
@@ -255,6 +258,7 @@
                 bind:value={condition.valueType}
                 placeholder={false}
                 on:change={e => onValueTypeChange(condition, e.detail)}
+                popoverAutoWidth
               />
               {#if ["string", "number"].includes(condition.valueType)}
                 <DrawerBindableInput
@@ -276,6 +280,7 @@
                   disabled={condition.noValue}
                   options={["True", "False"]}
                   bind:value={condition.referenceValue}
+                  popoverAutoWidth
                 />
               {/if}
               <Icon

--- a/packages/frontend-core/src/components/CoreFilterBuilder.svelte
+++ b/packages/frontend-core/src/components/CoreFilterBuilder.svelte
@@ -304,6 +304,7 @@
                 })
               }}
               placeholder={false}
+              popoverAutoWidth
             />
           </span>
           <span>of the following {builderType} groups:</span>
@@ -333,6 +334,7 @@
                         })
                       }}
                       placeholder={false}
+                      popoverAutoWidth
                     />
                   </span>
                   <span>of the following {builderType}s are matched:</span>
@@ -376,6 +378,7 @@
                           onFilterFieldUpdate(updated, groupIdx, filterIdx)
                         }}
                         placeholder="Column"
+                        popoverAutoWidth
                       />
                     {:else}
                       <ConditionField
@@ -406,6 +409,7 @@
                         onFilterFieldUpdate(updated, groupIdx, filterIdx)
                       }}
                       placeholder={false}
+                      popoverAutoWidth
                     />
                     <FilterField
                       placeholder="Value"
@@ -471,6 +475,7 @@
                     })
                   }}
                   placeholder={false}
+                  popoverAutoWidth
                 />
               </span>
               <span>when all {builderType}s are empty</span>

--- a/packages/frontend-core/src/components/FilterField.svelte
+++ b/packages/frontend-core/src/components/FilterField.svelte
@@ -188,6 +188,7 @@
               disabled={filter.noValue}
               options={getFieldOptions(filter.field)}
               value={readableValue}
+              popoverAutoWidth
               on:change={onChange}
             />
           {:else if filter.type === FieldType.OPTIONS}
@@ -195,6 +196,8 @@
               disabled={filter.noValue}
               options={getFieldOptions(filter.field)}
               value={readableValue}
+              popoverAutoWidth
+              wrapText
               on:change={onChange}
             />
           {:else if filter.type === FieldType.BOOLEAN}
@@ -205,6 +208,7 @@
                 { label: "False", value: "false" },
               ]}
               value={readableValue}
+              popoverAutoWidth
               on:change={onChange}
             />
           {:else if filter.type === FieldType.DATETIME}

--- a/packages/frontend-core/src/components/FilterUsers.svelte
+++ b/packages/frontend-core/src/components/FilterUsers.svelte
@@ -36,5 +36,6 @@
     getOptionValue={option => option._id}
     {disabled}
     searchPlaceholder={pickerLabels.searchPlaceholder}
+    popoverAutoWidth
   />
 </div>


### PR DESCRIPTION
## Description
- Improves dropdown sizing in filtering and conditional logic panels. Compact pickers can now allow their popovers to size to content up to a maximum width, while keeping selected/placeholder text truncated in the picker itself.
- Picker popovers also close when scrolling outside them to avoid detached popovers after horizontal drawer scrolling. (*This was a different bug I just happened to notice and fix*)

## Addresses
- https://github.com/Budibase/budibase/issues/17467

## Screenshots
<img width="433" height="473" alt="expand if needed" src="https://github.com/user-attachments/assets/0a1c6c68-8a9d-4b23-9a3b-2fcf55fdba7f" />

**Expand if needed**

<img width="337" height="308" alt="dont expand if not needed" src="https://github.com/user-attachments/assets/2a6074cd-ccd3-48fe-bf3d-6374b426728a" />

**Keep flush if it fits**

## Launchcontrol
Dropdowns in filter and condition panels are easier to read and no longer remain open after scrolling the surrounding panel.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves dropdowns in filter and condition builders by auto-sizing popovers to content, supporting wrapped labels, and closing popovers on outside scroll (ignores inner-popover scroll). Standardizes popover width behavior with a new width mode across popovers and menus.

- **New Features**
  - Added `popoverAutoWidth` to `Select`, `Combobox`, `Multiselect`, and `Picker` so popovers auto-size up to 400px while the control keeps truncated text.
  - Added `wrapText` for `Combobox` (also supported in `Picker`) to show long labels on multiple lines.
  - Enabled `popoverAutoWidth` (and `wrapText` where needed) across condition and filter UIs for clearer option labels.

- **Refactors**
  - Replaced `useAnchorWidth`/`autoWidth` flags with `widthMode` (`no-anchor` | `min-to-anchor` | `fixed-to-anchor`) across `Popover`, `ActionMenu`, and pickers for consistent sizing rules; added `closeOnScroll` handling and ignored inner-popover scrolls.

<sup>Written for commit 5ee162d98bdc535a0633e99a8f012b881217ae06. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18623?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



