### PR TITLE
Fix automation side panel layout

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowChart.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowChart.svelte
@@ -78,6 +78,8 @@
   const VIEWPORT_ANIMATION_DURATION = 180
   const MIN_ZOOM = 0.5
   const MAX_ZOOM = 2.5
+  const ACTION_PANEL_DEFAULT_WIDTH = 480
+  const ACTION_PANEL_STORAGE_KEY = "automation-side-panel-width"
 
   const memoAutomation = memo(automation)
 
@@ -273,7 +275,7 @@
   ) {
     lastVisibleActionTargetCheck = actionPanelTargetNodeId
     visibleSelectionRequest = actionPanelTargetNodeId
-    ensureSelectedNodeVisible(actionPanelTargetNodeId)
+    ensureActionPanelTargetVisible(actionPanelTargetNodeId)
   }
 
   // Check if automation has unpublished changes
@@ -460,6 +462,13 @@
     return undefined
   }
 
+  const getActionPanelWidth = () => {
+    const storedWidth = Number(localStorage.getItem(ACTION_PANEL_STORAGE_KEY))
+    return Number.isFinite(storedWidth) && storedWidth > 0
+      ? storedWidth
+      : ACTION_PANEL_DEFAULT_WIDTH
+  }
+
   const ensureSelectedNodeVisible = async (
     nodeId: string,
     options: { rightInset?: number } = {}
@@ -522,6 +531,58 @@
     setSyncedViewport(
       {
         x: nextX,
+        y: nextY,
+        zoom: currentViewport.zoom,
+      },
+      { duration: VIEWPORT_ANIMATION_DURATION }
+    )
+  }
+
+  const ensureActionPanelTargetVisible = async (nodeId: string) => {
+    await tick()
+    if (visibleSelectionRequest !== nodeId || !paneEl) {
+      return
+    }
+
+    const targetNode = get(nodes).find(node => node.id === nodeId)
+    const currentViewport = getViewport()
+    if (!targetNode || !currentViewport) {
+      return
+    }
+
+    const paneRect = paneEl.getBoundingClientRect()
+    const { width: nodeWidth, height: nodeHeight } =
+      getNodeDimensions(targetNode)
+    const position = getAbsoluteNodePosition(targetNode)
+    const margin = 24
+    const visiblePaneWidth = Math.max(paneRect.width - getActionPanelWidth(), 0)
+    const nodeRight =
+      position.x * currentViewport.zoom +
+      currentViewport.x +
+      nodeWidth * currentViewport.zoom
+    const nodeBottom =
+      position.y * currentViewport.zoom +
+      currentViewport.y +
+      nodeHeight * currentViewport.zoom
+    const nodeTop = position.y * currentViewport.zoom + currentViewport.y
+    const xOverflow = nodeRight + margin - visiblePaneWidth
+    const yOverflow = nodeBottom + margin - paneRect.height
+    const yUnderflow = margin - nodeTop
+
+    if (xOverflow <= 0 && yOverflow <= 0 && yUnderflow <= 0) {
+      return
+    }
+
+    let nextY = currentViewport.y
+    if (yOverflow > 0) {
+      nextY -= yOverflow
+    } else if (yUnderflow > 0) {
+      nextY += yUnderflow
+    }
+
+    setSyncedViewport(
+      {
+        x: xOverflow > 0 ? currentViewport.x - xOverflow : currentViewport.x,
         y: nextY,
         zoom: currentViewport.zoom,
       },

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowChart.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowChart.svelte
@@ -475,10 +475,7 @@
       ACTION_PANEL_MIN_WIDTH,
       Math.floor(window.innerWidth * ACTION_PANEL_MAX_WIDTH_RATIO)
     )
-    return Math.max(
-      ACTION_PANEL_MIN_WIDTH,
-      Math.min(rawWidth, maxWidth)
-    )
+    return Math.max(ACTION_PANEL_MIN_WIDTH, Math.min(rawWidth, maxWidth))
   }
 
   const ensureSelectedNodeVisible = async (
@@ -583,7 +580,12 @@
     const yOverflow = nodeBottom + margin - paneRect.height
     const yUnderflow = margin - nodeTop
 
-    if (xOverflow <= 0 && xUnderflow <= 0 && yOverflow <= 0 && yUnderflow <= 0) {
+    if (
+      xOverflow <= 0 &&
+      xUnderflow <= 0 &&
+      yOverflow <= 0 &&
+      yUnderflow <= 0
+    ) {
       return
     }
 

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowChart.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowChart.svelte
@@ -79,6 +79,8 @@
   const MIN_ZOOM = 0.5
   const MAX_ZOOM = 2.5
   const ACTION_PANEL_DEFAULT_WIDTH = 480
+  const ACTION_PANEL_MIN_WIDTH = 360
+  const ACTION_PANEL_MAX_WIDTH_RATIO = 0.6
   const ACTION_PANEL_STORAGE_KEY = "automation-side-panel-width"
 
   const memoAutomation = memo(automation)
@@ -464,9 +466,19 @@
 
   const getActionPanelWidth = () => {
     const storedWidth = Number(localStorage.getItem(ACTION_PANEL_STORAGE_KEY))
-    return Number.isFinite(storedWidth) && storedWidth > 0
-      ? storedWidth
-      : ACTION_PANEL_DEFAULT_WIDTH
+    const fallbackWidth = ACTION_PANEL_DEFAULT_WIDTH
+    const rawWidth =
+      Number.isFinite(storedWidth) && storedWidth > 0
+        ? storedWidth
+        : fallbackWidth
+    const maxWidth = Math.max(
+      ACTION_PANEL_MIN_WIDTH,
+      Math.floor(window.innerWidth * ACTION_PANEL_MAX_WIDTH_RATIO)
+    )
+    return Math.max(
+      ACTION_PANEL_MIN_WIDTH,
+      Math.min(rawWidth, maxWidth)
+    )
   }
 
   const ensureSelectedNodeVisible = async (
@@ -560,20 +572,28 @@
       position.x * currentViewport.zoom +
       currentViewport.x +
       nodeWidth * currentViewport.zoom
+    const nodeLeft = position.x * currentViewport.zoom + currentViewport.x
     const nodeBottom =
       position.y * currentViewport.zoom +
       currentViewport.y +
       nodeHeight * currentViewport.zoom
     const nodeTop = position.y * currentViewport.zoom + currentViewport.y
     const xOverflow = nodeRight + margin - visiblePaneWidth
+    const xUnderflow = margin - nodeLeft
     const yOverflow = nodeBottom + margin - paneRect.height
     const yUnderflow = margin - nodeTop
 
-    if (xOverflow <= 0 && yOverflow <= 0 && yUnderflow <= 0) {
+    if (xOverflow <= 0 && xUnderflow <= 0 && yOverflow <= 0 && yUnderflow <= 0) {
       return
     }
 
+    let nextX = currentViewport.x
     let nextY = currentViewport.y
+    if (xOverflow > 0) {
+      nextX -= xOverflow
+    } else if (xUnderflow > 0) {
+      nextX += xUnderflow
+    }
     if (yOverflow > 0) {
       nextY -= yOverflow
     } else if (yUnderflow > 0) {
@@ -582,7 +602,7 @@
 
     setSyncedViewport(
       {
-        x: xOverflow > 0 ? currentViewport.x - xOverflow : currentViewport.x,
+        x: nextX,
         y: nextY,
         zoom: currentViewport.zoom,
       },

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/test/FlowChart.test.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/test/FlowChart.test.ts
@@ -9,6 +9,14 @@ import { PublishResourceState } from "@budibase/types"
 
 const mocks = vi.hoisted(() => {
   type StoreValue = Record<string, unknown>
+  type MockNode = {
+    id: string
+    type: string
+    data: { block: unknown }
+    position: { x: number; y: number }
+    width: number
+    height: number
+  }
 
   const store = <T>(initial: T) => {
     let value = initial
@@ -32,6 +40,7 @@ const mocks = vi.hoisted(() => {
 
   return {
     viewport: { x: 0, y: 0, zoom: 1 },
+    mockNodes: [] as MockNode[],
     setViewport: vi.fn((viewport: { x: number; y: number; zoom: number }) => {
       mocks.viewport = viewport
     }),
@@ -144,7 +153,7 @@ vi.mock("@xyflow/svelte", () => ({
   useSvelteFlow: () => ({
     getViewport: () => mocks.viewport,
     setViewport: mocks.setViewport,
-    getNodes: () => [],
+    getNodes: () => mocks.mockNodes,
     getNodesBounds: () => ({ x: 0, y: 0, width: 0, height: 0 }),
   }),
 }))
@@ -220,7 +229,9 @@ const setPaneSize = (width: number, height: number) => {
 describe("FlowChart", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    localStorage.clear()
     mocks.viewport = { x: 0, y: 0, zoom: 1 }
+    mocks.mockNodes = []
     mocks.setViewport.mockClear()
     setPaneSize(1000, 600)
     global.ResizeObserver = class {
@@ -282,5 +293,79 @@ describe("FlowChart", () => {
 
     await tick()
     expect(mocks.setViewport).not.toHaveBeenCalled()
+  })
+
+  it("moves the canvas left when opening the add-step panel would hide the target on the right", async () => {
+    const automation = {
+      ...automationWithSteps([serverLogStep("step-1")]),
+      _id: "automation-1",
+      publishStatus: {
+        published: false,
+        name: "Automation",
+        state: PublishResourceState.DISABLED,
+      },
+    }
+
+    render(FlowChart, {
+      props: { automation },
+    })
+
+    await waitFor(() => {
+      expect(mocks.setViewport).toHaveBeenCalledWith(
+        { x: 100, y: 240, zoom: 1 },
+        { duration: 0 }
+      )
+    })
+    mocks.setViewport.mockClear()
+    mocks.viewport = { x: 300, y: 240, zoom: 1 }
+
+    mocks.automationStore.update(state => ({
+      ...state,
+      actionPanelBlock: { id: "step-1" },
+    }))
+
+    await waitFor(() => {
+      expect(mocks.setViewport).toHaveBeenCalledWith(
+        { x: -304, y: 240, zoom: 1 },
+        { duration: 180 }
+      )
+    })
+  })
+
+  it("vertically pans when opening the add-step panel would hide the target vertically", async () => {
+    const automation = {
+      ...automationWithSteps([serverLogStep("step-1")]),
+      _id: "automation-1",
+      publishStatus: {
+        published: false,
+        name: "Automation",
+        state: PublishResourceState.DISABLED,
+      },
+    }
+
+    render(FlowChart, {
+      props: { automation },
+    })
+
+    await waitFor(() => {
+      expect(mocks.setViewport).toHaveBeenCalledWith(
+        { x: 100, y: 240, zoom: 1 },
+        { duration: 0 }
+      )
+    })
+    mocks.setViewport.mockClear()
+    mocks.viewport = { x: -305, y: 540, zoom: 1 }
+
+    mocks.automationStore.update(state => ({
+      ...state,
+      actionPanelBlock: { id: "step-1" },
+    }))
+
+    await waitFor(() => {
+      expect(mocks.setViewport).toHaveBeenCalledWith(
+        { x: -305, y: 456, zoom: 1 },
+        { duration: 180 }
+      )
+    })
   })
 })

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/test/FlowChart.test.ts
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/test/FlowChart.test.ts
@@ -226,10 +226,19 @@ const setPaneSize = (width: number, height: number) => {
   )
 }
 
+const setInnerWidth = (value: number) => {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value,
+  })
+}
+
 describe("FlowChart", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     localStorage.clear()
+    setInnerWidth(1000)
     mocks.viewport = { x: 0, y: 0, zoom: 1 }
     mocks.mockNodes = []
     mocks.setViewport.mockClear()
@@ -332,6 +341,45 @@ describe("FlowChart", () => {
     })
   })
 
+  it("clamps the stored add-step panel width before calculating the viewport offset", async () => {
+    localStorage.setItem("automation-side-panel-width", "9999")
+
+    const automation = {
+      ...automationWithSteps([serverLogStep("step-1")]),
+      _id: "automation-1",
+      publishStatus: {
+        published: false,
+        name: "Automation",
+        state: PublishResourceState.DISABLED,
+      },
+    }
+
+    render(FlowChart, {
+      props: { automation },
+    })
+
+    await waitFor(() => {
+      expect(mocks.setViewport).toHaveBeenCalledWith(
+        { x: 100, y: 240, zoom: 1 },
+        { duration: 0 }
+      )
+    })
+    mocks.setViewport.mockClear()
+    mocks.viewport = { x: 300, y: 240, zoom: 1 }
+
+    mocks.automationStore.update(state => ({
+      ...state,
+      actionPanelBlock: { id: "step-1" },
+    }))
+
+    await waitFor(() => {
+      expect(mocks.setViewport).toHaveBeenCalledWith(
+        { x: -424, y: 240, zoom: 1 },
+        { duration: 180 }
+      )
+    })
+  })
+
   it("vertically pans when opening the add-step panel would hide the target vertically", async () => {
     const automation = {
       ...automationWithSteps([serverLogStep("step-1")]),
@@ -364,6 +412,43 @@ describe("FlowChart", () => {
     await waitFor(() => {
       expect(mocks.setViewport).toHaveBeenCalledWith(
         { x: -305, y: 456, zoom: 1 },
+        { duration: 180 }
+      )
+    })
+  })
+
+  it("pans right when the add-step target is hidden off the left edge", async () => {
+    const automation = {
+      ...automationWithSteps([serverLogStep("step-1")]),
+      _id: "automation-1",
+      publishStatus: {
+        published: false,
+        name: "Automation",
+        state: PublishResourceState.DISABLED,
+      },
+    }
+
+    render(FlowChart, {
+      props: { automation },
+    })
+
+    await waitFor(() => {
+      expect(mocks.setViewport).toHaveBeenCalledWith(
+        { x: 100, y: 240, zoom: 1 },
+        { duration: 0 }
+      )
+    })
+    mocks.setViewport.mockClear()
+    mocks.viewport = { x: -700, y: 240, zoom: 1 }
+
+    mocks.automationStore.update(state => ({
+      ...state,
+      actionPanelBlock: { id: "step-1" },
+    }))
+
+    await waitFor(() => {
+      expect(mocks.setViewport).toHaveBeenCalledWith(
+        { x: -576, y: 240, zoom: 1 },
         { duration: 180 }
       )
     })

--- a/packages/builder/src/components/common/ResizablePanel.svelte
+++ b/packages/builder/src/components/common/ResizablePanel.svelte
@@ -11,7 +11,7 @@
   export let position: "left" | "right" = "left"
   export let onResizeStart: () => void = () => {}
 
-  let width = defaultWidth
+  let width = minWidth
   let computedMaxWidth = defaultWidth
 
   const clampWidth = (value: number) =>
@@ -56,7 +56,7 @@
   }
 
   const [resizable, resizableHandle] = getHorizontalResizeActions(
-    defaultWidth,
+    minWidth,
     nextWidth => {
       if (!Number.isFinite(nextWidth)) {
         return
@@ -68,7 +68,8 @@
       }
     },
     onResizeStart,
-    position
+    position,
+    defaultWidth
   )
 
   onMount(() => {

--- a/packages/builder/src/components/common/ResizablePanel.test.ts
+++ b/packages/builder/src/components/common/ResizablePanel.test.ts
@@ -68,6 +68,30 @@ describe("ResizablePanel", () => {
     expect(localStorage.getItem("panel-width")).toBe("250")
   })
 
+  it("keeps double-click reset at the default width when the initial animation starts from min width", async () => {
+    localStorage.setItem("panel-width", "360")
+
+    const { container, getByRole } = render(ResizablePanel, {
+      storageKey: "panel-width",
+      defaultWidth: 480,
+      minWidth: 300,
+      maxWidthRatio: 0.6,
+    })
+
+    const panel = container.querySelector(".resizable-panel") as HTMLElement
+    const resizeHandle = getByRole("separator")
+
+    await waitFor(() => {
+      expect(panel).toHaveStyle("width: 360px")
+    })
+
+    await fireEvent.dblClick(resizeHandle)
+
+    await waitFor(() => {
+      expect(panel).toHaveStyle("width: 480px")
+    })
+  })
+
   it("recomputes max width on window resize and clamps current width", async () => {
     const { container } = render(ResizablePanel, {
       defaultWidth: 500,

--- a/packages/builder/src/components/common/resizable.ts
+++ b/packages/builder/src/components/common/resizable.ts
@@ -8,6 +8,7 @@ interface ResizeActionsConfig {
   clientDimension: "clientWidth" | "clientHeight"
   directionMultiplier?: 1 | -1
   initialValue?: number
+  resetValue?: number
   setValue?: (value: number) => void
   onResizeStart?: () => void
 }
@@ -18,6 +19,7 @@ const getResizeActions = ({
   clientDimension: elementProperty,
   directionMultiplier = 1,
   initialValue,
+  resetValue = initialValue,
   setValue = noop,
   onResizeStart = noop,
 }: ResizeActionsConfig) => {
@@ -124,7 +126,7 @@ const getResizeActions = ({
     const handleDoubleClick = () => {
       if (element) {
         element.style.removeProperty(elementDimension)
-        setValue(initialValue || 0)
+        setValue(resetValue || 0)
       }
     }
 
@@ -144,13 +146,15 @@ const getResizeActions = ({
 
 export const getVerticalResizeActions = (
   initialValue?: number,
-  setValue?: (value: number) => void
+  setValue?: (value: number) => void,
+  resetValue?: number
 ) => {
   return getResizeActions({
     elementDimension: "height",
     mouseCoordinate: "pageY",
     clientDimension: "clientHeight",
     initialValue,
+    resetValue,
     setValue,
   })
 }
@@ -159,7 +163,8 @@ export const getHorizontalResizeActions = (
   initialValue?: number,
   setValue?: (value: number) => void,
   onResizeStart?: () => void,
-  panelPosition: "left" | "right" = "left"
+  panelPosition: "left" | "right" = "left",
+  resetValue?: number
 ) => {
   return getResizeActions({
     elementDimension: "width",
@@ -167,6 +172,7 @@ export const getHorizontalResizeActions = (
     clientDimension: "clientWidth",
     directionMultiplier: panelPosition === "right" ? -1 : 1,
     initialValue,
+    resetValue,
     setValue,
     onResizeStart,
   })

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/[automationId]/_layout.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/[automationId]/_layout.svelte
@@ -15,6 +15,9 @@
   import AutomationLogsPanel from "@/components/automation/AutomationBuilder/FlowChart/AutomationLogsPanel.svelte"
   import type { AutomationLog } from "@budibase/types"
 
+  const SIDE_PANEL_STORAGE_KEY = "automation-side-panel-width"
+  const SIDE_PANEL_DEFAULT_WIDTH = 480
+
   const { goto, params, url, redirect, isActive, page, layout } = routify
   $goto
   $params
@@ -24,9 +27,17 @@
   $page
   $layout
 
+  let actionPanelContainer: HTMLDivElement | undefined
+  let observedActionPanel: HTMLDivElement | undefined
+  let actionPanelResizeObserver: ResizeObserver | undefined
+  let actionPanelWidth = 0
+
   $: automationId = $selectedAutomation?.data?._id
   $: blockRefs = $selectedAutomation.blockRefs
   $: selectedNodeId = $automationStore.selectedNodeId
+  $: actionPanelOpen =
+    !!$automationStore.actionPanelBlock && !$automationStore.selectedNodeId
+  $: syncActionPanelWidth(actionPanelOpen, actionPanelContainer)
   $: if (automationId) {
     builderStore.selectResource(automationId)
   }
@@ -43,12 +54,51 @@
 
   onDestroy(() => {
     stopSyncing?.()
+    actionPanelResizeObserver?.disconnect()
   })
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "Escape" && $automationStore.actionPanelBlock) {
       automationStore.actions.closeActionPanel()
     }
+  }
+
+  const getSidePanelWidth = () => {
+    const saved = localStorage.getItem(SIDE_PANEL_STORAGE_KEY)
+    const parsedWidth = saved ? parseInt(saved, 10) : SIDE_PANEL_DEFAULT_WIDTH
+    return Number.isFinite(parsedWidth) && parsedWidth > 0
+      ? parsedWidth
+      : SIDE_PANEL_DEFAULT_WIDTH
+  }
+
+  const syncActionPanelWidth = (
+    isOpen: boolean,
+    panel: HTMLDivElement | undefined
+  ) => {
+    if (!isOpen || !panel) {
+      actionPanelResizeObserver?.disconnect()
+      actionPanelResizeObserver = undefined
+      observedActionPanel = undefined
+      actionPanelWidth = 0
+      return
+    }
+
+    if (panel === observedActionPanel) {
+      return
+    }
+
+    actionPanelResizeObserver?.disconnect()
+    observedActionPanel = panel
+    actionPanelWidth = getPanelWidth(panel)
+    actionPanelResizeObserver = new ResizeObserver(() => {
+      actionPanelWidth = getPanelWidth(panel)
+    })
+    actionPanelResizeObserver.observe(panel)
+  }
+
+  const getPanelWidth = (panel: HTMLDivElement) => {
+    const width = panel.getBoundingClientRect().width
+    return width > 0 ? width : getSidePanelWidth()
   }
 </script>
 
@@ -63,7 +113,11 @@
     icon="path"
   />
   <div class="root">
-    <div class="content drawer-container">
+    <div
+      class="content drawer-container"
+      class:action-panel-open={actionPanelOpen}
+      style:--automation-action-panel-width={`${actionPanelWidth}px`}
+    >
       <slot />
     </div>
 
@@ -83,11 +137,13 @@
       </div>
     {/if}
 
-    {#if $automationStore.actionPanelBlock && !$automationStore.selectedNodeId}
-      <SelectStepSidePanel
-        block={$automationStore.actionPanelBlock}
-        onClose={() => automationStore.actions.closeActionPanel()}
-      />
+    {#if actionPanelOpen}
+      <div class="action-panel-container" bind:this={actionPanelContainer}>
+        <SelectStepSidePanel
+          block={$automationStore.actionPanelBlock}
+          onClose={() => automationStore.actions.closeActionPanel()}
+        />
+      </div>
     {/if}
 
     {#if $automationStore.showLogsPanel && $selectedAutomation?.data}
@@ -162,6 +218,11 @@
     overflow: auto;
     min-width: 0;
   }
+  .content.action-panel-open :global(.automation-heading) {
+    padding-right: calc(
+      var(--spacing-l) + var(--automation-action-panel-width)
+    );
+  }
   .step-panel-container {
     position: relative;
     z-index: 99;
@@ -170,6 +231,16 @@
     flex-direction: row;
     align-items: stretch;
     overflow: hidden;
+  }
+  .action-panel-container {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 99;
+    height: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
   }
   .step-panel {
     display: flex;

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/[automationId]/_layout.test.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/[automationId]/_layout.test.ts
@@ -2,6 +2,31 @@ import { render, waitFor } from "@testing-library/svelte"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import MockSlot from "@/test/mocks/MockSlot.svelte"
 
+interface BuilderStoreState {
+  isResizingPanel: boolean
+}
+
+interface AutomationStoreState {
+  actionPanelBlock?: { id: string }
+  automations: Array<{ _id: string }>
+  selectedNodeId?: string
+  selectedBranchNode?: { branchStepId: string }
+  showLogsPanel: boolean
+  showLogDetailsPanel: boolean
+  selectedLog?: { _id: string }
+}
+
+interface BlockRef {
+  pathTo: Array<{ stepIdx: number; id: string }>
+}
+
+interface SelectedAutomationState {
+  data: { _id: string; name: string }
+  blockRefs: Record<string, BlockRef>
+}
+
+type TestResizeObserverCallback = (entries: never[], observer: object) => void
+
 const mocks = vi.hoisted(() => {
   const store = <T>(initial: T) => {
     let value = initial
@@ -14,7 +39,9 @@ const mocks = vi.hoisted(() => {
       subscribe: (run: (value: T) => void) => {
         subscribers.add(run)
         run(value)
-        return () => subscribers.delete(run)
+        return () => {
+          subscribers.delete(run)
+        }
       },
       update: (updater: (value: T) => T) => {
         value = updater(value)
@@ -23,17 +50,17 @@ const mocks = vi.hoisted(() => {
     }
   }
 
-  const builderStore = store({ isResizingPanel: false })
-  const automationStore = store({
-    actionPanelBlock: undefined as unknown,
+  const builderStore = store<BuilderStoreState>({ isResizingPanel: false })
+  const automationStore = store<AutomationStoreState>({
+    actionPanelBlock: undefined,
     automations: [{ _id: "automation-1" }],
-    selectedNodeId: undefined as string | undefined,
-    selectedBranchNode: undefined as unknown,
+    selectedNodeId: undefined,
+    selectedBranchNode: undefined,
     showLogsPanel: false,
     showLogDetailsPanel: false,
-    selectedLog: undefined as unknown,
+    selectedLog: undefined,
   })
-  const selectedAutomation = store({
+  const selectedAutomation = store<SelectedAutomationState>({
     data: { _id: "automation-1", name: "Automation" },
     blockRefs: {},
   })
@@ -45,7 +72,7 @@ const mocks = vi.hoisted(() => {
     selectResource: vi.fn(),
     closeActionPanel: vi.fn(),
     select: vi.fn(),
-    resizeObserverCallback: undefined as ResizeObserverCallback | undefined,
+    resizeObserverCallback: undefined as TestResizeObserverCallback | undefined,
   }
 })
 
@@ -145,13 +172,13 @@ describe("Automation layout", () => {
     mocks.select.mockClear()
     mocks.resizeObserverCallback = undefined
     global.ResizeObserver = class {
-      constructor(callback: ResizeObserverCallback) {
+      constructor(callback: TestResizeObserverCallback) {
         mocks.resizeObserverCallback = callback
       }
       observe = vi.fn()
       unobserve = vi.fn()
       disconnect = vi.fn()
-    }
+    } as typeof globalThis.ResizeObserver
   })
 
   it("overlays the add-step panel and pushes automation header actions left", async () => {
@@ -173,9 +200,7 @@ describe("Automation layout", () => {
     ) as HTMLElement
 
     expect(actionPanel).toBeTruthy()
-    expect(container.querySelector(".content")).toHaveClass(
-      "action-panel-open"
-    )
+    expect(container.querySelector(".content")).toHaveClass("action-panel-open")
     await waitFor(() => {
       expect(
         (
@@ -184,11 +209,10 @@ describe("Automation layout", () => {
       ).toBe("520px")
     })
 
-    actionPanel.getBoundingClientRect = () =>
-      ({
-        width: 640,
-      }) as DOMRect
-    mocks.resizeObserverCallback?.([], {} as ResizeObserver)
+    const resizedRect = actionPanel.getBoundingClientRect()
+    Object.defineProperty(resizedRect, "width", { value: 640 })
+    actionPanel.getBoundingClientRect = () => resizedRect
+    mocks.resizeObserverCallback?.([], {})
 
     await waitFor(() => {
       expect(

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/[automationId]/_layout.test.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/[automationId]/_layout.test.ts
@@ -1,0 +1,225 @@
+import { render, waitFor } from "@testing-library/svelte"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import MockSlot from "@/test/mocks/MockSlot.svelte"
+
+const mocks = vi.hoisted(() => {
+  const store = <T>(initial: T) => {
+    let value = initial
+    const subscribers = new Set<(value: T) => void>()
+    return {
+      set: (next: T) => {
+        value = next
+        subscribers.forEach(run => run(value))
+      },
+      subscribe: (run: (value: T) => void) => {
+        subscribers.add(run)
+        run(value)
+        return () => subscribers.delete(run)
+      },
+      update: (updater: (value: T) => T) => {
+        value = updater(value)
+        subscribers.forEach(run => run(value))
+      },
+    }
+  }
+
+  const builderStore = store({ isResizingPanel: false })
+  const automationStore = store({
+    actionPanelBlock: undefined as unknown,
+    automations: [{ _id: "automation-1" }],
+    selectedNodeId: undefined as string | undefined,
+    selectedBranchNode: undefined as unknown,
+    showLogsPanel: false,
+    showLogDetailsPanel: false,
+    selectedLog: undefined as unknown,
+  })
+  const selectedAutomation = store({
+    data: { _id: "automation-1", name: "Automation" },
+    blockRefs: {},
+  })
+
+  return {
+    builderStore,
+    automationStore,
+    selectedAutomation,
+    selectResource: vi.fn(),
+    closeActionPanel: vi.fn(),
+    select: vi.fn(),
+    resizeObserverCallback: undefined as ResizeObserverCallback | undefined,
+  }
+})
+
+vi.mock("@roxi/routify", () => {
+  const routeStore = {
+    subscribe: (run: (value: undefined) => void) => {
+      run(undefined)
+      return () => {}
+    },
+  }
+  return {
+    goto: routeStore,
+    params: routeStore,
+    url: routeStore,
+    redirect: routeStore,
+    isActive: routeStore,
+    page: routeStore,
+    layout: routeStore,
+  }
+})
+
+vi.mock("@/helpers/urlStateSync", () => ({
+  syncURLToState: vi.fn(() => vi.fn()),
+}))
+
+vi.mock("@/stores/builder", () => ({
+  builderStore: {
+    subscribe: mocks.builderStore.subscribe,
+    selectResource: mocks.selectResource,
+  },
+  automationStore: {
+    subscribe: mocks.automationStore.subscribe,
+    actions: {
+      closeActionPanel: mocks.closeActionPanel,
+      select: mocks.select,
+    },
+  },
+  selectedAutomation: {
+    subscribe: mocks.selectedAutomation.subscribe,
+  },
+}))
+
+vi.mock("@/components/common/ResizablePanel.svelte", () => ({
+  default: MockSlot,
+}))
+
+vi.mock("@/components/automation/AutomationBuilder/StepPanel.svelte", () => ({
+  default: MockSlot,
+}))
+
+vi.mock(
+  "@/components/automation/AutomationBuilder/FlowChart/SelectStepSidePanel.svelte",
+  () => ({
+    default: MockSlot,
+  })
+)
+
+vi.mock("@/components/common/TopBar.svelte", () => ({
+  default: MockSlot,
+}))
+
+vi.mock(
+  "@/components/automation/AutomationBuilder/FlowChart/LogDetailsPanel.svelte",
+  () => ({
+    default: MockSlot,
+  })
+)
+
+vi.mock(
+  "@/components/automation/AutomationBuilder/FlowChart/AutomationLogsPanel.svelte",
+  () => ({
+    default: MockSlot,
+  })
+)
+
+import AutomationLayout from "./_layout.svelte"
+
+describe("Automation layout", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mocks.builderStore.set({ isResizingPanel: false })
+    mocks.automationStore.set({
+      actionPanelBlock: undefined,
+      automations: [{ _id: "automation-1" }],
+      selectedNodeId: undefined,
+      selectedBranchNode: undefined,
+      showLogsPanel: false,
+      showLogDetailsPanel: false,
+      selectedLog: undefined,
+    })
+    mocks.selectedAutomation.set({
+      data: { _id: "automation-1", name: "Automation" },
+      blockRefs: {},
+    })
+    mocks.selectResource.mockClear()
+    mocks.closeActionPanel.mockClear()
+    mocks.select.mockClear()
+    mocks.resizeObserverCallback = undefined
+    global.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        mocks.resizeObserverCallback = callback
+      }
+      observe = vi.fn()
+      unobserve = vi.fn()
+      disconnect = vi.fn()
+    }
+  })
+
+  it("overlays the add-step panel and pushes automation header actions left", async () => {
+    localStorage.setItem("automation-side-panel-width", "520")
+    mocks.automationStore.set({
+      actionPanelBlock: { id: "trigger" },
+      automations: [{ _id: "automation-1" }],
+      selectedNodeId: undefined,
+      selectedBranchNode: undefined,
+      showLogsPanel: false,
+      showLogDetailsPanel: false,
+      selectedLog: undefined,
+    })
+
+    const { container } = render(AutomationLayout)
+
+    const actionPanel = container.querySelector(
+      ".action-panel-container"
+    ) as HTMLElement
+
+    expect(actionPanel).toBeTruthy()
+    expect(container.querySelector(".content")).toHaveClass(
+      "action-panel-open"
+    )
+    await waitFor(() => {
+      expect(
+        (
+          container.querySelector(".content") as HTMLElement
+        ).style.getPropertyValue("--automation-action-panel-width")
+      ).toBe("520px")
+    })
+
+    actionPanel.getBoundingClientRect = () =>
+      ({
+        width: 640,
+      }) as DOMRect
+    mocks.resizeObserverCallback?.([], {} as ResizeObserver)
+
+    await waitFor(() => {
+      expect(
+        (
+          container.querySelector(".content") as HTMLElement
+        ).style.getPropertyValue("--automation-action-panel-width")
+      ).toBe("640px")
+    })
+    expect(container.querySelector(".step-panel-container")).toBeFalsy()
+  })
+
+  it("keeps the selected-step settings panel in the side column", () => {
+    mocks.automationStore.set({
+      actionPanelBlock: undefined,
+      automations: [{ _id: "automation-1" }],
+      selectedNodeId: "step-1",
+      selectedBranchNode: undefined,
+      showLogsPanel: false,
+      showLogDetailsPanel: false,
+      selectedLog: undefined,
+    })
+    mocks.selectedAutomation.set({
+      data: { _id: "automation-1", name: "Automation" },
+      blockRefs: {
+        "step-1": { pathTo: [{ stepIdx: 1, id: "step-1" }] },
+      },
+    })
+
+    const { container } = render(AutomationLayout)
+
+    expect(container.querySelector(".step-panel-container")).toBeTruthy()
+    expect(container.querySelector(".action-panel-container")).toBeFalsy()
+  })
+})


### PR DESCRIPTION
## Description
Fixes the automation side panel layout behavior and tightens the related `_layout.test.ts` mocks so they typecheck cleanly without relying on missing DOM globals.

## Launchcontrol
Fixes automation builder side panel layout behavior and keeps the related layout test type-safe.

