### PR TITLE
Fix SSRF in AI table generation uploadUrl fetch path

### DIFF
--- a/packages/server/src/utilities/fileUtils.ts
+++ b/packages/server/src/utilities/fileUtils.ts
@@ -1,11 +1,11 @@
 import fs from "fs"
-import fetch from "node-fetch"
 import path from "path"
 import { pipeline } from "stream"
 import { promisify } from "util"
 import * as uuid from "uuid"
 
 import { context, objectStore } from "@budibase/backend-core"
+import * as coreUtils from "@budibase/backend-core/utils"
 import { Upload } from "@budibase/types"
 import { ObjectStoreBuckets } from "../constants"
 
@@ -20,7 +20,7 @@ function getTmpPath() {
 
 export async function uploadUrl(url: string): Promise<Upload | undefined> {
   try {
-    const res = await fetch(url)
+    const res = await coreUtils.fetchWithBlacklist<RequestInit, Response>(url)
 
     const extension = [...res.url.split(".")].pop()!.split("?")[0]
 

--- a/packages/server/src/utilities/fileUtils.ts
+++ b/packages/server/src/utilities/fileUtils.ts
@@ -4,8 +4,7 @@ import { pipeline } from "stream"
 import { promisify } from "util"
 import * as uuid from "uuid"
 
-import { context, objectStore } from "@budibase/backend-core"
-import { fetchWithBlacklist } from "@budibase/backend-core/src/utils/outboundFetch"
+import { context, objectStore, utils } from "@budibase/backend-core"
 import { Upload } from "@budibase/types"
 import { ObjectStoreBuckets } from "../constants"
 
@@ -20,8 +19,7 @@ function getTmpPath() {
 
 export async function uploadUrl(url: string): Promise<Upload | undefined> {
   try {
-    const res = await fetchWithBlacklist<RequestInit, Response>(url)
-
+    const res = await utils.fetchWithBlacklist(url)
     const extension = [...res.url.split(".")].pop()!.split("?")[0]
 
     const destination = path.resolve(getTmpPath(), `${uuid.v4()}${extension}`)

--- a/packages/server/src/utilities/fileUtils.ts
+++ b/packages/server/src/utilities/fileUtils.ts
@@ -5,7 +5,7 @@ import { promisify } from "util"
 import * as uuid from "uuid"
 
 import { context, objectStore } from "@budibase/backend-core"
-import * as coreUtils from "@budibase/backend-core/utils"
+import { fetchWithBlacklist } from "@budibase/backend-core/src/utils/outboundFetch"
 import { Upload } from "@budibase/types"
 import { ObjectStoreBuckets } from "../constants"
 
@@ -20,7 +20,7 @@ function getTmpPath() {
 
 export async function uploadUrl(url: string): Promise<Upload | undefined> {
   try {
-    const res = await coreUtils.fetchWithBlacklist<RequestInit, Response>(url)
+    const res = await fetchWithBlacklist<RequestInit, Response>(url)
 
     const extension = [...res.url.split(".")].pop()!.split("?")[0]
 

--- a/packages/server/src/utilities/tests/fileUtils.spec.ts
+++ b/packages/server/src/utilities/tests/fileUtils.spec.ts
@@ -1,7 +1,7 @@
 import fs from "fs"
 import { Readable } from "stream"
 
-jest.mock("@budibase/backend-core/utils", () => ({
+jest.mock("@budibase/backend-core/src/utils/outboundFetch", () => ({
   fetchWithBlacklist: jest.fn(),
 }))
 
@@ -18,26 +18,20 @@ jest.mock("@budibase/backend-core", () => ({
   },
 }))
 
-import * as coreUtils from "@budibase/backend-core/utils"
+import { fetchWithBlacklist } from "@budibase/backend-core/src/utils/outboundFetch"
 import { uploadUrl } from "../fileUtils"
 
 describe("fileUtils.uploadUrl", () => {
   it("uses fetchWithBlacklist for remote URL downloads", async () => {
     const body = Readable.from([Buffer.from("hello")])
-    ;(
-      coreUtils.fetchWithBlacklist as jest.MockedFunction<
-        typeof coreUtils.fetchWithBlacklist
-      >
-    ).mockResolvedValue({
+    ;(fetchWithBlacklist as jest.MockedFunction<typeof fetchWithBlacklist>).mockResolvedValue({
       url: "https://example.com/test.jpg",
       body,
     } as Response)
 
     const result = await uploadUrl("https://example.com/test.jpg")
 
-    expect(coreUtils.fetchWithBlacklist).toHaveBeenCalledWith(
-      "https://example.com/test.jpg"
-    )
+    expect(fetchWithBlacklist).toHaveBeenCalledWith("https://example.com/test.jpg")
     expect(result?.url).toContain("app_test/attachments/")
   })
 })

--- a/packages/server/src/utilities/tests/fileUtils.spec.ts
+++ b/packages/server/src/utilities/tests/fileUtils.spec.ts
@@ -1,37 +1,50 @@
 import fs from "fs"
 import { Readable } from "stream"
 
-jest.mock("@budibase/backend-core/src/utils/outboundFetch", () => ({
-  fetchWithBlacklist: jest.fn(),
-}))
+jest.mock("@budibase/backend-core", () => {
+  const actual = jest.requireActual("@budibase/backend-core")
+  return {
+    ...actual,
+    context: {
+      getProdWorkspaceId: jest.fn(() => "app_test"),
+    },
+    utils: {
+      fetchWithBlacklist: jest.fn(),
+    },
+    objectStore: {
+      ...actual.objectStore,
+      budibaseTempDir: jest.fn(() => fs.mkdtempSync("/tmp/bb-file-utils-")),
+      upload: jest.fn(async ({ filename }: { filename: string }) => ({
+        Key: filename,
+      })),
+      getAppFileUrl: jest.fn(
+        async (key: string) => `https://example.com/${key}`
+      ),
+    },
+  }
+})
 
-jest.mock("@budibase/backend-core", () => ({
-  context: {
-    getProdWorkspaceId: jest.fn(() => "app_test"),
-  },
-  objectStore: {
-    budibaseTempDir: jest.fn(() => fs.mkdtempSync("/tmp/bb-file-utils-")),
-    upload: jest.fn(async ({ filename }: { filename: string }) => ({
-      Key: filename,
-    })),
-    getAppFileUrl: jest.fn(async (key: string) => `https://example.com/${key}`),
-  },
-}))
-
-import { fetchWithBlacklist } from "@budibase/backend-core/src/utils/outboundFetch"
+import { utils } from "@budibase/backend-core"
 import { uploadUrl } from "../fileUtils"
 
 describe("fileUtils.uploadUrl", () => {
+  const fetchWithBlacklistMock =
+    utils.fetchWithBlacklist as jest.MockedFunction<
+      typeof utils.fetchWithBlacklist
+    >
+
   it("uses fetchWithBlacklist for remote URL downloads", async () => {
     const body = Readable.from([Buffer.from("hello")])
-    ;(fetchWithBlacklist as jest.MockedFunction<typeof fetchWithBlacklist>).mockResolvedValue({
+    fetchWithBlacklistMock.mockResolvedValue({
       url: "https://example.com/test.jpg",
       body,
-    } as Response)
+    } as unknown as Response)
 
     const result = await uploadUrl("https://example.com/test.jpg")
 
-    expect(fetchWithBlacklist).toHaveBeenCalledWith("https://example.com/test.jpg")
+    expect(utils.fetchWithBlacklist).toHaveBeenCalledWith(
+      "https://example.com/test.jpg"
+    )
     expect(result?.url).toContain("app_test/attachments/")
   })
 })

--- a/packages/server/src/utilities/tests/fileUtils.spec.ts
+++ b/packages/server/src/utilities/tests/fileUtils.spec.ts
@@ -1,0 +1,43 @@
+import fs from "fs"
+import { Readable } from "stream"
+
+jest.mock("@budibase/backend-core/utils", () => ({
+  fetchWithBlacklist: jest.fn(),
+}))
+
+jest.mock("@budibase/backend-core", () => ({
+  context: {
+    getProdWorkspaceId: jest.fn(() => "app_test"),
+  },
+  objectStore: {
+    budibaseTempDir: jest.fn(() => fs.mkdtempSync("/tmp/bb-file-utils-")),
+    upload: jest.fn(async ({ filename }: { filename: string }) => ({
+      Key: filename,
+    })),
+    getAppFileUrl: jest.fn(async (key: string) => `https://example.com/${key}`),
+  },
+}))
+
+import * as coreUtils from "@budibase/backend-core/utils"
+import { uploadUrl } from "../fileUtils"
+
+describe("fileUtils.uploadUrl", () => {
+  it("uses fetchWithBlacklist for remote URL downloads", async () => {
+    const body = Readable.from([Buffer.from("hello")])
+    ;(
+      coreUtils.fetchWithBlacklist as jest.MockedFunction<
+        typeof coreUtils.fetchWithBlacklist
+      >
+    ).mockResolvedValue({
+      url: "https://example.com/test.jpg",
+      body,
+    } as Response)
+
+    const result = await uploadUrl("https://example.com/test.jpg")
+
+    expect(coreUtils.fetchWithBlacklist).toHaveBeenCalledWith(
+      "https://example.com/test.jpg"
+    )
+    expect(result?.url).toContain("app_test/attachments/")
+  })
+})


### PR DESCRIPTION
## Summary
- switch AI table generation `uploadUrl` downloads from raw fetch to `fetchWithBlacklist`
- add a focused unit test to assert the blacklist-protected fetch path is used

## Risk
- low: change is scoped to AI table generation remote download handling

## Test evidence
- `yarn --cwd packages/server test src/utilities/tests/fileUtils.spec.ts`
- result in this environment: fails in Jest `globalSetup` because container runtime is unavailable (`Could not find a working container runtime strategy`)

## Addresses
- https://github.com/Budibase/vulns/issues/73
