### PR TITLE
[Security] Invalidate user cache after bulk role updates

### DIFF
--- a/packages/backend-core/src/cache/user.ts
+++ b/packages/backend-core/src/cache/user.ts
@@ -148,7 +148,23 @@ export async function getUsers(
   return { users, notFoundIds: notFoundIds }
 }
 
+/**
+ * Invalidate a user from the cache.
+ * @param userId the id of the user to invalidate
+ */
 export async function invalidateUser(userId: string) {
   const client = await redis.getUserClient()
   await client.delete(userId)
+}
+
+/**
+ * Invalidate a list of users from the cache.
+ * @param userIds the ids of the users to invalidate
+ */
+export async function invalidateUsers(userIds: string[]) {
+  if (userIds.length === 0) {
+    return
+  }
+  const client = await redis.getUserClient()
+  await client.bulkDelete(userIds)
 }

--- a/packages/backend-core/src/users/db.ts
+++ b/packages/backend-core/src/users/db.ts
@@ -227,7 +227,9 @@ export class UserDB {
   }
 
   static async bulkUpdate(users: User[]) {
-    return await usersCore.bulkUpdateGlobalUsers(users)
+    const response = await usersCore.bulkUpdateGlobalUsers(users)
+    await Promise.all(users.map(user => cache.user.invalidateUser(user._id!)))
+    return response
   }
 
   static async save(user: User, opts: SaveUserOpts = {}): Promise<User> {

--- a/packages/backend-core/src/users/db.ts
+++ b/packages/backend-core/src/users/db.ts
@@ -228,7 +228,7 @@ export class UserDB {
 
   static async bulkUpdate(users: User[]) {
     const response = await usersCore.bulkUpdateGlobalUsers(users)
-    await Promise.all(users.map(user => cache.user.invalidateUser(user._id!)))
+    await cache.user.invalidateUsers(users.map(user => user._id!))
     return response
   }
 

--- a/packages/backend-core/src/users/test/db.spec.ts
+++ b/packages/backend-core/src/users/test/db.spec.ts
@@ -1,6 +1,7 @@
 import { BulkUserCreated, User, UserGroup, UserStatus } from "@budibase/types"
 import { DBTestConfiguration, generator, structures } from "../../../tests"
 import * as accounts from "../../accounts"
+import * as cache from "../../cache"
 import { getGlobalDB } from "../../context"
 import { withEnv } from "../../environment"
 import { UserDB } from "../db"
@@ -40,6 +41,33 @@ describe("UserDB", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     groups.getDefaultGroup.mockResolvedValue(undefined)
+  })
+
+  describe("bulkUpdate", () => {
+    it("invalidates cached user data for updated users", async () => {
+      await config.doInTenant(async () => {
+        const user = await db.save(
+          structures.users.user({
+            email: generator.email({}),
+            firstName: "Original",
+            tenantId: config.getTenantId(),
+          })
+        )
+
+        await cache.user.getUser({
+          userId: user._id!,
+          tenantId: config.getTenantId(),
+        })
+
+        await db.bulkUpdate([{ ...user, firstName: "Updated" }])
+
+        const refreshedUser = await cache.user.getUser({
+          userId: user._id!,
+          tenantId: config.getTenantId(),
+        })
+        expect(refreshedUser.firstName).toBe("Updated")
+      })
+    })
   })
 
   describe("save", () => {


### PR DESCRIPTION
## Description
Invalidate cached user records after bulk user updates so role changes made through bulk paths are reflected on subsequent authenticated requests instead of waiting for cache expiry.

## Addresses
- https://github.com/Budibase/vulns/issues/51
- https://github.com/Budibase/budibase/security/advisories/GHSA-6vp2-6r7m-2jvx

## App Export
- N/A

## Screenshots
- N/A, backend cache invalidation fix only.

## Launchcontrol
Bulk user role updates now clear stale user permission cache entries immediately.

Tests run:
- cd packages/backend-core && CI=1 yarn test src/users/test/db.spec.ts --testNamePattern=bulkUpdate
- cd packages/backend-core && CI=1 yarn test src/users/test/db.spec.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Immediately invalidate cached user records after bulk updates so role/permission changes apply on the next request. Addresses GHSA-6vp2-6r7m-2jvx.

- **Bug Fixes**
  - Updated `UserDB.bulkUpdate` to invalidate cache for all updated users via `cache.user.invalidateUsers` (uses Redis `bulkDelete` to reduce calls).
  - Added a test in `packages/backend-core/src/users/test/db.spec.ts` to confirm the cache returns updated user data.

<sup>Written for commit b509b832e3ec80fedaff4ef9f4d5619ba6eabe5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

