### PR TITLE
Fix query editor shortcut handling

### DIFF
--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -155,7 +155,7 @@
 
   function resetDependentFields() {
     if (newQuery.fields.extra) {
-      newQuery.fields.extra = {} as Query["fields"]["extra"]
+      newQuery.fields.extra = {} as QueryFields["extra"]
     }
   }
 

--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -164,9 +164,10 @@
   }
 
   const handleScroll = (e: Event) => {
-    scrolling = e.currentTarget instanceof HTMLElement
-      ? e.currentTarget.scrollTop !== 0
-      : false
+    scrolling =
+      e.currentTarget instanceof HTMLElement
+        ? e.currentTarget.scrollTop !== 0
+        : false
   }
 
   const handleBindingsChange = (
@@ -232,10 +233,12 @@
                 goto(`../../${response._id}`)
               }
             }}
-            disabled={!!(loading ||
+            disabled={!!(
+              loading ||
               !newQuery.name ||
               nameError ||
-              rows.length === 0)}
+              rows.length === 0
+            )}
             overBackground
           >
             <Icon size="S" name="floppy-disk" />

--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -59,7 +59,7 @@
 
   let datasource: DatasourceOption
   let integration: Integration
-  let schemaType: QueryField
+  let schemaType: QueryField | "fields"
 
   let schema: QuerySchemaMap = {}
   let nestedSchemaFields: NestedSchemaFields = {}

--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -31,13 +31,13 @@
     Integration,
     PreviewQueryResponse,
     Query,
+    QueryFields,
     QuerySchema,
     UIInternalDatasource,
   } from "@budibase/types"
 
   type DatasourceOption = Datasource | UIInternalDatasource
-  type QueryFields = Query["fields"] & Record<string, unknown>
-  type QueryField = keyof QueryFields | "fields"
+  type QueryField = keyof QueryFields
   type QuerySchemaMap = Record<string, QuerySchema | string>
   type NestedSchemaFields = NonNullable<Query["nestedSchemaFields"]>
   type RunQueryOptions = {
@@ -83,7 +83,7 @@
     schema = newQuery.schema
     // Set the location where the query code will be written to an empty string so that it doesn't
     // get changed from undefined -> "" by the input, breaking our unsaved changes checks
-    ;(newQuery.fields as QueryFields)[schemaType] ??= ""
+    newQuery.fields[schemaType] ??= ""
 
     queryHash = JSON.stringify(newQuery)
   }

