### PR TITLE
Better logging around RAG ingestion

### DIFF
--- a/packages/server/src/sdk/workspace/ai/knowledgeBase/uploads.ts
+++ b/packages/server/src/sdk/workspace/ai/knowledgeBase/uploads.ts
@@ -47,6 +47,17 @@ export const uploadKnowledgeBaseFile = async (
     fileId,
     input.filename
   )
+  const startedAtMs = Date.now()
+  console.log("Starting knowledge base file upload", {
+    workspaceId,
+    knowledgeBaseId: input.knowledgeBaseId,
+    fileId,
+    filename: input.filename,
+    mimetype: input.mimetype,
+    size: input.size ?? input.buffer.byteLength,
+    sourceType: input.source?.type,
+    objectStoreKey,
+  })
 
   try {
     await objectStore.upload({
@@ -74,6 +85,13 @@ export const uploadKnowledgeBaseFile = async (
         fileId: knowledgeBaseFile._id!,
         objectStoreKey,
       })
+      console.log("Completed knowledge base file upload and queued ingestion", {
+        workspaceId,
+        knowledgeBaseId: input.knowledgeBaseId,
+        fileId: knowledgeBaseFile._id,
+        objectStoreKey,
+        durationMs: Date.now() - startedAtMs,
+      })
 
       return knowledgeBaseFile
     } catch (error: any) {
@@ -81,9 +99,26 @@ export const uploadKnowledgeBaseFile = async (
       knowledgeBaseFile.errorMessage =
         error?.message || "Failed to process uploaded file"
       await updateKnowledgeBaseFile(knowledgeBaseFile)
+      console.error("Failed to enqueue knowledge base file ingestion", {
+        workspaceId,
+        knowledgeBaseId: input.knowledgeBaseId,
+        fileId: knowledgeBaseFile._id,
+        objectStoreKey,
+        durationMs: Date.now() - startedAtMs,
+        error,
+      })
       throw error
     }
   } catch (error: any) {
+    console.error("Failed to upload knowledge base file", {
+      workspaceId,
+      knowledgeBaseId: input.knowledgeBaseId,
+      fileId,
+      filename: input.filename,
+      objectStoreKey,
+      durationMs: Date.now() - startedAtMs,
+      error,
+    })
     await objectStore
       .deleteFile(ObjectStoreBuckets.APPS, objectStoreKey)
       .catch(() => {
@@ -96,6 +131,7 @@ export const uploadKnowledgeBaseFile = async (
 export const retryKnowledgeBaseFileIngestion = async (fileId: string) => {
   const workspaceId = context.getOrThrowWorkspaceId()
   const file = await getKnowledgeBaseFileOrThrow(fileId)
+  const startedAtMs = Date.now()
 
   if (!file.objectStoreKey) {
     throw new HTTPError("Knowledge base file does not have an object key", 400)
@@ -108,6 +144,12 @@ export const retryKnowledgeBaseFileIngestion = async (fileId: string) => {
   file.errorMessage = undefined
   file.processedAt = undefined
   await updateKnowledgeBaseFile(file)
+  console.log("Retrying knowledge base file ingestion", {
+    workspaceId,
+    knowledgeBaseId: file.knowledgeBaseId,
+    fileId,
+    objectStoreKey: file.objectStoreKey,
+  })
 
   try {
     await enqueueRagFileIngestion({
@@ -116,6 +158,12 @@ export const retryKnowledgeBaseFileIngestion = async (fileId: string) => {
       fileId,
       objectStoreKey: file.objectStoreKey,
     })
+    console.log("Requeued knowledge base file ingestion", {
+      workspaceId,
+      knowledgeBaseId: file.knowledgeBaseId,
+      fileId,
+      durationMs: Date.now() - startedAtMs,
+    })
 
     return file
   } catch (error: any) {
@@ -123,6 +171,13 @@ export const retryKnowledgeBaseFileIngestion = async (fileId: string) => {
     file.errorMessage =
       error?.message || "Failed to requeue knowledge base file ingestion"
     await updateKnowledgeBaseFile(file)
+    console.error("Failed to requeue knowledge base file ingestion", {
+      workspaceId,
+      knowledgeBaseId: file.knowledgeBaseId,
+      fileId,
+      durationMs: Date.now() - startedAtMs,
+      error,
+    })
     throw error
   }
 }

--- a/packages/server/src/sdk/workspace/ai/rag/processors/gemini.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/processors/gemini.ts
@@ -30,18 +30,48 @@ export class GeminiRagProcessor implements RagProcessor {
     input: KnowledgeBaseFile,
     fileBuffer: Buffer
   ): Promise<void> {
-    const ingested = await ingestGeminiFile({
+    const startedAtMs = Date.now()
+    const knowledgeBaseId = this.knowledgeBase._id
+    console.log("Starting Gemini RAG file ingestion", {
+      knowledgeBaseId,
       vectorStoreId: this.knowledgeBase.config.googleFileStoreId,
+      fileId: input._id,
       filename: input.filename,
       mimetype: input.mimetype,
-      buffer: fileBuffer,
+      fileSize: fileBuffer.byteLength,
     })
 
-    input.status = KnowledgeBaseFileStatus.READY
-    input.ragSourceId = ingested.fileId || input.ragSourceId
-    input.processedAt = new Date().toISOString()
-    input.errorMessage = undefined
-    await updateKnowledgeBaseFile(input)
+    try {
+      const ingested = await ingestGeminiFile({
+        vectorStoreId: this.knowledgeBase.config.googleFileStoreId,
+        filename: input.filename,
+        mimetype: input.mimetype,
+        buffer: fileBuffer,
+      })
+
+      input.status = KnowledgeBaseFileStatus.READY
+      input.ragSourceId = ingested.fileId || input.ragSourceId
+      input.processedAt = new Date().toISOString()
+      input.errorMessage = undefined
+      await updateKnowledgeBaseFile(input)
+      console.log("Completed Gemini RAG file ingestion", {
+        knowledgeBaseId,
+        vectorStoreId: this.knowledgeBase.config.googleFileStoreId,
+        fileId: input._id,
+        ragSourceId: input.ragSourceId,
+        durationMs: Date.now() - startedAtMs,
+      })
+    } catch (error) {
+      console.error("Failed Gemini RAG file ingestion", {
+        knowledgeBaseId,
+        vectorStoreId: this.knowledgeBase.config.googleFileStoreId,
+        fileId: input._id,
+        filename: input.filename,
+        durationMs: Date.now() - startedAtMs,
+        error,
+      })
+      throw error
+    }
   }
 
   async search(

--- a/packages/server/src/sdk/workspace/ai/rag/processors/gemini.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/processors/gemini.ts
@@ -50,7 +50,7 @@ export class GeminiRagProcessor implements RagProcessor {
       })
 
       input.status = KnowledgeBaseFileStatus.READY
-      input.ragSourceId = ingested.fileId || input.ragSourceId
+      input.ragSourceId = ingested.fileId
       input.processedAt = new Date().toISOString()
       input.errorMessage = undefined
       await updateKnowledgeBaseFile(input)

--- a/packages/server/src/sdk/workspace/ai/rag/queue.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/queue.ts
@@ -60,12 +60,31 @@ export function init(concurrency = DEFAULT_CONCURRENCY) {
 
     return getQueue().process(concurrency, async job => {
       const { workspaceId, knowledgeBaseId, fileId, objectStoreKey } = job.data
+      const startedAtMs = Date.now()
+      console.log("Starting RAG ingestion queue job", {
+        workspaceId,
+        knowledgeBaseId,
+        fileId,
+        objectStoreKey,
+        jobId: job.id,
+        attemptsMade: job.attemptsMade,
+        attempts: job.opts.attempts,
+      })
       await context.doInWorkspaceContext(workspaceId, async () => {
         let knowledgeBaseConfig: KnowledgeBase | undefined
         let knowledgeBaseFile: KnowledgeBaseFile | undefined
 
         knowledgeBaseConfig = await knowledgeBase.find(knowledgeBaseId)
         if (!knowledgeBaseConfig) {
+          console.log(
+            "Discarding RAG ingestion queue job: knowledge base missing",
+            {
+              workspaceId,
+              knowledgeBaseId,
+              fileId,
+              jobId: job.id,
+            }
+          )
           await job.discard()
           return
         }
@@ -75,6 +94,12 @@ export function init(concurrency = DEFAULT_CONCURRENCY) {
             await knowledgeBase.getKnowledgeBaseFileOrThrow(fileId)
         } catch (error: any) {
           if (error?.status === 404) {
+            console.log("Discarding RAG ingestion queue job: file missing", {
+              workspaceId,
+              knowledgeBaseId,
+              fileId,
+              jobId: job.id,
+            })
             await job.discard()
             return
           }
@@ -82,6 +107,12 @@ export function init(concurrency = DEFAULT_CONCURRENCY) {
         }
 
         if (!knowledgeBaseFile) {
+          console.log("Discarding RAG ingestion queue job: file not found", {
+            workspaceId,
+            knowledgeBaseId,
+            fileId,
+            jobId: job.id,
+          })
           await job.discard()
           return
         }
@@ -101,8 +132,25 @@ export function init(concurrency = DEFAULT_CONCURRENCY) {
             knowledgeBaseFile,
             buffer
           )
+          console.log("Completed RAG ingestion queue job", {
+            workspaceId,
+            knowledgeBaseId,
+            fileId,
+            jobId: job.id,
+            durationMs: Date.now() - startedAtMs,
+          })
         } catch (error: any) {
           await handleProcessingError(knowledgeBaseFile, job, error)
+          console.error("RAG ingestion queue job failed", {
+            workspaceId,
+            knowledgeBaseId,
+            fileId,
+            jobId: job.id,
+            durationMs: Date.now() - startedAtMs,
+            attemptsMade: job.attemptsMade,
+            attempts: job.opts.attempts,
+            error,
+          })
           throw error
         }
       })
@@ -115,6 +163,12 @@ export function init(concurrency = DEFAULT_CONCURRENCY) {
 
 export async function enqueueRagFileIngestion(job: RagIngestionJob) {
   init()
+  console.log("Enqueueing RAG ingestion job", {
+    workspaceId: job.workspaceId,
+    knowledgeBaseId: job.knowledgeBaseId,
+    fileId: job.fileId,
+    objectStoreKey: job.objectStoreKey,
+  })
   return await getQueue().add(job, { jobId: job.fileId })
 }
 
@@ -140,10 +194,22 @@ const handleProcessingError = async (
   const isFinalAttempt = job.attemptsMade + 1 >= attempts
 
   if (!isFinalAttempt) {
+    console.log("RAG ingestion job attempt failed, will retry", {
+      fileId: file._id,
+      attemptsMade: job.attemptsMade,
+      attempts,
+      errorMessage: error?.message,
+    })
     return
   }
 
   file.status = KnowledgeBaseFileStatus.FAILED
   file.errorMessage = error?.message || "Failed to process uploaded file"
+  console.error("RAG ingestion job exhausted retries, marking file failed", {
+    fileId: file._id,
+    attemptsMade: job.attemptsMade,
+    attempts,
+    errorMessage: file.errorMessage,
+  })
   await knowledgeBase.updateKnowledgeBaseFile(file)
 }


### PR DESCRIPTION
## Description
Better logging around RAG ingestion

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved observability for RAG ingestion with structured, timing-aware logs across uploads, the queue, and the Gemini processor. Also ensures `ragSourceId` is saved directly from the provider’s fileId for accurate tracing.

- **Refactors**
  - Uploads: log start/complete/fail with workspaceId, knowledgeBaseId, fileId, objectStoreKey, filename, mimetype, size, sourceType, and duration; retry logs with duration.
  - Queue: log enqueue/start/complete, retry attempts and exhausted retries, and discards when knowledge base or file is missing; include jobId and attempt counts.
  - Gemini processor: log start/complete/fail with knowledgeBaseId, vectorStoreId, fileId, filename, mimetype, fileSize, ragSourceId, and duration; set `ragSourceId` directly from ingested fileId.

<sup>Written for commit 843c807a8f2dc627be1eb4a33e3787728c16c9c8. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18628?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

