### PR TITLE
Track status changes in the actions timeline

### DIFF
--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
@@ -489,7 +489,7 @@ describe("agentRequests crud", () => {
         await updateRequestStatus({
           requestId,
           status: "completed",
-          allowFromNeedsInput: true,
+          isHumanResponse: true,
         })
 
         const [request] = await fetchRequestsByAgent("agent_1")

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
@@ -410,6 +410,181 @@ describe("agentRequests crud", () => {
     })
   })
 
+  describe("status_changed actions", () => {
+    it("records a status_changed action when transitioning to completed", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_1",
+          latestPrompt: "Book me a meeting",
+          operation: { name: "Scheduling", prompt: "Schedule meetings." },
+          source: "Chat",
+        }))!
+
+        await updateRequestStatus({ requestId, status: "completed" })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        const statusActions = (request.actions ?? []).filter(
+          action => action.type === "status_changed"
+        )
+        expect(statusActions).toEqual([
+          expect.objectContaining({
+            type: "status_changed",
+            from: "active",
+            to: "completed",
+            id: expect.any(String),
+            timestamp: expect.any(String),
+          }),
+        ])
+      })
+    })
+
+    it("records the error on the status_changed action when failing", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_1",
+          latestPrompt: "Book me a meeting",
+          operation: { name: "Scheduling", prompt: "Schedule meetings." },
+          source: "Chat",
+        }))!
+
+        await updateRequestStatus({
+          requestId,
+          status: "failed",
+          error: "Tool calls incomplete",
+        })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        const statusActions = (request.actions ?? []).filter(
+          action => action.type === "status_changed"
+        )
+        expect(statusActions).toEqual([
+          expect.objectContaining({
+            type: "status_changed",
+            from: "active",
+            to: "failed",
+            error: "Tool calls incomplete",
+          }),
+        ])
+      })
+    })
+
+    it("records one status_changed action per real transition", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_1",
+          latestPrompt: "Order 1500 pens",
+          operation: {
+            name: "Procurement",
+            prompt: "Handle procurement requests.",
+          },
+          source: "Chat",
+        }))!
+
+        await updateRequestStatus({ requestId, status: "needs_input" })
+        await updateRequestStatus({
+          requestId,
+          status: "completed",
+          allowFromNeedsInput: true,
+        })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        const statusActions = (request.actions ?? []).filter(
+          action => action.type === "status_changed"
+        )
+        expect(statusActions).toEqual([
+          expect.objectContaining({ from: "active", to: "needs_input" }),
+          expect.objectContaining({ from: "needs_input", to: "completed" }),
+        ])
+      })
+    })
+
+    it("does not record a duplicate action on a defensive re-entry to the same status", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_1",
+          latestPrompt: "Approve this purchase",
+          operation: {
+            name: "Procurement",
+            prompt: "Handle procurement requests.",
+          },
+          source: "Chat",
+        }))!
+
+        await updateRequestStatus({ requestId, status: "needs_input" })
+        await updateRequestStatus({ requestId, status: "needs_input" })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        const statusActions = (request.actions ?? []).filter(
+          action => action.type === "status_changed"
+        )
+        expect(statusActions).toHaveLength(1)
+      })
+    })
+
+    it("does not record an action when a transition is blocked by a terminal status", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_1",
+          latestPrompt: "Book me a meeting",
+          operation: { name: "Scheduling", prompt: "Schedule meetings." },
+          source: "Chat",
+        }))!
+
+        await updateRequestStatus({
+          requestId,
+          status: "failed",
+          error: "Tool calls incomplete",
+        })
+        await updateRequestStatus({ requestId, status: "completed" })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        const statusActions = (request.actions ?? []).filter(
+          action => action.type === "status_changed"
+        )
+        expect(statusActions).toEqual([
+          expect.objectContaining({ from: "active", to: "failed" }),
+        ])
+      })
+    })
+
+    it("does not record an action when the needs_input guard blocks the transition", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await initActiveRequest({
+          agentId: "agent_1",
+          userId: "user_1",
+          sessionId: "session_1",
+          latestPrompt: "Order 1500 pens",
+          operation: {
+            name: "Procurement",
+            prompt: "Handle procurement requests.",
+          },
+          source: "Chat",
+        }))!
+
+        await updateRequestStatus({ requestId, status: "needs_input" })
+        await updateRequestStatus({ requestId, status: "completed" })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        const statusActions = (request.actions ?? []).filter(
+          action => action.type === "status_changed"
+        )
+        expect(statusActions).toEqual([
+          expect.objectContaining({ from: "active", to: "needs_input" }),
+        ])
+      })
+    })
+  })
+
   describe("fetchRequestsSummary", () => {
     it("counts requests by status across the whole workspace", async () => {
       await config.doInContext(config.getProdWorkspaceId(), async () => {

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
@@ -471,7 +471,7 @@ describe("agentRequests crud", () => {
       })
     })
 
-    it("records one status_changed action per real transition", async () => {
+    it("records a status_changed action for each real transition", async () => {
       await config.doInContext(config.getProdWorkspaceId(), async () => {
         const { requestId } = (await initActiveRequest({
           agentId: "agent_1",

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
@@ -11,6 +11,7 @@ import type {
   AgentRequestEntry,
   AgentRequestsSummary,
   AgentRequestStatus,
+  StatusChangedAction,
   UserMessageAction,
 } from "@budibase/types"
 import { builderSocket } from "../../../../websockets"
@@ -466,8 +467,23 @@ export async function updateRequestStatus({
       return
     }
 
+    // Defensive re-entry (e.g. two escalate tool calls in the same turn)
+    // nothing actually changed, so there's nothing to record or save.
+    if (request.status === status) {
+      return
+    }
+
     const timestamp = nowIso()
     const isTerminal = status === "completed" || status === "failed"
+
+    const statusChangedAction: StatusChangedAction = {
+      id: utils.newid(),
+      timestamp,
+      type: "status_changed",
+      from: request.status,
+      to: status,
+      ...(error === undefined ? {} : { error }),
+    }
 
     const updatedEntries = request.entries.map((entry, idx) => {
       if (idx !== request.entries.length - 1) {
@@ -486,6 +502,7 @@ export async function updateRequestStatus({
       await saveRequest({
         ...request,
         entries: updatedEntries,
+        actions: [...(request.actions ?? []), statusChangedAction],
         status,
         updatedAt: timestamp,
         ...(isTerminal ? { completedAt: timestamp } : {}),


### PR DESCRIPTION
## Description

Continues the Activity requests actions timeline work on top of `operations/actions-timeline-3` (user interaction tracking). Adds the second tracked action type, `status_changed`, recorded from the single choke point `updateRequestStatus()` whenever a request's status actually transitions (e.g. active → needs_input → completed/failed).

A defensive re-entry (e.g. two `escalate` tool calls resolving in the same turn) that doesn't actually change the status no longer generates a duplicate action or an extra write/socket emit.

## Addresses
- https://github.com/Budibase/budibase/issues/18345

## Launchcontrol

_The Activity request detail panel timeline now also shows every status change (e.g. "Status changed to Needs input"), in addition to user messages._

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

