### PR TITLE
Track escalation timeline actions (escalation_raised, escalation_resolved)

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/activity/ActivitySidePanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/activity/ActivitySidePanel.svelte
@@ -6,6 +6,7 @@
     AgentRequest,
     AgentRequestAction,
     AgentRequestStatus,
+    EscalationResolvedAction,
   } from "@budibase/types"
   import dayjs from "dayjs"
   import { fly } from "svelte/transition"
@@ -27,6 +28,15 @@
     failed: "Failed",
   }
 
+  const escalationOutcomeLabel: Record<
+    EscalationResolvedAction["outcome"],
+    string
+  > = {
+    approved: "Escalation approved",
+    rejected: "Escalation rejected",
+    expired: "Escalation expired without a response",
+  }
+
   const formatActionLabel = (action: AgentRequestAction): string => {
     switch (action.type) {
       case "user_message":
@@ -39,6 +49,8 @@
         return action.recipients.length
           ? `Escalated to ${action.recipients.map(r => r.label).join(", ")}`
           : "Escalated"
+      case "escalation_resolved":
+        return escalationOutcomeLabel[action.outcome]
       default:
         throw action satisfies never
     }

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -24,9 +24,6 @@ jest.mock("../sdk/workspace/ai/agentRequests", () => {
   const actual = jest.requireActual("../sdk/workspace/ai/agentRequests")
   return {
     ...actual,
-    // Real by default (delegates to the actual implementation) so every test
-    // other than the resilience one below exercises the genuine write path -
-    // only overridden per-test to simulate a failure.
     recordEscalationResolved: jest.fn(actual.recordEscalationResolved),
   }
 })
@@ -35,8 +32,6 @@ jest.mock("ai", () => {
   const actual = jest.requireActual("ai")
   return {
     ...actual,
-    // resumeOperation only cares about the UIMessages it yields, not the raw
-    // wire protocol - skip the real parsing and pass the fake stream through.
     readUIMessageStream: (opts: { stream: unknown }) => opts.stream,
   }
 })

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -1,0 +1,259 @@
+import { context } from "@budibase/backend-core"
+import {
+  Agent,
+  DocumentType,
+  EscalationContextDoc,
+  EscalationSource,
+  SEPARATOR,
+  SuspendedOperationContext,
+} from "@budibase/types"
+import TestConfiguration from "../tests/utilities/TestConfiguration"
+import sdk from "../sdk"
+import { resumeOperation } from "./queue"
+
+jest.mock("../sdk/workspace/ai/agents", () => {
+  const actual = jest.requireActual("../sdk/workspace/ai/agents")
+  return {
+    ...actual,
+    getOrThrow: jest.fn(),
+    prepareAgentChatRun: jest.fn(),
+  }
+})
+
+jest.mock("../sdk/workspace/ai/agentRequests", () => {
+  const actual = jest.requireActual("../sdk/workspace/ai/agentRequests")
+  return {
+    ...actual,
+    // Real by default (delegates to the actual implementation) so every test
+    // other than the resilience one below exercises the genuine write path -
+    // only overridden per-test to simulate a failure.
+    recordEscalationResolved: jest.fn(actual.recordEscalationResolved),
+  }
+})
+
+jest.mock("ai", () => {
+  const actual = jest.requireActual("ai")
+  return {
+    ...actual,
+    // resumeOperation only cares about the UIMessages it yields, not the raw
+    // wire protocol - skip the real parsing and pass the fake stream through.
+    readUIMessageStream: (opts: { stream: unknown }) => opts.stream,
+  }
+})
+
+const prepareAgentChatRunMock = sdk.ai.agents.prepareAgentChatRun as jest.Mock
+const getOrThrowMock = sdk.ai.agents.getOrThrow as jest.Mock
+const recordEscalationResolvedMock = sdk.ai.agentRequests
+  .recordEscalationResolved as jest.Mock
+
+const mockApprovedRun = (text: string) => {
+  prepareAgentChatRunMock.mockResolvedValue({
+    toolDisplayNames: {},
+    sessionLogIndexer: { index: jest.fn().mockResolvedValue(undefined) },
+    stream: jest.fn().mockResolvedValue({
+      finishReason: Promise.resolve("stop"),
+      toUIMessageStream: () =>
+        (async function* () {
+          yield { id: "", role: "assistant", parts: [{ type: "text", text }] }
+        })(),
+    }),
+  })
+  getOrThrowMock.mockResolvedValue({ _id: "agent_1" } as Agent)
+}
+
+describe("resumeOperation", () => {
+  const config = new TestConfiguration()
+
+  const createRequest = () =>
+    sdk.ai.agentRequests.initActiveRequest({
+      agentId: "agent_1",
+      userId: "user_1",
+      sessionId: "session_1",
+      latestPrompt: "Buy 1500 pens",
+      operation: { name: "Procurement", prompt: "Handle procurement." },
+      source: "Chat",
+    })
+
+  const baseDoc = (
+    overrides: Partial<EscalationContextDoc> = {}
+  ): EscalationContextDoc => ({
+    _id: `${DocumentType.ESCALATION_CONTEXT}${SEPARATOR}esc_primary`,
+    source: EscalationSource.OPERATION,
+    appId: config.getProdWorkspaceId(),
+    tenantId: config.getTenantId(),
+    agentId: "agent_1",
+    operationId: "op_1",
+    sessionId: "session_1",
+    delay: 1000,
+    resolution: "pending",
+    ...overrides,
+  })
+
+  const baseCtx: SuspendedOperationContext = {
+    agentId: "agent_1",
+    operationId: "op_1",
+    sessionId: "session_1",
+    messages: [],
+  }
+
+  beforeEach(async () => {
+    prepareAgentChatRunMock.mockReset()
+    getOrThrowMock.mockReset()
+    await config.newTenant()
+  })
+
+  afterAll(() => {
+    config.end()
+  })
+
+  it("records escalation_resolved with outcome approved and continues the resumed turn", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const { requestId } = (await createRequest())!
+      mockApprovedRun("Approved and booked.")
+
+      await resumeOperation({
+        doc: baseDoc({ requestId, response: { accepted: true } }),
+        escalationId: "esc_primary",
+        resolution: "resolved",
+        ctx: baseCtx,
+      })
+
+      const [request] =
+        await sdk.ai.agentRequests.fetchRequestsByAgent("agent_1")
+      expect(request.actions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "escalation_resolved",
+            escalationId: "esc_primary",
+            outcome: "approved",
+            sessionId: "session_1",
+          }),
+        ])
+      )
+    })
+  })
+
+  it("records escalation_resolved with outcome rejected", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const { requestId } = (await createRequest())!
+
+      await resumeOperation({
+        doc: baseDoc({ requestId, response: { accepted: false } }),
+        escalationId: "esc_primary",
+        resolution: "resolved",
+        ctx: baseCtx,
+      })
+
+      const [request] =
+        await sdk.ai.agentRequests.fetchRequestsByAgent("agent_1")
+      expect(request.actions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "escalation_resolved",
+            escalationId: "esc_primary",
+            outcome: "rejected",
+          }),
+        ])
+      )
+      expect(prepareAgentChatRunMock).not.toHaveBeenCalled()
+    })
+  })
+
+  it("records escalation_resolved with outcome expired", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const { requestId } = (await createRequest())!
+
+      await resumeOperation({
+        doc: baseDoc({ requestId }),
+        escalationId: "esc_primary",
+        resolution: "expired",
+        ctx: baseCtx,
+      })
+
+      const [request] =
+        await sdk.ai.agentRequests.fetchRequestsByAgent("agent_1")
+      expect(request.actions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "escalation_resolved",
+            escalationId: "esc_primary",
+            outcome: "expired",
+          }),
+        ])
+      )
+      expect(request.status).toEqual("failed")
+    })
+  })
+
+  it("still records escalation_resolved for the expiring escalation, but doesn't finalize the request while another escalation is pending", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const { requestId } = (await createRequest())!
+      await sdk.ai.agentRequests.updateRequestStatus({
+        requestId,
+        status: "needs_input",
+      })
+      await context.getWorkspaceDB().put(
+        baseDoc({
+          _id: `${DocumentType.ESCALATION_CONTEXT}${SEPARATOR}esc_other`,
+          requestId,
+        })
+      )
+
+      await resumeOperation({
+        doc: baseDoc({ requestId }),
+        escalationId: "esc_primary",
+        resolution: "expired",
+        ctx: baseCtx,
+      })
+
+      const [request] =
+        await sdk.ai.agentRequests.fetchRequestsByAgent("agent_1")
+      expect(request.actions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "escalation_resolved",
+            escalationId: "esc_primary",
+            outcome: "expired",
+          }),
+        ])
+      )
+      expect(request.status).toEqual("needs_input")
+    })
+  })
+
+  it("does nothing when the escalation has no associated request", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      await expect(
+        resumeOperation({
+          doc: baseDoc(),
+          escalationId: "esc_primary",
+          resolution: "expired",
+          ctx: baseCtx,
+        })
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  it("continues the resume even if recording the escalation resolution fails", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const { requestId } = (await createRequest())!
+      recordEscalationResolvedMock.mockRejectedValueOnce(
+        new Error("DB unavailable")
+      )
+
+      await resumeOperation({
+        doc: baseDoc({ requestId }),
+        escalationId: "esc_primary",
+        resolution: "expired",
+        ctx: baseCtx,
+      })
+
+      const [request] =
+        await sdk.ai.agentRequests.fetchRequestsByAgent("agent_1")
+      expect(request.status).toEqual("failed")
+      expect(
+        (request.actions ?? []).filter(a => a.type === "escalation_resolved")
+      ).toEqual([])
+    })
+  })
+})

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -14,9 +14,8 @@ import {
   SEPARATOR,
   SuspendedOperationContext,
 } from "@budibase/types"
