### PR TITLE
fix backup object export and restored app manifest recovery

### DIFF
--- a/packages/cli/src/backups/objectStore.ts
+++ b/packages/cli/src/backups/objectStore.ts
@@ -16,10 +16,36 @@ const {
 
 const bucketList = Object.values(ObjectStoreBuckets)
 
+type BackupObject = {
+  bucket: string
+  Key: string
+}
+
+async function listBucketObjects(
+  client: ReturnType<typeof ObjectStore>,
+  bucket: string
+) {
+  const objects: BackupObject[] = []
+  let continuationToken: string | undefined
+  do {
+    const list = await client.listObjectsV2({
+      Bucket: bucket,
+      ContinuationToken: continuationToken,
+    })
+    objects.push(
+      ...(list.Contents?.filter(
+        (object): object is typeof object & { Key: string } => !!object.Key
+      ).map(object => ({ ...object, bucket, Key: object.Key })) || [])
+    )
+    continuationToken = list.NextContinuationToken
+  } while (continuationToken)
+  return objects
+}
+
 export async function exportObjects() {
   const path = join(TEMP_DIR, MINIO_DIR)
   fs.mkdirSync(path, { recursive: true })
-  let fullList: any[] = []
+  let fullList: BackupObject[] = []
   let errorCount = 0
   for (let bucket of bucketList) {
     const client = ObjectStore()
@@ -31,12 +57,7 @@ export async function exportObjects() {
       errorCount++
       continue
     }
-    const list = await client.listObjectsV2({
-      Bucket: bucket,
-    })
-    fullList = fullList.concat(
-      list.Contents?.map(el => ({ ...el, bucket })) || []
-    )
+    fullList = fullList.concat(await listBucketObjects(client, bucket))
   }
   if (errorCount === bucketList.length) {
     throw new Error("Unable to access MinIO/S3 - check environment config.")

--- a/packages/cli/src/backups/objectStore.ts
+++ b/packages/cli/src/backups/objectStore.ts
@@ -1,9 +1,10 @@
 import { objectStore } from "@budibase/backend-core"
 import fs from "fs"
-import { join } from "path"
+import { dirname, join } from "path"
 import { TEMP_DIR, MINIO_DIR } from "./utils"
 import { progressBar } from "../utils"
 import * as stream from "node:stream"
+import { pipeline } from "stream/promises"
 
 const {
   ObjectStoreBuckets,
@@ -17,7 +18,7 @@ const bucketList = Object.values(ObjectStoreBuckets)
 
 export async function exportObjects() {
   const path = join(TEMP_DIR, MINIO_DIR)
-  fs.mkdirSync(path)
+  fs.mkdirSync(path, { recursive: true })
   let fullList: any[] = []
   let errorCount = 0
   for (let bucket of bucketList) {
@@ -46,16 +47,12 @@ export async function exportObjects() {
     const filename = object.Key
     const data = await retrieve(object.bucket, filename)
     const possiblePath = filename.split("/")
-    if (possiblePath.length > 1) {
-      const dirs = possiblePath.slice(0, possiblePath.length - 1)
-      fs.mkdirSync(join(path, object.bucket, ...dirs), { recursive: true })
-    }
+    const destination = join(path, object.bucket, ...possiblePath)
+    fs.mkdirSync(dirname(destination), { recursive: true })
     if (data instanceof stream.Readable) {
-      data.pipe(
-        fs.createWriteStream(join(path, object.bucket, ...possiblePath))
-      )
+      await pipeline(data, fs.createWriteStream(destination))
     } else {
-      fs.writeFileSync(join(path, object.bucket, ...possiblePath), data)
+      fs.writeFileSync(destination, data)
     }
     bar.update(++count)
   }

--- a/packages/server/src/utilities/fileSystem/app.ts
+++ b/packages/server/src/utilities/fileSystem/app.ts
@@ -59,6 +59,24 @@ export const getComponentLibraryManifest = async (library: string) => {
     throw new Error("No app ID found - cannot get component libraries")
   }
 
+  const isMissingObject = (error: unknown) => {
+    if (!error || typeof error !== "object") {
+      return false
+    }
+    const err = error as {
+      name?: unknown
+      Code?: unknown
+      $metadata?: {
+        httpStatusCode?: unknown
+      }
+    }
+    return (
+      err.name === "NoSuchKey" ||
+      err.Code === "NoSuchKey" ||
+      err.$metadata?.httpStatusCode === 404
+    )
+  }
+
   let resp
   let path
   try {
@@ -72,7 +90,18 @@ export const getComponentLibraryManifest = async (library: string) => {
     )
     // Fallback to loading it from the old location for old apps
     path = join(appId, "node_modules", library, "package", filename)
-    resp = await objectStore.retrieve(ObjectStoreBuckets.APPS, path)
+    try {
+      resp = await objectStore.retrieve(ObjectStoreBuckets.APPS, path)
+    } catch (fallbackError) {
+      if (!isMissingObject(error) || !isMissingObject(fallbackError)) {
+        throw fallbackError
+      }
+      console.error(
+        `component-manifest-legacy-objectstore=failed appId=${appId} path=${path}`,
+        fallbackError
+      )
+      return updateClientLibrary(appId)
+    }
   }
   if (typeof resp !== "string") {
     resp = resp.toString()

--- a/packages/server/src/utilities/fileSystem/tests/appManifest.spec.ts
+++ b/packages/server/src/utilities/fileSystem/tests/appManifest.spec.ts
@@ -1,0 +1,101 @@
+jest.mock("@budibase/backend-core", () => {
+  const actual = jest.requireActual("@budibase/backend-core")
+  return {
+    ...actual,
+    context: {
+      ...actual.context,
+      getWorkspaceId: jest.fn(),
+    },
+    env: {
+      ...actual.env,
+      isTest: jest.fn(),
+    },
+    objectStore: {
+      ...actual.objectStore,
+      deleteFolder: jest.fn(),
+      retrieve: jest.fn(),
+    },
+  }
+})
+
+jest.mock("../../../environment", () => ({
+  __esModule: true,
+  default: {
+    UPLOAD_APPS_FILES_ON_TEST: false,
+  },
+  UPLOAD_APPS_FILES_ON_TEST: false,
+}))
+
+jest.mock("../filesystem", () => ({
+  TOP_LEVEL_PATH: "/mock/top/level/path",
+  deleteFolderFileSystem: jest.fn(),
+}))
+
+jest.mock("../clientLibrary", () => ({
+  shouldServeLocally: jest.fn(),
+  updateClientLibrary: jest.fn(),
+}))
+
+import { context, objectStore } from "@budibase/backend-core"
+import { ObjectStoreBuckets } from "../../../constants"
+import { shouldServeLocally, updateClientLibrary } from "../clientLibrary"
+import { getComponentLibraryManifest } from "../app"
+
+const mockedContext = context as jest.Mocked<typeof context>
+const mockedObjectStore = objectStore as jest.Mocked<typeof objectStore>
+const mockedShouldServeLocally = shouldServeLocally as jest.Mock
+const mockedUpdateClientLibrary = updateClientLibrary as jest.Mock
+
+const noSuchKey = () => ({
+  name: "NoSuchKey",
+  Code: "NoSuchKey",
+  $metadata: {
+    httpStatusCode: 404,
+  },
+})
+
+describe("getComponentLibraryManifest", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedContext.getWorkspaceId.mockReturnValue("app_dev_123")
+    mockedShouldServeLocally.mockResolvedValue(false)
+    jest.spyOn(console, "error").mockImplementation()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("loads a legacy manifest without updating the client library", async () => {
+    const manifest = { Button: { name: "Button" } }
+    mockedObjectStore.retrieve
+      .mockRejectedValueOnce(noSuchKey())
+      .mockResolvedValueOnce(JSON.stringify(manifest))
+
+    const result = await getComponentLibraryManifest(
+      "@budibase/standard-components"
+    )
+
+    expect(result).toEqual(manifest)
+    expect(mockedObjectStore.retrieve).toHaveBeenCalledWith(
+      ObjectStoreBuckets.APPS,
+      "app_dev_123/node_modules/@budibase/standard-components/package/manifest.json"
+    )
+    expect(mockedUpdateClientLibrary).not.toHaveBeenCalled()
+  })
+
+  it("regenerates the client library when restored app manifests are missing", async () => {
+    const manifest = { Container: { name: "Container" } }
+    mockedObjectStore.retrieve
+      .mockRejectedValueOnce(noSuchKey())
+      .mockRejectedValueOnce(noSuchKey())
+    mockedUpdateClientLibrary.mockResolvedValue(manifest)
+
+    const result = await getComponentLibraryManifest(
+      "@budibase/standard-components"
+    )
+
+    expect(result).toEqual(manifest)
+    expect(mockedUpdateClientLibrary).toHaveBeenCalledWith("app_dev_123")
+  })
+})


### PR DESCRIPTION
## Description
- fixes CLI backup exports stalling or failing when streamed S3/MinIO objects are written to disk
- ensures exported object directories are created before writing files, including nested attachment paths
- waits for streamed object writes to finish before creating the final backup tarball
- paginates S3/MinIO object listing so CLI backups include all objects, not just the first page
- recovers restored apps where both current and legacy component manifests are missing by regenerating the app client library

## Addresses
customer reporting the following when running a CLI backup or restoring from backup:
```cmd
Error - Failed to run CLI command - please report with the following message:
Error - Error: ENOENT: no such file or directory, open "D:\Budibase Backups\.temp\minio\tmp-file-attachments\app_[redacted]\[redacted].tar.gz'|
Error - Failed to run CLI command - please report with the following message:
Error - Error: aborted
```

due to the pagination issue large instance backups seem to be incomplete.
<img width="1032" height="548" alt="SCR-20260528-kthw" src="https://github.com/user-attachments/assets/48964207-6423-43a8-ba72-0fa52a40a16a" />


also covers restored apps failing to load component definitions when the object-store client manifest was not present in either the current or legacy location.
<img width="1017" height="710" alt="SCR-20260528-leqz" src="https://github.com/user-attachments/assets/bf28c2d7-5c41-4253-ab8f-e4c867fd905b" />


## Launchcontrol
fixes issues with budi backups export and import