### PR TITLE
[BUDI-18953] Grace period UI: locked modal with removal notice and export

### DIFF
--- a/packages/builder/src/components/portal/licensing/AccountLockedModal.svelte
+++ b/packages/builder/src/components/portal/licensing/AccountLockedModal.svelte
@@ -1,11 +1,27 @@
 <script lang="ts">
-  import { Modal, ModalContent, Body } from "@budibase/bbui"
+  import {
+    Modal,
+    ModalContent,
+    Body,
+    Button,
+    Detail,
+    Link,
+  } from "@budibase/bbui"
   import { LockReason } from "@budibase/types"
+  import ExportAppModal from "@/components/start/ExportAppModal.svelte"
+
+  const ONE_DAY_MS = 86400000
+  const SELF_HOST_DOCS_URL =
+    "https://docs.budibase.com/docs/hosting-methods#self-host-budibase"
 
   let modal: Modal
+  let exportModal: Modal
 
   export let lockedBy: LockReason | undefined
+  export let deactivationScheduledAt: string | undefined = undefined
   export let onConfirm: () => void
+  export let isOwner = true
+  export let appId: string | undefined = undefined
 
   export function show() {
     modal.show()
@@ -14,36 +30,172 @@
   export function hide() {
     modal.hide()
   }
+
+  function handleExport() {
+    exportModal.show()
+  }
+
+  $: isGracePeriodLock =
+    lockedBy === LockReason.FREE_TIER ||
+    lockedBy === LockReason.MIGRATION ||
+    lockedBy === LockReason.PAID_TO_FREE
+
+  $: modalTitle =
+    lockedBy === LockReason.FREE_TIER
+      ? "Your trial has ended"
+      : "Your tenant is currently de-activated"
+
+  $: scheduledDate = deactivationScheduledAt
+    ? new Date(deactivationScheduledAt)
+    : null
+
+  $: showRemovalNotice =
+    scheduledDate != null && !Number.isNaN(scheduledDate.getTime())
+
+  $: formattedDeactivationDate = showRemovalNotice
+    ? new Intl.DateTimeFormat("en-GB", {
+        weekday: "long",
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+      }).format(scheduledDate!)
+    : ""
+
+  $: daysRemaining = showRemovalNotice
+    ? Math.max(
+        0,
+        Math.ceil((scheduledDate!.getTime() - Date.now()) / ONE_DAY_MS)
+      )
+    : 0
+
+  $: removalNoticeMessage = showRemovalNotice
+    ? `Your data will be removed on ${formattedDeactivationDate} (${daysRemaining} day${daysRemaining === 1 ? "" : "s"} remaining).`
+    : ""
+
 </script>
 
 <Modal bind:this={modal}>
-  <ModalContent
-    title="Your tenant is currently de-activated"
-    size="S"
-    showCancelButton={false}
-    showCloseIcon={true}
-    confirmText={"View plans"}
-    {onConfirm}
-  >
-    <Body size="S">
-      {#if lockedBy === LockReason.MIGRATION}
-        You’re currently on the Budibase Free plan, which is no longer available
-        for cloud users. Your tenant has been temporarily locked. Upgrade to
-        keep building in the cloud, export your workspaces, or move to
-        self-hosted Budibase before your data is removed.
-      {:else if lockedBy === LockReason.PAID_TO_FREE}
-        Your paid Budibase subscription has expired and was not renewed. Your
-        tenant is now in a locked, limited-access state. Upgrade to keep
-        building in the cloud, export your workspaces, or move to self-hosted
-        Budibase before your data is removed.
-      {:else if lockedBy === LockReason.FREE_TIER}
-        Your Budibase Cloud trial has ended and your tenant is temporarily
-        locked. Upgrade to keep building in the cloud, export your workspaces,
-        or move to self-hosted Budibase before your data is removed.
-      {:else}
+  {#if isGracePeriodLock}
+    <ModalContent
+      title={modalTitle}
+      size="S"
+      showCancelButton={false}
+      showConfirmButton={false}
+      showCloseIcon={true}
+    >
+      <div class="locked-modal-content">
+        <Body size="S">
+          {#if lockedBy === LockReason.MIGRATION}
+            You’re currently on the Budibase Free plan, which is no longer
+            available for cloud users. Your tenant has been temporarily locked.
+            Upgrade to keep building in the cloud, export your workspaces, or
+            move to self-hosted Budibase before your data is removed.
+          {:else if lockedBy === LockReason.PAID_TO_FREE}
+            Your paid Budibase subscription has expired and was not renewed.
+            Your tenant is now in a locked, limited-access state. Upgrade to
+            keep building in the cloud, export your workspaces, or move to
+            self-hosted Budibase before your data is removed.
+          {:else}
+            Your Budibase Cloud trial has ended and your tenant is temporarily
+            locked. Upgrade to keep building in the cloud, export your
+            workspaces, or move to self-hosted Budibase before your data is
+            removed.
+          {/if}
+        </Body>
+
+        {#if showRemovalNotice}
+          <div class="removal-notice">
+            <Detail size="S" weight={600}>Data scheduled for removal</Detail>
+            <Body size="S">{removalNoticeMessage}</Body>
+          </div>
+
+          <Detail size="S" weight={600}>
+            You can still export your workspaces during this period.
+          </Detail>
+        {/if}
+      </div>
+
+      <div class="locked-modal-actions" slot="footer">
+        <Button cta on:click={onConfirm}>
+          {isOwner ? "Upgrade plan" : "View plans"}
+        </Button>
+        <Button secondary on:click={handleExport}>Export workspace</Button>
+        <Link
+          href={SELF_HOST_DOCS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Self-host Budibase
+        </Link>
+      </div>
+    </ModalContent>
+  {:else}
+    <ModalContent
+      title="Your tenant is currently de-activated"
+      size="S"
+      showCancelButton={false}
+      showCloseIcon={true}
+      confirmText="View plans"
+      {onConfirm}
+    >
+      <Body size="S">
         Due to the Free plan user limit being exceeded, your tenant has been
         de-activated. Upgrade your plan to re-activate your tenant.
-      {/if}
-    </Body>
-  </ModalContent>
+      </Body>
+    </ModalContent>
+  {/if}
 </Modal>
+
+{#if appId}
+  <Modal bind:this={exportModal}>
+    <ExportAppModal {appId} published={false} />
+  </Modal>
+{/if}
+
+<style>
+  .locked-modal-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-l);
+  }
+
+  .removal-notice {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-s);
+    padding: var(--spacing-m);
+    border: 1px solid var(--spectrum-global-color-gray-300);
+    border-radius: 8px;
+    background: var(--spectrum-global-color-gray-75);
+  }
+
+  .removal-notice :global(.spectrum-Detail) {
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--spectrum-global-color-gray-700);
+  }
+
+  .locked-modal-content :global(.spectrum-Detail) {
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--spectrum-global-color-gray-700);
+  }
+
+  .locked-modal-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--spacing-m);
+    width: 100%;
+  }
+
+  .locked-modal-actions :global(.spectrum-Button) {
+    width: 100%;
+    margin: 0;
+  }
+
+  .locked-modal-actions :global(a) {
+    align-self: center;
+    margin-top: var(--spacing-xs);
+  }
+</style>

