### PR TITLE
[BUDI-19203] Fix offline license activation and removal

### DIFF
--- a/packages/bbui/src/Form/Core/File.svelte
+++ b/packages/bbui/src/Form/Core/File.svelte
@@ -2,6 +2,7 @@
   import ActionButton from "../../ActionButton/ActionButton.svelte"
   import { uuid } from "../../helpers"
   import Icon from "../../Icon/Icon.svelte"
+  import ProgressCircle from "../../ProgressCircle/ProgressCircle.svelte"
   import { createEventDispatcher } from "svelte"
 
   const BYTES_IN_MB = 1000000
@@ -10,6 +11,8 @@
   export let statusText: string | undefined = undefined
   export let title: string = "Upload file"
   export let disabled: boolean = false
+  export let loading: boolean = false
+  export let hideButtonWhenSet: boolean = false
   export let allowClear: boolean | undefined = undefined
   export let extensions: string[] | undefined = undefined
   export let handleFileTooLarge: ((_file: File) => void) | undefined = undefined
@@ -39,6 +42,7 @@
   function handleFile(evt: Event) {
     const target = evt.target as HTMLInputElement
     processFile(target.files?.[0])
+    target.value = ""
   }
 
   function clearFile() {
@@ -48,7 +52,7 @@
 
 <input
   id={fieldId}
-  {disabled}
+  disabled={disabled || loading}
   type="file"
   accept={inputAccept}
   bind:this={fileInput}
@@ -58,7 +62,11 @@
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <div class="field">
-  {#if statusText}
+  {#if loading}
+    <div class="file-view">
+      <ProgressCircle size="S" />
+    </div>
+  {:else if statusText}
     <div class="file-view status" class:disabled>
       <div class="filename">{statusText}</div>
       {#if !disabled || (allowClear === true && disabled)}
@@ -89,9 +97,14 @@
       {/if}
     </div>
   {/if}
-  <ActionButton {disabled} on:click={() => fileInput?.click()}>
-    {title}
-  </ActionButton>
+  {#if !hideButtonWhenSet || !(loading || statusText || value)}
+    <ActionButton
+      disabled={disabled || loading}
+      on:click={() => fileInput?.click()}
+    >
+      {title}
+    </ActionButton>
+  {/if}
 </div>
 
 <style>

--- a/packages/bbui/src/Form/File.svelte
+++ b/packages/bbui/src/Form/File.svelte
@@ -7,6 +7,8 @@
   export let label: string | undefined = undefined
   export let labelPosition: LabelPosition = "above"
   export let disabled: boolean = false
+  export let loading: boolean = false
+  export let hideButtonWhenSet: boolean = false
   export let allowClear: boolean | undefined = undefined
   export let handleFileTooLarge: (_file: File) => void = () => {}
   export let previewUrl: string | undefined = undefined
@@ -20,7 +22,6 @@
 
   const dispatch = createEventDispatcher()
   const onChange = (e: CustomEvent) => {
-    value = e.detail
     dispatch("change", e.detail)
   }
 </script>
@@ -28,6 +29,8 @@
 <Field {helpText} {label} {labelPosition} {error} {tooltip}>
   <CoreFile
     {disabled}
+    {loading}
+    {hideButtonWhenSet}
     {allowClear}
     {title}
     {value}

--- a/packages/builder/src/settings/pages/upgrade.svelte
+++ b/packages/builder/src/settings/pages/upgrade.svelte
@@ -230,7 +230,6 @@
             value={offlineLicense}
             on:change={onOfflineLicenseChange}
             allowClear={true}
-            disabled={!!offlineLicense}
           />
         </div>
       </Layout>

--- a/packages/builder/src/settings/pages/upgrade.svelte
+++ b/packages/builder/src/settings/pages/upgrade.svelte
@@ -40,6 +40,7 @@
 
   let offlineLicenseIdentifier = ""
   let offlineLicense = undefined
+  let processingOfflineLicense = false
   const offlineLicenseExtensions = [".txt"]
 
   let installInfo
@@ -127,11 +128,13 @@
     try {
       await API.activateOfflineLicense(offlineLicenseToken)
       await auth.getSelf()
-      await getOfflineLicense()
       notifications.success("Successfully activated")
     } catch (e) {
       console.error(e)
-      notifications.error("Error activating offline license")
+      notifications.error(e?.message || "Error activating offline license")
+    } finally {
+      processingOfflineLicense = false
+      await getOfflineLicense()
     }
   }
 
@@ -139,26 +142,23 @@
     try {
       await API.deleteOfflineLicense()
       await auth.getSelf()
-      await getOfflineLicense()
       notifications.success("Successfully removed ofline license")
     } catch (e) {
       console.error(e)
       notifications.error("Error upload offline license")
+    } finally {
+      processingOfflineLicense = false
+      await getOfflineLicense()
     }
   }
 
   async function onOfflineLicenseChange(event) {
+    processingOfflineLicense = true
     if (event.detail) {
-      // prevent file preview jitter by assigning constant
-      // as soon as possible
-      offlineLicense = {
-        name: "license",
-      }
       const reader = new FileReader()
       reader.readAsText(event.detail)
       reader.onload = () => activateOfflineLicense(reader.result)
     } else {
-      offlineLicense = undefined
       await deleteOfflineLicense()
     }
   }
@@ -228,6 +228,8 @@
             title="Upload license"
             extensions={offlineLicenseExtensions}
             value={offlineLicense}
+            loading={processingOfflineLicense}
+            hideButtonWhenSet={true}
             on:change={onOfflineLicenseChange}
             allowClear={true}
           />

--- a/packages/pro/src/sdk/licensing/licenses/offline/offline.ts
+++ b/packages/pro/src/sdk/licensing/licenses/offline/offline.ts
@@ -10,13 +10,19 @@ import {
   OfflineLicense,
   Hosting,
 } from "@budibase/types"
-import { installation, events, context } from "@budibase/backend-core"
+import {
+  installation,
+  events,
+  context,
+  HTTPError,
+} from "@budibase/backend-core"
 import union from "lodash/union"
 import merge from "lodash/merge"
 
 // TOKEN
 
 export async function activateOfflineLicenseToken(offlineLicenseToken: string) {
+  await verifyOfflineLicenseToken(offlineLicenseToken)
   await db.licenseInfo.save({ offlineLicenseToken })
   await cache.refresh()
 }
@@ -91,13 +97,36 @@ export function enrichLicense(license: OfflineLicense) {
   return license
 }
 
+export async function verifyOfflineLicenseToken(
+  token: string
+): Promise<OfflineLicense> {
+  let license: OfflineLicense
+  try {
+    license = await signing.verifyLicenseToken(token)
+  } catch {
+    throw new HTTPError("Invalid offline license token", 400)
+  }
+
+  try {
+    verifyExpiry(license)
+  } catch {
+    throw new HTTPError("Offline license has expired", 400)
+  }
+
+  try {
+    await verifyInstallation(license)
+  } catch {
+    throw new HTTPError("Offline license does not match this installation", 400)
+  }
+
+  return license
+}
+
 export async function getOfflineLicense(): Promise<License | undefined> {
   try {
     const token = await getOfflineLicenseToken()
     if (token) {
-      const license = await signing.verifyLicenseToken(token)
-      verifyExpiry(license)
-      await verifyInstallation(license)
+      const license = await verifyOfflineLicenseToken(token)
       return enrichLicense(license)
     }
   } catch (e) {

--- a/packages/pro/src/sdk/licensing/licenses/offline/offline.ts
+++ b/packages/pro/src/sdk/licensing/licenses/offline/offline.ts
@@ -73,6 +73,8 @@ export function verifyExpiry(license: OfflineLicense) {
   }
 }
 
+export class OfflineLicenseMismatchError extends Error {}
+
 export async function verifyInstallation(license: OfflineLicense) {
   const identifier = await getIdentifier()
   if (
@@ -80,7 +82,7 @@ export async function verifyInstallation(license: OfflineLicense) {
     license.identifier.tenantId !== identifier.tenantId
   ) {
     // be intentionally vague
-    throw new Error("Invalid offline license")
+    throw new OfflineLicenseMismatchError("Invalid offline license")
   }
 }
 
@@ -115,8 +117,14 @@ export async function verifyOfflineLicenseToken(
 
   try {
     await verifyInstallation(license)
-  } catch {
-    throw new HTTPError("Offline license does not match this installation", 400)
+  } catch (e) {
+    if (e instanceof OfflineLicenseMismatchError) {
+      throw new HTTPError(
+        "Offline license does not match this installation",
+        400
+      )
+    }
+    throw e
   }
 
   return license

--- a/packages/pro/src/sdk/licensing/licenses/offline/offline.ts
+++ b/packages/pro/src/sdk/licensing/licenses/offline/offline.ts
@@ -68,7 +68,7 @@ export function getIdentifierFromBase64(
 export function verifyExpiry(license: OfflineLicense) {
   const now = Date.now()
   const expireAt = new Date(license.expireAt).getTime()
-  if (now > expireAt) {
+  if (!Number.isFinite(expireAt) || now > expireAt) {
     throw new Error(`Offline license has expired. expireAt=${license.expireAt}`)
   }
 }

--- a/packages/pro/src/sdk/licensing/licenses/offline/tests/offline.spec.ts
+++ b/packages/pro/src/sdk/licensing/licenses/offline/tests/offline.spec.ts
@@ -11,6 +11,7 @@ jest.mock("@budibase/backend-core", () => {
     __esModule: true, // Preserve the module structure
     ...mocked,
     Duration: actual.Duration,
+    HTTPError: actual.HTTPError,
   }
 })
 jest.mock("../../features")
@@ -71,13 +72,71 @@ describe("offline", () => {
   })
 
   describe("activateOfflineLicense", () => {
-    it("activates license", async () => {
-      const token = "token"
+    const token = "token"
+    const expiryOffsetMs = core.Duration.fromMinutes(1).toMs()
+
+    it("activates a valid license", async () => {
+      offlineLicense.expireAt = new Date(
+        Date.now() + expiryOffsetMs
+      ).toISOString()
+      signing.verifyLicenseToken.mockReturnValue(offlineLicense)
+      setupIdentifierMocks()
+
       await offline.activateOfflineLicenseToken(token)
+
       expect(db.licenseInfo.save).toHaveBeenCalledWith({
         offlineLicenseToken: token,
       })
       expect(cache.refresh).toHaveBeenCalledTimes(1)
+    })
+
+    it("rejects an invalid token without persisting it", async () => {
+      signing.verifyLicenseToken.mockImplementation(() => {
+        throw new Error("jwt malformed")
+      })
+
+      await expect(
+        offline.activateOfflineLicenseToken(token)
+      ).rejects.toMatchObject({
+        message: "Invalid offline license token",
+        status: 400,
+      })
+      expect(db.licenseInfo.save).not.toHaveBeenCalled()
+      expect(cache.refresh).not.toHaveBeenCalled()
+    })
+
+    it("rejects an expired token without persisting it", async () => {
+      offlineLicense.expireAt = new Date(
+        Date.now() - expiryOffsetMs
+      ).toISOString()
+      signing.verifyLicenseToken.mockReturnValue(offlineLicense)
+
+      await expect(
+        offline.activateOfflineLicenseToken(token)
+      ).rejects.toMatchObject({
+        message: "Offline license has expired",
+        status: 400,
+      })
+      expect(db.licenseInfo.save).not.toHaveBeenCalled()
+      expect(cache.refresh).not.toHaveBeenCalled()
+    })
+
+    it("rejects a token bound to a different installation without persisting it", async () => {
+      offlineLicense.expireAt = new Date(
+        Date.now() + expiryOffsetMs
+      ).toISOString()
+      offlineLicense.identifier.installId = generator.string()
+      signing.verifyLicenseToken.mockReturnValue(offlineLicense)
+      setupIdentifierMocks()
+
+      await expect(
+        offline.activateOfflineLicenseToken(token)
+      ).rejects.toMatchObject({
+        message: "Offline license does not match this installation",
+        status: 400,
+      })
+      expect(db.licenseInfo.save).not.toHaveBeenCalled()
+      expect(cache.refresh).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/pro/src/sdk/licensing/licenses/offline/tests/offline.spec.ts
+++ b/packages/pro/src/sdk/licensing/licenses/offline/tests/offline.spec.ts
@@ -138,6 +138,23 @@ describe("offline", () => {
       expect(db.licenseInfo.save).not.toHaveBeenCalled()
       expect(cache.refresh).not.toHaveBeenCalled()
     })
+
+    it("propagates operational errors from the installation lookup without persisting it", async () => {
+      offlineLicense.expireAt = new Date(
+        Date.now() + expiryOffsetMs
+      ).toISOString()
+      signing.verifyLicenseToken.mockReturnValue(offlineLicense)
+      installation.getInstall.mockRejectedValue(new Error("connection reset"))
+
+      await expect(offline.activateOfflineLicenseToken(token)).rejects.toThrow(
+        "connection reset"
+      )
+      await expect(
+        offline.activateOfflineLicenseToken(token)
+      ).rejects.not.toHaveProperty("status")
+      expect(db.licenseInfo.save).not.toHaveBeenCalled()
+      expect(cache.refresh).not.toHaveBeenCalled()
+    })
   })
 
   describe("deleteOfflineLicenseToken", () => {

--- a/packages/pro/src/sdk/licensing/licenses/offline/tests/offline.spec.ts
+++ b/packages/pro/src/sdk/licensing/licenses/offline/tests/offline.spec.ts
@@ -212,6 +212,14 @@ describe("offline", () => {
         new Error(`Offline license has expired. expireAt=${expireAt}`)
       )
     })
+
+    it("throws when expiry is not a valid date", () => {
+      const expireAt = "not-a-date"
+      offlineLicense.expireAt = expireAt
+      expect(() => offline.verifyExpiry(offlineLicense)).toThrow(
+        new Error(`Offline license has expired. expireAt=${expireAt}`)
+      )
+    })
   })
 
   describe("verifyInstallation", () => {


### PR DESCRIPTION
## Addresses
- https://github.com/Budibase/budibase/issues/19203

## Description
Fixes two related issues with offline Enterprise license handling:

1. **Activation was not verified.** `activateOfflineLicenseToken` persisted the uploaded token and refreshed the cache without checking the signature, expiry or installation match. If the token was invalid, the backend silently fell back to a Free license while the UI still showed a success notification. A new `verifyOfflineLicenseToken` helper now validates the token (signature, expiry, installation) before it is persisted, and returns a proper 400 error with a specific message otherwise.
2. **Removal was blocked.** The file input for the offline license was disabled once a license was attached, so clicking "clear" had no effect and the user couldn't remove/replace it. The `disabled` prop is no longer tied to the presence of a license.

Additionally, the upload UI now shows a loading state while the token is being verified, hides the upload button while a file is set, avoids clearing/reassigning the file input value incorrectly, and surfaces the backend error message in the failure notification instead of a generic one.

## Screen recording
https://github.com/user-attachments/assets/eb726dc3-80c1-4a2d-9567-4c9f2f1e011a

## Launchcontrol

Fixed a bug where an invalid offline Enterprise license would silently fall back to Free without warning the user, and fixed the inability to remove an already-uploaded offline license from the UI.