### PR TITLE
Update litellm to 1.83.10

### DIFF
--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -652,7 +652,7 @@ services:
     # -- Whether or not to deploy the litellm gateway.
     enabled: false
     # -- litellm image to use.
-    image: ghcr.io/berriai/litellm:main-v1.81.14-stable
+    image: ghcr.io/berriai/litellm:main-v1.83.10-stable
     # -- Port exposed by the litellm container.
     port: 4000
     # -- Number of litellm replicas.

--- a/hosting/docker-compose.build.yaml
+++ b/hosting/docker-compose.build.yaml
@@ -88,7 +88,7 @@ services:
       - couchdb-service
 
   litellm-service:
-    image: ghcr.io/berriai/litellm:main-v1.81.14-stable
+    image: ghcr.io/berriai/litellm:main-v1.83.10-stable
     ports:
       - "${LITELLM_PORT:-4000}:4000"
     volumes:
@@ -103,7 +103,11 @@ services:
     depends_on:
       - litellm-db
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 http://localhost:4000/health/liveliness || exit 1"]
+      test:
+        [
+          "CMD-SHELL",
+          "wget --no-verbose --tries=1 http://localhost:4000/health/liveliness || exit 1",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -118,7 +122,8 @@ services:
     volumes:
       - litellm_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d ${LITELLM_DB_NAME} -U ${LITELLM_DB_USER}"]
+      test:
+        ["CMD-SHELL", "pg_isready -d ${LITELLM_DB_NAME} -U ${LITELLM_DB_USER}"]
       interval: 1s
       timeout: 5s
       retries: 10

--- a/hosting/docker-compose.dev.yaml
+++ b/hosting/docker-compose.dev.yaml
@@ -63,7 +63,7 @@ services:
 
   litellm-service:
     container_name: budi-litellm-dev
-    image: ghcr.io/berriai/litellm:main-v1.81.14-stable
+    image: ghcr.io/berriai/litellm:main-v1.83.10-stable
     ports:
       - "${LITELLM_PORT:-4000}:4000"
     volumes:
@@ -77,11 +77,14 @@ services:
       - .env
     depends_on:
       - litellm-db
-    healthcheck:  
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 http://localhost:4000/health/liveliness || exit 1" ]  # Command to execute for health check
+    healthcheck:
+      test: [
+          "CMD-SHELL",
+          "wget --no-verbose --tries=1 http://localhost:4000/health/liveliness || exit 1",
+        ] # Command to execute for health check
       interval: 30s
-      timeout: 10s 
-      retries: 3   
+      timeout: 10s
+      retries: 3
       start_period: 40s
 
   litellm-db:
@@ -92,7 +95,8 @@ services:
       POSTGRES_USER: ${LITELLM_DB_USER}
       POSTGRES_PASSWORD: ${LITELLM_DB_PASSWORD}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d ${LITELLM_DB_NAME} -U ${LITELLM_DB_USER}"]
+      test:
+        ["CMD-SHELL", "pg_isready -d ${LITELLM_DB_NAME} -U ${LITELLM_DB_USER}"]
       interval: 1s
       timeout: 5s
       retries: 10

--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -122,7 +122,7 @@ services:
 
   litellm-service:
     restart: unless-stopped
-    image: ghcr.io/berriai/litellm:main-v1.81.14-stable
+    image: ghcr.io/berriai/litellm:main-v1.83.10-stable
     ports:
       - "${LITELLM_PORT:-4000}:4000"
     volumes:

--- a/hosting/litellm-version.json
+++ b/hosting/litellm-version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.81.14",
+  "version": "1.83.10",
   "channel": "stable"
 }

--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && \
 # Install litellm
 RUN python3 -m venv /opt/venv/litellm
 
-ARG LITELLM_PYPI_VERSION=1.81.14
+ARG LITELLM_PYPI_VERSION=1.83.10
 RUN /opt/venv/litellm/bin/pip install "litellm[proxy]==${LITELLM_PYPI_VERSION}"
 ENV PATH="/opt/venv/litellm/bin:${PATH}"
 RUN mkdir -p /litellm


### PR DESCRIPTION
## Description
Update litellm to 1.83.10

## Launchcontrol
Update litellm to 1.83.10

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `litellm` to 1.83.10 across Helm, Docker Compose, and single-container builds to align with the latest stable release. Updates the gateway image and PyPI version; no config changes required.

- **Dependencies**
  - Bumped `ghcr.io/berriai/litellm` image from `main-v1.81.14-stable` to `main-v1.83.10-stable` in Helm values and all Compose files.
  - Set `LITELLM_PYPI_VERSION=1.83.10` in `hosting/single/Dockerfile` and updated `hosting/litellm-version.json` to `1.83.10`.

- **Refactors**
  - Expanded Docker Compose healthcheck `test` fields to multiline arrays for readability (no behavior change).

<sup>Written for commit c6258009e7bd4426f18e96009a3d639f566772e6. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18633?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

