### PR TITLE
[Fixed] Create settings config when missing during tenant lock/activation

### DIFF
--- a/packages/worker/src/sdk/tenants/tenants.ts
+++ b/packages/worker/src/sdk/tenants/tenants.ts
@@ -23,31 +23,30 @@ export async function unlockTenant(tenantId: string) {
 }
 
 export async function setActivation(tenantId: string, active: boolean) {
-  const db = tenancy.getTenantDB(tenantId)
-  const settingsConfig = await db.tryGet<SettingsConfig>(
-    configs.generateConfigID(ConfigType.SETTINGS)
-  )
-  if (!settingsConfig?.config) {
-    throw new Error(
-      `Cannot set activation. Settings config not found for tenant ${tenantId}`
-    )
-  }
+  const { db, settingsConfig } = await getOrCreateSettingsConfig(tenantId)
   settingsConfig.config.active = active
   await db.put(settingsConfig)
 }
 
 async function setLock(tenantId: string, lockReason?: LockReason) {
-  const db = tenancy.getTenantDB(tenantId)
-  const settingsConfig = await db.tryGet<SettingsConfig>(
-    configs.generateConfigID(ConfigType.SETTINGS)
-  )
-  if (!settingsConfig?.config) {
-    throw new Error(
-      `Cannot lock. Settings config not found for tenant ${tenantId}`
-    )
-  }
+  const { db, settingsConfig } = await getOrCreateSettingsConfig(tenantId)
   settingsConfig.config.lockedBy = lockReason
   await db.put(settingsConfig)
+}
+
+async function getOrCreateSettingsConfig(tenantId: string) {
+  const db = tenancy.getTenantDB(tenantId)
+  const settingsConfig = (await db.tryGet<SettingsConfig>(
+    configs.generateConfigID(ConfigType.SETTINGS)
+  )) || {
+    _id: configs.generateConfigID(ConfigType.SETTINGS),
+    type: ConfigType.SETTINGS,
+    config: {},
+  }
+
+  settingsConfig.config ||= {}
+
+  return { db, settingsConfig }
 }
 
 async function removeGlobalDB(tenantId: string) {

--- a/packages/worker/src/sdk/tenants/tests/tenants.spec.ts
+++ b/packages/worker/src/sdk/tenants/tests/tenants.spec.ts
@@ -93,19 +93,23 @@ describe("tenants", () => {
       })
     })
 
-    it("should throw error when settings config not found", async () => {
-      const tenantId = structures.tenant.id()
+    it("should create settings config when not found", async () => {
       const lockReason = LockReason.FREE_TIER
 
       mockDb.tryGet.mockResolvedValue(null)
 
-      await expect(lockTenant(tenantId, lockReason)).rejects.toThrow(
-        `Cannot lock. Settings config not found for tenant ${tenantId}`
-      )
+      await lockTenant(structures.tenant.id(), lockReason)
+
+      expect(mockDb.put).toHaveBeenCalledWith({
+        _id: "config_settings",
+        type: ConfigType.SETTINGS,
+        config: {
+          lockedBy: lockReason,
+        },
+      })
     })
 
-    it("should throw error when settings config has no config property", async () => {
-      const tenantId = structures.tenant.id()
+    it("should initialise config property when missing", async () => {
       const lockReason = LockReason.FREE_TIER
 
       const settingsConfig = {
@@ -115,9 +119,14 @@ describe("tenants", () => {
 
       mockDb.tryGet.mockResolvedValue(settingsConfig)
 
-      await expect(lockTenant(tenantId, lockReason)).rejects.toThrow(
-        `Cannot lock. Settings config not found for tenant ${tenantId}`
-      )
+      await lockTenant(structures.tenant.id(), lockReason)
+
+      expect(mockDb.put).toHaveBeenCalledWith({
+        ...settingsConfig,
+        config: {
+          lockedBy: lockReason,
+        },
+      })
     })
   })
 
@@ -149,14 +158,18 @@ describe("tenants", () => {
       })
     })
 
-    it("should throw error when settings config not found", async () => {
-      const tenantId = structures.tenant.id()
-
+    it("should create settings config when not found", async () => {
       mockDb.tryGet.mockResolvedValue(null)
 
-      await expect(unlockTenant(tenantId)).rejects.toThrow(
-        `Cannot lock. Settings config not found for tenant ${tenantId}`
-      )
+      await unlockTenant(structures.tenant.id())
+
+      expect(mockDb.put).toHaveBeenCalledWith({
+        _id: "config_settings",
+        type: ConfigType.SETTINGS,
+        config: {
+          lockedBy: undefined,
+        },
+      })
     })
   })
 
@@ -213,19 +226,21 @@ describe("tenants", () => {
       })
     })
 
-    it("should throw error when settings config not found", async () => {
-      const tenantId = structures.tenant.id()
-
+    it("should create settings config when not found", async () => {
       mockDb.tryGet.mockResolvedValue(null)
 
-      await expect(setActivation(tenantId, true)).rejects.toThrow(
-        `Cannot set activation. Settings config not found for tenant ${tenantId}`
-      )
+      await setActivation(structures.tenant.id(), true)
+
+      expect(mockDb.put).toHaveBeenCalledWith({
+        _id: "config_settings",
+        type: ConfigType.SETTINGS,
+        config: {
+          active: true,
+        },
+      })
     })
 
-    it("should throw error when settings config has no config property", async () => {
-      const tenantId = structures.tenant.id()
-
+    it("should initialise config property when missing", async () => {
       const settingsConfig = {
         _id: "config_settings",
         type: ConfigType.SETTINGS,
@@ -233,9 +248,14 @@ describe("tenants", () => {
 
       mockDb.tryGet.mockResolvedValue(settingsConfig)
 
-      await expect(setActivation(tenantId, true)).rejects.toThrow(
-        `Cannot set activation. Settings config not found for tenant ${tenantId}`
-      )
+      await setActivation(structures.tenant.id(), true)
+
+      expect(mockDb.put).toHaveBeenCalledWith({
+        ...settingsConfig,
+        config: {
+          active: true,
+        },
+      })
     })
   })
 })


### PR DESCRIPTION
## Description

When attempting to lock or set activation on a tenant via `PUT /api/system/tenants/:tenantId/lock`, a `TypeError: Cannot read properties of undefined (reading 'error')` was thrown for tenants that did not have a settings config document in their database.

The root cause was that `setLock` and `setActivation` both threw an error when the settings config was missing, instead of handling this gracefully. This was blocking the free tier migration process, causing a large backlog of manual tasks that could not be resolved.

The fix introduces a `getOrCreateSettingsConfig` helper that creates a minimal settings config document on the fly when one does not exist, shared by both `setLock` and `setActivation`.

## Addresses
- https://github.com/Budibase/budibase/issues/18730

## Launchcontrol

Fixes a crash when locking tenants that have no settings config document, which was blocking the free tier migration. The settings config is now created automatically if missing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when locking/unlocking or activating tenants that lack a settings config by creating it on the fly. This removes the TypeError and unblocks the free-tier migration.

- **Bug Fixes**
  - Added `getOrCreateSettingsConfig` to create a minimal settings config when missing; used by `setLock` and `setActivation`.
  - Updated tests to cover config creation and initialization of `config` when absent.

<sup>Written for commit 1f73740272e5d245396aafcce86de47e02f3ee50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