--- a/packages/builder/src/components/portal/licensing/AccountLockedModal.svelte
+++ b/packages/builder/src/components/portal/licensing/AccountLockedModal.svelte
@@ -118,7 +118,9 @@
         <Button cta on:click={onConfirm}>
           {isOwner ? "Upgrade plan" : "View plans"}
         </Button>
-        <Button secondary on:click={handleExport}>Export workspace</Button>
+        {#if appId}
+          <Button secondary on:click={handleExport}>Export workspace</Button>
+        {/if}
         <Link
           href={SELF_HOST_DOCS_URL}
           target="_blank"

--- a/packages/builder/src/components/portal/licensing/AccountLockedModal.svelte
+++ b/packages/builder/src/components/portal/licensing/AccountLockedModal.svelte
@@ -71,7 +71,6 @@
   $: removalNoticeMessage = showRemovalNotice
     ? `Your data will be removed on ${formattedDeactivationDate} (${daysRemaining} day${daysRemaining === 1 ? "" : "s"} remaining).`
     : ""
-
 </script>
 
 <Modal bind:this={modal}>

--- a/packages/builder/src/pages/builder/_layout.svelte
+++ b/packages/builder/src/pages/builder/_layout.svelte
@@ -329,6 +329,9 @@
 <AccountLockedModal
   bind:this={accountLockedModal}
   lockedBy={$auth.user?.lockedBy}
+  deactivationScheduledAt={$auth.user?.deactivationScheduledAt}
+  appId={$enrichedApps.find(app => app.editable)?.devId}
+  {isOwner}
   onConfirm={() =>
     isOwner ? licensing.goToUpgradePage() : licensing.goToPricingPage()}
 />


### PR DESCRIPTION
## Description

Updates `AccountLockedModal` to support the 28-day grace period feature. When a tenant is locked due to a grace period reason (free tier trial end, migration, or paid-to-free), the modal now shows tailored messaging, a data removal notice with the scheduled deletion date and a days-remaining countdown, and an inline export flow instead of redirecting to the workspaces page.

## Addresses
- https://github.com/Budibase/budibase/issues/18953

## Screenshots

<img width="472" height="600" alt="Screenshot 2026-06-22 at 08 42 48" src="https://github.com/user-attachments/assets/97c19323-43d9-40a4-bc76-e18b7ddb27fa" />

## Launchcontrol

When a cloud tenant enters the grace period, the account locked modal now displays the scheduled data removal date, a days-remaining countdown, and a direct export button that opens the workspace export flow — giving users a clear path to upgrade, export, or self-host before their data is deleted.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

