### PR TITLE
tighten user update check

### DIFF
--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -109,6 +109,10 @@ export const save = async (ctx: UserCtx<UnsavedUser, SaveUserResponse>) => {
 export const changeTenantOwnerEmail = async (
   ctx: Ctx<ChangeTenantOwnerEmailRequest, void>
 ) => {
+  if (!ctx.internal) {
+    ctx.throw(403, "Unauthorized")
+  }
+
   const { newAccountEmail, originalEmail, tenantIds } = ctx.request.body
   try {
     for (const tenantId of tenantIds) {

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -1528,5 +1528,43 @@ describe("/api/global/users", () => {
         .set(config.defaultHeaders())
         .expect(403)
     })
+
+    it("should reject authenticated users on self-hosted", async () => {
+      const originalEmail = `original-${structures.uuid()}@example.com`
+      const newEmail = `new-${structures.uuid()}@example.com`
+      const tenantId = config.getTenantId()
+
+      const tenantUser = await config.doInTenant(async () => {
+        return await userSdk.db.save(
+          structures.users.user({
+            email: originalEmail,
+            tenantId,
+            roles: {},
+          }),
+          { requirePassword: false, isAccountHolder: true }
+        )
+      })
+
+      config.selfHosted()
+      try {
+        await config.request
+          .put(`/api/global/users/tenant/owner`)
+          .send({
+            newAccountEmail: newEmail,
+            originalEmail,
+            tenantIds: [tenantId],
+          })
+          .set(config.defaultHeaders())
+          .expect(403)
+      } finally {
+        config.cloudHosted()
+      }
+
+      const unchangedUser = await config.doInTenant(async () => {
+        return await userSdk.db.getUser(tenantUser._id!)
+      })
+
+      expect(unchangedUser!.email).toBe(originalEmail)
+    })
   })
 })


### PR DESCRIPTION
## Description
tightens authorisation around a global user maintenance path and adds regression coverage for hosted mode differences

## Addresses
https://github.com/Budibase/vulns/issues/83

## App Export
n/a

## Screenshots
n/a

## Launchcontrol
improves permission checks for user account maintenance operations