### PR TITLE
Custom ca support in single image and stale env directory fix

### DIFF
--- a/hosting/single/runner.sh
+++ b/hosting/single/runner.sh
@@ -77,6 +77,27 @@ repair_internal_couch_url() {
     fi
 }
 
+# Custom CA bundle support.
+# Mount the file at one of these paths:
+#   - ${DATA_DIR}/ca-bundle.pem
+#   - /etc/budibase/ca-bundle.pem
+# Or set CUSTOM_CA_BUNDLE_PATH to an explicit absolute path.
+CUSTOM_CA_BUNDLE_PATH="${CUSTOM_CA_BUNDLE_PATH:-}"
+if [[ -z "${CUSTOM_CA_BUNDLE_PATH}" ]]; then
+    for candidate in "${DATA_DIR}/ca-bundle.pem" "/etc/budibase/ca-bundle.pem"; do
+        if [[ -f "${candidate}" ]]; then
+            CUSTOM_CA_BUNDLE_PATH="${candidate}"
+            break
+        fi
+    done
+fi
+if [[ -n "${CUSTOM_CA_BUNDLE_PATH}" && -f "${CUSTOM_CA_BUNDLE_PATH}" ]]; then
+    echo "Installing custom CA bundle from ${CUSTOM_CA_BUNDLE_PATH}"
+    install -m 0644 "${CUSTOM_CA_BUNDLE_PATH}" /usr/local/share/ca-certificates/budibase-custom.crt
+    update-ca-certificates >/dev/null 2>&1 || echo "Warning: update-ca-certificates failed"
+    export NODE_EXTRA_CA_CERTS="${CUSTOM_CA_BUNDLE_PATH}"
+fi
+
 # Mount NFS or GCP Filestore if FILESHARE_IP and FILESHARE_NAME are set
 if [[ -n "${FILESHARE_IP}" && -n "${FILESHARE_NAME}" ]]; then
     echo "Mounting NFS share"
@@ -110,11 +131,39 @@ sync_couch_env_aliases
 
 # Randomize any unset sensitive environment variables using uuidgen
 env_vars=(COUCHDB_USER COUCHDB_PASSWORD MINIO_ACCESS_KEY MINIO_SECRET_KEY INTERNAL_API_KEY JWT_SECRET REDIS_PASSWORD LITELLM_MASTER_KEY LITELLM_SALT_KEY LITELLM_DB_PASSWORD)
+generated_vars=()
 for var in "${env_vars[@]}"; do
     if [[ -z "${!var}" ]]; then
         export "$var"="$(uuidgen | tr -d '-')"
+        generated_vars+=("$var")
     fi
 done
+
+# If ${DATA_DIR}/.env did not exist on this start, we just minted fresh
+# secrets. When ${DATA_DIR} is not backed by a persistent volume, those
+# secrets are regenerated on every restart, which invalidates JWTs,
+# encrypted session payloads and the redis AUTH password — the common
+# symptom is a flood of "Auth Error: Session not found" and 403
+# Unauthorized in the logs after the container restarts. Make this loud
+# so operators notice before they put the deployment in front of users.
+if [[ ! -f "${DATA_DIR}/.env" && "${#generated_vars[@]}" -gt 0 && "${BUDIBASE_ACK_EPHEMERAL_DATA:-0}" != "1" ]]; then
+    cat <<EOF >&2
+==============================================================================
+WARNING: ${DATA_DIR}/.env did not exist; generated fresh secrets for:
+  ${generated_vars[*]}
+
+If ${DATA_DIR} is NOT a persistent volume, these secrets will be regenerated
+on every container restart. That will:
+  - log every existing user out (Session not found / 403 Unauthorized)
+  - re-encrypt CouchDB/Redis credentials, breaking persisted data
+  - rotate JWT_SECRET, invalidating all signed tokens
+
+Mount a persistent volume at ${DATA_DIR} (docker -v / k8s PVC) BEFORE
+putting this container into production. Set BUDIBASE_ACK_EPHEMERAL_DATA=1
+to silence this warning.
+==============================================================================
+EOF
+fi
 
 repair_internal_couch_url
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds custom CA bundle support to the single-image runner. Also adds a startup warning when secrets are regenerated to help prevent silent auth/session issues.

- **New Features**
  - Custom CA: load a PEM from DATA_DIR/ca-bundle.pem, /etc/budibase/ca-bundle.pem, or an absolute CUSTOM_CA_BUNDLE_PATH; install into system trust and set NODE_EXTRA_CA_CERTS.
  - Startup safety: if DATA_DIR/.env is missing and secrets were generated, print a loud warning unless BUDIBASE_ACK_EPHEMERAL_DATA=1.

- **Migration**
  - To use a custom CA, mount the PEM at one of the supported paths or set CUSTOM_CA_BUNDLE_PATH. Ensure DATA_DIR is a persistent volume before production; set BUDIBASE_ACK_EPHEMERAL_DATA=1 to silence the warning in ephemeral envs.

<sup>Written for commit b2287ab819c7b00d2d313bf580ecbb31afaad672. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18850?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

