### PR TITLE
fix: show visual indicator in color orb when CSS variable is used

### DIFF
--- a/packages/bbui/src/ColorPicker/ColorPicker.svelte
+++ b/packages/bbui/src/ColorPicker/ColorPicker.svelte
@@ -26,8 +26,65 @@
   $: customValue = getCustomValue(value)
   $: checkColor = getCheckColor(value)
   $: themeClasses = getThemeClasses(spectrumTheme)
+  $: isCSSVariable = value?.startsWith("var(--") ?? false
+  $: resolvedCSS = isCSSVariable ? resolveCSSVariable(value) : null
+  $: previewBackground = getPreviewBackground()
 
   const dispatch = createEventDispatcher()
+
+  function getPreviewBackground(): string | null {
+    if (!value) return null
+    if (!isCSSVariable) return value
+    return resolvedCSS
+  }
+
+  function resolveCSSVariable(val: string): string | null {
+    try {
+      // Step 1: Resolve the full expression in the host document.
+      // This handles Spectrum vars, fallbacks (var(--x, #fff)), etc.
+      const temp = document.createElement("div")
+      temp.style.cssText = `background: ${val}; width: 0; height: 0; position: absolute;`
+      document.body.appendChild(temp)
+      const computed = getComputedStyle(temp).backgroundColor
+      document.body.removeChild(temp)
+      if (computed && computed !== "transparent" && computed !== "rgba(0, 0, 0, 0)") {
+        return computed
+      }
+
+      // Step 2: Resolve from preview iframes by variable name
+      const varName = extractVarName(val)
+      if (varName) {
+        for (const iframe of Array.from(document.querySelectorAll("iframe"))) {
+          const iframeDoc = iframe.contentWindow?.document
+          if (!iframeDoc?.body) continue
+          const resolved = resolveVarInDocument(varName, iframeDoc)
+          if (resolved) return resolved
+        }
+      }
+    } catch {}
+    return null
+  }
+
+  function extractVarName(val: string): string | null {
+    const match = val.match(/var\((--[^,)]+)/)
+    return match?.[1] ?? null
+  }
+
+  function resolveVarInDocument(varName: string, doc: Document): string | null {
+    const rootVal = doc.defaultView
+      ?.getComputedStyle(doc.documentElement)
+      .getPropertyValue(varName)
+      .trim()
+    if (rootVal) return rootVal
+    const probe = doc.createElement("div")
+    const sentinel = "rgb(1, 2, 3)"
+    probe.style.color = `var(${varName}, ${sentinel})`
+    probe.style.display = "none"
+    doc.body.appendChild(probe)
+    const resolved = doc.defaultView?.getComputedStyle(probe).color
+    probe.remove()
+    return resolved && resolved !== sentinel ? resolved : null
+  }
   const categories = [
     {
       label: "Theme colors",
@@ -194,8 +251,10 @@
 >
   <div
     class="fill {themeClasses}"
-    style={value ? `background: ${value};` : ""}
+    style={previewBackground ? `background: ${previewBackground};` : ""}
     class:placeholder={!value}
+    class:css-variable={isCSSVariable && !resolvedCSS}
+    title={value ?? ""}
   ></div>
 </div>
 
@@ -299,6 +358,22 @@
         #eee 75%,
         #eee 100%
       );
+  }
+  .fill.css-variable {
+    background:
+      repeating-linear-gradient(
+        -45deg,
+        transparent,
+        transparent 4px,
+        rgba(128, 96, 192, 0.08) 4px,
+        rgba(128, 96, 192, 0.08) 8px
+      ),
+      linear-gradient(
+        135deg,
+        #f3eff7 0%,
+        #ede6f5 100%
+      );
+    box-shadow: inset 0 0 0 1px rgba(128, 96, 192, 0.15);
   }
   .size--S {
     width: 20px;


### PR DESCRIPTION
## Description
When a CSS variable like `var(--myColor)` is set as a color value in the builder design panel, the color orb would appear empty — making it look like no color was applied — even though the CSS variable works correctly at runtime.

The root cause: the orb sets `background: var(--myColor)` directly, but custom CSS variables aren't defined in the builder's CSS scope, so the browser resolves them to `transparent`.

## Addresses
- Closes #18830

## What this PR does
Four changes to the ColorPicker component in the bbui package:

1. **Resolves the full CSS expression in the host document** — Evaluates the value as a CSS `background` property on a temporary element. This resolves Spectrum variables (e.g. `var(--spectrum-global-color-blue-600)`) to their computed color, and also correctly resolves fallback expressions like `var(--myColor, #ff0000)`.

2. **Resolves from preview iframes by variable name** — If the host document can't resolve the variable, searches all iframes (including the app preview) to find where custom CSS variables are defined.

3. **Shows a distinct visual indicator for unresolvable variables** — When a CSS variable truly can't be resolved in any document, the orb shows a subtle purple-tinted gradient pattern instead of looking empty. This communicates "a color is applied but can't be previewed here." The pattern is distinct from both the checkerboard (no color set) and solid fill (color preview).

4. **Adds a title attribute** — Hovering over the orb shows the raw value, so users can see the CSS variable name at a glance.

## How it works
- **Step 1**: Evaluate `background: <value>` on a hidden temp element in the host document. If `getComputedStyle` returns a non-transparent color, use it. This handles all host-resolvable vars, including those with fallback values.
- **Step 2**: Extract the variable name with `/var\((--[^,)]+)/` and search each iframe's document using `getPropertyValue` + a sentinel probe fallback.
- **Fallback**: If both steps fail, the orb shows the indicator pattern and the raw value is visible on hover via the `title` attribute.

## Verification
- Spectrum CSS variables resolve immediately in the host document
- Custom variables defined in the app preview iframe resolve correctly
- Var expressions with fallbacks (e.g. `var(--undefined, #ff0000)`) resolve to the fallback
- Completely undefined variables show the visual indicator
- No-value state unaffected (checkerboard placeholder)

## Launchcontrol
The color orb in the design panel now properly resolves CSS variables from both the host and preview iframes, correctly handles fallback expressions, and shows a visual indicator when resolution isn't possible.
