### PR TITLE
Display hidden auth connections

### DIFF
--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -172,7 +172,7 @@ const environment = {
   MICROSOFT_TENANT_ID: process.env.MICROSOFT_TENANT_ID,
   RAG_SHAREPOINT_DEFAULT_SCOPE:
     process.env.RAG_SHAREPOINT_DEFAULT_SCOPE ||
-    "offline_access https://graph.microsoft.com/Sites.Read.All",
+    "offline_access User.Read https://graph.microsoft.com/Sites.Read.All",
   SALT_ROUNDS: process.env.SALT_ROUNDS,
   REDIS_URL: process.env.REDIS_URL || "localhost:6379",
   REDIS_PASSWORD: process.env.REDIS_PASSWORD,

--- a/packages/builder/src/settings/pages/connections/KnowledgeConnections.svelte
+++ b/packages/builder/src/settings/pages/connections/KnowledgeConnections.svelte
@@ -8,7 +8,6 @@
   interface KnowledgeConnectionRow {
     icon: string
     connectionName: string
-    sites: string
     usedBy: string
   }
 
@@ -21,8 +20,7 @@
 
   const schema = {
     icon: { width: "40px", displayName: "" },
-    connectionName: { width: "220px", displayName: "Connection" },
-    sites: { width: "1fr", displayName: "Sites" },
+    connectionName: { width: "1fr", displayName: "Connection" },
     usedBy: { width: "260px", displayName: "Used by" },
   }
 
@@ -33,7 +31,6 @@
       .map(connection => ({
         icon: connection.sourceType,
         connectionName: connection.connectionKey,
-        sites: connection.connectionKey,
         usedBy: "-",
       }))
       .sort((a, b) => a.connectionName.localeCompare(b.connectionName))

--- a/packages/builder/src/settings/pages/connections/KnowledgeConnections.svelte
+++ b/packages/builder/src/settings/pages/connections/KnowledgeConnections.svelte
@@ -22,7 +22,7 @@
 
   const schema = {
     icon: { width: "40px", displayName: "" },
-    connectionName: { width: "1fr", displayName: "Connection" },
+    connectionName: { width: "160px", displayName: "Connection" },
     account: { width: "1fr", displayName: "Account" },
     useCount: { width: "60px", displayName: "#" },
   }

--- a/packages/builder/src/settings/pages/connections/KnowledgeConnections.svelte
+++ b/packages/builder/src/settings/pages/connections/KnowledgeConnections.svelte
@@ -2,10 +2,7 @@
   import { onMount } from "svelte"
   import { Layout, Table, Body } from "@budibase/bbui"
   import { API } from "@/api"
-  import {
-    AgentKnowledgeSourceType,
-    type AgentKnowledgeSourceConnection,
-  } from "@budibase/types"
+  import { AgentKnowledgeSourceType } from "@budibase/types"
   import KnowledgeConnectionIconRenderer from "./_components/KnowledgeConnectionIconRenderer.svelte"
   import { agentsStore } from "@/stores/portal"
 
@@ -13,7 +10,6 @@
     id: string
     icon: string
     connectionName: string
-    tenant: string
     account: string
   }
 
@@ -26,24 +22,9 @@
 
   const schema = {
     icon: { width: "40px", displayName: "" },
-    connectionName: { width: "200px", displayName: "Connection" },
-    tenant: { width: "1fr", displayName: "Tenant" },
+    connectionName: { width: "1fr", displayName: "Connection" },
     account: { width: "1fr", displayName: "Account" },
     useCount: { width: "60px", displayName: "#" },
-  }
-
-  const toConnectionRows = (
-    connections: AgentKnowledgeSourceConnection[]
-  ): KnowledgeConnectionRow[] => {
-    return connections
-      .map(connection => ({
-        id: connection._id!,
-        icon: connection.sourceType,
-        connectionName: "Microsoft",
-        tenant: connection.tenant || connection.tenantId || "-",
-        account: connection.account || "-",
-      }))
-      .sort((a, b) => a.connectionName.localeCompare(b.connectionName))
   }
 
   let loading = $state(true)
