### PR TITLE
Fix many-to-many relationship logic that caused conflicts on updates

### DIFF
--- a/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
+++ b/packages/builder/src/components/backend/TableNavigator/modals/CreateTableModal.svelte
@@ -1,7 +1,7 @@
 <svelte:options runes={true} />
 
 <script lang="ts">
-  import { goto as gotoStore, url } from "@roxi/routify"
+  import { goto as gotoStore, url as urlStore } from "@roxi/routify"
   import {
     DataEnvironmentMode,
     FieldType,
@@ -20,7 +20,6 @@
     BUDIBASE_INTERNAL_DB_ID,
     BUDIBASE_DATASOURCE_TYPE,
   } from "@/constants/backend"
-  import { get } from "svelte/store"
   import { SvelteSet } from "svelte/reactivity"
 
   interface Props {
@@ -39,8 +38,6 @@
     afterSave = async (table: Table) => {
       notifications.success(`Table ${name} created successfully.`)
 
-      const getCurrentUrl = get(url) as () => string
-      const currentUrl = getCurrentUrl()
       const path = currentUrl.endsWith("data")
         ? `./table/${table._id}`
         : `../../table/${table._id}`
@@ -49,6 +46,7 @@
   }: Props = $props()
 
   const goto = $derived($gotoStore)
+  const currentUrl = $derived($urlStore())
   const tableNames = $derived($tables.list.map(table => table.name))
   const selectedSource = $derived(
     $datasources.list.find(source => source._id === $datasources.selected)

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -528,7 +528,6 @@ export class ExternalRequest<T extends Operation> {
         through: relationship.tableId,
       })
       const rows = related[relatedKey]?.rows || []
-      const junctionLinkFields = Object.keys(body)
 
       const relationshipMatchPredicate = ({
         row,
@@ -544,6 +543,7 @@ export class ExternalRequest<T extends Operation> {
         // Match junction rows using the relationship link columns being written
         // for this sync operation, rather than the order of the table primary key.
         if (relationshipType === RelationshipType.MANY_TO_MANY) {
+          const junctionLinkFields = Object.keys(body)
           return junctionLinkFields.every(
             field => String(row[field]) === String(body[field])
           )

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -28,7 +28,6 @@ import {
   ViewV2,
 } from "@budibase/types"
 import dayjs from "dayjs"
-import { isEqual, omit } from "lodash"
 import { cloneDeep } from "lodash/fp"
 import { isRelationshipColumn } from "../../../db/utils"
 import env from "../../../environment"
@@ -529,6 +528,7 @@ export class ExternalRequest<T extends Operation> {
         through: relationship.tableId,
       })
       const rows = related[relatedKey]?.rows || []
+      const manyToManyKeys = Object.keys(body)
 
       const relationshipMatchPredicate = ({
         row,
@@ -541,12 +541,12 @@ export class ExternalRequest<T extends Operation> {
         linkSecondary?: string
         relationshipType: RelationshipType
       }) => {
-        // In many-to-many relationships, the table will contain 3 fields: a
-        // primary key (usually an auto-incrementing ID), and then the 2 foreign
-        // keys that link to the two tables. So a row is equal if the 2
-        // non-primary keys match the body.
+        // Junction rows are identified by the linking columns we are writing,
+        // not by whichever column happens to come first in the table primary key.
         if (relationshipType === RelationshipType.MANY_TO_MANY) {
-          return isEqual(omit(row, [linkPrimary]), omit(body, [linkPrimary]))
+          return manyToManyKeys.every(
+            field => String(row[field]) === String(body[field])
+          )
         }
 
         const matchesPrimaryLink =

--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -528,7 +528,7 @@ export class ExternalRequest<T extends Operation> {
         through: relationship.tableId,
       })
       const rows = related[relatedKey]?.rows || []
-      const manyToManyKeys = Object.keys(body)
+      const junctionLinkFields = Object.keys(body)
 
       const relationshipMatchPredicate = ({
         row,
@@ -541,10 +541,10 @@ export class ExternalRequest<T extends Operation> {
         linkSecondary?: string
         relationshipType: RelationshipType
       }) => {
-        // Junction rows are identified by the linking columns we are writing,
-        // not by whichever column happens to come first in the table primary key.
+        // Match junction rows using the relationship link columns being written
+        // for this sync operation, rather than the order of the table primary key.
         if (relationshipType === RelationshipType.MANY_TO_MANY) {
-          return manyToManyKeys.every(
+          return junctionLinkFields.every(
             field => String(row[field]) === String(body[field])
           )
         }

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -3483,6 +3483,87 @@ if (descriptions.length) {
               relation: [table2_row1, table2_row2],
             })
           })
+
+          it("should not mismatch existing links when the junction primary key starts with the related row id", async () => {
+            const table1Id = "table1_" + generator.guid()
+            const table2Id = "table2_" + generator.guid()
+            const joinTableId = "table1_table2_" + generator.guid()
+
+            await client!.schema.createTable(table1Id, table => {
+              table.increments("table1_id").primary()
+              table.string("name")
+            })
+
+            await client!.schema.createTable(table2Id, table => {
+              table.increments("table2_id").primary()
+              table.string("name")
+            })
+
+            await client!.schema.createTable(joinTableId, table => {
+              if (isMariaDB || isMySQL) {
+                table.specificType("table2_id", "int(10) unsigned")
+                table.specificType("table1_id", "int(10) unsigned")
+              } else {
+                table.integer("table2_id")
+                table.integer("table1_id")
+              }
+              table.primary(["table2_id", "table1_id"])
+            })
+
+            const resp = await config.api.datasource.fetchSchema({
+              datasourceId: datasource!._id!,
+            })
+
+            const primaryOrderTable1 = resp.datasource.entities![table1Id]!
+            const primaryOrderTable2 = resp.datasource.entities![table2Id]!
+            const primaryOrderJoin = resp.datasource.entities![joinTableId]!
+
+            primaryOrderTable1.schema.relation = {
+              name: "relation",
+              type: FieldType.LINK,
+              tableId: primaryOrderTable2._id!,
+              relationshipType: RelationshipType.MANY_TO_MANY,
+              fieldName: "table2_id",
+              through: primaryOrderJoin._id!,
+              throughFrom: "table2_id",
+              throughTo: "table1_id",
+            }
+
+            await config.api.table.save(primaryOrderTable1)
+
+            const table2_row1 = await config.api.row.save(primaryOrderTable2._id!, {
+              name: "one",
+            })
+            const table2_row2 = await config.api.row.save(primaryOrderTable2._id!, {
+              name: "two",
+            })
+            const table2_row3 = await config.api.row.save(primaryOrderTable2._id!, {
+              name: "three",
+            })
+
+            const row = await config.api.row.save(primaryOrderTable1._id!, {
+              name: "foo",
+              relation: [table2_row1, table2_row3],
+            })
+
+            await config.api.row.save(primaryOrderTable1._id!, {
+              ...row,
+              relation: [table2_row1, table2_row2, table2_row3],
+            })
+
+            const updatedRow = await config.api.row.get(
+              primaryOrderTable1._id!,
+              row._id!
+            )
+            expect(updatedRow.relation).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({ _id: table2_row1._id }),
+                expect.objectContaining({ _id: table2_row2._id }),
+                expect.objectContaining({ _id: table2_row3._id }),
+              ])
+            )
+            expect(updatedRow.relation).toHaveLength(3)
+          })
         })
 
       // Upserting isn't yet supported in MSSQL or Oracle, see:

