### PR TITLE
Fix MongoDB binding keys in queries

### DIFF
--- a/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/mongodb.spec.ts
@@ -386,6 +386,42 @@ if (descriptions.length) {
           ])
         })
 
+        it("a find query with a parameterised key", async () => {
+          await withCollection(collection =>
+            collection.insertOne({
+              name: "apartment",
+              accommodates: 9,
+            })
+          )
+
+          const query = await createQuery({
+            fields: {
+              json: `{
+                "{{ field }}": 9
+              }`,
+              extra: {
+                actionType: "find",
+              },
+            },
+            parameters: [
+              {
+                name: "field",
+                default: "accommodates",
+              },
+            ],
+          })
+
+          const result = await config.api.query.execute(query._id!)
+
+          expect(result.data).toEqual([
+            {
+              _id: expectValidId,
+              name: "apartment",
+              accommodates: 9,
+            },
+          ])
+        })
+
         it("does not allow quoted find parameters to inject Mongo operators", async () => {
           const query = await createQuery({
             fields: {
@@ -550,6 +586,50 @@ if (descriptions.length) {
               nested: {
                 enabled: true,
               },
+            })
+          })
+        })
+
+        it("a create query with a parameterised key", async () => {
+          const query = await createQuery({
+            fields: {
+              json: [
+                {
+                  "{{ fieldName }}": "Yellow",
+                },
+              ],
+              extra: {
+                actionType: "insertMany",
+              },
+            },
+            queryVerb: "create",
+            parameters: [
+              {
+                name: "fieldName",
+                default: "defaultField",
+              },
+            ],
+          })
+
+          const result = await config.api.query.execute(query._id!, {
+            parameters: { fieldName: "Banana" },
+          })
+
+          expect(result.data).toEqual([
+            {
+              acknowledged: true,
+              insertedCount: 1,
+              insertedIds: {
+                "0": expectValidId,
+              },
+            },
+          ])
+
+          await withCollection(async collection => {
+            const doc = await collection.findOne({ Banana: { $eq: "Yellow" } })
+            expect(doc).toEqual({
+              _id: expectValidBsonObjectId,
+              Banana: "Yellow",
             })
           })
         })

--- a/packages/server/src/sdk/workspace/queries/queries.spec.ts
+++ b/packages/server/src/sdk/workspace/queries/queries.spec.ts
@@ -25,6 +25,60 @@ describe("queries SDK", () => {
       expect(result).toEqual({ json: false })
     })
 
