### PR TITLE
Include the whole day for date-only "less than or equal" filters

### DIFF
--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -28,12 +28,15 @@ import {
   StringFieldSubType,
 } from "@budibase/types"
 import dayjs from "dayjs"
+import utc from "dayjs/plugin/utc"
 import { OperatorOptions, SqlNumberTypeRangeMap } from "./constants"
 import { processSearchFilters } from "./utils"
 import { deepGet, schema } from "./helpers"
 import isPlainObject from "lodash/isPlainObject"
 import isEmpty from "lodash/isEmpty"
 import { decodeNonAscii } from "./helpers/schema"
+
+dayjs.extend(utc)
 
 const HBS_REGEX = /{{([^{].*?)}}/g
 const LOGICAL_OPERATORS = Object.values(LogicalOperator)
@@ -388,9 +391,19 @@ function buildCondition(filter?: SearchFilter): SearchFilters | undefined {
     }
   } else if (operator === "rangeHigh" && value != null && value !== "") {
     query.range ??= {}
+    // A date-only "less than or equal to" bound comes through as midnight, which
+    // would drop the rest of that day. Push it to the end of the day so the whole
+    // date is included.
+    let high = value
+    if (type === FieldType.DATETIME) {
+      const date = dayjs.utc(value)
+      if (date.isValid() && date.isSame(date.startOf("day"))) {
+        high = date.endOf("day").toISOString()
+      }
+    }
     query.range[field] = {
       ...query.range[field],
-      high: value,
+      high,
     }
   } else if (operator === "rangeLow" && value != null && value !== "") {
     query.range ??= {}

--- a/packages/shared-core/src/tests/filters.spec.ts
+++ b/packages/shared-core/src/tests/filters.spec.ts
@@ -155,6 +155,50 @@ describe("filter to query conversion", () => {
   })
 })
 
+describe("date rangeHigh includes the whole day", () => {
+  const rangeFor = (value: string) => {
+    const query = buildQuery([
+      {
+        field: "dob",
+        type: FieldType.DATETIME,
+        operator: "rangeHigh",
+        value,
+      },
+    ])
+    return query.$and!.conditions![0].$and!.conditions![0].range!.dob
+  }
+
+  it("extends a date-only high bound to the end of that day", () => {
+    expect(rangeFor("2020-01-05")).toEqual({
+      high: "2020-01-05T23:59:59.999Z",
+    })
+  })
+
+  it("leaves a high bound with an explicit time untouched", () => {
+    expect(rangeFor("2020-01-05T14:30:00.000Z")).toEqual({
+      high: "2020-01-05T14:30:00.000Z",
+    })
+  })
+
+  it("matches rows from later in the target day", () => {
+    const docs = [
+      { id: 1, dob: "2020-01-05T00:00:00.000Z" },
+      { id: 2, dob: "2020-01-05T23:59:00.000Z" },
+      { id: 3, dob: "2020-01-06T00:01:00.000Z" },
+    ]
+    const query = buildQuery([
+      {
+        field: "dob",
+        type: FieldType.DATETIME,
+        operator: "rangeHigh",
+        value: "2020-01-05",
+      },
+    ])
+    const result = runQuery(docs, query)
+    expect(result.map(d => d.id)).toEqual([1, 2])
+  })
+})
+
 describe("runQuery notOneOf", () => {
   const docs = [
     { id: 1, name: "foo" },


### PR DESCRIPTION
## Description
Filtering a date column with `<= 07/07/2026` (date-only picker) drops everything later that day, a row at `07/07/2026 00:01` just disappears. The date-only value comes in as midnight so `<=` cuts off right there. Fixed it in `buildQuery` (shared-core): a date-only `rangeHigh` bound on a datetime field now reaches to the end of the day (`23:59:59.999`). Bounds that already carry a time are left alone.

Two things I'd like your steer on: I detect date-only by checking for midnight, the tidier route is threading the column's `dateOnly` flag into `buildQuery` but the filter object doesn't have it today. And the combined range picker has the same thing on its high end, left it out to keep this tight.

## Addresses
- https://github.com/Budibase/budibase/issues/19167

## App Export
Nothing to attach, logic fix with unit tests.

## Screenshots
No UI change. Regression tests in `filters.spec.ts` fail without the fix.

## Launchcontrol
"Less than or equal to" date filters now cover the whole day you pick instead of cutting off at midnight.
