### PR TITLE
Feat/helm chart ops

### DIFF
--- a/charts/budibase/templates/litellm-service-deployment.yaml
+++ b/charts/budibase/templates/litellm-service-deployment.yaml
@@ -29,6 +29,10 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: {{ .Values.services.litellm.port }}
+          {{- if .Values.services.litellm.startupProbe }}
+          startupProbe:
+            {{- toYaml .Values.services.litellm.startupProbe | nindent 12 }}
+          {{- end }}
           args:
             - --config
             - /app/config.yaml

--- a/charts/budibase/tests/app_service_deployment_test.yaml
+++ b/charts/budibase/tests/app_service_deployment_test.yaml
@@ -124,17 +124,17 @@ tests:
             name: APP_FEATURES
             value: "api"
 
-  - it: should set terminationGracePeriodSeconds to 75 by default
+  - it: should set terminationGracePeriodSeconds to 70 by default
     asserts:
       - equal:
           path: spec.template.spec.terminationGracePeriodSeconds
-          value: 75
+          value: 70
 
-  - it: should set preStop sleep to 40 by default
+  - it: should set preStop sleep to 45 by default
     asserts:
       - equal:
           path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
-          value: ["sleep", "40"]
+          value: ["sleep", "45"]
 
   - it: should not render readinessGates by default
     asserts:

--- a/charts/budibase/tests/automation_worker_deployment_test.yaml
+++ b/charts/budibase/tests/automation_worker_deployment_test.yaml
@@ -98,21 +98,21 @@ tests:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 4002
 
-  - it: should set terminationGracePeriodSeconds to 75 by default
+  - it: should set terminationGracePeriodSeconds to 70 by default
     set:
       services.automationWorkers.enabled: true
     asserts:
       - equal:
           path: spec.template.spec.terminationGracePeriodSeconds
-          value: 75
+          value: 70
 
-  - it: should set preStop sleep to 40 by default
+  - it: should set preStop sleep to 45 by default
     set:
       services.automationWorkers.enabled: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
-          value: ["sleep", "40"]
+          value: ["sleep", "45"]
 
   - it: should not render readinessGates by default
     set:

--- a/charts/budibase/tests/proxy_service_deployment_test.yaml
+++ b/charts/budibase/tests/proxy_service_deployment_test.yaml
@@ -96,17 +96,17 @@ tests:
           path: spec.template.spec.imagePullSecrets[0].name
           value: my-pull-secret
 
-  - it: should set terminationGracePeriodSeconds to 75 by default
+  - it: should set terminationGracePeriodSeconds to 70 by default
     asserts:
       - equal:
           path: spec.template.spec.terminationGracePeriodSeconds
-          value: 75
+          value: 70
 
-  - it: should set preStop sleep to 40 by default
+  - it: should set preStop sleep to 45 by default
     asserts:
       - equal:
           path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
-          value: ["sleep", "40"]
+          value: ["sleep", "45"]
 
   - it: should not render readinessGates by default
     asserts:

--- a/charts/budibase/tests/worker_service_deployment_test.yaml
+++ b/charts/budibase/tests/worker_service_deployment_test.yaml
@@ -136,17 +136,17 @@ tests:
             name: SMTP_HOST
             value: "smtp.example.com"
 
-  - it: should set terminationGracePeriodSeconds to 75 by default
+  - it: should set terminationGracePeriodSeconds to 70 by default
     asserts:
       - equal:
           path: spec.template.spec.terminationGracePeriodSeconds
-          value: 75
+          value: 70
 
-  - it: should set preStop sleep to 40 by default
+  - it: should set preStop sleep to 45 by default
     asserts:
       - equal:
           path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
-          value: ["sleep", "40"]
+          value: ["sleep", "45"]
 
   - it: should not render readinessGates by default
     asserts:

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -178,9 +178,9 @@ services:
       couchdb: "http://{{ .Release.Name }}-svc-couchdb:{{ .Values.services.couchdb.port }}"
     # -- The time in seconds to wait before sending SIGKILL after SIGTERM.
     # Must be greater than preStopDelaySeconds to allow graceful shutdown.
-    terminationGracePeriodSeconds: 75
+    terminationGracePeriodSeconds: 70
     # -- Seconds to sleep before SIGTERM to allow load balancer deregistration.
-    preStopDelaySeconds: 40
+    preStopDelaySeconds: 45
     # -- Pod readiness gates for the proxy pods. Useful for ALB target group
     # health tracking with the AWS Load Balancer Controller.
     # Example: [{conditionType: "target-health.elbv2.k8s.aws/my-tgb"}]
@@ -204,9 +204,11 @@ services:
         port: 10000
         scheme: HTTP
       # @ignore
-      failureThreshold: 40
+      failureThreshold: 24
       # @ignore
-      periodSeconds: 3
+      periodSeconds: 5
+      # @ignore
+      timeoutSeconds: 1
     # -- Readiness probe configuration for proxy pods. You shouldn't need to
     # change this, but if you want to you can find more information here:
     # <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/>
@@ -275,12 +277,12 @@ services:
     # -- The amount of time to wait between requesting a shutdown and killing the
     # container. This is used to give the apps service time to finish processing
     # any requests before shutting down. You shouldn't need to change this.
-    terminationGracePeriodSeconds: 75
+    terminationGracePeriodSeconds: 70
     # -- Seconds to wait after pod is Ready before adding to endpoints.
     # Ensures pods are stable before receiving traffic.
     minReadySeconds: 10
     # -- Seconds to sleep before SIGTERM to allow load balancer deregistration.
