### PR TITLE
Default workspace invites to end user

### DIFF
--- a/packages/bbui/src/Form/Core/InputDropdown.svelte
+++ b/packages/bbui/src/Form/Core/InputDropdown.svelte
@@ -19,7 +19,7 @@
   export let getOptionLabel = option => extractProperty(option, "label")
   export let getOptionValue = option => extractProperty(option, "value")
   export let getOptionSubtitle = option => option?.subtitle
-  export let isOptionSelected = () => false
+  export let isOptionSelected = _option => false
 
   const dispatch = createEventDispatcher()
   let open = false

--- a/packages/bbui/src/Form/InputDropdown.svelte
+++ b/packages/bbui/src/Form/InputDropdown.svelte
@@ -1,30 +1,38 @@
-<script>
+<script lang="ts">
   import Field from "./Field.svelte"
   import InputDropdown from "./Core/InputDropdown.svelte"
   import { createEventDispatcher } from "svelte"
+  import type { LabelPosition } from "../types"
 
-  export let inputValue = null
-  export let dropdownValue = null
+  interface Option {
+    label?: string
+    value?: string
+    subtitle?: string
+  }
+
+  export let inputValue: string | null = null
+  export let dropdownValue: string | null = null
   export let inputType = "text"
-  export let label = null
-  export let labelPosition = "above"
-  export let placeholder = null
+  export let label: string | undefined = undefined
+  export let labelPosition: LabelPosition = "above"
+  export let placeholder: string | undefined = undefined
   export let disabled = false
   export let readonly = false
-  export let error = null
+  export let error: string | undefined = undefined
   export let updateOnChange = true
-  export let quiet = false
-  export let autofocus
-  export let helpText = null
-  export let options = []
+  export let helpText: string | undefined = undefined
+  export let options: Option[] = []
 
-  const dispatch = createEventDispatcher()
+  const dispatch = createEventDispatcher<{
+    pick: string | null
+    change: string
+  }>()
 
