### PR TITLE
[BUDI-17938] Add explicit deletion for REST temp attachments

### DIFF
--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -644,6 +644,21 @@ export const getSignedUploadURL = async function (
   ctx.body = { signedUrl, publicUrl }
 }
 
+export const deleteTemporaryAttachment = async function (ctx: Ctx) {
+  const key = ctx.request.body?.key
+  if (!key || typeof key !== "string") {
+    ctx.throw(400, "A temporary attachment key is required")
+  }
+
+  const workspacePrefix = `${context.getProdWorkspaceId()}/`
+  if (!key.startsWith(workspacePrefix)) {
+    ctx.throw(403, "The temporary attachment key is not valid for this app")
+  }
+
+  await objectStore.deleteFile(ObjectStoreBuckets.TEMP, key)
+  ctx.status = 204
+}
+
 export async function servePwaManifest(ctx: UserCtx<void, any>) {
   const appId = context.getWorkspaceId()
   if (!appId) {

--- a/packages/server/src/api/routes/static.ts
+++ b/packages/server/src/api/routes/static.ts
@@ -47,5 +47,10 @@ router
     authorized(PermissionType.TABLE, PermissionLevel.WRITE),
     controller.getSignedUploadURL
   )
+  .delete(
+    "/api/attachments/temp",
+    authorized(PermissionType.TABLE, PermissionLevel.WRITE),
+    controller.deleteTemporaryAttachment
+  )
 
 export default router

--- a/packages/server/src/api/routes/tests/static.spec.ts
+++ b/packages/server/src/api/routes/tests/static.spec.ts
@@ -28,6 +28,7 @@ jest.mock("@budibase/backend-core", () => {
     objectStore: {
       ...actual.objectStore,
       upload: jest.fn(),
+      deleteFile: jest.fn(),
     },
   }
 })
@@ -36,6 +37,9 @@ import extract from "extract-zip"
 
 const mockedUpload = objectStore.upload as jest.MockedFunction<
   typeof objectStore.upload
+>
+const mockedDeleteFile = objectStore.deleteFile as jest.MockedFunction<
+  typeof objectStore.deleteFile
 >
 const mockedExtract = extract as jest.MockedFunction<typeof extract>
 
@@ -99,6 +103,49 @@ describe("/static", () => {
         .expect(200)
 
       expect(res.body.appId).toBe(config.devWorkspaceId)
+    })
+
+    describe("deleteTemporaryAttachment", () => {
+      it("should delete temporary attachment keys for the current workspace", async () => {
+        await request
+          .delete("/api/attachments/temp")
+          .send({
+            key: "app_prod_test123/4ed4c9bd-32f1-4f8e-a89d-e6f49de3f95f.pdf",
+          })
+          .set(config.defaultHeaders())
+          .expect(204)
+
+        expect(mockedDeleteFile).toHaveBeenCalledWith(
+          "tmp-file-attachments",
+          "app_prod_test123/4ed4c9bd-32f1-4f8e-a89d-e6f49de3f95f.pdf"
+        )
+      })
+
+      it("should require a key", async () => {
+        const res = await request
+          .delete("/api/attachments/temp")
+          .send({})
+          .set(config.defaultHeaders())
+          .expect(400)
+
+        expect(res.body.message).toEqual(
+          "A temporary attachment key is required"
+        )
+      })
+
+      it("should reject keys outside the current workspace", async () => {
+        const res = await request
+          .delete("/api/attachments/temp")
+          .send({
+            key: "another_workspace/file.pdf",
+          })
+          .set(config.defaultHeaders())
+          .expect(403)
+
+        expect(res.body.message).toEqual(
+          "The temporary attachment key is not valid for this app"
+        )
+      })
     })
   })
 


### PR DESCRIPTION
## Description
Adds an authenticated endpoint to explicitly delete REST-response temporary attachments from object storage, scoped to the current workspace prefix.

## Addresses
- https://github.com/Budibase/budibase/issues/17938

## App Export
- Not applicable (server-side API change).

## Screenshots
- Not applicable.

## Launchcontrol
Allows users to explicitly remove temporary files created from REST response attachments instead of waiting for automatic expiry.

## Risk
Low to medium: introduces a new delete endpoint; restricted to table-write users and workspace-scoped keys only.

## Test evidence
- Added route tests in packages/server/src/api/routes/tests/static.spec.ts covering success, missing key, and cross-workspace rejection.
- yarn lint:fix passed.
- yarn --cwd packages/server test src/api/routes/tests/static.spec.ts could not run in this environment due to missing container runtime for global test setup.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an authenticated DELETE endpoint to remove temporary REST attachment files from object storage. Enforces workspace scoping and write permissions so users can clean up files immediately.

- **New Features**
  - New DELETE /api/attachments/temp endpoint.
  - Requires body { key } and validates workspace prefix.
  - Protected by table write permissions; returns 204 on success.
  - Tests added for success, missing key (400), and cross-workspace (403).

<sup>Written for commit a4202bfb2bd6076f5b8875de708bd49a0396b78b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/18869?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

