### PR TITLE
Fix - hidden button on light mode

### DIFF
--- a/packages/bbui/src/Button/Button.svelte
+++ b/packages/bbui/src/Button/Button.svelte
@@ -140,5 +140,6 @@
   :global(.spectrum--lightest)
     .spectrum-Button--overBackground:not(.is-disabled):hover {
     color: var(--spectrum-global-color-gray-900);
+    background: rgba(0, 0, 0, 0.05);
   }
 </style>

--- a/packages/bbui/src/Button/Button.svelte
+++ b/packages/bbui/src/Button/Button.svelte
@@ -129,4 +129,16 @@
     background: var(--spectrum-global-color-gray-200);
     color: var(--spectrum-global-color-gray-500);
   }
+
+  :global(.spectrum--light) .spectrum-Button--overBackground.new-styles,
+  :global(.spectrum--lightest) .spectrum-Button--overBackground.new-styles {
+    color: var(--spectrum-global-color-gray-800);
+  }
+
+  :global(.spectrum--light)
+    .spectrum-Button--overBackground.new-styles:not(.is-disabled):hover,
+  :global(.spectrum--lightest)
+    .spectrum-Button--overBackground.new-styles:not(.is-disabled):hover {
+    color: var(--spectrum-global-color-gray-900);
+  }
 </style>

--- a/packages/bbui/src/Button/Button.svelte
+++ b/packages/bbui/src/Button/Button.svelte
@@ -130,15 +130,15 @@
     color: var(--spectrum-global-color-gray-500);
   }
 
-  :global(.spectrum--light) .spectrum-Button--overBackground.new-styles,
-  :global(.spectrum--lightest) .spectrum-Button--overBackground.new-styles {
+  :global(.spectrum--light) .spectrum-Button--overBackground,
+  :global(.spectrum--lightest) .spectrum-Button--overBackground {
     color: var(--spectrum-global-color-gray-800);
   }
 
   :global(.spectrum--light)
-    .spectrum-Button--overBackground.new-styles:not(.is-disabled):hover,
+    .spectrum-Button--overBackground:not(.is-disabled):hover,
   :global(.spectrum--lightest)
-    .spectrum-Button--overBackground.new-styles:not(.is-disabled):hover {
+    .spectrum-Button--overBackground:not(.is-disabled):hover {
     color: var(--spectrum-global-color-gray-900);
   }
 </style>


### PR DESCRIPTION
## Description
Fixing a UI issue where some buttons were not visible on light mode

## Screenshots (default vs hovering)
### Light
<img width="895" height="107" alt="image" src="https://github.com/user-attachments/assets/e37a93fb-dfd5-4418-9d45-330201c53bb9" />
<img width="895" height="107" alt="Screenshot 2026-04-30 at 16 55 14" src="https://github.com/user-attachments/assets/09be6783-d2bb-44d0-a2cf-d1ab63e046e3" />


### Dark
<img width="895" height="107" alt="Screenshot 2026-04-30 at 16 52 57" src="https://github.com/user-attachments/assets/f1db3241-405c-4961-9082-00fd8b90541b" />
<img width="895" height="107" alt="Screenshot 2026-04-30 at 16 54 29" src="https://github.com/user-attachments/assets/dc4b5767-6b56-40a4-87b2-8c59ac23028b" />


### Nord
<img width="895" height="107" alt="Screenshot 2026-04-30 at 16 53 11" src="https://github.com/user-attachments/assets/a6b485cf-de26-4b4d-b04a-b94a682097f8" />

<img width="895" height="107" alt="Screenshot 2026-04-30 at 16 54 24" src="https://github.com/user-attachments/assets/b4851d9b-e6c0-4686-b63d-769ebf8645db" />

### Midnight
<img width="895" height="107" alt="Screenshot 2026-04-30 at 16 52 57" src="https://github.com/user-attachments/assets/ed9b26b8-6436-46ab-b61f-b3ed68506646" />
<img width="895" height="107" alt="Screenshot 2026-04-30 at 16 54 29" src="https://github.com/user-attachments/assets/f85eace6-4ac7-4c73-b066-53a199cbaeb6" />


## Launchcontrol
Fixing a UI issue where some buttons were not visible on light mode