-  const onPick = e => {
+  const onPick = (e: CustomEvent<string | null>) => {
     dropdownValue = e.detail
     dispatch("pick", e.detail)
   }
-  const onChange = e => {
+  const onChange = (e: CustomEvent<string>) => {
     inputValue = e.detail
     dispatch("change", e.detail)
   }
@@ -33,15 +41,12 @@
 <Field {helpText} {label} {labelPosition} {error}>
   <InputDropdown
     {updateOnChange}
-    {error}
     {disabled}
     {readonly}
     {inputValue}
     {dropdownValue}
     {placeholder}
     {inputType}
-    {quiet}
-    {autofocus}
     {options}
     isOptionSelected={option => option === dropdownValue}
     on:change={onChange}

--- a/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
+++ b/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
@@ -299,7 +299,7 @@
     validateWorkspaceEmails(nextEmails)
   }
 
-  const updateHighlightedUser = (direction: number) => {
+  const updateHighlightedUser = (direction: 1 | -1) => {
     if (!suggestedUsers.length) {
       return
     }

--- a/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
+++ b/packages/builder/src/settings/pages/people/users/_components/AddUserModal.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import {
     keepOpen,
     Label,
@@ -25,8 +25,42 @@
   import { OnboardingType } from "@/constants"
   import { helpers } from "@budibase/shared-core"
   import { onDestroy } from "svelte"
+  import type { UserInfo } from "@/types"
+  import type { UserData as AddUsersData } from "../workspaceInviteUtils"
+  import type { StrippedUser, UserGroup } from "@budibase/types"
 
-  export let showOnboardingTypeModal
+  interface UserInput {
+    email: string | null
+    role: string | null
+    password: string
+    forceResetPassword: true
+    error: string | undefined
+  }
+
+  interface EndUserRoleOption {
+    label: string
+    value: string
+    color?: string
+  }
+
+  interface OnboardingOption {
+    label: string
+    subtitle?: string
+    value: string
+    disabled: boolean
+  }
+
+  type EmailPickerKeydownEvent = CustomEvent<KeyboardEvent>
+
+  type SuggestedUser = StrippedUser & {
+    firstName?: string
+    lastName?: string
+  }
+
+  export let showOnboardingTypeModal: (
+    addUsersData: AddUsersData,
+    onboardingType?: string
+  ) => unknown
   export let workspaceOnly = false
   export let useWorkspaceInviteModal = workspaceOnly
   export let assignToWorkspace = workspaceOnly
@@ -34,19 +68,27 @@
   export let showGroupSelect = !useWorkspaceInviteModal
   export let showInviteIcon = true
 
+  const createUserInput = (inputPassword: string): UserInput => ({
+    email: "",
+    role: Constants.BudibaseRoles.AppUser,
+    password: inputPassword,
+    forceResetPassword: true,
+    error: undefined,
+  })
+
   const password = generatePassword(12)
-  let userGroups = []
-  let emailsInput = []
-  let parsedEmails = []
+  let userGroups: string[] = []
+  let emailsInput: string[] = []
+  let parsedEmails: string[] = []
   let pendingEmailInput = ""
-  let emailError = null
-  let suggestedUsers = []
+  let emailError: string | undefined
+  let suggestedUsers: SuggestedUser[] = []
   let isSearchingUsers = false
-  let userSearchTimeout
+  let userSearchTimeout: ReturnType<typeof setTimeout> | undefined
   let userSearchId = 0
   let highlightedUserIndex = -1
   const maxItems = 15
-  let selectedRole = Constants.BudibaseRoles.Creator
+  let selectedRole = Constants.BudibaseRoles.AppUser
   const builtInEndUserRoles = [Constants.Roles.BASIC, Constants.Roles.ADMIN]
   const excludedRoleIds = [
     ...builtInEndUserRoles,
@@ -54,20 +96,23 @@
     Constants.Roles.CREATOR,
     Constants.Roles.GROUP,
   ]
-  let roleColorLookup = {}
-  $: roleColorLookup = ($roles || []).reduce((acc, role) => {
+  let roleColorLookup: Record<string, string | undefined> = {}
+  $: roleColorLookup = ($roles || []).reduce<
+    Record<string, string | undefined>
+  >((acc, role) => {
     acc[role._id] = role.uiMetadata?.color
     return acc
   }, {})
   $: customEndUserRoleOptions = ($roles || [])
     .filter(role => !excludedRoleIds.includes(role._id))
-    .map(role => ({
+    .map<EndUserRoleOption>(role => ({
       label: role.uiMetadata?.displayName || role.name || "Custom role",
       value: role._id,
       color:
         role.uiMetadata?.color ||
         "var(--spectrum-global-color-static-magenta-400)",
     }))
+  let endUserRoleOptions: EndUserRoleOption[] = []
   $: endUserRoleOptions = [
     {
       label: "Basic user",
@@ -82,17 +127,10 @@
     ...customEndUserRoleOptions,
   ]
   let endUserRole = Constants.Roles.BASIC
-  let onboardingType = OnboardingType.EMAIL
+  let onboardingType: string | null = OnboardingType.EMAIL
 
-  $: userData = [
-    {
-      email: "",
-      role: "appUser",
-      password,
-      forceResetPassword: true,
-    },
-  ]
-  $: hasError = userData.find(x => x.error != null)
+  let userData: UserInput[] = [createUserInput(password)]
+  $: hasError = userData.some(x => x.error != null)
   $: {
     if (!useWorkspaceInviteModal) {
       parsedEmails = []
@@ -105,14 +143,15 @@
     }
   }
   $: userCount =
-    $licensing.userCount +
+    ($licensing.userCount || 0) +
     (useWorkspaceInviteModal ? parsedEmails.length : userData.length)
   $: reached = licensing.usersLimitReached(userCount)
   $: exceeded = licensing.usersLimitExceeded(userCount)
   $: smtpConfigured =
     $admin.loaded && ($admin.cloud || !!$admin.checklist?.smtp?.checked)
   $: emailInviteDisabled = $admin.loaded ? !smtpConfigured : false
-  $: passwordInviteDisabled = $organisation.isSSOEnforced
+  $: passwordInviteDisabled = !!$organisation.isSSOEnforced
+  let onboardingOptions: OnboardingOption[] = []
   $: onboardingOptions = [
     {
       label: "Send email invites",
@@ -136,25 +175,17 @@
     onboardingType = OnboardingType.EMAIL
   }
 
-  $: internalGroups = $groups?.filter(g => !g?.scimInfo?.isSync)
+  let internalGroups: UserGroup[] = []
+  $: internalGroups = ($groups || []).filter(g => !g?.scimInfo?.isSync)
 
-  function removeInput(idx) {
-    userData = userData.filter((e, i) => i !== idx)
+  function removeInput(idx: number) {
+    userData = userData.filter((_input, i) => i !== idx)
   }
   function addNewInput() {
-    userData = [
-      ...userData,
-      {
-        email: "",
-        role: "appUser",
-        password: generatePassword(12),
-        forceResetPassword: true,
-        error: null,
-      },
-    ]
+    userData = [...userData, createUserInput(generatePassword(12))]
   }
 
-  function validateInput(input, index) {
+  function validateInput(input: UserInput, index: number) {
     if (input.email) {
       input.email = input.email.trim()
     }
@@ -162,7 +193,7 @@
     if (email) {
       const res = emailValidator(email)
       if (res === true) {
-        userData[index].error = null
+        userData[index].error = undefined
       } else {
         userData[index].error = res
       }
@@ -172,9 +203,9 @@
     return userData[index].error == null
   }
 
-  function validateWorkspaceEmails(emails = emailsInput) {
+  function validateWorkspaceEmails(emails: string[] = emailsInput) {
     if (!emails.length) {
-      emailError = null
+      emailError = undefined
       return false
     }
 
@@ -193,7 +224,7 @@
       return false
     }
 
-    emailError = null
+    emailError = undefined
     return true
   }
 
@@ -201,7 +232,7 @@
     validateWorkspaceEmails()
   }
 
-  const searchExistingUsers = async search => {
+  const searchExistingUsers = async (search: string) => {
     const nextSearchId = ++userSearchId
     const trimmedSearch = search.trim()
     if (!trimmedSearch) {
@@ -218,7 +249,9 @@
       if (nextSearchId !== userSearchId) {
         return
       }
-      suggestedUsers = (response.data || []).filter(user => user.email)
+      suggestedUsers = (response.data || []).filter(
+        (user): user is SuggestedUser => !!user.email
+      )
       highlightedUserIndex = suggestedUsers.findIndex(
         user => !isSuggestedUserSelected(user)
       )
@@ -254,7 +287,7 @@
     )
   }
 
-  const selectSuggestedUser = user => {
+  const selectSuggestedUser = (user: SuggestedUser) => {
     if (!user?.email || isSuggestedUserSelected(user)) {
       return
     }
@@ -266,7 +299,7 @@
     validateWorkspaceEmails(nextEmails)
   }
 
-  const updateHighlightedUser = direction => {
+  const updateHighlightedUser = (direction: number) => {
     if (!suggestedUsers.length) {
       return
     }
@@ -283,12 +316,12 @@
     highlightedUserIndex = -1
   }
 
-  const isSuggestedUserSelected = user => {
+  const isSuggestedUserSelected = (user: SuggestedUser) => {
     const userEmail = user?.email?.trim().toLowerCase()
     return emailsInput.some(email => email.trim().toLowerCase() === userEmail)
   }
 
-  const handleEmailPickerKeydown = event => {
+  const handleEmailPickerKeydown = (event: EmailPickerKeydownEvent) => {
     if (!suggestedUsers.length) {
       return
     }
@@ -312,7 +345,7 @@
     clearTimeout(userSearchTimeout)
   })
 
-  function buildWorkspaceUsers() {
+  function buildWorkspaceUsers(): UserInfo[] {
     return emailsInput.map(email => ({
       email,
       role: selectedRole,
@@ -325,7 +358,16 @@
     }))
   }
 
-  function generatePassword(length) {
+  function buildUserInputs(): UserInfo[] {
+    return userData.map(input => ({
+      email: input.email || "",
+      role: input.role || Constants.BudibaseRoles.AppUser,
+      password: input.password,
+      forceResetPassword: input.forceResetPassword,
+    }))
+  }
+
+  function generatePassword(length: number) {
     const array = new Uint8Array(length)
     window.crypto.getRandomValues(array)
     return Array.from(array, byte => byte.toString(36).padStart(2, "0"))
@@ -358,7 +400,7 @@
       return keepOpen
     }
     showOnboardingTypeModal({
-      users: userData,
+      users: buildUserInputs(),
       groups: userGroups,
       assignToWorkspace,
     })
@@ -474,7 +516,7 @@
             label="Add to groups (optional)"
             options={internalGroups}
             getOptionLabel={option => option.name}
-            getOptionValue={option => option._id}
+            getOptionValue={option => option._id || ""}
           />
         {/if}
 
@@ -494,7 +536,8 @@
           <div class="user-notification">
             <Icon name="info" />
             <span>
-              {capitalise($licensing.license.plan.type)} plan is limited to {$licensing.userLimit}
+              {capitalise($licensing.license?.plan.type || "")} plan is limited to
+              {$licensing.userLimit}
               users. Upgrade your plan to add more users</span
             >
           </div>
@@ -535,7 +578,8 @@
         <div class="user-notification">
           <Icon name="info" />
           <span>
-            {capitalise($licensing.license.plan.type)} plan is limited to {$licensing.userLimit}
+            {capitalise($licensing.license?.plan.type || "")} plan is limited to
+            {$licensing.userLimit}
             users. Upgrade your plan to add more users</span
           >
         </div>
@@ -556,7 +600,7 @@
       label="Groups"
       options={internalGroups}
       getOptionLabel={option => option.name}
-      getOptionValue={option => option._id}
+      getOptionValue={option => option._id || ""}
     />
   {/if}
 </ModalContent>

--- a/packages/shared-core/src/helpers/helpers.ts
+++ b/packages/shared-core/src/helpers/helpers.ts
@@ -1,4 +1,9 @@
-import { User } from "@budibase/types"
+export interface UserDisplayInfo {
+  _id?: string
+  email: string
+  firstName?: string
+  lastName?: string
+}
 
 /**
  * Gets a key within an object. The key supports dot syntax for retrieving deep
@@ -28,7 +33,7 @@ export const deepGet = (obj: Record<string, any> | undefined, key: string) => {
  * Gets the initials to show in a user avatar.
  * @param user the user
  */
-export const getUserInitials = (user: User) => {
+export const getUserInitials = (user: UserDisplayInfo | undefined) => {
   if (!user) {
     return "?"
   }
@@ -45,7 +50,7 @@ export const getUserInitials = (user: User) => {
  * Gets a deterministic colour for a particular user
  * @param user the user
  */
-export const getUserColor = (user: User) => {
+export const getUserColor = (user: UserDisplayInfo | undefined) => {
   let id = user?._id
   if (!id) {
     return "var(--spectrum-global-color-blue-400)"
@@ -68,7 +73,7 @@ export const getUserColor = (user: User) => {
  * Gets a friendly label to describe who a user is.
  * @param user the user
  */
-export const getUserLabel = (user: User) => {
+export const getUserLabel = (user: UserDisplayInfo | undefined) => {
   if (!user) {
     return ""
   }


### PR DESCRIPTION
## Description
Defaults the workspace invite modal role selection to End user instead of Creator. 

Also adds TypeScript annotations needed for `AddUserModal.svelte` now that its script uses `lang="ts"`, and types the `InputDropdown` wrapper props used by the modal.

## Screenshots
<img width="570" height="645" alt="default" src="https://github.com/user-attachments/assets/624092c3-8f3a-43b7-ba2c-62d43c9deab4" />

## Launchcontrol
Workspace invites now default new invitees to End user access rather than Creator access.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

