### PR TITLE
[#18050] Reconcile already-accepted invites during unverified-email OIDC/SSO logins

### DIFF
--- a/packages/backend-core/src/middleware/passport/sso/sso.ts
+++ b/packages/backend-core/src/middleware/passport/sso/sso.ts
@@ -14,6 +14,7 @@ import {
   SSOAuthDetails,
   SSOUser,
   User,
+  UserStatus,
 } from "@budibase/types"
 
 // no-op function for user save
@@ -133,10 +134,16 @@ async function syncAndSaveUser(
 }
 
 // only linkable while no one else could plausibly own it: never claimed
-// with a password, no account-portal ssoId, not a global admin, and if
-// already an SSO user, only from the same identity provider that linked it
+// with a password, not disabled, no account-portal ssoId, not a global
+// admin, and if already an SSO user, only from the same identity provider
+// that linked it
 function isAccountLinkable(user: User, details: SSOAuthDetails): boolean {
-  if (user.password || user.admin?.global || user.ssoId) {
+  if (
+    user.password ||
+    user.status === UserStatus.INACTIVE ||
+    user.admin?.global ||
+    user.ssoId
+  ) {
     return false
   }
   if (isSSOUser(user)) {

--- a/packages/backend-core/src/middleware/passport/sso/sso.ts
+++ b/packages/backend-core/src/middleware/passport/sso/sso.ts
@@ -7,6 +7,7 @@ import * as events from "../../../events"
 import * as locks from "../../../redis/redlockImpl"
 import {
   InviteWithCode,
+  isSSOUser,
   LockName,
   LockType,
   SaveSSOUserFunction,
@@ -72,6 +73,12 @@ export async function authenticate(
     pendingInvite = invites[0]
   }
 
+  const emailLookupWasSkipped =
+    !details.emailVerified && !allowUnverifiedEmailLinking
+  if (!dbUser && !pendingInvite && emailLookupWasSkipped) {
+    dbUser = await findLinkableAccountByEmail(details)
+  }
+
   // exit early if there is still no user/invite and auto creation is disabled
   if (!dbUser && !pendingInvite && requireLocalAccount) {
     return authError(
@@ -116,6 +123,32 @@ export async function authenticate(
   }
 
   return done(null, ssoUser)
+}
+
+// only linkable while no one else could plausibly own it: never claimed
+// with a password, no account-portal ssoId, not a global admin, and if
+// already an SSO user, only from the same identity provider that linked it
+function isAccountLinkable(user: User, details: SSOAuthDetails): boolean {
+  if (user.password || user.admin?.global || user.ssoId) {
+    return false
+  }
+  if (isSSOUser(user)) {
+    return (
+      user.provider === details.provider &&
+      user.providerType === details.providerType
+    )
+  }
+  return true
+}
+
+async function findLinkableAccountByEmail(
+  details: SSOAuthDetails
+): Promise<User | undefined> {
+  const user = await users.getGlobalUserByEmail(details.email!)
+  if (user && isAccountLinkable(user, details)) {
+    return user
+  }
+  return undefined
 }
 
 async function consumePendingInvite(invite: InviteWithCode, user: SSOUser) {

--- a/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
+++ b/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
@@ -1,6 +1,6 @@
 import { structures } from "../../../../../tests"
 import { testEnv } from "../../../../../tests/extra"
-import { InviteWithCode, SSOAuthDetails, User } from "@budibase/types"
+import { InviteWithCode, SSOAuthDetails, SSOUser, User } from "@budibase/types"
 
 import { HTTPError } from "../../../../errors"
 import * as sso from "../sso"
@@ -242,7 +242,8 @@ describe("sso", () => {
         })
       })
 
-      it("does not link to an existing account by email", async () => {
+      it("does not link to an already-claimed account by email", async () => {
+        // existingUser has a password set, so it is not linkable
         users.getGlobalUserByEmail.mockReturnValue(
           Promise.resolve(existingUser)
         )
@@ -254,8 +255,6 @@ describe("sso", () => {
 
         await sso.authenticate(details, false, mockDone, mockSaveUser)
 
-        // the victim's account must never be loaded by an unverified email
-        expect(users.getGlobalUserByEmail).not.toHaveBeenCalled()
         // instead a brand new account keyed on the sso id is created
         expect(mockSaveUser).toHaveBeenCalledWith(
           expect.objectContaining({ _id: "us_" + details.userId }),
@@ -263,10 +262,13 @@ describe("sso", () => {
         )
       })
 
-      it("rejects when a local account is required", async () => {
+      it("rejects when a local account is required and no linkable account exists", async () => {
+        users.getGlobalUserByEmail.mockReturnValueOnce(
+          Promise.resolve(undefined)
+        )
+
         await sso.authenticate(details, true, mockDone, mockSaveUser)
 
-        expect(users.getGlobalUserByEmail).not.toHaveBeenCalled()
         expect(mockDone.mock.calls.length).toBe(1)
         expect(getErrorMessage()).toContain(
           "Email does not yet exist. You must set up your local budibase account first."
@@ -286,6 +288,122 @@ describe("sso", () => {
         await sso.authenticate(details, false, mockDone, mockSaveUser, true)
 
         expect(users.getGlobalUserByEmail).toHaveBeenCalled()
+        expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+      })
+    })
+
+    describe("when there is a linkable account for the email (invite already accepted)", () => {
+      let existingUser: User & Partial<SSOUser>
+      let details: SSOAuthDetails
+
+      beforeEach(() => {
+        existingUser = structures.users.user()
+        existingUser._id = structures.uuid()
+        delete existingUser.password
+
+        details = structures.sso.authDetails(existingUser)
+        details.emailVerified = false
+
+        // no match on the sso id - forces the email fallback path
+        users.getById.mockImplementationOnce(() => {
+          throw new HTTPError("", 404)
+        })
+        nock("http://example.com").get("/").reply(200, undefined, {
+          "Content-Type": "image/png",
+        })
+      })
+
+      it("links an unclaimed account (no password) on first login", async () => {
+        users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
+        const ssoUser = structures.users.ssoUser({
+          user: existingUser,
+          details,
+        })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({ _id: existingUser._id }),
+          expect.anything()
+        )
+        expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+      })
+
+      it("keeps resolving the account on a later login from the same identity provider", async () => {
+        // simulates the account state after a first successful login: syncUser
+        // has already stamped provider/providerType onto the document
+        existingUser.provider = details.provider
+        existingUser.providerType = details.providerType
+        users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
+        const ssoUser = structures.users.ssoUser({
+          user: existingUser,
+          details,
+        })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({ _id: existingUser._id }),
+          expect.anything()
+        )
+        expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
+      })
+
+      it("does not link an account already linked via a different identity provider", async () => {
+        existingUser.provider = structures.uuid()
+        existingUser.providerType = details.providerType
+        users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
+        const ssoUser = structures.users.ssoUser({ details })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({ _id: "us_" + details.userId }),
+          expect.anything()
+        )
+      })
+
+      it("does not link a global admin account", async () => {
+        existingUser.admin = { global: true }
+        users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
+        const ssoUser = structures.users.ssoUser({ details })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({ _id: "us_" + details.userId }),
+          expect.anything()
+        )
+      })
+
+      it("does not link an account with an account-portal ssoId", async () => {
+        existingUser.ssoId = structures.uuid()
+        users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
+        const ssoUser = structures.users.ssoUser({ details })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({ _id: "us_" + details.userId }),
+          expect.anything()
+        )
+      })
+
+      it("reconciles even when a local account would otherwise be required", async () => {
+        users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
+        const ssoUser = structures.users.ssoUser({
+          user: existingUser,
+          details,
+        })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, true, mockDone, mockSaveUser)
+
         expect(mockDone).toHaveBeenCalledWith(null, ssoUser)
       })
     })

--- a/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
+++ b/packages/backend-core/src/middleware/passport/sso/tests/sso.spec.ts
@@ -1,6 +1,12 @@
 import { structures } from "../../../../../tests"
 import { testEnv } from "../../../../../tests/extra"
-import { InviteWithCode, SSOAuthDetails, SSOUser, User } from "@budibase/types"
+import {
+  InviteWithCode,
+  SSOAuthDetails,
+  SSOUser,
+  User,
+  UserStatus,
+} from "@budibase/types"
 
 import { HTTPError } from "../../../../errors"
 import * as sso from "../sso"
@@ -368,6 +374,20 @@ describe("sso", () => {
 
       it("does not link a global admin account", async () => {
         existingUser.admin = { global: true }
+        users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
+        const ssoUser = structures.users.ssoUser({ details })
+        mockSaveUser.mockReturnValueOnce(ssoUser)
+
+        await sso.authenticate(details, false, mockDone, mockSaveUser)
+
+        expect(mockSaveUser).toHaveBeenCalledWith(
+          expect.objectContaining({ _id: "us_" + details.userId }),
+          expect.anything()
+        )
+      })
+
+      it("does not link a disabled (inactive) account", async () => {
+        existingUser.status = UserStatus.INACTIVE
         users.getGlobalUserByEmail.mockResolvedValueOnce(existingUser)
         const ssoUser = structures.users.ssoUser({ details })
         mockSaveUser.mockReturnValueOnce(ssoUser)


### PR DESCRIPTION
## Addresses
- https://github.com/Budibase/budibase/issues/18050

## Description

When an SSO-enforced tenant's invite is auto-accepted (no password, no user interaction) before the user ever authenticates with the identity provider, and the identity provider doesn't mark the email as verified, `sso.authenticate()` had no way to reconcile the login with the already-existing account. It fell through to "create a new user", which collided on the unique email index and hard-failed the login with `EmailUnavailableError: Email already in use`.

This is a follow-up to #19302, which fixed the case where the invite is still pending at SSO login time. This PR fixes the more common case for SSO-enforced tenants: the invite acceptance page auto-accepts the moment `isSSOEnforced` is true, so by the time the SSO login happens there's no pending invite left to reconcile against, just an existing, unclaimed local account.

### The fix

`sso.authenticate()` now falls back to looking up the account by email and linking to it when the account is provably still unclaimed: no password set, not a global admin, and no account-portal `ssoId`. If the account has already been linked by SSO before, it's only linkable when the current login's `provider`/`providerType` match the ones that linked it previously - i.e. it's the same identity provider that established the connection, not a different one trying to claim the same email.

That last condition is what makes the account keep resolving on a *second* login, not just the first. An earlier version of this fix (tried and reverted before this PR) linked correctly on the first login but broke on the second: the account is no longer "unclaimed" in the strict sense once `syncUser()` stamps `provider`/`providerType` onto it after a successful login, so it became unfindable again and the second login collided with itself. Relaxing "unclaimed" to "not claimed by a *different* identity" fixes that without reopening the tenant-wide `allowUnverifiedEmailLinking` trust decision to every account in the tenant - it only ever applies to an account this exact identity provider has already established a connection to.

Manually verified end-to-end locally: invite auto-accepted, first OIDC login (unverified email) reconciles successfully, and a second login with the same identity keeps working.

## Screen recording

### User activation and Login with OIDC

https://github.com/user-attachments/assets/ca677b7b-e380-4e9b-a0d4-7c4bea54ddfa

### Login with OIDC doesn't claim an alredy used (e.g. with password) account

https://github.com/user-attachments/assets/2d9c2367-f72b-464e-a19b-66d99cb50f14

## Launchcontrol

Fixes the remaining case of an issue where SSO logins (Azure Entra ID/OIDC in the reported case) could fail or create a duplicate, access-less account after a user was invited to a tenant with SSO enforced.