### PR TITLE
[Functions alpha] Add saved-query catalog and virtual module declarations

### DIFF
--- a/packages/server/src/api/controllers/function.ts
+++ b/packages/server/src/api/controllers/function.ts
@@ -2,6 +2,7 @@ import {
   type CreateFunctionRequest,
   type CreateFunctionResponse,
   type FetchFunctionResponse,
+  type FetchFunctionQueryCatalogResponse,
   type FetchFunctionsResponse,
   type UpdateFunctionRequest,
   type UpdateFunctionResponse,
@@ -15,6 +16,14 @@ export const fetch = async (ctx: UserCtx<void, FetchFunctionsResponse>) => {
     functions: await Promise.all(
       functions.map(fn => sdk.functions.toFunctionResponse(fn))
     ),
+  }
+}
+
+export const queryCatalog = async (
+  ctx: UserCtx<void, FetchFunctionQueryCatalogResponse>
+) => {
+  ctx.body = {
+    queries: await sdk.functions.getQueryCatalog(),
   }
 }
 

--- a/packages/server/src/api/routes/function.ts
+++ b/packages/server/src/api/routes/function.ts
@@ -30,6 +30,11 @@ builderRoutes
     }),
     controller.create
   )
+  .get(
+    "/api/functions/query-catalog",
+    functionsEnabled,
+    controller.queryCatalog
+  )
   .get("/api/functions/:id", functionsEnabled, controller.find)
   .put(
     "/api/functions/:id",

--- a/packages/server/src/api/routes/tests/function.spec.ts
+++ b/packages/server/src/api/routes/tests/function.spec.ts
@@ -1,7 +1,13 @@
 import { context, features } from "@budibase/backend-core"
-import { DocumentType, FeatureFlag, prefixed } from "@budibase/types"
+import {
+  DocumentType,
+  FeatureFlag,
+  type FunctionDocument,
+  prefixed,
+} from "@budibase/types"
 import { setEnv } from "../../../environment"
 import { generateAutomationID } from "../../../db/utils"
+import sdk from "../../../sdk"
 import TestConfiguration from "../../../tests/utilities/TestConfiguration"
 import {
   basicDatasource,
@@ -66,6 +72,21 @@ describe("/functions", () => {
     })
   }
 
+  const createRestQuery = async () => {
+    const datasource = await config.restDatasource({
+      url: "https://example.com",
+    })
+    return await config.api.query.save({
+      ...basicQuery(datasource._id!),
+      name: "Find available rooms",
+      fields: {
+        path: "/rooms",
+        method: "GET",
+      },
+      parameters: [{ name: "available-on", default: "" }],
+    })
+  }
+
   it("returns 404 when Functions are disabled", async () => {
     await config.api.function.fetch({ status: 404 })
   })
@@ -75,6 +96,185 @@ describe("/functions", () => {
       config,
       method: "GET",
       url: "/api/functions",
+    })
+  })
+
+  it("catalogs Data and API Explorer queries with authoritative parameters", async () => {
+    await withFunctionsEnabled(async () => {
+      const dataQuery = await createQuery()
+      const restQuery = await createRestQuery()
+
+      const { queries } = await config.api.function.queryCatalog()
+
+      expect(queries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            queryId: dataQuery._id,
+            queryName: "Find rooms",
+            kind: "data",
+            parameters: [{ name: "building" }, { name: "floor" }],
+          }),
+          expect.objectContaining({
+            queryId: restQuery._id,
+            queryName: "Find available rooms",
+            kind: "api",
+            parameters: [{ name: "available-on" }],
+          }),
+        ])
+      )
+    })
+  })
+
+  it("generates declarations only for linked queries and preserves aliases on rename", async () => {
+    await withFunctionsEnabled(async () => {
+      const { function: created } = await createFunction()
+      await createRestQuery()
+
+      const beforeRename = await config.doInContext(
+        config.getDevWorkspaceId(),
+        async () => {
+          const fn = await context
+            .getWorkspaceDB()
+            .get<FunctionDocument>(created._id)
+          return await sdk.functions.getFunctionDeclarations(fn)
+        }
+      )
+
+      expect(beforeRename.declarations).toContain(
+        'declare module "@budibase/functions"'
+      )
+      expect(beforeRename.declarations).toContain('readonly "Inventory"')
+      expect(beforeRename.declarations).toContain('readonly "findRooms"')
+      expect(beforeRename.declarations).toContain(
+        'readonly "building": string | null'
+      )
+      expect(beforeRename.declarations).toContain("Promise<JsonValue>")
+      expect(beforeRename.declarations).not.toContain("findAvailableRooms")
+
+      const query = await config.api.query.get(created.capabilities[0].queryId)
+      await config.api.query.save({ ...query, name: "Rooms renamed" })
+
+      const afterRename = await config.doInContext(
+        config.getDevWorkspaceId(),
+        async () => {
+          const fn = await context
+            .getWorkspaceDB()
+            .get<FunctionDocument>(created._id)
+          return await sdk.functions.getFunctionDeclarations(fn)
+        }
+      )
+      const { function: fetched } = await config.api.function.find(created._id)
+
+      expect(afterRename).toEqual(beforeRename)
+      expect(fetched.capabilities[0].queryAlias).toBe("findRooms")
+    })
+  })
+
+  it("rejects datasource and query alias collisions", async () => {
+    await withFunctionsEnabled(async () => {
+      const firstQuery = await createQuery()
+      const secondQuery = await createQuery()
+
+      await config.api.function.create(
+        {
+          name: "Alias collision",
+          source: "",
+          capabilities: [
+            {
+              queryId: firstQuery._id!,
+              datasourceAlias: "Inventory",
+              queryAlias: "findRooms",
+            },
+            {
+              queryId: secondQuery._id!,
+              datasourceAlias: "Inventory",
+              queryAlias: "findAvailableRooms",
+            },
+          ],
+        },
+        { status: 400 }
+      )
+
+      const sameDatasourceQuery = await config.api.query.save({
+        ...basicQuery(firstQuery.datasourceId),
+        name: "Find floors",
+      })
+      await config.api.function.create(
+        {
+          name: "Query alias collision",
+          source: "",
+          capabilities: [
+            {
+              queryId: firstQuery._id!,
+              datasourceAlias: "Inventory",
+              queryAlias: "findRooms",
+            },
+            {
+              queryId: sameDatasourceQuery._id!,
+              datasourceAlias: "Inventory",
+              queryAlias: "findRooms",
+            },
+          ],
+        },
+        { status: 400 }
+      )
+    })
+  })
+
+  it("rejects cross-workspace queries", async () => {
+    const query = await createQuery()
+    await config.createWorkspace()
+
+    await withFunctionsEnabled(async () => {
+      await config.api.function.create(
+        {
+          name: "Cross-workspace query",
+          source: "",
+          capabilities: [
+            {
+              queryId: query._id!,
+              datasourceAlias: "Inventory",
+              queryAlias: "findRooms",
+            },
+          ],
+        },
+        { status: 404 }
+      )
+    })
+  })
+
+  it("rejects unsupported queries and invalid parameter metadata", async () => {
+    await withFunctionsEnabled(async () => {
+      const unsupported = await createQuery()
+      const invalidParameters = await createQuery()
+
+      await config.doInContext(config.getDevWorkspaceId(), async () => {
+        await context.getWorkspaceDB().put({
+          ...unsupported,
+          queryVerb: "unsupported",
+        })
+        await context.getWorkspaceDB().put({
+          ...invalidParameters,
+          parameters: [{ name: "", default: "" }],
+        })
+      })
+
+      for (const query of [unsupported, invalidParameters]) {
+        await config.api.function.create(
+          {
+            name: "Invalid query",
+            source: "",
+            capabilities: [
+              {
+                queryId: query._id!,
+                datasourceAlias: "Inventory",
+                queryAlias: "findRooms",
+              },
+            ],
+          },
+          { status: 400 }
+        )
+      }
     })
   })
 

