### PR TITLE
feat: expose view record counts to agents via get_table

### DIFF
--- a/packages/server/src/ai/tools/budibase/tables.ts
+++ b/packages/server/src/ai/tools/budibase/tables.ts
@@ -1,8 +1,45 @@
-import { ToolType } from "@budibase/types"
+import { ToolType, View, ViewV2 } from "@budibase/types"
 import { tool } from "ai"
 import { z } from "zod"
+import { helpers } from "@budibase/shared-core"
 import sdk from "../../../sdk"
 import type { BudibaseToolDefinition } from "."
+
+type ViewV2WithRowCount = ViewV2 & { rowCount?: number }
+
+const getViewRowCount = async (view: ViewV2): Promise<number> => {
+  const result = await sdk.rows.search({
+    tableId: view.tableId,
+    viewId: view.id,
+    query: {},
+    countRows: true,
+    limit: 1,
+  })
+  return result.totalRows ?? 0
+}
+
+const enrichViewsWithRowCounts = async (
+  views: Record<string, View | ViewV2> | undefined
+): Promise<Record<string, View | ViewV2WithRowCount> | undefined> => {
+  if (!views) {
+    return views
+  }
+  const entries = await Promise.all(
+    Object.entries(views).map(async ([name, view]) => {
+      if (!helpers.views.isV2(view)) {
+        return [name, view] as const
+      }
+      try {
+        const rowCount = await getViewRowCount(view)
+        return [name, { ...view, rowCount }] as const
+      } catch {
+        // A single failing view count must not break table inspection
+        return [name, { ...view, rowCount: undefined }] as const
+      }
+    })
+  )
+  return Object.fromEntries(entries)
+}
 
 const TABLE_TOOLS: BudibaseToolDefinition[] = [
   {
@@ -41,16 +78,21 @@ const TABLE_TOOLS: BudibaseToolDefinition[] = [
     name: "get_table",
     sourceType: ToolType.INTERNAL_TABLE,
     sourceLabel: "Budibase",
-    description: "Get details about a specific table by ID",
+    description:
+      "Get details about a specific table by ID, including its views and the " +
+      "current record count (rowCount) of each view",
     tool: tool({
-      description: "Get details about a specific table by ID",
+      description:
+        "Get details about a specific table by ID, including its views and the " +
+        "current record count (rowCount) of each view",
       inputSchema: z.object({
         tableId: z.string().describe("The ID of the table to retrieve"),
       }),
       execute: async input => {
         const { tableId } = input
         const table = await sdk.tables.getTable(tableId)
-        return { table }
+        const views = await enrichViewsWithRowCounts(table.views)
+        return { table: { ...table, views } }
       },
     }),
   },

--- a/packages/server/src/ai/tools/budibase/tests/tables.spec.ts
+++ b/packages/server/src/ai/tools/budibase/tests/tables.spec.ts
@@ -1,0 +1,143 @@
+import { BasicOperator, ViewV2 } from "@budibase/types"
+import { helpers } from "@budibase/shared-core"
+import { BudibaseToolDefinition, getBudibaseTools } from ".."
+import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
+import { basicRow, basicTable } from "../../../../tests/utilities/structures"
+
+type ToolInput<T extends BudibaseToolDefinition> = Parameters<
+  NonNullable<T["tool"]["execute"]>
+>[0]
+
+describe("AI Tools - Tables", () => {
+  const config = new TestConfiguration()
+
+  beforeAll(async () => {
+    await config.init()
+  })
+
+  afterAll(() => {
+    config.end()
+  })
+
+  const getTableTool = () => {
+    const tool = getBudibaseTools().find(tool => tool.name === "get_table")
+    if (!tool?.tool.execute) {
+      throw new Error("get_table tool not found")
+    }
+    return tool
+  }
+
+  const runGetTable = async (input: ToolInput<BudibaseToolDefinition>) => {
+    const tool = getTableTool()
+    return config.doInContext(undefined, async () => {
+      const result = await tool.tool.execute!(input, {
+        toolCallId: "test-tool-call",
+        messages: [],
+      })
+      if (Symbol.asyncIterator in Object(result)) {
+        throw new Error("Not expected")
+      }
+      return result as { table: { views?: Record<string, unknown> } }
+    })
+  }
+
+  const getViewRowCount = (
+    views: Record<string, unknown> | undefined,
+    viewName: string
+  ): number | undefined => {
+    const view = views?.[viewName]
+    if (!view || !helpers.views.isV2(view as ViewV2)) {
+      throw new Error(`View ${viewName} not found on table`)
+    }
+    return (view as ViewV2 & { rowCount?: number }).rowCount
+  }
+
+  it("exposes the record count of each view to agents", async () => {
+    const table = await config.api.table.save(basicTable())
+    await config.api.row.save(table._id!, basicRow(table._id!))
+    await config.api.row.save(table._id!, basicRow(table._id!))
+    await config.api.row.save(table._id!, basicRow(table._id!))
+
+    const view = await config.api.viewV2.create({
+      tableId: table._id!,
+      name: "All rows",
+    })
+
+    const result = await runGetTable({ tableId: table._id! })
+
+    expect(getViewRowCount(result.table.views, view.name)).toBe(3)
+  })
+
+  it("returns counts that match the view's filtered records", async () => {
+    const table = await config.api.table.save(basicTable())
+    await config.api.row.save(table._id!, {
+      ...basicRow(table._id!),
+      name: "Active",
+    })
+    await config.api.row.save(table._id!, {
+      ...basicRow(table._id!),
+      name: "Active",
+    })
+    await config.api.row.save(table._id!, {
+      ...basicRow(table._id!),
+      name: "Inactive",
+    })
+
+    const view = await config.api.viewV2.create({
+      tableId: table._id!,
+      name: "Active only",
+      query: [
+        {
+          operator: BasicOperator.EQUAL,
+          field: "name",
+          value: "Active",
+        },
+      ],
+    })
+
+    const result = await runGetTable({ tableId: table._id! })
+    const toolCount = getViewRowCount(result.table.views, view.name)
+
+    const search = await config.api.viewV2.search(view.id, { countRows: true })
+
+    expect(toolCount).toBe(2)
+    expect(toolCount).toBe(search.totalRows)
+  })
+
+  it("returns 0 for a view with no matching records", async () => {
+    const table = await config.api.table.save(basicTable())
+    await config.api.row.save(table._id!, {
+      ...basicRow(table._id!),
+      name: "Active",
+    })
+
+    const view = await config.api.viewV2.create({
+      tableId: table._id!,
+      name: "Empty view",
+      query: [
+        {
+          operator: BasicOperator.EQUAL,
+          field: "name",
+          value: "Nonexistent",
+        },
+      ],
+    })
+
+    const result = await runGetTable({ tableId: table._id! })
+
+    expect(getViewRowCount(result.table.views, view.name)).toBe(0)
+  })
+
+  it("leaves existing get_table behaviour unchanged for tables without views", async () => {
+    const table = await config.api.table.save(basicTable())
+
+    const result = await runGetTable({ tableId: table._id! })
+
+    expect(result.table).toMatchObject({
+      _id: table._id,
+      name: table.name,
+      schema: table.schema,
+    })
+    expect(Object.keys(result.table.views ?? {})).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Description

AI agents could see a table's views (via the `get_table` tool) but had no visibility into how many records each view contained, leaving them without useful context about the size and shape of the data.

This change enriches the `get_table` agent tool so every view is annotated with a `rowCount`, reusing the platform's existing `search({ countRows: true })` calculation. This ensures view filters and permissions are applied exactly as they are elsewhere in the platform.

The change is fully additive:

* Views now include a `rowCount`.
* Tables without views behave exactly as before.
* All other agent tools are unchanged.

## Addresses

* https://github.com/Budibase/budibase/issues/19059

## App Export

N/A — backend-only change to an agent tool.

Reproducible with any table that has ViewsV2:

1. Create a table with a few rows.
2. Create multiple views with different filters.
3. Run the agent's `get_table` tool.
4. Verify each view includes the correct record count.

## Screenshots

Not a UI-facing feature — the change is surfaced in the `get_table` agent tool output and can be inspected from the agent **Logs** tab.

Verified on a live workspace:

```text
Live view-search API  :  All Tasks=4  Active=3  Archived=0
get_table tool output :  {"All Tasks":4, "Active":3, "Archived":0}   ✅ identical
viewless table        :  {}                                          ✅ unchanged
```

Covered by tests in `tables.spec.ts`:

* View counts are exposed to agents.
* Counts match the underlying view.
* Views with zero matching records return `0`.
* Tables without views remain unchanged.

## Launchcontrol

AI agents can now see how many records each of a table's views contains, giving them better context about your data when answering questions or taking actions.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

