### PR TITLE
fix: Skip groups init for end users during builder root init

### DIFF
--- a/packages/builder/src/pages/builder/_layout.svelte
+++ b/packages/builder/src/pages/builder/_layout.svelte
@@ -249,7 +249,9 @@
           licensing.init(),
           appsStore.load(),
           organisation.init(),
-          groups.init(),
+          ...(sdk.users.hasBuilderPermissions($auth.user)
+            ? [groups.init()]
+            : []),
         ])
 
         await auth.getInitInfo()

--- a/packages/builder/src/pages/builder/groupsInitGuard.test.ts
+++ b/packages/builder/src/pages/builder/groupsInitGuard.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "fs"
+import { resolve } from "path"
+import { describe, expect, it } from "vitest"
+
+const readBuilderPage = (relativePath: string) =>
+  readFileSync(resolve(__dirname, relativePath), "utf8")
+
+const readSettingsPage = (relativePath: string) =>
+  readFileSync(resolve(__dirname, "../../settings/pages", relativePath), "utf8")
+
+describe("builder root init groups guard", () => {
+  it("only loads groups during root init for builder users", () => {
+    const source = readBuilderPage("_layout.svelte")
+
+    expect(source).toContain("sdk.users.hasBuilderPermissions($auth.user)")
+    expect(source).toMatch(
+      /\.\.\.\(sdk\.users\.hasBuilderPermissions\(\$auth\.user\)\s*\?\s*\[groups\.init\(\)\]\s*:\s*\[\]\)/
+    )
+    expect(source).not.toMatch(/organisation\.init\(\),\s*groups\.init\(\)/)
+  })
+
+  it("keeps groups init on people settings pages for builder access", () => {
+    expect(readSettingsPage("people/groups/index.svelte")).toContain(
+      "groups.init()"
+    )
+    expect(readSettingsPage("people/groups/group.svelte")).toContain(
+      "groups.init()"
+    )
+    expect(readSettingsPage("people/users/index.svelte")).toContain(
+      "groups.init()"
+    )
+  })
+})


### PR DESCRIPTION
## Description
Skips `groups.init()` during root builder init for users without builder permissions. Prevents an infinite reload loop for end users on `/builder/apps` after #19109 restricted `GET /api/global/groups` to builder/admin access.

Includes source tests in `groupsInitGuard.test.ts` covering the root layout guard and existing settings-page group loading.

## Addresses
- Reload loop regression from #19109 for BASIC users when User Groups is enabled

## App Export
- N/A

## Screenshots
- N/A

## Launchcontrol
End users can access the app portal without being stuck in a reload loop when User Groups is enabled.