### PR TITLE
View fix for external dbs on column delete

### DIFF
--- a/packages/builder/src/components/backend/DataTable/buttons/TableFilterButton.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/TableFilterButton.svelte
@@ -67,6 +67,7 @@
     datasource={{ type: "table", tableId }}
     on:change={e => (localFilters = e.detail)}
     {bindings}
+    flagInvalidFields
   />
   <div>
     <Button

--- a/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
+++ b/packages/builder/src/components/backend/DataTable/modals/CreateEditColumn.svelte
@@ -62,6 +62,9 @@
     FormulaResponseType,
     FieldSchemaConfig,
     UIFieldSchema,
+    SearchFilterGroup,
+    UISearchFilter,
+    ViewV2,
   } from "@budibase/types"
 
   export let field: FieldSchema
@@ -420,6 +423,57 @@
     }
     gridDispatch("close-edit-column")
   }
+
+  const collectFilterFields = (
+    group: SearchFilterGroup | UISearchFilter
+  ): string[] => {
+    if (group.groups) {
+      return group.groups.flatMap(collectFilterFields)
+    }
+    if ("filters" in group && group.filters) {
+      return group.filters
+        .map(filter => ("field" in filter ? filter.field : undefined))
+        .filter((field): field is string => field != null)
+    }
+    return []
+  }
+
+  const getViewFilterFields = (view: ViewV2): string[] => {
+    if (view.queryUI) {
+      return collectFilterFields(view.queryUI)
+    }
+    if (Array.isArray(view.query)) {
+      return view.query
+        .map(filter => ("field" in filter ? filter.field : undefined))
+        .filter((field): field is string => field != null)
+    }
+    return []
+  }
+
+  const filterUsesColumn = (field: string, column: string): boolean => {
+    const key = field.replace(/^\d+:/, "")
+    return key === column || key.startsWith(`${column}.`)
+  }
+
+  const getViewsFilteringOnColumn = (
+    table: Table | undefined,
+    column: string | undefined
+  ): string[] => {
+    if (!table?.views || !column) {
+      return []
+    }
+    return Object.values(table.views)
+      .filter(helpers.views.isV2)
+      .filter(view =>
+        getViewFilterFields(view).some(field => filterUsesColumn(field, column))
+      )
+      .map(view => view.name)
+  }
+
+  $: viewsFilteringOnColumn = getViewsFilteringOnColumn(
+    $tables.selected,
+    originalName
+  )
 
   async function deleteColumn() {
     try {
@@ -1069,6 +1123,14 @@
     Your data will be deleted and this action cannot be undone - enter the column
     name to confirm.
   </p>
+  {#if viewsFilteringOnColumn.length}
+    <p>
+      This column is used in filters for the following
+      {viewsFilteringOnColumn.length === 1 ? "view" : "views"}:
+      <strong>{viewsFilteringOnColumn.join(", ")}</strong>. These views will
+      show no data until their filters are updated.
+    </p>
+  {/if}
   <Input bind:value={deleteColName} placeholder={originalName} />
 </ConfirmDialog>
 

--- a/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
+++ b/packages/builder/src/components/backend/modals/DeleteDataConfirmationModal.svelte
@@ -115,7 +115,14 @@
   async function deleteView(view: ViewV2 | View) {
     try {
       if (helpers.views.isV2(view)) {
-        await viewsV2.delete(view as ViewV2)
+        const viewV2 = view as ViewV2
+        const isSelected = params.viewId === viewV2.id
+        await viewsV2.delete(viewV2)
+        if (isSelected) {
+          goto(
+            `/builder/workspace/${$appStore.appId}/data/table/${viewV2.tableId}`
+          )
+        }
       } else {
         await views.delete(view as View)
       }

--- a/packages/builder/src/components/design/settings/controls/FilterEditor/FilterBuilder.svelte
+++ b/packages/builder/src/components/design/settings/controls/FilterEditor/FilterBuilder.svelte
@@ -17,6 +17,7 @@
   export let builderType = undefined
   export let docsURL = undefined
   export let evaluationContext = {}
+  export let flagInvalidFields = false
 </script>
 
 <CoreFilterBuilder
@@ -34,5 +35,6 @@
   {builderType}
   {docsURL}
   {evaluationContext}
+  {flagInvalidFields}
   on:change
 />

--- a/packages/frontend-core/src/components/CoreFilterBuilder.svelte
+++ b/packages/frontend-core/src/components/CoreFilterBuilder.svelte
@@ -1,5 +1,6 @@
 <script>
   import {
+    AbsTooltip,
     Body,
     Button,
     Icon,
@@ -44,6 +45,7 @@
   export let drawerTitle = null
   export let bindingValueType = Constants.FilterValueType.BINDING
   export let useConditionValueControls = false
+  export let flagInvalidFields = false
 
   export let bindings
   export let panel
@@ -102,6 +104,41 @@
       label: field.displayName || field.name,
       value: field.name,
     }))
+
+  const INVALID_FIELD_TOOLTIP =
+    "This field may have been deleted or renamed and will be ignored. Delete or update as required"
+
+  const isInvalidField = (filter, options) => {
+    return (
+      flagInvalidFields &&
+      !!filter.field &&
+      !options.some(option => option.value === filter.field)
+    )
+  }
+
+  // A saved filter can reference a column that no longer exists. When enabled,
+  // keep the referenced field visible as a flagged option rather than an
+  // unset column select, so it can be seen and resolved.
+  const getFieldOptions = (filter, options) => {
+    if (isInvalidField(filter, options)) {
+      return [
+        {
+          label: filter.field,
+          value: filter.field,
+          icon: {
+            component: Icon,
+            props: {
+              name: "warning",
+              size: "M",
+              color: "var(--spectrum-global-color-yellow-600)",
+            },
+          },
+        },
+        ...options,
+      ]
+    }
+    return options
+  }
 
   const onFieldChange = filter => {
     const previousType = filter.type
@@ -376,17 +413,23 @@
                         {sanitizeValue}
                       />
                     {:else}
-                      <Select
-                        value={filter.field}
-                        options={fieldOptions}
-                        on:change={e => {
-                          const updated = { ...filter, field: e.detail }
-                          onFieldChange(updated)
-                          onFilterFieldUpdate(updated, groupIdx, filterIdx)
-                        }}
-                        placeholder="Column"
-                        popoverAutoWidth
-                      />
+                      <AbsTooltip
+                        text={isInvalidField(filter, fieldOptions)
+                          ? INVALID_FIELD_TOOLTIP
+                          : ""}
+                      >
+                        <Select
+                          value={filter.field}
+                          options={getFieldOptions(filter, fieldOptions)}
+                          on:change={e => {
+                            const updated = { ...filter, field: e.detail }
+                            onFieldChange(updated)
+                            onFilterFieldUpdate(updated, groupIdx, filterIdx)
+                          }}
+                          placeholder="Column"
+                          popoverAutoWidth
+                        />
+                      </AbsTooltip>
                     {/if}
                     <Select
                       value={filter.operator || OperatorOptions.Equals.value}

--- a/packages/frontend-core/src/components/CoreFilterBuilder.svelte
+++ b/packages/frontend-core/src/components/CoreFilterBuilder.svelte
@@ -106,7 +106,7 @@
     }))
 
   const INVALID_FIELD_TOOLTIP =
-    "This field may have been deleted or renamed and will be ignored. Delete or update as required"
+    "This field may have been deleted or renamed. No rows will be returned until it is updated or removed"
 
   const isInvalidField = (filter, options) => {
     return (

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -2243,6 +2243,161 @@ if (descriptions.length) {
             })
           })
 
