### PR TITLE
[Automations] Support standard separators in step names

### DIFF
--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItemHeader.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItemHeader.svelte
@@ -39,7 +39,7 @@
   export let itemName: string | undefined = undefined
   export let automation: Automation | undefined = undefined
 
-  let validRegex = /^[A-Za-z0-9_\s]+$/
+  let validRegex = /^[A-Za-z0-9_.\-\s]+$/
   let typing = false
   let editing = false
   const dispatch = createEventDispatcher()
@@ -141,7 +141,7 @@
     if (name !== block.name && name?.length > 0) {
       let invalidRoleName = !validRegex.test(name)
       if (invalidRoleName) {
-        return "Please enter a name consisting of only alphanumeric symbols and underscores"
+        return "Please enter a name consisting of only alphanumeric characters, spaces, underscores, hyphens and periods"
       }
     }
 

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItemHeader.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItemHeader.svelte
@@ -25,6 +25,10 @@
     AutomationTrigger,
     AutomationTriggerResult,
   } from "@budibase/types"
+  import {
+    AUTOMATION_STEP_NAME_ERROR,
+    isValidAutomationStepName,
+  } from "../../stepNameValidation"
 
   type TestResult = AutomationStepResult | AutomationTriggerResult
 
@@ -39,7 +43,6 @@
   export let itemName: string | undefined = undefined
   export let automation: Automation | undefined = undefined
 
-  let validRegex = /^[A-Za-z0-9_.\-\s]+$/
   let typing = false
   let editing = false
   const dispatch = createEventDispatcher()
@@ -139,9 +142,9 @@
     }
 
     if (name !== block.name && name?.length > 0) {
-      let invalidRoleName = !validRegex.test(name)
+      let invalidRoleName = !isValidAutomationStepName(name)
       if (invalidRoleName) {
-        return "Please enter a name consisting of only alphanumeric characters, spaces, underscores, hyphens and periods"
+        return AUTOMATION_STEP_NAME_ERROR
       }
     }
 

--- a/packages/builder/src/components/automation/SetupPanel/BlockHeader.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/BlockHeader.svelte
@@ -14,6 +14,10 @@
   import { getAutomationStepIconColor } from "@/components/automation/AutomationBuilder/FlowChart/AutomationStepCategories"
   import { restTemplates } from "@/stores/builder/restTemplates"
   import { createEventDispatcher } from "svelte"
+  import {
+    AUTOMATION_STEP_NAME_ERROR,
+    isValidAutomationStepName,
+  } from "../stepNameValidation"
 
   export let block: AutomationStep | AutomationTrigger | undefined = undefined
   export let automation: Automation | undefined = undefined
@@ -27,7 +31,6 @@
 
   let externalAction: ExternalAction | undefined
   let editing: boolean
-  let validRegex: RegExp = /^[A-Za-z0-9_.\-\s]+$/
 
   $: stepNames = automation?.definition.stepNames || {}
   $: blockHeading = getHeading(itemName, block) || ""
@@ -83,9 +86,9 @@
     }
 
     if (name !== block.name && name?.length > 0) {
-      let invalidRoleName = !validRegex.test(name)
+      let invalidRoleName = !isValidAutomationStepName(name)
       if (invalidRoleName) {
-        return "Please enter a name consisting of only alphanumeric characters, spaces, underscores, hyphens and periods"
+        return AUTOMATION_STEP_NAME_ERROR
       }
     }
   }

--- a/packages/builder/src/components/automation/SetupPanel/BlockHeader.svelte
+++ b/packages/builder/src/components/automation/SetupPanel/BlockHeader.svelte
@@ -27,7 +27,7 @@
 
   let externalAction: ExternalAction | undefined
   let editing: boolean
-  let validRegex: RegExp = /^[A-Za-z0-9_\s]+$/
+  let validRegex: RegExp = /^[A-Za-z0-9_.\-\s]+$/
 
   $: stepNames = automation?.definition.stepNames || {}
   $: blockHeading = getHeading(itemName, block) || ""
@@ -85,7 +85,7 @@
     if (name !== block.name && name?.length > 0) {
       let invalidRoleName = !validRegex.test(name)
       if (invalidRoleName) {
-        return "Please enter a name consisting of only alphanumeric symbols and underscores"
+        return "Please enter a name consisting of only alphanumeric characters, spaces, underscores, hyphens and periods"
       }
     }
   }

--- a/packages/builder/src/components/automation/stepNameValidation.test.ts
+++ b/packages/builder/src/components/automation/stepNameValidation.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+
+import { isValidAutomationStepName } from "./stepNameValidation"
+
+describe("isValidAutomationStepName", () => {
+  it.each([
+    "Create row",
+    "Create_row",
+    "Create-row",
+    "Create.row",
+    "Create row_1-step.2",
+    "123",
+  ])("allows valid step name %s", name => {
+    expect(isValidAutomationStepName(name)).toBe(true)
+  })
+
+  it.each(["Create/row", "Create:row", "Create(row)", "Create@row", ""])(
+    "rejects invalid step name %s",
+    name => {
+      expect(isValidAutomationStepName(name)).toBe(false)
+    }
+  )
+})

--- a/packages/builder/src/components/automation/stepNameValidation.ts
+++ b/packages/builder/src/components/automation/stepNameValidation.ts
@@ -1,0 +1,8 @@
+export const AUTOMATION_STEP_NAME_ERROR =
+  "Please enter a name consisting of only alphanumeric characters, spaces, underscores, hyphens and periods"
+
+const AUTOMATION_STEP_NAME_REGEX = /^[A-Za-z0-9_.\-\s]+$/
+
+export const isValidAutomationStepName = (name: string) => {
+  return AUTOMATION_STEP_NAME_REGEX.test(name)
+}


### PR DESCRIPTION
## Description
Automation step renaming only allowed alphanumeric characters, spaces, and underscores. This PR allows common standard separators in step names by permitting hyphens and periods in both automation rename surfaces.

Tested that it saves these new characters for step names without issue 

## Addresses
- https://github.com/Budibase/budibase/issues/18840

## Launchcontrol
Automation step names now support common separators like hyphens and periods, making naming conventions easier to follow.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

