### PR TITLE
Fix automation row triggers from views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,13 +55,13 @@
 
 ## Git
 
-Never auto-commit changes unless explicitly asked to do so. You may ask permission to commit.
-Each commit requires permission.
+Never run `git add`, `git commit`, or `git push` unless the most recent user prompt
+expressly asks for that exact git action. Requests to fix, test, or handle failing checks do not imply permission to stage, commit, or push.
+You may ask permission to run these commands, but do not run them until the user
+explicitly grants it.
 
-Never auto-push changes unless explicitly asked to do so. You may ask permission to push.
-Each push requires permission.
-
-For example, if I command `git add, commit, push` go ahead and do that once. Any subsequent changes will require permission. You may ask for permission on a per commit basis.
+Each `git add`, `git commit`, and `git push` requires permission from the most recent user
+prompt. Permission does not carry over from earlier prompts.
 
 ## Pull requests
 

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -52,9 +52,14 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   const table = await utils.getTableFromSource(source)
   const { _id, ...rowData } = ctx.request.body
 
-  const beforeRow = await sdk.rows.external.getRow(table._id!, _id, {
-    relationships: true,
-  })
+  const [beforeRow, beforeResponseRow] = await Promise.all([
+    sdk.rows.external.getRow(table._id!, _id, {
+      relationships: true,
+    }),
+    sdk.rows.external.getRow(source, _id, {
+      relationships: true,
+    }),
+  ])
 
   let dataToUpdate = cloneDeep(beforeRow)
   const allowedField = utils.getSourceFields(source)
@@ -86,26 +91,42 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   // The id might have been changed, so the refetching would fail. Recalculating the id just in case
   const updatedId =
     generateIdForRow({ ...beforeRow, ...dataToUpdate }, table) || _id
