### PR TITLE
feat: Allow Filtering Table Data Using State Variables (Before Data Is Saved)

### DIFF
--- a/packages/frontend-core/src/fetch/RelationshipFetch.test.ts
+++ b/packages/frontend-core/src/fetch/RelationshipFetch.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest"
+import { RelationshipDatasource, Table } from "@budibase/types"
+import RelationshipFetch from "./RelationshipFetch"
+import { APIClient } from "../api/types"
+
+describe("RelationshipFetch fallback behavior", () => {
+  const mockDatasource: RelationshipDatasource = {
+    type: "link",
+    tableId: "relatedTableId",
+    rowId: "temp-uuid-123",
+    rowTableId: "parentTableId",
+    fieldName: "parentLinkField",
+  }
+
+  const mockParentTableDefinition: Table = {
+    _id: "relatedTableId",
+    name: "relatedTable",
+    type: "table",
+    primaryDisplay: "name",
+    schema: {
+      childLinkField: {
+        type: "link",
+        tableId: "parentTableId",
+        fieldName: "parentLinkField",
+        name: "childLinkField",
+      },
+      name: {
+        type: "string",
+        name: "name",
+      },
+    },
+  } as unknown as Table
+
+  it("returns rows directly from fetchRelationshipData on success", async () => {
+    const mockAPI = {
+      fetchRelationshipData: vi.fn().mockResolvedValue([{ _id: "row1" }]),
+      fetchTableDefinition: vi.fn(),
+      searchTable: vi.fn(),
+    } as unknown as APIClient
+
+    const fetch = new RelationshipFetch({
+      API: mockAPI,
+      datasource: mockDatasource,
+      query: {},
+    })
+
+    const result = await fetch.getData()
+    expect(mockAPI.fetchRelationshipData).toHaveBeenCalledWith(
+      "parentTableId",
+      "temp-uuid-123",
+      "parentLinkField"
+    )
+    expect(result).toEqual({ rows: [{ _id: "row1" }] })
+    expect(mockAPI.searchTable).not.toHaveBeenCalled()
+  })
+
+  it("falls back to searchTable when fetchRelationshipData fails", async () => {
+    const mockAPI = {
+      fetchRelationshipData: vi.fn().mockRejectedValue(new Error("Row not found")),
+      fetchTableDefinition: vi.fn().mockResolvedValue(mockParentTableDefinition),
+      searchTable: vi.fn().mockResolvedValue({ rows: [{ _id: "row2" }] }),
+    } as unknown as APIClient
+
+    const fetch = new RelationshipFetch({
+      API: mockAPI,
+      datasource: mockDatasource,
+      query: {},
+    })
+
+    const result = await fetch.getData()
+    expect(mockAPI.fetchRelationshipData).toHaveBeenCalled()
+    expect(mockAPI.fetchTableDefinition).toHaveBeenCalledWith("relatedTableId")
+    expect(mockAPI.searchTable).toHaveBeenCalledWith("relatedTableId", {
+      query: {
+        equal: {
+          childLinkField: "temp-uuid-123",
+        },
+      },
+    })
+    expect(result).toEqual({ rows: [{ _id: "row2" }] })
+  })
+})

--- a/packages/frontend-core/src/fetch/RelationshipFetch.test.ts
+++ b/packages/frontend-core/src/fetch/RelationshipFetch.test.ts
@@ -57,8 +57,12 @@ describe("RelationshipFetch fallback behavior", () => {
 
   it("falls back to searchTable when fetchRelationshipData fails", async () => {
     const mockAPI = {
-      fetchRelationshipData: vi.fn().mockRejectedValue(new Error("Row not found")),
-      fetchTableDefinition: vi.fn().mockResolvedValue(mockParentTableDefinition),
+      fetchRelationshipData: vi
+        .fn()
+        .mockRejectedValue(new Error("Row not found")),
+      fetchTableDefinition: vi
+        .fn()
+        .mockResolvedValue(mockParentTableDefinition),
       searchTable: vi.fn().mockResolvedValue({ rows: [{ _id: "row2" }] }),
     } as unknown as APIClient
 

--- a/packages/frontend-core/src/fetch/RelationshipFetch.ts
+++ b/packages/frontend-core/src/fetch/RelationshipFetch.ts
@@ -35,6 +35,35 @@ export default class RelationshipFetch extends BaseDataFetch<
       )
       return { rows: res }
     } catch (error) {
+      try {
+        const definition = await this.getDefinition()
+        const schema = definition?.schema
+        let relatedFieldName: string | undefined
+        if (schema) {
+          for (const [key, fieldSchema] of Object.entries(schema)) {
+            if (
+              fieldSchema.type === "link" &&
+              fieldSchema.tableId === datasource.rowTableId &&
+              fieldSchema.fieldName === datasource.fieldName
+            ) {
+              relatedFieldName = key
+              break
+            }
+          }
+        }
+        if (relatedFieldName) {
+          const res = await this.API.searchTable(datasource.tableId, {
+            query: {
+              equal: {
+                [relatedFieldName]: datasource.rowId,
+              },
+            },
+          })
+          return { rows: res?.rows || [] }
+        }
+      } catch (fallbackError) {
+        // Ignore fallback error
+      }
       return { rows: [] }
     }
   }


### PR DESCRIPTION
## Description
Allows relationship (`link`) table components to dynamically filter and display related child records even when the primary (parent) record has not yet been saved to the database.

### Changes
- **Frontend Core (`RelationshipFetch.ts`)**: Added fallback search logic. If the standard `API.fetchRelationshipData` endpoint fails (which occurs when the parent row ID does not yet exist in the database), the client falls back to querying the related table directly via `API.searchTable`. It resolves the relationship's key from the related table's schema and matches it against the parent's unsaved `rowId` / UUID (e.g. stored in a state variable).
- **Unit Tests (`RelationshipFetch.test.ts`)**: Added a test suite using Vitest/jsdom to verify both the default API lookup and the fallback query mechanisms.


## Addresses
- #18843 

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._

## Launchcontrol

Allows table components displaying related rows to update and show linked records in real time even when the parent form has not yet been submitted or saved to the database.

Closes: #18843 


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