--- a/packages/server/src/api/routes/tests/row.spec.ts
+++ b/packages/server/src/api/routes/tests/row.spec.ts
@@ -3531,15 +3531,24 @@ if (descriptions.length) {
 
             await config.api.table.save(primaryOrderTable1)
 
-            const table2_row1 = await config.api.row.save(primaryOrderTable2._id!, {
-              name: "one",
-            })
-            const table2_row2 = await config.api.row.save(primaryOrderTable2._id!, {
-              name: "two",
-            })
-            const table2_row3 = await config.api.row.save(primaryOrderTable2._id!, {
-              name: "three",
-            })
+            const table2_row1 = await config.api.row.save(
+              primaryOrderTable2._id!,
+              {
+                name: "one",
+              }
+            )
+            const table2_row2 = await config.api.row.save(
+              primaryOrderTable2._id!,
+              {
+                name: "two",
+              }
+            )
+            const table2_row3 = await config.api.row.save(
+              primaryOrderTable2._id!,
+              {
+                name: "three",
+              }
+            )
 
             const row = await config.api.row.save(primaryOrderTable1._id!, {
               name: "foo",


### PR DESCRIPTION
## Description
Fixes a bug in SQL imported many-to-many updates where existing junction rows can be matched incorrectly during `handleManyRelationships`.

The issue happens when the junction table primary key ordering does not reflect the actual relationship identity, for example when the first primary key column is the related-row foreign key. The previous matcher compared many-to-many rows by omitting the first primary key column, which could make distinct relationships on the same main row look identical. That caused Budibase to treat the wrong existing link as already matched, then attempt to insert another existing link again, resulting in duplicate key errors.

This PR changes the matcher to compare the actual junction columns being written in the relationship body, rather than deriving identity from the first primary key column. It also adds a regression test covering the failing imported SQL scenario.

## Addresses
- https://github.com/Budibase/budibase/issues/18921
## App Export
It can be reproduced with the "default" Postgres

## Launchcontrol
Fix many-to-many relationship update conflicts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix many-to-many update matching for SQL datasources by matching junction rows using the link fields in the request body, preventing mismatched links and duplicate key errors. Addresses #18921.

- **Bug Fixes**
  - `packages/server`: Match many-to-many links by the body’s junction link columns (dynamic keys), not primary key order.
  - `packages/server`: Add a regression test for junction primary keys starting with the related row id to ensure existing links aren’t mismatched on update.
  - `packages/builder`: Fix Svelte context error in CreateTableModal by aliasing `url` to `urlStore`, deriving `currentUrl` via `$urlStore()`, and moving it to the correct reactive scope.

<sup>Written for commit a731cfc6c21f7124d8a875c4615382fff88d8f1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

