### PR TITLE
fix: dont forever sync legacy sharepoint

### DIFF
--- a/packages/builder/src/stores/portal/agents.spec.ts
+++ b/packages/builder/src/stores/portal/agents.spec.ts
@@ -239,6 +239,32 @@ describe("agentsStore sharepoint and file syncing", () => {
 
     expect(fetchAgentKnowledge).toHaveBeenCalledWith("agent_1")
   })
+
+  it("does not poll when a SharePoint source has no sync state", async () => {
+    vi.useFakeTimers()
+    fetchAgentKnowledge.mockResolvedValue({
+      operations: {
+        operation_1: {
+          files: [],
+          sharePointSources: [
+            {
+              sourceId: "source-1",
+              syncedCount: 0,
+              failedCount: 0,
+              processingCount: 0,
+              totalCount: 0,
+            },
+          ],
+        },
+      },
+    })
+
+    await store.fetchAgentKnowledge("agent_1")
+    fetchAgentKnowledge.mockClear()
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(fetchAgentKnowledge).not.toHaveBeenCalled()
+  })
 })
 
 describe("AgentsStore file operations", () => {

--- a/packages/builder/src/stores/portal/agents.ts
+++ b/packages/builder/src/stores/portal/agents.ts
@@ -177,19 +177,12 @@ export class AgentsStore extends BudiStore<AgentStoreState> {
         const hasProcessingFiles = knowledge.files.some(
           file => file.status === KnowledgeBaseFileStatus.PROCESSING
         )
-        const hasUnsyncedSharePointSites = knowledge.sharePointSources.some(
-          source => !source.lastRunAt
-        )
         const hasActiveSharePointSync = knowledge.sharePointSources.some(
           source =>
             source.runStatus === AgentKnowledgeSourceSyncRunStatus.QUEUED ||
             source.runStatus === AgentKnowledgeSourceSyncRunStatus.RUNNING
         )
-        return (
-          hasProcessingFiles ||
-          hasUnsyncedSharePointSites ||
-          hasActiveSharePointSync
-        )
+        return hasProcessingFiles || hasActiveSharePointSync
       })
 
     this.knowledgePolling.setContinuous(agentId, needsPolling)


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop infinite polling for legacy SharePoint sources that have no sync state. Polling now runs only when files are processing or a SharePoint sync is queued/running.

- **Bug Fixes**
  - Removed the “unsynced SharePoint sites” check from `agents` polling logic; now only polls for processing files or active SharePoint sync.
  - Added a test to ensure no polling occurs when a SharePoint source has no sync state.

<sup>Written for commit 7dead7ecbdd0f65b1f186f6b9c12bbdfdbf9af4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

note: this kinda autofixes too as daily syncs will update things, but the FE polling was greedy so I've fixed that while i was there

