### PR TITLE
[Bug] Validate linked relationship field names

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -646,16 +646,16 @@
       newError.subtype = `Auto Column requires a type.`
     }
 
-    if (
-      fieldInfo.type === FieldType.LINK &&
-      fieldInfo.fieldName &&
-      fieldInfo.tableId
-    ) {
-      const relatedTable = $tables.list.find(
-        tbl => tbl._id === fieldInfo.tableId
-      )
-      if (inUse(relatedTable, fieldInfo.fieldName) && !originalName) {
-        newError.relatedName = `Column name already in use in table ${relatedTable?.name}`
+    if (fieldInfo.type === FieldType.LINK && fieldInfo.fieldName) {
+      if (!fieldInfo.fieldName.match(ValidColumnNameRegex)) {
+        newError.relatedName = `Illegal character; must be alpha-numeric.`
+      } else if (fieldInfo.tableId) {
+        const relatedTable = $tables.list.find(
+          tbl => tbl._id === fieldInfo.tableId
+        )
+        if (inUse(relatedTable, fieldInfo.fieldName) && !originalName) {
+          newError.relatedName = `Column name already in use in table ${relatedTable?.name}`
+        }
       }
     }
     return newError

--- a/packages/server/src/automations/tests/steps/updateRow.spec.ts
+++ b/packages/server/src/automations/tests/steps/updateRow.spec.ts
@@ -94,8 +94,16 @@ describe("test the update row action", () => {
       sourceType: TableSourceType.INTERNAL,
       sourceId: INTERNAL_TABLE_SOURCE_ID,
       schema: {
-        user1: { ...linkField, name: "user1", fieldName: uuid.v4() },
-        user2: { ...linkField, name: "user2", fieldName: uuid.v4() },
+        user1: {
+          ...linkField,
+          name: "user1",
+          fieldName: uuid.v4().replace(/-/g, ""),
+        },
+        user2: {
+          ...linkField,
+          name: "user2",
+          fieldName: uuid.v4().replace(/-/g, ""),
+        },
       },
     })
 
@@ -148,8 +156,16 @@ describe("test the update row action", () => {
       sourceType: TableSourceType.INTERNAL,
       sourceId: INTERNAL_TABLE_SOURCE_ID,
       schema: {
-        user1: { ...linkField, name: "user1", fieldName: uuid.v4() },
-        user2: { ...linkField, name: "user2", fieldName: uuid.v4() },
+        user1: {
+          ...linkField,
+          name: "user1",
+          fieldName: uuid.v4().replace(/-/g, ""),
+        },
+        user2: {
+          ...linkField,
+          name: "user2",
+          fieldName: uuid.v4().replace(/-/g, ""),
+        },
       },
     })
 

--- a/packages/server/src/db/linkedRows/LinkController.ts
+++ b/packages/server/src/db/linkedRows/LinkController.ts
@@ -1,4 +1,5 @@
 import { context, logging } from "@budibase/backend-core"
+import { ValidColumnNameRegex } from "@budibase/shared-core"
 import {
   Database,
   FieldSchema,
@@ -96,6 +97,9 @@ class LinkController {
     for (let schema of Object.values(table.schema)) {
       if (schema.type !== FieldType.LINK) {
         continue
+      }
+      if (schema.fieldName && !schema.fieldName.match(ValidColumnNameRegex)) {
+        throw new Error("Column names can't contain special characters")
       }
       const unique = schema.tableId! + schema?.fieldName
       if (usedAlready.indexOf(unique) !== -1) {

--- a/packages/server/src/db/tests/linkController.spec.ts
+++ b/packages/server/src/db/tests/linkController.spec.ts
@@ -204,6 +204,22 @@ describe("test the link controller", () => {
     )
   })
 
+  it("should throw an error when linked field name has illegal characters", async () => {
+    const controller = await createLinkController(table1)
+    const copyTable = cloneDeep(table1)
+    copyTable.schema.link.fieldName = "Table 2!@£$%^&*()>"
+
+    let error: any
+    try {
+      controller.validateTable(copyTable)
+    } catch (err) {
+      error = err
+    }
+
+    expect(error).toBeDefined()
+    expect(error.message).toEqual("Column names can't contain special characters")
+  })
+
   it("should be able to remove a link when saving/updating the row", async () => {
     const row = await createLinkedRow()
     // remove the link from the row

--- a/packages/server/src/db/tests/linkController.spec.ts
+++ b/packages/server/src/db/tests/linkController.spec.ts
@@ -17,6 +17,7 @@ import {
   basicTable,
 } from "../../tests/utilities/structures"
 import LinkController from "../linkedRows/LinkController"
+import { isRelationshipColumn } from "../utils"
 
 const baseColumn = {
   type: FieldType.LINK,
@@ -207,6 +208,12 @@ describe("test the link controller", () => {
   it("should throw an error when linked field name has illegal characters", async () => {
     const controller = await createLinkController(table1)
     const copyTable = cloneDeep(table1)
+
+    if (!isRelationshipColumn(copyTable.schema.link)) {
+      throw new Error(
+        "Expected link schema to be a relationship field metadata"
+      )
+    }
     copyTable.schema.link.fieldName = "Table 2!@£$%^&*()>"
 
     let error: any
@@ -217,7 +224,9 @@ describe("test the link controller", () => {
     }
 
     expect(error).toBeDefined()
-    expect(error.message).toEqual("Column names can't contain special characters")
+    expect(error.message).toEqual(
+      "Column names can't contain special characters"
+    )
   })
 
   it("should be able to remove a link when saving/updating the row", async () => {


### PR DESCRIPTION
## Summary
- add server-side validation for LINK  values in 
- reject linked field names that include illegal characters using existing 
- add regression test coverage in 

## Risk
- low: validation only applies to LINK metadata at table-save time and reuses existing column-name rules

## Addresses
- https://github.com/Budibase/budibase/issues/18786


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `LINK` field names on server and builder to allow only alphanumeric characters, preventing invalid linked column names when creating or saving tables.

- **Bug Fixes**
  - Server: Validate `LINK` field names against `ValidColumnNameRegex` from `@budibase/shared-core` in `LinkController.validateTable`; throw "Column names can't contain special characters".
  - Builder: Validate `LINK` field names client-side using `ValidColumnNameRegex`; show "Illegal character; must be alpha-numeric."; keep related-table uniqueness when `tableId` is set.
  - Tests: Update automation tests to use alphanumeric `fieldName`s by stripping hyphens from `uuid.v4()`; add a unit test asserting the server error for illegal characters.

<sup>Written for commit 0ef30798a1139eb24d76aa28e6a145711f967db0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/18861?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



