### PR TITLE
Add actions timeline data model and user interaction tracking

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/activity/ActivitySidePanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/activity/ActivitySidePanel.svelte
@@ -39,6 +39,8 @@
         return action.recipients.length
           ? `Escalated to ${action.recipients.map(r => r.label).join(", ")}`
           : "Escalated"
+      default:
+        throw new Error(`Unhandled action type: ${(action satisfies never as AgentRequestAction).type}`)
     }
   }
 

--- a/packages/builder/src/pages/builder/workspace/[application]/activity/ActivitySidePanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/activity/ActivitySidePanel.svelte
@@ -103,6 +103,7 @@
       {
         id: "request-created",
         label: "Request created",
+        timestamp: dayjs(request.createdAt).format("MMM D, YYYY h:mm A"),
       },
     ]
   })
@@ -184,7 +185,12 @@
               {#if timelineEvents.length > 0}
                 {#each timelineEvents as event}
                   <div class="timeline-row">
-                    {event.label}
+                    <span class="timeline-text"
+                      ><span class="timeline-timestamp"
+                        >{event.timestamp} - </span
+                      >
+                      {event.label}</span
+                    >
                   </div>
                 {/each}
               {:else}
@@ -303,18 +309,31 @@
   .timeline-table {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 8px;
   }
 
   .timeline-row {
-    min-height: 32px;
-    padding: 8px 16px;
-    border-radius: 6px;
-    border: 1px solid var(--spectrum-alias-border-color);
-    background: var(--background);
     display: flex;
+    flex-direction: row;
     align-items: center;
-    gap: 11px;
+    align-self: stretch;
+    padding: 8px 16px;
+    gap: 6px;
+    border-radius: 6px;
+    border: 1px solid var(--spectrum-global-color-gray-200);
+    background: var(--spectrum-global-color-gray-100);
+  }
+
+  .timeline-text {
+    color: var(--spectrum-alias-text-color);
+    font-size: 15px;
+    line-height: 1.35;
+  }
+
+  .timeline-timestamp {
+    color: var(--spectrum-global-color-gray-600);
+    font-size: 13px;
+    line-height: 1.35;
   }
 
   .timeline-row.empty {

--- a/packages/builder/src/pages/builder/workspace/[application]/activity/ActivitySidePanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/activity/ActivitySidePanel.svelte
@@ -2,7 +2,11 @@
   import ResizablePanel from "@/components/common/ResizablePanel.svelte"
   import Panel from "@/components/design/Panel.svelte"
   import { Icon } from "@budibase/bbui"
-  import type { AgentRequest, AgentRequestStatus } from "@budibase/types"
+  import type {
+    AgentRequest,
+    AgentRequestAction,
+    AgentRequestStatus,
+  } from "@budibase/types"
   import dayjs from "dayjs"
   import { fly } from "svelte/transition"
   import ActivityStatusBadge from "./ActivityStatusBadge.svelte"
@@ -14,6 +18,28 @@
     highlight?: boolean
     underline?: boolean
     type?: "text" | "status-badge"
+  }
+
+  const statusChangedLabelByStatus: Record<AgentRequestStatus, string> = {
+    active: "Processing",
+    needs_input: "Needs input",
+    completed: "Completed",
+    failed: "Failed",
+  }
+
+  const formatActionLabel = (action: AgentRequestAction): string => {
+    switch (action.type) {
+      case "user_message":
+        return action.summary
+      case "status_changed":
+        return `Status changed to ${statusChangedLabelByStatus[action.to]}`
+      case "tool_call":
+        return action.readableName || action.toolName
+      case "escalation_raised":
+        return action.recipients.length
+          ? `Escalated to ${action.recipients.map(r => r.label).join(", ")}`
+          : "Escalated"
+    }
   }
 
   let {
@@ -91,21 +117,20 @@
     },
   ])
   let timelineEvents = $derived.by(() => {
-    if (!request) {
+    if (!request?.actions?.length) {
       return []
     }
 
-    if (!request.createdAt) {
-      return []
-    }
-
-    return [
-      {
-        id: "request-created",
-        label: "Request created",
-        timestamp: dayjs(request.createdAt).format("MMM D, YYYY h:mm A"),
-      },
-    ]
+    return [...request.actions]
+      .sort(
+        (a, b) =>
+          new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+      )
+      .map(action => ({
+        id: action.id,
+        label: formatActionLabel(action),
+        timestamp: dayjs(action.timestamp).format("MMM D, YYYY h:mm A"),
+      }))
   })
 </script>
 
@@ -187,8 +212,8 @@
                   <div class="timeline-row">
                     <span class="timeline-text"
                       ><span class="timeline-timestamp"
-                        >{event.timestamp} - </span
-                      >
+                        >{event.timestamp} -
+                      </span>
                       {event.label}</span
                     >
                   </div>

--- a/packages/builder/src/pages/builder/workspace/[application]/activity/ActivitySidePanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/activity/ActivitySidePanel.svelte
@@ -40,7 +40,9 @@
           ? `Escalated to ${action.recipients.map(r => r.label).join(", ")}`
           : "Escalated"
       default:
-        throw new Error(`Unhandled action type: ${(action satisfies never as AgentRequestAction).type}`)
+        throw new Error(
+          `Unhandled action type: ${(action satisfies never as AgentRequestAction).type}`
+        )
     }
   }
 

--- a/packages/builder/src/pages/builder/workspace/[application]/activity/ActivitySidePanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/activity/ActivitySidePanel.svelte
@@ -40,9 +40,7 @@
           ? `Escalated to ${action.recipients.map(r => r.label).join(", ")}`
           : "Escalated"
       default:
