### PR TITLE
Add breakdown by action type to the actions quota

### DIFF
--- a/packages/pro/src/db/quotas/quotas.ts
+++ b/packages/pro/src/db/quotas/quotas.ts
@@ -280,6 +280,18 @@ const coreUsageUpdate = (
     const currentMonth = utils.getCurrentMonthString()
     quotaUsage.monthly[currentMonth][name] = values.total
     setMonthlyTriggers(name, currentMonth, quotaUsage, values.triggers)
+    if (
+      !APP_QUOTA_NAMES.includes(name) &&
+      BREAKDOWN_QUOTA_NAMES.includes(name) &&
+      opts?.id
+    ) {
+      quotaUsage.monthly[currentMonth] = setBreakdown(
+        quotaUsage.monthly[currentMonth],
+        name,
+        opts.id,
+        values
+      )
+    }
   } else {
     throw new Error(`Invalid usage type: ${type}`)
   }
@@ -335,6 +347,19 @@ export const getCurrentUsageValues = async (
       if (quotaUsage.monthly[currentMonth][monthlyName]) {
         total = quotaUsage.monthly[currentMonth][monthlyName]
         appValues = getAppUsageValue(quotaUsage, type, name, id)
+      }
+      // For non-app quotas with breakdown (e.g. ACTIONS), read from global monthly
+      if (
+        !APP_QUOTA_NAMES.includes(name) &&
+        BREAKDOWN_QUOTA_NAMES.includes(monthlyName) &&
+        id
+      ) {
+        const breakdownName = utils.getBreakdownName(monthlyName, id)
+        if (breakdownName) {
+          const globalBreakdown =
+            quotaUsage.monthly[currentMonth].breakdown?.[breakdownName]
+          appValues.breakdown = globalBreakdown?.values?.[id] ?? 0
+        }
       }
       break
     }

