### PR TITLE
feat(automation): 增强自动化日志过滤功能

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/AutomationLogsPanel.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/AutomationLogsPanel.svelte
@@ -6,30 +6,43 @@
     Pagination,
     Button,
     Icon,
+    Toggle,
+    TextInput,
   } from "@budibase/bbui"
   import Panel from "@/components/design/Panel.svelte"
   import { automationStore } from "@/stores/builder"
   import { licensing, auth } from "@/stores/portal"
   import { createPaginationStore } from "@/helpers/pagination"
-  import { onMount } from "svelte"
+  import { onMount, onDestroy } from "svelte"
   import dayjs from "dayjs"
   import StatusRenderer from "@/settings/pages/automations/_components/StatusRenderer.svelte"
+  import { AutomationStatus } from "@budibase/types"
 
   export let automation
   export let onSelectLog = () => {}
   export let selectedLog = null
 
-  const ERROR = "error",
-    SUCCESS = "success",
-    STOPPED = "stopped",
-    STOPPED_ERROR = "stopped_error"
+  const ERROR = AutomationStatus.ERROR
+  const SUCCESS = AutomationStatus.SUCCESS
+  const STOPPED = AutomationStatus.STOPPED
+  const STOPPED_ERROR = AutomationStatus.STOPPED_ERROR
+  const TIMED_OUT = AutomationStatus.TIMED_OUT
+
+  const FAILURE_STATUSES = [ERROR, STOPPED_ERROR, TIMED_OUT]
 
   let pageInfo = createPaginationStore()
   let runHistory = null
   let status = null
+  let statuses = null
   let timeRange = null
   let loaded = false
   let totalLogs = 0
+  let showAdvancedFilters = false
+
+  let durationGte = null
+  let durationLte = null
+  let hasRetry = false
+  let attemptGte = null
 
   const AUTOMATION_LOG_PAGE_SIZE = 10
 
@@ -42,6 +55,14 @@
     { value: "15-m", label: "Past 15 mins" },
     { value: "5-m", label: "Past 5 mins" },
   ]
+
+  const quickFilterOptions = [
+    { value: null, label: "All runs" },
+    { value: "failures", label: "Failures only" },
+    { value: "success", label: "Success only" },
+  ]
+
+  let quickFilter = null
 
   $: automationLogRetentionDays =
     $licensing.license?.quotas?.constant?.automationLogRetentionDays?.value || 1
@@ -60,7 +81,6 @@
         return option.value !== "90-d"
       }
     }
-    // Enterprise plan: allow all options
     return true
   })
 
@@ -72,18 +92,96 @@
     { value: ERROR, label: "Error" },
     { value: STOPPED, label: "Stopped" },
     { value: STOPPED_ERROR, label: "Stopped - Error" },
+    { value: TIMED_OUT, label: "Timed out" },
   ]
 