+          describe("columns used in view filters", () => {
+            let view: ViewV2
+
+            const categoryFilter = (field: string): UISearchFilter => ({
+              logicalOperator: UILogicalOperator.ALL,
+              onEmptyFilter: EmptyFilterOption.RETURN_ALL,
+              groups: [
+                {
+                  logicalOperator: UILogicalOperator.ALL,
+                  filters: [
+                    {
+                      valueType: "Value",
+                      field,
+                      type: FieldType.STRING,
+                      operator: BasicOperator.EQUAL,
+                      value: "one",
+                    },
+                  ],
+                },
+              ],
+            })
+
+            beforeEach(async () => {
+              table = await config.api.table.save(
+                saveTableRequest({
+                  schema: {
+                    name: {
+                      name: "name",
+                      type: FieldType.STRING,
+                    },
+                    category: {
+                      name: "category",
+                      type: FieldType.STRING,
+                    },
+                  },
+                })
+              )
+              view = await config.api.viewV2.create({
+                name: generator.guid(),
+                tableId: table._id!,
+                queryUI: categoryFilter("category"),
+                schema: {
+                  id: { visible: true },
+                  name: { visible: true },
+                  category: { visible: true },
+                },
+              })
+              await config.api.row.save(table._id!, {
+                name: "a",
+                category: "one",
+              })
+              await config.api.row.save(table._id!, {
+                name: "b",
+                category: "two",
+              })
+            })
+
+            it("deleting the filtered column keeps the filter and the view fails closed", async () => {
+              table = await config.api.table.get(table._id!)
+              const { category, ...schema } = table.schema
+              await config.api.table.save({ ...table, schema }, { status: 200 })
+
+              // The filter is deliberately kept - removing it would widen the
+              // view's results. The search returns nothing until the filter
+              // is fixed by the user.
+              const updated = await config.api.viewV2.get(view.id)
+              expect(updated.queryUI?.groups?.[0].filters).toEqual([
+                expect.objectContaining({ field: "category", value: "one" }),
+              ])
+
+              const response = await config.api.viewV2.search(view.id)
+              expect(response.rows).toHaveLength(0)
+            })
+
+            it("hiding the filtered column keeps the view filtering", async () => {
+              table = await config.api.table.get(table._id!)
+              await config.api.table.save(
+                {
+                  ...table,
+                  schema: {
+                    ...table.schema,
+                    category: { ...table.schema.category, visible: false },
+                  },
+                },
+                { status: 200 }
+              )
+
+              const response = await config.api.viewV2.search(view.id)
+              expect(response.rows).toHaveLength(1)
+              expect(response.rows[0].name).toEqual("a")
+            })
+
+            it("renaming the filtered column keeps the filter and the view fails closed", async () => {
+              table = await config.api.table.get(table._id!)
+              const { category, ...schema } = table.schema
+              await config.api.table.save(
+                {
+                  ...table,
+                  schema: {
+                    ...schema,
+                    group: { ...category, name: "group" },
+                  },
+                  _rename: { old: "category", updated: "group" },
+                },
+                { status: 200 }
+              )
+
+              // Filters are never rewritten on schema changes - the stale
+              // reference fails closed until the user re-points it.
+              const updated = await config.api.viewV2.get(view.id)
+              expect(updated.queryUI?.groups?.[0].filters).toEqual([
+                expect.objectContaining({ field: "category", value: "one" }),
+              ])
+
+              const response = await config.api.viewV2.search(view.id)
+              expect(response.rows).toHaveLength(0)
+            })
+
+            it("fails closed instead of erroring when an existing view filter references a deleted column", async () => {
+              table = await config.api.table.get(table._id!)
+              const { category, ...schema } = table.schema
+              await config.api.table.save({ ...table, schema }, { status: 200 })
+
+              // put a stale filter into the stored view directly, as though
+              // the column disappeared without the view being touched
+              const staleQuery: SearchFilters = {
+                $and: { conditions: [{ equal: { category: "one" } }] },
+              }
+              await config.doInContext(undefined, async () => {
+                const db = context.getWorkspaceDB()
+                const setStaleFilter = (table: Table) => {
+                  const viewDoc = table.views![view.name] as ViewV2
+                  viewDoc.query = staleQuery
+                  viewDoc.queryUI = categoryFilter("category")
+                }
+                if (isInternal) {
+                  const tableDoc = await db.get<Table>(table._id!)
+                  setStaleFilter(tableDoc)
+                  await db.put(tableDoc)
+                } else {
+                  const dsDoc = await db.get<Datasource>(datasource!._id!)
+                  setStaleFilter(
+                    Object.values(dsDoc.entities!).find(
+                      entity => entity._id === table._id
+                    )!
+                  )
+                  await db.put(dsDoc)
+                }
+              })
+
+              const response = await config.api.viewV2.search(view.id)
+              expect(response.rows).toHaveLength(0)
+            })
+          })
+
           describe("foreign relationship columns", () => {
             const createAuxTable = () =>
               config.api.table.save(

--- a/packages/server/src/sdk/workspace/rows/queryUtils.ts
+++ b/packages/server/src/sdk/workspace/rows/queryUtils.ts
@@ -25,14 +25,20 @@ const isAllowedFilterKey = (key: string): boolean =>
   isRangeSearchOperator(key) ||
   isLogicalSearchOperator(key)
 
-export const validateFilters = (
+type InvalidFilterHandler = (kind: "operator" | "field", key: string) => void
+
+// Walks the filter tree, calling `onInvalid` for each invalid operator or
+// field reference - throw from it to abort the walk. `validFields` must
+// already be lowercased.
+const walkFilters = (
   filters: SearchFilters,
-  validFields: string[]
-) => {
-  validFields = validFields.map(f => f.toLowerCase())
+  validFields: string[],
+  onInvalid: InvalidFilterHandler
+): void => {
   for (const key of Object.keys(filters || {}) as (keyof SearchFilters)[]) {
     if (!isAllowedFilterKey(key)) {
-      throw new HTTPError(`Invalid filter operator: ${key}`, 400)
+      onInvalid("operator", key)
+      continue
     }
 
     if (ALLOWED_FILTER_META_KEYS.includes(key)) {
@@ -45,7 +51,7 @@ export const validateFilters = (
         continue
       }
       for (const condition of filter.conditions) {
-        validateFilters(condition, validFields)
+        walkFilters(condition, validFields, onInvalid)
       }
     } else {
       const filter = filters[key]
@@ -53,27 +59,63 @@ export const validateFilters = (
         continue
       }
 
-      for (const key of Object.keys(filter)) {
+      for (const field of Object.keys(filter)) {
         if (
-          !validFields.includes(key.toLowerCase()) &&
-          !validFields.includes(db.removeKeyNumbering(key).toLowerCase())
+          !validFields.includes(field.toLowerCase()) &&
+          !validFields.includes(db.removeKeyNumbering(field).toLowerCase())
         ) {
-          throw new HTTPError(`Invalid filter field: ${key}`, 400)
+          onInvalid("field", field)
         }
       }
     }
   }
 }
 
+export const validateFilters = (
+  filters: SearchFilters,
+  validFields: string[]
+) => {
+  walkFilters(
+    filters,
+    validFields.map(f => f.toLowerCase()),
+    (kind, key) => {
+      throw new HTTPError(`Invalid filter ${kind}: ${key}`, 400)
+    }
+  )
+}
+
+// Unlike validateFilters, this doesn't error on filter fields that aren't part
+// of the schema - it collects them. Saved view queries can reference columns
+// that have since been deleted from the table; searches against those views
+// must fail closed rather than reach the SQL layer, where external datasources
+// error on the unknown column.
+export const findInvalidFilterFields = (
+  filters: SearchFilters,
+  validFields: string[]
+): string[] => {
+  const invalid: string[] = []
+  walkFilters(
+    filters,
+    validFields.map(f => f.toLowerCase()),
+    (kind, key) => {
+      if (kind === "field") {
+        invalid.push(key)
+      }
+    }
+  )
+  return invalid
+}
+
 export const getQueryableFields = async (
   table: Table,
-  fields?: string[]
+  fields?: string[],
+  opts?: { includeHidden?: boolean }
 ): Promise<string[]> => {
   const extractTableFields = async (
     table: Table,
     allowedFields: string[],
     fromTables: string[],
-    opts?: { noRelationships?: boolean }
+    extractOpts?: { noRelationships?: boolean }
   ): Promise<string[]> => {
     const result = []
     if (isInternal({ table })) {
@@ -81,14 +123,16 @@ export const getQueryableFields = async (
     }
 
     for (const field of Object.keys(table.schema).filter(
-      f => allowedFields.includes(f) && table.schema[f].visible !== false
+      f =>
+        allowedFields.includes(f) &&
+        (opts?.includeHidden || table.schema[f].visible !== false)
     )) {
       const subSchema = table.schema[field]
       const isRelationship = subSchema.type === FieldType.LINK
       // avoid relationship loops
       if (
         isRelationship &&
-        (opts?.noRelationships || fromTables.includes(subSchema.tableId))
+        (extractOpts?.noRelationships || fromTables.includes(subSchema.tableId))
       ) {
         continue
       }

--- a/packages/server/src/sdk/workspace/rows/search.ts
+++ b/packages/server/src/sdk/workspace/rows/search.ts
@@ -17,7 +17,11 @@ import { dataFilters } from "@budibase/shared-core"
 import sdk from "../../index"
 import { checkFilters, searchInputMapping } from "./search/utils"
 import tracer from "dd-trace"
-import { getQueryableFields, validateFilters } from "./queryUtils"
+import {
+  findInvalidFilterFields,
+  getQueryableFields,
+  validateFilters,
+} from "./queryUtils"
 import { enrichSearchContext } from "../../../api/controllers/row/utils"
 
 export { isValidFilter } from "../../../integrations/utils"
@@ -99,6 +103,30 @@ export async function search(
         viewQuery = dataFilters.buildQuery(viewQuery)
       }
       viewQuery = checkFilters(table, viewQuery)
+
+      // Saved view queries can reference columns that have since been deleted
+      // from the table. The filters act as access control, so the search must
+      // fail closed: removing them would widen the results, and letting them
+      // through errors on external datasources. Hidden columns are still
+      // valid here - the view creator deliberately filtered on them.
+      if (dataFilters.hasFilters(viewQuery)) {
+        const viewQueryableFields = await getQueryableFields(table, undefined, {
+          includeHidden: true,
+        })
+        const invalidFields = findInvalidFilterFields(
+          viewQuery,
+          viewQueryableFields
+        )
+        if (invalidFields.length) {
+          span.addTags({ invalidViewFilterFields: invalidFields })
+          console.log(
+            `View ${options.viewId} filters on deleted columns: ${invalidFields.join(", ")} - returning no rows`
+          )
+          return {
+            rows: [],
+          }
+        }
+      }
 
       const conditions = viewQuery ? [viewQuery] : []
       options.query = {

--- a/packages/server/src/sdk/workspace/rows/tests/queryUtils.spec.ts
+++ b/packages/server/src/sdk/workspace/rows/tests/queryUtils.spec.ts
@@ -1,12 +1,18 @@
 import {
+  EmptyFilterOption,
   FieldType,
   RelationshipType,
   SearchFilters,
   Table,
 } from "@budibase/types"
+import _ from "lodash"
 import { structures } from "../../../../api/routes/tests/utilities"
 import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
-import { getQueryableFields, validateFilters } from "../queryUtils"
+import {
+  findInvalidFilterFields,
+  getQueryableFields,
+  validateFilters,
+} from "../queryUtils"
 
 describe("query utils", () => {
   describe("validateFilters", () => {
@@ -132,6 +138,63 @@ describe("query utils", () => {
     })
   })
 
+  describe("findInvalidFilterFields", () => {
+    it("returns nothing for filters on valid fields", () => {
+      const filters: SearchFilters = {
+        onEmptyFilter: EmptyFilterOption.RETURN_ALL,
+        equal: { one: "foo" },
+        $and: {
+          conditions: [{ equal: { one: "foo2" }, notEmpty: { two: null } }],
+        },
+      }
+
+      expect(findInvalidFilterFields(filters, ["one", "two"])).toEqual([])
+    })
+
+    it("finds filters on unknown fields", () => {
+      const filters: SearchFilters = {
+        onEmptyFilter: EmptyFilterOption.RETURN_ALL,
+        equal: { one: "foo", deleted: "bar" },
+      }
+
+      expect(findInvalidFilterFields(filters, ["one"])).toEqual(["deleted"])
+    })
+
+    it("finds unknown fields nested in logical operators", () => {
+      const filters: SearchFilters = {
+        $or: {
+          conditions: [
+            { $and: { conditions: [{ equal: { deleted: "foo" } }] } },
+            { equal: { one: "foo", missing: "bar" } },
+          ],
+        },
+      }
+
+      expect(findInvalidFilterFields(filters, ["one"])).toEqual([
+        "deleted",
+        "missing",
+      ])
+    })
+
+    it("handles numbered field prefixes", () => {
+      const filters: SearchFilters = {
+        equal: { "1:one": "foo", "2:deleted": "bar" },
+      }
+
+      expect(findInvalidFilterFields(filters, ["one"])).toEqual(["2:deleted"])
+    })
+
+    it("does not mutate the original filters", () => {
+      const filters: SearchFilters = {
+        equal: { one: "foo", deleted: "bar" },
+      }
+      const original = _.cloneDeep(filters)
+
+      findInvalidFilterFields(filters, ["one"])
+      expect(filters).toEqual(original)
+    })
+  })
+
   describe("getQueryableFields", () => {
     const config = new TestConfiguration()
 
@@ -163,6 +226,21 @@ describe("query utils", () => {
 
       const result = await getQueryableFields(table)
       expect(result).toEqual(["_id", "name"])
+    })
+
+    it("includes hidden fields when includeHidden is set", async () => {
+      const table: Table = await config.api.table.save({
+        ...structures.basicTable(),
+        schema: {
+          name: { name: "name", type: FieldType.STRING },
+          age: { name: "age", type: FieldType.NUMBER, visible: false },
+        },
+      })
+
+      const result = await getQueryableFields(table, undefined, {
+        includeHidden: true,
+      })
+      expect(result).toEqual(["_id", "name", "age"])
     })
 
     it("includes relationship fields", async () => {


### PR DESCRIPTION
## Description
There was an issue where external datasources would not handle the delete of a column and throw errors. This was actually a general error for external SQL dbs as the invalid column would throw a SQL error when it hit the search.

- Both internal and external Views now recover better when columns are deleted/renamed. Both the internal and external Views "fail closed", meaning when there is an invalid field in the filter they will return no rows at all. This was the existing expectation for internal views and it is now mirrored for external ones too. 
  - "Fail closed" is the expected result here as ignoring or removing invalid fields could potentially expose rows that would normally be excluded.
- A new warning has been added to the popover when deleting a column. If that column is used in any filter in the workspace views, it will be surfaced to the user. Previously there was no indication of an issue.
- A new warning icon and recovery flow has been added to the filter builder. Removed or renamed columns display with a working icon and popover. 
  - For internal views, invalid filters would display but with a blank column name and no indication of an issue.
  - For external views, invalid filters would just be completely blank, leaving the user unable to remove the filter, leaving them with an unrecoverable view.

## Addresses
-  https://github.com/orgs/Budibase/projects/20/views/1?sliceBy%5Bvalue%5D=P0&pane=issue&itemId=174374583&issue=Budibase%7Cbudibase%7C18510
- When deleting a View, instead or redirecting to the parent table, the browser would just reload the same view with errors displayed. This has been corrected.

## Screenshots
When deleting a column in BB now, all views currently filtering on that field will be listed with a warning
<img width="864" height="636" alt="Screenshot 2026-07-07 at 10 03 59" src="https://github.com/user-attachments/assets/a86fb735-576c-4531-8d20-65b3004d0989" />

Filter UI updated to surface filters that are not valid and give the user insight as to why that may be the case and allow them to proceed as they see fit.
<img width="1497" height="784" alt="Screenshot 2026-07-07 at 11 04 02" src="https://github.com/user-attachments/assets/03ec06a6-812f-436a-9b3b-33125bf4ab02" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

