### PR TITLE
Fix automation action bar light theme styling

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItemActions.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItemActions.svelte
@@ -48,6 +48,8 @@
       tooltipPosition={TooltipPosition.Left}
       tooltip={"Create branch"}
       size="S"
+      color="var(--automation-flow-action-icon-color)"
+      hoverColor="var(--automation-flow-action-icon-hover-color)"
     />
   {/if}
   {#if canShowAddBranch}
@@ -62,6 +64,8 @@
       tooltipPosition={TooltipPosition.Right}
       tooltip={"Add branch"}
       size="S"
+      color="var(--automation-flow-action-icon-color)"
+      hoverColor="var(--automation-flow-action-icon-hover-color)"
     />
   {/if}
   <Icon
@@ -75,16 +79,37 @@
     tooltipPosition={TooltipPosition.Right}
     tooltip={"Add a step"}
     size="S"
+    color="var(--automation-flow-action-icon-color)"
+    hoverColor="var(--automation-flow-action-icon-hover-color)"
   />
 </div>
 
 <style>
   .action-bar {
-    background-color: var(--spectrum-global-color-gray-100);
+    --automation-flow-action-icon-color: var(--spectrum-global-color-gray-700);
+    --automation-flow-action-icon-hover-color: var(
+      --spectrum-global-color-gray-900
+    );
+    background-color: var(
+      --automation-flow-action-background,
+      var(--spectrum-global-color-gray-100)
+    );
+    border: var(--automation-flow-action-border, 0);
     border-radius: 4px 4px 4px 4px;
     display: flex;
     gap: var(--spacing-m);
     padding: 8px 12px;
     cursor: default;
+  }
+
+  :global(.spectrum--light) .action-bar,
+  :global(.spectrum--lightest) .action-bar {
+    --automation-flow-action-background: var(--spectrum-global-color-gray-50);
+    --automation-flow-action-border: 1px solid
+      var(--spectrum-global-color-gray-200);
+    --automation-flow-action-icon-color: var(--spectrum-global-color-gray-900);
+    --automation-flow-action-icon-hover-color: var(
+      --spectrum-global-color-gray-900
+    );
   }
 </style>


### PR DESCRIPTION
## Description
Fixes a light theme styling issue where the automation branching/add-step action bar used the wrong background colour. The action bar now matches the branch node surface with a white background, outline, and dark icons.

## Addresses
- https://github.com/Budibase/budibase/issues/18659

## Screenshots
<img width="443" height="1076" alt="Screenshot 2026-04-29 at 16 53 09" src="https://github.com/user-attachments/assets/86656a02-c20d-4205-abc1-531933dca537" />

## Launchcontrol
Fixes the light theme styling for automation branching and add-step controls.


