### PR TITLE
Feat/OIDC unverified email linking env

### DIFF
--- a/packages/backend-core/src/environment.ts
+++ b/packages/backend-core/src/environment.ts
@@ -255,6 +255,9 @@ const environment = {
   ENABLE_SSO_MAINTENANCE_MODE: selfHosted
     ? process.env.ENABLE_SSO_MAINTENANCE_MODE
     : false,
+  // Boot time OIDC config for SSO - enables non-verified email linking,
+  OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING:
+    process.env.OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING,
   ...getPackageJsonFields(),
   DISABLE_PINO_LOGGER: process.env.DISABLE_PINO_LOGGER,
   OFFLINE_MODE: process.env.OFFLINE_MODE,

--- a/packages/backend-core/src/middleware/passport/sso/oidc.ts
+++ b/packages/backend-core/src/middleware/passport/sso/oidc.ts
@@ -2,6 +2,7 @@ import fetch from "node-fetch"
 import * as sso from "./sso"
 import { ssoCallbackUrl } from "../utils"
 import { validEmail } from "../../../utils"
+import env from "../../../environment"
 import {
   ConfigType,
   OIDCInnerConfig,
@@ -193,6 +194,22 @@ export async function strategyFactory(
   }
 }
 
+/**
+ * Resolves the effective allowUnverifiedEmailLinking value. A boot-time
+ * environment override wins over the per-provider database value when set,
+ * otherwise the database value is used.
+ */
+function resolveAllowUnverifiedEmailLinking(
+  configValue?: boolean
+): boolean | undefined {
+  const override = env.OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING
+  if (override === undefined) {
+    return configValue
+  }
+  const normalized = `${override}`.toLowerCase()
+  return normalized !== "" && normalized !== "false" && normalized !== "0"
+}
+
 export async function fetchStrategyConfig(
   oidcConfig: OIDCInnerConfig,
   callbackUrl?: string
@@ -232,7 +249,9 @@ export async function fetchStrategyConfig(
       clientSecret: clientSecret,
       callbackURL: callbackUrl,
       pkce: pkce,
-      allowUnverifiedEmailLinking: allowUnverifiedEmailLinking,
+      allowUnverifiedEmailLinking: resolveAllowUnverifiedEmailLinking(
+        allowUnverifiedEmailLinking
+      ),
     }
   } catch (err) {
     throw new Error(

--- a/packages/backend-core/src/middleware/passport/sso/tests/oidc.spec.ts
+++ b/packages/backend-core/src/middleware/passport/sso/tests/oidc.spec.ts
@@ -6,6 +6,7 @@ import {
 } from "@budibase/types"
 import * as _sso from "../sso"
 import * as oidc from "../oidc"
+import { setEnv } from "../../../../environment"
 import nock from "nock"
 import type OpenIDConnectStrategy from "@govtechsg/passport-openidconnect"
 
@@ -49,6 +50,47 @@ describe("oidc", () => {
         expectedOptions,
         expect.anything()
       )
+    })
+  })
+
+  describe("fetchStrategyConfig - allowUnverifiedEmailLinking", () => {
+    let restoreEnv: () => void
+
+    afterEach(() => {
+      restoreEnv?.()
+    })
+
+    it("uses the database value when the env override is unset", async () => {
+      restoreEnv = setEnv({ OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING: undefined })
+
+      const config = await oidc.fetchStrategyConfig(
+        { ...oidcConfig, allowUnverifiedEmailLinking: true },
+        callbackUrl
+      )
+
+      expect(config.allowUnverifiedEmailLinking).toBe(true)
+    })
+
+    it("env override forces the value on regardless of the database", async () => {
+      restoreEnv = setEnv({ OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING: "true" })
+
+      const config = await oidc.fetchStrategyConfig(
+        { ...oidcConfig, allowUnverifiedEmailLinking: false },
+        callbackUrl
+      )
+
+      expect(config.allowUnverifiedEmailLinking).toBe(true)
+    })
+
+    it("env override forces the value off regardless of the database", async () => {
+      restoreEnv = setEnv({ OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING: "false" })
+
+      const config = await oidc.fetchStrategyConfig(
+        { ...oidcConfig, allowUnverifiedEmailLinking: true },
+        callbackUrl
+      )
+
+      expect(config.allowUnverifiedEmailLinking).toBe(false)
     })
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a boot-time env flag to control OIDC unverified email linking for SSO. You can enable or disable linking globally without changing per-provider settings.

- **New Features**
  - `OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING` overrides the provider `allowUnverifiedEmailLinking` when set; otherwise the database value is used.
  - Normalization: any non-empty value except "false"/"0" is treated as true.
  - Tests verify env override precedence.

- **Migration**
  - Optional: set `OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING` to "true" or "false" and restart the service.

<sup>Written for commit 5bb26fbef419a2c98e3e19eca2953c78358f912c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

