### PR TITLE
overwrite workspace snippets when importing over existing workspace

### DIFF
--- a/packages/server/src/api/routes/tests/workspaceImport.spec.ts
+++ b/packages/server/src/api/routes/tests/workspaceImport.spec.ts
@@ -1,4 +1,5 @@
 import path from "path"
+import sdk from "../../../sdk"
 import { getAppObjectStorageEtags } from "../../../tests/utilities/objectStore"
 import * as setup from "./utilities"
 
@@ -218,5 +219,48 @@ describe("/applications/:appId/import", () => {
     expect(screens.length).toBe(2)
     expect(screens[0].routing.route).toBe("/derp")
     expect(screens[1].routing.route).toBe("/blank")
+  })
+
+  it("should override existing snippet code when importing over an existing workspace", async () => {
+    const appId = config.getDevWorkspaceId()
+    const snippetName = `importSnippet_${Date.now()}`
+    const importedSnippetCode = "return 'imported-version'"
+    const existingSnippetCode = "return 'existing-version'"
+
+    await config.api.workspace.update(appId!, {
+      snippets: [{ name: snippetName, code: importedSnippetCode }],
+    })
+
+    const exportPath = await sdk.backups.exportWorkspace(appId!, {
+      excludeRows: true,
+      tar: true,
+    })
+
+    await config.api.workspace.update(appId!, {
+      snippets: [{ name: snippetName, code: existingSnippetCode }],
+    })
+
+    const beforeImportWorkspace = await config.api.workspace.get(appId!)
+    expect(beforeImportWorkspace.snippets).toContainEqual({
+      name: snippetName,
+      code: existingSnippetCode,
+    })
+
+    await request
+      .post(`/api/applications/${appId}/import`)
+      .attach("appExport", exportPath)
+      .set(config.defaultHeaders())
+      .expect("Content-Type", /json/)
+      .expect(200)
+
+    const workspace = await config.api.workspace.get(appId!)
+    expect(workspace.snippets).toContainEqual({
+      name: snippetName,
+      code: importedSnippetCode,
+    })
+    expect(workspace.snippets).not.toContainEqual({
+      name: snippetName,
+      code: existingSnippetCode,
+    })
   })
 })

--- a/packages/server/src/api/routes/tests/workspaceImport.spec.ts
+++ b/packages/server/src/api/routes/tests/workspaceImport.spec.ts
@@ -226,13 +226,13 @@ describe("/applications/:appId/import", () => {
     const snippetName = `importSnippet_${Date.now()}`
     const importedSnippetCode = "return 'imported-version'"
     const existingSnippetCode = "return 'existing-version'"
-    const importedTheme = { primaryColor: "#00A86B" }
-    const existingTheme = { primaryColor: "#B22222" }
+    const importedCustomTheme = { primaryColor: "#00A86B" }
+    const existingCustomTheme = { primaryColor: "#B22222" }
     const importedFeatures = { componentValidation: true }
     const existingFeatures = { componentValidation: false }
 
     await config.api.workspace.update(appId!, {
-      theme: importedTheme,
+      customTheme: importedCustomTheme,
       features: importedFeatures,
       snippets: [{ name: snippetName, code: importedSnippetCode }],
     })
@@ -243,7 +243,7 @@ describe("/applications/:appId/import", () => {
     })
 
     await config.api.workspace.update(appId!, {
-      theme: existingTheme,
+      customTheme: existingCustomTheme,
       features: existingFeatures,
       snippets: [{ name: snippetName, code: existingSnippetCode }],
     })
@@ -263,13 +263,13 @@ describe("/applications/:appId/import", () => {
 
     const workspace = await config.api.workspace.get(appId!)
     expect({
-      theme: workspace.theme,
+      customTheme: workspace.customTheme,
       features: workspace.features,
       snippet: workspace.snippets?.find(
         snippet => snippet.name === snippetName
       ),
     }).toEqual({
-      theme: importedTheme,
+      customTheme: importedCustomTheme,
       features: expect.objectContaining(importedFeatures),
       snippet: { name: snippetName, code: importedSnippetCode },
     })

--- a/packages/server/src/api/routes/tests/workspaceImport.spec.ts
+++ b/packages/server/src/api/routes/tests/workspaceImport.spec.ts
@@ -221,13 +221,19 @@ describe("/applications/:appId/import", () => {
     expect(screens[1].routing.route).toBe("/blank")
   })
 
-  it("should override existing snippet code when importing over an existing workspace", async () => {
+  it("should import selected metadata while preserving workspace identity metadata", async () => {
     const appId = config.getDevWorkspaceId()
     const snippetName = `importSnippet_${Date.now()}`
     const importedSnippetCode = "return 'imported-version'"
     const existingSnippetCode = "return 'existing-version'"
+    const importedTheme = { primaryColor: "#00A86B" }
+    const existingTheme = { primaryColor: "#B22222" }
+    const importedFeatures = { componentValidation: true }
+    const existingFeatures = { componentValidation: false }
 
     await config.api.workspace.update(appId!, {
+      theme: importedTheme,
+      features: importedFeatures,
       snippets: [{ name: snippetName, code: importedSnippetCode }],
     })
 
@@ -237,6 +243,8 @@ describe("/applications/:appId/import", () => {
     })
 
     await config.api.workspace.update(appId!, {
+      theme: existingTheme,
+      features: existingFeatures,
       snippets: [{ name: snippetName, code: existingSnippetCode }],
     })
 
@@ -254,6 +262,26 @@ describe("/applications/:appId/import", () => {
       .expect(200)
 
     const workspace = await config.api.workspace.get(appId!)
+    expect({
+      theme: workspace.theme,
+      features: workspace.features,
+      snippet: workspace.snippets?.find(
+        snippet => snippet.name === snippetName
+      ),
+    }).toEqual({
+      theme: importedTheme,
+      features: expect.objectContaining(importedFeatures),
+      snippet: { name: snippetName, code: importedSnippetCode },
+    })
+
+    expect({
+      appId: workspace.appId,
+      tenantId: workspace.tenantId,
+    }).toEqual({
+      appId,
+      tenantId: beforeImportWorkspace.tenantId,
+    })
+
     expect(workspace.snippets).toContainEqual({
       name: snippetName,
       code: importedSnippetCode,

--- a/packages/server/src/sdk/workspace/workspaces/import.ts
+++ b/packages/server/src/sdk/workspace/workspaces/import.ts
@@ -42,6 +42,7 @@ async function getNewWorkspaceMetadata(
       automationErrors: undefined,
       theme: tempMetadata.theme,
       customTheme: tempMetadata.customTheme,
+      snippets: tempMetadata.snippets,
       features: tempMetadata.features,
       icon: tempMetadata.icon,
       navigation: tempMetadata.navigation,


### PR DESCRIPTION
## Description
Fix workspace import behaviour so existing snippets are overwritten by imported snippets when names match.

## Addresses
- https://github.com/Budibase/budibase/issues/18632

## Launchcontrol
When you import a workspace into one that already exists, snippets with the same name now correctly update to the imported code.

**Before**: old snippet code could stick around.
**Now:** imported snippet code replaces it, as users expect.