### PR TITLE
[CI] Setup merge queues

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
   workflow_call:
     inputs:

--- a/.github/workflows/cla-merge-group.yml
+++ b/.github/workflows/cla-merge-group.yml
@@ -1,0 +1,15 @@
+name: CLA Assistant (merge queue)
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA already enforced on PR
+        run: echo "CLA is enforced on pull_request_target; passing merge_group status."


### PR DESCRIPTION
## Description
Setup merge queues

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable merge queues by triggering CI and CLA checks on `merge_group` events (`checks_requested`). Adds a lightweight CLA workflow that reports success for merge groups since CLA is already enforced on `pull_request_target`, ensuring queued PRs get required statuses before merging.

<sup>Written for commit e37de164547665a7b05248b7748615b8972651c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