--- a/packages/server/src/sdk/workspace/functions/declarations.spec.ts
+++ b/packages/server/src/sdk/workspace/functions/declarations.spec.ts
@@ -1,0 +1,69 @@
+import ts from "typescript"
+import type { FunctionQueryCapability } from "@budibase/types"
+import { generateFunctionDeclarations } from "./declarations"
+
+const getDiagnostics = (files: Map<string, string>) => {
+  const options: ts.CompilerOptions = {
+    module: ts.ModuleKind.CommonJS,
+    noEmit: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2020,
+    types: [],
+  }
+  const host = ts.createCompilerHost(options)
+  const getSourceFile = host.getSourceFile.bind(host)
+
+  host.fileExists = fileName =>
+    files.has(fileName) || ts.sys.fileExists(fileName)
+  host.readFile = fileName => files.get(fileName) || ts.sys.readFile(fileName)
+  host.getSourceFile = (
+    fileName,
+    languageVersion,
+    onError,
+    shouldCreateNewSourceFile
+  ) => {
+    const source = files.get(fileName)
+    if (source !== undefined) {
+      return ts.createSourceFile(fileName, source, languageVersion)
+    }
+    return getSourceFile(
+      fileName,
+      languageVersion,
+      onError,
+      shouldCreateNewSourceFile
+    )
+  }
+
+  const program = ts.createProgram([...files.keys()], options, host)
+  return ts.getPreEmitDiagnostics(program)
+}
+
+describe("generateFunctionDeclarations", () => {
+  it("generates valid declarations for parameter names requiring quoting", () => {
+    const capabilities: FunctionQueryCapability[] = [
+      {
+        capabilityId: "capability_1",
+        queryId: "query_1",
+        datasourceAlias: "DataWarehouse",
+        queryAlias: "findRooms",
+        parameterNames: ['building "name"'],
+      },
+    ]
+    const declarations = generateFunctionDeclarations(capabilities)
+    const usage = `import { queries } from "@budibase/functions"
+
+queries.DataWarehouse.findRooms({
+  'building "name"': null,
+})
+`
+
+    expect(
+      getDiagnostics(
+        new Map([
+          ["functions.d.ts", declarations],
+          ["usage.ts", usage],
+        ])
+      )
+    ).toEqual([])
+  })
+})