-        throw new Error(
-          `Unhandled action type: ${(action satisfies never as AgentRequestAction).type}`
-        )
+        throw action satisfies never
     }
   }
 

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
@@ -489,7 +489,7 @@ describe("agentRequests crud", () => {
         await updateRequestStatus({
           requestId,
           status: "completed",
-          allowFromNeedsInput: true,
+          isHumanResponse: true,
         })
 
         const [request] = await fetchRequestsByAgent("agent_1")

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
@@ -410,6 +410,181 @@ describe("agentRequests crud", () => {
     })
   })
 
+  describe("status_changed actions", () => {
+    it("records a status_changed action when transitioning to completed", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_1",
+          latestPrompt: "Book me a meeting",
+          operation: { name: "Scheduling", prompt: "Schedule meetings." },
+          source: "Chat",
+        }))!
+
+        await updateRequestStatus({ requestId, status: "completed" })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        const statusActions = (request.actions ?? []).filter(
+          action => action.type === "status_changed"
+        )
+        expect(statusActions).toEqual([
+          expect.objectContaining({
+            type: "status_changed",
+            from: "active",
+            to: "completed",
+            id: expect.any(String),
+            timestamp: expect.any(String),
+          }),
+        ])
+      })
+    })
+
+    it("records the error on the status_changed action when failing", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_1",
+          latestPrompt: "Book me a meeting",
+          operation: { name: "Scheduling", prompt: "Schedule meetings." },
+          source: "Chat",
+        }))!
+
+        await updateRequestStatus({
+          requestId,
+          status: "failed",
+          error: "Tool calls incomplete",
+        })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        const statusActions = (request.actions ?? []).filter(
+          action => action.type === "status_changed"
+        )
+        expect(statusActions).toEqual([
+          expect.objectContaining({
+            type: "status_changed",
+            from: "active",
+            to: "failed",
+            error: "Tool calls incomplete",
+          }),
+        ])
+      })
+    })
+
+    it("records one status_changed action per real transition", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_1",
+          latestPrompt: "Order 1500 pens",
+          operation: {
+            name: "Procurement",
+            prompt: "Handle procurement requests.",
+          },
+          source: "Chat",
+        }))!
+
+        await updateRequestStatus({ requestId, status: "needs_input" })
+        await updateRequestStatus({
+          requestId,
+          status: "completed",
+          allowFromNeedsInput: true,
+        })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        const statusActions = (request.actions ?? []).filter(
+          action => action.type === "status_changed"
+        )
+        expect(statusActions).toEqual([
+          expect.objectContaining({ from: "active", to: "needs_input" }),
+          expect.objectContaining({ from: "needs_input", to: "completed" }),
+        ])
+      })
+    })
+
+    it("does not record a duplicate action on a defensive re-entry to the same status", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_1",
+          latestPrompt: "Approve this purchase",
+          operation: {
+            name: "Procurement",
+            prompt: "Handle procurement requests.",
+          },
+          source: "Chat",
+        }))!
+
+        await updateRequestStatus({ requestId, status: "needs_input" })
+        await updateRequestStatus({ requestId, status: "needs_input" })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        const statusActions = (request.actions ?? []).filter(
+          action => action.type === "status_changed"
+        )
+        expect(statusActions).toHaveLength(1)
+      })
+    })
+
+    it("does not record an action when a transition is blocked by a terminal status", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_1",
+          latestPrompt: "Book me a meeting",
+          operation: { name: "Scheduling", prompt: "Schedule meetings." },
+          source: "Chat",
+        }))!
+
+        await updateRequestStatus({
+          requestId,
+          status: "failed",
+          error: "Tool calls incomplete",
+        })
+        await updateRequestStatus({ requestId, status: "completed" })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        const statusActions = (request.actions ?? []).filter(
+          action => action.type === "status_changed"
+        )
+        expect(statusActions).toEqual([
+          expect.objectContaining({ from: "active", to: "failed" }),
+        ])
+      })
+    })
+
+    it("does not record an action when the needs_input guard blocks the transition", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_1",
+          latestPrompt: "Order 1500 pens",
+          operation: {
+            name: "Procurement",
+            prompt: "Handle procurement requests.",
+          },
+          source: "Chat",
+        }))!
+
+        await updateRequestStatus({ requestId, status: "needs_input" })
+        await updateRequestStatus({ requestId, status: "completed" })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        const statusActions = (request.actions ?? []).filter(
+          action => action.type === "status_changed"
+        )
+        expect(statusActions).toEqual([
+          expect.objectContaining({ from: "active", to: "needs_input" }),
+        ])
+      })
+    })
+  })
+
   describe("fetchRequestsSummary", () => {
     it("counts requests by status across the whole workspace", async () => {
       await config.doInContext(config.getProdWorkspaceId(), async () => {

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
@@ -15,7 +15,6 @@ import {
   generateAgentRequestTitle,
   generateInteractionSummary,
 } from "./helpers"
-import { truncateTitle } from "../chatConversations"
 
 jest.mock("./helpers", () => ({
   analyzeAgentRequestLink: jest.fn(),
@@ -987,17 +986,17 @@ describe("agentRequests crud", () => {
       })
     })
 
-    it("falls back to a truncated prompt when summary generation fails", async () => {
+    it("falls back to a generic placeholder when summary generation fails, never the raw prompt", async () => {
       analyzeAgentRequestLinkMock.mockResolvedValue({ decision: "new_thread" })
       generateInteractionSummaryMock.mockRejectedValue(new Error("LLM error"))
-      const longPrompt =
-        "I have been trying for the last hour to connect to the office VPN from my home network and it keeps timing out"
+      const sensitivePrompt =
+        "My SSN is 123-45-6789, please update my HR record with it"
 
       await config.doInContext(config.getProdWorkspaceId(), async () => {
         const created = await createOrUpdateRequestForPrompt({
           agentId: "agent_1",
           sessionId: "session_1",
-          latestUserPrompt: longPrompt,
+          latestUserPrompt: sensitivePrompt,
           operation: { name: "Support", prompt: "Help with IT issues." },
           source: "Chat",
           userId: "user_1",
@@ -1006,7 +1005,12 @@ describe("agentRequests crud", () => {
         expect(created?.request.actions?.[0]).toEqual(
           expect.objectContaining({
             type: "user_message",
-            summary: truncateTitle(longPrompt, 60),
+            summary: "User sent a message",
+          })
+        )
+        expect(created?.request.actions?.[0]).not.toEqual(
+          expect.objectContaining({
+            summary: expect.stringContaining("123-45-6789"),
           })
         )
       })

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
@@ -10,11 +10,17 @@ import {
   resolveFinalRequestStatus,
   updateRequestStatus,
 } from "./crud"
-import { analyzeAgentRequestLink, generateAgentRequestTitle } from "./helpers"
+import {
+  analyzeAgentRequestLink,
+  generateAgentRequestTitle,
+  generateInteractionSummary,
+} from "./helpers"
+import { truncateTitle } from "../chatConversations"
 
 jest.mock("./helpers", () => ({
   analyzeAgentRequestLink: jest.fn(),
   generateAgentRequestTitle: jest.fn(),
+  generateInteractionSummary: jest.fn(),
 }))
 
 jest.mock("../../../../websockets", () => ({
@@ -35,6 +41,7 @@ describe("agentRequests crud", () => {
 
   const analyzeAgentRequestLinkMock = analyzeAgentRequestLink as jest.Mock
   const generateAgentRequestTitleMock = generateAgentRequestTitle as jest.Mock
+  const generateInteractionSummaryMock = generateInteractionSummary as jest.Mock
   const emitAgentRequestChangeMock =
     builderSocket?.emitAgentRequestChange as jest.Mock
 
@@ -42,6 +49,8 @@ describe("agentRequests crud", () => {
     analyzeAgentRequestLinkMock.mockReset()
     generateAgentRequestTitleMock.mockReset()
     generateAgentRequestTitleMock.mockResolvedValue("Generated title")
+    generateInteractionSummaryMock.mockReset()
+    generateInteractionSummaryMock.mockResolvedValue("User asked something")
     emitAgentRequestChangeMock.mockReset()
     await config.newTenant()
   })
@@ -940,6 +949,160 @@ describe("agentRequests crud", () => {
         })
 
         expect(created).toBeUndefined()
+      })
+    })
+  })
+
+  describe("user_message actions", () => {
+    it("records the generated summary as the first action when creating a thread", async () => {
+      analyzeAgentRequestLinkMock.mockResolvedValue({ decision: "new_thread" })
+      generateInteractionSummaryMock.mockResolvedValue(
+        "User asked about VPN access"
+      )
+
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const created = await createOrUpdateRequestForPrompt({
+          agentId: "agent_1",
+          sessionId: "session_1",
+          latestUserPrompt: "I can't connect to the VPN from home",
+          operation: { name: "Support", prompt: "Help with IT issues." },
+          source: "Chat",
+          userId: "user_1",
+        })
+
+        expect(created?.request.actions).toEqual([
+          {
+            id: expect.any(String),
+            timestamp: expect.any(String),
+            sessionId: "session_1",
+            type: "user_message",
+            summary: "User asked about VPN access",
+          },
+        ])
+        expect(generateInteractionSummaryMock).toHaveBeenCalledWith({
+          latestPrompt: "I can't connect to the VPN from home",
+          agentId: "agent_1",
+          sessionId: "session_1",
+        })
+      })
+    })
+
+    it("falls back to a truncated prompt when summary generation fails", async () => {
+      analyzeAgentRequestLinkMock.mockResolvedValue({ decision: "new_thread" })
+      generateInteractionSummaryMock.mockRejectedValue(new Error("LLM error"))
+      const longPrompt =
+        "I have been trying for the last hour to connect to the office VPN from my home network and it keeps timing out"
+
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const created = await createOrUpdateRequestForPrompt({
+          agentId: "agent_1",
+          sessionId: "session_1",
+          latestUserPrompt: longPrompt,
+          operation: { name: "Support", prompt: "Help with IT issues." },
+          source: "Chat",
+          userId: "user_1",
+        })
+
+        expect(created?.request.actions?.[0]).toEqual(
+          expect.objectContaining({
+            type: "user_message",
+            summary: truncateTitle(longPrompt, 60),
+          })
+        )
+      })
+    })
+
+    it("appends a new user_message action for a follow-up turn via existingRequestId", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_1",
+          latestPrompt: "Book me a meeting",
+          operation: { name: "Scheduling", prompt: "Schedule meetings." },
+          source: "Chat",
+        }))!
+
+        generateInteractionSummaryMock.mockResolvedValue(
+          "User booked a meeting"
+        )
+
+        const result = await createOrUpdateRequestForPrompt({
+          agentId: "agent_1",
+          sessionId: "session_1",
+          latestUserPrompt: "Book me a meeting",
+          operation: { name: "Scheduling", prompt: "Schedule meetings." },
+          source: "Chat",
+          userId: "user_1",
+          existingRequestId: requestId,
+        })
+
+        expect(result?.request.actions).toEqual([
+          {
+            id: expect.any(String),
+            timestamp: expect.any(String),
+            sessionId: "session_1",
+            type: "user_message",
+            summary: "User booked a meeting",
+          },
+        ])
+      })
+    })
+
+    it("appends one action per follow-up turn linked into the same thread", async () => {
+      analyzeAgentRequestLinkMock.mockResolvedValueOnce({
+        decision: "new_thread",
+      })
+      generateInteractionSummaryMock.mockResolvedValueOnce(
+        "User asked about company policy"
+      )
+
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const first = await createOrUpdateRequestForPrompt({
+          agentId: "agent_1",
+          sessionId: "session_1",
+          latestUserPrompt: "Show me the holidays company policy",
+          operation: {
+            name: "Support",
+            prompt: "Help users with company policy questions.",
+          },
+          source: "Chat",
+          userId: "user_1",
+        })
+
+        analyzeAgentRequestLinkMock.mockResolvedValueOnce({
+          decision: "existing_thread",
+          requestId: first!.request._id,
+          entryAction: "append_latest_entry",
+        })
+        generateInteractionSummaryMock.mockResolvedValueOnce(
+          "User asked for a summary"
+        )
+
+        const second = await createOrUpdateRequestForPrompt({
+          agentId: "agent_1",
+          sessionId: "session_2",
+          latestUserPrompt: "summarise it in 50 words",
+          operation: {
+            name: "Support",
+            prompt: "Summarise company policies clearly.",
+          },
+          source: "Slack",
+          userId: "user_1",
+        })
+
+        expect(second?.request.actions).toEqual([
+          expect.objectContaining({
+            type: "user_message",
+            summary: "User asked about company policy",
+            sessionId: "session_1",
+          }),
+          expect.objectContaining({
+            type: "user_message",
+            summary: "User asked for a summary",
+            sessionId: "session_2",
+          }),
+        ])
       })
     })
   })

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
@@ -471,7 +471,7 @@ describe("agentRequests crud", () => {
       })
     })
 
