### PR TITLE
Response buffering to avoid premature close errors in server

### DIFF
--- a/hosting/single/nginx/nginx-default-site.conf
+++ b/hosting/single/nginx/nginx-default-site.conf
@@ -27,6 +27,12 @@ server {
     }
 
     location /app {
+        # Buffer responses so client disconnects do not surface as upstream
+        # ERR_STREAM_PREMATURE_CLOSE errors in the server logs.
+        proxy_buffering on;
+        proxy_buffer_size 16k;
+        proxy_buffers 8 32k;
+
         proxy_pass      http://127.0.0.1:4001;
     }
 
@@ -54,6 +60,14 @@ server {
     }
 
     location ~ ^/(builder|app_) {
+        # Buffer static builder/app responses (HTML, JS chunks, fonts, images)
+        # so that browser cancels do not propagate to the upstream as
+        # ERR_STREAM_PREMATURE_CLOSE.
+        proxy_buffering on;
+        proxy_buffer_size 16k;
+        proxy_buffers 16 32k;
+        proxy_busy_buffers_size 64k;
+
         proxy_http_version  1.1;
         proxy_set_header    Connection          $connection_upgrade;
         proxy_set_header    Upgrade             $http_upgrade;
@@ -120,6 +134,12 @@ server {
         proxy_read_timeout 120s;
         proxy_connect_timeout 120s;
         proxy_send_timeout 120s;
+
+        # Buffer JSON API responses so client cancels (e.g. SPA navigation)
+        # do not surface as ERR_STREAM_PREMATURE_CLOSE on the upstream node.
+        proxy_buffering on;
+        proxy_buffer_size 16k;
+        proxy_buffers 8 32k;
 
         proxy_http_version  1.1;
         proxy_set_header    Connection          $connection_upgrade;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable response buffering in NGINX to prevent ERR_STREAM_PREMATURE_CLOSE when clients abort requests. Turned on proxy_buffering with tuned buffers for /app, builder/app_ static assets, and API routes to keep upstream logs clean with no user-visible change.

<sup>Written for commit d2268e56aae03654f8fb0ae45a97c8d3a0970960. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18849?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

