### PR TITLE
Add queued polling for agent test runs

### DIFF
--- a/packages/backend-core/src/docIds/ids.ts
+++ b/packages/backend-core/src/docIds/ids.ts
@@ -137,6 +137,10 @@ export const getAgentTestSuiteID = (agentId: string) => {
   return `${DocumentType.AGENT_TEST_SUITE}${SEPARATOR}${agentId}`
 }
 
+export const getAgentTestRunID = (agentId: string, runId: string) => {
+  return `${DocumentType.AGENT_TEST_RUN}${SEPARATOR}${agentId}${SEPARATOR}${runId}`
+}
+
 export const generateAgentToolSourceID = () => {
   return `${DocumentType.AGENT_TOOL_SOURCE}${SEPARATOR}${newid()}`
 }

--- a/packages/backend-core/src/docIds/ids.ts
+++ b/packages/backend-core/src/docIds/ids.ts
@@ -138,7 +138,7 @@ export const getAgentTestSuiteID = (agentId: string) => {
 }
 
 export const getAgentTestRunID = (agentId: string, runId: string) => {
-  return `${DocumentType.AGENT_TEST_RUN}${SEPARATOR}${agentId}${SEPARATOR}${runId}`
+  return `${getAgentTestSuiteID(agentId)}${SEPARATOR}${DocumentType.AGENT_TEST_RUN}${SEPARATOR}${runId}`
 }
 
 export const generateAgentToolSourceID = () => {

--- a/packages/backend-core/src/queue/constants.ts
+++ b/packages/backend-core/src/queue/constants.ts
@@ -10,4 +10,5 @@ export enum JobQueue {
   RAG_INGESTION = "ragIngestionQueue",
   KNOWLEDGE_SOURCE_SYNC = "knowledgeSourceSyncQueue",
   AGENT_LOG_INDEXING = "agentLogIndexingQueue",
+  AGENT_TEST_RUN = "agentTestRunQueue",
 }

--- a/packages/backend-core/src/queue/listeners.ts
+++ b/packages/backend-core/src/queue/listeners.ts
@@ -93,6 +93,7 @@ enum QueueEventType {
   BATCH_USER_SYNC_PROCESSOR = "batch-user-sync-processor",
   RAG_INGESTION_PROCESSOR = "rag-ingestion-processor",
   AGENT_LOG_INDEXING_PROCESSOR = "agent-log-indexing-processor",
+  AGENT_TEST_RUN_PROCESSOR = "agent-test-run-processor",
   KNOWLEDGE_SOURCE_SYNC_PROCESSOR = "knowledge-source-sync-processor",
 }
 
@@ -108,6 +109,7 @@ const EventTypeMap: { [key in JobQueue]: QueueEventType } = {
     QueueEventType.BATCH_USER_SYNC_PROCESSOR,
   [JobQueue.RAG_INGESTION]: QueueEventType.RAG_INGESTION_PROCESSOR,
   [JobQueue.AGENT_LOG_INDEXING]: QueueEventType.AGENT_LOG_INDEXING_PROCESSOR,
+  [JobQueue.AGENT_TEST_RUN]: QueueEventType.AGENT_TEST_RUN_PROCESSOR,
   [JobQueue.KNOWLEDGE_SOURCE_SYNC]:
     QueueEventType.KNOWLEDGE_SOURCE_SYNC_PROCESSOR,
 }

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/TestComponents/TestCaseList.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/TestComponents/TestCaseList.svelte
@@ -32,7 +32,7 @@
     loading: boolean
     saving: boolean
     running: boolean
-    runningCaseId: string | null
+    runningCaseIds: Set<string>
     hasLatestRun: boolean
     latestResultsByCaseId: Map<string, AgentTestCaseResult[]>
     onSelectCase: (_caseId: string) => void
@@ -56,7 +56,7 @@
     loading,
     saving,
     running,
-    runningCaseId,
+    runningCaseIds,
     hasLatestRun,
     latestResultsByCaseId,
     onSelectCase,
@@ -200,10 +200,12 @@
           disabled={!casesForSelectedGroup.length ||
             loading ||
             saving ||
-            running}
+            casesForSelectedGroup.some(testCase =>
+              runningCaseIds.has(testCase.id)
+            )}
           on:click={onRunAll}
         >
-          {running ? "Running..." : "Run all tests"}
+          Run all tests
         </Button>
       </div>
     </div>
@@ -274,9 +276,7 @@
         {#each filteredCases as testCase (testCase.id)}
           {@const latestResults = latestResultsByCaseId.get(testCase.id)}
           {@const statusMeta = getVerdictMeta(getCaseStatus(latestResults))}
-          {@const isRunningCase = runningCaseId === testCase.id}
-          {@const showSpinner =
-            running && (runningCaseId === null || isRunningCase)}
+          {@const showSpinner = runningCaseIds.has(testCase.id)}
           <div class="case-row" class:selected={testCase.id === selectedCaseId}>
             <button
               class="case-row-select"
@@ -335,7 +335,13 @@
 </div>
 
 {#snippet caseMenuItems(caseId: string)}
-  <MenuItem icon="play" on:click={() => onRunCase(caseId)}>Run test</MenuItem>
+  <MenuItem
+    icon="play"
+    disabled={runningCaseIds.has(caseId)}
+    on:click={() => onRunCase(caseId)}
+  >
+    Run test
+  </MenuItem>
   <MenuItem icon="pencil-simple" on:click={() => onEditCase(caseId)}>
     Edit test
   </MenuItem>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/tests.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/tests.svelte
@@ -139,9 +139,7 @@
     selectedCaseId ? (latestResultsByCaseId.get(selectedCaseId) ?? []) : []
   )
   let running = $derived(activeRuns.length > 0)
-  let runningCaseIds = $derived(
-    new Set(activeRuns.flatMap(run => run.caseIds))
-  )
+  let runningCaseIds = $derived(new Set(activeRuns.flatMap(run => run.caseIds)))
 
   const resetState = (agentId?: string) => {
     suite = emptySuite(agentId)

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/tests.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/tests.svelte
@@ -371,10 +371,7 @@
     },
   })
 
