### PR TITLE
Fix relationship field name validation

### DIFF
--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -654,7 +654,9 @@
       const relatedTable = $tables.list.find(
         tbl => tbl._id === fieldInfo.tableId
       )
-      if (inUse(relatedTable, fieldInfo.fieldName) && !originalName) {
+      if (!fieldInfo.fieldName.match(ValidColumnNameRegex)) {
+        newError.relatedName = `Illegal character; must be alpha-numeric.`
+      } else if (inUse(relatedTable, fieldInfo.fieldName) && !originalName) {
         newError.relatedName = `Column name already in use in table ${relatedTable?.name}`
       }
     }

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -631,6 +631,10 @@ export const getSignedUploadURL = async function (
     if (!bucket || !key) {
       ctx.throw(400, "bucket and key values are required")
     }
+    const datasourceBucket = datasource?.config?.bucket
+    if (datasourceBucket && datasourceBucket !== bucket) {
+      ctx.throw(400, "bucket must match the datasource configuration")
+    }
     try {
       let endpoint = datasource?.config?.endpoint
       if (endpoint && !utils.urlHasProtocol(endpoint)) {

--- a/packages/server/src/api/routes/tests/static.spec.ts
+++ b/packages/server/src/api/routes/tests/static.spec.ts
@@ -215,6 +215,35 @@ describe("/static", () => {
         expect(res.body.message).toEqual("bucket and key values are required")
       })
 
+      it("should reject buckets that do not match a datasource bucket constraint", async () => {
+        const constrainedDatasource = await config.createDatasource({
+          datasource: {
+            type: "datasource",
+            name: "Constrained Test",
+            source: SourceName.S3,
+            config: {
+              accessKeyId: "bb",
+              secretAccessKey: "bb",
+              bucket: "allowed-bucket",
+            },
+          },
+        })
+
+        const res = await request
+          .post(`/api/attachments/${constrainedDatasource._id}/url`)
+          .send({
+            bucket: "other-bucket",
+            key: "bar",
+          })
+          .set(config.defaultHeaders())
+          .expect("Content-Type", /json/)
+          .expect(400)
+
+        expect(res.body.message).toEqual(
+          "bucket must match the datasource configuration"
+        )
+      })
+
       it("should allow non-creator app users to generate a signed upload URL", async () => {
         await config.loginAsRole(roles.BUILTIN_ROLE_IDS.BASIC, async () => {
           const res = await request

--- a/packages/server/src/automations/tests/steps/updateRow.spec.ts
+++ b/packages/server/src/automations/tests/steps/updateRow.spec.ts
@@ -19,6 +19,8 @@ describe("test the update row action", () => {
   let table: Table
   let row: Row
 
+  const uniqueFieldName = () => uuid.v4().replace(/-/g, "")
+
   beforeAll(async () => {
     await config.init()
     table = await config.createTable()
@@ -94,8 +96,8 @@ describe("test the update row action", () => {
       sourceType: TableSourceType.INTERNAL,
       sourceId: INTERNAL_TABLE_SOURCE_ID,
       schema: {
-        user1: { ...linkField, name: "user1", fieldName: uuid.v4() },
-        user2: { ...linkField, name: "user2", fieldName: uuid.v4() },
+        user1: { ...linkField, name: "user1", fieldName: uniqueFieldName() },
+        user2: { ...linkField, name: "user2", fieldName: uniqueFieldName() },
       },
     })
 
@@ -148,8 +150,8 @@ describe("test the update row action", () => {
       sourceType: TableSourceType.INTERNAL,
       sourceId: INTERNAL_TABLE_SOURCE_ID,
       schema: {
-        user1: { ...linkField, name: "user1", fieldName: uuid.v4() },
-        user2: { ...linkField, name: "user2", fieldName: uuid.v4() },
+        user1: { ...linkField, name: "user1", fieldName: uniqueFieldName() },
+        user2: { ...linkField, name: "user2", fieldName: uniqueFieldName() },
       },
     })
 

--- a/packages/server/src/db/linkedRows/LinkController.ts
+++ b/packages/server/src/db/linkedRows/LinkController.ts
@@ -1,4 +1,5 @@
 import { context, logging } from "@budibase/backend-core"
+import { ValidColumnNameRegex } from "@budibase/shared-core"
 import {
   Database,
   FieldSchema,
@@ -96,6 +97,9 @@ class LinkController {
     for (let schema of Object.values(table.schema)) {
       if (schema.type !== FieldType.LINK) {
         continue
+      }
+      if (schema.fieldName && !schema.fieldName.match(ValidColumnNameRegex)) {
+        throw new Error("Column names can't contain special characters")
       }
       const unique = schema.tableId! + schema?.fieldName
       if (usedAlready.indexOf(unique) !== -1) {

--- a/packages/server/src/db/tests/linkController.spec.ts
+++ b/packages/server/src/db/tests/linkController.spec.ts
@@ -204,6 +204,24 @@ describe("test the link controller", () => {
     )
   })
 
+  it("should throw an error when linked field name has illegal characters", async () => {
+    const controller = await createLinkController(table1)
+    const copyTable = cloneDeep(table1)
+    copyTable.schema.link.fieldName = "Table 2!@£$%^&*()>"
+
+    let error: any
+    try {
+      controller.validateTable(copyTable)
+    } catch (err) {
+      error = err
+    }
+
+    expect(error).toBeDefined()
+    expect(error.message).toEqual(
+      "Column names can't contain special characters"
+    )
+  })
+
   it("should be able to remove a link when saving/updating the row", async () => {
     const row = await createLinkedRow()
     // remove the link from the row

--- a/packages/server/src/db/tests/linkController.spec.ts
+++ b/packages/server/src/db/tests/linkController.spec.ts
@@ -207,7 +207,8 @@ describe("test the link controller", () => {
   it("should throw an error when linked field name has illegal characters", async () => {
     const controller = await createLinkController(table1)
     const copyTable = cloneDeep(table1)
-    copyTable.schema.link.fieldName = "Table 2!@£$%^&*()>"
+    const linkSchema = copyTable.schema.link as RelationshipFieldMetadata
+    linkSchema.fieldName = "Table 2!@£$%^&*()>"
 
     let error: any
     try {


### PR DESCRIPTION
## Summary
- validate linked relationship field names on the server using existing column name rules
- show builder validation errors for invalid related column names

Also addresses an issue relating to S3 Buckets name verification:
- keep S3 signed upload auth coverage and reject mismatched datasource buckets when configured

## Addresses
- https://github.com/Budibase/budibase/issues/18786
- https://github.com/Budibase/vulns/issues/72

## Screenshots

<img width="702" height="613" alt="illegal rel characters" src="https://github.com/user-attachments/assets/1016218c-4ec0-464d-89f4-2ee42f3ce7f0" />

**No longer allowed to create a relationship column with illegal characters**

<img width="1077" height="314" alt="rel" src="https://github.com/user-attachments/assets/0f076151-6e1f-4321-a8e7-2dfe73277de7" />

**Relationship works fine, even if the underlying table name has illegal column characters**
