### PR TITLE
clarifies button text in agent chat

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/AgentChatPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/AgentChatPanel.svelte
@@ -97,7 +97,7 @@
   <div class="chat-preview-header">
     <span class="chat-preview-pill">Chat preview</span>
     <button class="chat-preview-refresh" type="button" onclick={refreshChat}>
-      New chat
+      Clear chat
     </button>
   </div>
   <div class="chat-preview-body">

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/AgentChatPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/AgentChatPanel.svelte
@@ -97,7 +97,7 @@
   <div class="chat-preview-header">
     <span class="chat-preview-pill">Chat preview</span>
     <button class="chat-preview-refresh" type="button" onclick={refreshChat}>
-      Refresh chat
+      New chat
     </button>
   </div>
   <div class="chat-preview-body">


### PR DESCRIPTION
## Description
Agent button text "Refresh chat" gave the impression that the button would resume the current conversation, perhaps after fixing a stalled tool-call or something, however it simply clears the conversation and starts a new one. 

Support ticket `cnv_1co6jswm` raised this confusion and suggested a different name for it.

## Addresses
- Customer confusion over the function of the button itself


## Screenshots
<img width="141" height="187" alt="image" src="https://github.com/user-attachments/assets/9df24f09-105f-4e23-9071-76ee7af91302" />