+    it("enriches object keys recursively", async () => {
+      const result = await enrichContext(
+        {
+          json: {
+            "{{ fieldName }}": "value",
+            nested: {
+              "{{ nestedFieldName }}": "{{ nestedValue }}",
+            },
+          },
+        },
+        {
+          fieldName: "dynamicField",
+          nestedFieldName: "dynamicNestedField",
+          nestedValue: "nested field value",
+        }
+      )
+
+      expect(result).toEqual({
+        json: {
+          dynamicField: "value",
+          nested: {
+            dynamicNestedField: "nested field value",
+          },
+        },
+      })
+    })
+
+    it("enriches parsed JSON template keys", async () => {
+      const result = await enrichContext(
+        {
+          json: `{
+            "{{ fieldName }}": 9,
+            "nested": {
+              "{{ nestedFieldName }}": "{{ nestedValue }}"
+            }
+          }`,
+        },
+        {
+          fieldName: "accommodates",
+          nestedFieldName: "label",
+          nestedValue: "Apartment",
+        }
+      )
+
+      expect(result).toEqual({
+        json: {
+          accommodates: 9,
+          nested: {
+            label: "Apartment",
+          },
+        },
+      })
+    })
+
     it("falls back to requestBody when json is blank", async () => {
       const result = await enrichContext({
         json: "",

--- a/packages/server/src/sdk/workspace/queries/queries.ts
+++ b/packages/server/src/sdk/workspace/queries/queries.ts
@@ -17,6 +17,7 @@ const DEFAULT_ENRICH_CONTEXT_OPTS: Required<EnrichContextOpts> = {
 }
 
 const JSON_TEMPLATE_FIELDS = new Set(["json", "customData", "requestBody"])
+type EnrichableRecord = Record<string, JSONValue | undefined>
 
 const processTemplateString = (
   value: string,
@@ -35,80 +36,65 @@ const enrichJsonTemplate = (
   parameters: object,
   options: Required<EnrichContextOpts>
 ) =>
-  enrichContextSync(
+  enrichJsonValue(
     processJsonStringSync(template, parameters, {
       noEscaping: true,
       noHelpers: true,
       escapeNewlines: options.escapeNewlines,
-    }) as JSONValue | string,
+    }) as JSONValue,
     parameters,
     options
-  ) as JSONValue | string
+  )
 
-const enrichContextSync = (
-  fields: any,
+const enrichJsonValue = (
+  value: JSONValue,
   parameters: object,
   options: Required<EnrichContextOpts>
-): any => {
-  if (!fields || typeof fields !== "object") {
-    return fields
-  }
-  if (Array.isArray(fields)) {
-    return fields.map(field => enrichContextSync(field, parameters, options))
+): JSONValue => {
+  if (Array.isArray(value)) {
+    return value.map(item => enrichJsonValue(item, parameters, options))
   }
 
-  const enrichedQuery: Record<string, any> = {}
-  for (const key of Object.keys(fields)) {
-    if (fields[key] == null) {
+  if (value === null || typeof value !== "object") {
+    return typeof value === "string"
+      ? processTemplateString(value, parameters, options)
+      : value
+  }
+
+  const enrichedQuery: Record<string, JSONValue> = {}
+  for (const key of Object.keys(value)) {
+    const fieldValue = value[key]
+    if (fieldValue == null) {
       continue
     }
     const enrichedKey = processTemplateString(key, parameters, options)
-    if (typeof fields[key] === "object") {
-      enrichedQuery[enrichedKey] = enrichContextSync(
-        fields[key],
-        parameters,
-        options
-      )
-    } else if (typeof fields[key] === "string") {
-      enrichedQuery[enrichedKey] = processTemplateString(
-        fields[key],
-        parameters,
-        options
-      )
-    } else {
-      enrichedQuery[enrichedKey] = fields[key]
-    }
+    enrichedQuery[enrichedKey] = enrichJsonValue(fieldValue, parameters, options)
   }
   return enrichedQuery
 }
 
 const enrichContextObject = async (
-  fields: Record<string, any>,
+  fields: EnrichableRecord,
   parameters: object,
   options: Required<EnrichContextOpts>
-) => {
-  if (Array.isArray(fields)) {
-    return fields.map(field => enrichContextSync(field, parameters, options))
-  }
-
-  const enrichedQuery: Record<string, any> = {}
+): Promise<Record<string, JSONValue>> => {
+  const enrichedQuery: Record<string, JSONValue> = {}
   for (const key of Object.keys(fields)) {
-    if (fields[key] == null) {
+    const fieldValue = fields[key]
+    if (fieldValue == null) {
       continue
     }
     const enrichedKey = processTemplateString(key, parameters, options)
-    if (typeof fields[key] === "object") {
-      enrichedQuery[enrichedKey] = await enrichContextObject(
-        fields[key],
+    if (typeof fieldValue === "string") {
+      enrichedQuery[enrichedKey] = JSON_TEMPLATE_FIELDS.has(enrichedKey)
+        ? enrichJsonTemplate(fieldValue, parameters, options)
+        : processTemplateString(fieldValue, parameters, options)
+    } else {
+      enrichedQuery[enrichedKey] = enrichJsonValue(
+        fieldValue,
         parameters,
         options
       )
-    } else if (typeof fields[key] === "string") {
-      enrichedQuery[enrichedKey] = JSON_TEMPLATE_FIELDS.has(enrichedKey)
-        ? enrichJsonTemplate(fields[key], parameters, options)
-        : processTemplateString(fields[key], parameters, options)
-    } else {
-      enrichedQuery[enrichedKey] = fields[key]
     }
   }
   return enrichedQuery

--- a/packages/server/src/sdk/workspace/queries/queries.ts
+++ b/packages/server/src/sdk/workspace/queries/queries.ts
@@ -68,7 +68,11 @@ const enrichJsonValue = (
       continue
     }
     const enrichedKey = processTemplateString(key, parameters, options)
-    enrichedQuery[enrichedKey] = enrichJsonValue(fieldValue, parameters, options)
+    enrichedQuery[enrichedKey] = enrichJsonValue(
+      fieldValue,
+      parameters,
+      options
+    )
   }
   return enrichedQuery
 }

--- a/packages/server/src/sdk/workspace/queries/queries.ts
+++ b/packages/server/src/sdk/workspace/queries/queries.ts
@@ -35,11 +35,84 @@ const enrichJsonTemplate = (
   parameters: object,
   options: Required<EnrichContextOpts>
 ) =>
-  processJsonStringSync(template, parameters, {
-    noEscaping: true,
-    noHelpers: true,
-    escapeNewlines: options.escapeNewlines,
-  }) as JSONValue | string
+  enrichContextSync(
+    processJsonStringSync(template, parameters, {
+      noEscaping: true,
+      noHelpers: true,
+      escapeNewlines: options.escapeNewlines,
+    }) as JSONValue | string,
+    parameters,
+    options
+  ) as JSONValue | string
+
+const enrichContextSync = (
+  fields: any,
+  parameters: object,
+  options: Required<EnrichContextOpts>
+): any => {
+  if (!fields || typeof fields !== "object") {
+    return fields
+  }
+  if (Array.isArray(fields)) {
+    return fields.map(field => enrichContextSync(field, parameters, options))
+  }
+
+  const enrichedQuery: Record<string, any> = {}
+  for (const key of Object.keys(fields)) {
+    if (fields[key] == null) {
+      continue
+    }
+    const enrichedKey = processTemplateString(key, parameters, options)
+    if (typeof fields[key] === "object") {
+      enrichedQuery[enrichedKey] = enrichContextSync(
+        fields[key],
+        parameters,
+        options
+      )
+    } else if (typeof fields[key] === "string") {
+      enrichedQuery[enrichedKey] = processTemplateString(
+        fields[key],
+        parameters,
+        options
+      )
+    } else {
+      enrichedQuery[enrichedKey] = fields[key]
+    }
+  }
+  return enrichedQuery
+}
+
+const enrichContextObject = async (
+  fields: Record<string, any>,
+  parameters: object,
+  options: Required<EnrichContextOpts>
+) => {
+  if (Array.isArray(fields)) {
+    return fields.map(field => enrichContextSync(field, parameters, options))
+  }
+
+  const enrichedQuery: Record<string, any> = {}
+  for (const key of Object.keys(fields)) {
+    if (fields[key] == null) {
+      continue
+    }
+    const enrichedKey = processTemplateString(key, parameters, options)
+    if (typeof fields[key] === "object") {
+      enrichedQuery[enrichedKey] = await enrichContextObject(
+        fields[key],
+        parameters,
+        options
+      )
+    } else if (typeof fields[key] === "string") {
+      enrichedQuery[enrichedKey] = JSON_TEMPLATE_FIELDS.has(enrichedKey)
+        ? enrichJsonTemplate(fields[key], parameters, options)
+        : processTemplateString(fields[key], parameters, options)
+    } else {
+      enrichedQuery[enrichedKey] = fields[key]
+    }
+  }
+  return enrichedQuery
+}
 
 const isBlankJsonField = (value: any) =>
   typeof value === "string" && value.trim() === ""
@@ -133,31 +206,15 @@ export async function enrichContext(
     ...DEFAULT_ENRICH_CONTEXT_OPTS,
     ...opts,
   }
-  const enrichedQuery: Record<string, any> = {}
   if (!fields || !inputs) {
-    return enrichedQuery
+    return {}
   }
   if (Array.isArray(fields)) {
     return enrichArrayContext(fields, inputs, options)
   }
   const env = await getEnvironmentVariables()
   const parameters = { ...inputs, env }
-  // enrich the fields with dynamic parameters
-  for (let key of Object.keys(fields)) {
-    if (fields[key] == null) {
-      continue
-    }
-    if (typeof fields[key] === "object") {
-      // enrich nested fields object
-      enrichedQuery[key] = await enrichContext(fields[key], parameters, options)
-    } else if (typeof fields[key] === "string") {
-      enrichedQuery[key] = JSON_TEMPLATE_FIELDS.has(key)
-        ? enrichJsonTemplate(fields[key], parameters, options)
-        : processTemplateString(fields[key], parameters, options)
-    } else {
-      enrichedQuery[key] = fields[key]
-    }
-  }
+  const enrichedQuery = await enrichContextObject(fields, parameters, options)
   for (const key of ["json", "customData", "requestBody"]) {
     if (
       !Object.hasOwn(enrichedQuery, key) ||

--- a/packages/types/src/documents/workspace/query.ts
+++ b/packages/types/src/documents/workspace/query.ts
@@ -111,6 +111,7 @@ export interface MongoQueryFields {
       | "count"
       | "distinct"
       | "insertOne"
+      | "insertMany"
       | "deleteOne"
       | "deleteMany"
   }


### PR DESCRIPTION
## Description
Fixes MongoDB query binding interpolation when a binding is used as an object key. This covers both object-backed JSON fields and JSON strings from the query editor, such as `{ "{{ field }}": 9 }`.

Regression tests added for SDK query context enrichment and MongoDB `find`/`insertMany` query execution.

## Addresses
- https://github.com/Budibase/budibase/issues/18986

## Screenshots
BEFORE:
<img width="703" height="1237" alt="before" src="https://github.com/user-attachments/assets/edb5387a-d3a3-431f-9067-98055c72b818" />

AFTER:
<img width="957" height="947" alt="after" src="https://github.com/user-attachments/assets/89fddd69-a4c6-48fb-8f7b-ce7099083939" />


## Launchcontrol
Fixes MongoDB queries so bindings can be used as dynamic JSON keys.