### PR TITLE
Make closed side panel inert so Tab can't reveal it

### DIFF
--- a/packages/client/src/components/app/Layout.svelte
+++ b/packages/client/src/components/app/Layout.svelte
@@ -576,6 +576,7 @@
     class={"size--" + ($sidePanelStore.size || "small")}
     class:position--left={sidePanelPosition === "left"}
     class:position--right={sidePanelPosition !== "left"}
+    inert={$sidePanelStore.open ? undefined : true}
   >
     <div class="side-panel-header" class:left={sidePanelPosition === "left"}>
       <button


### PR DESCRIPTION
## Description

`#side-panel-container` in `Layout.svelte` (with its close button) is always rendered, even when an app uses no Side Panel. When closed it's only moved off-screen via `transform: translateX(100%)`, so the close button stays in the tab order — pressing <kbd>Tab</kbd> focuses it and the browser scrolls the empty panel into view.

Fix: mark the container `inert` while closed, removing it from the tab order and a11y tree. No effect on the open panel or its animation.

```svelte
<div id="side-panel-container" ... inert={$sidePanelStore.open ? undefined : true}>
```

## Addresses
- No tracked issue

## Screenshots
<img width="1258" height="1035" alt="image" src="https://github.com/user-attachments/assets/15159773-4360-4b80-94c8-6519366b86e6" />


## Launchcontrol
Stops an empty side panel from unexpectedly sliding into view when pressing Tab repeatedly in an app.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

