### PR TITLE
Fix webhook trigger parameter override

### DIFF
--- a/packages/server/src/automations/tests/triggers/webhook.spec.ts
+++ b/packages/server/src/automations/tests/triggers/webhook.spec.ts
@@ -101,13 +101,15 @@ describe("Webhook trigger test", () => {
     expect(queuedJob.event.timeout).toBeUndefined()
     expect(queuedJob.event.user).toBeUndefined()
     expect(queuedJob.event.metadata).toBeUndefined()
-    expect(queuedJob.event.normalData).toEqual("test")
-    expect(queuedJob.event.body).toEqual({
-      appId: "app_victim",
-      timeout: 1,
-      user: { email: "attacker@example.com" },
-      metadata: { automationChainCount: -1 },
+    expect(queuedJob.event).toMatchObject({
       normalData: "test",
+      body: {
+        appId: "app_victim",
+        timeout: 1,
+        user: { email: "attacker@example.com" },
+        metadata: { automationChainCount: -1 },
+        normalData: "test",
+      },
     })
 
     addMock.mockRestore()

--- a/packages/server/src/automations/tests/triggers/webhook.spec.ts
+++ b/packages/server/src/automations/tests/triggers/webhook.spec.ts
@@ -1,6 +1,8 @@
 import { mocks } from "@budibase/backend-core/tests"
 import { Table, Webhook, WebhookActionType } from "@budibase/types"
 import TestConfiguration from "../../../tests/utilities/TestConfiguration"
+import { automationQueue } from "../../bullboard"
+import { externalTrigger } from "../../triggers"
 import { createAutomationBuilder } from "../utilities/AutomationTestBuilder"
 
 mocks.licenses.useSyncAutomations()
@@ -62,5 +64,52 @@ describe("Webhook trigger test", () => {
     expect(typeof res).toBe("object")
     const collectedInfo = res as Record<string, any>
     expect(collectedInfo.value).toEqual("testing")
+  })
+
+  it("does not allow webhook fields to override automation execution params", async () => {
+    const addMock = jest
+      .spyOn(automationQueue, "add")
+      .mockResolvedValue({} as Awaited<ReturnType<typeof automationQueue.add>>)
+
+    const { automation } = await createAutomationBuilder(config)
+      .onWebhook({ body: {} })
+      .serverLog({ text: "{{ trigger.normalData }}" })
+      .save()
+
+    await config.doInContext(config.getProdWorkspaceId(), () =>
+      externalTrigger(automation, {
+        appId: config.getProdWorkspaceId(),
+        fields: {
+          appId: "app_victim",
+          timeout: 1,
+          user: { email: "attacker@example.com" },
+          metadata: { automationChainCount: -1 },
+          normalData: "test",
+          body: {
+            appId: "app_victim",
+            timeout: 1,
+            user: { email: "attacker@example.com" },
+            metadata: { automationChainCount: -1 },
+            normalData: "test",
+          },
+        },
+      })
+    )
+
+    const queuedJob = addMock.mock.calls[0][0]
+    expect(queuedJob.event.appId).toEqual(config.getProdWorkspaceId())
+    expect(queuedJob.event.timeout).toBeUndefined()
+    expect(queuedJob.event.user).toBeUndefined()
+    expect(queuedJob.event.metadata).toBeUndefined()
+    expect(queuedJob.event.normalData).toEqual("test")
+    expect(queuedJob.event.body).toEqual({
+      appId: "app_victim",
+      timeout: 1,
+      user: { email: "attacker@example.com" },
+      metadata: { automationChainCount: -1 },
+      normalData: "test",
+    })
+
+    addMock.mockRestore()
   })
 })

--- a/packages/server/src/automations/triggers.ts
+++ b/packages/server/src/automations/triggers.ts
@@ -235,9 +235,18 @@ export async function externalTrigger(
     sdk.automations.isRowAction(automation) ||
     sdk.automations.isWebhookAction(automation)
   ) {
+    const {
+      appId: _appId,
+      timeout: _timeout,
+      user: _user,
+      metadata: _metadata,
+      automation: _automation,
+      ...fields
+    } = params.fields || {}
+
     params = {
       ...params,
-      ...params.fields,
+      ...fields,
       fields: {},
     }
   }


### PR DESCRIPTION
## Description
Fixes a webhook trigger mass assignment issue where flattened webhook fields could override internal automation execution parameters such as appId, timeout, user, metadata, and automation before an async automation job was queued.

## Addresses
- https://github.com/Budibase/vulns/issues/55

## Launchcontrol
Prevents webhook request payloads from overriding internal automation execution context.

