### PR TITLE
feat: add per-screen background, gradient, and custom CSS styling options

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Screen/StylingPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Screen/StylingPanel.svelte
@@ -13,6 +13,7 @@
   import ClientBindingPanel from "@/components/common/bindings/ClientBindingPanel.svelte"
   import { getBindableProperties } from "@/dataBinding"
   import { selectedScreen, screenStore, themeStore } from "@/stores/builder"
+  import { background } from "../Component/componentStyles"
 
   let customCssDrawer
   let tempCustomCss = ""
@@ -67,78 +68,8 @@
       onChange={val => updateSetting("screenGradient", val)}
       props={{
         placeholder: "None",
-        options: [
-          {
-            label: "Warm Flame",
-            value:
-              "linear-gradient(45deg, #ff9a9e 0%, #fad0c4 99%, #fad0c4 100%);",
-          },
-          {
-            label: "Night Fade",
-            value: "linear-gradient(to top, #a18cd1 0%, #fbc2eb 100%);",
-          },
-          {
-            label: "Spring Warmth",
-            value: "linear-gradient(to top, #fad0c4 0%, #ffd1ff 100%);",
-          },
-          {
-            label: "Sunny Morning",
-            value: "linear-gradient(120deg, #f6d365 0%, #fda085 100%);",
-          },
-          {
-            label: "Winter Neva",
-            value: "linear-gradient(120deg, #a1c4fd 0%, #c2e9fb 100%);",
-          },
-          {
-            label: "Tempting Azure",
-            value: "linear-gradient(120deg, #84fab0 0%, #8fd3f4 100%);",
-          },
-          {
-            label: "Heavy Rain",
-            value: "linear-gradient(to top, #cfd9df 0%, #e2ebf0 100%);",
-          },
-          {
-            label: "Deep Blue",
-            value: "linear-gradient(120deg, #e0c3fc 0%, #8ec5fc 100%);",
-          },
-          {
-            label: "Near Moon",
-            value: "linear-gradient(to top, #5ee7df 0%, #b490ca 100%);",
-          },
-          {
-            label: "Wild Apple",
-            value: "linear-gradient(to top, #d299c2 0%, #fef9d7 100%);",
-          },
-          {
-            label: "Plum Plate",
-            value: "linear-gradient(135deg, #667eea 0%, #764ba2 100%);",
-          },
-          {
-            label: "Peach Kiss",
-            value:
-              "radial-gradient(circle farthest-corner at 50% 100%,rgba(255,173,138,.50), rgba(255,248,247,1) 100%);",
-          },
-          {
-            label: "Flamingo Sunrise",
-            value:
-              "-webkit-radial-gradient(center top, rgb(255, 250, 245), rgb(255, 242, 242))",
-          },
-          {
-            label: "Budi Mist",
-            value:
-              "radial-gradient(circle, rgba(252,215,212,1) 0%, rgba(255,227,214,1) 50%, rgba(207,218,255,1) 100%);",
-          },
-          {
-            label: "Ballet Slipper",
-            value:
-              "linear-gradient(135deg, rgba(252,215,212,1) 20%, rgba(207,218,255,1) 100%);",
-          },
-          {
-            label: "Black Noir",
-            value:
-              "linear-gradient(312deg, rgba(60,60,60,1) 0%, rgba(42,42,42,1) 100%);",
-          },
-        ],
+        options:
+          background.settings.find(s => s.label === "Gradient")?.options || [],
       }}
     />
   </div>

