### PR TITLE
[GHSA-mqhr-6j6h-74p5] Enforce same-origin check for REST datasource requests

### DIFF
--- a/packages/backend-core/src/utils/outboundFetch.ts
+++ b/packages/backend-core/src/utils/outboundFetch.ts
@@ -136,6 +136,7 @@ interface FetchWithBlacklistOptions<
 > {
   followRedirects?: boolean
   returnRedirectWithoutLocation?: boolean
+  rejectCrossOriginRedirects?: boolean
   fetchFn?: (
     url: string,
     request: RedirectSafeRequest<TRequest>,
@@ -177,6 +178,7 @@ export async function fetchWithBlacklist<
   {
     followRedirects = true,
     returnRedirectWithoutLocation = false,
+    rejectCrossOriginRedirects = false,
     fetchFn = fetch as unknown as (
       url: string,
       request: RedirectSafeRequest<TRequest>,
@@ -239,6 +241,9 @@ export async function fetchWithBlacklist<
     ).toString()
     nextRequest = nextRequestForRedirect(nextRequest, response.status)
     if (shouldStripSensitiveHeadersForRedirect(nextUrl, redirectUrl)) {
+      if (rejectCrossOriginRedirects) {
+        throw new Error("Redirect to a different origin is not permitted.")
+      }
       nextRequest = stripSensitiveHeadersForRedirect(nextRequest)
     }
     nextUrl = redirectUrl

--- a/packages/backend-core/src/utils/tests/outboundFetch.spec.ts
+++ b/packages/backend-core/src/utils/tests/outboundFetch.spec.ts
@@ -485,6 +485,56 @@ describe("outboundFetch", () => {
     expect(secondCallHeaders.get("authorization")).toBe("Bearer token")
   })
 
+  it("rejects a cross-origin redirect when rejectCrossOriginRedirects is true", async () => {
+    isBlacklistedMock.mockResolvedValue(false)
+    const resume = jest.fn()
+
+    fetchMock.mockResolvedValueOnce({
+      status: 302,
+      headers: {
+        get: jest.fn().mockReturnValue("https://leak.budibase.com/final"),
+      },
+      body: { resume },
+    } as any)
+
+    await expect(
+      fetchWithBlacklist("https://budibase.com/resource", undefined, {
+        rejectCrossOriginRedirects: true,
+      })
+    ).rejects.toThrow("Redirect to a different origin is not permitted.")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("still follows a same-origin redirect when rejectCrossOriginRedirects is true", async () => {
+    isBlacklistedMock.mockResolvedValue(false)
+    const resume = jest.fn()
+
+    fetchMock
+      .mockResolvedValueOnce({
+        status: 302,
+        headers: {
+          get: jest
+            .fn()
+            .mockReturnValue("https://budibase.com/same-origin-path"),
+        },
+        body: { resume },
+      } as any)
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        headers: { get: jest.fn() },
+      } as any)
+
+    const response = await fetchWithBlacklist(
+      "https://budibase.com/resource",
+      undefined,
+      { rejectCrossOriginRedirects: true }
+    )
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
   // ─── Pinned lookup ────────────────────────────────────────────────────────
 
   describe("createPinnedLookup", () => {

--- a/packages/server/src/api/routes/tests/queries/rest.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/rest.spec.ts
@@ -6,6 +6,7 @@ import {
   OAuth2CredentialsMethod,
   OAuth2GrantType,
   RestAuthType,
+  RestQueryFields,
   SourceName,
 } from "@budibase/types"
 import nock from "nock"
@@ -15,6 +16,7 @@ import { generator, mocks } from "@budibase/backend-core/tests"
 import type { MockAgent } from "undici"
 import { setEnv as setServerEnv } from "../../../../environment"
 import { installHttpMocking, resetHttpMocking } from "../../../../tests/jestEnv"
+import { Expectations } from "../../../../tests/utilities/api/base"
 
 describe("rest", () => {
   let config: TestConfiguration
@@ -958,6 +960,145 @@ describe("rest", () => {
         path: "www.example.com",
         queryString: "emptyParam1={{emptyParam1}}&emptyParam2={{emptyParam2}}",
       },
+    })
+  })
+
+  describe("origin validation", () => {
+    const originError: Expectations = {
+      status: 400,
+      body: {
+        message: "REST query path must remain on the datasource origin",
+      },
+    }
+
+    const createRestDatasource = (dsConfig: Record<string, any>) =>
+      config.api.datasource.create({
+        name: generator.guid(),
+        type: "test",
+        source: SourceName.REST,
+        config: dsConfig,
+      })
+
+    const mockOkOnBudibaseCom = () =>
+      mockAgent!
+        .get("http://budibase.com")
+        .intercept({ path: "/data", method: "GET" })
+        .reply(200, { ok: true }, { headers: jsonHeaders })
+
+    const previewPath = ({
+      datasourceId,
+      fields,
+      parameters = [],
+      expectations,
+    }: {
+      datasourceId: string
+      fields: RestQueryFields
+      parameters?: { name: string; default: string }[]
+      expectations?: Expectations
+    }) =>
+      config.api.query.preview(
+        {
+          datasourceId,
+          name: generator.guid(),
+          parameters,
+          queryVerb: "read",
+          transformer: "",
+          schema: {},
+          readable: true,
+          fields,
+        },
+        expectations
+      )
+
+    it("should allow a relative path on the same origin as the datasource base URL", async () => {
+      const ds = await createRestDatasource({ url: "http://budibase.com" })
+      mockOkOnBudibaseCom()
+
+      await previewPath({ datasourceId: ds._id!, fields: { path: "data" } })
+    })
+
+    it("should allow an absolute path that resolves to the same origin as the datasource base URL", async () => {
+      const ds = await createRestDatasource({ url: "http://budibase.com" })
+      mockOkOnBudibaseCom()
+
+      await previewPath({
+        datasourceId: ds._id!,
+        fields: { path: "http://budibase.com/data" },
+      })
+    })
+
+    it("should reject an absolute path pointing to a different host than the datasource base URL", async () => {
+      const ds = await createRestDatasource({ url: "http://budibase.com" })
+
+      await previewPath({
+        datasourceId: ds._id!,
+        fields: { path: "http://leak.budibase.com/data" },
+        expectations: originError,
+      })
+    })
+
+    it("should reject a parameterized path that resolves to a different host than the datasource base URL, without leaking datasource credentials", async () => {
+      const ds = await createRestDatasource({
+        url: "http://budibase.com",
+        defaultHeaders: { "X-Static-Secret": "STATIC_HDR_LEAK" },
+        authConfigs: [
+          {
+            _id: generator.guid(),
+            name: "Bearer",
+            type: RestAuthType.BEARER,
+            config: { token: "unauth-leak-token" },
+          },
+        ],
+      })
+
+      await previewPath({
+        datasourceId: ds._id!,
+        fields: { path: "{{ t }}" },
+        parameters: [{ name: "t", default: "http://leak.budibase.com/data" }],
+        expectations: originError,
+      })
+    })
+
+    it("should treat a different port as a different origin", async () => {
+      const ds = await createRestDatasource({
+        url: "http://budibase.com:8080",
+      })
+
+      await previewPath({
+        datasourceId: ds._id!,
+        fields: { path: "{{ t }}" },
+        parameters: [{ name: "t", default: "http://budibase.com:9090/data" }],
+        expectations: originError,
+      })
+    })
+
+    it("should treat a different scheme as a different origin", async () => {
+      const ds = await createRestDatasource({ url: "http://budibase.com" })
+
+      await previewPath({
+        datasourceId: ds._id!,
+        fields: { path: "{{ t }}" },
+        parameters: [{ name: "t", default: "https://budibase.com/data" }],
+        expectations: originError,
+      })
+    })
+
+    it("should reject cross-origin requests even when the datasource base URL has no scheme", async () => {
+      const ds = await createRestDatasource({ url: "budibase.com" })
+
+      await previewPath({
+        datasourceId: ds._id!,
+        fields: { path: "{{ t }}" },
+        parameters: [{ name: "t", default: "http://leak.budibase.com/data" }],
+        expectations: originError,
+      })
+    })
+
+    it("should still allow same-origin requests when the datasource base URL has no scheme", async () => {
+      const ds = await createRestDatasource({ url: "budibase.com" })
+      mockOkOnBudibaseCom()
+
+      await previewPath({ datasourceId: ds._id!, fields: { path: "data" } })
     })
   })
 

--- a/packages/server/src/api/routes/tests/queries/rest.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/rest.spec.ts
@@ -1100,6 +1100,56 @@ describe("rest", () => {
 
       await previewPath({ datasourceId: ds._id!, fields: { path: "data" } })
     })
+
+    it("should reject a same-origin request that redirects to a different origin, without leaking datasource credentials", async () => {
+      const ds = await createRestDatasource({
+        url: "http://budibase.com",
+        defaultHeaders: { "X-Static-Secret": "STATIC_HDR_LEAK" },
+        authConfigs: [
+          {
+            _id: generator.guid(),
+            name: "Bearer",
+            type: RestAuthType.BEARER,
+            config: { token: "unauth-leak-token" },
+          },
+        ],
+      })
+
+      mockAgent!
+        .get("http://budibase.com")
+        .intercept({ path: "/data", method: "GET" })
+        .reply(302, undefined, {
+          headers: { location: "http://leak.budibase.com/data" },
+        })
+
+      await previewPath({
+        datasourceId: ds._id!,
+        fields: { path: "data" },
+        expectations: {
+          status: 400,
+          body: {
+            message: "Redirect to a different origin is not permitted.",
+          },
+        },
+      })
+    })
+
+    it("should allow a same-origin redirect to succeed", async () => {
+      const ds = await createRestDatasource({ url: "http://budibase.com" })
+
+      mockAgent!
+        .get("http://budibase.com")
+        .intercept({ path: "/data", method: "GET" })
+        .reply(302, undefined, {
+          headers: { location: "http://budibase.com/data-final" },
+        })
+      mockAgent!
+        .get("http://budibase.com")
+        .intercept({ path: "/data-final", method: "GET" })
+        .reply(200, { ok: true }, { headers: jsonHeaders })
+
+      await previewPath({ datasourceId: ds._id!, fields: { path: "data" } })
+    })
   })
 
   describe("datasource auth and connection properties", () => {

--- a/packages/server/src/api/routes/tests/queries/rest.spec.ts
+++ b/packages/server/src/api/routes/tests/queries/rest.spec.ts
@@ -985,6 +985,29 @@ describe("rest", () => {
         .intercept({ path: "/data", method: "GET" })
         .reply(200, { ok: true }, { headers: jsonHeaders })
 
+    const SECRET_HEADER_VALUE = "STATIC_HDR_LEAK"
+    const SECRET_TOKEN_VALUE = "unauth-leak-token"
+
+    const createRestDatasourceWithSecrets = () =>
+      createRestDatasource({
+        url: "http://budibase.com",
+        defaultHeaders: { "X-Static-Secret": SECRET_HEADER_VALUE },
+        authConfigs: [
+          {
+            _id: generator.guid(),
+            name: "Bearer",
+            type: RestAuthType.BEARER,
+            config: { token: SECRET_TOKEN_VALUE },
+          },
+        ],
+      })
+
+    const expectNoLeakedSecrets = (result: unknown) => {
+      const serialized = JSON.stringify(result)
+      expect(serialized).not.toContain(SECRET_HEADER_VALUE)
+      expect(serialized).not.toContain(SECRET_TOKEN_VALUE)
+    }
+
     const previewPath = ({
       datasourceId,
       fields,
@@ -1038,25 +1061,16 @@ describe("rest", () => {
     })
 
     it("should reject a parameterized path that resolves to a different host than the datasource base URL, without leaking datasource credentials", async () => {
-      const ds = await createRestDatasource({
-        url: "http://budibase.com",
-        defaultHeaders: { "X-Static-Secret": "STATIC_HDR_LEAK" },
-        authConfigs: [
-          {
-            _id: generator.guid(),
-            name: "Bearer",
-            type: RestAuthType.BEARER,
-            config: { token: "unauth-leak-token" },
-          },
-        ],
-      })
+      const ds = await createRestDatasourceWithSecrets()
 
-      await previewPath({
+      const result = await previewPath({
         datasourceId: ds._id!,
         fields: { path: "{{ t }}" },
         parameters: [{ name: "t", default: "http://leak.budibase.com/data" }],
         expectations: originError,
       })
+
+      expectNoLeakedSecrets(result)
     })
 
     it("should treat a different port as a different origin", async () => {
@@ -1102,18 +1116,7 @@ describe("rest", () => {
     })
 
     it("should reject a same-origin request that redirects to a different origin, without leaking datasource credentials", async () => {
-      const ds = await createRestDatasource({
-        url: "http://budibase.com",
-        defaultHeaders: { "X-Static-Secret": "STATIC_HDR_LEAK" },
-        authConfigs: [
-          {
-            _id: generator.guid(),
-            name: "Bearer",
-            type: RestAuthType.BEARER,
-            config: { token: "unauth-leak-token" },
-          },
-        ],
-      })
+      const ds = await createRestDatasourceWithSecrets()
 
       mockAgent!
         .get("http://budibase.com")
@@ -1122,7 +1125,7 @@ describe("rest", () => {
           headers: { location: "http://leak.budibase.com/data" },
         })
 
-      await previewPath({
+      const result = await previewPath({
         datasourceId: ds._id!,
         fields: { path: "data" },
         expectations: {
@@ -1132,6 +1135,8 @@ describe("rest", () => {
           },
         },
       })
+
+      expectNoLeakedSecrets(result)
     })
 
     it("should allow a same-origin redirect to succeed", async () => {

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -669,8 +669,6 @@ export class RestIntegration implements IntegrationBase {
   private assertSameOrigin(url: string, rawPath: string | undefined) {
     const finalOrigin = this.getOrigin(url)
 
-    // queryString/pagination never affect the origin (only path and
-    // this.config.url do), so they're irrelevant here.
     const expectedOriginUrls: string[] = []
     if (this.config.url) {
       expectedOriginUrls.push(this.getUrl())

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -799,6 +799,7 @@ export class RestIntegration implements IntegrationBase {
         url,
         input,
         {
+          rejectCrossOriginRedirects: true,
           fetchFn: async (
             requestUrl: string,
             requestInput: RequestInit,

--- a/packages/server/src/integrations/rest.ts
+++ b/packages/server/src/integrations/rest.ts
@@ -347,8 +347,8 @@ export class RestIntegration implements IntegrationBase {
   }
 
   getUrl(
-    path: string,
-    queryString: string,
+    path = "",
+    queryString = "",
     pagination?: PaginationConfig,
     paginationValues?: PaginationValues
   ): string {
@@ -657,10 +657,41 @@ export class RestIntegration implements IntegrationBase {
     return this.buildHeadersFromAuthConfig(resolved.auth)
   }
 
+  private getOrigin(urlString: string): string | null {
+    try {
+      const parsed = new URL(urlString)
+      return `${parsed.protocol}//${parsed.host}`
+    } catch {
+      return null
+    }
+  }
+
+  private assertSameOrigin(url: string, rawPath: string | undefined) {
+    const finalOrigin = this.getOrigin(url)
+
+    // queryString/pagination never affect the origin (only path and
+    // this.config.url do), so they're irrelevant here.
+    const expectedOriginUrls: string[] = []
+    if (this.config.url) {
+      expectedOriginUrls.push(this.getUrl())
+    }
+    if (rawPath !== undefined) {
+      expectedOriginUrls.push(this.getUrl(rawPath))
+    }
+
+    const isCrossOrigin = expectedOriginUrls.some(
+      expectedUrl => this.getOrigin(expectedUrl) !== finalOrigin
+    )
+    if (isCrossOrigin) {
+      throw new Error("REST query path must remain on the datasource origin")
+    }
+  }
+
   async _req(query: RestQuery, retry401 = true): Promise<ParsedResponse> {
     const {
       path = "",
       queryString = "",
+      rawPath,
       headers = {},
       method = HttpMethod.GET,
       disabledHeaders,
@@ -671,6 +702,27 @@ export class RestIntegration implements IntegrationBase {
       pagination,
       paginationValues,
     } = query
+
+    const defaultQueryParameters = this.config.defaultQueryParameters || {}
+    let mergedQueryString = queryString
+    if (Object.keys(defaultQueryParameters).length > 0) {
+      const queryParams = queryString ? qs.decode(queryString) : {}
+      const merged = { ...defaultQueryParameters, ...queryParams }
+      mergedQueryString = qs.encode(merged)
+    }
+
+    this.startTimeMs = performance.now()
+    const url = this.getUrl(
+      path,
+      mergedQueryString,
+      pagination,
+      paginationValues
+    )
+
+    // Resolve and validate the destination BEFORE attaching any
+    // datasource-scoped credentials or headers below.
+    this.assertSameOrigin(url, rawPath)
+
     const authHeaders = await this.getAuthHeaders(authConfigId, authConfigType)
 
     this.headers = {
@@ -706,22 +758,6 @@ export class RestIntegration implements IntegrationBase {
       // @ts-ignore
       input.extraHttpOptions = { insecureHTTPParser: true }
     }
-
-    const defaultQueryParameters = this.config.defaultQueryParameters || {}
-    let mergedQueryString = queryString
-    if (Object.keys(defaultQueryParameters).length > 0) {
-      const queryParams = queryString ? qs.decode(queryString) : {}
-      const merged = { ...defaultQueryParameters, ...queryParams }
-      mergedQueryString = qs.encode(merged)
-    }
-
-    this.startTimeMs = performance.now()
-    const url = this.getUrl(
-      path,
-      mergedQueryString,
-      pagination,
-      paginationValues
-    )
 
     // Configure dispatcher for proxy and/or TLS settings
     // Use datasource config if set, otherwise fall back to environment variable

--- a/packages/server/src/integrations/tests/rest.spec.ts
+++ b/packages/server/src/integrations/tests/rest.spec.ts
@@ -230,7 +230,7 @@ describe("REST Integration", () => {
     expect(data).toEqual({ foo: "bar" })
   })
 
-  it("validates redirect targets against the outbound blacklist", async () => {
+  it("rejects a redirect to a different origin, even when the target is otherwise blacklisted", async () => {
     queueResponse(async (url, options) => {
       expect(url).toEqual("https://example.com/redirect")
       expect(options?.redirect).toEqual("manual")
@@ -241,7 +241,7 @@ describe("REST Integration", () => {
     })
 
     await expect(integration.read({ path: "redirect" })).rejects.toThrow(
-      "URL is blocked or could not be resolved safely."
+      "Redirect to a different origin is not permitted."
     )
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })

--- a/packages/server/src/threads/query.ts
+++ b/packages/server/src/threads/query.ts
@@ -190,7 +190,11 @@ class QueryRunner {
         }
       )
     } else {
+      const rawPath = fieldsClone.path
       query = await sdk.queries.enrichContext(fieldsClone, enrichedContext)
+      if (datasourceClone.source === SourceName.REST) {
+        query.rawPath = rawPath
+      }
     }
     // Add pagination values for REST queries
     if (this.pagination) {

--- a/packages/types/src/documents/workspace/query.ts
+++ b/packages/types/src/documents/workspace/query.ts
@@ -84,6 +84,8 @@ export enum BodyType {
 
 export interface RestQueryFields {
   path?: string
+  // Path as saved on the query, before parameter substitution.
+  rawPath?: string
   queryString?: string
   headers?: { [key: string]: any }
   disabledHeaders?: { [key: string]: any }


### PR DESCRIPTION
## Addresses
- https://github.com/Budibase/budibase/security/advisories/GHSA-mqhr-6j6h-74p5

## Description
REST datasource credentials (auth headers, `defaultHeaders`) were being attached to outgoing requests before the final request destination was validated against the datasource's configured origin. A query's `path` field, whether a literal absolute URL or a parameter resolved at runtime (e.g. `{{ t }}`), could point to an attacker-controlled host, causing stored credentials to be sent off-origin. If the query was granted `PUBLIC` access on a published app, this was exploitable by an unauthenticated request.

`RestIntegration` now resolves the final request URL and validates its origin against the datasource's base URL, and against the query's pre-enrichment path, before building auth/default headers. The request is rejected if either check fails.

## Launchcontrol
Fixes a security issue where a REST datasource's stored credentials (API keys, tokens, custom headers) could be exfiltrated to an attacker-controlled host by manipulating the request path of a query.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a same-origin check for REST datasource requests and blocks cross-origin redirects, so credentials never leave the configured origin. Fixes GHSA-mqhr-6j6h-74p5 by resolving the final URL (including default query params) and validating its origin before any auth/default headers are added.

- **Bug Fixes**
  - `RestIntegration` resolves the final URL, compares its origin to the datasource base URL and the query’s pre-enrichment `rawPath`, and rejects cross-origin requests with a 400 error (“REST query path must remain on the datasource origin”).
  - Apply auth headers and `defaultHeaders` only after origin validation to prevent leaks.
  - Add `rawPath` to `RestQueryFields` and set it via `QueryRunner`; tests cover absolute/relative paths, scheme/port changes, parameterized paths, base URLs without a scheme, same-origin redirects, and assert no credential leakage on rejection.
  - Reject cross-origin redirects: `fetchWithBlacklist` adds `rejectCrossOriginRedirects`; `RestIntegration` enables it so redirects to another origin fail with 400 (“Redirect to a different origin is not permitted.”).

<sup>Written for commit 7bef050de0b9679890bda186970dc9a4c215c74c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



