### PR TITLE
replace source sans with inter as app font

### DIFF
--- a/packages/builder/index.html
+++ b/packages/builder/index.html
@@ -4,10 +4,6 @@
     <meta charset="utf8" />
     <meta name="viewport" content="width=device-width" />
     <title>Budibase</title>
-    <link
-      href="/builder/fonts/source-sans-3/source-sans-3.css"
-      rel="stylesheet"
-    />
     <link href="/builder/fonts/inter/inter.css" rel="stylesheet" />
     <link
       href="/builder/fonts/phosphor-icons/phosphor-icons.css"

--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -414,6 +414,7 @@
     flex-direction: column;
     justify-content: flex-start;
     align-items: stretch;
+    font-family: var(--font-sans);
   }
 
   #app-body {

--- a/packages/frontend-core/src/components/ClientAppSkeleton.svelte
+++ b/packages/frontend-core/src/components/ClientAppSkeleton.svelte
@@ -100,7 +100,7 @@
     mix-blend-mode: multiply;
     background: rgb(0 0 0);
     font-size: 30px;
-    font-family: Source Sans 3;
+    font-family: var(--font-sans, "Inter", sans-serif);
     -webkit-font-smoothing: antialiased;
   }
 

--- a/packages/server/src/api/controllers/static/templates/BudibaseApp.svelte
+++ b/packages/server/src/api/controllers/static/templates/BudibaseApp.svelte
@@ -39,10 +39,6 @@
     <link rel="icon" type="image/png" href="/builder/bblogo.png" />
   {/if}
 
-  <link
-    href="/builder/fonts/source-sans-3/source-sans-3.css"
-    rel="stylesheet"
-  />
   <link href="/builder/fonts/inter/inter.css" rel="stylesheet" />
   <link
     href="/builder/fonts/phosphor-icons/phosphor-icons.css"
@@ -71,7 +67,15 @@
       height: 100vh;
       width: 100vw;
       display: none;
-      font-family: "Source Sans 3", sans-serif;
+      font-family:
+        "Inter",
+        -apple-system,
+        BlinkMacSystemFont,
+        Segoe UI,
+        "Helvetica Neue",
+        Arial,
+        "Noto Sans",
+        sans-serif;
       flex-direction: column;
       justify-content: center;
       align-items: center;
@@ -97,11 +101,11 @@
     /* Inject latest font CSS from bbui.css, as the real file is versioned with the client lib */
     .spectrum {
       --font-sans:
-        "Source Sans 3", -apple-system, BlinkMacSystemFont, Segoe UI, "Inter",
-        "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
+        "Inter", -apple-system, BlinkMacSystemFont, Segoe UI, "Helvetica Neue",
+        Arial, "Noto Sans", sans-serif !important;
       --font-accent:
-        "Source Sans 3", -apple-system, BlinkMacSystemFont, Segoe UI, "Inter",
-        "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
+        "Inter", -apple-system, BlinkMacSystemFont, Segoe UI, "Helvetica Neue",
+        Arial, "Noto Sans", sans-serif !important;
       --spectrum-alias-body-text-font-family: var(--font-sans) !important;
       --spectrum-global-font-family-base: var(--font-sans) !important;
       --spectrum-global-font-line-height-small: 1.4 !important;

--- a/packages/server/src/api/controllers/static/templates/preview.hbs
+++ b/packages/server/src/api/controllers/static/templates/preview.hbs
@@ -1,7 +1,6 @@
 <html lang="en">
 <head>
   <title>Budibase Builder Preview</title>
-  <link href="/builder/fonts/source-sans-3/source-sans-3.css" rel="stylesheet" />
   <link href="/builder/fonts/inter/inter.css" rel="stylesheet" />
   <link href="/builder/fonts/phosphor-icons/phosphor-icons.css" rel="stylesheet" />
   <link href="/builder/fonts/remixicon.css" rel="stylesheet" />
@@ -32,10 +31,10 @@
 
     /* Inject latest font CSS from bbui.css, as the real file is versioned with the client lib */
     .spectrum {
-      --font-sans: "Source Sans 3", -apple-system, BlinkMacSystemFont, Segoe UI,
-      "Inter", "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
-      --font-accent: "Source Sans 3", -apple-system, BlinkMacSystemFont, Segoe UI,
-      "Inter", "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
+      --font-sans: "Inter", -apple-system, BlinkMacSystemFont, Segoe UI,
+      "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
+      --font-accent: "Inter", -apple-system, BlinkMacSystemFont, Segoe UI,
+      "Helvetica Neue", Arial, "Noto Sans", sans-serif !important;
       --spectrum-alias-body-text-font-family: var(--font-sans) !important;
       --spectrum-global-font-family-base: var(--font-sans) !important;
       --spectrum-global-font-line-height-small: 1.4 !important;


### PR DESCRIPTION
## Description
updates Budibase apps to use Inter instead of Source Sans

This covers:
- Published/static app template
- Builder app preview iframe
- Builder design preview iframe (`componentPreview`)
- Runtime app root
- App preview skeleton/loading UI

## Addresses
#18598

## Screenshots
<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/99ad6ad7-f816-4a2c-b5f7-7dad35927874" />

## Launchcontrol
Budibase apps now use Inter as the default font


