### PR TITLE
Add status filter dropdown to Activity requests table

### DIFF
--- a/packages/backend-core/src/constants/db.ts
+++ b/packages/backend-core/src/constants/db.ts
@@ -28,6 +28,7 @@ export enum ViewName {
   BY_API_KEY = "by_api_key",
   AGENT_REQUESTS_BY_AGENT = "agent_requests_by_agent",
   AGENT_REQUESTS_BY_UPDATED_AT = "agent_requests_by_updated_at_2",
+  AGENT_REQUESTS_BY_STATUS_AND_UPDATED_AT = "agent_requests_by_status_and_updated_at",
   LINK = "by_link",
   ROUTING = "screen_routes_2",
   PROJECT_MEMBERS = "project_members",

--- a/packages/builder/src/pages/builder/workspace/[application]/activity/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/activity/index.svelte
@@ -208,6 +208,7 @@
       if (!($agentsStore.agents || []).length) {
         allRequests = []
         summary = null
+        loading = false
         return
       }
 

--- a/packages/builder/src/pages/builder/workspace/[application]/activity/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/activity/index.svelte
@@ -199,36 +199,52 @@
     return `Showing ${start}–${end} of ${filteredTotal} items`
   })
 
-  async function loadRequests(page = currentPage) {
-    if (!($agentsStore.agents || []).length) {
-      allRequests = []
-      summary = null
-      return
-    }
+  const loadRequests = (() => {
+    let requestSequence = 0
 
-    loading = true
-    try {
-      const response = await API.fetchAgentRequests({
-        limit: PAGE_SIZE,
-        page,
-        status: statusFilter === "all" ? undefined : statusFilter,
-      })
-      allRequests = response.requests
-      summary = response.summary
-      try {
-        await hydrateUserNames(response.requests)
-      } catch (error) {
-        console.error("Failed to hydrate agent request user names", error)
+    return async function loadRequests(page = currentPage) {
+      const sequence = ++requestSequence
+
+      if (!($agentsStore.agents || []).length) {
+        allRequests = []
+        summary = null
+        return
       }
-    } catch (error) {
-      console.error("Failed to fetch agent requests", error)
-      notifications.error("Failed to load agent actions")
-      allRequests = []
-      summary = null
-    } finally {
-      loading = false
+
+      loading = true
+      try {
+        const response = await API.fetchAgentRequests({
+          limit: PAGE_SIZE,
+          page,
+          status: statusFilter === "all" ? undefined : statusFilter,
+        })
+        if (sequence !== requestSequence) {
+          // A newer request was issued while this one was in flight - discard
+          // this stale response so it can't overwrite fresher state.
+          return
+        }
+        allRequests = response.requests
+        summary = response.summary
+        try {
+          await hydrateUserNames(response.requests)
+        } catch (error) {
+          console.error("Failed to hydrate agent request user names", error)
+        }
+      } catch (error) {
+        if (sequence !== requestSequence) {
+          return
+        }
+        console.error("Failed to fetch agent requests", error)
+        notifications.error("Failed to load agent actions")
+        allRequests = []
+        summary = null
+      } finally {
+        if (sequence === requestSequence) {
+          loading = false
+        }
+      }
     }
-  }
+  })()
 
   async function hydrateUserNames(requests: AgentRequest[]) {
     const missingUserIds = [...new Set(requests.map(request => request.userId))]

--- a/packages/builder/src/pages/builder/workspace/[application]/activity/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/activity/index.svelte
@@ -3,7 +3,13 @@
   import { agentsStore, featureFlags } from "@/stores/portal"
   import { users } from "@/stores/portal/users"
   import { builderStore } from "@/stores/builder"
-  import { Body, Pagination, Table, notifications } from "@budibase/bbui"
+  import {
+    Body,
+    Pagination,
+    Select,
+    Table,
+    notifications,
+  } from "@budibase/bbui"
   import { BuilderSocketEvent } from "@budibase/shared-core"
   import type {
     AgentRequestsSummary,
@@ -61,16 +67,26 @@
 
   const RELATIVE_TIME_REFRESH_MS = 30000
 
+  type StatusFilter = AgentRequestStatus | "all"
+
   let loading = $state(false)
   let currentPage = $state(1)
+  let statusFilter = $state<StatusFilter>("all")
   let selectedRequestId = $state<string | null>(null)
   let allRequests = $state<AgentRequest[]>([])
   let summary = $state<AgentRequestsSummary | null>(null)
   let userNames = $state<Record<string, string>>({})
   let activityEnabled = $derived($featureFlags[FeatureFlag.AI_AGENT_ACTIVITY])
 
+  let filteredTotal = $derived.by(() => {
+    if (!summary) {
+      return 0
+    }
+    return statusFilter === "all" ? summary.total : summary[statusFilter]
+  })
+
   let hasNextPage = $derived.by(() => {
-    return !!summary && summary.total > currentPage * PAGE_SIZE
+    return filteredTotal > currentPage * PAGE_SIZE
   })
 
   // Ticks on an interval purely to force updatedLabel to re-derive
@@ -82,6 +98,14 @@
     completed: { label: "Completed" },
     failed: { label: "Failed" },
   }
+
+  const statusFilterOptions: { label: string; value: StatusFilter }[] = [
+    { label: "All statuses", value: "all" },
+    ...(Object.keys(requestStatusMeta) as AgentRequestStatus[]).map(status => ({
+      label: requestStatusMeta[status].label,
+      value: status,
+    })),
+  ]
 
   const getRequestTitle = (request: AgentRequest) => {
     return request.title || "Untitled request"
@@ -167,13 +191,12 @@
   let paginationLabel = $derived.by(() => {
     const start = (currentPage - 1) * PAGE_SIZE + 1
     const end = start + paginatedRows.length - 1
-    const total = summary?.total || 0
 
     if (!paginatedRows.length) {
       return "Showing 0 items"
     }
 
-    return `Showing ${start}–${end} of ${total} items`
+    return `Showing ${start}–${end} of ${filteredTotal} items`
   })
 
   async function loadRequests(page = currentPage) {
@@ -188,6 +211,7 @@
       const response = await API.fetchAgentRequests({
         limit: PAGE_SIZE,
         page,
+        status: statusFilter === "all" ? undefined : statusFilter,
       })
       allRequests = response.requests
       summary = response.summary
@@ -240,6 +264,17 @@
       ...userNames,
       ...Object.fromEntries(entries),
     }
+  }
+
+  function changeStatusFilter(nextFilter: StatusFilter) {
+    if (nextFilter === statusFilter) {
+      return
+    }
+
+    statusFilter = nextFilter
+    currentPage = 1
+    selectedRequestId = null
+    loadRequests(1)
   }
 
   function changePage(nextPage: number) {
@@ -299,6 +334,15 @@
     }
 
     const handleAgentRequestChange = async (request: AgentRequest) => {
+      // With a status filter active, a change can move a request in or out
+      // of the filtered set (e.g. it stops being "Failed"), which a local
+      // patch can't express correctly - only a re-fetch can. loadRequests
+      // also refreshes summary from the server, so no manual patch is needed.
+      if (statusFilter !== "all") {
+        await loadRequests(currentPage)
+        return
+      }
+
       const previous = allRequests.find(r => r._id === request._id)
       if (previous) {
         allRequests = allRequests.map(r =>
@@ -369,6 +413,18 @@
         </section>
       {/each}
     </div>
+
+    <div class="filters-row">
+      <Select
+        size="M"
+        autoWidth
+        placeholder={false}
+        options={statusFilterOptions}
+        value={statusFilter}
+        on:change={({ detail }) => changeStatusFilter(detail)}
+      />
+    </div>
+
     <section class="requests-table-panel">
       <Table
         quiet
@@ -445,6 +501,15 @@
     display: flex;
     flex-direction: column;
     gap: calc(var(--spacing-s) - var(--spacing-xs));
+  }
+
+  .filters-row {
+    display: flex;
+    justify-content: flex-start;
+  }
+
+  .filters-row :global(.spectrum-Picker) {
+    min-width: 180px;
   }
 
   .requests-table-panel {

--- a/packages/frontend-core/src/api/agentRequests.ts
+++ b/packages/frontend-core/src/api/agentRequests.ts
@@ -1,10 +1,14 @@
-import type { FetchAgentRequestsResponse } from "@budibase/types"
+import type {
+  AgentRequestStatus,
+  FetchAgentRequestsResponse,
+} from "@budibase/types"
 import type { BaseAPIClient } from "./types"
 
 export interface AgentRequestEndpoints {
   fetchAgentRequests: (opts?: {
     limit?: number
     page?: number
+    status?: AgentRequestStatus
   }) => Promise<FetchAgentRequestsResponse>
 }
 
@@ -18,6 +22,9 @@ export const buildAgentRequestEndpoints = (
     }
     if (opts.page !== undefined) {
       params.set("page", String(opts.page))
+    }
+    if (opts.status !== undefined) {
+      params.set("status", opts.status)
     }
 
     const query = params.toString()

--- a/packages/server/src/api/controllers/ai/agentRequests.ts
+++ b/packages/server/src/api/controllers/ai/agentRequests.ts
@@ -1,5 +1,10 @@
 import { HTTPError } from "@budibase/backend-core"
-import type { FetchAgentRequestsResponse, UserCtx } from "@budibase/types"
+import {
+  AGENT_REQUEST_STATUSES,
+  type AgentRequestStatus,
+  type FetchAgentRequestsResponse,
+  type UserCtx,
+} from "@budibase/types"
 import sdk from "../../../sdk"
 
 const DEFAULT_LIMIT = 100
@@ -40,16 +45,35 @@ const sanitizePageQuery = (page?: string): number => {
   return parsedPage
 }
 
+const sanitizeStatusQuery = (
+  status?: string
+): AgentRequestStatus | undefined => {
+  const normalizedStatus = status?.trim()
+  if (!normalizedStatus) {
+    return undefined
+  }
+
+  if (
+    !AGENT_REQUEST_STATUSES.includes(normalizedStatus as AgentRequestStatus)
+  ) {
+    throw new HTTPError("Invalid status query", 400)
+  }
+
+  return normalizedStatus as AgentRequestStatus
+}
+
 export async function fetchAgentRequests(
   ctx: UserCtx<void, FetchAgentRequestsResponse>
 ) {
-  const { limit, page } = ctx.query as Record<string, string>
+  const { limit, page, status } = ctx.query as Record<string, string>
   const resolvedLimit = sanitizeLimitQuery(limit)
   const resolvedPage = sanitizePageQuery(page)
+  const resolvedStatus = sanitizeStatusQuery(status)
   const [requests, summary] = await Promise.all([
     sdk.ai.agentRequests.fetchRequests({
       limit: resolvedLimit,
       page: resolvedPage,
+      status: resolvedStatus,
     }),
     sdk.ai.agentRequests.fetchRequestsSummary(),
   ])

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
@@ -2,6 +2,7 @@ import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
 import { builderSocket } from "../../../../websockets"
 import {
   createOrUpdateRequestForPrompt,
+  fetchRequests,
   fetchRequestsByAgent,
   fetchRequestsSummary,
   findRequestBySession,
@@ -462,6 +463,124 @@ describe("agentRequests crud", () => {
           failed: 1,
           needs_input: 1,
         })
+      })
+    })
+  })
+
+  describe("fetchRequests", () => {
+    it("returns every request ordered by most recently updated when no status is given", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const operation = { name: "Scheduling", prompt: "Schedule meetings." }
+
+        const first = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_1",
+          latestPrompt: "Book me a meeting",
+          operation,
+          source: "Chat",
+        }))!
+        const second = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_2",
+          latestPrompt: "Book me a meeting",
+          operation,
+          source: "Chat",
+        }))!
+        await updateRequestStatus({
+          requestId: second.requestId,
+          status: "completed",
+        })
+
+        const requests = await fetchRequests({ limit: 10, page: 1 })
+        expect(requests.map(r => r._id)).toEqual([
+          second.requestId,
+          first.requestId,
+        ])
+      })
+    })
+
+    it("only returns requests matching the given status", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const operation = { name: "Scheduling", prompt: "Schedule meetings." }
+
+        const active = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_active",
+          latestPrompt: "Book me a meeting",
+          operation,
+          source: "Chat",
+        }))!
+
+        const completed = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_completed",
+          latestPrompt: "Book me a meeting",
+          operation,
+          source: "Chat",
+        }))!
+        await updateRequestStatus({
+          requestId: completed.requestId,
+          status: "completed",
+        })
+
+        const failedRequests = await fetchRequests({
+          limit: 10,
+          page: 1,
+          status: "failed",
+        })
+        expect(failedRequests).toHaveLength(0)
+
+        const completedRequests = await fetchRequests({
+          limit: 10,
+          page: 1,
+          status: "completed",
+        })
+        expect(completedRequests.map(r => r._id)).toEqual([completed.requestId])
+
+        const activeRequests = await fetchRequests({
+          limit: 10,
+          page: 1,
+          status: "active",
+        })
+        expect(activeRequests.map(r => r._id)).toEqual([active.requestId])
+      })
+    })
+
+    it("paginates within a single status", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const operation = { name: "Scheduling", prompt: "Schedule meetings." }
+
+        for (const sessionId of ["session_1", "session_2", "session_3"]) {
+          await initActiveRequest({
+            agentId: "agent_1",
+            userId: "user_1",
+            sessionId,
+            latestPrompt: "Book me a meeting",
+            operation,
+            source: "Chat",
+          })
+        }
+
+        const firstPage = await fetchRequests({
+          limit: 2,
+          page: 1,
+          status: "active",
+        })
+        const secondPage = await fetchRequests({
+          limit: 2,
+          page: 2,
+          status: "active",
+        })
+
+        expect(firstPage).toHaveLength(2)
+        expect(secondPage).toHaveLength(1)
+        expect(
+          firstPage.map(r => r._id).concat(secondPage.map(r => r._id))
+        ).toHaveLength(3)
       })
     })
   })

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
@@ -584,31 +584,6 @@ describe("agentRequests crud", () => {
     })
   })
 
