### PR TITLE
Authenticated embeds with configurable ancestors

### DIFF
--- a/hosting/nginx.dev.conf
+++ b/hosting/nginx.dev.conf
@@ -150,7 +150,7 @@ http {
       proxy_set_header   Host $host;
       proxy_set_header   x-budibase-embed "true";
       add_header x-budibase-embed "true";
-      add_header Content-Security-Policy "frame-ancestors *";
+      # frame-ancestors config moved: set by the app based on the workspace embed allowlist
     }
 
     # Redirects for renamed routes

--- a/hosting/proxy/nginx.prod.conf
+++ b/hosting/proxy/nginx.prod.conf
@@ -117,7 +117,7 @@ http {
       proxy_set_header    x-budibase-embed    "true";
 
       add_header x-budibase-embed "true";
-      add_header Content-Security-Policy "frame-ancestors *";
+      # frame-ancestors config moved: set by the app based on the workspace embed allowlist
 
       proxy_pass         $apps;
     }

--- a/hosting/single/nginx/nginx-default-site.conf
+++ b/hosting/single/nginx/nginx-default-site.conf
@@ -43,7 +43,7 @@ server {
         proxy_set_header Host                    $host;
         proxy_set_header x-budibase-embed        "true";
         add_header       x-budibase-embed        "true";
-        add_header       Content-Security-Policy "frame-ancestors *";
+        # frame-ancestors config moved: set by the app based on the workspace embed allowlist
     }
 
     location = / {

--- a/packages/backend-core/src/middleware/contentSecurityPolicy.ts
+++ b/packages/backend-core/src/middleware/contentSecurityPolicy.ts
@@ -131,36 +131,59 @@ export const contentSecurityPolicy = (async (ctx: Ctx, next: Next) => {
     }
   }
 
-  // Add custom app CSP whitelist
+  // Apply per-workspace CSP based on the workspace metadata. This covers the
+  // licensed custom app script whitelist as well as the embed origin allowlist.
+  const isEmbed = ctx.request?.get("x-budibase-embed")?.toLowerCase() === "true"
   const licensed = ctx.user?.license?.features.includes(
     Feature.CUSTOM_APP_SCRIPTS
   )
-  if (licensed && ctx.appId) {
+
+  // Default embeds to a wildcard allowlist so existing implementations keep
+  // working. The per-workspace allowlist below narrows this when configured,
+  // and this default holds even if the workspace metadata lookup fails.
+  if (isEmbed) {
+    directives["frame-ancestors"] = ["*"]
+  }
+
+  if (ctx.appId && (isEmbed || licensed)) {
     try {
       const appMetadata = await workspace.getWorkspaceMetadata(ctx.appId)
       if ("name" in appMetadata) {
-        for (let script of appMetadata.scripts || []) {
-          const inclusions = (script.cspWhitelist || "")
-            .split("\n")
-            .filter(domain => CSPDomainRegex.test(domain))
+        if (licensed) {
+          for (let script of appMetadata.scripts || []) {
+            const inclusions = (script.cspWhitelist || "")
+              .split("\n")
+              .filter(domain => CSPDomainRegex.test(domain))
 
-          // Apply app whitelist to all relevant directives
-          const directivesToUpdate = [
-            "default-src",
-            "script-src",
-            "connect-src",
-            "media-src",
-            "img-src",
-            "font-src",
-            "frame-src",
-          ]
-
-          for (const directive of directivesToUpdate) {
-            directives[directive] = [
-              ...(directives[directive] || []),
-              ...inclusions,
+            // Apply app whitelist to all relevant directives
+            const directivesToUpdate = [
+              "default-src",
+              "script-src",
+              "connect-src",
+              "media-src",
+              "img-src",
+              "font-src",
+              "frame-src",
             ]
+
+            for (const directive of directivesToUpdate) {
+              directives[directive] = [
+                ...(directives[directive] || []),
+                ...inclusions,
+              ]
+            }
           }
+        }
+
+        // Restrict who can embed this workspace's apps in an iframe. An empty
+        // allowlist keeps the previous behaviour of allowing any origin.
+        if (isEmbed) {
+          const allowedOrigins = (appMetadata.embedAllowedOrigins || [])
+            .map(origin => origin.trim())
+            .filter(origin => CSPDomainRegex.test(origin))
+          directives["frame-ancestors"] = allowedOrigins.length
+            ? allowedOrigins
+            : ["*"]
         }
       }
     } catch (err) {

--- a/packages/backend-core/src/middleware/tests/contentSecurityPolicy.spec.ts
+++ b/packages/backend-core/src/middleware/tests/contentSecurityPolicy.spec.ts
@@ -204,6 +204,89 @@ describe("contentSecurityPolicy middleware", () => {
     expect(next).toHaveBeenCalled()
   })
 
+  describe("embed allowed origins", () => {
+    const appId = "app_embed"
+    const buildWorkspace = (embedAllowedOrigins?: string[]): Workspace => ({
+      appId,
+      type: "foo",
+      version: "1",
+      componentLibraries: [],
+      name: "foo",
+      url: "/foo",
+      template: undefined,
+      instance: { _id: appId },
+      tenantId: "default",
+      status: "foo",
+      embedAllowedOrigins,
+    })
+
+    const embedRequest = (origins?: string[]) => {
+      ctx.appId = appId
+      ctx.request = { get: () => "true" }
+      // @ts-ignore
+      workspace.getWorkspaceMetadata.mockImplementation(() =>
+        buildWorkspace(origins)
+      )
+    }
+
+    it("should restrict frame-ancestors to the configured origins", async () => {
+      embedRequest(["https://example.com", "https://*.foo.bar"])
+
+      await contentSecurityPolicy(ctx, next)
+
+      const cspHeader = ctx.set.mock.calls[0][1]
+      expect(cspHeader).toContain(
+        "frame-ancestors https://example.com https://*.foo.bar"
+      )
+      expect(next).toHaveBeenCalled()
+    })
+
+    it("should allow any origin when the allowlist is empty", async () => {
+      embedRequest([])
+
+      await contentSecurityPolicy(ctx, next)
+
+      const cspHeader = ctx.set.mock.calls[0][1]
+      expect(cspHeader).toContain("frame-ancestors *")
+    })
+
+    it("should filter out invalid origins", async () => {
+      embedRequest(["https://example.com", "https://evil.com', script-src *"])
+
+      await contentSecurityPolicy(ctx, next)
+
+      const cspHeader = ctx.set.mock.calls[0][1]
+      expect(cspHeader).toContain("frame-ancestors https://example.com")
+      expect(cspHeader).not.toContain("script-src *")
+    })
+
+    it("should keep the wildcard default when the metadata lookup fails", async () => {
+      ctx.appId = appId
+      ctx.request = { get: () => "true" }
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation()
+      // @ts-ignore
+      workspace.getWorkspaceMetadata.mockImplementation(() => {
+        throw new Error("boom")
+      })
+
+      await contentSecurityPolicy(ctx, next)
+
+      const cspHeader = ctx.set.mock.calls[0][1]
+      expect(cspHeader).toContain("frame-ancestors *")
+      consoleSpy.mockRestore()
+    })
+
+    it("should not set frame-ancestors for non-embed requests", async () => {
+      ctx.appId = appId
+      ctx.request = { get: () => undefined }
+
+      await contentSecurityPolicy(ctx, next)
+
+      const cspHeader = ctx.set.mock.calls[0][1]
+      expect(cspHeader).not.toContain("frame-ancestors")
+    })
+  })
+
   describe("custom environment variables", () => {
     it("should add custom domains from environment variables", async () => {
       // @ts-ignore

--- a/packages/backend-core/src/utils/utils.ts
+++ b/packages/backend-core/src/utils/utils.ts
@@ -206,18 +206,31 @@ export function setCookie(
   ctx: Ctx,
   value: any,
   name = "builder",
-  opts: { sign: boolean; httpOnly?: boolean } = { sign: true }
+  opts: {
+    sign: boolean
+    httpOnly?: boolean
+    sameSite?: "lax" | "strict" | "none"
+    secure?: boolean
+  } = { sign: true }
 ) {
   if (value && opts && opts.sign) {
     value = jwt.sign(value, env.JWT_SECRET as Secret)
   }
 
+  // SameSite=None cookies (required for cross-origin iframe embedding) must be
+  // marked Secure to be accepted by the browser.
+  const secure = opts.secure ?? (opts.sameSite === "none" ? true : ctx.secure)
+
   const config: SetOption = {
     expires: MAX_VALID_DATE,
     path: "/",
     httpOnly: opts.httpOnly ?? false,
-    secure: ctx.secure,
+    secure,
     overwrite: true,
+  }
+
+  if (opts.sameSite) {
+    config.sameSite = opts.sameSite
   }
 
   if (env.COOKIE_DOMAIN) {

--- a/packages/backend-core/src/utils/utils.ts
+++ b/packages/backend-core/src/utils/utils.ts
@@ -219,7 +219,7 @@ export function setCookie(
 
   // SameSite=None cookies (required for cross-origin iframe embedding) must be
   // marked Secure to be accepted by the browser.
-  const secure = opts.secure ?? (opts.sameSite === "none" ? true : ctx.secure)
+  const secure = opts.sameSite === "none" ? true : (opts.secure ?? ctx.secure)
 
   const config: SetOption = {
     expires: MAX_VALID_DATE,

--- a/packages/backend-core/src/utils/utils.ts
+++ b/packages/backend-core/src/utils/utils.ts
@@ -217,9 +217,21 @@ export function setCookie(
     value = jwt.sign(value, env.JWT_SECRET as Secret)
   }
 
-  // SameSite=None cookies (required for cross-origin iframe embedding) must be
-  // marked Secure to be accepted by the browser.
-  const secure = opts.sameSite === "none" ? true : (opts.secure ?? ctx.secure)
+  // SameSite=None is required for cross-origin iframe embedding, but browsers
+  // only accept it alongside Secure, which in turn requires an HTTPS
+  // connection. When the connection isn't secure (e.g. local http dev) we can't
+  // send a Secure cookie, so fall back to Lax - which still works for same-site
+  // embedding. Over HTTPS this keeps the proper SameSite=None; Secure.
+  let sameSite = opts.sameSite
+  let secure = opts.secure ?? ctx.secure
+  if (sameSite === "none") {
+    if (secure) {
+      // honour an explicitly requested secure flag over a secure connection
+      secure = true
+    } else {
+      sameSite = "lax"
+    }
+  }
 
   const config: SetOption = {
     expires: MAX_VALID_DATE,
@@ -229,8 +241,8 @@ export function setCookie(
     overwrite: true,
   }
 
-  if (opts.sameSite) {
-    config.sameSite = opts.sameSite
+  if (sameSite) {
+    config.sameSite = sameSite
   }
 
   if (env.COOKIE_DOMAIN) {

--- a/packages/builder/src/settings/pages/embed.svelte
+++ b/packages/builder/src/settings/pages/embed.svelte
@@ -156,7 +156,6 @@
       label="Allowed domains"
       value={allowedOrigins}
       placeholder="https://example.com"
-      helpText="Only these domains will be permitted to embed this workspace's apps in an iframe. Leave empty to allow any domain."
       on:change={e => updateAllowedOrigins(e.detail)}
     />
   </div>

--- a/packages/builder/src/settings/pages/embed.svelte
+++ b/packages/builder/src/settings/pages/embed.svelte
@@ -44,12 +44,15 @@
   let ssoEmailClaim = ""
   // whether a key is already stored (server returns it masked)
   let ssoKeySet = false
+  // the algorithm the stored key was created for
+  let originalAlgorithm = "ES256"
 
   onMount(() => {
     const config = $appStore.embedSSO
     if (config) {
       ssoEnabled = config.enabled
       ssoAlgorithm = config.algorithm || "ES256"
+      originalAlgorithm = ssoAlgorithm
       ssoIssuer = config.issuer || ""
       ssoEmailClaim = config.emailClaim || ""
       ssoKeySet = !!config.key
@@ -57,17 +60,35 @@
   })
 
   $: isSecretAlgorithm = ssoAlgorithm === "HS256"
+  // the stored key is tied to its algorithm, so it can only be reused while the
+  // algorithm is unchanged - otherwise a new key must be entered
+  $: canReuseStoredKey = ssoKeySet && ssoAlgorithm === originalAlgorithm
+
+  const onSSOToggle = () => {
+    // persist immediately when disabling; enabling reveals the fields and waits
+    // for an explicit save once a key has been provided
+    if (!ssoEnabled) {
+      saveSSO()
+    }
+  }
 
   const saveSSO = async () => {
+    if (ssoEnabled && !ssoKey && !canReuseStoredKey) {
+      notifications.error(
+        "Please provide a verification key for the selected algorithm"
+      )
+      return
+    }
     try {
       const config = {
         enabled: ssoEnabled,
         algorithm: ssoAlgorithm,
-        key: ssoKey || (ssoKeySet ? PASSWORD_REPLACEMENT : ""),
+        key: ssoKey || (canReuseStoredKey ? PASSWORD_REPLACEMENT : ""),
         issuer: ssoIssuer || undefined,
         emailClaim: ssoEmailClaim || undefined,
       }
       await appStore.updateApp({ embedSSO: config })
+      originalAlgorithm = ssoAlgorithm
       if (ssoKey) {
         ssoKeySet = true
         ssoKey = ""
@@ -151,7 +172,7 @@
         to an existing Budibase user.
       </span>
     </div>
-    <Toggle text="Enable" bind:value={ssoEnabled} on:change={saveSSO} />
+    <Toggle text="Enable" bind:value={ssoEnabled} on:change={onSSOToggle} />
     {#if ssoEnabled}
       <Select
         label="Verification algorithm"
@@ -163,12 +184,17 @@
       <TextArea
         label={isSecretAlgorithm ? "Shared secret" : "Public key (PEM)"}
         bind:value={ssoKey}
-        placeholder={ssoKeySet
+        placeholder={canReuseStoredKey
           ? "A key is set — enter a new value to replace it"
           : isSecretAlgorithm
             ? "Shared HMAC secret"
             : "-----BEGIN PUBLIC KEY-----"}
-        helpText="Used to verify the signature of the incoming token."
+        helpText={ssoKeySet && !canReuseStoredKey
+          ? `Enter a new key for ${ssoAlgorithm} — the stored key cannot be reused after changing the algorithm.`
+          : "Used to verify the signature of the incoming token."}
+        error={ssoKeySet && !canReuseStoredKey
+          ? "A new key is required for the selected algorithm"
+          : undefined}
       />
       <Input
         label="Issuer (optional)"

--- a/packages/builder/src/settings/pages/embed.svelte
+++ b/packages/builder/src/settings/pages/embed.svelte
@@ -6,12 +6,77 @@
     Icon,
     notifications,
     Select,
+    PillInput,
+    Toggle,
+    TextArea,
+    Input,
+    Divider,
   } from "@budibase/bbui"
+  import { PASSWORD_REPLACEMENT } from "@budibase/types"
   import { AppStatus } from "@/constants"
   import { appsStore } from "@/stores/portal/apps"
   import { appStore, workspaceAppStore } from "@/stores/builder"
+  import { onMount } from "svelte"
 
   let selectedApp
+
+  $: allowedOrigins = $appStore.embedAllowedOrigins || []
+
+  const updateAllowedOrigins = async origins => {
+    try {
+      await appStore.updateApp({ embedAllowedOrigins: origins })
+      notifications.success("Allowed domains updated")
+    } catch (error) {
+      notifications.error("Error updating allowed domains")
+    }
+  }
+
+  const algorithmOptions = [
+    { label: "ES256 (public key)", value: "ES256" },
+    { label: "RS256 (public key)", value: "RS256" },
+    { label: "HS256 (shared secret)", value: "HS256" },
+  ]
+
+  let ssoEnabled = false
+  let ssoAlgorithm = "ES256"
+  let ssoKey = ""
+  let ssoIssuer = ""
+  let ssoEmailClaim = ""
+  // whether a key is already stored (server returns it masked)
+  let ssoKeySet = false
+
+  onMount(() => {
+    const config = $appStore.embedSSO
+    if (config) {
+      ssoEnabled = config.enabled
+      ssoAlgorithm = config.algorithm || "ES256"
+      ssoIssuer = config.issuer || ""
+      ssoEmailClaim = config.emailClaim || ""
+      ssoKeySet = !!config.key
+    }
+  })
+
+  $: isSecretAlgorithm = ssoAlgorithm === "HS256"
+
+  const saveSSO = async () => {
+    try {
+      const config = {
+        enabled: ssoEnabled,
+        algorithm: ssoAlgorithm,
+        key: ssoKey || (ssoKeySet ? PASSWORD_REPLACEMENT : ""),
+        issuer: ssoIssuer || undefined,
+        emailClaim: ssoEmailClaim || undefined,
+      }
+      await appStore.updateApp({ embedSSO: config })
+      if (ssoKey) {
+        ssoKeySet = true
+        ssoKey = ""
+      }
+      notifications.success("Embed SSO settings updated")
+    } catch (error) {
+      notifications.error("Error updating embed SSO settings")
+    }
+  }
 
   $: filteredApps = $appsStore.apps.filter(app => app.devId == $appStore.appId)
   $: workspace = filteredApps.length ? filteredApps[0] : {}
@@ -65,6 +130,63 @@
       </div>
     {/if}
   </div>
+  <div class="embed-domains">
+    <PillInput
+      label="Allowed domains"
+      value={allowedOrigins}
+      placeholder="https://example.com"
+      helpText="Only these domains will be permitted to embed this workspace's apps in an iframe. Leave empty to allow any domain."
+      on:change={e => updateAllowedOrigins(e.detail)}
+    />
+  </div>
+
+  <Divider />
+
+  <div class="embed-sso">
+    <div class="embed-sso-heading">
+      <span class="embed-sso-title">Authenticate embedded users</span>
+      <span class="embed-sso-description">
+        Let the host site sign in users by passing a signed token (e.g. the
+        <code>?jwt=</code> parameter) on the embed URL. The token's email is mapped
+        to an existing Budibase user.
+      </span>
+    </div>
+    <Toggle text="Enable" bind:value={ssoEnabled} on:change={saveSSO} />
+    {#if ssoEnabled}
+      <Select
+        label="Verification algorithm"
+        options={algorithmOptions}
+        bind:value={ssoAlgorithm}
+        getOptionLabel={o => o.label}
+        getOptionValue={o => o.value}
+      />
+      <TextArea
+        label={isSecretAlgorithm ? "Shared secret" : "Public key (PEM)"}
+        bind:value={ssoKey}
+        placeholder={ssoKeySet
+          ? "A key is set — enter a new value to replace it"
+          : isSecretAlgorithm
+            ? "Shared HMAC secret"
+            : "-----BEGIN PUBLIC KEY-----"}
+        helpText="Used to verify the signature of the incoming token."
+      />
+      <Input
+        label="Issuer (optional)"
+        bind:value={ssoIssuer}
+        placeholder="https://nextcloud.example.com"
+        helpText="If set, the token's 'iss' claim must match this value."
+      />
+      <Input
+        label="Email claim"
+        bind:value={ssoEmailClaim}
+        placeholder="email"
+        helpText="Path to the email in the token payload. Use 'userdata.email' for Nextcloud. Defaults to 'email'."
+      />
+      <div>
+        <Button cta on:click={saveSSO}>Save</Button>
+      </div>
+    {/if}
+  </div>
 </Layout>
 
 <style>
@@ -93,5 +215,26 @@
     flex-direction: column;
     gap: var(--spacing-m);
     width: fit-content;
+  }
+  .embed-domains {
+    max-width: 480px;
+  }
+  .embed-sso {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-l);
+    max-width: 480px;
+  }
+  .embed-sso-heading {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+  }
+  .embed-sso-title {
+    font-weight: 600;
+  }
+  .embed-sso-description {
+    color: var(--spectrum-global-color-gray-700);
+    font-size: var(--font-size-s);
   }
 </style>

--- a/packages/builder/src/stores/builder/app.ts
+++ b/packages/builder/src/stores/builder/app.ts
@@ -2,6 +2,7 @@ import { API } from "@/api"
 import {
   AppScript,
   AutomationSettings,
+  EmbedSSOConfig,
   Plugin,
   PWAManifest,
   UpdateWorkspaceRequest,
@@ -53,6 +54,8 @@ export interface AppMetaState {
   icon?: WorkspaceIcon
   pwa?: PWAManifest
   scripts: AppScript[]
+  embedAllowedOrigins: string[]
+  embedSSO?: EmbedSSOConfig
 }
 
 export const INITIAL_APP_META_STATE: AppMetaState = {
@@ -99,6 +102,7 @@ export const INITIAL_APP_META_STATE: AppMetaState = {
     screenshots: [],
   },
   scripts: [],
+  embedAllowedOrigins: [],
 }
 
 export class AppMetaStore extends BudiStore<AppMetaState> {
@@ -132,6 +136,8 @@ export class AppMetaStore extends BudiStore<AppMetaState> {
       hasAppPackage: true,
       pwa: workspace.pwa,
       scripts: workspace.scripts || [],
+      embedAllowedOrigins: workspace.embedAllowedOrigins || [],
+      embedSSO: workspace.embedSSO,
     }))
   }
 

--- a/packages/builder/src/stores/builder/tests/app.test.js
+++ b/packages/builder/src/stores/builder/tests/app.test.js
@@ -79,6 +79,7 @@ describe("Application Meta Store", () => {
       url,
       features,
       pwa,
+      embedSSO,
       componentLibraries,
     } = app
 
@@ -102,6 +103,7 @@ describe("Application Meta Store", () => {
       initialised: true,
       hasAppPackage: true,
       pwa,
+      embedSSO,
     })
   })
 

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -348,6 +348,24 @@ export const serveApp = async function (ctx: UserCtx<void, ServeAppResponse>) {
     const workspaceApp = await sdk.workspaceApps.getMatchedWorkspaceApp(ctx.url)
 
     const appInfo = await sdk.workspaces.metadata.get()
+
+    // When embedded, allow the host site to authenticate the user via a signed
+    // token. Establishing the session here sets the auth cookie on the initial
+    // document response so the client's subsequent API calls are authenticated.
+    if (bbHeaderEmbed && !ctx.isAuthenticated && appInfo.embedSSO?.enabled) {
+      const embedToken = ctx.query.jwt
+      if (typeof embedToken === "string" && embedToken) {
+        try {
+          await sdk.embedSSO.authenticateEmbedUser(
+            ctx,
+            appInfo.embedSSO,
+            embedToken
+          )
+        } catch (err) {
+          console.warn(`Embed SSO authentication failed: ${err}`)
+        }
+      }
+    }
     const clientVersion = isChatRoute ? envCore.VERSION : appInfo.version
     const clientCacheKey = await objectStore.getClientCacheKey(clientVersion)
     const clientAssetScopeId = isChatRoute

--- a/packages/server/src/api/controllers/workspace.ts
+++ b/packages/server/src/api/controllers/workspace.ts
@@ -602,6 +602,14 @@ export async function fetchAppPackage(
     application.version
   )
 
+  // never expose the embed SSO secret to the browser - strip it entirely for
+  // the published client and mask the key for the builder
+  if (application.embedSSO) {
+    application.embedSSO = isBuilder
+      ? sdk.embedSSO.maskConfigForBuilder(application.embedSSO)
+      : undefined
+  }
+
   ctx.body = {
     application: { ...application, upgradableVersion: envCore.VERSION },
     licenseType: license?.plan.type || PlanType.FREE,
@@ -1419,6 +1427,15 @@ export async function updateWorkspacePackage(
               : icon
         )
       }
+    }
+
+    // encrypt the embed SSO secret at rest (and preserve the existing secret
+    // when the builder submits the masked placeholder)
+    if (workspacePackage.embedSSO) {
+      newWorkspacePackage.embedSSO = sdk.embedSSO.encodeConfigForStorage(
+        workspacePackage.embedSSO,
+        application.embedSSO
+      )
     }
 
     // the locked by property is attached by server but generated from

--- a/packages/server/src/sdk/index.ts
+++ b/packages/server/src/sdk/index.ts
@@ -7,6 +7,7 @@ import { default as backups } from "./workspace/backups"
 import * as common from "./workspace/common"
 import { default as datasources } from "./workspace/datasources"
 import { default as deployment } from "./workspace/deployment"
+import * as embedSSO from "./workspace/embedSSO"
 import * as workspace from "./workspace/favourites"
 import { default as links } from "./workspace/links"
 import * as navigation from "./workspace/navigation"
@@ -44,6 +45,7 @@ const sdk = {
   navigation,
   resources,
   deployment,
+  embedSSO,
   dev,
   workspace,
 }

--- a/packages/server/src/sdk/workspace/embedSSO/index.ts
+++ b/packages/server/src/sdk/workspace/embedSSO/index.ts
@@ -2,6 +2,7 @@ import {
   constants,
   encryption,
   env as coreEnv,
+  HTTPError,
   sessions,
   tenancy,
   users,
@@ -37,6 +38,14 @@ export function encodeConfigForStorage(
 ): EmbedSSOConfig {
   let key = incoming.key
   if (key === PASSWORD_REPLACEMENT) {
+    // the stored key is tied to its algorithm (shared secret vs EC/RSA public
+    // key), so it cannot be reused if the algorithm has changed
+    if (existing && existing.algorithm !== incoming.algorithm) {
+      throw new HTTPError(
+        "A new verification key is required when changing the embed SSO algorithm",
+        400
+      )
+    }
     key = existing?.key || ""
   } else {
     key = encodeSecret(key)

--- a/packages/server/src/sdk/workspace/embedSSO/index.ts
+++ b/packages/server/src/sdk/workspace/embedSSO/index.ts
@@ -1,0 +1,128 @@
+import {
+  constants,
+  encryption,
+  env as coreEnv,
+  sessions,
+  tenancy,
+  users,
+  utils as coreUtils,
+} from "@budibase/backend-core"
+import { Ctx, EmbedSSOConfig, PASSWORD_REPLACEMENT } from "@budibase/types"
+import jwt from "jsonwebtoken"
+
+const SECRET_ENCODING_PREFIX = "bbembed_enc::"
+
+const encodeSecret = (value: string): string => {
+  if (!value || value.startsWith(SECRET_ENCODING_PREFIX)) {
+    return value
+  }
+  return `${SECRET_ENCODING_PREFIX}${encryption.encrypt(value)}`
+}
+
+const decodeSecret = (value: string): string => {
+  if (!value || !value.startsWith(SECRET_ENCODING_PREFIX)) {
+    return value
+  }
+  return encryption.decrypt(value.slice(SECRET_ENCODING_PREFIX.length))
+}
+
+/**
+ * Encrypt the secret before storage. When the incoming key is the password
+ * replacement sentinel, the existing (already encrypted) key is preserved so
+ * the masked value sent to the builder round-trips without overwriting it.
+ */
+export function encodeConfigForStorage(
+  incoming: EmbedSSOConfig,
+  existing?: EmbedSSOConfig
+): EmbedSSOConfig {
+  let key = incoming.key
+  if (key === PASSWORD_REPLACEMENT) {
+    key = existing?.key || ""
+  } else {
+    key = encodeSecret(key)
+  }
+  return { ...incoming, key }
+}
+
+/**
+ * Mask the secret so the builder can display and edit the config without ever
+ * receiving the real key.
+ */
+export function maskConfigForBuilder(config: EmbedSSOConfig): EmbedSSOConfig {
+  return { ...config, key: config.key ? PASSWORD_REPLACEMENT : "" }
+}
+
+const getEmailFromPayload = (
+  payload: Record<string, any>,
+  emailClaim = "email"
+): string | undefined => {
+  const value = emailClaim
+    .split(".")
+    .reduce<any>((acc, part) => (acc == null ? acc : acc[part]), payload)
+  return typeof value === "string" ? value : undefined
+}
+
+const verifyToken = (
+  token: string,
+  config: EmbedSSOConfig
+): Record<string, any> => {
+  const key = decodeSecret(config.key)
+  const options: jwt.VerifyOptions = { algorithms: [config.algorithm] }
+  if (config.issuer) {
+    options.issuer = config.issuer
+  }
+  const decoded = jwt.verify(token, key, options)
+  if (typeof decoded === "string") {
+    throw new Error("Unexpected token payload")
+  }
+  return decoded
+}
+
+/**
+ * Verify a signed token from the embedding host, map its identity to an
+ * existing Budibase user and, if found, establish a Budibase session by setting
+ * the auth cookie. Returns true if the user was authenticated.
+ */
+export async function authenticateEmbedUser(
+  ctx: Ctx,
+  config: EmbedSSOConfig,
+  token: string
+): Promise<boolean> {
+  let payload: Record<string, any>
+  try {
+    payload = verifyToken(token, config)
+  } catch (err) {
+    console.warn(`Embed SSO token verification failed: ${err}`)
+    return false
+  }
+
+  const email = getEmailFromPayload(payload, config.emailClaim)?.toLowerCase()
+  if (!email) {
+    console.warn("Embed SSO token did not contain a valid email claim")
+    return false
+  }
+
+  const user = await users.getGlobalUserByEmail(email)
+  if (!user || !user._id) {
+    console.warn("Embed SSO: no existing Budibase user for the provided email")
+    return false
+  }
+
+  const sessionId = coreUtils.newid()
+  const tenantId = tenancy.getTenantId()
+  await sessions.createASession(user._id, {
+    sessionId,
+    tenantId,
+    email: user.email,
+  })
+  const authToken = jwt.sign(
+    { userId: user._id, sessionId, tenantId, email: user.email },
+    coreEnv.JWT_SECRET!
+  )
+  coreUtils.setCookie(ctx, authToken, constants.Cookie.Auth, {
+    sign: false,
+    httpOnly: true,
+    sameSite: "none",
+  })
+  return true
+}

--- a/packages/server/src/sdk/workspace/embedSSO/tests/embedSSO.spec.ts
+++ b/packages/server/src/sdk/workspace/embedSSO/tests/embedSSO.spec.ts
@@ -89,6 +89,27 @@ describe("embedSSO sdk", () => {
       expect(options.secure).toBe(true)
     })
 
+    it("falls back to a Lax cookie over an insecure connection", async () => {
+      getGlobalUserByEmail.mockResolvedValue({
+        _id: "us_123",
+        email: "user@example.com",
+      } as any)
+
+      const token = jwt.sign({ userdata: { email: "user@example.com" } }, SECRET)
+      const ctx = { secure: false, cookies: { set: jest.fn() } }
+
+      const result = await authenticateEmbedUser(
+        ctx as any,
+        hmacConfig(),
+        token
+      )
+
+      expect(result).toBe(true)
+      const [, , options] = ctx.cookies.set.mock.calls[0]
+      expect(options.sameSite).toBe("lax")
+      expect(options.secure).toBe(false)
+    })
+
     it("rejects a token signed with the wrong secret", async () => {
       const token = jwt.sign(
         { userdata: { email: "user@example.com" } },

--- a/packages/server/src/sdk/workspace/embedSSO/tests/embedSSO.spec.ts
+++ b/packages/server/src/sdk/workspace/embedSSO/tests/embedSSO.spec.ts
@@ -95,7 +95,10 @@ describe("embedSSO sdk", () => {
         email: "user@example.com",
       } as any)
 
-      const token = jwt.sign({ userdata: { email: "user@example.com" } }, SECRET)
+      const token = jwt.sign(
+        { userdata: { email: "user@example.com" } },
+        SECRET
+      )
       const ctx = { secure: false, cookies: { set: jest.fn() } }
 
       const result = await authenticateEmbedUser(

--- a/packages/server/src/sdk/workspace/embedSSO/tests/embedSSO.spec.ts
+++ b/packages/server/src/sdk/workspace/embedSSO/tests/embedSSO.spec.ts
@@ -1,0 +1,175 @@
+import * as backendCore from "@budibase/backend-core"
+import { EmbedSSOConfig, PASSWORD_REPLACEMENT } from "@budibase/types"
+import jwt from "jsonwebtoken"
+
+jest.mock("@budibase/backend-core", (): typeof backendCore => {
+  const actual: typeof backendCore = jest.requireActual(
+    "@budibase/backend-core"
+  )
+  return {
+    ...actual,
+    sessions: {
+      ...actual.sessions,
+      createASession: jest.fn(),
+    },
+    users: {
+      ...actual.users,
+      getGlobalUserByEmail: jest.fn(),
+    },
+    tenancy: {
+      ...actual.tenancy,
+      getTenantId: jest.fn(() => "default"),
+    },
+  }
+})
+
+import {
+  authenticateEmbedUser,
+  encodeConfigForStorage,
+  maskConfigForBuilder,
+} from "../index"
+
+const getGlobalUserByEmail = backendCore.users
+  .getGlobalUserByEmail as jest.MockedFunction<
+  typeof backendCore.users.getGlobalUserByEmail
+>
+const createASession = backendCore.sessions
+  .createASession as jest.MockedFunction<
+  typeof backendCore.sessions.createASession
+>
+
+const SECRET = "super-secret-value"
+
+const hmacConfig = (
+  overrides: Partial<EmbedSSOConfig> = {}
+): EmbedSSOConfig => ({
+  enabled: true,
+  algorithm: "HS256",
+  key: SECRET,
+  emailClaim: "userdata.email",
+  ...overrides,
+})
+
+const buildCtx = () => ({
+  secure: true,
+  cookies: { set: jest.fn() },
+})
+
+describe("embedSSO sdk", () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("authenticateEmbedUser", () => {
+    it("maps a valid token to an existing user and sets the auth cookie", async () => {
+      getGlobalUserByEmail.mockResolvedValue({
+        _id: "us_123",
+        email: "user@example.com",
+      } as any)
+
+      const token = jwt.sign(
+        { userdata: { email: "User@Example.com" } },
+        SECRET,
+        { algorithm: "HS256" }
+      )
+      const ctx = buildCtx()
+
+      const result = await authenticateEmbedUser(
+        ctx as any,
+        hmacConfig(),
+        token
+      )
+
+      expect(result).toBe(true)
+      expect(getGlobalUserByEmail).toHaveBeenCalledWith("user@example.com")
+      expect(createASession).toHaveBeenCalled()
+      const [name, , options] = ctx.cookies.set.mock.calls[0]
+      expect(name).toBe(backendCore.constants.Cookie.Auth)
+      expect(options.sameSite).toBe("none")
+      expect(options.secure).toBe(true)
+    })
+
+    it("rejects a token signed with the wrong secret", async () => {
+      const token = jwt.sign(
+        { userdata: { email: "user@example.com" } },
+        "nope"
+      )
+      const ctx = buildCtx()
+
+      const result = await authenticateEmbedUser(
+        ctx as any,
+        hmacConfig(),
+        token
+      )
+
+      expect(result).toBe(false)
+      expect(getGlobalUserByEmail).not.toHaveBeenCalled()
+      expect(ctx.cookies.set).not.toHaveBeenCalled()
+    })
+
+    it("does not create a session when no Budibase user matches", async () => {
+      getGlobalUserByEmail.mockResolvedValue(undefined)
+      const token = jwt.sign(
+        { userdata: { email: "missing@example.com" } },
+        SECRET
+      )
+      const ctx = buildCtx()
+
+      const result = await authenticateEmbedUser(
+        ctx as any,
+        hmacConfig(),
+        token
+      )
+
+      expect(result).toBe(false)
+      expect(createASession).not.toHaveBeenCalled()
+      expect(ctx.cookies.set).not.toHaveBeenCalled()
+    })
+
+    it("validates the issuer when configured", async () => {
+      const token = jwt.sign(
+        { userdata: { email: "user@example.com" } },
+        SECRET,
+        {
+          issuer: "https://other.example.com",
+        }
+      )
+      const ctx = buildCtx()
+
+      const result = await authenticateEmbedUser(
+        ctx as any,
+        hmacConfig({ issuer: "https://nextcloud.example.com" }),
+        token
+      )
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe("encodeConfigForStorage", () => {
+    it("encrypts a newly provided key", () => {
+      const result = encodeConfigForStorage(hmacConfig({ key: "plain-secret" }))
+      expect(result.key).not.toBe("plain-secret")
+      expect(result.key).toContain("bbembed_enc::")
+    })
+
+    it("preserves the existing key when the masked placeholder is submitted", () => {
+      const existing = encodeConfigForStorage(hmacConfig({ key: "original" }))
+      const result = encodeConfigForStorage(
+        hmacConfig({ key: PASSWORD_REPLACEMENT }),
+        existing
+      )
+      expect(result.key).toBe(existing.key)
+    })
+  })
+
+  describe("maskConfigForBuilder", () => {
+    it("masks a set key", () => {
+      expect(maskConfigForBuilder(hmacConfig()).key).toBe(PASSWORD_REPLACEMENT)
+    })
+
+    it("leaves an empty key empty", () => {
+      expect(maskConfigForBuilder(hmacConfig({ key: "" })).key).toBe("")
+    })
+  })
+})

--- a/packages/server/src/sdk/workspace/embedSSO/tests/embedSSO.spec.ts
+++ b/packages/server/src/sdk/workspace/embedSSO/tests/embedSSO.spec.ts
@@ -161,6 +161,28 @@ describe("embedSSO sdk", () => {
       )
       expect(result.key).toBe(existing.key)
     })
+
+    it("rejects reusing the stored key when the algorithm changed", () => {
+      const existing = encodeConfigForStorage(hmacConfig({ key: "original" }))
+      expect(() =>
+        encodeConfigForStorage(
+          hmacConfig({ algorithm: "ES256", key: PASSWORD_REPLACEMENT }),
+          existing
+        )
+      ).toThrow(
+        "A new verification key is required when changing the embed SSO algorithm"
+      )
+    })
+
+    it("allows changing the algorithm together with a new key", () => {
+      const existing = encodeConfigForStorage(hmacConfig({ key: "original" }))
+      const result = encodeConfigForStorage(
+        hmacConfig({ algorithm: "ES256", key: "-----BEGIN PUBLIC KEY-----" }),
+        existing
+      )
+      expect(result.algorithm).toBe("ES256")
+      expect(result.key).toContain("bbembed_enc::")
+    })
   })
 
   describe("maskConfigForBuilder", () => {

--- a/packages/types/src/documents/workspace/workspace.ts
+++ b/packages/types/src/documents/workspace/workspace.ts
@@ -34,6 +34,13 @@ export interface Workspace extends Document {
   updatedBy?: string
   pwa?: PWAManifest
   scripts?: AppScript[]
+  // list of origins (e.g. https://example.com) allowed to embed this
+  // workspace's apps in an iframe. Empty/unset means any origin is allowed.
+  embedAllowedOrigins?: string[]
+  // configuration for authenticating embedded users via a signed token passed
+  // by the host site (e.g. Nextcloud). The token's identity is mapped to an
+  // existing Budibase user.
+  embedSSO?: EmbedSSOConfig
   // stores a list of IDs (automations, workspace apps, anything that can be published)
   // and when they were last published (timestamp)
   resourcesPublishedAt?: Record<string, string>
@@ -42,6 +49,23 @@ export interface Workspace extends Document {
   resourcesDeployedAt?: Record<string, string>
   /** @deprecated translations are configured globally via ConfigType.TRANSLATIONS */
   translationOverrides?: TranslationOverrides
+}
+
+export type EmbedSSOAlgorithm = "ES256" | "RS256" | "HS256"
+
+export interface EmbedSSOConfig {
+  enabled: boolean
+  // verification algorithm for the incoming token. ES256/RS256 use an
+  // asymmetric public key, HS256 uses a shared secret.
+  algorithm: EmbedSSOAlgorithm
+  // PEM-encoded public key (ES256/RS256) or shared secret (HS256). Stored
+  // encrypted at rest and never returned to the browser.
+  key: string
+  // optional expected issuer (the "iss" claim) to validate against.
+  issuer?: string
+  // dot-path into the token payload for the user's email, e.g. "userdata.email"
+  // for Nextcloud. Defaults to "email".
+  emailClaim?: string
 }
 
 export interface WorkspaceInstance {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds authenticated embeds with a per-workspace domain allowlist and SSO via signed tokens. Moves frame-ancestors CSP from Nginx to the app so each workspace controls who can iframe it; existing embeds keep working by default.

- **New Features**
  - Per-workspace CSP for embeds: sets frame-ancestors from the allowlist, filters invalid origins, defaults to "*" (even on metadata lookup failure); removed Nginx header.
  - Builder → Embed: manage Allowed domains and configure Embed SSO (ES256/RS256/HS256, key/public key, optional issuer, email claim).
  - SSO: on embedded loads, verifies ?jwt=, maps email to an existing user, creates a session, and sets an HttpOnly auth cookie; SameSite=None cookies are Secure and fall back to Lax over HTTP; cookies utility now supports sameSite/secure and auto-handles this.
  - SSO secret handling: key is stored encrypted at rest, never returned to the client, and is masked in Builder; reusing a masked key is blocked if the algorithm changes.

- **Migration**
  - No changes if you don’t use embeds; current embeds continue to work.
  - To restrict embedding, add allowed domains in Builder → Embed.
  - To enable SSO, configure Embed SSO and have the host append ?jwt=<token>; HTTPS is required for cross-site cookies, and users must already exist. Changing the JWT algorithm requires entering a new verification key.

<sup>Written for commit 48b3e81bb535db685868e6cd9c328f0be74b28c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/18888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

