### PR TITLE
Ignore updates for 'svelte' dependency in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: "@budibase/*"
+      - dependency-name: "svelte"
     open-pull-requests-limit: 0
     groups:
       all-non-major-security:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `svelte` to the ignore list in `.github/dependabot.yml` to stop automated version bump PRs. Reduces noise and keeps the current `svelte` version until we choose to upgrade.

<sup>Written for commit 7643c7d1a8dfaad28ea3c4edcbc1b8a837d2f987. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/18890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

