### PR TITLE
[Functions alpha] Add the linked-query and stable-alias editor

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionList.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionList.spec.ts
@@ -87,4 +87,20 @@ describe("FunctionList", () => {
     expect(screen.getByText("Unpublished changes")).toBeInTheDocument()
     expect(screen.getByText("1")).toBeInTheDocument()
   })
+
+  it("opens a Function from its name", async () => {
+    const fn = makeFunction()
+    const onOpen = vi.fn()
+    render(FunctionList, {
+      canManage: true,
+      functions: [fn],
+      onOpen,
+    })
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Customer lookup" })
+    )
+
+    expect(onOpen).toHaveBeenCalledWith(fn)
+  })
 })

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionList.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionList.svelte
@@ -18,6 +18,7 @@
     loading?: boolean
     error?: string
     canManage?: boolean
+    onOpen?: (_fn: UIFunction) => void
     onRetry?: () => void
     onCreate?: () => void
     onRename?: (_fn: UIFunction) => void
@@ -30,6 +31,7 @@
     loading = false,
     error = "",
     canManage = false,
+    onOpen = () => {},
     onRetry = () => {},
     onCreate = () => {},
     onRename = () => {},
@@ -108,7 +110,13 @@
         <div class="table-row" role="row">
           <div class="name" role="cell">
             <Icon name="code" size="S" />
-            <Body size="S">{fn.name}</Body>
+            <button
+              type="button"
+              class="name-button"
+              onclick={() => onOpen(fn)}
+            >
+              {fn.name}
+            </button>
           </div>
           <div role="cell">
             <span class:failed={fn.readiness === "build_failed"}>
@@ -210,6 +218,19 @@
     display: flex;
     align-items: center;
     gap: var(--spacing-s);
