### PR TITLE
feat: Enhanced Gap Control

### DIFF
--- a/packages/builder/src/components/design/settings/componentSettings.js
+++ b/packages/builder/src/components/design/settings/componentSettings.js
@@ -38,6 +38,7 @@ import TableConditionEditor from "./controls/TableConditionEditor.svelte"
 import ButtonConditionEditor from "./controls/ButtonConditionEditor.svelte"
 import MultilineDrawerBindableInput from "@/components/common/MultilineDrawerBindableInput.svelte"
 import FilterableSelect from "./controls/FilterableSelect.svelte"
+import GapControl from "./controls/GapControl.svelte"
 import { setComponentSettingsResolver } from "./componentSettingsRegistry"
 
 const componentMap = {
@@ -52,6 +53,7 @@ const componentMap = {
   dataProvider: DataProviderSelect,
   boolean: Checkbox,
   number: Stepper,
+  gapControl: GapControl,
   event: ButtonActionEditor,
   table: TableSelect,
   color: ColorPicker,

--- a/packages/builder/src/components/design/settings/controls/GapControl.svelte
+++ b/packages/builder/src/components/design/settings/controls/GapControl.svelte
@@ -3,17 +3,22 @@
   import { createEventDispatcher } from "svelte"
 
   export let value = "M"
+  export let options = []
+  export let units = ["rem", "px", "em", "%"]
 
   const dispatch = createEventDispatcher()
-  const units = ["rem", "px", "em", "%"]
 
-  const presetOptions = [
-    { label: "None", value: "N" },
-    { label: "Small", value: "S" },
-    { label: "Medium", value: "M" },
-    { label: "Large", value: "L" },
-    { label: "Custom", value: "custom" },
-  ]
+  // Use provided options from manifest, or default fallback
+  $: presetOptions =
+    options.length > 0
+      ? options
+      : [
+          { label: "None", value: "N" },
+          { label: "Small", value: "S" },
+          { label: "Medium", value: "M" },
+          { label: "Large", value: "L" },
+          { label: "Custom", value: "custom" },
+        ]
 
   $: isCustom = typeof value === "object"
   $: mode = isCustom ? "custom" : value

--- a/packages/builder/src/components/design/settings/controls/GapControl.svelte
+++ b/packages/builder/src/components/design/settings/controls/GapControl.svelte
@@ -106,7 +106,7 @@
 <div class="gap-control">
   <Select
     value={mode}
-    options={options}
+    {options}
     on:change={handleModeChange}
     placeholder={false}
   />

--- a/packages/builder/src/components/design/settings/controls/GapControl.svelte
+++ b/packages/builder/src/components/design/settings/controls/GapControl.svelte
@@ -103,17 +103,16 @@
   }
 </script>
 
-<div class="gap-wrapper">
-  <div class="gap-control">
-    <Select
-      value={mode}
-      options={options}
-      on:change={handleModeChange}
-      placeholder={false}
-    />
-  </div>
+<div class="gap-control">
+  <Select
+    value={mode}
+    options={options}
+    on:change={handleModeChange}
+    placeholder={false}
+  />
+</div>
 
-  {#if isCustom}
+{#if isCustom}
   <div class="custom-gaps">
     <!-- Column Gap Input -->
     <div class="gap-row">
@@ -208,15 +207,10 @@
         </Popover>
       </div>
     </div>
-    </div>
-  {/if}
-</div>
+  </div>
+{/if}
 
 <style>
-  .gap-wrapper {
-    display: contents;
-  }
-
   .gap-control {
     display: flex;
     flex-direction: column;

--- a/packages/builder/src/components/design/settings/controls/GapControl.svelte
+++ b/packages/builder/src/components/design/settings/controls/GapControl.svelte
@@ -1,22 +1,35 @@
-<script>
+<script lang="ts">
   import { Select, Icon, Popover, ActionButton } from "@budibase/bbui"
+
+  type GapValue = string | { column: string; row: string }
+
+  interface Props {
+    value?: GapValue
+    options?: { label: string; value: string }[]
+    units?: string[]
+    onChange?: (value: GapValue) => void
+  }
 
   let {
     value = "M",
     options = [],
     units = ["rem", "px", "em", "%"],
     onChange,
-  } = $props()
+  }: Props = $props()
 
-  let columnAnchor = $state()
-  let rowAnchor = $state()
+  let columnAnchor = $state<HTMLElement | undefined>(undefined)
+  let rowAnchor = $state<HTMLElement | undefined>(undefined)
   let showColumnUnitMenu = $state(false)
   let showRowUnitMenu = $state(false)
 
   let isCustom = $derived(typeof value === "object")
   let mode = $derived(isCustom ? "custom" : value)
-  let columnGap = $derived(isCustom ? value?.column || "0.5rem" : "")
-  let rowGap = $derived(isCustom ? value?.row || "0.5rem" : "")
+  let columnGap = $derived(
+    isCustom && typeof value === "object" ? value.column || "0.5rem" : ""
+  )
+  let rowGap = $derived(
+    isCustom && typeof value === "object" ? value.row || "0.5rem" : ""
+  )
 
   let columnParsed = $derived(parseValue(columnGap))
   let columnNumeric = $derived(columnParsed.number)
@@ -26,11 +39,11 @@
   let rowNumeric = $derived(rowParsed.number)
   let rowUnit = $derived(rowParsed.unit)
 
-  function parseValue(val) {
+  function parseValue(val: string): { number: string; unit: string } {
     if (!val || val === "") {
       return { number: "", unit: "rem" }
     }
-    const match = String(val).match(/^([\d.]+)(.*)$/)
+    const match = val.match(/^([\d.]+)(.*)$/)
     if (match) {
       return {
         number: match[1],
@@ -40,17 +53,17 @@
     return { number: val, unit: "rem" }
   }
 
-  function handleModeChange(e) {
+  function handleModeChange(e: CustomEvent<GapValue>) {
     const newMode = e.detail
-    if (newMode === "custom") {
+    if (newMode === "custom" || typeof newMode === "object") {
       onChange?.({ column: "0.5rem", row: "0.5rem" })
     } else {
       onChange?.(newMode)
     }
   }
 
-  function handleColumnNumberInput(e) {
-    const num = e.target.value
+  function handleColumnNumberInput(e: Event) {
+    const num = (e.target as HTMLInputElement).value
     if (num !== "") {
       onChange?.({
         column: `${num}${columnUnit}`,
@@ -59,8 +72,8 @@
     }
   }
 
-  function handleRowNumberInput(e) {
-    const num = e.target.value
+  function handleRowNumberInput(e: Event) {
+    const num = (e.target as HTMLInputElement).value
     if (num !== "") {
       onChange?.({
         column: columnGap || "0",
@@ -69,7 +82,7 @@
     }
   }
 
-  function selectColumnUnit(unit) {
+  function selectColumnUnit(unit: string) {
     if (columnNumeric) {
       onChange?.({
         column: `${columnNumeric}${unit}`,
@@ -79,7 +92,7 @@
     showColumnUnitMenu = false
   }
 
-  function selectRowUnit(unit) {
+  function selectRowUnit(unit: string) {
     if (rowNumeric) {
       onChange?.({
         column: columnGap || "0",
@@ -90,16 +103,17 @@
   }
 </script>
 
-<div class="gap-control">
-  <Select
-    value={mode}
-    options={options}
-    on:change={handleModeChange}
-    placeholder={false}
-  />
-</div>
+<div class="gap-wrapper">
+  <div class="gap-control">
+    <Select
+      value={mode}
+      options={options}
+      on:change={handleModeChange}
+      placeholder={false}
+    />
+  </div>
 
-{#if isCustom}
+  {#if isCustom}
   <div class="custom-gaps">
     <!-- Column Gap Input -->
     <div class="gap-row">
@@ -194,10 +208,15 @@
         </Popover>
       </div>
     </div>
-  </div>
-{/if}
+    </div>
+  {/if}
+</div>
 
 <style>
+  .gap-wrapper {
+    display: contents;
+  }
+
   .gap-control {
     display: flex;
     flex-direction: column;

--- a/packages/builder/src/components/design/settings/controls/GapControl.svelte
+++ b/packages/builder/src/components/design/settings/controls/GapControl.svelte
@@ -1,0 +1,305 @@
+<script>
+  import { Select, Icon, Popover, ActionButton } from "@budibase/bbui"
+  import { createEventDispatcher } from "svelte"
+
+  export let value = "M"
+
+  const dispatch = createEventDispatcher()
+  const units = ["rem", "px", "em", "%"]
+
+  const presetOptions = [
+    { label: "None", value: "N" },
+    { label: "Small", value: "S" },
+    { label: "Medium", value: "M" },
+    { label: "Large", value: "L" },
+    { label: "Custom", value: "custom" },
+  ]
+
+  $: isCustom = typeof value === "object"
+  $: mode = isCustom ? "custom" : value
+  $: columnGap = isCustom ? value?.column || "0.5rem" : ""
+  $: rowGap = isCustom ? value?.row || "0.5rem" : ""
+
+  // Parse column gap
+  $: columnParsed = parseValue(columnGap)
+  $: columnNumeric = columnParsed.number
+  $: columnUnit = columnParsed.unit
+
+  // Parse row gap
+  $: rowParsed = parseValue(rowGap)
+  $: rowNumeric = rowParsed.number
+  $: rowUnit = rowParsed.unit
+
+  let columnAnchor, rowAnchor
+  let showColumnUnitMenu = false
+  let showRowUnitMenu = false
+
+  function parseValue(val) {
+    if (!val || val === "") {
+      return { number: "", unit: "rem" }
+    }
+    const match = String(val).match(/^([\d.]+)(.*)$/)
+    if (match) {
+      return {
+        number: match[1],
+        unit: match[2] || "rem",
+      }
+    }
+    return { number: val, unit: "rem" }
+  }
+
+  function handleModeChange(e) {
+    const newMode = e.detail
+    if (newMode === "custom") {
+      dispatch("change", { column: "0.5rem", row: "0.5rem" })
+    } else {
+      dispatch("change", newMode)
+    }
+  }
+
+  function handleColumnNumberInput(e) {
+    const num = e.target.value
+    if (num !== "") {
+      const newValue = `${num}${columnUnit}`
+      dispatch("change", {
+        column: newValue,
+        row: rowGap || "0",
+      })
+    }
+  }
+
+  function handleRowNumberInput(e) {
+    const num = e.target.value
+    if (num !== "") {
+      const newValue = `${num}${rowUnit}`
+      dispatch("change", {
+        column: columnGap || "0",
+        row: newValue,
+      })
+    }
+  }
+
+  function selectColumnUnit(unit) {
+    if (columnNumeric) {
+      const newValue = `${columnNumeric}${unit}`
+      dispatch("change", {
+        column: newValue,
+        row: rowGap || "0",
+      })
+    }
+    showColumnUnitMenu = false
+  }
+
+  function selectRowUnit(unit) {
+    if (rowNumeric) {
+      const newValue = `${rowNumeric}${unit}`
+      dispatch("change", {
+        column: columnGap || "0",
+        row: newValue,
+      })
+    }
+    showRowUnitMenu = false
+  }
+</script>
+
+<div class="gap-control">
+  <Select
+    value={mode}
+    options={presetOptions}
+    on:change={handleModeChange}
+    placeholder={false}
+  />
+</div>
+
+{#if isCustom}
+  <div class="custom-gaps">
+    <!-- Column Gap Input -->
+    <div class="gap-row">
+      <div class="gap-input-wrapper">
+        <div class="gap-label">Column-Gap</div>
+        <div class="icon-box">
+          <Icon name="split-horizontal" />
+        </div>
+        <input
+          type="number"
+          class="gap-number-input"
+          value={columnNumeric}
+          placeholder="0.5"
+          step="0.1"
+          min="0"
+          on:input={handleColumnNumberInput}
+        />
+        <div bind:this={columnAnchor}>
+          <ActionButton
+            size="M"
+            quiet
+            on:click={() => (showColumnUnitMenu = !showColumnUnitMenu)}
+          >
+            {columnUnit.toUpperCase()}
+          </ActionButton>
+        </div>
+        <Popover
+          bind:open={showColumnUnitMenu}
+          anchor={columnAnchor}
+          align="right"
+        >
+          <div class="unit-menu">
+            {#each units as unit}
+              <!-- svelte-ignore a11y-no-static-element-interactions -->
+              <!-- svelte-ignore a11y-click-events-have-key-events -->
+              <div
+                class="unit-option"
+                class:selected={unit === columnUnit}
+                on:click={() => selectColumnUnit(unit)}
+              >
+                {unit.toUpperCase()}
+              </div>
+            {/each}
+          </div>
+        </Popover>
+      </div>
+    </div>
+
+    <!-- Row Gap Input -->
+    <div class="gap-row">
+      <div class="gap-input-wrapper">
+        <div class="gap-label">Row-Gap</div>
+        <div class="icon-box">
+          <Icon name="split-vertical" />
+        </div>
+        <input
+          type="number"
+          class="gap-number-input"
+          value={rowNumeric}
+          placeholder="0.5"
+          step="0.1"
+          min="0"
+          on:input={handleRowNumberInput}
+        />
+        <div bind:this={rowAnchor}>
+          <ActionButton
+            size="M"
+            quiet
+            on:click={() => (showRowUnitMenu = !showRowUnitMenu)}
+          >
+            {rowUnit.toUpperCase()}
+          </ActionButton>
+        </div>
+        <Popover bind:open={showRowUnitMenu} anchor={rowAnchor} align="right">
+          <div class="unit-menu">
+            {#each units as unit}
+              <!-- svelte-ignore a11y-no-static-element-interactions -->
+              <!-- svelte-ignore a11y-click-events-have-key-events -->
+              <div
+                class="unit-option"
+                class:selected={unit === rowUnit}
+                on:click={() => selectRowUnit(unit)}
+              >
+                {unit.toUpperCase()}
+              </div>
+            {/each}
+          </div>
+        </Popover>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .gap-control {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .custom-gaps {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .gap-row {
+    display: flex;
+    align-items: center;
+  }
+
+  .gap-label {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--spectrum-global-color-gray-700);
+    white-space: nowrap;
+    margin-right: 12px;
+    min-width: 78px;
+  }
+
+  .gap-input-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+  }
+
+  .icon-box {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border: 0px solid var(--spectrum-global-color-gray-300);
+    border-radius: 4px;
+    background-color: transparent;
+    flex-shrink: 0;
+  }
+
+  .icon-box :global(svg) {
+    width: 16px;
+    height: 16px;
+    color: var(--spectrum-global-color-gray-600);
+  }
+
+  .gap-number-input {
+    width: 60px;
+    height: 32px;
+    border: 1px solid var(--spectrum-global-color-gray-400);
+    border-radius: 4px;
+    padding: 0 8px;
+    font-size: 14px;
+    background-color: var(--spectrum-global-color-gray-50);
+    color: var(--spectrum-global-color-gray-900);
+  }
+
+  .gap-number-input:focus {
+    outline: none;
+    border-color: var(--spectrum-global-color-blue-400);
+    background-color: var(--spectrum-global-color-gray-75);
+  }
+
+  .gap-number-input::-webkit-inner-spin-button,
+  .gap-number-input::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  .unit-menu {
+    display: flex;
+    flex-direction: column;
+    min-width: 80px;
+  }
+
+  .unit-option {
+    padding: 8px 12px;
+    cursor: pointer;
+    font-size: 13px;
+    color: var(--spectrum-global-color-gray-800);
+    transition: background-color 130ms ease-out;
+  }
+
+  .unit-option:hover {
+    background-color: var(--spectrum-global-color-gray-200);
+  }
+
+  .unit-option.selected {
+    background-color: var(--spectrum-global-color-blue-400);
+    color: white;
+  }
+</style>

--- a/packages/builder/src/components/design/settings/controls/GapControl.svelte
+++ b/packages/builder/src/components/design/settings/controls/GapControl.svelte
@@ -8,18 +8,7 @@
 
   const dispatch = createEventDispatcher()
 
-  // Use provided options from manifest, or default fallback
-  $: presetOptions =
-    options.length > 0
-      ? options
-      : [
-          { label: "None", value: "N" },
-          { label: "Small", value: "S" },
-          { label: "Medium", value: "M" },
-          { label: "Large", value: "L" },
-          { label: "Custom", value: "custom" },
-        ]
-
+  $: presetOptions = options
   $: isCustom = typeof value === "object"
   $: mode = isCustom ? "custom" : value
   $: columnGap = isCustom ? value?.column || "0.5rem" : ""

--- a/packages/builder/src/components/design/settings/controls/GapControl.svelte
+++ b/packages/builder/src/components/design/settings/controls/GapControl.svelte
@@ -1,32 +1,30 @@
 <script>
   import { Select, Icon, Popover, ActionButton } from "@budibase/bbui"
-  import { createEventDispatcher } from "svelte"
 
-  export let value = "M"
-  export let options = []
-  export let units = ["rem", "px", "em", "%"]
+  let {
+    value = "M",
+    options = [],
+    units = ["rem", "px", "em", "%"],
+    onChange,
+  } = $props()
 
-  const dispatch = createEventDispatcher()
+  let columnAnchor = $state()
+  let rowAnchor = $state()
+  let showColumnUnitMenu = $state(false)
+  let showRowUnitMenu = $state(false)
 
-  $: presetOptions = options
-  $: isCustom = typeof value === "object"
-  $: mode = isCustom ? "custom" : value
-  $: columnGap = isCustom ? value?.column || "0.5rem" : ""
-  $: rowGap = isCustom ? value?.row || "0.5rem" : ""
+  let isCustom = $derived(typeof value === "object")
+  let mode = $derived(isCustom ? "custom" : value)
+  let columnGap = $derived(isCustom ? value?.column || "0.5rem" : "")
+  let rowGap = $derived(isCustom ? value?.row || "0.5rem" : "")
 
-  // Parse column gap
-  $: columnParsed = parseValue(columnGap)
-  $: columnNumeric = columnParsed.number
-  $: columnUnit = columnParsed.unit
+  let columnParsed = $derived(parseValue(columnGap))
+  let columnNumeric = $derived(columnParsed.number)
+  let columnUnit = $derived(columnParsed.unit)
 
-  // Parse row gap
-  $: rowParsed = parseValue(rowGap)
-  $: rowNumeric = rowParsed.number
-  $: rowUnit = rowParsed.unit
-
-  let columnAnchor, rowAnchor
-  let showColumnUnitMenu = false
-  let showRowUnitMenu = false
+  let rowParsed = $derived(parseValue(rowGap))
+  let rowNumeric = $derived(rowParsed.number)
+  let rowUnit = $derived(rowParsed.unit)
 
   function parseValue(val) {
     if (!val || val === "") {
@@ -45,18 +43,17 @@
   function handleModeChange(e) {
     const newMode = e.detail
     if (newMode === "custom") {
-      dispatch("change", { column: "0.5rem", row: "0.5rem" })
+      onChange?.({ column: "0.5rem", row: "0.5rem" })
     } else {
-      dispatch("change", newMode)
+      onChange?.(newMode)
     }
   }
 
   function handleColumnNumberInput(e) {
     const num = e.target.value
     if (num !== "") {
-      const newValue = `${num}${columnUnit}`
-      dispatch("change", {
-        column: newValue,
+      onChange?.({
+        column: `${num}${columnUnit}`,
         row: rowGap || "0",
       })
     }
@@ -65,19 +62,17 @@
   function handleRowNumberInput(e) {
     const num = e.target.value
     if (num !== "") {
-      const newValue = `${num}${rowUnit}`
-      dispatch("change", {
+      onChange?.({
         column: columnGap || "0",
-        row: newValue,
+        row: `${num}${rowUnit}`,
       })
     }
   }
 
   function selectColumnUnit(unit) {
     if (columnNumeric) {
-      const newValue = `${columnNumeric}${unit}`
-      dispatch("change", {
-        column: newValue,
+      onChange?.({
+        column: `${columnNumeric}${unit}`,
         row: rowGap || "0",
       })
     }
@@ -86,10 +81,9 @@
 
   function selectRowUnit(unit) {
     if (rowNumeric) {
-      const newValue = `${rowNumeric}${unit}`
-      dispatch("change", {
+      onChange?.({
         column: columnGap || "0",
-        row: newValue,
+        row: `${rowNumeric}${unit}`,
       })
     }
     showRowUnitMenu = false
@@ -99,7 +93,7 @@
 <div class="gap-control">
   <Select
     value={mode}
-    options={presetOptions}
+    options={options}
     on:change={handleModeChange}
     placeholder={false}
   />
@@ -121,7 +115,7 @@
           placeholder="0.5"
           step="0.1"
           min="0"
-          on:input={handleColumnNumberInput}
+          oninput={handleColumnNumberInput}
         />
         <div bind:this={columnAnchor}>
           <ActionButton
@@ -139,12 +133,14 @@
         >
           <div class="unit-menu">
             {#each units as unit}
-              <!-- svelte-ignore a11y-no-static-element-interactions -->
-              <!-- svelte-ignore a11y-click-events-have-key-events -->
               <div
                 class="unit-option"
                 class:selected={unit === columnUnit}
-                on:click={() => selectColumnUnit(unit)}
+                role="option"
+                aria-selected={unit === columnUnit}
+                onclick={() => selectColumnUnit(unit)}
+                onkeydown={e => e.key === "Enter" && selectColumnUnit(unit)}
+                tabindex="0"
               >
                 {unit.toUpperCase()}
               </div>
@@ -168,7 +164,7 @@
           placeholder="0.5"
           step="0.1"
           min="0"
-          on:input={handleRowNumberInput}
+          oninput={handleRowNumberInput}
         />
         <div bind:this={rowAnchor}>
           <ActionButton
@@ -182,12 +178,14 @@
         <Popover bind:open={showRowUnitMenu} anchor={rowAnchor} align="right">
           <div class="unit-menu">
             {#each units as unit}
-              <!-- svelte-ignore a11y-no-static-element-interactions -->
-              <!-- svelte-ignore a11y-click-events-have-key-events -->
               <div
                 class="unit-option"
                 class:selected={unit === rowUnit}
-                on:click={() => selectRowUnit(unit)}
+                role="option"
+                aria-selected={unit === rowUnit}
+                onclick={() => selectRowUnit(unit)}
+                onkeydown={e => e.key === "Enter" && selectRowUnit(unit)}
+                tabindex="0"
               >
                 {unit.toUpperCase()}
               </div>

--- a/packages/builder/src/components/design/settings/controls/PropertyControl.svelte
+++ b/packages/builder/src/components/design/settings/controls/PropertyControl.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { Label } from "@budibase/bbui"
   import {
     readableToRuntimeBinding,
@@ -133,7 +133,11 @@
       <Label size="M">{label}</Label>
     </div>
   {/if}
-  <div id={`${key}-prop-control`} class="control">
+  <div
+    id={`${key}-prop-control`}
+    class="control"
+    class:control-contents={type === "gapControl"}
+  >
     <svelte:component
       this={control}
       {componentInstance}
@@ -213,6 +217,10 @@
   }
   .control {
     position: relative;
+  }
+
+  .control-contents {
+    display: contents;
   }
   .text {
     font-size: var(--spectrum-global-dimension-font-size-75);

--- a/packages/builder/src/components/design/settings/controls/PropertyControl.svelte
+++ b/packages/builder/src/components/design/settings/controls/PropertyControl.svelte
@@ -133,7 +133,11 @@
       <Label size="M">{label}</Label>
     </div>
   {/if}
-  <div id={`${key}-prop-control`} class="control">
+  <div
+    id={`${key}-prop-control`}
+    class="control"
+    class:control-contents={type === "gapControl"}
+  >
     <svelte:component
       this={control}
       {componentInstance}
@@ -213,6 +217,10 @@
   }
   .control {
     position: relative;
+  }
+
+  .control-contents {
+    display: contents;
   }
   .text {
     font-size: var(--spectrum-global-dimension-font-size-75);

--- a/packages/builder/src/components/design/settings/controls/PropertyControl.svelte
+++ b/packages/builder/src/components/design/settings/controls/PropertyControl.svelte
@@ -133,11 +133,7 @@
       <Label size="M">{label}</Label>
     </div>
   {/if}
-  <div
-    id={`${key}-prop-control`}
-    class="control"
-    class:control-contents={type === "gapControl"}
-  >
+  <div id={`${key}-prop-control`} class="control">
     <svelte:component
       this={control}
       {componentInstance}
@@ -217,10 +213,6 @@
   }
   .control {
     position: relative;
-  }
-
-  .control-contents {
-    display: contents;
   }
   .text {
     font-size: var(--spectrum-global-dimension-font-size-75);

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -341,6 +341,30 @@
         "type": "gapControl",
         "label": "Gap",
         "key": "gap",
+        "showInBar": true,
+        "barStyle": "picker",
+        "options": [
+          {
+            "label": "None",
+            "value": "N"
+          },
+          {
+            "label": "Small",
+            "value": "S"
+          },
+          {
+            "label": "Medium",
+            "value": "M"
+          },
+          {
+            "label": "Large",
+            "value": "L"
+          },
+          {
+            "label": "Custom",
+            "value": "custom"
+          }
+        ],
         "defaultValue": "M",
         "dependsOn": {
           "setting": "layout",

--- a/packages/client/manifest.json
+++ b/packages/client/manifest.json
@@ -338,29 +338,9 @@
         }
       },
       {
-        "type": "select",
+        "type": "gapControl",
         "label": "Gap",
         "key": "gap",
-        "showInBar": true,
-        "barStyle": "picker",
-        "options": [
-          {
-            "label": "None",
-            "value": "N"
-          },
-          {
-            "label": "Small",
-            "value": "S"
-          },
-          {
-            "label": "Medium",
-            "value": "M"
-          },
-          {
-            "label": "Large",
-            "value": "L"
-          }
-        ],
         "defaultValue": "M",
         "dependsOn": {
           "setting": "layout",

--- a/packages/client/src/components/app/container/FlexContainer.svelte
+++ b/packages/client/src/components/app/container/FlexContainer.svelte
@@ -33,7 +33,7 @@
     .join(" ")
 
   // Merge custom gap styles with component styles to avoid conflicts with styleable action
-  $: enrichedStyles = {
+  $: gapStyles = {
     ...$component.styles,
     custom: ($component.styles?.custom || "") + customGapStyle,
   }
@@ -44,7 +44,7 @@
 <div
   class={classNames}
   class:clickable={!!onClick}
-  use:styleable={enrichedStyles}
+  use:styleable={gapStyles}
   class:wrap
   on:click={onClick}
 >

--- a/packages/client/src/components/app/container/FlexContainer.svelte
+++ b/packages/client/src/components/app/container/FlexContainer.svelte
@@ -16,14 +16,27 @@
   $: hAlignClass = hAlign ? `hAlign-${hAlign}` : ""
   $: vAlignClass = vAlign ? `vAlign-${vAlign}` : ""
   $: sizeClass = size ? `size-${size}` : ""
-  $: gapClass = gap ? `gap-${gap}` : ""
+  $: isCustomGap = gap && typeof gap === "object"
+  $: gapClass = gap && !isCustomGap ? `gap-${gap}` : ""
+  $: customGapStyle = isCustomGap
+    ? `--custom-column-gap: ${gap?.column || "0"}; --custom-row-gap: ${gap?.row || "0"};`
+    : ""
   $: classNames = [
     directionClass,
     hAlignClass,
     vAlignClass,
     sizeClass,
     gapClass,
-  ].join(" ")
+    isCustomGap ? "custom-gap" : "",
+  ]
+    .filter(Boolean)
+    .join(" ")
+
+  // Merge custom gap styles with component styles to avoid conflicts with styleable action
+  $: enrichedStyles = {
+    ...$component.styles,
+    custom: ($component.styles?.custom || "") + customGapStyle,
+  }
 </script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
@@ -31,7 +44,7 @@
 <div
   class={classNames}
   class:clickable={!!onClick}
-  use:styleable={$component.styles}
+  use:styleable={enrichedStyles}
   class:wrap
   on:click={onClick}
 >
@@ -112,6 +125,11 @@
   }
   .gap-L {
     gap: 32px;
+  }
+
+  .custom-gap {
+    column-gap: var(--custom-column-gap, 0);
+    row-gap: var(--custom-row-gap, 0);
   }
 
   .wrap {


### PR DESCRIPTION
## Description

Adds a new `GapControl` component for the Flex Container in the builder, replacing the previous simple `select` dropdown. The control supports a preset mode (S/M/L/XL) and a custom mode where users can independently set column and row gap values with a unit selector (px, %, em, rem). Also adds a `Space Around` alignment option to the Flex Container.

## Addresses
- Solves / Resolves https://github.com/Budibase/budibase/issues/19094

## Screenshots
<img width="1920" height="962" alt="2026-06-30_20-00-36 (1)" src="https://github.com/user-attachments/assets/47d3311d-2e43-4abf-933a-66d9c5b5131e" />

## Launchcontrol

Replaces the Flex Container's gap selector with a richer gap control that lets users pick from the standard presets (S/M/L/XL) still or dial in a custom column and row gap independently, with full unit support. 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

