### PR TITLE
Remove _ from svelte params in declarations

### DIFF
--- a/packages/bbui/src/FancyForm/FancyField.svelte
+++ b/packages/bbui/src/FancyForm/FancyField.svelte
@@ -7,7 +7,7 @@
   export let error: string | null = null
   export let focused: boolean = false
   export let clickable: boolean = false
-  export let validate: ((_value: V | undefined) => string | null) | null
+  export let validate: ((value: V | undefined) => string | null) | null
   export let value: V | undefined
   export let ref: HTMLDivElement | undefined = undefined
   export let autoHeight: boolean | undefined = undefined

--- a/packages/bbui/src/FancyForm/FancyInput.svelte
+++ b/packages/bbui/src/FancyForm/FancyInput.svelte
@@ -10,7 +10,7 @@
   export let type: string = "text"
   export let disabled: boolean = false
   export let error: string | null = null
-  export let validate: ((_value: string | undefined) => string | null) | null =
+  export let validate: ((value: string | undefined) => string | null) | null =
     null
   export let suffix: string | null = null
   export let validateOn: "change" | "blur" = "change"

--- a/packages/bbui/src/FancyForm/FancySelect.svelte
+++ b/packages/bbui/src/FancyForm/FancySelect.svelte
@@ -10,7 +10,7 @@
   export let value: string | undefined
   export let disabled: boolean = false
   export let error: string | null = null
-  export let validate: ((_value: string | undefined) => string) | null = null
+  export let validate: ((value: string | undefined) => string) | null = null
   export let options: O[] = []
   export let footer: string | undefined = undefined
   export let isOptionEnabled = (_option: O) => true
@@ -21,8 +21,8 @@
   export let getOptionSubtitle = (option: O) =>
     extractProperty(option, "subtitle")
   export let getOptionColour: (
-    _option: O,
-    _index?: number
+    option: O,
+    index?: number
   ) => string | null = () => null
 
   const dispatch = createEventDispatcher<{ change: string | undefined }>()
