### PR TITLE
Add prompt parameter to SharePoint OAuth authorization URL

### DIFF
--- a/packages/server/src/api/controllers/ai/sharepointAuth.ts
+++ b/packages/server/src/api/controllers/ai/sharepointAuth.ts
@@ -80,6 +80,7 @@ export async function startSharePointAuth(ctx: UserCtx<void, void>) {
   authorizeUrl.searchParams.set("redirect_uri", callbackUrl)
   authorizeUrl.searchParams.set("response_mode", "query")
   authorizeUrl.searchParams.set("scope", DEFAULT_SCOPE)
+  authorizeUrl.searchParams.set("prompt", "select_account")
   authorizeUrl.searchParams.set("state", state)
 
   ctx.redirect(authorizeUrl.toString())


### PR DESCRIPTION
## Description
If we are already logged in into microsoft, when logging in to microsoft, we were automatically redirected to budibase. This makes impossible to choose a different account. This PR tells the auth flow to always select/confirm the account to use.