### PR TITLE
Fix/surface all table import errors

### DIFF
--- a/packages/builder/src/stores/builder/datasources.ts
+++ b/packages/builder/src/stores/builder/datasources.ts
@@ -26,7 +26,11 @@ class TableImportError extends Error {
   errors: Record<string, string>
 
   constructor(errors: Record<string, string>) {
-    super()
+    super(
+      Object.entries(errors)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join("\n")
+    )
     this.name = "TableImportError"
     this.errors = errors
   }


### PR DESCRIPTION
## Description
On a 200 sync-tables response there can potentially be an error object included containing a list of all the failed imports. This was being ignored in the frontend and no information was being relayed to the user.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces table import failures in 200 OK sync-tables responses by throwing a `TableImportError` whose message lists all errors as “table: reason” lines. Users now see per-table failures instead of silent success.

<sup>Written for commit 2300c1c7212e9c9bdaa9cd8b140a0c2e2f540524. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18644?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

