### PR TITLE
Handle midflight drop, 409 on concurrent

### DIFF
--- a/packages/server/src/sdk/workspace/automations/crud.ts
+++ b/packages/server/src/sdk/workspace/automations/crud.ts
@@ -159,7 +159,21 @@ export async function update(automation: Automation) {
     oldAuto: oldAutomation,
     newAuto: automation,
   })
-  const response = await db.put(automation)
+  
+  // Retry once against the latest rev if CouchDB reports a
+  // conflict.
+  let response: { rev: string; id: string }
+  try {
+    response = await db.put(automation)
+  } catch (err: any) {
+    // Surface a 409 on True concurrent updates.
+    if (err?.statusCode !== 409 && err?.status !== 409) {
+      throw err
+    }
+    const latest = await db.get<Automation>(automation._id)
+    automation._rev = latest._rev
+    response = await db.put(automation)
+  }
   automation._rev = response.rev
 
   const oldAutoTrigger =

--- a/packages/server/src/sdk/workspace/automations/crud.ts
+++ b/packages/server/src/sdk/workspace/automations/crud.ts
@@ -160,19 +160,17 @@ export async function update(automation: Automation) {
     newAuto: automation,
   })
 
-  // Retry once against the latest rev if CouchDB reports a
-  // conflict.
   let response: { rev: string; id: string }
   try {
     response = await db.put(automation)
   } catch (err: any) {
-    // Surface a 409 on True concurrent updates.
-    if (err?.statusCode !== 409 && err?.status !== 409) {
-      throw err
+    if (err?.statusCode === 409 || err?.status === 409) {
+      throw new HTTPError(
+        "This automation was modified by another user. Refresh and try again.",
+        409
+      )
     }
-    const latest = await db.get<Automation>(automation._id)
-    automation._rev = latest._rev
-    response = await db.put(automation)
+    throw err
   }
   automation._rev = response.rev
 

--- a/packages/server/src/sdk/workspace/automations/crud.ts
+++ b/packages/server/src/sdk/workspace/automations/crud.ts
@@ -159,7 +159,7 @@ export async function update(automation: Automation) {
     oldAuto: oldAutomation,
     newAuto: automation,
   })
-  
+
   // Retry once against the latest rev if CouchDB reports a
   // conflict.
   let response: { rev: string; id: string }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds explicit conflict handling for CouchDB automation updates. On concurrent edits, we return a clear HTTP 409 to the client instead of retrying.

- **Bug Fixes**
  - Catch `db.put` conflicts (409) and rethrow as HTTP 409: "This automation was modified by another user. Refresh and try again."
  - Non-409 errors pass through unchanged.

<sup>Written for commit 7ab5ceedd68b2a731871e5d0eb22de088a1da6dd. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18851?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

