### PR TITLE
Enforce Functions runner resource limits

### DIFF
--- a/packages/functions-runner/src/child.ts
+++ b/packages/functions-runner/src/child.ts
@@ -25,7 +25,8 @@ const sendResult = (result: FunctionRunResult) => {
 
 const executeQuery = (
   capabilityId: string,
-  parameters: Record<string, JSONValue>
+  parameters: Record<string, JSONValue>,
+  signal: AbortSignal
 ) =>
   new Promise<JSONValue>((resolve, reject) => {
     if (!process.send) {
@@ -33,7 +34,26 @@ const executeQuery = (
       return
     }
     const requestId = String(++nextQueryId)
-    pendingQueries.set(requestId, { resolve, reject })
+    const abort = () => {
+      pendingQueries.delete(requestId)
+      reject(new Error("Function query was cancelled"))
+    }
+    if (signal.aborted) {
+      abort()
+      return
+    }
+    signal.addEventListener("abort", abort, { once: true })
+    const removeAbortListener = () => signal.removeEventListener("abort", abort)
+    pendingQueries.set(requestId, {
+      resolve: value => {
+        removeAbortListener()
+        resolve(value)
+      },
+      reject: error => {
+        removeAbortListener()
+        reject(error)
+      },
+    })
     const message: ChildMessage = {
       type: "query",
       requestId,
@@ -43,6 +63,7 @@ const executeQuery = (
     process.send(message, undefined, undefined, error => {
       if (error) {
         pendingQueries.delete(requestId)
+        removeAbortListener()
         reject(new Error("Function query transport failed"))
       }
     })
@@ -73,7 +94,11 @@ process.on("message", async (value: unknown) => {
     handledRequest = true
     sendResult(
       await executeFunctionInIsolate(message.request, queryRequest =>
-        executeQuery(queryRequest.capabilityId, queryRequest.parameters)
+        executeQuery(
+          queryRequest.capabilityId,
+          queryRequest.parameters,
+          queryRequest.signal
+        )
       )
     )
   } catch {

--- a/packages/functions-runner/src/isolate-bootstrap.js
+++ b/packages/functions-runner/src/isolate-bootstrap.js
@@ -14,11 +14,28 @@
     globalThis,
     "__budibaseInvokeQueryReference"
   )
-  const query = (capabilityId, parameters) =>
-    queryReference.apply(undefined, [capabilityId, parameters], {
-      arguments: { copy: true },
-      result: { promise: true, copy: true },
-    })
+  const query = async (capabilityId, parameters) => {
+    const response = await queryReference.apply(
+      undefined,
+      [capabilityId, parameters],
+      {
+        arguments: { copy: true },
+        result: { promise: true, copy: true },
+      }
+    )
+    if (response.error) {
+      throw new Error(response.error)
+    }
+    return response.result
+  }
+  const noop = Object.freeze(() => {})
+  const consoleValue = Object.freeze({
+    debug: noop,
+    info: noop,
+    log: noop,
+    warn: noop,
+    error: noop,
+  })
 
   Object.defineProperty(globalThis, "__budibaseInputs", {
     value: deepFreeze(inputsValue),
@@ -27,6 +44,11 @@
   })
   Object.defineProperty(globalThis, "__budibaseInvokeQuery", {
     value: Object.freeze(query),
+    writable: false,
+    configurable: false,
+  })
+  Object.defineProperty(globalThis, "console", {
+    value: consoleValue,
     writable: false,
     configurable: false,
   })

--- a/packages/functions-runner/src/isolatedVmRuntime.spec.ts
+++ b/packages/functions-runner/src/isolatedVmRuntime.spec.ts
@@ -148,6 +148,163 @@ describe("Functions isolate", () => {
     })
   })
 
+  it("rejects output over the byte limit", async () => {
+    const runRequest = request(`
+      export default async function run() {
+        return { output: { value: "too large" } }
+      }
+    `)
+    runRequest.limits = { ...runRequest.limits, maxOutputBytes: 10 }
+
+    await expect(
+      executeFunctionInIsolate(runRequest, noQueries)
+    ).resolves.toMatchObject({
+      status: "error",
+      error: { code: FunctionErrorCode.FUNCTION_OUTPUT_INVALID },
+    })
+  })
+
+  it.each([
+    ["before await", `while (true) {}`],
+    ["after await", `await Promise.resolve(); while (true) {}`],
+    ["unresolved promise", `await new Promise(() => {})`],
+  ])("times out an infinite run %s", async (_name, body) => {
+    const runRequest = request(`
+      export default async function run() {
+        ${body}
+        return { output: {} }
+      }
+    `)
+    runRequest.limits = { ...runRequest.limits, timeoutMs: 20 }
+
+    await expect(
+      executeFunctionInIsolate(runRequest, noQueries)
+    ).resolves.toMatchObject({
+      status: "error",
+      error: { code: FunctionErrorCode.FUNCTION_TIMEOUT },
+    })
+  })
+
+  it("returns a stable error under isolate memory pressure", async () => {
+    const runRequest = request(`
+      export default async function run() {
+        const values = []
+        while (true) {
+          values.push(new Array(100000).fill("memory pressure"))
+        }
+      }
+    `)
+    runRequest.limits = {
+      ...runRequest.limits,
+      isolateMemoryLimitMb: 8,
+      timeoutMs: 2_000,
+    }
+
+    await expect(
+      executeFunctionInIsolate(runRequest, noQueries)
+    ).resolves.toMatchObject({
+      status: "error",
+      error: { code: FunctionErrorCode.FUNCTION_MEMORY_LIMIT },
+    })
+  })
+
+  it("enforces the total query count", async () => {
+    const runRequest = request(`
+      export default async function run() {
+        await globalThis.__budibaseInvokeQuery("first", {})
+        await globalThis.__budibaseInvokeQuery("second", {})
+        return { output: {} }
+      }
+    `)
+    runRequest.limits = { ...runRequest.limits, maxQueryCalls: 1 }
+
+    await expect(
+      executeFunctionInIsolate(
+        runRequest,
+        () => new Promise(resolve => setTimeout(() => resolve({}), 10))
+      )
+    ).resolves.toMatchObject({
+      status: "error",
+      metrics: { queryCount: 1 },
+      error: { code: FunctionErrorCode.FUNCTION_QUERY_LIMIT },
+    })
+  })
+
+  it("enforces concurrent query calls", async () => {
+    const runRequest = request(`
+      export default async function run() {
+        await Promise.all([
+          globalThis.__budibaseInvokeQuery("first", {}),
+          globalThis.__budibaseInvokeQuery("second", {}),
+        ])
+        return { output: {} }
+      }
+    `)
+    runRequest.limits = {
+      ...runRequest.limits,
+      maxConcurrentQueryCalls: 1,
+    }
+
+    await expect(
+      executeFunctionInIsolate(
+        runRequest,
+        () => new Promise(resolve => setTimeout(() => resolve({}), 10))
+      )
+    ).resolves.toMatchObject({
+      status: "error",
+      metrics: { queryCount: 1 },
+      error: { code: FunctionErrorCode.FUNCTION_QUERY_LIMIT },
+    })
+  })
+
+  it("rejects oversized query results", async () => {
+    const runRequest = request(`
+      export default async function run() {
+        await globalThis.__budibaseInvokeQuery("query", {})
+        return { output: {} }
+      }
+    `)
+    runRequest.limits = { ...runRequest.limits, maxQueryResponseBytes: 10 }
+
+    await expect(
+      executeFunctionInIsolate(runRequest, async () => ({
+        value: "too large",
+      }))
+    ).resolves.toMatchObject({
+      status: "error",
+      error: { code: FunctionErrorCode.FUNCTION_PROTOCOL_ERROR },
+    })
+  })
+
+  it("provides a frozen no-op console", async () => {
+    const result = await executeFunctionInIsolate(
+      request(`
+      export default async function run() {
+        console.log("abcdef")
+        console.warn("ééé")
+        console.error("ignored")
+        return {
+          output: {
+            consoleFrozen: Object.isFrozen(console),
+            logFrozen: Object.isFrozen(console.log),
+          },
+        }
+      }
+    `),
+      noQueries
+    )
+
+    expect(result).toMatchObject({
+      status: "success",
+      output: {
+        consoleFrozen: true,
+        logFrozen: true,
+      },
+      metrics: { logBytes: 0 },
+    })
+    expect(result.logs).toBeUndefined()
+  })
+
   it("does not retain globals between invocations", async () => {
     const compiledJavaScript = `
       globalThis.invocationCount = (globalThis.invocationCount || 0) + 1

--- a/packages/functions-runner/src/isolatedVmRuntime.spec.ts
+++ b/packages/functions-runner/src/isolatedVmRuntime.spec.ts
@@ -45,6 +45,7 @@ describe("Functions isolate", () => {
       grantToken: FUNCTION_RUN_REQUEST_FIXTURE.grantToken,
       capabilityId: "capability-1",
       parameters: { id: "hello" },
+      signal: expect.any(AbortSignal),
     })
   })
 
@@ -253,6 +254,47 @@ describe("Functions isolate", () => {
     ).resolves.toMatchObject({
       status: "error",
       metrics: { queryCount: 1 },
+      error: { code: FunctionErrorCode.FUNCTION_QUERY_LIMIT },
+    })
+  })
+
+  it.each([
+    [
+      "total",
+      `
+        await query("first", {})
+        try {
+          await query("second", {})
+        } catch {}
+      `,
+      { maxQueryCalls: 1 },
+    ],
+    [
+      "concurrent",
+      `
+        try {
+          await Promise.all([query("first", {}), query("second", {})])
+        } catch {}
+      `,
+      { maxConcurrentQueryCalls: 1 },
+    ],
+  ])("keeps a caught %s query limit terminal", async (_name, body, limits) => {
+    const runRequest = request(`
+      export default async function run() {
+        const query = globalThis.__budibaseInvokeQuery
+        ${body}
+        return { output: { caught: true } }
+      }
+    `)
+    runRequest.limits = { ...runRequest.limits, ...limits }
+
+    await expect(
+      executeFunctionInIsolate(
+        runRequest,
+        () => new Promise(resolve => setTimeout(() => resolve({}), 10))
+      )
+    ).resolves.toMatchObject({
+      status: "error",
       error: { code: FunctionErrorCode.FUNCTION_QUERY_LIMIT },
     })
   })

--- a/packages/functions-runner/src/isolatedVmRuntime.ts
+++ b/packages/functions-runner/src/isolatedVmRuntime.ts
@@ -36,6 +36,7 @@ export interface FunctionQueryRequest {
   grantToken: string
   capabilityId: string
   parameters: Record<string, JSONValue>
+  signal: AbortSignal
 }
 
 export type FunctionQueryHandler = (
@@ -197,8 +198,10 @@ export const executeFunctionInIsolate = async (
   const startedAt = Date.now()
   let queryCount = 0
   let concurrentQueryCount = 0
+  let queryLimitExceeded = false
   let errorCode: FunctionErrorCode = FunctionErrorCode.FUNCTION_RUNTIME_ERROR
   let wallTimedOut = false
+  const queryAbortController = new AbortController()
   let isolate: ivm.Isolate
   try {
     isolate = new ivm.Isolate({
@@ -210,6 +213,7 @@ export const executeFunctionInIsolate = async (
 
   const wallTimer = setTimeout(() => {
     wallTimedOut = true
+    queryAbortController.abort()
     if (!isolate.isDisposed) {
       isolate.dispose()
     }
@@ -239,6 +243,7 @@ export const executeFunctionInIsolate = async (
           queryCount >= request.limits.maxQueryCalls ||
           concurrentQueryCount >= request.limits.maxConcurrentQueryCalls
         ) {
+          queryLimitExceeded = true
           errorCode = FunctionErrorCode.FUNCTION_QUERY_LIMIT
           return { error: QUERY_LIMIT_MESSAGE }
         }
@@ -251,6 +256,7 @@ export const executeFunctionInIsolate = async (
             grantToken: request.grantToken,
             capabilityId: capabilityIdValue,
             parameters,
+            signal: queryAbortController.signal,
           })
         } catch {
           return { error: QUERY_FAILED_MESSAGE }
@@ -314,6 +320,14 @@ export const executeFunctionInIsolate = async (
             result: { copy: true, promise: true },
             timeout: request.limits.timeoutMs,
           })
+          if (queryLimitExceeded) {
+            return createFailure(
+              request,
+              startedAt,
+              queryCount,
+              FunctionErrorCode.FUNCTION_QUERY_LIMIT
+            )
+          }
           try {
             return createResult(request, startedAt, queryCount, value)
           } catch {
@@ -343,6 +357,7 @@ export const executeFunctionInIsolate = async (
     return createFailure(request, startedAt, queryCount, errorCode)
   } finally {
     clearTimeout(wallTimer)
+    queryAbortController.abort()
     if (!isolate.isDisposed) {
       isolate.dispose()
     }

--- a/packages/functions-runner/src/isolatedVmRuntime.ts
+++ b/packages/functions-runner/src/isolatedVmRuntime.ts
@@ -15,6 +15,10 @@ export const FUNCTION_INVOKE_QUERY_GLOBAL = "__budibaseInvokeQuery"
 const INVALID_OUTPUT_MESSAGE = "Function output is invalid"
 const RUNTIME_ERROR_MESSAGE = "Function execution failed"
 const INVALID_QUERY_MESSAGE = "Function query payload is invalid"
+const QUERY_LIMIT_MESSAGE = "Function query limit exceeded"
+const QUERY_FAILED_MESSAGE = "Function query failed"
+const MEMORY_LIMIT_MESSAGE = "Function memory limit exceeded"
+const TIMEOUT_MESSAGE = "Function run timed out"
 const bootstrapSource = readFileSync(
   path.join(__dirname, "isolate-bootstrap.js"),
   "utf8"
@@ -151,11 +155,26 @@ const createResult = (
   }
 }
 
+const failureMessage = (code: FunctionErrorCode) => {
+  switch (code) {
+    case FunctionErrorCode.FUNCTION_OUTPUT_INVALID:
+      return INVALID_OUTPUT_MESSAGE
+    case FunctionErrorCode.FUNCTION_QUERY_LIMIT:
+      return QUERY_LIMIT_MESSAGE
+    case FunctionErrorCode.FUNCTION_MEMORY_LIMIT:
+      return MEMORY_LIMIT_MESSAGE
+    case FunctionErrorCode.FUNCTION_TIMEOUT:
+      return TIMEOUT_MESSAGE
+    default:
+      return RUNTIME_ERROR_MESSAGE
+  }
+}
+
 const createFailure = (
   request: FunctionRunRequest,
   startedAt: number,
   queryCount: number,
-  outputError: boolean
+  code: FunctionErrorCode
 ): FunctionRunResult => ({
   runId: request.runId,
   status: "error",
@@ -166,10 +185,8 @@ const createFailure = (
     logBytes: 0,
   },
   error: {
-    code: outputError
-      ? FunctionErrorCode.FUNCTION_OUTPUT_INVALID
-      : FunctionErrorCode.FUNCTION_RUNTIME_ERROR,
-    message: outputError ? INVALID_OUTPUT_MESSAGE : RUNTIME_ERROR_MESSAGE,
+    code,
+    message: failureMessage(code),
   },
 })
 
@@ -179,45 +196,82 @@ export const executeFunctionInIsolate = async (
 ): Promise<FunctionRunResult> => {
   const startedAt = Date.now()
   let queryCount = 0
-  let outputError = false
+  let concurrentQueryCount = 0
+  let errorCode: FunctionErrorCode = FunctionErrorCode.FUNCTION_RUNTIME_ERROR
+  let wallTimedOut = false
   let isolate: ivm.Isolate
   try {
     isolate = new ivm.Isolate({
       memoryLimit: request.limits.isolateMemoryLimitMb,
     })
   } catch {
-    return createFailure(request, startedAt, queryCount, false)
+    return createFailure(request, startedAt, queryCount, errorCode)
   }
+
+  const wallTimer = setTimeout(() => {
+    wallTimedOut = true
+    if (!isolate.isDisposed) {
+      isolate.dispose()
+    }
+  }, request.limits.timeoutMs)
 
   try {
     const context = await isolate.createContext()
     const queryReference = new ivm.Reference(
       async (capabilityIdValue: unknown, parametersValue: unknown) => {
         if (typeof capabilityIdValue !== "string" || !capabilityIdValue) {
-          throw new FunctionOutputError(INVALID_QUERY_MESSAGE)
+          errorCode = FunctionErrorCode.FUNCTION_PROTOCOL_ERROR
+          return { error: INVALID_QUERY_MESSAGE }
         }
-        const { normalized: parameters } = normalizeRecord(
-          parametersValue,
-          request.limits.maxInputDepth,
-          request.limits.maxInputBytes,
-          INVALID_QUERY_MESSAGE
-        )
+        let parameters: Record<string, JSONValue>
+        try {
+          parameters = normalizeRecord(
+            parametersValue,
+            request.limits.maxInputDepth,
+            request.limits.maxInputBytes,
+            INVALID_QUERY_MESSAGE
+          ).normalized
+        } catch {
+          errorCode = FunctionErrorCode.FUNCTION_PROTOCOL_ERROR
+          return { error: INVALID_QUERY_MESSAGE }
+        }
+        if (
+          queryCount >= request.limits.maxQueryCalls ||
+          concurrentQueryCount >= request.limits.maxConcurrentQueryCalls
+        ) {
+          errorCode = FunctionErrorCode.FUNCTION_QUERY_LIMIT
+          return { error: QUERY_LIMIT_MESSAGE }
+        }
         queryCount += 1
-        const result = await queryHandler({
-          runId: request.runId,
-          grantToken: request.grantToken,
-          capabilityId: capabilityIdValue,
-          parameters,
-        })
-        return normalizeValue(
-          result,
-          request.limits.maxQueryResponseDepth,
-          request.limits.maxQueryResponseBytes,
-          INVALID_QUERY_MESSAGE
-        ).normalized
+        concurrentQueryCount += 1
+        let result: JSONValue
+        try {
+          result = await queryHandler({
+            runId: request.runId,
+            grantToken: request.grantToken,
+            capabilityId: capabilityIdValue,
+            parameters,
+          })
+        } catch {
+          return { error: QUERY_FAILED_MESSAGE }
+        } finally {
+          concurrentQueryCount -= 1
+        }
+        try {
+          return {
+            result: normalizeValue(
+              result,
+              request.limits.maxQueryResponseDepth,
+              request.limits.maxQueryResponseBytes,
+              INVALID_QUERY_MESSAGE
+            ).normalized,
+          }
+        } catch {
+          errorCode = FunctionErrorCode.FUNCTION_PROTOCOL_ERROR
+          return { error: INVALID_QUERY_MESSAGE }
+        }
       }
     )
-
     try {
       const jail = context.global
       await jail.set("globalThis", jail.derefInto())
@@ -263,7 +317,7 @@ export const executeFunctionInIsolate = async (
           try {
             return createResult(request, startedAt, queryCount, value)
           } catch {
-            outputError = true
+            errorCode = FunctionErrorCode.FUNCTION_OUTPUT_INVALID
             throw new FunctionOutputError(INVALID_OUTPUT_MESSAGE)
           }
         } finally {
@@ -277,11 +331,20 @@ export const executeFunctionInIsolate = async (
       context.release()
     }
   } catch (error) {
-    if (error instanceof FunctionOutputError) {
-      outputError = true
+    if (wallTimedOut) {
+      errorCode = FunctionErrorCode.FUNCTION_TIMEOUT
+    } else if (error instanceof FunctionOutputError) {
+      errorCode = FunctionErrorCode.FUNCTION_OUTPUT_INVALID
+    } else if (isolate.isDisposed) {
+      errorCode = FunctionErrorCode.FUNCTION_MEMORY_LIMIT
+    } else if (String(error).toLowerCase().includes("timed out")) {
+      errorCode = FunctionErrorCode.FUNCTION_TIMEOUT
     }
-    return createFailure(request, startedAt, queryCount, outputError)
+    return createFailure(request, startedAt, queryCount, errorCode)
   } finally {
-    isolate.dispose()
+    clearTimeout(wallTimer)
+    if (!isolate.isDisposed) {
+      isolate.dispose()
+    }
   }
 }

--- a/packages/functions-runner/src/jsonLimits.ts
+++ b/packages/functions-runner/src/jsonLimits.ts
@@ -1,0 +1,37 @@
+import type { JSONValue } from "@budibase/types"
+
+export class JSONLimitError extends Error {}
+
+export interface JSONLimits {
+  maxBytes: number
+  maxDepth: number
+}
+
+const visitJSON = (value: JSONValue, maxDepth: number, depth: number): void => {
+  if (depth > maxDepth) {
+    throw new JSONLimitError()
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      visitJSON(item, maxDepth, depth + 1)
+    }
+    return
+  }
+  if (value && typeof value === "object") {
+    for (const item of Object.values(value)) {
+      visitJSON(item, maxDepth, depth + 1)
+    }
+  }
+}
+
+export const validateJSONLimits = (
+  value: JSONValue,
+  limits: JSONLimits
+): number => {
+  visitJSON(value, limits.maxDepth, 0)
+  const bytes = Buffer.byteLength(JSON.stringify(value))
+  if (bytes > limits.maxBytes) {
+    throw new JSONLimitError()
+  }
+  return bytes
+}

--- a/packages/functions-runner/src/jsonLimits.ts
+++ b/packages/functions-runner/src/jsonLimits.ts
@@ -27,11 +27,10 @@ const visitJSON = (value: JSONValue, maxDepth: number, depth: number): void => {
 export const validateJSONLimits = (
   value: JSONValue,
   limits: JSONLimits
-): number => {
+): void => {
   visitJSON(value, limits.maxDepth, 0)
   const bytes = Buffer.byteLength(JSON.stringify(value))
   if (bytes > limits.maxBytes) {
     throw new JSONLimitError()
   }
-  return bytes
 }

--- a/packages/functions-runner/src/server.spec.ts
+++ b/packages/functions-runner/src/server.spec.ts
@@ -64,4 +64,30 @@ describe("Functions runner service", () => {
       )
     }
   })
+
+  it("rejects an oversized request without buffering it unboundedly", async () => {
+    const server = createServer()
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve))
+
+    try {
+      const address = server.address() as AddressInfo
+      const response = await fetch(`http://127.0.0.1:${address.port}/runs`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "x".repeat(2 * 1024 * 1024 + 1),
+      })
+
+      expect(response.status).toBe(400)
+      expect(await response.json()).toEqual({
+        error: {
+          code: FunctionErrorCode.FUNCTION_PROTOCOL_ERROR,
+          message: "Function run request is too large",
+        },
+      })
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close(error => (error ? reject(error) : resolve()))
+      )
+    }
+  })
 })

