### PR TITLE
Relax Vouch requirements for pull requests

### DIFF
--- a/.github/workflows/vouched.yml
+++ b/.github/workflows/vouched.yml
@@ -20,12 +20,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: mitchellh/vouch/action/check-user@f44860978966ace98fb11aaaa20f2b27d7543e13
-        with:
-          user: ${{ github.event.pull_request.user.login }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   manage:
     if: github.event_name == 'issue_comment' && github.event.issue.pull_request
     runs-on: ubuntu-latest

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,11 +24,11 @@ If you do plan to raise a pull request, please take a look at the guide below.
 
 ## Vouching
 
-Due to the high code volume LLM era, we have decided to implement [Vouch](https://github.com/mitchellh/vouch) for our pull requests.
+We use [Vouch](https://github.com/mitchellh/vouch) to prevent explicitly denounced users from contributing pull requests.
 
-Your PR will not be merged unless you are added to our vouch list by our engineers.
+You do not need to be vouched for before opening or merging a pull request. Pull requests from users who have been explicitly denounced will be closed automatically.
 
-This is to ensure the quality of the product and free up time for our team. Thank you for your understanding.
+All pull requests remain subject to our normal review and contribution requirements.
 
 ## Not Sure Where to Start?
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -28,6 +28,8 @@ We use [Vouch](https://github.com/mitchellh/vouch) to prevent explicitly denounc
 
 You do not need to be vouched for before opening or merging a pull request. Pull requests from users who have been explicitly denounced will be closed automatically.
 
+Each contributor may have only one open pull request at a time.
+
 All pull requests remain subject to our normal review and contribution requirements.
 
 ## Not Sure Where to Start?


### PR DESCRIPTION
## Description
Allow pull requests from all contributors by default while continuing to automatically close pull requests from explicitly denounced users. Removes the separate user check that failed for unknown or unvouched contributors and updates the contribution guidance to reflect the policy.

## Launchcontrol
Allows anyone to contribute a pull request without first being vouched for, while retaining automatic closure for explicitly denounced users.