--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Screen/StylingPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Screen/StylingPanel.svelte
@@ -1,0 +1,185 @@
+<script>
+  import { get } from "svelte/store"
+  import {
+    DetailSummary,
+    ActionButton,
+    Drawer,
+    Button,
+    Select,
+    notifications,
+  } from "@budibase/bbui"
+  import PropertyControl from "@/components/design/settings/controls/PropertyControl.svelte"
+  import ColorPicker from "@/components/design/settings/controls/ColorPicker.svelte"
+  import ClientBindingPanel from "@/components/common/bindings/ClientBindingPanel.svelte"
+  import { getBindableProperties } from "@/dataBinding"
+  import { selectedScreen, screenStore, themeStore } from "@/stores/builder"
+
+  let customCssDrawer
+  let tempCustomCss = ""
+
+  $: bindings = getBindableProperties($selectedScreen, null)
+  $: backgroundChanged =
+    !!$selectedScreen?.screenBackground || !!$selectedScreen?.screenGradient
+
+  const updateSetting = async (key, value) => {
+    try {
+      await screenStore.updateSetting(get(selectedScreen), key, value)
+    } catch (error) {
+      notifications.error("Error updating style")
+    }
+  }
+
+  const openCustomCssDrawer = () => {
+    tempCustomCss = $selectedScreen?.screenCustomCss || ""
+    customCssDrawer.show()
+  }
+
+  const saveCustomCss = async () => {
+    try {
+      await screenStore.updateSetting(
+        get(selectedScreen),
+        "screenCustomCss",
+        tempCustomCss
+      )
+      customCssDrawer.hide()
+    } catch (error) {
+      notifications.error("Error updating custom style")
+    }
+  }
+</script>
+
+<DetailSummary
+  collapsible={false}
+  name={`Background${backgroundChanged ? " *" : ""}`}
+>
+  <div class="styles">
+    <PropertyControl
+      label="Color"
+      control={ColorPicker}
+      value={$selectedScreen?.screenBackground}
+      onChange={val => updateSetting("screenBackground", val)}
+      props={{ spectrumTheme: $themeStore.theme }}
+    />
+    <PropertyControl
+      label="Gradient"
+      control={Select}
+      value={$selectedScreen?.screenGradient}
+      onChange={val => updateSetting("screenGradient", val)}
+      props={{
+        placeholder: "None",
+        options: [
+          {
+            label: "Warm Flame",
+            value:
+              "linear-gradient(45deg, #ff9a9e 0%, #fad0c4 99%, #fad0c4 100%);",
+          },
+          {
+            label: "Night Fade",
+            value: "linear-gradient(to top, #a18cd1 0%, #fbc2eb 100%);",
+          },
+          {
+            label: "Spring Warmth",
+            value: "linear-gradient(to top, #fad0c4 0%, #ffd1ff 100%);",
+          },
+          {
+            label: "Sunny Morning",
+            value: "linear-gradient(120deg, #f6d365 0%, #fda085 100%);",
+          },
+          {
+            label: "Winter Neva",
+            value: "linear-gradient(120deg, #a1c4fd 0%, #c2e9fb 100%);",
+          },
+          {
+            label: "Tempting Azure",
+            value: "linear-gradient(120deg, #84fab0 0%, #8fd3f4 100%);",
+          },
+          {
+            label: "Heavy Rain",
+            value: "linear-gradient(to top, #cfd9df 0%, #e2ebf0 100%);",
+          },
+          {
+            label: "Deep Blue",
+            value: "linear-gradient(120deg, #e0c3fc 0%, #8ec5fc 100%);",
+          },
+          {
+            label: "Near Moon",
+            value: "linear-gradient(to top, #5ee7df 0%, #b490ca 100%);",
+          },
+          {
+            label: "Wild Apple",
+            value: "linear-gradient(to top, #d299c2 0%, #fef9d7 100%);",
+          },
+          {
+            label: "Plum Plate",
+            value: "linear-gradient(135deg, #667eea 0%, #764ba2 100%);",
+          },
+          {
+            label: "Peach Kiss",
+            value:
+              "radial-gradient(circle farthest-corner at 50% 100%,rgba(255,173,138,.50), rgba(255,248,247,1) 100%);",
+          },
+          {
+            label: "Flamingo Sunrise",
+            value:
+              "-webkit-radial-gradient(center top, rgb(255, 250, 245), rgb(255, 242, 242))",
+          },
+          {
+            label: "Budi Mist",
+            value:
+              "radial-gradient(circle, rgba(252,215,212,1) 0%, rgba(255,227,214,1) 50%, rgba(207,218,255,1) 100%);",
+          },
+          {
+            label: "Ballet Slipper",
+            value:
+              "linear-gradient(135deg, rgba(252,215,212,1) 20%, rgba(207,218,255,1) 100%);",
+          },
+          {
+            label: "Black Noir",
+            value:
+              "linear-gradient(312deg, rgba(60,60,60,1) 0%, rgba(42,42,42,1) 100%);",
+          },
+        ],
+      }}
+    />
+  </div>
+</DetailSummary>
+
+<DetailSummary
+  name={`Custom CSS${$selectedScreen?.screenCustomCss ? " *" : ""}`}
+  collapsible={false}
+>
+  <ActionButton on:click={openCustomCssDrawer}>Edit custom CSS</ActionButton>
+</DetailSummary>
+
+{#key $selectedScreen?._id}
+  <Drawer
+    bind:this={customCssDrawer}
+    title="Custom CSS"
+    on:drawerHide
+    on:drawerShow
+  >
+    <svelte:fragment slot="description">
+      Your CSS will be applied to the screen area
+    </svelte:fragment>
+    <Button cta slot="buttons" on:click={saveCustomCss}>Save</Button>
+    <svelte:component
+      this={ClientBindingPanel}
+      slot="body"
+      value={tempCustomCss}
+      on:change={event => (tempCustomCss = event.detail)}
+      allowJS
+      {bindings}
+      autofocusEditor={true}
+    />
+  </Drawer>
+{/key}
+
+<style>
+  .styles {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: stretch;
+    gap: 8px;
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Screen/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Screen/index.svelte
@@ -38,7 +38,7 @@
       </div>
     </span>
     {#if section === "settings"}
-      <Layout gap="XS" paddingX="XL" paddingY="XL">
+      <Layout gap="XS" padding="XL">
         <GeneralPanel />
       </Layout>
     {/if}

--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Screen/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Screen/index.svelte
@@ -9,7 +9,11 @@
   const tabs = ["settings", "styles"]
   let section = "settings"
 
-  $: $selectedScreen, (section = "settings")
+  let currentScreenId = $selectedScreen?._id
+  $: if ($selectedScreen?._id !== currentScreenId) {
+    currentScreenId = $selectedScreen?._id
+    section = "settings"
+  }
 </script>
 
 {#if $selectedScreen}

--- a/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Screen/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Screen/index.svelte
@@ -1,8 +1,15 @@
 <script>
   import GeneralPanel from "./GeneralPanel.svelte"
+  import StylingPanel from "./StylingPanel.svelte"
   import { selectedScreen } from "@/stores/builder"
   import Panel from "@/components/design/Panel.svelte"
-  import { Layout } from "@budibase/bbui"
+  import { Layout, ActionButton } from "@budibase/bbui"
+  import { capitalise } from "@/helpers"
+
+  const tabs = ["settings", "styles"]
+  let section = "settings"
+
+  $: $selectedScreen, (section = "settings")
 </script>
 
 {#if $selectedScreen}
@@ -12,8 +19,36 @@
     borderLeft
     wide
   >
-    <Layout gap="XS" paddingX="XL" paddingY="XL">
-      <GeneralPanel />
-    </Layout>
+    <span slot="panel-header-content">
+      <div class="settings-tabs">
+        {#each tabs as tab}
+          <ActionButton
+            size="M"
+            quiet
+            selected={section === tab}
+            on:click={() => (section = tab)}
+          >
+            {capitalise(tab)}
+          </ActionButton>
+        {/each}
+      </div>
+    </span>
+    {#if section === "settings"}
+      <Layout gap="XS" paddingX="XL" paddingY="XL">
+        <GeneralPanel />
+      </Layout>
+    {/if}
+    {#if section === "styles"}
+      <StylingPanel />
+    {/if}
   </Panel>
 {/if}
+
+<style>
+  .settings-tabs {
+    display: flex;
+    gap: var(--spacing-xs);
+    padding: 0 var(--spacing-l);
+    padding-bottom: var(--spacing-l);
+  }
+</style>

--- a/packages/client/src/components/app/Layout.svelte
+++ b/packages/client/src/components/app/Layout.svelte
@@ -58,6 +58,10 @@
 
   export let collapsible = false
 
+  export let screenBackground
+  export let screenGradient
+  export let screenCustomCss
+
   const NavigationClasses = {
     Top: "top",
     Left: "left",
@@ -331,6 +335,25 @@
     return style
   }
 
+  const getScreenStyle = (background, gradient, customCss) => {
+    let style = ""
+    if (gradient) {
+      style += `background: ${gradient};`
+    } else if (background) {
+      style += `background-color: ${background};`
+    }
+    if (customCss) {
+      style += customCss
+    }
+    return style || undefined
+  }
+
+  $: screenStyle = getScreenStyle(
+    screenBackground,
+    screenGradient,
+    screenCustomCss
+  )
+
   const getSanitizedUrl = (url, openInNewTab) => {
     if (!isInternal(url)) {
       return ensureExternal(url)
@@ -517,6 +540,7 @@
       {/if}
       <div
         class="main-wrapper"
+        style={screenStyle}
         on:click={() => {
           if ($builderStore.inBuilder) {
             builderStore.actions.selectComponent(screenId)

--- a/packages/client/src/stores/screens.ts
+++ b/packages/client/src/stores/screens.ts
@@ -147,6 +147,9 @@ const createScreenStore = () => {
           navigation: "None",
           pageWidth: activeScreen?.width || "Large",
           embedded: $appStore.embedded,
+          screenBackground: activeScreen?.screenBackground,
+          screenGradient: activeScreen?.screenGradient,
+          screenCustomCss: activeScreen?.screenCustomCss,
         }
         if (activeScreen?.showNavigation) {
           const navigationSettings = {

--- a/packages/client/src/stores/screens.ts
+++ b/packages/client/src/stores/screens.ts
@@ -143,7 +143,11 @@ const createScreenStore = () => {
       // If we don't have a legacy custom layout, build a layout structure
       // from the screen navigation settings
       if (!activeLayout) {
-        let layoutSettings: Partial<Layout> = {
+        let layoutSettings: Partial<Layout> &
+          Pick<
+            Screen,
+            "screenBackground" | "screenGradient" | "screenCustomCss"
+          > = {
           navigation: "None",
           pageWidth: activeScreen?.width || "Large",
           embedded: $appStore.embedded,

--- a/packages/types/src/documents/workspace/layout.ts
+++ b/packages/types/src/documents/workspace/layout.ts
@@ -15,4 +15,7 @@ export interface Layout extends Document {
   logoUrl?: string
   hideTitle?: boolean
   banner?: AppBanner
+  screenBackground?: string
+  screenGradient?: string
+  screenCustomCss?: string
 }

--- a/packages/types/src/documents/workspace/layout.ts
+++ b/packages/types/src/documents/workspace/layout.ts
@@ -15,7 +15,4 @@ export interface Layout extends Document {
   logoUrl?: string
   hideTitle?: boolean
   banner?: AppBanner
-  screenBackground?: string
-  screenGradient?: string
-  screenCustomCss?: string
 }

--- a/packages/types/src/documents/workspace/screen.ts
+++ b/packages/types/src/documents/workspace/screen.ts
@@ -23,6 +23,9 @@ export interface Screen extends Document {
   layoutId?: string
   showNavigation?: boolean
   width?: string
+  screenBackground?: string
+  screenGradient?: string
+  screenCustomCss?: string
   routing: ScreenRouting
   props: ScreenProps
   name?: string


### PR DESCRIPTION
## Description

Adds a **Styles** tab to the screen settings panel in the builder, giving users per-screen styling options similar to the existing component styles system. This will be specifically helpful on grid type layouts as well as flex layouts when the width is not **max**. You no longer have to use a container in flex mode to overcome the default background. When the screen root is selected, the panel now has two tabs — **Settings** (unchanged) and **Styles** (new).

The Styles tab provides:
- **Background color** — a colour picker applied to the screen area
- **Gradient** — a dropdown of preset gradients (matching the same options available on components via the background style group)
- **Custom CSS** — a full CSS editor using `ClientBindingPanel` in a `Drawer`, matching the pattern used by `CustomStylesSection` across the builder

## Addresses
- Resolves https://github.com/Budibase/budibase/issues/17584

## App Export
- N/A

## Screenshots
<img width="1119" height="334" alt="image" src="https://github.com/user-attachments/assets/f4c07c8d-43d0-487a-97ba-66a09888467f" />

## Launchcontrol

Users can now set a background colour, gradient, or custom CSS on individual screens from the screen's Styles tab in the design panel. These styles are applied to the main screen wrapper area in the rendered app. You no longer have to use a container in flex mode to overcome the default background



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-screen styling (background color, gradient, custom CSS) via a new Styles tab in screen settings. Styles apply to the main screen wrapper at runtime; the tab stays selected while editing.

- **New Features**
  - Styles tab with a color picker, preset gradients (shared options), and a Drawer-based custom CSS editor.
  - Runtime applies `screenBackground`, `screenGradient`, and `screenCustomCss` to `.main-wrapper` via `Layout.svelte`; the screens store passes these props when building layout.

- **Refactors**
  - Removed duplicated style fields from `Layout` types; styles now live on the `Screen` model.
  - Kept tab selection stable across re-renders (resets only when switching screens).

<sup>Written for commit 4a0b29da6764093e95452b38987db592901385df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/18887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



