### PR TITLE
Remove unnecessary tenantId

### DIFF
--- a/packages/server/src/api/controllers/ai/sharepointAuth.ts
+++ b/packages/server/src/api/controllers/ai/sharepointAuth.ts
@@ -209,7 +209,6 @@ export async function completeSharePointAuth(ctx: UserCtx<void, void>) {
     (async () => {
       await sdk.ai.knowledgeSources.createKnowledgeSourceConnection({
         sourceType: AgentKnowledgeSourceType.SHAREPOINT,
-        tenantId,
         tokenEndpoint,
         accessToken,
         refreshToken,

--- a/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
@@ -130,7 +130,6 @@ describe("agent files", () => {
       const connection = await createKnowledgeSourceConnection({
         sourceType: AgentKnowledgeSourceType.SHAREPOINT,
         account: "connected-sharepoint@budibase.com",
-        tenantId: config.getTenantId(),
         tokenEndpoint:
           "https://login.microsoftonline.com/common/oauth2/v2.0/token",
         accessToken: "header.payload.signature",

--- a/packages/server/src/sdk/workspace/ai/knowledgeSources/sharepointConnection/connection.ts
+++ b/packages/server/src/sdk/workspace/ai/knowledgeSources/sharepointConnection/connection.ts
@@ -12,7 +12,6 @@ import {
 type SharePointConnectionRecord = Pick<
   AgentKnowledgeSourceConnection,
   | "account"
-  | "tenantId"
   | "tokenEndpoint"
   | "accessToken"
   | "refreshToken"
@@ -49,7 +48,6 @@ const mapPersistedToCacheRecord = (
 ): SharePointConnectionRecord => {
   return {
     account: doc.account || "unknown",
-    tenantId: doc.tenantId,
     tokenEndpoint: doc.tokenEndpoint,
     accessToken: doc.accessToken,
     refreshToken: doc.refreshToken,
@@ -125,7 +123,6 @@ const refreshConnection = async (
   const saved = await updateKnowledgeSourceConnection<SharePointConnectionDoc>(
     connectionId,
     {
-      tenantId: updated.tenantId,
       tokenEndpoint: updated.tokenEndpoint,
       accessToken: updated.accessToken,
       refreshToken: updated.refreshToken,

--- a/packages/types/src/documents/global/agentKnowledgeSourceConnection.ts
+++ b/packages/types/src/documents/global/agentKnowledgeSourceConnection.ts
@@ -3,7 +3,6 @@ import { AgentKnowledgeSourceType, Document } from "../../"
 export interface AgentKnowledgeSourceConnection extends Document {
   sourceType: AgentKnowledgeSourceType
   account: string
-  tenantId: string
   tokenEndpoint: string
   accessToken: string
   refreshToken: string


### PR DESCRIPTION
## Description
Remove unnecessary oauth tenantId. This was never used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused SharePoint OAuth `tenantId` across server, SDK, and types to simplify connection storage and auth. No functional changes.

- **Refactors**
  - Removed `tenantId` from `AgentKnowledgeSourceConnection`.
  - Stopped sending `tenantId` in `completeSharePointAuth`.
  - Removed `tenantId` handling in SharePoint connection cache/update logic.
  - Updated tests to match the new connection shape.

<sup>Written for commit 33ebb4bcb907bd3ad30b76399e7c84733bc05a43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

