### PR TITLE
fix: can miss sharepoint name on partial falure

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/new/SelectSharePointSiteModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/new/SelectSharePointSiteModal.svelte
@@ -125,7 +125,10 @@
   }
 
   const handleSelect = async (mode: SharePointSelectionMode) => {
-    if (!agentId || !operationId || !selectedSiteId) {
+    const selectedSite = sharePointSites.find(
+      site => site.id === selectedSiteId
+    )
+    if (!agentId || !operationId || !selectedSite) {
       return
     }
     saving = true
@@ -133,7 +136,7 @@
       await agentsStore.connectOperationSharePointSite(agentId, operationId, {
         datasourceId: selectedDatasourceId,
         authConfigId: selectedAuthConfigId,
-        siteId: selectedSiteId,
+        site: selectedSite,
         filters: mode === "selective" ? [EXCLUDE_ALL_PATTERN] : undefined,
       })
       await workspaceDeploymentStore.fetch()

--- a/packages/server/src/api/controllers/ai/files.ts
+++ b/packages/server/src/api/controllers/ai/files.ts
@@ -381,7 +381,8 @@ export async function connectAgentSharePointSite(
   >
 ) {
   const { agentId, operationId } = ctx.params
-  const { datasourceId, authConfigId, siteId, filters } = ctx.request.body
+  const { datasourceId, authConfigId, site, filters } = ctx.request.body
+  const siteId = site.id
   if (!siteId) {
     throw new HTTPError("siteId is required", 400)
   }
@@ -415,8 +416,8 @@ export async function connectAgentSharePointSite(
       authConfigId,
       site: {
         id: siteId,
-        name: selectedOption?.name,
-        webUrl: selectedOption?.webUrl,
+        name: selectedOption?.name || site.name,
+        webUrl: selectedOption?.webUrl || site.webUrl,
       },
       filters: filters ? { patterns: filters } : undefined,
     },

--- a/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
+++ b/packages/server/src/api/routes/tests/ai/agentFiles.spec.ts
@@ -451,7 +451,7 @@ describe("agent files", () => {
       created._id!,
       operationId,
       {
-        siteId: "site-1",
+        site: { id: "site-1" },
         datasourceId: "datasource-1",
         authConfigId: "auth-1",
       },
@@ -461,6 +461,115 @@ describe("agent files", () => {
           message: "SharePoint auth config not found.",
         },
       }
+    )
+  })
+
+  it("persists submitted SharePoint metadata when the site listing omits the selected site", async () => {
+    const created = await config.api.agent.createWithOperation(
+      {
+        name: "SharePoint Site Metadata Agent",
+        aiconfig: "default",
+      },
+      operation
+    )
+    const operationId = created.operations?.[0]?.id || operation.id
+    const connection = await setSharePointConnection(created._id!)
+    mockSharePointOAuthTokenFetch(2)
+    mockSharePointSitesFetch([], 2)
+
+    await config.api.agent.connectSharePointSite(created._id!, operationId, {
+      ...connection,
+      site: {
+        id: "contoso.sharepoint.com,site-id,web-id",
+        name: "Product Documentation",
+        webUrl: "https://example.com/sites/product-documentation",
+      },
+    })
+
+    await config.doInContext(config.getDevWorkspaceId(), async () => {
+      const db = context.getWorkspaceDB()
+      const updated = await db.tryGet<Agent>(created._id!)
+      const source = updated?.operations
+        ?.find(operation => operation.id === operationId)
+        ?.knowledgeSources?.find(
+          source => source.type === AgentKnowledgeSourceType.SHAREPOINT
+        )
+
+      expect(source?.config.site).toEqual({
+        id: "contoso.sharepoint.com,site-id,web-id",
+        name: "Product Documentation",
+        webUrl: "https://example.com/sites/product-documentation",
+      })
+    })
+  })
+
+  it("prefers current SharePoint metadata over submitted metadata", async () => {
+    const created = await config.api.agent.createWithOperation(
+      {
+        name: "SharePoint Current Metadata Agent",
+        aiconfig: "default",
+      },
+      operation
+    )
+    const operationId = created.operations?.[0]?.id || operation.id
+    const connection = await setSharePointConnection(created._id!)
+    mockSharePointOAuthTokenFetch(2)
+    mockSharePointSitesFetch(
+      [
+        {
+          id: "site-1",
+          displayName: "Current Site Name",
+          webUrl: "https://example.com/sites/current",
+        },
+      ],
+      2
+    )
+
+    await config.api.agent.connectSharePointSite(created._id!, operationId, {
+      ...connection,
+      site: {
+        id: "site-1",
+        name: "Stale Site Name",
+        webUrl: "https://example.com/sites/stale",
+      },
+    })
+
+    await config.doInContext(config.getDevWorkspaceId(), async () => {
+      const db = context.getWorkspaceDB()
+      const updated = await db.tryGet<Agent>(created._id!)
+      const source = updated?.operations
+        ?.find(operation => operation.id === operationId)
+        ?.knowledgeSources?.find(
+          source => source.type === AgentKnowledgeSourceType.SHAREPOINT
+        )
+
+      expect(source?.config.site).toEqual({
+        id: "site-1",
+        name: "Current Site Name",
+        webUrl: "https://example.com/sites/current",
+      })
+    })
+  })
+
+  it("rejects an empty SharePoint site id", async () => {
+    const created = await config.api.agent.createWithOperation(
+      {
+        name: "SharePoint Empty Site Agent",
+        aiconfig: "default",
+      },
+      operation
+    )
+    const operationId = created.operations?.[0]?.id || operation.id
+
+    await config.api.agent.connectSharePointSite(
+      created._id!,
+      operationId,
+      {
+        site: { id: "" },
+        datasourceId: "datasource-1",
+        authConfigId: "auth-1",
+      },
+      { status: 400 }
     )
   })
 

--- a/packages/server/src/api/routes/utils/validators/agent.ts
+++ b/packages/server/src/api/routes/utils/validators/agent.ts
@@ -255,7 +255,11 @@ export function syncAgentKnowledgeSourcesValidator() {
 export function connectAgentSharePointSiteValidator() {
   return auth.joiValidator.body(
     Joi.object({
-      siteId: NON_EMPTY_STRING.required(),
+      site: Joi.object({
+        id: NON_EMPTY_STRING.required(),
+        name: OPTIONAL_STRING,
+        webUrl: OPTIONAL_STRING,
+      }).required(),
       datasourceId: NON_EMPTY_STRING.required(),
       authConfigId: NON_EMPTY_STRING.required(),
       filters: Joi.array().items(NON_EMPTY_STRING).optional(),

--- a/packages/types/src/api/web/global/agents.ts
+++ b/packages/types/src/api/web/global/agents.ts
@@ -100,7 +100,7 @@ export interface SyncAgentKnowledgeSourcesResponse {
 }
 
 export interface ConnectAgentSharePointSiteRequest {
-  siteId: string
+  site: KnowledgeSourceOption
   datasourceId: string
   authConfigId: string
   filters?: string[]


### PR DESCRIPTION
## Description
Fixes SharePoint knowledge sources sometimes persisting without their site name or URL when the connect-time site listing omits the selected site. The selected site metadata is now submitted with the connection request and used as a fallback preventing the loading placeholder or raw SharePoint site ID from becoming the permanent display name.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents SharePoint knowledge sources from saving without a site name or URL by sending the selected site’s metadata with the connection request and using it as a fallback when the site listing is missing.

- **Bug Fixes**
  - Builder now submits a `site` object (id, name, webUrl) instead of `siteId`.
  - Server accepts `site`, prefers current listing data, and falls back to submitted metadata to avoid placeholder or raw ID names.
  - Validation and types updated; adds tests for fallback behavior and empty site id rejection.

- **Migration**
  - Update clients to send `site: { id: string, name?: string, webUrl?: string }` instead of `siteId`.

<sup>Written for commit 34a71a6abc75b02fd550fe6d42de670b06c6dba3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

