### PR TITLE
Fix automation branch edge routing

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowEdgePaths.test.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowEdgePaths.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest"
+import { FLOW_ITEM_ACTION_BAR_WIDTH } from "./FlowGeometry"
+import { getPrimaryBranchPath } from "./FlowEdgePaths"
+
+const expectLineSegmentsToBeOrthogonal = (path: string) => {
+  const commands = [
+    ...path.matchAll(
+      /([ML]) ([\d.-]+),([\d.-]+)|Q ([\d.-]+),([\d.-]+) ([\d.-]+),([\d.-]+)/g
+    ),
+  ]
+  let currentPoint: { x: number; y: number } | undefined
+
+  for (const command of commands) {
+    const [, type, rawX, rawY] = command
+    if (!type) {
+      currentPoint = { x: Number(command[6]), y: Number(command[7]) }
+      continue
+    }
+    const x = Number(rawX)
+    const y = Number(rawY)
+    if (type === "M") {
+      currentPoint = { x, y }
+      continue
+    }
+    expect(type).toBe("L")
+    expect(currentPoint).toBeDefined()
+    expect(
+      x === currentPoint!.x || y === currentPoint!.y,
+      `Expected ${type} ${x},${y} to be horizontal or vertical from ${currentPoint!.x},${currentPoint!.y}`
+    ).toBe(true)
+    currentPoint = { x, y }
+  }
+}
+
+const getPathSegments = (path: string) => {
+  const commands = [
+    ...path.matchAll(
+      /([ML]) ([\d.-]+),([\d.-]+)|Q ([\d.-]+),([\d.-]+) ([\d.-]+),([\d.-]+)/g
+    ),
+  ]
+  const segmentGroups: Array<Array<"horizontal" | "vertical">> = []
+  let segments: Array<"horizontal" | "vertical"> = []
+  let currentPoint: { x: number; y: number } | undefined
+
+  for (const command of commands) {
+    const [, type, rawX, rawY] = command
+    if (!type) {
+      currentPoint = { x: Number(command[6]), y: Number(command[7]) }
+      continue
+    }
+    const point = { x: Number(rawX), y: Number(rawY) }
+    if (type === "M") {
+      if (segments.length) {
+        segmentGroups.push(segments)
+      }
+      segments = []
+      currentPoint = point
+      continue
+    }
+    if (currentPoint) {
+      segments.push(point.y === currentPoint.y ? "horizontal" : "vertical")
+    }
+    currentPoint = point
+  }
+
+  if (segments.length) {
+    segmentGroups.push(segments)
+  }
+
+  return segmentGroups
+}
+
+const getContinuousPathCommands = (path: string) => {
+  return path.split(" M ").map((group, idx) => {
+    const normalized = idx === 0 ? group : `M ${group}`
+    return [
+      ...normalized.matchAll(
+        /([ML]) ([\d.-]+),([\d.-]+)|Q ([\d.-]+),([\d.-]+) ([\d.-]+),([\d.-]+)/g
+      ),
+    ].map(command => {
+      if (command[1]) {
+        return {
+          type: command[1],
+          x: Number(command[2]),
+          y: Number(command[3]),
+        }
+      }
+      return {
+        type: "Q",
+        controlX: Number(command[4]),
+        controlY: Number(command[5]),
+        x: Number(command[6]),
+        y: Number(command[7]),
+      }
+    })
+  })
+}
+
+const expectNoSShapedSegments = (path: string) => {
+  const segmentGroups = getPathSegments(path)
+
+  for (const segments of segmentGroups) {
+    for (let i = 0; i < segments.length - 2; i++) {
+      expect(segments.slice(i, i + 3)).not.toEqual([
+        "horizontal",
+        "vertical",
+        "horizontal",
+      ])
+    }
+  }
+}
+
+describe("getPrimaryBranchPath", () => {
+  it("resumes same-row primary branch edges from the right side of the action bar", () => {
+    const sourceX = 200
+    const sourceY = 120
+    const preBranchLabelX = 300
+    const targetX = 400
+    const targetY = 120
+    const actionBarHalfWidth = FLOW_ITEM_ACTION_BAR_WIDTH / 2
+
+    const path = getPrimaryBranchPath({
+      sourceX,
+      sourceY,
+      targetX,
+      targetY,
+      preBranchLabelX,
+    })
+
+    expect(path).toBe(
+      [
+        `M ${sourceX},${sourceY}`,
+        `L ${preBranchLabelX - actionBarHalfWidth},${sourceY}`,
+        `M ${preBranchLabelX + actionBarHalfWidth},${sourceY}`,
+        `L ${targetX},${targetY}`,
+      ].join(" ")
+    )
+  })
+
+  it("routes offset primary branch edges without diagonal segments", () => {
+    const path = getPrimaryBranchPath({
+      sourceX: 200,
+      sourceY: 120,
+      targetX: 420,
+      targetY: 240,
+      preBranchLabelX: 300,
+    })
+
+    expectLineSegmentsToBeOrthogonal(path)
+  })
+
+  it("does not route offset primary branch edges as S-shaped paths", () => {
+    const path = getPrimaryBranchPath({
+      sourceX: 200,
+      sourceY: 120,
+      targetX: 420,
+      targetY: 240,
+      preBranchLabelX: 300,
+    })
+
+    expectNoSShapedSegments(path)
+  })
+
+  it("starts offset primary branch vertical lines from the middle of the action bar", () => {
+    const preBranchLabelX = 300
+    const sourceY = 120
+    const path = getPrimaryBranchPath({
+      sourceX: 200,
+      sourceY,
+      targetX: 420,
+      targetY: 240,
+      preBranchLabelX,
+    })
+    const [, branchPath] = getContinuousPathCommands(path)
+
+    expect(branchPath[0]).toMatchObject({
+      type: "M",
+      x: preBranchLabelX,
+      y: sourceY,
+    })
+    expect(branchPath[1]).toMatchObject({
+      type: "L",
+      x: preBranchLabelX,
+    })
+  })
+
+  it("starts same-row primary branch horizontal lines from the right edge of the action bar", () => {
+    const preBranchLabelX = 300
+    const sourceY = 120
+    const actionBarRight = preBranchLabelX + FLOW_ITEM_ACTION_BAR_WIDTH / 2
+    const path = getPrimaryBranchPath({
+      sourceX: 200,
+      sourceY,
+      targetX: 420,
+      targetY: sourceY,
+      preBranchLabelX,
+    })
+    const [, branchPath] = getContinuousPathCommands(path)
+
+    expect(branchPath[0]).toMatchObject({
+      type: "M",
+      x: actionBarRight,
+      y: sourceY,
+    })
+    expect(branchPath[1]).toMatchObject({
+      type: "L",
+      y: sourceY,
+    })
+  })
+
+  it("curves when changing from vertical to horizontal", () => {
+    const path = getPrimaryBranchPath({
+      sourceX: 200,
+      sourceY: 120,
+      targetX: 420,
+      targetY: 240,
+      preBranchLabelX: 300,
+    })
+    const [, branchPath] = getContinuousPathCommands(path)
+
+    // Q: quadratic Bézier curve.
+    expect(branchPath.some(command => command.type === "Q")).toBe(true)
+  })
+})

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowEdgePaths.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowEdgePaths.ts
@@ -1,0 +1,42 @@
+import { FLOW_ITEM_ACTION_BAR_WIDTH } from "./FlowGeometry"
+
+interface PrimaryBranchPathArgs {
+  sourceX: number
+  sourceY: number
+  targetX: number
+  targetY: number
+  preBranchLabelX: number
+}
+
+export const getPrimaryBranchPath = ({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  preBranchLabelX,
+}: PrimaryBranchPathArgs) => {
+  const actionBarHalfWidth = FLOW_ITEM_ACTION_BAR_WIDTH / 2
+  const actionBarLeft = preBranchLabelX - actionBarHalfWidth
+  const actionBarRight = preBranchLabelX + actionBarHalfWidth
+  const radius = 12
+
+  if (sourceY === targetY) {
+    return [
+      `M ${sourceX},${sourceY}`,
+      `L ${actionBarLeft},${sourceY}`,
+      `M ${actionBarRight},${sourceY}`,
+      `L ${targetX},${targetY}`,
+    ].join(" ")
+  }
+
+  const yDirection = targetY > sourceY ? 1 : -1
+
+  return [
+    `M ${sourceX},${sourceY}`,
+    `L ${actionBarLeft},${sourceY}`,
+    `M ${preBranchLabelX},${sourceY}`,
+    `L ${preBranchLabelX},${targetY - yDirection * radius}`,
+    `Q ${preBranchLabelX},${targetY} ${preBranchLabelX + radius},${targetY}`,
+    `L ${targetX},${targetY}`,
+  ].join(" ")
+}

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowGraphBuilder.test.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowGraphBuilder.test.ts
@@ -1,12 +1,64 @@
 import { describe, expect, it } from "vitest"
 import type { Edge as FlowEdge, Node as FlowNode } from "@xyflow/svelte"
