### PR TITLE
Block group init requests for users without permission

### DIFF
--- a/packages/builder/src/stores/portal/groups.ts
+++ b/packages/builder/src/stores/portal/groups.ts
@@ -1,5 +1,6 @@
 import { API } from "@/api"
-import { licensing } from "@/stores/portal"
+import { auth, licensing } from "@/stores/portal"
+import { sdk } from "@budibase/shared-core"
 import { UserGroup } from "@budibase/types"
 import { get } from "svelte/store"
 import { BudiStore } from "../BudiStore"
@@ -22,11 +23,19 @@ class GroupStore extends BudiStore<UserGroup[]> {
   }
 
   async init() {
-    // Only init if there is a groups license, just to be sure but the feature will be blocked
-    // on the backend anyway
-    if (get(licensing).groupsEnabled) {
-      const groups = await API.getGroups()
-      this.set(groups)
+    // Only init if there is a groups license and the user is a builder or
+    // admin - the endpoint 403s for end users
+    const user = get(auth).user
+    const canReadGroups =
+      sdk.users.hasBuilderPermissions(user) ||
+      sdk.users.hasAdminPermissions(user)
+    if (get(licensing).groupsEnabled && canReadGroups) {
+      try {
+        const groups = await API.getGroups()
+        this.set(groups)
+      } catch (error) {
+        console.error("Error fetching user groups", error)
+      }
     }
   }
 

--- a/packages/builder/src/stores/portal/groups.ts
+++ b/packages/builder/src/stores/portal/groups.ts
@@ -36,6 +36,8 @@ class GroupStore extends BudiStore<UserGroup[]> {
       } catch (error) {
         console.error("Error fetching user groups", error)
       }
+    } else {
+      this.set([])
     }
   }
 


### PR DESCRIPTION
## Description

Requests to the group API were causing redirect loops on login for endusers trying to access the apps portal

## Addresses
- Recently the endpoint was locked down here. https://github.com/Budibase/budibase/pull/19109
- https://github.com/orgs/Budibase/projects/20/views/1?pane=issue&itemId=207638501&issue=Budibase%7Cbudibase%7C19131


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

