### PR TITLE
fix: dont attempt to ingest large sharepoint files

### DIFF
--- a/packages/server/src/sdk/workspace/ai/rag/sources/sharepoint/sharepoint.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/sources/sharepoint/sharepoint.spec.ts
@@ -298,6 +298,73 @@ describe("rag/sharepoint sync deduplication", () => {
       totalDiscovered: 1,
     })
   })
+
+  it("does not download or retry SharePoint files larger than 100MB", async () => {
+    const sourceId = "sharepoint_source_1"
+    const siteId = "site-1"
+    const oversizedFileSize = 100 * 1024 * 1024 + 1
+
+    mockAgentsGetOrThrow.mockResolvedValue(
+      makeSharePointAgent(sourceId, siteId)
+    )
+    mockKnowledgeBaseListFiles.mockResolvedValue([
+      makeSharePointFile({
+        id: "existing_failed",
+        sourceId,
+        siteId,
+        driveId: "drive-a",
+        itemId: "item-1",
+        path: "oversized.txt",
+        status: KnowledgeBaseFileStatus.FAILED,
+        remoteSize: oversizedFileSize,
+      }),
+    ])
+
+    const fetchMock = createFetchMock([
+      {
+        match: `/sites/${encodeURIComponent(siteId)}/drives`,
+        response: {
+          ok: true,
+          status: 200,
+          json: async () => ({ value: [{ id: "drive-a" }] }),
+        } as Response,
+      },
+      {
+        match: "/drives/drive-a/root/children",
+        response: {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            value: [
+              {
+                id: "item-1",
+                name: "oversized.txt",
+                size: oversizedFileSize,
+                file: { mimeType: "text/plain" },
+              },
+            ],
+          }),
+        } as Response,
+      },
+    ])
+
+    const result = await syncSharePointSourcesForAgent("agent_1", sourceId)
+
+    expect(
+      fetchMock.mock.calls.some(([input]) =>
+        input.toString().includes("/drives/drive-a/items/item-1/content")
+      )
+    ).toBe(false)
+    expect(mockRetryKnowledgeBaseFileIngestion).not.toHaveBeenCalled()
+    expect(mockKnowledgeBaseUploadFile).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      synced: 0,
+      failed: 0,
+      unsupported: 1,
+      totalDiscovered: 1,
+    })
+  })
+
   it("deletes existing files that no longer match source filters", async () => {
     const sourceId = "sharepoint_source_1"
     const siteId = "site-1"

--- a/packages/server/src/sdk/workspace/ai/rag/sources/sharepoint/sharepoint.ts
+++ b/packages/server/src/sdk/workspace/ai/rag/sources/sharepoint/sharepoint.ts
@@ -42,6 +42,9 @@ import {
 } from "../../files"
 import env from "../../../../../../environment"
 
+const BYTES_IN_MB = 1024 * 1024
+const MAX_SHAREPOINT_KNOWLEDGE_FILE_SIZE_BYTES = 100 * BYTES_IN_MB
+
 export interface SharePointSyncResult {
   agentId: string
   synced: number
@@ -246,6 +249,10 @@ const isSupportedSharePointFile = (file: {
     mimetype: file.mimetype,
   })
 }
+
+const isOversizedSharePointFile = (file: { remoteSize?: number }) =>
+  file.remoteSize !== undefined &&
+  file.remoteSize > MAX_SHAREPOINT_KNOWLEDGE_FILE_SIZE_BYTES
 
 const normalizeSourceFilters = (
   filters?: AgentKnowledgeSourceFilterConfig
@@ -670,6 +677,11 @@ const runSharePointSourcesForOperation = async (
           filteredOut++
           continue
         }
+        if (isOversizedSharePointFile(file)) {
+          skipped++
+          unsupported++
+          continue
+        }
         if (!isSupportedSharePointFile(file)) {
           skipped++
 
@@ -779,6 +791,12 @@ const runSharePointSourcesForOperation = async (
             file.itemId,
             signal
           )
+
+          if (buffer.byteLength > MAX_SHAREPOINT_KNOWLEDGE_FILE_SIZE_BYTES) {
+            skipped++
+            unsupported++
+            continue
+          }
 
           throwIfSyncAborted(signal)
           phase = "uploading_file"


### PR DESCRIPTION
## Description
Stop ingesting oversized SharePoint files by enforcing a 100MB limit. Skips these files without downloading or retrying, and counts them as unsupported.

Wasnt doing any harm per say, but it was meaning that syncs took longer than they needed to and wasted a bunch of cycles

- **Bug Fixes**
  - Added size checks before download and after fetch to block files >100MB.
  - Oversized files are skipped and marked as unsupported; no retry attempts.
  - Added a test to ensure we never request file content for oversized items.

<sup>Written for commit 233a1557b22a9aafdca1d3575ae445df50329fd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

