### PR TITLE
Fix loop node header in light theme

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/nodes/LoopV2Node.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/nodes/LoopV2Node.svelte
@@ -117,9 +117,9 @@
     align-items: center;
     gap: 6px;
     padding: 4px 10px;
-    background: rgba(255, 255, 255, 0.03);
+    background: rgba(255, 255, 255, 0.55);
     backdrop-filter: blur(4px);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    border: 1px solid var(--spectrum-global-color-gray-300);
     border-radius: 16px;
     z-index: 10;
   }
@@ -128,14 +128,36 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    color: rgba(255, 255, 255, 0.5);
+    color: var(--spectrum-global-color-gray-700);
   }
 
   .loop-label {
     font-size: 12px;
     font-weight: 500;
-    color: rgba(255, 255, 255, 0.6);
+    color: var(--spectrum-global-color-gray-800);
     letter-spacing: 0.2px;
+  }
+
+  :global(.spectrum--dark) .loop-header,
+  :global(.spectrum--darkest) .loop-header,
+  :global(.spectrum--midnight) .loop-header,
+  :global(.spectrum--nord) .loop-header {
+    background: rgba(255, 255, 255, 0.03);
+    border-color: rgba(255, 255, 255, 0.08);
+  }
+
+  :global(.spectrum--dark) .loop-icon-wrapper,
+  :global(.spectrum--darkest) .loop-icon-wrapper,
+  :global(.spectrum--midnight) .loop-icon-wrapper,
+  :global(.spectrum--nord) .loop-icon-wrapper {
+    color: rgba(255, 255, 255, 0.5);
+  }
+
+  :global(.spectrum--dark) .loop-label,
+  :global(.spectrum--darkest) .loop-label,
+  :global(.spectrum--midnight) .loop-label,
+  :global(.spectrum--nord) .loop-label {
+    color: rgba(255, 255, 255, 0.6);
   }
 
   :global(.svelte-flow__node-loop-subflow-node) {


### PR DESCRIPTION
## Description
Fixes the automation loop node header styling in light theme. The loop container was updated to use a translucent white background, but the header text, icon, and border still used low-opacity white values that became unreadable on the light background.

## Addresses
- https://github.com/Budibase/budibase/issues/18826

## Screenshots
<img width="884" height="513" alt="loop" src="https://github.com/user-attachments/assets/0505fb5f-9ec7-4b36-bbfe-01b8976caa5f" />

## Launchcontrol
Fixes loop node header contrast in light theme so the label, icon, and border remain visible.