### PR TITLE
Update docker-compose.yaml - Remove 'version' is obsolete

### DIFF
--- a/hosting/docker-compose.build.yaml
+++ b/hosting/docker-compose.build.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 # optional ports are specified throughout for more advanced use cases.
 
 services:

--- a/hosting/docker-compose.yaml
+++ b/hosting/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 # optional ports are specified throughout for more advanced use cases.
 
 services:


### PR DESCRIPTION
Only fix the warning ;-)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the deprecated `version` key from `hosting/docker-compose.yaml` and `hosting/docker-compose.build.yaml` to align with the Compose Specification and stop deprecation warnings. No behavior change; Docker Compose infers the schema automatically.

<sup>Written for commit 4144a6a27b0a0c4528db30c5a48f5f5f0589a90c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

