### PR TITLE
fix(client): sub-link nav items disappear (#19147)

### DIFF
--- a/packages/client/src/components/app/navUtils.test.ts
+++ b/packages/client/src/components/app/navUtils.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { enrichNavItems } from "./navUtils"
+import { describe, it, expect } from "vitest"
+
+describe("enrichNavItems", () => {
+  it("keeps a sublinks parent whose sublinks don't match an accessible route", () => {
+    const navItems = [
+      { text: "Home", url: "/home", type: "link", roleId: "BASIC" },
+      {
+        text: "List",
+        type: "sublinks",
+        roleId: "BASIC",
+        subLinks: [
+          { text: "Sub 1", url: "/list", type: "link", roleId: "BASIC" },
+        ],
+      },
+    ]
+
+    const routeEntries = [
+      { path: "/home", screenId: "s1" },
+      { path: "/list/:id", screenId: "s2" },
+    ]
+
+    const userRoleHierarchy = ["ADMIN", "BASIC"]
+
+    const enriched = enrichNavItems(navItems, userRoleHierarchy, routeEntries)
+
+    expect(enriched.map(i => i.text)).toEqual(["Home", "List"])
+  })
+
+  it("keeps a sublinks parent that has an empty sublink (freshly added in drawer)", () => {
+    const navItems = [
+      {
+        text: "List",
+        type: "sublinks",
+        roleId: "BASIC",
+        subLinks: [{}],
+      },
+    ]
+
+    const routeEntries = []
+    const userRoleHierarchy = ["ADMIN", "BASIC"]
+
+    const enriched = enrichNavItems(navItems, userRoleHierarchy, routeEntries)
+
+    expect(enriched.map(i => i.text)).toEqual(["List"])
+  })
+})

--- a/packages/client/src/components/app/navUtils.ts
+++ b/packages/client/src/components/app/navUtils.ts
@@ -1,0 +1,86 @@
+import { Constants } from "@budibase/frontend-core"
+
+export const getRouteWithoutQueryParams = route => {
+  if (!route) {
+    return route
+  }
+  try {
+    return new URL(route, "http://localhost").pathname
+  } catch (error) {
+    return route
+  }
+}
+
+export const isInternal = url => {
+  return url?.startsWith("/")
+}
+
+export const ensureExternal = url => {
+  if (!url?.length) {
+    return url
+  }
+  return !url.startsWith("http") ? `http://${url}` : url
+}
+
+export const enrichNavItem = navItem => {
+  const internalLink = isInternal(navItem.url)
+  return {
+    ...navItem,
+    internalLink,
+    url: internalLink ? navItem.url : ensureExternal(navItem.url),
+  }
+}
+
+export const canAccessSubLink = (subLink, accessibleRoutes) => {
+  const url = subLink?.url
+  if (!url) {
+    return false
+  }
+
+  // We can only reliably validate static internal routes here.
+  if (!isInternal(url) || url.includes("{{")) {
+    return true
+  }
+
+  return accessibleRoutes.has(getRouteWithoutQueryParams(url))
+}
+
+export const enrichNavItems = (
+  navItems,
+  userRoleHierarchy,
+  routeEntries = []
+) => {
+  if (!navItems?.length) {
+    return []
+  }
+  const accessibleRoutes = new Set(routeEntries.map(route => route.path))
+
+  return navItems
+    .filter(navItem => {
+      // Strip nav items without text
+      if (!navItem.text) {
+        return false
+      }
+
+      // Strip out links without URLs
+      if (navItem.type !== "sublinks" && !navItem.url) {
+        return false
+      }
+
+      // Filter to only links allowed by the current role
+      const role = navItem.roleId || Constants.Roles.BASIC
+      return userRoleHierarchy?.find(roleId => roleId === role)
+    })
+    .map(navItem => {
+      const enrichedNavItem = enrichNavItem(navItem)
+      if (navItem.type === "sublinks" && navItem.subLinks?.length) {
+        enrichedNavItem.subLinks = navItem.subLinks
+          .filter(
+            subLink =>
+              subLink.text && canAccessSubLink(subLink, accessibleRoutes)
+          )
+          .map(enrichNavItem)
+      }
+      return enrichedNavItem
+    })
+}


### PR DESCRIPTION
## Description
Fixes #19147 — nav items configured as "Open sub-links" disappear from the app navigation bar.

## Root cause
In `packages/client/src/components/app/navUtils.ts`, `enrichNavItems` ended with:

    .filter(navItem => navItem.type !== "sublinks" || navItem.subLinks?.length > 0)

which dropped a sub-links **parent** whenever it had zero *accessible* sub-links. Sub-links are
gated by `canAccessSubLink`, which requires an exact match against `accessibleRoutes`. Two common,
valid cases fail that match and empty the parent:

1. `SubLinksDrawer` adds a new sub-link as an empty object `{}` (no url/text), which
   `canAccessSubLink` rejects immediately.
2. Screen routes are parameterised (e.g. `/list/:id`) while the sub-link url is clean (`/list`), so
   exact-string matching misses.

Either way `subLinks.length` hit 0 and the whole parent was removed. Top-level links aren't
route-gated, which is why they rendered and only the sub-links parent vanished.

## Fix
Remove the trailing filter so a sub-links parent always renders. `NavItem.svelte` already guards
its children with `{#each subLinks || [] as subLink}`, so a parent with an empty `subLinks` array
renders safely. Role filtering and `canAccessSubLink` are unchanged — the server already
role-filters routes in `routing.ts` (`clientFetch`), so sub-links to unreachable screens are still
correctly hidden.

## Tests
Added `navUtils.test.ts` covering both failure modes using the real `{ path, screenId }` route
shape:
- parent whose sub-link url doesn't match a parameterised accessible route
- parent with an empty `{}` sub-link (as created by the drawer)

Both fail against the old filter and pass with the fix. Full `@budibase/client` suite green;
client build passes.

## Design note for reviewers
Deleting the filter makes parents always render, which matches the issue's expectation ("All
'Open sub-links' items should be displayed"). The more conservative alternative is to keep the
filter and instead make `canAccessSubLink` tolerant of parameterised paths — but that still hides
the parent while editing (empty `{}` sub-links), i.e. the exact reported experience. Happy to switch
approaches if maintainers prefer keeping empty parents hidden.

## Screenshots
Before: "List" (Open sub-links) missing from nav bar. After: "List" renders.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

