### PR TITLE
[BUDI-18137] Add custom trigger automation confirmation prompts

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/ConfirmationSettings.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/ConfirmationSettings.svelte
@@ -1,0 +1,93 @@
+<script>
+  import { Checkbox, Label } from "@budibase/bbui"
+  import DrawerBindableInput from "@/components/common/bindings/DrawerBindableInput.svelte"
+
+  export let parameters
+  export let bindings = []
+  export let layout = "grid"
+
+  $: isGrid = layout === "grid"
+</script>
+
+{#if isGrid}
+  <br />
+  <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
+
+  {#if parameters.confirm}
+    <Label small>Title</Label>
+    <DrawerBindableInput
+      placeholder="Prompt User"
+      value={parameters.customTitleText}
+      on:change={e => (parameters.customTitleText = e.detail)}
+      {bindings}
+    />
+
+    <Label small>Text</Label>
+    <DrawerBindableInput
+      placeholder="Are you sure you want to continue?"
+      value={parameters.confirmText}
+      on:change={e => (parameters.confirmText = e.detail)}
+      {bindings}
+    />
+
+    <Label small>Confirm Text</Label>
+    <DrawerBindableInput
+      placeholder="Confirm"
+      value={parameters.confirmButtonText}
+      on:change={e => (parameters.confirmButtonText = e.detail)}
+      {bindings}
+    />
+    <Label small>Cancel Text</Label>
+    <DrawerBindableInput
+      placeholder="Cancel"
+      value={parameters.cancelButtonText}
+      on:change={e => (parameters.cancelButtonText = e.detail)}
+      {bindings}
+    />
+  {/if}
+{:else}
+  <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
+
+  {#if parameters.confirm}
+    <div class="params">
+      <DrawerBindableInput
+        label="Title"
+        placeholder="Prompt User"
+        value={parameters.customTitleText}
+        on:change={e => (parameters.customTitleText = e.detail)}
+        {bindings}
+      />
+      <DrawerBindableInput
+        label="Message"
+        placeholder="Are you sure you want to continue?"
+        value={parameters.confirmText}
+        on:change={e => (parameters.confirmText = e.detail)}
+        {bindings}
+      />
+
+      <DrawerBindableInput
+        label="Confirm Text"
+        placeholder="Confirm"
+        value={parameters.confirmButtonText}
+        on:change={e => (parameters.confirmButtonText = e.detail)}
+        {bindings}
+      />
+
+      <DrawerBindableInput
+        label="Cancel Text"
+        placeholder="Cancel"
+        value={parameters.cancelButtonText}
+        on:change={e => (parameters.cancelButtonText = e.detail)}
+        {bindings}
+      />
+    </div>
+  {/if}
+{/if}
+
+<style>
+  .params {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-l);
+  }
+</style>

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DeleteRow.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DeleteRow.svelte
@@ -2,6 +2,7 @@
   import { Select, Label, Checkbox, Body } from "@budibase/bbui"
   import { tables, datasources, viewsV2 } from "@/stores/builder"
   import DrawerBindableInput from "@/components/common/bindings/DrawerBindableInput.svelte"
+  import ConfirmationSettings from "./ConfirmationSettings.svelte"
 
   export let parameters
   export let bindings = []
@@ -51,41 +52,7 @@
       text="Do not display default notification"
       bind:value={parameters.notificationOverride}
     />
-    <br />
-    <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
-
-    {#if parameters.confirm}
-      <Label small>Title</Label>
-      <DrawerBindableInput
-        placeholder="Prompt User"
-        value={parameters.customTitleText}
-        on:change={e => (parameters.customTitleText = e.detail)}
-        {bindings}
-      />
-
-      <Label small>Text</Label>
-      <DrawerBindableInput
-        placeholder="Are you sure you want to continue?"
-        value={parameters.confirmText}
-        on:change={e => (parameters.confirmText = e.detail)}
-        {bindings}
-      />
-
-      <Label small>Confirm Text</Label>
-      <DrawerBindableInput
-        placeholder="Confirm"
-        value={parameters.confirmButtonText}
-        on:change={e => (parameters.confirmButtonText = e.detail)}
-        {bindings}
-      />
-      <Label small>Cancel Text</Label>
-      <DrawerBindableInput
-        placeholder="Cancel"
-        value={parameters.cancelButtonText}
-        on:change={e => (parameters.cancelButtonText = e.detail)}
-        {bindings}
-      />
-    {/if}
+    <ConfirmationSettings {parameters} {bindings} />
   </div>
 </div>
 

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DuplicateRow.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/DuplicateRow.svelte
@@ -7,10 +7,10 @@
     datasources,
     viewsV2,
   } from "@/stores/builder"
-  import DrawerBindableInput from "@/components/common/bindings/DrawerBindableInput.svelte"
   import { getSchemaForDatasourcePlus } from "@/dataBinding"
   import SaveFields from "./SaveFields.svelte"
   import { getDatasourceLikeProviders } from "@/components/design/settings/controls/ButtonActionEditor/actions/utils"
+  import ConfirmationSettings from "./ConfirmationSettings.svelte"
 
   export let parameters
   export let bindings = []
@@ -80,41 +80,7 @@
       text="Do not display default notification"
       bind:value={parameters.notificationOverride}
     />
-    <br />
-    <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
-
-    {#if parameters.confirm}
-      <Label small>Title</Label>
-      <DrawerBindableInput
-        placeholder="Prompt User"
-        value={parameters.customTitleText}
-        on:change={e => (parameters.customTitleText = e.detail)}
-        {bindings}
-      />
-
-      <Label small>Text</Label>
-      <DrawerBindableInput
-        placeholder="Are you sure you want to continue?"
-        value={parameters.confirmText}
-        on:change={e => (parameters.confirmText = e.detail)}
-        {bindings}
-      />
-
-      <Label small>Confirm Text</Label>
-      <DrawerBindableInput
-        placeholder="Confirm"
-        value={parameters.confirmButtonText}
-        on:change={e => (parameters.confirmButtonText = e.detail)}
-        {bindings}
-      />
-      <Label small>Cancel Text</Label>
-      <DrawerBindableInput
-        placeholder="Cancel"
-        value={parameters.cancelButtonText}
-        on:change={e => (parameters.cancelButtonText = e.detail)}
-        {bindings}
-      />
-    {/if}
+    <ConfirmationSettings {parameters} {bindings} />
   </div>
 
   {#if parameters.tableId}

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/ExecuteQuery.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/ExecuteQuery.svelte
@@ -1,9 +1,9 @@
 <script>
   import { Select, Layout, Checkbox } from "@budibase/bbui"
-  import DrawerBindableInput from "@/components/common/bindings/DrawerBindableInput.svelte"
   import { datasources, integrations, queries } from "@/stores/builder"
   import BindingBuilder from "@/components/integration/QueryBindingBuilder.svelte"
   import IntegrationQueryEditor from "@/components/integration/index.svelte"
+  import ConfirmationSettings from "./ConfirmationSettings.svelte"
   import {
     BUDIBASE_INTERNAL_DB_ID,
     BUDIBASE_DATASOURCE_TYPE,
@@ -60,42 +60,7 @@
       bind:value={parameters.notificationOverride}
     />
     {#if parameters.queryId}
-      <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
-
-      {#if parameters.confirm}
-        <div class="params">
-          <DrawerBindableInput
-            label="Title"
-            placeholder="Prompt User"
-            value={parameters.customTitleText}
-            on:change={e => (parameters.customTitleText = e.detail)}
-            {bindings}
-          />
-          <DrawerBindableInput
-            label="Message"
-            placeholder="Are you sure you want to continue?"
-            value={parameters.confirmText}
-            on:change={e => (parameters.confirmText = e.detail)}
-            {bindings}
-          />
-
-          <DrawerBindableInput
-            label="Confirm Text"
-            placeholder="Confirm"
-            value={parameters.confirmButtonText}
-            on:change={e => (parameters.confirmButtonText = e.detail)}
-            {bindings}
-          />
-
-          <DrawerBindableInput
-            label="Cancel Text"
-            placeholder="Cancel"
-            value={parameters.cancelButtonText}
-            on:change={e => (parameters.cancelButtonText = e.detail)}
-            {bindings}
-          />
-        </div>
-      {/if}
+      <ConfirmationSettings {parameters} {bindings} layout="stacked" />
 
       {#if query?.parameters?.length > 0}
         <br />

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/RowAction.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/RowAction.svelte
@@ -1,7 +1,8 @@
 <script>
-  import { Select, Label, Checkbox } from "@budibase/bbui"
+  import { Select, Label } from "@budibase/bbui"
   import { tables, datasources, viewsV2, rowActions } from "@/stores/builder"
   import DrawerBindableInput from "@/components/common/bindings/DrawerBindableInput.svelte"
+  import ConfirmationSettings from "./ConfirmationSettings.svelte"
 
   export let parameters
   export let bindings = []
@@ -55,39 +56,7 @@
     <Label small>Row action</Label>
     <Select bind:value={parameters.rowActionId} options={rowActionOptions} />
 
-    <br />
-    <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
-
-    {#if parameters.confirm}
-      <Label small>Title</Label>
-      <DrawerBindableInput
-        placeholder="Prompt User"
-        value={parameters.customTitleText}
-        on:change={e => (parameters.customTitleText = e.detail)}
-        {bindings}
-      />
-      <Label small>Text</Label>
-      <DrawerBindableInput
-        placeholder="Are you sure you want to continue?"
-        value={parameters.confirmText}
-        on:change={e => (parameters.confirmText = e.detail)}
-        {bindings}
-      />
-      <Label small>Confirm Text</Label>
-      <DrawerBindableInput
-        placeholder="Confirm"
-        value={parameters.confirmButtonText}
-        on:change={e => (parameters.confirmButtonText = e.detail)}
-        {bindings}
-      />
-      <Label small>Cancel Text</Label>
-      <DrawerBindableInput
-        placeholder="Cancel"
-        value={parameters.cancelButtonText}
-        on:change={e => (parameters.cancelButtonText = e.detail)}
-        {bindings}
-      />
-    {/if}
+    <ConfirmationSettings {parameters} {bindings} />
   </div>
 </div>
 

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/SaveRow.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/SaveRow.svelte
@@ -7,10 +7,10 @@
     datasources,
     viewsV2,
   } from "@/stores/builder"
-  import DrawerBindableInput from "@/components/common/bindings/DrawerBindableInput.svelte"
   import { getSchemaForDatasourcePlus } from "@/dataBinding"
   import SaveFields from "./SaveFields.svelte"
   import { getDatasourceLikeProviders } from "@/components/design/settings/controls/ButtonActionEditor/actions/utils"
+  import ConfirmationSettings from "./ConfirmationSettings.svelte"
 
   export let parameters
   export let bindings = []
@@ -80,41 +80,7 @@
       text="Do not display default notification"
       bind:value={parameters.notificationOverride}
     />
-    <br />
-    <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
-
-    {#if parameters.confirm}
-      <Label small>Title</Label>
-      <DrawerBindableInput
-        placeholder="Prompt User"
-        value={parameters.customTitleText}
-        on:change={e => (parameters.customTitleText = e.detail)}
-        {bindings}
-      />
-
-      <Label small>Text</Label>
-      <DrawerBindableInput
-        placeholder="Are you sure you want to continue?"
-        value={parameters.confirmText}
-        on:change={e => (parameters.confirmText = e.detail)}
-        {bindings}
-      />
-
-      <Label small>Confirm Text</Label>
-      <DrawerBindableInput
-        placeholder="Confirm"
-        value={parameters.confirmButtonText}
-        on:change={e => (parameters.confirmButtonText = e.detail)}
-        {bindings}
-      />
-      <Label small>Cancel Text</Label>
-      <DrawerBindableInput
-        placeholder="Cancel"
-        value={parameters.cancelButtonText}
-        on:change={e => (parameters.cancelButtonText = e.detail)}
-        {bindings}
-      />
-    {/if}
+    <ConfirmationSettings {parameters} {bindings} />
   </div>
 
   {#if parameters.tableId}

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/TriggerAutomation.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/TriggerAutomation.svelte
@@ -147,13 +147,12 @@
     {/if}
   </div>
 
-  <div class="params">
-    <Label small />
+  <div class="options">
     <Checkbox
       text="Do not display default notification"
       bind:value={parameters.notificationOverride}
     />
-    <ConfirmationSettings {parameters} {bindings} />
+    <ConfirmationSettings {parameters} {bindings} layout="stacked" />
   </div>
 </div>
 
@@ -190,12 +189,10 @@
     grid-template-columns: 15% auto;
   }
 
-  .params {
+  .options {
     margin-top: var(--spacing-l);
-    display: grid;
-    column-gap: var(--spacing-l);
-    row-gap: var(--spacing-s);
-    grid-template-columns: 60px 1fr;
-    align-items: center;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-l);
   }
 </style>

--- a/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/TriggerAutomation.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonActionEditor/actions/TriggerAutomation.svelte
@@ -4,6 +4,7 @@
   import DrawerBindableInput from "@/components/common/bindings/DrawerBindableInput.svelte"
   import { TriggerStepID } from "@/constants/backend/automations"
   import { sdk as coreSdk } from "@budibase/shared-core"
+  import ConfirmationSettings from "./ConfirmationSettings.svelte"
 
   export let parameters = {}
   export let bindings = []
@@ -146,21 +147,13 @@
     {/if}
   </div>
 
-  <div class="param-margin">
+  <div class="params">
     <Label small />
     <Checkbox
       text="Do not display default notification"
       bind:value={parameters.notificationOverride}
     />
-    <Checkbox text="Require confirmation" bind:value={parameters.confirm} />
-
-    {#if parameters.confirm}
-      <Label small>Confirm text</Label>
-      <Input
-        placeholder="Are you sure you want to trigger this automation?"
-        bind:value={parameters.confirmText}
-      />
-    {/if}
+    <ConfirmationSettings {parameters} {bindings} />
   </div>
 </div>
 
@@ -171,10 +164,6 @@
   }
   .timeout-width {
     width: 30%;
-  }
-
-  .param-margin {
-    margin-top: var(--spacing-l);
   }
 
   .field-name {
@@ -199,5 +188,14 @@
   }
   .fields:first-child {
     grid-template-columns: 15% auto;
+  }
+
+  .params {
+    margin-top: var(--spacing-l);
+    display: grid;
+    column-gap: var(--spacing-l);
+    row-gap: var(--spacing-s);
+    grid-template-columns: 60px 1fr;
+    align-items: center;
   }
 </style>


### PR DESCRIPTION
## Description
Adds consistent confirmation prompt configuration for Trigger Automation app actions.

Trigger Automation now uses the same reusable confirmation settings UI as other app actions, allowing users to configure the title, message, confirm button text, and cancel button text. The shared control is used by all app action editors that expose `Require confirmation`.

## Addresses
- https://github.com/Budibase/budibase/issues/18137

## Screenshots
<img width="1804" height="614" alt="confirm automation" src="https://github.com/user-attachments/assets/42e83a0f-7ccc-41f7-870c-ab300b628fcc" />

<img width="447" height="284" alt="modal" src="https://github.com/user-attachments/assets/4d413286-420a-4fb1-acf8-d86928887cb8" />

## Launchcontrol
Trigger Automation actions can now customise confirmation prompts consistently with other app actions.


