### PR TITLE
fix: rag sharepoint connect

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/index.svelte
@@ -266,7 +266,7 @@
 
   async function openSharePointFlow() {
     if (!hasSharePointConnection) {
-      bb.settings("/connections/apis")
+      bb.settings("/connections/apis/new/microsoft-sharepoint")
       return
     }
     await openSharePointSiteModal()


### PR DESCRIPTION
## Description
If we dont have a sharepoint connection, and then try add a sharepoint knowledge source, we get redirected to the connections screen and have to trawl through a bunch of connections. This takes us straigh to the sharepoint connection screen instead.

## Screenshots


### Before


https://github.com/user-attachments/assets/96c582d2-31b0-4335-a4eb-aabea8ee0b2c



### After

https://github.com/user-attachments/assets/c4921f89-0b8c-4728-880a-798f142ed1c2

