### PR TITLE
Fix condition drawer bindable inputs

### DIFF
--- a/packages/builder/src/components/common/bindings/DrawerBindableSlot.svelte
+++ b/packages/builder/src/components/common/bindings/DrawerBindableSlot.svelte
@@ -100,7 +100,9 @@
   }
 
   const isValidBoolean = value => {
-    return value === "false" || value === "true" || value == ""
+    return (
+      value == null || value === "false" || value === "true" || value === ""
+    )
   }
 
   const validationMap = {
@@ -131,6 +133,9 @@
     if (type === "json" && !isJSBinding(value)) {
       return "json-slot-icon"
     }
+    if (type === "date" || type === "datetime") {
+      return "date-slot-icon"
+    }
     if (
       ![
         "string",
@@ -150,7 +155,12 @@
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
-<div class="control" class:disabled>
+<div
+  class="control"
+  class:disabled
+  class:date-slot={type === "date" || type === "datetime"}
+  class:boolean-slot={type === "boolean"}
+>
   {#if !isValid(value) && !showComponent}
     <Input
       {label}
@@ -212,11 +222,17 @@
     position: relative;
   }
 
-  .slot-icon {
+  .slot-icon,
+  .date-slot-icon {
     right: 34px !important;
     border-right: 1px solid var(--spectrum-alias-border-color);
     border-top-right-radius: 0px !important;
     border-bottom-right-radius: 0px !important;
+  }
+
+  .control.boolean-slot {
+    border: 1px solid var(--spectrum-alias-border-color);
+    border-radius: 4px;
   }
 
   .icon.close {
@@ -264,5 +280,36 @@
 
   .control:not(.disabled) :global(.spectrum-Textfield-input) {
     padding-right: 40px;
+  }
+
+  .control.date-slot:not(.disabled)
+    :global(.spectrum-Datepicker .spectrum-Textfield-input) {
+    padding-right: 40px;
+  }
+
+  .control.date-slot :global(.spectrum-Datepicker) {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 34px 34px;
+    min-inline-size: 0;
+    min-width: 0;
+  }
+
+  .control.date-slot :global(.spectrum-Datepicker .spectrum-Textfield) {
+    grid-column: 1 / 3;
+    grid-row: 1;
+    min-width: 0;
+  }
+
+  .control.date-slot :global(.spectrum-Datepicker .spectrum-InputGroup-button) {
+    grid-column: 3;
+    grid-row: 1;
+    inline-size: 34px;
+    width: 34px;
+    min-inline-size: 34px;
+    min-width: 34px;
+  }
+
+  .date-slot-icon {
+    right: 34px !important;
   }
 </style>

--- a/packages/builder/src/components/design/settings/controls/ButtonConditionEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonConditionEditor.svelte
@@ -182,6 +182,19 @@
       : String(condition.referenceValue)
   }
 
+  const normaliseBooleanReferenceValue = (
+    condition: ComponentCondition
+  ): ComponentCondition => {
+    if (condition.valueType === "boolean") {
+      if (condition.referenceValue === "True") {
+        condition.referenceValue = "true"
+      } else if (condition.referenceValue === "False") {
+        condition.referenceValue = "false"
+      }
+    }
+    return condition
+  }
+
   const onOperatorChange = (
     condition: ComponentCondition,
     newOperator: ArrayOperator | BasicOperator
@@ -261,7 +274,7 @@
         condition.valueType = "string"
         condition.type = FieldType.STRING
       }
-      return condition
+      return normaliseBooleanReferenceValue(condition)
     })
     drawer.show()
   }

--- a/packages/builder/src/components/design/settings/controls/ButtonConditionEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonConditionEditor.svelte
@@ -11,6 +11,7 @@
     DatePicker,
   } from "@budibase/bbui"
   import DrawerBindableInput from "@/components/common/bindings/DrawerBindableInput.svelte"
+  import DrawerBindableSlot from "@/components/common/bindings/DrawerBindableSlot.svelte"
   import { QueryUtils, Constants } from "@budibase/frontend-core"
   import { generate } from "shortid"
   import { dndzone } from "svelte-dnd-action"
@@ -61,7 +62,7 @@
   const valueTypeOptions = [
     {
       value: "string",
-      label: "Binding",
+      label: "Text",
     },
     {
       value: "number",
@@ -76,6 +77,7 @@
       label: "Boolean",
     },
   ]
+  const bindingValueTypes = ["string", "Binding"]
 
   const valueTypeToFieldTypeMap: Record<
     ComponentCondition["valueType"],
