### PR TITLE
fixes icons in repeater block

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -7975,13 +7975,13 @@
               {
                 "label": "Column",
                 "value": "column",
-                "barIcon": "TableSelectColumn",
+                "barIcon": "rows-plus-bottom",
                 "barTitle": "Column layout"
               },
               {
                 "label": "Row",
                 "value": "row",
-                "barIcon": "TableSelectRow",
+                "barIcon": "columns-plus-right",
                 "barTitle": "Row layout"
               }
             ],


### PR DESCRIPTION
## Description
Icons for direction in the repeater block were previously incorrect

<img width="622" height="340" alt="image" src="https://github.com/user-attachments/assets/85466c61-093f-49dc-9011-00734d070d13" />

This PR brings them in-line with other direction icons

<img width="302" height="174" alt="image" src="https://github.com/user-attachments/assets/2126da1b-a161-4b75-b45d-911d6cca063f" />


## Launchcontrol

_fixes icons in repeater block._
