### PR TITLE
Refactor tenant endpoint access and internalize user lookup

### DIFF
--- a/packages/worker/src/api/index.ts
+++ b/packages/worker/src/api/index.ts
@@ -55,11 +55,6 @@ const PUBLIC_ENDPOINTS = [
   },
   // TODO: This should be an internal api
   {
-    route: "/api/global/users/tenant/:id",
-    method: "GET",
-  },
-  // TODO: This should be an internal api
-  {
     route: "/api/system/restored",
     method: "POST",
   },

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -1203,8 +1203,9 @@ describe("/api/global/users", () => {
         .expect("Content-Type", /json/)
         .expect(200)
 
-      expect(response.body.email).toBe(config.user!.email)
-      expect(response.body._id).toBe(config.user!._id)
+      expect(response.body._id).toBe(config.user!.email)
+      expect(response.body.tenantId).toBe(config.user!.tenantId)
+      expect(response.body.userId).toBe(config.user!._id)
     })
   })
 

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -1184,6 +1184,30 @@ describe("/api/global/users", () => {
     })
   })
 
+  describe("GET /api/global/users/tenant/:id", () => {
+    it("should reject unauthenticated access", async () => {
+      await config.request
+        .get(
+          `/api/global/users/tenant/${encodeURIComponent(config.user!.email)}`
+        )
+        .expect("Content-Type", /json/)
+        .expect(403)
+    })
+
+    it("should allow internal api access", async () => {
+      const response = await config.request
+        .get(
+          `/api/global/users/tenant/${encodeURIComponent(config.user!.email)}`
+        )
+        .set(config.internalAPIHeaders())
+        .expect("Content-Type", /json/)
+        .expect(200)
+
+      expect(response.body.email).toBe(config.user!.email)
+      expect(response.body._id).toBe(config.user!._id)
+    })
+  })
+
   describe("POST /api/global/users/:userId/permission/:role", () => {
     it("should assign CREATOR role and set builder properties", async () => {
       const user = await config.createUser()

--- a/packages/worker/src/api/routes/global/users.ts
+++ b/packages/worker/src/api/routes/global/users.ts
@@ -5,6 +5,7 @@ import {
   adminRoutes,
   builderOrAdminRoutes,
   cloudRestrictedRoutes,
+  internalRoutes,
   loggedInRoutes,
 } from "../endpointGroups"
 import { users } from "../validation"
@@ -136,4 +137,5 @@ loggedInRoutes
     controller.inviteAccept
   )
   .get("/api/global/users/accountholder", controller.accountHolderLookup)
-  .get("/api/global/users/tenant/:id", controller.tenantUserLookup)
+
+internalRoutes.get("/api/global/users/tenant/:id", controller.tenantUserLookup)


### PR DESCRIPTION
## Description
Internalized the tenant user lookup endpoint to fix an access control issue

## Addresses
- https://github.com/Budibase/vulns/issues/76


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized the tenant user lookup endpoint to fix an access control issue. Only internal API calls can GET `/api/global/users/tenant/:id`; public and session-auth access is removed. Addresses vuln-76.

- **Bug Fixes**
  - Removed from `PUBLIC_ENDPOINTS` and moved the route to `internalRoutes` (was under `loggedInRoutes`).
  - Added tests asserting 403 for unauthenticated access and 200 with expected payload for internal requests.

<sup>Written for commit 853414f4e849c145b14ac1d2547c2474b2155618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



