### PR TITLE
Fix/custom rest query save disabled

### DIFF
--- a/packages/builder/src/components/integration/APIEndpointViewer.spec.ts
+++ b/packages/builder/src/components/integration/APIEndpointViewer.spec.ts
@@ -1325,6 +1325,22 @@ describe("API Endpoint Viewer", () => {
       })
     })
 
+    // #18798: a scheme-less URL is accepted by the server (it defaults to
+    // http), so Save must enable for it just like it does for "https://...".
+    it("Save button is enabled for a scheme-less URL", async () => {
+      const { container } = setupDOM({ datasourceId: REST_DS_ID })
+      await waitFor(() =>
+        expect(container.querySelector(".url-input")).not.toBeNull()
+      )
+      const urlInput = container.querySelector(".url-input") as HTMLInputElement
+      await fireEvent.input(urlInput, { target: { value: "google.com" } })
+      await waitFor(() => {
+        expect(
+          getSaveButton(container)?.classList.contains("is-disabled")
+        ).toBe(false)
+      })
+    })
+
     it("loads the stored full URL into the URL input", async () => {
       queries.store.update(s => ({ ...s, list: [CUSTOM_QUERY] }))
       const { container } = setupDOM({ queryId: QUERY_ID })

--- a/packages/builder/src/components/integration/query.spec.ts
+++ b/packages/builder/src/components/integration/query.spec.ts
@@ -33,6 +33,18 @@ describe("isValidEndpointUrl", () => {
     expect(isValidEndpointUrl("https://someurl")).toBe(true)
   })
 
+  it("accepts a scheme-less host (e.g. google.com)", () => {
+    expect(isValidEndpointUrl("google.com")).toBe(true)
+  })
+
+  it("accepts a scheme-less host with a path", () => {
+    expect(isValidEndpointUrl("google.com/search")).toBe(true)
+  })
+
+  it("accepts a scheme-less host with a port", () => {
+    expect(isValidEndpointUrl("google.com:8080")).toBe(true)
+  })
+
   it("accepts localhost with a port", () => {
     expect(isValidEndpointUrl("http://localhost:4001")).toBe(true)
   })

--- a/packages/builder/src/components/integration/query.ts
+++ b/packages/builder/src/components/integration/query.ts
@@ -476,11 +476,22 @@ export function keyValueArrayToRecord(
 
 export function isValidEndpointUrl(url: string | undefined): boolean {
   if (!url || /\s/.test(url)) return false
-  if (!/^(https?:\/\/|\{\{)/.test(url)) return false
+  // Relative paths can't be reached on their own
+  if (url.startsWith("/")) return false
+  // Reject explicit non-http(s) schemes (e.g. ftp://, https:foo). A colon
+  // followed by digits is a port not a scheme, so "google.com:8080" is allowed.
+  const scheme = url.match(/^[a-zA-Z][a-zA-Z0-9+.-]*:/)
+  const hasScheme = !!scheme && !/^\d/.test(url.slice(scheme[0].length))
+  if (hasScheme && !/^https?:\/\//.test(url)) return false
   if (findHBSBlocks(url).length > 0) return true
+  // Any remaining handlebars markers are a malformed binding, not a host
+  if (/[{}]/.test(url)) return false
+  // Scheme-less hosts (e.g. "google.com") are valid - the server defaults a
+  // missing protocol to http, so accept them rather than disabling Save.
+  const candidate = /^https?:\/\//.test(url) ? url : `https://${url}`
   try {
-    new URL(url)
-    return true
+    const { protocol, hostname } = new URL(candidate)
+    return (protocol === "http:" || protocol === "https:") && hostname !== ""
   } catch {
     return false
   }


### PR DESCRIPTION
## Description
A new Custom REST query could not be saved when the endpoint was entered without a protocol (e.g. google.com). The request itself succeeded (Send returned 200), but the Save button remained disabled.

This was caused by a mismatch between frontend validation and backend behavior:

- Send allows scheme-less URLs and the server automatically prepends http:// when needed.
- Save depended on isValidEndpointUrl, which incorrectly required explicit http://, https://, or {{...}}, rejecting valid scheme-less hosts.

This PR updates isValidEndpointUrl to align with backend behavior by treating scheme-less URLs as valid and normalizing them during validation.

## Addresses
- https://github.com/Budibase/budibase/issues/18798

## App Export
- Not required — issue is fully reproducible from scratch:
  - Create REST datasource
  - Create Custom query
  - Enter google.com
  - Click Send (200 response)
  - Save button incorrectly disabled before fix

## Screenshots

- Before: Entering google.com → Send succeeds (200) → Save disabled
<img width="1230" height="365" alt="Screenshot 2026-06-17 at 7 12 08 PM" src="https://github.com/user-attachments/assets/12bfc55d-80fd-4f17-b14d-da13cccbe239" />

- After: Entering google.com → Save enabled → query saves successfully
 <img width="1226" height="352" alt="Screenshot 2026-06-17 at 7 04 03 PM" src="https://github.com/user-attachments/assets/72f1a61f-e1ee-47d7-b219-243d17799bc7" />

## Launchcontrol
Users can now save Custom REST API queries even when they enter a URL without http:// or https:// (for example google.com). Previously, the Save button remained disabled even though the request itself worked correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes disabled Save for Custom REST queries when the endpoint lacks a protocol (e.g. google.com). Fixes #18798 by aligning frontend validation with backend so scheme-less hosts are accepted and can be saved.

- **Bug Fixes**
  - Updated `isValidEndpointUrl` to allow scheme-less hosts (normalized for validation), reject relative paths and non-http(s) schemes, and support `{{...}}` bindings.
  - Added tests for scheme-less URLs in `APIEndpointViewer.spec.ts` and `query.spec.ts`.

<sup>Written for commit 5379927399c9d613059dd5a7a322a49901bf0423. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

