### PR TITLE
Make rollout strategy and imagePullPolicy configurable in Helm chart

### DIFF
--- a/charts/budibase/templates/app-service-deployment.yaml
+++ b/charts/budibase/templates/app-service-deployment.yaml
@@ -20,11 +20,14 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxSurge: {{ .Values.services.apps.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.services.apps.rollingUpdate.maxUnavailable }}
   template:
     metadata:
       annotations:
+        {{- if .Values.globals.deployTimestamp }}
+        rollme/deploy-timestamp: {{ .Values.globals.deployTimestamp | quote }}
+        {{- end }}
         ad.datadoghq.com/bbapps.logs: '[{"source":"nodejs"}]'
 {{- if .Values.services.couchdb.enabled }}
         checksum/couchdb-secret: {{ (lookup "v1" "Secret" .Release.Namespace (include "couchdb.fullname" .)) | toYaml | sha256sum }}
@@ -257,7 +260,7 @@ spec:
               key: {{ .secretKey | quote }}
         {{- end}}
         image: {{ .Values.services.apps.image | default (printf "%sbudibase/apps:%s" (.Values.globals.dockerRegistry | default "") (.Values.globals.appVersion | default .Chart.AppVersion)) }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.services.apps.imagePullPolicy | default "IfNotPresent" }}
         {{- with .Values.services.apps.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}

--- a/charts/budibase/templates/automation-worker-service-deployment.yaml
+++ b/charts/budibase/templates/automation-worker-service-deployment.yaml
@@ -22,6 +22,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if .Values.globals.deployTimestamp }}
+        rollme/deploy-timestamp: {{ .Values.globals.deployTimestamp | quote }}
+        {{- end }}
         ad.datadoghq.com/bbautomationworker.logs: '[{"source":"nodejs"}]'
 {{ if .Values.services.automationWorkers.templateAnnotations }}
 {{- toYaml .Values.services.automationWorkers.templateAnnotations | indent 8 -}}
