### PR TITLE
Improve Teams chat progress feedback

### DIFF
--- a/packages/server/__mocks__/chat.ts
+++ b/packages/server/__mocks__/chat.ts
@@ -9,11 +9,17 @@ interface MockCardElement {
   [key: string]: unknown
 }
 
+interface MockSentMessage {
+  edit: (message: unknown) => Promise<MockSentMessage>
+}
+
 interface ChatOptions {
   userName?: string
   adapters?: Record<string, unknown>
   state?: unknown
   logger?: string
+  fallbackStreamingPlaceholderText?: string | null
+  streamingUpdateIntervalMs?: number
 }
 
 const defaultPostEphemeralResult = (): MockPostEphemeralResult => ({
@@ -24,16 +30,28 @@ const mockWebhookState: Record<MockProvider, MockPostEphemeralResult> = {
   slack: defaultPostEphemeralResult(),
   teams: defaultPostEphemeralResult(),
 }
+const mockChatOptions: ChatOptions[] = []
 
 const toMessageText = (value: unknown) =>
   typeof value === "string" ? value : JSON.stringify(value)
+
+const createSentMessage = (
+  messages: string[],
+  index: number
+): MockSentMessage => ({
+  edit: async (message: unknown) => {
+    messages[index] = toMessageText(message)
+    return createSentMessage(messages, index)
+  },
+})
 
 const createMessageCollector = (
   provider: MockProvider,
   messages: string[]
 ) => ({
   post: async (message: unknown) => {
-    messages.push(toMessageText(message))
+    const index = messages.push(toMessageText(message)) - 1
+    return createSentMessage(messages, index)
   },
   postEphemeral: async (
     _user: unknown,
@@ -116,6 +134,7 @@ const invokeHandlers = async (
 export const resetMockChatState = () => {
   mockWebhookState.slack = defaultPostEphemeralResult()
   mockWebhookState.teams = defaultPostEphemeralResult()
+  mockChatOptions.length = 0
 }
 
 export const setMockPostEphemeralResult = (
@@ -124,6 +143,8 @@ export const setMockPostEphemeralResult = (
 ) => {
   mockWebhookState[provider] = result
 }
+
+export const getMockChatOptions = () => mockChatOptions
 
 export class ConsoleLogger {
   level: string
@@ -149,6 +170,7 @@ export class Chat {
   }
 
   constructor(_options: ChatOptions) {
+    mockChatOptions.push(_options)
     this.adapters = _options.adapters || {}
     const discordPublicKey = String(
       (_options.adapters?.discord as { publicKey?: string } | undefined)
@@ -250,6 +272,7 @@ export class Chat {
           id: body.threadId || body.conversation?.id || "teams:thread-1",
           ...createMessageCollector("teams", messages),
           subscribe: async () => {},
+          startTyping: async () => {},
         }
         const isMention = isTeamsMentionActivity(body)
         const message = {
@@ -445,14 +468,15 @@ export interface Thread {
   channelId?: string
   channel?: {
     id?: string
-    post: (message: string | MockCardElement) => Promise<void>
+    post: (message: string | MockCardElement) => Promise<MockSentMessage>
     postEphemeral?: (
       user: string | { userId?: string },
       message: string | MockCardElement,
       options: { fallbackToDM: boolean }
     ) => Promise<{ usedFallback: boolean } | null>
   }
-  post: (message: string | MockCardElement) => Promise<void>
+  post: (message: string | MockCardElement) => Promise<MockSentMessage>
+  startTyping?: () => Promise<void>
   subscribe?: () => Promise<void>
   postEphemeral?: (
     user: string | { userId?: string },
@@ -470,7 +494,7 @@ export interface SlashCommandEvent {
     userName?: string
   }
   channel: {
-    post: (message: string | MockCardElement) => Promise<void>
+    post: (message: string | MockCardElement) => Promise<MockSentMessage>
     postEphemeral?: (
       user: string | { userId?: string },
       message: string | MockCardElement,

--- a/packages/server/src/api/controllers/webhook/ms-teams.ts
+++ b/packages/server/src/api/controllers/webhook/ms-teams.ts
@@ -133,15 +133,6 @@ export const isTeamsMentionActivity = (activity?: MSTeamsActivity) => {
   )
 }
 
-const shouldShowTeamsProgress = ({
-  command,
-  content,
-}: {
-  command: SupportedChatCommand
-  content: string
-}) =>
-  command === ChatCommands.ASK || (command === ChatCommands.NEW && !!content)
-
 const createTeamsMessageHandler = ({
   workspaceId,
   chatAppId,
@@ -214,7 +205,9 @@ const createTeamsMessageHandler = ({
       externalUserId,
     }
 
-    const shouldShowProgress = shouldShowTeamsProgress({ command, content })
+    const shouldShowProgress =
+      command === ChatCommands.ASK ||
+      (command === ChatCommands.NEW && !!content)
     let progressMessage: SentMessage | undefined
     let hasUsedProgressMessage = false
     let delayTimer: ReturnType<typeof setTimeout> | undefined

--- a/packages/server/src/api/controllers/webhook/ms-teams.ts
+++ b/packages/server/src/api/controllers/webhook/ms-teams.ts
@@ -7,7 +7,7 @@ import {
   type MSTeamsActivity,
   type MSTeamsConversationScope,
 } from "@budibase/types"
-import { Chat, type Thread, type Message } from "chat"
+import { Chat, type Thread, type Message, type SentMessage } from "chat"
 import { createTeamsAdapter } from "@chat-adapter/teams"
 import sdk from "../../../sdk"
 import { handleChatMessage } from "./chatHandler"
@@ -17,6 +17,11 @@ import { runChatWebhook } from "./runChatWebhook"
 
 const TEAMS_FALLBACK_ERROR_MESSAGE =
   "Sorry, something went wrong while processing your request."
+const TEAMS_PROCESSING_MESSAGE = "Got it. I'm working on it..."
+const TEAMS_DELAY_MESSAGE =
+  "Still working. This is taking a little longer than usual..."
+const TEAMS_DELAY_MS = 10_000
+const TEAMS_STREAMING_UPDATE_INTERVAL_MS = 750
 
 export const stripTeamsMentions = (
   text: string,
@@ -128,6 +133,14 @@ export const isTeamsMentionActivity = (activity?: MSTeamsActivity) => {
   )
 }
 
+const shouldShowTeamsProgress = ({
+  command,
+  content,
+}: {
+  command: SupportedChatCommand
+  content: string
+}) => command === ChatCommands.ASK || (command === ChatCommands.NEW && !!content)
+
 const createTeamsMessageHandler = ({
   workspaceId,
   chatAppId,
@@ -200,13 +213,61 @@ const createTeamsMessageHandler = ({
       externalUserId,
     }
 
+    const shouldShowProgress = shouldShowTeamsProgress({ command, content })
+    let progressMessage: SentMessage | undefined
+    let hasUsedProgressMessage = false
+    let delayTimer: ReturnType<typeof setTimeout> | undefined
+    let delayUpdateInFlight: Promise<void> | undefined
+
+    const clearDelayTimer = () => {
+      if (delayTimer) {
+        clearTimeout(delayTimer)
+        delayTimer = undefined
+      }
+    }
+
+    const editOrPost = async (text: string) => {
+      if (progressMessage && !hasUsedProgressMessage) {
+        clearDelayTimer()
+        await delayUpdateInFlight
+        hasUsedProgressMessage = true
+        progressMessage = await progressMessage.edit(text)
+        return
+      }
+      await thread.post(text)
+    }
+
     try {
       await thread.subscribe()
+
+      if (shouldShowProgress) {
+        const typingThread = thread as Thread & {
+          startTyping?: () => Promise<void>
+        }
+        await typingThread.startTyping?.()
+        progressMessage = await thread.post(TEAMS_PROCESSING_MESSAGE)
+        delayTimer = setTimeout(() => {
+          if (!progressMessage || hasUsedProgressMessage) {
+            return
+          }
+          delayUpdateInFlight = progressMessage
+            .edit(TEAMS_DELAY_MESSAGE)
+            .then(updatedMessage => {
+              progressMessage = updatedMessage
+            })
+            .catch(error => {
+              console.error("Teams progress update failed", error)
+            })
+        }, TEAMS_DELAY_MS)
+      }
 
       await handleChatMessage({
         reply: async (text: string) => {
           const chunks = splitTeamsMessage(text)
-          for (const chunk of chunks) {
+          const firstChunk = chunks[0] || "No response generated."
+          const remainingChunks = chunks.slice(1)
+          await editOrPost(firstChunk)
+          for (const chunk of remainingChunks) {
             await thread.post(chunk)
           }
         },
@@ -248,7 +309,9 @@ const createTeamsMessageHandler = ({
         error instanceof HTTPError
           ? error.message
           : TEAMS_FALLBACK_ERROR_MESSAGE
-      await thread.post(msg)
+      await editOrPost(msg)
+    } finally {
+      clearDelayTimer()
     }
   }
 }
@@ -288,6 +351,8 @@ export async function MSTeamsWebhook(
         },
         state: await getTeamsState(),
         logger: "silent",
+        fallbackStreamingPlaceholderText: TEAMS_PROCESSING_MESSAGE,
+        streamingUpdateIntervalMs: TEAMS_STREAMING_UPDATE_INTERVAL_MS,
       })
 
       const handler = createTeamsMessageHandler({

--- a/packages/server/src/api/controllers/webhook/ms-teams.ts
+++ b/packages/server/src/api/controllers/webhook/ms-teams.ts
@@ -227,14 +227,29 @@ const createTeamsMessageHandler = ({
       }
     }
 
-    const editOrPost = async (text: string) => {
-      if (progressMessage && !hasUsedProgressMessage) {
-        clearDelayTimer()
-        await delayUpdateInFlight
-        hasUsedProgressMessage = true
+    const editProgressMessage = async (text: string) => {
+      if (!progressMessage || hasUsedProgressMessage) {
+        return false
+      }
+
+      clearDelayTimer()
+      await delayUpdateInFlight
+      hasUsedProgressMessage = true
+
+      try {
         progressMessage = await progressMessage.edit(text)
+        return true
+      } catch (error) {
+        console.error("Teams progress final update failed", error)
+        return false
+      }
+    }
+
+    const editOrPost = async (text: string) => {
+      if (await editProgressMessage(text)) {
         return
       }
+
       await thread.post(text)
     }
 
@@ -245,7 +260,11 @@ const createTeamsMessageHandler = ({
         const typingThread = thread as Thread & {
           startTyping?: () => Promise<void>
         }
-        await typingThread.startTyping?.()
+        try {
+          await typingThread.startTyping?.()
+        } catch (error) {
+          console.error("Teams typing indicator failed", error)
+        }
         progressMessage = await thread.post(TEAMS_PROCESSING_MESSAGE)
         delayTimer = setTimeout(() => {
           if (!progressMessage || hasUsedProgressMessage) {
@@ -280,13 +299,17 @@ const createTeamsMessageHandler = ({
             linkUrl: prompt.linkUrl,
           })
           if (delivery.usedDirectMessageFallback) {
-            await thread.post("I sent you a DM with your Budibase link.")
+            await editOrPost("I sent you a DM with your Budibase link.")
             return
           }
           if (!delivery.delivered) {
-            await thread.post(
+            await editOrPost(
               "I couldn't send a private Budibase link. Please try again in a direct message."
             )
+            return
+          }
+          if (progressMessage && !hasUsedProgressMessage) {
+            await editOrPost("I sent you a private Budibase link.")
           }
         },
         workspaceId,

--- a/packages/server/src/api/controllers/webhook/ms-teams.ts
+++ b/packages/server/src/api/controllers/webhook/ms-teams.ts
@@ -139,7 +139,8 @@ const shouldShowTeamsProgress = ({
 }: {
   command: SupportedChatCommand
   content: string
-}) => command === ChatCommands.ASK || (command === ChatCommands.NEW && !!content)
+}) =>
+  command === ChatCommands.ASK || (command === ChatCommands.NEW && !!content)
 
 const createTeamsMessageHandler = ({
   workspaceId,

--- a/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
@@ -53,11 +53,8 @@ import {
 import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
 import { webhookChat } from "../../../controllers/ai/chatConversations"
 
-const {
-  getMockChatOptions,
-  resetMockChatState,
-  setMockPostEphemeralResult,
-} = jest.requireActual("chat") as ChatMockModule
+const { getMockChatOptions, resetMockChatState, setMockPostEphemeralResult } =
+  jest.requireActual("chat") as ChatMockModule
 const mockedWebhookChat = webhookChat as jest.MockedFunction<typeof webhookChat>
 
 const extractLinkUrl = (messages: string[]) => {

--- a/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
@@ -6,6 +6,7 @@ interface MockWebhookChatPayload {
 }
 
 interface ChatMockModule {
+  getMockChatOptions: () => Record<string, unknown>[]
   resetMockChatState: () => void
   setMockPostEphemeralResult: (
     provider: "slack" | "teams",
@@ -52,9 +53,11 @@ import {
 import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
 import { webhookChat } from "../../../controllers/ai/chatConversations"
 
-const { resetMockChatState, setMockPostEphemeralResult } = jest.requireActual(
-  "chat"
-) as ChatMockModule
+const {
+  getMockChatOptions,
+  resetMockChatState,
+  setMockPostEphemeralResult,
+} = jest.requireActual("chat") as ChatMockModule
 const mockedWebhookChat = webhookChat as jest.MockedFunction<typeof webhookChat>
 
 const extractLinkUrl = (messages: string[]) => {
@@ -329,7 +332,14 @@ describe("agent teams integration provisioning", () => {
         },
       })
 
-      expect(response.body.messages).toContain("Mock assistant response")
+      expect(response.body.messages).toEqual(["Mock assistant response"])
+      const chatOptions = getMockChatOptions()
+      expect(chatOptions[chatOptions.length - 1]).toEqual(
+        expect.objectContaining({
+          fallbackStreamingPlaceholderText: "Got it. I'm working on it...",
+          streamingUpdateIntervalMs: 750,
+        })
+      )
       expect(mockedWebhookChat).toHaveBeenCalledTimes(1)
       const firstPart =
         mockedWebhookChat.mock.calls[0]?.[0].chat.messages[0]?.parts[0]


### PR DESCRIPTION
## Summary
- Add immediate Teams progress feedback for long-running chat responses.
- Edit the progress message into the final or failure response to avoid duplicate bot messages.
- Configure Chat SDK Teams fallback streaming defaults and cover the behavior in tests.

https://github.com/user-attachments/assets/9eea614f-cf6d-444b-9c29-5082dee6ea0f






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show real-time progress in Microsoft Teams for long-running chat replies, and merge that progress into the final reply, link notice, or error to avoid duplicate bot messages. Also set Teams-specific streaming defaults in the `chat` SDK and cover them in tests.

- **New Features**
  - Post “Got it. I’m working on it…” immediately; after 10s, update to “Still working. This is taking a little longer than usual...” if needed.
  - Merge progress into the first reply chunk, link-delivery messages (including DM fallback), or errors; if editing fails, post instead; post remaining chunks normally.
  - Send typing indicator when available; show progress only for `ask` and `new` (with content) commands.
  - Configure `chat` with `fallbackStreamingPlaceholderText` and `streamingUpdateIntervalMs` (750ms); tests assert these defaults.

<sup>Written for commit bf8f0bdc12e8128baa5aa8ab8f0699a998f8b210. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18624?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



