### PR TITLE
add project export and import

### DIFF
--- a/packages/server/src/api/controllers/project.ts
+++ b/packages/server/src/api/controllers/project.ts
@@ -2,7 +2,12 @@ import {
   CreateProjectRequest,
   CreateProjectResponse,
   Ctx,
+  ExportProjectRequest,
+  ExportProjectResponse,
   FetchProjectsResponse,
+  ImportProjectRequest,
+  ImportProjectResponse,
+  KoaFile,
   Project,
   ProjectResponse,
   UpdateProjectRequest,
@@ -71,4 +76,58 @@ export async function remove(ctx: Ctx<void, void>) {
   const { id, rev } = ctx.params
   await sdk.projects.remove(id, rev)
   ctx.status = 204
+}
+
+export async function exportBundle(
+  ctx: Ctx<ExportProjectRequest, ExportProjectResponse>
+) {
+  const { id } = ctx.params
+  const project = await sdk.projects.get(id)
+  if (!project) {
+    ctx.throw(404, `Project with id '${id}' not found.`)
+  }
+
+  const encryptPassword = ctx.request.body?.encryptPassword || undefined
+
+  ctx.req.setTimeout(0)
+
+  const extension = encryptPassword ? "enc.tar.gz" : "tar.gz"
+  const identifier = `${project.name}-project-export-${Date.now()}.${extension}`
+  ctx.attachment(identifier)
+  ctx.body = await sdk.projects.streamExportProject({
+    projectId: id,
+    encryptPassword,
+  })
+}
+
+type ProjectImportFiles = {
+  file?: KoaFile | KoaFile[]
+  projectExport?: KoaFile | KoaFile[]
+}
+
+export async function importBundle(
+  ctx: Ctx<ImportProjectRequest, ImportProjectResponse>
+) {
+  const files = ctx.request.files as ProjectImportFiles | undefined
+  const projectExport = files?.projectExport ?? files?.file
+
+  if (!projectExport) {
+    ctx.throw(400, "Must supply Project export file to import")
+  }
+  if (Array.isArray(projectExport)) {
+    ctx.throw(400, "Must only supply one Project export")
+  }
+  const filePath = projectExport.filepath
+  if (!filePath) {
+    ctx.throw(400, "Must supply Project export file to import")
+  }
+
+  ctx.body = await sdk.projects.importProject(
+    {
+      path: filePath,
+    },
+    {
+      encryptPassword: ctx.request.body?.encryptPassword || undefined,
+    }
+  )
 }

--- a/packages/server/src/api/routes/project.ts
+++ b/packages/server/src/api/routes/project.ts
@@ -13,6 +13,32 @@ const baseSchema = {
 builderRoutes
   .get("/api/projects", projectsEnabled, controller.fetch)
   .post(
+    "/api/projects/import",
+    projectsEnabled,
+    middleware.joiValidator.body(
+      Joi.object({
+        encryptPassword: Joi.string().optional().allow(""),
+      }),
+      {
+        allowUnknown: false,
+      }
+    ),
+    controller.importBundle
+  )
+  .post(
+    "/api/projects/:id/export",
+    projectsEnabled,
+    middleware.joiValidator.body(
+      Joi.object({
+        encryptPassword: Joi.string().optional().allow(""),
+      }),
+      {
+        allowUnknown: false,
+      }
+    ),
+    controller.exportBundle
+  )
+  .post(
     "/api/projects",
     projectsEnabled,
     middleware.joiValidator.body(Joi.object(baseSchema), {

--- a/packages/server/src/api/routes/tests/project.spec.ts
+++ b/packages/server/src/api/routes/tests/project.spec.ts
@@ -1,13 +1,29 @@
-import { features } from "@budibase/backend-core"
+import { context, features } from "@budibase/backend-core"
 import { structures } from "@budibase/backend-core/tests"
-import { FeatureFlag } from "@budibase/types"
+import {
+  FeatureFlag,
+  KnowledgeBaseFileStatus,
+  type Agent,
+  type KnowledgeBaseFile,
+  type ProjectPackageDependencyIndex,
+} from "@budibase/types"
+import { Header } from "@budibase/shared-core"
+import fsp from "fs/promises"
+import { tmpdir } from "os"
+import { join } from "path"
+import { Readable, Writable } from "stream"
+import { pipeline } from "stream/promises"
+import * as tar from "tar"
 import sdk from "../../../sdk"
+import { listAssignedAgentFiles } from "../../../sdk/workspace/projects/backups/exports"
 import TestConfiguration from "../../../tests/utilities/TestConfiguration"
 import { setupDefaultCompletionsAIConfig } from "../../../tests/utilities/aiConfig"
 import {
   basicDatasource,
   basicQuery,
+  basicScreen,
   basicTable,
+  createQueryScreen,
 } from "../../../tests/utilities/structures"
 
 describe("/projects", () => {
@@ -35,6 +51,144 @@ describe("/projects", () => {
     await cleanupAIConfig?.()
     cleanupAIConfig = undefined
   })
+
+  const readTarEntries = async (buffer: Buffer) => {
+    const files = new Map<string, Buffer>()
+    const parser = tar.list({
+      onReadEntry: entry => {
+        if (entry.type === "Directory") {
+          return
+        }
+
+        const chunks: Buffer[] = []
+        entry.on("data", chunk => chunks.push(chunk))
+        entry.on("end", () => {
+          files.set(
+            entry.path,
+            Buffer.concat(chunks.map(chunk => new Uint8Array(chunk)))
+          )
+        })
+      },
+    })
+    await pipeline(Readable.from(buffer), parser as unknown as Writable)
+    return files
+  }
+
+  const createTarPackage = async (entries: Record<string, unknown>) => {
+    const tmpPath = await fsp.mkdtemp(join(tmpdir(), "project-package-"))
+    const tarPath = join(tmpPath, "project-export.tar.gz")
+
+    try {
+      await Promise.all(
+        Object.entries(entries).map(async ([entryPath, value]) => {
+          const fullPath = join(tmpPath, entryPath)
+          await fsp.mkdir(join(fullPath, ".."), { recursive: true })
+          await fsp.writeFile(fullPath, JSON.stringify(value, null, 2))
+        })
+      )
+      await tar.create(
+        {
+          gzip: true,
+          file: tarPath,
+          cwd: tmpPath,
+        },
+        Object.keys(entries)
+      )
+      return await fsp.readFile(tarPath)
+    } finally {
+      await fsp.rm(tmpPath, { recursive: true, force: true })
+    }
+  }
+
+  const createOversizedTarPackage = async () => {
+    const oversizedEntryPath = "docs/automation/au_oversized.json"
+    const entries = createMinimalPackageEntries({
+      docs: {
+        [oversizedEntryPath]: {
+          _id: "au_oversized",
+          name: "Oversized automation",
+        },
+      },
+    })
+    const tmpPath = await fsp.mkdtemp(join(tmpdir(), "project-package-"))
+    const tarPath = join(tmpPath, "project-export.tar.gz")
+
+    try {
+      await Promise.all(
+        Object.entries(entries).map(async ([entryPath, value]) => {
+          const fullPath = join(tmpPath, entryPath)
+          await fsp.mkdir(join(fullPath, ".."), { recursive: true })
+          await fsp.writeFile(fullPath, JSON.stringify(value, null, 2))
+        })
+      )
+      await fsp.truncate(join(tmpPath, oversizedEntryPath), 101 * 1024 * 1024)
+      await tar.create(
+        {
+          gzip: true,
+          file: tarPath,
+          cwd: tmpPath,
+        },
+        Object.keys(entries)
+      )
+      return await fsp.readFile(tarPath)
+    } finally {
+      await fsp.rm(tmpPath, { recursive: true, force: true })
+    }
+  }
+
+  const createMinimalPackageEntries = (
+    overrides: {
+      manifest?: Record<string, unknown>
+      project?: Record<string, unknown>
+      dependencyIndex?: Record<string, unknown>
+      docs?: Record<string, unknown>
+      extraEntries?: Record<string, unknown>
+    } = {}
+  ) => {
+    const project = {
+      _id: "project_source",
+      name: "Operations",
+      createdAt: new Date().toISOString(),
+      ...overrides.project,
+    }
+    const manifest = {
+      formatVersion: 1,
+      artifactType: "project",
+      budibaseVersion: "test",
+      exportedAt: new Date().toISOString(),
+      project,
+      sourceWorkspace: {
+        id: "app_source",
+      },
+      resourcesByType: {
+        project: 1,
+      },
+      containsRows: false,
+      containsAttachments: false,
+      requiresSecrets: false,
+      unsupportedContent: [],
+      supportedImportModes: ["additiveImport"],
+      ...overrides.manifest,
+    }
+    const dependencyIndex = {
+      rootProjectId: "project_source",
+      directMembers: [],
+      resources: {
+        project_source: {
+          dependencies: [],
+        },
+      },
+      ...overrides.dependencyIndex,
+    }
+
+    return {
+      "manifest.json": manifest,
+      "project.json": project,
+      "dependency-index.json": dependencyIndex,
+      ...overrides.docs,
+      ...overrides.extraEntries,
+    }
+  }
 
   it("returns 404 when the feature flag is disabled", async () => {
     await config.api.project.fetch({ status: 404 })
@@ -445,6 +599,824 @@ describe("/projects", () => {
       expect(updatedTable.projectId).toBe(project._id)
       expect(updatedDatasource.projectId).toBe(project._id)
       expect(updatedQuery.projectId).toBe(project._id)
+    })
+  })
+
+  it("exports a project tarball with selective docs and manifest", async () => {
+    await withProjectsEnabled(async () => {
+      const { project } = await config.api.project.create({
+        name: "Operations",
+        description: "Operational workflows",
+        color: "#8CA171",
+      })
+
+      const datasource = await config.api.datasource.create({
+        ...basicDatasource().datasource,
+        config: {
+          password: "super-secret",
+        },
+        projectId: project._id,
+      })
+      const query = await config.api.query.save({
+        ...basicQuery(datasource._id!),
+        projectId: project._id,
+      })
+      const table = await config.api.table.save({
+        ...basicTable(),
+        projectId: project._id,
+      })
+      const { workspaceApp } = await config.api.workspaceApp.create({
+        name: "Operations app",
+        url: "/operations-app",
+        projectId: project._id,
+      })
+      const screen = await config.api.screen.save({
+        ...createQueryScreen(datasource._id!, query),
+        workspaceAppId: workspaceApp._id,
+      })
+
+      const automation = await config.createAutomation()
+      await config.api.automation.update({
+        ...automation,
+        projectId: project._id,
+      })
+      const agent = await config.api.agent.create({
+        name: "Ops agent",
+        aiconfig: "default",
+        live: true,
+        slackIntegration: {
+          botToken: "secret-token",
+          signingSecret: "secret-signing-key",
+        },
+        telegramIntegration: {
+          botToken: "secret-telegram-token",
+          webhookSecretToken: "secret-telegram-webhook",
+          botUserName: "ops_bot",
+        },
+        projectId: project._id,
+      })
+
+      const body = await config.api.project.export(project._id)
+      const files = await readTarEntries(body)
+
+      expect(Array.from(files.keys())).toEqual(
+        expect.arrayContaining([
+          "manifest.json",
+          "project.json",
+          "dependency-index.json",
+          `docs/datasource/${datasource._id}.json`,
+          `docs/query/${query._id}.json`,
+          `docs/table/${table._id}.json`,
+          `docs/automation/${automation._id}.json`,
+          `docs/agent/${agent._id}.json`,
+          `docs/workspace_app/${workspaceApp._id}.json`,
+          `docs/screen/${screen._id}.json`,
+        ])
+      )
+
+      const manifest = JSON.parse(files.get("manifest.json")!.toString())
+      expect(manifest).toMatchObject({
+        artifactType: "project",
+        formatVersion: 1,
+        containsRows: false,
+        containsAttachments: false,
+        requiresSecrets: true,
+        project: {
+          _id: project._id,
+          name: project.name,
+          description: project.description,
+          color: project.color,
+        },
+        resourcesByType: {
+          project: 1,
+          datasource: 1,
+          query: 1,
+          table: 1,
+          automation: 1,
+          agent: 1,
+          workspace_app: 1,
+          screen: 1,
+        },
+        unsupportedContent: [
+          {
+            type: "agent_linked_content",
+            count: 1,
+          },
+        ],
+        supportedImportModes: ["additiveImport"],
+      })
+
+      const exportedProject = JSON.parse(files.get("project.json")!.toString())
+      expect(exportedProject._id).toBe(project._id)
+      expect(exportedProject._rev).toBeUndefined()
+
+      const exportedDatasource = JSON.parse(
+        files.get(`docs/datasource/${datasource._id}.json`)!.toString()
+      )
+      expect(exportedDatasource.config.password).not.toBe("super-secret")
+
+      const exportedAgent = JSON.parse(
+        files.get(`docs/agent/${agent._id}.json`)!.toString()
+      )
+      expect(exportedAgent.live).toBe(false)
+      expect(exportedAgent.slackIntegration?.botToken).toBeUndefined()
+      expect(exportedAgent.slackIntegration?.signingSecret).toBeUndefined()
+      expect(exportedAgent.telegramIntegration?.botToken).toBeUndefined()
+      expect(
+        exportedAgent.telegramIntegration?.webhookSecretToken
+      ).toBeUndefined()
+      expect(exportedAgent.telegramIntegration?.botUserName).toBe("ops_bot")
+
+      const dependencyIndex = JSON.parse(
+        files.get("dependency-index.json")!.toString()
+      ) as ProjectPackageDependencyIndex
+      expect(dependencyIndex.rootProjectId).toBe(project._id)
+      expect(
+        dependencyIndex.directMembers.map(resource => resource.id)
+      ).toEqual(
+        expect.arrayContaining([
+          datasource._id,
+          query._id,
+          table._id,
+          automation._id,
+          agent._id,
+          workspaceApp._id,
+        ])
+      )
+    })
+  })
+
+  it("continues listing assigned agent files when one RAG lookup fails", async () => {
+    const file: KnowledgeBaseFile = {
+      _id: "kb_file_1",
+      knowledgeBaseId: "kb_1",
+      filename: "guide.pdf",
+      objectStoreKey: "files/guide.pdf",
+      ragSourceId: "rag_1",
+      status: KnowledgeBaseFileStatus.READY,
+      uploadedBy: "user_1",
+    }
+    const listFilesForAgent = jest.fn(async (agentId: string) => {
+      if (agentId === "ag_failed") {
+        throw new Error("RAG unavailable")
+      }
+      return [file]
+    })
+
+    await expect(
+      listAssignedAgentFiles(
+        "project_1",
+        [
+          { _id: "ag_failed", name: "Failed agent" } as Agent,
+          { _id: "ag_ok", name: "Working agent" } as Agent,
+        ],
+        listFilesForAgent
+      )
+    ).resolves.toEqual([file])
+
+    expect(listFilesForAgent).toHaveBeenCalledTimes(2)
+  })
+
+  it("returns 404 when exporting an unknown project", async () => {
+    await withProjectsEnabled(async () => {
+      await config.api.project.export("project_missing", undefined, {
+        status: 404,
+        body: {
+          message: "Project with id 'project_missing' not found.",
+        },
+      })
+    })
+  })
+
+  it("exports encrypted project tarballs when requested", async () => {
+    await withProjectsEnabled(async () => {
+      const { project } = await config.api.project.create({
+        name: "Operations",
+      })
+
+      const body = await config.api.project.export(project._id, {
+        encryptPassword: "abcde",
+      })
+      const files = await readTarEntries(body)
+
+      expect(Array.from(files.keys())).toEqual(
+        expect.arrayContaining([
+          "manifest.json.enc",
+          "project.json.enc",
+          "dependency-index.json.enc",
+        ])
+      )
+    })
+  })
+
+  it("imports empty projects without requiring docs", async () => {
+    await withProjectsEnabled(async () => {
+      const { project } = await config.api.project.create({
+        name: "Operations",
+      })
+
+      const body = await config.api.project.export(project._id)
+      const destinationWorkspace = await config.api.workspace.create({
+        name: "Imported workspace",
+      })
+
+      await config.withHeaders(
+        { [Header.APP_ID]: destinationWorkspace.appId },
+        async () => {
+          const imported = await config.api.project.import(body)
+          expect(imported.resources).toEqual({
+            project: [imported.project._id],
+          })
+        }
+      )
+    })
+  })
+
+  it("exports and imports app screens that need workspace app repair", async () => {
+    await withProjectsEnabled(async () => {
+      const { project } = await config.api.project.create({
+        name: "Operations",
+      })
+      const defaultWorkspaceApp = await config.api.workspaceApp.find(
+        config.getDefaultWorkspaceAppId()
+      )
+      const { workspaceApp } = await config.api.workspaceApp.update({
+        _id: defaultWorkspaceApp._id,
+        _rev: defaultWorkspaceApp._rev,
+        name: defaultWorkspaceApp.name,
+        url: defaultWorkspaceApp.url,
+        disabled: defaultWorkspaceApp.disabled,
+        navigation: defaultWorkspaceApp.navigation,
+        projectId: project._id,
+      })
+      const screen = await config.api.screen.save({
+        ...basicScreen("/operations"),
+        workspaceAppId: workspaceApp._id,
+      })
+
+      await config.doInContext(config.getDevWorkspaceId(), async () => {
+        const db = context.getWorkspaceDB()
+        await db.put({
+          ...screen,
+          workspaceAppId: undefined,
+        })
+      })
+
+      const body = await config.api.project.export(project._id)
+      const files = await readTarEntries(body)
+      const exportedScreen = JSON.parse(
+        files.get(`docs/screen/${screen._id}.json`)!.toString()
+      )
+
+      expect(exportedScreen.workspaceAppId).toBe(workspaceApp._id)
+
+      const destinationWorkspace = await config.api.workspace.create({
+        name: "Imported workspace",
+      })
+
+      await config.withHeaders(
+        { [Header.APP_ID]: destinationWorkspace.appId },
+        async () => {
+          const imported = await config.api.project.import(body)
+          const importedScreens = await config.api.screen.list()
+          const importedScreen = importedScreens.find(
+            existing => existing._id === imported.resources.screen?.[0]
+          )
+
+          expect(imported.resources.workspace_app).toHaveLength(1)
+          expect(imported.resources.screen).toHaveLength(1)
+          expect(importedScreen?.workspaceAppId).toBe(
+            imported.resources.workspace_app?.[0]
+          )
+        }
+      )
+    })
+  })
+
+  it("imports row action dependencies with remapped automation references", async () => {
+    await withProjectsEnabled(async () => {
+      const { project } = await config.api.project.create({
+        name: "Operations",
+      })
+      const table = await config.api.table.save({
+        ...basicTable(),
+        projectId: project._id,
+      })
+      const rowAction = await config.api.rowAction.save(table._id!, {
+        name: "Approve",
+      })
+
+      const body = await config.api.project.export(project._id)
+      const destinationWorkspace = await config.api.workspace.create({
+        name: "Imported workspace",
+      })
+
+      await config.withHeaders(
+        { [Header.APP_ID]: destinationWorkspace.appId },
+        async () => {
+          const imported = await config.api.project.import(body)
+          expect(imported.resources.table).toHaveLength(1)
+          expect(imported.resources.automation).toHaveLength(1)
+          expect(imported.resources.row_action).toHaveLength(1)
+
+          const importedRowActions = await config.api.rowAction.find(
+            imported.resources.table?.[0]!
+          )
+          const importedAction = Object.values(importedRowActions.actions)[0]
+
+          expect(importedAction).toBeDefined()
+          expect(importedAction.tableId).toBe(imported.resources.table?.[0])
+          expect(importedAction.automationId).toBe(
+            imported.resources.automation?.[0]
+          )
+          expect(importedAction.id).not.toBe(rowAction.id)
+
+          const importedAutomation = await config.api.automation.get(
+            imported.resources.automation?.[0]!
+          )
+          const triggerInputs = importedAutomation.definition.trigger
+            .inputs as {
+            tableId?: string
+            rowActionId?: string
+          }
+          expect(triggerInputs.tableId).toBe(imported.resources.table?.[0])
+          expect(triggerInputs.rowActionId).toBe(importedAction.id)
+        }
+      )
+    })
+  })
+
+  it("imports exported projects additively into another workspace", async () => {
+    await withProjectsEnabled(async () => {
+      const { project } = await config.api.project.create({
+        name: "Operations",
+        description: "Operational workflows",
+      })
+      const datasource = await config.api.datasource.create({
+        ...basicDatasource().datasource,
+        config: {
+          password: "super-secret",
+        },
+        projectId: project._id,
+      })
+      const query = await config.api.query.save({
+        ...basicQuery(datasource._id!),
+        projectId: project._id,
+      })
+      const table = await config.api.table.save({
+        ...basicTable(),
+        projectId: project._id,
+      })
+      const { workspaceApp } = await config.api.workspaceApp.create({
+        name: "Operations app",
+        url: "/operations-app",
+        projectId: project._id,
+      })
+      const screen = await config.api.screen.save({
+        ...createQueryScreen(datasource._id!, query),
+        workspaceAppId: workspaceApp._id,
+      })
+      const automation = await config.createAutomation()
+      await config.api.automation.update({
+        ...automation,
+        projectId: project._id,
+      })
+      const agent = await config.api.agent.create({
+        name: "Ops agent",
+        aiconfig: "default",
+        live: true,
+        slackIntegration: {
+          botToken: "secret-token",
+          signingSecret: "secret-signing-key",
+        },
+        projectId: project._id,
+      })
+
+      const body = await config.api.project.export(project._id)
+      const destinationWorkspace = await config.api.workspace.create({
+        name: "Imported workspace",
+      })
+
+      await config.withHeaders(
+        { [Header.APP_ID]: destinationWorkspace.appId },
+        async () => {
+          await config.api.workspaceApp.create({
+            name: "Existing app",
+            url: "/existing-app",
+          })
+
+          const imported = await config.api.project.import(body)
+          expect(imported.project._id).not.toBe(project._id)
+          expect(imported.resources.project).toEqual([imported.project._id])
+          expect(imported.resources.datasource).toHaveLength(1)
+          expect(imported.resources.query).toHaveLength(1)
+          expect(imported.resources.table).toHaveLength(1)
+          expect(imported.resources.automation).toHaveLength(1)
+          expect(imported.resources.agent).toHaveLength(1)
+          expect(imported.resources.workspace_app).toHaveLength(1)
+          expect(imported.resources.screen).toHaveLength(1)
+          expect(imported.requirements).toHaveLength(2)
+          expect(imported.requirements).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                type: "datasource_secrets",
+                resourceId: imported.resources.datasource?.[0],
+              }),
+              expect.objectContaining({
+                type: "agent_secrets",
+                resourceId: imported.resources.agent?.[0],
+              }),
+            ])
+          )
+
+          const { projects } = await config.api.project.fetch()
+          expect(projects.map(existing => existing._id)).toContain(
+            imported.project._id
+          )
+
+          const importedWorkspaceApps = await config.api.workspaceApp.fetch()
+          expect(
+            importedWorkspaceApps.workspaceApps.map(app => app.name)
+          ).toEqual(expect.arrayContaining(["Existing app", "Operations app"]))
+
+          const importedScreens = await config.api.screen.list()
+          const importedScreen = importedScreens.find(
+            screen => screen._id === imported.resources.screen?.[0]
+          )
+          expect(importedScreen).toBeDefined()
+          expect(importedScreen!.workspaceAppId).toBe(
+            imported.resources.workspace_app?.[0]
+          )
+          expect(importedScreen!.props._children?.[0].table._id).toBe(
+            imported.resources.query?.[0]
+          )
+          expect(importedScreen!.props._children?.[0].table.datasourceId).toBe(
+            imported.resources.datasource?.[0]
+          )
+
+          const importedQuery = await config.api.query.get(
+            imported.resources.query?.[0]!
+          )
+          expect(importedQuery.datasourceId).toBe(
+            imported.resources.datasource?.[0]
+          )
+          expect(importedQuery.projectId).toBe(imported.project._id)
+
+          const importedTable = await config.api.table.get(
+            imported.resources.table?.[0]!
+          )
+          expect(importedTable.projectId).toBe(imported.project._id)
+
+          const importedAutomation = await config.api.automation.get(
+            imported.resources.automation?.[0]!
+          )
+          expect(importedAutomation.projectId).toBe(imported.project._id)
+          expect(importedAutomation.appId).toBe(destinationWorkspace.appId)
+          expect(importedAutomation.disabled).toBe(true)
+
+          const importedDatasource = await config.api.datasource.get(
+            imported.resources.datasource?.[0]!
+          )
+          expect(importedDatasource.projectId).toBe(imported.project._id)
+          expect(importedDatasource.config?.password).not.toBe("super-secret")
+
+          const { agents } = await config.api.agent.fetch()
+          const importedAgent = agents.find(
+            existing => existing._id === imported.resources.agent?.[0]
+          )
+          expect(importedAgent).toBeDefined()
+          expect(importedAgent?.projectId).toBe(imported.project._id)
+          expect(importedAgent?.live).toBe(false)
+
+          const resourceGraph =
+            await config.api.resource.getResourceDependencies()
+          expect(
+            resourceGraph.body.resources[imported.project._id].dependencies.map(
+              resource => resource.id
+            )
+          ).toEqual(
+            expect.arrayContaining([
+              imported.resources.datasource?.[0],
+              imported.resources.query?.[0],
+              imported.resources.table?.[0],
+              imported.resources.automation?.[0],
+              imported.resources.agent?.[0],
+              imported.resources.workspace_app?.[0],
+              imported.resources.screen?.[0],
+            ])
+          )
+        }
+      )
+
+      expect(screen._id).toBeDefined()
+      expect(table._id).toBeDefined()
+      expect(agent._id).toBeDefined()
+    })
+  })
+
+  it("rejects encrypted project imports without a password", async () => {
+    await withProjectsEnabled(async () => {
+      const { project } = await config.api.project.create({
+        name: "Operations",
+      })
+
+      const body = await config.api.project.export(project._id, {
+        encryptPassword: "abcde",
+      })
+
+      await config.api.project.import(body, undefined, {
+        status: 400,
+        body: {
+          message: "Files are encrypted but no password has been supplied.",
+        },
+      })
+    })
+  })
+
+  it.each([
+    ["missing", undefined],
+    ["non-array", "additiveImport"],
+    ["empty", []],
+  ])(
+    "rejects packages with %s supported import modes",
+    async (_label, value) => {
+      await withProjectsEnabled(async () => {
+        const packageBuffer = await createTarPackage(
+          createMinimalPackageEntries({
+            manifest: {
+              supportedImportModes: value,
+            },
+          })
+        )
+
+        await config.api.project.import(packageBuffer, undefined, {
+          status: 400,
+          body: {
+            message: "Project package does not support additive import.",
+          },
+        })
+      })
+    }
+  )
+
+  it("rejects packages with docs that are not declared in the dependency index", async () => {
+    await withProjectsEnabled(async () => {
+      const packageBuffer = await createTarPackage(
+        createMinimalPackageEntries({
+          manifest: {
+            resourcesByType: {
+              project: 1,
+              automation: 1,
+            },
+          },
+          docs: {
+            "docs/automation/au_extra.json": {
+              _id: "au_extra",
+              name: "Unexpected automation",
+              definition: {
+                trigger: {
+                  id: "trigger",
+                  inputs: {},
+                },
+                steps: [],
+              },
+            },
+          },
+        })
+      )
+
+      await config.api.project.import(packageBuffer, undefined, {
+        status: 400,
+        body: {
+          message:
+            "Project package contains docs not listed in dependency-index.json.",
+        },
+      })
+    })
+  })
+
+  it("rejects packages that reference missing docs", async () => {
+    await withProjectsEnabled(async () => {
+      const packageBuffer = await createTarPackage(
+        createMinimalPackageEntries({
+          manifest: {
+            resourcesByType: {
+              project: 1,
+              automation: 1,
+            },
+          },
+          dependencyIndex: {
+            resources: {
+              project_source: {
+                dependencies: [
+                  {
+                    id: "au_missing",
+                    name: "Missing automation",
+                    type: "automation",
+                  },
+                ],
+              },
+              au_missing: {
+                dependencies: [],
+              },
+            },
+          },
+        })
+      )
+
+      await config.api.project.import(packageBuffer, undefined, {
+        status: 400,
+        body: {
+          message: "Project package dependency index references missing docs.",
+        },
+      })
+    })
+  })
+
+  it("rejects packages with docs that are not reachable from the project", async () => {
+    await withProjectsEnabled(async () => {
+      const packageBuffer = await createTarPackage(
+        createMinimalPackageEntries({
+          manifest: {
+            resourcesByType: {
+              project: 1,
+              automation: 1,
+            },
+          },
+          dependencyIndex: {
+            resources: {
+              project_source: {
+                dependencies: [],
+              },
+              au_orphan: {
+                dependencies: [],
+              },
+            },
+          },
+          docs: {
+            "docs/automation/au_orphan.json": {
+              _id: "au_orphan",
+              name: "Orphan automation",
+              definition: {
+                trigger: {
+                  id: "trigger",
+                  inputs: {},
+                },
+                steps: [],
+              },
+            },
+          },
+        })
+      )
+
+      await config.api.project.import(packageBuffer, undefined, {
+        status: 400,
+        body: {
+          message:
+            "Project package contains docs that are not reachable from the root project.",
+        },
+      })
+    })
+  })
+
+  it("rejects packages when doc paths do not match resource types", async () => {
+    await withProjectsEnabled(async () => {
+      const packageBuffer = await createTarPackage(
+        createMinimalPackageEntries({
+          manifest: {
+            resourcesByType: {
+              project: 1,
+              automation: 1,
+            },
+          },
+          dependencyIndex: {
+            resources: {
+              project_source: {
+                dependencies: [
+                  {
+                    id: "ta_wrong",
+                    name: "Wrongly typed table",
+                    type: "automation",
+                  },
+                ],
+              },
+              ta_wrong: {
+                dependencies: [],
+              },
+            },
+          },
+          docs: {
+            "docs/automation/ta_wrong.json": {
+              _id: "ta_wrong",
+              name: "Wrongly typed table",
+            },
+          },
+        })
+      )
+
+      await config.api.project.import(packageBuffer, undefined, {
+        status: 400,
+        body: {
+          message:
+            "Project package doc 'ta_wrong' does not match resource type 'automation'.",
+        },
+      })
+    })
+  })
+
+  it("rejects packages with unsupported root files", async () => {
+    await withProjectsEnabled(async () => {
+      const packageBuffer = await createTarPackage(
+        createMinimalPackageEntries({
+          extraEntries: {
+            "readme.txt": "unexpected",
+          },
+        })
+      )
+
+      await config.api.project.import(packageBuffer, undefined, {
+        status: 400,
+        body: {
+          message: "Project package contains unsupported files.",
+        },
+      })
+    })
+  })
+
+  it("rejects workspace exports", async () => {
+    await withProjectsEnabled(async () => {
+      const packageBuffer = await createTarPackage(
+        createMinimalPackageEntries({
+          extraEntries: {
+            "db.txt": "workspace export marker",
+          },
+        })
+      )
+
+      await config.api.project.import(packageBuffer, undefined, {
+        status: 400,
+        body: {
+          message: "Workspace exports cannot be imported as Project packages.",
+        },
+      })
+    })
+  })
+
+  it("rejects packages that exceed the extracted size limit before extraction", async () => {
+    await withProjectsEnabled(async () => {
+      const packageBuffer = await createOversizedTarPackage()
+
+      expect(packageBuffer.length).toBeLessThan(50 * 1024 * 1024)
+      await config.api.project.import(packageBuffer, undefined, {
+        status: 400,
+        body: {
+          message: "Project package is too large.",
+        },
+      })
+    })
+  })
+
+  it("rejects packages with paths that are too deep", async () => {
+    await withProjectsEnabled(async () => {
+      const packageBuffer = await createTarPackage(
+        createMinimalPackageEntries({
+          manifest: {
+            resourcesByType: {
+              project: 1,
+              automation: 1,
+            },
+          },
+          dependencyIndex: {
+            resources: {
+              project_source: {
+                dependencies: [
+                  {
+                    id: "au_deep",
+                    name: "Deep automation",
+                    type: "automation",
+                  },
+                ],
+              },
+              au_deep: {
+                dependencies: [],
+              },
+            },
+          },
+          docs: {
+            "docs/automation/nested/deeper/au_deep.json": {
+              _id: "au_deep",
+              name: "Deep automation",
+            },
+          },
+        })
+      )
+
+      await config.api.project.import(packageBuffer, undefined, {
+        status: 400,
+        body: {
+          message: "Project package contains paths that are too deep.",
+        },
+      })
     })
   })
 })

