### PR TITLE
[Functions] Add CodeMirror TypeScript editor and build workflow

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionCodeEditor.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionCodeEditor.spec.ts
@@ -1,0 +1,30 @@
+import { render, waitFor } from "@testing-library/svelte"
+import { beforeEach, describe, expect, it } from "vitest"
+import FunctionCodeEditor from "./FunctionCodeEditor.svelte"
+
+describe("FunctionCodeEditor", () => {
+  beforeEach(() => {
+    document.body.className = "spectrum"
+  })
+
+  it("renders TypeScript source and located compiler diagnostics", async () => {
+    const view = render(FunctionCodeEditor, {
+      value: "const broken: string = 42",
+      diagnostics: [
+        {
+          code: "TS2322",
+          message: "Type 'number' is not assignable to type 'string'.",
+          line: 1,
+          column: 7,
+        },
+      ],
+    })
+
+    expect(view.container).toHaveTextContent("const broken: string = 42")
+    await waitFor(() => {
+      expect(
+        view.container.querySelector(".cm-lintRange-error")
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionCodeEditor.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionCodeEditor.svelte
@@ -1,0 +1,222 @@
+<script lang="ts">
+  import { themeStore } from "@/stores/portal"
+  import type {
+    FunctionBuildDiagnostic,
+    FunctionQueryCapability,
+  } from "@budibase/types"
+  import {
+    autocompletion,
+    closeBrackets,
+    closeBracketsKeymap,
+    completionKeymap,
+    type CompletionContext,
+  } from "@codemirror/autocomplete"
+  import {
+    defaultKeymap,
+    history,
+    historyKeymap,
+    indentWithTab,
+  } from "@codemirror/commands"
+  import { javascript } from "@codemirror/lang-javascript"
+  import { bracketMatching, syntaxHighlighting } from "@codemirror/language"
+  import { setDiagnostics, type Diagnostic } from "@codemirror/lint"
+  import { EditorState } from "@codemirror/state"
+  import { oneDark, oneDarkHighlightStyle } from "@codemirror/theme-one-dark"
+  import {
+    drawSelection,
+    EditorView,
+    highlightActiveLine,
+    highlightActiveLineGutter,
+    keymap,
+    lineNumbers,
+  } from "@codemirror/view"
+  import { onDestroy, onMount } from "svelte"
+  import {
+    getFunctionDatasourceCompletions,
+    getFunctionQueryCompletions,
+  } from "./functionCompletions"
+
+  export let value = ""
+  export let capabilities: FunctionQueryCapability[] = []
+  export let diagnostics: FunctionBuildDiagnostic[] = []
+  export let readonly = false
+
+  const virtualModuleExports = [
+    { label: "inputs", type: "variable", detail: "Function inputs" },
+    { label: "queries", type: "variable", detail: "Linked queries" },
+    { label: "FunctionResult", type: "type" },
+    { label: "JsonValue", type: "type" },
+  ]
+
+  let container: HTMLDivElement
+  let editor: EditorView | undefined
+
+  const complete = (context: CompletionContext) => {
+    const before = context.state.doc.sliceString(0, context.pos)
+
+    // Complete the only module that Function source is allowed to import.
+    const [fromMatch, typedModuleName] =
+      before.match(/from\s+["']([^"']*)$/) || []
+    if (fromMatch) {
+      return {
+        from: context.pos - typedModuleName.length,
+        options: [
+          {
+            label: "@budibase/functions",
+            type: "module",
+          },
+        ],
+      }
+    }
+
+    // Complete exports while typing inside a named import.
+    if (/import\s+(?:type\s+)?{[^}]*$/.test(before)) {
+      const typedExport = context.matchBefore(/[\w$]*/)
+      return {
+        from: typedExport?.from ?? context.pos,
+        options: virtualModuleExports,
+      }
+    }
+
+    // Complete a query beneath an explicitly linked datasource.
+    const queryMatch = context.matchBefore(/queries\.[A-Za-z_$][\w$]*\.[\w$]*$/)
+    if (queryMatch) {
+      const [, datasourceAlias, typedQueryName] = queryMatch.text.split(".")
+      return {
+        from: context.pos - typedQueryName.length,
+        options: getFunctionQueryCompletions(capabilities, datasourceAlias).map(
+          item => ({
+            label: item.label,
+            type: "function",
+            detail: item.parameterNames.length
+              ? `(${item.parameterNames.join(", ")})`
+              : "()",
+          })
+        ),
+      }
+    }
+
+    // Complete an explicitly linked datasource after `queries.`.
+    const datasourceMatch = context.matchBefore(/queries\.[\w$]*$/)
+    if (datasourceMatch) {
+      const [, typedDatasourceAlias] = datasourceMatch.text.split(".")
+      return {
+        from: context.pos - typedDatasourceAlias.length,
+        options: getFunctionDatasourceCompletions(capabilities).map(label => ({
+          label,
+          type: "property",
+        })),
+      }
+    }
+
+    return null
+  }
+
+  const toEditorDiagnostics = (
+    values: FunctionBuildDiagnostic[]
+  ): Diagnostic[] =>
+    values.map(item => {
+      if (!editor || !item.line) {
+        return {
+          from: 0,
+          to: 0,
+          severity: "error",
+          message: item.message,
+          source: item.code,
+        }
+      }
+      const lineNumber = Math.min(item.line, editor.state.doc.lines)
+      const line = editor.state.doc.line(lineNumber)
+      const from = Math.min(
+        line.to,
+        line.from + Math.max(0, (item.column || 1) - 1)
+      )
+      return {
+        from,
+        to: Math.min(line.to, from + 1),
+        severity: "error",
+        message: item.message,
+        source: item.code,
+      }
+    })
+
+  const refreshDiagnostics = (
+    values: FunctionBuildDiagnostic[],
+    view?: EditorView
+  ) => {
+    if (view) {
+      view.dispatch(setDiagnostics(view.state, toEditorDiagnostics(values)))
+    }
+  }
+
+  $: refreshDiagnostics(diagnostics, editor)
+
+  $: if (editor && editor.state.doc.toString() !== value) {
+    editor.dispatch({
+      changes: { from: 0, to: editor.state.doc.length, insert: value },
+    })
+  }
+
+  onMount(() => {
+    const isDark = !$themeStore?.theme?.includes("light")
+    editor = new EditorView({
+      parent: container,
+      doc: value,
+      extensions: [
+        lineNumbers(),
+        history(),
+        drawSelection(),
+        highlightActiveLine(),
+        highlightActiveLineGutter(),
+        bracketMatching(),
+        closeBrackets(),
+        javascript({ typescript: true }),
+        syntaxHighlighting(oneDarkHighlightStyle, { fallback: true }),
+        ...(isDark ? [oneDark] : []),
+        autocompletion({ override: [complete] }),
+        keymap.of([
+          ...closeBracketsKeymap,
+          ...defaultKeymap,
+          ...historyKeymap,
+          ...completionKeymap,
+          indentWithTab,
+        ]),
+        EditorState.readOnly.of(readonly),
+        EditorView.updateListener.of(update => {
+          if (update.docChanged) {
+            value = update.state.doc.toString()
+          }
+        }),
+      ],
+    })
+    refreshDiagnostics(diagnostics, editor)
+  })
+
+  onDestroy(() => editor?.destroy())
+</script>
+
+<div class="function-code-editor" bind:this={container}></div>
+
+<style>
+  .function-code-editor {
+    min-height: 420px;
+    height: 100%;
+    overflow: hidden;
+    border: 1px solid var(--spectrum-global-color-gray-300);
+    border-radius: var(--radius-l);
+    background: var(--spectrum-global-color-gray-50);
+    font-size: 13px;
+  }
+  .function-code-editor :global(.cm-editor) {
+    height: 100%;
+    min-height: 420px;
+  }
+  .function-code-editor :global(.cm-scroller) {
+    overflow: auto;
+    font-family: var(--font-family-code);
+  }
+  .function-code-editor :global(.cm-focused) {
+    outline: 2px solid var(--spectrum-global-color-blue-500);
+    outline-offset: -2px;
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionQueryEditor.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionQueryEditor.spec.ts
@@ -102,6 +102,27 @@ describe("FunctionQueryEditor", () => {
     ])
   })
 
+  it("reports unsaved query configuration changes", async () => {
+    const onDirtyChange = vi.fn()
+    render(FunctionQueryEditor, {
+      catalog,
+      onDirtyChange,
+    })
+
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false)
+    await fireEvent.click(
+      screen.getByRole("button", { name: /Link a Data query/i })
+    )
+    await fireEvent.click(
+      screen.getByRole("option", {
+        name: /Find renamed customer/i,
+        hidden: true,
+      })
+    )
+
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true)
+  })
+
   it("removes links, including saved queries that are now missing", async () => {
     const onSave = vi.fn().mockResolvedValue(undefined)
     render(FunctionQueryEditor, {

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionQueryEditor.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionQueryEditor.svelte
@@ -30,6 +30,7 @@
     catalogError?: string
     onRetry?: () => void
     onSave?: (_capabilities: FunctionQueryCapabilityInput[]) => Promise<void>
+    onDirtyChange?: (_dirty: boolean) => void
   }
 
   let {
@@ -39,6 +40,7 @@
     catalogError = "",
     onRetry = () => {},
     onSave = async () => {},
+    onDirtyChange = () => {},
   }: Props = $props()
 
   let drafts = $state<FunctionQueryCapabilityInput[]>([])
@@ -93,6 +95,10 @@
   let dirty = $derived(
     JSON.stringify(drafts) !== syncedCapabilities || parameterMetadataChanged
   )
+
+  $effect(() => {
+    onDirtyChange(dirty)
+  })
 
   const getAvailableQueries = (kind: FunctionQueryKind) =>
     catalog.filter(

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/[functionId]/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/[functionId]/index.svelte
@@ -4,6 +4,7 @@
   import { appStore, builderStore, functionStore } from "@/stores/builder"
   import { auth, featureFlags } from "@/stores/portal"
   import {
+    Badge,
     Body,
     Button,
     Heading,
@@ -11,25 +12,96 @@
     notifications,
     ProgressCircle,
   } from "@budibase/bbui"
+  import { Utils } from "@budibase/frontend-core"
   import type {
+    FunctionBuildDiagnostic,
     FunctionQueryCapabilityInput,
     FunctionResponse,
   } from "@budibase/types"
   import { FeatureFlag } from "@budibase/types"
   import { params } from "@roxi/routify"
-  import { onMount } from "svelte"
+  import { onDestroy, onMount } from "svelte"
+  import FunctionCodeEditor from "../FunctionCodeEditor.svelte"
   import FunctionQueryEditor from "../FunctionQueryEditor.svelte"
   import { canManageFunctions } from "../permissions"
 
   let fn: FunctionResponse | undefined
   let loading = true
   let error = ""
+  let source = ""
+  let savedSource = ""
+  let diagnostics: FunctionBuildDiagnostic[] = []
+  let validating = false
+  let saving = false
+  let building = false
+  let queriesDirty = false
+  let actionError = ""
+  let validationRequest = 0
 
   $params
   $: functionId = $params.functionId
   $: enabled = $featureFlags[FeatureFlag.FUNCTIONS]
   $: canManage = enabled && canManageFunctions($auth.user, $appStore.appId)
   $: builderStore.selectResource(functionId)
+  $: sourceDirty = !!fn && source !== savedSource
+  $: draftDirty = sourceDirty || queriesDirty
+  $: displayedReadiness = draftDirty ? "build_required" : fn?.readiness
+
+  const readinessLabels = {
+    ready: "Ready",
+    build_required: "Build required",
+    build_failed: "Build failed",
+  }
+
+  const toCapabilityInputs = (value: FunctionResponse) =>
+    value.capabilities.map(capability => ({
+      queryId: capability.queryId,
+      datasourceAlias: capability.datasourceAlias,
+      queryAlias: capability.queryAlias,
+    }))
+
+  const debouncedValidate = Utils.debounce(
+    async (
+      value: string,
+      functionToValidate: FunctionResponse,
+      request: number
+    ) => {
+      validating = true
+      try {
+        const response = await functionStore.compile({
+          functionId: functionToValidate._id,
+          name: functionToValidate.name,
+          source: value,
+          capabilities: toCapabilityInputs(functionToValidate),
+        })
+        if (request === validationRequest) {
+          diagnostics = response.diagnostics
+        }
+      } catch (validationError) {
+        if (request === validationRequest) {
+          actionError =
+            getErrorMessage(validationError) || "Unable to validate Function"
+        }
+      } finally {
+        if (request === validationRequest) {
+          validating = false
+        }
+      }
+    },
+    500
+  )
+
+  const validate = (value: string) => {
+    if (!fn) {
+      return
+    }
+    const request = ++validationRequest
+    debouncedValidate(value, fn, request)
+  }
+
+  $: if (fn) {
+    validate(source)
+  }
 
   const load = async () => {
     loading = true
@@ -40,6 +112,9 @@
         functionStore.fetchQueryCatalog(),
       ])
       fn = loadedFunction
+      source = loadedFunction.source
+      savedSource = loadedFunction.source
+      diagnostics = loadedFunction.lastBuild?.diagnostics || []
     } catch (loadError) {
       error = getErrorMessage(loadError) || "Unable to load Function"
     } finally {
@@ -59,7 +134,52 @@
       source: fn.source,
       capabilities,
     })
+    diagnostics = []
+    validate(source)
     notifications.success("Linked queries saved")
+  }
+
+  const saveSource = async () => {
+    if (!fn?._rev || saving || !sourceDirty) {
+      return
+    }
+    saving = true
+    actionError = ""
+    try {
+      fn = await functionStore.save(fn, {
+        _rev: fn._rev,
+        name: fn.name,
+        source,
+        capabilities: toCapabilityInputs(fn),
+      })
+      savedSource = fn.source
+      notifications.success("Function draft saved")
+    } catch (saveError) {
+      actionError = getErrorMessage(saveError) || "Unable to save Function"
+    } finally {
+      saving = false
+    }
+  }
+
+  const build = async () => {
+    if (!fn || draftDirty || building) {
+      return
+    }
+    building = true
+    actionError = ""
+    try {
+      fn = await functionStore.build(fn)
+      diagnostics = fn.lastBuild?.diagnostics || []
+      if (fn.readiness === "ready") {
+        notifications.success("Function build succeeded")
+      } else {
+        notifications.error("Function build failed")
+      }
+    } catch (buildError) {
+      actionError = getErrorMessage(buildError) || "Unable to build Function"
+    } finally {
+      building = false
+    }
   }
 
   onMount(() => {
@@ -68,6 +188,10 @@
     } else {
       loading = false
     }
+  })
+
+  onDestroy(() => {
+    validationRequest += 1
   })
 </script>
 
@@ -106,11 +230,88 @@
       </div>
     {:else}
       <div class="heading">
-        <Heading size="L">{fn.name}</Heading>
-        <Body size="S" color="var(--spectrum-global-color-gray-600)">
-          Configure the saved queries this Function is allowed to call.
-        </Body>
+        <div>
+          <div class="title">
+            <Heading size="L">{fn.name}</Heading>
+            {#if displayedReadiness}
+              <Badge
+                grey={displayedReadiness === "build_required"}
+                red={displayedReadiness === "build_failed"}
+                green={displayedReadiness === "ready"}
+              >
+                {readinessLabels[displayedReadiness]}
+              </Badge>
+            {/if}
+          </div>
+          <Body size="S" color="var(--spectrum-global-color-gray-600)">
+            Write TypeScript, save the draft, then build its saved revision.
+          </Body>
+        </div>
+        <div class="actions">
+          <Button
+            secondary
+            disabled={!sourceDirty || saving || building}
+            on:click={saveSource}
+          >
+            {saving ? "Saving..." : "Save"}
+          </Button>
+          <Button
+            primary
+            disabled={draftDirty || saving || building}
+            on:click={build}
+          >
+            {building ? "Building..." : "Build"}
+          </Button>
+        </div>
       </div>
+
+      {#if actionError}
+        <div class="action-error" role="alert">
+          <Icon name="warning-circle" size="S" />
+          <span>{actionError}</span>
+          <Button secondary on:click={load}>Reload saved revision</Button>
+        </div>
+      {/if}
+
+      <section class="source-editor">
+        <div class="section-heading">
+          <div>
+            <Heading size="M">Source</Heading>
+            <Body size="S" color="var(--spectrum-global-color-gray-600)">
+              TypeScript diagnostics are authoritative and do not prevent
+              saving.
+            </Body>
+          </div>
+          {#if validating}
+            <div class="validating">
+              <ProgressCircle size="S" />
+              <Body size="S">Checking...</Body>
+            </div>
+          {/if}
+        </div>
+        <FunctionCodeEditor
+          bind:value={source}
+          capabilities={fn.capabilities}
+          {diagnostics}
+        />
+        {#if diagnostics.length}
+          <div class="diagnostics" aria-label="Function diagnostics">
+            {#each diagnostics as diagnostic}
+              <div class="diagnostic">
+                <code>{diagnostic.code}</code>
+                {#if diagnostic.line}
+                  <span>
+                    Line {diagnostic.line}{diagnostic.column
+                      ? `:${diagnostic.column}`
+                      : ""}
+                  </span>
+                {/if}
+                <span>{diagnostic.message}</span>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </section>
 
       <FunctionQueryEditor
         capabilities={fn.capabilities}
@@ -119,6 +320,7 @@
         catalogError={$functionStore.catalogError}
         onRetry={() => functionStore.fetchQueryCatalog()}
         onSave={saveCapabilities}
+        onDirtyChange={dirty => (queriesDirty = dirty)}
       />
     {/if}
   </main>
@@ -137,9 +339,67 @@
   }
   .heading {
     display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--spacing-l);
+    margin-bottom: var(--spacing-xl);
+  }
+  .heading > div:first-child,
+  .source-editor,
+  .diagnostics {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-s);
+  }
+  .title,
+  .actions,
+  .section-heading,
+  .validating,
+  .action-error,
+  .diagnostic {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s);
+  }
+  .section-heading {
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+  .section-heading > div:first-child {
+    display: flex;
     flex-direction: column;
     gap: var(--spacing-xs);
+  }
+  .source-editor {
+    gap: var(--spacing-m);
     margin-bottom: var(--spacing-xl);
+  }
+  .action-error {
+    margin-bottom: var(--spacing-l);
+    padding: var(--spacing-m);
+    border: 1px solid var(--spectrum-global-color-red-400);
+    border-radius: var(--radius-m);
+    color: var(--spectrum-global-color-red-700);
+  }
+  .action-error span {
+    flex: 1;
+  }
+  .diagnostics {
+    max-height: 180px;
+    overflow: auto;
+    padding: var(--spacing-m);
+    border: 1px solid var(--spectrum-global-color-red-300);
+    border-radius: var(--radius-m);
+    background: var(--spectrum-global-color-red-100);
+  }
+  .diagnostic {
+    align-items: flex-start;
+    color: var(--spectrum-global-color-red-800);
+    font-size: 12px;
+  }
+  .diagnostic code,
+  .diagnostic > span:first-of-type {
+    flex: 0 0 auto;
   }
   .state {
     display: flex;

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/functionCompletions.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/functionCompletions.spec.ts
@@ -1,0 +1,47 @@
+import type { FunctionQueryCapability } from "@budibase/types"
+import { describe, expect, it } from "vitest"
+import {
+  getFunctionDatasourceCompletions,
+  getFunctionQueryCompletions,
+} from "./functionCompletions"
+
+const capabilities: FunctionQueryCapability[] = [
+  {
+    capabilityId: "cap_customer",
+    queryId: "query_customer",
+    datasourceAlias: "crm",
+    queryAlias: "findCustomer",
+    parameterNames: ["customerId"],
+  },
+  {
+    capabilityId: "cap_order",
+    queryId: "query_order",
+    datasourceAlias: "crm",
+    queryAlias: "findOrder",
+    parameterNames: [],
+  },
+  {
+    capabilityId: "cap_event",
+    queryId: "query_event",
+    datasourceAlias: "events",
+    queryAlias: "send",
+    parameterNames: ["body"],
+  },
+]
+
+describe("Function completions", () => {
+  it("includes each explicitly linked datasource once", () => {
+    expect(getFunctionDatasourceCompletions(capabilities)).toEqual([
+      "crm",
+      "events",
+    ])
+  })
+
+  it("only includes queries linked beneath the selected datasource", () => {
+    expect(getFunctionQueryCompletions(capabilities, "crm")).toEqual([
+      { label: "findCustomer", parameterNames: ["customerId"] },
+      { label: "findOrder", parameterNames: [] },
+    ])
+    expect(getFunctionQueryCompletions(capabilities, "missing")).toEqual([])
+  })
+})

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/functionCompletions.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/functionCompletions.ts
@@ -1,0 +1,16 @@
+import type { FunctionQueryCapability } from "@budibase/types"
+
+export const getFunctionDatasourceCompletions = (
+  capabilities: FunctionQueryCapability[]
+) => [...new Set(capabilities.map(item => item.datasourceAlias))]
+
+export const getFunctionQueryCompletions = (
+  capabilities: FunctionQueryCapability[],
+  datasourceAlias: string
+) =>
+  capabilities
+    .filter(item => item.datasourceAlias === datasourceAlias)
+    .map(item => ({
+      label: item.queryAlias,
+      parameterNames: item.parameterNames,
+    }))

--- a/packages/builder/src/stores/builder/functions.ts
+++ b/packages/builder/src/stores/builder/functions.ts
@@ -3,6 +3,7 @@ import { duplicateName } from "@/helpers/duplicate"
 import { getErrorMessage } from "@/helpers/errors"
 import { BudiStore } from "@/stores/BudiStore"
 import type {
+  CompileFunctionRequest,
   CreateFunctionRequest,
   FunctionQueryCapabilityInput,
   FunctionQueryCatalogEntry,
@@ -144,6 +145,19 @@ export class FunctionStore extends BudiStore<FunctionStoreState> {
 
   async save(fn: FunctionResponse, request: UpdateFunctionRequest) {
     const response = await API.updateFunction(fn._id, request)
+    this.upsert(response.function)
+    return response.function
+  }
+
+  async compile(request: CompileFunctionRequest) {
+    return await API.compileFunction(request)
+  }
+
+  async build(fn: FunctionResponse) {
+    if (!fn._rev) {
+      throw new Error("Function revision is missing")
+    }
+    const response = await API.buildFunction(fn._id, fn._rev)
     this.upsert(response.function)
     return response.function
   }

--- a/packages/builder/src/stores/builder/tests/functions.spec.ts
+++ b/packages/builder/src/stores/builder/tests/functions.spec.ts
@@ -10,6 +10,8 @@ vi.mock("@/api", () => ({
     getFunctions: vi.fn(),
     getFunctionQueryCatalog: vi.fn(),
     getFunction: vi.fn(),
+    compileFunction: vi.fn(),
+    buildFunction: vi.fn(),
     createFunction: vi.fn(),
     updateFunction: vi.fn(),
     deleteFunction: vi.fn(),
@@ -204,6 +206,48 @@ describe("FunctionStore", () => {
       name: fn.name,
       _rev: fn._rev,
     })
+  })
+
+  it("validates an unsaved draft without changing the stored Function", async () => {
+    const fn = makeFunction()
+    const request = {
+      functionId: fn._id,
+      name: fn.name,
+      source: "invalid TypeScript",
+      capabilities: [],
+    }
+    vi.mocked(API.compileFunction).mockResolvedValue({
+      diagnostics: [{ code: "TS2304", message: "Cannot find name" }],
+    })
+
+    await expect(store.compile(request)).resolves.toEqual({
+      diagnostics: [{ code: "TS2304", message: "Cannot find name" }],
+    })
+
+    expect(API.compileFunction).toHaveBeenCalledWith(request)
+    expect(store.list).toEqual([])
+  })
+
+  it("builds the saved revision and stores its new readiness", async () => {
+    const fn = makeFunction({ readiness: "build_required" })
+    const built = makeFunction({ _rev: "2-two", readiness: "ready" })
+    vi.mocked(API.buildFunction).mockResolvedValue({ function: built })
+
+    await expect(store.build(fn)).resolves.toEqual(built)
+
+    expect(API.buildFunction).toHaveBeenCalledWith(fn._id, fn._rev)
+    expect(store.list[0]).toEqual(
+      expect.objectContaining({ _rev: "2-two", readiness: "ready" })
+    )
+  })
+
+  it("requires a revision before building", async () => {
+    const fn = makeFunction({ _rev: undefined })
+
+    await expect(store.build(fn)).rejects.toThrow(
+      "Function revision is missing"
+    )
+    expect(API.buildFunction).not.toHaveBeenCalled()
   })
 
   it("duplicates the draft without copying server-owned metadata", async () => {

--- a/packages/frontend-core/src/api/functions.ts
+++ b/packages/frontend-core/src/api/functions.ts
@@ -1,4 +1,7 @@
 import type {
+  BuildFunctionResponse,
+  CompileFunctionRequest,
+  CompileFunctionResponse,
   CreateFunctionRequest,
   CreateFunctionResponse,
   FetchFunctionResponse,
@@ -13,6 +16,13 @@ export interface FunctionEndpoints {
   getFunctions: () => Promise<FetchFunctionsResponse>
   getFunctionQueryCatalog: () => Promise<FetchFunctionQueryCatalogResponse>
   getFunction: (functionId: string) => Promise<FetchFunctionResponse>
+  compileFunction: (
+    fn: CompileFunctionRequest
+  ) => Promise<CompileFunctionResponse>
+  buildFunction: (
+    functionId: string,
+    revision: string
+  ) => Promise<BuildFunctionResponse>
   createFunction: (fn: CreateFunctionRequest) => Promise<CreateFunctionResponse>
   updateFunction: (
     functionId: string,
@@ -39,6 +49,20 @@ export const buildFunctionEndpoints = (
   getFunction: async functionId => {
     return await API.get({
       url: `/api/functions/${functionId}`,
+    })
+  },
+
+  compileFunction: async fn => {
+    return await API.post({
+      url: "/api/functions/compile",
+      body: fn,
+    })
+  },
+
+  buildFunction: async (functionId, revision) => {
+    return await API.post({
+      url: `/api/functions/${functionId}/build`,
+      body: { _rev: revision },
     })
   },
 

--- a/packages/types/src/api/web/workspace/function.ts
+++ b/packages/types/src/api/web/workspace/function.ts
@@ -1,4 +1,7 @@
-import type { FunctionDocument } from "../../../documents"
+import type {
+  FunctionBuildDiagnostic,
+  FunctionDocument,
+} from "../../../documents"
 import type { SourceName } from "../../../sdk"
 
 export type FunctionReadiness = "ready" | "build_required" | "build_failed"
@@ -38,6 +41,22 @@ export interface FetchFunctionResponse {
 }
 
 export interface UpdateFunctionResponse {
+  function: FunctionResponse
+}
+
+export interface CompileFunctionRequest extends FunctionDraftRequest {
+  functionId?: string
+}
+
+export interface CompileFunctionResponse {
+  diagnostics: FunctionBuildDiagnostic[]
+}
+
+export interface BuildFunctionRequest {
+  _rev: string
+}
+
+export interface BuildFunctionResponse {
   function: FunctionResponse
 }
 


### PR DESCRIPTION
## Description
Adds the CodeMirror 6 TypeScript authoring experience and Function draft build lifecycle on top of the Functions query-alias UI.

## Addresses
- https://github.com/Budibase/budibase/issues/19271

## Launchcontrol
- Function authors can edit TypeScript with linked-query completions, save invalid drafts, review compiler diagnostics, and build saved revisions into a ready Function.