### PR TITLE
Add portal group init regression test

### DIFF
--- a/packages/builder/src/stores/portal/groups.spec.ts
+++ b/packages/builder/src/stores/portal/groups.spec.ts
@@ -1,4 +1,5 @@
 import { API } from "@/api"
+import { GetGlobalSelfResponse } from "@budibase/types"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { auth, licensing } from "@/stores/portal"
 import { groups } from "./groups"
@@ -11,13 +12,16 @@ vi.mock("@/api", () => {
   }
 })
 
-vi.mock("@budibase/shared-core", () => {
+vi.mock("@budibase/shared-core", async importOriginal => {
+  const original = await importOriginal<typeof import("@budibase/shared-core")>()
   return {
+    ...original,
     sdk: {
+      ...original.sdk,
       users: {
+        ...original.sdk.users,
         hasBuilderPermissions: vi.fn(
-          (user?: { builder?: { global?: boolean } }) =>
-            !!user?.builder?.global
+          (user?: { builder?: { global?: boolean } }) => !!user?.builder?.global
         ),
         hasAdminPermissions: vi.fn(
           (user?: { admin?: { global?: boolean } }) => !!user?.admin?.global
@@ -45,11 +49,7 @@ const setGroupsEnabled = (groupsEnabled: boolean) => {
   }))
 }
 
-const setUser = (user?: {
-  admin: { global: boolean }
-  builder: { global: boolean }
-  roles: Record<string, string>
-}) => {
+const setUser = (user?: GetGlobalSelfResponse) => {
   auth.update(state => ({
     ...state,
     user,
@@ -69,7 +69,7 @@ describe("portal groups store", () => {
       builder: { global: false },
       admin: { global: false },
       roles: {},
-    })
+    } as GetGlobalSelfResponse)
     setGroupsEnabled(true)
     getGroups.mockRejectedValue(
       new Error("Non-builder users cannot fetch groups")

--- a/packages/builder/src/stores/portal/groups.spec.ts
+++ b/packages/builder/src/stores/portal/groups.spec.ts
@@ -1,0 +1,82 @@
+import { API } from "@/api"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { auth, licensing } from "@/stores/portal"
+import { groups } from "./groups"
+
+vi.mock("@/api", () => {
+  return {
+    API: {
+      getGroups: vi.fn(),
+    },
+  }
+})
+
+vi.mock("@budibase/shared-core", () => {
+  return {
+    sdk: {
+      users: {
+        hasBuilderPermissions: vi.fn(
+          (user?: { builder?: { global?: boolean } }) =>
+            !!user?.builder?.global
+        ),
+        hasAdminPermissions: vi.fn(
+          (user?: { admin?: { global?: boolean } }) => !!user?.admin?.global
+        ),
+      },
+    },
+  }
+})
+
+vi.mock("@/stores/portal", async () => {
+  const { writable } = await import("svelte/store")
+
+  return {
+    auth: writable({ user: undefined }),
+    licensing: writable({ groupsEnabled: false }),
+  }
+})
+
+const getGroups = vi.mocked(API.getGroups)
+
+const setGroupsEnabled = (groupsEnabled: boolean) => {
+  licensing.update(state => ({
+    ...state,
+    groupsEnabled,
+  }))
+}
+
+const setUser = (user?: {
+  admin: { global: boolean }
+  builder: { global: boolean }
+  roles: Record<string, string>
+}) => {
+  auth.update(state => ({
+    ...state,
+    user,
+  }))
+}
+
+describe("portal groups store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    groups.set([])
+    setGroupsEnabled(false)
+    setUser()
+  })
+
+  it("does not fetch groups for non-builder users when groups are licensed", async () => {
+    setUser({
+      builder: { global: false },
+      admin: { global: false },
+      roles: {},
+    })
+    setGroupsEnabled(true)
+    getGroups.mockRejectedValue(
+      new Error("Non-builder users cannot fetch groups")
+    )
+
+    await expect(groups.init()).resolves.toBeUndefined()
+
+    expect(getGroups).not.toHaveBeenCalled()
+  })
+})

--- a/packages/builder/src/stores/portal/groups.spec.ts
+++ b/packages/builder/src/stores/portal/groups.spec.ts
@@ -13,7 +13,8 @@ vi.mock("@/api", () => {
 })
 
 vi.mock("@budibase/shared-core", async importOriginal => {
-  const original = await importOriginal<typeof import("@budibase/shared-core")>()
+  const original =
+    await importOriginal<typeof import("@budibase/shared-core")>()
   return {
     ...original,
     sdk: {


### PR DESCRIPTION
## Description
* adds a regression tests that would have caught the groups issue

We'd really need an e2e test to do this properly, but in the mean time this will help a bit...if the API's drift the mock types will fail at least 


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

