### PR TITLE
[#18050] Reconcile pending invites during unverified-email OIDC/SSO logins

### DIFF
--- a/packages/backend-core/src/middleware/passport/sso/sso.ts
+++ b/packages/backend-core/src/middleware/passport/sso/sso.ts
@@ -139,40 +139,39 @@ async function claimInviteAndSaveUser(
       systemLock: true,
     },
     async () => {
-      let invitePending = true
       try {
         await cache.invite.getCode(invite.code, invite.info.tenantId)
-      } catch {
-        invitePending = false
+      } catch (err: any) {
+        // could be a concurrent claim by this same identity, or an
+        // expired/revoked/unreadable invite - only reuse if positively
+        // confirmed, otherwise fail closed
+        let concurrentUser: User | undefined
+        try {
+          concurrentUser = await users.getById(userId)
+        } catch (getByIdErr: any) {
+          if (!getByIdErr.status || getByIdErr.status !== 404) {
+            throw getByIdErr
+          }
+        }
+        if (!concurrentUser) {
+          throw err
+        }
+        return await syncAndSaveUser(concurrentUser, details, saveUserFn)
       }
 
-      let user: User | undefined
-      if (!invitePending) {
-        // a concurrent login already claimed this invite and created the
-        // account for it - reuse that account instead of creating a
-        // second one for the same email
-        user = await users.getGlobalUserByEmail(details.email!)
-      }
-      if (!user) {
-        // set up a blank user using the third party id, applying any access
-        // granted by the matching pending invite
-        const assignments = invitePending
-          ? users.deriveUserFieldsFromInvite(invite.info)
-          : { roles: {} }
-        user = {
-          _id: userId,
-          email: details.email!,
-          tenantId: invite.info.tenantId || context.getTenantId(),
-          ...assignments,
-        }
+      // set up a blank user using the third party id, applying any access
+      // granted by the matching pending invite
+      const user: User = {
+        _id: userId,
+        email: details.email!,
+        tenantId: invite.info.tenantId || context.getTenantId(),
+        ...users.deriveUserFieldsFromInvite(invite.info),
       }
 
       const ssoUser = await syncAndSaveUser(user, details, saveUserFn)
 
-      if (invitePending) {
-        await cache.invite.deleteCode(invite.code, invite.info.tenantId)
-        await events.user.inviteAccepted(ssoUser)
-      }
+      await cache.invite.deleteCode(invite.code, invite.info.tenantId)
+      await events.user.inviteAccepted(ssoUser)
 
       return ssoUser
     }

--- a/packages/backend-core/src/middleware/passport/sso/sso.ts
+++ b/packages/backend-core/src/middleware/passport/sso/sso.ts
@@ -80,46 +80,58 @@ export async function authenticate(
     )
   }
 
-  // first time creation
-  if (!dbUser) {
-    const assignments = pendingInvite
-      ? users.deriveUserFieldsFromInvite(pendingInvite.info)
-      : { roles: {} }
-    // setup a blank user using the third party id, applying any access
-    // granted by a matching pending invite
-    dbUser = {
-      _id: userId,
-      email: details.email,
-      tenantId: pendingInvite?.info.tenantId || context.getTenantId(),
-      ...assignments,
-    }
-  }
-
-  let ssoUser = await syncUser(dbUser, details)
-  // never prompt for password reset
-  ssoUser.forceResetPassword = false
-
+  let ssoUser: SSOUser
   try {
-    // don't try to re-save any existing password
-    delete ssoUser.password
-    // create or sync the user
-    ssoUser = (await saveUserFn(ssoUser, {
-      hashPassword: false,
-      requirePassword: false,
-    })) as SSOUser
+    if (pendingInvite) {
+      ssoUser = await claimInviteAndSaveUser(
+        pendingInvite,
+        userId,
+        details,
+        saveUserFn
+      )
+    } else {
+      if (!dbUser) {
+        // first time creation - no invite or existing account to draw from
+        dbUser = {
+          _id: userId,
+          email: details.email,
+          tenantId: context.getTenantId(),
+          roles: {},
+        }
+      }
+      ssoUser = await syncAndSaveUser(dbUser, details, saveUserFn)
+    }
   } catch (err: any) {
     return authError(done, "Error saving user", err)
-  }
-
-  if (pendingInvite) {
-    await consumePendingInvite(pendingInvite, ssoUser)
   }
 
   return done(null, ssoUser)
 }
 
