### PR TITLE
add projects workspace home ui

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/AssignProjectModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/AssignProjectModal.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import { Body, ModalContent, Select } from "@budibase/bbui"
+  import type { HomeRow, ProjectResponse } from "@budibase/types"
+
+  export let row: HomeRow | null = null
+  export let projects: ProjectResponse[] = []
+  export let onConfirm: (_projectId: string | undefined) => unknown = () => {}
+
+  interface ProjectOption {
+    label: string
+    value: string
+    color?: string
+  }
+
+  let selectedProjectId = ""
+  let projectOptions: ProjectOption[] = []
+
+  $: selectedProjectId = row?.projectId || ""
+  $: projectOptions = [
+    { label: "No project", value: "", color: undefined },
+    ...projects.map(project => ({
+      label: project.name,
+      value: project._id,
+      color: project.color,
+    })),
+  ] satisfies ProjectOption[]
+</script>
+
+<ModalContent
+  title={`Assign project${row ? ` to ${row.name}` : ""}`}
+  confirmText="Save"
+  size="M"
+  onConfirm={() => onConfirm(selectedProjectId || undefined)}
+>
+  {#if row}
+    <Body size="S" color="var(--spectrum-global-color-gray-700)">
+      Choose which project this {row.type} belongs to.
+    </Body>
+  {/if}
+
+  <Select
+    label="Project"
+    bind:value={selectedProjectId}
+    options={projectOptions}
+    getOptionLabel={option => option.label}
+    getOptionValue={option => option.value}
+    getOptionColour={option => option.color}
+  />
+</ModalContent>

--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/CreateProjectModal.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/CreateProjectModal.spec.ts
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@testing-library/svelte"
+import { describe, expect, it, vi } from "vitest"
+import MockBody from "@/test/mocks/MockBody.svelte"
+import MockColorPicker from "@/test/mocks/MockColorPicker.svelte"
+import MockInput from "@/test/mocks/MockInput.svelte"
+import MockModalContent from "@/test/mocks/MockModalContent.svelte"
+
+vi.mock("@budibase/bbui", () => ({
+  keepOpen: Symbol("keepOpen"),
+  Body: MockBody,
+  ColorPicker: MockColorPicker,
+  Input: MockInput,
+  ModalContent: MockModalContent,
+  TextArea: MockInput,
+}))
+
+import CreateProjectModal from "./CreateProjectModal.svelte"
+
+describe("CreateProjectModal", () => {
+  it("submits without a colour after the colour picker is cleared", async () => {
+    const onConfirm = vi.fn()
+
+    render(CreateProjectModal, {
+      props: {
+        onConfirm,
+      },
+    })
+
+    await fireEvent.input(screen.getByLabelText("Name"), {
+      target: { value: "Operations" },
+    })
+    await fireEvent.click(screen.getByText("Clear color"))
+    await fireEvent.click(screen.getByText("Create"))
+
+    expect(onConfirm).toHaveBeenCalledWith({
+      name: "Operations",
+      description: undefined,
+      color: undefined,
+    })
+  })
+})

--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/CreateProjectModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/CreateProjectModal.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import {
+    Body,
+    ColorPicker,
+    Input,
+    keepOpen,
+    ModalContent,
+    TextArea,
+  } from "@budibase/bbui"
+
+  interface ConfirmPayload {
+    name: string
+    description?: string
+    color?: string
+  }
+
+  export let onConfirm: (_payload: ConfirmPayload) => unknown = () => {}
+
+  let name = ""
+  let description = ""
+  let color: string | undefined = "#8CA171"
+  let nameError: string | undefined = undefined
+
+  $: if (name.trim()) {
+    nameError = undefined
+  }
+
+  const confirm = () => {
+    if (!name.trim()) {
+      nameError = "Name is required"
+      return keepOpen
+    }
+
+    return onConfirm({
+      name: name.trim(),
+      description: description.trim() || undefined,
+      color: color?.trim() || undefined,
+    })
+  }
+</script>
+
+<ModalContent
+  title="Create project"
+  confirmText="Create"
+  size="M"
+  onConfirm={confirm}
+>
+  <Input bind:value={name} label="Name" error={nameError} />
+  <TextArea
+    bind:value={description}
+    label="Description"
+    minHeight={96}
+    placeholder="What does this project cover?"
+  />
+
+  <div class="color-field">
+    <Body size="S" weight="600">Color</Body>
+    <ColorPicker bind:value={color} on:change={e => (color = e.detail)} />
+  </div>
+</ModalContent>
+
+<style>
+  .color-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/ExportProjectModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/ExportProjectModal.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import { Body, Input, ModalContent, Select, Toggle } from "@budibase/bbui"
+  import type { ProjectResponse } from "@budibase/types"
+
+  export let projects: ProjectResponse[] = []
+  export let selectedProjectId = ""
+
+  interface ConfirmPayload {
+    id: string
+    encryptPassword?: string
+  }
+
+  export let onConfirm: (_payload: ConfirmPayload) => unknown = () => {}
+
+  let projectId = ""
+  let encrypted = false
+  let encryptPassword = ""
+  let disabled = false
+  let initialised = false
+
+  $: if (!initialised && projects.length) {
+    const selectedProject = projects.find(
+      project => project._id === selectedProjectId
+    )
+
+    if (selectedProject) {
+      projectId = selectedProject._id
+    } else if (projects.length === 1) {
+      projectId = projects[0]._id
+    }
+
+    initialised = true
+  }
+
+  $: if (!encrypted && encryptPassword) {
+    encryptPassword = ""
+  }
+
+  $: disabled = !projectId || (encrypted && !encryptPassword.trim())
+</script>
+
+<ModalContent
+  title="Export project"
+  confirmText="Export"
+  size="M"
+  bind:disabled
+  onConfirm={() =>
+    onConfirm({
+      id: projectId,
+      encryptPassword: encrypted ? encryptPassword.trim() : undefined,
+    })}
+>
+  <Body size="S">
+    Export a portable Project package for use in another workspace. Rows and
+    attachments are not included yet.
+  </Body>
+
+  <Select
+    label="Project"
+    bind:value={projectId}
+    options={projects}
+    getOptionLabel={project => project.name}
+    getOptionValue={project => project._id}
+    getOptionColour={project => project.color}
+  />
+
+  <Toggle text="Encrypt export" bind:value={encrypted} />
+
+  {#if encrypted}
+    <Input
+      type="password"
+      label="Password"
+      placeholder="Type here..."
+      autocomplete="new-password"
+      bind:value={encryptPassword}
+    />
+  {/if}
+</ModalContent>

--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeControls.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeControls.svelte
@@ -32,54 +32,37 @@
   ] satisfies HomeFilterOption[]
 </script>
 
-<div class="controls">
-  <div class="controls-left">
-    <div class="filter">
-      {#each tabOptions as option}
-        <span
-          class="filter-tab"
-          style="--tab-icon-color: {getHomeTypeIconColor(option.value)}"
-        >
-          <ActionButton
-            quiet
-            selected={typeFilter === option.value}
-            disabled={option.disabled}
-            on:click={() =>
-              !option.disabled && dispatch("typeChange", option.value)}
-          >
-            <Icon
-              name={getHomeTypeIcon(option.value)}
-              size="S"
-              color={getHomeTypeIconColor(option.value)}
-              weight="fill"
-            />
-            {option.label}
-          </ActionButton>
-        </span>
-      {/each}
-    </div>
-  </div>
+<div class="filter">
+  {#each tabOptions as option}
+    <span
+      class="filter-tab"
+      style="--tab-icon-color: {getHomeTypeIconColor(option.value)}"
+    >
+      <ActionButton
+        quiet
+        selected={typeFilter === option.value}
+        disabled={option.disabled}
+        on:click={() =>
+          !option.disabled && dispatch("typeChange", option.value)}
+      >
+        <Icon
+          name={getHomeTypeIcon(option.value)}
+          size="S"
+          color={getHomeTypeIconColor(option.value)}
+          weight="fill"
+        />
+        {option.label}
+      </ActionButton>
+    </span>
+  {/each}
 </div>
 
 <style>
-  .controls {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    gap: var(--spacing-m);
-  }
-
-  .controls-left {
-    display: flex;
-    gap: var(--spacing-m);
-    align-items: center;
-  }
-
   .filter {
     display: flex;
-    gap: 10px;
-    padding: 3px;
-    border-radius: 7px;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-xs);
+    border-radius: var(--border-radius-s);
     background: var(--spectrum-global-color-gray-100);
   }
 
@@ -92,32 +75,20 @@
   }
 
   .filter :global(.spectrum-ActionButton) {
-    border-radius: 6px;
+    border-radius: var(--border-radius-s);
     transition:
       border-color 130ms ease-out,
       background 130ms ease-out;
     border: 1px solid transparent;
-    padding: 3px 10px;
+    padding: var(--spacing-xs) var(--spacing-s);
     height: auto;
   }
 
   .filter :global(.spectrum-ActionButton-label) {
     display: flex;
     align-items: center;
-    gap: 6px;
-    font-size: 14px;
+    gap: var(--spacing-xs);
+    font-size: var(--font-size-s);
     font-weight: 500;
-  }
-
-  @media (max-width: 1140px) {
-    .controls {
-      flex-direction: column;
-      align-items: stretch;
-      gap: var(--spacing-m);
-    }
-
-    .controls-left {
-      justify-content: flex-start;
-    }
   }
 </style>

--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeEmptyState.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeEmptyState.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte"
-  import { Body, Icon } from "@budibase/bbui"
+  import { Body, Button, Icon } from "@budibase/bbui"
   import type { HomeType } from "@budibase/types"
   import { getRowIcon, getRowIconColor } from "./rows"
 
@@ -8,6 +8,7 @@
   export let filteredRowsCount = 0
   export let typeFilter: HomeType = "all"
   export let searchTerm = ""
+  export let selectedProjectName = ""
 
   const dispatch = createEventDispatcher<{
     clearSearch: void
@@ -19,8 +20,12 @@
 
   $: hasAnyRows = allRowsCount > 0
   $: hasSearch = !!searchTerm.trim()
-  $: hasFilter = typeFilter !== "all"
+  $: hasProjectFilter = !!selectedProjectName
+  $: hasFilter = typeFilter !== "all" || hasProjectFilter
   $: isNoResults = hasAnyRows && filteredRowsCount === 0
+  $: noResultsText = hasProjectFilter
+    ? `No results in ${selectedProjectName}.`
+    : "No results."
 
   const agentColor = getRowIconColor("agent")
   const automationColor = getRowIconColor("automation")
@@ -35,26 +40,28 @@
   <div class="empty">
     {#if isNoResults}
       <Body size="M" color="var(--spectrum-global-color-gray-700)">
-        No results.
+        {noResultsText}
       </Body>
       <div class="actions">
         {#if hasSearch}
-          <button
-            type="button"
-            class="action"
+          <Button
+            secondary
+            quiet
+            size="S"
             on:click={() => dispatch("clearSearch")}
           >
             Clear search
-          </button>
+          </Button>
         {/if}
         {#if hasFilter}
-          <button
-            type="button"
-            class="action"
+          <Button
+            secondary
+            quiet
+            size="S"
             on:click={() => dispatch("resetFilters")}
           >
             Reset filter
-          </button>
+          </Button>
         {/if}
       </div>
     {:else}
@@ -173,7 +180,7 @@
 
 <style>
   .empty {
-    padding: var(--spacing-l);
+    padding: var(--spacing-xl) var(--spacing-l);
     display: flex;
     flex-direction: column;
     gap: var(--spacing-s);
@@ -185,23 +192,7 @@
   .actions {
     display: flex;
     gap: var(--spacing-s);
-  }
-
-  .action {
-    border: 1px solid var(--spectrum-global-color-gray-300);
-    background: transparent;
-    border-radius: 6px;
-    padding: 6px 10px;
-    cursor: pointer;
-    color: var(--spectrum-global-color-gray-800);
-    transition:
-      background 130ms ease-out,
-      border-color 130ms ease-out;
-  }
-
-  .action:hover {
-    background: var(--spectrum-global-color-gray-100);
-    border-color: var(--spectrum-global-color-gray-400);
+    flex-wrap: wrap;
   }
 
   .welcome {

--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeTable.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/HomeTable.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte"
-  import { Body, Icon } from "@budibase/bbui"
+  import { AbsTooltip, Body, Helpers, Icon } from "@budibase/bbui"
   import dayjs from "dayjs"
   import relativeTime from "dayjs/plugin/relativeTime"
   import FavouriteResourceButton from "@/pages/builder/_components/FavouriteResourceButton.svelte"
@@ -21,11 +21,14 @@
   export let allRowsCount = 0
   export let typeFilter: HomeType = "all"
   export let searchTerm = ""
+  export let projectsEnabled = false
+  export let selectedProjectName = ""
   export let sortColumn: HomeSortColumn
   export let sortOrder: HomeSortOrder
 
   const dispatch = createEventDispatcher<{
     openRow: HomeRow
+    create: void
     clearSearch: void
     resetFilters: void
     sortChange: HomeSortColumn
@@ -185,9 +188,23 @@
                 weight="fill"
               />
             </div>
-            <Body size="S" color="var(--spectrum-global-color-gray-900)"
-              >{row.name}</Body
-            >
+            <div class="name-content">
+              <div class="name-line">
+                <Body size="S" color="var(--spectrum-global-color-gray-900)"
+                  >{row.name}</Body
+                >
+                {#if projectsEnabled && row.projectName}
+                  <span
+                    class="project-chip"
+                    style={`--project-color: ${row.projectColor || "#8CA171"}`}
+                    title={row.projectName}
+                  >
+                    <span class="project-chip__dot"></span>
+                    <span class="project-chip__name">{row.projectName}</span>
+                  </span>
+                {/if}
+              </div>
+            </div>
           </div>
 
           <div class="cell">
@@ -203,13 +220,17 @@
           </div>
 
           <div class="cell">
-            <Body size="S" color="var(--spectrum-global-color-gray-700)">
-              {#if row.updatedAt}
-                {dayjs(row.updatedAt).fromNow()}
-              {:else}
+            {#if row.updatedAt}
+              <AbsTooltip text={Helpers.getDateDisplayValue(row.updatedAt)}>
+                <Body size="S" color="var(--spectrum-global-color-gray-700)">
+                  {dayjs(row.updatedAt).fromNow()}
+                </Body>
+              </AbsTooltip>
+            {:else}
+              <Body size="S" color="var(--spectrum-global-color-gray-700)">
                 -
-              {/if}
-            </Body>
+              </Body>
+            {/if}
           </div>
 
           <div class="cell actions">
@@ -236,6 +257,8 @@
             {searchTerm}
             {allRowsCount}
             filteredRowsCount={rows.length}
+            {selectedProjectName}
+            on:create={() => dispatch("create")}
             on:clearSearch={() => dispatch("clearSearch")}
             on:resetFilters={() => dispatch("resetFilters")}
             on:createAgent={() => dispatch("createAgent")}
@@ -261,7 +284,7 @@
 
   .table {
     --border: 1px solid var(--spectrum-global-color-gray-200);
-    border-radius: 6px;
+    border-radius: var(--border-radius-s);
     overflow: hidden;
     background: transparent;
     min-width: 700px;
@@ -275,6 +298,47 @@
     align-items: center;
   }
 
+  .name-content {
+    display: flex;
+    min-width: 0;
+  }
+
+  .name-line {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s);
+    min-width: 0;
+    flex-wrap: wrap;
+  }
+
+  .project-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    border-radius: 999px;
+    border: 1px solid var(--spectrum-global-color-gray-200);
+    padding: 2px var(--spacing-s);
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--spectrum-global-color-gray-800);
+    background: var(--spectrum-global-color-gray-75);
+    max-width: 180px;
+  }
+
+  .project-chip__name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .project-chip__dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 999px;
+    background: var(--project-color);
+    flex-shrink: 0;
+  }
+
   @media (max-width: 1200px) {
     .table-header,
     .row {
@@ -283,8 +347,8 @@
   }
 
   .table-header {
-    padding: 12px 12px;
-    font-size: 14px;
+    padding: 12px;
+    font-size: var(--font-size-s);
     color: var(--spectrum-global-color-gray-700);
     background: transparent;
   }
@@ -299,6 +363,7 @@
     background: transparent;
     color: inherit;
     font-family: var(--font-sans);
+    font-size: inherit;
     text-align: left;
     cursor: pointer;
   }
@@ -336,7 +401,7 @@
     padding: 9px 12px;
     text-align: left;
     border: none;
-    border-bottom: 0.5px solid var(--spectrum-global-color-gray-200);
+    border-bottom: 1px solid var(--spectrum-global-color-gray-200);
     background: var(--background-alt);
     transition: background 130ms ease-out;
     cursor: pointer;
@@ -380,10 +445,14 @@
     gap: var(--spacing-m);
   }
 
+  .name-line :global(.spectrum-Body) {
+    min-width: 0;
+  }
+
   .icon-wrapper {
     width: 24px;
     height: 24px;
-    border-radius: 4px;
+    border-radius: var(--border-radius-s);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -394,7 +463,7 @@
     justify-content: flex-end;
     display: flex;
     align-items: center;
-    gap: calc(var(--spacing-xs) + 12px);
+    gap: var(--spacing-m);
   }
 
   .actions > * {
@@ -419,7 +488,7 @@
   }
 
   .empty {
-    padding: 20px 0;
+    padding: var(--spacing-l) 0;
   }
 
   @media (max-width: 900px) {

--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/ImportProjectModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/ImportProjectModal.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import {
+    Body,
+    Dropzone,
+    Input,
+    Layout,
+    ModalContent,
+    Toggle,
+  } from "@budibase/bbui"
+  import type { UIFile } from "@budibase/types"
+
+  interface ConfirmPayload {
+    file: File
+    encryptPassword?: string
+  }
+
+  export let onConfirm: (_payload: ConfirmPayload) => unknown = () => {}
+
+  let encrypted = false
+  let manualEncrypted = false
+  let encryptPassword = ""
+  let file: File | undefined = undefined
+  let disabled = false
+
+  $: encrypted = manualEncrypted || !!file?.name?.endsWith(".enc.tar.gz")
+  $: disabled = !file || (encrypted && !encryptPassword.trim())
+
+  $: if (!encrypted && encryptPassword) {
+    encryptPassword = ""
+  }
+
+  const handleFileChange = (event: CustomEvent<Array<UIFile | File>>) => {
+    const nextFile = event.detail?.[0]
+    file = nextFile instanceof File ? nextFile : undefined
+    manualEncrypted = false
+  }
+</script>
+
+<ModalContent
+  title="Import project"
+  confirmText="Import"
+  size="M"
+  bind:disabled
+  onConfirm={() =>
+    file &&
+    onConfirm({
+      file,
+      encryptPassword: encrypted ? encryptPassword.trim() : undefined,
+    })}
+>
+  <Body size="S">
+    Importing a Project adds a new Project and its supported resource
+    definitions to this workspace without replacing existing apps or
+    automations.
+  </Body>
+
+  <Layout noPadding gap="S">
+    <Dropzone
+      gallery={false}
+      label="Project export"
+      on:change={handleFileChange}
+    />
+    <Toggle
+      text="Encrypted"
+      bind:value={manualEncrypted}
+      disabled={!!file?.name?.endsWith(".enc.tar.gz")}
+    />
+    {#if encrypted}
+      <Input
+        type="password"
+        label="Password"
+        placeholder="Type here..."
+        autocomplete="new-password"
+        bind:value={encryptPassword}
+      />
+    {/if}
+  </Layout>
+</ModalContent>

--- a/packages/builder/src/pages/builder/workspace/[application]/home/_components/rows.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/_components/rows.ts
@@ -184,6 +184,7 @@ export const buildHomeRows = ({
       id,
       name: app.name,
       type: "app",
+      projectId: app.projectId,
       status: app.publishStatus.state,
       updatedAt: app.updatedAt,
       createdAt: app.createdAt ? String(app.createdAt) : undefined,
@@ -201,6 +202,7 @@ export const buildHomeRows = ({
       id,
       name: automation.name,
       type: "automation",
+      projectId: automation.projectId,
       status: automation.publishStatus.state,
       updatedAt: automation.updatedAt,
       createdAt: automation.createdAt
@@ -220,6 +222,7 @@ export const buildHomeRows = ({
       id,
       name: agent.name,
       type: "agent",
+      projectId: agent.projectId,
       live: agent.live === true,
       updatedAt: agent.updatedAt,
       createdAt: agent.createdAt ? String(agent.createdAt) : undefined,

--- a/packages/builder/src/pages/builder/workspace/[application]/home/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/home/index.svelte
@@ -6,9 +6,13 @@
   import AgentModal from "@/pages/builder/workspace/[application]/agent/AgentModal.svelte"
   import CreateAutomationModal from "@/components/automation/AutomationPanel/CreateAutomationModal.svelte"
   import CreateWebhookModal from "@/components/automation/Shared/CreateWebhookModal.svelte"
+  import AssignProjectModal from "./_components/AssignProjectModal.svelte"
+  import CreateProjectModal from "./_components/CreateProjectModal.svelte"
+  import ExportProjectModal from "./_components/ExportProjectModal.svelte"
   import HomeControls from "./_components/HomeControls.svelte"
   import HomeMetrics from "./_components/HomeMetrics.svelte"
   import HomeTable from "./_components/HomeTable.svelte"
+  import ImportProjectModal from "./_components/ImportProjectModal.svelte"
   import {
     appStore,
     automationStore,
@@ -17,8 +21,16 @@
     workspaceFavouriteStore,
   } from "@/stores/builder"
   import { API } from "@/api"
-  import { agentsStore, appsStore, auth, licensing } from "@/stores/portal"
+  import {
+    agentsStore,
+    appsStore,
+    auth,
+    featureFlags,
+    licensing,
+    projectsStore,
+  } from "@/stores/portal"
   import EnterpriseBasicTrialBanner from "@/components/portal/licensing/EnterpriseBasicTrialBanner.svelte"
+  import { getErrorMessage } from "@/helpers/errors"
   import { buildLiveUrl } from "@/helpers/urls"
   import {
     ActionMenu,
@@ -30,11 +42,14 @@
     Modal,
     type ModalAPI,
     Notification,
+    keepOpen,
     notifications,
     PopoverAlignment,
+    Select,
     Tag,
   } from "@budibase/bbui"
   import {
+    FeatureFlag,
     type GetWorkspaceHomeMetricsResponse,
     type UIAutomation,
     type UIWorkspaceApp,
@@ -42,6 +57,7 @@
     type HomeSortColumn,
     type HomeSortOrder,
     type HomeType,
+    type ProjectResponse,
     PublishResourceState,
     type Agent,
     type Table,
@@ -85,8 +101,18 @@
   let selectedAgent: Agent | undefined
   let updateAgentModal: Pick<ModalAPI, "show" | "hide">
   let confirmDeleteAgentDialog: Pick<ModalAPI, "show" | "hide">
+  let selectedRow: HomeRow | null = null
+
+  let createProjectModal: ModalAPI
+  let assignProjectModal: ModalAPI
+  let exportProjectModal: ModalAPI
+  let importProjectModal: ModalAPI
+  let createProjectModalKey = 0
+  let exportProjectModalKey = 0
+  let importProjectModalKey = 0
 
   let typeFilter: HomeType = "all"
+  let selectedProjectId = ""
   let searchTerm = ""
   let metrics: GetWorkspaceHomeMetricsResponse | null = null
 
@@ -99,6 +125,8 @@
 
   const favourites = workspaceFavouriteStore.lookup
   $: currentUserId = $auth.user?._id || ""
+  $: projectsEnabled = $featureFlags[FeatureFlag.PROJECTS]
+  $: if (!projectsEnabled && selectedProjectId) selectedProjectId = ""
 
   let getFavourite: (
     _resourceType: WorkspaceResource,
@@ -160,6 +188,7 @@
       return {
         q: "",
         type: null as HomeType | null,
+        project: "",
         sort: null as HomeSortColumn | null,
         order: null as HomeSortOrder | null,
       }
@@ -167,9 +196,10 @@
     const params = new URLSearchParams(window.location.search)
     const q = params.get("q") ?? ""
     const type = normaliseType(params.get("type"))
+    const project = params.get("project") ?? ""
     const sort = normaliseSortColumn(params.get("sort"))
     const order = normaliseSortOrder(params.get("order"))
-    return { q, type, sort, order }
+    return { q, type, project, sort, order }
   }
 
   const writeUrlState = () => {
@@ -191,6 +221,12 @@
       params.delete("type")
     } else {
       params.set("type", typeFilter)
+    }
+
+    if (!projectsEnabled || !selectedProjectId) {
+      params.delete("project")
+    } else {
+      params.set("project", selectedProjectId)
     }
 
     const defaultSortColumn: HomeSortColumn = "updated"
@@ -218,6 +254,19 @@
     typeFilter = normalised
   }
 
+  const openPrimaryCreate = () => {
+    switch (typeFilter) {
+      case "automation":
+        return createAutomation()
+      case "agent":
+        return createAgent()
+      case "app":
+      case "all":
+      default:
+        return createApp()
+    }
+  }
+
   const setSort = (column: HomeSortColumn) => {
     if (sortColumn === column) {
       sortOrder = sortOrder === "asc" ? "desc" : "asc"
@@ -238,6 +287,21 @@
 
   const createAgent = () => {
     agentModal?.show()
+  }
+
+  const createProject = () => {
+    createProjectModalKey += 1
+    createProjectModal?.show()
+  }
+
+  const exportProject = () => {
+    exportProjectModalKey += 1
+    exportProjectModal?.show()
+  }
+
+  const importProject = () => {
+    importProjectModalKey += 1
+    importProjectModal?.show()
   }
 
   const goToCreate = (target: "data/new" | "apis/new") => {
@@ -300,10 +364,11 @@
       notifications.success(
         `App '${selectedWorkspaceApp.name}' deleted successfully`
       )
-    } catch (e: any) {
+    } catch (error) {
       let message = "Error deleting app"
-      if (e.message) {
-        message += ` - ${e.message}`
+      const errorMessage = getErrorMessage(error)
+      if (errorMessage) {
+        message += ` - ${errorMessage}`
       }
       notifications.error(message)
     }
@@ -350,6 +415,109 @@
     }
   }
 
+  const assignProject = async (projectId: string | undefined) => {
+    if (!projectsEnabled || !selectedRow) {
+      return keepOpen
+    }
+
+    try {
+      if (selectedRow.type === "app") {
+        await workspaceAppStore.edit({
+          ...selectedRow.resource,
+          projectId,
+        })
+      } else if (selectedRow.type === "automation") {
+        await automationStore.actions.save({
+          ...selectedRow.resource,
+          projectId,
+        })
+      } else if (selectedRow.type === "agent") {
+        await agentsStore.updateAgent({
+          ...selectedRow.resource,
+          projectId,
+        })
+      }
+
+      notifications.success("Project updated successfully")
+      assignProjectModal?.hide()
+    } catch (error) {
+      console.error(error)
+      notifications.error("Unable to update project")
+      return keepOpen
+    }
+  }
+
+  const handleCreateProject = async (
+    project: Pick<ProjectResponse, "name" | "description" | "color">
+  ) => {
+    try {
+      await projectsStore.create(project)
+      notifications.success("Project created successfully")
+      createProjectModal?.hide()
+    } catch (error) {
+      console.error(error)
+      notifications.error("Unable to create project")
+      return keepOpen
+    }
+  }
+
+  const handleExportProject = async ({
+    id,
+    encryptPassword,
+  }: {
+    id: string
+    encryptPassword?: string
+  }) => {
+    try {
+      await projectsStore.exportProject(id, { encryptPassword })
+      exportProjectModal?.hide()
+    } catch (error) {
+      console.error(error)
+      notifications.error(getErrorMessage(error) || "Unable to export project")
+      return keepOpen
+    }
+  }
+
+  const notifyImportFollowUps = (
+    response: Awaited<ReturnType<typeof projectsStore.importProject>>
+  ) => {
+    if (response.requirements.length) {
+      const names = response.requirements
+        .map(requirement => requirement.name)
+        .join(", ")
+      notifications.warning(`Some imported resources need secrets: ${names}`)
+    }
+
+    if (response.unsupportedContent.length) {
+      const summary = response.unsupportedContent
+        .map(item => `${item.count} ${item.type}`)
+        .join(", ")
+      notifications.warning(`Some Project content was not imported: ${summary}`)
+    }
+  }
+
+  const handleImportProject = async ({
+    file,
+    encryptPassword,
+  }: {
+    file: File
+    encryptPassword?: string
+  }) => {
+    try {
+      const response = await projectsStore.importProject(file, {
+        encryptPassword,
+      })
+      await Promise.all([appStore.refresh(), loadMetrics()])
+      importProjectModal?.hide()
+      notifications.success(`Imported project '${response.project.name}'`)
+      notifyImportFollowUps(response)
+    } catch (error) {
+      console.error(error)
+      notifications.error(getErrorMessage(error) || "Unable to import project")
+      return keepOpen
+    }
+  }
+
   const getContextMenuItemsForRow = (row: HomeRow) => {
     if (row.type === "app") {
       const workspaceApp = row.resource
@@ -376,6 +544,12 @@
             selectedWorkspaceApp = workspaceApp
             workspaceAppModal.show()
           },
+        },
+        {
+          icon: "stack",
+          name: "Assign project",
+          visible: projectsEnabled,
+          callback: () => assignProjectModal.show(),
         },
         {
           icon: "globe-simple",
@@ -426,6 +600,12 @@
       return [
         edit,
         {
+          icon: "stack",
+          name: "Assign project",
+          visible: projectsEnabled,
+          callback: () => assignProjectModal.show(),
+        },
+        {
           icon: "copy",
           name: "Duplicate",
           visible: true,
@@ -453,6 +633,12 @@
           name: "Edit",
           visible: true,
           callback: () => updateAgentModal.show(),
+        },
+        {
+          icon: "stack",
+          name: "Assign project",
+          visible: projectsEnabled,
+          callback: () => assignProjectModal.show(),
         },
         {
           icon: "copy",
@@ -485,6 +671,7 @@
     selectedWorkspaceApp = undefined
     selectedAutomation = undefined
     selectedAgent = undefined
+    selectedRow = row
 
     highlightedRowId = row._id
 
@@ -537,9 +724,55 @@
     getFavourite,
   })
 
-  $: allRows = sortHomeRows(baseRows, { sortColumn, sortOrder })
+  $: projectLookup = (
+    projectsEnabled
+      ? Object.fromEntries(
+          $projectsStore.map(project => [project._id, project])
+        )
+      : {}
+  ) as Record<string, ProjectResponse>
+  $: selectedProjectName = selectedProjectId
+    ? projectLookup[selectedProjectId]?.name || ""
+    : ""
+  $: if (
+    projectsEnabled &&
+    selectedProjectId &&
+    projectsStore.hasFetched() &&
+    !projectLookup[selectedProjectId]
+  ) {
+    selectedProjectId = ""
+  }
 
-  $: filteredRows = filterHomeRows({ rows: allRows, typeFilter, searchTerm })
+  $: projectOptions = [
+    { label: "All", value: "", color: undefined },
+    ...($projectsStore || []).map(project => ({
+      label: project.name,
+      value: project._id,
+      color: project.color,
+    })),
+  ]
+
+  $: rowsWithProjects = baseRows.map(row => {
+    const project = row.projectId ? projectLookup[row.projectId] : undefined
+    return {
+      ...row,
+      projectName: project?.name,
+      projectColor: project?.color,
+    }
+  })
+
+  $: allRows = sortHomeRows(rowsWithProjects, { sortColumn, sortOrder })
+
+  $: filteredRows = filterHomeRows({
+    rows: allRows,
+    typeFilter,
+    searchTerm,
+  }).filter(
+    row =>
+      !projectsEnabled ||
+      !selectedProjectId ||
+      row.projectId === selectedProjectId
+  )
   $: targetApp = $appsStore.apps.find(app => app.devId === $appStore.appId)
   $: automationErrorEntries = Object.entries(targetApp?.automationErrors || {})
     .filter(([, logIds]) => logIds.length > 0)
@@ -590,12 +823,15 @@
       return
     }
 
-    const { q, type, sort, order } = readUrlState()
+    const { q, type, project, sort, order } = readUrlState()
     if (q) {
       searchTerm = q
     }
     if (type) {
       typeFilter = type
+    }
+    if (project) {
+      selectedProjectId = project
     }
     if (sort) {
       sortColumn = sort
@@ -607,7 +843,11 @@
     hasMounted = true
     writeUrlState()
 
-    await Promise.all([agentsStore.fetchAgents(), loadMetrics()])
+    await Promise.all([
+      agentsStore.fetchAgents(),
+      projectsEnabled ? projectsStore.fetch() : Promise.resolve(),
+      loadMetrics(),
+    ])
   })
 </script>
 
@@ -658,6 +898,18 @@
         on:typeChange={({ detail }) => setTypeFilter(detail)}
       />
       <div class="controls-right">
+        {#if projectsEnabled && $projectsStore.length}
+          <div class="project-filter">
+            <Select
+              placeholder="Project"
+              bind:value={selectedProjectId}
+              options={projectOptions}
+              getOptionLabel={option => option.label}
+              getOptionValue={option => option.value}
+              getOptionColour={option => option.color}
+            />
+          </div>
+        {/if}
         <div class="search-wrapper">
           <Icon name="magnifying-glass" size="S" />
           <input
@@ -705,6 +957,21 @@
             App
           </MenuItem>
 
+          {#if projectsEnabled}
+            <MenuSeparator />
+            <MenuItem icon="stack" on:click={createProject}>Project</MenuItem>
+            <MenuItem icon="upload-simple" on:click={importProject}>
+              Import project
+            </MenuItem>
+            <MenuItem
+              icon="download-simple"
+              on:click={exportProject}
+              disabled={!$projectsStore.length}
+            >
+              Export project
+            </MenuItem>
+          {/if}
+
           <MenuSeparator />
           <MenuItem icon="cube" on:click={() => goToCreate("data/new")}>
             Connection
@@ -722,13 +989,19 @@
       allRowsCount={allRows.length}
       {typeFilter}
       {searchTerm}
+      {projectsEnabled}
+      {selectedProjectName}
       {sortColumn}
       {sortOrder}
       {highlightedRowId}
+      on:create={() => openPrimaryCreate()}
       on:openRow={({ detail }) => openRow(detail)}
       on:openContextMenu={({ detail }) => openHomeContextMenu(detail)}
       on:clearSearch={() => (searchTerm = "")}
-      on:resetFilters={() => (typeFilter = "all")}
+      on:resetFilters={() => {
+        typeFilter = "all"
+        selectedProjectId = ""
+      }}
       on:sortChange={({ detail }) => setSort(detail)}
       on:createAgent={createAgent}
       on:createAutomation={createAutomation}
@@ -736,6 +1009,38 @@
     />
   </div>
 </div>
+
+{#if projectsEnabled}
+  <Modal bind:this={createProjectModal}>
+    {#key createProjectModalKey}
+      <CreateProjectModal onConfirm={handleCreateProject} />
+    {/key}
+  </Modal>
+
+  <Modal bind:this={assignProjectModal}>
+    <AssignProjectModal
+      row={selectedRow}
+      projects={$projectsStore}
+      onConfirm={assignProject}
+    />
+  </Modal>
+
+  <Modal bind:this={exportProjectModal}>
+    {#key exportProjectModalKey}
+      <ExportProjectModal
+        projects={$projectsStore}
+        {selectedProjectId}
+        onConfirm={handleExportProject}
+      />
+    {/key}
+  </Modal>
+
+  <Modal bind:this={importProjectModal}>
+    {#key importProjectModalKey}
+      <ImportProjectModal onConfirm={handleImportProject} />
+    {/key}
+  </Modal>
+{/if}
 
 <WorkspaceAppModal
   bind:this={workspaceAppModal}
@@ -856,15 +1161,23 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: var(--spacing-m);
+    gap: var(--spacing-m) var(--spacing-l);
+    flex-wrap: wrap;
     position: relative;
-    margin-bottom: -12px;
   }
 
   .controls-row .controls-right {
     display: flex;
     align-items: center;
     gap: var(--spacing-m);
+    margin-left: auto;
+    flex-shrink: 0;
+    justify-content: flex-end;
+  }
+
+  .controls-row .project-filter {
+    flex: 0 0 auto;
+    width: 140px;
   }
 
   .controls-row .search-wrapper {
@@ -872,11 +1185,13 @@
     align-items: center;
     gap: var(--spacing-s);
     border: 1px solid var(--spectrum-global-color-gray-300);
-    border-radius: 6px;
-    padding: 3px 8px;
-    min-width: 200px;
+    border-radius: var(--border-radius-s);
+    padding: var(--spacing-xs) var(--spacing-s);
+    min-width: 140px;
     height: 32px;
     box-sizing: border-box;
+    flex: 1 1 160px;
+    max-width: 240px;
   }
 
   .controls-row .search-input {
@@ -885,7 +1200,7 @@
     outline: none;
     flex: 1;
     font-family: var(--font-sans);
-    font-size: 14px;
+    font-size: var(--font-size-s);
     color: var(--spectrum-global-color-gray-900);
   }
 
@@ -893,25 +1208,49 @@
     color: var(--spectrum-global-color-gray-600);
   }
 
-  .controls-row .create-menu-control :global(button) {
-    border-radius: 100px;
-    padding: 7px 15px 8px;
-    height: 32px;
-    box-sizing: border-box;
-  }
-
   .create-popover-container {
     position: absolute;
   }
 
   .create-popover-container :global(.spectrum-Popover) {
-    min-width: 245px;
-    border-radius: 6px !important;
-    background: var(--background) !important;
-    border: 1px solid var(--spectrum-global-color-gray-200) !important;
-    padding: 4px !important;
-    margin-top: 4px;
-    margin-left: 2px;
+    min-width: 240px;
+    border-radius: var(--border-radius-s);
+    background: var(--background);
+    border: 1px solid var(--spectrum-global-color-gray-200);
+    padding: var(--spacing-xs);
+    margin-top: var(--spacing-xs);
+  }
+
+  @media (max-width: 1080px) {
+    .controls-row .controls-right {
+      width: 100%;
+      margin-left: 0;
+      flex-shrink: 1;
+      justify-content: flex-end;
+    }
+
+    .controls-row .search-wrapper {
+      max-width: none;
+    }
+  }
+
+  @media (max-width: 720px) {
+    .controls-row .controls-right {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .controls-row .search-wrapper {
+      width: 100%;
+    }
+
+    .controls-row .create-menu-control {
+      width: 100%;
+    }
+
+    .controls-row .create-menu-control :global(button) {
+      width: 100%;
+    }
   }
 
   .create-popover-container :global(.spectrum-Menu) {
@@ -920,7 +1259,7 @@
   }
 
   .create-popover-container :global(.spectrum-Menu-item) {
-    border-radius: 4px;
+    border-radius: var(--border-radius-s);
     margin: 0;
   }
 
@@ -931,13 +1270,12 @@
   .create-popover-container
     :global(.spectrum-Menu-item)
     :global(.spectrum-Menu-itemLabel) {
-    font-size: 13px;
-    line-height: 17px;
+    font-size: var(--font-size-s);
     color: var(--spectrum-global-color-gray-800);
   }
 
   .create-popover-container :global(.spectrum-Menu-divider) {
-    margin: 4px 0;
+    margin: var(--spacing-xs) 0;
     background: var(--spectrum-global-color-gray-200);
   }
 </style>

--- a/packages/builder/src/test/mocks/MockColorPicker.svelte
+++ b/packages/builder/src/test/mocks/MockColorPicker.svelte
@@ -1,9 +1,21 @@
 <script lang="ts">
-  export let value = ""
+  import { createEventDispatcher } from "svelte"
+
+  export let value: string | undefined = ""
   export let disabled = false
+
+  const dispatch = createEventDispatcher<{
+    change: string | undefined
+  }>()
+
+  const clear = () => {
+    value = undefined
+    dispatch("change", value)
+  }
 </script>
 
 <label>
   <span>Color</span>
   <input aria-label="Color" bind:value {disabled} />
 </label>
+<button type="button" on:click={clear} {disabled}>Clear color</button>

--- a/packages/types/src/ui/home/types.ts
+++ b/packages/types/src/ui/home/types.ts
@@ -14,6 +14,9 @@ interface HomeRowBase {
   id: string
   name: string
   type: HomeRowType
+  projectId?: string
+  projectName?: string
+  projectColor?: string
   updatedAt?: string
   createdAt?: string
   favourite: WorkspaceFavourite


### PR DESCRIPTION
## description
adds the workspace home projects experience, including create, assign, import, export, filtering, row chips, and final terminology cleanup.

## addresses
- n/a

## app export
- n/a

## screenshots
to be added if required for review.

## launchcontrol
adds workspace home controls for creating, assigning, filtering, importing, and exporting projects.