### PR TITLE
Reject empty AI completions

### DIFF
--- a/packages/server/src/sdk/workspace/ai/llm/bbai.spec.ts
+++ b/packages/server/src/sdk/workspace/ai/llm/bbai.spec.ts
@@ -131,6 +131,40 @@ describe("createBBAIClient", () => {
     expect(incrementCreditsMock).toHaveBeenCalledWith(20)
   })
 
+  it("rejects streamed completions with no visible output", async () => {
+    mockChatGPTStreamResponse("")
+
+    await withEnv(
+      {
+        BBAI_LITELLM_KEY: "sk-test-key",
+      },
+      async () => {
+        const { chat } = await createBBAIClient("budibase/v1")
+        const result = await chat.doStream({
+          prompt: [
+            {
+              role: "user",
+              content: [{ type: "text", text: "hello" }],
+            },
+          ],
+        })
+        const reader = result.stream.getReader()
+
+        await expect(async () => {
+          for (
+            let next = await reader.read();
+            !next.done;
+            next = await reader.read()
+          ) {
+            // Read all stream
+          }
+        }).rejects.toThrow(
+          "The model completed without producing text or a tool call"
+        )
+      }
+    )
+  })
+
   it("increments credits for OpenAI models", async () => {
     mockChatGPTResponse("hello world")
 

--- a/packages/server/src/sdk/workspace/ai/llm/bbai.ts
+++ b/packages/server/src/sdk/workspace/ai/llm/bbai.ts
@@ -18,6 +18,7 @@ import environment from "../../../../environment"
 import { Readable } from "stream"
 import { blob } from "stream/consumers"
 import { unwrapLiteLLMFileId } from "./litellm"
+import { rejectEmptyCompletionMiddleware } from "./emptyCompletion"
 
 // The OpenAI client resolves its API key lazily, so an undefined key would
 // otherwise surface later as a misleading "OpenAI API key is missing" error.
@@ -183,40 +184,45 @@ export async function createBBAIClient(
   })
   const chat = wrapLanguageModel({
     model: client.chat(model),
-    middleware: {
-      specificationVersion: "v3",
-      async wrapGenerate({ doGenerate }) {
-        await quotas.throwIfBudibaseAICreditsExceeded()
-        const result = await doGenerate()
-        await incrementBudibaseAICreditsFromUsage(result.usage).catch(() => {})
-        return result
-      },
-      async wrapStream({ doStream }) {
-        await quotas.throwIfBudibaseAICreditsExceeded()
-        const result = await doStream()
-        const transformStream = new TransformStream<
-          LanguageModelV3StreamPart,
-          LanguageModelV3StreamPart
-        >({
-          async transform(chunk, controller) {
-            controller.enqueue(chunk)
-            if (chunk.type === "finish") {
-              await incrementBudibaseAICreditsFromUsage(chunk.usage).catch(
-                () => {}
-              )
-            }
-            return
-          },
-        }) as Parameters<typeof result.stream.pipeThrough>[0]
+    middleware: [
+      {
+        specificationVersion: "v3",
+        async wrapGenerate({ doGenerate }) {
+          await quotas.throwIfBudibaseAICreditsExceeded()
+          const result = await doGenerate()
+          await incrementBudibaseAICreditsFromUsage(result.usage).catch(
+            () => {}
+          )
+          return result
+        },
+        async wrapStream({ doStream }) {
+          await quotas.throwIfBudibaseAICreditsExceeded()
+          const result = await doStream()
+          const transformStream = new TransformStream<
+            LanguageModelV3StreamPart,
+            LanguageModelV3StreamPart
+          >({
+            async transform(chunk, controller) {
+              controller.enqueue(chunk)
+              if (chunk.type === "finish") {
+                await incrementBudibaseAICreditsFromUsage(chunk.usage).catch(
+                  () => {}
+                )
+              }
+              return
+            },
+          }) as Parameters<typeof result.stream.pipeThrough>[0]
 
-        return {
-          ...result,
-          stream: result.stream.pipeThrough(
-            transformStream
-          ) as LanguageModelV3StreamResult["stream"],
-        }
+          return {
+            ...result,
+            stream: result.stream.pipeThrough(
+              transformStream
+            ) as LanguageModelV3StreamResult["stream"],
+          }
+        },
       },
-    },
+      rejectEmptyCompletionMiddleware,
+    ],
   })
   return {
     chat,

--- a/packages/server/src/sdk/workspace/ai/llm/emptyCompletion.ts
+++ b/packages/server/src/sdk/workspace/ai/llm/emptyCompletion.ts
@@ -2,6 +2,7 @@ import {
   LanguageModelV3Content,
   LanguageModelV3Middleware,
   LanguageModelV3StreamPart,
+  LanguageModelV3StreamResult,
   NoContentGeneratedError,
 } from "@ai-sdk/provider"
 import { TransformStream } from "node:stream/web"
@@ -54,7 +55,9 @@ export const rejectEmptyCompletionMiddleware: LanguageModelV3Middleware = {
 
     return {
       ...result,
-      stream: result.stream.pipeThrough(transformStream),
+      stream: result.stream.pipeThrough(
+        transformStream
+      ) as LanguageModelV3StreamResult["stream"],
     }
   },
 }

--- a/packages/server/src/sdk/workspace/ai/llm/emptyCompletion.ts
+++ b/packages/server/src/sdk/workspace/ai/llm/emptyCompletion.ts
@@ -1,0 +1,60 @@
+import {
+  LanguageModelV3Content,
+  LanguageModelV3Middleware,
+  LanguageModelV3StreamPart,
+  NoContentGeneratedError,
+} from "@ai-sdk/provider"
+import { TransformStream } from "node:stream/web"
+
+const errorMessage =
+  "The model completed without producing text or a tool call. Please retry the request."
+
+const isGeneratedOutput = (part: LanguageModelV3Content) =>
+  (part.type === "text" && !!part.text.trim()) ||
+  part.type === "tool-call" ||
+  part.type === "tool-result" ||
+  part.type === "tool-approval-request" ||
+  part.type === "file"
+
+const isStreamOutput = (part: LanguageModelV3StreamPart) =>
+  (part.type === "text-delta" && !!part.delta.trim()) ||
+  part.type === "tool-call" ||
+  part.type === "tool-result" ||
+  part.type === "tool-approval-request" ||
+  part.type === "file" ||
+  part.type === "error"
+
+export const rejectEmptyCompletionMiddleware: LanguageModelV3Middleware = {
+  specificationVersion: "v3",
+  async wrapGenerate({ doGenerate }) {
+    const result = await doGenerate()
+    if (!result.content.some(isGeneratedOutput)) {
+      throw new NoContentGeneratedError({ message: errorMessage })
+    }
+    return result
+  },
+  async wrapStream({ doStream }) {
+    const result = await doStream()
+    let hasOutput = false
+    const transformStream = new TransformStream<
+      LanguageModelV3StreamPart,
+      LanguageModelV3StreamPart
+    >({
+      transform(part, controller) {
+        hasOutput ||= isStreamOutput(part)
+        if (part.type === "finish" && !hasOutput) {
+          controller.error(
+            new NoContentGeneratedError({ message: errorMessage })
+          )
+          return
+        }
+        controller.enqueue(part)
+      },
+    }) as Parameters<typeof result.stream.pipeThrough>[0]
+
+    return {
+      ...result,
+      stream: result.stream.pipeThrough(transformStream),
+    }
+  },
+}

--- a/packages/server/src/sdk/workspace/ai/llm/litellm.ts
+++ b/packages/server/src/sdk/workspace/ai/llm/litellm.ts
@@ -13,6 +13,8 @@ import {
 import nodeFetch from "node-fetch"
 import { Readable } from "stream"
 import { blob } from "stream/consumers"
+import { wrapLanguageModel } from "ai"
+import { rejectEmptyCompletionMiddleware } from "./emptyCompletion"
 
 type LiteLLMFetch = (
   input: Parameters<typeof fetch>[0],
@@ -54,7 +56,10 @@ export const createLiteLLMOpenAI = async (
   const llm = createOpenAI(clientConfig)
   const contextWindowTokens = await fetchModelMaxInputTokens(modelId)
   return {
-    chat: llm.chat(modelId),
+    chat: wrapLanguageModel({
+      model: llm.chat(modelId),
+      middleware: rejectEmptyCompletionMiddleware,
+    }),
     providerOptions: getLiteLLMProviderOptions,
     uploadFile: async (stream: Readable, filename: string) => {
       const fileId = await uploadFile({


### PR DESCRIPTION
## Description
Reject empty model completions and streams


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject empty model completions and streams. We now throw a `NoContentGeneratedError` when the model returns no text or tool output.

- **Bug Fixes**
  - Added `rejectEmptyCompletionMiddleware` to fail generate/stream calls with no text/tool output (message: "The model completed without producing text or a tool call. Please retry the request.").
  - Applied middleware via `wrapLanguageModel` to both BBAI chat and `LiteLLM` chat.
  - Covered streamed empty output with a unit test.

<sup>Written for commit a4d30b26beba5924e09714158021faec9ed46205. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