-  const startRun = async (
-    body: RunAgentTestSuiteRequest,
-    caseId?: string
-  ) => {
+  const startRun = async (body: RunAgentTestSuiteRequest, caseId?: string) => {
     const agentId = currentAgent?._id
     if (!agentId || running || saving) return false
 

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/tests.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/tests.svelte
@@ -25,9 +25,13 @@
   import TestDetail from "./TestComponents/TestDetail.svelte"
   import TestGroupModal from "./TestComponents/TestGroupModal.svelte"
   import * as routify from "@roxi/routify"
+  import { createPolling } from "@/utils/polling"
+  import { onDestroy } from "svelte"
+  import type { RunAgentTestSuiteRequest } from "@budibase/types"
 
   const { goto } = routify
   $goto
+  const TEST_RUN_POLL_INTERVAL_MS = 1000
 
   const emptySuite = (agentId = ""): AgentTestSuite => ({
     agentId,
@@ -73,6 +77,8 @@
   let saving = $state(false)
   let running = $state(false)
   let runningCaseId = $state<string | null>(null)
+  let activeRunId = $state<string | null>(null)
+  let runPollErrorCount = 0
   let preferredGroupId = $state<string | null>(buildDefaultAgentTestGroup().id)
   let preferredCaseId = $state<string | null>(null)
   let lastAgentId = $state<string | undefined>()
@@ -319,51 +325,86 @@
     }
   }
 
-  const runCase = async (caseId?: string) => {
+  const finishActiveRun = () => {
+    testRunPolling.stop()
+    activeRunId = null
+    running = false
+    runningCaseId = null
+    runPollErrorCount = 0
+  }
+
+  const pollActiveRun = async () => {
+    const agentId = currentAgent?._id
+    const runId = activeRunId
+    if (!agentId || !runId) return
+
+    const { run } = await API.fetchAgentTestRun(agentId, runId)
+    runPollErrorCount = 0
+    if (run.runId !== activeRunId || run.status === "running") {
+      return
+    }
+
+    finishActiveRun()
+    if (run.status === "completed" && run.run) {
+      mergeRunResults(run.run)
+      notifications.success(
+        `Run complete · ${run.run.passed}/${run.run.total} passed`
+      )
+      return
+    }
+
+    notifications.error(run.error || "Failed to run test")
+  }
+
+  const testRunPolling = createPolling({
+    intervalMs: TEST_RUN_POLL_INTERVAL_MS,
+    immediate: true,
+    poll: pollActiveRun,
+    shouldPoll: () => !!activeRunId && running,
+    onError: error => {
+      console.error("Failed to poll test run", error)
+      runPollErrorCount += 1
+      if (runPollErrorCount < 3) return
+
+      finishActiveRun()
+      notifications.error("Failed to fetch test run status")
+    },
+  })
+
+  const startRun = async (
+    body: RunAgentTestSuiteRequest,
+    caseId?: string
+  ) => {
     const agentId = currentAgent?._id
     if (!agentId || running || saving) return false
 
     running = true
     runningCaseId = caseId ?? null
+    activeRunId = null
+    runPollErrorCount = 0
     try {
-      const { run } = await API.runAgentTestSuite(
-        agentId,
-        caseId ? { caseId } : {}
-      )
-      mergeRunResults(run)
-      notifications.success(`Run complete · ${run.passed}/${run.total} passed`)
+      const { runId } = await API.runAgentTestSuite(agentId, body)
+      activeRunId = runId
+      testRunPolling.start()
       return true
     } catch (error) {
       console.error("Failed to run test", error)
       notifications.error("Failed to run test")
-      return false
-    } finally {
       running = false
       runningCaseId = null
+      return false
     }
+  }
+
+  const runCase = async (caseId?: string) => {
+    return startRun(caseId ? { caseId } : {}, caseId)
   }
 
   const runAllTests = async () => {
     const agentId = currentAgent?._id
     if (!agentId || !selectedGroupId || running || saving) return false
 
-    running = true
-    runningCaseId = null
-    try {
-      const { run } = await API.runAgentTestSuite(agentId, {
-        groupId: selectedGroupId,
-      })
-      mergeRunResults(run)
-      notifications.success(`Run complete · ${run.passed}/${run.total} passed`)
-      return true
-    } catch (error) {
-      console.error("Failed to run tests", error)
-      notifications.error("Failed to run tests")
-      return false
-    } finally {
-      running = false
-      runningCaseId = null
-    }
+    return startRun({ groupId: selectedGroupId })
   }
 
   $effect(() => {
@@ -374,8 +415,15 @@
     const agentId = currentAgent?._id
     if (agentId === lastAgentId) return
     lastAgentId = agentId
+    if (activeRunId) {
+      finishActiveRun()
+    }
     resetState(agentId)
     loadSuite(agentId)
+  })
+
+  onDestroy(() => {
+    testRunPolling.stop()
   })
 </script>
 

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/tests.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/tests.svelte
@@ -32,6 +32,7 @@
   const { goto } = routify
   $goto
   const TEST_RUN_POLL_INTERVAL_MS = 1000
+  const MAX_RUN_POLL_ERRORS = 3
 
   const emptySuite = (agentId = ""): AgentTestSuite => ({
     agentId,
@@ -72,13 +73,16 @@
   const getLatestResults = (testCase: AgentTestCase): AgentTestCaseResult[] =>
     testCase.lastResults || (testCase.lastResult ? [testCase.lastResult] : [])
 
+  interface ActiveTestRun {
+    runId: string
+    caseIds: string[]
+    pollErrorCount: number
+  }
+
   let suite = $state<AgentTestSuite>(emptySuite())
   let loading = $state(false)
   let saving = $state(false)
-  let running = $state(false)
-  let runningCaseId = $state<string | null>(null)
-  let activeRunId = $state<string | null>(null)
-  let runPollErrorCount = 0
+  let activeRuns = $state<ActiveTestRun[]>([])
   let preferredGroupId = $state<string | null>(buildDefaultAgentTestGroup().id)
   let preferredCaseId = $state<string | null>(null)
   let lastAgentId = $state<string | undefined>()
@@ -133,6 +137,10 @@
   )
   let latestResultsForSelected = $derived(
     selectedCaseId ? (latestResultsByCaseId.get(selectedCaseId) ?? []) : []
+  )
+  let running = $derived(activeRuns.length > 0)
+  let runningCaseIds = $derived(
+    new Set(activeRuns.flatMap(run => run.caseIds))
   )
 
   const resetState = (agentId?: string) => {
@@ -325,83 +333,120 @@
     }
   }
 
-  const finishActiveRun = () => {
-    testRunPolling.stop()
-    activeRunId = null
-    running = false
-    runningCaseId = null
-    runPollErrorCount = 0
+  const stopPollingIfIdle = () => {
+    if (!activeRuns.length) {
+      testRunPolling.stop()
+    }
   }
 
-  const pollActiveRun = async () => {
+  const clearActiveRuns = () => {
+    activeRuns = []
+    testRunPolling.stop()
+  }
+
+  const finishActiveRun = (runId: string) => {
+    activeRuns = activeRuns.filter(run => run.runId !== runId)
+    stopPollingIfIdle()
+  }
+
+  const updatePollErrorCount = (runId: string) => {
+    activeRuns = activeRuns.map(run =>
+      run.runId === runId
+        ? { ...run, pollErrorCount: run.pollErrorCount + 1 }
+        : run
+    )
+  }
+
+  const pollActiveRun = async (activeRun: ActiveTestRun) => {
     const agentId = currentAgent?._id
-    const runId = activeRunId
-    if (!agentId || !runId) return
+    if (!agentId) return
 
-    const { run } = await API.fetchAgentTestRun(agentId, runId)
-    runPollErrorCount = 0
-    if (run.runId !== activeRunId || run.status === "running") {
+    try {
+      const { run } = await API.fetchAgentTestRun(agentId, activeRun.runId)
+      if (run.runId !== activeRun.runId || run.status === "running") {
+        return
+      }
+
+      finishActiveRun(activeRun.runId)
+      if (run.status === "completed" && run.run) {
+        mergeRunResults(run.run)
+        notifications.success(
+          `Run complete · ${run.run.passed}/${run.run.total} passed`
+        )
+        return
+      }
+
+      notifications.error(run.error || "Failed to run test")
+    } catch (error) {
+      console.error("Failed to poll test run", error)
+      updatePollErrorCount(activeRun.runId)
+      if (activeRun.pollErrorCount + 1 < MAX_RUN_POLL_ERRORS) return
+
+      finishActiveRun(activeRun.runId)
+      notifications.error("Failed to fetch test run status")
+    }
+  }
+
+  const pollActiveRuns = async () => {
+    if (!activeRuns.length) {
       return
     }
 
-    finishActiveRun()
-    if (run.status === "completed" && run.run) {
-      mergeRunResults(run.run)
-      notifications.success(
-        `Run complete · ${run.run.passed}/${run.run.total} passed`
-      )
-      return
-    }
-
-    notifications.error(run.error || "Failed to run test")
+    await Promise.all(activeRuns.map(pollActiveRun))
   }
 
   const testRunPolling = createPolling({
     intervalMs: TEST_RUN_POLL_INTERVAL_MS,
     immediate: true,
-    poll: pollActiveRun,
-    shouldPoll: () => !!activeRunId && running,
-    onError: error => {
-      console.error("Failed to poll test run", error)
-      runPollErrorCount += 1
-      if (runPollErrorCount < 3) return
-
-      finishActiveRun()
-      notifications.error("Failed to fetch test run status")
-    },
+    poll: pollActiveRuns,
+    shouldPoll: () => activeRuns.length > 0,
   })
 
-  const startRun = async (body: RunAgentTestSuiteRequest, caseId?: string) => {
+  const startRun = async ({
+    body,
+    caseIds,
+  }: {
+    body: RunAgentTestSuiteRequest
+    caseIds: string[]
+  }) => {
     const agentId = currentAgent?._id
-    if (!agentId || running || saving) return false
+    if (!agentId || saving) return false
 
-    running = true
-    runningCaseId = caseId ?? null
-    activeRunId = null
-    runPollErrorCount = 0
     try {
       const { runId } = await API.runAgentTestSuite(agentId, body)
-      activeRunId = runId
+      activeRuns = [...activeRuns, { runId, caseIds, pollErrorCount: 0 }]
       testRunPolling.start()
       return true
     } catch (error) {
       console.error("Failed to run test", error)
       notifications.error("Failed to run test")
-      running = false
-      runningCaseId = null
       return false
     }
   }
 
-  const runCase = async (caseId?: string) => {
-    return startRun(caseId ? { caseId } : {}, caseId)
+  const runCase = async (caseId: string) => {
+    if (runningCaseIds.has(caseId)) return false
+    return startRun({
+      body: { caseId },
+      caseIds: [caseId],
+    })
   }
 
   const runAllTests = async () => {
     const agentId = currentAgent?._id
-    if (!agentId || !selectedGroupId || running || saving) return false
+    if (!agentId || !selectedGroupId || saving) return false
 
-    return startRun({ groupId: selectedGroupId })
+    const groupCaseIds = suite.cases
+      .filter(testCase => testCase.groupId === selectedGroupId)
+      .map(testCase => testCase.id)
+
+    if (!groupCaseIds.length) return false
+    if (groupCaseIds.some(caseId => runningCaseIds.has(caseId))) return false
+
+    return startRun({
+      body: { groupId: selectedGroupId },
+      caseIds: groupCaseIds,
+    })
   }
 
   $effect(() => {
@@ -412,9 +457,7 @@
     const agentId = currentAgent?._id
     if (agentId === lastAgentId) return
     lastAgentId = agentId
-    if (activeRunId) {
-      finishActiveRun()
-    }
+    clearActiveRuns()
     resetState(agentId)
     loadSuite(agentId)
   })
@@ -435,7 +478,7 @@
         {loading}
         {saving}
         {running}
-        {runningCaseId}
+        {runningCaseIds}
         hasLatestRun={hasAnyLatestResult}
         {latestResultsByCaseId}
         onSelectCase={id => (preferredCaseId = id)}

--- a/packages/frontend-core/src/api/agentTests.ts
+++ b/packages/frontend-core/src/api/agentTests.ts
@@ -1,5 +1,6 @@
 import type {
   FetchAgentTestSuiteResponse,
+  FetchAgentTestRunResponse,
   RunAgentTestSuiteRequest,
   RunAgentTestSuiteResponse,
   UpdateAgentTestSuiteRequest,
@@ -17,6 +18,10 @@ export interface AgentTestEndpoints {
     agentId: string,
     body?: RunAgentTestSuiteRequest
   ) => Promise<RunAgentTestSuiteResponse>
+  fetchAgentTestRun: (
+    agentId: string,
+    runId: string
+  ) => Promise<FetchAgentTestRunResponse>
 }
 
 export const buildAgentTestEndpoints = (
@@ -39,6 +44,12 @@ export const buildAgentTestEndpoints = (
     return await API.post({
       url: `/api/agent/${agentId}/tests/run`,
       body: body ?? {},
+    })
+  },
+
+  fetchAgentTestRun: async (agentId, runId) => {
+    return await API.get({
+      url: `/api/agent/${agentId}/tests/run/${runId}`,
     })
   },
 })

--- a/packages/server/src/api/controllers/ai/agentTests.ts
+++ b/packages/server/src/api/controllers/ai/agentTests.ts
@@ -1,5 +1,6 @@
 import { db, HTTPError } from "@budibase/backend-core"
 import type {
+  FetchAgentTestRunResponse,
   FetchAgentTestSuiteResponse,
   RunAgentTestSuiteRequest,
   RunAgentTestSuiteResponse,
@@ -49,7 +50,7 @@ export async function runAgentTestSuite(
   ctx: UserCtx<RunAgentTestSuiteRequest, RunAgentTestSuiteResponse>
 ) {
   const agentId = await getAgentId(ctx)
-  const run = await sdk.ai.tests.runSuite({
+  const run = await sdk.ai.tests.startRunSuite({
     agentId,
     user: ctx.user,
     caseId: ctx.request.body?.caseId,
@@ -57,5 +58,22 @@ export async function runAgentTestSuite(
     aiConfigIds: ctx.request.body?.aiConfigIds,
   })
 
-  ctx.body = { run }
+  ctx.body = {
+    runId: run.runId,
+    status: run.status,
+  }
+}
+
+export async function fetchAgentTestRun(
+  ctx: UserCtx<void, FetchAgentTestRunResponse>
+) {
+  const agentId = await getAgentId(ctx)
+  const { runId } = ctx.params
+  if (!runId) {
+    throw new HTTPError("runId is required", 400)
+  }
+
+  ctx.body = {
+    run: await sdk.ai.tests.fetchRun({ agentId, runId }),
+  }
 }

--- a/packages/server/src/api/routes/aiAgents.ts
+++ b/packages/server/src/api/routes/aiAgents.ts
@@ -79,6 +79,7 @@ aiTestBuilderAdminRoutes
     runAgentTestSuiteValidator(),
     ai.runAgentTestSuite
   )
+  .get("/api/agent/:agentId/tests/run/:runId", ai.fetchAgentTestRun)
 
 const aiRagBuilderAdminRoutes = endpointGroupList
   .group(auth.builderOrAdmin)

--- a/packages/server/src/automations/bullboard.ts
+++ b/packages/server/src/automations/bullboard.ts
@@ -7,7 +7,7 @@ import { KoaAdapter } from "@bull-board/koa"
 import { UserSyncProcessor } from "../events/docUpdates/syncUsers"
 import * as automation from "../threads/automation"
 import { getAppMigrationQueue } from "../workspaceMigrations/queue"
-import { rag } from "../sdk/workspace/ai"
+import { rag, tests as agentTests } from "../sdk/workspace/ai"
 
 export const automationQueue = new queue.BudibaseQueue<AutomationData>(
   queue.JobQueue.AUTOMATION,
@@ -46,6 +46,7 @@ export async function init() {
   queues.push(
     new BullAdapter(rag.knowledgeSourceSyncQueue.getQueue().getBullQueue())
   )
+  queues.push(new BullAdapter(agentTests.getQueue().getBullQueue()))
 
   const serverAdapter = new KoaAdapter()
   createBullBoard({ queues, serverAdapter })

--- a/packages/server/src/sdk/workspace/ai/tests/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/tests/crud.spec.ts
@@ -438,9 +438,7 @@ describe("agent tests crud", () => {
       const run = await testsCrud.fetchRun({ agentId, runId: "run-1" })
 
       expect(run.runId).toBe("run-1")
-      expect(mockDbTryGet).toHaveBeenCalledWith(
-        `agenttestrun_${agentId}_run-1`
-      )
+      expect(mockDbTryGet).toHaveBeenCalledWith(`agenttestrun_${agentId}_run-1`)
     })
 
     it("marks a test run as completed", async () => {

--- a/packages/server/src/sdk/workspace/ai/tests/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/tests/crud.spec.ts
@@ -402,4 +402,110 @@ describe("agent tests crud", () => {
       expect(mockDbPut).not.toHaveBeenCalled()
     })
   })
+
+  describe("run status documents", () => {
+    it("creates a running test run document", async () => {
+      const run = await testsCrud.createRun({
+        agentId,
+        runId: "run-1",
+        startedAt: "2026-01-01T00:00:00.000Z",
+      })
+
+      expect(run).toMatchObject({
+        _id: `agenttestrun_${agentId}_run-1`,
+        _rev: "2-newrev",
+        agentId,
+        runId: "run-1",
+        status: "running",
+      })
+      expect(mockDbPut).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _id: `agenttestrun_${agentId}_run-1`,
+          status: "running",
+        })
+      )
+    })
+
+    it("fetches a test run document", async () => {
+      mockDbTryGet.mockResolvedValue({
+        _id: `agenttestrun_${agentId}_run-1`,
+        agentId,
+        runId: "run-1",
+        status: "running",
+        startedAt: "2026-01-01T00:00:00.000Z",
+      })
+
+      const run = await testsCrud.fetchRun({ agentId, runId: "run-1" })
+
+      expect(run.runId).toBe("run-1")
+      expect(mockDbTryGet).toHaveBeenCalledWith(
+        `agenttestrun_${agentId}_run-1`
+      )
+    })
+
+    it("marks a test run as completed", async () => {
+      mockDbTryGet.mockResolvedValue({
+        _id: `agenttestrun_${agentId}_run-1`,
+        _rev: "1-old",
+        agentId,
+        runId: "run-1",
+        status: "running",
+        startedAt: "2026-01-01T00:00:00.000Z",
+      })
+
+      await testsCrud.completeRun({
+        agentId,
+        runId: "run-1",
+        run: {
+          agentId,
+          runId: "run-1",
+          total: 1,
+          passed: 1,
+          failed: 0,
+          startedAt: "2026-01-01T00:00:00.000Z",
+          completedAt: "2026-01-01T00:00:01.000Z",
+          snapshot: {
+            agentId,
+            agentName: "Agent",
+            aiconfig: "config-1",
+            enabledTools: [],
+            knowledgeBases: [],
+          },
+          results: [makeResult("case-1")],
+        },
+      })
+
+      expect(mockDbPut).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "completed",
+          completedAt: "2026-01-01T00:00:01.000Z",
+          run: expect.objectContaining({ total: 1 }),
+        })
+      )
+    })
+
+    it("marks a test run as errored", async () => {
+      mockDbTryGet.mockResolvedValue({
+        _id: `agenttestrun_${agentId}_run-1`,
+        _rev: "1-old",
+        agentId,
+        runId: "run-1",
+        status: "running",
+        startedAt: "2026-01-01T00:00:00.000Z",
+      })
+
+      await testsCrud.failRun({
+        agentId,
+        runId: "run-1",
+        error: "No tests found",
+      })
+
+      expect(mockDbPut).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "error",
+          error: "No tests found",
+        })
+      )
+    })
+  })
 })

--- a/packages/server/src/sdk/workspace/ai/tests/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/tests/crud.spec.ts
@@ -404,6 +404,8 @@ describe("agent tests crud", () => {
   })
 
   describe("run status documents", () => {
+    const runDocId = `agenttestsuite_${agentId}_agenttestrun_run-1`
+
     it("creates a running test run document", async () => {
       const run = await testsCrud.createRun({
         agentId,
@@ -412,7 +414,7 @@ describe("agent tests crud", () => {
       })
 
       expect(run).toMatchObject({
-        _id: `agenttestrun_${agentId}_run-1`,
+        _id: runDocId,
         _rev: "2-newrev",
         agentId,
         runId: "run-1",
@@ -420,7 +422,7 @@ describe("agent tests crud", () => {
       })
       expect(mockDbPut).toHaveBeenCalledWith(
         expect.objectContaining({
-          _id: `agenttestrun_${agentId}_run-1`,
+          _id: runDocId,
           status: "running",
         })
       )
@@ -428,7 +430,7 @@ describe("agent tests crud", () => {
 
     it("fetches a test run document", async () => {
       mockDbTryGet.mockResolvedValue({
-        _id: `agenttestrun_${agentId}_run-1`,
+        _id: runDocId,
         agentId,
         runId: "run-1",
         status: "running",
@@ -438,12 +440,12 @@ describe("agent tests crud", () => {
       const run = await testsCrud.fetchRun({ agentId, runId: "run-1" })
 
       expect(run.runId).toBe("run-1")
-      expect(mockDbTryGet).toHaveBeenCalledWith(`agenttestrun_${agentId}_run-1`)
+      expect(mockDbTryGet).toHaveBeenCalledWith(runDocId)
     })
 
     it("marks a test run as completed", async () => {
       mockDbTryGet.mockResolvedValue({
-        _id: `agenttestrun_${agentId}_run-1`,
+        _id: runDocId,
         _rev: "1-old",
         agentId,
         runId: "run-1",
@@ -484,7 +486,7 @@ describe("agent tests crud", () => {
 
     it("marks a test run as errored", async () => {
       mockDbTryGet.mockResolvedValue({
-        _id: `agenttestrun_${agentId}_run-1`,
+        _id: runDocId,
         _rev: "1-old",
         agentId,
         runId: "run-1",

--- a/packages/server/src/sdk/workspace/ai/tests/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/tests/crud.ts
@@ -5,6 +5,8 @@ import type {
   AgentTestCaseResult,
   AgentTestCaseSnapshot,
   AgentTestGroup,
+  AgentTestRun,
+  AgentTestRunDocument,
   AgentTestSuite,
   UpdateAgentTestSuiteRequest,
 } from "@budibase/types"
@@ -206,4 +208,81 @@ export async function persistRunResults({
   })
 
   await db.put({ ...suite, cases })
+}
+
+export async function createRun({
+  agentId,
+  runId,
+  startedAt,
+}: {
+  agentId: string
+  runId: string
+  startedAt: string
+}): Promise<AgentTestRunDocument> {
+  const db = context.getWorkspaceDB()
+  const run: AgentTestRunDocument = {
+    _id: docIds.getAgentTestRunID(agentId, runId),
+    agentId,
+    runId,
+    status: "running",
+    startedAt,
+  }
+
+  const response = await db.put(run)
+  return { ...run, _rev: response.rev }
+}
+
+export async function fetchRun({
+  agentId,
+  runId,
+}: {
+  agentId: string
+  runId: string
+}): Promise<AgentTestRunDocument> {
+  const db = context.getWorkspaceDB()
+  const run = await db.tryGet<AgentTestRunDocument>(
+    docIds.getAgentTestRunID(agentId, runId)
+  )
+  if (!run) {
+    throw new HTTPError("That test run was not found.", 404)
+  }
+  return run
+}
+
+export async function completeRun({
+  agentId,
+  runId,
+  run,
+}: {
+  agentId: string
+  runId: string
+  run: AgentTestRun
+}): Promise<void> {
+  const existing = await fetchRun({ agentId, runId })
+  const db = context.getWorkspaceDB()
+  await db.put({
+    ...existing,
+    status: "completed",
+    completedAt: run.completedAt,
+    run,
+  })
+}
+
+export async function failRun({
+  agentId,
+  runId,
+  error,
+}: {
+  agentId: string
+  runId: string
+  error: string
+}): Promise<void> {
+  const existing = await fetchRun({ agentId, runId })
+  const db = context.getWorkspaceDB()
+  await db.put({
+    ...existing,
+    status: "error",
+    completedAt: new Date().toISOString(),
+    error,
+  })
 }

--- a/packages/server/src/sdk/workspace/ai/tests/index.ts
+++ b/packages/server/src/sdk/workspace/ai/tests/index.ts
@@ -1,3 +1,4 @@
 export * from "./crud"
+export * from "./queue"
 export * from "./reviewers"
 export * from "./run"

--- a/packages/server/src/sdk/workspace/ai/tests/queue.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/tests/queue.spec.ts
@@ -1,0 +1,184 @@
+import type { ContextUser } from "@budibase/types"
+
+const mockAddedJobs: Array<{ data: any; opts: any }> = []
+let mockProcessCallback: ((job: any) => Promise<void>) | undefined
+
+class MockBudibaseQueue {
+  process = jest.fn(async (...args: any[]) => {
+    mockProcessCallback = args.length === 2 ? args[1] : args[0]
+  })
+
+  add = jest.fn(async (data: any, opts: any) => {
+    mockAddedJobs.push({ data, opts })
+    return { id: opts?.jobId, data }
+  })
+}
+
+const mockQueue = new MockBudibaseQueue()
+
+jest.mock("@budibase/backend-core", () => ({
+  context: {
+    getWorkspaceId: jest.fn().mockReturnValue("app_1"),
+    doInWorkspaceContext: jest.fn((_appId: string, fn: () => Promise<void>) =>
+      fn()
+    ),
+  },
+  getErrorMessage: jest.fn((error: unknown) =>
+    error instanceof Error ? error.message : String(error)
+  ),
+  queue: {
+    BudibaseQueue: jest.fn(() => mockQueue),
+    JobQueue: {
+      AGENT_TEST_RUN: "agentTestRunQueue",
+    },
+  },
+  utils: {
+    Duration: {
+      fromSeconds: jest.fn(() => ({ toMs: () => 10_000 })),
+      fromMinutes: jest.fn(() => ({ toMs: () => 1_200_000 })),
+    },
+  },
+}))
+
+jest.mock("./crud", () => ({
+  completeRun: jest.fn().mockResolvedValue(undefined),
+  createRun: jest.fn(),
+  failRun: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock("./run", () => ({
+  runSuite: jest.fn(),
+}))
+
+jest.mock("uuid", () => ({
+  v4: jest.fn().mockReturnValue("run-1"),
+}))
+
+import { context } from "@budibase/backend-core"
+import { completeRun, createRun, failRun } from "./crud"
+import { runSuite } from "./run"
+import { init, startRunSuite } from "./queue"
+
+describe("agent test run queue", () => {
+  const user = { _id: "user_1" } as ContextUser
+  const mockCreateRun = createRun as jest.Mock
+  const mockRunSuite = runSuite as jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockAddedJobs.length = 0
+    mockRunSuite.mockReset()
+    mockCreateRun.mockImplementation(
+      async ({
+        agentId,
+        runId,
+        startedAt,
+      }: {
+        agentId: string
+        runId: string
+        startedAt: string
+      }) => ({
+        agentId,
+        runId,
+        status: "running",
+        startedAt,
+      })
+    )
+  })
+
+  it("creates a run document and enqueues the run job", async () => {
+    const run = await startRunSuite({
+      agentId: "agent-1",
+      user,
+      caseId: "case-1",
+    })
+
+    expect(run).toMatchObject({
+      agentId: "agent-1",
+      runId: "run-1",
+      status: "running",
+    })
+    expect(mockAddedJobs[0]).toEqual({
+      data: expect.objectContaining({
+        workspaceId: "app_1",
+        agentId: "agent-1",
+        runId: "run-1",
+        user,
+        caseId: "case-1",
+      }),
+      opts: { jobId: "run-1" },
+    })
+  })
+
+  it("processes queued runs in the workspace context", async () => {
+    const completedRun = {
+      agentId: "agent-1",
+      runId: "run-1",
+      total: 1,
+      passed: 1,
+      failed: 0,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      completedAt: "2026-01-01T00:00:01.000Z",
+      snapshot: {
+        agentId: "agent-1",
+        agentName: "Agent",
+        aiconfig: "config-1",
+        enabledTools: [],
+        knowledgeBases: [],
+      },
+      results: [],
+    }
+    mockRunSuite.mockResolvedValue(completedRun)
+
+    init()
+    await mockProcessCallback?.({
+      id: "run-1",
+      data: {
+        workspaceId: "app_1",
+        agentId: "agent-1",
+        runId: "run-1",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        user,
+      },
+      opts: {},
+      attemptsMade: 0,
+    })
+
+    expect(context.doInWorkspaceContext).toHaveBeenCalledWith(
+      "app_1",
+      expect.any(Function)
+    )
+    expect(completeRun).toHaveBeenCalledWith({
+      agentId: "agent-1",
+      runId: "run-1",
+      run: completedRun,
+    })
+  })
+
+  it("marks the run as failed when processing errors", async () => {
+    const error = new Error("No tests found")
+    mockRunSuite.mockRejectedValue(error)
+
+    init()
+    await expect(
+      mockProcessCallback?.({
+        id: "run-1",
+        data: {
+          workspaceId: "app_1",
+          agentId: "agent-1",
+          runId: "run-1",
+          startedAt: "2026-01-01T00:00:00.000Z",
+          user,
+        },
+        opts: {},
+        attemptsMade: 0,
+      })
+    ).rejects.toThrow("No tests found")
+
+    expect(failRun).toHaveBeenCalledWith({
+      agentId: "agent-1",
+      runId: "run-1",
+      error: "No tests found",
+    })
+  })
+})

--- a/packages/server/src/sdk/workspace/ai/tests/queue.ts
+++ b/packages/server/src/sdk/workspace/ai/tests/queue.ts
@@ -1,0 +1,157 @@
+import type { Job } from "bull"
+import { context, getErrorMessage, queue, utils } from "@budibase/backend-core"
+import type { ContextUser } from "@budibase/types"
+import { completeRun, createRun, failRun } from "./crud"
+import { runSuite } from "./run"
+import { v4 } from "uuid"
+
+const DEFAULT_CONCURRENCY = 2
+const DEFAULT_BACKOFF_MS = utils.Duration.fromSeconds(10).toMs()
+const DEFAULT_TIMEOUT_MS = utils.Duration.fromMinutes(20).toMs()
+
+interface AgentTestRunJob {
+  workspaceId: string
+  agentId: string
+  runId: string
+  startedAt: string
+  user: ContextUser
+  caseId?: string
+  groupId?: string
+  aiConfigIds?: string[]
+}
+
+let agentTestRunQueue: queue.BudibaseQueue<AgentTestRunJob> | undefined
+let agentTestRunQueueInitialised = false
+
+export function getQueue() {
+  if (!agentTestRunQueue) {
+    agentTestRunQueue = new queue.BudibaseQueue<AgentTestRunJob>(
+      queue.JobQueue.AGENT_TEST_RUN,
+      {
+        maxStalledCount: 1,
+        jobOptions: {
+          attempts: 1,
+          backoff: {
+            type: "exponential",
+            delay: DEFAULT_BACKOFF_MS,
+          },
+          timeout: DEFAULT_TIMEOUT_MS,
+          removeOnComplete: true,
+          removeOnFail: 1000,
+        },
+        jobTags: data => ({
+          workspaceId: data.workspaceId,
+          agentId: data.agentId,
+          runId: data.runId,
+        }),
+      }
+    )
+  }
+
+  return agentTestRunQueue
+}
+
+const markRunFailed = async ({
+  agentId,
+  runId,
+  error,
+}: {
+  agentId: string
+  runId: string
+  error: unknown
+}) => {
+  const message = getErrorMessage(error)
+  try {
+    await failRun({ agentId, runId, error: message })
+  } catch (updateError) {
+    console.error("Failed to mark agent test run as failed", {
+      agentId,
+      runId,
+      error: updateError,
+    })
+  }
+}
+
+const processJob = async (job: Job<AgentTestRunJob>) => {
+  const {
+    workspaceId,
+    agentId,
+    runId,
+    startedAt,
+    user,
+    caseId,
+    groupId,
+    aiConfigIds,
+  } = job.data
+
+  await context.doInWorkspaceContext(workspaceId, async () => {
+    try {
+      const completedRun = await runSuite({
+        agentId,
+        user,
+        caseId,
+        groupId,
+        aiConfigIds,
+        runId,
+        startedAt,
+      })
+      await completeRun({ agentId, runId, run: completedRun })
+    } catch (error) {
+      await markRunFailed({ agentId, runId, error })
+      throw error
+    }
+  })
+}
+
+export function init(concurrency = DEFAULT_CONCURRENCY) {
+  if (agentTestRunQueueInitialised) {
+    return Promise.resolve()
+  }
+
+  try {
+    agentTestRunQueueInitialised = true
+    return getQueue().process(concurrency, processJob)
+  } catch (error) {
+    agentTestRunQueueInitialised = false
+    throw error
+  }
+}
+
+export async function startRunSuite({
+  agentId,
+  user,
+  caseId,
+  groupId,
+  aiConfigIds,
+}: {
+  agentId: string
+  user: ContextUser
+  caseId?: string
+  groupId?: string
+  aiConfigIds?: string[]
+}) {
+  const workspaceId = context.getWorkspaceId()
+  if (!workspaceId) {
+    throw new Error("workspaceId is required")
+  }
+
+  const runId = v4()
+  const startedAt = new Date().toISOString()
+  const run = await createRun({ agentId, runId, startedAt })
+  init()
+  await getQueue().add(
+    {
+      workspaceId,
+      agentId,
+      runId,
+      startedAt,
+      user,
+      caseId,
+      groupId,
+      aiConfigIds,
+    },
+    { jobId: runId }
+  )
+
+  return run
+}

--- a/packages/server/src/sdk/workspace/ai/tests/run.ts
+++ b/packages/server/src/sdk/workspace/ai/tests/run.ts
@@ -623,12 +623,16 @@ export async function runSuite({
   caseId,
   groupId,
   aiConfigIds,
+  runId = v4(),
+  startedAt = new Date().toISOString(),
 }: {
   agentId: string
   user: ContextUser
   caseId?: string
   groupId?: string
   aiConfigIds?: string[]
+  runId?: string
+  startedAt?: string
 }): Promise<AgentTestRun> {
   const agent = await sdk.ai.agents.getOrThrow(agentId)
   const suite = await fetchSuite(agentId)
@@ -639,8 +643,6 @@ export async function runSuite({
     )
   )
   const configSnapshots = await buildConfigSnapshotMap(runConfigIds)
-  const runId = v4()
-  const startedAt = new Date().toISOString()
   const snapshot = await buildRunSnapshot({
     agent,
     suite,

--- a/packages/server/src/startup/index.ts
+++ b/packages/server/src/startup/index.ts
@@ -28,7 +28,7 @@ import { generateApiKey, getChecklist } from "../utilities/workerRequests"
 import { watch } from "../watch"
 import { initialise as initialiseWebsockets } from "../websockets"
 import * as workspaceMigrations from "../workspaceMigrations/queue"
-import { rag } from "../sdk/workspace/ai"
+import { rag, tests as agentTests } from "../sdk/workspace/ai"
 
 export type State = "uninitialised" | "starting" | "ready"
 let STATE: State = "uninitialised"
@@ -174,6 +174,7 @@ export async function startup(
   )
   queuePromises.push(rag.ragQueue.init())
   queuePromises.push(rag.knowledgeSourceSyncQueue.init())
+  queuePromises.push(agentTests.init())
   queuePromises.push(
     rag.knowledgeSourceSyncQueue.rehydrateScheduledJobs().catch(err => {
       console.error("Failed to rehydrate knowledge source sync jobs", err)

--- a/packages/types/src/api/web/global/agentTests.ts
+++ b/packages/types/src/api/web/global/agentTests.ts
@@ -1,7 +1,7 @@
 import {
   AgentTestCaseDefinition,
   AgentTestGroup,
-  AgentTestRun,
+  AgentTestRunDocument,
   AgentTestSuite,
 } from "../../../documents"
 
@@ -24,5 +24,10 @@ export interface RunAgentTestSuiteRequest {
 }
 
 export interface RunAgentTestSuiteResponse {
-  run: AgentTestRun
+  runId: string
+  status: AgentTestRunDocument["status"]
+}
+
+export interface FetchAgentTestRunResponse {
+  run: AgentTestRunDocument
 }

--- a/packages/types/src/documents/document.ts
+++ b/packages/types/src/documents/document.ts
@@ -48,6 +48,7 @@ export enum DocumentType {
   AGENT_LOG_SESSION = "agentlogsession",
   AGENT_LOG_REQUEST = "agentlogrequest",
   AGENT_TEST_SUITE = "agenttestsuite",
+  AGENT_TEST_RUN = "agenttestrun",
   AGENT_KNOWLEDGE_SOURCE_SYNC_STATE = "agentknowledgesync",
   AGENT_KNOWLEDGE_SOURCE_CONNECTION = "agentknowledgeconn",
   KNOWLEDGE_BASE_FILE = "knowledgebasefile",

--- a/packages/types/src/documents/global/agentTests.ts
+++ b/packages/types/src/documents/global/agentTests.ts
@@ -120,3 +120,15 @@ export interface AgentTestRun {
   snapshot: AgentTestSnapshot
   results: AgentTestCaseResult[]
 }
+
+export type AgentTestRunStatus = "running" | "completed" | "error"
+
+export interface AgentTestRunDocument extends Document {
+  agentId: string
+  runId: string
+  status: AgentTestRunStatus
+  startedAt: string
+  completedAt?: string
+  run?: AgentTestRun
+  error?: string
+}


### PR DESCRIPTION
## Description
Agent test runs now start asynchronously and are processed through the existing Budibase queue infrastructure. The builder gets a run id immediately and polls a persisted run document until the queued test run completes or fails.

This avoids long model comparison requests timing out while still preserving the test results for the UI.



## Launchcontrol
Agent test runs now execute in the background, making model comparisons more reliable and avoiding request timeouts in the builder.

## Validation
- `yarn test src/sdk/workspace/ai/tests/queue.spec.ts`
- `yarn test src/sdk/workspace/ai/tests/run.spec.ts`
- `yarn test src/sdk/workspace/ai/tests/crud.spec.ts`
- `yarn check:types`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agent test runs now execute asynchronously on a queue. The builder supports parallel runs with per-case polling and progress, returning a `runId` to avoid timeouts.

- **New Features**
  - Added `AGENT_TEST_RUN` queue/processor with persisted `agenttestrun_*` docs (`running/completed/error`); initialised at startup and visible in Bull Board.
  - API: POST `/api/agent/:agentId/tests/run` now returns `{ runId, status }`; new GET `/api/agent/:agentId/tests/run/:runId` to fetch run; frontend adds `fetchAgentTestRun`.
  - Builder: parallel test runs with per-case spinners and disabled actions; “Run all” disabled when any case in group is running; 1s polling via `createPolling` tracks multiple runs and stops on unmount/agent change; retries polling errors up to 3 times; merges results and shows pass/fail summary.
  - SDK: `startRunSuite` enqueues jobs; new helpers `createRun`, `fetchRun`, `completeRun`, `failRun`; jobs run in workspace context with exponential backoff, 20m timeout, and default concurrency 2; added queue and CRUD tests.

- **Bug Fixes**
  - Fixed agent test formatting.

<sup>Written for commit bf5a78c0dbd139701029cdff0d02d1d8afdfd788. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