--- a/packages/server/src/api/routes/tests/resource.spec.ts
+++ b/packages/server/src/api/routes/tests/resource.spec.ts
@@ -1,4 +1,10 @@
-import { db, events, objectStore } from "@budibase/backend-core"
+import {
+  context,
+  db,
+  events,
+  features,
+  objectStore,
+} from "@budibase/backend-core"
 import { generator } from "@budibase/backend-core/tests"
 import { Header } from "@budibase/shared-core"
 import {
@@ -6,6 +12,7 @@ import {
   Automation,
   Datasource,
   FieldType,
+  FeatureFlag,
   Query,
   RelationshipType,
   ResourceType,
@@ -21,6 +28,7 @@ import tk from "timekeeper"
 import { createAutomationBuilder } from "../../../automations/tests/utilities/AutomationTestBuilder"
 import { generateRowActionsID } from "../../../db/utils"
 import {
+  basicDatasource,
   basicQuery,
   basicScreen,
   basicTable,
@@ -31,6 +39,13 @@ import { ObjectStoreBuckets } from "../../../constants"
 
 describe("/api/resources/usage", () => {
   const config = new TestConfiguration()
+  const withProjectsEnabled = async <T>(f: () => Promise<T>) => {
+    return await features.testutils.withFeatureFlags(
+      config.getTenantId(),
+      { [FeatureFlag.PROJECTS]: true },
+      f
+    )
+  }
 
   beforeAll(async () => {
     await config.init()
@@ -257,6 +272,154 @@ describe("/api/resources/usage", () => {
           },
         ],
       })
+    })
+
+    it("should include direct project members and transitive dependencies", async () => {
+      await withProjectsEnabled(async () => {
+        const { project } = await config.api.project.create({
+          name: "Operations",
+        })
+        const datasource = await config.api.datasource.create({
+          ...basicDatasource().datasource,
+          projectId: project._id,
+        })
+        const query = await config.api.query.save({
+          ...basicQuery(datasource._id!),
+          projectId: project._id,
+        })
+        const table = await config.api.table.save({
+          ...basicTable(),
+          projectId: project._id,
+        })
+        const { workspaceApp } = await config.api.workspaceApp.create({
+          name: "Operations app",
+          url: "/operations-app",
+          projectId: project._id,
+        })
+        const screen = await config.api.screen.save({
+          ...createQueryScreen(datasource._id!, query),
+          workspaceAppId: workspaceApp._id,
+        })
+
+        const automation = await config.createAutomation()
+        await config.api.automation.update({
+          ...automation,
+          projectId: project._id,
+        })
+        const agent = await config.api.agent.create({
+          name: "Ops agent",
+          aiconfig: "default",
+          projectId: project._id,
+        })
+
+        const result = await config.api.resource.getResourceDependencies()
+
+        expect(result.body.resources[project._id!]).toEqual({
+          dependencies: [
+            {
+              id: datasource._id,
+              name: datasource.name,
+              type: ResourceType.DATASOURCE,
+            },
+            {
+              id: table._id,
+              name: table.name,
+              type: ResourceType.TABLE,
+            },
+            {
+              id: query._id,
+              name: query.name,
+              type: ResourceType.QUERY,
+            },
+            {
+              id: automation._id,
+              name: automation.name,
+              type: ResourceType.AUTOMATION,
+            },
+            {
+              id: agent._id,
+              name: agent.name,
+              type: ResourceType.AGENT,
+            },
+            {
+              id: workspaceApp._id,
+              name: workspaceApp.name,
+              type: ResourceType.WORKSPACE_APP,
+            },
+            {
+              id: screen._id,
+              name: screen.name,
+              type: ResourceType.SCREEN,
+            },
+          ],
+        })
+      })
+    })
+
+    it("should include repaired app screens for project apps", async () => {
+      await withProjectsEnabled(async () => {
+        const { project } = await config.api.project.create({
+          name: "Operations",
+        })
+        const defaultWorkspaceApp = await config.api.workspaceApp.find(
+          config.getDefaultWorkspaceAppId()
+        )
+        const { workspaceApp } = await config.api.workspaceApp.update({
+          _id: defaultWorkspaceApp._id,
+          _rev: defaultWorkspaceApp._rev,
+          name: defaultWorkspaceApp.name,
+          url: defaultWorkspaceApp.url,
+          disabled: defaultWorkspaceApp.disabled,
+          navigation: defaultWorkspaceApp.navigation,
+          projectId: project._id,
+        })
+        const screen = await config.api.screen.save({
+          ...basicScreen("/operations"),
+          workspaceAppId: workspaceApp._id,
+        })
+
+        await config.doInContext(config.getDevWorkspaceId(), async () => {
+          const workspaceDb = context.getWorkspaceDB()
+          await workspaceDb.put({
+            ...screen,
+            workspaceAppId: undefined,
+          })
+        })
+
+        const result = await config.api.resource.getResourceDependencies()
+
+        expect(result.body.resources[project._id!].dependencies).toEqual(
+          expect.arrayContaining([
+            {
+              id: workspaceApp._id,
+              name: workspaceApp.name,
+              type: ResourceType.WORKSPACE_APP,
+            },
+            {
+              id: screen._id,
+              name: screen.name,
+              type: ResourceType.SCREEN,
+            },
+          ])
+        )
+      })
+    })
+
+    it("should not include project resources when the feature flag is disabled", async () => {
+      const { project } = await withProjectsEnabled(async () => {
+        const { project } = await config.api.project.create({
+          name: "Operations",
+        })
+        await config.api.datasource.create({
+          ...basicDatasource().datasource,
+          projectId: project._id,
+        })
+        return { project }
+      })
+
+      const result = await config.api.resource.getResourceDependencies()
+
+      expect(result.body.resources[project._id]).toBeUndefined()
     })
   })
 
@@ -605,6 +768,89 @@ describe("/api/resources/usage", () => {
         apps: [app1.app, app2.app],
         screens: [...app1.screens, ...app2.screens],
         tables: [table],
+      })
+    })
+
+    it("strips project assignments when duplicating with projects disabled", async () => {
+      const { datasource } = await withProjectsEnabled(async () => {
+        const { project } = await config.api.project.create({
+          name: "Operations",
+        })
+        const datasource = await config.api.datasource.create({
+          ...basicDatasource().datasource,
+          projectId: project._id,
+        })
+        return { datasource }
+      })
+      const newWorkspace = await config.api.workspace.create({
+        name: `Destination ${generator.natural()}`,
+      })
+
+      await duplicateResources([datasource._id!], newWorkspace.appId)
+
+      await config.withHeaders(
+        { [Header.APP_ID]: newWorkspace.appId },
+        async () => {
+          const copiedDatasource = await config.api.datasource.get(
+            datasource._id!
+          )
+          expect(copiedDatasource.projectId).toBeUndefined()
+        }
+      )
+    })
+
+    it("strips dangling project assignments when the project is not duplicated", async () => {
+      await withProjectsEnabled(async () => {
+        const { project } = await config.api.project.create({
+          name: "Operations",
+        })
+        const datasource = await config.api.datasource.create({
+          ...basicDatasource().datasource,
+          projectId: project._id,
+        })
+        const newWorkspace = await config.api.workspace.create({
+          name: `Destination ${generator.natural()}`,
+        })
+
+        await duplicateResources([datasource._id!], newWorkspace.appId)
+
+        await config.withHeaders(
+          { [Header.APP_ID]: newWorkspace.appId },
+          async () => {
+            const copiedDatasource = await config.api.datasource.get(
+              datasource._id!
+            )
+            expect(copiedDatasource.projectId).toBeUndefined()
+          }
+        )
+      })
+    })
+
+    it("preserves project assignments when the destination already has the project", async () => {
+      await withProjectsEnabled(async () => {
+        const { project } = await config.api.project.create({
+          name: "Operations",
+        })
+        const datasource = await config.api.datasource.create({
+          ...basicDatasource().datasource,
+          projectId: project._id,
+        })
+        const newWorkspace = await config.api.workspace.create({
+          name: `Destination ${generator.natural()}`,
+        })
+
+        await duplicateResources([project._id!], newWorkspace.appId)
+        await duplicateResources([datasource._id!], newWorkspace.appId)
+
+        await config.withHeaders(
+          { [Header.APP_ID]: newWorkspace.appId },
+          async () => {
+            const copiedDatasource = await config.api.datasource.get(
+              datasource._id!
+            )
+            expect(copiedDatasource.projectId).toBe(project._id)
+          }
+        )
       })
     })
 