-    it("records one status_changed action per real transition", async () => {
+    it("records a status_changed action for each real transition", async () => {
       await config.doInContext(config.getProdWorkspaceId(), async () => {
         const { requestId } = (await initActiveRequest({
           agentId: "agent_1",

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
@@ -162,14 +162,23 @@ async function refineUserMessageActionSummary({
     return request
   }
 
-  return await saveRequest({
-    ...latest,
-    actions: (latest.actions ?? []).map(action =>
-      action.id === actionId && action.type === "user_message"
-        ? { ...action, summary }
-        : action
-    ),
-  })
+  try {
+    return await saveRequest({
+      ...latest,
+      actions: (latest.actions ?? []).map(action =>
+        action.id === actionId && action.type === "user_message"
+          ? { ...action, summary }
+          : action
+      ),
+    })
+  } catch (err) {
+    // Best-effort upgrade - a concurrent writer (e.g. updateRequestStatus)
+    // winning the race is an expected outcome, not a failure of this flow.
+    if (dbCore.isDocumentConflictError(err)) {
+      return latest
+    }
+    throw err
+  }
 }
 
 const isTerminalStatus = (status: AgentRequest["status"]) =>

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
@@ -19,7 +19,6 @@ import {
   generateAgentRequestTitle,
   generateInteractionSummary,
 } from "./helpers"
-import { truncateTitle } from "../chatConversations"
 import {
   queryRequestsByAgent,
   queryRequestStatuses,
@@ -29,7 +28,6 @@ import {
 
 const THREAD_CANDIDATE_LIMIT = 10
 const THREAD_LOOKBACK_DAYS = 30
-const INTERACTION_SUMMARY_FALLBACK_LENGTH = 60
 
 const nowIso = () => new Date().toISOString()
 
@@ -81,16 +79,14 @@ const buildThread = ({
   }
 }
 
-// Fallback summary (truncated prompt) used when LLM summarisation fails or hasn't run yet.
 const buildFallbackUserMessageAction = (
-  sessionId: string,
-  latestPrompt: string
+  sessionId: string
 ): UserMessageAction => ({
   id: utils.newid(),
   timestamp: nowIso(),
   sessionId,
   type: "user_message",
-  summary: truncateTitle(latestPrompt, INTERACTION_SUMMARY_FALLBACK_LENGTH),
+  summary: "User sent a message",
 })
 
 async function buildUserMessageActionForTurn({
@@ -121,7 +117,7 @@ async function buildUserMessageActionForTurn({
       sessionId,
       error,
     })
-    return buildFallbackUserMessageAction(sessionId, latestPrompt)
+    return buildFallbackUserMessageAction(sessionId)
   }
 }
 
@@ -271,7 +267,7 @@ async function createNewRequest({
     return undefined
   }
 
-  const fallbackAction = buildFallbackUserMessageAction(sessionId, latestPrompt)
+  const fallbackAction = buildFallbackUserMessageAction(sessionId)
 
   const createdRequest = await saveRequest(
     buildThread({

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
@@ -1,4 +1,10 @@
-import { context, docIds, Duration, utils } from "@budibase/backend-core"
+import {
+  context,
+  db as dbCore,
+  docIds,
+  Duration,
+  utils,
+} from "@budibase/backend-core"
 import type {
   AgentRequest,
   AgentRequestAction,
@@ -378,47 +384,64 @@ export async function updateRequestStatus({
   // same conversation, an unrelated error) must leave it as-is.
   allowFromNeedsInput?: boolean
 }): Promise<void> {
-  const request = await context.getWorkspaceDB().tryGet<AgentRequest>(requestId)
-  if (!request) {
-    return
-  }
+  const db = context.getWorkspaceDB()
 
-  if (isTerminalStatus(request.status)) {
-    return
-  }
-
-  if (
-    request.status === "needs_input" &&
-    status !== "needs_input" &&
-    !allowFromNeedsInput
-  ) {
-    return
-  }
-
-  const timestamp = nowIso()
-  const isTerminal = status === "completed" || status === "failed"
-
-  const updatedEntries = request.entries.map((entry, idx) => {
-    if (idx !== request.entries.length - 1) {
-      return entry
+  // The user_message tracking job (createOrUpdateRequestForPrompt) writes to
+  // the same document concurrently. On a write conflict, re-read the latest
+  // revision and reapply the status transition instead of losing it - a
+  // caller-side .catch() around this function would otherwise swallow the
+  // conflict and leave the request stuck at its previous status.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const request = await db.tryGet<AgentRequest>(requestId)
+    if (!request) {
+      return
     }
-    return {
-      ...entry,
-      status,
-      updatedAt: timestamp,
-      ...(isTerminal ? { completedAt: timestamp } : {}),
-      ...(error === undefined ? {} : { error }),
-    }
-  })
 
-  await saveRequest({
-    ...request,
-    entries: updatedEntries,
-    status,
-    updatedAt: timestamp,
-    ...(isTerminal ? { completedAt: timestamp } : {}),
-    ...(error !== undefined ? { error } : {}),
-  })
+    if (isTerminalStatus(request.status)) {
+      return
+    }
+
+    if (
+      request.status === "needs_input" &&
+      status !== "needs_input" &&
+      !allowFromNeedsInput
+    ) {
+      return
+    }
+
+    const timestamp = nowIso()
+    const isTerminal = status === "completed" || status === "failed"
+
+    const updatedEntries = request.entries.map((entry, idx) => {
+      if (idx !== request.entries.length - 1) {
+        return entry
+      }
+      return {
+        ...entry,
+        status,
+        updatedAt: timestamp,
+        ...(isTerminal ? { completedAt: timestamp } : {}),
+        ...(error === undefined ? {} : { error }),
+      }
+    })
+
+    try {
+      await saveRequest({
+        ...request,
+        entries: updatedEntries,
+        status,
+        updatedAt: timestamp,
+        ...(isTerminal ? { completedAt: timestamp } : {}),
+        ...(error !== undefined ? { error } : {}),
+      })
+      return
+    } catch (err) {
+      if (dbCore.isDocumentConflictError(err) && attempt < 2) {
+        continue
+      }
+      throw err
+    }
+  }
 }
 
 export async function createOrUpdateRequestForPrompt({
@@ -478,9 +501,23 @@ export async function createOrUpdateRequestForPrompt({
         sessionId,
         latestPrompt: prompt,
       })
+
+      // Generating the title/summary can take a while, and the live turn
+      // driving this same request can finish (and change its status) while
+      // we wait. Re-read right before writing instead of saving on top of
+      // the snapshot read at the start of this function, so we don't
+      // silently overwrite a status change with stale data.
+      const latest = await context
+        .getWorkspaceDB()
+        .tryGet<AgentRequest>(existingRequestId)
+      if (!latest || isTerminalStatus(latest.status)) {
+        return { request: latest ?? withTitle, created: false }
+      }
+
       const updated = await saveRequest({
-        ...withTitle,
-        actions: [...(withTitle.actions ?? []), userMessageAction],
+        ...latest,
+        title: latest.title ?? withTitle.title,
+        actions: [...(latest.actions ?? []), userMessageAction],
       })
       return { request: updated, created: false }
     }
@@ -575,15 +612,24 @@ export async function createOrUpdateRequestForPrompt({
     latestPrompt: prompt,
   })
 
+  // LLM calls above can take a while, so re-read immediately before writing
+  // instead of saving on top of the snapshot fetched earlier in this function.
+  const latestRequest = await context
+    .getWorkspaceDB()
+    .tryGet<AgentRequest>(request._id!)
+  if (!latestRequest || isTerminalStatus(latestRequest.status)) {
+    return { request: latestRequest ?? request, created: false }
+  }
+
   return {
     request: await saveRequest({
-      ...request,
+      ...latestRequest,
       entries: nextEntries,
-      actions: [...(request.actions ?? []), userMessageAction],
+      actions: [...(latestRequest.actions ?? []), userMessageAction],
       updatedAt: timestamp,
       // Linking a follow-up prompt into this thread isn't a response to the
       // escalation. Leave needs_input as-is rather than reviving it.
-      status: request.status === "needs_input" ? "needs_input" : "active",
+      status: latestRequest.status === "needs_input" ? "needs_input" : "active",
     }),
     created: false,
   }

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
@@ -81,11 +81,18 @@ const buildThread = ({
   }
 }
 
-// Every user turn in the context of a request is tracked as a user_message
-// action, summarised into a short UI-facing title. The summary generation
-// falls back to a truncated prompt rather than skipping the action entirely,
-// so the timeline always has something to show for that turn even if the LLM
-// call fails.
+// Fallback summary (truncated prompt) used when LLM summarisation fails or hasn't run yet.
+const buildFallbackUserMessageAction = (
+  sessionId: string,
+  latestPrompt: string
+): UserMessageAction => ({
+  id: utils.newid(),
+  timestamp: nowIso(),
+  sessionId,
+  type: "user_message",
+  summary: truncateTitle(latestPrompt, INTERACTION_SUMMARY_FALLBACK_LENGTH),
+})
+
 async function buildUserMessageActionForTurn({
   agentId,
   sessionId,
@@ -95,6 +102,43 @@ async function buildUserMessageActionForTurn({
   sessionId: string
   latestPrompt: string
 }): Promise<UserMessageAction> {
+  try {
+    const summary = await generateInteractionSummary({
+      latestPrompt,
+      agentId,
+      sessionId,
+    })
+    return {
+      id: utils.newid(),
+      timestamp: nowIso(),
+      sessionId,
+      type: "user_message",
+      summary,
+    }
+  } catch (error) {
+    console.error("Failed to generate agent request interaction summary", {
+      agentId,
+      sessionId,
+      error,
+    })
+    return buildFallbackUserMessageAction(sessionId, latestPrompt)
+  }
+}
+
+// Upgrades the fallback summary in place once the LLM responds, without blocking the first save.
+async function refineUserMessageActionSummary({
+  request,
+  actionId,
+  agentId,
+  sessionId,
+  latestPrompt,
+}: {
+  request: AgentRequest
+  actionId: string
+  agentId: string
+  sessionId: string
+  latestPrompt: string
+}): Promise<AgentRequest> {
   let summary: string
   try {
     summary = await generateInteractionSummary({
@@ -108,16 +152,24 @@ async function buildUserMessageActionForTurn({
       sessionId,
       error,
     })
-    summary = truncateTitle(latestPrompt, INTERACTION_SUMMARY_FALLBACK_LENGTH)
+    return request
   }
 
-  return {
-    id: utils.newid(),
-    timestamp: nowIso(),
-    sessionId,
-    type: "user_message",
-    summary,
+  const latest = await context
+    .getWorkspaceDB()
+    .tryGet<AgentRequest>(request._id!)
+  if (!latest) {
+    return request
   }
+
+  return await saveRequest({
+    ...latest,
+    actions: (latest.actions ?? []).map(action =>
+      action.id === actionId && action.type === "user_message"
+        ? { ...action, summary }
+        : action
+    ),
+  })
 }
 
 const isTerminalStatus = (status: AgentRequest["status"]) =>
@@ -210,11 +262,7 @@ async function createNewRequest({
     return undefined
   }
 
-  const userMessageAction = await buildUserMessageActionForTurn({
-    agentId,
-    sessionId,
-    latestPrompt,
-  })
+  const fallbackAction = buildFallbackUserMessageAction(sessionId, latestPrompt)
 
   const createdRequest = await saveRequest(
     buildThread({
@@ -225,12 +273,20 @@ async function createNewRequest({
         operation,
         source,
       }),
-      actions: [userMessageAction],
+      actions: [fallbackAction],
     })
   )
 
-  return await generateAndSaveRequestTitleIfMissing({
+  const withSummary = await refineUserMessageActionSummary({
     request: createdRequest,
+    actionId: fallbackAction.id,
+    agentId,
+    sessionId,
+    latestPrompt,
+  })
+
+  return await generateAndSaveRequestTitleIfMissing({
+    request: withSummary,
     agentId,
     sessionId,
     latestPrompt,
@@ -386,11 +442,7 @@ export async function updateRequestStatus({
 }): Promise<void> {
   const db = context.getWorkspaceDB()
 
-  // The user_message tracking job (createOrUpdateRequestForPrompt) writes to
-  // the same document concurrently. On a write conflict, re-read the latest
-  // revision and reapply the status transition instead of losing it - a
-  // caller-side .catch() around this function would otherwise swallow the
-  // conflict and leave the request stuck at its previous status.
+  // Retries on conflict since createOrUpdateRequestForPrompt writes to the same document concurrently.
   for (let attempt = 0; attempt < 3; attempt++) {
     const request = await db.tryGet<AgentRequest>(requestId)
     if (!request) {
@@ -502,11 +554,7 @@ export async function createOrUpdateRequestForPrompt({
         latestPrompt: prompt,
       })
 
-      // Generating the title/summary can take a while, and the live turn
-      // driving this same request can finish (and change its status) while
-      // we wait. Re-read right before writing instead of saving on top of
-      // the snapshot read at the start of this function, so we don't
-      // silently overwrite a status change with stale data.
+      // Re-read before writing - the status may have changed while we awaited the LLM calls above.
       const latest = await context
         .getWorkspaceDB()
         .tryGet<AgentRequest>(existingRequestId)
@@ -612,8 +660,7 @@ export async function createOrUpdateRequestForPrompt({
     latestPrompt: prompt,
   })
 
-  // LLM calls above can take a while, so re-read immediately before writing
-  // instead of saving on top of the snapshot fetched earlier in this function.
+  // Re-read before writing - the status may have changed while we awaited the LLM calls above.
   const latestRequest = await context
     .getWorkspaceDB()
     .tryGet<AgentRequest>(request._id!)

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
@@ -11,6 +11,7 @@ import type {
   AgentRequestEntry,
   AgentRequestsSummary,
   AgentRequestStatus,
+  StatusChangedAction,
   UserMessageAction,
 } from "@budibase/types"
 import { builderSocket } from "../../../../websockets"
@@ -466,8 +467,23 @@ export async function updateRequestStatus({
       return
     }
 
+    // Defensive re-entry (e.g. two escalate tool calls in the same turn)
+    // nothing actually changed, so there's nothing to record or save.
+    if (request.status === status) {
+      return
+    }
+
     const timestamp = nowIso()
     const isTerminal = status === "completed" || status === "failed"
+
+    const statusChangedAction: StatusChangedAction = {
+      id: utils.newid(),
+      timestamp,
+      type: "status_changed",
+      from: request.status,
+      to: status,
+      ...(error === undefined ? {} : { error }),
+    }
 
     const updatedEntries = request.entries.map((entry, idx) => {
       if (idx !== request.entries.length - 1) {
@@ -486,6 +502,7 @@ export async function updateRequestStatus({
       await saveRequest({
         ...request,
         entries: updatedEntries,
+        actions: [...(request.actions ?? []), statusChangedAction],
         status,
         updatedAt: timestamp,
         ...(isTerminal ? { completedAt: timestamp } : {}),

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
@@ -1,12 +1,19 @@
-import { context, docIds, Duration } from "@budibase/backend-core"
+import { context, docIds, Duration, utils } from "@budibase/backend-core"
 import type {
   AgentRequest,
+  AgentRequestAction,
   AgentRequestEntry,
   AgentRequestsSummary,
   AgentRequestStatus,
+  UserMessageAction,
 } from "@budibase/types"
 import { builderSocket } from "../../../../websockets"
-import { analyzeAgentRequestLink, generateAgentRequestTitle } from "./helpers"
+import {
+  analyzeAgentRequestLink,
+  generateAgentRequestTitle,
+  generateInteractionSummary,
+} from "./helpers"
+import { truncateTitle } from "../chatConversations"
 import {
   queryRequestsByAgent,
   queryRequestStatuses,
@@ -16,6 +23,7 @@ import {
 
 const THREAD_CANDIDATE_LIMIT = 10
 const THREAD_LOOKBACK_DAYS = 30
+const INTERACTION_SUMMARY_FALLBACK_LENGTH = 60
 
 const nowIso = () => new Date().toISOString()
 
@@ -47,10 +55,12 @@ const buildThread = ({
   agentId,
   userId,
   entry,
+  actions = [],
 }: {
   agentId: string
   userId: string
   entry: AgentRequestEntry
+  actions?: AgentRequestAction[]
 }): AgentRequest => {
   return {
     _id: docIds.generateAgentRequestID(),
@@ -58,9 +68,49 @@ const buildThread = ({
     agentId,
     userId,
     entries: [entry],
+    actions,
     createdAt: entry.createdAt,
     updatedAt: entry.updatedAt,
     status: entry.status,
+  }
+}
+
+// Every user turn in the context of a request is tracked as a user_message
+// action, summarised into a short UI-facing title. The summary generation
+// falls back to a truncated prompt rather than skipping the action entirely,
+// so the timeline always has something to show for that turn even if the LLM
+// call fails.
+async function buildUserMessageActionForTurn({
+  agentId,
+  sessionId,
+  latestPrompt,
+}: {
+  agentId: string
+  sessionId: string
+  latestPrompt: string
+}): Promise<UserMessageAction> {
+  let summary: string
+  try {
+    summary = await generateInteractionSummary({
+      latestPrompt,
+      agentId,
+      sessionId,
+    })
+  } catch (error) {
+    console.error("Failed to generate agent request interaction summary", {
+      agentId,
+      sessionId,
+      error,
+    })
+    summary = truncateTitle(latestPrompt, INTERACTION_SUMMARY_FALLBACK_LENGTH)
+  }
+
+  return {
+    id: utils.newid(),
+    timestamp: nowIso(),
+    sessionId,
+    type: "user_message",
+    summary,
   }
 }
 
@@ -154,6 +204,12 @@ async function createNewRequest({
     return undefined
   }
 
+  const userMessageAction = await buildUserMessageActionForTurn({
+    agentId,
+    sessionId,
+    latestPrompt,
+  })
+
   const createdRequest = await saveRequest(
     buildThread({
       agentId,
@@ -163,6 +219,7 @@ async function createNewRequest({
         operation,
         source,
       }),
+      actions: [userMessageAction],
     })
   )
 
@@ -409,12 +466,21 @@ export async function createOrUpdateRequestForPrompt({
       if (isTerminalStatus(existing.status)) {
         return { request: existing, created: false }
       }
-      const updated = await generateAndSaveRequestTitleIfMissing({
+      const withTitle = await generateAndSaveRequestTitleIfMissing({
         request: existing,
         agentId,
         sessionId,
         latestPrompt: prompt,
         operation: resolvedOperation,
+      })
+      const userMessageAction = await buildUserMessageActionForTurn({
+        agentId,
+        sessionId,
+        latestPrompt: prompt,
+      })
+      const updated = await saveRequest({
+        ...withTitle,
+        actions: [...(withTitle.actions ?? []), userMessageAction],
       })
       return { request: updated, created: false }
     }
@@ -503,10 +569,17 @@ export async function createOrUpdateRequestForPrompt({
     )
   }
 
+  const userMessageAction = await buildUserMessageActionForTurn({
+    agentId,
+    sessionId,
+    latestPrompt: prompt,
+  })
+
   return {
     request: await saveRequest({
       ...request,
       entries: nextEntries,
+      actions: [...(request.actions ?? []), userMessageAction],
       updatedAt: timestamp,
       // Linking a follow-up prompt into this thread isn't a response to the
       // escalation. Leave needs_input as-is rather than reviving it.

--- a/packages/server/src/sdk/workspace/ai/agentRequests/helpers.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/helpers.spec.ts
@@ -1,7 +1,11 @@
 import { generateText } from "ai"
 import type { Agent, AgentRequest, LLMResponse } from "@budibase/types"
 import sdk from "../../.."
-import { analyzeAgentRequestLink, generateAgentRequestTitle } from "./helpers"
+import {
+  analyzeAgentRequestLink,
+  generateAgentRequestTitle,
+  generateInteractionSummary,
+} from "./helpers"
 
 jest.mock("ai", () => ({
   generateText: jest.fn(),
@@ -270,5 +274,63 @@ describe("generateAgentRequestTitle", () => {
         ]),
       })
     )
+  })
+})
+
+describe("generateInteractionSummary", () => {
+  const generateTextMock = jest.mocked(generateText)
+  const getOrThrowMock = jest.mocked(sdk.ai.agents.getOrThrow)
+  const createLLMMock = jest.mocked(sdk.ai.llm.createLLM)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getOrThrowMock.mockResolvedValue(buildAgent())
+    createLLMMock.mockResolvedValue(buildLLMResponse())
+  })
+
+  it("summarizes the user's latest message for the timeline", async () => {
+    generateTextMock.mockResolvedValue(
+      buildGenerateTextResult("User asked about VPN access")
+    )
+
+    await expect(
+      generateInteractionSummary({
+        latestPrompt: "I can't connect to the VPN from home",
+        agentId: "agent_1",
+        sessionId: "session_1",
+      })
+    ).resolves.toEqual("User asked about VPN access")
+
+    expect(createLLMMock).toHaveBeenCalledWith(
+      "config_1",
+      "session_1",
+      undefined,
+      "agent_1"
+    )
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: {
+          "x-litellm-tags": "bb-agent-request-interaction-summary",
+        },
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: "user",
+            content: "I can't connect to the VPN from home",
+          }),
+        ]),
+      })
+    )
+  })
+
+  it("throws when the model returns an empty response", async () => {
+    generateTextMock.mockResolvedValue(buildGenerateTextResult("   "))
+
+    await expect(
+      generateInteractionSummary({
+        latestPrompt: "I need a new laptop",
+        agentId: "agent_1",
+        sessionId: "session_1",
+      })
+    ).rejects.toThrow("Invalid interaction summary response")
   })
 })

--- a/packages/server/src/sdk/workspace/ai/agentRequests/helpers.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/helpers.ts
@@ -233,8 +233,7 @@ export async function generateInteractionSummary({
     messages: [
       {
         role: "system",
-        content:
-          'Summarize the user\'s intent in this single message for a UI timeline entry. Write it in third person starting with "User", e.g. "User asked about VPN access". Return plain text only. Use 4 to 6 words, no quotes, no punctuation unless necessary.',
+        content: `Summarize the user's intent in this single message for a UI timeline entry. Write it in third person starting with "User", e.g. "User asked about VPN access". Return plain text only. Use 4 to 6 words, no quotes, no punctuation unless necessary.`,
       },
       {
         role: "user",

--- a/packages/server/src/sdk/workspace/ai/agentRequests/helpers.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/helpers.ts
@@ -207,3 +207,46 @@ export async function generateAgentRequestTitle({
 
   return title
 }
+
+export async function generateInteractionSummary({
+  latestPrompt,
+  agentId,
+  sessionId,
+}: {
+  latestPrompt: string
+  agentId: string
+  sessionId: string
+}): Promise<string> {
+  const agent = await sdk.ai.agents.getOrThrow(agentId)
+  const llm = await sdk.ai.llm.createLLM(
+    agent.aiconfig,
+    sessionId,
+    undefined,
+    agentId
+  )
+  const result = await generateText({
+    model: llm.chat,
+    providerOptions: llm.providerOptions?.(false),
+    headers: {
+      "x-litellm-tags": "bb-agent-request-interaction-summary",
+    },
+    messages: [
+      {
+        role: "system",
+        content:
+          'Summarize the user\'s intent in this single message for a UI timeline entry. Write it in third person starting with "User", e.g. "User asked about VPN access". Return plain text only. Use 4 to 6 words, no quotes, no punctuation unless necessary.',
+      },
+      {
+        role: "user",
+        content: latestPrompt,
+      },
+    ],
+  })
+
+  const summary = normalizeTitle(result.text || "")
+  if (!summary) {
+    throw new Error("Invalid interaction summary response")
+  }
+
+  return summary
+}

--- a/packages/types/src/documents/global/agentRequests.ts
+++ b/packages/types/src/documents/global/agentRequests.ts
@@ -1,4 +1,5 @@
 import { Document } from "../../"
+import { EscalationNotificationChannel } from "../workspace"
 
 export const AGENT_REQUEST_STATUSES = [
   "active",
@@ -20,11 +21,52 @@ export interface AgentRequestEntry {
   completedAt?: string
 }
 
+interface AgentRequestActionBase {
+  id: string
+  timestamp: string
+  sessionId?: string
+}
+
+export interface UserMessageAction extends AgentRequestActionBase {
+  type: "user_message"
+  summary: string
+}
+
+export interface StatusChangedAction extends AgentRequestActionBase {
+  type: "status_changed"
+  from: AgentRequestStatus
+  to: AgentRequestStatus
+  error?: string
+}
+
+export interface ToolCallAction extends AgentRequestActionBase {
+  type: "tool_call"
+  toolName: string
+  readableName?: string
+  status: "success" | "error"
+}
+
+export interface EscalationRaisedAction extends AgentRequestActionBase {
+  type: "escalation_raised"
+  escalationId: string
+  recipients: Array<{
+    type: EscalationNotificationChannel
+    label: string
+  }>
+}
+
+export type AgentRequestAction =
+  | UserMessageAction
+  | StatusChangedAction
+  | ToolCallAction
+  | EscalationRaisedAction
+
 export interface AgentRequest extends Document {
   title?: string
   agentId: string
   userId: string
   entries: AgentRequestEntry[]
+  actions?: AgentRequestAction[]
   status: AgentRequestStatus
   error?: string
   completedAt?: string


### PR DESCRIPTION
## Addresses

- https://github.com/Budibase/budibase/issues/18345

## Description

Continues the Activity requests work on top of `operations/actions-timeline-2` (real-time status filter). Introduces a persisted `actions` log on `AgentRequest` and the first tracked action type, `user_message`, which records every user interaction in the context of a request with an LLM-generated summary (e.g. "User asked about VPN access").

## Screen recording

https://github.com/user-attachments/assets/640941c2-d8b9-4627-8f44-d121d798793b

## Launchcontrol

_The Activity request detail panel now shows a live log of what happened for a request, starting with every user message tracked with a short auto-generated summary._

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

