### PR TITLE
fix: handle unverified emails in ms oidc

### DIFF
--- a/packages/backend-core/src/constants/db.ts
+++ b/packages/backend-core/src/constants/db.ts
@@ -25,6 +25,7 @@ export enum AutomationViewMode {
 export enum ViewName {
   USER_BY_WORKSPACE = "by_app",
   USER_BY_EMAIL = "by_email2",
+  USER_BY_SSO_IDENTITY = "by_sso_identity",
   BY_API_KEY = "by_api_key",
   AGENT_REQUESTS_BY_AGENT = "agent_requests_by_agent",
   AGENT_REQUESTS_BY_UPDATED_AT = "agent_requests_by_updated_at_2",

--- a/packages/backend-core/src/db/views.ts
+++ b/packages/backend-core/src/db/views.ts
@@ -83,6 +83,20 @@ export const createNewUserEmailView = async () => {
   await createView(db, viewJs, ViewName.USER_BY_EMAIL)
 }
 
+export const createUserSSOIdentityView = async () => {
+  const db = getGlobalDB()
+  const viewJs = `function(doc) {
+    if (doc._id.startsWith("${DocumentType.USER}${SEPARATOR}") && Array.isArray(doc.ssoIdentities)) {
+      for (let identity of doc.ssoIdentities) {
+        if (identity.providerType && identity.provider && identity.userId) {
+          emit([identity.providerType, identity.provider, identity.userId], doc._id)
+        }
+      }
+    }
+  }`
+  await createView(db, viewJs, ViewName.USER_BY_SSO_IDENTITY)
+}
+
 export const createUserAppView = async () => {
   const db = getGlobalDB()
   const viewJs = `function(doc) {
@@ -216,6 +230,7 @@ export const queryPlatformView = async <T extends Document>(
 
 const CreateFuncByName: any = {
   [ViewName.USER_BY_EMAIL]: createNewUserEmailView,
+  [ViewName.USER_BY_SSO_IDENTITY]: createUserSSOIdentityView,
   [ViewName.BY_API_KEY]: createApiKeyView,
   [ViewName.USER_BY_WORKSPACE]: createUserAppView,
 }

--- a/packages/backend-core/src/middleware/passport/sso/oidc.ts
+++ b/packages/backend-core/src/middleware/passport/sso/oidc.ts
@@ -1,4 +1,5 @@
 import fetch from "node-fetch"
+import jwt from "jsonwebtoken"
 import * as sso from "./sso"
 import { ssoCallbackUrl } from "../utils"
 import { validEmail } from "../../../utils"
@@ -26,14 +27,6 @@ type OIDCUserInfoProfile = OpenIDConnectStrategy.MergedProfile & {
   provider?: string
 }
 
-// the id_token profile also exposes the raw claims via _json
-type OIDCIdProfile = OpenIDConnectStrategy.Profile & {
-  _json?: {
-    email?: string
-    email_verified?: boolean
-  }
-}
-
 export function buildVerifyFn(
   saveUserFn: SaveSSOUserFunction,
   allowUnverifiedEmailLinking = false
@@ -54,19 +47,20 @@ export function buildVerifyFn(
     uiProfile: OIDCUserInfoProfile | undefined,
     idProfile: OpenIDConnectStrategy.Profile,
     _context: OpenIDConnectStrategy.AuthContext,
-    _idToken: string,
+    idToken: string,
     accessToken: string,
     refreshToken: string,
     _params: Record<string, unknown>,
     done: OpenIDConnectStrategy.VerifyCallback
   ) => {
-    const profile = normalizeProfile(uiProfile, idProfile)
-    const jwtClaims = buildJwtClaims(uiProfile, idProfile)
+    const jwtClaims = buildJwtClaims(idToken, idProfile)
+    validateSubjects(uiProfile, idProfile, jwtClaims)
+    const profile = normalizeProfile(uiProfile, idProfile, jwtClaims)
     const details: SSOAuthDetails = {
       // store the issuer info to enable sync in future
       provider: issuer,
       providerType: SSOProviderType.OIDC,
-      userId: profile.id,
+      userId: jwtClaims.sub!,
       profile: profile,
       email: getEmail(profile, jwtClaims),
       emailVerified: getEmailVerified(profile, jwtClaims),
@@ -88,22 +82,21 @@ export function buildVerifyFn(
 
 function normalizeProfile(
   uiProfile: OIDCUserInfoProfile | undefined,
-  idProfile: OpenIDConnectStrategy.Profile
+  idProfile: OpenIDConnectStrategy.Profile,
+  jwtClaims: JwtClaims
 ): SSOProfile {
   const profileJson = { ...(uiProfile?._json || {}) }
 
   if (!profileJson.email && idProfile.emails?.length) {
     profileJson.email = idProfile.emails[0].value
     // keep email_verified aligned with the email it describes
-    profileJson.email_verified = (
-      idProfile as OIDCIdProfile
-    )._json?.email_verified
+    profileJson.email_verified = jwtClaims.email_verified
   }
 
   const displayName = uiProfile?.displayName || idProfile.displayName
 
   return {
-    id: uiProfile?.id || idProfile.id,
+    id: jwtClaims.sub!,
     name:
       uiProfile?.name ||
       idProfile.name ||
@@ -115,13 +108,42 @@ function normalizeProfile(
 }
 
 function buildJwtClaims(
-  uiProfile: OIDCUserInfoProfile | undefined,
+  idToken: string,
   idProfile: OpenIDConnectStrategy.Profile
 ): JwtClaims {
+  const decoded = jwt.decode(idToken)
+  if (!decoded || typeof decoded === "string") {
+    throw new Error("Could not decode ID token claims")
+  }
+
   return {
-    email: uiProfile?._json?.email || idProfile.emails?.[0]?.value,
-    email_verified: (idProfile as OIDCIdProfile)._json?.email_verified,
-    preferred_username: idProfile.username,
+    sub: typeof decoded.sub === "string" ? decoded.sub : undefined,
+    email:
+      typeof decoded.email === "string"
+        ? decoded.email
+        : idProfile.emails?.[0]?.value,
+    email_verified:
+      typeof decoded.email_verified === "boolean"
+        ? decoded.email_verified
+        : undefined,
+    preferred_username:
+      typeof decoded.preferred_username === "string"
+        ? decoded.preferred_username
+        : idProfile.username,
+  }
+}
+
+function validateSubjects(
+  uiProfile: OIDCUserInfoProfile | undefined,
+  idProfile: OpenIDConnectStrategy.Profile,
+  jwtClaims: JwtClaims
+) {
+  if (!jwtClaims.sub || idProfile.id !== jwtClaims.sub) {
+    throw new Error("ID token subject is invalid")
+  }
+
+  if (uiProfile && uiProfile.id !== jwtClaims.sub) {
+    throw new Error("UserInfo subject does not match ID token subject")
   }
 }
 
@@ -164,7 +186,14 @@ function getEmail(profile: SSOProfile, jwtClaims: JwtClaims) {
  */
 function getEmailVerified(profile: SSOProfile, jwtClaims: JwtClaims): boolean {
   if (profile._json.email) {
-    return profile._json.email_verified === true
+    if (typeof profile._json.email_verified === "boolean") {
+      return profile._json.email_verified
+    }
+
+    return (
+      profile._json.email.toLowerCase() === jwtClaims.email?.toLowerCase() &&
+      jwtClaims.email_verified === true
+    )
   }
 
   if (jwtClaims.email) {

--- a/packages/backend-core/src/middleware/passport/sso/sso.ts
+++ b/packages/backend-core/src/middleware/passport/sso/sso.ts
@@ -2,11 +2,14 @@ import { generateGlobalUserID } from "../../../db"
 import { authError } from "../utils"
 import * as users from "../../../users"
 import * as context from "../../../context"
+import * as crypto from "crypto"
 import {
   SaveSSOUserFunction,
   SSOAuthDetails,
+  SSOIdentity,
   SSOUser,
   User,
+  UserSSO,
 } from "@budibase/types"
 
 // no-op function for user save
@@ -14,6 +17,49 @@ import {
 // - prefer no-op over an optional argument to ensure function is provided to login flows
 export const ssoSaveUserNoOp: SaveSSOUserFunction = (user: SSOUser) =>
   Promise.resolve(user)
+
+const buildIdentity = (details: SSOAuthDetails): SSOIdentity => ({
+  provider: details.provider,
+  providerType: details.providerType,
+  userId: details.userId,
+})
+
+type StoredUser = User & Partial<UserSSO>
+
+const identitiesMatch = (left: SSOIdentity, right: SSOIdentity) =>
+  left.provider === right.provider &&
+  left.providerType === right.providerType &&
+  left.userId === right.userId
+
+const hasIdentity = (user: StoredUser, identity: SSOIdentity) =>
+  user.ssoIdentities?.some(existing => identitiesMatch(existing, identity)) ===
+  true
+
+const canMigrateLegacyIdentity = (user: StoredUser, identity: SSOIdentity) =>
+  !user.ssoIdentities?.length &&
+  user.provider === identity.provider &&
+  user.providerType === identity.providerType
+
+const generateSSOUserID = (identity: SSOIdentity) => {
+  const identityHash = crypto
+    .createHash("sha256")
+    .update(
+      [identity.providerType, identity.provider, identity.userId].join("\0")
+    )
+    .digest("hex")
+  return generateGlobalUserID(identityHash)
+}
+
+const getUserById = async (userId: string) => {
+  try {
+    return await users.getById(userId)
+  } catch (err: any) {
+    if (err.status === 404) {
+      return undefined
+    }
+    throw err
+  }
+}
 
 /**
  * Common authentication logic for third parties. e.g. OAuth, OIDC.
@@ -35,29 +81,68 @@ export async function authenticate(
     return authError(done, "sso user email required")
   }
 
-  // use the third party id
-  const userId = generateGlobalUserID(details.userId)
+  const identity = buildIdentity(details)
+  const userId = generateSSOUserID(identity)
 
-  let dbUser: User | undefined
+  let dbUser: StoredUser | undefined
 
-  // try to load by id
   try {
-    dbUser = await users.getById(userId)
+    // New SSO users use an issuer-scoped deterministic id. Existing local
+    // users are resolved through their persisted SSO identity.
+    dbUser = await getUserById(userId)
+    if (!dbUser) {
+      dbUser = await users.getGlobalUserBySSOIdentity(identity)
+    }
+
+    // Users created before SSO identities were persisted were keyed by the
+    // provider subject alone. Only accept that legacy key when its stored
+    // provider still matches the authenticating issuer.
+    if (!dbUser) {
+      const legacyUser = await getUserById(generateGlobalUserID(details.userId))
+      if (legacyUser && canMigrateLegacyIdentity(legacyUser, identity)) {
+        dbUser = legacyUser
+      }
+    }
   } catch (err: any) {
-    // abort when not 404 error
-    if (!err.status || err.status !== 404) {
+    return authError(
+      done,
+      "Unexpected error when retrieving existing user",
+      err
+    )
+  }
+
+  if (dbUser && !hasIdentity(dbUser, identity)) {
+    if (!canMigrateLegacyIdentity(dbUser, identity)) {
+      return authError(done, "SSO identity does not match existing user")
+    }
+    dbUser.ssoIdentities = [identity]
+  }
+
+  if (!dbUser) {
+    let emailUser: StoredUser | undefined
+    try {
+      emailUser = await users.getGlobalUserByEmail(details.email)
+    } catch (err: any) {
       return authError(
         done,
         "Unexpected error when retrieving existing user",
         err
       )
     }
-  }
 
-  // fallback to loading by email - only when the email has been verified by the
-  // identity provider.
-  if (!dbUser && (details.emailVerified || allowUnverifiedEmailLinking)) {
-    dbUser = await users.getGlobalUserByEmail(details.email)
+    if (emailUser) {
+      const canLink =
+        hasIdentity(emailUser, identity) ||
+        details.emailVerified === true ||
+        allowUnverifiedEmailLinking ||
+        canMigrateLegacyIdentity(emailUser, identity)
+
+      if (!canLink) {
+        return authError(done, "SSO identity cannot be linked to existing user")
+      }
+
+      dbUser = emailUser
+    }
   }
 
   // exit early if there is still no user and auto creation is disabled
@@ -76,7 +161,10 @@ export async function authenticate(
       email: details.email,
       roles: {},
       tenantId: context.getTenantId(),
+      ssoIdentities: [identity],
     }
+  } else if (!hasIdentity(dbUser, identity)) {
+    dbUser.ssoIdentities = [...(dbUser.ssoIdentities || []), identity]
   }
 
   let ssoUser = await syncUser(dbUser, details)

--- a/packages/backend-core/src/middleware/passport/sso/tests/oidc.spec.ts
+++ b/packages/backend-core/src/middleware/passport/sso/tests/oidc.spec.ts
@@ -7,6 +7,7 @@ import {
 import * as _sso from "../sso"
 import * as oidc from "../oidc"
 import nock from "nock"
+import jwt from "jsonwebtoken"
 import type OpenIDConnectStrategy from "@govtechsg/passport-openidconnect"
 
 jest.mock("@govtechsg/passport-openidconnect")
@@ -58,7 +59,7 @@ describe("oidc", () => {
     const profile = details.profile!
     const issuer = profile.provider
 
-    const idToken = generator.string()
+    let idToken: string
     const params: Record<string, unknown> = {}
     const context: OpenIDConnectStrategy.AuthContext = {}
 
@@ -94,6 +95,15 @@ describe("oidc", () => {
         username: details.email,
         _json: { email: details.email, email_verified: true },
       }
+      idToken = jwt.sign(
+        {
+          sub: profile.id,
+          email: details.email,
+          email_verified: true,
+          preferred_username: details.email,
+        },
+        "test-secret"
+      )
     })
 
     async function authenticate() {
@@ -152,7 +162,10 @@ describe("oidc", () => {
 
     it("marks email as unverified when no email_verified claim is present", async () => {
       delete uiProfile._json?.email_verified
-      delete idProfile._json
+      idToken = jwt.sign(
+        { sub: profile.id, email: details.email },
+        "test-secret"
+      )
 
       await authenticate()
 
@@ -167,7 +180,14 @@ describe("oidc", () => {
 
     it("uses id token email_verified when userinfo has no email", async () => {
       delete uiProfile._json?.email
-      idProfile._json = { email: details.email, email_verified: false }
+      idToken = jwt.sign(
+        {
+          sub: profile.id,
+          email: details.email,
+          email_verified: false,
+        },
+        "test-secret"
+      )
 
       await authenticate()
 
@@ -197,6 +217,10 @@ describe("oidc", () => {
     it("uses id token username to get email", async () => {
       delete uiProfile._json?.email
       delete idProfile.emails
+      idToken = jwt.sign(
+        { sub: profile.id, preferred_username: details.email },
+        "test-secret"
+      )
 
       await authenticate()
 
@@ -227,6 +251,10 @@ describe("oidc", () => {
       delete idProfile.emails
 
       idProfile.username = "invalidUsername"
+      idToken = jwt.sign(
+        { sub: profile.id, preferred_username: "invalidUsername" },
+        "test-secret"
+      )
 
       await expect(authenticate()).rejects.toThrow(
         "Could not determine user email from profile"
@@ -238,6 +266,14 @@ describe("oidc", () => {
       uiProfile._json = { email: upperEmail }
       idProfile.emails = [{ value: upperEmail }]
       idProfile.username = upperEmail
+      idToken = jwt.sign(
+        {
+          sub: profile.id,
+          email: upperEmail,
+          email_verified: true,
+        },
+        "test-secret"
+      )
 
       await authenticate()
 
@@ -248,6 +284,29 @@ describe("oidc", () => {
         mockSaveUser,
         false
       )
+    })
+
+    it("uses a matching verified id token email when userinfo omits email_verified", async () => {
+      delete uiProfile._json?.email_verified
+
+      await authenticate()
+
+      expect(sso.authenticate).toHaveBeenCalledWith(
+        expect.objectContaining({ emailVerified: true }),
+        false,
+        mockDone,
+        mockSaveUser,
+        false
+      )
+    })
+
+    it("rejects userinfo for a different subject", async () => {
+      uiProfile.id = generator.string()
+
+      await expect(authenticate()).rejects.toThrow(
+        "UserInfo subject does not match ID token subject"
+      )
+      expect(sso.authenticate).not.toHaveBeenCalled()
     })
 
     it("populates first and last name from profile data", async () => {

--- a/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
+++ b/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
@@ -19,6 +19,12 @@ const getErrorMessage = () => {
   return mockDone.mock.calls[0][2].message
 }
 
+const getIdentity = (details: SSOAuthDetails) => ({
+  provider: details.provider,
+  providerType: details.providerType,
+  userId: details.userId,
+})
+
 describe("sso", () => {
   describe("authenticate", () => {
     beforeEach(() => {
@@ -94,27 +100,41 @@ describe("sso", () => {
 
           await sso.authenticate(details, false, mockDone, mockSaveUser)
 
-          // default roles for new user
-          ssoUser.roles = {}
-
-          // modified external id to match user format
-          ssoUser._id = "us_" + details.userId
-          delete ssoUser.userId
-
-          // new sso user won't have a password
-          delete ssoUser.password
-
-          // new user isn't saved with rev
-          delete ssoUser._rev
-
-          // tenant id added
-          ssoUser.tenantId = context.getTenantId()
-
-          expect(mockSaveUser).toHaveBeenCalledWith(ssoUser, {
-            hashPassword: false,
-            requirePassword: false,
-          })
+          expect(mockSaveUser).toHaveBeenCalledWith(
+            expect.objectContaining({
+              _id: expect.stringMatching(/^us_[a-f0-9]{64}$/),
+              email: details.email,
+              roles: {},
+              tenantId: context.getTenantId(),
+              ssoIdentities: [getIdentity(details)],
+            }),
+            {
+              hashPassword: false,
+              requirePassword: false,
+            }
+          )
           expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+        })
+
+        it("uses different user ids for equal subjects from different issuers", async () => {
+          const firstDetails = {
+            ...details,
+            provider: "https://one.example.com",
+          }
+          const secondDetails = {
+            ...details,
+            provider: "https://two.example.com",
+          }
+          mockSaveUser
+            .mockImplementationOnce(user => Promise.resolve(user))
+            .mockImplementationOnce(user => Promise.resolve(user))
+
+          await sso.authenticate(firstDetails, false, mockDone, mockSaveUser)
+          await sso.authenticate(secondDetails, false, mockDone, mockSaveUser)
+
+          expect(mockSaveUser.mock.calls[0][0]._id).not.toEqual(
+            mockSaveUser.mock.calls[1][0]._id
+          )
         })
       })
     })
@@ -127,6 +147,7 @@ describe("sso", () => {
         existingUser = structures.users.user()
         existingUser._id = structures.uuid()
         details = structures.sso.authDetails(existingUser)
+        existingUser.ssoIdentities = [getIdentity(details)]
         nock("http://example.com").get("/").reply(200, undefined, {
           "Content-Type": "image/png",
         })
@@ -192,6 +213,33 @@ describe("sso", () => {
           expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
         })
       })
+
+      describe("exists by stored SSO identity", () => {
+        beforeEach(() => {
+          users.getGlobalUserBySSOIdentity.mockReturnValueOnce(
+            Promise.resolve(existingUser)
+          )
+        })
+
+        it("syncs and authenticates the bound user", async () => {
+          const ssoUser = structures.users.ssoUser({
+            user: existingUser,
+            details,
+          })
+          mockSaveUser.mockReturnValueOnce(ssoUser)
+
+          await sso.authenticate(details, true, mockDone, mockSaveUser)
+
+          expect(users.getGlobalUserBySSOIdentity).toHaveBeenCalledWith(
+            getIdentity(details)
+          )
+          expect(mockSaveUser).toHaveBeenCalledWith(
+            expect.objectContaining({ _id: existingUser._id }),
+            expect.anything()
+          )
+          expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+        })
+      })
     })
 
     describe("when the email is not verified", () => {
@@ -215,30 +263,22 @@ describe("sso", () => {
       })
 
       it("does not link to an existing account by email", async () => {
-        users.getGlobalUserByEmail.mockReturnValue(
+        users.getGlobalUserByEmail.mockReturnValueOnce(
           Promise.resolve(existingUser)
         )
-        const ssoUser = structures.users.ssoUser({
-          user: existingUser,
-          details,
-        })
-        mockSaveUser.mockReturnValueOnce(ssoUser)
-
         await sso.authenticate(details, false, mockDone, mockSaveUser)
 
-        // the victim's account must never be loaded by an unverified email
-        expect(users.getGlobalUserByEmail).not.toHaveBeenCalled()
-        // instead a brand new account keyed on the sso id is created
-        expect(mockSaveUser).toHaveBeenCalledWith(
-          expect.objectContaining({ _id: "us_" + details.userId }),
-          expect.anything()
+        expect(users.getGlobalUserByEmail).toHaveBeenCalled()
+        expect(mockSaveUser).not.toHaveBeenCalled()
+        expect(getErrorMessage()).toContain(
+          "SSO identity cannot be linked to existing user"
         )
       })
 
       it("rejects when a local account is required", async () => {
         await sso.authenticate(details, true, mockDone, mockSaveUser)
 
-        expect(users.getGlobalUserByEmail).not.toHaveBeenCalled()
+        expect(users.getGlobalUserByEmail).toHaveBeenCalled()
         expect(mockDone.mock.calls.length).toBe(1)
         expect(getErrorMessage()).toContain(
           "Email does not yet exist. You must set up your local budibase account first."
@@ -258,7 +298,56 @@ describe("sso", () => {
         await sso.authenticate(details, false, mockDone, mockSaveUser, true)
 
         expect(users.getGlobalUserByEmail).toHaveBeenCalled()
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({
+            ssoIdentities: [getIdentity(details)],
+          }),
+          expect.anything()
+        )
         expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+      })
+
+      it("migrates a user previously linked to the same issuer", async () => {
+        Object.assign(existingUser, {
+          provider: details.provider,
+          providerType: details.providerType,
+        })
+        users.getGlobalUserByEmail.mockReturnValueOnce(
+          Promise.resolve(existingUser)
+        )
+        const ssoUser = structures.users.ssoUser({
+          user: existingUser,
+          details,
+        })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({
+            _id: existingUser._id,
+            ssoIdentities: [getIdentity(details)],
+          }),
+          expect.anything()
+        )
+        expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+      })
+
+      it("does not migrate a user linked to a different issuer", async () => {
+        Object.assign(existingUser, {
+          provider: "https://different-issuer.example.com",
+          providerType: details.providerType,
+        })
+        users.getGlobalUserByEmail.mockReturnValueOnce(
+          Promise.resolve(existingUser)
+        )
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(mockSaveUser).not.toHaveBeenCalled()
+        expect(getErrorMessage()).toContain(
+          "SSO identity cannot be linked to existing user"
+        )
       })
     })
   })

--- a/packages/backend-core/src/users/users.ts
+++ b/packages/backend-core/src/users/users.ts
@@ -4,6 +4,7 @@ import {
   ContextUser,
   DatabaseQueryOpts,
   SearchUsersRequest,
+  SSOIdentity,
   User,
 } from "@budibase/types"
 import * as context from "../context"
@@ -121,6 +122,21 @@ export async function getGlobalUserByEmail(
   }
 
   return user
+}
+
+export async function getGlobalUserBySSOIdentity(
+  identity: SSOIdentity
+): Promise<User | undefined> {
+  const response = await queryGlobalView<User>(ViewName.USER_BY_SSO_IDENTITY, {
+    key: [identity.providerType, identity.provider, identity.userId],
+    include_docs: true,
+  })
+
+  if (Array.isArray(response)) {
+    throw new Error("Multiple users found for SSO identity")
+  }
+
+  return response
 }
 
 export async function doesUserExist(email: string) {

--- a/packages/server/src/api/routes/tests/user.spec.ts
+++ b/packages/server/src/api/routes/tests/user.spec.ts
@@ -88,6 +88,13 @@ describe("/users", () => {
         profile: { displayName: "Metadata User" },
         thirdPartyProfile: { id: "external" },
         ssoId: "sso-user",
+        ssoIdentities: [
+          {
+            provider: "google",
+            providerType: SSOProviderType.GOOGLE,
+            userId: "google-user",
+          },
+        ],
         forceResetPassword: false,
       }
       delete metadata._rev
@@ -102,6 +109,7 @@ describe("/users", () => {
         "profile",
         "thirdPartyProfile",
         "ssoId",
+        "ssoIdentities",
         "forceResetPassword",
       ]) {
         expect(found).not.toHaveProperty(field)

--- a/packages/server/src/sdk/users/tests/utils.spec.ts
+++ b/packages/server/src/sdk/users/tests/utils.spec.ts
@@ -232,6 +232,7 @@ describe("syncGlobalUsers", () => {
           profile: expect.anything(),
           thirdPartyProfile: expect.anything(),
           ssoId: expect.anything(),
+          ssoIdentities: expect.anything(),
           forceResetPassword: expect.anything(),
         })
       )
@@ -269,6 +270,7 @@ describe("syncGlobalUsers", () => {
           profile: expect.anything(),
           thirdPartyProfile: expect.anything(),
           ssoId: expect.anything(),
+          ssoIdentities: expect.anything(),
           forceResetPassword: expect.anything(),
         })
       )
@@ -366,6 +368,13 @@ describe("syncGlobalUsers", () => {
         profile: { displayName: "Persisted Token" },
         thirdPartyProfile: { id: "external" },
         ssoId: "sso-user",
+        ssoIdentities: [
+          {
+            provider: "google",
+            providerType: "google",
+            userId: "google-user",
+          },
+        ],
         forceResetPassword: false,
       })
 
@@ -379,6 +388,7 @@ describe("syncGlobalUsers", () => {
         "profile",
         "thirdPartyProfile",
         "ssoId",
+        "ssoIdentities",
         "forceResetPassword",
       ]) {
         expect(found).not.toHaveProperty(field)
@@ -409,6 +419,13 @@ describe("syncGlobalUsers", () => {
         profile: { displayName: "Persisted Token" },
         thirdPartyProfile: { id: "external" },
         ssoId: "sso-user",
+        ssoIdentities: [
+          {
+            provider: "google",
+            providerType: "google",
+            userId: "google-user",
+          },
+        ],
         forceResetPassword: false,
       })
 
@@ -423,6 +440,7 @@ describe("syncGlobalUsers", () => {
           profile: expect.anything(),
           thirdPartyProfile: expect.anything(),
           ssoId: expect.anything(),
+          ssoIdentities: expect.anything(),
           forceResetPassword: expect.anything(),
         })
       )

--- a/packages/server/src/utilities/sensitiveUserFields.spec.ts
+++ b/packages/server/src/utilities/sensitiveUserFields.spec.ts
@@ -1,0 +1,21 @@
+import { SSOProviderType } from "@budibase/types"
+import { stripSensitiveUserFields } from "./sensitiveUserFields"
+
+describe("stripSensitiveUserFields", () => {
+  it("removes persisted SSO identities", () => {
+    const user = {
+      email: "user@example.com",
+      ssoIdentities: [
+        {
+          provider: "https://issuer.example.com",
+          providerType: SSOProviderType.OIDC,
+          userId: "subject",
+        },
+      ],
+    }
+
+    expect(stripSensitiveUserFields(user)).toEqual({
+      email: "user@example.com",
+    })
+  })
+})

--- a/packages/server/src/utilities/sensitiveUserFields.ts
+++ b/packages/server/src/utilities/sensitiveUserFields.ts
@@ -1,9 +1,10 @@
-import { type UserSSO } from "@budibase/types"
+import { type SSOIdentity, type UserSSO } from "@budibase/types"
 
 interface SensitiveUserFields extends Partial<UserSSO> {
   password?: string
   thirdPartyProfile?: object
   ssoId?: string
+  ssoIdentities?: SSOIdentity[]
   forceResetPassword?: boolean
 }
 
@@ -17,6 +18,7 @@ export function stripSensitiveUserFields<T extends SensitiveUserFields>(
   delete user.profile
   delete user.thirdPartyProfile
   delete user.ssoId
+  delete user.ssoIdentities
   delete user.forceResetPassword
   return user
 }

--- a/packages/types/src/documents/global/user.ts
+++ b/packages/types/src/documents/global/user.ts
@@ -21,6 +21,12 @@ export enum SSOProviderType {
   GOOGLE = "google",
 }
 
+export interface SSOIdentity {
+  provider: string
+  providerType: SSOProviderType
+  userId: string
+}
+
 export interface UserSSO {
   provider: string // the individual provider e.g. Okta, Auth0, Google
   providerType: SSOProviderType
@@ -101,6 +107,7 @@ export interface User
   scimInfo?: { isSync: true } & Record<string, any>
   appFavourites?: string[]
   ssoId?: string
+  ssoIdentities?: SSOIdentity[]
   appSort?: string
   budibaseAccess?: boolean
   accountPortalAccess?: boolean

--- a/packages/types/src/sdk/sso.ts
+++ b/packages/types/src/sdk/sso.ts
@@ -8,6 +8,7 @@ import {
 import { SaveUserOpts } from "./user"
 
 export interface JwtClaims {
+  sub?: string
   preferred_username?: string
   email?: string
   email_verified?: boolean

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -130,6 +130,7 @@ export const changeTenantOwnerEmail = async (
         tenantUser.thirdPartyProfile = undefined
         tenantUser.profile = undefined
         tenantUser.oauth2 = undefined
+        tenantUser.ssoIdentities = undefined
 
         await userSdk.db.save(tenantUser, {
           currentUserId: tenantUser._id,

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -1480,6 +1480,13 @@ describe("/api/global/users", () => {
       const providerType = "oidc"
       const thirdPartyProfile = {}
       const oauth2 = {}
+      const ssoIdentities = [
+        {
+          provider: "https://issuer.example.com",
+          providerType: "oidc",
+          userId: "subject",
+        },
+      ]
 
       await config.doInTenant(async () => {
         await userSdk.db.save(
@@ -1491,6 +1498,7 @@ describe("/api/global/users", () => {
             providerType,
             thirdPartyProfile,
             oauth2,
+            ssoIdentities,
           } as any,
           { requirePassword: false, isAccountHolder: true }
         )
@@ -1511,6 +1519,7 @@ describe("/api/global/users", () => {
       expect(updatedUser.providerType).toBe(undefined)
       expect(updatedUser.thirdPartyProfile).toBe(undefined)
       expect(updatedUser.oauth2).toBe(undefined)
+      expect(updatedUser.ssoIdentities).toBe(undefined)
     })
 
     it("should require internal API headers", async () => {


### PR DESCRIPTION
## Description
_Describe the problem or feature in addition to a link to the relevant github issues._

## Addresses
- `<Enter the Link to the issue(s) this PR addresses>`
- ...more if required

## App Export
- If possible, attach an app export file along with your request template to make QA testing easier, with minimal setup.

## Screenshots
_If a UI facing feature, a short video of the happy path, and some screenshots of the new functionality._

## Launchcontrol

_Add a small description in layman's terms of what this PR achieves. This will be used in the release notes._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OIDC login to safely handle unverified emails and prevent incorrect account linking. Adds issuer-scoped SSO identities and user IDs for reliable user resolution across providers.

- **Bug Fixes**
  - OIDC: Decode `id_token` claims, require matching `sub` across ID token and UserInfo, and use `email_verified` from the token when needed.
  - Email linking: Only link to existing users when the email is verified (or the flag allows it); reject mismatched SSO identities; support migration when a legacy user was linked to the same issuer.
  - Identity model: Persist `ssoIdentities` on users and query via a new CouchDB view `by_sso_identity`; add `SSOIdentity` to `@budibase/types`; omit `ssoIdentities` from API responses and tenant-owner updates.
  - User IDs: Generate deterministic, issuer-scoped SSO user IDs from `[providerType, provider, userId]` (SHA-256), so equal subjects from different issuers produce different users.
  - Tests: Expanded OIDC/SSO tests to cover unverified emails, subject validation, identity linking, and sensitive field stripping.

<sup>Written for commit fa47a37887b6d27d5c137fc9b75331a4db8f1ba9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

