### PR TITLE
Fix FlatButtonGroup multi-select deselection

### DIFF
--- a/packages/builder/src/components/design/settings/controls/FlatButtonGroup/FlatButtonGroup.spec.ts
+++ b/packages/builder/src/components/design/settings/controls/FlatButtonGroup/FlatButtonGroup.spec.ts
@@ -1,0 +1,46 @@
+import { render, fireEvent, screen } from "@testing-library/svelte"
+import { describe, expect, it, vi } from "vitest"
+import FlatButtonGroup from "./FlatButtonGroup.svelte"
+
+describe("FlatButtonGroup", () => {
+  it("emits the remaining selected values when deselecting in multi-select mode", async () => {
+    const onChange = vi.fn()
+
+    render(FlatButtonGroup, {
+      props: {
+        isMultiSelect: true,
+        value: ["columns", "rows"],
+        onChange,
+        buttonProps: [
+          { text: "Columns", value: "columns" },
+          { text: "Rows", value: "rows" },
+          { text: "Cards", value: "cards" },
+        ],
+      },
+    })
+
+    await fireEvent.click(screen.getByText("Columns"))
+
+    expect(onChange).toHaveBeenCalledWith(["rows"])
+  })
+
+  it("emits the full selection when adding a new value in multi-select mode", async () => {
+    const onChange = vi.fn()
+
+    render(FlatButtonGroup, {
+      props: {
+        isMultiSelect: true,
+        value: ["rows"],
+        onChange,
+        buttonProps: [
+          { text: "Columns", value: "columns" },
+          { text: "Rows", value: "rows" },
+        ],
+      },
+    })
+
+    await fireEvent.click(screen.getByText("Columns"))
+
+    expect(onChange).toHaveBeenCalledWith(["rows", "columns"])
+  })
+})

--- a/packages/builder/src/components/design/settings/controls/FlatButtonGroup/FlatButtonGroup.svelte
+++ b/packages/builder/src/components/design/settings/controls/FlatButtonGroup/FlatButtonGroup.svelte
@@ -18,8 +18,7 @@
     let val
     if (isMultiSelect) {
       if (value.includes(v)) {
-        let idx = value.findIndex(i => i === v)
-        val = [...value].splice(idx, 1)
+        val = value.filter(i => i !== v)
       } else {
         val = [...value, v]
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Fixes a bug in the builder FlatButtonGroup control where deselecting an option in multi-select mode returned the removed value instead of the remaining selected values. Adds a focused component spec covering deselect and add behavior.

## Addresses
- N/A

## App Export
- N/A

## Screenshots
- N/A

## Launchcontrol
Fixes a builder settings control so multi-select options are updated correctly when a user deselects an item.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://budibasehq.slack.com/archives/C0B3BNTKZ8X/p1779093490983559?thread_ts=1779093490.983559&cid=C0B3BNTKZ8X)

<div><a href="https://cursor.com/agents/bc-85632d27-5a45-5ae7-ab01-be04716eecbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85632d27-5a45-5ae7-ab01-be04716eecbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes FlatButtonGroup multi-select so deselecting an option emits the remaining selected values instead of the removed one. Adds a focused spec covering deselect and add behavior.

<sup>Written for commit 05bb5d36a00090de96fb0bff7be084e59ab3f7b3. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18807?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

