### PR TITLE
Add allowUnverifiedEmailLinking to OIDC validation

### DIFF
--- a/packages/builder/src/settings/pages/auth/index.svelte
+++ b/packages/builder/src/settings/pages/auth/index.svelte
@@ -574,4 +574,8 @@
     display: flex;
     gap: var(--spacing-s);
   }
+
+  .lock :global(.spectrum-FieldLabel) {
+    text-wrap: wrap;
+  }
 </style>

--- a/packages/worker/src/api/routes/global/configs.ts
+++ b/packages/worker/src/api/routes/global/configs.ts
@@ -51,7 +51,8 @@ function oidcValidation() {
         uuid: Joi.string().required(),
         activated: Joi.boolean().required(),
         scopes: Joi.array().optional(),
-        pkce: Joi.string().valid(...Object.values(PKCEMethod)).optional().allow(null)
+        pkce: Joi.string().valid(...Object.values(PKCEMethod)).optional().allow(null),
+        allowUnverifiedEmailLinking: Joi.boolean().optional(),
       })
     ).required()
   }).unknown(true)

--- a/packages/worker/src/api/routes/global/tests/configs.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/configs.spec.ts
@@ -200,6 +200,18 @@ describe("configs", () => {
           )
         })
 
+        it("should preserve allowUnverifiedEmailLinking when set", async () => {
+          await saveConfig(oidc({ allowUnverifiedEmailLinking: true }))
+
+          const conf = await config.api.configs.getConfig(ConfigType.OIDC)
+          expect(conf.config.configs[0].allowUnverifiedEmailLinking).toBe(true)
+
+          await config.doInTenant(async () => {
+            const rawConf = await configs.getOIDCConfig()
+            expect(rawConf!.allowUnverifiedEmailLinking).toBe(true)
+          })
+        })
+
         it("should strip pkce field when null", async () => {
           await saveConfig(oidc({ pkce: null as any }))
 

--- a/packages/worker/src/api/routes/global/tests/configs.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/configs.spec.ts
@@ -200,17 +200,24 @@ describe("configs", () => {
           )
         })
 
-        it("should preserve allowUnverifiedEmailLinking when set", async () => {
-          await saveConfig(oidc({ allowUnverifiedEmailLinking: true }))
+        it.each([true, false])(
+          "should preserve allowUnverifiedEmailLinking when set to %s",
+          async allowUnverifiedEmailLinking => {
+            await saveConfig(oidc({ allowUnverifiedEmailLinking }))
 
-          const conf = await config.api.configs.getConfig(ConfigType.OIDC)
-          expect(conf.config.configs[0].allowUnverifiedEmailLinking).toBe(true)
+            const conf = await config.api.configs.getConfig(ConfigType.OIDC)
+            expect(conf.config.configs[0].allowUnverifiedEmailLinking).toBe(
+              allowUnverifiedEmailLinking
+            )
 
-          await config.doInTenant(async () => {
-            const rawConf = await configs.getOIDCConfig()
-            expect(rawConf!.allowUnverifiedEmailLinking).toBe(true)
-          })
-        })
+            await config.doInTenant(async () => {
+              const rawConf = await configs.getOIDCConfig()
+              expect(rawConf!.allowUnverifiedEmailLinking).toBe(
+                allowUnverifiedEmailLinking
+              )
+            })
+          }
+        )
 
         it("should strip pkce field when null", async () => {
           await saveConfig(oidc({ pkce: null as any }))


### PR DESCRIPTION
## Description
Add allowUnverifiedEmailLinking to OIDC validation

Also, fixing wrapping issues with long labels:
<img width="475" height="307" alt="image" src="https://github.com/user-attachments/assets/c4723482-4ec5-42cd-b0f5-7e6e3a24ec9e" />


## Launchcontrol
Fix OIDC settings validation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow OIDC configs to include `allowUnverifiedEmailLinking` and keep it when saving, fixing validation. Also fixes long label wrapping in auth settings.

- **Bug Fixes**
  - Updated OIDC validation to accept `allowUnverifiedEmailLinking` (boolean) and preserve it in stored configs.
  - Added parameterized tests (true/false) verifying the field is saved and returned by `getOIDCConfig`.
  - Wrapped `.spectrum-FieldLabel` text in the auth settings lock section to prevent overflow.

<sup>Written for commit 9b881073c86a8b08bde80f7cc503701bfc681ad3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



