### PR TITLE
fix sub-link nav items disappearing

### DIFF
--- a/packages/client/src/components/app/Layout.svelte
+++ b/packages/client/src/components/app/Layout.svelte
@@ -165,7 +165,7 @@
     ? `${$builderStore.screen?._id}-navigation`
     : "navigation"
 
-  function enrichNavItem(navItem) {
+  const enrichNavItem = navItem => {
     const internalLink = isInternal(navItem.url)
     return {
       ...navItem,
@@ -174,7 +174,7 @@
     }
   }
 
-  function getRouteWithoutQueryParams(route) {
+  const getRouteWithoutQueryParams = route => {
     if (!route) {
       return route
     }
@@ -185,7 +185,7 @@
     }
   }
 
-  function canAccessSubLink(subLink, accessibleRoutes) {
+  const canAccessSubLink = (subLink, accessibleRoutes) => {
     if ($builderStore.inBuilder) {
       return true
     }
@@ -203,7 +203,7 @@
     return accessibleRoutes.has(getRouteWithoutQueryParams(url))
   }
 
-  function enrichNavItems(navItems, userRoleHierarchy, routeEntries = []) {
+  const enrichNavItems = (navItems, userRoleHierarchy, routeEntries = []) => {
     if (!navItems?.length) {
       return []
     }

--- a/packages/client/src/components/app/Layout.svelte
+++ b/packages/client/src/components/app/Layout.svelte
@@ -165,7 +165,7 @@
     ? `${$builderStore.screen?._id}-navigation`
     : "navigation"
 
-  const enrichNavItem = navItem => {
+  function enrichNavItem(navItem) {
     const internalLink = isInternal(navItem.url)
     return {
       ...navItem,
@@ -174,7 +174,7 @@
     }
   }
 
-  const getRouteWithoutQueryParams = route => {
+  function getRouteWithoutQueryParams(route) {
     if (!route) {
       return route
     }
@@ -185,7 +185,11 @@
     }
   }
 
-  const canAccessSubLink = (subLink, accessibleRoutes) => {
+  function canAccessSubLink(subLink, accessibleRoutes) {
+    if ($builderStore.inBuilder) {
+      return true
+    }
+
     const url = subLink?.url
     if (!url) {
       return false
@@ -199,7 +203,7 @@
     return accessibleRoutes.has(getRouteWithoutQueryParams(url))
   }
 
-  const enrichNavItems = (navItems, userRoleHierarchy, routeEntries = []) => {
+  function enrichNavItems(navItems, userRoleHierarchy, routeEntries = []) {
     if (!navItems?.length) {
       return []
     }


### PR DESCRIPTION
## Description
Fixes a regression where navigation sub-links were being hidden in the app editor and builder preview.

The navigation layout was filtering sub-links too aggressively. That caused valid `sublinks` items to disappear when they did not match the exact route list available in the editor context. This change keeps the route access check for runtime users, but bypasses it in builder preview so configured sub-links remain visible while editing.

## Addresses
- https://github.com/Budibase/budibase/issues/19147

## Screenshots
<img width="824" height="205" alt="Screenshot 2026-07-06 at 10 18 33" src="https://github.com/user-attachments/assets/016e42d8-fd8d-4907-b17a-537b7000a875" />

<img width="1420" height="244" alt="Screenshot 2026-07-06 at 10 18 51" src="https://github.com/user-attachments/assets/75e3f3f0-dd21-4974-9377-49249c53c1cd" />

## Launchcontrol
Sub-links in the navigation were disappearing in the editor because the app was checking routes too strictly. I adjusted it so the editor still shows the configured sub-links, while real app users only see links they can actually access.