### PR TITLE
Refactor appId to workspaceId for consistency across codebase

### DIFF
--- a/packages/builder/src/api.ts
+++ b/packages/builder/src/api.ts
@@ -15,13 +15,13 @@ const newClient = (opts?: { production?: boolean }) =>
         request?.method === "DELETE" &&
         /^\/api\/applications\/app_dev_/.test(request.url)
 
-      // Attach app ID header from store
-      let appId = get(appStore).appId
-      if (appId) {
+      // Attach the workspace ID header from the store.
+      const workspaceId = get(appStore).appId
+      if (workspaceId) {
         if (!isWorkspaceDeleteRequest) {
           headers[Header.APP_ID] = opts?.production
-            ? sdk.workspaces.getProdWorkspaceID(appId)
-            : appId
+            ? sdk.workspaces.getProdWorkspaceID(workspaceId)
+            : workspaceId
         }
         headers[Header.CLIENT] = ClientHeader.BUILDER
       }
@@ -70,8 +70,8 @@ const newClient = (opts?: { production?: boolean }) =>
         }
       }
     },
-    onMigrationDetected: appId => {
-      const updatingUrl = `/builder/workspace/updating/${appId}`
+    onMigrationDetected: workspaceId => {
+      const updatingUrl = `/builder/workspace/updating/${workspaceId}`
 
       if (window.location.pathname === updatingUrl) {
         return

--- a/packages/builder/src/pages/builder/workspace/[application]/_components/InviteUsersModal.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/_components/InviteUsersModal.spec.ts
@@ -200,8 +200,8 @@ vi.mock("@budibase/shared-core", async importOriginal => {
       ...actual.sdk,
       workspaces: {
         ...actual.sdk.workspaces,
-        getProdWorkspaceID: (appId: string) =>
-          appId.replace("app_dev_", "app_"),
+        getProdWorkspaceID: (workspaceId: string) =>
+          workspaceId.replace("app_dev_", "app_"),
       },
     },
   }

--- a/packages/builder/src/settings/pages/people/groups/_components/AppAddModal.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/AppAddModal.svelte
@@ -54,20 +54,28 @@
   ]
   $: assignedWorkspaceIds = group ? groups.getGroupAppIds(group) : []
   $: workspaceOptions = Object.values(
-    $appsStore.apps.reduce<Record<string, WorkspaceOption>>((acc, app) => {
-      const prodAppId = appsStore.getProdWorkspaceID(app.devId || "")
-      if (!prodAppId) {
+    $appsStore.apps.reduce<Record<string, WorkspaceOption>>(
+      (acc, workspace) => {
+        const prodWorkspaceId = appsStore.getProdWorkspaceID(
+          workspace.devId || ""
+        )
+        if (!prodWorkspaceId) {
+          return acc
+        }
+        if (
+          assignedWorkspaceIds.includes(prodWorkspaceId) ||
+          acc[prodWorkspaceId]
+        ) {
+          return acc
+        }
+        acc[prodWorkspaceId] = {
+          label: workspace.name,
+          value: prodWorkspaceId,
+        }
         return acc
-      }
-      if (assignedWorkspaceIds.includes(prodAppId) || acc[prodAppId]) {
-        return acc
-      }
-      acc[prodAppId] = {
-        label: app.name,
-        value: prodAppId,
-      }
-      return acc
-    }, {})
+      },
+      {}
+    )
   ).sort((a, b) => a.label.localeCompare(b.label))
   $: validOptionIds = workspaceOptions.map(option => option.value)
   $: selectedWorkspaceIdsForSubmit = selectedWorkspaceIds.filter(id =>

--- a/packages/builder/src/settings/pages/people/groups/_components/AssignWorkspacePicker.svelte
+++ b/packages/builder/src/settings/pages/people/groups/_components/AssignWorkspacePicker.svelte
@@ -12,8 +12,10 @@
   $: group = $groups.find(x => x._id === groupId)
   $: assignedWorkspaceIds = group ? groups.getGroupAppIds(group) : []
   $: availableWorkspaceIds = Object.keys(
-    $appsStore.apps.reduce<Record<string, boolean>>((acc, app) => {
-      const prodWorkspaceId = appsStore.getProdWorkspaceID(app.devId || "")
+    $appsStore.apps.reduce<Record<string, boolean>>((acc, workspace) => {
+      const prodWorkspaceId = appsStore.getProdWorkspaceID(
+        workspace.devId || ""
+      )
       if (!prodWorkspaceId) {
         return acc
       }

--- a/packages/builder/src/stores/portal/apps.ts
+++ b/packages/builder/src/stores/portal/apps.ts
@@ -72,62 +72,66 @@ export class AppsStore extends BudiStore<PortalAppsStore> {
     }))
     const json = await API.getApps()
     if (Array.isArray(json)) {
-      // Merge apps into one sensible list
-      let appMap: Record<string, StoreApp> = {}
-      let devApps = json.filter(app => app.status === AppStatus.DEV)
-      let deployedApps = json.filter(app => app.status === AppStatus.DEPLOYED)
+      // Merge development and deployed workspaces into one sensible list.
+      let workspaceMap: Record<string, StoreApp> = {}
+      const devWorkspaces = json.filter(
+        workspace => workspace.status === AppStatus.DEV
+      )
+      const deployedWorkspaces = json.filter(
+        workspace => workspace.status === AppStatus.DEPLOYED
+      )
 
-      // First append all dev app version
-      devApps.forEach(app => {
-        const id = this.extractAppId(app.appId)
+      // First append all development workspace versions.
+      devWorkspaces.forEach(workspace => {
+        const id = this.extractAppId(workspace.appId)
         if (!id) {
           return
         }
-        appMap[id] = {
-          ...app,
-          devId: app.appId,
-          devRev: app._rev,
+        workspaceMap[id] = {
+          ...workspace,
+          devId: workspace.appId,
+          devRev: workspace._rev,
         }
       })
 
-      // Then merge with all prod app versions
-      deployedApps.forEach(app => {
-        const id = this.extractAppId(app.appId)
+      // Then merge in all deployed workspace versions.
+      deployedWorkspaces.forEach(workspace => {
+        const id = this.extractAppId(workspace.appId)
         if (!id) {
           return
         }
 
-        // Skip any deployed apps which don't have a dev counterpart
-        if (!appMap[id]) {
+        // Skip deployed workspaces without a development counterpart.
+        if (!workspaceMap[id]) {
           return
         }
 
-        // Extract certain properties from the dev app to override the prod app
+        // Preserve selected development metadata on the deployed workspace.
         let devProps: Pick<Workspace, "updatedBy" | "updatedAt"> = {}
-        if (appMap[id]) {
+        if (workspaceMap[id]) {
           devProps = {
-            updatedBy: appMap[id].updatedBy,
-            updatedAt: appMap[id].updatedAt,
+            updatedBy: workspaceMap[id].updatedBy,
+            updatedAt: workspaceMap[id].updatedAt,
           }
         }
-        appMap[id] = {
-          ...appMap[id],
-          ...app,
+        workspaceMap[id] = {
+          ...workspaceMap[id],
+          ...workspace,
           ...devProps,
-          prodId: app.appId,
-          prodRev: app._rev,
+          prodId: workspace.appId,
+          prodRev: workspace._rev,
         }
       })
 
       // Transform into an array and clean up
-      const apps = Object.values(appMap)
-      apps.forEach(app => {
-        const appId = this.extractAppId(app.devId)
-        if (appId) {
-          app.appId = appId
+      const apps = Object.values(workspaceMap)
+      apps.forEach(workspace => {
+        const workspaceId = this.extractAppId(workspace.devId)
+        if (workspaceId) {
+          workspace.appId = workspaceId
         }
-        delete app._id
-        delete app._rev
+        delete workspace._id
+        delete workspace._rev
       })
       this.update(state => ({
         ...state,
@@ -141,16 +145,16 @@ export class AppsStore extends BudiStore<PortalAppsStore> {
     }
   }
 
-  async save(appId: string, value: UpdateWorkspaceRequest) {
-    await API.saveAppMetadata(appId, value)
+  async save(workspaceId: string, value: UpdateWorkspaceRequest) {
+    await API.saveAppMetadata(workspaceId, value)
     this.update(state => {
-      const updatedAppIndex = state.apps.findIndex(
-        app => app.instance._id === appId
+      const updatedWorkspaceIndex = state.apps.findIndex(
+        workspace => workspace.instance._id === workspaceId
       )
-      if (updatedAppIndex !== -1) {
-        let updatedApp = state.apps[updatedAppIndex]
-        updatedApp = { ...updatedApp, ...value }
-        state.apps.splice(updatedAppIndex, 1, updatedApp)
+      if (updatedWorkspaceIndex !== -1) {
+        let updatedWorkspace = state.apps[updatedWorkspaceIndex]
+        updatedWorkspace = { ...updatedWorkspace, ...value }
+        state.apps.splice(updatedWorkspaceIndex, 1, updatedWorkspace)
       }
       return state
     })
@@ -163,19 +167,23 @@ export const sortBy = derived([appsStore, auth], ([$store, $auth]) => {
   return $store.sortBy || $auth.user?.appSort || "name"
 })
 
-// Centralise any logic that enriches the apps list
+// Centralise the logic that enriches the workspace list.
 export const enrichedApps = derived(
   [appsStore, auth, sortBy],
   ([$store, $auth, $sortBy]) => {
-    const enrichedApps: EnrichedApp[] = $store.apps.map(app => {
+    const enrichedApps: EnrichedApp[] = $store.apps.map(workspace => {
       const user = $auth.user
       return {
-        ...app,
-        deployed: app.status === AppStatus.DEPLOYED,
-        lockedYou: app.lockedBy != null && app.lockedBy.email === user?.email,
-        lockedOther: app.lockedBy != null && app.lockedBy.email !== user?.email,
-        favourite: !!user?.appFavourites?.includes(app.appId),
-        editable: sdk.users.isBuilder(user, app?.devId),
+        ...workspace,
+        deployed: workspace.status === AppStatus.DEPLOYED,
+        lockedYou:
+          workspace.lockedBy != null &&
+          workspace.lockedBy.email === user?.email,
+        lockedOther:
+          workspace.lockedBy != null &&
+          workspace.lockedBy.email !== user?.email,
+        favourite: !!user?.appFavourites?.includes(workspace.appId),
+        editable: sdk.users.isBuilder(user, workspace?.devId),
       }
     })
 

--- a/packages/frontend-core/src/api/app.ts
+++ b/packages/frontend-core/src/api/app.ts
@@ -27,31 +27,35 @@ import {
 import { BaseAPIClient } from "./types"
 
 export interface AppEndpoints {
-  fetchAppPackage: (appId: string) => Promise<FetchAppPackageResponse>
+  fetchAppPackage: (workspaceId: string) => Promise<FetchAppPackageResponse>
   saveAppMetadata: (
-    appId: string,
+    workspaceId: string,
     metadata: UpdateWorkspaceRequest
   ) => Promise<UpdateWorkspaceResponse>
-  unpublishApp: (appId: string) => Promise<UnpublishWorkspaceResponse>
+  unpublishApp: (workspaceId: string) => Promise<UnpublishWorkspaceResponse>
   publishAppChanges: (
-    appId: string,
+    workspaceId: string,
     opts?: PublishWorkspaceRequest
   ) => Promise<PublishWorkspaceResponse>
-  revertAppChanges: (appId: string) => Promise<RevertWorkspaceResponse>
-  updateAppClientVersion: (appId: string) => Promise<UpdateAppClientResponse>
-  revertAppClientVersion: (appId: string) => Promise<RevertAppClientResponse>
-  releaseAppLock: (appId: string) => Promise<ClearDevLockResponse>
+  revertAppChanges: (workspaceId: string) => Promise<RevertWorkspaceResponse>
+  updateAppClientVersion: (
+    workspaceId: string
+  ) => Promise<UpdateAppClientResponse>
+  revertAppClientVersion: (
+    workspaceId: string
+  ) => Promise<RevertAppClientResponse>
+  releaseAppLock: (workspaceId: string) => Promise<ClearDevLockResponse>
   getAppDeployments: () => Promise<FetchDeploymentResponse>
   createApp: (
-    app: CreateWorkspaceRequest | FormData
+    workspace: CreateWorkspaceRequest | FormData
   ) => Promise<CreateWorkspaceResponse>
-  deleteApp: (appId: string) => Promise<DeleteWorkspaceResponse>
+  deleteApp: (workspaceId: string) => Promise<DeleteWorkspaceResponse>
   duplicateApp: (
-    appId: string,
-    app: DuplicateWorkspaceRequest
+    workspaceId: string,
+    workspace: DuplicateWorkspaceRequest
   ) => Promise<DuplicateWorkspaceResponse>
   updateAppFromExport: (
-    appId: string,
+    workspaceId: string,
     body: ImportToUpdateWorkspaceRequest,
     appExport: File
   ) => Promise<ImportToUpdateWorkspaceResponse>
@@ -60,7 +64,9 @@ export interface AppEndpoints {
   fetchComponentLibDefinitions: (
     workspaceId: string
   ) => Promise<FetchAppDefinitionResponse>
-  addSampleData: (appId: string) => Promise<AddWorkspaceSampleDataResponse>
+  addSampleData: (
+    workspaceId: string
+  ) => Promise<AddWorkspaceSampleDataResponse>
   getPublishedApps: () => Promise<FetchPublishedAppsResponse["apps"]>
 
   // Missing request or response types
@@ -69,69 +75,69 @@ export interface AppEndpoints {
 
 export const buildAppEndpoints = (API: BaseAPIClient): AppEndpoints => ({
   /**
-   * Fetches screen definition for an app.
-   * @param appId the ID of the app to fetch from
+   * Fetches screen definition for a workspace.
+   * @param workspaceId the ID of the workspace to fetch from
    */
-  fetchAppPackage: async appId => {
+  fetchAppPackage: async workspaceId => {
     return await API.get({
-      url: `/api/applications/${appId}/appPackage`,
+      url: `/api/applications/${workspaceId}/appPackage`,
     })
   },
 
   /**
-   * Saves and patches metadata about an app.
-   * @param appId the ID of the app to update
-   * @param metadata the app metadata to save
+   * Saves and patches metadata about a workspace.
+   * @param workspaceId the ID of the workspace to update
+   * @param metadata the workspace metadata to save
    */
-  saveAppMetadata: async (appId, metadata) => {
+  saveAppMetadata: async (workspaceId, metadata) => {
     return await API.put({
-      url: `/api/applications/${appId}`,
+      url: `/api/applications/${workspaceId}`,
       body: metadata,
     })
   },
 
   /**
-   * Publishes the current app.
+   * Publishes the current workspace.
    */
-  publishAppChanges: async (appId, opts) => {
+  publishAppChanges: async (workspaceId, opts) => {
     return await API.post({
-      url: `/api/applications/${appId}/publish`,
+      url: `/api/applications/${workspaceId}/publish`,
       body: opts,
     })
   },
 
   /**
-   * Reverts an app to a previous version.
-   * @param appId the app ID to revert
+   * Reverts a workspace to a previous version.
+   * @param workspaceId the workspace ID to revert
    */
-  revertAppChanges: async appId => {
+  revertAppChanges: async workspaceId => {
     return await API.post({
-      url: `/api/dev/${appId}/revert`,
+      url: `/api/dev/${workspaceId}/revert`,
     })
   },
 
   /**
-   * Updates an app's version of the client library.
-   * @param appId the app ID to update
+   * Updates a workspace's version of the client library.
+   * @param workspaceId the workspace ID to update
    */
-  updateAppClientVersion: async appId => {
+  updateAppClientVersion: async workspaceId => {
     return await API.post({
-      url: `/api/applications/${appId}/client/update`,
+      url: `/api/applications/${workspaceId}/client/update`,
     })
   },
 
   /**
-   * Reverts an app's version of the client library to the previous version.
-   * @param appId the app ID to revert
+   * Reverts a workspace's client library to the previous version.
+   * @param workspaceId the workspace ID to revert
    */
-  revertAppClientVersion: async appId => {
+  revertAppClientVersion: async workspaceId => {
     return await API.post({
-      url: `/api/applications/${appId}/client/revert`,
+      url: `/api/applications/${workspaceId}/client/revert`,
     })
   },
 
   /**
-   * Gets a list of app deployments.
+   * Gets a list of workspace deployments.
    */
   getAppDeployments: async () => {
     return await API.get({
@@ -140,44 +146,44 @@ export const buildAppEndpoints = (API: BaseAPIClient): AppEndpoints => ({
   },
 
   /**
-   * Creates an app.
-   * @param app the app to create
+   * Creates a workspace.
+   * @param workspace the workspace to create
    */
-  createApp: async app => {
-    if (app instanceof FormData) {
+  createApp: async workspace => {
+    if (workspace instanceof FormData) {
       return await API.post({
         url: "/api/applications",
-        body: app,
+        body: workspace,
         json: false,
       })
     }
 
     return await API.post({
       url: "/api/applications",
-      body: app,
+      body: workspace,
     })
   },
 
   /**
-   * Duplicate an existing app
-   * @param app the app to dupe
+   * Duplicate an existing workspace
+   * @param workspace the workspace to duplicate
    */
-  duplicateApp: async (appId, app) => {
+  duplicateApp: async (workspaceId, workspace) => {
     return await API.post({
-      url: `/api/applications/${appId}/duplicate`,
-      body: app,
+      url: `/api/applications/${workspaceId}/duplicate`,
+      body: workspace,
     })
   },
 
   /**
-   * Update an application using an export - the body
+   * Update a workspace using an export - the body
    * should be of type FormData, with a "file" and a "password" if encrypted.
-   * @param appId The ID of the app to update - this will always be
+   * @param workspaceId The ID of the workspace to update - this will always be
    * converted to development ID.
    * @param body a FormData body with a file and password.
    */
-  updateAppFromExport: async (appId, body, appExport) => {
-    const devId = sdk.workspaces.getDevWorkspaceID(appId)
+  updateAppFromExport: async (workspaceId, body, appExport) => {
+    const devId = sdk.workspaces.getDevWorkspaceID(workspaceId)
     const formData = new FormData()
     formData.append("appExport", appExport)
     for (const [key, field] of Object.entries(body)) {
@@ -203,32 +209,32 @@ export const buildAppEndpoints = (API: BaseAPIClient): AppEndpoints => ({
   },
 
   /**
-   * Unpublishes a published app.
-   * @param appId the production ID of the app to unpublish
+   * Unpublishes a published workspace.
+   * @param workspaceId the production ID of the workspace to unpublish
    */
-  unpublishApp: async appId => {
+  unpublishApp: async workspaceId => {
     return await API.post({
-      url: `/api/applications/${appId}/unpublish`,
+      url: `/api/applications/${workspaceId}/unpublish`,
     })
   },
 
   /**
-   * Deletes a dev app.
-   * @param appId the dev app ID to delete
+   * Deletes a development workspace.
+   * @param workspaceId the development workspace ID to delete
    */
-  deleteApp: async appId => {
+  deleteApp: async workspaceId => {
     return await API.delete({
-      url: `/api/applications/${appId}`,
+      url: `/api/applications/${workspaceId}`,
     })
   },
 
   /**
-   * Releases the lock on a dev app.
-   * @param appId the dev app ID to unlock
+   * Releases the lock on a development workspace.
+   * @param workspaceId the development workspace ID to unlock
    */
-  releaseAppLock: async appId => {
+  releaseAppLock: async workspaceId => {
     return await API.delete({
-      url: `/api/dev/${appId}/lock`,
+      url: `/api/dev/${workspaceId}/lock`,
     })
   },
 
@@ -242,7 +248,7 @@ export const buildAppEndpoints = (API: BaseAPIClient): AppEndpoints => ({
   },
 
   /**
-   * Gets a list of apps.
+   * Gets a list of workspaces.
    */
   getApps: async () => {
     return await API.get({
@@ -253,21 +259,21 @@ export const buildAppEndpoints = (API: BaseAPIClient): AppEndpoints => ({
   /**
    * Fetches the definitions for component library components. This includes
    * their props and other metadata from components.json.
-   * @param appId ID of the currently running app
+   * @param workspaceId ID of the currently running app
    */
-  fetchComponentLibDefinitions: async appId => {
+  fetchComponentLibDefinitions: async workspaceId => {
     return await API.get({
-      url: `/api/${appId}/components/definitions`,
+      url: `/api/${workspaceId}/components/definitions`,
     })
   },
 
   /**
-   * Adds sample data to an app
-   * @param appId the app ID
+   * Adds sample data to a workspace
+   * @param workspaceId the app ID
    */
-  addSampleData: async appId => {
+  addSampleData: async workspaceId => {
     return await API.post({
-      url: `/api/applications/${appId}/sample`,
+      url: `/api/applications/${workspaceId}/sample`,
     })
   },
 

--- a/packages/server/src/utilities/fileSystem/clientLibrary.ts
+++ b/packages/server/src/utilities/fileSystem/clientLibrary.ts
@@ -16,20 +16,20 @@ export function devClientLibPath() {
  * Client library paths in the object store:
  * Previously, the entire client library package was downloaded from NPM
  * as a tarball and extracted to the object store, even though only the manifest
- * was ever needed. Therefore we need to support old apps which may still have
- * the manifest at this location for the first update.
+ * was ever needed. Therefore we need to support old workspaces which may still
+ * have the manifest at this location for the first update.
  *
  * The paths for the in-use version are:
- * {appId}/manifest.json
- * {appId}/budibase-client.js
- * {appId}/_chunks/...
- * {appId}/... (and any other app files)
+ * {workspaceId}/manifest.json
+ * {workspaceId}/budibase-client.js
+ * {workspaceId}/_chunks/...
+ * {workspaceId}/... (and any other workspace files)
  *
  * The paths for the backups are:
- * {appId}/.bak/manifest.json
- * {appId}/.bak/budibase-client.js
- * {appId}/.bak/_chunks/...
- * {appId}/.bak/... (complete folder backup)
+ * {workspaceId}/.bak/manifest.json
+ * {workspaceId}/.bak/budibase-client.js
+ * {workspaceId}/.bak/_chunks/...
+ * {workspaceId}/.bak/... (complete folder backup)
  *
  * We don't rely on NPM at all any more, as when updating to the latest version
  * we pull both the manifest and client bundle from the server's dependencies
@@ -37,22 +37,25 @@ export function devClientLibPath() {
  */
 
 /**
- * Backs up the current client library version by copying the entire app folder
- * to a backup location in the object store. Only the one previous version is
- * stored as a backup, which can be reverted to.
- * @param appId The app ID to backup
+ * Backs up the current client library version by copying the entire workspace
+ * folder to a backup location in the object store. Only the one previous
+ * version is stored as a backup, which can be reverted to.
+ * @param workspaceId The workspace ID to backup
  * @returns {Promise<void>}
  */
-export async function backupClientLibrary(appId: string) {
-  appId = sdk.workspaces.getProdWorkspaceID(appId)
+export async function backupClientLibrary(workspaceId: string) {
+  workspaceId = sdk.workspaces.getProdWorkspaceID(workspaceId)
   // First, remove any existing backup folder
   try {
-    await objectStore.deleteFolder(ObjectStoreBuckets.APPS, `${appId}/.bak`)
+    await objectStore.deleteFolder(
+      ObjectStoreBuckets.APPS,
+      `${workspaceId}/.bak`
+    )
   } catch (error) {
     // Ignore errors if backup doesn't exist
   }
 
-  await forEachObject(appId, async fileKey => {
+  await forEachObject(workspaceId, async fileKey => {
     if (fileKey.includes("/.bak/") || fileKey.endsWith(".bak")) {
       return
     }
@@ -62,7 +65,7 @@ export async function backupClientLibrary(appId: string) {
       fileKey
     )
 
-    const backupKey = fileKey.replace(appId, `${appId}/.bak`)
+    const backupKey = fileKey.replace(workspaceId, `${workspaceId}/.bak`)
     await objectStore.upload({
       bucket: ObjectStoreBuckets.APPS,
       filename: backupKey,
@@ -74,11 +77,11 @@ export async function backupClientLibrary(appId: string) {
 /**
  * Uploads the latest version of the component manifest and the client library
  * to the object store, overwriting the existing version.
- * @param appId The app ID to update
+ * @param workspaceId The workspace ID to update
  * @returns {Promise<void>}
  */
-export async function updateClientLibrary(appId: string) {
-  appId = sdk.workspaces.getProdWorkspaceID(appId)
+export async function updateClientLibrary(workspaceId: string) {
+  workspaceId = sdk.workspaces.getProdWorkspaceID(workspaceId)
 
   let manifest: string, client: string
   let dependencies = []
@@ -108,15 +111,15 @@ export async function updateClientLibrary(appId: string) {
   // Upload latest manifest and client library
   const files = [
     {
-      filename: join(appId, "manifest.json"),
+      filename: join(workspaceId, "manifest.json"),
       stream: fs.createReadStream(manifest),
     },
     {
-      filename: join(appId, "budibase-client.js"),
+      filename: join(workspaceId, "budibase-client.js"),
       stream: fs.createReadStream(client),
     },
     ...dependencies.map(dependency => ({
-      filename: join(appId, "chunks", path.basename(dependency)),
+      filename: join(workspaceId, "chunks", path.basename(dependency)),
       stream: fs.createReadStream(dependency),
     })),
   ]
@@ -133,13 +136,16 @@ export async function updateClientLibrary(appId: string) {
   const uploadedFiles = files.map(file => file.filename)
   const filesToDelete: string[] = []
   await utils.parallelForeach(
-    objectStore.listAllObjects(objectStore.ObjectStoreBuckets.APPS, appId),
+    objectStore.listAllObjects(
+      objectStore.ObjectStoreBuckets.APPS,
+      workspaceId
+    ),
     async file => {
       const key = file.Key
       if (!key) {
         return
       }
-      if (!key.startsWith(`${appId}/chunks/`)) {
+      if (!key.startsWith(`${workspaceId}/chunks/`)) {
         return
       }
       if (!uploadedFiles.includes(key)) {
@@ -161,19 +167,19 @@ export async function updateClientLibrary(appId: string) {
 
 /**
  * Reverts the version of the client library and manifest to the previously
- * used version for an app by restoring the entire backed up folder.
- * @param appId The app ID to revert
+ * used version for a workspace by restoring the entire backed up folder.
+ * @param workspaceId The workspace ID to revert
  * @returns {Promise<void>}
  */
-export async function revertClientLibrary(appId: string) {
-  appId = sdk.workspaces.getProdWorkspaceID(appId)
+export async function revertClientLibrary(workspaceId: string) {
+  workspaceId = sdk.workspaces.getProdWorkspaceID(workspaceId)
 
   let manifestContent
   let hasBackup = false
   const restoredFiles = new Set<string>()
 
   // First, restore all files from the backup folder
-  await forEachObject(`${appId}/.bak`, async filePath => {
+  await forEachObject(`${workspaceId}/.bak`, async filePath => {
     hasBackup = true
 
     // Download the backup file to temp
@@ -183,7 +189,7 @@ export async function revertClientLibrary(appId: string) {
     )
 
     // Restore to original location
-    const restoreKey = filePath.replace(`${appId}/.bak`, appId)
+    const restoreKey = filePath.replace(`${workspaceId}/.bak`, workspaceId)
     restoredFiles.add(restoreKey)
 
     // Read manifest content if this is the manifest file
@@ -200,7 +206,7 @@ export async function revertClientLibrary(appId: string) {
 
   // After successful restore, clean up any extra files that weren't in backup
   if (hasBackup) {
-    await forEachObject(appId, async filePath => {
+    await forEachObject(workspaceId, async filePath => {
       if (
         !filePath.includes("/.bak/") &&
         !filePath.endsWith(".bak") &&
@@ -213,7 +219,7 @@ export async function revertClientLibrary(appId: string) {
 
   // If no backup folder found, try to find old .bak files
   if (!hasBackup) {
-    await forEachObject(appId, async filePath => {
+    await forEachObject(workspaceId, async filePath => {
       if (!filePath.endsWith(".bak")) {
         return
       }
@@ -248,11 +254,11 @@ export async function revertClientLibrary(appId: string) {
   }
 
   if (!hasBackup) {
-    throw new Error(`No backup found for app ${appId}`)
+    throw new Error(`No backup found for workspace ${workspaceId}`)
   }
 
   if (!manifestContent) {
-    throw new Error(`No manifest found in backup for app ${appId}`)
+    throw new Error(`No manifest found in backup for workspace ${workspaceId}`)
   }
 
   return JSON.parse(manifestContent)

--- a/packages/server/src/utilities/fileSystem/clientLibrary.ts
+++ b/packages/server/src/utilities/fileSystem/clientLibrary.ts
@@ -22,13 +22,13 @@ export function devClientLibPath() {
  * The paths for the in-use version are:
  * {workspaceId}/manifest.json
  * {workspaceId}/budibase-client.js
- * {workspaceId}/_chunks/...
+ * {workspaceId}/chunks/...
  * {workspaceId}/... (and any other workspace files)
  *
  * The paths for the backups are:
  * {workspaceId}/.bak/manifest.json
  * {workspaceId}/.bak/budibase-client.js
- * {workspaceId}/.bak/_chunks/...
+ * {workspaceId}/.bak/chunks/...
  * {workspaceId}/.bak/... (complete folder backup)
  *
  * We don't rely on NPM at all any more, as when updating to the latest version

--- a/packages/server/src/utilities/fileSystem/tests/clientLibrary.spec.ts
+++ b/packages/server/src/utilities/fileSystem/tests/clientLibrary.spec.ts
@@ -58,15 +58,15 @@ type ObjectStoreFile = { Key?: string }
 type MockedReadFile = jest.MockedFunction<typeof fs.promises.readFile>
 
 describe("clientLibrary", () => {
-  const testAppId = "app_123"
-  const testAppIdDev = "app_dev_123"
+  const testWorkspaceId = "app_123"
+  const testDevWorkspaceId = "app_dev_123"
 
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
   describe("backupClientLibrary", () => {
-    it("should backup entire app folder to /.bak folder", async () => {
+    it("should backup entire workspace folder to /.bak folder", async () => {
       const mockFiles: ObjectStoreFile[] = [
         { Key: "app_123/manifest.json" },
         { Key: "app_123/budibase-client.js" },
@@ -76,7 +76,7 @@ describe("clientLibrary", () => {
 
       mockedObjectStore.listAllObjects.mockReturnValue(mockFiles as any)
 
-      await backupClientLibrary(testAppId)
+      await backupClientLibrary(testWorkspaceId)
 
       expect(mockedObjectStore.deleteFolder).toHaveBeenCalledWith(
         ObjectStoreBuckets.APPS,
@@ -115,7 +115,7 @@ describe("clientLibrary", () => {
 
       mockedObjectStore.listAllObjects.mockReturnValue(mockFiles as any)
 
-      await backupClientLibrary(testAppId)
+      await backupClientLibrary(testWorkspaceId)
 
       expect(mockedObjectStore.upload).toHaveBeenCalledTimes(1)
       expect(mockedObjectStore.upload).toHaveBeenCalledWith({
@@ -125,15 +125,15 @@ describe("clientLibrary", () => {
       })
     })
 
-    it("should handle dev app IDs correctly", async () => {
+    it("should handle dev workspace IDs correctly", async () => {
       const mockFiles: ObjectStoreFile[] = [{ Key: "app_123/manifest.json" }]
       mockedObjectStore.listAllObjects.mockReturnValue(mockFiles as any)
 
-      await backupClientLibrary(testAppIdDev)
+      await backupClientLibrary(testDevWorkspaceId)
 
       expect(mockedObjectStore.listAllObjects).toHaveBeenCalledWith(
         ObjectStoreBuckets.APPS,
-        testAppId // should be converted to prod ID
+        testWorkspaceId // should be converted to production workspace ID
       )
     })
 
@@ -142,7 +142,7 @@ describe("clientLibrary", () => {
       mockedObjectStore.listAllObjects.mockReturnValue(mockFiles as any)
       mockedObjectStore.deleteFolder.mockRejectedValue(new Error("Not found"))
 
-      await expect(backupClientLibrary(testAppId)).resolves.not.toThrow()
+      await expect(backupClientLibrary(testWorkspaceId)).resolves.not.toThrow()
       expect(mockedObjectStore.upload).toHaveBeenCalledTimes(1)
     })
   })
@@ -173,7 +173,7 @@ describe("clientLibrary", () => {
 
       mockedEnv.isDev.mockReturnValue(isDev)
 
-      const result = await updateClientLibrary(testAppId)
+      const result = await updateClientLibrary(testWorkspaceId)
 
       expect(mockedFs.readdirSync).toHaveBeenCalledTimes(1)
 
@@ -225,7 +225,7 @@ describe("clientLibrary", () => {
 
       mockedObjectStore.listAllObjects.mockReturnValue(existingFiles as any)
 
-      await updateClientLibrary(testAppId)
+      await updateClientLibrary(testWorkspaceId)
 
       expect(mockedObjectStore.deleteFiles).toHaveBeenCalledTimes(1)
       expect(mockedObjectStore.deleteFiles).toHaveBeenCalledWith(
@@ -261,7 +261,7 @@ describe("clientLibrary", () => {
         .mockReturnValueOnce(mockBackupFiles as any) // First call for backup files
         .mockReturnValueOnce(mockCurrentFiles as any) // Second call for cleanup
 
-      const result = await revertClientLibrary(testAppId)
+      const result = await revertClientLibrary(testWorkspaceId)
 
       expect(mockedObjectStore.upload).toHaveBeenCalledTimes(3)
       ;["manifest.json", "budibase-client.js", "manifest.json"].forEach(
@@ -302,7 +302,7 @@ describe("clientLibrary", () => {
         .mockReturnValueOnce([] as any) // No .bak folder
         .mockReturnValueOnce(mockOldBackupFiles as any) // Old .bak files
 
-      const result = await revertClientLibrary(testAppId)
+      const result = await revertClientLibrary(testWorkspaceId)
 
       expect(mockedObjectStore.streamUpload).toHaveBeenCalledTimes(2)
       expect(mockedObjectStore.streamUpload).toHaveBeenCalledWith({
@@ -324,8 +324,8 @@ describe("clientLibrary", () => {
         .mockReturnValueOnce([] as any) // No .bak folder
         .mockReturnValueOnce([] as any) // No old .bak files
 
-      await expect(revertClientLibrary(testAppId)).rejects.toThrow(
-        "No backup found for app app_123"
+      await expect(revertClientLibrary(testWorkspaceId)).rejects.toThrow(
+        "No backup found for workspace app_123"
       )
     })
 
@@ -338,12 +338,12 @@ describe("clientLibrary", () => {
         mockBackupFiles as any
       )
 
-      await expect(revertClientLibrary(testAppId)).rejects.toThrow(
-        "No manifest found in backup for app app_123"
+      await expect(revertClientLibrary(testWorkspaceId)).rejects.toThrow(
+        "No manifest found in backup for workspace app_123"
       )
     })
 
-    it("should handle dev app IDs correctly", async () => {
+    it("should handle dev workspace IDs correctly", async () => {
       const mockBackupFiles: ObjectStoreFile[] = [
         { Key: "app_123/.bak/manifest.json" },
       ]
@@ -352,11 +352,11 @@ describe("clientLibrary", () => {
         mockBackupFiles as any
       )
 
-      await revertClientLibrary(testAppIdDev)
+      await revertClientLibrary(testDevWorkspaceId)
 
       expect(mockedObjectStore.listAllObjects).toHaveBeenCalledWith(
         ObjectStoreBuckets.APPS,
-        "app_123/.bak" // should use prod ID
+        "app_123/.bak" // should use production workspace ID
       )
     })
   })

--- a/packages/shared-core/src/sdk/documents/users.ts
+++ b/packages/shared-core/src/sdk/documents/users.ts
@@ -11,15 +11,21 @@ import {
 } from "@budibase/types"
 import { getProdWorkspaceID } from "./workspaces"
 
-// checks if a user is specifically a builder, given an app ID
-// TODO: check its usages, as appId checks are not actually checked for global builders
-export function isBuilder(user?: UserBuilderInfo, appId?: string): boolean {
+// Checks whether a user is specifically a builder for a workspace.
+// Global builders do not require a workspace-specific permission.
+export function isBuilder(
+  user?: UserBuilderInfo,
+  workspaceId?: string
+): boolean {
   if (!user) {
     return false
   }
   if (user.builder?.global) {
     return true
-  } else if (appId && user.builder?.apps?.includes(getProdWorkspaceID(appId))) {
+  } else if (
+    workspaceId &&
+    user.builder?.apps?.includes(getProdWorkspaceID(workspaceId))
+  ) {
     return true
   }
   return false
@@ -47,7 +53,7 @@ export function isAdmin(user?: UserAdminInfo): boolean {
 
 export function isAdminOrWorkspaceBuilder(
   user: UserBuilderInfo & UserAdminInfo,
-  appId: string
+  workspaceId: string
 ): boolean {
   if (!user) {
     return false
@@ -57,7 +63,10 @@ export function isAdminOrWorkspaceBuilder(
     return true
   }
 
-  if (appId && user.builder?.apps?.includes(getProdWorkspaceID(appId))) {
+  if (
+    workspaceId &&
+    user.builder?.apps?.includes(getProdWorkspaceID(workspaceId))
+  ) {
     return true
   }
 
@@ -66,9 +75,9 @@ export function isAdminOrWorkspaceBuilder(
 
 export function isAdminOrBuilder(
   user: UserBuilderInfo & UserAdminInfo,
-  appId?: string
+  workspaceId?: string
 ): boolean {
-  return isBuilder(user, appId) || isAdmin(user)
+  return isBuilder(user, workspaceId) || isAdmin(user)
 }
 
 export function isAdminOrGlobalBuilder(
@@ -77,14 +86,14 @@ export function isAdminOrGlobalBuilder(
   return isGlobalBuilder(user) || isAdmin(user)
 }
 
-// check if they are a builder within an app (not necessarily a global builder)
+// Checks whether they can build within a workspace without being a global builder.
 export function hasAppBuilderPermissions(user?: UserBuilderInfo): boolean {
   if (!user) {
     return false
   }
-  const appLength = user.builder?.apps?.length
+  const workspaceCount = user.builder?.apps?.length
   const isGlobalBuilder = !!user.builder?.global
-  return !isGlobalBuilder && appLength != null && appLength > 0
+  return !isGlobalBuilder && workspaceCount != null && workspaceCount > 0
 }
 
 function hasAppCreatorPermissions(user?: Partial<UserRoleInfo>): boolean {
@@ -94,7 +103,7 @@ function hasAppCreatorPermissions(user?: Partial<UserRoleInfo>): boolean {
   return !!Object.values(user.roles ?? {}).find(x => x === "CREATOR")
 }
 
-// checks if a user is capable of building any app
+// Checks whether a user can build any workspace.
 export function hasBuilderPermissions(user?: UserBuilderInfo): boolean {
   if (!user) {
     return false
@@ -159,22 +168,24 @@ function getUserGroups(userId: string | undefined, groups?: UserGroup[]) {
 }
 
 export function getUserAppGroups(
-  appId: string,
+  workspaceId: string,
   userId: string,
   groups?: UserGroup[]
 ) {
-  const prodAppId = getProdWorkspaceID(appId)
+  const prodWorkspaceId = getProdWorkspaceID(workspaceId)
   const userGroups = getUserGroups(userId, groups)
   return userGroups.filter(group =>
-    Object.keys(group.roles || {}).find(app => app === prodAppId)
+    Object.keys(group.roles || {}).find(
+      workspaceId => workspaceId === prodWorkspaceId
+    )
   )
 }
 
 export function userAppAccessList(user: User, groups?: UserGroup[]) {
   const userGroups = getUserGroups(user._id, groups)
-  const userGroupApps = userGroups.flatMap(userGroup =>
+  const userGroupWorkspaces = userGroups.flatMap(userGroup =>
     Object.keys(userGroup.roles || {})
   )
-  const fullList = [...Object.keys(user?.roles || {}), ...userGroupApps]
+  const fullList = [...Object.keys(user?.roles || {}), ...userGroupWorkspaces]
   return [...new Set(fullList)]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized on workspaceId instead of appId across frontend, server, and shared SDK to align with workspace terminology. Also updated client library docs and errors to reference “workspace” and the “chunks” path; no behavior changes expected.

- **Refactors**
  - Renamed appId to workspaceId across `packages/frontend-core/src/api/app.ts`, `packages/server/src/utilities/fileSystem/*`, `packages/builder/*`, and tests; URLs stay the same.
  - Builder API client now reads workspaceId from the store and sets `Header.APP_ID` using `sdk.workspaces.getProdWorkspaceID`.
  - `AppEndpoints` now use workspaceId in method signatures and JSDoc; semantics unchanged.
  - `AppsStore.save` now accepts `workspaceId`; merge/enrichment logic uses workspace naming.
  - `sdk.users` helpers now take `workspaceId` (e.g., `isBuilder`, `isAdminOrWorkspaceBuilder`); semantics unchanged.
  - File system client library (`backupClientLibrary`, `updateClientLibrary`, `revertClientLibrary`) uses workspaceId and clearer “workspace” errors; docs reference the `chunks` path; tests updated.

- **Migration**
  - Update internal calls to `AppEndpoints` and `AppsStore.save` to pass a `workspaceId`.
  - Update usages of `sdk.users.isBuilder` and related helpers to pass a `workspaceId` for per-workspace checks.

<sup>Written for commit 2f2178844aaa5e72460900cd4dcca76dc585b324. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