-  // Reset the page every time that a filter gets updated
-  $: pageInfo.reset(), status, timeRange
+  function getUrlParams() {
+    const params = new URLSearchParams(window.location.search)
+    return {
+      status: params.get("status") || null,
+      timeRange: params.get("timeRange") || null,
+      quickFilter: params.get("quickFilter") || null,
+      durationGte: params.get("durationGte")
+        ? parseInt(params.get("durationGte"))
+        : null,
+      durationLte: params.get("durationLte")
+        ? parseInt(params.get("durationLte"))
+        : null,
+      hasRetry: params.get("hasRetry") === "true",
+      attemptGte: params.get("attemptGte")
+        ? parseInt(params.get("attemptGte"))
+        : null,
+    }
+  }
+
+  function updateUrlParams() {
+    const params = new URLSearchParams()
+    if (status) params.set("status", status)
+    if (timeRange) params.set("timeRange", timeRange)
+    if (quickFilter) params.set("quickFilter", quickFilter)
+    if (durationGte !== null) params.set("durationGte", durationGte.toString())
+    if (durationLte !== null) params.set("durationLte", durationLte.toString())
+    if (hasRetry) params.set("hasRetry", "true")
+    if (attemptGte !== null) params.set("attemptGte", attemptGte.toString())
+
+    const newUrl = `${window.location.pathname}${params.toString() ? "?" + params.toString() : ""}`
+    window.history.replaceState({}, "", newUrl)
+  }
+
+  function loadFiltersFromUrl() {
+    const params = getUrlParams()
+    status = params.status
+    timeRange = params.timeRange
+    quickFilter = params.quickFilter
+    durationGte = params.durationGte
+    durationLte = params.durationLte
+    hasRetry = params.hasRetry
+    attemptGte = params.attemptGte
+
+    applyQuickFilter()
+  }
+
+  function applyQuickFilter() {
+    if (quickFilter === "failures") {
+      statuses = [...FAILURE_STATUSES]
+      status = null
+    } else if (quickFilter === "success") {
+      statuses = null
+      status = SUCCESS
+    } else {
+      statuses = null
+    }
+  }
+
+  $: if (quickFilter !== undefined) {
+    applyQuickFilter()
+  }
+
+  $: pageInfo.reset(), status, timeRange, quickFilter, durationGte, durationLte, hasRetry, attemptGte
   $: page = $pageInfo.page
-  $: fetchLogs(automation._id, status, page, timeRange)
+  $: fetchLogs(
+    automation._id,
+    status,
+    statuses,
+    page,
+    timeRange,
+    durationGte,
+    durationLte,
+    hasRetry ? 1 : null
+  )
+  $: if (loaded) {
+    updateUrlParams()
+  }
 
   async function fetchLogs(
     automationId,
     status,
+    statuses,
     page,
     timeRange,
+    durationGte,
+    durationLte,
+    attemptGte,
     force = false
   ) {
     if (!force && !loaded) {
@@ -94,13 +192,31 @@
       const [length, units] = timeRange.split("-")
       startDate = dayjs().subtract(length, units)
     }
+
+    const logOptions = {
+      automationId,
+      page,
+      startDate,
+    }
+
+    if (statuses && statuses.length > 0) {
+      logOptions.statuses = statuses
+    } else if (status) {
+      logOptions.status = status
+    }
+
+    if (durationGte !== null && !isNaN(durationGte)) {
+      logOptions.durationGte = durationGte
+    }
+    if (durationLte !== null && !isNaN(durationLte)) {
+      logOptions.durationLte = durationLte
+    }
+    if (attemptGte !== null && !isNaN(attemptGte)) {
+      logOptions.attemptGte = attemptGte
+    }
+
     try {
-      const response = await automationStore.actions.getLogs({
-        automationId,
-        status,
-        page,
-        startDate,
-      })
+      const response = await automationStore.actions.getLogs(logOptions)
       pageInfo.fetched(response.hasNextPage, response.nextPage)
       totalLogs = response.totalLogs
       runHistory = response.data
@@ -110,8 +226,26 @@
     }
   }
 
+  function formatDuration(ms) {
+    if (ms === undefined || ms === null) return ""
+    if (ms < 1000) return `${ms}ms`
+    if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
+    return `${(ms / 60000).toFixed(1)}m`
+  }
+
   onMount(async () => {
-    await fetchLogs(automation._id, status, 0, timeRange, true)
+    loadFiltersFromUrl()
+    await fetchLogs(
+      automation._id,
+      status,
+      statuses,
+      0,
+      timeRange,
+      durationGte,
+      durationLte,
+      hasRetry ? 1 : null,
+      true
+    )
     loaded = true
   })
 </script>
@@ -120,24 +254,85 @@
 <div class="container">
   <Panel title="Logs" customWidth={400} borderLeft borderBottomHeader={false}>
     <div class="logs-panel-content">