@@ -162,8 +164,22 @@
 
   const getOperatorOptions = (condition: ComponentCondition) => {
     return QueryUtils.getValidOperatorsForType({
-      type: condition.type as FieldType,
+      type: getEffectiveType(condition),
     })
+  }
+
+  const getEffectiveType = (condition: ComponentCondition): FieldType => {
+    return String(condition.valueType) === "Binding"
+      ? FieldType.STRING
+      : (condition.type as FieldType)
+  }
+
+  const getReferenceValue = (
+    condition: ComponentCondition
+  ): string | undefined => {
+    return condition.referenceValue == null
+      ? undefined
+      : String(condition.referenceValue)
   }
 
   const onOperatorChange = (
@@ -188,6 +204,9 @@
   ) => {
     condition.referenceValue = null
     condition.valueType = newValueType
+    if (newValueType === "boolean") {
+      condition.referenceValue = "true"
+    }
 
     condition.type = valueTypeToFieldTypeMap[newValueType]
 
@@ -237,6 +256,10 @@
           datetime: "datetime",
         }
         condition.valueType = typeToValueTypeMap[condition.type] || "string"
+      }
+      if (String(condition.valueType) === "Binding") {
+        condition.valueType = "string"
+        condition.type = FieldType.STRING
       }
       return condition
     })
@@ -353,28 +376,55 @@
                   on:change={e => onValueTypeChange(condition, e.detail)}
                   popoverAutoWidth
                 />
