### PR TITLE
Raise single-image HEALTHCHECK start-period from 45s to 300s

### DIFF
--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -155,8 +155,6 @@ RUN jq --arg v "$BUDIBASE_VERSION" '.version = $v' /app/package.json > /tmp/pkg.
 RUN jq --arg v "$BUDIBASE_VERSION" '.version = $v' /worker/package.json > /tmp/pkg.json && mv /tmp/pkg.json /worker/package.json
 ENV BUDIBASE_VERSION=$BUDIBASE_VERSION
 
-# Long start-period: the image cold-boots serially in ~2-3min; a shorter grace makes
-# health-acting orchestrators (Swarm/Easypanel) kill it mid-boot into a crash-loop.
 HEALTHCHECK --interval=15s --timeout=15s --start-period=300s CMD "/healthcheck.sh"
 
 # Must set this just before running

--- a/hosting/single/Dockerfile
+++ b/hosting/single/Dockerfile
@@ -155,7 +155,9 @@ RUN jq --arg v "$BUDIBASE_VERSION" '.version = $v' /app/package.json > /tmp/pkg.
 RUN jq --arg v "$BUDIBASE_VERSION" '.version = $v' /worker/package.json > /tmp/pkg.json && mv /tmp/pkg.json /worker/package.json
 ENV BUDIBASE_VERSION=$BUDIBASE_VERSION
 
-HEALTHCHECK --interval=15s --timeout=15s --start-period=45s CMD "/healthcheck.sh"
+# Long start-period: the image cold-boots serially in ~2-3min; a shorter grace makes
+# health-acting orchestrators (Swarm/Easypanel) kill it mid-boot into a crash-loop.
+HEALTHCHECK --interval=15s --timeout=15s --start-period=300s CMD "/healthcheck.sh"
 
 # Must set this just before running
 ENV NODE_ENV=production


### PR DESCRIPTION
## Description

The single image starts its services serially (couch, minio, redis, internal Postgres, LiteLLM, then app/worker), so a cold boot takes ~2-3 min. The HEALTHCHECK `start-period` was only 45s. Plain docker just marks the container unhealthy and leaves it running, but health-acting orchestrators (Docker Swarm, Easypanel, Portainer) kill and reschedule it - so it got killed mid-boot and crash-looped (`non-zero exit (143): unhealthy container`).

Raised `start-period` to 300s. That only delays when failures count, not when the container reaches healthy, so plain docker run/compose is unaffected. One line in `hosting/single/Dockerfile`.

This is the minimal part of #18090; the fatal internal-Postgres gate and concurrent-instance corruption from that issue can follow separately.

## Addresses

https://github.com/Budibase/budibase/issues/18090

## App Export

n/a

## Screenshots

n/a

## Launchcontrol

Single-image containers no longer crash-loop on Docker Swarm / Easypanel during a slow cold boot; the healthcheck now waits long enough for all services to start.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the single-image Docker `HEALTHCHECK` start-period from 45s to 300s to cover 2–3 min cold boots. Prevents health-acting orchestrators (Docker Swarm, Easypanel, Portainer) from killing the container mid-boot and causing crash loops; plain Docker behavior is unchanged.

<sup>Written for commit 260db993dbcc447efabb845dcbf8e6dc344abf5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/18991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

