### PR TITLE
fix: resolve custom CSS variables in design panel color orb

### DIFF
--- a/packages/bbui/src/ColorPicker/ColorPicker.svelte
+++ b/packages/bbui/src/ColorPicker/ColorPicker.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Popover from "../Popover/Popover.svelte"
   import Layout from "../Layout/Layout.svelte"
-  import { createEventDispatcher } from "svelte"
+  import { createEventDispatcher, onMount } from "svelte"
   import "@spectrum-css/popover/dist/index-vars.css"
   import Icon from "../Icon/Icon.svelte"
   import Input from "../Form/Input.svelte"
@@ -22,6 +22,8 @@
 
   let dropdown: Popover | undefined
   let preview: HTMLElement | undefined
+  let displayColor: string | undefined
+  let refreshColor = 0
 
   $: customValue = getCustomValue(value)
   $: checkColor = getCheckColor(value)
@@ -182,39 +184,80 @@
     return "var(--spectrum-global-color-static-gray-900)"
   }
 
+  const resolveColorInDocument = (
+    val: string,
+    doc: Document
+  ): string | undefined => {
+    const match = val.match(/var\((--[^,)]+)(?:,[^)]+)?\)/)
+    if (!match) {
+      return undefined
+    }
+
+    const varName = match[1]
+    const rootValue = doc.defaultView
+      ?.getComputedStyle(doc.documentElement)
+      .getPropertyValue(varName)
+      .trim()
+    if (rootValue) {
+      return rootValue
+    }
+
+    const sentinel = "rgb(1, 2, 3)"
+    const probe = doc.createElement("div")
+    probe.style.color = `var(${varName}, ${sentinel})`
+    probe.style.display = "none"
+    doc.body.appendChild(probe)
+    const resolved = doc.defaultView?.getComputedStyle(probe).color
+    probe.remove()
+
+    return resolved && resolved !== sentinel ? resolved : undefined
+  }
+
   const resolveColor = (val: string | undefined): string | undefined => {
     if (!val) {
       return val
     }
-    const match = val.match(/var\((--[^)]+)\)/)
-    if (match) {
-      const varName = match[1]
-      try {
-        // Try resolving from the current document first
-        const hostStyle = window.getComputedStyle(document.documentElement)
-        let resolved = hostStyle.getPropertyValue(varName).trim()
-        if (resolved) {
-          return resolved
-        }
-        // If not found in host, try resolving from the preview iframe
-        const iframe = document.querySelector("iframe")
-        if (iframe && iframe.contentWindow) {
-          const iframeStyle = iframe.contentWindow.getComputedStyle(
-            iframe.contentWindow.document.documentElement
-          )
-          resolved = iframeStyle.getPropertyValue(varName).trim()
-          if (resolved) {
-            return resolved
-          }
-        }
-      } catch (e) {
-        // Fallback to original value on error
-      }
+
+    if (!val.includes("var(")) {
+      return val
     }
+
+    try {
+      const resolved = resolveColorInDocument(val, document)
+      if (resolved) {
+        return resolved
+      }
+
+      for (const iframe of Array.from(document.querySelectorAll("iframe"))) {
+        const iframeDocument = iframe.contentWindow?.document
+        if (!iframeDocument?.body) {
+          continue
+        }
+
+        const iframeResolved = resolveColorInDocument(val, iframeDocument)
+        if (iframeResolved) {
+          return iframeResolved
+        }
+      }
+    } catch (e) {
+      // Fall back to the original value if iframe access or CSS parsing fails.
+    }
+
     return val
   }
 
-  $: displayColor = resolveColor(value)
+  const refreshDisplayColor = () => {
+    refreshColor += 1
+  }
+
+  onMount(() => {
+    requestAnimationFrame(refreshDisplayColor)
+  })
+
+  $: {
+    refreshColor
+    displayColor = resolveColor(value)
+  }
 </script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
@@ -223,6 +266,7 @@
   bind:this={preview}
   class="preview size--{size || 'M'}"
   on:click={() => {
+    refreshDisplayColor()
     dropdown?.toggle()
   }}
 >

--- a/packages/bbui/src/ColorPicker/ColorPicker.svelte
+++ b/packages/bbui/src/ColorPicker/ColorPicker.svelte
@@ -181,6 +181,40 @@
 
     return "var(--spectrum-global-color-static-gray-900)"
   }
+
+  const resolveColor = (val: string | undefined): string | undefined => {
+    if (!val) {
+      return val
+    }
+    const match = val.match(/var\((--[^)]+)\)/)
+    if (match) {
+      const varName = match[1]
+      try {
+        // Try resolving from the current document first
+        const hostStyle = window.getComputedStyle(document.documentElement)
+        let resolved = hostStyle.getPropertyValue(varName).trim()
+        if (resolved) {
+          return resolved
+        }
+        // If not found in host, try resolving from the preview iframe
+        const iframe = document.querySelector("iframe")
+        if (iframe && iframe.contentWindow) {
+          const iframeStyle = iframe.contentWindow.getComputedStyle(
+            iframe.contentWindow.document.documentElement
+          )
+          resolved = iframeStyle.getPropertyValue(varName).trim()
+          if (resolved) {
+            return resolved
+          }
+        }
+      } catch (e) {
+        // Fallback to original value on error
+      }
+    }
+    return val
+  }
+
+  $: displayColor = resolveColor(value)
 </script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
@@ -194,7 +228,7 @@
 >
   <div
     class="fill {themeClasses}"
-    style={value ? `background: ${value};` : ""}
+    style={displayColor ? `background: ${displayColor};` : ""}
     class:placeholder={!value}
   ></div>
 </div>


### PR DESCRIPTION
## Description
This PR fixes the ColorPicker preview orb when a component color is set to a custom CSS variable, for example `var(--my-test-color)`.

The builder runs in the host document, while the app preview runs inside an iframe. A custom CSS variable can be defined in the preview iframe, so the host document cannot always resolve it directly. The ColorPicker now resolves CSS variables from the host document first, then from accessible preview iframes, and falls back to the original value if resolution is not possible.

## Addresses
- https://github.com/Budibase/budibase/issues/18830

## App Export
None

## Screenshots
After: the custom value is `var(--my-test-color)` and the Color orb resolves it to the orange value defined in the preview iframe.

![Color orb resolving custom CSS variable](https://raw.githubusercontent.com/jianongHe/budibase/pr-18917-evidence/pr-evidence/budibase-css-var-color-orb-pr-evidence.png)

## Verification
- `yarn workspace @budibase/bbui build`
- `yarn prettier --check packages/bbui/src/ColorPicker/ColorPicker.svelte`
- Manual Builder check with an Embed-defined CSS variable:
  - iframe variable: `--my-test-color = #ff3e00`
  - custom color input: `var(--my-test-color)`
  - Color orb computed background: `rgb(255, 62, 0)`

## Launchcontrol
Fix design panel color orb preview when custom CSS variables are used as component colors.
