### PR TITLE
fix: block unvouched pull requests

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -20,3 +20,4 @@ samwho
 aptkingston
 mike12345567
 shogunpurple
+-zzhzhangzhihao

--- a/.github/workflows/vouched.yml
+++ b/.github/workflows/vouched.yml
@@ -12,6 +12,14 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: mitchellh/vouch/action/check-pr@f44860978966ace98fb11aaaa20f2b27d7543e13
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          require-vouch: false
+          auto-close: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: mitchellh/vouch/action/check-user@f44860978966ace98fb11aaaa20f2b27d7543e13
         with:
           user: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/vouched.yml
+++ b/.github/workflows/vouched.yml
@@ -1,20 +1,20 @@
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
   issue_comment:
     types: [created]
 
 jobs:
-  check:
+  vouch-check:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
     steps:
-      - uses: mitchellh/vouch/action/check-pr@f44860978966ace98fb11aaaa20f2b27d7543e13
+      - uses: mitchellh/vouch/action/check-user@f44860978966ace98fb11aaaa20f2b27d7543e13
         with:
-          pr-number: ${{ github.event.pull_request.number }}
+          user: ${{ github.event.pull_request.user.login }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- make the vouch check fail for unvouched or denounced PR authors
- rerun the check when the PR head changes

## Testing
- git diff --check
- push hook lint:fix:changed passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block merges from unvouched or denounced PR authors by failing the Vouch check. Auto-close only denounced PRs; re-run on new commits.

- **Bug Fixes**
  - Update workflow: rename job to `vouch-check`, add `synchronize`, use `mitchellh/vouch/action/check-pr` with `require-vouch: false` and `auto-close: true`, and add `mitchellh/vouch/action/check-user` to fail unvouched/denounced authors.
  - Denounce `zzhzhangzhihao` in `.github/VOUCHED.td`.

<sup>Written for commit 0c13c23e3a1dca48189a40191ef83301c112df67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

