### PR TITLE
Temporally support existing sharepoint connectors

### DIFF
--- a/packages/server/src/api/controllers/ai/files.ts
+++ b/packages/server/src/api/controllers/ai/files.ts
@@ -65,12 +65,14 @@ export async function fetchAgentKnowledge(
     sdk.ai.agents.getOrThrow(agentId),
     sdk.ai.rag.fetchKnowledgeSourceSyncStateForAgent(agentId),
   ])
-  const runsBySiteId = new Map(syncState.runs.map(run => [run.sourceId, run]))
+  const runsBySourceId = new Map(syncState.runs.map(run => [run.sourceId, run]))
   const sharePointSources = getSharePointSources(agent)
     .filter(source => source.config.site.id)
     .map<SharePointKnowledgeSourceSnapshot>(source => {
       const site = source.config.site
-      const run = runsBySiteId.get(source.id)
+      // Temporary compatibility for pre-source-id sync state rows keyed by raw site id.
+      // New sync state writes use source.id as the canonical key.
+      const run = runsBySourceId.get(source.id) || runsBySourceId.get(site.id)
       const filesForSource = files.filter(
         file => file.source?.knowledgeSourceId === source.id
       )

--- a/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
@@ -474,4 +474,68 @@ describe("agent files", () => {
       expect(hasDisconnectJob).toBe(true)
     })
   })
+
+  it("maps SharePoint sync run by raw site id when source id is sanitized", async () => {
+    await withRagEnabled(async () => {
+      const created = await config.api.agent.create({
+        name: "SharePoint Snapshot Mapping Agent",
+        aiconfig: "default",
+      })
+      const siteId = "contoso.sharepoint.com,site-guid,web-guid"
+      const sourceId = `sharepoint_site_${siteId}`
+      const nowIso = "2026-05-04T10:32:21.401Z"
+
+      await setSharePointSourceInAgent(created._id!, [siteId])
+
+      await config.doInContext(config.getDevWorkspaceId(), async () => {
+        const db = context.getWorkspaceDB()
+        const agentDoc = await db.tryGet<Agent>(created._id!)
+        const knowledgeBaseId = "knowledgebase_test_snapshot_mapping"
+        await db.put({
+          ...agentDoc!,
+          knowledgeBases: [{ _id: knowledgeBaseId }],
+        })
+
+        await db.put({
+          _id: `knowledgebasefile_${knowledgeBaseId}_file_1`,
+          knowledgeBaseId,
+          filename: "file-1.txt",
+          mimetype: "text/plain",
+          size: 100,
+          objectStoreKey: "test/object-store-key",
+          ragSourceId: "rag-source-1",
+          status: KnowledgeBaseFileStatus.READY,
+          uploadedBy: `sharepoint:${sourceId}`,
+          source: {
+            type: "sharepoint",
+            knowledgeSourceId: sourceId,
+            siteId,
+            driveId: "drive-1",
+            itemId: "item-1",
+            path: "file-1.txt",
+          },
+        } as any)
+
+        await db.put({
+          _id: `agentknowledgesync_${created._id!}_sharepoint_${encodeURIComponent(siteId)}`,
+          agentId: created._id!,
+          sourceType: "sharepoint",
+          sourceId: siteId,
+          lastRunAt: nowIso,
+          synced: 1,
+          failed: 0,
+          skipped: 0,
+          totalDiscovered: 1,
+          status: "success",
+          createdAt: nowIso,
+          updatedAt: nowIso,
+        } as any)
+      })
+
+      const response = await config.api.agent.fetchFiles(created._id!)
+      expect(response.sharePointSources).toHaveLength(1)
+      expect(response.sharePointSources[0].sourceId).toBe(sourceId)
+      expect(response.sharePointSources[0].lastRunAt).toBe(nowIso)
+    })
+  })
 })

