### PR TITLE
Standardize app terminology to workspace

### DIFF
--- a/packages/server/src/ai/tools/budibase/automations.ts
+++ b/packages/server/src/ai/tools/budibase/automations.ts
@@ -84,9 +84,9 @@ const AUTOMATION_TOOLS: BudibaseToolDefinition[] = [
     name: "list_automations",
     sourceType: ToolType.AUTOMATION,
     sourceLabel: "Budibase",
-    description: "List all automations in the current app",
+    description: "List all automations in the current workspace",
     tool: tool({
-      description: "List all automations in the current app",
+      description: "List all automations in the current workspace",
       inputSchema: z.object({}),
       execute: async () => {
         const automations = await sdk.automations.fetch()

--- a/packages/server/src/ai/tools/budibase/tables.ts
+++ b/packages/server/src/ai/tools/budibase/tables.ts
@@ -9,9 +9,9 @@ const TABLE_TOOLS: BudibaseToolDefinition[] = [
     name: "list_tables",
     sourceType: ToolType.INTERNAL_TABLE,
     sourceLabel: "Budibase",
-    description: "List all tables in the current app",
+    description: "List all tables in the current workspace",
     tool: tool({
-      description: "List all tables in the current app",
+      description: "List all tables in the current workspace",
       inputSchema: z.object({
         showSchema: z
           .boolean()

--- a/packages/server/src/api/controllers/workspace.ts
+++ b/packages/server/src/api/controllers/workspace.ts
@@ -1383,7 +1383,7 @@ export async function duplicateWorkspace(
   const [workspace] = await dbCore.getWorkspacesByIDs([sourceAppId])
 
   if (!workspace) {
-    ctx.throw(404, "Source app not found")
+    ctx.throw(404, "Source workspace not found")
   }
 
   const workspaces = await dbCore.getAllWorkspaces({

--- a/packages/server/src/automations/tests/utilities/AutomationTestBuilder.ts
+++ b/packages/server/src/automations/tests/utilities/AutomationTestBuilder.ts
@@ -307,7 +307,7 @@ class AutomationRunner<TStep extends AutomationTriggerStepId> {
           throw new Error(
             `Automation with ID ${
               this.automation._id
-            } not found in app ${this.config.getDevWorkspaceId()}. You may have forgotten to call config.api.workspace.publish().`,
+            } not found in workspace ${this.config.getDevWorkspaceId()}. You may have forgotten to call config.api.workspace.publish().`,
             { cause: e }
           )
         } else {

--- a/packages/server/src/events/docUpdates/syncUsers.ts
+++ b/packages/server/src/events/docUpdates/syncUsers.ts
@@ -85,7 +85,7 @@ export default function process() {
       else if (err?.status === 409) {
         return
       } else {
-        logging.logAlert("Failed to perform user/group app sync", err)
+        logging.logAlert("Failed to perform user/group workspace sync", err)
       }
     }
   }

--- a/packages/server/src/middleware/tests/currentWorkspace.spec.ts
+++ b/packages/server/src/middleware/tests/currentWorkspace.spec.ts
@@ -136,7 +136,7 @@ class TestConfiguration {
   }
 }
 
-describe("Current app middleware", () => {
+describe("Current workspace middleware", () => {
   let config: TestConfiguration
 
   beforeEach(() => {

--- a/packages/server/src/sdk/workspace/rowActions/crud.ts
+++ b/packages/server/src/sdk/workspace/rowActions/crud.ts
@@ -50,9 +50,9 @@ export async function create(tableId: string, rowAction: { name: string }) {
 
   await ensureUniqueAndThrow(doc, action.name)
 
-  const appId = context.getWorkspaceId()
-  if (!appId) {
-    throw new Error("Could not get the current appId")
+  const workspaceId = context.getWorkspaceId()
+  if (!workspaceId) {
+    throw new Error("Could not get the current workspace ID")
   }
 
   const newRowActionId = `${
@@ -61,7 +61,7 @@ export async function create(tableId: string, rowAction: { name: string }) {
 
   const automation = await automations.create({
     name: action.name,
-    appId,
+    appId: workspaceId,
     definition: {
       trigger: {
         id: "trigger",


### PR DESCRIPTION
## Description
Standardize app terminology to workspace

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized terminology from “app” to “workspace” across server code to match current product language. Updates messages and variable names; behavior is unchanged.

- **Refactors**
  - Updated Budibase AI tool descriptions for listing automations/tables to say “workspace”.
  - Revised error/log messages: 404 in duplicate workspace, user/group sync alert, middleware test name, and AutomationTestBuilder error text.
  - Replaced `appId` with `workspaceId` in row action CRUD and passed it to `automations.create`.

<sup>Written for commit 0e12a805043f165e02c2f7cad7f74845faa04c4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