--- a/packages/functions-runner/src/start.ts
+++ b/packages/functions-runner/src/start.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_FUNCTION_LIMITS } from "@budibase/types"
 import { getEnvironment } from "./environment"
 import { createServer } from "./server"
 import { FunctionSupervisor } from "./supervisor"
@@ -5,6 +6,7 @@ import { FunctionSupervisor } from "./supervisor"
 const environment = getEnvironment()
 const supervisor = new FunctionSupervisor({
   terminationGraceMs: environment.terminationGraceMs,
+  maxConcurrentRuns: DEFAULT_FUNCTION_LIMITS.service.maxConcurrentRuns,
 })
 const server = createServer(supervisor)
 let shuttingDown = false

--- a/packages/functions-runner/src/supervisor.spec.ts
+++ b/packages/functions-runner/src/supervisor.spec.ts
@@ -140,7 +140,7 @@ describe("FunctionSupervisor", () => {
     const supervisor = createSupervisor("memory-abort")
 
     await expect(
-      supervisor.execute(request("run-memory"))
+      supervisor.execute(request("run-memory", 10_000))
     ).resolves.toMatchObject({
       runId: "run-memory",
       status: "error",

--- a/packages/functions-runner/src/supervisor.spec.ts
+++ b/packages/functions-runner/src/supervisor.spec.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_FUNCTION_LIMITS,
   FUNCTION_RUN_REQUEST_FIXTURE,
   FunctionErrorCode,
 } from "@budibase/types"
@@ -61,10 +62,14 @@ process.on("message", request => {
     })
     return
   }
+  let output = { pid: process.pid }
+  if (mode === "limits") {
+    output = { limits: request.limits }
+  }
   const result = {
     runId: mode === "wrong-run-id" ? "another-run" : request.runId,
     status: "success",
-    output: { pid: process.pid },
+    output,
     metrics: { durationMs: 1, queryCount: 0, outputBytes: 0, logBytes: 0 },
   }
   if (mode === "extra-message") {
@@ -217,7 +222,30 @@ describe("FunctionSupervisor", () => {
       grantToken: FUNCTION_RUN_REQUEST_FIXTURE.grantToken,
       capabilityId: "capability-1",
       parameters: { value: "input" },
+      signal: expect.any(AbortSignal),
     })
+  })
+
+  it("clamps request limits to runner-owned maximums", async () => {
+    const childFactory = jest.fn(() =>
+      spawn(process.execPath, ["-e", childFixture, "limits"], {
+        stdio: ["ignore", "ignore", "ignore", "ipc"],
+      })
+    )
+    const supervisor = new FunctionSupervisor({ childFactory })
+    const runRequest = request("run-clamped-limits")
+    for (const key of Object.keys(runRequest.limits)) {
+      runRequest.limits[key as keyof typeof runRequest.limits] =
+        Number.MAX_SAFE_INTEGER
+    }
+
+    await expect(supervisor.execute(runRequest)).resolves.toMatchObject({
+      status: "success",
+      output: { limits: DEFAULT_FUNCTION_LIMITS.run },
+    })
+    expect(childFactory).toHaveBeenCalledWith(
+      DEFAULT_FUNCTION_LIMITS.run.isolateMemoryLimitMb
+    )
   })
 
   it("rejects input over its byte limit before spawning", async () => {
@@ -298,6 +326,43 @@ describe("FunctionSupervisor", () => {
         message: "Function query payload is invalid",
       },
     })
+    expect(supervisor.activeRunCount()).toBe(0)
+  })
+
+  it("aborts outstanding queries when a run times out", async () => {
+    let querySignal: AbortSignal | undefined
+    let notifyQueryStarted: (() => void) | undefined
+    let notifyQueryCancelled: (() => void) | undefined
+    const queryStarted = new Promise<void>(resolve => {
+      notifyQueryStarted = resolve
+    })
+    const queryCancelled = new Promise<void>(resolve => {
+      notifyQueryCancelled = resolve
+    })
+    const supervisor = createSupervisor("query", 10, request => {
+      querySignal = request.signal
+      notifyQueryStarted?.()
+      return new Promise((_resolve, reject) => {
+        request.signal.addEventListener(
+          "abort",
+          () => {
+            notifyQueryCancelled?.()
+            reject(new Error("Query cancelled"))
+          },
+          { once: true }
+        )
+      })
+    })
+    const resultPromise = supervisor.execute(request("run-query-timeout", 500))
+
+    await queryStarted
+    expect(querySignal?.aborted).toBe(false)
+    await expect(resultPromise).resolves.toMatchObject({
+      error: { code: FunctionErrorCode.FUNCTION_TIMEOUT },
+    })
+    await queryCancelled
+    expect(querySignal?.aborted).toBe(true)
+    expect(supervisor.activeRunCount()).toBe(0)
   })
 
   it("cancels an active child and cleans up its state", async () => {

--- a/packages/functions-runner/src/supervisor.spec.ts
+++ b/packages/functions-runner/src/supervisor.spec.ts
@@ -25,6 +25,7 @@ process.on("message", request => {
   request = request.request
   globalThis.runRequest = request
   if (mode === "crash") process.exit(2)
+  if (mode === "memory-abort") process.abort()
   if (mode === "no-result") process.exit(0)
   if (mode === "malformed" || mode === "malformed-ignore-termination") {
     process.send({ invalid: true })
@@ -42,6 +43,21 @@ process.on("message", request => {
       requestId: "query-1",
       capabilityId: "capability-1",
       parameters: { value: "input" },
+    })
+    return
+  }
+  if (mode === "queries") {
+    process.send({
+      type: "query",
+      requestId: "query-1",
+      capabilityId: "capability-1",
+      parameters: {},
+    })
+    process.send({
+      type: "query",
+      requestId: "query-2",
+      capabilityId: "capability-2",
+      parameters: {},
     })
     return
   }
@@ -110,6 +126,22 @@ describe("FunctionSupervisor", () => {
       error: {
         code: FunctionErrorCode.FUNCTION_RUNTIME_ERROR,
         message: "Function child process exited unexpectedly",
+      },
+    })
+    expect(supervisor.activeRunCount()).toBe(0)
+  })
+
+  it("returns a stable result when a child hits its memory ceiling", async () => {
+    const supervisor = createSupervisor("memory-abort")
+
+    await expect(
+      supervisor.execute(request("run-memory"))
+    ).resolves.toMatchObject({
+      runId: "run-memory",
+      status: "error",
+      error: {
+        code: FunctionErrorCode.FUNCTION_MEMORY_LIMIT,
+        message: "Function memory limit exceeded",
       },
     })
     expect(supervisor.activeRunCount()).toBe(0)
@@ -185,6 +217,86 @@ describe("FunctionSupervisor", () => {
       grantToken: FUNCTION_RUN_REQUEST_FIXTURE.grantToken,
       capabilityId: "capability-1",
       parameters: { value: "input" },
+    })
+  })
+
+  it("rejects input over its byte limit before spawning", async () => {
+    const childFactory = jest.fn(() => {
+      throw new Error("must not spawn")
+    })
+    const supervisor = new FunctionSupervisor({ childFactory })
+    const runRequest = request("run-large-input")
+    runRequest.inputs = { value: "too large" }
+    runRequest.limits = { ...runRequest.limits, maxInputBytes: 10 }
+
+    await expect(supervisor.execute(runRequest)).resolves.toMatchObject({
+      error: {
+        code: FunctionErrorCode.FUNCTION_PROTOCOL_ERROR,
+        message: "Function input is invalid",
+      },
+    })
+    expect(childFactory).not.toHaveBeenCalled()
+  })
+
+  it("fails fast when runner capacity is exhausted and releases it", async () => {
+    const supervisor = new FunctionSupervisor({
+      childFactory: () =>
+        spawn(process.execPath, ["-e", childFixture, "hang"], {
+          stdio: ["ignore", "ignore", "ignore", "ipc"],
+        }),
+      maxConcurrentRuns: 1,
+      terminationGraceMs: 10,
+    })
+    const first = supervisor.execute(request("run-capacity-1", 5_000))
+
+    await expect(
+      supervisor.execute(request("run-capacity-busy"))
+    ).resolves.toMatchObject({
+      error: {
+        code: FunctionErrorCode.FUNCTION_RUNNER_BUSY,
+        message: "Functions runner is busy",
+      },
+    })
+    supervisor.terminate("run-capacity-1")
+    await first
+
+    const second = supervisor.execute(request("run-capacity-2", 5_000))
+    expect(supervisor.activeRunCount()).toBe(1)
+    supervisor.terminate("run-capacity-2")
+    await second
+    expect(supervisor.activeRunCount()).toBe(0)
+  })
+
+  it("enforces the query count at the supervisor boundary", async () => {
+    const supervisor = createSupervisor("queries", 10, async () => ({}))
+    const runRequest = request("run-query-limit")
+    runRequest.limits = {
+      ...runRequest.limits,
+      maxQueryCalls: 1,
+      maxConcurrentQueryCalls: 2,
+    }
+
+    await expect(supervisor.execute(runRequest)).resolves.toMatchObject({
+      error: { code: FunctionErrorCode.FUNCTION_QUERY_LIMIT },
+    })
+    expect(supervisor.activeRunCount()).toBe(0)
+  })
+
+  it("rejects oversized query results at the supervisor boundary", async () => {
+    const supervisor = createSupervisor("query", 10, async () => ({
+      value: "too large",
+    }))
+    const runRequest = request("run-query-response-limit")
+    runRequest.limits = {
+      ...runRequest.limits,
+      maxQueryResponseBytes: 10,
+    }
+
+    await expect(supervisor.execute(runRequest)).resolves.toMatchObject({
+      error: {
+        code: FunctionErrorCode.FUNCTION_PROTOCOL_ERROR,
+        message: "Function query payload is invalid",
+      },
     })
   })
 

--- a/packages/functions-runner/src/supervisor.ts
+++ b/packages/functions-runner/src/supervisor.ts
@@ -1,5 +1,9 @@
 import { DEFAULT_FUNCTION_LIMITS, FunctionErrorCode } from "@budibase/types"
-import type { FunctionRunResult, JSONValue } from "@budibase/types"
+import type {
+  FunctionRunLimits,
+  FunctionRunResult,
+  JSONValue,
+} from "@budibase/types"
 import { fork } from "node:child_process"
 import type { ChildProcess } from "node:child_process"
 import path from "node:path"
@@ -68,6 +72,58 @@ const defaultChildFactory = (memoryLimitMb: number) =>
 const defaultQueryHandler = (): Promise<JSONValue> =>
   Promise.reject(new Error(QUERY_FAILED_MESSAGE))
 
+const clampRunLimits = (limits: FunctionRunLimits): FunctionRunLimits => ({
+  maxInputBytes: Math.min(
+    limits.maxInputBytes,
+    DEFAULT_FUNCTION_LIMITS.run.maxInputBytes
+  ),
+  maxInputDepth: Math.min(
+    limits.maxInputDepth,
+    DEFAULT_FUNCTION_LIMITS.run.maxInputDepth
+  ),
+  isolateMemoryLimitMb: Math.min(
+    limits.isolateMemoryLimitMb,
+    DEFAULT_FUNCTION_LIMITS.run.isolateMemoryLimitMb
+  ),
+  timeoutMs: Math.min(limits.timeoutMs, DEFAULT_FUNCTION_LIMITS.run.timeoutMs),
+  maxQueryCalls: Math.min(
+    limits.maxQueryCalls,
+    DEFAULT_FUNCTION_LIMITS.run.maxQueryCalls
+  ),
+  maxConcurrentQueryCalls: Math.min(
+    limits.maxConcurrentQueryCalls,
+    DEFAULT_FUNCTION_LIMITS.run.maxConcurrentQueryCalls
+  ),
+  maxQueryResponseBytes: Math.min(
+    limits.maxQueryResponseBytes,
+    DEFAULT_FUNCTION_LIMITS.run.maxQueryResponseBytes
+  ),
+  maxQueryResponseDepth: Math.min(
+    limits.maxQueryResponseDepth,
+    DEFAULT_FUNCTION_LIMITS.run.maxQueryResponseDepth
+  ),
+  maxOutputBytes: Math.min(
+    limits.maxOutputBytes,
+    DEFAULT_FUNCTION_LIMITS.run.maxOutputBytes
+  ),
+  maxOutputDepth: Math.min(
+    limits.maxOutputDepth,
+    DEFAULT_FUNCTION_LIMITS.run.maxOutputDepth
+  ),
+  maxLogEntries: Math.min(
+    limits.maxLogEntries,
+    DEFAULT_FUNCTION_LIMITS.run.maxLogEntries
+  ),
+  maxLogBytes: Math.min(
+    limits.maxLogBytes,
+    DEFAULT_FUNCTION_LIMITS.run.maxLogBytes
+  ),
+  maxLogEntryBytes: Math.min(
+    limits.maxLogEntryBytes,
+    DEFAULT_FUNCTION_LIMITS.run.maxLogEntryBytes
+  ),
+})
+
 export class FunctionSupervisor {
   private readonly activeRuns = new Map<string, ActiveRun>()
   private readonly childFactory: (memoryLimitMb: number) => ChildProcess
@@ -94,7 +150,11 @@ export class FunctionSupervisor {
   }
 
   execute(value: unknown): Promise<FunctionRunResult> {
-    const request = validateFunctionRunRequest(value)
+    const validatedRequest = validateFunctionRunRequest(value)
+    const request = {
+      ...validatedRequest,
+      limits: clampRunLimits(validatedRequest.limits),
+    }
     const startedAt = Date.now()
 
     if (this.shuttingDown) {
@@ -160,6 +220,7 @@ export class FunctionSupervisor {
       let killTimer: NodeJS.Timeout | undefined
       let runTimer: NodeJS.Timeout | undefined
       let closed = false
+      const queryAbortController = new AbortController()
       const queryRequestIds = new Set<string>()
       let queryCount = 0
       let concurrentQueryCount = 0
@@ -168,6 +229,7 @@ export class FunctionSupervisor {
         if (closed || killTimer) {
           return
         }
+        queryAbortController.abort()
         child.kill("SIGTERM")
         killTimer = setTimeout(() => {
           if (!closed) {
@@ -297,6 +359,7 @@ export class FunctionSupervisor {
               grantToken: request.grantToken,
               capabilityId: message.capabilityId,
               parameters: message.parameters,
+              signal: queryAbortController.signal,
             })
           )
           .then(
@@ -349,6 +412,7 @@ export class FunctionSupervisor {
 
       child.on("close", (code, signal) => {
         closed = true
+        queryAbortController.abort()
         if (runTimer) {
           clearTimeout(runTimer)
         }

--- a/packages/functions-runner/src/supervisor.ts
+++ b/packages/functions-runner/src/supervisor.ts
@@ -1,4 +1,4 @@
-import { FunctionErrorCode } from "@budibase/types"
+import { DEFAULT_FUNCTION_LIMITS, FunctionErrorCode } from "@budibase/types"
 import type { FunctionRunResult, JSONValue } from "@budibase/types"
 import { fork } from "node:child_process"
 import type { ChildProcess } from "node:child_process"
@@ -6,6 +6,7 @@ import path from "node:path"
 import type { ChildMessage, ParentMessage } from "./ipc"
 import { validateChildMessage } from "./ipc"
 import type { FunctionQueryHandler } from "./isolatedVmRuntime"
+import { JSONLimitError, validateJSONLimits } from "./jsonLimits"
 import { FunctionProtocolError, validateFunctionRunRequest } from "./protocol"
 
 const CHILD_CRASHED_MESSAGE = "Function child process exited unexpectedly"
@@ -17,6 +18,11 @@ const RUN_CANCELLED_MESSAGE = "Function run was cancelled"
 const RUN_TIMEOUT_MESSAGE = "Function run timed out"
 const RUNNER_SHUTDOWN_MESSAGE = "Functions runner is shutting down"
 const QUERY_FAILED_MESSAGE = "Function query failed"
+const INPUT_INVALID_MESSAGE = "Function input is invalid"
+const QUERY_LIMIT_MESSAGE = "Function query limit exceeded"
+const QUERY_PAYLOAD_INVALID_MESSAGE = "Function query payload is invalid"
+const RUNNER_BUSY_MESSAGE = "Functions runner is busy"
+const MEMORY_LIMIT_MESSAGE = "Function memory limit exceeded"
 
 type TerminationReason = "cancelled" | "timeout" | "shutdown"
 
@@ -26,9 +32,10 @@ interface ActiveRun {
 }
 
 export interface FunctionSupervisorOptions {
-  childFactory?: () => ChildProcess
+  childFactory?: (memoryLimitMb: number) => ChildProcess
   queryHandler?: FunctionQueryHandler
   terminationGraceMs?: number
+  maxConcurrentRuns?: number
 }
 
 const failureResult = (
@@ -52,9 +59,10 @@ const failureResult = (
   },
 })
 
-const defaultChildFactory = () =>
+const defaultChildFactory = (memoryLimitMb: number) =>
   fork(path.join(__dirname, "child.js"), [], {
-    stdio: ["ignore", "inherit", "inherit", "ipc"],
+    execArgv: [`--max-old-space-size=${memoryLimitMb}`],
+    stdio: ["ignore", "ignore", "ignore", "ipc"],
   })
 
 const defaultQueryHandler = (): Promise<JSONValue> =>
@@ -62,15 +70,19 @@ const defaultQueryHandler = (): Promise<JSONValue> =>
 
 export class FunctionSupervisor {
   private readonly activeRuns = new Map<string, ActiveRun>()
-  private readonly childFactory: () => ChildProcess
+  private readonly childFactory: (memoryLimitMb: number) => ChildProcess
   private readonly queryHandler: FunctionQueryHandler
   private readonly terminationGraceMs: number
+  private readonly maxConcurrentRuns: number
   private shuttingDown = false
 
   constructor(options: FunctionSupervisorOptions = {}) {
     this.childFactory = options.childFactory || defaultChildFactory
     this.queryHandler = options.queryHandler || defaultQueryHandler
     this.terminationGraceMs = options.terminationGraceMs ?? 250
+    this.maxConcurrentRuns =
+      options.maxConcurrentRuns ??
+      DEFAULT_FUNCTION_LIMITS.service.maxConcurrentRuns
   }
 
   isHealthy() {
@@ -98,10 +110,38 @@ export class FunctionSupervisor {
     if (this.activeRuns.has(request.runId)) {
       throw new FunctionProtocolError("Function run ID is already active")
     }
+    if (this.activeRuns.size >= this.maxConcurrentRuns) {
+      return Promise.resolve(
+        failureResult(
+          request.runId,
+          startedAt,
+          FunctionErrorCode.FUNCTION_RUNNER_BUSY,
+          RUNNER_BUSY_MESSAGE
+        )
+      )
+    }
+    try {
+      validateJSONLimits(request.inputs, {
+        maxBytes: request.limits.maxInputBytes,
+        maxDepth: request.limits.maxInputDepth,
+      })
+    } catch (error) {
+      if (error instanceof JSONLimitError) {
+        return Promise.resolve(
+          failureResult(
+            request.runId,
+            startedAt,
+            FunctionErrorCode.FUNCTION_PROTOCOL_ERROR,
+            INPUT_INVALID_MESSAGE
+          )
+        )
+      }
+      throw error
+    }
 
     let child: ChildProcess
     try {
-      child = this.childFactory()
+      child = this.childFactory(request.limits.isolateMemoryLimitMb)
     } catch {
       return Promise.resolve(
         failureResult(
@@ -121,6 +161,8 @@ export class FunctionSupervisor {
       let runTimer: NodeJS.Timeout | undefined
       let closed = false
       const queryRequestIds = new Set<string>()
+      let queryCount = 0
+      let concurrentQueryCount = 0
 
       const requestChildExit = () => {
         if (closed || killTimer) {
@@ -218,6 +260,36 @@ export class FunctionSupervisor {
           return
         }
         queryRequestIds.add(message.requestId)
+        try {
+          validateJSONLimits(message.parameters, {
+            maxBytes: request.limits.maxInputBytes,
+            maxDepth: request.limits.maxInputDepth,
+          })
+        } catch {
+          failure = failureResult(
+            request.runId,
+            startedAt,
+            FunctionErrorCode.FUNCTION_PROTOCOL_ERROR,
+            QUERY_PAYLOAD_INVALID_MESSAGE
+          )
+          requestChildExit()
+          return
+        }
+        if (
+          queryCount >= request.limits.maxQueryCalls ||
+          concurrentQueryCount >= request.limits.maxConcurrentQueryCalls
+        ) {
+          failure = failureResult(
+            request.runId,
+            startedAt,
+            FunctionErrorCode.FUNCTION_QUERY_LIMIT,
+            QUERY_LIMIT_MESSAGE
+          )
+          requestChildExit()
+          return
+        }
+        queryCount += 1
+        concurrentQueryCount += 1
         Promise.resolve()
           .then(() =>
             this.queryHandler({
@@ -229,7 +301,23 @@ export class FunctionSupervisor {
           )
           .then(
             result => {
+              concurrentQueryCount -= 1
               if (!closed) {
+                try {
+                  validateJSONLimits(result, {
+                    maxBytes: request.limits.maxQueryResponseBytes,
+                    maxDepth: request.limits.maxQueryResponseDepth,
+                  })
+                } catch {
+                  failure = failureResult(
+                    request.runId,
+                    startedAt,
+                    FunctionErrorCode.FUNCTION_PROTOCOL_ERROR,
+                    QUERY_PAYLOAD_INVALID_MESSAGE
+                  )
+                  requestChildExit()
+                  return
+                }
                 sendMessage({
                   type: "queryResult",
                   requestId: message.requestId,
@@ -238,6 +326,7 @@ export class FunctionSupervisor {
               }
             },
             () => {
+              concurrentQueryCount -= 1
               if (!closed) {
                 sendMessage({
                   type: "queryResult",
@@ -258,7 +347,7 @@ export class FunctionSupervisor {
         )
       })
 
-      child.on("close", code => {
+      child.on("close", (code, signal) => {
         closed = true
         if (runTimer) {
           clearTimeout(runTimer)
@@ -308,6 +397,17 @@ export class FunctionSupervisor {
         }
         if (receivedResult) {
           resolve(receivedResult)
+          return
+        }
+        if (signal === "SIGABRT" || signal === "SIGKILL" || code === 134) {
+          resolve(
+            failureResult(
+              request.runId,
+              startedAt,
+              FunctionErrorCode.FUNCTION_MEMORY_LIMIT,
+              MEMORY_LIMIT_MESSAGE
+            )
+          )
           return
         }
 


### PR DESCRIPTION
## Description
Adds deterministic resource and envelope enforcement to the Functions alpha runner. Invocations now have wall-time and isolate memory termination, child-process heap ceilings and kill escalation, bounded request/input/query/output handling, query count and concurrency enforcement, and runner admission control with stable public error codes. Child stdout and stderr are suppressed so customer code cannot exhaust host logs.

For the alpha, `console` is intentionally exposed as a frozen no-op API rather than bridged to the host. Function calls to `console.debug`, `console.info`, `console.log`, `console.warn`, and `console.error` therefore remain compatible without writing to runner stdout or returning logs. Results omit `logs` and report `logBytes: 0`. This keeps the initial boundary small and avoids adding a host callback solely for log collection; bounded user-visible logging can be introduced separately when the alpha requires it.

Coverage includes CPU and wall timeout paths before and after `await`, unresolved promises, isolate and child memory failures, request/input/output limits, query count and concurrency envelopes, no-op console behavior, admission capacity release, and kill escalation. The Functions runner test suite, type check, build, ESLint, and Prettier checks pass.

## Addresses
- https://github.com/Budibase/budibase/issues/19261

## Launchcontrol
Adds predictable safety limits to the self-hosted Functions alpha so runaway or oversized Function executions are stopped without affecting the runner service.