@@ -70,7 +51,14 @@
           }
         },
       ])
-      rows = toConnectionRows(response.connections || [])
+      rows = (response.connections || [])
+        .map(connection => ({
+          id: connection._id!,
+          icon: connection.sourceType,
+          connectionName: "Microsoft",
+          account: connection.account || "-",
+        }))
+        .sort((a, b) => a.connectionName.localeCompare(b.connectionName))
     } finally {
       loading = false
     }

--- a/packages/builder/src/settings/pages/connections/KnowledgeConnections.svelte
+++ b/packages/builder/src/settings/pages/connections/KnowledgeConnections.svelte
@@ -8,6 +8,8 @@
   interface KnowledgeConnectionRow {
     icon: string
     connectionName: string
+    tenant: string
+    account: string
     usedBy: string
   }
 
@@ -20,7 +22,9 @@
 
   const schema = {
     icon: { width: "40px", displayName: "" },
-    connectionName: { width: "1fr", displayName: "Connection" },
+    connectionName: { width: "200px", displayName: "Connection" },
+    tenant: { width: "1fr", displayName: "Tenant" },
+    account: { width: "1fr", displayName: "Account" },
     usedBy: { width: "260px", displayName: "Used by" },
   }
 
@@ -30,7 +34,9 @@
     return connections
       .map(connection => ({
         icon: connection.sourceType,
-        connectionName: connection.connectionKey,
+        connectionName: "Microsoft",
+        tenant: connection.tenant || connection.tenantId || "-",
+        account: connection.account || "-",
         usedBy: "-",
       }))
       .sort((a, b) => a.connectionName.localeCompare(b.connectionName))