@@ -35,7 +35,7 @@
   $: fieldColour = getFieldAttribute(getOptionColour, value, options)
 
   const getFieldAttribute = (
-    getAttribute: (_option: O, _index?: number) => string | null,
+    getAttribute: (option: O, index?: number) => string | null,
     value: string | undefined,
     options: O[]
   ) => {

--- a/packages/bbui/src/Form/Combobox.svelte
+++ b/packages/bbui/src/Form/Combobox.svelte
@@ -41,7 +41,7 @@
   const defaultGetOptionLabel = (item: O) => extractProperty(item, "label")
   const defaultGetOptionValue = (item: O) => extractProperty(item, "value")
 
-  type OptionFormatter = (_option: O) => string
+  type OptionFormatter = (option: O) => string
 
   export let getOptionLabel: OptionFormatter = defaultGetOptionLabel
   export let getOptionValue: OptionFormatter = defaultGetOptionValue

--- a/packages/bbui/src/Form/Core/Dropzone.svelte
+++ b/packages/bbui/src/Form/Core/Dropzone.svelte
@@ -19,14 +19,13 @@
   export let disabled: boolean = false
   export let compact: boolean = false
   export let fileSizeLimit: number = BYTES_IN_MB * 20
-  export let processFiles: ((_files: FileList) => Promise<Value[]>) | null =
-    null
-  export let deleteAttachments: ((_keys: string[]) => Promise<void>) | null =
+  export let processFiles: ((files: FileList) => Promise<Value[]>) | null = null
+  export let deleteAttachments: ((keys: string[]) => Promise<void>) | null =
     null
   export let handleFileTooLarge:
-    | ((_limit: number, _currentFiles: Value[]) => void)
+    | ((limit: number, currentFiles: Value[]) => void)
     | null = null
-  export let handleTooManyFiles: ((_maximum: number) => void) | null = null
+  export let handleTooManyFiles: ((maximum: number) => void) | null = null
   export let gallery: boolean = true
   export let fileTags: string[] = []
   export let maximum: number | undefined = undefined

--- a/packages/bbui/src/Form/Core/File.svelte
+++ b/packages/bbui/src/Form/Core/File.svelte
@@ -15,7 +15,7 @@
   export let hideButtonWhenSet: boolean = false
   export let allowClear: boolean | undefined = undefined
   export let extensions: string[] | undefined = undefined
-  export let handleFileTooLarge: ((_file: File) => void) | undefined = undefined
+  export let handleFileTooLarge: ((file: File) => void) | undefined = undefined
   export let fileSizeLimit: number = BYTES_IN_MB * 20
   export let id: string | undefined = undefined
   export let previewUrl: string | undefined = undefined

--- a/packages/bbui/src/Form/Core/Picker.svelte
+++ b/packages/bbui/src/Form/Core/Picker.svelte
@@ -36,9 +36,9 @@
   export let isOptionEnabled = (option: O, _index?: number) =>
     option as unknown as boolean
   export let tooltipMessage:
-    | ((_option: O, _index?: number) => string)
+    | ((option: O, index?: number) => string)
     | undefined = undefined
-  export let onSelectOption: (_value: V) => void = () => {}
+  export let onSelectOption: (value: V) => void = () => {}
   export let getOptionLabel = (option: O, _index?: number) => `${option}`
   export let getOptionValue = (option: O, _index?: number) =>
     option as unknown as V
@@ -65,14 +65,8 @@
   export let footer: string | undefined = undefined
   export let customAnchor: HTMLElement | undefined = undefined
   export let loading: boolean = false
-  export let onOptionMouseenter: (
-    _e: MouseEvent,
-    _option: any
-  ) => void = () => {}
-  export let onOptionMouseleave: (
-    _e: MouseEvent,
-    _option: any
-  ) => void = () => {}
+  export let onOptionMouseenter: (e: MouseEvent, option: any) => void = () => {}
+  export let onOptionMouseleave: (e: MouseEvent, option: any) => void = () => {}
   export let showSelectAll: boolean = false
   export let selectAllText: string = "Select all"
   export let indeterminate: boolean = false
@@ -151,7 +145,7 @@
 
   const getSortedOptions = (
     options: any[],
-    getLabel: (_option: any) => string,
+    getLabel: (option: any) => string,
     sort: boolean
   ) => {
     if (!options?.length || !Array.isArray(options)) {
@@ -170,7 +164,7 @@
   const getFilteredOptions = (
     options: any[],
     term: string | null,
-    getLabel: (_option: any) => string
+    getLabel: (option: any) => string
   ) => {
     if (autocomplete && term) {
       const lowerCaseTerm = term.toLowerCase()

--- a/packages/bbui/src/Form/Core/Select.svelte
+++ b/packages/bbui/src/Form/Core/Select.svelte
@@ -30,7 +30,7 @@
   export let isOptionEnabled = (option: O, _index?: number) =>
     option as unknown as boolean
   export let tooltipMessage:
-    | ((_option: O, _index?: number) => string)
+    | ((option: O, index?: number) => string)
     | undefined = undefined
   export let readonly: boolean = false
   export let size: "S" | "M" | "L" = "M"

--- a/packages/bbui/src/Form/Dropzone.svelte
+++ b/packages/bbui/src/Form/Dropzone.svelte
@@ -10,16 +10,15 @@
   export let disabled: boolean = false
   export let error: string | undefined | false = undefined
   export let fileSizeLimit: number | undefined = undefined
-  export let processFiles:
-    | ((_files: FileList) => Promise<Value[]>)
-    | undefined = undefined
+  export let processFiles: ((files: FileList) => Promise<Value[]>) | undefined =
+    undefined
   export let deleteAttachments:
-    | ((_keys: string[]) => Promise<void>)
+    | ((keys: string[]) => Promise<void>)
     | undefined = undefined
   export let handleFileTooLarge:
-    | ((_limit: number, _currentFiles: Value[]) => void)
+    | ((limit: number, currentFiles: Value[]) => void)
     | undefined = undefined
-  export let handleTooManyFiles: ((_maximum: number) => void) | undefined =
+  export let handleTooManyFiles: ((maximum: number) => void) | undefined =
     undefined
   export let gallery: boolean = true
   export let fileTags: string[] = []

--- a/packages/bbui/src/Form/File.svelte
+++ b/packages/bbui/src/Form/File.svelte
@@ -10,7 +10,7 @@
   export let loading: boolean = false
   export let hideButtonWhenSet: boolean = false
   export let allowClear: boolean | undefined = undefined
-  export let handleFileTooLarge: (_file: File) => void = () => {}
+  export let handleFileTooLarge: (file: File) => void = () => {}
   export let previewUrl: string | undefined = undefined
   export let extensions: string[] | undefined = undefined
   export let error: string | undefined = undefined

--- a/packages/bbui/src/Form/Select.svelte
+++ b/packages/bbui/src/Form/Select.svelte
@@ -31,7 +31,7 @@
     (option as any)?.colour
   export let useOptionIconImage = false
   export let isOptionEnabled:
-    | ((_option: O, _index?: number) => boolean)
+    | ((option: O, index?: number) => boolean)
     | undefined = undefined
   export let quiet: boolean = false
   export let size: "S" | "M" | "L" = "M"
@@ -41,7 +41,7 @@
   export let sort: boolean = false
   export let tooltip: string | undefined = undefined
   export let tooltipMessage:
-    | ((_option: O, _index?: number) => string)
+    | ((option: O, index?: number) => string)
     | undefined = undefined
   export let autocomplete: boolean = false
   export let customPopoverHeight: string | undefined = undefined

--- a/packages/bbui/src/Markdown/MarkdownEditor.svelte
+++ b/packages/bbui/src/Markdown/MarkdownEditor.svelte
@@ -18,7 +18,7 @@
   let latestValue: string | null
   interface EditorInstance extends EasyMDE {
     togglePreview: () => void
-    value: (_value?: string) => string
+    value: (value?: string) => string
   }
   let mde: EditorInstance | null = null
   let blurBoundTo: EditorInstance | null = null

--- a/packages/bbui/src/Modal/ModalContent.svelte
+++ b/packages/bbui/src/Modal/ModalContent.svelte
@@ -26,7 +26,7 @@
 
   export let showSecondaryButton: boolean = false
   export let secondaryButtonText: string | undefined = undefined
-  export let secondaryAction: ((_e: Event) => Promise<any> | any) | undefined =
+  export let secondaryAction: ((e: Event) => Promise<any> | any) | undefined =
     undefined
   export let secondaryButtonWarning: boolean = false
   export let custom: boolean = false

--- a/packages/bbui/src/Notification/Notification.svelte
+++ b/packages/bbui/src/Notification/Notification.svelte
@@ -9,7 +9,7 @@
   export let message: string = ""
   export let dismissable: boolean = false
   export let actionMessage: string | null = null
-  export let action: ((_dismiss: () => void) => void) | null = null
+  export let action: ((dismiss: () => void) => void) | null = null
   export let wide: boolean = false
 
   const dispatch = createEventDispatcher<{ dismiss: void }>()

--- a/packages/bbui/src/Table/SelectEditRenderer.svelte
+++ b/packages/bbui/src/Table/SelectEditRenderer.svelte
@@ -3,7 +3,7 @@
   import Checkbox from "../Form/Checkbox.svelte"
 
   export let selected: boolean | undefined
-  export let onEdit: (_e: Event) => void
+  export let onEdit: (e: Event) => void
   export let allowSelectRows: boolean = false
   export let allowEditRows: boolean = false
   export let data: Record<string, any>

--- a/packages/bbui/src/Tabs/Tabs.svelte
+++ b/packages/bbui/src/Tabs/Tabs.svelte
@@ -27,7 +27,7 @@
   export let onTop: boolean = false
   export let size: "S" | "M" | "L" = "M"
   export let disabled: boolean = false
-  export let beforeSwitch: ((_title: string) => boolean) | null = null
+  export let beforeSwitch: ((title: string) => boolean) | null = null
   export let hideTabsList: boolean = false
 
   let thisSelected: string | undefined = undefined

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/nodes/StepNode.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowCanvas/nodes/StepNode.svelte
@@ -21,7 +21,7 @@
   export let viewMode: ViewMode.EDITOR | ViewMode.LOGS = ViewMode.EDITOR
   export let selectedLogStepId: string | null = null
   export let onStepSelect: (
-    _data: AutomationStepResult | AutomationTriggerResult
+    data: AutomationStepResult | AutomationTriggerResult
   ) => void = () => {}
   const memoEnvVariables = memo($environment.variables)
 

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/FlowItem.svelte
@@ -48,7 +48,7 @@
   export let selectedLogStepId: string | null = null
   export let unexecuted: boolean = false
   export let onStepSelect: (
-    _data: AutomationStepResult | AutomationTriggerResult
+    data: AutomationStepResult | AutomationTriggerResult
   ) => void = () => {}
   const view = getContext<Writable<DragView>>("draggableView")
   const contentPos =

--- a/packages/builder/src/components/automation/AutomationBuilder/FlowChart/LogFlowItem.svelte
+++ b/packages/builder/src/components/automation/AutomationBuilder/FlowChart/LogFlowItem.svelte
@@ -22,7 +22,7 @@
   export let logData: AutomationLog | null = null
   export let selectedLogStepId: string | null = null
   export let onStepSelect: (
-    _data: AutomationStepResult | AutomationTriggerResult
+    data: AutomationStepResult | AutomationTriggerResult
   ) => void = () => {}
 
   const view = getContext<Writable<DragView>>("draggableView")

--- a/packages/builder/src/components/backend/DataTable/buttons/DeleteRowsButton.svelte
+++ b/packages/builder/src/components/backend/DataTable/buttons/DeleteRowsButton.svelte
@@ -9,7 +9,7 @@
   }
 
   export let selectedRows: unknown[] = []
-  export let deleteRows: (_rows: unknown[]) => void | Promise<void>
+  export let deleteRows: (rows: unknown[]) => void | Promise<void>
   export let item: string = "row"
   export let action: string = "Delete"
   export let confirmationTitle: string | undefined

--- a/packages/builder/src/components/backend/Datasources/ConfigEditor/index.svelte
+++ b/packages/builder/src/components/backend/Datasources/ConfigEditor/index.svelte
@@ -10,7 +10,7 @@
 
   export let integration: UIIntegration
   export let config: Record<string, any>
-  export let onSubmit: (_value: {
+  export let onSubmit: (value: {
     config: Record<string, any>
     name: string
     projectIds?: string[]

--- a/packages/builder/src/components/common/NavHeader.svelte
+++ b/packages/builder/src/components/common/NavHeader.svelte
@@ -12,7 +12,7 @@
   export let title: string | undefined = undefined
   export let placeholder: string = ""
   export let value: string | undefined = undefined
-  export let onAdd: ((_e: Event) => void) | undefined = undefined
+  export let onAdd: ((e: Event) => void) | undefined = undefined
   export let search: boolean = false
   export let searchable = true
   export let showAddIcon = true

--- a/packages/builder/src/components/common/RoleSelect.svelte
+++ b/packages/builder/src/components/common/RoleSelect.svelte
@@ -50,7 +50,7 @@
     allowRemove: boolean,
     allowedRoles: string[] | null,
     allowCreator: boolean,
-    enrichLabel: (_label: string) => string
+    enrichLabel: (label: string) => string
   ): RoleOption[] => {
     // Use roles whitelist if specified
     if (allowedRoles?.length) {

--- a/packages/builder/src/components/common/ai/AIInput.svelte
+++ b/packages/builder/src/components/common/ai/AIInput.svelte
@@ -5,7 +5,7 @@
   import { createEventDispatcher } from "svelte"
   import BBAI from "assets/bb-ai.svg"
 
-  export let onSubmit: (_prompt: string) => Promise<void>
+  export let onSubmit: (prompt: string) => Promise<void>
   export let placeholder: string = ""
   export let expanded: boolean = false
   export let expandedOnly: boolean = false

--- a/packages/builder/src/components/common/bindings/BindingSidePanel.svelte
+++ b/packages/builder/src/components/common/bindings/BindingSidePanel.svelte
@@ -21,9 +21,9 @@
   import SnippetDrawer from "./SnippetDrawer.svelte"
   import UpgradeButton from "@/pages/builder/_components/UpgradeButton.svelte"
 
-  export let addHelper: (_helper: Helper, _js?: boolean) => void = () => {}
-  export let addBinding: (_binding: EnrichedBinding) => void = () => {}
-  export let addSnippet: (_snippet: Snippet) => void = () => {}
+  export let addHelper: (helper: Helper, js?: boolean) => void = () => {}
+  export let addBinding: (binding: EnrichedBinding) => void = () => {}
+  export let addSnippet: (snippet: Snippet) => void = () => {}
   export let bindings: EnrichedBinding[] | undefined
   export let snippets: Snippet[] | null = null
   export let mode: BindingMode | undefined = BindingMode.Text

--- a/packages/builder/src/components/design/ScreenDetailsModal.svelte
+++ b/packages/builder/src/components/design/ScreenDetailsModal.svelte
@@ -5,7 +5,7 @@
   import { screenStore, workspaceAppStore, appStore } from "@/stores/builder"
   import { buildLiveUrl } from "@/helpers/urls"
 
-  export let onConfirm: (_data: { route: string }) => Promise<void>
+  export let onConfirm: (data: { route: string }) => Promise<void>
   export let onCancel: (() => Promise<void>) | undefined = undefined
   export let route: string = ""
   export let role: string | undefined = undefined

--- a/packages/builder/src/components/projects/AssignProjectModal.svelte
+++ b/packages/builder/src/components/projects/AssignProjectModal.svelte
@@ -12,7 +12,7 @@
 
   interface Props {
     resource?: AssignableProjectResource | null
-    onConfirm?: (_projectIds: string[]) => unknown
+    onConfirm?: (projectIds: string[]) => unknown
   }
 
   let { resource = null, onConfirm = () => {} }: Props = $props()

--- a/packages/builder/src/components/settings/UserGroupPicker.svelte
+++ b/packages/builder/src/components/settings/UserGroupPicker.svelte
@@ -18,7 +18,7 @@
   export let labelKey: string
   export let iconComponent: ComponentType | null = null
   export let extractIconProps: (
-    _item: EnrichedPickerItem
+    item: EnrichedPickerItem
   ) => Record<string, unknown> = item => item
 
   const dispatch = createEventDispatcher<{

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/_components/SideNav/SideNav.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/_components/SideNav/SideNav.svelte
@@ -85,7 +85,7 @@
   $goto
   $url
 
-  type ResourceLinkFn = (_id: string) => string
+  type ResourceLinkFn = (id: string) => string
 
   interface UIFavouriteResource {
     name: string

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/AgentChatPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/AgentChatPanel.svelte
@@ -32,7 +32,7 @@
 
   // Preview is transient, so escalation polling lives here, not in Chatbox.
   let chatbox = $state<
-    | { appendAssistantMessage: (_m: UIMessage<AgentMessageMetadata>) => void }
+    | { appendAssistantMessage: (m: UIMessage<AgentMessageMetadata>) => void }
     | undefined
   >()
   const delivered = new Set<string>()

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/GenerateInstructionsControl.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/GenerateInstructionsControl.svelte
@@ -19,7 +19,7 @@
     promptInstructions?: string
     promptBindings?: EnrichedBinding[]
     bindingIcons?: Record<string, string | undefined>
-    onApplyInstructions?: (_instructions: string) => void
+    onApplyInstructions?: (instructions: string) => void
     triggerLabel?: string
   }
 

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/LogComponents/LogsSessionDetail.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/LogComponents/LogsSessionDetail.svelte
@@ -13,7 +13,7 @@
     expandedStepId: string | null
     expandedStepDetail: AgentLogRequestDetail | null
     expandedStepLoading: boolean
-    onToggleStep: (_entry: AgentLogEntry) => void | Promise<void>
+    onToggleStep: (entry: AgentLogEntry) => void | Promise<void>
   }
 
   let {

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/LogComponents/LogsSessionList.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/LogComponents/LogsSessionList.svelte
@@ -20,7 +20,7 @@
     statusFilter?: string
     dateRange?: [Dayjs | null, Dayjs | null]
     triggerFilter?: string
-    onSessionRowClick: (_row: { sessionId?: string }) => void
+    onSessionRowClick: (row: { sessionId?: string }) => void
     onLoadMore: () => void | Promise<void>
   }
 

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/LogComponents/LogsSessionStep.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/LogComponents/LogsSessionStep.svelte
@@ -18,7 +18,7 @@
     expanded: boolean
     detail?: AgentLogRequestDetail
     loadingStep: boolean
-    onToggleStep: (_entry: AgentLogEntry) => void | Promise<void>
+    onToggleStep: (entry: AgentLogEntry) => void | Promise<void>
   }
 
   let { entry, index, expanded, detail, loadingStep, onToggleStep }: Props =

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/OperationNameInput.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/OperationNameInput.svelte
@@ -4,7 +4,7 @@
     onSave = (_value: string) => {},
   }: {
     value?: string
-    onSave?: (_value: string) => void
+    onSave?: (value: string) => void
   } = $props()
 
   let editing = $state(false)

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/TestComponents/TestCaseFields.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/TestComponents/TestCaseFields.svelte
@@ -10,9 +10,7 @@
   type Props = {
     selectedCase: AgentTestCase
     groupOptions: GroupOption[]
-    onUpdateCase: (
-      _updater: (_testCase: AgentTestCase) => AgentTestCase
-    ) => void
+    onUpdateCase: (updater: (testCase: AgentTestCase) => AgentTestCase) => void
   }
 
   let { selectedCase, groupOptions, onUpdateCase }: Props = $props()

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/TestComponents/TestCaseList.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/TestComponents/TestCaseList.svelte
@@ -35,17 +35,17 @@
     runningCaseIds: Set<string>
     hasLatestRun: boolean
     latestResultsByCaseId: Map<string, AgentTestCaseResult[]>
-    onSelectCase: (_caseId: string) => void
-    onSelectGroup: (_groupId: string) => void
+    onSelectCase: (caseId: string) => void
+    onSelectGroup: (groupId: string) => void
     onCreateGroup: () => void
     onRenameGroup: () => void
     onDeleteGroup: () => void
     onAddCase: () => void
-    onEditCase: (_caseId: string) => void
-    onRunCase: (_caseId: string) => void
+    onEditCase: (caseId: string) => void
+    onRunCase: (caseId: string) => void
     onRunAll: () => void
-    onDuplicateCase: (_caseId: string) => void
-    onRemoveCase: (_caseId: string) => void
+    onDuplicateCase: (caseId: string) => void
+    onRemoveCase: (caseId: string) => void
   }
 
   let {

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/TestComponents/TestCaseModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/TestComponents/TestCaseModal.svelte
@@ -16,9 +16,9 @@
     groupOptions: ToolOption[]
     aiConfigOptions: AIConfigOption[]
     defaultAiConfigId?: string
-    isExisting: (_id: string) => boolean
+    isExisting: (id: string) => boolean
     disabled?: boolean
-    onSave: (_testCase: AgentTestCase) => Promise<boolean>
+    onSave: (testCase: AgentTestCase) => Promise<boolean>
   }
 
   let {
@@ -75,7 +75,7 @@
   }
 
   const updateDraftCase = (
-    updater: (_testCase: AgentTestCase) => AgentTestCase
+    updater: (testCase: AgentTestCase) => AgentTestCase
   ) => {
     if (!draftCase) return
     draftCase = updater(draftCase)

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/TestComponents/TestGroupModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/TestComponents/TestGroupModal.svelte
@@ -5,7 +5,7 @@
   type Props = {
     disabled?: boolean
     onSave: (
-      _group: AgentTestGroup | Omit<AgentTestGroup, "id">
+      group: AgentTestGroup | Omit<AgentTestGroup, "id">
     ) => Promise<boolean>
   }
 

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/TestComponents/TestReviewersEditor.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/TestComponents/TestReviewersEditor.svelte
@@ -24,9 +24,7 @@
     selectedCase: AgentTestCase
     toolOptions: ToolOption[]
     operationOptions: OperationOption[]
-    onUpdateCase: (
-      _updater: (_testCase: AgentTestCase) => AgentTestCase
-    ) => void
+    onUpdateCase: (updater: (testCase: AgentTestCase) => AgentTestCase) => void
   }
 
   let { selectedCase, toolOptions, operationOptions, onUpdateCase }: Props =

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/ToolsDropdown.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/ToolsDropdown.svelte
@@ -11,7 +11,7 @@
     toolSections: Record<string, AgentTool[]>
     toolSearch: string
     webSearchEnabled: boolean
-    onToolClick: (_tool: AgentTool) => void
+    onToolClick: (tool: AgentTool) => void
     onAddApiConnection: () => void
     onConfigureWebSearch: () => void
   }

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/knowledge/KnowledgeTable.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/knowledge/KnowledgeTable.svelte
@@ -10,7 +10,7 @@
     loading: boolean
     isUploading?: boolean
     rows: KnowledgeTableRow[]
-    onRowClick?: (_row: KnowledgeTableRow) => void
+    onRowClick?: (row: KnowledgeTableRow) => void
   }
 
   let { loading, isUploading = false, rows, onRowClick }: Props = $props()

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/knowledge/new/SelectSharePointSiteModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/knowledge/new/SelectSharePointSiteModal.svelte
@@ -16,8 +16,8 @@
     operationId: string
     existingSiteIds?: string[]
     onCreated?: (
-      _siteId: string,
-      _mode: SharePointSelectionMode
+      siteId: string,
+      mode: SharePointSelectionMode
     ) => Promise<void> | void
   }
 

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/knowledge/new/SharePointConnectionStepModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/knowledge/new/SharePointConnectionStepModal.svelte
@@ -21,7 +21,7 @@
     hasSharePointDatasource?: boolean
     onNext: () => Promise<void> | void
     onConfigure: () => Promise<void> | void
-    onConnectionChange: (_connectionId: string) => void
+    onConnectionChange: (connectionId: string) => void
   }
 
   let {

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/knowledge/new/SharePointSiteStepModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/knowledge/new/SharePointSiteStepModal.svelte
@@ -16,8 +16,8 @@
     saving?: boolean
     showBack?: boolean
     onBack: () => Promise<void> | void
-    onSelect: (_mode: SharePointSelectionMode) => Promise<void> | void
-    onSiteChange: (_siteId: string) => void
+    onSelect: (mode: SharePointSelectionMode) => Promise<void> | void
+    onSiteChange: (siteId: string) => void
   }
 
   let {

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/knowledge/sharepoint/DisplaySharePointSiteModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/knowledge/sharepoint/DisplaySharePointSiteModal.svelte
@@ -19,7 +19,7 @@
     agentId?: string
     operationId: string
     siteId?: string
-    onEdit?: (_siteId: string) => Promise<void> | void
+    onEdit?: (siteId: string) => Promise<void> | void
   }
 
   let { agentId, operationId, siteId, onEdit }: Props = $props()

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/knowledge/sharepoint/tree/SharePointEntryTreeItem.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/agent/[agentId]/knowledge/sharepoint/tree/SharePointEntryTreeItem.svelte
@@ -18,7 +18,7 @@
     node: SharePointEntryTreeNode
     selectedPaths?: string[]
     fileDescendantPathsByNodePath?: Map<string, string[]>
-    onTogglePaths?: (_paths: string[], _nextSelected: boolean) => void
+    onTogglePaths?: (paths: string[], nextSelected: boolean) => void
     showStatus?: boolean
   }
 

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/chat/_components/AgentList.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/chat/_components/AgentList.svelte
@@ -4,9 +4,9 @@
 
   export let resolvedDefaultAgent: AgentListItem | undefined
   export let otherAgents: AgentListItem[] = []
-  export let isAgentAvailable: (_agentId: string) => boolean
-  export let onToggleEnabled: (_agentId: string, _enabled: boolean) => void
-  export let onOpenSettings: (_agent: AgentListItem) => void
+  export let isAgentAvailable: (agentId: string) => boolean
+  export let onToggleEnabled: (agentId: string, enabled: boolean) => void
+  export let onOpenSettings: (agent: AgentListItem) => void
 </script>
 
 <div class="settings-group">

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/chat/_components/AgentSettingsModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/chat/_components/AgentSettingsModal.svelte
@@ -23,15 +23,15 @@
   export let selectedAgentConfig: ChatAppAgent | undefined
   export let defaultAgentId: string | undefined
   export let showDefaultControls = true
-  export let isAgentAvailable: (_agentId: string) => boolean
-  export let onSetDefault: ((_agentId: string) => void) | undefined = undefined
+  export let isAgentAvailable: (agentId: string) => boolean
+  export let onSetDefault: ((agentId: string) => void) | undefined = undefined
   export let onUpdateConversationStarters: (
-    _agentId: string,
-    _starters: ConversationStarter[]
+    agentId: string,
+    starters: ConversationStarter[]
   ) => void
   export let onUpdateAccessRole: (
-    _agentId: string,
-    _roleId?: string
+    agentId: string,
+    roleId?: string
   ) => void = () => {}
   export let onClose: () => void
 

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/chat/_components/ChatSettingsPanel.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/chat/_components/ChatSettingsPanel.svelte
@@ -16,20 +16,20 @@
 
   export let namedAgents: Agent[] = []
   export let agents: ChatAgentConfig[] = []
-  export let isAgentAvailable: (_agentId: string) => boolean
+  export let isAgentAvailable: (agentId: string) => boolean
   export let handleAvailabilityToggle: (
-    _agentId: string,
-    _enabled: boolean
+    agentId: string,
+    enabled: boolean
   ) => void
-  export let handleDefaultToggle: (_agentId: string) => void
-  export let handleAddAgent: (_agentId: string) => void
+  export let handleDefaultToggle: (agentId: string) => void
+  export let handleAddAgent: (agentId: string) => void
   export let handleUpdateConversationStarters: (
-    _agentId: string,
-    _starters: ConversationStarter[]
+    agentId: string,
+    starters: ConversationStarter[]
   ) => void
   export let handleUpdateAccessRole: (
-    _agentId: string,
-    _roleId?: string
+    agentId: string,
+    roleId?: string
   ) => void = () => {}
 
   let selectedAgentId: string | undefined

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/design/_components/NewScreen/AppSelectionModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/design/_components/NewScreen/AppSelectionModal.svelte
@@ -2,7 +2,7 @@
   import { ModalContent, Body, Select } from "@budibase/bbui"
   import { workspaceAppStore } from "@/stores/builder"
 
-  export let onConfirm: (_selectedAppId: string) => Promise<void> | void
+  export let onConfirm: (selectedAppId: string) => Promise<void> | void
   export let selectedAppId: string | undefined = undefined
 
   async function handleConfirm() {

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/design/_components/NewScreen/TypeModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/design/_components/NewScreen/TypeModal.svelte
@@ -13,7 +13,7 @@
 
   export let title: string
   export let types: SelectableType[]
-  export let onConfirm: (_selectedType: string) => Promise<void>
+  export let onConfirm: (selectedType: string) => Promise<void>
   export let showCancelButton: boolean = true
 
   let selectedType: string | null = null

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/design/_components/NewScreen/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/design/_components/NewScreen/index.svelte
@@ -27,7 +27,7 @@
   let title: string
   let rootModal: Modal
   let createScreenModal: CreateScreenModal
-  let cancelHandler: (_e: CustomEvent<ModalCancelFrom>) => void = () => {}
+  let cancelHandler: (e: CustomEvent<ModalCancelFrom>) => void = () => {}
   let selectedType: AutoScreenTypes | undefined
   let currentStepIndex: number
 

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/home/_components/CreateProjectModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/home/_components/CreateProjectModal.svelte
@@ -13,7 +13,7 @@
   import type { ProjectFormPayload, ProjectResponse } from "@budibase/types"
 
   interface Props {
-    onConfirm?: (_payload: ProjectFormPayload) => unknown
+    onConfirm?: (payload: ProjectFormPayload) => unknown
     project?: ProjectResponse
   }
 

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/home/_components/ExportProjectModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/home/_components/ExportProjectModal.svelte
@@ -13,7 +13,7 @@
     projects?: ProjectResponse[]
     selectedProjectId?: string
     projectIdsWithResources?: string[]
-    onConfirm?: (_payload: ConfirmPayload) => unknown
+    onConfirm?: (payload: ConfirmPayload) => unknown
   }
 
   let {

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/home/_components/HomeControls.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/home/_components/HomeControls.svelte
@@ -8,7 +8,7 @@
   interface Props {
     typeFilter?: HomeType
     variant?: "default" | "panel"
-    onTypeChange?: (_type: HomeType) => void
+    onTypeChange?: (type: HomeType) => void
   }
 
   let {

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/home/_components/HomeProjectTabs.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/home/_components/HomeProjectTabs.svelte
@@ -7,7 +7,7 @@
   interface Props {
     projects?: ProjectResponse[]
     selectedProjectId?: string
-    onSelect?: (_projectId: string) => void
+    onSelect?: (projectId: string) => void
     onCreateProject?: () => void
     onEditProject?: () => void
     onDeleteProject?: () => void

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/home/_components/HomeTable.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/home/_components/HomeTable.svelte
@@ -35,14 +35,14 @@
     sortOrder: HomeSortOrder
     variant?: "default" | "panel"
     highlightedRowId?: string | null
-    onOpenRow?: (_row: HomeRow) => void
+    onOpenRow?: (row: HomeRow) => void
     onClearSearch?: () => void
     onResetFilters?: () => void
-    onSortChange?: (_column: HomeSortColumn) => void
+    onSortChange?: (column: HomeSortColumn) => void
     onCreateAgent?: () => void
     onCreateAutomation?: () => void
     onCreateApp?: () => void
-    onOpenContextMenu?: (_payload: ContextMenuPayload) => void
+    onOpenContextMenu?: (payload: ContextMenuPayload) => void
   }
 
   let {

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/home/_components/ImportProjectModal.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/home/_components/ImportProjectModal.svelte
@@ -17,7 +17,7 @@
   }
 
   interface Props {
-    onConfirm?: (_payload: ConfirmPayload) => unknown
+    onConfirm?: (payload: ConfirmPayload) => unknown
   }
 
   let { onConfirm = () => {} }: Props = $props()

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/home/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/home/index.svelte
@@ -150,8 +150,8 @@
   $: if (!projectsEnabled && selectedProjectId) selectedProjectId = ""
 
   let getFavourite: (
-    _resourceType: WorkspaceResource,
-    _resourceId: string
+    resourceType: WorkspaceResource,
+    resourceId: string
   ) => WorkspaceFavourite
 
   $: getFavourite = (resourceType, resourceId) => {

--- a/packages/builder/src/settings/RouteHeader.svelte
+++ b/packages/builder/src/settings/RouteHeader.svelte
@@ -31,7 +31,7 @@
   }
 
   const resolveTitle = (
-    title: string | ((_path: string | undefined) => string) | undefined,
+    title: string | ((path: string | undefined) => string) | undefined,
     path: string | undefined
   ) => {
     if (typeof title === "function") {

--- a/packages/builder/src/settings/components/RouteCrumbs.svelte
+++ b/packages/builder/src/settings/components/RouteCrumbs.svelte
@@ -6,12 +6,12 @@
   export let matched: MatchedRoute | undefined
   export let locked: string | undefined
   export let resolveTitle: (
-    _title: string | ((_path: string | undefined) => string) | undefined,
-    _path: string | undefined
+    title: string | ((path: string | undefined) => string) | undefined,
+    path: string | undefined
   ) => string | undefined
   export let resolvePathParams: (
-    _path: string | undefined,
-    _params: Record<string, string>
+    path: string | undefined,
+    params: Record<string, string>
   ) => string | undefined
 
   $: route = matched?.entry

--- a/packages/builder/src/settings/components/SubtreeCrumbs.svelte
+++ b/packages/builder/src/settings/components/SubtreeCrumbs.svelte
@@ -6,12 +6,12 @@
   export let stack: MatchedRoute[]
   export let currentRoute: MatchedRoute | undefined
   export let resolveTitle: (
-    _title: string | ((_path: string | undefined) => string) | undefined,
-    _path: string | undefined
+    title: string | ((path: string | undefined) => string) | undefined,
+    path: string | undefined
   ) => string | undefined
   export let resolvePathParams: (
-    _path: string | undefined,
-    _params: Record<string, string>
+    path: string | undefined,
+    params: Record<string, string>
   ) => string | undefined
 </script>
 

--- a/packages/builder/src/settings/pages/ai/AIConfigEditor.svelte
+++ b/packages/builder/src/settings/pages/ai/AIConfigEditor.svelte
@@ -25,9 +25,7 @@
     disableProviderOnEdit?: boolean
     setDefaultOnFirstCreate?: boolean
     useRouteProviderOnEdit?: boolean
-    onCreate?:
-      | ((_created: AIConfigResponse) => void | Promise<void>)
-      | undefined
+    onCreate?: ((created: AIConfigResponse) => void | Promise<void>) | undefined
     deleteBlockedMessage?: string | undefined
   }
 

--- a/packages/builder/src/settings/pages/people/users/_components/ImportUsersModal.svelte
+++ b/packages/builder/src/settings/pages/people/users/_components/ImportUsersModal.svelte
@@ -16,7 +16,7 @@
   const FILE_SIZE_LIMIT = BYTES_IN_MB * 5
   const MAX_USERS_UPLOAD_LIMIT = 1000
 
-  export let createUsersFromCsv: (_data: {
+  export let createUsersFromCsv: (data: {
     userEmails: string[]
     usersRole: string
     userGroups: string[]

--- a/packages/client/src/components/app/Calendar.svelte
+++ b/packages/client/src/components/app/Calendar.svelte
@@ -109,7 +109,7 @@
   export let eventEnd: string
   export let eventTitle: string
 
-  export let onClick: ((_payload: CalendarEventPayload) => void) | undefined
+  export let onClick: ((payload: CalendarEventPayload) => void) | undefined
   export let showButtons: boolean
   export let buttonType: CalendarButtonType = "action"
   export let monthText: string = "Month"

--- a/packages/client/src/components/app/Chatbox.svelte
+++ b/packages/client/src/components/app/Chatbox.svelte
@@ -26,8 +26,8 @@
 
   interface ChatboxControllerWithConversationDelete extends ChatboxController {
     deleteConversation: (
-      _conversationId: string,
-      _conversationAgentId?: string
+      conversationId: string,
+      conversationAgentId?: string
     ) => Promise<void>
   }
 

--- a/packages/client/src/components/app/forms/InnerForm.svelte
+++ b/packages/client/src/components/app/forms/InnerForm.svelte
@@ -25,7 +25,7 @@
       defaultValue: T
       disabled: boolean
       readonly: boolean
-      validator: ((_value: T) => string | null) | null
+      validator: ((value: T) => string | null) | null
       error: string | null | undefined
       lastUpdate: number
     }
@@ -111,7 +111,7 @@
   // extracted values from the field array
   const deriveFieldProperty = (
     fieldStores: Readable<FieldInfo>[],
-    getProp: (_field: FieldInfo) => any
+    getProp: (field: FieldInfo) => any
   ) => {
     return derived(fieldStores, fieldValues => {
       return fieldValues.reduce(

--- a/packages/client/src/components/app/forms/RatingField.svelte
+++ b/packages/client/src/components/app/forms/RatingField.svelte
@@ -26,7 +26,7 @@
   export let variant: ColourVariant = "Primary"
 
   export let validation: UIFieldValidationRule[] | undefined
-  export let onChange: (_event: { value: number }) => void
+  export let onChange: (event: { value: number }) => void
 
   let hoverRating: number | null = null
   let fieldState: FieldState

--- a/packages/client/src/components/app/forms/RelationshipField.svelte
+++ b/packages/client/src/components/app/forms/RelationshipField.svelte
@@ -38,7 +38,7 @@
   export let validation: UIFieldValidationRule[] | undefined = undefined
   export let autocomplete: boolean = true
   export let defaultValue: ValueType | undefined = undefined
-  export let onChange: (_props: { value: ValueType; label?: string }) => void
+  export let onChange: (props: { value: ValueType; label?: string }) => void
   export let filter: UISearchFilter | LegacyFilter[] | undefined = undefined
   export let datasourceType: "table" | "user" = "table"
   export let primaryDisplay: string | undefined = undefined

--- a/packages/client/src/components/app/forms/Slider.svelte
+++ b/packages/client/src/components/app/forms/Slider.svelte
@@ -16,7 +16,7 @@
   export let disabled = false
   export let readonly = false
   export let validation: UIFieldValidationRule[] | undefined
-  export let onChange: ((_event: { value: number }) => void) | undefined
+  export let onChange: ((event: { value: number }) => void) | undefined
   export let span = 6
   export let helpText: string | undefined = undefined
   export let iconLeft: string | undefined

--- a/packages/client/src/utils/LegacyHost.svelte
+++ b/packages/client/src/utils/LegacyHost.svelte
@@ -10,7 +10,7 @@
     context?: Map<any, any>
     $$slots?: Record<string, any>
     $$scope?: any
-  }) => { $set?: (_p: any) => void; $destroy?: () => void }
+  }) => { $set?: (p: any) => void; $destroy?: () => void }
 
   let container: HTMLElement
   let instance: any

--- a/packages/frontend-core/src/components/Chatbox/index.svelte
+++ b/packages/frontend-core/src/components/Chatbox/index.svelte
@@ -39,12 +39,12 @@
     persistConversation?: boolean
     conversationStarters?: { prompt: string }[]
     initialPrompt?: string
-    onchatsaved?: (_event: {
+    onchatsaved?: (event: {
       detail: { chatId?: string; chat: ChatConversationLike }
     }) => void
     // Fired when an escalation parks; the consumer polls the outcome and
     // injects it via appendAssistantMessage.
-    onEscalationPending?: (_detail: { escalationId: string }) => void
+    onEscalationPending?: (detail: { escalationId: string }) => void
     // Live resolution per escalationId (from the poll) - drives the card state.
     escalationState?: Record<
       string,
@@ -53,8 +53,8 @@
     // Dev-only: show the inline Approve/Reject buttons on the escalation card.
     showInlineApproval?: boolean
     onResolve?: (
-      _escalationId: string,
-      _accepted: boolean
+      escalationId: string,
+      accepted: boolean
     ) => Promise<EscalationRespondResult | undefined>
     isAgentPreviewChat?: boolean
     readOnly?: boolean


### PR DESCRIPTION
## Description
Remove _ from svelte params in declarations. Not needed since https://github.com/Budibase/budibase/pull/18913/changes#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized Svelte prop and callback typings by removing leading underscores from parameter names across `@budibase/bbui`, builder, client, and frontend-core packages. No runtime changes; improves readability and IDE hints now that unused-parameter suppression is no longer required.

- **Refactors**
  - Renamed callback and validator parameters to descriptive names (e.g., validate(value), onClick(event), onEdit(e)).
  - Aligned option helpers to use option/index naming and updated related generics.
  - Cleaned up file/attachment handlers in Dropzone/File components (e.g., processFiles(files), handleTooManyFiles(maximum)).
  - Minor type fixes for editor, tabs, notifications, chatbox, and form fields to use clear argument names.

<sup>Written for commit a5a9f25238baee92f5daf8a0d43150467f022d11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Budibase/budibase/pull/19392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

