### PR TITLE
translate app filter operator labels

### DIFF
--- a/packages/client/src/components/app/filter/Filter.svelte
+++ b/packages/client/src/components/app/filter/Filter.svelte
@@ -21,7 +21,12 @@
   import Container from "../container/Container.svelte"
   import { getAction } from "@/utils/getAction"
   import { ActionTypes } from "@/constants"
-  import { QueryUtils, fetchData, memo } from "@budibase/frontend-core"
+  import {
+    QueryUtils,
+    fetchData,
+    loadTranslationsByGroup,
+    memo,
+  } from "@budibase/frontend-core"
   import FilterButton from "./FilterButton.svelte"
   import { onDestroy } from "svelte"
   import { uiStateStore } from "@/stores"
@@ -44,6 +49,7 @@
 
   const rowCache = writable({})
   setContext("rows", rowCache)
+  const filterLabels = loadTranslationsByGroup("filter")
 
   // Core filter template
   const baseFilter: UISearchFilter = {
@@ -158,19 +164,24 @@
     )
 
     const isDateTime = fieldType === FieldType.DATETIME
-    // Label mixins. Override the display text
-    const opToDisplay: Record<string, any> = {
-      rangeHigh: isDateTime ? "Before" : undefined,
-      rangeLow: isDateTime ? "After" : undefined,
-      [FilterType.EQUAL]: "Is",
-      [FilterType.NOT_EQUAL]: "Is not",
+    const opToDisplay: Record<string, string> = {
+      equal: filterLabels.is,
+      notEqual: filterLabels.isNot,
+      string: filterLabels.startsWith,
+      fuzzy: filterLabels.like,
+      empty: filterLabels.empty,
+      notEmpty: filterLabels.notEmpty,
+      oneOf: filterLabels.isIn,
+      notOneOf: filterLabels.notOneOf,
+      rangeLow: filterLabels.moreThanOrEqualTo,
+      rangeHigh: filterLabels.lessThanOrEqualTo,
     }
 
     // Add in the range operator for datetime fields
     coreOperators = [
       ...coreOperators,
       ...(fieldType === FieldType.DATETIME
-        ? [{ value: RangeOperator.RANGE, label: "Between" }]
+        ? [{ value: RangeOperator.RANGE, label: filterLabels.between }]
         : []),
     ]
 

--- a/packages/client/src/components/app/filter/FilterPopover.svelte
+++ b/packages/client/src/components/app/filter/FilterPopover.svelte
@@ -16,6 +16,7 @@
     FilterValueType,
     OperatorOptions,
   } from "@budibase/frontend-core/src/constants"
+  import { loadTranslationsByGroup } from "@budibase/frontend-core"
   import {
     type FieldSchema,
     type FilterConfig,
@@ -54,6 +55,7 @@
 
   const dispatch = createEventDispatcher()
   const rowCache: Writable<Record<string, any>> = getContext("rows")
+  const filterLabels = loadTranslationsByGroup("filter")
 
   let popover: PopoverAPI | undefined
   let anchor: HTMLElement | undefined
@@ -326,8 +328,8 @@
             value={editableFilter.value}
             disabled={editableFilter.noValue}
             options={[
-              { label: "True", value: "true" },
-              { label: "False", value: "false" },
+              { label: filterLabels.true, value: "true" },
+              { label: filterLabels.false, value: "false" },
             ]}
             on:change={e => {
               if (!editableFilter) return

--- a/packages/shared-core/src/translations/filter.ts
+++ b/packages/shared-core/src/translations/filter.ts
@@ -1,0 +1,71 @@
+import { createTranslationDefinitions } from "./types"
+
+const category = "filter"
+
+export const filterTranslations = createTranslationDefinitions(category, [
+  {
+    key: "is",
+    name: "Is operator label",
+    defaultValue: "Is",
+  },
+  {
+    key: "isNot",
+    name: "Is not operator label",
+    defaultValue: "Is not",
+  },
+  {
+    key: "startsWith",
+    name: "Starts with operator label",
+    defaultValue: "Starts with",
+  },
+  {
+    key: "like",
+    name: "Like operator label",
+    defaultValue: "Like",
+  },
+  {
+    key: "empty",
+    name: "Is empty operator label",
+    defaultValue: "Is empty",
+  },
+  {
+    key: "notEmpty",
+    name: "Is not empty operator label",
+    defaultValue: "Is not empty",
+  },
+  {
+    key: "isIn",
+    name: "Is in operator label",
+    defaultValue: "Is in",
+  },
+  {
+    key: "notOneOf",
+    name: "Is not in operator label",
+    defaultValue: "Is not in",
+  },
+  {
+    key: "moreThanOrEqualTo",
+    name: "More than or equal to operator label",
+    defaultValue: "More than or equal to",
+  },
+  {
+    key: "lessThanOrEqualTo",
+    name: "Less than or equal to operator label",
+    defaultValue: "Less than or equal to",
+  },
+  {
+    key: "between",
+    name: "Between operator label",
+    defaultValue: "Between",
+  },
+  {
+    key: "true",
+    name: "True option label",
+    defaultValue: "True",
+  },
+  {
+    key: "false",
+    name: "False option label",
+    defaultValue: "False",
+  },
+])

--- a/packages/shared-core/src/translations/index.ts
+++ b/packages/shared-core/src/translations/index.ts
@@ -2,6 +2,7 @@ import { userMenuTranslations } from "./userMenu"
 import { profileModalTranslations } from "./profileModal"
 import { passwordModalTranslations } from "./passwordModal"
 import { pickerTranslations } from "./picker"
+import { filterTranslations } from "./filter"
 import { recaptchaTranslations } from "./recaptcha"
 import { portalTranslations } from "./portal"
 import { loginTranslations } from "./login"
@@ -19,6 +20,7 @@ export {
   profileModalTranslations,
   passwordModalTranslations,
   pickerTranslations,
+  filterTranslations,
   recaptchaTranslations,
   portalTranslations,
   loginTranslations,
@@ -31,6 +33,7 @@ const translationModules = [
   profileModalTranslations,
   passwordModalTranslations,
   pickerTranslations,
+  filterTranslations,
   recaptchaTranslations,
   portalTranslations,
   loginTranslations,
@@ -44,6 +47,7 @@ export const TRANSLATION_CATEGORY_LABELS: Record<TranslationCategory, string> =
     profileModal: "Profile modal",
     passwordModal: "Password modal",
     picker: "Picker",
+    filter: "Filter",
     recaptcha: "reCAPTCHA",
     portal: "Portal",
     login: "Login",

--- a/packages/shared-core/src/translations/types.ts
+++ b/packages/shared-core/src/translations/types.ts
@@ -3,6 +3,7 @@ export type TranslationCategory =
   | "profileModal"
   | "passwordModal"
   | "picker"
+  | "filter"
   | "recaptcha"
   | "portal"
   | "login"


### PR DESCRIPTION
## Description
Adds a new filter translation group for the app filter UI and wires the app filter operator labels to use it.

## Addresses
- https://github.com/Budibase/budibase/issues/18933

## Screenshots
**Filter builder settings**
<img width="846" height="312" alt="Screenshot 2026-06-17 at 10 58 10" src="https://github.com/user-attachments/assets/307383da-d180-4db1-b310-424011d4a064" />

**Filter component translations**
<img width="286" height="404" alt="Screenshot 2026-06-17 at 10 57 09" src="https://github.com/user-attachments/assets/76b2a421-b5be-4935-9fff-0d9516a84a4f" />

## Launchcontrol
The app’s filter dropdowns now use the translation system, so those labels can be localised properly instead of staying hardcoded in English