### PR TITLE
fix: style account linking page

### DIFF
--- a/packages/server/src/api/controllers/ai/chatIdentityLinks.ts
+++ b/packages/server/src/api/controllers/ai/chatIdentityLinks.ts
@@ -147,7 +147,11 @@ const providerDisplayName = (provider: ChatIdentityLinkProvider) => {
   if (provider === AgentChannelProvider.TELEGRAM) {
     return "Telegram"
   }
-  return "Slack"
+  if (provider === AgentChannelProvider.SLACK) {
+    return "Slack"
+  }
+
+  throw provider satisfies never
 }
 
 const renderLinkConfirmationPage = (

--- a/packages/server/src/api/controllers/ai/chatIdentityLinks.ts
+++ b/packages/server/src/api/controllers/ai/chatIdentityLinks.ts
@@ -1,10 +1,11 @@
 import { context, HTTPError, utils } from "@budibase/backend-core"
 import { WebClient } from "@slack/web-api"
 import { helpers } from "@budibase/shared-core"
-import type {
-  ChatIdentityLinkSession,
-  ChatIdentityLinkProvider,
-  UserCtx,
+import {
+  AgentChannelProvider,
+  type ChatIdentityLinkProvider,
+  type ChatIdentityLinkSession,
+  type UserCtx,
 } from "@budibase/types"
 import { getGlobalIDFromUserMetadataID } from "../../../db/utils"
 import sdk from "../../../sdk"
@@ -17,6 +18,94 @@ import {
 
 const CHAT_LINK_RETURN_URL_COOKIE = "budibase:returnurl"
 const BUILDER_LOGIN_PATH = "/builder/auth/login"
+
+const CHAT_LINK_PAGE_STYLES = `
+      :root {
+        color-scheme: light;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        color: #292929;
+        background: #ffffff;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 40px;
+        background: #ffffff;
+      }
+      main {
+        width: 100%;
+        max-width: 400px;
+        min-height: 480px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+      }
+      img {
+        width: 44px;
+        height: 44px;
+        margin-bottom: 24px;
+      }
+      h1 {
+        margin: 0;
+        font-size: 24px;
+        line-height: 1.25;
+        font-weight: 600;
+        letter-spacing: -0.02em;
+      }
+      p {
+        margin: 16px 0 24px;
+        color: #6f6f6f;
+        font-size: 14px;
+        line-height: 1.5;
+      }
+      strong {
+        color: #292929;
+        font-weight: 500;
+      }
+      form {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+      }
+      button {
+        min-height: 40px;
+        padding: 0 20px;
+        border: 0;
+        border-radius: 4px;
+        background: #424242;
+        color: white;
+        font: inherit;
+        font-size: 14px;
+        font-weight: 500;
+        letter-spacing: -0.02em;
+        cursor: pointer;
+      }
+      button:hover {
+        background: #292929;
+      }
+      button:focus-visible {
+        outline: 2px solid #2680eb;
+        outline-offset: 2px;
+      }
+      @media (max-width: 480px) {
+        body {
+          padding: 24px;
+        }
+        main {
+          min-height: 360px;
+        }
+        h1 {
+          font-size: 22px;
+        }
+      }
+`
 
 const resolveToken = (token?: string) => {
   if (!token) {
@@ -48,24 +137,43 @@ const getCurrentGlobalUserId = (ctx: UserCtx) => {
   return currentUserId
 }
 
+const providerDisplayName = (provider: ChatIdentityLinkProvider) => {
+  if (provider === AgentChannelProvider.DISCORD) {
+    return "Discord"
+  }
+  if (provider === AgentChannelProvider.MSTEAMS) {
+    return "Teams"
+  }
+  if (provider === AgentChannelProvider.TELEGRAM) {
+    return "Telegram"
+  }
+  return "Slack"
+}
+
 const renderLinkConfirmationPage = (
   session: ChatIdentityLinkSession,
   action: string
 ) => {
   const externalIdentity = session.externalUserName || session.externalUserId
+  const providerName = providerDisplayName(session.provider)
   return `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Confirm chat account link</title>
+    <style>${CHAT_LINK_PAGE_STYLES}</style>
   </head>
   <body>
-    <p>Confirm linking your Budibase account to ${helpers.escapeHtml(session.provider)} user ${helpers.escapeHtml(externalIdentity)}.</p>
-    <form method="post" action="${helpers.escapeHtml(action)}">
-      <input type="hidden" name="confirmationToken" value="${helpers.escapeHtml(session.confirmationToken)}">
-      <button type="submit">Confirm</button>
-    </form>
+    <main>
+      <img src="/builder/bblogo.png" alt="Budibase">
+      <h1>Confirm chat account link</h1>
+      <p>Link your Budibase account to <strong>${helpers.escapeHtml(externalIdentity)}</strong> on <strong>${helpers.escapeHtml(providerName)}</strong>.</p>
+      <form method="post" action="${helpers.escapeHtml(action)}">
+        <input type="hidden" name="confirmationToken" value="${helpers.escapeHtml(session.confirmationToken)}">
+        <button type="submit">Link account</button>
+      </form>
+    </main>
   </body>
 </html>`
 }
@@ -77,9 +185,14 @@ const renderLinkSuccessPage = () => {
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Authentication succeeded</title>
+    <style>${CHAT_LINK_PAGE_STYLES}</style>
   </head>
   <body>
-    <p>Authentication succeeded.</p>
+    <main>
+      <img src="/builder/bblogo.png" alt="Budibase">
+      <h1>Authentication succeeded</h1>
+      <p>Authentication succeeded. You can return to your chat to continue.</p>
+    </main>
     <script>
       if (window.opener && !window.opener.closed) {
         try {

--- a/packages/server/src/api/routes/tests/ai/agentSlack.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentSlack.spec.ts
@@ -433,6 +433,9 @@ describe("agent slack integration provisioning", () => {
         .expect(200)
       expect(authHandoff.type).toEqual("text/html")
       expect(authHandoff.text).toContain("Confirm chat account link")
+      expect(authHandoff.text).toContain("<style>")
+      expect(authHandoff.text).toContain("/builder/bblogo.png")
+      expect(authHandoff.text).toContain("Link account")
       const confirmationToken = extractConfirmationToken(authHandoff.text)
       expect(confirmationToken).toBeTruthy()
 
@@ -460,6 +463,11 @@ describe("agent slack integration provisioning", () => {
         .expect(200)
       expect(confirmHandoff.type).toEqual("text/html")
       expect(confirmHandoff.text).toContain("Authentication succeeded.")
+      expect(confirmHandoff.text).toContain("<style>")
+      expect(confirmHandoff.text).toContain("/builder/bblogo.png")
+      expect(confirmHandoff.text).toContain(
+        "You can return to your chat to continue."
+      )
 
       await config.doInTenant(async () => {
         const link = await sdk.ai.chatIdentityLinks.getChatIdentityLink({

--- a/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentTeams.spec.ts
@@ -89,6 +89,8 @@ const extractLinkUrl = (messages: string[]) => {
   return urls[0]
 }
 
+const getLinkPath = (linkUrl: string) => new URL(linkUrl).pathname
+
 describe("agent teams integration provisioning", () => {
   const config = new TestConfiguration()
   let cleanupAIConfig: undefined | (() => Promise<void>)
@@ -357,8 +359,19 @@ describe("agent teams integration provisioning", () => {
         },
       })
 
-      expect(extractLinkUrl(response.body.messages)).toBeTruthy()
+      const linkUrl = extractLinkUrl(response.body.messages)
+      expect(linkUrl).toBeTruthy()
       expect(mockedWebhookChat).not.toHaveBeenCalled()
+
+      const handoff = await config
+        .getRequest()!
+        .get(getLinkPath(linkUrl!))
+        .set(config.defaultHeaders({}, true))
+        .expect(200)
+      expect(handoff.text).toContain(
+        "Link your Budibase account to <strong>Teams User</strong> on <strong>Teams</strong>."
+      )
+      expect(handoff.text).not.toContain("msteams")
     })
 
     it("blocks unlinked users and guides them to link first", async () => {


### PR DESCRIPTION
## Description
* styles the account linkning page


## Addressess
#19118

## Screenshots

<img width="1512" height="910" alt="Screenshot 2026-07-07 at 16 05 22" src="https://github.com/user-attachments/assets/7e830496-2ac4-4725-8c6a-01e4f6985efd" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