-    preStopDelaySeconds: 40
+    preStopDelaySeconds: 45
     # -- Pod readiness gates for the apps pods. Useful for ALB target group
     # health tracking with the AWS Load Balancer Controller.
     # Example: [{conditionType: "target-health.elbv2.k8s.aws/my-tgb"}]
@@ -310,9 +312,11 @@ services:
         port: 4002
         scheme: HTTP
       # @ignore
-      failureThreshold: 30
+      failureThreshold: 24
       # @ignore
-      periodSeconds: 3
+      periodSeconds: 5
+      # @ignore
+      timeoutSeconds: 1
     # -- Readiness probe configuration for apps pods. You shouldn't need to
     # change this, but if you want to you can find more information here:
     # <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/>
@@ -383,9 +387,9 @@ services:
     # the container. This is used to give the automation worker service time to
     # finish processing any requests before shutting down. You shouldn't need to
     # change this.
-    terminationGracePeriodSeconds: 75
+    terminationGracePeriodSeconds: 70
     # -- Seconds to sleep before SIGTERM to allow load balancer deregistration.
-    preStopDelaySeconds: 40
+    preStopDelaySeconds: 45
     # -- Pod readiness gates for the automation worker pods. Useful for ALB
     # target group health tracking with the AWS Load Balancer Controller.
     # Example: [{conditionType: "target-health.elbv2.k8s.aws/my-tgb"}]
@@ -416,9 +420,11 @@ services:
         port: 4002
         scheme: HTTP
       # @ignore
-      failureThreshold: 30
+      failureThreshold: 12
       # @ignore
-      periodSeconds: 3
+      periodSeconds: 30
+      # @ignore
+      timeoutSeconds: 1
     # -- Readiness probe configuration for automation worker pods. You shouldn't
     # need to change this, but if you want to you can find more information
     # here:
@@ -490,12 +496,12 @@ services:
     # the container. This is used to give the worker service time to finish
     # processing any requests before shutting down. You shouldn't need to change
     # this.
-    terminationGracePeriodSeconds: 75
+    terminationGracePeriodSeconds: 70
     # -- Seconds to wait after pod is Ready before adding to endpoints.
     # Ensures pods are stable before receiving traffic.
     minReadySeconds: 10
     # -- Seconds to sleep before SIGTERM to allow load balancer deregistration.
-    preStopDelaySeconds: 40
+    preStopDelaySeconds: 45
     # -- Pod readiness gates for the worker pods. Useful for ALB target group
     # health tracking with the AWS Load Balancer Controller.
     # Example: [{conditionType: "target-health.elbv2.k8s.aws/my-tgb"}]
@@ -525,9 +531,11 @@ services:
         port: 4003
         scheme: HTTP
       # @ignore
-      failureThreshold: 40
+      failureThreshold: 24
       # @ignore
-      periodSeconds: 3
+      periodSeconds: 5
+      # @ignore
+      timeoutSeconds: 1
     # -- Readiness probe configuration for worker pods. You shouldn't need to
     # change this, but if you want to you can find more information here:
     # <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/>
@@ -658,9 +666,9 @@ services:
     # -- Number of litellm replicas.
     replicaCount: 2
     # -- The time in seconds to wait before sending SIGKILL after SIGTERM.
-    terminationGracePeriodSeconds: 75
+    terminationGracePeriodSeconds: 70
     # -- Seconds to sleep before SIGTERM to allow load balancer deregistration.
-    preStopDelaySeconds: 40
+    preStopDelaySeconds: 45
     # -- Pod readiness gates for the litellm pods. Useful for ALB target group
     # health tracking with the AWS Load Balancer Controller.
     # Example: [{conditionType: "target-health.elbv2.k8s.aws/my-tgb"}]
@@ -669,6 +677,19 @@ services:
     # Requires podDisruptionBudget.enabled to be true.
     # Set minAvailable to override the global podDisruptionBudget.minAvailable for this service.
     pdb: {}
+    # -- Startup probe configuration for litellm pods. Uses a TCP socket check
+    # because litellm doesn't expose a dedicated /health endpoint on startup.
+    # @default -- TCP socket check on the litellm port.
+    startupProbe:
+      # @ignore
+      tcpSocket:
+        port: 4000
+      # @ignore
+      failureThreshold: 24
+      # @ignore
+      periodSeconds: 5
+      # @ignore
+      timeoutSeconds: 1
     # -- Resources for litellm pods.
     resources: {}
     # -- Extra environment variables for the litellm container.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a startup probe for the `litellm` service and tunes shutdown/probe timings across services to improve rollout stability and health check reliability. Updates defaults and tests to match the new timings.

- **New Features**
  - Added optional `services.litellm.startupProbe` (default TCP check on port 4000) and rendered it in the deployment.

- **Refactors**
  - Set default `terminationGracePeriodSeconds` to 70 and `preStopDelaySeconds` to 45 across services.
  - Probe tuning: lowered failureThresholds (proxy/apps/worker: 24; automation worker: 12), increased periodSeconds (proxy/apps/worker: 5s; automation worker: 30s), and added a 1s timeout.
  - Updated Helm tests to reflect the new defaults.

<sup>Written for commit b909b4dc78635ebddd0a9a58ca0cc01f263c0ff2. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18825?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

