### PR TITLE
[Codex] [110] Cover MongoDB JSON binding injection

### DIFF
--- a/packages/server/src/sdk/workspace/queries/queries.spec.ts
+++ b/packages/server/src/sdk/workspace/queries/queries.spec.ts
@@ -79,6 +79,22 @@ describe("queries SDK", () => {
       })
     })
 
+    it("keeps injected MongoDB operators inside quoted JSON binding values", async () => {
+      const payload = `x", "name": {"$ne": "x"}, "$comment": "bud-033`
+      const result = await enrichContext(
+        {
+          json: `{"name": "{{ name }}"}`,
+        },
+        { name: payload }
+      )
+
+      expect(result).toEqual({
+        json: {
+          name: payload,
+        },
+      })
+    })
+
     it("falls back to requestBody when json is blank", async () => {
       const result = await enrichContext({
         json: "",


### PR DESCRIPTION
## Description
Adds regression coverage proving MongoDB JSON template bindings keep duplicate-key and dollar-operator payloads inside the quoted binding value instead of allowing the parsed query shape to be rewritten.