### PR TITLE
feat: Allow Filtering Table Data Using State Variables (Before Data Is Saved)

### DIFF
--- a/packages/backend-core/src/sql/sql.ts
+++ b/packages/backend-core/src/sql/sql.ts
@@ -627,7 +627,33 @@ class InternalBuilder {
             subQuery = this.addJoinFieldCheck(subQuery, manyToMany)
           }
 
-          if (isBareRelationshipFilter && operation === BasicOperator.EMPTY) {
+          if (
+            isBareRelationshipFilter &&
+            operation !== BasicOperator.EMPTY &&
+            operation !== BasicOperator.NOT_EMPTY
+          ) {
+            const throughAlias =
+              aliases?.[manyToMany.through] || relationship.through
+            let throughTable = this.tableNameWithSchema(manyToMany.through, {
+              alias: throughAlias,
+              schema,
+            })
+            const fromKey = `${throughAlias}.${manyToMany.from}`
+            const mainKey = `${fromAlias}.${manyToMany.fromPrimary}`
+            let subQuery = this.knex
+              .select(this.knex.raw(1))
+              .from(throughTable)
+              .where(fromKey, "=", this.rawQuotedIdentifier(mainKey))
+            if (this.client === SqlClient.SQL_LITE) {
+              subQuery = this.addJoinFieldCheck(subQuery, manyToMany)
+            }
+            query = query.whereExists(
+              whereCb(`${throughAlias}.${manyToMany.to}`, subQuery)
+            )
+          } else if (
+            isBareRelationshipFilter &&
+            operation === BasicOperator.EMPTY
+          ) {
             query = query.whereNotExists(subQuery)
           } else if (
             isBareRelationshipFilter &&
@@ -660,7 +686,16 @@ class InternalBuilder {
             this.rawQuotedIdentifier(foreignKey)
           )
 
-          if (isBareRelationshipFilter && operation === BasicOperator.EMPTY) {
+          if (
+            isBareRelationshipFilter &&
+            operation !== BasicOperator.EMPTY &&
+            operation !== BasicOperator.NOT_EMPTY
+          ) {
+            query = whereCb(`${fromAlias}.${relationship.from}`, query)
+          } else if (
+            isBareRelationshipFilter &&
+            operation === BasicOperator.EMPTY
+          ) {
             query = query.whereNotExists(subQuery)
           } else if (
             isBareRelationshipFilter &&

--- a/packages/backend-core/src/sql/tests/filters.spec.ts
+++ b/packages/backend-core/src/sql/tests/filters.spec.ts
@@ -328,4 +328,75 @@ describe("SQL filter parameterization", () => {
     expect(result.sql.toLowerCase()).toContain('"kind" is null')
     expect(result.bindings).toEqual(expect.arrayContaining(["a", "b"]))
   })
+
+  it("builds bare relationship equal filter without junction table directly on foreign key", () => {
+    const table = buildTable({
+      rel: {
+        name: "rel",
+        type: FieldType.LINK,
+        constraints: baseConstraints,
+        fieldName: "rel",
+        tableId: "relTableId",
+        relationshipType: RelationshipType.MANY_TO_ONE,
+      },
+    })
+    const query = buildQuery(table, {
+      equal: { rel: "temp-uuid-123" },
+    })
+    const relTable = buildTable({})
+    relTable.name = "relTable"
+    relTable._id = "relTableId"
+    query.tables = { ...query.tables, relTable }
+    query.relationships = [
+      {
+        tableName: "relTable",
+        column: "rel",
+        from: "rel",
+        to: "id",
+      },
+    ]
+
+    const result = new Sql(SqlClient.POSTGRES)._query(query) as SqlQuery
+
+    expect(result.sql.toLowerCase()).toContain('"tbl"."rel" = $1')
+    expect(result.bindings).toEqual(["temp-uuid-123", 25])
+  })
+
+  it("builds bare relationship equal filter with junction table directly on junction table", () => {
+    const table = buildTable({
+      rel: {
+        name: "rel",
+        type: FieldType.LINK,
+        constraints: baseConstraints,
+        fieldName: "rel",
+        tableId: "relTableId",
+        relationshipType: RelationshipType.MANY_TO_MANY,
+      },
+    })
+    const query = buildQuery(table, {
+      equal: { rel: "temp-uuid-123" },
+    })
+    const relTable = buildTable({})
+    relTable.name = "relTable"
+    relTable._id = "relTableId"
+    query.tables = { ...query.tables, relTable }
+    query.relationships = [
+      {
+        tableName: "relTable",
+        column: "rel",
+        through: "tbl_relTable",
+        from: "tbl_id",
+        to: "relTable_id",
+        fromPrimary: "id",
+        toPrimary: "id",
+      },
+    ]
+
+    const result = new Sql(SqlClient.POSTGRES)._query(query) as SqlQuery
+
+    expect(result.sql.toLowerCase()).toContain(
+      'exists (select 1 from "tbl_reltable" as "tbl_reltable" where "tbl_reltable"."tbl_id" = "tbl"."id" and (coalesce("tbl_reltable"."reltable_id" = $1, false)))'
+    )
+    expect(result.bindings).toEqual(["temp-uuid-123", 25])
+  })
 })

--- a/packages/frontend-core/src/components/FilterField.svelte
+++ b/packages/frontend-core/src/components/FilterField.svelte
@@ -189,7 +189,7 @@
               value={readableValue}
               on:change={onChange}
             />
-          {:else if [FieldType.STRING, FieldType.LONGFORM, FieldType.NUMBER, FieldType.BIGINT, FieldType.FORMULA, FieldType.AI, FieldType.BARCODEQR].includes(filter.type)}
+          {:else if [FieldType.STRING, FieldType.LONGFORM, FieldType.NUMBER, FieldType.BIGINT, FieldType.FORMULA, FieldType.AI, FieldType.BARCODEQR, FieldType.LINK].includes(filter.type)}
             <Input
               disabled={filter.noValue}
               value={readableValue}

--- a/packages/server/src/db/linkedRows/LinkController.ts
+++ b/packages/server/src/db/linkedRows/LinkController.ts
@@ -241,13 +241,11 @@ class LinkController {
           }
 
           if (linkId && linkId !== "" && linkDocIds.indexOf(linkId) === -1) {
-            // first check the doc we're linking to exists
-            try {
-              await this._db.get(linkId)
-            } catch (err) {
-              // skip links that don't exist
-              continue
-            }
+            // Allow creating links even when the target document doesn't exist yet.
+            // This supports workflows where a child record (e.g. Employee) must be
+            // linked to a parent UUID from state before the parent (e.g. Company)
+            // has been saved — enabling real-time filtering of child records by that
+            // UUID. See: https://github.com/Budibase/budibase/issues/18843
             operations.push(
               new LinkDocument(
                 table._id!,

--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -119,7 +119,7 @@ export const getValidOperatorsForType = (
   } else if (type === FieldType.BARCODEQR) {
     ops = stringOps
   } else if (type === FieldType.LINK) {
-    ops = [Op.Empty, Op.NotEmpty]
+    ops = [Op.Equals, Op.NotEquals, Op.Empty, Op.NotEmpty]
   }
 
   // Only allow equal/not equal for _id in SQL tables


### PR DESCRIPTION

## Description
Enables table components to filter by relationship (link) columns using any state variable binding including temporary UUIDs, session values, URL parameters, or unsaved form fields even before the parent record has been saved to the database.

This unlocks real-time parent -> child workflows where child records are created and displayed inside a parent form before the parent form is submitted.

### Changes
- **`packages/shared-core/src/filters.ts`**: Added Equals and `NotEquals `to the valid operator set for `FieldType`.LINK columns. Previously only `isEmpty/isNotEmpty` were available, making value-based filtering of relationship fields impossible in the UI.
- **`packages/frontend-core/src/components/FilterField.svelte`**: Extended the text `<Input> `control to render for `FieldType.LINK` when the operator is Equals or `NotEquals`. This allows builders to bind any state expression (e.g. `{{ state.session_id }}`) as the filter value for a relationship column.
- **Backend SQL Builder (`packages/backend-core/src/sql/sql.ts`)**: Updated `addRelationshipForFilter` to directly query junction tables or foreign keys for relationship filter parameters when executing value-based filters (such as `equal` or `notEqual`), bypassing the need to search the related table first.
- **Backend Tests (`packages/backend-core/src/sql/tests/filters.spec.ts`)**: Added unit tests to cover both direct foreign key queries (many-to-one) and junction table queries (many-to-many) for relationship filtering.
-` **packages/server/src/db/linkedRows/LinkController.ts**`: Removed the` this._db.get(linkId)` existence check in `rowSaved()`. Previously, attempting to link a child record to a parent ID that didn't yet exist in the database caused the link to be silently dropped, meaning the junction table entry was never created and no filter could match. Removing this guard allows the LinkDocument to be created immediately, enabling the SQS junction table to record the association and the filter query to resolve correctly.


## Addresses
- #18843

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._

## Launchcontrol

Allows table components to be dynamically filtered using state variables (like temporary UUIDs) before parent form records are saved.

Closes: #18843 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

