### PR TITLE
Change vulnerability reporting method to GitHub

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,10 +6,4 @@ As an open source product, we will only patch the latest major version for secur
 
 ## Disclosing
 
-You can get in touch with us regarding a vulnerability via email at community@budibase.com.
-
-You can also disclose via huntr.dev. If you believe you have found a vulnerability, please disclose it on huntr and let us know.
-
-https://huntr.dev/bounties/disclose
-
-This will enable us to review the vulnerability and potentially reward you for your work.
+Please report vulnerabilities via GitHub: https://github.com/Budibase/budibase/security/advisories/new


### PR DESCRIPTION
Directing folks to:  https://github.com/Budibase/budibase/security/advisories/new