### PR TITLE
Add copy controls to automation log JSON

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/LogDetailsPanel.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/LogDetailsPanel.svelte
@@ -1,5 +1,12 @@
 <script>
-  import { Body, Icon, ActionButton, Divider } from "@budibase/bbui"
+  import {
+    Body,
+    Icon,
+    ActionButton,
+    Divider,
+    Helpers,
+    notifications,
+  } from "@budibase/bbui"
   import Panel from "@/components/design/Panel.svelte"
   import JSONViewer from "@/components/common/JSONViewer.svelte"
   import dayjs from "dayjs"
@@ -36,6 +43,11 @@
       expandedBranches.add(id)
     }
     expandedBranches = new Set(expandedBranches)
+  }
+
+  function copyContext(e) {
+    Helpers.copyToClipboard(JSON.stringify(e.detail?.value))
+    notifications.success("Copied to clipboard")
   }
 </script>
 
@@ -95,10 +107,18 @@
                 <Body size="S" textAlign="center">No inputs available</Body>
               </div>
             {:else}
-              <JSONViewer value={currentStepData?.inputs} />
+              <JSONViewer
+                value={currentStepData?.inputs}
+                showCopyIcon
+                on:click-copy={copyContext}
+              />
             {/if}
           {:else if selectedTab === "Data out"}
-            <JSONViewer value={currentStepData?.outputs} />
+            <JSONViewer
+              value={currentStepData?.outputs}
+              showCopyIcon
+              on:click-copy={copyContext}
+            />
           {:else if selectedTab === "Branch Info"}
             {#if branchDetails}
               <div class="branch-list">


### PR DESCRIPTION
## Description
Adds copy controls to the Automation Logs Data in and Data out JSON viewers, matching the copy behavior already available while testing automations.

## Addresses
- https://github.com/Budibase/budibase/issues/18668

## Screenshots
<img width="386" height="808" alt="copy log" src="https://github.com/user-attachments/assets/14f45bc7-1fd8-4b1c-9b63-b3e27eeb1dff" />

## Launchcontrol
Automation log Data in and Data out JSON values can now be copied directly from the log details panel.