--- a/packages/server/src/sdk/workspace/backups/imports.ts
+++ b/packages/server/src/sdk/workspace/backups/imports.ts
@@ -156,7 +156,7 @@ export async function untarFile(file: { path: string }) {
   return tmpPath
 }
 
-async function decryptFiles(path: string, password: string) {
+export async function decryptFiles(path: string, password: string) {
   try {
     const processDirectory = async (dirPath: string) => {
       for (let file of await fsp.readdir(dirPath)) {

--- a/packages/server/src/sdk/workspace/projects/backups/constants.ts
+++ b/packages/server/src/sdk/workspace/projects/backups/constants.ts
@@ -1,0 +1,6 @@
+export const PROJECT_EXPORT_FORMAT_VERSION = 1
+export const PROJECT_MANIFEST_FILE = "manifest.json"
+export const PROJECT_FILE = "project.json"
+export const PROJECT_DEPENDENCY_INDEX_FILE = "dependency-index.json"
+export const PROJECT_DOCS_DIRECTORY = "docs"
+export const PROJECT_ATTACHMENTS_DIRECTORY = "attachments"

--- a/packages/server/src/sdk/workspace/projects/backups/exports.ts
+++ b/packages/server/src/sdk/workspace/projects/backups/exports.ts
@@ -1,0 +1,404 @@
+import { context, encryption, logging } from "@budibase/backend-core"
+import {
+  Agent,
+  AnyDocument,
+  Datasource,
+  KnowledgeBaseFile,
+  Project,
+  ProjectPackageDependencyIndex,
+  ProjectPackageManifest,
+  ProjectPackageUnsupportedContent,
+  ResourceType,
+  Screen,
+  UsedResource,
+} from "@budibase/types"
+import fsp from "fs/promises"
+import { dirname, join } from "path"
+import * as tar from "tar"
+import { v4 as uuid } from "uuid"
+import sdk from "../../.."
+import { budibaseTempDir } from "../../../../utilities/budibaseDir"
+import { streamFile } from "../../../../utilities/fileSystem"
+import {
+  PROJECT_ATTACHMENTS_DIRECTORY,
+  PROJECT_DEPENDENCY_INDEX_FILE,
+  PROJECT_DOCS_DIRECTORY,
+  PROJECT_EXPORT_FORMAT_VERSION,
+  PROJECT_FILE,
+  PROJECT_MANIFEST_FILE,
+} from "./constants"
+
+async function tarFilesToTmp(tmpDir: string, files: string[]) {
+  const fileName = `${uuid()}.tar.gz`
+  const exportFile = join(budibaseTempDir(), fileName)
+  await tar.create(
+    {
+      gzip: true,
+      file: exportFile,
+      noDirRecurse: false,
+      cwd: tmpDir,
+    },
+    files
+  )
+  return exportFile
+}
+
+function getExportDirectoryName(resourceType: ResourceType) {
+  return resourceType
+}
+
+export async function listAssignedAgentFiles(
+  projectId: string,
+  assignedAgents: Agent[],
+  listFilesForAgent = sdk.ai.rag.listFilesForAgent
+): Promise<KnowledgeBaseFile[]> {
+  return (
+    await Promise.all(
+      assignedAgents.map(async agent => {
+        try {
+          return await listFilesForAgent(agent._id!)
+        } catch (err) {
+          logging.logWarn(
+            "Project export: failed to list RAG files for agent",
+            {
+              err,
+              projectId,
+              agentId: agent._id,
+            }
+          )
+          return []
+        }
+      })
+    )
+  ).flat()
+}
+
+async function getDirectMembers(projectId: string): Promise<UsedResource[]> {
+  const [datasources, tables, queries, automations, agents, workspaceApps] =
+    await Promise.all([
+      sdk.datasources.fetch(),
+      sdk.tables.getAllTables(),
+      sdk.queries.fetch(),
+      sdk.automations.fetch(),
+      sdk.ai.agents.fetch(),
+      sdk.workspaceApps.fetch(),
+    ])
+
+  const asUsedResource = (
+    doc: { _id?: string; name?: string },
+    type: ResourceType
+  ): UsedResource => ({
+    id: doc._id!,
+    name: doc.name || "Unknown",
+    type,
+  })
+
+  return [
+    ...datasources
+      .filter(datasource => datasource.projectId === projectId)
+      .map(datasource => asUsedResource(datasource, ResourceType.DATASOURCE)),
+    ...tables
+      .filter(table => table.projectId === projectId)
+      .map(table => asUsedResource(table, ResourceType.TABLE)),
+    ...queries
+      .filter(query => query.projectId === projectId)
+      .map(query => asUsedResource(query, ResourceType.QUERY)),
+    ...automations
+      .filter(automation => automation.projectId === projectId)
+      .map(automation => asUsedResource(automation, ResourceType.AUTOMATION)),
+    ...agents
+      .filter(agent => agent.projectId === projectId)
+      .map(agent => asUsedResource(agent, ResourceType.AGENT)),
+    ...workspaceApps
+      .filter(workspaceApp => workspaceApp.projectId === projectId)
+      .map(workspaceApp =>
+        asUsedResource(workspaceApp, ResourceType.WORKSPACE_APP)
+      ),
+  ]
+}
+
+async function getUnsupportedContent(
+  projectId: string
+): Promise<ProjectPackageUnsupportedContent[]> {
+  const agents = await sdk.ai.agents.fetch()
+  const workspaceApps = await sdk.workspaceApps.fetch()
+  const assignedAgents = agents.filter(agent => agent.projectId === projectId)
+  const assignedWorkspaceApps = workspaceApps.filter(
+    workspaceApp => workspaceApp.projectId === projectId
+  )
+  const assignedWorkspaceAppIds = new Set(
+    assignedWorkspaceApps.map(workspaceApp => workspaceApp._id)
+  )
+  const defaultWorkspaceApp =
+    workspaceApps.find(workspaceApp => workspaceApp.isDefault) ||
+    workspaceApps[0]
+  const [assignedAgentFiles, orphanScreens] = await Promise.all([
+    listAssignedAgentFiles(projectId, assignedAgents),
+    defaultWorkspaceApp && assignedWorkspaceAppIds.has(defaultWorkspaceApp._id)
+      ? sdk.screens
+          .fetch(undefined, { repairMissingWorkspaceAppId: false })
+          .then(screens => screens.filter(screen => !screen.workspaceAppId))
+      : [],
+  ])
+
+  const unsupported: ProjectPackageUnsupportedContent[] = []
+
+  if (assignedAgentFiles.length) {
+    unsupported.push({
+      type: "agent_file",
+      count: assignedAgentFiles.length,
+      reason:
+        "Agent files and related RAG data are excluded from Project exports.",
+    })
+  }
+
+  if (assignedAgents.length) {
+    unsupported.push({
+      type: "agent_linked_content",
+      count: assignedAgents.length,
+      reason:
+        "Agent chats, deployments, and other linked AI content are excluded from Project exports.",
+    })
+  }
+
+  if (assignedWorkspaceApps.length && orphanScreens.length) {
+    unsupported.push({
+      type: "screen",
+      count: orphanScreens.length,
+      reason:
+        "Screens without a workspace app link are excluded from deterministic Project export packaging.",
+    })
+  }
+
+  return unsupported
+}
+
+async function sanitizeDocumentForExport(
+  doc: AnyDocument,
+  type: ResourceType,
+  screenWorkspaceAppIdByScreenId?: Map<string, string>
+) {
+  const sanitized = structuredClone(doc)
+  delete sanitized._rev
+
+  if (type === ResourceType.DATASOURCE) {
+    return await sdk.datasources.removeSecretSingle(sanitized as Datasource)
+  }
+
+  if (type === ResourceType.AGENT) {
+    return sdk.ai.agents.sanitiseAgentForExport(sanitized as Agent)
+  }
+
+  if (type === ResourceType.SCREEN && !sanitized.workspaceAppId) {
+    const workspaceAppId = screenWorkspaceAppIdByScreenId?.get(doc._id!)
+    if (workspaceAppId) {
+      ;(sanitized as Screen).workspaceAppId = workspaceAppId
+    }
+  }
+
+  return sanitized
+}
+
+function sanitizeProjectForExport(project: Project) {
+  const sanitized = structuredClone(project)
+  delete sanitized._rev
+  return sanitized
+}
+
+function buildManifest(
+  project: Project,
+  workspaceId: string,
+  dependencies: UsedResource[],
+  unsupportedContent: ProjectPackageUnsupportedContent[]
+): ProjectPackageManifest {
+  const resourcesByType = dependencies.reduce<
+    Partial<Record<ResourceType, number>>
+  >(
+    (acc, dependency) => {
+      acc[dependency.type] = (acc[dependency.type] || 0) + 1
+      return acc
+    },
+    { [ResourceType.PROJECT]: 1 }
+  )
+
+  return {
+    formatVersion: PROJECT_EXPORT_FORMAT_VERSION,
+    artifactType: "project",
+    budibaseVersion: process.env.BUDIBASE_VERSION || "unknown",
+    exportedAt: new Date().toISOString(),
+    project: {
+      _id: project._id!,
+      name: project.name,
+      description: project.description,
+      color: project.color,
+      createdAt: String(project.createdAt),
+      updatedAt: project.updatedAt,
+    },
+    sourceWorkspace: {
+      id: workspaceId,
+    },
+    resourcesByType,
+    containsRows: false,
+    containsAttachments: false,
+    requiresSecrets:
+      !!resourcesByType[ResourceType.DATASOURCE] ||
+      !!resourcesByType[ResourceType.AGENT],
+    unsupportedContent,
+    supportedImportModes: ["additiveImport"],
+  }
+}
+
+async function writeJsonFile(filePath: string, value: unknown) {
+  await fsp.mkdir(dirname(filePath), { recursive: true })
+  await fsp.writeFile(filePath, JSON.stringify(value, null, 2))
+}
+
+async function encryptDirectory(dirPath: string, password: string) {
+  for (let file of await fsp.readdir(dirPath)) {
+    const fullPath = join(dirPath, file)
+    if (file === PROJECT_ATTACHMENTS_DIRECTORY) {
+      continue
+    }
+
+    const stats = await fsp.lstat(fullPath)
+    if (stats.isFile()) {
+      await encryption.encryptFile({ dir: dirPath, filename: file }, password)
+      await fsp.rm(fullPath)
+    } else if (stats.isDirectory()) {
+      await encryptDirectory(fullPath, password)
+    }
+  }
+}
+
+export async function exportProject(
+  projectId: string,
+  opts?: {
+    encryptPassword?: string
+  }
+) {
+  const workspaceId = context.getWorkspaceId()
+  if (!workspaceId) {
+    throw new Error("Could not determine workspace for Project export")
+  }
+
+  const project = await sdk.projects.get(projectId)
+  if (!project) {
+    throw new Error(`Project '${projectId}' not found`)
+  }
+
+  const graph = await sdk.resources.getResourcesInfo()
+  const projectDependencies = Array.from(
+    new Map(
+      (graph[projectId]?.dependencies || []).map(resource => [
+        resource.id,
+        resource,
+      ])
+    ).values()
+  )
+  const directMembers = await getDirectMembers(projectId)
+  const unsupportedContent = await getUnsupportedContent(projectId)
+
+  const typeByResourceId = new Map(
+    projectDependencies.map(resource => [resource.id, resource.type])
+  )
+  const docsToExport = projectDependencies.map(resource => resource.id)
+  const exportedDocs = docsToExport.length
+    ? await context.getWorkspaceDB().getMultiple<AnyDocument>(docsToExport, {
+        allowMissing: false,
+      })
+    : []
+
+  const dependencyIndex: ProjectPackageDependencyIndex = {
+    rootProjectId: projectId,
+    directMembers,
+    resources: {
+      [projectId]: graph[projectId] || { dependencies: [] },
+      ...Object.fromEntries(
+        docsToExport.map(id => [id, graph[id] || { dependencies: [] }])
+      ),
+    },
+  }
+
+  const manifest = buildManifest(
+    project,
+    workspaceId,
+    projectDependencies,
+    unsupportedContent
+  )
+  const screenWorkspaceAppIdByScreenId = new Map<string, string>()
+
+  for (const workspaceAppId of docsToExport.filter(
+    id => typeByResourceId.get(id) === ResourceType.WORKSPACE_APP
+  )) {
+    for (const dependency of graph[workspaceAppId]?.dependencies || []) {
+      if (dependency.type === ResourceType.SCREEN) {
+        screenWorkspaceAppIdByScreenId.set(dependency.id, workspaceAppId)
+      }
+    }
+  }
+
+  const tmpPath = await fsp.mkdtemp(join(budibaseTempDir(), "project-export-"))
+  try {
+    await writeJsonFile(join(tmpPath, PROJECT_MANIFEST_FILE), manifest)
+    await writeJsonFile(
+      join(tmpPath, PROJECT_FILE),
+      sanitizeProjectForExport(project)
+    )
+    await writeJsonFile(
+      join(tmpPath, PROJECT_DEPENDENCY_INDEX_FILE),
+      dependencyIndex
+    )
+    await fsp.mkdir(join(tmpPath, PROJECT_DOCS_DIRECTORY), { recursive: true })
+
+    for (const doc of exportedDocs) {
+      const type = typeByResourceId.get(doc._id!)
+      if (!type) {
+        continue
+      }
+
+      const sanitized = await sanitizeDocumentForExport(
+        doc,
+        type,
+        screenWorkspaceAppIdByScreenId
+      )
+      await writeJsonFile(
+        join(
+          tmpPath,
+          PROJECT_DOCS_DIRECTORY,
+          getExportDirectoryName(type),
+          `${doc._id}.json`
+        ),
+        sanitized
+      )
+    }
+
+    if (opts?.encryptPassword) {
+      await encryptDirectory(tmpPath, opts.encryptPassword)
+    }
+
+    return await tarFilesToTmp(tmpPath, await fsp.readdir(tmpPath))
+  } finally {
+    await fsp.rm(tmpPath, { recursive: true, force: true })
+  }
+}
+
+export async function streamExportProject({
+  projectId,
+  encryptPassword,
+}: {
+  projectId: string
+  encryptPassword?: string
+}) {
+  const tarPath = await exportProject(projectId, {
+    encryptPassword,
+  })
+  const stream = streamFile(tarPath)
+  const cleanup = () => {
+    fsp.rm(tarPath, { force: true }).catch(() => {})
+  }
+
+  stream.once("close", cleanup)
+  stream.once("error", cleanup)
+
+  return stream
+}

--- a/packages/server/src/sdk/workspace/projects/backups/imports.ts
+++ b/packages/server/src/sdk/workspace/projects/backups/imports.ts
@@ -1,0 +1,818 @@
+import { context, docIds, HTTPError, utils } from "@budibase/backend-core"
+import {
+  Agent,
+  AnyDocument,
+  Datasource,
+  DocumentType,
+  ImportProjectResponse,
+  Project,
+  ProjectImportRequirement,
+  ProjectPackageDependencyIndex,
+  ProjectPackageManifest,
+  ResourceType,
+  RowActionPermissions,
+  TableRowActions,
+  SEPARATOR,
+  VirtualDocumentType,
+  prefixed,
+} from "@budibase/types"
+import fs from "fs"
+import fsp from "fs/promises"
+import { basename, join, relative } from "path"
+import { Writable } from "stream"
+import { pipeline } from "stream/promises"
+import * as tar from "tar"
+import {
+  extractTableIdFromRowActionsID,
+  generateAutomationID,
+  generateDatasourceID,
+  generateQueryID,
+  generateRowActionsID,
+  generateScreenID,
+  generateTableID,
+} from "../../../../db/utils"
+import { decryptFiles, untarFile } from "../../backups/imports"
+import sdk from "../../.."
+import {
+  PROJECT_DEPENDENCY_INDEX_FILE,
+  PROJECT_DOCS_DIRECTORY,
+  PROJECT_EXPORT_FORMAT_VERSION,
+  PROJECT_FILE,
+  PROJECT_MANIFEST_FILE,
+} from "./constants"
+
+const IMPORT_ORDER: ResourceType[] = [
+  ResourceType.AGENT,
+  ResourceType.DATASOURCE,
+  ResourceType.TABLE,
+  ResourceType.QUERY,
+  ResourceType.AUTOMATION,
+  ResourceType.ROW_ACTION,
+  ResourceType.WORKSPACE_APP,
+  ResourceType.SCREEN,
+]
+
+const ALLOWED_IMPORT_TYPES = new Set(IMPORT_ORDER)
+
+const MAX_ARCHIVE_SIZE_BYTES = 50 * 1024 * 1024
+const MAX_EXTRACTED_SIZE_BYTES = 100 * 1024 * 1024
+const MAX_PACKAGE_FILES = 2000
+const MAX_PACKAGE_DOCS = 1000
+const MAX_PATH_SEGMENTS = 4
+const MAX_ENCRYPT_PASSWORD_LENGTH = 1024
+
+const PREASSIGNED_IMPORT_TYPES: ResourceType[] = [
+  ResourceType.AGENT,
+  ResourceType.DATASOURCE,
+  ResourceType.TABLE,
+  ResourceType.AUTOMATION,
+  ResourceType.ROW_ACTION,
+  ResourceType.WORKSPACE_APP,
+  ResourceType.SCREEN,
+  ResourceType.QUERY,
+]
+
+interface ImportedDoc {
+  resourceType: ResourceType
+  path: string
+  doc: AnyDocument
+}
+
+interface ExtractedProjectPackage {
+  tmpPath: string
+  manifest: ProjectPackageManifest
+  project: Project
+  dependencyIndex: ProjectPackageDependencyIndex
+  docs: ImportedDoc[]
+}
+
+interface InsertedDocRef {
+  _id: string
+  _rev: string
+}
+
+interface ProjectPackageTarEntry {
+  path: string
+  type?: string
+  size?: number
+  resume?: () => void
+}
+
+const readJsonFile = async <T>(filePath: string): Promise<T> => {
+  return JSON.parse(await fsp.readFile(filePath, "utf8"))
+}
+
+const readDirectoryRecursively = async (
+  dirPath: string,
+  rootPath = dirPath,
+  totals = { files: 0, bytes: 0 }
+): Promise<string[]> => {
+  const entries = await fsp.readdir(dirPath, { withFileTypes: true })
+  const files: string[] = []
+
+  for (const entry of entries) {
+    const fullPath = join(dirPath, entry.name)
+    const relPath = relative(rootPath, fullPath)
+    if (relPath.split(/[\\/]/).length > MAX_PATH_SEGMENTS) {
+      throw new HTTPError(
+        "Project package contains paths that are too deep.",
+        400
+      )
+    }
+    if (entry.isSymbolicLink()) {
+      throw new HTTPError("Project package contains unsupported links.", 400)
+    }
+    if (entry.isDirectory()) {
+      files.push(
+        ...(await readDirectoryRecursively(fullPath, rootPath, totals))
+      )
+    } else {
+      const stats = await fsp.stat(fullPath)
+      totals.files += 1
+      totals.bytes += stats.size
+      if (totals.files > MAX_PACKAGE_FILES) {
+        throw new HTTPError("Project package contains too many files.", 400)
+      }
+      if (totals.bytes > MAX_EXTRACTED_SIZE_BYTES) {
+        throw new HTTPError("Project package is too large.", 400)
+      }
+      files.push(fullPath)
+    }
+  }
+
+  return files
+}
+
+const validateProjectPackageBeforeExtraction = async (file: {
+  path: string
+}) => {
+  const totals = { files: 0, bytes: 0 }
+  const fileTypes = new Set(["File", "OldFile", "ContiguousFile"])
+  const linkTypes = new Set(["Link", "SymbolicLink"])
+  const stream = fs.createReadStream(file.path)
+  let validationError: HTTPError | undefined
+
+  const fail = (error: HTTPError) => {
+    validationError = error
+    stream.destroy(error)
+  }
+
+  const parser = new tar.Parser({
+    onReadEntry: (entry: ProjectPackageTarEntry) => {
+      if (validationError) {
+        return
+      }
+      if (
+        entry.path.split(/[\\/]/).filter(Boolean).length > MAX_PATH_SEGMENTS
+      ) {
+        fail(
+          new HTTPError(
+            "Project package contains paths that are too deep.",
+            400
+          )
+        )
+        return
+      }
+      if (entry.type && linkTypes.has(entry.type)) {
+        fail(new HTTPError("Project package contains unsupported links.", 400))
+        return
+      }
+      if (!entry.type || fileTypes.has(entry.type)) {
+        totals.files += 1
+        totals.bytes += entry.size || 0
+        if (totals.files > MAX_PACKAGE_FILES) {
+          fail(new HTTPError("Project package contains too many files.", 400))
+          return
+        }
+        if (totals.bytes > MAX_EXTRACTED_SIZE_BYTES) {
+          fail(new HTTPError("Project package is too large.", 400))
+          return
+        }
+      }
+      entry.resume?.()
+    },
+  })
+
+  try {
+    await pipeline(stream, parser as unknown as Writable)
+  } catch (err) {
+    throw validationError || err
+  }
+}
+
+const getResourceTypeForDocPath = (
+  tmpPath: string,
+  filePath: string
+): ResourceType => {
+  const relPath = relative(tmpPath, filePath)
+  const pathParts = relPath.split(/[\\/]/)
+  const [docsDirectory, resourceType] = pathParts
+  if (
+    docsDirectory !== PROJECT_DOCS_DIRECTORY ||
+    pathParts.length !== 3 ||
+    !relPath.endsWith(".json")
+  ) {
+    throw new HTTPError(`Unsupported Project doc path '${relPath}'.`, 400)
+  }
+  if (
+    !resourceType ||
+    !ALLOWED_IMPORT_TYPES.has(resourceType as ResourceType)
+  ) {
+    throw new HTTPError(`Unsupported Project doc path '${relPath}'.`, 400)
+  }
+  return resourceType as ResourceType
+}
+
+const RESOURCE_ID_PREFIXES: Record<ResourceType, string[]> = {
+  [ResourceType.PROJECT]: [prefixed(DocumentType.PROJECT)],
+  [ResourceType.AGENT]: [prefixed(DocumentType.AGENT)],
+  [ResourceType.DATASOURCE]: [
+    prefixed(DocumentType.DATASOURCE),
+    prefixed(DocumentType.DATASOURCE_PLUS),
+  ],
+  [ResourceType.TABLE]: [prefixed(DocumentType.TABLE)],
+  [ResourceType.ROW_ACTION]: [prefixed(DocumentType.ROW_ACTIONS)],
+  [ResourceType.QUERY]: [prefixed(DocumentType.QUERY)],
+  [ResourceType.AUTOMATION]: [prefixed(DocumentType.AUTOMATION)],
+  [ResourceType.WORKSPACE_APP]: [prefixed(DocumentType.WORKSPACE_APP)],
+  [ResourceType.SCREEN]: [prefixed(DocumentType.SCREEN)],
+}
+
+const validateDocMatchesPath = (importedDoc: ImportedDoc) => {
+  const id = importedDoc.doc._id
+  if (!id) {
+    throw new HTTPError("Project package contains a doc without an id.", 400)
+  }
+
+  const expectedFileName = `${id}.json`
+  if (basename(importedDoc.path) !== expectedFileName) {
+    throw new HTTPError(`Project package doc path does not match '${id}'.`, 400)
+  }
+
+  const validPrefixes = RESOURCE_ID_PREFIXES[importedDoc.resourceType]
+  if (!validPrefixes.some(prefix => id.startsWith(prefix))) {
+    throw new HTTPError(
+      `Project package doc '${id}' does not match resource type '${importedDoc.resourceType}'.`,
+      400
+    )
+  }
+}
+
+const remapObjectKeys = <T>(
+  value: Record<string, T>,
+  idMap: Map<string, string>
+) => {
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nestedValue]) => [
+      idMap.get(key) || key,
+      nestedValue,
+    ])
+  )
+}
+
+const remapValue = (value: unknown, idMap: Map<string, string>): unknown => {
+  if (typeof value === "string") {
+    return idMap.get(value) || value
+  }
+  if (Array.isArray(value)) {
+    return value.map(item => remapValue(item, idMap))
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [
+        key,
+        remapValue(nestedValue, idMap),
+      ])
+    )
+  }
+  return value
+}
+
+const sanitizeImportedDoc = (
+  doc: AnyDocument,
+  resourceType: ResourceType,
+  idMap: Map<string, string>,
+  workspaceId: string
+): AnyDocument => {
+  const remapped = remapValue(structuredClone(doc), idMap) as AnyDocument
+  delete remapped._rev
+
+  if (resourceType === ResourceType.ROW_ACTION) {
+    const rowActions = remapped as TableRowActions
+    rowActions.actions = Object.fromEntries(
+      Object.entries((doc as TableRowActions).actions || {}).map(
+        ([actionId, action]) => {
+          const permissions = (action.permissions || {
+            table: { runAllowed: true },
+            views: {},
+          }) as RowActionPermissions
+          return [
+            idMap.get(actionId) || actionId,
+            {
+              ...(remapValue(action, idMap) as typeof action),
+              permissions: {
+                ...permissions,
+                views: remapObjectKeys<RowActionPermissions["views"][string]>(
+                  permissions.views || {},
+                  idMap
+                ),
+              },
+            },
+          ]
+        }
+      )
+    )
+    return rowActions
+  }
+
+  if (resourceType === ResourceType.AUTOMATION) {
+    remapped.appId = workspaceId
+    remapped.disabled = true
+  }
+
+  if (resourceType === ResourceType.AGENT) {
+    remapped.live = false
+  }
+
+  if (resourceType === ResourceType.WORKSPACE_APP) {
+    remapped.disabled = true
+    remapped.isDefault = false
+  }
+
+  return remapped
+}
+
+const generateImportedId = (
+  resourceType: ResourceType,
+  doc: AnyDocument,
+  idMap: Map<string, string>
+) => {
+  switch (resourceType) {
+    case ResourceType.AGENT:
+      return docIds.generateAgentID()
+    case ResourceType.DATASOURCE:
+      return generateDatasourceID({
+        plus: !!doc._id?.startsWith(prefixed(DocumentType.DATASOURCE_PLUS)),
+      })
+    case ResourceType.TABLE:
+      return generateTableID()
+    case ResourceType.QUERY: {
+      const datasourceId = doc.datasourceId && idMap.get(doc.datasourceId)
+      if (!datasourceId) {
+        throw new HTTPError(
+          `Project import could not remap datasource for query '${doc._id}'.`,
+          400
+        )
+      }
+      return generateQueryID(datasourceId)
+    }
+    case ResourceType.AUTOMATION:
+      return generateAutomationID()
+    case ResourceType.ROW_ACTION: {
+      const tableId = idMap.get(extractTableIdFromRowActionsID(doc._id!))
+      if (!tableId) {
+        throw new HTTPError(
+          `Project import could not remap table for row actions '${doc._id}'.`,
+          400
+        )
+      }
+      return generateRowActionsID(tableId)
+    }
+    case ResourceType.WORKSPACE_APP:
+      return docIds.generateWorkspaceAppID()
+    case ResourceType.SCREEN:
+      return generateScreenID()
+    default:
+      throw new HTTPError(
+        `Project import does not support resource type '${resourceType}'.`,
+        400
+      )
+  }
+}
+
+const validateManifest = (manifest: ProjectPackageManifest) => {
+  if (manifest.artifactType !== "project") {
+    throw new HTTPError("Supplied file is not a Project package.", 400)
+  }
+  if (manifest.formatVersion !== PROJECT_EXPORT_FORMAT_VERSION) {
+    throw new HTTPError(
+      `Unsupported Project package format version '${manifest.formatVersion}'.`,
+      400
+    )
+  }
+  if (
+    !Array.isArray(manifest.supportedImportModes) ||
+    !manifest.supportedImportModes.includes("additiveImport")
+  ) {
+    throw new HTTPError(
+      "Project package does not support additive import.",
+      400
+    )
+  }
+}
+
+const validateDependencyIndex = (
+  project: Project,
+  dependencyIndex: ProjectPackageDependencyIndex,
+  docs: ImportedDoc[],
+  manifest: ProjectPackageManifest
+) => {
+  if (dependencyIndex.rootProjectId !== project._id) {
+    throw new HTTPError(
+      "Project package dependency index does not match project.json.",
+      400
+    )
+  }
+
+  const actualDocIds = new Set(docs.map(doc => doc.doc._id!))
+  const expectedDocIds = new Set(
+    Object.keys(dependencyIndex.resources).filter(
+      id => id !== dependencyIndex.rootProjectId
+    )
+  )
+
+  if (!dependencyIndex.resources[dependencyIndex.rootProjectId]) {
+    throw new HTTPError(
+      "Project package docs do not match dependency-index.json.",
+      400
+    )
+  }
+
+  for (const doc of docs) {
+    validateDocMatchesPath(doc)
+    if (!expectedDocIds.has(doc.doc._id!)) {
+      throw new HTTPError(
+        "Project package contains docs not listed in dependency-index.json.",
+        400
+      )
+    }
+  }
+
+  for (const expectedDocId of expectedDocIds) {
+    if (!actualDocIds.has(expectedDocId)) {
+      throw new HTTPError(
+        "Project package dependency index references missing docs.",
+        400
+      )
+    }
+  }
+
+  const reachable = new Set<string>()
+  const visit = (id: string) => {
+    if (reachable.has(id)) {
+      return
+    }
+    reachable.add(id)
+    for (const dependency of dependencyIndex.resources[id]?.dependencies ||
+      []) {
+      if (dependencyIndex.resources[dependency.id]) {
+        visit(dependency.id)
+      }
+    }
+  }
+  visit(dependencyIndex.rootProjectId)
+
+  for (const docId of actualDocIds) {
+    if (!reachable.has(docId)) {
+      throw new HTTPError(
+        "Project package contains docs that are not reachable from the root project.",
+        400
+      )
+    }
+  }
+
+  if (
+    dependencyIndex.directMembers.some(member => !actualDocIds.has(member.id))
+  ) {
+    throw new HTTPError(
+      "Project package docs do not match dependency-index.json.",
+      400
+    )
+  }
+
+  const countedResources = docs.reduce<Partial<Record<ResourceType, number>>>(
+    (acc, doc) => {
+      acc[doc.resourceType] = (acc[doc.resourceType] || 0) + 1
+      return acc
+    },
+    { [ResourceType.PROJECT]: 1 }
+  )
+
+  const resourceTypes = new Set([
+    ...Object.keys(countedResources),
+    ...Object.keys(manifest.resourcesByType),
+  ])
+
+  for (const resourceType of resourceTypes) {
+    const actualCount = countedResources[resourceType as ResourceType] || 0
+    const expectedCount =
+      manifest.resourcesByType[resourceType as ResourceType] || 0
+    if (actualCount !== expectedCount) {
+      throw new HTTPError(
+        `Project package resource count mismatch for '${resourceType}'.`,
+        400
+      )
+    }
+  }
+}
+
+const assignImportedIds = (docs: ImportedDoc[], idMap: Map<string, string>) => {
+  for (const resourceType of PREASSIGNED_IMPORT_TYPES) {
+    for (const importedDoc of docs.filter(
+      doc => doc.resourceType === resourceType
+    )) {
+      idMap.set(
+        importedDoc.doc._id!,
+        generateImportedId(resourceType, importedDoc.doc, idMap)
+      )
+
+      if (resourceType === ResourceType.ROW_ACTION) {
+        for (const actionId of Object.keys(
+          (importedDoc.doc as TableRowActions).actions || {}
+        )) {
+          idMap.set(
+            actionId,
+            `${VirtualDocumentType.ROW_ACTION}${SEPARATOR}${utils.newid()}`
+          )
+        }
+      }
+    }
+  }
+}
+
+const bulkInsertDocs = async (
+  docs: AnyDocument[],
+  insertedDocs: InsertedDocRef[]
+) => {
+  const response = (await context.getWorkspaceDB().bulkDocs(docs)) as Array<{
+    id?: string
+    rev?: string
+    error?: string
+  }>
+
+  let failedId: string | undefined
+
+  response.forEach((result, index) => {
+    if (result.id && result.rev) {
+      insertedDocs.push({
+        _id: result.id,
+        _rev: result.rev,
+      })
+    }
+
+    if (!failedId && (result.error || !result.id || !result.rev)) {
+      failedId = docs[index]._id
+    }
+  })
+
+  if (failedId) {
+    throw new HTTPError(
+      `Project import failed while saving '${failedId}'.`,
+      400
+    )
+  }
+}
+
+async function extractProjectPackage(
+  file: { path: string },
+  encryptPassword?: string
+): Promise<ExtractedProjectPackage> {
+  const fileStats = await fsp.stat(file.path)
+  if (fileStats.size > MAX_ARCHIVE_SIZE_BYTES) {
+    throw new HTTPError("Project package is too large.", 400)
+  }
+  if (encryptPassword && encryptPassword.length > MAX_ENCRYPT_PASSWORD_LENGTH) {
+    throw new HTTPError("Project package password is too long.", 400)
+  }
+
+  await validateProjectPackageBeforeExtraction(file)
+  const tmpPath = await untarFile(file)
+  try {
+    if (encryptPassword) {
+      await decryptFiles(tmpPath, encryptPassword)
+    }
+
+    const packageFiles = await readDirectoryRecursively(tmpPath)
+    const rootEntries = await fsp.readdir(tmpPath)
+    if (rootEntries.some(entry => entry.endsWith(".enc")) && !encryptPassword) {
+      throw new HTTPError(
+        "Files are encrypted but no password has been supplied.",
+        400
+      )
+    }
+    if (rootEntries.includes("db.txt")) {
+      throw new HTTPError(
+        "Workspace exports cannot be imported as Project packages.",
+        400
+      )
+    }
+    if (
+      rootEntries.some(
+        entry =>
+          ![
+            PROJECT_MANIFEST_FILE,
+            PROJECT_FILE,
+            PROJECT_DEPENDENCY_INDEX_FILE,
+            PROJECT_DOCS_DIRECTORY,
+          ].includes(entry)
+      )
+    ) {
+      throw new HTTPError("Project package contains unsupported files.", 400)
+    }
+
+    const manifestPath = join(tmpPath, PROJECT_MANIFEST_FILE)
+    const projectPath = join(tmpPath, PROJECT_FILE)
+    const dependencyIndexPath = join(tmpPath, PROJECT_DEPENDENCY_INDEX_FILE)
+    const docsPath = join(tmpPath, PROJECT_DOCS_DIRECTORY)
+
+    await Promise.all([
+      fsp.access(manifestPath).catch(() => {
+        throw new HTTPError("Project package is missing manifest.json.", 400)
+      }),
+      fsp.access(projectPath).catch(() => {
+        throw new HTTPError("Project package is missing project.json.", 400)
+      }),
+      fsp.access(dependencyIndexPath).catch(() => {
+        throw new HTTPError(
+          "Project package is missing dependency-index.json.",
+          400
+        )
+      }),
+    ])
+
+    const [manifest, project, dependencyIndex] = await Promise.all([
+      readJsonFile<ProjectPackageManifest>(manifestPath),
+      readJsonFile<Project>(projectPath),
+      readJsonFile<ProjectPackageDependencyIndex>(dependencyIndexPath),
+    ])
+
+    const docFiles = await fsp
+      .access(docsPath)
+      .then(() =>
+        packageFiles.filter(filePath => filePath.startsWith(docsPath))
+      )
+      .catch(() => [])
+
+    if (docFiles.length > MAX_PACKAGE_DOCS) {
+      throw new HTTPError("Project package contains too many docs.", 400)
+    }
+    if (docFiles.some(filePath => !filePath.endsWith(".json"))) {
+      throw new HTTPError(
+        "Project package contains unsupported doc files.",
+        400
+      )
+    }
+
+    validateManifest(manifest)
+
+    const docs = await Promise.all(
+      docFiles
+        .filter(filePath => filePath.endsWith(".json"))
+        .map(async filePath => ({
+          path: filePath,
+          resourceType: getResourceTypeForDocPath(tmpPath, filePath),
+          doc: await readJsonFile<AnyDocument>(filePath),
+        }))
+    )
+
+    validateDependencyIndex(project, dependencyIndex, docs, manifest)
+
+    return {
+      tmpPath,
+      manifest,
+      project,
+      dependencyIndex,
+      docs,
+    }
+  } catch (err) {
+    await fsp.rm(tmpPath, { recursive: true, force: true })
+    throw err
+  }
+}
+
+const buildRequirements = (docs: ImportedDoc[]): ProjectImportRequirement[] => {
+  return docs.flatMap<ProjectImportRequirement>(importedDoc => {
+    if (importedDoc.resourceType === ResourceType.DATASOURCE) {
+      const doc = importedDoc.doc as Datasource
+      return [
+        {
+          type: "datasource_secrets" as const,
+          resourceId: doc._id!,
+          name: doc.name || "Unknown",
+          reason:
+            "Datasource credentials are excluded from Project exports and must be reconfigured after import.",
+        },
+      ]
+    }
+
+    if (importedDoc.resourceType === ResourceType.AGENT) {
+      const doc = importedDoc.doc as Agent
+      if (
+        doc.discordIntegration ||
+        doc.slackIntegration ||
+        doc.MSTeamsIntegration ||
+        doc.telegramIntegration
+      ) {
+        return [
+          {
+            type: "agent_secrets" as const,
+            resourceId: doc._id!,
+            name: doc.name || "Unknown",
+            reason:
+              "Agent integration secrets are excluded from Project exports and must be reconfigured after import.",
+          },
+        ]
+      }
+    }
+
+    return []
+  })
+}
+
+export async function importProject(
+  file: { path: string },
+  opts?: { encryptPassword?: string }
+): Promise<ImportProjectResponse> {
+  const workspaceId = context.getWorkspaceId()
+  if (!workspaceId) {
+    throw new Error("Could not determine workspace for Project import")
+  }
+
+  const extracted = await extractProjectPackage(file, opts?.encryptPassword)
+  const insertedDocs: InsertedDocRef[] = []
+  let importedProject: Project | undefined
+  try {
+    importedProject = await sdk.projects.create({
+      name: extracted.project.name,
+      description: extracted.project.description,
+      color: extracted.project.color,
+    })
+
+    const idMap = new Map<string, string>([
+      [extracted.project._id!, importedProject._id!],
+    ])
+
+    assignImportedIds(extracted.docs, idMap)
+
+    const resources: Partial<Record<ResourceType, string[]>> = {
+      [ResourceType.PROJECT]: [importedProject._id!],
+    }
+
+    for (const resourceType of IMPORT_ORDER) {
+      const docsToInsert = extracted.docs
+        .filter(doc => doc.resourceType === resourceType)
+        .map(({ doc }) => {
+          const newId = idMap.get(doc._id!)
+          const remappedDoc = sanitizeImportedDoc(
+            { ...doc, _id: newId },
+            resourceType,
+            idMap,
+            workspaceId
+          )
+          return remappedDoc
+        })
+
+      if (!docsToInsert.length) {
+        continue
+      }
+
+      await bulkInsertDocs(docsToInsert, insertedDocs)
+      resources[resourceType] = docsToInsert.map(doc => doc._id!)
+    }
+
+    const requirements = buildRequirements(extracted.docs).map(requirement => ({
+      ...requirement,
+      resourceId: idMap.get(requirement.resourceId) || requirement.resourceId,
+    }))
+
+    return {
+      project: {
+        _id: importedProject._id!,
+        _rev: importedProject._rev!,
+        name: importedProject.name,
+        description: importedProject.description,
+        color: importedProject.color,
+        createdAt: String(importedProject.createdAt),
+        updatedAt: importedProject.updatedAt,
+      },
+      resources,
+      unsupportedContent: extracted.manifest.unsupportedContent,
+      requirements,
+    }
+  } catch (err) {
+    if (insertedDocs.length) {
+      await context.getWorkspaceDB().bulkRemove(insertedDocs, {
+        silenceErrors: true,
+      })
+    }
+    if (importedProject?._id && importedProject._rev) {
+      await context
+        .getWorkspaceDB()
+        .remove(importedProject._id, importedProject._rev)
+        .catch(() => {})
+    }
+    throw err
+  } finally {
+    await fsp.rm(extracted.tmpPath, { recursive: true, force: true })
+  }
+}

