### PR TITLE
Fix vouch check rerun after status changes

### DIFF
--- a/.github/workflows/vouched.yml
+++ b/.github/workflows/vouched.yml
@@ -33,13 +33,16 @@ jobs:
       group: vouch-manage
       cancel-in-progress: false
     permissions:
+      actions: write
+      checks: read
       contents: write
       issues: write
       pull-requests: read
     steps:
       - uses: actions/checkout@v4
 
-      - uses: mitchellh/vouch/action/manage-by-issue@f44860978966ace98fb11aaaa20f2b27d7543e13
+      - id: manage
+        uses: mitchellh/vouch/action/manage-by-issue@f44860978966ace98fb11aaaa20f2b27d7543e13
         with:
           repo: ${{ github.repository }}
           issue-id: ${{ github.event.issue.number }}
@@ -49,3 +52,20 @@ jobs:
           allow-unvouch: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Re-run vouch check
+        if: steps.manage.outputs.status == 'vouched' || steps.manage.outputs.status == 'denounced'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          head_sha=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" --jq '.head.sha')
+          run_id=$(
+            gh api "repos/$REPOSITORY/commits/$head_sha/check-runs" \
+              --jq '[.check_runs[] | select(.name == "vouch-check" and .conclusion == "failure")] | sort_by(.started_at) | last | .details_url? | select(.) | capture("/actions/runs/(?<id>[0-9]+)").id'
+          )
+
+          if [ -n "$run_id" ]; then
+            gh run rerun "$run_id" --failed --repo "$REPOSITORY"
+          fi


### PR DESCRIPTION
## Description
When a contributor is vouched or denounced from a pull request comment, the VOUCHED list changes but the existing required vouch-check remains attached to the pull request head commit with its previous result.

The manage job now uses its status output to detect successful vouch state changes, finds the latest failed vouch-check on the commented pull request head SHA, and reruns the failed Actions run.

The run script is necessary because an issue_comment workflow runs against the default branch. Running check-user directly from that workflow would attach its result to the default-branch SHA and would not replace the required failed check on the pull request commit. Rerunning the original pull_request_target run preserves the correct pull request and head-SHA association.

The rerun only occurs after manage reports vouched or denounced, and is a no-op when no failed vouch-check exists. The required vouch-check remains in place, so an unvouched contributor cannot merge.


## Summary by cubic
Automatically re-runs the PR vouch check when a maintainer vouches or denounces via comment, so the required check reflects the new status on the PR’s head commit. Prevents stale failed checks from blocking merges.

- Bug Fixes
  - Capture manage step output and rerun only when status is `vouched` or `denounced`.
  - Add `actions: write` and `checks: read` permissions to rerun checks.
  - Use `gh` to find the latest failed `vouch-check` on the PR head SHA and rerun it, preserving PR/SHA association; no-op if none.

<sup>Written for commit fdf3e44cb04a7ec0c5ef2b5d1ff422bf6d3494f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

