### PR TITLE
fix: cant find agent tools when trying to search by db / table name

### DIFF
--- a/packages/builder/src/components/common/CodeEditor/index.ts
+++ b/packages/builder/src/components/common/CodeEditor/index.ts
@@ -131,13 +131,16 @@ export const snippetAutoComplete = (snippets: Snippet[]): BindingCompletion => {
 
 const bindingFilter = (options: BindingCompletionOption[], query: string) => {
   return options.filter(completion => {
-    const section_parsed = completion.section?.toString().toLowerCase()
-    const label_parsed = completion.label.toLowerCase()
-    const query_parsed = query.toLowerCase()
+    const section =
+      typeof completion.section === "string"
+        ? completion.section
+        : completion.section?.name
+    const parsedSection = section?.toLowerCase()
+    const parsedLabel = completion.label.toLowerCase()
+    const parsedQuery = query.toLowerCase()
 
     return (
-      section_parsed?.includes(query_parsed) ||
-      label_parsed.includes(query_parsed)
+      parsedSection?.includes(parsedQuery) || parsedLabel.includes(parsedQuery)
     )
   })
 }

--- a/packages/builder/src/components/common/CodeEditor/tests/index.test.ts
+++ b/packages/builder/src/components/common/CodeEditor/tests/index.test.ts
@@ -1,6 +1,42 @@
+import { CompletionContext } from "@codemirror/autocomplete"
+import { EditorState } from "@codemirror/state"
+import type { EnrichedBinding } from "@budibase/types"
 import { describe, expect, it } from "vitest"
 
-import { hbInsert, htmlInsert, jsInsert } from ".."
+import {
+  bindingsToCompletions,
+  EditorModes,
+  hbAutocomplete,
+  hbInsert,
+  htmlInsert,
+  jsInsert,
+} from ".."
+
+describe("hbAutocomplete", () => {
+  it("finds bindings by their datasource category", () => {
+    const warehouseBinding: EnrichedBinding = {
+      runtimeBinding: "table_orders_list_rows",
+      readableBinding: "Warehouse.Orders.list_rows",
+      category: "Warehouse",
+      display: {
+        name: "Orders.List Rows",
+        type: "tool",
+      },
+    }
+    const doc = "{{ warehouse"
+    const state = EditorState.create({ doc })
+    const context = new CompletionContext(state, doc.length, false)
+    const autocomplete = hbAutocomplete(
+      bindingsToCompletions([warehouseBinding], EditorModes.Handlebars)
+    )
+
+    const result = autocomplete(context)
+
+    expect(result?.options.map(option => option.label)).toContain(
+      "Orders.List Rows"
+    )
+  })
+})
 
 describe("hbInsert", () => {
   it("wraps bindings when not inside existing handlebars", () => {

--- a/packages/builder/src/components/common/CodeEditor/tests/index.test.ts
+++ b/packages/builder/src/components/common/CodeEditor/tests/index.test.ts
@@ -21,6 +21,7 @@ describe("hbAutocomplete", () => {
       display: {
         name: "Orders.List Rows",
         type: "tool",
+        rank: 1,
       },
     }
     const doc = "{{ warehouse"


### PR DESCRIPTION
## Description

Design Partner was unable to use the typeahead search when they started their query with the datasource name