### PR TITLE
[Security] Require admin access for SCIM routes

### DIFF
--- a/packages/worker/src/api/routes/global/scim.ts
+++ b/packages/worker/src/api/routes/global/scim.ts
@@ -1,4 +1,5 @@
 import Router from "@koa/router"
+import { auth } from "@budibase/backend-core"
 import { middleware as proMiddleware } from "@budibase/pro"
 import { Feature } from "@budibase/types"
 import * as userController from "../../controllers/global/scim/users"
@@ -10,6 +11,7 @@ const router: Router = new Router({
 
 router.use(proMiddleware.requireSCIM)
 router.use(proMiddleware.doInScimContext)
+router.use(auth.adminOnly)
 
 router.get("/users", userController.get)
 router.get("/users/:id", proMiddleware.scimUserOnly("id"), userController.find)

--- a/packages/worker/src/api/routes/global/tests/scim.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/scim.spec.ts
@@ -8,8 +8,14 @@ import {
   ScimUpdateRequest,
   ScimUserResponse,
 } from "@budibase/types"
+import {
+  context,
+  db as dbCore,
+  encryption,
+  events,
+  utils,
+} from "@budibase/backend-core"
 import { TestConfiguration } from "../../../../tests"
-import { events } from "@budibase/backend-core"
 
 jest.setTimeout(30000)
 
@@ -27,6 +33,33 @@ describe("scim", () => {
   beforeEach(setup)
 
   const config = new TestConfiguration()
+
+  async function createAPIKeyForUser(userId: string) {
+    const apiKey = encryption.encrypt(
+      `${config.tenantId}${dbCore.SEPARATOR}${utils.newid()}`
+    )
+
+    await config.doInTenant(async () => {
+      const db = context.getGlobalDB()
+      await db.put({
+        _id: dbCore.generateDevInfoID(userId),
+        userId,
+        apiKey,
+      })
+    })
+
+    return apiKey
+  }
+
+  async function withAPIKey<T>(apiKey: string, fn: () => Promise<T>) {
+    const previousAPIKey = config.apiKey
+    config.apiKey = apiKey
+    try {
+      return await fn()
+    } finally {
+      config.apiKey = previousAPIKey
+    }
+  }
 
   const unauthorisedTests = (fn: (...params: any) => Promise<any>) => {
     describe("unauthorised calls", () => {
@@ -82,6 +115,19 @@ describe("scim", () => {
   })
 
   describe("/api/global/scim/v2/users", () => {
+    describe("authorisation", () => {
+      it("returns 403 when a non-admin user API key calls SCIM", async () => {
+        const user = await config.createUser()
+        const apiKey = await createAPIKeyForUser(user._id!)
+
+        const response = await withAPIKey(apiKey, () =>
+          config.api.scimUsersAPI.get({ expect: 403 })
+        )
+
+        expect(response).toEqual(config.adminOnlyResponse())
+      })
+    })
+
     describe("GET /api/global/scim/v2/users", () => {
       const getScimUsers = config.api.scimUsersAPI.get
 


### PR DESCRIPTION
## Description
Require admin authorization on SCIM v2 routes after the SCIM feature and context gates so provisioning endpoints are restricted to tenant admins.

## Addresses
- https://github.com/Budibase/vulns/issues/58
- https://github.com/Budibase/budibase/security/advisories/GHSA-q9rw-q89f-jx2f

## App Export
- N/A

## Screenshots
- N/A, backend authorization fix only.

## Launchcontrol
SCIM provisioning endpoints now require admin access.

Tests run:
- cd packages/worker && CI=1 yarn test src/api/routes/global/tests/scim.spec.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require admin access for all SCIM v2 routes so provisioning is limited to tenant admins. Non-admin API keys now receive 403, addressing GHSA-q9rw-q89f-jx2f.

- **Bug Fixes**
  - Added `auth.adminOnly` after `proMiddleware.requireSCIM` and `proMiddleware.doInScimContext` in `packages/worker/src/api/routes/global/scim.ts`.
  - Expanded `scim.spec.ts` with helpers to create user API keys and verify non-admin SCIM calls return 403.

<sup>Written for commit db99c495611d91e2f6bf2c3847a3bbf4980cab14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

