### PR TITLE
Fix live-update pagination and summary counts on Activity page

### DIFF
--- a/packages/backend-core/src/constants/db.ts
+++ b/packages/backend-core/src/constants/db.ts
@@ -27,7 +27,7 @@ export enum ViewName {
   USER_BY_EMAIL = "by_email2",
   BY_API_KEY = "by_api_key",
   AGENT_REQUESTS_BY_AGENT = "agent_requests_by_agent",
-  AGENT_REQUESTS_BY_UPDATED_AT = "agent_requests_by_updated_at",
+  AGENT_REQUESTS_BY_UPDATED_AT = "agent_requests_by_updated_at_2",
   LINK = "by_link",
   ROUTING = "screen_routes_2",
   PROJECT_MEMBERS = "project_members",
@@ -42,6 +42,11 @@ export const DeprecatedViews: Record<string, string[]> = {
   [ViewName.USER_BY_EMAIL]: [
     // removed due to inaccuracy in view doc filter logic
     "by_email",
+  ],
+  [ViewName.AGENT_REQUESTS_BY_UPDATED_AT]: [
+    // map function changed to emit doc.status as the value, needed a fresh
+    // view so already-created design docs pick up the new definition
+    "agent_requests_by_updated_at",
   ],
 }
 

--- a/packages/builder/src/pages/builder/workspace/[application]/activity/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/activity/index.svelte
@@ -313,6 +313,15 @@
         return
       }
 
+      // A brand-new request always lands on page 1, pushing every other
+      // page's rows down by one. On page 1 we can patch locally; on any
+      // other page the shift can only be reproduced by re-fetching that
+      // page's offset from the server.
+      if (currentPage !== 1) {
+        await loadRequests(currentPage)
+        return
+      }
+
       if (summary) {
         summary = {
           ...summary,
@@ -321,11 +330,6 @@
         }
       }
 
-      // Only insert live on page 1. A request created while viewing a
-      // later page belongs on page 1, not under the user on this one.
-      if (currentPage !== 1) {
-        return
-      }
       allRequests = [request, ...allRequests].slice(0, PAGE_SIZE)
       try {
         await hydrateUserNames([request])

--- a/packages/builder/src/pages/builder/workspace/[application]/activity/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/activity/index.svelte
@@ -167,12 +167,13 @@
   let paginationLabel = $derived.by(() => {
     const start = (currentPage - 1) * PAGE_SIZE + 1
     const end = start + paginatedRows.length - 1
+    const total = summary?.total || 0
 
     if (!paginatedRows.length) {
       return "Showing 0 items"
     }
 
-    return `Showing ${start} to ${end} items`
+    return `Showing ${start}–${end} of ${total} items`
   })
 
   async function loadRequests(page = currentPage) {

--- a/packages/builder/src/pages/builder/workspace/[application]/activity/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/activity/index.svelte
@@ -311,11 +311,11 @@
             [request.status]: summary[request.status] + 1,
           }
         }
-          try {
-              await hydrateUserNames([request])
-          } catch (error) {
-              console.error("Failed to hydrate agent request user name", error)
-          }
+        try {
+          await hydrateUserNames([request])
+        } catch (error) {
+          console.error("Failed to hydrate agent request user name", error)
+        }
         return
       }
 
@@ -328,9 +328,9 @@
         return
       }
 
