### PR TITLE
add row-selection toggle with delete-rows compatibility

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -8594,6 +8594,16 @@
       },
       {
         "type": "boolean",
+        "label": "Row selection",
+        "key": "allowRowSelection",
+        "defaultValue": true,
+        "dependsOn": {
+          "setting": "allowDeleteRows",
+          "value": false
+        }
+      },
+      {
+        "type": "boolean",
         "label": "Striped rows",
         "key": "stripeRows",
         "defaultValue": false

--- a/packages/client/src/components/app/GridBlock.svelte
+++ b/packages/client/src/components/app/GridBlock.svelte
@@ -15,6 +15,7 @@
   export let allowAddRows = true
   export let allowEditRows = true
   export let allowDeleteRows = true
+  export let allowRowSelection = true
   export let stripeRows = false
   export let quiet = false
   export let initialFilter = null
@@ -96,6 +97,9 @@
     autoRefreshEnabled ? autoRefresh : null,
     gridContext?.rows?.actions?.refreshData
   )
+  $: if (!allowRowSelection && !allowDeleteRows) {
+    gridContext?.selectedRows?.set?.({})
+  }
 
   /**
    *
@@ -278,6 +282,7 @@
     canAddRows={allowAddRows}
     canEditRows={allowEditRows}
     canDeleteRows={allowDeleteRows}
+    canSelectRows={allowRowSelection || allowDeleteRows}
     canEditColumns={false}
     canExpandRows={false}
     canSaveSchema={false}

--- a/packages/frontend-core/src/components/grid/layout/Grid.svelte
+++ b/packages/frontend-core/src/components/grid/layout/Grid.svelte
@@ -42,6 +42,7 @@
   export let canExpandRows = true
   export let canEditRows = true
   export let canDeleteRows = true
+  export let canSelectRows = true
   export let canEditColumns = true
   export let canSaveSchema = true
   export let stripeRows = false
@@ -102,6 +103,7 @@
     canExpandRows,
     canEditRows,
     canDeleteRows,
+    canSelectRows,
     canEditColumns,
     canSaveSchema,
     stripeRows,

--- a/packages/frontend-core/src/components/grid/stores/config.ts
+++ b/packages/frontend-core/src/components/grid/stores/config.ts
@@ -82,9 +82,8 @@ export const deriveStores = (context: StoreContext): ConfigDerivedStore => {
         config.canEditColumns = false
       }
 
-      // Determine if we can select rows. Always true in the meantime as you can
-      // use the selected rows binding regardless of readonly state.
-      config.canSelectRows = true
+      // Determine if we can select rows.
+      config.canSelectRows = $props.canSelectRows !== false
 
       return config
     }

--- a/packages/frontend-core/src/components/grid/stores/index.ts
+++ b/packages/frontend-core/src/components/grid/stores/index.ts
@@ -78,6 +78,7 @@ export interface BaseStoreProps {
   canAddRows?: boolean
   canEditRows?: boolean
   canDeleteRows?: boolean
+  canSelectRows?: boolean
   canEditColumns?: boolean
   canExpandRows?: boolean
   canSaveSchema?: boolean


### PR DESCRIPTION
## Description
Adds a Row selection setting to the Table (gridblock) component so row checkboxes can be hidden when not needed.

## Addresses
- https://github.com/Budibase/budibase/issues/17463

## Screenshots
<img width="313" height="94" alt="Screenshot 2026-05-14 at 14 31 44" src="https://github.com/user-attachments/assets/1683fd83-cf6e-4161-82dc-9fce784b31dd" />

**Table with these settings disabled**
<img width="107" height="425" alt="Screenshot 2026-05-14 at 14 32 00" src="https://github.com/user-attachments/assets/98f363a5-6ed9-4821-93ac-6e1861689b1b" />

## Launchcontrol
You can now turn off the row checkboxes in Table components when you don’t need them.  If row deletion is turned on, checkboxes stay on automatically, since deleting rows depends on selecting them first.