### PR TITLE
Remove required validation option for checkbox fields

### DIFF
--- a/packages/builder/src/components/design/settings/controls/ValidationEditor/constraints.spec.ts
+++ b/packages/builder/src/components/design/settings/controls/ValidationEditor/constraints.spec.ts
@@ -10,6 +10,13 @@ describe("validation constraints", () => {
     expect(values).toContain("maxLength")
   })
 
+  it("does not offer required validation for boolean fields", () => {
+    const constraints = getConstraintsForType("boolean")
+    const values = constraints.map(constraint => constraint.value)
+
+    expect(values).toStrictEqual(["equal", "notEqual"])
+  })
+
   it("returns empty constraints for unknown field types", () => {
     expect(getConstraintsForType("not-a-real-type")).toStrictEqual([])
   })

--- a/packages/builder/src/components/design/settings/controls/ValidationEditor/constraints.ts
+++ b/packages/builder/src/components/design/settings/controls/ValidationEditor/constraints.ts
@@ -75,7 +75,7 @@ const ConstraintMap: Record<string, ValidationConstraintOption[]> = {
     Constraints.Equal,
     Constraints.NotEqual,
   ],
-  ["boolean"]: [Constraints.Required, Constraints.Equal, Constraints.NotEqual],
+  ["boolean"]: [Constraints.Equal, Constraints.NotEqual],
   ["datetime"]: [
     Constraints.Required,
     Constraints.MaxValue,


### PR DESCRIPTION
## Summary
- remove the Required validation option from boolean fields
- keep Must equal / Must not equal available for explicit checkbox validation
- add a regression test for boolean validation constraints

Fixes #18802

## Testing
- yarn workspace @budibase/builder test src/components/design/settings/controls/ValidationEditor/constraints.spec.ts
- yarn lint:changed
- yarn prettier --check packages/builder/src/components/design/settings/controls/ValidationEditor/constraints.ts packages/builder/src/components/design/settings/controls/ValidationEditor/constraints.spec.ts
- yarn workspace @budibase/builder check:types
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the “Required” validation option for checkbox/boolean fields so they only support “Must equal” and “Must not equal”. Adds a regression test to lock the behavior. Fixes #18802.

- Bug Fixes
  - Updated constraints to remove `Required` for `boolean`; now only `equal` and `notEqual`.
  - Added a unit test in `@budibase/builder` to verify boolean constraints.

<sup>Written for commit 79743938b3e4ac170a3b34b7634b8aad6af468d8. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18805?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