--- a/packages/server/src/sdk/workspace/functions/declarations.ts
+++ b/packages/server/src/sdk/workspace/functions/declarations.ts
@@ -1,0 +1,68 @@
+import { createHash } from "crypto"
+import type { FunctionQueryCapability } from "@budibase/types"
+
+const property = (value: string) => JSON.stringify(value)
+
+const renderParameters = (parameterNames: string[]) => {
+  if (!parameterNames.length) {
+    return "()"
+  }
+  const properties = [...parameterNames]
+    .sort((a, b) => a.localeCompare(b))
+    .map(name => `          readonly ${property(name)}: string | null`)
+    .join("\n")
+  return `(parameters: Readonly<{\n${properties}\n        }>)`
+}
+
+const renderQueries = (capabilities: FunctionQueryCapability[]) => {
+  const grouped = new Map<string, FunctionQueryCapability[]>()
+  for (const capability of capabilities) {
+    const queries = grouped.get(capability.datasourceAlias) || []
+    queries.push(capability)
+    grouped.set(capability.datasourceAlias, queries)
+  }
+
+  return [...grouped.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([datasourceAlias, queries]) => {
+      const renderedQueries = queries
+        .sort((a, b) => a.queryAlias.localeCompare(b.queryAlias))
+        .map(
+          query =>
+            `      readonly ${property(query.queryAlias)}: ${renderParameters(query.parameterNames)} => Promise<JsonValue>`
+        )
+        .join("\n")
+      return `    readonly ${property(datasourceAlias)}: Readonly<{\n${renderedQueries}\n    }>`
+    })
+    .join("\n")
+}
+
+export const generateFunctionDeclarations = (
+  capabilities: FunctionQueryCapability[]
+) => {
+  const queries = renderQueries(capabilities)
+  return `declare module "@budibase/functions" {
+  export type JsonValue =
+    | string
+    | number
+    | boolean
+    | null
+    | JsonValue[]
+    | { [key: string]: JsonValue }
+
+  export const inputs: Readonly<Record<string, JsonValue>>
+  export const queries: Readonly<{
+${queries}
+  }>
+
+  export interface FunctionResult {
+    output: Record<string, JsonValue>
+    status?: "success" | "error" | "stopped"
+  }
+}
+`
+}
+
+export const hashFunctionDeclarations = (declarations: string) => {
+  return createHash("sha256").update(declarations).digest("hex")
+}

