### PR TITLE
Fix PWA zip symlink file reads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Each commit requires permission.
 Never auto-push changes unless explicitly asked to do so. You may ask permission to push.
 Each push requires permission.
 
-Never auto-stage or add changes unless explicitly asked to do so. As a developer I want to review the changes that the LLM has made.
+Never auto-stage or add changes unless explicitly asked to do so. As a developer I want to review the changes that the LLM has made. If I have already staged changes, then leave the changes staged.
 
 For example, if I command `git add, commit, push` go ahead and do that once. Any subsequent changes will require permission. You may ask for permission on a per commit basis.
 

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -278,12 +278,7 @@ export async function processPWAZip(ctx: UserCtx) {
         }
       }
 
-      if (
-        !icon.src ||
-        !icon.sizes ||
-        !resolvedSrc ||
-        !validIconFile
-      ) {
+      if (!icon.src || !icon.sizes || !resolvedSrc || !validIconFile) {
         continue
       }
 

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -235,7 +235,13 @@ export async function processPWAZip(ctx: UserCtx) {
     await extract(filePath, { dir: tempDir })
     const iconsJsonPath = join(tempDir, "icons.json")
 
-    if (!fs.existsSync(iconsJsonPath)) {
+    let iconsJsonStats
+    try {
+      iconsJsonStats = await fsp.lstat(iconsJsonPath)
+    } catch (_err) {
+      ctx.throw(400, "Invalid zip structure - missing icons.json")
+    }
+    if (!iconsJsonStats.isFile()) {
       ctx.throw(400, "Invalid zip structure - missing icons.json")
     }
 
@@ -253,16 +259,30 @@ export async function processPWAZip(ctx: UserCtx) {
 
     const icons = []
     const baseDir = path.dirname(iconsJsonPath)
+    const realBaseDir = await fsp.realpath(baseDir)
     const appId = context.getProdWorkspaceId()
 
     for (const icon of iconsData.icons) {
       const resolvedSrc = icon.src ? path.resolve(baseDir, icon.src) : undefined
+      let validIconFile = false
+      if (resolvedSrc?.startsWith(baseDir + path.sep)) {
+        try {
+          const [iconStats, realSrc] = await Promise.all([
+            fsp.lstat(resolvedSrc),
+            fsp.realpath(resolvedSrc),
+          ])
+          validIconFile =
+            iconStats.isFile() && realSrc.startsWith(realBaseDir + path.sep)
+        } catch (_err) {
+          validIconFile = false
+        }
+      }
+
       if (
         !icon.src ||
         !icon.sizes ||
         !resolvedSrc ||
-        !resolvedSrc.startsWith(baseDir + path.sep) ||
-        !fs.existsSync(resolvedSrc)
+        !validIconFile
       ) {
         continue
       }

--- a/packages/server/src/api/routes/tests/static.spec.ts
+++ b/packages/server/src/api/routes/tests/static.spec.ts
@@ -411,6 +411,78 @@ describe("/static", () => {
         expect(res.body.message).toMatch("No valid icons found in the zip file")
         expect(mockedUpload).not.toHaveBeenCalled()
       })
+
+      it("rejects a symlinked icons.json file", async () => {
+        const sensitiveDir = path.join(tmpdir(), `sensitive-${Date.now()}`)
+        await fsp.mkdir(sensitiveDir, { recursive: true })
+        const sensitiveFile = path.join(sensitiveDir, "icons.json")
+        await fsp.writeFile(
+          sensitiveFile,
+          JSON.stringify({
+            icons: [
+              {
+                src: "icon-192.png",
+                sizes: "192x192",
+                type: "image/png",
+              },
+            ],
+          })
+        )
+        await fsp.writeFile(path.join(tempDir, "icon-192.png"), "fake-png-data")
+        await fsp.symlink(sensitiveFile, path.join(tempDir, "icons.json"))
+
+        try {
+          const res = await request
+            .post("/api/pwa/process-zip")
+            .attach("file", Buffer.from("fake-zip"), "icons.zip")
+            .set(config.defaultHeaders())
+
+          expect(res.status).toEqual(500)
+          expect(res.body.message).toMatch(
+            "Invalid zip structure - missing icons.json"
+          )
+          expect(mockedUpload).not.toHaveBeenCalled()
+        } finally {
+          await fsp.rm(sensitiveDir, { recursive: true, force: true })
+        }
+      })
+
+      it("skips icons whose src is a symlink to a file outside the zip directory", async () => {
+        const sensitiveDir = path.join(tmpdir(), `sensitive-${Date.now()}`)
+        await fsp.mkdir(sensitiveDir, { recursive: true })
+        const sensitiveFile = path.join(sensitiveDir, "secret.png")
+        await fsp.writeFile(sensitiveFile, "sensitive-data")
+        await fsp.symlink(sensitiveFile, path.join(tempDir, "evil.png"))
+
+        try {
+          const iconsJson = {
+            icons: [
+              {
+                src: "evil.png",
+                sizes: "192x192",
+                type: "image/png",
+              },
+            ],
+          }
+          await fsp.writeFile(
+            path.join(tempDir, "icons.json"),
+            JSON.stringify(iconsJson)
+          )
+
+          const res = await request
+            .post("/api/pwa/process-zip")
+            .attach("file", Buffer.from("fake-zip"), "icons.zip")
+            .set(config.defaultHeaders())
+
+          expect(res.status).toEqual(500)
+          expect(res.body.message).toMatch(
+            "No valid icons found in the zip file"
+          )
+          expect(mockedUpload).not.toHaveBeenCalled()
+        } finally {
+          await fsp.rm(sensitiveDir, { recursive: true, force: true })
+        }
+      })
     })
   })
 })


### PR DESCRIPTION
## Description
Fixes a PWA zip upload file-read vulnerability where symlink entries in uploaded archives could be followed when reading icons from the extracted zip. The PWA processing now requires `icons.json` and icon sources to be regular files, and verifies icon real paths remain within the extracted archive directory before upload.

## Addresses
- Reported PWA zip symlink file-read vulnerability
- https://github.com/Budibase/vulns/issues/69

## Launchcontrol
Prevents uploaded PWA zip files from using symbolic links to read files from the server filesystem.
