### PR TITLE
Fix for primary display healing if the column is dropped

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/data/table/[tableId]/_components/CreateViewButton.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/data/table/[tableId]/_components/CreateViewButton.svelte
@@ -42,6 +42,16 @@
     return cloned
   }
 
+  const getPrimaryDisplay = () => {
+    // The table's display column can reference a deleted or hidden column -
+    // sending it would fail the view's display column validation
+    const displayColumn = table.schema?.[table.primaryDisplay]
+    if (!displayColumn || displayColumn.visible === false) {
+      return undefined
+    }
+    return table.primaryDisplay
+  }
+
   const saveView = async () => {
     popover.hide()
     try {
@@ -49,7 +59,7 @@
         name: trimmedName,
         tableId: table._id,
         schema: calculation ? {} : enrichSchema(table.schema),
-        primaryDisplay: calculation ? undefined : table.primaryDisplay,
+        primaryDisplay: calculation ? undefined : getPrimaryDisplay(),
         type: calculation ? ViewV2Type.CALCULATION : undefined,
       })
       notifications.success(`View ${name} created`)

--- a/packages/server/src/api/controllers/row/utils/sqlUtils.ts
+++ b/packages/server/src/api/controllers/row/utils/sqlUtils.ts
@@ -162,7 +162,7 @@ export async function buildSqlFieldList(
     table = await sdk.views.getTable(source.id)
 
     fields = Object.keys(helpers.views.basicFields(source)).filter(
-      f => table.schema[f].type !== FieldType.LINK
+      f => table.schema[f] && table.schema[f].type !== FieldType.LINK
     )
   } else {
     table = source

--- a/packages/server/src/api/routes/tests/datasource.spec.ts
+++ b/packages/server/src/api/routes/tests/datasource.spec.ts
@@ -1364,8 +1364,13 @@ if (descriptions.length) {
 
           // The view follows the table's healed display column, and the
           // dropped column is removed from its schema so it can be updated
+          ds = await config.api.datasource.get(datasource._id!)
+          table = Object.values(ds.entities!).find(
+            t => t.name === "view_display_test"
+          )!
           const updated = await config.api.viewV2.get(view.id)
-          expect(updated.primaryDisplay).toBeDefined()
+          expect(table.primaryDisplay).toBeDefined()
+          expect(updated.primaryDisplay).toEqual(table.primaryDisplay)
           expect(updated.primaryDisplay).not.toEqual("name")
           expect(Object.keys(updated.schema!)).not.toContain("name")
 

--- a/packages/server/src/api/routes/tests/datasource.spec.ts
+++ b/packages/server/src/api/routes/tests/datasource.spec.ts
@@ -1257,6 +1257,129 @@ if (descriptions.length) {
               table.schema.enum.constraints!.inclusion!.toSorted()
             ).toEqual(enumOptions)
           })
