### PR TITLE
Fix branch automation node dragging

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/DragZone.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/DragZone.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { selectedAutomation } from "@/stores/builder"
+  import { isNoOpBlockMove } from "@/stores/builder/automations"
   import { getContext, onDestroy, onMount } from "svelte"
   import { type Writable } from "svelte/store"
   import { generate } from "shortid"
@@ -15,6 +17,11 @@
 
   const view = getContext<Writable<DragView>>("draggableView")
 
+  $: sourcePath = $view?.moveStep?.id
+    ? $selectedAutomation?.blockRefs?.[$view.moveStep.id]?.pathTo
+    : undefined
+  $: isNoOpDrop = sourcePath && path ? isNoOpBlockMove(sourcePath, path) : false
+
   onMount(() => {
     // Always return up-to-date values
     view.update((state: DragView) => {
@@ -24,7 +31,9 @@
           ...(state.dropzones || {}),
           [dzid]: {
             get dims() {
-              return dropEle ? dropEle.getBoundingClientRect() : new DOMRect()
+              return dropEle && !isNoOpDrop
+                ? dropEle.getBoundingClientRect()
+                : new DOMRect()
             },
             path,
           },
@@ -48,6 +57,7 @@
   class="drag-zone"
   class:edge={variant === "edge"}
   class:drag-over={$view?.droptarget === dzid}
+  class:hidden={isNoOpDrop}
   style={variant === "edge" && (width || height)
     ? `width: ${width ? Math.round(width) + "px" : "auto"}; height: ${
         height ? Math.round(height) + "px" : "auto"
@@ -60,6 +70,9 @@
 <style>
   .drag-zone.drag-over {
     background-color: #1ca872b8;
+  }
+  .drag-zone.hidden {
+    visibility: hidden;
   }
   .drag-zone {
     min-height: calc(var(--spectrum-global-dimension-size-225) + 12px);

--- a/packages/builder/src/stores/builder/automations.ts
+++ b/packages/builder/src/stores/builder/automations.ts
@@ -101,6 +101,26 @@ import { EnvVar } from "../portal/environment"
 import { rowActions } from "./rowActions"
 import { contextMenuStore } from "./contextMenu"
 
+export const isNoOpBlockMove = (
+  sourcePath: BlockPath[],
+  destPath: BlockPath[]
+): boolean => {
+  const pathSource = sourcePath.at(-1)
+  const pathEnd = destPath.at(-1)
+  if (!pathSource || !pathEnd) {
+    return false
+  }
+
+  const isOwnDragzone = pathSource.id === pathEnd.id
+  const isFirstBranchStep =
+    pathEnd.branchStepId &&
+    pathEnd.branchStepId === pathSource.branchStepId &&
+    pathEnd.branchIdx === pathSource.branchIdx &&
+    pathSource.stepIdx === 0
+
+  return Boolean(isOwnDragzone || isFirstBranchStep)
+}
+
 const initialAutomationState: AutomationStoreState = {
   automations: [],
   testProgress: {},
@@ -276,26 +296,14 @@ const automationActions = (store: AutomationStore) => ({
     destPath: BlockPath[],
     automation: Automation
   ) => {
-    // The last part of the source node address, containing the id.
-    const pathSource = sourcePath.at(-1)
+    // If dragging into an area that will not affect the tree structure
+    // Ignore the drag and drop.
+    if (isNoOpBlockMove(sourcePath, destPath)) {
+      return
+    }
 
     // The last part of the destination node address, containing the id.
     const pathEnd = destPath.at(-1)
-
-    // Check if dragging a step into its own drag zone
-    const isOwnDragzone = pathSource?.id === pathEnd?.id
-
-    // Check if dragging the first branch step into the branch node drag zone
-    const isFirstBranchStep =
-      pathEnd?.branchStepId &&
-      pathEnd.branchIdx === pathSource?.branchIdx &&
-      pathSource?.stepIdx === 0
-
-    // If dragging into an area that will not affect the tree structure
-    // Ignore the drag and drop.
-    if (isOwnDragzone || isFirstBranchStep) {
-      return
-    }
 
     // Use core delete to remove and return the deleted block
     // from the automation

--- a/packages/builder/src/stores/builder/tests/automations.test.ts
+++ b/packages/builder/src/stores/builder/tests/automations.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, vi } from "vitest"
 import { writable } from "svelte/store"
-import { automationStore } from "../automations"
+import { automationStore, isNoOpBlockMove } from "../automations"
 import { type AutomationBlockRef } from "@/types/automations"
 import { nestedLoopBranchAutomation } from "@/test/automationFixtures"
 
@@ -73,5 +73,104 @@ describe("automation store", () => {
       "branch",
       "branch-child",
     ])
+  })
+
+  it("allows moving the first branch step into another branch on the same branch block", () => {
+    const sourcePath = [
+      {
+        stepIdx: 1,
+        branchIdx: -1,
+        branchStepId: "",
+        id: "branch",
+      },
+      {
+        branchIdx: 0,
+        branchStepId: "branch",
+        stepIdx: 0,
+        id: "source-step",
+      },
+    ]
+    const destPath = [
+      {
+        stepIdx: 1,
+        branchIdx: -1,
+        branchStepId: "",
+        id: "branch",
+      },
+      {
+        branchIdx: 1,
+        branchStepId: "branch",
+        stepIdx: 0,
+        id: "branch",
+      },
+    ]
+
+    expect(isNoOpBlockMove(sourcePath, destPath)).toBe(false)
+  })
+
+  it("allows moving the first branch step into a branch with the same index on another branch block", () => {
+    const sourcePath = [
+      {
+        stepIdx: 1,
+        branchIdx: -1,
+        branchStepId: "",
+        id: "source-branch",
+      },
+      {
+        branchIdx: 0,
+        branchStepId: "source-branch",
+        stepIdx: 0,
+        id: "source-step",
+      },
+    ]
+    const destPath = [
+      {
+        stepIdx: 2,
+        branchIdx: -1,
+        branchStepId: "",
+        id: "dest-branch",
+      },
+      {
+        branchIdx: 0,
+        branchStepId: "dest-branch",
+        stepIdx: 0,
+        id: "dest-branch",
+      },
+    ]
+
+    expect(isNoOpBlockMove(sourcePath, destPath)).toBe(false)
+  })
+
+  it("treats moving the first branch step into its own branch node as a no-op", () => {
+    const sourcePath = [
+      {
+        stepIdx: 1,
+        branchIdx: -1,
+        branchStepId: "",
+        id: "branch",
+      },
+      {
+        branchIdx: 0,
+        branchStepId: "branch",
+        stepIdx: 0,
+        id: "source-step",
+      },
+    ]
+    const destPath = [
+      {
+        stepIdx: 1,
+        branchIdx: -1,
+        branchStepId: "",
+        id: "branch",
+      },
+      {
+        branchIdx: 0,
+        branchStepId: "branch",
+        stepIdx: 0,
+        id: "branch",
+      },
+    ]
+
+    expect(isNoOpBlockMove(sourcePath, destPath)).toBe(true)
   })
 })

--- a/packages/server/src/automations/steps/serverLog.ts
+++ b/packages/server/src/automations/steps/serverLog.ts
@@ -1,16 +1,29 @@
+import { processStringSync } from "@budibase/string-templates"
 import { ServerLogStepInputs, ServerLogStepOutputs } from "@budibase/types"
+import * as automationUtils from "../automationUtils"
 
 export async function run({
   inputs,
   appId,
+  context,
 }: {
   inputs: ServerLogStepInputs
   appId: string
+  context: Record<string, any>
 }): Promise<ServerLogStepOutputs> {
   if (typeof inputs.text !== "string") {
     inputs.text = JSON.stringify(inputs.text)
   }
-  const message = `App ${appId} - ${inputs.text}`
+  let text
+  try {
+    text = processStringSync(inputs.text, context, { noThrow: false })
+  } catch (err) {
+    return {
+      success: false,
+      message: automationUtils.getError(err),
+    }
+  }
+  const message = `App ${appId} - ${text}`
   console.log(message)
   return {
     success: true,

--- a/packages/server/src/automations/tests/steps/serverLog.spec.ts
+++ b/packages/server/src/automations/tests/steps/serverLog.spec.ts
@@ -1,5 +1,10 @@
 import TestConfiguration from "../../../tests/utilities/TestConfiguration"
 import { createAutomationBuilder } from "../utilities/AutomationTestBuilder"
+import { AutomationStatus } from "@budibase/types"
+
+function encodeJS(js: string): string {
+  return `{{ js "${Buffer.from(js, "utf-8").toString("base64")}" }}`
+}
 
 describe("test the server log action", () => {
   const config = new TestConfiguration()
@@ -22,5 +27,30 @@ describe("test the server log action", () => {
       `App ${config.getDevWorkspaceId()} - Hello World`
     )
     expect(result.steps[0].outputs.success).toEqual(true)
+  })
+
+  it("should fail when log text JavaScript errors", async () => {
+    const result = await createAutomationBuilder(config)
+      .onAppAction()
+      .serverLog({ text: encodeJS("return kill") })
+      .test({ fields: {} })
+
+    expect(result.status).toEqual(AutomationStatus.ERROR)
+    expect(result.steps[0].outputs.success).toEqual(false)
+    expect(result.steps[0].outputs.message).toContain(
+      "ReferenceError: kill is not defined"
+    )
+  })
+
+  it("should stop after a log text JavaScript error", async () => {
+    const result = await createAutomationBuilder(config)
+      .onAppAction()
+      .serverLog({ text: encodeJS("return kill") })
+      .serverLog({ text: "This should not run" })
+      .test({ fields: {} })
+
+    expect(result.status).toEqual(AutomationStatus.ERROR)
+    expect(result.steps).toHaveLength(1)
+    expect(result.steps[0].outputs.success).toEqual(false)
   })
 })

--- a/packages/server/src/automations/tests/steps/serverLog.spec.ts
+++ b/packages/server/src/automations/tests/steps/serverLog.spec.ts
@@ -1,10 +1,8 @@
-import TestConfiguration from "../../../tests/utilities/TestConfiguration"
-import { createAutomationBuilder } from "../utilities/AutomationTestBuilder"
+import { encodeJSBinding } from "@budibase/string-templates"
 import { AutomationStatus } from "@budibase/types"
 
-function encodeJS(js: string): string {
-  return `{{ js "${Buffer.from(js, "utf-8").toString("base64")}" }}`
-}
+import TestConfiguration from "../../../tests/utilities/TestConfiguration"
+import { createAutomationBuilder } from "../utilities/AutomationTestBuilder"
 
 describe("test the server log action", () => {
   const config = new TestConfiguration()
@@ -32,7 +30,7 @@ describe("test the server log action", () => {
   it("should fail when log text JavaScript errors", async () => {
     const result = await createAutomationBuilder(config)
       .onAppAction()
-      .serverLog({ text: encodeJS("return kill") })
+      .serverLog({ text: encodeJSBinding("return kill") })
       .test({ fields: {} })
 
     expect(result.status).toEqual(AutomationStatus.ERROR)
@@ -45,7 +43,7 @@ describe("test the server log action", () => {
   it("should stop after a log text JavaScript error", async () => {
     const result = await createAutomationBuilder(config)
       .onAppAction()
-      .serverLog({ text: encodeJS("return kill") })
+      .serverLog({ text: encodeJSBinding("return kill") })
       .serverLog({ text: "This should not run" })
       .test({ fields: {} })
 

--- a/packages/server/src/threads/automation.ts
+++ b/packages/server/src/threads/automation.ts
@@ -924,7 +924,8 @@ class Orchestrator {
       if (
         step.stepId !== AutomationActionStepId.EXECUTE_BASH &&
         step.stepId !== AutomationActionStepId.EXECUTE_SCRIPT_V2 &&
-        step.stepId !== AutomationActionStepId.EXTRACT_STATE
+        step.stepId !== AutomationActionStepId.EXTRACT_STATE &&
+        step.stepId !== AutomationActionStepId.SERVER_LOG
       ) {
         // The EXECUTE_SCRIPT_V2 step saves its input.code value as a `{{ js
         // "..." }}` template, and expects to receive it that way in the


### PR DESCRIPTION
## Description
Fixes automation node drag/drop handling when moving the first step between branch nodes. The no-op move detection now verifies both the branch step id and branch index, so branches with matching names or equivalent indexes on different branch blocks do not incorrectly block valid drops.

Also added a fix so that errors in the backend log throw as an error in the automation.

## Addresses
- https://github.com/Budibase/budibase/issues/18782

## Screenshots
https://github.com/user-attachments/assets/cf39ab67-6871-4154-b2c8-a30b4984efe0

<img width="1031" height="1137" alt="error backend step" src="https://github.com/user-attachments/assets/f95f2952-b7c7-4821-97bc-0c9d6287fa6f" />

**If a backend log step errors, then throw an error**

## Launchcontrol
Fixes dragging automation nodes between branches when branch labels or positions overlap.


