### PR TITLE
Fix: builder Actions menu crash on on-click, on-change and on-screen-load

### DIFF
--- a/packages/builder/src/dataBinding.ts
+++ b/packages/builder/src/dataBinding.ts
@@ -1858,7 +1858,7 @@ const bindingReplacement = (
   convertTo: BindingKey
 ): string => {
   if (typeof textWithBindings !== "string") {
-    return textWithBindings == null ? "" : `${textWithBindings}`
+    return textWithBindings as unknown as string
   }
   let bindingText = textWithBindings
   // Decide from base64 if using JS


### PR DESCRIPTION
## Description

Opening the Actions drawer for any event handler (on-click, on-change, on-screen-load) crashed the builder with:

```
TypeError: fpExports.cloneDeep(...).filter is not a function
    at ButtonActionDrawer
```

**Root cause:** introduced in ddb9980271 ("Convert builder data binding helpers to TypeScript").

When converting `dataBinding.js` to TypeScript, the early return in `bindingReplacement` for non-string values was changed from a pass-through to a string coercion:

```diff
- return textWithBindings
+ return textWithBindings == null ? "" : `${textWithBindings}`
```

`PropertyControl.svelte` calls `runtimeToReadableBinding(bindings, value)` where `value` is the raw actions array for event-type settings. The coercion turned that array into the string `"[object Object],[object Object]"`, which was then passed down to `ButtonActionDrawer` as its `actions` prop.

`ButtonActionDrawer` calls `cloneDeep(actions).filter(...)` on initialisation. With a string as `actions`, `cloneDeep` returns a string, and strings have no `.filter` method — hence the TypeError.

**Fix:** restore the original pass-through behaviour with `return textWithBindings as unknown as string`. The null/undefined case is correctly handled by callers — for example `PropertyControl` already checks `enriched == null` and falls back to `defaultValue` — so returning them unchanged matches the original JS semantics and requires no changes at any call site.

## Addresses
- Crash when opening Actions menu for on-click, on-change or on-screen-load event handlers in the builder

## Launchcontrol

Fixes a builder crash introduced by the TypeScript migration of `dataBinding.js`. Opening any Actions drawer (on-click, on-change, on-screen-load) previously threw a TypeError and was completely broken.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a builder crash when opening the Actions drawer for on-click, on-change, and on-screen-load. Restores pass-through for non-string values in `bindingReplacement`, preventing array-to-string coercion that triggered a `cloneDeep(...).filter` TypeError.

<sup>Written for commit 9994334504346f505f54b7f4f7d5630aaecd1b74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/18964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

