### PR TITLE
Fix flaky plugin URL upload test relying on live DNS resolution

### DIFF
--- a/packages/server/src/api/routes/tests/plugin.spec.ts
+++ b/packages/server/src/api/routes/tests/plugin.spec.ts
@@ -478,7 +478,7 @@ describe("/plugins", () => {
           BLACKLIST_IPS: "",
         },
         async () => {
-          nock("https://www.someurl.com")
+          nock("https://8.8.8.8")
             .get("/comment-box/comment-box-1.0.2.tar.gz")
             .replyWithFile(
               200,
@@ -487,7 +487,7 @@ describe("/plugins", () => {
 
           const { plugin } = await config.api.plugin.create({
             source: PluginSource.URL,
-            url: "https://www.someurl.com/comment-box/comment-box-1.0.2.tar.gz",
+            url: "https://8.8.8.8/comment-box/comment-box-1.0.2.tar.gz",
           })
           expect(plugin._id).toEqual("plg_comment-box")
           expect(events.plugin.imported).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Description

See https://github.com/Budibase/budibase/actions/runs/29492799221/job/87604550365?pr=19215

`src/api/routes/tests/plugin.spec.ts` → `"should be able to create a plugin from a URL"` started failing today in CI with `getaddrinfo ENOTFOUND www.someurl.com`, even though nothing in the plugin upload code path changed.

Root cause: `fetchWithBlacklist` (`packages/backend-core/src/utils/outboundFetch.ts`, and its duplicate in `packages/server/src/automations/steps/utils.ts`) resolves the target hostname via a real `dns.lookup()` and pins the outbound connection to that resolved IP, as an anti-DNS-rebinding measure added in #18868. That resolution happens *before* `nock` gets a chance to intercept anything - `nock` only patches `http`/`https`, not the `dns` module - so mocking a made-up hostname with `nock` only works if that hostname happens to still have a real DNS record.

This test used `https://www.someurl.com/...`. That's not a fictional hostname - it's a real, currently-registered domain parked through a domain-parking service: `dig` shows an active `CNAME`, but that target currently has no `A` record, so resolution fails. The domain was presumably resolving to *something* until recently (CI was green as of yesterday, and the two commits that landed on `master` since then only touch an unrelated builder store), and stopped once its parking page's IP was pulled - something entirely outside this repo's control.

This is the same failure mode the codebase already works around elsewhere: `httpBlacklist.spec.ts` and `blacklist.spec.ts` use IP literals (e.g. `8.8.8.8`, `127.0.0.1`) instead of hostnames precisely because `resolveAddress()` skips the DNS lookup entirely when the address is already a literal IP (`net.isIP` check). This PR applies that same pattern here: the mocked URL now uses `8.8.8.8` instead of a third-party hostname, so the test no longer depends on any external domain's DNS state.

## Launchcontrol
No user-facing change - test-only fix for a CI flake caused by a third-party parked domain's DNS state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the plugin URL upload test by replacing the third-party hostname with the IP literal 8.8.8.8. This bypasses real DNS resolution that `nock` cannot intercept, making the test deterministic in CI.

<sup>Written for commit aeb21aeb62ef3ad294b0b3d36f86e4d69392aefa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

