### PR TITLE
Mark packages as private and add build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "scripts": {
     "setup": "git config submodule.recurse true && git submodule update && node ./hosting/scripts/setup.js && yarn && yarn build && yarn dev",
     "build": "DISABLE_V8_COMPILE_CACHE=1 NODE_OPTIONS=--max-old-space-size=1500 lerna run build --stream",
+    "build:npm": "DISABLE_V8_COMPILE_CACHE=1 yarn build --scope @budibase/backend-core --scope @budibase/bbui --scope @budibase/cli --scope @budibase/frontend-core --scope @budibase/pro --scope @budibase/sdk --scope @budibase/shared-core --scope @budibase/string-templates --scope @budibase/types",
     "build:apps": "DISABLE_V8_COMPILE_CACHE=1 yarn build --scope @budibase/server --scope @budibase/worker",
     "build:cli": "yarn build --scope @budibase/cli",
     "build:dev": "lerna run --stream prebuild && yarn nx run-many --target=build --output-style=dynamic --watch --preserveWatchOutput",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@budibase/client",
+  "private": true,
   "version": "0.0.0",
   "license": "MPL-2.0",
   "module": "dist/budibase-client.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@budibase/server",
+  "private": true,
   "email": "hi@budibase.com",
   "version": "0.0.0",
   "description": "Budibase Web Server",

--- a/packages/upgrade-tests/package.json
+++ b/packages/upgrade-tests/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@budibase/upgrade-tests",
+  "private": true,
   "version": "0.0.0",
   "description": "Budibase upgrade testing framework",
   "main": "src/index.ts",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@budibase/worker",
+  "private": true,
   "email": "hi@budibase.com",
   "version": "0.0.0",
   "description": "Budibase background service",


### PR DESCRIPTION
## Description
Mark packages as private in the `package.json` files for client, server, upgrade-tests, and worker. Introduce a new `build:npm` script to streamline the build process for specific packages.

## Launchcontrol
This update enhances package management by marking certain packages as private and adds a new build script for improved development efficiency.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked `@budibase/client`, `@budibase/server`, `@budibase/upgrade-tests`, and `@budibase/worker` as private to prevent accidental publishing. Added a root `build:npm` script to build only the packages we publish.

- **Refactors**
  - Set `"private": true` in `@budibase/client`, `@budibase/server`, `@budibase/upgrade-tests`, `@budibase/worker`.
  - Added `build:npm` to run `yarn build` scoped to: `@budibase/backend-core`, `@budibase/bbui`, `@budibase/cli`, `@budibase/frontend-core`, `@budibase/pro`, `@budibase/sdk`, `@budibase/shared-core`, `@budibase/string-templates`, `@budibase/types`.

<sup>Written for commit 30e8855118358f2a71c3168b97d045ab3900fd75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