-import { automationQueue } from "../automations/bullboard"
+import { automationQueue } from "../automations"
 import sdk from "../sdk"
-import { prepareAgentChatRun } from "../sdk/workspace/ai/agents"
 import { getFullUser } from "../utilities/users"
 import * as slack from "./notifications/slack"
 import * as discord from "./notifications/discord"
@@ -232,7 +231,7 @@ async function persistResumeResult(escalationId: string, message: UIMessage) {
   })
 }
 
-async function resumeOperation({
+export async function resumeOperation({
   doc,
   escalationId,
   resolution,
@@ -253,6 +252,23 @@ async function resumeOperation({
     agentId: ctx.agentId,
     operationId: ctx.operationId,
   })
+
+  if (doc.requestId) {
+    await sdk.ai.agentRequests
+      .recordEscalationResolved({
+        requestId: doc.requestId,
+        escalationId,
+        outcome,
+        sessionId: ctx.sessionId,
+      })
+      .catch(error => {
+        console.error("Failed to record escalation resolution", {
+          escalationId,
+          agentId: ctx.agentId,
+          error,
+        })
+      })
+  }
 
   const markEscalationRequestResolved = async (params: {
     status: "completed" | "failed"
@@ -391,7 +407,7 @@ async function resumeOperation({
     },
   ]
 
-  const run = await prepareAgentChatRun({
+  const run = await sdk.ai.agents.prepareAgentChatRun({
     agent,
     agentId: ctx.agentId,
     modelMessages: messages,

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.spec.ts
@@ -1,5 +1,11 @@
 import { context } from "@budibase/backend-core"
-import { DocumentType, EscalationSource, SEPARATOR } from "@budibase/types"
+import {
+  DocumentType,
+  EscalateToolResultStatus,
+  EscalationNotificationChannel,
+  EscalationSource,
+  SEPARATOR,
+} from "@budibase/types"
 import TestConfiguration from "../../../../tests/utilities/TestConfiguration"
 import { builderSocket } from "../../../../websockets"
 import {
@@ -8,6 +14,7 @@ import {
   fetchRequestsByAgent,
   fetchRequestsSummary,
   initActiveRequest,
+  recordEscalationResolved,
   recordToolCall,
   resolveFinalRequestOutcome,
   resolveFinalRequestStatus,
@@ -754,6 +761,256 @@ describe("agentRequests crud", () => {
             sessionId: "session_1",
             toolName: "book_meeting",
             status: "success",
+          })
+        ).resolves.toBeUndefined()
+      })
+    })
+  })
+
+  describe("escalation_raised actions", () => {
+    const createBookingRequest = () =>
+      initActiveRequest({
+        agentId: "agent_1",
+        userId: "user_1",
+        sessionId: "session_1",
+        latestPrompt: "Book me a meeting",
+        operation: { name: "Scheduling", prompt: "Schedule meetings." },
+        source: "Chat",
+      })
+
+    const putEscalationContextDoc = async (
+      escalationId: string,
+      requestId: string,
+      recipients: Array<{ type: EscalationNotificationChannel; config: any }>
+    ) => {
+      await context.getWorkspaceDB().put({
+        _id: `${DocumentType.ESCALATION_CONTEXT}${SEPARATOR}${escalationId}`,
+        source: EscalationSource.OPERATION,
+        appId: config.getProdWorkspaceId(),
+        tenantId: config.getTenantId(),
+        agentId: "agent_1",
+        sessionId: "session_1",
+        requestId,
+        delay: 1000,
+        resolution: "pending",
+        recipients,
+      })
+    }
+
+    it("records an escalation_raised action with resolved recipient labels", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await createBookingRequest())!
+        const user = await config.createUser({
+          firstName: "Manolo",
+          lastName: "Garcia",
+        })
+        await putEscalationContextDoc("esc_1", requestId, [
+          {
+            type: EscalationNotificationChannel.SLACK,
+            config: { channelId: "C1", channelName: "operations" },
+          },
+          {
+            type: EscalationNotificationChannel.SLACK,
+            config: { globalUserId: user._id },
+          },
+        ])
+
+        await recordToolCall({
+          requestId,
+          agentId: "agent_1",
+          sessionId: "session_1",
+          toolName: "escalate",
+          status: "success",
+          output: {
+            status: EscalateToolResultStatus.PENDING_APPROVAL,
+            escalationId: "esc_1",
+            note: "Escalated for approval",
+          },
+        })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        expect(request.actions).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: "escalation_raised",
+              escalationId: "esc_1",
+              sessionId: "session_1",
+              recipients: [
+                {
+                  type: EscalationNotificationChannel.SLACK,
+                  label: "operations",
+                },
+                {
+                  type: EscalationNotificationChannel.SLACK,
+                  label: "Manolo Garcia",
+                },
+              ],
+            }),
+          ])
+        )
+        expect(
+          (request.actions ?? []).filter(a => a.type === "tool_call")
+        ).toEqual([])
+        expect(generateToolCallSummaryMock).not.toHaveBeenCalled()
+      })
+    })
+
+    it("falls back to a generic tool_call when the escalation context doc can't be found", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await createBookingRequest())!
+
+        await recordToolCall({
+          requestId,
+          agentId: "agent_1",
+          sessionId: "session_1",
+          toolName: "escalate",
+          status: "success",
+          output: {
+            status: EscalateToolResultStatus.PENDING_APPROVAL,
+            escalationId: "esc_missing",
+          },
+        })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        expect(
+          (request.actions ?? []).filter(a => a.type === "escalation_raised")
+        ).toEqual([])
+        expect(
+          (request.actions ?? []).filter(a => a.type === "tool_call")
+        ).toEqual([expect.objectContaining({ toolName: "escalate" })])
+        expect(generateToolCallSummaryMock).toHaveBeenCalled()
+      })
+    })
+
+    it("records a generic tool_call when escalate is unavailable", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await createBookingRequest())!
+
+        await recordToolCall({
+          requestId,
+          agentId: "agent_1",
+          sessionId: "session_1",
+          toolName: "escalate",
+          status: "error",
+          output: { status: EscalateToolResultStatus.UNAVAILABLE },
+        })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        expect(
+          (request.actions ?? []).filter(a => a.type === "escalation_raised")
+        ).toEqual([])
+        expect(
+          (request.actions ?? []).filter(a => a.type === "tool_call")
+        ).toEqual([
+          expect.objectContaining({ toolName: "escalate", status: "error" }),
+        ])
+      })
+    })
+
+    it("records a generic tool_call when escalate was already approved (resume)", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await createBookingRequest())!
+
+        await recordToolCall({
+          requestId,
+          agentId: "agent_1",
+          sessionId: "session_1",
+          toolName: "escalate",
+          status: "success",
+          output: { status: EscalateToolResultStatus.ALREADY_APPROVED },
+        })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        expect(
+          (request.actions ?? []).filter(a => a.type === "escalation_raised")
+        ).toEqual([])
+        expect(
+          (request.actions ?? []).filter(a => a.type === "tool_call")
+        ).toEqual([expect.objectContaining({ toolName: "escalate" })])
+      })
+    })
+  })
+
+  describe("escalation_resolved actions", () => {
+    const createBookingRequest = () =>
+      initActiveRequest({
+        agentId: "agent_1",
+        userId: "user_1",
+        sessionId: "session_1",
+        latestPrompt: "Book me a meeting",
+        operation: { name: "Scheduling", prompt: "Schedule meetings." },
+        source: "Chat",
+      })
+
+    it.each(["approved", "rejected", "expired"] as const)(
+      "records an escalation_resolved action for outcome %s",
+      async outcome => {
+        await config.doInContext(config.getProdWorkspaceId(), async () => {
+          const { requestId } = (await createBookingRequest())!
+
+          await recordEscalationResolved({
+            requestId,
+            escalationId: "esc_1",
+            outcome,
+            sessionId: "session_1",
+          })
+
+          const [request] = await fetchRequestsByAgent("agent_1")
+          expect(
+            (request.actions ?? []).filter(
+              a => a.type === "escalation_resolved"
+            )
+          ).toEqual([
+            expect.objectContaining({
+              type: "escalation_resolved",
+              escalationId: "esc_1",
+              outcome,
+              sessionId: "session_1",
+            }),
+          ])
+        })
+      }
+    )
+
+    it("records one action per escalation on the same request", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        const { requestId } = (await createBookingRequest())!
+
+        await recordEscalationResolved({
+          requestId,
+          escalationId: "esc_1",
+          outcome: "approved",
+        })
+        await recordEscalationResolved({
+          requestId,
+          escalationId: "esc_2",
+          outcome: "rejected",
+        })
+
+        const [request] = await fetchRequestsByAgent("agent_1")
+        const resolvedActions = (request.actions ?? []).filter(
+          a => a.type === "escalation_resolved"
+        )
+        expect(resolvedActions).toEqual([
+          expect.objectContaining({
+            escalationId: "esc_1",
+            outcome: "approved",
+          }),
+          expect.objectContaining({
+            escalationId: "esc_2",
+            outcome: "rejected",
+          }),
+        ])
+      })
+    })
+
+    it("does nothing if the requestId does not exist", async () => {
+      await config.doInContext(config.getProdWorkspaceId(), async () => {
+        await expect(
+          recordEscalationResolved({
+            requestId: "agentrequest_missing",
+            escalationId: "esc_1",
+            outcome: "approved",
           })
         ).resolves.toBeUndefined()
       })

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
@@ -227,7 +227,8 @@ type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
 // succession.
 async function appendAction(
   requestId: string,
-  action: DistributiveOmit<AgentRequestAction, "id" | "timestamp">
+  action: DistributiveOmit<AgentRequestAction, "id" | "timestamp">,
+  timestamp: string = nowIso()
 ): Promise<AgentRequestAction | undefined> {
   const db = context.getWorkspaceDB()
 
@@ -240,14 +241,14 @@ async function appendAction(
     const fullAction = {
       ...action,
       id: utils.newid(),
-      timestamp: nowIso(),
+      timestamp,
     } as AgentRequestAction
 
     try {
       await saveRequest({
         ...request,
         actions: [...(request.actions ?? []), fullAction],
-        updatedAt: fullAction.timestamp,
+        updatedAt: nowIso(),
       })
       return fullAction
     } catch (err) {
@@ -312,6 +313,8 @@ async function recordEscalationRaised({
   sessionId: string
   escalationId: string
 }): Promise<void> {
+  const timestamp = nowIso()
+
   const doc = await getContextDoc(escalationId)
   if (!doc) {
     throw new Error(`Escalation context doc not found: ${escalationId}`)
@@ -323,12 +326,16 @@ async function recordEscalationRaised({
     }))
   )
 
-  await appendAction(requestId, {
-    type: "escalation_raised",
-    escalationId,
-    recipients,
-    sessionId,
-  })
+  await appendAction(
+    requestId,
+    {
+      type: "escalation_raised",
+      escalationId,
+      recipients,
+      sessionId,
+    },
+    timestamp
+  )
 }
 
 export async function recordEscalationResolved({

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
@@ -5,12 +5,14 @@ import {
   Duration,
   utils,
 } from "@budibase/backend-core"
+import { ESCALATE_TOOL_NAME, EscalateToolResultStatus } from "@budibase/types"
 import type {
   AgentRequest,
   AgentRequestAction,
   AgentRequestEntry,
   AgentRequestsSummary,
   AgentRequestStatus,
+  EscalationResolvedAction,
   StatusChangedAction,
   UserMessageAction,
   ToolCallAction,
@@ -29,7 +31,11 @@ import {
   queryRequestsByUpdatedAt,
   queryRequestsByStatusAndUpdatedAt,
 } from "./views"
-import { listContextDocs } from "../../escalations"
+import {
+  getContextDoc,
+  listContextDocs,
+  resolveRecipientLabel,
+} from "../../escalations"
 
 const THREAD_CANDIDATE_LIMIT = 10
 const THREAD_LOOKBACK_DAYS = 30
@@ -252,6 +258,53 @@ async function appendAction(
   }
 }
 
+async function recordEscalationRaised({
+  requestId,
+  sessionId,
+  escalationId,
+}: {
+  requestId: string
+  sessionId: string
+  escalationId: string
+}): Promise<void> {
+  const doc = await getContextDoc(escalationId)
+  if (!doc) {
+    throw new Error(`Escalation context doc not found: ${escalationId}`)
+  }
+  const recipients = await Promise.all(
+    (doc.recipients ?? []).map(async recipient => ({
+      type: recipient.type,
+      label: await resolveRecipientLabel(recipient),
+    }))
+  )
+
+  await appendAction(requestId, {
+    type: "escalation_raised",
+    escalationId,
+    recipients,
+    sessionId,
+  })
+}
+
+export async function recordEscalationResolved({
+  requestId,
+  escalationId,
+  outcome,
+  sessionId,
+}: {
+  requestId: string
+  escalationId: string
+  outcome: EscalationResolvedAction["outcome"]
+  sessionId?: string
+}): Promise<void> {
+  await appendAction(requestId, {
+    type: "escalation_resolved",
+    escalationId,
+    outcome,
+    sessionId,
+  })
+}
+
 export async function recordToolCall({
   requestId,
   agentId,
@@ -271,6 +324,35 @@ export async function recordToolCall({
   input?: unknown
   output?: unknown
 }): Promise<void> {
+  if (toolName === ESCALATE_TOOL_NAME && status === "success") {
+    const escalationOutput = output as
+      | { status?: string; escalationId?: string }
+      | undefined
+    if (
+      escalationOutput?.status === EscalateToolResultStatus.PENDING_APPROVAL &&
+      escalationOutput.escalationId
+    ) {
+      try {
+        await recordEscalationRaised({
+          requestId,
+          sessionId,
+          escalationId: escalationOutput.escalationId,
+        })
+        return
+      } catch (error) {
+        console.error(
+          "Failed to record escalation_raised action, falling back to a generic tool_call",
+          {
+            agentId,
+            sessionId,
+            escalationId: escalationOutput.escalationId,
+            error,
+          }
+        )
+      }
+    }
+  }
+
   let summary: string | undefined
   try {
     summary = await generateToolCallSummary({

--- a/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/crud.ts
@@ -369,21 +369,6 @@ export async function recordToolCall({
   input?: unknown
   output?: unknown
 }): Promise<void> {
-  // Save the action up front so the timeline shows it via readableName/
-  // toolName while the LLM summary is still generating. Call sites on the
-  // agent runtime's hot path deliberately fire-and-forget this promise so the
-  // summary never blocks the next step.
-  const action = await appendAction(requestId, {
-    type: "tool_call",
-    toolName,
-    status,
-    sessionId,
-    ...(readableName === undefined ? {} : { readableName }),
-  })
-  if (!action) {
-    return
-  }
-
   if (toolName === ESCALATE_TOOL_NAME && status === "success") {
     const escalationOutput = output as
       | { status?: string; escalationId?: string }
@@ -411,6 +396,21 @@ export async function recordToolCall({
         )
       }
     }
+  }
+
+  // Save the action up front so the timeline shows it via readableName/
+  // toolName while the LLM summary is still generating. Call sites on the
+  // agent runtime's hot path deliberately fire-and-forget this promise so the
+  // summary never blocks the next step.
+  const action = await appendAction(requestId, {
+    type: "tool_call",
+    toolName,
+    status,
+    sessionId,
+    ...(readableName === undefined ? {} : { readableName }),
+  })
+  if (!action) {
+    return
   }
 
   let summary: string | undefined

--- a/packages/server/src/sdk/workspace/ai/agentRequests/helpers.ts
+++ b/packages/server/src/sdk/workspace/ai/agentRequests/helpers.ts
@@ -331,6 +331,8 @@ const summarizeActionForOutcome = (action: AgentRequestAction) => {
       }
     case "escalation_raised":
       return { type: action.type, recipients: action.recipients }
+    case "escalation_resolved":
+      return { type: action.type, outcome: action.outcome }
   }
 }
 

--- a/packages/server/src/sdk/workspace/escalations.spec.ts
+++ b/packages/server/src/sdk/workspace/escalations.spec.ts
@@ -1,0 +1,100 @@
+import {
+  EscalationNotificationChannel,
+  EscalationRecipient,
+} from "@budibase/types"
+import TestConfiguration from "../../tests/utilities/TestConfiguration"
+import { resolveRecipientLabel } from "./escalations"
+
+describe("resolveRecipientLabel", () => {
+  const config = new TestConfiguration()
+
+  beforeEach(async () => {
+    await config.newTenant()
+  })
+
+  afterAll(() => {
+    config.end()
+  })
+
+  const channelRecipient = (
+    config: Record<string, any>
+  ): EscalationRecipient => ({
+    type: EscalationNotificationChannel.SLACK,
+    config,
+  })
+
+  it("uses the channel name when present", async () => {
+    const recipient = channelRecipient({
+      channelId: "C123",
+      channelName: "operations",
+    })
+
+    await expect(resolveRecipientLabel(recipient)).resolves.toEqual(
+      "operations"
+    )
+  })
+
+  it("falls back to the raw channel id when there is no channel name", async () => {
+    const recipient = channelRecipient({ channelId: "C123" })
+
+    await expect(resolveRecipientLabel(recipient)).resolves.toEqual("C123")
+  })
+
+  it("resolves a recipient's full name from their Budibase profile", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const user = await config.createUser({
+        firstName: "Manolo",
+        lastName: "Garcia",
+      })
+      const recipient = channelRecipient({ globalUserId: user._id })
+
+      await expect(resolveRecipientLabel(recipient)).resolves.toEqual(
+        "Manolo Garcia"
+      )
+    })
+  })
+
+  it("falls back to the recipient's email when no name is set", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const user = await config.createUser({ firstName: "", lastName: "" })
+      const recipient = channelRecipient({ globalUserId: user._id })
+
+      await expect(resolveRecipientLabel(recipient)).resolves.toEqual(
+        user.email
+      )
+    })
+  })
+
+  it("falls back to the raw globalUserId when the user can't be resolved", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const recipient = channelRecipient({ globalUserId: "us_nonexistent" })
+
+      await expect(resolveRecipientLabel(recipient)).resolves.toEqual(
+        "us_nonexistent"
+      )
+    })
+  })
+
+  it("returns Unknown when the recipient config has no usable field", async () => {
+    const recipient = channelRecipient({})
+
+    await expect(resolveRecipientLabel(recipient)).resolves.toEqual("Unknown")
+  })
+
+  it("prefers the channel name over a globalUserId on the same recipient", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const user = await config.createUser({
+        firstName: "Manolo",
+        lastName: "Garcia",
+      })
+      const recipient = channelRecipient({
+        channelName: "operations",
+        globalUserId: user._id,
+      })
+
+      await expect(resolveRecipientLabel(recipient)).resolves.toEqual(
+        "operations"
+      )
+    })
+  })
+})

