### PR TITLE
[VULN-118] Stop forwarding MongoDB TLS file paths on Cloud

### DIFF
--- a/packages/server/src/integrations/mongodb.ts
+++ b/packages/server/src/integrations/mongodb.ts
@@ -350,10 +350,9 @@ const getSchema = () => {
 const SCHEMA: Integration = getSchema()
 
 export function buildMongoClientOptions(
-  config: MongoDBConfig,
-  selfHosted = !!environment.SELF_HOSTED
+  config: MongoDBConfig
 ): MongoClientOptions {
-  return selfHosted
+  return environment.SELF_HOSTED
     ? {
         tlsCertificateKeyFile: config.tlsCertificateKeyFile || undefined,
         tlsCAFile: config.tlsCAFile || undefined,

--- a/packages/server/src/integrations/mongodb.ts
+++ b/packages/server/src/integrations/mongodb.ts
@@ -349,16 +349,25 @@ const getSchema = () => {
 
 const SCHEMA: Integration = getSchema()
 
+export function buildMongoClientOptions(
+  config: MongoDBConfig,
+  selfHosted = !!environment.SELF_HOSTED
+): MongoClientOptions {
+  return selfHosted
+    ? {
+        tlsCertificateKeyFile: config.tlsCertificateKeyFile || undefined,
+        tlsCAFile: config.tlsCAFile || undefined,
+      }
+    : {}
+}
+
 export class MongoIntegration implements IntegrationBase {
   private config: MongoDBConfig
   private client: MongoClient
 
   constructor(config: MongoDBConfig) {
     this.config = config
-    const options: MongoClientOptions = {
-      tlsCertificateKeyFile: config.tlsCertificateKeyFile || undefined,
-      tlsCAFile: config.tlsCAFile || undefined,
-    }
+    const options = buildMongoClientOptions(config)
     this.client = new MongoClient(config.connectionString, options)
   }
 

--- a/packages/server/src/integrations/tests/mongodb.spec.ts
+++ b/packages/server/src/integrations/tests/mongodb.spec.ts
@@ -1,0 +1,41 @@
+import { buildMongoClientOptions, MongoDBConfig } from "../mongodb"
+import { withEnv } from "../../environment"
+
+describe("MongoDB Integration", () => {
+  const baseConfig: MongoDBConfig = {
+    connectionString: "mongodb://localhost:27017",
+    db: "test",
+    tlsCertificateKeyFile: "/etc/passwd",
+    tlsCAFile: "/etc/shadow",
+  }
+
+  describe("buildMongoClientOptions", () => {
+    it("drops tlsCertificateKeyFile and tlsCAFile when not self-hosted", () => {
+      const options = buildMongoClientOptions(baseConfig, false)
+
+      expect(options).toEqual({})
+    })
+
+    it("passes tlsCertificateKeyFile and tlsCAFile through when self-hosted", () => {
+      const options = buildMongoClientOptions(baseConfig, true)
+
+      expect(options).toEqual({
+        tlsCertificateKeyFile: "/etc/passwd",
+        tlsCAFile: "/etc/shadow",
+      })
+    })
+
+    it("defaults to environment.SELF_HOSTED when not explicitly provided", () => {
+      withEnv({ SELF_HOSTED: undefined }, () => {
+        expect(buildMongoClientOptions(baseConfig)).toEqual({})
+      })
+
+      withEnv({ SELF_HOSTED: "true" }, () => {
+        expect(buildMongoClientOptions(baseConfig)).toEqual({
+          tlsCertificateKeyFile: "/etc/passwd",
+          tlsCAFile: "/etc/shadow",
+        })
+      })
+    })
+  })
+})

--- a/packages/server/src/integrations/tests/mongodb.spec.ts
+++ b/packages/server/src/integrations/tests/mongodb.spec.ts
@@ -11,25 +11,12 @@ describe("MongoDB Integration", () => {
 
   describe("buildMongoClientOptions", () => {
     it("drops tlsCertificateKeyFile and tlsCAFile when not self-hosted", () => {
-      const options = buildMongoClientOptions(baseConfig, false)
-
-      expect(options).toEqual({})
-    })
-
-    it("passes tlsCertificateKeyFile and tlsCAFile through when self-hosted", () => {
-      const options = buildMongoClientOptions(baseConfig, true)
-
-      expect(options).toEqual({
-        tlsCertificateKeyFile: "/etc/passwd",
-        tlsCAFile: "/etc/shadow",
-      })
-    })
-
-    it("defaults to environment.SELF_HOSTED when not explicitly provided", () => {
       withEnv({ SELF_HOSTED: undefined }, () => {
         expect(buildMongoClientOptions(baseConfig)).toEqual({})
       })
+    })
 
+    it("passes tlsCertificateKeyFile and tlsCAFile through when self-hosted", () => {
       withEnv({ SELF_HOSTED: "true" }, () => {
         expect(buildMongoClientOptions(baseConfig)).toEqual({
           tlsCertificateKeyFile: "/etc/passwd",


### PR DESCRIPTION
## Description
`MongoIntegration` forwarded `tlsCertificateKeyFile`/`tlsCAFile` from the datasource config directly into the MongoDB driver as filesystem paths, regardless of environment. The builder UI only exposes these fields when `SELF_HOSTED` is true, but that gating was UI-only — the backend still accepted and used them on Cloud if present in the request payload, which is unsafe on a shared, multi-tenant server.

`buildMongoClientOptions()` now only forwards these fields into the driver when `environment.SELF_HOSTED` is true, enforcing server-side what the UI already implied. Self-hosted behavior is unchanged — that deployment model's server filesystem belongs to the customer, so the same concern doesn't apply there.

## Addresses
- Vuln #118

## Launchcontrol
Fixed a security issue affecting Budibase Cloud related to MongoDB datasource TLS configuration. Self-hosted behavior is unaffected.