+  }
+  .name-button {
+    appearance: none;
+    border: 0;
+    background: transparent;
+    color: var(--spectrum-global-color-blue-700);
+    cursor: pointer;
+    font: inherit;
+    padding: 0;
+    text-align: left;
+  }
+  .name-button:hover {
+    text-decoration: underline;
   }
   .failed {
     color: var(--spectrum-global-color-red-600);

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionQueryEditor.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionQueryEditor.spec.ts
@@ -1,0 +1,190 @@
+import { fireEvent, render, screen, within } from "@testing-library/svelte"
+import type {
+  FunctionQueryCapability,
+  FunctionQueryCatalogEntry,
+} from "@budibase/types"
+import { SourceName } from "@budibase/types"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import FunctionQueryEditor from "./FunctionQueryEditor.svelte"
+
+if (!Element.prototype.animate) {
+  Element.prototype.animate = () =>
+    Object.assign(Object.create(null), {
+      onfinish: null,
+      cancel: () => {},
+      finished: Promise.resolve(),
+    }) as Animation
+}
+
+const catalog: FunctionQueryCatalogEntry[] = [
+  {
+    queryId: "query_customer",
+    queryName: "Find renamed customer",
+    datasourceId: "datasource_crm",
+    datasourceName: "Renamed CRM",
+    source: SourceName.POSTGRES,
+    kind: "data",
+    parameters: [{ name: "customerId" }],
+  },
+  {
+    queryId: "query_event",
+    queryName: "Send event",
+    datasourceId: "datasource_events",
+    datasourceName: "Events API",
+    source: SourceName.REST,
+    kind: "api",
+    parameters: [{ name: "event" }],
+  },
+]
+
+const capability: FunctionQueryCapability = {
+  capabilityId: "cap_customer",
+  queryId: "query_customer",
+  datasourceAlias: "crm",
+  queryAlias: "findCustomer",
+  parameterNames: ["customerId"],
+}
+
+describe("FunctionQueryEditor", () => {
+  beforeEach(() => {
+    document.body.className = "spectrum"
+  })
+
+  it("shows current display names without changing stored aliases", () => {
+    render(FunctionQueryEditor, {
+      capabilities: [capability],
+      catalog,
+    })
+
+    expect(screen.getByText("Find renamed customer")).toBeInTheDocument()
+    expect(screen.getByText("Renamed CRM")).toBeInTheDocument()
+    expect(screen.getByText("queries.crm.findCustomer()")).toBeInTheDocument()
+    expect(screen.getByText("customerId: string | null")).toBeInTheDocument()
+  })
+
+  it("selects Data and API Explorer queries and saves only explicit links", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    render(FunctionQueryEditor, {
+      catalog,
+      onSave,
+    })
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: /Link a Data query/i })
+    )
+    await fireEvent.click(
+      screen.getByRole("option", {
+        name: /Find renamed customer/i,
+        hidden: true,
+      })
+    )
+    await fireEvent.click(
+      screen.getByRole("button", { name: /Link an API query/i })
+    )
+    await fireEvent.click(
+      screen.getByRole("option", { name: /Send event/i, hidden: true })
+    )
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Save query links" })
+    )
+
+    expect(onSave).toHaveBeenCalledWith([
+      {
+        queryId: "query_customer",
+        datasourceAlias: "renamedCRM",
+        queryAlias: "findRenamedCustomer",
+      },
+      {
+        queryId: "query_event",
+        datasourceAlias: "eventsAPI",
+        queryAlias: "sendEvent",
+      },
+    ])
+  })
+
+  it("removes links, including saved queries that are now missing", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    render(FunctionQueryEditor, {
+      capabilities: [
+        {
+          ...capability,
+          queryId: "query_deleted",
+          parameterNames: ["lastKnownId"],
+        },
+      ],
+      catalog,
+      onSave,
+    })
+
+    const missing = screen.getByTestId("linked-query-query_deleted")
+    expect(within(missing).getByText("Missing query")).toBeInTheDocument()
+    expect(
+      within(missing).getByText("lastKnownId: string | null")
+    ).toBeInTheDocument()
+
+    await fireEvent.click(
+      within(missing).getByRole("button", { name: "Remove missing query" })
+    )
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Save query links" })
+    )
+
+    expect(onSave).toHaveBeenCalledWith([])
+  })
+
+  it("prevents invalid aliases with an actionable error", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    const view = render(FunctionQueryEditor, {
+      capabilities: [capability],
+      catalog,
+      onSave,
+    })
+
+    const inputs = view.container.querySelectorAll("input")
+    await fireEvent.input(inputs[1], {
+      target: { value: "invalid alias" },
+    })
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Save query links" })
+    )
+
+    expect(
+      screen.getByText("Use a JavaScript identifier, for example customerData.")
+    ).toBeInTheDocument()
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it("shows catalog failures and retries", async () => {
+    const onRetry = vi.fn()
+    render(FunctionQueryEditor, {
+      capabilities: [capability],
+      catalogError: "Unable to fetch saved queries",
+      onRetry,
+    })
+
+    expect(screen.getByTestId("query-catalog-error")).toHaveTextContent(
+      "Unable to fetch saved queries"
+    )
+    expect(screen.getByText("Query details unavailable")).toBeInTheDocument()
+    expect(screen.queryByText("Missing query")).not.toBeInTheDocument()
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }))
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+
+  it("highlights declaration parameter changes", () => {
+    render(FunctionQueryEditor, {
+      capabilities: [
+        {
+          ...capability,
+          parameterNames: ["oldParameter"],
+        },
+      ],
+      catalog,
+    })
+
+    expect(screen.getByText(/Query parameters changed/)).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Save query links" })
+    ).not.toHaveClass("is-disabled")
+  })
+})

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionQueryEditor.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionQueryEditor.svelte
@@ -1,0 +1,517 @@
+<svelte:options runes={true} />
+
+<script lang="ts">
+  import { getErrorMessage } from "@/helpers/errors"
+  import {
+    Body,
+    Button,
+    Heading,
+    Icon,
+    Input,
+    ProgressCircle,
+    Select,
+  } from "@budibase/bbui"
+  import type {
+    FunctionQueryCapability,
+    FunctionQueryCapabilityInput,
+    FunctionQueryCatalogEntry,
+    FunctionQueryKind,
+  } from "@budibase/types"
+  import {
+    hasFunctionQueryAliasErrors,
+    toFunctionQueryAlias,
+    validateFunctionQueryAliases,
+  } from "./queryAliases"
+
+  interface Props {
+    capabilities?: FunctionQueryCapability[]
+    catalog?: FunctionQueryCatalogEntry[]
+    catalogLoading?: boolean
+    catalogError?: string
+    onRetry?: () => void
+    onSave?: (_capabilities: FunctionQueryCapabilityInput[]) => Promise<void>
+  }
+
+  let {
+    capabilities = [],
+    catalog = [],
+    catalogLoading = false,
+    catalogError = "",
+    onRetry = () => {},
+    onSave = async () => {},
+  }: Props = $props()
+
+  let drafts = $state<FunctionQueryCapabilityInput[]>([])
+  let syncedCapabilities = $state("")
+  let saving = $state(false)
+  let saveError = $state("")
+  let showErrors = $state(false)
+  let queryToAdd = $state<Record<FunctionQueryKind, string | undefined>>({
+    data: undefined,
+    api: undefined,
+  })
+
+  const toInputs = (
+    values: FunctionQueryCapability[]
+  ): FunctionQueryCapabilityInput[] =>
+    values.map(capability => ({
+      queryId: capability.queryId,
+      datasourceAlias: capability.datasourceAlias,
+      queryAlias: capability.queryAlias,
+    }))
+
+  const haveSameParameterNames = (left: string[], right: string[]) =>
+    left.length === right.length &&
+    left.every((name, index) => name === right[index])
+
+  $effect(() => {
+    const serialised = JSON.stringify(toInputs(capabilities))
+    if (serialised !== syncedCapabilities) {
+      drafts = toInputs(capabilities)
+      syncedCapabilities = serialised
+      showErrors = false
+      saveError = ""
+    }
+  })
+
+  let catalogByQueryId = $derived(
+    new Map(catalog.map(entry => [entry.queryId, entry]))
+  )
+  let errors = $derived(validateFunctionQueryAliases(drafts, catalog))
+  let parameterMetadataChanged = $derived.by(() =>
+    capabilities.some(capability => {
+      const entry = catalogByQueryId.get(capability.queryId)
+      return (
+        !!entry &&
+        !haveSameParameterNames(
+          capability.parameterNames,
+          entry.parameters.map(parameter => parameter.name)
+        )
+      )
+    })
+  )
+  let dirty = $derived(
+    JSON.stringify(drafts) !== syncedCapabilities || parameterMetadataChanged
+  )
+
+  const getAvailableQueries = (kind: FunctionQueryKind) =>
+    catalog.filter(
+      entry =>
+        entry.kind === kind &&
+        !drafts.some(capability => capability.queryId === entry.queryId)
+    )
+
+  const getOptionLabel = (entry: FunctionQueryCatalogEntry) => entry.queryName
+  const getOptionValue = (entry: FunctionQueryCatalogEntry) => entry.queryId
+  const getOptionSubtitle = (entry: FunctionQueryCatalogEntry) => {
+    if (!entry.parameters.length) {
+      return `${entry.datasourceName} · No parameters`
+    }
+    const suffix = entry.parameters.length === 1 ? "" : "s"
+    return `${entry.datasourceName} · ${entry.parameters.length} parameter${suffix}`
+  }
+
+  const getUnavailableQueryTitle = () => {
+    if (catalogLoading) {
+      return "Loading query details"
+    }
+    if (catalogError) {
+      return "Query details unavailable"
+    }
+    return "Missing query"
+  }
+
+  const getUnavailableQueryDescription = (
+    capability: FunctionQueryCapabilityInput,
+    missing: boolean
+  ) => {
+    if (missing) {
+      return `The saved query ${capability.queryId} was deleted or is unavailable.`
+    }
+    return "Stored aliases and last-known parameters are shown below."
+  }
+
+  const uniqueAlias = (
+    preferred: string,
+    isUsed: (_alias: string) => boolean
+  ) => {
+    let alias = preferred
+    let suffix = 2
+    while (isUsed(alias)) {
+      alias = `${preferred}${suffix}`
+      suffix += 1
+    }
+    return alias
+  }
+
+  const addQuery = (kind: FunctionQueryKind, queryId?: string) => {
+    queryToAdd[kind] = undefined
+    if (!queryId || drafts.some(capability => capability.queryId === queryId)) {
+      return
+    }
+    const entry = catalogByQueryId.get(queryId)
+    if (!entry) {
+      return
+    }
+
+    const existingDatasourceCapability = drafts.find(capability => {
+      const linkedEntry = catalogByQueryId.get(capability.queryId)
+      return linkedEntry?.datasourceId === entry.datasourceId
+    })
+    const preferredDatasourceAlias =
+      existingDatasourceCapability?.datasourceAlias ||
+      toFunctionQueryAlias(entry.datasourceName, "datasource")
+    const datasourceAlias = existingDatasourceCapability
+      ? preferredDatasourceAlias
+      : uniqueAlias(preferredDatasourceAlias, alias =>
+          drafts.some(capability => capability.datasourceAlias === alias)
+        )
+    const preferredQueryAlias = toFunctionQueryAlias(entry.queryName, "query")
+    const queryAlias = uniqueAlias(preferredQueryAlias, alias =>
+      drafts.some(
+        capability =>
+          capability.datasourceAlias === datasourceAlias &&
+          capability.queryAlias === alias
+      )
+    )
+
+    drafts = [
+      ...drafts,
+      {
+        queryId,
+        datasourceAlias,
+        queryAlias,
+      },
+    ]
+    saveError = ""
+  }
+
+  const removeQuery = (queryId: string) => {
+    drafts = drafts.filter(capability => capability.queryId !== queryId)
+    saveError = ""
+  }
+
+  const parametersChanged = (
+    capability: FunctionQueryCapabilityInput,
+    entry: FunctionQueryCatalogEntry
+  ) => {
+    const persisted = capabilities.find(
+      candidate => candidate.queryId === capability.queryId
+    )
+    if (!persisted) {
+      return false
+    }
+    return !haveSameParameterNames(
+      persisted.parameterNames,
+      entry.parameters.map(parameter => parameter.name)
+    )
+  }
+
+  const getPersistedCapability = (
+    queryId: string
+  ): FunctionQueryCapability | undefined =>
+    capabilities.find(capability => capability.queryId === queryId)
+
+  const save = async () => {
+    showErrors = true
+    saveError = ""
+    if (hasFunctionQueryAliasErrors(errors) || saving) {
+      return
+    }
+    saving = true
+    try {
+      await onSave(drafts)
+    } catch (error) {
+      saveError = getErrorMessage(error) || "Unable to save linked queries"
+    } finally {
+      saving = false
+    }
+  }
+</script>
+
+<section class="query-editor">
+  <div class="editor-heading">
+    <div>
+      <Heading size="M">Linked queries</Heading>
+      <Body size="S" color="var(--spectrum-global-color-gray-600)">
+        Only linked saved queries are available to this Function. Aliases remain
+        stable when a datasource or query is renamed.
+      </Body>
+    </div>
+    <Button primary disabled={!dirty || saving} on:click={save}>
+      Save query links
+    </Button>
+  </div>
+
+  {#if catalogLoading}
+    <div class="catalog-state" data-testid="query-catalog-loading">
+      <ProgressCircle size="S" />
+      <Body size="S">Loading saved queries...</Body>
+    </div>
+  {:else if catalogError}
+    <div class="catalog-state error" data-testid="query-catalog-error">
+      <Icon name="warning-circle" size="S" />
+      <Body size="S">{catalogError}</Body>
+      <Button secondary on:click={onRetry}>Retry</Button>
+    </div>
+  {:else}
+    <div class="query-pickers">
+      <Select
+        label="Data queries"
+        value={queryToAdd.data}
+        options={getAvailableQueries("data")}
+        {getOptionLabel}
+        {getOptionValue}
+        {getOptionSubtitle}
+        showSelectedSubtitle
+        autocomplete
+        searchPlaceholder="Search Data queries"
+        placeholder="Link a Data query"
+        on:change={event => addQuery("data", event.detail)}
+      />
+      <Select
+        label="API Explorer queries"
+        value={queryToAdd.api}
+        options={getAvailableQueries("api")}
+        {getOptionLabel}
+        {getOptionValue}
+        {getOptionSubtitle}
+        showSelectedSubtitle
+        autocomplete
+        searchPlaceholder="Search API queries"
+        placeholder="Link an API query"
+        on:change={event => addQuery("api", event.detail)}
+      />
+    </div>
+  {/if}
+
+  {#if !drafts.length}
+    <div class="empty" data-testid="linked-queries-empty">
+      <Icon name="link" size="L" />
+      <Heading size="S">No linked queries</Heading>
+      <Body size="S" color="var(--spectrum-global-color-gray-600)">
+        Select a saved Data or API Explorer query to make it callable.
+      </Body>
+    </div>
+  {:else}
+    <div class="linked-queries">
+      {#each drafts as capability, index (capability.queryId)}
+        {@const entry = catalogByQueryId.get(capability.queryId)}
+        {@const missing = !catalogLoading && !catalogError && !entry}
+        <article
+          class:missing
+          class="linked-query"
+          data-testid={`linked-query-${capability.queryId}`}
+        >
+          <div class="query-heading">
+            <div>
+              <div class="query-title">
+                <Icon
+                  name={entry?.kind === "api" ? "globe-simple" : "database"}
+                  size="S"
+                />
+                <Heading size="S">
+                  {entry?.queryName || getUnavailableQueryTitle()}
+                </Heading>
+              </div>
+              <Body size="S" color="var(--spectrum-global-color-gray-600)">
+                {entry?.datasourceName ||
+                  getUnavailableQueryDescription(capability, missing)}
+              </Body>
+            </div>
+            <button
+              type="button"
+              class="remove-button"
+              aria-label={`Remove ${entry?.queryName || (missing ? "missing query" : "query")}`}
+              onclick={() => removeQuery(capability.queryId)}
+            >
+              <Icon name="trash" size="S" />
+              Remove
+            </button>
+          </div>
+
+          {#if missing}
+            <div class="missing-message">
+              <Icon name="warning-circle" size="S" />
+              Remove this link before saving, or restore the saved query.
+            </div>
+          {/if}
+
+          <div class="aliases">
+            <Input
+              label="Datasource alias"
+              bind:value={capability.datasourceAlias}
+              error={showErrors ? errors[index]?.datasourceAlias : undefined}
+            />
+            <Input
+              label="Query alias"
+              bind:value={capability.queryAlias}
+              error={showErrors ? errors[index]?.queryAlias : undefined}
+            />
+          </div>
+
+          <div class="code-reference">
+            Available in code as
+            <code
+              >queries.{capability.datasourceAlias ||
+                "datasource"}.{capability.queryAlias || "query"}()</code
+            >
+          </div>
+
+          <div class="parameters">
+            <span>Parameters</span>
+            {#if entry?.parameters.length}
+              {#each entry.parameters as parameter (parameter.name)}
+                <code>{parameter.name}: string | null</code>
+              {/each}
+            {:else if !entry && getPersistedCapability(capability.queryId)?.parameterNames.length}
+              {#each getPersistedCapability(capability.queryId)?.parameterNames || [] as parameter (parameter)}
+                <code>{parameter}: string | null</code>
+              {/each}
+              <span class="parameter-note">Last known</span>
+            {:else}
+              <span>None</span>
+            {/if}
+          </div>
+
+          {#if entry && parametersChanged(capability, entry)}
+            <div class="parameter-change">
+              Query parameters changed. Save and rebuild this Function to update
+              its declarations.
+            </div>
+          {/if}
+        </article>
+      {/each}
+    </div>
+  {/if}
+
+  {#if showErrors && hasFunctionQueryAliasErrors(errors)}
+    <div class="save-error" role="alert">
+      Fix the alias errors before saving.
+    </div>
+  {:else if saveError}
+    <div class="save-error" role="alert">{saveError}</div>
+  {/if}
+</section>
+
+<style>
+  .query-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-l);
+  }
+  .editor-heading,
+  .query-heading {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--spacing-l);
+  }
+  .editor-heading > div,
+  .query-heading > div {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+  }
+  .query-pickers {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--spacing-l);
+    padding: var(--spacing-l);
+    border: 1px solid var(--spectrum-global-color-gray-300);
+    border-radius: var(--radius-l);
+    background: var(--spectrum-global-color-gray-100);
+  }
+  .catalog-state {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s);
+    min-height: 48px;
+  }
+  .catalog-state.error {
+    color: var(--spectrum-global-color-red-700);
+  }
+  .empty {
+    display: flex;
+    min-height: 180px;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-s);
+    border: 1px dashed var(--spectrum-global-color-gray-400);
+    border-radius: var(--radius-l);
+    text-align: center;
+  }
+  .linked-queries {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-m);
+  }
+  .linked-query {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-m);
+    padding: var(--spacing-l);
+    border: 1px solid var(--spectrum-global-color-gray-300);
+    border-radius: var(--radius-l);
+  }
+  .linked-query.missing {
+    border-color: var(--spectrum-global-color-red-500);
+  }
+  .query-title {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s);
+  }
+  .remove-button {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    border: 0;
+    background: transparent;
+    color: var(--spectrum-global-color-red-700);
+    cursor: pointer;
+    font: inherit;
+  }
+  .aliases {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--spacing-l);
+  }
+  .code-reference,
+  .parameters,
+  .missing-message,
+  .parameter-change {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--spacing-xs);
+    color: var(--spectrum-global-color-gray-700);
+    font-size: 12px;
+  }
+  .missing-message,
+  .parameter-change,
+  .save-error {
+    color: var(--spectrum-global-color-red-700);
+  }
+  code {
+    padding: 2px var(--spacing-xs);
+    border-radius: var(--radius-s);
+    background: var(--spectrum-global-color-gray-200);
+    color: var(--spectrum-global-color-gray-800);
+    font-family: var(--font-family-code);
+  }
+  .parameter-note {
+    color: var(--spectrum-global-color-gray-600);
+    font-style: italic;
+  }
+  .save-error {
+    font-size: 13px;
+  }
+  @media (max-width: 900px) {
+    .query-pickers,
+    .aliases {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionQueryEditor.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionQueryEditor.svelte
@@ -23,7 +23,7 @@
     validateFunctionQueryAliases,
   } from "./queryAliases"
 
-  interface Props {
+  export interface Props {
     capabilities?: FunctionQueryCapability[]
     catalog?: FunctionQueryCatalogEntry[]
     catalogLoading?: boolean

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/[functionId]/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/[functionId]/index.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+  import TopBar from "@/components/common/TopBar.svelte"
+  import { getErrorMessage } from "@/helpers/errors"
+  import { appStore, builderStore, functionStore } from "@/stores/builder"
+  import { auth, featureFlags } from "@/stores/portal"
+  import {
+    Body,
+    Button,
+    Heading,
+    Icon,
+    notifications,
+    ProgressCircle,
+  } from "@budibase/bbui"
+  import type {
+    FunctionQueryCapabilityInput,
+    FunctionResponse,
+  } from "@budibase/types"
+  import { FeatureFlag } from "@budibase/types"
+  import { params } from "@roxi/routify"
+  import { onMount } from "svelte"
+  import FunctionQueryEditor from "../FunctionQueryEditor.svelte"
+  import { canManageFunctions } from "../permissions"
+
+  let fn: FunctionResponse | undefined
+  let loading = true
+  let error = ""
+
+  $params
+  $: functionId = $params.functionId
+  $: enabled = $featureFlags[FeatureFlag.FUNCTIONS]
+  $: canManage = enabled && canManageFunctions($auth.user, $appStore.appId)
+  $: builderStore.selectResource(functionId)
+
+  const load = async () => {
+    loading = true
+    error = ""
+    try {
+      const [loadedFunction] = await Promise.all([
+        functionStore.fetchOne(functionId),
+        functionStore.fetchQueryCatalog(),
+      ])
+      fn = loadedFunction
+    } catch (loadError) {
+      error = getErrorMessage(loadError) || "Unable to load Function"
+    } finally {
+      loading = false
+    }
+  }
+
+  const saveCapabilities = async (
+    capabilities: FunctionQueryCapabilityInput[]
+  ) => {
+    if (!fn?._rev) {
+      throw new Error("Function revision is missing")
+    }
+    fn = await functionStore.save(fn, {
+      _rev: fn._rev,
+      name: fn.name,
+      source: fn.source,
+      capabilities,
+    })
+    notifications.success("Linked queries saved")
+  }
+
+  onMount(() => {
+    if (canManage) {
+      load()
+    } else {
+      loading = false
+    }
+  })
+</script>
+
+<div class="wrapper">
+  <TopBar
+    breadcrumbs={[
+      { text: "Automations", url: "../../" },
+      { text: "Functions", url: "../" },
+      { text: fn?.name || "Function" },
+    ]}
+    icon="code"
+  />
+
+  <main class="function-page">
+    {#if !canManage}
+      <div class="state" data-testid="function-permission-state">
+        <Icon name="lock" size="L" />
+        <Heading size="S">You don't have permission to manage Functions</Heading
+        >
+      </div>
+    {:else if loading}
+      <div class="state" data-testid="function-loading-state">
+        <ProgressCircle size="M" />
+        <Body size="S">Loading Function...</Body>
+      </div>
+    {:else if error || !fn}
+      <div class="state" data-testid="function-error-state">
+        <Icon name="warning-circle" size="L" />
+        <Heading size="S">Unable to load Function</Heading>
+        {#if error}
+          <Body size="S" color="var(--spectrum-global-color-gray-600)">
+            {error}
+          </Body>
+        {/if}
+        <Button secondary on:click={load}>Retry</Button>
+      </div>
+    {:else}
+      <div class="heading">
+        <Heading size="L">{fn.name}</Heading>
+        <Body size="S" color="var(--spectrum-global-color-gray-600)">
+          Configure the saved queries this Function is allowed to call.
+        </Body>
+      </div>
+
+      <FunctionQueryEditor
+        capabilities={fn.capabilities}
+        catalog={$functionStore.queryCatalog}
+        catalogLoading={$functionStore.catalogLoading}
+        catalogError={$functionStore.catalogError}
+        onRetry={() => functionStore.fetchQueryCatalog()}
+        onSave={saveCapabilities}
+      />
+    {/if}
+  </main>
+</div>
+
+<style>
+  .wrapper {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+  .function-page {
+    flex: 1;
+    overflow: auto;
+    padding: var(--spacing-xl);
+  }
+  .heading {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+    margin-bottom: var(--spacing-xl);
+  }
+  .state {
+    display: flex;
+    min-height: 320px;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-s);
+    text-align: center;
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/index.svelte
@@ -7,6 +7,7 @@
   import { auth, featureFlags } from "@/stores/portal"
   import { Modal, ModalContent, notifications } from "@budibase/bbui"
   import { FeatureFlag } from "@budibase/types"
+  import { goto as gotoStore } from "@roxi/routify"
   import { onMount } from "svelte"
   import FunctionList from "./FunctionList.svelte"
   import FunctionNameModal from "./FunctionNameModal.svelte"
@@ -27,6 +28,7 @@ export default async function (): Promise<FunctionResult> {
   $: enabled = $featureFlags[FeatureFlag.FUNCTIONS]
   $: canManage = enabled && canManageFunctions($auth.user, $appStore.appId)
   $: functions = functionStore.getList($functionStore)
+  $: goto = $gotoStore
   $: if (enabled) {
     builderStore.selectResource("functions")
   }
@@ -36,12 +38,13 @@ export default async function (): Promise<FunctionResult> {
       title: "New Function",
       confirmText: "Create",
       onConfirm: async name => {
-        await functionStore.create({
+        const fn = await functionStore.create({
           name,
           source: DEFAULT_SOURCE,
           capabilities: [],
         })
         notifications.success("Function created")
+        goto(`./${fn._id}`)
       },
     })
   }
@@ -130,6 +133,7 @@ export default async function (): Promise<FunctionResult> {
     {canManage}
     onRetry={() => functionStore.fetch()}
     onCreate={createFunction}
+    onOpen={fn => goto(`./${fn._id}`)}
     onRename={renameFunction}
     onDuplicate={duplicateFunction}
     onDelete={requestDelete}

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/queryAliases.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/queryAliases.spec.ts
@@ -1,0 +1,143 @@
+import type {
+  FunctionQueryCapabilityInput,
+  FunctionQueryCatalogEntry,
+} from "@budibase/types"
+import { SourceName } from "@budibase/types"
+import { describe, expect, it } from "vitest"
+import {
+  hasFunctionQueryAliasErrors,
+  toFunctionQueryAlias,
+  validateFunctionQueryAliases,
+} from "./queryAliases"
+
+const catalog: FunctionQueryCatalogEntry[] = [
+  {
+    queryId: "query_customers",
+    queryName: "Find customer",
+    datasourceId: "datasource_crm",
+    datasourceName: "Customer CRM",
+    source: SourceName.POSTGRES,
+    kind: "data",
+    parameters: [{ name: "id" }],
+  },
+  {
+    queryId: "query_orders",
+    queryName: "Find orders",
+    datasourceId: "datasource_crm",
+    datasourceName: "Customer CRM",
+    source: SourceName.POSTGRES,
+    kind: "data",
+    parameters: [],
+  },
+  {
+    queryId: "query_events",
+    queryName: "Send event",
+    datasourceId: "datasource_api",
+    datasourceName: "Events API",
+    source: SourceName.REST,
+    kind: "api",
+    parameters: [],
+  },
+]
+
+const validate = (capabilities: FunctionQueryCapabilityInput[]) =>
+  validateFunctionQueryAliases(capabilities, catalog)
+
+describe("Function query aliases", () => {
+  it("generates stable JavaScript identifiers from display names", () => {
+    expect(toFunctionQueryAlias("Customer CRM", "datasource")).toBe(
+      "customerCRM"
+    )
+    expect(toFunctionQueryAlias("123", "query")).toBe("query")
+    expect(toFunctionQueryAlias("default", "query")).toBe("default")
+  })
+
+  it("rejects invalid identifiers", () => {
+    const errors = validate([
+      {
+        queryId: "query_customers",
+        datasourceAlias: "customer data",
+        queryAlias: "invalid-alias",
+      },
+    ])
+
+    expect(errors[0]).toEqual({
+      datasourceAlias: "Use a JavaScript identifier, for example customerData.",
+      queryAlias: "Use a JavaScript identifier, for example customerData.",
+    })
+    expect(hasFunctionQueryAliasErrors(errors)).toBe(true)
+  })
+
+  it("allows reserved words as property aliases", () => {
+    const errors = validate([
+      {
+        queryId: "query_customers",
+        datasourceAlias: "default",
+        queryAlias: "class",
+      },
+    ])
+
+    expect(hasFunctionQueryAliasErrors(errors)).toBe(false)
+  })
+
+  it("rejects datasource and query alias collisions", () => {
+    const errors = validate([
+      {
+        queryId: "query_customers",
+        datasourceAlias: "data",
+        queryAlias: "find",
+      },
+      {
+        queryId: "query_events",
+        datasourceAlias: "data",
+        queryAlias: "find",
+      },
+    ])
+
+    expect(errors[1].datasourceAlias).toBe(
+      "This alias is already used by another datasource."
+    )
+    expect(errors[0].queryAlias).toBe(
+      "This query alias is already linked for this datasource."
+    )
+    expect(errors[1].queryAlias).toBe(
+      "This query alias is already linked for this datasource."
+    )
+  })
+
+  it("requires one stable alias for queries from the same datasource", () => {
+    const errors = validate([
+      {
+        queryId: "query_customers",
+        datasourceAlias: "crm",
+        queryAlias: "customer",
+      },
+      {
+        queryId: "query_orders",
+        datasourceAlias: "customerData",
+        queryAlias: "orders",
+      },
+    ])
+
+    expect(errors[1].datasourceAlias).toBe(
+      "Use the same alias for every query from this datasource."
+    )
+  })
+
+  it("does not infer datasource collisions for missing catalog entries", () => {
+    const errors = validate([
+      {
+        queryId: "query_missing_one",
+        datasourceAlias: "legacyDatasource",
+        queryAlias: "first",
+      },
+      {
+        queryId: "query_missing_two",
+        datasourceAlias: "legacyDatasource",
+        queryAlias: "second",
+      },
+    ])
+
+    expect(hasFunctionQueryAliasErrors(errors)).toBe(false)
+  })
+})

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/queryAliases.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/queryAliases.ts
@@ -1,0 +1,94 @@
+import type {
+  FunctionQueryCapabilityInput,
+  FunctionQueryCatalogEntry,
+} from "@budibase/types"
+
+const IDENTIFIER_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/
+
+export interface FunctionQueryAliasErrors {
+  datasourceAlias?: string
+  queryAlias?: string
+}
+
+const getIdentifierError = (alias: string) => {
+  if (!alias) {
+    return "Enter an alias."
+  }
+  if (alias.length > 128) {
+    return "Aliases must be 128 characters or fewer."
+  }
+  if (!IDENTIFIER_PATTERN.test(alias)) {
+    return "Use a JavaScript identifier, for example customerData."
+  }
+  return undefined
+}
+
+export const toFunctionQueryAlias = (name: string, fallback: string) => {
+  const words = name.match(/[A-Za-z0-9_$]+/g) || []
+  const alias = words
+    .map((word, index) => {
+      const normalised = word.replace(/^[0-9]+/, "")
+      if (!normalised) {
+        return ""
+      }
+      return index === 0
+        ? normalised[0].toLowerCase() + normalised.slice(1)
+        : normalised[0].toUpperCase() + normalised.slice(1)
+    })
+    .join("")
+  return alias || fallback
+}
+
+export const validateFunctionQueryAliases = (
+  capabilities: FunctionQueryCapabilityInput[],
+  catalog: FunctionQueryCatalogEntry[]
+): FunctionQueryAliasErrors[] => {
+  const errors = capabilities.map(capability => ({
+    datasourceAlias: getIdentifierError(capability.datasourceAlias),
+    queryAlias: getIdentifierError(capability.queryAlias),
+  }))
+  const catalogByQueryId = new Map(catalog.map(entry => [entry.queryId, entry]))
+  const datasourceByAlias = new Map<string, string>()
+  const aliasByDatasource = new Map<string, string>()
+  const queryAliases = new Map<string, number>()
+
+  capabilities.forEach((capability, index) => {
+    const entry = catalogByQueryId.get(capability.queryId)
+    if (entry) {
+      const existingDatasource = datasourceByAlias.get(
+        capability.datasourceAlias
+      )
+      if (existingDatasource && existingDatasource !== entry.datasourceId) {
+        errors[index].datasourceAlias =
+          "This alias is already used by another datasource."
+      } else {
+        datasourceByAlias.set(capability.datasourceAlias, entry.datasourceId)
+      }
+
+      const existingAlias = aliasByDatasource.get(entry.datasourceId)
+      if (existingAlias && existingAlias !== capability.datasourceAlias) {
+        errors[index].datasourceAlias =
+          "Use the same alias for every query from this datasource."
+      } else {
+        aliasByDatasource.set(entry.datasourceId, capability.datasourceAlias)
+      }
+    }
+
+    const fullAlias = `${capability.datasourceAlias}.${capability.queryAlias}`
+    const existingQueryIndex = queryAliases.get(fullAlias)
+    if (existingQueryIndex !== undefined) {
+      errors[index].queryAlias =
+        "This query alias is already linked for this datasource."
+      errors[existingQueryIndex].queryAlias =
+        "This query alias is already linked for this datasource."
+    } else {
+      queryAliases.set(fullAlias, index)
+    }
+  })
+
+  return errors
+}
+
+export const hasFunctionQueryAliasErrors = (
+  errors: FunctionQueryAliasErrors[]
+) => errors.some(error => !!error.datasourceAlias || !!error.queryAlias)

--- a/packages/builder/src/stores/builder/functions.ts
+++ b/packages/builder/src/stores/builder/functions.ts
@@ -5,6 +5,7 @@ import { BudiStore } from "@/stores/BudiStore"
 import type {
   CreateFunctionRequest,
   FunctionQueryCapabilityInput,
+  FunctionQueryCatalogEntry,
   FunctionResponse,
   UpdateFunctionRequest,
 } from "@budibase/types"
@@ -22,14 +23,19 @@ export interface UIFunction extends FunctionResponse {
 interface FunctionStoreState {
   functions: FunctionResponse[]
   publishedFunctions: FunctionResponse[]
+  queryCatalog: FunctionQueryCatalogEntry[]
   loading: boolean
+  catalogLoading: boolean
   error?: string
+  catalogError?: string
 }
 
 const initialState: FunctionStoreState = {
   functions: [],
   publishedFunctions: [],
+  queryCatalog: [],
   loading: false,
+  catalogLoading: false,
 }
 
 const toCapabilityInputs = (
@@ -105,6 +111,29 @@ export class FunctionStore extends BudiStore<FunctionStoreState> {
     const response = await API.getFunction(functionId)
     this.upsert(response.function)
     return response.function
+  }
+
+  async fetchQueryCatalog() {
+    this.update(state => ({
+      ...state,
+      catalogLoading: true,
+      catalogError: undefined,
+    }))
+    try {
+      const response = await API.getFunctionQueryCatalog()
+      this.update(state => ({
+        ...state,
+        queryCatalog: response.queries,
+        catalogLoading: false,
+      }))
+    } catch (error) {
+      const message = getErrorMessage(error) || "Unable to load saved queries"
+      this.update(state => ({
+        ...state,
+        catalogLoading: false,
+        catalogError: message,
+      }))
+    }
   }
 
   async create(draft: CreateFunctionRequest) {

--- a/packages/builder/src/stores/builder/tests/functions.spec.ts
+++ b/packages/builder/src/stores/builder/tests/functions.spec.ts
@@ -1,12 +1,14 @@
 import { API, productionAPI } from "@/api"
 import { FunctionStore } from "@/stores/builder/functions"
 import type { FunctionResponse } from "@budibase/types"
+import { SourceName } from "@budibase/types"
 import { get } from "svelte/store"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("@/api", () => ({
   API: {
     getFunctions: vi.fn(),
+    getFunctionQueryCatalog: vi.fn(),
     getFunction: vi.fn(),
     createFunction: vi.fn(),
     updateFunction: vi.fn(),
@@ -118,6 +120,42 @@ describe("FunctionStore", () => {
 
     expect(API.getFunction).toHaveBeenCalledWith(fn._id)
     expect(store.list[0]._id).toBe(fn._id)
+  })
+
+  it("loads the saved query catalog", async () => {
+    const query = {
+      queryId: "query_one",
+      queryName: "Find customer",
+      datasourceId: "datasource_one",
+      datasourceName: "CRM",
+      source: SourceName.POSTGRES,
+      kind: "data" as const,
+      parameters: [{ name: "id" }],
+    }
+    vi.mocked(API.getFunctionQueryCatalog).mockResolvedValue({
+      queries: [query],
+    })
+
+    await store.fetchQueryCatalog()
+
+    expect(get(store)).toMatchObject({
+      queryCatalog: [query],
+      catalogLoading: false,
+      catalogError: undefined,
+    })
+  })
+
+  it("stores query catalog API failures for retry", async () => {
+    vi.mocked(API.getFunctionQueryCatalog).mockRejectedValue(
+      new Error("Catalog unavailable")
+    )
+
+    await store.fetchQueryCatalog()
+
+    expect(get(store)).toMatchObject({
+      catalogLoading: false,
+      catalogError: "Catalog unavailable",
+    })
   })
 
   it("creates and renames while sending only editable Function fields", async () => {

--- a/packages/frontend-core/src/api/functions.ts
+++ b/packages/frontend-core/src/api/functions.ts
@@ -2,6 +2,7 @@ import type {
   CreateFunctionRequest,
   CreateFunctionResponse,
   FetchFunctionResponse,
+  FetchFunctionQueryCatalogResponse,
   FetchFunctionsResponse,
   UpdateFunctionRequest,
   UpdateFunctionResponse,
@@ -10,6 +11,7 @@ import type { BaseAPIClient } from "./types"
 
 export interface FunctionEndpoints {
   getFunctions: () => Promise<FetchFunctionsResponse>
+  getFunctionQueryCatalog: () => Promise<FetchFunctionQueryCatalogResponse>
   getFunction: (functionId: string) => Promise<FetchFunctionResponse>
   createFunction: (fn: CreateFunctionRequest) => Promise<CreateFunctionResponse>
   updateFunction: (
@@ -25,6 +27,12 @@ export const buildFunctionEndpoints = (
   getFunctions: async () => {
     return await API.get({
       url: "/api/functions",
+    })
+  },
+
+  getFunctionQueryCatalog: async () => {
+    return await API.get({
+      url: "/api/functions/query-catalog",
     })
   },
 


### PR DESCRIPTION
## Description
Adds the linked-query configuration experience for Function drafts.

Builders can open a Function from the Functions list and explicitly link eligible saved queries from the Function query catalog. Data queries and API Explorer queries are presented separately with their current datasource name, query name, and parameter count. Only explicitly selected query IDs and their editable aliases are submitted when the Function draft is saved.

Each linked query shows its current datasource/query display names beside the stable code path, for example `queries.customerData.findCustomer()`. Renaming the underlying datasource or saved query therefore updates the descriptive UI without silently rewriting stored aliases or Function source. The editor also displays the current `string | null` parameter metadata and highlights parameter drift so the draft can be saved and rebuilt with updated declarations.

Alias validation requires JavaScript identifier-shaped names, enforces the server's 128-character limit, keeps one alias per datasource, and prevents datasource/query collisions. Reserved words remain valid because aliases are emitted as quoted property names in generated declarations and are valid property-access names.

Missing or deleted saved queries remain visible with stored aliases and last-known parameters so builders can remove the stale link. Catalog loading failures are handled separately and include retry support, avoiding false missing-query warnings when metadata is temporarily unavailable.

## Addresses
- https://github.com/Budibase/budibase/issues/19270

## Launchcontrol

Lets automation builders choose exactly which saved Data and API queries a Function may call, assign stable code-friendly aliases, review query parameters, and safely resolve renamed or deleted queries.
