### PR TITLE
Add core-only agent dev stack

### DIFF
--- a/.agents/skills/budibase-setup-run/SKILL.md
+++ b/.agents/skills/budibase-setup-run/SKILL.md
@@ -57,7 +57,7 @@ yarn build
 yarn dev:agent
 ```
 
-`yarn dev:agent` preserves existing build artifacts by skipping the root clean/prebuild step. Use it after a successful build or when restoring a VM image that already contains valid `dist` outputs.
+`yarn dev:agent` preserves existing build artifacts by skipping the root clean/prebuild step. It also starts only the core Docker services and disables LiteLLM readiness checks for the dev process, which keeps startup lighter in constrained VM environments. Use it after a successful build or when restoring a VM image that already contains valid `dist` outputs.
 
 ## Manual Setup
 
@@ -92,7 +92,7 @@ For automated VM runs after a successful build, use:
 yarn dev:agent
 ```
 
-This keeps the normal developer workflow unchanged while reducing startup work in cached environments.
+This keeps the normal developer workflow unchanged while reducing startup work and memory usage in cached environments.
 
 Access Budibase at:
 
@@ -164,20 +164,6 @@ Run the optimized automated-environment startup path:
 
 ```bash
 yarn dev:agent
-```
-
-Run frontend/dev stack without local server processes:
-
-```bash
-yarn dev:noserver
-```
-
-Switch development modes:
-
-```bash
-yarn mode:self
-yarn mode:cloud
-yarn mode:account
 ```
 
 ## Troubleshooting

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "kill-all": "yarn run kill-builder && yarn run kill-server && yarn kill-accountportal",
     "dev:init": "node scripts/dev/manage.js",
     "dev": "yarn dev:init && yarn run kill-all && lerna run --parallel prebuild && lerna run --stream dev",
-    "dev:agent": "yarn dev:init && lerna run --stream dev",
+    "dev:agent": "yarn dev:init && BUDIBASE_DEV_STACK=core LITELLM_MASTER_KEY= lerna run --stream dev",
     "dev:noserver": "yarn dev:init && yarn run kill-builder && lerna run --stream dev:stack:up && lerna run --stream dev --ignore @budibase/backend-core --ignore @budibase/server --ignore @budibase/worker",
     "dev:server": "yarn dev:init && yarn run kill-server && lerna run --stream dev --scope @budibase/worker --scope @budibase/server",
     "dev:built": "yarn dev:init && yarn run kill-all && cd packages/server && yarn dev:stack:up && cd ../../ && lerna run --stream dev:built",

--- a/packages/server/scripts/dev/manage.js
+++ b/packages/server/scripts/dev/manage.js
@@ -9,6 +9,14 @@ const CONFIG = {
   log: true,
 }
 
+const CORE_SERVICES = [
+  "minio-service",
+  "proxy-service",
+  "couchdb-service",
+  "redis-service",
+]
+const NON_CORE_SERVICES = ["litellm-service", "litellm-db"]
+
 const Commands = {
   Up: "up",
   Down: "down",
@@ -17,7 +25,13 @@ const Commands = {
 
 async function up() {
   console.log("Spinning up your budibase dev environment... 🔧✨")
-  await compose.upAll(CONFIG)
+
+  if (process.env.BUDIBASE_DEV_STACK === "core") {
+    await compose.stopMany(NON_CORE_SERVICES, CONFIG)
+    await compose.upMany(CORE_SERVICES, CONFIG)
+  } else {
+    await compose.upAll(CONFIG)
+  }
 
   // We always ensure to restart the proxy service in case of nginx conf changes
   await compose.restartOne("proxy-service", CONFIG)

--- a/packages/server/scripts/dev/manage.js
+++ b/packages/server/scripts/dev/manage.js
@@ -27,7 +27,7 @@ async function up() {
   console.log("Spinning up your budibase dev environment... 🔧✨")
 
   if (process.env.BUDIBASE_DEV_STACK === "core") {
-    await compose.stopMany(NON_CORE_SERVICES, CONFIG)
+    await compose.stopMany(CONFIG, ...NON_CORE_SERVICES)
     await compose.upMany(CORE_SERVICES, CONFIG)
   } else {
     await compose.upAll(CONFIG)


### PR DESCRIPTION
## Summary
- Add a lighter `yarn dev:agent` path for automated VM environments
- Start only the core Docker services and disable LiteLLM readiness checks for that path
- Update the setup skill to describe the agent-specific startup flow and remove extra dev-mode guidance

## Testing
- Validated the updated skill files with the skill validator
- Checked the updated Node scripts parse cleanly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a core-only agent dev stack for automated VM runs. It starts only essential Docker services and makes `yarn dev:agent` faster and lighter.

- **New Features**
  - `dev:agent` now sets `BUDIBASE_DEV_STACK=core` and unsets `LITELLM_MASTER_KEY` to keep startup minimal.
  - `packages/server/scripts/dev/manage.js` brings up core services only (minio, proxy, couchdb, redis) and stops LiteLLM services; proxy still restarts for config changes.
  - Updated `.agents/skills/budibase-setup-run/SKILL.md` to document the agent-specific startup flow and remove extra dev-mode steps.

- **Bug Fixes**
  - Corrected `compose.stopMany` argument order in core mode to reliably stop LiteLLM services.

<sup>Written for commit b5d666726b96f2ba24249f84ab1af203f4046ca6. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18641?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