-  const row = await sdk.rows.external.getRow(table._id!, updatedId, {
-    relationships: true,
-  })
-
-  const [enrichedRow, oldRow] = await Promise.all([
-    outputProcessing(table, row, {
-      squash: true,
-      preserveLinks: true,
+  const [row, responseRow] = await Promise.all([
+    sdk.rows.external.getRow(table._id!, updatedId, {
+      relationships: true,
     }),
-    outputProcessing(table, beforeRow, {
-      squash: true,
-      preserveLinks: true,
+    sdk.rows.external.getRow(source, updatedId, {
+      relationships: true,
     }),
   ])
+
+  const [enrichedRow, oldRow, automationRow, oldAutomationRow] =
+    await Promise.all([
+      outputProcessing(source, responseRow, {
+        squash: true,
+        preserveLinks: true,
+      }),
+      outputProcessing(source, beforeResponseRow, {
+        squash: true,
+        preserveLinks: true,
+      }),
+      outputProcessing(table, row, {
+        squash: true,
+        preserveLinks: true,
+      }),
+      outputProcessing(table, beforeRow, {
+        squash: true,
+        preserveLinks: true,
+      }),
+    ])
 
   return {
     ...response,
     row: enrichedRow,
     table,
     oldRow,
+    automationRow,
+    oldAutomationRow,
   }
 }
 

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -86,26 +86,40 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   // The id might have been changed, so the refetching would fail. Recalculating the id just in case
   const updatedId =
     generateIdForRow({ ...beforeRow, ...dataToUpdate }, table) || _id
-  const row = await sdk.rows.external.getRow(table._id!, updatedId, {
+  const fullRow = await sdk.rows.external.getRow(table._id!, updatedId, {
     relationships: true,
   })
+  const row = sdk.views.isView(source)
+    ? await sdk.rows.external.getRow(source, updatedId, {
+        relationships: true,
+      })
+    : fullRow
+  const fullBeforeRow = cloneDeep(beforeRow)
 
   const [enrichedRow, oldRow] = await Promise.all([
-    outputProcessing(table, row, {
+    outputProcessing(source, row, {
       squash: true,
       preserveLinks: true,
     }),
-    outputProcessing(table, beforeRow, {
+    outputProcessing(source, beforeRow, {
       squash: true,
       preserveLinks: true,
     }),
   ])
+  const automationRow = sdk.views.isView(source)
+    ? { ...fullRow, ...enrichedRow }
+    : enrichedRow
+  const automationOldRow = sdk.views.isView(source)
+    ? { ...fullBeforeRow, ...oldRow }
+    : oldRow
 
   return {
     ...response,
     row: enrichedRow,
     table,
     oldRow,
+    automationRow,
+    automationOldRow,
   }
 }
 

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -45,9 +45,6 @@ export async function handleRequest<T extends Operation>(
 export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   const source = await utils.getSource(ctx)
 
-  const { viewId, tableId } = utils.getSourceId(ctx)
-  const sourceId = viewId || tableId
-
   if (sdk.views.isView(source) && helpers.views.isCalculationView(source)) {
     ctx.throw(400, "Cannot update rows through a calculation view")
   }

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -52,14 +52,9 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   const table = await utils.getTableFromSource(source)
   const { _id, ...rowData } = ctx.request.body
 
-  const [beforeRow, beforeResponseRow] = await Promise.all([
-    sdk.rows.external.getRow(table._id!, _id, {
-      relationships: true,
-    }),
-    sdk.rows.external.getRow(source, _id, {
-      relationships: true,
-    }),
-  ])
+  const beforeRow = await sdk.rows.external.getRow(table._id!, _id, {
+    relationships: true,
+  })
 
   let dataToUpdate = cloneDeep(beforeRow)
   const allowedField = utils.getSourceFields(source)
@@ -91,42 +86,26 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   // The id might have been changed, so the refetching would fail. Recalculating the id just in case
   const updatedId =
     generateIdForRow({ ...beforeRow, ...dataToUpdate }, table) || _id
-  const [row, responseRow] = await Promise.all([
-    sdk.rows.external.getRow(table._id!, updatedId, {
-      relationships: true,
+  const row = await sdk.rows.external.getRow(table._id!, updatedId, {
+    relationships: true,
+  })
+
+  const [enrichedRow, oldRow] = await Promise.all([
+    outputProcessing(table, row, {
+      squash: true,
+      preserveLinks: true,
     }),
-    sdk.rows.external.getRow(source, updatedId, {
-      relationships: true,
+    outputProcessing(table, beforeRow, {
+      squash: true,
+      preserveLinks: true,
     }),
   ])
-
-  const [enrichedRow, oldRow, automationRow, oldAutomationRow] =
-    await Promise.all([
-      outputProcessing(source, responseRow, {
-        squash: true,
-        preserveLinks: true,
-      }),
-      outputProcessing(source, beforeResponseRow, {
-        squash: true,
-        preserveLinks: true,
-      }),
-      outputProcessing(table, row, {
-        squash: true,
-        preserveLinks: true,
-      }),
-      outputProcessing(table, beforeRow, {
-        squash: true,
-        preserveLinks: true,
-      }),
-    ])
 
   return {
     ...response,
     row: enrichedRow,
     table,
     oldRow,
-    automationRow,
-    oldAutomationRow,
   }
 }
 

--- a/packages/server/src/api/controllers/row/external.ts
+++ b/packages/server/src/api/controllers/row/external.ts
@@ -89,16 +89,16 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   // The id might have been changed, so the refetching would fail. Recalculating the id just in case
   const updatedId =
     generateIdForRow({ ...beforeRow, ...dataToUpdate }, table) || _id
-  const row = await sdk.rows.external.getRow(sourceId, updatedId, {
+  const row = await sdk.rows.external.getRow(table._id!, updatedId, {
     relationships: true,
   })
 
   const [enrichedRow, oldRow] = await Promise.all([
-    outputProcessing(source, row, {
+    outputProcessing(table, row, {
       squash: true,
       preserveLinks: true,
     }),
-    outputProcessing(source, beforeRow, {
+    outputProcessing(table, beforeRow, {
       squash: true,
       preserveLinks: true,
     }),

--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -55,21 +55,6 @@ function pickApi(tableId: string) {
   return internal
 }
 
-interface PatchResult {
-  row: Row
-  table: Table
-  oldRow: Row
-  automationRow?: Row
-  oldAutomationRow?: Row
-}
-
-interface SaveResult {
-  row: Row
-  table: Table
-  squashed?: Row
-  automationRow?: Row
-}
-
 async function _patch(
   ctx: UserCtx<PatchRowRequest, PatchRowResponse>,
   { isAutomation = false }: { isAutomation?: boolean } = {}
@@ -84,12 +69,12 @@ async function _patch(
   }
   try {
     const api = pickApi(tableId)
-    const work = async (): Promise<PatchResult> => {
+    const work = async () => {
       const response = await api.patch(ctx)
       events.action.crudExecuted({ type: "update" })
       return response
     }
-    const { row, table, oldRow, automationRow, oldAutomationRow } = isAutomation
+    const { row, table, oldRow } = isAutomation
       ? await work()
       : await quotas.addAction(work)
     if (!row) {
@@ -99,9 +84,9 @@ async function _patch(
     ctx.eventEmitter?.emitRow({
       eventName: EventType.ROW_UPDATE,
       appId,
-      row: automationRow || row,
+      row,
       table,
-      oldRow: oldAutomationRow || oldRow,
+      oldRow,
       user: sdk.users.getUserContextBindings(ctx.user),
     })
     ctx.message = `${table.name} updated successfully.`
@@ -140,7 +125,7 @@ async function _save(
       isAutomation,
     })
   }
-  let saveResult: SaveResult
+  let saveResult: { row: Row; table: Table; squashed?: Row }
   if (tableId.includes("datasource_plus")) {
     if (isAutomation) {
       saveResult = await sdk.rows.save(
@@ -172,12 +157,12 @@ async function _save(
       return response
     })
   }
-  const { row, table, squashed, automationRow } = saveResult
+  const { row, table, squashed } = saveResult
 
   ctx.eventEmitter?.emitRow({
     eventName: EventType.ROW_SAVE,
     appId,
-    row: automationRow || row,
+    row,
     table,
     user: sdk.users.getUserContextBindings(ctx.user),
   })

--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -55,6 +55,21 @@ function pickApi(tableId: string) {
   return internal
 }
 
+interface PatchResult {
+  row: Row
+  table: Table
+  oldRow: Row
+  automationRow?: Row
+  oldAutomationRow?: Row
+}
+
+interface SaveResult {
+  row: Row
+  table: Table
+  squashed?: Row
+  automationRow?: Row
+}
+
 async function _patch(
   ctx: UserCtx<PatchRowRequest, PatchRowResponse>,
   { isAutomation = false }: { isAutomation?: boolean } = {}
@@ -69,12 +84,12 @@ async function _patch(
   }
   try {
     const api = pickApi(tableId)
-    const work = async () => {
+    const work = async (): Promise<PatchResult> => {
       const response = await api.patch(ctx)
       events.action.crudExecuted({ type: "update" })
       return response
     }
-    const { row, table, oldRow } = isAutomation
+    const { row, table, oldRow, automationRow, oldAutomationRow } = isAutomation
       ? await work()
       : await quotas.addAction(work)
     if (!row) {
@@ -84,9 +99,9 @@ async function _patch(
     ctx.eventEmitter?.emitRow({
       eventName: EventType.ROW_UPDATE,
       appId,
-      row,
+      row: automationRow || row,
       table,
-      oldRow,
+      oldRow: oldAutomationRow || oldRow,
       user: sdk.users.getUserContextBindings(ctx.user),
     })
     ctx.message = `${table.name} updated successfully.`
@@ -125,7 +140,7 @@ async function _save(
       isAutomation,
     })
   }
-  let saveResult: { row: Row; table: Table; squashed?: Row }
+  let saveResult: SaveResult
   if (tableId.includes("datasource_plus")) {
     if (isAutomation) {
       saveResult = await sdk.rows.save(
@@ -157,12 +172,12 @@ async function _save(
       return response
     })
   }
-  const { row, table, squashed } = saveResult
+  const { row, table, squashed, automationRow } = saveResult
 
   ctx.eventEmitter?.emitRow({
     eventName: EventType.ROW_SAVE,
     appId,
-    row,
+    row: automationRow || row,
     table,
     user: sdk.users.getUserContextBindings(ctx.user),
   })

--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -48,6 +48,15 @@ import * as utils from "./utils"
 
 export * as views from "./views"
 
+interface RowMutationResult {
+  row: Row
+  table: Table
+  oldRow?: Row
+  squashed?: Row
+  automationRow?: Row
+  automationOldRow?: Row
+}
+
 function pickApi(tableId: string) {
   if (isExternalTableID(tableId)) {
     return external
@@ -69,12 +78,12 @@ async function _patch(
   }
   try {
     const api = pickApi(tableId)
-    const work = async () => {
+    const work = async (): Promise<RowMutationResult> => {
       const response = await api.patch(ctx)
       events.action.crudExecuted({ type: "update" })
       return response
     }
-    const { row, table, oldRow } = isAutomation
+    const { row, table, oldRow, automationRow, automationOldRow } = isAutomation
       ? await work()
       : await quotas.addAction(work)
     if (!row) {
@@ -84,9 +93,9 @@ async function _patch(
     ctx.eventEmitter?.emitRow({
       eventName: EventType.ROW_UPDATE,
       appId,
-      row,
+      row: automationRow || row,
       table,
-      oldRow,
+      oldRow: automationOldRow || oldRow || {},
       user: sdk.users.getUserContextBindings(ctx.user),
     })
     ctx.message = `${table.name} updated successfully.`
@@ -125,7 +134,7 @@ async function _save(
       isAutomation,
     })
   }
-  let saveResult: { row: Row; table: Table; squashed?: Row }
+  let saveResult: RowMutationResult
   if (tableId.includes("datasource_plus")) {
     if (isAutomation) {
       saveResult = await sdk.rows.save(
@@ -157,12 +166,12 @@ async function _save(
       return response
     })
   }
-  const { row, table, squashed } = saveResult
+  const { row, table, squashed, automationRow } = saveResult
 
   ctx.eventEmitter?.emitRow({
     eventName: EventType.ROW_SAVE,
     appId,
-    row,
+    row: automationRow || row,
     table,
     user: sdk.users.getUserContextBindings(ctx.user),
   })

--- a/packages/server/src/api/controllers/row/internal.ts
+++ b/packages/server/src/api/controllers/row/internal.ts
@@ -40,8 +40,13 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
   const inputs = ctx.request.body
   const isUserTable = tableId === InternalTables.USER_METADATA
   let oldRow
+  let automationOldRow
   try {
-    oldRow = await outputProcessing(source, await findRow(tableId, inputs._id!))
+    const beforeRow = await findRow(tableId, inputs._id!)
+    oldRow = await outputProcessing(source, cloneDeep(beforeRow))
+    automationOldRow = sdk.views.isView(source)
+      ? { ...beforeRow, ...oldRow }
+      : oldRow
   } catch (err) {
     if (isUserTable) {
       // don't include the rev, it'll be the global rev
@@ -49,6 +54,7 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
       oldRow = {
         _id: inputs._id,
       }
+      automationOldRow = oldRow
     } else {
       throw "Row does not exist"
     }
@@ -94,7 +100,7 @@ export async function patch(ctx: UserCtx<PatchRowRequest, PatchRowResponse>) {
     updateAIColumns: true,
   })
 
-  return { ...result, oldRow }
+  return { ...result, oldRow, automationOldRow }
 }
 
 export async function destroy(ctx: UserCtx) {

--- a/packages/server/src/api/controllers/row/staticFormula.ts
+++ b/packages/server/src/api/controllers/row/staticFormula.ts
@@ -146,8 +146,9 @@ export async function finaliseRow(
     : source
 
   row.type = "row"
-  // process the row before return, to include relationships
-  let enrichedRow = await outputProcessing(source, cloneDeep(row), {
+  // process the row before return, to include relationships.
+  // use the full table schema so automation row triggers receive columns hidden by a view.
+  let enrichedRow = await outputProcessing(table, cloneDeep(row), {
     squash: false,
   })
   // use enriched row to generate formulas for saving, specifically only use as context

--- a/packages/server/src/api/controllers/row/staticFormula.ts
+++ b/packages/server/src/api/controllers/row/staticFormula.ts
@@ -146,20 +146,22 @@ export async function finaliseRow(
     : source
 
   row.type = "row"
-  // process the row before return, to include relationships.
-  // use the full table schema so automation row triggers receive columns hidden by a view.
-  let enrichedRow = await outputProcessing(table, cloneDeep(row), {
+  // process the row before return, to include relationships
+  let enrichedRow = await outputProcessing(source, cloneDeep(row), {
     squash: false,
   })
+  let automationRow = sdk.views.isView(source)
+    ? mergeRows(cloneDeep(row), enrichedRow)
+    : enrichedRow
   // use enriched row to generate formulas for saving, specifically only use as context
   row = await processFormulas(table, row, {
     dynamic: false,
-    contextRows: [enrichedRow],
+    contextRows: [automationRow],
   })
 
   if (updateAIColumns) {
     row = await processAIColumns(table, row, {
-      contextRows: [enrichedRow],
+      contextRows: [automationRow],
     })
   }
 
@@ -175,10 +177,14 @@ export async function finaliseRow(
     dynamic: false,
   })
 
+  automationRow = sdk.views.isView(source)
+    ? mergeRows(retrieved, enrichedRow)
+    : enrichedRow
+
   // this updates the related formulas in other rows based on the relations to this row
   if (updateFormula) {
     await updateRelatedFormula(table, enrichedRow)
   }
   const squashed = await linkRows.squashLinks(source, enrichedRow)
-  return { row: enrichedRow, squashed, table }
+  return { row: enrichedRow, squashed, table, automationRow }
 }

--- a/packages/server/src/api/controllers/row/staticFormula.ts
+++ b/packages/server/src/api/controllers/row/staticFormula.ts
@@ -146,9 +146,8 @@ export async function finaliseRow(
     : source
 
   row.type = "row"
-  // process the row before return, to include relationships.
-  // use the full table schema so automation row triggers receive columns hidden by a view.
-  let enrichedRow = await outputProcessing(table, cloneDeep(row), {
+  // process the row before return, to include relationships
+  let enrichedRow = await outputProcessing(source, cloneDeep(row), {
     squash: false,
   })
   // use enriched row to generate formulas for saving, specifically only use as context

--- a/packages/server/src/automations/tests/triggers/rowViewExternal.spec.ts
+++ b/packages/server/src/automations/tests/triggers/rowViewExternal.spec.ts
@@ -1,0 +1,139 @@
+import { generator, mocks } from "@budibase/backend-core/tests"
+import { Datasource, FieldType, Table, TableSourceType } from "@budibase/types"
+import {
+  DatabaseName,
+  datasourceDescribe,
+} from "../../../integrations/tests/utils"
+import { captureAutomationResults } from "../utilities"
+import { createAutomationBuilder } from "../utilities/AutomationTestBuilder"
+
+const descriptions = datasourceDescribe({ only: [DatabaseName.MYSQL] })
+
+if (descriptions.length) {
+  describe.each(descriptions)(
+    "external row view automation triggers ($dbName)",
+    ({ config, dsProvider }) => {
+      let datasource: Datasource
+
+      beforeAll(async () => {
+        const ds = await dsProvider()
+        datasource = ds.datasource!
+        mocks.licenses.useCloudFree()
+      })
+
+      afterAll(() => {
+        config.end()
+      })
+
+      const createExternalTable = async (): Promise<Table> => {
+        return config.api.table.save({
+          name: generator.guid().substring(0, 10),
+          type: "table",
+          sourceType: TableSourceType.EXTERNAL,
+          sourceId: datasource._id!,
+          primary: ["id"],
+          primaryDisplay: "name",
+          schema: {
+            id: {
+              type: FieldType.NUMBER,
+              name: "id",
+              autocolumn: true,
+              constraints: {
+                presence: true,
+              },
+            },
+            name: {
+              type: FieldType.STRING,
+              name: "name",
+              constraints: {
+                type: "string",
+              },
+            },
+            description: {
+              type: FieldType.STRING,
+              name: "description",
+              default: "hidden value",
+              constraints: {
+                type: "string",
+              },
+            },
+          },
+        })
+      }
+
+      const createNameOnlyView = async (tableId: string) => {
+        return config.api.viewV2.create({
+          tableId,
+          name: generator.guid(),
+          schema: {
+            name: {
+              visible: true,
+            },
+            description: {
+              visible: false,
+            },
+          },
+        })
+      }
+
+      it("includes columns hidden by a view when a row is created through that view", async () => {
+        const table = await createExternalTable()
+        const view = await createNameOnlyView(table._id!)
+        const { automation } = await createAutomationBuilder(config)
+          .onRowSaved({ tableId: table._id! })
+          .serverLog({ text: "Row created!" })
+          .save()
+
+        await config.api.workspace.publish()
+
+        const results = await captureAutomationResults(automation, async () => {
+          await config.withProdApp(async () => {
+            await config.api.row.save(view.id, {
+              name: "foo",
+            })
+          })
+        })
+
+        expect(results).toHaveLength(1)
+        expect(results[0].data.event.row).toEqual(
+          expect.objectContaining({
+            name: "foo",
+            description: "hidden value",
+          })
+        )
+      })
+
+      it("includes columns hidden by a view when a row is updated through that view", async () => {
+        const table = await createExternalTable()
+        const view = await createNameOnlyView(table._id!)
+        const { automation } = await createAutomationBuilder(config)
+          .onRowUpdated({ tableId: table._id! })
+          .serverLog({ text: "Row updated!" })
+          .save()
+
+        await config.api.workspace.publish()
+
+        const results = await captureAutomationResults(automation, async () => {
+          await config.withProdApp(async () => {
+            const row = await config.api.row.save(table._id!, {
+              name: "foo",
+              description: "hidden value",
+            })
+            await config.api.row.save(view.id, {
+              _id: row._id!,
+              name: "bar",
+            })
+          })
+        })
+
+        expect(results).toHaveLength(1)
+        expect(results[0].data.event.row).toEqual(
+          expect.objectContaining({
+            name: "bar",
+            description: "hidden value",
+          })
+        )
+      })
+    }
+  )
+}

--- a/packages/server/src/sdk/workspace/rows/external.ts
+++ b/packages/server/src/sdk/workspace/rows/external.ts
@@ -78,15 +78,24 @@ export async function save(
 
   const rowId = response.row._id
   if (rowId) {
-    const row = await getRow(table, rowId, {
+    const fullRow = await getRow(table, rowId, {
       relationships: true,
+    })
+    const row = sdk.views.isView(source)
+      ? await getRow(source, rowId, {
+          relationships: true,
+        })
+      : fullRow
+    const processedRow = await outputProcessing(source, row, {
+      preserveLinks: true,
+      squash: true,
     })
     return {
       ...response,
-      row: await outputProcessing(table, row, {
-        preserveLinks: true,
-        squash: true,
-      }),
+      row: processedRow,
+      automationRow: sdk.views.isView(source)
+        ? { ...fullRow, ...processedRow }
+        : processedRow,
     }
   } else {
     return response

--- a/packages/server/src/sdk/workspace/rows/external.ts
+++ b/packages/server/src/sdk/workspace/rows/external.ts
@@ -49,10 +49,13 @@ export async function save(
 ) {
   const { tableId, viewId } = tryExtractingTableAndViewId(sourceId)
   let source: Table | ViewV2
+  let table: Table
   if (viewId) {
     source = await sdk.views.get(viewId)
+    table = await sdk.views.getTable(viewId)
   } else {
     source = await sdk.tables.getTable(tableId)
+    table = source
   }
 
   if (sdk.views.isView(source) && helpers.views.isCalculationView(source)) {
@@ -75,12 +78,12 @@ export async function save(
 
   const rowId = response.row._id
   if (rowId) {
-    const row = await getRow(source, rowId, {
+    const row = await getRow(table, rowId, {
       relationships: true,
     })
     return {
       ...response,
-      row: await outputProcessing(source, row, {
+      row: await outputProcessing(table, row, {
         preserveLinks: true,
         squash: true,
       }),

--- a/packages/server/src/sdk/workspace/rows/external.ts
+++ b/packages/server/src/sdk/workspace/rows/external.ts
@@ -78,28 +78,15 @@ export async function save(
 
   const rowId = response.row._id
   if (rowId) {
-    const [row, responseRow] = await Promise.all([
-      getRow(table, rowId, {
-        relationships: true,
-      }),
-      getRow(source, rowId, {
-        relationships: true,
-      }),
-    ])
-    const [enrichedRow, automationRow] = await Promise.all([
-      outputProcessing(source, responseRow, {
-        preserveLinks: true,
-        squash: true,
-      }),
-      outputProcessing(table, row, {
-        preserveLinks: true,
-        squash: true,
-      }),
-    ])
+    const row = await getRow(table, rowId, {
+      relationships: true,
+    })
     return {
       ...response,
-      row: enrichedRow,
-      automationRow,
+      row: await outputProcessing(table, row, {
+        preserveLinks: true,
+        squash: true,
+      }),
     }
   } else {
     return response

--- a/packages/server/src/sdk/workspace/rows/external.ts
+++ b/packages/server/src/sdk/workspace/rows/external.ts
@@ -78,15 +78,28 @@ export async function save(
 
   const rowId = response.row._id
   if (rowId) {
-    const row = await getRow(table, rowId, {
-      relationships: true,
-    })
-    return {
-      ...response,
-      row: await outputProcessing(table, row, {
+    const [row, responseRow] = await Promise.all([
+      getRow(table, rowId, {
+        relationships: true,
+      }),
+      getRow(source, rowId, {
+        relationships: true,
+      }),
+    ])
+    const [enrichedRow, automationRow] = await Promise.all([
+      outputProcessing(source, responseRow, {
         preserveLinks: true,
         squash: true,
       }),
+      outputProcessing(table, row, {
+        preserveLinks: true,
+        squash: true,
+      }),
+    ])
+    return {
+      ...response,
+      row: enrichedRow,
+      automationRow,
     }
   } else {
     return response


### PR DESCRIPTION
## Description
Fixes row created and row updated automation trigger payloads for rows saved through datasource views. Hidden view columns are now retained in backend automation event data by enriching automation rows from the underlying table schema.

## Addresses
- https://github.com/Budibase/budibase/issues/17241

## Launchcontrol
Automation row triggers now include hidden view columns when rows are created or updated through datasource views.

