### PR TITLE
Fix mysql test docker-compose, updating it to mysql 9

### DIFF
--- a/packages/server/scripts/integrations/mysql/docker-compose.yaml
+++ b/packages/server/scripts/integrations/mysql/docker-compose.yaml
@@ -1,16 +1,16 @@
 # Use root/example as user/password credentials
-version: '3.1'
+version: "3.1"
 
 services:
-
   db:
-    image: mysql
+    image: mysql:9
     restart: always
-    command: --init-file /data/application/init.sql --default-authentication-plugin=mysql_native_password
+    command: --init-file /data/application/init.sql
     volumes:
       - ./init.sql:/data/application/init.sql
     environment:
       MYSQL_ROOT_PASSWORD: root
+      MYSQL_ROOT_HOST: "%"
     ports:
       - 3306:3306
 


### PR DESCRIPTION
## Description
Fix mysql test docker-compose, updating it to mysql 9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the MySQL test Docker Compose to use `mysql:9` and allow root access from the host, fixing container startup with MySQL 9.

- **Bug Fixes**
  - Bump image to `mysql:9`.
  - Remove `--default-authentication-plugin=mysql_native_password`.
  - Add `MYSQL_ROOT_HOST="%"` to permit host connections during tests.

<sup>Written for commit d4d6b9e6e2af01b342741365b3a42be098d2a84e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