-        if (allRequests.length >= PAGE_SIZE) {
-            hasNextPage = true
-        }
+      if (allRequests.length >= PAGE_SIZE) {
+        hasNextPage = true
+      }
 
       if (summary) {
         summary = {

--- a/packages/builder/src/pages/builder/workspace/[application]/activity/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/activity/index.svelte
@@ -67,8 +67,11 @@
   let allRequests = $state<AgentRequest[]>([])
   let summary = $state<AgentRequestsSummary | null>(null)
   let userNames = $state<Record<string, string>>({})
-  let hasNextPage = $state(false)
   let activityEnabled = $derived($featureFlags[FeatureFlag.AI_AGENT_ACTIVITY])
+
+  let hasNextPage = $derived.by(() => {
+    return !!summary && summary.total > currentPage * PAGE_SIZE
+  })
 
   // Ticks on an interval purely to force updatedLabel to re-derive
   let now = $state(Date.now())
@@ -175,7 +178,7 @@
   async function loadRequests(page = currentPage) {
     if (!($agentsStore.agents || []).length) {
       allRequests = []
-      hasNextPage = false
+      summary = null
       return
     }
 
@@ -187,7 +190,6 @@
       })
       allRequests = response.requests
       summary = response.summary
-      hasNextPage = response.requests.length === PAGE_SIZE
       try {
         await hydrateUserNames(response.requests)
       } catch (error) {
@@ -197,7 +199,7 @@
       console.error("Failed to fetch agent requests", error)
       notifications.error("Failed to load agent actions")
       allRequests = []
-      hasNextPage = false
+      summary = null
     } finally {
       loading = false
     }
@@ -280,7 +282,7 @@
     const currentAgentIds = ($agentsStore.agents || []).map(agent => agent._id)
     if (!currentAgentIds.length) {
       allRequests = []
-      hasNextPage = false
+      summary = null
       return
     }
 

--- a/packages/builder/src/pages/builder/workspace/[application]/activity/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/activity/index.svelte
@@ -5,7 +5,10 @@
   import { builderStore } from "@/stores/builder"
   import { Body, Pagination, Table, notifications } from "@budibase/bbui"
   import { BuilderSocketEvent } from "@budibase/shared-core"
-  import type { AgentRequestStatus } from "@budibase/types"
+  import type {
+    AgentRequestsSummary,
+    AgentRequestStatus,
+  } from "@budibase/types"
   import { FeatureFlag, type AgentRequest } from "@budibase/types"
   import { goto } from "@roxi/routify"
   import dayjs from "dayjs"
@@ -30,7 +33,7 @@
     value: number
   }
 
-  const PAGE_SIZE = 40
+  const PAGE_SIZE = 20
   const tableSchema = {
     title: {
       type: "string",
@@ -62,6 +65,7 @@
   let currentPage = $state(1)
   let selectedRequestId = $state<string | null>(null)
   let allRequests = $state<AgentRequest[]>([])
+  let summary = $state<AgentRequestsSummary | null>(null)
   let userNames = $state<Record<string, string>>({})
   let hasNextPage = $state(false)
   let activityEnabled = $derived($featureFlags[FeatureFlag.AI_AGENT_ACTIVITY])
@@ -98,25 +102,19 @@
   let filteredRequests = $derived(allRequests)
 
   let summaryMetrics = $derived.by<SummaryMetric[]>(() => {
-    const requests = filteredRequests
+    const counts = summary || {
+      total: 0,
+      active: 0,
+      needs_input: 0,
+      completed: 0,
+      failed: 0,
+    }
     return [
-      { label: "All requests", value: requests.length },
-      {
-        label: "Completed",
-        value: requests.filter(r => r.status === "completed").length,
-      },
-      {
-        label: "Processing",
-        value: requests.filter(r => r.status === "active").length,
-      },
-      {
-        label: "Needs input",
-        value: requests.filter(r => r.status === "needs_input").length,
-      },
-      {
-        label: "Failed",
-        value: requests.filter(r => r.status === "failed").length,
-      },
+      { label: "All requests", value: counts.total },
+      { label: "Completed", value: counts.completed },
+      { label: "Processing", value: counts.active },
+      { label: "Needs input", value: counts.needs_input },
+      { label: "Failed", value: counts.failed },
     ]
   })
 
@@ -188,6 +186,7 @@
         page,
       })
       allRequests = response.requests
