### PR TITLE
Revert "Bump svelte from 5.40.2 to 5.55.7 in the all-non-major-security group across 1 directory"

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prettier-plugin-svelte": "^3.4.0",
     "proper-lockfile": "^4.1.2",
     "rollup-plugin-visualizer": "^6.0.3",
-    "svelte": "5.55.7",
+    "svelte": "5.40.2",
     "svelte-check": "^4.3.1",
     "svelte-eslint-parser": "^1.3.1",
     "svelte-preprocess": "^6.0.3",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -127,7 +127,7 @@
     "serialize-error": "^7.0.1",
     "snowflake-sdk": "^2.0.4",
     "socket.io": "4.8.1",
-    "svelte": "5.55.7",
+    "svelte": "5.40.2",
     "tar": "7.5.11",
     "tmp": "0.2.6",
     "to-json-schema": "0.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8490,12 +8490,7 @@ aria-query@5.3.0:
   dependencies:
     dequal "^2.0.3"
 
-aria-query@5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.1.tgz#ebcb2c0d7fc43e68e4cb22f774d1209cb627ab42"
-  integrity sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==
-
-aria-query@^5.0.0, aria-query@^5.3.0:
+aria-query@^5.0.0, aria-query@^5.3.0, aria-query@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
   integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
@@ -11123,11 +11118,6 @@ detective-typescript@^9.0.0, detective-typescript@^9.1.1:
     node-source-walk "^5.0.1"
     typescript "^4.9.5"
 
-devalue@^5.8.1:
-  version "5.8.1"
-  resolved "https://registry.yarnpkg.com/devalue/-/devalue-5.8.1.tgz#f27290d3a324e2eb20c2714369b01b8ec4de4c61"
-  integrity sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==
-
 devlop@^1.0.0, devlop@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/devlop/-/devlop-1.1.0.tgz#4db7c2ca4dc6e0e834c30be70c94bbc976dc7018"
@@ -12106,10 +12096,10 @@ esquery@^1.4.2, esquery@^1.5.0:
   dependencies:
     estraverse "^5.1.0"
 
-esrap@^2.2.4:
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/esrap/-/esrap-2.2.9.tgz#97b7939015dccfb8c00b0d3e1a2c8735ba46bac9"
-  integrity sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==
+esrap@^2.1.0:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/esrap/-/esrap-2.2.3.tgz#cbc5a6aad5349697b78ef7af62704e733a50d2c1"
+  integrity sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.15"
 
@@ -22143,23 +22133,21 @@ svelte-spa-router@^4.0.1:
   dependencies:
     regexparam "2.0.2"
 
-svelte@5.55.7:
-  version "5.55.7"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-5.55.7.tgz#04d19e5d4e8e5b6afd7e648c30ab434bb20bfc86"
-  integrity sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==
+svelte@5.40.2:
+  version "5.40.2"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-5.40.2.tgz#94f8e9e5d5d2a07fd703af7335c04fa0e22d354b"
+  integrity sha512-wr/SwBVCVfeHU8FZr48vRrzSpWdBBzGo5mlErjGzeW4reJhK/CWutLZbk/eHwhKqO17ccjeTcvsqjrT4aK3wZA==
   dependencies:
     "@jridgewell/remapping" "^2.3.4"
     "@jridgewell/sourcemap-codec" "^1.5.0"
     "@sveltejs/acorn-typescript" "^1.0.5"
     "@types/estree" "^1.0.5"
-    "@types/trusted-types" "^2.0.7"
     acorn "^8.12.1"
-    aria-query "5.3.1"
+    aria-query "^5.3.1"
     axobject-query "^4.1.0"
     clsx "^2.1.1"
-    devalue "^5.8.1"
     esm-env "^1.2.1"
-    esrap "^2.2.4"
+    esrap "^2.1.0"
     is-reference "^3.0.3"
     locate-character "^3.0.0"
     magic-string "^0.30.11"


### PR DESCRIPTION
Reverts Budibase/budibase#18814

Svelte versions beyond v5.40.0 cause a number of backwards compatibility issues. We need to migrate more components before pushing forward.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the recent `svelte` upgrade and pins to 5.40.2 to restore compatibility. This prevents breakages until we migrate affected components.

- **Dependencies**
  - Pin `svelte` to 5.40.2 in root and `packages/server` manifests.
  - Refresh `yarn.lock` to align transitive deps with 5.40.2.

<sup>Written for commit deb0f4791b99d9525a53479241fef2f84668f789. Summary will update on new commits. <a href="https://cubic.dev/pr/Budibase/budibase/pull/18858?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

