### PR TITLE
Add query JSON binding regression coverage

### DIFF
--- a/packages/server/src/sdk/workspace/queries/queries.spec.ts
+++ b/packages/server/src/sdk/workspace/queries/queries.spec.ts
@@ -79,6 +79,24 @@ describe("queries SDK", () => {
       })
     })
 
+    it("keeps quoted JSON bindings as string values", async () => {
+      const payload = 'x", "name": {"$ne": "x"}, "$comment": "bud-033'
+      const result = await enrichContext(
+        {
+          json: '{"name": "{{ name }}"}',
+        },
+        {
+          name: payload,
+        }
+      )
+
+      expect(result).toEqual({
+        json: {
+          name: payload,
+        },
+      })
+    })
+
     it("falls back to requestBody when json is blank", async () => {
       const result = await enrichContext({
         json: "",


### PR DESCRIPTION
## Summary

- Added regression coverage for quoted JSON template bindings in query enrichment.
- The test asserts that enriched JSON keeps a dynamic value as a string value rather than changing the parsed object shape.

## Testing

- `CI=true yarn test src/sdk/workspace/queries/queries.spec.ts` did not complete locally; Jest reached the target spec startup and then produced no further output before being interrupted.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

