### PR TITLE
fix: resolve flaky test

### DIFF
--- a/packages/server/src/workspaceMigrations/migrations/tests/20250729134531_workspace_cleanups.spec.ts
+++ b/packages/server/src/workspaceMigrations/migrations/tests/20250729134531_workspace_cleanups.spec.ts
@@ -38,6 +38,7 @@ describe.each([
   })
 
   beforeEach(async () => {
+    tk.freeze(structures.generator.date())
     await config.newTenant()
     for (const workspaceId of [
       config.getDevWorkspaceId(),
@@ -58,7 +59,6 @@ describe.each([
       defaultWorkspaceApp = workspaceApps[0]
     }
 
-    tk.freeze(structures.generator.date())
     jest.clearAllMocks()
   })
 
@@ -127,7 +127,6 @@ describe.each([
       const workspaceApp2 = await createWorkspaceApp(true)
 
       tk.travel(Date.now() + 1000)
-
       await sdk.workspaceApps.update(workspaceApp1)
 
       const toDelete1 = defaultWorkspaceApp._id!
@@ -164,6 +163,7 @@ describe.each([
 
     expect(workspaceApps).toHaveLength(1)
     expect(workspaceApps[0]._id).toBe(keptWorkspaceAppId)
+    expect(workspaceApps[0].isDefault).toBe(true)
 
     // All screens should now reference the kept workspace app
     const screensWithWorkspaceAppId = screens.filter(s => s.workspaceAppId)


### PR DESCRIPTION
## Description
Resolve flaky test by ensuring date freezing is consistent in beforeEach

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the workspace cleanup migration test by freezing time at the start of beforeEach to avoid inconsistent dates. Also verifies the retained workspace app is still marked as default.

- **Bug Fixes**
  - Call `tk.freeze(structures.generator.date())` at the start of `beforeEach` and remove the later freeze to prevent timing-related flakiness with `tk.travel`.
  - Add `expect(workspaceApps[0].isDefault).toBe(true)` to ensure the cleanup keeps the default app.

<sup>Written for commit fc10f7e080e8dc893ab2947d8b7271a865bfa64c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

