### PR TITLE
Fix/s3 upload

### DIFF
--- a/packages/server/src/api/routes/static.ts
+++ b/packages/server/src/api/routes/static.ts
@@ -44,7 +44,7 @@ router
   .post(
     "/api/attachments/:datasourceId/url",
     recaptcha,
-    authorized(PermissionType.TABLE, PermissionLevel.READ),
+    authorized(PermissionType.TABLE, PermissionLevel.WRITE),
     controller.getSignedUploadURL
   )
 

--- a/packages/server/src/api/routes/static.ts
+++ b/packages/server/src/api/routes/static.ts
@@ -44,7 +44,7 @@ router
   .post(
     "/api/attachments/:datasourceId/url",
     recaptcha,
-    authorized(BUILDER),
+    authorized(PermissionType.TABLE, PermissionLevel.READ),
     controller.getSignedUploadURL
   )
 

--- a/packages/server/src/api/routes/tests/static.spec.ts
+++ b/packages/server/src/api/routes/tests/static.spec.ts
@@ -1,4 +1,4 @@
-import { constants, objectStore } from "@budibase/backend-core"
+import { constants, objectStore, roles } from "@budibase/backend-core"
 import { Datasource, SourceName } from "@budibase/types"
 import fsp from "fs/promises"
 import path from "path"
@@ -194,6 +194,25 @@ describe("/static", () => {
           .expect("Content-Type", /json/)
           .expect(400)
         expect(res.body.message).toEqual("bucket and key values are required")
+      })
+
+      it("should allow non-creator app users to generate a signed upload URL", async () => {
+        await config.loginAsRole(roles.BUILTIN_ROLE_IDS.BASIC, async () => {
+          const res = await request
+            .post(`/api/attachments/${datasource._id}/url`)
+            .send({
+              bucket: "foo",
+              key: "bar",
+            })
+            .set(config.defaultHeaders())
+            .expect("Content-Type", /json/)
+            .expect(200)
+
+          expect(res.body.signedUrl).toBeDefined()
+          expect(res.body.publicUrl).toEqual(
+            "https://foo.s3.eu-west-1.amazonaws.com/bar"
+          )
+        })
       })
     })
   })

--- a/packages/server/src/api/routes/tests/static.spec.ts
+++ b/packages/server/src/api/routes/tests/static.spec.ts
@@ -1,5 +1,5 @@
 import { constants, objectStore, roles } from "@budibase/backend-core"
-import { Datasource, SourceName } from "@budibase/types"
+import { BuiltinPermissionID, Datasource, SourceName } from "@budibase/types"
 import fsp from "fs/promises"
 import path from "path"
 import { tmpdir } from "os"
@@ -169,6 +169,25 @@ describe("/static", () => {
           })
           .expect("Content-Type", /json/)
           .expect(401)
+      })
+
+      it("should deny app users without write permissions", async () => {
+        const readOnlyRole = await config.api.roles.save({
+          name: "s3_signed_url_read_only",
+          permissionId: BuiltinPermissionID.READ_ONLY,
+          inherits: roles.BUILTIN_ROLE_IDS.PUBLIC,
+        })
+        await config.loginAsRole(readOnlyRole._id!, async () => {
+          await request
+            .post(`/api/attachments/${datasource._id}/url`)
+            .send({
+              bucket: "foo",
+              key: "bar",
+            })
+            .set(config.defaultHeaders())
+            .expect("Content-Type", /json/)
+            .expect(403)
+        })
       })
 
       it("should require a bucket parameter", async () => {


### PR DESCRIPTION
## Description
This PR fixes an issue where the S3 upload component returned a 403 Not Authorised for non-builder app users. The signed upload URL endpoint was changed to use app-role permissions instead of builder/creator-only access.

## Addresses
- Customer ticket

## Screenshots
<img width="412" height="112" alt="Screenshot 2026-05-28 at 10 03 23" src="https://github.com/user-attachments/assets/a8f9e68e-b4cd-40f5-99b5-07324e62718c" />

## Launchcontrol
Fixes a bug that stopped regular app users from uploading files to S3. Before, only builder access users could upload.
