### PR TITLE
Feat/recover exited sqs in single image

### DIFF
--- a/hosting/couchdb/Dockerfile
+++ b/hosting/couchdb/Dockerfile
@@ -146,6 +146,8 @@ WORKDIR /opt/sqs
 ADD sqs ./
 RUN chmod +x ./install.sh && ./install.sh
 
+RUN npm install -g pm2
+
 WORKDIR /
 ADD runner.sh ./bbcouch-runner.sh
 RUN chmod +x ./bbcouch-runner.sh /opt/clouseau/bin/clouseau /opt/sqs/sqs

--- a/hosting/couchdb/runner.sh
+++ b/hosting/couchdb/runner.sh
@@ -157,8 +157,15 @@ sed -i "s#COUCHDB_ERLANG_COOKIE#${COUCHDB_ERLANG_COOKIE}#g" /opt/clouseau/clouse
 # Start CouchDB.
 /docker-entrypoint.sh /opt/couchdb/bin/couchdb > /dev/stdout 2>&1 &
 
-# Start SQS. Use 127.0.0.1 instead of localhost to avoid IPv6 issues.
-/opt/sqs/sqs --server "http://127.0.0.1:5984" --data-dir ${DATA_DIR}/sqs --bind-address=0.0.0.0 --max-threads=20 > /dev/stdout 2>&1 &
+# Start SQS under pm2 so it restarts automatically on crash.
+# Use 127.0.0.1 instead of localhost to avoid IPv6 issues.
+SQS_LAUNCH_SCRIPT="/tmp/sqs-launch.sh"
+cat > "$SQS_LAUNCH_SCRIPT" <<EOF
+#!/bin/bash
+exec /opt/sqs/sqs --server "http://127.0.0.1:5984" --data-dir "${DATA_DIR}/sqs" --bind-address=0.0.0.0 --max-threads=20
+EOF
+chmod +x "$SQS_LAUNCH_SCRIPT"
+pm2 start "$SQS_LAUNCH_SCRIPT" --name sqs --interpreter bash --restart-delay=5000
 
 # Wait for CouchDB to start up.
 while [[ $(curl -s -w "%{http_code}\n" http://localhost:5984/_up -o /dev/null) -ne 200 ]]; do

--- a/packages/server/src/sdk/workspace/rows/search/internal/sqs.ts
+++ b/packages/server/src/sdk/workspace/rows/search/internal/sqs.ts
@@ -1,5 +1,6 @@
 import {
   context,
+  HTTPError,
   locks,
   sql,
   SQLITE_DESIGN_DOC_ID,
@@ -522,6 +523,9 @@ export async function search(
     return response
   } catch (err: any) {
     const msg = typeof err === "string" ? err : err.message
+    if (msg?.includes("ECONNREFUSED")) {
+      throw new HTTPError("Search is temporarily unavailable", 503)
+    }
     if (!opts?.retrying && resyncDefinitionsRequired(err.status, msg)) {
       await locks.doWithLock(
         {

--- a/packages/worker/src/api/controllers/system/environment.ts
+++ b/packages/worker/src/api/controllers/system/environment.ts
@@ -4,32 +4,40 @@ import { Ctx, GetEnvironmentResponse, MaintenanceType } from "@budibase/types"
 import nodeFetch from "node-fetch"
 import env from "../../../environment"
 
-let sqsAvailable: boolean
+let sqsAvailable: boolean | undefined
+let sqsLastChecked: number | undefined
+const SQS_AVAILABLE_CACHE_TTL_MS = 30_000
+
 async function isSqsAvailable() {
-  // We cache this value for the duration of the Node process because we don't
-  // want every page load to be making this relatively expensive check.
-  if (sqsAvailable !== undefined) {
+  const now = Date.now()
+  if (
+    sqsAvailable !== undefined &&
+    sqsLastChecked !== undefined &&
+    now - sqsLastChecked < SQS_AVAILABLE_CACHE_TTL_MS
+  ) {
     return sqsAvailable
   }
 
   try {
-    const { url } = dbCore.getCouchInfo()
-    if (!url) {
+    const { sqlUrl } = dbCore.getCouchInfo()
+    if (!sqlUrl) {
       sqsAvailable = false
+      sqsLastChecked = now
       return false
     }
     await helpers.retry(
       async () => {
-        await nodeFetch(url, { timeout: 2000 })
+        await nodeFetch(sqlUrl, { timeout: 2000 })
       },
       { times: 3 }
     )
-    console.log("connected to SQS")
     sqsAvailable = true
+    sqsLastChecked = now
     return true
   } catch (e) {
     console.warn("failed to connect to SQS", e)
     sqsAvailable = false
+    sqsLastChecked = now
     return false
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Auto-restart SQS in the single CouchDB image using `pm2`, and handle SQS downtime more gracefully with a cached liveness check and clear 503 responses for search.

- **Bug Fixes**
  - Start SQS under `pm2` with a 5s restart delay to recover if the process exits.
  - Return HTTP 503 “Search is temporarily unavailable” when SQS connection is refused.
  - Add a cached SQS liveness check (30s TTL) using `sqlUrl`, with retries and a short timeout.

- **Dependencies**
  - Install `pm2` globally in the CouchDB image.

<sup>Written for commit 2b9af68823fc33a6009417bf024d76abe7d136a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

