### PR TITLE
Fix: allow multiple escalations on a resumed AgentRequest

### DIFF
--- a/packages/server/src/ai/tools/budibase/escalate.ts
+++ b/packages/server/src/ai/tools/budibase/escalate.ts
@@ -135,22 +135,3 @@ export const createEscalatePlaceholderTool = (): AiToolDefinition => ({
     }),
   }),
 })
-
-// Used on resume, where the escalation has already been approved. If the model
-// follows its instructions and calls escalate again, it gets the approval
-// in-band instead of a missing tool or a fresh escalation.
-export const createResolvedEscalateTool = () =>
-  tool({
-    description: "Escalate to a human for approval.",
-    inputSchema: z.object({
-      title: z.string(),
-      summary: z.string(),
-      reason: z.string(),
-    }),
-    execute: async () => ({
-      status: EscalateToolResultStatus.ALREADY_APPROVED,
-      note:
-        "This request has already been reviewed and APPROVED by a human " +
-        "reviewer. Do not escalate again - proceed to fulfil it.",
-    }),
-  })

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -2,7 +2,10 @@ import { context } from "@budibase/backend-core"
 import {
   Agent,
   DocumentType,
+  ESCALATE_TOOL_NAME,
   EscalationContextDoc,
+  EscalationNotificationChannel,
+  EscalationRaisedAction,
   EscalationSource,
   SEPARATOR,
   SuspendedOperationContext,
@@ -10,6 +13,7 @@ import {
 import TestConfiguration from "../tests/utilities/TestConfiguration"
 import sdk from "../sdk"
 import { resumeOperation } from "./queue"
+import { createEscalateTool } from "../ai/tools/budibase"
 
 jest.mock("../sdk/workspace/ai/agents", () => {
   const actual = jest.requireActual("../sdk/workspace/ai/agents")
@@ -266,6 +270,101 @@ describe("resumeOperation", () => {
       expect(
         (request.actions ?? []).filter(a => a.type === "escalation_resolved")
       ).toEqual([])
+    })
+  })
+
+  it("raises and tracks a second, genuinely new escalation created during the resumed run", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const { requestId } = (await createRequest())!
+
+      const secondEscalationInput = {
+        title: "New procurement request",
+        summary: "Buy 500 more pens for the new starters",
+        reason: "Spend exceeds the approved budget",
+      }
+
+      prepareAgentChatRunMock.mockImplementation(async ({ getRequestId }) => ({
+        toolDisplayNames: {},
+        sessionLogIndexer: { index: jest.fn().mockResolvedValue(undefined) },
+        stream: jest
+          .fn()
+          .mockImplementation(async ({ onToolCalls, onToolCallCompleted }) => {
+            const escalateTool = createEscalateTool({
+              agentId: "agent_1",
+              operationId: "op_1",
+              sessionId: "session_1",
+              recipients: [
+                {
+                  type: EscalationNotificationChannel.SLACK,
+                  config: { channelId: "C1" },
+                },
+              ],
+              delayMs: 1000,
+              getMessages: () => [],
+              getRequestId,
+            })
+
+            if (!escalateTool.execute) {
+              throw new Error("escalate tool has no execute function")
+            }
+            const output = await escalateTool.execute(secondEscalationInput, {
+              toolCallId: "tc_second_escalation",
+              messages: [],
+            })
+
+            onToolCalls?.([ESCALATE_TOOL_NAME])
+            await onToolCallCompleted?.({
+              toolName: ESCALATE_TOOL_NAME,
+              status: "success",
+              input: secondEscalationInput,
+              output,
+            })
+
+            return {
+              finishReason: Promise.resolve("stop"),
+              toUIMessageStream: () =>
+                (async function* () {
+                  yield {
+                    id: "",
+                    role: "assistant",
+                    parts: [
+                      {
+                        type: "text",
+                        text: "Escalated the new request for approval.",
+                      },
+                    ],
+                  }
+                })(),
+            }
+          }),
+      }))
+      getOrThrowMock.mockResolvedValue({ _id: "agent_1" } as Agent)
+
+      await resumeOperation({
+        doc: baseDoc({ requestId, response: { accepted: true } }),
+        escalationId: "esc_primary",
+        resolution: "resolved",
+        ctx: baseCtx,
+      })
+
+      const [request] =
+        await sdk.ai.agentRequests.fetchRequestsByAgent("agent_1")
+
+      const raisedActions = (request.actions ?? []).filter(
+        (a): a is EscalationRaisedAction => a.type === "escalation_raised"
+      )
+      expect(raisedActions).toHaveLength(1)
+      const [raisedAction] = raisedActions
+      expect(raisedAction.escalationId).not.toEqual("esc_primary")
+
+      const newEscalationDoc = await sdk.escalations.getContextDoc(
+        raisedAction.escalationId
+      )
+      expect(newEscalationDoc?.requestId).toEqual(requestId)
+      expect(newEscalationDoc?.resolution).toEqual("pending")
+
+      // The new escalation is still pending, so the request must not close.
+      expect(request.status).toEqual("needs_input")
     })
   })
 })

