### PR TITLE
feat: show pop up if your sharepoint connection is not configured correctly

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/index.svelte
@@ -99,6 +99,9 @@
         connection.sourceType === AgentKnowledgeSourceType.SHAREPOINT
     )
   )
+  let hasSharePointDatasource = $derived(
+    $knowledgeConnectionsStore.sharePointDatasourceIds.length > 0
+  )
   let selectedSiteIds = $derived.by(() =>
     sharePointSources
       .map(source => source.config.site.id)
@@ -178,6 +181,10 @@
 
   async function openSharePointFlow() {
     if (!hasSharePointConnection) {
+      if (hasSharePointDatasource) {
+        await selectSharePointSiteModal?.show()
+        return
+      }
       bb.settings("/connections/apis/new/microsoft-sharepoint")
       return
     }

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/new/SelectSharePointSiteModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/new/SelectSharePointSiteModal.svelte
@@ -2,6 +2,7 @@
   import { notifications } from "@budibase/bbui"
   import { type KnowledgeSourceOption } from "@budibase/types"
   import { workspaceDeploymentStore } from "@/stores/builder"
+  import { bb } from "@/stores/bb"
   import { agentsStore, knowledgeConnectionsStore } from "@/stores/portal"
   import type { SharePointSelectionMode } from "../renderers/types"
   import { EXCLUDE_ALL_PATTERN } from "../sharepoint/sharePointModalUtils"
@@ -182,6 +183,13 @@
   options={sharePointConnectionOptions}
   {selectedConnectionId}
   {loadingNextStep}
+  hasSharePointDatasource={$knowledgeConnectionsStore.sharePointDatasourceIds
+    .length > 0}
+  onConfigure={() => {
+    hide()
+    const datasourceId = $knowledgeConnectionsStore.sharePointDatasourceIds[0]
+    bb.settings(`/connections/apis/${datasourceId}`)
+  }}
   onConnectionChange={connectionId => {
     selectedConnectionId = connectionId
     const full = $knowledgeConnectionsStore.connections.find(

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/new/SharePointConnectionStepModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/knowledge/new/SharePointConnectionStepModal.svelte
@@ -18,7 +18,9 @@
     options: SharePointConnectionOption[]
     selectedConnectionId: string
     loadingNextStep?: boolean
+    hasSharePointDatasource?: boolean
     onNext: () => Promise<void> | void
+    onConfigure: () => Promise<void> | void
     onConnectionChange: (_connectionId: string) => void
   }
 
@@ -26,7 +28,9 @@
     options,
     selectedConnectionId,
     loadingNextStep = false,
+    hasSharePointDatasource = false,
     onNext,
+    onConfigure,
     onConnectionChange,
   }: Props = $props()
 
@@ -54,7 +58,15 @@
       </div>
 
       {#if options.length === 0}
-        <Body size="S">No SharePoint OAuth2 auth configs found.</Body>
+        {#if hasSharePointDatasource}
+          <Body size="S">
+            Your SharePoint connection cannot be used for Agent Knowledge
+            because it does not have an OAuth2 client credentials auth config.
+            Add one to continue.
+          </Body>
+        {:else}
+          <Body size="S">No SharePoint connections found.</Body>
+        {/if}
       {:else}
         <Select
           value={selectedConnectionId}
@@ -69,14 +81,18 @@
     </div>
 
     <ButtonGroup slot="footer">
-      <Button
-        cta
-        primary
-        on:click={onNext}
-        disabled={!selectedConnectionId || loadingNextStep}
-      >
-        {loadingNextStep ? "Loading..." : "Next"}
-      </Button>
+      {#if options.length === 0 && hasSharePointDatasource}
+        <Button cta primary on:click={onConfigure}>Configure connection</Button>
+      {:else}
+        <Button
+          cta
+          primary
+          on:click={onNext}
+          disabled={!selectedConnectionId || loadingNextStep}
+        >
+          {loadingNextStep ? "Loading..." : "Next"}
+        </Button>
+      {/if}
     </ButtonGroup>
   </ModalContent>
 </Modal>

--- a/packages/builder/src/stores/portal/knowledgeConnections.spec.ts
+++ b/packages/builder/src/stores/portal/knowledgeConnections.spec.ts
@@ -8,12 +8,28 @@ import {
 } from "@budibase/types"
 import { deriveKnowledgeConnections } from "./knowledgeConnectionsUtils"
 
-const sharePointDatasource = (authConfigs: RestAuthConfig[]): Datasource => ({
+const sharePointDatasource = (
+  authConfigs: RestAuthConfig[],
+  template: Pick<Datasource, "restTemplate" | "restTemplateId"> = {
+    restTemplateId: "microsoft-sharepoint",
+  }
+): Datasource => ({
   _id: "datasource_1",
   type: "datasource",
   source: SourceName.REST,
-  restTemplateId: "microsoft-sharepoint",
+  ...template,
   config: { authConfigs },
+})
+
+const clientCredentialsAuthConfig = (): RestAuthConfig => ({
+  _id: "auth_1",
+  name: "Agent Knowledge",
+  type: RestAuthType.OAUTH2,
+  url: "https://login.microsoftonline.com/tenant/oauth2/v2.0/token",
+  clientId: "client-id",
+  clientSecret: "client-secret",
+  method: OAuth2CredentialsMethod.BODY,
+  grantType: OAuth2GrantType.CLIENT_CREDENTIALS,
 })
 
 describe("deriveKnowledgeConnections", () => {
@@ -35,18 +51,7 @@ describe("deriveKnowledgeConnections", () => {
 
   it("returns OAuth2 client credentials as compatible connections", () => {
     const result = deriveKnowledgeConnections([
-      sharePointDatasource([
-        {
-          _id: "auth_1",
-          name: "Agent Knowledge",
-          type: RestAuthType.OAUTH2,
-          url: "https://login.microsoftonline.com/tenant/oauth2/v2.0/token",
-          clientId: "client-id",
-          clientSecret: "client-secret",
-          method: OAuth2CredentialsMethod.BODY,
-          grantType: OAuth2GrantType.CLIENT_CREDENTIALS,
-        },
-      ]),
+      sharePointDatasource([clientCredentialsAuthConfig()]),
     ])
 
     expect(result.connections).toEqual([
@@ -55,5 +60,28 @@ describe("deriveKnowledgeConnections", () => {
         authConfigId: "auth_1",
       }),
     ])
+  })
+
+  it.each([
+    {
+      name: "legacy template name",
+      template: { restTemplate: "SharePoint Sites" },
+    },
+    {
+      name: "legacy child template ID",
+      template: { restTemplateId: "microsoft-sharepoint-sites" as const },
+    },
+  ])("supports a $name", ({ template }) => {
+    const result = deriveKnowledgeConnections([
+      sharePointDatasource([clientCredentialsAuthConfig()], template),
+    ])
+
+    expect(result.connections).toEqual([
+      expect.objectContaining({
+        datasourceId: "datasource_1",
+        authConfigId: "auth_1",
+      }),
+    ])
+    expect(result.sharePointDatasourceIds).toEqual(["datasource_1"])
   })
 })

--- a/packages/builder/src/stores/portal/knowledgeConnections.spec.ts
+++ b/packages/builder/src/stores/portal/knowledgeConnections.spec.ts
@@ -1,0 +1,59 @@
+import {
+  OAuth2CredentialsMethod,
+  OAuth2GrantType,
+  RestAuthType,
+  SourceName,
+  type Datasource,
+  type RestAuthConfig,
+} from "@budibase/types"
+import { deriveKnowledgeConnections } from "./knowledgeConnectionsUtils"
+
+const sharePointDatasource = (authConfigs: RestAuthConfig[]): Datasource => ({
+  _id: "datasource_1",
+  type: "datasource",
+  source: SourceName.REST,
+  restTemplateId: "microsoft-sharepoint",
+  config: { authConfigs },
+})
+
+describe("deriveKnowledgeConnections", () => {
+  it("distinguishes a SharePoint datasource with Basic Auth from no datasource", () => {
+    const result = deriveKnowledgeConnections([
+      sharePointDatasource([
+        {
+          _id: "auth_1",
+          name: "Basic Auth",
+          type: RestAuthType.BASIC,
+          config: { username: "user", password: "password" },
+        },
+      ]),
+    ])
+
+    expect(result.connections).toEqual([])
+    expect(result.sharePointDatasourceIds).toEqual(["datasource_1"])
+  })
+
+  it("returns OAuth2 client credentials as compatible connections", () => {
+    const result = deriveKnowledgeConnections([
+      sharePointDatasource([
+        {
+          _id: "auth_1",
+          name: "Agent Knowledge",
+          type: RestAuthType.OAUTH2,
+          url: "https://login.microsoftonline.com/tenant/oauth2/v2.0/token",
+          clientId: "client-id",
+          clientSecret: "client-secret",
+          method: OAuth2CredentialsMethod.BODY,
+          grantType: OAuth2GrantType.CLIENT_CREDENTIALS,
+        },
+      ]),
+    ])
+
+    expect(result.connections).toEqual([
+      expect.objectContaining({
+        datasourceId: "datasource_1",
+        authConfigId: "auth_1",
+      }),
+    ])
+  })
+})

--- a/packages/builder/src/stores/portal/knowledgeConnections.ts
+++ b/packages/builder/src/stores/portal/knowledgeConnections.ts
@@ -1,25 +1,11 @@
+import type { Datasource } from "@budibase/types"
+import { derived, type Writable } from "svelte/store"
 import { DerivedBudiStore } from "../BudiStore"
+import { datasources } from "../builder/datasources"
 import {
-  Datasource,
-  OAuth2RestAuthConfig,
-  isOAuth2ClientCredentialsAuthConfig,
-} from "@budibase/types"
-import { derived, Writable } from "svelte/store"
-import { datasources, getRestTemplateIdentifier } from "../builder/datasources"
-
-interface KnowledgeConnection {
-  _id: string
-  datasourceId: string
-  authConfigId: string
-  sourceType: "sharepoint"
-  authType: "client_credentials"
-  datasourceName: string
-  authConfigName: string
-}
-
-interface KnowledgeConnectionsState {
-  connections: KnowledgeConnection[]
-}
+  deriveKnowledgeConnections,
+  type KnowledgeConnectionsState,
+} from "./knowledgeConnectionsUtils"
 
 class KnowledgeConnectionsStore extends DerivedBudiStore<
   KnowledgeConnectionsState,
@@ -29,30 +15,10 @@ class KnowledgeConnectionsStore extends DerivedBudiStore<
     const makeDerivedStore = (_store: Writable<KnowledgeConnectionsState>) =>
       derived([datasources], ([$datasources]) => {
         const list = $datasources.rawList as Datasource[]
-        const connections = list.flatMap(datasource => {
-          if (
-            getRestTemplateIdentifier(datasource) !== "microsoft-sharepoint"
-          ) {
-            return []
-          }
-          const authConfigs = (datasource.config?.authConfigs ||
-            []) as OAuth2RestAuthConfig[]
-          return authConfigs
-            .filter(config => isOAuth2ClientCredentialsAuthConfig(config))
-            .map(config => ({
-              _id: `${datasource._id}:${config._id}`,
-              datasourceId: datasource._id!,
-              authConfigId: config._id,
-              sourceType: "sharepoint" as const,
-              authType: "client_credentials" as const,
-              datasourceName: datasource.name || "Datasource",
-              authConfigName: config.name || "OAuth2 config",
-            }))
-        })
-        return { connections }
+        return deriveKnowledgeConnections(list)
       })
 
-    super({ connections: [] }, makeDerivedStore)
+    super({ connections: [], sharePointDatasourceIds: [] }, makeDerivedStore)
   }
 }
 

--- a/packages/builder/src/stores/portal/knowledgeConnectionsUtils.ts
+++ b/packages/builder/src/stores/portal/knowledgeConnectionsUtils.ts
@@ -1,0 +1,52 @@
+import {
+  type Datasource,
+  type RestAuthConfig,
+  isOAuth2ClientCredentialsAuthConfig,
+} from "@budibase/types"
+
+export interface KnowledgeConnection {
+  _id: string
+  datasourceId: string
+  authConfigId: string
+  sourceType: "sharepoint"
+  authType: "client_credentials"
+  datasourceName: string
+  authConfigName: string
+}
+
+export interface KnowledgeConnectionsState {
+  connections: KnowledgeConnection[]
+  sharePointDatasourceIds: string[]
+}
+
+export const deriveKnowledgeConnections = (
+  list: Datasource[]
+): KnowledgeConnectionsState => {
+  const sharePointDatasources = list.filter(
+    datasource =>
+      (datasource.restTemplateId || datasource.restTemplate) ===
+      "microsoft-sharepoint"
+  )
+  const connections = sharePointDatasources.flatMap(datasource => {
+    const authConfigs = (datasource.config?.authConfigs ||
+      []) as RestAuthConfig[]
+    return authConfigs
+      .filter(config => isOAuth2ClientCredentialsAuthConfig(config))
+      .map(config => ({
+        _id: `${datasource._id}:${config._id}`,
+        datasourceId: datasource._id!,
+        authConfigId: config._id,
+        sourceType: "sharepoint" as const,
+        authType: "client_credentials" as const,
+        datasourceName: datasource.name || "Datasource",
+        authConfigName: config.name || "OAuth2 config",
+      }))
+  })
+
+  return {
+    connections,
+    sharePointDatasourceIds: sharePointDatasources.flatMap(datasource =>
+      datasource._id ? [datasource._id] : []
+    ),
+  }
+}

--- a/packages/builder/src/stores/portal/knowledgeConnectionsUtils.ts
+++ b/packages/builder/src/stores/portal/knowledgeConnectionsUtils.ts
@@ -4,6 +4,19 @@ import {
   isOAuth2ClientCredentialsAuthConfig,
 } from "@budibase/types"
 
+import { restTemplates } from "@/stores/builder/restTemplates"
+
+const SHAREPOINT_TEMPLATE_ID = "microsoft-sharepoint"
+
+const isSharePointDatasource = (datasource: Datasource) => {
+  const templateRef = datasource.restTemplateId || datasource.restTemplate
+  const templateId = restTemplates.get(templateRef)?.id
+
+  return templateId
+    ? restTemplates.getById(templateId)?.id === SHAREPOINT_TEMPLATE_ID
+    : false
+}
+
 export interface KnowledgeConnection {
   _id: string
   datasourceId: string
@@ -22,11 +35,7 @@ export interface KnowledgeConnectionsState {
 export const deriveKnowledgeConnections = (
   list: Datasource[]
 ): KnowledgeConnectionsState => {
-  const sharePointDatasources = list.filter(
-    datasource =>
-      (datasource.restTemplateId || datasource.restTemplate) ===
-      "microsoft-sharepoint"
-  )
+  const sharePointDatasources = list.filter(isSharePointDatasource)
   const connections = sharePointDatasources.flatMap(datasource => {
     const authConfigs = (datasource.config?.authConfigs ||
       []) as RestAuthConfig[]


### PR DESCRIPTION
## Description
Shows a prompt when a SharePoint datasource exists but isn’t configured for Agent Knowledge (missing OAuth2 client credentials). The modal explains the issue and lets users jump to configure the existing connection instead of creating a new one.

- **New Features**
  - Detects SharePoint datasources without a compatible OAuth2 config and shows a “Configure connection” action that links to the datasource’s settings.
  - If no compatible connection exists but a datasource does, the SharePoint flow opens the selection modal instead of redirecting to create a new connection.

- **Refactors**
  - Extracted connection derivation to a new `knowledgeConnectionsUtils` with `deriveKnowledgeConnections`, now used by `knowledgeConnectionsStore`.
  - Added unit tests to validate detection of SharePoint datasources and compatible OAuth2 client-credentials configs.

## Screenshots

https://github.com/user-attachments/assets/551adc74-a0db-4267-8616-d8398087424a

## Launchcontrol

adds a hint if your sharepoint config is not suitable for the knowledgebase



<!-- This is an auto-generated description by cubic. -->

<sup>Written for commit 679ce6588eafeacbffefa42d485e01b2805e58ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