+
+        it("re-points primaryDisplay when its column is dropped from the source database", async () => {
+          await client.schema.createTable("display_test", table => {
+            table.increments("id").primary()
+            table.string("name")
+            table.string("description")
+          })
+          await config.api.datasource.fetchSchema({
+            datasourceId: datasource._id!,
+          })
+
+          let ds = await config.api.datasource.get(datasource._id!)
+          let table = Object.values(ds.entities!).find(
+            t => t.name === "display_test"
+          )!
+          await config.api.table.save({ ...table, primaryDisplay: "name" })
+
+          await client.schema.alterTable("display_test", table => {
+            table.dropColumn("name")
+          })
+          await config.api.datasource.fetchSchema({
+            datasourceId: datasource._id!,
+          })
+
+          ds = await config.api.datasource.get(datasource._id!)
+          table = Object.values(ds.entities!).find(
+            t => t.name === "display_test"
+          )!
+          expect(table.primaryDisplay).toBeDefined()
+          expect(table.primaryDisplay).not.toEqual("name")
+          expect(table.schema[table.primaryDisplay!]).toBeDefined()
+        })
+
+        it("still searches views referencing a column dropped from the source database", async () => {
+          await client.schema.createTable("stale_view_test", table => {
+            table.increments("id").primary()
+            table.string("name")
+            table.string("doomed")
+          })
+          await config.api.datasource.fetchSchema({
+            datasourceId: datasource._id!,
+          })
+
+          const ds = await config.api.datasource.get(datasource._id!)
+          const table = Object.values(ds.entities!).find(
+            t => t.name === "stale_view_test"
+          )!
+          const view = await config.api.viewV2.create({
+            name: generator.guid(),
+            tableId: table._id!,
+            schema: {
+              id: { visible: true },
+              name: { visible: true },
+              doomed: { visible: true },
+            },
+          })
+          await config.api.row.save(table._id!, { name: "a", doomed: "gone" })
+
+          await client.schema.alterTable("stale_view_test", table => {
+            table.dropColumn("doomed")
+          })
+          await config.api.datasource.fetchSchema({
+            datasourceId: datasource._id!,
+          })
+
+          // The view schema still contains the dropped column - the search
+          // must skip it rather than reference it in the generated SQL
+          const response = await config.api.viewV2.search(view.id)
+          expect(response.rows).toHaveLength(1)
+          expect(response.rows[0].name).toEqual("a")
+          expect(response.rows[0].doomed).toBeUndefined()
+        })
+
+        it("re-points view display columns when the display column is dropped from the source database", async () => {
+          await client.schema.createTable("view_display_test", table => {
+            table.increments("id").primary()
+            table.string("name")
+            table.string("description")
+          })
+          await config.api.datasource.fetchSchema({
+            datasourceId: datasource._id!,
+          })
+
+          let ds = await config.api.datasource.get(datasource._id!)
+          let table = Object.values(ds.entities!).find(
+            t => t.name === "view_display_test"
+          )!
+          await config.api.table.save({ ...table, primaryDisplay: "name" })
+          const view = await config.api.viewV2.create({
+            name: generator.guid(),
+            tableId: table._id!,
+            schema: {
+              id: { visible: true },
+              name: { visible: true },
+              description: { visible: true },
+            },
+          })
+
+          await client.schema.alterTable("view_display_test", table => {
+            table.dropColumn("name")
+          })
+          await config.api.datasource.fetchSchema({
+            datasourceId: datasource._id!,
+          })
+
+          // The view follows the table's healed display column, and the
+          // dropped column is removed from its schema so it can be updated
+          const updated = await config.api.viewV2.get(view.id)
+          expect(updated.primaryDisplay).toBeDefined()
+          expect(updated.primaryDisplay).not.toEqual("name")
+          expect(Object.keys(updated.schema!)).not.toContain("name")
+
+          await config.api.viewV2.update(
+            {
+              ...updated,
+              schema: {
+                id: { visible: true },
+                description: { visible: false },
+              },
+            },
+            { status: 200 }
+          )
+        })
       })
 
       describe("verify", () => {

--- a/packages/server/src/api/routes/tests/table.spec.ts
+++ b/packages/server/src/api/routes/tests/table.spec.ts
@@ -398,6 +398,56 @@ if (descriptions.length) {
           expect(res.name).toBeUndefined()
         })
 
+        it("re-points primaryDisplay when its column is deleted", async () => {
+          const table = await config.api.table.save(
+            tableForDatasource(datasource, {
+              schema: {
+                name: {
+                  name: "name",
+                  type: FieldType.STRING,
+                },
+                description: {
+                  name: "description",
+                  type: FieldType.STRING,
+                },
+              },
+              primaryDisplay: "name",
+            })
+          )
+
+          const { name, description, ...rest } = table.schema
+          const updated = await config.api.table.save({
+            ...table,
+            schema: { description, ...rest },
+          })
+
+          expect(updated.primaryDisplay).toEqual("description")
+        })
+
+        isInternal &&
+          it("removes primaryDisplay when no eligible column remains", async () => {
+            const table = await config.api.table.save(
+              tableForDatasource(datasource, {
+                schema: {
+                  name: {
+                    name: "name",
+                    type: FieldType.STRING,
+                  },
+                  attachment: {
+                    name: "attachment",
+                    type: FieldType.ATTACHMENTS,
+                  },
+                },
+                primaryDisplay: "name",
+              })
+            )
+
+            const { name, ...schema } = table.schema
+            const updated = await config.api.table.save({ ...table, schema })
+
+            expect(updated.primaryDisplay).toBeUndefined()
+          })
+
         isInternal &&
           it("updates only the passed fields", async () => {
             await timekeeper.withFreeze(new Date(2021, 1, 1), async () => {

--- a/packages/server/src/api/routes/tests/table.spec.ts
+++ b/packages/server/src/api/routes/tests/table.spec.ts
@@ -415,7 +415,7 @@ if (descriptions.length) {
             })
           )
 
-          const { name, description, ...rest } = table.schema
+          const { name: _deleted, description, ...rest } = table.schema
           const updated = await config.api.table.save({
             ...table,
             schema: { description, ...rest },
@@ -442,7 +442,7 @@ if (descriptions.length) {
               })
             )
 
-            const { name, ...schema } = table.schema
+            const { name: _deleted, ...schema } = table.schema
             const updated = await config.api.table.save({ ...table, schema })
 
             expect(updated.primaryDisplay).toBeUndefined()

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1060,6 +1060,60 @@ if (descriptions.length) {
             })
           })
 