-import { branchStep, loopStep, serverLogStep } from "@/test/automationFixtures"
-import { renderLoopV2Container } from "./FlowGraphBuilder"
+import {
+  automationTrigger,
+  branchStep,
+  branchWithManyLanesStep,
+  exhaustiveAutomationSteps,
+  linearAutomationSteps,
+  loopStep,
+  loopWithBranchChildStep,
+  loopWithLinearChildrenStep,
+  serverLogStep,
+} from "@/test/automationFixtures"
+import { renderChain, renderLoopV2Container } from "./FlowGraphBuilder"
 import {
   FLOW_ITEM_ACTION_BAR_WIDTH,
   LOOP_INSERT_ACTION_OFFSET,
   STEP,
 } from "./FlowGeometry"
+import {
+  expectAllEdgesResolvable,
+  expectBranchEdge,
+  expectLoopEdge,
+  expectSubflowNodesInsideParent,
+  expectUniqueGraphIds,
+  getEdge,
+  getNode,
+} from "./FlowTestAssertions"
+
+const createGraph = () => ({
+  nodes: [] as FlowNode[],
+  edges: [] as FlowEdge[],
+})
+
+const createDeps = (graph: { nodes: FlowNode[]; edges: FlowEdge[] }) => ({
+  xSpacing: 160,
+  ySpacing: 340,
+  blockRefs: {},
+  newNodes: graph.nodes,
+  newEdges: graph.edges,
+})
+
+const renderTestChain = (
+  chain: Parameters<typeof renderChain>[0],
+  graph = createGraph()
+) => {
+  graph.nodes.push({
+    id: automationTrigger.id,
+    type: "step-node",
+    data: { block: automationTrigger },
+    position: { x: 0, y: -340 },
+  })
+  renderChain(chain, automationTrigger.id, automationTrigger, 0, 0, {
+    xSpacing: 160,
+    ySpacing: 340,
+    blockRefs: {},
+    newNodes: graph.nodes,
+    newEdges: graph.edges,
+  })
+  return graph
+}
 
 describe("renderLoopV2Container", () => {
   it("reserves exit space after the final child in mixed loop subflows", () => {
@@ -21,13 +73,7 @@ describe("renderLoopV2Container", () => {
       edges: [],
     }
 
-    renderLoopV2Container(loop, 0, 0, {
-      xSpacing: 0,
-      ySpacing: 340,
-      blockRefs: {},
-      newNodes: graph.nodes,
-      newEdges: graph.edges,
-    })
+    renderLoopV2Container(loop, 0, 0, createDeps(graph))
 
     const loopNode = graph.nodes.find(node => node.id === loop.id)!
     const finalNode = graph.nodes.find(node => node.id === finalStep.id)!
@@ -46,18 +92,162 @@ describe("renderLoopV2Container", () => {
       edges: [],
     }
 
-    renderLoopV2Container(loop, 0, 0, {
-      xSpacing: 0,
-      ySpacing: 340,
-      blockRefs: {},
-      newNodes: graph.nodes,
-      newEdges: graph.edges,
-    })
+    renderLoopV2Container(loop, 0, 0, createDeps(graph))
 
     const firstNode = graph.nodes.find(node => node.id === firstStep.id)!
     const actionBarRight =
       LOOP_INSERT_ACTION_OFFSET + FLOW_ITEM_ACTION_BAR_WIDTH / 2
 
     expect(firstNode.position.x).toBeGreaterThan(actionBarRight)
+  })
+
+  it("connects linear loop children and exit anchor with loop insertion metadata", () => {
+    const loop = loopWithLinearChildrenStep()
+    const graph = createGraph()
+
+    renderLoopV2Container(loop, 0, 0, createDeps(graph))
+
+    expectUniqueGraphIds(graph)
+    expectAllEdgesResolvable(graph)
+
+    expect(getNode(graph, "linear-loop").type).toBe("loop-subflow-node")
+    expect(getNode(graph, "loop-child-1").parentId).toBe("linear-loop")
+    expect(getNode(graph, "loop-child-2").parentId).toBe("linear-loop")
+    expect(getNode(graph, "loop-child-3").parentId).toBe("linear-loop")
+
+    expectLoopEdge(getEdge(graph, "loop-child-1", "loop-child-2"), {
+      loopStepId: "linear-loop",
+      loopChildInsertIndex: 1,
+    })
+    expectLoopEdge(getEdge(graph, "loop-child-2", "loop-child-3"), {
+      loopStepId: "linear-loop",
+      loopChildInsertIndex: 2,
+    })
+    expectLoopEdge(
+      getEdge(graph, "loop-child-3", "anchor-linear-loop-loop-loop-child-3"),
+      {
+        loopStepId: "linear-loop",
+        loopChildInsertIndex: 3,
+      }
+    )
+    expectSubflowNodesInsideParent(graph)
+  })
+
+  it("renders branch children inside loops as subflow branch lanes with anchors", () => {
+    const loop = loopWithBranchChildStep()
+    const graph = createGraph()
+
+    renderLoopV2Container(loop, 0, 0, createDeps(graph))
+
+    expectUniqueGraphIds(graph)
+    expectAllEdgesResolvable(graph)
+
+    const firstBranch = getNode(graph, "branch-loop-branch-0-first")
+    const secondBranch = getNode(graph, "branch-loop-branch-1-second")
+    const emptyBranch = getNode(graph, "branch-loop-branch-2-empty")
+
+    expect(firstBranch.parentId).toBe("loop-with-branch")
+    expect(secondBranch.parentId).toBe("loop-with-branch")
+    expect(emptyBranch.parentId).toBe("loop-with-branch")
+
+    expectBranchEdge(getEdge(graph, "loop-before-branch", firstBranch.id), {
+      branchStepId: "loop-branch",
+      branchIdx: 0,
+      branchesCount: 3,
+      isSubflowEdge: true,
+    })
+    expectLoopEdge(
+      getEdge(
+        graph,
+        "loop-branch-second-child-2",
+        "anchor-branch-loop-branch-1-second"
+      ),
+      {
+        loopStepId: "loop-with-branch",
+        loopChildInsertIndex: 1,
+      }
+    )
+    expectLoopEdge(
+      getEdge(
+        graph,
+        "loop-after-branch",
+        "anchor-loop-with-branch-loop-loop-after-branch"
+      ),
+      {
+        loopStepId: "loop-with-branch",
+        loopChildInsertIndex: 3,
+      }
+    )
+    expectSubflowNodesInsideParent(graph)
+  })
+})
+
+describe("renderChain", () => {
+  it("renders linear automation steps with resolvable sequential edges", () => {
+    const graph = renderTestChain(linearAutomationSteps())
+
+    expectUniqueGraphIds(graph)
+    expectAllEdgesResolvable(graph)
+
+    expect(getNode(graph, "step-1").position.y).toBe(0)
+    expect(getNode(graph, "step-2").position.y).toBe(340)
+    expect(getNode(graph, "step-3").position.y).toBe(680)
+    expect(getEdge(graph, "trigger", "step-1").data).toMatchObject({
+      block: automationTrigger,
+    })
+    getEdge(graph, "step-1", "step-2")
+    getEdge(graph, "step-2", "step-3")
+  })
+
+  it("renders top-level branch lanes with terminal anchors for empty and linear lanes", () => {
+    const branch = branchWithManyLanesStep()
+    const graph = renderTestChain([branch])
+
+    expectUniqueGraphIds(graph)
+    expectAllEdgesResolvable(graph)
+
+    expectBranchEdge(getEdge(graph, "trigger", "branch-branch-many-0-alpha"), {
+      branchStepId: "branch-many",
+      branchIdx: 0,
+      branchesCount: 4,
+    })
+    expectBranchEdge(getEdge(graph, "trigger", "branch-branch-many-3-delta"), {
+      branchStepId: "branch-many",
+      branchIdx: 3,
+      branchesCount: 4,
+    })
+
+    getEdge(graph, "alpha-1", "alpha-2")
+    getNode(graph, "anchor-alpha-2")
+    getEdge(
+      graph,
+      "branch-branch-many-1-beta",
+      "anchor-branch-branch-many-1-beta"
+    )
+    getEdge(graph, "delta-loop", "anchor-delta-loop")
+  })
+
+  it("renders exhaustive mixed automations without duplicate ids or dangling edges", () => {
+    const graph = renderTestChain(exhaustiveAutomationSteps())
+
+    expectUniqueGraphIds(graph)
+    expectAllEdgesResolvable(graph)
+
+    getEdge(graph, "start", "loop-with-branch")
+    expectBranchEdge(
+      getEdge(graph, "loop-with-branch", "branch-post-loop-branch-0-success"),
+      {
+        branchStepId: "post-loop-branch",
+        branchIdx: 0,
+        branchesCount: 3,
+      }
+    )
+    getEdge(graph, "success-child", "anchor-success-child")
+    getEdge(graph, "fallback-loop", "anchor-fallback-loop")
+    getEdge(
+      graph,
+      "branch-post-loop-branch-2-empty",
+      "anchor-branch-post-loop-branch-2-empty"
+    )
   })
 })

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowGraphBuilder.test.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowGraphBuilder.test.ts
@@ -145,6 +145,11 @@ describe("renderLoopV2Container", () => {
     const firstBranch = getNode(graph, "branch-loop-branch-0-first")
     const secondBranch = getNode(graph, "branch-loop-branch-1-second")
     const emptyBranch = getNode(graph, "branch-loop-branch-2-empty")
+    const middleBranchEdge = getEdge(
+      graph,
+      "loop-before-branch",
+      secondBranch.id
+    )
 
     expect(firstBranch.parentId).toBe("loop-with-branch")
     expect(secondBranch.parentId).toBe("loop-with-branch")
@@ -155,6 +160,11 @@ describe("renderLoopV2Container", () => {
       branchIdx: 0,
       branchesCount: 3,
       isSubflowEdge: true,
+    })
+    expect(middleBranchEdge.data).toMatchObject({
+      isPrimaryEdge: true,
+      branchIdx: 1,
+      branchesCount: 3,
     })
     expectLoopEdge(
       getEdge(

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowGraphBuilder.test.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowGraphBuilder.test.ts
@@ -4,7 +4,6 @@ import {
   automationTrigger,
   branchStep,
   branchWithManyLanesStep,
-  exhaustiveAutomationSteps,
   linearAutomationSteps,
   loopStep,
   loopWithBranchChildStep,
@@ -235,29 +234,5 @@ describe("renderChain", () => {
       "anchor-branch-branch-many-1-beta"
     )
     getEdge(graph, "delta-loop", "anchor-delta-loop")
-  })
-
-  it("renders exhaustive mixed automations without duplicate ids or dangling edges", () => {
-    const graph = renderTestChain(exhaustiveAutomationSteps())
-
-    expectUniqueGraphIds(graph)
-    expectAllEdgesResolvable(graph)
-
-    getEdge(graph, "start", "loop-with-branch")
-    expectBranchEdge(
-      getEdge(graph, "loop-with-branch", "branch-post-loop-branch-0-success"),
-      {
-        branchStepId: "post-loop-branch",
-        branchIdx: 0,
-        branchesCount: 3,
-      }
-    )
-    getEdge(graph, "success-child", "anchor-success-child")
-    getEdge(graph, "fallback-loop", "anchor-fallback-loop")
-    getEdge(
-      graph,
-      "branch-post-loop-branch-2-empty",
-      "anchor-branch-post-loop-branch-2-empty"
-    )
   })
 })

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowLayout.test.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowLayout.test.ts
@@ -10,6 +10,14 @@ import {
   LOOP,
   LOOP_INSERT_ACTION_OFFSET,
 } from "./FlowGeometry"
+import {
+  expectNodeBelow,
+  expectNodeRightOf,
+  getNode,
+} from "./FlowTestAssertions"
+
+const cloneGraph = (graph: { nodes: FlowNode[]; edges: FlowEdge[] }) =>
+  JSON.parse(JSON.stringify(graph)) as { nodes: FlowNode[]; edges: FlowEdge[] }
 
 describe("applyLoopClearance", () => {
   it("leaves enough room for the add action bar after loop subflows", () => {
@@ -63,6 +71,52 @@ describe("applyLoopClearance", () => {
     expect(actionBarRight).toBeLessThan(delayNode.position.x)
   })
 
+  it("moves the whole subtree after a loop by the same horizontal delta", () => {
+    const graph: { nodes: FlowNode[]; edges: FlowEdge[] } = {
+      nodes: [
+        {
+          id: "loop",
+          type: "loop-subflow-node",
+          data: { containerWidth: 520 },
+          position: { x: 0, y: 0 },
+        },
+        {
+          id: "after-loop",
+          type: "step-node",
+          data: {},
+          position: { x: 300, y: 0 },
+        },
+        {
+          id: "tail",
+          type: "step-node",
+          data: {},
+          position: { x: 300, y: 340 },
+        },
+      ],
+      edges: [
+        {
+          id: "edge-loop-after-loop",
+          source: "loop",
+          target: "after-loop",
+          type: "add-item",
+        },
+        {
+          id: "edge-after-loop-tail",
+          source: "after-loop",
+          target: "tail",
+          type: "add-item",
+        },
+      ],
+    }
+
+    applyLoopClearance(graph)
+
+    expectNodeRightOf(graph, "after-loop", "loop", LOOP.clearance)
+    expect(getNode(graph, "tail").position.x).toBe(
+      getNode(graph, "after-loop").position.x
+    )
+  })
+
   it("applies clearance to a later loop after shifting it with an earlier loop", () => {
     const loopWidth = 520
     const graph: { nodes: FlowNode[]; edges: FlowEdge[] } = {
@@ -109,6 +163,174 @@ describe("applyLoopClearance", () => {
     const loop2Right = loop2.position.x + loopWidth
 
     expect(afterLoop2.position.x).toBe(loop2Right + LOOP.clearance)
+  })
+
+  it("ignores loop edges inside subflow containers", () => {
+    const graph: { nodes: FlowNode[]; edges: FlowEdge[] } = {
+      nodes: [
+        {
+          id: "loop",
+          type: "loop-subflow-node",
+          data: { containerWidth: 520 },
+          position: { x: 0, y: 0 },
+        },
+        {
+          id: "inner-child",
+          parentId: "loop",
+          type: "step-node",
+          data: {},
+          position: { x: 80, y: 90 },
+        },
+        {
+          id: "inner-anchor",
+          parentId: "loop",
+          type: "anchor-node",
+          data: {},
+          position: { x: 200, y: 90 },
+        },
+      ],
+      edges: [
+        {
+          id: "edge-inner-child-inner-anchor",
+          source: "inner-child",
+          target: "inner-anchor",
+          type: "add-item",
+        },
+      ],
+    }
+
+    applyLoopClearance(graph)
+
+    expect(getNode(graph, "inner-anchor").position.x).toBe(200)
+  })
+
+  it("is deterministic for repeated runs against the same graph shape", () => {
+    const graph: { nodes: FlowNode[]; edges: FlowEdge[] } = {
+      nodes: [
+        {
+          id: "loop-1",
+          type: "loop-subflow-node",
+          data: { containerWidth: 520 },
+          position: { x: 0, y: 0 },
+        },
+        {
+          id: "loop-2",
+          type: "loop-subflow-node",
+          data: { containerWidth: 480 },
+          position: { x: 400, y: 0 },
+        },
+        {
+          id: "tail",
+          type: "step-node",
+          data: {},
+          position: { x: 800, y: 0 },
+        },
+      ],
+      edges: [
+        {
+          id: "edge-loop-1-loop-2",
+          source: "loop-1",
+          target: "loop-2",
+          type: "add-item",
+        },
+        {
+          id: "edge-loop-2-tail",
+          source: "loop-2",
+          target: "tail",
+          type: "add-item",
+        },
+      ],
+    }
+    const first = cloneGraph(graph)
+    const second = cloneGraph(graph)
+
+    applyLoopClearance(first)
+    applyLoopClearance(second)
+
+    expect(second.nodes).toEqual(first.nodes)
+  })
+})
+
+describe("applyBranchLaneClearance", () => {
+  it("shifts branch descendants with their lane and leaves sibling lanes independent", () => {
+    const graph: { nodes: FlowNode[]; edges: FlowEdge[] } = {
+      nodes: [
+        {
+          id: "source",
+          type: "step-node",
+          data: {},
+          position: { x: 0, y: 0 },
+        },
+        {
+          id: "branch-0",
+          type: "branch-node",
+          data: {},
+          position: { x: 400, y: 0 },
+        },
+        {
+          id: "branch-0-child",
+          type: "step-node",
+          data: {},
+          position: { x: 800, y: 0 },
+        },
+        {
+          id: "branch-1",
+          type: "branch-node",
+          data: {},
+          position: { x: 400, y: 20 },
+        },
+        {
+          id: "branch-1-child",
+          type: "step-node",
+          data: {},
+          position: { x: 800, y: 20 },
+        },
+      ],
+      edges: [
+        {
+          id: "edge-source-branch-0",
+          source: "source",
+          target: "branch-0",
+          type: "add-item",
+          data: {
+            isBranchEdge: true,
+            branchStepId: "branch",
+            branchIdx: 0,
+          },
+        },
+        {
+          id: "edge-branch-0-child",
+          source: "branch-0",
+          target: "branch-0-child",
+          type: "add-item",
+        },
+        {
+          id: "edge-source-branch-1",
+          source: "source",
+          target: "branch-1",
+          type: "add-item",
+          data: {
+            isBranchEdge: true,
+            branchStepId: "branch",
+            branchIdx: 1,
+          },
+        },
+        {
+          id: "edge-branch-1-child",
+          source: "branch-1",
+          target: "branch-1-child",
+          type: "add-item",
+        },
+      ],
+    }
+
+    applyBranchLaneClearance(graph)
+
+    expectNodeBelow(graph, "branch-1", "branch-0", 120)
+    expect(getNode(graph, "branch-1-child").position.y).toBe(
+      getNode(graph, "branch-1").position.y
+    )
+    expect(getNode(graph, "branch-0-child").position.y).toBe(0)
   })
 
   it("separates branch lanes when a lower branch contains a tall loop", () => {
@@ -242,6 +464,148 @@ describe("applyLoopClearance", () => {
     const lowerLoop = graph.nodes.find(node => node.id === "lower-loop")!
 
     expect(lowerLoop.position.y).toBeGreaterThan(upperNestedBottom)
+  })
+
+  it("ignores branch edges inside loop subflows", () => {
+    const graph: { nodes: FlowNode[]; edges: FlowEdge[] } = {
+      nodes: [
+        {
+          id: "loop",
+          type: "loop-subflow-node",
+          data: { containerWidth: 700, containerHeight: 360 },
+          position: { x: 0, y: 0 },
+        },
+        {
+          id: "subflow-branch-0",
+          parentId: "loop",
+          type: "branch-node",
+          data: {},
+          position: { x: 100, y: 0 },
+        },
+        {
+          id: "subflow-branch-1",
+          parentId: "loop",
+          type: "branch-node",
+          data: {},
+          position: { x: 100, y: 20 },
+        },
+      ],
+      edges: [
+        {
+          id: "edge-subflow-branch-0",
+          source: "loop",
+          target: "subflow-branch-0",
+          type: "add-item",
+          data: {
+            isBranchEdge: true,
+            isSubflowEdge: true,
+            branchStepId: "branch",
+            branchIdx: 0,
+          },
+        },
+        {
+          id: "edge-subflow-branch-1",
+          source: "loop",
+          target: "subflow-branch-1",
+          type: "add-item",
+          data: {
+            isBranchEdge: true,
+            isSubflowEdge: true,
+            branchStepId: "branch",
+            branchIdx: 1,
+          },
+        },
+      ],
+    }
+
+    applyBranchLaneClearance(graph)
+
+    expect(getNode(graph, "subflow-branch-1").position.y).toBe(20)
+  })
+})
+
+describe("applyPostLoopBranchClearance", () => {
+  it("shifts every branch fanout descendant below the loop container", () => {
+    const graph: { nodes: FlowNode[]; edges: FlowEdge[] } = {
+      nodes: [
+        {
+          id: "loop",
+          type: "loop-subflow-node",
+          data: { containerWidth: 700, containerHeight: 360 },
+          position: { x: 0, y: 200 },
+        },
+        {
+          id: "branch-0",
+          type: "branch-node",
+          data: {},
+          position: { x: 900, y: 0 },
+        },
+        {
+          id: "branch-0-child",
+          type: "step-node",
+          data: {},
+          position: { x: 1200, y: 0 },
+        },
+        {
+          id: "branch-1",
+          type: "branch-node",
+          data: {},
+          position: { x: 900, y: 180 },
+        },
+        {
+          id: "branch-1-child",
+          type: "step-node",
+          data: {},
+          position: { x: 1200, y: 180 },
+        },
+      ],
+      edges: [
+        {
+          id: "edge-loop-branch-0",
+          source: "loop",
+          target: "branch-0",
+          type: "add-item",
+          data: {
+            isBranchEdge: true,
+            branchStepId: "post-loop-branch",
+            branchIdx: 0,
+          },
+        },
+        {
+          id: "edge-branch-0-child",
+          source: "branch-0",
+          target: "branch-0-child",
+          type: "add-item",
+        },
+        {
+          id: "edge-loop-branch-1",
+          source: "loop",
+          target: "branch-1",
+          type: "add-item",
+          data: {
+            isBranchEdge: true,
+            branchStepId: "post-loop-branch",
+            branchIdx: 1,
+          },
+        },
+        {
+          id: "edge-branch-1-child",
+          source: "branch-1",
+          target: "branch-1-child",
+          type: "add-item",
+        },
+      ],
+    }
+
+    applyPostLoopBranchClearance(graph)
+
+    expectNodeBelow(graph, "branch-0", "loop", 120)
+    expect(getNode(graph, "branch-0-child").position.y).toBe(
+      getNode(graph, "branch-0").position.y
+    )
+    expect(getNode(graph, "branch-1-child").position.y).toBe(
+      getNode(graph, "branch-1").position.y
+    )
   })
 
   it("moves branch fan-outs after loops below the loop container", () => {

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowLayout.test.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowLayout.test.ts
@@ -333,6 +333,95 @@ describe("applyBranchLaneClearance", () => {
     expect(getNode(graph, "branch-0-child").position.y).toBe(0)
   })
 
+  it("keeps the middle lane aligned with the source path for odd branch counts", () => {
+    const graph: { nodes: FlowNode[]; edges: FlowEdge[] } = {
+      nodes: [
+        {
+          id: "source",
+          type: "step-node",
+          data: {},
+          position: { x: 0, y: 100 },
+        },
+        {
+          id: "branch-0",
+          type: "branch-node",
+          data: {},
+          position: { x: 400, y: 100 },
+        },
+        {
+          id: "branch-1",
+          type: "branch-node",
+          data: {},
+          position: { x: 400, y: 100 },
+        },
+        {
+          id: "branch-1-child",
+          type: "step-node",
+          data: {},
+          position: { x: 800, y: 100 },
+        },
+        {
+          id: "branch-2",
+          type: "branch-node",
+          data: {},
+          position: { x: 400, y: 100 },
+        },
+      ],
+      edges: [
+        {
+          id: "edge-source-branch-0",
+          source: "source",
+          target: "branch-0",
+          type: "add-item",
+          data: {
+            isBranchEdge: true,
+            branchStepId: "branch",
+            branchIdx: 0,
+          },
+        },
+        {
+          id: "edge-source-branch-1",
+          source: "source",
+          target: "branch-1",
+          type: "add-item",
+          data: {
+            isBranchEdge: true,
+            branchStepId: "branch",
+            branchIdx: 1,
+          },
+        },
+        {
+          id: "edge-branch-1-child",
+          source: "branch-1",
+          target: "branch-1-child",
+          type: "add-item",
+        },
+        {
+          id: "edge-source-branch-2",
+          source: "source",
+          target: "branch-2",
+          type: "add-item",
+          data: {
+            isBranchEdge: true,
+            branchStepId: "branch",
+            branchIdx: 2,
+          },
+        },
+      ],
+    }
+
+    applyBranchLaneClearance(graph)
+
+    expect(getNode(graph, "branch-1").position.y).toBe(
+      getNode(graph, "source").position.y
+    )
+    expect(getNode(graph, "branch-1-child").position.y).toBe(
+      getNode(graph, "branch-1").position.y
+    )
+    expectNodeBelow(graph, "branch-1", "branch-0", 120)
+    expectNodeBelow(graph, "branch-2", "branch-1-child", 120)
+  })
+
   it("separates branch lanes when a lower branch contains a tall loop", () => {
     const graph: { nodes: FlowNode[]; edges: FlowEdge[] } = {
       nodes: [

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowLayout.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowLayout.ts
@@ -62,7 +62,7 @@ const shiftNodes = (
   delta: number,
   axis: "x" | "y"
 ) => {
-  if (delta <= 0) return
+  if (delta === 0) return
   for (const id of ids) {
     const node = nodesById[id]
     if (!node || node.parentId) continue
@@ -153,9 +153,7 @@ export const applyBranchLaneClearance = (graph: {
 
     branches.sort((a, b) => a.branchIdx - b.branchIdx)
     const siblingIds = new Set(branches.map(branch => branch.nodeId))
-    let previousBottom = -Infinity
-
-    for (const branch of branches) {
+    const branchLanes = branches.map(branch => {
       const blockedIds = new Set(siblingIds)
       blockedIds.delete(branch.nodeId)
       const subtreeIds = collectSubtree(
@@ -164,16 +162,38 @@ export const applyBranchLaneClearance = (graph: {
         outgoing,
         blockedIds
       )
-      const bounds = getSubtreeBounds(subtreeIds, nodesById)
-      const delta = previousBottom + BRANCH_LANE_CLEARANCE - bounds.top
-
-      if (delta > 0) {
-        shiftNodes(subtreeIds, nodesById, delta, "y")
-        bounds.top += delta
-        bounds.bottom += delta
+      return {
+        ...branch,
+        subtreeIds,
+        bounds: getSubtreeBounds(subtreeIds, nodesById),
       }
+    })
 
-      previousBottom = Math.max(previousBottom, bounds.bottom)
+    const shiftBranchLane = (
+      lane: (typeof branchLanes)[number],
+      delta: number
+    ) => {
+      shiftNodes(lane.subtreeIds, nodesById, delta, "y")
+      lane.bounds.top += delta
+      lane.bounds.bottom += delta
+    }
+
+    const primaryIndex = Math.floor((branchLanes.length - 1) / 2)
+
+    for (let i = primaryIndex - 1; i >= 0; i--) {
+      const lane = branchLanes[i]
+      const lowerLane = branchLanes[i + 1]
+      const delta =
+        lowerLane.bounds.top - BRANCH_LANE_CLEARANCE - lane.bounds.bottom
+      shiftBranchLane(lane, delta)
+    }
+
+    for (let i = primaryIndex + 1; i < branchLanes.length; i++) {
+      const lane = branchLanes[i]
+      const upperLane = branchLanes[i - 1]
+      const delta =
+        upperLane.bounds.bottom + BRANCH_LANE_CLEARANCE - lane.bounds.top
+      shiftBranchLane(lane, delta)
     }
   }
 }

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowTestAssertions.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowTestAssertions.ts
@@ -1,0 +1,153 @@
+import { expect } from "vitest"
+import type { Edge as FlowEdge, Node as FlowNode } from "@xyflow/svelte"
+import { ANCHOR, BRANCH, LOOP, STEP } from "./FlowGeometry"
+
+export interface FlowGraph {
+  nodes: FlowNode[]
+  edges: FlowEdge[]
+}
+
+export const getNode = (graph: FlowGraph, id: string) => {
+  const node = graph.nodes.find(node => node.id === id)
+  expect(node, `Expected node "${id}" to exist`).toBeDefined()
+  return node!
+}
+
+export const getEdge = (graph: FlowGraph, source: string, target: string) => {
+  const edge = graph.edges.find(
+    edge => edge.source === source && edge.target === target
+  )
+  expect(
+    edge,
+    `Expected edge "${source}" -> "${target}" to exist`
+  ).toBeDefined()
+  return edge!
+}
+
+export const getNodeHeight = (node: FlowNode) => {
+  if (node.type === "loop-subflow-node") {
+    return typeof node.data?.containerHeight === "number"
+      ? node.data.containerHeight
+      : LOOP.minHeight
+  }
+  if (node.type === "branch-node") {
+    return BRANCH.height
+  }
+  if (node.type === "anchor-node") {
+    return ANCHOR.height
+  }
+  return STEP.height
+}
+
+export const getNodeWidth = (node: FlowNode) => {
+  if (node.type === "loop-subflow-node") {
+    return typeof node.data?.containerWidth === "number"
+      ? node.data.containerWidth
+      : STEP.width
+  }
+  if (node.type === "anchor-node") {
+    return ANCHOR.width
+  }
+  return STEP.width
+}
+
+export const expectAllEdgesResolvable = (graph: FlowGraph) => {
+  const ids = new Set(graph.nodes.map(node => node.id))
+
+  for (const edge of graph.edges) {
+    expect(ids.has(edge.source), `Missing edge source "${edge.source}"`).toBe(
+      true
+    )
+    expect(ids.has(edge.target), `Missing edge target "${edge.target}"`).toBe(
+      true
+    )
+  }
+}
+
+export const expectUniqueGraphIds = (graph: FlowGraph) => {
+  const nodeIds = graph.nodes.map(node => node.id)
+  const edgeIds = graph.edges.map(edge => edge.id)
+
+  expect(new Set(nodeIds).size).toBe(nodeIds.length)
+  expect(new Set(edgeIds).size).toBe(edgeIds.length)
+}
+
+export const expectNodeRightOf = (
+  graph: FlowGraph,
+  rightNodeId: string,
+  leftNodeId: string,
+  clearance = 0
+) => {
+  const rightNode = getNode(graph, rightNodeId)
+  const leftNode = getNode(graph, leftNodeId)
+  const leftRight = leftNode.position.x + getNodeWidth(leftNode)
+
+  expect(rightNode.position.x).toBeGreaterThanOrEqual(leftRight + clearance)
+}
+
+export const expectNodeBelow = (
+  graph: FlowGraph,
+  lowerNodeId: string,
+  upperNodeId: string,
+  clearance = 0
+) => {
+  const lowerNode = getNode(graph, lowerNodeId)
+  const upperNode = getNode(graph, upperNodeId)
+  const upperBottom = upperNode.position.y + getNodeHeight(upperNode)
+
+  expect(lowerNode.position.y).toBeGreaterThanOrEqual(upperBottom + clearance)
+}
+
+export const expectSubflowNodesInsideParent = (graph: FlowGraph) => {
+  for (const node of graph.nodes) {
+    if (!node.parentId) {
+      continue
+    }
+
+    const parent = getNode(graph, node.parentId)
+    expect(node.position.x).toBeGreaterThanOrEqual(0)
+    expect(node.position.y).toBeGreaterThanOrEqual(0)
+    expect(node.position.x + getNodeWidth(node)).toBeLessThanOrEqual(
+      getNodeWidth(parent) + getNodeWidth(node)
+    )
+    expect(node.position.y + getNodeHeight(node)).toBeLessThanOrEqual(
+      getNodeHeight(parent) + getNodeHeight(node)
+    )
+  }
+}
+
+export const expectBranchEdge = (
+  edge: FlowEdge,
+  expected: {
+    branchStepId: string
+    branchIdx: number
+    branchesCount?: number
+    isSubflowEdge?: boolean
+  }
+) => {
+  expect(edge.data).toMatchObject({
+    isBranchEdge: true,
+    branchStepId: expected.branchStepId,
+    branchIdx: expected.branchIdx,
+  })
+  if (typeof expected.branchesCount === "number") {
+    expect(edge.data).toMatchObject({ branchesCount: expected.branchesCount })
+  }
+  if (expected.isSubflowEdge) {
+    expect(edge.data).toMatchObject({ isSubflowEdge: true })
+  }
+}
+
+export const expectLoopEdge = (
+  edge: FlowEdge,
+  expected: {
+    loopStepId: string
+    loopChildInsertIndex: number
+  }
+) => {
+  expect(edge.data).toMatchObject({
+    insertIntoLoopV2: true,
+    loopStepId: expected.loopStepId,
+    loopChildInsertIndex: expected.loopChildInsertIndex,
+  })
+}

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowTestAssertions.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/FlowTestAssertions.ts
@@ -51,6 +51,12 @@ export const getNodeWidth = (node: FlowNode) => {
   return STEP.width
 }
 
+const getContainedNodeWidth = (node: FlowNode) =>
+  node.type === "anchor-node" ? 0 : getNodeWidth(node)
+
+const getContainedNodeHeight = (node: FlowNode) =>
+  node.type === "anchor-node" ? 0 : getNodeHeight(node)
+
 export const expectAllEdgesResolvable = (graph: FlowGraph) => {
   const ids = new Set(graph.nodes.map(node => node.id))
 
@@ -107,11 +113,11 @@ export const expectSubflowNodesInsideParent = (graph: FlowGraph) => {
     const parent = getNode(graph, node.parentId)
     expect(node.position.x).toBeGreaterThanOrEqual(0)
     expect(node.position.y).toBeGreaterThanOrEqual(0)
-    expect(node.position.x + getNodeWidth(node)).toBeLessThanOrEqual(
-      getNodeWidth(parent) + getNodeWidth(node)
+    expect(node.position.x + getContainedNodeWidth(node)).toBeLessThanOrEqual(
+      getNodeWidth(parent)
     )
-    expect(node.position.y + getNodeHeight(node)).toBeLessThanOrEqual(
-      getNodeHeight(parent) + getNodeHeight(node)
+    expect(node.position.y + getContainedNodeHeight(node)).toBeLessThanOrEqual(
+      getNodeHeight(parent)
     )
   }
 }

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/edges/CustomEdge.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/edges/CustomEdge.svelte
@@ -24,6 +24,7 @@
     FLOW_ITEM_ACTION_BAR_WIDTH,
     LOOP_INSERT_ACTION_OFFSET,
   } from "../FlowGeometry"
+  import { getPrimaryBranchPath } from "../FlowEdgePaths"
   import {
     isBranchStep,
     AutomationActionStepId,
@@ -135,6 +136,16 @@
         isBranchTarget ? preBranchLabelX : labelX
       )
     : undefined
+  $: primaryBranchPath =
+    isBranchTarget && isPrimaryBranchEdge
+      ? getPrimaryBranchPath({
+          sourceX,
+          sourceY,
+          targetX,
+          targetY,
+          preBranchLabelX,
+        })
+      : undefined
 
   $: edgePath = isAnchorTarget
     ? getStraightPath({
@@ -143,7 +154,7 @@
         targetX: labelX,
         targetY: labelY,
       })[0]
-    : loopTargetPath || loopSourcePath || basePath[0]
+    : loopTargetPath || loopSourcePath || primaryBranchPath || basePath[0]
 
   $: blockId = resolveBlockId(data?.block as FlowBlockContext | undefined)
   $: blockRef = blockId ? $selectedAutomation?.blockRefs?.[blockId] : undefined

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/test/AutomationStepHelpers.test.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/test/AutomationStepHelpers.test.ts
@@ -7,7 +7,7 @@ import {
   branchStep,
   nestedLoopBranchAutomation,
 } from "@/test/automationFixtures"
-import { getLogStepData, processLogSteps } from "./AutomationStepHelpers"
+import { getLogStepData, processLogSteps } from "../AutomationStepHelpers"
 
 vi.mock("@/stores/builder", () => {
   return {

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/test/FlowEdgePaths.test.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/test/FlowEdgePaths.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
-import { FLOW_ITEM_ACTION_BAR_WIDTH } from "./FlowGeometry"
-import { getPrimaryBranchPath } from "./FlowEdgePaths"
+import { FLOW_ITEM_ACTION_BAR_WIDTH } from "../FlowCanvas/FlowGeometry"
+import { getPrimaryBranchPath } from "../FlowCanvas/FlowEdgePaths"
 
 const expectLineSegmentsToBeOrthogonal = (path: string) => {
   const commands = [

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/test/FlowGraphBuilder.test.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/test/FlowGraphBuilder.test.ts
@@ -10,12 +10,12 @@ import {
   loopWithLinearChildrenStep,
   serverLogStep,
 } from "@/test/automationFixtures"
-import { renderChain, renderLoopV2Container } from "./FlowGraphBuilder"
+import { renderChain, renderLoopV2Container } from "../FlowCanvas/FlowGraphBuilder"
 import {
   FLOW_ITEM_ACTION_BAR_WIDTH,
   LOOP_INSERT_ACTION_OFFSET,
   STEP,
-} from "./FlowGeometry"
+} from "../FlowCanvas/FlowGeometry"
 import {
   expectAllEdgesResolvable,
   expectBranchEdge,
@@ -24,7 +24,7 @@ import {
   expectUniqueGraphIds,
   getEdge,
   getNode,
-} from "./FlowTestAssertions"
+} from "../FlowCanvas/FlowTestAssertions"
 
 const createGraph = () => ({
   nodes: [] as FlowNode[],

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/test/FlowGraphBuilder.test.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/test/FlowGraphBuilder.test.ts
@@ -10,7 +10,10 @@ import {
   loopWithLinearChildrenStep,
   serverLogStep,
 } from "@/test/automationFixtures"
-import { renderChain, renderLoopV2Container } from "../FlowCanvas/FlowGraphBuilder"
+import {
+  renderChain,
+  renderLoopV2Container,
+} from "../FlowCanvas/FlowGraphBuilder"
 import {
   FLOW_ITEM_ACTION_BAR_WIDTH,
   LOOP_INSERT_ACTION_OFFSET,

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/test/FlowLayout.test.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/test/FlowLayout.test.ts
@@ -4,17 +4,17 @@ import {
   applyBranchLaneClearance,
   applyLoopClearance,
   applyPostLoopBranchClearance,
-} from "./FlowLayout"
+} from "../FlowCanvas/FlowLayout"
 import {
   FLOW_ITEM_ACTION_BAR_WIDTH,
   LOOP,
   LOOP_INSERT_ACTION_OFFSET,
-} from "./FlowGeometry"
+} from "../FlowCanvas/FlowGeometry"
 import {
   expectNodeBelow,
   expectNodeRightOf,
   getNode,
-} from "./FlowTestAssertions"
+} from "../FlowCanvas/FlowTestAssertions"
 
 const cloneGraph = (graph: { nodes: FlowNode[]; edges: FlowEdge[] }) =>
   JSON.parse(JSON.stringify(graph)) as { nodes: FlowNode[]; edges: FlowEdge[] }

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/test/FlowTestAssertions.test.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/test/FlowTestAssertions.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import type { Edge as FlowEdge, Node as FlowNode } from "@xyflow/svelte"
+import { expectSubflowNodesInsideParent } from "../FlowCanvas/FlowTestAssertions"
+
+const createGraph = (childPosition: { x: number; y: number }) => ({
+  nodes: [
+    {
+      id: "parent",
+      type: "loop-subflow-node",
+      data: { containerWidth: 360, containerHeight: 120 },
+      position: { x: 0, y: 0 },
+    },
+    {
+      id: "child",
+      parentId: "parent",
+      type: "step-node",
+      data: {},
+      position: childPosition,
+    },
+  ] as FlowNode[],
+  edges: [] as FlowEdge[],
+})
+
+describe("expectSubflowNodesInsideParent", () => {
+  it("allows child nodes that fit inside their parent bounds", () => {
+    expect(() =>
+      expectSubflowNodesInsideParent(createGraph({ x: 0, y: 0 }))
+    ).not.toThrow()
+  })
+
+  it("fails when child nodes overflow their parent bounds", () => {
+    expect(() =>
+      expectSubflowNodesInsideParent(createGraph({ x: 1, y: 1 }))
+    ).toThrow()
+  })
+
+  it("allows anchor handle positions on the parent boundary", () => {
+    const graph = createGraph({ x: 0, y: 0 })
+    graph.nodes[1] = {
+      id: "anchor",
+      parentId: "parent",
+      type: "anchor-node",
+      data: {},
+      position: { x: 360, y: 120 },
+    } as FlowNode
+
+    expect(() => expectSubflowNodesInsideParent(graph)).not.toThrow()
+  })
+})

--- a/packages/builder/src/test/automationFixtures.ts
+++ b/packages/builder/src/test/automationFixtures.ts
@@ -52,37 +52,63 @@ export const serverLogStep = (id: string): ServerLogStep => ({
   schema: automationSchema,
 })
 
-export const branchStep = (children: AutomationStep[] = []): BranchStep => ({
-  id: "branch",
-  stepId: AutomationActionStepId.BRANCH,
-  type: AutomationStepType.LOGIC,
-  name: "Branch",
-  tagline: "",
-  icon: "",
-  description: "",
-  inputs: {
-    branches: [
-      {
-        id: "matched",
-        name: "Matched",
-        condition: {},
-      },
-      {
-        id: "fallback",
-        name: "Fallback",
-        condition: {},
-      },
-    ],
-    children: {
-      matched: children,
-      fallback: [],
-    },
-  },
-  schema: automationSchema,
-})
+interface BranchStepOptions {
+  id?: string
+  branches?: Array<{
+    id: string
+    name: string
+    children?: AutomationStep[]
+  }>
+}
 
-export const loopStep = (children: AutomationStep[] = []): LoopV2Step => ({
-  id: "loop",
+export const branchStep = (
+  children: AutomationStep[] = [],
+  options: BranchStepOptions = {}
+): BranchStep => {
+  const branches = options.branches || [
+    {
+      id: "matched",
+      name: "Matched",
+      children,
+    },
+    {
+      id: "fallback",
+      name: "Fallback",
+      children: [],
+    },
+  ]
+
+  return {
+    id: options.id || "branch",
+    stepId: AutomationActionStepId.BRANCH,
+    type: AutomationStepType.LOGIC,
+    name: "Branch",
+    tagline: "",
+    icon: "",
+    description: "",
+    inputs: {
+      branches: branches.map(branch => ({
+        id: branch.id,
+        name: branch.name,
+        condition: {},
+      })),
+      children: branches.reduce<Record<string, AutomationStep[]>>(
+        (acc, branch) => {
+          acc[branch.id] = branch.children || []
+          return acc
+        },
+        {}
+      ),
+    },
+    schema: automationSchema,
+  }
+}
+
+export const loopStep = (
+  children: AutomationStep[] = [],
+  id = "loop"
+): LoopV2Step => ({
+  id,
   stepId: AutomationActionStepId.LOOP_V2,
   type: AutomationStepType.LOGIC,
   name: "Loop",
@@ -96,6 +122,118 @@ export const loopStep = (children: AutomationStep[] = []): LoopV2Step => ({
   },
   schema: automationSchema,
 })
+
+export const automationWithSteps = (steps: AutomationStep[]): Automation => ({
+  name: "Automation",
+  appId: "app",
+  type: "automation",
+  definition: {
+    trigger: automationTrigger,
+    steps,
+  },
+})
+
+export const linearAutomationSteps = () => [
+  serverLogStep("step-1"),
+  serverLogStep("step-2"),
+  serverLogStep("step-3"),
+]
+
+export const branchWithManyLanesStep = () =>
+  branchStep([], {
+    id: "branch-many",
+    branches: [
+      {
+        id: "alpha",
+        name: "Alpha",
+        children: [serverLogStep("alpha-1"), serverLogStep("alpha-2")],
+      },
+      {
+        id: "beta",
+        name: "Beta",
+        children: [],
+      },
+      {
+        id: "gamma",
+        name: "Gamma",
+        children: [serverLogStep("gamma-1")],
+      },
+      {
+        id: "delta",
+        name: "Delta",
+        children: [loopStep([serverLogStep("delta-loop-child")], "delta-loop")],
+      },
+    ],
+  })
+
+export const loopWithLinearChildrenStep = () =>
+  loopStep(
+    [
+      serverLogStep("loop-child-1"),
+      serverLogStep("loop-child-2"),
+      serverLogStep("loop-child-3"),
+    ],
+    "linear-loop"
+  )
+
+export const loopWithBranchChildStep = () =>
+  loopStep(
+    [
+      serverLogStep("loop-before-branch"),
+      branchStep([], {
+        id: "loop-branch",
+        branches: [
+          {
+            id: "first",
+            name: "First",
+            children: [serverLogStep("loop-branch-first-child")],
+          },
+          {
+            id: "second",
+            name: "Second",
+            children: [
+              serverLogStep("loop-branch-second-child-1"),
+              serverLogStep("loop-branch-second-child-2"),
+            ],
+          },
+          {
+            id: "empty",
+            name: "Empty",
+            children: [],
+          },
+        ],
+      }),
+      serverLogStep("loop-after-branch"),
+    ],
+    "loop-with-branch"
+  )
+
+export const exhaustiveAutomationSteps = () => [
+  serverLogStep("start"),
+  loopWithBranchChildStep(),
+  branchStep([], {
+    id: "post-loop-branch",
+    branches: [
+      {
+        id: "success",
+        name: "Success",
+        children: [serverLogStep("success-child")],
+      },
+      {
+        id: "fallback",
+        name: "Fallback",
+        children: [
+          loopStep([serverLogStep("fallback-loop-child")], "fallback-loop"),
+        ],
+      },
+      {
+        id: "empty",
+        name: "Empty",
+        children: [],
+      },
+    ],
+  }),
+]
 
 export const automationBlockDefinitions: BlockDefinitions = {
   TRIGGER: {},

--- a/packages/builder/src/test/automationFixtures.ts
+++ b/packages/builder/src/test/automationFixtures.ts
@@ -208,33 +208,6 @@ export const loopWithBranchChildStep = () =>
     "loop-with-branch"
   )
 
-export const exhaustiveAutomationSteps = () => [
-  serverLogStep("start"),
-  loopWithBranchChildStep(),
-  branchStep([], {
-    id: "post-loop-branch",
-    branches: [
-      {
-        id: "success",
-        name: "Success",
-        children: [serverLogStep("success-child")],
-      },
-      {
-        id: "fallback",
-        name: "Fallback",
-        children: [
-          loopStep([serverLogStep("fallback-loop-child")], "fallback-loop"),
-        ],
-      },
-      {
-        id: "empty",
-        name: "Empty",
-        children: [],
-      },
-    ],
-  }),
-]
-
 export const automationBlockDefinitions: BlockDefinitions = {
   TRIGGER: {},
   CREATABLE_TRIGGER: {},


### PR DESCRIPTION
## Description
Fix automation branch edge routing so primary branch paths stay orthogonal and align with the action bar. Adds regression coverage for odd and even branch fanouts, including curved turns between vertical and horizontal segments.

For the fix, I was able to verify that the tests added did catch the issue. 

## Addresses
- https://github.com/Budibase/budibase/issues/18645

## Screenshots
<img width="691" height="532" alt="Screenshot 2026-05-19 at 09 22 59" src="https://github.com/user-attachments/assets/336bfdc8-238d-42b0-a397-44e85adb0e08" />

*The middle branch was previously slightly off centre*

## Launchcontrol
Automation branch edges now route with orthogonal segments only, and the middle branch of odd fanouts stays aligned with the source path.