-                {#if ["string", "number"].includes(condition.valueType)}
+                {#if bindingValueTypes.includes(condition.valueType) || condition.valueType === "number"}
                   <DrawerBindableInput
                     disabled={condition.noValue}
                     {bindings}
                     placeholder="Value"
                     value={condition.referenceValue}
+                    inputType={condition.valueType === "number"
+                      ? "number"
+                      : undefined}
                     on:change={e => (condition.referenceValue = e.detail)}
                   />
                 {:else if condition.valueType === "datetime"}
-                  <DatePicker
-                    placeholder="Value"
+                  <DrawerBindableSlot
+                    title="Value"
+                    type="date"
+                    value={getReferenceValue(condition)}
+                    on:change={e => (condition.referenceValue = e.detail)}
+                    {bindings}
+                    updateOnChange={false}
                     disabled={condition.noValue}
-                    bind:value={condition.referenceValue}
-                  />
+                  >
+                    <DatePicker
+                      placeholder="Value"
+                      disabled={condition.noValue}
+                      value={condition.referenceValue}
+                      on:change={e => (condition.referenceValue = e.detail)}
+                    />
+                  </DrawerBindableSlot>
                 {:else if condition.valueType === "boolean"}
-                  <Select
-                    placeholder="Value"
+                  <DrawerBindableSlot
+                    title="Value"
+                    type="boolean"
+                    value={getReferenceValue(condition)}
+                    on:change={e => (condition.referenceValue = e.detail)}
+                    {bindings}
+                    updateOnChange={false}
                     disabled={condition.noValue}
-                    options={["True", "False"]}
-                    bind:value={condition.referenceValue}
-                    popoverAutoWidth
-                  />
+                  >
+                    <Select
+                      placeholder={false}
+                      disabled={condition.noValue}
+                      options={[
+                        { label: "True", value: "true" },
+                        { label: "False", value: "false" },
+                      ]}
+                      bind:value={condition.referenceValue}
+                      popoverAutoWidth
+                    />
+                  </DrawerBindableSlot>
                 {/if}
                 <Icon
                   name="copy"

--- a/packages/builder/src/components/design/settings/controls/ButtonConditionEditor.svelte
+++ b/packages/builder/src/components/design/settings/controls/ButtonConditionEditor.svelte
@@ -171,7 +171,7 @@
   const getEffectiveType = (condition: ComponentCondition): FieldType => {
     return String(condition.valueType) === "Binding"
       ? FieldType.STRING
-      : (condition.type as FieldType)
+      : condition.type
   }
 
   const getReferenceValue = (

--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Component/ConditionalUIDrawer.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Component/ConditionalUIDrawer.svelte
@@ -83,7 +83,18 @@
     if (link.valueType === "Binding") {
       link.valueType = "string"
     }
+    normaliseBooleanReferenceValue(link)
   })
+
+  const normaliseBooleanReferenceValue = condition => {
+    if (condition.valueType === "boolean") {
+      if (condition.referenceValue === "True") {
+        condition.referenceValue = "true"
+      } else if (condition.referenceValue === "False") {
+        condition.referenceValue = "false"
+      }
+    }
+  }
 
   const makeLabel = setting => {
     const { section, label } = setting

--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Component/ConditionalUIDrawer.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Component/ConditionalUIDrawer.svelte
@@ -12,6 +12,7 @@
   import { dndzone } from "svelte-dnd-action"
   import { generate } from "shortid"
   import DrawerBindableInput from "@/components/common/bindings/DrawerBindableInput.svelte"
+  import DrawerBindableSlot from "@/components/common/bindings/DrawerBindableSlot.svelte"
   import { QueryUtils, Constants } from "@budibase/frontend-core"
   import { selectedComponent, componentStore } from "@/stores/builder"
   import { getComponentForSetting } from "@/components/design/settings/componentSettingsRegistry"
@@ -41,7 +42,7 @@
   const valueTypeOptions = [
     {
       value: "string",
-      label: "Binding",
+      label: "Text",
     },
     {
       value: "number",
@@ -56,6 +57,7 @@
       label: "Boolean",
     },
   ]
+  const bindingValueTypes = ["string", "Binding"]
 
   let dragDisabled = true
 
@@ -77,6 +79,9 @@
   $: conditions.forEach(link => {
     if (!link.id) {
       link.id = generate()
+    }
+    if (link.valueType === "Binding") {
+      link.valueType = "string"
     }
   })
 
@@ -125,7 +130,13 @@
   }
 
   const getOperatorOptions = condition => {
-    return QueryUtils.getValidOperatorsForType({ type: condition.valueType })
+    return QueryUtils.getValidOperatorsForType({
+      type: getEffectiveValueType(condition),
+    })
+  }
+
+  const getEffectiveValueType = condition => {
+    return condition.valueType === "Binding" ? "string" : condition.valueType
   }
 
   const onOperatorChange = (condition, newOperator) => {
@@ -142,6 +153,9 @@
 
   const onValueTypeChange = (condition, newType) => {
     condition.referenceValue = null
+    if (newType === "boolean") {
+      condition.referenceValue = "true"
+    }
 
     // Ensure a valid operator is set
     const validOperators = QueryUtils.getValidOperatorsForType({
@@ -260,28 +274,55 @@
                 on:change={e => onValueTypeChange(condition, e.detail)}
                 popoverAutoWidth
               />
-              {#if ["string", "number"].includes(condition.valueType)}
+              {#if bindingValueTypes.includes(condition.valueType) || condition.valueType === "number"}
                 <DrawerBindableInput
                   disabled={condition.noValue}
                   {bindings}
                   placeholder="Value"
                   value={condition.referenceValue}
+                  inputType={condition.valueType === "number"
+                    ? "number"
+                    : undefined}
                   on:change={e => (condition.referenceValue = e.detail)}
                 />
               {:else if condition.valueType === "datetime"}
-                <DatePicker
-                  placeholder="Value"
+                <DrawerBindableSlot
+                  title="Value"
+                  type="date"
+                  value={condition.referenceValue}
+                  on:change={e => (condition.referenceValue = e.detail)}
+                  {bindings}
+                  updateOnChange={false}
                   disabled={condition.noValue}
-                  bind:value={condition.referenceValue}
-                />
+                >
+                  <DatePicker
+                    placeholder="Value"
+                    disabled={condition.noValue}
+                    value={condition.referenceValue}
+                    on:change={e => (condition.referenceValue = e.detail)}
+                  />
+                </DrawerBindableSlot>
               {:else if condition.valueType === "boolean"}
-                <Select
-                  placeholder="Value"
+                <DrawerBindableSlot
+                  title="Value"
+                  type="boolean"
+                  value={condition.referenceValue}
+                  on:change={e => (condition.referenceValue = e.detail)}
+                  {bindings}
+                  updateOnChange={false}
                   disabled={condition.noValue}
-                  options={["True", "False"]}
-                  bind:value={condition.referenceValue}
-                  popoverAutoWidth
-                />
+                >
+                  <Select
+                    placeholder={false}
+                    disabled={condition.noValue}
+                    options={[
+                      { label: "True", value: "true" },
+                      { label: "False", value: "false" },
+                    ]}
+                    bind:value={condition.referenceValue}
+                    popoverAutoWidth
+                  />
+                </DrawerBindableSlot>
               {/if}
               <Icon
                 name="copy"


### PR DESCRIPTION
## Description
Remove the legacy Binding option from condition drawers and make the value input type-aware while preserving existing Binding configs.

## Addresses
- https://github.com/Budibase/budibase/issues/17535

## Screenshots
<img width="1858" height="395" alt="conditions date JS binding" src="https://github.com/user-attachments/assets/f2616ccd-f6f7-4dd5-a306-591a32b667ea" />

**JS Date binding value**

<img width="1869" height="222" alt="bindable boolean" src="https://github.com/user-attachments/assets/8c62c4df-3100-4b72-839d-094436eea2dc" />

**Bindable boolean value**

<img width="1869" height="490" alt="conditions date calendar" src="https://github.com/user-attachments/assets/d0658144-1612-40b4-8300-f2f422512879" />

**Direct Date value from calendar**

<img width="1869" height="191" alt="date text binding" src="https://github.com/user-attachments/assets/6a720e94-69f6-4554-b336-ff765a4268a0" />

**Free-form date binding from text**

## Attachment (with example binding conditions)
[condition-bindings.gz](https://github.com/user-attachments/files/28013613/condition-bindings.gz)

## Launchcontrol
Make condition drawer value inputs type-aware, including bindable date and boolean controls, while keeping legacy Binding values working.

