### PR TITLE
Minor ui updates

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowChart.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowChart.svelte
@@ -116,7 +116,17 @@
 
   $: $automationStore.showTestModal === true && testDataModal.show()
 
+  const toggleLiveIconColor = (disabled: boolean, live: boolean) => {
+    if (disabled) return "var(--spectrum-global-color-gray-500)"
+    if (live) return ""
+    return "#fff"
+  }
+
   $: isLive = automation.publishStatus.state === PublishResourceState.PUBLISHED
+  $: toggleLiveIconColorValue = toggleLiveIconColor(
+    !automation?.definition?.trigger || changingStatus,
+    isLive
+  )
 
   // Memo auto - selectedAutomation
   $: memoAutomation.set($selectedAutomation.data || automation)
@@ -423,7 +433,7 @@
         primary={!isLive}
         secondary={isLive}
         icon={isLive ? "stop" : "play"}
-        iconColor={isLive ? "" : "var(--bb-blue)"}
+        iconColor={toggleLiveIconColorValue}
         iconWeight="fill"
         disabled={!automation?.definition?.trigger || changingStatus}
         on:click={handleToggleLive}
@@ -523,6 +533,23 @@
 
   .toggle-active :global(.spectrum-Switch) {
     margin: 0px;
+  }
+
+  .toggle-active :global(button.spectrum-Button.new-styles) {
+    transition:
+      background 130ms ease-out,
+      color 130ms ease-out;
+  }
+  .toggle-active :global(button.spectrum-Button--primary.new-styles:not(.is-disabled)) {
+    background: var(--color-blue-500);
+    border-color: transparent;
+    color: #fff;
+  }
+  .toggle-active :global(button.spectrum-Button--primary.new-styles:not(.is-disabled) .spectrum-Button-label) {
+    color: #fff;
+  }
+  .toggle-active :global(button.spectrum-Button--primary.new-styles:not(.is-disabled):hover) {
+    background: var(--color-blue-600);
   }
 
   .root :global(.main-content) {

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowChart.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowChart.svelte
@@ -540,15 +540,23 @@
       background 130ms ease-out,
       color 130ms ease-out;
   }