@@ -246,7 +249,7 @@ spec:
         {{- end}}
 
         image: {{ .Values.services.automationWorkers.image | default (printf "%sbudibase/apps:%s" (.Values.globals.dockerRegistry | default "") (.Values.globals.appVersion | default .Chart.AppVersion)) }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.services.automationWorkers.imagePullPolicy | default "IfNotPresent" }}
         {{- with .Values.services.automationWorkers.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}

--- a/charts/budibase/templates/proxy-service-deployment.yaml
+++ b/charts/budibase/templates/proxy-service-deployment.yaml
@@ -20,11 +20,14 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxSurge: {{ .Values.services.proxy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.services.proxy.rollingUpdate.maxUnavailable }}
   template:
     metadata:
       annotations:
+        {{- if .Values.globals.deployTimestamp }}
+        rollme/deploy-timestamp: {{ .Values.globals.deployTimestamp | quote }}
+        {{- end }}
         ad.datadoghq.com/proxy-service.logs: '[{"source":"nginx","service":"budibase-proxy"}]'
         ad.datadoghq.com/proxy-service.check_names: '["nginx"]'
         ad.datadoghq.com/proxy-service.init_configs: '[{}]'
@@ -45,7 +48,7 @@ spec:
       {{- end }}
       containers:
       - image: {{ .Values.services.proxy.image | default (printf "%sbudibase/proxy:%s" (.Values.globals.dockerRegistry | default "") (.Values.globals.appVersion | default .Chart.AppVersion)) }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.services.proxy.imagePullPolicy | default "IfNotPresent" }}
         {{- with .Values.services.proxy.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}

--- a/charts/budibase/templates/worker-service-deployment.yaml
+++ b/charts/budibase/templates/worker-service-deployment.yaml
@@ -20,11 +20,14 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxSurge: {{ .Values.services.worker.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.services.worker.rollingUpdate.maxUnavailable }}
   template:
     metadata:
       annotations:
+        {{- if .Values.globals.deployTimestamp }}
+        rollme/deploy-timestamp: {{ .Values.globals.deployTimestamp | quote }}
+        {{- end }}
         ad.datadoghq.com/bbworker.logs: '[{"source":"nodejs"}]'
 {{- if .Values.services.couchdb.enabled }}
         checksum/couchdb-secret: {{ (lookup "v1" "Secret" .Release.Namespace (include "couchdb.fullname" .)) | toYaml | sha256sum }}
@@ -231,7 +234,7 @@ spec:
               key: {{ .secretKey | quote }}
         {{- end}}
         image: {{ .Values.services.worker.image | default (printf "%sbudibase/worker:%s" (.Values.globals.dockerRegistry | default "") (.Values.globals.appVersion | default .Chart.AppVersion)) }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.services.worker.imagePullPolicy | default "IfNotPresent" }}
         {{- with .Values.services.worker.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}

--- a/charts/budibase/tests/app_service_deployment_test.yaml
+++ b/charts/budibase/tests/app_service_deployment_test.yaml
@@ -79,7 +79,15 @@ tests:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 4002
 
-  - it: should set imagePullPolicy to Always
+  - it: should default imagePullPolicy to IfNotPresent
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: should allow overriding imagePullPolicy
+    set:
+      services.apps.imagePullPolicy: Always
     asserts:
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy

--- a/charts/budibase/tests/worker_service_deployment_test.yaml
+++ b/charts/budibase/tests/worker_service_deployment_test.yaml
@@ -85,7 +85,15 @@ tests:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 4003
 
-  - it: should set imagePullPolicy to Always
+  - it: should default imagePullPolicy to IfNotPresent
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: should allow overriding imagePullPolicy
+    set:
+      services.worker.imagePullPolicy: Always
     asserts:
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy

--- a/charts/budibase/values.yaml
+++ b/charts/budibase/values.yaml
@@ -77,6 +77,11 @@ globals:
   # -- The version of Budibase to deploy. Defaults to what's specified by {{ .Chart.AppVersion }}.
   # Ends up being used as the image version tag for the apps, proxy, and worker images.
   appVersion: ""
+  # -- Opaque value stamped onto every pod template as an annotation. Changing it
+  # (e.g. to a fresh timestamp on each deploy) triggers a rolling restart of the
+  # pods without changing the image, which is useful for picking up mutable tags
+  # or externally-managed config. Leave empty to disable (no annotation is added).
+  deployTimestamp: ""
   # -- Sets the environment variable BUDIBASE_ENVIRONMENT for the apps and worker pods. Should not
   # ordinarily need to be changed.
   budibaseEnv: PRODUCTION
@@ -178,6 +183,16 @@ services:
     port: 10000
     # -- The number of proxy replicas to run.
     replicaCount: 2
+    # -- Image pull policy for the proxy pods. Release tags are immutable, so
+    # IfNotPresent avoids a registry round-trip on every pod start. Set to Always
+    # if you deploy a mutable tag (e.g. "latest" or a shared "develop" tag).
+    imagePullPolicy: IfNotPresent
+    # -- Rolling update strategy for the proxy Deployment. maxUnavailable: 0 keeps
+    # the rollout zero-downtime; raise maxSurge (int or percentage, e.g. "25%") to
+    # replace more pods at once and speed up rollouts when spare capacity exists.
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
     # -- The DNS resolver the nginx proxy uses to resolve upstreams at request time.
     # MUST be an IP address (nginx resolves this once at config-load and exits fatally
     # if it is an unresolvable DNS name). Leave empty to auto-detect the kube-dns
@@ -281,6 +296,16 @@ services:
     port: 4002
     # -- The number of apps replicas to run.
     replicaCount: 2
+    # -- Image pull policy for the apps pods. Release tags are immutable, so
+    # IfNotPresent avoids a registry round-trip on every pod start. Set to Always
+    # if you deploy a mutable tag (e.g. "latest" or a shared "develop" tag).
+    imagePullPolicy: IfNotPresent
+    # -- Rolling update strategy for the apps Deployment. maxUnavailable: 0 keeps
+    # the rollout zero-downtime; raise maxSurge (int or percentage, e.g. "25%") to
+    # replace more pods at once and speed up rollouts when spare capacity exists.
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
     # -- The log level for the apps service.
     logLevel: info
     # -- Whether or not to log HTTP requests to the apps service.
@@ -392,6 +417,10 @@ services:
     # -- Whether or not to enable the automation worker service. If you disable this,
     # automations will be processed by the apps service.
     enabled: true
+    # -- Image pull policy for the automation worker pods. Release tags are
+    # immutable, so IfNotPresent avoids a registry round-trip on every pod start.
+    # Set to Always if you deploy a mutable tag (e.g. "latest").
+    imagePullPolicy: IfNotPresent
     # @ignore (you shouldn't need to change this)
     port: 4002
     # -- The number of automation worker replicas to run.
@@ -507,6 +536,16 @@ services:
     port: 4003
     # -- The number of worker replicas to run.
     replicaCount: 2
+    # -- Image pull policy for the worker pods. Release tags are immutable, so
+    # IfNotPresent avoids a registry round-trip on every pod start. Set to Always
+    # if you deploy a mutable tag (e.g. "latest" or a shared "develop" tag).
+    imagePullPolicy: IfNotPresent
+    # -- Rolling update strategy for the worker Deployment. maxUnavailable: 0 keeps
+    # the rollout zero-downtime; raise maxSurge (int or percentage, e.g. "25%") to
+    # replace more pods at once and speed up rollouts when spare capacity exists.
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
     # -- The log level for the worker service.
     logLevel: info
     # -- Whether or not to log HTTP requests to the worker service.


### PR DESCRIPTION
Removing some of the hardcoded values on rollout and deployment config. Enables finetuning based on available cluster headroom.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

