### PR TITLE
Add workspace invite user suggestions

### DIFF
--- a/packages/bbui/src/Form/PillInput.svelte
+++ b/packages/bbui/src/Form/PillInput.svelte
@@ -97,6 +97,7 @@
     }
     const target = event.target as HTMLInputElement
     inputValue = target.value
+    dispatch("input", inputValue)
     if (shouldSplit(inputValue)) {
       const pattern = getSplitPattern()
       const endsWithSeparator = new RegExp(`${pattern.source}$`).test(
@@ -125,6 +126,10 @@
 
   const handleKeydown = (event: KeyboardEvent) => {
     if (readonly || disabled) {
+      return
+    }
+    dispatch("keydown", event)
+    if (event.defaultPrevented) {
       return
     }
     if (

--- a/packages/builder/src/pages/builder/workspace/[application]/_components/InviteUsersModal.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/InviteUsersModal.spec.ts
@@ -353,6 +353,35 @@ describe("InviteUsersModal", () => {
     })
   })
 
+  it("adds the highlighted suggested user when enter is pressed", async () => {
+    searchUsersMock.mockResolvedValue({
+      data: [
+        {
+          _id: "user_1",
+          email: "enter@example.com",
+          firstName: "Enter",
+          lastName: "User",
+        },
+      ],
+    })
+    render(InviteUsersModal, { props: { onHide: vi.fn() } })
+
+    await fireEvent.input(getEmailInput(), {
+      target: { value: "enter" },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("enter@example.com")).toBeInTheDocument()
+    })
+
+    await fireEvent.keyDown(getEmailInput(), { key: "Enter" })
+
+    await waitFor(() => {
+      expect(screen.getByText("enter@example.com")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Invite users" })).toBeEnabled()
+    })
+  })
+
   it("closes the user suggestions when the email input blurs", async () => {
     searchUsersMock.mockResolvedValue({
       data: [

--- a/packages/builder/src/pages/builder/workspace/[application]/_components/InviteUsersModal.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/InviteUsersModal.spec.ts
@@ -308,11 +308,46 @@ describe("InviteUsersModal", () => {
 
     await waitFor(() => {
       expect(searchUsersMock).toHaveBeenCalledWith({
-        query: { string: { email: "existing" } },
+        query: { fuzzy: { email: "existing" } },
         limit: 8,
       })
       expect(screen.getByText("existing@example.com")).toBeInTheDocument()
       expect(screen.getByRole("button", { name: "Invite users" })).toBeEnabled()
+    })
+  })
+
+  it("shows an already selected suggested user as disabled", async () => {
+    searchUsersMock.mockResolvedValue({
+      data: [
+        {
+          _id: "user_1",
+          email: "existing@example.com",
+          firstName: "Existing",
+          lastName: "User",
+        },
+      ],
+    })
+    render(InviteUsersModal, { props: { onHide: vi.fn() } })
+
+    await fireEvent.input(getEmailInput(), {
+      target: { value: "existing" },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("existing@example.com")).toBeInTheDocument()
+    })
+
+    await fireEvent.mouseDown(screen.getByText("existing@example.com"))
+    await fireEvent.input(getEmailInput(), {
+      target: { value: "existing" },
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("option", {
+          name: /Existing User existing@example.com/,
+        })
+      ).toBeDisabled()
     })
   })
 

--- a/packages/builder/src/pages/builder/workspace/[application]/_components/InviteUsersModal.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/InviteUsersModal.spec.ts
@@ -352,4 +352,32 @@ describe("InviteUsersModal", () => {
       expect(screen.getByRole("button", { name: "Invite users" })).toBeEnabled()
     })
   })
+
+  it("closes the user suggestions when the email input blurs", async () => {
+    searchUsersMock.mockResolvedValue({
+      data: [
+        {
+          _id: "user_1",
+          email: "existing@example.com",
+          firstName: "Existing",
+          lastName: "User",
+        },
+      ],
+    })
+    render(InviteUsersModal, { props: { onHide: vi.fn() } })
+
+    await fireEvent.input(getEmailInput(), {
+      target: { value: "existing" },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("existing@example.com")).toBeInTheDocument()
+    })
+
+    await fireEvent.blur(getEmailInput())
+
+    await waitFor(() => {
+      expect(screen.queryByText("existing@example.com")).not.toBeInTheDocument()
+    })
+  })
 })