-  .toggle-active :global(button.spectrum-Button--primary.new-styles:not(.is-disabled)) {
+  .toggle-active
+    :global(button.spectrum-Button--primary.new-styles:not(.is-disabled)) {
     background: var(--color-blue-500);
     border-color: transparent;
     color: #fff;
   }
-  .toggle-active :global(button.spectrum-Button--primary.new-styles:not(.is-disabled) .spectrum-Button-label) {
+  .toggle-active
+    :global(
+      button.spectrum-Button--primary.new-styles:not(.is-disabled)
+        .spectrum-Button-label
+    ) {
     color: #fff;
   }
-  .toggle-active :global(button.spectrum-Button--primary.new-styles:not(.is-disabled):hover) {
+  .toggle-active
+    :global(
+      button.spectrum-Button--primary.new-styles:not(.is-disabled):hover
+    ) {
     background: var(--color-blue-600);
   }
 

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowChart.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowChart.svelte
@@ -5,7 +5,6 @@
   import {
     notifications,
     Modal,
-    Button,
     ActionButton,
     Switcher,
     StatusLight,
@@ -26,6 +25,7 @@
     deploymentStore,
     contextMenuStore,
   } from "@/stores/builder"
+  import LiveToggleButton from "@/components/common/LiveToggleButton.svelte"
   import { environment } from "@/stores/portal"
   import { type AutomationBlock, ViewMode } from "@/types/automations"
   import { ActionStepID } from "@/constants/backend/automations"
@@ -116,17 +116,7 @@
 
   $: $automationStore.showTestModal === true && testDataModal.show()
 
-  const toggleLiveIconColor = (disabled: boolean, live: boolean) => {
-    if (disabled) return "var(--spectrum-global-color-gray-500)"
-    if (live) return ""
-    return "#fff"
-  }
-
   $: isLive = automation.publishStatus.state === PublishResourceState.PUBLISHED
-  $: toggleLiveIconColorValue = toggleLiveIconColor(
-    !automation?.definition?.trigger || changingStatus,
-    isLive
-  )
 
   // Memo auto - selectedAutomation
   $: memoAutomation.set($selectedAutomation.data || automation)
@@ -429,17 +419,11 @@
     </ActionButton>
 
     <div class="toggle-active setting-spacing">
-      <Button
-        primary={!isLive}
-        secondary={isLive}
-        icon={isLive ? "stop" : "play"}
-        iconColor={toggleLiveIconColorValue}
-        iconWeight="fill"
+      <LiveToggleButton
+        live={isLive}
         disabled={!automation?.definition?.trigger || changingStatus}
         on:click={handleToggleLive}
-      >
-        {isLive ? "Stop" : "Set live"}
-      </Button>
+      />
     </div>
   </div>
 </div>
@@ -533,31 +517,6 @@
 
   .toggle-active :global(.spectrum-Switch) {
     margin: 0px;
-  }
-
-  .toggle-active :global(button.spectrum-Button.new-styles) {
-    transition:
-      background 130ms ease-out,
-      color 130ms ease-out;
-  }
-  .toggle-active
-    :global(button.spectrum-Button--primary.new-styles:not(.is-disabled)) {
-    background: var(--color-blue-500);
-    border-color: transparent;
-    color: #fff;
-  }
-  .toggle-active
-    :global(
-      button.spectrum-Button--primary.new-styles:not(.is-disabled)
-        .spectrum-Button-label
-    ) {
-    color: #fff;
-  }
-  .toggle-active
-    :global(
-      button.spectrum-Button--primary.new-styles:not(.is-disabled):hover
-    ) {
-    background: var(--color-blue-600);
   }
 
   .root :global(.main-content) {

--- a/packages/builder/src/components/common/LiveToggleButton.svelte
+++ b/packages/builder/src/components/common/LiveToggleButton.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte"
+  import { Button } from "@budibase/bbui"
+
+  type ButtonSize = "XXS" | "XS" | "S" | "M" | "L" | "XL" | "XXL" | "XXXL"
+
+  interface Props {
+    live: boolean
+    disabled?: boolean
+    size?: ButtonSize
+  }
+
+  let { live, disabled = false, size = "M" }: Props = $props()
+  const dispatch = createEventDispatcher<{ click: void }>()
+
+  let iconColor = $derived(
+    disabled
+      ? "var(--spectrum-global-color-gray-500)"
+      : live
+        ? undefined
+        : "var(--spectrum-global-color-static-gray-50)"
+  )
+</script>
+
+<div class="live-toggle-button">
+  <Button
+    primary={!live}
+    secondary={live}
+    icon={live ? "stop" : "play"}
+    {iconColor}
+    iconWeight="fill"
+    {disabled}
+    {size}
+    on:click={() => dispatch("click")}
+  >
+    {live ? "Stop" : "Set live"}
+  </Button>
+</div>
+
+<style>
+  .live-toggle-button {
+    display: contents;
+  }
+
+  .live-toggle-button :global(button.spectrum-Button.new-styles) {
+    transition:
+      background 130ms ease-out,
+      color 130ms ease-out;
+  }
+
+  .live-toggle-button
+    :global(button.spectrum-Button--primary.new-styles:not(.is-disabled)) {
+    background: var(--color-blue-500);
+    border-color: transparent;
+    color: var(--spectrum-global-color-static-gray-50);
+  }
+
+  .live-toggle-button
+    :global(
+      button.spectrum-Button--primary.new-styles:not(.is-disabled)
+        .spectrum-Button-label
+    ) {
+    color: var(--spectrum-global-color-static-gray-50);
+  }
+
+  .live-toggle-button
+    :global(
+      button.spectrum-Button--primary.new-styles:not(.is-disabled):hover
+    ) {
+    background: var(--color-blue-600);
+  }
+</style>

--- a/packages/builder/src/components/common/TopBar.svelte
+++ b/packages/builder/src/components/common/TopBar.svelte
@@ -134,13 +134,13 @@
     font-size: 11px;
     line-height: 1.1;
   }
-  .breadcrumbs a {
+  .breadcrumb-item a {
     font-size: 14px;
     font-weight: 500 !important;
-    color: var(--spectrum-global-color-gray-900);
-  }
-  .breadcrumbs a:first-child {
     color: var(--spectrum-global-color-gray-600);
+  }
+  .breadcrumb-item:last-child > a {
+    color: var(--spectrum-global-color-gray-900);
   }
   .breadcrumbs .divider {
     font-size: 14px;

--- a/packages/builder/src/components/common/TopBar.svelte
+++ b/packages/builder/src/components/common/TopBar.svelte
@@ -24,6 +24,10 @@
   let publishSuccessPopover: PopoverAPI | undefined
   let topBarEl: HTMLElement | undefined
   let topBarObserver: ResizeObserver | undefined
+  $: lastVisibleBreadcrumbIndex = breadcrumbs.reduce(
+    (lastIndex, breadcrumb, idx) => (breadcrumb.text ? idx : lastIndex),
+    -1
+  )
 
   $: if (topBarEl) {
     topBarObserver?.disconnect()
@@ -63,7 +67,12 @@
     {#each breadcrumbs as breadcrumb, idx}
       {#if breadcrumb.text}
         <div class="breadcrumb-item">
-          <a href={$url(breadcrumb.url || "./")}>{breadcrumb.text}</a>
+          <a
+            href={$url(breadcrumb.url || "./")}
+            aria-current={idx === lastVisibleBreadcrumbIndex
+              ? "page"
+              : undefined}>{breadcrumb.text}</a
+          >
           {#if breadcrumb.tag}
             <div class="breadcrumb-tag-wrapper">
               <Tag emphasized>{breadcrumb.tag}</Tag>
@@ -139,7 +148,7 @@
     font-weight: 500 !important;
     color: var(--spectrum-global-color-gray-600);
   }
-  .breadcrumb-item:last-child > a {
+  .breadcrumb-item a[aria-current="page"] {
     color: var(--spectrum-global-color-gray-900);
   }
   .breadcrumbs .divider {

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
@@ -95,6 +95,16 @@
     }
   }
 
+  function agentToggleIconColor(disabled: boolean, live: boolean) {
+    if (disabled) return "var(--spectrum-global-color-gray-500)"
+    if (live) return ""
+    return "#fff"
+  }
+
+  let agentToggleIconColorValue = $derived(
+    agentToggleIconColor(togglingLive, currentAgent?.live === true)
+  )
+
   onDestroy(() => stopSyncing?.())
 </script>
 
@@ -163,7 +173,7 @@
         primary={!currentAgent?.live}
         secondary={currentAgent?.live}
         icon={currentAgent?.live ? "stop" : "play"}
-        iconColor={currentAgent?.live ? "" : "var(--bb-blue)"}
+        iconColor={agentToggleIconColorValue}
         iconWeight="fill"
         on:click={toggleAgentLive}
         disabled={togglingLive}
@@ -345,6 +355,23 @@
     display: flex;
     justify-content: flex-end;
     align-items: center;
+  }
+
+  .start-pause-row :global(button.spectrum-Button.new-styles) {
+    transition:
+      background 130ms ease-out,
+      color 130ms ease-out;
+  }
+  .start-pause-row :global(button.spectrum-Button--primary.new-styles:not(.is-disabled)) {
+    background: var(--color-blue-500);
+    border-color: transparent;
+    color: #fff;
+  }
+  .start-pause-row :global(button.spectrum-Button--primary.new-styles:not(.is-disabled) .spectrum-Button-label) {
+    color: #fff;
+  }
+  .start-pause-row :global(button.spectrum-Button--primary.new-styles:not(.is-disabled):hover) {
+    background: var(--color-blue-600);
   }
 
   .status-icons {

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
@@ -362,15 +362,23 @@
       background 130ms ease-out,
       color 130ms ease-out;
   }
-  .start-pause-row :global(button.spectrum-Button--primary.new-styles:not(.is-disabled)) {
+  .start-pause-row
+    :global(button.spectrum-Button--primary.new-styles:not(.is-disabled)) {
     background: var(--color-blue-500);
     border-color: transparent;
     color: #fff;
   }
-  .start-pause-row :global(button.spectrum-Button--primary.new-styles:not(.is-disabled) .spectrum-Button-label) {
+  .start-pause-row
+    :global(
+      button.spectrum-Button--primary.new-styles:not(.is-disabled)
+        .spectrum-Button-label
+    ) {
     color: #fff;
   }
-  .start-pause-row :global(button.spectrum-Button--primary.new-styles:not(.is-disabled):hover) {
+  .start-pause-row
+    :global(
+      button.spectrum-Button--primary.new-styles:not(.is-disabled):hover
+    ) {
     background: var(--color-blue-600);
   }
 

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import {
     ActionButton,
-    Button,
     Icon,
     Layout,
     StatusLight,
     notifications,
   } from "@budibase/bbui"
+  import LiveToggleButton from "@/components/common/LiveToggleButton.svelte"
   import TopBar from "@/components/common/TopBar.svelte"
   import { syncURLToState } from "@/helpers/urlStateSync"
   import { agentsStore, featureFlags, selectedAgent } from "@/stores/portal"
@@ -95,16 +95,6 @@
     }
   }
 
-  function agentToggleIconColor(disabled: boolean, live: boolean) {
-    if (disabled) return "var(--spectrum-global-color-gray-500)"
-    if (live) return ""
-    return "#fff"
-  }
-
-  let agentToggleIconColorValue = $derived(
-    agentToggleIconColor(togglingLive, currentAgent?.live === true)
-  )
-
   onDestroy(() => stopSyncing?.())
 </script>
 
@@ -169,16 +159,11 @@
           color="var(--spectrum-global-color-gray-600)"
         />
       </div>
-      <Button
-        primary={!currentAgent?.live}
-        secondary={currentAgent?.live}
-        icon={currentAgent?.live ? "stop" : "play"}
-        iconColor={agentToggleIconColorValue}
-        iconWeight="fill"
-        on:click={toggleAgentLive}
+      <LiveToggleButton
+        live={currentAgent?.live === true}
         disabled={togglingLive}
-        >{currentAgent?.live ? "Stop" : "Set live"}</Button
-      >
+        on:click={toggleAgentLive}
+      />
     </div>
   </div>
   <div class="config-page" class:full-width={activeTab === "Logs"}>
@@ -355,31 +340,6 @@
     display: flex;
     justify-content: flex-end;
     align-items: center;
-  }
-
-  .start-pause-row :global(button.spectrum-Button.new-styles) {
-    transition:
-      background 130ms ease-out,
-      color 130ms ease-out;
-  }
-  .start-pause-row
-    :global(button.spectrum-Button--primary.new-styles:not(.is-disabled)) {
-    background: var(--color-blue-500);
-    border-color: transparent;
-    color: #fff;
-  }
-  .start-pause-row
-    :global(
-      button.spectrum-Button--primary.new-styles:not(.is-disabled)
-        .spectrum-Button-label
-    ) {
-    color: #fff;
-  }
-  .start-pause-row
-    :global(
-      button.spectrum-Button--primary.new-styles:not(.is-disabled):hover
-    ) {
-    background: var(--color-blue-600);
   }
 
   .status-icons {

--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/_components/AppPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/_components/AppPanel.svelte
@@ -35,7 +35,10 @@
     return "#fff"
   }
 
-  $: workspaceLiveIconColorValue = workspaceLiveIconColor(changingStatus, isLive)
+  $: workspaceLiveIconColorValue = workspaceLiveIconColor(
+    changingStatus,
+    isLive
+  )
 
   $: deviceIcon = getPreviewDeviceIcon(currentDevice)
 
@@ -182,15 +185,23 @@
       background 130ms ease-out,
       color 130ms ease-out;
   }
-  .workspace-live-toggle :global(button.spectrum-Button--primary.new-styles:not(.is-disabled)) {
+  .workspace-live-toggle
+    :global(button.spectrum-Button--primary.new-styles:not(.is-disabled)) {
     background: var(--color-blue-500);
     border-color: transparent;
     color: #fff;
   }
-  .workspace-live-toggle :global(button.spectrum-Button--primary.new-styles:not(.is-disabled) .spectrum-Button-label) {
+  .workspace-live-toggle
+    :global(
+      button.spectrum-Button--primary.new-styles:not(.is-disabled)
+        .spectrum-Button-label
+    ) {
     color: #fff;
   }
-  .workspace-live-toggle :global(button.spectrum-Button--primary.new-styles:not(.is-disabled):hover) {
+  .workspace-live-toggle
+    :global(
+      button.spectrum-Button--primary.new-styles:not(.is-disabled):hover
+    ) {
     background: var(--color-blue-600);
   }
 

--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/_components/AppPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/_components/AppPanel.svelte
@@ -8,9 +8,10 @@
     selectedAppUrls,
     workspaceAppStore,
   } from "@/stores/builder"
+  import LiveToggleButton from "@/components/common/LiveToggleButton.svelte"
   import UndoRedoControl from "@/components/common/UndoRedoControl.svelte"
   import ScreenErrorsButton from "./ScreenErrorsButton.svelte"
-  import { ActionButton, Button, Divider, Icon } from "@budibase/bbui"
+  import { ActionButton, Divider, Icon } from "@budibase/bbui"
   import {
     getNextPreviewDevice,
     getPreviewDeviceIcon,
@@ -28,17 +29,6 @@
 
   $: isLive =
     selectedWorkspaceApp?.publishStatus.state === PublishResourceState.PUBLISHED
-
-  const workspaceLiveIconColor = (disabled: boolean, live: boolean) => {
-    if (disabled) return "var(--spectrum-global-color-gray-500)"
-    if (live) return ""
-    return "#fff"
-  }
-
-  $: workspaceLiveIconColorValue = workspaceLiveIconColor(
-    changingStatus,
-    isLive
-  )
 
   $: deviceIcon = getPreviewDeviceIcon(currentDevice)
 
@@ -116,17 +106,11 @@
           <Divider size="S" vertical />
         </div>
         <div class="workspace-live-toggle">
-          <Button
-            primary={!isLive}
-            secondary={isLive}
-            icon={isLive ? "stop" : "play"}
-            iconColor={workspaceLiveIconColorValue}
-            iconWeight="fill"
-            on:click={handleToggleLive}
+          <LiveToggleButton
+            live={isLive}
             disabled={changingStatus}
-          >
-            {isLive ? "Stop" : "Set live"}
-          </Button>
+            on:click={handleToggleLive}
+          />
         </div>
       </div>
     </div>
@@ -178,31 +162,6 @@
     align-items: center;
     justify-content: right;
     min-width: 96px;
-  }
-
-  .workspace-live-toggle :global(button.spectrum-Button.new-styles) {
-    transition:
-      background 130ms ease-out,
-      color 130ms ease-out;
-  }
-  .workspace-live-toggle
-    :global(button.spectrum-Button--primary.new-styles:not(.is-disabled)) {
-    background: var(--color-blue-500);
-    border-color: transparent;
-    color: #fff;
-  }
-  .workspace-live-toggle
-    :global(
-      button.spectrum-Button--primary.new-styles:not(.is-disabled)
-        .spectrum-Button-label
-    ) {
-    color: #fff;
-  }
-  .workspace-live-toggle
-    :global(
-      button.spectrum-Button--primary.new-styles:not(.is-disabled):hover
-    ) {
-    background: var(--color-blue-600);
   }
 
   .workspace-info {

--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/_components/AppPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/_components/AppPanel.svelte
@@ -29,6 +29,14 @@
   $: isLive =
     selectedWorkspaceApp?.publishStatus.state === PublishResourceState.PUBLISHED
 
+  const workspaceLiveIconColor = (disabled: boolean, live: boolean) => {
+    if (disabled) return "var(--spectrum-global-color-gray-500)"
+    if (live) return ""
+    return "#fff"
+  }
+
+  $: workspaceLiveIconColorValue = workspaceLiveIconColor(changingStatus, isLive)
+
   $: deviceIcon = getPreviewDeviceIcon(currentDevice)
 
   const previewApp = () => {
@@ -109,7 +117,7 @@
             primary={!isLive}
             secondary={isLive}
             icon={isLive ? "stop" : "play"}
-            iconColor={isLive ? "" : "var(--bb-blue)"}
+            iconColor={workspaceLiveIconColorValue}
             iconWeight="fill"
             on:click={handleToggleLive}
             disabled={changingStatus}
@@ -167,6 +175,23 @@
     align-items: center;
     justify-content: right;
     min-width: 96px;
+  }
+
+  .workspace-live-toggle :global(button.spectrum-Button.new-styles) {
+    transition:
+      background 130ms ease-out,
+      color 130ms ease-out;
+  }
+  .workspace-live-toggle :global(button.spectrum-Button--primary.new-styles:not(.is-disabled)) {
+    background: var(--color-blue-500);
+    border-color: transparent;
+    color: #fff;
+  }
+  .workspace-live-toggle :global(button.spectrum-Button--primary.new-styles:not(.is-disabled) .spectrum-Button-label) {
+    color: #fff;
+  }
+  .workspace-live-toggle :global(button.spectrum-Button--primary.new-styles:not(.is-disabled):hover) {
+    background: var(--color-blue-600);
   }
 
   .workspace-info {

--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeTable.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeTable.svelte
@@ -64,7 +64,7 @@
 
   const getStatusColor = (status: string) => {
     if (status === "Live") {
-      return "#8CA171"
+      return "var(--color-green-500)"
     }
     if (status === "Stopped") {
       return "var(--color-orange-400)"

--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeTable.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeTable.svelte
@@ -62,12 +62,15 @@
     return "-"
   }
 
-  const getStatusColor = (status: string) =>
-    status === "Live"
-      ? "#8CA171"
-      : status === "Not Deployed"
-        ? "var(--color-orange-400)"
-        : "var(--spectrum-global-color-gray-600)"
+  const getStatusColor = (status: string) => {
+    if (status === "Live") {
+      return "#8CA171"
+    }
+    if (status === "Stopped") {
+      return "var(--color-orange-400)"
+    }
+    return "var(--spectrum-global-color-gray-600)"
+  }
 
   export let highlightedRowId: string | null = null
 

--- a/packages/builder/src/settings/pages/connections/Connections.svelte
+++ b/packages/builder/src/settings/pages/connections/Connections.svelte
@@ -18,6 +18,7 @@
     icon: { width: "auto", displayName: "" },
     name: {
       sortable: true,
+      color: "var(--spectrum-global-color-gray-900)",
     },
     type: {
       sortable: true,

--- a/packages/builder/src/settings/pages/connections/_components/TypeRenderer.svelte
+++ b/packages/builder/src/settings/pages/connections/_components/TypeRenderer.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { Tags, Tag } from "@budibase/bbui"
   import type { UIWorkspaceConnection } from "@/types"
 
   export let row: UIWorkspaceConnection
@@ -17,19 +16,21 @@
   // Legacy OAuth2 connections don't have auth array - they ARE the OAuth2 config
   $: isLegacyOAuth2 = row.source === "oauth2"
 
-  $: authTags = isLegacyOAuth2
-    ? [{ label: authTypeLabels.oauth2 }]
-    : uniqueTypes.map(type => ({
-        label: authTypeLabels[type] || type,
-      }))
+  $: authLabels = isLegacyOAuth2
+    ? [authTypeLabels.oauth2]
+    : uniqueTypes.map(type => authTypeLabels[type] || type)
+  $: authLabelText = authLabels.length > 0 ? authLabels.join(", ") : "No auth"
 </script>
 
-<Tags>
-  {#if authTags.length > 0}
-    {#each authTags as tag}
-      <Tag>{tag.label}</Tag>
-    {/each}
-  {:else}
-    <Tag>No auth</Tag>
-  {/if}
-</Tags>
+<div class="connection-auth-labels">
+  {authLabelText}
+</div>
+
+<style>
+  .connection-auth-labels {
+    margin-inline-start: auto;
+    width: max-content;
+    max-width: 100%;
+    color: var(--spectrum-global-color-gray-700);
+  }
+</style>


### PR DESCRIPTION
- improved the set live button so it stands out vs the publish button
- highlighted the active page within the breadcrumbs
- updated the auth label within connections table to not be a tag so it doesn't look like a button


## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._
<img width="3840" height="1474" alt="CleanShot 2026-05-14 at 13 48 07@2x" src="https://github.com/user-attachments/assets/131e4d3b-f073-40a8-8a48-e979294bbf37" />
<img width="3832" height="1358" alt="CleanShot 2026-05-14 at 13 48 25@2x" src="https://github.com/user-attachments/assets/e6013245-9f8d-4872-9477-6c5109884a0e" />

