### PR TITLE
Ensure Redis dependency is present for rate limit store

### DIFF
--- a/packages/server/src/api/routes/public/index.ts
+++ b/packages/server/src/api/routes/public/index.ts
@@ -38,7 +38,7 @@ if (!env.DISABLE_RATE_LIMITING) {
   }
 
   // Normal tests avoid the Redis-backed store because koa2-ratelimit uses the
-  // node-redis package directly and opens a real connection on construction.
+  // node-redis package directly and opens a real connection on construction, this makes the rests run very slowy, so we have this escape hatch.
   if (!env.isTest()) {
     rateLimitStore = new Stores.Redis(
       getPublicApiRedisConfig(

--- a/packages/server/src/api/routes/public/index.ts
+++ b/packages/server/src/api/routes/public/index.ts
@@ -37,6 +37,8 @@ if (!env.DISABLE_RATE_LIMITING) {
     return parseInt(env.API_REQ_LIMIT_PER_SEC)
   }
 
+  // Normal tests avoid the Redis-backed store because koa2-ratelimit uses the
+  // node-redis package directly and opens a real connection on construction.
   if (!env.isTest()) {
     rateLimitStore = new Stores.Redis(
       getPublicApiRedisConfig(

--- a/packages/server/src/api/routes/public/tests/rateLimit.spec.ts
+++ b/packages/server/src/api/routes/public/tests/rateLimit.spec.ts
@@ -1,0 +1,80 @@
+describe("public api rate limiting", () => {
+  const emptyEndpoints = { read: [], write: [] }
+
+  beforeEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+
+    jest.doMock("../applications", () => ({
+      __esModule: true,
+      default: emptyEndpoints,
+    }))
+    jest.doMock("../metrics", () => ({
+      __esModule: true,
+      default: emptyEndpoints,
+    }))
+    jest.doMock("../queries", () => ({
+      __esModule: true,
+      default: emptyEndpoints,
+    }))
+    jest.doMock("../roles", () => ({
+      __esModule: true,
+      default: emptyEndpoints,
+    }))
+    jest.doMock("../rows", () => ({
+      __esModule: true,
+      default: emptyEndpoints,
+    }))
+    jest.doMock("../tables", () => ({
+      __esModule: true,
+      default: emptyEndpoints,
+    }))
+    jest.doMock("../users", () => ({
+      __esModule: true,
+      default: emptyEndpoints,
+    }))
+    jest.doMock("../views", () => ({
+      __esModule: true,
+      default: emptyEndpoints,
+    }))
+    jest.doMock("../workspaces", () => ({
+      __esModule: true,
+      default: emptyEndpoints,
+    }))
+    jest.doMock("../../../../middleware/authorized", () => ({
+      authorizedMiddleware: jest.fn(() => jest.fn()),
+    }))
+    jest.doMock("../../../../middleware/publicApi", () => ({
+      publicApiMiddleware: jest.fn(() => jest.fn()),
+    }))
+    jest.doMock("../../../../middleware/resourceId", () => ({
+      paramResource: jest.fn(() => jest.fn()),
+      paramSubResource: jest.fn(() => jest.fn()),
+    }))
+    jest.doMock("../middleware/mapper", () => ({
+      __esModule: true,
+      default: jest.fn(),
+    }))
+    jest.doMock("../middleware/testErrorHandling", () => ({
+      __esModule: true,
+      default: jest.fn(() => jest.fn()),
+    }))
+  })
+
+  it("initialises the Redis-backed rate limit store", () => {
+    jest.doMock("../../../../environment", () => ({
+      __esModule: true,
+      default: {
+        isTest: () => false,
+        isDev: () => false,
+        DISABLE_RATE_LIMITING: undefined,
+        REDIS_CLUSTERED: undefined,
+        TOP_LEVEL_PATH: "/tmp",
+      },
+    }))
+
+    const { shutdown } = require("../index")
+
+    shutdown()
+  })
+})


### PR DESCRIPTION
## Description
Regression test to ensure that the "redis" package is present as it is a required peer dependency for the koa ratelimit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression test that verifies the Redis-backed rate limit store initializes in non-test environments, ensuring `redis` remains required for `koa2-ratelimit`. Added a clarifying comment noting that tests skip the Redis store via `env.isTest()` because `node-redis` opens a real connection on construction.

<sup>Written for commit 1977eb650faa07885c8aa18d66d0ef5d038f5d89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/18918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