--- a/packages/server/src/sdk/workspace/projects/index.ts
+++ b/packages/server/src/sdk/workspace/projects/index.ts
@@ -1,1 +1,3 @@
 export * from "./crud"
+export * from "./backups/exports"
+export * from "./backups/imports"

--- a/packages/server/src/sdk/workspace/screens/screens.ts
+++ b/packages/server/src/sdk/workspace/screens/screens.ts
@@ -4,7 +4,8 @@ import sdk from "../.."
 import { generateScreenID, getScreenParams } from "../../../db/utils"
 
 export async function fetch(
-  db: Database = context.getWorkspaceDB()
+  db: Database = context.getWorkspaceDB(),
+  opts?: { repairMissingWorkspaceAppId?: boolean }
 ): Promise<Screen[]> {
   const screens = (
     await db.allDocs<Screen>(
@@ -16,7 +17,10 @@ export async function fetch(
 
   // Handling a bug where some screens have missing workspaceAppId (in this case, they are part of the default workspace app)
   const screensWithMissingWorkspaceApp = screens.filter(s => !s.workspaceAppId)
-  if (screensWithMissingWorkspaceApp.length) {
+  if (
+    opts?.repairMissingWorkspaceAppId !== false &&
+    screensWithMissingWorkspaceApp.length
+  ) {
     const allWorkspaces = await sdk.workspaceApps.fetch()
     const defaultWorkspaceApp =
       allWorkspaces.find(a => a.isDefault) || allWorkspaces[0]

--- a/packages/server/src/tests/utilities/api/project.ts
+++ b/packages/server/src/tests/utilities/api/project.ts
@@ -1,7 +1,10 @@
 import {
   CreateProjectRequest,
   CreateProjectResponse,
+  ExportProjectRequest,
   FetchProjectsResponse,
+  ImportProjectRequest,
+  ImportProjectResponse,
   UpdateProjectRequest,
   UpdateProjectResponse,
 } from "@budibase/types"
@@ -24,6 +27,43 @@ export class ProjectAPI extends TestAPI {
         status: 201,
         ...expectations,
       },
+    })
+  }
+
+  export = async (
+    id: string,
+    body?: ExportProjectRequest,
+    expectations?: Expectations
+  ) => {
+    const expectsError = (expectations?.status || 200) >= 400
+    const exp = {
+      ...expectations,
+      headers: {
+        ...expectations?.headers,
+        ...(expectsError ? {} : { "Content-Type": "application/gzip" }),
+      },
+    }
+
+    return await this._post<Buffer>(`/api/projects/${id}/export`, {
+      body,
+      expectations: exp,
+    })
+  }
+
+  import = async (
+    file: Buffer | string,
+    body?: ImportProjectRequest,
+    expectations?: Expectations
+  ) => {
+    return await this._post<ImportProjectResponse>(`/api/projects/import`, {
+      fields: body,
+      files: {
+        file: {
+          file,
+          name: "project-export.tar.gz",
+        },
+      },
+      expectations,
     })
   }
 


### PR DESCRIPTION
## description
adds project export and import support, including package manifests, dependency indexes, encryption, additive imports, id remapping, and package validation.

## addresses
- n/a

## app export
- n/a

## screenshots
n/a

## launchcontrol
allows supported project definitions to be exported from one workspace and imported into another.