### PR TITLE
Security fix: limit pwa zip depth - size

### DIFF
--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -79,6 +79,55 @@ const PWA_ICON_PATTERNS = [
   /^ios\/(\d+)\.png$/i,
 ]
 
+const MAX_PWA_ZIP_FILE_COUNT = 100
+const MAX_PWA_ZIP_ENTRY_SIZE = 10 * 1024 * 1024 // 10MB per file
+const MAX_PWA_ZIP_TOTAL_SIZE = 50 * 1024 * 1024 // 50MB uncompressed total
+const MAX_PWA_ZIP_DEPTH = 10
+
+const validatePWAZipEntries = () => {
+  let fileCount = 0
+  let totalUncompressedSize = 0
+
+  return (entry: { fileName: string; uncompressedSize: number }) => {
+    // extract-zip skips these itself, so don't count them against the limits.
+    if (entry.fileName.startsWith("__MACOSX/")) {
+      return
+    }
+
+    const depth = entry.fileName.split("/").filter(Boolean).length
+    if (depth > MAX_PWA_ZIP_DEPTH) {
+      throw new BadRequestError(
+        `Invalid zip - directory depth exceeds ${MAX_PWA_ZIP_DEPTH}`
+      )
+    }
+
+    // Directory entries carry no content, only enforce the depth limit on them.
+    if (entry.fileName.endsWith("/")) {
+      return
+    }
+
+    fileCount++
+    if (fileCount > MAX_PWA_ZIP_FILE_COUNT) {
+      throw new BadRequestError(
+        `Invalid zip - too many files (max ${MAX_PWA_ZIP_FILE_COUNT})`
+      )
+    }
+
+    if (entry.uncompressedSize > MAX_PWA_ZIP_ENTRY_SIZE) {
+      throw new BadRequestError(
+        `Invalid zip - file "${entry.fileName}" exceeds the maximum size`
+      )
+    }
+
+    totalUncompressedSize += entry.uncompressedSize
+    if (totalUncompressedSize > MAX_PWA_ZIP_TOTAL_SIZE) {
+      throw new BadRequestError(
+        "Invalid zip - uncompressed contents exceed the maximum size"
+      )
+    }
+  }
+}
+
 const listFilesRecursively = async (directory: string): Promise<string[]> => {
   const entries = await fsp.readdir(directory, { withFileTypes: true })
   const files = await Promise.all(
@@ -287,7 +336,7 @@ export async function processPWAZip(ctx: UserCtx) {
   try {
     await fsp.mkdir(tempDir, { recursive: true })
 
-    await extract(filePath, { dir: tempDir })
+    await extract(filePath, { dir: tempDir, onEntry: validatePWAZipEntries() })
 
     const files = await listFilesRecursively(tempDir)
     const manifestPath = files.find(filePath => {
@@ -386,6 +435,8 @@ export async function processPWAZip(ctx: UserCtx) {
     const errorMessage =
       error instanceof Error ? error.message : "Unknown error"
     ctx.throw(500, `Error processing zip: ${errorMessage}`)
+  } finally {
+    await fsp.rm(tempDir, { recursive: true, force: true })
   }
 }
 

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -94,7 +94,9 @@ const validatePWAZipEntries = () => {
       return
     }
 
-    const depth = entry.fileName.split("/").filter(Boolean).length
+    const depth =
+      entry.fileName.split("/").filter(Boolean).length -
+      (entry.fileName.endsWith("/") ? 0 : 1)
     if (depth > MAX_PWA_ZIP_DEPTH) {
       throw new BadRequestError(
         `Invalid zip - directory depth exceeds ${MAX_PWA_ZIP_DEPTH}`

--- a/packages/server/src/api/controllers/static/index.ts
+++ b/packages/server/src/api/controllers/static/index.ts
@@ -334,7 +334,7 @@ export async function processPWAZip(ctx: UserCtx) {
     ctx.throw(400, "Invalid file - must be a zip file")
   }
 
-  const tempDir = join(tmpdir(), `pwa-${Date.now()}`)
+  const tempDir = await fsp.mkdtemp(join(tmpdir(), "pwa-"))
   try {
     await fsp.mkdir(tempDir, { recursive: true })
 

--- a/packages/server/src/api/routes/tests/static.spec.ts
+++ b/packages/server/src/api/routes/tests/static.spec.ts
@@ -382,7 +382,7 @@ describe("/static", () => {
 
         expect(firstResponse.status).toEqual(200)
         expect(secondResponse.status).toEqual(200)
-        expect(new Set(capturedDirs)).toHaveLength(2)
+        expect([...new Set(capturedDirs)]).toHaveLength(2)
       } finally {
         dateNowSpy.mockRestore()
       }

--- a/packages/server/src/api/routes/tests/static.spec.ts
+++ b/packages/server/src/api/routes/tests/static.spec.ts
@@ -340,6 +340,54 @@ describe("/static", () => {
       await fsp.rm(tempDir, { recursive: true, force: true })
     })
 
+    it("uses a unique temp directory for each concurrent request", async () => {
+      const capturedDirs: string[] = []
+      const dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(1000)
+
+      mockedExtract.mockImplementation(async (_zipPath: string, opts: any) => {
+        capturedDirs.push(opts.dir)
+        await fsp.mkdir(opts.dir, { recursive: true })
+        await fsp.writeFile(
+          path.join(opts.dir, "icons.json"),
+          JSON.stringify({
+            icons: [
+              {
+                src: "icon-192.png",
+                sizes: "192x192",
+                type: "image/png",
+              },
+            ],
+          })
+        )
+        await fsp.writeFile(
+          path.join(opts.dir, "icon-192.png"),
+          "fake-png-data"
+        )
+      })
+      mockedUpload.mockResolvedValue({
+        Key: "app_prod_test123/pwa/some-uuid.png",
+      } as any)
+
+      try {
+        const [firstResponse, secondResponse] = await Promise.all([
+          request
+            .post("/api/pwa/process-zip")
+            .attach("file", Buffer.from("fake-zip"), "icons.zip")
+            .set(config.defaultHeaders()),
+          request
+            .post("/api/pwa/process-zip")
+            .attach("file", Buffer.from("fake-zip"), "icons.zip")
+            .set(config.defaultHeaders()),
+        ])
+
+        expect(firstResponse.status).toEqual(200)
+        expect(secondResponse.status).toEqual(200)
+        expect(new Set(capturedDirs)).toHaveLength(2)
+      } finally {
+        dateNowSpy.mockRestore()
+      }
+    })
+
     describe("path traversal prevention", () => {
       it("skips icons whose src attempts to escape the zip directory via ../ traversal", async () => {
         const sensitiveDir = path.join(tmpdir(), `sensitive-${Date.now()}`)

--- a/packages/server/src/api/routes/tests/static.spec.ts
+++ b/packages/server/src/api/routes/tests/static.spec.ts
@@ -593,5 +593,163 @@ describe("/static", () => {
         }
       })
     })
+
+    describe("resource limits", () => {
+      const mockExtractWithEntries = (
+        entries: { fileName: string; uncompressedSize: number }[]
+      ) => {
+        mockedExtract.mockImplementation(
+          async (_zipPath: string, opts: any) => {
+            await fsp.mkdir(opts.dir, { recursive: true })
+            for (const entry of entries) {
+              opts.onEntry?.(entry, {})
+              if (!entry.fileName.endsWith("/")) {
+                const dest = path.join(opts.dir, entry.fileName)
+                await fsp.mkdir(path.dirname(dest), { recursive: true })
+                await fsp.writeFile(dest, "x")
+              }
+            }
+          }
+        )
+      }
+
+      it("rejects a zip containing too many files", async () => {
+        mockExtractWithEntries(
+          Array.from({ length: 101 }, (_, i) => ({
+            fileName: `icon-${i}.png`,
+            uncompressedSize: 100,
+          }))
+        )
+
+        const res = await request
+          .post("/api/pwa/process-zip")
+          .attach("file", Buffer.from("fake-zip"), "icons.zip")
+          .set(config.defaultHeaders())
+
+        expect(res.status).toEqual(400)
+        expect(res.body.message).toMatch("too many files")
+        expect(mockedUpload).not.toHaveBeenCalled()
+      })
+
+      it("rejects a zip with a single oversized file", async () => {
+        mockExtractWithEntries([
+          { fileName: "icon.png", uncompressedSize: 11 * 1024 * 1024 },
+        ])
+
+        const res = await request
+          .post("/api/pwa/process-zip")
+          .attach("file", Buffer.from("fake-zip"), "icons.zip")
+          .set(config.defaultHeaders())
+
+        expect(res.status).toEqual(400)
+        expect(res.body.message).toMatch('file "icon.png" exceeds')
+        expect(mockedUpload).not.toHaveBeenCalled()
+      })
+
+      it("rejects a zip whose total uncompressed size is too large", async () => {
+        mockExtractWithEntries(
+          Array.from({ length: 6 }, (_, i) => ({
+            fileName: `icon-${i}.png`,
+            uncompressedSize: 9 * 1024 * 1024,
+          }))
+        )
+
+        const res = await request
+          .post("/api/pwa/process-zip")
+          .attach("file", Buffer.from("fake-zip"), "icons.zip")
+          .set(config.defaultHeaders())
+
+        expect(res.status).toEqual(400)
+        expect(res.body.message).toMatch("uncompressed contents exceed")
+        expect(mockedUpload).not.toHaveBeenCalled()
+      })
+
+      it("rejects a zip that nests directories too deeply", async () => {
+        mockExtractWithEntries([
+          {
+            fileName: "a/b/c/d/e/f/g/h/i/j/k/icon.png",
+            uncompressedSize: 100,
+          },
+        ])
+
+        const res = await request
+          .post("/api/pwa/process-zip")
+          .attach("file", Buffer.from("fake-zip"), "icons.zip")
+          .set(config.defaultHeaders())
+
+        expect(res.status).toEqual(400)
+        expect(res.body.message).toMatch("directory depth exceeds")
+        expect(mockedUpload).not.toHaveBeenCalled()
+      })
+
+      it("does not count __MACOSX entries against the file limit", async () => {
+        const entries = [
+          ...Array.from({ length: 60 }, (_, i) => ({
+            fileName: `__MACOSX/icon-${i}.png`,
+            uncompressedSize: 100,
+          })),
+          { fileName: "icon-192.png", uncompressedSize: 100 },
+          {
+            fileName: "icons.json",
+            uncompressedSize: 100,
+          },
+        ]
+        mockedExtract.mockImplementation(
+          async (_zipPath: string, opts: any) => {
+            await fsp.mkdir(opts.dir, { recursive: true })
+            for (const entry of entries) {
+              opts.onEntry?.(entry, {})
+            }
+            await fsp.writeFile(
+              path.join(opts.dir, "icons.json"),
+              JSON.stringify({
+                icons: [
+                  { src: "icon-192.png", sizes: "192x192", type: "image/png" },
+                ],
+              })
+            )
+            await fsp.writeFile(
+              path.join(opts.dir, "icon-192.png"),
+              "fake-png-data"
+            )
+          }
+        )
+        mockedUpload.mockResolvedValue({
+          Key: "app_prod_test123/pwa/some-uuid.png",
+        } as any)
+
+        const res = await request
+          .post("/api/pwa/process-zip")
+          .attach("file", Buffer.from("fake-zip"), "icons.zip")
+          .set(config.defaultHeaders())
+          .expect(200)
+
+        expect(res.body.icons).toHaveLength(1)
+      })
+
+      it("removes the temporary extraction directory once finished", async () => {
+        const rmSpy = jest.spyOn(fsp, "rm")
+        try {
+          mockExtractWithEntries([
+            { fileName: "icon.png", uncompressedSize: 11 * 1024 * 1024 },
+          ])
+
+          await request
+            .post("/api/pwa/process-zip")
+            .attach("file", Buffer.from("fake-zip"), "icons.zip")
+            .set(config.defaultHeaders())
+
+          const cleanedTempDir = rmSpy.mock.calls.some(
+            ([target]) =>
+              typeof target === "string" &&
+              target.includes(`${path.sep}pwa-`) &&
+              !target.includes("pwa-test-")
+          )
+          expect(cleanedTempDir).toBe(true)
+        } finally {
+          rmSpy.mockRestore()
+        }
+      })
+    })
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds strict validation to PWA ZIP uploads to block oversized, deeply nested, or excessive files, uses a unique temp directory per concurrent request, and always cleans up after extraction.

- **Bug Fixes**
  - Enforce limits during `extract-zip` onEntry: max 100 files, 10MB/file, 50MB total uncompressed, max directory depth 10; ignore `__MACOSX/`.
  - Use unique temp directory per request via `fs.mkdtemp`; always remove it after processing.
  - Return 400 with clear messages when a limit is hit; tests cover concurrency, limits, `__MACOSX` handling, and cleanup.

<sup>Written for commit bc534582255498f2b3dd1ec6d0d1c9b70e20b0fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