+      <div class="quick-filters">
+        <Select
+          placeholder="Quick filter"
+          label="Quick filter"
+          bind:value={quickFilter}
+          options={quickFilterOptions}
+        />
+      </div>
+
       <div class="filters">
         <div class="filter-group">
           <Select
-            placeholder="All"
+            placeholder="All statuses"
             label="Status"
             bind:value={status}
             options={statusOptions}
+            disabled={quickFilter !== null}
           />
         </div>
         <div class="filter-group">
           <Select
-            placeholder="All"
+            placeholder="All time"
             label="Date range"
             bind:value={timeRange}
             options={timeOptions}
           />
         </div>
       </div>
+
+      <div class="advanced-filter-toggle">
+        <Button
+          size="S"
+          secondary
+          on:click={() => (showAdvancedFilters = !showAdvancedFilters)}
+        >
+          <Icon name={showAdvancedFilters ? "ChevronUp" : "ChevronDown"} size="S" />
+          {showAdvancedFilters ? "Hide" : "Show"} advanced filters
+        </Button>
+      </div>
+
+      {#if showAdvancedFilters}
+        <div class="advanced-filters">
+          <div class="filter-row">
+            <div class="filter-group">
+              <Toggle
+                text="With retries only"
+                value={hasRetry}
+                on:change={e => {
+                  hasRetry = e.detail
+                  if (hasRetry) {
+                    attemptGte = 1
+                  } else {
+                    attemptGte = null
+                  }
+                }}
+              />
+            </div>
+          </div>
+
+          <div class="filter-row">
+            <div class="filter-group">
+              <label class="filter-label">Duration (ms)</label>
+              <div class="duration-filters">
+                <TextInput
+                  placeholder="Min"
+                  type="number"
+                  bind:value={durationGte}
+                />
+                <span class="separator">-</span>
+                <TextInput
+                  placeholder="Max"
+                  type="number"
+                  bind:value={durationLte}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      {/if}
 
       <!-- Free plan message and upgrade prompt -->
       {#if $licensing.isFreePlan}
@@ -176,19 +371,35 @@
                   on:click={() => onSelectLog(log)}
                 >
                   <div class="log-content">
-                    <div class="log-info">
-                      <Body size="S" weight="600">
-                        Log #{totalLogs -
-                          (($pageInfo.pageNumber - 1) *
-                            AUTOMATION_LOG_PAGE_SIZE +
-                            idx)}
-                      </Body>
-                      <Body size="S">
-                        {dayjs(log.createdAt).format("MMM DD, YYYY HH:mm")}
-                      </Body>
-                    </div>
-                    <div class="log-status">
-                      <StatusRenderer value={log.status} />
+                    <div class="log-main">
+                      <div class="log-header">
+                        <Body size="S" weight="600">
+                          Log #{totalLogs -
+                            (($pageInfo.pageNumber - 1) *
+                              AUTOMATION_LOG_PAGE_SIZE +
+                              idx)}
+                        </Body>
+                        <div class="log-status">
+                          <StatusRenderer value={log.status} />
+                        </div>
+                      </div>
+                      <div class="log-meta">
+                        <Body size="XS">
+                          {dayjs(log.createdAt).format("MMM DD, YYYY HH:mm:ss")}
+                        </Body>
+                        {#if log.durationMs !== undefined && log.durationMs !== null}
+                          <Body size="XS" class="log-duration">
+                            <Icon name="Clock" size="XS" />
+                            {formatDuration(log.durationMs)}
+                          </Body>
+                        {/if}
+                        {#if log.attempt !== undefined && log.attempt !== null && log.attempt > 0}
+                          <Body size="XS" class="log-attempt">
+                            <Icon name="Refresh" size="XS" />
+                            Attempt {log.attempt}
+                          </Body>
+                        {/if}
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -318,5 +529,93 @@
     justify-content: right;
     padding: var(--spacing-m) 0;
     margin-top: var(--spacing-s);
+  }
+
+  .quick-filters {
+    display: flex;
+    flex-direction: row;
+    gap: var(--spacing-m);
+  }
+
+  .advanced-filter-toggle {
+    display: flex;
+    justify-content: flex-start;
+  }
+
+  .advanced-filters {
+    background: var(--spectrum-global-color-gray-75);
+    border: 1px solid var(--spectrum-global-color-gray-300);
+    border-radius: var(--border-radius-s);
+    padding: var(--spacing-m);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-m);
+  }
+
+  .filter-row {
+    display: flex;
+    flex-direction: row;
+    gap: var(--spacing-m);
+  }
+
+  .filter-label {
+    display: block;
+    font-size: var(--spectrum-alias-item-text-size-s);
+    color: var(--spectrum-global-color-gray-700);
+    margin-bottom: var(--spacing-s);
+  }
+
+  .duration-filters {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s);
+  }
+
+  .separator {
+    color: var(--spectrum-global-color-gray-600);
+    font-size: var(--spectrum-alias-item-text-size-m);
+  }
+
+  .log-main {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+    flex: 1;
+  }
+
+  .log-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--spacing-m);
+  }
+
+  .log-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--spacing-s);
+    color: var(--spectrum-global-color-gray-600);
+  }
+
+  .log-duration,
+  .log-attempt {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-xs) var(--spacing-s);
+    background: var(--spectrum-global-color-gray-200);
+    border-radius: var(--border-radius-s);
+    font-size: 10px;
+    line-height: 1.2;
+  }
+
+  .log-attempt {
+    background: var(--spectrum-global-color-orange-200);
+    color: var(--spectrum-global-color-orange-900);
+  }
+
+  .log-status {
+    flex-shrink: 0;
   }
 </style>

