### PR TITLE
Chore/automation tests

### DIFF
--- a/packages/server/src/automations/tests/scenarios/looping.spec.ts
+++ b/packages/server/src/automations/tests/scenarios/looping.spec.ts
@@ -1,5 +1,6 @@
 import {
   AutomationActionStepId,
+  AutomationStatus,
   AutomationStepResult,
   AutomationStepStatus,
   FilterCondition,
@@ -184,7 +185,7 @@ describe("Looping automations", () => {
     expect(filterResults[0].outputs.result).toBe(true)
     expect(filterResults[1].outputs).toMatchObject({
       result: false,
-      status: "stopped",
+      status: AutomationStatus.STOPPED,
     })
     expect(filterResults).toHaveLength(3)
     expect(logResults).toHaveLength(2)

--- a/packages/server/src/automations/tests/scenarios/supportEscalationEmails.spec.ts
+++ b/packages/server/src/automations/tests/scenarios/supportEscalationEmails.spec.ts
@@ -1,5 +1,9 @@
 import { setEnv as setCoreEnv } from "@budibase/backend-core"
-import { FilterCondition, SendEmailResponse } from "@budibase/types"
+import {
+  FilterCondition,
+  SendEmailResponse,
+  SmtpEmailStepInputs,
+} from "@budibase/types"
 import { setupDefaultCompletionsAIConfig } from "../../../tests/utilities/aiConfig"
 import { mockChatGPTResponse } from "../../../tests/utilities/mocks/ai/openai"
 import * as workerRequests from "../../../utilities/workerRequests"
@@ -76,12 +80,7 @@ describe("Support escalation email automations", () => {
         subject: "Urgent support ticket",
         contents:
           "<p>{{ trigger.fields.customer }} needs help: {{ trigger.fields.message }}</p>",
-        cc: undefined as unknown as string,
-        bcc: undefined as unknown as string,
-        startTime: undefined as unknown as Date,
-        endTime: undefined as unknown as Date,
-        summary: undefined as unknown as string,
-      })
+      } as SmtpEmailStepInputs)
       .serverLog({
         text: "Escalated {{ trigger.fields.customer }} to tier 2",
       })

--- a/packages/server/src/automations/tests/steps/filter.spec.ts
+++ b/packages/server/src/automations/tests/steps/filter.spec.ts
@@ -1,6 +1,6 @@
 import { createAutomationBuilder } from "../utilities/AutomationTestBuilder"
 import TestConfiguration from "../../../tests/utilities/TestConfiguration"
-import { FilterCondition } from "@budibase/types"
+import { AutomationStatus, FilterCondition } from "@budibase/types"
 import { run } from "../../steps/filter"
 
 function stringToFilterCondition(
@@ -121,7 +121,7 @@ describe("test the filter logic", () => {
         comparisonValue: expectedComparisonValue,
       }
       if (!expectedResult) {
-        expectedOutput.status = "stopped"
+        expectedOutput.status = AutomationStatus.STOPPED
       }
 
       expect(result.steps[0].outputs).toEqual(expectedOutput)

--- a/packages/server/src/automations/tests/steps/loop.spec.ts
+++ b/packages/server/src/automations/tests/steps/loop.spec.ts
@@ -24,6 +24,7 @@ import {
   FieldType,
   FilterCondition,
   AutomationStepStatus,
+  AutomationStatus,
   AutomationStepResult,
   AutomationActionStepId,
 } from "@budibase/types"
@@ -211,7 +212,7 @@ describe("Loop Automations", () => {
 
     expect(results.steps[0].outputs).toEqual(
       expect.objectContaining({
-        status: "FAILURE_CONDITION_MET",
+        status: AutomationStepStatus.FAILURE_CONDITION,
         success: false,
       })
     )
@@ -715,7 +716,7 @@ describe("Loop Automations", () => {
         refValue: 1,
         result: false,
         success: true,
-        status: "stopped",
+        status: AutomationStatus.STOPPED,
       })
     })
 
@@ -1174,7 +1175,7 @@ describe("Loop Automations", () => {
       expect(logResults[0].outputs.message).toContain("Processed: process")
 
       expect(filterResults[1].outputs.result).toBe(false)
-      expect(filterResults[1].outputs.status).toBe("stopped")
+      expect(filterResults[1].outputs.status).toBe(AutomationStatus.STOPPED)
 
       expect(filterResults).toHaveLength(3)
       expect(logResults).toHaveLength(2)

--- a/packages/server/src/automations/tests/steps/sendSmtpEmail.spec.ts
+++ b/packages/server/src/automations/tests/steps/sendSmtpEmail.spec.ts
@@ -24,13 +24,14 @@ function generateResponse(to: string, from: string): SendEmailResponse {
 
 const smtpInputs = (
   overrides: Partial<SmtpEmailStepInputs> = {}
-): SmtpEmailStepInputs => ({
-  to: "user1@example.com",
-  from: "admin@example.com",
-  subject: "hello",
-  contents: "testing",
-  ...overrides,
-} as SmtpEmailStepInputs)
+): SmtpEmailStepInputs =>
+  ({
+    to: "user1@example.com",
+    from: "admin@example.com",
+    subject: "hello",
+    contents: "testing",
+    ...overrides,
+  }) as SmtpEmailStepInputs
 
 describe("SMTP email automations", () => {
   const config = new TestConfiguration()

--- a/packages/server/src/automations/tests/steps/sendSmtpEmail.spec.ts
+++ b/packages/server/src/automations/tests/steps/sendSmtpEmail.spec.ts
@@ -29,13 +29,8 @@ const smtpInputs = (
   from: "admin@example.com",
   subject: "hello",
   contents: "testing",
-  cc: undefined as unknown as string,
-  bcc: undefined as unknown as string,
-  startTime: undefined as unknown as Date,
-  endTime: undefined as unknown as Date,
-  summary: undefined as unknown as string,
   ...overrides,
-})
+} as SmtpEmailStepInputs)
 
 describe("SMTP email automations", () => {
   const config = new TestConfiguration()


### PR DESCRIPTION
## Description
Address review comments on the automation test coverage PR. This tightens test helpers, replaces literal automation status assertions with shared constants, and keeps the SMTP tests compact.

## Addresses
- PR review comments on https://github.com/Budibase/budibase/pull/18716

## App Export
- N/A

## Screenshots
- N/A

## Launchcontrol
Automation test comment cleanup only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up automation tests by replacing string status assertions with enums and using typed SMTP inputs. Aligns failure-condition expectations and removes unused fields across loop, filter, and scenario specs.

- **Refactors**
  - Use `AutomationStatus` and `AutomationStepStatus` from `@budibase/types` (e.g., `AutomationStatus.STOPPED`, `AutomationStepStatus.FAILURE_CONDITION`) instead of string literals.
  - Switch SMTP tests to `SmtpEmailStepInputs` and simplify input helpers; remove undefined fields.

<sup>Written for commit 968e022831faae6f9543be4e45f1536137eddc7c. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18815?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

