### PR TITLE
fix(agent): disable browser credential autofill on agent/operation name modals

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/agent/AgentModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/AgentModal.svelte
@@ -79,6 +79,7 @@
   >
     <div class="agent-form">
       <form
+        autocomplete="off"
         on:submit|preventDefault={() => {
           if (loading || !trimmedName) {
             return
@@ -92,6 +93,7 @@
           error={nameError}
           on:input={() => (touched = true)}
           placeholder="Support agent"
+          autocomplete="off"
         />
       </form>
     </div>

--- a/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/OperationNameModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/OperationNameModal.svelte
@@ -89,6 +89,7 @@
     onConfirm={submit}
   >
     <form
+      autocomplete="off"
       onsubmit={event => {
         event.preventDefault()
         submitError = undefined
@@ -105,6 +106,7 @@
         error={nameError}
         on:input={() => (touched = true)}
         {placeholder}
+        autocomplete="off"
       />
     </form>
   </ModalContent>


### PR DESCRIPTION
## Problem

Fixes #19160

Browser password managers (1Password, Chrome autofill, Bitwarden, etc.) incorrectly identify the **"New agent"** and **"New/Edit operation"** name inputs as credential fields and display unwanted autofill overlays. This doesn't affect other automation modals because they use different input field contexts.

The issue is that the modals have a bare `<Input label="Name" />` inside a `<form>` with no `autocomplete` hint. Browsers apply credential-detection heuristics and infer that a lone text field in a form might be a username.

## Root Cause

Browsers use several signals to decide whether to offer password/credential autofill:
- A `<form>` element with no `autocomplete` attribute
- A single text input labeled `"Name"` (a common username pattern)
- No explicit `autocomplete="off"` anywhere in the chain

The new automation modal doesn't trigger this because its form structure is different (multiple fields, different labels).

## Fix

Two layers of suppression for maximum browser compatibility:

1. `autocomplete="off"` on the `<form>` element — tells the browser not to autocomplete the form as a whole
2. `autocomplete="off"` on the `<Input>` component — field-level hint for browsers that ignore form-level `autocomplete`

The `bbui` `Input` component already accepts and forwards the `autocomplete` prop natively — no bbui package changes required.

**Files changed:**
- `packages/builder/src/pages/builder/workspace/[application]/agent/AgentModal.svelte`
- `packages/builder/src/pages/builder/workspace/[application]/agent/[agentId]/OperationNameModal.svelte`

## Testing

1. Open a workspace with a browser that has 1Password / Chrome autofill enabled
2. Click **+ New agent** → the name input should not show any autofill/credential overlay
3. Open an agent, click **+ Add operation** → the operation name input should not show any autofill overlay
4. Confirm the **New automation** modal is unaffected (control test)
5. Confirm agent/operation creation still works correctly end-to-end

## Notes

- `autocomplete="off"` is the [recommended standard approach](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute) for suppressing autofill on non-credential fields
- Some browsers (notably Chrome) may still override `autocomplete="off"` for password fields as a security measure, but plain text inputs respect it reliably
- The fix is purely additive (no logic changed) and has zero risk of regression

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable browser credential autofill in the New agent and New/Edit operation modals by turning off autocomplete on the form and input. Fixes #19160 and prevents 1Password/Chrome overlays on the name fields.

- **Bug Fixes**
  - Set `autocomplete="off"` on the modal form and name input in `AgentModal.svelte` and `OperationNameModal.svelte`.

<sup>Written for commit 6e5679514795e477ce0507377e3ee4b83d039518. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

