### PR TITLE
Fixes failing test due some DNS issues

### DIFF
--- a/.github/workflows/budibase_ci.yml
+++ b/.github/workflows/budibase_ci.yml
@@ -358,7 +358,7 @@ jobs:
     runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-test-server-${{ matrix.datasource }}-${{ matrix.shard_index }}-${{ github.event.pull_request.number || github.ref }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     needs:
       - install-deps
       - compute-affected-jobs

--- a/packages/server/src/api/routes/tests/plugin.spec.ts
+++ b/packages/server/src/api/routes/tests/plugin.spec.ts
@@ -24,7 +24,7 @@ jest.mock("../../controllers/plugin/github", () => {
 import fs from "fs"
 import os from "os"
 import path from "path"
-import { events, objectStore, tenancy } from "@budibase/backend-core"
+import { events, objectStore, tenancy, withEnv } from "@budibase/backend-core"
 import { Plugin, PluginSource, PluginType } from "@budibase/types"
 import nock from "nock"
 import * as tar from "tar"
@@ -109,7 +109,9 @@ describe("/plugins", () => {
   let request = setup.getRequest()
   let config = setup.getConfig()
 
-  afterAll(setup.afterAll)
+  afterAll(() => {
+    setup.afterAll()
+  })
 
   beforeAll(async () => {
     await config.init()
@@ -470,19 +472,27 @@ describe("/plugins", () => {
 
   describe("url", () => {
     it("should be able to create a plugin from a URL", async () => {
-      nock("https://example.com")
-        .get("/comment-box/comment-box-1.0.2.tar.gz")
-        .replyWithFile(
-          200,
-          "src/api/routes/tests/data/comment-box-1.0.2.tar.gz"
-        )
+      await withEnv(
+        {
+          // Set blacklist to empty to allow the request to go through, since the blacklist is mocked in this suite and doesn't actually perform DNS lookups.
+          BLACKLIST_IPS: "",
+        },
+        async () => {
+          nock("https://www.someurl.com")
+            .get("/comment-box/comment-box-1.0.2.tar.gz")
+            .replyWithFile(
+              200,
+              "src/api/routes/tests/data/comment-box-1.0.2.tar.gz"
+            )
 
-      const { plugin } = await config.api.plugin.create({
-        source: PluginSource.URL,
-        url: "https://example.com/comment-box/comment-box-1.0.2.tar.gz",
-      })
-      expect(plugin._id).toEqual("plg_comment-box")
-      expect(events.plugin.imported).toHaveBeenCalledTimes(1)
+          const { plugin } = await config.api.plugin.create({
+            source: PluginSource.URL,
+            url: "https://www.someurl.com/comment-box/comment-box-1.0.2.tar.gz",
+          })
+          expect(plugin._id).toEqual("plg_comment-box")
+          expect(events.plugin.imported).toHaveBeenCalledTimes(1)
+        }
+      )
     })
   })
 

--- a/packages/server/src/api/routes/tests/plugin.spec.ts
+++ b/packages/server/src/api/routes/tests/plugin.spec.ts
@@ -470,7 +470,7 @@ describe("/plugins", () => {
 
   describe("url", () => {
     it("should be able to create a plugin from a URL", async () => {
-      nock("https://www.someurl.com")
+      nock("https://example.com")
         .get("/comment-box/comment-box-1.0.2.tar.gz")
         .replyWithFile(
           200,
@@ -479,7 +479,7 @@ describe("/plugins", () => {
 
       const { plugin } = await config.api.plugin.create({
         source: PluginSource.URL,
-        url: "https://www.someurl.com/comment-box/comment-box-1.0.2.tar.gz",
+        url: "https://example.com/comment-box/comment-box-1.0.2.tar.gz",
       })
       expect(plugin._id).toEqual("plg_comment-box")
       expect(events.plugin.imported).toHaveBeenCalledTimes(1)

--- a/packages/server/src/api/routes/tests/plugin.spec.ts
+++ b/packages/server/src/api/routes/tests/plugin.spec.ts
@@ -474,7 +474,7 @@ describe("/plugins", () => {
     it("should be able to create a plugin from a URL", async () => {
       await withEnv(
         {
-          // Set blacklist to empty to allow the request to go through, since the blacklist is mocked in this suite and doesn't actually perform DNS lookups.
+          // Set blacklist to empty to allow the request to go through, since the url is mocked in this test we don't want to perform DNS lookups.
           BLACKLIST_IPS: "",
         },
         async () => {


### PR DESCRIPTION
## Description
Fixing an issue with a test that started failing. We are using `https://www.someurl.com`, that stopped resolving. Even if we are using `nock`, internally we run `dns.lookup` to validate blacklisted ips, and this started failing. This PR removes this dependency, disabling the blacklist. We could not mock normally due the way backend-core is used 🤷🏽 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the plugin-from-URL test by disabling IP blacklist lookups via `withEnv`, so it relies only on `nock` and no longer fails due to DNS resolution. Also enables CI to cancel in-progress test-server jobs to reduce noise and speed up feedback.

- **Bug Fixes**
  - Use `withEnv` from `@budibase/backend-core` to set `BLACKLIST_IPS=""` during the test, skipping DNS validation.
  - Wrap `afterAll` in a function to ensure teardown runs reliably.

- **Refactors**
  - Set `cancel-in-progress: true` for test-server jobs in the CI workflow.

<sup>Written for commit 1d8e2f27569381d5a7fcb423bf811f3b9e52d2df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

