### PR TITLE
Validate AI configuration and improve agent live toggle handling

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
@@ -56,6 +56,9 @@
     if (!currentAgent?._id) {
       return false
     }
+    if (!currentAgent.live) {
+      return false
+    }
     const publishStatus = $workspaceDeploymentStore.agents[currentAgent._id]
     if (!publishStatus?.publishedAt) {
       return false

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/_layout.svelte
@@ -110,8 +110,14 @@
       )
     } catch (error) {
       console.error(error)
+      const errorMessage = nextLive
+        ? "Error setting agent live"
+        : "Error stopping agent"
+
       notifications.error(
-        nextLive ? "Error setting agent live" : "Error stopping agent"
+        [errorMessage, (error as { message?: string }).message]
+          .filter(Boolean)
+          .join(": ")
       )
     } finally {
       togglingLive = false

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/config.svelte
@@ -383,12 +383,6 @@
   }) {
     if (!currentAgent) return
     if (saving) return
-    if (!draft.aiconfig) {
-      if (showNotifications) {
-        notifications.error("Please select an AI model")
-      }
-      return
-    }
 
     saving = true
     try {

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -399,9 +399,7 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
   ctx.res.setHeader("Transfer-Encoding", "chunked")
 
   const agent = await sdk.ai.agents.getOrThrow(agentId)
-  if (!agent.aiconfig) {
-    ctx.throw(500, "Agent is not properly configured: missing AI config")
-  }
+  await sdk.ai.agents.assertAgentHasValidConfig(agent)
 
   try {
     const chatId = chat._id ?? docIds.generateChatConversationID()

--- a/packages/server/src/api/controllers/ai/chatConversations.ts
+++ b/packages/server/src/api/controllers/ai/chatConversations.ts
@@ -399,6 +399,9 @@ export async function agentChatStream(ctx: UserCtx<ChatAgentRequest, void>) {
   ctx.res.setHeader("Transfer-Encoding", "chunked")
 
   const agent = await sdk.ai.agents.getOrThrow(agentId)
+  if (!agent.aiconfig) {
+    ctx.throw(500, "Agent is not properly configured: missing AI config")
+  }
 
   try {
     const chatId = chat._id ?? docIds.generateChatConversationID()

--- a/packages/server/src/api/routes/tests/ai/agent.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agent.spec.ts
@@ -1,7 +1,9 @@
 import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
+import { setupDefaultCompletionsAIConfig } from "../../../../tests/utilities/aiConfig"
 
 describe("agent duplicate", () => {
   const config = new TestConfiguration()
+  let cleanupAIConfig: undefined | (() => Promise<void>)
 
   afterAll(() => {
     config.end()
@@ -9,6 +11,12 @@ describe("agent duplicate", () => {
 
   beforeEach(async () => {
     await config.newTenant()
+    cleanupAIConfig = await setupDefaultCompletionsAIConfig(config, "default")
+  })
+
+  afterEach(async () => {
+    await cleanupAIConfig?.()
+    cleanupAIConfig = undefined
   })
 
   it("duplicates an agent with a unique copy name", async () => {

--- a/packages/server/src/api/routes/tests/ai/agentDiscord.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentDiscord.spec.ts
@@ -44,6 +44,7 @@ import {
 } from "@budibase/types"
 import sdk from "../../../../sdk"
 import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
+import { setupDefaultCompletionsAIConfig } from "../../../../tests/utilities/aiConfig"
 import { webhookChat } from "../../../controllers/ai/chatConversations"
 
 const DISCORD_PUBLIC_KEY_DER_PREFIX = "302a300506032b6570032100"
@@ -99,6 +100,7 @@ const secretMatch = (plain: string, encoded: string) => {
 
 describe("agent discord integration sync", () => {
   const config = new TestConfiguration()
+  let cleanupAIConfig: undefined | (() => Promise<void>)
 
   async function getPersistedAgent(id: string | undefined) {
     const result = await db.doWithDB(config.getDevWorkspaceId(), db =>
@@ -117,8 +119,17 @@ describe("agent discord integration sync", () => {
 
   beforeEach(async () => {
     await config.newTenant()
+    cleanupAIConfig = await setupDefaultCompletionsAIConfig(
+      config,
+      "test-config"
+    )
     mockedWebhookChat.mockClear()
     nock.cleanAll()
+  })
+
+  afterEach(async () => {
+    await cleanupAIConfig?.()
+    cleanupAIConfig = undefined
   })
 
   afterAll(() => {

--- a/packages/server/src/api/routes/tests/ai/agentSlack.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentSlack.spec.ts
@@ -50,6 +50,7 @@ import {
   type ChatConversation,
 } from "@budibase/types"
 import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
+import { setupDefaultCompletionsAIConfig } from "../../../../tests/utilities/aiConfig"
 import { webhookChat } from "../../../controllers/ai/chatConversations"
 
 const SECRET_ENCODING_PREFIX = "bbai_enc::"
@@ -81,6 +82,7 @@ const secretMatch = (plain: string, encoded: string) => {
 
 describe("agent slack integration provisioning", () => {
   const config = new TestConfiguration()
+  let cleanupAIConfig: undefined | (() => Promise<void>)
 
   async function getPersistedAgent(id: string | undefined) {
     const result = await db.doWithDB(config.getDevWorkspaceId(), db =>
@@ -99,8 +101,17 @@ describe("agent slack integration provisioning", () => {
 
   beforeEach(async () => {
     await config.newTenant()
+    cleanupAIConfig = await setupDefaultCompletionsAIConfig(
+      config,
+      "test-config"
+    )
     mockedWebhookChat.mockClear()
     resetMockChatState()
+  })
+
+  afterEach(async () => {
+    await cleanupAIConfig?.()
+    cleanupAIConfig = undefined
   })
 
   afterAll(() => {

--- a/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
@@ -63,6 +63,7 @@ import {
   type ChatConversation,
 } from "@budibase/types"
 import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
+import { setupDefaultCompletionsAIConfig } from "../../../../tests/utilities/aiConfig"
 import { webhookChat } from "../../../controllers/ai/chatConversations"
 
 const { getMockChatOptions, resetMockChatState, setMockPostEphemeralResult } =
@@ -78,6 +79,7 @@ const extractLinkUrl = (messages: string[]) => {
 
 describe("agent teams integration provisioning", () => {
   const config = new TestConfiguration()
+  let cleanupAIConfig: undefined | (() => Promise<void>)
 
   const getPersistedChatApp = async (
     workspaceId = config.getDevWorkspaceId()
@@ -88,8 +90,17 @@ describe("agent teams integration provisioning", () => {
 
   beforeEach(async () => {
     await config.newTenant()
+    cleanupAIConfig = await setupDefaultCompletionsAIConfig(
+      config,
+      "test-config"
+    )
     mockedWebhookChat.mockClear()
     resetMockChatState()
+  })
+
+  afterEach(async () => {
+    await cleanupAIConfig?.()
+    cleanupAIConfig = undefined
   })
 
   afterAll(() => {

--- a/packages/server/src/api/routes/tests/ai/agentTelegram.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentTelegram.spec.ts
@@ -50,6 +50,7 @@ import {
   type ChatConversation,
 } from "@budibase/types"
 import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
+import { setupDefaultCompletionsAIConfig } from "../../../../tests/utilities/aiConfig"
 import { webhookChat } from "../../../controllers/ai/chatConversations"
 
 const SECRET_ENCODING_PREFIX = "bbai_enc::"
@@ -76,6 +77,7 @@ const secretMatch = (plain: string, encoded: string) => {
 
 describe("agent telegram integration provisioning", () => {
   const config = new TestConfiguration()
+  let cleanupAIConfig: undefined | (() => Promise<void>)
 
   async function getPersistedAgent(id: string | undefined) {
     const result = await db.doWithDB(config.getDevWorkspaceId(), db =>
@@ -99,9 +101,18 @@ describe("agent telegram integration provisioning", () => {
 
   beforeEach(async () => {
     await config.newTenant()
+    cleanupAIConfig = await setupDefaultCompletionsAIConfig(
+      config,
+      "test-config"
+    )
     mockedWebhookChat.mockClear()
     resetMockChatState()
     mockFetch()
+  })
+
+  afterEach(async () => {
+    await cleanupAIConfig?.()
+    cleanupAIConfig = undefined
   })
 
   afterEach(() => {

--- a/packages/server/src/api/routes/tests/deploy.spec.ts
+++ b/packages/server/src/api/routes/tests/deploy.spec.ts
@@ -13,10 +13,12 @@ import { cloneDeep } from "lodash/fp"
 import { createAutomationBuilder } from "../../../automations/tests/utilities/AutomationTestBuilder"
 import { getRowParams } from "../../../db/utils"
 import { basicTable } from "../../../tests/utilities/structures"
+import { setupDefaultCompletionsAIConfig } from "../../../tests/utilities/aiConfig"
 import * as setup from "./utilities"
 
 describe("/api/deploy", () => {
   let config = setup.getConfig()
+  let cleanupAIConfig: undefined | (() => Promise<void>)
 
   afterAll(() => {
     setup.afterAll()
@@ -28,6 +30,12 @@ describe("/api/deploy", () => {
 
   beforeEach(async () => {
     await config.newTenant()
+    cleanupAIConfig = await setupDefaultCompletionsAIConfig(config, "default")
+  })
+
+  afterEach(async () => {
+    await cleanupAIConfig?.()
+    cleanupAIConfig = undefined
   })
 
   describe("GET /api/deploy/status", () => {

--- a/packages/server/src/sdk/workspace/ai/agents/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/crud.spec.ts
@@ -17,7 +17,7 @@ const mockKnowledgeBaseFind = jest.fn()
 const mockKnowledgeBaseListFiles = jest.fn()
 const mockKnowledgeBaseRemoveFile = jest.fn()
 const mockKnowledgeBaseRemove = jest.fn()
-const mockCreateLLM = jest.fn()
+const mockAssertAgentHasValidConfig = jest.fn().mockResolvedValue(undefined)
 
 jest.mock("@budibase/backend-core", () => {
   const actual = jest.requireActual("@budibase/backend-core")
@@ -48,9 +48,12 @@ jest.mock("../knowledgeBase", () => ({
   remove: (...args: any[]) => mockKnowledgeBaseRemove(...args),
 }))
 
-jest.mock("../llm", () => ({
-  createLLM: (...args: any[]) => mockCreateLLM(...args),
-}))
+jest.mock("./utils", () => {
+  return {
+    assertAgentHasValidConfig: (...args: any[]) =>
+      mockAssertAgentHasValidConfig(...args),
+  }
+})
 
 import type { Agent, KnowledgeBase, KnowledgeBaseFile } from "@budibase/types"
 import * as agentsCrud from "./crud"
@@ -58,7 +61,6 @@ import * as agentsCrud from "./crud"
 describe("agents crud", () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockCreateLLM.mockResolvedValue({})
   })
 
   describe("remove", () => {
@@ -223,7 +225,13 @@ describe("agents crud", () => {
         live: true,
       })
 
-      expect(mockCreateLLM).toHaveBeenCalledWith("cfg_1")
+      expect(mockAssertAgentHasValidConfig).toHaveBeenCalledTimes(1)
+      expect(mockAssertAgentHasValidConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          aiconfig: "cfg_1",
+          live: true,
+        })
+      )
     })
   })
 
@@ -270,7 +278,14 @@ describe("agents crud", () => {
         live: true,
       })
 
-      expect(mockCreateLLM).toHaveBeenCalledWith("cfg_1")
+      expect(mockAssertAgentHasValidConfig).toHaveBeenCalledTimes(1)
+      expect(mockAssertAgentHasValidConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _id: "agent_upd",
+          aiconfig: "cfg_1",
+          live: true,
+        })
+      )
     })
   })
 })

--- a/packages/server/src/sdk/workspace/ai/agents/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/crud.spec.ts
@@ -17,6 +17,7 @@ const mockKnowledgeBaseFind = jest.fn()
 const mockKnowledgeBaseListFiles = jest.fn()
 const mockKnowledgeBaseRemoveFile = jest.fn()
 const mockKnowledgeBaseRemove = jest.fn()
+const mockCreateLLM = jest.fn()
 
 jest.mock("@budibase/backend-core", () => {
   const actual = jest.requireActual("@budibase/backend-core")
@@ -47,12 +48,17 @@ jest.mock("../knowledgeBase", () => ({
   remove: (...args: any[]) => mockKnowledgeBaseRemove(...args),
 }))
 
+jest.mock("../llm", () => ({
+  createLLM: (...args: any[]) => mockCreateLLM(...args),
+}))
+
 import type { Agent, KnowledgeBase, KnowledgeBaseFile } from "@budibase/types"
 import * as agentsCrud from "./crud"
 
 describe("agents crud", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockCreateLLM.mockResolvedValue({})
   })
 
   describe("remove", () => {
@@ -206,6 +212,19 @@ describe("agents crud", () => {
         expect.objectContaining({ name: "New Agent" })
       )
     })
+
+    it("validates the AI config before publishing a live agent", async () => {
+      mockDbPut.mockResolvedValue({ rev: "1-new" })
+      mockDbTryGet.mockResolvedValue(undefined)
+
+      await agentsCrud.create({
+        name: "Live Agent",
+        aiconfig: "cfg_1",
+        live: true,
+      })
+
+      expect(mockCreateLLM).toHaveBeenCalledWith("cfg_1")
+    })
   })
 
   describe("update", () => {
@@ -230,6 +249,28 @@ describe("agents crud", () => {
       expect(mockAgentUpdated).toHaveBeenCalledWith(
         expect.objectContaining({ _id: "agent_upd", name: "Updated Name" })
       )
+    })
+
+    it("validates the AI config before publishing an agent", async () => {
+      const existing = {
+        _id: "agent_upd",
+        _rev: "1-abc",
+        name: "Original Name",
+        aiconfig: "cfg_1",
+        enabledTools: [],
+        knowledgeBases: [],
+        live: false,
+      } as Agent
+
+      mockDbTryGet.mockResolvedValue(existing)
+      mockDbPut.mockResolvedValue({ rev: "2-abc" })
+
+      await agentsCrud.update({
+        ...existing,
+        live: true,
+      })
+
+      expect(mockCreateLLM).toHaveBeenCalledWith("cfg_1")
     })
   })
 })

--- a/packages/server/src/sdk/workspace/ai/agents/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/crud.ts
@@ -9,6 +9,7 @@ import { DocumentType } from "@budibase/types"
 import type { Agent, Optional } from "@budibase/types"
 import { helpers } from "@budibase/shared-core"
 import * as knowledgeBaseSdk from "../knowledgeBase"
+import { assertAgentHasValidConfig } from "./utils"
 
 const SECRET_MASK = "********"
 const SECRET_ENCODING_PREFIX = "bbai_enc::"
@@ -329,6 +330,10 @@ export async function create(
     telegramIntegration: request.telegramIntegration,
   }
 
+  if (agent.live) {
+    await assertAgentHasValidConfig(agent)
+  }
+
   const { rev } = await db.put({
     ...agent,
     discordIntegration: encodeDiscordIntegrationSecrets(
@@ -416,6 +421,10 @@ export async function update(agent: Agent): Promise<Agent> {
       existing: existing?.telegramIntegration,
       incoming: agent.telegramIntegration,
     }),
+  }
+
+  if (updated.live) {
+    await assertAgentHasValidConfig(updated)
   }
 
   const hasBeenPublished =

--- a/packages/server/src/sdk/workspace/ai/agents/utils.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/utils.ts
@@ -303,5 +303,11 @@ export const assertAgentHasValidConfig = async (agent: Agent) => {
     )
   }
 
-  await sdk.ai.llm.createLLM(agent.aiconfig)
+  const aiConfig = await sdk.ai.configs.find(agent.aiconfig)
+  if (!aiConfig) {
+    throw new HTTPError(
+      `Agent is not properly configured: AI config "${agent.aiconfig}" not found`,
+      422
+    )
+  }
 }

--- a/packages/server/src/sdk/workspace/ai/agents/utils.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/utils.ts
@@ -21,6 +21,7 @@ import {
 } from "../../../../ai/tools"
 import sdk from "../../.."
 import { createExaTool, createParallelTool } from "../../../../ai/tools/search"
+import { HTTPError } from "@budibase/backend-core"
 
 const HELPER_TOOL_NAMES = new Set([
   "list_tables",
@@ -292,4 +293,15 @@ export function formatIncompleteToolCallError(
 ): string {
   const toolNames = incompleteTools.map(t => t.toolName).join(", ")
   return `The AI model failed to complete tool execution${toolNames ? ` for: ${toolNames}` : ""}. This may be due to a compatibility issue with the selected model. Please try a different model or try again.`
+}
+
+export const assertAgentHasValidConfig = async (agent: Agent) => {
+  if (!agent.aiconfig) {
+    throw new HTTPError(
+      "Agent is not properly configured: missing AI config",
+      422
+    )
+  }
+
+  await sdk.ai.llm.createLLM(agent.aiconfig)
 }

--- a/packages/server/src/tests/api/chatConversations.spec.ts
+++ b/packages/server/src/tests/api/chatConversations.spec.ts
@@ -11,11 +11,22 @@ import type { LanguageModelUsage, ModelMessage, ToolSet } from "ai"
 import { convertToModelMessages, pruneMessages, streamText } from "ai"
 import { quotas } from "@budibase/pro"
 import TestConfiguration from "../utilities/TestConfiguration"
+import { setupDefaultCompletionsAIConfig } from "../utilities/aiConfig"
 import sdk from "../../sdk"
 import * as agentLogs from "../../sdk/workspace/ai/agentLogs"
 import type { LanguageModelV3 } from "@ai-sdk/provider"
 import { webhookChat } from "../../api/controllers/ai"
 import { MockLanguageModelV3 } from "ai/test"
+
+const mockAiConfigsFind = jest.fn()
+
+jest.mock("../../sdk/workspace/ai/configs", () => {
+  const actual = jest.requireActual("../../sdk/workspace/ai/configs")
+  return {
+    ...actual,
+    find: (...args: any[]) => mockAiConfigsFind(...args),
+  }
+})
 
 jest.mock("@budibase/pro", () => {
   const actual = jest.requireActual("@budibase/pro")
@@ -135,6 +146,7 @@ const createChatTestLanguageModel = () =>
 
 describe("chat conversations authorization", () => {
   const config = new TestConfiguration()
+  let cleanupAIConfig: undefined | (() => Promise<void>)
   let userA: User
   let userB: User
   let chatApp: ChatApp
@@ -147,6 +159,7 @@ describe("chat conversations authorization", () => {
 
   beforeAll(async () => {
     await config.init("chat-conversation-scope")
+    cleanupAIConfig = await setupDefaultCompletionsAIConfig(config, "default")
     userA = config.getUser()
     userB = await config.createUser({
       roles: {
@@ -238,7 +251,8 @@ describe("chat conversations authorization", () => {
     )
   })
 
-  afterAll(() => {
+  afterAll(async () => {
+    await cleanupAIConfig?.()
     config.end()
   })
 
@@ -708,6 +722,7 @@ describe("chat conversation transient behavior", () => {
       providerOptions: jest.fn(),
       uploadFile: jest.fn(),
     })
+    mockAiConfigsFind.mockResolvedValue({ _id: "config-1" } as any)
     ;(
       convertToModelMessages as jest.MockedFunction<
         typeof convertToModelMessages
@@ -1236,6 +1251,7 @@ describe("Agent chat tool call tracking", () => {
       providerOptions: jest.fn().mockReturnValue({}),
       uploadFile: jest.fn(),
     })
+    mockAiConfigsFind.mockResolvedValue({ _id: "config-1" } as any)
     ;(
       convertToModelMessages as jest.MockedFunction<
         typeof convertToModelMessages

--- a/packages/server/src/tests/utilities/aiConfig.ts
+++ b/packages/server/src/tests/utilities/aiConfig.ts
@@ -7,11 +7,10 @@ import {
 import TestConfiguration from "./TestConfiguration"
 
 export async function setupDefaultCompletionsAIConfig(
-  config: TestConfiguration
+  config: TestConfiguration,
+  configId = docIds.generateAIConfigID()
 ): Promise<() => Promise<void>> {
   const created: { workspaceId: string; id: string; rev: string }[] = []
-
-  const configId = docIds.generateAIConfigID()
   await config.withApp(config.getDevWorkspaceId(), async () => {
     const db = context.getWorkspaceDB()
     const workspaceId = config.getDevWorkspaceId()


### PR DESCRIPTION
## Description
Validate agent config when needed, preventing silent errors.

https://jam.dev/c/e9ac4f27-5621-475e-95ac-52dcc9d5125d

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate agent config when an agent is set live (create/update) or starts a chat, using server-side checks with clearer error messages. Prevents silent failures, hides “Unpublished changes” for non‑live agents, and removes a redundant client prompt.

- **Bug Fixes**
  - Validate AI config before chat and any live publish; return 422 if missing or not found.
  - Show detailed server error messages when the live toggle fails.
  - Hide “Unpublished changes” when the agent is not live.

<sup>Written for commit 46f195b4bf88dcd788108c66403ad6712c8f3ae9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/18910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

