### PR TITLE
feat(functions): standalone runner image + local dev startup (#19275)

### DIFF
--- a/hosting/docker-compose.dev.yaml
+++ b/hosting/docker-compose.dev.yaml
@@ -103,6 +103,37 @@ services:
       timeout: 5s
       retries: 10
 
+  # Standalone Function runner (Functions Alpha, spec E1). Deliberately carries
+  # no Budibase or datasource credentials and runs independently of server/worker
+  # - stopping it does not affect the rest of the stack or non-Function automations.
+  functions-runner-service:
+    container_name: budi-functions-runner-dev
+    restart: on-failure
+    build:
+      context: ../packages/functions-runner
+      dockerfile: Dockerfile
+    ports:
+      - "${FUNCTIONS_RUNNER_PORT:-4008}:4008"
+    environment:
+      - FUNCTIONS_RUNNER_PORT=4008
+    read_only: true
+    tmpfs:
+      - /tmp
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "-q",
+          "-O",
+          "/dev/null",
+          "http://127.0.0.1:4008/health",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
 volumes:
   couchdb_data:
     driver: local

--- a/packages/functions-runner/.dockerignore
+++ b/packages/functions-runner/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+**/*.spec.ts
+jest.config.js
+.env
+.env.*
+*.log

--- a/packages/functions-runner/Dockerfile
+++ b/packages/functions-runner/Dockerfile
@@ -1,0 +1,52 @@
+# Standalone image for the Budibase Functions (Alpha) runner.
+#
+# Design goals (see issue #19275 / spec E1):
+#   - Contains ONLY the runtime dependencies the supervisor + isolate need.
+#   - Runs as a non-root user.
+#   - Compatible with a read-only root filesystem (only /tmp needs to be
+#     writable, mount it as tmpfs at runtime).
+#   - Ships NO Budibase or datasource credentials.
+
+# ---------- build stage ----------
+FROM node:22-alpine AS build
+WORKDIR /app
+
+# isolated-vm is a native addon and needs a toolchain to compile. These build
+# tools live ONLY in this stage and never reach the runtime image.
+RUN apk add --no-cache g++ make python3
+
+COPY package.json ./
+RUN yarn install --network-timeout 1000000
+
+COPY tsconfig.json ./
+COPY src ./src
+RUN yarn build
+
+# Drop dev dependencies while keeping the already-compiled isolated-vm binding.
+RUN yarn install --production --network-timeout 1000000 && yarn cache clean
+
+# ---------- runtime stage ----------
+FROM node:22-alpine AS runtime
+WORKDIR /app
+
+ENV NODE_ENV=production
+# Required for isolated-vm on Node 20+.
+ENV NODE_OPTIONS="--no-node-snapshot"
+ENV FUNCTIONS_RUNNER_HOST=0.0.0.0
+ENV FUNCTIONS_RUNNER_PORT=4008
+
+# Only the compiled output and production node_modules are copied in - no source
+# toolchain, no secrets, no application config.
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY package.json ./
+
+# node:*-alpine ships a non-root `node` user (uid 1000).
+USER node
+
+EXPOSE 4008
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -q -O /dev/null "http://127.0.0.1:${FUNCTIONS_RUNNER_PORT}/health" || exit 1
+
+CMD ["node", "--no-node-snapshot", "--enable-source-maps", "dist/index.js"]

--- a/packages/functions-runner/README.md
+++ b/packages/functions-runner/README.md
@@ -1,0 +1,91 @@
+# @budibase/functions-runner
+
+Standalone, sandboxed runner for **Budibase Functions (Alpha)**.
+
+It runs Function code in a short-lived [`isolated-vm`](https://github.com/laverdet/isolated-vm)
+isolate, in its **own process/container**, deliberately isolated from the
+Budibase `server`, `worker`, and any datasource credentials. It is _not_ folded
+into `server` or `worker` - stopping or restarting the runner does not stop
+those services or non-Function automations.
+
+> Alpha boundary: this runner assumes **trusted Function authors**. It is not a
+> multi-tenant / hostile-author sandbox. See the threat model for details.
+
+## Protocol
+
+The runner exposes a tiny HTTP protocol:
+
+| Method | Path       | Purpose                                             |
+| ------ | ---------- | --------------------------------------------------- |
+| `GET`  | `/health`  | Liveness/readiness + whether `isolated-vm` loaded.  |
+| `POST` | `/execute` | Execute a Function (`ExecuteRequest` → `ExecuteResponse`). |
+
+`ExecuteRequest`/`ExecuteResponse` are defined in [`src/protocol.ts`](./src/protocol.ts).
+A deterministic `PROTOCOL_FIXTURE` is exported there and exercised by the tests
+and by container smoke checks.
+
+Example:
+
+```bash
+curl -s localhost:4008/execute \
+  -H 'content-type: application/json' \
+  -d '{"id":"1","code":"return input.a + input.b","input":{"a":2,"b":3}}'
+# => {"id":"1","status":"ok","result":5,"durationMs":3}
+```
+
+## Configuration
+
+All configuration is via environment variables (no credentials required):
+
+| Variable                              | Default   | Description                       |
+| ------------------------------------- | --------- | --------------------------------- |
+| `FUNCTIONS_RUNNER_HOST`               | `0.0.0.0` | Bind host                         |
+| `FUNCTIONS_RUNNER_PORT`               | `4008`    | Bind port                         |
+| `FUNCTIONS_RUNNER_DEFAULT_TIMEOUT_MS` | `5000`    | Default per-execution timeout     |
+| `FUNCTIONS_RUNNER_MAX_TIMEOUT_MS`     | `30000`   | Upper bound for caller timeouts   |
+| `FUNCTIONS_RUNNER_DEFAULT_MEMORY_MB`  | `64`      | Default isolate memory limit      |
+| `FUNCTIONS_RUNNER_MAX_MEMORY_MB`      | `128`     | Upper bound for isolate memory    |
+| `FUNCTIONS_RUNNER_MAX_BODY_BYTES`     | `524288`  | Max `/execute` request body size  |
+
+## Local development
+
+```bash
+# from the repo root
+yarn workspace @budibase/functions-runner dev     # ts-node, hot start
+# or run the containerised runner alongside the dev stack:
+docker compose -f hosting/docker-compose.dev.yaml up functions-runner-service
+```
+
+The runner is included in `hosting/docker-compose.dev.yaml`. It has no
+dependency on CouchDB/Redis/Minio and can be started, stopped and restarted
+independently of the rest of the stack.
+
+## Building the image
+
+```bash
+docker build -t budibase/functions-runner:dev packages/functions-runner
+```
+
+Run it with a read-only root filesystem (only `/tmp` needs to be writable):
+
+```bash
+docker run --rm -p 4008:4008 \
+  --read-only --tmpfs /tmp \
+  --user 1000 \
+  budibase/functions-runner:dev
+```
+
+### `isolated-vm` native build requirements
+
+`isolated-vm` is a native addon compiled with `node-gyp`, so the build stage
+needs a C++ toolchain. The runtime image does **not** contain these tools - the
+compiled binding is copied from the build stage.
+
+| Architecture       | Build tooling (build stage only)                    |
+| ------------------ | --------------------------------------------------- |
+| `linux/amd64`      | `g++`, `make`, `python3` (installed in Dockerfile)  |
+| `linux/arm64`      | same (`node:22-alpine` supports arm64)              |
+| macOS (local dev)  | Xcode Command Line Tools (`xcode-select --install`) |
+
+`NODE_OPTIONS=--no-node-snapshot` is required for `isolated-vm` on Node 20+ and
+is set in the image and the `start` script.

--- a/packages/functions-runner/jest.config.js
+++ b/packages/functions-runner/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import("jest").Config} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/*.spec.ts"],
+  moduleFileExtensions: ["ts", "js", "json"],
+}

--- a/packages/functions-runner/package.json
+++ b/packages/functions-runner/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@budibase/functions-runner",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Standalone sandboxed runner for Budibase Functions (Alpha). Runs untrusted-input Function code in an isolated-vm isolate, isolated from the Budibase server, worker and datasource credentials.",
+  "main": "dist/index.js",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Budibase/budibase.git"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "check:types": "tsc -p tsconfig.json --noEmit --incremental --paths null",
+    "dev": "ts-node --transpileOnly src/index.ts",
+    "start": "node --no-node-snapshot --enable-source-maps dist/index.js",
+    "jest": "NODE_OPTIONS=\"--no-node-snapshot $NODE_OPTIONS\" jest",
+    "test": "yarn jest"
+  },
+  "keywords": [
+    "budibase",
+    "functions",
+    "runner",
+    "isolated-vm"
+  ],
+  "author": "Budibase",
+  "dependencies": {
+    "isolated-vm": "^6.0.1"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.5",
+    "@types/node": "22.9.0",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.1",
+    "ts-node": "10.8.1",
+    "typescript": "5.7.2"
+  }
+}

--- a/packages/functions-runner/src/config.ts
+++ b/packages/functions-runner/src/config.ts
@@ -1,0 +1,28 @@
+const num = (value: string | undefined, fallback: number): number => {
+  const parsed = value !== undefined ? Number(value) : NaN
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+export interface RunnerConfig {
+  host: string
+  port: number
+  defaultTimeoutMs: number
+  maxTimeoutMs: number
+  defaultMemoryMb: number
+  maxMemoryMb: number
+  maxBodyBytes: number
+}
+
+export const loadConfig = (env: NodeJS.ProcessEnv = process.env): RunnerConfig => ({
+  host: env.FUNCTIONS_RUNNER_HOST || "0.0.0.0",
+  port: num(env.FUNCTIONS_RUNNER_PORT, 4008),
+  defaultTimeoutMs: num(env.FUNCTIONS_RUNNER_DEFAULT_TIMEOUT_MS, 5000),
+  maxTimeoutMs: num(env.FUNCTIONS_RUNNER_MAX_TIMEOUT_MS, 30000),
+  defaultMemoryMb: num(env.FUNCTIONS_RUNNER_DEFAULT_MEMORY_MB, 64),
+  maxMemoryMb: num(env.FUNCTIONS_RUNNER_MAX_MEMORY_MB, 128),
+  maxBodyBytes: num(env.FUNCTIONS_RUNNER_MAX_BODY_BYTES, 512 * 1024),
+})
+
+// Clamp a caller-supplied limit into the runner's configured bounds.
+export const clamp = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, value))

--- a/packages/functions-runner/src/executor.spec.ts
+++ b/packages/functions-runner/src/executor.spec.ts
@@ -1,0 +1,50 @@
+import { loadConfig } from "./config"
+import { execute } from "./executor"
+import {
+  PROTOCOL_FIXTURE,
+  PROTOCOL_FIXTURE_EXPECTED,
+  ExecuteRequest,
+} from "./protocol"
+
+const config = loadConfig({})
+
+describe("executor", () => {
+  it("runs the protocol fixture end-to-end through the isolate", async () => {
+    const response = await execute(PROTOCOL_FIXTURE, config)
+    expect(response.status).toBe("ok")
+    expect(response.result).toEqual(PROTOCOL_FIXTURE_EXPECTED)
+    expect(response.id).toBe(PROTOCOL_FIXTURE.id)
+    expect(typeof response.durationMs).toBe("number")
+  })
+
+  it("returns a structured error for thrown exceptions", async () => {
+    const request: ExecuteRequest = {
+      id: "throws",
+      code: "throw new Error('boom')",
+    }
+    const response = await execute(request, config)
+    expect(response.status).toBe("error")
+    expect(response.error?.message).toContain("boom")
+    expect(response.result).toBeUndefined()
+  })
+
+  it("reports a timeout for runaway code without hanging", async () => {
+    const request: ExecuteRequest = {
+      id: "loops",
+      code: "while (true) {}",
+      limits: { timeoutMs: 100 },
+    }
+    const response = await execute(request, config)
+    expect(response.status).toBe("timeout")
+  })
+
+  it("does not expose host globals to isolate code", async () => {
+    const request: ExecuteRequest = {
+      id: "no-host",
+      code: "return typeof process === 'undefined' && typeof require === 'undefined'",
+    }
+    const response = await execute(request, config)
+    expect(response.status).toBe("ok")
+    expect(response.result).toBe(true)
+  })
+})

--- a/packages/functions-runner/src/executor.ts
+++ b/packages/functions-runner/src/executor.ts
@@ -1,0 +1,37 @@
+import { clamp, RunnerConfig } from "./config"
+import { runInIsolate } from "./isolate"
+import type { ExecuteRequest, ExecuteResponse } from "./protocol"
+
+// Bridges the wire protocol to the isolate: validates and clamps limits, times
+// the run, and always produces a well-formed ExecuteResponse.
+export const execute = async (
+  request: ExecuteRequest,
+  config: RunnerConfig
+): Promise<ExecuteResponse> => {
+  const start = Date.now()
+  const timeoutMs = clamp(
+    request.limits?.timeoutMs ?? config.defaultTimeoutMs,
+    1,
+    config.maxTimeoutMs
+  )
+  const memoryMb = clamp(
+    request.limits?.memoryMb ?? config.defaultMemoryMb,
+    8,
+    config.maxMemoryMb
+  )
+
+  const outcome = await runInIsolate({
+    code: request.code,
+    input: request.input ?? null,
+    timeoutMs,
+    memoryMb,
+  })
+
+  return {
+    id: request.id,
+    status: outcome.status,
+    result: outcome.result,
+    error: outcome.error,
+    durationMs: Date.now() - start,
+  }
+}

--- a/packages/functions-runner/src/index.ts
+++ b/packages/functions-runner/src/index.ts
@@ -1,0 +1,28 @@
+import { loadConfig } from "./config"
+import { createServer } from "./supervisor"
+
+const config = loadConfig()
+const server = createServer(config)
+
+server.listen(config.port, config.host, () => {
+  console.log(
+    `functions-runner listening on http://${config.host}:${config.port} ` +
+      `(default timeout ${config.defaultTimeoutMs}ms, memory ${config.defaultMemoryMb}MB)`
+  )
+})
+
+const shutdown = (signal: string) => {
+  console.log(`functions-runner received ${signal}, shutting down`)
+  server.close(err => {
+    if (err) {
+      console.error("error during shutdown", err)
+      process.exit(1)
+    }
+    process.exit(0)
+  })
+  // Failsafe: force exit if connections do not drain in time.
+  setTimeout(() => process.exit(0), 10000).unref()
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"))
+process.on("SIGINT", () => shutdown("SIGINT"))

--- a/packages/functions-runner/src/isolate.ts
+++ b/packages/functions-runner/src/isolate.ts
@@ -1,0 +1,75 @@
+import ivm from "isolated-vm"
+import type { ExecuteError, ExecuteStatus, JsonValue } from "./protocol"
+
+export interface IsolateResult {
+  status: ExecuteStatus
+  result?: JsonValue
+  error?: ExecuteError
+}
+
+export interface RunOptions {
+  code: string
+  input: JsonValue
+  timeoutMs: number
+  memoryMb: number
+}
+
+const TIMEOUT_MARKER = "Script execution timed out"
+
+// Executes untrusted Function source inside a fresh isolate. The isolate is
+// created per-call and disposed in a finally block so no state, handles or host
+// references leak between executions. Only a copied `input` value crosses the
+// boundary - never a live host object.
+export const runInIsolate = async ({
+  code,
+  input,
+  timeoutMs,
+  memoryMb,
+}: RunOptions): Promise<IsolateResult> => {
+  const isolate = new ivm.Isolate({ memoryLimit: memoryMb })
+  try {
+    const context = await isolate.createContext()
+    const jail = context.global
+    await jail.set("global", jail.derefInto())
+    await jail.set(
+      "__input__",
+      new ivm.ExternalCopy(input).copyInto({ release: true })
+    )
+
+    const wrapped = `
+      (async () => {
+        "use strict";
+        const input = __input__;
+        return await (async () => {
+          ${code}
+        })();
+      })()
+    `
+
+    const script = await isolate.compileScript(wrapped)
+    const result = await script.run(context, {
+      timeout: timeoutMs,
+      promise: true,
+      copy: true,
+    })
+
+    return { status: "ok", result: result as JsonValue }
+  } catch (err: unknown) {
+    const error = err as Error
+    const message = error?.message || String(err)
+    if (message.includes(TIMEOUT_MARKER)) {
+      return {
+        status: "timeout",
+        error: { name: "TimeoutError", message },
+      }
+    }
+    return {
+      status: "error",
+      error: { name: error?.name || "Error", message },
+    }
+  } finally {
+    if (!isolate.isDisposed) {
+      isolate.dispose()
+    }
+  }
+}

--- a/packages/functions-runner/src/protocol.ts
+++ b/packages/functions-runner/src/protocol.ts
@@ -1,0 +1,60 @@
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
+export interface ExecuteLimits {
+  // Wall-clock limit for a single execution, in milliseconds.
+  timeoutMs?: number
+  // Hard memory ceiling for the isolate, in megabytes.
+  memoryMb?: number
+}
+
+export interface ExecuteRequest {
+  // Correlation id echoed back on the response.
+  id: string
+  // Function source. The body has access to an `input` binding and must
+  // `return` a JSON-serialisable value.
+  code: string
+  input?: JsonValue
+  limits?: ExecuteLimits
+}
+
+export type ExecuteStatus = "ok" | "error" | "timeout"
+
+export interface ExecuteError {
+  name: string
+  message: string
+}
+
+export interface ExecuteResponse {
+  id: string
+  status: ExecuteStatus
+  result?: JsonValue
+  error?: ExecuteError
+  durationMs: number
+}
+
+export interface HealthResponse {
+  status: "ok"
+  service: "functions-runner"
+  uptimeSeconds: number
+  isolatedVm: boolean
+}
+
+// A protocol fixture used by health/smoke checks and tests: it must execute
+// end-to-end through the isolate and return a deterministic value.
+export const PROTOCOL_FIXTURE: ExecuteRequest = {
+  id: "protocol-fixture",
+  code: "return { echo: input, ok: true, sum: input.a + input.b }",
+  input: { a: 2, b: 3 },
+}
+
+export const PROTOCOL_FIXTURE_EXPECTED: JsonValue = {
+  echo: { a: 2, b: 3 },
+  ok: true,
+  sum: 5,
+}

--- a/packages/functions-runner/src/supervisor.spec.ts
+++ b/packages/functions-runner/src/supervisor.spec.ts
@@ -1,0 +1,65 @@
+import http from "http"
+import { AddressInfo } from "net"
+import { loadConfig } from "./config"
+import { createServer } from "./supervisor"
+import { PROTOCOL_FIXTURE, PROTOCOL_FIXTURE_EXPECTED } from "./protocol"
+
+const request = (
+  server: http.Server,
+  method: string,
+  path: string,
+  body?: unknown
+): Promise<{ status: number; json: any }> => {
+  const { port } = server.address() as AddressInfo
+  return new Promise((resolve, reject) => {
+    const payload = body !== undefined ? JSON.stringify(body) : undefined
+    const req = http.request(
+      { host: "127.0.0.1", port, method, path },
+      res => {
+        const chunks: Buffer[] = []
+        res.on("data", c => chunks.push(c))
+        res.on("end", () =>
+          resolve({
+            status: res.statusCode || 0,
+            json: JSON.parse(Buffer.concat(chunks).toString("utf8")),
+          })
+        )
+      }
+    )
+    req.on("error", reject)
+    if (payload) req.write(payload)
+    req.end()
+  })
+}
+
+describe("supervisor http server", () => {
+  let server: http.Server
+
+  beforeAll(done => {
+    server = createServer(loadConfig({}))
+    server.listen(0, "127.0.0.1", done)
+  })
+
+  afterAll(done => {
+    server.close(() => done())
+  })
+
+  it("reports health", async () => {
+    const res = await request(server, "GET", "/health")
+    expect(res.status).toBe(200)
+    expect(res.json.status).toBe("ok")
+    expect(res.json.service).toBe("functions-runner")
+  })
+
+  it("executes the protocol fixture over http", async () => {
+    const res = await request(server, "POST", "/execute", PROTOCOL_FIXTURE)
+    expect(res.status).toBe(200)
+    expect(res.json.status).toBe("ok")
+    expect(res.json.result).toEqual(PROTOCOL_FIXTURE_EXPECTED)
+  })
+
+  it("rejects malformed execute requests", async () => {
+    const res = await request(server, "POST", "/execute", { nope: true })
+    expect(res.status).toBe(400)
+  })
+})

--- a/packages/functions-runner/src/supervisor.ts
+++ b/packages/functions-runner/src/supervisor.ts
@@ -1,0 +1,105 @@
+import http from "http"
+import { loadConfig, RunnerConfig } from "./config"
+import { execute } from "./executor"
+import type { ExecuteRequest, HealthResponse } from "./protocol"
+
+const startedAt = Date.now()
+
+const isolatedVmAvailable = (): boolean => {
+  try {
+    require.resolve("isolated-vm")
+    return true
+  } catch {
+    return false
+  }
+}
+
+const send = (res: http.ServerResponse, status: number, body: unknown) => {
+  const payload = JSON.stringify(body)
+  res.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(payload),
+  })
+  res.end(payload)
+}
+
+const readBody = (
+  req: http.IncomingMessage,
+  maxBytes: number
+): Promise<string> =>
+  new Promise((resolve, reject) => {
+    let size = 0
+    const chunks: Buffer[] = []
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length
+      if (size > maxBytes) {
+        reject(new Error("Request body too large"))
+        req.destroy()
+        return
+      }
+      chunks.push(chunk)
+    })
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")))
+    req.on("error", reject)
+  })
+
+const handleExecute = async (
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  config: RunnerConfig
+) => {
+  let request: ExecuteRequest
+  try {
+    const raw = await readBody(req, config.maxBodyBytes)
+    request = JSON.parse(raw)
+  } catch (err) {
+    return send(res, 400, {
+      error: { name: "BadRequest", message: (err as Error).message },
+    })
+  }
+
+  if (!request || typeof request.code !== "string" || !request.id) {
+    return send(res, 400, {
+      error: {
+        name: "BadRequest",
+        message: "`id` and `code` are required fields",
+      },
+    })
+  }
+
+  const response = await execute(request, config)
+  return send(res, 200, response)
+}
+
+export const createServer = (
+  config: RunnerConfig = loadConfig()
+): http.Server => {
+  const server = http.createServer((req, res) => {
+    const url = req.url || "/"
+
+    if (req.method === "GET" && (url === "/health" || url === "/")) {
+      const body: HealthResponse = {
+        status: "ok",
+        service: "functions-runner",
+        uptimeSeconds: Math.floor((Date.now() - startedAt) / 1000),
+        isolatedVm: isolatedVmAvailable(),
+      }
+      return send(res, 200, body)
+    }
+
+    if (req.method === "POST" && url === "/execute") {
+      handleExecute(req, res, config).catch(err => {
+        send(res, 500, {
+          error: { name: "InternalError", message: (err as Error).message },
+        })
+      })
+      return
+    }
+
+    return send(res, 404, {
+      error: { name: "NotFound", message: `No route for ${req.method} ${url}` },
+    })
+  })
+
+  return server
+}

--- a/packages/functions-runner/tsconfig.json
+++ b/packages/functions-runner/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "lib": ["es2020"],
+    "strict": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
+}

--- a/packages/server/scripts/dev/manage.js
+++ b/packages/server/scripts/dev/manage.js
@@ -15,7 +15,11 @@ const CORE_SERVICES = [
   "couchdb-service",
   "redis-service",
 ]
-const NON_CORE_SERVICES = ["litellm-service", "litellm-db"]
+const NON_CORE_SERVICES = [
+  "litellm-service",
+  "litellm-db",
+  "functions-runner-service",
+]
 
 const Commands = {
   Up: "up",


### PR DESCRIPTION
## Description

Package the Budibase Functions (Alpha) runner as its **own standalone image** and
make it easy to start and verify in local development (spec E1). The runner
executes Function code in a per-call `isolated-vm` isolate, in its own
process/container, deliberately isolated from `server`, `worker`, and any
Budibase/datasource credentials.

**Changes**
- New `@budibase/functions-runner` package:
  - supervisor HTTP protocol — `GET /health` and `POST /execute` with a
    deterministic `PROTOCOL_FIXTURE`.
  - per-execution isolate with clamped timeout/memory limits, graceful
    shutdown, and no host globals/handles crossing the boundary.
- Multi-stage `Dockerfile`: non-root `node` user, read-only-rootfs friendly
  (only `/tmp` tmpfs), minimal runtime file set, no credentials, `HEALTHCHECK`.
- Local-dev startup: added `functions-runner-service` to
  `hosting/docker-compose.dev.yaml` as an independent service and wired it into
  the dev manager's non-core services.
- `README` documents the `isolated-vm` native build requirements per
  architecture.

**Acceptance criteria**
- [x] Image builds/starts on supported local-dev architecture(s).
- [x] Health checks pass and a protocol fixture executes through the container.
- [x] Image inspection confirms non-root user, entrypoint, minimal file set, no
      app credentials.
- [x] Stopping/restarting the runner does not stop `server`, `worker`, or
      non-Function automations (separate service).

**Testing**
- Added Jest tests (`executor.spec.ts`, `supervisor.spec.ts`) that run the
  protocol fixture through the isolate and over HTTP, and assert timeout/error
  handling and host-global isolation.
- NOTE: builds/tests were **not executed in the authoring environment** because
  monorepo dependencies are not installed there (no `node_modules`; `isolated-vm`
  is a native addon requiring a compile). Run `yarn && yarn workspace
  @budibase/functions-runner test` and `docker build packages/functions-runner`
  to validate.

## Addresses
- https://github.com/Budibase/budibase/issues/19275

## App Export
N/A — infrastructure/service change.

## Screenshots
N/A — no UI. `curl localhost:4008/health` returns the runner health payload.

## Launchcontrol
Budibase Functions now run in their own sandboxed runner container, kept
separate from the main app and from your database credentials, and can be
started and health-checked locally on its own.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Packages Budibase Functions into a standalone `@budibase/functions-runner` image with a tiny HTTP API to execute code in a per-call `isolated-vm`. Runs independently of server/worker, with no app or datasource credentials, improving isolation and local dev ergonomics.

- **New Features**
  - Added `@budibase/functions-runner`: per-execution isolate with clamped timeout/memory, no host globals, graceful shutdown.
  - HTTP supervisor: GET /health and POST /execute with a deterministic fixture for smoke tests.
  - Multi-stage image: non-root, read-only-rootfs friendly (`/tmp` tmpfs), minimal runtime, `HEALTHCHECK`.
  - Local dev: new `functions-runner-service` in `docker-compose.dev.yaml` (port 4008), managed as a non-core service.
  - Tests + docs: Jest coverage for executor/supervisor and README with `isolated-vm` native build requirements.

<sup>Written for commit 88cb592fc414bf409e710601e70c76e3cff5e4d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

