### PR TITLE
add project assignment controls

### DIFF
--- a/packages/builder/src/components/backend/DatasourceNavigator/modals/UpdateDatasourceModal.svelte
+++ b/packages/builder/src/components/backend/DatasourceNavigator/modals/UpdateDatasourceModal.svelte
@@ -3,16 +3,27 @@
   import { datasources, integrations } from "@/stores/builder"
   import { notifications, Input, ModalContent, Modal } from "@budibase/bbui"
   import { integrationForDatasource } from "@/stores/selectors"
+  import ProjectSelect from "@/components/common/ProjectSelect.svelte"
 
   let error = ""
   let modal
   let name
+  let originalName = ""
+  let originalProjectId = ""
+  let projectId = ""
+  let hasChanges = false
+
+  $: hasChanges = name !== originalName || projectId !== originalProjectId
 
   export let datasource
   export let onCancel = undefined
 
   export const show = () => {
-    name = datasource?.name
+    error = ""
+    originalName = datasource?.name || ""
+    originalProjectId = datasource?.projectId || ""
+    name = originalName
+    projectId = originalProjectId
     modal.show()
   }
   export const hide = () => {
@@ -21,7 +32,11 @@
 
   function checkValid(evt) {
     const datasourceName = evt.target.value
-    if ($datasources?.list.some(ds => ds.name === datasourceName)) {
+    if (
+      $datasources?.list.some(
+        ds => ds._id !== datasource?._id && ds.name === datasourceName
+      )
+    ) {
       error = `Datasource with name ${datasourceName} already exists. Please choose another name.`
       return
     }
@@ -32,10 +47,12 @@
     const updatedDatasource = {
       ...datasource,
       name,
+      projectId: projectId || undefined,
     }
     await datasources.save({
       datasource: updatedDatasource,
       integration: integrationForDatasource(get(integrations), datasource),
+      skipConnectionCheck: true,
     })
     notifications.success(`Datasource ${name} updated successfully.`)
     hide()
@@ -48,7 +65,7 @@
     size="L"
     confirmText="Save"
     onConfirm={updateDatasource}
-    disabled={error || !name || !datasource?.type}
+    disabled={!hasChanges || !!error || !name || !datasource?.type}
   >
     <Input
       label="Datasource Name"
@@ -56,5 +73,6 @@
       bind:value={name}
       {error}
     />
+    <ProjectSelect bind:value={projectId} />
   </ModalContent>
 </Modal>

--- a/packages/builder/src/components/backend/Datasources/ConfigEditor/index.svelte
+++ b/packages/builder/src/components/backend/Datasources/ConfigEditor/index.svelte
@@ -6,18 +6,25 @@
   import { get } from "svelte/store"
   import type { UIIntegration } from "@budibase/types"
   import InfoDisplay from "@/pages/builder/workspace/[application]/design/[workspaceAppId]/[screenId]/[componentId]/_components/Component/InfoDisplay.svelte"
+  import ProjectSelect from "@/components/common/ProjectSelect.svelte"
 
   export let integration: UIIntegration
   export let config: Record<string, any>
   export let onSubmit: (_value: {
     config: Record<string, any>
     name: string
+    projectId?: string
   }) => Promise<void> | void = () => {}
   export let showNameField: boolean = false
   export let nameFieldValue: string = ""
+  export let showProjectField: boolean = false
+  export let projectIdValue: string = ""
+
+  let projectId = ""
 
   $: configStore = createValidatedConfigStore(integration, config)
   $: nameStore = createValidatedNameStore(nameFieldValue, showNameField)
+  $: projectId = projectIdValue || ""
 
   const handleConfirm = async () => {
     configStore.markAllFieldsActive()
@@ -29,6 +36,7 @@
       return onSubmit({
         config,
         name,
+        projectId: projectId || undefined,
       })
     }
 
@@ -66,6 +74,10 @@
       on:blur={nameStore.markActive}
       on:change={e => nameStore.updateValue(e.detail)}
     />
+  {/if}
+
+  {#if showProjectField}
+    <ProjectSelect bind:value={projectId} />
   {/if}
 
   {#each $configStore.validatedConfig as { type, key, value, error, name, config, placeholder }}

--- a/packages/builder/src/components/backend/TableNavigator/TableNavItem/EditModal.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/TableNavItem/EditModal.svelte
@@ -1,7 +1,9 @@
 <script>
   import { cloneDeep } from "lodash/fp"
+  import { get } from "svelte/store"
   import { tables, datasources } from "@/stores/builder"
   import { Input, Modal, ModalContent, notifications } from "@budibase/bbui"
+  import ProjectSelect from "@/components/common/ProjectSelect.svelte"
 
   export let table
 
@@ -14,26 +16,37 @@
 
   let originalName
   let updatedName
+  let originalProjectId = ""
+  let projectId = ""
+  let hasChanges = false
+
+  $: hasChanges =
+    updatedName !== originalName || projectId !== originalProjectId
 
   async function save() {
     const updatedTable = cloneDeep(table)
     updatedTable.name = updatedName
+    updatedTable.projectId = projectId || undefined
     await tables.save(updatedTable)
     await datasources.fetch()
-    notifications.success("Table renamed successfully")
+    notifications.success("Table updated successfully")
   }
 
   function checkValid(evt) {
     const tableName = evt.target.value
-    error =
-      originalName === tableName
-        ? `Table with name ${tableName} already exists. Please choose another name.`
-        : ""
+    error = get(tables).list.some(
+      existing => existing._id !== table._id && existing.name === tableName
+    )
+      ? `Table with name ${tableName} already exists. Please choose another name.`
+      : ""
   }
 
   const initForm = () => {
+    error = ""
     originalName = table.name + ""
     updatedName = table.name + ""
+    originalProjectId = table.projectId || ""
+    projectId = originalProjectId
   }
 </script>
 
@@ -43,7 +56,7 @@
     title="Edit Table"
     confirmText="Save"
     onConfirm={save}
-    disabled={updatedName === originalName || error}
+    disabled={!hasChanges || !!error}
   >
     <form on:submit|preventDefault={() => editTableNameModal.confirm()}>
       <Input
@@ -53,6 +66,7 @@
         on:input={checkValid}
         {error}
       />
+      <ProjectSelect bind:value={projectId} />
     </form>
   </ModalContent>
 </Modal>

--- a/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
@@ -4,6 +4,7 @@
   import { notifications, Input, ModalContent } from "@budibase/bbui"
   import { API } from "@/api"
   import { tables, datasources, dataEnvironmentStore } from "@/stores/builder"
+  import ProjectSelect from "@/components/common/ProjectSelect.svelte"
   import TableDataImport from "../TableDataImport.svelte"
   import { chunkRows, IMPORT_ROWS_PER_CHUNK } from "../utils"
   import {
@@ -45,6 +46,7 @@
   let rows = []
   let allValid = true
   let displayColumn = null
+  let projectId = ""
 
   const buildOptionConstraints = (schema, rows) => {
     const updatedSchema = {}
@@ -165,6 +167,7 @@
       type: "table",
       sourceId: targetDatasourceId,
       sourceType: DB_TYPE_INTERNAL,
+      projectId: projectId || undefined,
     }
 
     // Only set primary display if defined
@@ -214,6 +217,7 @@
     bind:value={name}
     {error}
   />
+  <ProjectSelect bind:value={projectId} />
   <TableDataImport
     {promptUpload}
     bind:rows

--- a/packages/builder/src/components/common/ProjectSelect.svelte
+++ b/packages/builder/src/components/common/ProjectSelect.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { Select } from "@budibase/bbui"
+  import { FeatureFlag } from "@budibase/types"
+  import { featureFlags, projectsStore } from "@/stores/portal"
+
+  interface ProjectOption {
+    label: string
+    value: string
+    color?: string
+  }
+
+  export let value = ""
+  export let label = "Project"
+  export let includeEmptyOption = true
+  export let emptyLabel = "No project"
+
+  let options: ProjectOption[] = []
+
+  $: projectsEnabled = $featureFlags[FeatureFlag.PROJECTS]
+
+  $: if (projectsEnabled) {
+    projectsStore.ensureFetched().catch(console.error)
+  }
+
+  $: options = [
+    ...(includeEmptyOption
+      ? [{ label: emptyLabel, value: "", color: undefined }]
+      : []),
+    ...$projectsStore.map(project => ({
+      label: project.name,
+      value: project._id,
+      color: project.color,
+    })),
+  ]
+</script>
+
+{#if projectsEnabled}
+  <Select
+    {label}
+    bind:value
+    {options}
+    getOptionLabel={option => option.label}
+    getOptionValue={option => option.value}
+    getOptionColour={option => option.color}
+  />
+{/if}

--- a/packages/builder/src/components/integration/APIEndpointViewer.svelte
+++ b/packages/builder/src/components/integration/APIEndpointViewer.svelte
@@ -81,6 +81,7 @@
   import ExpandablePanel from "@/components/common/ExpandablePanel.svelte"
   import ConnectionSelect from "./rest/ConnectionSelect.svelte"
   import AccessLevelSelect from "@/components/integration/AccessLevelSelect.svelte"
+  import ProjectSelect from "@/components/common/ProjectSelect.svelte"
   import { getErrorMessage } from "@/helpers/errors"
   import { confirm } from "@/helpers"
   import {
@@ -963,6 +964,9 @@
           {#if editableQuery}
             <div class="access">
               <AccessLevelSelect query={editableQuery} label="Access" />
+            </div>
+            <div class="project">
+              <ProjectSelect bind:value={editableQuery.projectId} />
             </div>
           {/if}
           {#if endpointDocs}

--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -27,6 +27,7 @@
   import { Utils } from "@budibase/frontend-core"
   import ConnectedQueryUsage from "./ConnectedQueryUsage.svelte"
   import { getErrorMessage } from "@/helpers/errors"
+  import ProjectSelect from "@/components/common/ProjectSelect.svelte"
   import type {
     Datasource,
     Integration,
@@ -56,6 +57,8 @@
   let scrolling = false
   let showSidePanel = false
   let nameError: string | null = null
+  let projectId = ""
+  let canSaveQuery = false
 
   let newQuery: Query
 
@@ -71,6 +74,10 @@
 
   const parseQuery = (query: Query) => {
     modified = false
+    nameError = null
+    showSidePanel = false
+    rows = []
+    nestedSchemaFields = {}
 
     datasource = $datasources.list.find(
       (ds: DatasourceOption) => ds._id === query.datasourceId
@@ -88,6 +95,7 @@
     // Set the location where the query code will be written to an empty string so that it doesn't
     // get changed from undefined -> "" by the input, breaking our unsaved changes checks
     newQuery.fields[schemaType] ??= ""
+    projectId = newQuery.projectId || ""
 
     // Initialize pagination for SQL Read queries
     if (newQuery.queryVerb === "read" && schemaType === "sql") {
@@ -117,7 +125,14 @@
 
   const debouncedCheckIsModified = Utils.debounce(checkIsModified, 1000)
 
+  $: if (newQuery) {
+    newQuery.projectId = projectId || undefined
+  }
+
   $: debouncedCheckIsModified(newQuery)
+
+  $: canSaveQuery =
+    rows.length > 0 || (!!newQuery?._id && Object.keys(schema || {}).length > 0)
 
   async function runQuery({ suppressErrors = true }: RunQueryOptions = {}) {
     try {
@@ -275,7 +290,7 @@
               loading ||
               !newQuery.name ||
               nameError ||
-              rows.length === 0
+              !canSaveQuery
             )}
             overBackground
           >
@@ -306,6 +321,7 @@
             }}
             error={nameError || undefined}
           />
+          <ProjectSelect bind:value={projectId} />
           {#if integration.query}
             <Label>Function</Label>
             <Select

--- a/packages/builder/src/pages/builder/workspace/[application]/data/_components/CreateExternalDatasourceModal/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/_components/CreateExternalDatasourceModal/index.svelte
@@ -36,17 +36,7 @@
   $: handleStoreChanges($store, modal, $goto)
 
   export function show(integration) {
-    if (integration.name === IntegrationTypes.REST) {
-      // A REST integration is created immediately, we don't need to display a config modal.
-      loading = true
-      datasources
-        .create({ integration, config: configFromIntegration(integration) })
-        .then(datasource => {
-          store.setIntegration(integration)
-          store.setDatasource(datasource)
-        })
-        .finally(() => (loading = false))
-    } else if (integration.name === IntegrationTypes.GOOGLE_SHEETS) {
+    if (integration.name === IntegrationTypes.GOOGLE_SHEETS) {
       // This prompt redirects users to the Google OAuth flow, they'll be returned to this modal afterwards
       // with query params populated that trigger the `onGoogleAuth` store.
       store.googleAuthStage()
@@ -65,11 +55,12 @@
     store.editConfigStage()
   })
 
-  const createDatasource = async config => {
+  const createDatasource = async ({ config, projectId }) => {
     try {
       const datasource = await datasources.create({
         integration: get(store).integration,
         config,
+        projectId,
       })
       store.setDatasource(datasource)
 
@@ -104,7 +95,8 @@
     <DatasourceConfigEditor
       integration={$store.integration}
       config={$store.config}
-      onSubmit={({ config }) => createDatasource(config)}
+      showProjectField
+      onSubmit={createDatasource}
     />
   {:else if $store.stage === "selectTables"}
     <TableImportSelection

--- a/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/EditDatasourceConfig.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/datasource/[datasourceId]/_components/EditDatasourceConfig.svelte
@@ -11,11 +11,11 @@
 
   let modal
 
-  async function saveDatasource({ config, name }) {
+  async function saveDatasource({ config, name, projectId }) {
     try {
       await datasources.save({
         integration,
-        datasource: { ...datasource, config, name },
+        datasource: { ...datasource, config, name, projectId },
       })
 
       notifications.success(
@@ -35,7 +35,9 @@
     {integration}
     config={datasource.config}
     showNameField
+    showProjectField
     nameFieldValue={datasource.name}
+    projectIdValue={datasource.projectId || ""}
     onSubmit={saveDatasource}
   />
 </Modal>

--- a/packages/builder/src/stores/builder/datasources.ts
+++ b/packages/builder/src/stores/builder/datasources.ts
@@ -212,12 +212,14 @@ export class DatasourceStore extends DerivedBudiStore<
     integration,
     config,
     name,
+    projectId,
     restTemplateId,
     restTemplateVersion,
   }: {
     integration: UIIntegration
     config: Record<string, any>
     name?: string
+    projectId?: string
     restTemplateId?: RestTemplateId
     restTemplateVersion?: RestTemplateSpecVersion
   }) {
@@ -229,6 +231,7 @@ export class DatasourceStore extends DerivedBudiStore<
       source: integration.name as SourceName,
       config,
       name: `${name || integration.friendlyName}${nameModifier}`,
+      projectId,
       plus: integration.plus && integration.name !== SourceName.REST,
       isSQL: integration.isSQL,
       ...(restTemplateId && { restTemplateId }),
@@ -254,11 +257,16 @@ export class DatasourceStore extends DerivedBudiStore<
   async save({
     integration,
     datasource,
+    skipConnectionCheck,
   }: {
     integration: Integration
     datasource: Datasource
+    skipConnectionCheck?: boolean
   }) {
-    if (!(await this.checkDatasourceValidity(integration, datasource)).valid) {
+    if (
+      !skipConnectionCheck &&
+      !(await this.checkDatasourceValidity(integration, datasource)).valid
+    ) {
       throw new Error("Unable to connect")
     }
 

--- a/packages/builder/src/stores/builder/restTemplates.ts
+++ b/packages/builder/src/stores/builder/restTemplates.ts
@@ -2028,7 +2028,7 @@ const splunkRestTemplateGroup: RestTemplate = {
       id: "splunk-mission-control-automation",
       name: "Splunk Mission Control Automation",
       description:
-        "Mission Control Automation API for SOAR playbook integrations.",
+        "Mission Control Automation API for SOAR project integrations.",
       specs: [
         {
           version: "3.1.0",

--- a/packages/builder/src/stores/portal/index.ts
+++ b/packages/builder/src/stores/portal/index.ts
@@ -20,6 +20,7 @@ export { themeStore } from "./theme"
 export { temporalStore } from "./temporal"
 export { navigation } from "./navigation"
 export { featureFlags } from "./featureFlags"
+export { projectsStore } from "./projects"
 export { agentsStore, selectedAgent } from "./agents"
 export { knowledgeConnectionsStore } from "./knowledgeConnections"
 export {

--- a/packages/builder/src/stores/portal/projects.spec.ts
+++ b/packages/builder/src/stores/portal/projects.spec.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  ResourceType,
+  type CreateProjectResponse,
+  type FetchProjectsResponse,
+  type ImportProjectResponse,
+  type ProjectResponse,
+  type UpdateProjectResponse,
+} from "@budibase/types"
+import { API } from "@/api"
+import { ProjectsStore } from "./projects"
+import { get } from "svelte/store"
+
+vi.mock("@/api", () => {
+  return {
+    API: {
+      projects: {
+        fetch: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        exportBundle: vi.fn(),
+        importBundle: vi.fn(),
+      },
+    },
+  }
+})
+
+vi.mock("@budibase/frontend-core", () => {
+  return {
+    downloadStream: vi.fn(),
+  }
+})
+
+const fetchProjects = vi.mocked(API.projects.fetch)
+const createProject = vi.mocked(API.projects.create)
+const updateProject = vi.mocked(API.projects.update)
+const deleteProject = vi.mocked(API.projects.delete)
+const importBundle = vi.mocked(API.projects.importBundle)
+
+const defer = <T>() => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+const project = (id: string): ProjectResponse => ({
+  _id: id,
+  _rev: "1-rev",
+  name: id,
+  createdAt: "2026-01-01T00:00:00.000Z",
+})
+
+const getProjects = (store: ProjectsStore) => get(store.store)
+
+describe("ProjectsStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("does not let an older fetch complete over a newer in-flight fetch", async () => {
+    const store = new ProjectsStore()
+    const older = defer<FetchProjectsResponse>()
+    const newer = defer<FetchProjectsResponse>()
+
+    fetchProjects
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise)
+
+    const olderFetch = store.fetch()
+    const newerFetch = store.fetch()
+
+    older.resolve({ projects: [project("stale_project")] })
+    await olderFetch
+
+    const ensuredFetch = store.ensureFetched()
+
+    expect(fetchProjects).toHaveBeenCalledTimes(2)
+
+    newer.resolve({ projects: [project("project_1")] })
+
+    await expect(newerFetch).resolves.toEqual([project("project_1")])
+    await expect(ensuredFetch).resolves.toEqual([project("project_1")])
+  })
+
+  it("returns the import response when the post-import refresh fails", async () => {
+    const store = new ProjectsStore()
+    const response: ImportProjectResponse = {
+      project: project("project_1"),
+      resources: {
+        [ResourceType.PROJECT]: ["project_1"],
+      },
+      unsupportedContent: [],
+      requirements: [],
+    }
+    const file = new File(["project"], "project.tar.gz")
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    importBundle.mockResolvedValue(response)
+    fetchProjects.mockRejectedValue(new Error("refresh failed"))
+
+    await expect(store.importProject(file)).resolves.toEqual(response)
+    expect(fetchProjects).toHaveBeenCalledTimes(1)
+
+    warn.mockRestore()
+  })
+
+  it("does not let an in-flight fetch overwrite a created project", async () => {
+    const store = new ProjectsStore()
+    const fetch = defer<FetchProjectsResponse>()
+    const created = project("created_project")
+    const response: CreateProjectResponse = { project: created }
+
+    fetchProjects.mockReturnValue(fetch.promise)
+    createProject.mockResolvedValue(response)
+
+    const fetchPromise = store.fetch()
+    await store.create({ name: "Created project" })
+    fetch.resolve({ projects: [project("stale_project")] })
+
+    await expect(fetchPromise).resolves.toEqual([project("stale_project")])
+    expect(getProjects(store)).toEqual([created])
+  })
+
+  it("does not let an in-flight fetch overwrite an updated project", async () => {
+    const store = new ProjectsStore()
+    const fetch = defer<FetchProjectsResponse>()
+    const original = project("project_1")
+    const updated: ProjectResponse = {
+      ...original,
+      _rev: "2-rev",
+      name: "Updated project",
+    }
+    const response: UpdateProjectResponse = { project: updated }
+
+    fetchProjects.mockResolvedValueOnce({ projects: [original] })
+    await store.fetch()
+    fetchProjects.mockReturnValue(fetch.promise)
+    updateProject.mockResolvedValue(response)
+
+    const fetchPromise = store.fetch()
+    await store.updateProject({
+      _id: original._id,
+      _rev: original._rev,
+      name: updated.name,
+    })
+    fetch.resolve({ projects: [original] })
+
+    await expect(fetchPromise).resolves.toEqual([original])
+    expect(getProjects(store)).toEqual([updated])
+  })
+
+  it("does not let an in-flight fetch re-add a deleted project", async () => {
+    const store = new ProjectsStore()
+    const fetch = defer<FetchProjectsResponse>()
+    const deleted = project("project_1")
+    const retained = project("project_2")
+
+    fetchProjects.mockResolvedValueOnce({ projects: [deleted, retained] })
+    await store.fetch()
+    fetchProjects.mockReturnValue(fetch.promise)
+    deleteProject.mockResolvedValue(undefined)
+
+    const fetchPromise = store.fetch()
+    await store.deleteProject(deleted._id, deleted._rev)
+    fetch.resolve({ projects: [deleted, retained] })
+
+    await expect(fetchPromise).resolves.toEqual([deleted, retained])
+    expect(getProjects(store)).toEqual([retained])
+  })
+})

--- a/packages/builder/src/stores/portal/projects.ts
+++ b/packages/builder/src/stores/portal/projects.ts
@@ -1,0 +1,104 @@
+import { API } from "@/api"
+import { downloadStream } from "@budibase/frontend-core"
+import type {
+  CreateProjectRequest,
+  ImportProjectRequest,
+  ImportProjectResponse,
+  ProjectResponse,
+  UpdateProjectRequest,
+} from "@budibase/types"
+import { BudiStore } from "../BudiStore"
+import { get } from "svelte/store"
+
+export class ProjectsStore extends BudiStore<ProjectResponse[]> {
+  private loaded = false
+  private fetchPromise: Promise<ProjectResponse[]> | undefined
+
+  constructor() {
+    super([])
+  }
+
+  fetch = async () => {
+    const promise = API.projects
+      .fetch()
+      .then(({ projects }) => {
+        if (this.fetchPromise === promise) {
+          this.loaded = true
+          this.set(projects)
+        }
+        return projects
+      })
+      .finally(() => {
+        if (this.fetchPromise === promise) {
+          this.fetchPromise = undefined
+        }
+      })
+    this.fetchPromise = promise
+    return await promise
+  }
+
+  ensureFetched = async () => {
+    if (this.fetchPromise) {
+      return await this.fetchPromise
+    }
+    if (this.loaded) {
+      return get(this.store)
+    }
+    return await this.fetch()
+  }
+
+  hasFetched = () => this.loaded
+
+  private invalidateFetch = () => {
+    this.fetchPromise = undefined
+  }
+
+  create = async (project: CreateProjectRequest) => {
+    const response = await API.projects.create(project)
+    this.invalidateFetch()
+    this.update(state => [...state, response.project])
+    return response.project
+  }
+
+  exportProject = async (
+    id: string,
+    body?: {
+      encryptPassword?: string
+    }
+  ) => {
+    const response = await API.projects.exportBundle(id, body)
+    await downloadStream(response)
+  }
+
+  importProject = async (
+    file: File,
+    body?: ImportProjectRequest
+  ): Promise<ImportProjectResponse> => {
+    const response = await API.projects.importBundle(file, body)
+    try {
+      await this.fetch()
+    } catch (err) {
+      console.warn("Failed to refresh projects after import", err)
+    }
+    return response
+  }
+
+  updateProject = async (project: UpdateProjectRequest) => {
+    const response = await API.projects.update(project)
+    this.invalidateFetch()
+    this.update(state =>
+      state.map(existing =>
+        existing._id === response.project._id ? response.project : existing
+      )
+    )
+    return response.project
+  }
+
+  deleteProject = async (id: string, rev: string) => {
+    await API.projects.delete(id, rev)
+    this.invalidateFetch()
+    this.update(state => state.filter(project => project._id !== id))
+  }
+}
+
+export const projectsStore = new ProjectsStore()

--- a/packages/frontend-core/src/api/index.ts
+++ b/packages/frontend-core/src/api/index.ts
@@ -23,6 +23,7 @@ import { buildFlagEndpoints } from "./flags"
 import { buildLayoutEndpoints } from "./layouts"
 import { buildOtherEndpoints } from "./other"
 import { buildPermissionsEndpoints } from "./permissions"
+import { buildProjectEndpoints } from "./projects"
 import { buildQueryEndpoints } from "./queries"
 import { buildRelationshipEndpoints } from "./relationships"
 import { buildRoleEndpoints } from "./roles"
@@ -327,6 +328,7 @@ export const createAPIClient = (config: APIClientConfig = {}): APIClient => {
     rowActions: buildRowActionEndpoints(API),
     oauth2: buildOAuth2Endpoints(API),
     navigation: buildNavigationEndpoints(API),
+    projects: buildProjectEndpoints(API),
     workspaceApp: buildWorkspaceAppEndpoints(API),
     workspace: buildWorkspaceFavouriteEndpoints(API),
     workspaceHome: buildWorkspaceHomeEndpoints(API),

--- a/packages/frontend-core/src/api/projects.ts
+++ b/packages/frontend-core/src/api/projects.ts
@@ -1,0 +1,78 @@
+import {
+  CreateProjectRequest,
+  CreateProjectResponse,
+  ExportProjectRequest,
+  FetchProjectsResponse,
+  ImportProjectRequest,
+  ImportProjectResponse,
+  UpdateProjectRequest,
+  UpdateProjectResponse,
+} from "@budibase/types"
+import { BaseAPIClient } from "./types"
+
+export interface ProjectEndpoints {
+  fetch: () => Promise<FetchProjectsResponse>
+  create: (project: CreateProjectRequest) => Promise<CreateProjectResponse>
+  exportBundle: (id: string, body?: ExportProjectRequest) => Promise<Response>
+  importBundle: (
+    file: File,
+    body?: ImportProjectRequest
+  ) => Promise<ImportProjectResponse>
+  update: (project: UpdateProjectRequest) => Promise<UpdateProjectResponse>
+  delete: (id: string, rev: string) => Promise<void>
+}
+
+export const buildProjectEndpoints = (
+  API: BaseAPIClient
+): ProjectEndpoints => ({
+  fetch: async () => {
+    return await API.get({
+      url: "/api/projects",
+    })
+  },
+  create: async project => {
+    return await API.post({
+      url: "/api/projects",
+      body: project,
+    })
+  },
+  exportBundle: async (id, body) => {
+    return await API.post<ExportProjectRequest | undefined, Response>({
+      url: `/api/projects/${id}/export`,
+      body,
+      parseResponse: response => response,
+    })
+  },
+  importBundle: async (file, body) => {
+    const formData = new FormData()
+    formData.append("file", file)
+    for (const [key, value] of Object.entries(body || {})) {
+      if (value !== undefined) {
+        formData.append(key, value)
+      }
+    }
+    return await API.post<FormData, ImportProjectResponse>({
+      url: "/api/projects/import",
+      body: formData,
+      json: false,
+    })
+  },
+  update: async project => {
+    const { _id, _rev, name, description, color } = project
+    return await API.put({
+      url: `/api/projects/${_id}`,
+      body: {
+        _id,
+        _rev,
+        name,
+        description,
+        color,
+      },
+    })
+  },
+  delete: async (id, rev) => {
+    return await API.delete({
+      url: `/api/projects/${id}/${rev}`,
+    })
+  },
+})

--- a/packages/frontend-core/src/api/types.ts
+++ b/packages/frontend-core/src/api/types.ts
@@ -20,6 +20,7 @@ import { MigrationEndpoints } from "./migrations"
 import { OAuth2Endpoints } from "./oauth2"
 import { OtherEndpoints } from "./other"
 import { PermissionEndpoints } from "./permissions"
+import { ProjectEndpoints } from "./projects"
 import { PluginEndpoins } from "./plugins"
 import { QueryEndpoints } from "./queries"
 import { RelationshipEndpoints } from "./relationships"
@@ -160,6 +161,7 @@ export type APIClient = BaseAPIClient &
     viewV2: ViewV2Endpoints
     oauth2: OAuth2Endpoints
     navigation: NavigationEndpoints
+    projects: ProjectEndpoints
     workspaceApp: WorkspaceAppEndpoints
     workspace: WorkspaceFavouriteEndpoints
     workspaceHome: WorkspaceHomeEndpoints


### PR DESCRIPTION
## description
adds frontend project api/store support and assignment controls for supported resources, including tables, datasources, queries, api requests, apps, automations, and agents.

## addresses
- n/a

## app export
- n/a

## screenshots
to be added if required for review.

## launchcontrol
adds controls for assigning budibase resources to projects.