### PR TITLE
Add QA bot Slack notification workflow

### DIFF
--- a/.github/workflows/qa-bot-lgtm-slack.yml
+++ b/.github/workflows/qa-bot-lgtm-slack.yml
@@ -1,0 +1,27 @@
+name: QA bot LGTM Slack notification
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  notify-slack:
+    if: github.event.label.name == 'qa-bot-lgtm'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_COMMUNITY_PR_WEBHOOK_URL }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          payload=$(jq -n \
+            --arg text "QA bot found no issues with PR #${PR_NUMBER}: ${PR_TITLE}. It is good for human review: ${PR_URL}" \
+            '{text: $text}')
+
+          curl --fail --show-error --silent \
+            --request POST \
+            --header "Content-type: application/json" \
+            --data "$payload" \
+            "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## Description
Adds a GitHub Actions workflow that posts to the community PR Slack webhook when the `qa-bot-lgtm` label is added to a pull request. The Slack message includes the PR link and indicates that the QA bot found no issues and the PR is good for human review.


## Launchcontrol
Adds an automated Slack notification when QA bot approves a pull request for human review.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

