### PR TITLE
[codex] Patch path-to-regexp ReDoS advisory

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19367,9 +19367,9 @@ path-scurry@^2.0.0, path-scurry@^2.0.2:
     minipass "^7.1.2"
 
 path-to-regexp@^0.1.12, path-to-regexp@~0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
-  integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.13.tgz#9b22ec16bc3ab88d05a0c7e369869421401ab17d"
+  integrity sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==
 
 path-to-regexp@^6.1.0:
   version "6.3.0"


### PR DESCRIPTION
## Description
Updates the Yarn lockfile resolution for `path-to-regexp@^0.1.12` / `~0.1.12` from `0.1.12` to patched `0.1.13`.

This addresses the High Dependabot alert for `GHSA-37ch-88jc-xwx2` / `CVE-2026-4867`, where `path-to-regexp` versions below `0.1.13` can generate vulnerable regular expressions for routes with multiple parameters in one segment.

## Addresses
- https://github.com/Budibase/budibase/security/dependabot/1307

## App Export
- Not applicable, dependency-only security patch.

## Screenshots
- Not applicable, no UI changes.

## Launchcontrol
Updates a vulnerable routing dependency to the patched version to prevent a potential regular expression denial-of-service issue.