### PR TITLE
feat: Add Sort Order Configuration to Options & Multi-Select Pickers

### DIFF
--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -4247,10 +4247,21 @@
         }
       },
       {
-        "type": "boolean",
-        "label": "Alphabetical",
-        "key": "sort",
-        "defaultValue": true
+        "type": "select",
+        "label": "Sort Order",
+        "key": "sortOrder",
+        "defaultValue": "ascending",
+        "placeholder": "None (backend order)",
+        "options": [
+          {
+            "label": "Ascending",
+            "value": "ascending"
+          },
+          {
+            "label": "Descending",
+            "value": "descending"
+          }
+        ]
       },
       {
         "type": "boolean",
@@ -4440,6 +4451,23 @@
           "setting": "optionsType",
           "value": "select"
         }
+      },
+      {
+        "type": "select",
+        "label": "Sort Order",
+        "key": "sortOrder",
+        "defaultValue": "ascending",
+        "placeholder": "None (backend order)",
+        "options": [
+          {
+            "label": "Ascending",
+            "value": "ascending"
+          },
+          {
+            "label": "Descending",
+            "value": "descending"
+          }
+        ]
       },
       {
         "type": "boolean",

--- a/packages/client/src/components/app/forms/MultiFieldSelect.svelte
+++ b/packages/client/src/components/app/forms/MultiFieldSelect.svelte
@@ -34,6 +34,7 @@
   export let showSelectAll: boolean = false
   export let selectAllText: string = "Select all"
   export let wrapText: boolean = false
+  export let sortOrder: string | null = null
 
   let fieldState: FieldState | undefined
   let fieldApi: FieldApi | undefined
@@ -47,7 +48,8 @@
     dataProvider,
     labelColumn,
     valueColumn,
-    customOptions
+    customOptions,
+    sortOrder
   )
   const pickerLabels = loadTranslationsByGroup("picker")
 

--- a/packages/client/src/components/app/forms/OptionsField.svelte
+++ b/packages/client/src/components/app/forms/OptionsField.svelte
@@ -20,7 +20,7 @@
   export let autocomplete = false
   export let direction = "vertical"
   export let onChange
-  export let sort = true
+  export let sortOrder = null
   export let span
   export let helpText = null
   export let wrapText = false
@@ -36,7 +36,8 @@
     dataProvider,
     labelColumn,
     valueColumn,
-    customOptions
+    customOptions,
+    sortOrder
   )
   const pickerLabels = loadTranslationsByGroup("picker")
 
@@ -76,7 +77,6 @@
         getOptionLabel={flatOptions ? x => x : x => x.label}
         getOptionValue={flatOptions ? x => x : x => x.value}
         {autocomplete}
-        {sort}
         searchPlaceholder={pickerLabels.searchPlaceholder}
         {wrapText}
       />
@@ -93,7 +93,6 @@
         getOptionLabel={flatOptions ? x => x : x => x.label}
         getOptionTitle={flatOptions ? x => x : x => x.label}
         getOptionValue={flatOptions ? x => x : x => x.value}
-        {sort}
       />
     {/if}
   {/if}

--- a/packages/client/src/components/app/forms/optionsParser.js
+++ b/packages/client/src/components/app/forms/optionsParser.js
@@ -1,14 +1,28 @@
+/**
+ * Retrieves and optionally sorts the options for an Options Picker or
+ * Multi-select Picker component.
+ *
+ * @param {string|null} optionsSource - "schema", "provider", "custom", or null
+ * @param {object}      fieldSchema   - Schema for the bound field
+ * @param {object}      dataProvider  - Data provider context (rows + schema)
+ * @param {string}      labelColumn   - Column name to use as option label
+ * @param {string}      valueColumn   - Column name to use as option value
+ * @param {Array}       customOptions - Manually defined options
+ * @param {string|null} sortOrder     - "ascending", "descending", or null/"none"
+ */
 export const getOptions = (
   optionsSource,
   fieldSchema,
   dataProvider,
   labelColumn,
   valueColumn,
-  customOptions
+  customOptions,
+  sortOrder
 ) => {
   // Take options from schema
   if (optionsSource == null || optionsSource === "schema") {
-    return fieldSchema?.constraints?.inclusion ?? []
+    const schemaOptions = fieldSchema?.constraints?.inclusion ?? []
+    return sortOptions(schemaOptions, sortOrder, x => x)
   }
 
   // Extract options from data provider
@@ -23,7 +37,7 @@ export const getOptions = (
         options.push({ value, label })
       }
     })
-    return options
+    return sortOptions(options, sortOrder, x => x.label)
   }
 
   // Extract custom options
@@ -37,8 +51,30 @@ export const getOptions = (
         }
       }
     })
-    return customOptions
+    return sortOptions(customOptions, sortOrder, x => x.label ?? x.value)
   }
 
   return []
+}
+
+/**
+ * Sorts an array of options by their label.
+ *
+ * @param {Array}    options   - Options array to sort
+ * @param {string}   sortOrder - "ascending", "descending", or null/undefined/"none"
+ * @param {Function} getLabel  - Accessor that returns the label string for an option
+ * @returns {Array} Sorted (or original) options array
+ */
+const sortOptions = (options, sortOrder, getLabel) => {
+  if (!sortOrder || sortOrder === "none" || !options?.length) {
+    return options
+  }
+  const sorted = [...options].sort((a, b) => {
+    const la = String(getLabel(a) ?? "").toLowerCase()
+    const lb = String(getLabel(b) ?? "").toLowerCase()
+    if (la < lb) return -1
+    if (la > lb) return 1
+    return 0
+  })
+  return sortOrder === "descending" ? sorted.reverse() : sorted
 }


### PR DESCRIPTION
## Description
This PR replaces the legacy "Alphabetical" checkbox in the **Options Picker** with a unified **Sort Order** configuration (`Ascending` / `Descending` / `None`). It also brings this same configuration to the **Multi-select Picker** component, which previously lacked sorting settings.

Sorting has been moved client-side to `optionsParser.js` to support all option sources uniformly:
1. **Schema** (built-in field/inclusion constraints)
2. **Data Providers** (internal/external tables)
3. **Custom Option Lists**

## Addresses
- #17729 

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
<img width="1210" height="671" alt="image" src="https://github.com/user-attachments/assets/1d321cce-92a9-406c-9f10-14e7701750f5" />

## Launchcontrol

Adds a new "Sort Order" configuration to Options Pickers and Multi-select Pickers, allowing developers to present dropdown options in Ascending, Descending, or original backend order. This simplifies common tasks like sorting years/dates from newest to oldest or arranging status options alphabetically, without requiring manual sorting workarounds in database queries.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

