### PR TITLE
fix: mime type display in agent knowledge builder

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/knowledgeFileDisplayType.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/knowledgeFileDisplayType.spec.ts
@@ -40,9 +40,11 @@ const expectedByMimeType: Record<string, string> = {
   "text/xml": "XML",
   "text/html": "HTML",
   "application/msword": "DOC",
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "DOCX",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    "DOCX",
   "application/vnd.ms-powerpoint": "PPT",
-  "application/vnd.openxmlformats-officedocument.presentationml.presentation": "PPTX",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+    "PPTX",
   "application/vnd.ms-excel": "XLS",
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "XLSX",
   "application/rtf": "RTF",
@@ -52,7 +54,9 @@ const expectedByMimeType: Record<string, string> = {
 describe("getKnowledgeFileDisplayType", () => {
   it("covers all supported knowledge file extensions", () => {
     for (const extension of KNOWLEDGE_FILE_EXTENSIONS) {
-      const label = getKnowledgeFileDisplayType({ filename: `file${extension}` })
+      const label = getKnowledgeFileDisplayType({
+        filename: `file${extension}`,
+      })
       expect(label).toBe(expectedByExtension[extension])
     }
   })

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/knowledgeFileDisplayType.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/knowledgeFileDisplayType.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest"
+import {
+  getKnowledgeFileDisplayType,
+  KNOWLEDGE_FILE_EXTENSIONS,
+  KNOWLEDGE_FILE_MIME_TYPES,
+} from "@budibase/types"
+
+const expectedByExtension: Record<string, string> = {
+  ".txt": "Text",
+  ".md": "Markdown",
+  ".markdown": "Markdown",
+  ".json": "JSON",
+  ".yaml": "YAML",
+  ".yml": "YAML",
+  ".csv": "CSV",
+  ".tsv": "TSV",
+  ".pdf": "PDF",
+  ".html": "HTML",
+  ".htm": "HTML",
+  ".xml": "XML",
+  ".doc": "DOC",
+  ".docx": "DOCX",
+  ".ppt": "PPT",
+  ".pptx": "PPTX",
+  ".xls": "XLS",
+  ".xlsx": "XLSX",
+  ".rtf": "RTF",
+}
+
+const expectedByMimeType: Record<string, string> = {
+  "text/plain": "Text",
+  "text/markdown": "Markdown",
+  "text/csv": "CSV",
+  "text/tab-separated-values": "TSV",
+  "application/pdf": "PDF",
+  "application/json": "JSON",
+  "application/yaml": "YAML",
+  "text/yaml": "YAML",
+  "application/xml": "XML",
+  "text/xml": "XML",
+  "text/html": "HTML",
+  "application/msword": "DOC",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "DOCX",
+  "application/vnd.ms-powerpoint": "PPT",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation": "PPTX",
+  "application/vnd.ms-excel": "XLS",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "XLSX",
+  "application/rtf": "RTF",
+  "text/rtf": "RTF",
+}
+
+describe("getKnowledgeFileDisplayType", () => {
+  it("covers all supported knowledge file extensions", () => {
+    for (const extension of KNOWLEDGE_FILE_EXTENSIONS) {
+      const label = getKnowledgeFileDisplayType({ filename: `file${extension}` })
+      expect(label).toBe(expectedByExtension[extension])
+    }
+  })
+
+  it("covers all supported knowledge file MIME types", () => {
+    for (const mimetype of KNOWLEDGE_FILE_MIME_TYPES) {
+      const label = getKnowledgeFileDisplayType({ mimetype })
+      expect(label).toBe(expectedByMimeType[mimetype])
+    }
+  })
+
+  it("prefers extension label over MIME label", () => {
+    const label = getKnowledgeFileDisplayType({
+      filename: "notes.docx",
+      mimetype: "text/plain",
+    })
+    expect(label).toBe("DOCX")
+  })
+
+  it("uses short MIME subtype for unknown MIME types", () => {
+    const label = getKnowledgeFileDisplayType({
+      mimetype: "application/x-custom-type",
+    })
+    expect(label).toBe("X-CUSTOM-TYPE")
+  })
+
+  it("falls back to Text when no file metadata is provided", () => {
+    const label = getKnowledgeFileDisplayType({})
+    expect(label).toBe("Text")
+  })
+})

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/renderers/KnowledgeNameRenderer.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/renderers/KnowledgeNameRenderer.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import { Helpers } from "@budibase/bbui"
-  import { KnowledgeBaseFileStatus } from "@budibase/types"
+  import {
+    getKnowledgeFileDisplayType,
+    KnowledgeBaseFileStatus,
+  } from "@budibase/types"
   import type { KnowledgeTableRow } from "./types"
 
   export interface Props {
@@ -9,27 +11,6 @@
 
   let { row }: Props = $props()
 
-  const mimeTypeLabels: Record<string, string> = {
-    "application/pdf": "PDF",
-    "text/plain": "Text",
-    "text/markdown": "Markdown",
-    "text/csv": "CSV",
-    "application/msword": "DOC",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-      "DOCX",
-    "application/vnd.ms-excel": "XLS",
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "XLSX",
-    "application/vnd.ms-powerpoint": "PPT",
-    "application/vnd.openxmlformats-officedocument.presentationml.presentation":
-      "PPTX",
-  }
-
-  const getDisplayMimeType = (mimetype?: string) => {
-    if (!mimetype) {
-      return "Text"
-    }
-    return mimeTypeLabels[mimetype] || Helpers.capitalise(mimetype)
-  }
 </script>
 
 <div class="file-name">
@@ -41,7 +22,10 @@
       : row.mimetype || "text/plain"}
     >{row.kind === "sharepoint_connection"
       ? row.subtitle || "SharePoint"
-      : getDisplayMimeType(row.mimetype)}</span
+      : getKnowledgeFileDisplayType({
+          filename: row.filename,
+          mimetype: row.mimetype,
+        })}</span
   >
   {#if row.kind !== "sharepoint_connection" && row.status === KnowledgeBaseFileStatus.FAILED && row.errorMessage}
     <span class="file-error">{row.errorMessage}</span>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/renderers/KnowledgeNameRenderer.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/renderers/KnowledgeNameRenderer.svelte
@@ -36,11 +36,9 @@
   <span class="file-title">{row.filename}</span>
   <span
     class="file-meta"
-    title={
-      row.kind === "sharepoint_connection"
-        ? row.subtitle || "SharePoint"
-        : row.mimetype || "text/plain"
-    }
+    title={row.kind === "sharepoint_connection"
+      ? row.subtitle || "SharePoint"
+      : row.mimetype || "text/plain"}
     >{row.kind === "sharepoint_connection"
       ? row.subtitle || "SharePoint"
       : getDisplayMimeType(row.mimetype)}</span

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/renderers/KnowledgeNameRenderer.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/renderers/KnowledgeNameRenderer.svelte
@@ -10,7 +10,6 @@
   }
 
   let { row }: Props = $props()
-
 </script>
 
 <div class="file-name">

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/renderers/KnowledgeNameRenderer.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/renderers/KnowledgeNameRenderer.svelte
@@ -8,14 +8,42 @@
   }
 
   let { row }: Props = $props()
+
+  const mimeTypeLabels: Record<string, string> = {
+    "application/pdf": "PDF",
+    "text/plain": "Text",
+    "text/markdown": "Markdown",
+    "text/csv": "CSV",
+    "application/msword": "DOC",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+      "DOCX",
+    "application/vnd.ms-excel": "XLS",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "XLSX",
+    "application/vnd.ms-powerpoint": "PPT",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+      "PPTX",
+  }
+
+  const getDisplayMimeType = (mimetype?: string) => {
+    if (!mimetype) {
+      return "Text"
+    }
+    return mimeTypeLabels[mimetype] || Helpers.capitalise(mimetype)
+  }
 </script>
 
 <div class="file-name">
   <span class="file-title">{row.filename}</span>
-  <span class="file-meta"
+  <span
+    class="file-meta"
+    title={
+      row.kind === "sharepoint_connection"
+        ? row.subtitle || "SharePoint"
+        : row.mimetype || "text/plain"
+    }
     >{row.kind === "sharepoint_connection"
       ? row.subtitle || "SharePoint"
-      : Helpers.capitalise(row.mimetype || "text")}</span
+      : getDisplayMimeType(row.mimetype)}</span
   >
   {#if row.kind !== "sharepoint_connection" && row.status === KnowledgeBaseFileStatus.FAILED && row.errorMessage}
     <span class="file-error">{row.errorMessage}</span>
@@ -40,6 +68,12 @@
   .file-error {
     font-size: 12px;
     color: var(--spectrum-global-color-gray-700);
+  }
+
+  .file-meta {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .file-error {

--- a/packages/types/src/core/knowledgeFiles.ts
+++ b/packages/types/src/core/knowledgeFiles.ts
@@ -51,6 +51,62 @@ const KNOWLEDGE_FILE_MIME_TYPE_SET = new Set<string>(KNOWLEDGE_FILE_MIME_TYPES)
 const trimString = (value?: string) =>
   typeof value === "string" ? value.trim() : ""
 
+const DISPLAY_LABEL_BY_EXTENSION: Partial<Record<(typeof KNOWLEDGE_FILE_EXTENSIONS)[number], string>> = {
+  ".txt": "Text",
+  ".md": "Markdown",
+  ".markdown": "Markdown",
+  ".json": "JSON",
+  ".yaml": "YAML",
+  ".yml": "YAML",
+  ".csv": "CSV",
+  ".tsv": "TSV",
+  ".pdf": "PDF",
+  ".html": "HTML",
+  ".htm": "HTML",
+  ".xml": "XML",
+  ".doc": "DOC",
+  ".docx": "DOCX",
+  ".ppt": "PPT",
+  ".pptx": "PPTX",
+  ".xls": "XLS",
+  ".xlsx": "XLSX",
+  ".rtf": "RTF",
+}
+
+const DISPLAY_LABEL_BY_MIME_TYPE: Partial<Record<(typeof KNOWLEDGE_FILE_MIME_TYPES)[number], string>> = {
+  "text/plain": "Text",
+  "text/markdown": "Markdown",
+  "text/csv": "CSV",
+  "text/tab-separated-values": "TSV",
+  "application/pdf": "PDF",
+  "application/json": "JSON",
+  "application/yaml": "YAML",
+  "text/yaml": "YAML",
+  "application/xml": "XML",
+  "text/xml": "XML",
+  "text/html": "HTML",
+  "application/msword": "DOC",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "DOCX",
+  "application/vnd.ms-powerpoint": "PPT",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation": "PPTX",
+  "application/vnd.ms-excel": "XLS",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "XLSX",
+  "application/rtf": "RTF",
+  "text/rtf": "RTF",
+}
+
+const fallbackLabelFromMimeType = (mimetype?: string) => {
+  const normalized = trimString(mimetype).toLowerCase()
+  if (!normalized) {
+    return "Text"
+  }
+  const [, subtype] = normalized.split("/")
+  if (!subtype) {
+    return normalized.toUpperCase()
+  }
+  return subtype.toUpperCase()
+}
+
 export const getKnowledgeFileExtension = (filename?: string) => {
   const normalized = trimString(filename).toLowerCase()
   const index = normalized.lastIndexOf(".")
@@ -83,4 +139,34 @@ export const isKnowledgeFileSupported = ({
     return true
   }
   return KNOWLEDGE_FILE_MIME_TYPE_SET.has(normalizedMimetype)
+}
+
+export const getKnowledgeFileDisplayType = ({
+  filename,
+  mimetype,
+}: {
+  filename?: string
+  mimetype?: string
+}) => {
+  const extension = getKnowledgeFileExtension(filename) as
+    | (typeof KNOWLEDGE_FILE_EXTENSIONS)[number]
+    | ""
+  if (extension) {
+    const extensionLabel = DISPLAY_LABEL_BY_EXTENSION[extension]
+    if (extensionLabel) {
+      return extensionLabel
+    }
+  }
+
+  const normalizedMimetype = trimString(mimetype).toLowerCase() as
+    | (typeof KNOWLEDGE_FILE_MIME_TYPES)[number]
+    | ""
+  if (normalizedMimetype) {
+    const mimetypeLabel = DISPLAY_LABEL_BY_MIME_TYPE[normalizedMimetype]
+    if (mimetypeLabel) {
+      return mimetypeLabel
+    }
+  }
+
+  return fallbackLabelFromMimeType(mimetype)
 }

--- a/packages/types/src/core/knowledgeFiles.ts
+++ b/packages/types/src/core/knowledgeFiles.ts
@@ -51,7 +51,9 @@ const KNOWLEDGE_FILE_MIME_TYPE_SET = new Set<string>(KNOWLEDGE_FILE_MIME_TYPES)
 const trimString = (value?: string) =>
   typeof value === "string" ? value.trim() : ""
 
-const DISPLAY_LABEL_BY_EXTENSION: Partial<Record<(typeof KNOWLEDGE_FILE_EXTENSIONS)[number], string>> = {
+const DISPLAY_LABEL_BY_EXTENSION: Partial<
+  Record<(typeof KNOWLEDGE_FILE_EXTENSIONS)[number], string>
+> = {
   ".txt": "Text",
   ".md": "Markdown",
   ".markdown": "Markdown",
@@ -73,7 +75,9 @@ const DISPLAY_LABEL_BY_EXTENSION: Partial<Record<(typeof KNOWLEDGE_FILE_EXTENSIO
   ".rtf": "RTF",
 }
 
-const DISPLAY_LABEL_BY_MIME_TYPE: Partial<Record<(typeof KNOWLEDGE_FILE_MIME_TYPES)[number], string>> = {
+const DISPLAY_LABEL_BY_MIME_TYPE: Partial<
+  Record<(typeof KNOWLEDGE_FILE_MIME_TYPES)[number], string>
+> = {
   "text/plain": "Text",
   "text/markdown": "Markdown",
   "text/csv": "CSV",
@@ -86,9 +90,11 @@ const DISPLAY_LABEL_BY_MIME_TYPE: Partial<Record<(typeof KNOWLEDGE_FILE_MIME_TYP
   "text/xml": "XML",
   "text/html": "HTML",
   "application/msword": "DOC",
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "DOCX",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    "DOCX",
   "application/vnd.ms-powerpoint": "PPT",
-  "application/vnd.openxmlformats-officedocument.presentationml.presentation": "PPTX",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+    "PPTX",
   "application/vnd.ms-excel": "XLS",
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "XLSX",
   "application/rtf": "RTF",


### PR DESCRIPTION
## Description
* some mimetypes are very long causing overflows

## Screenshots

before:
<img width="776" height="420" alt="Screenshot 2026-05-07 at 08 27 31" src="https://github.com/user-attachments/assets/ba30ab20-a925-47c3-b467-85fa11e7c718" />

after:
<img width="755" height="389" alt="Screenshot 2026-05-07 at 13 25 42" src="https://github.com/user-attachments/assets/29a27a2e-d2e0-458f-aac2-43cace5a3504" />