--- a/packages/builder/src/pages/builder/workspace/[application]/_components/InviteUsersModal.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/InviteUsersModal.spec.ts
@@ -17,6 +17,7 @@ const {
   organisationStore,
   licensingStore,
   usersMock,
+  searchUsersMock,
   assignExistingUsersToWorkspaceMock,
 } = vi.hoisted(() => {
   const createStore = <T>(initialValue: T) => {
@@ -70,6 +71,7 @@ const {
       create: vi.fn(async () => ({ successful: [], unsuccessful: [] })),
       fetch: vi.fn(async () => []),
     },
+    searchUsersMock: vi.fn(async () => ({ data: [] })),
     assignExistingUsersToWorkspaceMock: vi.fn(async (userData: any) => ({
       usersToInvite: userData.users,
       addedToWorkspaceEmails: [],
@@ -110,6 +112,7 @@ vi.mock("@budibase/bbui", async importOriginal => {
     PillInput: actual.PillInput,
     RadioGroup: MockSelect,
     Select: MockSelect,
+    Avatar: MockBody,
     Helpers: {
       uuid: vi.fn(() => "session-id"),
     },
@@ -130,6 +133,12 @@ vi.mock("@/components/common/GlobalRoleSelect.svelte", async () => {
     default: MockGlobalRoleSelect,
   }
 })
+
+vi.mock("@/api", () => ({
+  API: {
+    searchUsers: searchUsersMock,
+  },
+}))
 
 vi.mock(
   "@/settings/pages/people/users/_components/InvitedModal.svelte",
@@ -224,6 +233,7 @@ describe("InviteUsersModal", () => {
     })
     licensingStore.usersLimitReached.mockReturnValue(false)
     licensingStore.usersLimitExceeded.mockReturnValue(false)
+    searchUsersMock.mockResolvedValue({ data: [] })
   })
 
   it("keeps invite action disabled when no emails are entered", () => {
@@ -269,6 +279,76 @@ describe("InviteUsersModal", () => {
     })
 
     await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Invite users" })).toBeEnabled()
+    })
+  })
+
+  it("adds an existing user from the email suggestions", async () => {
+    searchUsersMock.mockResolvedValue({
+      data: [
+        {
+          _id: "user_1",
+          email: "existing@example.com",
+          firstName: "Existing",
+          lastName: "User",
+        },
+      ],
+    })
+    render(InviteUsersModal, { props: { onHide: vi.fn() } })
+
+    await fireEvent.input(getEmailInput(), {
+      target: { value: "existing" },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("existing@example.com")).toBeInTheDocument()
+    })
+
+    await fireEvent.mouseDown(screen.getByText("existing@example.com"))
+
+    await waitFor(() => {
+      expect(searchUsersMock).toHaveBeenCalledWith({
+        query: { string: { email: "existing" } },
+        limit: 8,
+      })
+      expect(screen.getByText("existing@example.com")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Invite users" })).toBeEnabled()
+    })
+  })
+
+  it("adds the highlighted suggested user when tab is pressed", async () => {
+    searchUsersMock.mockResolvedValue({
+      data: [
+        {
+          _id: "user_1",
+          email: "first@example.com",
+          firstName: "First",
+          lastName: "User",
+        },
+        {
+          _id: "user_2",
+          email: "second@example.com",
+          firstName: "Second",
+          lastName: "User",
+        },
+      ],
+    })
+    render(InviteUsersModal, { props: { onHide: vi.fn() } })
+
+    await fireEvent.input(getEmailInput(), {
+      target: { value: "user" },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("first@example.com")).toBeInTheDocument()
+    })
+
+    await fireEvent.keyDown(getEmailInput(), { key: "ArrowDown" })
+    await fireEvent.keyDown(getEmailInput(), { key: "Tab" })
+
+    await waitFor(() => {
+      expect(screen.getByText("second@example.com")).toBeInTheDocument()
+      expect(screen.queryByText("first@example.com")).not.toBeInTheDocument()
       expect(screen.getByRole("button", { name: "Invite users" })).toBeEnabled()
     })
   })

--- a/packages/builder/src/pages/builder/workspace/[application]/_components/InviteUsersModal.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/InviteUsersModal.spec.ts
@@ -1,6 +1,13 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/svelte"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+interface SearchUser {
+  _id: string
+  email: string
+  firstName: string
+  lastName: string
+}
+
 vi.mock("svelte", async importOriginal => {
   const actual = await importOriginal<typeof import("svelte")>()
   return {
@@ -71,7 +78,7 @@ const {
       create: vi.fn(async () => ({ successful: [], unsuccessful: [] })),
       fetch: vi.fn(async () => []),
     },
-    searchUsersMock: vi.fn(async () => ({ data: [] })),
+    searchUsersMock: vi.fn(async () => ({ data: [] as SearchUser[] })),
     assignExistingUsersToWorkspaceMock: vi.fn(async (userData: any) => ({
       usersToInvite: userData.users,
       addedToWorkspaceEmails: [],

--- a/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
+++ b/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
@@ -389,6 +389,7 @@
             on:change={handleEmailsChange}
             on:input={handlePendingEmailInput}
             on:keydown={handleEmailPickerKeydown}
+            on:blur={clearUserSearch}
           />
 
           {#if suggestedUsers.length}

--- a/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
+++ b/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
@@ -210,17 +210,16 @@
     isSearchingUsers = true
     try {
       const response = await API.searchUsers({
-        query: { string: { email: trimmedSearch } },
+        query: { fuzzy: { email: trimmedSearch } },
         limit: 8,
       })
       if (nextSearchId !== userSearchId) {
         return
       }
-      const selectedEmails = new Set(emailsInput.map(email => email.trim()))
-      suggestedUsers = (response.data || []).filter(
-        user => user.email && !selectedEmails.has(user.email)
+      suggestedUsers = (response.data || []).filter(user => user.email)
+      highlightedUserIndex = suggestedUsers.findIndex(
+        user => !isSuggestedUserSelected(user)
       )
-      highlightedUserIndex = suggestedUsers.length ? 0 : -1
     } catch (error) {
       if (nextSearchId === userSearchId) {
         suggestedUsers = []
@@ -254,7 +253,7 @@
   }
 
   const selectSuggestedUser = user => {
-    if (!user?.email || emailsInput.includes(user.email)) {
+    if (!user?.email || isSuggestedUserSelected(user)) {
       return
     }
     const nextEmails = [...emailsInput, user.email]
@@ -269,12 +268,22 @@
     if (!suggestedUsers.length) {
       return
     }
-    const nextIndex =
-      highlightedUserIndex === -1
-        ? 0
-        : (highlightedUserIndex + direction + suggestedUsers.length) %
-          suggestedUsers.length
-    highlightedUserIndex = nextIndex
+    const startIndex = highlightedUserIndex === -1 ? 0 : highlightedUserIndex
+    for (let offset = 1; offset <= suggestedUsers.length; offset++) {
+      const nextIndex =
+        (startIndex + direction * offset + suggestedUsers.length) %
+        suggestedUsers.length
+      if (!isSuggestedUserSelected(suggestedUsers[nextIndex])) {
+        highlightedUserIndex = nextIndex
+        return
+      }
+    }
+    highlightedUserIndex = -1
+  }
+
+  const isSuggestedUserSelected = user => {
+    const userEmail = user?.email?.trim().toLowerCase()
+    return emailsInput.some(email => email.trim().toLowerCase() === userEmail)
   }
 
   const handleEmailPickerKeydown = event => {
@@ -398,11 +407,15 @@
           {#if suggestedUsers.length}
             <div class="user-suggestions" role="listbox">
               {#each suggestedUsers as user, index (user._id || user.email)}
+                {@const userSelected = isSuggestedUserSelected(user)}
                 <button
                   class="user-suggestion"
                   class:is-highlighted={highlightedUserIndex === index}
+                  class:is-selected={userSelected}
                   type="button"
                   role="option"
+                  disabled={userSelected}
+                  aria-disabled={userSelected}
                   aria-selected={highlightedUserIndex === index}
                   on:mouseenter={() => (highlightedUserIndex = index)}
                   on:mousedown|preventDefault={() => selectSuggestedUser(user)}
@@ -418,6 +431,11 @@
                     </span>
                     <span class="user-suggestion-email">{user.email}</span>
                   </span>
+                  {#if userSelected}
+                    <span class="user-suggestion-check">
+                      <Icon name="check" size="S" />
+                    </span>
+                  {/if}
                 </button>
               {/each}
             </div>
@@ -626,10 +644,19 @@
   .user-suggestion.is-highlighted {
     background: var(--spectrum-global-color-gray-100);
   }
+  .user-suggestion.is-selected {
+    color: var(--spectrum-global-color-gray-600);
+    cursor: default;
+  }
+  .user-suggestion.is-selected:hover,
+  .user-suggestion.is-selected.is-highlighted {
+    background: transparent;
+  }
   .user-suggestion-details {
     min-width: 0;
     display: flex;
     flex-direction: column;
+    flex: 1;
   }
   .user-suggestion-name,
   .user-suggestion-email {
@@ -644,5 +671,10 @@
   .user-suggestion-email {
     color: var(--spectrum-global-color-gray-600);
     font-size: 12px;
+  }
+  .user-suggestion-check {
+    display: inline-flex;
+    align-items: center;
+    color: var(--spectrum-global-color-gray-600);
   }
 </style>

--- a/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
+++ b/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
@@ -288,7 +288,10 @@
     } else if (event.detail?.key === "ArrowUp") {
       event.detail.preventDefault()
       updateHighlightedUser(-1)
-    } else if (event.detail?.key === "Tab" && highlightedUserIndex >= 0) {
+    } else if (
+      ["Enter", "Tab"].includes(event.detail?.key) &&
+      highlightedUserIndex >= 0
+    ) {
       event.detail.preventDefault()
       selectSuggestedUser(suggestedUsers[highlightedUserIndex])
     }

--- a/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
+++ b/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
@@ -11,7 +11,9 @@
     PillInput,
     Layout,
     Icon,
+    Avatar,
   } from "@budibase/bbui"
+  import { API } from "@/api"
   import { groups } from "@/stores/portal/groups"
   import GlobalRoleSelect from "@/components/common/GlobalRoleSelect.svelte"
   import { licensing } from "@/stores/portal/licensing"
@@ -21,6 +23,8 @@
   import { Constants, emailValidator } from "@budibase/frontend-core"
   import { capitalise } from "@/helpers"
   import { OnboardingType } from "@/constants"
+  import { helpers } from "@budibase/shared-core"
+  import { onDestroy } from "svelte"
 
   export let showOnboardingTypeModal
   export let workspaceOnly = false
@@ -34,6 +38,11 @@
   let parsedEmails = []
   let pendingEmailInput = ""
   let emailError = null
+  let suggestedUsers = []
+  let isSearchingUsers = false
+  let userSearchTimeout
+  let userSearchId = 0
+  let highlightedUserIndex = -1
   const maxItems = 15
   let selectedRole = Constants.BudibaseRoles.Creator
   const builtInEndUserRoles = [Constants.Roles.BASIC, Constants.Roles.ADMIN]
@@ -161,8 +170,7 @@
     return userData[index].error == null
   }
 
-  function validateWorkspaceEmails() {
-    const emails = emailsInput
+  function validateWorkspaceEmails(emails = emailsInput) {
     if (!emails.length) {
       emailError = null
       return false
@@ -190,6 +198,105 @@
   const handleEmailsChange = () => {
     validateWorkspaceEmails()
   }
+
+  const searchExistingUsers = async search => {
+    const nextSearchId = ++userSearchId
+    const trimmedSearch = search.trim()
+    if (!trimmedSearch) {
+      suggestedUsers = []
+      return
+    }
+
+    isSearchingUsers = true
+    try {
+      const response = await API.searchUsers({
+        query: { string: { email: trimmedSearch } },
+        limit: 8,
+      })
+      if (nextSearchId !== userSearchId) {
+        return
+      }
+      const selectedEmails = new Set(emailsInput.map(email => email.trim()))
+      suggestedUsers = (response.data || []).filter(
+        user => user.email && !selectedEmails.has(user.email)
+      )
+      highlightedUserIndex = suggestedUsers.length ? 0 : -1
+    } catch (error) {
+      if (nextSearchId === userSearchId) {
+        suggestedUsers = []
+        highlightedUserIndex = -1
+      }
+    } finally {
+      if (nextSearchId === userSearchId) {
+        isSearchingUsers = false
+      }
+    }
+  }
+
+  const clearUserSearch = () => {
+    clearTimeout(userSearchTimeout)
+    userSearchId += 1
+    suggestedUsers = []
+    highlightedUserIndex = -1
+    isSearchingUsers = false
+  }
+
+  const handlePendingEmailInput = () => {
+    clearTimeout(userSearchTimeout)
+    if (!useWorkspaceInviteModal || !pendingEmailInput.trim()) {
+      clearUserSearch()
+      return
+    }
+    userSearchTimeout = setTimeout(
+      () => searchExistingUsers(pendingEmailInput),
+      500
+    )
+  }
+
+  const selectSuggestedUser = user => {
+    if (!user?.email || emailsInput.includes(user.email)) {
+      return
+    }
+    const nextEmails = [...emailsInput, user.email]
+    emailsInput = nextEmails
+    pendingEmailInput = ""
+    suggestedUsers = []
+    highlightedUserIndex = -1
+    validateWorkspaceEmails(nextEmails)
+  }
+
+  const updateHighlightedUser = direction => {
+    if (!suggestedUsers.length) {
+      return
+    }
+    const nextIndex =
+      highlightedUserIndex === -1
+        ? 0
+        : (highlightedUserIndex + direction + suggestedUsers.length) %
+          suggestedUsers.length
+    highlightedUserIndex = nextIndex
+  }
+
+  const handleEmailPickerKeydown = event => {
+    if (!suggestedUsers.length) {
+      return
+    }
+
+    if (event.detail?.key === "ArrowDown") {
+      event.detail.preventDefault()
+      updateHighlightedUser(1)
+    } else if (event.detail?.key === "ArrowUp") {
+      event.detail.preventDefault()
+      updateHighlightedUser(-1)
+    } else if (event.detail?.key === "Tab" && highlightedUserIndex >= 0) {
+      event.detail.preventDefault()
+      selectSuggestedUser(suggestedUsers[highlightedUserIndex])
+    }
+  }
+
+  onDestroy(() => {
+    clearTimeout(userSearchTimeout)
+  })
 
   function buildWorkspaceUsers() {
     return emailsInput.map(email => ({
@@ -271,15 +378,49 @@
   {#if useWorkspaceInviteModal}
     <div class="workspace-invite-modal">
       <Layout noPadding gap="S">
-        <PillInput
-          label="Type or paste emails below, separated by commas"
-          bind:value={emailsInput}
-          bind:inputValue={pendingEmailInput}
-          error={emailError}
-          splitOnSpace={true}
-          maxItems={maxItems + 1}
-          on:change={handleEmailsChange}
-        />
+        <div class="user-email-picker">
+          <PillInput
+            label="Type or paste emails below, separated by commas"
+            bind:value={emailsInput}
+            bind:inputValue={pendingEmailInput}
+            error={emailError}
+            splitOnSpace={true}
+            maxItems={maxItems + 1}
+            on:change={handleEmailsChange}
+            on:input={handlePendingEmailInput}
+            on:keydown={handleEmailPickerKeydown}
+          />
+
+          {#if suggestedUsers.length}
+            <div class="user-suggestions" role="listbox">
+              {#each suggestedUsers as user, index (user._id || user.email)}
+                <button
+                  class="user-suggestion"
+                  class:is-highlighted={highlightedUserIndex === index}
+                  type="button"
+                  role="option"
+                  aria-selected={highlightedUserIndex === index}
+                  on:mouseenter={() => (highlightedUserIndex = index)}
+                  on:mousedown|preventDefault={() => selectSuggestedUser(user)}
+                >
+                  <Avatar
+                    size="S"
+                    initials={helpers.getUserInitials(user)}
+                    color={helpers.getUserColor(user)}
+                  />
+                  <span class="user-suggestion-details">
+                    <span class="user-suggestion-name">
+                      {helpers.getUserLabel(user)}
+                    </span>
+                    <span class="user-suggestion-email">{user.email}</span>
+                  </span>
+                </button>
+              {/each}
+            </div>
+          {:else if isSearchingUsers}
+            <div class="user-suggestions loading">Searching...</div>
+          {/if}
+        </div>
 
         <GlobalRoleSelect
           bind:value={selectedRole}
@@ -443,5 +584,61 @@
   .workspace-invite-modal :global(.pill-input) {
     gap: 6px;
     padding: 8px;
+  }
+  .user-email-picker {
+    position: relative;
+  }
+  .user-suggestions {
+    position: absolute;
+    z-index: 2;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    padding: 4px;
+    border: 1px solid var(--spectrum-global-color-gray-200);
+    border-radius: var(--spectrum-global-dimension-size-50);
+    background: var(--spectrum-global-color-gray-50);
+    box-shadow: 0 1px 4px var(--drop-shadow);
+  }
+  .user-suggestions.loading {
+    color: var(--spectrum-global-color-gray-600);
+    font-size: 14px;
+    padding: 8px;
+  }
+  .user-suggestion {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s);
+    padding: 6px 8px;
+    border: 0;
+    border-radius: var(--spectrum-global-dimension-size-50);
+    background: transparent;
+    color: var(--spectrum-global-color-gray-800);
+    text-align: left;
+    cursor: pointer;
+  }
+  .user-suggestion:hover,
+  .user-suggestion.is-highlighted {
+    background: var(--spectrum-global-color-gray-100);
+  }
+  .user-suggestion-details {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  .user-suggestion-name,
+  .user-suggestion-email {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .user-suggestion-name {
+    font-size: 14px;
+    font-weight: 600;
+  }
+  .user-suggestion-email {
+    color: var(--spectrum-global-color-gray-600);
+    font-size: 12px;
   }
 </style>

--- a/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
+++ b/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
@@ -248,7 +248,7 @@
     }
     userSearchTimeout = setTimeout(
       () => searchExistingUsers(pendingEmailInput),
-      500
+      350
     )
   }
 


### PR DESCRIPTION
## Description
Adds existing user suggestions to the workspace invite email field. Typing in the pill input searches existing users, shows up to 8 matching users with avatars, and allows selection by mouse or keyboard.

## Addresses
- https://github.com/Budibase/budibase/issues/18637

## Screenshots
<img width="577" height="577" alt="one user match" src="https://github.com/user-attachments/assets/abf838e9-43c7-4995-990d-489470bb5192" />

**One user match**

<img width="577" height="577" alt="no user match" src="https://github.com/user-attachments/assets/66f8a253-a83c-4f24-9812-09649f3aea99" />

**No user match**

<img width="577" height="577" alt="8 user limit" src="https://github.com/user-attachments/assets/4e887f64-4e64-45db-8926-4646b29c2a8b" />

**Display up to eight users**

<img width="611" height="588" alt="selected" src="https://github.com/user-attachments/assets/7e09a6f4-633f-45b9-8605-c875fef85e88" />

**Existing user is disabled and checked**

## Launchcontrol
Workspace invites now suggest existing users while typing, making it easier to add current users to a workspace.