--- a/packages/server/src/sdk/workspace/functions/index.ts
+++ b/packages/server/src/sdk/workspace/functions/index.ts
@@ -1,15 +1,24 @@
-import { context, docIds, HTTPError, utils } from "@budibase/backend-core"
 import { createHash } from "crypto"
+import { context, docIds, HTTPError } from "@budibase/backend-core"
 import {
   DEFAULT_FUNCTION_LIMITS,
   DocumentType,
   type AnyDocument,
   type FunctionDocument,
-  type FunctionQueryCapability,
   type FunctionQueryCapabilityInput,
   type FunctionResponse,
-  type Query,
 } from "@budibase/types"
+import {
+  generateFunctionDeclarations,
+  hashFunctionDeclarations,
+} from "./declarations"
+import { buildCapabilities } from "./queryCatalog"
+
+export {
+  generateFunctionDeclarations,
+  hashFunctionDeclarations,
+} from "./declarations"
+export { getQueryCatalog, resolveSavedQuery } from "./queryCatalog"
 
 interface FunctionDraftInput {
   name: string
@@ -75,59 +84,37 @@ const validateDraft = (draft: FunctionDraftInput) => {
   }
 }
 
-const getQuery = async (queryId: string) => {
-  if (!docIds.isType(queryId, DocumentType.QUERY)) {
-    throw new HTTPError(`Query '${queryId}' not found.`, 404)
-  }
-
-  const query = await getDb().tryGet<Query>(queryId)
-  if (!query) {
-    throw new HTTPError(`Query '${queryId}' not found.`, 404)
-  }
-  return query
-}
-
-const buildCapabilities = async (
-  inputs: FunctionQueryCapabilityInput[],
-  existing: FunctionQueryCapability[] = []
-) => {
-  return await Promise.all(
-    inputs.map(async input => {
-      const query = await getQuery(input.queryId)
-      const persisted = existing.find(
-        capability => capability.queryId === input.queryId
-      )
-      return {
-        capabilityId: persisted?.capabilityId || utils.newid(),
-        queryId: input.queryId,
-        datasourceAlias: input.datasourceAlias,
-        queryAlias: input.queryAlias,
-        parameterNames: query.parameters.map(parameter => parameter.name),
-      }
-    })
+export const getFunctionDeclarations = async (fn: FunctionDocument) => {
+  const capabilities = await buildCapabilities(
+    fn.capabilities.map(capability => ({
+      queryId: capability.queryId,
+      datasourceAlias: capability.datasourceAlias,
+      queryAlias: capability.queryAlias,
+    })),
+    fn.capabilities
   )
+  const declarations = generateFunctionDeclarations(capabilities)
+  return {
+    capabilities,
+    declarations,
+    declarationsHash: hashFunctionDeclarations(declarations),
+  }
 }
 
-export const getFunctionDeclarationsHash = async (fn: FunctionDocument) => {
-  const capabilities = await Promise.all(
-    fn.capabilities.map(async capability => {
-      const query = await getDb().tryGet<Query>(capability.queryId)
-      return {
-        ...capability,
-        parameterNames: query?.parameters.map(parameter => parameter.name) || [
-          "__missing__",
-        ],
-      }
-    })
-  )
-
-  capabilities.sort((a, b) => a.capabilityId.localeCompare(b.capabilityId))
-  return hash(JSON.stringify(capabilities))
-}
+export const getFunctionDeclarationsHash = async (fn: FunctionDocument) =>
+  (await getFunctionDeclarations(fn)).declarationsHash
 
 export const getFunctionReadiness = async (fn: FunctionDocument) => {
   const sourceHash = getFunctionSourceHash(fn.source)
-  const declarationsHash = await getFunctionDeclarationsHash(fn)
+  let declarationsHash: string
+  try {
+    declarationsHash = await getFunctionDeclarationsHash(fn)
+  } catch (error) {
+    if (error instanceof HTTPError) {
+      return "build_required"
+    }
+    throw error
+  }
 
   if (
     fn.lastBuild?.sourceHash !== sourceHash ||

--- a/packages/server/src/sdk/workspace/functions/queryCatalog.ts
+++ b/packages/server/src/sdk/workspace/functions/queryCatalog.ts
@@ -1,0 +1,207 @@
+import { context, docIds, HTTPError, utils } from "@budibase/backend-core"
+import {
+  DocumentType,
+  SourceName,
+  type Datasource,
+  type FunctionQueryCapability,
+  type FunctionQueryCapabilityInput,
+  type FunctionQueryCatalogEntry,
+  type Query,
+  type QueryParameter,
+  type QueryVerb,
+} from "@budibase/types"
+
+interface ResolvedQuery {
+  query: Query & { _id: string }
+  datasource: Datasource & { _id: string }
+  parameterNames: string[]
+}
+
+const SUPPORTED_QUERY_VERBS: QueryVerb[] = [
+  "read",
+  "create",
+  "update",
+  "delete",
+  "patch",
+]
+
+const isQueryParameter = (parameter: unknown): parameter is QueryParameter => {
+  if (typeof parameter !== "object" || parameter === null) {
+    return false
+  }
+
+  if (!("name" in parameter) || !("default" in parameter)) {
+    return false
+  }
+
+  const { name, default: defaultValue } = parameter
+
+  return (
+    typeof name === "string" &&
+    name.trim().length > 0 &&
+    typeof defaultValue === "string"
+  )
+}
+
+const getParameterNames = (query: Query) => {
+  if (!Array.isArray(query.parameters)) {
+    throw new HTTPError(`Query '${query._id}' has invalid parameters.`, 400)
+  }
+
+  const parameterNames = query.parameters.map(parameter => {
+    if (!isQueryParameter(parameter)) {
+      throw new HTTPError(`Query '${query._id}' has invalid parameters.`, 400)
+    }
+    return parameter.name
+  })
+  if (new Set(parameterNames).size !== parameterNames.length) {
+    throw new HTTPError(
+      `Query '${query._id}' has duplicate parameter names.`,
+      400
+    )
+  }
+  return parameterNames
+}
+
+const isSupportedSource = (source: SourceName) => {
+  return Object.values(SourceName).includes(source)
+}
+
+export const resolveSavedQuery = async (
+  queryId: string
+): Promise<ResolvedQuery> => {
+  const db = context.getWorkspaceDB()
+  if (!docIds.isType(queryId, DocumentType.QUERY)) {
+    throw new HTTPError(`Query '${queryId}' not found.`, 404)
+  }
+
+  const query = await db.tryGet<Query>(queryId)
+  if (!query?._id) {
+    throw new HTTPError(`Query '${queryId}' not found.`, 404)
+  }
+  if (!SUPPORTED_QUERY_VERBS.includes(query.queryVerb)) {
+    throw new HTTPError(
+      `Query '${queryId}' is not supported by Functions.`,
+      400
+    )
+  }
+
+  const datasource = await db.tryGet<Datasource>(query.datasourceId)
+  if (!datasource?._id || !isSupportedSource(datasource.source)) {
+    throw new HTTPError(
+      `Query '${queryId}' is not supported by Functions.`,
+      400
+    )
+  }
+
+  return {
+    query: { ...query, _id: query._id },
+    datasource: { ...datasource, _id: datasource._id },
+    parameterNames: getParameterNames(query),
+  }
+}
+
+const validateAliasMappings = (
+  resolved: Array<{
+    input: FunctionQueryCapabilityInput
+    query: ResolvedQuery
+  }>
+) => {
+  const datasourceIdsByAlias = new Map<string, string>()
+  const aliasesByDatasourceId = new Map<string, string>()
+  const queryAliases = new Set<string>()
+
+  for (const { input, query } of resolved) {
+    const existingDatasourceId = datasourceIdsByAlias.get(input.datasourceAlias)
+    if (existingDatasourceId && existingDatasourceId !== query.datasource._id) {
+      throw new HTTPError(
+        `Datasource alias '${input.datasourceAlias}' is already in use.`,
+        400
+      )
+    }
+    datasourceIdsByAlias.set(input.datasourceAlias, query.datasource._id)
+
+    const existingAlias = aliasesByDatasourceId.get(query.datasource._id)
+    if (existingAlias && existingAlias !== input.datasourceAlias) {
+      throw new HTTPError(
+        `Datasource '${query.datasource.name || query.datasource.source}' has multiple aliases.`,
+        400
+      )
+    }
+    aliasesByDatasourceId.set(query.datasource._id, input.datasourceAlias)
+
+    const queryAlias = `${input.datasourceAlias}.${input.queryAlias}`
+    if (queryAliases.has(queryAlias)) {
+      throw new HTTPError(`Query alias '${queryAlias}' is already in use.`, 400)
+    }
+    queryAliases.add(queryAlias)
+  }
+}
+
+export const buildCapabilities = async (
+  inputs: FunctionQueryCapabilityInput[],
+  existing: FunctionQueryCapability[] = []
+): Promise<FunctionQueryCapability[]> => {
+  const resolved = await Promise.all(
+    inputs.map(async input => ({
+      input,
+      query: await resolveSavedQuery(input.queryId),
+    }))
+  )
+  validateAliasMappings(resolved)
+
+  return resolved.map(({ input, query }) => {
+    const persisted = existing.find(
+      capability => capability.queryId === input.queryId
+    )
+    return {
+      capabilityId: persisted?.capabilityId || utils.newid(),
+      queryId: input.queryId,
+      datasourceAlias: input.datasourceAlias,
+      queryAlias: input.queryAlias,
+      parameterNames: query.parameterNames,
+    }
+  })
+}
+
+const toCatalogEntry = (
+  resolved: ResolvedQuery
+): FunctionQueryCatalogEntry => ({
+  queryId: resolved.query._id,
+  queryName: resolved.query.name,
+  datasourceId: resolved.datasource._id,
+  datasourceName: resolved.datasource.name || resolved.datasource.source,
+  source: resolved.datasource.source,
+  kind: resolved.datasource.source === SourceName.REST ? "api" : "data",
+  parameters: resolved.parameterNames.map(name => ({ name })),
+})
+
+export const getQueryCatalog = async () => {
+  const db = context.getWorkspaceDB()
+  const result = await db.allDocs<Query>(
+    docIds.getDocParams(DocumentType.QUERY, null, { include_docs: true })
+  )
+  const entries = await Promise.all(
+    result.rows.map(async row => {
+      if (!row.doc?._id) {
+        return undefined
+      }
+      try {
+        return toCatalogEntry(await resolveSavedQuery(row.doc._id))
+      } catch (error) {
+        if (error instanceof HTTPError) {
+          return undefined
+        }
+        throw error
+      }
+    })
+  )
+
+  return entries
+    .filter((entry): entry is FunctionQueryCatalogEntry => !!entry)
+    .sort(
+      (a, b) =>
+        a.datasourceName.localeCompare(b.datasourceName) ||
+        a.queryName.localeCompare(b.queryName)
+    )
+}

--- a/packages/server/src/tests/utilities/api/function.ts
+++ b/packages/server/src/tests/utilities/api/function.ts
@@ -2,6 +2,7 @@ import type {
   CreateFunctionRequest,
   CreateFunctionResponse,
   FetchFunctionResponse,
+  FetchFunctionQueryCatalogResponse,
   FetchFunctionsResponse,
   UpdateFunctionRequest,
   UpdateFunctionResponse,
@@ -9,6 +10,13 @@ import type {
 import { type Expectations, TestAPI } from "./base"
 
 export class FunctionAPI extends TestAPI {
+  queryCatalog = async (expectations?: Expectations) => {
+    return await this._get<FetchFunctionQueryCatalogResponse>(
+      "/api/functions/query-catalog",
+      { expectations }
+    )
+  }
+
   fetch = async (expectations?: Expectations) => {
     return await this._get<FetchFunctionsResponse>("/api/functions", {
       expectations,

--- a/packages/types/src/api/web/workspace/function.ts
+++ b/packages/types/src/api/web/workspace/function.ts
@@ -1,4 +1,5 @@
 import type { FunctionDocument } from "../../../documents"
+import type { SourceName } from "../../../sdk"
 
 export type FunctionReadiness = "ready" | "build_required" | "build_failed"
 
@@ -38,4 +39,24 @@ export interface FetchFunctionResponse {
 
 export interface UpdateFunctionResponse {
   function: FunctionResponse
+}
+
+export type FunctionQueryKind = "data" | "api"
+
+export interface FunctionQueryCatalogParameter {
+  name: string
+}
+
+export interface FunctionQueryCatalogEntry {
+  queryId: string
+  queryName: string
+  datasourceId: string
+  datasourceName: string
+  source: SourceName
+  kind: FunctionQueryKind
+  parameters: FunctionQueryCatalogParameter[]
+}
+
+export interface FetchFunctionQueryCatalogResponse {
+  queries: FunctionQueryCatalogEntry[]
 }


### PR DESCRIPTION
## Description
Adds the saved-query catalog and authoritative server-side capability resolution for Functions. Generates deterministic virtual `@budibase/functions` declarations for linked queries, inputs, `FunctionResult`, and `JsonValue`, including a declaration hash used by Function readiness.

Validation rejects missing or cross-workspace queries, unsupported query kinds, invalid parameter metadata, and datasource/query alias collisions. Tests cover Data and API Explorer queries, alias preservation across display-name changes, linked-query filtering, parameter generation, and TypeScript compilation of the generated declarations.

### Generated declarations
The server generates an ambient `@budibase/functions` module for the Function code editor and compiler. It exposes JSON-compatible `inputs`, a nested `queries.<datasourceAlias>.<queryAlias>` API containing only explicitly linked saved queries, and the `JsonValue` and `FunctionResult` types.

Each query accepts a readonly parameter object whose fields are typed as `string | null` and returns `Promise<JsonValue>`. Property names are safely quoted, while datasource aliases, query aliases, and parameter names are sorted so equivalent capabilities always produce identical declaration text. A SHA-256 hash of that effective declaration text is stored for Function readiness and rebuild detection.

For example, a linked `Inventory.findRooms` query is presented to Function authors as:

```ts
const rooms = await queries.Inventory.findRooms({
  building: "HQ",
  floor: null,
})
```

## Addresses
- https://github.com/Budibase/budibase/issues/19255

## Launchcontrol
Adds the saved-query catalog and typed query API used when authoring Functions in the self-hosted alpha.
