### PR TITLE
Fix RAG search

### DIFF
--- a/hosting/docker-compose.dev.yaml
+++ b/hosting/docker-compose.dev.yaml
@@ -90,6 +90,8 @@ services:
   litellm-db:
     image: postgres:16
     restart: always
+    volumes:
+      - litellm_db_data:/var/lib/postgresql/data
     environment:
       POSTGRES_DB: ${LITELLM_DB_NAME}
       POSTGRES_USER: ${LITELLM_DB_USER}
@@ -107,4 +109,6 @@ volumes:
   minio_data:
     driver: local
   redis_data:
+    driver: local
+  litellm_db_data:
     driver: local

--- a/packages/server/src/sdk/workspace/ai/knowledgeBase/geminiFileStore.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/knowledgeBase/geminiFileStore.spec.ts
@@ -15,7 +15,6 @@ import {
   createGeminiFileStore,
   deleteGeminiFileFromStore,
   ingestGeminiFile,
-  searchGeminiFileStore,
 } from "./geminiFileStore"
 
 interface MockResponse {
@@ -141,37 +140,6 @@ describe("geminiFileStore", () => {
           fileId: "missing-file",
         })
       ).resolves.toBeUndefined()
-    })
-  })
-
-  it("sends file id filters when searching Gemini vector store", async () => {
-    await withEnv({ GEMINI_API_KEY: "test-gemini-key" }, async () => {
-      mockFetch.mockResolvedValue(response({ ok: true, status: 200, json: {} }))
-
-      await searchGeminiFileStore({
-        vectorStoreId: "vector-store-1",
-        query: "what is policy",
-        fileIds: ["file-1", "file-2"],
-      })
-
-      const body = JSON.parse(mockFetch.mock.calls[0][1].body)
-      expect(body.filters).toEqual({
-        file_ids: ["file-1", "file-2"],
-      })
-    })
-  })
-
-  it("does not send file id filters when searching without source ids", async () => {
-    await withEnv({ GEMINI_API_KEY: "test-gemini-key" }, async () => {
-      mockFetch.mockResolvedValue(response({ ok: true, status: 200, json: {} }))
-
-      await searchGeminiFileStore({
-        vectorStoreId: "vector-store-1",
-        query: "what is policy",
-      })
-
-      const body = JSON.parse(mockFetch.mock.calls[0][1].body)
-      expect(body.filters).toBeUndefined()
     })
   })
 })

--- a/packages/server/src/sdk/workspace/ai/knowledgeBase/geminiFileStore.ts
+++ b/packages/server/src/sdk/workspace/ai/knowledgeBase/geminiFileStore.ts
@@ -168,11 +168,9 @@ export async function ingestGeminiFile({
 export async function searchGeminiFileStore({
   vectorStoreId,
   query,
-  fileIds,
 }: {
   vectorStoreId: string
   query: string
-  fileIds?: string[]
 }): Promise<RagSearchResultItem[]> {
   const geminiApiKey = getGeminiApiKey()
   const response = await fetch(
@@ -184,7 +182,6 @@ export async function searchGeminiFileStore({
       headers: await getCommonAuthHeaders(),
       body: JSON.stringify({
         query,
-        ...(fileIds?.length ? { filters: { file_ids: fileIds } } : {}),
         custom_llm_provider: "gemini",
         ...(geminiApiKey ? { api_key: geminiApiKey } : {}),
       }),

--- a/packages/server/src/sdk/workspace/ai/rag/files.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/files.spec.ts
@@ -475,7 +475,7 @@ describe("rag files", () => {
       ])
     })
 
-    it("passes only current ready source ids to processor search", async () => {
+    it("searches processor once when ready files exist", async () => {
       mockKnowledgeBaseFind.mockResolvedValue(defaultKnowledgeBase)
       mockKnowledgeBaseListFiles.mockResolvedValue([
         {
@@ -518,10 +518,7 @@ describe("rag files", () => {
         chunks: [],
         sources: [],
       })
-      expect(mockProcessorSearch).toHaveBeenCalledWith("What is policy?", [
-        "source-ready-1",
-        "source-ready-2",
-      ])
+      expect(mockProcessorSearch).toHaveBeenCalledWith("What is policy?")
     })
 
     it("allows filename fallback only for currently ready files", async () => {

--- a/packages/server/src/sdk/workspace/ai/rag/files.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/files.ts
@@ -252,7 +252,7 @@ export const retrieveContextForAgent = async (
     const readyFileSourceIds = new Set(readyFileSources)
     const readySourceIdByFilename = getReadySourceIdByFilename(readyFiles)
     const processor = getProcessor(knowledgeBase)
-    const returned = await processor.search(question, readyFileSources)
+    const returned = await processor.search(question)
 
     for (const chunk of returned) {
       if (!chunk.source) {

--- a/packages/server/src/sdk/workspace/ai/rag/processors/gemini.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/processors/gemini.spec.ts
@@ -80,28 +80,4 @@ describe("GeminiRagProcessor", () => {
       },
     ])
   })
-
-  it("passes allowed source ids to Gemini vector store search", async () => {
-    mockSearchGeminiFileStore.mockResolvedValue([])
-
-    const processor = new GeminiRagProcessor({
-      _id: "kb_1",
-      name: "KB",
-      type: KnowledgeBaseType.GEMINI,
-      config: {
-        googleFileStoreId: "store_1",
-      },
-    } as any)
-
-    await processor.search("What is policy?", [
-      "gemini-file-1",
-      "gemini-file-2",
-    ])
-
-    expect(mockSearchGeminiFileStore).toHaveBeenCalledWith({
-      vectorStoreId: "store_1",
-      query: "What is policy?",
-      fileIds: ["gemini-file-1", "gemini-file-2"],
-    })
-  })
 })

--- a/packages/server/src/sdk/workspace/ai/rag/processors/gemini.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/processors/gemini.ts
@@ -74,14 +74,10 @@ export class GeminiRagProcessor implements RagProcessor {
     }
   }
 
-  async search(
-    question: string,
-    sourceIds?: string[]
-  ): Promise<RetrievedContextChunk[]> {
+  async search(question: string): Promise<RetrievedContextChunk[]> {
     const rows = await searchGeminiFileStore({
       vectorStoreId: this.knowledgeBase.config.googleFileStoreId,
       query: question,
-      fileIds: sourceIds,
     })
 
     const results = rows.map<RetrievedContextChunk>(row => {

--- a/packages/server/src/sdk/workspace/ai/rag/processors/index.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/processors/index.ts
@@ -11,9 +11,6 @@ export interface RagProcessor {
     fileBuffer: Buffer
   ): Promise<void>
 
-  search(
-    question: string,
-    sourceIds?: string[]
-  ): Promise<RetrievedContextChunk[]>
+  search(question: string): Promise<RetrievedContextChunk[]>
   deleteFiles(fileIds: string[]): Promise<void>
 }


### PR DESCRIPTION
## Description
Fix RAG search

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RAG search by removing per-file filtering and querying the Gemini vector store once per question. Also adds a persistent volume for `litellm-db` in dev to prevent data loss between restarts.

- **Bug Fixes**
  - Removed `fileIds` from Gemini vector store search; `RagProcessor.search` now uses `search(question)` with no per-file filters.
  - Updated Gemini processor and tests; retrieval runs a single search when ready files exist.
  - Added `litellm_db_data` volume to `docker-compose.dev` for persistent `litellm-db` storage.

<sup>Written for commit 8388a7d7ef7d9f8025857f14cdfa8a7c809f84c9. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18640?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

