### PR TITLE
[18139] Fix static formula relationship primaryDisplay resolution

### DIFF
--- a/packages/server/src/api/controllers/row/staticFormula.ts
+++ b/packages/server/src/api/controllers/row/staticFormula.ts
@@ -1,15 +1,88 @@
 import { context } from "@budibase/backend-core"
-import { FieldType, FormulaType, Row, Table, ViewV2 } from "@budibase/types"
+import {
+  FieldType,
+  FormulaType,
+  IncludeRelationship,
+  Operation,
+  Row,
+  Table,
+  ViewV2,
+} from "@budibase/types"
 import { cloneDeep, merge } from "lodash/fp"
 import isEqual from "lodash/isEqual"
 import * as linkRows from "../../../db/linkedRows"
 import { getRowParams } from "../../../db/utils"
+import { handleRequest } from "../row/external"
+import { breakRowIdField, isExternalTableID } from "../../../integrations/utils"
 import sdk from "../../../sdk"
 import {
   outputProcessing,
   processAIColumns,
   processFormulas,
 } from "../../../utilities/rowProcessor"
+
+async function withLinkPrimaryDisplay<T extends Row | Row[]>(source: Table | ViewV2, rows: T) {
+  const baseRows = Array.isArray(rows) ? rows : [rows]
+  const squashedRows = await linkRows.squashLinks(source, cloneDeep(baseRows))
+
+  return baseRows.map((row, index) => {
+    const squashedRow = squashedRows[index]
+    for (const [columnName, schema] of Object.entries(source.schema || {})) {
+      if (schema.type !== FieldType.LINK) {
+        continue
+      }
+      const linkRows = row[columnName]
+      const squashedLinks = squashedRow?.[columnName]
+      if (!Array.isArray(linkRows) || !Array.isArray(squashedLinks)) {
+        continue
+      }
+      const displayById = new Map(
+        squashedLinks
+          .filter(link => link?._id != null)
+          .map(link => [link._id, link.primaryDisplay])
+      )
+      row[columnName] = linkRows.map((link: Row, linkIndex: number) => ({
+        ...link,
+        // Some SQL relationship enrichments do not carry _id on related rows.
+        // Fall back to positional matching so static formulas can still access
+        // {{ relation.0.primaryDisplay }} like live evaluation does.
+        primaryDisplay:
+          link.primaryDisplay ??
+          displayById.get(link._id) ??
+          squashedLinks[linkIndex]?.primaryDisplay,
+      }))
+    }
+    return row
+  }) as T extends Row[] ? Row[] : Row
+}
+
+function normaliseLinkBindingContext(
+  table: Table,
+  row: Row,
+  contextRow: Row
+): Row {
+  const normalised = cloneDeep(contextRow)
+  for (const [columnName, schema] of Object.entries(table.schema)) {
+    if (schema.type !== FieldType.LINK) {
+      continue
+    }
+    const contextLinks = normalised[columnName]
+    if (Array.isArray(contextLinks) && contextLinks.length > 0) {
+      normalised[columnName] = contextLinks.map(link =>
+        typeof link === "object" && link != null ? link : { _id: link }
+      )
+      continue
+    }
+
+    const rawLinks = row[columnName]
+    if (Array.isArray(rawLinks) && rawLinks.length > 0) {
+      normalised[columnName] = rawLinks.map(link =>
+        typeof link === "object" && link != null ? link : { _id: link }
+      )
+    }
+  }
+  return normalised
+}
 
 function mergeRows(row1: Row, row2: Row) {
   const merged = merge(row1, row2)
@@ -94,6 +167,56 @@ export async function updateRelatedFormula(
 }
 
 export async function updateAllFormulasInTable(table: Table) {
+  if (isExternalTableID(table._id!)) {
+    const response = await handleRequest(Operation.READ, table, {
+      includeSqlRelationships: IncludeRelationship.INCLUDE,
+    })
+    const rows = response.rows || []
+    if (!rows.length) {
+      return
+    }
+
+    const enrichedRows = await outputProcessing(table, cloneDeep(rows), {
+      squash: true,
+      preserveLinks: true,
+    })
+
+    for (let row of rows) {
+      const enrichedRow = enrichedRows.find(
+        (enriched: Row) => enriched._id === row._id
+      )
+      if (!enrichedRow) {
+        continue
+      }
+
+      const contextRow = normaliseLinkBindingContext(table, row, enrichedRow)
+      const processed = await processFormulas(table, cloneDeep(row), {
+        dynamic: false,
+        contextRows: [contextRow],
+      })
+
+      if (isEqual(processed, row)) {
+        continue
+      }
+
+      const formulaOnly: Row = { _id: row._id }
+      for (const [columnName, schema] of Object.entries(table.schema)) {
+        if (
+          schema.type === FieldType.FORMULA &&
+          schema.formulaType === FormulaType.STATIC
+        ) {
+          formulaOnly[columnName] = processed[columnName]
+        }
+      }
+
+      await handleRequest(Operation.UPDATE, table, {
+        id: breakRowIdField(row._id!),
+        row: formulaOnly,
+      })
+    }
+    return
+  }
+
   const db = context.getWorkspaceDB()
   // start by getting the raw rows (which will be written back to DB after update)
   let rows = (
@@ -102,11 +225,17 @@ export async function updateAllFormulasInTable(table: Table) {
         include_docs: true,
       })
     )
-  ).rows.map(row => row.doc!)
+  ).rows.map(row => {
+    const doc = row.doc!
+    if (!doc.tableId) {
+      doc.tableId = table._id!
+    }
+    return doc
+  })
   // now enrich the rows, note the clone so that we have the base state of the
   // rows so that we don't write any of the enriched information back
   let enrichedRows = await outputProcessing(table, cloneDeep(rows), {
-    squash: false,
+    squash: true,
   })
   const updatedRows = []
   for (let row of rows) {
@@ -115,9 +244,10 @@ export async function updateAllFormulasInTable(table: Table) {
       (enriched: Row) => enriched._id === row._id
     )
     if (enrichedRow) {
+      const contextRow = normaliseLinkBindingContext(table, row, enrichedRow)
       let processed = await processFormulas(table, cloneDeep(row), {
         dynamic: false,
-        contextRows: [enrichedRow],
+        contextRows: [contextRow],
       })
       // values have changed, need to add to bulk docs to update
       if (!isEqual(processed, row)) {
@@ -150,6 +280,7 @@ export async function finaliseRow(
   let enrichedRow = await outputProcessing(source, cloneDeep(row), {
     squash: false,
   })
+  enrichedRow = await withLinkPrimaryDisplay(source, enrichedRow)
   // use enriched row to generate formulas for saving, specifically only use as context
   row = await processFormulas(table, row, {
     dynamic: false,

--- a/packages/server/src/api/controllers/row/utils/utils.ts
+++ b/packages/server/src/api/controllers/row/utils/utils.ts
@@ -53,6 +53,13 @@ export async function processRelationshipFields(
       // process additional types
       relatedRow = processDates(linkedTable, relatedRow)
       relatedRow = await processFormulas(linkedTable, relatedRow)
+      if (
+        linkedTable.primaryDisplay &&
+        relatedRow.primaryDisplay == null &&
+        relatedRow[linkedTable.primaryDisplay] != null
+      ) {
+        relatedRow.primaryDisplay = relatedRow[linkedTable.primaryDisplay]
+      }
       row[relationship.column][key] = relatedRow
     }
   }

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -4093,6 +4093,15 @@ if (descriptions.length) {
             const { rows } = await config.api.row.search(table._id!)
             expect(rows[0].formula).toBe(1)
           })
+
+        it("should support relationship primaryDisplay in static formulas after column update", async () => {
+          await updateFormulaColumn("JOB ID: {{ links.0.primaryDisplay }}", {
+            formulaType: FormulaType.STATIC,
+          })
+          const { rows } = await config.api.row.search(table._id!)
+          expect(rows[0].formula).toBe(`JOB ID: ${relatedRow.name}`)
+        })
+
       })
 
       describe("Formula JS protection", () => {

--- a/packages/server/src/sdk/workspace/tables/external/index.ts
+++ b/packages/server/src/sdk/workspace/tables/external/index.ts
@@ -12,6 +12,7 @@ import {
 } from "@budibase/types"
 import { cloneDeep } from "lodash/fp"
 import { makeTableRequest } from "../../../../api/controllers/table/ExternalRequest"
+import { runStaticFormulaChecks } from "../../../../api/controllers/table/bulkFormula"
 import {
   foreignKeyStructure,
   hasTypeChanged,
@@ -285,6 +286,8 @@ export async function save(
   if (updatedDatasource.isSQL) {
     tableToSave.sql = true
   }
+
+  await runStaticFormulaChecks(tableToSave, { oldTable, deletion: false })
 
   return { datasource: updatedDatasource, table: tableToSave, oldTable }
 }

--- a/packages/server/src/utilities/rowProcessor/index.ts
+++ b/packages/server/src/utilities/rowProcessor/index.ts
@@ -485,6 +485,14 @@ export async function coreOutputProcessing(
 
   // process formulas after the complex types had been processed
   rows = await processFormulas(table, rows, { dynamic: true })
+  // External rows don't always persist static formula values in the same way
+  // as internal rows, so evaluate static formulas during output as well.
+  if (isExternalTableID(table._id!)) {
+    rows = await processFormulas(table, rows, {
+      dynamic: false,
+      contextRows: rows,
+    })
+  }
 
   // remove null properties to match internal API
   const isExternal = isExternalTableID(table._id!)


### PR DESCRIPTION
## Description
_Describe the problem or feature in addition to a link to the relevant github issues._

## Addresses
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._

## Launchcontrol

_Add a small description in layman's terms of what this PR achieves. This will be used in the release notes._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes static formulas that reference relationship primaryDisplay so they resolve consistently for internal and SQL/external tables. Addresses Linear 18139 by aligning static formula evaluation with live behavior and ensuring values are persisted where needed.

- **Bug Fixes**
  - Ensure relationship rows expose primaryDisplay during formula evaluation, with id-based and positional fallbacks for SQL links.
  - Normalize link fields in the formula context so references like links.0.primaryDisplay work after column updates.
  - Evaluate static formulas on read for external tables, matching internal behavior.
  - Recompute and persist only static formula fields for external tables in updateAllFormulasInTable.
  - Populate missing primaryDisplay from the linked table’s display field during relationship processing.
  - Run static formula checks on external table save and add a test covering links.0.primaryDisplay in static formulas.

<sup>Written for commit b2a1849f5cd0fa31620eb13a03ded6c17f5f39a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/18872?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

