### PR TITLE
Merge RAG logs with the request logs on LiteLLM

### DIFF
--- a/packages/server/src/sdk/workspace/ai/agents/agentRuntime.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/agentRuntime.ts
@@ -25,6 +25,7 @@ import {
 import { updatePendingToolCalls } from "./utils"
 import { estimateTokens } from "./usage"
 import { createReportUsedSourcesTool } from "../../../../ai/tools/budibase/knowledge/reportUsedSources"
+import { withLiteLLMSessionId } from "../llm/requestSession"
 
 interface PrepareAgentChatRunParams {
   agent: Agent
@@ -153,79 +154,81 @@ export const prepareAgentChatRun = async ({
     systemPromptTokens,
     contextUsage,
     stream: async ({ onFinish, onToolCalls, pendingToolCalls } = {}) =>
-      await agentRunner.stream({
-        messages: modelMessages,
-        async onStepFinish({
-          content,
-          toolCalls,
-          toolResults,
-          response,
-          usage,
-        }) {
-          if (!contextUsage.input) {
-            contextUsage.input = usage
-          }
-          contextUsage.output = usage
-          sessionLogIndexer.addRequestId(response?.id)
-          if (onToolCalls) {
-            const toolNames = toolCalls
-              .map(toolCall => toolCall.toolName)
-              .filter(Boolean)
-            if (toolNames.length) {
-              onToolCalls(toolNames)
+      await withLiteLLMSessionId(sessionId, () =>
+        agentRunner.stream({
+          messages: modelMessages,
+          async onStepFinish({
+            content,
+            toolCalls,
+            toolResults,
+            response,
+            usage,
+          }) {
+            if (!contextUsage.input) {
+              contextUsage.input = usage
             }
-          }
-          if (pendingToolCalls) {
-            updatePendingToolCalls(pendingToolCalls, toolCalls, toolResults)
-          }
-
-          for (const toolResult of toolResults) {
-            if (
-              toolResult.toolName === "search_knowledge" &&
-              !toolResult.preliminary
-            ) {
-              const output = toolResult.output as
-                | { sources?: AgentMessageMetadata["ragSources"] }
-                | undefined
-              for (const source of output?.sources || []) {
-                if (!source?.sourceId) {
-                  continue
-                }
-                const existing = retrievedKnowledgeSourceById.get(
-                  source.sourceId
-                )
-                retrievedKnowledgeSourceById.set(source.sourceId, {
-                  ...existing,
-                  ...source,
-                })
+            contextUsage.output = usage
+            sessionLogIndexer.addRequestId(response?.id)
+            if (onToolCalls) {
+              const toolNames = toolCalls
+                .map(toolCall => toolCall.toolName)
+                .filter(Boolean)
+              if (toolNames.length) {
+                onToolCalls(toolNames)
               }
             }
-            if (
-              toolResult.toolName === "report_used_sources" &&
-              !toolResult.preliminary
-            ) {
-              const output = toolResult.output as
-                | { accepted?: AgentMessageMetadata["ragSources"] }
-                | undefined
-              setUsedKnowledgeSources(output?.accepted)
+            if (pendingToolCalls) {
+              updatePendingToolCalls(pendingToolCalls, toolCalls, toolResults)
             }
-            await quotas.addAction(ActionType.AI_AGENT, async () => {})
-          }
 
-          if (!pendingToolCalls) {
-            return
-          }
-
-          for (const part of content) {
-            if (part.type === "tool-error") {
-              pendingToolCalls.delete(part.toolCallId)
+            for (const toolResult of toolResults) {
+              if (
+                toolResult.toolName === "search_knowledge" &&
+                !toolResult.preliminary
+              ) {
+                const output = toolResult.output as
+                  | { sources?: AgentMessageMetadata["ragSources"] }
+                  | undefined
+                for (const source of output?.sources || []) {
+                  if (!source?.sourceId) {
+                    continue
+                  }
+                  const existing = retrievedKnowledgeSourceById.get(
+                    source.sourceId
+                  )
+                  retrievedKnowledgeSourceById.set(source.sourceId, {
+                    ...existing,
+                    ...source,
+                  })
+                }
+              }
+              if (
+                toolResult.toolName === "report_used_sources" &&
+                !toolResult.preliminary
+              ) {
+                const output = toolResult.output as
+                  | { accepted?: AgentMessageMetadata["ragSources"] }
+                  | undefined
+                setUsedKnowledgeSources(output?.accepted)
+              }
+              await quotas.addAction(ActionType.AI_AGENT, async () => {})
             }
-          }
-        },
-        async onFinish({ response }) {
-          sessionLogIndexer.addRequestId(response?.id)
-          await onFinish?.(response?.id)
-        },
-      }),
+
+            if (!pendingToolCalls) {
+              return
+            }
+
+            for (const part of content) {
+              if (part.type === "tool-error") {
+                pendingToolCalls.delete(part.toolCallId)
+              }
+            }
+          },
+          async onFinish({ response }) {
+            sessionLogIndexer.addRequestId(response?.id)
+            await onFinish?.(response?.id)
+          },
+        })
+      ),
   }
 }

--- a/packages/server/src/sdk/workspace/ai/knowledgeBase/geminiFileStore.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/knowledgeBase/geminiFileStore.spec.ts
@@ -11,6 +11,7 @@ jest.mock("../configs/litellm", () => ({
 }))
 
 import { setEnv, withEnv } from "../../../../environment"
+import { withLiteLLMSessionId } from "../llm/requestSession"
 import {
   createGeminiFileStore,
   deleteGeminiFileFromStore,
@@ -248,6 +249,31 @@ describe("geminiFileStore", () => {
         },
       ])
       expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it("includes litellm_session_id when a session context is active", async () => {
+    await withEnv({ GEMINI_API_KEY: "test-gemini-key" }, async () => {
+      let requestBody: Record<string, unknown> | undefined
+      mockFetch.mockResolvedValueOnce(
+        response({
+          ok: true,
+          status: 200,
+          json: { data: [] },
+        })
+      )
+
+      await withLiteLLMSessionId("chatconvo_123", async () =>
+        searchGeminiFileStore({
+          vectorStoreId: "vector-store-1",
+          query: "hello",
+        })
+      )
+
+      const [, init] = mockFetch.mock.calls[0]
+      requestBody = JSON.parse(String(init?.body))
+      expect(requestBody?.litellm_session_id).toBe("chatconvo_123")
+      expect(requestBody?.metadata).toEqual({ session_id: "chatconvo_123" })
     })
   })
 

--- a/packages/server/src/sdk/workspace/ai/knowledgeBase/geminiFileStore.ts
+++ b/packages/server/src/sdk/workspace/ai/knowledgeBase/geminiFileStore.ts
@@ -3,6 +3,7 @@ import { helpers } from "@budibase/shared-core"
 import fetch from "node-fetch"
 import environment from "../../../../environment"
 import { getKeySettings } from "../configs/litellm"
+import { getLiteLLMSessionId } from "../llm/requestSession"
 
 interface CreateVectorStoreResponse {
   id?: string
@@ -259,6 +260,7 @@ export async function searchGeminiFileStore({
   query: string
 }): Promise<RagSearchResultItem[]> {
   const geminiApiKey = getGeminiApiKey()
+  const sessionId = getLiteLLMSessionId()
   const response = await requestWithRetries(async () =>
     fetch(
       `${environment.LITELLM_URL}/v1/vector_stores/${encodeURIComponent(
@@ -271,6 +273,12 @@ export async function searchGeminiFileStore({
           query,
           custom_llm_provider: "gemini",
           ...(geminiApiKey ? { api_key: geminiApiKey } : {}),
+          ...(sessionId
+            ? {
+                litellm_session_id: sessionId,
+                metadata: { session_id: sessionId },
+              }
+            : {}),
         }),
       }
     )

--- a/packages/server/src/sdk/workspace/ai/llm/requestSession.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/llm/requestSession.spec.ts
@@ -1,0 +1,10 @@
+import { getLiteLLMSessionId, withLiteLLMSessionId } from "./requestSession"
+
+describe("withLiteLLMSessionId", () => {
+  it("scopes session id to the wrapped call", async () => {
+    await withLiteLLMSessionId("chatconvo_123", async () => {
+      expect(getLiteLLMSessionId()).toBe("chatconvo_123")
+    })
+    expect(getLiteLLMSessionId()).toBeUndefined()
+  })
+})

--- a/packages/server/src/sdk/workspace/ai/llm/requestSession.ts
+++ b/packages/server/src/sdk/workspace/ai/llm/requestSession.ts
@@ -1,0 +1,10 @@
+import { AsyncLocalStorage } from "async_hooks"
+
+const requestSessionStorage = new AsyncLocalStorage<string>()
+
+export const getLiteLLMSessionId = () => requestSessionStorage.getStore()
+
+export const withLiteLLMSessionId = <T>(
+  sessionId: string,
+  fn: () => T | Promise<T>
+): Promise<T> => Promise.resolve(requestSessionStorage.run(sessionId, fn))


### PR DESCRIPTION
## Description
Merging the request logs, nowadays the RAG log are separated from the rest of the logs
<img width="895" height="671" alt="image" src="https://github.com/user-attachments/assets/5e8818bc-2035-482a-a6a6-f39c4aa4536e" />
<img width="926" height="471" alt="image" src="https://github.com/user-attachments/assets/c67c7f97-5f1c-4430-8c27-f9f994305349" />


Unifying them will help us better debugging:
<img width="900" height="521" alt="image" src="https://github.com/user-attachments/assets/4dafd7cd-48e0-4172-b3cb-e1ac088247e7" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merged RAG logs with LiteLLM request logs by passing a shared session ID through agent runs and vector store searches. RAG events now appear under the same LiteLLM request for easier debugging.

- **New Features**
  - Added `withLiteLLMSessionId` and `getLiteLLMSessionId` using `AsyncLocalStorage`.
  - Run `agentRunner.stream` within the current session.
  - `searchGeminiFileStore` sends `litellm_session_id` and `metadata.session_id` when a session is active.
  - Added tests for session scoping and vector store request payloads.

<sup>Written for commit 5e014f2e4e884e8afc0f193016a09af956923710. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/18988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

