### PR TITLE
[18747] Display actions breakdown modal in usage page and home metrics

### DIFF
--- a/packages/builder/src/components/usage/ActionsBreakdownModal.svelte
+++ b/packages/builder/src/components/usage/ActionsBreakdownModal.svelte
@@ -49,7 +49,7 @@
             value={getPercentage(item.used)}
           />
           <Body size="S" color="var(--spectrum-global-color-gray-600)">
-            {getPercentage(item.used).toFixed(1)}% of total actions
+            {getPercentage(item.used).toFixed(1)}% of monthly limit
           </Body>
         </div>
       {/each}

--- a/packages/builder/src/components/usage/ActionsBreakdownModal.svelte
+++ b/packages/builder/src/components/usage/ActionsBreakdownModal.svelte
@@ -1,0 +1,74 @@
+<script>
+  import {
+    Body,
+    Heading,
+    Layout,
+    ModalContent,
+    ProgressBar,
+  } from "@budibase/bbui"
+
+  export let usage
+  export let breakdown = []
+
+  const getPercentage = used => {
+    if (!usage?.total || usage.total <= 0) {
+      return 0
+    }
+    return Math.min((used / usage.total) * 100, 100)
+  }
+</script>
+
+<ModalContent
+  title="Actions breakdown"
+  size="M"
+  showCancelButton={false}
+  showConfirmButton={false}
+>
+  <Layout noPadding gap="L">
+    <div class="total">
+      <Body size="S" color="var(--spectrum-global-color-gray-700)">
+        Total: <strong
+          >{usage?.used?.toLocaleString()} / {usage?.total?.toLocaleString()}</strong
+        >
+      </Body>
+    </div>
+    <Layout noPadding gap="M">
+      {#each breakdown as item}
+        <div class="breakdown-item">
+          <div class="breakdown-header">
+            <Heading size="XS" weight="light">{item.name}</Heading>
+            <Body size="S">{item.used.toLocaleString()}</Body>
+          </div>
+          <ProgressBar
+            showPercentage={false}
+            width={"100%"}
+            duration={1}
+            value={getPercentage(item.used)}
+          />
+          <Body size="S" color="var(--spectrum-global-color-gray-600)">
+            {getPercentage(item.used).toFixed(1)}% of total actions
+          </Body>
+        </div>
+      {/each}
+    </Layout>
+  </Layout>
+</ModalContent>
+
+<style>
+  .total {
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--spectrum-global-color-gray-200);
+  }
+
+  .breakdown-item {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .breakdown-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+</style>

--- a/packages/builder/src/components/usage/ActionsBreakdownModal.svelte
+++ b/packages/builder/src/components/usage/ActionsBreakdownModal.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import {
     Body,
     Heading,
@@ -7,10 +7,14 @@
     ProgressBar,
   } from "@budibase/bbui"
 
-  export let usage
-  export let breakdown = []
+  interface Props {
+    usage: { name: string; used: number; total: number }
+    breakdown?: Array<{ name: string; used: number }>
+  }
 
-  const getPercentage = used => {
+  let { usage, breakdown = [] }: Props = $props()
+
+  const getPercentage = (used: number) => {
     if (!usage?.total || usage.total <= 0) {
       return 0
     }

--- a/packages/builder/src/components/usage/ActionsBreakdownModal.svelte
+++ b/packages/builder/src/components/usage/ActionsBreakdownModal.svelte
@@ -44,7 +44,6 @@
             <Body size="S">{item.used.toLocaleString()}</Body>
           </div>
           <ProgressBar
-            showPercentage={false}
             width={"100%"}
             duration={1}
             value={getPercentage(item.used)}

--- a/packages/builder/src/components/usage/Usage.svelte
+++ b/packages/builder/src/components/usage/Usage.svelte
@@ -1,14 +1,18 @@
 <script>
-  import { Body, ProgressBar, Heading, Icon, Link } from "@budibase/bbui"
+  import { Body, ProgressBar, Heading, Icon, Link, Modal } from "@budibase/bbui"
   import { helpers } from "@budibase/shared-core"
   import { admin } from "@/stores/portal/admin"
   import { auth } from "@/stores/portal/auth"
+  import ActionsBreakdownModal from "./ActionsBreakdownModal.svelte"
+
   export let usage
   export let warnWhenFull = false
+  export let breakdown = null
 
   let percentage
   let unlimited = false
   let showWarning = false
+  let breakdownModal
 
   $: accountPortalAccess = $auth?.user?.accountPortalAccess
   const { accountPortalUpgradeUrl } = helpers
@@ -38,6 +42,15 @@
           {usage.name}
         </span>
       </Heading>
+      {#if breakdown}
+        <button
+          class="info-btn"
+          on:click={() => breakdownModal.show()}
+          aria-label="View breakdown"
+        >
+          <Icon name="InfoOutline" size="S" />
+        </button>
+      {/if}
     </div>
     <Body size="S">
       <span class="nowrap">
@@ -79,6 +92,12 @@
   </div>
 </div>
 
+{#if breakdown}
+  <Modal bind:this={breakdownModal}>
+    <ActionsBreakdownModal {usage} {breakdown} />
+  </Modal>
+{/if}
+
 <style>
   .usage {
     display: flex;
@@ -95,8 +114,26 @@
   }
   .header-container {
     display: flex;
+    align-items: center;
   }
   .nowrap {
     white-space: nowrap;
+  }
+
+  .info-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    margin-left: 6px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    color: var(--spectrum-global-color-gray-600);
+    opacity: 0.7;
+  }
+
+  .info-btn:hover {
+    opacity: 1;
+    color: var(--spectrum-global-color-blue-500);
   }
 </style>

--- a/packages/builder/src/components/usage/index.ts
+++ b/packages/builder/src/components/usage/index.ts
@@ -1,2 +1,3 @@
+export { default as ActionsBreakdownModal } from "./ActionsBreakdownModal.svelte"
 export { default as Usage } from "./Usage.svelte"
 export { default as DashCard } from "./UsageDashCard.svelte"

--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeMetrics.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeMetrics.svelte
@@ -16,7 +16,7 @@
   export let showBudibaseAIMetric = true
 
   let githubStars: number | null = null
-  let actionsBreakdownModal: any
+  let actionsBreakdownModal: Modal
 
   $: canViewOrganisationUsers = $flattenedRoutes.some(
     (route: Route) => route.path === "/people/users"

--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeMetrics.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeMetrics.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Body, Icon } from "@budibase/bbui"
+  import { Body, Icon, Modal } from "@budibase/bbui"
   import type { GetWorkspaceHomeMetricsResponse } from "@budibase/types"
   import { onMount } from "svelte"
   import type { Route } from "@/types/routing"
@@ -7,6 +7,8 @@
   import { API } from "@/api"
   import { bb } from "@/stores/bb"
   import { flattenedRoutes } from "@/stores/routing"
+  import { licensing } from "@/stores/portal/licensing"
+  import { ActionsBreakdownModal } from "@/components/usage"
 
   const GITHUB_REPO_URL = "https://github.com/Budibase/budibase"
 
@@ -14,9 +16,18 @@
   export let showBudibaseAIMetric = true
 
   let githubStars: number | null = null
+  let actionsBreakdownModal: any
+
   $: canViewOrganisationUsers = $flattenedRoutes.some(
     (route: Route) => route.path === "/people/users"
   )
+
+  $: actionsBreakdown = $licensing.actionsBreakdown
+  $: actionsUsage = {
+    name: "Actions",
+    used: metrics?.operationsThisMonth ?? 0,
+    total: $licensing.actionsLimit ?? 0,
+  }
 
   const formatMetric = (value: number) => {
     return new Intl.NumberFormat("en").format(value)
@@ -71,9 +82,27 @@
     <Body size="XL" weight="600">
       {metrics ? formatMetric(metrics.operationsThisMonth) : "-"}
     </Body>
-    <Body size="S" color="var(--spectrum-global-color-gray-600)">
-      Actions this month
-    </Body>
+    {#if actionsBreakdown}
+      <button
+        type="button"
+        class="metric-label-link metric-label-button"
+        on:click={() => actionsBreakdownModal.show()}
+      >
+        <Body size="S" color="var(--spectrum-global-color-gray-600)">
+          Actions this month
+        </Body>
+        <Icon
+          name="arrow-up-right"
+          size="XS"
+          color="var(--spectrum-global-color-gray-600)"
+          weight="regular"
+        />
+      </button>
+    {:else}
+      <Body size="S" color="var(--spectrum-global-color-gray-600)">
+        Actions this month
+      </Body>
+    {/if}
   </div>
 
   {#if showBudibaseAIMetric}
@@ -109,6 +138,12 @@
     </a>
   </div>
 </div>
+
+{#if actionsBreakdown}
+  <Modal bind:this={actionsBreakdownModal}>
+    <ActionsBreakdownModal usage={actionsUsage} breakdown={actionsBreakdown} />
+  </Modal>
+{/if}
 
 <style>
   .metrics {

--- a/packages/builder/src/settings/pages/usage.svelte
+++ b/packages/builder/src/settings/pages/usage.svelte
@@ -74,11 +74,15 @@
         const used = quotaUsage.monthly.current[key]
         if (value.value !== 0) {
           const isAICredits = value.name === "Budibase AI Credits"
-          monthlyUsage.push({
+          const entry = {
             name: value.name,
             used: isAICredits ? Math.floor((used ?? 0) / 1000) : (used ?? 0),
             total: isAICredits ? Math.floor(value.value / 1000) : value.value,
-          })
+          }
+          if (key === "actions" && $licensing.actionsBreakdown) {
+            entry.breakdown = $licensing.actionsBreakdown
+          }
+          monthlyUsage.push(entry)
         }
       }
     }
@@ -233,7 +237,11 @@
             </Layout>
             <Layout noPadding gap="M">
               {#each monthlyUsage as usage}
-                <Usage {usage} warnWhenFull={WARN_USAGE.includes(usage.name)} />
+                <Usage
+                  {usage}
+                  warnWhenFull={WARN_USAGE.includes(usage.name)}
+                  breakdown={usage.breakdown ?? null}
+                />
               {/each}
             </Layout>
           </div>

--- a/packages/builder/src/stores/portal/licensing.ts
+++ b/packages/builder/src/stores/portal/licensing.ts
@@ -19,6 +19,12 @@ const { accountPortalUpgradeUrl } = helpers
 const UNLIMITED = -1
 const ONE_DAY_MILLIS = 86400000
 
+const BREAKDOWN_ACTION_NAME_MAP: Record<string, string> = {
+  automationStep: "Automation Steps",
+  aiAgent: "Agent Tool Calls",
+  crud: "Row Writes",
+}
+
 type MonthlyMetrics = { [key in MonthlyQuotaName]?: number }
 type StaticMetrics = { [key in StaticQuotaName]?: number }
 type UsageMetrics = MonthlyMetrics & StaticMetrics
@@ -68,6 +74,7 @@ interface LicensingState {
   actionsExceeded: boolean
   errUserLimit: boolean
   showTrialBanner: boolean
+  actionsBreakdown: Array<{ name: string; used: number }> | null
 }
 
 class LicensingStore extends BudiStore<LicensingState> {
@@ -116,6 +123,7 @@ class LicensingStore extends BudiStore<LicensingState> {
       // AI Limits
       aiCreditsExceeded: false,
       showTrialBanner: false,
+      actionsBreakdown: null,
     })
 
     this.goToUpgradePage = this.goToUpgradePage.bind(this)
@@ -328,6 +336,22 @@ class LicensingStore extends BudiStore<LicensingState> {
     const aiCreditsLimit = aiCreditsQuota.value
     const actionsQuota = license.quotas.usage.monthly.actions
     const actionsLimit = actionsQuota.value
+
+    const actionsValues = usage.monthly.current.breakdown?.actions?.values
+    let actionsBreakdown: Array<{ name: string; used: number }> | null = null
+    if (actionsValues) {
+      const actionsTotal = usage.monthly.current.actions ?? 0
+      const tracked = Object.entries(BREAKDOWN_ACTION_NAME_MAP).map(
+        ([k, name]) => ({ name, used: actionsValues[k] ?? 0 })
+      )
+      const untracked =
+        actionsTotal - tracked.reduce((sum, item) => sum + item.used, 0)
+      actionsBreakdown = [
+        ...tracked.sort((a, b) => b.used - a.used),
+        ...(untracked > 0 ? [{ name: "N/A", used: untracked }] : []),
+      ]
+    }
+
     const userCount = usage.usageQuota.users
     const userLimitReached = this.usersLimitReached(userCount, userLimit)
     const userLimitExceeded = this.usersLimitExceeded(userCount, userLimit)
@@ -364,6 +388,7 @@ class LicensingStore extends BudiStore<LicensingState> {
         actionsLimit,
         aiCreditsExceeded,
         actionsExceeded,
+        actionsBreakdown,
       }
     })
   }


### PR DESCRIPTION
## Description

Surfaces the per-type actions breakdown (already tracked in the backend since #18769) in two places in the UI:

- **Settings > Account > Usage**: an info icon appears next to the Actions quota. Clicking it opens a modal that shows how actions are distributed across Automation Steps, Agent Tool Calls, and Row Writes, plus an N/A bucket for actions recorded before breakdown tracking was introduced.
- **Home metrics card**: the "Actions this month" label becomes a clickable link (matching the style of "Total users") that opens the same modal.

The breakdown computation lives in the `licensing` store (`actionsBreakdown`) so both surfaces share a single source of truth and stay in sync automatically when the store updates.

## Addresses
- https://github.com/Budibase/budibase/issues/18747

## Screenshots

https://github.com/user-attachments/assets/e22d9a15-ce1c-416c-afd3-a06e25fc66c6

## Launchcontrol

Users can now click an info icon on the Actions usage quota (Settings > Account > Usage) or the "Actions this month" home metric card to see a breakdown of action usage by type: Automation Steps, Agent Tool Calls, and Row Writes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Actions breakdown modal and surfaces it from Usage and the Home metrics card so users can see where Actions are spent. The breakdown is computed once in the `licensing` store and reused across both places (addresses #18747).

- **New Features**
  - Settings > Account > Usage: info icon next to the Actions quota opens a modal with counts for Automation Steps, Agent Tool Calls, Row Writes, plus an N/A bucket for pre-breakdown events.
  - Home metrics: “Actions this month” opens the same modal when breakdown data is available.
  - Licensing store: shared `actionsBreakdown` derived from monthly usage with type mapping and an untracked bucket.

- **Refactors**
  - Migrated `ActionsBreakdownModal` to Svelte 5 runes.
  - Typed the modal instance as `Modal` instead of `any`.
  - Removed non-existent `ProgressBar` prop `showPercentage`.
  - Fixed breakdown percentage label to reflect the monthly Actions limit.

<sup>Written for commit bc1e2c881b59b5e2a33bdbe76ff0700cc4861447. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



