### PR TITLE
fix: include the whole day for date-only 'less than or equal' datetime filters

### DIFF
--- a/packages/shared-core/src/filters.ts
+++ b/packages/shared-core/src/filters.ts
@@ -343,6 +343,23 @@ function buildCondition(filter?: SearchFilter): SearchFilters | undefined {
           return
         }
         if (typeof value === "string") {
+          // For a "less than or equal to" bound the user picks a date, and when
+          // no time is chosen it defaults to the start of the day (midnight).
+          // Comparing against midnight would drop every row later that same day,
+          // so extend a date-only high bound to the end of the day to include
+          // the whole date. See https://github.com/Budibase/budibase/issues/19167
+          if (operator === "rangeHigh") {
+            const startOfDay = value.match(
+              /^(\d{4}-\d{2}-\d{2})(?:T00:00:00(?:\.000)?)?(Z)?$/
+            )
+            if (startOfDay) {
+              // A bare "YYYY-MM-DD" is parsed as UTC, so keep it in UTC by
+              // appending a "Z"; otherwise preserve whatever timezone suffix the
+              // original value used so the offset handling stays unchanged.
+              const suffix = value.length === 10 ? "Z" : startOfDay[2] || ""
+              value = `${startOfDay[1]}T23:59:59.999${suffix}`
+            }
+          }
           value = new Date(value).toISOString()
         } else if (isRangeSearchOperator(operator)) {
           query[operator] ??= {}

--- a/packages/shared-core/src/tests/filters.spec.ts
+++ b/packages/shared-core/src/tests/filters.spec.ts
@@ -155,6 +155,51 @@ describe("filter to query conversion", () => {
   })
 })
 
+describe("date rangeHigh includes the whole day", () => {
+  const highBoundFor = (value: string) => {
+    const query = buildQuery([
+      {
+        field: "dob",
+        type: FieldType.DATETIME,
+        operator: "rangeHigh",
+        value,
+      },
+    ])
+    return query.$and!.conditions![0].$and!.conditions![0].range!.dob.high
+  }
+
+  it("extends a date-only (midnight) high bound to the end of that day", () => {
+    expect(highBoundFor("2020-01-05")).toEqual("2020-01-05T23:59:59.999Z")
+    expect(highBoundFor("2020-01-05T00:00:00.000Z")).toEqual(
+      "2020-01-05T23:59:59.999Z"
+    )
+  })
+
+  it("leaves a high bound with an explicit time untouched", () => {
+    expect(highBoundFor("2020-01-05T14:30:00.000Z")).toEqual(
+      "2020-01-05T14:30:00.000Z"
+    )
+  })
+
+  it("matches rows from later in the target day", () => {
+    const docs = [
+      { id: 1, dob: "2020-01-05T00:00:00.000Z" },
+      { id: 2, dob: "2020-01-05T23:59:00.000Z" },
+      { id: 3, dob: "2020-01-06T00:01:00.000Z" },
+    ]
+    const query = buildQuery([
+      {
+        field: "dob",
+        type: FieldType.DATETIME,
+        operator: "rangeHigh",
+        value: "2020-01-05",
+      },
+    ])
+    const result = runQuery(docs, query)
+    expect(result.map(d => d.id)).toEqual([1, 2])
+  })
+})
+
 describe("runQuery notOneOf", () => {
   const docs = [
     { id: 1, name: "foo" },


### PR DESCRIPTION
## Description

Fixes #19167

When filtering a **datetime** column with a **"less than or equal to"** (`rangeHigh`) filter, selecting a date with no time returns almost nothing: only rows at exactly `00:00` on that day are matched. Everything later that same day is excluded.

### Root cause

A date-only selection in a filter arrives as the **start** of the day (midnight). For a datetime column the server compares timestamps directly, so `column <= 2026-07-18T00:00:00` correctly excludes `2026-07-18T00:01`, `2026-07-18T17:30`, etc. — even though the user asked for everything *on or before the 18th*.

### Fix

In `buildCondition` (`packages/shared-core/src/filters.ts`), when a `rangeHigh` bound on a `DATETIME` field has no explicit time (a bare `YYYY-MM-DD`, or midnight `T00:00:00(.000)` with or without a `Z`), extend it to the **end of that day** (`23:59:59.999`) before it becomes the query bound. This gives the server a proper upper-bound time so the whole date is included, which is what the maintainers noted a `DATETIME` filter needs.

Bounds that carry a real time (e.g. `14:30`) are left untouched, and the low bound is unaffected. A bare `YYYY-MM-DD` is kept in UTC (it is parsed as UTC by `new Date`), while values that already carry a timezone suffix keep it, so existing offset handling is preserved.

### How I verified

- Added unit tests in `packages/shared-core/src/tests/filters.spec.ts`:
  - a midnight / date-only `rangeHigh` bound is extended to `…T23:59:59.999Z`,
  - a bound with an explicit time is left unchanged,
  - an end-to-end `runQuery` check confirming rows from later in the target day now match.
- Verified the transform is timezone-independent by running the value conversion under `UTC`, `America/New_York`, `Asia/Kolkata` and `Australia/Sydney` — the midnight/date-only cases all normalise to `2026-…T23:59:59.999Z` and explicit-time bounds are unchanged.

> Note: this reopens the fix discussed in #19171. That earlier attempt keyed on midnight after the issue was first triaged; here the change is scoped so it only fires for genuinely time-less selections and supplies the end-of-day time the server needs, in line with @mikesealey's follow-up on #19167.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes date-only "less than or equal" filters on DATETIME fields so the entire selected day is included. Date-only upper bounds are expanded to 23:59:59.999 before building the query.

- **Bug Fixes**
  - In `buildCondition`, extend `rangeHigh` date-only values (`YYYY-MM-DD` or midnight) to `23:59:59.999`; keep explicit-time bounds unchanged and preserve existing timezone behavior.
  - Added unit tests to verify the transform and confirm rows later in the selected day now match.

<sup>Written for commit f66e9c9b9ac162964d2daa77eb91fea6dba5b8bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