-async function consumePendingInvite(invite: InviteWithCode, user: SSOUser) {
-  await locks.doWithLock(
+async function syncAndSaveUser(
+  user: User,
+  details: SSOAuthDetails,
+  saveUserFn: SaveSSOUserFunction
+): Promise<SSOUser> {
+  const ssoUser = await syncUser(user, details)
+  // never prompt for password reset
+  ssoUser.forceResetPassword = false
+  // don't try to re-save any existing password
+  delete ssoUser.password
+  // create or sync the user
+  return (await saveUserFn(ssoUser, {
+    hashPassword: false,
+    requirePassword: false,
+  })) as SSOUser
+}
+
+async function claimInviteAndSaveUser(
+  invite: InviteWithCode,
+  userId: string,
+  details: SSOAuthDetails,
+  saveUserFn: SaveSSOUserFunction
+): Promise<SSOUser> {
+  const { result } = await locks.doWithLock(
     {
       type: LockType.AUTO_EXTEND,
       name: LockName.PROCESS_USER_INVITE,
@@ -127,16 +139,45 @@ async function consumePendingInvite(invite: InviteWithCode, user: SSOUser) {
       systemLock: true,
     },
     async () => {
+      let invitePending = true
       try {
-        // re-validate under lock in case another login already consumed it
         await cache.invite.getCode(invite.code, invite.info.tenantId)
       } catch {
-        return
+        invitePending = false
       }
-      await cache.invite.deleteCode(invite.code, invite.info.tenantId)
-      await events.user.inviteAccepted(user)
+
+      let user: User | undefined
+      if (!invitePending) {
+        // a concurrent login already claimed this invite and created the
+        // account for it - reuse that account instead of creating a
+        // second one for the same email
+        user = await users.getGlobalUserByEmail(details.email!)
+      }
+      if (!user) {
+        // set up a blank user using the third party id, applying any access
+        // granted by the matching pending invite
+        const assignments = invitePending
+          ? users.deriveUserFieldsFromInvite(invite.info)
+          : { roles: {} }
+        user = {
+          _id: userId,
+          email: details.email!,
+          tenantId: invite.info.tenantId || context.getTenantId(),
+          ...assignments,
+        }
+      }
+
+      const ssoUser = await syncAndSaveUser(user, details, saveUserFn)
+
+      if (invitePending) {
+        await cache.invite.deleteCode(invite.code, invite.info.tenantId)
+        await events.user.inviteAccepted(ssoUser)
+      }
+
+      return ssoUser
     }
   )
+  return result
 }
 
 /**

--- a/packages/backend-core/src/middleware/passport/sso/sso.ts
+++ b/packages/backend-core/src/middleware/passport/sso/sso.ts
@@ -2,7 +2,13 @@ import { generateGlobalUserID } from "../../../db"
 import { authError } from "../utils"
 import * as users from "../../../users"
 import * as context from "../../../context"
+import * as cache from "../../../cache"
+import * as events from "../../../events"
+import * as locks from "../../../redis/redlockImpl"
 import {
+  InviteWithCode,
+  LockName,
+  LockType,
   SaveSSOUserFunction,
   SSOAuthDetails,
   SSOUser,
@@ -60,8 +66,14 @@ export async function authenticate(
     dbUser = await users.getGlobalUserByEmail(details.email)
   }
 
-  // exit early if there is still no user and auto creation is disabled
-  if (!dbUser && requireLocalAccount) {
+  let pendingInvite: InviteWithCode | undefined
+  if (!dbUser) {
+    const invites = await cache.invite.getExistingInvites([details.email])
+    pendingInvite = invites[0]
+  }
+
+  // exit early if there is still no user/invite and auto creation is disabled
+  if (!dbUser && !pendingInvite && requireLocalAccount) {
     return authError(
       done,
       "Email does not yet exist. You must set up your local budibase account first."
@@ -70,12 +82,16 @@ export async function authenticate(
 
   // first time creation
   if (!dbUser) {
-    // setup a blank user using the third party id
+    const assignments = pendingInvite
+      ? users.deriveUserFieldsFromInvite(pendingInvite.info)
+      : { roles: {} }
+    // setup a blank user using the third party id, applying any access
+    // granted by a matching pending invite
     dbUser = {
       _id: userId,
       email: details.email,
-      roles: {},
-      tenantId: context.getTenantId(),
+      tenantId: pendingInvite?.info.tenantId || context.getTenantId(),
+      ...assignments,
     }
   }
 
@@ -95,7 +111,32 @@ export async function authenticate(
     return authError(done, "Error saving user", err)
   }
 
+  if (pendingInvite) {
+    await consumePendingInvite(pendingInvite, ssoUser)
+  }
+
   return done(null, ssoUser)
+}
+
+async function consumePendingInvite(invite: InviteWithCode, user: SSOUser) {
+  await locks.doWithLock(
+    {
+      type: LockType.AUTO_EXTEND,
+      name: LockName.PROCESS_USER_INVITE,
+      resource: invite.code,
+      systemLock: true,
+    },
+    async () => {
+      try {
+        // re-validate under lock in case another login already consumed it
+        await cache.invite.getCode(invite.code, invite.info.tenantId)
+      } catch {
+        return
+      }
+      await cache.invite.deleteCode(invite.code, invite.info.tenantId)
+      await events.user.inviteAccepted(user)
+    }
+  )
 }
 
 /**

--- a/packages/backend-core/src/middleware/passport/sso/sso.ts
+++ b/packages/backend-core/src/middleware/passport/sso/sso.ts
@@ -14,6 +14,7 @@ import {
   SSOAuthDetails,
   SSOUser,
   User,
+  UserStatus,
 } from "@budibase/types"
 
 // no-op function for user save
@@ -133,10 +134,16 @@ async function syncAndSaveUser(
 }
 
 // only linkable while no one else could plausibly own it: never claimed
-// with a password, no account-portal ssoId, not a global admin, and if
-// already an SSO user, only from the same identity provider that linked it
+// with a password, not disabled, no account-portal ssoId, not a global
+// admin, and if already an SSO user, only from the same identity provider
+// that linked it
 function isAccountLinkable(user: User, details: SSOAuthDetails): boolean {
-  if (user.password || user.admin?.global || user.ssoId) {
+  if (
+    user.password ||
+    user.status === UserStatus.INACTIVE ||
+    user.admin?.global ||
+    user.ssoId
+  ) {
     return false
   }
   if (isSSOUser(user)) {

--- a/packages/backend-core/src/middleware/passport/sso/sso.ts
+++ b/packages/backend-core/src/middleware/passport/sso/sso.ts
@@ -7,6 +7,7 @@ import * as events from "../../../events"
 import * as locks from "../../../redis/redlockImpl"
 import {
   InviteWithCode,
+  isSSOUser,
   LockName,
   LockType,
   SaveSSOUserFunction,
@@ -72,6 +73,12 @@ export async function authenticate(
     pendingInvite = invites[0]
   }
 
+  const emailLookupWasSkipped =
+    !details.emailVerified && !allowUnverifiedEmailLinking
+  if (!dbUser && !pendingInvite && emailLookupWasSkipped) {
+    dbUser = await findLinkableAccountByEmail(details)
+  }
+
   // exit early if there is still no user/invite and auto creation is disabled
   if (!dbUser && !pendingInvite && requireLocalAccount) {
     return authError(
@@ -116,6 +123,32 @@ export async function authenticate(
   }
 
   return done(null, ssoUser)
+}
+
+// only linkable while no one else could plausibly own it: never claimed
+// with a password, no account-portal ssoId, not a global admin, and if
+// already an SSO user, only from the same identity provider that linked it
+function isAccountLinkable(user: User, details: SSOAuthDetails): boolean {
+  if (user.password || user.admin?.global || user.ssoId) {
+    return false
+  }
+  if (isSSOUser(user)) {
+    return (
+      user.provider === details.provider &&
+      user.providerType === details.providerType
+    )
+  }
+  return true
+}
+
+async function findLinkableAccountByEmail(
+  details: SSOAuthDetails
+): Promise<User | undefined> {
+  const user = await users.getGlobalUserByEmail(details.email!)
+  if (user && isAccountLinkable(user, details)) {
+    return user
+  }
+  return undefined
 }
 
 async function consumePendingInvite(invite: InviteWithCode, user: SSOUser) {

--- a/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
+++ b/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
@@ -1,6 +1,6 @@
 import { structures } from "../../../../../tests"
 import { testEnv } from "../../../../../tests/extra"
-import { InviteWithCode, SSOAuthDetails, User } from "@budibase/types"
+import { InviteWithCode, SSOAuthDetails, SSOUser, User } from "@budibase/types"
 
 import { HTTPError } from "../../../../errors"
 import * as sso from "../sso"
@@ -242,7 +242,8 @@ describe("sso", () => {
         })
       })
 
-      it("does not link to an existing account by email", async () => {
+      it("does not link to an already-claimed account by email", async () => {
+        // existingUser has a password set, so it is not linkable
         users.getGlobalUserByEmail.mockReturnValue(
           Promise.resolve(existingUser)
         )
@@ -254,8 +255,6 @@ describe("sso", () => {
 
         await sso.authenticate(details, false, mockDone, mockSaveUser)
 
-        // the victim's account must never be loaded by an unverified email
-        expect(users.getGlobalUserByEmail).not.toHaveBeenCalled()
         // instead a brand new account keyed on the sso id is created
         expect(mockSaveUser).toHaveBeenCalledWith(
           expect.objectContaining({ _id: "us_" + details.userId }),
@@ -263,10 +262,13 @@ describe("sso", () => {
         )
       })
 
-      it("rejects when a local account is required", async () => {
+      it("rejects when a local account is required and no linkable account exists", async () => {
+        users.getGlobalUserByEmail.mockReturnValueOnce(
+          Promise.resolve(undefined)
+        )
+
         await sso.authenticate(details, true, mockDone, mockSaveUser)
 
-        expect(users.getGlobalUserByEmail).not.toHaveBeenCalled()
         expect(mockDone.mock.calls.length).toBe(1)
         expect(getErrorMessage()).toContain(
           "Email does not yet exist. You must set up your local budibase account first."
@@ -286,6 +288,122 @@ describe("sso", () => {
         await sso.authenticate(details, false, mockDone, mockSaveUser, true)
 
         expect(users.getGlobalUserByEmail).toHaveBeenCalled()
+        expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+      })
+    })
+
+    describe("when there is a linkable account for the email (invite already accepted)", () => {
+      let existingUser: User & Partial<SSOUser>
+      let details: SSOAuthDetails
+
+      beforeEach(() => {
+        existingUser = structures.users.user()
+        existingUser._id = structures.uuid()
+        delete existingUser.password
+
+        details = structures.sso.authDetails(existingUser)
+        details.emailVerified = false
+
+        // no match on the sso id - forces the email fallback path
+        users.getById.mockImplementationOnce(() => {
+          throw new HTTPError("", 404)
+        })
+        nock("http://example.com").get("/").reply(200, undefined, {
+          "Content-Type": "image/png",
+        })
+      })
+
+      it("links an unclaimed account (no password) on first login", async () => {
+        users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
+        const ssoUser = structures.users.ssoUser({
+          user: existingUser,
+          details,
+        })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({ _id: existingUser._id }),
+          expect.anything()
+        )
+        expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+      })
+
+      it("keeps resolving the account on a later login from the same identity provider", async () => {
+        // simulates the account state after a first successful login: syncUser
+        // has already stamped provider/providerType onto the document
+        existingUser.provider = details.provider
+        existingUser.providerType = details.providerType
+        users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
+        const ssoUser = structures.users.ssoUser({
+          user: existingUser,
+          details,
+        })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({ _id: existingUser._id }),
+          expect.anything()
+        )
+        expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+      })
+
+      it("does not link an account already linked via a different identity provider", async () => {
+        existingUser.provider = structures.uuid()
+        existingUser.providerType = details.providerType
+        users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
+        const ssoUser = structures.users.ssoUser({ details })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({ _id: "us_" + details.userId }),
+          expect.anything()
+        )
+      })
+
+      it("does not link a global admin account", async () => {
+        existingUser.admin = { global: true }
+        users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
+        const ssoUser = structures.users.ssoUser({ details })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({ _id: "us_" + details.userId }),
+          expect.anything()
+        )
+      })
+
+      it("does not link an account with an account-portal ssoId", async () => {
+        existingUser.ssoId = structures.uuid()
+        users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
+        const ssoUser = structures.users.ssoUser({ details })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({ _id: "us_" + details.userId }),
+          expect.anything()
+        )
+      })
+
+      it("reconciles even when a local account would otherwise be required", async () => {
+        users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
+        const ssoUser = structures.users.ssoUser({
+          user: existingUser,
+          details,
+        })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, true, mockDone, mockSaveUser)
+
         expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
       })
     })

--- a/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
+++ b/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
@@ -364,32 +364,19 @@ describe("sso", () => {
         expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
       })
 
-      it("does not delete the invite if it was already consumed by a concurrent login", async () => {
-        mockInvite.getCode.mockReset()
-        mockInvite.getCode.mockRejectedValueOnce(new Error("invalid invite"))
-
-        const ssoUser = structures.users.ssoUser({ details })
-        mockSaveUser.mockReturnValueOnce(ssoUser)
-
-        await sso.authenticate(details, false, mockDone, mockSaveUser)
-
-        expect(mockInvite.deleteCode).not.toHaveBeenCalled()
-        expect(events.user.inviteAccepted).not.toHaveBeenCalled()
-        expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
-      })
-
-      it("reuses the account created by a concurrent login racing for the same invite, instead of creating a second one", async () => {
-        // simulates another login (e.g. a different identity provider)
-        // winning the race: it consumed the invite and saved its own
-        // account for this email before we acquired the lock
+      it("reuses the account when the same identity's own concurrent login already claimed the invite", async () => {
+        // simulates a second, racing request for this exact identity
+        // (e.g. a double-submitted login) losing the lock race: the
+        // winner already consumed the invite and saved the account for
+        // this precise third party id before we acquired the lock
         mockInvite.getCode.mockReset()
         mockInvite.getCode.mockRejectedValueOnce(new Error("invalid invite"))
 
         const existingUser = structures.users.user({
-          _id: "us_some-other-identity",
+          _id: "us_" + details.userId,
           email: details.email,
         })
-        users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
+        users.getById.mockResolvedValueOnce(existingUser)
 
         const ssoUser = structures.users.ssoUser({
           user: existingUser,
@@ -399,7 +386,8 @@ describe("sso", () => {
 
         await sso.authenticate(details, false, mockDone, mockSaveUser)
 
-        expect(users.getGlobalUserByEmail).toHaveBeenCalledWith(details.email)
+        // reused via the deterministic id, never by email match
+        expect(users.getGlobalUserByEmail).not.toHaveBeenCalled()
         // the winner's account is reused - no second document is created
         expect(mockSaveUser).toHaveBeenCalledWith(
           expect.objectContaining({ _id: existingUser._id }),
@@ -408,6 +396,26 @@ describe("sso", () => {
         expect(mockInvite.deleteCode).not.toHaveBeenCalled()
         expect(events.user.inviteAccepted).not.toHaveBeenCalled()
         expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+      })
+
+      it("fails closed when the invite can no longer be validated and no concurrent claim for this identity can be confirmed", async () => {
+        // covers expired/revoked invites and failed reads alike - none of
+        // these are a positively identified concurrent claim, so this must
+        // not fall back to linking by email or creating a fresh account
+        mockInvite.getCode.mockReset()
+        mockInvite.getCode.mockRejectedValueOnce(new Error("invite expired"))
+        users.getById.mockImplementationOnce(() => {
+          throw new HTTPError("", 404)
+        })
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(users.getGlobalUserByEmail).not.toHaveBeenCalled()
+        expect(mockSaveUser).not.toHaveBeenCalled()
+        expect(mockInvite.deleteCode).not.toHaveBeenCalled()
+        expect(events.user.inviteAccepted).not.toHaveBeenCalled()
+        expect(mockDone.mock.calls.length).toBe(1)
+        expect(getErrorMessage()).toBeDefined()
       })
     })
 

--- a/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
+++ b/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
@@ -1,6 +1,12 @@
 import { structures } from "../../../../../tests"
 import { testEnv } from "../../../../../tests/extra"
-import { InviteWithCode, SSOAuthDetails, SSOUser, User } from "@budibase/types"
+import {
+  InviteWithCode,
+  SSOAuthDetails,
+  SSOUser,
+  User,
+  UserStatus,
+} from "@budibase/types"
 
 import { HTTPError } from "../../../../errors"
 import * as sso from "../sso"
@@ -368,6 +374,20 @@ describe("sso", () => {
 
       it("does not link a global admin account", async () => {
         existingUser.admin = { global: true }
+        users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
+        const ssoUser = structures.users.ssoUser({ details })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({ _id: "us_" + details.userId }),
+          expect.anything()
+        )
+      })
+
+      it("does not link a disabled (inactive) account", async () => {
+        existingUser.status = UserStatus.INACTIVE
         users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
         const ssoUser = structures.users.ssoUser({ details })
         mockSaveUser.mockReturnValueOnce(ssoUser)

--- a/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
+++ b/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
@@ -377,6 +377,38 @@ describe("sso", () => {
         expect(events.user.inviteAccepted).not.toHaveBeenCalled()
         expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
       })
+
+      it("reuses the account created by a concurrent login racing for the same invite, instead of creating a second one", async () => {
+        // simulates another login (e.g. a different identity provider)
+        // winning the race: it consumed the invite and saved its own
+        // account for this email before we acquired the lock
+        mockInvite.getCode.mockReset()
+        mockInvite.getCode.mockRejectedValueOnce(new Error("invalid invite"))
+
+        const existingUser = structures.users.user({
+          _id: "us_some-other-identity",
+          email: details.email,
+        })
+        users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
+
+        const ssoUser = structures.users.ssoUser({
+          user: existingUser,
+          details,
+        })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(users.getGlobalUserByEmail).toHaveBeenCalledWith(details.email)
+        // the winner's account is reused - no second document is created
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({ _id: existingUser._id }),
+          expect.anything()
+        )
+        expect(mockInvite.deleteCode).not.toHaveBeenCalled()
+        expect(events.user.inviteAccepted).not.toHaveBeenCalled()
+        expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+      })
     })
 
     describe("when there is no user and no pending invite", () => {

--- a/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
+++ b/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
@@ -1,10 +1,11 @@
 import { structures } from "../../../../../tests"
 import { testEnv } from "../../../../../tests/extra"
-import { SSOAuthDetails, User } from "@budibase/types"
+import { InviteWithCode, SSOAuthDetails, User } from "@budibase/types"
 
 import { HTTPError } from "../../../../errors"
 import * as sso from "../sso"
 import * as context from "../../../../context"
+import * as events from "../../../../events"
 import nock from "nock"
 
 const mockDone = jest.fn()
@@ -14,6 +15,28 @@ jest.mock("../../../../users")
 import * as _users from "../../../../users"
 
 const users = jest.mocked(_users)
+
+jest.mock("../../../../cache", () => ({
+  ...jest.requireActual("../../../../cache"),
+  invite: {
+    ...jest.requireActual("../../../../cache").invite,
+    getExistingInvites: jest.fn(),
+    getCode: jest.fn(),
+    deleteCode: jest.fn(),
+  },
+}))
+import * as cache from "../../../../cache"
+
+const mockInvite = cache.invite as unknown as {
+  getExistingInvites: jest.Mock
+  getCode: jest.Mock
+  deleteCode: jest.Mock
+}
+
+jest.mock("../../../../redis/redlockImpl")
+import * as _locks from "../../../../redis/redlockImpl"
+
+const locks = jest.mocked(_locks)
 
 const getErrorMessage = () => {
   return mockDone.mock.calls[0][2].message
@@ -25,6 +48,11 @@ describe("sso", () => {
       jest.clearAllMocks()
       testEnv.singleTenant()
       nock.cleanAll()
+      mockInvite.getExistingInvites.mockResolvedValue([])
+      locks.doWithLock.mockImplementation(async (_opts: any, fn: any) => ({
+        executed: true,
+        result: await fn(),
+      }))
     })
 
     describe("validation", () => {
@@ -258,6 +286,138 @@ describe("sso", () => {
         await sso.authenticate(details, false, mockDone, mockSaveUser, true)
 
         expect(users.getGlobalUserByEmail).toHaveBeenCalled()
+        expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+      })
+    })
+
+    describe("when there is a pending invite for the email", () => {
+      let details: SSOAuthDetails
+      let invite: InviteWithCode
+      let assignments: {
+        roles: Record<string, string>
+        admin: { global: boolean }
+      }
+
+      beforeEach(() => {
+        details = structures.sso.authDetails()
+        // no verified-email signal from the identity provider
+        details.emailVerified = false
+
+        assignments = {
+          roles: { app_1: "BASIC" },
+          admin: { global: false },
+        }
+
+        invite = {
+          code: structures.uuid(),
+          email: details.email!,
+          info: { tenantId: context.getTenantId(), apps: assignments.roles },
+        }
+
+        // no match on the sso id - forces the invite fallback path
+        users.getById.mockImplementationOnce(() => {
+          throw new HTTPError("", 404)
+        })
+        users.deriveUserFieldsFromInvite.mockReturnValueOnce(assignments)
+
+        mockInvite.getExistingInvites.mockResolvedValueOnce([invite])
+        mockInvite.getCode.mockResolvedValueOnce({
+          email: invite.email,
+          info: invite.info,
+        })
+        mockInvite.deleteCode.mockResolvedValueOnce(undefined)
+      })
+
+      it("reconciles the invite without requiring a verified email, deletes it, and fires the accepted event", async () => {
+        const ssoUser = structures.users.ssoUser({ details })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        // the invite is matched purely on email - no account-linking lookup happens
+        expect(users.getGlobalUserByEmail).not.toHaveBeenCalled()
+
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({
+            _id: "us_" + details.userId,
+            email: details.email,
+            roles: assignments.roles,
+            admin: assignments.admin,
+          }),
+          expect.anything()
+        )
+
+        expect(mockInvite.deleteCode).toHaveBeenCalledWith(
+          invite.code,
+          invite.info.tenantId
+        )
+        expect(events.user.inviteAccepted).toHaveBeenCalledWith(ssoUser)
+        expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+      })
+
+      it("reconciles the invite even when a local account would otherwise be required", async () => {
+        const ssoUser = structures.users.ssoUser({ details })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, true, mockDone, mockSaveUser)
+
+        expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+      })
+
+      it("does not delete the invite if it was already consumed by a concurrent login", async () => {
+        mockInvite.getCode.mockReset()
+        mockInvite.getCode.mockRejectedValueOnce(new Error("invalid invite"))
+
+        const ssoUser = structures.users.ssoUser({ details })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(mockInvite.deleteCode).not.toHaveBeenCalled()
+        expect(events.user.inviteAccepted).not.toHaveBeenCalled()
+        expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+      })
+    })
+
+    describe("when there is no user and no pending invite", () => {
+      it("still rejects unverified email logins when a local account is required", async () => {
+        const details = structures.sso.authDetails()
+        details.emailVerified = false
+
+        users.getById.mockImplementationOnce(() => {
+          throw new HTTPError("", 404)
+        })
+
+        await sso.authenticate(details, true, mockDone, mockSaveUser)
+
+        expect(mockInvite.deleteCode).not.toHaveBeenCalled()
+        expect(mockDone.mock.calls.length).toBe(1)
+        expect(getErrorMessage()).toContain(
+          "Email does not yet exist. You must set up your local budibase account first."
+        )
+      })
+
+      it("still creates a plain new user from the login when a local account is not required", async () => {
+        const details = structures.sso.authDetails()
+        details.emailVerified = false
+
+        users.getById.mockImplementationOnce(() => {
+          throw new HTTPError("", 404)
+        })
+        const ssoUser = structures.users.ssoUser({ details })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        // no invite involved - just the default, empty-access new user
+        expect(mockInvite.deleteCode).not.toHaveBeenCalled()
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({
+            _id: "us_" + details.userId,
+            roles: {},
+          }),
+          expect.anything()
+        )
         expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
       })
     })

--- a/packages/backend-core/src/users/index.ts
+++ b/packages/backend-core/src/users/index.ts
@@ -1,4 +1,5 @@
 export * from "./users"
 export * from "./utils"
 export * from "./lookup"
+export * from "./invites"
 export { UserDB } from "./db"

--- a/packages/backend-core/src/users/invites.ts
+++ b/packages/backend-core/src/users/invites.ts
@@ -1,0 +1,47 @@
+import { Invite, UserRoles } from "@budibase/types"
+
+export interface InviteUserAssignments {
+  roles: UserRoles
+  admin: { global: boolean }
+  builder?: { global: boolean; creator?: boolean; apps?: string[] }
+  userGroups?: string[]
+}
+
+/**
+ * Translates the role/permission info stored against a pending invite into
+ * the fields a User document needs
+ */
+export function deriveUserFieldsFromInvite(
+  info: Invite["info"]
+): InviteUserAssignments {
+  const appRoles = info.apps || {}
+  const creatorAppsFromRoles = Object.keys(appRoles).filter(
+    appId => appRoles[appId] === "CREATOR"
+  )
+
+  const builderApps = [...(info.builder?.apps || []), ...creatorAppsFromRoles]
+  const uniqueBuilderApps = [...new Set(builderApps)]
+  const hasCreatorPerms =
+    !!info.builder?.creator || creatorAppsFromRoles.length > 0
+
+  const assignments: InviteUserAssignments = {
+    roles: appRoles,
+    admin: { global: info.admin?.global || false },
+  }
+
+  if (info.builder || hasCreatorPerms || uniqueBuilderApps.length) {
+    assignments.builder = { global: info.builder?.global || false }
+    if (hasCreatorPerms) {
+      assignments.builder.creator = true
+    }
+    if (uniqueBuilderApps.length) {
+      assignments.builder.apps = uniqueBuilderApps
+    }
+  }
+
+  if (info.userGroups?.length) {
+    assignments.userGroups = info.userGroups
+  }
+
+  return assignments
+}

--- a/packages/worker/src/api/controllers/global/users.ts
+++ b/packages/worker/src/api/controllers/global/users.ts
@@ -737,52 +737,13 @@ export const inviteAccept = async (
           resolvedTenantId
         )
         const user = await tenancy.doInTenant(info.tenantId, async () => {
-          const appRoles = info.apps || {}
-          const creatorAppsFromRoles = Object.keys(appRoles).filter(
-            appId => appRoles[appId] === "CREATOR"
-          )
-
-          const builderApps = [
-            ...(info?.builder?.apps || []),
-            ...creatorAppsFromRoles,
-          ]
-          const uniqueBuilderApps = [...new Set(builderApps)]
-          const hasCreatorPerms =
-            !!info?.builder?.creator || creatorAppsFromRoles.length > 0
-
-          let request: any = {
+          const request: any = {
             firstName,
             lastName,
             password,
             email,
-            admin: { global: info?.admin?.global || false },
-            roles: appRoles,
             tenantId: info.tenantId,
-          }
-          const builder: {
-            global: boolean
-            creator?: boolean
-            apps?: string[]
-          } = {
-            global: info?.builder?.global || false,
-          }
-
-          if (hasCreatorPerms) {
-            builder.creator = true
-          }
-          if (uniqueBuilderApps.length) {
-            builder.apps = uniqueBuilderApps
-          }
-
-          const cleanedInviteInfo = { ...info }
-          delete cleanedInviteInfo.apps
-          delete cleanedInviteInfo.builder
-          request = {
-            ...request,
-            ...cleanedInviteInfo,
-          }
-          if (info?.builder || hasCreatorPerms || uniqueBuilderApps.length) {
-            request.builder = builder
+            ...users.deriveUserFieldsFromInvite(info),
           }
 
           const saved = await userSdk.db.save(request)

--- a/packages/worker/src/api/routes/global/tests/users.spec.ts
+++ b/packages/worker/src/api/routes/global/tests/users.spec.ts
@@ -1,8 +1,11 @@
 import { InviteUsersResponse, OIDCUser, User } from "@budibase/types"
+import { randomUUID } from "crypto"
 
 import {
   accounts as _accounts,
+  cache,
   events,
+  middleware,
   tenancy,
   withEnv,
 } from "@budibase/backend-core"
@@ -402,6 +405,60 @@ describe("/api/global/users", () => {
       expect(user?.roles?.[workspaceId]).toBe("CREATOR")
       expect(user?.builder?.creator).toBe(true)
       expect(user?.builder?.apps).toEqual([workspaceId])
+    })
+
+    it("reconciles an OIDC login with a pending invite for the same email, regardless of casing or email verification", async () => {
+      const email = structures.users.newEmail()
+      const workspaceId = "app_oidc_invite_workspace"
+      const request = [
+        {
+          email,
+          userInfo: {
+            apps: { [workspaceId]: "BASIC" },
+          },
+        },
+      ]
+
+      await config.api.users.sendMultiUserInvite(request)
+
+      // different casing, no email_verified claim
+      const uppercaseEmail = email.toUpperCase()
+      const ssoUserId = `oidc-test-${randomUUID()}`
+      const verify: any = middleware.oidc.buildVerifyFn(userSdk.db.save, false)
+
+      const { err, user: loggedInUser } = await config.doInTenant(
+        () =>
+          new Promise<{ err: any; user: any }>(resolve => {
+            verify(
+              "https://issuer.example.com",
+              { id: ssoUserId, _json: { email: uppercaseEmail } } as any,
+              { id: ssoUserId, emails: [] } as any,
+              {} as any,
+              "id-token",
+              "access-token",
+              "refresh-token",
+              {},
+              (err: any, user: any) => resolve({ err, user })
+            )
+          })
+      )
+
+      expect(err).toBeFalsy()
+      expect(loggedInUser.email).toBe(email.toLowerCase())
+      expect(loggedInUser.roles?.[workspaceId]).toBe("BASIC")
+
+      // a single reconciled user, invite consumed
+      const remainingInvites = await config.doInTenant(() =>
+        cache.invite.getInviteCodes()
+      )
+      expect(
+        remainingInvites.some(
+          invite => invite.email.toLowerCase() === email.toLowerCase()
+        )
+      ).toBe(false)
+      expect(events.user.inviteAccepted).toHaveBeenCalledWith(
+        expect.objectContaining({ email: email.toLowerCase() })
+      )
     })
 
     it("should not be able to generate an invitation for existing user", async () => {


### PR DESCRIPTION
## Addresses
- https://github.com/Budibase/budibase/issues/18050

## Description

When a user is invited to a Budibase tenant and then logs in via OIDC/SAML SSO before accepting that invite through any other path, Budibase currently fails to reconcile the SSO login with the invited identity whenever the identity provider does not mark the email as verified (`email_verified` absent/`false`) and `allowUnverifiedEmailLinking` is off (the secure default).

Azure Entra ID, in the reporting customer's configuration, does not send `email_verified: true`. Without a verified email or that opt-in flag, `sso.authenticate()` has no way today to know the login corresponds to an existing, pending invite, so it falls through to "create a brand new user keyed on the SSO subject id" - producing a second, access-less account while the original invite is left showing as pending in Settings → People.

**This is not a casing bug.** An earlier fix (`f0b5821f00`, "Fix OIDC invite email casing mismatch") already normalizes email casing on both the OIDC and invite-matching sides - that part of the original report is already handled. What was still missing, and what this PR fixes, is the actual reconciliation between the invited identity and the SSO identity on first login: even with identical, correctly-cased emails on both sides, the login and the invite were never being linked, because linking by email is deliberately gated behind email verification for security reasons unrelated to casing.

## Screen recording

https://github.com/user-attachments/assets/87206581-b7e1-4352-a2f7-8ae0b482ec0c

### The fix

`sso.authenticate()` now checks for a matching pending invite (case-insensitive, via the existing invite cache) before falling back to first-time user creation, but **only** when no existing user was found by SSO id or by a verified/allowed email lookup. If a pending invite matches:

- the new account is seeded with the invite's `roles`/`admin`/`builder`/`userGroups`/`tenantId` (via a new shared helper, `deriveUserFieldsFromInvite`, also now used by the existing password-based invite-accept flow so both paths can't drift apart)
- it bypasses `requireLocalAccount` for that one case (the pending invite itself is the proof of intent - no different from the browser links normally used to onboard)
- after save, the invite is re-validated and deleted under the existing invite-processing lock (`LockName.PROCESS_USER_INVITE`), guarding against a concurrent accept/login race double-consuming or double-deleting it
- the `inviteAccepted` event fires, exactly as it does for the password-based accept flow

This is deliberately narrower than turning on `allowUnverifiedEmailLinking`: it only activates for an email with a genuinely pending, non-expired, admin-issued invite (7-day TTL), it does not change anything about how unverified emails are handled for accounts that aren't currently invited, and the existing test coverage documenting that stricter default behaviour (`sso.spec.ts`) is unchanged/still green.

### Scope note - two flows, this PR covers one

Investigation surfaced two distinct real-world paths that hit this bug:
1. **Invite still pending when SSO login happens** - fixed here.
2. **Invite already accepted (no password) before SSO login happens** - this is actually the dominant path for SSO-enforced tenants, since the invite acceptance page auto-accepts (no password) and redirects straight to SSO login the moment `isSSOEnforced` is true. This case is **not** covered by this PR.

### Related PR

[#19219](https://github.com/Budibase/budibase/pull/19219) (draft, different author) is also touching `sso.ts`/`sso.spec.ts` right now, for a related but distinct purpose: issuer-scoped SSO identities to prevent subject collisions across providers and to migrate legacy accounts. It does not touch invite reconciliation (confirmed - no mention of invites in that diff), so it shouldn't conflict in intent, but a textual merge conflict in `sso.ts`'s `authenticate()` is likely whichever lands second.

## Launchcontrol

Fixes an issue where inviting a user to a Budibase tenant using SSO (Azure Entra ID/OIDC in the reported case) could create a second, useless account with no workspace access instead of granting the invited user their intended access when they signed in. The original invite now correctly gets applied to the account the user actually logs into.