### PR TITLE
[BUDI-19273] Add Function Logs tab and run details

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionLogs.spec.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionLogs.spec.ts
@@ -1,0 +1,215 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/svelte"
+import type {
+  FetchFunctionRunsResponse,
+  FunctionRunSummary,
+  FunctionRunSummaryStatus,
+} from "@budibase/types"
+import { FunctionErrorCode } from "@budibase/types"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import FunctionLogs from "./FunctionLogs.svelte"
+
+const api = vi.hoisted(() => ({
+  getFunctionRuns: vi.fn(),
+  getFunctionRun: vi.fn(),
+}))
+
+vi.mock("@/api", () => ({ API: api }))
+
+const makeRun = (
+  status: FunctionRunSummaryStatus,
+  overrides: Partial<FunctionRunSummary> = {}
+): FunctionRunSummary => ({
+  _id: `function_run_${status}`,
+  runId: `run_${status}`,
+  functionId: "fn_one",
+  functionName: "Customer lookup",
+  sourceHash: `hash_${status}`,
+  environment: "development",
+  status,
+  invocation: {
+    type: "automation",
+    automationId: "automation_one",
+    stepId: "step_one",
+  },
+  startedAt: "2026-07-23T12:00:00.000Z",
+  ...(status === "running"
+    ? {}
+    : {
+        finishedAt: "2026-07-23T12:00:01.500Z",
+        durationMs: 1500,
+      }),
+  queryCount: 2,
+  ...overrides,
+})
+
+const runsResponse = (
+  runs: FunctionRunSummary[],
+  overrides: Partial<FetchFunctionRunsResponse> = {}
+): FetchFunctionRunsResponse => ({
+  runs,
+  hasMore: false,
+  ...overrides,
+})
+
+describe("FunctionLogs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    document.body.className = "spectrum"
+    api.getFunctionRun.mockImplementation(
+      async (_functionId: string, runId: string) => ({
+        run: makeRun("success", { runId }),
+      })
+    )
+  })
+
+  it("renders every status and labels both environments", async () => {
+    api.getFunctionRuns.mockResolvedValue(
+      runsResponse([
+        makeRun("running"),
+        makeRun("success", { environment: "published" }),
+        makeRun("error"),
+        makeRun("stopped", { environment: "published" }),
+      ])
+    )
+
+    const view = render(FunctionLogs, { functionId: "fn_one" })
+
+    await screen.findByText("Running")
+    expect(screen.getByText("Success")).toBeInTheDocument()
+    expect(screen.getByText("Error")).toBeInTheDocument()
+    expect(screen.getByText("Stopped")).toBeInTheDocument()
+    expect(screen.getAllByText("Development")).toHaveLength(2)
+    expect(screen.getAllByText("Published")).toHaveLength(2)
+    expect(screen.getByText("—")).toBeInTheDocument()
+    expect(screen.getAllByText("1.5 s")).toHaveLength(3)
+
+    expect(
+      view.container.querySelector('tr[data-status="success"]')
+    ).toHaveAttribute("data-environment", "published")
+    expect(
+      view.container.querySelector('tr[data-status="error"]')
+    ).toHaveAttribute("data-environment", "development")
+  })
+
+  it("appends bookmark pages without changing merged API order", async () => {
+    api.getFunctionRuns
+      .mockResolvedValueOnce(
+        runsResponse(
+          [
+            makeRun("success", {
+              runId: "newest",
+              environment: "development",
+            }),
+            makeRun("success", {
+              runId: "middle",
+              environment: "published",
+            }),
+          ],
+          { hasMore: true, nextBookmark: "page_two" }
+        )
+      )
+      .mockResolvedValueOnce(
+        runsResponse([
+          makeRun("error", {
+            runId: "oldest",
+            environment: "development",
+          }),
+        ])
+      )
+
+    const view = render(FunctionLogs, { functionId: "fn_one" })
+    await screen.findByRole("button", { name: "Load more" })
+    await fireEvent.click(screen.getByRole("button", { name: "Load more" }))
+
+    await waitFor(() => {
+      expect(view.container.querySelectorAll("tbody tr")).toHaveLength(3)
+    })
+    const rows = Array.from(view.container.querySelectorAll("tbody tr"))
+    expect(rows.map(row => row.getAttribute("data-environment"))).toEqual([
+      "development",
+      "published",
+      "development",
+    ])
+    expect(api.getFunctionRuns).toHaveBeenNthCalledWith(2, "fn_one", {
+      bookmark: "page_two",
+      limit: 20,
+    })
+  })
+
+  it("shows a loading state", () => {
+    api.getFunctionRuns.mockReturnValue(new Promise(() => {}))
+
+    render(FunctionLogs, { functionId: "fn_one" })
+
+    expect(screen.getByTestId("function-logs-loading")).toBeInTheDocument()
+  })
+
+  it("shows an empty state", async () => {
+    api.getFunctionRuns.mockResolvedValue(runsResponse([]))
+
+    render(FunctionLogs, { functionId: "fn_one" })
+
+    expect(await screen.findByTestId("function-logs-empty")).toHaveTextContent(
+      "No Function runs yet"
+    )
+  })
+
+  it("shows an error state and retries", async () => {
+    api.getFunctionRuns
+      .mockRejectedValueOnce(new Error("History unavailable"))
+      .mockResolvedValueOnce(runsResponse([makeRun("success")]))
+
+    render(FunctionLogs, { functionId: "fn_one" })
+
+    const errorState = await screen.findByTestId("function-logs-error")
+    expect(errorState).toHaveTextContent("History unavailable")
+    await fireEvent.click(
+      within(errorState).getByRole("button", { name: "Retry" })
+    )
+    expect(await screen.findByText("Success")).toBeInTheDocument()
+  })
+
+  it("renders only contracted sanitized run details", async () => {
+    const boundedMessage = "x".repeat(512)
+    const failedRun = makeRun("error", {
+      error: {
+        code: FunctionErrorCode.FUNCTION_QUERY_DENIED,
+        message: boundedMessage,
+      },
+    })
+    api.getFunctionRuns.mockResolvedValue(runsResponse([failedRun]))
+    api.getFunctionRun.mockResolvedValue({
+      run: {
+        ...failedRun,
+        inputs: { secretInput: "do-not-render" },
+        output: { secretOutput: "do-not-render" },
+        stack: "host-stack-do-not-render",
+        logs: [{ message: "user-message-do-not-render" }],
+      },
+    })
+
+    render(FunctionLogs, { functionId: "fn_one" })
+    await fireEvent.click(
+      await screen.findByRole("button", { name: "View details" })
+    )
+
+    const detail = await screen.findByRole("complementary", {
+      name: "Function run details",
+    })
+    expect(detail).toHaveTextContent("Automation")
+    expect(detail).toHaveTextContent("automation_one")
+    expect(detail).toHaveTextContent("step_one")
+    expect(detail).toHaveTextContent("hash_error")
+    expect(detail).toHaveTextContent("FUNCTION_QUERY_DENIED")
+    expect(detail).toHaveTextContent(boundedMessage)
+    expect(detail).not.toHaveTextContent("do-not-render")
+    expect(detail).not.toHaveTextContent("host-stack-do-not-render")
+    expect(detail).not.toHaveTextContent("user-message-do-not-render")
+  })
+})

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionLogs.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionLogs.svelte
@@ -1,0 +1,330 @@
+<svelte:options runes={true} />
+
+<script lang="ts">
+  import { API } from "@/api"
+  import { getErrorMessage } from "@/helpers/errors"
+  import {
+    Badge,
+    Body,
+    Button,
+    Heading,
+    Icon,
+    ProgressCircle,
+  } from "@budibase/bbui"
+  import type { FunctionRunSummary } from "@budibase/types"
+  import { onMount } from "svelte"
+  import FunctionRunDetail from "./FunctionRunDetail.svelte"
+  import {
+    formatFunctionRunDuration,
+    formatFunctionRunTimestamp,
+    functionEnvironmentLabels,
+    functionRunStatusLabels,
+  } from "./functionLogs"
+
+  const PAGE_SIZE = 20
+
+  interface Props {
+    functionId: string
+  }
+
+  let { functionId }: Props = $props()
+
+  let runs = $state<FunctionRunSummary[]>([])
+  let loading = $state(false)
+  let error = $state("")
+  let hasMore = $state(false)
+  let nextBookmark = $state<string>()
+  let selectedRun = $state<FunctionRunSummary>()
+  let detailLoading = $state(false)
+  let detailError = $state("")
+
+  const runKey = (run: FunctionRunSummary) => `${run.environment}:${run.runId}`
+
+  const loadRuns = async (bookmark?: string, append = false) => {
+    if (loading) {
+      return
+    }
+    loading = true
+    error = ""
+    try {
+      const response = await API.getFunctionRuns(functionId, {
+        bookmark,
+        limit: PAGE_SIZE,
+      })
+      if (append) {
+        const existingKeys = new Set(runs.map(runKey))
+        runs = [
+          ...runs,
+          ...response.runs.filter(run => !existingKeys.has(runKey(run))),
+        ]
+      } else {
+        runs = response.runs
+        selectedRun = undefined
+      }
+      hasMore = response.hasMore
+      nextBookmark = response.nextBookmark
+    } catch (loadError) {
+      error = getErrorMessage(loadError) || "Unable to load Function logs"
+      if (!append) {
+        runs = []
+        hasMore = false
+        nextBookmark = undefined
+        selectedRun = undefined
+      }
+    } finally {
+      loading = false
+    }
+  }
+
+  const loadMore = async () => {
+    if (hasMore && nextBookmark) {
+      await loadRuns(nextBookmark, true)
+    }
+  }
+
+  const selectRun = async (run: FunctionRunSummary) => {
+    selectedRun = run
+    detailLoading = true
+    detailError = ""
+    const requestedRunId = run.runId
+    try {
+      const response = await API.getFunctionRun(functionId, requestedRunId)
+      if (selectedRun?.runId === requestedRunId) {
+        selectedRun = response.run
+      }
+    } catch (loadError) {
+      if (selectedRun?.runId === requestedRunId) {
+        detailError =
+          getErrorMessage(loadError) || "Unable to load Function run details"
+      }
+    } finally {
+      if (selectedRun?.runId === requestedRunId) {
+        detailLoading = false
+      }
+    }
+  }
+
+  const retrySelectedRun = () => {
+    if (selectedRun) {
+      selectRun(selectedRun)
+    }
+  }
+
+  onMount(() => {
+    loadRuns()
+  })
+</script>
+
+<section class="logs" aria-label="Function logs">
+  <div class="logs-heading">
+    <div>
+      <Heading size="M">Logs</Heading>
+      <Body size="S" color="var(--spectrum-global-color-gray-600)">
+        Sanitized development and published execution history.
+      </Body>
+    </div>
+    <Button secondary disabled={loading} on:click={() => loadRuns()}>
+      Refresh
+    </Button>
+  </div>
+
+  {#if loading && !runs.length}
+    <div class="state" data-testid="function-logs-loading">
+      <ProgressCircle size="M" />
+      <Body size="S">Loading Function logs...</Body>
+    </div>
+  {:else if error && !runs.length}
+    <div class="state" data-testid="function-logs-error" role="alert">
+      <Icon name="warning-circle" size="L" />
+      <Heading size="S">Unable to load Function logs</Heading>
+      <Body size="S" color="var(--spectrum-global-color-gray-600)">
+        {error}
+      </Body>
+      <Button secondary on:click={() => loadRuns()}>Retry</Button>
+    </div>
+  {:else if !runs.length}
+    <div class="state" data-testid="function-logs-empty">
+      <Icon name="clock" size="L" />
+      <Heading size="S">No Function runs yet</Heading>
+      <Body size="S" color="var(--spectrum-global-color-gray-600)">
+        Runs will appear here after this Function is invoked.
+      </Body>
+    </div>
+  {:else}
+    {#if error}
+      <div class="pagination-error" role="alert">
+        <Body size="S">{error}</Body>
+        <Button secondary on:click={loadMore}>Retry</Button>
+      </div>
+    {/if}
+    <div class:with-detail={selectedRun} class="logs-content">
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Started</th>
+              <th>Environment</th>
+              <th>Duration</th>
+              <th><span class="visually-hidden">Actions</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each runs as run (runKey(run))}
+              <tr data-status={run.status} data-environment={run.environment}>
+                <td>
+                  <Badge
+                    size="S"
+                    green={run.status === "success"}
+                    red={run.status === "error"}
+                    orange={run.status === "running"}
+                    grey={run.status === "stopped"}
+                  >
+                    {functionRunStatusLabels[run.status]}
+                  </Badge>
+                </td>
+                <td>
+                  <time datetime={run.startedAt}>
+                    {formatFunctionRunTimestamp(run.startedAt)}
+                  </time>
+                </td>
+                <td>{functionEnvironmentLabels[run.environment]}</td>
+                <td>{formatFunctionRunDuration(run.durationMs)}</td>
+                <td>
+                  <Button secondary on:click={() => selectRun(run)}>
+                    View details
+                  </Button>
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+
+        {#if hasMore}
+          <div class="pagination">
+            <Button secondary disabled={loading} on:click={loadMore}>
+              {loading ? "Loading..." : "Load more"}
+            </Button>
+          </div>
+        {/if}
+      </div>
+
+      {#if selectedRun}
+        <FunctionRunDetail
+          run={selectedRun}
+          loading={detailLoading}
+          error={detailError}
+          onretry={retrySelectedRun}
+          onclose={() => {
+            selectedRun = undefined
+            detailError = ""
+          }}
+        />
+      {/if}
+    </div>
+  {/if}
+</section>
+
+<style>
+  .logs,
+  .table-wrapper {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+  }
+  .logs {
+    gap: var(--spacing-l);
+  }
+  .logs-heading,
+  .pagination-error {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-m);
+  }
+  .logs-heading > div {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+  }
+  .logs-content {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--spacing-l);
+  }
+  .logs-content.with-detail {
+    grid-template-columns: minmax(0, 1fr) minmax(320px, 0.45fr);
+  }
+  .table-wrapper {
+    overflow-x: auto;
+    gap: var(--spacing-m);
+  }
+  table {
+    width: 100%;
+    border-spacing: 0;
+    border: 1px solid var(--spectrum-global-color-gray-300);
+    border-radius: var(--radius-m);
+  }
+  th,
+  td {
+    padding: var(--spacing-s) var(--spacing-m);
+    border-bottom: 1px solid var(--spectrum-global-color-gray-200);
+    text-align: left;
+    white-space: nowrap;
+  }
+  th {
+    color: var(--spectrum-global-color-gray-600);
+    font-size: 12px;
+    font-weight: 600;
+  }
+  td {
+    font-size: 13px;
+  }
+  tbody tr:last-child td {
+    border-bottom: 0;
+  }
+  tbody tr[data-status="error"] {
+    background: var(--spectrum-global-color-red-100);
+  }
+  tbody tr[data-status="success"] {
+    background: var(--spectrum-global-color-green-100);
+  }
+  .state {
+    display: flex;
+    min-height: 280px;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-s);
+    text-align: center;
+  }
+  .pagination,
+  .pagination-error {
+    padding: var(--spacing-s);
+  }
+  .pagination {
+    display: flex;
+    justify-content: center;
+  }
+  .pagination-error {
+    border: 1px solid var(--spectrum-global-color-red-300);
+    border-radius: var(--radius-m);
+    color: var(--spectrum-global-color-red-700);
+  }
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  @media (max-width: 1100px) {
+    .logs-content.with-detail {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionLogs.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionLogs.svelte
@@ -23,7 +23,7 @@
 
   const PAGE_SIZE = 20
 
-  interface Props {
+  export interface Props {
     functionId: string
   }
 

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionRunDetail.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionRunDetail.svelte
@@ -1,0 +1,185 @@
+<svelte:options runes={true} />
+
+<script lang="ts">
+  import { Badge, Body, Button, Heading, ProgressCircle } from "@budibase/bbui"
+  import type { FunctionRunSummary } from "@budibase/types"
+  import {
+    formatFunctionRunDuration,
+    formatFunctionRunTimestamp,
+    functionEnvironmentLabels,
+    functionRunStatusLabels,
+  } from "./functionLogs"
+
+  interface Props {
+    run: FunctionRunSummary
+    loading?: boolean
+    error?: string
+    onretry?: () => void
+    onclose?: () => void
+  }
+
+  let {
+    run,
+    loading = false,
+    error = "",
+    onretry = () => {},
+    onclose = () => {},
+  }: Props = $props()
+</script>
+
+<aside class="run-detail" aria-label="Function run details">
+  <div class="detail-heading">
+    <div>
+      <Heading size="S">Run details</Heading>
+      <Body size="XS" color="var(--spectrum-global-color-gray-600)">
+        Sanitized execution summary
+      </Body>
+    </div>
+    <Button secondary on:click={onclose}>Close</Button>
+  </div>
+
+  {#if loading}
+    <div class="detail-state" data-testid="function-run-detail-loading">
+      <ProgressCircle size="S" />
+      <Body size="S">Loading details...</Body>
+    </div>
+  {:else if error}
+    <div class="detail-state error" role="alert">
+      <Body size="S">{error}</Body>
+      <Button secondary on:click={onretry}>Retry</Button>
+    </div>
+  {:else}
+    <dl>
+      <div>
+        <dt>Status</dt>
+        <dd>
+          <Badge
+            size="S"
+            green={run.status === "success"}
+            red={run.status === "error"}
+            orange={run.status === "running"}
+            grey={run.status === "stopped"}
+          >
+            {functionRunStatusLabels[run.status]}
+          </Badge>
+        </dd>
+      </div>
+      <div>
+        <dt>Environment</dt>
+        <dd>{functionEnvironmentLabels[run.environment]}</dd>
+      </div>
+      <div>
+        <dt>Started</dt>
+        <dd>
+          <time datetime={run.startedAt}>
+            {formatFunctionRunTimestamp(run.startedAt)}
+          </time>
+        </dd>
+      </div>
+      {#if run.finishedAt}
+        <div>
+          <dt>Finished</dt>
+          <dd>
+            <time datetime={run.finishedAt}>
+              {formatFunctionRunTimestamp(run.finishedAt)}
+            </time>
+          </dd>
+        </div>
+      {/if}
+      <div>
+        <dt>Duration</dt>
+        <dd>{formatFunctionRunDuration(run.durationMs)}</dd>
+      </div>
+      <div>
+        <dt>Invocation source</dt>
+        <dd>Automation</dd>
+      </div>
+      <div>
+        <dt>Automation ID</dt>
+        <dd><code>{run.invocation.automationId}</code></dd>
+      </div>
+      <div>
+        <dt>Step ID</dt>
+        <dd><code>{run.invocation.stepId}</code></dd>
+      </div>
+      <div>
+        <dt>Query count</dt>
+        <dd>{run.queryCount}</dd>
+      </div>
+      <div>
+        <dt>Source hash</dt>
+        <dd><code>{run.sourceHash}</code></dd>
+      </div>
+      {#if run.error}
+        <div>
+          <dt>Error code</dt>
+          <dd><code>{run.error.code}</code></dd>
+        </div>
+        <div>
+          <dt>Error message</dt>
+          <dd class="error-message">{run.error.message}</dd>
+        </div>
+      {/if}
+    </dl>
+  {/if}
+</aside>
+
+<style>
+  .run-detail {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: var(--spacing-l);
+    padding: var(--spacing-l);
+    border: 1px solid var(--spectrum-global-color-gray-300);
+    border-radius: var(--radius-m);
+    background: var(--spectrum-global-color-gray-50);
+  }
+  .detail-heading,
+  .detail-state {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-s);
+  }
+  .detail-heading > div {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+  }
+  .detail-state {
+    justify-content: flex-start;
+    padding: var(--spacing-l) 0;
+  }
+  .detail-state.error {
+    flex-wrap: wrap;
+    color: var(--spectrum-global-color-red-700);
+  }
+  dl {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-m);
+    margin: 0;
+  }
+  dl > div {
+    display: grid;
+    grid-template-columns: minmax(100px, 0.75fr) minmax(0, 1fr);
+    gap: var(--spacing-m);
+  }
+  dt {
+    color: var(--spectrum-global-color-gray-600);
+    font-size: 12px;
+  }
+  dd {
+    min-width: 0;
+    margin: 0;
+    overflow-wrap: anywhere;
+    font-size: 13px;
+  }
+  code {
+    font-size: 12px;
+  }
+  .error-message {
+    color: var(--spectrum-global-color-red-700);
+  }
+</style>

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionRunDetail.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/FunctionRunDetail.svelte
@@ -10,7 +10,7 @@
     functionRunStatusLabels,
   } from "./functionLogs"
 
-  interface Props {
+  export interface Props {
     run: FunctionRunSummary
     loading?: boolean
     error?: string

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/[functionId]/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/[functionId]/index.svelte
@@ -11,6 +11,8 @@
     Icon,
     notifications,
     ProgressCircle,
+    Tab,
+    Tabs,
   } from "@budibase/bbui"
   import { Utils } from "@budibase/frontend-core"
   import type {
@@ -22,6 +24,7 @@
   import { params } from "@roxi/routify"
   import { onDestroy, onMount } from "svelte"
   import FunctionCodeEditor from "../FunctionCodeEditor.svelte"
+  import FunctionLogs from "../FunctionLogs.svelte"
   import FunctionQueryEditor from "../FunctionQueryEditor.svelte"
   import { canManageFunctions } from "../permissions"
 
@@ -37,6 +40,7 @@
   let queriesDirty = false
   let actionError = ""
   let validationRequest = 0
+  let selectedTab = "Code"
 
   $params
   $: functionId = $params.functionId
@@ -244,84 +248,99 @@
             {/if}
           </div>
           <Body size="S" color="var(--spectrum-global-color-gray-600)">
-            Write TypeScript, save the draft, then build its saved revision.
+            {selectedTab === "Code"
+              ? "Write TypeScript, save the draft, then build its saved revision."
+              : "Review sanitized development and published execution history."}
           </Body>
         </div>
-        <div class="actions">
-          <Button
-            secondary
-            disabled={!sourceDirty || saving || building}
-            on:click={saveSource}
-          >
-            {saving ? "Saving..." : "Save"}
-          </Button>
-          <Button
-            primary
-            disabled={draftDirty || saving || building}
-            on:click={build}
-          >
-            {building ? "Building..." : "Build"}
-          </Button>
-        </div>
-      </div>
-
-      {#if actionError}
-        <div class="action-error" role="alert">
-          <Icon name="warning-circle" size="S" />
-          <span>{actionError}</span>
-          <Button secondary on:click={load}>Reload saved revision</Button>
-        </div>
-      {/if}
-
-      <section class="source-editor">
-        <div class="section-heading">
-          <div>
-            <Heading size="M">Source</Heading>
-            <Body size="S" color="var(--spectrum-global-color-gray-600)">
-              TypeScript diagnostics are authoritative and do not prevent
-              saving.
-            </Body>
-          </div>
-          {#if validating}
-            <div class="validating">
-              <ProgressCircle size="S" />
-              <Body size="S">Checking...</Body>
-            </div>
-          {/if}
-        </div>
-        <FunctionCodeEditor
-          bind:value={source}
-          capabilities={fn.capabilities}
-          {diagnostics}
-        />
-        {#if diagnostics.length}
-          <div class="diagnostics" aria-label="Function diagnostics">
-            {#each diagnostics as diagnostic}
-              <div class="diagnostic">
-                <code>{diagnostic.code}</code>
-                {#if diagnostic.line}
-                  <span>
-                    Line {diagnostic.line}{diagnostic.column
-                      ? `:${diagnostic.column}`
-                      : ""}
-                  </span>
-                {/if}
-                <span>{diagnostic.message}</span>
-              </div>
-            {/each}
+        {#if selectedTab === "Code"}
+          <div class="actions">
+            <Button
+              secondary
+              disabled={!sourceDirty || saving || building}
+              on:click={saveSource}
+            >
+              {saving ? "Saving..." : "Save"}
+            </Button>
+            <Button
+              primary
+              disabled={draftDirty || saving || building}
+              on:click={build}
+            >
+              {building ? "Building..." : "Build"}
+            </Button>
           </div>
         {/if}
-      </section>
+      </div>
 
-      <FunctionQueryEditor
-        capabilities={fn.capabilities}
-        catalog={$functionStore.queryCatalog}
-        catalogLoading={$functionStore.catalogLoading}
-        catalogError={$functionStore.catalogError}
-        onRetry={() => functionStore.fetchQueryCatalog()}
-        onSave={saveCapabilities}
-        onDirtyChange={dirty => (queriesDirty = dirty)}
-      />
+      <Tabs
+        noHorizPadding
+        selected={selectedTab}
+        on:select={event => (selectedTab = event.detail)}
+      >
+        <Tab title="Code">
+          {#if actionError}
+            <div class="action-error" role="alert">
+              <Icon name="warning-circle" size="S" />
+              <span>{actionError}</span>
+              <Button secondary on:click={load}>Reload saved revision</Button>
+            </div>
+          {/if}
+
+          <section class="source-editor">
+            <div class="section-heading">
+              <div>
+                <Heading size="M">Source</Heading>
+                <Body size="S" color="var(--spectrum-global-color-gray-600)">
+                  TypeScript diagnostics are authoritative and do not prevent
+                  saving.
+                </Body>
+              </div>
+              {#if validating}
+                <div class="validating">
+                  <ProgressCircle size="S" />
+                  <Body size="S">Checking...</Body>
+                </div>
+              {/if}
+            </div>
+            <FunctionCodeEditor
+              bind:value={source}
+              capabilities={fn.capabilities}
+              {diagnostics}
+            />
+            {#if diagnostics.length}
+              <div class="diagnostics" aria-label="Function diagnostics">
+                {#each diagnostics as diagnostic}
+                  <div class="diagnostic">
+                    <code>{diagnostic.code}</code>
+                    {#if diagnostic.line}
+                      <span>
+                        Line {diagnostic.line}{diagnostic.column
+                          ? `:${diagnostic.column}`
+                          : ""}
+                      </span>
+                    {/if}
+                    <span>{diagnostic.message}</span>
+                  </div>
+                {/each}
+              </div>
+            {/if}
+          </section>
+
+          <FunctionQueryEditor
+            capabilities={fn.capabilities}
+            catalog={$functionStore.queryCatalog}
+            catalogLoading={$functionStore.catalogLoading}
+            catalogError={$functionStore.catalogError}
+            onRetry={() => functionStore.fetchQueryCatalog()}
+            onSave={saveCapabilities}
+            onDirtyChange={dirty => (queriesDirty = dirty)}
+          />
+        </Tab>
+        <Tab title="Logs">
+          <FunctionLogs functionId={fn._id} />
+        </Tab>
+      </Tabs>
     {/if}
   </main>
 </div>

--- a/packages/builder/src/pages/builder/workspace/[application]/automation/functions/functionLogs.ts
+++ b/packages/builder/src/pages/builder/workspace/[application]/automation/functions/functionLogs.ts
@@ -1,0 +1,31 @@
+import dayjs from "dayjs"
+import type {
+  FunctionEnvironment,
+  FunctionRunSummaryStatus,
+} from "@budibase/types"
+
+export const functionRunStatusLabels: Record<FunctionRunSummaryStatus, string> =
+  {
+    running: "Running",
+    success: "Success",
+    error: "Error",
+    stopped: "Stopped",
+  }
+
+export const functionEnvironmentLabels: Record<FunctionEnvironment, string> = {
+  development: "Development",
+  published: "Published",
+}
+
+export const formatFunctionRunTimestamp = (value: string) =>
+  dayjs(value).format("MMM D, YYYY, h:mm:ss A")
+
+export const formatFunctionRunDuration = (durationMs?: number) => {
+  if (durationMs === undefined) {
+    return "—"
+  }
+  if (durationMs < 1000) {
+    return `${durationMs} ms`
+  }
+  return `${(durationMs / 1000).toFixed(1)} s`
+}

--- a/packages/frontend-core/src/api/functions.ts
+++ b/packages/frontend-core/src/api/functions.ts
@@ -6,6 +6,8 @@ import type {
   CreateFunctionResponse,
   FetchFunctionResponse,
   FetchFunctionQueryCatalogResponse,
+  FetchFunctionRunResponse,
+  FetchFunctionRunsResponse,
   FetchFunctionsResponse,
   UpdateFunctionRequest,
   UpdateFunctionResponse,
@@ -16,6 +18,14 @@ export interface FunctionEndpoints {
   getFunctions: () => Promise<FetchFunctionsResponse>
   getFunctionQueryCatalog: () => Promise<FetchFunctionQueryCatalogResponse>
   getFunction: (functionId: string) => Promise<FetchFunctionResponse>
+  getFunctionRuns: (
+    functionId: string,
+    options?: { bookmark?: string; limit?: number }
+  ) => Promise<FetchFunctionRunsResponse>
+  getFunctionRun: (
+    functionId: string,
+    runId: string
+  ) => Promise<FetchFunctionRunResponse>
   compileFunction: (
     fn: CompileFunctionRequest
   ) => Promise<CompileFunctionResponse>
@@ -49,6 +59,26 @@ export const buildFunctionEndpoints = (
   getFunction: async functionId => {
     return await API.get({
       url: `/api/functions/${functionId}`,
+    })
+  },
+
+  getFunctionRuns: async (functionId, options = {}) => {
+    const params = new URLSearchParams()
+    if (options.bookmark) {
+      params.set("bookmark", options.bookmark)
+    }
+    if (options.limit !== undefined) {
+      params.set("limit", String(options.limit))
+    }
+    const query = params.toString()
+    return await API.get({
+      url: `/api/functions/${functionId}/runs${query ? `?${query}` : ""}`,
+    })
+  },
+
+  getFunctionRun: async (functionId, runId) => {
+    return await API.get({
+      url: `/api/functions/${functionId}/runs/${runId}`,
     })
   },
 

--- a/packages/types/src/api/web/workspace/function.ts
+++ b/packages/types/src/api/web/workspace/function.ts
@@ -1,6 +1,7 @@
 import type {
   FunctionBuildDiagnostic,
   FunctionDocument,
+  FunctionRunSummary,
 } from "../../../documents"
 import type { SourceName } from "../../../sdk"
 
@@ -78,4 +79,14 @@ export interface FunctionQueryCatalogEntry {
 
 export interface FetchFunctionQueryCatalogResponse {
   queries: FunctionQueryCatalogEntry[]
+}
+
+export interface FetchFunctionRunsResponse {
+  runs: FunctionRunSummary[]
+  hasMore: boolean
+  nextBookmark?: string
+}
+
+export interface FetchFunctionRunResponse {
+  run: FunctionRunSummary
 }


### PR DESCRIPTION
## Description
Adds the Function Logs tab and sanitized execution-detail UI for the Functions alpha. History is paginated through the merged development/published history API and excludes invocation payloads, outputs, logs, and stack traces.

## Addresses
- https://github.com/Budibase/budibase/issues/19273

## Launchcontrol
Builders can review Function execution status, environment, timing, query count, source hash, and bounded failure details from the Function editor.