### PR TITLE
perf: O(1) field lookup in ExternalRequest cleanupConfig (drop quadratic on wide external tables)

### DIFF
--- a/packages/server/src/api/controllers/row/ExternalRequest.ts
+++ b/packages/server/src/api/controllers/row/ExternalRequest.ts
@@ -102,14 +102,18 @@ function cleanupConfig(config: RunConfig, table: Table): RunConfig {
     FieldType.OPTIONS,
     FieldType.NUMBER,
   ]
-  // filter out fields which cannot be keys
-  const fieldNames = Object.entries(table.schema)
-    .filter(schema => primaryOptions.find(val => val === schema[1].type))
-    // map to fieldName
-    .map(entry => entry[0])
+  // filter out fields which cannot be keys — collect into a Set so the per-field
+  // lookup in iterateObject is O(1) instead of a fieldNames.find scan (O(fields²) per
+  // row otherwise, which matters for wide external tables).
+  const fieldNames = new Set(
+    Object.entries(table.schema)
+      .filter(schema => primaryOptions.find(val => val === schema[1].type))
+      // map to fieldName
+      .map(entry => entry[0])
+  )
   const iterateObject = (obj: { [key: string]: any }) => {
     for (let [field, value] of Object.entries(obj)) {
-      if (fieldNames.find(name => name === field) && isRowId(value)) {
+      if (fieldNames.has(field) && isRowId(value)) {
         obj[field] = convertRowId(value)
       }
     }


### PR DESCRIPTION
## Description

`cleanupConfig` in `ExternalRequest.ts` builds the list of eligible key field names, then in `iterateObject` checks each field of each object against that list with `fieldNames.find(name => name === field)`:

```ts
const fieldNames = Object.entries(table.schema)
  .filter(schema => primaryOptions.find(val => val === schema[1].type))
  .map(entry => entry[0])
const iterateObject = (obj) => {
  for (let [field, value] of Object.entries(obj)) {
    if (fieldNames.find(name => name === field) && isRowId(value)) { ... }
  }
}
```

The `find` is O(fieldNames), run for every field of every iterated object, so it's O(fields²) per row/filter. For external tables with many columns this adds up on the external-request path.

This collects the field names into a `Set` and uses `Set.has` for an O(1) lookup, making it O(fields). Behaviour is identical — `fieldNames.find(name => name === field)` truthiness is exactly `fieldNames.has(field)` (the `.map` already yielded plain field-name strings).

Small, self-contained, no behaviour change. I couldn't run the full server suite locally, but the change is local and type-preserving.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a Set for field-name checks in ExternalRequest `cleanupConfig` to make lookups O(1) instead of scanning an array. This cuts per-row work from O(fields²) to O(fields) on wide external tables with no behavior change.

<sup>Written for commit 54cf0efd1a22bf00137c910ce9c6c43530eb587e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
---

### Scale note

`cleanupConfig` runs once per external-request `RunConfig`, and `iterateObject` is invoked on the request row and on each filter object. For each of those objects it previously did `fieldNames.find` for every field — **O(columns²) per object**, where `columns` is the table width.

This is a real concern for external datasources specifically, because Budibase connects to **existing external schemas** it doesn't control — denormalized reporting tables, legacy ERP/CRM tables, and spreadsheet-derived tables with **50–150 columns are routine** there (unlike Budibase-internal tables, which tend to be narrow). On a 100-column table that's ~10,000 comparisons per object versus ~100.

Two honest caveats:
- This is reasoned from the loop shape, **not a benchmark** — I couldn't run the server suite against a live external datasource locally.
- For narrow tables the difference is negligible.

The reason it's still worth merging is that it's **free**: building the `Set` is O(columns), the same order as the old `.map`, so there's no downside on narrow tables and a removed latent quadratic on wide ones. Pure safety margin, no behaviour or cost trade-off.
