### PR TITLE
Migrate remaining settings user components still in js

### DIFF
--- a/packages/builder/src/settings/pages/people/groups/_components/AppAddModal.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/AppAddModal.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import {
     Body,
     Layout,

--- a/packages/builder/src/settings/pages/people/groups/_components/AppAddModal.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/AppAddModal.svelte
@@ -34,7 +34,9 @@
   let workspaceSearchTerm = ""
 
   $: group = $groups.find(x => x._id === groupId)
-  $: roleColorLookup = ($roles || []).reduce<Record<string, string | undefined>>((acc, role) => {
+  $: roleColorLookup = ($roles || []).reduce<
+    Record<string, string | undefined>
+  >((acc, role) => {
     acc[role._id] = role.uiMetadata?.color
     return acc
   }, {})

--- a/packages/builder/src/settings/pages/people/groups/_components/AppAddModal.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/AppAddModal.svelte
@@ -15,7 +15,12 @@
   import { Constants } from "@budibase/frontend-core"
   import GroupIcon from "./GroupIcon.svelte"
 
-  export let groupId
+  export let groupId: string
+
+  interface WorkspaceOption {
+    label: string
+    value: string
+  }
 
   const workspaceRoleOptions = Constants.BudibaseRoleOptions.filter(
     option =>
@@ -23,13 +28,13 @@
       option.value === Constants.BudibaseRoles.AppUser
   )
 
-  let selectedWorkspaceIds = []
+  let selectedWorkspaceIds: string[] = []
   let selectedRole = Constants.BudibaseRoles.AppUser
   let selectedEndUserRole = Constants.Roles.BASIC
   let workspaceSearchTerm = ""
 
   $: group = $groups.find(x => x._id === groupId)
-  $: roleColorLookup = ($roles || []).reduce((acc, role) => {
+  $: roleColorLookup = ($roles || []).reduce<Record<string, string | undefined>>((acc, role) => {
     acc[role._id] = role.uiMetadata?.color
     return acc
   }, {})
@@ -45,10 +50,13 @@
       color: roleColorLookup[Constants.Roles.ADMIN],
     },
   ]
-  $: assignedWorkspaceIds = groups.getGroupAppIds(group)
+  $: assignedWorkspaceIds = group ? groups.getGroupAppIds(group) : []
   $: workspaceOptions = Object.values(
-    $appsStore.apps.reduce((acc, app) => {
-      const prodAppId = appsStore.getProdAppID(app.devId)
+    $appsStore.apps.reduce<Record<string, WorkspaceOption>>((acc, app) => {
+      const prodAppId = appsStore.getProdAppID(app.devId || "")
+      if (!prodAppId) {
+        return acc
+      }
       if (assignedWorkspaceIds.includes(prodAppId) || acc[prodAppId]) {
         return acc
       }
@@ -116,8 +124,8 @@
       bind:searchTerm={workspaceSearchTerm}
       label="Workspaces"
       options={workspaceOptions}
-      getOptionLabel={option => option.label}
-      getOptionValue={option => option.value}
+      getOptionLabel={(option: WorkspaceOption) => option.label}
+      getOptionValue={(option: WorkspaceOption) => option.value}
       placeholder={workspaceOptions.length
         ? "Select workspaces"
         : "No available workspaces"}

--- a/packages/builder/src/settings/pages/people/groups/_components/AssignWorkspacePicker.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/AssignWorkspacePicker.svelte
@@ -4,16 +4,19 @@
   import { groups } from "@/stores/portal/groups"
   import AppAddModal from "./AppAddModal.svelte"
 
-  export let groupId
+  export let groupId: string
 
-  let assignWorkspaceModal
-  let appAddModal
+  let assignWorkspaceModal: Modal
+  let appAddModal: AppAddModal
 
   $: group = $groups.find(x => x._id === groupId)
-  $: assignedWorkspaceIds = groups.getGroupAppIds(group)
+  $: assignedWorkspaceIds = group ? groups.getGroupAppIds(group) : []
   $: availableWorkspaceIds = Object.keys(
-    $appsStore.apps.reduce((acc, app) => {
-      const prodAppId = appsStore.getProdAppID(app.devId)
+    $appsStore.apps.reduce<Record<string, boolean>>((acc, app) => {
+      const prodAppId = appsStore.getProdAppID(app.devId || "")
+      if (!prodAppId) {
+        return acc
+      }
       if (assignedWorkspaceIds.includes(prodAppId) || acc[prodAppId]) {
         return acc
       }

--- a/packages/builder/src/settings/pages/people/groups/_components/AssignWorkspacePicker.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/AssignWorkspacePicker.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { Button, Modal } from "@budibase/bbui"
   import { appsStore } from "@/stores/portal/apps"
   import { groups } from "@/stores/portal/groups"

--- a/packages/builder/src/settings/pages/people/groups/_components/GroupIcon.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/GroupIcon.svelte
@@ -1,8 +1,9 @@
-<script>
+<script lang="ts">
   import { IconAvatar } from "@budibase/bbui"
+  import type { UserGroup } from "@budibase/types"
 
-  export let group
-  export let size = "M"
+  export let group: UserGroup | undefined = undefined
+  export let size: "XS" | "S" | "M" | "L" = "M"
 </script>
 
 <div class="icon-group">

--- a/packages/builder/src/settings/pages/people/groups/group.svelte
+++ b/packages/builder/src/settings/pages/people/groups/group.svelte
@@ -29,10 +29,14 @@
   import { sdk } from "@budibase/shared-core"
   import { Constants } from "@budibase/frontend-core"
   import { bb } from "@/stores/bb"
+  import type { StoreApp } from "@/types"
+  import type { UserGroup } from "@budibase/types"
+  import type { Readable } from "svelte/store"
 
-  export let groupId
+  export let groupId: string
 
-  const routing = getContext("routing")
+  const routing =
+    getContext<Readable<{ params: { groupId?: string } }>>("routing")
 
   // Override
   $: params = $routing?.params
@@ -42,12 +46,14 @@
   }
 
   let loaded = false
-  let editModal, deleteModal, editWorkspaceRoleModal
-  let selectedWorkspace
+  let editModal: Modal
+  let deleteModal: ConfirmDialog
+  let editWorkspaceRoleModal: Modal
+  let selectedWorkspace: (StoreApp & { prodAppId: string }) | undefined
   let editWorkspaceRoleModalToken = 0
-  let workspaceSearch
+  let workspaceSearch = ""
   let workspacePageNumber = 0
-  let previousWorkspaceSearch
+  let previousWorkspaceSearch = ""
   let defaultUpdating = false
   const WORKSPACE_PAGE_SIZE = 3
 
@@ -89,11 +95,18 @@
   ]
   $: groupApps = $appsStore.apps
     .filter(app => {
-      const prodAppId = appsStore.getProdAppID(app.devId)
-      return groups.getGroupAppIds(group).includes(prodAppId)
+      const prodAppId = appsStore.getProdAppID(app.devId || "")
+      return (
+        !!prodAppId &&
+        !!group &&
+        groups.getGroupAppIds(group).includes(prodAppId)
+      )
     })
     .map(app => {
-      const prodAppId = appsStore.getProdAppID(app.devId)
+      const prodAppId = appsStore.getProdAppID(app.devId || "")
+      if (!prodAppId) {
+        return undefined
+      }
       return {
         ...app,
         _id: prodAppId,
@@ -104,6 +117,7 @@
           : group?.roles?.[prodAppId],
       }
     })
+    .filter(app => app !== undefined)
   $: filteredGroupApps = workspaceSearch
     ? groupApps.filter(app =>
         app.name?.toLowerCase().includes(workspaceSearch.toLowerCase())
@@ -130,7 +144,7 @@
       ? [...Array(WORKSPACE_PAGE_SIZE - workspacePageRows.length)].map(
           (_, index) => ({
             _id: `workspace-filler-${workspacePageNumber}-${index}`,
-            __skeleton: true,
+            __skeleton: true as const,
             __selectable: false,
           })
         )
@@ -146,6 +160,9 @@
 
   async function deleteGroup() {
     try {
+      if (!group) {
+        return
+      }
       await groups.delete(group)
       notifications.success("User group deleted successfully")
       bb.settings("/people/groups")
@@ -154,11 +171,11 @@
     }
   }
 
-  async function saveGroup(group) {
+  async function saveGroup(group: UserGroup) {
     try {
       await groups.save(group)
-    } catch (error) {
-      if (error.message) {
+    } catch (error: any) {
+      if (error?.message) {
         notifications.error(error.message)
       } else {
         notifications.error(`Failed to save user group`)
@@ -166,7 +183,7 @@
     }
   }
 
-  async function updateDefaultStatus(isDefault) {
+  async function updateDefaultStatus(isDefault: boolean) {
     if (!group?._id || group?.isDefault === isDefault || defaultUpdating) {
       return
     }
@@ -176,14 +193,14 @@
       notifications.success(
         isDefault ? "Default group updated" : "Default group removed"
       )
-    } catch (error) {
+    } catch (error: any) {
       notifications.error(error?.message || "Failed to update default group")
     } finally {
       defaultUpdating = false
     }
   }
 
-  const removeApp = async app => {
+  const removeApp = async (app: string) => {
     try {
       await groups.removeApp(groupId, app)
     } catch (error) {
@@ -191,7 +208,11 @@
     }
   }
 
-  const openWorkspaceRoleModal = workspace => {
+  const openWorkspaceRoleModal = (
+    workspace:
+      | (StoreApp & { prodAppId: string; __skeleton?: boolean })
+      | { __skeleton: true }
+  ) => {
     if (workspaceReadonly || workspace?.__skeleton) {
       return
     }
@@ -223,7 +244,7 @@
       <div class="header-actions">
         <div
           class="default-toggle"
-          title={isScimGroup && "Group synced from your AD"}
+          title={isScimGroup ? "Group synced from your AD" : undefined}
         >
           <Toggle
             value={!!group?.isDefault}
@@ -243,7 +264,7 @@
           >
             Edit
           </MenuItem>
-          <div title={isScimGroup && "Group synced from your AD"}>
+          <div title={isScimGroup ? "Group synced from your AD" : undefined}>
             <MenuItem
               icon="trash"
               on:click={() => deleteModal.show()}

--- a/packages/builder/src/settings/pages/people/groups/group.svelte
+++ b/packages/builder/src/settings/pages/people/groups/group.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import {
     ActionMenu,
     Heading,

--- a/packages/builder/src/settings/pages/people/users/user.svelte
+++ b/packages/builder/src/settings/pages/people/users/user.svelte
@@ -37,16 +37,18 @@
   import { sdk } from "@budibase/shared-core"
   import ActiveDirectoryInfo from "../_components/ActiveDirectoryInfo.svelte"
   import { bb } from "@/stores/bb"
+  import type { User, UserGroup } from "@budibase/types"
+  import type { Readable } from "svelte/store"
 
   $goto
 
-  export let userId
+  export let userId: string
 
-  const routing = getContext("routing")
+  const routing =
+    getContext<Readable<{ params: { userId?: string } }>>("routing")
 
   // Override
   $: params = $routing?.params
-  $: userId = params.userId
   $: if (params.userId && userId !== params.userId) {
     userId = params.userId
   }
@@ -96,15 +98,18 @@
     },
   ]
 
-  let deleteModal
-  let resetPasswordModal
-  let popoverAnchor
+  let deleteModal: Modal
+  let resetPasswordModal: Modal
+  let popoverAnchor: HTMLDivElement
   let searchTerm = ""
-  let popover
-  let user, tenantOwner
+  let popover: Popover
+  let user: (User & { provider?: string }) | undefined
+  let tenantOwner:
+    | Awaited<ReturnType<typeof users.getAccountHolder>>
+    | undefined
   let loaded = false
-  let userFieldsToUpdate = {}
-  let roleUpdateTarget
+  let userFieldsToUpdate: Partial<User> = {}
+  let roleUpdateTarget: string | undefined
   let saving = false
 
   $: internalGroups = $groups?.filter(g => !g?.scimInfo?.isSync)
@@ -113,7 +118,7 @@
   $: isAdmin = sdk.users.isAdmin($auth.user)
   $: isScim = user?.scimInfo?.isSync
   $: readonly = !isAdmin || isScim
-  $: privileged = sdk.users.isAdminOrGlobalBuilder(user)
+  $: privileged = user ? sdk.users.isAdminOrGlobalBuilder(user) : false
   $: nameLabel = getNameLabel(user)
   $: filteredGroups = getFilteredGroups(internalGroups, searchTerm)
   $: availableApps = user
@@ -125,16 +130,16 @@
     })
   })
   $: globalRole = users.getUserRole(user)
-  $: isTenantOwner = tenantOwner?.email && tenantOwner.email === user?.email
+  $: isTenantOwner = !!tenantOwner?.email && tenantOwner.email === user?.email
 
-  const getApps = (user, appIds) => {
+  const getApps = (user: User, appIds: string[]) => {
     let availableApps = $appsStore.apps
       .slice()
       .filter(app =>
-        appIds.find(id => id === appsStore.getProdAppID(app.devId))
+        appIds.find(id => id === appsStore.getProdAppID(app.devId || ""))
       )
     return availableApps.map(app => {
-      const prodAppId = appsStore.getProdAppID(app.devId)
+      const prodAppId = appsStore.getProdAppID(app.devId || "")
       return {
         name: app.name,
         devId: app.devId,
@@ -144,7 +149,7 @@
     })
   }
 
-  const getFilteredGroups = (groups, search) => {
+  const getFilteredGroups = (groups: UserGroup[], search: string) => {
     if (!search) {
       return groups
     }
@@ -152,7 +157,7 @@
     return groups.filter(group => group.name?.toLowerCase().includes(search))
   }
 
-  const getRole = (prodAppId, user) => {
+  const getRole = (prodAppId: string, user: User) => {
     if (privileged) {
       return Constants.Roles.ADMIN
     }
@@ -167,18 +172,19 @@
 
     // check if access via group for creator
     const foundGroup = $groups?.find(
-      group => group.roles?.[prodAppId] || group.builder?.apps[prodAppId]
+      group =>
+        group.roles?.[prodAppId] || group.builder?.apps.includes(prodAppId)
     )
-    if (foundGroup.builder?.apps[prodAppId]) {
+    if (foundGroup?.builder?.apps.includes(prodAppId)) {
       return Constants.Roles.CREATOR
     }
     // can't tell how groups will control role
-    if (foundGroup.roles[prodAppId]) {
+    if (foundGroup?.roles?.[prodAppId]) {
       return Constants.Roles.GROUP
     }
   }
 
-  const getNameLabel = user => {
+  const getNameLabel = (user: User | undefined) => {
     const { firstName, lastName, email } = user || {}
     if (!firstName && !lastName) {
       return email || ""
@@ -206,6 +212,9 @@
         globalRole === Constants.BudibaseRoles.Admin &&
         roleUpdateTarget &&
         roleUpdateTarget !== Constants.BudibaseRoles.Admin
+      if (!user) {
+        return
+      }
       await users.save({
         ...user,
         ...userFieldsToUpdate,
@@ -221,16 +230,16 @@
     }
   }
 
-  async function updateUserFirstName(evt) {
-    userFieldsToUpdate.firstName = evt.target.value
+  async function updateUserFirstName(evt: Event) {
+    userFieldsToUpdate.firstName = (evt.target as HTMLInputElement).value
   }
 
-  async function updateUserLastName(evt) {
-    userFieldsToUpdate.lastName = evt.target.value
+  async function updateUserLastName(evt: Event) {
+    userFieldsToUpdate.lastName = (evt.target as HTMLInputElement).value
   }
 
-  async function updateUserRole({ detail }) {
-    let flags = {}
+  async function updateUserRole({ detail }: CustomEvent<string>) {
+    let flags: Partial<User> = {}
     if (detail === Constants.BudibaseRoles.Developer) {
       flags = { admin: { global: false }, builder: { global: true } }
     } else if (detail === Constants.BudibaseRoles.Admin) {
@@ -259,19 +268,19 @@
       notifications.error("Need a valid userId buddy")
       return
     }
-    user = await users.get(userId)
+    user = (await users.get(userId)) ?? undefined
     if (!user?._id) {
       bb.settings("/people/users")
     }
     tenantOwner = await users.getAccountHolder()
   }
 
-  const addGroup = async groupId => {
+  const addGroup = async (groupId: string) => {
     await groups.addUser(groupId, userId)
     await fetchUser()
   }
 
-  const removeGroup = async groupId => {
+  const removeGroup = async (groupId: string) => {
     await groups.removeUser(groupId, userId)
     await fetchUser()
   }
@@ -279,6 +288,17 @@
   setContext("groups", {
     removeGroup,
   })
+
+  const getPickerGroups = (
+    groups: UserGroup[]
+  ): Array<
+    Record<string, object | string | number | boolean | undefined> & {
+      _id: string
+    }
+  > =>
+    groups
+      .filter((group): group is UserGroup & { _id: string } => !!group._id)
+      .map(group => ({ ...group }))
 
   onMount(async () => {
     try {
@@ -354,12 +374,12 @@
           />
         </div>
         <!-- don't let a user remove the privileges that let them be here -->
-        {#if userId !== $auth.user._id}
+        {#if userId !== $auth.user?._id}
           <!-- Disabled if it's not admin, enabled for SCIM integration   -->
           <div class="field">
             <Label size="L">Role</Label>
             <Select
-              placeholder={null}
+              placeholder={false}
               disabled={!sdk.users.isAdmin($auth.user) || isTenantOwner}
               value={isTenantOwner ? "owner" : globalRole}
               options={isTenantOwner
@@ -394,14 +414,16 @@
           <Heading size="XS">Groups</Heading>
           {#if internalGroups?.length && isAdmin}
             <div bind:this={popoverAnchor}>
-              <Button on:click={popover.show()} secondary>Add to group</Button>
+              <Button on:click={() => popover.show()} secondary>
+                Add to group
+              </Button>
             </div>
             <Popover align="right" bind:this={popover} anchor={popoverAnchor}>
               <UserGroupPicker
                 labelKey="name"
                 bind:searchTerm
-                list={filteredGroups}
-                selected={user.userGroups}
+                list={getPickerGroups(filteredGroups)}
+                selected={user?.userGroups}
                 on:select={e => addGroup(e.detail)}
                 on:deselect={e => removeGroup(e.detail)}
                 iconComponent={GroupIcon}

--- a/packages/builder/src/settings/pages/people/users/user.svelte
+++ b/packages/builder/src/settings/pages/people/users/user.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { goto } from "@roxi/routify"
   import {
     ActionMenu,


### PR DESCRIPTION
## Description
Migrating remaining settings user components still in JS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated remaining Settings > People components from JS to TypeScript for safer props, better store typing, and fewer runtime errors across group and user pages.

- **Refactors**
  - Added TypeScript to `group.svelte`, `user.svelte`, `AppAddModal.svelte`, `AssignWorkspacePicker.svelte`, and `GroupIcon.svelte`.
  - Strongly typed props, stores, routing context, events, and modal/popover refs; added `WorkspaceOption`, `Readable`, and stricter unions (e.g., `GroupIcon` size, skeleton rows).
  - Introduced `getPickerGroups` and typed reducers for workspace options to remove unsafe access.

- **Bug Fixes**
  - Safely handle missing `prodAppId` and `group` when building workspace lists; filter undefined apps.
  - Correct creator/group role detection using `builder.apps.includes(prodAppId)` with null-safe checks.
  - Prevent invalid UI states: block actions on skeleton/read-only rows, ensure string-only `title` props, guard tenant owner/user on save, set `Select` placeholder to `false`, and use `$auth.user?._id` safely.

<sup>Written for commit 3f7e782c6c581f3bb6c0e9c9b5e317bc799734a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

