### PR TITLE
Revert "[Security] Require auth for S3 signed upload URLs"

### DIFF
--- a/packages/server/src/api/routes/static.ts
+++ b/packages/server/src/api/routes/static.ts
@@ -44,7 +44,6 @@ router
   .post(
     "/api/attachments/:datasourceId/url",
     recaptcha,
-    authorized(BUILDER),
     controller.getSignedUploadURL
   )
 

--- a/packages/server/src/api/routes/tests/static.spec.ts
+++ b/packages/server/src/api/routes/tests/static.spec.ts
@@ -160,17 +160,6 @@ describe("/static", () => {
         )
       })
 
-      it("should require authorization to generate a signed upload URL", async () => {
-        await request
-          .post(`/api/attachments/${datasource._id}/url`)
-          .send({
-            bucket: "foo",
-            key: "bar",
-          })
-          .expect("Content-Type", /json/)
-          .expect(401)
-      })
-
       it("should require a bucket parameter", async () => {
         const res = await request
           .post(`/api/attachments/${datasource._id}/url`)


### PR DESCRIPTION
Reverts Budibase/budibase#18774

This is causing issues with valid "uploading from public"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the auth requirement for generating S3 signed upload URLs to restore valid public uploads. Removes `authorized(BUILDER)` from `POST /api/attachments/:datasourceId/url` and the test that expected a 401 for unauthenticated requests.

<sup>Written for commit c6a21650712f22799825b17df2a159ae1b40c025. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/18863?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

