### PR TITLE
Fix: tenant de-activation modal cannot be closed

### DIFF
--- a/packages/builder/src/components/portal/licensing/AccountLockedModal.svelte
+++ b/packages/builder/src/components/portal/licensing/AccountLockedModal.svelte
@@ -16,12 +16,12 @@
   }
 </script>
 
-<Modal bind:this={modal} on:hide={modal}>
+<Modal bind:this={modal}>
   <ModalContent
-    title="Your account is currently de-activated"
+    title="Your tenant is currently de-activated"
     size="S"
-    showCancelButton={true}
-    showCloseIcon={false}
+    showCancelButton={false}
+    showCloseIcon={true}
     confirmText={"View plans"}
     {onConfirm}
   >
@@ -31,8 +31,8 @@
         for cloud users. Your tenant has been temporarily locked. Please upgrade
         to a paid plan to keep your data — otherwise it will be removed soon.
       {:else}
-        Due to the Free plan user limit being exceeded, your account has been
-        de-activated. Upgrade your plan to re-activate your account.
+        Due to the Free plan user limit being exceeded, your tenant has been
+        de-activated. Upgrade your plan to re-activate your tenant.
       {/if}
     </Body>
   </ModalContent>


### PR DESCRIPTION
## Addresses

https://github.com/Budibase/budibase/issues/18954

## Description

The tenant de-activation modal could not be dismissed, permanently blocking the UI and preventing users from accessing functionality that should remain available while locked (e.g. exporting a workspace).

**Root cause:** `on:hide={modal}` in `AccountLockedModal.svelte` passed a component instance object as an event handler. When Svelte fired the `hide` event, it attempted to call the object as a function, throwing a `TypeError` that aborted the DOM update cycle before `{#if visible}` could remove the modal.

## Changes

- Removed the erroneous `on:hide={modal}` handler from `AccountLockedModal`
- Replaced the redundant "Cancel" button with a standard close icon (X), since clicking outside and Escape already dismiss the modal
- Updated modal title and body copy to use "tenant" consistently instead of "account"

## Screen recording

https://github.com/user-attachments/assets/27692f1f-bc7b-40ff-ac2e-ab09ccbf89f9


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug that kept the tenant de-activation modal from closing, blocking the UI and actions like workspace export. The modal now closes via X, outside click, and Escape. Fixes #18954.

- **Bug Fixes**
  - Removed invalid `on:hide={modal}` handler in `AccountLockedModal.svelte` to prevent a `TypeError`.
  - Replaced the Cancel button with a standard close icon.
  - Updated modal title and body to use “tenant” consistently.

<sup>Written for commit 3b8735bf4fdd0d2dfd9f782f05a3721369fc0aaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/18955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



