### PR TITLE
[VULN-119] Add regression test showing MySQL injection report does not reproduce

### DIFF
--- a/packages/server/src/integrations/tests/mysql.spec.ts
+++ b/packages/server/src/integrations/tests/mysql.spec.ts
@@ -1,0 +1,65 @@
+jest.mock("../../sdk", () => ({
+  __esModule: true,
+  default: {
+    queries: {
+      enrichContext: jest.fn(
+        async (bindings: string[], parameters: Record<string, any>) =>
+          bindings.map(binding => parameters[binding.replace(/[{} ]/g, "")])
+      ),
+      enrichArrayContext: jest.fn(
+        async (bindings: string[], parameters: Record<string, any>) =>
+          bindings.map(binding => parameters[binding.replace(/[{} ]/g, "")])
+      ),
+    },
+  },
+}))
+
+import { SourceName } from "@budibase/types"
+import { interpolateSQL } from "../queries/sql"
+
+describe("interpolateSQL SQL injection hardening", () => {
+  const mysqlIntegration = {
+    getBindingIdentifier: () => "?",
+    getStringConcat: (parts: string[]) => `concat(${parts.join(", ")})`,
+  }
+
+  it("prevents a MySQL binding from injecting an extra statement into the final SQL", async () => {
+    const fields = {
+      sql: "SELECT * FROM users WHERE id = {{ id }}",
+      bindings: [],
+    }
+
+    const result = await interpolateSQL(
+      SourceName.MYSQL,
+      fields,
+      { id: "1; DROP TABLE users; --" },
+      mysqlIntegration as any,
+      { nullDefaultSupport: false }
+    )
+
+    expect(result.sql).toBe("SELECT * FROM users WHERE id = ?")
+    expect(result.sql).not.toContain("DROP TABLE")
+    expect(result.bindings).toEqual(["1; DROP TABLE users; --"])
+  })
+
+  it("prevents a quoted MySQL binding from smuggling an extra statement into the final SQL", async () => {
+    const fields = {
+      sql: "SELECT * FROM users WHERE name = '{{ name }}'",
+      bindings: [],
+    }
+
+    const result = await interpolateSQL(
+      SourceName.MYSQL,
+      fields,
+      { name: "'; DROP TABLE users; --" },
+      mysqlIntegration as any,
+      { nullDefaultSupport: false }
+    )
+
+    expect(result.sql).toBe(
+      "SELECT * FROM users WHERE name = concat('', ?, '')"
+    )
+    expect(result.sql).not.toContain("DROP TABLE")
+    expect(result.bindings).toEqual(["'; DROP TABLE users; --"])
+  })
+})


### PR DESCRIPTION
## Addresses
- Vuln #119

## Description
Vuln #119 reports a critical SQL injection in the MySQL integration, pointing at `multipleStatements: true` in `packages/server/src/integrations/mysql.ts` and a PoC where a payload like `1; DROP TABLE sensitive_data; --` is assumed to become a second executable statement.

That PoC does not match how Budibase actually builds MySQL queries. `interpolateSQL` (`packages/server/src/integrations/queries/sql.ts`) rewrites Handlebars bindings such as `{{ id }}` into driver placeholders (`?`) and keeps the actual values in a separate `bindings` array. It never concatenates user input into the SQL string. As a result, a payload containing a semicolon stays a bound parameter value; the driver never parses it as SQL syntax, so `multipleStatements: true` cannot be leveraged through this path.

This PR does not change `multipleStatements` on the MySQL config. Removing it was considered, but it was intentionally introduced in 2022 (`Support multiple statements`, PR merging `bug/sev4/mysql-multiple-statements`) to fix a real bug, and no functional dependency on it was found or ruled out in this pass, so flipping it needs its own follow-up investigation rather than being bundled with an unrelated vulnerability report.

Instead, this PR adds a regression test (`packages/server/src/integrations/tests/mysql.spec.ts`) that exercises `interpolateSQL` with the exact payload from the report, both unquoted and quoted, and asserts the resulting SQL has no injected statement and the payload remains intact in `bindings`. This documents that the reported exploitation path does not reproduce against the current parameter-handling code, without claiming that MySQL query execution is safe in general.

## Launchcontrol
Added a regression test documenting that the SQL injection reported in vuln #119 does not reproduce against Budibase's current MySQL query parameter handling; no runtime behavior changed.