### PR TITLE
[18091] Fix 498 error when triggering public automation with reCAPTCHA enabled (public screens -> unauthenticated user)  

### DIFF
--- a/packages/builder/src/settings/pages/recaptcha.svelte
+++ b/packages/builder/src/settings/pages/recaptcha.svelte
@@ -17,6 +17,7 @@
   import { onMount } from "svelte"
   import LockedFeature from "@/pages/builder/_components/LockedFeature.svelte"
   import RouteActions from "@/settings/components/RouteActions.svelte"
+  import { recaptchaStore } from "@/stores/builder"
 
   $redirect
 
@@ -53,6 +54,7 @@
         },
       }
       await API.saveConfig(recaptchaConfig)
+      recaptchaStore.setAvailable(true)
       notifications.success(`Recaptcha configuration updated`)
     } catch (err: any) {
       notifications.error(

--- a/packages/builder/src/stores/builder/recaptcha.ts
+++ b/packages/builder/src/stores/builder/recaptcha.ts
@@ -24,6 +24,14 @@ export class RecaptchaStore extends BudiStore<RecaptchaState> {
     })
   }
 
+  setAvailable = (available: boolean) => {
+    this.update(state => {
+      state.available = available
+      state.enabled = state.enabled && available
+      return state
+    })
+  }
+
   async setState(enabled: boolean) {
     const appId = get(appStore).appId
     await API.saveAppMetadata(appId, {

--- a/packages/client/src/components/ClientApp.svelte
+++ b/packages/client/src/components/ClientApp.svelte
@@ -229,7 +229,7 @@
   >
     {#if $environmentStore.maintenance.length > 0}
       <MaintenanceScreen maintenanceList={$environmentStore.maintenance} />
-    {:else if $featuresStore.recaptchaEnabled && $appStore.application?.features?.recaptchaEnabled && $appStore.recaptchaKey && !$recaptchaStore.verified && !$builderStore.inBuilder}
+    {:else if $appStore.recaptchaEnabled && $appStore.application?.features?.recaptchaEnabled && $appStore.recaptchaKey && !$recaptchaStore.verified && !$builderStore.inBuilder}
       <RecaptchaV2 />
     {:else}
       <EmbedProvider>

--- a/packages/client/src/stores/app.ts
+++ b/packages/client/src/stores/app.ts
@@ -13,6 +13,7 @@ interface AppStoreState {
   application?: Workspace
   pageWidth?: string
   recaptchaKey?: string
+  recaptchaEnabled?: boolean
   clientCacheKey?: string
 }
 

--- a/packages/server/src/api/controllers/recaptcha.ts
+++ b/packages/server/src/api/controllers/recaptcha.ts
@@ -48,7 +48,10 @@ export async function verify(
       const session: RecaptchaSessionCookie = {
         sessionId,
       }
-      utils.setCookie(ctx, session, Cookie.RecaptchaSession)
+      utils.setCookie(ctx, session, Cookie.RecaptchaSession, {
+        sign: true,
+        sameSite: "none",
+      })
     }
 
     ctx.body = {

--- a/packages/server/src/api/controllers/workspace.ts
+++ b/packages/server/src/api/controllers/workspace.ts
@@ -40,6 +40,7 @@ import {
   FetchPublishedChatAppsResponse,
   FetchWorkspacesResponse,
   FieldType,
+  Feature,
   ImportToUpdateWorkspaceRequest,
   ImportToUpdateWorkspaceResponse,
   Layout,
@@ -69,6 +70,7 @@ import {
   generateUserMetadataID,
   generateWorkspaceID,
   getDevWorkspaceID,
+  getProdWorkspaceID,
   getLayoutParams,
   isDevWorkspaceID,
   WorkspaceStatus,
@@ -618,6 +620,7 @@ export async function fetchAppPackage(
     clientLibPath,
     hasLock: await doesUserHaveLock(application.appId, ctx.user),
     recaptchaKey: recaptchaConfig?.config.siteKey,
+    recaptchaEnabled: license?.features?.includes(Feature.RECAPTCHA) ?? false,
     clientCacheKey,
   }
 }
@@ -1074,6 +1077,7 @@ export async function update(
   }
 
   const app = await updateWorkspacePackage(ctx.request.body, ctx.params.appId)
+  await syncRecaptchaStateToPublishedApp(ctx.params.appId, ctx.request.body)
   await events.app.updated(app)
   ctx.body = app
   builderSocket?.emitAppMetadataUpdate(ctx, {
@@ -1087,6 +1091,36 @@ export async function update(
       chainAutomations: app.automations?.chainAutomations,
     },
   })
+}
+
+const syncRecaptchaStateToPublishedApp = async (
+  workspaceId: string,
+  updates: UpdateWorkspaceRequest
+) => {
+  const recaptchaEnabled = updates.features?.recaptchaEnabled
+  if (!isDevWorkspaceID(workspaceId) || typeof recaptchaEnabled !== "boolean") {
+    return
+  }
+
+  const prodWorkspaceId = getProdWorkspaceID(workspaceId)
+  const prodMetadata = await context.doInWorkspaceContext(
+    prodWorkspaceId,
+    async () => {
+      return sdk.workspaces.metadata.tryGet()
+    }
+  )
+  if (!prodMetadata) {
+    return
+  }
+
+  await updateWorkspacePackage(
+    {
+      features: {
+        recaptchaEnabled,
+      },
+    },
+    prodWorkspaceId
+  )
 }
 
 export async function updateClient(

--- a/packages/server/src/api/routes/tests/recaptcha.spec.ts
+++ b/packages/server/src/api/routes/tests/recaptcha.spec.ts
@@ -79,9 +79,34 @@ describe("/recaptcha", () => {
         { status: 200 }
       )
       expect(res.body.verified).toBe(true)
+      expect(res.headers["set-cookie"][0].toLowerCase()).toContain(
+        "samesite=lax"
+      )
 
       // Check if the nock interceptor was called
       expect(scope.isDone()).toBe(true)
+    })
+
+    it("should set a cross-site recaptcha cookie over https", async () => {
+      recaptchaSucceed()
+
+      await config.withHeaders(
+        {
+          "X-Forwarded-Proto": "https",
+        },
+        async () => {
+          const res = await config.api.recaptcha.verify(
+            {
+              token: "valid-token",
+            },
+            { status: 200 }
+          )
+          const cookie = res.headers["set-cookie"][0].toLowerCase()
+
+          expect(cookie).toContain("samesite=none")
+          expect(cookie).toContain("secure")
+        }
+      )
     })
 
     it("should handle invalid recaptcha token", async () => {

--- a/packages/server/src/api/routes/tests/workspace.spec.ts
+++ b/packages/server/src/api/routes/tests/workspace.spec.ts
@@ -8,6 +8,7 @@ import {
   type Workspace,
   AppFontFamily,
   BuiltinPermissionID,
+  Feature,
   PermissionLevel,
   Screen,
   Theme,
@@ -929,6 +930,21 @@ describe("/applications", () => {
       )
     })
 
+    it("should expose recaptcha availability to public app packages", async () => {
+      mocks.licenses.useUnlimited({ features: [Feature.RECAPTCHA] })
+
+      await config.publish()
+      const res = await config.withHeaders(
+        { referer: `http://localhost:10000/app${workspace.url}` },
+        () =>
+          config.api.workspace.getAppPackage(config.getProdWorkspaceId(), {
+            publicUser: true,
+          })
+      )
+
+      expect(res.recaptchaEnabled).toBe(true)
+    })
+
     it("should allow users in multiple groups with different roles to access all permitted screens", async () => {
       mocks.licenses.useUnlimited()
 
@@ -1359,6 +1375,20 @@ describe("/applications", () => {
       })
 
       expect(updatedApp.name).toBe("TEST_APP")
+    })
+
+    it("updates published recaptcha state without requiring publish", async () => {
+      await config.api.workspace.publish(workspace.appId)
+      await config.api.workspace.update(workspace.appId, {
+        features: {
+          recaptchaEnabled: true,
+        },
+      })
+
+      await config.withProdApp(async () => {
+        const prodApp = await sdk.workspaces.metadata.get()
+        expect(prodApp.features?.recaptchaEnabled).toBe(true)
+      })
     })
   })
 

--- a/packages/server/src/db/utils.ts
+++ b/packages/server/src/db/utils.ts
@@ -48,6 +48,7 @@ export const InternalTables = dbCore.InternalTable
 export const UNICODE_MAX = dbCore.UNICODE_MAX
 export const generateWorkspaceID = dbCore.generateWorkspaceID
 export const getDevWorkspaceID = dbCore.getDevWorkspaceID
+export const getProdWorkspaceID = dbCore.getProdWorkspaceID
 export const generateRoleID = dbCore.generateRoleID
 export const getRoleParams = dbCore.getRoleParams
 export const getQueryIndex = dbCore.getQueryIndex

--- a/packages/types/src/api/web/workspace/workspace.ts
+++ b/packages/types/src/api/web/workspace/workspace.ts
@@ -52,6 +52,7 @@ export interface FetchAppPackageResponse {
   clientLibPath: string
   hasLock: boolean
   recaptchaKey?: string
+  recaptchaEnabled?: boolean
   clientCacheKey?: string
 }
 


### PR DESCRIPTION
## Description
Fix the recaptcha session cookie so it can be shared cross-site over HTTPS while keeping local behavior intact.

## Addresses
- https://github.com/Budibase/budibase/issues/18091

## Launchcontrol
Adjust recaptcha session cookie settings so HTTPS cross-site flows work correctly.