+      summary = response.summary
       hasNextPage = response.requests.length === PAGE_SIZE
       try {
         await hydrateUserNames(response.requests)
@@ -297,12 +296,27 @@
     }
 
     const handleAgentRequestChange = async (request: AgentRequest) => {
-      const exists = allRequests.some(r => r._id === request._id)
-      if (exists) {
+      const previous = allRequests.find(r => r._id === request._id)
+      if (previous) {
         allRequests = allRequests.map(r =>
           r._id === request._id ? request : r
         )
+        if (summary && previous.status !== request.status) {
+          summary = {
+            ...summary,
+            [previous.status]: summary[previous.status] - 1,
+            [request.status]: summary[request.status] + 1,
+          }
+        }
         return
+      }
+
+      if (summary) {
+        summary = {
+          ...summary,
+          total: summary.total + 1,
+          [request.status]: summary[request.status] + 1,
+        }
       }
 
       // Only insert live on page 1. A request created while viewing a

--- a/packages/server/src/api/controllers/ai/agentRequests.ts
+++ b/packages/server/src/api/controllers/ai/agentRequests.ts
@@ -46,11 +46,15 @@ export async function fetchAgentRequests(
   const { limit, page } = ctx.query as Record<string, string>
   const resolvedLimit = sanitizeLimitQuery(limit)
   const resolvedPage = sanitizePageQuery(page)
-  const requests = await sdk.ai.agentRequests.fetchRequests({
-    limit: resolvedLimit,
-    page: resolvedPage,
-  })
+  const [requests, summary] = await Promise.all([
+    sdk.ai.agentRequests.fetchRequests({
+      limit: resolvedLimit,
+      page: resolvedPage,
+    }),
+    sdk.ai.agentRequests.fetchRequestsSummary(),
+  ])
   ctx.body = {
     requests,
+    summary,
   }
 }

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
@@ -4,7 +4,6 @@ import {
   createOrUpdateRequestForPrompt,
   fetchRequestsByAgent,
   fetchRequestsSummary,
-  findRequestBySession,
   initActiveRequest,
   resolveFinalRequestStatus,
   updateRequestStatus,
@@ -462,31 +461,6 @@ describe("agentRequests crud", () => {
           failed: 1,
           needs_input: 1,
         })
-      })
-    })
-  })
-
-  describe("findRequestBySession", () => {
-    it("finds the request that has an entry with the given sessionId", async () => {
-      await config.doInContext(config.getProdWorkspaceId(), async () => {
-        const { requestId } = (await initActiveRequest({
-          agentId: "agent_1",
-          userId: "user_1",
-          sessionId: "session_1",
-          latestPrompt: "Book me a meeting",
-          operation: { name: "Scheduling", prompt: "Schedule meetings." },
-          source: "Chat",
-        }))!
-
-        const found = await findRequestBySession("agent_1", "session_1")
-        expect(found?._id).toEqual(requestId)
-      })
-    })
-
-    it("returns undefined when no request matches the session", async () => {
-      await config.doInContext(config.getProdWorkspaceId(), async () => {
-        const found = await findRequestBySession("agent_1", "unknown-session")
-        expect(found).toBeUndefined()
       })
     })
   })

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
@@ -3,6 +3,7 @@ import { builderSocket } from "../../../../websockets"
 import {
   createOrUpdateRequestForPrompt,
   fetchRequestsByAgent,
+  fetchRequestsSummary,
   findRequestBySession,
   initActiveRequest,
   resolveFinalRequestStatus,
@@ -396,6 +397,71 @@ describe("agentRequests crud", () => {
 
         const [request] = await fetchRequestsByAgent("agent_1")
         expect(request.status).toEqual("completed")
+      })
+    })
+  })
+
+  describe("fetchRequestsSummary", () => {
+    it("counts requests by status across the whole workspace", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const operation = { name: "Scheduling", prompt: "Schedule meetings." }
+
+        await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_active",
+          latestPrompt: "Book me a meeting",
+          operation,
+          source: "Chat",
+        })
+
+        const completed = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_completed",
+          latestPrompt: "Book me a meeting",
+          operation,
+          source: "Chat",
+        }))!
+        await updateRequestStatus({
+          requestId: completed.requestId,
+          status: "completed",
+        })
+
+        const failed = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_failed",
+          latestPrompt: "Book me a meeting",
+          operation,
+          source: "Chat",
+        }))!
+        await updateRequestStatus({
+          requestId: failed.requestId,
+          status: "failed",
+          error: "Tool calls incomplete",
+        })
+
+        const needsInput = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_needs_input",
+          latestPrompt: "Approve this purchase",
+          operation,
+          source: "Chat",
+        }))!
+        await updateRequestStatus({
+          requestId: needsInput.requestId,
+          status: "needs_input",
+        })
+
+        expect(await fetchRequestsSummary()).toEqual({
+          total: 4,
+          active: 1,
+          completed: 1,
+          failed: 1,
+          needs_input: 1,
+        })
       })
     })
   })

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
@@ -1,8 +1,16 @@
 import { context, docIds, Duration } from "@budibase/backend-core"
-import type { AgentRequest, AgentRequestEntry } from "@budibase/types"
+import type {
+  AgentRequest,
+  AgentRequestEntry,
+  AgentRequestsSummary,
+} from "@budibase/types"
 import { builderSocket } from "../../../../websockets"
 import { analyzeAgentRequestLink, generateAgentRequestTitle } from "./helpers"
-import { queryRequestsByAgent, queryRequestsByUpdatedAt } from "./views"
+import {
+  queryRequestsByAgent,
+  queryRequestStatuses,
+  queryRequestsByUpdatedAt,
+} from "./views"
 
 const THREAD_CANDIDATE_LIMIT = 10
 const THREAD_LOOKBACK_DAYS = 30
@@ -176,6 +184,17 @@ export async function fetchRequests({
     limit,
     page,
   })