--- a/packages/server/src/sdk/workspace/ai/rag/sources/sharepoint/sharepoint.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/sources/sharepoint/sharepoint.spec.ts
@@ -95,7 +95,7 @@ const makeSharePointAgent = (
   sourceId: string,
   siteId: string,
   patterns?: string[],
-  connectionId = "connection_1"
+  connectionId?: string
 ): Agent =>
   ({
     _id: "agent_1",
@@ -104,7 +104,7 @@ const makeSharePointAgent = (
         id: sourceId,
         type: AgentKnowledgeSourceType.SHAREPOINT,
         config: {
-          connectionId,
+          ...(connectionId ? { connectionId } : {}),
           site: { id: siteId },
           ...(patterns ? { filters: { patterns } } : {}),
         },
@@ -282,6 +282,44 @@ describe("rag/sharepoint sync deduplication", () => {
       unsupported: 0,
       totalDiscovered: 1,
     })
+  })
+
+  it("uses the oldest SharePoint connection for legacy fallback", async () => {
+    const sourceId = "sharepoint_source_1"
+    const siteId = "site-1"
+
+    mockAgentsGetOrThrow.mockResolvedValue(
+      makeSharePointAgent(sourceId, siteId, undefined, undefined)
+    )
+    mockListKnowledgeSourceConnections.mockResolvedValue([
+      {
+        _id: "connection_newer",
+        sourceType: AgentKnowledgeSourceType.SHAREPOINT,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        _id: "connection_older",
+        sourceType: AgentKnowledgeSourceType.SHAREPOINT,
+        createdAt: "2025-01-01T00:00:00.000Z",
+      },
+    ])
+    mockKnowledgeBaseListFiles.mockResolvedValue([])
+    jest.spyOn(globalThis, "fetch").mockImplementation(async input => {
+      const url = input.toString()
+      if (url.includes(`/sites/${encodeURIComponent(siteId)}/drives`)) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ value: [] }),
+        } as Response
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`)
+    })
+
+    await syncSharePointSourcesForAgent("agent_1", sourceId)
+    expect(mockGetSharePointBearerToken).toHaveBeenCalledWith(
+      "connection_older"
+    )
   })
 
   it("deletes existing files that no longer match source filters", async () => {

--- a/packages/server/src/sdk/workspace/ai/rag/sources/sharepoint/sharepoint.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/sources/sharepoint/sharepoint.ts
@@ -21,6 +21,7 @@ import {
 import {
   agents as agentsSdk,
   knowledgeBase as knowledgeBaseSdk,
+  knowledgeSources as knowledgeSourcesSdk,
 } from "../../.."
 import {
   collectSharePointFilesRecursive,
@@ -272,7 +273,18 @@ const runSharePointSourcesForAgent = async (
     sourceFilters,
   })
 
-  const connectionId = sourceConnectionId
+  let connectionId = sourceConnectionId
+  if (!connectionId) {
+    // Temporary compatibility for legacy sources created before connectionId
+    // was persisted on agent knowledge source config. New sources must include
+    // config.connectionId and should not rely on this fallback.
+    const sharePointConnections =
+      await knowledgeSourcesSdk.listKnowledgeSourceConnections()
+    const fallbackConnection = sharePointConnections.find(
+      connection => connection.sourceType === AgentKnowledgeSourceType.SHAREPOINT
+    )
+    connectionId = fallbackConnection?._id
+  }
   if (!connectionId) {
     throw new HTTPError("SharePoint is not connected for this workspace", 400)
   }

--- a/packages/server/src/sdk/workspace/ai/rag/sources/sharepoint/sharepoint.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/sources/sharepoint/sharepoint.ts
@@ -21,8 +21,8 @@ import {
 import {
   agents as agentsSdk,
   knowledgeBase as knowledgeBaseSdk,
-  knowledgeSources as knowledgeSourcesSdk,
 } from "../../.."
+import * as knowledgeSourcesSdk from "../../../knowledgeSources"
 import {
   collectSharePointFilesRecursive,
   downloadSharePointFileBuffer,
@@ -280,11 +280,27 @@ const runSharePointSourcesForAgent = async (
     // config.connectionId and should not rely on this fallback.
     const sharePointConnections =
       await knowledgeSourcesSdk.listKnowledgeSourceConnections()
-    const fallbackConnection = sharePointConnections.find(
-      connection =>
-        connection.sourceType === AgentKnowledgeSourceType.SHAREPOINT
-    )
-    connectionId = fallbackConnection?._id
+    const sharePointOnlyConnections = sharePointConnections
+      .filter(
+        connection =>
+          connection.sourceType === AgentKnowledgeSourceType.SHAREPOINT
+      )
+      .sort((a, b) => {
+        function toDate(value: string | number | undefined): number {
+          if (!value) {
+            return Number.MAX_SAFE_INTEGER
+          }
+          if (typeof value === "number") {
+            return value
+          }
+          const parsed = Date.parse(value)
+          return isNaN(parsed) ? Number.MAX_SAFE_INTEGER : parsed
+        }
+        return toDate(a.createdAt) - toDate(b.createdAt)
+      })
+    // Legacy fallback: when connectionId is missing, use the oldest SharePoint
+    // connection because that was historically the one used at connection time.
+    connectionId = sharePointOnlyConnections[0]?._id
   }
   if (!connectionId) {
     throw new HTTPError("SharePoint is not connected for this workspace", 400)

--- a/packages/server/src/sdk/workspace/ai/rag/sources/sharepoint/sharepoint.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/sources/sharepoint/sharepoint.ts
@@ -281,7 +281,8 @@ const runSharePointSourcesForAgent = async (
     const sharePointConnections =
       await knowledgeSourcesSdk.listKnowledgeSourceConnections()
     const fallbackConnection = sharePointConnections.find(
-      connection => connection.sourceType === AgentKnowledgeSourceType.SHAREPOINT
+      connection =>
+        connection.sourceType === AgentKnowledgeSourceType.SHAREPOINT
     )
     connectionId = fallbackConnection?._id
   }


### PR DESCRIPTION
## Description
We have some beta users with sharepoint configured already, so this PR will add temporally backwards compatiblity to ensure not having breaking changes from https://github.com/Budibase/budibase/pull/18658

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds temporary backward compatibility for SharePoint RAG sources to avoid breaking existing beta workspaces. Sync state now uses `source.id` as the canonical key with a fallback to legacy raw `site.id`, and missing `connectionId` falls back to the oldest SharePoint connection.

- **Bug Fixes**
  - Map SharePoint sync runs by `source.id` with a fallback to legacy raw `site.id` so last run info and files resolve correctly.
  - If a SharePoint source lacks `connectionId`, use the oldest SharePoint connection as a legacy fallback; still error when no connection exists.

<sup>Written for commit 250f772bc3083be62d2fbcadc46e2bdbbdef76f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

