### PR TITLE
[BUDI-18117] Preserve valid JSON for multiline REST bindings

### DIFF
--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -170,6 +170,57 @@ const isPlainRecord = (value: unknown): value is Record<string, JSONValue> => {
   return Object.prototype.toString.call(value) === "[object Object]"
 }
 
+const escapeControlCharsInJsonStrings = (value: string): string => {
+  let result = ""
+  let inString = false
+  let escaped = false
+
+  for (const char of value) {
+    if (!inString) {
+      if (char === '"') {
+        inString = true
+      }
+      result += char
+      continue
+    }
+
+    if (escaped) {
+      result += char
+      escaped = false
+      continue
+    }
+
+    if (char === "\\") {
+      result += char
+      escaped = true
+      continue
+    }
+
+    if (char === '"') {
+      inString = false
+      result += char
+      continue
+    }
+
+    if (char === "\n") {
+      result += "\\n"
+      continue
+    }
+    if (char === "\r") {
+      result += "\\r"
+      continue
+    }
+    if (char === "\t") {
+      result += "\\t"
+      continue
+    }
+
+    result += char
+  }
+
+  return result
+}
+
 const normaliseBody = (raw: unknown): NormalisedBody => {
   if (raw == null) {
     return { bodyString: "", bodyObject: {}, jsonValue: undefined }
@@ -191,6 +242,26 @@ const normaliseBody = (raw: unknown): NormalisedBody => {
         jsonValue: parsed,
       }
     } catch (err) {
+      const sanitised = escapeControlCharsInJsonStrings(raw)
+      if (sanitised !== raw) {
+        try {
+          const parsed = JSON.parse(sanitised) as JSONValue
+          if (isPlainRecord(parsed)) {
+            return {
+              bodyString: sanitised,
+              bodyObject: parsed,
+              jsonValue: parsed,
+            }
+          }
+          return {
+            bodyString: sanitised,
+            bodyObject: {},
+            jsonValue: parsed,
+          }
+        } catch (_ignored) {
+          // keep original parse error for existing behaviour
+        }
+      }
       return {
         bodyString: raw,
         bodyObject: {},

--- a/packages/server/src/integrations/tests/rest.spec.ts
+++ b/packages/server/src/integrations/tests/rest.spec.ts
@@ -406,6 +406,22 @@ describe("REST Integration", () => {
       )
     })
 
+    it("should escape literal newline characters in JSON string values", () => {
+      const output = integration.addBody(
+        "json",
+        `{ "message": "Hello,\nI'd like to enquire....\r\nThanks." }`,
+        {}
+      )
+      expect(output.body).toEqual(
+        JSON.stringify({
+          message: "Hello,\nI'd like to enquire....\r\nThanks.",
+        })
+      )
+      expect((output.headers! as any)["Content-Type"]).toEqual(
+        "application/json"
+      )
+    })
+
     it("should allow raw XML", () => {
       const output = integration.addBody("xml", "<a>1</a><b>2</b>", {})
       const body = output.body?.toString()


### PR DESCRIPTION
## Description
Fixes REST JSON request body handling when a bound value introduces literal newline characters. The integration now sanitizes control characters inside JSON string literals before parsing so request bodies remain valid JSON.

## Addresses
- https://github.com/Budibase/budibase/issues/18117

## App Export
- Not applicable (server-side integration change).

## Screenshots
- Not applicable.

## Launchcontrol
Prevents REST automations from failing with "Invalid JSON Body" when multiline text is inserted into JSON request templates.

## Risk
Low: change is limited to REST JSON body normalization and includes a regression test.

## Test evidence
- Added regression test in packages/server/src/integrations/tests/rest.spec.ts for literal newlines in JSON string values.
- yarn lint:fix passed.
- yarn --cwd packages/server test src/integrations/tests/rest.spec.ts could not run in this environment due to missing container runtime for global test setup.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves valid JSON in REST requests when bindings inject multiline text. Escapes control characters in JSON string values before parsing to prevent "Invalid JSON Body" errors (Linear BUDI-18117).

- **Bug Fixes**
  - Added sanitization for literal newline, carriage return, and tab characters inside JSON strings in the REST body normalizer, with a safe re-parse fallback that preserves original errors if still invalid.
  - Added a regression test in `packages/server` to cover newline/CRLF handling and ensure the `application/json` header is set.

<sup>Written for commit aa9f7d9c0e17d56d5526c1d1a4aa76be646eb66e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/18870?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