--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { goto as gotoStore } from "@roxi/routify"
   import { datasources, integrations, queries } from "@/stores/builder"
   import {
@@ -26,49 +26,71 @@
   import { Utils } from "@budibase/frontend-core"
   import ConnectedQueryUsage from "./ConnectedQueryUsage.svelte"
   import { getErrorMessage } from "@/helpers/errors"
+  import type {
+    Datasource,
+    Integration,
+    PreviewQueryResponse,
+    Query,
+    QuerySchema,
+    UIInternalDatasource,
+  } from "@budibase/types"
+
+  type DatasourceOption = Datasource | UIInternalDatasource
+  type QueryFields = Query["fields"] & Record<string, unknown>
+  type QueryField = keyof QueryFields | "fields"
+  type QuerySchemaMap = Record<string, QuerySchema | string>
+  type NestedSchemaFields = NonNullable<Query["nestedSchemaFields"]>
+  type RunQueryOptions = {
+    suppressErrors?: boolean
+  }
 
   $: goto = $gotoStore
 
-  export let query
-  let queryHash
+  export let query: Query
+  let queryHash = ""
 
   let loading = false
   let modified = false
   let scrolling = false
   let showSidePanel = false
-  let nameError
+  let nameError: string | null = null
 
-  let newQuery
+  let newQuery: Query
 
-  let datasource
-  let integration
-  let schemaType
+  let datasource: DatasourceOption
+  let integration: Integration
+  let schemaType: QueryField
 
-  let schema = {}
-  let nestedSchemaFields = {}
-  let rows = []
-  let keys = {}
+  let schema: QuerySchemaMap = {}
+  let nestedSchemaFields: NestedSchemaFields = {}
+  let rows: PreviewQueryResponse["rows"] = []
 
-  const parseQuery = query => {
+  const parseQuery = (query: Query) => {
     modified = false
 
-    datasource = $datasources.list.find(ds => ds._id === query.datasourceId)
-    integration = $integrations[datasource.source]
-    schemaType = integration.query[query.queryVerb].type
+    datasource = $datasources.list.find(
+      (ds: DatasourceOption) => ds._id === query.datasourceId
+    )!
+    const matchingIntegration = $integrations[datasource.source]
+    if (!matchingIntegration) {
+      return
+    }
+    integration = matchingIntegration
+    schemaType = matchingIntegration.query[query.queryVerb].type as QueryField
 
     newQuery = cloneDeep(query)
     // init schema from the query if one already exists
     schema = newQuery.schema
     // Set the location where the query code will be written to an empty string so that it doesn't
     // get changed from undefined -> "" by the input, breaking our unsaved changes checks
-    newQuery.fields[schemaType] ??= ""
+    ;(newQuery.fields as QueryFields)[schemaType] ??= ""
 
     queryHash = JSON.stringify(newQuery)
   }
 
   $: parseQuery(query)
 
-  const checkIsModified = newQuery => {
+  const checkIsModified = (newQuery: Query) => {
     const newQueryHash = JSON.stringify(newQuery)
     modified = newQueryHash !== queryHash
 
@@ -79,7 +101,7 @@
 
   $: debouncedCheckIsModified(newQuery)
 
-  async function runQuery({ suppressErrors = true }) {
+  async function runQuery({ suppressErrors = true }: RunQueryOptions = {}) {
     try {
       showSidePanel = true
       loading = true
@@ -125,7 +147,7 @@
       notifications.success("Query saved successfully")
       return response
     } catch (error) {
-      notifications.error(error.message || "Error saving query")
+      notifications.error(getErrorMessage(error) || "Error saving query")
     } finally {
       loading = false
     }
@@ -133,31 +155,45 @@
 
   function resetDependentFields() {
     if (newQuery.fields.extra) {
-      newQuery.fields.extra = {}
+      newQuery.fields.extra = {} as Query["fields"]["extra"]
     }
   }
 
-  function populateExtraQuery(extraQueryFields) {
+  function populateExtraQuery(extraQueryFields: Query["fields"]["extra"]) {
     newQuery.fields.extra = extraQueryFields
   }
 
-  const handleScroll = e => {
-    scrolling = e.target.scrollTop !== 0
+  const handleScroll = (e: Event) => {
+    scrolling = e.currentTarget instanceof HTMLElement
+      ? e.currentTarget.scrollTop !== 0
+      : false
   }
 
-  async function handleKeyDown(evt) {
-    keys[evt.key] = true
-    if ((keys["Meta"] || keys["Control"]) && keys["Enter"]) {
-      await runQuery({ suppressErrors: false })
+  const handleBindingsChange = (
+    e: CustomEvent<{ name: string; value: string }[]>
+  ) => {
+    newQuery.parameters = e.detail.map(binding => {
+      return {
+        name: binding.name,
+        default: binding.value,
+      }
+    })
+  }
+
+  const handleSchemaChange = (newSchema?: QuerySchemaMap) => {
+    if (newSchema) {
+      schema = newSchema
     }
   }
 
-  function handleKeyUp(evt) {
-    delete keys[evt.key]
+  async function handleKeyDown(evt: KeyboardEvent) {
+    if (evt.key === "Enter" && (evt.metaKey || evt.ctrlKey)) {
+      await runQuery({ suppressErrors: false })
+    }
   }
 </script>
 
-<svelte:window on:keydown={handleKeyDown} on:keyup={handleKeyUp} />
+<svelte:window on:keydown={handleKeyDown} />
 <QueryViewerSavePromptModal
   checkIsModified={() => checkIsModified(newQuery)}
   attemptSave={() => runQuery({ suppressErrors: false }).then(saveQuery)}
@@ -173,12 +209,13 @@
         </Body>
       </div>
       <div class="controls">
-        <ConnectedQueryUsage sourceId={query._id} />
+        {#if query._id}
+          <ConnectedQueryUsage sourceId={query._id} />
+        {/if}
         <ActionButton
           icon="play"
           disabled={loading}
-          on:click={runQuery}
-          overBackground
+          on:click={() => runQuery()}
         >
           Run query
         </ActionButton>
@@ -188,17 +225,17 @@
               const response = await saveQuery()
 
               // When creating a new query the initally passed in query object will have no id.
-              if (response._id && !newQuery._id) {
+              if (response?._id && !newQuery._id) {
                 // Set the comparison query hash to match the new query so that the user doesn't
                 // get nagged when navigating to the edit view
                 queryHash = JSON.stringify(newQuery)
                 goto(`../../${response._id}`)
               }
             }}
-            disabled={loading ||
+            disabled={!!(loading ||
               !newQuery.name ||
               nameError ||
-              rows.length === 0}
+              rows.length === 0)}
             overBackground
           >
             <Icon size="S" name="floppy-disk" />
@@ -215,7 +252,10 @@
           <Input
             value={newQuery.name}
             on:input={e => {
-              let newValue = e.target.value || ""
+              let newValue =
+                e.currentTarget instanceof HTMLInputElement
+                  ? e.currentTarget.value
+                  : ""
               if (newValue.match(ValidQueryNameRegex)) {
                 newQuery.name = newValue.trim()
                 nameError = null
@@ -223,7 +263,7 @@
                 nameError = "Invalid query name"
               }
             }}
-            error={nameError}
+            error={nameError || undefined}
           />
           {#if integration.query}
             <Label>Function</Label>
@@ -235,7 +275,7 @@
                 integration.query[verb]?.displayName || capitalise(verb)}
             />
             <Label>Access</Label>
-            <AccessLevelSelect query={newQuery} />
+            <AccessLevelSelect query={newQuery} label={undefined} />
             {#if integration?.extra && newQuery.queryVerb}
               <ExtraQueryConfig
                 query={newQuery}
@@ -249,7 +289,7 @@
         <Divider />
 
         <div class="heading">
-          <Heading weight="L" size="XS">Query</Heading>
+          <Heading weight="heavy" size="XS">Query</Heading>
         </div>
         <div class="copy">
           <Body size="S">
@@ -275,7 +315,7 @@
         <Divider />
 
         <div class="heading">
-          <Heading weight="L" size="XS">Bindings</Heading>
+          <Heading weight="heavy" size="XS">Bindings</Heading>
         </div>
         <div class="copy">
           <Body size="S">
@@ -286,22 +326,14 @@
         </div>
         {#key newQuery.parameters}
           <BindingBuilder
-            hideHeading
             queryBindings={newQuery.parameters}
-            on:change={e => {
-              newQuery.parameters = e.detail.map(binding => {
-                return {
-                  name: binding.name,
-                  default: binding.value,
-                }
-              })
-            }}
+            on:change={handleBindingsChange}
           />
         {/key}
 
         <Divider />
         <div class="heading">
-          <Heading weight="L" size="XS">Transformer</Heading>
+          <Heading weight="heavy" size="XS">Transformer</Heading>
         </div>
         <div class="copy">
           <Body size="S">
@@ -309,8 +341,9 @@
           </Body>
         </div>
         <CodeMirrorEditor
+          label={undefined}
           height={200}
-          value={newQuery.transformer}
+          value={newQuery.transformer || ""}
           resize="vertical"
           on:change={e => (newQuery.transformer = e.detail)}
         />
@@ -321,9 +354,7 @@
   <div class:showSidePanel class="sidePanel">
     <QueryViewerSidePanel
       onClose={() => (showSidePanel = false)}
-      onSchemaChange={newSchema => {
-        schema = newSchema
-      }}
+      onSchemaChange={handleSchemaChange}
       {rows}
       {schema}
     />

--- a/packages/types/src/documents/workspace/query.ts
+++ b/packages/types/src/documents/workspace/query.ts
@@ -35,14 +35,16 @@ export interface ImportEndpoint {
   queryString?: string
 }
 
+export type QueryFields = RestQueryFields &
+  SQLQueryFields &
+  MongoQueryFields &
+  GoogleSheetsQueryFields
+
 export interface Query extends Document {
   datasourceId: string
   name: string
   parameters: QueryParameter[]
-  fields: RestQueryFields &
-    SQLQueryFields &
-    MongoQueryFields &
-    GoogleSheetsQueryFields
+  fields: QueryFields
   transformer: string | null
   schema: Record<string, QuerySchema | string>
   nestedSchemaFields?: Record<string, Record<string, QuerySchema | string>>


### PR DESCRIPTION
## Description
Fixes the query editor shortcut handling so only the actual Cmd/Ctrl+Enter keydown runs a query. This prevents stale key state from causing Cmd+C or Cmd+V in the SQL editor to execute the query.

Also adds TypeScript annotations to QueryViewer.svelte while preserving the existing behavior.

## Addresses
- Fixes https://github.com/Budibase/budibase/issues/18779