+          it("can still read and update a view whose display column no longer exists", async () => {
+            const displayTable = await config.api.table.save(
+              saveTableRequest({
+                primaryDisplay: "name",
+                schema: {
+                  name: {
+                    name: "name",
+                    type: FieldType.STRING,
+                  },
+                  category: {
+                    name: "category",
+                    type: FieldType.STRING,
+                  },
+                },
+              })
+            )
+            const staleView = await config.api.viewV2.create({
+              tableId: displayTable._id!,
+              name: generator.guid(),
+              primaryDisplay: "category",
+              schema: {
+                id: { visible: true },
+                name: { visible: true },
+                category: { visible: true },
+              },
+            })
+
+            // deleting the column the view uses as its display column leaves
+            // the view's primaryDisplay referencing a missing column
+            const saved = await config.api.table.get(displayTable._id!)
+            const { category, ...schema } = saved.schema
+            await config.api.table.save({ ...saved, schema }, { status: 200 })
+
+            // reads fall back to the table's display column
+            const fetched = await config.api.viewV2.get(staleView.id)
+            expect(fetched.primaryDisplay).toEqual("name")
+
+            // saving any view change must fall back to the table's display
+            // column rather than rejecting the update
+            await config.api.viewV2.update(
+              {
+                ...staleView,
+                schema: {
+                  id: { visible: true },
+                  name: { visible: true },
+                },
+              },
+              { status: 200 }
+            )
+
+            const updated = await config.api.viewV2.get(staleView.id)
+            expect(updated.primaryDisplay).toEqual("name")
+          })
+
           it("can update an existing view data", async () => {
             const tableId = table._id!
             await config.api.viewV2.update({

--- a/packages/server/src/api/routes/tests/viewV2.spec.ts
+++ b/packages/server/src/api/routes/tests/viewV2.spec.ts
@@ -1090,7 +1090,7 @@ if (descriptions.length) {
             // deleting the column the view uses as its display column leaves
             // the view's primaryDisplay referencing a missing column
             const saved = await config.api.table.get(displayTable._id!)
-            const { category, ...schema } = saved.schema
+            const { category: _deleted, ...schema } = saved.schema
             await config.api.table.save({ ...saved, schema }, { status: 200 })
 
             // reads fall back to the table's display column

--- a/packages/server/src/sdk/workspace/datasources/datasources.ts
+++ b/packages/server/src/sdk/workspace/datasources/datasources.ts
@@ -37,6 +37,7 @@ import {
 import { setupCreationAuth as googleSetupCreationAuth } from "../../../integrations/googlesheets"
 import sdk from "../../index"
 import { getEnvironmentVariables } from "../../utils"
+import { ensureValidPrimaryDisplay } from "../tables/utils"
 
 const ENV_VAR_PREFIX = "env."
 
@@ -394,6 +395,8 @@ const preSaveAction: Partial<Record<SourceName, any>> = {
  */
 export function setDefaultDisplayColumns(datasource: Datasource) {
   for (const entity of Object.values(datasource.entities || {})) {
+    // the display column can have been dropped from the source database
+    ensureValidPrimaryDisplay(entity)
     if (entity.primaryDisplay) {
       continue
     }

--- a/packages/server/src/sdk/workspace/datasources/plus.ts
+++ b/packages/server/src/sdk/workspace/datasources/plus.ts
@@ -115,6 +115,26 @@ export async function buildSchemaFromSource(
   datasource.entities = tables
 
   datasources.setDefaultDisplayColumns(datasource)
+
+  // The fetched schema can drop columns that views still reference - sync
+  // each table's views the same way a table save would, so view schemas and
+  // view display columns don't point at columns that no longer exist
+  for (const [tableName, table] of Object.entries(tables)) {
+    if (!table.views) {
+      continue
+    }
+    const previousPrimaryDisplay = oldTables[tableName]?.primaryDisplay
+    for (const [viewName, view] of Object.entries(table.views)) {
+      if (!sdk.views.isV2(view)) {
+        continue
+      }
+      table.views[viewName] = sdk.views.syncSchema(view, table.schema, {
+        primaryDisplay: table.primaryDisplay,
+        previousPrimaryDisplay,
+      })
+    }
+  }
+
   const dbResp = await db.put(tableSdk.populateExternalTableSchemas(datasource))
   datasource._rev = dbResp.rev
 

--- a/packages/server/src/sdk/workspace/tables/external/index.ts
+++ b/packages/server/src/sdk/workspace/tables/external/index.ts
@@ -32,6 +32,7 @@ import {
 import datasourceSdk from "../../datasources"
 import * as viewSdk from "../../views"
 import { getTable } from "../getters"
+import { ensureValidPrimaryDisplay } from "../utils"
 import { populateExternalTableSchemas } from "../validation"
 
 const DEFAULT_PRIMARY_COLUMN = "id"
@@ -148,6 +149,8 @@ export async function save(
       name: DEFAULT_PRIMARY_COLUMN,
     }
   }
+
+  ensureValidPrimaryDisplay(tableToSave)
 
   for (let view in tableToSave.views) {
     const tableView = tableToSave.views[view]

--- a/packages/server/src/sdk/workspace/tables/internal/index.ts
+++ b/packages/server/src/sdk/workspace/tables/internal/index.ts
@@ -24,6 +24,7 @@ import { EventType, updateLinks } from "../../../../db/linkedRows"
 import { generateTableID, getRowParams } from "../../../../db/utils"
 import * as viewsSdk from "../../views"
 import { getTable } from "../getters"
+import { ensureValidPrimaryDisplay } from "../utils"
 import { checkAutoColumns } from "./utils"
 
 export async function create(
@@ -135,6 +136,8 @@ export async function save(
   }
 
   table = await tableSaveFunctions.mid(table, renaming)
+
+  ensureValidPrimaryDisplay(table)
 
   // update schema of non-statistics views when new columns are added
   for (let view in table.views) {

--- a/packages/server/src/sdk/workspace/tables/utils.ts
+++ b/packages/server/src/sdk/workspace/tables/utils.ts
@@ -1,6 +1,9 @@
 import { Table, TableSourceType } from "@budibase/types"
 import { isExternalTableID } from "../../../integrations/utils"
-import { isTableIdOrExternalTableId } from "@budibase/shared-core"
+import {
+  isAllowedDisplayField,
+  isTableIdOrExternalTableId,
+} from "@budibase/shared-core"
 
 export function isExternal(opts: { table?: Table; tableId?: string }): boolean {
   if (opts.table && opts.table.sourceType === TableSourceType.EXTERNAL) {
@@ -17,4 +20,20 @@ export function isInternal(opts: { table?: Table; tableId?: string }): boolean {
 
 export function isTable(table: any): table is Table {
   return table._id && isTableIdOrExternalTableId(table._id)
+}
+
+// A dangling reference breaks view creation, so re-point it to another eligible column,
+// or remove it if there is none.
+export function ensureValidPrimaryDisplay(table: Table) {
+  if (!table.primaryDisplay || table.schema[table.primaryDisplay]) {
+    return
+  }
+  const fallback = Object.keys(table.schema).find(name =>
+    isAllowedDisplayField(name, table.schema[name].type)
+  )
+  if (fallback) {
+    table.primaryDisplay = fallback
+  } else {
+    delete table.primaryDisplay
+  }
 }

--- a/packages/server/src/sdk/workspace/views/external.ts
+++ b/packages/server/src/sdk/workspace/views/external.ts
@@ -6,7 +6,11 @@ import { enrichSchema, isV2 } from "."
 import sdk from "../.."
 import * as utils from "../../../db/utils"
 import { breakExternalTableId } from "../../../integrations/utils"
-import { ensureQuerySet, ensureQueryUISet } from "./utils"
+import {
+  ensureQuerySet,
+  ensureQueryUISet,
+  ensureValidPrimaryDisplay,
+} from "./utils"
 
 export async function get(viewId: string): Promise<ViewV2> {
   const tableId = getTableIdFromViewId(viewId)
@@ -37,7 +41,10 @@ export async function getEnriched(
   if (!found) {
     return
   }
-  return await enrichSchema(ensureQueryUISet(found), table.schema)
+  return await enrichSchema(
+    ensureValidPrimaryDisplay(ensureQueryUISet(found), table),
+    table.schema
+  )
 }
 
 export async function create(

--- a/packages/server/src/sdk/workspace/views/index.ts
+++ b/packages/server/src/sdk/workspace/views/index.ts
@@ -28,7 +28,7 @@ import sdk from "../.."
 import { isExternalTableID } from "../../../integrations/utils"
 import * as external from "./external"
 import * as internal from "./internal"
-import { ensureQueryUISet } from "./utils"
+import { ensureQueryUISet, ensureValidPrimaryDisplay } from "./utils"
 
 function pickApi(tableId: any) {
   if (isExternalTableID(tableId)) {
@@ -59,7 +59,11 @@ export async function getAllEnriched(): Promise<ViewV2Enriched[]> {
     const v2Views = Object.values(table.views).filter(isV2)
     const enrichedViews = await Promise.all(
       v2Views.map(view =>
-        enrichSchema(ensureQueryUISet(view), table.schema, tables)
+        enrichSchema(
+          ensureValidPrimaryDisplay(ensureQueryUISet(view), table),
+          table.schema,
+          tables
+        )
       )
     )
     views = views.concat(enrichedViews)
@@ -231,6 +235,11 @@ async function guardViewSchema(
   if (!helpers.views.isCalculationView(view)) {
     checkRequiredFields(table, view)
   }
+
+  // Falling back to the table's display column here means a view whose
+  // display column no longer exists can still be saved, rather than every
+  // save being rejected by the display column check
+  ensureValidPrimaryDisplay(view, table)
 
   checkDisplayField(view)
 }

--- a/packages/server/src/sdk/workspace/views/internal.ts
+++ b/packages/server/src/sdk/workspace/views/internal.ts
@@ -5,7 +5,11 @@ import { getTableIdFromViewId } from "@budibase/shared-core"
 import { enrichSchema, isV2 } from "."
 import sdk from "../.."
 import * as utils from "../../../db/utils"
-import { ensureQuerySet, ensureQueryUISet } from "./utils"
+import {
+  ensureQuerySet,
+  ensureQueryUISet,
+  ensureValidPrimaryDisplay,
+} from "./utils"
 
 export async function get(viewId: string): Promise<ViewV2> {
   const tableId = getTableIdFromViewId(viewId)
@@ -28,7 +32,10 @@ export async function getEnriched(
   if (!found) {
     return
   }
-  return await enrichSchema(ensureQueryUISet(found), table.schema)
+  return await enrichSchema(
+    ensureValidPrimaryDisplay(ensureQueryUISet(found), table),
+    table.schema
+  )
 }
 
 export async function create(

--- a/packages/server/src/sdk/workspace/views/utils.ts
+++ b/packages/server/src/sdk/workspace/views/utils.ts
@@ -1,10 +1,22 @@
-import { ViewV2 } from "@budibase/types"
+import { Table, ViewV2 } from "@budibase/types"
 import { utils, dataFilters } from "@budibase/shared-core"
 import { cloneDeep, isPlainObject } from "lodash"
 import { HTTPError } from "@budibase/backend-core"
 
 function isEmptyObject(obj: any) {
   return obj && isPlainObject(obj) && Object.keys(obj).length === 0
+}
+
+// A view's display column can reference a table column that no longer
+// exists, e.g. dropped from an external datasource. There is nothing to
+// display in that case - fall back to the table's display column.
+export function ensureValidPrimaryDisplay<
+  T extends Omit<ViewV2, "id" | "version">,
+>(view: T, table: Table): T {
+  if (view.primaryDisplay && !table.schema[view.primaryDisplay]) {
+    view.primaryDisplay = table.primaryDisplay
+  }
+  return view
 }
 
 export function ensureQueryUISet(viewArg: Readonly<ViewV2>): ViewV2 {


### PR DESCRIPTION
## Description
There were a number of issues relating the `primaryDisplay` column in tables and views. If the column was deleted outside the builder, typically in an external connection, it would cause a severe degradation of the associated table and views. A refetch of the schema could not fix it.

Fixes: 
- Deleting a display column (API or source DB + refetch) re-points the table's display to another column
- Schema refetch also syncs views (schemas + display columns follow)
- Broken views now load, render the right display column and can be edited. Fall back to the table's display by default.
  - Previously all views would be completely unrecoverable.
- View creation works on previously-damaged tables, which was blocked before.

## Addresses
- https://github.com/orgs/Budibase/projects/20/views/1?sliceBy%5Bvalue%5D=P0&pane=issue&itemId=174374583&issue=Budibase%7Cbudibase%7C18510
- https://github.com/Budibase/budibase/pull/19161
  - A lot of the issues mentioned here we found working this


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

