### PR TITLE
Improve worker routing

### DIFF
--- a/packages/backend-core/src/Endpoint/EndpointGroup.ts
+++ b/packages/backend-core/src/Endpoint/EndpointGroup.ts
@@ -1,7 +1,13 @@
 import Endpoint, { CtxFn, Method } from "./Endpoint"
 import Router from "@koa/router"
+import type { EndpointMatcher } from "@budibase/types"
 
 type ArrayOneOrMore<T> = [T, ...T[]]
+
+export interface EndpointGroupOptions {
+  public?: boolean
+  noTenancy?: boolean
+}
 
 export default class EndpointGroup {
   endpoints: Endpoint[] = []
@@ -10,6 +16,11 @@ export default class EndpointGroup {
   applied = false
   // if locked, can't add anymore middlewares
   private locked = false
+  private options: EndpointGroupOptions
+
+  constructor(options: EndpointGroupOptions = {}) {
+    this.options = options
+  }
 
   addGroupMiddleware(
     middleware: CtxFn,
@@ -98,5 +109,20 @@ export default class EndpointGroup {
       )
     }
     return this.endpoints
+  }
+
+  endpointMatchers(options: EndpointGroupOptions): EndpointMatcher[] {
+    if (
+      (options.public !== undefined &&
+        options.public !== this.options.public) ||
+      (options.noTenancy !== undefined &&
+        options.noTenancy !== this.options.noTenancy)
+    ) {
+      return []
+    }
+    return this.endpoints.map(endpoint => ({
+      route: endpoint.url,
+      method: endpoint.method.toUpperCase(),
+    }))
   }
 }

--- a/packages/backend-core/src/Endpoint/EndpointGroupList.ts
+++ b/packages/backend-core/src/Endpoint/EndpointGroupList.ts
@@ -1,10 +1,33 @@
 import { EndpointGroup, CtxFn } from "./"
