### PR TITLE
fix(builder): integrate Functions into workspace routes

### DIFF
--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/automation/functions/[functionId]/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/automation/functions/[functionId]/index.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import FunctionPage from "@/pages/builder/workspace/[application]/automation/functions/[functionId]/index.svelte"
+</script>
+
+<FunctionPage />

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/automation/functions/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/automation/functions/index.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import FunctionsPage from "@/pages/builder/workspace/[application]/automation/functions/index.svelte"
+</script>
+
+<FunctionsPage />

--- a/packages/builder/src/pages/builder/workspace/[workspaceId]/home/index.svelte
+++ b/packages/builder/src/pages/builder/workspace/[workspaceId]/home/index.svelte
@@ -83,7 +83,7 @@
   } from "./_components/urlState"
 
   import UpdateAgentModal from "../_components/UpdateAgentModal.svelte"
-  import { canManageFunctions } from "../automation/functions/permissions"
+  import { canManageFunctions } from "@/pages/builder/workspace/[application]/automation/functions/permissions"
 
   $: goto = $gotoStore
   $: url = $urlStore
@@ -1094,6 +1094,8 @@
                   variant="pill"
                   onCreateAgent={createAgent}
                   onCreateAutomation={createAutomation}
+                  onCreateFunction={() => goToCreate("automation/functions")}
+                  showFunctions={functionsEnabled}
                   onCreateApp={createApp}
                   onCreateConnection={() => goToCreate("data/new")}
                   onCreateTable={openCreateTable}


### PR DESCRIPTION
## Description

Adds the workspace-scoped route wrappers and Create-menu wiring required for Functions on the integrated playground branch.

## Addresses
- Integration fix for the Functions alpha workspace route migration

## Launchcontrol

Makes Functions navigation and creation available in the integrated workspace route tree.