### PR TITLE
fix: only allow one agent tool-call popover at a time

### DIFF
--- a/packages/frontend-core/src/components/Chatbox/index.svelte
+++ b/packages/frontend-core/src/components/Chatbox/index.svelte
@@ -17,6 +17,7 @@
   import { createAPIClient } from "@budibase/frontend-core"
   import { Chat } from "@ai-sdk/svelte"
   import { formatToolName } from "../../utils/aiTools"
+  import { getNextActiveToolPopover, isToolPopoverOpen } from "./toolPopover"
   import ReasoningStatus from "./ReasoningStatus.svelte"
   import ContextUsage from "./ContextUsage.svelte"
   import {
@@ -74,6 +75,7 @@
   let chatAreaElement = $state<HTMLDivElement>()
   let textareaElement = $state<HTMLTextAreaElement>()
   let expandedTools = $state<Record<string, boolean>>({})
+  let activeToolId = $state<string | null>(null)
   let reasoningTextByMessageId = $state<Record<string, string>>({})
   let inputValue = $state("")
   let lastInitialPrompt = $state("")
@@ -346,6 +348,7 @@
       }
       chatInstance.messages = chat?.messages || []
       expandedTools = {}
+      activeToolId = null
       reasoningTextByMessageId = {}
     }
   })
@@ -526,7 +529,7 @@
   }
 
   const toggleTool = (toolId: string) => {
-    expandedTools = { ...expandedTools, [toolId]: !expandedTools[toolId] }
+    activeToolId = getNextActiveToolPopover(activeToolId, toolId)
   }
 
   const formatToolOutput = (output: unknown): string =>
@@ -676,13 +679,16 @@
                 <div class="tool-part" class:tool-running={isRunning}>
                   <button
                     class="tool-header"
-                    class:tool-header-expanded={expandedTools[toolId]}
+                    class:tool-header-expanded={isToolPopoverOpen(
+                      activeToolId,
+                      toolId
+                    )}
                     type="button"
                     onclick={() => toggleTool(toolId)}
                   >
                     <span
                       class="tool-chevron"
-                      class:expanded={expandedTools[toolId]}
+                      class:expanded={isToolPopoverOpen(activeToolId, toolId)}
                     >
                       <span class="tool-chevron-icon tool-chevron-icon-default">
                         <Icon
@@ -729,7 +735,7 @@
                       </span>
                     {/if}
                   </button>
-                  {#if expandedTools[toolId]}
+                  {#if isToolPopoverOpen(activeToolId, toolId)}
                     <div class="tool-details">
                       {#if part.input}
                         <div class="tool-section">
@@ -1173,9 +1179,6 @@
   }
 
   .tool-details {
-    position: absolute;
-    top: 100%;
-    left: 0;
     margin-top: var(--spacing-m);
     width: 100%;
     max-width: 100%;
@@ -1188,7 +1191,6 @@
     border-radius: 6px;
     padding: var(--spacing-m);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-    z-index: 1;
     overflow-x: hidden;
     min-width: 0;
   }

--- a/packages/frontend-core/src/components/Chatbox/toolPopover.test.ts
+++ b/packages/frontend-core/src/components/Chatbox/toolPopover.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import { getNextActiveToolPopover, isToolPopoverOpen } from "./toolPopover"
+
+describe("tool-call popover active state", () => {
+  it("opens tool A when no popover is open", () => {
+    const active = getNextActiveToolPopover(null, "A")
+    expect(active).toBe("A")
+    expect(isToolPopoverOpen(active, "A")).toBe(true)
+  })
+
+  it("closes A automatically when B is opened", () => {
+    let active = getNextActiveToolPopover(null, "A")
+    active = getNextActiveToolPopover(active, "B")
+    expect(active).toBe("B")
+    expect(isToolPopoverOpen(active, "A")).toBe(false)
+    expect(isToolPopoverOpen(active, "B")).toBe(true)
+  })
+
+  it("leaves no popover open when A is toggled closed", () => {
+    let active = getNextActiveToolPopover(null, "A")
+    active = getNextActiveToolPopover(active, "A")
+    expect(active).toBeNull()
+    expect(isToolPopoverOpen(active, "A")).toBe(false)
+  })
+
+  it("keeps only the last opened popover open across A, B and C", () => {
+    let active: string | null = null
+    for (const id of ["A", "B", "C"]) {
+      active = getNextActiveToolPopover(active, id)
+    }
+    expect(active).toBe("C")
+    expect(isToolPopoverOpen(active, "A")).toBe(false)
+    expect(isToolPopoverOpen(active, "B")).toBe(false)
+    expect(isToolPopoverOpen(active, "C")).toBe(true)
+  })
+
+  it("renders content only for the active popover", () => {
+    const active = getNextActiveToolPopover(null, "A")
+    expect(isToolPopoverOpen(active, "A")).toBe(true)
+    expect(isToolPopoverOpen(active, "B")).toBe(false)
+  })
+})

--- a/packages/frontend-core/src/components/Chatbox/toolPopover.ts
+++ b/packages/frontend-core/src/components/Chatbox/toolPopover.ts
@@ -1,0 +1,10 @@
+// Only one tool-call popover may be open at a time.
+export const getNextActiveToolPopover = (
+  activeToolId: string | null,
+  toolId: string
+): string | null => (activeToolId === toolId ? null : toolId)
+
+export const isToolPopoverOpen = (
+  activeToolId: string | null,
+  toolId: string
+): boolean => activeToolId === toolId


### PR DESCRIPTION
## Description

Agent tool-call popovers in the chat UI could be opened simultaneously, resulting in multiple overlapping panels.

### Root Cause

Tool-call open/close state was stored in a shared `expandedTools` map, and `toggleTool` only updated the state of the clicked tool. As a result, opening a second or third tool call left previously opened popovers visible.

Additionally, the tool-call details panel was rendered as a floating overlay (`position: absolute; top: 100%`), causing expanded panels to overlap subsequent tool-call rows. Multiple open panels could obscure content and make close controls difficult to access.

### Fix

This change introduces a single `activeToolId` to ensure that only one tool-call popover can be open at a time.

Behavior after the fix:

* Opening a tool call expands its details panel.
* Opening a different tool call automatically closes the previously open panel.
* Clicking an already open tool call closes it.
* The existing reasoning/thinking expander behavior remains unchanged.

The tool-call details panel has also been changed from an overlay to an inline expansion, allowing it to push subsequent rows downward instead of covering them.

## Addresses

* https://github.com/Budibase/budibase/issues/18694

## App Export

N/A – frontend-only UI change.

To reproduce:

1. Open an agent chat containing two or more tool calls.
2. Expand multiple tool calls.

Before this fix, multiple popovers remain open and overlap each other.

After this fix, only one tool-call popover can be open at a time and panels expand inline without obscuring other rows.

## Screenshots

### Before


https://github.com/user-attachments/assets/8e8e433e-f2eb-476c-8aea-f6e79e2c94ab



## Launchcontrol

Fixed the AI agent chat so that tool-call details now open one at a time and expand inline instead of overlapping. This prevents popovers from hiding other tool calls and keeps all rows accessible while browsing agent activity.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