--- a/packages/server/src/escalation/queue.spec.ts
+++ b/packages/server/src/escalation/queue.spec.ts
@@ -128,6 +128,23 @@ describe("resumeOperation", () => {
     })
   })
 
+  it("passes getRequestId resolving to the escalation's request id", async () => {
+    await config.doInContext(config.getProdWorkspaceId(), async () => {
+      const { requestId } = (await createRequest())!
+      mockApprovedRun("Approved and booked.")
+
+      await resumeOperation({
+        doc: baseDoc({ requestId, response: { accepted: true } }),
+        escalationId: "esc_primary",
+        resolution: "resolved",
+        ctx: baseCtx,
+      })
+
+      const { getRequestId } = prepareAgentChatRunMock.mock.calls[0][0]
+      expect(getRequestId()).toEqual(requestId)
+    })
+  })
+
   it("records escalation_resolved with outcome rejected", async () => {
     await config.doInContext(config.getProdWorkspaceId(), async () => {
       const { requestId } = (await createRequest())!

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -415,7 +415,6 @@ export async function resumeOperation({
     sessionId: ctx.sessionId,
     user,
     operationId: ctx.operationId,
-    escalationResolved: true,
     additionalInstructions: approvalInstructions,
     getRequestId: () => doc.requestId,
   })

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -7,6 +7,7 @@ import {
   AutomationActionStepId,
   ContextUser,
   DocumentType,
+  ESCALATE_TOOL_NAME,
   EscalationContextDoc,
   EscalationNotificationDoc,
   EscalationRecipient,
@@ -436,6 +437,19 @@ export async function resumeOperation({
     const result = await run.stream({
       pendingToolCalls,
       unrecoveredToolFailures,
+      onToolCalls: toolNames => {
+        const requestId = doc.requestId
+        if (requestId && toolNames.includes(ESCALATE_TOOL_NAME)) {
+          sdk.ai.agentRequests
+            .updateRequestStatus({ requestId, status: "needs_input" })
+            .catch(error => {
+              console.error(
+                "Failed to update agent request status to needs_input",
+                { escalationId, agentId: ctx.agentId, error }
+              )
+            })
+        }
+      },
       onToolCallCompleted: ({ toolName, status, input, output }) => {
         const requestId = doc.requestId
         if (!requestId) {

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -417,6 +417,7 @@ export async function resumeOperation({
     operationId: ctx.operationId,
     escalationResolved: true,
     additionalInstructions: approvalInstructions,
+    getRequestId: () => doc.requestId,
   })
 
   const pendingToolCalls = new Set<string>()

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -339,14 +339,16 @@ export async function resumeOperation({
   // approval as user input.
   const approvalInstructions =
     "ESCALATION APPROVAL: The user's request in this conversation has been " +
-    "reviewed and APPROVED by an authorised human reviewer. Approval is already " +
-    "granted - do NOT escalate or ask for approval again. Begin your reply by " +
-    "briefly confirming the request was approved, then CARRY OUT the user's " +
-    "original request: take the action they asked for using " +
-    "your available tools. Actually attempt it. If you cannot complete it because " +
-    "a required tool or capability is missing, say specifically what is missing " +
-    "and that the request could not be completed - never imply it was done when " +
-    "it was not."
+    "reviewed and APPROVED by an authorised human reviewer. This specific " +
+    "request is already approved - do not escalate or ask for approval again " +
+    "for it. Begin your reply by briefly confirming the request was approved, " +
+    "then CARRY OUT the user's original request: take the action they asked " +
+    "for using your available tools. Actually attempt it. If you cannot " +
+    "complete it because a required tool or capability is missing, say " +
+    "specifically what is missing and that the request could not be " +
+    "completed - never imply it was done when it was not. If doing so " +
+    "surfaces a genuinely new request that needs its own human sign-off, you " +
+    "may escalate that separately."
 
   const resumeUserId = ctx.userId ?? "escalation-resume"
 
@@ -399,7 +401,9 @@ export async function resumeOperation({
               decision: "approved",
               note:
                 "An authorised human reviewer approved this request. Proceed " +
-                "to fulfil it and confirm to the user. Do not escalate again.",
+                "to fulfil it and confirm to the user. Do not escalate this " +
+                "same request again - a genuinely new, different request " +
+                "can still be escalated separately.",
             },
           },
         },

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -338,18 +338,17 @@ export async function resumeOperation({
 
   // System prompt, not a user message, so the model doesn't distrust the
   // approval as user input.
-  const approvalInstructions =
-    "ESCALATION APPROVAL: The user's request in this conversation has been " +
-    "reviewed and APPROVED by an authorised human reviewer. This specific " +
-    "request is already approved - do not escalate or ask for approval again " +
-    "for it. Begin your reply by briefly confirming the request was approved, " +
-    "then CARRY OUT the user's original request: take the action they asked " +
-    "for using your available tools. Actually attempt it. If you cannot " +
-    "complete it because a required tool or capability is missing, say " +
-    "specifically what is missing and that the request could not be " +
-    "completed - never imply it was done when it was not. If doing so " +
-    "surfaces a genuinely new request that needs its own human sign-off, you " +
-    "may escalate that separately."
+  const approvalInstructions = `ESCALATION APPROVAL: The user's request in \
+this conversation has been reviewed and APPROVED by an authorised human \
+reviewer. This specific request is already approved - do not escalate or \
+ask for approval again for it. Begin your reply by briefly confirming the \
+request was approved, then CARRY OUT the user's original request: take the \
+action they asked for using your available tools. Actually attempt it. If \
+you cannot complete it because a required tool or capability is missing, \
+say specifically what is missing and that the request could not be \
+completed - never imply it was done when it was not. If doing so surfaces \
+a genuinely new request that needs its own human sign-off, you may \
+escalate that separately.`
 
   const resumeUserId = ctx.userId ?? "escalation-resume"
 
@@ -400,11 +399,10 @@ export async function resumeOperation({
             value: {
               status: "approved",
               decision: "approved",
-              note:
-                "An authorised human reviewer approved this request. Proceed " +
-                "to fulfil it and confirm to the user. Do not escalate this " +
-                "same request again - a genuinely new, different request " +
-                "can still be escalated separately.",
+              note: `An authorised human reviewer approved this request. \
+Proceed to fulfil it and confirm to the user. Do not escalate this same \
+request again - a genuinely new, different request can still be \
+escalated separately.`,
             },
           },
         },

--- a/packages/server/src/escalation/queue.ts
+++ b/packages/server/src/escalation/queue.ts
@@ -338,17 +338,18 @@ export async function resumeOperation({
 
   // System prompt, not a user message, so the model doesn't distrust the
   // approval as user input.
-  const approvalInstructions = `ESCALATION APPROVAL: The user's request in \
-this conversation has been reviewed and APPROVED by an authorised human \
-reviewer. This specific request is already approved - do not escalate or \
-ask for approval again for it. Begin your reply by briefly confirming the \
-request was approved, then CARRY OUT the user's original request: take the \
-action they asked for using your available tools. Actually attempt it. If \
-you cannot complete it because a required tool or capability is missing, \
-say specifically what is missing and that the request could not be \
-completed - never imply it was done when it was not. If doing so surfaces \
-a genuinely new request that needs its own human sign-off, you may \
-escalate that separately.`
+  const approvalInstructions =
+    "ESCALATION APPROVAL: The user's request in this conversation has been " +
+    "reviewed and APPROVED by an authorised human reviewer. This specific " +
+    "request is already approved - do not escalate or ask for approval again " +
+    "for it. Begin your reply by briefly confirming the request was approved, " +
+    "then CARRY OUT the user's original request: take the action they asked " +
+    "for using your available tools. Actually attempt it. If you cannot " +
+    "complete it because a required tool or capability is missing, say " +
+    "specifically what is missing and that the request could not be " +
+    "completed - never imply it was done when it was not. If doing so " +
+    "surfaces a genuinely new request that needs its own human sign-off, you " +
+    "may escalate that separately."
 
   const resumeUserId = ctx.userId ?? "escalation-resume"
 
@@ -399,10 +400,11 @@ escalate that separately.`
             value: {
               status: "approved",
               decision: "approved",
-              note: `An authorised human reviewer approved this request. \
-Proceed to fulfil it and confirm to the user. Do not escalate this same \
-request again - a genuinely new, different request can still be \
-escalated separately.`,
+              note:
+                "An authorised human reviewer approved this request. Proceed " +
+                "to fulfil it and confirm to the user. Do not escalate this " +
+                "same request again - a genuinely new, different request " +
+                "can still be escalated separately.",
             },
           },
         },

--- a/packages/server/src/sdk/workspace/ai/agents/agentRuntime.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/agentRuntime.spec.ts
@@ -1,5 +1,5 @@
 import type { Agent, LLMResponse } from "@budibase/types"
-import { FeatureFlag } from "@budibase/types"
+import { EscalationNotificationChannel, FeatureFlag } from "@budibase/types"
 
 const mockRouterStream = jest.fn()
 
@@ -54,6 +54,18 @@ jest.mock("../../../../ai/tools/budibase/knowledge/reportUsedSources", () => ({
   createReportUsedSourcesTool: jest.fn(),
 }))
 
+const mockCreateEscalateTool = jest.fn()
+jest.mock("../../../../ai/tools/budibase/escalate", () => ({
+  createEscalateTool: (...args: unknown[]) => mockCreateEscalateTool(...args),
+}))
+
+const mockCreateListSessionEscalationsTool = jest.fn()
+jest.mock("../../../../ai/tools/budibase/listSessionEscalations", () => ({
+  createListSessionEscalationsTool: (...args: unknown[]) =>
+    mockCreateListSessionEscalationsTool(...args),
+  LIST_SESSION_ESCALATIONS_TOOL_NAME: "list_session_escalations",
+}))
+
 jest.mock("dd-trace", () => ({
   __esModule: true,
   default: {
@@ -74,16 +86,25 @@ jest.mock("@budibase/backend-core", () => {
       ...actual.features,
       isEnabled: (...args: unknown[]) => mockIsEnabled(...args),
     },
+    cache: {
+      ...actual.cache,
+      get: jest.fn().mockResolvedValue(undefined),
+      store: jest.fn().mockResolvedValue(undefined),
+    },
   }
 })
 
-import { ToolLoopAgent } from "ai"
+import type { ContextUser } from "@budibase/types"
+import { tool, ToolLoopAgent } from "ai"
+import { z } from "zod"
 import {
   chooseOperationForQuestion,
+  prepareAgentChatRun,
   prepareAgentRunContext,
 } from "./agentRuntime"
 import sdk from "../../.."
 import { buildPromptAndTools } from "./utils"
+import { createSessionLogIndexer } from "../agentLogs"
 
 describe("chooseOperationForQuestion", () => {
   const operation1 = {
@@ -375,6 +396,138 @@ describe("prepareAgentRunContext", () => {
       expect.objectContaining({
         fallbackPromptInstructions: expect.stringContaining("- IT support"),
       })
+    )
+  })
+})
+
+describe("prepareAgentChatRun - escalate tool selection", () => {
+  const recipients = [
+    { type: EscalationNotificationChannel.SLACK, config: { channel: "C1" } },
+  ]
+
+  const operationWithRecipients = {
+    id: "operation_1",
+    name: "Procurement",
+    live: true,
+    allowKnowledgeSourceDownload: true,
+    escalation: { recipients, delay: 120 },
+  }
+
+  const operationWithoutRecipients = {
+    id: "operation_2",
+    name: "IT support",
+    live: true,
+    allowKnowledgeSourceDownload: true,
+  }
+
+  const agent = {
+    _id: "agent_1",
+    name: "Support Agent",
+    aiconfig: "config-1",
+    operations: [operationWithRecipients, operationWithoutRecipients],
+  } satisfies Agent
+
+  const llm = {
+    chat: {} as any,
+    providerOptions: jest.fn().mockReturnValue(undefined),
+    uploadFile: jest.fn(),
+  } satisfies LLMResponse
+
+  const user = {} as ContextUser
+  const realTool = { name: "escalate-real-tool" }
+  const escalatePlaceholder = tool({
+    description: "placeholder",
+    inputSchema: z.object({}),
+    execute: async () => ({}),
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsEnabled.mockImplementation(
+      async (flag: FeatureFlag) => flag === FeatureFlag.ESCALATION
+    )
+    jest.mocked(sdk.ai.llm.createLLM).mockResolvedValue(llm)
+    jest.mocked(createSessionLogIndexer).mockReturnValue({
+      addRequestId: jest.fn(),
+      getRequestIds: jest.fn().mockReturnValue([]),
+      index: jest.fn().mockResolvedValue(undefined),
+    })
+    mockCreateEscalateTool.mockReturnValue(realTool)
+    mockCreateListSessionEscalationsTool.mockReturnValue({})
+  })
+
+  const runFor = async (
+    operation: (typeof agent.operations)[number],
+    overrides: Partial<Parameters<typeof prepareAgentChatRun>[0]> = {}
+  ) => {
+    jest.mocked(buildPromptAndTools).mockResolvedValue({
+      systemPrompt: "system prompt",
+      tools: { escalate: escalatePlaceholder },
+      toolDisplayNames: {},
+    })
+
+    return prepareAgentChatRun({
+      agent,
+      agentId: "agent_1",
+      modelMessages: [],
+      errorLabel: "test",
+      sessionId: "session_1",
+      user,
+      operationId: operation.id,
+      ...overrides,
+    })
+  }
+
+  it("swaps escalate for the real tool when the selected operation has recipients configured", async () => {
+    await runFor(operationWithRecipients)
+
+    expect(mockCreateEscalateTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "agent_1",
+        operationId: operationWithRecipients.id,
+        sessionId: "session_1",
+        recipients,
+        delayMs: 120000,
+      })
+    )
+    expect(ToolLoopAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: expect.objectContaining({ escalate: realTool }),
+      })
+    )
+  })
+
+  it("resolves getRequestId lazily via the provided callback", async () => {
+    const getRequestId = jest.fn().mockReturnValue("request_1")
+
+    await runFor(operationWithRecipients, { getRequestId })
+
+    const call = mockCreateEscalateTool.mock.calls[0][0]
+    expect(getRequestId).not.toHaveBeenCalled()
+    expect(call.getRequestId()).toEqual("request_1")
+    expect(getRequestId).toHaveBeenCalledTimes(1)
+  })
+
+  it("leaves the placeholder tool untouched when the operation has no recipients configured", async () => {
+    await runFor(operationWithoutRecipients)
+
+    expect(mockCreateEscalateTool).not.toHaveBeenCalled()
+    expect(ToolLoopAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: expect.objectContaining({ escalate: escalatePlaceholder }),
+      })
+    )
+  })
+
+  it("strips the escalate tool entirely when the ESCALATION feature flag is disabled", async () => {
+    mockIsEnabled.mockResolvedValue(false)
+
+    await runFor(operationWithRecipients)
+
+    expect(mockCreateEscalateTool).not.toHaveBeenCalled()
+    expect(mockCreateListSessionEscalationsTool).not.toHaveBeenCalled()
+    expect(ToolLoopAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ tools: undefined })
     )
   })
 })

--- a/packages/server/src/sdk/workspace/ai/agents/agentRuntime.ts
+++ b/packages/server/src/sdk/workspace/ai/agents/agentRuntime.ts
@@ -37,10 +37,7 @@ import {
 } from "./utils"
 import { estimateTokens } from "./usage"
 import { createReportUsedSourcesTool } from "../../../../ai/tools/budibase/knowledge/reportUsedSources"
-import {
-  createEscalateTool,
-  createResolvedEscalateTool,
-} from "../../../../ai/tools/budibase/escalate"
+import { createEscalateTool } from "../../../../ai/tools/budibase"
 import {
   createListSessionEscalationsTool,
   LIST_SESSION_ESCALATIONS_TOOL_NAME,
@@ -70,8 +67,6 @@ interface PrepareAgentChatRunParams {
   startedAt?: string
   // Pin the run to a specific operation instead of routing on the question.
   operationId?: string
-  // On resume swap escalate for a resolved stub so the model can't trigger a fresh escalation
-  escalationResolved?: boolean
   // Appended to the system prompt - a trusted channel for run-time directives
   // Puting it in the user input made it suspicious.
   additionalInstructions?: string
@@ -414,7 +409,6 @@ export const prepareAgentChatRun = async ({
   user,
   startedAt,
   operationId,
-  escalationResolved,
   additionalInstructions,
   getRequestId,
 }: PrepareAgentChatRunParams): Promise<AgentChatRun> => {
@@ -484,14 +478,9 @@ export const prepareAgentChatRun = async ({
 
   if (tools.escalate) {
     const recipients = selectedOperation?.escalation?.recipients
-    if (escalationResolved) {
-      // Resumed run: replace with a no-op so the model can't re-escalate.
-      // The prior escalate call is in the message history, so the tool must
-      // remain in the schema or the model will see an unresolved tool call.
-      tools.escalate = createResolvedEscalateTool()
-    } else if (selectedOperation && recipients?.length) {
-      // Fresh run: escalation is configured per operation, so resolve it from
-      // the operation this run actually selected - never a different one.
+    if (selectedOperation && recipients?.length) {
+      // Always the real tool, on resumes too. A resumed run must still be
+      // able to raise a genuinely new escalation.
       tools.escalate = createEscalateTool({
         agentId,
         operationId: selectedOperation.id,


### PR DESCRIPTION
## Addresses
https://github.com/Budibase/budibase/issues/19207

## Description
When an `AgentRequest` was resumed after a human approved an escalation, `resumeOperation()` unconditionally swapped the real `escalate` tool for a stub (`createResolvedEscalateTool`) that always returned `ALREADY_APPROVED` without ever calling `escalationProcessor.create()`. This meant that once the first escalation on a request was approved, the agent could never raise a second, genuinely new escalation during the rest of that resumed session, even if it was about something completely unrelated, the request would get permanently stuck in `Needs input`.

Three supporting gaps compounded the same root cause:
- `resumeOperation()` didn't pass `getRequestId` to `prepareAgentChatRun`, so even a real second escalation created during a resume wouldn't have been stamped with the owning `requestId`, breaking its timeline tracking and the anti-premature-close guard in `resolveFinalRequestOutcome`.
- `resumeOperation()` didn't wire up `onToolCalls` on its `run.stream()` call the way the two `chatConversations.ts` call-sites already do, so a real second escalation wouldn't move the request back to `needs_input` through that path.
- Three separate pieces of prompt text told the model, in absolute terms, never to escalate again after an approval, contradicting the base system prompt, which already correctly says to only escalate genuinely new requests.

### Fix
- Always pass `getRequestId: () => doc.requestId` from `resumeOperation()` to `prepareAgentChatRun`.
- Remove the unconditional stub swap in `agentRuntime.ts`; the real `escalate` tool (`createEscalateTool`) is now used whenever the selected operation has recipients configured, on both fresh runs and resumes. `createResolvedEscalateTool` is now unused and has been removed.
- Reword the absolute "do NOT escalate again" instructions in `queue.ts` (`approvalInstructions` and the synthetic `tool-result` note) to scope the prohibition to the specific, already-approved request, while explicitly allowing a genuinely new one to be escalated separately.
- Wire `onToolCalls` into the resumed run's `run.stream()` call, replicating the same handling `chatConversations.ts` already has (moves the request to `needs_input` when `escalate` succeeds), without introducing a controller -> queue dependency.

## Screen recording
https://github.com/user-attachments/assets/ba45170c-7257-4221-a06b-bfebaf55137c




## Launchcontrol
Fixes a bug where an AI agent could get permanently stuck waiting for human approval: after a human approved one escalation on a request, the agent lost the ability to raise a second, unrelated escalation for the rest of that conversation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug that blocked new escalations on a resumed `AgentRequest` after one approval. Resumed runs now use the real `escalate` tool, correctly attach new escalations to the same request, and move the request back to `needs_input` when escalation happens.

- **Bug Fixes**
  - Always use the real `escalate` tool on resumes; removed `createResolvedEscalateTool` and the `escalationResolved` swap in `prepareAgentChatRun`.
  - Pass `getRequestId` from `resumeOperation()` to `prepareAgentChatRun` so new escalations attach to the same request.
  - Wire `onToolCalls` in resumed streams to set the request status to `needs_input` when `escalate` is called.
  - Added tests to verify tool selection behavior and that a second, new escalation during a resumed run is raised, tracked, and keeps the request open.

<sup>Written for commit ed5a6caf944bafbbdd0986e51437a21d231695f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

