### PR TITLE
Allow empty automation branch conditions

### DIFF
--- a/packages/server/src/api/routes/tests/automation.spec.ts
+++ b/packages/server/src/api/routes/tests/automation.spec.ts
@@ -17,6 +17,7 @@ import {
   Table,
   WebhookTriggerInputs,
   isDidNotTriggerResponse,
+  isBranchStep,
   isEmailTrigger,
 } from "@budibase/types"
 import {
@@ -229,6 +230,28 @@ describe("/automations", () => {
       expect(message).toEqual("Automation created successfully")
     })
 
+    it("allows a branch step with empty condition UI", async () => {
+      const automation = createAutomationBuilder(config)
+        .onAppAction()
+        .branch({
+          activeBranch: {
+            steps: stepBuilder =>
+              stepBuilder.serverLog({ text: "Active user" }),
+            condition: {},
+          },
+        })
+        .build()
+      const [step] = automation.definition.steps
+      if (!isBranchStep(step)) {
+        throw new Error("Expected branch step")
+      }
+      step.inputs.branches[0].conditionUI = null
+
+      const { message } = await config.api.automation.post(automation)
+
+      expect(message).toEqual("Automation created successfully")
+    })
+
     it("Should check validation on an branch that has a condition that is not valid", async () => {
       const automation = createAutomationBuilder(config)
         .onAppAction()
@@ -242,17 +265,42 @@ describe("/automations", () => {
         .serverLog({ text: "Inactive user" })
         .build()
       const [step] = automation.definition.steps
-      step.inputs.branches[0].condition = {
-        INCORRECT: { "trigger.fields.status": "active" },
+      if (!isBranchStep(step)) {
+        throw new Error("Expected branch step")
+      }
+      const invalidAutomation = {
+        ...automation,
+        definition: {
+          ...automation.definition,
+          steps: [
+            {
+              ...step,
+              inputs: {
+                ...step.inputs,
+                branches: [
+                  {
+                    ...step.inputs.branches[0],
+                    condition: {
+                      INCORRECT: { "trigger.fields.status": "active" },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
       }
 
-      await config.api.automation.post(automation, {
-        status: 400,
-        body: {
-          message:
-            'Invalid body - "definition.steps[0].inputs.branches[0].condition.INCORRECT" is not allowed',
-        },
-      })
+      const response = await config.request!
+        .post("/api/automations")
+        .send(invalidAutomation)
+        .set(config.defaultHeaders())
+        .expect(400)
+        .expect("Content-Type", /json/)
+
+      expect(response.body.message).toEqual(
+        'Invalid body - "definition.steps[0].inputs.branches[0].condition.INCORRECT" is not allowed'
+      )
     })
 
     it("should apply authorization to endpoint", async () => {

--- a/packages/server/src/api/routes/tests/automation.spec.ts
+++ b/packages/server/src/api/routes/tests/automation.spec.ts
@@ -291,8 +291,8 @@ describe("/automations", () => {
         },
       }
 
-      const response = await config.request!
-        .post("/api/automations")
+      const response = await config
+        .request!.post("/api/automations")
         .send(invalidAutomation)
         .set(config.defaultHeaders())
         .expect(400)

--- a/packages/server/src/api/routes/tests/automation.spec.ts
+++ b/packages/server/src/api/routes/tests/automation.spec.ts
@@ -212,7 +212,7 @@ describe("/automations", () => {
       })
     })
 
-    it("Should check validation on a branch step with empty conditions", async () => {
+    it("allows a branch step with empty conditions", async () => {
       const automation = createAutomationBuilder(config)
         .onAppAction()
         .branch({
@@ -224,13 +224,9 @@ describe("/automations", () => {
         })
         .build()
 
-      await config.api.automation.post(automation, {
-        status: 400,
-        body: {
-          message:
-            'Invalid body - "definition.steps[0].inputs.branches[0].condition" must have at least 1 key',
-        },
-      })
+      const { message } = await config.api.automation.post(automation)
+
+      expect(message).toEqual("Automation created successfully")
     })
 
     it("Should check validation on an branch that has a condition that is not valid", async () => {
@@ -240,14 +236,15 @@ describe("/automations", () => {
           activeBranch: {
             steps: stepBuilder =>
               stepBuilder.serverLog({ text: "Active user" }),
-            condition: {
-              //@ts-ignore
-              INCORRECT: { "trigger.fields.status": "active" },
-            },
+            condition: {},
           },
         })
         .serverLog({ text: "Inactive user" })
         .build()
+      const [step] = automation.definition.steps
+      step.inputs.branches[0].condition = {
+        INCORRECT: { "trigger.fields.status": "active" },
+      }
 
       await config.api.automation.post(automation, {
         status: 400,

--- a/packages/server/src/api/routes/utils/validators.ts
+++ b/packages/server/src/api/routes/utils/validators.ts
@@ -330,7 +330,7 @@ function generateStepSchema(allowStepTypes: string[]) {
   const branchSchema = Joi.object({
     id: Joi.string().required(),
     name: Joi.string().required(),
-    condition: filterObject({ unknown: false }).required().min(1),
+    condition: filterObject({ unknown: false }).required(),
     conditionUI: Joi.object(),
   })
 

--- a/packages/server/src/api/routes/utils/validators.ts
+++ b/packages/server/src/api/routes/utils/validators.ts
@@ -331,7 +331,7 @@ function generateStepSchema(allowStepTypes: string[]) {
     id: Joi.string().required(),
     name: Joi.string().required(),
     condition: filterObject({ unknown: false }).required(),
-    conditionUI: Joi.object(),
+    conditionUI: Joi.object().allow(null),
   })
 
   return Joi.object({

--- a/packages/types/src/documents/workspace/automation/StepInputsOutputs.ts
+++ b/packages/types/src/documents/workspace/automation/StepInputsOutputs.ts
@@ -170,7 +170,7 @@ export type Branch = {
   id: any
   name: string
   condition: BranchSearchFilters
-  conditionUI?: UISearchFilter
+  conditionUI?: UISearchFilter | null
 }
 
 export type BranchSearchFilters = SearchFilters


### PR DESCRIPTION
## Description
Allows automation branch conditions to be an empty object. This matches runtime branch handling, where an empty condition acts as the default/ELSE branch, and fixes API validation rejecting this payload.

## Addresses
- https://github.com/Budibase/budibase/issues/19103


## Launchcontrol
Allows automation branches with no configured condition to be saved successfully.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