+}
+
+export async function fetchRequestsSummary(): Promise<AgentRequestsSummary> {
+  const statuses = await queryRequestStatuses()
+  return {
+    total: statuses.length,
+    active: statuses.filter(status => status === "active").length,
+    needs_input: statuses.filter(status => status === "needs_input").length,
+    completed: statuses.filter(status => status === "completed").length,
+    failed: statuses.filter(status => status === "failed").length,
+  }
 }
 
 export async function fetchRequestsByAgent(

--- a/packages/server/src/sdk/workspace/ai/agentRequests/views.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/views.ts
@@ -71,7 +71,7 @@ export const queryRequestsByUpdatedAt = async ({
 }
 
 export const queryRequestStatuses = async (): Promise<AgentRequestStatus[]> => {
-  return (await db.queryView<AgentRequest>(
+  return (await db.queryView(
     REQUESTS_BY_UPDATED_AT_VIEW,
     {
       include_docs: false,
@@ -79,5 +79,5 @@ export const queryRequestStatuses = async (): Promise<AgentRequestStatus[]> => {
     context.getProdWorkspaceDB(),
     createRequestsByUpdatedAtView,
     { arrayResponse: true }
-  )) as unknown as AgentRequestStatus[]
+  )) as AgentRequestStatus[]
 }

--- a/packages/server/src/sdk/workspace/ai/agentRequests/views.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/views.ts
@@ -1,4 +1,5 @@
 import { context, db, ViewName } from "@budibase/backend-core"
+import type { AgentRequestStatus } from "@budibase/types"
 import type { AgentRequest } from "@budibase/types"
 import { DocumentType } from "@budibase/types"
 
@@ -13,7 +14,7 @@ const buildRequestsByAgentView = (): string => `function(doc) {
 
 const buildRequestsByUpdatedAtView = (): string => `function(doc) {
   if (doc._id && doc._id.startsWith("${DocumentType.AGENT_REQUEST}_") && (doc.updatedAt || doc.createdAt)) {
-    emit(doc.updatedAt || doc.createdAt, null)
+    emit(doc.updatedAt || doc.createdAt, doc.status)
   }
 }`
 
@@ -67,4 +68,16 @@ export const queryRequestsByUpdatedAt = async ({
     createRequestsByUpdatedAtView,
     { arrayResponse: true }
   )) as AgentRequest[]
+}
+
+export const queryRequestStatuses = async (): Promise<AgentRequestStatus[]> => {
+  return (await db.queryView<AgentRequest>(
+    REQUESTS_BY_UPDATED_AT_VIEW,
+    {
+      include_docs: false,
+    },
+    context.getProdWorkspaceDB(),
+    createRequestsByUpdatedAtView,
+    { arrayResponse: true }
+  )) as unknown as AgentRequestStatus[]
 }

--- a/packages/types/src/api/web/global/agentRequests.ts
+++ b/packages/types/src/api/web/global/agentRequests.ts
@@ -1,5 +1,10 @@
-import { AgentRequest } from "../../../documents"
+import { AgentRequest, AgentRequestStatus } from "../../../documents"
+
+export type AgentRequestsSummary = Record<AgentRequestStatus, number> & {
+  total: number
+}
 
 export interface FetchAgentRequestsResponse {
   requests: AgentRequest[]
+  summary: AgentRequestsSummary
 }


### PR DESCRIPTION
## Addresses

- https://github.com/Budibase/budibase/pull/19150

## Description

Follow-up fixes on top of the Activity page real-time updates (WebSocket-driven), addressing bugs found around pagination and the summary tiles:

- Fixed a bug where the summary tiles (`All requests`, `Completed`, `Processing`, `Needs input`, `Failed`) could get out of sync with real-time updates.
- Fixed the real-time pagination component so status changes on existing requests update the row wherever it lives, regardless of the page the user is currently viewing.
- Fixed a room mismatch bug (dev vs prod workspace id) that caused real-time tile updates to silently stop working.
- When a brand-new request comes in while the user is on a page other than page 1, the page now refreshes from the server (`loadRequests(currentPage)`) so rows shift down correctly, instead of being silently ignored until a manual refresh.
- Updated the pagination footer copy from `Showing 1 to 20 items` to `Showing 1–20 of 208 items`, including the total count.

## Screen recording

https://github.com/user-attachments/assets/ff17de9d-edc3-4dd7-9531-7ca3739ac67a

## Launchcontrol
Fixes real-time updates on the Activity page so request counts, tiles, and pagination stay accurate as new agent requests come in and existing ones change status, no matter which page you're viewing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