+import type { EndpointGroupOptions } from "./EndpointGroup"
+import type { EndpointMatcher } from "@budibase/types"
+
+type GroupMiddleware = CtxFn | { middleware: CtxFn; first: boolean }
 
 export default class EndpointGroupList {
   private groups: EndpointGroup[] = []
 
-  group(...middlewares: (CtxFn | { middleware: CtxFn; first: boolean })[]) {
-    const group = new EndpointGroup()
+  group(...args: GroupMiddleware[]): EndpointGroup
+  group(
+    options: EndpointGroupOptions,
+    ...middlewares: GroupMiddleware[]
+  ): EndpointGroup
+  group(
+    optionsOrMiddleware?: EndpointGroupOptions | GroupMiddleware,
+    ...remainingMiddlewares: GroupMiddleware[]
+  ) {
+    const isOptions =
+      optionsOrMiddleware &&
+      typeof optionsOrMiddleware === "object" &&
+      !("middleware" in optionsOrMiddleware) &&
+      ("public" in optionsOrMiddleware || "noTenancy" in optionsOrMiddleware)
+    const options = isOptions ? optionsOrMiddleware : {}
+    const middlewares = isOptions
+      ? remainingMiddlewares
+      : [optionsOrMiddleware, ...remainingMiddlewares].filter(
+          (middleware): middleware is GroupMiddleware => !!middleware
+        )
+    const group = new EndpointGroup(options)
     if (middlewares.length) {
       middlewares.forEach(middleware => {
         if ("first" in middleware) {
@@ -38,5 +61,9 @@ export default class EndpointGroupList {
     }
 
     return [...staticEndpoints, ...parameterizedEndpoints]
+  }
+
+  endpointMatchers(options: EndpointGroupOptions): EndpointMatcher[] {
+    return this.groups.flatMap(group => group.endpointMatchers(options))
   }
 }

--- a/packages/backend-core/src/Endpoint/index.ts
+++ b/packages/backend-core/src/Endpoint/index.ts
@@ -1,3 +1,6 @@
 export { default as Endpoint, type Method, type CtxFn } from "./Endpoint"
-export { default as EndpointGroup } from "./EndpointGroup"
+export {
+  default as EndpointGroup,
+  type EndpointGroupOptions,
+} from "./EndpointGroup"
 export { default as EndpointGroupList } from "./EndpointGroupList"

--- a/packages/backend-core/src/Endpoint/tests/EndpointGroupList.spec.ts
+++ b/packages/backend-core/src/Endpoint/tests/EndpointGroupList.spec.ts
@@ -1,0 +1,25 @@
+import EndpointGroupList from "../EndpointGroupList"
+
+describe("EndpointGroupList", () => {
+  it("returns matchers for groups with matching route policy", () => {
+    const groups = new EndpointGroupList()
+    const publicRoutes = groups.group({ public: true })
+    const publicNoTenancyRoutes = groups.group({
+      public: true,
+      noTenancy: true,
+    })
+    const loggedInRoutes = groups.group()
+
+    publicRoutes.get("/api/public", () => {})
+    publicNoTenancyRoutes.post("/api/public/no-tenancy", () => {})
+    loggedInRoutes.get("/api/private", () => {})
+
+    expect(groups.endpointMatchers({ public: true })).toEqual([
+      { route: "/api/public", method: "GET" },
+      { route: "/api/public/no-tenancy", method: "POST" },
+    ])
+    expect(groups.endpointMatchers({ noTenancy: true })).toEqual([
+      { route: "/api/public/no-tenancy", method: "POST" },
+    ])
+  })
+})

--- a/packages/worker/src/api/index.ts
+++ b/packages/worker/src/api/index.ts
@@ -4,65 +4,11 @@ const compress = require("koa-compress")
 
 import zlib from "zlib"
 import { routes } from "./routes"
+import { endpointGroupList } from "./routes/endpointGroups"
 import { middleware as pro } from "@budibase/pro"
 import { auth, middleware } from "@budibase/backend-core"
 
-const PUBLIC_ENDPOINTS = [
-  // deprecated single tenant sso callback
-  {
-    route: "/api/admin/auth/google/callback",
-    method: "GET",
-  },
-  // deprecated single tenant sso callback
-  {
-    route: "/api/admin/auth/oidc/callback",
-    method: "GET",
-  },
-  {
-    // this covers all of the POST auth routes
-    route: "/api/global/auth/:tenantId",
-    method: "POST",
-  },
-  {
-    // this covers all of the GET auth routes
-    route: "/api/global/auth/:tenantId",
-    method: "GET",
-  },
-  {
-    // this covers all of the public config routes
-    route: "/api/global/configs/public",
-    method: "GET",
-  },
-  {
-    route: "/api/global/configs/checklist",
-    method: "GET",
-  },
-  {
-    route: "/api/global/users/init",
-    method: "POST",
-  },
-  {
-    route: "/api/global/users/invite/accept",
-    method: "POST",
-  },
-  {
-    route: "/api/system/environment",
-    method: "GET",
-  },
-  {
-    route: "/api/system/status",
-    method: "GET",
-  },
-  // TODO: This should be an internal api
-  {
-    route: "/api/system/restored",
-    method: "POST",
-  },
-  {
-    route: "/api/global/users/invite",
-    method: "GET",
-  },
-]
+const publicEndpoints = endpointGroupList.endpointMatchers({ public: true })
 
 const ALLOW_INACTIVE_TENANT_ENDPOINTS = [
   {
@@ -71,62 +17,9 @@ const ALLOW_INACTIVE_TENANT_ENDPOINTS = [
   },
 ]
 
-const NO_TENANCY_ENDPOINTS = [
-  // system endpoints are not specific to any tenant
-  {
-    route: "/api/system",
-    method: "ALL",
-  },
-  // tenant is determined in request body
-  // used for creating the tenant
-  {
-    route: "/api/global/users/init",
-    method: "POST",
-  },
-  // tenant is retrieved from the user found by the requested email
-  {
-    route: "/api/global/users/sso",
-    method: "POST",
-  },
-  // deprecated single tenant sso callback
-  {
-    route: "/api/admin/auth/google/callback",
-    method: "GET",
-  },
-  // deprecated single tenant sso callback
-  {
-    route: "/api/admin/auth/oidc/callback",
-    method: "GET",
-  },
-  // global user search - no tenancy
-  // :id is user id
-  // TODO: this should really be `/api/system/users/:id`
-  {
-    route: "/api/global/users/tenant/:id",
-    method: "GET",
-  },
-  // tenant is determined from code in redis
-  {
-    route: "/api/global/users/invite/accept",
-    method: "POST",
-  },
-  {
-    route: "/api/global/users/invite/:code",
-    method: "GET",
-  },
-  {
-    route: "/api/global/users/accountholder",
-    method: "GET",
-  },
-  {
-    route: "/api/global/users/tenant/owner",
-    method: "PUT",
-  },
-]
-
-// most public endpoints are gets, but some are posts
-// add them all to be safe
-const NO_CSRF_ENDPOINTS = [...PUBLIC_ENDPOINTS]
+const noTenancyEndpoints = endpointGroupList.endpointMatchers({
+  noTenancy: true,
+})
 
 const router: Router = new Router()
 
@@ -146,12 +39,12 @@ router
     })
   )
   .use("/health", ctx => (ctx.status = 200))
-  .use(auth.buildAuthMiddleware(PUBLIC_ENDPOINTS))
-  .use(auth.buildTenancyMiddleware(PUBLIC_ENDPOINTS, NO_TENANCY_ENDPOINTS))
+  .use(auth.buildAuthMiddleware(publicEndpoints))
+  .use(auth.buildTenancyMiddleware(publicEndpoints, noTenancyEndpoints))
   .use(middleware.activeTenant(ALLOW_INACTIVE_TENANT_ENDPOINTS))
-  .use(auth.buildCsrfMiddleware({ noCsrfPatterns: NO_CSRF_ENDPOINTS }))
+  .use(auth.buildCsrfMiddleware({ noCsrfPatterns: publicEndpoints }))
   .use(pro.licensing())
-  // for now no public access is allowed to worker (bar health check)
+  // reject requests that are not declared public and have no authenticated user
   .use((ctx, next) => {
     if (ctx.publicEndpoint) {
       return next()

--- a/packages/worker/src/api/routes/endpointGroups/standard.ts
+++ b/packages/worker/src/api/routes/endpointGroups/standard.ts
@@ -3,6 +3,20 @@ import cloudRestricted from "../../../middleware/cloudRestricted"
 
 export const endpointGroupList = new EndpointGroupList()
 
+export const publicRoutes = endpointGroupList.group({ public: true })
+publicRoutes.lockMiddleware()
+
+export const publicNoTenancyRoutes = endpointGroupList.group({
+  public: true,
+  noTenancy: true,
+})
+publicNoTenancyRoutes.lockMiddleware()
+
+export const loggedInNoTenancyRoutes = endpointGroupList.group({
+  noTenancy: true,
+})
+loggedInNoTenancyRoutes.lockMiddleware()
+
 export const builderOrAdminRoutes = endpointGroupList.group(
   auth.workspaceBuilderOrAdmin
 )
@@ -17,8 +31,32 @@ adminRoutes.lockMiddleware()
 export const cloudRestrictedRoutes = endpointGroupList.group(cloudRestricted)
 cloudRestrictedRoutes.lockMiddleware()
 
+export const cloudRestrictedNoTenancyRoutes = endpointGroupList.group(
+  { noTenancy: true },
+  cloudRestricted
+)
+cloudRestrictedNoTenancyRoutes.lockMiddleware()
+
+export const publicCloudRestrictedNoTenancyRoutes = endpointGroupList.group(
+  { public: true, noTenancy: true },
+  cloudRestricted
+)
+publicCloudRestrictedNoTenancyRoutes.lockMiddleware()
+
 export const internalRoutes = endpointGroupList.group(middleware.internalApi)
 internalRoutes.lockMiddleware()
 
+export const internalNoTenancyRoutes = endpointGroupList.group(
+  { noTenancy: true },
+  middleware.internalApi
+)
+internalNoTenancyRoutes.lockMiddleware()
+
 export const loggedInRoutes = endpointGroupList.group()
 loggedInRoutes.lockMiddleware()
+
+export const adminNoTenancyRoutes = endpointGroupList.group(
+  { noTenancy: true },
+  auth.adminOnly
+)
+adminNoTenancyRoutes.lockMiddleware()

--- a/packages/worker/src/api/routes/global/auth.ts
+++ b/packages/worker/src/api/routes/global/auth.ts
@@ -1,7 +1,11 @@
 import * as authController from "../../controllers/global/auth"
 import { auth } from "@budibase/backend-core"
 import Joi from "joi"
-import { loggedInRoutes } from "../endpointGroups"
+import {
+  loggedInRoutes,
+  publicNoTenancyRoutes,
+  publicRoutes,
+} from "../endpointGroups"
 import { emailLockout, ipLockout } from "../../../middleware"
 
 function buildAuthValidation() {
@@ -27,7 +31,7 @@ function buildResetUpdateValidation() {
   }).required().unknown(false))
 }
 
-loggedInRoutes
+publicRoutes
   // PASSWORD
   .post(
     "/api/global/auth/:tenantId/login",
@@ -36,7 +40,6 @@ loggedInRoutes
     emailLockout,
     authController.login
   )
-  .post("/api/global/auth/logout", authController.logout)
   .post(
     "/api/global/auth/:tenantId/reset",
     buildResetValidation(),
@@ -47,10 +50,6 @@ loggedInRoutes
     buildResetUpdateValidation(),
     authController.resetUpdate
   )
-  // INIT
-  .post("/api/global/auth/init", authController.setInitInfo)
-  .get("/api/global/auth/init", authController.getInitInfo)
-
   // DATASOURCE - MULTI TENANT
   .get(
     "/api/global/auth/:tenantId/datasource/:provider",
@@ -76,7 +75,6 @@ loggedInRoutes
 
   // GOOGLE - SINGLE TENANT - DEPRECATED
   .get("/api/global/auth/google/callback", authController.googleCallback)
-  .get("/api/admin/auth/google/callback", authController.googleCallback)
 
   // OIDC - MULTI TENANT
   .get(
@@ -87,4 +85,12 @@ loggedInRoutes
 
   // OIDC - SINGLE TENANT - DEPRECATED
   .get("/api/global/auth/oidc/callback", authController.oidcCallback)
+
+loggedInRoutes
+  .post("/api/global/auth/logout", authController.logout)
+  .post("/api/global/auth/init", authController.setInitInfo)
+  .get("/api/global/auth/init", authController.getInitInfo)
+
+publicNoTenancyRoutes
+  .get("/api/admin/auth/google/callback", authController.googleCallback)
   .get("/api/admin/auth/oidc/callback", authController.oidcCallback)

--- a/packages/worker/src/api/routes/global/configs.ts
+++ b/packages/worker/src/api/routes/global/configs.ts
@@ -2,7 +2,7 @@ import { auth } from "@budibase/backend-core"
 import { ConfigType, PKCEMethod } from "@budibase/types"
 import Joi from "joi"
 import * as controller from "../../controllers/global/configs"
-import { adminRoutes, loggedInRoutes } from "../endpointGroups"
+import { adminRoutes, loggedInRoutes, publicRoutes } from "../endpointGroups"
 
 function smtpValidation() {
   // prettier-ignore
@@ -141,9 +141,14 @@ adminRoutes
     controller.upload
   )
 
-loggedInRoutes
+loggedInRoutes.get(
+  "/api/global/configs/:type",
+  buildConfigGetValidation(),
+  controller.find
+)
+
+publicRoutes
   .get("/api/global/configs/checklist", controller.configChecklist)
   .get("/api/global/configs/public", controller.publicSettings)
   .get("/api/global/configs/public/oidc", controller.publicOidc)
   .get("/api/global/configs/public/translations", controller.publicTranslations)
-  .get("/api/global/configs/:type", buildConfigGetValidation(), controller.find)

--- a/packages/worker/src/api/routes/global/users.ts
+++ b/packages/worker/src/api/routes/global/users.ts
@@ -4,9 +4,12 @@ import * as controller from "../../controllers/global/users"
 import {
   adminRoutes,
   builderOrAdminRoutes,
-  cloudRestrictedRoutes,
-  internalRoutes,
+  cloudRestrictedNoTenancyRoutes,
+  internalNoTenancyRoutes,
   loggedInRoutes,
+  loggedInNoTenancyRoutes,
+  publicCloudRestrictedNoTenancyRoutes,
+  publicNoTenancyRoutes,
 } from "../endpointGroups"
 import { users } from "../validation"
 
@@ -66,22 +69,23 @@ function buildChangeTenantOwnerEmailValidation() {
   )
 }
 
-cloudRestrictedRoutes
+cloudRestrictedNoTenancyRoutes
   .post(
     "/api/global/users/sso",
     users.buildAddSsoSupport(),
     controller.addSsoSupport
-  )
-  .post(
-    "/api/global/users/init",
-    buildAdminInitValidation(),
-    controller.adminUser
   )
   .put(
     "/api/global/users/tenant/owner",
     buildChangeTenantOwnerEmailValidation(),
     controller.changeTenantOwnerEmail
   )
+
+publicCloudRestrictedNoTenancyRoutes.post(
+  "/api/global/users/init",
+  buildAdminInitValidation(),
+  controller.adminUser
+)
 
 adminRoutes
   .post(
@@ -129,13 +133,21 @@ adminRoutes
 loggedInRoutes
   // search can be used by any user now, to retrieve users for user column
   .post("/api/global/users/search", controller.search)
-  // non-global endpoints
+
+publicNoTenancyRoutes
   .get("/api/global/users/invite/:code", controller.checkInvite)
   .post(
     "/api/global/users/invite/accept",
     buildInviteAcceptValidation(),
     controller.inviteAccept
   )
-  .get("/api/global/users/accountholder", controller.accountHolderLookup)
 
-internalRoutes.get("/api/global/users/tenant/:id", controller.tenantUserLookup)
+loggedInNoTenancyRoutes.get(
+  "/api/global/users/accountholder",
+  controller.accountHolderLookup
+)
+
+internalNoTenancyRoutes.get(
+  "/api/global/users/tenant/:id",
+  controller.tenantUserLookup
+)

--- a/packages/worker/src/api/routes/system/accounts.ts
+++ b/packages/worker/src/api/routes/system/accounts.ts
@@ -1,6 +1,6 @@
 import * as controller from "../../controllers/system/accounts"
-import { internalRoutes } from "../endpointGroups"
+import { internalNoTenancyRoutes } from "../endpointGroups"
 
-internalRoutes
+internalNoTenancyRoutes
   .put("/api/system/accounts/:accountId/metadata", controller.save)
   .delete("/api/system/accounts/:accountId/metadata", controller.destroy)

--- a/packages/worker/src/api/routes/system/environment.ts
+++ b/packages/worker/src/api/routes/system/environment.ts
@@ -1,4 +1,4 @@
 import * as controller from "../../controllers/system/environment"
-import { loggedInRoutes } from "../endpointGroups"
+import { publicNoTenancyRoutes } from "../endpointGroups"
 
-loggedInRoutes.get("/api/system/environment", controller.fetch)
+publicNoTenancyRoutes.get("/api/system/environment", controller.fetch)

--- a/packages/worker/src/api/routes/system/logs.ts
+++ b/packages/worker/src/api/routes/system/logs.ts
@@ -1,7 +1,7 @@
 import * as controller from "../../controllers/system/logs"
-import { adminRoutes } from "../endpointGroups"
+import { adminNoTenancyRoutes } from "../endpointGroups"
 import env from "../../../environment"
 
 if (env.SELF_HOSTED) {
-  adminRoutes.get("/api/system/logs", controller.getLogs)
+  adminNoTenancyRoutes.get("/api/system/logs", controller.getLogs)
 }

--- a/packages/worker/src/api/routes/system/restore.ts
+++ b/packages/worker/src/api/routes/system/restore.ts
@@ -1,4 +1,4 @@
 import * as controller from "../../controllers/system/restore"
-import { loggedInRoutes } from "../endpointGroups"
+import { publicNoTenancyRoutes } from "../endpointGroups"
 
-loggedInRoutes.post("/api/system/restored", controller.systemRestored)
+publicNoTenancyRoutes.post("/api/system/restored", controller.systemRestored)

--- a/packages/worker/src/api/routes/system/status.ts
+++ b/packages/worker/src/api/routes/system/status.ts
@@ -1,4 +1,4 @@
 import * as controller from "../../controllers/system/status"
-import { loggedInRoutes } from "../endpointGroups"
+import { publicNoTenancyRoutes } from "../endpointGroups"
 
-loggedInRoutes.get("/api/system/status", controller.fetch)
+publicNoTenancyRoutes.get("/api/system/status", controller.fetch)

--- a/packages/worker/src/api/routes/system/tenants.ts
+++ b/packages/worker/src/api/routes/system/tenants.ts
@@ -1,9 +1,9 @@
 import * as controller from "../../controllers/system/tenants"
-import { adminRoutes } from "../endpointGroups"
+import { adminNoTenancyRoutes } from "../endpointGroups"
 
-adminRoutes.delete("/api/system/tenants/:tenantId", controller.destroy)
-adminRoutes.put("/api/system/tenants/:tenantId/lock", controller.lock)
-adminRoutes.put(
+adminNoTenancyRoutes.delete("/api/system/tenants/:tenantId", controller.destroy)
+adminNoTenancyRoutes.put("/api/system/tenants/:tenantId/lock", controller.lock)
+adminNoTenancyRoutes.put(
   "/api/system/tenants/:tenantId/activation",
   controller.activation
 )


### PR DESCRIPTION
## Description
Improve worker routing to use the routing groups properly, instead of having a separate public/internal list

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch worker routing to use endpoint-group policy flags (`public`, `noTenancy`) and auto-generated endpoint matchers for auth, tenancy, and CSRF. Removes hand-maintained public/no-tenancy lists and aligns routes to the new groups for consistency.

- **Refactors**
  - Add `EndpointGroupOptions` (`public`, `noTenancy`) and `endpointMatchers` in `@budibase/backend-core`; export types and add a spec.
  - Extend `EndpointGroupList.group` to accept options; add `endpointMatchers` to aggregate matchers across groups.
  - Replace hard-coded PUBLIC/NO_TENANCY arrays by `endpointGroupList.endpointMatchers({ public: true })` and `endpointGroupList.endpointMatchers({ noTenancy: true })` in the worker.
  - Define standard groups in the worker: public, public+noTenancy, loggedIn+noTenancy, internal+noTenancy, admin+noTenancy, and cloud-restricted variants; lock their middleware.
  - Reassign routes to the correct groups (auth callbacks and login to public, system env/status/restored to public+noTenancy, internal lookups to internal+noTenancy, logs/tenants to admin+noTenancy, etc.).

<sup>Written for commit cb583908b211ec297484525f1e4d352944551e94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

