### PR TITLE
Fix loop step light theme styling

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/nodes/LoopV2Node.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/nodes/LoopV2Node.svelte
@@ -139,10 +139,18 @@
   }
 
   :global(.svelte-flow__node-loop-subflow-node) {
-    background: rgba(255, 255, 255, 0.01) !important;
-    border: 1.5px solid rgba(255, 255, 255, 0.1) !important;
+    background: rgba(255, 255, 255, 0.45) !important;
+    border: 1.5px solid var(--spectrum-global-color-gray-300) !important;
     border-radius: 16px !important;
     transition: all 0.2s ease !important;
+  }
+
+  :global(.spectrum--dark) :global(.svelte-flow__node-loop-subflow-node),
+  :global(.spectrum--darkest) :global(.svelte-flow__node-loop-subflow-node),
+  :global(.spectrum--midnight) :global(.svelte-flow__node-loop-subflow-node),
+  :global(.spectrum--nord) :global(.svelte-flow__node-loop-subflow-node) {
+    background: rgba(255, 255, 255, 0.01) !important;
+    border-color: rgba(255, 255, 255, 0.1) !important;
   }
 
   :global(.svelte-flow__node-loop-subflow-node:has(.loop-container.selected)) {
@@ -150,6 +158,16 @@
   }
 
   :global(.svelte-flow__node-loop-subflow-node:hover) {
+    border-color: var(--spectrum-global-color-gray-400) !important;
+    background: rgba(255, 255, 255, 0.6) !important;
+  }
+
+  :global(.spectrum--dark) :global(.svelte-flow__node-loop-subflow-node:hover),
+  :global(.spectrum--darkest)
+    :global(.svelte-flow__node-loop-subflow-node:hover),
+  :global(.spectrum--midnight)
+    :global(.svelte-flow__node-loop-subflow-node:hover),
+  :global(.spectrum--nord) :global(.svelte-flow__node-loop-subflow-node:hover) {
     border-color: rgba(255, 255, 255, 0.15) !important;
     background: rgba(255, 255, 255, 0.02) !important;
   }


### PR DESCRIPTION
## Description

Loop subflow nodes now keep a visible surface in light theme while preserving the internal edge lines and the existing dark-theme styling.

## Addresses
- https://github.com/Budibase/budibase/issues/18826

## Screenshots
<img width="653" height="277" alt="loop" src="https://github.com/user-attachments/assets/1c731e98-9398-484e-a132-175faac3e963" />


## Launchcontrol

Loop steps in light theme now show a visible container without hiding the edges inside the loop.\n