### PR TITLE
docs: Add Chinese (zh) translation of README

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -1,0 +1,197 @@
+<p align="center">
+  <a href="https://www.budibase.com">
+    <img alt="Budibase" src="https://res.cloudinary.com/daog6scxm/image/upload/v1696515725/Branding/Assets/Symbol/RGB/Full%20Colour/Budibase_Symbol_RGB_FullColour_cbqvha_1_z5cwq2.svg" width="60" />
+  </a>
+</p>
+<h1 align="center">
+  Budibase
+</h1>
+<h3 align="center">
+  用 AI 智能体驱动您的业务运营
+</h3>
+<p align="center">
+  Budibase 是一个开源运营平台，帮助工程师节省数百小时，安全地构建智能体、应用和自动化流程。
+</p>
+
+<h3 align="center">
+ 🤖 🎨 🚀
+</h3>
+<br>
+
+<p align="center">
+  <img alt="Budibase agent ui" src="https://res.cloudinary.com/daog6scxm/image/upload/v1775572268/github/Agent_preview.jpg">
+</p>
+
+<p align="center">
+  <a href="https://github.com/Budibase/budibase/releases">
+    <img alt="GitHub all releases" src="https://img.shields.io/github/downloads/Budibase/budibase/total">
+  </a>
+  <a href="https://github.com/Budibase/budibase/releases">
+    <img alt="GitHub release (latest by date)" src="https://img.shields.io/github/v/release/Budibase/budibase">
+  </a>
+  <a href="https://twitter.com/intent/follow?screen_name=budibase">
+    <img src="https://img.shields.io/twitter/follow/budibase?style=social" alt="Follow @budibase" />
+  </a>
+  <img src="https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg" alt="Code of conduct" />
+  <a href="https://codecov.io/gh/Budibase/budibase">
+    <img src="https://codecov.io/gh/Budibase/budibase/graph/badge.svg?token=***">
+  </a>
+</p>
+
+<h3 align="center">
+  <a href="https://account.budibase.app/register">快速开始 - 由我们托管（Budibase Cloud）</a>
+  <span> · </span>
+  <a href="https://docs.budibase.com/docs/hosting-methods">快速开始 - 自行托管（Docker、K8s、DO）</a>
+  <span> · </span>
+  <a href="https://docs.budibase.com/docs">文档</a>
+  <span> · </span>
+  <a href="https://github.com/Budibase/budibase/discussions?discussions_q=category%3AIdeas">功能建议</a>
+  <span> · </span>
+  <a href="https://github.com/Budibase/budibase/issues">报告 Bug</a>
+  <span> · </span>
+  技术支持：<a href="https://github.com/Budibase/budibase/discussions">讨论区</a>
+</h3>
+
+<br /><br />
+
+## ✨ 功能特性
+
+### 在一个平台上管理您的业务运营
+
+处理请求、自动化工作流、管理流程、连接业务系统——无需拼凑多个工具。
+
+员工每天都会提问、申请审批、报告问题。Budibase 智能体能够理解这些请求并自动处理工作。
+
+<br /><br />
+
+### 用 AI 智能体驱动团队运营
+
+员工每天都会提问、申请审批、报告问题。Budibase 智能体能够理解这些请求并自动处理工作。
+
+<p align="center">
+  <img alt="Budibase chat deploy" src="https://res.cloudinary.com/daog6scxm/image/upload/v1775573887/github/Agent_Chat.jpg">
+</p>
+
+<br /><br />
+
+### 能执行操作的智能体
+
+Budibase 智能体不仅能回答问题，还能在您的业务中运行工作流——创建记录、路由审批、更新应用，并自动通知团队。
+
+<p align="center">
+  <img alt="Budibase agent actions" src="https://res.cloudinary.com/daog6scxm/image/upload/v1775572270/github/Agent_Actions.jpg">
+</p>
+<br /><br />
+
+### 连接您的业务工具
+
+集成数据库、AI 模型和业务应用，让智能体和自动化流程能够在您的运营中执行操作。
+
+### 安全可靠地部署
+
+Budibase 是开源的，具备可扩展性。使用 Budibase，您可以在自己的基础设施上自行托管，并全局管理用户、入职流程、SMTP、应用、分组、主题等。您还可以为用户/分组提供门户，并将用户管理权限下放给分组管理员。
+
+<br />
+
+---
+
+<br />
+
+## Budibase 公共 API
+
+与我们在 Budibase 中构建的所有功能一样，我们的公共 API 简单易用、灵活且具有良好的可扩展性。简而言之，Budibase API 支持：
+
+- 将 Budibase 作为后端
+- 系统互操作性
+
+#### 文档
+
+您可以通过以下渠道了解 Budibase API：
+
+- [通用文档](https://docs.budibase.com/docs/public-api)：了解如何获取 API 密钥、如何使用规范以及如何使用 Postman
+- [交互式 API 文档](https://docs.budibase.com/reference/appcreate)：了解如何与 API 交互
+
+<br /><br />
+
+## 🏁 快速开始
+
+使用 Docker、Kubernetes 和 Digital Ocean 在现有基础设施上部署 Budibase。如果不需要自行托管，也可以使用 Budibase Cloud 快速上手。
+
+### [开始自行托管 Budibase](https://docs.budibase.com/docs/hosting-methods)
+
+- [Docker - 单一 ARM 兼容镜像](https://docs.budibase.com/docs/docker)
+- [Docker Compose](https://docs.budibase.com/docs/docker-compose)
+- [Kubernetes](https://docs.budibase.com/docs/kubernetes-k8s)
+- [Digital Ocean](https://docs.budibase.com/docs/digitalocean)
+- [Portainer](https://docs.budibase.com/docs/portainer)
+
+### [使用 Budibase Cloud 开始](https://budibase.com)
+
+<br /><br />
+
+## 🎓 学习 Budibase
+
+Budibase 文档[在这里](https://docs.budibase.com/docs)。
+<br />
+
+<br /><br />
+
+## 💬 社区
+
+如果您有问题或想与其他 Budibase 用户交流并加入我们的社区，请前往 [Github 讨论区](https://github.com/Budibase/budibase/discussions)
+
+<br /><br /><br />
+
+## ❗ 行为准则
+
+Budibase 致力于为每个人提供友好、多元且无骚扰的体验。我们期望 Budibase 社区中的每个人都能遵守我们的[**行为准则**](https://github.com/Budibase/budibase/blob/HEAD/docs/CODE_OF_CONDUCT.md)。请仔细阅读。
+<br />
+
+<br /><br />
+
+## 🙌 为 Budibase 贡献
+
+从提交 Bug 报告到创建 Pull Request：每一份贡献都会受到赞赏和欢迎。如果您计划实现新功能或更改 API，请先创建一个 Issue。这样我们可以确保您的工作不会白费。
+环境搭建说明请参阅[这里](https://github.com/Budibase/budibase/tree/HEAD/docs/CONTRIBUTING.md)。
+
+### 不确定从哪里开始？
+
+开始贡献的一个好方法是查找 [good first issue](https://github.com/Budibase/budibase/labels/good%20first%20issue) 标签。
+
+### 仓库组织结构
+
+Budibase 是一个由 lerna 管理的 monorepo。Lerna 负责管理 budibase 包的构建和发布。以下是构成 Budibase 的主要包：
+
+- [packages/builder](https://github.com/Budibase/budibase/tree/HEAD/packages/builder) - 包含 budibase 构建器客户端 Svelte 应用的代码。
+
+- [packages/client](https://github.com/Budibase/budibase/tree/HEAD/packages/client) - 运行在浏览器中的模块，负责读取 JSON 定义并创建实时的 Web 应用。
+
+- [packages/server](https://github.com/Budibase/budibase/tree/HEAD/packages/server) - Budibase 服务器。这个 Koa 应用负责为构建器和 budibase 应用提供 JS 服务，以及提供与数据库和文件系统交互的 API。
+
+更多信息请参阅 [CONTRIBUTING.md](https://github.com/Budibase/budibase/blob/HEAD/docs/CONTRIBUTING.md)
+
+<br /><br />
+
+## 📝 许可证
+
+Budibase 是开源的，采用 [GPL v3](https://www.gnu.org/licenses/gpl-3.0.en.html) 许可证。客户端和组件库采用 [MPL](https://directory.fsf.org/wiki/License:MPL-2.0) 许可证——因此您构建的应用可以自由选择许可证。Budibase 付费功能采用 [Business Source License](https://github.com/Budibase/budibase/blob/master/packages/pro/license.md) 许可证。
+
+<br /><br />
+
+## ⭐ Star 增长趋势
+
+[![Star 增长趋势](https://starchart.cc/Budibase/budibase.svg)](https://starchart.cc/Budibase/budibase)
+
+如果在构建器更新之间遇到问题，请使用[此处](https://github.com/Budibase/budibase/blob/HEAD/docs/CONTRIBUTING.md#troubleshooting)的指南清理环境。
+
+<br /><br />
+
+## 贡献者 ✨
+
+感谢以下杰出贡献者（[emoji 说明](https://allcontributors.org/docs/en/emoji-key)）：
+
+<a href="https://github.com/Budibase/budibase/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Budibase/budibase" />
+</a>
+
+由 [contrib.rocks](https://contrib.rocks) 提供支持。


### PR DESCRIPTION
Adds a Chinese (zh) translation of the main README as README_zh.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Chinese (zh) translation of the main README as `README_zh.md` for Chinese-speaking users. The content mirrors the English README with links and images preserved.

- **New Features**
  - Added `README_zh.md` covering features, quick start (self-hosting and cloud), public API, docs, community, contributing, licensing, and badges.

<sup>Written for commit 97371569b3ee60ddfd54ae3a36b544b9f9c88858. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

