### PR TITLE
Improve UX for Filter component by focusing input and supporting enter key

### DIFF
--- a/packages/client/src/components/app/filter/FilterPopover.svelte
+++ b/packages/client/src/components/app/filter/FilterPopover.svelte
@@ -196,6 +196,17 @@
       ...retrieved,
     }))
   }
+
+  const applyFilter = () => {
+    const sanitized = sanitizeOperator(editableFilter)
+    const { noValue, value, operator } = sanitized || {}
+
+    // Check for empty filter. if empty on invalid set it to undefined.
+    const update = (!noValue && !value) || !operator ? undefined : sanitized
+
+    dispatch("change", update)
+    hide()
+  }
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -241,6 +252,7 @@
 
         {#if editableFilter?.type && [FieldType.STRING, FieldType.LONGFORM, FieldType.NUMBER, FieldType.BIGINT, FieldType.FORMULA, FieldType.AI].includes(editableFilter.type)}
           <Input
+            autofocus
             disabled={editableFilter.noValue}
             value={editableFilter.value}
             on:change={e => {
@@ -250,6 +262,7 @@
                 value: e.detail,
               })
             }}
+            on:enterkey={applyFilter}
           />
         {:else if (editableFilter?.type && editableFilter?.type === FieldType.ARRAY) || (editableFilter.type === FieldType.OPTIONS && (editableFilter.operator === ArrayOperator.ONE_OF || editableFilter.operator === ArrayOperator.NOT_ONE_OF))}
           {@const isMulti = isArrayOperator(editableFilter.operator)}
@@ -368,20 +381,7 @@
           <Input disabled />
         {/if}
         <!-- Needs to be disabled if there is nothing-->
-        <Button
-          cta
-          on:click={() => {
-            const sanitized = sanitizeOperator(editableFilter)
-            const { noValue, value, operator } = sanitized || {}
-
-            // Check for empty filter. if empty on invalid set it to undefined.
-            const update =
-              (!noValue && !value) || !operator ? undefined : sanitized
-
-            dispatch("change", update)
-            hide()
-          }}
-        >
+        <Button cta on:click={applyFilter}>
           {buttonText || "Apply"}
         </Button>
       {/if}


### PR DESCRIPTION
## Description
Improves the Filter component UX by reducing the required actions to apply a filter. When a filter button is clicked, the text search box is automatically focused so users can type immediately. Additionally, the filter can be applied directly by pressing the "Enter" key on the focused input.


## Addresses
- #18666 

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._

## Launchcontrol

Improves the Filter component UX by reducing the required actions to apply a filter. 

Closes: #18666




<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