--- a/packages/builder/src/settings/pages/connections/KnowledgeConnections.svelte
+++ b/packages/builder/src/settings/pages/connections/KnowledgeConnections.svelte
@@ -62,7 +62,14 @@
 
   onMount(async () => {
     try {
-      const response = await API.fetchAgentKnowledgeSourceConnections()
+      const [response] = await Promise.all([
+        API.fetchAgentKnowledgeSourceConnections(),
+        async () => {
+          if (!$agentsStore.agentsLoaded) {
+            await agentsStore.init()
+          }
+        },
+      ])
       rows = toConnectionRows(response.connections || [])
     } finally {
       loading = false

--- a/packages/builder/src/settings/pages/connections/KnowledgeConnections.svelte
+++ b/packages/builder/src/settings/pages/connections/KnowledgeConnections.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
   import { onMount } from "svelte"
   import { Layout, Table, Body } from "@budibase/bbui"
-  import { agentsStore } from "@/stores/portal"
-  import {
-    AgentKnowledgeSourceType,
-    type AgentKnowledgeSource,
-  } from "@budibase/types"
+  import { API } from "@/api"
+  import type { AgentKnowledgeSourceConnection } from "@budibase/types"
   import KnowledgeConnectionIconRenderer from "./_components/KnowledgeConnectionIconRenderer.svelte"
 
   interface KnowledgeConnectionRow {
@@ -29,62 +26,26 @@
     usedBy: { width: "260px", displayName: "Used by" },
   }
 
-  const compactList = (values: string[], max = 2) => {
-    if (values.length <= max) {
-      return values.join(", ")
-    }
-    return `${values.slice(0, max).join(", ")} +${values.length - max} more`
-  }
-
-  const toConnectionRows = (): KnowledgeConnectionRow[] => {
-    const siteNames = new Set<string>()
-    const agentNames = new Set<string>()
-
-    for (const agent of $agentsStore.agents) {
-      for (const source of (agent.knowledgeSources ||
-        []) as AgentKnowledgeSource[]) {
-        if (source.type !== AgentKnowledgeSourceType.SHAREPOINT) {
-          continue
-        }
-        const site = source.config.site
-        const siteId = site?.id?.trim()
-        if (!siteId) {
-          continue
-        }
-        siteNames.add(site?.name || site?.webUrl || siteId)
-        agentNames.add(agent.name || agent._id || "Agent")
-      }
-    }
-
-    if (siteNames.size === 0) {
-      return []
-    }
-
-    const orderedSites = Array.from(siteNames).sort((a, b) =>
-      a.localeCompare(b)
-    )
-    const orderedAgents = Array.from(agentNames).sort((a, b) =>
-      a.localeCompare(b)
-    )
-
-    return [
-      {
-        icon: "sharepoint",
-        connectionName: "SharePoint",
-        sites: compactList(orderedSites),
-        usedBy: compactList(orderedAgents),
-      } satisfies KnowledgeConnectionRow,
-    ]
+  const toConnectionRows = (
+    connections: AgentKnowledgeSourceConnection[]
+  ): KnowledgeConnectionRow[] => {
+    return connections
+      .map(connection => ({
+        icon: connection.sourceType,
+        connectionName: connection.connectionKey,
+        sites: connection.connectionKey,
+        usedBy: "-",
+      }))
+      .sort((a, b) => a.connectionName.localeCompare(b.connectionName))
   }
 
   let loading = $state(true)
-  let rows = $derived(toConnectionRows())
+  let rows = $state<KnowledgeConnectionRow[]>([])
 
   onMount(async () => {
     try {
-      if (!$agentsStore.agentsLoaded) {
-        await agentsStore.init()
-      }
+      const response = await API.fetchAgentKnowledgeSourceConnections()
+      rows = toConnectionRows(response.connections || [])
     } finally {
       loading = false
     }

--- a/packages/builder/src/settings/pages/connections/KnowledgeConnections.svelte
+++ b/packages/builder/src/settings/pages/connections/KnowledgeConnections.svelte
@@ -2,15 +2,19 @@
   import { onMount } from "svelte"
   import { Layout, Table, Body } from "@budibase/bbui"
   import { API } from "@/api"
-  import type { AgentKnowledgeSourceConnection } from "@budibase/types"
+  import {
+    AgentKnowledgeSourceType,
+    type AgentKnowledgeSourceConnection,
+  } from "@budibase/types"
   import KnowledgeConnectionIconRenderer from "./_components/KnowledgeConnectionIconRenderer.svelte"
+  import { agentsStore } from "@/stores/portal"
 
   interface KnowledgeConnectionRow {
+    id: string
     icon: string
     connectionName: string
     tenant: string
     account: string
-    usedBy: string
   }
 
   const customRenderers = [
@@ -25,7 +29,7 @@
     connectionName: { width: "200px", displayName: "Connection" },
     tenant: { width: "1fr", displayName: "Tenant" },
     account: { width: "1fr", displayName: "Account" },
-    usedBy: { width: "260px", displayName: "Used by" },
+    useCount: { width: "60px", displayName: "#" },
   }
 
   const toConnectionRows = (
@@ -33,17 +37,28 @@
   ): KnowledgeConnectionRow[] => {
     return connections
       .map(connection => ({
+        id: connection._id!,
         icon: connection.sourceType,
         connectionName: "Microsoft",
         tenant: connection.tenant || connection.tenantId || "-",
         account: connection.account || "-",
-        usedBy: "-",
       }))
       .sort((a, b) => a.connectionName.localeCompare(b.connectionName))
   }
 
   let loading = $state(true)
   let rows = $state<KnowledgeConnectionRow[]>([])
+
+  let enrichedRows = $derived(
+    rows.map(r => ({
+      ...r,
+      useCount: $agentsStore.agents.filter(a =>
+        a.knowledgeSources?.some(
+          s => s.type === AgentKnowledgeSourceType.SHAREPOINT
+        )
+      ).length,
+    }))
+  )
 
   onMount(async () => {
     try {
@@ -60,7 +75,7 @@
     <div class="section-title">Connected knowledge sources</div>
   </div>
 
-  {#if !loading && rows.length === 0}
+  {#if !loading && enrichedRows.length === 0}
     <div class="empty-state">
       <Body size="S">No knowledge sources are currently connected.</Body>
     </div>
@@ -68,7 +83,7 @@
     <Table
       compact
       rounded
-      data={rows}
+      data={enrichedRows}
       {loading}
       {schema}
       {customRenderers}

--- a/packages/frontend-core/src/api/agents.ts
+++ b/packages/frontend-core/src/api/agents.ts
@@ -8,6 +8,7 @@ import {
   DuplicateAgentResponse,
   FetchAgentKnowledgeResponse,
   FetchAgentKnowledgeSourceEntriesResponse,
+  FetchAgentKnowledgeSourceConnectionsResponse,
   FetchAgentKnowledgeSourceOptionsResponse,
   FetchAgentsResponse,
   ProvisionAgentSlackChannelRequest,
@@ -72,6 +73,7 @@ export interface AgentEndpoints {
   fetchAgentKnowledgeSourceOptions: (
     agentId: string
   ) => Promise<FetchAgentKnowledgeSourceOptionsResponse>
+  fetchAgentKnowledgeSourceConnections: () => Promise<FetchAgentKnowledgeSourceConnectionsResponse>
   fetchAgentKnowledgeSourceAllEntries: (
     agentId: string,
     siteId: string
@@ -221,6 +223,12 @@ export const buildAgentEndpoints = (API: BaseAPIClient): AgentEndpoints => ({
   fetchAgentKnowledgeSourceOptions: async (agentId: string) => {
     return await API.get<FetchAgentKnowledgeSourceOptionsResponse>({
       url: `/api/agent/${agentId}/knowledge-sources/options`,
+    })
+  },
+
+  fetchAgentKnowledgeSourceConnections: async () => {
+    return await API.get<FetchAgentKnowledgeSourceConnectionsResponse>({
+      url: "/api/agent/knowledge-sources/connections",
     })
   },
 

--- a/packages/server/src/api/controllers/ai/files.ts
+++ b/packages/server/src/api/controllers/ai/files.ts
@@ -18,6 +18,8 @@ import {
   SyncAgentKnowledgeSourcesResponse,
   UserCtx,
   KnowledgeBaseFileStatus,
+  AgentKnowledgeSourceConnectionSummary,
+  RequiredKeys,
 } from "@budibase/types"
 import sdk from "../../../sdk"
 import { getSharePointSiteIds, getSharePointSources } from "./sharepoint"
@@ -119,7 +121,21 @@ export async function fetchAgentKnowledgeSourceConnections(
 ) {
   const connections =
     await sdk.ai.knowledgeSources.listKnowledgeSourceConnections()
-  ctx.body = { connections }
+  ctx.body = {
+    connections: connections.map(
+      connection =>
+        ({
+          _id: connection._id,
+          _rev: connection._rev,
+          createdAt: connection.createdAt,
+          updatedAt: connection.updatedAt,
+          sourceType: connection.sourceType,
+          connectionKey: connection.connectionKey,
+          tenant: connection.tenant,
+          account: connection.account,
+        }) satisfies RequiredKeys<AgentKnowledgeSourceConnectionSummary>
+    ),
+  }
   ctx.status = 200
 }
 

--- a/packages/server/src/api/controllers/ai/files.ts
+++ b/packages/server/src/api/controllers/ai/files.ts
@@ -12,6 +12,7 @@ import {
   FetchAgentKnowledgeResponse,
   FetchAgentKnowledgeSourceOptionsResponse,
   FetchAgentKnowledgeSourceEntriesResponse,
+  FetchAgentKnowledgeSourceConnectionsResponse,
   isKnowledgeFileSupported,
   SyncAgentKnowledgeSourcesRequest,
   SyncAgentKnowledgeSourcesResponse,
@@ -110,6 +111,15 @@ export async function fetchAgentKnowledge(
     hasSharePointConnection,
     sharePointSources,
   }
+  ctx.status = 200
+}
+
+export async function fetchAgentKnowledgeSourceConnections(
+  ctx: UserCtx<void, FetchAgentKnowledgeSourceConnectionsResponse>
+) {
+  const connections =
+    await sdk.ai.knowledgeSources.listKnowledgeSourceConnections()
+  ctx.body = { connections }
   ctx.status = 200
 }
 

--- a/packages/server/src/api/controllers/ai/files.ts
+++ b/packages/server/src/api/controllers/ai/files.ts
@@ -131,7 +131,6 @@ export async function fetchAgentKnowledgeSourceConnections(
           updatedAt: connection.updatedAt,
           sourceType: connection.sourceType,
           connectionKey: connection.connectionKey,
-          tenant: connection.tenant,
           account: connection.account,
         }) satisfies RequiredKeys<AgentKnowledgeSourceConnectionSummary>
     ),

--- a/packages/server/src/api/controllers/ai/sharepointAuth.ts
+++ b/packages/server/src/api/controllers/ai/sharepointAuth.ts
@@ -14,6 +14,7 @@ const DEFAULT_SCOPE = env.RAG_SHAREPOINT_DEFAULT_SCOPE
 const STATE_CACHE_TTL_SECONDS = 600
 const MICROSOFT_PROVIDER = "microsoft"
 const SHAREPOINT_SOURCE_TYPE = "sharepoint"
+const MICROSOFT_GRAPH_BASE = "https://graph.microsoft.com/v1.0"
 
 const getMicrosoftConfig = () => {
   if (!env.MICROSOFT_CLIENT_ID || !env.MICROSOFT_CLIENT_SECRET) {
@@ -178,6 +179,40 @@ export async function completeSharePointAuth(ctx: UserCtx<void, void>) {
   }
 
   const expiresIn = Number(tokenPayload?.expires_in || 0)
+  const tokenType = tokenPayload?.token_type || "Bearer"
+  const bearerToken = `${tokenType} ${accessToken}`
+  let account = "unknown"
+
+  try {
+    const meResponse = await fetch(`${MICROSOFT_GRAPH_BASE}/me?$select=displayName,mail,userPrincipalName`, {
+      headers: {
+        Authorization: bearerToken,
+      },
+    })
+    if (meResponse.ok) {
+      const mePayload = await meResponse.json()
+      const mail =
+        typeof mePayload?.mail === "string"
+          ? mePayload.mail.trim()
+          : ""
+      const upn =
+        typeof mePayload?.userPrincipalName === "string"
+          ? mePayload.userPrincipalName.trim()
+          : ""
+      account = mail || upn || "unknown"
+    } else {
+      console.log("Unable to fetch Microsoft account profile after OAuth", {
+        appId,
+        status: meResponse.status,
+      })
+    }
+  } catch (error) {
+    console.log("Unable to fetch Microsoft account profile after OAuth", {
+      appId,
+      error,
+    })
+  }
+  const tenant = tenantId || "unknown"
 
   await context.doInContext(appId, () =>
     sdk.ai.knowledgeSources.upsertKnowledgeSourceConnection(
@@ -188,10 +223,12 @@ export async function completeSharePointAuth(ctx: UserCtx<void, void>) {
         tokenEndpoint,
         accessToken,
         refreshToken,
-        tokenType: tokenPayload?.token_type || "Bearer",
+        tokenType,
         expiresAt: Date.now() + Math.max((expiresIn || 0) - 60, 0) * 1000,
         clientId,
         clientSecret,
+        tenant,
+        account,
       }
     )
   )

--- a/packages/server/src/api/controllers/ai/sharepointAuth.ts
+++ b/packages/server/src/api/controllers/ai/sharepointAuth.ts
@@ -213,8 +213,6 @@ export async function completeSharePointAuth(ctx: UserCtx<void, void>) {
       error,
     })
   }
-  const tenant = tenantId || "unknown"
-
   await context.doInContext(appId, () =>
     sdk.ai.knowledgeSources.upsertKnowledgeSourceConnection(
       SHAREPOINT_SOURCE_TYPE,
@@ -228,7 +226,6 @@ export async function completeSharePointAuth(ctx: UserCtx<void, void>) {
         expiresAt: Date.now() + Math.max((expiresIn || 0) - 60, 0) * 1000,
         clientId,
         clientSecret,
-        tenant,
         account,
       }
     )

--- a/packages/server/src/api/controllers/ai/sharepointAuth.ts
+++ b/packages/server/src/api/controllers/ai/sharepointAuth.ts
@@ -184,17 +184,18 @@ export async function completeSharePointAuth(ctx: UserCtx<void, void>) {
   let account = "unknown"
 
   try {
-    const meResponse = await fetch(`${MICROSOFT_GRAPH_BASE}/me?$select=displayName,mail,userPrincipalName`, {
-      headers: {
-        Authorization: bearerToken,
-      },
-    })
+    const meResponse = await fetch(
+      `${MICROSOFT_GRAPH_BASE}/me?$select=displayName,mail,userPrincipalName`,
+      {
+        headers: {
+          Authorization: bearerToken,
+        },
+      }
+    )
     if (meResponse.ok) {
       const mePayload = await meResponse.json()
       const mail =
-        typeof mePayload?.mail === "string"
-          ? mePayload.mail.trim()
-          : ""
+        typeof mePayload?.mail === "string" ? mePayload.mail.trim() : ""
       const upn =
         typeof mePayload?.userPrincipalName === "string"
           ? mePayload.userPrincipalName.trim()

--- a/packages/server/src/api/routes/aiAgents.ts
+++ b/packages/server/src/api/routes/aiAgents.ts
@@ -67,6 +67,10 @@ const aiRagBuilderAdminRoutes = endpointGroupList
 
 aiRagBuilderAdminRoutes
   .get(
+    "/api/agent/knowledge-sources/connections",
+    ai.fetchAgentKnowledgeSourceConnections
+  )
+  .get(
     "/api/agent/knowledge-sources/sharepoint/connect",
     ai.startSharePointAuth
   )

--- a/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
@@ -132,7 +132,6 @@ describe("agent files", () => {
         "sharepoint",
         sharePointConnectionCacheKey("connection", workspaceConnectionId),
         {
-          tenant: "microsoft-account",
           account: "connected-sharepoint@budibase.com",
           tenantId: config.getTenantId(),
           tokenEndpoint:

--- a/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
@@ -132,6 +132,8 @@ describe("agent files", () => {
         "sharepoint",
         sharePointConnectionCacheKey("connection", workspaceConnectionId),
         {
+          tenant: "microsoft-account",
+          account: "connected-sharepoint@budibase.com",
           tenantId: config.getTenantId(),
           tokenEndpoint:
             "https://login.microsoftonline.com/common/oauth2/v2.0/token",

--- a/packages/server/src/sdk/workspace/ai/knowledgeSources/connections.ts
+++ b/packages/server/src/sdk/workspace/ai/knowledgeSources/connections.ts
@@ -1,5 +1,9 @@
 import { context, docIds } from "@budibase/backend-core"
-import type { AgentKnowledgeSourceConnection } from "@budibase/types"
+import {
+  DocumentType,
+  prefixed,
+  type AgentKnowledgeSourceConnection,
+} from "@budibase/types"
 
 const getConnectionDocId = (sourceType: string, connectionKey: string) =>
   docIds.generateAgentKnowledgeSourceConnectionID(sourceType, connectionKey)
@@ -66,4 +70,19 @@ export const hasKnowledgeSourceConnection = async (
     connectionKey
   )
   return !!connection?.refreshToken
+}
+
+export const listKnowledgeSourceConnections = async () => {
+  const db = context.getWorkspaceDB()
+  const response = await db.allDocs<AgentKnowledgeSourceConnection>({
+    include_docs: true,
+    startkey: prefixed(DocumentType.AGENT_KNOWLEDGE_SOURCE_CONNECTION),
+    endkey: `${prefixed(DocumentType.AGENT_KNOWLEDGE_SOURCE_CONNECTION)}\ufff0`,
+  })
+
+  return response.rows
+    .map(row => row.doc)
+    .filter(
+      (doc): doc is AgentKnowledgeSourceConnection => !!doc && !doc._deleted
+    )
 }

--- a/packages/server/src/sdk/workspace/ai/sharepoint/connection.ts
+++ b/packages/server/src/sdk/workspace/ai/sharepoint/connection.ts
@@ -11,16 +11,18 @@ import {
   upsertKnowledgeSourceConnection,
 } from "../knowledgeSources"
 
-interface SharePointConnectionCacheRecord {
-  tenantId: string
-  tokenEndpoint: string
-  accessToken: string
-  refreshToken: string
-  tokenType?: string
-  expiresAt?: number
-  clientId: string
-  clientSecret: string
-}
+type SharePointConnectionRecord = Pick<
+  AgentKnowledgeSourceConnection,
+  | "account"
+  | "tenantId"
+  | "tokenEndpoint"
+  | "accessToken"
+  | "refreshToken"
+  | "tokenType"
+  | "expiresAt"
+  | "clientId"
+  | "clientSecret"
+>
 
 const SHAREPOINT_API_BASE = "https://graph.microsoft.com/v1.0"
 const SHAREPOINT_API_BASE_URL = new URL(SHAREPOINT_API_BASE)
@@ -51,12 +53,13 @@ interface SharePointConnectionDoc extends AgentKnowledgeSourceConnection {
 
 const persistConnection = async (
   connectionKey: string,
-  connection: SharePointConnectionCacheRecord
+  connection: SharePointConnectionRecord
 ) => {
   await upsertKnowledgeSourceConnection<SharePointConnectionDoc>(
     SHAREPOINT_SOURCE_TYPE,
     connectionKey,
     {
+      account: connection.account,
       tenantId: connection.tenantId,
       tokenEndpoint: connection.tokenEndpoint,
       accessToken: connection.accessToken,
@@ -69,10 +72,11 @@ const persistConnection = async (
   )
 }
 
-const mapPersistedToCacheRecord = (
+const mapPersistedToConnectionRecord = (
   doc: SharePointConnectionDoc
-): SharePointConnectionCacheRecord => {
+): SharePointConnectionRecord => {
   return {
+    account: doc.account || "unknown",
     tenantId: doc.tenantId,
     tokenEndpoint: doc.tokenEndpoint,
     accessToken: doc.accessToken,
@@ -86,7 +90,7 @@ const mapPersistedToCacheRecord = (
 
 const readPersistedConnection = async (
   connectionKey: string
-): Promise<SharePointConnectionCacheRecord | undefined> => {
+): Promise<SharePointConnectionRecord | undefined> => {
   const doc = await getKnowledgeSourceConnection<SharePointConnectionDoc>(
     SHAREPOINT_SOURCE_TYPE,
     connectionKey
@@ -94,12 +98,12 @@ const readPersistedConnection = async (
   if (!doc?.refreshToken) {
     return
   }
-  return mapPersistedToCacheRecord(doc)
+  return mapPersistedToConnectionRecord(doc)
 }
 
 const readConnection = async (
   connectionKey: string
-): Promise<SharePointConnectionCacheRecord> => {
+): Promise<SharePointConnectionRecord> => {
   const persistedConnection = await readPersistedConnection(connectionKey)
   if (persistedConnection?.refreshToken) {
     return persistedConnection
@@ -112,8 +116,8 @@ const readConnection = async (
 
 const refreshConnection = async (
   connectionKey: string,
-  connection: SharePointConnectionCacheRecord
-): Promise<SharePointConnectionCacheRecord> => {
+  connection: SharePointConnectionRecord
+): Promise<SharePointConnectionRecord> => {
   const response = await fetch(connection.tokenEndpoint, {
     method: "POST",
     headers: {
@@ -137,7 +141,7 @@ const refreshConnection = async (
   }
 
   const expiresIn = Number(payload?.expires_in || 0)
-  const updated: SharePointConnectionCacheRecord = {
+  const updated: SharePointConnectionRecord = {
     ...connection,
     accessToken: payload?.access_token || connection.accessToken,
     refreshToken: payload?.refresh_token || connection.refreshToken,

--- a/packages/types/src/api/web/global/agents.ts
+++ b/packages/types/src/api/web/global/agents.ts
@@ -2,6 +2,7 @@ import { Optional } from "../../../shared"
 import {
   Agent,
   AgentKnowledgeSourceFilterConfig,
+  AgentKnowledgeSourceConnection,
   AgentKnowledgeSourceSyncRunStatus,
   ChatApp,
   ChatConversation,
@@ -57,6 +58,10 @@ export interface FetchAgentKnowledgeResponse {
   files: KnowledgeBaseFile[]
   hasSharePointConnection: boolean
   sharePointSources: SharePointKnowledgeSourceSnapshot[]
+}
+
+export interface FetchAgentKnowledgeSourceConnectionsResponse {
+  connections: AgentKnowledgeSourceConnection[]
 }
 
 export interface KnowledgeSourceEntry {

--- a/packages/types/src/api/web/global/agents.ts
+++ b/packages/types/src/api/web/global/agents.ts
@@ -68,7 +68,6 @@ export type AgentKnowledgeSourceConnectionSummary = Pick<
   | "updatedAt"
   | "sourceType"
   | "connectionKey"
-  | "tenant"
   | "account"
 >
 

--- a/packages/types/src/api/web/global/agents.ts
+++ b/packages/types/src/api/web/global/agents.ts
@@ -60,8 +60,20 @@ export interface FetchAgentKnowledgeResponse {
   sharePointSources: SharePointKnowledgeSourceSnapshot[]
 }
 
+export type AgentKnowledgeSourceConnectionSummary = Pick<
+  AgentKnowledgeSourceConnection,
+  | "_id"
+  | "_rev"
+  | "createdAt"
+  | "updatedAt"
+  | "sourceType"
+  | "connectionKey"
+  | "tenant"
+  | "account"
+>
+
 export interface FetchAgentKnowledgeSourceConnectionsResponse {
-  connections: AgentKnowledgeSourceConnection[]
+  connections: AgentKnowledgeSourceConnectionSummary[]
 }
 
 export interface KnowledgeSourceEntry {

--- a/packages/types/src/documents/global/agentKnowledgeSourceConnection.ts
+++ b/packages/types/src/documents/global/agentKnowledgeSourceConnection.ts
@@ -3,7 +3,6 @@ import { AgentKnowledgeSourceType, Document } from "../../"
 export interface AgentKnowledgeSourceConnection extends Document {
   sourceType: AgentKnowledgeSourceType
   connectionKey: string
-  tenant: string
   account: string
   tenantId: string
   tokenEndpoint: string

--- a/packages/types/src/documents/global/agentKnowledgeSourceConnection.ts
+++ b/packages/types/src/documents/global/agentKnowledgeSourceConnection.ts
@@ -3,6 +3,8 @@ import { AgentKnowledgeSourceType, Document } from "../../"
 export interface AgentKnowledgeSourceConnection extends Document {
   sourceType: AgentKnowledgeSourceType
   connectionKey: string
+  tenant: string
+  account: string
   tenantId: string
   tokenEndpoint: string
   accessToken: string


### PR DESCRIPTION
## Description
Display all knowledge source connections instead of inferring it from agents.
Also, improving the way we display the settings, and getting extra data to display, preparing to support multiple auth in the future.

<img width="882" height="269" alt="image" src="https://github.com/user-attachments/assets/0e48f5df-01ee-4403-a350-6901744c25f3" />





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show all knowledge source auth connections on the Connections page with account and usage count, not inferred from agents. Adds a new API to list connection summaries and stores the Microsoft account during OAuth so hidden connections are visible.

- **New Features**
  - Builder: Connections table loads via `fetchAgentKnowledgeSourceConnections`, shows Connection, Account, and usage count; removed Sites; initializes agents store if needed.
  - API: `GET /api/agent/knowledge-sources/connections` returns `{ connections }` with summary fields (`_id`, `_rev`, timestamps, `sourceType`, `connectionKey`, `account`).
  - SDK: `listKnowledgeSourceConnections()` to list stored connections.
  - Types: Added `FetchAgentKnowledgeSourceConnectionsResponse` and `AgentKnowledgeSourceConnectionSummary`; added `account` to `AgentKnowledgeSourceConnection`.
  - SharePoint OAuth: Fetches `/me` from Microsoft Graph to store `account`; default scope now includes `User.Read`.

- **Migration**
  - If you override `RAG_SHAREPOINT_DEFAULT_SCOPE`, add `User.Read` to populate account names.
  - Existing connections may show account as "unknown" until users re-authenticate.

<sup>Written for commit 22932f789f7a5d102ac5d746c62c832841ee401a. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18657?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