--- a/packages/server/src/sdk/workspace/escalations.ts
+++ b/packages/server/src/sdk/workspace/escalations.ts
@@ -5,6 +5,7 @@ import {
   DocumentType,
   EscalationContextDoc,
   EscalationNotificationDoc,
+  EscalationRecipient,
   EscalationResult,
   EscalationRespondResult,
   EscalationResponse,
@@ -19,6 +20,7 @@ import {
 } from "@budibase/string-templates"
 import { IsolatedVM } from "../../jsRunner/vm"
 import { RESOLUTION_STRATEGY_SNIPPETS } from "../../escalation/resolutionStrategies"
+import { getFullUser } from "../../utilities/users"
 
 const getDocId = (escalationId: string): string =>
   `${DocumentType.ESCALATION_CONTEXT}${SEPARATOR}${escalationId}`
@@ -56,6 +58,36 @@ export async function getResult(
     summary: doc.summary,
     resumeResult,
   }
+}
+
+// Human-readable label for a recipient. The channel's or the person's real
+// name, never the provider (Slack/Discord/...). A globalUserId recipient is
+// always a real Budibase user (the builder's recipient picker only offers
+// users with an existing chat identity link), so the profile name is always
+// resolvable
+export async function resolveRecipientLabel(
+  recipient: EscalationRecipient
+): Promise<string> {
+  const { config } = recipient
+  if (config?.channelName) {
+    return config.channelName
+  }
+  if (config?.channelId) {
+    return config.channelId
+  }
+  if (config?.globalUserId) {
+    try {
+      const user = await getFullUser(config.globalUserId)
+      return user.fullName || user.email || config.globalUserId
+    } catch (error) {
+      console.error("Failed to resolve escalation recipient's user", {
+        globalUserId: config.globalUserId,
+        error,
+      })
+      return config.globalUserId
+    }
+  }
+  return "Unknown"
 }
 
 export interface EscalationContextQuery {

--- a/packages/types/src/documents/global/agentRequests.ts
+++ b/packages/types/src/documents/global/agentRequests.ts
@@ -57,11 +57,18 @@ export interface EscalationRaisedAction extends AgentRequestActionBase {
   }>
 }
 
