### PR TITLE
[Security] Block active content attachment uploads

### DIFF
--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -50,8 +50,12 @@ import { isWorkspaceFullyMigrated } from "../../../workspaceMigrations"
 const ACTIVE_CONTENT_EXTENSIONS = new Set([
   "html",
   "htm",
+  "js",
+  "jse",
+  "mjs",
   "svg",
   "svgz",
+  "wasm",
   "xhtml",
   "mhtml",
   "shtml",
@@ -60,6 +64,9 @@ const ACTIVE_CONTENT_EXTENSIONS = new Set([
 const ACTIVE_CONTENT_MIME_TYPES = [
   "text/html",
   "image/svg+xml",
+  "application/javascript",
+  "application/wasm",
+  "text/javascript",
   "application/xhtml+xml",
 ]
 
@@ -165,29 +172,25 @@ export const uploadFile = async function (
         )
       }
 
-      if (isPublicUser) {
-        if (ACTIVE_CONTENT_EXTENSIONS.has(extensionLower)) {
-          throw new ActiveContentFileError(fileName)
-        }
+      if (ACTIVE_CONTENT_EXTENSIONS.has(extensionLower)) {
+        throw new ActiveContentFileError(fileName)
+      }
 
-        const mimeType =
-          typeof rawMimeType === "string"
-            ? rawMimeType.toLowerCase()
-            : undefined
-        if (
-          mimeType &&
-          ACTIVE_CONTENT_MIME_TYPES.some(type => mimeType.includes(type))
-        ) {
-          throw new ActiveContentFileError(fileName)
-        }
+      const mimeType =
+        typeof rawMimeType === "string" ? rawMimeType.toLowerCase() : undefined
+      if (
+        mimeType &&
+        ACTIVE_CONTENT_MIME_TYPES.some(type => mimeType.includes(type))
+      ) {
+        throw new ActiveContentFileError(fileName)
+      }
 
-        if (
-          filePath &&
-          (typeof filePath === "string" || Buffer.isBuffer(filePath)) &&
-          (await detectActiveContent(filePath))
-        ) {
-          throw new ActiveContentFileError(fileName)
-        }
+      if (
+        filePath &&
+        (typeof filePath === "string" || Buffer.isBuffer(filePath)) &&
+        (await detectActiveContent(filePath))
+      ) {
+        throw new ActiveContentFileError(fileName)
       }
 
       // filenames converted to UUIDs so they are unique

--- a/packages/server/src/api/routes/tests/attachment.spec.ts
+++ b/packages/server/src/api/routes/tests/attachment.spec.ts
@@ -61,6 +61,15 @@ describe("/api/applications/:appId/sync", () => {
       )) as unknown as APIError
       expect(resp.message).toContain("No file provided")
     })
+
+    it("should reject active content for builder uploads", async () => {
+      let resp = (await config.api.attachment.process(
+        "xss.svg",
+        Buffer.from("<svg><script>alert(1)</script></svg>"),
+        { status: 400 }
+      )) as unknown as APIError
+      expect(resp.message).toContain("active content")
+    })
   })
 
   describe("/api/attachments/:tableId/upload", () => {
@@ -89,13 +98,14 @@ describe("/api/applications/:appId/sync", () => {
       })
     })
 
-    it("should allow active content for authenticated users", async () => {
-      const resp = await config.api.attachment.upload(
+    it("should reject active content for authenticated users", async () => {
+      const resp = (await config.api.attachment.upload(
         tableId,
         "image.png",
-        Buffer.from("<svg><script>alert(1)</script></svg>")
-      )
-      expect(resp.length).toBe(1)
+        Buffer.from("<svg><script>alert(1)</script></svg>"),
+        { status: 400 }
+      )) as unknown as APIError
+      expect(resp.message).toContain("active content")
     })
   })
 })


### PR DESCRIPTION
## Description
Apply active-content attachment checks to all upload paths, not only public-user uploads, so authenticated users cannot store browser-executable attachment content through builder or table upload endpoints.

## Addresses
- https://github.com/Budibase/vulns/issues/34
- https://github.com/Budibase/budibase/security/advisories/GHSA-82rc-gxrg-v4gf

## App Export
- N/A

## Screenshots
- N/A, backend upload validation fix only.

## Launchcontrol
Attachment uploads now reject active web content for all users.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block active-content attachment uploads across all endpoints to prevent browser-executable files from being stored. Applies to both public and authenticated uploads to mitigate stored XSS.

- **Bug Fixes**
  - Enforce extension, MIME, and content-based checks on all upload paths (builder and table) for every user.
  - Expand blocked types: extensions `js`, `jse`, `mjs`, `wasm`; MIME `application/javascript`, `text/javascript`, `application/wasm`.
  - Update tests to assert 400 rejection for builder uploads and authenticated table uploads.

<sup>Written for commit f4f52c1cd4ea62cb998a10ddd3368b99464c06fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