-  describe("findRequestBySession", () => {
-    it("finds the request that has an entry with the given sessionId", async () => {
-      await config.doInContext(config.getProdWorkspaceId(), async () => {
-        const { requestId } = (await initActiveRequest({
-          agentId: "agent_1",
-          userId: "user_1",
-          sessionId: "session_1",
-          latestPrompt: "Book me a meeting",
-          operation: { name: "Scheduling", prompt: "Schedule meetings." },
-          source: "Chat",
-        }))!
-
-        const found = await findRequestBySession("agent_1", "session_1")
-        expect(found?._id).toEqual(requestId)
-      })
-    })
-
-    it("returns undefined when no request matches the session", async () => {
-      await config.doInContext(config.getProdWorkspaceId(), async () => {
-        const found = await findRequestBySession("agent_1", "unknown-session")
-        expect(found).toBeUndefined()
-      })
-    })
-  })
-
   describe("resolveFinalRequestStatus", () => {
     it("fails with an incomplete tool calls error when tool calls are incomplete", () => {
       expect(

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
@@ -3,6 +3,7 @@ import type {
   AgentRequest,
   AgentRequestEntry,
   AgentRequestsSummary,
+  AgentRequestStatus,
 } from "@budibase/types"
 import { builderSocket } from "../../../../websockets"
 import { analyzeAgentRequestLink, generateAgentRequestTitle } from "./helpers"
@@ -10,6 +11,7 @@ import {
   queryRequestsByAgent,
   queryRequestStatuses,
   queryRequestsByUpdatedAt,
+  queryRequestsByStatusAndUpdatedAt,
 } from "./views"
 
 const THREAD_CANDIDATE_LIMIT = 10
@@ -176,10 +178,16 @@ async function createNewRequest({
 export async function fetchRequests({
   limit,
   page,
+  status,
 }: {
   limit: number
   page: number
+  status?: AgentRequestStatus
 }): Promise<AgentRequest[]> {
+  if (status) {
+    return await queryRequestsByStatusAndUpdatedAt({ status, limit, page })
+  }
+
   return await queryRequestsByUpdatedAt({
     limit,
     page,

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
@@ -2,7 +2,6 @@ import { context, docIds, Duration } from "@budibase/backend-core"
 import type {
   AgentRequest,
   AgentRequestEntry,
-  AgentRequestStatus,
   AgentRequestsSummary,
   AgentRequestStatus,
 } from "@budibase/types"

--- a/packages/server/src/sdk/workspace/ai/agentRequests/views.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/views.ts
@@ -5,6 +5,8 @@ import { DocumentType } from "@budibase/types"
 
 const REQUESTS_BY_AGENT_VIEW = ViewName.AGENT_REQUESTS_BY_AGENT
 const REQUESTS_BY_UPDATED_AT_VIEW = ViewName.AGENT_REQUESTS_BY_UPDATED_AT
+const REQUESTS_BY_STATUS_AND_UPDATED_AT_VIEW =
+  ViewName.AGENT_REQUESTS_BY_STATUS_AND_UPDATED_AT
 
 const buildRequestsByAgentView = (): string => `function(doc) {
   if (doc._id && doc._id.startsWith("${DocumentType.AGENT_REQUEST}_") && doc.agentId) {
@@ -15,6 +17,12 @@ const buildRequestsByAgentView = (): string => `function(doc) {
 const buildRequestsByUpdatedAtView = (): string => `function(doc) {
   if (doc._id && doc._id.startsWith("${DocumentType.AGENT_REQUEST}_") && (doc.updatedAt || doc.createdAt)) {
     emit(doc.updatedAt || doc.createdAt, doc.status)
+  }
+}`
+
+const buildRequestsByStatusAndUpdatedAtView = (): string => `function(doc) {
+  if (doc._id && doc._id.startsWith("${DocumentType.AGENT_REQUEST}_") && doc.status && (doc.updatedAt || doc.createdAt)) {
+    emit([doc.status, doc.updatedAt || doc.createdAt], null)
   }
 }`
 
@@ -31,6 +39,14 @@ export const createRequestsByUpdatedAtView = async () => {
     context.getProdWorkspaceDB(),
     buildRequestsByUpdatedAtView(),
     REQUESTS_BY_UPDATED_AT_VIEW
+  )
+}
+
+export const createRequestsByStatusAndUpdatedAtView = async () => {
+  await db.createView(
+    context.getProdWorkspaceDB(),
+    buildRequestsByStatusAndUpdatedAtView(),
+    REQUESTS_BY_STATUS_AND_UPDATED_AT_VIEW
   )
 }
 
@@ -66,6 +82,31 @@ export const queryRequestsByUpdatedAt = async ({
     },
     context.getProdWorkspaceDB(),
     createRequestsByUpdatedAtView,
+    { arrayResponse: true }
+  )) as AgentRequest[]
+}
+
+export const queryRequestsByStatusAndUpdatedAt = async ({
+  status,
+  limit,
+  page,
+}: {
+  status: AgentRequestStatus
+  limit: number
+  page: number
+}): Promise<AgentRequest[]> => {
+  return (await db.queryView<AgentRequest>(
+    REQUESTS_BY_STATUS_AND_UPDATED_AT_VIEW,
+    {
+      include_docs: true,
+      descending: true,
+      startkey: [status, {}],
+      endkey: [status],
+      limit,
+      skip: (page - 1) * limit,
+    },
+    context.getProdWorkspaceDB(),
+    createRequestsByStatusAndUpdatedAtView,
     { arrayResponse: true }
   )) as AgentRequest[]
 }

--- a/packages/types/src/documents/global/agentRequests.ts
+++ b/packages/types/src/documents/global/agentRequests.ts
@@ -1,10 +1,13 @@
 import { Document } from "../../"
 
-export type AgentRequestStatus =
-  | "active"
-  | "needs_input"
-  | "completed"
-  | "failed"
+export const AGENT_REQUEST_STATUSES = [
+  "active",
+  "needs_input",
+  "completed",
+  "failed",
+] as const
+
+export type AgentRequestStatus = (typeof AGENT_REQUEST_STATUSES)[number]
 
 export interface AgentRequestEntry {
   sessionId: string


### PR DESCRIPTION
## Addresses

- https://github.com/Budibase/budibase/pull/19150

## Description

Adds a status filter dropdown (All statuses / Processing / Needs input / Completed / Failed) to the Activity page, placed left-aligned between the summary tiles and the requests table.

The filter is server-side rather than client-only, so pagination and the "Showing X-Y of Z items" count stay accurate for the selected status instead of only reflecting whatever happened to be on the currently loaded page:

- New CouchDB view keyed by `[status, updatedAt]` for status-scoped, paginated queries (`packages/server/src/sdk/workspace/ai/agentRequests/views.ts`).
- `fetchRequests` now accepts an optional `status`; the controller validates it against `AgentRequestStatus` before passing it through.
- `AgentRequestStatus` is now derived from a single `AGENT_REQUEST_STATUSES` const array (`packages/types/src/documents/global/agentRequests.ts`) instead of being duplicated as a separate validation list, following the same pattern already used for `UrlValidationProtocol`.
- Real-time updates re-fetch the current page when a filter is active, since a status change can move a request in or out of the filtered set in a way a local patch can't express correctly.

## Screen recording

https://github.com/user-attachments/assets/6011cc5c-8cad-4e52-a651-82ac9c40aba4

## Launchcontrol
Adds a status filter to the Activity page so you can quickly narrow the requests table down to just Processing, Needs input, Completed, or Failed requests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

