### PR TITLE
Remove no-wrap for field description labels

### DIFF
--- a/packages/bbui/src/Form/Field.svelte
+++ b/packages/bbui/src/Form/Field.svelte
@@ -78,4 +78,7 @@
   .description {
     margin-bottom: var(--spacing-xs);
   }
+  .description :global(label) {
+    white-space: normal;
+  }
 </style>


### PR DESCRIPTION
## Description
The `Label` component within the `Field` description had an explicit no-wrap set. When [litellm was updated ](https://github.com/Budibase/budibase/pull/18633) the field descriptions returned in the AI Config page were much longer, causing the whole page to scroll. This was always an issue, the update just surfaced it.

## Addresses
- Remove `no-wrap` for description field labels

## Screenshots
<img width="1225" height="771" alt="Screenshot 2026-04-28 at 09 45 37" src="https://github.com/user-attachments/assets/9407f2fc-ec45-464a-963c-7fcb637cd892" />