--- a/packages/pro/src/db/quotas/quotas.ts
+++ b/packages/pro/src/db/quotas/quotas.ts
@@ -121,7 +121,7 @@ const setBreakdown = (
   values: UsageValues
 ) => {
   const breakdownName = utils.getBreakdownName(name, id)
-  if (!breakdownName || !values?.breakdown) {
+  if (!breakdownName || values?.breakdown == null) {
     return monthUsage
   }
   if (!monthUsage.breakdown) {

--- a/packages/pro/src/db/quotas/utils.ts
+++ b/packages/pro/src/db/quotas/utils.ts
@@ -109,5 +109,7 @@ export const getBreakdownName = (
         : isDatasourceOrDatasourcePlusId(id)
           ? BreakdownQuotaName.DATASOURCE_QUERIES
           : undefined
+    case MonthlyQuotaName.ACTIONS:
+      return BreakdownQuotaName.ACTIONS
   }
 }

--- a/packages/pro/src/sdk/quotas/helpers/actions.ts
+++ b/packages/pro/src/sdk/quotas/helpers/actions.ts
@@ -1,8 +1,12 @@
-import { MonthlyQuotaName, QuotaUsageType } from "@budibase/types"
+import { ActionType, MonthlyQuotaName, QuotaUsageType } from "@budibase/types"
 import * as quotas from "./../quotas"
 
-export const addAction = async <T>(addActionFn: () => Promise<T>) => {
+export const addAction = async <T>(
+  actionType: ActionType,
+  addActionFn: () => Promise<T>
+) => {
   return quotas.increment(MonthlyQuotaName.ACTIONS, QuotaUsageType.MONTHLY, {
     fn: addActionFn,
+    id: actionType,
   })
 }

--- a/packages/pro/src/sdk/quotas/quotas.ts
+++ b/packages/pro/src/sdk/quotas/quotas.ts
@@ -393,7 +393,7 @@ export const updateUsage = async (
           if (appValue) {
             appValue = Math.max(0, appValue)
           }
-          if (breakdownValue) {
+          if (breakdownValue != null) {
             breakdownValue = Math.max(0, breakdownValue)
             breakdownValuesToApply = {
               ...breakdownValuesToApply,

--- a/packages/pro/src/sdk/quotas/tests/breakdown.spec.ts
+++ b/packages/pro/src/sdk/quotas/tests/breakdown.spec.ts
@@ -1,7 +1,39 @@
-import { MonthlyQuotaName, MonthlyUsage, QuotaUsageType } from "@budibase/types"
+import {
+  ActionType,
+  MonthlyQuotaName,
+  MonthlyUsage,
+  QuotaUsageType,
+} from "@budibase/types"
 import { DBTestConfiguration } from "../../../../tests"
 import * as db from "../../../db"
+import * as dbQuotaUtils from "../../../db/quotas/utils"
 import * as quotas from "../quotas"
+
+jest.mock("../../../db/quotas/utils", () => {
+  const actual = jest.requireActual("../../../db/quotas/utils")
+  return {
+    ...actual,
+    getCurrentMonthString: jest
+      .fn()
+      .mockImplementation(actual.getCurrentMonthString),
+    // setCurrentMonth calls getCurrentMonthString directly (same-module reference),
+    // so we override it here to go through the mockable export
+    setCurrentMonth: (usage: any) => {
+      const {
+        getCurrentMonthString,
+        generateNewMonthlyQuotas,
+      } = require("../../../db/quotas/utils")
+      const currentMonth = getCurrentMonthString()
+      if (!usage.monthly) {
+        usage.monthly = {}
+      }
+      if (!usage.monthly[currentMonth]) {
+        usage.monthly[currentMonth] = generateNewMonthlyQuotas()
+      }
+      usage.monthly.current = usage.monthly[currentMonth]
+    },
+  }
+})
 
 import { sql, utils } from "@budibase/backend-core"
 
@@ -78,6 +110,115 @@ async function updateQuotas(testCase: UpdateTest) {
 describe("quotas", () => {
   beforeEach(async () => {
     config.newTenant()
+  })
+
+  describe("actions global breakdown", () => {
+    const actions = MonthlyQuotaName.ACTIONS
+
+    it("tracks breakdown by action type at the global monthly level", async () => {
+      await config.doInTenant(async () => {
+        await quotas.increment(actions, QuotaUsageType.MONTHLY, {
+          id: ActionType.CRUD,
+        })
+        await quotas.increment(actions, QuotaUsageType.MONTHLY, {
+          id: ActionType.CRUD,
+        })
+        await quotas.increment(actions, QuotaUsageType.MONTHLY, {
+          id: ActionType.AUTOMATION_STEP,
+        })
+        await quotas.increment(actions, QuotaUsageType.MONTHLY, {
+          id: ActionType.AI_AGENT,
+        })
+
+        const month = db.quotas.utils.getCurrentMonthString()
+        const doc = await db.quotas.getQuotaUsage()
+        const monthDoc = doc.monthly[month]
+
+        expect(monthDoc.actions).toBe(4)
+        expect(monthDoc.breakdown?.actions?.parent).toBe("actions")
+        expect(monthDoc.breakdown?.actions?.values[ActionType.CRUD]).toBe(2)
+        expect(
+          monthDoc.breakdown?.actions?.values[ActionType.AUTOMATION_STEP]
+        ).toBe(1)
+        expect(monthDoc.breakdown?.actions?.values[ActionType.AI_AGENT]).toBe(1)
+      })
+    })
+
+    it("breakdown does not carry over to a new month", async () => {
+      await config.doInTenant(async () => {
+        await quotas.increment(actions, QuotaUsageType.MONTHLY, {
+          id: ActionType.CRUD,
+        })
+        await quotas.increment(actions, QuotaUsageType.MONTHLY, {
+          id: ActionType.CRUD,
+        })
+
+        const getCurrentMonthStringMock =
+          dbQuotaUtils.getCurrentMonthString as jest.MockedFunction<
+            typeof dbQuotaUtils.getCurrentMonthString
+          >
+
+        const oldMonth = getCurrentMonthStringMock()
+
+        getCurrentMonthStringMock.mockReturnValue("1-2099")
+
+        try {
+          // reading quota usage triggers setCurrentMonth, which creates the new month entry
+          const doc = await db.quotas.getQuotaUsage()
+
+          expect(doc.monthly["1-2099"]).toBeDefined()
+          expect(doc.monthly["1-2099"].actions).toBe(0)
+          expect(doc.monthly["1-2099"].breakdown).toBeUndefined()
+
+          // old month data is preserved but not accessible via current
+          expect(doc.monthly[oldMonth].actions).toBe(2)
+          expect(
+            doc.monthly[oldMonth].breakdown?.actions?.values[ActionType.CRUD]
+          ).toBe(2)
+
+          // current now points to the new empty month
+          expect(doc.monthly.current).toBe(doc.monthly["1-2099"])
+        } finally {
+          const getCurrentMonthStringMock =
+            dbQuotaUtils.getCurrentMonthString as jest.MockedFunction<
+              typeof dbQuotaUtils.getCurrentMonthString
+            >
+          getCurrentMonthStringMock.mockImplementation(
+            jest.requireActual("../../../db/quotas/utils").getCurrentMonthString
+          )
+        }
+      })
+    })
+
+    it("getCurrentUsageValues returns the per-type breakdown count", async () => {
+      await config.doInTenant(async () => {
+        await quotas.increment(actions, QuotaUsageType.MONTHLY, {
+          id: ActionType.CRUD,
+        })
+        await quotas.increment(actions, QuotaUsageType.MONTHLY, {
+          id: ActionType.CRUD,
+        })
+        await quotas.increment(actions, QuotaUsageType.MONTHLY, {
+          id: ActionType.AUTOMATION_STEP,
+        })
+
+        const crudValues = await db.quotas.getCurrentUsageValues(
+          QuotaUsageType.MONTHLY,
+          actions,
+          ActionType.CRUD
+        )
+        expect(crudValues.total).toBe(3)
+        expect(crudValues.breakdown).toBe(2)
+
+        const automationValues = await db.quotas.getCurrentUsageValues(
+          QuotaUsageType.MONTHLY,
+          actions,
+          ActionType.AUTOMATION_STEP
+        )
+        expect(automationValues.total).toBe(3)
+        expect(automationValues.breakdown).toBe(1)
+      })
+    })
   })
 
   describe("app breakdown", () => {

--- a/packages/pro/src/sdk/quotas/tests/breakdown.spec.ts
+++ b/packages/pro/src/sdk/quotas/tests/breakdown.spec.ts
@@ -190,6 +190,30 @@ describe("quotas", () => {
       })
     })
 
+    it("writes a zero breakdown value instead of leaving the stale count", async () => {
+      await config.doInTenant(async () => {
+        await quotas.increment(actions, QuotaUsageType.MONTHLY, {
+          id: ActionType.CRUD,
+        })
+
+        // Force the breakdown counter back to 0 via a direct decrement
+        await quotas.updateUsage({
+          usageChange: -1,
+          name: actions,
+          type: QuotaUsageType.MONTHLY,
+          opts: { id: ActionType.CRUD },
+        })
+
+        const month = db.quotas.utils.getCurrentMonthString()
+        const doc = await db.quotas.getQuotaUsage()
+        const monthDoc = doc.monthly[month]
+
+        // Total is 0, breakdown must also reflect 0, not the stale 1
+        expect(monthDoc.actions).toBe(0)
+        expect(monthDoc.breakdown?.actions?.values[ActionType.CRUD]).toBe(0)
+      })
+    })
+
     it("getCurrentUsageValues returns the per-type breakdown count", async () => {
       await config.doInTenant(async () => {
         await quotas.increment(actions, QuotaUsageType.MONTHLY, {

--- a/packages/server/src/api/controllers/query/index.ts
+++ b/packages/server/src/api/controllers/query/index.ts
@@ -4,6 +4,7 @@ import { utils as JsonUtils, ValidQueryNameRegex } from "@budibase/shared-core"
 import { findHBSBlocks } from "@budibase/string-templates"
 import {
   ActionFailureReason,
+  ActionType,
   ContextUser,
   CreateDatasourceRequest,
   Datasource,
@@ -455,7 +456,7 @@ async function execute(
     const { rows, pagination, extra, info } =
       query.queryVerb === "read" || opts.isAutomation
         ? await Runner.run<QueryResponse>(inputs)
-        : await quotas.addAction(async () => {
+        : await quotas.addAction(ActionType.CRUD, async () => {
             const response = await Runner.run<QueryResponse>(inputs)
             events.action.crudExecuted({ type: query.queryVerb })
             return response

--- a/packages/server/src/api/controllers/row/index.ts
+++ b/packages/server/src/api/controllers/row/index.ts
@@ -6,6 +6,7 @@ import { quotas } from "@budibase/pro"
 import { dataFilters } from "@budibase/shared-core"
 import {
   ActionFailureReason,
+  ActionType,
   Ctx,
   DeleteRow,
   DeleteRowRequest,
@@ -77,7 +78,7 @@ async function _patch(
     }
     const { row, table, oldRow } = isAutomation
       ? await work()
-      : await quotas.addAction(work)
+      : await quotas.addAction(ActionType.CRUD, work)
     if (!row) {
       ctx.throw(404, "Row not found")
     }
@@ -139,7 +140,7 @@ async function _save(
         ctx.user?._id
       )
     } else {
-      saveResult = await quotas.addAction(async () => {
+      saveResult = await quotas.addAction(ActionType.CRUD, async () => {
         const response = await sdk.rows.save(
           sourceId,
           ctx.request.body,
@@ -154,7 +155,7 @@ async function _save(
       sdk.rows.save(sourceId, ctx.request.body, ctx.user?._id)
     )
   } else {
-    saveResult = await quotas.addAction(async () => {
+    saveResult = await quotas.addAction(ActionType.CRUD, async () => {
       const response = await quotas.addRow(() =>
         sdk.rows.save(sourceId, ctx.request.body, ctx.user?._id)
       )
@@ -251,7 +252,9 @@ async function deleteRows(
     events.action.crudExecuted({ type: "delete" })
     return response
   }
-  const { rows } = isAutomation ? await work() : await quotas.addAction(work)
+  const { rows } = isAutomation
+    ? await work()
+    : await quotas.addAction(ActionType.CRUD, work)
 
   if (!tableId.includes("datasource_plus")) {
     await quotas.removeRows(rows.length)
@@ -281,7 +284,9 @@ async function deleteRow(
     events.action.crudExecuted({ type: "delete" })
     return response
   }
-  const resp = isAutomation ? await work() : await quotas.addAction(work)
+  const resp = isAutomation
+    ? await work()
+    : await quotas.addAction(ActionType.CRUD, work)
   if (!tableId.includes("datasource_plus")) {
     await quotas.removeRow()
   }

--- a/packages/server/src/automations/steps/ai/agent.ts
+++ b/packages/server/src/automations/steps/ai/agent.ts
@@ -3,6 +3,7 @@ import { events, getErrorMessage } from "@budibase/backend-core"
 import { quotas } from "@budibase/pro"
 import {
   ActionFailureReason,
+  ActionType,
   AgentStepInputs,
   AgentStepOutputs,
   AutomationStepInputBase,
@@ -145,7 +146,7 @@ export async function run({
               }
             }
             for (const _toolResult of toolResults) {
-              await quotas.addAction(async () => {})
+              await quotas.addAction(ActionType.AI_AGENT, async () => {})
             }
           },
         })

--- a/packages/server/src/automations/tests/actions.spec.ts
+++ b/packages/server/src/automations/tests/actions.spec.ts
@@ -1,5 +1,5 @@
 import { quotas } from "@budibase/pro"
-import { FieldType, TableSourceType } from "@budibase/types"
+import { ActionType, FieldType, TableSourceType } from "@budibase/types"
 import TestConfiguration from "../../tests/utilities/TestConfiguration"
 import * as automation from "../index"
 import { createAutomationBuilder } from "./utilities/AutomationTestBuilder"
@@ -10,7 +10,11 @@ jest.mock("@budibase/pro", () => {
     ...actual,
     quotas: {
       ...actual.quotas,
-      addAction: jest.fn().mockImplementation((fn: () => Promise<any>) => fn()),
+      addAction: jest
+        .fn()
+        .mockImplementation((_type: ActionType, fn: () => Promise<unknown>) =>
+          fn()
+        ),
     },
   }
 })

--- a/packages/server/src/automations/tests/utils.spec.ts
+++ b/packages/server/src/automations/tests/utils.spec.ts
@@ -1,5 +1,6 @@
 import { enableCronOrEmailTrigger } from "../utils"
 import {
+  ActionType,
   Automation,
   AutomationStepType,
   AutomationTriggerStepId,
@@ -16,7 +17,7 @@ jest.mock("../../features", () => ({
 jest.mock("@budibase/pro", () => ({
   quotas: {
     addAutomation: async <T>(fn: () => Promise<T> | T) => fn(),
-    addAction: async <T>(fn: () => Promise<T> | T) => fn(),
+    addAction: async <T>(_type: ActionType, fn: () => Promise<T> | T) => fn(),
   },
 }))
 

--- a/packages/server/src/automations/triggers.ts
+++ b/packages/server/src/automations/triggers.ts
@@ -7,6 +7,7 @@ import { context, db as dbCore, logging } from "@budibase/backend-core"
 import { quotas } from "@budibase/pro"
 import { dataFilters, sdk } from "@budibase/shared-core"
 import {
+  ActionType,
   Automation,
   AutomationData,
   AutomationEventType,
@@ -117,7 +118,7 @@ async function queueRelevantRowAutomations(
       })
       if (shouldTrigger) {
         try {
-          await quotas.addAction(() =>
+          await quotas.addAction(ActionType.AUTOMATION_STEP, () =>
             automationQueue.add({ automation, event }, JOB_OPTS)
           )
         } catch (e) {
@@ -264,11 +265,13 @@ export async function externalTrigger(
       appId: context.getWorkspaceId(),
       automation,
     }
-    return quotas.addAction(() =>
+    return quotas.addAction(ActionType.AUTOMATION_STEP, () =>
       executeInThread({ data } as AutomationJob, { onProgress })
     )
   } else {
-    return quotas.addAction(() => automationQueue.add(data, JOB_OPTS))
+    return quotas.addAction(ActionType.AUTOMATION_STEP, () =>
+      automationQueue.add(data, JOB_OPTS)
+    )
   }
 }
 

--- a/packages/server/src/sdk/workspace/ai/agents/agentRuntime.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/agentRuntime.ts
@@ -1,5 +1,6 @@
 import { ai, quotas } from "@budibase/pro"
 import {
+  ActionType,
   Agent,
   AgentMessageMetadata,
   ChatConversationRequest,
@@ -177,7 +178,7 @@ export const prepareAgentChatRun = async ({
                 | undefined
               setUsedKnowledgeSources(output?.accepted)
             }
-            await quotas.addAction(async () => {})
+            await quotas.addAction(ActionType.AI_AGENT, async () => {})
           }
 
           if (!pendingToolCalls) {

--- a/packages/server/src/tests/api/chatConversations.spec.ts
+++ b/packages/server/src/tests/api/chatConversations.spec.ts
@@ -1,5 +1,5 @@
 import { context, docIds, roles } from "@budibase/backend-core"
-import { AgentChannelProvider, DocumentType } from "@budibase/types"
+import { ActionType, AgentChannelProvider, DocumentType } from "@budibase/types"
 import type {
   Agent,
   ChatApp,
@@ -14,7 +14,7 @@ import TestConfiguration from "../utilities/TestConfiguration"
 import sdk from "../../sdk"
 import * as agentLogs from "../../sdk/workspace/ai/agentLogs"
 import type { LanguageModelV3 } from "@ai-sdk/provider"
-import { webhookChat } from "../../api/controllers/ai/chatConversations"
+import { webhookChat } from "../../api/controllers/ai"
 import { MockLanguageModelV3 } from "ai/test"
 
 jest.mock("@budibase/pro", () => {
@@ -23,7 +23,11 @@ jest.mock("@budibase/pro", () => {
     ...actual,
     quotas: {
       ...actual.quotas,
-      addAction: jest.fn().mockImplementation((fn: () => Promise<any>) => fn()),
+      addAction: jest
+        .fn()
+        .mockImplementation((_type: ActionType, fn: () => Promise<unknown>) =>
+          fn()
+        ),
       throwIfBudibaseAICreditsExceeded: jest.fn(),
     },
     ai: {

--- a/packages/server/src/tests/api/rowExternal.spec.ts
+++ b/packages/server/src/tests/api/rowExternal.spec.ts
@@ -1,5 +1,5 @@
 import { quotas } from "@budibase/pro"
-import { ActionFailureReason } from "@budibase/types"
+import { ActionFailureReason, ActionType } from "@budibase/types"
 import { destroy, find, patch, save } from "../../api/controllers/row"
 
 jest.mock("@budibase/pro", () => {
@@ -8,7 +8,11 @@ jest.mock("@budibase/pro", () => {
     ...actual,
     quotas: {
       ...actual.quotas,
-      addAction: jest.fn().mockImplementation((fn: () => Promise<any>) => fn()),
+      addAction: jest
+        .fn()
+        .mockImplementation((_type: ActionType, fn: () => Promise<unknown>) =>
+          fn()
+        ),
       addRow: jest.fn().mockImplementation((fn: () => Promise<any>) => fn()),
       removeRow: jest.fn(),
       removeRows: jest.fn(),

--- a/packages/server/src/tests/automations/agentStep.spec.ts
+++ b/packages/server/src/tests/automations/agentStep.spec.ts
@@ -1,4 +1,5 @@
 import { quotas } from "@budibase/pro"
+import { ActionType } from "@budibase/types"
 import { run } from "../../automations/steps/ai/agent"
 
 jest.mock("@budibase/pro", () => {
@@ -7,7 +8,11 @@ jest.mock("@budibase/pro", () => {
     ...actual,
     quotas: {
       ...actual.quotas,
-      addAction: jest.fn().mockImplementation((fn: () => Promise<any>) => fn()),
+      addAction: jest
+        .fn()
+        .mockImplementation((_type: ActionType, fn: () => Promise<unknown>) =>
+          fn()
+        ),
     },
   }
 })

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -12,6 +12,7 @@ import {
 } from "@budibase/string-templates"
 import {
   ActionFailureReason,
+  ActionType,
   Automation,
   AutomationActionStepId,
   AutomationData,
@@ -585,8 +586,9 @@ class Orchestrator {
         const step = steps[stepIndex]
         switch (step.stepId) {
           case AutomationActionStepId.BRANCH: {
-            const branchResults = await quotas.addAction(() =>
-              this.executeBranchStep(ctx, step)
+            const branchResults = await quotas.addAction(
+              ActionType.AUTOMATION_STEP,
+              () => this.executeBranchStep(ctx, step)
             )
             ctx._stepResults.push(...branchResults)
             results.push(...branchResults)
@@ -631,7 +633,7 @@ class Orchestrator {
             this.reportStepProgress(step, "running", undefined, ctx)
             addToContext(
               step,
-              await quotas.addAction(async () => {
+              await quotas.addAction(ActionType.AUTOMATION_STEP, async () => {
                 const response = await this.executeStep(ctx, step)
                 if (step.stepId === AutomationActionStepId.EXTRACT_STATE) {
                   ctx.state ??= {}

--- a/packages/types/src/documents/global/quotas.ts
+++ b/packages/types/src/documents/global/quotas.ts
@@ -4,6 +4,7 @@ export enum BreakdownQuotaName {
   ROW_QUERIES = "rowQueries",
   DATASOURCE_QUERIES = "datasourceQueries",
   AUTOMATIONS = "automations",
+  ACTIONS = "actions",
 }
 
 export const APP_QUOTA_NAMES = [
@@ -15,6 +16,7 @@ export const APP_QUOTA_NAMES = [
 export const BREAKDOWN_QUOTA_NAMES = [
   MonthlyQuotaName.QUERIES,
   MonthlyQuotaName.AUTOMATIONS,
+  MonthlyQuotaName.ACTIONS,
 ]
 
 export interface UsageBreakdown {

--- a/packages/types/src/sdk/licensing/quota.ts
+++ b/packages/types/src/sdk/licensing/quota.ts
@@ -27,6 +27,12 @@ export enum MonthlyQuotaName {
   ACTIONS = "actions",
 }
 
+export enum ActionType {
+  AUTOMATION_STEP = "automationStep",
+  CRUD = "crud",
+  AI_AGENT = "aiAgent",
+}
+
 export enum ConstantQuotaName {
   AGENT_LOG_RETENTION_DAYS = "agentLogRetentionDays",
   AUTOMATION_LOG_RETENTION_DAYS = "automationLogRetentionDays",


### PR DESCRIPTION
## Description

The `actions` quota currently stores only an aggregate counter. This PR extends the monthly usage document so that, alongside the total, a per-type breakdown is tracked: `automationStep`, `crud`, and `aiAgent`.

The breakdown is stored in the existing `MonthlyUsage.breakdown` structure at the global monthly level (not per-app), and is reset to zero at the start of each new month like every other monthly metric.

## Addresses
- https://github.com/Budibase/budibase/issues/18747

## Screenshots
N/A — backend-only change. The resulting structure in the quota usage document is:

```json
"current": {
  "queries": 0,
  "automations": 98,
  "budibaseAICredits": 0,
  "actions": 4407,
  "triggers": {},
  "breakdown": {
    "actions": {
      "parent": "actions",
      "values": { "automationStep": 1000, "crud": 3000, "aiAgent": 407 }
    }
  }
}
```

## Launchcontrol

The monthly actions quota now records a breakdown by action type (automation step, CRUD, AI agent) in addition to the existing aggregate total.