+export interface EscalationResolvedAction extends AgentRequestActionBase {
+  type: "escalation_resolved"
+  escalationId: string
+  outcome: "approved" | "rejected" | "expired"
+}
+
 export type AgentRequestAction =
   | UserMessageAction
   | StatusChangedAction
   | ToolCallAction
   | EscalationRaisedAction
+  | EscalationResolvedAction
 
 export interface AgentRequest extends Document {
   title?: string


### PR DESCRIPTION
## Addresses
- Continuation of the AgentRequest activity timeline work (`operations/actions-timeline-7`, PR #19184).

## Description
Implements Step 5 of the AgentRequest activity timeline: when an operation escalates to a human, the timeline now records who it was escalated to (channel or person's real name, never the provider), and once that escalation is resolved, the outcome (approved/rejected/expired).

- `recordToolCall()` now detects a `pending_approval` `escalate` call and records `escalation_raised` instead of a generic `tool_call`, resolving each recipient's label via the new `resolveRecipientLabel()` (channel name, or the Budibase profile name for a person recipient).
- `resumeOperation()` records `escalation_resolved` unconditionally as soon as the outcome is known, independent of whether the request itself is finalized (a request can have several escalations in flight).
- Fixes a silent gap in `summarizeActionForOutcome()` that would have dropped `escalation_resolved` from the LLM outcome judge's input.
- Aligns `queue.ts` with the rest of the codebase by calling `prepareAgentChatRun` via `sdk.ai.agents` instead of a direct import, which is also what makes it reliably mockable in tests.
- Adds the first integration test for `escalation/queue.ts`'s `resumeOperation` (approved/rejected/expired/multi-escalation).

## Screen recording

https://github.com/user-attachments/assets/0682e1c3-75f4-4e67-93a5-a7e7a4c6e981

## Launchcontrol
The Activity timeline for an AI agent request now shows when a request was escalated to a human (and to whom), and how that escalation was resolved (approved, rejected, or expired without a response).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Budibase/budibase/pull/19192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