--- a/packages/builder/src/stores/builder/automations.ts
+++ b/packages/builder/src/stores/builder/automations.ts
@@ -1475,18 +1475,33 @@ const automationActions = (store: AutomationStore) => ({
     automationId,
     startDate,
     status,
+    statuses,
     page,
+    durationGte,
+    durationLte,
+    attemptGte,
+    attemptLte,
   }: {
     automationId?: string
     startDate?: string
     status?: AutomationStatus
+    statuses?: AutomationStatus[]
     page?: string
+    durationGte?: number
+    durationLte?: number
+    attemptGte?: number
+    attemptLte?: number
   } = {}) => {
     return await API.getAutomationLogs({
       automationId,
       startDate,
       status,
+      statuses,
       page,
+      durationGte,
+      durationLte,
+      attemptGte,
+      attemptLte,
     })
   },
 

--- a/packages/pro/src/sdk/automations/logging/index.ts
+++ b/packages/pro/src/sdk/automations/logging/index.ts
@@ -1,6 +1,7 @@
 import { context, db as dbUtils } from "@budibase/backend-core"
 import {
   Automation,
+  AutomationLog,
   AutomationLogPage,
   AutomationResults,
   AutomationStatus,
@@ -16,6 +17,82 @@ import {
 
 export const oldestLogDate = _oldestLogDate
 
+export interface LogSearchOptions {
+  startDate?: string
+  status?: AutomationStatus
+  statuses?: AutomationStatus[]
+  automationId?: string
+  page?: string
+  durationGte?: number
+  durationLte?: number
+  attemptGte?: number
+  attemptLte?: number
+}
+
+interface FilterOptions {
+  statuses?: AutomationStatus[]
+  durationGte?: number
+  durationLte?: number
+  attemptGte?: number
+  attemptLte?: number
+}
+
+function matchesFilters(log: AutomationLog, filters: FilterOptions): boolean {
+  if (filters.statuses && filters.statuses.length > 0) {
+    if (!filters.statuses.includes(log.status)) {
+      return false
+    }
+  }
+
+  if (filters.durationGte !== undefined) {
+    if (log.durationMs === undefined || log.durationMs < filters.durationGte) {
+      return false
+    }
+  }
+  if (filters.durationLte !== undefined) {
+    if (log.durationMs === undefined || log.durationMs > filters.durationLte) {
+      return false
+    }
+  }
+
+  if (filters.attemptGte !== undefined) {
+    if (log.attempt === undefined || log.attempt < filters.attemptGte) {
+      return false
+    }
+  }
+  if (filters.attemptLte !== undefined) {
+    if (log.attempt === undefined || log.attempt > filters.attemptLte) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function applyFilters(
+  response: AutomationLogPage,
+  filters: FilterOptions
+): AutomationLogPage {
+  const hasFilters =
+    (filters.statuses && filters.statuses.length > 0) ||
+    filters.durationGte !== undefined ||
+    filters.durationLte !== undefined ||
+    filters.attemptGte !== undefined ||
+    filters.attemptLte !== undefined
+
+  if (!hasFilters) {
+    return response
+  }
+
+  const filteredData = response.data.filter(log => matchesFilters(log, filters))
+
+  return {
+    ...response,
+    data: filteredData,
+    totalLogs: filteredData.length,
+  }
+}
+
 async function getLogs(
   startDate?: string,
   status?: string,
@@ -25,7 +102,6 @@ async function getLogs(
   let response: AutomationLogPage
   let endDate = new Date().toISOString()
   const maxStartDate = await oldestLogDate()
-  // check that the start date does not exceed license
   if (!startDate || startDate < maxStartDate) {
     startDate = maxStartDate
   }
@@ -46,22 +122,41 @@ async function getLogs(
   return response
 }
 
-export interface LogSearchOptions {
-  startDate?: string
-  status?: AutomationStatus
-  automationId?: string
-  page?: string
-}
-
 export async function logSearch(options: LogSearchOptions) {
-  // before querying logs, make sure old logs are cleared out
   await clearOldHistory()
-  return await getLogs(
+
+  let status = options.status
+  const filters: FilterOptions = {}
+
+  if (options.statuses && options.statuses.length > 0) {
+    if (options.statuses.length === 1) {
+      status = options.statuses[0]
+    } else {
+      filters.statuses = options.statuses
+    }
+  }
+
+  if (options.durationGte !== undefined) {
+    filters.durationGte = options.durationGte
+  }
+  if (options.durationLte !== undefined) {
+    filters.durationLte = options.durationLte
+  }
+  if (options.attemptGte !== undefined) {
+    filters.attemptGte = options.attemptGte
+  }
+  if (options.attemptLte !== undefined) {
+    filters.attemptLte = options.attemptLte
+  }
+
+  const response = await getLogs(
     options.startDate,
-    options.status,
+    status,
     options.automationId,
     options.page
   )
+
+  return applyFilters(response, filters)
 }
 
 export async function storeLog(

--- a/packages/pro/src/sdk/automations/logging/tests/index.spec.ts
+++ b/packages/pro/src/sdk/automations/logging/tests/index.spec.ts
@@ -51,6 +51,8 @@ async function generateAutomationLog(
   log: {
     date: Date
     status: AutomationStatus
+    durationMs?: number
+    attempt?: number
   }
 ) {
   const _id = generateAutomationLogID(
@@ -71,6 +73,8 @@ async function generateAutomationLog(
     automationName: "automationName",
     trigger: triggerResult,
     steps: [triggerResult],
+    durationMs: log.durationMs,
+    attempt: log.attempt,
   }
   await workspaceDb.put(obj)
   const result = await workspaceDb.get<AutomationLog>(_id)
@@ -231,6 +235,159 @@ describe("paid log testing", () => {
         totalLogs: allLogs.length,
         totalRows: 180,
       })
+    })
+  })
+})
+
+describe("filter testing", () => {
+  const automationId = "au_filter_test_123"
+
+  beforeAll(async () => {
+    newApp()
+    await generateAutomationLog(automationId, {
+      date: daysAgo(0),
+      status: AutomationStatus.SUCCESS,
+      durationMs: 500,
+      attempt: 0,
+    })
+    await generateAutomationLog(automationId, {
+      date: daysAgo(0),
+      status: AutomationStatus.ERROR,
+      durationMs: 1500,
+      attempt: 0,
+    })
+    await generateAutomationLog(automationId, {
+      date: daysAgo(0),
+      status: AutomationStatus.STOPPED_ERROR,
+      durationMs: 3000,
+      attempt: 2,
+    })
+    await generateAutomationLog(automationId, {
+      date: daysAgo(0),
+      status: AutomationStatus.TIMED_OUT,
+      durationMs: 10000,
+      attempt: 3,
+    })
+    await generateAutomationLog(automationId, {
+      date: daysAgo(0),
+      status: AutomationStatus.SUCCESS,
+      durationMs: 200,
+      attempt: 1,
+    })
+  })
+
+  beforeEach(() => {
+    mocks.licenses.setAutomationLogsQuota(30)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("statuses filtering", () => {
+    it("should filter by multiple failure statuses", async () => {
+      const logs = await logSearch({
+        statuses: [
+          AutomationStatus.ERROR,
+          AutomationStatus.STOPPED_ERROR,
+          AutomationStatus.TIMED_OUT,
+        ],
+      })
+      expect(logs.data).toHaveLength(3)
+      expect(logs.data.every(l => l.status !== AutomationStatus.SUCCESS)).toBe(
+        true
+      )
+    })
+
+    it("should handle single status in statuses array", async () => {
+      const logs = await logSearch({
+        statuses: [AutomationStatus.SUCCESS],
+      })
+      expect(logs.data).toHaveLength(2)
+      expect(logs.data.every(l => l.status === AutomationStatus.SUCCESS)).toBe(
+        true
+      )
+    })
+  })
+
+  describe("duration filtering", () => {
+    it("should filter by duration greater than", async () => {
+      const logs = await logSearch({
+        durationGte: 1000,
+      })
+      expect(logs.data).toHaveLength(3)
+      expect(logs.data.every(l => l.durationMs! >= 1000)).toBe(true)
+    })
+
+    it("should filter by duration less than", async () => {
+      const logs = await logSearch({
+        durationLte: 1000,
+      })
+      expect(logs.data).toHaveLength(2)
+      expect(logs.data.every(l => l.durationMs! <= 1000)).toBe(true)
+    })
+
+    it("should filter by duration range", async () => {
+      const logs = await logSearch({
+        durationGte: 1000,
+        durationLte: 5000,
+      })
+      expect(logs.data).toHaveLength(2)
+      expect(
+        logs.data.every(l => l.durationMs! >= 1000 && l.durationMs! <= 5000)
+      ).toBe(true)
+    })
+  })
+
+  describe("attempt filtering", () => {
+    it("should filter by attempt greater than", async () => {
+      const logs = await logSearch({
+        attemptGte: 1,
+      })
+      expect(logs.data).toHaveLength(3)
+      expect(logs.data.every(l => l.attempt! >= 1)).toBe(true)
+    })
+
+    it("should filter by attempt greater than 2", async () => {
+      const logs = await logSearch({
+        attemptGte: 2,
+      })
+      expect(logs.data).toHaveLength(2)
+      expect(logs.data.every(l => l.attempt! >= 2)).toBe(true)
+    })
+  })
+
+  describe("combined filtering", () => {
+    it("should filter by failure statuses AND with retries", async () => {
+      const logs = await logSearch({
+        statuses: [
+          AutomationStatus.ERROR,
+          AutomationStatus.STOPPED_ERROR,
+          AutomationStatus.TIMED_OUT,
+        ],
+        attemptGte: 1,
+      })
+      expect(logs.data).toHaveLength(2)
+      expect(
+        logs.data.every(
+          l =>
+            l.status !== AutomationStatus.SUCCESS &&
+            l.attempt! >= 1
+        )
+      ).toBe(true)
+    })
+
+    it("should filter by failure statuses AND duration range", async () => {
+      const logs = await logSearch({
+        statuses: [
+          AutomationStatus.ERROR,
+          AutomationStatus.STOPPED_ERROR,
+          AutomationStatus.TIMED_OUT,
+        ],
+        durationGte: 1000,
+        durationLte: 5000,
+      })
+      expect(logs.data).toHaveLength(2)
     })
   })
 })

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -274,6 +274,7 @@ class Orchestrator {
   private emitter: ContextEmitter
   private stopped: boolean
   private readonly onProgress?: (event: AutomationTestProgressEvent) => void
+  private startTime: number = Date.now()
 
   constructor(
     job: Readonly<AutomationJob>,
@@ -328,6 +329,10 @@ class Orchestrator {
   }
 
   private async logResult(result: AutomationResults) {
+    result.durationMs = Date.now() - this.startTime
+    if (this.job.attemptsMade !== undefined) {
+      result.attempt = this.job.attemptsMade
+    }
     await storeLog(this.automation, result)
   }
 

--- a/packages/types/src/api/web/workspace/automation.ts
+++ b/packages/types/src/api/web/workspace/automation.ts
@@ -51,8 +51,13 @@ export interface CreateAutomationResponse {
 export interface SearchAutomationLogsRequest {
   startDate?: string
   status?: AutomationStatus
+  statuses?: AutomationStatus[]
   automationId?: string
   page?: string
+  durationGte?: number
+  durationLte?: number
+  attemptGte?: number
+  attemptLte?: number
 }
 export interface SearchAutomationLogsResponse extends AutomationLogPage {}
 

--- a/packages/types/src/documents/workspace/automation/automation.ts
+++ b/packages/types/src/documents/workspace/automation/automation.ts
@@ -245,6 +245,8 @@ export interface AutomationResults {
   trigger: AutomationTriggerResult
   steps: [AutomationTriggerResult, ...AutomationStepResult[]]
   state?: Record<string, any>
+  durationMs?: number
+  attempt?: number
 }
 
 export interface DidNotTriggerResponse {
@@ -258,6 +260,8 @@ export interface DidNotTriggerResponse {
 export interface AutomationLog extends AutomationResults, Document {
   automationName: string
   _rev?: string
+  durationMs?: number
+  attempt?: number
 }
 
 export interface AutomationLogPage {


### PR DESCRIPTION
添加持续时间、尝试次数和状态多选过滤功能
在日志面板中增加高级过滤选项和快速过滤
记录自动化执行的持续时间和尝试次数
添加相关测试用例验证过滤功能

## Description
_Describe the problem or feature in addition to a link to the relevant github issues._

## Addresses
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._

## Launchcontrol

_Add a small description in layman's terms of what this PR achieves. This will be used in the release notes._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enhances Automation Logs with advanced and quick filters, and records run duration and retry attempt to speed up troubleshooting. Extends the logs search API to filter by statuses, duration, and attempts.

- **New Features**
  - Quick filters: All, Failures only, Success only.
  - Advanced filters: duration min/max (ms), "with retries only".
  - Multi-status filtering support via `statuses` in the API (UI exposes Failures preset).
  - Logs now include `durationMs` and `attempt`; shown in the panel with clock/attempt badges.
  - Filters persist in the URL (status, time range, quick filter, duration, attempts).
  - API/types updated to accept `statuses`, `durationGte`, `durationLte`, `attemptGte`, `attemptLte`; store wired up.
  - Tests added for status, duration, attempts, and combined filters.

<sup>Written for commit db08785be40fea44c371f3fc9fd80cbf53423a32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

